### PR TITLE
fix(storage): contain decoded $DATA paths

### DIFF
--- a/src/main/notebook/run-document-data-paths.test.ts
+++ b/src/main/notebook/run-document-data-paths.test.ts
@@ -170,4 +170,12 @@ describe('run document data-path codec', () => {
     const doc = { ...buildDocument(), workspaceCwd: '/Users/x/proj' }
     expect(encodeRunDocumentDataPaths(doc, ROOT).workspaceCwd).toBe('/Users/x/proj')
   })
+
+  it('rejects an escaping $DATA path during Notebook hydration', () => {
+    const doc = { ...buildDocument(), workspaceCwd: '$DATA/../../outside' }
+
+    expect(() => decodeRunDocumentDataPaths(doc, ROOT)).toThrow(
+      /portable relative path within the data root/
+    )
+  })
 })

--- a/src/main/projects/preview-repository.test.ts
+++ b/src/main/projects/preview-repository.test.ts
@@ -124,4 +124,28 @@ describe('preview state repository (integration)', () => {
     const loaded = await repository.get('project-a')
     expect(loaded?.items[0].path).toBe(absolutePath)
   })
+
+  it('rejects an escaping $DATA path from persisted Preview state', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-preview-'))
+
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+
+    await migrateApplicationDatabase(client)
+
+    const state = createState()
+    await client.projectPreviewState.create({
+      data: {
+        projectId: 'project-a',
+        panelState: state.panelState,
+        activeItemId: state.activeItemId ?? null,
+        items: JSON.stringify(state.items.map((item) => ({ ...item, path: '$DATA/../../outside' })))
+      }
+    })
+
+    const repository = new PreviewStateRepository(() => Promise.resolve(client))
+    await expect(repository.get('project-a')).rejects.toThrow(
+      /portable relative path within the data root/
+    )
+  })
 })

--- a/src/main/session-persistence/data-path-roundtrip.test.ts
+++ b/src/main/session-persistence/data-path-roundtrip.test.ts
@@ -80,4 +80,10 @@ describe('session data-path round-trip', () => {
       decoded.messages[0].uploads?.[0]
     )
   })
+
+  it('rejects an escaping $DATA path during Session hydration', () => {
+    expect(() => decodeSessionDataPaths({ ...session, cwd: '$DATA/../../outside' }, ROOT)).toThrow(
+      /portable relative path within the data root/
+    )
+  })
 })

--- a/src/main/storage/data-path.test.ts
+++ b/src/main/storage/data-path.test.ts
@@ -14,6 +14,14 @@ describe('data-path sentinel codec', () => {
   it('leaves external absolute paths unchanged', () => {
     expect(encodeDataPath('/Users/x/external/file.csv', ROOT)).toBe('/Users/x/external/file.csv')
   })
+  it
+    .runIf(process.platform !== 'win32')
+    .each([`${ROOT}/uploads/folder\\name.txt`, `${ROOT}/uploads/c:notes.txt`])(
+    'leaves an in-root path with a non-portable filename unchanged: %s',
+    (absolute) => {
+      expect(encodeDataPath(absolute, ROOT)).toBe(absolute)
+    }
+  )
   it('is idempotent on an already-encoded sentinel, regardless of the given root', () => {
     expect(encodeDataPath('$DATA/artifacts/x', '/data/os')).toBe('$DATA/artifacts/x')
   })

--- a/src/main/storage/data-path.test.ts
+++ b/src/main/storage/data-path.test.ts
@@ -17,9 +17,33 @@ describe('data-path sentinel codec', () => {
   it('is idempotent on an already-encoded sentinel, regardless of the given root', () => {
     expect(encodeDataPath('$DATA/artifacts/x', '/data/os')).toBe('$DATA/artifacts/x')
   })
+  it('normalizes a portable encoded sentinel', () => {
+    expect(encodeDataPath('$DATA/uploads/./nested//file.txt', ROOT)).toBe(
+      '$DATA/uploads/nested/file.txt'
+    )
+    expect(decodeDataPath('$DATA/uploads/./nested//file.txt', ROOT)).toBe(
+      join(ROOT, 'uploads/nested/file.txt')
+    )
+  })
   it('decodes a $DATA sentinel against the current data root', () => {
     // decode joins host-natively (backslashes on Windows), so derive the expected the same way.
     expect(decodeDataPath('$DATA/uploads/f.txt', ROOT)).toBe(join(ROOT, 'uploads/f.txt'))
+  })
+  it.each([
+    '$DATA/../outside.txt',
+    '$DATA/safe/../../outside.txt',
+    '$DATA/C:/Windows/system.ini',
+    '$DATA/c:relative.txt',
+    '$DATA//server/share/file.txt',
+    '$DATA/\\\\server\\share\\file.txt',
+    '$DATA/folder\\file.txt'
+  ])('rejects a non-portable or escaping sentinel: %s', (stored) => {
+    expect(() => decodeDataPath(stored, ROOT)).toThrow(
+      /portable relative path within the data root/
+    )
+    expect(() => encodeDataPath(stored, ROOT)).toThrow(
+      /portable relative path within the data root/
+    )
   })
   it('round-trips against a different root (relocation)', () => {
     const enc = encodeDataPath(`${ROOT}/runtime/env`, ROOT)

--- a/src/main/storage/data-path.ts
+++ b/src/main/storage/data-path.ts
@@ -1,13 +1,51 @@
-import { isAbsolute, join, relative, sep } from 'node:path'
+import { isAbsolute, join, posix, relative, resolve, sep, win32 } from 'node:path'
 
 import { resolveDataRoot } from '../storage-root'
 
 export const DATA_ROOT_SENTINEL = '$DATA'
 
+const DATA_ROOT_PREFIX = `${DATA_ROOT_SENTINEL}/`
+const WINDOWS_DRIVE_PREFIX = /(?:^|\/)[a-z]:/i
+
+const invalidDataPathError = (): Error =>
+  new Error('$DATA path must be a portable relative path within the data root.')
+
 // True when `candidate` is inside `root` (not the root itself, not an escaping sibling).
 const isInside = (root: string, candidate: string): boolean => {
+  const rel = relative(resolve(root), resolve(candidate))
+  return !!rel && rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel)
+}
+
+const isInsideOrEqual = (root: string, candidate: string): boolean => {
   const rel = relative(root, candidate)
-  return !!rel && !rel.startsWith('..') && !isAbsolute(rel)
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel))
+}
+
+const normalizeDataPathSuffix = (suffix: string): string => {
+  if (suffix.includes('\\') || posix.isAbsolute(suffix) || win32.isAbsolute(suffix)) {
+    throw invalidDataPathError()
+  }
+
+  if (WINDOWS_DRIVE_PREFIX.test(suffix) || suffix.split('/').includes('..')) {
+    throw invalidDataPathError()
+  }
+
+  const normalized = posix.normalize(suffix)
+  return normalized === '.' ? '' : normalized
+}
+
+const resolveEncodedDataPath = (
+  stored: string,
+  dataRoot: string
+): { encoded: string; decoded: string } => {
+  const suffix = normalizeDataPathSuffix(stored.slice(DATA_ROOT_PREFIX.length))
+  const root = resolve(dataRoot)
+  const decoded = join(dataRoot, suffix)
+  const resolvedDecoded = resolve(decoded)
+
+  if (!isInsideOrEqual(root, resolvedDecoded)) throw invalidDataPathError()
+
+  return { encoded: `${DATA_ROOT_PREFIX}${suffix}`, decoded }
 }
 
 // Replaces a data-root prefix with the portable "$DATA" sentinel; leaves external paths untouched.
@@ -19,7 +57,9 @@ export const encodeDataPath = (
   // Already-encoded sentinel: short-circuit before the relative() check below, which
   // otherwise resolves a non-absolute `abs` against process.cwd() and could spuriously
   // match depending on the working directory.
-  if (abs.startsWith(`${DATA_ROOT_SENTINEL}/`)) return abs
+  if (abs.startsWith(DATA_ROOT_PREFIX)) {
+    return resolveEncodedDataPath(abs, dataRoot).encoded
+  }
   if (!isInside(dataRoot, abs)) return abs
   const rel = relative(dataRoot, abs).split(sep).join('/')
   return `${DATA_ROOT_SENTINEL}/${rel}`
@@ -31,7 +71,6 @@ export const decodeDataPath = (
   dataRoot: string = resolveDataRoot()
 ): string | undefined => {
   if (!stored) return stored
-  const prefix = `${DATA_ROOT_SENTINEL}/`
-  if (!stored.startsWith(prefix)) return stored
-  return join(dataRoot, stored.slice(prefix.length))
+  if (!stored.startsWith(DATA_ROOT_PREFIX)) return stored
+  return resolveEncodedDataPath(stored, dataRoot).decoded
 }

--- a/src/main/storage/data-path.ts
+++ b/src/main/storage/data-path.ts
@@ -21,17 +21,23 @@ const isInsideOrEqual = (root: string, candidate: string): boolean => {
   return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel))
 }
 
-const normalizeDataPathSuffix = (suffix: string): string => {
+const tryNormalizeDataPathSuffix = (suffix: string): string | undefined => {
   if (suffix.includes('\\') || posix.isAbsolute(suffix) || win32.isAbsolute(suffix)) {
-    throw invalidDataPathError()
+    return undefined
   }
 
   if (WINDOWS_DRIVE_PREFIX.test(suffix) || suffix.split('/').includes('..')) {
-    throw invalidDataPathError()
+    return undefined
   }
 
   const normalized = posix.normalize(suffix)
   return normalized === '.' ? '' : normalized
+}
+
+const normalizeDataPathSuffix = (suffix: string): string => {
+  const normalized = tryNormalizeDataPathSuffix(suffix)
+  if (normalized === undefined) throw invalidDataPathError()
+  return normalized
 }
 
 const resolveEncodedDataPath = (
@@ -62,7 +68,8 @@ export const encodeDataPath = (
   }
   if (!isInside(dataRoot, abs)) return abs
   const rel = relative(dataRoot, abs).split(sep).join('/')
-  return `${DATA_ROOT_SENTINEL}/${rel}`
+  const normalized = tryNormalizeDataPathSuffix(rel)
+  return normalized === undefined ? abs : `${DATA_ROOT_PREFIX}${normalized}`
 }
 
 // Resolves a "$DATA/..." sentinel against the current data root; leaves other values untouched.


### PR DESCRIPTION
## Problem

Persisted `$DATA/...` paths were treated as trusted. Decoding passed the suffix directly to `join(dataRoot, suffix)`, so a value such as `$DATA/../../etc` could materialize outside the configured data root.

The shared codec is used while hydrating Session paths, project Preview items, and Notebook run documents. A tampered or corrupt persisted value could therefore point those consumers at files outside app-managed storage.

## Proposed change

- validate already-encoded `$DATA` values in both encode and decode paths
- normalize portable forward-slash suffixes
- reject parent traversal, drive-prefixed paths, UNC/absolute paths, and backslashes
- resolve the decoded candidate and enforce containment within the resolved data root
- keep Session, Preview, and Notebook on the same shared codec
- add shared invariant tests plus consumer contract coverage for all three persistence surfaces

## Scope and non-goals

- No new persisted fields, database schema, migration, data model, enum value, or UI interaction.
- Valid historical app-generated `$DATA/...` values remain compatible.
- Invalid historical values containing `..`, drive prefixes, UNC/absolute forms, or backslashes are intentionally rejected rather than repaired.
- Existing consumer behavior handles rejection: Session files enter the established corrupt/quarantine path; Preview and Notebook loads fail instead of returning an out-of-root path.

## Acceptance criteria and validation

Checks listed below ran after the final material edit.

- shared codec and Session/Preview/Notebook consumption -> `vitest run src/main/storage/data-path.test.ts src/main/session-persistence/data-path-roundtrip.test.ts src/main/projects/preview-repository.test.ts src/main/notebook/run-document-data-paths.test.ts --maxWorkers=1 --testTimeout=30000 --hookTimeout=30000` -> passed, 4 files / 28 tests
- main-process type safety -> `tsc --noEmit -p tsconfig.node.json --composite false` -> passed
- linted source and tests -> `eslint --cache .` -> passed with 0 errors; 11 existing warnings outside this diff
- patch hygiene -> `git diff --check` -> passed

The full portable suite was not run locally. The path-sensitive PR Gate lanes and exact Node 22 environment remain authoritative for Windows/macOS/Linux coverage; the local checks ran on Node 24.

## Review focus

- cross-platform rejection of drive, UNC, backslash, and parent-segment forms
- containment after path resolution
- intentional strict rejection of invalid persisted historical values
- preservation of valid relocation and external-path pass-through behavior
