### PR TITLE
fix(skill): accept prepared replay after framework switch

### DIFF
--- a/src/main/acp/handler-workflows.test.ts
+++ b/src/main/acp/handler-workflows.test.ts
@@ -292,9 +292,10 @@ describe('ACP Save as skill workflow', () => {
     ['OpenCode', 'opencode', 'opencode-openai'],
     ['Codex Responses', 'codex', 'codex-responses'],
     ['Codex Bridge', 'codex', 'codex-bridge']
-  ])('binds context-reset hidden-turn provenance on %s', async (_name, frameworkId, modelRoute) => {
+  ])('accepts pending context-reset replay on %s', async (_name, frameworkId, modelRoute) => {
     const harness = createHarness((session) => {
       session.agentFrameworkId = frameworkId
+      session.pendingHistoryReplay = { kind: 'all' }
       session.conversationGraph = ensureConversationRuntimeSegment(session.conversationGraph!, {
         id: 'runtime-segment-after-context-reset',
         frameworkId,
@@ -318,6 +319,34 @@ describe('ACP Save as skill workflow', () => {
         })
       })
     )
+  })
+
+  it('rejects pending full replay without a fresh durable Runtime Segment', async () => {
+    const harness = createHarness((session) => {
+      session.pendingHistoryReplay = { kind: 'all' }
+    })
+
+    await expect(harness.workflows.saveAsSkill(harness.request)).rejects.toThrow(
+      'requires a prepared Session'
+    )
+    expect(harness.startContinuation).not.toHaveBeenCalled()
+  })
+
+  it('rejects pending interrupted-turn replay after a context reset', async () => {
+    const harness = createHarness((session) => {
+      session.pendingHistoryReplay = { kind: 'before-message', messageId: 'prompt-1' }
+      session.conversationGraph = ensureConversationRuntimeSegment(session.conversationGraph!, {
+        id: 'runtime-segment-after-context-reset',
+        frameworkId: 'claude-code',
+        startedAt: 3,
+        forceNew: true
+      })
+    })
+
+    await expect(harness.workflows.saveAsSkill(harness.request)).rejects.toThrow(
+      'requires a prepared Session'
+    )
+    expect(harness.startContinuation).not.toHaveBeenCalled()
   })
 
   it('rejects when the prepared control changes before runtime admission', async () => {

--- a/src/main/acp/handler-workflows.ts
+++ b/src/main/acp/handler-workflows.ts
@@ -122,14 +122,50 @@ const prepareSaveAsSkillContinuation = (
     session.resumeRecovery.promptMessageId === request.promptMessageId &&
     !session.pendingHistoryReplay &&
     runtime.hasLiveSession(session.projectId, session.id)
-  if (session.pendingHistoryReplay || (session.resumeRecovery && !recoveredPreparedControlRun)) {
+  const graph = session.conversationGraph
+  const frame = graph?.frames.find(({ id }) => id === graph.activeFrameId)
+  const activeBranchMessages =
+    graph && frame ? resolveMessageBranchPath(graph, frame.activeBranchId) : []
+  const controlMessage = activeBranchMessages.at(-1)
+  const previousMessage = activeBranchMessages.at(-2)
+  const preparedControlTurn = Boolean(
+    (preparedControlRun || recoveredPreparedControlRun) &&
+    controlMessage?.id === request.promptMessageId &&
+    controlMessage.role === 'user' &&
+    controlMessage.turnIntent === 'save-as-skill' &&
+    previousMessage?.role === 'agent' &&
+    previousMessage.status === 'complete'
+  )
+  const controlRuntimeSegment = graph?.runtimeSegments.find(
+    ({ id }) => id === controlMessage?.runtimeSegmentId
+  )
+  const latestFrameRuntimeSegment = graph?.runtimeSegments
+    .filter(({ agentFrameId }) => agentFrameId === frame?.id)
+    .at(-1)
+  const verifiedContextReset = Boolean(
+    controlMessage?.runtimeSegmentId &&
+    previousMessage?.runtimeSegmentId &&
+    controlMessage.runtimeSegmentId !== previousMessage.runtimeSegmentId &&
+    controlRuntimeSegment?.id === latestFrameRuntimeSegment?.id &&
+    controlRuntimeSegment?.agentFrameId === frame?.id &&
+    controlRuntimeSegment?.frameworkId === sessionBackend.framework.id &&
+    (!session.agentFrameworkId || session.agentFrameworkId === sessionBackend.framework.id)
+  )
+  const preparedContextResetReplay = Boolean(
+    preparedControlRun &&
+    preparedControlTurn &&
+    session.pendingHistoryReplay?.kind === 'all' &&
+    verifiedContextReset
+  )
+  if (
+    (session.pendingHistoryReplay && !preparedContextResetReplay) ||
+    (session.resumeRecovery && !recoveredPreparedControlRun)
+  ) {
     throw new Error('Save as skill requires a prepared Session.')
   }
   if (hasCurrentRunningDelegatedAttempt(session)) {
     throw new Error('Save as skill is unavailable while delegated work is still running.')
   }
-  const graph = session.conversationGraph
-  const frame = graph?.frames.find(({ id }) => id === graph.activeFrameId)
   if (
     !graph ||
     !frame ||
@@ -138,35 +174,9 @@ const prepareSaveAsSkillContinuation = (
   ) {
     throw new Error('Save as skill stopped because the active conversation branch changed.')
   }
-  const activeBranchMessages = resolveMessageBranchPath(graph, frame.activeBranchId)
-  const controlMessage = activeBranchMessages.at(-1)
-  const previousMessage = activeBranchMessages.at(-2)
-  if (
-    (!preparedControlRun && !recoveredPreparedControlRun) ||
-    controlMessage?.id !== request.promptMessageId ||
-    controlMessage.role !== 'user' ||
-    controlMessage.turnIntent !== 'save-as-skill' ||
-    previousMessage?.role !== 'agent' ||
-    previousMessage.status !== 'complete'
-  ) {
+  if (!preparedControlTurn) {
     throw new Error('Save as skill requires a prepared control turn.')
   }
-
-  const controlRuntimeSegment = graph.runtimeSegments.find(
-    ({ id }) => id === controlMessage.runtimeSegmentId
-  )
-  const latestFrameRuntimeSegment = graph.runtimeSegments
-    .filter(({ agentFrameId }) => agentFrameId === frame.id)
-    .at(-1)
-  const verifiedContextReset = Boolean(
-    controlMessage.runtimeSegmentId &&
-    previousMessage.runtimeSegmentId &&
-    controlMessage.runtimeSegmentId !== previousMessage.runtimeSegmentId &&
-    controlRuntimeSegment?.id === latestFrameRuntimeSegment?.id &&
-    controlRuntimeSegment?.agentFrameId === frame.id &&
-    controlRuntimeSegment?.frameworkId === sessionBackend.framework.id &&
-    (!session.agentFrameworkId || session.agentFrameworkId === sessionBackend.framework.id)
-  )
 
   const historyReplay = buildSessionHistoryReplay(
     activeBranchMessages.slice(0, -1).filter((message) => !isHiddenControlMessage(message)),


### PR DESCRIPTION
## Problem

When a main Session was created with Claude Code and the active framework was later switched to Codex, **Save as skill** failed with `Save as skill requires a prepared Session.`

Fresh provider adoption correctly created a new Runtime Segment and marked the Session for full history replay. The Save-as-skill workflow rejected that legitimate `pendingHistoryReplay: { kind: 'all' }` state before checking the durable control turn and new Runtime Segment.

## Proposed change

Accept a pending full replay only when all of the existing preparation evidence agrees:

- the requested hidden control Message owns the active run;
- the control Message is the active Branch tail after a completed Agent response;
- the control and previous Message belong to different Runtime Segments;
- the control Segment is the newest Segment for the active Agent Frame;
- the Segment framework and live Session backend match; and
- the pending replay is exactly the full-history `all` variant.

Stale full replay without a fresh Segment and interrupted-turn `before-message` replay remain fail-closed.

## Scope and non-goals

- No renderer behavior or renderer-facing contract changes.
- No provider resume-policy or provider adapter changes.
- No new state or enum values.
- No persistence schema, serialized format, migration, or write-path changes.
- Historical compatibility: no migration is required. Existing valid prepared Session state can now proceed; malformed or stale historical state remains rejected.
- Persistence impact: the fix only refines validation of the existing persisted conversation graph and `pendingHistoryReplay` fields.

## Acceptance criteria and validation

The checks below ran after the final material edit.

| Behavior | Framework / path | Command | Result |
| --- | --- | --- | --- |
| Prepared full replay is admitted and bound to the fresh Runtime Segment | Claude Code, OpenCode, Codex Responses, Codex Bridge | `npm test -- src/main/acp/handler-workflows.test.ts` | 26 passed |
| Renderer prepares and dispatches Save as skill with the current provider | Workspace runtime owner | Included in focused Test Impact Set below | 8 passed |
| Framework/backend incompatibility fresh-adopts without regressing provider lifecycle | Provider Session resumer | Included in focused Test Impact Set below | 20 passed |
| Electron IPC and shared application-command routes preserve the workflow contract | Electron IPC + application commands | Included in focused Test Impact Set below | 39 + 14 passed |
| Focused ACP/renderer Test Impact Set | Shared workflow and consumers | `npm test -- src/main/acp/handler-workflows.test.ts src/main/acp/ipc.test.ts src/main/acp/provider-session-resumer.test.ts src/main/acp/application-commands.test.ts src/renderer/src/lib/acp/workspace-runtime-save-as-skill-owner.test.tsx` | 5 files, 107 passed |
| Main-process types | Node/main runtime | `npm run typecheck:node` | Passed |
| Repository lint | Repository | `npm run lint` | Passed with 0 errors; 10 unrelated existing warnings |

Per maintainer request, the complete local `npm test` suite was not run; exact-head PR CI remains the full portable and platform validation authority.

Included compatibility dimensions: all four materially distinct replay targets (`claude-code`, `opencode`, `codex-response`, `codex-bridge`), Electron IPC, and the shared application-command route. Model-specific lanes are excluded because model selection does not change this persisted state contract. Platform-specific local lanes are excluded because the change does not touch paths, processes, packaging, timing, or OS APIs.

Uncovered local risk: the exact packaged-app click sequence against live Claude Code and Codex processes was reproduced at the deterministic persisted workflow seam rather than through a live-model E2E run. PR CI and review remain authoritative for the final diff.

## Review focus

Please verify that the new admission exception is narrow enough: only a fully prepared current control turn with a backend-matched fresh Runtime Segment may carry pending full replay into provider admission.
