### PR TITLE
feat(host-skills): harden package authoring contract

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -2744,6 +2744,9 @@ const hostSkills = {
     return skillsRpc('validate', { name })
   },
   async edit(name, path, content, oldString = undefined) {
+    if (oldString !== undefined && (typeof oldString !== 'string' || oldString.length === 0)) {
+      throw new TypeError('host.skills.edit: oldString must be a non-empty string when provided')
+    }
     return skillsRpc('edit', {
       name,
       path,

--- a/resources/skills/skill-creator/SKILL.md
+++ b/resources/skills/skill-creator/SKILL.md
@@ -22,7 +22,7 @@ await host.skills.publish(name, true)
 await host.skills.delete(stableId)
 ```
 
-Without `old_string`, `edit` creates a file and fails if it exists. With `old_string`, the old text
+Without `oldString`, `edit` creates a file and fails if it exists. With `oldString`, the old text
 must occur exactly once. Never silently overwrite an existing draft file. `publish` promotes the
 complete draft into Personal Skills. `delete` is privileged and always uses app approval. When a
 published Skill and its draft coexist, delete only by the exact `draft-<name>` or `personal-<name>`

--- a/src/main/acp/session-capability-owner.test.ts
+++ b/src/main/acp/session-capability-owner.test.ts
@@ -713,13 +713,13 @@ describe('ACP session capability owner', () => {
   })
 
   it.each([
-    ['claude-code', claudeCodeFramework, true, false],
-    ['opencode', opencodeFramework, true, false],
-    ['codex-response', codexFramework, true, false],
-    ['codex-bridge', codexFramework, false, true]
+    ['claude-code', claudeCodeFramework, true, false, 'open-science-notebook'],
+    ['opencode', opencodeFramework, true, false, 'open_science_notebook'],
+    ['codex-response', codexFramework, true, false, 'open-science-notebook'],
+    ['codex-bridge', codexFramework, false, true, 'open-science-notebook']
   ] as const)(
-    'publishes Host Lineage, Frames, and LLM through the %s primary control descriptor',
-    async (_route, framework, nativeMcpEnabled, bridgeMcpAliasesEnabled) => {
+    'publishes the shared Host control plane through the %s primary descriptor',
+    async (_route, framework, nativeMcpEnabled, bridgeMcpAliasesEnabled, notebookServerName) => {
       const owner = createOwner()
       const built = await owner.provision({
         stableAppSessionId: 'session-1',
@@ -732,11 +732,18 @@ describe('ACP session capability owner', () => {
       })
 
       expect(built.descriptor.controlRpcMethods).toEqual(
-        expect.arrayContaining(['capabilitiesCall', 'lineageCall', 'framesCall', 'llmCall'])
+        expect.arrayContaining([
+          'capabilitiesCall',
+          'lineageCall',
+          'skillsCall',
+          'framesCall',
+          'llmCall'
+        ])
       )
       expect(built.descriptor.capabilities).toEqual(
-        expect.arrayContaining(['host-frames', 'host-llm'])
+        expect.arrayContaining(['notebook', 'host-skills', 'host-frames', 'host-llm'])
       )
+      expect(built.descriptor.modelFacingMcpServerNames).toContain(notebookServerName)
     }
   )
 

--- a/src/main/agents/customize/skill-creator-package.test.ts
+++ b/src/main/agents/customize/skill-creator-package.test.ts
@@ -52,6 +52,8 @@ describe('skill-creator bundled package', () => {
     const skill = await readFile(join(skillRoot, 'SKILL.md'), 'utf8')
     expect(skill).toContain('JavaScript control-plane REPL')
     expect(skill).toContain('host.skills.validate(')
+    expect(skill).toContain('oldString')
+    expect(skill).not.toContain('old_string')
     expect(skill).toContain('host.agents.attachSkill(')
     expect(skill).toContain('references/schemas.md')
     expect(skill).toContain('agents/grader.md')

--- a/src/main/notebook/repl-loop.integration.test.ts
+++ b/src/main/notebook/repl-loop.integration.test.ts
@@ -1907,15 +1907,51 @@ describe('repl_loop local RPC transport', () => {
   }, 60_000)
 
   it('routes host.skills through its native skillsCall method', async () => {
-    let received: { method?: string; params?: Record<string, unknown> } = {}
+    const requests: { method?: string; params?: Record<string, unknown> }[] = []
     const server = createServer((request, response) => {
       let body = ''
       request.on('data', (chunk) => (body += chunk))
       request.on('end', () => {
-        received = JSON.parse(body)
+        const received = JSON.parse(body) as {
+          method?: string
+          params?: Record<string, unknown>
+        }
+        requests.push(received)
+        const results: Record<string, unknown> = {
+          list: [
+            {
+              id: 'personal:demo',
+              name: 'demo',
+              displayName: 'Demo',
+              description: 'Demo Skill',
+              origin: 'personal',
+              editable: true
+            }
+          ],
+          read: {
+            name: 'demo',
+            origin: 'draft',
+            path: 'SKILL.md',
+            content: '---\nname: demo\n---\nDemo\n',
+            files: ['SKILL.md', 'references/guide.md']
+          },
+          validate: {
+            valid: true,
+            name: 'demo',
+            origin: 'draft',
+            errors: [],
+            warnings: [{ code: 'missingResource', path: 'SKILL.md', message: 'Missing guide.md' }]
+          },
+          edit: { status: 'edited', name: 'demo', path: 'SKILL.md', origin: 'draft' },
+          publish: { status: 'published', id: 'personal:demo', name: 'demo', origin: 'personal' },
+          delete:
+            received.params?.name === 'declined-demo'
+              ? { status: 'declined', operation: 'delete' }
+              : { status: 'deleted', operation: 'delete', name: 'demo' }
+        }
         response
           .writeHead(200, { 'content-type': 'application/json' })
-          .end(JSON.stringify({ result: { status: 'edited', origin: 'draft' } }))
+          .end(JSON.stringify({ result: results[String(received.params?.op)] }))
       })
     })
     const connection = await listenForLocalRpc(server, {
@@ -1930,27 +1966,104 @@ describe('repl_loop local RPC transport', () => {
     })
 
     try {
+      const methods = await send('return Object.keys(host.skills).sort()')
+      expect(JSON.parse(methods.result ?? '[]')).toEqual([
+        'delete',
+        'edit',
+        'list',
+        'publish',
+        'read',
+        'validate'
+      ])
+
       const result = await send(
-        "return await host.skills.edit('demo', 'SKILL.md', 'new body', 'old body')"
+        'return JSON.stringify({' +
+          'list: await host.skills.list(), ' +
+          "read: await host.skills.read('demo'), " +
+          "validate: await host.skills.validate('demo'), " +
+          "edit: await host.skills.edit('demo', 'SKILL.md', 'new body', 'old body'), " +
+          "publish: await host.skills.publish('demo', true), " +
+          "deleted: await host.skills.delete('demo'), " +
+          "declined: await host.skills.delete('declined-demo')" +
+          '})'
       )
       expect(result.error).toBeNull()
-      expect(received).toMatchObject({
-        method: 'skillsCall',
-        params: {
-          op: 'edit',
+      expect(JSON.parse(result.result ?? '{}')).toEqual({
+        list: [
+          {
+            id: 'personal:demo',
+            name: 'demo',
+            displayName: 'Demo',
+            description: 'Demo Skill',
+            origin: 'personal',
+            editable: true
+          }
+        ],
+        read: {
           name: 'demo',
+          origin: 'draft',
           path: 'SKILL.md',
-          content: 'new body',
-          old_string: 'old body'
+          content: '---\nname: demo\n---\nDemo\n',
+          files: ['SKILL.md', 'references/guide.md']
+        },
+        validate: {
+          valid: true,
+          name: 'demo',
+          origin: 'draft',
+          errors: [],
+          warnings: [{ code: 'missingResource', path: 'SKILL.md', message: 'Missing guide.md' }]
+        },
+        edit: { status: 'edited', name: 'demo', path: 'SKILL.md', origin: 'draft' },
+        publish: { status: 'published', id: 'personal:demo', name: 'demo', origin: 'personal' },
+        deleted: { status: 'deleted', operation: 'delete', name: 'demo' },
+        declined: { status: 'declined', operation: 'delete' }
+      })
+      expect(requests).toEqual([
+        { method: 'skillsCall', params: { op: 'list', session_id: 'session-1' } },
+        {
+          method: 'skillsCall',
+          params: { op: 'read', name: 'demo', path: 'SKILL.md', session_id: 'session-1' }
+        },
+        {
+          method: 'skillsCall',
+          params: { op: 'validate', name: 'demo', session_id: 'session-1' }
+        },
+        {
+          method: 'skillsCall',
+          params: {
+            op: 'edit',
+            name: 'demo',
+            path: 'SKILL.md',
+            content: 'new body',
+            old_string: 'old body',
+            session_id: 'session-1'
+          }
+        },
+        {
+          method: 'skillsCall',
+          params: { op: 'publish', name: 'demo', overwrite: true, session_id: 'session-1' }
+        },
+        {
+          method: 'skillsCall',
+          params: { op: 'delete', name: 'demo', session_id: 'session-1' }
+        },
+        {
+          method: 'skillsCall',
+          params: { op: 'delete', name: 'declined-demo', session_id: 'session-1' }
         }
-      })
+      ])
+      expect(JSON.stringify(result)).not.toContain('old_string')
+      expect(JSON.stringify(result)).not.toContain('body')
 
-      const validated = await send("return await host.skills.validate('demo')")
-      expect(validated.error).toBeNull()
-      expect(received).toMatchObject({
-        method: 'skillsCall',
-        params: { op: 'validate', name: 'demo' }
-      })
+      const publicError = await send(
+        "try { await host.skills.edit('demo', 'SKILL.md', 'new body', '') } " +
+          'catch (error) { return error.message }'
+      )
+      expect(publicError.result).toBe(
+        'host.skills.edit: oldString must be a non-empty string when provided'
+      )
+      expect(JSON.stringify(publicError)).not.toContain('old_string')
+      expect(requests).toHaveLength(7)
     } finally {
       child.kill()
       await new Promise<void>((resolve, reject) =>

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -1206,34 +1206,49 @@ describe('AgentBackendResolver bridge predicates', () => {
         provider: { apiEndpoints: ['openai'] as const }
       }
     }
-  ])('advertises exact enabled Connector Skill names to $name', async (testCase) => {
-    const harness = makeHarness({
-      connectorIds: ['pubmed', 'literature'],
-      connectorSkillNames: ['mcp-pubmed', 'mcp-literature', 'mcp-custom-chemistry'],
-      targetOverride: () => testCase.target
-    })
+  ])(
+    'rematerializes exact enabled Connector Skill names for each $name generation',
+    async (testCase) => {
+      const harness = makeHarness({
+        connectorIds: ['pubmed', 'literature'],
+        connectorSkillNames: ['mcp-pubmed', 'mcp-literature', 'mcp-custom-chemistry'],
+        targetOverride: () => testCase.target
+      })
+      const target = {
+        frameworkId: testCase.frameworkId,
+        providerId: 'provider-a',
+        model: { kind: 'provider-default' as const },
+        reasoningEffort: 'high' as const
+      }
 
-    const backend = await harness.resolver.resolveExplicitTarget({
-      frameworkId: testCase.frameworkId,
-      providerId: 'provider-a',
-      model: { kind: 'provider-default' },
-      reasoningEffort: 'high'
-    })
-    const instructions =
-      testCase.frameworkId === 'claude-code'
-        ? backend.systemPromptAppends?.join('\n\n')
-        : backend.persistentSystemPrompt
+      const previousBackend = await harness.resolver.resolveExplicitTarget(target)
+      await previousBackend.anthropicBridgeLease?.release()
+      await previousBackend.responsesBridgeLease?.release()
+      await previousBackend.providerTransportLease?.release()
 
-    expect(instructions).toContain(
-      'Globally Enabled Connector Skills: `mcp-pubmed`, `mcp-literature`, `mcp-custom-chemistry`.'
-    )
-    expect(instructions).toContain('Allowed Specialist Skills for this session')
-    expect(instructions).not.toContain('host.mcp("custom-chemistry"')
-    expect(instructions).not.toContain('`mcp-openalex`')
-    await backend.anthropicBridgeLease?.release()
-    await backend.responsesBridgeLease?.release()
-    await backend.providerTransportLease?.release()
-  })
+      const backend = await harness.resolver.resolveExplicitTarget(target)
+      const instructions =
+        testCase.frameworkId === 'claude-code'
+          ? backend.systemPromptAppends?.join('\n\n')
+          : backend.persistentSystemPrompt
+
+      expect(instructions).toContain(
+        'Globally Enabled Connector Skills: `mcp-pubmed`, `mcp-literature`, `mcp-custom-chemistry`.'
+      )
+      expect(instructions).toContain('Allowed Specialist Skills for this session')
+      expect(instructions).not.toContain('host.mcp("custom-chemistry"')
+      expect(instructions).not.toContain('`mcp-openalex`')
+      expect(harness.runtime.provisionClaudeRuntimeConfig).toHaveBeenCalledTimes(
+        testCase.frameworkId === 'claude-code' ? 2 : 0
+      )
+      expect(harness.runtime.materializeAgentSkills).toHaveBeenCalledTimes(
+        testCase.frameworkId === 'claude-code' ? 0 : 2
+      )
+      await backend.anthropicBridgeLease?.release()
+      await backend.responsesBridgeLease?.release()
+      await backend.providerTransportLease?.release()
+    }
+  )
 
   it.each([
     { name: 'OpenCode', frameworkId: 'opencode' as const, target: {} },

--- a/src/main/skills/export.ts
+++ b/src/main/skills/export.ts
@@ -1,13 +1,15 @@
-import { lstat, readFile, readdir } from 'node:fs/promises'
-import { basename, join, posix } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import { basename } from 'node:path'
 
 import { zipSync, type Zippable } from 'fflate'
 import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
 import type { BundledSkill } from './registry'
 import { canonicalSkillDocument } from './skill-document-name'
-import { isUnsafeSkillArchivePath } from './zip-extract'
-
-const INTERNAL_SKILL_FILES = new Set(['.source.json', '.specialist-package.json'])
+import {
+  inspectSkillPackage,
+  SkillPackagePolicyError,
+  type SkillPackageFile
+} from './skill-package-inspection'
 const WINDOWS_RESERVED_BASENAME = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])$/i
 
 const normalizeExportedSkillDocument = (raw: string, name: string): string => {
@@ -47,71 +49,53 @@ type SkillExportDialog = {
   writeFile: (filePath: string, bytes: Uint8Array) => Promise<unknown>
 }
 
-const collectFiles = async (
-  directory: string,
-  skillName: string,
-  relativeDirectory = '',
-  state: { files: Zippable; fileCount: number; totalBytes: number } = {
-    files: {},
-    fileCount: 0,
-    totalBytes: 0
-  },
-  depth = 0
-): Promise<Zippable> => {
-  if (depth > SKILL_IMPORT_LIMITS.maxDepth) {
-    throw new Error('Skill tree exceeds the export depth limit.')
-  }
-  const entries = await readdir(directory, { withFileTypes: true })
-  entries.sort((left, right) => left.name.localeCompare(right.name))
-
-  for (const entry of entries) {
-    if (!relativeDirectory && INTERNAL_SKILL_FILES.has(entry.name)) continue
-    const relativePath = relativeDirectory ? posix.join(relativeDirectory, entry.name) : entry.name
-    if (isUnsafeSkillArchivePath(relativePath)) {
-      throw new Error('Skill path cannot be imported safely.')
-    }
-    const absolutePath = join(directory, entry.name)
-    const metadata = await lstat(absolutePath)
-    if (metadata.isSymbolicLink() || (metadata.isFile() && metadata.nlink > 1)) {
+const collectFiles = async (directory: string, skillName: string): Promise<Zippable> => {
+  let inventory: SkillPackageFile[]
+  try {
+    inventory = await inspectSkillPackage(directory)
+  } catch (error) {
+    if (!(error instanceof SkillPackagePolicyError)) throw error
+    if (error.reason === 'unsafePath') throw new Error('Skill path cannot be imported safely.')
+    if (error.reason === 'symbolicLink' || error.reason === 'hardLink') {
       throw new Error('Unsafe Skill filesystem entry.')
     }
-    if (metadata.isDirectory()) {
-      await collectFiles(absolutePath, skillName, relativePath, state, depth + 1)
-    } else if (metadata.isFile()) {
-      state.fileCount += 1
-      state.totalBytes += metadata.size
-      if (state.fileCount > SKILL_IMPORT_LIMITS.maxFiles) {
-        throw new Error('Skill tree exceeds the export file-count limit.')
-      }
-      if (metadata.size > SKILL_IMPORT_LIMITS.maxFileBytes) {
-        throw new Error('Skill file exceeds the export size limit.')
-      }
-      if (state.totalBytes > SKILL_IMPORT_LIMITS.maxTotalBytes) {
-        throw new Error('Skill tree exceeds the total export size limit.')
-      }
-      let bytes = new Uint8Array(await readFile(absolutePath))
-      if (relativePath === 'SKILL.md') {
-        bytes = new TextEncoder().encode(
-          normalizeExportedSkillDocument(
-            new TextDecoder('utf-8', { fatal: true }).decode(bytes),
-            skillName
-          )
-        )
-      }
-      state.totalBytes += bytes.byteLength - metadata.size
-      if (bytes.byteLength > SKILL_IMPORT_LIMITS.maxFileBytes) {
-        throw new Error('Skill file exceeds the export size limit.')
-      }
-      if (state.totalBytes > SKILL_IMPORT_LIMITS.maxTotalBytes) {
-        throw new Error('Skill tree exceeds the total export size limit.')
-      }
-      state.files[relativePath] = [bytes, { mtime: new Date('1980-01-01T00:00:00.000Z') }]
-    } else {
+    if (error.reason === 'unsupportedEntry') {
       throw new Error('Unsupported Skill filesystem entry.')
     }
+    if (error.reason === 'depthLimit') {
+      throw new Error('Skill tree exceeds the export depth limit.')
+    }
+    if (error.reason === 'fileCountLimit') {
+      throw new Error('Skill tree exceeds the export file-count limit.')
+    }
+    if (error.reason === 'fileSizeLimit') {
+      throw new Error('Skill file exceeds the export size limit.')
+    }
+    throw new Error('Skill tree exceeds the total export size limit.')
   }
 
-  return state.files
+  const files: Zippable = {}
+  let totalBytes = 0
+  for (const file of inventory) {
+    let bytes = new Uint8Array(await readFile(file.absolutePath))
+    if (file.relativePath === 'SKILL.md') {
+      bytes = new TextEncoder().encode(
+        normalizeExportedSkillDocument(
+          new TextDecoder('utf-8', { fatal: true }).decode(bytes),
+          skillName
+        )
+      )
+    }
+    totalBytes += bytes.byteLength
+    if (bytes.byteLength > SKILL_IMPORT_LIMITS.maxFileBytes) {
+      throw new Error('Skill file exceeds the export size limit.')
+    }
+    if (totalBytes > SKILL_IMPORT_LIMITS.maxTotalBytes) {
+      throw new Error('Skill tree exceeds the total export size limit.')
+    }
+    files[file.relativePath] = [bytes, { mtime: new Date('1980-01-01T00:00:00.000Z') }]
+  }
+  return files
 }
 
 export const buildSkillExportArchive = async (

--- a/src/main/skills/host-skills-service.test.ts
+++ b/src/main/skills/host-skills-service.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { link, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -81,11 +81,349 @@ describe('HostSkillsService', () => {
 
     await expect(
       service.dispatch({ op: 'validate', params: { name: 'analysis-helper' } })
-    ).resolves.toEqual({ valid: true, name: 'analysis-helper', origin: 'draft' })
+    ).resolves.toEqual({
+      valid: true,
+      name: 'analysis-helper',
+      origin: 'draft',
+      errors: [],
+      warnings: []
+    })
+  })
+
+  it('returns a deterministic recursive file inventory only for SKILL.md reads', async () => {
+    const { service, root } = await makeFixture()
+    await service.dispatch({
+      op: 'edit',
+      params: {
+        name: 'package-reader',
+        path: 'SKILL.md',
+        content: '---\nname: package-reader\ndescription: Read a package.\n---\nBody.\n'
+      }
+    })
+    await service.dispatch({
+      op: 'edit',
+      params: { name: 'package-reader', path: 'z-last.md', content: 'Last.\n' }
+    })
+    await service.dispatch({
+      op: 'edit',
+      params: { name: 'package-reader', path: 'references/guide.md', content: 'Guide.\n' }
+    })
+    await service.dispatch({
+      op: 'edit',
+      params: { name: 'package-reader', path: 'scripts/check.js', content: 'export {}\n' }
+    })
+    await service.dispatch({
+      op: 'edit',
+      params: { name: 'package-reader', path: 'a/nested.md', content: 'Nested.\n' }
+    })
+    await service.dispatch({
+      op: 'edit',
+      params: { name: 'package-reader', path: 'a-file.md', content: 'Sibling.\n' }
+    })
+    await writeFile(
+      join(root, 'skills', 'drafts', 'package-reader', '.specialist-package.json'),
+      '{"ownerIds":["internal-id"]}'
+    )
+
+    await expect(
+      service.dispatch({ op: 'read', params: { name: 'package-reader' } })
+    ).resolves.toEqual({
+      name: 'package-reader',
+      origin: 'draft',
+      path: 'SKILL.md',
+      content: '---\nname: package-reader\ndescription: Read a package.\n---\nBody.\n',
+      files: [
+        'SKILL.md',
+        'a-file.md',
+        'a/nested.md',
+        'references/guide.md',
+        'scripts/check.js',
+        'z-last.md'
+      ]
+    })
+    await expect(
+      service.dispatch({
+        op: 'read',
+        params: { name: 'package-reader', path: 'references/guide.md' }
+      })
+    ).resolves.toEqual({
+      name: 'package-reader',
+      origin: 'draft',
+      path: 'references/guide.md',
+      content: 'Guide.\n'
+    })
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'fails closed when SKILL.md inventory contains a symbolic link',
+    async () => {
+      const { service, root } = await makeFixture()
+      await service.dispatch({
+        op: 'edit',
+        params: {
+          name: 'unsafe-package',
+          path: 'SKILL.md',
+          content: '---\nname: unsafe-package\ndescription: Unsafe package.\n---\nBody.\n'
+        }
+      })
+      const packageRoot = join(root, 'skills', 'drafts', 'unsafe-package')
+      await symlink(join(root, 'outside.md'), join(packageRoot, 'linked.md'))
+
+      await expect(
+        service.dispatch({ op: 'read', params: { name: 'unsafe-package' } })
+      ).rejects.toThrow('host.skills.read: Skill package contains a symbolic link.')
+    }
+  )
+
+  it('fails closed when SKILL.md inventory contains a hard link', async () => {
+    const { service, root } = await makeFixture()
+    await service.dispatch({
+      op: 'edit',
+      params: {
+        name: 'unsafe-package',
+        path: 'SKILL.md',
+        content: '---\nname: unsafe-package\ndescription: Unsafe package.\n---\nBody.\n'
+      }
+    })
+    const packageRoot = join(root, 'skills', 'drafts', 'unsafe-package')
+    await mkdir(join(packageRoot, 'references'))
+    await link(join(packageRoot, 'SKILL.md'), join(packageRoot, 'references', 'shared.md'))
+    await expect(
+      service.dispatch({ op: 'read', params: { name: 'unsafe-package' } })
+    ).rejects.toThrow('host.skills.read: Skill package contains a hard link.')
+  })
+
+  it('reports deterministic frontmatter, body, Markdown link, and evaluation issues', async () => {
+    const { service } = await makeFixture()
+    await service.dispatch({
+      op: 'edit',
+      params: {
+        name: 'report-example',
+        path: 'SKILL.md',
+        content:
+          '---\nname: report-example\ndescription: Report issues.\nlicense: MIT\n---\n\n[missing](references/missing.md)\n'
+      }
+    })
+    await service.dispatch({
+      op: 'edit',
+      params: {
+        name: 'report-example',
+        path: 'references/guide.md',
+        content:
+          '[also missing](../assets/missing.txt) [external](https://example.com) [section](#part)\n'
+      }
+    })
+    await service.dispatch({
+      op: 'edit',
+      params: { name: 'report-example', path: 'trigger-evals.json', content: '{not json' }
+    })
+    await service.dispatch({
+      op: 'edit',
+      params: {
+        name: 'report-example',
+        path: 'evals/evals.json',
+        content: JSON.stringify({ schema_version: 2, evals: [] })
+      }
+    })
+
+    await expect(
+      service.dispatch({ op: 'validate', params: { name: 'report-example' } })
+    ).resolves.toEqual({
+      valid: false,
+      name: 'report-example',
+      origin: 'draft',
+      errors: [
+        {
+          code: 'invalidFrontmatterFields',
+          path: 'SKILL.md',
+          message: 'SKILL.md frontmatter may only contain name, displayName, and description.'
+        },
+        {
+          code: 'invalidOutputEvals',
+          path: 'evals/evals.json',
+          message: 'evals/evals.json does not match the supported version 1 structure.'
+        },
+        {
+          code: 'invalidJson',
+          path: 'trigger-evals.json',
+          message: 'trigger-evals.json must contain valid JSON.'
+        }
+      ],
+      warnings: [
+        {
+          code: 'missingLocalLink',
+          path: 'SKILL.md',
+          message: 'Local Markdown target does not exist: references/missing.md.'
+        },
+        {
+          code: 'missingLocalLink',
+          path: 'references/guide.md',
+          message: 'Local Markdown target does not exist: assets/missing.txt.'
+        }
+      ]
+    })
+  })
+
+  it('warns for an empty instruction body without blocking publish', async () => {
+    const { service, reload } = await makeFixture()
+    await service.dispatch({
+      op: 'edit',
+      params: {
+        name: 'empty-body',
+        path: 'SKILL.md',
+        content: '---\nname: empty-body\ndescription: Empty body.\n---\n  \n'
+      }
+    })
+
+    await expect(
+      service.dispatch({ op: 'validate', params: { name: 'empty-body' } })
+    ).resolves.toEqual({
+      valid: true,
+      name: 'empty-body',
+      origin: 'draft',
+      errors: [],
+      warnings: [
+        {
+          code: 'emptyBody',
+          path: 'SKILL.md',
+          message: 'SKILL.md has no instruction body.'
+        }
+      ]
+    })
+    await expect(
+      service.dispatch({ op: 'publish', params: { name: 'empty-body' } })
+    ).resolves.toMatchObject({ status: 'published', name: 'empty-body' })
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'returns package safety violations as validation errors and blocks publish',
+    async () => {
+      const { service, root, userSkills, reload } = await makeFixture()
+      await service.dispatch({
+        op: 'edit',
+        params: {
+          name: 'unsafe-validation',
+          path: 'SKILL.md',
+          content: '---\nname: unsafe-validation\ndescription: Unsafe package.\n---\nBody.\n'
+        }
+      })
+      await symlink(
+        join(root, 'outside.md'),
+        join(root, 'skills', 'drafts', 'unsafe-validation', 'linked.md')
+      )
+
+      await expect(
+        service.dispatch({ op: 'validate', params: { name: 'unsafe-validation' } })
+      ).resolves.toEqual({
+        valid: false,
+        name: 'unsafe-validation',
+        origin: 'draft',
+        errors: [
+          {
+            code: 'unsafePackageEntry',
+            path: 'linked.md',
+            message: 'Skill package contains a symbolic link.'
+          }
+        ],
+        warnings: []
+      })
+      await expect(
+        service.dispatch({ op: 'publish', params: { name: 'unsafe-validation' } })
+      ).rejects.toThrow('host.skills.publish: Skill package contains a symbolic link.')
+      expect(await userSkills.list()).toHaveLength(0)
+      expect(reload).not.toHaveBeenCalled()
+      await expect(
+        readFile(join(root, 'skills', 'drafts', 'unsafe-validation', 'SKILL.md'), 'utf8')
+      ).resolves.toContain('name: unsafe-validation')
+    }
+  )
+
+  it('returns a validation report for a known draft without SKILL.md', async () => {
+    const { service, reload } = await makeFixture()
+    await service.dispatch({
+      op: 'edit',
+      params: { name: 'incomplete-draft', path: 'references/notes.md', content: 'Notes.\n' }
+    })
+
+    await expect(
+      service.dispatch({ op: 'validate', params: { name: 'incomplete-draft' } })
+    ).resolves.toEqual({
+      valid: false,
+      name: 'incomplete-draft',
+      origin: 'draft',
+      errors: [
+        {
+          code: 'missingSkillDocument',
+          path: 'SKILL.md',
+          message: 'Skill package must contain SKILL.md at its root.'
+        }
+      ],
+      warnings: []
+    })
+    await expect(
+      service.dispatch({ op: 'publish', params: { name: 'incomplete-draft' } })
+    ).rejects.toThrow('host.skills.publish: Skill package must contain SKILL.md at its root.')
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('enforces the documented trigger and output evaluation structures', async () => {
+    const { service } = await makeFixture()
+    await service.dispatch({
+      op: 'edit',
+      params: {
+        name: 'valid-evals',
+        path: 'SKILL.md',
+        content: '---\nname: valid-evals\ndescription: Validate evals.\n---\nBody.\n'
+      }
+    })
+    await service.dispatch({
+      op: 'edit',
+      params: {
+        name: 'valid-evals',
+        path: 'trigger-evals.json',
+        content: JSON.stringify({
+          schema_version: 1,
+          kind: 'trigger',
+          cases: [{ id: 'create', query: 'Create a Skill.', should_trigger: true }]
+        })
+      }
+    })
+    await service.dispatch({
+      op: 'edit',
+      params: {
+        name: 'valid-evals',
+        path: 'evals/evals.json',
+        content: JSON.stringify({
+          schema_version: 1,
+          skill_id: 'personal-valid-evals',
+          source_revision: 'revision',
+          evals: [
+            {
+              id: 'create',
+              prompt: 'Create a Skill.',
+              expected_output: 'A Skill package.',
+              files: [],
+              expectations: ['The package is valid.']
+            }
+          ]
+        })
+      }
+    })
+
+    await expect(
+      service.dispatch({ op: 'validate', params: { name: 'valid-evals' } })
+    ).resolves.toEqual({
+      valid: true,
+      name: 'valid-evals',
+      origin: 'draft',
+      errors: [],
+      warnings: []
+    })
   })
 
   it('creates a draft with exact create/replace semantics, publishes it, and reads it back', async () => {
-    const { service, root, reload } = await makeFixture()
+    const { service, root, userSkills, reload } = await makeFixture()
     const manifest =
       '---\nname: analysis-helper\ndescription: Analyze a dataset.\n---\nUse the script.\n'
 
@@ -115,6 +453,14 @@ describe('HostSkillsService', () => {
       }
     })
 
+    const draftSkillDocument = join(root, 'skills', 'drafts', 'analysis-helper', 'SKILL.md')
+    reload.mockImplementationOnce(async () => {
+      await expect(userSkills.list()).resolves.toContainEqual(
+        expect.objectContaining({ id: 'personal-analysis-helper' })
+      )
+      await expect(readFile(draftSkillDocument)).rejects.toMatchObject({ code: 'ENOENT' })
+    })
+
     await expect(
       service.dispatch({ op: 'publish', params: { name: 'analysis-helper' } })
     ).resolves.toEqual({
@@ -134,9 +480,7 @@ describe('HostSkillsService', () => {
       content: 'console.log("v2")\n',
       origin: 'personal'
     })
-    await expect(
-      readFile(join(root, 'skills', 'drafts', 'analysis-helper', 'SKILL.md'))
-    ).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(readFile(draftSkillDocument)).rejects.toMatchObject({ code: 'ENOENT' })
     expect(reload).toHaveBeenCalledTimes(1)
   })
 
@@ -190,6 +534,17 @@ describe('HostSkillsService', () => {
       service.dispatch({
         op: 'edit',
         params: { name: 'bad', path: 'SKILL.md', old_string: 'same', content: 'new' }
+      })
+    ).rejects.toThrow('exactly once')
+
+    await service.dispatch({
+      op: 'edit',
+      params: { name: 'overlap', path: 'SKILL.md', content: 'aaa' }
+    })
+    await expect(
+      service.dispatch({
+        op: 'edit',
+        params: { name: 'overlap', path: 'SKILL.md', old_string: 'aa', content: 'new' }
       })
     ).rejects.toThrow('exactly once')
   })
@@ -443,6 +798,9 @@ describe('HostSkillsService', () => {
     expect(await userSkills.list()).toHaveLength(1)
     expect(reload).not.toHaveBeenCalled()
 
+    reload.mockImplementationOnce(async () => {
+      await expect(userSkills.list()).resolves.toHaveLength(0)
+    })
     await expect(
       service.dispatch(
         { op: 'delete', params: { name: 'personal-disposable' } },

--- a/src/main/skills/host-skills-service.ts
+++ b/src/main/skills/host-skills-service.ts
@@ -4,8 +4,13 @@ import { dirname, join, resolve, sep } from 'node:path'
 
 import type { TrustedCallingSession } from '../../shared/agents-contract'
 import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
-import { frontmatterFieldNames, parseSkillDocument } from './frontmatter'
+import { parseSkillDocument } from './frontmatter'
 import type { BundledSkill } from './registry'
+import {
+  inspectSkillPackage,
+  validateSkillPackage,
+  type SkillValidationIssue
+} from './skill-package-inspection'
 import { SAFE_SKILL_NAME, assertUsableSkillName, parseUserSkillId } from './user-skill-repository'
 import { isUnsafeSkillArchivePath } from './zip-extract'
 
@@ -27,6 +32,59 @@ type HostSkillsServiceOptions = {
 }
 
 type Params = Record<string, unknown>
+
+type HostSkillOrigin = 'draft' | BundledSkill['source']
+
+export type HostSkillSummary = Readonly<{
+  id: string
+  name: string
+  displayName: string
+  description: string
+  origin: HostSkillOrigin
+  editable: boolean
+}>
+
+export type HostSkillReadResult = Readonly<{
+  name: string
+  origin: HostSkillOrigin
+  path: string
+  content: string
+  files?: string[]
+}>
+
+export type HostSkillValidationResult = Readonly<{
+  valid: boolean
+  name: string
+  origin: HostSkillOrigin
+  errors: SkillValidationIssue[]
+  warnings: SkillValidationIssue[]
+}>
+
+type HostSkillEditResult = Readonly<{
+  status: 'edited'
+  name: string
+  path: string
+  origin: 'draft'
+}>
+
+type HostSkillPublishResult = Readonly<{
+  status: 'published'
+  id: string
+  name: string
+  origin: 'personal'
+}>
+
+type HostSkillDeleteResult =
+  | Readonly<{ status: 'declined'; operation: 'delete' }>
+  | Readonly<{ status: 'deleted'; operation: 'delete'; name: string }>
+
+export type HostSkillsResult =
+  | HostSkillSummary[]
+  | HostSkillReadResult
+  | HostSkillValidationResult
+  | HostSkillEditResult
+  | HostSkillPublishResult
+  | HostSkillDeleteResult
 
 const asString = (value: unknown): string | undefined =>
   typeof value === 'string' ? value : undefined
@@ -109,7 +167,7 @@ export class HostSkillsService {
     return result
   }
 
-  async dispatch(request: unknown, context: TrustedCallingSession = {}): Promise<unknown> {
+  async dispatch(request: unknown, context: TrustedCallingSession = {}): Promise<HostSkillsResult> {
     const op =
       request && typeof request === 'object' && 'op' in request
         ? asString((request as { op: unknown }).op)
@@ -150,7 +208,7 @@ export class HostSkillsService {
     }
   }
 
-  private async list(): Promise<unknown[]> {
+  private async list(): Promise<HostSkillSummary[]> {
     const installed = (await this.options.catalog.list()).map((skill) => ({
       id: skill.id,
       name: skill.name,
@@ -179,7 +237,7 @@ export class HostSkillsService {
           name,
           displayName,
           description,
-          origin: 'draft',
+          origin: 'draft' as const,
           editable: true
         }
       })
@@ -197,7 +255,26 @@ export class HostSkillsService {
     return matches[0]
   }
 
-  private async read(params: Params): Promise<unknown> {
+  private async readFromPackage(
+    root: string,
+    name: string,
+    origin: HostSkillOrigin,
+    relativePath: string
+  ): Promise<HostSkillReadResult> {
+    const files =
+      relativePath === 'SKILL.md'
+        ? (await inspectSkillPackage(root)).map(({ relativePath: path }) => path)
+        : undefined
+    return {
+      name,
+      path: relativePath,
+      content: await readPackageText(root, relativePath),
+      origin,
+      ...(files ? { files } : {})
+    }
+  }
+
+  private async read(params: Params): Promise<HostSkillReadResult> {
     const requestedName = asString(params.name)?.trim()
     if (!requestedName) throw new Error('name is required')
     const relativePath = safeRelativePath(params.path, 'SKILL.md')
@@ -205,65 +282,56 @@ export class HostSkillsService {
       explicitDraftName(requestedName) ??
       (SAFE_SKILL_NAME.test(requestedName) ? requestedName : undefined)
     if (draftName && (await exists(this.draftDir(draftName)))) {
-      return {
-        name: draftName,
-        path: relativePath,
-        content: await readPackageText(this.draftDir(draftName), relativePath),
-        origin: 'draft'
-      }
+      return this.readFromPackage(this.draftDir(draftName), draftName, 'draft', relativePath)
     }
 
     const skill = await this.resolvePublished(requestedName)
     if (!skill) throw new Error(`Unknown Skill: ${requestedName}`)
-    const result = await this.options.catalog.withSkillRead(skill.id, async (lockedSkill) => ({
-      name: lockedSkill.name,
-      path: relativePath,
-      content: await readPackageText(lockedSkill.sourceDir, relativePath),
-      origin: lockedSkill.source
-    }))
+    const result = await this.options.catalog.withSkillRead(skill.id, (lockedSkill) =>
+      this.readFromPackage(
+        lockedSkill.sourceDir,
+        lockedSkill.name,
+        lockedSkill.source,
+        relativePath
+      )
+    )
     if (!result) throw new Error(`Unknown Skill: ${requestedName}`)
     return result
   }
 
-  private async validatePackage(sourceDir: string, expectedName?: string): Promise<string> {
-    const skillDocument = await readPackageText(sourceDir, 'SKILL.md')
-    const parsed = parseSkillDocument(skillDocument)
-    if (!parsed.name?.trim() || !parsed.description?.trim()) {
-      throw new Error('SKILL.md requires name and description frontmatter')
+  private async validationResult(
+    sourceDir: string,
+    name: string,
+    origin: HostSkillOrigin,
+    expectedName?: string
+  ): Promise<HostSkillValidationResult> {
+    const report = await validateSkillPackage(sourceDir, name, expectedName)
+    return {
+      valid: report.errors.length === 0,
+      name: report.name,
+      origin,
+      errors: report.errors,
+      warnings: report.warnings
     }
-    const fieldNames = frontmatterFieldNames(skillDocument).sort()
-    if (
-      (fieldNames.length !== 2 && fieldNames.length !== 3) ||
-      fieldNames[0] !== 'description' ||
-      (fieldNames.length === 3 && fieldNames[1] !== 'displayname') ||
-      fieldNames.at(-1) !== 'name'
-    ) {
-      throw new Error('SKILL.md frontmatter may only contain name, displayName, and description')
-    }
-    const name = parsed.name.trim()
-    if (expectedName && name !== expectedName)
-      throw new Error('SKILL.md name must match the draft name')
-    return name
   }
 
-  private async validate(params: Params): Promise<unknown> {
+  private async validate(params: Params): Promise<HostSkillValidationResult> {
     const requestedName = asString(params.name)?.trim()
     if (!requestedName) throw new Error('name is required')
     const draftName =
       explicitDraftName(requestedName) ??
       (SAFE_SKILL_NAME.test(requestedName) ? requestedName : undefined)
     if (draftName && (await exists(this.draftDir(draftName)))) {
-      const name = await this.validatePackage(this.draftDir(draftName), draftName)
-      return { valid: true, name, origin: 'draft' }
+      return this.validationResult(this.draftDir(draftName), draftName, 'draft', draftName)
     }
 
     const published = await this.resolvePublished(requestedName)
     if (!published) throw new Error(`Unknown Skill: ${requestedName}`)
-    const name = await this.options.catalog.withSkillRead(published.id, (skill) =>
-      this.validatePackage(skill.sourceDir)
+    const result = await this.options.catalog.withSkillRead(published.id, (skill) =>
+      this.validationResult(skill.sourceDir, skill.name, skill.source)
     )
-    if (!name) throw new Error(`Unknown Skill: ${requestedName}`)
-    return { valid: true, name, origin: published.source }
+    if (!result) throw new Error(`Unknown Skill: ${requestedName}`)
+    return result
   }
 
   private async ensureDraft(name: string): Promise<{ name: string; path: string }> {
@@ -327,25 +395,11 @@ export class HostSkillsService {
     target: string,
     nextBytes: number
   ): Promise<void> {
-    let count = 0
-    let total = 0
-    let replacedBytes = 0
-    const visit = async (dir: string, depth: number): Promise<void> => {
-      if (depth > SKILL_IMPORT_LIMITS.maxDepth) throw new Error('draft is nested too deeply')
-      for (const entry of await readdir(dir, { withFileTypes: true })) {
-        const path = join(dir, entry.name)
-        const metadata = await lstat(path)
-        if (metadata.isSymbolicLink()) throw new Error('draft contains a symbolic link')
-        if (entry.isDirectory()) {
-          await visit(path, depth + 1)
-        } else if (entry.isFile()) {
-          count += 1
-          total += metadata.size
-          if (resolve(path) === resolve(target)) replacedBytes = metadata.size
-        }
-      }
-    }
-    await visit(root, 0)
+    const inventory = await inspectSkillPackage(root)
+    let count = inventory.length
+    const total = inventory.reduce((sum, file) => sum + file.size, 0)
+    const replacedBytes =
+      inventory.find(({ absolutePath }) => resolve(absolutePath) === resolve(target))?.size ?? 0
     if (!(await exists(target))) count += 1
     if (count > SKILL_IMPORT_LIMITS.maxFiles) throw new Error('draft has too many files')
     if (total - replacedBytes + nextBytes > SKILL_IMPORT_LIMITS.maxTotalBytes) {
@@ -370,7 +424,7 @@ export class HostSkillsService {
     }
   }
 
-  private async edit(params: Params): Promise<unknown> {
+  private async edit(params: Params): Promise<HostSkillEditResult> {
     const requestedName = asString(params.name)?.trim()
     const content = asString(params.content)
     if (!requestedName) throw new Error('name is required')
@@ -392,14 +446,14 @@ export class HostSkillsService {
     let next = content
     if (hasOldString) {
       const oldString = asString(params.old_string)
-      if (!oldString) throw new Error('old_string must be a non-empty string')
+      if (!oldString) throw new Error('oldString must be a non-empty string')
       const current = await readBoundedText(target)
       const first = current.indexOf(oldString)
-      const second = first < 0 ? -1 : current.indexOf(oldString, first + oldString.length)
-      if (first < 0 || second >= 0) throw new Error('old_string must match exactly once')
+      const second = first < 0 ? -1 : current.indexOf(oldString, first + 1)
+      if (first < 0 || second >= 0) throw new Error('oldString must match exactly once')
       next = `${current.slice(0, first)}${content}${current.slice(first + oldString.length)}`
     } else if (await exists(target)) {
-      throw new Error(`${relativePath} already exists; use old_string for an exact replacement`)
+      throw new Error(`${relativePath} already exists; use oldString for an exact replacement`)
     }
 
     await this.validateDraftBudget(root, target, Buffer.byteLength(next))
@@ -414,7 +468,7 @@ export class HostSkillsService {
     return { status: 'edited', name: draft.name, path: relativePath, origin: 'draft' }
   }
 
-  private async publish(params: Params): Promise<unknown> {
+  private async publish(params: Params): Promise<HostSkillPublishResult> {
     const name = asString(params.name)?.trim()
     if (!name || !SAFE_SKILL_NAME.test(name)) throw new Error('a draft name is required')
     const overwrite = params.overwrite === true
@@ -423,7 +477,8 @@ export class HostSkillsService {
     }
     const draft = this.draftDir(name)
     if (!(await exists(draft))) throw new Error(`Unknown draft: ${name}`)
-    await this.validatePackage(draft, name)
+    const validation = await this.validationResult(draft, name, 'draft', name)
+    if (!validation.valid) throw new Error(validation.errors[0]?.message ?? 'Skill is invalid')
 
     const id = await this.options.catalog.publishPersonalDirectory(name, draft, overwrite)
     await rm(draft, { recursive: true, force: true })
@@ -431,7 +486,10 @@ export class HostSkillsService {
     return { status: 'published', id, name, origin: 'personal' }
   }
 
-  private async delete(params: Params, context: TrustedCallingSession): Promise<unknown> {
+  private async delete(
+    params: Params,
+    context: TrustedCallingSession
+  ): Promise<HostSkillDeleteResult> {
     const requestedName = asString(params.name)?.trim()
     if (!requestedName) throw new Error('name is required')
 

--- a/src/main/skills/skill-package-inspection.ts
+++ b/src/main/skills/skill-package-inspection.ts
@@ -1,0 +1,354 @@
+import { lstat, readFile, readdir } from 'node:fs/promises'
+import { join, posix } from 'node:path'
+
+import { marked } from 'marked'
+
+import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
+import { frontmatterFieldNames, parseSkillDocument } from './frontmatter'
+import { isUnsafeSkillArchivePath } from './zip-extract'
+
+const APP_OWNED_ROOT_FILES = new Set(['.source.json', '.specialist-package.json'])
+
+const compareText = (left: string, right: string): number =>
+  left < right ? -1 : left > right ? 1 : 0
+
+export type SkillPackageFile = Readonly<{
+  absolutePath: string
+  relativePath: string
+  size: number
+}>
+
+export type SkillValidationIssue = Readonly<{
+  code: string
+  path: string
+  message: string
+}>
+
+type SkillPackagePolicyReason =
+  | 'unsafePath'
+  | 'symbolicLink'
+  | 'hardLink'
+  | 'unsupportedEntry'
+  | 'depthLimit'
+  | 'fileCountLimit'
+  | 'fileSizeLimit'
+  | 'totalSizeLimit'
+
+const POLICY_DETAILS: Record<SkillPackagePolicyReason, { code: string; message: string }> = {
+  unsafePath: {
+    code: 'unsafePackageEntry',
+    message: 'Skill package contains a path that cannot be handled safely.'
+  },
+  symbolicLink: {
+    code: 'unsafePackageEntry',
+    message: 'Skill package contains a symbolic link.'
+  },
+  hardLink: {
+    code: 'unsafePackageEntry',
+    message: 'Skill package contains a hard link.'
+  },
+  unsupportedEntry: {
+    code: 'unsupportedPackageEntry',
+    message: 'Skill package contains an unsupported filesystem entry.'
+  },
+  depthLimit: {
+    code: 'packageDepthExceeded',
+    message: 'Skill package exceeds the maximum directory depth.'
+  },
+  fileCountLimit: {
+    code: 'packageFileCountExceeded',
+    message: 'Skill package has too many files.'
+  },
+  fileSizeLimit: {
+    code: 'packageFileSizeExceeded',
+    message: 'Skill package contains an oversized file.'
+  },
+  totalSizeLimit: {
+    code: 'packageTotalSizeExceeded',
+    message: 'Skill package exceeds the total size limit.'
+  }
+}
+
+export class SkillPackagePolicyError extends Error {
+  readonly code: string
+
+  constructor(
+    readonly reason: SkillPackagePolicyReason,
+    readonly relativePath: string
+  ) {
+    const details = POLICY_DETAILS[reason]
+    super(details.message)
+    this.name = 'SkillPackagePolicyError'
+    this.code = details.code
+  }
+
+  toIssue(): SkillValidationIssue {
+    return { code: this.code, path: this.relativePath || '.', message: this.message }
+  }
+}
+
+export const inspectSkillPackage = async (root: string): Promise<SkillPackageFile[]> => {
+  const files: SkillPackageFile[] = []
+  let totalBytes = 0
+
+  const visit = async (
+    directory: string,
+    relativeDirectory: string,
+    depth: number
+  ): Promise<void> => {
+    const directoryMetadata = await lstat(directory)
+    if (directoryMetadata.isSymbolicLink()) {
+      throw new SkillPackagePolicyError('symbolicLink', relativeDirectory)
+    }
+    if (!directoryMetadata.isDirectory()) {
+      throw new SkillPackagePolicyError('unsupportedEntry', relativeDirectory)
+    }
+    if (depth > SKILL_IMPORT_LIMITS.maxDepth) {
+      throw new SkillPackagePolicyError('depthLimit', relativeDirectory)
+    }
+
+    const entries = (await readdir(directory, { withFileTypes: true })).sort((left, right) =>
+      compareText(left.name, right.name)
+    )
+    for (const entry of entries) {
+      if (!relativeDirectory && APP_OWNED_ROOT_FILES.has(entry.name)) continue
+      const relativePath = relativeDirectory
+        ? posix.join(relativeDirectory, entry.name)
+        : entry.name
+      if (isUnsafeSkillArchivePath(relativePath)) {
+        throw new SkillPackagePolicyError('unsafePath', relativePath)
+      }
+
+      const absolutePath = join(directory, entry.name)
+      const metadata = await lstat(absolutePath)
+      if (metadata.isSymbolicLink()) {
+        throw new SkillPackagePolicyError('symbolicLink', relativePath)
+      }
+      if (metadata.isDirectory()) {
+        await visit(absolutePath, relativePath, depth + 1)
+        continue
+      }
+      if (!metadata.isFile()) {
+        throw new SkillPackagePolicyError('unsupportedEntry', relativePath)
+      }
+      if (metadata.nlink > 1) throw new SkillPackagePolicyError('hardLink', relativePath)
+
+      if (metadata.size > SKILL_IMPORT_LIMITS.maxFileBytes) {
+        throw new SkillPackagePolicyError('fileSizeLimit', relativePath)
+      }
+      if (files.length + 1 > SKILL_IMPORT_LIMITS.maxFiles) {
+        throw new SkillPackagePolicyError('fileCountLimit', relativePath)
+      }
+      totalBytes += metadata.size
+      if (totalBytes > SKILL_IMPORT_LIMITS.maxTotalBytes) {
+        throw new SkillPackagePolicyError('totalSizeLimit', relativePath)
+      }
+      files.push({ absolutePath, relativePath, size: metadata.size })
+    }
+  }
+
+  await visit(root, '', 0)
+  return files.sort((left, right) => compareText(left.relativePath, right.relativePath))
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.length > 0
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string')
+
+const validTriggerEvals = (value: unknown): boolean =>
+  isRecord(value) &&
+  value.schema_version === 1 &&
+  value.kind === 'trigger' &&
+  Array.isArray(value.cases) &&
+  value.cases.every(
+    (item) =>
+      isRecord(item) &&
+      isNonEmptyString(item.id) &&
+      isNonEmptyString(item.query) &&
+      typeof item.should_trigger === 'boolean'
+  )
+
+const validOutputEvals = (value: unknown): boolean =>
+  isRecord(value) &&
+  value.schema_version === 1 &&
+  isNonEmptyString(value.skill_id) &&
+  isNonEmptyString(value.source_revision) &&
+  Array.isArray(value.evals) &&
+  value.evals.every(
+    (item) =>
+      isRecord(item) &&
+      isNonEmptyString(item.id) &&
+      isNonEmptyString(item.prompt) &&
+      isNonEmptyString(item.expected_output) &&
+      isStringArray(item.files) &&
+      isStringArray(item.expectations)
+  )
+
+const collectMarkdownHrefs = (value: unknown, hrefs: string[]): void => {
+  if (Array.isArray(value)) {
+    for (const item of value) collectMarkdownHrefs(item, hrefs)
+    return
+  }
+  if (!isRecord(value)) return
+  if ((value.type === 'link' || value.type === 'image') && typeof value.href === 'string') {
+    hrefs.push(value.href)
+  }
+  for (const child of Object.values(value)) {
+    if (child && typeof child === 'object') collectMarkdownHrefs(child, hrefs)
+  }
+}
+
+const localMarkdownTarget = (sourcePath: string, rawHref: string): string | undefined => {
+  let href = rawHref.trim()
+  if (href.startsWith('<') && href.endsWith('>')) href = href.slice(1, -1).trim()
+  if (!href || href.startsWith('#') || href.startsWith('/') || href.startsWith('//'))
+    return undefined
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(href)) return undefined
+  href = href.split(/[?#]/, 1)[0] ?? ''
+  if (!href) return undefined
+  try {
+    href = decodeURIComponent(href)
+  } catch {
+    return undefined
+  }
+  const target = posix.normalize(posix.join(posix.dirname(sourcePath), href))
+  return !target || target === '.' || isUnsafeSkillArchivePath(target) ? undefined : target
+}
+
+const compareIssues = (left: SkillValidationIssue, right: SkillValidationIssue): number => {
+  for (const key of ['path', 'code', 'message'] as const) {
+    if (left[key] < right[key]) return -1
+    if (left[key] > right[key]) return 1
+  }
+  return 0
+}
+
+const sortedUniqueIssues = (issues: SkillValidationIssue[]): SkillValidationIssue[] => {
+  const unique = new Map(
+    issues.map((issue) => [`${issue.path}\0${issue.code}\0${issue.message}`, issue])
+  )
+  return [...unique.values()].sort(compareIssues)
+}
+
+export type SkillPackageValidation = Readonly<{
+  name: string
+  files: string[]
+  errors: SkillValidationIssue[]
+  warnings: SkillValidationIssue[]
+}>
+
+export const validateSkillPackage = async (
+  root: string,
+  packageName: string,
+  expectedName?: string
+): Promise<SkillPackageValidation> => {
+  let inventory: SkillPackageFile[]
+  try {
+    inventory = await inspectSkillPackage(root)
+  } catch (error) {
+    if (!(error instanceof SkillPackagePolicyError)) throw error
+    return { name: packageName, files: [], errors: [error.toIssue()], warnings: [] }
+  }
+
+  const files = inventory.map(({ relativePath }) => relativePath)
+  const byPath = new Map(inventory.map((file) => [file.relativePath, file]))
+  const errors: SkillValidationIssue[] = []
+  const warnings: SkillValidationIssue[] = []
+  const skillFile = byPath.get('SKILL.md')
+  if (!skillFile) {
+    errors.push({
+      code: 'missingSkillDocument',
+      path: 'SKILL.md',
+      message: 'Skill package must contain SKILL.md at its root.'
+    })
+  } else {
+    const skillDocument = await readFile(skillFile.absolutePath, 'utf8')
+    const parsed = parseSkillDocument(skillDocument)
+    if (!parsed.name?.trim() || !parsed.description?.trim()) {
+      errors.push({
+        code: 'missingRequiredFrontmatter',
+        path: 'SKILL.md',
+        message: 'SKILL.md requires name and description frontmatter.'
+      })
+    } else {
+      const fieldNames = frontmatterFieldNames(skillDocument).sort()
+      if (
+        (fieldNames.length !== 2 && fieldNames.length !== 3) ||
+        fieldNames[0] !== 'description' ||
+        (fieldNames.length === 3 && fieldNames[1] !== 'displayname') ||
+        fieldNames.at(-1) !== 'name'
+      ) {
+        errors.push({
+          code: 'invalidFrontmatterFields',
+          path: 'SKILL.md',
+          message: 'SKILL.md frontmatter may only contain name, displayName, and description.'
+        })
+      } else if (expectedName && parsed.name.trim() !== expectedName) {
+        errors.push({
+          code: 'nameMismatch',
+          path: 'SKILL.md',
+          message: 'SKILL.md name must match the draft name.'
+        })
+      }
+    }
+    if (!parsed.body.trim()) {
+      warnings.push({
+        code: 'emptyBody',
+        path: 'SKILL.md',
+        message: 'SKILL.md has no instruction body.'
+      })
+    }
+  }
+
+  const fileSet = new Set(files)
+  for (const file of inventory.filter(({ relativePath }) =>
+    relativePath.toLowerCase().endsWith('.md')
+  )) {
+    const hrefs: string[] = []
+    collectMarkdownHrefs(marked.lexer(await readFile(file.absolutePath, 'utf8')), hrefs)
+    for (const href of hrefs) {
+      const target = localMarkdownTarget(file.relativePath, href)
+      if (target && !fileSet.has(target)) {
+        warnings.push({
+          code: 'missingLocalLink',
+          path: file.relativePath,
+          message: `Local Markdown target does not exist: ${target}.`
+        })
+      }
+    }
+  }
+
+  for (const [path, isValid, code] of [
+    ['trigger-evals.json', validTriggerEvals, 'invalidTriggerEvals'],
+    ['evals/evals.json', validOutputEvals, 'invalidOutputEvals']
+  ] as const) {
+    const file = byPath.get(path)
+    if (!file) continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(await readFile(file.absolutePath, 'utf8'))
+    } catch {
+      errors.push({ code: 'invalidJson', path, message: `${path} must contain valid JSON.` })
+      continue
+    }
+    if (!isValid(parsed)) {
+      errors.push({
+        code,
+        path,
+        message: `${path} does not match the supported version 1 structure.`
+      })
+    }
+  }
+
+  return {
+    name: packageName,
+    files,
+    errors: sortedUniqueIssues(errors),
+    warnings: sortedUniqueIssues(warnings)
+  }
+}


### PR DESCRIPTION
## Problem

The existing `host.skills` authoring surface was routed correctly through the JavaScript Kernel REPL, but its package contract was too shallow: `read("SKILL.md")` did not expose a safe recursive inventory, validation was not machine-readable, publish did not share the complete package validator, and the public camelCase/edit semantics were not fully certified at the Adapter and four runtime routes.

## Proposed change

- add one deterministic, bounded package inspector shared by Host Skills validation and Skill export;
- return recursive POSIX `files` only for exact `SKILL.md` reads while rejecting unsafe paths, links, unsupported entries, and package budget violations;
- return structured `validate` reports with deterministic errors and warnings, validate documented eval fixtures and local Markdown targets, and block publish only on errors;
- preserve create-only edits when `oldString` is omitted and require exactly one, including overlapping, match when it is supplied;
- keep public methods, parameters, results, prose, and errors camelCase while mapping `oldString` to private RPC `old_string`;
- certify the shared REPL surface, exact result shapes, publish/delete reload boundary, and fresh Skill materialization for Claude Code, OpenCode, Codex Responses, and Codex bridge routes.

## Scope and non-goals

This keeps `host.skills` behind the existing `repl_execute` / `skillsCall` path. It does not add direct MCP CRUD, a sidecar or runtime eval API, binary/per-file mutation methods, database/schema/data-relation changes, renderer/UI changes, or public snake_case aliases. Local `docs/internal` material is not included.

## Acceptance criteria and validation

The final Test Impact Set ran after the last material edit and was independently reviewed against repository standards and the design.

- Package inventory, validation, edit/publish/delete behavior, JS Adapter projection, RPC auth, four-route capability/materialization, and reload retirement -> `npm test -- src/main/skills/host-skills-service.test.ts src/main/skills/export.test.ts src/main/acp/session-capability-owner.test.ts src/main/settings/backend-resolver.test.ts src/main/agents/customize/skill-creator-package.test.ts src/main/notebook/local-rpc-server.skills.test.ts src/main/notebook/mcp-server.test.ts src/main/acp/runtime-coordinator.test.ts src/main/skills/user-skill-catalog-observer.test.ts src/main/notebook/repl-loop.integration.test.ts` -> 10 files passed; 271 tests passed, 30 skipped.
- Node and web type safety -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed with 0 errors and 11 unrelated baseline warnings.
- Full fallback -> `npm test` -> 14,712 passed, 199 skipped, 2 failed. The R-kernel cancellation case passed immediately when retried alone (1 passed; full-run load flake). The remaining deterministic `settings-backend.architecture.test.ts` failure is unchanged on `origin/main`: `SettingsService` already exposes `listUserSkills`, while its baseline architecture lock omits that method; neither file is changed by this PR.
- Structural consumers -> `codegraph sync`, `codegraph impact HostSkillsService`, and `codegraph impact inspectSkillPackage` -> index current; consumers remain the existing IPC, export, Host owner, and tests.
- Independent final standards/spec reviews -> no remaining actionable high-value findings.

Exact-head CI remains authoritative for portable and platform lanes.

## Review focus

Please focus on the fail-closed filesystem traversal and deterministic issue ordering, the shared validation/publish boundary, the public camelCase/private snake_case seam, and the composed mutation-to-runtime-generation certification.
