### PR TITLE
fix(cli): mount AppImage before running installed command

### DIFF
--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -76,7 +76,7 @@ describe('planCliLauncher', () => {
     expect(plan.shim).toContain("OPEN_SCIENCE_APP_PATH='/opt/a b/$(x)`y`\\z/o'\\''brien'")
   })
 
-  it('uses the stable AppImage file and resolves the CLI entry after the current mount starts', () => {
+  it('mounts the stable AppImage without passing Node flags through AppRun', () => {
     const plan = planCliLauncher(
       posixEnv({
         appExecPath: '/tmp/.mount_open-scienceOLD/open-science',
@@ -85,23 +85,25 @@ describe('planCliLauncher', () => {
       })
     )
 
-    expect(plan.shim).toContain(
-      "OPEN_SCIENCE_APP_PATH='/home/alice/Open Science'\\''s build.AppImage'"
-    )
-    expect(plan.shim).toContain("exec '/home/alice/Open Science'\\''s build.AppImage' -e")
-    expect(plan.shim).toContain('process.resourcesPath')
-    expect(plan.shim).toContain('process.argv.slice(1)')
-    expect(plan.shim).toContain(' -- "$@"')
+    expect(plan.shim).toContain("app_image='/home/alice/Open Science'\\''s build.AppImage'")
+    expect(plan.shim).toContain('"$app_image" --appimage-mount')
+    expect(plan.shim).toContain('app_exec="$mount_dir"/\'open-science\'')
+    expect(plan.shim).toContain('cli_entry="$mount_dir"/\'resources/cli/index.mjs\'')
+    expect(plan.shim).toContain('"$app_exec" "$cli_entry" "$@"')
+    expect(plan.shim).not.toContain(' -e ')
     expect(plan.shim).not.toContain('/tmp/.mount_open-scienceOLD')
   })
 
-  it('preserves a leading CLI flag after terminating Node runtime options', () => {
-    const probe = spawnSync(
-      process.execPath,
-      ['-e', 'process.stdout.write(JSON.stringify(process.argv.slice(1)))', '--', '--help'],
-      { encoding: 'utf8' }
-    )
-    expect(probe).toMatchObject({ status: 0, stdout: '["--help"]' })
+  it('rejects AppImage payload paths outside the current mount', () => {
+    expect(() =>
+      planCliLauncher(
+        posixEnv({
+          appExecPath: '/tmp/.mount_open-science/open-science',
+          cliEntryPath: '/opt/Open Science/resources/cli/index.mjs',
+          appImagePath: '/home/alice/Open Science.AppImage'
+        })
+      )
+    ).toThrow('inside the current AppImage mount')
   })
 
   it('targets a per-user bin dir with a .cmd shim on Windows', () => {
@@ -235,6 +237,65 @@ pdescribe('AppImage launcher reconciliation (POSIX)', () => {
     expect(await isCliShimStale(appImageEnv())).toBe(false)
   })
 
+  it('runs the CLI through the mounted payload and cleans up the mount process', async () => {
+    const mountDir = join(home, 'mounted AppImage')
+    const appImagePath = join(home, "Open Science's build.AppImage")
+    const resultPath = join(home, 'cli-result.txt')
+    const stoppedPath = join(home, 'mount-stopped.txt')
+    const cliDir = join(mountDir, 'resources', 'cli')
+    await mkdir(cliDir, { recursive: true })
+    await writeFile(
+      appImagePath,
+      [
+        '#!/bin/sh',
+        '[ "$1" = "--appimage-mount" ] || exit 90',
+        'printf "%s\\n" "$FAKE_MOUNT_DIR"',
+        'trap \'printf stopped > "$FAKE_STOPPED"; exit 0\' 1 2 15',
+        'while :; do sleep 0.05; done'
+      ].join('\n'),
+      { mode: 0o755 }
+    )
+    await writeFile(
+      join(mountDir, 'open-science'),
+      [
+        '#!/bin/sh',
+        'printf "%s\\n" "$OPEN_SCIENCE_APP_PATH" > "$FAKE_RESULT"',
+        'printf "%s\\n" "$ELECTRON_RUN_AS_NODE" >> "$FAKE_RESULT"',
+        'printf "%s\\n" "$@" >> "$FAKE_RESULT"',
+        'exit 23'
+      ].join('\n'),
+      { mode: 0o755 }
+    )
+    await writeFile(join(cliDir, 'index.mjs'), '')
+
+    const env = appImageEnv({
+      appExecPath: '/tmp/.mount_current/open-science',
+      cliEntryPath: '/tmp/.mount_current/resources/cli/index.mjs',
+      appImagePath
+    })
+    await installCliLauncher(env)
+    const run = spawnSync(planCliLauncher(env).target, ['--help', 'two words'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        FAKE_MOUNT_DIR: mountDir,
+        FAKE_RESULT: resultPath,
+        FAKE_STOPPED: stoppedPath
+      },
+      timeout: 10_000
+    })
+
+    expect(run).toMatchObject({ status: 23, signal: null })
+    expect((await readFile(resultPath, 'utf8')).trim().split('\n')).toEqual([
+      appImagePath,
+      '1',
+      join(mountDir, 'resources', 'cli', 'index.mjs'),
+      '--help',
+      'two words'
+    ])
+    await expect(readFile(stoppedPath, 'utf8')).resolves.toBe('stopped')
+  })
+
   it('detects and migrates a legacy shim that pins an old FUSE mount', async () => {
     await installCliLauncher(posixEnv())
     const env = appImageEnv()
@@ -244,7 +305,7 @@ pdescribe('AppImage launcher reconciliation (POSIX)', () => {
     expect(result).toMatchObject({ installed: true })
 
     const shim = await readFile(result!.target, 'utf8')
-    expect(shim).toContain("OPEN_SCIENCE_APP_PATH='/home/alice/Open Science.AppImage'")
+    expect(shim).toContain("app_image='/home/alice/Open Science.AppImage'")
     expect(shim).not.toContain('/tmp/.mount_open-scienceNEW')
   })
 
@@ -255,7 +316,7 @@ pdescribe('AppImage launcher reconciliation (POSIX)', () => {
     expect(await isCliShimStale(moved)).toBe(true)
     await ensureCliLauncherCurrent(moved)
     expect(await readFile(planCliLauncher(moved).target, 'utf8')).toContain(
-      "OPEN_SCIENCE_APP_PATH='/home/alice/Applications/Open Science.AppImage'"
+      "app_image='/home/alice/Applications/Open Science.AppImage'"
     )
   })
 

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process'
 import { access, chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, posix } from 'node:path'
 
 import type { CliLauncherStatus } from '../../shared/cli'
 
@@ -42,20 +42,24 @@ const isOnPath = (binDir: string, pathVar: string, platform: NodeJS.Platform): b
     .some((entry) => entry === binDir)
 }
 
-// AppImage exposes APPIMAGE as the stable bundle path and APPDIR/process paths inside its ephemeral
-// FUSE mount. Start the stable bundle in Node mode, then resolve the CLI entry from the new process's
-// resourcesPath so the launcher remains usable while the desktop app is not running.
-const appImageCliBootstrap = [
-  "Promise.all([import('node:path'), import('node:url')])",
-  '.then(([{ join }, { pathToFileURL }]) =>',
-  "import(pathToFileURL(join(process.resourcesPath, 'cli', 'index.mjs')).href))",
-  '.then(({ reportCliError, runCli }) => runCli(process.argv.slice(1)).catch(reportCliError))',
-  '.catch((error) => { console.error(error instanceof Error ? error.message : error);',
-  'process.exitCode = 1 })'
-].join('')
-
 const isLinuxAppImage = (env: CliLauncherEnv): boolean =>
   env.platform === 'linux' && env.packaged && Boolean(env.appImagePath)
+
+// electron-builder's AppRun may prepend --no-sandbox before user arguments when user namespaces are
+// unavailable. Node mode rejects that Chromium flag before it can reach a script argument. Ask the
+// AppImage runtime to mount and wait instead, then invoke the payload directly for the lifetime of the
+// CLI process so AppRun never gets a chance to rewrite the Node argument list.
+const appImagePayloadPaths = (env: CliLauncherEnv): { executable: string; cliEntry: string } => {
+  const currentMount = posix.dirname(env.appExecPath)
+  const executable = posix.relative(currentMount, env.appExecPath)
+  const cliEntry = posix.relative(currentMount, env.cliEntryPath)
+  const isInsideMount = (path: string): boolean =>
+    path.length > 0 && !posix.isAbsolute(path) && path !== '..' && !path.startsWith('../')
+  if (!isInsideMount(executable) || !isInsideMount(cliEntry)) {
+    throw new Error('AppImage CLI paths must be inside the current AppImage mount.')
+  }
+  return { executable, cliEntry }
+}
 
 // POSIX: a /bin/sh shim in ~/.local/bin. Single-quote every path so it survives spaces and shell
 // metacharacters: inside single quotes nothing is special (no $, backtick, or backslash expansion),
@@ -64,16 +68,61 @@ const isLinuxAppImage = (env: CliLauncherEnv): boolean =>
 // $/backtick and need backslash handling.
 const posixShim = (env: CliLauncherEnv): string => {
   const quote = (value: string): string => `'${value.replace(/'/g, "'\\''")}'`
-  const command = isLinuxAppImage(env) ? env.appImagePath! : env.appExecPath
-  const appPathLine = env.packaged ? `OPEN_SCIENCE_APP_PATH=${quote(command)} ` : ''
-  const args = isLinuxAppImage(env)
-    ? `-e ${quote(appImageCliBootstrap)} -- "$@"`
-    : `${quote(env.cliEntryPath)} "$@"`
+  if (isLinuxAppImage(env)) {
+    const { executable, cliEntry } = appImagePayloadPaths(env)
+    return [
+      '#!/bin/sh',
+      '# Open Science command-line launcher. Managed by the app (Settings -> General -> Command line',
+      '# tool); edits will be overwritten on reinstall. Mounts the AppImage for this CLI process.',
+      `app_image=${quote(env.appImagePath!)}`,
+      'mount_output=$(mktemp "${TMPDIR:-/tmp}/open-science-cli.XXXXXX") || {',
+      "  echo 'Open Science could not create a temporary file for the AppImage mount.' >&2",
+      '  exit 1',
+      '}',
+      'mount_pid=',
+      'cleanup() {',
+      '  if [ -n "$mount_pid" ]; then',
+      '    kill "$mount_pid" 2>/dev/null || :',
+      '    wait "$mount_pid" 2>/dev/null || :',
+      '  fi',
+      '  rm -f "$mount_output"',
+      '}',
+      'trap cleanup 0',
+      "trap 'exit 129' 1",
+      "trap 'exit 130' 2",
+      "trap 'exit 143' 15",
+      '"$app_image" --appimage-mount >"$mount_output" &',
+      'mount_pid=$!',
+      'while [ ! -s "$mount_output" ]; do',
+      '  if ! kill -0 "$mount_pid" 2>/dev/null; then',
+      '    wait "$mount_pid"',
+      '    mount_status=$?',
+      '    if [ "$mount_status" -eq 0 ]; then mount_status=1; fi',
+      "    echo 'Open Science AppImage exited before reporting its mount point.' >&2",
+      '    exit "$mount_status"',
+      '  fi',
+      '  sleep 0.05',
+      'done',
+      'mount_dir=$(sed -n \'1p\' "$mount_output")',
+      `app_exec="$mount_dir"/${quote(executable)}`,
+      `cli_entry="$mount_dir"/${quote(cliEntry)}`,
+      'if [ ! -x "$app_exec" ] || [ ! -f "$cli_entry" ]; then',
+      "  echo 'Open Science AppImage is missing its executable or CLI entry.' >&2",
+      '  exit 1',
+      'fi',
+      'OPEN_SCIENCE_APP_PATH="$app_image" ELECTRON_RUN_AS_NODE=1 \\',
+      '  "$app_exec" "$cli_entry" "$@"',
+      'status=$?',
+      'exit "$status"',
+      ''
+    ].join('\n')
+  }
+  const appPathLine = env.packaged ? `OPEN_SCIENCE_APP_PATH=${quote(env.appExecPath)} ` : ''
   return [
     '#!/bin/sh',
     '# Open Science command-line launcher. Managed by the app (Settings -> General -> Command line',
     "# tool); edits will be overwritten on reinstall. Runs the app's Electron in Node mode.",
-    `${appPathLine}ELECTRON_RUN_AS_NODE=1 exec ${quote(command)} ${args}`,
+    `${appPathLine}ELECTRON_RUN_AS_NODE=1 exec ${quote(env.appExecPath)} ${quote(env.cliEntryPath)} "$@"`,
     ''
   ].join('\n')
 }
@@ -210,7 +259,7 @@ export const getCliLauncherStatus = async (env: CliLauncherEnv): Promise<CliLaun
 }
 
 // Only an existing app-managed AppImage launcher is eligible for automatic migration. Comparing the
-// complete planned content covers the stable AppImage path, bootstrap, and CLI entry behavior.
+// complete planned content covers the stable AppImage path, mount procedure, and CLI entry behavior.
 export const isCliShimStale = async (env: CliLauncherEnv): Promise<boolean> => {
   if (!isLinuxAppImage(env)) return false
   const plan = planCliLauncher(env)


### PR DESCRIPTION
## Summary

- replace the AppImage `-e` launcher with a runtime-managed `--appimage-mount` flow;
- invoke the mounted Electron binary and bundled `resources/cli/index.mjs` directly in Node mode;
- keep the stable `APPIMAGE` path for later desktop launches and tear down the mount when the CLI exits;
- preserve full-content reconciliation and the app-managed launcher guard;
- add path-containment checks plus a Linux behavior test for argument forwarding, exit status, and mount cleanup.

## Root cause

The generated electron-builder AppRun conditionally prepends `--no-sandbox` when `unshare -Ur` is unavailable. With `ELECTRON_RUN_AS_NODE=1`, Node sees that Chromium flag before either `-e` or a script-file argument and exits with `bad option: --no-sandbox`.

The launcher now asks the AppImage runtime to mount and wait, then runs the payload executable directly. This bypasses AppRun argument rewriting without pinning an ephemeral `/tmp/.mount_*` path.

This supersedes the reverted approach in #1187 and retains the stable-path goal from #1150.

## User impact

The Settings-installed `open-science` command remains usable after the desktop app exits and across later AppImage remounts. User-managed launchers at the same path are not rewritten by startup reconciliation.

## Validation

- `npm test -- src/main/cli-install/launcher.test.ts src/main/cli-install/ipc.test.ts src/main/application-command-wiring.test.ts`: 26 passed, 11 POSIX tests skipped on the Windows host
- `npm run typecheck:node`: passed
- `npm run lint -- --no-cache`: 0 errors, 10 pre-existing warnings outside this change
- `git diff --check`: passed
- full `npm test`: attempted; unrelated current-main failures remain, including Windows symlink `EPERM`, long-test timeouts, and a Settings interface snapshot mismatch introduced outside these files

Linux CI is expected to execute the POSIX fake-runtime behavior test that is skipped on Windows.

Closes #1185
