### PR TITLE
feat(cli): add plan and execution controls

### DIFF
--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -186,20 +186,19 @@ open-science run \
   --json
 ```
 
-- --plan-first marks this turn as Plan First. The Run remains running while its generated Plan
+- `--plan-first` marks this turn as Plan First. The Run remains running while its generated Plan
   waits for an explicit response.
-- --auto-review and --no-auto-review update the Session automatic-review setting. When enabled, a
+- `--auto-review` and `--no-auto-review` update the Session automatic-review setting. When enabled, a
   successful turn starts the existing reviewer workflow before the Run becomes terminal; the Run
-  review property reports whether it started and its final lifecycle/outcome.
-- --specialist accepts a Specialist UUID or stable Profile name. It binds only a new Session. An
-  existing Session cannot be rebound, and a presentation displayName is not an identifier.
-- --delegation allow|deny updates whether the Session may create new delegated children. deny does
-  not cancel, hide, or prevent collection/messaging of children admitted earlier.
+  `review` property reports whether it started and its final lifecycle/outcome.
+- `--specialist` accepts a Specialist UUID or stable Profile name. It binds only a new Session. An
+  existing Session cannot be rebound, and a presentation `displayName` is not an identifier.
+- `--delegation allow|deny` updates whether the Session may create new delegated children. `deny`
+  does not cancel, hide, or prevent collection/messaging of children admitted earlier.
 
-Ordinary --wait retains its terminal-only behavior. Add --return-on-attention to return a
-still-running Run when automation must respond to a Plan, permission, or delegated question. The
-current release projects Plan approval as structured Run attention; permission and delegated
-question events remain available from the event stream.
+Ordinary `--wait` retains its terminal-only behavior. Add `--return-on-attention` to return a
+still-running Run when its Plan needs approval. Plan approval is the only structured Run attention
+in this release; permission and delegated-question events do not cause an attention return.
 
 Inspect and respond to an active Plan with its exact version and revision:
 
@@ -217,8 +216,8 @@ continues the parked Run; feedback asks the live Plan interaction for a revision
 
 The controls use the Session JSON authority; they do not add a Prisma/SQLite migration:
 
-- This change adds delegationPolicy with values allow or deny. Historical Session files that omit
-  it, and malformed values, restore as allow.
+- Session JSON stores `delegationPolicy` with values `allow` or `deny`. Historical Session files
+  that omit it, and malformed values, restore as `allow`.
 - autoReviewEnabled and specialistId already existed and are reused. Historical
   autoReviewEnabled omissions remain disabled; an omitted specialistId remains Main Agent.
 - Plan artifacts/approval/continuation continue under runtimeContext.plan; delegated attempts,
@@ -257,13 +256,13 @@ open-science run \
 
 Exit codes form part of the automation contract:
 
-| Exit code | Meaning                                                       |
-| --------- | ------------------------------------------------------------- |
-| `0`       | The command succeeded, including a completed waited run.      |
-| `1`       | A run failed or a general command failure occurred.           |
-| `2`       | CLI usage was invalid.                                        |
-| `3`       | The local daemon was unavailable.                             |
-| `4`       | A requested project, run, session, or artifact was not found. |
+| Exit code | Meaning                                                                   |
+| --------- | ------------------------------------------------------------------------- |
+| `0`       | The command succeeded, including a completed waited run.                  |
+| `1`       | A run failed or a general command failure occurred.                       |
+| `2`       | CLI usage was invalid.                                                    |
+| `3`       | The local daemon was unavailable.                                         |
+| `4`       | A requested project, run, session, artifact, or Specialist was not found. |
 
 Timeouts and `session_busy` conflicts use exit code `1` and retain their distinct `timeout` and
 `session_busy` error codes in structured output.

--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -169,6 +169,64 @@ open-science run \
 The default approval profile is `ask`. Unattended workflows must explicitly use
 `--approval-profile auto` or `--approval-profile full` when that access is appropriate.
 
+### Execution controls
+
+The run command exposes four provider-neutral controls:
+
+```bash
+open-science run \
+  --project "Systematic review" \
+  --prompt-file ./task.md \
+  --plan-first \
+  --auto-review \
+  --specialist literature-reviewer \
+  --delegation deny \
+  --wait \
+  --return-on-attention \
+  --json
+```
+
+- --plan-first marks this turn as Plan First. The Run remains running while its generated Plan
+  waits for an explicit response.
+- --auto-review and --no-auto-review update the Session automatic-review setting. When enabled, a
+  successful turn starts the existing reviewer workflow before the Run becomes terminal; the Run
+  review property reports whether it started and its final lifecycle/outcome.
+- --specialist accepts a Specialist UUID or stable Profile name. It binds only a new Session. An
+  existing Session cannot be rebound, and a presentation displayName is not an identifier.
+- --delegation allow|deny updates whether the Session may create new delegated children. deny does
+  not cancel, hide, or prevent collection/messaging of children admitted earlier.
+
+Ordinary --wait retains its terminal-only behavior. Add --return-on-attention to return a
+still-running Run when automation must respond to a Plan, permission, or delegated question. The
+current release projects Plan approval as structured Run attention; permission and delegated
+question events remain available from the event stream.
+
+Inspect and respond to an active Plan with its exact version and revision:
+
+```bash
+open-science plan show <session-id> --json
+open-science plan approve <session-id> --artifact-version <id> --revision <number> --json
+open-science plan reject <session-id> --artifact-version <id> --revision <number> --json
+open-science plan revise <session-id> --feedback "Split the validation step" --json
+```
+
+Version/revision matching prevents a stale automation client from deciding a newer Plan. Approval
+continues the parked Run; feedback asks the live Plan interaction for a revision.
+
+### Session persistence and compatibility
+
+The controls use the Session JSON authority; they do not add a Prisma/SQLite migration:
+
+- This change adds delegationPolicy with values allow or deny. Historical Session files that omit
+  it, and malformed values, restore as allow.
+- autoReviewEnabled and specialistId already existed and are reused. Historical
+  autoReviewEnabled omissions remain disabled; an omitted specialistId remains Main Agent.
+- Plan artifacts/approval/continuation continue under runtimeContext.plan; delegated attempts,
+  messages, and questions continue under runtimeContext.delegatedWork.
+
+No Session or Run status enum is added. Existing waiting-plan-approval remains the durable Session
+status, while a public Run remains running and carries an attention discriminant.
+
 ## Machine-readable output
 
 Use `--json` to emit one result. `--jsonl` requires `run --wait` and emits progress events followed by

--- a/packages/open-science/README.md
+++ b/packages/open-science/README.md
@@ -57,6 +57,13 @@ await progress
 console.log(observedResult.output)
 ```
 
+Plan First runs can opt into actionable waiting with returnOnAttention. When the returned Run has
+attention.kind equal to plan-approval, use getSessionPlan and respondSessionPlan. Calling waitForRun
+without returnOnAttention keeps the original terminal-only behavior.
+
+Automatic review and Specialist binding reuse existing Session JSON fields. Delegation adds
+delegationPolicy with values allow or deny; an omitted historical value restores as allow.
+
 To stop a still-running task instead of waiting for it, cancel it explicitly. Cancellation waits for
 provider work and application finalization to drain before returning the terminal Run:
 

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -34,6 +34,10 @@ Commands:
   run status <run-id>
   run cancel <run-id>
   session status <session-id>
+  plan show <session-id>
+  plan approve <session-id> --artifact-version <id> --revision <number>
+  plan reject <session-id> --artifact-version <id> --revision <number>
+  plan revise <session-id> --feedback <text>
   artifacts list <session-id>
   artifacts download <artifact-id> --output <path>
   rollback-to-0.7.3 --yes [--output <path>]
@@ -50,7 +54,13 @@ Options:
   --prompt-file <path>   Read the prompt from a UTF-8 file
   --approval-profile <profile>  ask, auto, or full (default: ask)
   --skill <id>           Force-load a skill for this run (repeatable)
+  --plan-first           Require an approved Plan before execution
+  --auto-review          Enable automatic review for this Session
+  --no-auto-review       Disable automatic review for this Session
+  --specialist <id-or-name>  Bind a new Session to a Specialist
+  --delegation <policy>  allow or deny new delegated children
   --wait                 Wait for the run to finish
+  --return-on-attention  With --wait, return when the run needs an external response
   --timeout-ms <ms>      Stop waiting after this many milliseconds
   --cancel-on-timeout    Cancel the server run when --timeout-ms expires
   --jsonl                With run --wait, stream one machine-readable event per line
@@ -75,13 +85,18 @@ const VALUE_OPTIONS = {
   '--prompt': 'prompt',
   '--prompt-file': 'promptFile',
   '--approval-profile': 'approvalProfile',
+  '--specialist': 'specialist',
+  '--delegation': 'delegation',
+  '--artifact-version': 'artifactVersion',
+  '--revision': 'revision',
+  '--feedback': 'feedback',
   '--timeout-ms': 'timeoutMs',
   '--description': 'description',
   '--output': 'output'
 }
 
-const TASK_COMMANDS = new Set(['project', 'run', 'session', 'artifacts'])
-const GROUP_COMMANDS = new Set(['codex', 'project', 'session', 'artifacts'])
+const TASK_COMMANDS = new Set(['project', 'run', 'session', 'plan', 'artifacts'])
+const GROUP_COMMANDS = new Set(['codex', 'project', 'session', 'plan', 'artifacts'])
 
 export class CliUsageError extends Error {
   constructor(message) {
@@ -116,7 +131,19 @@ export const parseCliArgs = (argv) => {
     else if (arg === '--force') options.force = true
     else if (arg === '--jsonl') options.jsonl = true
     else if (arg === '--wait') options.wait = true
-    else if (arg === '--cancel-on-timeout') options.cancelOnTimeout = true
+    else if (arg === '--return-on-attention') options.returnOnAttention = true
+    else if (arg === '--plan-first') options.planFirst = true
+    else if (arg === '--auto-review') {
+      if (options.autoReviewEnabled === false) {
+        throw new CliUsageError('Use only one of --auto-review or --no-auto-review.')
+      }
+      options.autoReviewEnabled = true
+    } else if (arg === '--no-auto-review') {
+      if (options.autoReviewEnabled === true) {
+        throw new CliUsageError('Use only one of --auto-review or --no-auto-review.')
+      }
+      options.autoReviewEnabled = false
+    } else if (arg === '--cancel-on-timeout') options.cancelOnTimeout = true
     else if (arg === '--skill') {
       const value = args.shift()
       if (!value) throw new CliUsageError('--skill requires a value.')
@@ -149,6 +176,16 @@ export const parseCliArgs = (argv) => {
     }
     options.timeoutMs = timeoutMs
   }
+  if (options.revision !== undefined) {
+    const revision = Number(options.revision)
+    if (!Number.isInteger(revision) || revision < 0) {
+      throw new CliUsageError(`Invalid Plan revision: ${options.revision}`)
+    }
+    options.revision = revision
+  }
+  if (options.delegation && !['allow', 'deny'].includes(options.delegation)) {
+    throw new CliUsageError(`Invalid delegation policy: ${options.delegation}`)
+  }
   if (options.json && options.jsonl) {
     throw new CliUsageError('Use only one of --json or --jsonl.')
   }
@@ -163,6 +200,9 @@ export const parseCliArgs = (argv) => {
   }
   if (options.timeoutMs !== undefined && (command !== 'run' || subcommand || !options.wait)) {
     throw new CliUsageError('--timeout-ms requires run --wait.')
+  }
+  if (options.returnOnAttention && (command !== 'run' || subcommand || !options.wait)) {
+    throw new CliUsageError('--return-on-attention requires run --wait.')
   }
   if (options.cancelOnTimeout && options.timeoutMs === undefined) {
     throw new CliUsageError('--cancel-on-timeout requires --timeout-ms.')
@@ -184,6 +224,25 @@ export const parseCliArgs = (argv) => {
       throw new CliUsageError('codex login does not support machine-readable output.')
     }
     if (positionals.length > 0) throw new CliUsageError('codex login accepts no arguments.')
+  }
+  const runOnlyOptions = [
+    ['--plan-first', options.planFirst],
+    ['--auto-review/--no-auto-review', options.autoReviewEnabled !== undefined],
+    ['--specialist', options.specialist !== undefined],
+    ['--delegation', options.delegation !== undefined]
+  ]
+  for (const [label, present] of runOnlyOptions) {
+    if (present && (command !== 'run' || subcommand)) {
+      throw new CliUsageError(`${label} requires run.`)
+    }
+  }
+  if (
+    command !== 'plan' &&
+    (options.artifactVersion !== undefined ||
+      options.revision !== undefined ||
+      options.feedback !== undefined)
+  ) {
+    throw new CliUsageError('Plan response options require a plan command.')
   }
   return {
     command,
@@ -657,6 +716,11 @@ const emitRunEvent = (event, options, deps) => {
     )
   } else if (
     event.type === 'run.event' &&
+    event.data?.planProjection?.lifecycle === 'awaiting_approval'
+  ) {
+    deps.warn('Run is waiting for Plan approval.')
+  } else if (
+    event.type === 'run.event' &&
     event.data?.kind !== 'message' &&
     (event.data?.title || event.data?.text)
   ) {
@@ -704,6 +768,41 @@ export const runTaskCommand = async (parsed, dependencies = {}) => {
     if (!sessionId) throw new CliUsageError('Session id is required.')
     outputValue(await client.getSession(sessionId), options, deps)
     return
+  }
+  if (command === 'plan') {
+    const sessionId = positionals[0]
+    if (!sessionId) throw new CliUsageError('Session id is required.')
+    if (subcommand === 'show') {
+      outputValue(await client.getSessionPlan(sessionId), options, deps)
+      return
+    }
+    if (subcommand === 'approve' || subcommand === 'reject') {
+      if (!options.artifactVersion) {
+        throw new CliUsageError('--artifact-version is required.')
+      }
+      if (options.revision === undefined) {
+        throw new CliUsageError('--revision is required.')
+      }
+      outputValue(
+        await client.respondSessionPlan(sessionId, {
+          decision: subcommand === 'approve' ? 'approved' : 'rejected',
+          artifactVersionId: options.artifactVersion,
+          expectedRevision: options.revision
+        }),
+        options,
+        deps
+      )
+      return
+    }
+    if (subcommand === 'revise') {
+      if (!options.feedback?.trim()) throw new CliUsageError('--feedback is required.')
+      outputValue(
+        await client.respondSessionPlan(sessionId, { feedback: options.feedback.trim() }),
+        options,
+        deps
+      )
+      return
+    }
   }
   if (command === 'artifacts' && subcommand === 'list') {
     const sessionId = positionals[0]
@@ -754,7 +853,13 @@ export const runTaskCommand = async (parsed, dependencies = {}) => {
         ...(options.cwd ? { cwd: resolve(options.cwd) } : {}),
         ...(options.session ? { sessionId: options.session } : {}),
         ...(options.approvalProfile ? { permissionProfile: options.approvalProfile } : {}),
-        ...(options.skills?.length ? { skillIds: options.skills } : {})
+        ...(options.skills?.length ? { skillIds: options.skills } : {}),
+        ...(options.planFirst ? { turnIntent: 'plan-first' } : {}),
+        ...(options.autoReviewEnabled !== undefined
+          ? { autoReviewEnabled: options.autoReviewEnabled }
+          : {}),
+        ...(options.specialist ? { specialist: options.specialist } : {}),
+        ...(options.delegation ? { delegationPolicy: options.delegation } : {})
       })
       sessionIdRef.current = started.sessionId
       for (const event of sessionIdRef.pending.splice(0)) {
@@ -764,10 +869,14 @@ export const runTaskCommand = async (parsed, dependencies = {}) => {
         }
       }
       try {
+        const waitOptions = {
+          ...(options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs }),
+          ...(options.returnOnAttention ? { returnOnAttention: true } : {})
+        }
         result = options.wait
-          ? options.timeoutMs === undefined
+          ? Object.keys(waitOptions).length === 0
             ? await client.waitForRun(started.id)
-            : await client.waitForRun(started.id, { timeoutMs: options.timeoutMs })
+            : await client.waitForRun(started.id, waitOptions)
           : started
       } catch (error) {
         if (options.cancelOnTimeout && error?.code === 'timeout') {
@@ -792,7 +901,12 @@ export const runTaskCommand = async (parsed, dependencies = {}) => {
     else if (result.status === 'completed') deps.log(result.output || `Run completed: ${result.id}`)
     else if (result.status === 'failed') deps.log(`Run failed: ${result.error ?? result.id}`)
     else if (result.status === 'cancelled') deps.log(`Run cancelled: ${result.id}`)
-    else deps.log(`Run started: ${result.id} (session ${result.sessionId})`)
+    else if (result.attention?.kind === 'plan-approval') {
+      const plan = result.attention.plan
+      deps.log(
+        `Run is waiting for Plan approval: open-science plan approve ${result.sessionId} --artifact-version ${plan.artifactVersionId} --revision ${plan.revision}`
+      )
+    } else deps.log(`Run started: ${result.id} (session ${result.sessionId})`)
     if (result.status === 'failed') deps.setExitCode(1)
     return
   }
@@ -816,7 +930,7 @@ export const reportCliError = (error, argv = process.argv.slice(2), dependencies
       ? 3
       : ['project_not_found', 'session_not_found', 'run_not_found', 'artifact_not_found'].includes(
             code
-          )
+          ) || code === 'specialist_not_found'
         ? 4
         : 1)
   if (argv.includes('--json') || argv.includes('--jsonl')) {

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -60,7 +60,7 @@ Options:
   --specialist <id-or-name>  Bind a new Session to a Specialist
   --delegation <policy>  allow or deny new delegated children
   --wait                 Wait for the run to finish
-  --return-on-attention  With --wait, return when the run needs an external response
+  --return-on-attention  With --wait, return when the Plan needs approval
   --timeout-ms <ms>      Stop waiting after this many milliseconds
   --cancel-on-timeout    Cancel the server run when --timeout-ms expires
   --jsonl                With run --wait, stream one machine-readable event per line

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -102,15 +102,42 @@ describe('task CLI', () => {
         '--skill',
         'literature-review',
         '--skill',
-        'citation-check'
+        'citation-check',
+        '--plan-first',
+        '--auto-review',
+        '--specialist',
+        'literature-specialist',
+        '--delegation',
+        'deny',
+        '--wait',
+        '--return-on-attention'
       ])
     ).toMatchObject({
       command: 'run',
       options: {
         session: 'session-1',
         approvalProfile: 'full',
-        skills: ['literature-review', 'citation-check']
+        skills: ['literature-review', 'citation-check'],
+        planFirst: true,
+        autoReviewEnabled: true,
+        specialist: 'literature-specialist',
+        delegation: 'deny',
+        returnOnAttention: true
       }
+    })
+    expect(() => parseCliArgs(['run', '--delegation', 'sometimes'])).toThrow(
+      'Invalid delegation policy: sometimes'
+    )
+    expect(() => parseCliArgs(['run', '--return-on-attention'])).toThrow(
+      '--return-on-attention requires run --wait.'
+    )
+    expect(() => parseCliArgs(['run', '--auto-review', '--no-auto-review'])).toThrow(
+      'Use only one of --auto-review or --no-auto-review.'
+    )
+    expect(parseCliArgs(['plan', 'show', 'session-1', '--json'])).toMatchObject({
+      command: 'plan',
+      subcommand: 'show',
+      positionals: ['session-1']
     })
     expect(() => parseCliArgs(['run', '--approval-profile', 'unsafe'])).toThrow(
       'Invalid approval profile: unsafe'
@@ -183,6 +210,68 @@ describe('task CLI', () => {
     expect(client.waitForRun).toHaveBeenCalledWith('run-1')
     expect(JSON.parse(log.mock.calls[0][0])).toMatchObject({ status: 'completed', output: 'Done' })
     expect(log).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards execution controls and can return on actionable Plan attention', async () => {
+    const attention = {
+      kind: 'plan-approval',
+      plan: { artifactVersionId: 'plan-version', revision: 4 }
+    }
+    const client = {
+      startRun: vi.fn().mockResolvedValue({
+        id: 'run-1',
+        sessionId: 'session-1',
+        status: 'running'
+      }),
+      waitForRun: vi.fn().mockResolvedValue({
+        id: 'run-1',
+        sessionId: 'session-1',
+        projectId: 'project-1',
+        status: 'running',
+        startedAt: 1,
+        artifacts: [],
+        attention
+      })
+    }
+    const log = vi.fn()
+
+    await runTaskCommand(
+      {
+        command: 'run',
+        options: {
+          project: 'project-1',
+          prompt: 'Plan this.',
+          wait: true,
+          returnOnAttention: true,
+          planFirst: true,
+          autoReviewEnabled: true,
+          specialist: 'literature-specialist',
+          delegation: 'deny',
+          json: false,
+          jsonl: false
+        }
+      },
+      {
+        connect: vi.fn().mockResolvedValue(client),
+        log,
+        stdinIsTTY: true
+      }
+    )
+
+    expect(client.startRun).toHaveBeenCalledWith({
+      project: 'project-1',
+      prompt: 'Plan this.',
+      turnIntent: 'plan-first',
+      autoReviewEnabled: true,
+      specialist: 'literature-specialist',
+      delegationPolicy: 'deny'
+    })
+    expect(client.waitForRun).toHaveBeenCalledWith('run-1', {
+      returnOnAttention: true
+    })
+    expect(log).toHaveBeenCalledWith(
+      'Run is waiting for Plan approval: open-science plan approve session-1 --artifact-version plan-version --revision 4'
+    )
   })
 
   it('parses and runs the explicit offline rollback command', async () => {
@@ -312,6 +401,63 @@ describe('task CLI', () => {
     expect(client.listArtifacts).toHaveBeenCalledWith('session-1')
     expect(client.downloadArtifact).toHaveBeenCalledWith('artifact-1')
     expect(writeDownload).toHaveBeenCalledWith(expect.any(Response), 'report.md')
+  })
+
+  it('dispatches Plan show, decision, and revision feedback through the SDK', async () => {
+    const client = {
+      getSessionPlan: vi.fn().mockResolvedValue({
+        artifactVersionId: 'plan-version',
+        revision: 2
+      }),
+      respondSessionPlan: vi.fn().mockResolvedValue({ changed: true })
+    }
+    const deps = {
+      connect: vi.fn().mockResolvedValue(client),
+      log: vi.fn()
+    }
+    const outputOptions = { json: true, jsonl: false }
+
+    await runTaskCommand(
+      {
+        command: 'plan',
+        subcommand: 'show',
+        positionals: ['session-1'],
+        options: outputOptions
+      },
+      deps
+    )
+    await runTaskCommand(
+      {
+        command: 'plan',
+        subcommand: 'approve',
+        positionals: ['session-1'],
+        options: {
+          ...outputOptions,
+          artifactVersion: 'plan-version',
+          revision: 2
+        }
+      },
+      deps
+    )
+    await runTaskCommand(
+      {
+        command: 'plan',
+        subcommand: 'revise',
+        positionals: ['session-1'],
+        options: { ...outputOptions, feedback: 'Split the validation step.' }
+      },
+      deps
+    )
+
+    expect(client.getSessionPlan).toHaveBeenCalledWith('session-1')
+    expect(client.respondSessionPlan).toHaveBeenNthCalledWith(1, 'session-1', {
+      decision: 'approved',
+      artifactVersionId: 'plan-version',
+      expectedRevision: 2
+    })
+    expect(client.respondSessionPlan).toHaveBeenNthCalledWith(2, 'session-1', {
+      feedback: 'Split the validation step.'
+    })
   })
 
   it('reads stdin, emits JSONL events, and sets a failed-run exit code', async () => {

--- a/packages/open-science/client.test.ts
+++ b/packages/open-science/client.test.ts
@@ -29,6 +29,8 @@ describe('OpenScienceClient', () => {
         'createProject',
         'listSessions',
         'getSession',
+        'getSessionPlan',
+        'respondSessionPlan',
         'startRun',
         'getRun',
         'cancelRun',
@@ -123,6 +125,39 @@ describe('OpenScienceClient', () => {
       })
     )
     expect(fetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('returns a running run only when actionable waiting is explicitly enabled', async () => {
+    const attention = {
+      kind: 'plan-approval',
+      plan: { artifactVersionId: 'plan-version', revision: 2 }
+    }
+    const fetch = vi.fn().mockResolvedValue(
+      response(200, {
+        data: {
+          id: 'run-1',
+          sessionId: 'session-1',
+          projectId: 'project-1',
+          status: 'running',
+          startedAt: 1,
+          artifacts: [],
+          attention
+        }
+      })
+    )
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const client = new OpenScienceClient({
+      baseUrl: 'http://127.0.0.1:44100',
+      token: 'secret-token',
+      fetch,
+      sleep
+    })
+
+    await expect(client.waitForRun('run-1', { returnOnAttention: true })).resolves.toMatchObject({
+      status: 'running',
+      attention
+    })
+    expect(sleep).not.toHaveBeenCalled()
   })
 
   it('stops waiting after the requested timeout without cancelling the run', async () => {
@@ -254,6 +289,14 @@ describe('OpenScienceClient', () => {
       if (path === '/api/v1/sessions/session%2F1') {
         return response(200, { data: { id: 'session-1', status: 'idle' } })
       }
+      if (path === '/api/v1/sessions/session%2F1/plan' && init?.method !== 'POST') {
+        return response(200, {
+          data: { artifactVersionId: 'plan-version', revision: 2 }
+        })
+      }
+      if (path === '/api/v1/sessions/session%2F1/plan/respond') {
+        return response(200, { data: { changed: true } })
+      }
       if (path === '/api/v1/sessions/session%2F1/artifacts') {
         return response(200, { data: [{ id: 'artifact-1' }] })
       }
@@ -270,6 +313,12 @@ describe('OpenScienceClient', () => {
     await client.createProject({ name: 'Created' })
     await client.listSessions('Research / Lab')
     await client.getSession('session/1')
+    await client.getSessionPlan('session/1')
+    await client.respondSessionPlan('session/1', {
+      decision: 'approved',
+      artifactVersionId: 'plan-version',
+      expectedRevision: 2
+    })
     await client.listArtifacts('session/1')
     expect(await (await client.downloadArtifact('artifact/1')).text()).toBe('file bytes')
 
@@ -283,6 +332,8 @@ describe('OpenScienceClient', () => {
       '/api/v1/projects',
       '/api/v1/sessions?project=Research%20%2F%20Lab',
       '/api/v1/sessions/session%2F1',
+      '/api/v1/sessions/session%2F1/plan',
+      '/api/v1/sessions/session%2F1/plan/respond',
       '/api/v1/sessions/session%2F1/artifacts',
       '/api/v1/artifacts/artifact%2F1/content'
     ])

--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -62,10 +62,35 @@ export type SessionPlan = {
   }
 }
 
-export type RunAttention =
-  | { kind: 'plan-approval'; plan: SessionPlan }
-  | { kind: 'permission' }
-  | { kind: 'delegated-question' }
+export type RunAttention = { kind: 'plan-approval'; plan: SessionPlan }
+
+export type PlanDecisionResponse = {
+  projection: SessionPlan
+  changed: boolean
+  continuationCommandId?: string
+}
+
+export type PlanFeedbackResponse = {
+  kind: 'feedback'
+  routeToInteractionId: string
+  artifactVersionId: string
+  text: string
+  message: {
+    id: string
+    role: 'user'
+    content: string
+    status: 'complete'
+    responseToMessageId: string
+    eventIds: string[]
+    createdAt: number
+    updatedAt: number
+  }
+  planRevision: number
+  continuationProjection?: SessionPlan
+  continuationCommandId: string
+}
+
+export type PlanResponse = PlanDecisionResponse | PlanFeedbackResponse
 
 export type Run = {
   id: string
@@ -148,7 +173,7 @@ export class OpenScienceClient {
           expectedRevision: number
         }
       | { feedback: string }
-  ): Promise<unknown>
+  ): Promise<PlanResponse>
   startRun(request: {
     project: string
     prompt: string

--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -1,4 +1,6 @@
 export type PermissionProfile = 'ask' | 'auto' | 'full'
+export type DelegationPolicy = 'allow' | 'deny'
+export type TurnIntent = 'plan-first'
 export type RunStatus = 'running' | 'completed' | 'failed' | 'cancelled'
 export type RunProgressPhase =
   | 'accepted'
@@ -29,6 +31,42 @@ export type Project = {
   updatedAt: number
 }
 
+export type PlanLifecycle =
+  | 'awaiting_approval'
+  | 'approved'
+  | 'in_progress'
+  | 'interrupted'
+  | 'blocked'
+  | 'completed'
+  | 'rejected'
+
+export type SessionPlan = {
+  artifactId: string
+  artifactVersionId: string
+  artifactChecksum: string
+  originatingPromptMessageId?: string
+  materializedAt?: number
+  revision: number
+  approval: 'pending' | 'approved' | 'rejected'
+  lifecycle: PlanLifecycle
+  requiresExplicitContinuation: boolean
+  document: unknown
+  stepStatuses: Record<string, unknown>
+  stepStates: Record<string, unknown>
+  counts: {
+    phases: number
+    delegations: number
+    steps: number
+    completed: number
+    inProgress: number
+  }
+}
+
+export type RunAttention =
+  | { kind: 'plan-approval'; plan: SessionPlan }
+  | { kind: 'permission' }
+  | { kind: 'delegated-question' }
+
 export type Run = {
   id: string
   sessionId: string
@@ -42,6 +80,15 @@ export type Run = {
   output?: string
   error?: string
   artifacts: Artifact[]
+  attention?: RunAttention
+  review?: {
+    started: boolean
+    reason?: string
+    id?: string
+    lifecycle?: 'running' | 'complete' | 'error'
+    outcome?: 'pass' | 'flagged' | null
+    errorMessage?: string
+  }
 }
 
 export type SessionStatus =
@@ -53,6 +100,9 @@ export type Session = {
   title: string
   status: SessionStatus
   permissionProfile?: PermissionProfile
+  autoReviewEnabled: boolean
+  specialistId?: string
+  delegationPolicy: DelegationPolicy
   createdAt: number
   updatedAt: number
   output?: string
@@ -88,6 +138,17 @@ export class OpenScienceClient {
   createProject(request: { name: string; description?: string }): Promise<Project>
   listSessions(project?: string): Promise<Session[]>
   getSession(sessionId: string): Promise<Session>
+  getSessionPlan(sessionId: string): Promise<SessionPlan | null>
+  respondSessionPlan(
+    sessionId: string,
+    response:
+      | {
+          decision: 'approved' | 'rejected'
+          artifactVersionId: string
+          expectedRevision: number
+        }
+      | { feedback: string }
+  ): Promise<unknown>
   startRun(request: {
     project: string
     prompt: string
@@ -95,12 +156,21 @@ export class OpenScienceClient {
     sessionId?: string
     permissionProfile?: PermissionProfile
     skillIds?: string[]
+    turnIntent?: TurnIntent
+    autoReviewEnabled?: boolean
+    specialist?: string
+    delegationPolicy?: DelegationPolicy
   }): Promise<Run>
   getRun(runId: string): Promise<Run>
   cancelRun(runId: string): Promise<Run>
   waitForRun(
     runId: string,
-    options?: { pollIntervalMs?: number; signal?: AbortSignal; timeoutMs?: number }
+    options?: {
+      pollIntervalMs?: number
+      returnOnAttention?: boolean
+      signal?: AbortSignal
+      timeoutMs?: number
+    }
   ): Promise<Run>
   listArtifacts(sessionId: string): Promise<Artifact[]>
   downloadArtifact(artifactId: string, options?: { signal?: AbortSignal }): Promise<Response>

--- a/packages/open-science/index.mjs
+++ b/packages/open-science/index.mjs
@@ -58,6 +58,17 @@ export class OpenScienceClient {
     return this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}`)
   }
 
+  getSessionPlan(sessionId) {
+    return this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/plan`)
+  }
+
+  respondSessionPlan(sessionId, response) {
+    return this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/plan/respond`, {
+      method: 'POST',
+      body: response
+    })
+  }
+
   startRun(request) {
     return this.request('/api/v1/runs', { method: 'POST', body: request })
   }
@@ -70,7 +81,10 @@ export class OpenScienceClient {
     return this.request(`/api/v1/runs/${encodeURIComponent(runId)}/cancel`, { method: 'POST' })
   }
 
-  async waitForRun(runId, { pollIntervalMs = 250, signal, timeoutMs } = {}) {
+  async waitForRun(
+    runId,
+    { pollIntervalMs = 250, returnOnAttention = false, signal, timeoutMs } = {}
+  ) {
     if (timeoutMs !== undefined && (!Number.isFinite(timeoutMs) || timeoutMs <= 0)) {
       throw new TypeError('timeoutMs must be a positive number.')
     }
@@ -82,6 +96,7 @@ export class OpenScienceClient {
       }
       const run = await this.getRun(runId)
       if (run.status !== 'running') return run
+      if (returnOnAttention && run.attention) return run
       await this.sleep(pollIntervalMs)
     }
   }

--- a/src/main/acp/application-commands.test.ts
+++ b/src/main/acp/application-commands.test.ts
@@ -412,7 +412,7 @@ describe('ACP application commands', () => {
     expect(dependencies.runtime.respondToPermission).toHaveBeenCalledTimes(humanCallers.length)
   })
 
-  it('routes Plan decisions and revision feedback only from a current human', async () => {
+  it('routes Plan decisions and revision feedback from current humans and Task automation', async () => {
     const dependencies = createDependencies()
     const router = createApplicationCommandRouter()
     registerAcpCommands(router.registrar, dependencies)
@@ -440,7 +440,24 @@ describe('ACP application commands', () => {
         acpCommands.respondPlan,
         invocation([request], createTaskCallerContext())
       )
-    ).rejects.toThrow('Only a current human caller can respond to a Session Plan.')
+    ).resolves.toMatchObject({ changed: true })
+    await expect(
+      router.dispatcher.invoke(
+        acpCommands.respondPlan,
+        invocation([request], createTaskCallerContext({ isAuthorizationCurrent: () => false }))
+      )
+    ).rejects.toThrow('Caller authorization is no longer current.')
+    await expect(
+      router.dispatcher.invoke(
+        acpCommands.respondPlan,
+        invocation(
+          [request],
+          createWebCallerContext('agent-origin', { actionOrigin: 'agent-session' })
+        )
+      )
+    ).rejects.toThrow(
+      'Only a current human or Task automation caller can respond to a Session Plan.'
+    )
   })
 
   it('checks archive availability before resetting Session context or compacting', async () => {
@@ -770,7 +787,7 @@ describe('ACP application commands', () => {
     expect(respondDelegatedQuestion).not.toHaveBeenCalled()
   })
 
-  it('exposes Plan projection reads to the same current human callers on Electron and Web', async () => {
+  it('exposes Plan projection reads to current humans and Task automation', async () => {
     const dependencies = createDependencies()
     const router = createApplicationCommandRouter()
     registerAcpCommands(router.registrar, dependencies)
@@ -793,7 +810,7 @@ describe('ACP application commands', () => {
         acpCommands.getPlanProjection,
         invocation(['project-1', 'session-1'], createTaskCallerContext())
       )
-    ).rejects.toThrow('Only a current human caller can access a Session Plan.')
+    ).resolves.toBeNull()
     await expect(
       router.dispatcher.invoke(
         acpCommands.getPlanProjection,
@@ -804,7 +821,9 @@ describe('ACP application commands', () => {
       )
     ).rejects.toThrow('Caller authorization is no longer current.')
 
-    expect(dependencies.runtime.getSessionPlanProjection).toHaveBeenCalledTimes(humanCallers.length)
+    expect(dependencies.runtime.getSessionPlanProjection).toHaveBeenCalledTimes(
+      humanCallers.length + 1
+    )
   })
 
   it('accepts structured answers only from a current human-originated caller', async () => {

--- a/src/main/acp/application-commands.ts
+++ b/src/main/acp/application-commands.ts
@@ -21,7 +21,7 @@ import {
   type ApplicationCommandInstallation,
   type ApplicationCommandRegistrar
 } from '../application-command-router'
-import { canSatisfyHumanApproval } from '../caller-context'
+import { canAccessSessionPlan, canSatisfyHumanApproval } from '../caller-context'
 import type { AcpHandlerWorkflows } from './handler-workflows'
 import {
   resolveElicitationResponseSessionId,
@@ -115,7 +115,7 @@ const acpCommands = Object.freeze({
   respondPlan: defineApplicationCommand<
     'acp:respond-plan',
     readonly [request: Parameters<AcpRuntimeCoordinator['respondSessionPlan']>[0]],
-    unknown
+    Awaited<ReturnType<AcpRuntimeCoordinator['respondSessionPlan']>>
   >('acp:respond-plan')
 })
 
@@ -285,14 +285,18 @@ const registerAcpCommands = (
           dependencies.runtime.revokePermissionGrant(invocation.args[0])
         ),
       'acp:get-plan-projection': (invocation) => {
-        if (!canSatisfyHumanApproval(invocation.callerContext)) {
-          throw new Error('Only a current human caller can access a Session Plan.')
+        if (!canAccessSessionPlan(invocation.callerContext)) {
+          throw new Error(
+            'Only a current human or Task automation caller can access a Session Plan.'
+          )
         }
         return dependencies.runtime.getSessionPlanProjection(invocation.args[0], invocation.args[1])
       },
       'acp:respond-plan': (invocation) => {
-        if (!canSatisfyHumanApproval(invocation.callerContext)) {
-          throw new Error('Only a current human caller can respond to a Session Plan.')
+        if (!canAccessSessionPlan(invocation.callerContext)) {
+          throw new Error(
+            'Only a current human or Task automation caller can respond to a Session Plan.'
+          )
         }
         return dependencies.archiveAvailability
           ? dependencies.archiveAvailability.withSessionAvailable(

--- a/src/main/acp/task-agent-port.test.ts
+++ b/src/main/acp/task-agent-port.test.ts
@@ -58,7 +58,8 @@ describe('ACP Task Agent port', () => {
       port.createSession({
         projectId: 'project-1',
         permissionProfile: 'auto',
-        cwd: '/workspace/external'
+        cwd: '/workspace/external',
+        specialistId: 'specialist-1'
       })
     ).resolves.toMatchObject({
       sessionId: 'session-created',
@@ -72,7 +73,8 @@ describe('ACP Task Agent port', () => {
         projectId: 'project-1',
         permissionProfile: 'ask',
         previousFrameworkId: 'codex',
-        previousBackendId: 'codex:shared'
+        previousBackendId: 'codex:shared',
+        specialistId: 'specialist-1'
       })
     ).resolves.toMatchObject({
       sessionId: 'session-resumed',
@@ -83,6 +85,7 @@ describe('ACP Task Agent port', () => {
       sessionId: 'session-stable',
       promptMessageId: 'persisted-prompt',
       text: 'Continue the research.',
+      turnIntent: 'plan-first',
       skillIds: ['literature-review'],
       historyPreamble: 'Previous conversation.',
       contextReset: true,
@@ -93,7 +96,8 @@ describe('ACP Task Agent port', () => {
     expect(create).toHaveBeenCalledWith({
       projectName: 'project-1',
       permissionProfile: 'auto',
-      cwd: '/workspace/external'
+      cwd: '/workspace/external',
+      specialistId: 'specialist-1'
     })
     expect(withSessionAvailable).toHaveBeenCalledWith('project-1', 'session-stable', admitted)
     expect(runtime.resumeSession).toHaveBeenCalledWith({
@@ -102,7 +106,8 @@ describe('ACP Task Agent port', () => {
       projectName: 'project-1',
       permissionProfile: 'ask',
       previousFrameworkId: 'codex',
-      previousBackendId: 'codex:shared'
+      previousBackendId: 'codex:shared',
+      specialistId: 'specialist-1'
     })
     expect(runtime.setPermissionProfile).toHaveBeenCalledWith({
       sessionId: 'session-stable',
@@ -113,6 +118,7 @@ describe('ACP Task Agent port', () => {
       text: 'Continue the research.',
       provenanceContext: { promptMessageId: 'persisted-prompt' },
       forcedSkillIds: ['literature-review'],
+      turnIntent: 'plan-first',
       historyPreamble: 'Previous conversation.',
       contextReset: true,
       resumeFallback: { historyPreamble: 'Fallback conversation.' }

--- a/src/main/acp/task-agent-port.ts
+++ b/src/main/acp/task-agent-port.ts
@@ -34,6 +34,7 @@ const toAcpPromptRequest = (request: TaskAgentPromptRequest): AcpPromptRequest =
   sessionId: request.sessionId,
   text: request.text,
   provenanceContext: { promptMessageId: request.promptMessageId },
+  ...(request.turnIntent ? { turnIntent: request.turnIntent } : {}),
   ...(request.skillIds?.length ? { forcedSkillIds: request.skillIds } : {}),
   ...(request.historyPreamble ? { historyPreamble: request.historyPreamble } : {}),
   ...(request.contextReset ? { contextReset: true } : {}),
@@ -57,7 +58,8 @@ const createAcpTaskAgentPort = (
     createSessionWorkflow.create({
       projectName: request.projectId,
       permissionProfile: request.permissionProfile,
-      ...(request.cwd ? { cwd: request.cwd } : {})
+      ...(request.cwd ? { cwd: request.cwd } : {}),
+      ...(request.specialistId ? { specialistId: request.specialistId } : {})
     }),
   resumeSession: (request) =>
     runtime.resumeSession({
@@ -68,7 +70,8 @@ const createAcpTaskAgentPort = (
       previousFrameworkId: request.previousFrameworkId,
       previousBackendId: request.previousBackendId,
       providerSessionId: request.providerSessionId,
-      providerContinuityToken: request.providerContinuityToken
+      providerContinuityToken: request.providerContinuityToken,
+      ...(request.specialistId ? { specialistId: request.specialistId } : {})
     }),
   setPermissionProfile: (sessionId, profile) =>
     runtime.setPermissionProfile({ sessionId, profile }).then(() => undefined),

--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -239,12 +239,12 @@ describe('application command composition', () => {
       expect(composition.remoteWeb.rejectedCommandNames()).not.toContain(command)
     }
     expect(composition.task.commandNames()).toEqual(
-      expect.arrayContaining(['reviewer:get-for-session', 'reviewer:run'])
+      expect.arrayContaining(['reviewer:abort', 'reviewer:get-for-session', 'reviewer:run'])
     )
     expect(composition.task.commandNames()).not.toContain('reviewer:abort-fix-loop')
   })
 
-  it('exposes only the twelve Task commands and no transport-wide capability', async () => {
+  it('exposes only the thirteen Task commands and no transport-wide capability', async () => {
     const composition = createApplicationCommandComposition(dependencies())
 
     expect(composition.task.commandNames()).toEqual([
@@ -255,6 +255,7 @@ describe('application command composition', () => {
       'sessions:set-delegation-policy',
       'acp:get-plan-projection',
       'acp:respond-plan',
+      'reviewer:abort',
       'reviewer:get-for-session',
       'reviewer:run',
       'artifacts:finalize-run',

--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -229,7 +229,7 @@ describe('application command composition', () => {
     expect(listProjects).toHaveBeenCalledOnce()
   })
 
-  it('keeps Reviewer commands on local and remote Web but out of Task', () => {
+  it('exposes only Reviewer run and reads to Task automation', () => {
     const composition = createApplicationCommandComposition(dependencies())
     const reviewerCommands = ['reviewer:abort-fix-loop', 'reviewer:get-for-session', 'reviewer:run']
 
@@ -238,10 +238,13 @@ describe('application command composition', () => {
     for (const command of reviewerCommands) {
       expect(composition.remoteWeb.rejectedCommandNames()).not.toContain(command)
     }
-    expect(composition.task.commandNames()).not.toEqual(expect.arrayContaining(reviewerCommands))
+    expect(composition.task.commandNames()).toEqual(
+      expect.arrayContaining(['reviewer:get-for-session', 'reviewer:run'])
+    )
+    expect(composition.task.commandNames()).not.toContain('reviewer:abort-fix-loop')
   })
 
-  it('exposes only the seven Task commands and no transport-wide capability', async () => {
+  it('exposes only the twelve Task commands and no transport-wide capability', async () => {
     const composition = createApplicationCommandComposition(dependencies())
 
     expect(composition.task.commandNames()).toEqual([
@@ -249,6 +252,11 @@ describe('application command composition', () => {
       'projects:create',
       'sessions:load-all',
       'sessions:save-session',
+      'sessions:set-delegation-policy',
+      'acp:get-plan-projection',
+      'acp:respond-plan',
+      'reviewer:get-for-session',
+      'reviewer:run',
       'artifacts:finalize-run',
       'preview-resources:acquire',
       'preview-resources:release'

--- a/src/main/application-command-composition.ts
+++ b/src/main/application-command-composition.ts
@@ -120,7 +120,10 @@ const ELECTRON_NATIVE_COMMAND_NAMES = Object.freeze([
   'uploads:stage-local-file'
 ])
 
-const TASK_NATIVE_COMMAND_NAMES = Object.freeze(['sessions:set-delegation-policy'])
+const TASK_NATIVE_COMMAND_NAMES = Object.freeze([
+  'sessions:set-delegation-policy',
+  'reviewer:abort'
+])
 
 const TASK_COMMAND_NAMES = Object.freeze([
   'projects:list',
@@ -130,6 +133,7 @@ const TASK_COMMAND_NAMES = Object.freeze([
   'sessions:set-delegation-policy',
   'acp:get-plan-projection',
   'acp:respond-plan',
+  'reviewer:abort',
   'reviewer:get-for-session',
   'reviewer:run',
   'artifacts:finalize-run',

--- a/src/main/application-command-composition.ts
+++ b/src/main/application-command-composition.ts
@@ -120,11 +120,18 @@ const ELECTRON_NATIVE_COMMAND_NAMES = Object.freeze([
   'uploads:stage-local-file'
 ])
 
+const TASK_NATIVE_COMMAND_NAMES = Object.freeze(['sessions:set-delegation-policy'])
+
 const TASK_COMMAND_NAMES = Object.freeze([
   'projects:list',
   'projects:create',
   'sessions:load-all',
   'sessions:save-session',
+  'sessions:set-delegation-policy',
+  'acp:get-plan-projection',
+  'acp:respond-plan',
+  'reviewer:get-for-session',
+  'reviewer:run',
   'artifacts:finalize-run',
   'preview-resources:acquire',
   'preview-resources:release'
@@ -278,8 +285,9 @@ const certifyInventory = (
   }
 
   const nonWebNames = [...commands.keys()].filter((name) => !localWebNames.includes(name)).sort()
-  if (nonWebNames.join('\n') !== [...ELECTRON_NATIVE_COMMAND_NAMES].sort().join('\n')) {
-    failInventory(`unexpected Electron-native commands ${nonWebNames.join(', ')}`)
+  const nativeCommandNames = [...ELECTRON_NATIVE_COMMAND_NAMES, ...TASK_NATIVE_COMMAND_NAMES]
+  if (nonWebNames.join('\n') !== nativeCommandNames.sort().join('\n')) {
+    failInventory(`unexpected native commands ${nonWebNames.join(', ')}`)
   }
   const remotePartition = new Set([...remoteWebNames, ...remoteRejectedNames])
   if (

--- a/src/main/application-command-wiring.test.ts
+++ b/src/main/application-command-wiring.test.ts
@@ -203,7 +203,9 @@ describe('production application command wiring', () => {
     expect(webServiceSource).toContain(
       "Pick<ApplicationCommandComposition, 'localWeb' | 'remoteWeb' | 'task'>"
     )
-    expect(webServiceSource).toContain('{ commands: applicationCommands.task, agent: taskAgent }')
+    expect(webServiceSource).toContain(
+      '{ commands: applicationCommands.task, agent: taskAgent, controls: taskControls }'
+    )
     expect(webServiceSource).toContain('localWeb: applicationCommands.localWeb')
     expect(webServiceSource).toContain('remoteWeb: applicationCommands.remoteWeb')
     expect(readSource('src/main/tasks/task-runner.ts')).not.toContain('applicationCommands')

--- a/src/main/caller-context.test.ts
+++ b/src/main/caller-context.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   ClientLeaseRegistry,
   callerContextForEvent,
+  canAccessSessionPlan,
   canSatisfyHumanApproval,
   createCallerContext,
   createElectronCallerContext,
@@ -53,6 +54,15 @@ describe('caller context', () => {
     expect(hasCallerAuthority(context, 'manage-remote-pairing')).toBe(true)
     current = false
     expect(hasCallerAuthority(context, 'manage-remote-pairing')).toBe(false)
+  })
+
+  it('grants current Task automation only the Session Plan capability', () => {
+    const currentTask = createTaskCallerContext()
+    const staleTask = createTaskCallerContext({ isAuthorizationCurrent: () => false })
+
+    expect(canSatisfyHumanApproval(currentTask)).toBe(false)
+    expect(canAccessSessionPlan(currentTask)).toBe(true)
+    expect(canAccessSessionPlan(staleTask)).toBe(false)
   })
 
   it('never treats an agent-originated action as a human approval', () => {

--- a/src/main/caller-context.ts
+++ b/src/main/caller-context.ts
@@ -88,6 +88,13 @@ const canSatisfyHumanApproval = (context: CallerContext): boolean =>
   context.principalKind === 'human' &&
   context.actionOrigin === 'human'
 
+const canAccessSessionPlan = (context: CallerContext): boolean =>
+  context.isAuthorizationCurrent() &&
+  ((context.principalKind === 'human' && context.actionOrigin === 'human') ||
+    (context.surface === 'task' &&
+      context.principalKind === 'automation' &&
+      context.actionOrigin === 'automation'))
+
 export type ClientLease = Readonly<{
   clientId: string
   release: () => void
@@ -157,6 +164,7 @@ export class ClientLeaseRegistry {
 
 export {
   callerContextForEvent,
+  canAccessSessionPlan,
   canSatisfyHumanApproval,
   createCallerContext,
   createElectronCallerContext,

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -239,7 +239,7 @@ const dispatchCommand = (
 }
 
 describe('Data and content application commands', () => {
-  it('owns exactly the 49 current data and content invoke channels', () => {
+  it('owns exactly the 50 current data and content invoke channels', () => {
     expect(registeredCommands()).toEqual(
       [
         'artifacts:finalize-run',
@@ -280,6 +280,7 @@ describe('Data and content application commands', () => {
         'sessions:save-manifest',
         'sessions:update-archive',
         'sessions:save-session',
+        'sessions:set-delegation-policy',
         'uploads:abort-transfer',
         'uploads:append-transfer',
         'uploads:begin-transfer',

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -5,7 +5,7 @@ import {
   type ApplicationCommandRouter,
   type ApplicationInvocation
 } from './application-command-router'
-import { createCallerContext, type CallerContext } from './caller-context'
+import { createCallerContext, createTaskCallerContext, type CallerContext } from './caller-context'
 import { ArtifactOwnershipPersistenceRaceError } from './artifacts/provenance-repository'
 import {
   dataContentApplicationCommandGroups,
@@ -138,6 +138,7 @@ const createDependencies = () => {
     loadAll: vi.fn(),
     loadOne: vi.fn(),
     saveSession: vi.fn(async () => ({ created: true, session })),
+    setDelegationPolicy: vi.fn(async () => session),
     deleteSession: vi.fn(),
     saveManifest: vi.fn(),
     updateArchive: vi.fn(async () => session)
@@ -211,6 +212,7 @@ const WRAPPED_COMMAND_KEYS = [
   'sessionLoadOne',
   'sessionSaveManifest',
   'sessionSave',
+  'sessionSetDelegationPolicy',
   'uploadStageLocalFile',
   'uploadStageLocalPath'
 ] as const satisfies readonly DataContentCommandKey[]
@@ -639,6 +641,41 @@ describe('Data and content application commands', () => {
       session: deps.session,
       originClientId: 'web:renderer-1'
     })
+  })
+
+  it('allows only current Task automation to update main-owned delegation policy', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+    const args = ['project-1', 'session-1', 'deny'] as const
+
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.sessionSetDelegationPolicy,
+        invocation(args, createTaskCallerContext())
+      )
+    ).resolves.toBe(deps.session)
+    expect(deps.sessions.setDelegationPolicy).toHaveBeenCalledWith(...args)
+    expect(deps.events.publish).toHaveBeenCalledWith('session:updated', {
+      session: deps.session,
+      originClientId: 'web:headless-task-api'
+    })
+
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.sessionSetDelegationPolicy,
+        invocation(args)
+      )
+    ).rejects.toThrow(
+      'Channel only available from current Task automation: sessions:set-delegation-policy'
+    )
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.sessionSetDelegationPolicy,
+        invocation(args, createTaskCallerContext({ isAuthorizationCurrent: () => false }))
+      )
+    ).rejects.toThrow('Caller authorization is no longer current.')
+    expect(deps.sessions.setDelegationPolicy).toHaveBeenCalledOnce()
   })
 
   it('dispatches every remaining Project and Session wrapper to its existing owner', async () => {

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -261,6 +261,11 @@ const dataContentApplicationCommands = Object.freeze({
     ],
     SessionPersistence.PersistedChatSession
   >('sessions:save-session'),
+  sessionSetDelegationPolicy: defineApplicationCommand<
+    'sessions:set-delegation-policy',
+    readonly [projectId: string, sessionId: string, policy: SessionPersistence.DelegationPolicy],
+    SessionPersistence.PersistedChatSession
+  >('sessions:set-delegation-policy'),
   uploadAbortTransfer: uploadCommand('uploads:abort-transfer', 'abortTransfer'),
   uploadAppendTransfer: uploadCommand('uploads:append-transfer', 'appendTransfer'),
   uploadBeginTransfer: uploadCommand('uploads:begin-transfer', 'beginTransfer'),
@@ -325,7 +330,8 @@ const dataContentApplicationCommandGroups = Object.freeze([
     dataContentApplicationCommands.sessionLoadOne,
     dataContentApplicationCommands.sessionSaveManifest,
     dataContentApplicationCommands.sessionUpdateArchive,
-    dataContentApplicationCommands.sessionSave
+    dataContentApplicationCommands.sessionSave,
+    dataContentApplicationCommands.sessionSetDelegationPolicy
   ] as const),
   defineApplicationCommandGroup('uploads', [
     dataContentApplicationCommands.uploadAbortTransfer,
@@ -357,6 +363,21 @@ const assertElectronCaller = (
 ): void => {
   if (invocation.callerContext.surface !== 'electron') {
     throw new Error(`Channel only available from the Electron app: ${name}`)
+  }
+}
+
+const assertTaskAutomationCaller = (
+  invocation: ApplicationInvocation<readonly unknown[]>,
+  name: string
+): void => {
+  const { callerContext } = invocation
+  if (
+    !callerContext.isAuthorizationCurrent() ||
+    callerContext.surface !== 'task' ||
+    callerContext.principalKind !== 'automation' ||
+    callerContext.actionOrigin !== 'automation'
+  ) {
+    throw new Error(`Channel only available from current Task automation: ${name}`)
   }
 }
 
@@ -517,6 +538,25 @@ const registerDataContentApplicationCommands = (
             { session: result.session, originClientId }
           )
           return result.session
+        })
+      },
+      'sessions:set-delegation-policy': (invocation) => {
+        assertTaskAutomationCaller(
+          invocation,
+          dataContentApplicationCommands.sessionSetDelegationPolicy.name
+        )
+        const originClientId = invocation.callerContext.lifecycleClientId
+        return dependencies.withDataRootWrite(async () => {
+          const session = await dependencies.sessions.setDelegationPolicy(
+            invocation.args[0],
+            invocation.args[1],
+            invocation.args[2]
+          )
+          publishLifecycle(dependencies.events, LIFECYCLE_CHANNELS.sessionUpdated, {
+            session,
+            originClientId
+          })
+          return session
         })
       }
     })

--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -590,6 +590,40 @@ describe('production delegated-work composition', () => {
     )
   })
 
+  it('blocks only new child admission when the Session delegation policy is deny', async () => {
+    root = await mkdtemp(join(tmpdir(), 'delegated-production-policy-'))
+    const harness = await createCompositionHarness(root, 'codex')
+    harness.replaceDurable({ ...harness.durable(), delegationPolicy: 'deny' })
+
+    await expect(
+      harness.composition.host.delegate(
+        harness.caller,
+        { task: 'blocked child', name: 'blocked child' },
+        { wait: false }
+      )
+    ).rejects.toMatchObject({
+      code: 'admission_rejection',
+      message: expect.stringMatching(/delegation is disabled/i)
+    })
+    expect(harness.execution.reservationCounts()).toEqual([])
+
+    harness.replaceDurable({ ...harness.durable(), delegationPolicy: 'allow' })
+    const admitted = await harness.composition.host.delegate(
+      harness.caller,
+      { task: 'existing child', name: 'existing child' },
+      { wait: false }
+    )
+    expect(admitted).toMatchObject({
+      kind: 'receipts',
+      children: [{ name: 'existing child' }]
+    })
+
+    harness.replaceDurable({ ...harness.durable(), delegationPolicy: 'deny' })
+    await expect(harness.composition.host.children(harness.caller)).resolves.toEqual([
+      expect.objectContaining({ name: 'existing child' })
+    ])
+  })
+
   it('rejects a removed own context field before reservation, workspace, or durable mutation', async () => {
     root = await mkdtemp(join(tmpdir(), 'delegated-production-removed-context-'))
     const harness = await createCompositionHarness(root, 'codex')

--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -624,6 +624,51 @@ describe('production delegated-work composition', () => {
     ])
   })
 
+  it('rechecks authoritative delegation policy inside durable child admission', async () => {
+    root = await mkdtemp(join(tmpdir(), 'delegated-production-policy-race-'))
+    const harness = await createCompositionHarness(root, 'codex')
+    let firstRead = true
+    const racingComposition = createProductionDelegatedWorkComposition({
+      dataRoot: root,
+      sessions: {
+        commands: harness.commands,
+        readSession: async () => {
+          const snapshot = structuredClone(harness.durable())
+          if (firstRead) {
+            firstRead = false
+            harness.replaceDurable({ ...snapshot, delegationPolicy: 'deny' })
+          }
+          return snapshot
+        }
+      },
+      resolveInput: async () => {
+        throw new Error('no inputs')
+      },
+      frameworks: {
+        async forSession(current) {
+          return {
+            frameworkId: current.agentFrameworkId!,
+            execution: harness.execution,
+            assertAvailable: async () => undefined
+          }
+        }
+      },
+      resolveExecutionModel: async () => testExecutionModel('codex')
+    })
+
+    await expect(
+      racingComposition.host.delegate(
+        harness.caller,
+        { task: 'racing child', name: 'racing child' },
+        { wait: false }
+      )
+    ).rejects.toMatchObject({
+      code: 'admission_rejection',
+      message: expect.stringMatching(/delegation is disabled/i)
+    })
+    expect(harness.durable().runtimeContext?.delegatedWork?.records ?? []).toEqual([])
+  })
+
   it('rejects a removed own context field before reservation, workspace, or durable mutation', async () => {
     root = await mkdtemp(join(tmpdir(), 'delegated-production-removed-context-'))
     const harness = await createCompositionHarness(root, 'codex')

--- a/src/main/delegation/production-composition.ts
+++ b/src/main/delegation/production-composition.ts
@@ -264,6 +264,14 @@ const createProductionDelegatedWorkComposition = (
   const host: ProductionDelegatedWorkComposition['host'] = Object.freeze({
     async delegate(caller, request, delegateOptions) {
       try {
+        const policySession = await options.sessions.readSession(caller.session)
+        if (policySession?.delegationPolicy === 'deny') {
+          throw new DurableDelegatedWorkError(
+            'admission_rejection',
+            'delegation is disabled for this Session',
+            'Delegation is disabled for this Session. Enable delegation before creating a Subagent.'
+          )
+        }
         const result = await (
           await workFor(caller.session)
         ).work.delegate(caller, request, delegateOptions)

--- a/src/main/host-application-commands.test.ts
+++ b/src/main/host-application-commands.test.ts
@@ -167,7 +167,7 @@ const commandByName = (name: string): ApplicationCommand<string, readonly unknow
 }
 
 describe('Host application commands', () => {
-  it('defines the exact 51 request channels in their existing capability groups', () => {
+  it('defines the exact 52 request channels in their existing capability groups', () => {
     const expected = RENDERER_CONTRACT_GROUPS.filter(({ capability }) =>
       HOST_CAPABILITIES.includes(capability as (typeof HOST_CAPABILITIES)[number])
     ).map(({ capability, contracts }) => ({
@@ -181,7 +181,7 @@ describe('Host application commands', () => {
         .filter((channel): channel is string => channel !== null)
     }))
 
-    expect(expected.flatMap(({ channels }) => channels)).toHaveLength(51)
+    expect(expected.flatMap(({ channels }) => channels)).toHaveLength(52)
     expect(
       hostApplicationCommandGroups.map(({ name, commands }) => ({
         capability: name,
@@ -197,7 +197,7 @@ describe('Host application commands', () => {
       {} as HostApplicationCommandDependencies
     )
 
-    expect(router.dispatcher.commandNames()).toHaveLength(51)
+    expect(router.dispatcher.commandNames()).toHaveLength(52)
     installation.uninstall()
     expect(router.dispatcher.commandNames()).toEqual([])
   })

--- a/src/main/host-application-commands.test.ts
+++ b/src/main/host-application-commands.test.ts
@@ -170,16 +170,20 @@ describe('Host application commands', () => {
   it('defines the exact 52 request channels in their existing capability groups', () => {
     const expected = RENDERER_CONTRACT_GROUPS.filter(({ capability }) =>
       HOST_CAPABILITIES.includes(capability as (typeof HOST_CAPABILITIES)[number])
-    ).map(({ capability, contracts }) => ({
-      capability,
-      channels: contracts
+    ).map(({ capability, contracts }) => {
+      const rendererChannels = contracts
         .filter(
           ({ kind, surfaceInstallation }) =>
             kind === 'method' && surfaceInstallation.localWeb === 'web-rpc'
         )
         .map(({ channel }) => channel)
         .filter((channel): channel is string => channel !== null)
-    }))
+      return {
+        capability,
+        channels:
+          capability === 'reviewer' ? ['reviewer:abort', ...rendererChannels] : rendererChannels
+      }
+    })
 
     expect(expected.flatMap(({ channels }) => channels)).toHaveLength(52)
     expect(

--- a/src/main/host-application-commands.test.ts
+++ b/src/main/host-application-commands.test.ts
@@ -104,6 +104,7 @@ const createDependencies = (): HostApplicationCommandDependencies => ({
   reviewer: {
     run: vi.fn(async () => ({ started: true })),
     getForSession: vi.fn(async () => []),
+    abort: vi.fn(() => undefined),
     abortFixLoop: vi.fn(() => undefined)
   },
   storage: {
@@ -295,6 +296,10 @@ describe('Host application commands', () => {
       invocation([{ mode: 'remoteit' }])
     )
     await router.dispatcher.invoke(
+      hostApplicationCommands.reviewer.abort,
+      invocation([reviewSession])
+    )
+    await router.dispatcher.invoke(
       hostApplicationCommands.reviewer.abortFixLoop,
       invocation([reviewSession])
     )
@@ -358,6 +363,7 @@ describe('Host application commands', () => {
     expect(dependencies.remoteAccess.setMode).toHaveBeenCalledWith('remoteit')
     expect(dependencies.reviewer.run).toHaveBeenCalledWith(reviewRun)
     expect(dependencies.reviewer.getForSession).toHaveBeenCalledWith(reviewSession)
+    expect(dependencies.reviewer.abort).toHaveBeenCalledWith(reviewSession)
     expect(dependencies.storage.commitAndRelaunch).toHaveBeenCalledWith(parent)
     expect(dependencies.storage.setDataRootAndRelaunch).toHaveBeenCalledWith(root)
 

--- a/src/main/host-application-commands.ts
+++ b/src/main/host-application-commands.ts
@@ -208,6 +208,9 @@ const remoteAccessCommands = Object.freeze({
 })
 
 const reviewerCommands = Object.freeze({
+  abort: defineApplicationCommand<'reviewer:abort', readonly [request: ReviewSessionRequest], void>(
+    'reviewer:abort'
+  ),
   abortFixLoop: defineApplicationCommand<
     'reviewer:abort-fix-loop',
     readonly [request: ReviewSessionRequest],
@@ -350,7 +353,7 @@ type HostApplicationCommandDependencies = Readonly<{
     RemoteAccessService,
     'snapshot' | 'detect' | 'setMode' | 'disable' | 'approve' | 'reject' | 'revoke'
   >
-  reviewer: Pick<ReviewerCommandOwner, 'run' | 'getForSession' | 'abortFixLoop'>
+  reviewer: Pick<ReviewerCommandOwner, 'run' | 'getForSession' | 'abort' | 'abortFixLoop'>
   storage: Readonly<{
     getInfo: () => Promise<StorageInfo>
     revealAppStorage: () => Promise<RevealAppStorageResult>
@@ -505,6 +508,7 @@ const registerHostApplicationCommands = (
       }
     })
     scope.registerGroup(hostApplicationCommandGroups[6], {
+      'reviewer:abort': ({ args }) => dependencies.reviewer.abort(args[0]),
       'reviewer:abort-fix-loop': ({ args }) => dependencies.reviewer.abortFixLoop(args[0]),
       'reviewer:get-for-session': ({ args }) => dependencies.reviewer.getForSession(args[0]),
       'reviewer:run': ({ args }) => dependencies.reviewer.run(args[0])

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -376,6 +376,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           notificationInbox,
           settingsService,
           taskAgent,
+          taskControls,
           detectActiveSessions,
           prepareForQuit,
           dispose: disposeApplicationRuntime
@@ -446,7 +447,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           requestQuit: () => app.quit(),
           externalAccess: remoteAccess.webAccess,
           applicationEvents,
-          taskAgent
+          taskAgent,
+          taskControls
         })
         remoteAccess.attachWebController(webController)
         registerRemoteAccessIpcHandlers(remoteAccess)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -862,6 +862,10 @@ const createApplicationModules = async (
       }
       return { created, session: durableSession }
     },
+    setDelegationPolicy: async (projectId, sessionId, policy) => {
+      await projectDeletionCoordinator.recoverPendingDeletions()
+      return sessionPersistenceCoordinator.setSessionDelegationPolicy(projectId, sessionId, policy)
+    },
     updateArchive: async (request) => {
       await projectDeletionCoordinator.recoverPendingDeletions()
       return archiveCoordinator.updateSessionArchive(request)
@@ -2878,13 +2882,7 @@ const createApplicationModules = async (
     taskControls: {
       specialists: {
         resolve: (reference) => profileService.resolveRunnableByReference(reference)
-      },
-      plans: {
-        getProjection: (projectId, sessionId) =>
-          runtime.getSessionPlanProjection(projectId, sessionId),
-        respond: (input) => runtime.respondSessionPlan(input)
-      },
-      reviewer: reviewerCommandOwner
+      }
     },
     sessionDeletionCapability: sessionPersistenceCoordinator,
     archiveCapability: archiveCoordinator,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -292,6 +292,7 @@ import { ConversationSkillImporter, SkillImportApprovalBroker } from './skills/c
 import { HostSkillsService, type HostSkillsCatalog } from './skills/host-skills-service'
 import { UserSkillCatalogObserver } from './skills/user-skill-catalog-observer'
 import type { ConversationSkillImportApprovalResponse } from '../shared/settings'
+import type { TaskControlPorts } from './tasks/task-control-ports'
 import type { TaskAgentPort } from './tasks/task-runner'
 
 const permissionGrantsLog = createLogger('permission-grants')
@@ -325,6 +326,7 @@ export type ApplicationRuntimeInterfaces = {
   >
   settingsService: WindowSettingsCapabilities
   taskAgent: TaskAgentPort
+  taskControls: TaskControlPorts
   sessionDeletionCapability: Pick<SessionPersistenceCoordinator, 'setSessionDeletionHandlers'>
   archiveCapability: Pick<ArchiveCoordinator, 'isSessionAvailableById' | 'setMarkReadSessions'>
   detectActiveSessions: () => ReturnType<typeof detectActiveSessions>
@@ -2873,6 +2875,17 @@ const createApplicationModules = async (
     notificationInbox,
     settingsService,
     taskAgent,
+    taskControls: {
+      specialists: {
+        resolve: (reference) => profileService.resolveRunnableByReference(reference)
+      },
+      plans: {
+        getProjection: (projectId, sessionId) =>
+          runtime.getSessionPlanProjection(projectId, sessionId),
+        respond: (input) => runtime.respondSessionPlan(input)
+      },
+      reviewer: reviewerCommandOwner
+    },
     sessionDeletionCapability: sessionPersistenceCoordinator,
     archiveCapability: archiveCoordinator,
     detectActiveSessions: () =>

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -650,6 +650,33 @@ describe('reviewer IPC handlers', () => {
     })
   })
 
+  describe('Task review-chain cancellation', () => {
+    it('aborts an active initial review without exposing a new Electron handler', async () => {
+      let finishRun: (() => void) | undefined
+      let reviewSignal: AbortSignal | undefined
+      runReview.mockImplementation(
+        (options?: { onStarted?: () => void; fixLoopAbortSignal?: AbortSignal }) => {
+          reviewSignal = options?.fixLoopAbortSignal
+          options?.onStarted?.()
+          return new Promise<void>((resolve) => {
+            finishRun = resolve
+          })
+        }
+      )
+      const owner = createReviewerCommandOwner({ acpRuntime })
+
+      await expect(owner.run(createRequest())).resolves.toEqual({ started: true })
+      expect(reviewSignal?.aborted).toBe(false)
+
+      owner.abort({ projectId: 'project-1', appSessionId: 'session-1' })
+      expect(reviewSignal?.aborted).toBe(true)
+      expect(handlers.has('reviewer:abort')).toBe(false)
+
+      finishRun?.()
+      await vi.waitFor(() => expect(runReview).toHaveBeenCalledOnce())
+    })
+  })
+
   describe('orchestrator callback wiring', () => {
     type OrchestratorCallbacks = {
       onStarted?: () => void

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -106,6 +106,7 @@ type ReviewerCommandOwner = Readonly<{
   run: (request: ReviewRunRequest) => Promise<ReviewRunResult>
   triggerReview: (request: ReviewRunRequest) => Promise<ReviewRunResult>
   getForSession: (request: ReviewSessionRequest) => Promise<ReviewWithChecks[]>
+  abort: (request: ReviewSessionRequest) => void
   abortFixLoop: (request: ReviewSessionRequest) => void
 }>
 
@@ -149,6 +150,10 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
   // reviewer session id). Project deletion owns the same signal, so user cancellation and Project
   // quiescence converge on one operation without maintaining competing AbortControllers.
   const fixLoopAbortControllers = new Map<string, () => void>()
+  // Task cancellation targets the whole admitted Review chain, including the initial assessment.
+  // Keep this separate from the renderer's fix-loop-only affordance and allow concurrent manual
+  // Reviews for different turns in one Session to be cancelled together.
+  const activeReviewAbortControllers = new Map<string, Set<() => void>>()
 
   // Guards against concurrent reviews of the same turn — e.g. a double-clicked "Re-run review" or two
   // stale cards fired at once. Project is part of the key because Session ids are not globally owned.
@@ -184,6 +189,17 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
     } else {
       log.warn('abort-fix-loop: no active fix loop found for session', request)
     }
+  }
+
+  const abort = (request: ReviewSessionRequest): void => {
+    const key = `${request.projectId}\0${request.appSessionId}`
+    const controllers = activeReviewAbortControllers.get(key)
+    if (!controllers || controllers.size === 0) {
+      log.warn('abort: no active review found for session', request)
+      return
+    }
+    log.info('review abort requested', request)
+    for (const controller of controllers) controller()
   }
 
   // Returns whether a review actually STARTED. The session is loaded up front (not in the background)
@@ -348,6 +364,10 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
 
       const effectiveMainSessionId = mainSessionId ?? sessionId
       const effectiveMainSessionKey = `${projectId}\0${effectiveMainSessionId}`
+      const activeControllers =
+        activeReviewAbortControllers.get(effectiveMainSessionKey) ?? new Set<() => void>()
+      activeControllers.add(projectAdmission.abort)
+      activeReviewAbortControllers.set(effectiveMainSessionKey, activeControllers)
 
       void runReview({
         sessionId,
@@ -416,6 +436,10 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
           // genuine pre-push failure (scope/insert), not a persistence race, so it is not auto-retried.
           settle({ started: false, reason: 'run-failed' })
           inFlightReviewKeys.delete(inFlightKey)
+          activeControllers.delete(projectAdmission.abort)
+          if (activeControllers.size === 0) {
+            activeReviewAbortControllers.delete(effectiveMainSessionKey)
+          }
           try {
             releaseDataRootWriter?.()
           } finally {
@@ -447,7 +471,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
     })
   }
 
-  return { run: triggerReview, triggerReview, getForSession, abortFixLoop }
+  return { run: triggerReview, triggerReview, getForSession, abort, abortFixLoop }
 }
 
 // Registers the legacy Electron adapter against an injectable owner. A future Host command

--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -405,7 +405,7 @@ describe('Session persistence coordinator architecture', () => {
   it('keeps the facade and every deep owner within their completion gates', () => {
     for (const [file, source] of sources) {
       const physicalLines = source.split(/\r?\n/).length - Number(source.endsWith('\n'))
-      expect(physicalLines, file).toBeLessThanOrEqual(file === 'coordinator.ts' ? 1000 : 660)
+      expect(physicalLines, file).toBeLessThanOrEqual(file === 'coordinator.ts' ? 1000 : 750)
     }
   })
 
@@ -451,6 +451,7 @@ describe('Session persistence coordinator architecture', () => {
         'saveSideChatProjection',
         'sessionMetadataSnapshot',
         'sessionProjectId',
+        'setSessionDelegationPolicy',
         'setSessionDeletionHandlers',
         'setSessionEnabledComputeHosts',
         'settleMessage',
@@ -809,6 +810,7 @@ describe('Session persistence coordinator architecture', () => {
         'replaceMetadata',
         'saveSession',
         'sessionProjectId',
+        'setDelegationPolicy',
         'setEnabledComputeHosts'
       ].sort()
     )
@@ -886,6 +888,7 @@ describe('Session persistence coordinator architecture', () => {
       saveSideChatProjection: ['sideChatOwner.saveProjection'],
       sessionMetadataSnapshot: ['stateOwner.metadataSnapshot'],
       sessionProjectId: ['stateOwner.sessionProjectId'],
+      setSessionDelegationPolicy: ['stateOwner.setDelegationPolicy'],
       setSessionEnabledComputeHosts: ['stateOwner.setEnabledComputeHosts'],
       readChildren: ['delegatedWorkOwner.readChildren'],
       recoverInterruptedDelegatedWork: ['delegatedWorkOwner.recoverInterruptedDelegatedWork'],

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -1157,6 +1157,49 @@ describe('SessionPersistenceCoordinator', () => {
     expect(durable).toMatchObject({ title: 'Renderer rename', archivedAt: 10 })
   })
 
+  it('updates delegation policy through its dedicated durable Session owner', async () => {
+    const previousUpdatedAt = Date.now() + 10_000
+    let durable = createSession({ delegationPolicy: 'allow', updatedAt: previousUpdatedAt })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      })),
+      saveSession: vi.fn(async (session) => {
+        durable = structuredClone(session)
+      })
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    await expect(
+      coordinator.setSessionDelegationPolicy('project-1', 'session-1', 'deny')
+    ).resolves.toMatchObject({ delegationPolicy: 'deny' })
+
+    expect(durable.delegationPolicy).toBe('deny')
+    expect(durable.updatedAt).toBeGreaterThan(previousUpdatedAt)
+  })
+
+  it('preserves main-owned delegation policy on an ordinary existing-Session save', async () => {
+    let durable = createSession({ delegationPolicy: 'deny' })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      })),
+      saveSession: vi.fn(async (session) => {
+        durable = structuredClone(session)
+      })
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    await expect(
+      coordinator.saveSession(
+        createSession({ title: 'Renderer rename', delegationPolicy: 'allow' })
+      )
+    ).resolves.toMatchObject({ title: 'Renderer rename', delegationPolicy: 'deny' })
+    expect(durable.delegationPolicy).toBe('deny')
+  })
+
   it('updates enabled Compute Hosts through the durable Session owner', async () => {
     const previousUpdatedAt = Date.now() + 10_000
     let durable = createSession({

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -1,6 +1,7 @@
 import type { ProjectFilesChangedEvent } from '../../shared/project-files'
 import type { ProjectFileSource } from '../../shared/project-files'
 import type {
+  DelegationPolicy,
   LoadAllSessionsResult,
   PersistedChatMessage,
   PersistedChatSession,
@@ -715,6 +716,14 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
         { conflictRebaseFields: ['specialistId'] }
       )
     })
+  }
+
+  setSessionDelegationPolicy(
+    projectId: string,
+    sessionId: string,
+    policy: DelegationPolicy
+  ): Promise<PersistedChatSession> {
+    return this.enqueue(() => this.stateOwner.setDelegationPolicy(projectId, sessionId, policy))
   }
 
   setSessionEnabledComputeHosts(

--- a/src/main/session-persistence/delegated-work-owner.ts
+++ b/src/main/session-persistence/delegated-work-owner.ts
@@ -29,6 +29,7 @@ import type {
 } from '../delegation/session-records'
 import { canonicalStructuredOutputEqual } from '../delegation/structured-output'
 import { allocateDelegateNames } from '../delegation/delegated-work-admission'
+import { DurableDelegatedWorkError } from '../delegation/durable-delegated-work-error'
 import {
   DelegatedWorkAttemptConflictError,
   SessionMessageDeliveryPersistenceOwner
@@ -76,7 +77,14 @@ class SessionDelegatedWorkPersistenceOwner implements DelegatedWorkRecordCommand
     key: SessionKey,
     input: CreateChildrenInput
   ): Promise<readonly CreatedNamedChild[]> {
-    return this.store.mutate(key, input.expectedRevision, (graph, records) => {
+    return this.store.mutate(key, input.expectedRevision, (graph, records, session) => {
+      if (session.delegationPolicy === 'deny') {
+        throw new DurableDelegatedWorkError(
+          'admission_rejection',
+          'delegation is disabled for this Session',
+          'Delegation is disabled for this Session. Enable delegation before creating a Subagent.'
+        )
+      }
       if (input.children.length === 0)
         throw new Error('Child creation requires at least one child.')
       const parent = graph.frames.find((frame) => frame.id === input.parentFrameId)

--- a/src/main/session-persistence/delegated-work-records.test.ts
+++ b/src/main/session-persistence/delegated-work-records.test.ts
@@ -132,6 +132,27 @@ const child = (
 })
 
 describe('delegated-work Session records', () => {
+  it('rejects child admission when the authoritative Session policy is deny', async () => {
+    const { coordinator, durable, repository } = createHarness({
+      ...createRootSession(),
+      delegationPolicy: 'deny'
+    })
+
+    await expect(
+      coordinator.createChildren(key, {
+        expectedRevision: 0,
+        parentFrameId: durable().conversationGraph!.rootFrameId,
+        originMessageId: rootPrompt.id,
+        children: [child(1)]
+      })
+    ).rejects.toMatchObject({
+      code: 'admission_rejection',
+      message: expect.stringMatching(/delegation is disabled/i)
+    })
+    expect(repository.saveSession).not.toHaveBeenCalled()
+    expect(durable().runtimeContext?.delegatedWork?.records ?? []).toEqual([])
+  })
+
   it('publishes durable child start and finish projections after each repository commit', async () => {
     const published: PersistedChatSession[] = []
     const { coordinator, durable } = createHarness(createRootSession(), (session) => {

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -462,6 +462,7 @@ describe('session persistence IPC handlers', () => {
       loadAll: vi.fn().mockResolvedValue(loadResult),
       loadOne: vi.fn(),
       saveSession: vi.fn(),
+      setDelegationPolicy: vi.fn(),
       updateArchive: vi.fn(),
       deleteSession: vi.fn(),
       saveManifest: vi.fn()
@@ -491,6 +492,7 @@ describe('session persistence IPC handlers', () => {
         order.push('saved')
         return { created: false, session }
       }),
+      setDelegationPolicy: vi.fn(),
       updateArchive: vi.fn(),
       deleteSession: vi.fn(),
       saveManifest: vi.fn()
@@ -519,6 +521,7 @@ describe('session persistence IPC handlers', () => {
       loadAll: vi.fn().mockResolvedValue({ sessions: [], manifest: { version: 1 as const } }),
       loadOne: vi.fn(),
       saveSession: vi.fn(),
+      setDelegationPolicy: vi.fn(),
       updateArchive: vi.fn(),
       deleteSession: vi.fn(),
       saveManifest: vi.fn()

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -4,6 +4,7 @@ import type {
   DeleteSessionRequest,
   LoadAllSessionsResult,
   LoadSessionRequest,
+  DelegationPolicy,
   PersistedChatSession,
   SaveSessionOptions,
   SaveSessionManifestRequest,
@@ -27,6 +28,11 @@ type SessionPersistenceBackend = {
     session: PersistedChatSession,
     options?: SaveSessionOptions
   ) => Promise<{ created: boolean; session: PersistedChatSession }>
+  setDelegationPolicy?: (
+    projectId: string,
+    sessionId: string,
+    policy: DelegationPolicy
+  ) => Promise<PersistedChatSession>
   updateArchive?: (request: UpdateSessionArchiveRequest) => Promise<PersistedChatSession>
   deleteSession: (projectId: string, sessionId: string) => Promise<void>
   saveManifest: (request: SaveSessionManifestRequest) => Promise<void>
@@ -39,6 +45,11 @@ type SessionPersistenceHandlers = {
     session: PersistedChatSession,
     options?: SaveSessionOptions
   ) => Promise<{ created: boolean; session: PersistedChatSession }>
+  setDelegationPolicy: (
+    projectId: string,
+    sessionId: string,
+    policy: DelegationPolicy
+  ) => Promise<PersistedChatSession>
   updateArchive: (request: UpdateSessionArchiveRequest) => Promise<PersistedChatSession>
   deleteSession: (request: DeleteSessionRequest) => Promise<void>
   saveManifest: (request: SaveSessionManifestRequest) => Promise<void>
@@ -128,6 +139,12 @@ const createSessionPersistenceHandlersWithAttributionAuthority = (
       return options
         ? repository.saveSession(authorized, options)
         : repository.saveSession(authorized)
+    },
+    setDelegationPolicy: (projectId, sessionId, policy) => {
+      if (!repository.setDelegationPolicy) {
+        throw new Error('Session delegation policy mutation is unavailable.')
+      }
+      return repository.setDelegationPolicy(projectId, sessionId, policy)
     },
     updateArchive: (request) => {
       if (!repository.updateArchive) throw new Error('Session archive is unavailable.')

--- a/src/main/session-persistence/state-owner.ts
+++ b/src/main/session-persistence/state-owner.ts
@@ -6,6 +6,7 @@ import type { ProjectFilesChangedEvent, ProjectFileSource } from '../../shared/p
 import {
   materializeSessionConversationGraph,
   sanitizeSessionRuntimeContext,
+  type DelegationPolicy,
   type PersistedChatMessage,
   type PersistedChatSession,
   type PersistedSessionStatus,
@@ -446,6 +447,29 @@ class SessionPersistenceStateOwner {
     return message
   }
 
+  async setDelegationPolicy(
+    projectId: string,
+    sessionId: string,
+    policy: DelegationPolicy
+  ): Promise<PersistedChatSession> {
+    if (policy !== 'allow' && policy !== 'deny') {
+      throw new Error('Delegation policy must be allow or deny.')
+    }
+    this.options.assertMutable(projectId, sessionId, 'mutate')
+    const loaded = await this.options.repository.loadSessionWithDiagnostics(projectId, sessionId)
+    if (loaded.status !== 'found') {
+      throw new Error(`Cannot update delegation policy for a ${loaded.status} Session.`)
+    }
+    const durableSession: PersistedChatSession = {
+      ...loaded.session,
+      delegationPolicy: policy,
+      updatedAt: Math.max(loaded.session.updatedAt + 1, Date.now())
+    }
+    await this.options.repository.saveSession(durableSession)
+    this.recordSession(durableSession)
+    return durableSession
+  }
+
   async setEnabledComputeHosts(
     projectId: string,
     sessionId: string,
@@ -530,6 +554,11 @@ class SessionPersistenceStateOwner {
     delete rendererOwnedSession.runtimeContext
     delete rendererOwnedSession.archivedAt
     const authority = authoritative.status === 'found' ? authoritative.session : undefined
+    const delegationPolicyChanged =
+      authority !== undefined &&
+      (rendererOwnedSession.delegationPolicy === 'deny' ? 'deny' : 'allow') !==
+        (authority.delegationPolicy === 'deny' ? 'deny' : 'allow')
+    if (authority) delete rendererOwnedSession.delegationPolicy
     const permissionOwnedStatus =
       authority?.runtimeContext?.permission?.state === 'pending'
         ? 'waiting-permission'
@@ -549,6 +578,9 @@ class SessionPersistenceStateOwner {
       ...(authority?.archivedAt ? { archivedAt: authority.archivedAt } : {}),
       ...(authority ? { branchSource: authority.branchSource } : {}),
       ...(authority
+        ? { delegationPolicy: authority.delegationPolicy === 'deny' ? 'deny' : 'allow' }
+        : {}),
+      ...(authority
         ? {
             enabledComputeHosts: authority.enabledComputeHosts
               ? [...authority.enabledComputeHosts]
@@ -557,7 +589,10 @@ class SessionPersistenceStateOwner {
         : {}),
       ...(mainOwnedStatus ? { status: mainOwnedStatus } : {}),
       updatedAt:
-        authority?.runtimeContext || mainOwnedStatus || authority?.enabledComputeHosts !== undefined
+        authority?.runtimeContext ||
+        mainOwnedStatus ||
+        authority?.enabledComputeHosts !== undefined ||
+        delegationPolicyChanged
           ? Math.max(rendererOwnedSession.updatedAt, (authority?.updatedAt ?? -1) + 1, Date.now())
           : rendererOwnedSession.updatedAt
     }

--- a/src/main/tasks/task-control-ports.ts
+++ b/src/main/tasks/task-control-ports.ts
@@ -1,0 +1,19 @@
+import type { ReviewRunRequest, ReviewRunResult, ReviewWithChecks } from '../../shared/reviewer'
+import type { ActivePlanProjection, PlanResponseCommand } from '../../shared/session-plan/contract'
+import type { PlanResponseResult } from '../session-plan/plan-service'
+
+type TaskControlPorts = {
+  specialists: {
+    resolve(reference: string): Promise<{ id: string }>
+  }
+  plans: {
+    getProjection(projectId: string, sessionId: string): Promise<ActivePlanProjection | null>
+    respond(input: PlanResponseCommand): Promise<PlanResponseResult>
+  }
+  reviewer: {
+    triggerReview(request: ReviewRunRequest): Promise<ReviewRunResult>
+    getForSession(request: { projectId: string; appSessionId: string }): Promise<ReviewWithChecks[]>
+  }
+}
+
+export type { TaskControlPorts }

--- a/src/main/tasks/task-control-ports.ts
+++ b/src/main/tasks/task-control-ports.ts
@@ -1,18 +1,6 @@
-import type { ReviewRunRequest, ReviewRunResult, ReviewWithChecks } from '../../shared/reviewer'
-import type { ActivePlanProjection, PlanResponseCommand } from '../../shared/session-plan/contract'
-import type { PlanResponseResult } from '../session-plan/plan-service'
-
 type TaskControlPorts = {
   specialists: {
     resolve(reference: string): Promise<{ id: string }>
-  }
-  plans: {
-    getProjection(projectId: string, sessionId: string): Promise<ActivePlanProjection | null>
-    respond(input: PlanResponseCommand): Promise<PlanResponseResult>
-  }
-  reviewer: {
-    triggerReview(request: ReviewRunRequest): Promise<ReviewRunResult>
-    getForSession(request: { projectId: string; appSessionId: string }): Promise<ReviewWithChecks[]>
   }
 }
 

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -571,7 +571,8 @@ describe('TaskRunner', () => {
     })
     expect(review).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'session-controlled' }),
-      'assistant-controlled'
+      'assistant-controlled',
+      expect.any(AbortSignal)
     )
     expect(completed.review).toEqual({
       started: true,
@@ -583,6 +584,70 @@ describe('TaskRunner', () => {
       kind: 'plan-approval',
       plan: { artifactVersionId: 'plan-version', revision: 2 }
     })
+  })
+
+  it('aborts an in-flight automatic review when Run cancellation is accepted', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    let markReviewStarted: (() => void) | undefined
+    const reviewStarted = new Promise<void>((resolve) => {
+      markReviewStarted = resolve
+    })
+    const review = vi.fn(
+      (_session: PersistedChatSession, _turnMessageId: string, signal: AbortSignal) =>
+        new Promise<never>((_resolve, reject) => {
+          markReviewStarted?.()
+          const rejectCancellation = (): void => reject(new Error('review cancelled'))
+          if (signal.aborted) rejectCancellation()
+          else signal.addEventListener('abort', rejectCancellation, { once: true })
+        })
+    )
+    const cancelPrompt = vi.fn(async () => undefined)
+    const ids = ['review-user', 'review-run', 'review-agent']
+    const runner = createRunner({
+      sessions: {
+        list: async () => [],
+        save: async () => undefined
+      },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-review-cancel' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt,
+        prompt: async () => {
+          emitEvent?.({
+            id: 'review-message-event',
+            timestamp: 10,
+            kind: 'message',
+            level: 'info',
+            sessionId: 'session-review-cancel',
+            role: 'assistant',
+            text: 'Review this output.'
+          })
+        }
+      },
+      reviewer: { review },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      },
+      createId: () => ids.shift() ?? 'generated-id'
+    })
+
+    const started = await runner.startRun({
+      project: project.id,
+      prompt: 'Produce and review.',
+      autoReviewEnabled: true
+    })
+    await reviewStarted
+    const cancelled = await runner.cancelRun(started.id)
+
+    expect(cancelled).toMatchObject({ status: 'cancelled', review: undefined })
+    expect(cancelPrompt).toHaveBeenCalledWith('session-review-cancel')
+    expect(review.mock.calls[0]?.[2].aborted).toBe(true)
   })
 
   it('uses the dedicated policy mutation for an existing Session', async () => {

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -68,6 +68,8 @@ const createRunner = (overrides: Partial<TaskRunnerDependencies> = {}): TaskRunn
       finalizeRun: async () => ({ ok: true, artifacts: [] })
     },
     runtimeEvents: { subscribe: () => () => undefined },
+    specialists: { resolve: async (reference) => ({ id: reference }) },
+    reviewer: { review: async () => ({ started: true }) },
     createId: () => 'generated-id',
     now: () => 1,
     ...overrides
@@ -264,6 +266,26 @@ describe('TaskRunner', () => {
     expect(createSession).not.toHaveBeenCalled()
   })
 
+  it('rejects rebinding an existing Session to a different Specialist', async () => {
+    const bound = { ...session, specialistId: 'specialist-existing' }
+    const runner = createRunner({
+      sessions: { list: async () => [bound], save: async () => undefined },
+      specialists: { resolve: async () => ({ id: 'specialist-other' }) }
+    })
+
+    await expect(
+      runner.startRun({
+        project: project.id,
+        sessionId: bound.id,
+        prompt: 'Continue with another Specialist.',
+        specialist: 'other-name'
+      })
+    ).rejects.toMatchObject({
+      code: 'invalid_request',
+      message: `Session ${bound.id} is bound to a different Specialist.`
+    })
+  })
+
   it('rejects a cwd that conflicts with an existing Session workspace', async () => {
     const existingRoot = await mkdtemp(join(tmpdir(), 'open-science-task-existing-cwd-'))
     const requestedRoot = await mkdtemp(join(tmpdir(), 'open-science-task-requested-cwd-'))
@@ -433,6 +455,123 @@ describe('TaskRunner', () => {
           turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 }
         }
       ]
+    })
+  })
+
+  it('applies Plan, review, Specialist, and delegation controls to a new Session', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    const savedSessions: PersistedChatSession[] = []
+    const createSession = vi.fn(async () => ({
+      sessionId: 'session-controlled',
+      frameworkId: 'codex' as const
+    }))
+    const prompt = vi.fn(async () => {
+      emitEvent?.({
+        id: 'plan-event',
+        timestamp: 9,
+        kind: 'plan',
+        level: 'info',
+        sessionId: 'session-controlled',
+        text: 'Plan awaiting approval.',
+        planProjection: {
+          artifactId: 'plan-artifact',
+          artifactVersionId: 'plan-version',
+          artifactChecksum: 'plan-checksum',
+          revision: 2,
+          approval: 'pending',
+          lifecycle: 'awaiting_approval'
+        } as never
+      })
+      emitEvent?.({
+        id: 'message-event',
+        timestamp: 10,
+        kind: 'message',
+        level: 'info',
+        sessionId: 'session-controlled',
+        role: 'assistant',
+        text: 'Controlled output.'
+      })
+    })
+    const resolveSpecialist = vi.fn(async () => ({ id: 'specialist-uuid' }))
+    const review = vi.fn(async () => ({
+      started: true,
+      id: 'review-1',
+      lifecycle: 'complete' as const,
+      outcome: 'pass' as const
+    }))
+    const ids = ['user-controlled', 'run-controlled', 'assistant-controlled']
+    const runner = createRunner({
+      sessions: {
+        list: async () => [],
+        save: async (saved) => {
+          savedSessions.push(structuredClone(saved))
+        }
+      },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession,
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt
+      },
+      specialists: { resolve: resolveSpecialist },
+      reviewer: { review },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      },
+      createId: () => ids.shift() ?? 'generated-id'
+    })
+
+    const started = await runner.startRun({
+      project: project.id,
+      prompt: 'Plan and execute.',
+      turnIntent: 'plan-first',
+      autoReviewEnabled: true,
+      specialist: 'stable-specialist-name',
+      delegationPolicy: 'deny'
+    })
+    const completed = await runner.waitForRun(started.id)
+
+    expect(resolveSpecialist).toHaveBeenCalledWith('stable-specialist-name')
+    expect(createSession).toHaveBeenCalledWith({
+      projectId: project.id,
+      permissionProfile: 'ask',
+      specialistId: 'specialist-uuid'
+    })
+    expect(prompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        turnIntent: 'plan-first',
+        promptMessageId: 'user-controlled'
+      }),
+      expect.any(Object)
+    )
+    expect(savedSessions.at(-1)).toMatchObject({
+      autoReviewEnabled: true,
+      specialistId: 'specialist-uuid',
+      delegationPolicy: 'deny',
+      messages: [
+        expect.objectContaining({ id: 'user-controlled', turnIntent: 'plan-first' }),
+        expect.objectContaining({ id: 'assistant-controlled', content: 'Controlled output.' })
+      ]
+    })
+    expect(review).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'session-controlled' }),
+      'assistant-controlled'
+    )
+    expect(completed.review).toEqual({
+      started: true,
+      id: 'review-1',
+      lifecycle: 'complete',
+      outcome: 'pass'
+    })
+    expect(completed.attention).toMatchObject({
+      kind: 'plan-approval',
+      plan: { artifactVersionId: 'plan-version', revision: 2 }
     })
   })
 

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -44,13 +44,21 @@ const session: PersistedChatSession = {
   updatedAt: 2
 }
 
-const createRunner = (overrides: Partial<TaskRunnerDependencies> = {}): TaskRunner =>
-  new TaskRunner({
+type TaskRunnerOverrides = Omit<Partial<TaskRunnerDependencies>, 'sessions'> & {
+  sessions?: Partial<TaskSessionPort>
+}
+
+const createRunner = (overrides: TaskRunnerOverrides = {}): TaskRunner => {
+  const defaultSessions: TaskSessionPort = {
+    list: async () => [],
+    save: async () => undefined,
+    setDelegationPolicy: async () => undefined
+  }
+  return new TaskRunner({
     projects: {
       list: async () => [project],
       create: async (request) => ({ ...project, ...request })
     },
-    sessions: { list: async () => [], save: async () => undefined },
     previewResources: {
       acquire: async () => ({ id: 'resource-1', url: 'preview://resource-1', size: 0 }),
       release: async () => undefined
@@ -72,9 +80,10 @@ const createRunner = (overrides: Partial<TaskRunnerDependencies> = {}): TaskRunn
     reviewer: { review: async () => ({ started: true }) },
     createId: () => 'generated-id',
     now: () => 1,
-    ...overrides
+    ...overrides,
+    sessions: { ...defaultSessions, ...overrides.sessions }
   })
-
+}
 describe('TaskRunner', () => {
   it('lists projects through its public interface', async () => {
     const projects: TaskProjectPort = {
@@ -111,7 +120,8 @@ describe('TaskRunner', () => {
     }
     const sessions: TaskSessionPort = {
       list: async () => [session],
-      save: async () => undefined
+      save: async () => undefined,
+      setDelegationPolicy: async () => undefined
     }
     const runner = createRunner({ projects, sessions })
 
@@ -573,6 +583,31 @@ describe('TaskRunner', () => {
       kind: 'plan-approval',
       plan: { artifactVersionId: 'plan-version', revision: 2 }
     })
+  })
+
+  it('uses the dedicated policy mutation for an existing Session', async () => {
+    const existing = { ...session, delegationPolicy: 'allow' as const }
+    const setDelegationPolicy = vi.fn(async () => undefined)
+    const ids = ['policy-user', 'policy-run', 'policy-agent']
+    const runner = createRunner({
+      sessions: {
+        list: async () => [existing],
+        save: async () => undefined,
+        setDelegationPolicy
+      },
+      createId: () => ids.shift() ?? 'generated-id'
+    })
+
+    const started = await runner.startRun({
+      project: project.id,
+      sessionId: existing.id,
+      prompt: 'Continue without delegation.',
+      delegationPolicy: 'deny'
+    })
+    await runner.waitForRun(started.id)
+
+    expect(setDelegationPolicy).toHaveBeenCalledOnce()
+    expect(setDelegationPolicy).toHaveBeenCalledWith(project.id, existing.id, 'deny')
   })
 
   it('skips automatic review when the current turn has no assistant message', async () => {

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -1148,6 +1148,52 @@ describe('TaskRunner', () => {
     }
   })
 
+  it('rejects a new authored turn while a restored Plan awaits approval', async () => {
+    const existing: PersistedChatSession = {
+      ...session,
+      id: 'session-plan-pending',
+      status: 'waiting-plan-approval',
+      runtimeContext: {
+        version: 1,
+        revision: 3,
+        plan: {
+          artifactId: 'plan-artifact',
+          artifactVersionId: 'plan-version',
+          artifactChecksum: 'plan-checksum',
+          approval: 'pending',
+          stepStatuses: {}
+        }
+      }
+    }
+    const resumeSession = vi.fn(async () => ({ sessionId: existing.id }))
+    const save = vi.fn(async () => undefined)
+    const runner = createRunner({
+      sessions: { list: async () => [existing], save },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'unused' }),
+        resumeSession,
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async () => undefined
+      }
+    })
+
+    await expect(
+      runner.startRun({
+        project: project.id,
+        sessionId: existing.id,
+        prompt: 'Start another turn.'
+      })
+    ).rejects.toMatchObject({
+      code: 'session_busy',
+      message: `Session is waiting for Plan approval: ${existing.id}`
+    })
+    expect(resumeSession).not.toHaveBeenCalled()
+    expect(save).not.toHaveBeenCalled()
+  })
+
   it('checks archive admission before an existing session is resumed or saved', async () => {
     const existing = { ...session, id: 'session-archived' }
     const resumeSession = async (): Promise<never> => {

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -650,6 +650,81 @@ describe('TaskRunner', () => {
     expect(review.mock.calls[0]?.[2].aborted).toBe(true)
   })
 
+  it('aborts and awaits an in-flight automatic review when disposed', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    let markReviewStarted: (() => void) | undefined
+    let releaseReviewCleanup: (() => void) | undefined
+    const reviewStarted = new Promise<void>((resolve) => {
+      markReviewStarted = resolve
+    })
+    const reviewCleanup = new Promise<void>((resolve) => {
+      releaseReviewCleanup = resolve
+    })
+    const review = vi.fn(
+      (_session: PersistedChatSession, _turnMessageId: string, signal: AbortSignal) =>
+        new Promise<never>((_resolve, reject) => {
+          markReviewStarted?.()
+          const rejectAfterCleanup = (): void => {
+            void reviewCleanup.then(() => reject(new Error('review disposed')))
+          }
+          if (signal.aborted) rejectAfterCleanup()
+          else signal.addEventListener('abort', rejectAfterCleanup, { once: true })
+        })
+    )
+    const ids = ['dispose-user', 'dispose-run', 'dispose-agent']
+    const runner = createRunner({
+      sessions: {
+        list: async () => [],
+        save: async () => undefined
+      },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-review-dispose' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async () => {
+          emitEvent?.({
+            id: 'dispose-message-event',
+            timestamp: 10,
+            kind: 'message',
+            level: 'info',
+            sessionId: 'session-review-dispose',
+            role: 'assistant',
+            text: 'Review before disposal.'
+          })
+        }
+      },
+      reviewer: { review },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      },
+      createId: () => ids.shift() ?? 'generated-id'
+    })
+
+    await runner.startRun({
+      project: project.id,
+      prompt: 'Produce and review before disposal.',
+      autoReviewEnabled: true
+    })
+    await reviewStarted
+    let disposed = false
+    const disposal = runner.dispose().then(() => {
+      disposed = true
+    })
+
+    expect(review.mock.calls[0]?.[2].aborted).toBe(true)
+    await Promise.resolve()
+    expect(disposed).toBe(false)
+    releaseReviewCleanup?.()
+    await disposal
+    expect(disposed).toBe(true)
+  })
+
   it('uses the dedicated policy mutation for an existing Session', async () => {
     const existing = { ...session, delegationPolicy: 'allow' as const }
     const setDelegationPolicy = vi.fn(async () => undefined)
@@ -816,7 +891,7 @@ describe('TaskRunner', () => {
     ])
 
     unsubscribe()
-    runner.dispose()
+    await runner.dispose()
   })
 
   it('marks provider acceptance before the first visible provider event', async () => {
@@ -866,7 +941,7 @@ describe('TaskRunner', () => {
       'first-visible-output',
       'completed'
     ])
-    runner.dispose()
+    await runner.dispose()
   })
 
   it('emits liveness heartbeats until the first visible provider event', async () => {
@@ -909,7 +984,7 @@ describe('TaskRunner', () => {
       await vi.advanceTimersByTimeAsync(20_000)
       expect(progress).toHaveLength(countAfterCompletion)
     } finally {
-      runner.dispose()
+      await runner.dispose()
       vi.useRealTimers()
     }
   })
@@ -923,7 +998,7 @@ describe('TaskRunner', () => {
     const started = await runner.startRun({ project: project.id, prompt: 'Research this.' })
 
     await expect(runner.waitForRun(started.id)).resolves.toMatchObject({ status: 'completed' })
-    runner.dispose()
+    await runner.dispose()
   })
 
   it('stops liveness heartbeats after the first visible provider event', async () => {
@@ -1020,7 +1095,7 @@ describe('TaskRunner', () => {
       const completed = await runner.waitForRun(started.id)
       expect(completed.output).toBe('Working on it.')
     } finally {
-      runner.dispose()
+      await runner.dispose()
       vi.useRealTimers()
     }
   })
@@ -2212,7 +2287,7 @@ describe('TaskRunner', () => {
     })
   })
 
-  it('releases its runtime-event subscription when disposed', () => {
+  it('releases its runtime-event subscription when disposed', async () => {
     let unsubscribeCount = 0
     const runner = createRunner({
       runtimeEvents: {
@@ -2222,7 +2297,7 @@ describe('TaskRunner', () => {
       }
     })
 
-    runner.dispose()
+    await runner.dispose()
 
     expect(unsubscribeCount).toBe(1)
   })

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -575,6 +575,66 @@ describe('TaskRunner', () => {
     })
   })
 
+  it('skips automatic review when the current turn has no assistant message', async () => {
+    const historical: PersistedChatSession = {
+      ...session,
+      autoReviewEnabled: true,
+      messages: [
+        {
+          id: 'historical-user',
+          role: 'user',
+          content: 'Earlier request.',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 1
+        },
+        {
+          id: 'historical-agent',
+          role: 'agent',
+          content: 'Earlier response.',
+          status: 'complete',
+          responseToMessageId: 'historical-user',
+          eventIds: [],
+          createdAt: 2,
+          updatedAt: 2
+        }
+      ]
+    }
+    const savedSessions: PersistedChatSession[] = []
+    const review = vi.fn(async () => ({ started: true }))
+    const ids = ['current-user', 'current-run', 'unused-agent']
+    const runner = createRunner({
+      sessions: {
+        list: async () => [historical],
+        save: async (saved) => {
+          savedSessions.push(structuredClone(saved))
+        }
+      },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [historical.id],
+        createSession: async () => ({ sessionId: 'must-not-create' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async () => undefined
+      },
+      reviewer: { review },
+      createId: () => ids.shift() ?? 'generated-id'
+    })
+
+    const started = await runner.startRun({
+      project: project.id,
+      sessionId: historical.id,
+      prompt: 'Produce no visible response.'
+    })
+    const completed = await runner.waitForRun(started.id)
+
+    expect(completed).toMatchObject({ status: 'completed', output: '' })
+    expect(review).not.toHaveBeenCalled()
+    expect(savedSessions.at(-1)?.messages).toHaveLength(3)
+  })
   it('keeps concurrent external-workspace Sessions isolated by canonical cwd', async () => {
     const requestedCwds = await Promise.all([
       mkdtemp(join(tmpdir(), 'open-science-task-concurrent-a-')),
@@ -1590,6 +1650,22 @@ describe('TaskRunner', () => {
         cancelPrompt: async () => undefined,
         prompt: async () => {
           emitEvent?.({
+            id: 'failed-plan',
+            timestamp: 9,
+            kind: 'plan',
+            level: 'info',
+            sessionId: 'session-tool',
+            text: 'Plan awaiting approval.',
+            planProjection: {
+              artifactId: 'failed-plan-artifact',
+              artifactVersionId: 'failed-plan-version',
+              artifactChecksum: 'failed-plan-checksum',
+              revision: 1,
+              approval: 'pending',
+              lifecycle: 'awaiting_approval'
+            } as never
+          })
+          emitEvent?.({
             id: 'tool-start',
             timestamp: 10,
             kind: 'tool',
@@ -1643,10 +1719,12 @@ describe('TaskRunner', () => {
     })
 
     const started = await runner.startRun({ project: project.id, prompt: 'Run analysis.' })
-    await expect(runner.waitForRun(started.id)).resolves.toMatchObject({
+    const failed = await runner.waitForRun(started.id)
+    expect(failed).toMatchObject({
       status: 'failed',
       error: 'Provider quota exceeded.'
     })
+    expect(failed.attention).toBeUndefined()
     expect(savedSessions.at(-1)).toMatchObject({
       status: 'error',
       error: 'Provider quota exceeded.',
@@ -1701,7 +1779,25 @@ describe('TaskRunner', () => {
         createSession: async () => ({ sessionId: 'session-cancel' }),
         resumeSession: async (request) => ({ sessionId: request.sessionId }),
         setPermissionProfile: async () => undefined,
-        prompt: async () => promptGate,
+        prompt: async () => {
+          emitEvent?.({
+            id: 'cancel-plan',
+            timestamp: 10,
+            kind: 'plan',
+            level: 'info',
+            sessionId: 'session-cancel',
+            text: 'Plan awaiting approval.',
+            planProjection: {
+              artifactId: 'cancel-plan-artifact',
+              artifactVersionId: 'cancel-plan-version',
+              artifactChecksum: 'cancel-plan-checksum',
+              revision: 1,
+              approval: 'pending',
+              lifecycle: 'awaiting_approval'
+            } as never
+          })
+          return promptGate
+        },
         cancelPrompt
       },
       runtimeEvents: {
@@ -1719,6 +1815,10 @@ describe('TaskRunner', () => {
     runner.subscribeProgress((event) => progressPhases.push(event.phase))
 
     const started = await runner.startRun({ project: project.id, prompt: 'Long research.' })
+    expect(started.attention).toMatchObject({
+      kind: 'plan-approval',
+      plan: { artifactVersionId: 'cancel-plan-version' }
+    })
     const cancelled = await runner.cancelRun(started.id)
 
     expect(cancelPrompt).toHaveBeenCalledOnce()
@@ -1731,6 +1831,7 @@ describe('TaskRunner', () => {
       completedAt: expect.any(Number)
     })
     expect(cancelled.cancelledAt).toBe(cancelled.completedAt)
+    expect(cancelled.attention).toBeUndefined()
     expect(progressPhases.at(-1)).toBe('cancelled')
     expect(savedSessions.at(-1)).toMatchObject({
       id: 'session-cancel',

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -50,6 +50,7 @@ type TaskProjectPort = {
 type TaskSessionPort = {
   list(): Promise<PersistedChatSession[]>
   save(session: PersistedChatSession): Promise<void>
+  setDelegationPolicy(projectId: string, sessionId: string, policy: DelegationPolicy): Promise<void>
 }
 
 type TaskPreviewResourcePort = {
@@ -738,6 +739,14 @@ class TaskRunner {
           createdAt: now,
           updatedAt: now
         }
+
+    if (existing && request.delegationPolicy !== undefined) {
+      const setDelegationPolicy = this.dependencies.sessions.setDelegationPolicy
+      if (!setDelegationPolicy) {
+        throw new Error('Task delegation policy control is unavailable.')
+      }
+      await setDelegationPolicy(project.id, existing.id, request.delegationPolicy)
+    }
 
     // Starting a new authored turn consumes the old Resume authority. History replay remains durable
     // until the provider accepts this replacement turn, so a pre-acceptance rejection can retry it.

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -133,7 +133,11 @@ type TaskSpecialistPort = {
 }
 
 type TaskReviewerPort = {
-  review(session: PersistedChatSession, turnMessageId: string): Promise<TaskRunReview>
+  review(
+    session: PersistedChatSession,
+    turnMessageId: string,
+    signal: AbortSignal
+  ): Promise<TaskRunReview>
 }
 
 type TaskRunnerDependencies = {
@@ -157,6 +161,7 @@ type MutableTaskRun = TaskRun & {
   providerAccepted: boolean
   firstVisibleOutput: boolean
   heartbeatTimer?: ReturnType<typeof setTimeout>
+  reviewAbortController?: AbortController
   cancellation?: {
     accepted: boolean
     dispatch: Promise<void>
@@ -596,6 +601,7 @@ class TaskRunner {
     cancellation.dispatch = Promise.resolve()
       .then(() => this.dependencies.agent.cancelPrompt(run.sessionId))
       .then(() => {
+        run.reviewAbortController?.abort()
         cancellation.accepted = true
       })
       .catch((error) => {
@@ -846,16 +852,25 @@ class TaskRunner {
             message.role === 'agent' && message.responseToMessageId === run.promptMessageId
         )
       if (reviewedMessage) {
+        const reviewAbortController = new AbortController()
+        run.reviewAbortController = reviewAbortController
         try {
           run.review = await this.dependencies.reviewer.review(
             completed!.session,
-            reviewedMessage.id
+            reviewedMessage.id,
+            reviewAbortController.signal
           )
         } catch (error) {
-          run.review = {
-            started: false,
-            reason: 'run-failed',
-            errorMessage: error instanceof Error ? error.message : String(error)
+          if (!reviewAbortController.signal.aborted) {
+            run.review = {
+              started: false,
+              reason: 'run-failed',
+              errorMessage: error instanceof Error ? error.message : String(error)
+            }
+          }
+        } finally {
+          if (run.reviewAbortController === reviewAbortController) {
+            run.reviewAbortController = undefined
           }
         }
       }

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -832,7 +832,10 @@ class TaskRunner {
     if (!run.cancellation && completed!.session.autoReviewEnabled === true) {
       const reviewedMessage = [...completed!.session.messages]
         .reverse()
-        .find((message) => message.role === 'agent')
+        .find(
+          (message) =>
+            message.role === 'agent' && message.responseToMessageId === run.promptMessageId
+        )
       if (reviewedMessage) {
         try {
           run.review = await this.dependencies.reviewer.review(
@@ -851,6 +854,7 @@ class TaskRunner {
     const terminalCancellation = run.cancellation
     if (terminalCancellation) await terminalCancellation.dispatch.catch(() => undefined)
     const terminalCancellationAccepted = terminalCancellation?.accepted === true
+    if (terminalCancellationAccepted) run.attention = undefined
     run.status = terminalCancellationAccepted ? 'cancelled' : 'completed'
     run.output = completed!.output
     run.artifacts = completed!.artifacts
@@ -881,6 +885,7 @@ class TaskRunner {
       updatedAt: this.dependencies.now()
     }
     run.status = 'failed'
+    run.attention = undefined
     run.error = message
     run.output = completed?.output
     run.artifacts = completed?.artifacts ?? []

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -371,6 +371,8 @@ class TaskRunner {
   private readonly activeRunBySession = new Map<string, string>()
   private readonly progressListeners = new Set<(event: TaskRunProgressEvent) => void>()
   private readonly unsubscribeEvents: () => void
+  private disposed = false
+  private disposal: Promise<void> | undefined
 
   constructor(private readonly dependencies: TaskRunnerDependencies) {
     this.unsubscribeEvents = dependencies.runtimeEvents.subscribe((event) =>
@@ -378,10 +380,20 @@ class TaskRunner {
     )
   }
 
-  dispose(): void {
+  dispose(): Promise<void> {
+    if (this.disposal) return this.disposal
+    this.disposed = true
     this.unsubscribeEvents()
-    for (const run of this.runs.values()) this.stopHeartbeat(run)
+    const activeReviewCompletions: Promise<void>[] = []
+    for (const run of this.runs.values()) {
+      this.stopHeartbeat(run)
+      if (!run.reviewAbortController) continue
+      run.reviewAbortController.abort()
+      activeReviewCompletions.push(run.completion)
+    }
     this.progressListeners.clear()
+    this.disposal = Promise.allSettled(activeReviewCompletions).then(() => undefined)
+    return this.disposal
   }
 
   subscribeProgress(listener: (event: TaskRunProgressEvent) => void): () => void {
@@ -844,7 +856,7 @@ class TaskRunner {
       await this.failRun(run, acceptedSession, completed, error)
       return
     }
-    if (!run.cancellation && completed!.session.autoReviewEnabled === true) {
+    if (!this.disposed && !run.cancellation && completed!.session.autoReviewEnabled === true) {
       const reviewedMessage = [...completed!.session.messages]
         .reverse()
         .find(

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -19,6 +19,7 @@ import type { PermissionProfileId } from '../../shared/permission-profiles'
 import type { Project } from '../../shared/projects'
 import type { AgentFrameworkId } from '../../shared/settings'
 import type {
+  DelegationPolicy,
   PersistedArtifact,
   PersistedChatMessage,
   PersistedChatSession,
@@ -32,6 +33,7 @@ import type {
   TaskRun,
   TaskRunProgressEvent,
   TaskRunProgressPhase,
+  TaskRunReview,
   TaskSessionSummary
 } from '../../shared/task-api'
 
@@ -73,6 +75,7 @@ type TaskAgentCreateSessionRequest = {
   projectId: string
   permissionProfile: PermissionProfileId
   cwd?: string
+  specialistId?: string
 }
 
 type TaskAgentResumeSessionRequest = {
@@ -84,12 +87,14 @@ type TaskAgentResumeSessionRequest = {
   permissionProfile: PermissionProfileId
   previousFrameworkId?: AgentFrameworkId
   previousBackendId?: string
+  specialistId?: string
 }
 
 type TaskAgentPromptRequest = {
   sessionId: string
   promptMessageId: string
   text: string
+  turnIntent?: 'plan-first'
   skillIds?: string[]
   historyPreamble?: string
   contextReset?: boolean
@@ -122,6 +127,14 @@ type TaskRuntimeEventPort = {
   subscribe(listener: (event: AcpRuntimeEvent) => void): () => void
 }
 
+type TaskSpecialistPort = {
+  resolve(reference: string): Promise<{ id: string }>
+}
+
+type TaskReviewerPort = {
+  review(session: PersistedChatSession, turnMessageId: string): Promise<TaskRunReview>
+}
+
 type TaskRunnerDependencies = {
   projects: TaskProjectPort
   sessions: TaskSessionPort
@@ -129,6 +142,8 @@ type TaskRunnerDependencies = {
   agent: TaskAgentPort
   artifacts: TaskArtifactPort
   runtimeEvents: TaskRuntimeEventPort
+  specialists: TaskSpecialistPort
+  reviewer: TaskReviewerPort
   createId: () => string
   now: () => number
 }
@@ -190,7 +205,9 @@ const cloneRun = (run: MutableTaskRun): TaskRun => ({
   completedAt: run.completedAt,
   output: run.output,
   error: run.error,
-  artifacts: [...run.artifacts]
+  artifacts: [...run.artifacts],
+  attention: run.attention,
+  review: run.review
 })
 
 const createTitle = (prompt: string): string => {
@@ -198,12 +215,18 @@ const createTitle = (prompt: string): string => {
   return normalized.length <= 60 ? normalized : `${normalized.slice(0, 57)}...`
 }
 
-const createUserMessage = (id: string, content: string, now: number): PersistedChatMessage => ({
+const createUserMessage = (
+  id: string,
+  content: string,
+  now: number,
+  turnIntent?: 'plan-first'
+): PersistedChatMessage => ({
   id,
   role: 'user',
   content,
   status: 'complete',
   eventIds: [],
+  ...(turnIntent ? { turnIntent } : {}),
   createdAt: now,
   updatedAt: now
 })
@@ -271,6 +294,9 @@ const summarizeSession = (session: PersistedChatSession): TaskSessionSummary => 
   title: session.title,
   status: session.status,
   permissionProfile: session.permissionProfile,
+  autoReviewEnabled: session.autoReviewEnabled === true,
+  specialistId: session.specialistId,
+  delegationPolicy: session.delegationPolicy === 'deny' ? 'deny' : 'allow',
   createdAt: session.createdAt,
   updatedAt: session.updatedAt,
   output: [...session.messages].reverse().find((message) => message.role === 'agent')?.content,
@@ -438,6 +464,25 @@ class TaskRunner {
     ) {
       throw new TaskRunnerError('invalid_request', 'Skill ids must be non-empty strings.')
     }
+    if (request.turnIntent !== undefined && request.turnIntent !== 'plan-first') {
+      throw new TaskRunnerError('invalid_request', 'Turn intent must be plan-first.')
+    }
+    if (request.autoReviewEnabled !== undefined && typeof request.autoReviewEnabled !== 'boolean') {
+      throw new TaskRunnerError('invalid_request', 'Auto review must be a boolean.')
+    }
+    if (
+      request.specialist !== undefined &&
+      (typeof request.specialist !== 'string' || !request.specialist.trim())
+    ) {
+      throw new TaskRunnerError('invalid_request', 'Specialist must be a non-empty id or name.')
+    }
+    if (
+      request.delegationPolicy !== undefined &&
+      request.delegationPolicy !== 'allow' &&
+      request.delegationPolicy !== 'deny'
+    ) {
+      throw new TaskRunnerError('invalid_request', 'Delegation policy must be allow or deny.')
+    }
     const prompt = typeof request.prompt === 'string' ? request.prompt.trim() : ''
     if (!prompt) throw new TaskRunnerError('invalid_request', 'Prompt is required.')
     const cwd =
@@ -594,6 +639,29 @@ class TaskRunner {
     const now = this.dependencies.now()
     const permissionProfile =
       request.permissionProfile ?? existing?.permissionProfile ?? DEFAULT_PERMISSION_PROFILE
+    const requestedSpecialist = request.specialist?.trim()
+    let specialistId = existing?.specialistId
+    if (requestedSpecialist) {
+      let resolved: { id: string }
+      try {
+        resolved = await this.dependencies.specialists.resolve(requestedSpecialist)
+      } catch (error) {
+        throw new TaskRunnerError(
+          'specialist_not_found',
+          error instanceof Error ? error.message : String(error)
+        )
+      }
+      if (existing && existing.specialistId !== resolved.id) {
+        throw new TaskRunnerError(
+          'invalid_request',
+          `Session ${existing.id} is bound to a different Specialist.`
+        )
+      }
+      specialistId = resolved.id
+    }
+    const autoReviewEnabled = request.autoReviewEnabled ?? existing?.autoReviewEnabled ?? false
+    const delegationPolicy: DelegationPolicy =
+      request.delegationPolicy ?? existing?.delegationPolicy ?? 'allow'
     let sessionInfo: TaskAgentSession
 
     if (existing) {
@@ -619,24 +687,29 @@ class TaskRunner {
           previousFrameworkId: existing.agentFrameworkId,
           previousBackendId: existing.agentBackendId,
           providerSessionId: existing.providerSessionId,
-          providerContinuityToken: existing.providerContinuityToken
+          providerContinuityToken: existing.providerContinuityToken,
+          ...(specialistId ? { specialistId } : {})
         })
       }
     } else {
       sessionInfo = await this.dependencies.agent.createSession({
         projectId: project.id,
         permissionProfile,
-        ...(request.cwd ? { cwd: request.cwd } : {})
+        ...(request.cwd ? { cwd: request.cwd } : {}),
+        ...(specialistId ? { specialistId } : {})
       })
     }
 
-    const userMessage = createUserMessage(userMessageId, prompt, now)
+    const userMessage = createUserMessage(userMessageId, prompt, now, request.turnIntent)
     const session: PersistedChatSession = existing
       ? {
           ...existing,
           cwd: sessionInfo.cwd ?? existing.cwd,
           status: 'running',
           permissionProfile,
+          autoReviewEnabled,
+          delegationPolicy,
+          specialistId,
           agentFrameworkId: sessionInfo.frameworkId ?? existing.agentFrameworkId,
           agentBackendId: sessionInfo.backendId ?? existing.agentBackendId,
           providerSessionId: sessionInfo.providerSessionId ?? existing.providerSessionId,
@@ -653,6 +726,9 @@ class TaskRunner {
           cwd: request.cwd ?? sessionInfo.cwd ?? '',
           status: 'running',
           permissionProfile,
+          autoReviewEnabled,
+          delegationPolicy,
+          specialistId,
           agentFrameworkId: sessionInfo.frameworkId,
           agentBackendId: sessionInfo.backendId,
           providerSessionId: sessionInfo.providerSessionId,
@@ -703,6 +779,7 @@ class TaskRunner {
           sessionId: session.id,
           promptMessageId: session.activeRun!.promptMessageId,
           text: prompt,
+          ...(request.turnIntent ? { turnIntent: request.turnIntent } : {}),
           ...(request.skillIds?.length ? { skillIds: request.skillIds } : {}),
           ...(historyPreamble ? { historyPreamble } : {}),
           ...(contextReset ? { contextReset: true } : {}),
@@ -751,6 +828,25 @@ class TaskRunner {
     } catch (error) {
       await this.failRun(run, acceptedSession, completed, error)
       return
+    }
+    if (!run.cancellation && completed!.session.autoReviewEnabled === true) {
+      const reviewedMessage = [...completed!.session.messages]
+        .reverse()
+        .find((message) => message.role === 'agent')
+      if (reviewedMessage) {
+        try {
+          run.review = await this.dependencies.reviewer.review(
+            completed!.session,
+            reviewedMessage.id
+          )
+        } catch (error) {
+          run.review = {
+            started: false,
+            reason: 'run-failed',
+            errorMessage: error instanceof Error ? error.message : String(error)
+          }
+        }
+      }
     }
     const terminalCancellation = run.cancellation
     if (terminalCancellation) await terminalCancellation.dispatch.catch(() => undefined)
@@ -945,6 +1041,12 @@ class TaskRunner {
         continue
       }
       run.events.push(event)
+      if (event.kind === 'plan' && event.planProjection) {
+        run.attention =
+          event.planProjection.lifecycle === 'awaiting_approval'
+            ? { kind: 'plan-approval', plan: event.planProjection }
+            : undefined
+      }
       if (
         run.providerAccepted &&
         !run.firstVisibleOutput &&

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -530,6 +530,15 @@ class TaskRunner {
         )
       }
     }
+    if (
+      existing?.status === 'waiting-plan-approval' &&
+      existing.runtimeContext?.plan?.approval === 'pending'
+    ) {
+      throw new TaskRunnerError(
+        'session_busy',
+        `Session is waiting for Plan approval: ${existing.id}`
+      )
+    }
     const userMessageId = this.dependencies.createId()
     const runId = this.dependencies.createId()
     if (existing) this.reserveSession(existing.id, runId)

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -1537,6 +1537,29 @@ describe('startWebHttpServer', () => {
       expectedRevision: 2
     })
 
+    tasks.respondSessionPlan.mockClear()
+    for (const invalidResponse of [
+      null,
+      {},
+      { feedback: '   ' },
+      { feedback: 'revise', decision: 'rejected' },
+      { decision: 'maybe', artifactVersionId: 'plan-version', expectedRevision: 2 },
+      { decision: 'approved', artifactVersionId: '', expectedRevision: 2 },
+      { decision: 'approved', artifactVersionId: 'plan-version', expectedRevision: -1 },
+      { decision: 'approved', artifactVersionId: 'plan-version', expectedRevision: 1.5 }
+    ]) {
+      const invalidPlanResponse = await fetch(`${base}/api/v1/sessions/session%2F1/plan/respond`, {
+        method: 'POST',
+        headers: { ...headers, 'content-type': 'application/json' },
+        body: JSON.stringify(invalidResponse)
+      })
+      expect(invalidPlanResponse.status).toBe(400)
+      expect(await invalidPlanResponse.json()).toMatchObject({
+        error: { code: 'invalid_request' }
+      })
+    }
+    expect(tasks.respondSessionPlan).not.toHaveBeenCalled()
+
     const artifacts = await fetch(`${base}/api/v1/sessions/session%2F1/artifacts`, { headers })
     expect(await artifacts.json()).toEqual({
       data: [{ id: 'artifact/1', name: 'report.md' }]

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -1380,6 +1380,12 @@ describe('startWebHttpServer', () => {
       createProject: vi.fn().mockResolvedValue({ id: 'project-2', name: 'Created' }),
       listSessions: vi.fn().mockResolvedValue([{ id: 'session/1', title: 'Review' }]),
       getSession: vi.fn().mockResolvedValue({ id: 'session/1', title: 'Review' }),
+      getSessionPlan: vi.fn().mockResolvedValue({
+        artifactVersionId: 'plan-version',
+        revision: 2,
+        lifecycle: 'awaiting_approval'
+      }),
+      respondSessionPlan: vi.fn().mockResolvedValue({ changed: true }),
       startRun: vi.fn().mockResolvedValue({
         id: 'run-1',
         sessionId: 'session-1',
@@ -1504,6 +1510,32 @@ describe('startWebHttpServer', () => {
     const session = await fetch(`${base}/api/v1/sessions/session%2F1`, { headers })
     expect(await session.json()).toEqual({ data: { id: 'session/1', title: 'Review' } })
     expect(tasks.getSession).toHaveBeenCalledWith('session/1')
+
+    const plan = await fetch(`${base}/api/v1/sessions/session%2F1/plan`, { headers })
+    expect(await plan.json()).toEqual({
+      data: {
+        artifactVersionId: 'plan-version',
+        revision: 2,
+        lifecycle: 'awaiting_approval'
+      }
+    })
+    expect(tasks.getSessionPlan).toHaveBeenCalledWith('session/1')
+
+    const approvedPlan = await fetch(`${base}/api/v1/sessions/session%2F1/plan/respond`, {
+      method: 'POST',
+      headers: { ...headers, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        decision: 'approved',
+        artifactVersionId: 'plan-version',
+        expectedRevision: 2
+      })
+    })
+    expect(await approvedPlan.json()).toEqual({ data: { changed: true } })
+    expect(tasks.respondSessionPlan).toHaveBeenCalledWith('session/1', {
+      decision: 'approved',
+      artifactVersionId: 'plan-version',
+      expectedRevision: 2
+    })
 
     const artifacts = await fetch(`${base}/api/v1/sessions/session%2F1/artifacts`, { headers })
     expect(await artifacts.json()).toEqual({

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -199,6 +199,45 @@ const taskErrorStatus = (error: TaskApiError): number => {
   return 404
 }
 
+const parseTaskPlanResponseRequest = (value: unknown): TaskPlanResponseRequest => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TaskApiError('invalid_request', 'Plan response must be an object.')
+  }
+  const candidate = value as Record<string, unknown>
+  if ('feedback' in candidate) {
+    if (
+      typeof candidate.feedback !== 'string' ||
+      candidate.feedback.trim().length === 0 ||
+      'decision' in candidate ||
+      'artifactVersionId' in candidate ||
+      'expectedRevision' in candidate
+    ) {
+      throw new TaskApiError(
+        'invalid_request',
+        'Plan feedback must be a non-empty string without decision fields.'
+      )
+    }
+    return { feedback: candidate.feedback.trim() }
+  }
+  if (
+    (candidate.decision !== 'approved' && candidate.decision !== 'rejected') ||
+    typeof candidate.artifactVersionId !== 'string' ||
+    candidate.artifactVersionId.trim().length === 0 ||
+    !Number.isInteger(candidate.expectedRevision) ||
+    (candidate.expectedRevision as number) < 0
+  ) {
+    throw new TaskApiError(
+      'invalid_request',
+      'Plan decision requires approved or rejected, a non-empty artifact version, and a non-negative integer revision.'
+    )
+  }
+  return {
+    decision: candidate.decision,
+    artifactVersionId: candidate.artifactVersionId.trim(),
+    expectedRevision: candidate.expectedRevision as number
+  }
+}
+
 class ExternalAuthorizationExpiredError extends Error {
   constructor() {
     super('Remote authorization expired before the request was executed.')
@@ -376,7 +415,7 @@ const handleTaskApiRequest = async (
         /^\/api\/v1\/sessions\/([^/]+)\/plan\/respond$/
       )
       if (sessionPlanResponseMatch && request.method === 'POST' && tasks.respondSessionPlan) {
-        const body = (await readJsonBody(request)) as TaskPlanResponseRequest
+        const body = parseTaskPlanResponseRequest(await readJsonBody(request))
         assertExternalAuthorizationCurrent(externalAuthorization)
         json(response, 200, {
           data: await tasks.respondSessionPlan(

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -11,6 +11,7 @@ import { net } from 'electron'
 import { WebSocket, WebSocketServer } from 'ws'
 
 import { toApplicationCommandErrorEnvelope } from '../../shared/application-command-contract'
+import { PlanCommandError } from '../../shared/session-plan/contract'
 import type { WebRpcErrorCode } from '../../shared/web-rpc-contract'
 import {
   ClientLeaseRegistry,
@@ -35,7 +36,7 @@ import {
 } from './application-event-projections'
 import { InternalWebEventStream } from './internal-web-event-stream'
 import { authenticateRequest, persistAuthCookie } from './auth'
-import type { StartTaskRunRequest } from '../../shared/task-api'
+import type { StartTaskRunRequest, TaskPlanResponseRequest } from '../../shared/task-api'
 import { TaskApiError, type HeadlessTaskApi } from './task-api'
 
 const MAX_RPC_BODY_BYTES = 64 * 1024 * 1024
@@ -90,7 +91,8 @@ type WebServerOptions = {
     | 'acquireArtifact'
     | 'releaseArtifact'
     | 'runWithCallerContext'
-  >
+  > &
+    Partial<Pick<HeadlessTaskApi, 'getSessionPlan' | 'respondSessionPlan'>>
   onShutdownRequest?: () => void
   bootstrap: {
     appName: string
@@ -225,6 +227,12 @@ const taskError = (response: ServerResponse, error: unknown): void => {
     })
     return
   }
+  if (error instanceof PlanCommandError) {
+    json(response, error.code === 'invalid-plan' ? 400 : 409, {
+      error: { code: error.code, message: error.message }
+    })
+    return
+  }
   if (error instanceof TaskApiError) {
     json(response, taskErrorStatus(error), {
       error: { code: error.code, message: error.message }
@@ -353,6 +361,28 @@ const handleTaskApiRequest = async (
         assertExternalAuthorizationCurrent(externalAuthorization)
         json(response, 200, {
           data: await tasks.cancelRun(decodeURIComponent(cancelRunMatch[1]))
+        })
+        return true
+      }
+      const sessionPlanMatch = url.pathname.match(/^\/api\/v1\/sessions\/([^/]+)\/plan$/)
+      if (sessionPlanMatch && request.method === 'GET' && tasks.getSessionPlan) {
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, {
+          data: await tasks.getSessionPlan(decodeURIComponent(sessionPlanMatch[1]))
+        })
+        return true
+      }
+      const sessionPlanResponseMatch = url.pathname.match(
+        /^\/api\/v1\/sessions\/([^/]+)\/plan\/respond$/
+      )
+      if (sessionPlanResponseMatch && request.method === 'POST' && tasks.respondSessionPlan) {
+        const body = (await readJsonBody(request)) as TaskPlanResponseRequest
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, {
+          data: await tasks.respondSessionPlan(
+            decodeURIComponent(sessionPlanResponseMatch[1]),
+            body
+          )
         })
         return true
       }

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -5,6 +5,7 @@ import { app } from 'electron'
 import type { ApplicationCommandComposition } from '../application-command-composition'
 import { createLogger } from '../logger'
 import type { ApplicationEventSource } from '../application-events'
+import type { TaskControlPorts } from '../tasks/task-control-ports'
 import type { TaskAgentPort } from '../tasks/task-runner'
 import { resolveConfigRoot } from '../storage-root'
 import { loadOrCreateWebToken } from './auth'
@@ -68,13 +69,15 @@ const createWebServiceController = (
     requestQuit,
     externalAccess,
     applicationEvents,
-    taskAgent
+    taskAgent,
+    taskControls
   }: {
     applicationCommands: Pick<ApplicationCommandComposition, 'localWeb' | 'remoteWeb' | 'task'>
     requestQuit: () => void
     externalAccess?: ExternalWebAccess
     applicationEvents: ApplicationEventSource
     taskAgent: TaskAgentPort
+    taskControls?: TaskControlPorts
   },
   deps: Partial<WebServiceControllerDeps> = {}
 ): WebServiceController => {
@@ -97,7 +100,7 @@ const createWebServiceController = (
       pid: process.pid
     }))
   const tasks = new HeadlessTaskApi(
-    { commands: applicationCommands.task, agent: taskAgent },
+    { commands: applicationCommands.task, agent: taskAgent, controls: taskControls },
     {
       subscribeEvents: (listener) =>
         applicationEvents.subscribe((event) => {

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -146,7 +146,7 @@ const createWebServiceController = (
       try {
         await close()
       } finally {
-        tasks.dispose()
+        await tasks.dispose()
       }
     })()
     return disposal

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -129,7 +129,7 @@ describe('HeadlessTaskApi adapter', () => {
         expectedRevision: 3
       }
     ])
-    api.dispose()
+    await api.dispose()
   })
   it('exposes Task Run progress through one subscription seam', async () => {
     const invoke = vi.fn(async (channel: string) => {
@@ -162,7 +162,7 @@ describe('HeadlessTaskApi adapter', () => {
       'completed'
     ])
     unsubscribe()
-    api.dispose()
+    await api.dispose()
   })
 
   it('maps public query and artifact commands to the compatibility façade', async () => {
@@ -520,7 +520,83 @@ describe('HeadlessTaskApi adapter', () => {
     expect(invoke).toHaveBeenCalledWith('reviewer:abort', expect.anything(), [
       { projectId: project.id, appSessionId: 'session-review-cancel' }
     ])
-    api.dispose()
+    await api.dispose()
+  })
+
+  it('awaits Reviewer cleanup before completing Task API disposal', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    let markAbortStarted: (() => void) | undefined
+    let releaseAbort: (() => void) | undefined
+    const abortStarted = new Promise<void>((resolve) => {
+      markAbortStarted = resolve
+    })
+    const abortGate = new Promise<void>((resolve) => {
+      releaseAbort = resolve
+    })
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'projects:list') return [project]
+      if (channel === 'sessions:load-all') return { sessions: [], manifest: { version: 1 } }
+      if (channel === 'sessions:save-session') return undefined
+      if (channel === 'reviewer:run') return { started: true }
+      if (channel === 'reviewer:get-for-session') {
+        return [{ id: 'review-1', turnMessageId: 'dispose-agent', lifecycle: 'running' }]
+      }
+      if (channel === 'reviewer:abort') {
+        markAbortStarted?.()
+        await abortGate
+        return undefined
+      }
+      throw new Error(`Unexpected RPC channel: ${channel}`)
+    })
+    const agent = createAgent({
+      createSession: vi.fn(async () => ({ sessionId: 'session-review-dispose' })),
+      prompt: vi.fn(async () => {
+        emitEvent?.({
+          id: 'dispose-message-event',
+          timestamp: 10,
+          kind: 'message',
+          level: 'info',
+          sessionId: 'session-review-dispose',
+          role: 'assistant',
+          text: 'Review before disposal.'
+        })
+      })
+    })
+    const ids = ['dispose-user', 'dispose-run', 'dispose-agent']
+    const api = new HeadlessTaskApi(
+      { commands: commandsFrom(invoke), agent },
+      {
+        createId: () => ids.shift() ?? 'generated-id',
+        subscribeEvents: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      }
+    )
+
+    await api.startRun({
+      project: project.id,
+      prompt: 'Produce and review before disposal.',
+      autoReviewEnabled: true
+    })
+    await vi.waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith('reviewer:get-for-session', expect.anything(), [
+        { projectId: project.id, appSessionId: 'session-review-dispose' }
+      ])
+    )
+    let disposed = false
+    const disposal = api.dispose().then(() => {
+      disposed = true
+    })
+    await abortStarted
+
+    expect(disposed).toBe(false)
+    releaseAbort?.()
+    await disposal
+    expect(disposed).toBe(true)
+    expect(invoke).toHaveBeenCalledWith('reviewer:abort', expect.anything(), [
+      { projectId: project.id, appSessionId: 'session-review-dispose' }
+    ])
   })
 
   it('does not enter the direct Agent port for cancellation after authorization expires', async () => {

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -466,6 +466,63 @@ describe('HeadlessTaskApi adapter', () => {
     expect(agent.cancelPrompt).toHaveBeenCalledWith('session-cancel-context')
   })
 
+  it('aborts the Reviewer command when cancellation reaches an automatic review', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'projects:list') return [project]
+      if (channel === 'sessions:load-all') return { sessions: [], manifest: { version: 1 } }
+      if (channel === 'sessions:save-session') return undefined
+      if (channel === 'reviewer:run') return { started: true }
+      if (channel === 'reviewer:get-for-session') {
+        return [{ id: 'review-1', turnMessageId: 'review-agent', lifecycle: 'running' }]
+      }
+      if (channel === 'reviewer:abort') return undefined
+      throw new Error(`Unexpected RPC channel: ${channel}`)
+    })
+    const agent = createAgent({
+      createSession: vi.fn(async () => ({ sessionId: 'session-review-cancel' })),
+      prompt: vi.fn(async () => {
+        emitEvent?.({
+          id: 'review-message-event',
+          timestamp: 10,
+          kind: 'message',
+          level: 'info',
+          sessionId: 'session-review-cancel',
+          role: 'assistant',
+          text: 'Review this output.'
+        })
+      })
+    })
+    const ids = ['review-user', 'review-run', 'review-agent']
+    const api = new HeadlessTaskApi(
+      { commands: commandsFrom(invoke), agent },
+      {
+        createId: () => ids.shift() ?? 'generated-id',
+        subscribeEvents: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      }
+    )
+
+    const run = await api.startRun({
+      project: project.id,
+      prompt: 'Produce and review.',
+      autoReviewEnabled: true
+    })
+    await vi.waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith('reviewer:get-for-session', expect.anything(), [
+        { projectId: project.id, appSessionId: 'session-review-cancel' }
+      ])
+    )
+    await expect(api.cancelRun(run.id)).resolves.toMatchObject({ status: 'cancelled' })
+
+    expect(invoke).toHaveBeenCalledWith('reviewer:abort', expect.anything(), [
+      { projectId: project.id, appSessionId: 'session-review-cancel' }
+    ])
+    api.dispose()
+  })
+
   it('does not enter the direct Agent port for cancellation after authorization expires', async () => {
     let finishPrompt: (() => void) | undefined
     const promptGate = new Promise<void>((resolve) => {

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -75,7 +75,7 @@ describe('HeadlessTaskApi adapter', () => {
     )
   })
 
-  it('reads and responds to a Session Plan through direct Task controls', async () => {
+  it('reads and responds to a Session Plan through the Task command view', async () => {
     const persisted: PersistedChatSession = {
       id: 'session-plan',
       projectId: project.id,
@@ -94,24 +94,17 @@ describe('HeadlessTaskApi adapter', () => {
       approval: 'pending',
       lifecycle: 'awaiting_approval'
     } as never
-    const getProjection = vi.fn(async () => projection)
-    const respond = vi.fn(async () => ({ projection, changed: true }))
-    const api = new HeadlessTaskApi({
-      commands: commandsFrom(async (channel) => {
-        if (channel === 'sessions:load-all') {
-          return { sessions: [persisted], manifest: { version: 1 } }
-        }
-        throw new Error(`Unexpected Task command: ${channel}`)
-      }),
-      agent: createAgent(),
-      controls: {
-        specialists: { resolve: async (reference) => ({ id: reference }) },
-        plans: { getProjection, respond },
-        reviewer: {
-          triggerReview: async () => ({ started: false, reason: 'already-reviewed' }),
-          getForSession: async () => []
-        }
+    const commandInvoke = vi.fn(async (channel: string) => {
+      if (channel === 'sessions:load-all') {
+        return { sessions: [persisted], manifest: { version: 1 } }
       }
+      if (channel === 'acp:get-plan-projection') return projection
+      if (channel === 'acp:respond-plan') return { projection, changed: true }
+      throw new Error(`Unexpected Task command: ${channel}`)
+    })
+    const api = new HeadlessTaskApi({
+      commands: commandsFrom(commandInvoke),
+      agent: createAgent()
     })
 
     await expect(api.getSessionPlan(persisted.id)).resolves.toBe(projection)
@@ -123,17 +116,21 @@ describe('HeadlessTaskApi adapter', () => {
       })
     ).resolves.toEqual({ projection, changed: true })
 
-    expect(getProjection).toHaveBeenCalledWith(project.id, persisted.id)
-    expect(respond).toHaveBeenCalledWith({
-      projectId: project.id,
-      sessionId: persisted.id,
-      decision: 'approved',
-      artifactVersionId: 'plan-version',
-      expectedRevision: 3
-    })
+    expect(commandInvoke).toHaveBeenCalledWith('acp:get-plan-projection', expect.anything(), [
+      project.id,
+      persisted.id
+    ])
+    expect(commandInvoke).toHaveBeenCalledWith('acp:respond-plan', expect.anything(), [
+      {
+        projectId: project.id,
+        sessionId: persisted.id,
+        decision: 'approved',
+        artifactVersionId: 'plan-version',
+        expectedRevision: 3
+      }
+    ])
     api.dispose()
   })
-
   it('exposes Task Run progress through one subscription seam', async () => {
     const invoke = vi.fn(async (channel: string) => {
       if (channel === 'projects:list') return [project]

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -75,6 +75,65 @@ describe('HeadlessTaskApi adapter', () => {
     )
   })
 
+  it('reads and responds to a Session Plan through direct Task controls', async () => {
+    const persisted: PersistedChatSession = {
+      id: 'session-plan',
+      projectId: project.id,
+      title: 'Plan session',
+      cwd: '/workspace/plan',
+      status: 'waiting-plan-approval',
+      messages: [],
+      createdAt: 1,
+      updatedAt: 2
+    }
+    const projection = {
+      artifactId: 'plan-artifact',
+      artifactVersionId: 'plan-version',
+      artifactChecksum: 'checksum',
+      revision: 3,
+      approval: 'pending',
+      lifecycle: 'awaiting_approval'
+    } as never
+    const getProjection = vi.fn(async () => projection)
+    const respond = vi.fn(async () => ({ projection, changed: true }))
+    const api = new HeadlessTaskApi({
+      commands: commandsFrom(async (channel) => {
+        if (channel === 'sessions:load-all') {
+          return { sessions: [persisted], manifest: { version: 1 } }
+        }
+        throw new Error(`Unexpected Task command: ${channel}`)
+      }),
+      agent: createAgent(),
+      controls: {
+        specialists: { resolve: async (reference) => ({ id: reference }) },
+        plans: { getProjection, respond },
+        reviewer: {
+          triggerReview: async () => ({ started: false, reason: 'already-reviewed' }),
+          getForSession: async () => []
+        }
+      }
+    })
+
+    await expect(api.getSessionPlan(persisted.id)).resolves.toBe(projection)
+    await expect(
+      api.respondSessionPlan(persisted.id, {
+        decision: 'approved',
+        artifactVersionId: 'plan-version',
+        expectedRevision: 3
+      })
+    ).resolves.toEqual({ projection, changed: true })
+
+    expect(getProjection).toHaveBeenCalledWith(project.id, persisted.id)
+    expect(respond).toHaveBeenCalledWith({
+      projectId: project.id,
+      sessionId: persisted.id,
+      decision: 'approved',
+      artifactVersionId: 'plan-version',
+      expectedRevision: 3
+    })
+    api.dispose()
+  })
+
   it('exposes Task Run progress through one subscription seam', async () => {
     const invoke = vi.fn(async (channel: string) => {
       if (channel === 'projects:list') return [project]

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -523,6 +523,74 @@ describe('HeadlessTaskApi adapter', () => {
     await api.dispose()
   })
 
+  it('keeps admitted automatic-review polling alive after remote authorization expires', async () => {
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    let authorizationCurrent = true
+    const context = createTaskCallerContext({
+      location: 'remote',
+      isAuthorizationCurrent: () => authorizationCurrent
+    })
+    const invoke = vi.fn(
+      async (channel: string, callerContext: CallerContext): Promise<unknown> => {
+        if (channel === 'projects:list') return [project]
+        if (channel === 'sessions:load-all') {
+          return { sessions: [], manifest: { version: 1 } }
+        }
+        if (channel === 'sessions:save-session') return undefined
+        if (channel === 'reviewer:run') {
+          expect(callerContext).toBe(context)
+          authorizationCurrent = false
+          return { started: true }
+        }
+        if (channel === 'reviewer:get-for-session') {
+          expect(callerContext).toEqual(taskCallerContext())
+          expect(callerContext.isAuthorizationCurrent()).toBe(true)
+          return [{ id: 'review-expired', turnMessageId: 'expired-agent', lifecycle: 'completed' }]
+        }
+        throw new Error(`Unexpected RPC channel: ${channel}`)
+      }
+    )
+    const agent = createAgent({
+      createSession: vi.fn(async () => ({ sessionId: 'session-review-expired' })),
+      prompt: vi.fn(async () => {
+        emitEvent?.({
+          id: 'expired-message-event',
+          timestamp: 10,
+          kind: 'message',
+          level: 'info',
+          sessionId: 'session-review-expired',
+          role: 'assistant',
+          text: 'Review after authorization expiry.'
+        })
+      })
+    })
+    const ids = ['expired-user', 'expired-run', 'expired-agent']
+    const api = new HeadlessTaskApi(
+      { commands: commandsFrom(invoke), agent },
+      {
+        createId: () => ids.shift() ?? 'generated-id',
+        subscribeEvents: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      }
+    )
+
+    const run = await api.runWithCallerContext(context, () =>
+      api.startRun({
+        project: project.id,
+        prompt: 'Produce and review after authorization expiry.',
+        autoReviewEnabled: true
+      })
+    )
+    await expect(api.waitForRun(run.id)).resolves.toMatchObject({
+      status: 'completed',
+      review: { started: true, id: 'review-expired', lifecycle: 'completed' }
+    })
+    expect(authorizationCurrent).toBe(false)
+    await api.dispose()
+  })
+
   it('awaits Reviewer cleanup before completing Task API disposal', async () => {
     let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
     let markAbortStarted: (() => void) | undefined

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -286,10 +286,14 @@ class HeadlessTaskApi {
     if (!started.started) return started
 
     for (;;) {
-      const reviews = (await this.invoke('reviewer:get-for-session', {
-        projectId: session.projectId,
-        appSessionId: session.id
-      })) as ReviewWithChecks[]
+      // Polling is lifecycle work for an admitted review. Keep it independent from the originating
+      // request lease, which may expire while the separate Reviewer runtime is still working.
+      const reviews = (await this.commandClient.invoke(
+        this.ports.commands,
+        'reviewer:get-for-session',
+        TASK_CALLER_CONTEXT,
+        [{ projectId: session.projectId, appSessionId: session.id }]
+      )) as ReviewWithChecks[]
       const review = [...reviews]
         .reverse()
         .find((candidate) => candidate.turnMessageId === turnMessageId)

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -7,6 +7,7 @@ import type {
   FinalizeRunArtifactsResult
 } from '../../shared/artifacts'
 import type { Project } from '../../shared/projects'
+import type { ReviewRunResult, ReviewWithChecks } from '../../shared/reviewer'
 import type { ActivePlanProjection, PlanResponseCommand } from '../../shared/session-plan/contract'
 import type { PersistedArtifact, PersistedChatSession } from '../../shared/session-persistence'
 import type {
@@ -72,6 +73,9 @@ class HeadlessTaskApi {
         },
         save: async (session) => {
           await this.invoke('sessions:save-session', session)
+        },
+        setDelegationPolicy: async (projectId, sessionId, policy) => {
+          await this.invoke('sessions:set-delegation-policy', projectId, sessionId, policy)
         }
       },
       agent: {
@@ -155,9 +159,11 @@ class HeadlessTaskApi {
 
   async getSessionPlan(sessionId: string): Promise<ActivePlanProjection | null> {
     const session = await this.runner.getSession(sessionId)
-    const plans = this.ports.controls?.plans
-    if (!plans) throw new Error('Task Plan controls are unavailable.')
-    return plans.getProjection(session.projectId, session.id)
+    return this.invoke(
+      'acp:get-plan-projection',
+      session.projectId,
+      session.id
+    ) as Promise<ActivePlanProjection | null>
   }
 
   async respondSessionPlan(
@@ -165,8 +171,6 @@ class HeadlessTaskApi {
     request: TaskPlanResponseRequest
   ): Promise<PlanResponseResult> {
     const session = await this.runner.getSession(sessionId)
-    const plans = this.ports.controls?.plans
-    if (!plans) throw new Error('Task Plan controls are unavailable.')
     const command: PlanResponseCommand =
       'feedback' in request && typeof request.feedback === 'string'
         ? { projectId: session.projectId, sessionId: session.id, feedback: request.feedback }
@@ -177,7 +181,7 @@ class HeadlessTaskApi {
             artifactVersionId: request.artifactVersionId,
             expectedRevision: request.expectedRevision
           }
-    return plans.respond(command)
+    return this.invoke('acp:respond-plan', command) as Promise<PlanResponseResult>
   }
 
   startRun(request: StartTaskRunRequest): Promise<TaskRun> {
@@ -242,29 +246,21 @@ class HeadlessTaskApi {
     session: PersistedChatSession,
     turnMessageId: string
   ): Promise<TaskRunReview> {
-    const reviewer = this.ports.controls?.reviewer
-    if (!reviewer) {
-      return {
-        started: false,
-        reason: 'run-failed',
-        errorMessage: 'Task Reviewer controls are unavailable.'
-      }
-    }
-    const started = await reviewer.triggerReview({
+    const started = (await this.invoke('reviewer:run', {
       sessionId: session.id,
       turnMessageId,
       projectId: session.projectId,
       mainSessionId: session.id,
       model: session.agentModel,
       origin: 'auto'
-    })
+    })) as ReviewRunResult
     if (!started.started) return started
 
     for (;;) {
-      const reviews = await reviewer.getForSession({
+      const reviews = (await this.invoke('reviewer:get-for-session', {
         projectId: session.projectId,
         appSessionId: session.id
-      })
+      })) as ReviewWithChecks[]
       const review = [...reviews]
         .reverse()
         .find((candidate) => candidate.turnMessageId === turnMessageId)

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -7,17 +7,22 @@ import type {
   FinalizeRunArtifactsResult
 } from '../../shared/artifacts'
 import type { Project } from '../../shared/projects'
+import type { ActivePlanProjection, PlanResponseCommand } from '../../shared/session-plan/contract'
 import type { PersistedArtifact, PersistedChatSession } from '../../shared/session-persistence'
 import type {
   AcquiredTaskArtifact,
   StartTaskRunRequest,
+  TaskPlanResponseRequest,
   TaskRun,
   TaskRunProgressEvent,
+  TaskRunReview,
   TaskSessionSummary
 } from '../../shared/task-api'
 import { createApplicationCommandClient } from '../application-command-client'
 import type { ApplicationCommandByNameDispatcher } from '../application-command-composition'
 import { createTaskCallerContext, type CallerContext } from '../caller-context'
+import type { PlanResponseResult } from '../session-plan/plan-service'
+import type { TaskControlPorts } from '../tasks/task-control-ports'
 import {
   TaskRunner,
   TaskRunnerError,
@@ -32,6 +37,7 @@ const TASK_CALLER_CONTEXT = createTaskCallerContext()
 type TaskApiPorts = {
   commands: ApplicationCommandByNameDispatcher
   agent: TaskAgentPort
+  controls?: TaskControlPorts
 }
 
 type TaskApiDependencies = {
@@ -110,6 +116,10 @@ class HeadlessTaskApi {
         }
       },
       runtimeEvents: { subscribe: subscribeEvents },
+      specialists: {
+        resolve: (reference) => this.resolveSpecialist(reference)
+      },
+      reviewer: { review: (session, turnMessageId) => this.review(session, turnMessageId) },
       createId: dependencies.createId ?? randomUUID,
       now: dependencies.now ?? Date.now
     } satisfies TaskRunnerDependencies)
@@ -141,6 +151,33 @@ class HeadlessTaskApi {
 
   getSession(sessionId: string): Promise<TaskSessionSummary> {
     return this.runner.getSession(sessionId)
+  }
+
+  async getSessionPlan(sessionId: string): Promise<ActivePlanProjection | null> {
+    const session = await this.runner.getSession(sessionId)
+    const plans = this.ports.controls?.plans
+    if (!plans) throw new Error('Task Plan controls are unavailable.')
+    return plans.getProjection(session.projectId, session.id)
+  }
+
+  async respondSessionPlan(
+    sessionId: string,
+    request: TaskPlanResponseRequest
+  ): Promise<PlanResponseResult> {
+    const session = await this.runner.getSession(sessionId)
+    const plans = this.ports.controls?.plans
+    if (!plans) throw new Error('Task Plan controls are unavailable.')
+    const command: PlanResponseCommand =
+      'feedback' in request && typeof request.feedback === 'string'
+        ? { projectId: session.projectId, sessionId: session.id, feedback: request.feedback }
+        : {
+            projectId: session.projectId,
+            sessionId: session.id,
+            decision: request.decision,
+            artifactVersionId: request.artifactVersionId,
+            expectedRevision: request.expectedRevision
+          }
+    return plans.respond(command)
   }
 
   startRun(request: StartTaskRunRequest): Promise<TaskRun> {
@@ -193,6 +230,55 @@ class HeadlessTaskApi {
       return Promise.reject(new Error('Caller authorization is no longer current.'))
     }
     return operation()
+  }
+
+  private resolveSpecialist(reference: string): Promise<{ id: string }> {
+    const specialists = this.ports.controls?.specialists
+    if (!specialists) return Promise.reject(new Error('Task Specialist controls are unavailable.'))
+    return specialists.resolve(reference)
+  }
+
+  private async review(
+    session: PersistedChatSession,
+    turnMessageId: string
+  ): Promise<TaskRunReview> {
+    const reviewer = this.ports.controls?.reviewer
+    if (!reviewer) {
+      return {
+        started: false,
+        reason: 'run-failed',
+        errorMessage: 'Task Reviewer controls are unavailable.'
+      }
+    }
+    const started = await reviewer.triggerReview({
+      sessionId: session.id,
+      turnMessageId,
+      projectId: session.projectId,
+      mainSessionId: session.id,
+      model: session.agentModel,
+      origin: 'auto'
+    })
+    if (!started.started) return started
+
+    for (;;) {
+      const reviews = await reviewer.getForSession({
+        projectId: session.projectId,
+        appSessionId: session.id
+      })
+      const review = [...reviews]
+        .reverse()
+        .find((candidate) => candidate.turnMessageId === turnMessageId)
+      if (review && review.lifecycle !== 'running') {
+        return {
+          started: true,
+          id: review.id,
+          lifecycle: review.lifecycle,
+          outcome: review.outcome,
+          errorMessage: review.errorMessage
+        }
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    }
   }
 }
 

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -123,7 +123,9 @@ class HeadlessTaskApi {
       specialists: {
         resolve: (reference) => this.resolveSpecialist(reference)
       },
-      reviewer: { review: (session, turnMessageId) => this.review(session, turnMessageId) },
+      reviewer: {
+        review: (session, turnMessageId, signal) => this.review(session, turnMessageId, signal)
+      },
       createId: dependencies.createId ?? randomUUID,
       now: dependencies.now ?? Date.now
     } satisfies TaskRunnerDependencies)
@@ -244,8 +246,34 @@ class HeadlessTaskApi {
 
   private async review(
     session: PersistedChatSession,
-    turnMessageId: string
+    turnMessageId: string,
+    signal: AbortSignal
   ): Promise<TaskRunReview> {
+    const reviewSession = { projectId: session.projectId, appSessionId: session.id }
+    const throwIfAborted = async (): Promise<void> => {
+      if (!signal.aborted) return
+      // Cancellation is cleanup for an already-authorized Task Run. Use the fixed Task capability so
+      // an expired remote request lease cannot strand the separate Reviewer runtime.
+      await this.commandClient.invoke(this.ports.commands, 'reviewer:abort', TASK_CALLER_CONTEXT, [
+        reviewSession
+      ])
+      throw new Error('Automatic review was cancelled.')
+    }
+    const waitForPoll = (): Promise<void> =>
+      new Promise((resolve) => {
+        const onAbort = (): void => {
+          clearTimeout(timer)
+          resolve()
+        }
+        const timer = setTimeout(() => {
+          signal.removeEventListener('abort', onAbort)
+          resolve()
+        }, 250)
+        signal.addEventListener('abort', onAbort, { once: true })
+        if (signal.aborted) onAbort()
+      })
+
+    await throwIfAborted()
     const started = (await this.invoke('reviewer:run', {
       sessionId: session.id,
       turnMessageId,
@@ -254,6 +282,7 @@ class HeadlessTaskApi {
       model: session.agentModel,
       origin: 'auto'
     })) as ReviewRunResult
+    await throwIfAborted()
     if (!started.started) return started
 
     for (;;) {
@@ -273,7 +302,8 @@ class HeadlessTaskApi {
           errorMessage: review.errorMessage
         }
       }
-      await new Promise((resolve) => setTimeout(resolve, 250))
+      await waitForPoll()
+      await throwIfAborted()
     }
   }
 }

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -131,9 +131,9 @@ class HeadlessTaskApi {
     } satisfies TaskRunnerDependencies)
   }
 
-  dispose(): void {
+  async dispose(): Promise<void> {
     try {
-      this.runner.dispose()
+      await this.runner.dispose()
     } finally {
       this.commandClient.dispose()
     }

--- a/src/shared/renderer-surface-matrix.test.ts
+++ b/src/shared/renderer-surface-matrix.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../test/fixtures/renderer-contract-certification'
 
 import {
+  canAccessSessionPlan,
   canSatisfyHumanApproval,
   createElectronCallerContext,
   createTaskCallerContext,
@@ -210,6 +211,7 @@ describe('renderer surface compatibility matrix', () => {
       canSatisfyHumanApproval(createWebCallerContext('remote-browser', { location: 'remote' }))
     ).toBe(true)
     expect(canSatisfyHumanApproval(createTaskCallerContext())).toBe(false)
+    expect(canAccessSessionPlan(createTaskCallerContext())).toBe(true)
     expect(
       canSatisfyHumanApproval(
         createWebCallerContext('expired-browser', {

--- a/src/shared/renderer-surface-matrix.test.ts
+++ b/src/shared/renderer-surface-matrix.test.ts
@@ -33,7 +33,11 @@ const TASK_RUN_REQUEST_FIELDS = {
   cwd: true,
   sessionId: true,
   permissionProfile: true,
-  skillIds: true
+  skillIds: true,
+  turnIntent: true,
+  autoReviewEnabled: true,
+  specialist: true,
+  delegationPolicy: true
 } as const satisfies Record<keyof StartTaskRunRequest, true>
 
 const permissionPaths = [
@@ -215,12 +219,16 @@ describe('renderer surface compatibility matrix', () => {
       )
     ).toBe(false)
     expect(Object.keys(TASK_RUN_REQUEST_FIELDS).sort()).toEqual([
+      'autoReviewEnabled',
       'cwd',
+      'delegationPolicy',
       'permissionProfile',
       'project',
       'prompt',
       'sessionId',
-      'skillIds'
+      'skillIds',
+      'specialist',
+      'turnIntent'
     ])
   })
 

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -2777,6 +2777,19 @@ describe('normalizeSessionFile with activities', () => {
     expect(corrupt?.autoReviewEnabled).toBe(false)
   })
 
+  it('round-trips delegation policy and defaults historical or malformed values to allow', () => {
+    const base = { ...createSessionWithActivity(undefined), activities: undefined }
+    const denied = normalizeSessionFile({ ...base, delegationPolicy: 'deny' })
+    const allowed = normalizeSessionFile({ ...base, delegationPolicy: 'allow' })
+    const legacy = normalizeSessionFile({ ...base })
+    const malformed = normalizeSessionFile({ ...base, delegationPolicy: 'sometimes' })
+
+    expect(denied?.delegationPolicy).toBe('deny')
+    expect(allowed?.delegationPolicy).toBe('allow')
+    expect(legacy?.delegationPolicy).toBe('allow')
+    expect(malformed?.delegationPolicy).toBe('allow')
+  })
+
   it('round-trips enabledComputeHosts and filters out invalid values', () => {
     const base = { ...createSessionWithActivity(undefined), activities: undefined }
 

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -552,7 +552,6 @@ export type SessionConflictRebaseField =
   | 'permissionProfile'
   | 'autoReviewEnabled'
   | 'enabledComputeHosts'
-  | 'delegationPolicy'
   | 'pinned'
   | 'specialistId'
 

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -412,6 +412,8 @@ export type PersistedSessionResumeRecovery = {
 export type PersistedPendingHistoryReplay =
   { kind: 'all' } | { kind: 'before-message'; messageId: string }
 
+export type DelegationPolicy = 'allow' | 'deny'
+
 export type PersistedToolActivityStatus = 'pending' | 'in_progress' | 'completed' | 'failed'
 export type PersistedToolActivityDisposition = 'declined' | 'permission-closed'
 
@@ -493,6 +495,9 @@ export type PersistedChatSession = {
   // Per-conversation auto-review toggle. Absent (older files) or non-true is treated as disabled;
   // only an explicit true enables it.
   autoReviewEnabled?: boolean
+  // Controls admission of new delegated children for this Session. Older files omit it and restore
+  // to allow. Switching to deny never cancels or hides children that were already admitted.
+  delegationPolicy?: DelegationPolicy
   // Per-session enabled compute hosts (providerIds like "ssh:alias"). Stored as an array for JSON
   // compatibility; semantically a set (single-select for now, multi-select-ready internally).
   // Absent on older sessions — treated as empty (no host enabled).
@@ -547,6 +552,7 @@ export type SessionConflictRebaseField =
   | 'permissionProfile'
   | 'autoReviewEnabled'
   | 'enabledComputeHosts'
+  | 'delegationPolicy'
   | 'pinned'
   | 'specialistId'
 
@@ -3365,6 +3371,8 @@ const sanitizeSession = (
     // Auto-review defaults off: a missing or non-boolean value restores as disabled, and only an
     // explicit true turns it on.
     autoReviewEnabled: session.autoReviewEnabled === true ? true : false,
+    // Only deny changes behavior; missing/malformed historical values preserve delegation.
+    delegationPolicy: session.delegationPolicy === 'deny' ? 'deny' : 'allow',
     messages: Array.isArray(session.messages)
       ? session.messages
           .map((message) => sanitizeMessage(message, options))

--- a/src/shared/task-api.ts
+++ b/src/shared/task-api.ts
@@ -41,10 +41,7 @@ export type StartTaskRunRequest = {
   delegationPolicy?: DelegationPolicy
 }
 
-export type TaskRunAttention =
-  | { kind: 'plan-approval'; plan: ActivePlanProjection }
-  | { kind: 'permission' }
-  | { kind: 'delegated-question' }
+export type TaskRunAttention = { kind: 'plan-approval'; plan: ActivePlanProjection }
 
 export type TaskRunReview = {
   started: boolean

--- a/src/shared/task-api.ts
+++ b/src/shared/task-api.ts
@@ -1,7 +1,9 @@
 import type { ArtifactFile } from './artifacts'
 import type { PermissionProfileId } from './permission-profiles'
 import type { Project } from './projects'
-import type { PersistedSessionStatus } from './session-persistence'
+import type { ReviewLifecycle, ReviewOutcome, ReviewRunNotStartedReason } from './reviewer'
+import type { DelegationPolicy, PersistedSessionStatus } from './session-persistence'
+import type { ActivePlanProjection } from './session-plan/contract'
 
 export type TaskRunStatus = 'running' | 'completed' | 'failed' | 'cancelled'
 
@@ -32,7 +34,35 @@ export type StartTaskRunRequest = {
   cwd?: string
   permissionProfile?: PermissionProfileId
   skillIds?: string[]
+  turnIntent?: 'plan-first'
+  autoReviewEnabled?: boolean
+  // Accepts an immutable Specialist UUID or its stable Profile name. displayName is presentation-only.
+  specialist?: string
+  delegationPolicy?: DelegationPolicy
 }
+
+export type TaskRunAttention =
+  | { kind: 'plan-approval'; plan: ActivePlanProjection }
+  | { kind: 'permission' }
+  | { kind: 'delegated-question' }
+
+export type TaskRunReview = {
+  started: boolean
+  reason?: ReviewRunNotStartedReason
+  id?: string
+  lifecycle?: ReviewLifecycle
+  outcome?: ReviewOutcome | null
+  errorMessage?: string
+}
+
+export type TaskPlanResponseRequest =
+  | {
+      decision: 'approved' | 'rejected'
+      artifactVersionId: string
+      expectedRevision: number
+      feedback?: never
+    }
+  | { feedback: string; decision?: never; artifactVersionId?: never; expectedRevision?: never }
 
 export type TaskRun = {
   id: string
@@ -47,6 +77,8 @@ export type TaskRun = {
   output?: string
   error?: string
   artifacts: ArtifactFile[]
+  attention?: TaskRunAttention
+  review?: TaskRunReview
 }
 
 export type TaskSessionSummary = {
@@ -55,6 +87,9 @@ export type TaskSessionSummary = {
   title: string
   status: PersistedSessionStatus
   permissionProfile?: PermissionProfileId
+  autoReviewEnabled: boolean
+  specialistId?: string
+  delegationPolicy: DelegationPolicy
   createdAt: number
   updatedAt: number
   output?: string
@@ -80,3 +115,4 @@ export type TaskApiErrorCode =
   | 'session_busy'
   | 'run_not_found'
   | 'artifact_not_found'
+  | 'specialist_not_found'


### PR DESCRIPTION
## Problem

Headless and CLI callers had no public, typed way to control execution behaviors that already exist behind application/runtime owners:

- request a Plan-first turn and respond when the Plan reaches approval;
- enable or disable automatic Review for a Session;
- bind a new Session to a Specialist by stable id/name;
- deny admission of new delegated children.

This occurs when automation starts or resumes a Task through the HTTP/npm/CLI surface and needs one of those controls. Without a public control path, Plan-first automation cannot complete the approval handshake, headless auto-review is not reliably started, Specialist selection is unavailable, and delegation remains unrestricted. Scripts otherwise have to parse human text or depend on private renderer/IPC behavior.

## Proposed change

- Extend the typed Task start request with `turnIntent`, `autoReviewEnabled`, `specialist`, and `delegationPolicy`.
- Route Task Plan reads/responses and Reviewer run/reads through the transport-neutral application-command view. Keep Specialist lookup as a narrow, read-only resolver rather than exposing Specialist management.
- Add a Task-only `sessions:set-delegation-policy` application command so explicit policy changes enter the queued Session persistence owner instead of relying on whole-session projection saves.
- Add Plan read/respond HTTP and npm client methods plus:
  - `open-science plan show`
  - `open-science plan approve`
  - `open-science plan reject`
  - `open-science plan revise`
- Add CLI run controls:
  - `--plan-first`
  - `--auto-review` / `--no-auto-review`
  - `--specialist <id-or-name>`
  - `--delegation allow|deny`
  - `--return-on-attention`
- Keep `--wait` terminal-only by default. `--return-on-attention` explicitly returns a running Task Run only for structured Plan approval attention.
- Resolve Specialist references from UUID or stable Profile `name`; `displayName` remains presentation-only. An existing Session cannot be rebound to another Specialist.
- Enforce delegation denial at the production delegation admission seam. Existing children remain visible/collectable/stoppable and are not cancelled when the policy changes to `deny`.
- Trigger auto-review through the existing Reviewer application commands and project its terminal result on the Task Run.

## Architecture, data model, and interaction

All supported agent frameworks continue through the shared ACP Task adapter; there are no Claude Code, OpenCode, Codex Responses, or bridge-specific branches.

Task Plan and Reviewer operations now follow the same application-command seam used by Web. Task automation receives a Plan-specific authorization predicate while `canSatisfyHumanApproval(Task)` remains false, so permission and structured-question responses remain human-only. Plan responses use the existing centralized archive admission and reject unavailable/archived Sessions.

There is no Prisma/SQLite schema change, data relationship change, or provider-specific execution model. The user interaction change is limited to the documented HTTP/npm/CLI controls and Plan-only `returnOnAttention` behavior.

### Session JSON persistence

Exactly one new Session JSON field is introduced by this PR:

- `delegationPolicy: allow | deny`

`delegationPolicy` is main-owned after Session creation. Explicit Task changes use the dedicated queued mutation; ordinary renderer whole-session saves preserve the authoritative value and cannot restore a stale policy.

Existing fields are reused rather than duplicated:

- `autoReviewEnabled`
- `specialistId`
- `messages[].turnIntent`
- `runtimeContext.plan`
- `runtimeContext.delegatedWork`

Reviewer persistence continues to use the existing Review tables and schema.

### Compatibility

- Historical Session JSON with missing or malformed `delegationPolicy` restores as `allow`, preserving previous behavior.
- Historical missing `autoReviewEnabled` remains disabled.
- Historical missing `specialistId` remains a Main Agent Session.
- Existing Plan and delegated-work JSON shapes remain readable.
- No historical backfill is performed.

### Enums and statuses

- Adds the closed control type `DelegationPolicy = allow | deny`.
- Public Run attention contains only the implemented `plan-approval` discriminant.
- Does **not** add or change Session lifecycle, Task Run status, Review lifecycle, or delegated-work status values.
- Reuses the existing persisted `waiting-plan-approval` Session status; an externally actionable Task Run remains `running` with Plan attention.

## Scope and non-goals

- Does not cancel previously admitted delegated children when delegation is denied.
- Does not change default `--wait` behavior.
- Does not add a database field, migration, or provider-specific execution model.
- Does not add permission/delegated-question Run attention, Reviewer JSONL, delegated-work JSONL/results, or a new waiting status in this release.
- Keeps Plan artifact-version/revision preconditions to reject stale automation decisions.
- Does not run the complete local `npm test`; PR CI remains authoritative for the full/platform-selected plan.

## Acceptance criteria and validation

The checks below ran after the last material edit and the final rebase:

- Caller policy + ACP Plan commands + Task API/Runner + Session persistence + npm client/CLI → targeted Vitest command → **8 files, 246 tests passed**
- Highest-risk Task/Plan/persistence/npm subset → targeted Vitest command → **6 files, 221 tests passed**
- Shared/Web TypeScript consumers → `npm run typecheck:web` → **passed**
- Changed source/test files → ESLint → **passed**
- npm package contents → `npm run check:cli-package` → **passed**
- Changed files → Prettier and `git diff --check` → **passed**

Local Node typecheck reaches one existing workspace dependency mismatch: the installed `@agentclientprotocol/claude-agent-acp` package does not expose the patched `waitForMcpServers` symbol. Three command inventory/matrix suites also cannot start locally because the shared Electron package has no installed `dist` directory. PR CI is authoritative for those dependency/platform checks.

## Review focus

- Task application-command scoping for Plan, Reviewer, and the Task-only delegation-policy mutation.
- Main-owned `delegationPolicy` preservation under stale renderer saves.
- Archive admission and Task-specific Plan authorization without granting human approval authority.
- Plan-only public attention semantics versus terminal Run state.
- Specialist immutability and stable-name resolution.
- Delegation enforcement at admission without disturbing existing children.

Closes #1188