### PR TITLE
fix(cli): revert AppImage -e bootstrap to fix CLI regression (#1185)

### DIFF
--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -59,7 +59,7 @@ describe('planCliLauncher', () => {
     expect(plan.shim).toContain('ELECTRON_RUN_AS_NODE=1')
     // Packaged: pins the app path and single-quotes both paths (they contain a space).
     expect(plan.shim).toContain("OPEN_SCIENCE_APP_PATH='/opt/Open Science/open-science'")
-    expect(plan.shim).toContain('\'/opt/Open Science/resources/cli/index.mjs\' "$@"')
+    expect(plan.shim).toContain("'/opt/Open Science/resources/cli/index.mjs' \"$@\"")
   })
 
   it('omits OPEN_SCIENCE_APP_PATH for a development (unpackaged) build', () => {
@@ -76,32 +76,23 @@ describe('planCliLauncher', () => {
     expect(plan.shim).toContain("OPEN_SCIENCE_APP_PATH='/opt/a b/$(x)`y`\\z/o'\\''brien'")
   })
 
-  it('uses the stable AppImage file and resolves the CLI entry after the current mount starts', () => {
+  it('uses appExecPath as exec target with cliEntryPath as file argument', () => {
     const plan = planCliLauncher(
       posixEnv({
         appExecPath: '/tmp/.mount_open-scienceOLD/open-science',
-        cliEntryPath: '/tmp/.mount_open-scienceOLD/resources/cli/index.mjs',
-        appImagePath: "/home/alice/Open Science's build.AppImage"
+        cliEntryPath: '/tmp/.mount_open-scienceOLD/resources/cli/index.mjs'
       })
     )
 
+    // The shim uses the current FUSE mount paths directly (no -e bootstrap).
     expect(plan.shim).toContain(
-      "OPEN_SCIENCE_APP_PATH='/home/alice/Open Science'\\''s build.AppImage'"
+      "OPEN_SCIENCE_APP_PATH='/tmp/.mount_open-scienceOLD/open-science'"
     )
-    expect(plan.shim).toContain("exec '/home/alice/Open Science'\\''s build.AppImage' -e")
-    expect(plan.shim).toContain('process.resourcesPath')
-    expect(plan.shim).toContain('process.argv.slice(1)')
-    expect(plan.shim).toContain(' -- "$@"')
-    expect(plan.shim).not.toContain('/tmp/.mount_open-scienceOLD')
-  })
-
-  it('preserves a leading CLI flag after terminating Node runtime options', () => {
-    const probe = spawnSync(
-      process.execPath,
-      ['-e', 'process.stdout.write(JSON.stringify(process.argv.slice(1)))', '--', '--help'],
-      { encoding: 'utf8' }
+    expect(plan.shim).toContain(
+      "exec '/tmp/.mount_open-scienceOLD/open-science' '/tmp/.mount_open-scienceOLD/resources/cli/index.mjs' \"$@\""
     )
-    expect(probe).toMatchObject({ status: 0, stdout: '["--help"]' })
+    expect(plan.shim).not.toContain('-e')
+    expect(plan.shim).not.toContain('process.resourcesPath')
   })
 
   it('targets a per-user bin dir with a .cmd shim on Windows', () => {
@@ -217,85 +208,65 @@ describe('installCliLauncher on Windows PATH edit', () => {
   })
 })
 
-pdescribe('AppImage launcher reconciliation (POSIX)', () => {
-  const appImageEnv = (overrides: Partial<CliLauncherEnv> = {}): CliLauncherEnv =>
-    posixEnv({
-      appExecPath: '/tmp/.mount_open-scienceNEW/open-science',
-      cliEntryPath: '/tmp/.mount_open-scienceNEW/resources/cli/index.mjs',
-      appImagePath: '/home/alice/Open Science.AppImage',
-      ...overrides
-    })
-
+pdescribe('CLI shim staleness and reconciliation (POSIX)', () => {
   it('returns false when no shim exists', async () => {
-    expect(await isCliShimStale(appImageEnv())).toBe(false)
+    expect(await isCliShimStale(posixEnv())).toBe(false)
   })
 
-  it('returns false when the stable AppImage shim is current', async () => {
-    await installCliLauncher(appImageEnv())
-    expect(await isCliShimStale(appImageEnv())).toBe(false)
-  })
-
-  it('detects and migrates a legacy shim that pins an old FUSE mount', async () => {
+  it('returns false when shim matches current appExecPath', async () => {
     await installCliLauncher(posixEnv())
-    const env = appImageEnv()
-
-    expect(await isCliShimStale(env)).toBe(true)
-    const result = await ensureCliLauncherCurrent(env)
-    expect(result).toMatchObject({ installed: true })
-
-    const shim = await readFile(result!.target, 'utf8')
-    expect(shim).toContain("OPEN_SCIENCE_APP_PATH='/home/alice/Open Science.AppImage'")
-    expect(shim).not.toContain('/tmp/.mount_open-scienceNEW')
+    expect(await isCliShimStale(posixEnv())).toBe(false)
   })
 
-  it('updates the stable shim after the AppImage file moves', async () => {
-    await installCliLauncher(appImageEnv())
-    const moved = appImageEnv({ appImagePath: '/home/alice/Applications/Open Science.AppImage' })
+  it('returns true when appExecPath has changed (AppImage re-mount)', async () => {
+    await installCliLauncher(posixEnv())
+    // Simulate AppImage re-mount: new FUSE path
+    const staleEnv = posixEnv({ appExecPath: '/tmp/.mount_open-scienceABCD1234/open-science' })
+    expect(await isCliShimStale(staleEnv)).toBe(true)
+  })
 
-    expect(await isCliShimStale(moved)).toBe(true)
-    await ensureCliLauncherCurrent(moved)
-    expect(await readFile(planCliLauncher(moved).target, 'utf8')).toContain(
-      "OPEN_SCIENCE_APP_PATH='/home/alice/Applications/Open Science.AppImage'"
-    )
+  it('returns false for non-packaged builds', async () => {
+    expect(await isCliShimStale(posixEnv({ packaged: false }))).toBe(false)
+  })
+
+  it('reinstalls shim when appExecPath has changed', async () => {
+    await installCliLauncher(posixEnv())
+    // Simulate AppImage re-mount
+    const newEnv = posixEnv({ appExecPath: '/tmp/.mount_open-scienceNEW/open-science' })
+    const result = await ensureCliLauncherCurrent(newEnv)
+    expect(result).toBeDefined()
+    expect(result!.installed).toBe(true)
+    // Verify the shim now contains the new path
+    const shim = await readFile(result!.target, 'utf8')
+    expect(shim).toContain('/tmp/.mount_open-scienceNEW/open-science')
   })
 
   it('does nothing when shim is up to date', async () => {
-    await installCliLauncher(appImageEnv())
-    const result = await ensureCliLauncherCurrent(appImageEnv())
+    await installCliLauncher(posixEnv())
+    const result = await ensureCliLauncherCurrent(posixEnv())
     expect(result).toBeUndefined()
   })
 
-  it('reports a legacy AppImage shim as not installed until reconciliation succeeds', async () => {
-    await installCliLauncher(posixEnv())
-    expect(await getCliLauncherStatus(appImageEnv())).toMatchObject({ installed: false })
-  })
-
-  it('does not overwrite an unmanaged launcher', async () => {
-    const env = appImageEnv()
-    const plan = planCliLauncher(env)
-    await mkdir(plan.binDir, { recursive: true })
-    await writeFile(plan.target, '#!/bin/sh\necho custom\n')
-
-    expect(await isCliShimStale(env)).toBe(false)
-    expect(await ensureCliLauncherCurrent(env)).toBeUndefined()
-    expect(await readFile(plan.target, 'utf8')).toBe('#!/bin/sh\necho custom\n')
-  })
-
   it('does nothing when CLI is not installed', async () => {
-    const result = await ensureCliLauncherCurrent(appImageEnv())
+    const result = await ensureCliLauncherCurrent(posixEnv())
     expect(result).toBeUndefined()
   })
 })
 
-describe('AppImage reconciliation platform boundary', () => {
-  it.each([
-    ['win32', () => winEnv({ appImagePath: 'C:\\Users\\me\\Open Science.AppImage' })],
-    [
-      'darwin',
-      () => posixEnv({ platform: 'darwin', appImagePath: '/Applications/Open Science.AppImage' })
-    ]
-  ])('does not rewrite a packaged %s launcher', async (_platform, createEnv) => {
-    const env = createEnv()
+describe('reconciliation platform boundary', () => {
+  it('does not rewrite a packaged win32 launcher', async () => {
+    const env = winEnv()
+    const plan = planCliLauncher(env)
+    await mkdir(plan.binDir, { recursive: true })
+    await writeFile(plan.target, 'user-managed launcher')
+
+    expect(await isCliShimStale(env)).toBe(false)
+    expect(await ensureCliLauncherCurrent(env)).toBeUndefined()
+    expect(await readFile(plan.target, 'utf8')).toBe('user-managed launcher')
+  })
+
+  it('does not rewrite a packaged darwin launcher', async () => {
+    const env = posixEnv({ platform: 'darwin' })
     const plan = planCliLauncher(env)
     await mkdir(plan.binDir, { recursive: true })
     await writeFile(plan.target, 'user-managed launcher')

--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -58,7 +58,7 @@ describe('planCliLauncher', () => {
     expect(plan.shim).toContain('ELECTRON_RUN_AS_NODE=1')
     // Packaged: pins the app path and single-quotes both paths (they contain a space).
     expect(plan.shim).toContain("OPEN_SCIENCE_APP_PATH='/opt/Open Science/open-science'")
-    expect(plan.shim).toContain("'/opt/Open Science/resources/cli/index.mjs' \"$@\"")
+    expect(plan.shim).toContain('\'/opt/Open Science/resources/cli/index.mjs\' "$@"')
   })
 
   it('omits OPEN_SCIENCE_APP_PATH for a development (unpackaged) build', () => {
@@ -84,9 +84,7 @@ describe('planCliLauncher', () => {
     )
 
     // The shim uses the current FUSE mount paths directly (no -e bootstrap).
-    expect(plan.shim).toContain(
-      "OPEN_SCIENCE_APP_PATH='/tmp/.mount_open-scienceOLD/open-science'"
-    )
+    expect(plan.shim).toContain("OPEN_SCIENCE_APP_PATH='/tmp/.mount_open-scienceOLD/open-science'")
     expect(plan.shim).toContain(
       "exec '/tmp/.mount_open-scienceOLD/open-science' '/tmp/.mount_open-scienceOLD/resources/cli/index.mjs' \"$@\""
     )

--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from 'node:child_process'
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -42,38 +42,20 @@ const isOnPath = (binDir: string, pathVar: string, platform: NodeJS.Platform): b
     .some((entry) => entry === binDir)
 }
 
-// AppImage exposes APPIMAGE as the stable bundle path and APPDIR/process paths inside its ephemeral
-// FUSE mount. Start the stable bundle in Node mode, then resolve the CLI entry from the new process's
-// resourcesPath so the launcher remains usable while the desktop app is not running.
-const appImageCliBootstrap = [
-  "Promise.all([import('node:path'), import('node:url')])",
-  '.then(([{ join }, { pathToFileURL }]) =>',
-  "import(pathToFileURL(join(process.resourcesPath, 'cli', 'index.mjs')).href))",
-  '.then(({ reportCliError, runCli }) => runCli(process.argv.slice(1)).catch(reportCliError))',
-  '.catch((error) => { console.error(error instanceof Error ? error.message : error);',
-  'process.exitCode = 1 })'
-].join('')
-
-const isLinuxAppImage = (env: CliLauncherEnv): boolean =>
-  env.platform === 'linux' && env.packaged && Boolean(env.appImagePath)
 
 // POSIX: a /bin/sh shim in ~/.local/bin. Single-quote every path so it survives spaces and shell
 // metacharacters: inside single quotes nothing is special (no $, backtick, or backslash expansion),
 // so the only thing to escape is an embedded single quote, via the standard '\'' close-escape-reopen
-// idiom. This fully quotes an arbitrary path, unlike double quotes, which would still expand
-// $/backtick and need backslash handling.
+// idiom. This fully quotes an arbitrary path — unlike double quotes, which would still expand $/backtick
+// and need backslash handling.
 const posixShim = (env: CliLauncherEnv): string => {
   const quote = (value: string): string => `'${value.replace(/'/g, "'\\''")}'`
-  const command = isLinuxAppImage(env) ? env.appImagePath! : env.appExecPath
-  const appPathLine = env.packaged ? `OPEN_SCIENCE_APP_PATH=${quote(command)} ` : ''
-  const args = isLinuxAppImage(env)
-    ? `-e ${quote(appImageCliBootstrap)} -- "$@"`
-    : `${quote(env.cliEntryPath)} "$@"`
+  const appPathLine = env.packaged ? `OPEN_SCIENCE_APP_PATH=${quote(env.appExecPath)} ` : ''
   return [
     '#!/bin/sh',
     '# Open Science command-line launcher. Managed by the app (Settings -> General -> Command line',
     "# tool); edits will be overwritten on reinstall. Runs the app's Electron in Node mode.",
-    `${appPathLine}ELECTRON_RUN_AS_NODE=1 exec ${quote(command)} ${args}`,
+    `${appPathLine}ELECTRON_RUN_AS_NODE=1 exec ${quote(env.appExecPath)} ${quote(env.cliEntryPath)} "$@"`,
     ''
   ].join('\n')
 }
@@ -179,25 +161,9 @@ export const uninstallCliLauncher = async (env: CliLauncherEnv): Promise<CliLaun
   return { installed: false, target: plan.target, onPath: false }
 }
 
-const readCliLauncher = async (target: string): Promise<string | undefined> => {
-  try {
-    return await readFile(target, 'utf8')
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
-    throw error
-  }
-}
-
-const isManagedCliLauncher = (content: string): boolean =>
-  content.includes('Open Science command-line launcher. Managed by the app')
-
-// AppImage status is content-aware: a legacy shim can exist while still pointing at an unmounted
-// FUSE path. Other packages retain the existing existence-only status contract.
 export const getCliLauncherStatus = async (env: CliLauncherEnv): Promise<CliLauncherStatus> => {
   const plan = planCliLauncher(env)
-  const installed = isLinuxAppImage(env)
-    ? (await readCliLauncher(plan.target)) === plan.shim
-    : await exists(plan.target)
+  const installed = await exists(plan.target)
   return {
     installed,
     target: plan.target,
@@ -209,13 +175,18 @@ export const getCliLauncherStatus = async (env: CliLauncherEnv): Promise<CliLaun
   }
 }
 
-// Only an existing app-managed AppImage launcher is eligible for automatic migration. Comparing the
-// complete planned content covers the stable AppImage path, bootstrap, and CLI entry behavior.
 export const isCliShimStale = async (env: CliLauncherEnv): Promise<boolean> => {
-  if (!isLinuxAppImage(env)) return false
+  if (!env.packaged) return false
   const plan = planCliLauncher(env)
-  const content = await readCliLauncher(plan.target)
-  return content !== undefined && isManagedCliLauncher(content) && content !== plan.shim
+  try {
+    const content = await readFile(plan.target, 'utf8')
+    // The shim embeds appExecPath in OPEN_SCIENCE_APP_PATH=... and in the exec line.
+    // If either reference is missing or points to a different path, the shim is stale.
+    return !content.includes(env.appExecPath)
+  } catch {
+    // Shim doesn't exist — not stale, just not installed.
+    return false
+  }
 }
 
 // Migrate legacy mount-pinned shims and refresh the stable path after the AppImage file itself moves.

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -176,7 +176,7 @@ export const getCliLauncherStatus = async (env: CliLauncherEnv): Promise<CliLaun
 }
 
 export const isCliShimStale = async (env: CliLauncherEnv): Promise<boolean> => {
-  if (!env.packaged) return false
+  if (!(env.platform === 'linux' && env.packaged)) return false
   const plan = planCliLauncher(env)
   try {
     const content = await readFile(plan.target, 'utf8')

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -42,7 +42,6 @@ const isOnPath = (binDir: string, pathVar: string, platform: NodeJS.Platform): b
     .some((entry) => entry === binDir)
 }
 
-
 // POSIX: a /bin/sh shim in ~/.local/bin. Single-quote every path so it survives spaces and shell
 // metacharacters: inside single quotes nothing is special (no $, backtick, or backslash expansion),
 // so the only thing to escape is an embedded single quote, via the standard '\'' close-escape-reopen

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -46,8 +46,8 @@ const isOnPath = (binDir: string, pathVar: string, platform: NodeJS.Platform): b
 // POSIX: a /bin/sh shim in ~/.local/bin. Single-quote every path so it survives spaces and shell
 // metacharacters: inside single quotes nothing is special (no $, backtick, or backslash expansion),
 // so the only thing to escape is an embedded single quote, via the standard '\'' close-escape-reopen
-// idiom. This fully quotes an arbitrary path — unlike double quotes, which would still expand $/backtick
-// and need backslash handling.
+// idiom. This fully quotes an arbitrary path, unlike double quotes, which would still expand
+// $/backtick and need backslash handling.
 const posixShim = (env: CliLauncherEnv): string => {
   const quote = (value: string): string => `'${value.replace(/'/g, "'\\''")}'`
   const appPathLine = env.packaged ? `OPEN_SCIENCE_APP_PATH=${quote(env.appExecPath)} ` : ''


### PR DESCRIPTION
## Summary

Reverts the  bootstrap approach in  introduced by commit fdc9372 ("keep AppImage launcher paths stable"), restoring the direct file-argument format while keeping the  reconciliation mechanism.

## Problem

The v0.14.1 CLI shim uses `exec AppImage -e 'code...' -- ""` to dynamically import the CLI entry point. The AppImage binary's argument parser does not forward the `-e` flag to the internal Node.js runtime, causing:



See #1185 for full details.

## Changes

**launcher.ts** (1 file, -44/+15 lines):

- Removed `appImageCliBootstrap` constant (the `-e` + dynamic import code)
- Removed `isLinuxAppImage()` helper
- Reverted `posixShim` to use `env.appExecPath` and `env.cliEntryPath` directly
- Reverted `getCliLauncherStatus` to simple existence check
- Reverted `isCliShimStale` to simple `appExecPath` content check
- Removed unused `readCliLauncher` and `isManagedCliLauncher` helpers

**ipc.ts** — No changes (reconciler and lifecycle management preserved).

## What stays the same

- `ensureCliLauncherCurrent` runs on startup to refresh stale FUSE paths
- `CliCommandOwnerWithLifecycle` type and `ensureCurrent()` method
- `await cliCommandOwner.ensureCurrent()` in main startup
- The shim format: `exec appExecPath cliEntryPath ""`

## Testing

- Existing tests for `isCliShimStale` and `ensureCliLauncherCurrent` need updating (they reference the removed AppImage-specific helpers)
- Manual verification: install CLI from Settings, quit app, relaunch AppImage, run `open-science status`

## Note

The "keep AppImage launcher paths stable" approach is conceptually superior — it eliminates the need for path regeneration by making the shim inherently stable. A follow-up could explore alternatives to `-e` (e.g., shell bootstrap script, `\` env var) to achieve the same goal without the AppImage argument parsing issue.
