### PR TITLE
refactor(app-commands): unify command module inventory

### DIFF
--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -27,6 +27,8 @@ import {
   type ApplicationCommandCompositionDependencies
 } from './application-command-composition'
 import {
+  defineApplicationCommand,
+  defineApplicationCommandGroup,
   type ApplicationCommandInstallation,
   type ApplicationCommandRouter,
   type ApplicationCommandRegistrationScope,
@@ -35,6 +37,10 @@ import {
 import { createCallerContext } from './caller-context'
 
 const EMPTY_OWNER = Object.freeze({})
+const unexpectedCommand = defineApplicationCommand<'test:unexpected', readonly [], void>(
+  'test:unexpected'
+)
+const unexpectedGroup = defineApplicationCommandGroup('test-unexpected', [unexpectedCommand])
 const project = (id: string): Project => ({
   id,
   name: 'Project',
@@ -90,6 +96,8 @@ const installInstrumentedRouterFactory = (
     failCompleteAt?: number
     failUninstallAt?: ReadonlySet<number>
     failRouterDispose?: boolean
+    registerUnexpectedCommand?: boolean
+    skipRegisteredGroup?: string
     onRegisterGroup?: (groupName: string, handlers: unknown) => void
   }> = {}
 ): void => {
@@ -113,12 +121,16 @@ const installInstrumentedRouterFactory = (
             handlers
           ) => {
             options.onRegisterGroup?.(group.name, handlers)
+            if (options.skipRegisteredGroup === group.name) return
             scope.registerGroup(group, handlers)
           }
           return Object.freeze({
             ...scope,
             registerGroup,
             complete: (cleanup): ApplicationCommandInstallation => {
+              if (options.registerUnexpectedCommand && index === 0) {
+                scope.registerGroup(unexpectedGroup, { 'test:unexpected': () => undefined })
+              }
               if (options.failCompleteAt === index) {
                 throw new Error(`complete failed:${index}`)
               }
@@ -191,7 +203,6 @@ describe('application command composition', () => {
     const composition = createApplicationCommandComposition(dependencies())
 
     expect(composition.localWeb.commandNames()).toEqual(expectedLocalWebCommands())
-    expect(composition.localWeb.commandNames()).toHaveLength(247)
   })
 
   it('partitions remote Web dispatch from fail-closed pre-dispatch rejections', async () => {
@@ -206,9 +217,7 @@ describe('application command composition', () => {
     )
 
     expect(composition.remoteWeb.commandNames()).toEqual(expectedRemoteCommands())
-    expect(composition.remoteWeb.commandNames()).toHaveLength(177)
     expect(composition.remoteWeb.rejectedCommandNames()).toEqual(expectedRemoteRejections())
-    expect(composition.remoteWeb.rejectedCommandNames()).toHaveLength(70)
 
     await expect(
       composition.remoteWeb.invoke('compute:download', invocation('remote'))
@@ -254,7 +263,6 @@ describe('application command composition', () => {
     )
     expect(composition).not.toHaveProperty('registrar')
     expect(composition).not.toHaveProperty('dispatcher')
-    expect(composition.electron.commandNames()).toHaveLength(6)
     expect(composition).not.toHaveProperty('cli')
     expect(composition).not.toHaveProperty('localRpc')
     expect(composition).not.toHaveProperty('specialist')
@@ -300,53 +308,44 @@ describe('application command composition', () => {
     ).rejects.toThrow('Application command router is disposed.')
   })
 
-  it('installs every registrar family in a fixed order and stops at a partial failure', () => {
-    const orderedNames = [
-      'acp',
-      'notebook',
-      'notebookEnvironment',
-      'notebookRuntime',
-      'settingsCore',
-      'settingsIntegration',
-      'settingsRuntime',
-      'compute',
-      'permissionGrants',
-      'dataContent',
-      'host'
-    ] as const satisfies readonly (keyof ApplicationCommandCompositionDependencies)[]
-    const source = dependencies()
-    const reads: string[] = []
-    const ordered = Object.create(null) as ApplicationCommandCompositionDependencies
-    for (const name of orderedNames) {
-      Object.defineProperty(ordered, name, {
-        enumerable: true,
-        get: () => {
-          reads.push(name)
-          return source[name]
-        }
-      })
-    }
+  it('rejects declared commands that are missing from the installed router inventory', () => {
+    const events: string[] = []
+    installInstrumentedRouterFactory(events, { skipRegisteredGroup: 'acp' })
 
+    expect(() => createApplicationCommandComposition(dependencies())).toThrow(
+      'declared commands are not installed: acp:'
+    )
+    expect(events.at(-1)).toBe('router:dispose')
+  })
+
+  it('rejects installed commands that are missing from the declared inventory', () => {
+    const events: string[] = []
+    installInstrumentedRouterFactory(events, { registerUnexpectedCommand: true })
+
+    expect(() => createApplicationCommandComposition(dependencies())).toThrow(
+      'installed commands are not declared: test:unexpected'
+    )
+    expect(events.at(-1)).toBe('router:dispose')
+  })
+
+  it('installs every command module and stops at a partial failure', () => {
+    const source = dependencies()
     const normalEvents: string[] = []
     installInstrumentedRouterFactory(normalEvents)
-    const composition = createApplicationCommandComposition(ordered)
-    expect(reads).toEqual(orderedNames)
-    expect(normalEvents).toEqual(orderedNames.map((_, index) => `install:${index}`))
+    const composition = createApplicationCommandComposition(source)
+    const installEvents = [...normalEvents]
+    const installationCount = installEvents.length
+    const lastInstallationIndex = installationCount - 1
+    const uninstallEvents = Array.from(
+      { length: installationCount },
+      (_, index) => `uninstall:${lastInstallationIndex - index}`
+    )
+    expect(installationCount).toBeGreaterThan(0)
+    expect(installEvents).toEqual(
+      Array.from({ length: installationCount }, (_, index) => `install:${index}`)
+    )
     composition.dispose()
-    expect(normalEvents.slice(11)).toEqual([
-      'uninstall:10',
-      'uninstall:9',
-      'uninstall:8',
-      'uninstall:7',
-      'uninstall:6',
-      'uninstall:5',
-      'uninstall:4',
-      'uninstall:3',
-      'uninstall:2',
-      'uninstall:1',
-      'uninstall:0',
-      'router:dispose'
-    ])
+    expect(normalEvents).toEqual([...installEvents, ...uninstallEvents, 'router:dispose'])
     const disposedEventCount = normalEvents.length
     composition.dispose()
     expect(normalEvents).toHaveLength(disposedEventCount)
@@ -400,7 +399,7 @@ describe('application command composition', () => {
     let disposedRemoteAccessHandler:
       ((invocation: ApplicationInvocation<readonly unknown[]>) => unknown) | undefined
     installInstrumentedRouterFactory(disposeFailureEvents, {
-      failUninstallAt: new Set([10, 3]),
+      failUninstallAt: new Set([lastInstallationIndex, 3]),
       failRouterDispose: true,
       onRegisterGroup: (groupName, handlers) => {
         if (groupName !== 'remote-access') return
@@ -422,19 +421,13 @@ describe('application command composition', () => {
     expect(disposalFailure).toBeInstanceOf(AggregateError)
     expect(
       (disposalFailure as AggregateError).errors.map((error) => (error as Error).message)
-    ).toEqual(['uninstall failed:10', 'uninstall failed:3', 'router dispose failed'])
-    expect(disposeFailureEvents.slice(11)).toEqual([
-      'uninstall:10',
-      'uninstall:9',
-      'uninstall:8',
-      'uninstall:7',
-      'uninstall:6',
-      'uninstall:5',
-      'uninstall:4',
-      'uninstall:3',
-      'uninstall:2',
-      'uninstall:1',
-      'uninstall:0',
+    ).toEqual([
+      `uninstall failed:${lastInstallationIndex}`,
+      'uninstall failed:3',
+      'router dispose failed'
+    ])
+    expect(disposeFailureEvents.slice(installationCount)).toEqual([
+      ...uninstallEvents,
       'router:dispose'
     ])
     expect(() => disposeFailure.dispose()).not.toThrow()
@@ -446,7 +439,7 @@ describe('application command composition', () => {
       ((invocation: ApplicationInvocation<readonly unknown[]>) => unknown) | undefined
     const slotFailureEvents: string[] = []
     installInstrumentedRouterFactory(slotFailureEvents, {
-      failCompleteAt: 10,
+      failCompleteAt: lastInstallationIndex,
       failRouterDispose: true,
       onRegisterGroup: (groupName, handlers) => {
         if (groupName !== 'remote-access') return
@@ -467,18 +460,9 @@ describe('application command composition', () => {
     expect(slotConstructionFailure).toBeInstanceOf(AggregateError)
     expect(
       (slotConstructionFailure as AggregateError).errors.map((error) => (error as Error).message)
-    ).toEqual(['complete failed:10', 'router dispose failed'])
-    expect(slotFailureEvents.slice(11)).toEqual([
-      'uninstall:9',
-      'uninstall:8',
-      'uninstall:7',
-      'uninstall:6',
-      'uninstall:5',
-      'uninstall:4',
-      'uninstall:3',
-      'uninstall:2',
-      'uninstall:1',
-      'uninstall:0',
+    ).toEqual([`complete failed:${lastInstallationIndex}`, 'router dispose failed'])
+    expect(slotFailureEvents.slice(installationCount)).toEqual([
+      ...uninstallEvents.slice(1),
       'router:dispose'
     ])
     expect(() => remoteAccessHandler?.(invocation('remote'))).toThrow(

--- a/src/main/application-command-composition.ts
+++ b/src/main/application-command-composition.ts
@@ -12,8 +12,10 @@ import {
   createApplicationCommandRouter,
   type ApplicationCommand,
   type ApplicationCommandDiagnostic,
+  type ApplicationCommandGroup,
   type ApplicationCommandInstallation,
-  type ApplicationInvocation
+  type ApplicationInvocation,
+  type ApplicationCommandRegistrar
 } from './application-command-router'
 import {
   computeApplicationCommandGroup,
@@ -67,6 +69,7 @@ import {
 } from './settings/runtime-application-commands'
 
 type AnyApplicationCommand = ApplicationCommand<string, readonly unknown[], unknown>
+type AnyApplicationCommandGroup = ApplicationCommandGroup<string, readonly AnyApplicationCommand[]>
 type NotebookEnvironmentDependencies = Parameters<
   typeof installNotebookEnvironmentApplicationCommands
 >[1]
@@ -83,6 +86,11 @@ type ApplicationCommandByNameDispatcher = Readonly<{
 
 type RemoteWebApplicationCommandDispatcher = ApplicationCommandByNameDispatcher &
   Readonly<{ rejectedCommandNames: () => readonly string[] }>
+
+type ApplicationCommandModuleDescriptor = Readonly<{
+  groups: readonly AnyApplicationCommandGroup[]
+  install: (registrar: ApplicationCommandRegistrar) => ApplicationCommandInstallation
+}>
 
 type ApplicationCommandCompositionDependencies = Readonly<{
   acp: AcpApplicationCommandDependencies
@@ -107,14 +115,6 @@ type ApplicationCommandComposition = Readonly<{
   dispose: () => void
 }>
 
-const GROUP_COUNT = 28
-const INTERNAL_COMMAND_COUNT = 249
-const LOCAL_WEB_COMMAND_COUNT = 247
-const REMOTE_WEB_COMMAND_COUNT = 177
-const REMOTE_REJECTED_COMMAND_COUNT = 70
-const TASK_COMMAND_COUNT = 7
-const VALIDATED_ELECTRON_COMMAND_COUNT = 6
-
 const ELECTRON_NATIVE_COMMAND_NAMES = Object.freeze([
   'sessions:export-conversation',
   'uploads:stage-local-file'
@@ -128,22 +128,6 @@ const TASK_COMMAND_NAMES = Object.freeze([
   'artifacts:finalize-run',
   'preview-resources:acquire',
   'preview-resources:release'
-])
-
-const APPLICATION_COMMAND_GROUPS = Object.freeze([
-  acpApplicationCommands,
-  notebookApplicationCommands,
-  notebookEnvironmentApplicationCommands,
-  runtimeApplicationCommandGroup,
-  settingsCoreApplicationCommandGroup,
-  settingsSkillApplicationCommandGroup,
-  settingsConnectorApplicationCommandGroup,
-  settingsApprovalApplicationCommandGroup,
-  settingsRuntimeApplicationCommandGroup,
-  computeApplicationCommandGroup,
-  permissionGrantApplicationCommandGroup,
-  ...dataContentApplicationCommandGroups,
-  ...hostApplicationCommandGroups
 ])
 
 const failInventory = (detail: string): never => {
@@ -160,6 +144,58 @@ const collectCatalogCommands = (
       channel !== null && kind === 'method' && installed(surfaceInstallation) ? [channel] : []
     ).sort()
   )
+
+const defineApplicationCommandModule = (
+  groups: readonly AnyApplicationCommandGroup[],
+  install: ApplicationCommandModuleDescriptor['install']
+): ApplicationCommandModuleDescriptor =>
+  Object.freeze({ groups: Object.freeze([...groups]), install })
+
+const createApplicationCommandModules = (
+  dependencies: ApplicationCommandCompositionDependencies,
+  remoteAccess: RemoteAccessOwner
+): readonly ApplicationCommandModuleDescriptor[] =>
+  Object.freeze([
+    defineApplicationCommandModule([acpApplicationCommands], (registrar) =>
+      registerAcpCommands(registrar, dependencies.acp)
+    ),
+    defineApplicationCommandModule([notebookApplicationCommands], (registrar) =>
+      installNotebookApplicationCommands(registrar, dependencies.notebook)
+    ),
+    defineApplicationCommandModule([notebookEnvironmentApplicationCommands], (registrar) =>
+      installNotebookEnvironmentApplicationCommands(registrar, dependencies.notebookEnvironment)
+    ),
+    defineApplicationCommandModule([runtimeApplicationCommandGroup], (registrar) =>
+      registerRuntimeApplicationCommands(registrar, dependencies.notebookRuntime)
+    ),
+    defineApplicationCommandModule([settingsCoreApplicationCommandGroup], (registrar) =>
+      registerCoreSettingsApplicationCommands(registrar, dependencies.settingsCore)
+    ),
+    defineApplicationCommandModule(
+      [
+        settingsSkillApplicationCommandGroup,
+        settingsConnectorApplicationCommandGroup,
+        settingsApprovalApplicationCommandGroup
+      ],
+      (registrar) =>
+        registerIntegrationSettingsApplicationCommands(registrar, dependencies.settingsIntegration)
+    ),
+    defineApplicationCommandModule([settingsRuntimeApplicationCommandGroup], (registrar) =>
+      registerRuntimeSettingsApplicationCommands(registrar, dependencies.settingsRuntime)
+    ),
+    defineApplicationCommandModule([computeApplicationCommandGroup], (registrar) =>
+      registerComputeApplicationCommands(registrar, dependencies.compute)
+    ),
+    defineApplicationCommandModule([permissionGrantApplicationCommandGroup], (registrar) =>
+      registerPermissionGrantApplicationCommands(registrar, dependencies.permissionGrants)
+    ),
+    defineApplicationCommandModule(dataContentApplicationCommandGroups, (registrar) =>
+      registerDataContentApplicationCommands(registrar, dependencies.dataContent)
+    ),
+    defineApplicationCommandModule(hostApplicationCommandGroups, (registrar) =>
+      registerHostApplicationCommands(registrar, { ...dependencies.host, remoteAccess })
+    )
+  ])
 
 const createRemoteAccessSlot = (): Readonly<{
   owner: RemoteAccessOwner
@@ -197,20 +233,18 @@ const createRemoteAccessSlot = (): Readonly<{
   })
 }
 
-const certifyInventory = (): Readonly<{
+const certifyInventory = (
+  groups: readonly AnyApplicationCommandGroup[]
+): Readonly<{
   commands: ReadonlyMap<string, AnyApplicationCommand>
   electronNames: readonly string[]
   localWebNames: readonly string[]
   remoteWebNames: readonly string[]
   remoteRejectedNames: readonly string[]
 }> => {
-  if (APPLICATION_COMMAND_GROUPS.length !== GROUP_COUNT) {
-    failInventory(`expected ${GROUP_COUNT} groups, received ${APPLICATION_COMMAND_GROUPS.length}`)
-  }
-
   const groupNames = new Set<string>()
   const commands = new Map<string, AnyApplicationCommand>()
-  for (const group of APPLICATION_COMMAND_GROUPS) {
+  for (const group of groups) {
     if (groupNames.has(group.name)) failInventory(`duplicate group ${group.name}`)
     groupNames.add(group.name)
     for (const command of group.commands) {
@@ -218,26 +252,20 @@ const certifyInventory = (): Readonly<{
       commands.set(command.name, command as AnyApplicationCommand)
     }
   }
-  if (commands.size !== INTERNAL_COMMAND_COUNT) {
-    failInventory(`expected ${INTERNAL_COMMAND_COUNT} commands, received ${commands.size}`)
-  }
-
   const localWebNames = collectCatalogCommands(({ localWeb }) => localWeb === 'web-rpc')
   const electronNames = ELECTRON_APPLICATION_COMMAND_CHANNELS
   const remoteWebNames = collectCatalogCommands(({ remoteWeb }) => remoteWeb === 'web-rpc')
   const remoteRejectedNames = collectCatalogCommands(
     ({ localWeb, remoteWeb }) => localWeb === 'web-rpc' && remoteWeb === 'rejecting-stub'
   )
-  const expectedCounts = [
-    [electronNames, VALIDATED_ELECTRON_COMMAND_COUNT, 'validated Electron commands'],
-    [localWebNames, LOCAL_WEB_COMMAND_COUNT, 'local Web commands'],
-    [remoteWebNames, REMOTE_WEB_COMMAND_COUNT, 'remote Web commands'],
-    [remoteRejectedNames, REMOTE_REJECTED_COMMAND_COUNT, 'remote Web rejections'],
-    [TASK_COMMAND_NAMES, TASK_COMMAND_COUNT, 'Task commands']
+  const surfaceInventories = [
+    [electronNames, 'validated Electron commands'],
+    [localWebNames, 'local Web commands'],
+    [remoteWebNames, 'remote Web commands'],
+    [remoteRejectedNames, 'remote Web rejections'],
+    [TASK_COMMAND_NAMES, 'Task commands']
   ] as const
-  for (const [names, count, label] of expectedCounts) {
-    if (names.length !== count)
-      failInventory(`expected ${count} ${label}, received ${names.length}`)
+  for (const [names, label] of surfaceInventories) {
     if (new Set(names).size !== names.length) failInventory(`${label} contains duplicate names`)
     for (const name of names) {
       if (!commands.has(name)) failInventory(`${label} contains unknown command ${name}`)
@@ -270,46 +298,37 @@ const certifyInventory = (): Readonly<{
   })
 }
 
+const certifyInstalledInventory = (
+  declaredCommands: ReadonlyMap<string, AnyApplicationCommand>,
+  installedNames: readonly string[]
+): void => {
+  const declared = new Set(declaredCommands.keys())
+  const installed = new Set(installedNames)
+  const missing = [...declaredCommands.keys()].filter((name) => !installed.has(name)).sort()
+  const unexpected = [...installed].filter((name) => !declared.has(name)).sort()
+  const differences = [
+    ...(missing.length > 0 ? [`declared commands are not installed: ${missing.join(', ')}`] : []),
+    ...(unexpected.length > 0
+      ? [`installed commands are not declared: ${unexpected.join(', ')}`]
+      : [])
+  ]
+  if (differences.length > 0) failInventory(differences.join('; '))
+}
+
 const createApplicationCommandComposition = (
   dependencies: ApplicationCommandCompositionDependencies,
   onDiagnostic?: (diagnostic: ApplicationCommandDiagnostic) => void
 ): ApplicationCommandComposition => {
-  const certified = certifyInventory()
-  const router = createApplicationCommandRouter(onDiagnostic)
   const remoteAccess = createRemoteAccessSlot()
+  const modules = createApplicationCommandModules(dependencies, remoteAccess.owner)
+  const certified = certifyInventory(modules.flatMap(({ groups }) => groups))
+  const router = createApplicationCommandRouter(onDiagnostic)
   const installations: ApplicationCommandInstallation[] = []
   let disposed = false
 
-  const installers = [
-    () => registerAcpCommands(router.registrar, dependencies.acp),
-    () => installNotebookApplicationCommands(router.registrar, dependencies.notebook),
-    () =>
-      installNotebookEnvironmentApplicationCommands(
-        router.registrar,
-        dependencies.notebookEnvironment
-      ),
-    () => registerRuntimeApplicationCommands(router.registrar, dependencies.notebookRuntime),
-    () => registerCoreSettingsApplicationCommands(router.registrar, dependencies.settingsCore),
-    () =>
-      registerIntegrationSettingsApplicationCommands(
-        router.registrar,
-        dependencies.settingsIntegration
-      ),
-    () =>
-      registerRuntimeSettingsApplicationCommands(router.registrar, dependencies.settingsRuntime),
-    () => registerComputeApplicationCommands(router.registrar, dependencies.compute),
-    () =>
-      registerPermissionGrantApplicationCommands(router.registrar, dependencies.permissionGrants),
-    () => registerDataContentApplicationCommands(router.registrar, dependencies.dataContent),
-    () =>
-      registerHostApplicationCommands(router.registrar, {
-        ...dependencies.host,
-        remoteAccess: remoteAccess.owner
-      })
-  ] as const
-
   try {
-    for (const install of installers) installations.push(install())
+    for (const module of modules) installations.push(module.install(router.registrar))
+    certifyInstalledInventory(certified.commands, router.dispatcher.commandNames())
   } catch (error) {
     const failures: unknown[] = [error]
     for (const installation of [...installations].reverse()) {


### PR DESCRIPTION
## Problem

`application-command-composition.ts` maintained the command inventory in three parallel forms: a group list, an installer list, and several exact counts. Adding one command therefore changed a central high-traffic file even when the command's own module was correct. That caused frequent merge conflicts, and a missed count update failed the full CI suite (often surfacing on Windows) without representing an actual platform-specific defect.

## Proposed change

- Introduce one private, ordered command-module descriptor list that pairs each module's declared groups with its installer.
- Derive inventory certification and installation from that same descriptor list.
- Replace hand-maintained group/command/surface counts with structural checks that preserve duplicate-name, catalog-membership, remote-partition, codec, and native-command validation.
- Certify the router's installed command names against the declared inventory in both directions, using the existing rollback path on mismatch.
- Add regression coverage for missing and unexpected router registrations, and derive lifecycle expectations from observed module installations instead of a second module list in tests.

## Scope and non-goals

- No public API, renderer contract, command routing, platform behavior, or ACP behavior changes.
- No historical-data compatibility work is required.
- No state or enum values are added.
- No persistence schema or persisted data is changed.
- The module test-impact ownership gap for this composition root is not changed here; the existing full-CI fallback remains the authority.

## Acceptance criteria and validation

All listed checks ran after the last material edit:

- Declared/installed inventory drift and command-composition behavior: 6 focused Vitest files, 44 tests passed.
- Main-process TypeScript surface: `npm run typecheck:node` passed.
- Repository lint: `npm run lint -- --concurrency auto` passed with 0 errors; 10 pre-existing warnings are outside the changed files.
- Changed-file formatting: Prettier check passed.
- Patch integrity: `git diff --check origin/main...HEAD` passed.
- Standards and Spec reviews of the final commit reported no findings.
- Local `test:affected:explain` selects the full fallback because `src/main/application-command-composition.ts` has no module owner. The PR Gate classifier instead selected its macOS related-test path: `vitest --changed` ran the composition test file (10/10) with coverage. Static checks, macOS build/E2E, CI Integrity, CodeQL, and automated review also passed.
- Uncovered risk: the PR Gate skipped Windows and full-suite lanes for this diff. A complete local `npm test` was intentionally not duplicated, so those remain post-merge/nightly coverage rather than evidence from this PR.

## Review focus

- Confirm each descriptor pairs the correct command groups with its existing installer.
- Confirm the bidirectional installed/declared check runs only after all installations and preserves rollback/disposal behavior.
- Confirm the remaining inventory checks enforce semantics rather than snapshot counts.
