### PR TITLE
fix(storage): preserve committed root on cleanup errors

### DIFF
--- a/src/main/storage/migration-service.test.ts
+++ b/src/main/storage/migration-service.test.ts
@@ -1516,7 +1516,7 @@ describe('commitDataRootSwitch (commit phase)', () => {
     }
   )
 
-  it('preserves an unexpected cleanup rejection while diagnosing its phase', async () => {
+  it('treats an unexpected cleanup rejection as degraded success after pointer persistence', async () => {
     await seedVerifiedMarker(emptyParent, currentDataRoot)
     const deps = fakeDeps()
     const logger = fakeDiagnosticLogger()
@@ -1524,24 +1524,26 @@ describe('commitDataRootSwitch (commit phase)', () => {
       throw new Error('cleanup-secret')
     })
 
-    await expect(
-      commitDataRootSwitch(
-        {
-          currentDataRoot,
-          setDataRoot: deps.setDataRoot,
-          deleteSources,
-          expectedToken: 'tok-test',
-          logger
-        },
-        emptyParent
-      )
-    ).rejects.toThrow('cleanup-secret')
+    const result = await commitDataRootSwitch(
+      {
+        currentDataRoot,
+        setDataRoot: deps.setDataRoot,
+        deleteSources,
+        expectedToken: 'tok-test',
+        logger
+      },
+      emptyParent
+    )
+
+    expect(result).toEqual({ ok: true })
+    expect(deps.setDataRoot).toHaveBeenCalledOnce()
     expect(diagnosticRecords(logger)).toContainEqual(
       expect.objectContaining({
         operation: 'data-root-commit',
         phase: 'cleanup-source',
-        outcome: 'failed',
-        errorCategory: 'error'
+        outcome: 'completed',
+        cleanupDegraded: true,
+        cleanupFailureCount: 0
       })
     )
     expect(JSON.stringify(diagnosticRecords(logger))).not.toContain('cleanup-secret')

--- a/src/main/storage/migration-service.ts
+++ b/src/main/storage/migration-service.ts
@@ -724,20 +724,21 @@ export const commitDataRootSwitch = async (
   const dirsToDelete = runtimePreserved ? [...MIGRATED_DIRS, 'runtime'] : migratedDirs
 
   const doDeleteSources = deps.deleteSources ?? deleteSources
-  let deleteResult: Awaited<ReturnType<NonNullable<MigrationCommitDeps['deleteSources']>>>
+  let cleanupFailureCount = 0
   try {
-    deleteResult = await doDeleteSources(deps.currentDataRoot, dirsToDelete)
-  } catch (error) {
-    operation.fail(error)
-    throw error
-  }
-  if (deleteResult.failed.length > 0) {
+    const deleteResult = await doDeleteSources(deps.currentDataRoot, dirsToDelete)
+    cleanupFailureCount = deleteResult.failed.length
+    if (cleanupFailureCount > 0) cleanupDegraded = true
+  } catch {
+    // Pointer persistence above is the commit boundary. An unexpected cleanup rejection cannot roll
+    // that back, so treat it like any other harmless old-root residue and continue to relaunch. This
+    // keeps the write-gate raised until the fresh process starts against the persisted new root.
     cleanupDegraded = true
   }
 
   operation.complete({
     cleanupDegraded,
-    cleanupFailureCount: deleteResult.failed.length
+    cleanupFailureCount
   })
   return { ok: true }
 }


### PR DESCRIPTION
## Problem

After `settings.dataRoot` was persisted, an unexpected rejection from old-root cleanup escaped as a failed commit. The command boundary then lifted the write gate even though the current process still cached the old root while persisted settings pointed to the new root.

## Proposed change

Treat any source-cleanup rejection after pointer persistence as degraded cleanup, complete the commit successfully, and continue the existing relaunch flow. Diagnostics report `cleanupDegraded: true` without retaining the rejected error text.

The regression test now proves that pointer persistence occurs, the outcome remains successful, and cleanup is diagnosed as degraded.

## Scope and non-goals

- No database, settings schema, persistent field, state enum, API, or data-model changes.
- No new UI. The existing committing/relaunch interaction continues instead of showing ?Move failed?.
- No automatic reconciliation of data written to an old root by a historical affected process. Conflict-safe historical merging requires a separate recovery design.

## Acceptance criteria and validation

Checks were run after the last material source edit.

- Unexpected cleanup rejection after pointer persistence -> `npm test -- src/main/storage/migration-service.test.ts -t "treats an unexpected cleanup rejection"` -> passed (1 passed).
- Migration commit, cleanup engine, and write-gate state -> `npm test -- src/main/storage/migration-service.test.ts src/main/storage/data-migration.test.ts src/main/storage/migration-state.test.ts` -> passed (99 passed, 8 platform-condition skips).
- Main-process types -> `npm run typecheck:node` -> passed.
- Lint -> `npm run lint` -> passed with 0 errors and 17 pre-existing Prettier warnings outside this diff.
- Diff whitespace -> `git diff --check` -> passed.

The storage IPC test file could not run locally because the Windows native `safe-file-publisher` package requires a Visual Studio C++ workload unavailable in this environment. Its failures occurred during target path classification before migration commit code; Windows PR CI remains authoritative for that integration/platform lane. The full portable suite was intentionally not run locally per maintainer direction.

## Review focus

Please verify that every operation after `setDataRoot(target)` remains best-effort and cannot convert an already-committed switch into a failure outcome.
