### PR TITLE
refactor(app-shell): centralize presentation priority

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -383,6 +383,18 @@ colors communicate a successful or failed probe/migration result.
 - Workspace: `flex h-svh min-w-0 bg-bg-10 text-foreground overflow-hidden`.
 - Main content column: `min-w-0 flex-1 overflow-hidden`.
 - Use `ScrollArea` for scrollable content. Do not create multiple nested scroll containers in the same direction.
+- The App Shell presentation owner selects the only root presentation allowed to be interactive.
+  Feature stores retain their own requested/open state; they do not coordinate presentation order
+  with one another.
+- Root presentation priority is fixed: close confirmation, missing data-root recovery, legacy data
+  move, update, compute approval, Connector approval, Skill import approval, global search, Settings,
+  preview, then base content. A covered presentation stays requested and resumes when higher-priority
+  work clears.
+- Session visibility, App Shell shortcut eligibility, and `Cmd/Ctrl+W` routing must consume that
+  projection. Do not rebuild parallel Boolean gate lists in `AppContent` or feature components.
+- When a presentation above preview/base owns the shell, base content is `inert` and
+  `aria-hidden`. Nested dialogs and fullscreen viewers retain local priority before base-pane or
+  window close behavior.
 
 ### Button
 

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -92,7 +92,18 @@ const mocks = vi.hoisted(() => {
     syncUnreadTaskView: vi.fn(),
     globalSearch: { props: undefined as { open: boolean } | undefined },
     homePage: { props: undefined as { onOpenGlobalSearch: () => void } | undefined },
-    closeActiveModal: { handler: undefined as (() => boolean) | undefined }
+    closeActiveModal: {
+      handler: undefined as (() => 'handled' | 'close-preview' | 'close-base') | undefined
+    },
+    sideChatParentSessionIds: new Set<string>(),
+    presentationProps: {
+      closeConfirmation: undefined as { active?: boolean } | undefined,
+      update: undefined as { active?: boolean } | undefined,
+      computeApproval: undefined as { active?: boolean } | undefined,
+      connectorApproval: undefined as { active?: boolean } | undefined,
+      skillImportApproval: undefined as { active?: boolean } | undefined,
+      workspace: undefined as { isPreviewPresentationActive?: boolean } | undefined
+    }
   }
 })
 
@@ -103,7 +114,7 @@ vi.mock('@/lib/deep-link', () => ({
   useDeepLinkNavigation: mocks.deepLinkNavigation
 }))
 vi.mock('@/hooks/useCloseActivePaneShortcut', () => ({
-  useCloseActivePaneShortcut: (handler?: () => boolean) => {
+  useCloseActivePaneShortcut: (handler?: () => 'handled' | 'close-preview' | 'close-base') => {
     mocks.closeActiveModal.handler = handler
   }
 }))
@@ -185,7 +196,10 @@ vi.mock('@/pages/onboarding/startup-gate', () => ({
 }))
 
 vi.mock('@/components/CloseConfirmModal', () => ({
-  CloseConfirmModal: (): React.JSX.Element => <div data-testid="close-confirm" />
+  CloseConfirmModal: (props: { active?: boolean }): React.JSX.Element => {
+    mocks.presentationProps.closeConfirmation = props
+    return <div data-testid="close-confirm" />
+  }
 }))
 vi.mock('@/components/DataRootMissingDialog', () => ({
   DataRootMissingDialog: ({
@@ -205,7 +219,13 @@ vi.mock('@/components/LifecycleToast', () => ({
   LifecycleToast: (): React.JSX.Element => <div data-testid="lifecycle-toast" />
 }))
 vi.mock('@/components/UpdateDialog', () => ({
-  UpdateDialog: (): React.JSX.Element => <div data-testid="update-dialog" />
+  UpdateDialog: (props: { active?: boolean }): React.JSX.Element => {
+    mocks.presentationProps.update = props
+    return <div data-testid="update-dialog" />
+  }
+}))
+vi.mock('@/components/PermissionUndoSnackbar', () => ({
+  PermissionUndoSnackbar: (): React.JSX.Element => <div data-testid="permission-undo" />
 }))
 vi.mock('@/lib/acp/useWorkspaceAgentRuntime', () => ({
   WorkspaceAgentRuntimeProvider: ({ children }: { children: ReactNode }): ReactNode => children
@@ -237,10 +257,22 @@ vi.mock('@/pages/onboarding/OnboardingWizard', () => ({
   }
 }))
 vi.mock('@/pages/settings/ConnectorApprovalDialog', () => ({
-  ConnectorApprovalDialog: (): React.JSX.Element => <div data-testid="approval-dialog" />
+  ConnectorApprovalDialog: (props: { active?: boolean }): React.JSX.Element => {
+    mocks.presentationProps.connectorApproval = props
+    return <div data-testid="approval-dialog" />
+  }
 }))
 vi.mock('@/pages/settings/SkillImportApprovalDialog', () => ({
-  SkillImportApprovalDialog: (): React.JSX.Element => <div data-testid="skill-import-dialog" />
+  SkillImportApprovalDialog: (props: { active?: boolean }): React.JSX.Element => {
+    mocks.presentationProps.skillImportApproval = props
+    return <div data-testid="skill-import-dialog" />
+  }
+}))
+vi.mock('@/pages/settings/ComputeApprovalDialog', () => ({
+  ComputeApprovalDialog: (props: { active?: boolean }): React.JSX.Element => {
+    mocks.presentationProps.computeApproval = props
+    return <div data-testid="compute-approval-dialog" />
+  }
 }))
 vi.mock('@/pages/settings/SettingsPage', () => ({
   SettingsPage: ({
@@ -268,17 +300,26 @@ vi.mock('@/pages/workspace/EnvStatusBanner', () => ({
 vi.mock('@/pages/workspace/WorkspacePage', () => ({
   WorkspacePage: ({
     isSessionPersistenceReady,
-    canDeleteConversations
+    canDeleteConversations,
+    isPreviewPresentationActive
   }: {
     isSessionPersistenceReady: boolean
     canDeleteConversations: boolean
+    isPreviewPresentationActive?: boolean
   }): React.JSX.Element => (
     <div
+      ref={() => {
+        mocks.presentationProps.workspace = { isPreviewPresentationActive }
+      }}
       data-testid="workspace-page"
       data-ready={String(isSessionPersistenceReady)}
       data-can-delete-conversations={String(canDeleteConversations)}
     />
   )
+}))
+vi.mock('@/pages/workspace/use-side-chat-controller', () => ({
+  SideChatProvider: ({ children }: { children: ReactNode }): ReactNode => children,
+  useOpenSideChatParentSessionIds: (): ReadonlySet<string> => mocks.sideChatParentSessionIds
 }))
 
 import App from './App'
@@ -375,6 +416,12 @@ describe('App startup routing', () => {
     mocks.globalSearch.props = undefined
     mocks.homePage.props = undefined
     mocks.closeActiveModal.handler = undefined
+    mocks.sideChatParentSessionIds.clear()
+    for (const key of Object.keys(mocks.presentationProps) as Array<
+      keyof typeof mocks.presentationProps
+    >) {
+      mocks.presentationProps[key] = undefined
+    }
   })
 
   afterEach(async () => {
@@ -478,7 +525,7 @@ describe('App startup routing', () => {
     expect(mocks.settings.openSettings).not.toHaveBeenCalled()
 
     act(() => {
-      expect(mocks.closeActiveModal.handler?.()).toBe(true)
+      expect(mocks.closeActiveModal.handler?.()).toBe('handled')
     })
     expect(document.querySelector('[data-testid="global-search"]')).toBeNull()
   })
@@ -496,6 +543,85 @@ describe('App startup routing', () => {
 
     expect(mocks.settings.openSettings).not.toHaveBeenCalled()
     dialog.remove()
+  })
+
+  it('does not open global search from a shortcut or Home action over an active dialog', async () => {
+    mocks.settings.isLoaded = true
+    await render()
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    document.body.appendChild(dialog)
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, cancelable: true })
+      )
+      mocks.homePage.props?.onOpenGlobalSearch()
+    })
+
+    expect(document.querySelector('[data-testid="global-search"]')).toBeNull()
+    dialog.remove()
+  })
+
+  it('activates only the highest-priority pending approval and resumes the next one', async () => {
+    mocks.settings.isLoaded = true
+    mocks.settings.isSettingsOpen = true
+    mocks.settings.pendingApprovals = [{ id: 'connector', sessionId: 'connector-session' }]
+    mocks.compute.pendingApprovals = [{ id: 'compute', session_id: 'compute-session' }]
+    mocks.skillImport.pending = [{ id: 'skill', sessionId: 'skill-session' }]
+    await render()
+
+    expect(mocks.presentationProps.computeApproval?.active).toBe(true)
+    expect(mocks.presentationProps.connectorApproval?.active).toBe(false)
+    expect(mocks.presentationProps.skillImportApproval?.active).toBe(false)
+    expect(container.querySelector('[data-testid="settings-page"]')?.textContent).toBe('closed')
+    expect(
+      container.querySelector('[data-testid="home-page"]')?.closest('[aria-hidden="true"]')
+    ).not.toBeNull()
+    expect(
+      container.querySelector('[data-testid="lifecycle-toast"]')?.closest('[aria-hidden="true"]')
+    ).not.toBeNull()
+    expect(
+      container.querySelector('[data-testid="permission-undo"]')?.closest('[aria-hidden="true"]')
+    ).not.toBeNull()
+
+    mocks.compute.pendingApprovals = []
+    await act(async () => root.render(<App />))
+
+    expect(mocks.presentationProps.computeApproval?.active).toBe(false)
+    expect(mocks.presentationProps.connectorApproval?.active).toBe(true)
+    expect(mocks.presentationProps.skillImportApproval?.active).toBe(false)
+  })
+
+  it('does not let Side Chat-owned approvals block workspace visibility or global search', async () => {
+    mocks.settings.isLoaded = true
+    mocks.navigation.view = 'workspace'
+    mocks.sideChatParentSessionIds.add('side-chat-session')
+    mocks.compute.pendingApprovals = [{ id: 'compute', session_id: 'side-chat-session' }]
+    await render()
+
+    expect(mocks.presentationProps.computeApproval?.active).toBe(false)
+    expect(mocks.presentationProps.workspace?.isPreviewPresentationActive).toBe(true)
+    expect(mocks.syncUnreadTaskView).toHaveBeenLastCalledWith({
+      isSessionContentVisible: true
+    })
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'k', metaKey: true, cancelable: true })
+      )
+    })
+
+    expect(mocks.globalSearch.props?.open).toBe(true)
+  })
+
+  it('consumes the close shortcut while a decision-required approval is active', async () => {
+    mocks.settings.isLoaded = true
+    mocks.compute.pendingApprovals = [{ id: 'compute', session_id: 'compute-session' }]
+    await render()
+
+    expect(mocks.closeActiveModal.handler?.()).toBe('handled')
+    expect(mocks.update.closeDialog).not.toHaveBeenCalled()
   })
 
   it('ignores a closed dialog portal when opening Settings', async () => {
@@ -521,7 +647,7 @@ describe('App startup routing', () => {
     await render()
 
     act(() => {
-      expect(mocks.closeActiveModal.handler?.()).toBe(true)
+      expect(mocks.closeActiveModal.handler?.()).toBe('handled')
     })
 
     expect(mocks.update.closeDialog).toHaveBeenCalledOnce()
@@ -539,7 +665,7 @@ describe('App startup routing', () => {
     document.body.appendChild(dialog)
 
     act(() => {
-      expect(mocks.closeActiveModal.handler?.()).toBe(true)
+      expect(mocks.closeActiveModal.handler?.()).toBe('handled')
     })
 
     expect(onKeyDown).toHaveBeenCalledOnce()

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type { OpenSessionFromNotificationRequest } from '../../shared/notifications'
 import type { StorageInfo } from '../../shared/storage'
@@ -15,8 +15,8 @@ import { PermissionUndoSnackbar } from '@/components/PermissionUndoSnackbar'
 import { SessionPersistenceAlert } from '@/components/SessionPersistenceAlert'
 import { UpdateDialog } from '@/components/UpdateDialog'
 import { GlobalSearchDialog } from '@/components/global-search/GlobalSearchDialog'
-import { STREAMDOWN_FULLSCREEN_SELECTOR } from '@/components/streamdown/dom-selectors'
 import { Button } from '@/components/ui/button'
+import { resolveAppShellPresentation } from '@/app-shell-presentation-owner'
 import { HomePage } from '@/pages/home/HomePage'
 import { OnboardingWizard } from '@/pages/onboarding/OnboardingWizard'
 import { resolveStartupView } from '@/pages/onboarding/startup-gate'
@@ -30,7 +30,10 @@ import {
   SideChatProvider,
   useOpenSideChatParentSessionIds
 } from '@/pages/workspace/use-side-chat-controller'
-import { useCloseActivePaneShortcut } from '@/hooks/useCloseActivePaneShortcut'
+import {
+  useCloseActivePaneShortcut,
+  type AppShellCloseRequest
+} from '@/hooks/useCloseActivePaneShortcut'
 import { useLifecycleSync } from '@/hooks/useLifecycleSync'
 import { useQuitPersistenceFlush } from '@/hooks/useQuitPersistenceFlush'
 import { useUnreadTaskViewSync } from '@/hooks/useUnreadTaskViewSync'
@@ -93,14 +96,25 @@ const AppContent = (): React.JSX.Element | null => {
   const checkEnvironment = useSettingsStore((state) => state.checkEnvironment)
   const isSettingsOpen = useSettingsStore((state) => state.isSettingsOpen)
   const openSettings = useSettingsStore((state) => state.openSettings)
-  const hasConnectorApproval = useSettingsStore((state) => state.pendingApprovals.length > 0)
+  const hasConnectorApproval = useSettingsStore((state) =>
+    state.pendingApprovals.some(
+      (candidate) => !candidate.sessionId || !openSideChatParentSessionIds.has(candidate.sessionId)
+    )
+  )
   const closeSettings = useSettingsStore((state) => state.closeSettings)
   const enqueueApproval = useSettingsStore((state) => state.enqueueApproval)
   const enqueueComputeApproval = useComputeStore((state) => state.enqueueApproval)
-  const hasComputeApproval = useComputeStore((state) => state.pendingApprovals.length > 0)
+  const hasComputeApproval = useComputeStore((state) =>
+    state.pendingApprovals.some(
+      (candidate) =>
+        !candidate.session_id || !openSideChatParentSessionIds.has(candidate.session_id)
+    )
+  )
   const enqueueSkillImport = useSkillImportStore((state) => state.enqueue)
   const dismissSkillImport = useSkillImportStore((state) => state.dismiss)
-  const hasSkillImportApproval = useSkillImportStore((state) => state.pending.length > 0)
+  const hasSkillImportApproval = useSkillImportStore((state) =>
+    state.pending.some((candidate) => !openSideChatParentSessionIds.has(candidate.sessionId))
+  )
   const applyJobUpdate = useSessionJobStore((state) => state.applyUpdate)
   const initUpdates = useUpdateStore((state) => state.init)
   const isUpdateDialogOpen = useUpdateStore((state) => state.isDialogOpen)
@@ -166,54 +180,82 @@ const AppContent = (): React.JSX.Element | null => {
   })
   const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false)
   const [isGlobalSearchOpen, setIsGlobalSearchOpen] = useState(false)
-  // Cmd+W / Ctrl+W closes transient modals before falling through to preview panes/window.
-  const closeActiveModal = useCallback((): boolean => {
-    const update = useUpdateStore.getState()
-    if (update.isDialogOpen) {
-      if (update.status.state !== 'applying') update.closeDialog()
-      return true
-    }
-    if (isGlobalSearchOpen) {
-      setIsGlobalSearchOpen(false)
-      return true
-    }
-    const contextWindowDialog = document.querySelector<HTMLElement>(
-      '[data-slot="context-window-dialog"][data-state="open"]'
-    )
-    if (contextWindowDialog) {
-      contextWindowDialog.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
-      )
-      return true
-    }
-    return settingsPageRef.current?.closeActivePane() ?? false
-  }, [isGlobalSearchOpen])
-  useCloseActivePaneShortcut(closeActiveModal)
   const startupView = isSettingsLoaded
     ? resolveStartupView({ onboardingDone: onboardingCompletedAt !== undefined })
     : undefined
+  const appShellPresentation = useMemo(
+    () =>
+      resolveAppShellPresentation({
+        startupView,
+        isSessionPersistenceHydrated,
+        isSessionPersistenceLoading,
+        view,
+        presentations: {
+          closeConfirmation: isCloseConfirmOpen,
+          dataRootRecovery: missingDataRoot !== undefined,
+          legacyDataMove: legacyMove !== undefined,
+          update: isUpdateDialogOpen,
+          computeApproval: hasComputeApproval,
+          connectorApproval: hasConnectorApproval,
+          skillImportApproval: hasSkillImportApproval,
+          globalSearch: isGlobalSearchOpen,
+          settings: isSettingsOpen,
+          preview: isPreviewModalOpen
+        }
+      }),
+    [
+      hasComputeApproval,
+      hasConnectorApproval,
+      hasSkillImportApproval,
+      isCloseConfirmOpen,
+      isGlobalSearchOpen,
+      isPreviewModalOpen,
+      isSessionPersistenceHydrated,
+      isSessionPersistenceLoading,
+      isSettingsOpen,
+      isUpdateDialogOpen,
+      legacyMove,
+      missingDataRoot,
+      startupView,
+      view
+    ]
+  )
+
+  // Cmd+W / Ctrl+W executes the owner's topmost-presentation decision before the preview/window
+  // ladder in useCloseActivePaneShortcut handles the owner's close-preview/close-base fallthrough.
+  const resolveCloseRequest = useCallback((): AppShellCloseRequest => {
+    const action = appShellPresentation.resolveCloseAction()
+    if (action.kind === 'close-update') {
+      const update = useUpdateStore.getState()
+      if (update.status.state !== 'applying') update.closeDialog()
+      return 'handled'
+    }
+    if (action.kind === 'close-global-search') {
+      setIsGlobalSearchOpen(false)
+      return 'handled'
+    }
+    if (action.kind === 'close-settings') {
+      settingsPageRef.current?.closeActivePane()
+      return 'handled'
+    }
+    if (action.kind === 'dismiss-dom-presentation') {
+      action.target.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+      )
+      return 'handled'
+    }
+    if (action.kind === 'close-preview' || action.kind === 'close-base') return action.kind
+    return 'handled'
+  }, [appShellPresentation])
+  useCloseActivePaneShortcut(resolveCloseRequest)
 
   const retrySettingsInitialization = useCallback(async (): Promise<void> => {
     if (await loadSettings({ force: true })) await checkEnvironment()
   }, [checkEnvironment, loadSettings])
 
-  // Only acknowledge a conversation when no app-level gate covers the workspace. The hook performs
-  // the remaining navigation/session/DOM checks before main is allowed to clear its unread marker.
-  const isSessionContentVisible =
-    isSessionPersistenceHydrated &&
-    !isSessionPersistenceLoading &&
-    startupView === 'app' &&
-    view === 'workspace' &&
-    !isSettingsOpen &&
-    !hasConnectorApproval &&
-    !hasComputeApproval &&
-    !hasSkillImportApproval &&
-    !isUpdateDialogOpen &&
-    !isCloseConfirmOpen &&
-    missingDataRoot === undefined &&
-    legacyMove === undefined
-
-  useUnreadTaskViewSync({ isSessionContentVisible })
+  useUnreadTaskViewSync({
+    isSessionContentVisible: appShellPresentation.isSessionContentVisible
+  })
 
   useEffect(() => {
     const openSettingsFromShortcut = (event: KeyboardEvent): void => {
@@ -222,21 +264,7 @@ const AppContent = (): React.JSX.Element | null => {
         event.isComposing ||
         event.key !== ',' ||
         !(event.metaKey || event.ctrlKey) ||
-        document.querySelector(
-          `[role="dialog"]:not([data-state="closed"]), [role="alertdialog"]:not([data-state="closed"]), ${STREAMDOWN_FULLSCREEN_SELECTOR}`
-        ) !== null ||
-        startupView !== 'app' ||
-        !isSessionPersistenceHydrated ||
-        isSettingsOpen ||
-        isGlobalSearchOpen ||
-        hasConnectorApproval ||
-        hasComputeApproval ||
-        hasSkillImportApproval ||
-        isUpdateDialogOpen ||
-        isPreviewModalOpen ||
-        isCloseConfirmOpen ||
-        missingDataRoot !== undefined ||
-        legacyMove !== undefined
+        !appShellPresentation.allowsShortcut('settings')
       ) {
         return
       }
@@ -246,21 +274,7 @@ const AppContent = (): React.JSX.Element | null => {
 
     window.addEventListener('keydown', openSettingsFromShortcut)
     return () => window.removeEventListener('keydown', openSettingsFromShortcut)
-  }, [
-    hasComputeApproval,
-    hasConnectorApproval,
-    hasSkillImportApproval,
-    isCloseConfirmOpen,
-    isGlobalSearchOpen,
-    isPreviewModalOpen,
-    isSessionPersistenceHydrated,
-    isSettingsOpen,
-    isUpdateDialogOpen,
-    legacyMove,
-    missingDataRoot,
-    openSettings,
-    startupView
-  ])
+  }, [appShellPresentation, openSettings])
 
   useEffect(() => {
     const toggleGlobalSearch = (event: KeyboardEvent): void => {
@@ -269,18 +283,7 @@ const AppContent = (): React.JSX.Element | null => {
         event.isComposing ||
         event.key.toLowerCase() !== 'k' ||
         !(event.metaKey || event.ctrlKey) ||
-        !isSettingsLoaded ||
-        startupView !== 'app' ||
-        !isSessionPersistenceHydrated ||
-        isSettingsOpen ||
-        hasConnectorApproval ||
-        hasComputeApproval ||
-        hasSkillImportApproval ||
-        isUpdateDialogOpen ||
-        isPreviewModalOpen ||
-        isCloseConfirmOpen ||
-        missingDataRoot !== undefined ||
-        legacyMove !== undefined
+        !appShellPresentation.allowsShortcut('globalSearch')
       ) {
         return
       }
@@ -290,20 +293,7 @@ const AppContent = (): React.JSX.Element | null => {
 
     window.addEventListener('keydown', toggleGlobalSearch)
     return () => window.removeEventListener('keydown', toggleGlobalSearch)
-  }, [
-    hasComputeApproval,
-    hasConnectorApproval,
-    hasSkillImportApproval,
-    isCloseConfirmOpen,
-    isSessionPersistenceHydrated,
-    isPreviewModalOpen,
-    isSettingsLoaded,
-    isSettingsOpen,
-    isUpdateDialogOpen,
-    legacyMove,
-    missingDataRoot,
-    startupView
-  ])
+  }, [appShellPresentation])
 
   // Load app info and subscribe to update-status broadcasts once at startup.
   useEffect(() => {
@@ -573,62 +563,88 @@ const AppContent = (): React.JSX.Element | null => {
     )
   }
 
+  const activePresentation = appShellPresentation.active
+  const isBasePresentationActive = activePresentation === 'base' || activePresentation === 'preview'
+
   return (
     <>
-      <EnvStatusBanner ui={envUi} onRetry={() => void retryEnv()} />
-      {sessionPersistence.loadError ? (
-        <SessionPersistenceAlert
-          title="Saved conversations could not be loaded"
-          message={sessionPersistence.loadError}
-          onRetry={sessionPersistence.retryLoad}
-        />
-      ) : sessionPersistence.writeError ? (
-        <SessionPersistenceAlert
-          title="Conversation storage needs attention"
-          message={sessionPersistence.writeError}
-          onRetry={sessionPersistence.retryWrites}
-        />
-      ) : sessionPersistence.loadWarning ? (
-        <SessionPersistenceAlert
-          title="Saved conversation data was damaged"
-          message={sessionPersistence.loadWarning}
-          variant="warning"
-          onDismiss={sessionPersistence.dismissLoadWarning}
-        />
-      ) : null}
-      <WorkspaceAgentRuntimeProvider>
-        {view === 'home' ? (
-          <HomePage
-            canDeleteProjects={sessionPersistence.canDeleteSessionsAndProjects}
-            hasCompleteSessionCatalog={sessionPersistence.hasCompleteSessionCatalog}
-            onOpenGlobalSearch={() => setIsGlobalSearchOpen(true)}
+      <div
+        className="contents"
+        inert={!isBasePresentationActive}
+        aria-hidden={isBasePresentationActive ? undefined : true}
+      >
+        <EnvStatusBanner ui={envUi} onRetry={() => void retryEnv()} />
+        {sessionPersistence.loadError ? (
+          <SessionPersistenceAlert
+            title="Saved conversations could not be loaded"
+            message={sessionPersistence.loadError}
+            onRetry={sessionPersistence.retryLoad}
           />
-        ) : (
-          <WorkspacePage
-            isSessionPersistenceHydrated={isSessionPersistenceHydrated}
-            isSessionPersistenceReady={isSessionPersistenceReady}
-            canDeleteConversations={sessionPersistence.canDeleteSessionsAndProjects}
+        ) : sessionPersistence.writeError ? (
+          <SessionPersistenceAlert
+            title="Conversation storage needs attention"
+            message={sessionPersistence.writeError}
+            onRetry={sessionPersistence.retryWrites}
           />
-        )}
-      </WorkspaceAgentRuntimeProvider>
+        ) : sessionPersistence.loadWarning ? (
+          <SessionPersistenceAlert
+            title="Saved conversation data was damaged"
+            message={sessionPersistence.loadWarning}
+            variant="warning"
+            onDismiss={sessionPersistence.dismissLoadWarning}
+          />
+        ) : null}
+        <WorkspaceAgentRuntimeProvider>
+          {view === 'home' ? (
+            <HomePage
+              canDeleteProjects={sessionPersistence.canDeleteSessionsAndProjects}
+              hasCompleteSessionCatalog={sessionPersistence.hasCompleteSessionCatalog}
+              onOpenGlobalSearch={() => {
+                if (appShellPresentation.allowsShortcut('globalSearch')) {
+                  setIsGlobalSearchOpen(true)
+                }
+              }}
+            />
+          ) : (
+            <WorkspacePage
+              isSessionPersistenceHydrated={isSessionPersistenceHydrated}
+              isSessionPersistenceReady={isSessionPersistenceReady}
+              canDeleteConversations={sessionPersistence.canDeleteSessionsAndProjects}
+              isPreviewPresentationActive={isBasePresentationActive}
+            />
+          )}
+        </WorkspaceAgentRuntimeProvider>
+        <LifecycleToast
+          notice={lifecycleSync.notice}
+          onDismiss={lifecycleSync.dismissNotice}
+          onView={lifecycleSync.viewNotice}
+        />
+        <PermissionUndoSnackbar />
+      </div>
       <SettingsPage
         ref={settingsPageRef}
-        open={isSettingsOpen}
+        open={activePresentation === 'settings'}
         onClose={closeSettings}
         onOpenSession={openPermissionSession}
       />
-      <ConnectorApprovalDialog blockedSessionIds={openSideChatParentSessionIds} />
-      <SkillImportApprovalDialog blockedSessionIds={openSideChatParentSessionIds} />
-      <LifecycleToast
-        notice={lifecycleSync.notice}
-        onDismiss={lifecycleSync.dismissNotice}
-        onView={lifecycleSync.viewNotice}
+      <ConnectorApprovalDialog
+        active={activePresentation === 'connectorApproval'}
+        blockedSessionIds={openSideChatParentSessionIds}
       />
-      <PermissionUndoSnackbar />
-      <ComputeApprovalDialog blockedSessionIds={openSideChatParentSessionIds} />
-      <UpdateDialog />
-      <CloseConfirmModal onOpenChange={setIsCloseConfirmOpen} />
-      {isGlobalSearchOpen ? (
+      <SkillImportApprovalDialog
+        active={activePresentation === 'skillImportApproval'}
+        blockedSessionIds={openSideChatParentSessionIds}
+      />
+      <ComputeApprovalDialog
+        active={activePresentation === 'computeApproval'}
+        blockedSessionIds={openSideChatParentSessionIds}
+      />
+      <UpdateDialog active={activePresentation === 'update'} />
+      <CloseConfirmModal
+        active={activePresentation === 'closeConfirmation'}
+        onOpenChange={setIsCloseConfirmOpen}
+      />
+      {activePresentation === 'globalSearch' ? (
         <GlobalSearchDialog
           open
           onOpenChange={setIsGlobalSearchOpen}
@@ -636,12 +652,13 @@ const AppContent = (): React.JSX.Element | null => {
         />
       ) : null}
       <DataRootMissingDialog
-        open={missingDataRoot !== undefined}
+        open={activePresentation === 'dataRootRecovery'}
         dataRoot={missingDataRoot ?? ''}
         onResolved={() => setMissingDataRoot(undefined)}
       />
       {legacyMove !== undefined ? (
         <LegacyDataMoveDialog
+          active={activePresentation === 'legacyDataMove'}
           currentDataRoot={legacyMove.currentDataRoot}
           defaultParent={legacyMove.defaultParent}
           onDismiss={() => setLegacyMove(undefined)}

--- a/src/renderer/src/app-shell-presentation-owner.architecture.test.ts
+++ b/src/renderer/src/app-shell-presentation-owner.architecture.test.ts
@@ -1,0 +1,142 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, extname, relative, resolve } from 'node:path'
+import {
+  createSourceFile,
+  forEachChild,
+  isBinaryExpression,
+  isCallExpression,
+  isIdentifier,
+  isImportDeclaration,
+  isStringLiteralLike,
+  ScriptKind,
+  ScriptTarget,
+  type Node
+} from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+const rendererRoot = __dirname
+const appPath = resolve(rendererRoot, 'App.tsx')
+const ownerPath = resolve(rendererRoot, 'app-shell-presentation-owner.ts')
+const readSource = (path: string): string => readFileSync(path, 'utf8')
+const modulePath = (path: string): string => path.replace(/\.[cm]?[jt]sx?$/, '')
+
+const productionSources = (): readonly string[] => {
+  const paths: string[] = []
+  const visit = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = resolve(directory, entry.name)
+      if (entry.isDirectory()) visit(path)
+      else if (/\.[cm]?tsx?$/.test(entry.name) && !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)) {
+        paths.push(path)
+      }
+    }
+  }
+  visit(rendererRoot)
+  return paths.sort()
+}
+
+const importsTarget = (sourcePath: string, targetPath: string): boolean => {
+  let importsOwner = false
+  const sourceFile = createSourceFile(
+    sourcePath,
+    readSource(sourcePath),
+    ScriptTarget.Latest,
+    true,
+    extname(sourcePath) === '.tsx' ? ScriptKind.TSX : ScriptKind.TS
+  )
+  const visit = (node: Node): void => {
+    if (isImportDeclaration(node) && isStringLiteralLike(node.moduleSpecifier)) {
+      const specifier = node.moduleSpecifier.text
+      const resolved = specifier.startsWith('@/')
+        ? resolve(rendererRoot, specifier.slice(2))
+        : specifier.startsWith('.')
+          ? resolve(dirname(sourcePath), specifier)
+          : undefined
+      if (resolved && modulePath(resolved) === modulePath(targetPath)) importsOwner = true
+    }
+    forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return importsOwner
+}
+
+const rootGateIdentifiers = new Set([
+  'hasComputeApproval',
+  'hasConnectorApproval',
+  'hasSkillImportApproval',
+  'isCloseConfirmOpen',
+  'isGlobalSearchOpen',
+  'isPreviewModalOpen',
+  'isSettingsOpen',
+  'isUpdateDialogOpen',
+  'legacyMove',
+  'missingDataRoot'
+])
+
+const repeatedRootGateLists = (source: string): readonly string[] => {
+  const sourceFile = createSourceFile(appPath, source, ScriptTarget.Latest, true, ScriptKind.TSX)
+  const violations = new Set<string>()
+  const insideOwnerProjection = (node: Node): boolean => {
+    for (let current: Node | undefined = node; current; current = current.parent) {
+      if (
+        isCallExpression(current) &&
+        isIdentifier(current.expression) &&
+        current.expression.text === 'resolveAppShellPresentation'
+      ) {
+        return true
+      }
+    }
+    return false
+  }
+  const identifiersWithin = (node: Node): readonly string[] => {
+    const identifiers = new Set<string>()
+    const collect = (candidate: Node): void => {
+      if (isIdentifier(candidate) && rootGateIdentifiers.has(candidate.text)) {
+        identifiers.add(candidate.text)
+      }
+      forEachChild(candidate, collect)
+    }
+    collect(node)
+    return [...identifiers].sort()
+  }
+  const visit = (node: Node): void => {
+    if (isBinaryExpression(node) && !insideOwnerProjection(node)) {
+      const identifiers = identifiersWithin(node)
+      if (identifiers.length > 1) violations.add(identifiers.join(','))
+    }
+    forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return [...violations].sort()
+}
+
+describe('App Shell presentation owner architecture', () => {
+  it('keeps the root App as the only production composition consumer', () => {
+    const importers = productionSources()
+      .filter((path) => importsTarget(path, ownerPath))
+      .map((path) => relative(rendererRoot, path).replaceAll('\\', '/'))
+
+    expect(importers).toEqual(['App.tsx'])
+  })
+
+  it('routes visibility, root shortcuts, and close commands through the owner projection', () => {
+    const appSource = readSource(appPath)
+
+    expect(appSource.match(/resolveAppShellPresentation\(/g)).toHaveLength(1)
+    expect(appSource).toContain(
+      'isSessionContentVisible: appShellPresentation.isSessionContentVisible'
+    )
+    expect(appSource).toContain("!appShellPresentation.allowsShortcut('settings')")
+    expect(appSource).toContain("!appShellPresentation.allowsShortcut('globalSearch')")
+    expect(appSource).toContain('const action = appShellPresentation.resolveCloseAction()')
+    expect(appSource).not.toContain('STREAMDOWN_FULLSCREEN_SELECTOR')
+    expect(appSource).not.toContain('document.querySelector')
+    expect(repeatedRootGateLists(appSource)).toEqual([])
+  })
+
+  it('rejects a recreated multi-store gate list outside the owner projection', () => {
+    expect(
+      repeatedRootGateLists('const eligible = !isSettingsOpen && !hasComputeApproval')
+    ).toEqual(['hasComputeApproval,isSettingsOpen'])
+  })
+})

--- a/src/renderer/src/app-shell-presentation-owner.test.ts
+++ b/src/renderer/src/app-shell-presentation-owner.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+
+import {
+  resolveAppShellPresentation,
+  type AppShellPresentationInput,
+  type AppShellPresentationState
+} from './app-shell-presentation-owner'
+
+const noPresentations = (): AppShellPresentationState => ({
+  closeConfirmation: false,
+  dataRootRecovery: false,
+  legacyDataMove: false,
+  update: false,
+  computeApproval: false,
+  connectorApproval: false,
+  skillImportApproval: false,
+  globalSearch: false,
+  settings: false,
+  preview: false
+})
+
+const input = (
+  presentations: Partial<AppShellPresentationState> = {},
+  overrides: Partial<Omit<AppShellPresentationInput, 'presentations'>> = {}
+): AppShellPresentationInput => ({
+  startupView: 'app',
+  isSessionPersistenceHydrated: true,
+  isSessionPersistenceLoading: false,
+  view: 'workspace',
+  ...overrides,
+  presentations: { ...noPresentations(), ...presentations }
+})
+
+describe('App Shell presentation owner', () => {
+  it('selects one presentation from the fixed semantic priority', () => {
+    const priority: Array<keyof AppShellPresentationState> = [
+      'closeConfirmation',
+      'dataRootRecovery',
+      'legacyDataMove',
+      'update',
+      'computeApproval',
+      'connectorApproval',
+      'skillImportApproval',
+      'globalSearch',
+      'settings',
+      'preview'
+    ]
+
+    for (let index = 0; index < priority.length; index += 1) {
+      const available = Object.fromEntries(
+        priority.slice(index).map((presentation) => [presentation, true])
+      ) as Partial<AppShellPresentationState>
+
+      expect(resolveAppShellPresentation(input(available)).active).toBe(priority[index])
+    }
+    expect(resolveAppShellPresentation(input()).active).toBe('base')
+  })
+
+  it('keeps startup non-interactive and only reports uncovered workspace content as visible', () => {
+    expect(resolveAppShellPresentation(input({}, { startupView: undefined })).active).toBe(
+      'startup'
+    )
+    expect(
+      resolveAppShellPresentation(input({}, { isSessionPersistenceHydrated: false }))
+        .isSessionContentVisible
+    ).toBe(false)
+    expect(
+      resolveAppShellPresentation(input({}, { isSessionPersistenceLoading: true }))
+        .isSessionContentVisible
+    ).toBe(false)
+    expect(resolveAppShellPresentation(input({}, { view: 'home' })).isSessionContentVisible).toBe(
+      false
+    )
+    expect(resolveAppShellPresentation(input({ settings: true })).isSessionContentVisible).toBe(
+      false
+    )
+    expect(resolveAppShellPresentation(input()).isSessionContentVisible).toBe(true)
+  })
+
+  it('lets only base content open tools and lets global search toggle itself closed', () => {
+    const base = resolveAppShellPresentation(input())
+    expect(base.allowsShortcut('settings')).toBe(true)
+    expect(base.allowsShortcut('globalSearch')).toBe(true)
+
+    const nestedDialog = document.createElement('div')
+    nestedDialog.setAttribute('role', 'dialog')
+    document.body.appendChild(nestedDialog)
+    expect(base.allowsShortcut('settings')).toBe(false)
+    expect(base.allowsShortcut('globalSearch')).toBe(false)
+    nestedDialog.remove()
+
+    const search = resolveAppShellPresentation(input({ globalSearch: true }))
+    expect(search.allowsShortcut('globalSearch')).toBe(true)
+    expect(search.allowsShortcut('settings')).toBe(false)
+    expect(
+      resolveAppShellPresentation(input({ settings: true })).allowsShortcut('globalSearch')
+    ).toBe(false)
+  })
+
+  it('ignores closed and hidden DOM presentations when checking shortcut eligibility', () => {
+    const base = resolveAppShellPresentation(input())
+    const closed = document.createElement('div')
+    closed.setAttribute('role', 'dialog')
+    closed.dataset.state = 'closed'
+    const hidden = document.createElement('div')
+    hidden.hidden = true
+    const hiddenDialog = document.createElement('div')
+    hiddenDialog.setAttribute('role', 'alertdialog')
+    hidden.appendChild(hiddenDialog)
+    document.body.append(closed, hidden)
+
+    expect(base.allowsShortcut('settings')).toBe(true)
+    expect(base.allowsShortcut('globalSearch')).toBe(true)
+    closed.remove()
+    hidden.remove()
+  })
+
+  it.each([
+    ['startup', {}, { startupView: undefined }, 'consume'],
+    ['closeConfirmation', { closeConfirmation: true }, {}, 'consume'],
+    ['dataRootRecovery', { dataRootRecovery: true }, {}, 'consume'],
+    ['legacyDataMove', { legacyDataMove: true }, {}, 'consume'],
+    ['update', { update: true }, {}, 'close-update'],
+    ['computeApproval', { computeApproval: true }, {}, 'consume'],
+    ['connectorApproval', { connectorApproval: true }, {}, 'consume'],
+    ['skillImportApproval', { skillImportApproval: true }, {}, 'consume'],
+    ['globalSearch', { globalSearch: true }, {}, 'close-global-search'],
+    ['settings', { settings: true }, {}, 'close-settings'],
+    ['preview', { preview: true }, {}, 'close-preview'],
+    ['base', {}, {}, 'close-base']
+  ] as const)('maps %s to the owned close action', (_name, presentations, overrides, action) => {
+    expect(
+      resolveAppShellPresentation(input(presentations, overrides)).resolveCloseAction().kind
+    ).toBe(action)
+  })
+
+  it.each([
+    ['semantic dialog', 'role', 'dialog'],
+    ['Context window dialog', 'data-slot', 'context-window-dialog']
+  ])('closes an open nested %s before base panes or the window', (_name, attribute, value) => {
+    const dialog = document.createElement('div')
+    dialog.setAttribute(attribute, value)
+    document.body.appendChild(dialog)
+
+    const action = resolveAppShellPresentation(input()).resolveCloseAction()
+    expect(action.kind).toBe('dismiss-dom-presentation')
+    expect(action.kind === 'dismiss-dom-presentation' ? action.target : undefined).toBe(dialog)
+    dialog.remove()
+  })
+
+  it.each([
+    ['workspace dialog', 'role', 'dialog'],
+    ['workspace alert dialog', 'role', 'alertdialog'],
+    ['Streamdown fullscreen', 'data-streamdown', 'table-fullscreen'],
+    ['Context window', 'data-slot', 'context-window-dialog']
+  ])('closes a nested %s before its preview', (_name, attribute, value) => {
+    const nestedPresentation = document.createElement('div')
+    nestedPresentation.setAttribute(attribute, value)
+    document.body.appendChild(nestedPresentation)
+
+    const action = resolveAppShellPresentation(input({ preview: true })).resolveCloseAction()
+    expect(action.kind).toBe('dismiss-dom-presentation')
+    expect(action.kind === 'dismiss-dom-presentation' ? action.target : undefined).toBe(
+      nestedPresentation
+    )
+    nestedPresentation.remove()
+  })
+})

--- a/src/renderer/src/app-shell-presentation-owner.ts
+++ b/src/renderer/src/app-shell-presentation-owner.ts
@@ -1,0 +1,118 @@
+import { STREAMDOWN_FULLSCREEN_SELECTOR } from '@/components/streamdown/dom-selectors'
+import type { NavigationView } from '@/stores/navigation-store'
+
+export type AppShellPresentationState = Readonly<{
+  closeConfirmation: boolean
+  dataRootRecovery: boolean
+  legacyDataMove: boolean
+  update: boolean
+  computeApproval: boolean
+  connectorApproval: boolean
+  skillImportApproval: boolean
+  globalSearch: boolean
+  settings: boolean
+  preview: boolean
+}>
+
+export type AppShellPresentationInput = Readonly<{
+  startupView: 'app' | 'onboarding' | undefined
+  isSessionPersistenceHydrated: boolean
+  isSessionPersistenceLoading: boolean
+  view: NavigationView
+  presentations: AppShellPresentationState
+}>
+
+export type AppShellPresentation = keyof AppShellPresentationState | 'startup' | 'base'
+export type AppShellShortcut = 'settings' | 'globalSearch'
+
+export type AppShellCloseAction =
+  | Readonly<{ kind: 'consume' }>
+  | Readonly<{ kind: 'close-update' }>
+  | Readonly<{ kind: 'close-global-search' }>
+  | Readonly<{ kind: 'close-settings' }>
+  | Readonly<{ kind: 'close-preview' }>
+  | Readonly<{ kind: 'close-base' }>
+  | Readonly<{ kind: 'dismiss-dom-presentation'; target: HTMLElement }>
+
+export type AppShellPresentationProjection = Readonly<{
+  active: AppShellPresentation
+  isSessionContentVisible: boolean
+  allowsShortcut: (shortcut: AppShellShortcut, root?: ParentNode) => boolean
+  resolveCloseAction: (root?: ParentNode) => AppShellCloseAction
+}>
+
+const PRESENTATION_PRIORITY: ReadonlyArray<keyof AppShellPresentationState> = [
+  'closeConfirmation',
+  'dataRootRecovery',
+  'legacyDataMove',
+  'update',
+  'computeApproval',
+  'connectorApproval',
+  'skillImportApproval',
+  'globalSearch',
+  'settings',
+  'preview'
+]
+
+const BLOCKING_DOM_PRESENTATION_SELECTOR = `[role="dialog"], [role="alertdialog"], [data-slot="context-window-dialog"], ${STREAMDOWN_FULLSCREEN_SELECTOR}`
+
+const isEffectivelyOpen = (element: HTMLElement): boolean =>
+  element.dataset.state !== 'closed' && element.closest('[aria-hidden="true"], [hidden]') === null
+
+const findTopmostDomPresentation = (
+  root: ParentNode,
+  selector = BLOCKING_DOM_PRESENTATION_SELECTOR
+): HTMLElement | undefined =>
+  Array.from(root.querySelectorAll<HTMLElement>(selector)).filter(isEffectivelyOpen).at(-1)
+
+const resolveActivePresentation = (input: AppShellPresentationInput): AppShellPresentation => {
+  if (input.startupView !== 'app' || !input.isSessionPersistenceHydrated) return 'startup'
+
+  return PRESENTATION_PRIORITY.find((presentation) => input.presentations[presentation]) ?? 'base'
+}
+
+const closeActionFor = (active: AppShellPresentation, root: ParentNode): AppShellCloseAction => {
+  if (active === 'base') {
+    const nestedPresentation = findTopmostDomPresentation(root)
+    return nestedPresentation
+      ? { kind: 'dismiss-dom-presentation', target: nestedPresentation }
+      : { kind: 'close-base' }
+  }
+
+  // Workspace dialogs and fullscreen viewers can be nested inside a preview modal. They own the
+  // first close command; the preview state remains intact until the next command.
+  if (active === 'preview') {
+    const nestedPresentation = findTopmostDomPresentation(root)
+    return nestedPresentation
+      ? { kind: 'dismiss-dom-presentation', target: nestedPresentation }
+      : { kind: 'close-preview' }
+  }
+
+  if (active === 'update') return { kind: 'close-update' }
+  if (active === 'globalSearch') return { kind: 'close-global-search' }
+  if (active === 'settings') return { kind: 'close-settings' }
+
+  // Startup, recovery, close confirmation, and approval presentations require an explicit decision.
+  return { kind: 'consume' }
+}
+
+// Projects independently-owned store/local state into the one presentation that may interact with
+// the user. The projection also owns every App Shell shortcut decision so callers cannot rebuild the
+// priority as parallel Boolean gate lists.
+export const resolveAppShellPresentation = (
+  input: AppShellPresentationInput
+): AppShellPresentationProjection => {
+  const active = resolveActivePresentation(input)
+
+  return {
+    active,
+    isSessionContentVisible:
+      active === 'base' && input.view === 'workspace' && !input.isSessionPersistenceLoading,
+    allowsShortcut: (shortcut, root = document) => {
+      if (shortcut === 'globalSearch' && active === 'globalSearch') return true
+      if (active !== 'base') return false
+      return findTopmostDomPresentation(root) === undefined
+    },
+    resolveCloseAction: (root = document) => closeActionFor(active, root)
+  }
+}

--- a/src/renderer/src/components/CloseConfirmModal.render.test.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.render.test.tsx
@@ -76,6 +76,24 @@ const findButtonByName = async (pattern: RegExp): Promise<HTMLButtonElement> => 
 }
 
 describe('CloseConfirmModal', () => {
+  it('retains a covered close request until its presentation becomes active', async () => {
+    act(() => root.render(<CloseConfirmModal active={false} />))
+    act(() => {
+      emit({ requestId: 'r-covered', variant: 'close-to-tray', sessions: [] })
+    })
+
+    expect(sendResponse).toHaveBeenCalledWith({ requestId: 'r-covered', ack: true })
+    expect(document.body.querySelector('[role="alertdialog"]')).toBeNull()
+    expect(sendResponse).not.toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: 'r-covered', choice: expect.anything() })
+    )
+
+    act(() => root.render(<CloseConfirmModal active />))
+
+    await findByText(/Minimize or quit?/)
+    expect(document.body.querySelector('[role="alertdialog"]')).not.toBeNull()
+  })
+
   it('uses shared settings dialog chrome for the close confirmation', async () => {
     render()
     act(() => {

--- a/src/renderer/src/components/CloseConfirmModal.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.tsx
@@ -26,8 +26,10 @@ type ActiveRequest = {
 // only), so every call into window.api.window here must tolerate that absence. onOpenChange also
 // feeds unread visibility projection, preventing a covered conversation from being acknowledged.
 export const CloseConfirmModal = ({
+  active = true,
   onOpenChange
 }: {
+  active?: boolean
   onOpenChange?: (open: boolean) => void
 }): React.JSX.Element | null => {
   const [request, setRequest] = useState<ActiveRequest | undefined>(undefined)
@@ -75,7 +77,7 @@ export const CloseConfirmModal = ({
 
   return (
     <AlertDialog.Root
-      open={Boolean(request)}
+      open={active && Boolean(request)}
       onOpenChange={(open) => {
         if (!open) reply('cancel')
       }}

--- a/src/renderer/src/components/LegacyDataMoveDialog.render.test.tsx
+++ b/src/renderer/src/components/LegacyDataMoveDialog.render.test.tsx
@@ -69,6 +69,25 @@ afterEach(() => {
 })
 
 describe('LegacyDataMoveDialog', () => {
+  it('keeps a covered legacy prompt pending without dismissing it', async () => {
+    const api = installApi()
+
+    await act(async () => {
+      root.render(
+        <LegacyDataMoveDialog
+          active={false}
+          currentDataRoot="/home/u/.open-science"
+          defaultParent="/home/u"
+          onDismiss={vi.fn()}
+        />
+      )
+      await Promise.resolve()
+    })
+
+    expect(document.body.querySelector('[role="alertdialog"]')).toBeNull()
+    expect(api.dismissLegacyMovePrompt).not.toHaveBeenCalled()
+  })
+
   it('uses shared settings dialog chrome without changing the move choices', async () => {
     installApi()
     await renderDialog()

--- a/src/renderer/src/components/LegacyDataMoveDialog.tsx
+++ b/src/renderer/src/components/LegacyDataMoveDialog.tsx
@@ -12,6 +12,8 @@ import {
 import { StorageMigrationModal } from '@/pages/settings/StorageMigrationModal'
 
 type LegacyDataMoveDialogProps = {
+  // App Shell presentation ownership may temporarily cover this prompt without discarding its state.
+  active?: boolean
   // The hidden config root where a legacy install's data currently lives (e.g. ~/.open-science).
   currentDataRoot: string
   // The parent the "Move to OpenScience" action relocates into; its derived data root (resolved via
@@ -28,6 +30,7 @@ type LegacyDataMoveDialogProps = {
 // restart. Moving sets settings.dataRoot, which by itself disqualifies the prompt on the next launch,
 // so only the "keep it here" path needs to persist a dismissal.
 const LegacyDataMoveDialog = ({
+  active = true,
   currentDataRoot,
   defaultParent,
   onDismiss
@@ -84,6 +87,7 @@ const LegacyDataMoveDialog = ({
   if (migrationTarget !== null) {
     return (
       <StorageMigrationModal
+        active={active}
         targetPath={migrationTarget}
         onClose={() => setMigrationTarget(null)}
       />
@@ -91,7 +95,7 @@ const LegacyDataMoveDialog = ({
   }
 
   return (
-    <AlertDialog.Root open>
+    <AlertDialog.Root open={active}>
       <AlertDialog.Portal>
         <AlertDialog.Overlay className={dialogOverlayClassName} />
         <AlertDialog.Content className={dialogPanelClassName('w-[min(460px,calc(100vw-2rem))]')}>

--- a/src/renderer/src/components/UpdateDialog.render.test.tsx
+++ b/src/renderer/src/components/UpdateDialog.render.test.tsx
@@ -32,6 +32,18 @@ afterEach(() => {
 })
 
 describe('UpdateDialog', () => {
+  it('preserves a covered update request while suppressing its presentation', () => {
+    useUpdateStore.setState({
+      isDialogOpen: true,
+      status: { state: 'available', current: '0.1.0', latest: '0.2.0' }
+    })
+
+    act(() => root.render(<UpdateDialog active={false} />))
+
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull()
+    expect(useUpdateStore.getState().isDialogOpen).toBe(true)
+  })
+
   it('uses shared settings dialog chrome and prevents outside-click dismissal', () => {
     useUpdateStore.setState({
       isDialogOpen: true,

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -19,14 +19,14 @@ import { formatBytes } from '../../../shared/update'
 // Update confirmation dialog: shows the target version and release notes so the user can decide
 // before a large download. Opened from the external capsule and the settings About section. When the
 // manifest carries no notes, it links to the matching GitHub release so the user can still read them.
-const UpdateDialog = (): React.JSX.Element | null => {
+const UpdateDialog = ({ active = true }: { active?: boolean }): React.JSX.Element | null => {
   const status = useUpdateStore((state) => state.status)
   const isOpen = useUpdateStore((state) => state.isDialogOpen)
   const closeDialog = useUpdateStore((state) => state.closeDialog)
   const download = useUpdateStore((state) => state.download)
   const apply = useUpdateStore((state) => state.apply)
 
-  const open = Boolean(isOpen && status.latest)
+  const open = Boolean(active && isOpen && status.latest)
   const dialogStatus = useRetainedDialogValue(open ? status : undefined)
   const releaseUrl = `${APP.links.githubReleases}/tag/v${dialogStatus?.latest ?? ''}`
   const isDownloading = dialogStatus?.state === 'downloading'

--- a/src/renderer/src/hooks/useCloseActivePaneShortcut.test.ts
+++ b/src/renderer/src/hooks/useCloseActivePaneShortcut.test.ts
@@ -165,7 +165,7 @@ describe('useCloseActivePaneShortcut', () => {
   it('lets an active modal handle the shortcut before preview panes or the window', () => {
     useNavigationStore.setState({ view: 'workspace' })
     usePreviewWorkbenchStore.getState().upsertAndActivateItem(fileTab('kept-open'))
-    const closeActiveModal = vi.fn(() => true)
+    const closeActiveModal = vi.fn(() => 'handled' as const)
 
     const { unmount } = renderHook(() => useCloseActivePaneShortcut(closeActiveModal))
     act(() => closeActivePane?.())
@@ -184,7 +184,7 @@ describe('useCloseActivePaneShortcut', () => {
     preview.setToolItemExpanded('expanded-tool')
     preview.openFileDialog(fileTab('dialog'))
 
-    const { unmount } = renderHook(() => useCloseActivePaneShortcut())
+    const { unmount } = renderHook(() => useCloseActivePaneShortcut(() => 'close-preview'))
     act(() => closeActivePane?.())
     expect(usePreviewWorkbenchStore.getState().fileDialogItem).toBeUndefined()
     expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBe('expanded-tool')

--- a/src/renderer/src/hooks/useCloseActivePaneShortcut.ts
+++ b/src/renderer/src/hooks/useCloseActivePaneShortcut.ts
@@ -4,6 +4,7 @@ import { useNavigationStore, type NavigationView } from '@/stores/navigation-sto
 import { usePreviewWorkbenchStore, type PreviewPanelState } from '@/stores/preview-workbench-store'
 
 export type CloseActivePaneAction = 'close-active-tab' | 'collapse-pane' | 'close-window'
+export type AppShellCloseRequest = 'handled' | 'close-preview' | 'close-base'
 
 // Cmd+W / Ctrl+W walks a three-level ladder inside the workspace: close the active preview tab, then
 // collapse the (now empty) third-column panel, then fall through to closing the window. Gating on the
@@ -21,23 +22,27 @@ export const decideCloseActivePaneAction = (input: {
   return 'close-window'
 }
 
-// Wires the main-process close chord to the tab-vs-pane-vs-window decision. Store state is read
-// imperatively so the subscription is installed once yet always sees the current view and panel state.
-export const useCloseActivePaneShortcut = (closeActiveModal?: () => boolean): void => {
-  const closeActiveModalRef = useRef(closeActiveModal)
+// Executes the App Shell owner's presentation-tier decision, then applies the preview-internal
+// tab-vs-pane-vs-window ladder only for the requested tier. Store state is read imperatively so the
+// subscription is installed once yet always sees the current view and panel state.
+export const useCloseActivePaneShortcut = (
+  resolveCloseRequest?: () => AppShellCloseRequest
+): void => {
+  const resolveCloseRequestRef = useRef(resolveCloseRequest)
   useEffect(() => {
-    closeActiveModalRef.current = closeActiveModal
-  }, [closeActiveModal])
+    resolveCloseRequestRef.current = resolveCloseRequest
+  }, [resolveCloseRequest])
 
   useEffect(
     () =>
       window.api.window.onCloseActivePane(() => {
-        if (closeActiveModalRef.current?.()) return
+        const request = resolveCloseRequestRef.current?.() ?? 'close-base'
+        if (request === 'handled') return
 
         const preview = usePreviewWorkbenchStore.getState()
         const view = useNavigationStore.getState().view
         const activeItem = preview.items.find((item) => item.id === preview.activeItemId)
-        if (view === 'workspace') {
+        if (request === 'close-preview' && view === 'workspace') {
           if (preview.fileDialogItem) {
             preview.closeFileDialog()
             return
@@ -47,6 +52,7 @@ export const useCloseActivePaneShortcut = (closeActiveModal?: () => boolean): vo
             return
           }
         }
+        if (request === 'close-preview') return
 
         const action = decideCloseActivePaneAction({
           view,

--- a/src/renderer/src/pages/settings/ComputeApprovalDialog.render.test.tsx
+++ b/src/renderer/src/pages/settings/ComputeApprovalDialog.render.test.tsx
@@ -48,6 +48,15 @@ describe('ComputeApprovalDialog', () => {
     expect(document.body.querySelector('[role="dialog"]')).toBeNull()
   })
 
+  it('keeps a covered approval queued while suppressing its presentation', () => {
+    useComputeStore.setState({ pendingApprovals: [request] })
+
+    act(() => root.render(<ComputeApprovalDialog active={false} />))
+
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull()
+    expect(useComputeStore.getState().pendingApprovals).toEqual([request])
+  })
+
   it('keeps approvals for the open Side chat parent queued without showing its dialog', () => {
     useComputeStore.setState({
       pendingApprovals: [{ ...request, session_id: 'session-side' }]

--- a/src/renderer/src/pages/settings/ComputeApprovalDialog.tsx
+++ b/src/renderer/src/pages/settings/ComputeApprovalDialog.tsx
@@ -28,8 +28,10 @@ import { useComputeStore } from '@/stores/compute-store'
 //   This project      — approve for (provider, operation) for all future calls in this project
 //   Always            — approve for (provider, operation) across projects
 export function ComputeApprovalDialog({
+  active = true,
   blockedSessionIds
 }: {
+  active?: boolean
   blockedSessionIds?: ReadonlySet<string>
 }): React.JSX.Element | null {
   const request = useComputeStore((state) =>
@@ -58,7 +60,7 @@ export function ComputeApprovalDialog({
   const showFull = expandedRequestId === dialogRequest.id
 
   return (
-    <Dialog.Root open={Boolean(request)}>
+    <Dialog.Root open={active && Boolean(request)}>
       <Dialog.Portal>
         <Dialog.Overlay className={cn(dialogOverlayClassName, 'z-[60]')} />
         <Dialog.Content
@@ -153,7 +155,7 @@ export function ComputeApprovalDialog({
       </Dialog.Portal>
       <PermissionScopeConfirmationDialog
         confirmation={
-          pendingBroadScope
+          active && pendingBroadScope
             ? {
                 scope: pendingBroadScope,
                 subject: `remote commands on ${dialogRequest.provider_name}`,

--- a/src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx
@@ -49,6 +49,24 @@ describe('ConnectorApprovalDialog', () => {
     expect(document.body.querySelector('[role="dialog"]')).toBeNull()
   })
 
+  it('keeps a covered approval queued while suppressing its presentation', () => {
+    useSettingsStore.setState({
+      pendingApprovals: [
+        {
+          id: 'r1',
+          connector: 'biomart',
+          method: 'get_data',
+          argsPreview: '{}'
+        }
+      ]
+    })
+
+    act(() => root.render(<ConnectorApprovalDialog active={false} />))
+
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull()
+    expect(useSettingsStore.getState().pendingApprovals).toHaveLength(1)
+  })
+
   it('keeps approvals for the open Side chat parent queued without showing its dialog', () => {
     useSettingsStore.setState({
       pendingApprovals: [

--- a/src/renderer/src/pages/settings/ConnectorApprovalDialog.tsx
+++ b/src/renderer/src/pages/settings/ConnectorApprovalDialog.tsx
@@ -13,8 +13,10 @@ import { useSettingsStore } from '@/stores/settings-store'
 // service, so a call that isn't pre-allowed or skip-approved is held until the user decides here.
 // Requests are answered one at a time (oldest first); the card can't be dismissed without a decision.
 export function ConnectorApprovalDialog({
+  active = true,
   blockedSessionIds
 }: {
+  active?: boolean
   blockedSessionIds?: ReadonlySet<string>
 }): React.JSX.Element | null {
   const request = useSettingsStore((state) =>
@@ -51,7 +53,7 @@ export function ConnectorApprovalDialog({
   const deny = (): void => void respondApproval(request.id, 'deny')
 
   return (
-    <Dialog.Root open>
+    <Dialog.Root open={active}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-[60] bg-black/50" />
         <Dialog.Content
@@ -116,7 +118,7 @@ export function ConnectorApprovalDialog({
       </Dialog.Portal>
       <PermissionScopeConfirmationDialog
         confirmation={
-          pendingBroadScope
+          active && pendingBroadScope
             ? {
                 scope: pendingBroadScope,
                 subject: `${displayName} ${request.method}`,

--- a/src/renderer/src/pages/settings/SkillImportApprovalDialog.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillImportApprovalDialog.render.test.tsx
@@ -53,6 +53,21 @@ const importCandidate = (subPath: string, name: string): SkillBundlePreview => (
 })
 
 describe('SkillImportApprovalDialog', () => {
+  it('keeps a covered approval queued while suppressing its presentation', () => {
+    useSkillImportStore.getState().enqueue({
+      id: 'approval-covered',
+      sessionId: 'session-1',
+      source: { kind: 'attachment', label: 'paper-finder.skill' },
+      previews: [importCandidate('paper-finder', 'Paper Finder')],
+      skipped: []
+    })
+
+    act(() => root.render(<SkillImportApprovalDialog active={false} />))
+
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull()
+    expect(useSkillImportStore.getState().pending).toHaveLength(1)
+  })
+
   it('keeps approvals for the open Side chat parent queued without showing its dialog', () => {
     useSkillImportStore.getState().enqueue({
       id: 'approval-side',

--- a/src/renderer/src/pages/settings/SkillImportApprovalDialog.tsx
+++ b/src/renderer/src/pages/settings/SkillImportApprovalDialog.tsx
@@ -14,11 +14,13 @@ import { SkillImportCandidatePreview } from './SkillImportCandidatePreview'
 import { useSkillImportCandidatePreview } from './useSkillImportCandidatePreview'
 
 type SkillImportApprovalRequestDialogProps = {
+  active: boolean
   request: ConversationSkillImportApprovalRequest
   respond: (response: ConversationSkillImportApprovalResponse) => Promise<void>
 }
 
 const SkillImportApprovalRequestDialog = ({
+  active,
   request,
   respond
 }: SkillImportApprovalRequestDialogProps): React.JSX.Element => {
@@ -75,7 +77,7 @@ const SkillImportApprovalRequestDialog = ({
 
   return (
     <>
-      <Dialog.Root open>
+      <Dialog.Root open={active}>
         <Dialog.Portal>
           <Dialog.Overlay className={dialogOverlayClassName} />
           <Dialog.Content
@@ -213,14 +215,19 @@ const SkillImportApprovalRequestDialog = ({
           </Dialog.Content>
         </Dialog.Portal>
       </Dialog.Root>
-      <SkillImportCandidatePreview {...candidatePreview.previewProps} />
+      <SkillImportCandidatePreview
+        {...candidatePreview.previewProps}
+        open={active && candidatePreview.previewProps.open}
+      />
     </>
   )
 }
 
 export function SkillImportApprovalDialog({
+  active = true,
   blockedSessionIds
 }: {
+  active?: boolean
   blockedSessionIds?: ReadonlySet<string>
 }): React.JSX.Element | null {
   const request = useSkillImportStore((state) =>
@@ -229,6 +236,11 @@ export function SkillImportApprovalDialog({
   const respond = useSkillImportStore((state) => state.respond)
 
   return request ? (
-    <SkillImportApprovalRequestDialog key={request.id} request={request} respond={respond} />
+    <SkillImportApprovalRequestDialog
+      key={request.id}
+      active={active}
+      request={request}
+      respond={respond}
+    />
   ) : null
 }

--- a/src/renderer/src/pages/settings/StorageMigrationModal.render.test.tsx
+++ b/src/renderer/src/pages/settings/StorageMigrationModal.render.test.tsx
@@ -54,6 +54,24 @@ afterEach(() => {
 })
 
 describe('StorageMigrationModal', () => {
+  it('continues a covered migration while suppressing its presentation', async () => {
+    const api = installApi()
+
+    await act(async () => {
+      root.render(<StorageMigrationModal active={false} targetPath="/mnt/data" onClose={vi.fn()} />)
+      await Promise.resolve()
+    })
+
+    expect(api.migrate).toHaveBeenCalledWith('/mnt/data')
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull()
+
+    await act(async () => {
+      root.render(<StorageMigrationModal active targetPath="/mnt/data" onClose={vi.fn()} />)
+    })
+
+    expect(document.body.textContent).toMatch(/data copied/i)
+  })
+
   it('advances past "Checking…" under StrictMode instead of stranding on detect (mountedRef reset)', async () => {
     // Regression: StrictMode's dev mount→unmount→mount left mountedRef false for the real mount, so
     // every async guard bailed and the modal stuck on the detecting copy. Rendering under StrictMode

--- a/src/renderer/src/pages/settings/StorageMigrationModal.tsx
+++ b/src/renderer/src/pages/settings/StorageMigrationModal.tsx
@@ -16,6 +16,7 @@ import {
 type Stage = 'detecting' | 'confirm' | 'migrating' | 'done' | 'committing' | 'error'
 
 type StorageMigrationModalProps = {
+  active?: boolean
   targetPath: string
   onClose: () => void
 }
@@ -48,6 +49,7 @@ const formatElapsed = (ms: number): string => {
 // (moved / cancelled / switchover failed / failed) to matching UI. Mounted only while a move is in
 // flight, so unmount always means "tear down the progress subscription".
 const StorageMigrationModal = ({
+  active: isPresentationActive = true,
   targetPath,
   onClose
 }: StorageMigrationModalProps): React.JSX.Element => {
@@ -212,7 +214,7 @@ const StorageMigrationModal = ({
   const isSwitchover = Boolean(outcome && 'switchoverFailed' in outcome)
 
   return (
-    <Dialog.Root open>
+    <Dialog.Root open={isPresentationActive}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-[60] bg-black/50" />
         <Dialog.Content

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -64,6 +64,7 @@ type WorkspacePageProps = {
   isSessionPersistenceHydrated: boolean
   isSessionPersistenceReady: boolean
   canDeleteConversations: boolean
+  isPreviewPresentationActive?: boolean
 }
 
 // New-conversation drafts are project-scoped so switching projects never leaks unsent intent.
@@ -75,7 +76,8 @@ const OPEN_DIALOG_SELECTOR =
 const WorkspacePage = ({
   isSessionPersistenceHydrated,
   isSessionPersistenceReady,
-  canDeleteConversations
+  canDeleteConversations,
+  isPreviewPresentationActive = true
 }: WorkspacePageProps): React.JSX.Element => {
   // The active project scopes which sessions are visible and stamps newly created ones. The workspace
   // is only reachable via openProject/openSession (which set it); '' is a defensive sentinel that
@@ -867,6 +869,7 @@ const WorkspacePage = ({
     <main className="h-[100dvh] overflow-hidden bg-bg-10 text-[13px] leading-normal text-text-000 md:h-screen md:p-[10px]">
       <WorkspacePanelLayout
         hasPreviewItems={previewItems.length > 0}
+        isPreviewPresentationActive={isPreviewPresentationActive}
         restoredPlanResponder={
           activeSession
             ? {
@@ -1141,7 +1144,11 @@ const WorkspacePage = ({
       />
 
       <FilePreviewDialog
-        item={fileDialogItem?.projectId === activeProjectId ? fileDialogItem : undefined}
+        item={
+          isPreviewPresentationActive && fileDialogItem?.projectId === activeProjectId
+            ? fileDialogItem
+            : undefined
+        }
         onClose={closeFileDialog}
       />
 

--- a/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
+++ b/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
@@ -440,6 +440,7 @@ const useWorkspacePanelLayout = (previewPort: PreviewPanelLayoutPort): Workspace
 
 type WorkspacePanelLayoutProps = {
   hasPreviewItems: boolean
+  isPreviewPresentationActive?: boolean
   restoredPlanResponder?: RestoredPlanResponder
   preview: PreviewPanelLayoutPort
   renderDesktopSidebar: (options: {
@@ -460,6 +461,7 @@ type WorkspacePanelLayoutProps = {
 // Adapts the controller to the desktop split view and mobile drawer/sheet without owning page data.
 const WorkspacePanelLayout = ({
   hasPreviewItems,
+  isPreviewPresentationActive = true,
   restoredPlanResponder,
   preview: previewPort,
   renderDesktopSidebar,
@@ -553,7 +555,7 @@ const WorkspacePanelLayout = ({
 
       {isMobile ? (
         <MobilePreviewSheet
-          open={preview.state === 'open'}
+          open={isPreviewPresentationActive && preview.state === 'open'}
           onClose={preview.collapse}
           restoredPlanResponder={restoredPlanResponder}
         />


### PR DESCRIPTION
## Problem

`AppContent` repeated overlapping gate lists for conversation visibility, Settings/global-search shortcuts, and close routing. The lists had drifted, approval dialogs could compete through portal order, and a non-dismissible overlay could let `Cmd/Ctrl+W` reach an underlying preview or window.

## Proposed change

- Add one pure App Shell presentation owner with a fixed semantic priority:
  close confirmation → data-root recovery → legacy move → update → compute approval → Connector approval → Skill import approval → global search → Settings → preview → base.
- Project independently owned store/local state into one active presentation; covered requests remain in their original stores and resume when higher-priority UI clears.
- Route session visibility, App Shell shortcut eligibility, and the close command through the same projection.
- Mark base content, lifecycle toast, and Undo snackbar inert/aria-hidden while a higher presentation owns the shell.
- Suppress covered root dialogs through optional presentation-only `active` props without changing their request lifecycles.
- Keep nested dialog/fullscreen fallback and preview-internal tab/pane close behavior.
- Document the ownership rule and add architecture/regression tests.

## Scope and non-goals

- No Zustand ownership transfer.
- No persistent/database/settings schema change.
- No new runtime or persisted data fields; additions are TypeScript projection types and presentation-only props.
- No shared IPC/request-contract change.
- Notification navigation, dialog copy, and visual design are unchanged.
- Cross-store approvals use the fixed order above, not strict arrival order.

## Historical compatibility

No historical data migration or persisted-data compatibility work is required. Existing Settings, preview persistence, notification tokens, and pending main-process approval payloads retain their shapes.

The intentional behavioral compatibility change is that simultaneous root overlays now use deterministic semantic priority instead of accidental portal/z-index order. Suppressed pending decisions are retained, not discarded.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Presentation priority, shortcut eligibility, nested overlays, close routing, App integration, real dialog state retention, and unread visibility → explicit 12-file Vitest impact set → **169 tests passed**.
- Renderer and main TypeScript contracts → `npm run typecheck` → **passed**.
- Source/style rules → `npm run lint` → **passed with 0 errors**; 11 warnings remain in unchanged files.
- Diff hygiene → `git diff --check` → **passed**.
- Standards/spec independent review of the final diff → **0 findings on both axes**.
- Full fallback → `npm test` → **attempted but not green in this Windows workspace**: 180 failures are in unchanged `src/main` suites, chiefly symlink `EPERM`, Prisma test databases missing `codecVersion`, and cascading storage/reviewer failures/timeouts. The changed renderer impact set is green; exact-head CI remains authoritative for the complete portable suite.

No local platform/E2E lane was run because the change is renderer presentation policy with no main/preload, persistence, migration, build, or packaging change.

## Review focus

- Whether the fixed semantic priority matches product expectations for simultaneous overlays.
- Whether covered dialogs retain their owning state and resume safely.
- Whether the explicit `handled | close-preview | close-base` seam preserves preview/window close behavior.
- Residual risk: nested DOM fallback treats the last matching portal node as topmost; it does not compute actual z-index/focus order.
