### PR TITLE
fix(crash-diagnostics): enable local Crashpad across desktop platforms

### DIFF
--- a/src/main/crash-diagnostics.test.ts
+++ b/src/main/crash-diagnostics.test.ts
@@ -3,32 +3,35 @@ import { describe, expect, it, vi } from 'vitest'
 import { installChildProcessGoneLogging, startLocalCrashReporting } from './crash-diagnostics'
 
 describe('startLocalCrashReporting', () => {
-  it('starts Windows Crashpad with uploads and compression disabled', () => {
+  it.each<NodeJS.Platform>(['win32', 'darwin', 'linux'])(
+    'starts local Crashpad on %s with uploads and compression disabled',
+    (platform) => {
+      const start = vi.fn()
+
+      const status = startLocalCrashReporting({
+        platform,
+        productName: 'Open Science',
+        companyName: 'aipoch',
+        appVersion: '0.9.1',
+        start
+      })
+
+      expect(status).toEqual({ enabled: true, uploadsEnabled: false })
+      expect(start).toHaveBeenCalledWith({
+        productName: 'Open Science',
+        companyName: 'aipoch',
+        uploadToServer: false,
+        compress: false,
+        extra: { appVersion: '0.9.1' }
+      })
+    }
+  )
+
+  it('does not start Crashpad on unsupported Electron platforms', () => {
     const start = vi.fn()
 
     const status = startLocalCrashReporting({
-      platform: 'win32',
-      productName: 'Open Science',
-      companyName: 'aipoch',
-      appVersion: '0.9.1',
-      start
-    })
-
-    expect(status).toEqual({ enabled: true, uploadsEnabled: false })
-    expect(start).toHaveBeenCalledWith({
-      productName: 'Open Science',
-      companyName: 'aipoch',
-      uploadToServer: false,
-      compress: false,
-      extra: { appVersion: '0.9.1' }
-    })
-  })
-
-  it('does not start Crashpad outside Windows', () => {
-    const start = vi.fn()
-
-    const status = startLocalCrashReporting({
-      platform: 'darwin',
+      platform: 'freebsd',
       productName: 'Open Science',
       companyName: 'aipoch',
       appVersion: '0.9.1',

--- a/src/main/crash-diagnostics.ts
+++ b/src/main/crash-diagnostics.ts
@@ -24,8 +24,8 @@ type DiagnosticLogger = {
   error: (message: string, metadata: Record<string, unknown>) => void
 }
 
-// Starts local-only Crashpad before a Windows renderer can be created. Other platforms keep their
-// existing crash-reporting behavior and never call Electron's crashReporter.start().
+// Starts local-only Crashpad before any renderer can be created on Electron's supported desktop
+// platforms. Unsupported Node platforms keep their existing crash-reporting behavior.
 const startLocalCrashReporting = ({
   platform,
   productName,
@@ -33,7 +33,8 @@ const startLocalCrashReporting = ({
   appVersion,
   start
 }: StartLocalCrashReportingOptions): LocalCrashReportingStatus => {
-  if (platform !== 'win32') return { enabled: false }
+  if (platform !== 'win32' && platform !== 'darwin' && platform !== 'linux')
+    return { enabled: false }
 
   start({
     productName,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -205,10 +205,10 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
     },
     quit: () => app.quit(),
     prepare: async () => {
-      // Start Windows Crashpad after the single-instance lock but before any BrowserWindow can create
-      // a renderer. Upload stays disabled: dumps remain local for explicit support collection. Without
-      // this initialization the affected Windows renderer failures surface only as
-      // Crashpad_NotConnectedToHandler, which masks the native crash that caused the white window.
+      // Start local-only Crashpad after the single-instance lock but before any BrowserWindow can
+      // create a renderer. Upload stays disabled: dumps remain local for explicit support collection.
+      // Without this initialization, native failures can terminate a process without leaving the dump
+      // needed to distinguish a renderer, utility, or main-process crash.
       const crashReporting = startLocalCrashReporting({
         platform: process.platform,
         productName: APP_NAME,


### PR DESCRIPTION
## Problem

Open Science only started its local-only Crashpad reporter on Windows. Linux and macOS therefore could terminate after a native main, renderer, or utility-process failure without leaving the local dump needed to distinguish the failing process. This matches the missing Linux dump coverage reported in #1207.

The OpenCode ACP process remains stdio-coupled to the Electron main process, so its disappearance after the main process exits is not treated here as evidence of a second independent crash.

## Proposed change

- Start the existing local-only Crashpad reporter on Windows, macOS, and Linux before any renderer is created.
- Keep uploads and compression disabled exactly as before.
- Cover all three supported desktop platforms plus an unsupported-platform fallback in the focused unit test.
- Update startup comments to describe the cross-platform diagnostic contract.

## Scope and non-goals

- No claim that the original native crash mechanism is fixed; the next crash dump is still needed for root-cause analysis.
- No changes to ACP lifecycle, Session recovery, UI interactions, database schema, data model, or enum values.
- No historical migration; previously missing crash dumps cannot be reconstructed.
- No automatic upload and no custom dump-retention policy.

Persistence impact: future Linux and macOS native crashes may create local minidumps in Electron's Crashpad/crashDumps directory. This extends the existing Windows behavior and does not send data off-device.

Refs #1207

## Acceptance criteria and validation

Checks below were run after the last material edit:

- Desktop-platform Crashpad gating -> `npm test -- src/main/crash-diagnostics.test.ts` -> passed (1 file, 5 tests).
- Linted source and tests -> `npm run lint` -> passed with 0 errors; 10 unrelated pre-existing warnings remain outside this diff.
- Node type safety -> `npm run typecheck:node` -> locally blocked because the existing workspace installation lacks `sharp`; errors are confined to unchanged `src/main/uploads/attachment-media*.ts` files.
- Patch hygiene -> `git diff --check` -> passed.

The module manifest does not expose a `test:module` id for crash diagnostics, so the focused project-owned test was used instead of the full portable suite, per maintainer direction. PR CI remains authoritative for Node type checking and full/platform coverage.

## Review focus

- Whether the explicit `win32` / `darwin` / `linux` allowlist matches the intended Electron desktop support boundary.
- Whether retaining the existing `uploadToServer: false` behavior is sufficient for local-only crash-data privacy.