### PR TITLE
fix(notebook): clarify viewImage execution paths

### DIFF
--- a/resources/skills/self-awareness/SKILL.md
+++ b/resources/skills/self-awareness/SKILL.md
@@ -25,7 +25,8 @@ The current project-native result contains 17 known boolean keys:
 - `frames` gates the read-only `host.frames` namespace.
 - `llm` gates `host.llm` one-shot, tool-less inference.
 - `viewImage` gates transient `host.viewImage(source, options?)` image attachment from an Artifact or
-  Upload Version in the current Project, or a current-Session relative workspace path.
+  Upload Version in the current Project, or a path relative to the current execution workspace. For
+  a generated file, pass the same relative path used to save it.
 - `delegate`, `children`, `collect`, `stopChild`, and `resolveMessage` are Main/root-only delegated
   work operations.
 - `sendFrameMessage` and `messageReceipt` are available to Main/root and Delegate agents when their

--- a/src/main/host-sdk/help.test.ts
+++ b/src/main/host-sdk/help.test.ts
@@ -85,9 +85,11 @@ describe('Host SDK help', () => {
       call_forms: [{ signature: 'await host.viewImage(source, options?)' }]
     })
     if (help.kind !== 'operation') throw new Error('expected operation help')
-    expect(JSON.stringify(help.request)).toMatch(
-      /Artifact or Upload Version in the current Project/u
-    )
+    const request = JSON.stringify(help.request)
+    expect(request).toMatch(/Artifact or Upload Version in the current Project/u)
+    expect(request).toMatch(/path relative to the current execution workspace/u)
+    expect(request).toMatch(/same relative path used to save it/u)
+    expect(request).not.toMatch(/Notebook/u)
   })
 
   it('keeps the published REPL subagent surface and Help registry in lockstep', () => {

--- a/src/main/host-sdk/help.ts
+++ b/src/main/host-sdk/help.ts
@@ -681,7 +681,7 @@ const VIEW_IMAGE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
         type: '{ versionId: string } | { path: string }',
         required: true,
         description:
-          'Artifact or Upload Version in the current Project, or current-Session relative workspace path.'
+          'Artifact or Upload Version in the current Project, or a path relative to the current execution workspace. For a generated file, pass the same relative path used to save it.'
       }
     ]
   },

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1721,13 +1721,13 @@ const createApplicationModules = async (
   // server's (lazily-started) connection for host.mcp() env injection — wire the second half here to
   // avoid a construction cycle.
   notebookService.setMcpRpcConnectionResolver(
-    ({ sessionId, projectId, agentFrameId, attemptId, workspaceCwd }) =>
+    ({ sessionId, projectId, agentFrameId, attemptId, executionCwd }) =>
       notebookRpcServer.issueControlConnection(
         sessionId,
         projectId,
         agentFrameId,
         attemptId ? { role: 'delegate', attemptId } : { role: 'main' },
-        workspaceCwd
+        executionCwd
       )
   )
   // The renderer's approval card responds here; the broker resolves the held connector call.

--- a/src/main/notebook/execution-owner.ts
+++ b/src/main/notebook/execution-owner.ts
@@ -71,7 +71,7 @@ type McpRpcConnectionBinding = {
   projectId: string
   agentFrameId: string
   attemptId?: string
-  workspaceCwd: string
+  executionCwd: string
 }
 type McpRpcConnectionResolver = (
   binding: McpRpcConnectionBinding

--- a/src/main/notebook/host-view-image-service.test.ts
+++ b/src/main/notebook/host-view-image-service.test.ts
@@ -121,12 +121,12 @@ const harness = (
 }
 
 const context = (
-  workspaceCwd = '/workspace',
+  executionCwd = '/workspace',
   controlInvocationId = 'run-1'
 ): HostViewImageContext => ({
   projectId: 'project-a',
   sessionId: 'calling-session',
-  workspaceCwd,
+  executionCwd,
   controlInvocationId,
   signal: new AbortController().signal
 })
@@ -239,13 +239,17 @@ describe('HostViewImageService', () => {
     ).rejects.toThrow(/ambiguous/u)
   })
 
-  it('accepts only an existing real workspace file contained by the trusted Session root', async () => {
+  it('accepts a code-relative file and rejects application-owned sibling paths', async () => {
     root = await mkdtemp(join(tmpdir(), 'host-view-image-'))
-    const workspace = join(root, 'workspace')
+    const workspace = join(root, 'data')
+    const handoff = join(root, 'handoff')
     const outside = join(root, 'outside')
     await mkdir(join(workspace, 'results'), { recursive: true })
+    await mkdir(handoff)
     await mkdir(outside)
     await writeFile(join(workspace, 'results', 'image.png'), 'image')
+    await writeFile(join(handoff, 'connector.png'), 'handoff')
+    await writeFile(join(root, 'run.json'), '{}')
     await writeFile(join(outside, 'secret.png'), 'secret')
     await symlink(join(outside, 'secret.png'), join(workspace, 'escape.png'))
     const h = harness()
@@ -263,6 +267,9 @@ describe('HostViewImageService', () => {
     for (const path of [
       '../outside/secret.png',
       '..\\outside\\secret.png',
+      '../handoff/connector.png',
+      '..\\handoff\\connector.png',
+      '../run.json',
       join(outside, 'secret.png'),
       'C:\\outside\\secret.png',
       '\\\\server\\share\\secret.png',

--- a/src/main/notebook/host-view-image-service.ts
+++ b/src/main/notebook/host-view-image-service.ts
@@ -28,7 +28,7 @@ export type HostViewImageBackend = Readonly<{
 export type HostViewImageContext = Readonly<{
   projectId: string
   sessionId: string
-  workspaceCwd: string
+  executionCwd: string
   controlInvocationId: string
   signal: AbortSignal
 }>
@@ -207,7 +207,7 @@ const isContainedPath = (root: string, candidate: string): boolean => {
   return child === '' || (child !== '..' && !child.startsWith(`..${sep}`) && !isAbsolute(child))
 }
 
-const resolveWorkspaceSource = async (workspaceCwd: string, path: string): Promise<string> => {
+const resolveWorkspaceSource = async (executionCwd: string, path: string): Promise<string> => {
   const crossPlatformPath = path.replaceAll('\\', '/')
   if (
     path.includes('\0') ||
@@ -218,20 +218,22 @@ const resolveWorkspaceSource = async (workspaceCwd: string, path: string): Promi
     crossPlatformPath.split('/').includes('..')
   ) {
     throw new HostViewImageError(
-      'source.path must be relative and stay inside the Session workspace.'
+      'source.path must be relative and stay inside the current execution workspace.'
     )
   }
   try {
-    const workspaceRoot = await realpath(workspaceCwd)
+    const workspaceRoot = await realpath(executionCwd)
     const lexicalTarget = resolve(workspaceRoot, path)
     if (!isContainedPath(workspaceRoot, lexicalTarget)) {
       throw new HostViewImageError(
-        'source.path must be relative and stay inside the Session workspace.'
+        'source.path must be relative and stay inside the current execution workspace.'
       )
     }
     const target = await realpath(lexicalTarget)
     if (!isContainedPath(workspaceRoot, target)) {
-      throw new HostViewImageError('source.path escapes the Session workspace through a symlink.')
+      throw new HostViewImageError(
+        'source.path escapes the current execution workspace through a symlink.'
+      )
     }
     if (!(await stat(target)).isFile()) {
       throw new HostViewImageError('source.path must name a regular file.')
@@ -354,7 +356,7 @@ export class HostViewImageService {
       let sourceKind: HostViewImageResult['sourceKind']
       let expectedCanonicalPath: string | undefined
       if ('path' in source) {
-        filePath = await resolveWorkspaceSource(context.workspaceCwd, source.path)
+        filePath = await resolveWorkspaceSource(context.executionCwd, source.path)
         expectedCanonicalPath = filePath
         sourceKind = 'workspacePath'
       } else {

--- a/src/main/notebook/local-rpc-server.capabilities.test.ts
+++ b/src/main/notebook/local-rpc-server.capabilities.test.ts
@@ -196,7 +196,7 @@ describe('capabilitiesCall RPC', () => {
     })
   })
 
-  it('does not advertise host.viewImage without a trusted Session workspace', async () => {
+  it('does not advertise host.viewImage without a trusted execution workspace', async () => {
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
       transport: 'tcp',
       hostViewImage: {
@@ -226,7 +226,7 @@ describe('capabilitiesCall RPC', () => {
     endInvocation()
   })
 
-  it('reports host.viewImage unavailable from host.help without a trusted Session workspace', async () => {
+  it('reports host.viewImage unavailable from host.help without a trusted execution workspace', async () => {
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
       transport: 'tcp',
       hostViewImage: {
@@ -256,7 +256,7 @@ describe('capabilitiesCall RPC', () => {
     endInvocation()
   })
 
-  it('advertises host.viewImage with an active invocation and trusted Session workspace', async () => {
+  it('advertises host.viewImage with an active invocation and trusted execution workspace', async () => {
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
       transport: 'tcp',
       hostViewImage: {

--- a/src/main/notebook/local-rpc-server.test.ts
+++ b/src/main/notebook/local-rpc-server.test.ts
@@ -77,7 +77,7 @@ afterEach(async () => {
 })
 
 describe('notebook local RPC server', () => {
-  it('binds viewImage to the trusted active control invocation and workspace', async () => {
+  it('binds viewImage to the trusted active control invocation and execution workspace', async () => {
     const stage = vi.fn(async (_source, _options, trusted) => trusted)
     const isAvailable = vi.fn(async () => true)
     const discard = vi.fn()
@@ -170,7 +170,7 @@ describe('notebook local RPC server', () => {
         result: {
           projectId: 'project-1',
           sessionId: 'session-1',
-          workspaceCwd: '/trusted/workspace',
+          executionCwd: '/trusted/workspace',
           controlInvocationId: 'run-1',
           signal: {}
         }
@@ -181,7 +181,7 @@ describe('notebook local RPC server', () => {
         expect.objectContaining({
           projectId: 'project-1',
           sessionId: 'session-1',
-          workspaceCwd: '/trusted/workspace',
+          executionCwd: '/trusted/workspace',
           controlInvocationId: 'run-1'
         })
       )

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -250,7 +250,7 @@ type NotebookRpcSessionBinding = {
   delegatedWorkAttemptId?: string
   allowedMethods?: ReadonlySet<string>
   activeControlInvocation?: TrustedControlInvocationIdentity
-  workspaceCwd?: string
+  executionCwd?: string
   isControl?: true
   delegatedNotebook?: {
     attemptId: string
@@ -1004,7 +1004,7 @@ class NotebookLocalRpcServer {
       role: 'main' | 'delegate'
       attemptId?: string
     }> = { role: 'main' },
-    workspaceCwd?: string
+    executionCwd?: string
   ): Promise<
     NotebookRpcConnection & {
       beginControlInvocation(context: TrustedControlInvocationIdentity): () => void
@@ -1036,7 +1036,7 @@ class NotebookLocalRpcServer {
           ? DELEGATED_CONTROL_RPC_METHODS
           : CONTROL_RPC_METHODS,
       isControl: true,
-      ...(workspaceCwd ? { workspaceCwd } : {})
+      ...(executionCwd ? { executionCwd } : {})
     }
     this.sessionRpcCapabilities.set(token, binding)
     const ownedControlInvocationIds = new Set<string>()
@@ -1215,8 +1215,8 @@ class NotebookLocalRpcServer {
     const callerRole = sessionBinding.delegatedWorkRole ?? 'main'
     const hasDelegatedIdentity = Boolean(
       sessionBinding.projectId &&
-        sessionBinding.agentFrameId &&
-        (callerRole !== 'delegate' || sessionBinding.delegatedWorkAttemptId)
+      sessionBinding.agentFrameId &&
+      (callerRole !== 'delegate' || sessionBinding.delegatedWorkAttemptId)
     )
     const hasDelegatedOrigin = sessionBinding.delegatedNotebook
       ? Boolean(sessionBinding.delegatedNotebook.provenanceContext.promptMessageId)
@@ -1233,7 +1233,7 @@ class NotebookLocalRpcServer {
       callerRole,
       isControl: Boolean(sessionBinding.isControl),
       hasActiveControlInvocation: Boolean(sessionBinding.activeControlInvocation),
-      hasWorkspace: Boolean(sessionBinding.workspaceCwd),
+      hasWorkspace: Boolean(sessionBinding.executionCwd),
       allowsMethod,
       delegatedWorkReady,
       services: {
@@ -1369,8 +1369,8 @@ class NotebookLocalRpcServer {
                 'host.viewImage requires an active trusted control invocation.'
               )
             }
-            if (!sessionBinding.workspaceCwd) {
-              throw new RpcHttpError(403, 'host.viewImage requires a trusted Session workspace.')
+            if (!sessionBinding.executionCwd) {
+              throw new RpcHttpError(403, 'host.viewImage requires a trusted execution workspace.')
             }
             if (Object.keys(params).some((key) => key !== 'source' && key !== 'options')) {
               throw new Error('host.viewImage RPC params are invalid.')
@@ -1448,7 +1448,7 @@ class NotebookLocalRpcServer {
             ...(sessionBinding.projectId ? { projectId: sessionBinding.projectId } : {}),
             ...(method === 'viewImageCall'
               ? {
-                  workspaceCwd: sessionBinding.workspaceCwd,
+                  executionCwd: sessionBinding.executionCwd,
                   controlInvocationId: sessionBinding.activeControlInvocation?.toolInvocationId
                 }
               : {}),
@@ -1787,16 +1787,16 @@ class NotebookLocalRpcServer {
       if (!this.hostViewImage) throw new Error('host.viewImage is not configured.')
       const projectId = typeof params.projectId === 'string' ? params.projectId : ''
       const sessionId = typeof params.sessionId === 'string' ? params.sessionId : ''
-      const workspaceCwd = typeof params.workspaceCwd === 'string' ? params.workspaceCwd : ''
+      const executionCwd = typeof params.executionCwd === 'string' ? params.executionCwd : ''
       const controlInvocationId =
         typeof params.controlInvocationId === 'string' ? params.controlInvocationId : ''
-      if (!projectId || !sessionId || !workspaceCwd || !controlInvocationId) {
+      if (!projectId || !sessionId || !executionCwd || !controlInvocationId) {
         throw new RpcHttpError(403, 'host.viewImage trusted capability identity is incomplete.')
       }
       return this.hostViewImage.stage(params.source, params.options, {
         projectId,
         sessionId,
-        workspaceCwd,
+        executionCwd,
         controlInvocationId,
         signal
       })

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -1948,7 +1948,7 @@ describe('notebook runtime service', () => {
       sessionId: 'session-1',
       projectId: 'default-project',
       agentFrameId: 'root-frame-session-1',
-      workspaceCwd: join(root, 'notebooks', 'default-project', 'session-1', 'data')
+      executionCwd: join(root, 'notebooks', 'default-project', 'session-1', 'data')
     })
     expect(executions.map((request) => request.mcpRpcToken)).toEqual([
       'session-token',
@@ -2144,7 +2144,7 @@ describe('notebook runtime service', () => {
       projectId: 'project-1',
       agentFrameId: 'child-frame',
       attemptId: 'attempt-1',
-      workspaceCwd: join(
+      executionCwd: join(
         root,
         'notebooks',
         'project-1',
@@ -2159,7 +2159,7 @@ describe('notebook runtime service', () => {
       projectId: 'project-1',
       agentFrameId: 'child-frame',
       attemptId: 'attempt-2',
-      workspaceCwd: join(
+      executionCwd: join(
         root,
         'notebooks',
         'project-1',

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -147,7 +147,7 @@ type McpRpcConnectionBinding = {
   projectId: string
   agentFrameId: string
   attemptId?: string
-  workspaceCwd: string
+  executionCwd: string
 }
 
 type NotebookRuntimeServiceOptions = ProjectIdScope & {

--- a/src/main/notebook/session-aggregate.ts
+++ b/src/main/notebook/session-aggregate.ts
@@ -516,7 +516,7 @@ export class NotebookSessionAggregate<
           projectId: string
           agentFrameId: string
           attemptId?: string
-          workspaceCwd: string
+          executionCwd: string
         }) => Promise<NotebookSessionMcpRpcConnection>)
       | undefined
   ): Promise<NotebookSessionMcpRpcConnection | undefined> {
@@ -528,7 +528,7 @@ export class NotebookSessionAggregate<
         sessionId: this.sessionId,
         projectId: this.projectId,
         agentFrameId: lane.agentFrameId,
-        workspaceCwd: this.dataRoot,
+        executionCwd: this.dataRoot,
         ...(lane.attemptId ? { attemptId: lane.attemptId } : {})
       })
       return this.mcpRpcConnection


### PR DESCRIPTION
## Problem

`host.viewImage({ path })` resolves a generated file relative to the shared execution workspace used by Python, R, and REPL. The control capability called that root `workspaceCwd`, even though the Agent-facing Notebook MCP already uses `workspaceCwd` for the durable Session cwd.

That naming collision led the previous revision of this PR to bind the capability to `notebookSessionRoot`. The change made `data/...` happen to resolve, but also widened path authority to application-owned siblings such as `handoff`, `run.json`, caches, and Frame storage.

## Proposed change

- keep the control capability scoped to the shared execution `dataRoot`
- rename the internal control binding from `workspaceCwd` to `executionCwd`
- keep the public `host.viewImage` JavaScript contract camelCase and unchanged
- describe `{ path }` generically as relative to the current execution workspace, using the same relative path used to save a generated file
- verify code-relative paths succeed while application-owned sibling paths remain rejected

## Scope and non-goals

- no `data/...` or `handoff/...` magic-prefix resolution
- no ambient access to `notebookSessionRoot`
- no change to explicit `OPEN_SCIENCE_HANDOFF_DIR` cross-kernel transfer
- no change to Artifact or Upload `{ versionId }` resolution
- no new status or enum values
- no database, schema, `run.json`, or other persisted-data changes
- no historical-data migration or compatibility path required

## Acceptance criteria and validation

Checks run after the final rebase onto `origin/main` (`16ea4829`, v0.15.1):

- execution path authority and focused consumers -> `npm test -- src/main/notebook/host-view-image-service.test.ts src/main/notebook/runtime-service.test.ts src/main/notebook/local-rpc-server.test.ts src/main/notebook/local-rpc-server.capabilities.test.ts src/main/notebook/session-aggregate.test.ts src/main/notebook/e2e.certification.test.ts src/main/host-sdk/help.test.ts src/main/skills/self-awareness-skill.test.ts src/main/runtime-electron-wiring.test.ts` -> 8 files passed, 308 tests passed; one environment-gated file skipped (9 tests)
- Node process type safety -> `npm run typecheck:node` -> passed
- lint -> `npm run lint` -> 0 errors; 17 pre-existing Prettier warnings
- patch hygiene -> `git diff --check origin/main...HEAD` -> passed
- independent Standards review -> no findings
- independent Spec review -> no findings

The impact classifier selects the full suite because `resources/skills/self-awareness/SKILL.md` has no declared module owner. Per maintainer request, the complete local `npm test` suite was not run; exact-head PR CI is authoritative for the complete and platform lanes.

## Review focus

Please verify that the control capability receives `executionCwd = dataRoot` for both root and delegated lanes, while the Agent-facing Notebook MCP retains its separate durable Session `workspaceCwd` meaning.
