### PR TITLE
fix(command): tolerate concurrent catalog additions

### DIFF
--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -612,8 +612,6 @@ describe('preload bridge — runtime renderer contract catalog', () => {
   it('routes every owned method through its cataloged Electron channel', async () => {
     const requestContracts = runtimeContracts.filter(({ kind }) => kind === 'method')
 
-    expect(runtimeContracts).toHaveLength(198)
-
     for (const contract of requestContracts) {
       invokeMock.mockClear()
 
@@ -678,7 +676,7 @@ describe('preload bridge — runtime renderer contract catalog', () => {
 })
 
 describe('preload bridge — core renderer contract catalog', () => {
-  it('pins the exact 23-group, 157-callable T1d complement', () => {
+  it('pins the core T1d capability complement', () => {
     expect(coreContractGroups.map(({ capability }) => capability)).toEqual([
       'artifacts',
       'cli',
@@ -705,28 +703,13 @@ describe('preload bridge — core renderer contract catalog', () => {
       'uploads',
       'window'
     ])
-    expect(coreContracts).toHaveLength(158)
-    expect({
-      requests: coreContracts.filter(
-        ({ dispatchPolicy }) => dispatchPolicy.electron === 'electron-ipc-request'
-      ).length,
-      events: coreContracts.filter(({ kind }) => kind === 'event').length,
-      sends: coreContracts.filter(
-        ({ dispatchPolicy }) => dispatchPolicy.electron === 'electron-ipc-send'
-      ).length,
-      surfaceNative: coreContracts.filter(
-        ({ dispatchPolicy }) => dispatchPolicy.electron === 'surface-native'
-      ).length
-    }).toEqual({ requests: 118, events: 29, sends: 10, surfaceNative: 1 })
   })
 
-  it('routes all 118 request methods through their cataloged Electron channels', async () => {
+  it('routes every request method through its cataloged Electron channel', async () => {
     const requestContracts = coreContracts.filter(
       ({ dispatchPolicy }) => dispatchPolicy.electron === 'electron-ipc-request'
     )
     const localFile = { name: 'catalog.csv' } as File
-
-    expect(requestContracts).toHaveLength(118)
 
     for (const contract of requestContracts) {
       invokeMock.mockClear()
@@ -748,9 +731,6 @@ describe('preload bridge — core renderer contract catalog', () => {
     const genericEventContracts = eventContracts.filter(
       ({ lifecycleDispatch }) => lifecycleDispatch == null
     )
-
-    expect(eventContracts).toHaveLength(29)
-    expect(genericEventContracts).toHaveLength(28)
 
     for (const contract of genericEventContracts) {
       onMock.mockClear()
@@ -776,16 +756,13 @@ describe('preload bridge — core renderer contract catalog', () => {
     }
   })
 
-  it('routes all nine generic one-way sends through their cataloged Electron channels', () => {
+  it('routes every generic one-way send through its cataloged Electron channel', () => {
     const sendContracts = coreContracts.filter(
       ({ dispatchPolicy }) => dispatchPolicy.electron === 'electron-ipc-send'
     )
     const genericSendContracts = sendContracts.filter(
       ({ lifecycleDispatch }) => lifecycleDispatch == null
     )
-
-    expect(sendContracts).toHaveLength(10)
-    expect(genericSendContracts).toHaveLength(9)
 
     for (const contract of genericSendContracts) {
       sendMock.mockClear()

--- a/src/renderer/web/renderer-argument-shape-characterization.test.ts
+++ b/src/renderer/web/renderer-argument-shape-characterization.test.ts
@@ -187,7 +187,6 @@ describe('renderer argument-shape characterization', () => {
     const actualPaths = collectFunctionPaths(webApi).sort()
 
     expect(new Set(actualPaths).size).toBe(actualPaths.length)
-    expect(actualPaths).toHaveLength(289)
 
     expect(actualPaths).toEqual(expectedPaths)
   })

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -3,8 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from './web-api-map.generated'
 import {
   ELECTRON_APPLICATION_COMMAND_CHANNELS,
-  RENDERER_CONTRACT_CATALOG,
-  RENDERER_CONTRACT_GROUPS
+  RENDERER_CONTRACT_CATALOG
 } from './renderer-contract-catalog'
 import { projectRendererContractMaps } from './renderer-contract'
 
@@ -16,19 +15,11 @@ describe('renderer contract catalog', () => {
   it('pins the complete capability-owned inventory and legacy map projection', () => {
     const projection = projectRendererContractMaps(RENDERER_CONTRACT_CATALOG)
 
-    expect(RENDERER_CONTRACT_GROUPS).toHaveLength(33)
-    expect(RENDERER_CONTRACT_CATALOG).toHaveLength(356)
     expect(projection.invoke).toEqual(WEB_INVOKE_CHANNELS)
     expect(projection.event).toEqual(WEB_EVENT_CHANNELS)
-    expect(Object.keys(projection.invoke)).toHaveLength(257)
-    expect(Object.keys(projection.event)).toHaveLength(37)
   })
 
   it('separates actual Web installation from the generated compatibility projection', () => {
-    expect(
-      paths(({ surfaceInstallation }) => surfaceInstallation.localWeb !== 'unavailable')
-    ).toHaveLength(289)
-
     expect(
       paths(({ surfaceInstallation }) => surfaceInstallation.localWeb === 'browser-native')
     ).toEqual(['getRuntimeVersions', 'saveBlobFile', 'saveManagedFile', 'window.close'])
@@ -56,12 +47,6 @@ describe('renderer contract catalog', () => {
         remoteWeb: 'caller-context'
       }
     })
-    expect(
-      paths(({ surfaceInstallation }) => surfaceInstallation.localWeb === 'unavailable')
-    ).toHaveLength(67)
-    expect(
-      paths(({ surfaceInstallation }) => surfaceInstallation.remoteWeb === 'rejecting-stub')
-    ).toHaveLength(70)
 
     expect(
       paths(({ eventDeliverability }) =>

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -244,14 +244,10 @@ describe('renderer surface inventory', () => {
       ...Object.keys(WEB_EVENT_CHANNELS)
     ])
 
-    expect(electronPaths).toHaveLength(356)
-
     expectSameSet(
       electronPaths,
       RENDERER_CONTRACT_CATALOG.map(({ publicPath }) => publicPath)
     )
-    expect(Object.keys(WEB_INVOKE_CHANNELS)).toHaveLength(257)
-    expect(Object.keys(WEB_EVENT_CHANNELS)).toHaveLength(37)
     expectSameSet(
       electronPaths.filter((path) => !generatedPaths.has(path)),
       GENERATED_SOURCE_OMISSIONS
@@ -286,7 +282,6 @@ describe('renderer surface inventory', () => {
     const expectedRemoteLocalOnly = expand(REMOTE_LOCAL_ONLY_CHANNELS, ':')
 
     expectSameSet(REMOTE_LOCAL_ONLY_RPC_CHANNELS, expectedRemoteLocalOnly)
-    expect(expectedRemoteLocalOnly).toHaveLength(70)
     expect(
       expectedRemoteLocalOnly.every((channel) => WEB_RPC_ALLOWED_CHANNELS.includes(channel))
     ).toBe(true)


### PR DESCRIPTION
## Problem

Renderer and preload contract tests pin absolute inventory sizes in addition to exact catalog, set, projection, and per-contract routing assertions. Valid command additions on concurrent PR branches therefore make unrelated synthetic merges fail only because a global count changed.

The runtime composition side is now structurally certified by #1203. This PR removes the remaining count-only test coupling that #1203 intentionally made unnecessary.

## Proposed change

- remove redundant global cardinality assertions from preload, renderer catalog, renderer surface, and Web argument-shape tests
- keep exact capability classification, catalog projection, set equality, uniqueness, omission, policy-subset, and per-contract routing assertions
- make count-neutral test names describe the behavior that remains under test

## Scope and non-goals

- test-only change; no production source or user-visible behavior changes
- no historical data compatibility is required
- no state or enum value is added
- no persistence or migration behavior changes
- this does not include the PR-specific module-impact omission in #1201 or stale reviewer expectations in #1105

## Acceptance criteria and validation

All checks below ran after the last material edit and after rebasing onto current `main`.

- changed renderer/preload inventories plus app-command structural certification and module-manifest validation -> focused Vitest selection -> 8 files and 191 tests passed; `scripts/ci/classify-pr-changes.test.ts` has one current-main failure because `src/main/local-fs/service.ts` lacks a Windows runtime signal
- declared `settings_service_facade` module contracts and consumers -> direct Vitest execution of the 28-file module selection -> 27 files and 693 tests passed; 7 existing symlink tests in `src/main/settings/service.test.ts` could not create Windows symlinks and failed with `EPERM`
- main/preload TypeScript -> `tsc --noEmit -p tsconfig.node.json --composite false` -> passed
- renderer TypeScript -> `tsc --noEmit -p tsconfig.web.json --composite false` -> passed
- generated renderer API projection -> `node scripts/generate-web-api-map.mjs --check` -> passed
- modified-file lint -> ESLint on all four changed files -> passed
- patch integrity -> `git diff --check origin/main...HEAD` -> passed

The Windows module launcher emits the expected selective plan but fails before starting Vitest with `spawnSync npm.cmd EINVAL`; the exact emitted file list was run directly.

Uncovered risks: exact-head cross-platform and complete portable coverage remain authoritative in PR CI. The unrelated current-main Windows classifier gap and local symlink privilege failures are not changed here. Independent review is still pending.

## Review focus

Please verify that every removed count was redundant with an exact catalog/set/iteration assertion, and that capability-specific or behavior-specific exact expectations remain intact.
