### PR TITLE
perf(message-scroller): transcript perf fixes + keep identity continuous across session bind

### DIFF
--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -425,6 +425,10 @@ if (process.argv.includes('--version')) {
     }))
     .onRequest(acp.methods.agent.authenticate, () => ({}))
     .onRequest(acp.methods.agent.session.new, async (context) => {
+      // Some lifecycle races (e.g. pending-session binding) only surface when session creation is
+      // slow like a real agent spawn; opt in via FAKE_OPENCODE_NEW_SESSION_DELAY_MS.
+      const newSessionDelayMs = Number(process.env.FAKE_OPENCODE_NEW_SESSION_DELAY_MS ?? 0)
+      if (newSessionDelayMs > 0) await delay(newSessionDelayMs)
       const sessionId = `e2e-session-${nextSessionId++}`
       const mcpServers = context.params.mcpServers ?? []
       sessionRoutes.set(sessionId, {

--- a/e2e/message-scroll-session-bind.spec.ts
+++ b/e2e/message-scroll-session-bind.spec.ts
@@ -10,6 +10,16 @@ const MESSAGE_COUNT = 500
 const JUMP_BACK_THRESHOLD_PX = 400
 const LIVE_EDGE_THRESHOLD_PX = 50
 
+// The bind scroll reset only becomes observable when session creation is slow like a real agent
+// spawn; the fake agent honors this delay (see e2e/fixtures/fake-opencode.mjs). Save/restore so
+// other spec files in the same Playwright worker never inherit the delay.
+const savedSessionDelayEnv = process.env.FAKE_OPENCODE_NEW_SESSION_DELAY_MS
+process.env.FAKE_OPENCODE_NEW_SESSION_DELAY_MS = '4000'
+test.afterEach(() => {
+  if (savedSessionDelayEnv === undefined) delete process.env.FAKE_OPENCODE_NEW_SESSION_DELAY_MS
+  else process.env.FAKE_OPENCODE_NEW_SESSION_DELAY_MS = savedSessionDelayEnv
+})
+
 type SeedMessage = {
   id: string
   role: 'user' | 'agent'
@@ -196,9 +206,6 @@ const expectLiveEdge = async (page: Page): Promise<void> => {
 
 test('keeps the transcript pinned when a branched session binds mid-run', async ({ app }) => {
   test.setTimeout(300_000)
-  // The bind scroll reset only becomes observable when session creation is slow like a real
-  // agent spawn; the fake agent honors this delay (see e2e/fixtures/fake-opencode.mjs).
-  process.env.FAKE_OPENCODE_NEW_SESSION_DELAY_MS ??= '4000'
 
   let page = await app.completeOnboarding()
   page = await forceEnglishLocale(page)

--- a/e2e/message-scroll-session-bind.spec.ts
+++ b/e2e/message-scroll-session-bind.spec.ts
@@ -1,0 +1,245 @@
+import { expect } from '@playwright/test'
+import type { Page } from 'playwright'
+
+import { test } from './fixtures/electron-app'
+
+const LONG_STREAM_PROMPT = 'Stream the long scroll journey.'
+const LONG_STREAM_FINAL_SEGMENT = 'Segment 3 paragraph 7'
+const VIEWPORT_SELECTOR = '[data-slot="message-scroller-viewport"]'
+const MESSAGE_COUNT = 500
+const JUMP_BACK_THRESHOLD_PX = 400
+const LIVE_EDGE_THRESHOLD_PX = 50
+
+type SeedMessage = {
+  id: string
+  role: 'user' | 'agent'
+  content: string
+  status: 'complete'
+  eventIds: string[]
+  createdAt: number
+  updatedAt: number
+}
+
+const USER_TOPICS = [
+  'Compare the benchmark runs for the parser rewrite.',
+  'Why does the index rebuild take longer on cold cache?',
+  'Summarize the flame graph from the latest profile.',
+  'Draft the rollout plan for the streaming change.',
+  'Explain the regression in the scroll anchoring test.',
+  'What changed in the persistence envelope format?',
+  'Review the memory numbers from the stress run.',
+  'How should we shard the transcript fixture data?'
+]
+
+const AGENT_PARAGRAPHS = [
+  'The profile shows layout work dominating the main thread while the transcript grows. Most of the cost comes from style recalculation on rows that are far outside the viewport, which suggests containment is not applied uniformly.',
+  'Breaking the run into phases makes the pattern clearer. Hydration is cheap, the first paint is bounded by the rows near the anchor, and the expensive tail is markdown re-parsing for messages that have not changed since the last render.',
+  'The scroll samples tell a consistent story. Median frames stay near the vsync budget, but the p95 spikes line up with the moments the scroller crosses rows that carry code fences, because those rows re-measure once syntax highlighting resolves.',
+  'A reasonable mitigation is to memoize the rendered markdown per message id and revision. The transcript is append-mostly, so a cache keyed by id plus updatedAt should collapse almost all of the repeated parse work without changing the rendering pipeline.',
+  'Long tasks cluster around streaming bursts. Each chunk notification triggers a re-render of the streaming row, and when the chunk cadence is faster than the frame budget the main thread never gets back below fifty milliseconds between chunks.',
+  'The manifest-driven restore path is linear in the number of messages. Normalization is tolerant and cheap, but the downstream React tree construction is not, so the open-time cost scales with transcript length rather than with viewport size.',
+  'Containment with an estimated intrinsic size keeps offscreen rows from participating in layout, but the estimate has to be close to the real row height or the scrollbar thumb drifts while rows resolve their actual size during fast scrolls.',
+  'None of these costs are inherent to the data model. They are all rendering-pipeline costs, which means the fix belongs in the scroller and the message row components rather than in persistence or in the agent bridge.'
+]
+
+const agentContent = (index: number): string => {
+  const paragraphCount = 3 + (index % 6)
+  const parts: string[] = []
+  for (let paragraph = 0; paragraph < paragraphCount; paragraph += 1) {
+    parts.push(AGENT_PARAGRAPHS[(index + paragraph) % AGENT_PARAGRAPHS.length])
+  }
+  if (index % 14 === 1) {
+    parts.push(
+      ['```ts', 'const sample = frames[0]', 'if (sample > 50) report(sample)', '```'].join('\n')
+    )
+  }
+  return parts.join('\n\n')
+}
+
+const buildMessages = (count: number): SeedMessage[] => {
+  const base = Date.now() - count * 1_000
+  return Array.from({ length: count }, (_, index) => {
+    const createdAt = base + index * 1_000
+    const isUser = index % 2 === 0
+    return {
+      id: `bind-message-${index}`,
+      role: isUser ? 'user' : 'agent',
+      content: isUser
+        ? `${USER_TOPICS[(index / 2) % USER_TOPICS.length]} (turn ${index / 2})`
+        : agentContent(index),
+      status: 'complete',
+      eventIds: [],
+      createdAt,
+      updatedAt: createdAt
+    }
+  })
+}
+
+const seedSession = async (page: Page, messages: SeedMessage[]): Promise<void> => {
+  await page.evaluate(async (seededMessages) => {
+    const bridge = globalThis as unknown as {
+      api: {
+        projects: {
+          create: (request: { name: string; description: string }) => Promise<{ id: string }>
+        }
+        sessions: {
+          saveManifest: (request: { lastProjectId: string; lastSessionId: string }) => Promise<void>
+          saveSession: (session: Record<string, unknown>) => Promise<void>
+        }
+      }
+    }
+    const project = await bridge.api.projects.create({
+      name: 'Session bind project',
+      description: 'Seeded transcript for the session bind scroll regression.'
+    })
+    const now = Date.now()
+    await bridge.api.sessions.saveSession({
+      id: 'session-bind-source-session',
+      projectId: project.id,
+      title: 'Session bind session',
+      cwd: '/tmp/session-bind',
+      status: 'idle',
+      agentFrameworkId: 'opencode',
+      messages: seededMessages,
+      createdAt: now - seededMessages.length * 1_000,
+      updatedAt: now
+    })
+    await bridge.api.sessions.saveManifest({
+      lastProjectId: project.id,
+      lastSessionId: 'session-bind-source-session'
+    })
+  }, messages)
+}
+
+// The CI machine can run a non-English system locale; pin English via the app's own preference
+// storage (survives restarts, no fixture changes needed).
+const forceEnglishLocale = async (page: Page): Promise<Page> => {
+  await page.evaluate(() => {
+    globalThis.localStorage.setItem('open-science-language', 'en')
+  })
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await page.getByText('Loading settings...').waitFor({ state: 'hidden', timeout: 60_000 })
+  return page
+}
+
+type ScrollSample = { t: number; top: number }
+type SamplerResult = { samples: ScrollSample[]; firstRowConnected: boolean }
+
+// Sampling covers two signals: scrollTop per frame (a full reset to the turn anchor is hundreds of
+// px) and the DOM identity of the first transcript row (a full-transcript remount, the root cause
+// of the reset, replaces every row node).
+const startScrollSampler = (page: Page): Promise<void> =>
+  page.evaluate((viewportSelector) => {
+    const win = globalThis as unknown as {
+      __scrollSampler: {
+        samples: ScrollSample[]
+        stop: () => SamplerResult
+      }
+    }
+    const firstRow = document.querySelector('[data-slot="message-scroller-item"]')
+    const samples: ScrollSample[] = []
+    let active = true
+    const sample = (): void => {
+      if (!active) return
+      const viewport = document.querySelector(viewportSelector)
+      samples.push({
+        t: performance.now(),
+        top: viewport instanceof HTMLElement ? viewport.scrollTop : -1
+      })
+      requestAnimationFrame(sample)
+    }
+    requestAnimationFrame(sample)
+    win.__scrollSampler = {
+      samples,
+      stop: () => {
+        active = false
+        return { samples, firstRowConnected: firstRow?.isConnected ?? false }
+      }
+    }
+  }, VIEWPORT_SELECTOR)
+
+const stopScrollSampler = (page: Page): Promise<SamplerResult> =>
+  page.evaluate(() =>
+    (
+      globalThis as unknown as {
+        __scrollSampler: { stop: () => SamplerResult }
+      }
+    ).__scrollSampler.stop()
+  )
+
+const maxScrollDrop = (samples: ScrollSample[]): number => {
+  let maxDrop = 0
+  for (let index = 1; index < samples.length; index += 1) {
+    maxDrop = Math.max(maxDrop, samples[index - 1].top - samples[index].top)
+  }
+  return Math.round(maxDrop)
+}
+
+// Anchor corrections while a reply streams are a few hundred px; a bind-time reset to the turn
+// anchor from near the live edge is larger.
+const expectNoBindReset = (result: SamplerResult): void => {
+  expect(result.firstRowConnected).toBe(true)
+  expect(maxScrollDrop(result.samples)).toBeLessThanOrEqual(JUMP_BACK_THRESHOLD_PX)
+}
+
+const expectLiveEdge = async (page: Page): Promise<void> => {
+  const edge = await page.evaluate((viewportSelector) => {
+    const viewport = document.querySelector(viewportSelector)
+    if (!(viewport instanceof HTMLElement)) return { top: -1, maxTop: -1 }
+    return {
+      top: Math.round(viewport.scrollTop),
+      maxTop: Math.round(viewport.scrollHeight - viewport.clientHeight)
+    }
+  }, VIEWPORT_SELECTOR)
+  expect(edge.maxTop - edge.top).toBeLessThanOrEqual(LIVE_EDGE_THRESHOLD_PX)
+}
+
+test('keeps the transcript pinned when a branched session binds mid-run', async ({ app }) => {
+  test.setTimeout(300_000)
+  // The bind scroll reset only becomes observable when session creation is slow like a real
+  // agent spawn; the fake agent honors this delay (see e2e/fixtures/fake-opencode.mjs).
+  process.env.FAKE_OPENCODE_NEW_SESSION_DELAY_MS ??= '4000'
+
+  let page = await app.completeOnboarding()
+  page = await forceEnglishLocale(page)
+  page = await app.configureFakeAgent()
+  await seedSession(page, buildMessages(MESSAGE_COUNT))
+
+  page = await app.restart()
+  await page
+    .getByRole('region', { name: 'Recent sessions' })
+    .getByRole('button', { name: 'Session bind session' })
+    .click()
+  await expect(page.locator(`[data-message-id="bind-message-${MESSAGE_COUNT - 1}"]`)).toBeVisible({
+    timeout: 300_000
+  })
+
+  const textbox = page.getByRole('textbox', { name: 'Ask anything' })
+  const sendButton = page.getByRole('button', { name: 'Send message' })
+
+  // Branch-submit (#1276): the pending branched session renders the copied transcript, the new
+  // user message, and the loader immediately; binding swaps the session id once createSession
+  // resolves. The transcript must not remount or jump back to the turn anchor across the bind.
+  await textbox.fill(LONG_STREAM_PROMPT)
+  await page.getByRole('button', { name: 'More send options' }).click()
+  await page.getByTestId('menu-branch-in-new-session').click()
+  await expect(page.getByText(LONG_STREAM_PROMPT).last()).toBeVisible({ timeout: 60_000 })
+  // Let the pending session's initial anchor positioning finish before sampling the bind window.
+  await page.waitForTimeout(800)
+
+  await startScrollSampler(page)
+  await expect(page.getByText(LONG_STREAM_FINAL_SEGMENT)).toBeVisible({ timeout: 120_000 })
+  await page.waitForTimeout(500)
+  expectNoBindReset(await stopScrollSampler(page))
+  await expectLiveEdge(page)
+
+  // A plain follow-up in the bound session stays at the live edge too.
+  await textbox.fill(LONG_STREAM_PROMPT)
+  await expect(sendButton).toBeEnabled()
+  await startScrollSampler(page)
+  await sendButton.click()
+  await expect(page.getByText(LONG_STREAM_FINAL_SEGMENT).last()).toBeVisible({ timeout: 120_000 })
+  await page.waitForTimeout(500)
+  expectNoBindReset(await stopScrollSampler(page))
+  await expectLiveEdge(page)
+})

--- a/e2e/message-scroller-performance.spec.ts
+++ b/e2e/message-scroller-performance.spec.ts
@@ -1,0 +1,348 @@
+import { expect } from '@playwright/test'
+import type { Page } from 'playwright'
+
+import { test } from './fixtures/electron-app'
+
+const ROW_SELECTOR = '[data-slot="message-scroller-item"]'
+const VIEWPORT_SELECTOR = '[data-slot="message-scroller-viewport"]'
+const LONG_STREAM_PROMPT = 'Stream the long scroll journey.'
+const LONG_STREAM_FINAL_SEGMENT = 'Segment 3 paragraph 7'
+const SCROLL_STEPS = 20
+const RAF_FALLBACK_MS = 500
+
+type SeedMessage = {
+  id: string
+  role: 'user' | 'agent'
+  content: string
+  status: 'complete'
+  eventIds: string[]
+  createdAt: number
+  updatedAt: number
+}
+
+type FrameSummary = {
+  count: number
+  p50: number
+  p95: number
+  max: number
+  over50ms: number
+}
+
+type LongTaskSummary = {
+  count: number
+  totalMs: number
+  max: number
+}
+
+const round = (value: number): number => Math.round(value * 100) / 100
+
+const summarizeFrames = (frames: number[]): FrameSummary => {
+  const sorted = [...frames].sort((a, b) => a - b)
+  const percentile = (p: number): number =>
+    sorted.length === 0
+      ? 0
+      : sorted[Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1))]
+  return {
+    count: sorted.length,
+    p50: round(percentile(50)),
+    p95: round(percentile(95)),
+    max: round(sorted.at(-1) ?? 0),
+    over50ms: sorted.filter((frame) => frame > 50).length
+  }
+}
+
+const summarizeLongTasks = (durations: number[]): LongTaskSummary => ({
+  count: durations.length,
+  totalMs: round(durations.reduce((total, duration) => total + duration, 0)),
+  max: round(Math.max(0, ...durations))
+})
+
+const USER_TOPICS = [
+  'Compare the benchmark runs for the parser rewrite.',
+  'Why does the index rebuild take longer on cold cache?',
+  'Summarize the flame graph from the latest profile.',
+  'Draft the rollout plan for the streaming change.',
+  'Explain the regression in the scroll anchoring test.',
+  'What changed in the persistence envelope format?',
+  'Review the memory numbers from the stress run.',
+  'How should we shard the transcript fixture data?'
+]
+
+const AGENT_PARAGRAPHS = [
+  'The profile shows layout work dominating the main thread while the transcript grows. Most of the cost comes from style recalculation on rows that are far outside the viewport, which suggests containment is not applied uniformly.',
+  'Breaking the run into phases makes the pattern clearer. Hydration is cheap, the first paint is bounded by the rows near the anchor, and the expensive tail is markdown re-parsing for messages that have not changed since the last render.',
+  'The scroll samples tell a consistent story. Median frames stay near the vsync budget, but the p95 spikes line up with the moments the scroller crosses rows that carry code fences, because those rows re-measure once syntax highlighting resolves.',
+  'A reasonable mitigation is to memoize the rendered markdown per message id and revision. The transcript is append-mostly, so a cache keyed by id plus updatedAt should collapse almost all of the repeated parse work without changing the rendering pipeline.',
+  'Long tasks cluster around streaming bursts. Each chunk notification triggers a re-render of the streaming row, and when the chunk cadence is faster than the frame budget the main thread never gets back below fifty milliseconds between chunks.',
+  'The manifest-driven restore path is linear in the number of messages. Normalization is tolerant and cheap, but the downstream React tree construction is not, so the open-time cost scales with transcript length rather than with viewport size.',
+  'Containment with an estimated intrinsic size keeps offscreen rows from participating in layout, but the estimate has to be close to the real row height or the scrollbar thumb drifts while rows resolve their actual size during fast scrolls.',
+  'None of these costs are inherent to the data model. They are all rendering-pipeline costs, which means the fix belongs in the scroller and the message row components rather than in persistence or in the agent bridge.'
+]
+
+const agentContent = (index: number): string => {
+  const paragraphCount = 3 + (index % 6)
+  const parts: string[] = []
+  for (let paragraph = 0; paragraph < paragraphCount; paragraph += 1) {
+    parts.push(AGENT_PARAGRAPHS[(index + paragraph) % AGENT_PARAGRAPHS.length])
+  }
+  if (index % 14 === 1) {
+    parts.push(
+      [
+        '```ts',
+        `const sample = frames[${index} % SCROLL_STEPS]`,
+        'if (sample > 50) reportLongFrame(sample)',
+        '```'
+      ].join('\n')
+    )
+  } else if (index % 14 === 7) {
+    parts.push(
+      [
+        `- Median frame stayed under budget in run ${index % 5}`,
+        '- P95 spiked near the code-fence rows',
+        '- Long tasks clustered around streaming bursts'
+      ].join('\n')
+    )
+  }
+  return parts.join('\n\n')
+}
+
+const buildMessages = (count: number): SeedMessage[] => {
+  const base = Date.now() - count * 1_000
+  return Array.from({ length: count }, (_, index) => {
+    const createdAt = base + index * 1_000
+    const isUser = index % 2 === 0
+    return {
+      id: `perf-message-${index}`,
+      role: isUser ? 'user' : 'agent',
+      content: isUser
+        ? `${USER_TOPICS[(index / 2) % USER_TOPICS.length]} (turn ${index / 2})`
+        : agentContent(index),
+      status: 'complete',
+      eventIds: [],
+      createdAt,
+      updatedAt: createdAt
+    }
+  })
+}
+
+const seedSession = async (page: Page, messages: SeedMessage[]): Promise<void> => {
+  await page.evaluate(async (seededMessages) => {
+    const bridge = globalThis as unknown as {
+      api: {
+        projects: {
+          create: (request: { name: string; description: string }) => Promise<{ id: string }>
+        }
+        sessions: {
+          saveManifest: (request: { lastProjectId: string; lastSessionId: string }) => Promise<void>
+          saveSession: (session: Record<string, unknown>) => Promise<void>
+        }
+      }
+    }
+    const project = await bridge.api.projects.create({
+      name: 'Transcript perf project',
+      description: 'Seeded long transcript for performance measurement.'
+    })
+    const now = Date.now()
+    await bridge.api.sessions.saveSession({
+      id: 'perf-seed-session',
+      projectId: project.id,
+      title: 'Transcript performance session',
+      cwd: '/tmp/transcript-perf',
+      status: 'idle',
+      agentFrameworkId: 'opencode',
+      messages: seededMessages,
+      createdAt: now - seededMessages.length * 1_000,
+      updatedAt: now
+    })
+    await bridge.api.sessions.saveManifest({
+      lastProjectId: project.id,
+      lastSessionId: 'perf-seed-session'
+    })
+  }, messages)
+}
+
+const measureScroll = (
+  page: Page
+): Promise<{
+  frames: number[]
+  longTasks: number[]
+  startTop: number
+  endTop: number
+  minTop: number
+}> =>
+  page.evaluate(
+    async ({ viewportSelector, steps, rafFallbackMs }) => {
+      const viewport = document.querySelector(viewportSelector)
+      if (!(viewport instanceof HTMLElement)) {
+        throw new Error('Message scroller viewport not found.')
+      }
+      viewport.style.scrollBehavior = 'auto'
+      const frames: number[] = []
+      const longTasks: number[] = []
+      let collecting = true
+      let last = performance.now()
+      const collect = (now: number): void => {
+        if (!collecting) return
+        frames.push(now - last)
+        last = now
+        requestAnimationFrame(collect)
+      }
+      requestAnimationFrame(collect)
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) longTasks.push(entry.duration)
+      })
+      observer.observe({ type: 'longtask' })
+      const nextFrame = (): Promise<void> =>
+        new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, rafFallbackMs)
+          requestAnimationFrame(() => {
+            clearTimeout(timer)
+            resolve()
+          })
+        })
+      const stepTo = async (target: number): Promise<void> => {
+        const origin = viewport.scrollTop
+        for (let step = 1; step <= steps; step += 1) {
+          viewport.scrollTop = origin + ((target - origin) * step) / steps
+          await nextFrame()
+        }
+      }
+      const startTop = viewport.scrollTop
+      // Offscreen rows resolve their real heights during the upward pass and scroll anchoring can
+      // nudge scrollTop off an exact target, so track the minimum reached instead of the endpoint.
+      let minTop = startTop
+      const trackMin = async (target: number): Promise<void> => {
+        const origin = viewport.scrollTop
+        for (let step = 1; step <= steps; step += 1) {
+          viewport.scrollTop = origin + ((target - origin) * step) / steps
+          await nextFrame()
+          minTop = Math.min(minTop, viewport.scrollTop)
+        }
+      }
+      await trackMin(0)
+      await stepTo(viewport.scrollHeight)
+      collecting = false
+      observer.disconnect()
+      return { frames, longTasks, startTop, endTop: viewport.scrollTop, minTop }
+    },
+    {
+      viewportSelector: VIEWPORT_SELECTOR,
+      steps: SCROLL_STEPS,
+      rafFallbackMs: RAF_FALLBACK_MS
+    }
+  )
+
+const startStreamingCollector = (page: Page): Promise<void> =>
+  page.evaluate(() => {
+    const frames: number[] = []
+    const longTasks: number[] = []
+    let active = true
+    let last = performance.now()
+    const collect = (now: number): void => {
+      if (!active) return
+      frames.push(now - last)
+      last = now
+      requestAnimationFrame(collect)
+    }
+    requestAnimationFrame(collect)
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) longTasks.push(entry.duration)
+    })
+    observer.observe({ type: 'longtask' })
+    ;(globalThis as unknown as { __perfStreamCollector: unknown }).__perfStreamCollector = {
+      stop: () => {
+        active = false
+        observer.disconnect()
+        return { frames, longTasks }
+      }
+    }
+  })
+
+const stopStreamingCollector = (page: Page): Promise<{ frames: number[]; longTasks: number[] }> =>
+  page.evaluate(() =>
+    (
+      globalThis as unknown as {
+        __perfStreamCollector: { stop: () => { frames: number[]; longTasks: number[] } }
+      }
+    ).__perfStreamCollector.stop()
+  )
+
+for (const messageCount of [500, 2000]) {
+  test(`transcript performance with ${messageCount} messages`, async ({ app }) => {
+    test.setTimeout(600_000)
+    let page = await app.completeOnboarding()
+    page = await app.configureFakeAgent()
+    await seedSession(page, buildMessages(messageCount))
+
+    const relaunchStartedAt = Date.now()
+    page = await app.restart()
+    // The app restores to home; open the seeded session like message-scroll-reanchor does.
+    await page
+      .getByRole('region', { name: 'Recent sessions' })
+      .getByRole('button', { name: 'Transcript performance session' })
+      .click()
+
+    const rows = page.locator(ROW_SELECTOR)
+    await expect(rows).toHaveCount(messageCount, { timeout: 300_000 })
+    await expect(rows.last()).toBeVisible()
+    const ttiFromNavigationMs = await page.evaluate(async () => {
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, 1_000)
+        requestAnimationFrame(() =>
+          requestAnimationFrame(() => {
+            clearTimeout(timer)
+            resolve()
+          })
+        )
+      })
+      return performance.now()
+    })
+    const ttiWallMs = Date.now() - relaunchStartedAt
+
+    const dom = await page.evaluate(
+      ({ rowSelector }) => ({
+        messageRows: document.querySelectorAll(rowSelector).length,
+        totalElements: document.querySelectorAll('*').length
+      }),
+      { rowSelector: ROW_SELECTOR }
+    )
+
+    const scroll = await measureScroll(page)
+
+    await page.getByRole('textbox', { name: 'Ask anything' }).fill(LONG_STREAM_PROMPT)
+    await page.getByRole('button', { name: 'Send message' }).click()
+    // Start collecting after the click so Playwright's actionability checks stay out of the
+    // window; the fixed wait covers the deterministic ~2.5s fake-agent stream without polling.
+    await startStreamingCollector(page)
+    await page.waitForTimeout(4_000)
+    const streaming = await stopStreamingCollector(page)
+    await expect(page.getByText(LONG_STREAM_FINAL_SEGMENT)).toBeVisible({ timeout: 120_000 })
+
+    console.log(
+      `PERF_RESULT ${JSON.stringify({
+        scenario: `${messageCount}-messages`,
+        tti: { wallMs: ttiWallMs, fromNavigationMs: round(ttiFromNavigationMs) },
+        dom,
+        scroll: {
+          startTop: round(scroll.startTop),
+          endTop: round(scroll.endTop),
+          minTop: round(scroll.minTop),
+          frames: summarizeFrames(scroll.frames),
+          longTasks: summarizeLongTasks(scroll.longTasks)
+        },
+        streaming: {
+          frames: summarizeFrames(streaming.frames),
+          longTasks: summarizeLongTasks(streaming.longTasks)
+        }
+      })}`
+    )
+
+    expect(dom.messageRows).toBe(messageCount)
+    expect(scroll.startTop).toBeGreaterThan(0)
+    // Scroll anchoring compensates while offscreen rows resolve real heights, so an exact top
+    // landing is not guaranteed; reaching the top quartile proves the upward sweep happened.
+    expect(scroll.minTop).toBeLessThan(scroll.startTop * 0.25)
+    expect(scroll.endTop).toBeGreaterThan(scroll.minTop)
+    expect(scroll.frames.length).toBeGreaterThan(0)
+  })
+}

--- a/e2e/message-scroller-performance.spec.ts
+++ b/e2e/message-scroller-performance.spec.ts
@@ -10,6 +10,27 @@ const LONG_STREAM_FINAL_SEGMENT = 'Segment 3 paragraph 7'
 const SCROLL_STEPS = 20
 const RAF_FALLBACK_MS = 500
 
+type StreamingMetricsSnapshot = {
+  acpChunkEventsReceived: number
+  agentMessageChunkCommits: number
+  agentMessageChunksCommitted: number
+}
+
+// The app's own streaming pipeline counters (src/renderer/src/lib/streaming-metrics.ts), exposed
+// as window.__streamingMetrics in dev and e2e builds. Cross-checks the rAF/longtask sampling
+// against what the pipeline actually committed; null in builds that gate the handle off.
+const readStreamingMetrics = (page: Page): Promise<StreamingMetricsSnapshot | null> =>
+  page.evaluate(() => {
+    const metrics = (window as unknown as { __streamingMetrics?: StreamingMetricsSnapshot })
+      .__streamingMetrics
+    if (!metrics) return null
+    return {
+      acpChunkEventsReceived: metrics.acpChunkEventsReceived,
+      agentMessageChunkCommits: metrics.agentMessageChunkCommits,
+      agentMessageChunksCommitted: metrics.agentMessageChunksCommitted
+    }
+  })
+
 type SeedMessage = {
   id: string
   role: 'user' | 'agent'
@@ -313,9 +334,22 @@ for (const messageCount of [500, 2000]) {
     await page.getByRole('button', { name: 'Send message' }).click()
     // Start collecting after the click so Playwright's actionability checks stay out of the
     // window; the fixed wait covers the deterministic ~2.5s fake-agent stream without polling.
+    const metricsBefore = await readStreamingMetrics(page)
     await startStreamingCollector(page)
     await page.waitForTimeout(4_000)
     const streaming = await stopStreamingCollector(page)
+    const metricsAfter = await readStreamingMetrics(page)
+    const streamingMetrics =
+      metricsBefore && metricsAfter
+        ? {
+            acpChunkEventsReceived:
+              metricsAfter.acpChunkEventsReceived - metricsBefore.acpChunkEventsReceived,
+            agentMessageChunkCommits:
+              metricsAfter.agentMessageChunkCommits - metricsBefore.agentMessageChunkCommits,
+            agentMessageChunksCommitted:
+              metricsAfter.agentMessageChunksCommitted - metricsBefore.agentMessageChunksCommitted
+          }
+        : null
     await expect(page.getByText(LONG_STREAM_FINAL_SEGMENT)).toBeVisible({ timeout: 120_000 })
 
     console.log(
@@ -333,7 +367,8 @@ for (const messageCount of [500, 2000]) {
         streaming: {
           frames: summarizeFrames(streaming.frames),
           longTasks: summarizeLongTasks(streaming.longTasks)
-        }
+        },
+        streamingMetrics
       })}`
     )
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:module": "node scripts/ci/module-test-impact.mjs module",
     "test:affected": "node scripts/ci/module-test-impact.mjs affected",
     "test:affected:explain": "node scripts/ci/module-test-impact.mjs affected --explain",
-    "build:e2e": "electron-vite build",
+    "build:e2e": "electron-vite build --mode e2e",
     "test:e2e": "playwright test",
     "test:e2e:journey": "playwright test e2e/electron-foundation.spec.ts e2e/settings-persistence.spec.ts e2e/windows-window-system.spec.ts",
     "test:e2e:workspace": "playwright test e2e/launch-environment.spec.ts e2e/workspace-conversation.spec.ts e2e/workspace-files.spec.ts",

--- a/src/renderer/src/components/ui/message-scroller.tsx
+++ b/src/renderer/src/components/ui/message-scroller.tsx
@@ -65,10 +65,14 @@ function MessageScrollerContent({
 function MessageScrollerItem({
   className,
   disableContainment = false,
+  containmentEstimate = '[contain-intrinsic-size:auto_10rem]',
   scrollAnchor = false,
   ...props
 }: React.ComponentProps<typeof MessageScrollerPrimitive.Item> & {
   disableContainment?: boolean
+  // Offscreen-size estimate for content-visibility rows; closer per-row-type estimates keep the
+  // scrollbar stable while rows resolve their real height.
+  containmentEstimate?: string
 }) {
   return (
     <MessageScrollerPrimitive.Item
@@ -76,7 +80,7 @@ function MessageScrollerItem({
       scrollAnchor={scrollAnchor}
       className={cn(
         'min-w-0 shrink-0',
-        !disableContainment && '[contain-intrinsic-size:auto_10rem] [content-visibility:auto]',
+        !disableContainment && `${containmentEstimate} [content-visibility:auto]`,
         className
       )}
       {...props}

--- a/src/renderer/src/lib/streaming-metrics.ts
+++ b/src/renderer/src/lib/streaming-metrics.ts
@@ -1,6 +1,9 @@
 // Dev-only streaming pipeline counters for before/after perf comparisons. Counting is a few
 // integer increments per call, so it runs everywhere; only the `window.__streamingMetrics`
-// handle is DEV-gated (tree-shaken out of production renderer builds).
+// handle is gated to dev and e2e builds (tree-shaken out of production renderer builds). The e2e
+// build (`npm run build:e2e`, vite mode "e2e") exposes it so the performance benchmark
+// (e2e/message-scroller-performance.spec.ts) can cross-check its frame sampling against these
+// pipeline counters.
 const streamingMetrics = {
   // Assistant chunk events applied to the session store (workspace-events.ts).
   acpChunkEventsReceived: 0,
@@ -60,7 +63,7 @@ export const recordAgentMessageChunkCommit = (chunkCount: number): void => {
   streamingMetrics.agentMessageChunksCommitted += chunkCount
 }
 
-if (import.meta.env.DEV && typeof window !== 'undefined') {
+if ((import.meta.env.DEV || import.meta.env.MODE === 'e2e') && typeof window !== 'undefined') {
   // Live reference: reading window.__streamingMetrics in the console always shows current values.
   ;(window as unknown as { __streamingMetrics: typeof streamingMetrics }).__streamingMetrics =
     streamingMetrics

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -938,6 +938,9 @@ const WorkspaceMessageItemImpl = ({
       key={message.id}
       messageId={message.id}
       disableContainment={message.status === 'streaming' || isAssistantPresenting}
+      containmentEstimate={
+        isUserMessage ? '[contain-intrinsic-size:auto_3rem]' : '[contain-intrinsic-size:auto_21rem]'
+      }
       scrollAnchor={message.role === 'user'}
       className="min-w-0"
     >

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -462,6 +462,11 @@ const editSendButtonClassName =
 const ignoreEditPaste = (): void => {}
 // A branch-changing resend with several downstream turns asks for confirmation first.
 const EDIT_TRUNCATION_WARNING_TURNS = 2
+// Offscreen height guesses for contain-intrinsic-size, from row heights measured by
+// e2e/message-scroller-performance.spec.ts: user rows ≈46px, agent rows ≈336px. Better guesses
+// mean less scrollHeight drift while content-visibility rows resolve their real heights.
+const USER_ROW_CONTAINMENT_ESTIMATE = '[contain-intrinsic-size:auto_3rem]'
+const AGENT_ROW_CONTAINMENT_ESTIMATE = '[contain-intrinsic-size:auto_21rem]'
 // Staged uploads render as gray file pills inside the sent bubble.
 const uploadedAttachmentButtonClassName =
   'inline-flex max-w-full items-center gap-1.5 rounded-md border border-border-200 bg-bg-200 px-2 py-0.5 text-left text-[13px] leading-5 text-text-000 transition-colors hover:bg-bg-000 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-200/60'
@@ -939,7 +944,7 @@ const WorkspaceMessageItemImpl = ({
       messageId={message.id}
       disableContainment={message.status === 'streaming' || isAssistantPresenting}
       containmentEstimate={
-        isUserMessage ? '[contain-intrinsic-size:auto_3rem]' : '[contain-intrinsic-size:auto_21rem]'
+        isUserMessage ? USER_ROW_CONTAINMENT_ESTIMATE : AGENT_ROW_CONTAINMENT_ESTIMATE
       }
       scrollAnchor={message.role === 'user'}
       className="min-w-0"

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -721,21 +721,52 @@ const WorkspaceMessageScrollerImpl = ({
         : undefined,
     [legacyAgentBackendId, legacyAgentModel]
   )
-  const messageCreatedAtById = new Map(
-    activeSession?.messages.map((message) => [message.id, message.createdAt]) ?? []
+  const sessionMessages = activeSession?.messages
+  const messageCreatedAtById = useMemo(
+    () => new Map(sessionMessages?.map((message) => [message.id, message.createdAt]) ?? []),
+    [sessionMessages]
   )
 
   // Counts the user turns after each message; the destructive-resend warning keys off turns, not
   // raw message count, so a single follow-up turn stays warning-free.
-  const subsequentTurnCountByMessageId = new Map<string, number>()
-  if (activeSession) {
+  const subsequentTurnCountByMessageId = useMemo(() => {
+    const counts = new Map<string, number>()
     let subsequentTurns = 0
-    for (let index = activeSession.messages.length - 1; index >= 0; index -= 1) {
-      const message = activeSession.messages[index]
-      subsequentTurnCountByMessageId.set(message.id, subsequentTurns)
+    for (let index = (sessionMessages?.length ?? 0) - 1; index >= 0; index -= 1) {
+      const message = sessionMessages?.[index]
+      if (!message) continue
+      counts.set(message.id, subsequentTurns)
       if (message.role === 'user') subsequentTurns += 1
     }
-  }
+    return counts
+  }, [sessionMessages])
+
+  // Streaming rebuilds the transcript once per chunk. Index the conversation graph once per render
+  // so the per-row lookups in the item map below stay O(1) instead of scanning the graph per row.
+  const conversationGraph = activeSession?.conversationGraph
+  const graphMessageNodeById = useMemo(
+    () => new Map(conversationGraph?.messages.map((message) => [message.id, message]) ?? []),
+    [conversationGraph]
+  )
+  const graphRuntimeSegmentById = useMemo(
+    () => new Map(conversationGraph?.runtimeSegments.map((segment) => [segment.id, segment]) ?? []),
+    [conversationGraph]
+  )
+  const revisionMessagesByRootId = useMemo(() => {
+    const byRootId = new Map<string, NonNullable<typeof conversationGraph>['messages']>()
+    for (const message of conversationGraph?.messages ?? []) {
+      if (message.role !== 'user' || message.revisionRootMessageId === undefined) continue
+      const revisions = byRootId.get(message.revisionRootMessageId) ?? []
+      revisions.push(message)
+      byRootId.set(message.revisionRootMessageId, revisions)
+    }
+    for (const revisions of byRootId.values()) {
+      revisions.sort(
+        (left, right) => left.createdAt - right.createdAt || left.id.localeCompare(right.id)
+      )
+    }
+    return byRootId
+  }, [conversationGraph])
 
   // Build a map from job_id → JobSummary for all session jobs (used in binding)
   const sessionJobs = useMemo((): JobSummary[] => {
@@ -1060,14 +1091,9 @@ const WorkspaceMessageScrollerImpl = ({
                   const artifacts = artifactVisibility.artifactsForMessage(item.message)
                   // Jobs pre-assigned to this slot: each job appears in exactly one slot.
                   const jobsBeforeMessage = jobSlotsByItemIndex.get(itemIndex) ?? []
-                  const graph = activeSession?.conversationGraph
-                  const messageNode = graph?.messages.find(
-                    (message) => message.id === item.message.id
-                  )
+                  const messageNode = graphMessageNodeById.get(item.message.id)
                   const runtimeSegment = messageNode?.runtimeSegmentId
-                    ? graph?.runtimeSegments.find(
-                        (segment) => segment.id === messageNode.runtimeSegmentId
-                      )
+                    ? graphRuntimeSegmentById.get(messageNode.runtimeSegmentId)
                     : undefined
                   // Legacy sessions synthesize this segment with a fallback framework. Keep only
                   // the session-level values that were actually persisted.
@@ -1082,16 +1108,7 @@ const WorkspaceMessageScrollerImpl = ({
                     ? messageNode?.revisionRootMessageId
                     : undefined
                   const revisions = revisionRootMessageId
-                    ? (graph?.messages
-                        .filter(
-                          (message) =>
-                            message.role === 'user' &&
-                            message.revisionRootMessageId === revisionRootMessageId
-                        )
-                        .sort(
-                          (left, right) =>
-                            left.createdAt - right.createdAt || left.id.localeCompare(right.id)
-                        ) ?? [])
+                    ? (revisionMessagesByRootId.get(revisionRootMessageId) ?? [])
                     : []
                   const revisionIndex = revisions.findIndex(
                     (message) => message.id === item.message.id

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -371,8 +371,18 @@ const WorkspaceMessageScrollerImpl = ({
   const activeConversationFrame = activeSession?.conversationGraph?.frames.find(
     (frame) => frame.id === activeSession.conversationGraph?.activeFrameId
   )
-  const currentPresentationScopeId = currentSessionId
-    ? JSON.stringify([currentSessionId, activeConversationFrame?.activeBranchId ?? 'legacy'])
+  // A pending Session keeps its first-rendered presentation identities after binding (the store
+  // records them as boundFromPending*/boundTo*), so neither the id swap nor the graph rebase
+  // remounts the transcript. A later intentional branch switch still changes the scope (#1124).
+  const activeBranchId = activeConversationFrame?.activeBranchId
+  const presentationBranchId =
+    activeSession?.boundToMessageBranchId !== undefined &&
+    activeBranchId === activeSession.boundToMessageBranchId
+      ? activeSession.boundFromPendingMessageBranchId
+      : activeBranchId
+  const presentationSessionId = activeSession?.boundFromPendingSessionId ?? currentSessionId
+  const currentPresentationScopeId = presentationSessionId
+    ? JSON.stringify([presentationSessionId, presentationBranchId ?? 'legacy'])
     : undefined
   const artifactVisibility = useWorkspaceArtifactVisibility(activeSession)
   const handoffEvents = useHandoffLifecycleEvents(handoffLifecycleSource, currentSessionId)
@@ -1019,7 +1029,7 @@ const WorkspaceMessageScrollerImpl = ({
   return (
     <>
       <MessageScrollerProvider
-        key={activeSession?.id ?? 'empty-conversation'}
+        key={activeSession?.boundFromPendingSessionId ?? activeSession?.id ?? 'empty-conversation'}
         autoScroll
         defaultScrollPosition="last-anchor"
         scrollPreviousItemPeek={64}

--- a/src/renderer/src/stores/session-store-message-graph-owner.ts
+++ b/src/renderer/src/stores/session-store-message-graph-owner.ts
@@ -453,19 +453,30 @@ export const createSessionMessageGraphOwner = <
     )
     if (!pendingSession) return undefined
 
-    // Keep the transcript's presentation identity continuous across the id swap: remember the
-    // pending-side identities the UI was keyed on, and rebase the conversation graph's
-    // session-derived root ids off the dead pending id.
-    const previousActiveBranchId = pendingSession.conversationGraph?.frames.find(
-      (frame) => frame.id === pendingSession.conversationGraph?.activeFrameId
-    )?.activeBranchId
-    const boundFromPendingMessageBranchId = previousActiveBranchId?.endsWith(`-${pendingSessionId}`)
-      ? previousActiveBranchId
+    // Keep the transcript's presentation identity continuous across the id swap: rebase the
+    // conversation graph's session-derived root ids off the dead pending id, and remember the
+    // active branch id before/after the rebase so the UI can translate its scope keys. Reading
+    // the pair off the rebased graph keeps it consistent with the rebase by construction —
+    // if the rebase declines a rename, no pair is recorded and the scope stays as-is.
+    const graphBeforeBind = pendingSession.conversationGraph
+    const graphAfterBind = graphBeforeBind
+      ? rebaseConversationGraphSessionId(graphBeforeBind, pendingSessionId, sessionId)
       : undefined
-    const boundToMessageBranchId = boundFromPendingMessageBranchId?.replace(
-      `-${pendingSessionId}`,
-      `-${sessionId}`
-    )
+    const activeBranchIdOf = (graph: typeof graphBeforeBind): string | undefined =>
+      graph?.frames.find((frame) => frame.id === graph.activeFrameId)?.activeBranchId
+    const branchIdBeforeBind = activeBranchIdOf(graphBeforeBind)
+    const branchIdAfterBind = activeBranchIdOf(graphAfterBind)
+    // Only a branch id the rebase actually remapped is bind-derived; legacy or fork-derived ids
+    // must keep driving the presentation scope untouched.
+    const bindRemappedBranchIdentity =
+      branchIdBeforeBind !== undefined &&
+      branchIdAfterBind !== undefined &&
+      branchIdBeforeBind !== branchIdAfterBind
+        ? {
+            boundFromPendingMessageBranchId: branchIdBeforeBind,
+            boundToMessageBranchId: branchIdAfterBind
+          }
+        : {}
 
     const now = Date.now()
     set({
@@ -478,16 +489,8 @@ export const createSessionMessageGraphOwner = <
               id: sessionId,
               isPending: false,
               boundFromPendingSessionId: pendingSessionId,
-              ...(boundFromPendingMessageBranchId && boundToMessageBranchId
-                ? { boundFromPendingMessageBranchId, boundToMessageBranchId }
-                : {}),
-              conversationGraph: session.conversationGraph
-                ? rebaseConversationGraphSessionId(
-                    session.conversationGraph,
-                    pendingSessionId,
-                    sessionId
-                  )
-                : session.conversationGraph,
+              ...bindRemappedBranchIdentity,
+              conversationGraph: graphAfterBind ?? session.conversationGraph,
               cwd: cwd ?? session.cwd,
               agentFrameworkId: agentFrameworkId ?? session.agentFrameworkId,
               agentBackendId: agentBackendId ?? session.agentBackendId,

--- a/src/renderer/src/stores/session-store-message-graph-owner.ts
+++ b/src/renderer/src/stores/session-store-message-graph-owner.ts
@@ -3,6 +3,7 @@ import {
   activateConversationBranch,
   forkEditedConversationMessage,
   projectConversationMessage,
+  rebaseConversationGraphSessionId,
   resolveActiveConversationActivities,
   resolveActiveConversationMessages
 } from '../../../shared/conversation-graph'
@@ -452,6 +453,20 @@ export const createSessionMessageGraphOwner = <
     )
     if (!pendingSession) return undefined
 
+    // Keep the transcript's presentation identity continuous across the id swap: remember the
+    // pending-side identities the UI was keyed on, and rebase the conversation graph's
+    // session-derived root ids off the dead pending id.
+    const previousActiveBranchId = pendingSession.conversationGraph?.frames.find(
+      (frame) => frame.id === pendingSession.conversationGraph?.activeFrameId
+    )?.activeBranchId
+    const boundFromPendingMessageBranchId = previousActiveBranchId?.endsWith(`-${pendingSessionId}`)
+      ? previousActiveBranchId
+      : undefined
+    const boundToMessageBranchId = boundFromPendingMessageBranchId?.replace(
+      `-${pendingSessionId}`,
+      `-${sessionId}`
+    )
+
     const now = Date.now()
     set({
       selectedSessionId:
@@ -462,6 +477,17 @@ export const createSessionMessageGraphOwner = <
               ...session,
               id: sessionId,
               isPending: false,
+              boundFromPendingSessionId: pendingSessionId,
+              ...(boundFromPendingMessageBranchId && boundToMessageBranchId
+                ? { boundFromPendingMessageBranchId, boundToMessageBranchId }
+                : {}),
+              conversationGraph: session.conversationGraph
+                ? rebaseConversationGraphSessionId(
+                    session.conversationGraph,
+                    pendingSessionId,
+                    sessionId
+                  )
+                : session.conversationGraph,
               cwd: cwd ?? session.cwd,
               agentFrameworkId: agentFrameworkId ?? session.agentFrameworkId,
               agentBackendId: agentBackendId ?? session.agentBackendId,

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -97,6 +97,11 @@ export type ChatSession = Omit<
   branchSwitchBlocked?: boolean
   conversationGraphSyncBlocked?: boolean
   pendingContextReplayMessageId?: string
+  // Transient presentation identities from before a pending Session bound to its backend id. The
+  // transcript keys its scroller and row remount scope on these so the bind never remounts it.
+  boundFromPendingSessionId?: string
+  boundFromPendingMessageBranchId?: string
+  boundToMessageBranchId?: string
   // Transient independent facts for the blocking lane. Plan remains owned by its durable
   // projection, while Side chat remains an overlay that never settles these facts.
   interactionState?: SessionInteractionState
@@ -173,6 +178,9 @@ export const toPersistedSession = (session: ChatSession): PersistedChatSession =
     branchSwitchBlocked,
     conversationGraphSyncBlocked,
     pendingContextReplayMessageId,
+    boundFromPendingSessionId,
+    boundFromPendingMessageBranchId,
+    boundToMessageBranchId,
     interactionState,
     activePlanProjection,
     planHistoryProjections,
@@ -195,6 +203,9 @@ export const toPersistedSession = (session: ChatSession): PersistedChatSession =
   void branchSwitchBlocked
   void conversationGraphSyncBlocked
   void pendingContextReplayMessageId
+  void boundFromPendingSessionId
+  void boundFromPendingMessageBranchId
+  void boundToMessageBranchId
   void interactionState
   void activePlanProjection
   void runtimeContext

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -2084,6 +2084,43 @@ describe('session store', () => {
     ])
   })
 
+  it('keeps presentation identity continuous and rebases the graph when binding', () => {
+    const pending = useSessionStore.getState().appendPendingUserMessage({
+      content: 'Continue the analysis',
+      cwd: '/workspace/project'
+    })
+    const pendingSessionId = pending?.sessionId ?? ''
+
+    useSessionStore.getState().bindPendingSession({
+      pendingSessionId,
+      sessionId: 'transport-session-1',
+      cwd: '/workspace/project'
+    })
+
+    const bound = useSessionStore.getState().sessions[0]
+    expect(bound).toMatchObject({
+      id: 'transport-session-1',
+      isPending: false,
+      boundFromPendingSessionId: pendingSessionId,
+      boundFromPendingMessageBranchId: `message-branch-${pendingSessionId}`,
+      boundToMessageBranchId: 'message-branch-transport-session-1'
+    })
+    // No graph id keeps embedding the dead pending id after the bind.
+    expect(JSON.stringify(bound.conversationGraph)).not.toContain(pendingSessionId)
+    expect(bound.conversationGraph?.rootFrameId).toBe('root-frame-transport-session-1')
+    expect(bound.conversationGraph?.frames[0]?.activeBranchId).toBe(
+      'message-branch-transport-session-1'
+    )
+    expect(bound.conversationGraph?.runtimeSegments[0]?.id).toBe(
+      'runtime-segment-transport-session-1'
+    )
+    // The presentation identities stay in memory only, never on disk.
+    const persisted = toPersistedSession(bound)
+    expect(persisted).not.toHaveProperty('boundFromPendingSessionId')
+    expect(persisted).not.toHaveProperty('boundFromPendingMessageBranchId')
+    expect(persisted).not.toHaveProperty('boundToMessageBranchId')
+  })
+
   it('appends follow-up user messages to the same session and restarts the run', () => {
     const first = useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',

--- a/src/shared/conversation-graph.test.ts
+++ b/src/shared/conversation-graph.test.ts
@@ -8,6 +8,7 @@ import {
   forkConversationAfterActivity,
   forkEditedConversationMessage,
   getActiveConversationContext,
+  rebaseConversationGraphSessionId,
   resolveActiveConversationActivities,
   resolveActiveConversationMessages,
   synchronizeActiveConversationActivities,
@@ -466,5 +467,78 @@ describe('conversation graph', () => {
 
     const visibleAgain = activateConversationBranch(hidden, originalBranchId)
     expect(visibleAgain.activeFrameId).toBe(hidden.rootFrameId)
+  })
+
+  it('rebases session-derived root ids across every reference when a pending Session binds', () => {
+    const graph = createLinearConversationGraph({
+      sessionId: 'pending-session-1',
+      messages: [message('u1', 'user', 'question', 1), message('a1', 'agent', 'answer', 2)],
+      frameworkId: 'opencode',
+      createdAt: 1,
+      updatedAt: 2
+    })
+
+    const rebased = rebaseConversationGraphSessionId(graph, 'pending-session-1', 'session-1')
+
+    expect(rebased.rootFrameId).toBe('root-frame-session-1')
+    expect(rebased.activeFrameId).toBe('root-frame-session-1')
+    expect(rebased.frames[0]).toMatchObject({
+      id: 'root-frame-session-1',
+      activeBranchId: 'message-branch-session-1'
+    })
+    expect(rebased.branches[0]).toMatchObject({
+      id: 'message-branch-session-1',
+      agentFrameId: 'root-frame-session-1'
+    })
+    expect(rebased.runtimeSegments[0]).toMatchObject({
+      id: 'runtime-segment-session-1',
+      agentFrameId: 'root-frame-session-1'
+    })
+    expect(
+      rebased.messages.every(
+        (node) =>
+          node.agentFrameId === 'root-frame-session-1' &&
+          node.introducedOnBranchId === 'message-branch-session-1' &&
+          node.runtimeSegmentId === 'runtime-segment-session-1'
+      )
+    ).toBe(true)
+    // The input graph is untouched.
+    expect(graph.rootFrameId).toBe('root-frame-pending-session-1')
+    expect(JSON.stringify(rebased)).not.toContain('pending-session-1')
+  })
+
+  it('rebase leaves forked branch and delegate frame ids untouched', () => {
+    const base = createLinearConversationGraph({
+      sessionId: 'pending-session-1',
+      messages: [message('u1', 'user', 'question', 1), message('a1', 'agent', 'answer', 2)],
+      frameworkId: 'opencode',
+      createdAt: 1,
+      updatedAt: 2
+    })
+    const forked = forkEditedConversationMessage(base, 'u1', 'branch-edited', 3)
+
+    const rebased = rebaseConversationGraphSessionId(forked, 'pending-session-1', 'session-1')
+
+    expect(rebased.branches.map((branch) => branch.id)).toEqual([
+      'message-branch-session-1',
+      'branch-edited'
+    ])
+    expect(rebased.branches[1]).toMatchObject({
+      agentFrameId: 'root-frame-session-1',
+      parentBranchId: 'message-branch-session-1'
+    })
+    expect(rebased.activeFrameId).toBe('root-frame-session-1')
+  })
+
+  it('rebase returns the input graph unchanged when no session-derived ids exist', () => {
+    const graph = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages: [message('u1', 'user', 'question', 1)],
+      frameworkId: 'opencode',
+      createdAt: 1,
+      updatedAt: 1
+    })
+
+    expect(rebaseConversationGraphSessionId(graph, 'pending-session-9', 'session-9')).toBe(graph)
   })
 })

--- a/src/shared/conversation-graph.ts
+++ b/src/shared/conversation-graph.ts
@@ -807,6 +807,71 @@ export const ensureConversationRuntimeSegment = (
   return next
 }
 
+// Rewrites the session-id-derived root identity ids (root frame, root branch, initial runtime
+// segment) when a pending Session binds to its backend id, so no graph id keeps embedding the dead
+// pending id. Every reference across frames, branches, messages, activities, activity groups, and
+// runtime segments is remapped; ids not derived from the Session id are left untouched.
+export const rebaseConversationGraphSessionId = (
+  graph: PersistedConversationGraph,
+  fromSessionId: string,
+  toSessionId: string
+): PersistedConversationGraph => {
+  if (fromSessionId === toSessionId) return graph
+
+  const next = structuredClone(graph)
+  const renamedIds = new Map<string, string>()
+  for (const kind of ['root-frame', 'message-branch', 'runtime-segment']) {
+    const fromId = `${kind}-${fromSessionId}`
+    if (
+      next.rootFrameId === fromId ||
+      next.frames.some((frame) => frame.id === fromId) ||
+      next.branches.some((branch) => branch.id === fromId) ||
+      next.runtimeSegments.some((segment) => segment.id === fromId)
+    ) {
+      renamedIds.set(fromId, `${kind}-${toSessionId}`)
+    }
+  }
+  if (renamedIds.size === 0) return graph
+
+  const remap = (id: string): string => renamedIds.get(id) ?? id
+  const remapOptional = (id: string | undefined): string | undefined =>
+    id === undefined ? undefined : remap(id)
+
+  next.rootFrameId = remap(next.rootFrameId)
+  next.activeFrameId = remap(next.activeFrameId)
+  for (const frame of next.frames) {
+    frame.id = remap(frame.id)
+    frame.parentFrameId = remapOptional(frame.parentFrameId)
+    frame.activeBranchId = remap(frame.activeBranchId)
+  }
+  for (const branch of next.branches) {
+    branch.id = remap(branch.id)
+    branch.agentFrameId = remap(branch.agentFrameId)
+    branch.parentBranchId = remapOptional(branch.parentBranchId)
+  }
+  for (const message of next.messages) {
+    message.agentFrameId = remap(message.agentFrameId)
+    message.introducedOnBranchId = remap(message.introducedOnBranchId)
+    message.runtimeSegmentId = remapOptional(message.runtimeSegmentId)
+  }
+  for (const activity of next.activities) {
+    activity.agentFrameId = remap(activity.agentFrameId)
+    activity.messageBranchId = remap(activity.messageBranchId)
+    activity.runtimeSegmentId = remap(activity.runtimeSegmentId)
+  }
+  for (const group of next.activityGroups) {
+    group.agentFrameId = remap(group.agentFrameId)
+    group.messageBranchId = remap(group.messageBranchId)
+  }
+  for (const segment of next.runtimeSegments) {
+    segment.id = remap(segment.id)
+    segment.agentFrameId = remap(segment.agentFrameId)
+  }
+
+  validateConversationGraph(next)
+  return next
+}
+
 export const getActiveConversationContext = (
   graph: PersistedConversationGraph,
   promptMessageId: string


### PR DESCRIPTION
## Background

Two transcript issues, diagnosed and fixed together (both reproduced with the benchmark/regression specs included here):

1. **Streaming perf audit** per the shadcn [Message Scroller Performance](https://ui.shadcn.com/docs/components/base/message-scroller#performance) guidance — exposed an O(n²) per-tick row mapping as the dominant streaming cost.
2. **User-reported bug**: mid-stream the reply suddenly freezes (>5s in dev), and when it resumes the viewport jumps back to the turn's user message. Diagnosed to session-identity flips during pending-Session bind.

## Changes

### Performance

- **New `e2e/message-scroller-performance.spec.ts`**: seeds sessions with 500/2000 messages and measures open TTI, DOM size, scroll frame health (rAF deltas + longtasks), and main-thread cost while the fake agent streams. Emits one `PERF_RESULT` JSON line per scenario, cross-checked against the app's own streaming pipeline counters (`window.__streamingMetrics`, exposed in the e2e build via vite mode `e2e`).
- **Fix O(n²) row mapping**: every 33ms presentation tick linearly scanned `conversationGraph.messages` per row — hoisted into per-render indexes memoized on conversationGraph identity (O(1) per row).
- **Per-row-type containment estimates**: `MessageScrollerItem` gains `containmentEstimate`; user rows 3rem / agent rows 21rem (measured heights, named constants), cutting scrollHeight drift from ~8.5% to ~1%.

### Session bind identity continuity (the freeze + scroll reset)

Sending a message opens a **pending Session**; `bindPendingSession` later rewrites the session `id` and `selectedSessionId`. Both flips invalidated the `MessageScrollerProvider` key and every row key (`[scopeId, item.id]`), causing two full-transcript remounts (multi-second main-thread block in dev) and a re-anchor to the turn's user row via `defaultScrollPosition="last-anchor"`.

Fix (stable logical identity — bind-in-place was rejected because ACP assigns the session id and event routing keys on it):

- `bindPendingSession` records `boundFromPendingSessionId` (+ branch id pair) as transient, non-persisted fields, and rebases the graph with the new `rebaseConversationGraphSessionId` so no graph id embeds the dead pending id.
- The scroller keys Provider/scope on the bind-stable identity: the id swap and graph rebase no longer remount the transcript, while intentional branch switches (#1124) still do.
- New regression spec `e2e/message-scroll-session-bind.spec.ts` (fake agent with opt-in `FAKE_OPENCODE_NEW_SESSION_DELAY_MS`): RED without the fix (row nodes replaced, scrollTop drops 336/496px), GREEN with it (zero scope flips, row nodes survive, stays at live edge).

## Benchmark (2000 rows, back-to-back same-machine runs)

| Metric | main | this PR |
|---|---|---|
| Streaming frame p95 / max | 200 / 1026ms | **133 / 908ms** |
| Streaming longtasks (total / max) | 2316ms / 946ms | **2106ms / 836ms** |
| Scroll frame p95 | 67.7ms | **53.3ms** |
| Scroll longtasks | 3 / 245ms | **0** |

> Note: absolute numbers at this base are ~2x worse than at 6e2188d1 across **all** configurations including unmodified main (streaming longtask max ~320-420ms→~840-960ms; DOM 50,892→63,898 elements). A `git bisect` with the benchmark attributes that regression to d5789a7f `feat(workspace): branch from completed Agent messages` (#1276) — ~5 extra DOM elements per agent row (+18.6%). On main itself, not caused by this PR; to be investigated separately.

## Audit conclusions (plan items that needed no change)

- **Streaming-row Streamdown cost**: negligible per CDP CPU profile (incremental normalizer + block streaming cover it).
- **Session-level memo comparator**: field-complete; no over-render observed.

## Verification

- 6 e2e pass: message-scroll anchor/reanchor/release, session-bind regression, benchmark (2 scenarios)
- 278 related unit tests pass (4 added); tsc (web+node) + eslint clean
- E2E note: specs use English locators and require an English locale since the i18n rollout; pre-existing suite convention, unchanged by this PR

Virtualization (@tanstack/react-virtual) was evaluated on a companion branch and deferred; archived as draft PR #1318 with the full A/B/A+B comparison.
