### PR TITLE
fix(host-capabilities): require workspace for viewImage projection

### DIFF
--- a/src/main/notebook/local-rpc-server.capabilities.test.ts
+++ b/src/main/notebook/local-rpc-server.capabilities.test.ts
@@ -147,6 +147,100 @@ describe('capabilitiesCall RPC', () => {
     })
   })
 
+  it('does not advertise host.viewImage without a trusted Session workspace', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostViewImage: {
+        isAvailable: async () => true,
+        stage: async () => ({}) as never,
+        complete: async () => [],
+        discard: () => {},
+        discardSession: () => {},
+        shutdown: () => {}
+      }
+    })
+    const connection = await server.issueControlConnection(
+      'trusted-session',
+      'trusted-project',
+      'root-frame-trusted-session'
+    )
+    const endInvocation = connection.beginControlInvocation({
+      turnId: 'turn-1',
+      controlInvocationGeneration: 1,
+      toolInvocationId: 'tool-1'
+    })
+
+    await expect(callCapabilities(connection)).resolves.toMatchObject({
+      payload: { result: { viewImage: false } }
+    })
+
+    endInvocation()
+  })
+
+  it('advertises host.viewImage with an active invocation and trusted Session workspace', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostViewImage: {
+        isAvailable: async () => true,
+        stage: async () => ({}) as never,
+        complete: async () => [],
+        discard: () => {},
+        discardSession: () => {},
+        shutdown: () => {}
+      }
+    })
+    const connection = await server.issueControlConnection(
+      'trusted-session',
+      'trusted-project',
+      'root-frame-trusted-session',
+      { role: 'main' },
+      '/trusted-workspace'
+    )
+    const endInvocation = connection.beginControlInvocation({
+      turnId: 'turn-1',
+      controlInvocationGeneration: 1,
+      toolInvocationId: 'tool-1'
+    })
+
+    await expect(callCapabilities(connection)).resolves.toMatchObject({
+      payload: { result: { viewImage: true } }
+    })
+
+    endInvocation()
+  })
+
+  it('does not advertise host.viewImage when its certified visual route is unavailable', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostViewImage: {
+        isAvailable: async () => false,
+        stage: async () => ({}) as never,
+        complete: async () => [],
+        discard: () => {},
+        discardSession: () => {},
+        shutdown: () => {}
+      }
+    })
+    const connection = await server.issueControlConnection(
+      'trusted-session',
+      'trusted-project',
+      'root-frame-trusted-session',
+      { role: 'main' },
+      '/trusted-workspace'
+    )
+    const endInvocation = connection.beginControlInvocation({
+      turnId: 'turn-1',
+      controlInvocationGeneration: 1,
+      toolInvocationId: 'tool-1'
+    })
+
+    await expect(callCapabilities(connection)).resolves.toMatchObject({
+      payload: { result: { viewImage: false } }
+    })
+
+    endInvocation()
+  })
+
   it('rejects bootstrap, invalid, and released tokens instead of returning an all-false bitmap', async () => {
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
       transport: 'tcp'

--- a/src/main/notebook/local-rpc-server.capabilities.test.ts
+++ b/src/main/notebook/local-rpc-server.capabilities.test.ts
@@ -23,6 +23,21 @@ const callCapabilities = async (
   }
 }
 
+const callHostSdkHelp = async (
+  connection: RpcConnection,
+  query: string
+): Promise<{ response: Response; payload: Record<string, unknown> }> => {
+  const response = await fetch(connection.endpoint, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${connection.token}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ method: 'hostSdkHelp', params: { query } })
+  })
+  return {
+    response,
+    payload: (await response.json()) as Record<string, unknown>
+  }
+}
+
 let server: NotebookLocalRpcServer | undefined
 
 afterEach(async () => {
@@ -172,6 +187,36 @@ describe('capabilitiesCall RPC', () => {
 
     await expect(callCapabilities(connection)).resolves.toMatchObject({
       payload: { result: { viewImage: false } }
+    })
+
+    endInvocation()
+  })
+
+  it('reports host.viewImage unavailable from host.help without a trusted Session workspace', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostViewImage: {
+        isAvailable: async () => true,
+        stage: async () => ({}) as never,
+        complete: async () => [],
+        discard: () => {},
+        discardSession: () => {},
+        shutdown: () => {}
+      }
+    })
+    const connection = await server.issueControlConnection(
+      'trusted-session',
+      'trusted-project',
+      'root-frame-trusted-session'
+    )
+    const endInvocation = connection.beginControlInvocation({
+      turnId: 'turn-1',
+      controlInvocationGeneration: 1,
+      toolInvocationId: 'tool-1'
+    })
+
+    await expect(callHostSdkHelp(connection, 'viewImage')).resolves.toMatchObject({
+      payload: { result: { availability: { status: 'unavailable' } } }
     })
 
     endInvocation()

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -1363,6 +1363,7 @@ class NotebookLocalRpcServer {
               viewImage:
                 sessionBinding.isControl === true &&
                 Boolean(sessionBinding.activeControlInvocation) &&
+                Boolean(sessionBinding.workspaceCwd) &&
                 allows('viewImageCall') &&
                 Boolean(this.hostViewImage) &&
                 (await this.hostViewImage!.isAvailable({ sessionId: sessionBinding.sessionId }))

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -1475,6 +1475,7 @@ class NotebookLocalRpcServer {
                       view_image_available:
                         sessionBinding.isControl === true &&
                         Boolean(sessionBinding.activeControlInvocation) &&
+                        Boolean(sessionBinding.workspaceCwd) &&
                         (!sessionBinding.allowedMethods ||
                           sessionBinding.allowedMethods.has('viewImageCall')) &&
                         Boolean(this.hostViewImage) &&


### PR DESCRIPTION
## Problem

`capabilitiesCall` could advertise `host.viewImage` even though `viewImageCall` rejects the same control capability when it lacks a trusted Session workspace.

## Proposed change

Require `workspaceCwd` in the `viewImage` readiness projection, matching the call-time guard.

## Scope and non-goals

Only the local RPC capability projection and its focused tests change. No capability schemas, `host.help`, JS adapter, skills, architecture, data model, or UI changes are included.

## Acceptance criteria and validation

- Active invocation + available visual service + no workspace projects `viewImage: false`.
- Adding a trusted workspace projects `viewImage: true`.
- An unavailable visual route remains fail-closed.

Checks run after the final edit:

- `npm test -- src/main/notebook/local-rpc-server.capabilities.test.ts`
- `npm run typecheck:node`
- `npm run lint`
- `npm test`

## Review focus

Confirm the readiness projection now mirrors the trusted workspace requirement enforced by `viewImageCall`.