### PR TITLE
refactor(host-js)!: camel-case delegation interface

### DIFF
--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -253,7 +253,7 @@ const runProductionDelegation = async (sessionId, task, name, wait) =>
 const runProductionTimedDelegationRequest = async (sessionId, request) =>
   executeControlCode(
     sessionId,
-    `return await host.delegate(${JSON.stringify(request)}, { timeout_seconds: 0 })`
+    `return await host.delegate(${JSON.stringify(request)}, { timeoutSeconds: 0 })`
   )
 
 const waitForSessionCancellation = (sessionId) =>
@@ -528,7 +528,7 @@ if (process.argv.includes('--version')) {
           const dispatched = controlResultValue(
             await executeControlCode(
               context.params.sessionId,
-              `globalThis.s2Pending = await host.delegate([{ task: ${JSON.stringify(DELEGATED_TERMINAL_TASK)}, name: "Bounded terminal child" }, { task: ${JSON.stringify(DELEGATED_BOUNDED_SLOW_TASK)}, name: ${JSON.stringify(DELEGATED_BOUNDED_SLOW_TASK)} }], { timeout_seconds: 1 }); return globalThis.s2Pending`
+              `globalThis.s2Pending = await host.delegate([{ task: ${JSON.stringify(DELEGATED_TERMINAL_TASK)}, name: "Bounded terminal child" }, { task: ${JSON.stringify(DELEGATED_BOUNDED_SLOW_TASK)}, name: ${JSON.stringify(DELEGATED_BOUNDED_SLOW_TASK)} }], { timeoutSeconds: 1 }); return globalThis.s2Pending`
             )
           )
           if (
@@ -545,7 +545,7 @@ if (process.argv.includes('--version')) {
           const terminal = controlResultValue(
             await executeControlCode(
               context.params.sessionId,
-              `const slow = globalThis.s2Pending.children[1]; return await host.collect([{ frame_id: slow.frame_id, attempt_id: slow.attempt_id }], { timeout_seconds: 30 })`
+              `const slow = globalThis.s2Pending.children[1]; return await host.collect([{ frameId: slow.frame_id, attemptId: slow.attempt_id }], { timeoutSeconds: 30 })`
             )
           )
           if (terminal.length !== 1 || terminal[0].status !== 'completed') {
@@ -628,7 +628,7 @@ if (process.argv.includes('--version')) {
           const downward = controlResultValue(
             await executeControlCode(
               context.params.sessionId,
-              `const sent = await host.send_frame_message(${JSON.stringify(child.frame_id)}, ${JSON.stringify(RELIABLE_CHILD_DIRECTIVE)}, { kind: "info", request_id: "e2e-main-to-child" }); return await host.message_receipt(sent.message_id, { timeout_seconds: 30 })`
+              `const sent = await host.sendFrameMessage(${JSON.stringify(child.frame_id)}, ${JSON.stringify(RELIABLE_CHILD_DIRECTIVE)}, { kind: "info", requestId: "e2e-main-to-child" }); return await host.messageReceipt(sent.message_id, { timeoutSeconds: 30 })`
             )
           )
           if (downward.status !== 'accepted' || downward.direction !== 'to_child') {
@@ -656,7 +656,7 @@ if (process.argv.includes('--version')) {
           const receipt = controlResultValue(
             await executeControlCode(
               context.params.sessionId,
-              `return await host.message_receipt("e2e-child-park", { timeout_seconds: 0 })`
+              `return await host.messageReceipt("e2e-child-park", { timeoutSeconds: 0 })`
             )
           )
           if (receipt.status !== 'queued') {
@@ -679,7 +679,7 @@ if (process.argv.includes('--version')) {
           const receipt = controlResultValue(
             await executeControlCode(
               context.params.sessionId,
-              `return await host.message_receipt(${JSON.stringify(messageId)}, { timeout_seconds: 0 })`
+              `return await host.messageReceipt(${JSON.stringify(messageId)}, { timeoutSeconds: 0 })`
             )
           )
           if (receipt.status !== 'uncertain') {
@@ -755,7 +755,7 @@ if (process.argv.includes('--version')) {
           const continued = controlResultValue(
             await executeControlCode(
               context.params.sessionId,
-              `const receipt = await host.send_frame_message(${JSON.stringify(frameId)}, "Continue after Settings changed"); return await host.collect([{ frame_id: receipt.target_frame_id, attempt_id: receipt.continuation_attempt_id }], { timeout_seconds: 30 })`
+              `const receipt = await host.sendFrameMessage(${JSON.stringify(frameId)}, "Continue after Settings changed"); return await host.collect([{ frameId: receipt.target_frame_id, attemptId: receipt.continuation_attempt_id }], { timeoutSeconds: 30 })`
             )
           )
           if (continued.length !== 1 || continued[0].status !== 'completed') {
@@ -791,7 +791,7 @@ if (process.argv.includes('--version')) {
               {
                 task: DELEGATED_STRUCTURED_OUTPUT_TASK,
                 name: DELEGATED_STRUCTURED_OUTPUT_TASK,
-                output_schema: {
+                outputSchema: {
                   type: 'object',
                   required: ['count'],
                   properties: { count: { type: 'number' } },
@@ -817,7 +817,7 @@ if (process.argv.includes('--version')) {
           const submission = controlResultValue(
             await executeControlCode(
               context.params.sessionId,
-              `let invalid = false; try { await host.submit_output({ count: "three" }) } catch { invalid = true }; const receipt = await host.submit_output({ count: 3 }); return { invalid, receipt }`
+              `let invalid = false; try { await host.submitOutput({ count: "three" }) } catch { invalid = true }; const receipt = await host.submitOutput({ count: 3 }); return { invalid, receipt }`
             )
           )
           if (!submission.invalid || submission.receipt?.accepted !== true) {
@@ -830,7 +830,7 @@ if (process.argv.includes('--version')) {
           const upward = controlResultValue(
             await executeControlCode(
               context.params.sessionId,
-              `const sent = await host.send_frame_message("parent", "Child reliable question reached Main", { kind: "question", request_id: "e2e-child-to-main" }); return await host.message_receipt(sent.message_id, { timeout_seconds: 0 })`
+              `const sent = await host.sendFrameMessage("parent", "Child reliable question reached Main", { kind: "question", requestId: "e2e-child-to-main" }); return await host.messageReceipt(sent.message_id, { timeoutSeconds: 0 })`
             )
           )
           if (upward.status !== 'queued' || upward.direction !== 'to_parent') {
@@ -841,7 +841,7 @@ if (process.argv.includes('--version')) {
           const upward = controlResultValue(
             await executeControlCode(
               context.params.sessionId,
-              `return await host.send_frame_message("parent", "Parked reliable child question", { kind: "question", request_id: "e2e-child-park" })`
+              `return await host.sendFrameMessage("parent", "Parked reliable child question", { kind: "question", requestId: "e2e-child-park" })`
             )
           )
           if (upward.status !== 'queued') {
@@ -851,7 +851,7 @@ if (process.argv.includes('--version')) {
         } else if (prompt.includes(DELEGATED_RELIABLE_FAILURE_TASK)) {
           await executeControlCode(
             context.params.sessionId,
-            `return await host.send_frame_message("parent", "Trigger reliable post-fence persistence failure", { kind: "info", request_id: "e2e-child-post-fence" })`
+            `return await host.sendFrameMessage("parent", "Trigger reliable post-fence persistence failure", { kind: "info", requestId: "e2e-child-post-fence" })`
           )
           reply = 'Child queued a post-fence reliable message.'
         } else if (
@@ -861,7 +861,7 @@ if (process.argv.includes('--version')) {
           const suffix = prompt.includes(DELEGATED_RELIABLE_FAIRNESS_TASK_B) ? 'B' : 'A'
           await executeControlCode(
             context.params.sessionId,
-            `return await host.send_frame_message("parent", "Reliable fairness child ${suffix}", { request_id: "e2e-fairness-${suffix.toLowerCase()}" })`
+            `return await host.sendFrameMessage("parent", "Reliable fairness child ${suffix}", { requestId: "e2e-fairness-${suffix.toLowerCase()}" })`
           )
           reply = `Child ${suffix} queued its reliable fairness message.`
         } else if (prompt.includes(RELIABLE_CHILD_DIRECTIVE)) {
@@ -872,7 +872,7 @@ if (process.argv.includes('--version')) {
           const answered = controlResultValue(
             await executeControlCode(
               context.params.sessionId,
-              `const sent = await host.send_frame_message(${JSON.stringify(childFrameId)}, "Main answered the reliable child question", { kind: "info", request_id: "e2e-main-reply-to-child" }); return await host.message_receipt(sent.message_id, { timeout_seconds: 30 })`
+              `const sent = await host.sendFrameMessage(${JSON.stringify(childFrameId)}, "Main answered the reliable child question", { kind: "info", requestId: "e2e-main-reply-to-child" }); return await host.messageReceipt(sent.message_id, { timeoutSeconds: 30 })`
             )
           )
           if (answered.status !== 'accepted' || answered.direction !== 'to_child') {

--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -2340,6 +2340,47 @@ async function agentsRpc(op, params = {}, sessionId = COMPUTE_SESSION_ID) {
   return body.result
 }
 
+// Delegation services intentionally retain their snake_case RPC/domain contracts. Project only the
+// known public Host method and caller-input labels at this agent-facing seam; domain error codes,
+// enum values, and unrelated diagnostic text must remain byte-for-byte unchanged.
+const HOST_DELEGATION_ERROR_NAMES = Object.freeze([
+  ['host.stop_child', 'host.stopChild'],
+  ['host.send_frame_message', 'host.sendFrameMessage'],
+  ['host.message_receipt', 'host.messageReceipt'],
+  ['host.resolve_message', 'host.resolveMessage'],
+  ['host.submit_output', 'host.submitOutput'],
+  ['stop_child', 'stopChild'],
+  ['send_frame_message', 'sendFrameMessage'],
+  ['message_receipt', 'messageReceipt'],
+  ['resolve_message', 'resolveMessage'],
+  ['submit_output', 'submitOutput'],
+  ['output_schema', 'outputSchema'],
+  ['timeout_seconds', 'timeoutSeconds'],
+  ['frame_ids', 'frameIds'],
+  ['frame_id', 'frameId'],
+  ['attempt_id', 'attemptId'],
+  ['request_id', 'requestId'],
+  ['reply_to_message_id', 'replyToMessageId'],
+  ['message_id', 'messageId']
+])
+
+const projectedHostDelegationErrorText = (value) => {
+  const text = value && typeof value === 'object' ? JSON.stringify(value) : String(value)
+  return HOST_DELEGATION_ERROR_NAMES.reduce((projected, [privateName, publicName]) => {
+    const escaped = privateName.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&')
+    return projected.replace(
+      new RegExp(`(^|[^A-Za-z0-9_])${escaped}(?=$|[^A-Za-z0-9_])`, 'gu'),
+      (_, prefix) => prefix + publicName
+    )
+  }, text)
+}
+
+const hostDelegationError = (publicMethod, value) => {
+  const projected = projectedHostDelegationErrorText(value)
+  const detail = projected.replace(new RegExp(`^host\\.${publicMethod}:\\s*`), '')
+  return new Error(`host.${publicMethod}: ${detail}`)
+}
+
 async function delegateRpc(request, options = {}) {
   if (!RPC_ENDPOINT) throw new Error('host.delegate is unavailable: control RPC endpoint not set')
   const delegationCallId = String(++DELEGATE_CALL_SEQUENCE)
@@ -2353,7 +2394,7 @@ async function delegateRpc(request, options = {}) {
   })
   const body = await res.json().catch(() => ({}))
   if (!res.ok || body.error) {
-    throw new Error(`host.delegate: ${body.error || 'HTTP ' + res.status}`)
+    throw hostDelegationError('delegate', body.error || 'HTTP ' + res.status)
   }
   const outcome = body.result || {}
   return {
@@ -2395,11 +2436,28 @@ async function hostHelp(query = undefined) {
 }
 
 async function hostDelegate(request, options = {}) {
-  return delegateRpc(request, options)
+  const requests = Array.isArray(request) ? request : [request]
+  const normalizedRequests = requests.map((candidate) =>
+    remappedHostObject(candidate, 'host.delegate request', {
+      task: 'task',
+      name: 'name',
+      profile: 'profile',
+      inputs: 'inputs',
+      outputSchema: 'output_schema'
+    })
+  )
+  const normalizedOptions = remappedHostObject(options, 'host.delegate options', {
+    wait: 'wait',
+    timeoutSeconds: 'timeout_seconds'
+  })
+  return delegateRpc(
+    Array.isArray(request) ? normalizedRequests : normalizedRequests[0],
+    normalizedOptions
+  )
 }
 
 async function hostStopChild(frameIds) {
-  if (!RPC_ENDPOINT) throw new Error('host.stop_child is unavailable: control RPC endpoint not set')
+  if (!RPC_ENDPOINT) throw new Error('host.stopChild is unavailable: control RPC endpoint not set')
   const res = await capturedRpcFetch(RPC_ENDPOINT, {
     method: 'POST',
     headers: { 'content-type': 'application/json', authorization: 'Bearer ' + (RPC_TOKEN || '') },
@@ -2410,7 +2468,7 @@ async function hostStopChild(frameIds) {
   })
   const body = await res.json().catch(() => ({}))
   if (!res.ok || body.error) {
-    throw new Error(`host.stop_child: ${body.error || 'HTTP ' + res.status}`)
+    throw hostDelegationError('stopChild', body.error || 'HTTP ' + res.status)
   }
   return (body.result || []).map((child) => ({
     frame_id: child.frameId,
@@ -2438,7 +2496,7 @@ async function delegatedObservationRpc(op, selectors = undefined, options = unde
   })
   const body = await res.json().catch(() => ({}))
   if (!res.ok || body.error) {
-    throw new Error(`host.${op}: ${body.error || 'HTTP ' + res.status}`)
+    throw hostDelegationError(op, body.error || 'HTTP ' + res.status)
   }
   return (body.result || []).map((child) => ({
     frame_id: child.frameId,
@@ -2463,7 +2521,7 @@ async function delegatedObservationRpc(op, selectors = undefined, options = unde
 
 async function hostSubmitOutput(value) {
   if (!RPC_ENDPOINT)
-    throw new Error('host.submit_output is unavailable: control RPC endpoint not set')
+    throw new Error('host.submitOutput is unavailable: control RPC endpoint not set')
   const res = await capturedRpcFetch(RPC_ENDPOINT, {
     method: 'POST',
     headers: { 'content-type': 'application/json', authorization: 'Bearer ' + (RPC_TOKEN || '') },
@@ -2471,11 +2529,7 @@ async function hostSubmitOutput(value) {
   })
   const body = await res.json().catch(() => ({}))
   if (!res.ok || body.error) {
-    const detail =
-      body.error && typeof body.error === 'object'
-        ? JSON.stringify(body.error)
-        : body.error || 'HTTP ' + res.status
-    throw new Error(`host.submit_output: ${detail}`)
+    throw hostDelegationError('submitOutput', body.error || 'HTTP ' + res.status)
   }
   return body.result
 }
@@ -2485,12 +2539,37 @@ async function hostChildren(frameIds = undefined) {
 }
 
 async function hostCollect(selectors, options = undefined) {
-  return delegatedObservationRpc('collect', selectors, options)
+  if (!Array.isArray(selectors)) {
+    throw new TypeError('host.collect selectors must be an array.')
+  }
+  const normalizedSelectors = selectors.map((selector) =>
+    typeof selector === 'string'
+      ? selector
+      : remappedHostObject(selector, 'host.collect selector', {
+          frameId: 'frame_id',
+          attemptId: 'attempt_id'
+        })
+  )
+  const normalizedOptions =
+    options === undefined
+      ? undefined
+      : remappedHostObject(options, 'host.collect options', {
+          timeoutSeconds: 'timeout_seconds'
+        })
+  return delegatedObservationRpc('collect', normalizedSelectors, normalizedOptions)
 }
 
 async function hostSendFrameMessage(target, message, options = undefined) {
+  const normalizedOptions =
+    options === undefined
+      ? undefined
+      : remappedHostObject(options, 'host.sendFrameMessage options', {
+          kind: 'kind',
+          requestId: 'request_id',
+          replyToMessageId: 'reply_to_message_id'
+        })
   if (!RPC_ENDPOINT) {
-    throw new Error('host.send_frame_message is unavailable: control RPC endpoint not set')
+    throw new Error('host.sendFrameMessage is unavailable: control RPC endpoint not set')
   }
   const res = await capturedRpcFetch(RPC_ENDPOINT, {
     method: 'POST',
@@ -2501,37 +2580,52 @@ async function hostSendFrameMessage(target, message, options = undefined) {
         op: 'send_message',
         target,
         message,
-        ...(options !== undefined ? { options } : {})
+        ...(normalizedOptions !== undefined ? { options: normalizedOptions } : {})
       }
     })
   })
   const body = await res.json().catch(() => ({}))
   if (!res.ok || body.error) {
-    throw new Error(`host.send_frame_message: ${body.error || 'HTTP ' + res.status}`)
+    throw hostDelegationError('sendFrameMessage', body.error || 'HTTP ' + res.status)
   }
   return body.result
 }
 
 async function hostMessageReceipt(selector, options = undefined) {
-  return delegatedMessageRpc('message_receipt', { selector, options })
-}
-
-async function hostResolveMessage(messageId, options) {
-  return delegatedMessageRpc('resolve_message', {
-    message_id: messageId,
-    action: options && options.action
+  const normalizedOptions =
+    options === undefined
+      ? undefined
+      : remappedHostObject(options, 'host.messageReceipt options', {
+          timeoutSeconds: 'timeout_seconds'
+        })
+  return delegatedMessageRpc('message_receipt', 'messageReceipt', {
+    selector,
+    options: normalizedOptions
   })
 }
 
-async function delegatedMessageRpc(op, params) {
-  if (!RPC_ENDPOINT) throw new Error(`host.${op} is unavailable: control RPC endpoint not set`)
+async function hostResolveMessage(messageId, options) {
+  const normalizedOptions = remappedHostObject(options, 'host.resolveMessage options', {
+    action: 'action'
+  })
+  return delegatedMessageRpc('resolve_message', 'resolveMessage', {
+    message_id: messageId,
+    action: normalizedOptions.action
+  })
+}
+
+async function delegatedMessageRpc(op, publicMethod, params) {
+  if (!RPC_ENDPOINT)
+    throw new Error(`host.${publicMethod} is unavailable: control RPC endpoint not set`)
   const res = await capturedRpcFetch(RPC_ENDPOINT, {
     method: 'POST',
     headers: { 'content-type': 'application/json', authorization: 'Bearer ' + (RPC_TOKEN || '') },
     body: JSON.stringify({ method: 'delegatedWorkCall', params: { op, ...params } })
   })
   const body = await res.json().catch(() => ({}))
-  if (!res.ok || body.error) throw new Error(`host.${op}: ${body.error || 'HTTP ' + res.status}`)
+  if (!res.ok || body.error) {
+    throw hostDelegationError(publicMethod, body.error || 'HTTP ' + res.status)
+  }
   return body.result
 }
 
@@ -2841,11 +2935,11 @@ const subagentHostOperations = Object.freeze({
   delegate: hostDelegate,
   children: hostChildren,
   collect: hostCollect,
-  stop_child: hostStopChild,
-  send_frame_message: hostSendFrameMessage,
-  message_receipt: hostMessageReceipt,
-  resolve_message: hostResolveMessage,
-  submit_output: hostSubmitOutput
+  stopChild: hostStopChild,
+  sendFrameMessage: hostSendFrameMessage,
+  messageReceipt: hostMessageReceipt,
+  resolveMessage: hostResolveMessage,
+  submitOutput: hostSubmitOutput
 })
 
 // Persistent sandbox: user-declared globals persist across requests (assign to `globalThis`/bare).

--- a/src/main/agent-framework/app-mcp-names.test.ts
+++ b/src/main/agent-framework/app-mcp-names.test.ts
@@ -74,9 +74,9 @@ describe('resolveCanonicalMcpToolIdentity', () => {
   )
 
   it.each(['codex', 'claude-code', 'opencode'] as const)(
-    'does not reinterpret the Host SDK send_frame_message method as an MCP tool for %s',
+    'does not reinterpret the Host SDK sendFrameMessage method as an MCP tool for %s',
     (frameworkId) => {
-      const guidance = "Use await host.send_frame_message('parent', message)."
+      const guidance = "Use await host.sendFrameMessage('parent', message)."
 
       expect(renderAppMcpToolReferences(frameworkId, guidance)).toBe(guidance)
     }

--- a/src/main/delegation/acp-execution.test.ts
+++ b/src/main/delegation/acp-execution.test.ts
@@ -307,7 +307,7 @@ describe('ACP delegate execution production adapter', () => {
         attemptId: 'with-schema',
         input: { outputSchema: { type: 'number' } },
         expected:
-          'Review evidence.\n\nReturn ordinary text and any Artifacts as usual. Before finishing, submit the structured result with host.submit_output(value) using this JSON Schema:\n{"type":"number"}'
+          'Review evidence.\n\nReturn ordinary text and any Artifacts as usual. Before finishing, submit the structured result with host.submitOutput(value) using this JSON Schema:\n{"type":"number"}'
       },
       {
         attemptId: 'with-both',
@@ -316,7 +316,7 @@ describe('ACP delegate execution production adapter', () => {
           outputSchema: { type: 'object', required: ['answer'] }
         },
         expected:
-          'Review evidence.\n\nImmutable input copies are available in the read-only ./inputs/ directory. Inspect that directory and read the relevant files.\n\nReturn ordinary text and any Artifacts as usual. Before finishing, submit the structured result with host.submit_output(value) using this JSON Schema:\n{"type":"object","required":["answer"]}'
+          'Review evidence.\n\nImmutable input copies are available in the read-only ./inputs/ directory. Inspect that directory and read the relevant files.\n\nReturn ordinary text and any Artifacts as usual. Before finishing, submit the structured result with host.submitOutput(value) using this JSON Schema:\n{"type":"object","required":["answer"]}'
       }
     ]
 

--- a/src/main/delegation/acp-execution.ts
+++ b/src/main/delegation/acp-execution.ts
@@ -150,7 +150,7 @@ const buildInitialDelegatePrompt = (input: DelegateExecutionInput): string => {
   }
   if (input.outputSchema !== undefined) {
     sections.push(
-      `Return ordinary text and any Artifacts as usual. Before finishing, submit the structured result with host.submit_output(value) using this JSON Schema:\n${JSON.stringify(input.outputSchema)}`
+      `Return ordinary text and any Artifacts as usual. Before finishing, submit the structured result with host.submitOutput(value) using this JSON Schema:\n${JSON.stringify(input.outputSchema)}`
     )
   }
   return sections.join('\n\n')

--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -883,12 +883,12 @@ describe('production delegated-work composition', () => {
       const initialPrompt = control.prompts[0]
       expect(initialPrompt).toContain('Return a structured count')
       expect(initialPrompt).toContain('read-only ./inputs/')
-      expect(initialPrompt).toContain('host.submit_output(value)')
+      expect(initialPrompt).toContain('host.submitOutput(value)')
       expect(initialPrompt.indexOf('Return a structured count')).toBeLessThan(
         initialPrompt.indexOf('read-only ./inputs/')
       )
       expect(initialPrompt.indexOf('read-only ./inputs/')).toBeLessThan(
-        initialPrompt.indexOf('host.submit_output(value)')
+        initialPrompt.indexOf('host.submitOutput(value)')
       )
       expect(initialPrompt).not.toContain(control.input.workspaceCwd!)
       expect(initialPrompt).not.toContain('upload-version:framework-input')

--- a/src/main/host-sdk/delegate-contract.test.ts
+++ b/src/main/host-sdk/delegate-contract.test.ts
@@ -27,11 +27,25 @@ describe('Agent-facing delegate contract', () => {
           type: 'array',
           items: { type: 'string', minLength: 1, identity: 'immutable_upload_or_artifact_version' }
         },
-        output_schema: expect.objectContaining({ description: expect.stringContaining('2020-12') })
+        outputSchema: expect.objectContaining({
+          description: expect.stringMatching(/2020-12.*host\.submitOutput/s)
+        })
       }
     })
     expect(requestArray).toEqual({ type: 'array', minItems: 1, items: singleRequest })
     expect(singleRequest.properties).not.toHaveProperty('context')
+    expect(singleRequest.properties).not.toHaveProperty('output_schema')
+    expect(singleRequest.additionalProperties).toBe(false)
+    expect(DELEGATE_AGENT_CONTRACT.options).toMatchObject({
+      additionalProperties: false,
+      properties: {
+        timeoutSeconds: { minimum: 0, maximum: 1800 }
+      }
+    })
+    expect(DELEGATE_AGENT_CONTRACT.options.properties).not.toHaveProperty('timeout_seconds')
+    expect(DELEGATE_AGENT_CONTRACT.returns.oneOf[0].properties.children.items.required).toContain(
+      'frame_id'
+    )
     expect(singleRequest.properties.profile.description).toContain(
       'Omit to inherit the authenticated parent Specialist'
     )
@@ -46,7 +60,7 @@ describe('Agent-facing delegate contract', () => {
     )
   })
 
-  it('normalizes wire request and options shapes without replacing domain admission validation', () => {
+  it('parses private snake-case wire requests without replacing domain admission validation', () => {
     expect(
       parseDelegateRpcCall({
         request: [{ task: 'Audit', inputs: ['upload-version-1'] }],
@@ -85,11 +99,45 @@ describe('Agent-facing delegate contract', () => {
         options: { wait: false, timeout_seconds: 1 }
       })
     ).toThrow('omit timeout_seconds or set wait:true')
+    expect(() =>
+      parseDelegateRpcCall({ request: { task: 'Extract', outputSchema: { type: 'number' } } })
+    ).toThrow('private RPC requests use output_schema')
+    expect(() =>
+      parseDelegateRpcCall({
+        request: { task: 'Extract', output_schema: {}, outputSchema: {} }
+      })
+    ).toThrow('private RPC requests use output_schema')
+    expect(() =>
+      parseDelegateRpcCall({
+        request: { task: 'Observe' },
+        options: { timeout_seconds: 0, timeoutSeconds: 0 }
+      })
+    ).toThrow('private RPC options use timeout_seconds')
   })
 })
 
 describe('Agent-facing collect contract', () => {
-  it('normalizes string and explicit Attempt selectors with bounded options', () => {
+  it('publishes camel-case selector and option inputs while retaining snake-case returns', () => {
+    const explicitSelector = COLLECT_AGENT_CONTRACT.selectors.items.oneOf[1]
+    expect(explicitSelector).toMatchObject({
+      additionalProperties: false,
+      required: ['frameId', 'attemptId'],
+      properties: { frameId: { type: 'string' }, attemptId: { type: 'string' } }
+    })
+    expect(explicitSelector.properties).not.toHaveProperty('frame_id')
+    expect(explicitSelector.properties).not.toHaveProperty('attempt_id')
+    expect(COLLECT_AGENT_CONTRACT.options.properties.timeoutSeconds).toMatchObject({
+      minimum: 0,
+      maximum: 1800,
+      default: 30
+    })
+    expect(COLLECT_AGENT_CONTRACT.options.properties).not.toHaveProperty('timeout_seconds')
+    expect(COLLECT_AGENT_CONTRACT.options.additionalProperties).toBe(false)
+    expect(COLLECT_AGENT_CONTRACT.returns.items.oneOf[0].required).toContain('frame_id')
+    expect(COLLECT_AGENT_CONTRACT.returns.items.oneOf[0].required).toContain('attempt_id')
+  })
+
+  it('parses private snake-case wire selectors with bounded options', () => {
     expect(
       parseCollectRpcCall({
         selectors: ['frame-1', { frame_id: 'frame-2', attempt_id: 'attempt-2' }],
@@ -99,15 +147,31 @@ describe('Agent-facing collect contract', () => {
       selectors: ['frame-1', { frameId: 'frame-2', attemptId: 'attempt-2' }],
       options: { timeoutSeconds: 0 }
     })
-    expect(COLLECT_AGENT_CONTRACT.options.properties.timeout_seconds).toMatchObject({
-      minimum: 0,
-      maximum: 1800,
-      default: 30
-    })
     for (const invalid of [-1, 1801, Number.NaN, Number.POSITIVE_INFINITY, '30']) {
       expect(() =>
         parseCollectRpcCall({ selectors: ['frame-1'], options: { timeout_seconds: invalid } })
       ).toThrow('finite number from 0 through 1800')
     }
+    expect(() =>
+      parseCollectRpcCall({ selectors: [{ frameId: 'frame-1', attemptId: 'attempt-1' }] })
+    ).toThrow('private RPC selectors use {frame_id, attempt_id}')
+    expect(() =>
+      parseCollectRpcCall({
+        selectors: [
+          {
+            frame_id: 'frame-1',
+            attempt_id: 'attempt-1',
+            frameId: 'frame-1',
+            attemptId: 'attempt-1'
+          }
+        ]
+      })
+    ).toThrow('private RPC selectors use {frame_id, attempt_id}')
+    expect(() =>
+      parseCollectRpcCall({
+        selectors: ['frame-1'],
+        options: { timeout_seconds: 0, timeoutSeconds: 0 }
+      })
+    ).toThrow('private RPC options use timeout_seconds')
   })
 })

--- a/src/main/host-sdk/delegate-contract.ts
+++ b/src/main/host-sdk/delegate-contract.ts
@@ -89,16 +89,18 @@ const COLLECT_AGENT_CONTRACT = {
         { type: 'string', minLength: 1 },
         {
           type: 'object',
-          required: ['frame_id', 'attempt_id'],
-          properties: { frame_id: { type: 'string' }, attempt_id: { type: 'string' } }
+          additionalProperties: false,
+          required: ['frameId', 'attemptId'],
+          properties: { frameId: { type: 'string' }, attemptId: { type: 'string' } }
         }
       ]
     }
   },
   options: {
     type: 'object',
+    additionalProperties: false,
     properties: {
-      timeout_seconds: { type: 'number', minimum: 0, maximum: 1800, default: 30 }
+      timeoutSeconds: { type: 'number', minimum: 0, maximum: 1800, default: 30 }
     }
   },
   returns: { type: 'array', items: DELEGATE_OBSERVATION_SCHEMA },
@@ -111,6 +113,7 @@ const COLLECT_AGENT_CONTRACT = {
 
 const DELEGATE_REQUEST_OBJECT_SCHEMA = {
   type: 'object',
+  additionalProperties: false,
   required: ['task', 'name'],
   properties: {
     task: {
@@ -140,22 +143,22 @@ const DELEGATE_REQUEST_OBJECT_SCHEMA = {
       },
       description: 'Immutable Upload Version or Artifact Version identities only.'
     },
-    output_schema: {
-      description:
-        'Optional JSON Schema Draft 2020-12 contract for child host.submit_output(value).'
+    outputSchema: {
+      description: 'Optional JSON Schema Draft 2020-12 contract for child host.submitOutput(value).'
     }
   }
 } as const
 
 const DELEGATE_OPTIONS_SCHEMA = {
   type: 'object',
+  additionalProperties: false,
   properties: {
     wait: {
       type: 'boolean',
       default: true,
       description: 'Wait for all children to settle when true.'
     },
-    timeout_seconds: {
+    timeoutSeconds: {
       type: 'number',
       minimum: 0,
       maximum: 1800,
@@ -204,7 +207,7 @@ const DELEGATE_AGENT_CONTRACT = {
         }
       },
       {
-        description: 'Returned when options.timeout_seconds is explicit.',
+        description: 'Returned when options.timeoutSeconds is explicit.',
         type: 'object',
         required: ['kind', 'children'],
         optional: [],
@@ -254,6 +257,9 @@ type CollectRpcCall = Readonly<{
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
 
+const hasOwn = (value: Record<string, unknown>, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(value, key)
+
 const parseDelegateRpcCall = (params: Readonly<Record<string, unknown>>): DelegateRpcCall => {
   const request = params.request
   if (!isRecord(request) && !Array.isArray(request)) {
@@ -265,6 +271,11 @@ const parseDelegateRpcCall = (params: Readonly<Record<string, unknown>>): Delega
     throw new Error('host.delegate options must be an object; omit it when no options are needed.')
   }
   const requestedOptions = isRecord(params.options) ? params.options : {}
+  if (hasOwn(requestedOptions, 'timeoutSeconds')) {
+    throw new Error(
+      'host.delegate private RPC options use timeout_seconds; caller-facing timeoutSeconds must be remapped before transport.'
+    )
+  }
   if (requestedOptions.wait !== undefined && typeof requestedOptions.wait !== 'boolean') {
     throw new Error('host.delegate options.wait must be true or false.')
   }
@@ -286,6 +297,11 @@ const parseDelegateRpcCall = (params: Readonly<Record<string, unknown>>): Delega
     )
   }
   const mapRequest = (candidate: Record<string, unknown>): DurableDelegateRequest => {
+    if (hasOwn(candidate, 'outputSchema')) {
+      throw new Error(
+        'host.delegate private RPC requests use output_schema; caller-facing outputSchema must be remapped before transport.'
+      )
+    }
     const { output_schema, ...rest } = candidate
     return {
       ...(rest as DurableDelegateRequest),
@@ -315,6 +331,11 @@ const parseCollectRpcCall = (params: Readonly<Record<string, unknown>>): Collect
   }
   const selectors = params.selectors.map((selector) => {
     if (typeof selector === 'string' && selector.trim()) return selector
+    if (isRecord(selector) && (hasOwn(selector, 'frameId') || hasOwn(selector, 'attemptId'))) {
+      throw new Error(
+        'host.collect private RPC selectors use {frame_id, attempt_id}; caller-facing selectors must be remapped before transport.'
+      )
+    }
     if (
       isRecord(selector) &&
       typeof selector.frame_id === 'string' &&
@@ -332,6 +353,11 @@ const parseCollectRpcCall = (params: Readonly<Record<string, unknown>>): Collect
     throw new Error('host.collect options must be an object; omit it to use the 30-second default.')
   }
   const requestedOptions = isRecord(params.options) ? params.options : {}
+  if (hasOwn(requestedOptions, 'timeoutSeconds')) {
+    throw new Error(
+      'host.collect private RPC options use timeout_seconds; caller-facing timeoutSeconds must be remapped before transport.'
+    )
+  }
   const timeoutSeconds = requestedOptions.timeout_seconds
   if (
     timeoutSeconds !== undefined &&

--- a/src/main/host-sdk/help.test.ts
+++ b/src/main/host-sdk/help.test.ts
@@ -54,6 +54,13 @@ describe('Host SDK help', () => {
     })
     if (catalog.kind !== 'catalog') throw new Error('expected catalog')
     expect(catalog.topics.map(({ id }) => id)).toEqual([...HOST_SDK_SUBAGENT_OPERATION_IDS])
+    expect(catalog.topics.map(({ id, path, aliases }) => ({ id, path, aliases }))).toEqual(
+      HOST_SDK_SUBAGENT_OPERATION_IDS.map((id) => ({
+        id,
+        path: id,
+        aliases: [id.slice('host.'.length)]
+      }))
+    )
     expect(JSON.stringify(catalog).length).toBeLessThanOrEqual(2_500)
   })
 
@@ -61,7 +68,7 @@ describe('Host SDK help', () => {
     const source = readFileSync(resolve(process.cwd(), 'resources/notebook/repl_loop.js'), 'utf8')
     const match = source.match(/const subagentHostOperations = Object\.freeze\(\{([\s\S]*?)\n\}\)/)
     expect(match).not.toBeNull()
-    const published = [...(match?.[1].matchAll(/^\s{2}([a-z_]+):/gm) ?? [])]
+    const published = [...(match?.[1].matchAll(/^\s{2}([a-z][A-Za-z0-9]*):/gm) ?? [])]
       .map((entry) => `host.${entry[1]}`)
       .sort()
     expect(published).toEqual([...HOST_SDK_SUBAGENT_OPERATION_IDS])
@@ -78,7 +85,7 @@ describe('Host SDK help', () => {
       'name',
       'profile',
       'inputs',
-      'output_schema'
+      'outputSchema'
     ])
     expect(named(requestFields, 'task')).toMatchObject({ type: 'string', required: true })
     expect(named(requestFields, 'name')).toMatchObject({ type: 'string', required: true })
@@ -89,7 +96,7 @@ describe('Host SDK help', () => {
 
     const optionFields = fields(canonical.options)
     expect(named(optionFields, 'wait')).toMatchObject({ type: 'boolean', default: true })
-    expect(named(optionFields, 'timeout_seconds')).toMatchObject({
+    expect(named(optionFields, 'timeoutSeconds')).toMatchObject({
       type: 'number',
       range: '0..1800'
     })
@@ -100,7 +107,7 @@ describe('Host SDK help', () => {
         { value: 'receipts', when: 'wait=false', statuses: ['running'] },
         {
           value: 'observations',
-          when: 'timeout_seconds is set',
+          when: 'timeoutSeconds is set',
           statuses: ['running', 'awaiting_user', 'completed', 'cancelled', 'error']
         },
         {
@@ -138,14 +145,14 @@ describe('Host SDK help', () => {
     expect(canonical).not.toHaveProperty('errors')
     expect(canonical.examples).toHaveLength(1)
     expect(canonical.constraints).toContainEqual(
-      expect.stringMatching(/children.*collect.*stop_child/i)
+      expect.stringMatching(/children.*collect.*stopChild/i)
     )
     expect(serialized.length).toBeLessThanOrEqual(3_200)
   })
 
   it('uses the same flat field-description shape for every operation topic', () => {
     for (const id of HOST_SDK_SUBAGENT_OPERATION_IDS) {
-      const help = operation(id, id === 'host.submit_output' ? 'delegate' : 'main')
+      const help = operation(id, id === 'host.submitOutput' ? 'delegate' : 'main')
       expect(Array.isArray((help.request as { fields?: unknown }).fields)).toBe(true)
       expect(Array.isArray((help.options as { fields?: unknown }).fields)).toBe(true)
       expect(help).not.toHaveProperty('errors')
@@ -160,7 +167,7 @@ describe('Host SDK help', () => {
   it('keeps lifecycle operation fields sufficient for direct use', () => {
     const children = operation('children')
     expect(fields(children.request)).toEqual([
-      expect.objectContaining({ name: 'frame_ids', type: 'string[]', required: false })
+      expect.objectContaining({ name: 'frameIds', type: 'string[]', required: false })
     ])
     expect(fields(children.returns, 'item_fields').map(({ name }) => name)).toEqual([
       'frame_id',
@@ -178,23 +185,50 @@ describe('Host SDK help', () => {
     expect(fields(collect.request)).toEqual([
       expect.objectContaining({ name: 'selectors', type: 'selector[]', required: true })
     ])
-    expect(named(fields(collect.options), 'timeout_seconds')).toMatchObject({
+    expect(named(fields(collect.options), 'timeoutSeconds')).toMatchObject({
       default: 30,
       range: '0..1800'
     })
+    expect(collect.call_forms[0]?.signature).toBe('await host.collect(selectors, options?)')
+    expect(collect.examples[0]?.code).toContain('{ frameId: frame_id, attemptId: attempt_id }')
 
-    const stop = operation('stop_child')
+    const stop = operation('stopChild')
     expect(fields(stop.request)).toEqual([
-      expect.objectContaining({ name: 'frame_ids', type: 'string[]', required: true })
+      expect.objectContaining({ name: 'frameIds', type: 'string[]', required: true })
     ])
     expect(fields(stop.returns, 'item_fields').map(({ name }) => name)).toEqual([
       'frame_id',
       'status'
     ])
+    expect(stop.call_forms[0]?.signature).toBe('await host.stopChild(frameIds)')
+
+    const send = operation('sendFrameMessage')
+    expect(fields(send.options).map(({ name }) => name)).toEqual([
+      'kind',
+      'requestId',
+      'replyToMessageId'
+    ])
+    expect(send.call_forms[0]?.signature).toBe(
+      'await host.sendFrameMessage(target, message, options?)'
+    )
+
+    const receipt = operation('messageReceipt')
+    expect(fields(receipt.options)).toEqual([
+      expect.objectContaining({ name: 'timeoutSeconds', type: 'number', required: false })
+    ])
+    expect(receipt.examples[0]?.code).toContain('{ timeoutSeconds: 30 }')
+
+    const resolveMessage = operation('resolveMessage')
+    expect(fields(resolveMessage.request)).toEqual([
+      expect.objectContaining({ name: 'messageId', type: 'string', required: true })
+    ])
+
+    const submitOutput = operation('submitOutput', 'delegate')
+    expect(submitOutput.call_forms[0]?.signature).toBe('await host.submitOutput(value)')
   })
 
   it('describes reliable receipt routes and states without exhaustive unions', () => {
-    for (const topic of ['send_frame_message', 'message_receipt']) {
+    for (const topic of ['sendFrameMessage', 'messageReceipt']) {
       const help = operation(topic)
       expect(help.returns).toMatchObject({
         discriminators: [
@@ -229,7 +263,7 @@ describe('Host SDK help', () => {
         'same_request_safe'
       ])
     }
-    expect(operation('resolve_message').returns).toMatchObject({
+    expect(operation('resolveMessage').returns).toMatchObject({
       discriminators: [
         { name: 'direction', values: ['to_child', 'to_parent'] },
         { name: 'disposition', values: ['message', 'continued'] },
@@ -261,6 +295,18 @@ describe('Host SDK help', () => {
       kind: 'not_found',
       query: 'send_message'
     })
+    for (const legacyTopic of [
+      'stop_child',
+      'send_frame_message',
+      'message_receipt',
+      'resolve_message',
+      'submit_output'
+    ]) {
+      expect(hostSdkHelp.query(legacyTopic, mainContext)).toMatchObject({
+        kind: 'not_found',
+        query: legacyTopic
+      })
+    }
   })
 
   it('projects availability from trusted role and provisioning independently', () => {
@@ -273,7 +319,7 @@ describe('Host SDK help', () => {
     for (const id of HOST_SDK_SUBAGENT_OPERATION_IDS) {
       const operationName = id.slice('host.'.length) as keyof typeof provisioned
       const result = hostSdkHelp.query(id, {
-        callerRole: operationName === 'submit_output' ? 'delegate' : 'main',
+        callerRole: operationName === 'submitOutput' ? 'delegate' : 'main',
         capabilities: { ...provisioned, [operationName]: false }
       })
       expect(result).toMatchObject({ availability: { status: 'unavailable' } })
@@ -281,13 +327,13 @@ describe('Host SDK help', () => {
   })
 
   it('advertises reliable parent messaging to an authenticated Delegate', () => {
-    expect(hostSdkHelp.query('send_frame_message', delegateContext)).toMatchObject({
+    expect(hostSdkHelp.query('sendFrameMessage', delegateContext)).toMatchObject({
       availability: { status: 'available' }
     })
-    expect(hostSdkHelp.query('message_receipt', delegateContext)).toMatchObject({
+    expect(hostSdkHelp.query('messageReceipt', delegateContext)).toMatchObject({
       availability: { status: 'available' }
     })
-    expect(hostSdkHelp.query('resolve_message', delegateContext)).toMatchObject({
+    expect(hostSdkHelp.query('resolveMessage', delegateContext)).toMatchObject({
       availability: {
         status: 'unavailable',
         reason: 'Only root Main can resolve uncertain delivery.'
@@ -302,7 +348,7 @@ describe('Host SDK help', () => {
       throw new Error('expected catalogs')
     }
     expect(childCatalog.topics.map(({ id }) => id)).toEqual(rootCatalog.topics.map(({ id }) => id))
-    for (const topic of ['delegate', 'children', 'collect', 'stop_child', 'resolve_message']) {
+    for (const topic of ['delegate', 'children', 'collect', 'stopChild', 'resolveMessage']) {
       expect(hostSdkHelp.query(topic, delegateContext)).toMatchObject({
         availability: { status: 'unavailable' }
       })

--- a/src/main/host-sdk/help.ts
+++ b/src/main/host-sdk/help.ts
@@ -2,11 +2,11 @@ const HOST_SDK_SUBAGENT_OPERATION_IDS = [
   'host.children',
   'host.collect',
   'host.delegate',
-  'host.message_receipt',
-  'host.resolve_message',
-  'host.send_frame_message',
-  'host.stop_child',
-  'host.submit_output'
+  'host.messageReceipt',
+  'host.resolveMessage',
+  'host.sendFrameMessage',
+  'host.stopChild',
+  'host.submitOutput'
 ] as const
 
 type HostSdkSubagentOperation =
@@ -177,10 +177,10 @@ const DELEGATE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
         description: 'Immutable Version ids staged read-only under ./inputs/.'
       },
       {
-        name: 'output_schema',
+        name: 'outputSchema',
         type: 'JSON Schema',
         required: false,
-        description: 'JSON Schema 2020-12 for host.submit_output.'
+        description: 'JSON Schema 2020-12 for host.submitOutput.'
       }
     ]
   },
@@ -194,7 +194,7 @@ const DELEGATE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
         description: 'Wait for all children unless false.'
       },
       {
-        name: 'timeout_seconds',
+        name: 'timeoutSeconds',
         type: 'number',
         required: false,
         range: '0..1800',
@@ -208,7 +208,7 @@ const DELEGATE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
       { value: 'receipts', when: 'wait=false', statuses: ['running'] },
       {
         value: 'observations',
-        when: 'timeout_seconds is set',
+        when: 'timeoutSeconds is set',
         statuses: ['running', 'awaiting_user', 'completed', 'cancelled', 'error']
       },
       {
@@ -224,7 +224,7 @@ const DELEGATE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
     'Non-empty batches are admitted atomically.',
     'Use host.agents.list() for profiles; omission inherits.',
     'Timeout observes; it does not stop children.',
-    'Async follow-up: host.children() recovers; host.collect(selectors) observes; host.stop_child(frame_ids) cancels.'
+    'Async follow-up: host.children() recovers; host.collect(selectors) observes; host.stopChild(frameIds) cancels.'
   ],
   examples: [
     {
@@ -263,13 +263,11 @@ const CHILDREN_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   path: 'host.children',
   aliases: ['children'],
   summary: 'List current direct-child Attempts on the active Message Branch.',
-  call_forms: [
-    { signature: 'await host.children(frame_ids?)', accepts: 'optional_frame_id_array' }
-  ],
+  call_forms: [{ signature: 'await host.children(frameIds?)', accepts: 'optional_frame_id_array' }],
   request: {
     fields: [
       {
-        name: 'frame_ids',
+        name: 'frameIds',
         type: 'string[]',
         required: false,
         description: 'Selected Frames; omit to list all accessible direct children.'
@@ -304,14 +302,14 @@ const COLLECT_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
         name: 'selectors',
         type: 'selector[]',
         required: true,
-        description: 'Frame ids or {frame_id, attempt_id} handles; array must be non-empty.'
+        description: 'Frame ids or {frameId, attemptId} handles; array must be non-empty.'
       }
     ]
   },
   options: {
     fields: [
       {
-        name: 'timeout_seconds',
+        name: 'timeoutSeconds',
         type: 'number',
         required: false,
         default: 30,
@@ -328,7 +326,7 @@ const COLLECT_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   examples: [
     {
       title: 'Collect pinned Attempts',
-      code: 'await host.collect(sent.children.map(({ frame_id, attempt_id }) => ({ frame_id, attempt_id })))'
+      code: 'await host.collect(sent.children.map(({ frame_id, attempt_id }) => ({ frameId: frame_id, attemptId: attempt_id })))'
     }
   ],
   resolveAvailability: rootOnlyAvailability('collect', 'Delegate agents cannot collect children.')
@@ -336,17 +334,17 @@ const COLLECT_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
 
 const STOP_CHILD_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   kind: 'operation',
-  id: 'host.stop_child',
-  path: 'host.stop_child',
-  aliases: ['stop_child'],
+  id: 'host.stopChild',
+  path: 'host.stopChild',
+  aliases: ['stopChild'],
   summary: 'Stop one or more direct-child Frames.',
   call_forms: [
-    { signature: 'await host.stop_child(frame_ids)', accepts: 'non_empty_frame_id_array' }
+    { signature: 'await host.stopChild(frameIds)', accepts: 'non_empty_frame_id_array' }
   ],
   request: {
     fields: [
       {
-        name: 'frame_ids',
+        name: 'frameIds',
         type: 'string[]',
         required: true,
         description: 'Non-empty direct-child Frame ids.'
@@ -373,29 +371,29 @@ const STOP_CHILD_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   examples: [
     {
       title: 'Stop children',
-      code: 'await host.stop_child(current.map(({ frame_id }) => frame_id))'
+      code: 'await host.stopChild(current.map(({ frame_id }) => frame_id))'
     }
   ],
   resolveAvailability: rootOnlyAvailability(
-    'stop_child',
+    'stopChild',
     'Delegate agents cannot stop or manage child Frames.'
   )
 }
 
 const SUBMIT_OUTPUT_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   kind: 'operation',
-  id: 'host.submit_output',
-  path: 'host.submit_output',
-  aliases: ['submit_output'],
+  id: 'host.submitOutput',
+  path: 'host.submitOutput',
+  aliases: ['submitOutput'],
   summary: 'Submit the authenticated child Attempt structured JSON value.',
-  call_forms: [{ signature: 'await host.submit_output(value)', accepts: 'json_value' }],
+  call_forms: [{ signature: 'await host.submitOutput(value)', accepts: 'json_value' }],
   request: {
     fields: [
       {
         name: 'value',
         type: 'JSON value',
         required: true,
-        description: 'Value validated against this Attempt’s admitted output_schema.'
+        description: 'Value validated against this Attempt’s admitted outputSchema.'
       }
     ]
   },
@@ -407,23 +405,23 @@ const SUBMIT_OUTPUT_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
     ]
   },
   constraints: [
-    'Available only to a running child delegated with output_schema.',
+    'Available only to a running child delegated with outputSchema.',
     'The first valid value is durable; equal retry is idempotent and different retry is rejected.'
   ],
-  examples: [{ title: 'Submit output', code: 'await host.submit_output({ answer: 42 })' }],
+  examples: [{ title: 'Submit output', code: 'await host.submitOutput({ answer: 42 })' }],
   resolveAvailability: ({ callerRole, capabilities }) => {
     if (callerRole !== 'delegate') {
       return { status: 'unavailable', reason: 'Only a delegated child Attempt can submit output.' }
     }
-    return capabilities.submit_output
+    return capabilities.submitOutput
       ? { status: 'available' }
-      : unavailableProvisioning('submit_output')
+      : unavailableProvisioning('submitOutput')
   }
 }
 
 const messageAvailability =
   (
-    operation: 'send_frame_message' | 'message_receipt'
+    operation: 'sendFrameMessage' | 'messageReceipt'
   ): HostSdkHelpOperationDescriptor['resolveAvailability'] =>
   ({ capabilities }) =>
     capabilities[operation] ? { status: 'available' } : unavailableProvisioning(operation)
@@ -522,13 +520,13 @@ const DELIVERY_DISCRIMINATORS = [
 
 const SEND_FRAME_MESSAGE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   kind: 'operation',
-  id: 'host.send_frame_message',
-  path: 'host.send_frame_message',
-  aliases: ['send_frame_message'],
+  id: 'host.sendFrameMessage',
+  path: 'host.sendFrameMessage',
+  aliases: ['sendFrameMessage'],
   summary: 'Durably queue a reliable message to a direct child or root parent.',
   call_forms: [
     {
-      signature: 'await host.send_frame_message(target, message, options?)',
+      signature: 'await host.sendFrameMessage(target, message, options?)',
       accepts: 'positional_arguments'
     }
   ],
@@ -552,9 +550,9 @@ const SEND_FRAME_MESSAGE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
         default: 'info',
         description: 'info/question.'
       },
-      { name: 'request_id', type: 'string', required: false, description: 'Idempotency id.' },
+      { name: 'requestId', type: 'string', required: false, description: 'Idempotency id.' },
       {
-        name: 'reply_to_message_id',
+        name: 'replyToMessageId',
         type: 'string',
         required: false,
         description: 'Reply target.'
@@ -566,20 +564,20 @@ const SEND_FRAME_MESSAGE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
     fields: DELIVERY_RECEIPT_FIELDS
   },
   constraints: [
-    'Receipt is delivery evidence, not a reply; same request_id recovers, and uncertain is not auto-retried.'
+    'Receipt is delivery evidence, not a reply; same requestId recovers, and uncertain is not auto-retried.'
   ],
   examples: [],
-  resolveAvailability: messageAvailability('send_frame_message')
+  resolveAvailability: messageAvailability('sendFrameMessage')
 }
 
 const MESSAGE_RECEIPT_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   kind: 'operation',
-  id: 'host.message_receipt',
-  path: 'host.message_receipt',
-  aliases: ['message_receipt'],
+  id: 'host.messageReceipt',
+  path: 'host.messageReceipt',
+  aliases: ['messageReceipt'],
   summary: 'Observe an owned delivery receipt for a bounded time.',
   call_forms: [
-    { signature: 'await host.message_receipt(selector, options?)', accepts: 'selector_options' }
+    { signature: 'await host.messageReceipt(selector, options?)', accepts: 'selector_options' }
   ],
   request: {
     fields: [
@@ -587,14 +585,14 @@ const MESSAGE_RECEIPT_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
         name: 'selector',
         type: 'string',
         required: true,
-        description: 'Owned message_id or request_id.'
+        description: 'Owned messageId or requestId.'
       }
     ]
   },
   options: {
     fields: [
       {
-        name: 'timeout_seconds',
+        name: 'timeoutSeconds',
         type: 'number',
         required: false,
         default: 30,
@@ -615,27 +613,27 @@ const MESSAGE_RECEIPT_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   examples: [
     {
       title: 'Observe delivery',
-      code: 'await host.message_receipt(receipt.message_id, { timeout_seconds: 30 })'
+      code: 'await host.messageReceipt(receipt.message_id, { timeoutSeconds: 30 })'
     }
   ],
-  resolveAvailability: messageAvailability('message_receipt')
+  resolveAvailability: messageAvailability('messageReceipt')
 }
 
 const RESOLVE_MESSAGE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   kind: 'operation',
-  id: 'host.resolve_message',
-  path: 'host.resolve_message',
-  aliases: ['resolve_message'],
+  id: 'host.resolveMessage',
+  path: 'host.resolveMessage',
+  aliases: ['resolveMessage'],
   summary: 'Acknowledge uncertain delivery risk and release its lane fence.',
   call_forms: [
     {
-      signature: "await host.resolve_message(message_id, { action: 'acknowledge_uncertain' })",
+      signature: "await host.resolveMessage(messageId, { action: 'acknowledge_uncertain' })",
       accepts: 'message_resolution'
     }
   ],
   request: {
     fields: [
-      { name: 'message_id', type: 'string', required: true, description: 'Uncertain command id.' }
+      { name: 'messageId', type: 'string', required: true, description: 'Uncertain command id.' }
     ]
   },
   options: {
@@ -662,11 +660,11 @@ const RESOLVE_MESSAGE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   examples: [
     {
       title: 'Release fence',
-      code: "await host.resolve_message(receipt.message_id, { action: 'acknowledge_uncertain' })"
+      code: "await host.resolveMessage(receipt.message_id, { action: 'acknowledge_uncertain' })"
     }
   ],
   resolveAvailability: rootOnlyAvailability(
-    'resolve_message',
+    'resolveMessage',
     'Only root Main can resolve uncertain delivery.'
   )
 }

--- a/src/main/notebook/delegated-lane-capability.test.ts
+++ b/src/main/notebook/delegated-lane-capability.test.ts
@@ -115,19 +115,19 @@ describe('delegated Notebook lane capability', () => {
           kind: 'catalog',
           topics: expect.arrayContaining([
             expect.objectContaining({ id: 'host.children' }),
-            expect.objectContaining({ id: 'host.stop_child' }),
+            expect.objectContaining({ id: 'host.stopChild' }),
             expect.objectContaining({
-              id: 'host.send_frame_message',
+              id: 'host.sendFrameMessage',
               availability: { status: 'available' }
             }),
             expect.objectContaining({
-              id: 'host.message_receipt',
+              id: 'host.messageReceipt',
               availability: { status: 'available' }
             })
           ])
         }
       })
-      for (const topic of ['children', 'stop_child']) {
+      for (const topic of ['children', 'stopChild']) {
         const help = await request(child, 'hostSdkHelp', { query: topic, caller_role: 'main' })
         expect(help.status).toBe(200)
         await expect(help.json()).resolves.toMatchObject({
@@ -195,7 +195,7 @@ describe('delegated Notebook lane capability', () => {
     }
   })
 
-  it('binds submit_output ownership to the child capability and fences revoked writes', async () => {
+  it('binds submitOutput ownership to the child capability and fences revoked writes', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'delegated-output-capability-'))
     const submitOutput = vi.fn(async () => ({ accepted: true as const }))
     const service = new NotebookRuntimeService({

--- a/src/main/notebook/local-rpc-server.delegated-work.test.ts
+++ b/src/main/notebook/local-rpc-server.delegated-work.test.ts
@@ -121,11 +121,11 @@ describe('authenticated delegatedWorkCall route', () => {
       'host.children': 'unavailable',
       'host.collect': 'unavailable',
       'host.delegate': 'available',
-      'host.message_receipt': 'unavailable',
-      'host.resolve_message': 'unavailable',
-      'host.send_frame_message': 'unavailable',
-      'host.stop_child': 'unavailable',
-      'host.submit_output': 'unavailable'
+      'host.messageReceipt': 'unavailable',
+      'host.resolveMessage': 'unavailable',
+      'host.sendFrameMessage': 'unavailable',
+      'host.stopChild': 'unavailable',
+      'host.submitOutput': 'unavailable'
     })
     await expect(
       fetch(child.endpoint, {
@@ -136,21 +136,81 @@ describe('authenticated delegatedWorkCall route', () => {
         },
         body: JSON.stringify({
           method: 'hostSdkHelp',
-          params: { query: 'send_frame_message', caller_role: 'main' }
+          params: { query: 'sendFrameMessage', caller_role: 'main' }
         })
       }).then((response) => response.json())
     ).resolves.toMatchObject({
       result: {
-        id: 'host.send_frame_message',
+        id: 'host.sendFrameMessage',
         availability: {
           status: 'unavailable',
-          reason: 'host.send_frame_message is not provisioned for this Session.'
+          reason: 'host.sendFrameMessage is not provisioned for this Session.'
         }
       }
     })
 
     main.release()
     child.release()
+  })
+
+  it('keeps delegated-work RPC diagnostics on the private snake_case contract', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      delegatedWorkService: {
+        delegate: vi.fn(),
+        children: vi.fn(),
+        stopChildren: vi.fn(),
+        sendMessage: vi.fn()
+      }
+    })
+    const connection = await server.issueControlConnection(
+      'session-1',
+      'project-1',
+      'child-frame',
+      { role: 'delegate', attemptId: 'attempt-1' }
+    )
+    const endInvocation = connection.beginControlInvocation({
+      turnId: 'turn-1',
+      controlInvocationGeneration: 1,
+      toolInvocationId: 'tool-1',
+      originatingUserMessageId: 'message-1'
+    })
+    const call = async (
+      params: Record<string, unknown>,
+      method = 'delegatedWorkCall'
+    ): Promise<unknown> => {
+      const response = await fetch(connection.endpoint, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ method, params })
+      })
+      expect(response.status).toBe(500)
+      return response.json()
+    }
+
+    await expect(call({ value: 'done' }, 'delegatedOutputCall')).resolves.toEqual({
+      error: 'host.submit_output is not configured.'
+    })
+    await expect(
+      call({
+        op: 'send_message',
+        target: 'child-frame',
+        message: 'hello',
+        options: { request_id: 42 }
+      })
+    ).resolves.toEqual({ error: 'host.send_frame_message request_id must be a string.' })
+    await expect(call({ op: 'children', frame_ids: 'child-frame' })).resolves.toEqual({
+      error: 'host.children frame_ids must be an array of strings.'
+    })
+    await expect(call({ operation: 'stop_children', frame_ids: [] })).resolves.toEqual({
+      error: 'host.stop_child requires one or more frame ids.'
+    })
+
+    endInvocation()
+    connection.release()
   })
 
   it('forwards a request array through the authenticated host seam without reordering it', async () => {
@@ -633,7 +693,7 @@ describe('authenticated delegatedWorkCall route', () => {
     connection.release()
   })
 
-  it('routes an authenticated send_message to terminal-child continuation', async () => {
+  it('routes an authenticated sendFrameMessage call to terminal-child continuation', async () => {
     const session = { projectId: 'project-1', sessionId: 'session-1' }
     const execution = createDeterministicDelegateExecution()
     const records = createInMemoryDelegatedWorkRecords({

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -1821,11 +1821,11 @@ class NotebookLocalRpcServer {
           delegate: Boolean(this.delegatedWorkService?.delegate),
           children: Boolean(this.delegatedWorkService?.children),
           collect: Boolean(this.delegatedWorkService?.collect),
-          stop_child: Boolean(this.delegatedWorkService?.stopChildren),
-          send_frame_message: Boolean(this.delegatedWorkService?.sendMessage),
-          message_receipt: Boolean(this.delegatedWorkService?.messageReceipt),
-          resolve_message: Boolean(this.delegatedWorkService?.resolveMessage),
-          submit_output: Boolean(this.delegatedWorkService?.submitOutput)
+          stopChild: Boolean(this.delegatedWorkService?.stopChildren),
+          sendFrameMessage: Boolean(this.delegatedWorkService?.sendMessage),
+          messageReceipt: Boolean(this.delegatedWorkService?.messageReceipt),
+          resolveMessage: Boolean(this.delegatedWorkService?.resolveMessage),
+          submitOutput: Boolean(this.delegatedWorkService?.submitOutput)
         }
       })
     }

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -146,7 +146,7 @@ describe('notebook MCP server config', () => {
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toMatch(/do not prefetch.*topics/i)
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain('Delegate agents should use the same catalog')
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain('unavailable root-only topics remain visible')
-    expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).not.toContain('host.send_frame_message(')
+    expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).not.toContain('host.sendFrameMessage(')
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).not.toContain('host.send_message(')
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).not.toContain('{task')
 
@@ -415,7 +415,7 @@ describe('repl_execute tool', () => {
     expect(tool?.description).toContain('field descriptions')
     expect(tool?.description).toMatch(/do not prefetch.*topics/i)
     expect(tool?.description).toContain('Delegate agents should use the same catalog')
-    expect(tool?.description).not.toContain('host.send_frame_message(')
+    expect(tool?.description).not.toContain('host.sendFrameMessage(')
     expect(tool?.description).not.toContain('host.send_message(')
   })
 

--- a/src/main/notebook/repl-loop.integration.test.ts
+++ b/src/main/notebook/repl-loop.integration.test.ts
@@ -70,6 +70,11 @@ describe('repl_loop local RPC transport', () => {
           "detachSkill: 'detachSkill' in host.agents, detach_skill: 'detach_skill' in host.agents, " +
           "attachConnector: 'attachConnector' in host.agents, attach_connector: 'attach_connector' in host.agents, " +
           "detachConnector: 'detachConnector' in host.agents, detach_connector: 'detach_connector' in host.agents, " +
+          "stopChild: 'stopChild' in host, stop_child: 'stop_child' in host, " +
+          "sendFrameMessage: 'sendFrameMessage' in host, send_frame_message: 'send_frame_message' in host, " +
+          "messageReceipt: 'messageReceipt' in host, message_receipt: 'message_receipt' in host, " +
+          "resolveMessage: 'resolveMessage' in host, resolve_message: 'resolve_message' in host, " +
+          "submitOutput: 'submitOutput' in host, submit_output: 'submit_output' in host, " +
           "listCompute: 'listCompute' in host.compute, list_compute: 'list_compute' in host.compute, " +
           "callCommand: 'callCommand' in c, call_command: 'call_command' in c, " +
           "submitJob: 'submitJob' in c, submit_job: 'submit_job' in c, " +
@@ -93,6 +98,16 @@ describe('repl_loop local RPC transport', () => {
         attach_connector: false,
         detachConnector: true,
         detach_connector: false,
+        stopChild: true,
+        stop_child: false,
+        sendFrameMessage: true,
+        send_frame_message: false,
+        messageReceipt: true,
+        message_receipt: false,
+        resolveMessage: true,
+        resolve_message: false,
+        submitOutput: true,
+        submit_output: false,
         listCompute: true,
         list_compute: false,
         callCommand: true,
@@ -125,12 +140,12 @@ describe('repl_loop local RPC transport', () => {
     }
   })
 
-  it('publishes send_frame_message without the legacy send_message alias', async () => {
+  it('does not publish the pre-reliability send_message alias', async () => {
     const { child, send } = startLoop({})
 
     try {
       const result = await send(
-        'return { current: typeof host.send_frame_message, legacy: typeof host.send_message }'
+        'return { current: typeof host.sendFrameMessage, legacy: typeof host.send_message }'
       )
       expect(result.error).toBeNull()
       expect(JSON.parse(result.result ?? '{}')).toEqual({
@@ -206,11 +221,11 @@ describe('repl_loop local RPC transport', () => {
               delegate: true,
               children: true,
               collect: true,
-              stop_child: true,
-              send_frame_message: true,
-              message_receipt: true,
-              resolve_message: true,
-              submit_output: true
+              stopChild: true,
+              sendFrameMessage: true,
+              messageReceipt: true,
+              resolveMessage: true,
+              submitOutput: true
             }
           })
         } else if (call.params?.op === 'children') {
@@ -507,7 +522,7 @@ describe('repl_loop local RPC transport', () => {
 
     try {
       const firstCell = await send(
-        "globalThis.pendingDelegation = await host.delegate({ task: 'Trace sources', name: 'Source trace' }, { wait: false }); return { delegated: globalThis.pendingDelegation, children: await host.children() }"
+        "globalThis.pendingDelegation = await host.delegate({ task: 'Trace sources', name: 'Source trace', outputSchema: { type: 'object' } }, { wait: false }); return { delegated: globalThis.pendingDelegation, children: await host.children() }"
       )
       expect(firstCell.error).toBeNull()
       expect(JSON.parse(firstCell.result ?? '{}')).toEqual({
@@ -533,7 +548,7 @@ describe('repl_loop local RPC transport', () => {
         ]
       })
       const secondCell = await send(
-        'return { results: await host.collect(globalThis.pendingDelegation.children.map(({ frame_id, attempt_id }) => ({ frame_id, attempt_id })), { timeout_seconds: 0 }) }'
+        'return { results: await host.collect(globalThis.pendingDelegation.children.map(({ frame_id, attempt_id }) => ({ frameId: frame_id, attemptId: attempt_id })), { timeoutSeconds: 0 }) }'
       )
       expect(secondCell.error).toBeNull()
       expect(JSON.parse(secondCell.result ?? '{}')).toEqual({
@@ -559,7 +574,11 @@ describe('repl_loop local RPC transport', () => {
         {
           method: 'delegatedWorkCall',
           params: {
-            request: { task: 'Trace sources', name: 'Source trace' },
+            request: {
+              task: 'Trace sources',
+              name: 'Source trace',
+              output_schema: { type: 'object' }
+            },
             options: { wait: false },
             delegation_call_id: '1'
           }
@@ -582,7 +601,7 @@ describe('repl_loop local RPC transport', () => {
     }
   }, 60_000)
 
-  it('routes host.submit_output through its dedicated child capability method', async () => {
+  it('routes host.submitOutput through its dedicated child capability method', async () => {
     let received: { method?: string; params?: Record<string, unknown> } = {}
     const server = createServer((request, response) => {
       let body = ''
@@ -604,7 +623,7 @@ describe('repl_loop local RPC transport', () => {
       OPEN_SCIENCE_MCP_RPC_TOKEN: 'child-token'
     })
     try {
-      const result = await send('return await host.submit_output({ answer: 42 })')
+      const result = await send('return await host.submitOutput({ answer: 42 })')
       expect(result.error).toBeNull()
       expect(JSON.parse(result.result ?? '{}')).toEqual({ accepted: true })
       expect(received).toEqual({
@@ -619,7 +638,7 @@ describe('repl_loop local RPC transport', () => {
     }
   }, 60_000)
 
-  it('routes host.send_frame_message kind through delegated work and projects a continuation receipt', async () => {
+  it('routes host.sendFrameMessage options through delegated work and projects a continuation receipt', async () => {
     let received: { method?: string; params?: Record<string, unknown> } = {}
     const server = createServer((request, response) => {
       let body = ''
@@ -651,7 +670,7 @@ describe('repl_loop local RPC transport', () => {
 
     try {
       const result = await send(
-        "return JSON.stringify(await host.send_frame_message('child-frame', 'Check a counterexample', { kind: 'question' }))"
+        "return JSON.stringify(await host.sendFrameMessage('child-frame', 'Check a counterexample', { kind: 'question', requestId: 'request-1', replyToMessageId: 'message-0' }))"
       )
       expect(result.error).toBeNull()
       expect(JSON.parse(result.result as string)).toEqual({
@@ -666,7 +685,11 @@ describe('repl_loop local RPC transport', () => {
           op: 'send_message',
           target: 'child-frame',
           message: 'Check a counterexample',
-          options: { kind: 'question' }
+          options: {
+            kind: 'question',
+            request_id: 'request-1',
+            reply_to_message_id: 'message-0'
+          }
         }
       })
     } finally {
@@ -677,7 +700,7 @@ describe('repl_loop local RPC transport', () => {
     }
   }, 60_000)
 
-  it('keeps the two-argument host.send_frame_message call compatible', async () => {
+  it('keeps the two-argument host.sendFrameMessage call compatible', async () => {
     let received: { method?: string; params?: Record<string, unknown> } = {}
     const server = createServer((request, response) => {
       let body = ''
@@ -709,7 +732,7 @@ describe('repl_loop local RPC transport', () => {
 
     try {
       const result = await send(
-        "return JSON.stringify(await host.send_frame_message('child-frame', 'Check a counterexample'))"
+        "return JSON.stringify(await host.sendFrameMessage('child-frame', 'Check a counterexample'))"
       )
       expect(result.error).toBeNull()
       expect(JSON.parse(result.result as string)).toEqual({
@@ -735,7 +758,7 @@ describe('repl_loop local RPC transport', () => {
     }
   }, 60_000)
 
-  it('projects a Delegate-to-parent queued send_frame_message receipt without a child', async () => {
+  it('projects a Delegate-to-parent queued sendFrameMessage receipt without a child', async () => {
     let received: { method?: string; params?: Record<string, unknown> } = {}
     const server = createServer((request, response) => {
       let body = ''
@@ -769,7 +792,7 @@ describe('repl_loop local RPC transport', () => {
 
     try {
       const result = await send(
-        "return JSON.stringify(await host.send_frame_message('parent', 'Which cohort?', { kind: 'question' }))"
+        "return JSON.stringify(await host.sendFrameMessage('parent', 'Which cohort?', { kind: 'question' }))"
       )
       expect(result.error).toBeNull()
       expect(JSON.parse(result.result as string)).toEqual({
@@ -789,6 +812,155 @@ describe('repl_loop local RPC transport', () => {
           options: { kind: 'question' }
         }
       })
+    } finally {
+      child.kill()
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      )
+    }
+  }, 60_000)
+
+  it('remaps camelCase stop and message inputs onto the private delegated-work wire', async () => {
+    const received: Array<{ method?: string; params?: Record<string, unknown> }> = []
+    const server = createServer((request, response) => {
+      let body = ''
+      request.on('data', (chunk) => (body += chunk))
+      request.on('end', () => {
+        const call = JSON.parse(body)
+        received.push(call)
+        const result =
+          call.params.operation === 'stop_children'
+            ? [{ frameId: 'child-frame', status: 'cancelled' }]
+            : { status: 'accepted' }
+        response
+          .writeHead(200, { 'content-type': 'application/json' })
+          .end(JSON.stringify({ result }))
+      })
+    })
+    const connection = await listenForLocalRpc(server, {
+      name: 'repl-loop-delegated-message-remap-test',
+      transport: 'pipe'
+    })
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: connection.endpoint,
+      OPEN_SCIENCE_MCP_RPC_SOCKET_PATH: connection.socketPath,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: 'test-token'
+    })
+
+    try {
+      const result = await send(
+        "return { stopped: await host.stopChild(['child-frame']), observed: await host.messageReceipt('request-1', { timeoutSeconds: 0 }), resolved: await host.resolveMessage('message-1', { action: 'acknowledge_uncertain' }) }"
+      )
+      expect(result.error).toBeNull()
+      expect(JSON.parse(result.result ?? '{}')).toEqual({
+        stopped: [{ frame_id: 'child-frame', status: 'cancelled' }],
+        observed: { status: 'accepted' },
+        resolved: { status: 'accepted' }
+      })
+      expect(received).toEqual([
+        {
+          method: 'delegatedWorkCall',
+          params: { operation: 'stop_children', frame_ids: ['child-frame'] }
+        },
+        {
+          method: 'delegatedWorkCall',
+          params: {
+            op: 'message_receipt',
+            selector: 'request-1',
+            options: { timeout_seconds: 0 }
+          }
+        },
+        {
+          method: 'delegatedWorkCall',
+          params: {
+            op: 'resolve_message',
+            message_id: 'message-1',
+            action: 'acknowledge_uncertain'
+          }
+        }
+      ])
+    } finally {
+      child.kill()
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      )
+    }
+  }, 60_000)
+
+  it('rejects legacy and mixed-case delegated-work inputs before issuing RPC', async () => {
+    let requestCount = 0
+    const server = createServer((_request, response) => {
+      requestCount += 1
+      response
+        .writeHead(200, { 'content-type': 'application/json' })
+        .end(JSON.stringify({ result: {} }))
+    })
+    const connection = await listenForLocalRpc(server, {
+      name: 'repl-loop-delegated-input-rejection-test',
+      transport: 'pipe'
+    })
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: connection.endpoint,
+      OPEN_SCIENCE_MCP_RPC_SOCKET_PATH: connection.socketPath,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: 'test-token'
+    })
+
+    try {
+      const result = await send(
+        "const capture = async (call) => { try { await call(); return null } catch (error) { return error.message } }; return await Promise.all([capture(() => host.delegate({ task: 'x', output_schema: {} })), capture(() => host.delegate({ task: 'x' }, { timeout_seconds: 0 })), capture(() => host.collect([{ frameId: 'f', attempt_id: 'a' }], { timeoutSeconds: 0 })), capture(() => host.sendFrameMessage('f', 'x', { requestId: 'r', request_id: 'r' })), capture(() => host.messageReceipt('r', { timeout_seconds: 0 })), capture(() => host.resolveMessage('m', { action: 'acknowledge_uncertain', message_id: 'm' }))])"
+      )
+      expect(result.error).toBeNull()
+      expect(JSON.parse(result.result ?? '[]')).toEqual([
+        'host.delegate request unknown option: output_schema',
+        'host.delegate options unknown option: timeout_seconds',
+        'host.collect selector unknown option: attempt_id',
+        'host.sendFrameMessage options unknown option: request_id',
+        'host.messageReceipt options unknown option: timeout_seconds',
+        'host.resolveMessage options unknown option: message_id'
+      ])
+      expect(requestCount).toBe(0)
+    } finally {
+      child.kill()
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      )
+    }
+  }, 60_000)
+
+  it('projects private delegation parser errors onto public camelCase names only', async () => {
+    const privateErrors = [
+      'host.delegate: options.timeout_seconds is invalid; error_code=timeout_seconds_invalid',
+      'host.collect: selector invalid; use {frame_id, attempt_id}; code=selector_invalid',
+      'host.message_receipt: message_receipt timeout_seconds is invalid; action=acknowledge_uncertain',
+      'database unavailable; enum=acknowledge_uncertain; code=reply_to_message_id_invalid'
+    ]
+    let requestCount = 0
+    const server = createServer((_request, response) => {
+      const error = privateErrors[requestCount++]
+      response.writeHead(400, { 'content-type': 'application/json' }).end(JSON.stringify({ error }))
+    })
+    const connection = await listenForLocalRpc(server, {
+      name: 'repl-loop-delegated-error-projection-test',
+      transport: 'pipe'
+    })
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: connection.endpoint,
+      OPEN_SCIENCE_MCP_RPC_SOCKET_PATH: connection.socketPath,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: 'test-token'
+    })
+
+    try {
+      const result = await send(
+        "const capture = async (call) => { try { await call(); return null } catch (error) { return error.message } }; return [await capture(() => host.delegate({ task: 'x' }, { timeoutSeconds: 1801 })), await capture(() => host.collect([{ frameId: 'f', attemptId: 'a' }])), await capture(() => host.messageReceipt('request-1', { timeoutSeconds: 1801 })), await capture(() => host.sendFrameMessage('f', 'x'))]"
+      )
+      expect(result.error).toBeNull()
+      expect(JSON.parse(result.result ?? '[]')).toEqual([
+        'host.delegate: options.timeoutSeconds is invalid; error_code=timeout_seconds_invalid',
+        'host.collect: selector invalid; use {frameId, attemptId}; code=selector_invalid',
+        'host.messageReceipt: messageReceipt timeoutSeconds is invalid; action=acknowledge_uncertain',
+        'host.sendFrameMessage: database unavailable; enum=acknowledge_uncertain; code=reply_to_message_id_invalid'
+      ])
+      expect(requestCount).toBe(4)
     } finally {
       child.kill()
       await new Promise<void>((resolve, reject) =>


### PR DESCRIPTION
## Problem

The public JavaScript delegation surface exposed snake_case method and caller-input names, unlike the rest of the Host SDK. That leaked private transport spelling into agent-facing code and allowed legacy or mixed-case requests to cross the public boundary.

## Proposed change

- Rename the public delegation methods to stopChild, sendFrameMessage, messageReceipt, resolveMessage, and submitOutput.
- Accept camelCase caller inputs and translate them to the existing private delegated-work RPC contract at the REPL seam.
- Reject legacy or mixed snake_case caller inputs before transport.
- Align Host Help, prompts, contract tests, integration tests, and shipped E2E consumers with the public camelCase surface.
- Preserve private snake_case RPC diagnostics and project them to camelCase only for public REPL callers.

## Scope and non-goals

- This is a breaking caller-facing Host JavaScript API rename.
- Delegated-work RPC operation names and wire fields are unchanged.
- Persisted records, core domain interfaces, and return projections are unchanged.
- No schema, dependency, or renderer behavior changes are included.

## Acceptance criteria and validation

All checks below ran after the final material edit.

- Public/private Host SDK boundary, legacy-input rejection, RPC diagnostics, and REPL projection -> npm test -> PASS: 998 files passed, 15 skipped; 14,560 tests passed, 209 skipped.
- Node and renderer contracts -> npm run typecheck -> PASS.
- Source lint -> npm run lint -> PASS with 0 errors; 11 existing warnings are outside this diff.
- Packaged Electron compilation used by E2E -> npm run build:e2e -> PASS.
- Focused RPC and REPL regression tests -> npm test -- src/main/notebook/local-rpc-server.delegated-work.test.ts src/main/notebook/repl-loop.integration.test.ts -> PASS: 34 passed, 30 skipped.

Supplemental Subagent release-gate E2E produced 10 passes and 3 initial failures. The post-fence recovery case passed on isolated rerun. Two remaining failures occur outside the renamed call boundary: Provider deletion retained default reasoning effort instead of the expected unavailable presentation, and manual branch switching changed the Session to error while its receipt remained queued. CI remains authoritative for these broader stateful journeys.

## Review focus

- Public camelCase to private snake_case translation and strict mixed-case rejection.
- Diagnostic projection without rewriting domain error codes or enum values.
- Preservation of existing wire, persistence, domain, and return contracts.
