### PR TITLE
feat(session-persistence): persist branch source lineage

### DIFF
--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -922,6 +922,41 @@ describe('SessionPersistenceCoordinator', () => {
     expect(durable.updatedAt).toBeGreaterThan(previousUpdatedAt)
   })
 
+  it('keeps branch source immutable and does not backfill historical Sessions', async () => {
+    const originalBranchSource = {
+      sessionId: 'source-session',
+      agentFrameId: 'source-frame',
+      messageBranchId: 'source-branch',
+      headMessageId: 'source-head'
+    }
+    let durable = createSession({ branchSource: originalBranchSource })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      })),
+      saveSession: vi.fn(async (session) => {
+        durable = structuredClone(session)
+      })
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+
+    await expect(
+      coordinator.saveSession(
+        createSession({
+          branchSource: { sessionId: 'replacement-source' }
+        })
+      )
+    ).resolves.toMatchObject({ branchSource: originalBranchSource })
+
+    durable = createSession()
+    const historical = await coordinator.saveSession(
+      createSession({ branchSource: { sessionId: 'retroactive-source' } })
+    )
+    expect(historical.branchSource).toBeUndefined()
+    expect(durable.branchSource).toBeUndefined()
+  })
+
   it('preserves authoritative permission context and waiting status on a stale renderer save', async () => {
     let durable = createSession({
       status: 'waiting-permission',

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -153,7 +153,14 @@ describe('session persistence repository (per-session files)', () => {
 
   it('saves each session to sessions/<projectId>/<id>.json and loads it back', async () => {
     const repository = new SessionRepository(await createStorageRoot())
-    const session = createSession()
+    const session = createSession({
+      branchSource: {
+        sessionId: 'source-session',
+        agentFrameId: 'source-frame',
+        messageBranchId: 'source-branch',
+        headMessageId: 'source-message'
+      }
+    })
 
     await repository.saveSession(session)
 
@@ -167,6 +174,7 @@ describe('session persistence repository (per-session files)', () => {
       schemaVersion: 1,
       rootFrameId: 'root-frame-session-1'
     })
+    expect(raw.session.branchSource).toEqual(session.branchSource)
 
     const { sessions } = await repository.loadAll()
     expect(sessions).toHaveLength(1)
@@ -174,6 +182,7 @@ describe('session persistence repository (per-session files)', () => {
       id: 'session-1',
       projectId: 'project-a',
       title: 'Saved conversation',
+      branchSource: session.branchSource,
       messages: [{ content: 'Summarize this file' }]
     })
   })

--- a/src/main/session-persistence/state-owner.ts
+++ b/src/main/session-persistence/state-owner.ts
@@ -547,6 +547,7 @@ class SessionPersistenceStateOwner {
       messages: mergeMainOwnedRelayMessages(rendererOwnedSession.messages, authority?.messages),
       ...(authority?.runtimeContext ? { runtimeContext: authority.runtimeContext } : {}),
       ...(authority?.archivedAt ? { archivedAt: authority.archivedAt } : {}),
+      ...(authority ? { branchSource: authority.branchSource } : {}),
       ...(authority
         ? {
             enabledComputeHosts: authority.enabledComputeHosts

--- a/src/renderer/src/stores/session-store-message-graph-owner.ts
+++ b/src/renderer/src/stores/session-store-message-graph-owner.ts
@@ -54,6 +54,21 @@ const createPendingSessionId = (): string => {
   return `pending-session-${Date.now()}-${pendingSessionSequence}`
 }
 
+const createSessionBranchSource = (
+  source: ChatSession
+): NonNullable<ChatSession['branchSource']> => {
+  const graph = source.conversationGraph
+  const frame = graph?.frames.find((candidate) => candidate.id === graph.activeFrameId)
+  const branch = graph?.branches.find((candidate) => candidate.id === frame?.activeBranchId)
+
+  return {
+    sessionId: source.id,
+    ...(frame ? { agentFrameId: frame.id } : {}),
+    ...(branch ? { messageBranchId: branch.id } : {}),
+    ...(branch?.headMessageId ? { headMessageId: branch.headMessageId } : {})
+  }
+}
+
 export const createSortIndex = (): number => {
   timelineSequence += 1
   return timelineSequence
@@ -378,6 +393,7 @@ export const createSessionMessageGraphOwner = <
     const newSession: ChatSession = {
       id: sessionId,
       projectId: source.projectId,
+      branchSource: createSessionBranchSource(source),
       isPending: true,
       title: trimmedContent
         ? createBranchTitleFromMessage(trimmedContent)

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -4753,6 +4753,12 @@ describe('branchInNewSession', () => {
     expect(useSessionStore.getState().sessions[1]).toEqual(sourceBefore)
 
     const branched = useSessionStore.getState().sessions[0]
+    const sourceFrame = sourceBefore.conversationGraph?.frames.find(
+      (frame) => frame.id === sourceBefore.conversationGraph?.activeFrameId
+    )
+    const sourceBranch = sourceBefore.conversationGraph?.branches.find(
+      (branch) => branch.id === sourceFrame?.activeBranchId
+    )
     expect(branched).toMatchObject({
       id: result?.sessionId,
       isPending: true,
@@ -4766,6 +4772,12 @@ describe('branchInNewSession', () => {
       agentModel: 'gpt-5.4',
       autoReviewEnabled: true,
       enabledComputeHosts: ['ssh:build'],
+      branchSource: {
+        sessionId: 'source-session',
+        agentFrameId: sourceFrame?.id,
+        messageBranchId: sourceBranch?.id,
+        headMessageId: sourceBranch?.headMessageId
+      },
       activeRun: { promptMessageId: result?.messageId, startedAt: Date.now() }
     })
     expect(branched.messages.map((message) => message.content)).toEqual([

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -168,6 +168,44 @@ describe('conversation graph materialization diagnostics', () => {
   })
 })
 
+describe('session branch source persistence', () => {
+  it('restores a complete source snapshot without inferring one for historical sessions', () => {
+    const historical = createSessionWithActivity(undefined)
+    const restored = normalizeSessionFile({
+      ...historical,
+      activities: undefined,
+      branchSource: {
+        sessionId: 'source-session',
+        agentFrameId: 'source-frame',
+        messageBranchId: 'source-branch',
+        headMessageId: 'source-head'
+      }
+    })
+
+    expect(restored?.branchSource).toEqual({
+      sessionId: 'source-session',
+      agentFrameId: 'source-frame',
+      messageBranchId: 'source-branch',
+      headMessageId: 'source-head'
+    })
+    expect(normalizeSessionFile(historical)?.branchSource).toBeUndefined()
+  })
+
+  it('discards malformed or empty source snapshots', () => {
+    const base = { ...createSessionWithActivity(undefined), activities: undefined }
+
+    expect(
+      normalizeSessionFile({ ...base, branchSource: { sessionId: '' } })?.branchSource
+    ).toBeUndefined()
+    expect(
+      normalizeSessionFile({
+        ...base,
+        branchSource: { sessionId: 'source-session', messageBranchId: 42 }
+      })?.branchSource
+    ).toBeUndefined()
+  })
+})
+
 describe('branch Plan history persistence', () => {
   it('restores only branch-bound projections and recomputes their display state', () => {
     const valid = createHistoricalPlan()

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -447,10 +447,20 @@ export type PersistedActivityGroup = {
   completedAt?: number
 }
 
+export type PersistedSessionBranchSource = {
+  sessionId: string
+  agentFrameId?: string
+  messageBranchId?: string
+  headMessageId?: string
+}
+
 export type PersistedChatSession = {
   id: string
   // Owning project. On load this is authoritative from the file's directory (sessions/<projectId>/).
   projectId: string
+  // Immutable snapshot of the direct Session and active conversation path copied by
+  // Branch in new session. Historical Sessions omit it and remain unrelated.
+  branchSource?: PersistedSessionBranchSource
   title: string
   cwd: string
   status: PersistedSessionStatus
@@ -3243,6 +3253,35 @@ const sanitizePendingHistoryReplay = (
   return messageId ? { kind: 'before-message', messageId } : undefined
 }
 
+const sanitizeSessionBranchSource = (value: unknown): PersistedSessionBranchSource | undefined => {
+  if (
+    !isRecord(value) ||
+    !hasOnlyFields(value, ['sessionId', 'agentFrameId', 'messageBranchId', 'headMessageId'])
+  ) {
+    return undefined
+  }
+
+  const sessionId = asString(value.sessionId)
+  const agentFrameId = asString(value.agentFrameId)
+  const messageBranchId = asString(value.messageBranchId)
+  const headMessageId = asString(value.headMessageId)
+  if (
+    !sessionId ||
+    (value.agentFrameId !== undefined && !agentFrameId) ||
+    (value.messageBranchId !== undefined && !messageBranchId) ||
+    (value.headMessageId !== undefined && !headMessageId)
+  ) {
+    return undefined
+  }
+
+  return {
+    sessionId,
+    ...(agentFrameId ? { agentFrameId } : {}),
+    ...(messageBranchId ? { messageBranchId } : {}),
+    ...(headMessageId ? { headMessageId } : {})
+  }
+}
+
 // Rebuilds a persisted chat session and normalizes any runtime-only interrupted state.
 const sanitizeSession = (
   session: unknown,
@@ -3294,6 +3333,7 @@ const sanitizeSession = (
   }
   const activeRun = sanitizeActiveRun(session.activeRun)
   const resumeRecovery = sanitizeSessionResumeRecovery(session.resumeRecovery)
+  const branchSource = sanitizeSessionBranchSource(session.branchSource)
   const pendingHistoryReplay =
     sanitizePendingHistoryReplay(session.pendingHistoryReplay) ??
     // Migrate feature-preview files that used the cutoff id as a top-level scalar.
@@ -3315,6 +3355,7 @@ const sanitizeSession = (
 
   if (activeRun) sanitized.activeRun = activeRun
   if (resumeRecovery) sanitized.resumeRecovery = resumeRecovery
+  if (branchSource) sanitized.branchSource = branchSource
   if (pendingHistoryReplay) sanitized.pendingHistoryReplay = pendingHistoryReplay
   if (error) sanitized.error = error
   // Only meaningful alongside an error; persisted only when explicitly false (absent = reportable).


### PR DESCRIPTION
## Problem

`Branch in new session` copies the active conversation path into a new Session, but the persisted Session did not record which Session/path it came from. After restart, that lineage was unavailable.

## Proposed change

- Add optional `branchSource` metadata to persisted Session JSON v2:
  - required `sessionId`
  - optional `agentFrameId`, `messageBranchId`, and `headMessageId`
- Capture the direct source Session's active frame and active message branch when the new Session is created.
- Strictly sanitize the persisted shape.
- Let main-process persistence accept the snapshot on the first durable write, then preserve the authoritative value so renderer saves cannot rewrite it.
- Cover creation, JSON round-trip, malformed input, immutable ownership, and historical records with tests.

## Scope and non-goals

### Historical compatibility

Existing Session history without `branchSource` is treated as having no source. There is no inference or backfill.

### Enum/state changes

None. No enum values or state-machine states are added.

### Persistence changes

This is an additive optional field in the existing Session JSON v2 format. `SESSION_FILE_VERSION` remains `2`. There is no Prisma/SQLite schema change or database migration.

Deleting the source Session remains allowed and does not rewrite the child snapshot; a child may retain a dangling source reference.

### Other non-goals

- No lineage UI, navigation, or tree rendering.
- No provider/ACP protocol, replay, resume, or wire-format change. The `claude-code`, `opencode`, `codex-response`, and `codex-bridge` paths are outside this change.
- No platform-specific path behavior is changed.

## Acceptance criteria and validation

- Branch creation records the direct source and active path: `npm run test:module -- session_renderer` — 405 tests passed.
- Persistence lifecycle, immutability, and no historical backfill: `npm run test:module -- session_persistence` — 268 tests passed.
- Raw Session JSON remains v2 and round-trips the optional field: `npm test -- src/main/session-persistence/repository.test.ts` — 54 tests passed.
- Node contract: `npm run typecheck:node` — passed.
- Renderer contract: `npm run typecheck:web` — passed.
- Lint: `npm run lint` — 0 errors; changed-file ESLint is clean.
- Patch hygiene: `git diff --check` — passed.
- Independent Standards and Spec reviews — no findings.

Per maintainer direction, the full `npm test` suite was not run locally; PR CI is authoritative.

## Review focus

- Whether the optional v2 sanitizer is strict enough.
- Whether capturing `activeFrameId` + `activeBranchId` matches branch semantics.
- Whether main-owned preservation is the right immutability boundary.
