### PR TITLE
feat(providers): add GLM-5.3 to Coding Plan

### DIFF
--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -100,9 +100,10 @@ describe('provider registry', () => {
     )
     // Quota-based plan: fixed catalog, no live model-list refresh.
     expect(resolveVendorModelsUrl('glmcodingplan')).toBeUndefined()
-    expect(defaultVendorModel('glmcodingplan')).toBe('glm-5.2')
+    expect(defaultVendorModel('glmcodingplan')).toBe('glm-5.3')
     // The coding plan drops GLM's vision variant, so it serves no multimodal model.
     expect(isVendorModelMultimodal('glmcodingplan', 'glm-5v-turbo')).toBe(false)
+    expect(isVendorModelMultimodal('glmcodingplan', 'glm-5.3')).toBe(false)
     expect(isVendorModelMultimodal('glmcodingplan', 'glm-5.2')).toBe(false)
     // Each region points at its own subscription console.
     expect(resolveVendorApiKeyUrl('glmcodingplan', 'global')).toBe('https://z.ai/subscribe')
@@ -123,6 +124,10 @@ describe('provider registry', () => {
     expect(resolveVendorModelReasoningEffort('deepseek', 'deepseek-v4-pro')).toEqual({
       supported: true,
       slots: ['none', 'high', 'max', 'max', 'max']
+    })
+    expect(resolveVendorModelReasoningEffort('glmcodingplan', 'glm-5.3')).toEqual({
+      supported: true,
+      slots: ['low', 'high', 'max', 'max', 'max']
     })
     expect(resolveVendorModelReasoningEffort('stepfun', 'step-3.7-flash')).toEqual({
       supported: true,
@@ -665,6 +670,7 @@ describe('provider registry', () => {
       expect(resolveModelContextWindow('xai', 'grok-4.3')).toBe(1_000_000)
       expect(resolveModelContextWindow('xai', 'grok-build-0.1')).toBe(256_000)
       expect(resolveModelContextWindow('deepseek', 'deepseek-v4-flash')).toBe(1_000_000)
+      expect(resolveModelContextWindow('glmcodingplan', 'glm-5.3')).toBe(1_000_000)
       expect(resolveModelContextWindow('zhipu', 'glm-5.2')).toBe(1_000_000)
       expect(resolveModelContextWindow('zhipu', 'glm-5.1')).toBe(200_000)
       expect(resolveModelContextWindow('kimi', 'kimi-k3')).toBe(1_000_000)

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -384,6 +384,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     // The coding plan does not serve GLM's vision variant, so glm-5v-turbo is omitted and there is no
     // `multimodal` rule (image input stays disabled for this endpoint).
     models: [
+      { id: 'glm-5.3', contextWindow: 1_000_000, reasoningEffort: 'low-high-max' },
       { id: 'glm-5.2', contextWindow: 1_000_000, reasoningEffort: 'none-high-max' },
       { id: 'glm-5.1', contextWindow: 200_000 },
       { id: 'glm-5', contextWindow: 200_000 },


### PR DESCRIPTION
## Problem

GLM Coding Plan now supports GLM-5.3, but the bundled provider catalog still defaults to GLM-5.2 and does not offer GLM-5.3.

Official model references:
- https://docs.bigmodel.cn/cn/guide/models/text/glm-5.3
- https://docs.z.ai/guides/llm/glm-5.3

## Proposed change

- Add `glm-5.3` as the first model in the GLM Coding Plan catalog.
- Declare its 1M context window.
- Map its always-on `low` / `high` / `max` thinking levels through the existing `low-high-max` reasoning profile.
- Add registry contract coverage for the default model, text-only capability, reasoning profile, and context window.

## Scope and non-goals

- This changes only the `glmcodingplan` catalog.
- The pay-as-you-go `zhipu` provider is intentionally unchanged because the referenced documentation still marks the model API as coming soon.
- No provider type, enum value, database schema, persisted record shape, or migration is added.
- Existing explicit provider/model selections remain valid. A GLM Coding Plan provider without an explicit saved model, including a historical record in that state, now resolves to GLM-5.3 as the new catalog default.

## Acceptance criteria and validation

The checks below ran after the last material edit:

- GLM Coding Plan catalog/default, context, reasoning, and consumer contracts -> `npm run test:module -- settings_provider_accounts` -> 20 files passed, 335 tests passed.
- Shared registry types consumed by the main process -> `npm run typecheck:node` -> passed.
- Shared registry types consumed by the renderer -> `npm run typecheck:web` -> passed.
- Source style and static lint rules -> `npm run lint` -> passed with 10 pre-existing warnings in unrelated files and no errors.
- Patch integrity -> `git diff --check` -> passed.

The full portable test suite was not run locally per the requested module-scoped validation workflow. PR CI remains authoritative for the full and platform lanes.

## Review focus

- Confirm GLM-5.3 should become the default GLM Coding Plan model.
- Confirm the existing `low-high-max` projection accurately represents the documented thinking levels.
- Confirm keeping the pay-as-you-go Zhipu catalog unchanged until its API is available.
