### PR TITLE
fix(reviewer): show composer review loading state

### DIFF
--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -461,6 +461,7 @@ const createPanelDefaults = (): PanelProps => ({
   },
   review: {
     disabled: false,
+    running: false,
     request: vi.fn()
   },
   sessionTools: {
@@ -3104,12 +3105,43 @@ describe('ConversationPanel + menu', () => {
       '[data-testid="menu-request-review"]'
     ) as HTMLButtonElement
     expect(reviewItem.disabled).toBe(true)
+    expect(reviewItem.getAttribute('aria-busy')).toBeNull()
+    expect(reviewItem.textContent).toBe('Request review')
+    expect(reviewItem.querySelector('svg')?.classList.contains('animate-spin')).toBe(false)
 
     act(() => {
       reviewItem.click()
     })
 
     // disabled button click should not call the handler
+    expect(onRequestReview).not.toHaveBeenCalled()
+  })
+
+  it('shows a disabled loading state while the active session is being reviewed', () => {
+    const onRequestReview = vi.fn()
+    renderPanel({
+      review: {
+        disabled: true,
+        running: true,
+        request: onRequestReview
+      }
+    })
+
+    const reviewItem = container.querySelector(
+      '[data-testid="menu-request-review"]'
+    ) as HTMLButtonElement
+    const loadingIcon = reviewItem.querySelector('svg')
+
+    expect(reviewItem.disabled).toBe(true)
+    expect(reviewItem.getAttribute('aria-busy')).toBe('true')
+    expect(reviewItem.textContent).toBe('Reviewing\u2026')
+    expect(loadingIcon?.classList.contains('animate-spin')).toBe(true)
+    expect(loadingIcon?.classList.contains('motion-reduce:animate-none')).toBe(true)
+
+    act(() => {
+      reviewItem.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
     expect(onRequestReview).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -231,6 +231,7 @@ type ConversationPanelContextWindow = {
 
 type ConversationPanelReview = {
   disabled: boolean
+  running: boolean
   request: () => void
 }
 
@@ -344,7 +345,11 @@ const ConversationPanel = ({
     compactDisabledReason: compactContextDisabledReason,
     compact: onCompactContext
   } = contextWindow
-  const { disabled: isRequestReviewDisabled, request: onRequestReview } = review
+  const {
+    disabled: isRequestReviewDisabled,
+    running: isReviewing,
+    request: onRequestReview
+  } = review
   const { notebookReference, openNotebook: onOpenNotebook, openJobs: onOpenJobList } = sessionTools
   const { unavailableReason: subagentUnavailableReason, stop: onStopSubagents } = subagents
   const specialistId = activeSession
@@ -1257,19 +1262,30 @@ const ConversationPanel = ({
                             ) : null}
                             <DropdownMenuItem
                               data-testid="menu-request-review"
-                              disabled={!canEditDraft || isRequestReviewDisabled}
+                              disabled={!canEditDraft || isRequestReviewDisabled || isReviewing}
+                              aria-busy={isReviewing || undefined}
                               onSelect={() => {
-                                if (canEditDraft && !isRequestReviewDisabled) onRequestReview()
+                                if (canEditDraft && !isRequestReviewDisabled && !isReviewing) {
+                                  onRequestReview()
+                                }
                               }}
                               className="items-center gap-2"
                             >
-                              <ScanEye
-                                className="size-4 shrink-0 text-text-200"
-                                strokeWidth={2}
-                                aria-hidden="true"
-                              />
+                              {isReviewing ? (
+                                <Loader2
+                                  className="size-4 shrink-0 animate-spin text-text-200 motion-reduce:animate-none"
+                                  strokeWidth={2}
+                                  aria-hidden="true"
+                                />
+                              ) : (
+                                <ScanEye
+                                  className="size-4 shrink-0 text-text-200"
+                                  strokeWidth={2}
+                                  aria-hidden="true"
+                                />
+                              )}
                               <span className="text-[13px] font-medium leading-5">
-                                Request review
+                                {isReviewing ? 'Reviewing\u2026' : 'Request review'}
                               </span>
                             </DropdownMenuItem>
                             <DropdownMenuSeparator />

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -1045,6 +1045,7 @@ const WorkspacePage = ({
             }}
             review={{
               disabled: isRequestReviewDisabled,
+              running: isReviewing,
               request: requestManualReview
             }}
             sessionTools={{


### PR DESCRIPTION
## Problem

While the active Session Reviewer is running, the composer review menu item is disabled but still looks like the ordinary “Request review” action. The menu therefore does not explain why the action cannot be selected.

## Proposed change

- pass the active Session’s review-running lifecycle into the composer menu separately from the general disabled state
- render a Lucide loading spinner and `Reviewing…` while that review is running
- keep the item disabled and expose `aria-busy`
- stop the spinner under `prefers-reduced-motion`
- preserve the ordinary icon and label for unrelated disabled reasons

## Scope and non-goals

This is a renderer-only presentation change. It does not change reviewer orchestration, persistence, concurrency rules, or other session states.

## Acceptance criteria and validation

The checks below ran after the last material edit:

- review menu loading and ordinary disabled states → `npm test -- src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx` → 94 tests passed
- workspace page owner and contract coverage → project-generated `workspace_page` Vitest file set run directly → 23 files / 387 tests passed
- renderer type safety → `npm run typecheck:web` → passed
- lint → `npm run lint` → passed with 11 pre-existing warnings in unchanged files and 0 errors
- patch integrity → `git diff --check` → passed

`npm run test:module -- workspace_page` generated the expected 23-file plan but its Windows child-process launcher failed twice with `spawnSync npm.cmd EINVAL`. The exact generated file list was then run directly with Vitest and passed.

Consumers beyond the renderer workspace are excluded because the change only adds an internal `ConversationPanel` presentation prop derived from the existing Project-scoped review selector. Cross-platform and full-suite coverage remain authoritative in PR CI.

## Review focus

Please verify that only an active review lifecycle switches the menu to `Reviewing…`, while other disabled reasons retain `Request review`.