### PR TITLE
fix(conversation): hide completion footer during continuations

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -650,6 +650,66 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(failureRegion?.textContent).toBe('Response failed.')
   })
 
+  it('waits to announce completion until an ask-user continuation settles', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const prompt = createMessage({ id: 'prompt-continuation', sortIndex: 1, createdAt: 100 })
+    const streamingReply = createMessage({
+      id: 'reply-continuation',
+      role: 'agent',
+      content: 'Choose a chart type.',
+      status: 'streaming',
+      streamId: 'stream-continuation',
+      responseToMessageId: prompt.id,
+      sortIndex: 2,
+      createdAt: 101
+    })
+    const render = async (session: ChatSession): Promise<void> => {
+      await act(async () => {
+        root.render(
+          <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
+        )
+      })
+    }
+
+    root = createRoot(container)
+    await render(
+      createSession({
+        activeRun: { promptMessageId: prompt.id, startedAt: 100 },
+        messages: [prompt, streamingReply]
+      })
+    )
+
+    const completionRegion = container.querySelector(
+      '[data-testid="message-completion-live-region"]'
+    )
+    const completedReply = {
+      ...streamingReply,
+      status: 'complete' as const,
+      completedAt: 102,
+      updatedAt: 102
+    }
+    await render(
+      createSession({
+        activeRun: undefined,
+        agentPromptInFlight: true,
+        awaitingFirstAgentOutput: true,
+        messages: [prompt, completedReply]
+      })
+    )
+    expect(completionRegion?.textContent).toBe('')
+
+    await render(
+      createSession({
+        status: 'idle',
+        activeRun: undefined,
+        agentPromptInFlight: false,
+        awaitingFirstAgentOutput: false,
+        messages: [prompt, completedReply]
+      })
+    )
+    expect(completionRegion?.textContent).toBe('Response completed.')
+  })
+
   it('does not replay a buffered assistant message after switching sessions', async () => {
     vi.useFakeTimers()
     vi.stubGlobal(

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -907,6 +907,47 @@ describe('WorkspaceMessageScroller loading render', () => {
     )
   })
 
+  it('hides only the current prompt footer while an ask-user continuation is running', async () => {
+    const html = await renderScroller(
+      createSession({
+        status: 'running',
+        activeRun: undefined,
+        agentPromptInFlight: true,
+        awaitingFirstAgentOutput: true,
+        messages: [
+          createMessage({ id: 'prompt-1', content: 'First prompt', sortIndex: 1 }),
+          createMessage({
+            id: 'reply-1',
+            role: 'agent',
+            content: 'First answer',
+            responseToMessageId: 'prompt-1',
+            completedAt: 1710000001000,
+            sortIndex: 2
+          }),
+          createMessage({ id: 'prompt-2', content: 'Create a chart', sortIndex: 3 }),
+          createMessage({
+            id: 'reply-2',
+            role: 'agent',
+            content: 'Choose a chart type.',
+            responseToMessageId: 'prompt-2',
+            completedAt: 1710000003000,
+            turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 },
+            sortIndex: 4
+          })
+        ]
+      })
+    )
+
+    expect(html).toContain('>Thinking</span>')
+    expect(html.match(/data-slot="assistant-message-footer"/g)).toHaveLength(1)
+    expect(html.indexOf('data-slot="assistant-message-footer"')).toBeGreaterThan(
+      html.indexOf('First answer')
+    )
+    expect(html.indexOf('data-slot="assistant-message-footer"')).toBeLessThan(
+      html.indexOf('Choose a chart type.')
+    )
+  })
+
   it('does not present an interrupted tool turn as completed before its final activity', async () => {
     const html = await renderScroller(
       createSession({

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -528,13 +528,29 @@ const WorkspaceMessageScrollerImpl = ({
     () => findDurablePlanOwnerActivityId(activeSession, rawConversationItems),
     [activeSession, rawConversationItems]
   )
-  // Assistant text can be split into several messages around tool calls. All fragments share the
-  // prompt they respond to, but only the last visible fragment in that turn owns whole-turn metadata.
-  // Legacy unlinked messages remain independent so older transcripts do not lose their timestamps.
-  const assistantFooterMessageIds = useMemo(
-    () => resolveTurnTerminalAgentMessageIds(activeSession?.messages ?? []),
-    [activeSession?.messages]
-  )
+  const openPromptMessageId =
+    activeSession &&
+    (activeSession.activeRun ||
+      activeSession.agentPromptInFlight ||
+      activeSession.status.startsWith('waiting-'))
+      ? (activeSession.activeRun?.promptMessageId ??
+        activeSession.messages.findLast((message) => message.role === 'user')?.id)
+      : undefined
+
+  // Provider stops complete individual Agent messages during Ask-User continuations. Keep the
+  // current logical prompt's footer and terminal announcement hidden until that prompt settles.
+  const assistantFooterMessageIds = useMemo(() => {
+    const messages = activeSession?.messages ?? []
+    const footerIds = resolveTurnTerminalAgentMessageIds(messages)
+    if (!openPromptMessageId) return footerIds
+
+    for (const message of messages) {
+      if (message.role === 'agent' && message.responseToMessageId === openPromptMessageId) {
+        footerIds.delete(message.id)
+      }
+    }
+    return footerIds
+  }, [activeSession?.messages, openPromptMessageId])
   const agentLoadingPhase = getAgentLoadingPhase(activeSession)
   const [terminalAnnouncement, setTerminalAnnouncement] = useState<
     TerminalAnnouncement | undefined


### PR DESCRIPTION
## Problem

During an AskUser continuation, the provider can mark an intermediate Agent message as complete while the same logical prompt is still running. The message scroller treated that fragment as the terminal response, so its completion footer appeared beside the active `Thinking` indicator and the live region announced completion too early.

## Proposed change

- Resolve the currently open prompt from `activeRun`, `agentPromptInFlight`, or a waiting session state.
- Exclude Agent messages owned by that prompt from the terminal footer owner set until the prompt settles.
- Use the same filtered owner set for terminal screen-reader announcements.
- Preserve completed footers for earlier prompts and leave message status, persistence, and Artifact ownership unchanged.
- Add render and interaction regressions for footer placement and live-region timing.

## Scope and non-goals

This is a renderer presentation fix. It does not change provider events, runtime state transitions, persisted message completion, usage accounting, translations, or Artifact/version ownership.

## Validation

- `npm test -- src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx src/renderer/src/pages/workspace/agent-loading-message.test.ts src/renderer/src/pages/workspace/workspace-conversation-items.test.ts` (135/135 passed)
- `npm run typecheck` (passed)
- `npm run lint` (0 errors; 10 pre-existing warnings outside the changed files)
- Prettier check and `git diff --check` (passed)
- Independent requirements, standards, and general code reviews (no findings)

The repository impact classifier selected the full-suite fallback. `npm test` completed with 1,013 files passing, 14 skipped, and 3 failing:

- `resources/skills/literature-review/kernel.test.ts` fails independently because this machine only exposes `/usr/bin/python3` 3.9.6, which cannot evaluate the script's `str | None` annotation.
- `src/main/notebook/kernel-executor.test.ts` fails independently because the same Apple Python executable, when symlinked as the managed `python` binary by the test, invokes the Xcode shim instead of starting the kernel loop.
- `src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts` timed out under full-suite concurrency and passed independently (12/12).

## Review focus

- Whether the open-prompt detection covers all continuation and waiting states without hiding historical terminal footers.
- Whether footer rendering and live-region announcements remain aligned through the shared filtered owner set.

## Authors

- Roxi (@roxi3906)
