### PR TITLE
refactor(host-capabilities): centralize capability projection

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -983,15 +983,41 @@ const HOST_CAPABILITY_MAX_FIELDS = 64
 const HOST_CAPABILITY_MAX_KEY_LENGTH = 64
 const HOST_CAPABILITY_KEY_PATTERN = /^[a-z][a-zA-Z0-9]*$/
 const HOST_CAPABILITY_DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+// This is the JavaScript-side known catalog, intentionally mirrored by a contract test instead of
+// importing TypeScript into the bundled REPL resource.
+const HOST_CAPABILITY_KNOWN_KEYS = Object.freeze([
+  'mcp',
+  'compute',
+  'agents',
+  'skills',
+  'artifacts',
+  'lineage',
+  'frames',
+  'llm',
+  'viewImage',
+  'children',
+  'collect',
+  'delegate',
+  'messageReceipt',
+  'resolveMessage',
+  'sendFrameMessage',
+  'stopChild',
+  'submitOutput'
+])
 
 function isValidHostCapabilityProjection(value) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false
   if (Object.getPrototypeOf(value) !== Object.prototype) return false
 
   const entries = Object.entries(value)
+  const knownEntries = HOST_CAPABILITY_KNOWN_KEYS.filter((name) =>
+    Object.hasOwn(value, name)
+  ).map((name) => [name, value[name]])
+  const unknownEntries = entries.filter(([name]) => !HOST_CAPABILITY_KNOWN_KEYS.includes(name))
   return (
     entries.length <= HOST_CAPABILITY_MAX_FIELDS &&
-    entries.every(
+    knownEntries.every(([, enabled]) => typeof enabled === 'boolean') &&
+    unknownEntries.every(
       ([name, enabled]) =>
         name.length <= HOST_CAPABILITY_MAX_KEY_LENGTH &&
         HOST_CAPABILITY_KEY_PATTERN.test(name) &&

--- a/resources/skills/self-awareness/SKILL.md
+++ b/resources/skills/self-awareness/SKILL.md
@@ -14,7 +14,7 @@ JavaScript control REPL; Python and R data kernels do not receive it.
 const caps = await host.capabilities()
 ```
 
-The current v1 known result contains exactly nine boolean keys:
+The current project-native result contains 17 known boolean keys:
 
 - `mcp` gates `host.mcp` connector calls.
 - `compute` gates the `host.compute` namespace.
@@ -26,6 +26,12 @@ The current v1 known result contains exactly nine boolean keys:
 - `llm` gates `host.llm` one-shot, tool-less inference.
 - `viewImage` gates transient `host.viewImage(source, options?)` image attachment from an Artifact or
   Upload Version in the current Project, or a current-Session relative workspace path.
+- `delegate`, `children`, `collect`, `stopChild`, and `resolveMessage` are Main/root-only delegated
+  work operations.
+- `sendFrameMessage` and `messageReceipt` are available to Main/root and Delegate agents when their
+  trusted route is provisioned.
+- `submitOutput` is available only to an authenticated Delegate Attempt with an admitted output
+  schema.
 
 Newer runtimes may return additive boolean keys. Do not assume their meaning until their matching
 Skill documents them. Older runtimes can omit known keys.
@@ -50,6 +56,10 @@ if (caps.llm === true) {
 
 if (caps.viewImage === true) {
   await host.viewImage({ path: 'results/plot.png' }, { maxSize: 1200 })
+}
+
+if (caps.sendFrameMessage === true) {
+  await host.sendFrameMessage('parent', 'The analysis is ready.')
 }
 ```
 

--- a/src/main/host-sdk/capability-projection.test.ts
+++ b/src/main/host-sdk/capability-projection.test.ts
@@ -1,0 +1,139 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  HOST_CAPABILITY_KEYS,
+  projectHostCapabilities,
+  type HostCapabilityProjection
+} from './capability-projection'
+
+const allServices = {
+  mcp: true,
+  compute: true,
+  agents: true,
+  skills: true,
+  artifacts: true,
+  lineage: true,
+  frames: true,
+  llm: true,
+  viewImage: true,
+  delegate: true,
+  children: true,
+  collect: true,
+  stopChild: true,
+  sendFrameMessage: true,
+  messageReceipt: true,
+  resolveMessage: true,
+  submitOutput: true
+} as const
+
+const project = (
+  overrides: Partial<Parameters<typeof projectHostCapabilities>[0]> = {}
+): HostCapabilityProjection =>
+  projectHostCapabilities({
+    callerRole: 'main',
+    isControl: true,
+    hasActiveControlInvocation: true,
+    hasWorkspace: true,
+    allowsMethod: () => true,
+    delegatedWorkReady: true,
+    services: allServices,
+    ...overrides
+  })
+
+describe('Host capability projection', () => {
+  it('owns the complete 17-key project-native catalog', () => {
+    expect(HOST_CAPABILITY_KEYS).toEqual([
+      'mcp',
+      'compute',
+      'agents',
+      'skills',
+      'artifacts',
+      'lineage',
+      'frames',
+      'llm',
+      'viewImage',
+      'children',
+      'collect',
+      'delegate',
+      'messageReceipt',
+      'resolveMessage',
+      'sendFrameMessage',
+      'stopChild',
+      'submitOutput'
+    ])
+  })
+
+  it('projects root-only, bidirectional, and delegate-only operations from trusted route readiness', () => {
+    expect(project()).toMatchObject({
+      delegate: true,
+      children: true,
+      collect: true,
+      stopChild: true,
+      sendFrameMessage: true,
+      messageReceipt: true,
+      resolveMessage: true,
+      submitOutput: false
+    })
+    expect(project({ callerRole: 'delegate' })).toMatchObject({
+      delegate: false,
+      children: false,
+      collect: false,
+      stopChild: false,
+      sendFrameMessage: true,
+      messageReceipt: true,
+      resolveMessage: false,
+      submitOutput: true
+    })
+    expect(project({ delegatedWorkReady: false })).toMatchObject({
+      delegate: false,
+      children: false,
+      collect: false,
+      stopChild: false,
+      sendFrameMessage: false,
+      messageReceipt: false,
+      resolveMessage: false,
+      submitOutput: false
+    })
+  })
+
+  it.each(['claude-code', 'opencode', 'codex-response', 'codex-bridge'])
+  ('keeps the shared Main projection stable for %s', () => {
+    expect(project()).toMatchObject({
+      delegate: true,
+      children: true,
+      collect: true,
+      stopChild: true,
+      sendFrameMessage: true,
+      messageReceipt: true,
+      resolveMessage: true,
+      submitOutput: false
+    })
+  })
+
+  it('requires each operation route and service instead of advertising an uncallable method', () => {
+    expect(
+      project({
+        allowsMethod: (method) => method !== 'delegatedWorkCall' && method !== 'delegatedOutputCall'
+      })
+    ).toMatchObject({
+      delegate: false,
+      sendFrameMessage: false,
+      submitOutput: false
+    })
+    expect(project({ services: { ...allServices, sendFrameMessage: false } })).toMatchObject({
+      sendFrameMessage: false,
+      messageReceipt: true
+    })
+  })
+
+  it('keeps the bundled JavaScript known catalog aligned without a runtime cross-layer import', () => {
+    const source = readFileSync(resolve(__dirname, '../../../resources/notebook/repl_loop.js'), 'utf8')
+    const match = source.match(/const HOST_CAPABILITY_KNOWN_KEYS = Object\.freeze\(\[([\s\S]*?)\]\)/)
+    expect(match?.[1].match(/'[^']+'/g)?.map((key) => key.slice(1, -1))).toEqual(
+      HOST_CAPABILITY_KEYS
+    )
+  })
+})

--- a/src/main/host-sdk/capability-projection.ts
+++ b/src/main/host-sdk/capability-projection.ts
@@ -1,0 +1,116 @@
+const HOST_CAPABILITY_BASE_KEYS = [
+  'mcp',
+  'compute',
+  'agents',
+  'skills',
+  'artifacts',
+  'lineage',
+  'frames',
+  'llm',
+  'viewImage'
+] as const
+
+const HOST_CAPABILITY_OPERATION_KEYS = [
+  'children',
+  'collect',
+  'delegate',
+  'messageReceipt',
+  'resolveMessage',
+  'sendFrameMessage',
+  'stopChild',
+  'submitOutput'
+] as const
+
+const HOST_CAPABILITY_KEYS = Object.freeze([
+  ...HOST_CAPABILITY_BASE_KEYS,
+  ...HOST_CAPABILITY_OPERATION_KEYS
+])
+
+type HostCapabilityBaseKey = (typeof HOST_CAPABILITY_BASE_KEYS)[number]
+type HostCapabilityOperationKey = (typeof HOST_CAPABILITY_OPERATION_KEYS)[number]
+type HostCapabilityKey = (typeof HOST_CAPABILITY_KEYS)[number]
+type HostCapabilityProjection = Readonly<Record<HostCapabilityKey, boolean>>
+
+type HostCapabilityProjectionContext = Readonly<{
+  callerRole: 'main' | 'delegate'
+  isControl: boolean
+  hasActiveControlInvocation: boolean
+  hasWorkspace: boolean
+  allowsMethod(method: string): boolean
+  delegatedWorkReady: boolean
+  services: Readonly<{
+    mcp: boolean
+    compute: boolean
+    agents: boolean
+    skills: boolean
+    artifacts: boolean
+    lineage: boolean
+    frames: boolean
+    llm: boolean
+    viewImage: boolean
+    delegate: boolean
+    children: boolean
+    collect: boolean
+    stopChild: boolean
+    sendFrameMessage: boolean
+    messageReceipt: boolean
+    resolveMessage: boolean
+    submitOutput: boolean
+  }>
+}>
+
+const rootOnly = (context: HostCapabilityProjectionContext, available: boolean): boolean =>
+  context.callerRole === 'main' && context.delegatedWorkReady && available
+
+const communication = (context: HostCapabilityProjectionContext, available: boolean): boolean =>
+  context.delegatedWorkReady && available
+
+const projectHostCapabilities = (
+  context: HostCapabilityProjectionContext
+): HostCapabilityProjection => {
+  const allows = (method: string): boolean => context.allowsMethod(method)
+  const routeReady = context.delegatedWorkReady && allows('delegatedWorkCall')
+
+  return Object.freeze({
+    mcp: allows('mcpCall') && context.services.mcp,
+    compute: allows('computeCall') && context.services.compute,
+    agents: allows('agentsCall') && context.services.agents,
+    skills: allows('skillsCall') && context.services.skills,
+    artifacts: allows('artifactsCall') && context.services.artifacts,
+    lineage: allows('lineageCall') && context.services.lineage,
+    frames: context.isControl && allows('framesCall') && context.services.frames,
+    llm: context.isControl && allows('llmCall') && context.services.llm,
+    viewImage:
+      context.isControl &&
+      context.hasActiveControlInvocation &&
+      context.hasWorkspace &&
+      allows('viewImageCall') &&
+      context.services.viewImage,
+    delegate: routeReady && rootOnly(context, context.services.delegate),
+    children: routeReady && rootOnly(context, context.services.children),
+    collect: routeReady && rootOnly(context, context.services.collect),
+    stopChild: routeReady && rootOnly(context, context.services.stopChild),
+    sendFrameMessage: routeReady && communication(context, context.services.sendFrameMessage),
+    messageReceipt: routeReady && communication(context, context.services.messageReceipt),
+    resolveMessage: routeReady && rootOnly(context, context.services.resolveMessage),
+    submitOutput:
+      context.callerRole === 'delegate' &&
+      context.delegatedWorkReady &&
+      allows('delegatedOutputCall') &&
+      context.services.submitOutput
+  })
+}
+
+export {
+  HOST_CAPABILITY_BASE_KEYS,
+  HOST_CAPABILITY_KEYS,
+  HOST_CAPABILITY_OPERATION_KEYS,
+  projectHostCapabilities
+}
+export type {
+  HostCapabilityBaseKey,
+  HostCapabilityKey,
+  HostCapabilityOperationKey,
+  HostCapabilityProjection,
+  HostCapabilityProjectionContext
+}

--- a/src/main/host-sdk/help.ts
+++ b/src/main/host-sdk/help.ts
@@ -1,21 +1,16 @@
-const HOST_SDK_SUBAGENT_OPERATION_IDS = [
-  'host.children',
-  'host.collect',
-  'host.delegate',
-  'host.messageReceipt',
-  'host.resolveMessage',
-  'host.sendFrameMessage',
-  'host.stopChild',
-  'host.submitOutput'
-] as const
+import {
+  HOST_CAPABILITY_OPERATION_KEYS,
+  type HostCapabilityOperationKey
+} from './capability-projection'
+
+const HOST_SDK_SUBAGENT_OPERATION_IDS = HOST_CAPABILITY_OPERATION_KEYS.map(
+  (operation) => `host.${operation}` as const
+) as readonly `host.${HostCapabilityOperationKey}`[]
 const HOST_SDK_OPERATION_IDS = Object.freeze(
   [...HOST_SDK_SUBAGENT_OPERATION_IDS, 'host.viewImage'].sort()
 )
 
-type HostSdkSubagentOperation =
-  (typeof HOST_SDK_SUBAGENT_OPERATION_IDS)[number] extends `host.${infer Operation}`
-    ? Operation
-    : never
+type HostSdkSubagentOperation = HostCapabilityOperationKey
 
 type HostSdkHelpContext = Readonly<{
   callerRole: 'main' | 'delegate'

--- a/src/main/notebook/local-rpc-server.capabilities.test.ts
+++ b/src/main/notebook/local-rpc-server.capabilities.test.ts
@@ -81,7 +81,15 @@ describe('capabilitiesCall RPC', () => {
         lineage: true,
         frames: true,
         llm: true,
-        viewImage: false
+        viewImage: false,
+        delegate: false,
+        children: false,
+        collect: false,
+        stopChild: false,
+        sendFrameMessage: false,
+        messageReceipt: false,
+        resolveMessage: false,
+        submitOutput: false
       }
     })
   })
@@ -112,6 +120,32 @@ describe('capabilitiesCall RPC', () => {
         }
       }
     })
+  })
+
+  it('does not advertise delegated work without the trusted origin required by its route', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      delegatedWorkService: {
+        delegate: async () => ({}) as never,
+        sendMessage: async () => ({}) as never
+      }
+    })
+    const connection = await server.issueControlConnection(
+      'trusted-session',
+      'trusted-project',
+      'root-frame-trusted-session'
+    )
+    const endInvocation = connection.beginControlInvocation({
+      turnId: 'turn-1',
+      controlInvocationGeneration: 1,
+      toolInvocationId: 'tool-1'
+    })
+
+    await expect(callCapabilities(connection)).resolves.toMatchObject({
+      payload: { result: { delegate: false, sendFrameMessage: false } }
+    })
+
+    endInvocation()
   })
 
   it('does not advertise Host Frames to an ordinary non-control Session token', async () => {

--- a/src/main/notebook/local-rpc-server.delegated-work.test.ts
+++ b/src/main/notebook/local-rpc-server.delegated-work.test.ts
@@ -66,7 +66,7 @@ describe('authenticated delegatedWorkCall route', () => {
     child.release()
   })
 
-  it('describes delegate availability from the authenticated control binding without an active invocation', async () => {
+  it('keeps delegated help unavailable until its authenticated route is ready', async () => {
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
       transport: 'tcp',
       delegatedWorkService: { delegate: vi.fn() }
@@ -99,7 +99,13 @@ describe('authenticated delegatedWorkCall route', () => {
     }
 
     await expect(ask(main.endpoint, main.token, 'delegate', 'delegate')).resolves.toMatchObject({
-      result: { kind: 'operation', availability: { status: 'available' } }
+      result: {
+        kind: 'operation',
+        availability: {
+          status: 'unavailable',
+          reason: 'host.delegate is not provisioned for this Session.'
+        }
+      }
     })
     await expect(ask(child.endpoint, child.token, 'main', 'delegate')).resolves.toMatchObject({
       result: {
@@ -120,7 +126,7 @@ describe('authenticated delegatedWorkCall route', () => {
     ).toEqual({
       'host.children': 'unavailable',
       'host.collect': 'unavailable',
-      'host.delegate': 'available',
+      'host.delegate': 'unavailable',
       'host.messageReceipt': 'unavailable',
       'host.resolveMessage': 'unavailable',
       'host.sendFrameMessage': 'unavailable',

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -56,6 +56,10 @@ import type {
   DurableDelegatedWork
 } from '../delegation/durable-delegated-work'
 import { hostSdkHelp } from '../host-sdk/help'
+import {
+  projectHostCapabilities,
+  type HostCapabilityProjection
+} from '../host-sdk/capability-projection'
 import { parseCollectRpcCall, parseDelegateRpcCall } from '../host-sdk/delegate-contract'
 import { createNestedDelegateInvocationId } from '../../shared/delegated-caller-source'
 import { StructuredOutputError } from '../delegation/structured-output'
@@ -904,6 +908,7 @@ class NotebookLocalRpcServer {
       agentFrameId: scope.agentFrameId,
       allowedMethods: new Set([
         ...NOTEBOOK_LOCAL_RPC_METHODS,
+        'capabilitiesCall',
         'hostSdkHelp',
         'delegatedWorkCall',
         'delegatedOutputCall',
@@ -1202,6 +1207,59 @@ class NotebookLocalRpcServer {
     }
   }
 
+  private async projectHostCapabilities(
+    sessionBinding: NotebookRpcSessionBinding
+  ): Promise<HostCapabilityProjection> {
+    const allowsMethod = (method: string): boolean =>
+      !sessionBinding.allowedMethods || sessionBinding.allowedMethods.has(method)
+    const callerRole = sessionBinding.delegatedWorkRole ?? 'main'
+    const hasDelegatedIdentity = Boolean(
+      sessionBinding.projectId &&
+        sessionBinding.agentFrameId &&
+        (callerRole !== 'delegate' || sessionBinding.delegatedWorkAttemptId)
+    )
+    const hasDelegatedOrigin = sessionBinding.delegatedNotebook
+      ? Boolean(sessionBinding.delegatedNotebook.provenanceContext.promptMessageId)
+      : Boolean(sessionBinding.activeControlInvocation?.originatingUserMessageId)
+    const delegatedWorkReady =
+      hasDelegatedIdentity &&
+      hasDelegatedOrigin &&
+      (sessionBinding.delegatedNotebook
+        ? !sessionBinding.delegatedNotebook.revoked &&
+          (await sessionBinding.delegatedNotebook.isAttemptWritable())
+        : Boolean(sessionBinding.isControl && sessionBinding.activeControlInvocation))
+
+    return projectHostCapabilities({
+      callerRole,
+      isControl: Boolean(sessionBinding.isControl),
+      hasActiveControlInvocation: Boolean(sessionBinding.activeControlInvocation),
+      hasWorkspace: Boolean(sessionBinding.workspaceCwd),
+      allowsMethod,
+      delegatedWorkReady,
+      services: {
+        mcp: Boolean(this.connectorService),
+        compute: Boolean(this.computeService),
+        agents: Boolean(this.agentsService),
+        skills: Boolean(this.skillsService),
+        artifacts: Boolean(this.hostArtifacts),
+        lineage: Boolean(this.hostLineage),
+        frames: Boolean(this.hostFrames),
+        llm: Boolean(this.hostLlm) && (await this.hostLlm!.isAvailable()),
+        viewImage:
+          Boolean(this.hostViewImage) &&
+          (await this.hostViewImage!.isAvailable({ sessionId: sessionBinding.sessionId })),
+        delegate: Boolean(this.delegatedWorkService?.delegate),
+        children: Boolean(this.delegatedWorkService?.children),
+        collect: Boolean(this.delegatedWorkService?.collect),
+        stopChild: Boolean(this.delegatedWorkService?.stopChildren),
+        sendFrameMessage: Boolean(this.delegatedWorkService?.sendMessage),
+        messageReceipt: Boolean(this.delegatedWorkService?.messageReceipt),
+        resolveMessage: Boolean(this.delegatedWorkService?.resolveMessage),
+        submitOutput: Boolean(this.delegatedWorkService?.submitOutput)
+      }
+    })
+  }
+
   // Authenticates one HTTP request, dispatches it, and serializes either result or error.
   private async handleRequest(
     lifecycle: NotebookRpcServerLifecycle,
@@ -1266,20 +1324,7 @@ class NotebookLocalRpcServer {
       activeRequest.method = method
       let params = isRecord(payload.params) ? payload.params : {}
       if (method === 'hostSdkHelp') delete params.view_image_available
-      let hostCapabilities:
-        | Record<
-            | 'mcp'
-            | 'compute'
-            | 'agents'
-            | 'skills'
-            | 'artifacts'
-            | 'lineage'
-            | 'frames'
-            | 'llm'
-            | 'viewImage',
-            boolean
-          >
-        | undefined
+      let hostCapabilities: HostCapabilityProjection | undefined
       if (isArtifactRpcMethod(method)) {
         const acquired = this.acquireArtifactRpcRequest(method, bearerToken, params)
         params = acquired.params
@@ -1341,33 +1386,8 @@ class NotebookLocalRpcServer {
               'host.agents.switch requires an active trusted control invocation.'
             )
           }
-          if (method === 'capabilitiesCall') {
-            const allows = (rpcMethod: string): boolean =>
-              !sessionBinding.allowedMethods || sessionBinding.allowedMethods.has(rpcMethod)
-            hostCapabilities = {
-              mcp: allows('mcpCall') && Boolean(this.connectorService),
-              compute: allows('computeCall') && Boolean(this.computeService),
-              agents: allows('agentsCall') && Boolean(this.agentsService),
-              skills: allows('skillsCall') && Boolean(this.skillsService),
-              artifacts: allows('artifactsCall') && Boolean(this.hostArtifacts),
-              lineage: allows('lineageCall') && Boolean(this.hostLineage),
-              frames:
-                Boolean(sessionBinding.isControl) &&
-                allows('framesCall') &&
-                Boolean(this.hostFrames),
-              llm:
-                sessionBinding.isControl === true &&
-                allows('llmCall') &&
-                Boolean(this.hostLlm) &&
-                (await this.hostLlm!.isAvailable()),
-              viewImage:
-                sessionBinding.isControl === true &&
-                Boolean(sessionBinding.activeControlInvocation) &&
-                Boolean(sessionBinding.workspaceCwd) &&
-                allows('viewImageCall') &&
-                Boolean(this.hostViewImage) &&
-                (await this.hostViewImage!.isAvailable({ sessionId: sessionBinding.sessionId }))
-            }
+          if (method === 'capabilitiesCall' || method === 'hostSdkHelp') {
+            hostCapabilities = await this.projectHostCapabilities(sessionBinding)
           }
           if (
             method === 'delegatedWorkCall' &&
@@ -1472,16 +1492,7 @@ class NotebookLocalRpcServer {
                 : method === 'hostSdkHelp'
                   ? {
                       caller_role: sessionBinding.delegatedWorkRole,
-                      view_image_available:
-                        sessionBinding.isControl === true &&
-                        Boolean(sessionBinding.activeControlInvocation) &&
-                        Boolean(sessionBinding.workspaceCwd) &&
-                        (!sessionBinding.allowedMethods ||
-                          sessionBinding.allowedMethods.has('viewImageCall')) &&
-                        Boolean(this.hostViewImage) &&
-                        (await this.hostViewImage!.isAvailable({
-                          sessionId: sessionBinding.sessionId
-                        }))
+                      _hostCapabilityProjection: hostCapabilities
                     }
                   : {})
           }
@@ -1566,7 +1577,9 @@ class NotebookLocalRpcServer {
         }
       }
       const result =
-        hostCapabilities ?? (await this.dispatch(method, resolvedParams, disconnect.signal))
+        method === 'capabilitiesCall'
+          ? hostCapabilities
+          : await this.dispatch(method, resolvedParams, disconnect.signal)
 
       writeJson(response, 200, { result })
     } catch (error) {
@@ -2094,19 +2107,13 @@ class NotebookLocalRpcServer {
     }
 
     if (method === 'hostSdkHelp') {
+      const capabilities = params._hostCapabilityProjection
+      if (!capabilities || typeof capabilities !== 'object' || Array.isArray(capabilities)) {
+        throw new Error('Host capability projection is unavailable.')
+      }
       return hostSdkHelp.query(params.query, {
         callerRole: params.caller_role === 'delegate' ? 'delegate' : 'main',
-        capabilities: {
-          delegate: Boolean(this.delegatedWorkService?.delegate),
-          children: Boolean(this.delegatedWorkService?.children),
-          collect: Boolean(this.delegatedWorkService?.collect),
-          stopChild: Boolean(this.delegatedWorkService?.stopChildren),
-          sendFrameMessage: Boolean(this.delegatedWorkService?.sendMessage),
-          messageReceipt: Boolean(this.delegatedWorkService?.messageReceipt),
-          resolveMessage: Boolean(this.delegatedWorkService?.resolveMessage),
-          submitOutput: Boolean(this.delegatedWorkService?.submitOutput),
-          viewImage: params.view_image_available === true
-        }
+        capabilities: capabilities as HostCapabilityProjection
       })
     }
 

--- a/src/main/skills/self-awareness-skill.test.ts
+++ b/src/main/skills/self-awareness-skill.test.ts
@@ -23,13 +23,13 @@ describe('self-awareness bundled Skill', () => {
     expect(skill?.description).toMatch(/JavaScript control REPL/i)
   })
 
-  it('documents the shipped nine-key JavaScript contract and read limits', async () => {
+  it('documents the shipped 17-key JavaScript contract and read limits', async () => {
     const body = await new SkillRegistry(skillsRoot).body('self-awareness')
 
     for (const phrase of [
       'repl_execute',
       'await host.capabilities()',
-      'exactly nine boolean keys',
+      '17 known boolean keys',
       '`mcp`',
       '`compute`',
       '`agents`',
@@ -39,6 +39,14 @@ describe('self-awareness bundled Skill', () => {
       '`frames`',
       '`llm`',
       '`viewImage`',
+      '`delegate`',
+      '`children`',
+      '`collect`',
+      '`stopChild`',
+      '`sendFrameMessage`',
+      '`messageReceipt`',
+      '`resolveMessage`',
+      '`submitOutput`',
       'caps.compute === true',
       'caps.artifacts === true',
       'caps.frames === true',


### PR DESCRIPTION
## Problem

`host.capabilities()` and `host.help()` independently derived operation availability, so the published contract could disagree with the callable route.

## Proposed change

Centralize the 17-key host capability catalog and role-aware projection in one main-process owner. Both read interfaces now consume that projection; the bundled JavaScript catalog is locked to it by a contract test.

## Scope and non-goals

No database, UI, or unimplemented API placeholders. The eight shipped lowerCamelCase operation flags are role- and route-sensitive.

## Acceptance criteria and validation

- Main/root-only, bidirectional, and Delegate-only projections are covered.
- Shared contract coverage names claude-code, opencode, codex-response, and codex-bridge.
- Focused tests after the last edit: `npm test -- src/main/host-sdk/capability-projection.test.ts src/main/host-sdk/help.test.ts src/main/notebook/local-rpc-server.capabilities.test.ts src/main/notebook/local-rpc-server.delegated-work.test.ts src/main/skills/self-awareness-skill.test.ts src/main/notebook/repl-loop.integration.test.ts` (67 passed, 30 skipped).
- `npm run typecheck:node` and `npm run lint -- --quiet` passed after the last edit.

## Review focus

Please verify that trusted binding, allowed-method, service, and route readiness gates remain fail-closed.