### PR TITLE
feat(reviewer): add configurable model routing

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -130,7 +130,9 @@
     },
     "reviewer_orchestrator": {
       "ownerPaths": [
+        "src/main/reviewer/acp-runtime.ts",
         "src/main/reviewer/orchestrator.ts",
+        "src/main/reviewer/model-runtime-owner.ts",
         "src/main/reviewer/review-assessment-owner.ts",
         "src/main/reviewer/reviewer-fix-loop-owner.ts",
         "src/main/reviewer/reviewer-session-driver.ts"
@@ -144,6 +146,7 @@
       "testFiles": {
         "owner": [
           "src/main/reviewer/reviewer-orchestrator.architecture.test.ts",
+          "src/main/reviewer/model-runtime-owner.test.ts",
           "src/main/reviewer/review-assessment-owner.test.ts",
           "src/main/reviewer/orchestrator.test.ts",
           "src/main/reviewer/orchestrator-drive.test.ts",
@@ -442,7 +445,11 @@
       "fallbackCapability": "main_runtime"
     },
     "settings_service_facade": {
-      "ownerPaths": ["src/main/settings/service.ts", "src/main/settings/subagent-model-owner.ts"],
+      "ownerPaths": [
+        "src/main/settings/service.ts",
+        "src/main/settings/reviewer-model-owner.ts",
+        "src/main/settings/subagent-model-owner.ts"
+      ],
       "interfacePaths": [
         "src/main/settings/service.ts",
         "src/main/settings/application-commands.ts",

--- a/src/main/acp/generation-activity-owner.test.ts
+++ b/src/main/acp/generation-activity-owner.test.ts
@@ -23,12 +23,14 @@ describe('AcpGenerationActivityOwner', () => {
     const activity = owner.withActivity(() => release.promise)
 
     expect(owner.blockers()).toEqual({ reconnect: true, retirement: true })
+    expect(owner.blocksLiveEffortChange()).toBe(true)
     expect(Object.isFrozen(owner.blockers())).toBe(true)
 
     release.resolve()
     await activity
 
     expect(owner.blockers()).toEqual({ reconnect: false, retirement: false })
+    expect(owner.blocksLiveEffortChange()).toBe(false)
     expect(activityChanged).toHaveBeenCalledOnce()
   })
 
@@ -48,6 +50,7 @@ describe('AcpGenerationActivityOwner', () => {
     const operation = owner.withOperation(() => failed)
 
     expect(owner.blockers()).toEqual({ reconnect: false, retirement: true })
+    expect(owner.blocksLiveEffortChange()).toBe(false)
     reject(boom)
     await expect(operation).rejects.toBe(boom)
 
@@ -89,6 +92,7 @@ describe('AcpGenerationActivityOwner', () => {
 
     owner.acquireStartup(token)
     expect(owner.blockers()).toEqual({ reconnect: true, retirement: true })
+    expect(owner.blocksLiveEffortChange()).toBe(false)
 
     owner.releaseStartup(token)
     owner.releaseStartup(token)

--- a/src/main/acp/generation-activity-owner.ts
+++ b/src/main/acp/generation-activity-owner.ts
@@ -21,16 +21,20 @@ export class AcpGenerationActivityOwner {
   constructor(private readonly options: AcpGenerationActivityOwnerOptions) {}
 
   blockers(): AcpGenerationActivityBlockers {
-    const reconnect =
-      this.options.hasActivePrompts() ||
-      this.options.hasActiveReviewerSessions() ||
-      this.additionalActivity?.() === true ||
-      this.activityLeaseCount > 0 ||
-      this.startupTokens.size > 0
+    const reconnect = this.blocksLiveEffortChange() || this.startupTokens.size > 0
     return Object.freeze({
       reconnect,
       retirement: reconnect || this.operationLeaseCount > 0
     })
+  }
+
+  blocksLiveEffortChange(): boolean {
+    return (
+      this.options.hasActivePrompts() ||
+      this.options.hasActiveReviewerSessions() ||
+      this.additionalActivity?.() === true ||
+      this.activityLeaseCount > 0
+    )
   }
 
   bindAdditionalActivity(probe: () => boolean): void {

--- a/src/main/acp/runtime-activity.ts
+++ b/src/main/acp/runtime-activity.ts
@@ -12,7 +12,8 @@ export type AcpRuntimeActivityOptions = {
 export type AcpRuntimeActivity = Pick<
   AcpRuntime,
   'buildReviewerSession' | 'disposeReviewerSession' | 'sendPrompt'
->
+> &
+  Partial<Pick<AcpRuntime, 'captureBackend'>>
 
 export type AcpRuntimeActivityOwner = {
   withActivity: <T>(

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -2767,23 +2767,29 @@ describe('AcpRuntimeCoordinator', () => {
     })
     const oldActivityStarted = createDeferred()
     const releaseOldActivity = createDeferred()
+    let oldBackendId: string | undefined
+    let newBackendId: string | undefined
 
     const oldActivity = coordinator.withActivity({}, async (runtime) => {
       oldActivityStarted.resolve()
       await releaseOldActivity.promise
+      oldBackendId = runtime.captureBackend?.().backendId
       await runtime.buildReviewerSession({ cwd: '/workspace', mcpServers: [] })
     })
     await oldActivityStarted.promise
 
     await coordinator.requestAgentFrameworkSwitch()
-    await coordinator.withActivity({}, (runtime) =>
-      runtime.buildReviewerSession({ cwd: '/workspace', mcpServers: [] })
-    )
+    await coordinator.withActivity({}, (runtime) => {
+      newBackendId = runtime.captureBackend?.().backendId
+      return runtime.buildReviewerSession({ cwd: '/workspace', mcpServers: [] })
+    })
     releaseOldActivity.resolve()
     await oldActivity
 
     expect(vi.mocked(created[0].runtime.buildReviewerSession)).toHaveBeenCalledOnce()
     expect(vi.mocked(created[1].runtime.buildReviewerSession)).toHaveBeenCalledOnce()
+    expect(oldBackendId).toBe('claude-code:owned')
+    expect(newBackendId).toBe('codex:owned')
   })
 
   it('lazily adopts the main session on the pinned runtime only when an activity sends a prompt', async () => {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -1070,6 +1070,7 @@ class AcpRuntimeCoordinator {
     }
 
     return {
+      captureBackend: () => runtime.captureBackend(),
       buildReviewerSession: (request) => this.buildReviewerSessionOnRuntime(runtime, request),
       disposeReviewerSession: (session) => {
         this.reviewerRuntimes.delete(session)

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -22981,6 +22981,30 @@ describe('ACP runtime — session effort', () => {
     expect(fakeAgent.configChanges[1]).toMatchObject({ configId: 'effort', value: 'high' })
   })
 
+  it('keeps an admitted background activity on its original reasoning effort', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['s-effort-activity'], {
+      configOptions: [thoughtLevelOption(['default', 'low', 'high'])]
+    })
+    const runtime = createEffortRuntime(process, 'low')
+    const activityStarted = createDeferred()
+    const finishActivity = createDeferred()
+    await runtime.createSession({ cwd: '/workspace' })
+    fakeAgent.configChanges.length = 0
+
+    const activity = runtime.withActivity({}, async () => {
+      activityStarted.resolve()
+      await finishActivity.promise
+    })
+    await activityStarted.promise
+
+    await expect(runtime.applyReasoningEffortChange('high')).resolves.toBe(false)
+    expect(fakeAgent.configChanges).toEqual([])
+
+    finishActivity.resolve()
+    await activity
+  })
+
   it('keeps a session created concurrently with a live effort change on the new level', async () => {
     const process = new FakeAgentProcess()
     const staleConfigurationStarted = createDeferred()

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -676,16 +676,14 @@ class AcpRuntime {
     return this.modelChanges.apply(target)
   }
 
-  // Live-applies a reasoning-effort change to every open session — the ACP equivalent of a model
-  // switch, no respawn. Returns false when the active framework only carries effort in its baked
-  // spawn config (opencode advertises no thought_level option), or when applying to a session
-  // genuinely failed — the caller then falls back to the provider-switch reconnect rather than
-  // leaving the UI showing a level the agent never received. All sessions are attempted even after
-  // a failure, so the set never straddles two levels longer than the reconnect takes. Sessions that
-  // simply advertise no effort option are skipped (a reconnect could not give their model one
-  // either). On success the generation view tracks the new level, so sessions created later in
-  // this process inherit it; the persisted setting covers the next respawn.
+  // Live-applies a reasoning-effort change to every open session when the generation is idle. A
+  // prompt or background activity keeps its admitted model/effort immutable; returning false lets
+  // the settings workflow defer the new persisted effort through its reconnect path. The same
+  // fallback covers frameworks that carry effort only in baked spawn config and genuine live-update
+  // failures. On success the generation view tracks the new level, so sessions created later in this
+  // process inherit it; the persisted setting covers the next respawn.
   async applyReasoningEffortChange(effort: ResolvedReasoningEffort): Promise<boolean> {
+    if (!this.modelChanges.barrier && this.generationActivity.blockers().reconnect) return false
     return this.modelChanges.applyReasoningEffort(effort)
   }
 

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -683,7 +683,7 @@ class AcpRuntime {
   // failures. On success the generation view tracks the new level, so sessions created later in this
   // process inherit it; the persisted setting covers the next respawn.
   async applyReasoningEffortChange(effort: ResolvedReasoningEffort): Promise<boolean> {
-    if (!this.modelChanges.barrier && this.generationActivity.blockers().reconnect) return false
+    if (!this.modelChanges.barrier && this.generationActivity.blocksLiveEffortChange()) return false
     return this.modelChanges.applyReasoningEffort(effort)
   }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -157,6 +157,7 @@ import {
   registerReviewerIpcHandlers,
   type ReviewerCommandOwner
 } from './reviewer/ipc'
+import { ReviewerModelRuntimeOwner } from './reviewer/model-runtime-owner'
 import {
   createDefaultReviewRepository,
   createDefaultSessionRepository,
@@ -2567,8 +2568,25 @@ const createApplicationModules = async (
   // and 'reviewer:get-for-session' so the renderer's fire-and-forget reviewer calls resolve to
   // real handlers instead of no-ops. Passing the already-constructed AcpRuntime so the reviewer
   // can spawn sessions under the same agent connection.
+  const reviewerModelRuntime = await modules.add(
+    {
+      appVersion: app.getVersion(),
+      captureModel: () => settingsService.admitReviewerExecutionModel(),
+      resolveTarget: (target, context) =>
+        settingsService.resolveExplicitAgentBackend(target, context)
+    },
+    (options) => {
+      const owner = new ReviewerModelRuntimeOwner(options)
+      return {
+        name: 'reviewer-model-runtime',
+        capability: owner,
+        dispose: () => owner.shutdown()
+      }
+    }
+  )
   const reviewerOptions = {
     acpRuntime: runtime,
+    modelRuntime: reviewerModelRuntime,
     mcpEntryPath: mainEntryPath,
     artifactProvenanceRepository,
     withSessionMutation: <Result>(

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2052,8 +2052,25 @@ const createApplicationModules = async (
   permissionGrantRegistry.subscribe(() => runtime.notifyPermissionGrantsChanged())
   // Single shared teardown owner for both the before-quit handler (index.ts) and the pre-update-install
   // gate. Update handling is deliberately constructed below, after this dependency is complete.
+  let reviewerModelRuntimeShutdown:
+    Pick<ReviewerModelRuntimeOwner, 'shutdown' | 'shutdownForUpdateGate'> | undefined
   const shutdownCoordinator = new BackendShutdownCoordinator({
-    runtime,
+    runtime: {
+      shutdownForQuit: async () => {
+        const [main, reviewer] = await Promise.all([
+          runtime.shutdownForQuit(),
+          reviewerModelRuntimeShutdown?.shutdown() ?? Promise.resolve({ reaped: true })
+        ])
+        return { reaped: main.reaped && reviewer.reaped }
+      },
+      shutdownForUpdateGate: async () => {
+        const [main, reviewer] = await Promise.all([
+          runtime.shutdownForUpdateGate(),
+          reviewerModelRuntimeShutdown?.shutdownForUpdateGate() ?? Promise.resolve({ reaped: true })
+        ])
+        return { reaped: main.reaped && reviewer.reaped }
+      }
+    },
     notebook: notebookService,
     log: createLogger('shutdown')
   })
@@ -2577,10 +2594,20 @@ const createApplicationModules = async (
     },
     (options) => {
       const owner = new ReviewerModelRuntimeOwner(options)
+      reviewerModelRuntimeShutdown = owner
       return {
         name: 'reviewer-model-runtime',
         capability: owner,
-        dispose: () => owner.shutdown()
+        disposeTimeoutMs: QUIT_SHUTDOWN_BUDGET_MS,
+        dispose: async () => {
+          try {
+            if (!(await owner.shutdown()).reaped) {
+              throw new BackendShutdownOutcomeError('degraded')
+            }
+          } finally {
+            if (reviewerModelRuntimeShutdown === owner) reviewerModelRuntimeShutdown = undefined
+          }
+        }
       }
     }
   )

--- a/src/main/reviewer/acp-runtime.ts
+++ b/src/main/reviewer/acp-runtime.ts
@@ -11,6 +11,7 @@ export type ReviewerAcpRuntime = Pick<
   AcpRuntime,
   'buildReviewerSession' | 'disposeReviewerSession' | 'sendPrompt'
 > &
+  Partial<Pick<AcpRuntime, 'captureBackend'>> &
   Partial<AcpRuntimeActivityOwner>
 
 export const withReviewerRuntimeActivity = <T>(

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -170,6 +170,33 @@ describe('reviewer IPC handlers', () => {
     expect(passed.artifactStorageRoot).not.toBe(CONFIG_ROOT)
   })
 
+  it('uses the Main-process Reviewer model admission instead of the renderer model label', async () => {
+    const fixedReviewerRuntime = {} as AcpRuntime
+    const release = vi.fn(async () => undefined)
+    const modelRuntime = {
+      admit: vi.fn(async () => ({
+        model: 'reviewer-model',
+        reviewerAcpRuntime: fixedReviewerRuntime,
+        release
+      }))
+    }
+    const owner = createReviewerCommandOwner({ acpRuntime, modelRuntime })
+
+    await expect(owner.run({ ...createRequest(), model: 'renderer-model' })).resolves.toEqual({
+      started: true
+    })
+    await vi.waitFor(() => expect(release).toHaveBeenCalledOnce())
+
+    const passed = runReview.mock.calls[0][0] as {
+      acpRuntime: AcpRuntime
+      reviewerAcpRuntime?: AcpRuntime
+      model: string
+    }
+    expect(passed.acpRuntime).toBe(acpRuntime)
+    expect(passed.reviewerAcpRuntime).toBe(fixedReviewerRuntime)
+    expect(passed.model).toBe('reviewer-model')
+  })
+
   it('lets injected options override the config/data split independently', async () => {
     runReview.mockClear()
     // Reset the captured-roots recorders so this test only observes its own wiring.

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -86,6 +86,15 @@ type ReviewerIpcOptions = {
     sessionId: string,
     mutation: () => Promise<Result>
   ) => Promise<Result>
+  modelRuntime?: Readonly<{
+    admit: () => Promise<
+      Readonly<{
+        model: string
+        reviewerAcpRuntime?: ReviewerAcpRuntime
+        release: () => Promise<void>
+      }>
+    >
+  }>
 }
 
 type ReviewerCommandOwner = Readonly<{
@@ -161,7 +170,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
       evidenceScope,
       projectId,
       mainSessionId,
-      model
+      model: rendererModel
     } = request
 
     // Reserve the turn SYNCHRONOUSLY (before any await) so a double-click / multiple stale cards can't
@@ -245,6 +254,26 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
 
     log.info('review triggered', { sessionId, turnMessageId })
 
+    let modelAdmission: Awaited<
+      ReturnType<NonNullable<ReviewerIpcOptions['modelRuntime']>['admit']>
+    >
+    try {
+      modelAdmission = options.modelRuntime
+        ? await options.modelRuntime.admit()
+        : {
+            model: rendererModel ?? '',
+            release: async () => undefined
+          }
+    } catch (error) {
+      inFlightReviewKeys.delete(inFlightKey)
+      log.error('review start failed: model admission failed', {
+        sessionId,
+        turnMessageId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      return { started: false, reason: 'run-failed' }
+    }
+
     let releaseDataRootWriter: (() => void) | undefined
     try {
       // The review can publish immutable scope snapshots after `triggerReview` has already returned
@@ -253,6 +282,13 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
       releaseDataRootWriter = acquireDataRootWriter()
     } catch {
       inFlightReviewKeys.delete(inFlightKey)
+      await modelAdmission.release().catch((error: unknown) => {
+        log.error('review start cleanup failed', {
+          sessionId,
+          turnMessageId,
+          error: error instanceof Error ? error.message : String(error)
+        })
+      })
       return { started: false, reason: 'run-failed' }
     }
 
@@ -281,7 +317,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
         evidenceScope,
         projectId,
         mainSessionId,
-        model: model ?? '',
+        model: modelAdmission.model,
         // Reload on every orchestrator request. In particular, the post-correction read must observe
         // the newly persisted [Auditor] and agent messages instead of the review-start snapshot.
         getSession: loadCurrentSession,
@@ -290,6 +326,9 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
           ? (mutation) => options.withSessionMutation!(projectId, sessionId, mutation)
           : undefined,
         acpRuntime: options.acpRuntime,
+        ...(modelAdmission.reviewerAcpRuntime
+          ? { reviewerAcpRuntime: modelAdmission.reviewerAcpRuntime }
+          : {}),
         // Artifacts live under the relocatable data root; DB/sessions stay on the config root.
         artifactStorageRoot: dataRoot,
         artifactVersionContentResolver: (request) =>
@@ -333,12 +372,19 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
             error: error instanceof Error ? error.message : String(error)
           })
         })
-        .finally(() => {
+        .finally(async () => {
           // If the run ended without ever signalling onStarted, no review actually began — this is a
           // genuine pre-push failure (scope/insert), not a persistence race, so it is not auto-retried.
           settle({ started: false, reason: 'run-failed' })
           inFlightReviewKeys.delete(inFlightKey)
           releaseDataRootWriter?.()
+          await modelAdmission.release().catch((error: unknown) => {
+            log.error('review runtime cleanup failed', {
+              sessionId,
+              turnMessageId,
+              error: error instanceof Error ? error.message : String(error)
+            })
+          })
         })
     })
   }

--- a/src/main/reviewer/model-runtime-owner.test.ts
+++ b/src/main/reviewer/model-runtime-owner.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AcpRuntime, AcpRuntimeOptions } from '../acp/runtime'
+import type { ResolvedAgentBackend } from '../agent-framework'
+import { ReviewerModelRuntimeOwner } from './model-runtime-owner'
+
+describe('ReviewerModelRuntimeOwner', () => {
+  it.each([
+    {
+      path: 'claude-code',
+      frameworkId: 'claude-code',
+      modelRoute: 'claude-anthropic'
+    },
+    {
+      path: 'opencode',
+      frameworkId: 'opencode',
+      modelRoute: 'opencode-openai'
+    },
+    {
+      path: 'codex-response',
+      frameworkId: 'codex',
+      modelRoute: 'codex-responses'
+    },
+    {
+      path: 'codex-response-compatibility',
+      frameworkId: 'codex',
+      modelRoute: 'codex-responses-compatibility'
+    },
+    {
+      path: 'codex-bridge',
+      frameworkId: 'codex',
+      modelRoute: 'codex-bridge'
+    }
+  ] as const)(
+    'owns an isolated runtime without rewriting the $path backend',
+    async ({ path, frameworkId, modelRoute }) => {
+      const shutdownForQuit = vi.fn(async () => [])
+      const fixedRuntime = {
+        buildReviewerSession: vi.fn(),
+        disposeReviewerSession: vi.fn(),
+        sendPrompt: vi.fn(),
+        shutdownForQuit
+      } as unknown as AcpRuntime
+      let runtimeOptions: AcpRuntimeOptions | undefined
+      const target = {
+        frameworkId,
+        providerId: `${path}-reviewer-provider`,
+        model: { kind: 'required' as const, id: `${path}-reviewer-model` },
+        reasoningEffort: 'high' as const
+      }
+      const backend = {
+        framework: { id: frameworkId },
+        modelRoute,
+        executablePath: '/agent',
+        env: {},
+        contextUsageModel: target.model.id
+      } as ResolvedAgentBackend
+      const resolveTarget = vi.fn(async () => backend)
+      const owner = new ReviewerModelRuntimeOwner({
+        appVersion: 'test',
+        captureModel: async () => ({ model: target.model.id, fixedTarget: target }),
+        resolveTarget,
+        createRuntime: (options) => {
+          runtimeOptions = options
+          return fixedRuntime
+        }
+      })
+
+      const admission = await owner.admit()
+
+      expect(admission.model).toBe(target.model.id)
+      expect(admission.reviewerAcpRuntime).toBe(fixedRuntime)
+      expect(
+        runtimeOptions?.resolveBackend?.({
+          forcedSkillIds: [],
+          systemPromptAppends: ['reviewer rubric']
+        })
+      ).toBe(backend)
+      expect(resolveTarget).toHaveBeenCalledWith(target, {
+        forcedSkillIds: [],
+        systemPromptAppends: []
+      })
+      expect(() =>
+        runtimeOptions?.resolveBackend?.({ forcedSkillIds: [], systemPromptAppends: [] })
+      ).toThrow('no longer available')
+
+      await admission.release()
+      expect(shutdownForQuit).toHaveBeenCalledOnce()
+    }
+  )
+
+  it('shuts down every admitted runtime and closes further admission', async () => {
+    const shutdownForQuit = vi.fn(async () => [])
+    const releaseBridge = vi.fn(async () => undefined)
+    const fixedRuntime = {
+      buildReviewerSession: vi.fn(),
+      disposeReviewerSession: vi.fn(),
+      sendPrompt: vi.fn(),
+      shutdownForQuit
+    } as unknown as AcpRuntime
+    const target = {
+      frameworkId: 'claude-code' as const,
+      providerId: 'reviewer-provider',
+      model: { kind: 'required' as const, id: 'reviewer-model' },
+      reasoningEffort: 'high' as const
+    }
+    const owner = new ReviewerModelRuntimeOwner({
+      appVersion: 'test',
+      captureModel: async () => ({ model: 'reviewer-model', fixedTarget: target }),
+      resolveTarget: vi.fn(
+        async () =>
+          ({
+            framework: { id: 'claude-code' },
+            executablePath: '/agent',
+            env: {},
+            responsesBridgeLease: { release: releaseBridge }
+          }) as unknown as ResolvedAgentBackend
+      ),
+      createRuntime: () => fixedRuntime
+    })
+
+    const admission = await owner.admit()
+    await owner.shutdown()
+
+    expect(shutdownForQuit).toHaveBeenCalledOnce()
+    expect(releaseBridge).toHaveBeenCalledOnce()
+    await admission.release()
+    expect(shutdownForQuit).toHaveBeenCalledOnce()
+    await expect(owner.admit()).rejects.toThrow('shutting down')
+  })
+
+  it('releases a fixed backend that resolves after shutdown starts', async () => {
+    let finishResolution: ((backend: ResolvedAgentBackend) => void) | undefined
+    const releaseBridge = vi.fn(async () => undefined)
+    const resolution = new Promise<ResolvedAgentBackend>((resolve) => {
+      finishResolution = resolve
+    })
+    const createRuntime = vi.fn()
+    const resolveTarget = vi.fn(() => resolution)
+    const owner = new ReviewerModelRuntimeOwner({
+      appVersion: 'test',
+      captureModel: async () => ({
+        model: 'reviewer-model',
+        fixedTarget: {
+          frameworkId: 'claude-code',
+          providerId: 'reviewer-provider',
+          model: { kind: 'required', id: 'reviewer-model' },
+          reasoningEffort: 'high'
+        }
+      }),
+      resolveTarget,
+      createRuntime
+    })
+
+    const admission = owner.admit()
+    await vi.waitFor(() => expect(resolveTarget).toHaveBeenCalledOnce())
+    let shutdownFinished = false
+    const shutdown = owner.shutdown().then(() => {
+      shutdownFinished = true
+    })
+    await Promise.resolve()
+    expect(shutdownFinished).toBe(false)
+    finishResolution?.({
+      framework: { id: 'claude-code' },
+      executablePath: '/agent',
+      env: {},
+      responsesBridgeLease: { release: releaseBridge }
+    } as unknown as ResolvedAgentBackend)
+
+    await expect(admission).rejects.toThrow('shutting down')
+    await shutdown
+    expect(releaseBridge).toHaveBeenCalledOnce()
+    expect(createRuntime).not.toHaveBeenCalled()
+  })
+
+  it('makes shutdown await a release that is already closing its runtime', async () => {
+    let finishRuntimeShutdown: (() => void) | undefined
+    const runtimeShutdown = new Promise<void>((resolve) => {
+      finishRuntimeShutdown = resolve
+    })
+    const shutdownForQuit = vi.fn(() => runtimeShutdown)
+    const fixedRuntime = {
+      buildReviewerSession: vi.fn(),
+      disposeReviewerSession: vi.fn(),
+      sendPrompt: vi.fn(),
+      shutdownForQuit
+    } as unknown as AcpRuntime
+    const owner = new ReviewerModelRuntimeOwner({
+      appVersion: 'test',
+      captureModel: async () => ({
+        model: 'reviewer-model',
+        fixedTarget: {
+          frameworkId: 'claude-code',
+          providerId: 'reviewer-provider',
+          model: { kind: 'required', id: 'reviewer-model' },
+          reasoningEffort: 'high'
+        }
+      }),
+      resolveTarget: vi.fn(
+        async () =>
+          ({
+            framework: { id: 'claude-code' },
+            executablePath: '/agent',
+            env: {}
+          }) as ResolvedAgentBackend
+      ),
+      createRuntime: () => fixedRuntime
+    })
+    const admission = await owner.admit()
+
+    const release = admission.release()
+    await vi.waitFor(() => expect(shutdownForQuit).toHaveBeenCalledOnce())
+    let shutdownFinished = false
+    const shutdown = owner.shutdown().then(() => {
+      shutdownFinished = true
+    })
+    await Promise.resolve()
+    expect(shutdownFinished).toBe(false)
+
+    finishRuntimeShutdown?.()
+    await Promise.all([release, shutdown])
+    expect(shutdownForQuit).toHaveBeenCalledOnce()
+  })
+
+  it('turns an unavailable fixed backend into an actionable Reviewer runtime failure', async () => {
+    const createRuntime = vi.fn()
+    const owner = new ReviewerModelRuntimeOwner({
+      appVersion: 'test',
+      captureModel: async () => ({
+        model: 'removed-model',
+        fixedTarget: {
+          frameworkId: 'codex',
+          providerId: 'removed-provider',
+          model: { kind: 'required', id: 'removed-model' },
+          reasoningEffort: 'high'
+        }
+      }),
+      resolveTarget: vi.fn(async () => {
+        throw new Error('No active model provider is configured.')
+      }),
+      createRuntime
+    })
+
+    const admission = await owner.admit()
+
+    expect(admission.model).toBe('removed-model')
+    expect(createRuntime).not.toHaveBeenCalled()
+    await expect(
+      admission.reviewerAcpRuntime?.buildReviewerSession({ cwd: '/work', mcpServers: [] })
+    ).rejects.toThrow(
+      'The configured Reviewer model is unavailable: No active model provider is configured.'
+    )
+  })
+
+  it('keeps Follow Active on the existing scoped runtime path', async () => {
+    const createRuntime = vi.fn()
+    const owner = new ReviewerModelRuntimeOwner({
+      appVersion: 'test',
+      captureModel: async () => ({ model: 'active-model' }),
+      resolveTarget: vi.fn(),
+      createRuntime
+    })
+
+    const admission = await owner.admit()
+
+    expect(admission.model).toBe('active-model')
+    expect(admission.reviewerAcpRuntime).toBeUndefined()
+    expect(createRuntime).not.toHaveBeenCalled()
+    await admission.release()
+  })
+})

--- a/src/main/reviewer/model-runtime-owner.test.ts
+++ b/src/main/reviewer/model-runtime-owner.test.ts
@@ -174,7 +174,11 @@ describe('ReviewerModelRuntimeOwner', () => {
   })
 
   it('uses a non-latching update gate before admitting a fresh runtime', async () => {
-    const firstShutdown = vi.fn(async () => ({ reaped: true }))
+    let finishFirstShutdown: ((outcome: { reaped: boolean }) => void) | undefined
+    const firstShutdownOutcome = new Promise<{ reaped: boolean }>((resolve) => {
+      finishFirstShutdown = resolve
+    })
+    const firstShutdown = vi.fn(() => firstShutdownOutcome)
     const secondShutdown = vi.fn(async () => ({ reaped: true }))
     const runtimes = [firstShutdown, secondShutdown].map(
       (shutdownForQuit) =>
@@ -213,8 +217,13 @@ describe('ReviewerModelRuntimeOwner', () => {
 
     const firstAdmission = await owner.admit()
 
-    await expect(owner.shutdownForUpdateGate()).resolves.toEqual({ reaped: true })
-    expect(firstShutdown).toHaveBeenCalledOnce()
+    const updateGate = owner.shutdownForUpdateGate()
+    await vi.waitFor(() => expect(firstShutdown).toHaveBeenCalledOnce())
+    await expect(owner.admit()).rejects.toThrow(
+      'Reviewer cannot start while an update is preparing to install.'
+    )
+    finishFirstShutdown?.({ reaped: true })
+    await expect(updateGate).resolves.toEqual({ reaped: true })
     await firstAdmission.release()
     expect(firstShutdown).toHaveBeenCalledOnce()
 

--- a/src/main/reviewer/model-runtime-owner.test.ts
+++ b/src/main/reviewer/model-runtime-owner.test.ts
@@ -53,7 +53,7 @@ describe('ReviewerModelRuntimeOwner', () => {
         modelRoute,
         executablePath: '/agent',
         env: {},
-        contextUsageModel: target.model.id
+        contextUsageModel: `${target.model.id}-tokenizer`
       } as ResolvedAgentBackend
       const resolveTarget = vi.fn(async () => backend)
       const owner = new ReviewerModelRuntimeOwner({

--- a/src/main/reviewer/model-runtime-owner.test.ts
+++ b/src/main/reviewer/model-runtime-owner.test.ts
@@ -34,7 +34,7 @@ describe('ReviewerModelRuntimeOwner', () => {
   ] as const)(
     'owns an isolated runtime without rewriting the $path backend',
     async ({ path, frameworkId, modelRoute }) => {
-      const shutdownForQuit = vi.fn(async () => [])
+      const shutdownForQuit = vi.fn(async () => ({ reaped: true }))
       const fixedRuntime = {
         buildReviewerSession: vi.fn(),
         disposeReviewerSession: vi.fn(),
@@ -90,7 +90,7 @@ describe('ReviewerModelRuntimeOwner', () => {
   )
 
   it('shuts down every admitted runtime and closes further admission', async () => {
-    const shutdownForQuit = vi.fn(async () => [])
+    const shutdownForQuit = vi.fn(async () => ({ reaped: true }))
     const releaseBridge = vi.fn(async () => undefined)
     const fixedRuntime = {
       buildReviewerSession: vi.fn(),
@@ -173,9 +173,60 @@ describe('ReviewerModelRuntimeOwner', () => {
     expect(createRuntime).not.toHaveBeenCalled()
   })
 
+  it('uses a non-latching update gate before admitting a fresh runtime', async () => {
+    const firstShutdown = vi.fn(async () => ({ reaped: true }))
+    const secondShutdown = vi.fn(async () => ({ reaped: true }))
+    const runtimes = [firstShutdown, secondShutdown].map(
+      (shutdownForQuit) =>
+        ({
+          buildReviewerSession: vi.fn(),
+          disposeReviewerSession: vi.fn(),
+          sendPrompt: vi.fn(),
+          shutdownForQuit
+        }) as unknown as AcpRuntime
+    )
+    const owner = new ReviewerModelRuntimeOwner({
+      appVersion: 'test',
+      captureModel: async () => ({
+        model: 'reviewer-model',
+        fixedTarget: {
+          frameworkId: 'claude-code',
+          providerId: 'reviewer-provider',
+          model: { kind: 'required', id: 'reviewer-model' },
+          reasoningEffort: 'high'
+        }
+      }),
+      resolveTarget: vi.fn(
+        async () =>
+          ({
+            framework: { id: 'claude-code' },
+            executablePath: '/agent',
+            env: {}
+          }) as ResolvedAgentBackend
+      ),
+      createRuntime: vi.fn(() => {
+        const runtime = runtimes.shift()
+        if (!runtime) throw new Error('Unexpected Reviewer runtime creation.')
+        return runtime
+      })
+    })
+
+    const firstAdmission = await owner.admit()
+
+    await expect(owner.shutdownForUpdateGate()).resolves.toEqual({ reaped: true })
+    expect(firstShutdown).toHaveBeenCalledOnce()
+    await firstAdmission.release()
+    expect(firstShutdown).toHaveBeenCalledOnce()
+
+    const secondAdmission = await owner.admit()
+    expect(secondAdmission.reviewerAcpRuntime).toBeDefined()
+    await expect(owner.shutdown()).resolves.toEqual({ reaped: true })
+    expect(secondShutdown).toHaveBeenCalledOnce()
+  })
+
   it('makes shutdown await a release that is already closing its runtime', async () => {
-    let finishRuntimeShutdown: (() => void) | undefined
-    const runtimeShutdown = new Promise<void>((resolve) => {
+    let finishRuntimeShutdown: ((outcome: { reaped: boolean }) => void) | undefined
+    const runtimeShutdown = new Promise<{ reaped: boolean }>((resolve) => {
       finishRuntimeShutdown = resolve
     })
     const shutdownForQuit = vi.fn(() => runtimeShutdown)
@@ -217,7 +268,7 @@ describe('ReviewerModelRuntimeOwner', () => {
     await Promise.resolve()
     expect(shutdownFinished).toBe(false)
 
-    finishRuntimeShutdown?.()
+    finishRuntimeShutdown?.({ reaped: true })
     await Promise.all([release, shutdown])
     expect(shutdownForQuit).toHaveBeenCalledOnce()
   })

--- a/src/main/reviewer/model-runtime-owner.ts
+++ b/src/main/reviewer/model-runtime-owner.ts
@@ -70,8 +70,13 @@ class ReviewerModelRuntimeOwner {
   }
 
   admit(): Promise<ReviewerModelRuntimeAdmission> {
-    const updateGate = this.updateGatePromise
-    if (updateGate) return updateGate.then(() => this.admit())
+    if (this.updateGatePromise) {
+      return Promise.reject(
+        new Error(
+          'Reviewer cannot start while an update is preparing to install. Retry if the update does not proceed.'
+        )
+      )
+    }
     const admission = this.admitOwned()
     const settled = admission.then(
       () => undefined,

--- a/src/main/reviewer/model-runtime-owner.ts
+++ b/src/main/reviewer/model-runtime-owner.ts
@@ -1,0 +1,175 @@
+import { homedir } from 'node:os'
+
+import { releaseResolvedAgentBackendLeases, type ResolvedAgentBackend } from '../agent-framework'
+import type {
+  AgentBackendResolutionContext,
+  ExplicitAgentBackendTarget
+} from '../settings/backend-resolver'
+import { composeAcpRuntimeBaseOwners } from '../acp/runtime-base-composition'
+import { composeAcpRuntimeSessionOwners } from '../acp/runtime-session-composition'
+import { AcpRuntime, type AcpRuntimeOptions } from '../acp/runtime'
+import type { ReviewerAcpRuntime } from './acp-runtime'
+
+type CapturedReviewerModel = Readonly<{
+  model: string
+  fixedTarget?: ExplicitAgentBackendTarget
+}>
+
+type OwnedReviewerAcpRuntime = ReviewerAcpRuntime & Pick<AcpRuntime, 'shutdownForQuit'>
+
+type ActiveReviewerRuntime = Readonly<{
+  runtime: OwnedReviewerAcpRuntime
+  close: () => Promise<void>
+}>
+
+type ReviewerModelRuntimeAdmission = Readonly<{
+  model: string
+  reviewerAcpRuntime?: ReviewerAcpRuntime
+  release: () => Promise<void>
+}>
+
+type ReviewerModelRuntimeOwnerOptions = Readonly<{
+  appVersion: string
+  captureModel: () => Promise<CapturedReviewerModel>
+  resolveTarget: (
+    target: ExplicitAgentBackendTarget,
+    context: AgentBackendResolutionContext
+  ) => Promise<ResolvedAgentBackend>
+  createRuntime?: (options: AcpRuntimeOptions) => OwnedReviewerAcpRuntime
+}>
+
+const createRuntime = (options: AcpRuntimeOptions): OwnedReviewerAcpRuntime => {
+  const base = composeAcpRuntimeBaseOwners(options)
+  return new AcpRuntime(options, base, composeAcpRuntimeSessionOwners(options, base))
+}
+
+const unavailableRuntime = (error: unknown): ReviewerAcpRuntime => {
+  const detail = error instanceof Error ? error.message : String(error)
+  const fail = async (): Promise<never> => {
+    throw new Error(`The configured Reviewer model is unavailable: ${detail}`)
+  }
+  return Object.freeze({
+    buildReviewerSession: fail,
+    disposeReviewerSession: () => ({
+      rejectedToolCalls: 0,
+      reviewerBridgeScoped: undefined
+    }),
+    sendPrompt: fail
+  })
+}
+
+class ReviewerModelRuntimeOwner {
+  private readonly runtimeFactory: NonNullable<ReviewerModelRuntimeOwnerOptions['createRuntime']>
+  private readonly activeRuntimes = new Set<ActiveReviewerRuntime>()
+  private readonly pendingAdmissions = new Set<Promise<void>>()
+  private shuttingDown = false
+
+  constructor(private readonly options: ReviewerModelRuntimeOwnerOptions) {
+    this.runtimeFactory = options.createRuntime ?? createRuntime
+  }
+
+  admit(): Promise<ReviewerModelRuntimeAdmission> {
+    const admission = this.admitOwned()
+    const settled = admission.then(
+      () => undefined,
+      () => undefined
+    )
+    this.pendingAdmissions.add(settled)
+    void settled.finally(() => this.pendingAdmissions.delete(settled))
+    return admission
+  }
+
+  private async admitOwned(): Promise<ReviewerModelRuntimeAdmission> {
+    if (this.shuttingDown) throw new Error('Reviewer model runtime is shutting down.')
+    const captured = await this.options.captureModel()
+    if (this.shuttingDown) throw new Error('Reviewer model runtime is shutting down.')
+    if (!captured.fixedTarget) {
+      return Object.freeze({ model: captured.model, release: async () => undefined })
+    }
+
+    const target = captured.fixedTarget
+    let backend: ResolvedAgentBackend
+    try {
+      backend = await this.options.resolveTarget(target, {
+        forcedSkillIds: [],
+        systemPromptAppends: []
+      })
+    } catch (error) {
+      if (this.shuttingDown) throw new Error('Reviewer model runtime is shutting down.')
+      return Object.freeze({
+        model: captured.model,
+        reviewerAcpRuntime: unavailableRuntime(error),
+        release: async () => undefined
+      })
+    }
+    if (this.shuttingDown) {
+      await releaseResolvedAgentBackendLeases(backend)
+      throw new Error('Reviewer model runtime is shutting down.')
+    }
+
+    let claimed = false
+    let runtime: OwnedReviewerAcpRuntime
+    try {
+      runtime = this.runtimeFactory({
+        appVersion: this.options.appVersion,
+        defaultCwd: homedir(),
+        resolveBackend: () => {
+          if (claimed) {
+            throw new Error('The admitted Reviewer backend connection is no longer available.')
+          }
+          claimed = true
+          return backend
+        }
+      })
+    } catch (error) {
+      await releaseResolvedAgentBackendLeases(backend)
+      throw error
+    }
+
+    let closePromise: Promise<void> | undefined
+    const active: ActiveReviewerRuntime = Object.freeze({
+      runtime,
+      close: () => {
+        closePromise ??= (async () => {
+          try {
+            await runtime.shutdownForQuit()
+          } finally {
+            if (!claimed) await releaseResolvedAgentBackendLeases(backend)
+          }
+        })()
+        return closePromise
+      }
+    })
+    this.activeRuntimes.add(active)
+    return Object.freeze({
+      model: backend.contextUsageModel ?? captured.model,
+      reviewerAcpRuntime: runtime,
+      release: async () => {
+        if (!this.activeRuntimes.has(active)) return
+        try {
+          await active.close()
+        } finally {
+          this.activeRuntimes.delete(active)
+        }
+      }
+    })
+  }
+
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true
+    await Promise.all([...this.pendingAdmissions])
+    const runtimes = [...this.activeRuntimes]
+    try {
+      await Promise.all(runtimes.map((runtime) => runtime.close()))
+    } finally {
+      for (const runtime of runtimes) this.activeRuntimes.delete(runtime)
+    }
+  }
+}
+
+export { ReviewerModelRuntimeOwner }
+export type {
+  CapturedReviewerModel,
+  ReviewerModelRuntimeAdmission,
+  ReviewerModelRuntimeOwnerOptions
+}

--- a/src/main/reviewer/model-runtime-owner.ts
+++ b/src/main/reviewer/model-runtime-owner.ts
@@ -19,7 +19,7 @@ type OwnedReviewerAcpRuntime = ReviewerAcpRuntime & Pick<AcpRuntime, 'shutdownFo
 
 type ActiveReviewerRuntime = Readonly<{
   runtime: OwnedReviewerAcpRuntime
-  close: () => Promise<void>
+  close: () => Promise<{ reaped: boolean }>
 }>
 
 type ReviewerModelRuntimeAdmission = Readonly<{
@@ -62,6 +62,7 @@ class ReviewerModelRuntimeOwner {
   private readonly runtimeFactory: NonNullable<ReviewerModelRuntimeOwnerOptions['createRuntime']>
   private readonly activeRuntimes = new Set<ActiveReviewerRuntime>()
   private readonly pendingAdmissions = new Set<Promise<void>>()
+  private updateGatePromise: Promise<{ reaped: boolean }> | undefined
   private shuttingDown = false
 
   constructor(private readonly options: ReviewerModelRuntimeOwnerOptions) {
@@ -69,6 +70,8 @@ class ReviewerModelRuntimeOwner {
   }
 
   admit(): Promise<ReviewerModelRuntimeAdmission> {
+    const updateGate = this.updateGatePromise
+    if (updateGate) return updateGate.then(() => this.admit())
     const admission = this.admitOwned()
     const settled = admission.then(
       () => undefined,
@@ -126,13 +129,13 @@ class ReviewerModelRuntimeOwner {
       throw error
     }
 
-    let closePromise: Promise<void> | undefined
+    let closePromise: Promise<{ reaped: boolean }> | undefined
     const active: ActiveReviewerRuntime = Object.freeze({
       runtime,
       close: () => {
         closePromise ??= (async () => {
           try {
-            await runtime.shutdownForQuit()
+            return await runtime.shutdownForQuit()
           } finally {
             if (!claimed) await releaseResolvedAgentBackendLeases(backend)
           }
@@ -155,14 +158,40 @@ class ReviewerModelRuntimeOwner {
     })
   }
 
-  async shutdown(): Promise<void> {
+  shutdownForUpdateGate(): Promise<{ reaped: boolean }> {
+    if (this.shuttingDown) return this.shutdown()
+    if (this.updateGatePromise) return this.updateGatePromise
+
+    const gate = this.closeActiveRuntimes()
+    this.updateGatePromise = gate
+    void gate.finally(() => {
+      if (this.updateGatePromise === gate) this.updateGatePromise = undefined
+    })
+    return gate
+  }
+
+  async shutdown(): Promise<{ reaped: boolean }> {
     this.shuttingDown = true
+    const updateGateOutcome = await this.updateGatePromise
+    const activeOutcome = await this.closeActiveRuntimes()
+    return {
+      reaped: (updateGateOutcome?.reaped ?? true) && activeOutcome.reaped
+    }
+  }
+
+  private async closeActiveRuntimes(): Promise<{ reaped: boolean }> {
     await Promise.all([...this.pendingAdmissions])
     const runtimes = [...this.activeRuntimes]
+    let outcomes: PromiseSettledResult<{ reaped: boolean }>[] = []
     try {
-      await Promise.all(runtimes.map((runtime) => runtime.close()))
+      outcomes = await Promise.allSettled(runtimes.map((runtime) => runtime.close()))
     } finally {
       for (const runtime of runtimes) this.activeRuntimes.delete(runtime)
+    }
+    return {
+      reaped: outcomes.every(
+        (outcome) => outcome.status === 'fulfilled' && outcome.value.reaped === true
+      )
     }
   }
 }

--- a/src/main/reviewer/model-runtime-owner.ts
+++ b/src/main/reviewer/model-runtime-owner.ts
@@ -150,7 +150,7 @@ class ReviewerModelRuntimeOwner {
     })
     this.activeRuntimes.add(active)
     return Object.freeze({
-      model: backend.contextUsageModel ?? captured.model,
+      model: captured.model,
       reviewerAcpRuntime: runtime,
       release: async () => {
         if (!this.activeRuntimes.has(active)) return

--- a/src/main/reviewer/orchestrator-prompt-prefix.test.ts
+++ b/src/main/reviewer/orchestrator-prompt-prefix.test.ts
@@ -347,7 +347,7 @@ describe('runScopedReview — framework-neutral rubric delivery (fix-loop re-rev
     // buildReviewerSession is called twice: once for the initial review (submit a warn finding so the
     // fix loop runs, no prefix), once for the scoped re-review (return a prefix + capture the prompt).
     let buildCall = 0
-    const runtime = {
+    const reviewerRuntime = {
       buildReviewerSession: async (request: { mcpServers: unknown[] }) => {
         buildCall += 1
         if (buildCall === 1) {
@@ -369,7 +369,9 @@ describe('runScopedReview — framework-neutral rubric delivery (fix-loop re-rev
         }
         return { session: makeFakeReviewerSession(scopedPromptSink), promptPrefix: scopedPrefix }
       },
-      disposeReviewerSession: () => ({ rejectedToolCalls: 0, reviewerBridgeScoped: undefined }),
+      disposeReviewerSession: () => ({ rejectedToolCalls: 0, reviewerBridgeScoped: undefined })
+    } as unknown as AcpRuntime
+    const runtime = {
       // The [Auditor] correction turn: append the auditor user turn + the agent's correction turn so
       // the fix loop resolves a new correctionTurnMessageId (msg-4-correction) for the scoped review.
       sendPrompt: async () => {
@@ -413,6 +415,7 @@ describe('runScopedReview — framework-neutral rubric delivery (fix-loop re-rev
       getSession: () => currentSession,
       reviewRepository: repository,
       acpRuntime: runtime,
+      reviewerAcpRuntime: reviewerRuntime,
       artifactStorageRoot: temporaryRoot!,
       fixLoopMaxRounds: 1
     })

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -59,8 +59,11 @@ export type RunReviewOptions = {
   // Joins every durable Review write to the Session deletion/save ordering boundary without holding
   // the lock while the remote reviewer model is running.
   runSessionMutation?: ReviewMutationRunner
-  // The ACP runtime that owns the agent connection (used to spawn the reviewer session).
+  // The ACP runtime that owns the main Agent connection and correction turns.
   acpRuntime: ReviewerAcpRuntime
+  // Optional fixed-model runtime used only for Reviewer sessions. When absent, Reviewer sessions
+  // use the scoped main runtime selected at Review-chain start.
+  reviewerAcpRuntime?: ReviewerAcpRuntime
   // Storage root for artifact reads (used by the scope-bounded evidence reader).
   artifactStorageRoot: string
   // Native Version resolver for current provenance rows. Tests and legacy callers may omit it and
@@ -128,6 +131,7 @@ const runReviewWithSession = async (
     reviewRepository,
     runSessionMutation,
     acpRuntime,
+    reviewerAcpRuntime = acpRuntime,
     artifactStorageRoot,
     artifactVersionContentResolver,
     reviewerMcpEntryPath,
@@ -156,7 +160,7 @@ const runReviewWithSession = async (
     projectId,
     reviewRepository,
     runSessionMutation,
-    acpRuntime,
+    acpRuntime: reviewerAcpRuntime,
     artifactStorageRoot,
     artifactVersionContentResolver,
     reviewerMcpEntryPath,
@@ -186,6 +190,7 @@ const runReviewWithSession = async (
         reviewRepository,
         runSessionMutation,
         acpRuntime,
+        reviewerAcpRuntime,
         artifactStorageRoot,
         artifactVersionContentResolver,
         reviewerMcpEntryPath,

--- a/src/main/reviewer/review-assessment-owner.test.ts
+++ b/src/main/reviewer/review-assessment-owner.test.ts
@@ -152,13 +152,19 @@ const makeRepository = (): ReviewRepository =>
     })
   }) as unknown as ReviewRepository
 
-const runtime = (runtimeModel?: string): AcpRuntime =>
+const runtime = (contextModel?: string, sessionModel?: string): AcpRuntime =>
   ({
-    ...(runtimeModel
+    ...(contextModel || sessionModel
       ? {
           captureBackend: () => ({
-            context: { model: runtimeModel, supportsImageInput: false },
-            session: { modelRequired: false }
+            context: {
+              ...(contextModel ? { model: contextModel } : {}),
+              supportsImageInput: false
+            },
+            session: {
+              ...(sessionModel ? { model: sessionModel } : {}),
+              modelRequired: false
+            }
           })
         }
       : {}),
@@ -271,6 +277,20 @@ describe('review assessment owner', () => {
     expect(updates).toContainEqual(
       expect.objectContaining({ lifecycle: 'running', model: 'actual-runtime-model' })
     )
+  })
+
+  it('records the selected session model instead of the context tokenization model', async () => {
+    const reviewRepository = makeRepository()
+
+    await runReviewAssessment({
+      ...commonOptions(reviewRepository),
+      acpRuntime: runtime('tokenization-model', 'selected-runtime-model'),
+      mode: 'initial'
+    })
+
+    expect(reviewRepository.updateReview).toHaveBeenCalledWith('assessment-review', {
+      model: 'selected-runtime-model'
+    })
   })
 
   it('disposes a built session when the pinned model cannot be persisted', async () => {

--- a/src/main/reviewer/review-assessment-owner.test.ts
+++ b/src/main/reviewer/review-assessment-owner.test.ts
@@ -152,8 +152,16 @@ const makeRepository = (): ReviewRepository =>
     })
   }) as unknown as ReviewRepository
 
-const runtime = (): AcpRuntime =>
+const runtime = (runtimeModel?: string): AcpRuntime =>
   ({
+    ...(runtimeModel
+      ? {
+          captureBackend: () => ({
+            context: { model: runtimeModel, supportsImageInput: false },
+            session: { modelRequired: false }
+          })
+        }
+      : {}),
     buildReviewerSession: async () => {
       outsideMutation('acp:build')
       return {
@@ -244,6 +252,49 @@ describe('review assessment owner', () => {
       'write:commit',
       'mutation:end'
     ])
+  })
+
+  it('reconciles the Review model with the backend pinned by the runtime', async () => {
+    const reviewRepository = makeRepository()
+    const updates: ReviewWithChecks[] = []
+
+    await runReviewAssessment({
+      ...commonOptions(reviewRepository),
+      acpRuntime: runtime('actual-runtime-model'),
+      mode: 'initial',
+      onReviewUpdate: (value) => updates.push(value)
+    })
+
+    expect(reviewRepository.updateReview).toHaveBeenCalledWith('assessment-review', {
+      model: 'actual-runtime-model'
+    })
+    expect(updates).toContainEqual(
+      expect.objectContaining({ lifecycle: 'running', model: 'actual-runtime-model' })
+    )
+  })
+
+  it('disposes a built session when the pinned model cannot be persisted', async () => {
+    const reviewRepository = makeRepository()
+    const updateReview = vi.mocked(reviewRepository.updateReview)
+    const persistUpdate = updateReview.getMockImplementation()
+    updateReview.mockImplementation(async (id, patch) => {
+      if (patch.model) {
+        insideMutation('write:model-error')
+        throw new Error('model persistence failed')
+      }
+      if (!persistUpdate) throw new Error('missing repository test implementation')
+      return persistUpdate(id, patch)
+    })
+
+    const result = await runReviewAssessment({
+      ...commonOptions(reviewRepository),
+      acpRuntime: runtime('actual-runtime-model'),
+      mode: 'initial'
+    })
+
+    expect(result.review.lifecycle).toBe('error')
+    expect(result.review.errorMessage).toBe('model persistence failed')
+    expect(harness.events).toContain('acp:dispose')
   })
 
   it('stops MCP independently and preserves session then bridge error precedence', async () => {

--- a/src/main/reviewer/review-assessment-owner.ts
+++ b/src/main/reviewer/review-assessment-owner.ts
@@ -220,7 +220,7 @@ export const runReviewAssessment = async (
     })
     reviewerSession = built.session
     const backend = acpRuntime.captureBackend?.()
-    const runtimeModel = backend?.context.model ?? backend?.session.model
+    const runtimeModel = backend?.session.model ?? backend?.context.model
     if (runtimeModel && runtimeModel !== review.model) {
       review = await runReviewMutation(runSessionMutation, () =>
         reviewRepository.updateReview(review.id, { model: runtimeModel })

--- a/src/main/reviewer/review-assessment-owner.ts
+++ b/src/main/reviewer/review-assessment-owner.ts
@@ -219,6 +219,14 @@ export const runReviewAssessment = async (
       systemPromptAppend: REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND
     })
     reviewerSession = built.session
+    const backend = acpRuntime.captureBackend?.()
+    const runtimeModel = backend?.context.model ?? backend?.session.model
+    if (runtimeModel && runtimeModel !== review.model) {
+      review = await runReviewMutation(runSessionMutation, () =>
+        reviewRepository.updateReview(review.id, { model: runtimeModel })
+      )
+      onReviewUpdate?.({ ...review, checks: [] })
+    }
     if (options.mode === 'initial') {
       log.info('reviewer session started', { sessionId: reviewerSession.sessionId })
     }

--- a/src/main/reviewer/reviewer-fix-loop-owner.ts
+++ b/src/main/reviewer/reviewer-fix-loop-owner.ts
@@ -43,7 +43,10 @@ type ReviewerFixLoopOptions = {
   getSession: SessionProvider
   reviewRepository: ReviewRepository
   runSessionMutation?: ReviewMutationRunner
+  // Main Agent runtime used for [Auditor] correction turns.
   acpRuntime: ReviewerAcpRuntime
+  // Runtime pinned for every scoped Reviewer re-assessment in this chain.
+  reviewerAcpRuntime?: ReviewerAcpRuntime
   artifactStorageRoot: string
   artifactVersionContentResolver?: ArtifactVersionContentResolver
   reviewerMcpEntryPath?: string
@@ -111,6 +114,7 @@ export const runReviewerFixLoop = async (options: ReviewerFixLoopOptions): Promi
     reviewRepository,
     runSessionMutation,
     acpRuntime,
+    reviewerAcpRuntime = acpRuntime,
     artifactStorageRoot,
     artifactVersionContentResolver,
     reviewerMcpEntryPath,
@@ -301,7 +305,7 @@ export const runReviewerFixLoop = async (options: ReviewerFixLoopOptions): Promi
       projectId,
       reviewRepository,
       runSessionMutation,
-      acpRuntime,
+      acpRuntime: reviewerAcpRuntime,
       artifactStorageRoot,
       artifactVersionContentResolver,
       reviewerMcpEntryPath,

--- a/src/main/reviewer/reviewer-orchestrator.architecture.test.ts
+++ b/src/main/reviewer/reviewer-orchestrator.architecture.test.ts
@@ -430,7 +430,9 @@ describe('Reviewer orchestrator architecture', () => {
 
     expect(module).toEqual({
       ownerPaths: [
+        'src/main/reviewer/acp-runtime.ts',
         'src/main/reviewer/orchestrator.ts',
+        'src/main/reviewer/model-runtime-owner.ts',
         'src/main/reviewer/review-assessment-owner.ts',
         'src/main/reviewer/reviewer-fix-loop-owner.ts',
         'src/main/reviewer/reviewer-session-driver.ts'
@@ -444,6 +446,7 @@ describe('Reviewer orchestrator architecture', () => {
       testFiles: {
         owner: [
           architectureTestPath,
+          'src/main/reviewer/model-runtime-owner.test.ts',
           'src/main/reviewer/review-assessment-owner.test.ts',
           'src/main/reviewer/orchestrator.test.ts',
           'src/main/reviewer/orchestrator-drive.test.ts',

--- a/src/main/settings/application-commands.test.ts
+++ b/src/main/settings/application-commands.test.ts
@@ -52,6 +52,7 @@ const expectedChannels = [
   'settings:set-package-mirror',
   'settings:set-network-proxy',
   'settings:set-project-files-filter',
+  'settings:set-reviewer-model',
   'settings:set-subagent-model',
   'settings:validate-provider'
 ] as const
@@ -116,7 +117,7 @@ const createDependencies = (): Readonly<{
 }
 
 describe('Settings core application commands', () => {
-  it('installs the exact 36-command inventory and dispatches a remote-safe preflight query', async () => {
+  it('installs the exact 39-command inventory and dispatches a remote-safe preflight query', async () => {
     const { dependencies, serviceMethod } = createDependencies()
     const preflight = { agentReady: true }
     serviceMethod('getPreflight').mockResolvedValue(preflight)
@@ -169,6 +170,7 @@ describe('Settings core application commands', () => {
     await invoke('previewSkillZip', [{ dataBase64: 'AA==' }])
     await invoke('refreshProviderModels', [{ providerId: 'provider-1' }])
     await invoke('scanRepoSkills', [{ repo: 'org/repo' }])
+    await invoke('setReviewerModel', [{ configuration: { mode: 'inherit' } }])
     await invoke('setSubagentModel', [{ configuration: { mode: 'inherit' } }])
     await invoke('validateProvider', [{ providerId: 'provider-1' }])
 
@@ -186,6 +188,7 @@ describe('Settings core application commands', () => {
       providerId: 'provider-1'
     })
     expect(serviceMethod('scanRepoSkills')).toHaveBeenCalledWith({ repo: 'org/repo' })
+    expect(serviceMethod('setReviewerModel')).toHaveBeenCalledWith({ mode: 'inherit' })
     expect(serviceMethod('setSubagentModel')).toHaveBeenCalledWith({ mode: 'inherit' })
     expect(serviceMethod('validateProvider')).toHaveBeenCalledWith({ providerId: 'provider-1' })
   })

--- a/src/main/settings/application-commands.ts
+++ b/src/main/settings/application-commands.ts
@@ -17,6 +17,7 @@ import type {
   SetPackageMirrorRequest,
   SetNetworkProxyRequest,
   SetProjectFilesFilterRequest,
+  SetReviewerModelRequest,
   SetSubagentModelRequest,
   ValidateProviderRequest
 } from '../../shared/settings'
@@ -35,6 +36,7 @@ import {
   readGitHubToken,
   readNotificationsEnabled,
   readProjectFilesFilter,
+  readReviewerModel,
   readSubagentModel
 } from './transport-validation'
 import type { AppearanceSettingsWorkflows } from './workflows/appearance'
@@ -75,6 +77,7 @@ type CoreSettingsCommandStore = Pick<
   | 'setPackageMirror'
   | 'setNetworkProxy'
   | 'setProjectFilesFilter'
+  | 'setReviewerModel'
   | 'setSubagentModel'
   | 'validateProvider'
 >
@@ -264,6 +267,11 @@ const settingsCoreApplicationCommands = Object.freeze({
     readonly [request: SetProjectFilesFilterRequest],
     StoreResult<'setProjectFilesFilter'>
   >('settings:set-project-files-filter'),
+  setReviewerModel: defineApplicationCommand<
+    'settings:set-reviewer-model',
+    readonly [request: SetReviewerModelRequest],
+    StoreResult<'setReviewerModel'>
+  >('settings:set-reviewer-model'),
   setSubagentModel: defineApplicationCommand<
     'settings:set-subagent-model',
     readonly [request: SetSubagentModelRequest],
@@ -313,6 +321,7 @@ const settingsCoreApplicationCommandGroup = defineApplicationCommandGroup('setti
   settingsCoreApplicationCommands.setPackageMirror,
   settingsCoreApplicationCommands.setNetworkProxy,
   settingsCoreApplicationCommands.setProjectFilesFilter,
+  settingsCoreApplicationCommands.setReviewerModel,
   settingsCoreApplicationCommands.setSubagentModel,
   settingsCoreApplicationCommands.validateProvider
 ] as const)
@@ -428,6 +437,8 @@ const registerCoreSettingsApplicationCommands = (
         requireLocalCaller(callerContext, 'settings:set-project-files-filter')
         return dependencies.service.setProjectFilesFilter(readProjectFilesFilter(args[0]))
       },
+      'settings:set-reviewer-model': ({ args }) =>
+        dependencies.service.setReviewerModel(readReviewerModel(args[0])),
       'settings:set-subagent-model': ({ args }) =>
         dependencies.service.setSubagentModel(readSubagentModel(args[0])),
       'settings:validate-provider': ({ args }) => dependencies.service.validateProvider(args[0])

--- a/src/main/settings/capabilities.test.ts
+++ b/src/main/settings/capabilities.test.ts
@@ -37,7 +37,8 @@ describe('Settings capabilities', () => {
       closePreference: 'minimize',
       notebookRuntimes: { python: { source: 'managed' } },
       packageMirror: { pypiIndex: 'https://pypi.example/simple' },
-      subagentModel: { mode: 'inherit' }
+      subagentModel: { mode: 'inherit' },
+      reviewerModel: { mode: 'inherit' }
     })
   })
 })

--- a/src/main/settings/document-codec.ts
+++ b/src/main/settings/document-codec.ts
@@ -204,7 +204,8 @@ const sanitizeSettings = (value: unknown): StoredSettings => {
   const settings: StoredSettings = {
     version: SETTINGS_FILE_VERSION,
     providers,
-    subagentModel: sanitizeSubagentModel(value.subagentModel)
+    subagentModel: sanitizeSubagentModel(value.subagentModel),
+    reviewerModel: sanitizeSubagentModel(value.reviewerModel)
   }
   const claudeSubscriptionProviderId = asString(value.claudeSubscriptionProviderId)
   if (

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -42,6 +42,7 @@ type FakeSettingsService = Record<
   | 'uninstallCodex'
   | 'setAgentFramework'
   | 'setReasoningEffort'
+  | 'setReviewerModel'
   | 'setSubagentModel'
   | 'resolveActiveReasoningEffort'
   | 'resolveActiveModelChangeTarget'
@@ -120,6 +121,9 @@ const createFakeService = (): FakeSettingsService => ({
   setReasoningEffort: vi
     .fn()
     .mockResolvedValue({ claude: {}, providers: [], reasoningEffort: 'high' }),
+  setReviewerModel: vi
+    .fn()
+    .mockResolvedValue({ claude: {}, providers: [], reviewerModel: { mode: 'inherit' } }),
   setSubagentModel: vi
     .fn()
     .mockResolvedValue({ claude: {}, providers: [], subagentModel: { mode: 'inherit' } }),
@@ -1117,6 +1121,30 @@ describe('settings IPC handlers', () => {
       })
     ).rejects.toThrow('Invalid Subagent model configuration.')
     expect(service.setSubagentModel).toHaveBeenCalledOnce()
+  })
+
+  it('validates and forwards one complete Reviewer model mutation', async () => {
+    handlers.clear()
+    const service = createFakeService()
+    const configuration = {
+      mode: 'fixed' as const,
+      providerId: 'provider-a',
+      model: 'reviewer-model',
+      reasoningEffort: 'high' as const
+    }
+    const snapshot = { claude: {}, providers: [], reviewerModel: configuration }
+    service.setReviewerModel.mockResolvedValue(snapshot)
+    registerTestSettingsIpcHandlers({ service: asService(service) })
+
+    await expect(invoke('settings:set-reviewer-model', { configuration })).resolves.toBe(snapshot)
+    expect(service.setReviewerModel).toHaveBeenCalledWith(configuration)
+
+    await expect(
+      invoke('settings:set-reviewer-model', {
+        configuration: { ...configuration, model: '' }
+      })
+    ).rejects.toThrow('Invalid Reviewer model configuration.')
+    expect(service.setReviewerModel).toHaveBeenCalledOnce()
   })
 
   it('persists the notifications preference on set-notifications-enabled', async () => {

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -45,6 +45,7 @@ import {
   type SetNotificationsEnabledRequest,
   type SetProjectFilesFilterRequest,
   type SetReasoningEffortRequest,
+  type SetReviewerModelRequest,
   type SetSubagentModelRequest,
   type SetSkillEnabledRequest,
   type SetSkillsEnabledRequest,
@@ -68,6 +69,7 @@ import {
   readNotificationsEnabled,
   readProjectFilesFilter,
   readReasoningEffort,
+  readReviewerModel,
   readSubagentModel
 } from './transport-validation'
 
@@ -166,6 +168,12 @@ const registerSettingsIpcHandlers = ({
   ipcMainHandle('settings:set-subagent-model', async (_event, request: SetSubagentModelRequest) => {
     const configuration = readSubagentModel(request)
     const snapshot = await service.setSubagentModel(configuration)
+    broadcastToRenderers('settings:changed', snapshot)
+    return snapshot
+  })
+  ipcMainHandle('settings:set-reviewer-model', async (_event, request: SetReviewerModelRequest) => {
+    const configuration = readReviewerModel(request)
+    const snapshot = await service.setReviewerModel(configuration)
     broadcastToRenderers('settings:changed', snapshot)
     return snapshot
   })

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -122,6 +122,32 @@ describe('settings repository', () => {
     })
   })
 
+  it('defaults and atomically persists the Reviewer model policy', async () => {
+    expect(sanitizeSettings({ providers: [] }).reviewerModel).toEqual({ mode: 'inherit' })
+
+    const repository = new SettingsRepository(await createStorageRoot())
+    await repository.setReviewerModel({
+      mode: 'fixed',
+      providerId: 'provider-a',
+      model: 'reviewer-model',
+      reasoningEffort: 'high'
+    })
+
+    await expect(repository.getSettings()).resolves.toMatchObject({
+      reviewerModel: {
+        mode: 'fixed',
+        providerId: 'provider-a',
+        model: 'reviewer-model',
+        reasoningEffort: 'high'
+      }
+    })
+
+    await repository.setReviewerModel({ mode: 'inherit' })
+    await expect(repository.getSettings()).resolves.toMatchObject({
+      reviewerModel: { mode: 'inherit' }
+    })
+  })
+
   it('keeps only an existing Claude subscription provider as the preferred mode', () => {
     const providers = [
       {

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -36,7 +36,7 @@ import {
 import { sanitizePackageMirror } from './record-codec'
 import { sanitizeSettings } from './document-codec'
 import { SettingsDocumentStore } from './document-store'
-import { buildSubagentModelMutation } from './subagent-model-settings'
+import { buildReviewerModelMutation, buildSubagentModelMutation } from './subagent-model-settings'
 
 // Stable semantic mutation facade. The injected document store owns arbitration and atomic IO; all
 // secret handling remains above this layer in crypto.ts and service.ts.
@@ -281,6 +281,12 @@ class SettingsRepository {
     ...args: Parameters<typeof buildSubagentModelMutation>
   ): Promise<StoredSettings> {
     return this.mutate(buildSubagentModelMutation(...args))
+  }
+
+  async setReviewerModel(
+    ...args: Parameters<typeof buildReviewerModelMutation>
+  ): Promise<StoredSettings> {
+    return this.mutate(buildReviewerModelMutation(...args))
   }
 
   async setNotificationsEnabled(enabled: boolean): Promise<StoredSettings> {

--- a/src/main/settings/reviewer-model-owner.ts
+++ b/src/main/settings/reviewer-model-owner.ts
@@ -1,0 +1,82 @@
+import type { ReviewerModelConfiguration } from '../../shared/settings'
+import { DEFAULT_AGENT_FRAMEWORK_ID, getAgentFramework } from '../agent-framework'
+import type { ExplicitAgentBackendTarget } from './backend-resolver'
+import type { ProviderAccountsModule } from './provider-accounts'
+import type { SettingsRepository } from './repository'
+
+type ReviewerModelOwnerOptions = {
+  repository: SettingsRepository
+  providers: ProviderAccountsModule
+}
+
+type ReviewerModelAdmission = Readonly<{
+  model: string
+  fixedTarget?: ExplicitAgentBackendTarget
+}>
+
+class ReviewerModelOwner {
+  constructor(private readonly options: ReviewerModelOwnerOptions) {}
+
+  async set(configuration: ReviewerModelConfiguration): Promise<void> {
+    await this.options.repository.setReviewerModel(configuration, (settings, candidate) => {
+      if (candidate.mode === 'inherit') return
+      const provider = settings.providers.find((entry) => entry.id === candidate.providerId)
+      const validationFailed =
+        provider?.lastValidationFailure !== undefined &&
+        (provider.lastValidatedAt === undefined ||
+          provider.lastValidationFailure.at >= provider.lastValidatedAt)
+      if (!provider || validationFailed) {
+        throw new Error(
+          'The selected Reviewer model is no longer available. Refresh the model catalog.'
+        )
+      }
+      const framework = getAgentFramework(settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID)
+      const target = this.options.providers.resolveRuntimeTarget(
+        provider,
+        { kind: 'required', model: candidate.model },
+        framework
+      )
+      if (
+        !target.frameworkCompatible ||
+        (framework.id === 'codex' && !target.modelBridgeSupported)
+      ) {
+        throw new Error(
+          'The selected Reviewer model is not available for the active Agent Framework. Refresh the model catalog.'
+        )
+      }
+      return target.reasoningEffortProfile.supported
+        ? candidate
+        : { ...candidate, reasoningEffort: 'default' }
+    })
+  }
+
+  async admit(): Promise<ReviewerModelAdmission> {
+    const settings = await this.options.repository.getSettings()
+    const configuration = settings.reviewerModel ?? { mode: 'inherit' as const }
+    if (configuration.mode === 'inherit') {
+      const activeProvider = settings.activeProviderId
+        ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
+        : undefined
+      return Object.freeze({
+        model: settings.activeModel ?? activeProvider?.model ?? ''
+      })
+    }
+    return Object.freeze({
+      model: configuration.model,
+      fixedTarget: Object.freeze({
+        frameworkId: settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID,
+        providerId: configuration.providerId,
+        model: Object.freeze({ kind: 'required' as const, id: configuration.model }),
+        reasoningEffort: configuration.reasoningEffort
+      })
+    })
+  }
+}
+
+const createReviewerModels = (
+  repository: SettingsRepository,
+  providers: ProviderAccountsModule
+): ReviewerModelOwner => new ReviewerModelOwner({ repository, providers })
+
+export { createReviewerModels, ReviewerModelOwner }
+export type { ReviewerModelAdmission, ReviewerModelOwnerOptions }

--- a/src/main/settings/reviewer-model-owner.ts
+++ b/src/main/settings/reviewer-model-owner.ts
@@ -1,12 +1,13 @@
 import type { ReviewerModelConfiguration } from '../../shared/settings'
 import { DEFAULT_AGENT_FRAMEWORK_ID, getAgentFramework } from '../agent-framework'
-import type { ExplicitAgentBackendTarget } from './backend-resolver'
+import type { AgentBackendResolver, ExplicitAgentBackendTarget } from './backend-resolver'
 import type { ProviderAccountsModule } from './provider-accounts'
 import type { SettingsRepository } from './repository'
 
 type ReviewerModelOwnerOptions = {
   repository: SettingsRepository
   providers: ProviderAccountsModule
+  backendResolver: Pick<AgentBackendResolver, 'captureConfiguredSelection'>
 }
 
 type ReviewerModelAdmission = Readonly<{
@@ -18,6 +19,10 @@ class ReviewerModelOwner {
   constructor(private readonly options: ReviewerModelOwnerOptions) {}
 
   async set(configuration: ReviewerModelConfiguration): Promise<void> {
+    const frameworkId =
+      configuration.mode === 'fixed'
+        ? (await this.options.backendResolver.captureConfiguredSelection()).frameworkId
+        : undefined
     await this.options.repository.setReviewerModel(configuration, (settings, candidate) => {
       if (candidate.mode === 'inherit') return
       const provider = settings.providers.find((entry) => entry.id === candidate.providerId)
@@ -30,7 +35,9 @@ class ReviewerModelOwner {
           'The selected Reviewer model is no longer available. Refresh the model catalog.'
         )
       }
-      const framework = getAgentFramework(settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID)
+      const framework = getAgentFramework(
+        frameworkId ?? settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
+      )
       const target = this.options.providers.resolveRuntimeTarget(
         provider,
         { kind: 'required', model: candidate.model },
@@ -61,10 +68,11 @@ class ReviewerModelOwner {
         model: settings.activeModel ?? activeProvider?.model ?? ''
       })
     }
+    const { frameworkId } = await this.options.backendResolver.captureConfiguredSelection()
     return Object.freeze({
       model: configuration.model,
       fixedTarget: Object.freeze({
-        frameworkId: settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID,
+        frameworkId,
         providerId: configuration.providerId,
         model: Object.freeze({ kind: 'required' as const, id: configuration.model }),
         reasoningEffort: configuration.reasoningEffort
@@ -75,8 +83,9 @@ class ReviewerModelOwner {
 
 const createReviewerModels = (
   repository: SettingsRepository,
-  providers: ProviderAccountsModule
-): ReviewerModelOwner => new ReviewerModelOwner({ repository, providers })
+  providers: ProviderAccountsModule,
+  backendResolver: AgentBackendResolver
+): ReviewerModelOwner => new ReviewerModelOwner({ repository, providers, backendResolver })
 
 export { createReviewerModels, ReviewerModelOwner }
 export type { ReviewerModelAdmission, ReviewerModelOwnerOptions }

--- a/src/main/settings/reviewer-model-owner.ts
+++ b/src/main/settings/reviewer-model-owner.ts
@@ -1,4 +1,4 @@
-import type { ReviewerModelConfiguration } from '../../shared/settings'
+import { providerValidationFailed, type ReviewerModelConfiguration } from '../../shared/settings'
 import { DEFAULT_AGENT_FRAMEWORK_ID, getAgentFramework } from '../agent-framework'
 import type { AgentBackendResolver, ExplicitAgentBackendTarget } from './backend-resolver'
 import type { ProviderAccountsModule } from './provider-accounts'
@@ -26,10 +26,7 @@ class ReviewerModelOwner {
     await this.options.repository.setReviewerModel(configuration, (settings, candidate) => {
       if (candidate.mode === 'inherit') return
       const provider = settings.providers.find((entry) => entry.id === candidate.providerId)
-      const validationFailed =
-        provider?.lastValidationFailure !== undefined &&
-        (provider.lastValidatedAt === undefined ||
-          provider.lastValidationFailure.at >= provider.lastValidatedAt)
+      const validationFailed = provider ? providerValidationFailed(provider) : false
       if (!provider || validationFailed) {
         throw new Error(
           'The selected Reviewer model is no longer available. Refresh the model catalog.'
@@ -67,6 +64,10 @@ class ReviewerModelOwner {
       return Object.freeze({
         model: settings.activeModel ?? activeProvider?.model ?? ''
       })
+    }
+    const provider = settings.providers.find((entry) => entry.id === configuration.providerId)
+    if (provider && providerValidationFailed(provider)) {
+      throw new Error('The configured Reviewer model provider validation failed.')
     }
     const { frameworkId } = await this.options.backendResolver.captureConfiguredSelection()
     return Object.freeze({

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -5388,6 +5388,33 @@ describe('SettingsService: Reviewer model', () => {
     })
   })
 
+  it('rejects a fixed Reviewer provider whose latest validation failed', async () => {
+    const service = createService()
+    const created = await service.upsertProvider({
+      type: 'custom',
+      name: 'Failing Reviewer gateway',
+      apiEndpoints: ['anthropic'],
+      baseUrl: 'https://reviewer.example/v1',
+      model: 'reviewer-model',
+      key: 'secret'
+    })
+    const provider = created.providers.find(
+      (candidate) => candidate.name === 'Failing Reviewer gateway'
+    )!
+    const fixed = {
+      mode: 'fixed' as const,
+      providerId: provider.id,
+      model: 'reviewer-model',
+      reasoningEffort: 'high' as const
+    }
+    await service.setReviewerModel(fixed)
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 401 }))
+    await service.validateProvider({ providerId: provider.id })
+
+    await expect(service.admitReviewerExecutionModel()).rejects.toThrow('validation failed')
+    expect((await service.getSettingsView()).reviewerModel).toEqual(fixed)
+  })
+
   it('preserves a fixed Reviewer selection when its provider is deleted', async () => {
     const service = createService()
     const created = await service.upsertProvider({

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -5353,6 +5353,41 @@ describe('SettingsService: Reviewer model', () => {
     })
   })
 
+  it('uses the effective Agent Framework override for a fixed Reviewer target', async () => {
+    vi.stubEnv('OPEN_SCIENCE_AGENT_FRAMEWORK', 'opencode')
+    await repository.setAgentFramework('claude-code')
+    const service = createService(undefined, {
+      opencodeDetected: { path: '/usr/local/bin/opencode', version: '1.19.0' }
+    })
+    const created = await service.upsertProvider({
+      type: 'custom',
+      name: 'Overridden Reviewer gateway',
+      apiEndpoints: ['anthropic'],
+      baseUrl: 'https://reviewer.example/v1',
+      model: 'reviewer-model',
+      key: 'secret'
+    })
+    const provider = created.providers.find(
+      (candidate) => candidate.name === 'Overridden Reviewer gateway'
+    )!
+    await service.setReviewerModel({
+      mode: 'fixed',
+      providerId: provider.id,
+      model: 'reviewer-model',
+      reasoningEffort: 'high'
+    })
+
+    await expect(service.admitReviewerExecutionModel()).resolves.toMatchObject({
+      model: 'reviewer-model',
+      fixedTarget: {
+        frameworkId: 'opencode',
+        providerId: provider.id,
+        model: { kind: 'required', id: 'reviewer-model' },
+        reasoningEffort: 'high'
+      }
+    })
+  })
+
   it('preserves a fixed Reviewer selection when its provider is deleted', async () => {
     const service = createService()
     const created = await service.upsertProvider({

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -5294,6 +5294,115 @@ describe('SettingsService: Subagent model', () => {
   })
 })
 
+describe('SettingsService: Reviewer model', () => {
+  it('atomically validates and saves a fixed Reviewer target', async () => {
+    const service = createService()
+    const created = await service.upsertProvider({
+      type: 'custom',
+      name: 'Reviewer gateway',
+      apiEndpoints: ['anthropic'],
+      baseUrl: 'https://reviewer.example/v1',
+      model: 'reviewer-model',
+      key: 'secret'
+    })
+    const provider = created.providers.find((candidate) => candidate.name === 'Reviewer gateway')!
+
+    const snapshot = await service.setReviewerModel({
+      mode: 'fixed',
+      providerId: provider.id,
+      model: 'reviewer-model',
+      reasoningEffort: 'high'
+    })
+
+    expect(snapshot.reviewerModel).toEqual({
+      mode: 'fixed',
+      providerId: provider.id,
+      model: 'reviewer-model',
+      reasoningEffort: 'high'
+    })
+  })
+
+  it('admits the configured fixed Reviewer backend for one Review chain', async () => {
+    const service = createService()
+    const created = await service.upsertProvider({
+      type: 'custom',
+      name: 'Admitted Reviewer gateway',
+      apiEndpoints: ['anthropic'],
+      baseUrl: 'https://reviewer.example/v1',
+      model: 'reviewer-model',
+      key: 'secret'
+    })
+    const provider = created.providers.find(
+      (candidate) => candidate.name === 'Admitted Reviewer gateway'
+    )!
+    await service.setReviewerModel({
+      mode: 'fixed',
+      providerId: provider.id,
+      model: 'reviewer-model',
+      reasoningEffort: 'high'
+    })
+
+    const admission = await service.admitReviewerExecutionModel()
+
+    expect(admission.model).toBe('reviewer-model')
+    expect(admission.fixedTarget).toEqual({
+      frameworkId: 'claude-code',
+      providerId: provider.id,
+      model: { kind: 'required', id: 'reviewer-model' },
+      reasoningEffort: 'high'
+    })
+  })
+
+  it('preserves a fixed Reviewer selection when its provider is deleted', async () => {
+    const service = createService()
+    const created = await service.upsertProvider({
+      type: 'custom',
+      name: 'Restorable Reviewer gateway',
+      apiEndpoints: ['anthropic'],
+      baseUrl: 'https://reviewer.example/v1',
+      model: 'reviewer-model',
+      key: 'secret'
+    })
+    const provider = created.providers.find(
+      (candidate) => candidate.name === 'Restorable Reviewer gateway'
+    )!
+    const fixed = {
+      mode: 'fixed' as const,
+      providerId: provider.id,
+      model: 'reviewer-model',
+      reasoningEffort: 'high' as const
+    }
+    await service.setReviewerModel(fixed)
+
+    await service.deleteProvider(provider.id)
+
+    expect((await service.getSettingsView()).reviewerModel).toEqual(fixed)
+    await expect(service.admitReviewerExecutionModel()).resolves.toMatchObject({
+      model: 'reviewer-model',
+      fixedTarget: { providerId: provider.id }
+    })
+  })
+
+  it('follows the Active model without admitting a second backend', async () => {
+    const service = createService()
+    const created = await service.upsertProvider({
+      type: 'custom',
+      name: 'Active Reviewer gateway',
+      apiEndpoints: ['anthropic'],
+      baseUrl: 'https://active.example/v1',
+      model: 'active-model',
+      key: 'secret'
+    })
+    await service.setActiveProvider(created.providers[0].id, 'active-model')
+    await service.setReviewerModel({ mode: 'inherit' })
+
+    const admission = await service.admitReviewerExecutionModel()
+
+    expect(admission).toMatchObject({ model: 'active-model' })
+    expect(admission.fixedTarget).toBeUndefined()
+  })
+})
+
 describe('SettingsService: notifications preference', () => {
   it('projects enabled when no preference is stored', async () => {
     const service = createService()

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -50,6 +50,7 @@ import type {
   PreviewSkillZipRequest,
   ProjectFilesFilterPreference,
   ReasoningEffort,
+  ReviewerModelConfiguration,
   SubagentModelConfiguration,
   SkillBundlePreviewResult,
   SkillImportPreviewContent,
@@ -107,6 +108,7 @@ import type { StoredConnectors, StoredCustomMcpOAuthState, StoredSettings } from
 import type { CodexAuthControllerPort } from './codex-auth'
 import { createSettingsIdSequence } from './id-sequence'
 import { createSubagentModels, SubagentModelOwner } from './subagent-model-owner'
+import { createReviewerModels, ReviewerModelOwner } from './reviewer-model-owner'
 
 import type { SystemProxyEnvironment } from './system-proxy'
 import { type ClaudeIsolatedAuthControllerPort } from './claude-isolated-auth'
@@ -187,6 +189,7 @@ class SettingsService {
   private readonly runtimeManager: AgentRuntimeManager
   private readonly backendResolver: AgentBackendResolver
   private readonly subagentModels: SubagentModelOwner
+  private readonly reviewerModels: ReviewerModelOwner
   private readonly storageRoot: string
   private readonly applyNetworkProxy: (settings: NetworkProxySettings) => Promise<void>
   private readonly userClaudeDir: string
@@ -260,6 +263,7 @@ class SettingsService {
       this.providers,
       this.backendResolver
     )
+    this.reviewerModels = createReviewerModels(this.repository, this.providers)
   }
 
   // Returns the raw stored settings document (unmasked), for main-process bootstrap needs (e.g. priming
@@ -384,6 +388,15 @@ class SettingsService {
   async setSubagentModel(configuration: SubagentModelConfiguration): Promise<SettingsSnapshot> {
     await this.subagentModels.set(configuration)
     return this.getSettingsView()
+  }
+
+  async setReviewerModel(configuration: ReviewerModelConfiguration): Promise<SettingsSnapshot> {
+    await this.reviewerModels.set(configuration)
+    return this.getSettingsView()
+  }
+
+  async admitReviewerExecutionModel(): ReturnType<ReviewerModelOwner['admit']> {
+    return this.reviewerModels.admit()
   }
 
   // Projects one of the app's five stable user-intent slots through the active model's static effort

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -263,7 +263,11 @@ class SettingsService {
       this.providers,
       this.backendResolver
     )
-    this.reviewerModels = createReviewerModels(this.repository, this.providers)
+    this.reviewerModels = createReviewerModels(
+      this.repository,
+      this.providers,
+      this.backendResolver
+    )
   }
 
   // Returns the raw stored settings document (unmasked), for main-process bootstrap needs (e.g. priming

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -54,6 +54,7 @@ const settingsPaths = {
   responsesProtocolTypes: resolve(settingsRoot, 'responses-protocol-types.ts'),
   responsesRequestAdapter: resolve(settingsRoot, 'responses-request-adapter.ts'),
   responsesResponseAdapter: resolve(settingsRoot, 'responses-response-adapter.ts'),
+  reviewerModelOwner: resolve(settingsRoot, 'reviewer-model-owner.ts'),
   subagentModelOwner: resolve(settingsRoot, 'subagent-model-owner.ts'),
   subagentModelSettings: resolve(settingsRoot, 'subagent-model-settings.ts'),
   service: resolve(settingsRoot, 'service.ts'),
@@ -281,7 +282,7 @@ const productionSourcePaths = productionSources()
 describe('Settings backend ownership architecture', () => {
   it('locks the final facade ceilings and every internal owner below the hard limit', () => {
     // Repository remains one atomic mutation facade; Subagent validation runs inside its CAS write.
-    expect(rawLineCount(readSource(settingsPaths.repository))).toBeLessThanOrEqual(683)
+    expect(rawLineCount(readSource(settingsPaths.repository))).toBeLessThanOrEqual(700)
     expect(rawLineCount(readSource(settingsPaths.subagentModelSettings))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.recordCodec))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.documentCodec))).toBeLessThanOrEqual(660)
@@ -302,6 +303,7 @@ describe('Settings backend ownership architecture', () => {
     expect(rawLineCount(readSource(settingsPaths.responsesResponseAdapter))).toBeLessThanOrEqual(
       660
     )
+    expect(rawLineCount(readSource(settingsPaths.reviewerModelOwner))).toBeLessThanOrEqual(660)
     expect(rawLineCount(readSource(settingsPaths.subagentModelOwner))).toBeLessThanOrEqual(660)
     // Main's facade plus typed Subagent forwarding, proxy projection, and owner composition.
     expect(rawLineCount(readSource(settingsPaths.service))).toBeLessThanOrEqual(1050)
@@ -373,7 +375,9 @@ describe('Settings backend ownership architecture', () => {
       'value:createSubagentModels'
     ])
     expect(exportInventoryFrom(settingsPaths.subagentModelSettings)).toEqual([
+      'type:ReviewerModelValidator',
       'type:SubagentModelValidator',
+      'value:buildReviewerModelMutation',
       'value:buildSubagentModelMutation'
     ])
   })
@@ -416,6 +420,7 @@ describe('Settings backend ownership architecture', () => {
       'setPackageMirror',
       'setProjectFilesFilter',
       'setReasoningEffort',
+      'setReviewerModel',
       'setRuntimeEnablement',
       'setRuntimeSelection',
       'setSkillEnabled',
@@ -494,7 +499,7 @@ describe('Settings backend ownership architecture', () => {
   it('locks the SettingsService application interface', () => {
     expect(publicOperationsOf(settingsPaths.service, 'SettingsService')).toEqual(
       `
-        addCustomServer addManualInterpreter admitSubagentExecutionModel authenticateCustomServer buildCustomServerTemplateExport
+        addCustomServer addManualInterpreter admitReviewerExecutionModel admitSubagentExecutionModel authenticateCustomServer buildCustomServerTemplateExport
         buildSkillExport cancelClaudeIsolatedLogin cancelClaudeLogin cancelCodexLogin cancelCustomServerAuthentication captureActiveAgentBackendSelection captureActiveExplicitAgentBackendTarget checkEnvironment clearGrantedLocalRoots codexSkillCatalog
         codexSkillDescriptorsForIds createSkill deleteProvider deleteSkill detectClaude detectCodex
         detectOpencode dismissLegacyDataMovePrompt getAppIconVariant getClosePreference
@@ -515,7 +520,7 @@ describe('Settings backend ownership architecture', () => {
         setConversationSkillImportEnabled setCustomServerAuthenticator setCustomServerEnabled
         setDataRoot setDefaultPermissionProfile setEnvironmentEnabled setInstallAuthorized
         setCustomServerRuntimeProjectionProvider setNcbiCredentials setNetworkProxy setNotificationsEnabled
-        setPackageMirror setProjectFilesFilter setReasoningEffort setRuntimeSelection setSkillDeletionGuard setSkillEnabled setSkillsEnabled setSubagentModel
+        setPackageMirror setProjectFilesFilter setReasoningEffort setReviewerModel setRuntimeSelection setSkillDeletionGuard setSkillEnabled setSkillsEnabled setSubagentModel
         setToolPermission skillNudgeNamesForIds skillsNeedingForceLoad uninstallClaude uninstallCodex
         uninstallOpencode updateCustomServer updateSkill upsertProvider validateProvider withHostSkillRead
       `
@@ -535,6 +540,7 @@ describe('Settings backend ownership architecture', () => {
       'src/main/settings/preferences.ts',
       'src/main/settings/provider-accounts.ts',
       'src/main/settings/provider-auth-lifecycle.ts',
+      'src/main/settings/reviewer-model-owner.ts',
       'src/main/settings/service.ts',
       'src/main/settings/skill-catalog.ts',
       'src/main/settings/subagent-model-owner.ts'
@@ -555,6 +561,7 @@ describe('Settings backend ownership architecture', () => {
       'src/main/settings/backend-route-planner.ts',
       'src/main/settings/backend-selection-owner.ts',
       'src/main/settings/provider-transport-owner.ts',
+      'src/main/settings/reviewer-model-owner.ts',
       'src/main/settings/service.ts',
       'src/main/settings/subagent-model-owner.ts'
     ])
@@ -563,6 +570,8 @@ describe('Settings backend ownership architecture', () => {
       'src/main/acp/restricted-inference-runner.ts',
       'src/main/artifacts/code-reconstruction.ts',
       'src/main/notebook/host-llm-service.ts',
+      'src/main/reviewer/model-runtime-owner.ts',
+      'src/main/settings/reviewer-model-owner.ts',
       'src/main/settings/service.ts',
       'src/main/settings/subagent-model-owner.ts',
       'src/main/side-chat/runtime-owner.ts'
@@ -682,6 +691,7 @@ describe('Settings backend ownership architecture', () => {
       'projectFilesFilter',
       'providers',
       'reasoningEffort',
+      'reviewerModel',
       'subagentModel',
       'version'
     ])
@@ -777,6 +787,7 @@ describe('Settings backend ownership architecture', () => {
     ])
     expect(manifest.modules.settings_service_facade.ownerPaths).toEqual([
       'src/main/settings/service.ts',
+      'src/main/settings/reviewer-model-owner.ts',
       'src/main/settings/subagent-model-owner.ts'
     ])
     expect(manifest.modules.settings_service_facade.interfacePaths).toEqual([

--- a/src/main/settings/settings-view.ts
+++ b/src/main/settings/settings-view.ts
@@ -54,6 +54,7 @@ export const buildSettingsSnapshot = (
     networkProxy: resolveNetworkProxySettings(settings.networkProxy),
     reasoningEffort: preferences.reasoningEffort,
     subagentModel: settings.subagentModel ?? { mode: 'inherit' },
+    reviewerModel: settings.reviewerModel ?? { mode: 'inherit' },
     notificationsEnabled: preferences.notificationsEnabled,
     conversationSkillImportEnabled: preferences.conversationSkillImportEnabled,
     closePreference: preferences.closePreference,

--- a/src/main/settings/subagent-model-settings.ts
+++ b/src/main/settings/subagent-model-settings.ts
@@ -1,10 +1,15 @@
-import type { SubagentModelConfiguration } from '../../shared/settings'
+import type { ReviewerModelConfiguration, SubagentModelConfiguration } from '../../shared/settings'
 import type { StoredSettings } from './types'
 
 type SubagentModelValidator = (
   settings: StoredSettings,
   configuration: SubagentModelConfiguration
 ) => SubagentModelConfiguration | void
+
+type ReviewerModelValidator = (
+  settings: StoredSettings,
+  configuration: ReviewerModelConfiguration
+) => ReviewerModelConfiguration | void
 
 const buildSubagentModelMutation =
   (configuration: SubagentModelConfiguration, validate?: SubagentModelValidator) =>
@@ -13,5 +18,12 @@ const buildSubagentModelMutation =
     subagentModel: structuredClone(validate?.(settings, configuration) ?? configuration)
   })
 
-export { buildSubagentModelMutation }
-export type { SubagentModelValidator }
+const buildReviewerModelMutation =
+  (configuration: ReviewerModelConfiguration, validate?: ReviewerModelValidator) =>
+  (settings: StoredSettings): StoredSettings => ({
+    ...settings,
+    reviewerModel: structuredClone(validate?.(settings, configuration) ?? configuration)
+  })
+
+export { buildReviewerModelMutation, buildSubagentModelMutation }
+export type { ReviewerModelValidator, SubagentModelValidator }

--- a/src/main/settings/transport-validation.test.ts
+++ b/src/main/settings/transport-validation.test.ts
@@ -9,6 +9,7 @@ import {
   readNotificationsEnabled,
   readProjectFilesFilter,
   readReasoningEffort,
+  readReviewerModel,
   readSubagentModel
 } from './transport-validation'
 
@@ -67,6 +68,27 @@ describe('Settings transport validation', () => {
     expect(() =>
       readSubagentModel({ configuration: { mode: 'inherit', providerId: 'stale' } })
     ).toThrow('Invalid Subagent model configuration.')
+  })
+
+  it('accepts only complete atomic Reviewer model configurations', () => {
+    expect(
+      readReviewerModel({
+        configuration: {
+          mode: 'fixed',
+          providerId: 'provider-a',
+          model: 'reviewer-model',
+          reasoningEffort: 'max'
+        }
+      })
+    ).toEqual({
+      mode: 'fixed',
+      providerId: 'provider-a',
+      model: 'reviewer-model',
+      reasoningEffort: 'max'
+    })
+    expect(() => readReviewerModel({ configuration: { mode: 'fixed' } })).toThrow(
+      'Invalid Reviewer model configuration.'
+    )
   })
 
   it('accepts only boolean conversation Skill import preferences', () => {

--- a/src/main/settings/transport-validation.ts
+++ b/src/main/settings/transport-validation.ts
@@ -4,6 +4,7 @@ import {
   type AppIconVariant,
   type ProjectFilesFilterPreference,
   type ReasoningEffort,
+  type ReviewerModelConfiguration,
   type SubagentModelConfiguration
 } from '../../shared/settings'
 import type { CloseActionPreference } from '../../shared/window-controls'
@@ -30,10 +31,13 @@ const readReasoningEffort = (request: unknown): ReasoningEffort => {
   return effort
 }
 
-const readSubagentModel = (request: unknown): SubagentModelConfiguration => {
+const readModelConfiguration = (
+  request: unknown,
+  label: 'Subagent' | 'Reviewer'
+): SubagentModelConfiguration => {
   const configuration = readField(request, 'configuration')
   if (typeof configuration !== 'object' || configuration === null || Array.isArray(configuration)) {
-    throw new Error('Invalid Subagent model configuration.')
+    throw new Error(`Invalid ${label} model configuration.`)
   }
   const value = configuration as Record<string, unknown>
   if (value.mode === 'inherit' && Object.keys(value).length === 1) return { mode: 'inherit' }
@@ -56,8 +60,14 @@ const readSubagentModel = (request: unknown): SubagentModelConfiguration => {
       reasoningEffort: value.reasoningEffort
     }
   }
-  throw new Error('Invalid Subagent model configuration.')
+  throw new Error(`Invalid ${label} model configuration.`)
 }
+
+const readSubagentModel = (request: unknown): SubagentModelConfiguration =>
+  readModelConfiguration(request, 'Subagent')
+
+const readReviewerModel = (request: unknown): ReviewerModelConfiguration =>
+  readModelConfiguration(request, 'Reviewer')
 
 const readConversationSkillImportEnabled = (request: unknown): boolean => {
   const enabled = readField(request, 'enabled')
@@ -144,5 +154,6 @@ export {
   readNotificationsEnabled,
   readProjectFilesFilter,
   readReasoningEffort,
+  readReviewerModel,
   readSubagentModel
 }

--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -9,6 +9,7 @@ import type {
   ProviderType,
   ProviderValidationFailure,
   ReasoningEffort,
+  ReviewerModelConfiguration,
   SubagentModelConfiguration
 } from '../../shared/settings'
 import { SETTINGS_FILE_VERSION } from '../../shared/settings'
@@ -156,6 +157,8 @@ export type StoredSettings = {
   reasoningEffort?: ReasoningEffort
   // Global direct-Subagent model routing. Absence in older documents means dynamic inheritance.
   subagentModel?: SubagentModelConfiguration
+  // Global Reviewer model routing. Absence in older documents means follow the Active model.
+  reviewerModel?: ReviewerModelConfiguration
   // Desktop-notification preference for finished/failed agent tasks. Absent means enabled.
   notificationsEnabled?: boolean
   // Conversation-driven Skill package import. Absent means enabled.

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -505,6 +505,7 @@ describe('preload bridge — public surface inventory', () => {
       'settings.setPackageMirror',
       'settings.setProjectFilesFilter',
       'settings.setReasoningEffort',
+      'settings.setReviewerModel',
       'settings.setSkillEnabled',
       'settings.setSkillsEnabled',
       'settings.setSubagentModel',
@@ -611,7 +612,7 @@ describe('preload bridge — runtime renderer contract catalog', () => {
   it('routes every owned method through its cataloged Electron channel', async () => {
     const requestContracts = runtimeContracts.filter(({ kind }) => kind === 'method')
 
-    expect(runtimeContracts).toHaveLength(197)
+    expect(runtimeContracts).toHaveLength(198)
 
     for (const contract of requestContracts) {
       invokeMock.mockClear()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -220,6 +220,8 @@ const api: OpenScienceAPI = {
       electronRendererContracts.invoke('settings.setAgentFramework', request),
     setReasoningEffort: (request) =>
       electronRendererContracts.invoke('settings.setReasoningEffort', request),
+    setReviewerModel: (request) =>
+      electronRendererContracts.invoke('settings.setReviewerModel', request),
     setSubagentModel: (request) =>
       electronRendererContracts.invoke('settings.setSubagentModel', request),
     onChanged: (listener) => electronRendererContracts.subscribe('settings.onChanged', listener),

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -227,6 +227,7 @@ import type {
   SetDefaultPermissionProfileRequest,
   SetAppIconVariantRequest,
   SetReasoningEffortRequest,
+  SetReviewerModelRequest,
   SetSubagentModelRequest,
   SetSkillEnabledRequest,
   SetSkillsEnabledRequest,
@@ -458,6 +459,7 @@ export interface OpenScienceAPI {
     setActiveProvider(request: SetActiveProviderRequest): Promise<SettingsSnapshot>
     setAgentFramework(request: SetAgentFrameworkRequest): Promise<SettingsSnapshot>
     setReasoningEffort(request: SetReasoningEffortRequest): Promise<SettingsSnapshot>
+    setReviewerModel(request: SetReviewerModelRequest): Promise<SettingsSnapshot>
     setSubagentModel(request: SetSubagentModelRequest): Promise<SettingsSnapshot>
     onChanged(listener: (snapshot: SettingsSnapshot) => void): () => void
     setNotificationsEnabled(request: SetNotificationsEnabledRequest): Promise<SettingsSnapshot>

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -3219,6 +3219,7 @@ describe('assembleReviewRunRequest — shared turn selection', () => {
     expect(result!.sessionId).toBe('transport-session-1')
     expect(result!.turnMessageId).toBe(lastAgent!.id)
     expect(result!.mainSessionId).toBe('transport-session-1')
+    expect(result).not.toHaveProperty('model')
   })
 
   it('skips autoReviewEnabled — returns a request even when auto-review is off', () => {

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -40,7 +40,6 @@ import {
   recordTextEventApplied,
   recordToolEventApplied
 } from '../streaming-metrics'
-import { useSettingsStore } from '../../stores/settings-store'
 import { saveSessionInOrder } from '../session-persistence/session-persistence'
 import {
   createRuntimeStreamId,
@@ -410,8 +409,7 @@ const assembleReviewRunRequest = (sessionId: string): ReviewRunRequest | undefin
     sessionId,
     turnMessageId: lastAgentMessage.id,
     projectId: session.projectId ?? '',
-    mainSessionId: sessionId,
-    model: useSettingsStore.getState().activeModel
+    mainSessionId: sessionId
   }
 }
 

--- a/src/renderer/src/pages/settings/ProvidersPanel.tsx
+++ b/src/renderer/src/pages/settings/ProvidersPanel.tsx
@@ -7,7 +7,7 @@ import { isCodexSubscriptionProvider } from '../../../../shared/settings'
 import { ActiveModelSelect } from './ActiveModelSelect'
 import { ProviderList } from './ProviderList'
 import { ReasoningEffortSelect } from './ReasoningEffortSelect'
-import { SubagentModelSelect } from './SubagentModelSelect'
+import { ReviewerModelSelect, SubagentModelSelect } from './SubagentModelSelect'
 import { SettingsSection } from './SettingsLayout'
 import { ClaudeIsolatedSignInModal } from './ClaudeIsolatedSignInModal'
 
@@ -326,6 +326,17 @@ const ProvidersPanel = ({
       >
         <div className="max-w-2xl">
           <SubagentModelSelect />
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        title="Reviewer model"
+        aria-label="Reviewer model"
+        description="Model used for manual, automatic, and re-run Reviews. Follow Active model keeps the current behavior; a fixed selection runs in an isolated Reviewer runtime."
+        separated
+      >
+        <div className="max-w-2xl">
+          <ReviewerModelSelect />
         </div>
       </SettingsSection>
 

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -380,7 +380,7 @@ describe('SettingsPage layout', () => {
       'button'
     )
 
-    // The Model panel splits Active model, Reasoning effort, and Subagent model (their own
+    // The Model panel splits Active model, Reasoning effort, Subagent model, and Reviewer model (their own
     // sections) from provider management; the agent framework moved to the Agent sub-panel.
     expect(document.body.textContent).toContain('Active model')
     expect(document.body.textContent).toContain('Reasoning effort')
@@ -388,13 +388,16 @@ describe('SettingsPage layout', () => {
     expect(document.body.textContent).toContain('may approximate unsupported levels')
     expect(document.body.textContent).toContain('Providers')
     expect(document.body.textContent).not.toContain('Agent framework')
-    expect(document.body.querySelectorAll('[data-slot="settings-section"]')).toHaveLength(4)
+    expect(document.body.querySelectorAll('[data-slot="settings-section"]')).toHaveLength(5)
     expect(
       Array.from(document.body.querySelectorAll('[data-slot="settings-section"]')).map((section) =>
         section.getAttribute('aria-label')
       )
-    ).toEqual(['Active model', 'Reasoning effort', 'Subagent model', 'Providers'])
+    ).toEqual(['Active model', 'Reasoning effort', 'Subagent model', 'Reviewer model', 'Providers'])
     expect(document.body.textContent).toContain('Model used by subagents when Delegation is on.')
+    expect(document.body.textContent).toContain(
+      'Model used for manual, automatic, and re-run Reviews.'
+    )
     // The add action lives with the list as a dashed ghost row, not a section-header button.
     const addRow = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
       (button) => button.textContent?.trim() === 'Add provider'

--- a/src/renderer/src/pages/settings/SubagentModelSelect.render.test.tsx
+++ b/src/renderer/src/pages/settings/SubagentModelSelect.render.test.tsx
@@ -4,7 +4,7 @@ import { createRoot } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
-import { SubagentModelSelect } from './SubagentModelSelect'
+import { ReviewerModelSelect, SubagentModelSelect } from './SubagentModelSelect'
 
 if (!Element.prototype.hasPointerCapture) {
   Element.prototype.hasPointerCapture = (): boolean => false
@@ -221,6 +221,36 @@ describe('SubagentModelSelect', () => {
     expect(
       document.body.querySelector('[aria-label="Subagent model Reasoning effort"]')?.textContent
     ).toContain('High')
+    act(() => root.unmount())
+  })
+})
+
+describe('ReviewerModelSelect', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({
+      ...createInitialSettingsState(),
+      setReviewerModel: vi.fn(async () => undefined)
+    })
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('presents Follow Active as the default Reviewer policy', () => {
+    const container = document.createElement('div')
+    document.body.append(container)
+    const root = createRoot(container)
+    act(() => root.render(<ReviewerModelSelect />))
+
+    expect(
+      document.body.querySelector('[aria-label="Reviewer model Model"]')?.textContent
+    ).toContain('Follow Active model')
+    expect(
+      document.body.querySelector<HTMLButtonElement>(
+        '[aria-label="Reviewer model Reasoning effort"]'
+      )?.disabled
+    ).toBe(true)
     act(() => root.unmount())
   })
 })

--- a/src/renderer/src/pages/settings/SubagentModelSelect.tsx
+++ b/src/renderer/src/pages/settings/SubagentModelSelect.tsx
@@ -21,10 +21,25 @@ import {
 import { ProviderKindIcon } from './provider-icons'
 import { providerKindKey } from './provider-form-value'
 import { SettingsField, SettingsRow } from './SettingsLayout'
+import type { SubagentModelConfiguration } from '../../../../shared/settings'
 
 const INHERIT_KEY = 'same-as-main-model'
 
-const SubagentModelSelect = (): React.JSX.Element => {
+type ModelPolicySelectProps = Readonly<{
+  ariaLabel: string
+  inheritLabel: string
+  configuration: SubagentModelConfiguration
+  pending: boolean
+  setConfiguration: (configuration: SubagentModelConfiguration) => Promise<void>
+}>
+
+const ModelPolicySelect = ({
+  ariaLabel,
+  inheritLabel,
+  configuration,
+  pending,
+  setConfiguration
+}: ModelPolicySelectProps): React.JSX.Element => {
   const providers = useSettingsStore((state) => state.providers)
   const activeProviderId = useSettingsStore((state) => state.activeProviderId)
   const claudeSubscriptionProviderId = useSettingsStore(
@@ -32,9 +47,6 @@ const SubagentModelSelect = (): React.JSX.Element => {
   )
   const frameworkId = useSettingsStore((state) => state.agentFrameworkId)
   const frameworkEndpoints = useSettingsStore(selectFrameworkApiEndpoints)
-  const configuration = useSettingsStore((state) => state.subagentModel)
-  const pending = useSettingsStore((state) => state.subagentModelPending)
-  const setConfiguration = useSettingsStore((state) => state.setSubagentModel)
   const catalog = buildConfiguredModelCatalog({
     providers,
     activeProviderId,
@@ -105,7 +117,7 @@ const SubagentModelSelect = (): React.JSX.Element => {
             void setConfiguration({ mode: 'fixed', ...identity, reasoningEffort })
           }}
         >
-          <SelectTrigger aria-label="Subagent model Model">
+          <SelectTrigger aria-label={`${ariaLabel} Model`}>
             <span className="flex items-center gap-2 truncate">
               {configuration.mode === 'fixed' && selectedEntry ? (
                 <>
@@ -125,12 +137,12 @@ const SubagentModelSelect = (): React.JSX.Element => {
                   {configuration.model} · {configuration.providerId} · Unavailable
                 </span>
               ) : (
-                <span className="truncate">Same as main model</span>
+                <span className="truncate">{inheritLabel}</span>
               )}
             </span>
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value={INHERIT_KEY}>Same as main model</SelectItem>
+            <SelectItem value={INHERIT_KEY}>{inheritLabel}</SelectItem>
             {unavailable ? (
               <SelectItem value={selectedKey} disabled>
                 {configuration.model} · {configuration.providerId} · Unavailable
@@ -162,16 +174,16 @@ const SubagentModelSelect = (): React.JSX.Element => {
       <SettingsField label="Reasoning effort">
         {configuration.mode === 'inherit' ? (
           <Select value={INHERIT_KEY} disabled>
-            <SelectTrigger aria-label="Subagent model Reasoning effort">
+            <SelectTrigger aria-label={`${ariaLabel} Reasoning effort`}>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value={INHERIT_KEY}>Same as main model</SelectItem>
+              <SelectItem value={INHERIT_KEY}>{inheritLabel}</SelectItem>
             </SelectContent>
           </Select>
         ) : effortProfile && !effortProfile.supported ? (
           <Select value="not-supported" disabled>
-            <SelectTrigger aria-label="Subagent model Reasoning effort">
+            <SelectTrigger aria-label={`${ariaLabel} Reasoning effort`}>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -195,7 +207,7 @@ const SubagentModelSelect = (): React.JSX.Element => {
               void setConfiguration({ ...configuration, reasoningEffort })
             }}
           >
-            <SelectTrigger aria-label="Subagent model Reasoning effort">
+            <SelectTrigger aria-label={`${ariaLabel} Reasoning effort`}>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -213,4 +225,24 @@ const SubagentModelSelect = (): React.JSX.Element => {
   )
 }
 
-export { SubagentModelSelect }
+const SubagentModelSelect = (): React.JSX.Element => (
+  <ModelPolicySelect
+    ariaLabel="Subagent model"
+    inheritLabel="Same as main model"
+    configuration={useSettingsStore((state) => state.subagentModel)}
+    pending={useSettingsStore((state) => state.subagentModelPending)}
+    setConfiguration={useSettingsStore((state) => state.setSubagentModel)}
+  />
+)
+
+const ReviewerModelSelect = (): React.JSX.Element => (
+  <ModelPolicySelect
+    ariaLabel="Reviewer model"
+    inheritLabel="Follow Active model"
+    configuration={useSettingsStore((state) => state.reviewerModel)}
+    pending={useSettingsStore((state) => state.reviewerModelPending)}
+    setConfiguration={useSettingsStore((state) => state.setReviewerModel)}
+  />
+)
+
+export { ReviewerModelSelect, SubagentModelSelect }

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -843,7 +843,6 @@ const WorkspaceMessageScrollerImpl = ({
         scopeTurnMessageId: review.scope.turnMessageId,
         projectId: review.projectId,
         mainSessionId: review.sessionId,
-        model: useSettingsStore.getState().activeModel,
         // Explicit user Re-run: bypass main's auto-only per-turn idempotency so the stale/error review
         // is genuinely re-run rather than refused as already-reviewed.
         origin: 'manual'

--- a/src/renderer/src/stores/settings-preferences-slice.ts
+++ b/src/renderer/src/stores/settings-preferences-slice.ts
@@ -4,6 +4,7 @@ import type {
   AppIconVariant,
   ProjectFilesFilterPreference,
   ReasoningEffort,
+  ReviewerModelConfiguration,
   SettingsSnapshot,
   SubagentModelConfiguration
 } from '../../../shared/settings'
@@ -20,6 +21,8 @@ type SettingsPreferencesState = {
   networkProxy?: NetworkProxySettings
   packageMirror?: PackageMirror
   reasoningEffort: ReasoningEffort
+  reviewerModel?: ReviewerModelConfiguration
+  reviewerModelPending?: boolean
   subagentModel?: SubagentModelConfiguration
   subagentModelPending?: boolean
   notificationsEnabled: boolean
@@ -41,6 +44,7 @@ type OptimisticPreferenceField =
 
 export type SettingsPreferencesActions = {
   setReasoningEffort: (effort: ReasoningEffort) => Promise<void>
+  setReviewerModel: (configuration: ReviewerModelConfiguration) => Promise<void>
   setSubagentModel: (configuration: SubagentModelConfiguration) => Promise<void>
   setNotificationsEnabled: (enabled: boolean) => Promise<void>
   setConversationSkillImportEnabled: (enabled: boolean) => Promise<void>
@@ -66,7 +70,12 @@ type SettingsPreferencesCommands = Pick<
   | 'markOnboardingComplete'
   | 'setPackageMirror'
 > &
-  Partial<Pick<Window['api']['settings'], 'getSettings' | 'setSubagentModel' | 'setNetworkProxy'>>
+  Partial<
+    Pick<
+      Window['api']['settings'],
+      'getSettings' | 'setReviewerModel' | 'setSubagentModel' | 'setNetworkProxy'
+    >
+  >
 
 type SettingsPreferencesSliceOptions = {
   getState: () => SettingsPreferencesState
@@ -122,6 +131,30 @@ export const createSettingsPreferencesSlice = ({
   }
 
   return {
+    setReviewerModel: async (configuration) => {
+      const write = writeCoordinator.begin('reviewerModel')
+      setState({ reviewerModelPending: true })
+      try {
+        const snapshot = await getCommands().setReviewerModel!({ configuration })
+        if (!write.isCurrent()) return
+        reconcileSnapshot(snapshot)
+        write.succeed()
+      } catch (error) {
+        write.fail('Could not save Reviewer model. Refresh the model catalog and try again.')
+        console.error('Failed to set Reviewer model', error)
+        const refresh = getCommands().getSettings
+        if (refresh) {
+          try {
+            reconcileSnapshot(await refresh())
+          } catch (refreshError) {
+            console.error('Failed to refresh Settings after rejected Reviewer model', refreshError)
+          }
+        }
+      } finally {
+        if (write.isCurrent()) setState({ reviewerModelPending: false })
+      }
+    },
+
     setSubagentModel: async (configuration) => {
       const write = writeCoordinator.begin('subagentModel')
       setState({ subagentModelPending: true })

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -71,6 +71,7 @@ import type {
   ProviderType,
   ProviderView,
   ReasoningEffort,
+  ReviewerModelConfiguration,
   SettingsSnapshot,
   AppIconVariant,
   SubagentModelConfiguration
@@ -110,6 +111,8 @@ type SettingsStoreData = RuntimeSetupState &
     networkProxy: NetworkProxySettings
     // Reasoning-effort preference applied to agent requests; 'default' leaves the agent's own default.
     reasoningEffort: ReasoningEffort
+    reviewerModel: ReviewerModelConfiguration
+    reviewerModelPending: boolean
     subagentModel: SubagentModelConfiguration
     subagentModelPending: boolean
     // Whether the app posts an OS notification when an agent task finishes or fails while unfocused.
@@ -169,6 +172,8 @@ export const createInitialSettingsState = (): SettingsStoreData => ({
   packageMirror: undefined,
   networkProxy: DEFAULT_NETWORK_PROXY_SETTINGS,
   reasoningEffort: DEFAULT_REASONING_EFFORT,
+  reviewerModel: { mode: 'inherit' },
+  reviewerModelPending: false,
   subagentModel: { mode: 'inherit' },
   subagentModelPending: false,
   notificationsEnabled: DEFAULT_NOTIFICATIONS_ENABLED,
@@ -190,6 +195,7 @@ const applySnapshot = (snapshot: SettingsSnapshot): Partial<SettingsStoreData> =
   packageMirror: isMirrorConfigured(snapshot.packageMirror) ? snapshot.packageMirror : undefined,
   networkProxy: snapshot.networkProxy ?? DEFAULT_NETWORK_PROXY_SETTINGS,
   reasoningEffort: snapshot.reasoningEffort,
+  reviewerModel: snapshot.reviewerModel ?? { mode: 'inherit' },
   subagentModel: snapshot.subagentModel ?? { mode: 'inherit' },
   // Defensive: main always fills this, but an untyped snapshot (tests, older backends) must not
   // write undefined into the boolean preference.

--- a/src/renderer/src/stores/settings-write-coordinator.ts
+++ b/src/renderer/src/stores/settings-write-coordinator.ts
@@ -2,6 +2,7 @@ export type SettingsWriteKey =
   | 'activeProvider'
   | 'agentFramework'
   | 'reasoningEffort'
+  | 'reviewerModel'
   | 'subagentModel'
   | 'notifications'
   | 'conversationSkillImport'

--- a/src/renderer/web/renderer-argument-shape-characterization.test.ts
+++ b/src/renderer/web/renderer-argument-shape-characterization.test.ts
@@ -187,7 +187,7 @@ describe('renderer argument-shape characterization', () => {
     const actualPaths = collectFunctionPaths(webApi).sort()
 
     expect(new Set(actualPaths).size).toBe(actualPaths.length)
-    expect(actualPaths).toHaveLength(288)
+    expect(actualPaths).toHaveLength(289)
 
     expect(actualPaths).toEqual(expectedPaths)
   })

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -17,17 +17,17 @@ describe('renderer contract catalog', () => {
     const projection = projectRendererContractMaps(RENDERER_CONTRACT_CATALOG)
 
     expect(RENDERER_CONTRACT_GROUPS).toHaveLength(33)
-    expect(RENDERER_CONTRACT_CATALOG).toHaveLength(355)
+    expect(RENDERER_CONTRACT_CATALOG).toHaveLength(356)
     expect(projection.invoke).toEqual(WEB_INVOKE_CHANNELS)
     expect(projection.event).toEqual(WEB_EVENT_CHANNELS)
-    expect(Object.keys(projection.invoke)).toHaveLength(256)
+    expect(Object.keys(projection.invoke)).toHaveLength(257)
     expect(Object.keys(projection.event)).toHaveLength(37)
   })
 
   it('separates actual Web installation from the generated compatibility projection', () => {
     expect(
       paths(({ surfaceInstallation }) => surfaceInstallation.localWeb !== 'unavailable')
-    ).toHaveLength(288)
+    ).toHaveLength(289)
 
     expect(
       paths(({ surfaceInstallation }) => surfaceInstallation.localWeb === 'browser-native')

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -346,7 +346,7 @@ export const RENDERER_CONTRACT_GROUPS = Object.freeze([
     ['setNcbiCredentials', 'settings:set-ncbi-credentials'], ['setNotificationsEnabled', 'settings:set-notifications-enabled', LOCAL],
     ['setPackageMirror', 'settings:set-package-mirror', LOCAL], ['setProjectFilesFilter', 'settings:set-project-files-filter', LOCAL],
     ['setNetworkProxy', 'settings:set-network-proxy', LOCAL],
-    ['setReasoningEffort', 'settings:set-reasoning-effort'], ['setSubagentModel', 'settings:set-subagent-model'],
+    ['setReasoningEffort', 'settings:set-reasoning-effort'], ['setReviewerModel', 'settings:set-reviewer-model'], ['setSubagentModel', 'settings:set-subagent-model'],
     ['setSkillEnabled', 'settings:set-skill-enabled'], ['setSkillsEnabled', 'settings:set-skills-enabled'], ['setToolPermission', 'settings:set-tool-permission'],
     ['uninstallClaude', 'settings:uninstall-claude', LOCAL], ['uninstallCodex', 'settings:uninstall-codex', LOCAL],
     ['uninstallOpencode', 'settings:uninstall-opencode', LOCAL], ['updateCustomServer', 'settings:update-custom-server'],

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -244,13 +244,13 @@ describe('renderer surface inventory', () => {
       ...Object.keys(WEB_EVENT_CHANNELS)
     ])
 
-    expect(electronPaths).toHaveLength(355)
+    expect(electronPaths).toHaveLength(356)
 
     expectSameSet(
       electronPaths,
       RENDERER_CONTRACT_CATALOG.map(({ publicPath }) => publicPath)
     )
-    expect(Object.keys(WEB_INVOKE_CHANNELS)).toHaveLength(256)
+    expect(Object.keys(WEB_INVOKE_CHANNELS)).toHaveLength(257)
     expect(Object.keys(WEB_EVENT_CHANNELS)).toHaveLength(37)
     expectSameSet(
       electronPaths.filter((path) => !generatedPaths.has(path)),

--- a/src/shared/reviewer.ts
+++ b/src/shared/reviewer.ts
@@ -260,7 +260,8 @@ export type ReviewRunRequest = {
   // Main session to inject the [Auditor] correction message into (if warn/fail checks exist).
   // In production auto-review this is the same as sessionId. Omitting it skips correction injection.
   mainSessionId?: string
-  // Provider/model tag recorded on the Review row (e.g. 'claude-opus-4-5'). Falls back to ''.
+  // Legacy mixed-version hint. Production Main resolves and persists its admitted Reviewer model;
+  // callers that do not install a model admission owner may still use this as a fallback.
   model?: string
   // Turn whose content is actually audited, when it differs from turnMessageId (the grouping id).
   // Defaults to turnMessageId. Used when re-running a fix-loop review: the review row is grouped under

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -319,6 +319,14 @@ export const DEFAULT_SUBAGENT_MODEL_CONFIGURATION: SubagentModelConfiguration = 
   mode: 'inherit'
 })
 
+// Reviewer uses the same compound provider/model/effort selection shape as direct Subagents, but
+// keeps an independent persisted policy and runtime admission path.
+export type ReviewerModelConfiguration = SubagentModelConfiguration
+
+export const DEFAULT_REVIEWER_MODEL_CONFIGURATION: ReviewerModelConfiguration = Object.freeze({
+  mode: 'inherit'
+})
+
 // Desktop notifications for finished/failed agent tasks are opt-out: they only fire while the app
 // is unfocused, so the default surprises no one staring at the window.
 export const DEFAULT_NOTIFICATIONS_ENABLED = true
@@ -413,6 +421,7 @@ export type SettingsSnapshot = {
   // default untouched; concrete levels apply to subsequent requests when the agent supports them.
   reasoningEffort: ReasoningEffort
   subagentModel?: SubagentModelConfiguration
+  reviewerModel?: ReviewerModelConfiguration
   // Whether the app posts an OS notification when an agent task finishes or fails while unfocused.
   notificationsEnabled: boolean
   // Whether conversations may detect attached Skill packages and request an app-owned import flow.
@@ -452,6 +461,10 @@ export type SetReasoningEffortRequest = {
 
 export type SetSubagentModelRequest = {
   configuration: SubagentModelConfiguration
+}
+
+export type SetReviewerModelRequest = {
+  configuration: ReviewerModelConfiguration
 }
 
 export type SetNotificationsEnabledRequest = {

--- a/src/shared/web-api-map.generated.ts
+++ b/src/shared/web-api-map.generated.ts
@@ -215,6 +215,7 @@ export const WEB_INVOKE_CHANNELS = {
   'settings.setPackageMirror': 'settings:set-package-mirror',
   'settings.setProjectFilesFilter': 'settings:set-project-files-filter',
   'settings.setReasoningEffort': 'settings:set-reasoning-effort',
+  'settings.setReviewerModel': 'settings:set-reviewer-model',
   'settings.setSkillEnabled': 'settings:set-skill-enabled',
   'settings.setSkillsEnabled': 'settings:set-skills-enabled',
   'settings.setSubagentModel': 'settings:set-subagent-model',


### PR DESCRIPTION
## Problem

Reviewer execution implicitly reused the active Main runtime and renderer-provided model label. Users could not choose a dedicated Reviewer provider/model/effort, and the stored `Review.model` could diverge from the backend that actually performed the review.

Closes #1195.

## Proposed change

- Add an application-wide Reviewer model policy under Settings > Model Providers: follow the active model or pin a provider, model, and reasoning effort.
- Admit Reviewer execution in Main. A fixed selection owns one fully resolved backend and isolated ACP runtime for the complete initial-review / correction / scoped-re-review chain.
- Keep correction prompts on the Main conversation runtime, while all Reviewer analysis and re-review work uses the admitted Reviewer runtime.
- Route automatic, manual, rerun, and delegated-audit entry points through the same Main-owned admission path.
- Persist the actual pinned runtime model on the Review row and fail with an actionable Reviewer error when a stored fixed selection is no longer available.
- Make admission, release, and application shutdown share explicit resource-ownership barriers so backend leases and agent processes cannot outlive teardown.

## Scope and non-goals

- Included: `claude-code`, `opencode`, `codex-response` (native and compatibility routes), and `codex-bridge` backend paths.
- Included: settings/IPC/preload/web contracts, renderer policy UI, Main orchestration, lifecycle cleanup, and module-impact certification.
- Not included: per-project or per-session Reviewer overrides, a Review schema migration, historical Review backfill, or changes to Reviewer lifecycle/outcome states.

## Compatibility, state, and persistence

- Historical settings without `reviewerModel`, or with malformed values, load as `inherit`.
- Existing Review rows remain unchanged; future rows continue to use the existing `Review.model` column.
- Deleting a provider preserves a stored fixed Reviewer selection. A future run reports that the configured Reviewer model is unavailable instead of silently switching models; an already admitted run retains its backend lease.
- The only new persisted value is optional `settings.json.reviewerModel` with the `inherit | fixed` configuration discriminant. There is no Prisma/database migration and no new Review lifecycle/outcome enum value.

## Validation

- `npm run test:module -- reviewer_orchestrator` — 27 files, 420 tests passed.
- `npm run test:module -- settings_repository` — 19 files, 545 tests passed.
- `npm run test:module -- settings_service_facade` — 28 files, 701 tests passed.
- `npm run test:module -- settings_backend_resolution` — 34 files passed / 1 skipped; 453 tests passed / 3 skipped.
- `npm run test:module -- workspace_runtime` — 6 files, 286 tests passed.
- `npm run test:module -- workspace_page` — 23 files, 387 tests passed.
- Settings renderer suites — 2 files, 67 tests passed.
- Real ACP Reviewer protocol matrix — 12 tests passed across Claude role/MCP, Codex permission and elicitation behavior, bridge activation/rollback, OpenCode spoof rejection, and cleanup.
- `npm run typecheck:node` and `npm run typecheck:web` — passed.
- `npm run check:web-api-map` — passed.
- `npm run lint` — passed with 0 errors and 10 pre-existing warnings outside this change.

Per maintainer request, the full local `npm test` suite was not run; exact-head PR CI is the authoritative full-suite check.

## Review focus

- Main-owned backend admission and lease/process teardown under concurrent release and shutdown.
- Reviewer-vs-Main runtime separation in the correction loop.
- Missing/malformed settings compatibility and unavailable fixed-selection behavior.
- Cross-framework Reviewer protocol behavior, especially bridge-scoped tools and permissions.
