### PR TITLE
feat(cli): add codex device login

### DIFF
--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -70,6 +70,9 @@ on any browser-capable device, enter the code, and keep the terminal open until 
 success. Credentials are written only to the app-owned
 <code>codex-subscription/auth.json</code> profile.
 
+The native login follows the profile's saved Network proxy mode. Manual uses the configured proxy,
+Direct clears inherited proxy variables, and System uses the environment that launched the CLI.
+
 When that profile already contains credentials, the command exits without replacing them. Start a
 new device-code flow explicitly with:
 

--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -55,6 +55,32 @@ human-readable, JSON, and JSONL output never includes the local token.
 Use `--port <port>` to override the default port of `44100`. `--app-path <path>` selects a specific
 Open Science executable. Development builds also support `--config-root <path>`.
 
+## Codex subscription sign-in
+
+Sign the Open Science Codex profile in from a server terminal without starting the daemon or opening
+the Web UI:
+
+```bash
+open-science codex login
+```
+
+The command runs the native Codex version already configured by Open Science with OAuth device-code
+authentication. It prints a verification URL and one-time code in the current terminal; open the URL
+on any browser-capable device, enter the code, and keep the terminal open until Codex reports
+success. Credentials are written only to the app-owned
+<code>codex-subscription/auth.json</code> profile.
+
+When that profile already contains credentials, the command exits without replacing them. Start a
+new device-code flow explicitly with:
+
+```bash
+open-science codex login --force
+```
+
+The login command is interactive and intentionally does not support <code>--json</code> or
+<code>--jsonl</code>. It does not contact the Open Science daemon or expose the one-time code through
+daemon logs.
+
 ### Linux AppImage sandbox fallback
 
 `open-science start` keeps Chromium sandboxing enabled by default. On some Linux hosts, an AppImage

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -12,6 +12,7 @@ import { spawn, spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
 import { findServiceState, readWebToken, resolveConfigRoot, STATE_FILE } from './config-root.mjs'
+import { codexLoginCommand } from './codex-login.mjs'
 import { connectToOpenScience } from './index.mjs'
 import { locateApp } from './locate-app.mjs'
 
@@ -26,6 +27,7 @@ Commands:
   stop        Gracefully stop the backend
   status      Show backend status
   url         Print the authenticated web URL
+  codex login [--force]
   project list
   project create <name> [--description <text>]
   run --project <id-or-name> (--prompt <text> | --prompt-file <path>) [--wait]
@@ -56,6 +58,7 @@ Options:
   --yes                  Confirm the offline rollback conversion
   --no-open              Do not open the browser after start
   --no-sandbox           Disable Chromium's process sandbox (security risk; start only)
+  --force                Sign in again even when Codex credentials already exist
   --json                 Emit one machine-readable result
   -h, --help             Show this help`
 
@@ -78,7 +81,7 @@ const VALUE_OPTIONS = {
 }
 
 const TASK_COMMANDS = new Set(['project', 'run', 'session', 'artifacts'])
-const GROUP_COMMANDS = new Set(['project', 'session', 'artifacts'])
+const GROUP_COMMANDS = new Set(['codex', 'project', 'session', 'artifacts'])
 
 export class CliUsageError extends Error {
   constructor(message) {
@@ -110,6 +113,7 @@ export const parseCliArgs = (argv) => {
     else if (arg === '--no-sandbox') options.noSandbox = true
     else if (arg === '--json') options.json = true
     else if (arg === '--yes') options.yes = true
+    else if (arg === '--force') options.force = true
     else if (arg === '--jsonl') options.jsonl = true
     else if (arg === '--wait') options.wait = true
     else if (arg === '--cancel-on-timeout') options.cancelOnTimeout = true
@@ -171,6 +175,15 @@ export const parseCliArgs = (argv) => {
   }
   if (options.dataRoot && command !== 'rollback-to-0.7.3') {
     throw new CliUsageError('--data-root requires rollback-to-0.7.3.')
+  }
+  if (options.force && (command !== 'codex' || subcommand !== 'login')) {
+    throw new CliUsageError('--force requires codex login.')
+  }
+  if (command === 'codex' && subcommand === 'login') {
+    if (options.json || options.jsonl) {
+      throw new CliUsageError('codex login does not support machine-readable output.')
+    }
+    if (positionals.length > 0) throw new CliUsageError('codex login accepts no arguments.')
   }
   return {
     command,
@@ -826,6 +839,7 @@ export const runCli = async (argv = process.argv.slice(2)) => {
   else if (command === 'stop') await stopCommand(options)
   else if (command === 'status') await statusCommand(options)
   else if (command === 'url') await urlCommand(options)
+  else if (command === 'codex' && parsed.subcommand === 'login') await codexLoginCommand(options)
   else if (command === 'rollback-to-0.7.3') await rollbackCommand(options)
   else if (TASK_COMMANDS.has(command)) await runTaskCommand(parsed)
   else throw new CliUsageError(`Unknown command: ${command}\n\n${usage}`)

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -123,6 +123,18 @@ describe('task CLI', () => {
     )
     expect(() => parseCliArgs(['run', '--cwd', '   '])).toThrow('--cwd requires a non-empty path.')
     expect(() => parseCliArgs(['status', '--unknown'])).toThrow('Unknown option: --unknown')
+    expect(parseCliArgs(['codex', 'login', '--force'])).toEqual({
+      command: 'codex',
+      subcommand: 'login',
+      options: { open: true, json: false, force: true }
+    })
+    expect(() => parseCliArgs(['codex', 'login', '--json'])).toThrow(
+      'codex login does not support machine-readable output.'
+    )
+    expect(() => parseCliArgs(['codex', 'login', 'extra'])).toThrow(
+      'codex login accepts no arguments.'
+    )
+    expect(() => parseCliArgs(['status', '--force'])).toThrow('--force requires codex login.')
   })
 
   it('reads a prompt file, waits for completion, and emits one JSON result', async () => {

--- a/packages/open-science/codex-login.mjs
+++ b/packages/open-science/codex-login.mjs
@@ -1,0 +1,174 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+import { spawn } from 'node:child_process'
+import { access, mkdir, readFile } from 'node:fs/promises'
+import { isAbsolute, join, normalize } from 'node:path'
+
+import { resolveConfigRoot } from './config-root.mjs'
+import { locateApp } from './locate-app.mjs'
+
+const CODEX_CONFIG_OVERRIDE = 'cli_auth_credentials_store="file"'
+const CODEX_ENV_KEYS = [
+  'CODEX_API_KEY',
+  'OPENAI_API_KEY',
+  'CODEX_CONFIG',
+  'CODEX_HOME',
+  'CODEX_PATH',
+  'DEFAULT_AUTH_REQUEST',
+  'HOME',
+  'MODEL_PROVIDER',
+  'NO_BROWSER',
+  'USERPROFILE'
+]
+
+export class CodexLoginError extends Error {
+  constructor(message, code = 'codex_login_failed', exitCode = 1) {
+    super(message)
+    this.name = 'CodexLoginError'
+    this.code = code
+    this.exitCode = exitCode
+  }
+}
+
+export const createCodexLoginEnvironment = (
+  codexHome,
+  sourceEnv = process.env,
+  platform = process.platform
+) => {
+  const env = { ...sourceEnv }
+  for (const key of CODEX_ENV_KEYS) delete env[key]
+  env.CODEX_HOME = codexHome
+  env.HOME = codexHome
+  if (platform === 'win32') env.USERPROFILE = codexHome
+  return env
+}
+
+export const resolveConfiguredCodexNativePath = async (configRoot, dependencies = {}) => {
+  const deps = {
+    readFile: (path) => readFile(path, 'utf8'),
+    access: (path) => access(path),
+    ...dependencies
+  }
+  let settings
+  try {
+    settings = JSON.parse(await deps.readFile(join(configRoot, 'settings.json')))
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      throw new CodexLoginError(
+        'Codex is not configured for this Open Science profile. Configure the Codex runtime first.',
+        'codex_not_configured'
+      )
+    }
+    throw new CodexLoginError(
+      'Open Science could not read the configured Codex runtime.',
+      'codex_configuration_invalid'
+    )
+  }
+
+  const nativePath =
+    typeof settings?.codex?.nativePath === 'string' ? settings.codex.nativePath.trim() : ''
+  if (!nativePath || !isAbsolute(nativePath)) {
+    throw new CodexLoginError(
+      'The configured Codex runtime has no native CLI path. Repair the Codex installation first.',
+      'codex_not_configured'
+    )
+  }
+
+  const resolvedPath = normalize(nativePath)
+  try {
+    await deps.access(resolvedPath)
+  } catch {
+    throw new CodexLoginError(
+      'The configured Codex CLI does not exist: ' + resolvedPath,
+      'codex_not_found'
+    )
+  }
+  return resolvedPath
+}
+
+export const runCodexProcess = (codexPath, args, options = {}) =>
+  new Promise((resolveRun, rejectRun) => {
+    const needsShell = process.platform === 'win32' && /\.(?:cmd|bat)$/i.test(codexPath)
+    const child = spawn(needsShell ? '"' + codexPath + '"' : codexPath, args, {
+      env: options.env,
+      shell: needsShell,
+      stdio: options.inherit ? 'inherit' : ['ignore', 'pipe', 'pipe'],
+      windowsHide: true
+    })
+    let stdout = ''
+    let stderr = ''
+    if (!options.inherit) {
+      child.stdout?.setEncoding('utf8')
+      child.stderr?.setEncoding('utf8')
+      child.stdout?.on('data', (chunk) => {
+        stdout += chunk
+      })
+      child.stderr?.on('data', (chunk) => {
+        stderr += chunk
+      })
+    }
+    child.once('error', rejectRun)
+    child.once('exit', (code, signal) => resolveRun({ code, signal, stdout, stderr }))
+  })
+
+const DEFAULT_DEPS = {
+  locateApp: (options) => locateApp(options),
+  resolveConfigRoot: (options) => resolveConfigRoot(options),
+  resolveNativePath: (configRoot) => resolveConfiguredCodexNativePath(configRoot),
+  mkdir: (path) => mkdir(path, { recursive: true }),
+  runCodex: runCodexProcess,
+  log: (...args) => console.log(...args)
+}
+
+export const codexLoginCommand = async (options, dependencies = {}) => {
+  const deps = { ...DEFAULT_DEPS, ...dependencies }
+  const app = await deps.locateApp({ appPath: options.appPath })
+  if (app.packaged && options.configRoot) {
+    throw new CodexLoginError(
+      '--config-root is only supported for development builds.',
+      'invalid_cli_usage',
+      2
+    )
+  }
+  const configRoot = deps.resolveConfigRoot({
+    packaged: app.packaged,
+    override: options.configRoot,
+    env: app.packaged ? {} : process.env
+  })
+  const codexPath = await deps.resolveNativePath(configRoot)
+  const codexHome = join(configRoot, 'codex-subscription')
+  await deps.mkdir(codexHome)
+  const env = createCodexLoginEnvironment(codexHome)
+  const baseArgs = ['-c', CODEX_CONFIG_OVERRIDE, 'login']
+
+  if (!options.force) {
+    const status = await deps.runCodex(codexPath, [...baseArgs, 'status'], {
+      env,
+      inherit: false
+    })
+    if (status.code === 0) {
+      deps.log(
+        'Codex is already signed in for Open Science. Use "open-science codex login --force" to sign in again.'
+      )
+      return
+    }
+    if (status.code !== 1 || status.signal) {
+      throw new CodexLoginError('Open Science could not check the existing Codex sign-in.')
+    }
+  }
+
+  deps.log('Starting Codex device-code sign-in. Keep this terminal open until it completes...')
+  const login = await deps.runCodex(codexPath, [...baseArgs, '--device-auth'], {
+    env,
+    inherit: true
+  })
+  if (login.code !== 0 || login.signal) {
+    const suffix = login.signal ? ' after receiving ' + login.signal : ''
+    throw new CodexLoginError(
+      'Codex device-code sign-in did not complete' + suffix + '.',
+      'codex_login_failed',
+      login.code ?? 1
+    )
+  }
+  deps.log('Codex is signed in for Open Science.')
+}

--- a/packages/open-science/codex-login.mjs
+++ b/packages/open-science/codex-login.mjs
@@ -20,6 +20,26 @@ const CODEX_ENV_KEYS = [
   'NO_BROWSER',
   'USERPROFILE'
 ]
+const PROXY_ENV_KEYS = [
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+  'NO_PROXY',
+  'no_proxy'
+]
+const PROXY_SERVER_ENV_KEYS = PROXY_ENV_KEYS.slice(0, 6)
+const LOOPBACK_PROXY_BYPASS = [
+  'localhost',
+  '.localhost',
+  '127.0.0.1',
+  '127.0.0.0/8',
+  '::1',
+  '[::1]'
+]
+const SUPPORTED_PROXY_PROTOCOLS = new Set(['http:', 'https:', 'socks:', 'socks4:', 'socks5:'])
 
 export class CodexLoginError extends Error {
   constructor(message, code = 'codex_login_failed', exitCode = 1) {
@@ -30,20 +50,83 @@ export class CodexLoginError extends Error {
   }
 }
 
+const normalizedProxySettings = (value) => {
+  if (!value || typeof value !== 'object') return { mode: 'system' }
+  if (value.mode === 'direct') return { mode: 'direct' }
+  if (value.mode !== 'manual' || typeof value.server !== 'string') return { mode: 'system' }
+
+  try {
+    const url = new URL(value.server.trim())
+    if (
+      !SUPPORTED_PROXY_PROTOCOLS.has(url.protocol) ||
+      !url.hostname ||
+      url.username ||
+      url.password ||
+      (url.pathname !== '' && url.pathname !== '/') ||
+      url.search ||
+      url.hash
+    ) {
+      return { mode: 'system' }
+    }
+    const bypassRules =
+      typeof value.bypassRules === 'string'
+        ? value.bypassRules
+            .split(/[,;\n]/)
+            .map((entry) => entry.trim())
+            .filter(Boolean)
+        : []
+    return {
+      mode: 'manual',
+      server: `${url.protocol}//${url.host}`,
+      bypassRules
+    }
+  } catch {
+    return { mode: 'system' }
+  }
+}
+
+const withLoopbackProxyBypass = (env, configuredRules = []) => {
+  const inheritedRules = [env.NO_PROXY, env.no_proxy]
+    .flatMap((value) => value?.split(',') ?? [])
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+  const bypass = [
+    ...new Set([...configuredRules, ...inheritedRules, ...LOOPBACK_PROXY_BYPASS])
+  ].join(',')
+  env.NO_PROXY = bypass
+  env.no_proxy = bypass
+}
+
+export const applyCodexLoginProxyPolicy = (env, value) => {
+  const settings = normalizedProxySettings(value)
+  if (settings.mode === 'system') {
+    if (PROXY_SERVER_ENV_KEYS.some((key) => Boolean(env[key]))) withLoopbackProxyBypass(env)
+    return env
+  }
+
+  for (const key of PROXY_ENV_KEYS) delete env[key]
+  if (settings.mode === 'direct') return env
+
+  for (const key of PROXY_SERVER_ENV_KEYS) env[key] = settings.server
+  withLoopbackProxyBypass(env, settings.bypassRules)
+  return env
+}
+
 export const createCodexLoginEnvironment = (
   codexHome,
   sourceEnv = process.env,
-  platform = process.platform
+  platform = process.platform,
+  networkProxy
 ) => {
   const env = { ...sourceEnv }
   for (const key of CODEX_ENV_KEYS) delete env[key]
   env.CODEX_HOME = codexHome
   env.HOME = codexHome
   if (platform === 'win32') env.USERPROFILE = codexHome
-  return env
+  return applyCodexLoginProxyPolicy(env, networkProxy)
 }
 
-export const resolveConfiguredCodexNativePath = async (configRoot, dependencies = {}) => {
+export const resolveCodexLoginConfiguration = async (configRoot, dependencies = {}) => {
   const deps = {
     readFile: (path) => readFile(path, 'utf8'),
     access: (path) => access(path),
@@ -83,8 +166,11 @@ export const resolveConfiguredCodexNativePath = async (configRoot, dependencies 
       'codex_not_found'
     )
   }
-  return resolvedPath
+  return { codexPath: resolvedPath, networkProxy: settings.networkProxy }
 }
+
+export const resolveConfiguredCodexNativePath = async (configRoot, dependencies = {}) =>
+  (await resolveCodexLoginConfiguration(configRoot, dependencies)).codexPath
 
 export const runCodexProcess = (codexPath, args, options = {}) =>
   new Promise((resolveRun, rejectRun) => {
@@ -114,7 +200,7 @@ export const runCodexProcess = (codexPath, args, options = {}) =>
 const DEFAULT_DEPS = {
   locateApp: (options) => locateApp(options),
   resolveConfigRoot: (options) => resolveConfigRoot(options),
-  resolveNativePath: (configRoot) => resolveConfiguredCodexNativePath(configRoot),
+  resolveConfiguration: (configRoot) => resolveCodexLoginConfiguration(configRoot),
   mkdir: (path) => mkdir(path, { recursive: true }),
   runCodex: runCodexProcess,
   log: (...args) => console.log(...args)
@@ -135,10 +221,10 @@ export const codexLoginCommand = async (options, dependencies = {}) => {
     override: options.configRoot,
     env: app.packaged ? {} : process.env
   })
-  const codexPath = await deps.resolveNativePath(configRoot)
+  const { codexPath, networkProxy } = await deps.resolveConfiguration(configRoot)
   const codexHome = join(configRoot, 'codex-subscription')
   await deps.mkdir(codexHome)
-  const env = createCodexLoginEnvironment(codexHome)
+  const env = createCodexLoginEnvironment(codexHome, process.env, process.platform, networkProxy)
   const baseArgs = ['-c', CODEX_CONFIG_OVERRIDE, 'login']
 
   if (!options.force) {

--- a/packages/open-science/codex-login.test.ts
+++ b/packages/open-science/codex-login.test.ts
@@ -1,0 +1,171 @@
+import { resolve } from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  CodexLoginError,
+  codexLoginCommand,
+  createCodexLoginEnvironment,
+  resolveConfiguredCodexNativePath
+} from './codex-login.mjs'
+
+const configRoot = resolve('open-science-config')
+const codexPath = resolve('managed-codex', process.platform === 'win32' ? 'codex.exe' : 'codex')
+
+// The exact Vitest mock tuple types are test-local implementation detail.
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const commandDeps = (runCodex = vi.fn()) => ({
+  locateApp: vi.fn().mockResolvedValue({ packaged: false }),
+  resolveConfigRoot: vi.fn().mockReturnValue(configRoot),
+  resolveNativePath: vi.fn().mockResolvedValue(codexPath),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  runCodex,
+  log: vi.fn()
+})
+
+describe('Codex CLI login', () => {
+  it('isolates Codex credentials from the user environment', () => {
+    const codexHome = resolve('profile', 'codex-subscription')
+    const env = createCodexLoginEnvironment(
+      codexHome,
+      {
+        PATH: '/usr/bin',
+        HOME: '/home/alice',
+        USERPROFILE: '/users/alice',
+        CODEX_HOME: '/home/alice/.codex',
+        CODEX_API_KEY: 'secret',
+        OPENAI_API_KEY: 'secret',
+        CODEX_CONFIG: 'secret',
+        CODEX_PATH: '/other/codex',
+        DEFAULT_AUTH_REQUEST: 'browser',
+        MODEL_PROVIDER: 'other',
+        NO_BROWSER: '1'
+      },
+      'win32'
+    )
+
+    expect(env).toMatchObject({
+      PATH: '/usr/bin',
+      CODEX_HOME: codexHome,
+      HOME: codexHome,
+      USERPROFILE: codexHome
+    })
+    expect(env).not.toHaveProperty('CODEX_API_KEY')
+    expect(env).not.toHaveProperty('OPENAI_API_KEY')
+    expect(env).not.toHaveProperty('CODEX_CONFIG')
+    expect(env).not.toHaveProperty('CODEX_PATH')
+    expect(env).not.toHaveProperty('DEFAULT_AUTH_REQUEST')
+    expect(env).not.toHaveProperty('MODEL_PROVIDER')
+    expect(env).not.toHaveProperty('NO_BROWSER')
+  })
+
+  it('uses the absolute native Codex path recorded in settings', async () => {
+    const readFile = vi.fn().mockResolvedValue(JSON.stringify({ codex: { nativePath: codexPath } }))
+    const access = vi.fn().mockResolvedValue(undefined)
+
+    await expect(resolveConfiguredCodexNativePath(configRoot, { readFile, access })).resolves.toBe(
+      codexPath
+    )
+    expect(readFile).toHaveBeenCalledWith(resolve(configRoot, 'settings.json'))
+    expect(access).toHaveBeenCalledWith(codexPath)
+  })
+
+  it('fails closed when no native Codex path is configured', async () => {
+    await expect(
+      resolveConfiguredCodexNativePath(configRoot, {
+        readFile: vi.fn().mockResolvedValue(JSON.stringify({ codex: {} })),
+        access: vi.fn()
+      })
+    ).rejects.toMatchObject({
+      code: 'codex_not_configured',
+      message: expect.stringContaining('no native CLI path')
+    })
+  })
+
+  it('does not replace an existing Open Science Codex login by default', async () => {
+    const runCodex = vi.fn().mockResolvedValue({ code: 0, signal: null, stdout: '', stderr: '' })
+    const deps = commandDeps(runCodex)
+
+    await codexLoginCommand({ force: false }, deps)
+
+    expect(runCodex).toHaveBeenCalledTimes(1)
+    expect(runCodex.mock.calls[0][1]).toEqual([
+      '-c',
+      'cli_auth_credentials_store="file"',
+      'login',
+      'status'
+    ])
+    expect(deps.log).toHaveBeenCalledWith(expect.stringContaining('--force'))
+  })
+
+  it('runs native device auth in the current terminal for a signed-out profile', async () => {
+    const runCodex = vi
+      .fn()
+      .mockResolvedValueOnce({ code: 1, signal: null, stdout: '', stderr: 'Not logged in' })
+      .mockResolvedValueOnce({ code: 0, signal: null, stdout: '', stderr: '' })
+    const deps = commandDeps(runCodex)
+
+    await codexLoginCommand({ force: false }, deps)
+
+    expect(runCodex).toHaveBeenNthCalledWith(
+      2,
+      codexPath,
+      ['-c', 'cli_auth_credentials_store="file"', 'login', '--device-auth'],
+      expect.objectContaining({
+        inherit: true,
+        env: expect.objectContaining({
+          CODEX_HOME: resolve(configRoot, 'codex-subscription'),
+          HOME: resolve(configRoot, 'codex-subscription')
+        })
+      })
+    )
+    expect(deps.log).toHaveBeenLastCalledWith('Codex is signed in for Open Science.')
+  })
+
+  it('starts a replacement login without checking status when forced', async () => {
+    const runCodex = vi.fn().mockResolvedValue({ code: 0, signal: null, stdout: '', stderr: '' })
+    const deps = commandDeps(runCodex)
+
+    await codexLoginCommand({ force: true }, deps)
+
+    expect(runCodex).toHaveBeenCalledOnce()
+    expect(runCodex.mock.calls[0][1]).toContain('--device-auth')
+  })
+
+  it('preserves the native login exit code on failure', async () => {
+    const runCodex = vi
+      .fn()
+      .mockResolvedValueOnce({ code: 1, signal: null, stdout: '', stderr: 'Not logged in' })
+      .mockResolvedValueOnce({ code: 17, signal: null, stdout: '', stderr: '' })
+
+    await expect(codexLoginCommand({ force: false }, commandDeps(runCodex))).rejects.toEqual(
+      expect.objectContaining({
+        name: 'CodexLoginError',
+        code: 'codex_login_failed',
+        exitCode: 17
+      })
+    )
+  })
+
+  it('rejects config-root overrides for packaged profiles', async () => {
+    const deps = {
+      ...commandDeps(),
+      locateApp: vi.fn().mockResolvedValue({ packaged: true })
+    }
+
+    await expect(codexLoginCommand({ configRoot, force: false }, deps)).rejects.toEqual(
+      expect.objectContaining({
+        code: 'invalid_cli_usage',
+        exitCode: 2
+      })
+    )
+  })
+
+  it('uses a typed error contract for callers', () => {
+    expect(new CodexLoginError('failed')).toMatchObject({
+      name: 'CodexLoginError',
+      code: 'codex_login_failed',
+      exitCode: 1
+    })
+  })
+})

--- a/packages/open-science/codex-login.test.ts
+++ b/packages/open-science/codex-login.test.ts
@@ -4,8 +4,10 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   CodexLoginError,
+  applyCodexLoginProxyPolicy,
   codexLoginCommand,
   createCodexLoginEnvironment,
+  resolveCodexLoginConfiguration,
   resolveConfiguredCodexNativePath
 } from './codex-login.mjs'
 
@@ -17,7 +19,7 @@ const codexPath = resolve('managed-codex', process.platform === 'win32' ? 'codex
 const commandDeps = (runCodex = vi.fn()) => ({
   locateApp: vi.fn().mockResolvedValue({ packaged: false }),
   resolveConfigRoot: vi.fn().mockReturnValue(configRoot),
-  resolveNativePath: vi.fn().mockResolvedValue(codexPath),
+  resolveConfiguration: vi.fn().mockResolvedValue({ codexPath }),
   mkdir: vi.fn().mockResolvedValue(undefined),
   runCodex,
   log: vi.fn()
@@ -59,12 +61,73 @@ describe('Codex CLI login', () => {
     expect(env).not.toHaveProperty('NO_BROWSER')
   })
 
+  it('applies the configured manual proxy without inheriting stale proxy values', () => {
+    const env = applyCodexLoginProxyPolicy(
+      {
+        HTTP_PROXY: 'http://stale.example.test:8080',
+        NO_PROXY: 'stale.internal'
+      },
+      {
+        mode: 'manual',
+        server: 'socks5://127.0.0.1:1086',
+        bypassRules: 'example.internal'
+      }
+    )
+
+    expect(env.HTTP_PROXY).toBe('socks5://127.0.0.1:1086')
+    expect(env.HTTPS_PROXY).toBe('socks5://127.0.0.1:1086')
+    expect(env.ALL_PROXY).toBe('socks5://127.0.0.1:1086')
+    expect(env.NO_PROXY).toContain('example.internal')
+    expect(env.NO_PROXY).toContain('127.0.0.1')
+    expect(env.NO_PROXY).not.toContain('stale.internal')
+    expect(env.no_proxy).toBe(env.NO_PROXY)
+  })
+
+  it('clears inherited proxy values in Direct mode', () => {
+    const env = applyCodexLoginProxyPolicy(
+      {
+        HTTP_PROXY: 'http://stale.example.test:8080',
+        HTTPS_PROXY: 'http://stale.example.test:8080',
+        NO_PROXY: 'stale.internal'
+      },
+      { mode: 'direct' }
+    )
+
+    expect(env).not.toHaveProperty('HTTP_PROXY')
+    expect(env).not.toHaveProperty('HTTPS_PROXY')
+    expect(env).not.toHaveProperty('NO_PROXY')
+  })
+
+  it('preserves inherited proxy values in System mode and adds loopback bypasses', () => {
+    const env = applyCodexLoginProxyPolicy(
+      {
+        HTTPS_PROXY: 'http://system.example.test:8080',
+        NO_PROXY: 'existing.internal'
+      },
+      undefined
+    )
+
+    expect(env.HTTPS_PROXY).toBe('http://system.example.test:8080')
+    expect(env.NO_PROXY).toContain('existing.internal')
+    expect(env.NO_PROXY).toContain('localhost')
+    expect(env.no_proxy).toBe(env.NO_PROXY)
+  })
+
   it('uses the absolute native Codex path recorded in settings', async () => {
-    const readFile = vi.fn().mockResolvedValue(JSON.stringify({ codex: { nativePath: codexPath } }))
+    const networkProxy = { mode: 'direct' }
+    const readFile = vi
+      .fn()
+      .mockResolvedValue(JSON.stringify({ codex: { nativePath: codexPath }, networkProxy }))
     const access = vi.fn().mockResolvedValue(undefined)
 
     await expect(resolveConfiguredCodexNativePath(configRoot, { readFile, access })).resolves.toBe(
       codexPath
+    )
+    await expect(resolveCodexLoginConfiguration(configRoot, { readFile, access })).resolves.toEqual(
+      {
+        codexPath,
+        networkProxy
+      }
     )
     expect(readFile).toHaveBeenCalledWith(resolve(configRoot, 'settings.json'))
     expect(access).toHaveBeenCalledWith(codexPath)
@@ -104,6 +167,10 @@ describe('Codex CLI login', () => {
       .mockResolvedValueOnce({ code: 1, signal: null, stdout: '', stderr: 'Not logged in' })
       .mockResolvedValueOnce({ code: 0, signal: null, stdout: '', stderr: '' })
     const deps = commandDeps(runCodex)
+    deps.resolveConfiguration.mockResolvedValue({
+      codexPath,
+      networkProxy: { mode: 'manual', server: 'http://proxy.example.test:3128' }
+    })
 
     await codexLoginCommand({ force: false }, deps)
 
@@ -115,7 +182,8 @@ describe('Codex CLI login', () => {
         inherit: true,
         env: expect.objectContaining({
           CODEX_HOME: resolve(configRoot, 'codex-subscription'),
-          HOME: resolve(configRoot, 'codex-subscription')
+          HOME: resolve(configRoot, 'codex-subscription'),
+          HTTPS_PROXY: 'http://proxy.example.test:3128'
         })
       })
     )


### PR DESCRIPTION
## Problem

On headless or remote servers, the existing application login path depends on a browser callback and cannot be completed from terminal-only access. The CLI needs a self-contained login path where the browser may run on another device.

Closes #1189.

## Proposed change

- Add `open-science codex login [--force]`.
- Run the configured native Codex CLI's device-code login directly in the caller's terminal.
- Use an application-owned `CODEX_HOME` and file-backed credential storage.
- Preserve an existing login by default; require `--force` for an explicit re-login.
- Apply the saved Manual, Direct, or System network proxy policy to the native login process.
- Document the command and failure/repair behavior.

## Scope and non-goals

- No Web, renderer, daemon, or browser-callback interaction.
- No ACP changes or dependency upgrades.
- No database/schema/data-model fields.
- No new persisted application status or enum values.
- Persistence is limited to the native Codex profile, primarily `codex-subscription/auth.json`.
- Historical settings without an absolute, existing `codex.nativePath` are not migrated or guessed; the command fails with repair guidance.

## Acceptance criteria and validation

| Behavior | Evidence |
| --- | --- |
| Parser, environment isolation, existing-login safety, device-flow invocation, exit-code propagation | `npm run test:cli` ? 47 tests passed |
| Node contracts | `npm run typecheck:node` ? passed |
| Changed-file lint and formatting | focused ESLint and Prettier checks ? passed |
| Published CLI package includes the new entrypoint | `npm run check:cli-package` ? passed |
| Patch hygiene | `git diff --check` ? passed |

All listed checks were run after the final material edit. Per the requested workflow, the full local `npm test` suite was not run; PR CI is authoritative for the complete suite and cross-platform coverage.

## Review focus

- Credential and environment isolation.
- Default no-overwrite behavior and `--force` semantics.
- Windows `.cmd` / `.bat` launch handling.
- CLI package contents.

