### PR TITLE
fix(skills): refresh catalog after local changes

### DIFF
--- a/src/main/application-events.ts
+++ b/src/main/application-events.ts
@@ -57,6 +57,7 @@ export type ApplicationEventMap = {
   'connectors:approval-request': ConnectorApprovalRequest
   'skills:conversation-import-request': ConversationSkillImportApprovalRequest
   'skills:conversation-import-settled': string
+  'skills:catalog-changed': undefined
   'compute:approval-request': ComputeApprovalRequest
   'compute:job-updated': JobSummary
   'specialist:catalog-changed': undefined

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -284,6 +284,7 @@ import {
 } from './runtime-electron-wiring'
 import { ConversationSkillImporter, SkillImportApprovalBroker } from './skills/conversation-import'
 import { HostSkillsService, type HostSkillsCatalog } from './skills/host-skills-service'
+import { UserSkillCatalogObserver } from './skills/user-skill-catalog-observer'
 import type { ConversationSkillImportApprovalResponse } from '../shared/settings'
 import type { TaskAgentPort } from './tasks/task-runner'
 
@@ -428,6 +429,17 @@ const createApplicationModules = async (
   // startup runs before the runtime exists, while later reads must preserve live prompt state.
   const runtimeRef: { current: ReturnType<typeof createAcpRuntime> | undefined } = {
     current: undefined
+  }
+  const userSkillCatalogObserverRef: { current: UserSkillCatalogObserver | undefined } = {
+    current: undefined
+  }
+  const requestSkillCatalogRefresh = (): void => {
+    const observer = userSkillCatalogObserverRef.current
+    if (observer) {
+      void observer.notifyCatalogChanged()
+      return
+    }
+    void runtimeRef.current?.requestSkillsReload()
   }
   const sideChatOwnerRef: { current: SideChatRuntimeOwner | undefined } = {
     current: undefined
@@ -1132,7 +1144,7 @@ const createApplicationModules = async (
       skillImportApprovalBroker.request(request, cancellation),
     // If a prompt is active the coordinator defers the reconnect until its terminal event, making the
     // new Skill available on the next user turn without interrupting the importing tool call.
-    onSkillsChanged: () => void runtimeRef.current?.requestSkillsReload()
+    onSkillsChanged: requestSkillCatalogRefresh
   })
   const moleculePreviewHandler = createMoleculePreviewHandler({
     writeArtifactForCurrentRun: (sessionId, input) => {
@@ -1580,7 +1592,7 @@ const createApplicationModules = async (
         rawInput: { skillApproval: { kind: 'delete', ...payload } }
       })
     },
-    onPublishedSkillsChanged: () => void runtimeRef.current?.requestSkillsReload()
+    onPublishedSkillsChanged: requestSkillCatalogRefresh
   })
   const hostLlmLog = createLogger('notebook:host-llm')
   const hostLlmService = new HostLlmService({
@@ -1796,6 +1808,27 @@ const createApplicationModules = async (
   )
   surfaceAdapters = afterAcpAdapters
   runtimeRef.current = runtime
+  const userSkillCatalogObserver = await modules.add(
+    {
+      storageRoot: configRoot,
+      catalog: { list: () => settingsService.listUserSkills() },
+      onCatalogChanged: async () => {
+        broadcastToRenderers('skills:catalog-changed', undefined)
+        await runtime.requestSkillsReload()
+      }
+    },
+    (options) => {
+      const observer = new UserSkillCatalogObserver(options)
+      return {
+        name: 'user-skill-catalog-observer',
+        capability: observer,
+        start: () => observer.start(),
+        rollback: () => observer.dispose(),
+        dispose: () => observer.dispose()
+      }
+    }
+  )
+  userSkillCatalogObserverRef.current = userSkillCatalogObserver
   const sideChatLog = createLogger('side-chat')
   const sideChatRuntime = await modules.add(
     {
@@ -2076,7 +2109,10 @@ const createApplicationModules = async (
         return mainApplied && sideChatApplied
       }
     },
-    skills: { requestSkillsReload: () => void runtime.requestSkillsReload() },
+    skills: {
+      requestSkillsReload: () => void runtime.requestSkillsReload(),
+      notifySkillCatalogChanged: requestSkillCatalogRefresh
+    },
     connectors: {
       invalidatePermissionProjection: () => permissionGrantProjection.invalidateProjection(),
       refreshConnectorSkillDocs: (customServerId) =>

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -261,7 +261,10 @@ const registerTestSettingsIpcHandlers = ({
         applyReasoningEffort: onReasoningEffortChanged ?? (async () => false),
         applyModelChange: async () => false
       },
-      skills: { requestSkillsReload: onSkillsChanged ?? (() => undefined) },
+      skills: {
+        requestSkillsReload: onSkillsChanged ?? (() => undefined),
+        notifySkillCatalogChanged: onSkillsChanged ?? (() => undefined)
+      },
       connectors: {
         invalidatePermissionProjection: onConnectorsChanged ?? (() => undefined),
         refreshConnectorSkillDocs: async () => undefined,

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -486,6 +486,10 @@ class SettingsService {
     return this.skills.listHostSkills()
   }
 
+  async listUserSkills(): Promise<BundledSkill[]> {
+    return this.skills.listUserSkills()
+  }
+
   async withHostSkillRead<T>(
     id: string,
     read: (skill: BundledSkill) => Promise<T>

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -178,6 +178,13 @@ class SkillCatalogModule {
     return this.catalog()
   }
 
+  // Main-process observer adapter. Keeping this read on the existing repository owner avoids a
+  // second production transaction facade while excluding immutable bundled packages from each
+  // writable-directory reconciliation.
+  async listUserSkills(): Promise<BundledSkill[]> {
+    return this.userSkills.list()
+  }
+
   async withHostSkillRead<T>(
     id: string,
     read: (skill: BundledSkill) => Promise<T>

--- a/src/main/settings/workflows.test.ts
+++ b/src/main/settings/workflows.test.ts
@@ -29,7 +29,10 @@ const testEffects = (effects: TestSettingsWorkflowEffects = {}): SettingsWorkflo
     applyReasoningEffort: effects.applyReasoningEffort ?? (async () => false),
     applyModelChange: effects.applyModelChange ?? (async () => false)
   },
-  skills: { requestSkillsReload: effects.requestSkillsReload ?? (() => undefined) },
+  skills: {
+    requestSkillsReload: effects.requestSkillsReload ?? (() => undefined),
+    notifySkillCatalogChanged: effects.notifySkillCatalogChanged ?? (() => undefined)
+  },
   connectors: {
     invalidatePermissionProjection: effects.invalidatePermissionProjection ?? (() => undefined),
     refreshConnectorSkillDocs: effects.refreshConnectorSkillDocs ?? (async () => undefined),
@@ -475,9 +478,10 @@ describe('SettingsWorkflows catalog and appearance effects', () => {
   it('reloads once after successful Skill mutations and not after a failure', async () => {
     const { store, capability } = fakeStore()
     const requestSkillsReload = vi.fn()
+    const notifySkillCatalogChanged = vi.fn()
     const workflows = createSettingsWorkflows(
       capability,
-      testEffects({ requestSkillsReload })
+      testEffects({ requestSkillsReload, notifySkillCatalogChanged })
     ).skills
 
     await workflows.setSkillEnabled({ id: 'skill', enabled: true })
@@ -486,15 +490,16 @@ describe('SettingsWorkflows catalog and appearance effects', () => {
     store.deleteSkill.mockRejectedValue(new Error('delete failed'))
     await expect(workflows.deleteSkill({ id: 'skill' })).rejects.toThrow('delete failed')
 
-    expect(requestSkillsReload).toHaveBeenCalledTimes(3)
+    expect(notifySkillCatalogChanged).toHaveBeenCalledTimes(2)
+    expect(requestSkillsReload).toHaveBeenCalledOnce()
   })
 
   it('reloads installed Skill batches only when an item changed', async () => {
     const { store, capability } = fakeStore()
-    const requestSkillsReload = vi.fn()
+    const notifySkillCatalogChanged = vi.fn()
     const workflows = createSettingsWorkflows(
       capability,
-      testEffects({ requestSkillsReload })
+      testEffects({ notifySkillCatalogChanged })
     ).skills
     const request = { skills: [] }
 
@@ -509,7 +514,7 @@ describe('SettingsWorkflows catalog and appearance effects', () => {
     })
     await workflows.importAgentHomeSkills(request)
 
-    expect(requestSkillsReload).toHaveBeenCalledOnce()
+    expect(notifySkillCatalogChanged).toHaveBeenCalledOnce()
   })
 
   it('invalidates permissions before a fire-and-forget Connector refresh and reloads on settle', async () => {

--- a/src/main/settings/workflows/skills.ts
+++ b/src/main/settings/workflows/skills.ts
@@ -26,6 +26,7 @@ type SkillSettingsWorkflowStore = Pick<
 
 type SkillSettingsWorkflowEffects = {
   requestSkillsReload: () => void
+  notifySkillCatalogChanged: () => void
 }
 
 type WorkflowResult<Method extends keyof SkillSettingsWorkflowStore> = Promise<
@@ -82,14 +83,14 @@ class SkillSettingsWorkflows {
   ): WorkflowResult<'importAgentHomeSkills'> {
     const result = await this.settings.importAgentHomeSkills(request)
     if (result.results.some((item) => item.status === 'imported' || item.status === 'updated')) {
-      this.effects.requestSkillsReload()
+      this.effects.notifySkillCatalogChanged()
     }
     return result
   }
 
   private async afterSkillsChanged<Result>(mutation: () => Promise<Result>): Promise<Result> {
     const result = await mutation()
-    this.effects.requestSkillsReload()
+    this.effects.notifySkillCatalogChanged()
     return result
   }
 }

--- a/src/main/skills/registry.ts
+++ b/src/main/skills/registry.ts
@@ -1,11 +1,11 @@
-import { createHash } from 'node:crypto'
-import { readdir, readFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import type { SkillSource } from '../../shared/settings'
 import { createLogger } from '../logger'
 import { parseFrontmatter } from './frontmatter'
 import { resolveBundledSkillsRoot } from './resource-path'
+import { skillPackageCompatibility } from './skill-package-compatibility'
 
 const log = createLogger('skills')
 
@@ -43,28 +43,6 @@ type ManifestEntry = {
 }
 
 const SAFE_ID = /^[a-z0-9-]+$/
-
-const bundledSkillCompatibility = async (sourceDir: string): Promise<string> => {
-  const hash = createHash('sha256')
-  const visit = async (directory: string, prefix = ''): Promise<void> => {
-    const entries = await readdir(directory, { withFileTypes: true })
-    entries.sort((left, right) => left.name.localeCompare(right.name))
-    for (const entry of entries) {
-      const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name
-      const absolutePath = join(directory, entry.name)
-      if (entry.isDirectory()) {
-        await visit(absolutePath, relativePath)
-      } else if (entry.isFile()) {
-        hash.update(relativePath)
-        hash.update('\0')
-        hash.update(await readFile(absolutePath))
-        hash.update('\0')
-      }
-    }
-  }
-  await visit(sourceDir)
-  return `sha256:${hash.digest('hex')}`
-}
 
 // Reads and validates the manifest, dropping malformed entries.
 const readManifest = async (rootDir: string): Promise<ManifestEntry[]> => {
@@ -131,7 +109,7 @@ class SkillRegistry {
           source: entry.source,
           updatedAt: entry.updatedAt,
           sourceDir,
-          compatibility: await bundledSkillCompatibility(sourceDir),
+          compatibility: await skillPackageCompatibility(sourceDir),
           author: fields.author,
           license: fields.license,
           // The "Third-party software, content, terms, and information" row; several key spellings.

--- a/src/main/skills/skill-package-compatibility.ts
+++ b/src/main/skills/skill-package-compatibility.ts
@@ -1,0 +1,30 @@
+import { createHash } from 'node:crypto'
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+// A package compatibility value covers every regular file, not only SKILL.md. Agent-authored Skills
+// commonly include scripts, references, or assets, and changing any of those files must invalidate a
+// framework projection even when the frontmatter and its timestamp stay unchanged.
+const skillPackageCompatibility = async (sourceDir: string): Promise<string> => {
+  const hash = createHash('sha256')
+  const visit = async (directory: string, prefix = ''): Promise<void> => {
+    const entries = await readdir(directory, { withFileTypes: true })
+    entries.sort((left, right) => left.name.localeCompare(right.name))
+    for (const entry of entries) {
+      const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name
+      const absolutePath = join(directory, entry.name)
+      if (entry.isDirectory()) {
+        await visit(absolutePath, relativePath)
+      } else if (entry.isFile()) {
+        hash.update(relativePath)
+        hash.update('\0')
+        hash.update(await readFile(absolutePath))
+        hash.update('\0')
+      }
+    }
+  }
+  await visit(sourceDir)
+  return `sha256:${hash.digest('hex')}`
+}
+
+export { skillPackageCompatibility }

--- a/src/main/skills/user-skill-catalog-observer.test.ts
+++ b/src/main/skills/user-skill-catalog-observer.test.ts
@@ -1,0 +1,122 @@
+import type { FSWatcher, watch } from 'node:fs'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { EventEmitter } from 'node:events'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { UserSkillCatalogObserver } from './user-skill-catalog-observer'
+import { UserSkillRepository } from './user-skill-repository'
+
+const makeStorage = (): Promise<string> => mkdtemp(join(tmpdir(), 'skill-catalog-observer-'))
+
+const fakeWatcher = (): {
+  watchDirectory: typeof watch
+  emitChange: () => void
+  close: ReturnType<typeof vi.fn>
+} => {
+  const emitter = new EventEmitter()
+  const close = vi.fn()
+  const watcher = Object.assign(emitter, {
+    close,
+    ref: vi.fn(),
+    unref: vi.fn()
+  }) as unknown as FSWatcher
+  let listener: (() => void) | undefined
+  const watchDirectory = vi.fn((_path, _options, onChange) => {
+    listener = onChange as () => void
+    return watcher
+  }) as unknown as typeof watch
+
+  return { watchDirectory, emitChange: () => listener?.(), close }
+}
+
+const waitForCalls = async (callback: ReturnType<typeof vi.fn>, count: number): Promise<void> => {
+  await vi.waitFor(() => expect(callback).toHaveBeenCalledTimes(count))
+}
+
+describe('UserSkillCatalogObserver', () => {
+  it('publishes valid direct additions and ignores malformed packages', async () => {
+    const storageRoot = await makeStorage()
+    const watcher = fakeWatcher()
+    const onCatalogChanged = vi.fn()
+    const observer = new UserSkillCatalogObserver({
+      storageRoot,
+      catalog: new UserSkillRepository(storageRoot),
+      onCatalogChanged,
+      watchDirectory: watcher.watchDirectory,
+      debounceMs: 1,
+      reconcileIntervalMs: 60_000
+    })
+    await observer.start()
+
+    const direct = join(storageRoot, 'skills', 'personal', 'direct')
+    await mkdir(direct, { recursive: true })
+    watcher.emitChange()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(onCatalogChanged).not.toHaveBeenCalled()
+
+    await writeFile(
+      join(direct, 'SKILL.md'),
+      '---\nname: direct\ndescription: Directly installed.\n---\nUse this Skill.\n'
+    )
+    watcher.emitChange()
+    await waitForCalls(onCatalogChanged, 1)
+
+    observer.dispose()
+    expect(watcher.close).toHaveBeenCalledOnce()
+  })
+
+  it('publishes supporting-file changes and deduplicates unchanged watcher events', async () => {
+    const storageRoot = await makeStorage()
+    const skillDirectory = join(storageRoot, 'skills', 'imported', 'bundle')
+    await mkdir(join(skillDirectory, 'scripts'), { recursive: true })
+    await writeFile(
+      join(skillDirectory, 'SKILL.md'),
+      '---\nname: bundle\ndescription: Bundled.\n---\nRun the script.\n'
+    )
+    await writeFile(join(skillDirectory, 'scripts', 'run.js'), 'console.log("v1")\n')
+
+    const watcher = fakeWatcher()
+    const onCatalogChanged = vi.fn()
+    const observer = new UserSkillCatalogObserver({
+      storageRoot,
+      catalog: new UserSkillRepository(storageRoot),
+      onCatalogChanged,
+      watchDirectory: watcher.watchDirectory,
+      debounceMs: 1,
+      reconcileIntervalMs: 60_000
+    })
+    await observer.start()
+
+    watcher.emitChange()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(onCatalogChanged).not.toHaveBeenCalled()
+
+    await writeFile(join(skillDirectory, 'scripts', 'run.js'), 'console.log("v2")\n')
+    watcher.emitChange()
+    await waitForCalls(onCatalogChanged, 1)
+
+    observer.dispose()
+  })
+
+  it('forces one shared notification for explicit catalog mutations', async () => {
+    const watcher = fakeWatcher()
+    const onCatalogChanged = vi.fn()
+    const storageRoot = await makeStorage()
+    const observer = new UserSkillCatalogObserver({
+      storageRoot,
+      catalog: new UserSkillRepository(storageRoot),
+      onCatalogChanged,
+      watchDirectory: watcher.watchDirectory,
+      reconcileIntervalMs: 60_000
+    })
+    await observer.start()
+
+    await observer.notifyCatalogChanged()
+
+    expect(onCatalogChanged).toHaveBeenCalledOnce()
+    observer.dispose()
+  })
+})

--- a/src/main/skills/user-skill-catalog-observer.ts
+++ b/src/main/skills/user-skill-catalog-observer.ts
@@ -1,0 +1,142 @@
+import { watch, type FSWatcher } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import type { SkillSource } from '../../shared/settings'
+import { createLogger, diagnosticErrorFields } from '../logger'
+import type { BundledSkill } from './registry'
+
+const log = createLogger('skills')
+const DEFAULT_DEBOUNCE_MS = 150
+const DEFAULT_RECONCILE_INTERVAL_MS = 2_000
+const OBSERVED_SOURCES: readonly Extract<SkillSource, 'imported' | 'personal'>[] = [
+  'imported',
+  'personal'
+]
+
+type UserSkillCatalog = {
+  list(): Promise<readonly BundledSkill[]>
+}
+
+type UserSkillCatalogObserverOptions = {
+  storageRoot: string
+  onCatalogChanged: () => void | Promise<void>
+  catalog: UserSkillCatalog
+  watchDirectory?: typeof watch
+  debounceMs?: number
+  reconcileIntervalMs?: number
+}
+
+const catalogFingerprint = (skills: readonly BundledSkill[]): string =>
+  JSON.stringify(
+    skills
+      .map((skill) => ({
+        id: skill.id,
+        name: skill.name,
+        displayName: skill.displayName,
+        description: skill.description,
+        source: skill.source,
+        updatedAt: skill.updatedAt,
+        compatibility: skill.compatibility,
+        author: skill.author,
+        license: skill.license,
+        thirdParty: skill.thirdParty
+      }))
+      .sort((left, right) => left.id.localeCompare(right.id))
+  )
+
+// Observes only the application-managed writable catalog. The repository remains the authority for
+// recovery and validation, so hidden transaction directories and malformed packages never produce a
+// catalog event. If recursive fs.watch is unavailable or later fails, a bounded periodic
+// reconciliation keeps direct filesystem installs discoverable across supported platforms.
+class UserSkillCatalogObserver {
+  private watcher: FSWatcher | undefined
+  private debounceTimer: ReturnType<typeof setTimeout> | undefined
+  private reconcileTimer: ReturnType<typeof setInterval> | undefined
+  private fingerprint = ''
+  private reconcileTail = Promise.resolve()
+  private disposed = false
+
+  constructor(private readonly options: UserSkillCatalogObserverOptions) {}
+
+  async start(): Promise<void> {
+    const skillsRoot = join(this.options.storageRoot, 'skills')
+    await Promise.all(
+      OBSERVED_SOURCES.map((source) => mkdir(join(skillsRoot, source), { recursive: true }))
+    )
+    this.fingerprint = catalogFingerprint(await this.options.catalog.list())
+
+    try {
+      this.watcher = (this.options.watchDirectory ?? watch)(skillsRoot, { recursive: true }, () =>
+        this.scheduleReconcile()
+      )
+      this.watcher.on('error', (error) => {
+        log.warn('user skill catalog watcher failed; periodic reconciliation remains active', {
+          ...diagnosticErrorFields(error)
+        })
+        this.watcher?.close()
+        this.watcher = undefined
+        this.startPeriodicReconciliation()
+      })
+    } catch (error) {
+      log.warn('user skill catalog watcher unavailable; using periodic reconciliation', {
+        ...diagnosticErrorFields(error)
+      })
+      this.startPeriodicReconciliation()
+    }
+  }
+
+  notifyCatalogChanged(): Promise<void> {
+    return this.enqueueReconcile(true)
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.watcher?.close()
+    this.watcher = undefined
+    if (this.debounceTimer) clearTimeout(this.debounceTimer)
+    if (this.reconcileTimer) clearInterval(this.reconcileTimer)
+    this.debounceTimer = undefined
+    this.reconcileTimer = undefined
+  }
+
+  private scheduleReconcile(): void {
+    if (this.disposed) return
+    if (this.debounceTimer) clearTimeout(this.debounceTimer)
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = undefined
+      void this.enqueueReconcile(false)
+    }, this.options.debounceMs ?? DEFAULT_DEBOUNCE_MS)
+    this.debounceTimer.unref?.()
+  }
+
+  private startPeriodicReconciliation(): void {
+    if (this.disposed || this.reconcileTimer) return
+    this.reconcileTimer = setInterval(
+      () => this.scheduleReconcile(),
+      this.options.reconcileIntervalMs ?? DEFAULT_RECONCILE_INTERVAL_MS
+    )
+    this.reconcileTimer.unref?.()
+  }
+
+  private enqueueReconcile(force: boolean): Promise<void> {
+    const reconcile = this.reconcileTail.then(() => this.reconcile(force))
+    this.reconcileTail = reconcile.catch((error) => {
+      log.warn('user skill catalog reconciliation failed', diagnosticErrorFields(error))
+    })
+    return reconcile
+  }
+
+  private async reconcile(force: boolean): Promise<void> {
+    if (this.disposed) return
+    const fingerprint = catalogFingerprint(await this.options.catalog.list())
+    if (this.disposed) return
+    const changed = fingerprint !== this.fingerprint
+    this.fingerprint = fingerprint
+    if (changed || force) await this.options.onCatalogChanged()
+  }
+}
+
+export { UserSkillCatalogObserver, catalogFingerprint }
+export type { UserSkillCatalogObserverOptions }

--- a/src/main/skills/user-skill-store.ts
+++ b/src/main/skills/user-skill-store.ts
@@ -7,6 +7,7 @@ import type { SkillReference, SkillSource } from '../../shared/settings'
 import { createLogger } from '../logger'
 import type { BundledSkill } from './registry'
 import { readSkillFile } from './skill-files'
+import { skillPackageCompatibility } from './skill-package-compatibility'
 import {
   SOURCE_MANIFEST,
   type SkillPackageTransactionOwner
@@ -136,6 +137,7 @@ export class UserSkillStore {
             source,
             updatedAt,
             sourceDir: skillDirectory,
+            compatibility: await skillPackageCompatibility(skillDirectory),
             author: fields.author,
             license: fields.license,
             thirdParty: fields['third-party'] ?? fields['third_party'] ?? fields.thirdparty

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -470,6 +470,7 @@ describe('preload bridge — public surface inventory', () => {
       'settings.onConnectorApprovalRequest',
       'settings.onConnectorRuntimeChanged',
       'settings.onInstallLog',
+      'settings.onSkillCatalogChanged',
       'settings.onSkillImportApprovalRequest',
       'settings.onSkillImportApprovalSettled',
       'settings.previewAgentHomeSkill',
@@ -607,7 +608,7 @@ describe('preload bridge — runtime renderer contract catalog', () => {
   it('routes every owned method through its cataloged Electron channel', async () => {
     const requestContracts = runtimeContracts.filter(({ kind }) => kind === 'method')
 
-    expect(runtimeContracts).toHaveLength(194)
+    expect(runtimeContracts).toHaveLength(195)
 
     for (const contract of requestContracts) {
       invokeMock.mockClear()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -331,6 +331,8 @@ const api: OpenScienceAPI = {
       electronRendererContracts.subscribe('settings.onConnectorApprovalRequest', listener),
     onConnectorRuntimeChanged: (listener) =>
       electronRendererContracts.subscribe('settings.onConnectorRuntimeChanged', listener),
+    onSkillCatalogChanged: (listener) =>
+      electronRendererContracts.subscribe('settings.onSkillCatalogChanged', listener),
     onSkillImportApprovalRequest: (listener) =>
       electronRendererContracts.subscribe('settings.onSkillImportApprovalRequest', listener),
     onSkillImportApprovalSettled: (listener) =>

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -529,6 +529,7 @@ export interface OpenScienceAPI {
     retryCustomServer(request: AuthenticateCustomServerRequest): Promise<ConnectorsSnapshot>
     onConnectorApprovalRequest(listener: AcpListener<ConnectorApprovalRequest>): RemoveListener
     onConnectorRuntimeChanged(listener: AcpListener<undefined>): RemoveListener
+    onSkillCatalogChanged(listener: AcpListener<undefined>): RemoveListener
     onSkillImportApprovalRequest(
       listener: AcpListener<ConversationSkillImportApprovalRequest>
     ): RemoveListener

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -66,6 +66,7 @@ const installApi = (): void => {
           enabled: true
         }
       ]),
+      onSkillCatalogChanged: vi.fn(() => vi.fn()),
       getSkillDetail: vi.fn().mockResolvedValue({
         id: 'alpha',
         name: 'Alpha',

--- a/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
@@ -100,7 +100,8 @@ beforeEach(() => {
     settings: {
       listConnectors: vi.fn().mockResolvedValue({ connectors: [], customServers: [], ncbi: null }),
       onConnectorRuntimeChanged: vi.fn(() => vi.fn()),
-      listSkills: vi.fn().mockResolvedValue([])
+      listSkills: vi.fn().mockResolvedValue([]),
+      onSkillCatalogChanged: vi.fn(() => vi.fn())
     }
   } as unknown as Window['api']
   useSpecialistStore.setState({

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -589,7 +589,10 @@ describe('WorkspacePage draft preservation', () => {
 
   it('does not downgrade Skill history when the catalog fails to load', async () => {
     const listSkills = vi.fn().mockRejectedValue(new Error('catalog unavailable'))
-    window.api = { ...window.api, settings: { listSkills } } as never
+    window.api = {
+      ...window.api,
+      settings: { listSkills, onSkillCatalogChanged: vi.fn(() => vi.fn()) }
+    } as never
     useSessionStore.setState((state) => ({
       sessions: state.sessions.map((candidate) =>
         candidate.id === 'sess-a'

--- a/src/renderer/src/stores/settings-skills-slice.test.ts
+++ b/src/renderer/src/stores/settings-skills-slice.test.ts
@@ -47,6 +47,7 @@ const preview: SkillImportPreviewContent = {
 
 const createCommands = (): SkillCommands => ({
   listSkills: vi.fn(async () => []),
+  onSkillCatalogChanged: vi.fn(() => () => undefined),
   setSkillEnabled: vi.fn(async () => []),
   createSkill: vi.fn(async () => []),
   updateSkill: vi.fn(async () => []),
@@ -108,6 +109,24 @@ describe('settings Skills slice', () => {
     await store.getState().loadSkills()
 
     expect(store.getState().skills).toEqual([skill('loaded')])
+  })
+
+  it('subscribes once and reconciles a catalog change published by main', async () => {
+    let onCatalogChanged: ((payload: undefined) => void) | undefined
+    vi.mocked(commands.onSkillCatalogChanged).mockImplementation((listener) => {
+      onCatalogChanged = listener
+      return () => undefined
+    })
+    vi.mocked(commands.listSkills)
+      .mockResolvedValueOnce([skill('initial')])
+      .mockResolvedValueOnce([skill('direct')])
+
+    await store.getState().loadSkills()
+    await store.getState().loadSkills()
+    onCatalogChanged?.(undefined)
+    await vi.waitFor(() => expect(store.getState().skills).toEqual([skill('direct')]))
+
+    expect(commands.onSkillCatalogChanged).toHaveBeenCalledOnce()
   })
 
   it('optimistically toggles a Skill before reconciling the authoritative catalog', async () => {

--- a/src/renderer/src/stores/settings-skills-slice.ts
+++ b/src/renderer/src/stores/settings-skills-slice.ts
@@ -53,6 +53,7 @@ type SettingsSkillsCommands = Pick<
   | 'listAgentHomeSkills'
   | 'previewAgentHomeSkill'
   | 'importAgentHomeSkills'
+  | 'onSkillCatalogChanged'
 >
 
 type SettingsSkillsSliceOptions = {
@@ -70,20 +71,37 @@ export const createSettingsSkillsSlice = ({
   setState,
   getCommands
 }: SettingsSkillsSliceOptions): SettingsSkillsActions => {
+  let reconcileGeneration = 0
   const reconcileCatalog = async (command: () => Promise<SkillView[]>): Promise<void> => {
-    setState({ skills: await command() })
+    const generation = ++reconcileGeneration
+    const skills = await command()
+    if (generation === reconcileGeneration) setState({ skills })
   }
 
   const reconcileImport = async <Result extends { skills: SkillView[] }>(
     command: () => Promise<Result>
   ): Promise<Result> => {
+    const generation = ++reconcileGeneration
     const result = await command()
-    setState({ skills: result.skills })
+    if (generation === reconcileGeneration) setState({ skills: result.skills })
     return result
   }
 
+  // The settings store is a renderer-window singleton. Keep one listener for that context's lifetime;
+  // Electron releases the preload subscription when the window is destroyed, while retaining the
+  // remover here prevents repeated loadSkills calls from installing duplicate listeners.
+  let removeCatalogChangedListener: (() => void) | undefined
+  const subscribeToCatalogChanges = (): void => {
+    removeCatalogChangedListener ??= getCommands().onSkillCatalogChanged(() => {
+      void reconcileCatalog(() => getCommands().listSkills()).catch(() => undefined)
+    })
+  }
+
   return {
-    loadSkills: () => reconcileCatalog(() => getCommands().listSkills()),
+    loadSkills: () => {
+      subscribeToCatalogChanges()
+      return reconcileCatalog(() => getCommands().listSkills())
+    },
     setSkillEnabled: async (id, enabled) => {
       setState({
         skills: getState().skills.map((skill) => (skill.id === id ? { ...skill, enabled } : skill))

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -57,6 +57,7 @@ type SettingsApi = {
   deleteProvider: ReturnType<typeof vi.fn>
   markOnboardingComplete: ReturnType<typeof vi.fn>
   listSkills: ReturnType<typeof vi.fn>
+  onSkillCatalogChanged: ReturnType<typeof vi.fn>
   setSkillEnabled: ReturnType<typeof vi.fn>
   createSkill: ReturnType<typeof vi.fn>
   updateSkill: ReturnType<typeof vi.fn>
@@ -227,6 +228,7 @@ beforeEach(() => {
       .fn()
       .mockResolvedValue({ ...snapshot([]), onboardingCompletedAt: 4242 }),
     listSkills: vi.fn().mockResolvedValue([]),
+    onSkillCatalogChanged: vi.fn(() => vi.fn()),
     setSkillEnabled: vi.fn().mockResolvedValue([]),
     createSkill: vi.fn().mockResolvedValue([]),
     updateSkill: vi.fn().mockResolvedValue([]),

--- a/src/renderer/web/renderer-argument-shape-characterization.test.ts
+++ b/src/renderer/web/renderer-argument-shape-characterization.test.ts
@@ -187,7 +187,7 @@ describe('renderer argument-shape characterization', () => {
     const actualPaths = collectFunctionPaths(webApi).sort()
 
     expect(new Set(actualPaths).size).toBe(actualPaths.length)
-    expect(actualPaths).toHaveLength(284)
+    expect(actualPaths).toHaveLength(285)
 
     expect(actualPaths).toEqual(expectedPaths)
   })

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -17,17 +17,17 @@ describe('renderer contract catalog', () => {
     const projection = projectRendererContractMaps(RENDERER_CONTRACT_CATALOG)
 
     expect(RENDERER_CONTRACT_GROUPS).toHaveLength(33)
-    expect(RENDERER_CONTRACT_CATALOG).toHaveLength(351)
+    expect(RENDERER_CONTRACT_CATALOG).toHaveLength(352)
     expect(projection.invoke).toEqual(WEB_INVOKE_CHANNELS)
     expect(projection.event).toEqual(WEB_EVENT_CHANNELS)
     expect(Object.keys(projection.invoke)).toHaveLength(253)
-    expect(Object.keys(projection.event)).toHaveLength(36)
+    expect(Object.keys(projection.event)).toHaveLength(37)
   })
 
   it('separates actual Web installation from the generated compatibility projection', () => {
     expect(
       paths(({ surfaceInstallation }) => surfaceInstallation.localWeb !== 'unavailable')
-    ).toHaveLength(284)
+    ).toHaveLength(285)
 
     expect(
       paths(({ surfaceInstallation }) => surfaceInstallation.localWeb === 'browser-native')

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -330,6 +330,7 @@ export const RENDERER_CONTRACT_GROUPS = Object.freeze([
     ['logoutIsolatedClaude', 'settings:logout-isolated-claude', LOCAL], ['logoutIsolatedCodex', 'settings:logout-isolated-codex', LOCAL],
     ['logoutSharedClaude', 'settings:logout-shared-claude', LOCAL], ['markOnboardingComplete', 'settings:mark-onboarding-complete'],
     ['onConnectorApprovalRequest', 'connectors:approval-request', EVENT], ['onConnectorRuntimeChanged', 'settings:connector-runtime-changed', EVENT], ['onInstallLog', 'settings:install-log', EVENT],
+    ['onSkillCatalogChanged', 'skills:catalog-changed', EVENT],
     ['onSkillImportApprovalRequest', 'skills:conversation-import-request', EVENT],
     ['onSkillImportApprovalSettled', 'skills:conversation-import-settled', EVENT], ['previewAgentHomeSkill', 'settings:preview-agent-home-skill'], ['previewCustomServerTemplateExport', 'settings:preview-custom-server-template-export', ELECTRON],
     ['previewGitHubSkill', 'settings:preview-github-skill'], ['previewSkillZip', 'settings:preview-skill-zip'],

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -243,14 +243,14 @@ describe('renderer surface inventory', () => {
       ...Object.keys(WEB_EVENT_CHANNELS)
     ])
 
-    expect(electronPaths).toHaveLength(351)
+    expect(electronPaths).toHaveLength(352)
 
     expectSameSet(
       electronPaths,
       RENDERER_CONTRACT_CATALOG.map(({ publicPath }) => publicPath)
     )
     expect(Object.keys(WEB_INVOKE_CHANNELS)).toHaveLength(253)
-    expect(Object.keys(WEB_EVENT_CHANNELS)).toHaveLength(36)
+    expect(Object.keys(WEB_EVENT_CHANNELS)).toHaveLength(37)
     expectSameSet(
       electronPaths.filter((path) => !generatedPaths.has(path)),
       GENERATED_SOURCE_OMISSIONS

--- a/src/shared/web-api-map.generated.ts
+++ b/src/shared/web-api-map.generated.ts
@@ -285,6 +285,7 @@ export const WEB_EVENT_CHANNELS = {
   'settings.onConnectorApprovalRequest': 'connectors:approval-request',
   'settings.onConnectorRuntimeChanged': 'settings:connector-runtime-changed',
   'settings.onInstallLog': 'settings:install-log',
+  'settings.onSkillCatalogChanged': 'skills:catalog-changed',
   'settings.onSkillImportApprovalRequest': 'skills:conversation-import-request',
   'settings.onSkillImportApprovalSettled': 'skills:conversation-import-settled',
   'storage.onProgress': 'storage:migrate-progress',


### PR DESCRIPTION
## Problem

Skills written directly into Open Science's managed `skills/personal` or `skills/imported` directories were readable by main only after another catalog read, while the renderer slash-search projection and active ACP runtime remained stale until restart.

## Proposed change

- observe the two Open Science-managed writable Skill directories and reconcile changes through the existing validated user-skill catalog
- publish a typed `skills:catalog-changed` event so every renderer window reloads its `SkillView[]`
- request the existing ACP Skill runtime rotation so future turns use the updated catalog
- hash complete user Skill packages so supporting scripts, references, and assets invalidate framework materialization too
- route explicit create/import/publish mutations through the same notification path

## Scope and non-goals

- observes only `<storageRoot>/skills/personal` and `<storageRoot>/skills/imported`
- does not auto-import or auto-trust `~/.agents/skills`, `~/.codex/skills`, or `~/.claude/skills`
- does not change database schema, settings schema, or durable Skill manifests
- does not add a persisted status/enum value

## Compatibility and persistence

- existing valid personal/imported directories are discovered without migration; malformed, unsafe, hidden staging, and backup directories remain skipped by the existing repository validation
- no historical data rewrite is required
- no new persisted enum or state is introduced
- persistence effects are limited to ensuring the two managed source directories exist and computing in-memory/content-derived compatibility fingerprints

## Acceptance criteria and validation

The checks below ran after the last material code edit:

- direct filesystem add/update detection, invalid-package filtering, package-content invalidation, explicit mutation notification -> `npm run test:module -- user_skills_repository` -> 17 files / 663 tests passed
- renderer event subscription and authoritative catalog reconciliation -> included in the module suite; focused rerun 12 tests passed
- main/preload/shared contracts -> included in the module suite; generated map checked with `npm run check:web-api-map`
- Node process types -> `npm run typecheck:node` -> passed
- renderer/preload types -> `npm run typecheck:web` -> passed
- linted source -> `npm run lint` -> passed with 0 errors; 11 pre-existing warnings outside this diff

Per the requested workflow, the full local `npm test` suite was not run; PR CI remains authoritative for the full portable and platform lanes.

## Review focus

- filesystem events are debounced and reconciled against validated catalog fingerprints; polling is used only when recursive `fs.watch` is unavailable or fails
- explicit and filesystem-driven changes share one renderer/runtime notification path
- `claude-code`, `opencode`, `codex-response`, and `codex-bridge` all consume the existing shared `requestSkillsReload`/future-runtime seam; no framework-specific catalog path was added
- Windows is covered by the module's `windows_sensitive` capability overlay; exact platform behavior remains covered by PR CI

Closes #1178
