### PR TITLE
fix(ci): stabilize cross-platform certification tests

### DIFF
--- a/src/main/diagnostics/operation.test.ts
+++ b/src/main/diagnostics/operation.test.ts
@@ -62,7 +62,8 @@ describe('diagnostic operation', () => {
     const operation = startDiagnosticOperation(logger, {
       operation: 'data-root-migration',
       operationId: 'migration-1',
-      fields: { source: 'legacy' }
+      fields: { source: 'legacy' },
+      now: () => 0
     })
 
     operation.phase('copy', { filesCopied: 3 })

--- a/src/main/local-fs/service.ts
+++ b/src/main/local-fs/service.ts
@@ -1,7 +1,7 @@
 import { hostname, userInfo } from 'node:os'
 import { randomUUID } from 'node:crypto'
 import { readdir, realpath, stat } from 'node:fs/promises'
-import { basename, join } from 'node:path'
+import { basename, join, posix } from 'node:path'
 
 import { app, shell } from 'electron'
 
@@ -119,7 +119,7 @@ export class LocalFsService {
       const dirents = await readdir(parent, { withFileTypes: true })
       return dirents
         .filter((dirent) => dirent.isDirectory() || dirent.isSymbolicLink())
-        .map((dirent) => ({ path: join(parent, dirent.name), label: dirent.name }))
+        .map((dirent) => ({ path: posix.join(parent, dirent.name), label: dirent.name }))
     } catch {
       return []
     }


### PR DESCRIPTION
## Problem

The scheduled certification workflows exposed two cross-platform test assumptions on `a840ff4d0`:

- Nightly run https://github.com/aipoch/open-science/actions/runs/31839437725 intermittently observed 1 ms between two real clock reads while `operation.test.ts` asserted an exact zero duration.
- Windows Full Test runs https://github.com/aipoch/open-science/actions/runs/31840587169 and https://github.com/aipoch/open-science/actions/runs/31844684749 used the Windows host's `node:path.join` while simulating Darwin/Linux drive discovery, producing backslash paths and preventing macOS boot-volume de-duplication.

## Proposed change

- Inject a fixed clock into the diagnostic phase-context test.
- Use `node:path.posix.join` only when constructing Darwin/Linux mount-entry paths. Other host-native path operations keep the existing `join`.

## Scope and non-goals

- No public API or IPC shape changes.
- No historical-data compatibility or migration work.
- No new state or enum values.
- No persistence or database changes.
- No attempt to address unrelated local Windows symlink privileges or regenerate shared dependency artifacts.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Deterministic diagnostic timing -> `npm test -- src/main/diagnostics/operation.test.ts` -> passed, 11/11.
- POSIX drive paths and macOS boot-volume de-duplication on a Windows host -> `npm test -- src/main/local-fs/service.test.ts -t LocalFsService.listDrives` -> passed, 3/3.
- Local filesystem owner test file -> `npm test -- src/main/local-fs/service.test.ts` -> 18/20 passed; the two unrelated symlink-creation cases were blocked locally by Windows `EPERM`. All three changed-behavior `listDrives` cases passed.
- Lint -> `npm run lint` -> passed with 0 errors. Existing/worktree formatting warnings remain non-blocking; Git's LF normalization removes the local mixed-EOL warning from the staged blob.
- Node typecheck -> `npm run typecheck:node` -> environment-blocked: the only reusable no-download `node_modules` donors contain Prisma/ACP generated declarations that do not match this exact source head (`assessmentSnapshot` and `waitForMcpServers`). No dependencies or generated artifacts were modified.

The final diff and this Test Impact Set were independently reviewed and accepted. Exact-head PR CI is authoritative for Node typecheck, the complete portable suite, and Windows certification.

## Review focus

- Confirm that the fixed clock changes only test determinism.
- Confirm that `posix.join` is confined to the Darwin/Linux mount-parent path and that host-native filesystem paths continue using the existing `join`.
- Confirm the exact-head PR CI closes the two local environment gaps above.