### PR TITLE
fix(ci): restore main certification gates

### DIFF
--- a/scripts/ci/change-impact.json
+++ b/scripts/ci/change-impact.json
@@ -122,6 +122,7 @@
         "src/main/crash-diagnostics.ts",
         "src/main/index.ts",
         "src/main/lifecycle-shutdown.ts",
+        "src/main/local-fs/service.ts",
         "src/main/local-rpc-transport.ts",
         "src/main/notebook/environment-discovery.ts",
         "src/main/notebook/environment-state-tracker.ts",

--- a/scripts/ci/change-impact.json
+++ b/scripts/ci/change-impact.json
@@ -122,7 +122,6 @@
         "src/main/crash-diagnostics.ts",
         "src/main/index.ts",
         "src/main/lifecycle-shutdown.ts",
-        "src/main/local-fs/service.ts",
         "src/main/local-rpc-transport.ts",
         "src/main/notebook/environment-discovery.ts",
         "src/main/notebook/environment-state-tracker.ts",

--- a/src/main/local-fs/service.ts
+++ b/src/main/local-fs/service.ts
@@ -1,6 +1,6 @@
 import { hostname, userInfo } from 'node:os'
 import { randomUUID } from 'node:crypto'
-import { access, readdir, realpath, stat } from 'node:fs/promises'
+import { readdir, realpath, stat } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 
 import { app, shell } from 'electron'
@@ -24,6 +24,7 @@ import {
   validateLocalPath
 } from '../../shared/local-fs'
 import { readBoundedManagedFilePreview } from '../managed-file-preview'
+import { isWindowsPlatform, listWindowsDrives } from './windows-drive-listing'
 
 // The slice of the granted-roots repository the feature persists through. Structural so tests can
 // inject an in-memory store; production wires the SQLite-backed GrantedLocalRootsRepository.
@@ -75,24 +76,10 @@ export class LocalFsService {
     return { home: app.getPath('home'), machineName: buildMachineName() }
   }
 
-  // Mounted drives/volumes for the browsers' drive switchers. win32 probes A:–Z: for existence
-  // (no volume labels — that would need PowerShell/wmic); darwin lists /Volumes; other POSIX
-  // checks the conventional per-user and /mnt mount parents. Everything is existence-checked, so
-  // unmounted letters and empty mount parents never surface.
+  // Mounted drives/volumes for the browsers' drive switchers. Windows probes mounted drive letters;
+  // darwin lists /Volumes; other POSIX checks conventional mount parents.
   async listDrives(): Promise<LocalDrive[]> {
-    if (process.platform === 'win32') {
-      const drives: LocalDrive[] = []
-      for (let code = 65; code <= 90; code += 1) {
-        const letter = String.fromCharCode(code)
-        try {
-          await access(`${letter}:\\`)
-          drives.push({ path: `${letter}:\\`, label: `${letter}:` })
-        } catch {
-          // Letter not mounted.
-        }
-      }
-      return drives
-    }
+    if (isWindowsPlatform(process.platform)) return listWindowsDrives()
     if (process.platform === 'darwin') {
       const volumes = await this.listMountEntries('/Volumes')
       // The boot volume appears in /Volumes as a symlink to /. Label the root entry with the

--- a/src/main/local-fs/windows-drive-listing.ts
+++ b/src/main/local-fs/windows-drive-listing.ts
@@ -1,0 +1,21 @@
+import { access } from 'node:fs/promises'
+
+import type { LocalDrive } from '../../shared/local-fs'
+
+const isWindowsPlatform = (platform: NodeJS.Platform): boolean => platform === 'win32'
+
+const listWindowsDrives = async (): Promise<LocalDrive[]> => {
+  const drives: LocalDrive[] = []
+  for (let code = 65; code <= 90; code += 1) {
+    const letter = String.fromCharCode(code)
+    try {
+      await access(`${letter}:\\`)
+      drives.push({ path: `${letter}:\\`, label: `${letter}:` })
+    } catch {
+      // Letter not mounted.
+    }
+  }
+  return drives
+}
+
+export { isWindowsPlatform, listWindowsDrives }

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -37,7 +37,8 @@ import {
 } from './composer/composer-doc'
 import {
   buildSessionComposerHistory,
-  buildStarterComposerHistory
+  buildStarterComposerHistory,
+  starterHistorySessionSelector
 } from './composer/composer-history'
 import { ConversationPanel } from './ConversationPanel'
 import { DeleteSessionDialog } from './DeleteSessionDialog'
@@ -54,7 +55,6 @@ import {
   hasBlockingRootPermissionRequest
 } from './session-permissions'
 import { WorkspaceSidebarContainer } from './WorkspaceSidebarContainer'
-import { NO_VISIBLE_SESSIONS, visibleProjectSessions } from './visible-project-sessions'
 import { useJobAnalysisEffect } from '@/lib/compute/useJobAnalysisEffect'
 import { WorkspacePanelLayout } from './workspace-panel-layout'
 import { useWorkspaceComposerController } from './workspace-composer-controller'
@@ -246,12 +246,9 @@ const WorkspacePage = ({
   // Starter history is only consumed when no session is active, so this subscription collapses to
   // a stable empty list while a session is selected — background session updates then never
   // re-render the page through it.
+  const hideStarterHistory = activeSession !== undefined || activeProject?.archivedAt !== undefined
   const starterHistorySessions = useSessionStore(
-    useShallow((state) =>
-      activeSession === undefined && activeProject?.archivedAt === undefined
-        ? visibleProjectSessions(state.sessions, scopedProjectId)
-        : NO_VISIBLE_SESSIONS
-    )
+    useShallow(starterHistorySessionSelector(scopedProjectId, hideStarterHistory))
   )
   const composerHistoryEntries = useMemo(
     () =>

--- a/src/renderer/src/pages/workspace/composer/composer-history.test.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-history.test.ts
@@ -5,7 +5,8 @@ import type { ChatMessage, ChatSession } from '@/stores/session-store'
 import {
   buildSessionComposerHistory,
   buildStarterComposerHistory,
-  normalizeHistorySkills
+  normalizeHistorySkills,
+  starterHistorySessionSelector
 } from './composer-history'
 
 const message = (
@@ -119,6 +120,21 @@ describe('composer history', () => {
 
     expect(entries.map((entry) => entry.messageId)).toEqual(['shared-opener', 'older-opener'])
     expect(entries[0].id).toBe('branch-a:shared-opener')
+  })
+
+  it('selects visible same-Project sessions only while starter history is active', () => {
+    const sessions = [
+      session('visible', []),
+      session('archived', [], { archivedAt: 2 }),
+      session('other-project', [], { projectId: 'project-2' })
+    ]
+
+    expect(
+      starterHistorySessionSelector('project-1', false)({ sessions }).map(({ id }) => id)
+    ).toEqual(['visible'])
+
+    const hiddenSelector = starterHistorySessionSelector('project-1', true)
+    expect(hiddenSelector({ sessions })).toBe(hiddenSelector({ sessions: [] }))
   })
 
   it('downgrades missing and Specialist-disallowed Skills to plain text', () => {

--- a/src/renderer/src/pages/workspace/composer/composer-history.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-history.ts
@@ -1,6 +1,7 @@
 import { isHiddenControlMessage, type MessagePart } from '../../../../../shared/session-persistence'
 import type { ChatMessage, ChatSession } from '@/stores/session-store'
 
+import { NO_VISIBLE_SESSIONS, visibleProjectSessions } from '../visible-project-sessions'
 import {
   docFromMessageParts,
   docFromText,
@@ -21,6 +22,11 @@ type HistoryMessage = Pick<
   'id' | 'role' | 'content' | 'parts' | 'uploads' | 'turnIntent'
 >
 type HistorySession = Pick<ChatSession, 'id' | 'messages' | 'isPending' | 'createdAt' | 'updatedAt'>
+
+export const starterHistorySessionSelector =
+  (projectId: string, hidden: boolean) =>
+  (state: { sessions: ChatSession[] }): ChatSession[] =>
+    hidden ? NO_VISIBLE_SESSIONS : visibleProjectSessions(state.sessions, projectId)
 
 const docFromHistoryMessage = (message: HistoryMessage): ComposerDoc => {
   if (!message.parts) return docFromText(message.content)


### PR DESCRIPTION
## Problem

The scheduled Nightly run on `main@6f40d371` failed two deterministic certification tests:

- `src/main/local-fs/service.ts` contains Windows-specific runtime behavior but was not classified by the `windows_sensitive` CI overlay.
- `WorkspacePage.tsx` had grown to 1,203 lines, exceeding its existing 1,200-line architecture completion gate.

The same base failures propagated through both macOS full-suite shards in PR Gate run 31791435562, then caused the coverage merge and deterministic gate to fail.

- Nightly: https://github.com/aipoch/open-science/actions/runs/31791587988
- PR Gate: https://github.com/aipoch/open-science/actions/runs/31791435562

## Proposed change

- Isolate Windows drive discovery in `windows-drive-listing.ts`, which is covered by the existing filename-based `windows_sensitive` classification rule; no protected CI control-plane configuration is changed.
- Move the new-conversation Composer history session selector behind the existing Composer history owner.
- Preserve the selector's project, archive, and inactive-session behavior with a focused unit test.
- Keep the existing 1,200-line WorkspacePage completion gate unchanged; the page is now exactly 1,200 lines.

## Scope and non-goals

- No product behavior or user interaction changes.
- No historical-data compatibility handling.
- No persisted data, database schema, or migration changes.
- No lifecycle, status, or enum additions.
- No broadening of Windows classification patterns.

## Acceptance criteria and validation

- Windows-sensitive source certification after the final local-filesystem edit -> `npm test -- scripts/ci/classify-pr-changes.test.ts` -> 1 file, 41 tests passed.
- Windows drive-discovery behavior after the final edit -> `npm test -- src/main/local-fs/service.test.ts -t "probes A"` -> 1 passed, 19 skipped.
- Workspace architecture/helper behavior -> focused WorkspacePage, Composer history, and classifier run -> 3 files, 52 tests passed.
- WorkspacePage owner, contract, and consumer coverage -> the exact 23-file plan emitted by `npm run test:module -- workspace_page` was run directly after the Windows launcher returned `spawnSync npm.cmd EINVAL` -> 23 files, 390 tests passed.
- Source/config lint -> `npm run lint` -> 0 errors, 10 pre-existing warnings outside this change; focused ESLint for the final local-filesystem files also passed.
- Changed-file formatting -> focused Prettier checks passed.
- Workspace completion gate -> `WorkspacePage.tsx` is 1,200 lines -> passed.

The full local-filesystem service test file is not a clean Windows-host signal: four existing portability cases fail locally (two symlink-permission cases and two tests that simulate POSIX platforms while using Windows path separators). The directly changed Windows branch passes, and PR CI's portable/platform lanes remain authoritative.

`npm run typecheck:web` could not complete locally because the shared dependency directory does not contain the optional `sharp` package. No dependency installation was performed. PR CI's clean `npm ci` environment remains authoritative for typecheck and the complete portable/platform suites.

Per maintainer request, the complete local `npm test` suite was not run.

The Windows consumer lanes are selected by the new Windows-specific module name. The Workspace Module plan covers the changed Composer history owner, WorkspacePage interface, sidebar contract, and session-store consumer. No persistence or migration lane is required.

## Review focus

- Windows drive discovery remains behaviorally identical while matching the existing Windows-sensitive file convention.
- Referentially stable empty starter-history selection while a session or archived Project is active.
- Preservation of the existing WorkspacePage architecture gate without raising its threshold.