### PR TITLE
fix(session-branches): block switching during plan approval

### DIFF
--- a/src/renderer/src/stores/session-store-message-graph-owner.ts
+++ b/src/renderer/src/stores/session-store-message-graph-owner.ts
@@ -644,6 +644,7 @@ export const createSessionMessageGraphOwner = <
               session.status === 'running' ||
               session.status === 'waiting-for-user' ||
               session.status === 'waiting-permission' ||
+              session.status === 'waiting-plan-approval' ||
               session.fixLoopActive ||
               session.compacting ||
               session.branchSwitchBlocked

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -5405,6 +5405,38 @@ describe('truncateSessionFromMessage', () => {
     expect(useSessionStore.getState().sessions[0].branchContextResetRequired).toBe(true)
   })
 
+  it('does not activate another Message Branch while a Plan awaits approval', () => {
+    seedSession()
+    useSessionStore.getState().truncateSessionFromMessage('session-1', 'user-2')
+    const edited = useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'edited user-2'
+    })
+    useSessionStore.getState().finishRun('session-1')
+
+    const editedSession = useSessionStore.getState().sessions[0]
+    const originalBranchId = editedSession.conversationGraph?.branches[0].id
+    useSessionStore.getState().setActivePlanProjection('session-1', {
+      ...createPlanProjection('version-1'),
+      originatingPromptMessageId: edited?.messageId
+    })
+    const waitingSession = useSessionStore.getState().sessions[0]
+    const activeFrame = waitingSession.conversationGraph?.frames.find(
+      (frame) => frame.id === waitingSession.conversationGraph?.activeFrameId
+    )
+    expect(waitingSession.status).toBe('waiting-plan-approval')
+
+    useSessionStore.getState().activateMessageBranch('session-1', originalBranchId ?? '')
+
+    const unchanged = useSessionStore.getState().sessions[0]
+    expect(unchanged).toBe(waitingSession)
+    expect(
+      unchanged.conversationGraph?.frames.find(
+        (frame) => frame.id === unchanged.conversationGraph?.activeFrameId
+      )?.activeBranchId
+    ).toBe(activeFrame?.activeBranchId)
+  })
+
   it('materializes only the selected Message Branch Plan activities', () => {
     // Transcript projection receives this already-selected compatibility view. Exercise the public
     // Branch switch here, where the Graph is resolved into Session messages and activities.


### PR DESCRIPTION
## Problem

While a Session was in `waiting-plan-approval`, Message Branch arrows were already disabled in the renderer. However, the Store action `activateMessageBranch` did not guard that status. A stale click or direct Store call could therefore switch the active branch and project the renderer Session to `idle` while Main still held the original Plan approval open, splitting the interaction state.

## Proposed change

- Treat the existing `waiting-plan-approval` status as a Store-level Message Branch switch blocker.
- Add a regression test through the public Store action proving that the Session object, waiting status, and active branch remain unchanged.

The visible interaction remains: revision arrows stay visible but disabled while Plan approval is pending, then become available again after approve, reject, or feedback settles the approval. Stale/direct activation attempts are silently ignored by the Store.

## Scope and non-goals

- No Main-process changes.
- No protocol, architecture, or data-model changes.
- No new fields or enum values.
- No persistence-format or migration changes.
- No historical-data compatibility or repair path is required.
- No visual UI change; this hardens the Store invariant behind the existing disabled-arrow behavior.

## Acceptance criteria and validation

Checks were run after the last material edit.

- Pending Plan branch-switch invariant: new Store regression test passes as part of the owner suite.
- `session_renderer` module impact set: 4 files / 409 tests passed (Store owner, architecture, session-persistence contract, workspace-runtime consumer).
- Original minimal reproduction: passes; status remains `waiting-plan-approval`, active branch does not change, and the same Session object is retained.
- Targeted ESLint on both changed files: passed.
- `git diff --check`: passed.
- `typecheck:web`: attempted locally but unavailable because the reused repository-root install is missing `i18next`, `react-i18next`, and `sharp`, and its generated Prisma client is stale (missing `assessmentSnapshot`). No install/regeneration was performed; clean PR CI is authoritative.

The declared consumer test is included. Main and platform-specific lanes are excluded because this patch changes no cross-process interface, protocol, persistence path, or platform behavior. Remaining validation risk is limited to the stale shared local dependency/generated-client state described above.

## Review focus

- Store guard parity with the renderer's existing disabled-arrow gate.
- Regression coverage proving stale/direct branch activation is a no-op during Plan approval.