### PR TITLE
fix(host-capabilities): allow additive capability fields

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -979,17 +979,27 @@ async function hostMcp(server, method, args = undefined, kwargs = undefined) {
   return body.result
 }
 
-const HOST_CAPABILITY_NAMES = [
-  'mcp',
-  'compute',
-  'agents',
-  'skills',
-  'artifacts',
-  'lineage',
-  'frames',
-  'llm',
-  'viewImage'
-]
+const HOST_CAPABILITY_MAX_FIELDS = 64
+const HOST_CAPABILITY_MAX_KEY_LENGTH = 64
+const HOST_CAPABILITY_KEY_PATTERN = /^[a-z][a-zA-Z0-9]*$/
+const HOST_CAPABILITY_DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+function isValidHostCapabilityProjection(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  if (Object.getPrototypeOf(value) !== Object.prototype) return false
+
+  const entries = Object.entries(value)
+  return (
+    entries.length <= HOST_CAPABILITY_MAX_FIELDS &&
+    entries.every(
+      ([name, enabled]) =>
+        name.length <= HOST_CAPABILITY_MAX_KEY_LENGTH &&
+        HOST_CAPABILITY_KEY_PATTERN.test(name) &&
+        !HOST_CAPABILITY_DANGEROUS_KEYS.has(name) &&
+        typeof enabled === 'boolean'
+    )
+  )
+}
 
 async function hostCapabilities(...args) {
   if (args.length !== 0) throw new TypeError('host.capabilities accepts no arguments')
@@ -1004,18 +1014,10 @@ async function hostCapabilities(...args) {
     throw new Error(body.error || 'host.capabilities HTTP ' + res.status)
   }
   const result = body.result
-  if (
-    !result ||
-    typeof result !== 'object' ||
-    Array.isArray(result) ||
-    Object.keys(result).length !== HOST_CAPABILITY_NAMES.length ||
-    HOST_CAPABILITY_NAMES.some((name) => typeof result[name] !== 'boolean')
-  ) {
+  if (!isValidHostCapabilityProjection(result)) {
     throw new Error('host.capabilities returned an invalid capability projection')
   }
-  return Object.freeze(
-    Object.fromEntries(HOST_CAPABILITY_NAMES.map((name) => [name, result[name]]))
-  )
+  return Object.freeze(Object.fromEntries(Object.entries(result)))
 }
 
 const HOST_LLM_STOP_REASONS = new Set([

--- a/resources/skills/self-awareness/SKILL.md
+++ b/resources/skills/self-awareness/SKILL.md
@@ -14,7 +14,7 @@ JavaScript control REPL; Python and R data kernels do not receive it.
 const caps = await host.capabilities()
 ```
 
-The v1 result contains exactly nine boolean keys:
+The current v1 known keys are nine booleans:
 
 - `mcp` gates `host.mcp` connector calls.
 - `compute` gates the `host.compute` namespace.
@@ -27,7 +27,10 @@ The v1 result contains exactly nine boolean keys:
 - `viewImage` gates transient `host.viewImage(source, options?)` image attachment from an Artifact or
   Upload Version in the current Project, or a current-Session relative workspace path.
 
-Interpret the result narrowly:
+Newer runtimes may return additive boolean keys. Do not assume their meaning until their matching
+Skill documents them. Older runtimes can omit known keys.
+
+Interpret every key narrowly:
 
 - `true` means the current session capability authorizes the namespace and the application has its
   handler configured. It does not mean a resource exists, approval is unnecessary, or a call will

--- a/resources/skills/self-awareness/SKILL.md
+++ b/resources/skills/self-awareness/SKILL.md
@@ -14,7 +14,7 @@ JavaScript control REPL; Python and R data kernels do not receive it.
 const caps = await host.capabilities()
 ```
 
-The current v1 known keys are nine booleans:
+The current v1 known result contains exactly nine boolean keys:
 
 - `mcp` gates `host.mcp` connector calls.
 - `compute` gates the `host.compute` namespace.

--- a/src/main/notebook/repl-loop.integration.test.ts
+++ b/src/main/notebook/repl-loop.integration.test.ts
@@ -1024,6 +1024,19 @@ describe('repl_loop local RPC transport', () => {
         const result =
           requests.length === 3
             ? {
+                mcp: true,
+                compute: true,
+                agents: true,
+                skills: true,
+                artifacts: true,
+                lineage: true,
+                frames: true,
+                llm: true,
+                viewImage: true,
+                'not-valid': true
+              }
+            : requests.length === 4
+              ? {
                 mcp: 'yes',
                 compute: true,
                 agents: true,
@@ -1034,6 +1047,17 @@ describe('repl_loop local RPC transport', () => {
                 llm: true,
                 viewImage: true
               }
+              : requests.length === 2
+                ? {
+                    mcp: true,
+                    compute: true,
+                    agents: true,
+                    skills: true,
+                    artifacts: true,
+                    lineage: true,
+                    frames: true,
+                    llm: true
+                  }
             : {
                 mcp: true,
                 compute: true,
@@ -1043,7 +1067,8 @@ describe('repl_loop local RPC transport', () => {
                 lineage: true,
                 frames: true,
                 llm: true,
-                viewImage: true
+                viewImage: true,
+                experimentalFeature: true
               }
         response
           .writeHead(200, { 'content-type': 'application/json' })
@@ -1064,7 +1089,8 @@ describe('repl_loop local RPC transport', () => {
       const projection = await send(
         'const first = await host.capabilities(); first.mcp = false; ' +
           'const second = await host.capabilities(); ' +
-          'return JSON.stringify({ first, second, frozen: Object.isFrozen(first), same: first === second })'
+          'return JSON.stringify({ first, second, frozen: Object.isFrozen(first), same: first === second, ' +
+          "missingKnownKey: Object.hasOwn(second, 'viewImage') })"
       )
       expect(projection.error).toBeNull()
       expect(JSON.parse(projection.result ?? '{}')).toEqual({
@@ -1077,7 +1103,8 @@ describe('repl_loop local RPC transport', () => {
           lineage: true,
           frames: true,
           llm: true,
-          viewImage: true
+          viewImage: true,
+          experimentalFeature: true
         },
         second: {
           mcp: true,
@@ -1087,11 +1114,11 @@ describe('repl_loop local RPC transport', () => {
           artifacts: true,
           lineage: true,
           frames: true,
-          llm: true,
-          viewImage: true
+          llm: true
         },
         frozen: true,
-        same: false
+        same: false,
+        missingKnownKey: false
       })
       expect(requests).toEqual([
         { method: 'capabilitiesCall', params: {} },
@@ -1105,14 +1132,23 @@ describe('repl_loop local RPC transport', () => {
       expect(extraArgument.result).toBe('TypeError: host.capabilities accepts no arguments')
       expect(requests).toHaveLength(2)
 
-      const invalidProjection = await send(
+      const invalidKey = await send(
         "try { await host.capabilities(); return 'no error' } " +
           'catch (error) { return error.message }'
       )
-      expect(invalidProjection.result).toBe(
+      expect(invalidKey.result).toBe(
         'host.capabilities returned an invalid capability projection'
       )
       expect(requests).toHaveLength(3)
+
+      const nonBoolean = await send(
+        "try { await host.capabilities(); return 'no error' } " +
+          'catch (error) { return error.message }'
+      )
+      expect(nonBoolean.result).toBe(
+        'host.capabilities returned an invalid capability projection'
+      )
+      expect(requests).toHaveLength(4)
     } finally {
       child.kill()
       await new Promise<void>((resolve, reject) =>

--- a/src/main/notebook/repl-loop.integration.test.ts
+++ b/src/main/notebook/repl-loop.integration.test.ts
@@ -1037,16 +1037,16 @@ describe('repl_loop local RPC transport', () => {
               }
             : requests.length === 4
               ? {
-                mcp: 'yes',
-                compute: true,
-                agents: true,
-                skills: true,
-                artifacts: true,
-                lineage: true,
-                frames: true,
-                llm: true,
-                viewImage: true
-              }
+                  mcp: 'yes',
+                  compute: true,
+                  agents: true,
+                  skills: true,
+                  artifacts: true,
+                  lineage: true,
+                  frames: true,
+                  llm: true,
+                  viewImage: true
+                }
               : requests.length === 2
                 ? {
                     mcp: true,
@@ -1058,18 +1058,18 @@ describe('repl_loop local RPC transport', () => {
                     frames: true,
                     llm: true
                   }
-            : {
-                mcp: true,
-                compute: true,
-                agents: true,
-                skills: true,
-                artifacts: true,
-                lineage: true,
-                frames: true,
-                llm: true,
-                viewImage: true,
-                experimentalFeature: true
-              }
+                : {
+                    mcp: true,
+                    compute: true,
+                    agents: true,
+                    skills: true,
+                    artifacts: true,
+                    lineage: true,
+                    frames: true,
+                    llm: true,
+                    viewImage: true,
+                    experimentalFeature: true
+                  }
         response
           .writeHead(200, { 'content-type': 'application/json' })
           .end(JSON.stringify({ result }))
@@ -1136,18 +1136,14 @@ describe('repl_loop local RPC transport', () => {
         "try { await host.capabilities(); return 'no error' } " +
           'catch (error) { return error.message }'
       )
-      expect(invalidKey.result).toBe(
-        'host.capabilities returned an invalid capability projection'
-      )
+      expect(invalidKey.result).toBe('host.capabilities returned an invalid capability projection')
       expect(requests).toHaveLength(3)
 
       const nonBoolean = await send(
         "try { await host.capabilities(); return 'no error' } " +
           'catch (error) { return error.message }'
       )
-      expect(nonBoolean.result).toBe(
-        'host.capabilities returned an invalid capability projection'
-      )
+      expect(nonBoolean.result).toBe('host.capabilities returned an invalid capability projection')
       expect(requests).toHaveLength(4)
     } finally {
       child.kill()


### PR DESCRIPTION
## Problem

The JavaScript control-REPL adapter required an exact nine-key capability bitmap, preventing newer runtimes from returning additive capability fields and older runtimes from omitting later known fields.

## Proposed change

Validate a bounded plain-object boolean map with lowerCamelCase keys, reject invalid or dangerous keys, and return a fresh frozen copy that preserves valid additive fields. The Self-awareness Skill now describes the nine current v1 known keys, additive fields, missing keys, and `=== true` feature gating.

## Scope and non-goals

Only the control-REPL adapter, its integration contract, and the public Self-awareness Skill changed. This does not alter the local-RPC projection, `host.help`, the main-process capability catalog, architecture, persistence, data models, or UI.

## Acceptance criteria and validation

- additive, missing-known, invalid-key, non-boolean, fresh, and frozen projection behavior → `RUN_KERNEL=1 npm test -- src/main/notebook/repl-loop.integration.test.ts` → pass
- Node process type surface → `npm run typecheck:node` → pass
- lint → `npm run lint` → pass
- portable suite after final edit → `npm test` → pass

All listed checks ran after the final material edit. The adapter is limited to the JavaScript control REPL; no ACP framework, launcher, model, or platform-specific behavior changed. Existing local-RPC authentication and fail-closed error handling remain unchanged.

## Review focus

Confirm that the adapter validates only the transport response and preserves the main-process capability catalog unchanged.