### PR TITLE
fix(workspace): align conversation with composer

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -875,7 +875,7 @@ const WorkspaceMessageScrollerImpl = ({
             {/* No wrapper div: message-scroller only measures/anchors Content's direct children. */}
             <MessageScrollerContent
               ref={messageScrollerContentRef}
-              className="gap-0 px-4 pb-[56px]"
+              className="mx-auto w-full max-w-4xl gap-0 px-4 pb-[56px]"
             >
               <VisibleMessageSnapshotCommit
                 scopeId={currentPresentationScopeId}

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -349,8 +349,9 @@ describe('conversation message scroller integration', () => {
     expect(workspaceMessageItemSource).toContain('sessionLinks')
   })
 
-  // Agent replies should read as a full-width transcript surface, while user bubbles stay compact.
-  it('renders agent replies across the full scroller width', () => {
+  // The transcript shares the composer's centered content track; agent replies fill that track,
+  // while user bubbles stay compact and right-aligned within it.
+  it('aligns the transcript width with the composer', () => {
     if (!existsSync(workspaceMessageScrollerPath)) {
       expect(existsSync(workspaceMessageScrollerPath)).toBe(true)
       return
@@ -369,7 +370,9 @@ describe('conversation message scroller integration', () => {
     expect(workspaceMessageItemSource).toContain(
       "'relative w-full max-w-[56rem] text-sm leading-relaxed text-text-000 md:text-[15px]'"
     )
-    expect(workspaceMessageScrollerSource).toContain('className="gap-0 px-4 pb-[56px]"')
+    expect(workspaceMessageScrollerSource).toContain(
+      'className="mx-auto w-full max-w-4xl gap-0 px-4 pb-[56px]"'
+    )
     // Rows must stay direct children of MessageScrollerContent; no transcript wrapper div.
     expect(workspaceMessageScrollerSource).not.toContain('conversationContentClassName')
   })


### PR DESCRIPTION
## Problem

The conversation transcript used the full message-scroller width while the bottom composer used a centered `max-w-4xl` content track. On wide workspaces this pushed assistant content too far left and user messages too far right instead of aligning both with the expanded composer.

## Proposed change

Constrain `MessageScrollerContent` to the same centered `max-w-4xl` track as the composer, while preserving the existing message padding, compact user bubbles, assistant measure, and direct-child anchoring required by Message Scroller.

Add a workspace layout contract assertion so the transcript and composer cannot drift apart again.

## Scope and non-goals

- No color, typography, motion, or message-content changes.
- No state or enum additions.
- No persistence or data-format changes.
- No historical-data compatibility work is required.
- No full `npm test` run, per maintainer request; PR CI remains authoritative.

## Acceptance criteria and validation

Checks ran after the last material edit.

- Transcript/composer alignment contract -> `npm test -- src/renderer/src/pages/workspace/workspace-components.test.tsx` -> 28 passed.
- Message-scroller rendering -> `npm test -- src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx` -> 60 passed.
- Conversation consumer behavior -> `npm test -- src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx` -> 96 passed.
- Subagent transcript consumer -> `npm test -- src/renderer/src/pages/workspace/SubagentReleaseSurfaces.render.test.tsx` -> 14 passed.
- Workspace module -> `npm run test:module -- workspace_page` -> 388 passed, 1 failed on the existing `WorkspacePage.tsx` line-count gate (1203 > 1200); the same failure reproduces unchanged on `origin/main`.
- Renderer types -> `npm run typecheck:web` -> passed.
- Lint -> `npm run lint` -> passed with 0 errors and 10 pre-existing warnings.

No protocol, persistence, platform, or runtime consumer lanes are included because the final diff changes only renderer layout classes and its source-level contract test. Local visual E2E was not run; PR CI is the final authority.

## Review focus

Please verify that the shared max-width belongs on `MessageScrollerContent`, keeping transcript rows as direct children so scroll anchoring and content visibility behavior remain unchanged.
