### PR TITLE
fix(file-browser): prevent cross-host request races

### DIFF
--- a/src/renderer/src/pages/settings/FileBrowserModal.render.test.tsx
+++ b/src/renderer/src/pages/settings/FileBrowserModal.render.test.tsx
@@ -14,6 +14,20 @@ import { useProjectStore } from '@/stores/project-store'
 let container: HTMLDivElement
 let root: Root
 
+const deferred = <T,>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: unknown) => void
+} => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
 const connectedHost = (overrides: Partial<ComputeHost> = {}): ComputeHost => ({
   id: 'host-1',
   providerId: 'ssh:biowulf',
@@ -263,6 +277,222 @@ describe('FileBrowserModal', () => {
     })
     // Should show success message
     expect(document.body.textContent).toContain('Saved to Downloads')
+  })
+
+  it('keeps the active host listing when the previous host responds last', async () => {
+    const hostAListing = deferred<DirListing>()
+    const hostBListing = deferred<DirListing>()
+    const download = vi.fn().mockResolvedValue({
+      path: '/Users/user/Downloads/from-host-b.txt',
+      name: 'from-host-b.txt',
+      size: 2,
+      mimeType: 'text/plain'
+    } as LocalFile)
+    const listDir = vi.fn((providerId: string) =>
+      providerId === 'ssh:host-a' ? hostAListing.promise : hostBListing.promise
+    )
+    useComputeStore.setState({
+      ...createInitialComputeState(),
+      isLoaded: true,
+      loadHosts: vi.fn(),
+      hosts: [
+        connectedHost({
+          id: 'host-a',
+          providerId: 'ssh:host-a',
+          displayName: 'host-a',
+          sshAlias: 'host-a',
+          scratchRoot: '/scratch/a'
+        }),
+        connectedHost({
+          id: 'host-b',
+          providerId: 'ssh:host-b',
+          displayName: 'host-b',
+          sshAlias: 'host-b',
+          scratchRoot: '/scratch/b'
+        })
+      ]
+    })
+    setComputeApi({
+      listDir,
+      bookmarksGet: vi.fn().mockResolvedValue([]),
+      bookmarksSet: vi.fn().mockResolvedValue(undefined),
+      download,
+      revealInFolder: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await act(async () => {
+      root.render(
+        <FileBrowserModal open={true} onClose={vi.fn()} initialProviderId={'ssh:host-a'} />
+      )
+    })
+
+    const hostBButton = Array.from(document.querySelectorAll('button')).find(
+      (element) => element.textContent?.trim() === 'host-b'
+    ) as HTMLButtonElement | undefined
+    await act(async () => {
+      hostBButton?.click()
+    })
+
+    await act(async () => {
+      hostBListing.resolve({
+        entries: [{ name: 'from-host-b.txt', isDirectory: false, size: 2, mtimeMs: 1704067200000 }],
+        truncated: false,
+        roots: { home: '/home/b', scratch: '/scratch/b' },
+        resolvedPath: '/scratch/b'
+      })
+      await hostBListing.promise
+    })
+    expect(document.body.textContent).toContain('from-host-b.txt')
+
+    await act(async () => {
+      hostAListing.resolve({
+        entries: [{ name: 'from-host-a.txt', isDirectory: false, size: 1, mtimeMs: 1704067200000 }],
+        truncated: false,
+        roots: { home: '/home/a', scratch: '/scratch/a' },
+        resolvedPath: '/scratch/a'
+      })
+      await hostAListing.promise
+    })
+
+    expect(document.body.textContent).toContain('from-host-b.txt')
+    expect(document.body.textContent).not.toContain('from-host-a.txt')
+
+    const fileButton = Array.from(document.querySelectorAll('[role=option]')).find((element) =>
+      element.textContent?.includes('from-host-b.txt')
+    ) as HTMLButtonElement | undefined
+    await act(async () => {
+      fileButton?.click()
+    })
+    const downloadButton = Array.from(document.querySelectorAll('button')).find((element) =>
+      element.getAttribute('aria-label')?.includes('OS Downloads')
+    ) as HTMLButtonElement | undefined
+    await act(async () => {
+      downloadButton?.click()
+      await Promise.resolve()
+    })
+
+    expect(download).toHaveBeenCalledWith('ssh:host-b', '/scratch/b/from-host-b.txt', {
+      kind: 'os-downloads'
+    })
+  })
+
+  it('keeps the active host bookmarks when the previous host responds last', async () => {
+    const hostABookmarks = deferred<string[]>()
+    const hostBBookmarks = deferred<string[]>()
+    const bookmarksGet = vi.fn((providerId: string) =>
+      providerId === 'ssh:host-a' ? hostABookmarks.promise : hostBBookmarks.promise
+    )
+    useComputeStore.setState({
+      ...createInitialComputeState(),
+      isLoaded: true,
+      loadHosts: vi.fn(),
+      hosts: [
+        connectedHost({
+          id: 'host-a',
+          providerId: 'ssh:host-a',
+          displayName: 'host-a',
+          sshAlias: 'host-a',
+          scratchRoot: '/scratch/a'
+        }),
+        connectedHost({
+          id: 'host-b',
+          providerId: 'ssh:host-b',
+          displayName: 'host-b',
+          sshAlias: 'host-b',
+          scratchRoot: '/scratch/b'
+        })
+      ]
+    })
+    setComputeApi({
+      listDir: vi.fn((providerId: string) =>
+        Promise.resolve({
+          ...mockListing,
+          resolvedPath: providerId === 'ssh:host-a' ? '/scratch/a' : '/scratch/b'
+        })
+      ),
+      bookmarksGet,
+      bookmarksSet: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await act(async () => {
+      root.render(
+        <FileBrowserModal open={true} onClose={vi.fn()} initialProviderId={'ssh:host-a'} />
+      )
+      await Promise.resolve()
+    })
+    const hostBButton = Array.from(document.querySelectorAll('button')).find(
+      (element) => element.textContent?.trim() === 'host-b'
+    ) as HTMLButtonElement | undefined
+    await act(async () => {
+      hostBButton?.click()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      hostBBookmarks.resolve(['/scratch/b/pinned'])
+      await hostBBookmarks.promise
+    })
+    await act(async () => {
+      hostABookmarks.resolve(['/scratch/a/pinned'])
+      await hostABookmarks.promise
+    })
+
+    const goToButton = document.querySelector('[aria-haspopup=listbox]') as
+      HTMLButtonElement | undefined
+    await act(async () => {
+      goToButton?.click()
+    })
+
+    expect(document.body.textContent).toContain('/scratch/b/pinned')
+    expect(document.body.textContent).not.toContain('/scratch/a/pinned')
+  })
+
+  it('shows an inline error when bookmarks fail to load', async () => {
+    setComputeApi({
+      listDir: vi.fn().mockResolvedValue(mockListing),
+      bookmarksGet: vi.fn().mockRejectedValue(new Error('Bookmark service unavailable')),
+      bookmarksSet: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await act(async () => {
+      root.render(
+        <FileBrowserModal open={true} onClose={vi.fn()} initialProviderId={'ssh:biowulf'} />
+      )
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain("Couldn't load bookmarks.")
+    expect(document.body.textContent).toContain('Bookmark service unavailable')
+  })
+
+  it('restores bookmarks and shows an inline error when saving fails', async () => {
+    setComputeApi({
+      listDir: vi.fn().mockResolvedValue(mockListing),
+      bookmarksGet: vi.fn().mockResolvedValue([]),
+      bookmarksSet: vi.fn().mockRejectedValue(new Error('Bookmark write failed'))
+    })
+
+    await act(async () => {
+      root.render(
+        <FileBrowserModal open={true} onClose={vi.fn()} initialProviderId={'ssh:biowulf'} />
+      )
+      await Promise.resolve()
+    })
+    const goToButton = document.querySelector('[aria-haspopup=listbox]') as
+      HTMLButtonElement | undefined
+    await act(async () => {
+      goToButton?.click()
+    })
+    const pinButton = Array.from(document.querySelectorAll('button')).find((element) =>
+      element.textContent?.includes('Pin current folder')
+    ) as HTMLButtonElement | undefined
+    await act(async () => {
+      pinButton?.click()
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain("Couldn't update bookmarks.")
+    expect(document.body.textContent).toContain('Bookmark write failed')
   })
 
   it('shows Add to project button when a project is active', async () => {

--- a/src/renderer/src/pages/settings/FileBrowserModal.render.test.tsx
+++ b/src/renderer/src/pages/settings/FileBrowserModal.render.test.tsx
@@ -495,6 +495,37 @@ describe('FileBrowserModal', () => {
     expect(document.body.textContent).toContain('Bookmark write failed')
   })
 
+  it('removes a bookmark and persists the updated list', async () => {
+    const bookmarksSet = vi.fn().mockResolvedValue(undefined)
+    setComputeApi({
+      listDir: vi.fn().mockResolvedValue(mockListing),
+      bookmarksGet: vi.fn().mockResolvedValue(['/scratch/user/pinned']),
+      bookmarksSet
+    })
+
+    await act(async () => {
+      root.render(
+        <FileBrowserModal open={true} onClose={vi.fn()} initialProviderId={'ssh:biowulf'} />
+      )
+      await Promise.resolve()
+    })
+    const goToButton = document.querySelector('[aria-haspopup=listbox]') as
+      HTMLButtonElement | undefined
+    await act(async () => {
+      goToButton?.click()
+    })
+    const removeButton = Array.from(document.querySelectorAll('button')).find(
+      (element) => element.getAttribute('aria-label') === 'Remove bookmark /scratch/user/pinned'
+    ) as HTMLButtonElement | undefined
+    await act(async () => {
+      removeButton?.click()
+      await Promise.resolve()
+    })
+
+    expect(bookmarksSet).toHaveBeenCalledWith('ssh:biowulf', [])
+    expect(document.body.textContent).not.toContain('/scratch/user/pinned')
+  })
+
   it('shows Add to project button when a project is active', async () => {
     // Set an active project
     useProjectStore.setState({

--- a/src/renderer/src/pages/settings/FileBrowserModal.tsx
+++ b/src/renderer/src/pages/settings/FileBrowserModal.tsx
@@ -121,8 +121,19 @@ const parentPath = (p: string): string => {
 
 type BrowserState =
   | { kind: 'loading' }
-  | { kind: 'ok'; listing: DirListing }
+  | { kind: 'ok'; listing: DirListing; providerId: string }
   | { kind: 'error'; detail: string; kind_hint?: string }
+
+type SelectedRemoteFile = {
+  entry: RemoteDirEntry
+  providerId: string
+  resolvedDir: string
+}
+
+type BookmarksState =
+  | { kind: 'loading'; items: string[] }
+  | { kind: 'ready'; items: string[] }
+  | { kind: 'error'; items: string[]; summary: string; detail: string }
 
 type GoToItem = { label: string; path: string; icon: React.ReactNode }
 
@@ -348,15 +359,20 @@ export function FileBrowserModal({
   const [cwd, setCwd] = useState<string>('~')
   const [history, setHistory] = useState<string[]>([])
   const [browserState, setBrowserState] = useState<BrowserState>({ kind: 'loading' })
-  const [selected, setSelected] = useState<RemoteDirEntry | null>(null)
+  const [selected, setSelected] = useState<SelectedRemoteFile | null>(null)
+  const navigationGeneration = useRef(0)
 
   // Address bar
   const [addressInput, setAddressInput] = useState('')
   const [addressEditing, setAddressEditing] = useState(false)
 
   // Bookmarks
-  const [bookmarks, setBookmarks] = useState<string[]>([])
-  const bookmarksLoaded = useRef(false)
+  const [bookmarksState, setBookmarksState] = useState<BookmarksState>({
+    kind: 'loading',
+    items: []
+  })
+  const bookmarksGeneration = useRef(0)
+  const bookmarks = bookmarksState.items
 
   // Go-to dropdown open state
   const [gotoOpen, setGotoOpen] = useState(false)
@@ -374,6 +390,10 @@ export function FileBrowserModal({
   const navigate = useCallback(
     async (path: string, pushHistory = true) => {
       if (!host) return
+      const providerId = host.providerId
+      // Renderer IPC cannot be cancelled. Only the latest navigation may commit its result.
+      const generation = ++navigationGeneration.current
+      const isCurrent = (): boolean => navigationGeneration.current === generation
       if (pushHistory && cwd !== path) {
         setHistory((h) => [...h, cwd])
       }
@@ -381,12 +401,14 @@ export function FileBrowserModal({
       setSelected(null)
       setBrowserState({ kind: 'loading' })
       try {
-        const listing = await window.api.compute.listDir(host.providerId, path)
-        setBrowserState({ kind: 'ok', listing })
+        const listing = await window.api.compute.listDir(providerId, path)
+        if (!isCurrent()) return
+        setBrowserState({ kind: 'ok', listing, providerId })
         // Update cwd to resolvedPath so the address bar reflects the real path.
         setCwd(listing.resolvedPath)
         setAddressInput(listing.resolvedPath)
       } catch (err) {
+        if (!isCurrent()) return
         const e = err as Error & { remoteFsError?: { detail: string; remoteKind: string } }
         const fsErr = e.remoteFsError ?? decodeRemoteFsError(e.message ?? '')
         const detail = fsErr?.detail ?? e.message ?? 'Unknown error'
@@ -394,12 +416,17 @@ export function FileBrowserModal({
         // Connection failure means the probe result is stale — re-probe in the background so
         // the host chip reflects the current unreachable state (green → grey).
         if (fsErr?.remoteKind === 'connection') {
-          void probeHost(host.providerId).catch(() => undefined)
+          void probeHost(providerId).catch(() => undefined)
         }
       }
     },
     [host, cwd, probeHost]
   )
+
+  const invalidatePendingRequests = useCallback((): void => {
+    navigationGeneration.current += 1
+    bookmarksGeneration.current += 1
+  }, [])
 
   // Adjust state during render on the open edge (React's "adjust state when a prop changes" pattern
   // — https://react.dev/learn/you-might-not-need-an-effect). The modal stays mounted across opens in
@@ -437,15 +464,40 @@ export function FileBrowserModal({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, host?.providerId])
 
+  const bookmarkProviderId = host?.providerId
+
   // Load bookmarks when host changes.
   useEffect(() => {
-    if (!open || !host) return
-    bookmarksLoaded.current = false
-    void window.api.compute.bookmarksGet(host.providerId).then((bms) => {
-      setBookmarks(bms)
-      bookmarksLoaded.current = true
-    })
-  }, [open, host?.providerId])
+    if (!open || !bookmarkProviderId) return
+    const providerId = bookmarkProviderId
+    // Host switches and bookmark writes invalidate older reads through the shared generation.
+    const generation = ++bookmarksGeneration.current
+    const isCurrent = (): boolean => bookmarksGeneration.current === generation
+    void (async () => {
+      await Promise.resolve()
+      if (!isCurrent()) return
+      setBookmarksState({ kind: 'loading', items: [] })
+      try {
+        const items = await window.api.compute.bookmarksGet(providerId)
+        if (!isCurrent()) return
+        setBookmarksState({ kind: 'ready', items })
+      } catch (error) {
+        if (!isCurrent()) return
+        const detail =
+          error instanceof Error && error.message ? error.message : 'Failed to load bookmarks.'
+        setBookmarksState({
+          kind: 'error',
+          items: [],
+          summary: "Couldn't load bookmarks.",
+          detail
+        })
+      }
+    })()
+  }, [bookmarkProviderId, open])
+
+  useEffect(() => {
+    if (!open) invalidatePendingRequests()
+  }, [invalidatePendingRequests, open])
 
   const handleBack = (): void => {
     const prev = history[history.length - 1]
@@ -486,21 +538,53 @@ export function FileBrowserModal({
     void navigate(next)
   }
 
+  const saveBookmarks = async (
+    providerId: string,
+    next: string[],
+    previous: string[]
+  ): Promise<void> => {
+    const generation = ++bookmarksGeneration.current
+    const isCurrent = (): boolean => bookmarksGeneration.current === generation
+    setBookmarksState({ kind: 'ready', items: next })
+    try {
+      await window.api.compute.bookmarksSet(providerId, next)
+    } catch (error) {
+      if (!isCurrent()) return
+      const detail =
+        error instanceof Error && error.message ? error.message : 'Failed to update bookmarks.'
+      setBookmarksState({
+        kind: 'error',
+        items: previous,
+        summary: "Couldn't update bookmarks.",
+        detail
+      })
+    }
+  }
+
   const handlePinCurrent = async (): Promise<void> => {
-    if (!host) return
+    if (!host || bookmarksState.kind === 'loading') return
     const path = browserState.kind === 'ok' ? browserState.listing.resolvedPath : cwd
     if (bookmarks.includes(path)) return
+    const providerId = browserState.kind === 'ok' ? browserState.providerId : host.providerId
     const next = [...bookmarks, path]
-    setBookmarks(next)
     setGotoOpen(false)
-    await window.api.compute.bookmarksSet(host.providerId, next)
+    await saveBookmarks(providerId, next, bookmarks)
   }
 
   const handleRemoveBookmark = async (path: string): Promise<void> => {
-    if (!host) return
+    if (!host || bookmarksState.kind === 'loading') return
     const next = bookmarks.filter((b) => b !== path)
-    setBookmarks(next)
-    await window.api.compute.bookmarksSet(host.providerId, next)
+    await saveBookmarks(host.providerId, next, bookmarks)
+  }
+
+  const handleHostSelect = (providerId: string): void => {
+    if (providerId === activeProviderId) return
+    invalidatePendingRequests()
+    setActiveProviderId(providerId)
+    setSelected(null)
+    setBrowserState({ kind: 'loading' })
+    setBookmarksState({ kind: 'loading', items: [] })
+    setGotoOpen(false)
   }
 
   const isAtRoot = (): boolean => {
@@ -524,7 +608,10 @@ export function FileBrowserModal({
     <Dialog.Root
       open={open}
       onOpenChange={(o) => {
-        if (!o) onClose()
+        if (!o) {
+          invalidatePendingRequests()
+          onClose()
+        }
       }}
     >
       <Dialog.Portal>
@@ -544,7 +631,7 @@ export function FileBrowserModal({
               <button
                 key={h.providerId}
                 type="button"
-                onClick={() => setActiveProviderId(h.providerId)}
+                onClick={() => handleHostSelect(h.providerId)}
                 disabled={!h.probeResult?.ok}
                 className={cn(
                   'flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors',
@@ -636,8 +723,14 @@ export function FileBrowserModal({
                     </button>
                   ))}
                   {goToItems.length > 0 && <div className="my-1 border-t border-border" />}
+                  {bookmarksState.kind === 'loading' && (
+                    <p className={'px-2 py-1.5 text-xs text-muted-foreground'}>
+                      Loading bookmarks...
+                    </p>
+                  )}
                   {/* Pin current folder */}
                   <button
+                    disabled={bookmarksState.kind === 'loading'}
                     type="button"
                     className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-accent"
                     onClick={() => void handlePinCurrent()}
@@ -714,6 +807,19 @@ export function FileBrowserModal({
           <div className="flex min-h-0 flex-1">
             {/* File listing */}
             <div className="flex min-h-0 flex-1 flex-col overflow-auto">
+              {bookmarksState.kind === 'error' && (
+                <div
+                  role={'alert'}
+                  className={
+                    'm-2 flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive'
+                  }
+                >
+                  <div className={'flex-1'}>
+                    <p className={'font-semibold'}>{bookmarksState.summary}</p>
+                    <p className={'mt-0.5 text-muted-foreground'}>{bookmarksState.detail}</p>
+                  </div>
+                </div>
+              )}
               {/* Error banner */}
               {browserState.kind === 'error' && (
                 <div
@@ -778,12 +884,19 @@ export function FileBrowserModal({
                       key={entry.name}
                       type="button"
                       role="option"
-                      aria-selected={selected?.name === entry.name}
+                      aria-selected={selected?.entry.name === entry.name}
                       className={cn(
                         'grid w-full grid-cols-[1fr_80px_80px] items-center px-3 py-1.5 text-left text-xs transition-colors hover:bg-accent',
-                        selected?.name === entry.name ? 'bg-accent/80' : ''
+                        selected?.entry.name === entry.name ? 'bg-accent/80' : ''
                       )}
-                      onClick={() => setSelected(entry)}
+                      onClick={() => {
+                        if (browserState.kind !== 'ok') return
+                        setSelected({
+                          entry,
+                          providerId: browserState.providerId,
+                          resolvedDir: browserState.listing.resolvedPath
+                        })
+                      }}
                       onDoubleClick={() => handleEntryDoubleClick(entry)}
                     >
                       <span className="flex items-center gap-1.5 truncate">
@@ -815,11 +928,11 @@ export function FileBrowserModal({
             </div>
 
             {/* Detail panel (appears when a file is selected) */}
-            {selected && !selected.isDirectory && (
+            {selected && !selected.entry.isDirectory && (
               <DetailPanel
-                entry={selected}
-                resolvedDir={listing?.resolvedPath ?? cwd}
-                providerId={host?.providerId ?? ''}
+                entry={selected.entry}
+                resolvedDir={selected.resolvedDir}
+                providerId={selected.providerId}
                 activeProjectId={activeProject?.id}
                 onClose={() => setSelected(null)}
               />


### PR DESCRIPTION
## Problem

Remote directory and bookmark IPC requests could resolve after the user switched compute hosts. Those stale responses updated the shared browser state unconditionally, so the active host chip could show host B while the directory entries or bookmarks came from host A. File details then combined the selected entry/path with the current host, which could download from the wrong provider.

## Proposed change

- gate directory and bookmark responses with independent request generations
- invalidate pending requests immediately when the host changes or the modal closes
- retain the provider and resolved-directory snapshot with each selected file
- use that source snapshot for download and path actions
- expose bookmark loading and inline load/save errors, rolling back optimistic bookmark changes on failure
- cover out-of-order directory and bookmark responses plus bookmark error handling

## Scope and non-goals

- renderer-only change; no main, preload, shared IPC, or architecture changes
- no persisted field, schema, or bookmark format changes
- no new public or persisted enum values
- existing bookmarks that may already have been written under the wrong provider are not automatically migrated because arbitrary remote paths cannot be classified safely

## Acceptance criteria and validation

All checks below ran after the last material edit:

- out-of-order directory response and provider/path-consistent download -> npm test -- src/renderer/src/pages/settings/FileBrowserModal.render.test.tsx -> passed (13/13)
- renderer type safety -> npm run typecheck:web -> passed
- linted source/configuration -> npm run lint -> passed with 0 errors; 10 pre-existing warnings outside the changed files

The final diff is limited to FileBrowserModal.tsx and its renderer test. No main/preload consumers or platform-specific paths changed, so node, persistence, migration, and platform lanes were excluded from the local impact set. PR Gate CI remains authoritative for the complete selected plan.

## Review focus

- generation invalidation across host changes and modal lifetime
- provider/path provenance captured by the selected-file snapshot
- bookmark rollback and stale-response handling
