### PR TITLE
fix(e2e): bypass hidden-window animations

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -220,9 +220,13 @@ const makeTreeWritable = async (root: string): Promise<void> => {
 
 const openMainWindow = async (
   application: ElectronApplication,
-  rendererFailures: RendererFailureGate
+  rendererFailures: RendererFailureGate,
+  windowMode: E2eWindowMode
 ): Promise<Page> => {
   const page = await application.firstWindow()
+  // Hidden BrowserWindows do not produce animation frames reliably, so make
+  // presentation buffers commit immediately without changing normal-window tests.
+  if (windowMode === 'hidden') await page.emulateMedia({ reducedMotion: 'reduce' })
   await rendererFailures.observe(page)
   await page.waitForLoadState('domcontentloaded')
   await expect
@@ -523,7 +527,11 @@ class ElectronAppHarness implements ElectronApp {
       this.roots.fakeRemoteItRoot,
       this.windowMode
     )
-    this.currentPage = await openMainWindow(this.application, this.rendererFailures)
+    this.currentPage = await openMainWindow(
+      this.application,
+      this.rendererFailures,
+      this.windowMode
+    )
   }
 
   private get runningApplication(): ElectronApplication {


### PR DESCRIPTION
## Problem

Recent PR Gate runs repeatedly fail the Windows workspace E2E job after E2E BrowserWindows were changed to stay hidden. The deterministic fake Agent completes its turn, but the transcript often remains at only the first rendered fragment (for example, "Deterministic reply") until the assertion times out. The same hidden-window behavior also increases visual instability on macOS.

## Root cause

Workspace event presentation and smooth Markdown streaming both use animation-frame-driven buffers. Hidden Electron BrowserWindows do not produce animation frames reliably, so their presentation queues can stop after an initial fragment even though the canonical Agent turn has completed.

## Proposed change

- Pass the E2E window mode into the shared page initialization path.
- Emulate reduced motion only for hidden E2E windows so existing presentation buffers commit immediately.
- Preserve normal-window E2E behavior and all production presentation behavior.

## Scope and non-goals

- No production source or runtime defaults change.
- No retries, assertion timeouts, or visual baselines are loosened.
- Native window-system tests using windowMode "normal" remain unchanged.

## Acceptance criteria and validation

- Original Windows regression:
  - npx playwright test e2e/workspace-conversation.spec.ts --grep "archives a completed session" - pass.
- Hidden window lifecycle:
  - npx playwright test e2e/window-presentation.spec.ts - pass.
- Related presentation path:
  - npx playwright test e2e/workspace-conversation.spec.ts --grep "shows context compaction" - pass.
- Workspace E2E:
  - all functional cases that completed setup passed, including the formerly failing streaming cases;
  - two full local runs were interrupted only by nondeterministic Windows EPERM failures while atomically renaming a temporary settings.json, before the affected tests entered their interaction steps.
- npm run typecheck:node - pass.
- npm run lint - pass with 11 pre-existing warnings and no new warning.
- npm run build:e2e - pass.
- npm test was attempted locally; unrelated Windows environment failures remain (symlink privilege errors, temporary Prisma schema mismatch, and one resource-sensitive compression timeout). PR Gate is the authority for the isolated full-suite result.

## Review focus

Please verify that reduced motion is applied only to hidden E2E windows and that normal-window tests retain native presentation semantics.

