### PR TITLE
fix(projects): coordinate project deletion cleanup

### DIFF
--- a/src/main/acp/application-commands.test.ts
+++ b/src/main/acp/application-commands.test.ts
@@ -479,6 +479,140 @@ describe('ACP application commands', () => {
     expect(dependencies.runtime.compactSession).not.toHaveBeenCalled()
   })
 
+  it('holds Session admission through ACP response mutations', async () => {
+    const responseSnapshot: AcpStateSnapshot = {
+      ...snapshot,
+      pendingPermissions: [
+        {
+          requestId: 'permission-1',
+          sessionId: 'permission-session',
+          toolCallId: 'tool-1',
+          title: 'Use a tool',
+          options: []
+        }
+      ],
+      pendingElicitations: [
+        {
+          requestId: 'question-1',
+          sessionId: 'elicitation-session',
+          toolCallId: 'tool-2',
+          message: 'Choose',
+          fields: []
+        }
+      ]
+    }
+    let admittedSessionId: string | undefined
+    const admitted: string[] = []
+    const withinAdmission = async <Result>(
+      sessionId: string,
+      operation: () => Promise<Result>
+    ): Promise<Result> => {
+      expect(admittedSessionId).toBeUndefined()
+      admittedSessionId = sessionId
+      admitted.push(sessionId)
+      try {
+        return await operation()
+      } finally {
+        admittedSessionId = undefined
+      }
+    }
+    const base = createDependencies()
+    const runtime: AcpApplicationCommandDependencies['runtime'] = {
+      ...base.runtime,
+      getSnapshot: vi.fn(() => responseSnapshot),
+      respondToPermission: vi.fn(async () => {
+        expect(admittedSessionId).toBe('permission-session')
+        return responseSnapshot
+      }),
+      respondToElicitation: vi.fn(async () => {
+        expect(admittedSessionId).toBe('elicitation-session')
+        return responseSnapshot
+      }),
+      respondSessionPlan: vi.fn(async () => {
+        expect(admittedSessionId).toBe('plan-session')
+        return { projection: {} as never, changed: true }
+      }),
+      setPermissionProfile: vi.fn(async () => {
+        expect(admittedSessionId).toBe('profile-session')
+        return responseSnapshot
+      }),
+      revokePermissionGrant: vi.fn(async () => {
+        expect(admittedSessionId).toBe('profile-session')
+        return responseSnapshot
+      })
+    }
+    const respondDelegatedQuestion = vi.fn(async () => {
+      expect(admittedSessionId).toBe('delegated-session')
+    })
+    const dependencies: AcpApplicationCommandDependencies = {
+      ...base,
+      runtime,
+      archiveAvailability: {
+        withSessionAvailable: async <Result>(
+          _projectId: string,
+          sessionId: string,
+          operation: () => Promise<Result>
+        ): Promise<Result> => withinAdmission(sessionId, operation),
+        withSessionAvailableById: withinAdmission
+      },
+      respondDelegatedQuestion
+    }
+    const router = createApplicationCommandRouter()
+    registerAcpCommands(router.registrar, dependencies)
+
+    await router.dispatcher.invoke(
+      acpCommands.respondPermission,
+      invocation([{ requestId: 'permission-1', optionId: 'allow-once' }])
+    )
+    await router.dispatcher.invoke(
+      acpCommands.respondElicitation,
+      invocation([{ requestId: 'question-1', action: 'decline' }])
+    )
+    await router.dispatcher.invoke(
+      acpCommands.respondElicitation,
+      invocation([
+        {
+          requestId: 'delegated-question-1',
+          action: 'accept',
+          delegatedQuestion: {
+            projectId: 'project-1',
+            sessionId: 'delegated-session',
+            action: 'confirm',
+            answers: []
+          }
+        }
+      ])
+    )
+    await router.dispatcher.invoke(
+      acpCommands.respondPlan,
+      invocation([
+        {
+          projectId: 'project-1',
+          sessionId: 'plan-session',
+          feedback: 'Revise the plan.'
+        }
+      ])
+    )
+    await router.dispatcher.invoke(
+      acpCommands.setPermissionProfile,
+      invocation([{ sessionId: 'profile-session', profile: 'auto' }])
+    )
+    await router.dispatcher.invoke(
+      acpCommands.revokePermissionGrant,
+      invocation([{ sessionId: 'profile-session', categoryKey: 'mcp:tool' }])
+    )
+
+    expect(admitted).toEqual([
+      'permission-session',
+      'elicitation-session',
+      'delegated-session',
+      'plan-session',
+      'profile-session',
+      'profile-session'
+    ])
+    expect(respondDelegatedQuestion).toHaveBeenCalledOnce()
+  })
+
   it('exposes Plan projection reads to the same current human callers on Electron and Web', async () => {
     const dependencies = createDependencies()
     const router = createApplicationCommandRouter()

--- a/src/main/acp/application-commands.test.ts
+++ b/src/main/acp/application-commands.test.ts
@@ -520,12 +520,20 @@ describe('ACP application commands', () => {
     const runtime: AcpApplicationCommandDependencies['runtime'] = {
       ...base.runtime,
       getSnapshot: vi.fn(() => responseSnapshot),
-      respondToPermission: vi.fn(async () => {
-        expect(admittedSessionId).toBe('permission-session')
+      respondToPermission: vi.fn(async (response) => {
+        expect(admittedSessionId).toBe(
+          response.requestId === 'restored-permission'
+            ? 'restored-permission-session'
+            : 'permission-session'
+        )
         return responseSnapshot
       }),
-      respondToElicitation: vi.fn(async () => {
-        expect(admittedSessionId).toBe('elicitation-session')
+      respondToElicitation: vi.fn(async (response) => {
+        expect(admittedSessionId).toBe(
+          response.requestId === 'restored-question'
+            ? 'restored-elicitation-session'
+            : 'elicitation-session'
+        )
         return responseSnapshot
       }),
       respondSessionPlan: vi.fn(async () => {
@@ -569,6 +577,35 @@ describe('ACP application commands', () => {
       invocation([{ requestId: 'question-1', action: 'decline' }])
     )
     await router.dispatcher.invoke(
+      acpCommands.respondPermission,
+      invocation([
+        {
+          requestId: 'restored-permission',
+          optionId: 'allow-once',
+          restored: {
+            projectId: 'project-1',
+            sessionId: 'restored-permission-session'
+          }
+        }
+      ])
+    )
+    await router.dispatcher.invoke(
+      acpCommands.respondElicitation,
+      invocation([
+        {
+          requestId: 'restored-question',
+          action: 'decline',
+          request: {
+            requestId: 'restored-question',
+            sessionId: 'restored-elicitation-session',
+            toolCallId: 'tool-restored',
+            message: 'Choose again',
+            fields: []
+          }
+        }
+      ])
+    )
+    await router.dispatcher.invoke(
       acpCommands.respondElicitation,
       invocation([
         {
@@ -605,12 +642,132 @@ describe('ACP application commands', () => {
     expect(admitted).toEqual([
       'permission-session',
       'elicitation-session',
+      'restored-permission-session',
+      'restored-elicitation-session',
       'delegated-session',
       'plan-session',
       'profile-session',
       'profile-session'
     ])
     expect(respondDelegatedQuestion).toHaveBeenCalledOnce()
+  })
+
+  it('rejects forged and unknown ACP response authority before Session admission', async () => {
+    const responseSnapshot: AcpStateSnapshot = {
+      ...snapshot,
+      sessionIds: ['permission-session', 'elicitation-session', 'forged-session'],
+      pendingPermissions: [
+        {
+          requestId: 'permission-1',
+          sessionId: 'permission-session',
+          toolCallId: 'tool-1',
+          title: 'Use a tool',
+          options: []
+        }
+      ],
+      pendingElicitations: [
+        {
+          requestId: 'question-1',
+          sessionId: 'elicitation-session',
+          toolCallId: 'tool-2',
+          message: 'Choose',
+          fields: []
+        }
+      ]
+    }
+    const base = createDependencies()
+    const admitted: string[] = []
+    const withSessionAvailableById = <Result>(
+      sessionId: string,
+      operation: () => Promise<Result>
+    ): Promise<Result> => {
+      admitted.push(sessionId)
+      return operation()
+    }
+    const respondDelegatedQuestion = vi.fn(async () => undefined)
+    const dependencies: AcpApplicationCommandDependencies = {
+      ...base,
+      runtime: {
+        ...base.runtime,
+        getSnapshot: vi.fn(() => responseSnapshot)
+      },
+      archiveAvailability: {
+        withSessionAvailable: async <Result>(
+          _projectId: string,
+          _sessionId: string,
+          operation: () => Promise<Result>
+        ): Promise<Result> => operation(),
+        withSessionAvailableById
+      },
+      respondDelegatedQuestion
+    }
+    const router = createApplicationCommandRouter()
+    registerAcpCommands(router.registrar, dependencies)
+
+    await expect(
+      router.dispatcher.invoke(
+        acpCommands.respondPermission,
+        invocation([
+          {
+            requestId: 'permission-1',
+            optionId: 'allow-once',
+            restored: { projectId: 'forged-project', sessionId: 'forged-session' }
+          }
+        ])
+      )
+    ).rejects.toThrow('Permission response Session does not match the pending request.')
+    await expect(
+      router.dispatcher.invoke(
+        acpCommands.respondElicitation,
+        invocation([
+          {
+            requestId: 'question-1',
+            action: 'decline',
+            request: {
+              requestId: 'question-1',
+              sessionId: 'forged-session',
+              toolCallId: 'tool-2',
+              message: 'Choose',
+              fields: []
+            }
+          }
+        ])
+      )
+    ).rejects.toThrow('Structured input response Session does not match the pending request.')
+    await expect(
+      router.dispatcher.invoke(
+        acpCommands.respondElicitation,
+        invocation([
+          {
+            requestId: 'question-1',
+            action: 'accept',
+            delegatedQuestion: {
+              projectId: 'forged-project',
+              sessionId: 'forged-session',
+              action: 'confirm',
+              answers: []
+            }
+          }
+        ])
+      )
+    ).rejects.toThrow('Structured input response Session does not match the pending request.')
+    await expect(
+      router.dispatcher.invoke(
+        acpCommands.respondPermission,
+        invocation([{ requestId: 'unknown-permission', optionId: 'allow-once' }])
+      )
+    ).rejects.toThrow('Unknown permission request.')
+    await expect(
+      router.dispatcher.invoke(
+        acpCommands.respondElicitation,
+        invocation([{ requestId: 'unknown-question', action: 'decline' }])
+      )
+    ).rejects.toThrow('Unknown structured input request.')
+
+    expect(admitted).toEqual([])
+    expect(dependencies.runtime.respondToPermission).not.toHaveBeenCalled()
+    expect(dependencies.runtime.respondToElicitation).not.toHaveBeenCalled()
+    expect(respondDelegatedQuestion).not.toHaveBeenCalled()
   })
 
   it('exposes Plan projection reads to the same current human callers on Electron and Web', async () => {

--- a/src/main/acp/application-commands.ts
+++ b/src/main/acp/application-commands.ts
@@ -172,6 +172,34 @@ type AcpApplicationCommandDependencies = Readonly<{
   ) => Promise<void>
 }>
 
+const permissionResponseSessionId = (
+  runtime: Pick<AcpApplicationCommandRuntime, 'getSnapshot'>,
+  response: AcpPermissionResponse
+): string | undefined =>
+  response.restored?.sessionId ??
+  runtime
+    .getSnapshot()
+    .pendingPermissions.find((request) => request.requestId === response.requestId)?.sessionId
+
+const elicitationResponseSessionId = (
+  runtime: Pick<AcpApplicationCommandRuntime, 'getSnapshot'>,
+  response: ElicitationResponse
+): string | undefined =>
+  response.delegatedQuestion?.sessionId ??
+  response.request?.sessionId ??
+  runtime
+    .getSnapshot()
+    .pendingElicitations?.find((request) => request.requestId === response.requestId)?.sessionId
+
+const withResponseAdmission = <Result>(
+  archiveAvailability: AcpApplicationCommandDependencies['archiveAvailability'],
+  sessionId: string | undefined,
+  operation: () => Promise<Result>
+): Promise<Result> =>
+  archiveAvailability && sessionId
+    ? archiveAvailability.withSessionAvailableById(sessionId, operation)
+    : operation()
+
 const registerAcpCommands = (
   registrar: ApplicationCommandRegistrar,
   dependencies: AcpApplicationCommandDependencies
@@ -232,30 +260,45 @@ const registerAcpCommands = (
         if (!canSatisfyHumanApproval(invocation.callerContext)) {
           throw new Error('Only a current human caller can respond to permission requests.')
         }
-        return dependencies.runtime.respondToPermission(invocation.args[0])
+        const response = invocation.args[0]
+        const sessionId = dependencies.archiveAvailability
+          ? permissionResponseSessionId(dependencies.runtime, response)
+          : undefined
+        return withResponseAdmission(dependencies.archiveAvailability, sessionId, () =>
+          dependencies.runtime.respondToPermission(response)
+        )
       },
       'acp:respond-elicitation': (invocation) => {
         if (!canSatisfyHumanApproval(invocation.callerContext)) {
           throw new Error('Only a current human caller can respond to structured questions.')
         }
         const response = invocation.args[0]
-        if (response.delegatedQuestion) {
-          if (!dependencies.respondDelegatedQuestion) {
-            throw new Error('Delegated question response owner is unavailable.')
+        const sessionId = dependencies.archiveAvailability
+          ? elicitationResponseSessionId(dependencies.runtime, response)
+          : undefined
+        return withResponseAdmission(dependencies.archiveAvailability, sessionId, () => {
+          if (response.delegatedQuestion) {
+            if (!dependencies.respondDelegatedQuestion) {
+              throw new Error('Delegated question response owner is unavailable.')
+            }
+            return dependencies
+              .respondDelegatedQuestion({
+                ...response.delegatedQuestion,
+                requestId: response.requestId
+              })
+              .then(() => dependencies.runtime.getSnapshot())
           }
-          return dependencies
-            .respondDelegatedQuestion({
-              ...response.delegatedQuestion,
-              requestId: response.requestId
-            })
-            .then(() => dependencies.runtime.getSnapshot())
-        }
-        return dependencies.runtime.respondToElicitation(response)
+          return dependencies.runtime.respondToElicitation(response)
+        })
       },
       'acp:set-permission-profile': (invocation) =>
-        dependencies.runtime.setPermissionProfile(invocation.args[0]),
+        withResponseAdmission(dependencies.archiveAvailability, invocation.args[0].sessionId, () =>
+          dependencies.runtime.setPermissionProfile(invocation.args[0])
+        ),
       'acp:revoke-permission-grant': (invocation) =>
-        dependencies.runtime.revokePermissionGrant(invocation.args[0]),
+        withResponseAdmission(dependencies.archiveAvailability, invocation.args[0].sessionId, () =>
+          dependencies.runtime.revokePermissionGrant(invocation.args[0])
+        ),
       'acp:get-plan-projection': (invocation) => {
         if (!canSatisfyHumanApproval(invocation.callerContext)) {
           throw new Error('Only a current human caller can access a Session Plan.')

--- a/src/main/acp/application-commands.ts
+++ b/src/main/acp/application-commands.ts
@@ -23,6 +23,10 @@ import {
 } from '../application-command-router'
 import { canSatisfyHumanApproval } from '../caller-context'
 import type { AcpHandlerWorkflows } from './handler-workflows'
+import {
+  resolveElicitationResponseSessionId,
+  resolvePermissionResponseSessionId
+} from './response-session-admission'
 import type { AcpRuntimeCoordinator } from './runtime-coordinator'
 import type { ActivePlanProjection } from '../../shared/session-plan/contract'
 
@@ -172,25 +176,6 @@ type AcpApplicationCommandDependencies = Readonly<{
   ) => Promise<void>
 }>
 
-const permissionResponseSessionId = (
-  runtime: Pick<AcpApplicationCommandRuntime, 'getSnapshot'>,
-  response: AcpPermissionResponse
-): string | undefined =>
-  response.restored?.sessionId ??
-  runtime
-    .getSnapshot()
-    .pendingPermissions.find((request) => request.requestId === response.requestId)?.sessionId
-
-const elicitationResponseSessionId = (
-  runtime: Pick<AcpApplicationCommandRuntime, 'getSnapshot'>,
-  response: ElicitationResponse
-): string | undefined =>
-  response.delegatedQuestion?.sessionId ??
-  response.request?.sessionId ??
-  runtime
-    .getSnapshot()
-    .pendingElicitations?.find((request) => request.requestId === response.requestId)?.sessionId
-
 const withResponseAdmission = <Result>(
   archiveAvailability: AcpApplicationCommandDependencies['archiveAvailability'],
   sessionId: string | undefined,
@@ -262,7 +247,7 @@ const registerAcpCommands = (
         }
         const response = invocation.args[0]
         const sessionId = dependencies.archiveAvailability
-          ? permissionResponseSessionId(dependencies.runtime, response)
+          ? resolvePermissionResponseSessionId(dependencies.runtime.getSnapshot(), response)
           : undefined
         return withResponseAdmission(dependencies.archiveAvailability, sessionId, () =>
           dependencies.runtime.respondToPermission(response)
@@ -274,7 +259,7 @@ const registerAcpCommands = (
         }
         const response = invocation.args[0]
         const sessionId = dependencies.archiveAvailability
-          ? elicitationResponseSessionId(dependencies.runtime, response)
+          ? resolveElicitationResponseSessionId(dependencies.runtime.getSnapshot(), response)
           : undefined
         return withResponseAdmission(dependencies.archiveAvailability, sessionId, () => {
           if (response.delegatedQuestion) {

--- a/src/main/acp/create-session-workflow.test.ts
+++ b/src/main/acp/create-session-workflow.test.ts
@@ -64,6 +64,41 @@ const createHarness = (
 }
 
 describe('ACP create-Session workflow', () => {
+  it('holds Project admission through Session publication', async () => {
+    const created = createDeferred<AcpCreateSessionResponse>()
+    let admissionActive = false
+    const createSession = vi.fn(async () => {
+      expect(admissionActive).toBe(true)
+      return created.promise
+    })
+    const withProjectAvailable = async <Result>(
+      projectId: string | undefined,
+      operation: () => Promise<Result>
+    ): Promise<Result> => {
+      expect(projectId).toBe('project-1')
+      admissionActive = true
+      try {
+        return await operation()
+      } finally {
+        admissionActive = false
+      }
+    }
+    const workflow = createAcpCreateSessionWorkflow({ createSession }, { withProjectAvailable })
+
+    const pending = workflow.create({
+      cwd: '/workspace',
+      projectName: 'project-1',
+      permissionProfile: 'ask'
+    })
+    await vi.waitFor(() => expect(createSession).toHaveBeenCalledOnce())
+    expect(admissionActive).toBe(true)
+
+    created.resolve({ sessionId: 'session-1', cwd: '/workspace' })
+    await pending
+
+    expect(admissionActive).toBe(false)
+  })
+
   it('trims and uses an explicit workspace without acquiring managed storage', async () => {
     const harness = createHarness()
     const request = {
@@ -125,3 +160,14 @@ describe('ACP create-Session workflow', () => {
     }
   )
 })
+
+const createDeferred = <Value>(): {
+  promise: Promise<Value>
+  resolve: (value: Value) => void
+} => {
+  let resolve!: (value: Value) => void
+  const promise = new Promise<Value>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}

--- a/src/main/acp/create-session-workflow.ts
+++ b/src/main/acp/create-session-workflow.ts
@@ -14,7 +14,10 @@ type DataRootWrite = <Result>(write: () => Promise<Result>) => Promise<Result>
 type AcpCreateSessionWorkflowDependencies = {
   workspaces: ManagedSessionWorkspaceCapability
   withDataRootWrite: DataRootWrite
-  assertProjectAvailable(projectId: string | undefined): Promise<void>
+  withProjectAvailable<Result>(
+    projectId: string | undefined,
+    operation: () => Promise<Result>
+  ): Promise<Result>
 }
 
 type AcpCreateSessionWorkflow = {
@@ -33,22 +36,26 @@ const createAcpCreateSessionWorkflow = (
 
   return {
     async create(request: AcpCreateSessionRequest): Promise<AcpCreateSessionResponse> {
-      await dependencies.assertProjectAvailable?.(request.projectName)
-      const explicitCwd = request.cwd?.trim()
-      if (explicitCwd) {
-        return sessions.createSession({ ...request, cwd: explicitCwd })
-      }
-
-      return runDataRootWrite(async () => {
-        const workspace = await workspaces.acquire()
-        try {
-          const response = await sessions.createSession({ ...request, cwd: workspace.cwd })
-          workspace.commit()
-          return response
-        } finally {
-          await workspace.release()
+      const createAvailableSession = async (): Promise<AcpCreateSessionResponse> => {
+        const explicitCwd = request.cwd?.trim()
+        if (explicitCwd) {
+          return sessions.createSession({ ...request, cwd: explicitCwd })
         }
-      })
+
+        return runDataRootWrite(async () => {
+          const workspace = await workspaces.acquire()
+          try {
+            const response = await sessions.createSession({ ...request, cwd: workspace.cwd })
+            workspace.commit()
+            return response
+          } finally {
+            await workspace.release()
+          }
+        })
+      }
+      return dependencies.withProjectAvailable
+        ? dependencies.withProjectAvailable(request.projectName, createAvailableSession)
+        : createAvailableSession()
     }
   }
 }

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -372,6 +372,104 @@ it('rejects ACP response mutations before runtime work when Session admission is
   expect(responseRuntime.revokePermissionGrant).not.toHaveBeenCalled()
 })
 
+it('rejects forged and unknown ACP response authority before Session admission', () => {
+  const admitted: string[] = []
+  const withSessionAvailableById = <Result>(
+    sessionId: string,
+    operation: () => Promise<Result>
+  ): Promise<Result> => {
+    admitted.push(sessionId)
+    return operation()
+  }
+  const responseRuntime = {
+    getSnapshot: vi.fn(() => ({
+      status: 'idle',
+      cwd: '/workspace',
+      sessionIds: ['permission-session', 'elicitation-session', 'forged-session'],
+      events: [],
+      pendingPermissions: [
+        {
+          requestId: 'permission-1',
+          sessionId: 'permission-session',
+          toolCallId: 'tool-1',
+          title: 'Use a tool',
+          options: []
+        }
+      ],
+      pendingElicitations: [
+        {
+          requestId: 'question-1',
+          sessionId: 'elicitation-session',
+          toolCallId: 'tool-2',
+          message: 'Choose',
+          fields: []
+        }
+      ],
+      permissionProfiles: {},
+      permissionGrants: {},
+      promptInFlight: false,
+      promptInFlightSessionIds: [],
+      contextUsageBySession: {}
+    })),
+    respondToPermission: vi.fn(),
+    respondToElicitation: vi.fn()
+  }
+  const respondDelegatedQuestion = vi.fn()
+  installAcpIpcHandlers(responseRuntime as never, {} as never, respondDelegatedQuestion, {
+    withSessionAvailableById
+  })
+
+  expect(() =>
+    handlers.get('acp:respond-permission')?.(undefined, {
+      requestId: 'permission-1',
+      optionId: 'allow-once',
+      restored: { projectId: 'forged-project', sessionId: 'forged-session' }
+    })
+  ).toThrow('Permission response Session does not match the pending request.')
+  expect(() =>
+    handlers.get('acp:respond-elicitation')?.(undefined, {
+      requestId: 'question-1',
+      action: 'decline',
+      request: {
+        requestId: 'question-1',
+        sessionId: 'forged-session',
+        toolCallId: 'tool-2',
+        message: 'Choose',
+        fields: []
+      }
+    })
+  ).toThrow('Structured input response Session does not match the pending request.')
+  expect(() =>
+    handlers.get('acp:respond-elicitation')?.(undefined, {
+      requestId: 'question-1',
+      action: 'accept',
+      delegatedQuestion: {
+        projectId: 'forged-project',
+        sessionId: 'forged-session',
+        action: 'confirm',
+        answers: []
+      }
+    })
+  ).toThrow('Structured input response Session does not match the pending request.')
+  expect(() =>
+    handlers.get('acp:respond-permission')?.(undefined, {
+      requestId: 'unknown-permission',
+      optionId: 'allow-once'
+    })
+  ).toThrow('Unknown permission request.')
+  expect(() =>
+    handlers.get('acp:respond-elicitation')?.(undefined, {
+      requestId: 'unknown-question',
+      action: 'decline'
+    })
+  ).toThrow('Unknown structured input request.')
+
+  expect(admitted).toEqual([])
+  expect(responseRuntime.respondToPermission).not.toHaveBeenCalled()
+  expect(responseRuntime.respondToElicitation).not.toHaveBeenCalled()
+  expect(respondDelegatedQuestion).not.toHaveBeenCalled()
+})
+
 describe('ACP module transport seam', () => {
   it('holds archive admission until Save as skill is accepted without awaiting turn completion', async () => {
     const session = materializeSessionConversationGraph({

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -140,6 +140,12 @@ const { createAcpRuntime } = await import('./runtime-composition')
 const { createAcpCreateSessionWorkflow } = await import('./create-session-workflow')
 const { createAcpHandlerWorkflows } = await import('./handler-workflows')
 type AcpTestOptions = Parameters<typeof createAcpRuntime>[0]
+const passThroughSessionAdmission = {
+  withSessionAvailableById: <Result>(
+    _sessionId: string,
+    operation: () => Promise<Result>
+  ): Promise<Result> => operation()
+}
 
 // Minimal options — createRuntime just forwards them into the mocked AcpRuntime constructor.
 const registerWithFakes = (overrides?: {
@@ -205,7 +211,9 @@ const registerWithFakes = (overrides?: {
       options.taskNotifications,
       overrides?.archiveAvailability,
       overrides?.interruptedTurnSessions
-    )
+    ),
+    undefined,
+    overrides?.archiveAvailability ?? passThroughSessionAdmission
   )
   return options as AcpTestOptions
 }
@@ -239,7 +247,8 @@ it('routes delegated question responses to their owner without touching Main eli
   installAcpIpcHandlers(
     { respondToElicitation, getSnapshot: () => snapshot } as never,
     {} as never,
-    respondDelegatedQuestion
+    respondDelegatedQuestion,
+    passThroughSessionAdmission
   )
 
   await expect(
@@ -411,7 +420,9 @@ describe('ACP module transport seam', () => {
     const createSessionWorkflow = createAcpCreateSessionWorkflow(runtime)
     installAcpIpcHandlers(
       runtime,
-      createAcpHandlerWorkflows(runtime, createSessionWorkflow, options.taskNotifications)
+      createAcpHandlerWorkflows(runtime, createSessionWorkflow, options.taskNotifications),
+      undefined,
+      passThroughSessionAdmission
     )
 
     expect(handlers.has('acp:get-state')).toBe(true)
@@ -898,6 +909,27 @@ describe('installAcpIpcHandlers — reset-session-context bridge', () => {
     expect(resumeSession).not.toHaveBeenCalled()
     expect(result).toEqual({ sessionId: 's-1', cwd: '/workspace', contextReset: true })
   })
+
+  it('rejects reset before runtime mutation when Session admission is closed', async () => {
+    const failure = new Error('Project is being deleted.')
+    const withSessionAvailableById = vi.fn().mockRejectedValue(failure)
+    registerWithFakes({
+      archiveAvailability: {
+        withSessionAvailable: async <Result>(
+          _projectId: string,
+          _sessionId: string,
+          operation: () => Promise<Result>
+        ): Promise<Result> => operation(),
+        withSessionAvailableById
+      }
+    })
+    const request: AcpResumeSessionRequest = { sessionId: 's-1', cwd: '/workspace' }
+
+    await expect(handlers.get('acp:reset-session-context')?.({}, request)).rejects.toBe(failure)
+
+    expect(withSessionAvailableById).toHaveBeenCalledWith('s-1', expect.any(Function))
+    expect(resetSessionContext).not.toHaveBeenCalled()
+  })
 })
 
 describe('installAcpIpcHandlers — resume-session diagnostics', () => {
@@ -1084,6 +1116,27 @@ describe('installAcpIpcHandlers — native context compaction bridge', () => {
     expect(compactSession).toHaveBeenCalledOnce()
     expect(compactSession).toHaveBeenCalledWith(request)
     expect(result).toMatchObject({ status: 'idle', cwd: '/workspace' })
+  })
+
+  it('rejects compaction before runtime mutation when Session admission is closed', async () => {
+    const failure = new Error('Project is being deleted.')
+    const withSessionAvailableById = vi.fn().mockRejectedValue(failure)
+    registerWithFakes({
+      archiveAvailability: {
+        withSessionAvailable: async <Result>(
+          _projectId: string,
+          _sessionId: string,
+          operation: () => Promise<Result>
+        ): Promise<Result> => operation(),
+        withSessionAvailableById
+      }
+    })
+    const request: AcpCompactSessionRequest = { sessionId: 's-1' }
+
+    await expect(handlers.get('acp:compact-session')?.({}, request)).rejects.toBe(failure)
+
+    expect(withSessionAvailableById).toHaveBeenCalledWith('s-1', expect.any(Function))
+    expect(compactSession).not.toHaveBeenCalled()
   })
 })
 

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -274,6 +274,104 @@ it('routes delegated question responses to their owner without touching Main eli
   expect(respondToElicitation).not.toHaveBeenCalled()
 })
 
+it('rejects ACP response mutations before runtime work when Session admission is closed', async () => {
+  const failure = new Error('Project is being deleted.')
+  const admitted: string[] = []
+  const sessionAdmission = {
+    withSessionAvailableById: async <Result>(
+      sessionId: string,
+      operation: () => Promise<Result>
+    ): Promise<Result> => {
+      void operation
+      admitted.push(sessionId)
+      throw failure
+    }
+  }
+  const responseSnapshot = {
+    status: 'idle',
+    cwd: '/workspace',
+    sessionIds: ['permission-session', 'elicitation-session'],
+    events: [],
+    pendingPermissions: [
+      {
+        requestId: 'permission-1',
+        sessionId: 'permission-session',
+        toolCallId: 'tool-1',
+        title: 'Use a tool',
+        options: []
+      }
+    ],
+    pendingElicitations: [
+      {
+        requestId: 'question-1',
+        sessionId: 'elicitation-session',
+        toolCallId: 'tool-2',
+        message: 'Choose',
+        fields: []
+      }
+    ],
+    permissionProfiles: {},
+    permissionGrants: {},
+    promptInFlight: false,
+    promptInFlightSessionIds: [],
+    contextUsageBySession: {}
+  }
+  const responseRuntime = {
+    getSnapshot: vi.fn(() => responseSnapshot),
+    respondToPermission: vi.fn(),
+    respondToElicitation: vi.fn(),
+    respondSessionPlan: vi.fn(),
+    setPermissionProfile: vi.fn(),
+    revokePermissionGrant: vi.fn()
+  }
+  installAcpIpcHandlers(responseRuntime as never, {} as never, undefined, sessionAdmission)
+
+  await expect(
+    handlers.get('acp:respond-permission')?.(undefined, {
+      requestId: 'permission-1',
+      optionId: 'allow-once'
+    })
+  ).rejects.toBe(failure)
+  await expect(
+    handlers.get('acp:respond-elicitation')?.(undefined, {
+      requestId: 'question-1',
+      action: 'decline'
+    })
+  ).rejects.toBe(failure)
+  await expect(
+    handlers.get('acp:respond-plan')?.(undefined, {
+      projectId: 'project-1',
+      sessionId: 'plan-session',
+      feedback: 'Revise the plan.'
+    })
+  ).rejects.toBe(failure)
+  await expect(
+    handlers.get('acp:set-permission-profile')?.(undefined, {
+      sessionId: 'profile-session',
+      profile: 'auto'
+    })
+  ).rejects.toBe(failure)
+  await expect(
+    handlers.get('acp:revoke-permission-grant')?.(undefined, {
+      sessionId: 'profile-session',
+      categoryKey: 'mcp:tool'
+    })
+  ).rejects.toBe(failure)
+
+  expect(admitted).toEqual([
+    'permission-session',
+    'elicitation-session',
+    'plan-session',
+    'profile-session',
+    'profile-session'
+  ])
+  expect(responseRuntime.respondToPermission).not.toHaveBeenCalled()
+  expect(responseRuntime.respondToElicitation).not.toHaveBeenCalled()
+  expect(responseRuntime.respondSessionPlan).not.toHaveBeenCalled()
+  expect(responseRuntime.setPermissionProfile).not.toHaveBeenCalled()
+  expect(responseRuntime.revokePermissionGrant).not.toHaveBeenCalled()
+})
+
 describe('ACP module transport seam', () => {
   it('holds archive admission until Save as skill is accepted without awaiting turn completion', async () => {
     const session = materializeSessionConversationGraph({

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -32,6 +32,32 @@ type AcpIpcSessionAdmission = {
   ): Promise<Result>
 }
 
+const permissionResponseSessionId = (
+  runtime: AcpRuntimeCoordinator,
+  response: AcpPermissionResponse
+): string | undefined =>
+  response.restored?.sessionId ??
+  runtime
+    .getSnapshot()
+    .pendingPermissions.find((request) => request.requestId === response.requestId)?.sessionId
+
+const elicitationResponseSessionId = (
+  runtime: AcpRuntimeCoordinator,
+  response: ElicitationResponse
+): string | undefined =>
+  response.delegatedQuestion?.sessionId ??
+  response.request?.sessionId ??
+  runtime
+    .getSnapshot()
+    .pendingElicitations?.find((request) => request.requestId === response.requestId)?.sessionId
+
+const withResponseAdmission = <Result>(
+  sessionAdmission: AcpIpcSessionAdmission,
+  sessionId: string | undefined,
+  operation: () => Promise<Result>
+): Promise<Result> =>
+  sessionId ? sessionAdmission.withSessionAvailableById(sessionId, operation) : operation()
+
 const registerAcpIpcHandlerSet = (
   runtime: AcpRuntimeCoordinator,
   workflows: AcpHandlerWorkflows,
@@ -93,7 +119,9 @@ const registerAcpIpcHandlerSet = (
     return runtime.deleteSession(request)
   })
   ipcMainHandle('acp:respond-permission', (_event, response: AcpPermissionResponse) =>
-    runtime.respondToPermission(response)
+    withResponseAdmission(sessionAdmission, permissionResponseSessionId(runtime, response), () =>
+      runtime.respondToPermission(response)
+    )
   )
   ipcMainHandle('acp:get-plan-projection', (_event, projectId: string, sessionId: string) =>
     runtime.getSessionPlanProjection(projectId, sessionId)
@@ -101,25 +129,37 @@ const registerAcpIpcHandlerSet = (
   ipcMainHandle(
     'acp:respond-plan',
     (_event, request: Parameters<AcpRuntimeCoordinator['respondSessionPlan']>[0]) =>
-      runtime.respondSessionPlan(request)
+      sessionAdmission.withSessionAvailableById(request.sessionId, () =>
+        runtime.respondSessionPlan(request)
+      )
   )
   ipcMainHandle('acp:respond-elicitation', (_event, response: ElicitationResponse) => {
-    if (response.delegatedQuestion) {
-      if (!respondDelegatedQuestion) {
-        throw new Error('Delegated question response owner is unavailable.')
+    return withResponseAdmission(
+      sessionAdmission,
+      elicitationResponseSessionId(runtime, response),
+      () => {
+        if (response.delegatedQuestion) {
+          if (!respondDelegatedQuestion) {
+            throw new Error('Delegated question response owner is unavailable.')
+          }
+          return respondDelegatedQuestion({
+            ...response.delegatedQuestion,
+            requestId: response.requestId
+          }).then(() => runtime.getSnapshot())
+        }
+        return runtime.respondToElicitation(response)
       }
-      return respondDelegatedQuestion({
-        ...response.delegatedQuestion,
-        requestId: response.requestId
-      }).then(() => runtime.getSnapshot())
-    }
-    return runtime.respondToElicitation(response)
+    )
   })
   ipcMainHandle('acp:set-permission-profile', (_event, request: AcpSetPermissionProfileRequest) =>
-    runtime.setPermissionProfile(request)
+    sessionAdmission.withSessionAvailableById(request.sessionId, () =>
+      runtime.setPermissionProfile(request)
+    )
   )
   ipcMainHandle('acp:revoke-permission-grant', (_event, request: AcpRevokePermissionGrantRequest) =>
-    runtime.revokePermissionGrant(request)
+    sessionAdmission.withSessionAvailableById(request.sessionId, () =>
+      runtime.revokePermissionGrant(request)
+    )
   )
 }
 

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -25,9 +25,17 @@ import { AcpRuntimeCoordinator } from './runtime-coordinator'
 import type { AcpHandlerWorkflows } from './handler-workflows'
 import { installAgentShutdownGuard } from './shutdown-guard'
 
+type AcpIpcSessionAdmission = {
+  withSessionAvailableById<Result>(
+    sessionId: string,
+    operation: () => Promise<Result>
+  ): Promise<Result>
+}
+
 const registerAcpIpcHandlerSet = (
   runtime: AcpRuntimeCoordinator,
   workflows: AcpHandlerWorkflows,
+  sessionAdmission: AcpIpcSessionAdmission,
   respondDelegatedQuestion?: (
     input: NonNullable<ElicitationResponse['delegatedQuestion']> & { requestId: string }
   ) => Promise<void>
@@ -47,10 +55,14 @@ const registerAcpIpcHandlerSet = (
       workflows.continueInterruptedTurn(request)
   )
   ipcMainHandle('acp:reset-session-context', (_event, request: AcpResumeSessionRequest) =>
-    runtime.resetSessionContext(request)
+    sessionAdmission.withSessionAvailableById(request.sessionId, () =>
+      runtime.resetSessionContext(request)
+    )
   )
   ipcMainHandle('acp:compact-session', (_event, request: AcpCompactSessionRequest) =>
-    runtime.compactSession(request)
+    sessionAdmission.withSessionAvailableById(request.sessionId, () =>
+      runtime.compactSession(request)
+    )
   )
   // Prompt calls wait for the turn to stop, then return the latest snapshot.
   ipcMainHandle('acp:send-prompt', (_event, request: AcpPromptRequest) => {
@@ -115,13 +127,16 @@ const registerAcpIpcHandlerSet = (
 const installAcpIpcHandlers = (
   runtime: AcpRuntimeCoordinator,
   workflows: AcpHandlerWorkflows,
-  respondDelegatedQuestion?: (
-    input: NonNullable<ElicitationResponse['delegatedQuestion']> & { requestId: string }
-  ) => Promise<void>
+  respondDelegatedQuestion:
+    | ((
+        input: NonNullable<ElicitationResponse['delegatedQuestion']> & { requestId: string }
+      ) => Promise<void>)
+    | undefined,
+  sessionAdmission: AcpIpcSessionAdmission
 ): IpcHandlerInstallation => {
   const scope = createIpcHandlerInstallationScope()
   try {
-    registerAcpIpcHandlerSet(runtime, workflows, respondDelegatedQuestion)
+    registerAcpIpcHandlerSet(runtime, workflows, sessionAdmission, respondDelegatedQuestion)
     // Kill the agent child on quit so it never outlives the app as an orphaned process.
     return scope.complete(installAgentShutdownGuard(app, runtime))
   } catch (error) {
@@ -131,3 +146,4 @@ const installAcpIpcHandlers = (
 }
 
 export { installAcpIpcHandlers }
+export type { AcpIpcSessionAdmission }

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -23,6 +23,10 @@ import type {
 } from '../../shared/acp'
 import { AcpRuntimeCoordinator } from './runtime-coordinator'
 import type { AcpHandlerWorkflows } from './handler-workflows'
+import {
+  resolveElicitationResponseSessionId,
+  resolvePermissionResponseSessionId
+} from './response-session-admission'
 import { installAgentShutdownGuard } from './shutdown-guard'
 
 type AcpIpcSessionAdmission = {
@@ -31,25 +35,6 @@ type AcpIpcSessionAdmission = {
     operation: () => Promise<Result>
   ): Promise<Result>
 }
-
-const permissionResponseSessionId = (
-  runtime: AcpRuntimeCoordinator,
-  response: AcpPermissionResponse
-): string | undefined =>
-  response.restored?.sessionId ??
-  runtime
-    .getSnapshot()
-    .pendingPermissions.find((request) => request.requestId === response.requestId)?.sessionId
-
-const elicitationResponseSessionId = (
-  runtime: AcpRuntimeCoordinator,
-  response: ElicitationResponse
-): string | undefined =>
-  response.delegatedQuestion?.sessionId ??
-  response.request?.sessionId ??
-  runtime
-    .getSnapshot()
-    .pendingElicitations?.find((request) => request.requestId === response.requestId)?.sessionId
 
 const withResponseAdmission = <Result>(
   sessionAdmission: AcpIpcSessionAdmission,
@@ -119,8 +104,10 @@ const registerAcpIpcHandlerSet = (
     return runtime.deleteSession(request)
   })
   ipcMainHandle('acp:respond-permission', (_event, response: AcpPermissionResponse) =>
-    withResponseAdmission(sessionAdmission, permissionResponseSessionId(runtime, response), () =>
-      runtime.respondToPermission(response)
+    withResponseAdmission(
+      sessionAdmission,
+      resolvePermissionResponseSessionId(runtime.getSnapshot(), response),
+      () => runtime.respondToPermission(response)
     )
   )
   ipcMainHandle('acp:get-plan-projection', (_event, projectId: string, sessionId: string) =>
@@ -136,7 +123,7 @@ const registerAcpIpcHandlerSet = (
   ipcMainHandle('acp:respond-elicitation', (_event, response: ElicitationResponse) => {
     return withResponseAdmission(
       sessionAdmission,
-      elicitationResponseSessionId(runtime, response),
+      resolveElicitationResponseSessionId(runtime.getSnapshot(), response),
       () => {
         if (response.delegatedQuestion) {
           if (!respondDelegatedQuestion) {

--- a/src/main/acp/response-session-admission.ts
+++ b/src/main/acp/response-session-admission.ts
@@ -1,0 +1,72 @@
+import type { AcpPermissionResponse, AcpStateSnapshot, ElicitationResponse } from '../../shared/acp'
+
+type AcpResponseAdmissionSnapshot = Pick<
+  AcpStateSnapshot,
+  'pendingPermissions' | 'pendingElicitations'
+>
+
+const assertMatchingSession = (
+  authoritativeSessionId: string,
+  suppliedSessionId: string | undefined,
+  responseKind: string
+): void => {
+  if (suppliedSessionId && suppliedSessionId !== authoritativeSessionId) {
+    throw new Error(`${responseKind} Session does not match the pending request.`)
+  }
+}
+
+const resolvePermissionResponseSessionId = (
+  snapshot: AcpResponseAdmissionSnapshot,
+  response: AcpPermissionResponse
+): string => {
+  // A live request id is authoritative. The restored locator is only an admission locator when no
+  // live request exists; the permission owner still validates its durable authority before mutation.
+  const pending = snapshot.pendingPermissions.find(
+    (request) => request.requestId === response.requestId
+  )
+  if (pending) {
+    assertMatchingSession(pending.sessionId, response.restored?.sessionId, 'Permission response')
+    return pending.sessionId
+  }
+  if (response.restored) return response.restored.sessionId
+  throw new Error('Unknown permission request.')
+}
+
+const resolveElicitationResponseSessionId = (
+  snapshot: AcpResponseAdmissionSnapshot,
+  response: ElicitationResponse
+): string => {
+  if (response.request && response.request.requestId !== response.requestId) {
+    throw new Error('Structured input response request does not match its restored authority.')
+  }
+
+  // Detached durable questions and delegated questions are absent from the live ACP queue. Their
+  // owners validate the echoed request/project authority after this Session admission check.
+  const pending = snapshot.pendingElicitations?.find(
+    (request) => request.requestId === response.requestId
+  )
+  if (pending) {
+    assertMatchingSession(
+      pending.sessionId,
+      response.request?.sessionId,
+      'Structured input response'
+    )
+    assertMatchingSession(
+      pending.sessionId,
+      response.delegatedQuestion?.sessionId,
+      'Structured input response'
+    )
+    return pending.sessionId
+  }
+
+  const restoredSessionId = response.request?.sessionId
+  const delegatedSessionId = response.delegatedQuestion?.sessionId
+  if (restoredSessionId && delegatedSessionId && restoredSessionId !== delegatedSessionId) {
+    throw new Error('Structured input response Session locators do not match.')
+  }
+  if (delegatedSessionId) return delegatedSessionId
+  if (restoredSessionId) return restoredSessionId
+  throw new Error('Unknown structured input request.')
+}
+
+export { resolveElicitationResponseSessionId, resolvePermissionResponseSessionId }

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -1662,8 +1662,8 @@ describe('AcpRuntimeCoordinator', () => {
       return fake.runtime
     })
 
-    const activeSession = await coordinator.createSession()
-    const idleSession = await coordinator.createSession()
+    const activeSession = await coordinator.createSession({ projectName: 'other-project' })
+    const idleSession = await coordinator.createSession({ projectName: 'deleting-project' })
     created[0].emitState({
       promptInFlight: true,
       promptInFlightSessionIds: [activeSession.sessionId]
@@ -1672,6 +1672,11 @@ describe('AcpRuntimeCoordinator', () => {
     const reloadRequest = coordinator.requestSkillsReload()
 
     expect(coordinator.getSnapshot().sessionIds).toEqual([activeSession.sessionId])
+    expect(coordinator.getOwnedSessionIds()).toEqual([
+      activeSession.sessionId,
+      idleSession.sessionId
+    ])
+    expect(coordinator.liveSessionProjectId(idleSession.sessionId)).toBe('deleting-project')
     await expect(
       coordinator.sendPrompt({ sessionId: idleSession.sessionId, text: 'stale turn' })
     ).rejects.toThrow('resume')

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -1366,6 +1366,34 @@ describe('AcpRuntimeCoordinator', () => {
     expect(createdRuntime.sendAppContinuation).toHaveBeenCalledOnce()
   })
 
+  it('does not reacquire dispatch admission for an already admitted continuation', async () => {
+    let createdRuntime!: ReturnType<typeof createFakeRuntime>
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      createdRuntime = createFakeRuntime({
+        frameworkId: 'claude-code',
+        sessionIds: ['session-1'],
+        callbacks
+      })
+      return createdRuntime.runtime
+    })
+    const session = await coordinator.createSession({ cwd: '/workspace' })
+    const admittedSessionIds: string[] = []
+    coordinator.setPromptDispatchAdmissionGuard(async (sessionId, dispatch) => {
+      admittedSessionIds.push(sessionId)
+      return dispatch()
+    })
+
+    await expect(
+      coordinator.startContinuationWhenDispatchAdmitted(
+        { sessionId: session.sessionId, text: 'already deletion-admitted' },
+        async () => undefined
+      )
+    ).resolves.toBe('provider_prompt_accepted')
+
+    expect(admittedSessionIds).toEqual([])
+    expect(createdRuntime.sendAppContinuation).toHaveBeenCalledOnce()
+  })
+
   it('stops a prompt for handoff without reporting a user generation cancellation', async () => {
     const onSessionCancellationRequested = vi.fn()
     const fake = createFakeRuntime({

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -1331,6 +1331,39 @@ describe('AcpRuntimeCoordinator', () => {
     expect(createdRuntime.sendAppContinuation).toHaveBeenCalledOnce()
   })
 
+  it('applies the final dispatch admission wrapper to app-owned continuations', async () => {
+    const admission = createDeferred<void>()
+    let createdRuntime!: ReturnType<typeof createFakeRuntime>
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      createdRuntime = createFakeRuntime({
+        frameworkId: 'claude-code',
+        sessionIds: ['session-1'],
+        callbacks
+      })
+      return createdRuntime.runtime
+    })
+    const session = await coordinator.createSession({ cwd: '/workspace' })
+    const admittedSessionIds: string[] = []
+    coordinator.setPromptDispatchAdmissionGuard(async (sessionId, dispatch) => {
+      admittedSessionIds.push(sessionId)
+      await admission.promise
+      return dispatch()
+    })
+
+    const continuation = coordinator.sendAppContinuation({
+      sessionId: session.sessionId,
+      text: 'approved recovery continuation'
+    })
+    await Promise.resolve()
+    expect(createdRuntime.sendAppContinuation).not.toHaveBeenCalled()
+
+    admission.resolve()
+    await continuation
+
+    expect(admittedSessionIds).toEqual([session.sessionId])
+    expect(createdRuntime.sendAppContinuation).toHaveBeenCalledOnce()
+  })
+
   it('stops a prompt for handoff without reporting a user generation cancellation', async () => {
     const onSessionCancellationRequested = vi.fn()
     const fake = createFakeRuntime({

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -358,7 +358,8 @@ describe('AcpRuntimeCoordinator', () => {
       wakeMessages: vi.fn(async () => undefined),
       stopSession: vi.fn(async () => undefined),
       stopAll: vi.fn(async () => undefined),
-      deleteSession: vi.fn(async () => undefined)
+      deleteSession: vi.fn(async () => undefined),
+      deleteProject: vi.fn(async () => undefined)
     }
     const permissionEvents: unknown[] = []
     const stateChanges: AcpStateSnapshot[] = []
@@ -443,7 +444,8 @@ describe('AcpRuntimeCoordinator', () => {
       stopActiveBranch,
       stopSession: vi.fn(async () => undefined),
       stopAll: vi.fn(async () => undefined),
-      deleteSession: vi.fn(async () => undefined)
+      deleteSession: vi.fn(async () => undefined),
+      deleteProject: vi.fn(async () => undefined)
     }
     const coordinator = new AcpRuntimeCoordinator(
       (callbacks) => {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -752,6 +752,23 @@ class AcpRuntimeCoordinator {
     request: AcpPromptRequest,
     validate: () => Promise<void>
   ): Promise<DelegateMessageAcceptanceEvidence> {
+    return this.startContinuationWhenWithDispatchAdmission(request, validate, false)
+  }
+
+  startContinuationWhenDispatchAdmitted(
+    request: AcpPromptRequest,
+    validate: () => Promise<void>
+  ): Promise<DelegateMessageAcceptanceEvidence> {
+    // The caller owns final deletion admission for the whole validation/resume/acceptance lifecycle.
+    // Bypass only the nested dispatch guard; root-session admission remains linearized below.
+    return this.startContinuationWhenWithDispatchAdmission(request, validate, true)
+  }
+
+  private startContinuationWhenWithDispatchAdmission(
+    request: AcpPromptRequest,
+    validate: () => Promise<void>,
+    dispatchAdmitted: boolean
+  ): Promise<DelegateMessageAcceptanceEvidence> {
     let resolve!: (evidence: DelegateMessageAcceptanceEvidence) => void
     let reject!: (error: unknown) => void
     const accepted = new Promise<DelegateMessageAcceptanceEvidence>(
@@ -786,7 +803,9 @@ class AcpRuntimeCoordinator {
           error
         )
       }
-      await this.dispatchPrompt(request, acceptance, 'sendAppContinuation')
+      await (dispatchAdmitted
+        ? this.dispatchAdmittedPrompt(request, acceptance, 'sendAppContinuation')
+        : this.dispatchPrompt(request, acceptance, 'sendAppContinuation'))
       if (!acceptance.settled) {
         acceptance.settled = true
         resolve('provider_prompt_completed')

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -112,6 +112,11 @@ type RootAdmissionLease = {
   release: () => void
 }
 
+type PromptAdmissionGuard = <Result>(
+  sessionId: string,
+  dispatch: () => Promise<Result>
+) => Promise<Result>
+
 // Keeps each framework generation in its own AcpRuntime. Framework changes preserve active turns, then
 // retire their runtime so every later turn resumes through the newly selected framework.
 class AcpRuntimeCoordinator {
@@ -143,6 +148,7 @@ class AcpRuntimeCoordinator {
   private readonly rootAdmissionTails = new Map<string, Promise<void>>()
   private readonly activeRootAdmissions = new Map<string, RootAdmissionLease>()
   private promptAdmissionGuard?: (sessionId: string) => Promise<void>
+  private promptDispatchAdmissionGuard?: PromptAdmissionGuard
   private promptAdmissionClosedForQuit = false
   private providerShutdownStartedForQuit = false
   private readonly pendingSessionAdoptions = new Map<string, AcpRuntime>()
@@ -633,6 +639,10 @@ class AcpRuntimeCoordinator {
     this.promptAdmissionGuard = guard
   }
 
+  setPromptDispatchAdmissionGuard(guard: PromptAdmissionGuard): void {
+    this.promptDispatchAdmissionGuard = guard
+  }
+
   sendPrompt(request: AcpPromptRequest): ReturnType<AcpRuntime['sendPrompt']> {
     return this.sendObservedPrompt(request)
   }
@@ -780,6 +790,28 @@ class AcpRuntimeCoordinator {
   }
 
   private dispatchPrompt(
+    request: AcpPromptRequest,
+    acceptance: PromptAcceptance | undefined,
+    operation: 'sendPrompt' | 'sendAppContinuation' | 'sendApplicationPrompt',
+    pinnedRuntime?: AcpRuntime,
+    retainAsLatestUserPrompt = operation === 'sendPrompt',
+    attribution?: MessageAttribution
+  ): ReturnType<AcpRuntime['sendPrompt']> {
+    const dispatch = (): ReturnType<AcpRuntime['sendPrompt']> =>
+      this.dispatchAdmittedPrompt(
+        request,
+        acceptance,
+        operation,
+        pinnedRuntime,
+        retainAsLatestUserPrompt,
+        attribution
+      )
+    return this.promptDispatchAdmissionGuard
+      ? this.promptDispatchAdmissionGuard(request.sessionId, dispatch)
+      : dispatch()
+  }
+
+  private dispatchAdmittedPrompt(
     request: AcpPromptRequest,
     acceptance: PromptAcceptance | undefined,
     operation: 'sendPrompt' | 'sendAppContinuation' | 'sendApplicationPrompt',

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -279,6 +279,12 @@ class AcpRuntimeCoordinator {
     }
   }
 
+  // Renderer aggregation intentionally hides idle sessions from retired generations. Destructive
+  // lifecycle operations need the coordinator's complete ownership set instead.
+  getOwnedSessionIds(): string[] {
+    return Array.from(this.sessionRuntimes.keys())
+  }
+
   captureSessionBackend(sessionId: string): ReturnType<AcpRuntime['captureBackend']> | undefined {
     return this.findRuntimeForSession(sessionId)?.captureBackend()
   }

--- a/src/main/archive/coordinator.test.ts
+++ b/src/main/archive/coordinator.test.ts
@@ -355,6 +355,39 @@ describe('ArchiveCoordinator', () => {
     await expect(coordinator.assertProjectAvailable(project.id)).resolves.toBeUndefined()
   })
 
+  it('retains and re-enters a Project deletion fence after teardown fails', async () => {
+    const projects = {
+      get: vi.fn().mockResolvedValue(project),
+      updateArchive: vi.fn()
+    }
+    const sessions = {
+      assertProjectArchivable: vi.fn(),
+      assertSessionAvailable: vi.fn().mockResolvedValue(undefined),
+      updateArchive: vi.fn(),
+      sessionProjectId: vi.fn().mockResolvedValue(project.id)
+    }
+    const coordinator = new ArchiveCoordinator(projects, sessions, {
+      isSessionBusy: vi.fn(),
+      isProjectBusy: vi.fn(),
+      liveSessionProjectId: vi.fn()
+    })
+    const failedTeardown = vi.fn().mockRejectedValue(new Error('runtime cleanup failed'))
+
+    await expect(coordinator.withProjectDeletion(project.id, failedTeardown)).rejects.toThrow(
+      'runtime cleanup failed'
+    )
+    await expect(coordinator.assertProjectAvailable(project.id)).rejects.toThrow(
+      'Project is being deleted.'
+    )
+
+    const retry = vi.fn().mockResolvedValue(undefined)
+    await expect(coordinator.withProjectDeletion(project.id, retry)).resolves.toBeUndefined()
+    expect(retry).toHaveBeenCalledOnce()
+
+    coordinator.releaseProjectDeletion(project.id)
+    await expect(coordinator.assertProjectAvailable(project.id)).resolves.toBeUndefined()
+  })
+
   it('releases admission after prompt dispatch starts without awaiting prompt completion', async () => {
     const prompt = createDeferred<string>()
     const projects = {

--- a/src/main/archive/coordinator.test.ts
+++ b/src/main/archive/coordinator.test.ts
@@ -308,4 +308,116 @@ describe('ArchiveCoordinator', () => {
     )
     expect(sessions.assertSessionAvailable).not.toHaveBeenCalled()
   })
+
+  it('establishes a Project deletion fence after admitted Session work drains', async () => {
+    const admitted = createDeferred<void>()
+    const projects = {
+      get: vi.fn().mockResolvedValue(project),
+      updateArchive: vi.fn()
+    }
+    const sessions = {
+      assertProjectArchivable: vi.fn(),
+      assertSessionAvailable: vi.fn().mockResolvedValue(undefined),
+      updateArchive: vi.fn(),
+      sessionProjectId: vi.fn().mockResolvedValue(project.id)
+    }
+    const coordinator = new ArchiveCoordinator(projects, sessions, {
+      isSessionBusy: vi.fn(),
+      isProjectBusy: vi.fn(),
+      liveSessionProjectId: vi.fn()
+    })
+    const quiesce = vi.fn().mockResolvedValue(undefined)
+
+    const existing = coordinator.withSessionAvailable(
+      project.id,
+      session.id,
+      () => admitted.promise
+    )
+    await vi.waitFor(() => expect(sessions.assertSessionAvailable).toHaveBeenCalledOnce())
+    const deletion = coordinator.withProjectDeletion(project.id, quiesce)
+    await Promise.resolve()
+
+    expect(quiesce).not.toHaveBeenCalled()
+    admitted.resolve(undefined)
+    await existing
+    await deletion
+
+    expect(quiesce).toHaveBeenCalledOnce()
+    await expect(coordinator.assertProjectAvailable(project.id)).rejects.toThrow(
+      'Project is being deleted.'
+    )
+    const blockedDispatch = vi.fn().mockResolvedValue(undefined)
+    await expect(
+      coordinator.withSessionDeletionAdmissionById(session.id, blockedDispatch)
+    ).rejects.toThrow('Project is being deleted.')
+    expect(blockedDispatch).not.toHaveBeenCalled()
+    coordinator.releaseProjectDeletion(project.id)
+    await expect(coordinator.assertProjectAvailable(project.id)).resolves.toBeUndefined()
+  })
+
+  it('releases admission after prompt dispatch starts without awaiting prompt completion', async () => {
+    const prompt = createDeferred<string>()
+    const projects = {
+      get: vi.fn().mockResolvedValue(project),
+      updateArchive: vi.fn()
+    }
+    const sessions = {
+      assertProjectArchivable: vi.fn(),
+      assertSessionAvailable: vi.fn().mockResolvedValue(undefined),
+      updateArchive: vi.fn(),
+      sessionProjectId: vi.fn().mockResolvedValue(project.id)
+    }
+    const coordinator = new ArchiveCoordinator(projects, sessions, {
+      isSessionBusy: vi.fn(),
+      isProjectBusy: vi.fn(),
+      liveSessionProjectId: vi.fn()
+    })
+    const dispatch = vi.fn(() => prompt.promise)
+    const quiesce = vi.fn().mockResolvedValue(undefined)
+
+    const prompting = coordinator.withSessionDeletionAdmissionById(session.id, dispatch)
+    await vi.waitFor(() => expect(dispatch).toHaveBeenCalledOnce())
+    await coordinator.withProjectDeletion(project.id, quiesce)
+
+    expect(quiesce).toHaveBeenCalledOnce()
+    prompt.resolve('complete')
+    await expect(prompting).resolves.toBe('complete')
+  })
+
+  it('allows deletion-only dispatch admission for a non-Project runtime', async () => {
+    const projects = {
+      get: vi.fn(),
+      updateArchive: vi.fn()
+    }
+    const sessions = {
+      assertProjectArchivable: vi.fn(),
+      assertSessionAvailable: vi.fn(),
+      updateArchive: vi.fn(),
+      sessionProjectId: vi.fn().mockResolvedValue(undefined)
+    }
+    const coordinator = new ArchiveCoordinator(projects, sessions, {
+      isSessionBusy: vi.fn(),
+      isProjectBusy: vi.fn(),
+      liveSessionProjectId: vi.fn().mockReturnValue(undefined)
+    })
+    const dispatch = vi.fn().mockResolvedValue('reviewed')
+
+    await expect(
+      coordinator.withSessionDeletionAdmissionById('reviewer-session', dispatch)
+    ).resolves.toBe('reviewed')
+
+    expect(dispatch).toHaveBeenCalledOnce()
+    expect(projects.get).not.toHaveBeenCalled()
+  })
 })
+
+const createDeferred = <Value>(): {
+  promise: Promise<Value>
+  resolve: (value: Value) => void
+} => {
+  let resolve!: (value: Value) => void
+  const promise = new Promise<Value>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}

--- a/src/main/archive/coordinator.test.ts
+++ b/src/main/archive/coordinator.test.ts
@@ -384,6 +384,44 @@ describe('ArchiveCoordinator', () => {
     await expect(prompting).resolves.toBe('complete')
   })
 
+  it('drains an admitted Project continuation before establishing its deletion fence', async () => {
+    const continuation = createDeferred<string>()
+    const projects = {
+      get: vi.fn().mockResolvedValue(project),
+      updateArchive: vi.fn()
+    }
+    const sessions = {
+      assertProjectArchivable: vi.fn(),
+      assertSessionAvailable: vi.fn(),
+      updateArchive: vi.fn(),
+      sessionProjectId: vi.fn()
+    }
+    const coordinator = new ArchiveCoordinator(projects, sessions, {
+      isSessionBusy: vi.fn(),
+      isProjectBusy: vi.fn(),
+      liveSessionProjectId: vi.fn()
+    })
+    const deliver = vi.fn(() => continuation.promise)
+    const quiesce = vi.fn().mockResolvedValue(undefined)
+
+    const delivering = coordinator.withProjectDeletionAdmission(project.id, deliver)
+    await vi.waitFor(() => expect(deliver).toHaveBeenCalledOnce())
+    const deletion = coordinator.withProjectDeletion(project.id, quiesce)
+    await Promise.resolve()
+
+    expect(quiesce).not.toHaveBeenCalled()
+    continuation.resolve('accepted')
+    await expect(delivering).resolves.toBe('accepted')
+    await deletion
+
+    expect(quiesce).toHaveBeenCalledOnce()
+    const lateDelivery = vi.fn().mockResolvedValue('accepted')
+    await expect(
+      coordinator.withProjectDeletionAdmission(project.id, lateDelivery)
+    ).rejects.toThrow('Project is being deleted.')
+    expect(lateDelivery).not.toHaveBeenCalled()
+  })
+
   it('allows deletion-only dispatch admission for a non-Project runtime', async () => {
     const projects = {
       get: vi.fn(),

--- a/src/main/archive/coordinator.ts
+++ b/src/main/archive/coordinator.ts
@@ -140,6 +140,18 @@ class ArchiveCoordinator {
     })
   }
 
+  withProjectDeletionAdmission<Result>(
+    projectId: string,
+    operation: () => Promise<Result>
+  ): Promise<Result> {
+    // Parent-message delivery holds this short lifecycle through validation, optional resume, and
+    // provider acceptance so Project deletion cannot snapshot ACP ownership in the middle.
+    return this.enqueue(async () => {
+      this.assertProjectDeletionAvailable(projectId)
+      return operation()
+    })
+  }
+
   restoreProjectDeletion(projectId: string): void {
     this.deletingProjectIds.add(projectId)
   }

--- a/src/main/archive/coordinator.ts
+++ b/src/main/archive/coordinator.ts
@@ -34,6 +34,7 @@ type SessionRuntimeActivity = {
 class ArchiveCoordinator {
   private queue: Promise<void> = Promise.resolve()
   private markReadSessions: (sessionIds: string[]) => Promise<void> = async () => undefined
+  private readonly deletingProjectIds = new Set<string>()
 
   constructor(
     private readonly projects: ProjectArchiveRepository,
@@ -51,7 +52,9 @@ class ArchiveCoordinator {
   }
 
   private async activeProject(projectId: string): Promise<Project> {
+    this.assertProjectDeletionAvailable(projectId)
     const project = await this.projects.get(projectId)
+    this.assertProjectDeletionAvailable(projectId)
     if (!project) throw new Error('Project not found.')
     if (project.archivedAt !== undefined) {
       throw new Error('Restore this archived Project before continuing.')
@@ -61,6 +64,7 @@ class ArchiveCoordinator {
 
   updateProjectArchive(request: UpdateProjectArchiveRequest): Promise<Project> {
     return this.enqueue(async () => {
+      this.assertProjectDeletionAvailable(request.id)
       const project = await this.projects.get(request.id)
       if (!project) throw new Error('Project not found.')
       const currentArchivedAt = project.archivedAt ?? null
@@ -109,6 +113,41 @@ class ArchiveCoordinator {
     })
   }
 
+  withProjectAvailable<Result>(
+    projectId: string | undefined,
+    operation: () => Promise<Result>
+  ): Promise<Result> {
+    if (!projectId) return operation()
+    return this.enqueue(async () => {
+      await this.activeProject(projectId)
+      return operation()
+    })
+  }
+
+  withProjectDeletion<Result>(
+    projectId: string,
+    operation: () => Promise<Result>
+  ): Promise<Result> {
+    return this.enqueue(async () => {
+      this.assertProjectDeletionAvailable(projectId)
+      this.deletingProjectIds.add(projectId)
+      try {
+        return await operation()
+      } catch (error) {
+        this.deletingProjectIds.delete(projectId)
+        throw error
+      }
+    })
+  }
+
+  restoreProjectDeletion(projectId: string): void {
+    this.deletingProjectIds.add(projectId)
+  }
+
+  releaseProjectDeletion(projectId: string): void {
+    this.deletingProjectIds.delete(projectId)
+  }
+
   assertSessionAvailable(projectId: string, sessionId: string): Promise<void> {
     return this.enqueue(() => this.assertSessionAvailableNow(projectId, sessionId))
   }
@@ -138,6 +177,20 @@ class ArchiveCoordinator {
       await this.assertSessionAvailableByIdNow(sessionId)
       return operation()
     })
+  }
+
+  withSessionDeletionAdmissionById<Result>(
+    sessionId: string,
+    operation: () => Promise<Result>
+  ): Promise<Result> {
+    const admitted = this.enqueue(async () => {
+      const projectId =
+        (await this.sessions.sessionProjectId(sessionId)) ??
+        this.runtime.liveSessionProjectId(sessionId)
+      if (projectId) this.assertProjectDeletionAvailable(projectId)
+      return { result: operation() }
+    })
+    return admitted.then(({ result }) => result)
   }
 
   isSessionAvailableById(sessionId: string): Promise<boolean> {
@@ -170,6 +223,12 @@ class ArchiveCoordinator {
     }
     await this.activeProject(projectId)
     await this.sessions.assertSessionAvailable(projectId, sessionId)
+  }
+
+  private assertProjectDeletionAvailable(projectId: string): void {
+    if (this.deletingProjectIds.has(projectId)) {
+      throw new Error('Project is being deleted.')
+    }
   }
 }
 

--- a/src/main/archive/coordinator.ts
+++ b/src/main/archive/coordinator.ts
@@ -129,14 +129,10 @@ class ArchiveCoordinator {
     operation: () => Promise<Result>
   ): Promise<Result> {
     return this.enqueue(async () => {
-      this.assertProjectDeletionAvailable(projectId)
+      // ProjectDeletionIntent is durable before this boundary. Re-entry is a recovery retry, and a
+      // failed teardown must retain the fence until the coordinator completes or explicitly aborts.
       this.deletingProjectIds.add(projectId)
-      try {
-        return await operation()
-      } catch (error) {
-        this.deletingProjectIds.delete(projectId)
-        throw error
-      }
+      return operation()
     })
   }
 

--- a/src/main/compute/compute-service.architecture.test.ts
+++ b/src/main/compute/compute-service.architecture.test.ts
@@ -324,6 +324,17 @@ describe('Compute service architecture', () => {
     expect(backgroundProjectRecovery).toBeGreaterThan(backgroundOrphanRecovery)
   })
 
+  it('awaits Compute Job barrier rollback when a new Project deletion aborts', () => {
+    const source = readSource(computePaths.mainIpc)
+    const abortStart = source.indexOf('abortProjectDeletion: async (projectId) => {')
+    const abortEnd = source.indexOf('const detectArchiveBlockingSessions', abortStart)
+    const abortSource = source.slice(abortStart, abortEnd)
+
+    expect(abortStart).toBeGreaterThan(-1)
+    expect(abortEnd).toBeGreaterThan(abortStart)
+    expect(abortSource).toContain('await computeJobDeletionPort.abortProjectJobDeletion(projectId)')
+  })
+
   it('treats unreadable Session authority as unknown during Compute Job recovery', () => {
     const source = readSource(computePaths.mainIpc)
     const livenessStart = source.indexOf('const isComputeJobOwnerLive')

--- a/src/main/delegation/frame-workspace.test.ts
+++ b/src/main/delegation/frame-workspace.test.ts
@@ -54,4 +54,37 @@ describe('production delegated Frame workspace', () => {
     expect((await stat(join(first.cwd, 'inputs', '02-report.md'))).mode & 0o222).toBe(0)
     await workspace.deleteSession(session)
   })
+
+  it('deletes every Session workspace owned by one Project without touching another Project', async () => {
+    root = await mkdtemp(join(tmpdir(), 'delegated-project-workspace-'))
+    const input = join(root, 'input.csv')
+    await writeFile(input, 'value\n1\n')
+    const workspaceRoot = join(root, 'workspaces')
+    const workspace = createProductionFrameWorkspace({
+      root: workspaceRoot,
+      resolveInput: async () => ({ path: input })
+    })
+    const first = await workspace.prepare(
+      { projectId: 'project-1', sessionId: 'session-1' },
+      'frame-1',
+      ['upload-version:upload-1']
+    )
+    const second = await workspace.prepare(
+      { projectId: 'project-1', sessionId: 'session-2' },
+      'frame-2',
+      ['upload-version:upload-1']
+    )
+    const other = await workspace.prepare(
+      { projectId: 'project-2', sessionId: 'session-3' },
+      'frame-3',
+      ['upload-version:upload-1']
+    )
+
+    await workspace.deleteProject('project-1')
+
+    await expect(stat(join(workspaceRoot, 'project-1'))).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(stat(first.cwd)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(stat(second.cwd)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(stat(other.cwd)).resolves.toBeDefined()
+  })
 })

--- a/src/main/delegation/frame-workspace.test.ts
+++ b/src/main/delegation/frame-workspace.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -93,4 +93,35 @@ describe('production delegated Frame workspace', () => {
       await workspace.deleteProject('project-2')
     }
   })
+
+  it.runIf(process.platform !== 'win32')(
+    'does not follow workspace symlinks while restoring delete permissions',
+    async () => {
+      root = await mkdtemp(join(tmpdir(), 'delegated-project-workspace-symlink-'))
+      const workspaceRoot = join(root, 'workspaces')
+      const externalRoot = join(root, 'external-owned')
+      const externalFile = join(externalRoot, 'protected.txt')
+      await mkdir(join(workspaceRoot, 'project-1'), { recursive: true })
+      await mkdir(externalRoot)
+      await writeFile(externalFile, 'keep permissions')
+      await chmod(externalRoot, 0o500)
+      await chmod(externalFile, 0o400)
+      await symlink(externalRoot, join(workspaceRoot, 'project-1', 'external-link'), 'dir')
+      const workspace = createProductionFrameWorkspace({
+        root: workspaceRoot,
+        resolveInput: async () => ({ path: externalFile })
+      })
+
+      try {
+        await workspace.deleteProject('project-1')
+
+        expect((await stat(externalRoot)).mode & 0o777).toBe(0o500)
+        expect((await stat(externalFile)).mode & 0o777).toBe(0o400)
+        await expect(readFile(externalFile, 'utf8')).resolves.toBe('keep permissions')
+      } finally {
+        await chmod(externalRoot, 0o700)
+        await chmod(externalFile, 0o600)
+      }
+    }
+  )
 })

--- a/src/main/delegation/frame-workspace.test.ts
+++ b/src/main/delegation/frame-workspace.test.ts
@@ -80,11 +80,17 @@ describe('production delegated Frame workspace', () => {
       ['upload-version:upload-1']
     )
 
-    await workspace.deleteProject('project-1')
+    try {
+      await workspace.deleteProject('project-1')
 
-    await expect(stat(join(workspaceRoot, 'project-1'))).rejects.toMatchObject({ code: 'ENOENT' })
-    await expect(stat(first.cwd)).rejects.toMatchObject({ code: 'ENOENT' })
-    await expect(stat(second.cwd)).rejects.toMatchObject({ code: 'ENOENT' })
-    await expect(stat(other.cwd)).resolves.toBeDefined()
+      await expect(stat(join(workspaceRoot, 'project-1'))).rejects.toMatchObject({ code: 'ENOENT' })
+      await expect(stat(first.cwd)).rejects.toMatchObject({ code: 'ENOENT' })
+      await expect(stat(second.cwd)).rejects.toMatchObject({ code: 'ENOENT' })
+      await expect(stat(other.cwd)).resolves.toBeDefined()
+    } finally {
+      // Prepared inputs are read-only. Restore their permissions through the production cleanup
+      // boundary so the shared temporary-root teardown is portable to macOS.
+      await workspace.deleteProject('project-2')
+    }
   })
 })

--- a/src/main/delegation/frame-workspace.ts
+++ b/src/main/delegation/frame-workspace.ts
@@ -17,6 +17,7 @@ type ProductionFrameWorkspace = Readonly<{
   validateInput(identity: string, session: SessionKey): Promise<boolean>
   prepare(session: SessionKey, frameId: string, inputs: readonly string[]): Promise<{ cwd: string }>
   deleteSession(session: SessionKey): Promise<void>
+  deleteProject(projectId: string): Promise<void>
 }>
 
 const safeSegment = (value: string, label: string): string => {
@@ -75,12 +76,10 @@ const makeTreeRemovable = async (path: string): Promise<void> => {
 const createProductionFrameWorkspace = (
   options: ProductionFrameWorkspaceOptions
 ): ProductionFrameWorkspace => {
+  const projectRoot = (projectId: string): string =>
+    join(options.root, safeSegment(projectId, 'Project id'))
   const sessionRoot = (session: SessionKey): string =>
-    join(
-      options.root,
-      safeSegment(session.projectId, 'Project id'),
-      safeSegment(session.sessionId, 'Session id')
-    )
+    join(projectRoot(session.projectId), safeSegment(session.sessionId, 'Session id'))
 
   const resolve = async (
     identity: string,
@@ -136,6 +135,11 @@ const createProductionFrameWorkspace = (
     },
     async deleteSession(session: SessionKey): Promise<void> {
       const root = sessionRoot(session)
+      await makeTreeRemovable(root)
+      await rm(root, { recursive: true, force: true })
+    },
+    async deleteProject(projectId: string): Promise<void> {
+      const root = projectRoot(projectId)
       await makeTreeRemovable(root)
       await rm(root, { recursive: true, force: true })
     }

--- a/src/main/delegation/frame-workspace.ts
+++ b/src/main/delegation/frame-workspace.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { chmod, copyFile, mkdir, readdir, rename, rm, stat } from 'node:fs/promises'
+import { chmod, copyFile, lstat, mkdir, readdir, rename, rm, stat } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 
 import { parseArtifactVersionLocator } from '../../shared/artifact-provenance'
@@ -63,8 +63,11 @@ const assertVersionIdentityScope = (identity: string, session: SessionKey): void
 }
 
 const makeTreeRemovable = async (path: string): Promise<void> => {
-  const entry = await stat(path).catch(() => undefined)
+  const entry = await lstat(path).catch(() => undefined)
   if (!entry) return
+  // chmod and traversal must never follow a workspace symlink into caller-owned data. The parent
+  // directory is made writable, which is sufficient for rm to unlink this leaf.
+  if (entry.isSymbolicLink()) return
   if (!entry.isDirectory()) {
     await chmod(path, 0o644)
     return

--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -2426,7 +2426,7 @@ describe('production delegated-work composition', () => {
       .toBe('accepted')
   })
 
-  it('deletes stable child workspaces after restart without relying on the in-memory work cache', async () => {
+  it('deletes dormant Project workspaces after restart without relying on the in-memory work cache', async () => {
     root = await mkdtemp(join(tmpdir(), 'delegated-production-restart-delete-'))
     const harness = await createCompositionHarness(root, 'codex')
     const receipt = await harness.composition.host.delegate(
@@ -2453,9 +2453,7 @@ describe('production delegated-work composition', () => {
       dataRoot: root,
       sessions: {
         commands: harness.commands,
-        readSession: async () => harness.durable(),
-        findSessions: async (sessionId) =>
-          sessionId === harness.session.id ? [harness.durable()] : []
+        readSession: async () => harness.durable()
       },
       resolveInput: async () => {
         throw new Error('no inputs')
@@ -2473,7 +2471,7 @@ describe('production delegated-work composition', () => {
     } as ProductionDelegatedWorkOptions)
 
     expect(receipt.children[0]).toBeDefined()
-    await restarted.root.deleteSession(harness.session.id)
+    await restarted.root.deleteProject(harness.session.projectId)
 
     await expect(access(stableSessionWorkspace)).rejects.toMatchObject({ code: 'ENOENT' })
   })

--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -2552,6 +2552,35 @@ describe('production delegated-work composition', () => {
     expect(harness.composition.root.pendingPermissions()).toEqual([])
   })
 
+  it('does not await pending work initialization owned by another Project', async () => {
+    root = await mkdtemp(join(tmpdir(), 'delegated-production-project-isolation-'))
+    const forSession = vi.fn(async () => new Promise<never>(() => undefined))
+    const harness = await createCompositionHarness(
+      root,
+      'codex',
+      undefined,
+      undefined,
+      {},
+      [],
+      undefined,
+      { forSession } as never
+    )
+    const unrelatedSession = {
+      ...structuredClone(harness.durable()),
+      id: 'session-other-project',
+      projectId: 'project-2'
+    }
+    harness.replaceDurable(unrelatedSession)
+
+    void harness.composition.host.readAgentFrame(
+      { projectId: unrelatedSession.projectId, sessionId: unrelatedSession.id },
+      unrelatedSession.conversationGraph!.rootFrameId
+    )
+    await vi.waitFor(() => expect(forSession).toHaveBeenCalledOnce())
+
+    await expect(harness.composition.root.deleteProject('project-1')).resolves.toBeUndefined()
+  })
+
   it('keeps a Turn fence when cancellation precedes scoped-work creation', async () => {
     root = await mkdtemp(join(tmpdir(), 'delegated-production-prework-fence-'))
     const harness = await createCompositionHarness(root, 'codex')

--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -2476,6 +2476,82 @@ describe('production delegated-work composition', () => {
     await expect(access(stableSessionWorkspace)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
+  it('retains failed Project work ownership and permission routing for cleanup retry', async () => {
+    root = await mkdtemp(join(tmpdir(), 'delegated-production-project-delete-retry-'))
+    const handles = new Map<string, { executionId: string }>()
+    let failDispose = true
+    const harness = await createCompositionHarness(root, 'codex', undefined, undefined, {
+      artifactEvidence: {
+        turns: {
+          async openExecution({ executionId }: { executionId: string }) {
+            const handle = { executionId }
+            handles.set(executionId, handle)
+            return handle
+          },
+          async finalize() {
+            return undefined
+          },
+          async dispose() {
+            if (failDispose) {
+              failDispose = false
+              throw new Error('injected Project cleanup failure')
+            }
+          },
+          handleForExecution(executionId: string) {
+            const handle = handles.get(executionId)
+            if (!handle) throw new Error(`No active Artifact turn for ${executionId}`)
+            return handle
+          },
+          handoffFile: () => '/tmp/current-run.json',
+          async publishHandoff() {
+            return undefined
+          }
+        } as never,
+        artifactStorageSessionId: ({ sessionId }) => sessionId,
+        async finalizePublication() {
+          return undefined
+        },
+        async project() {
+          return []
+        }
+      }
+    })
+    await harness.composition.host.delegate(
+      harness.caller,
+      { task: 'Retain cleanup owner', name: 'Retain cleanup owner' },
+      { wait: false }
+    )
+    await expect.poll(() => harness.execution.controls()).toHaveLength(1)
+    const control = harness.execution.controls()[0]
+    control.accept()
+    control.emit({
+      kind: 'permission',
+      awaiting: true,
+      requestId: 'provider-project-delete-retry',
+      title: 'Write evidence',
+      options: [{ optionId: 'allow', name: 'Allow', kind: 'allow_once' }]
+    })
+    await expect.poll(() => harness.composition.root.pendingPermissions()).toHaveLength(1)
+
+    await expect(harness.composition.root.deleteProject(harness.session.projectId)).rejects.toThrow(
+      'Delegated Project cleanup failed'
+    )
+
+    expect(harness.durable().runtimeContext?.delegatedWork?.records[0].attempts[0].status).toBe(
+      'running'
+    )
+    expect(harness.composition.root.pendingPermissions()).toHaveLength(1)
+
+    await expect(
+      harness.composition.root.deleteProject(harness.session.projectId)
+    ).resolves.toBeUndefined()
+    expect(harness.durable().runtimeContext?.delegatedWork?.records[0].attempts[0]).toMatchObject({
+      status: 'cancelled',
+      cancellationReason: 'session_stop'
+    })
+    expect(harness.composition.root.pendingPermissions()).toEqual([])
+  })
+
   it('keeps a Turn fence when cancellation precedes scoped-work creation', async () => {
     root = await mkdtemp(join(tmpdir(), 'delegated-production-prework-fence-'))
     const harness = await createCompositionHarness(root, 'codex')

--- a/src/main/delegation/production-composition.ts
+++ b/src/main/delegation/production-composition.ts
@@ -451,11 +451,17 @@ const createProductionDelegatedWorkComposition = (
       // covers Sessions that have no in-memory work after restart as well as every cached Session
       // settled above.
       const workspaceDeletion = await Promise.allSettled([workspace.deleteProject(projectId)])
-      for (const { key } of scoped) works.delete(keyOf(key))
-      for (const [requestId, pending] of permissions) {
-        if (pending.key.projectId === projectId) permissions.delete(requestId)
+      for (const [index, result] of workDeletion.entries()) {
+        if (result.status === 'rejected') continue
+        const { key } = scoped[index]
+        works.delete(keyOf(key))
+        for (const [requestId, pending] of permissions) {
+          if (pending.key.projectId === key.projectId && pending.key.sessionId === key.sessionId) {
+            permissions.delete(requestId)
+          }
+        }
+        unavailableReasons.delete(key.sessionId)
       }
-      for (const { key } of scoped) unavailableReasons.delete(key.sessionId)
       const failures = [...workDeletion, ...workspaceDeletion].flatMap((result) =>
         result.status === 'rejected' ? [result.reason] : []
       )

--- a/src/main/delegation/production-composition.ts
+++ b/src/main/delegation/production-composition.ts
@@ -95,6 +95,7 @@ type RootDelegatedWorkControl = Readonly<{
   wakeMessages?(sessionId: string): Promise<void>
   stopAll(): Promise<void>
   deleteSession(sessionId: string): Promise<void>
+  deleteProject(projectId: string): Promise<void>
 }>
 
 type ProductionDelegatedWorkComposition = Readonly<{
@@ -253,6 +254,8 @@ const createProductionDelegatedWorkComposition = (
         .filter(([identity]) => identity.endsWith(`\u0000${sessionId}`))
         .map(([, work]) => work)
     )
+  const worksForProject = async (projectId: string): Promise<ScopedWork[]> =>
+    (await Promise.all([...works.values()])).filter(({ key }) => key.projectId === projectId)
 
   const host: ProductionDelegatedWorkComposition['host'] = Object.freeze({
     async delegate(caller, request, delegateOptions) {
@@ -437,6 +440,27 @@ const createProductionDelegatedWorkComposition = (
       )
       if (failures.length > 0) {
         throw new AggregateError(failures, `Delegated Session cleanup failed: ${sessionId}`)
+      }
+    },
+    async deleteProject(projectId) {
+      const scoped = await worksForProject(projectId)
+      const workDeletion = await Promise.allSettled(
+        scoped.map(({ key, work }) => work.deleteSession(key))
+      )
+      // The stable Project directory is authoritative for dormant workspaces. Removing it directly
+      // covers Sessions that have no in-memory work after restart as well as every cached Session
+      // settled above.
+      const workspaceDeletion = await Promise.allSettled([workspace.deleteProject(projectId)])
+      for (const { key } of scoped) works.delete(keyOf(key))
+      for (const [requestId, pending] of permissions) {
+        if (pending.key.projectId === projectId) permissions.delete(requestId)
+      }
+      for (const { key } of scoped) unavailableReasons.delete(key.sessionId)
+      const failures = [...workDeletion, ...workspaceDeletion].flatMap((result) =>
+        result.status === 'rejected' ? [result.reason] : []
+      )
+      if (failures.length > 0) {
+        throw new AggregateError(failures, `Delegated Project cleanup failed: ${projectId}`)
       }
     }
   })

--- a/src/main/delegation/production-composition.ts
+++ b/src/main/delegation/production-composition.ts
@@ -255,7 +255,11 @@ const createProductionDelegatedWorkComposition = (
         .map(([, work]) => work)
     )
   const worksForProject = async (projectId: string): Promise<ScopedWork[]> =>
-    (await Promise.all([...works.values()])).filter(({ key }) => key.projectId === projectId)
+    Promise.all(
+      [...works.entries()]
+        .filter(([identity]) => identity.startsWith(`${projectId}\u0000`))
+        .map(([, work]) => work)
+    )
 
   const host: ProductionDelegatedWorkComposition['host'] = Object.freeze({
     async delegate(caller, request, delegateOptions) {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -730,12 +730,7 @@ const createApplicationModules = async (
         if (!owner) throw new Error('Project runtime cleanup is not initialized.')
         await archiveCoordinator.withProjectDeletion(projectId, async () => {
           notebookService.beginProjectDeletion(projectId)
-          try {
-            await owner.quiesceProject(projectId)
-          } catch (error) {
-            notebookService.releaseProjectDeletion(projectId)
-            throw error
-          }
+          await owner.quiesceProject(projectId)
         })
       },
       restoreProjectDeletion: async (projectId) => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1506,89 +1506,98 @@ const createApplicationModules = async (
     },
     parentMessages: {
       async deliver(delivery) {
-        const runtime = runtimeRef.current
-        if (!runtime) throw new Error('ACP runtime is not available.')
-        const session = await sessionRepository.loadSession(
+        return archiveCoordinator.withProjectDeletionAdmission(
           delivery.session.projectId,
-          delivery.session.sessionId
-        )
-        const graph = session?.conversationGraph
-        const rootFrame = graph?.frames.find((frame) => frame.id === delivery.targetFrameId)
-        const rootBranch = graph?.branches.find((branch) => branch.id === rootFrame?.activeBranchId)
-        if (
-          !session ||
-          session.id !== delivery.session.sessionId ||
-          session.projectId !== delivery.session.projectId ||
-          graph?.rootFrameId !== delivery.targetFrameId ||
-          !rootBranch ||
-          !graph.messages.some((message) => message.id === delivery.originMessageId)
-        ) {
-          throw new Error('Parent message durable root provenance is unavailable.')
-        }
-        return runtime.startContinuationWhen(
-          {
-            sessionId: delivery.session.sessionId,
-            text:
-              `[Delegated ${delivery.kind} from Frame ${delivery.sourceFrameId}, ` +
-              `Attempt ${delivery.sourceAttemptId}]\n\n${delivery.text}`,
-            suppressUserMessage: true,
-            provenanceContext: {
-              promptMessageId: delivery.rootPromptMessageId,
-              originMessageId: delivery.originMessageId,
-              rootFrameId: graph.rootFrameId,
-              agentFrameId: graph.rootFrameId,
-              messageBranchId: delivery.rootBranchId,
-              messageBranchAncestry: [delivery.rootBranchId],
-              messageAncestry: [delivery.originMessageId],
-              runtimeSegmentId: `delegated-message-${delivery.messageId}`
-            }
-          },
           async () => {
-            const latest = await sessionRepository.loadSession(
+            const runtime = runtimeRef.current
+            if (!runtime) throw new Error('ACP runtime is not available.')
+            const session = await sessionRepository.loadSession(
               delivery.session.projectId,
               delivery.session.sessionId
             )
-            const latestGraph = latest?.conversationGraph
-            const latestRoot = latestGraph?.frames.find(({ id }) => id === delivery.targetFrameId)
-            const latestBranch = latestGraph?.branches.find(
-              ({ id }) => id === latestRoot?.activeBranchId
+            const graph = session?.conversationGraph
+            const rootFrame = graph?.frames.find((frame) => frame.id === delivery.targetFrameId)
+            const rootBranch = graph?.branches.find(
+              (branch) => branch.id === rootFrame?.activeBranchId
             )
             if (
-              !latest ||
-              latestBranch?.id !== delivery.rootBranchId ||
-              `${latestBranch.id}:${latestBranch.createdAt}` !== delivery.rootBranchRevision
+              !session ||
+              session.id !== delivery.session.sessionId ||
+              session.projectId !== delivery.session.projectId ||
+              graph?.rootFrameId !== delivery.targetFrameId ||
+              !rootBranch ||
+              !graph.messages.some((message) => message.id === delivery.originMessageId)
             ) {
-              throw new DelegateMessageParkedError(
-                'Parent message root Branch changed before dispatch.'
-              )
+              throw new Error('Parent message durable root provenance is unavailable.')
             }
-            const started = await delivery.startDispatch()
-            if (started !== 'started') {
-              throw new DelegateMessageParkedError(
-                'Parent message dispatch fence was not acquired.'
-              )
-            }
-            if (!runtime.hasLiveSession(latest.projectId, latest.id)) {
-              await runtime.resumeSession({
-                sessionId: latest.id,
-                cwd: latest.cwd,
-                projectName: latest.projectId,
-                ...(latest.permissionProfile
-                  ? { permissionProfile: latest.permissionProfile }
-                  : {}),
-                ...(latest.agentFrameworkId
-                  ? { previousFrameworkId: latest.agentFrameworkId }
-                  : {}),
-                ...(latest.agentBackendId ? { previousBackendId: latest.agentBackendId } : {}),
-                ...(latest.specialistId ? { specialistId: latest.specialistId } : {}),
-                ...(latest.providerSessionId
-                  ? { providerSessionId: latest.providerSessionId }
-                  : {}),
-                ...(latest.providerContinuityToken
-                  ? { providerContinuityToken: latest.providerContinuityToken }
-                  : {})
-              })
-            }
+            return runtime.startContinuationWhenDispatchAdmitted(
+              {
+                sessionId: delivery.session.sessionId,
+                text:
+                  `[Delegated ${delivery.kind} from Frame ${delivery.sourceFrameId}, ` +
+                  `Attempt ${delivery.sourceAttemptId}]\n\n${delivery.text}`,
+                suppressUserMessage: true,
+                provenanceContext: {
+                  promptMessageId: delivery.rootPromptMessageId,
+                  originMessageId: delivery.originMessageId,
+                  rootFrameId: graph.rootFrameId,
+                  agentFrameId: graph.rootFrameId,
+                  messageBranchId: delivery.rootBranchId,
+                  messageBranchAncestry: [delivery.rootBranchId],
+                  messageAncestry: [delivery.originMessageId],
+                  runtimeSegmentId: `delegated-message-${delivery.messageId}`
+                }
+              },
+              async () => {
+                const latest = await sessionRepository.loadSession(
+                  delivery.session.projectId,
+                  delivery.session.sessionId
+                )
+                const latestGraph = latest?.conversationGraph
+                const latestRoot = latestGraph?.frames.find(
+                  ({ id }) => id === delivery.targetFrameId
+                )
+                const latestBranch = latestGraph?.branches.find(
+                  ({ id }) => id === latestRoot?.activeBranchId
+                )
+                if (
+                  !latest ||
+                  latestBranch?.id !== delivery.rootBranchId ||
+                  `${latestBranch.id}:${latestBranch.createdAt}` !== delivery.rootBranchRevision
+                ) {
+                  throw new DelegateMessageParkedError(
+                    'Parent message root Branch changed before dispatch.'
+                  )
+                }
+                const started = await delivery.startDispatch()
+                if (started !== 'started') {
+                  throw new DelegateMessageParkedError(
+                    'Parent message dispatch fence was not acquired.'
+                  )
+                }
+                if (!runtime.hasLiveSession(latest.projectId, latest.id)) {
+                  await runtime.resumeSession({
+                    sessionId: latest.id,
+                    cwd: latest.cwd,
+                    projectName: latest.projectId,
+                    ...(latest.permissionProfile
+                      ? { permissionProfile: latest.permissionProfile }
+                      : {}),
+                    ...(latest.agentFrameworkId
+                      ? { previousFrameworkId: latest.agentFrameworkId }
+                      : {}),
+                    ...(latest.agentBackendId ? { previousBackendId: latest.agentBackendId } : {}),
+                    ...(latest.specialistId ? { specialistId: latest.specialistId } : {}),
+                    ...(latest.providerSessionId
+                      ? { providerSessionId: latest.providerSessionId }
+                      : {}),
+                    ...(latest.providerContinuityToken
+                      ? { providerContinuityToken: latest.providerContinuityToken }
+                      : {})
+                  })
+                }
+              }
+            )
           }
         )
       }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2851,6 +2851,10 @@ const createApplicationModules = async (
       acp: {
         runtime,
         workflows: acpHandlerWorkflows,
+        sessionAdmission: {
+          withSessionAvailableById: (sessionId, operation) =>
+            archiveCoordinator.withSessionAvailableById(sessionId, operation)
+        },
         respondDelegatedQuestion: (input) => {
           if (!delegatedWork.root.respondQuestion) {
             throw new Error('Delegated question response owner is unavailable.')

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1280,26 +1280,6 @@ const createApplicationModules = async (
       }
     }
   )
-  const projectDeletionRecovery = new ProjectDeletionRecoveryLoop(
-    async () => {
-      // A retained child Session plan must finish before its parent Project intent can prepare.
-      await jobDeletionOwner.reconcileOrphanJobs(isComputeJobOwnerLive)
-      await projectDeletionCoordinator.recoverPendingDeletions()
-    },
-    {
-      onError: (error) =>
-        createLogger('compute-job-deletion').error(
-          'background deletion recovery failed; retry scheduled',
-          diagnosticErrorFields(error)
-        )
-    }
-  )
-  await modules.add(projectDeletionRecovery, (recovery) => ({
-    name: 'project-deletion-recovery',
-    capability: undefined,
-    start: () => recovery.start(),
-    dispose: () => recovery.stop()
-  }))
   // Augment computeService with getEnabledComputeHosts so the RPC server can serve list_compute.
   // Must preserve ComputeService's prototype methods (list/getDetails/submitJob/...) — see the helper.
   const computeServiceWithRegistry = attachEnabledComputeHosts(computeService, hostsRegistry)
@@ -1942,10 +1922,10 @@ const createApplicationModules = async (
     },
     sideChat: sideChatRuntime,
     compute: {
-      reconcileProject: (projectId) => {
+      reconcileProject: async (projectId) => {
         const deletionOwner = computeJobDeletionRef.current
         if (!deletionOwner) throw new Error('Compute Job deletion is not initialized.')
-        return deletionOwner.reconcileProjectOrphanJobs(projectId, isComputeJobOwnerLive)
+        await deletionOwner.reconcileProjectOrphanJobs(projectId, isComputeJobOwnerLive)
       }
     }
   })
@@ -1960,6 +1940,29 @@ const createApplicationModules = async (
   } catch (error) {
     sideChatLog.error('durable Side chat hydration failed', diagnosticErrorFields(error))
   }
+  // Recovery quiesces every runtime owner, so do not start its first attempt until ACP, Delegation,
+  // Notebook, Side Chat, and the composed quiescence boundary are all initialized. The bounded
+  // durable barrier restoration above still runs early enough to block admission during startup.
+  const projectDeletionRecovery = new ProjectDeletionRecoveryLoop(
+    async () => {
+      // A retained child Session plan must finish before its parent Project intent can prepare.
+      await jobDeletionOwner.reconcileOrphanJobs(isComputeJobOwnerLive)
+      await projectDeletionCoordinator.recoverPendingDeletions()
+    },
+    {
+      onError: (error) =>
+        createLogger('compute-job-deletion').error(
+          'background deletion recovery failed; retry scheduled',
+          diagnosticErrorFields(error)
+        )
+    }
+  )
+  await modules.add(projectDeletionRecovery, (recovery) => ({
+    name: 'project-deletion-recovery',
+    capability: undefined,
+    start: () => recovery.start(),
+    dispose: () => recovery.stop()
+  }))
   declareElectronAdapter('side-chat', () =>
     registerSideChatIpcHandlers(sideChatRuntime, {
       loadParentSession: (projectId, sessionId) =>

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -738,10 +738,14 @@ const createApplicationModules = async (
         notebookService.beginProjectDeletion(projectId)
         await computeJobDeletionPort.restoreProjectJobDeletion(projectId)
       },
+      finalizeProjectDeletion: async (projectId) => {
+        const owner = sideChatOwnerRef.current
+        if (!owner) throw new Error('Side chat runtime cleanup is not initialized.')
+        await owner.completeProjectDeletion(projectId)
+      },
       completeProjectDeletion: (projectId) => {
         archiveCoordinator.releaseProjectDeletion(projectId)
         notebookService.releaseProjectDeletion(projectId)
-        sideChatOwnerRef.current?.completeProjectDeletion(projectId)
       },
       abortProjectDeletion: (projectId) => {
         archiveCoordinator.releaseProjectDeletion(projectId)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -751,11 +751,12 @@ const createApplicationModules = async (
         notebookService.releaseProjectDeletion(projectId)
         reviewerProjectRuntime.releaseProjectDeletion(projectId)
       },
-      abortProjectDeletion: (projectId) => {
+      abortProjectDeletion: async (projectId) => {
         archiveCoordinator.releaseProjectDeletion(projectId)
         notebookService.releaseProjectDeletion(projectId)
         reviewerProjectRuntime.releaseProjectDeletion(projectId)
         sideChatOwnerRef.current?.restoreProject(projectId)
+        await computeJobDeletionPort.abortProjectJobDeletion(projectId)
       }
     }
   )

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1929,12 +1929,7 @@ const createApplicationModules = async (
       deleteSession: (sessionId) => runtime.deleteSession({ sessionId })
     },
     delegation: {
-      listActiveSessions: () =>
-        getActiveDelegatedSessions().map(({ projectName, sessionId }) => ({
-          projectId: projectName,
-          sessionId
-        })),
-      deleteSession: (sessionId) => delegatedWork.root.deleteSession(sessionId)
+      deleteProject: (projectId) => delegatedWork.root.deleteProject(projectId)
     },
     notebook: {
       shutdownProject: (projectId) => notebookService.shutdownProject(projectId)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -746,10 +746,12 @@ const createApplicationModules = async (
       completeProjectDeletion: (projectId) => {
         archiveCoordinator.releaseProjectDeletion(projectId)
         notebookService.releaseProjectDeletion(projectId)
+        sideChatOwnerRef.current?.completeProjectDeletion(projectId)
       },
       abortProjectDeletion: (projectId) => {
         archiveCoordinator.releaseProjectDeletion(projectId)
         notebookService.releaseProjectDeletion(projectId)
+        sideChatOwnerRef.current?.restoreProject(projectId)
       }
     }
   )

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1924,7 +1924,7 @@ const createApplicationModules = async (
   sideChatOwnerRef.current = sideChatRuntime
   projectRuntimeQuiescenceRef.current = new ProjectRuntimeQuiescenceOwner({
     acp: {
-      listSessionIds: () => runtime.getSnapshot().sessionIds,
+      listSessionIds: () => runtime.getOwnedSessionIds(),
       liveSessionProjectId: (sessionId) => runtime.liveSessionProjectId(sessionId),
       deleteSession: (sessionId) => runtime.deleteSession({ sessionId })
     },

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -176,6 +176,7 @@ import {
   ProjectDeletionCoordinator,
   ProjectDeletionRecoveryLoop
 } from './projects/deletion-coordinator'
+import { ProjectRuntimeQuiescenceOwner } from './projects/project-runtime-quiescence-owner'
 import { getProjectDbClient } from './projects/prisma-client'
 import { seedDefaultPermissionGrants } from './permission-grants/defaults'
 import { createPermissionGrantRegistry } from './permission-grants/registry'
@@ -610,6 +611,7 @@ const createApplicationModules = async (
       ): Promise<void>
     }
   } = {}
+  const projectRuntimeQuiescenceRef: { current?: ProjectRuntimeQuiescenceOwner } = {}
   const computeJobDeletionPort = {
     restoreProjectJobDeletion: (projectId: string): Promise<void> => {
       if (!computeJobDeletionRef.current) {
@@ -724,10 +726,9 @@ const createApplicationModules = async (
     permissionGrantRegistry,
     {
       beforeProjectDelete: async (projectId) => {
-        await sideChatOwnerRef.current?.invalidateProject(projectId)
-        const deletionOwner = computeJobDeletionRef.current
-        if (!deletionOwner) throw new Error('Compute Job deletion is not initialized.')
-        await deletionOwner.reconcileProjectOrphanJobs(projectId, isComputeJobOwnerLive)
+        const owner = projectRuntimeQuiescenceRef.current
+        if (!owner) throw new Error('Project runtime cleanup is not initialized.')
+        await owner.quiesceProject(projectId)
       },
       restoreProjectDeletion: (projectId) =>
         computeJobDeletionPort.restoreProjectJobDeletion(projectId)
@@ -1902,6 +1903,32 @@ const createApplicationModules = async (
     }
   )
   sideChatOwnerRef.current = sideChatRuntime
+  projectRuntimeQuiescenceRef.current = new ProjectRuntimeQuiescenceOwner({
+    acp: {
+      listSessionIds: () => runtime.getSnapshot().sessionIds,
+      liveSessionProjectId: (sessionId) => runtime.liveSessionProjectId(sessionId),
+      deleteSession: (sessionId) => runtime.deleteSession({ sessionId })
+    },
+    delegation: {
+      listActiveSessions: () =>
+        getActiveDelegatedSessions().map(({ projectName, sessionId }) => ({
+          projectId: projectName,
+          sessionId
+        })),
+      deleteSession: (sessionId) => delegatedWork.root.deleteSession(sessionId)
+    },
+    notebook: {
+      shutdownProject: (projectId) => notebookService.shutdownProject(projectId)
+    },
+    sideChat: sideChatRuntime,
+    compute: {
+      reconcileProject: (projectId) => {
+        const deletionOwner = computeJobDeletionRef.current
+        if (!deletionOwner) throw new Error('Compute Job deletion is not initialized.')
+        return deletionOwner.reconcileProjectOrphanJobs(projectId, isComputeJobOwnerLive)
+      }
+    }
+  })
   try {
     const persistedSideChats = await sessionPersistenceCoordinator.loadPersistedSideChats()
     sideChatRuntime.hydrate(persistedSideChats.sideChats)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -728,10 +728,29 @@ const createApplicationModules = async (
       beforeProjectDelete: async (projectId) => {
         const owner = projectRuntimeQuiescenceRef.current
         if (!owner) throw new Error('Project runtime cleanup is not initialized.')
-        await owner.quiesceProject(projectId)
+        await archiveCoordinator.withProjectDeletion(projectId, async () => {
+          notebookService.beginProjectDeletion(projectId)
+          try {
+            await owner.quiesceProject(projectId)
+          } catch (error) {
+            notebookService.releaseProjectDeletion(projectId)
+            throw error
+          }
+        })
       },
-      restoreProjectDeletion: (projectId) =>
-        computeJobDeletionPort.restoreProjectJobDeletion(projectId)
+      restoreProjectDeletion: async (projectId) => {
+        archiveCoordinator.restoreProjectDeletion(projectId)
+        notebookService.beginProjectDeletion(projectId)
+        await computeJobDeletionPort.restoreProjectJobDeletion(projectId)
+      },
+      completeProjectDeletion: (projectId) => {
+        archiveCoordinator.releaseProjectDeletion(projectId)
+        notebookService.releaseProjectDeletion(projectId)
+      },
+      abortProjectDeletion: (projectId) => {
+        archiveCoordinator.releaseProjectDeletion(projectId)
+        notebookService.releaseProjectDeletion(projectId)
+      }
     }
   )
   const detectArchiveBlockingSessions = (): ReturnType<typeof detectActiveSessions> =>
@@ -1957,6 +1976,9 @@ const createApplicationModules = async (
       throw new Error('Close Side chat before sending a message to Main.')
     }
   })
+  runtime.setPromptDispatchAdmissionGuard((sessionId, dispatch) =>
+    archiveCoordinator.withSessionDeletionAdmissionById(sessionId, dispatch)
+  )
   const codeReconstructionLog = createLogger('artifacts:code-reconstruction')
   const codeReconstructionRunner = await modules.add(
     {
@@ -1988,7 +2010,8 @@ const createApplicationModules = async (
     runner: codeReconstructionRunner
   })
   const createSessionWorkflow = createAcpCreateSessionWorkflow(runtime, {
-    assertProjectAvailable: (projectId) => archiveCoordinator.assertProjectAvailable(projectId)
+    withProjectAvailable: (projectId, operation) =>
+      archiveCoordinator.withProjectAvailable(projectId, operation)
   })
   const acpHandlerWorkflows = createAcpHandlerWorkflows(
     runtime,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -158,6 +158,7 @@ import {
   type ReviewerCommandOwner
 } from './reviewer/ipc'
 import { ReviewerModelRuntimeOwner } from './reviewer/model-runtime-owner'
+import { ReviewerProjectRuntimeOwner } from './reviewer/project-runtime-owner'
 import {
   createDefaultReviewRepository,
   createDefaultSessionRepository,
@@ -566,6 +567,7 @@ const createApplicationModules = async (
   const reviewerCommandOwnerRef: { current: ReviewerCommandOwner | undefined } = {
     current: undefined
   }
+  const reviewerProjectRuntime = new ReviewerProjectRuntimeOwner()
   const messageAttributionAuthority = new MainMessageAttributionAuthority()
   const notebookActivityRef: {
     current: { getActiveNotebookSessions(): { projectId: string; sessionId: string }[] } | undefined
@@ -736,6 +738,7 @@ const createApplicationModules = async (
       restoreProjectDeletion: async (projectId) => {
         archiveCoordinator.restoreProjectDeletion(projectId)
         notebookService.beginProjectDeletion(projectId)
+        reviewerProjectRuntime.restoreProjectDeletion(projectId)
         await computeJobDeletionPort.restoreProjectJobDeletion(projectId)
       },
       finalizeProjectDeletion: async (projectId) => {
@@ -746,10 +749,12 @@ const createApplicationModules = async (
       completeProjectDeletion: (projectId) => {
         archiveCoordinator.releaseProjectDeletion(projectId)
         notebookService.releaseProjectDeletion(projectId)
+        reviewerProjectRuntime.releaseProjectDeletion(projectId)
       },
       abortProjectDeletion: (projectId) => {
         archiveCoordinator.releaseProjectDeletion(projectId)
         notebookService.releaseProjectDeletion(projectId)
+        reviewerProjectRuntime.releaseProjectDeletion(projectId)
         sideChatOwnerRef.current?.restoreProject(projectId)
       }
     }
@@ -1924,6 +1929,7 @@ const createApplicationModules = async (
     notebook: {
       shutdownProject: (projectId) => notebookService.shutdownProject(projectId)
     },
+    reviewer: reviewerProjectRuntime,
     sideChat: sideChatRuntime,
     compute: {
       reconcileProject: async (projectId) => {
@@ -2677,6 +2683,7 @@ const createApplicationModules = async (
   const reviewerOptions = {
     acpRuntime: runtime,
     modelRuntime: reviewerModelRuntime,
+    projectRuntime: reviewerProjectRuntime,
     mcpEntryPath: mainEntryPath,
     artifactProvenanceRepository,
     withSessionMutation: <Result>(

--- a/src/main/notebook/execution-owner.ts
+++ b/src/main/notebook/execution-owner.ts
@@ -300,7 +300,8 @@ class NotebookExecutionOwner {
   }
   async executeControl(
     session: NotebookSessionAggregate,
-    request: ExecuteNotebookControlRequest
+    request: ExecuteNotebookControlRequest,
+    signal?: AbortSignal
   ): Promise<NotebookControlResult> {
     const { runId: controlInvocationId, sequence: controlInvocationGeneration } =
       this.options.runTerminalization.allocateRunIdentity()
@@ -309,7 +310,8 @@ class NotebookExecutionOwner {
         session,
         request,
         controlInvocationId,
-        controlInvocationGeneration
+        controlInvocationGeneration,
+        signal
       )
     )
 
@@ -365,7 +367,8 @@ class NotebookExecutionOwner {
     session: NotebookSessionAggregate,
     request: ExecuteNotebookControlRequest,
     runId: string,
-    controlInvocationGeneration: number
+    controlInvocationGeneration: number,
+    signal?: AbortSignal
   ): Promise<NotebookControlResult> {
     this.options.notifyAvailable(session, 'agent')
     const runningRun: NotebookRunRecord = {
@@ -451,6 +454,7 @@ class NotebookExecutionOwner {
                   runtimeRoot: session.runtimeRoot,
                   protectedDirs: [getAppClaudeConfigDir(this.options.configRoot)],
                   timeoutMs: request.timeoutMs,
+                  signal,
                   mcpRpcEndpoint: mcpRpc?.endpoint,
                   mcpRpcSocketPath: mcpRpc?.socketPath,
                   mcpRpcToken: mcpRpc?.token,
@@ -489,7 +493,8 @@ class NotebookExecutionOwner {
 
   async executeShell(
     session: NotebookSessionAggregate,
-    request: ExecuteShellRequest
+    request: ExecuteShellRequest,
+    signal?: AbortSignal
   ): Promise<NotebookShellResult> {
     const { runId } = this.options.runTerminalization.allocateRunIdentity()
     const runningRun: NotebookRunRecord = {
@@ -539,13 +544,15 @@ class NotebookExecutionOwner {
                 cwd: session.cwd,
                 handoffDir: join(session.notebookSessionRoot, 'handoff'),
                 runtimeRoot: session.runtimeRoot,
-                timeoutMs: request.timeoutMs
+                timeoutMs: request.timeoutMs,
+                signal
               })
         ).finally(async () => {
           workingFiles = await workingFileObservation.finish()
         })
-        const status: NotebookRunStatus =
-          shellResult.exitCode === 0
+        const status: NotebookRunStatus = shellResult.cancelled
+          ? 'cancelled'
+          : shellResult.exitCode === 0
             ? 'completed'
             : shellResult.exitCode === null
               ? 'timeout'

--- a/src/main/notebook/runtime-service.architecture.test.ts
+++ b/src/main/notebook/runtime-service.architecture.test.ts
@@ -221,6 +221,7 @@ describe('Notebook runtime facade architecture', () => {
       [
         'appendCodeCell',
         'beginCodeCell',
+        'beginProjectDeletion',
         'bindRuntime',
         'blockPrefixRecovery',
         'clearCorruptRecoveryBlock',
@@ -247,6 +248,7 @@ describe('Notebook runtime facade architecture', () => {
         'managePackages',
         'peekHandoffContext',
         'recoverInterruptedOperations',
+        'releaseProjectDeletion',
         'restart',
         'revokeRuntime',
         'runCell',
@@ -256,6 +258,7 @@ describe('Notebook runtime facade architecture', () => {
         'setMcpRpcConnectionResolver',
         'shutdown',
         'shutdownAll',
+        'shutdownProject',
         'shutdownSession',
         'state',
         'switchRuntime',

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -323,6 +323,42 @@ describe('notebook runtime service', () => {
     expect(shutdowns[2]).not.toHaveBeenCalled()
   })
 
+  it('blocks new Project lanes and drains a pending lane creation before deletion snapshots', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    const load = repository.loadOrCreate.bind(repository)
+    const loading = createDeferred<void>()
+    vi.spyOn(repository, 'loadOrCreate').mockImplementation(async (request) => {
+      await loading.promise
+      return load(request)
+    })
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository,
+      environmentStateTracker: verifiedPackageMutationTracker()
+    })
+    const request = {
+      projectName: 'project-1',
+      sessionId: 'session-pending',
+      workspaceCwd: '/workspace'
+    }
+
+    const pending = service.state(request)
+    await vi.waitFor(() => expect(repository.loadOrCreate).toHaveBeenCalledOnce())
+    const deleting = service.shutdownProject('project-1')
+    loading.resolve(undefined)
+
+    await expect(pending).rejects.toThrow('Project is being deleted.')
+    await expect(deleting).resolves.toBeUndefined()
+    await expect(service.state(request)).rejects.toThrow('Project is being deleted.')
+
+    service.releaseProjectDeletion('project-1')
+    await expect(service.state(request)).resolves.toMatchObject({ sessionId: 'session-pending' })
+    await service.shutdown(request)
+  })
+
   it('peeks only actionable in-memory handoff state without creating or reloading a Session', async () => {
     const root = await createStorageRoot()
     const { service } = lifecycleCallbackHarness(root)

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -359,6 +359,109 @@ describe('notebook runtime service', () => {
     await service.shutdown(request)
   })
 
+  it('drains an admitted restart before shutting down the Project lane', async () => {
+    const root = await createStorageRoot()
+    const restartGate = createDeferred<void>()
+    const events: string[] = []
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      environmentStateTracker: verifiedPackageMutationTracker(),
+      executorFactory: () => ({
+        execute: async (request): Promise<NotebookExecutionResult> => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: request.cwd,
+          outputs: []
+        }),
+        shutdown: async () => {
+          events.push('shutdown')
+          return { reaped: true }
+        },
+        restart: async () => {
+          events.push('restart-started')
+          await restartGate.promise
+          events.push('restart-finished')
+        }
+      })
+    })
+    const request = {
+      projectName: 'project-1',
+      sessionId: 'session-restarting',
+      workspaceCwd: root
+    }
+    await service.execute({ ...request, code: '1' })
+
+    const restarting = service.restart(request)
+    await vi.waitFor(() => expect(events).toContain('restart-started'))
+    const deleting = service.shutdownProject('project-1')
+    await Promise.resolve()
+
+    expect(events).not.toContain('shutdown')
+    await expect(service.state(request)).rejects.toThrow('Project is being deleted.')
+
+    restartGate.resolve(undefined)
+    await restarting
+    await deleting
+
+    expect(events).toEqual(['restart-started', 'restart-finished', 'shutdown'])
+  })
+
+  it('drains an admitted execution before shutting down the Project lane', async () => {
+    const root = await createStorageRoot()
+    const executionGate = createDeferred<NotebookExecutionResult>()
+    const execute = vi.fn(() => executionGate.promise)
+    const shutdown = vi.fn(async () => ({ reaped: true }))
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      environmentStateTracker: verifiedPackageMutationTracker(),
+      executorFactory: () => ({ execute, shutdown })
+    })
+    const request = {
+      projectName: 'project-1',
+      sessionId: 'session-executing',
+      workspaceCwd: root
+    }
+    const begin = await service.beginCodeCell(request)
+    await service.appendCodeCell({
+      ...request,
+      cellId: begin.cellId,
+      writeId: begin.writeId,
+      delta: '1'
+    })
+    await service.finishCodeCell({
+      ...request,
+      cellId: begin.cellId,
+      writeId: begin.writeId
+    })
+
+    const running = service.runCell({ ...request, cellId: begin.cellId })
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce())
+    const deleting = service.shutdownProject('project-1')
+    await Promise.resolve()
+
+    expect(shutdown).not.toHaveBeenCalled()
+    executionGate.resolve({
+      status: 'completed',
+      stdout: '',
+      stderr: '',
+      traceback: '',
+      cwdAfter: root,
+      outputs: []
+    })
+    await running
+    await deleting
+
+    expect(shutdown).toHaveBeenCalledOnce()
+  })
+
   it('peeks only actionable in-memory handoff state without creating or reloading a Session', async () => {
     const root = await createStorageRoot()
     const { service } = lifecycleCallbackHarness(root)

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -253,6 +253,76 @@ describe('notebook runtime service', () => {
     )
   })
 
+  it('shuts down every idle root and Frame lane owned by one Project', async () => {
+    const root = await createStorageRoot()
+    const shutdowns = [vi.fn(), vi.fn(), vi.fn()]
+    let executorIndex = 0
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      environmentStateTracker: verifiedPackageMutationTracker(),
+      executorFactory: () => {
+        const shutdown = shutdowns[executorIndex++]
+        return {
+          execute: async (request) => ({
+            status: 'completed' as const,
+            stdout: '',
+            stderr: '',
+            traceback: '',
+            cwdAfter: request.cwd,
+            outputs: []
+          }),
+          shutdown: async () => {
+            shutdown()
+            return { reaped: true }
+          }
+        }
+      }
+    })
+    const rootContext = {
+      rootFrameId: 'root-frame-session-1',
+      agentFrameId: 'root-frame-session-1',
+      messageBranchId: 'branch-root',
+      runtimeSegmentId: 'runtime-root',
+      promptMessageId: 'message-root'
+    }
+    const childContext = {
+      ...rootContext,
+      agentFrameId: 'child-frame-1',
+      messageBranchId: 'branch-child',
+      runtimeSegmentId: 'runtime-child',
+      promptMessageId: 'message-child'
+    }
+    await service.execute({
+      projectName: 'project-1',
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      code: 'root_value = 1',
+      provenanceContext: rootContext
+    })
+    await service.execute({
+      projectName: 'project-1',
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      code: 'child_value = 2',
+      provenanceContext: childContext
+    })
+    await service.execute({
+      projectName: 'project-2',
+      sessionId: 'session-2',
+      workspaceCwd: '/workspace',
+      code: 'other_value = 3'
+    })
+
+    await service.shutdownProject('project-1')
+
+    expect(shutdowns[0]).toHaveBeenCalledOnce()
+    expect(shutdowns[1]).toHaveBeenCalledOnce()
+    expect(shutdowns[2]).not.toHaveBeenCalled()
+  })
+
   it('peeks only actionable in-memory handoff state without creating or reloading a Session', async () => {
     const root = await createStorageRoot()
     const { service } = lifecycleCallbackHarness(root)

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -411,10 +411,28 @@ describe('notebook runtime service', () => {
     expect(events).toEqual(['restart-started', 'restart-finished', 'shutdown'])
   })
 
-  it('drains an admitted execution before shutting down the Project lane', async () => {
+  it('cancels an admitted execution before shutting down the Project lane', async () => {
     const root = await createStorageRoot()
-    const executionGate = createDeferred<NotebookExecutionResult>()
-    const execute = vi.fn(() => executionGate.promise)
+    let executionSignal: AbortSignal | undefined
+    const execute = vi.fn(
+      (request: NotebookExecutionRequest) =>
+        new Promise<NotebookExecutionResult>((resolve) => {
+          executionSignal = request.signal
+          request.signal?.addEventListener(
+            'abort',
+            () =>
+              resolve({
+                status: 'cancelled',
+                stdout: '',
+                stderr: 'cancelled',
+                traceback: '',
+                cwdAfter: request.cwd,
+                outputs: []
+              }),
+            { once: true }
+          )
+        })
+    )
     const shutdown = vi.fn(async () => ({ reaped: true }))
     const service = new NotebookRuntimeService({
       configRoot: root,
@@ -445,21 +463,88 @@ describe('notebook runtime service', () => {
     const running = service.runCell({ ...request, cellId: begin.cellId })
     await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce())
     const deleting = service.shutdownProject('project-1')
-    await Promise.resolve()
+    await vi.waitFor(() => expect(executionSignal?.aborted).toBe(true))
 
-    expect(shutdown).not.toHaveBeenCalled()
-    executionGate.resolve({
-      status: 'completed',
-      stdout: '',
-      stderr: '',
-      traceback: '',
-      cwdAfter: root,
-      outputs: []
-    })
-    await running
+    await expect(running).resolves.toMatchObject({ status: 'cancelled' })
     await deleting
 
     expect(shutdown).toHaveBeenCalledOnce()
+  })
+
+  it('cancels admitted control and shell executions before Project shutdown completes', async () => {
+    const root = await createStorageRoot()
+    let controlSignal: AbortSignal | undefined
+    let shellSignal: AbortSignal | undefined
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      environmentStateTracker: verifiedPackageMutationTracker(),
+      executorFactory: () => ({
+        execute: (request) =>
+          new Promise<NotebookExecutionResult>((resolve) => {
+            controlSignal = request.signal
+            request.signal?.addEventListener(
+              'abort',
+              () =>
+                resolve({
+                  status: 'cancelled',
+                  stdout: '',
+                  stderr: 'cancelled',
+                  traceback: '',
+                  cwdAfter: request.cwd,
+                  outputs: []
+                }),
+              { once: true }
+            )
+          }),
+        shutdown: async () => ({ reaped: true })
+      }),
+      shellProcess: {
+        execute: (request) =>
+          new Promise((resolve) => {
+            shellSignal = request.signal
+            request.signal?.addEventListener(
+              'abort',
+              () =>
+                resolve({
+                  stdout: '',
+                  stderr: 'Shell command was cancelled.',
+                  exitCode: null,
+                  cancelled: true
+                }),
+              { once: true }
+            )
+          })
+      }
+    })
+    const scope = { projectName: 'project-1', workspaceCwd: root }
+
+    const control = service.executeControl({ ...scope, sessionId: 'control-session', code: '1' })
+    const shell = service.executeShell({
+      ...scope,
+      sessionId: 'shell-session',
+      command: 'long-running-command'
+    })
+    await vi.waitFor(() => {
+      expect(controlSignal).toBeInstanceOf(AbortSignal)
+      expect(shellSignal).toBeInstanceOf(AbortSignal)
+    })
+
+    const deleting = service.shutdownProject('project-1')
+    await vi.waitFor(() => {
+      expect(controlSignal?.aborted).toBe(true)
+      expect(shellSignal?.aborted).toBe(true)
+    })
+
+    await expect(control).resolves.toMatchObject({ status: 'cancelled' })
+    await expect(shell).resolves.toEqual({
+      stdout: '',
+      stderr: 'Shell command was cancelled.',
+      exitCode: null
+    })
+    await expect(deleting).resolves.toBeUndefined()
   })
 
   it('drains an admitted Project-scoped package install before shutdown completes', async () => {
@@ -889,8 +974,10 @@ describe('notebook runtime service', () => {
     )
     const execution = await executionStarted.promise
 
-    expect(execution.signal).toBe(cancellation.signal)
+    expect(execution.signal).toBeInstanceOf(AbortSignal)
+    expect(execution.signal?.aborted).toBe(false)
     cancellation.abort()
+    expect(execution.signal?.aborted).toBe(true)
 
     await expect(run).resolves.toMatchObject({ status: 'cancelled' })
     await expect(
@@ -2347,7 +2434,8 @@ describe('notebook runtime service', () => {
         cwd: join(root, 'notebooks', 'default-project', 'session-1', 'data'),
         handoffDir: join(root, 'notebooks', 'default-project', 'session-1', 'handoff'),
         runtimeRoot: getRuntimeRoot(root),
-        timeoutMs: 321
+        timeoutMs: 321,
+        signal: expect.any(AbortSignal)
       })
       expect(result).toEqual({
         stdout: 'partial output',

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -6192,6 +6192,7 @@ describe('v4 runtime bindings & agent tools', () => {
       enablement?: RuntimeEnablement
       executions?: NotebookExecutionRequest[]
       terminations?: string[]
+      terminate?: (kind: 'python' | 'r' | 'repl', env: string) => Promise<void>
       platform?: NodeJS.Platform
       repository?: NotebookRunRepository
       discoverRuntimes?: (language: 'python' | 'r') => Promise<DiscoveredInterpreter[]>
@@ -6240,9 +6241,11 @@ describe('v4 runtime bindings & agent tools', () => {
           }
         },
         shutdown: async () => ({ reaped: true }),
-        terminate: async (kind, env) => {
-          options.terminations?.push(`${kind}:${env}`)
-        }
+        terminate:
+          options.terminate ??
+          (async (kind, env) => {
+            options.terminations?.push(`${kind}:${env}`)
+          })
       })
     })
 
@@ -8400,6 +8403,51 @@ describe('v4 runtime bindings & agent tools', () => {
     // after the in-flight run drains (here already finished), not left to idle-timeout.
     await vi.waitFor(() => expect(terminations).toContain('python:default-python'))
     await service.shutdownAll()
+  })
+
+  it('waits for a deferred runtime-revocation drain before removing the Project lane', async () => {
+    const root = await createStorageRoot()
+    const terminationStarted = createDeferred<void>()
+    const terminationGate = createDeferred<void>()
+    const events: string[] = []
+    const service = bindingService(root, {
+      enablement: { enabled: { [userPyA.envId]: true }, installAuthorized: {} },
+      terminate: async () => {
+        events.push('revocation-started')
+        terminationStarted.resolve(undefined)
+        await terminationGate.promise
+        events.push('revocation-finished')
+      }
+    })
+    const request = {
+      projectName: 'project-1',
+      sessionId: 's',
+      workspaceCwd: root
+    }
+    await service.bindRuntime({
+      ...request,
+      language: 'python',
+      runtimeId: userPyA.envId
+    })
+    await service.execute({ ...request, code: '1', language: 'python' })
+
+    await service.revokeRuntime('python', userPyA.envId)
+    await terminationStarted.promise
+
+    let deletionCompleted = false
+    const deleting = service.shutdownProject('project-1').then(() => {
+      deletionCompleted = true
+      events.push('project-deleted')
+    })
+    await Promise.resolve()
+
+    expect(deletionCompleted).toBe(false)
+    expect(events).toEqual(['revocation-started'])
+
+    terminationGate.resolve(undefined)
+    await deleting
+
+    expect(events).toEqual(['revocation-started', 'revocation-finished', 'project-deleted'])
   })
 
   it('shares one aggregate initialization across concurrent public session reads', async () => {

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -462,6 +462,81 @@ describe('notebook runtime service', () => {
     expect(shutdown).toHaveBeenCalledOnce()
   })
 
+  it('drains an admitted Project-scoped package install before shutdown completes', async () => {
+    const root = await createStorageRoot()
+    const installGate = createDeferred<InstallResultForTest>()
+    const installPackagesImpl = vi.fn(() => installGate.promise)
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      environmentStateTracker: verifiedPackageMutationTracker(),
+      installPackagesImpl
+    })
+
+    const installing = service.managePackages({
+      projectId: 'project-1',
+      language: 'python',
+      packages: ['numpy']
+    })
+    await vi.waitFor(() => expect(installPackagesImpl).toHaveBeenCalledOnce())
+
+    let shutdownCompleted = false
+    const deleting = service.shutdownProject('project-1').then(() => {
+      shutdownCompleted = true
+    })
+    await Promise.resolve()
+
+    expect(shutdownCompleted).toBe(false)
+
+    installGate.resolve({
+      ok: true,
+      needsRestart: false,
+      log: 'installed',
+      method: 'pip'
+    })
+    await installing
+    await deleting
+
+    expect(shutdownCompleted).toBe(true)
+  })
+
+  it('rejects new Project-scoped installs during deletion without blocking global installs', async () => {
+    const root = await createStorageRoot()
+    const installPackagesImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      needsRestart: false,
+      log: 'installed',
+      method: 'pip'
+    })
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectName: 'default-project',
+      repository: new NotebookRunRepository(root),
+      environmentStateTracker: verifiedPackageMutationTracker(),
+      installPackagesImpl
+    })
+
+    service.beginProjectDeletion('project-1')
+    await expect(
+      service.managePackages({
+        projectId: 'project-1',
+        language: 'python',
+        packages: ['numpy']
+      })
+    ).rejects.toThrow('Project is being deleted.')
+    expect(installPackagesImpl).not.toHaveBeenCalled()
+
+    await expect(
+      service.managePackages({ language: 'python', packages: ['numpy'] })
+    ).resolves.toMatchObject({ ok: true })
+    expect(installPackagesImpl).toHaveBeenCalledOnce()
+
+    service.releaseProjectDeletion('project-1')
+  })
+
   it('peeks only actionable in-memory handoff state without creating or reloading a Session', async () => {
     const root = await createStorageRoot()
     const { service } = lifecycleCallbackHarness(root)

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -580,8 +580,10 @@ class NotebookRuntimeService {
     runtimes: NotebookRuntimeListing[]
     bindings: NotebookRuntimeBindings
   }> {
-    const session = await this.sessionLifecycle.ensure(request)
-    return this.runtimeBindingOwner.list(session)
+    return this.sessionLifecycle.runProjectOperation(request, async () => {
+      const session = await this.sessionLifecycle.ensure(request)
+      return this.runtimeBindingOwner.list(session)
+    })
   }
 
   // notebook_bind_runtime: the FIRST binding of a language for the session. Refuses a disabled/unknown
@@ -589,12 +591,14 @@ class NotebookRuntimeService {
   async bindRuntime(
     request: NotebookSessionRequest & { language: NotebookLanguage; runtimeId: string }
   ): Promise<{ bound: NotebookRuntimeBinding; bindings: NotebookRuntimeBindings }> {
-    return this.runtimeBindingOwner.runWrite(
-      notebookLaneKey(this.sessionLifecycle.laneForRequest(request)),
-      async () => {
-        const session = await this.sessionLifecycle.ensure(request)
-        return this.runtimeBindingOwner.bind(session, request.language, request.runtimeId)
-      }
+    return this.sessionLifecycle.runProjectOperation(request, () =>
+      this.runtimeBindingOwner.runWrite(
+        notebookLaneKey(this.sessionLifecycle.laneForRequest(request)),
+        async () => {
+          const session = await this.sessionLifecycle.ensure(request)
+          return this.runtimeBindingOwner.bind(session, request.language, request.runtimeId)
+        }
+      )
     )
   }
 
@@ -603,26 +607,28 @@ class NotebookRuntimeService {
   async switchRuntime(
     request: NotebookSessionRequest & { language: NotebookLanguage; runtimeId: string }
   ): Promise<{ bound: NotebookRuntimeBinding; bindings: NotebookRuntimeBindings }> {
-    return this.runtimeBindingOwner.runWrite(
-      notebookLaneKey(this.sessionLifecycle.laneForRequest(request)),
-      async () => {
-        const session = await this.sessionLifecycle.ensure(request)
-        const result = await this.runtimeBindingOwner.switch(
-          session,
-          request.language,
-          request.runtimeId,
-          async () => {
-            // PHYSICALLY tear down the CURRENT runtime's kernel for this language BEFORE rebinding, so the
-            // new runtime starts fresh and two same-language interpreters never coexist.
-            const oldEnv = this.resolveRunEnv(session, request.language)
-            const kind = request.language === 'r' ? 'r' : 'python'
-            await session.terminateExecutor(kind, oldEnv)
-            await this.tearDownLanguageBinding(session, request.language, oldEnv)
-          }
-        )
-        this.sessionLifecycle.notifyChanged(session)
-        return result
-      }
+    return this.sessionLifecycle.runProjectOperation(request, () =>
+      this.runtimeBindingOwner.runWrite(
+        notebookLaneKey(this.sessionLifecycle.laneForRequest(request)),
+        async () => {
+          const session = await this.sessionLifecycle.ensure(request)
+          const result = await this.runtimeBindingOwner.switch(
+            session,
+            request.language,
+            request.runtimeId,
+            async () => {
+              // PHYSICALLY tear down the CURRENT runtime's kernel for this language BEFORE rebinding, so the
+              // new runtime starts fresh and two same-language interpreters never coexist.
+              const oldEnv = this.resolveRunEnv(session, request.language)
+              const kind = request.language === 'r' ? 'r' : 'python'
+              await session.terminateExecutor(kind, oldEnv)
+              await this.tearDownLanguageBinding(session, request.language, oldEnv)
+            }
+          )
+          this.sessionLifecycle.notifyChanged(session)
+          return result
+        }
+      )
     )
   }
 
@@ -684,22 +690,24 @@ class NotebookRuntimeService {
     writeId: string
     status: NotebookCell['status']
   }> {
-    const session = await this.sessionLifecycle.ensure(request)
-    const cellId = request.cellId ?? `cell-${randomUUID()}`
-    const writeId = `write-${randomUUID()}`
-    const source = request.source ?? 'agent'
-    const cell = session.beginCellWrite({
-      cellId,
-      language: request.language ?? 'python',
-      writeId,
-      source,
-      startedAt: Date.now()
+    return this.sessionLifecycle.runProjectOperation(request, async () => {
+      const session = await this.sessionLifecycle.ensure(request)
+      const cellId = request.cellId ?? `cell-${randomUUID()}`
+      const writeId = `write-${randomUUID()}`
+      const source = request.source ?? 'agent'
+      const cell = session.beginCellWrite({
+        cellId,
+        language: request.language ?? 'python',
+        writeId,
+        source,
+        startedAt: Date.now()
+      })
+
+      this.sessionLifecycle.notifyAvailable(session, source)
+      this.sessionLifecycle.notifyChanged(session)
+
+      return { sessionId: session.sessionId, cellId, writeId, status: cell.status }
     })
-
-    this.sessionLifecycle.notifyAvailable(session, source)
-    this.sessionLifecycle.notifyChanged(session)
-
-    return { sessionId: session.sessionId, cellId, writeId, status: cell.status }
   }
 
   // Appends raw code text to the locked cell and streams the change to the preview.
@@ -709,24 +717,26 @@ class NotebookRuntimeService {
     writeId: string
     receivedBytes: number
   }> {
-    const session = await this.sessionLifecycle.ensure(request)
-    const current = session.cellView(request.cellId)
-    try {
-      assertNotebookCodeAppendWithinLimit(current.code, request.delta)
-    } catch (error) {
-      session.abortCellWrite(request.cellId, request.writeId)
+    return this.sessionLifecycle.runProjectOperation(request, async () => {
+      const session = await this.sessionLifecycle.ensure(request)
+      const current = session.cellView(request.cellId)
+      try {
+        assertNotebookCodeAppendWithinLimit(current.code, request.delta)
+      } catch (error) {
+        session.abortCellWrite(request.cellId, request.writeId)
+        this.sessionLifecycle.notifyChanged(session)
+        throw error
+      }
+      const cell = session.appendCellCode(request.cellId, request.writeId, request.delta)
       this.sessionLifecycle.notifyChanged(session)
-      throw error
-    }
-    const cell = session.appendCellCode(request.cellId, request.writeId, request.delta)
-    this.sessionLifecycle.notifyChanged(session)
 
-    return {
-      sessionId: session.sessionId,
-      cellId: cell.id,
-      writeId: request.writeId,
-      receivedBytes: Buffer.byteLength(cell.code, 'utf8')
-    }
+      return {
+        sessionId: session.sessionId,
+        cellId: cell.id,
+        writeId: request.writeId,
+        receivedBytes: Buffer.byteLength(cell.code, 'utf8')
+      }
+    })
   }
 
   // Releases a write lock so the completed cell can be run by the same shared interpreter.
@@ -736,11 +746,13 @@ class NotebookRuntimeService {
     code: string
     status: NotebookCell['status']
   }> {
-    const session = await this.sessionLifecycle.ensure(request)
-    const cell = session.finishCellWrite(request.cellId, request.writeId)
-    this.sessionLifecycle.notifyChanged(session)
+    return this.sessionLifecycle.runProjectOperation(request, async () => {
+      const session = await this.sessionLifecycle.ensure(request)
+      const cell = session.finishCellWrite(request.cellId, request.writeId)
+      this.sessionLifecycle.notifyChanged(session)
 
-    return { sessionId: session.sessionId, cellId: cell.id, code: cell.code, status: cell.status }
+      return { sessionId: session.sessionId, cellId: cell.id, code: cell.code, status: cell.status }
+    })
   }
 
   // Compatibility facade: Session lookup and public summary projection stay here; lifecycle is owned.
@@ -748,9 +760,11 @@ class NotebookRuntimeService {
     request: RunNotebookCellRequest,
     signal?: AbortSignal
   ): Promise<NotebookRunSummary> {
-    const session = await this.sessionLifecycle.ensure(request)
-    const run = await this.executionOwner.executeDataCell(session, request, signal)
-    return this.sessionReadModel.toRunSummary(session, run)
+    return this.sessionLifecycle.runProjectOperation(request, async () => {
+      const session = await this.sessionLifecycle.ensure(request)
+      const run = await this.executionOwner.executeDataCell(session, request, signal)
+      return this.sessionReadModel.toRunSummary(session, run)
+    })
   }
 
   // Convenience path used by the terminal and MCP to write a temporary cell and run it.
@@ -785,17 +799,21 @@ class NotebookRuntimeService {
   // Compatibility facade for the control-plane REPL. Admission, capability lifetime, dispatch,
   // terminalization, and completion interception belong to NotebookExecutionOwner.
   async executeControl(request: ExecuteNotebookControlRequest): Promise<NotebookControlResult> {
-    assertNotebookCodeWithinLimit(request.code)
-    const session = await this.sessionLifecycle.ensure(request)
-    return this.executionOwner.executeControl(session, request)
+    return this.sessionLifecycle.runProjectOperation(request, async () => {
+      assertNotebookCodeWithinLimit(request.code)
+      const session = await this.sessionLifecycle.ensure(request)
+      return this.executionOwner.executeControl(session, request)
+    })
   }
 
   // Compatibility facade for stateless shell execution. The owner deliberately admits calls without
   // a per-Session queue while the repository continues to serialize durable run writes.
   async executeShell(request: ExecuteShellRequest): Promise<NotebookShellResult> {
-    assertNotebookCodeWithinLimit(request.command)
-    const session = await this.sessionLifecycle.ensure(request)
-    return this.executionOwner.executeShell(session, request)
+    return this.sessionLifecycle.runProjectOperation(request, async () => {
+      assertNotebookCodeWithinLimit(request.command)
+      const session = await this.sessionLifecycle.ensure(request)
+      return this.executionOwner.executeShell(session, request)
+    })
   }
 
   // Read-only handoff projection for a fresh Agent context. A missing aggregate means Notebook was
@@ -809,25 +827,27 @@ class NotebookRuntimeService {
   async state(
     request: NotebookSessionStateRequest
   ): Promise<NotebookSessionState & { runtimeBindings: NotebookRuntimeBindings }> {
-    const requestedRunIds = request.runIds ?? []
-    if (requestedRunIds.length > NOTEBOOK_STATE_TARGET_RUN_LIMIT) {
-      throw new Error(
-        `Notebook state accepts at most ${NOTEBOOK_STATE_TARGET_RUN_LIMIT} targeted run IDs per request.`
-      )
-    }
-    if (
-      request.historySummaryFrameId !== undefined &&
-      Buffer.byteLength(request.historySummaryFrameId, 'utf8') >
-        NOTEBOOK_STATE_HISTORY_FRAME_ID_LIMIT_BYTES
-    ) {
-      throw new Error(
-        `Notebook state history summary Frame ID must not exceed ${NOTEBOOK_STATE_HISTORY_FRAME_ID_LIMIT_BYTES} UTF-8 bytes.`
-      )
-    }
-    const runIds = [...new Set(requestedRunIds)]
-    const session = await this.sessionLifecycle.ensure(request)
-    await this.runTerminalization.reconcilePending(session)
-    return this.sessionReadModel.state(session, runIds, request.historySummaryFrameId)
+    return this.sessionLifecycle.runProjectOperation(request, async () => {
+      const requestedRunIds = request.runIds ?? []
+      if (requestedRunIds.length > NOTEBOOK_STATE_TARGET_RUN_LIMIT) {
+        throw new Error(
+          `Notebook state accepts at most ${NOTEBOOK_STATE_TARGET_RUN_LIMIT} targeted run IDs per request.`
+        )
+      }
+      if (
+        request.historySummaryFrameId !== undefined &&
+        Buffer.byteLength(request.historySummaryFrameId, 'utf8') >
+          NOTEBOOK_STATE_HISTORY_FRAME_ID_LIMIT_BYTES
+      ) {
+        throw new Error(
+          `Notebook state history summary Frame ID must not exceed ${NOTEBOOK_STATE_HISTORY_FRAME_ID_LIMIT_BYTES} UTF-8 bytes.`
+        )
+      }
+      const runIds = [...new Set(requestedRunIds)]
+      const session = await this.sessionLifecycle.ensure(request)
+      await this.runTerminalization.reconcilePending(session)
+      return this.sessionReadModel.state(session, runIds, request.historySummaryFrameId)
+    })
   }
 
   // Resolves the durable reference for a session, preferring the live runtime session but falling
@@ -861,37 +881,40 @@ class NotebookRuntimeService {
   // and lazily respawns its loops) and only shuts down + recreates for executors that don't support it.
   // Reports 'restarting' for the duration and settles back to 'idle' once the fresh process is ready.
   async restart(request: NotebookSessionRequest): Promise<NotebookSessionState> {
-    const session = await this.sessionLifecycle.ensure(request)
+    return this.sessionLifecycle.runProjectOperation(request, async () => {
+      const session = await this.sessionLifecycle.ensure(request)
 
-    // A restart respawns fresh loops, so any pending R-restart recommendation for this session's envs
-    // is cleared. Snapshot the keys before teardown drops them from kernelStatuses.
-    const envKeys = session.kernelProcessKeys()
+      // A restart respawns fresh loops, so any pending R-restart recommendation for this session's envs
+      // is cleared. Snapshot the keys before teardown drops them from kernelStatuses.
+      const envKeys = session.kernelProcessKeys()
 
-    envKeys.forEach((processKey) => session.setKernelStatus(processKey, 'restarting'))
-    await this.repository.clearKernelTerminations({
-      projectName: session.projectId,
-      sessionId: session.sessionId,
-      lane: session.lane,
-      status: 'restarting'
-    })
-    session.clearAllDurableKernelTerminations()
-    this.sessionLifecycle.notifyChanged(session)
-
-    try {
-      await session.restartExecutor(() => this.sessionLifecycle.createExecutor(session.lane))
-      this.environmentOperations.clearRestartRecommendations(envKeys)
-    } finally {
-      envKeys.forEach((processKey) => session.setKernelStatus(processKey, 'idle'))
-      await this.repository.updateKernelStatus({
+      envKeys.forEach((processKey) => session.setKernelStatus(processKey, 'restarting'))
+      await this.repository.clearKernelTerminations({
         projectName: session.projectId,
         sessionId: session.sessionId,
         lane: session.lane,
-        status: 'idle'
+        status: 'restarting'
       })
-    }
-    this.sessionLifecycle.notifyChanged(session)
+      session.clearAllDurableKernelTerminations()
+      this.sessionLifecycle.notifyChanged(session)
 
-    return this.state(request)
+      try {
+        await session.restartExecutor(() => this.sessionLifecycle.createExecutor(session.lane))
+        this.environmentOperations.clearRestartRecommendations(envKeys)
+      } finally {
+        envKeys.forEach((processKey) => session.setKernelStatus(processKey, 'idle'))
+        await this.repository.updateKernelStatus({
+          projectName: session.projectId,
+          sessionId: session.sessionId,
+          lane: session.lane,
+          status: 'idle'
+        })
+      }
+      this.sessionLifecycle.notifyChanged(session)
+
+      await this.runTerminalization.reconcilePending(session)
+      return this.sessionReadModel.state(session)
+    })
   }
 
   // Reads installed package metadata from the app-managed runtime bound to this session. The shared
@@ -899,7 +922,9 @@ class NotebookRuntimeService {
   // ordinary notebook runs to proceed. External runtimes are rejected because inventory capture must
   // execute their interpreter; notebookExecute provides the explicit execution approval for that case.
   async inspectPackages(request: InspectPackagesRequest): Promise<InspectPackagesResult> {
-    return this.packageOperations.inspect(request)
+    return this.sessionLifecycle.runProjectOperation(request, () =>
+      this.packageOperations.inspect(request)
+    )
   }
 
   // Installs packages into the shared global environments (never inside a session/kernel). Resolves

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -935,6 +935,14 @@ class NotebookRuntimeService {
     return this.sessionLifecycle.shutdownProject(projectId)
   }
 
+  beginProjectDeletion(projectId: string): void {
+    this.sessionLifecycle.beginProjectDeletion(projectId)
+  }
+
+  releaseProjectDeletion(projectId: string): void {
+    this.sessionLifecycle.releaseProjectDeletion(projectId)
+  }
+
   // Crash recovery (WS13): reconcile any runtime operation the previous process left in flight. Run at
   // app startup and refresh guarded startup blocks before new writes. For each journalled op: if a child
   // MIGHT still be running, BLOCK its target and leave the entry (recovery never signals the orphan);

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -934,7 +934,12 @@ class NotebookRuntimeService {
   // env — a pip/conda/CRAN install can never overlap a cell mid-import (§5, G2/D5). Installs into
   // DIFFERENT envs proceed concurrently (the lock is keyed by resolved env name, not language).
   async managePackages(request: InstallRequest): Promise<InstallResult> {
-    return this.packageOperations.manage(request)
+    const manage = (): Promise<InstallResult> => this.packageOperations.manage(request)
+    if (request.projectId === undefined && request.projectName === undefined) return manage()
+
+    // Project admission is keyed only by project identity. InstallRequest intentionally keeps the
+    // session fields optional because settings and repair flows can manage a global environment.
+    return this.sessionLifecycle.runProjectOperation(request as NotebookSessionRequest, manage)
   }
 
   // Named-environment management (design D2), delegating to the injected provisioner-backed manager.

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -931,6 +931,10 @@ class NotebookRuntimeService {
     return this.sessionLifecycle.shutdownSession(sessionId)
   }
 
+  async shutdownProject(projectId: string): Promise<void> {
+    return this.sessionLifecycle.shutdownProject(projectId)
+  }
+
   // Crash recovery (WS13): reconcile any runtime operation the previous process left in flight. Run at
   // app startup and refresh guarded startup blocks before new writes. For each journalled op: if a child
   // MIGHT still be running, BLOCK its target and leave the entry (recovery never signals the orphan);

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -402,6 +402,7 @@ class NotebookRuntimeService {
       repository: this.repository,
       sessions: this.sessions,
       runtimeBindings: this.runtimeBindingOwner,
+      waitForRevocationDrains: () => this.environmentOperations.waitForRevocationDrains(),
       executorFactory: options.executorFactory,
       defaultExecutorOptions: resolveDefaultExecutorOptions,
       platform: options.platform,

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -761,9 +761,13 @@ class NotebookRuntimeService {
     request: RunNotebookCellRequest,
     signal?: AbortSignal
   ): Promise<NotebookRunSummary> {
-    return this.sessionLifecycle.runProjectOperation(request, async () => {
+    return this.sessionLifecycle.runProjectOperation(request, async (deletionSignal) => {
       const session = await this.sessionLifecycle.ensure(request)
-      const run = await this.executionOwner.executeDataCell(session, request, signal)
+      const run = await this.executionOwner.executeDataCell(
+        session,
+        request,
+        signal ? AbortSignal.any([signal, deletionSignal]) : deletionSignal
+      )
       return this.sessionReadModel.toRunSummary(session, run)
     })
   }
@@ -800,20 +804,20 @@ class NotebookRuntimeService {
   // Compatibility facade for the control-plane REPL. Admission, capability lifetime, dispatch,
   // terminalization, and completion interception belong to NotebookExecutionOwner.
   async executeControl(request: ExecuteNotebookControlRequest): Promise<NotebookControlResult> {
-    return this.sessionLifecycle.runProjectOperation(request, async () => {
+    return this.sessionLifecycle.runProjectOperation(request, async (deletionSignal) => {
       assertNotebookCodeWithinLimit(request.code)
       const session = await this.sessionLifecycle.ensure(request)
-      return this.executionOwner.executeControl(session, request)
+      return this.executionOwner.executeControl(session, request, deletionSignal)
     })
   }
 
   // Compatibility facade for stateless shell execution. The owner deliberately admits calls without
   // a per-Session queue while the repository continues to serialize durable run writes.
   async executeShell(request: ExecuteShellRequest): Promise<NotebookShellResult> {
-    return this.sessionLifecycle.runProjectOperation(request, async () => {
+    return this.sessionLifecycle.runProjectOperation(request, async (deletionSignal) => {
       assertNotebookCodeWithinLimit(request.command)
       const session = await this.sessionLifecycle.ensure(request)
-      return this.executionOwner.executeShell(session, request)
+      return this.executionOwner.executeShell(session, request, deletionSignal)
     })
   }
 

--- a/src/main/notebook/session-lifecycle.ts
+++ b/src/main/notebook/session-lifecycle.ts
@@ -78,6 +78,8 @@ const kernelInstanceForProcessKey = (processKey: string): NotebookKernelInstance
 // Orchestrates one Registry generation without duplicating Registry or Aggregate state.
 class NotebookSessionLifecycleOwner {
   private readonly announcedAgentLaneKeys = new Set<string>()
+  private readonly deletingProjectIds = new Set<string>()
+  private readonly pendingEnsuresByProject = new Map<string, Set<Promise<RuntimeSession>>>()
 
   constructor(private readonly options: NotebookSessionLifecycleOptions) {}
 
@@ -99,8 +101,14 @@ class NotebookSessionLifecycleOwner {
 
   ensure(request: NotebookSessionRequest): Promise<RuntimeSession> {
     const projectId = resolveProjectId(request, this.options.defaultProjectId)
+    try {
+      this.assertProjectAvailable(projectId)
+    } catch (error) {
+      return Promise.reject(error)
+    }
     const lane = this.laneForRequest(request)
-    return this.options.sessions.getOrCreate(lane, async () => {
+    const ensuring = this.options.sessions.getOrCreate(lane, async () => {
+      this.assertProjectAvailable(projectId)
       let document = await this.options.repository.loadOrCreate({
         projectName: projectId,
         sessionId: request.sessionId,
@@ -139,6 +147,7 @@ class NotebookSessionLifecycleOwner {
 
       try {
         await this.options.runtimeBindings.reload(session, document.runtimeBindings)
+        this.assertProjectAvailable(projectId)
         return session
       } catch (error) {
         await session.shutdownExecutor().catch(() => undefined)
@@ -150,6 +159,19 @@ class NotebookSessionLifecycleOwner {
         throw error
       }
     })
+    const pending =
+      this.pendingEnsuresByProject.get(projectId) ?? new Set<Promise<RuntimeSession>>()
+    pending.add(ensuring)
+    this.pendingEnsuresByProject.set(projectId, pending)
+    void ensuring
+      .finally(() => {
+        pending.delete(ensuring)
+        if (pending.size === 0 && this.pendingEnsuresByProject.get(projectId) === pending) {
+          this.pendingEnsuresByProject.delete(projectId)
+        }
+      })
+      .catch(() => undefined)
+    return ensuring
   }
 
   createExecutor(lane: NotebookLaneIdentity): NotebookSessionOwnedExecutor {
@@ -184,6 +206,8 @@ class NotebookSessionLifecycleOwner {
   }
 
   async shutdownProject(projectId: string): Promise<void> {
+    this.beginProjectDeletion(projectId)
+    await Promise.allSettled(this.pendingEnsuresByProject.get(projectId) ?? [])
     const lanes = Array.from(this.options.sessions.values())
       .filter((session) => session.projectId === projectId)
       .map((session) => session.lane)
@@ -196,6 +220,14 @@ class NotebookSessionLifecycleOwner {
     }
   }
 
+  beginProjectDeletion(projectId: string): void {
+    this.deletingProjectIds.add(projectId)
+  }
+
+  releaseProjectDeletion(projectId: string): void {
+    this.deletingProjectIds.delete(projectId)
+  }
+
   private async shutdownLane(
     lane: NotebookLaneIdentity
   ): Promise<{ sessionId: string; status: 'shutdown' }> {
@@ -206,6 +238,12 @@ class NotebookSessionLifecycleOwner {
       await this.options.sessions.remove(lane)
     })
     return { sessionId, status: 'shutdown' }
+  }
+
+  private assertProjectAvailable(projectId: string): void {
+    if (this.deletingProjectIds.has(projectId)) {
+      throw new Error('Project is being deleted.')
+    }
   }
 
   shutdownAll(): Promise<{ reaped: boolean }> {

--- a/src/main/notebook/session-lifecycle.ts
+++ b/src/main/notebook/session-lifecycle.ts
@@ -82,6 +82,7 @@ class NotebookSessionLifecycleOwner {
   private readonly deletingProjectIds = new Set<string>()
   private readonly pendingEnsuresByProject = new Map<string, Set<Promise<RuntimeSession>>>()
   private readonly pendingOperationsByProject = new Map<string, Set<Promise<unknown>>>()
+  private readonly operationAbortControllersByProject = new Map<string, Set<AbortController>>()
 
   constructor(private readonly options: NotebookSessionLifecycleOptions) {}
 
@@ -178,7 +179,7 @@ class NotebookSessionLifecycleOwner {
 
   runProjectOperation<Result>(
     request: NotebookSessionRequest,
-    operation: () => Promise<Result>
+    operation: (deletionSignal: AbortSignal) => Promise<Result>
   ): Promise<Result> {
     const projectId = resolveProjectId(request, this.options.defaultProjectId)
     try {
@@ -186,6 +187,11 @@ class NotebookSessionLifecycleOwner {
     } catch (error) {
       return Promise.reject(error)
     }
+    const controller = new AbortController()
+    const controllers =
+      this.operationAbortControllersByProject.get(projectId) ?? new Set<AbortController>()
+    controllers.add(controller)
+    this.operationAbortControllersByProject.set(projectId, controllers)
     let resolveRunning!: (value: Result | PromiseLike<Result>) => void
     let rejectRunning!: (reason?: unknown) => void
     const running = new Promise<Result>((resolve, reject) => {
@@ -198,12 +204,19 @@ class NotebookSessionLifecycleOwner {
     // Register before invoking the operation so a synchronous teardown can observe the lease, while
     // preserving the existing guarantee that callers start work before the method returns.
     try {
-      void operation().then(resolveRunning, rejectRunning)
+      void operation(controller.signal).then(resolveRunning, rejectRunning)
     } catch (error) {
       rejectRunning(error)
     }
     void running
       .finally(() => {
+        controllers.delete(controller)
+        if (
+          controllers.size === 0 &&
+          this.operationAbortControllersByProject.get(projectId) === controllers
+        ) {
+          this.operationAbortControllersByProject.delete(projectId)
+        }
         pending.delete(running)
         if (pending.size === 0 && this.pendingOperationsByProject.get(projectId) === pending) {
           this.pendingOperationsByProject.delete(projectId)
@@ -264,6 +277,10 @@ class NotebookSessionLifecycleOwner {
 
   beginProjectDeletion(projectId: string): void {
     this.deletingProjectIds.add(projectId)
+    const reason = new Error('Project is being deleted.')
+    for (const controller of this.operationAbortControllersByProject.get(projectId) ?? []) {
+      controller.abort(reason)
+    }
   }
 
   releaseProjectDeletion(projectId: string): void {

--- a/src/main/notebook/session-lifecycle.ts
+++ b/src/main/notebook/session-lifecycle.ts
@@ -80,6 +80,7 @@ class NotebookSessionLifecycleOwner {
   private readonly announcedAgentLaneKeys = new Set<string>()
   private readonly deletingProjectIds = new Set<string>()
   private readonly pendingEnsuresByProject = new Map<string, Set<Promise<RuntimeSession>>>()
+  private readonly pendingOperationsByProject = new Map<string, Set<Promise<unknown>>>()
 
   constructor(private readonly options: NotebookSessionLifecycleOptions) {}
 
@@ -174,6 +175,43 @@ class NotebookSessionLifecycleOwner {
     return ensuring
   }
 
+  runProjectOperation<Result>(
+    request: NotebookSessionRequest,
+    operation: () => Promise<Result>
+  ): Promise<Result> {
+    const projectId = resolveProjectId(request, this.options.defaultProjectId)
+    try {
+      this.assertProjectAvailable(projectId)
+    } catch (error) {
+      return Promise.reject(error)
+    }
+    let resolveRunning!: (value: Result | PromiseLike<Result>) => void
+    let rejectRunning!: (reason?: unknown) => void
+    const running = new Promise<Result>((resolve, reject) => {
+      resolveRunning = resolve
+      rejectRunning = reject
+    })
+    const pending = this.pendingOperationsByProject.get(projectId) ?? new Set<Promise<unknown>>()
+    pending.add(running)
+    this.pendingOperationsByProject.set(projectId, pending)
+    // Register before invoking the operation so a synchronous teardown can observe the lease, while
+    // preserving the existing guarantee that callers start work before the method returns.
+    try {
+      void operation().then(resolveRunning, rejectRunning)
+    } catch (error) {
+      rejectRunning(error)
+    }
+    void running
+      .finally(() => {
+        pending.delete(running)
+        if (pending.size === 0 && this.pendingOperationsByProject.get(projectId) === pending) {
+          this.pendingOperationsByProject.delete(projectId)
+        }
+      })
+      .catch(() => undefined)
+    return running
+  }
+
   createExecutor(lane: NotebookLaneIdentity): NotebookSessionOwnedExecutor {
     const { sessionId } = notebookLaneScope(lane)
     const generation = Symbol(`notebook-executor:${notebookLaneKey(lane)}`)
@@ -207,7 +245,10 @@ class NotebookSessionLifecycleOwner {
 
   async shutdownProject(projectId: string): Promise<void> {
     this.beginProjectDeletion(projectId)
-    await Promise.allSettled(this.pendingEnsuresByProject.get(projectId) ?? [])
+    await Promise.allSettled([
+      ...(this.pendingEnsuresByProject.get(projectId) ?? []),
+      ...(this.pendingOperationsByProject.get(projectId) ?? [])
+    ])
     const lanes = Array.from(this.options.sessions.values())
       .filter((session) => session.projectId === projectId)
       .map((session) => session.lane)

--- a/src/main/notebook/session-lifecycle.ts
+++ b/src/main/notebook/session-lifecycle.ts
@@ -44,6 +44,7 @@ type NotebookSessionLifecycleOptions = {
   repository: NotebookRunRepository
   sessions: NotebookSessionRegistry<RuntimeSession>
   runtimeBindings: NotebookRuntimeBindingOwner
+  waitForRevocationDrains: () => Promise<void>
   executorFactory?: (
     sessionId: string,
     lifecycle: NotebookExecutorLifecycleCallbacks
@@ -276,6 +277,10 @@ class NotebookSessionLifecycleOwner {
     const key = notebookLaneKey(lane)
     await this.options.runtimeBindings.withSessionTeardown(key, async () => {
       await this.options.runtimeBindings.waitForWrites(key)
+      // A non-forced runtime revoke releases its binding write after scheduling kernel termination.
+      // Holding the lane teardown gate while waiting closes both sides of the race: an earlier revoke
+      // must finish before removal, while a later revoke cannot enter until the lane is already gone.
+      await this.options.waitForRevocationDrains()
       await this.options.sessions.remove(lane)
     })
     return { sessionId, status: 'shutdown' }

--- a/src/main/notebook/session-lifecycle.ts
+++ b/src/main/notebook/session-lifecycle.ts
@@ -183,6 +183,19 @@ class NotebookSessionLifecycleOwner {
     return this.shutdownLane(this.rootLane(sessionId))
   }
 
+  async shutdownProject(projectId: string): Promise<void> {
+    const lanes = Array.from(this.options.sessions.values())
+      .filter((session) => session.projectId === projectId)
+      .map((session) => session.lane)
+    const results = await Promise.allSettled(lanes.map((lane) => this.shutdownLane(lane)))
+    const failures = results.flatMap((result) =>
+      result.status === 'rejected' ? [result.reason] : []
+    )
+    if (failures.length > 0) {
+      throw new AggregateError(failures, 'Notebook Project cleanup failed: ' + projectId)
+    }
+  }
+
   private async shutdownLane(
     lane: NotebookLaneIdentity
   ): Promise<{ sessionId: string; status: 'shutdown' }> {

--- a/src/main/notebook/shell-process.test.ts
+++ b/src/main/notebook/shell-process.test.ts
@@ -207,14 +207,19 @@ describe('notebook shell process behavior', () => {
   })
 
   describe.runIf(process.platform !== 'win32')('process results', () => {
-    const execute = (command: string, timeoutMs = 5_000): ReturnType<typeof runShellCommand> =>
+    const execute = (
+      command: string,
+      timeoutMs = 5_000,
+      signal?: AbortSignal
+    ): ReturnType<typeof runShellCommand> =>
       runShellCommand({
         command,
         cwd: process.cwd(),
         handoffDir: process.cwd(),
         runtimeRoot: join(process.cwd(), '.open-science-test-runtime'),
         platform: 'linux',
-        timeoutMs
+        timeoutMs,
+        signal
       })
 
     it('preserves stdout, stderr, and a non-zero exit code as one ordinary result', async () => {
@@ -244,6 +249,18 @@ describe('notebook shell process behavior', () => {
         stdout: '',
         stderr: 'before timeout\nShell command timed out after 50ms and was killed.',
         exitCode: null
+      })
+    })
+
+    it('does not spawn work for an already-aborted shell request', async () => {
+      const controller = new AbortController()
+      controller.abort()
+
+      await expect(execute('echo should-not-run', 5_000, controller.signal)).resolves.toEqual({
+        stdout: '',
+        stderr: 'Shell command was cancelled.',
+        exitCode: null,
+        cancelled: true
       })
     })
   })

--- a/src/main/notebook/shell-process.ts
+++ b/src/main/notebook/shell-process.ts
@@ -23,6 +23,7 @@ type NotebookShellResult = {
   stderr: string
   exitCode: number | null
   truncated?: boolean
+  cancelled?: boolean
 }
 
 type NotebookShellProcessRequest = {
@@ -31,6 +32,7 @@ type NotebookShellProcessRequest = {
   handoffDir: string
   runtimeRoot: string
   timeoutMs?: number
+  signal?: AbortSignal
 }
 
 // Runtime-private port: platform invocation, encoding, env projection, and teardown stay in its adapter.
@@ -261,6 +263,16 @@ const runShellCommand = (
   }
 ): Promise<NotebookShellResult> =>
   new Promise((resolve) => {
+    if (options.signal?.aborted) {
+      resolve({
+        stdout: '',
+        stderr: 'Shell command was cancelled.',
+        exitCode: null,
+        cancelled: true
+      })
+      return
+    }
+
     const timeoutMs = options.timeoutMs ?? NOTEBOOK_SHELL_DEFAULT_TIMEOUT_MS
     const platform = options.platform ?? process.platform
     const invocation = protectManagedRuntimeWrites(
@@ -284,15 +296,46 @@ const runShellCommand = (
     let settled = false
     // Timeout owns settlement even if Windows taskkill emits exit before its promise resolves.
     let timedOut = false
+    let cancelled = false
 
     const finish = (result: NotebookShellResult): void => {
       if (settled) return
       settled = true
       clearTimeout(timeoutTimer)
+      options.signal?.removeEventListener('abort', abort)
       resolve({ ...result, stderr: normalizePowerShellStderr(result.stderr) })
     }
 
+    const terminateAndFinish = (result: NotebookShellResult): void => {
+      void terminateShellOnTimeout(child, platform).then((usedWindowsTerminator) => {
+        if (usedWindowsTerminator) {
+          // child.kill() only reaches the PowerShell parent on Windows; taskkill /T /F reaps the
+          // full tree. Settle only after it completes so callers can safely inspect or remove cwd.
+          finish(result)
+          return
+        }
+
+        // POSIX group teardown continues in the background so a wedged command tree cannot delay the
+        // result. Its SIGKILL timer intentionally survives the shell leader's exit.
+        finish(result)
+      })
+    }
+
+    const abort = (): void => {
+      if (settled || timedOut || cancelled) return
+      cancelled = true
+      clearTimeout(timeoutTimer)
+      terminateAndFinish({
+        stdout,
+        stderr:
+          stderr + `${stderr && !stderr.endsWith('\n') ? '\n' : ''}Shell command was cancelled.`,
+        exitCode: null,
+        cancelled: true
+      })
+    }
+
     const timeoutTimer = setTimeout(() => {
+      if (settled || cancelled) return
       timedOut = true
       const timeoutResult: NotebookShellResult = {
         stdout,
@@ -302,20 +345,11 @@ const runShellCommand = (
         exitCode: null,
         ...(truncated ? { truncated: true } : {})
       }
-
-      void terminateShellOnTimeout(child, platform).then((usedWindowsTerminator) => {
-        if (usedWindowsTerminator) {
-          // child.kill() only reaches the PowerShell parent on Windows; taskkill /T /F reaps the
-          // full tree. Settle only after it completes so callers can safely inspect or remove cwd.
-          finish(timeoutResult)
-          return
-        }
-
-        // POSIX group teardown continues in the background so a wedged command tree cannot delay the
-        // timeout result. Its SIGKILL timer intentionally survives the shell leader's exit.
-        finish(timeoutResult)
-      })
+      terminateAndFinish(timeoutResult)
     }, timeoutMs)
+
+    options.signal?.addEventListener('abort', abort, { once: true })
+    if (options.signal?.aborted) abort()
 
     child.stdout.setEncoding('utf8')
     child.stderr.setEncoding('utf8')
@@ -351,7 +385,7 @@ const runShellCommand = (
       )
     })
     child.once('error', (error) => {
-      if (!timedOut)
+      if (!timedOut && !cancelled)
         finish({
           stdout,
           stderr: stderr || error.message,
@@ -360,7 +394,7 @@ const runShellCommand = (
         })
     })
     child.once('exit', (code) => {
-      if (!timedOut)
+      if (!timedOut && !cancelled)
         finish({ stdout, stderr, exitCode: code, ...(truncated ? { truncated: true } : {}) })
     })
   })

--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -128,7 +128,8 @@ describe('ProjectDeletionCoordinator', () => {
   it('releases the deletion fence without starting teardown when intent creation fails', async () => {
     const projects = createProjects()
     projects.createDeletionIntent = vi.fn().mockRejectedValue(new Error('intent unavailable'))
-    const abortProjectDeletion = vi.fn()
+    const aborted = createDeferred<void>()
+    const abortProjectDeletion = vi.fn(() => aborted.promise)
     const beforeProjectDelete = vi.fn().mockResolvedValue(undefined)
     const restoreProjectDeletion = vi.fn().mockResolvedValue(undefined)
     const coordinator = new ProjectDeletionCoordinator(
@@ -145,14 +146,29 @@ describe('ProjectDeletionCoordinator', () => {
       }
     )
 
-    await expect(coordinator.deleteProject('project-1')).rejects.toThrow('intent unavailable')
+    const deletion = coordinator.deleteProject('project-1')
+    let deletionSettled = false
+    void deletion.then(
+      () => {
+        deletionSettled = true
+      },
+      () => {
+        deletionSettled = true
+      }
+    )
+
+    await vi.waitFor(() => expect(abortProjectDeletion).toHaveBeenCalledWith('project-1'))
+    await Promise.resolve()
 
     expect(restoreProjectDeletion).toHaveBeenCalledWith('project-1')
     expect(beforeProjectDelete).not.toHaveBeenCalled()
-    expect(abortProjectDeletion).toHaveBeenCalledWith('project-1')
+    expect(deletionSettled).toBe(false)
     expect(restoreProjectDeletion.mock.invocationCallOrder[0]).toBeLessThan(
       vi.mocked(projects.createDeletionIntent).mock.invocationCallOrder[0]
     )
+
+    aborted.resolve(undefined)
+    await expect(deletion).rejects.toThrow('intent unavailable')
   })
 
   it('retains the durable intent and deletion barrier when runtime quiescence fails', async () => {

--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -87,10 +87,11 @@ describe('ProjectDeletionCoordinator', () => {
     )
   })
 
-  it('awaits runtime invalidation before starting whole-project deletion', async () => {
+  it('persists retry authority before awaiting runtime invalidation', async () => {
     const projects = createProjects()
     const sessions = createSessions()
     const invalidated = createDeferred<void>()
+    const restoreProjectDeletion = vi.fn().mockResolvedValue(undefined)
     const beforeProjectDelete = vi.fn(() => invalidated.promise)
     const coordinator = new ProjectDeletionCoordinator(
       projects,
@@ -99,13 +100,20 @@ describe('ProjectDeletionCoordinator', () => {
       undefined,
       undefined,
       undefined,
-      { beforeProjectDelete }
+      { beforeProjectDelete, restoreProjectDeletion }
     )
 
     const deletion = coordinator.deleteProject('project-1')
     await vi.waitFor(() => expect(beforeProjectDelete).toHaveBeenCalledWith('project-1'))
-    expect(projects.createDeletionIntent).not.toHaveBeenCalled()
+    expect(projects.createDeletionIntent).toHaveBeenCalledWith('project-1')
+    expect(restoreProjectDeletion).toHaveBeenCalledWith('project-1')
     expect(sessions.deleteProjectSessions).not.toHaveBeenCalled()
+    expect(vi.mocked(projects.createDeletionIntent).mock.invocationCallOrder[0]).toBeLessThan(
+      restoreProjectDeletion.mock.invocationCallOrder[0]
+    )
+    expect(restoreProjectDeletion.mock.invocationCallOrder[0]).toBeLessThan(
+      beforeProjectDelete.mock.invocationCallOrder[0]
+    )
 
     invalidated.resolve(undefined)
     await deletion
@@ -114,10 +122,12 @@ describe('ProjectDeletionCoordinator', () => {
     expect(sessions.deleteProjectSessions).toHaveBeenCalledWith('project-1')
   })
 
-  it('releases the runtime admission fence when durable intent creation fails', async () => {
+  it('does not start runtime teardown when durable intent creation fails', async () => {
     const projects = createProjects()
     projects.createDeletionIntent = vi.fn().mockRejectedValue(new Error('intent unavailable'))
     const abortProjectDeletion = vi.fn()
+    const beforeProjectDelete = vi.fn().mockResolvedValue(undefined)
+    const restoreProjectDeletion = vi.fn().mockResolvedValue(undefined)
     const coordinator = new ProjectDeletionCoordinator(
       projects,
       createSessions(),
@@ -126,19 +136,23 @@ describe('ProjectDeletionCoordinator', () => {
       undefined,
       undefined,
       {
-        beforeProjectDelete: vi.fn().mockResolvedValue(undefined),
+        beforeProjectDelete,
+        restoreProjectDeletion,
         abortProjectDeletion
       }
     )
 
     await expect(coordinator.deleteProject('project-1')).rejects.toThrow('intent unavailable')
 
-    expect(abortProjectDeletion).toHaveBeenCalledWith('project-1')
+    expect(restoreProjectDeletion).not.toHaveBeenCalled()
+    expect(beforeProjectDelete).not.toHaveBeenCalled()
+    expect(abortProjectDeletion).not.toHaveBeenCalled()
   })
 
-  it('aborts partial runtime invalidation when pre-delete quiescence fails', async () => {
+  it('retains the durable intent and deletion barrier when runtime quiescence fails', async () => {
     const projects = createProjects()
     const abortProjectDeletion = vi.fn()
+    const restoreProjectDeletion = vi.fn().mockResolvedValue(undefined)
     const coordinator = new ProjectDeletionCoordinator(
       projects,
       createSessions(),
@@ -148,14 +162,17 @@ describe('ProjectDeletionCoordinator', () => {
       undefined,
       {
         beforeProjectDelete: vi.fn().mockRejectedValue(new Error('runtime cleanup failed')),
+        restoreProjectDeletion,
         abortProjectDeletion
       }
     )
 
     await expect(coordinator.deleteProject('project-1')).rejects.toThrow('runtime cleanup failed')
 
-    expect(abortProjectDeletion).toHaveBeenCalledWith('project-1')
-    expect(projects.createDeletionIntent).not.toHaveBeenCalled()
+    expect(projects.createDeletionIntent).toHaveBeenCalledWith('project-1')
+    expect(restoreProjectDeletion).toHaveBeenCalledWith('project-1')
+    expect(projects.deleteDeletionIntent).not.toHaveBeenCalled()
+    expect(abortProjectDeletion).not.toHaveBeenCalled()
   })
 
   it('retains the Project and deletion intent when grant pruning fails, then resumes idempotently', async () => {
@@ -322,7 +339,7 @@ describe('ProjectDeletionCoordinator', () => {
     }
   )
 
-  it('keeps the project row and clears intent when session and index cleanup fails', async () => {
+  it('keeps the project row, intent, and fence when session cleanup fails', async () => {
     const projects = createProjects()
     const sessions = createSessions({
       deleteProjectSessions: vi.fn().mockRejectedValue(new Error('directory busy'))
@@ -344,8 +361,8 @@ describe('ProjectDeletionCoordinator', () => {
     await expect(coordinator.deleteProject('project-1')).rejects.toThrow('directory busy')
 
     expect(projects.delete).not.toHaveBeenCalled()
-    expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-1')
-    expect(abortProjectDeletion).toHaveBeenCalledWith('project-1')
+    expect(projects.deleteDeletionIntent).not.toHaveBeenCalled()
+    expect(abortProjectDeletion).not.toHaveBeenCalled()
   })
 
   it('keeps an online intent when Session authority committed before a derived failure', async () => {
@@ -369,16 +386,26 @@ describe('ProjectDeletionCoordinator', () => {
     projects.listDeletionIntents = vi.fn().mockResolvedValue(['project-1'])
     const sessions = createSessions()
     const reviews = { deleteReviewsForProject: vi.fn().mockResolvedValue(undefined) }
+    const restoreProjectDeletion = vi.fn().mockResolvedValue(undefined)
+    const beforeProjectDelete = vi.fn().mockResolvedValue(undefined)
     const coordinator = new ProjectDeletionCoordinator(
       projects,
       sessions,
       { delete: vi.fn().mockResolvedValue(undefined) },
-      reviews
+      reviews,
+      undefined,
+      undefined,
+      { restoreProjectDeletion, beforeProjectDelete }
     )
 
     await coordinator.recoverPendingDeletions()
 
+    expect(restoreProjectDeletion).toHaveBeenCalledWith('project-1')
+    expect(beforeProjectDelete).toHaveBeenCalledWith('project-1')
     expect(sessions.deleteProjectSessions).toHaveBeenCalledWith('project-1')
+    expect(beforeProjectDelete.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(sessions.deleteProjectSessions).mock.invocationCallOrder[0]
+    )
     expect(projects.delete).toHaveBeenCalledWith('project-1')
     expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-1')
     expect(reviews.deleteReviewsForProject).toHaveBeenCalledWith('project-1')
@@ -590,25 +617,35 @@ describe('ProjectDeletionCoordinator', () => {
     expect(sessions.completeProjectSessionDeletion).not.toHaveBeenCalled()
   })
 
-  it('clears a stale pre-commit recovery intent and continues with later Projects', async () => {
+  it('retains a failed recovery intent before continuing on the next retry', async () => {
     const projects = createProjects()
     projects.listDeletionIntents = vi.fn().mockResolvedValue(['project-1', 'project-2'])
+    let projectOneAttempts = 0
     const sessions = createSessions({
       deleteProjectSessions: vi.fn(async (projectId: string) => {
-        if (projectId === 'project-1') throw new Error('transient session cleanup failure')
+        if (projectId === 'project-1' && projectOneAttempts++ === 0) {
+          throw new Error('transient session cleanup failure')
+        }
         return { status: 'completed' as const }
-      }),
-      getProjectSessionDeletionState: vi.fn().mockResolvedValue('live')
+      })
     })
     const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
       delete: vi.fn().mockResolvedValue(undefined)
     })
 
+    await expect(coordinator.recoverPendingDeletions()).rejects.toThrow(
+      'transient session cleanup failure'
+    )
+
+    expect(sessions.deleteProjectSessions).toHaveBeenCalledOnce()
+    expect(projects.deleteDeletionIntent).not.toHaveBeenCalled()
+    expect(projects.delete).not.toHaveBeenCalledWith('project-1')
+    expect(projects.delete).not.toHaveBeenCalledWith('project-2')
+
     await expect(coordinator.recoverPendingDeletions()).resolves.toBeUndefined()
 
-    expect(sessions.deleteProjectSessions).toHaveBeenCalledTimes(2)
+    expect(sessions.deleteProjectSessions).toHaveBeenCalledTimes(3)
     expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-1')
-    expect(projects.delete).not.toHaveBeenCalledWith('project-1')
     expect(projects.delete).toHaveBeenCalledWith('project-2')
     expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-2')
   })

--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -90,7 +90,7 @@ describe('ProjectDeletionCoordinator', () => {
     )
   })
 
-  it('persists retry authority before awaiting runtime invalidation', async () => {
+  it('installs the deletion fence before committing retry authority and starting teardown', async () => {
     const projects = createProjects()
     const sessions = createSessions()
     const invalidated = createDeferred<void>()
@@ -111,10 +111,10 @@ describe('ProjectDeletionCoordinator', () => {
     expect(projects.createDeletionIntent).toHaveBeenCalledWith('project-1')
     expect(restoreProjectDeletion).toHaveBeenCalledWith('project-1')
     expect(sessions.deleteProjectSessions).not.toHaveBeenCalled()
-    expect(vi.mocked(projects.createDeletionIntent).mock.invocationCallOrder[0]).toBeLessThan(
-      restoreProjectDeletion.mock.invocationCallOrder[0]
-    )
     expect(restoreProjectDeletion.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(projects.createDeletionIntent).mock.invocationCallOrder[0]
+    )
+    expect(vi.mocked(projects.createDeletionIntent).mock.invocationCallOrder[0]).toBeLessThan(
       beforeProjectDelete.mock.invocationCallOrder[0]
     )
 
@@ -125,7 +125,7 @@ describe('ProjectDeletionCoordinator', () => {
     expect(sessions.deleteProjectSessions).toHaveBeenCalledWith('project-1')
   })
 
-  it('does not start runtime teardown when durable intent creation fails', async () => {
+  it('releases the deletion fence without starting teardown when intent creation fails', async () => {
     const projects = createProjects()
     projects.createDeletionIntent = vi.fn().mockRejectedValue(new Error('intent unavailable'))
     const abortProjectDeletion = vi.fn()
@@ -147,9 +147,12 @@ describe('ProjectDeletionCoordinator', () => {
 
     await expect(coordinator.deleteProject('project-1')).rejects.toThrow('intent unavailable')
 
-    expect(restoreProjectDeletion).not.toHaveBeenCalled()
+    expect(restoreProjectDeletion).toHaveBeenCalledWith('project-1')
     expect(beforeProjectDelete).not.toHaveBeenCalled()
-    expect(abortProjectDeletion).not.toHaveBeenCalled()
+    expect(abortProjectDeletion).toHaveBeenCalledWith('project-1')
+    expect(restoreProjectDeletion.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(projects.createDeletionIntent).mock.invocationCallOrder[0]
+    )
   })
 
   it('retains the durable intent and deletion barrier when runtime quiescence fails', async () => {

--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -44,13 +44,20 @@ describe('ProjectDeletionCoordinator', () => {
       prune: vi.fn().mockResolvedValue([]),
       finalizeOwnerDeletion: vi.fn().mockResolvedValue(undefined)
     }
+    const completeProjectDeletion = vi.fn()
+    const abortProjectDeletion = vi.fn()
     const coordinator = new ProjectDeletionCoordinator(
       projects,
       sessions,
       preview,
       reviews,
       provenance,
-      permissionGrants
+      permissionGrants,
+      {
+        beforeProjectDelete: vi.fn().mockResolvedValue(undefined),
+        completeProjectDeletion,
+        abortProjectDeletion
+      }
     )
 
     await coordinator.deleteProject('project-1')
@@ -70,6 +77,8 @@ describe('ProjectDeletionCoordinator', () => {
       kind: 'project',
       projectId: 'project-1'
     })
+    expect(completeProjectDeletion).toHaveBeenCalledWith('project-1')
+    expect(abortProjectDeletion).not.toHaveBeenCalled()
     expect(vi.mocked(permissionGrants.prune).mock.invocationCallOrder[0]).toBeLessThan(
       vi.mocked(projects.delete).mock.invocationCallOrder[0]
     )
@@ -103,6 +112,28 @@ describe('ProjectDeletionCoordinator', () => {
 
     expect(projects.createDeletionIntent).toHaveBeenCalledWith('project-1')
     expect(sessions.deleteProjectSessions).toHaveBeenCalledWith('project-1')
+  })
+
+  it('releases the runtime admission fence when durable intent creation fails', async () => {
+    const projects = createProjects()
+    projects.createDeletionIntent = vi.fn().mockRejectedValue(new Error('intent unavailable'))
+    const abortProjectDeletion = vi.fn()
+    const coordinator = new ProjectDeletionCoordinator(
+      projects,
+      createSessions(),
+      { delete: vi.fn().mockResolvedValue(undefined) },
+      undefined,
+      undefined,
+      undefined,
+      {
+        beforeProjectDelete: vi.fn().mockResolvedValue(undefined),
+        abortProjectDeletion
+      }
+    )
+
+    await expect(coordinator.deleteProject('project-1')).rejects.toThrow('intent unavailable')
+
+    expect(abortProjectDeletion).toHaveBeenCalledWith('project-1')
   })
 
   it('retains the Project and deletion intent when grant pruning fails, then resumes idempotently', async () => {
@@ -228,12 +259,20 @@ describe('ProjectDeletionCoordinator', () => {
           })
       }
       const provenance = { deleteProjectProvenance: vi.fn().mockResolvedValue(undefined) }
+      const completeProjectDeletion = vi.fn()
+      const abortProjectDeletion = vi.fn()
       const coordinator = new ProjectDeletionCoordinator(
         projects,
         sessions,
         preview,
         reviews,
-        provenance
+        provenance,
+        undefined,
+        {
+          beforeProjectDelete: vi.fn().mockResolvedValue(undefined),
+          completeProjectDeletion,
+          abortProjectDeletion
+        }
       )
 
       await expect(coordinator.deleteProject('project-1')).rejects.toThrow(
@@ -246,6 +285,8 @@ describe('ProjectDeletionCoordinator', () => {
       expect(reviews.deleteReviewsForProject).toHaveBeenCalledOnce()
       expect(provenance.deleteProjectProvenance).not.toHaveBeenCalled()
       expect(sessions.completeProjectSessionDeletion).not.toHaveBeenCalled()
+      expect(completeProjectDeletion).not.toHaveBeenCalled()
+      expect(abortProjectDeletion).not.toHaveBeenCalled()
 
       await expect(coordinator.recoverPendingDeletions()).resolves.toBeUndefined()
 
@@ -254,6 +295,8 @@ describe('ProjectDeletionCoordinator', () => {
       expect(provenance.deleteProjectProvenance).toHaveBeenCalledWith('project-1')
       expect(sessions.completeProjectSessionDeletion).toHaveBeenCalledWith('project-1')
       expect(intentExists).toBe(false)
+      expect(completeProjectDeletion).toHaveBeenCalledWith('project-1')
+      expect(abortProjectDeletion).not.toHaveBeenCalled()
     }
   )
 
@@ -262,14 +305,25 @@ describe('ProjectDeletionCoordinator', () => {
     const sessions = createSessions({
       deleteProjectSessions: vi.fn().mockRejectedValue(new Error('directory busy'))
     })
-    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
-      delete: vi.fn().mockResolvedValue(undefined)
-    })
+    const abortProjectDeletion = vi.fn()
+    const coordinator = new ProjectDeletionCoordinator(
+      projects,
+      sessions,
+      { delete: vi.fn().mockResolvedValue(undefined) },
+      undefined,
+      undefined,
+      undefined,
+      {
+        beforeProjectDelete: vi.fn().mockResolvedValue(undefined),
+        abortProjectDeletion
+      }
+    )
 
     await expect(coordinator.deleteProject('project-1')).rejects.toThrow('directory busy')
 
     expect(projects.delete).not.toHaveBeenCalled()
     expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-1')
+    expect(abortProjectDeletion).toHaveBeenCalledWith('project-1')
   })
 
   it('keeps an online intent when Session authority committed before a derived failure', async () => {

--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -44,6 +44,7 @@ describe('ProjectDeletionCoordinator', () => {
       prune: vi.fn().mockResolvedValue([]),
       finalizeOwnerDeletion: vi.fn().mockResolvedValue(undefined)
     }
+    const finalizeProjectDeletion = vi.fn().mockResolvedValue(undefined)
     const completeProjectDeletion = vi.fn()
     const abortProjectDeletion = vi.fn()
     const coordinator = new ProjectDeletionCoordinator(
@@ -55,6 +56,7 @@ describe('ProjectDeletionCoordinator', () => {
       permissionGrants,
       {
         beforeProjectDelete: vi.fn().mockResolvedValue(undefined),
+        finalizeProjectDeletion,
         completeProjectDeletion,
         abortProjectDeletion
       }
@@ -77,6 +79,7 @@ describe('ProjectDeletionCoordinator', () => {
       kind: 'project',
       projectId: 'project-1'
     })
+    expect(finalizeProjectDeletion).toHaveBeenCalledWith('project-1')
     expect(completeProjectDeletion).toHaveBeenCalledWith('project-1')
     expect(abortProjectDeletion).not.toHaveBeenCalled()
     expect(vi.mocked(permissionGrants.prune).mock.invocationCallOrder[0]).toBeLessThan(
@@ -714,6 +717,58 @@ describe('ProjectDeletionCoordinator', () => {
     expect(projects.deleteDeletionIntent).not.toHaveBeenCalled()
   })
 
+  it('retains the intent, tombstone, and fences when final runtime cleanup fails', async () => {
+    let projectExists = true
+    let intentExists = false
+    const projects = createProjects()
+    projects.get = vi.fn(async () => (projectExists ? project : null))
+    projects.delete = vi.fn(async () => {
+      projectExists = false
+    })
+    projects.createDeletionIntent = vi.fn(async () => {
+      intentExists = true
+    })
+    projects.deleteDeletionIntent = vi.fn(async () => {
+      intentExists = false
+    })
+    projects.listDeletionIntents = vi.fn(async () => (intentExists ? ['project-1'] : []))
+    const sessions = createSessions()
+    const cleanupFailure = new Error('side chat profile busy')
+    const finalizeProjectDeletion = vi
+      .fn()
+      .mockRejectedValueOnce(cleanupFailure)
+      .mockResolvedValueOnce(undefined)
+    const completeProjectDeletion = vi.fn()
+    const coordinator = new ProjectDeletionCoordinator(
+      projects,
+      sessions,
+      { delete: vi.fn().mockResolvedValue(undefined) },
+      undefined,
+      undefined,
+      undefined,
+      {
+        beforeProjectDelete: vi.fn().mockResolvedValue(undefined),
+        finalizeProjectDeletion,
+        completeProjectDeletion
+      }
+    )
+
+    await expect(coordinator.deleteProject('project-1')).rejects.toBe(cleanupFailure)
+
+    expect(projectExists).toBe(false)
+    expect(intentExists).toBe(true)
+    expect(sessions.completeProjectSessionDeletion).not.toHaveBeenCalled()
+    expect(projects.deleteDeletionIntent).not.toHaveBeenCalled()
+    expect(completeProjectDeletion).not.toHaveBeenCalled()
+
+    await expect(coordinator.recoverPendingDeletions()).resolves.toBeUndefined()
+
+    expect(finalizeProjectDeletion).toHaveBeenCalledTimes(2)
+    expect(sessions.completeProjectSessionDeletion).toHaveBeenCalledWith('project-1')
+    expect(intentExists).toBe(false)
+    expect(completeProjectDeletion).toHaveBeenCalledWith('project-1')
+  })
+
   it('keeps the recovery intent until derived project cleanup has finished', async () => {
     const order: string[] = []
     const projects = createProjects()
@@ -745,12 +800,31 @@ describe('ProjectDeletionCoordinator', () => {
         deleteProjectProvenance: vi.fn(async () => {
           order.push('provenance')
         })
+      },
+      undefined,
+      {
+        beforeProjectDelete: vi.fn().mockResolvedValue(undefined),
+        finalizeProjectDeletion: vi.fn(async () => {
+          order.push('finalize')
+        }),
+        completeProjectDeletion: vi.fn(() => {
+          order.push('complete')
+        })
       }
     )
 
     await coordinator.deleteProject('project-1')
 
-    expect(order).toEqual(['project', 'preview', 'reviews', 'provenance', 'tombstone', 'intent'])
+    expect(order).toEqual([
+      'project',
+      'preview',
+      'reviews',
+      'provenance',
+      'finalize',
+      'tombstone',
+      'intent',
+      'complete'
+    ])
   })
 
   it('reuses a successful recovery gate for later operations', async () => {

--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -178,6 +178,85 @@ describe('ProjectDeletionCoordinator', () => {
     expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-1')
   })
 
+  it.each([
+    {
+      name: 'Preview',
+      previewFailures: [new Error('preview unavailable'), undefined],
+      reviewFailures: [undefined, undefined]
+    },
+    {
+      name: 'Review',
+      previewFailures: [undefined, undefined],
+      reviewFailures: [new Error('review unavailable'), undefined]
+    }
+  ])(
+    'retains the deletion intent when $name cleanup fails after the Project hard delete',
+    async ({ previewFailures, reviewFailures }) => {
+      let projectExists = true
+      let intentExists = false
+      const projects = createProjects()
+      projects.get = vi.fn(async () => (projectExists ? project : null))
+      projects.delete = vi.fn(async () => {
+        projectExists = false
+      })
+      projects.createDeletionIntent = vi.fn(async () => {
+        intentExists = true
+      })
+      projects.deleteDeletionIntent = vi.fn(async () => {
+        intentExists = false
+      })
+      projects.listDeletionIntents = vi.fn(async () => (intentExists ? ['project-1'] : []))
+      const sessions = createSessions()
+      const preview = {
+        delete: vi
+          .fn()
+          .mockImplementationOnce(async () => {
+            if (previewFailures[0]) throw previewFailures[0]
+          })
+          .mockImplementationOnce(async () => {
+            if (previewFailures[1]) throw previewFailures[1]
+          })
+      }
+      const reviews = {
+        deleteReviewsForProject: vi
+          .fn()
+          .mockImplementationOnce(async () => {
+            if (reviewFailures[0]) throw reviewFailures[0]
+          })
+          .mockImplementationOnce(async () => {
+            if (reviewFailures[1]) throw reviewFailures[1]
+          })
+      }
+      const provenance = { deleteProjectProvenance: vi.fn().mockResolvedValue(undefined) }
+      const coordinator = new ProjectDeletionCoordinator(
+        projects,
+        sessions,
+        preview,
+        reviews,
+        provenance
+      )
+
+      await expect(coordinator.deleteProject('project-1')).rejects.toThrow(
+        'Project derived cleanup failed: project-1'
+      )
+
+      expect(projectExists).toBe(false)
+      expect(intentExists).toBe(true)
+      expect(preview.delete).toHaveBeenCalledOnce()
+      expect(reviews.deleteReviewsForProject).toHaveBeenCalledOnce()
+      expect(provenance.deleteProjectProvenance).not.toHaveBeenCalled()
+      expect(sessions.completeProjectSessionDeletion).not.toHaveBeenCalled()
+
+      await expect(coordinator.recoverPendingDeletions()).resolves.toBeUndefined()
+
+      expect(preview.delete).toHaveBeenCalledTimes(2)
+      expect(reviews.deleteReviewsForProject).toHaveBeenCalledTimes(2)
+      expect(provenance.deleteProjectProvenance).toHaveBeenCalledWith('project-1')
+      expect(sessions.completeProjectSessionDeletion).toHaveBeenCalledWith('project-1')
+      expect(intentExists).toBe(false)
+    }
+  )
+
   it('keeps the project row and clears intent when session and index cleanup fails', async () => {
     const projects = createProjects()
     const sessions = createSessions({

--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -136,6 +136,28 @@ describe('ProjectDeletionCoordinator', () => {
     expect(abortProjectDeletion).toHaveBeenCalledWith('project-1')
   })
 
+  it('aborts partial runtime invalidation when pre-delete quiescence fails', async () => {
+    const projects = createProjects()
+    const abortProjectDeletion = vi.fn()
+    const coordinator = new ProjectDeletionCoordinator(
+      projects,
+      createSessions(),
+      { delete: vi.fn().mockResolvedValue(undefined) },
+      undefined,
+      undefined,
+      undefined,
+      {
+        beforeProjectDelete: vi.fn().mockRejectedValue(new Error('runtime cleanup failed')),
+        abortProjectDeletion
+      }
+    )
+
+    await expect(coordinator.deleteProject('project-1')).rejects.toThrow('runtime cleanup failed')
+
+    expect(abortProjectDeletion).toHaveBeenCalledWith('project-1')
+    expect(projects.createDeletionIntent).not.toHaveBeenCalled()
+  })
+
   it('retains the Project and deletion intent when grant pruning fails, then resumes idempotently', async () => {
     let projectExists = true
     let intentExists = false

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -43,6 +43,8 @@ type ProjectPermissionGrantDeletion = {
 type ProjectDeletionLifecycle = {
   beforeProjectDelete(projectId: string): Promise<void>
   restoreProjectDeletion?(projectId: string): Promise<void>
+  completeProjectDeletion?(projectId: string): void
+  abortProjectDeletion?(projectId: string): void
 }
 
 type ProjectDeletionRecoveryLoopOptions = {
@@ -197,22 +199,30 @@ class ProjectDeletionCoordinator {
     if (!project) return
 
     await this.lifecycle?.beforeProjectDelete(projectId)
-    await this.projects.createDeletionIntent(projectId)
+    let retainDeletionBarrier = false
     try {
-      await this.sessions.deleteProjectSessions(projectId)
-    } catch (error) {
+      await this.projects.createDeletionIntent(projectId)
+      retainDeletionBarrier = true
       try {
-        const state = await this.sessions.getProjectSessionDeletionState(projectId)
-        if (state === 'live' || state === 'absent') {
-          await this.projects.deleteDeletionIntent(projectId)
+        await this.sessions.deleteProjectSessions(projectId)
+      } catch (error) {
+        try {
+          const state = await this.sessions.getProjectSessionDeletionState(projectId)
+          if (state === 'live' || state === 'absent') {
+            await this.projects.deleteDeletionIntent(projectId)
+            retainDeletionBarrier = false
+          }
+        } catch {
+          // Unknown durable Session state is fail-closed; retain the intent and admission fence.
         }
-      } catch {
-        // Unknown durable Session state is fail-closed; retain the intent for recovery.
+        throw error
       }
+
+      await this.finishDeletion(projectId)
+    } catch (error) {
+      if (!retainDeletionBarrier) this.lifecycle?.abortProjectDeletion?.(projectId)
       throw error
     }
-
-    await this.finishDeletion(projectId)
   }
 
   // Replays intents serially so crash recovery follows the same ordering as an online deletion.
@@ -248,12 +258,14 @@ class ProjectDeletionCoordinator {
         }
         if (sessionState === 'live' && (await this.projects.get(projectId))) {
           await this.projects.deleteDeletionIntent(projectId)
+          this.lifecycle?.abortProjectDeletion?.(projectId)
           continue
         }
         throw error
       }
       if (result.status === 'orphan-retained') {
         await this.projects.deleteDeletionIntent(projectId)
+        this.lifecycle?.abortProjectDeletion?.(projectId)
         retainedProjectIds.add(projectId)
         continue
       }
@@ -277,6 +289,7 @@ class ProjectDeletionCoordinator {
       })
       if (result.status === 'orphan-retained') {
         await this.projects.deleteDeletionIntent(projectId)
+        this.lifecycle?.abortProjectDeletion?.(projectId)
         continue
       }
       await this.finishDeletion(projectId)
@@ -326,6 +339,7 @@ class ProjectDeletionCoordinator {
 
     // Keep the intent until all derived and tombstone cleanup has completed.
     await this.projects.deleteDeletionIntent(projectId)
+    this.lifecycle?.completeProjectDeletion?.(projectId)
   }
 }
 

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -198,7 +198,12 @@ class ProjectDeletionCoordinator {
     const project = await this.projects.get(projectId)
     if (!project) return
 
-    await this.lifecycle?.beforeProjectDelete(projectId)
+    try {
+      await this.lifecycle?.beforeProjectDelete(projectId)
+    } catch (error) {
+      this.lifecycle?.abortProjectDeletion?.(projectId)
+      throw error
+    }
     let retainDeletionBarrier = false
     try {
       await this.projects.createDeletionIntent(projectId)

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -192,42 +192,22 @@ class ProjectDeletionCoordinator {
     }
   }
 
-  // The intent is durable before session/index deletion starts. If that reversible phase fails, the
-  // intent is removed because the project record is still authoritative and visible.
+  // Persist retry authority before any destructive runtime cleanup. Once the intent exists, every
+  // failure remains fail-closed: the Project may still be visible, but admission stays fenced and
+  // recovery replays quiescence before continuing durable deletion.
   private async runDeletion(projectId: string): Promise<void> {
     const project = await this.projects.get(projectId)
     if (!project) return
 
-    try {
-      await this.lifecycle?.beforeProjectDelete(projectId)
-    } catch (error) {
-      this.lifecycle?.abortProjectDeletion?.(projectId)
-      throw error
-    }
-    let retainDeletionBarrier = false
-    try {
-      await this.projects.createDeletionIntent(projectId)
-      retainDeletionBarrier = true
-      try {
-        await this.sessions.deleteProjectSessions(projectId)
-      } catch (error) {
-        try {
-          const state = await this.sessions.getProjectSessionDeletionState(projectId)
-          if (state === 'live' || state === 'absent') {
-            await this.projects.deleteDeletionIntent(projectId)
-            retainDeletionBarrier = false
-          }
-        } catch {
-          // Unknown durable Session state is fail-closed; retain the intent and admission fence.
-        }
-        throw error
-      }
+    await this.projects.createDeletionIntent(projectId)
+    await this.prepareDeletion(projectId)
+    await this.sessions.deleteProjectSessions(projectId)
+    await this.finishDeletion(projectId)
+  }
 
-      await this.finishDeletion(projectId)
-    } catch (error) {
-      if (!retainDeletionBarrier) this.lifecycle?.abortProjectDeletion?.(projectId)
-      throw error
-    }
+  private async prepareDeletion(projectId: string): Promise<void> {
+    await this.lifecycle?.restoreProjectDeletion?.(projectId)
+    await this.lifecycle?.beforeProjectDelete(projectId)
   }
 
   // Replays intents serially so crash recovery follows the same ordering as an online deletion.
@@ -235,39 +215,19 @@ class ProjectDeletionCoordinator {
     const projectIds = await this.projects.listDeletionIntents()
     const retainedProjectIds = new Set<string>()
     for (const projectId of projectIds) {
-      let result: ProjectSessionDeletionResult
-      try {
-        // An absent Project plus an unmarked tombstone identifies a cross-version orphan adoption.
-        // Re-derive its conservative policy from durable state so a crash immediately after intent
-        // creation cannot turn the next retry into authority-creating normal deletion.
-        const requireExistingUploadAuthority =
-          !(await this.projects.get(projectId)) &&
-          (await this.sessions.getProjectSessionDeletionState(projectId)) === 'legacy-committed'
-        if (requireExistingUploadAuthority) {
-          result = await this.sessions.deleteProjectSessions(projectId, {
+      await this.prepareDeletion(projectId)
+      // An absent Project plus an unmarked tombstone identifies a cross-version orphan adoption.
+      // Re-derive its conservative policy from durable state so a crash immediately after intent
+      // creation cannot turn the next retry into authority-creating normal deletion. Any rejection
+      // naturally retains the intent because runtime cleanup may already have removed resources.
+      const requireExistingUploadAuthority =
+        !(await this.projects.get(projectId)) &&
+        (await this.sessions.getProjectSessionDeletionState(projectId)) === 'legacy-committed'
+      const result: ProjectSessionDeletionResult = requireExistingUploadAuthority
+        ? await this.sessions.deleteProjectSessions(projectId, {
             requireExistingUploadAuthority: true
           })
-        } else {
-          result = await this.sessions.deleteProjectSessions(projectId)
-        }
-      } catch (error) {
-        // A visible Project row is insufficient evidence of a pre-commit failure: a crash may occur
-        // after the atomic Session rename but before deleting that row. Clear the intent only when
-        // the durable tombstone positively proves the Session phase never committed. Unknown marker
-        // state and committed state both retain the intent and retry the irreversible tail.
-        let sessionState: ProjectSessionDeletionState
-        try {
-          sessionState = await this.sessions.getProjectSessionDeletionState(projectId)
-        } catch {
-          throw error
-        }
-        if (sessionState === 'live' && (await this.projects.get(projectId))) {
-          await this.projects.deleteDeletionIntent(projectId)
-          this.lifecycle?.abortProjectDeletion?.(projectId)
-          continue
-        }
-        throw error
-      }
+        : await this.sessions.deleteProjectSessions(projectId)
       if (result.status === 'orphan-retained') {
         await this.projects.deleteDeletionIntent(projectId)
         this.lifecycle?.abortProjectDeletion?.(projectId)
@@ -289,6 +249,7 @@ class ProjectDeletionCoordinator {
     for (const projectId of projectIds) {
       if (retainedProjectIds.has(projectId)) continue
       await this.projects.createDeletionIntent(projectId)
+      await this.prepareDeletion(projectId)
       const result = await this.sessions.deleteProjectSessions(projectId, {
         requireExistingUploadAuthority: true
       })

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -45,7 +45,7 @@ type ProjectDeletionLifecycle = {
   restoreProjectDeletion?(projectId: string): Promise<void>
   finalizeProjectDeletion?(projectId: string): Promise<void>
   completeProjectDeletion?(projectId: string): void
-  abortProjectDeletion?(projectId: string): void
+  abortProjectDeletion?(projectId: string): Promise<void> | void
 }
 
 type ProjectDeletionRecoveryLoopOptions = {
@@ -212,7 +212,7 @@ class ProjectDeletionCoordinator {
       await this.lifecycle?.restoreProjectDeletion?.(projectId)
       await this.projects.createDeletionIntent(projectId)
     } catch (error) {
-      this.lifecycle?.abortProjectDeletion?.(projectId)
+      await this.lifecycle?.abortProjectDeletion?.(projectId)
       throw error
     }
   }
@@ -242,7 +242,7 @@ class ProjectDeletionCoordinator {
         : await this.sessions.deleteProjectSessions(projectId)
       if (result.status === 'orphan-retained') {
         await this.projects.deleteDeletionIntent(projectId)
-        this.lifecycle?.abortProjectDeletion?.(projectId)
+        await this.lifecycle?.abortProjectDeletion?.(projectId)
         retainedProjectIds.add(projectId)
         continue
       }
@@ -267,7 +267,7 @@ class ProjectDeletionCoordinator {
       })
       if (result.status === 'orphan-retained') {
         await this.projects.deleteDeletionIntent(projectId)
-        this.lifecycle?.abortProjectDeletion?.(projectId)
+        await this.lifecycle?.abortProjectDeletion?.(projectId)
         continue
       }
       await this.finishDeletion(projectId)

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -43,6 +43,7 @@ type ProjectPermissionGrantDeletion = {
 type ProjectDeletionLifecycle = {
   beforeProjectDelete(projectId: string): Promise<void>
   restoreProjectDeletion?(projectId: string): Promise<void>
+  finalizeProjectDeletion?(projectId: string): Promise<void>
   completeProjectDeletion?(projectId: string): void
   abortProjectDeletion?(projectId: string): void
 }
@@ -298,6 +299,11 @@ class ProjectDeletionCoordinator {
     // from the durable intent after a crash, so both SQLite rows and immutable bytes are eventually
     // removed even if the Project row is already gone.
     await this.provenance?.deleteProjectProvenance(projectId)
+
+    // Fallible runtime/profile cleanup must finish while the existing intent and Session tombstone
+    // still provide retry authority. The completion callback below is reserved for releasing the
+    // in-memory fences only after both durable markers have been removed.
+    await this.lifecycle?.finalizeProjectDeletion?.(projectId)
 
     // The marked Session tombstone is the durable phase boundary. Remove it only after every Project
     // tail has completed, and keep the intent if physical cleanup fails so recovery retries it.

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -193,17 +193,28 @@ class ProjectDeletionCoordinator {
     }
   }
 
-  // Persist retry authority before any destructive runtime cleanup. Once the intent exists, every
-  // failure remains fail-closed: the Project may still be visible, but admission stays fenced and
-  // recovery replays quiescence before continuing durable deletion.
+  // Install the non-destructive admission fence before committing deletion intent, then persist
+  // retry authority before any destructive runtime cleanup. Once the intent exists, every failure
+  // remains fail-closed: the Project may still be visible, but recovery retains the fence and replays
+  // quiescence before continuing durable deletion.
   private async runDeletion(projectId: string): Promise<void> {
     const project = await this.projects.get(projectId)
     if (!project) return
 
-    await this.projects.createDeletionIntent(projectId)
-    await this.prepareDeletion(projectId)
+    await this.createDeletionIntentWithFence(projectId)
+    await this.lifecycle?.beforeProjectDelete(projectId)
     await this.sessions.deleteProjectSessions(projectId)
     await this.finishDeletion(projectId)
+  }
+
+  private async createDeletionIntentWithFence(projectId: string): Promise<void> {
+    try {
+      await this.lifecycle?.restoreProjectDeletion?.(projectId)
+      await this.projects.createDeletionIntent(projectId)
+    } catch (error) {
+      this.lifecycle?.abortProjectDeletion?.(projectId)
+      throw error
+    }
   }
 
   private async prepareDeletion(projectId: string): Promise<void> {
@@ -249,8 +260,8 @@ class ProjectDeletionCoordinator {
     const projectIds = await this.sessions.listLegacyProjectSessionTombstones()
     for (const projectId of projectIds) {
       if (retainedProjectIds.has(projectId)) continue
-      await this.projects.createDeletionIntent(projectId)
-      await this.prepareDeletion(projectId)
+      await this.createDeletionIntentWithFence(projectId)
+      await this.lifecycle?.beforeProjectDelete(projectId)
       const result = await this.sessions.deleteProjectSessions(projectId, {
         requireExistingUploadAuthority: true
       })

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -298,12 +298,22 @@ class ProjectDeletionCoordinator {
       ?.finalizeOwnerDeletion?.({ kind: 'project', projectId })
       .catch(() => undefined)
 
-    // Preview state is derived UI state; a cleanup failure must not resurrect deleted chat data.
-    await this.preview.delete(projectId).catch(() => undefined)
-
-    // Reviews are derived project data. Keeping this after the project/session commit makes normal
-    // deletion and crash recovery remove the same orphan rows without risking review loss on failure.
-    await this.reviews?.deleteReviewsForProject(projectId).catch(() => undefined)
+    // Preview and Review rows have no Project FK cascade. Attempt both independent tails, then retain
+    // the durable intent on any failure so startup or an explicit retry can finish their cleanup.
+    const reviews = this.reviews
+    const derivedCleanup = [
+      () => this.preview.delete(projectId),
+      ...(reviews ? [() => reviews.deleteReviewsForProject(projectId)] : [])
+    ]
+    const derivedResults = await Promise.allSettled(
+      derivedCleanup.map((cleanup) => Promise.resolve().then(cleanup))
+    )
+    const derivedFailures = derivedResults.flatMap((result) =>
+      result.status === 'rejected' ? [result.reason] : []
+    )
+    if (derivedFailures.length > 0) {
+      throw new AggregateError(derivedFailures, 'Project derived cleanup failed: ' + projectId)
+    }
 
     // Session deletion retains provenance, but Project deletion is terminal. This tail is replayed
     // from the durable intent after a crash, so both SQLite rows and immutable bytes are eventually

--- a/src/main/projects/project-runtime-quiescence-owner.test.ts
+++ b/src/main/projects/project-runtime-quiescence-owner.test.ts
@@ -15,12 +15,14 @@ describe('ProjectRuntimeQuiescenceOwner', () => {
       deleteProject: vi.fn().mockResolvedValue(undefined)
     }
     const notebook = { shutdownProject: vi.fn().mockResolvedValue(undefined) }
+    const reviewer = { quiesceProject: vi.fn().mockResolvedValue(undefined) }
     const sideChat = { invalidateProject: vi.fn().mockResolvedValue(undefined) }
     const compute = { reconcileProject: vi.fn().mockResolvedValue(undefined) }
     const owner = new ProjectRuntimeQuiescenceOwner({
       acp,
       delegation,
       notebook,
+      reviewer,
       sideChat,
       compute
     })
@@ -31,6 +33,7 @@ describe('ProjectRuntimeQuiescenceOwner', () => {
     expect(acp.deleteSession).not.toHaveBeenCalledWith('acp-other')
     expect(delegation.deleteProject).toHaveBeenCalledWith('project-1')
     expect(notebook.shutdownProject).toHaveBeenCalledWith('project-1')
+    expect(reviewer.quiesceProject).toHaveBeenCalledWith('project-1')
     expect(sideChat.invalidateProject).toHaveBeenCalledWith('project-1')
     expect(compute.reconcileProject).toHaveBeenCalledWith('project-1')
   })
@@ -45,12 +48,14 @@ describe('ProjectRuntimeQuiescenceOwner', () => {
       deleteProject: vi.fn().mockResolvedValue(undefined)
     }
     const notebook = { shutdownProject: vi.fn().mockResolvedValue(undefined) }
+    const reviewer = { quiesceProject: vi.fn().mockResolvedValue(undefined) }
     const sideChat = { invalidateProject: vi.fn().mockResolvedValue(undefined) }
     const compute = { reconcileProject: vi.fn().mockResolvedValue(undefined) }
     const owner = new ProjectRuntimeQuiescenceOwner({
       acp,
       delegation,
       notebook,
+      reviewer,
       sideChat,
       compute
     })
@@ -61,6 +66,7 @@ describe('ProjectRuntimeQuiescenceOwner', () => {
 
     expect(delegation.deleteProject).toHaveBeenCalledWith('project-1')
     expect(notebook.shutdownProject).toHaveBeenCalledWith('project-1')
+    expect(reviewer.quiesceProject).toHaveBeenCalledWith('project-1')
     expect(sideChat.invalidateProject).toHaveBeenCalledWith('project-1')
     expect(compute.reconcileProject).toHaveBeenCalledWith('project-1')
   })
@@ -84,6 +90,7 @@ describe('ProjectRuntimeQuiescenceOwner', () => {
       },
       delegation,
       notebook: { shutdownProject: vi.fn().mockResolvedValue(undefined) },
+      reviewer: { quiesceProject: vi.fn().mockResolvedValue(undefined) },
       sideChat: { invalidateProject: vi.fn().mockResolvedValue(undefined) },
       compute: { reconcileProject: vi.fn().mockResolvedValue(undefined) }
     })
@@ -114,6 +121,7 @@ describe('ProjectRuntimeQuiescenceOwner', () => {
       },
       delegation,
       notebook,
+      reviewer: { quiesceProject: vi.fn().mockResolvedValue(undefined) },
       sideChat: { invalidateProject: vi.fn().mockResolvedValue(undefined) },
       compute: { reconcileProject: vi.fn().mockResolvedValue(undefined) }
     })
@@ -127,5 +135,35 @@ describe('ProjectRuntimeQuiescenceOwner', () => {
     await quiescing
 
     expect(delegation.deleteProject).toHaveBeenCalledWith('project-1')
+  })
+
+  it('drains Reviewer work before enumerating and deleting ACP sessions', async () => {
+    let releaseReviewer!: () => void
+    const reviewerDrained = new Promise<void>((resolve) => {
+      releaseReviewer = resolve
+    })
+    const acp = {
+      listSessionIds: vi.fn(() => []),
+      liveSessionProjectId: vi.fn(),
+      deleteSession: vi.fn().mockResolvedValue(undefined)
+    }
+    const owner = new ProjectRuntimeQuiescenceOwner({
+      acp,
+      delegation: { deleteProject: vi.fn().mockResolvedValue(undefined) },
+      notebook: { shutdownProject: vi.fn().mockResolvedValue(undefined) },
+      reviewer: { quiesceProject: vi.fn(() => reviewerDrained) },
+      sideChat: { invalidateProject: vi.fn().mockResolvedValue(undefined) },
+      compute: { reconcileProject: vi.fn().mockResolvedValue(undefined) }
+    })
+
+    const quiescing = owner.quiesceProject('project-1')
+    await Promise.resolve()
+
+    expect(acp.listSessionIds).not.toHaveBeenCalled()
+
+    releaseReviewer()
+    await quiescing
+
+    expect(acp.listSessionIds).toHaveBeenCalled()
   })
 })

--- a/src/main/projects/project-runtime-quiescence-owner.test.ts
+++ b/src/main/projects/project-runtime-quiescence-owner.test.ts
@@ -70,4 +70,32 @@ describe('ProjectRuntimeQuiescenceOwner', () => {
     expect(sideChat.invalidateProject).toHaveBeenCalledWith('project-1')
     expect(compute.reconcileProject).toHaveBeenCalledWith('project-1')
   })
+
+  it('discovers Delegation again after ACP teardown closes the root admission source', async () => {
+    let acpStopped = false
+    const delegation = {
+      listActiveSessions: vi.fn(() =>
+        acpStopped ? [{ projectId: 'project-1', sessionId: 'late-child' }] : []
+      ),
+      deleteSession: vi.fn().mockResolvedValue(undefined)
+    }
+    const owner = new ProjectRuntimeQuiescenceOwner({
+      acp: {
+        listSessionIds: () => ['root-session'],
+        liveSessionProjectId: () => 'project-1',
+        deleteSession: vi.fn(async () => {
+          acpStopped = true
+        })
+      },
+      delegation,
+      notebook: { shutdownProject: vi.fn().mockResolvedValue(undefined) },
+      sideChat: { invalidateProject: vi.fn().mockResolvedValue(undefined) },
+      compute: { reconcileProject: vi.fn().mockResolvedValue(undefined) }
+    })
+
+    await owner.quiesceProject('project-1')
+
+    expect(delegation.listActiveSessions).toHaveBeenCalledOnce()
+    expect(delegation.deleteSession).toHaveBeenCalledWith('late-child')
+  })
 })

--- a/src/main/projects/project-runtime-quiescence-owner.test.ts
+++ b/src/main/projects/project-runtime-quiescence-owner.test.ts
@@ -12,11 +12,7 @@ describe('ProjectRuntimeQuiescenceOwner', () => {
       deleteSession: vi.fn().mockResolvedValue(undefined)
     }
     const delegation = {
-      listActiveSessions: vi.fn(() => [
-        { projectId: 'project-1', sessionId: 'delegated-target' },
-        { projectId: 'project-2', sessionId: 'delegated-other' }
-      ]),
-      deleteSession: vi.fn().mockResolvedValue(undefined)
+      deleteProject: vi.fn().mockResolvedValue(undefined)
     }
     const notebook = { shutdownProject: vi.fn().mockResolvedValue(undefined) }
     const sideChat = { invalidateProject: vi.fn().mockResolvedValue(undefined) }
@@ -33,8 +29,7 @@ describe('ProjectRuntimeQuiescenceOwner', () => {
 
     expect(acp.deleteSession).toHaveBeenCalledWith('acp-target')
     expect(acp.deleteSession).not.toHaveBeenCalledWith('acp-other')
-    expect(delegation.deleteSession).toHaveBeenCalledWith('delegated-target')
-    expect(delegation.deleteSession).not.toHaveBeenCalledWith('delegated-other')
+    expect(delegation.deleteProject).toHaveBeenCalledWith('project-1')
     expect(notebook.shutdownProject).toHaveBeenCalledWith('project-1')
     expect(sideChat.invalidateProject).toHaveBeenCalledWith('project-1')
     expect(compute.reconcileProject).toHaveBeenCalledWith('project-1')
@@ -47,8 +42,7 @@ describe('ProjectRuntimeQuiescenceOwner', () => {
       deleteSession: vi.fn().mockRejectedValue(new Error('ACP unavailable'))
     }
     const delegation = {
-      listActiveSessions: vi.fn(() => [{ projectId: 'project-1', sessionId: 'session-2' }]),
-      deleteSession: vi.fn().mockResolvedValue(undefined)
+      deleteProject: vi.fn().mockResolvedValue(undefined)
     }
     const notebook = { shutdownProject: vi.fn().mockResolvedValue(undefined) }
     const sideChat = { invalidateProject: vi.fn().mockResolvedValue(undefined) }
@@ -65,19 +59,18 @@ describe('ProjectRuntimeQuiescenceOwner', () => {
       'Project runtime cleanup failed: project-1'
     )
 
-    expect(delegation.deleteSession).toHaveBeenCalledWith('session-2')
+    expect(delegation.deleteProject).toHaveBeenCalledWith('project-1')
     expect(notebook.shutdownProject).toHaveBeenCalledWith('project-1')
     expect(sideChat.invalidateProject).toHaveBeenCalledWith('project-1')
     expect(compute.reconcileProject).toHaveBeenCalledWith('project-1')
   })
 
-  it('discovers Delegation again after ACP teardown closes the root admission source', async () => {
+  it('deletes authoritative Project Delegation state after ACP teardown closes admission', async () => {
     let acpStopped = false
     const delegation = {
-      listActiveSessions: vi.fn(() =>
-        acpStopped ? [{ projectId: 'project-1', sessionId: 'late-child' }] : []
-      ),
-      deleteSession: vi.fn().mockResolvedValue(undefined)
+      deleteProject: vi.fn(async () => {
+        expect(acpStopped).toBe(true)
+      })
     }
     const owner = new ProjectRuntimeQuiescenceOwner({
       acp: {
@@ -95,7 +88,6 @@ describe('ProjectRuntimeQuiescenceOwner', () => {
 
     await owner.quiesceProject('project-1')
 
-    expect(delegation.listActiveSessions).toHaveBeenCalledOnce()
-    expect(delegation.deleteSession).toHaveBeenCalledWith('late-child')
+    expect(delegation.deleteProject).toHaveBeenCalledWith('project-1')
   })
 })

--- a/src/main/projects/project-runtime-quiescence-owner.test.ts
+++ b/src/main/projects/project-runtime-quiescence-owner.test.ts
@@ -66,19 +66,21 @@ describe('ProjectRuntimeQuiescenceOwner', () => {
   })
 
   it('deletes authoritative Project Delegation state after ACP teardown closes admission', async () => {
-    let acpStopped = false
+    const ownedSessionIds = new Set(['root-session'])
+    const deleteSession = vi.fn(async (sessionId: string) => {
+      ownedSessionIds.delete(sessionId)
+    })
     const delegation = {
       deleteProject: vi.fn(async () => {
-        expect(acpStopped).toBe(true)
+        expect(ownedSessionIds.has('root-session')).toBe(false)
+        ownedSessionIds.add('late-continuation')
       })
     }
     const owner = new ProjectRuntimeQuiescenceOwner({
       acp: {
-        listSessionIds: () => ['root-session'],
+        listSessionIds: () => [...ownedSessionIds],
         liveSessionProjectId: () => 'project-1',
-        deleteSession: vi.fn(async () => {
-          acpStopped = true
-        })
+        deleteSession
       },
       delegation,
       notebook: { shutdownProject: vi.fn().mockResolvedValue(undefined) },
@@ -89,5 +91,7 @@ describe('ProjectRuntimeQuiescenceOwner', () => {
     await owner.quiesceProject('project-1')
 
     expect(delegation.deleteProject).toHaveBeenCalledWith('project-1')
+    expect(deleteSession).toHaveBeenNthCalledWith(1, 'root-session')
+    expect(deleteSession).toHaveBeenNthCalledWith(2, 'late-continuation')
   })
 })

--- a/src/main/projects/project-runtime-quiescence-owner.test.ts
+++ b/src/main/projects/project-runtime-quiescence-owner.test.ts
@@ -94,4 +94,38 @@ describe('ProjectRuntimeQuiescenceOwner', () => {
     expect(deleteSession).toHaveBeenNthCalledWith(1, 'root-session')
     expect(deleteSession).toHaveBeenNthCalledWith(2, 'late-continuation')
   })
+
+  it('drains Notebook work before deleting authoritative Project Delegation state', async () => {
+    let releaseNotebook!: () => void
+    const notebookDrained = new Promise<void>((resolve) => {
+      releaseNotebook = resolve
+    })
+    const delegation = {
+      deleteProject: vi.fn().mockResolvedValue(undefined)
+    }
+    const notebook = {
+      shutdownProject: vi.fn(() => notebookDrained)
+    }
+    const owner = new ProjectRuntimeQuiescenceOwner({
+      acp: {
+        listSessionIds: vi.fn(() => []),
+        liveSessionProjectId: vi.fn(),
+        deleteSession: vi.fn().mockResolvedValue(undefined)
+      },
+      delegation,
+      notebook,
+      sideChat: { invalidateProject: vi.fn().mockResolvedValue(undefined) },
+      compute: { reconcileProject: vi.fn().mockResolvedValue(undefined) }
+    })
+
+    const quiescing = owner.quiesceProject('project-1')
+    await vi.waitFor(() => expect(notebook.shutdownProject).toHaveBeenCalledWith('project-1'))
+
+    expect(delegation.deleteProject).not.toHaveBeenCalled()
+
+    releaseNotebook()
+    await quiescing
+
+    expect(delegation.deleteProject).toHaveBeenCalledWith('project-1')
+  })
 })

--- a/src/main/projects/project-runtime-quiescence-owner.test.ts
+++ b/src/main/projects/project-runtime-quiescence-owner.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { ProjectRuntimeQuiescenceOwner } from './project-runtime-quiescence-owner'
+
+describe('ProjectRuntimeQuiescenceOwner', () => {
+  it('stops every runtime owned by the Project without touching another Project', async () => {
+    const acp = {
+      listSessionIds: vi.fn(() => ['acp-target', 'acp-other']),
+      liveSessionProjectId: vi.fn((sessionId: string) =>
+        sessionId === 'acp-target' ? 'project-1' : 'project-2'
+      ),
+      deleteSession: vi.fn().mockResolvedValue(undefined)
+    }
+    const delegation = {
+      listActiveSessions: vi.fn(() => [
+        { projectId: 'project-1', sessionId: 'delegated-target' },
+        { projectId: 'project-2', sessionId: 'delegated-other' }
+      ]),
+      deleteSession: vi.fn().mockResolvedValue(undefined)
+    }
+    const notebook = { shutdownProject: vi.fn().mockResolvedValue(undefined) }
+    const sideChat = { invalidateProject: vi.fn().mockResolvedValue(undefined) }
+    const compute = { reconcileProject: vi.fn().mockResolvedValue(undefined) }
+    const owner = new ProjectRuntimeQuiescenceOwner({
+      acp,
+      delegation,
+      notebook,
+      sideChat,
+      compute
+    })
+
+    await owner.quiesceProject('project-1')
+
+    expect(acp.deleteSession).toHaveBeenCalledWith('acp-target')
+    expect(acp.deleteSession).not.toHaveBeenCalledWith('acp-other')
+    expect(delegation.deleteSession).toHaveBeenCalledWith('delegated-target')
+    expect(delegation.deleteSession).not.toHaveBeenCalledWith('delegated-other')
+    expect(notebook.shutdownProject).toHaveBeenCalledWith('project-1')
+    expect(sideChat.invalidateProject).toHaveBeenCalledWith('project-1')
+    expect(compute.reconcileProject).toHaveBeenCalledWith('project-1')
+  })
+
+  it('attempts every runtime boundary and fails closed when one cleanup fails', async () => {
+    const acp = {
+      listSessionIds: vi.fn(() => ['session-1']),
+      liveSessionProjectId: vi.fn(() => 'project-1'),
+      deleteSession: vi.fn().mockRejectedValue(new Error('ACP unavailable'))
+    }
+    const delegation = {
+      listActiveSessions: vi.fn(() => [{ projectId: 'project-1', sessionId: 'session-2' }]),
+      deleteSession: vi.fn().mockResolvedValue(undefined)
+    }
+    const notebook = { shutdownProject: vi.fn().mockResolvedValue(undefined) }
+    const sideChat = { invalidateProject: vi.fn().mockResolvedValue(undefined) }
+    const compute = { reconcileProject: vi.fn().mockResolvedValue(undefined) }
+    const owner = new ProjectRuntimeQuiescenceOwner({
+      acp,
+      delegation,
+      notebook,
+      sideChat,
+      compute
+    })
+
+    await expect(owner.quiesceProject('project-1')).rejects.toThrow(
+      'Project runtime cleanup failed: project-1'
+    )
+
+    expect(delegation.deleteSession).toHaveBeenCalledWith('session-2')
+    expect(notebook.shutdownProject).toHaveBeenCalledWith('project-1')
+    expect(sideChat.invalidateProject).toHaveBeenCalledWith('project-1')
+    expect(compute.reconcileProject).toHaveBeenCalledWith('project-1')
+  })
+})

--- a/src/main/projects/project-runtime-quiescence-owner.ts
+++ b/src/main/projects/project-runtime-quiescence-owner.ts
@@ -28,9 +28,9 @@ type ProjectRuntimeQuiescenceOptions = {
   compute: ProjectComputeRuntime
 }
 
-// Owns the single fail-closed runtime boundary that every Project deletion entry must cross before
-// durable deletion begins. Each subsystem is attempted even when another teardown fails, while the
-// aggregate rejection keeps Project and Session authority intact for an explicit retry.
+// Owns the single fail-closed runtime boundary that every Project deletion entry crosses after its
+// durable intent is written and before Project/Session authority is removed. Each subsystem is
+// attempted even when another teardown fails; aggregate rejection retains the intent for recovery.
 class ProjectRuntimeQuiescenceOwner {
   constructor(private readonly options: ProjectRuntimeQuiescenceOptions) {}
 

--- a/src/main/projects/project-runtime-quiescence-owner.ts
+++ b/src/main/projects/project-runtime-quiescence-owner.ts
@@ -46,6 +46,13 @@ class ProjectRuntimeQuiescenceOwner {
     // ACP teardown closes the source of new delegated work. Delete the authoritative Project
     // workspace only after that drain so cached, late, and dormant Frame state are covered together.
     await this.capture(failures, () => this.options.delegation.deleteProject(projectId))
+    const remainingAcpSessionIds = this.projectAcpSessionIds(projectId, failures)
+    await this.captureAll(
+      failures,
+      [...remainingAcpSessionIds].map(
+        (sessionId) => () => this.options.acp.deleteSession(sessionId)
+      )
+    )
     await this.capture(failures, () => this.options.notebook.shutdownProject(projectId))
     await this.capture(failures, () => this.options.compute.reconcileProject(projectId))
 

--- a/src/main/projects/project-runtime-quiescence-owner.ts
+++ b/src/main/projects/project-runtime-quiescence-owner.ts
@@ -5,8 +5,7 @@ type ProjectAcpRuntime = {
 }
 
 type ProjectDelegationRuntime = {
-  listActiveSessions(): readonly { projectId: string; sessionId: string }[]
-  deleteSession(sessionId: string): Promise<void>
+  deleteProject(projectId: string): Promise<void>
 }
 
 type ProjectNotebookRuntime = {
@@ -44,15 +43,9 @@ class ProjectRuntimeQuiescenceOwner {
       failures,
       [...acpSessionIds].map((sessionId) => () => this.options.acp.deleteSession(sessionId))
     )
-    // ACP teardown closes the source of new delegated work. Discover children only after that drain
-    // so a child admitted while its root was being cancelled cannot escape the initial snapshot.
-    const delegatedSessionIds = this.projectDelegatedSessionIds(projectId, failures).filter(
-      (sessionId) => !acpSessionIds.has(sessionId)
-    )
-    await this.captureAll(
-      failures,
-      delegatedSessionIds.map((sessionId) => () => this.options.delegation.deleteSession(sessionId))
-    )
+    // ACP teardown closes the source of new delegated work. Delete the authoritative Project
+    // workspace only after that drain so cached, late, and dormant Frame state are covered together.
+    await this.capture(failures, () => this.options.delegation.deleteProject(projectId))
     await this.capture(failures, () => this.options.notebook.shutdownProject(projectId))
     await this.capture(failures, () => this.options.compute.reconcileProject(projectId))
 
@@ -71,22 +64,6 @@ class ProjectRuntimeQuiescenceOwner {
     } catch (error) {
       failures.push(error)
       return new Set()
-    }
-  }
-
-  private projectDelegatedSessionIds(projectId: string, failures: unknown[]): string[] {
-    try {
-      return [
-        ...new Set(
-          this.options.delegation
-            .listActiveSessions()
-            .filter((session) => session.projectId === projectId)
-            .map((session) => session.sessionId)
-        )
-      ]
-    } catch (error) {
-      failures.push(error)
-      return []
     }
   }
 

--- a/src/main/projects/project-runtime-quiescence-owner.ts
+++ b/src/main/projects/project-runtime-quiescence-owner.ts
@@ -12,6 +12,10 @@ type ProjectNotebookRuntime = {
   shutdownProject(projectId: string): Promise<unknown>
 }
 
+type ProjectReviewerRuntime = {
+  quiesceProject(projectId: string): Promise<void>
+}
+
 type ProjectSideChatRuntime = {
   invalidateProject(projectId: string): Promise<void>
 }
@@ -24,6 +28,7 @@ type ProjectRuntimeQuiescenceOptions = {
   acp: ProjectAcpRuntime
   delegation: ProjectDelegationRuntime
   notebook: ProjectNotebookRuntime
+  reviewer: ProjectReviewerRuntime
   sideChat: ProjectSideChatRuntime
   compute: ProjectComputeRuntime
 }
@@ -36,8 +41,12 @@ class ProjectRuntimeQuiescenceOwner {
 
   async quiesceProject(projectId: string): Promise<void> {
     const failures: unknown[] = []
-    const acpSessionIds = this.projectAcpSessionIds(projectId, failures)
 
+    // Reviewer owns fire-and-forget ACP/MCP work and correction loops outside the primary ACP Session
+    // index. Fence and drain it before the first ACP ownership snapshot so it cannot publish a late
+    // reviewer or correction Session while Project teardown is already in progress.
+    await this.capture(failures, () => this.options.reviewer.quiesceProject(projectId))
+    const acpSessionIds = this.projectAcpSessionIds(projectId, failures)
     await this.capture(failures, () => this.options.sideChat.invalidateProject(projectId))
     await this.captureAll(
       failures,
@@ -102,6 +111,7 @@ export type {
   ProjectComputeRuntime,
   ProjectDelegationRuntime,
   ProjectNotebookRuntime,
+  ProjectReviewerRuntime,
   ProjectRuntimeQuiescenceOptions,
   ProjectSideChatRuntime
 }

--- a/src/main/projects/project-runtime-quiescence-owner.ts
+++ b/src/main/projects/project-runtime-quiescence-owner.ts
@@ -43,8 +43,10 @@ class ProjectRuntimeQuiescenceOwner {
       failures,
       [...acpSessionIds].map((sessionId) => () => this.options.acp.deleteSession(sessionId))
     )
-    // ACP teardown closes the source of new delegated work. Delete the authoritative Project
-    // workspace only after that drain so cached, late, and dormant Frame state are covered together.
+    // ACP teardown and Notebook shutdown close both sources of new delegated work. Delete the
+    // authoritative Project workspace only after those drains so cached, late, and dormant Frame
+    // state are covered together.
+    await this.capture(failures, () => this.options.notebook.shutdownProject(projectId))
     await this.capture(failures, () => this.options.delegation.deleteProject(projectId))
     const remainingAcpSessionIds = this.projectAcpSessionIds(projectId, failures)
     await this.captureAll(
@@ -53,7 +55,6 @@ class ProjectRuntimeQuiescenceOwner {
         (sessionId) => () => this.options.acp.deleteSession(sessionId)
       )
     )
-    await this.capture(failures, () => this.options.notebook.shutdownProject(projectId))
     await this.capture(failures, () => this.options.compute.reconcileProject(projectId))
 
     if (failures.length > 0) {

--- a/src/main/projects/project-runtime-quiescence-owner.ts
+++ b/src/main/projects/project-runtime-quiescence-owner.ts
@@ -38,14 +38,16 @@ class ProjectRuntimeQuiescenceOwner {
   async quiesceProject(projectId: string): Promise<void> {
     const failures: unknown[] = []
     const acpSessionIds = this.projectAcpSessionIds(projectId, failures)
-    const delegatedSessionIds = this.projectDelegatedSessionIds(projectId, failures).filter(
-      (sessionId) => !acpSessionIds.has(sessionId)
-    )
 
     await this.capture(failures, () => this.options.sideChat.invalidateProject(projectId))
     await this.captureAll(
       failures,
       [...acpSessionIds].map((sessionId) => () => this.options.acp.deleteSession(sessionId))
+    )
+    // ACP teardown closes the source of new delegated work. Discover children only after that drain
+    // so a child admitted while its root was being cancelled cannot escape the initial snapshot.
+    const delegatedSessionIds = this.projectDelegatedSessionIds(projectId, failures).filter(
+      (sessionId) => !acpSessionIds.has(sessionId)
     )
     await this.captureAll(
       failures,

--- a/src/main/projects/project-runtime-quiescence-owner.ts
+++ b/src/main/projects/project-runtime-quiescence-owner.ts
@@ -1,0 +1,120 @@
+type ProjectAcpRuntime = {
+  listSessionIds(): readonly string[]
+  liveSessionProjectId(sessionId: string): string | undefined
+  deleteSession(sessionId: string): Promise<unknown>
+}
+
+type ProjectDelegationRuntime = {
+  listActiveSessions(): readonly { projectId: string; sessionId: string }[]
+  deleteSession(sessionId: string): Promise<void>
+}
+
+type ProjectNotebookRuntime = {
+  shutdownProject(projectId: string): Promise<unknown>
+}
+
+type ProjectSideChatRuntime = {
+  invalidateProject(projectId: string): Promise<void>
+}
+
+type ProjectComputeRuntime = {
+  reconcileProject(projectId: string): Promise<void>
+}
+
+type ProjectRuntimeQuiescenceOptions = {
+  acp: ProjectAcpRuntime
+  delegation: ProjectDelegationRuntime
+  notebook: ProjectNotebookRuntime
+  sideChat: ProjectSideChatRuntime
+  compute: ProjectComputeRuntime
+}
+
+// Owns the single fail-closed runtime boundary that every Project deletion entry must cross before
+// durable deletion begins. Each subsystem is attempted even when another teardown fails, while the
+// aggregate rejection keeps Project and Session authority intact for an explicit retry.
+class ProjectRuntimeQuiescenceOwner {
+  constructor(private readonly options: ProjectRuntimeQuiescenceOptions) {}
+
+  async quiesceProject(projectId: string): Promise<void> {
+    const failures: unknown[] = []
+    const acpSessionIds = this.projectAcpSessionIds(projectId, failures)
+    const delegatedSessionIds = this.projectDelegatedSessionIds(projectId, failures).filter(
+      (sessionId) => !acpSessionIds.has(sessionId)
+    )
+
+    await this.capture(failures, () => this.options.sideChat.invalidateProject(projectId))
+    await this.captureAll(
+      failures,
+      [...acpSessionIds].map((sessionId) => () => this.options.acp.deleteSession(sessionId))
+    )
+    await this.captureAll(
+      failures,
+      delegatedSessionIds.map((sessionId) => () => this.options.delegation.deleteSession(sessionId))
+    )
+    await this.capture(failures, () => this.options.notebook.shutdownProject(projectId))
+    await this.capture(failures, () => this.options.compute.reconcileProject(projectId))
+
+    if (failures.length > 0) {
+      throw new AggregateError(failures, 'Project runtime cleanup failed: ' + projectId)
+    }
+  }
+
+  private projectAcpSessionIds(projectId: string, failures: unknown[]): Set<string> {
+    try {
+      return new Set(
+        this.options.acp
+          .listSessionIds()
+          .filter((sessionId) => this.options.acp.liveSessionProjectId(sessionId) === projectId)
+      )
+    } catch (error) {
+      failures.push(error)
+      return new Set()
+    }
+  }
+
+  private projectDelegatedSessionIds(projectId: string, failures: unknown[]): string[] {
+    try {
+      return [
+        ...new Set(
+          this.options.delegation
+            .listActiveSessions()
+            .filter((session) => session.projectId === projectId)
+            .map((session) => session.sessionId)
+        )
+      ]
+    } catch (error) {
+      failures.push(error)
+      return []
+    }
+  }
+
+  private async capture(failures: unknown[], operation: () => Promise<unknown>): Promise<void> {
+    try {
+      await operation()
+    } catch (error) {
+      failures.push(error)
+    }
+  }
+
+  private async captureAll(
+    failures: unknown[],
+    operations: readonly (() => Promise<unknown>)[]
+  ): Promise<void> {
+    const results = await Promise.allSettled(
+      operations.map((operation) => Promise.resolve().then(operation))
+    )
+    for (const result of results) {
+      if (result.status === 'rejected') failures.push(result.reason)
+    }
+  }
+}
+
+export { ProjectRuntimeQuiescenceOwner }
+export type {
+  ProjectAcpRuntime,
+  ProjectComputeRuntime,
+  ProjectDelegationRuntime,
+  ProjectNotebookRuntime,
+  ProjectRuntimeQuiescenceOptions,
+  ProjectSideChatRuntime
+}

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReviewRunRequest } from '../../shared/reviewer'
 import { REVIEWER_IPC } from '../../shared/reviewer'
 import type { AcpRuntime } from '../acp/runtime'
+import { ReviewerProjectRuntimeOwner } from './project-runtime-owner'
 
 // Distinct roots so a config-vs-data mix-up is unambiguous: artifacts must read from the data root.
 const CONFIG_ROOT = join(tmpdir(), 'open-science-config-root')
@@ -152,6 +153,40 @@ describe('reviewer IPC handlers', () => {
 
     finishRun?.()
     await backgroundRun
+  })
+
+  it('fences new Project reviews and drains an admitted background run during deletion', async () => {
+    let finishRun!: () => void
+    let reviewSignal: AbortSignal | undefined
+    runReview.mockImplementation(
+      (options?: { onStarted?: () => void; fixLoopAbortSignal?: AbortSignal }) => {
+        reviewSignal = options?.fixLoopAbortSignal
+        options?.onStarted?.()
+        return new Promise<void>((resolve) => {
+          finishRun = resolve
+        })
+      }
+    )
+    const projectRuntime = new ReviewerProjectRuntimeOwner()
+    const owner = createReviewerCommandOwner({ acpRuntime, projectRuntime })
+
+    await expect(owner.run(createRequest())).resolves.toEqual({ started: true })
+
+    let quiesced = false
+    const quiescing = projectRuntime.quiesceProject('project-1').then(() => {
+      quiesced = true
+    })
+    await vi.waitFor(() => expect(reviewSignal?.aborted).toBe(true))
+
+    expect(quiesced).toBe(false)
+    await expect(
+      owner.run({ ...createRequest(), turnMessageId: 'message-after-fence' })
+    ).rejects.toThrow('Project is being deleted.')
+    expect(runReview).toHaveBeenCalledOnce()
+
+    finishRun()
+    await quiescing
+    expect(quiesced).toBe(true)
   })
 
   it('runs reviews with artifacts rooted at the data root, not the config root', async () => {

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -25,6 +25,7 @@ import { SessionRepository } from '../session-persistence/repository'
 import { broadcastToRenderers } from '../renderer-broadcast'
 import { ArtifactProvenanceRepository } from '../artifacts/provenance-repository'
 import { acquireDataRootWriter } from '../storage/migration-state'
+import { ReviewerProjectRuntimeOwner, type ReviewerProjectAdmission } from './project-runtime-owner'
 
 const log = createLogger('reviewer:ipc')
 
@@ -95,6 +96,7 @@ type ReviewerIpcOptions = {
       }>
     >
   }>
+  projectRuntime?: Pick<ReviewerProjectRuntimeOwner, 'admit'>
 }
 
 type ReviewerCommandOwner = Readonly<{
@@ -119,9 +121,11 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
       loadSession: (projectId, appSessionId) =>
         sessionRepository.loadSession(projectId, appSessionId)
     })
-  // Per-session AbortControllers for active fix loops. Keyed by the main session id (not the
-  // reviewer session id). Entries are created when a fix loop starts and deleted when it ends.
-  const fixLoopAbortControllers = new Map<string, AbortController>()
+  const projectRuntime = options.projectRuntime ?? new ReviewerProjectRuntimeOwner()
+  // Per-session abort capabilities for active fix loops. Keyed by the main session id (not the
+  // reviewer session id). Project deletion owns the same signal, so user cancellation and Project
+  // quiescence converge on one operation without maintaining competing AbortControllers.
+  const fixLoopAbortControllers = new Map<string, () => void>()
 
   // Guards against concurrent reviews of the same turn — e.g. a double-clicked "Re-run review" or two
   // stale cards fired at once. Project is part of the key because Session ids are not globally owned.
@@ -152,7 +156,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
     const controller = fixLoopAbortControllers.get(key)
     if (controller) {
       log.info('fix loop abort requested', request)
-      controller.abort()
+      controller()
     } else {
       log.warn('abort-fix-loop: no active fix loop found for session', request)
     }
@@ -162,7 +166,10 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
   // so a load failure — or an already-in-flight run for this turn — is reported as started:false with
   // NO Review row created. That lets a caller (e.g. the ReviewerCard "Re-run") release its pending
   // state and leave the turn retriable, instead of us fabricating a non-retriable error review.
-  const triggerReview = async (request: ReviewRunRequest): Promise<ReviewRunResult> => {
+  const triggerAdmittedReview = async (
+    request: ReviewRunRequest,
+    projectAdmission: ReviewerProjectAdmission
+  ): Promise<ReviewRunResult> => {
     const {
       sessionId,
       turnMessageId,
@@ -172,6 +179,10 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
       mainSessionId,
       model: rendererModel
     } = request
+    const finishBeforeBackground = (result: ReviewRunResult): ReviewRunResult => {
+      projectAdmission.release()
+      return result
+    }
 
     // Reserve the turn SYNCHRONOUSLY (before any await) so a double-click / multiple stale cards can't
     // both pass the guard before the key is set. Released on the start-failure paths and, on success,
@@ -181,7 +192,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
       log.info('review skipped: already in flight for this turn', { sessionId, turnMessageId })
       // The turn IS being handled by the in-flight run — this is NOT a retry candidate. Retrying
       // after the lock releases would launch a duplicate review (and possibly a second fix loop).
-      return { started: false, reason: 'already-in-flight' }
+      return finishBeforeBackground({ started: false, reason: 'already-in-flight' })
     }
     inFlightReviewKeys.add(inFlightKey)
 
@@ -198,7 +209,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
         if (existing.some((review) => review.turnMessageId === turnMessageId)) {
           inFlightReviewKeys.delete(inFlightKey)
           log.info('auto review skipped: turn already has a review', { sessionId, turnMessageId })
-          return { started: false, reason: 'already-reviewed' }
+          return finishBeforeBackground({ started: false, reason: 'already-reviewed' })
         }
       } catch (error) {
         // Fail CLOSED: if the lookup itself threw we cannot confirm the turn is un-reviewed, and
@@ -211,7 +222,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
           turnMessageId,
           error: error instanceof Error ? error.message : String(error)
         })
-        return { started: false, reason: 'idempotency-check-failed' }
+        return finishBeforeBackground({ started: false, reason: 'idempotency-check-failed' })
       }
     }
 
@@ -236,7 +247,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
         error: error instanceof Error ? error.message : String(error)
       })
       // Transient store read failure — no Review row, lock released. Safe (and worth) retrying.
-      return { started: false, reason: 'load-failed' }
+      return finishBeforeBackground({ started: false, reason: 'load-failed' })
     }
 
     // Session load succeeded but the id is gone (deleted between the card render and the click).
@@ -249,7 +260,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
       log.warn('review start failed: session not found', { sessionId, turnMessageId })
       // The session may simply not be flushed to disk yet (async persistence queue) — a retry can
       // catch it once the write lands, so report the race-shaped reason rather than a hard failure.
-      return { started: false, reason: 'not-found' }
+      return finishBeforeBackground({ started: false, reason: 'not-found' })
     }
 
     log.info('review triggered', { sessionId, turnMessageId })
@@ -271,7 +282,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
         turnMessageId,
         error: error instanceof Error ? error.message : String(error)
       })
-      return { started: false, reason: 'run-failed' }
+      return finishBeforeBackground({ started: false, reason: 'run-failed' })
     }
 
     let releaseDataRootWriter: (() => void) | undefined
@@ -289,7 +300,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
           error: error instanceof Error ? error.message : String(error)
         })
       })
-      return { started: false, reason: 'run-failed' }
+      return finishBeforeBackground({ started: false, reason: 'run-failed' })
     }
 
     // Resolve `started` only once the running Review row has actually been created and pushed
@@ -304,9 +315,6 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
         resolveStart(result)
       }
 
-      // Create an AbortController for this review's fix loop. The controller is registered
-      // before runReview starts so the abort-fix-loop handler can find it immediately.
-      const abortController = new AbortController()
       const effectiveMainSessionId = mainSessionId ?? sessionId
       const effectiveMainSessionKey = `${projectId}\0${effectiveMainSessionId}`
 
@@ -352,16 +360,16 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
             broadcastSuppressNextAutoReview(projectId, mainSessionId, true)
           }
         },
-        // Broadcast fix-loop lifecycle events and register/deregister the abort controller.
+        // Broadcast fix-loop lifecycle events and register/deregister the admitted abort capability.
         onFixLoopStart: () => {
-          fixLoopAbortControllers.set(effectiveMainSessionKey, abortController)
+          fixLoopAbortControllers.set(effectiveMainSessionKey, projectAdmission.abort)
           broadcastFixLoopStart(projectId, effectiveMainSessionId)
         },
         onFixLoopEnd: () => {
           fixLoopAbortControllers.delete(effectiveMainSessionKey)
           broadcastFixLoopEnd(projectId, effectiveMainSessionId)
         },
-        fixLoopAbortSignal: abortController.signal
+        fixLoopAbortSignal: projectAdmission.signal
       })
         .catch((error: unknown) => {
           // runReview records expected failures as lifecycle='error' itself; an unexpected throw here
@@ -377,15 +385,34 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
           // genuine pre-push failure (scope/insert), not a persistence race, so it is not auto-retried.
           settle({ started: false, reason: 'run-failed' })
           inFlightReviewKeys.delete(inFlightKey)
-          releaseDataRootWriter?.()
-          await modelAdmission.release().catch((error: unknown) => {
-            log.error('review runtime cleanup failed', {
-              sessionId,
-              turnMessageId,
-              error: error instanceof Error ? error.message : String(error)
+          try {
+            releaseDataRootWriter?.()
+          } finally {
+            await modelAdmission.release().catch((error: unknown) => {
+              log.error('review runtime cleanup failed', {
+                sessionId,
+                turnMessageId,
+                error: error instanceof Error ? error.message : String(error)
+              })
             })
-          })
+            projectAdmission.release()
+          }
         })
+    })
+  }
+
+  const triggerReview = (request: ReviewRunRequest): Promise<ReviewRunResult> => {
+    let projectAdmission: ReviewerProjectAdmission
+    try {
+      // Admission is acquired synchronously before session/repository/model work begins. Once
+      // Project deletion closes it, no new Reviewer operation can slip into the quiescence snapshot.
+      projectAdmission = projectRuntime.admit(request.projectId)
+    } catch (error) {
+      return Promise.reject(error)
+    }
+    return triggerAdmittedReview(request, projectAdmission).catch((error: unknown) => {
+      projectAdmission.release()
+      throw error
     })
   }
 

--- a/src/main/reviewer/orchestrator-drive.test.ts
+++ b/src/main/reviewer/orchestrator-drive.test.ts
@@ -28,6 +28,20 @@ describe('driveReviewerToStop', () => {
     )
   })
 
+  it('stops waiting when the admitted Review chain is aborted', async () => {
+    const session = { nextUpdate: (): Promise<FakeUpdate> => new Promise<FakeUpdate>(() => {}) }
+    const controller = new AbortController()
+
+    const driving = driveReviewerToStop(session, {
+      timeoutMs: 5000,
+      maxUpdates: 100,
+      signal: controller.signal
+    })
+    controller.abort()
+
+    await expect(driving).rejects.toThrow('reviewer session was aborted before stopping')
+  })
+
   it('throws once the update cap is exceeded (fast-looping reviewer that never stops)', async () => {
     // Always resolves a non-stop discrete update immediately — would loop forever without the cap.
     const session = {

--- a/src/main/reviewer/orchestrator.start-contract.test.ts
+++ b/src/main/reviewer/orchestrator.start-contract.test.ts
@@ -148,4 +148,42 @@ describe('runReview started-contract (real orchestrator)', () => {
     expect(onStarted).not.toHaveBeenCalled()
     expect(createReview).not.toHaveBeenCalled()
   })
+
+  it('propagates the admitted Review signal into the initial assessment drive', async () => {
+    const controller = new AbortController()
+    const prompt = vi.fn()
+    const disposeReviewerSession = vi.fn(() => ({
+      rejectedToolCalls: 0,
+      reviewerBridgeScoped: undefined
+    }))
+    const cancellableRuntime = {
+      buildReviewerSession: vi.fn().mockResolvedValue({
+        session: {
+          sessionId: 'reviewer-session-1',
+          prompt,
+          nextUpdate: () => new Promise(() => {})
+        }
+      }),
+      disposeReviewerSession
+    } as unknown as AcpRuntime
+    const createReview = vi.fn().mockResolvedValue(runningReview())
+    const options = baseOptions(makeRepo(createReview), {
+      onStarted: vi.fn(),
+      onReviewUpdate: vi.fn()
+    })
+
+    const running = runReview({
+      ...options,
+      acpRuntime: cancellableRuntime,
+      fixLoopAbortSignal: controller.signal
+    })
+    await vi.waitFor(() => expect(prompt).toHaveBeenCalledOnce())
+    controller.abort()
+
+    await expect(running).resolves.toMatchObject({
+      lifecycle: 'error',
+      errorMessage: 'reviewer session was aborted before stopping'
+    })
+    expect(disposeReviewerSession).toHaveBeenCalledOnce()
+  })
 })

--- a/src/main/reviewer/orchestrator.ts
+++ b/src/main/reviewer/orchestrator.ts
@@ -98,8 +98,8 @@ export type RunReviewOptions = {
   // Called when the fix loop ends (all pass, cap reached, or aborted). Used to unlock the session
   // composer in the renderer.
   onFixLoopEnd?: () => void
-  // AbortSignal to stop the fix loop early (e.g. when the user presses cancel). When aborted,
-  // the loop exits at the next round boundary without further [Auditor] injections.
+  // AbortSignal for the admitted Review chain. It stops an active initial Reviewer session and also
+  // makes the fix loop exit at the next round boundary without further [Auditor] injections.
   fixLoopAbortSignal?: AbortSignal
   // How long the fix loop waits for the correction turn to reach durable session storage. The main
   // agent can finish before the renderer's persistence queue flushes, so a single immediate read races.
@@ -168,7 +168,8 @@ const runReviewWithSession = async (
     onReviewUpdate,
     onStarted,
     reviewerTimeoutMs,
-    reviewerMaxUpdates
+    reviewerMaxUpdates,
+    abortSignal: fixLoopAbortSignal
   })
   const finalReview = assessment.review
   if (finalReview.lifecycle === 'error') return finalReview

--- a/src/main/reviewer/project-runtime-owner.test.ts
+++ b/src/main/reviewer/project-runtime-owner.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { ReviewerProjectRuntimeOwner } from './project-runtime-owner'
+
+describe('ReviewerProjectRuntimeOwner', () => {
+  it('aborts and drains admitted work for only the deleting Project', async () => {
+    const owner = new ReviewerProjectRuntimeOwner()
+    const target = owner.admit('project-1')
+    const other = owner.admit('project-2')
+
+    let quiesced = false
+    const quiescing = owner.quiesceProject('project-1').then(() => {
+      quiesced = true
+    })
+    await Promise.resolve()
+
+    expect(target.signal.aborted).toBe(true)
+    expect(other.signal.aborted).toBe(false)
+    expect(quiesced).toBe(false)
+    expect(() => owner.admit('project-1')).toThrow('Project is being deleted.')
+
+    target.release()
+    await quiescing
+    expect(quiesced).toBe(true)
+
+    const stillAvailable = owner.admit('project-2')
+    stillAvailable.release()
+    other.release()
+  })
+
+  it('restores and releases a deletion fence without creating an operation', () => {
+    const owner = new ReviewerProjectRuntimeOwner()
+
+    owner.restoreProjectDeletion('project-1')
+    expect(() => owner.admit('project-1')).toThrow('Project is being deleted.')
+
+    owner.releaseProjectDeletion('project-1')
+    const admission = owner.admit('project-1')
+    expect(admission.signal.aborted).toBe(false)
+    admission.release()
+  })
+})

--- a/src/main/reviewer/project-runtime-owner.ts
+++ b/src/main/reviewer/project-runtime-owner.ts
@@ -1,0 +1,70 @@
+type ReviewerProjectAdmission = Readonly<{
+  signal: AbortSignal
+  abort: () => void
+  release: () => void
+}>
+
+type ActiveReviewerOperation = Readonly<{
+  signalAbort: () => void
+  settled: Promise<void>
+}>
+
+// Owns Project-scoped Reviewer admission independently from the command adapter. It is constructed
+// before deletion recovery starts, so a restored durable intent can fence Reviewer commands even
+// before the Reviewer model/runtime composition is available.
+class ReviewerProjectRuntimeOwner {
+  private readonly deletingProjectIds = new Set<string>()
+  private readonly activeByProject = new Map<string, Map<symbol, ActiveReviewerOperation>>()
+
+  admit(projectId: string): ReviewerProjectAdmission {
+    if (this.deletingProjectIds.has(projectId)) {
+      throw new Error('Project is being deleted.')
+    }
+
+    const token = Symbol('reviewer-project-operation')
+    const controller = new AbortController()
+    let settle!: () => void
+    const settled = new Promise<void>((resolve) => {
+      settle = resolve
+    })
+    const active = this.activeByProject.get(projectId) ?? new Map()
+    active.set(token, { signalAbort: () => controller.abort(), settled })
+    this.activeByProject.set(projectId, active)
+
+    let released = false
+    return Object.freeze({
+      signal: controller.signal,
+      abort: () => controller.abort(),
+      release: () => {
+        if (released) return
+        released = true
+        active.delete(token)
+        if (active.size === 0 && this.activeByProject.get(projectId) === active) {
+          this.activeByProject.delete(projectId)
+        }
+        settle()
+      }
+    })
+  }
+
+  async quiesceProject(projectId: string): Promise<void> {
+    this.restoreProjectDeletion(projectId)
+    for (;;) {
+      const active = Array.from(this.activeByProject.get(projectId)?.values() ?? [])
+      if (active.length === 0) return
+      for (const operation of active) operation.signalAbort()
+      await Promise.all(active.map((operation) => operation.settled))
+    }
+  }
+
+  restoreProjectDeletion(projectId: string): void {
+    this.deletingProjectIds.add(projectId)
+  }
+
+  releaseProjectDeletion(projectId: string): void {
+    this.deletingProjectIds.delete(projectId)
+  }
+}
+
+export { ReviewerProjectRuntimeOwner }
+export type { ReviewerProjectAdmission }

--- a/src/main/reviewer/review-assessment-owner.test.ts
+++ b/src/main/reviewer/review-assessment-owner.test.ts
@@ -20,6 +20,7 @@ const harness = vi.hoisted(() => ({
   submission: undefined as NewCheck[] | undefined,
   submit: undefined as ((checks: NewCheck[]) => Promise<void>) | undefined,
   promptError: undefined as Error | undefined,
+  nextUpdate: undefined as (() => Promise<{ kind: string; stopReason?: string }>) | undefined,
   disposeError: undefined as Error | undefined,
   stopError: undefined as Error | undefined,
   bridgeScoped: undefined as boolean | undefined
@@ -200,7 +201,7 @@ const runtime = (contextModel?: string, sessionModel?: string): AcpRuntime =>
             outsideMutation('acp:prompt')
             if (harness.promptError) throw harness.promptError
           },
-          nextUpdate: async () => ({ kind: 'stop', stopReason: 'end_turn' })
+          nextUpdate: harness.nextUpdate ?? (async () => ({ kind: 'stop', stopReason: 'end_turn' }))
         }
       }
     },
@@ -246,6 +247,7 @@ describe('review assessment owner', () => {
     harness.submission = [{ status: 'pass', claim: 'Pass', evidence: 'Verified' }]
     harness.submit = undefined
     harness.promptError = undefined
+    harness.nextUpdate = undefined
     harness.disposeError = undefined
     harness.stopError = undefined
     harness.bridgeScoped = undefined
@@ -300,6 +302,29 @@ describe('review assessment owner', () => {
     expect(updates).toContainEqual(
       expect.objectContaining({ lifecycle: 'running', model: 'actual-runtime-model' })
     )
+  })
+
+  it('aborts an active initial Reviewer session and persists its existing error lifecycle', async () => {
+    harness.submission = undefined
+    harness.nextUpdate = () => new Promise(() => {})
+    const reviewRepository = makeRepository()
+    const controller = new AbortController()
+
+    const assessment = runReviewAssessment({
+      ...commonOptions(reviewRepository),
+      mode: 'initial',
+      abortSignal: controller.signal
+    })
+    await vi.waitFor(() => expect(harness.events).toContain('acp:prompt'))
+    controller.abort()
+
+    const result = await assessment
+    expect(result.review).toMatchObject({
+      lifecycle: 'error',
+      errorMessage: 'reviewer session was aborted before stopping'
+    })
+    expect(harness.events).toContain('acp:dispose')
+    expect(harness.events).toContain('mcp:stop')
   })
 
   it('records the selected session model instead of the context tokenization model', async () => {

--- a/src/main/reviewer/review-assessment-owner.ts
+++ b/src/main/reviewer/review-assessment-owner.ts
@@ -46,6 +46,7 @@ type CommonAssessmentOptions = {
   onReviewUpdate?: (review: ReviewWithChecks) => void
   reviewerTimeoutMs: number
   reviewerMaxUpdates: number
+  abortSignal?: AbortSignal
 }
 
 type InitialAssessmentOptions = CommonAssessmentOptions & {
@@ -145,7 +146,8 @@ export const runReviewAssessment = async (
     model,
     onReviewUpdate,
     reviewerTimeoutMs,
-    reviewerMaxUpdates
+    reviewerMaxUpdates,
+    abortSignal
   } = options
   const trackedChecks = options.mode === 'tracked' ? options.trackedChecks : []
 
@@ -237,7 +239,7 @@ export const runReviewAssessment = async (
     reviewerSession.prompt([{ type: 'text', text: reviewerPromptText }])
     const stopReason = await driveReviewerToStop(
       reviewerSession,
-      { timeoutMs: reviewerTimeoutMs, maxUpdates: reviewerMaxUpdates },
+      { timeoutMs: reviewerTimeoutMs, maxUpdates: reviewerMaxUpdates, signal: abortSignal },
       { onUpdate: (entry) => capturedLog.push(entry) }
     )
     if (options.mode === 'initial') {

--- a/src/main/reviewer/reviewer-session-driver.ts
+++ b/src/main/reviewer/reviewer-session-driver.ts
@@ -28,6 +28,7 @@ type DrivableSession = {
 type DriveOptions = {
   timeoutMs: number
   maxUpdates: number
+  signal?: AbortSignal
 }
 
 type DriveCallbacks = {
@@ -90,6 +91,7 @@ const flushAccumulator = (
 
 // Sentinel used to distinguish the timeout branch from a real reviewer update in Promise.race.
 const TIMEOUT = Symbol('reviewer-drive-timeout')
+const ABORTED = Symbol('reviewer-drive-aborted')
 
 // Consumes reviewer session updates until it stops, returning the stop reason. Throws if the
 // reviewer does not stop within timeoutMs, or if it emits more than maxUpdates discrete updates —
@@ -105,7 +107,7 @@ export const driveReviewerToStop = async (
   options: DriveOptions,
   callbacks?: DriveCallbacks
 ): Promise<string | undefined> => {
-  const { timeoutMs, maxUpdates } = options
+  const { timeoutMs, maxUpdates, signal } = options
   const { onUpdate } = callbacks ?? {}
   const deadline = Date.now() + timeoutMs
   let updates = 0
@@ -114,17 +116,29 @@ export const driveReviewerToStop = async (
   const acc: ChunkAccumulator = { thoughtText: null, messageText: null, pendingTools: new Map() }
 
   for (;;) {
+    if (signal?.aborted) throw new Error('reviewer session was aborted before stopping')
     const remaining = deadline - Date.now()
     if (remaining <= 0) throw new Error('reviewer session timed out before stopping')
 
     let timer: ReturnType<typeof setTimeout> | undefined
+    let abortListener: (() => void) | undefined
     const timeout = new Promise<typeof TIMEOUT>((resolve) => {
       timer = setTimeout(() => resolve(TIMEOUT), remaining)
     })
+    const aborted = new Promise<typeof ABORTED>((resolve) => {
+      if (!signal) return
+      if (signal.aborted) {
+        resolve(ABORTED)
+        return
+      }
+      abortListener = () => resolve(ABORTED)
+      signal.addEventListener('abort', abortListener, { once: true })
+    })
 
     try {
-      const result = await Promise.race([session.nextUpdate(), timeout])
+      const result = await Promise.race([session.nextUpdate(), timeout, aborted])
       if (result === TIMEOUT) throw new Error('reviewer session timed out before stopping')
+      if (result === ABORTED) throw new Error('reviewer session was aborted before stopping')
 
       if (result.kind === 'stop') {
         // Flush any in-flight streaming chunks before returning.
@@ -236,6 +250,7 @@ export const driveReviewerToStop = async (
       }
     } finally {
       if (timer) clearTimeout(timer)
+      if (signal && abortListener) signal.removeEventListener('abort', abortListener)
     }
   }
 }

--- a/src/main/runtime-electron-wiring.test.ts
+++ b/src/main/runtime-electron-wiring.test.ts
@@ -33,6 +33,7 @@ describe('production Electron runtime wiring', () => {
     const compute = { handlers: {}, enabledHosts: {} } as never
     const runtime = {} as never
     const workflows = {} as never
+    const sessionAdmission = {} as never
 
     await installElectronRuntimeAdapters({
       compute,
@@ -54,7 +55,7 @@ describe('production Electron runtime wiring', () => {
           }
         }
       ],
-      acp: { runtime, workflows },
+      acp: { runtime, workflows, sessionAdmission },
       afterAcp: [
         {
           name: 'settings',
@@ -67,7 +68,12 @@ describe('production Electron runtime wiring', () => {
     })
 
     expect(installComputeIpcHandlers).toHaveBeenCalledWith(compute)
-    expect(installAcpIpcHandlers).toHaveBeenCalledWith(runtime, workflows)
+    expect(installAcpIpcHandlers).toHaveBeenCalledWith(
+      runtime,
+      workflows,
+      undefined,
+      sessionAdmission
+    )
     expect(order).toEqual(['notifications', 'compute', 'connectors', 'acp', 'settings'])
   })
 
@@ -76,6 +82,7 @@ describe('production Electron runtime wiring', () => {
     const compute = { handlers: {}, enabledHosts: {} } as never
     const runtime = {} as never
     const workflows = {} as never
+    const sessionAdmission = {} as never
     installComputeIpcHandlers.mockReturnValueOnce({
       uninstall: vi.fn(() => {
         rollbackOrder.push('compute')
@@ -103,7 +110,7 @@ describe('production Electron runtime wiring', () => {
             }
           }
         ],
-        acp: { runtime, workflows },
+        acp: { runtime, workflows, sessionAdmission },
         afterAcp: []
       })
     ).rejects.toThrow('adapter install failed')

--- a/src/main/runtime-electron-wiring.ts
+++ b/src/main/runtime-electron-wiring.ts
@@ -1,4 +1,4 @@
-import { installAcpIpcHandlers } from './acp/ipc'
+import { installAcpIpcHandlers, type AcpIpcSessionAdmission } from './acp/ipc'
 import type { AcpHandlerWorkflows } from './acp/handler-workflows'
 import type { AcpRuntimeCoordinator } from './acp/runtime-coordinator'
 import { installComputeIpcHandlers, type ComputeIpcAdapter } from './compute/ipc'
@@ -22,6 +22,7 @@ export type ElectronRuntimeAdapterInterfaces = {
   readonly acp: {
     runtime: AcpRuntimeCoordinator
     workflows: AcpHandlerWorkflows
+    sessionAdmission: AcpIpcSessionAdmission
     respondDelegatedQuestion?: (
       input: NonNullable<ElicitationResponse['delegatedQuestion']> & { requestId: string }
     ) => Promise<void>
@@ -65,9 +66,12 @@ export const installElectronRuntimeAdapters = async ({
     await install('compute', () => installComputeIpcHandlers(compute))
     for (const surface of beforeAcp) await install(surface.name, () => surface.install())
     await install('acp', () =>
-      acp.respondDelegatedQuestion
-        ? installAcpIpcHandlers(acp.runtime, acp.workflows, acp.respondDelegatedQuestion)
-        : installAcpIpcHandlers(acp.runtime, acp.workflows)
+      installAcpIpcHandlers(
+        acp.runtime,
+        acp.workflows,
+        acp.respondDelegatedQuestion,
+        acp.sessionAdmission
+      )
     )
     for (const surface of afterAcp) await install(surface.name, () => surface.install())
   } catch (error) {

--- a/src/main/side-chat/runtime-owner.test.ts
+++ b/src/main/side-chat/runtime-owner.test.ts
@@ -706,12 +706,39 @@ describe('SideChatRuntimeOwner lifecycle', () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-side-chat-project-deleted-'))
     const persistence = createPersistence()
     const captureTarget = vi.fn()
+    const relay = createRelayOwner()
+    relay.hydrate([
+      {
+        projectId: 'project-deleted',
+        parentSessionId: 'parent-deleted',
+        relays: [
+          {
+            sideChatId: 'side-chat-project-deleted',
+            id: 'relay-deleted',
+            text: 'Do not deliver after deletion.',
+            createdAt: 10
+          }
+        ]
+      },
+      {
+        projectId: 'project-kept',
+        parentSessionId: 'parent-kept',
+        relays: [
+          {
+            sideChatId: 'side-chat-project-kept',
+            id: 'relay-kept',
+            text: 'Keep this advisory.',
+            createdAt: 20
+          }
+        ]
+      }
+    ])
     const owner = new SideChatRuntimeOwner({
       appVersion: '0.11.0',
       configRoot: temporaryRoot,
       captureTarget,
       resolveTarget: vi.fn(),
-      relay: createRelayOwner(),
+      relay,
       persistence,
       onEvent: vi.fn()
     })
@@ -747,10 +774,12 @@ describe('SideChatRuntimeOwner lifecycle', () => {
     ])
 
     await owner.invalidateProject('project-deleted')
+    const deletedRelayClaim = relay.claim('parent-deleted')
 
     expect(owner.list().chats).toEqual([
       expect.objectContaining({ parentSessionId: 'parent-kept', projectId: 'project-kept' })
     ])
+    expect(deletedRelayClaim?.messages).toEqual([expect.objectContaining({ id: 'relay-deleted' })])
     expect(persistence.clear).not.toHaveBeenCalled()
     await expect(
       owner.start({
@@ -779,6 +808,12 @@ describe('SideChatRuntimeOwner lifecycle', () => {
 
     await owner.invalidateProject('project-deleted')
     await owner.completeProjectDeletion('project-deleted')
+    expect(deletedRelayClaim?.commit()).toEqual([])
+    deletedRelayClaim?.restore()
+    expect(relay.claim('parent-deleted')).toBeUndefined()
+    expect(relay.claim('parent-kept')?.messages).toEqual([
+      expect.objectContaining({ id: 'relay-kept' })
+    ])
     owner.restoreProject('project-deleted')
     expect(owner.list().chats).toEqual([
       expect.objectContaining({ parentSessionId: 'parent-kept', projectId: 'project-kept' })
@@ -787,12 +822,27 @@ describe('SideChatRuntimeOwner lifecycle', () => {
 
   it('retains dormant Side chats when Project profile cleanup fails', async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-side-chat-project-cleanup-'))
+    const relay = createRelayOwner()
+    relay.hydrate([
+      {
+        projectId: 'project-deleted',
+        parentSessionId: 'parent-deleted',
+        relays: [
+          {
+            sideChatId: 'side-chat-\u0000-invalid',
+            id: 'relay-retry',
+            text: 'Retain until cleanup succeeds.',
+            createdAt: 10
+          }
+        ]
+      }
+    ])
     const owner = new SideChatRuntimeOwner({
       appVersion: '0.11.0',
       configRoot: temporaryRoot,
       captureTarget: vi.fn(),
       resolveTarget: vi.fn(),
-      relay: createRelayOwner(),
+      relay,
       persistence: createPersistence(),
       onEvent: vi.fn()
     })
@@ -817,6 +867,9 @@ describe('SideChatRuntimeOwner lifecycle', () => {
     await expect(owner.completeProjectDeletion('project-deleted')).rejects.toThrow(
       'Side chat Project cleanup failed: project-deleted'
     )
+    const retryRelayClaim = relay.claim('parent-deleted')
+    expect(retryRelayClaim?.messages).toEqual([expect.objectContaining({ id: 'relay-retry' })])
+    retryRelayClaim?.restore()
 
     owner.restoreProject('project-deleted')
     expect(owner.list().chats).toEqual([

--- a/src/main/side-chat/runtime-owner.test.ts
+++ b/src/main/side-chat/runtime-owner.test.ts
@@ -1880,10 +1880,16 @@ describe('SideChatRuntimeOwner lifecycle', () => {
     )
   })
 
-  it('keeps a Side chat retryable when durable close cleanup fails', async () => {
+  it('drains a failed in-flight close before Project invalidation and keeps it retryable', async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-side-chat-close-retry-'))
     const persistence = createPersistence()
-    persistence.clear.mockRejectedValueOnce(new Error('Session file is busy'))
+    const clearStarted = deferred<void>()
+    const failClear = deferred<void>()
+    persistence.clear.mockImplementationOnce(async () => {
+      clearStarted.resolve()
+      await failClear.promise
+      throw new Error('Session file is busy')
+    })
     const deleteSession = vi.fn(async () => ({ sessionIds: [] }))
     const owner = new SideChatRuntimeOwner({
       appVersion: '0.11.0',
@@ -1915,10 +1921,18 @@ describe('SideChatRuntimeOwner lifecycle', () => {
       text: 'Hello'
     })
 
-    await expect(owner.close({ sideSessionId: started.sideSessionId })).rejects.toThrow(
-      'Session file is busy'
+    const closeFailure = expect(
+      owner.close({ sideSessionId: started.sideSessionId })
+    ).rejects.toThrow('Session file is busy')
+    await clearStarted.promise
+    const invalidationFailure = expect(owner.invalidateProject('project-1')).rejects.toThrow(
+      'Side chat Project invalidation failed: project-1'
     )
+    failClear.resolve()
+
+    await Promise.all([closeFailure, invalidationFailure])
     expect(deleteSession).not.toHaveBeenCalled()
+    owner.restoreProject('project-1')
     expect(owner.list().chats).toContainEqual(
       expect.objectContaining({ sideSessionId: started.sideSessionId })
     )

--- a/src/main/side-chat/runtime-owner.test.ts
+++ b/src/main/side-chat/runtime-owner.test.ts
@@ -760,6 +760,29 @@ describe('SideChatRuntimeOwner lifecycle', () => {
       })
     ).rejects.toThrow('parent Project is unavailable')
     expect(captureTarget).not.toHaveBeenCalled()
+
+    owner.restoreProject('project-deleted')
+
+    expect(owner.list().chats).toEqual([
+      expect.objectContaining({ parentSessionId: 'parent-deleted', projectId: 'project-deleted' }),
+      expect.objectContaining({ parentSessionId: 'parent-kept', projectId: 'project-kept' })
+    ])
+    captureTarget.mockRejectedValueOnce(new Error('backend unavailable'))
+    await expect(
+      owner.start({
+        parentSessionId: 'another-parent',
+        projectId: 'project-deleted',
+        text: 'Available after rollback'
+      })
+    ).rejects.toThrow('backend unavailable')
+    expect(captureTarget).toHaveBeenCalledOnce()
+
+    await owner.invalidateProject('project-deleted')
+    owner.completeProjectDeletion('project-deleted')
+    owner.restoreProject('project-deleted')
+    expect(owner.list().chats).toEqual([
+      expect.objectContaining({ parentSessionId: 'parent-kept', projectId: 'project-kept' })
+    ])
   })
 
   it('publishes a terminal lifecycle event and keeps a disconnected runtime dormant', async () => {

--- a/src/main/side-chat/runtime-owner.test.ts
+++ b/src/main/side-chat/runtime-owner.test.ts
@@ -707,6 +707,13 @@ describe('SideChatRuntimeOwner lifecycle', () => {
     const persistence = createPersistence()
     const captureTarget = vi.fn()
     const relay = createRelayOwner()
+    const deletedProfile = join(
+      temporaryRoot,
+      'runtime-support',
+      'side-chat',
+      'side-chat-project-deleted'
+    )
+    await mkdir(deletedProfile, { recursive: true })
     relay.hydrate([
       {
         projectId: 'project-deleted',
@@ -774,11 +781,13 @@ describe('SideChatRuntimeOwner lifecycle', () => {
     ])
 
     await owner.invalidateProject('project-deleted')
+    await owner.invalidateParents(['parent-deleted'])
     const deletedRelayClaim = relay.claim('parent-deleted')
 
     expect(owner.list().chats).toEqual([
       expect.objectContaining({ parentSessionId: 'parent-kept', projectId: 'project-kept' })
     ])
+    await expect(access(deletedProfile)).resolves.toBeUndefined()
     expect(deletedRelayClaim?.messages).toEqual([expect.objectContaining({ id: 'relay-deleted' })])
     expect(persistence.clear).not.toHaveBeenCalled()
     await expect(
@@ -808,6 +817,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
 
     await owner.invalidateProject('project-deleted')
     await owner.completeProjectDeletion('project-deleted')
+    await expect(access(deletedProfile)).rejects.toThrow()
     expect(deletedRelayClaim?.commit()).toEqual([])
     deletedRelayClaim?.restore()
     expect(relay.claim('parent-deleted')).toBeUndefined()

--- a/src/main/side-chat/runtime-owner.test.ts
+++ b/src/main/side-chat/runtime-owner.test.ts
@@ -778,10 +778,52 @@ describe('SideChatRuntimeOwner lifecycle', () => {
     expect(captureTarget).toHaveBeenCalledOnce()
 
     await owner.invalidateProject('project-deleted')
-    owner.completeProjectDeletion('project-deleted')
+    await owner.completeProjectDeletion('project-deleted')
     owner.restoreProject('project-deleted')
     expect(owner.list().chats).toEqual([
       expect.objectContaining({ parentSessionId: 'parent-kept', projectId: 'project-kept' })
+    ])
+  })
+
+  it('retains dormant Side chats when Project profile cleanup fails', async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-side-chat-project-cleanup-'))
+    const owner = new SideChatRuntimeOwner({
+      appVersion: '0.11.0',
+      configRoot: temporaryRoot,
+      captureTarget: vi.fn(),
+      resolveTarget: vi.fn(),
+      relay: createRelayOwner(),
+      persistence: createPersistence(),
+      onEvent: vi.fn()
+    })
+    owner.hydrate([
+      {
+        projectId: 'project-deleted',
+        parentSessionId: 'parent-deleted',
+        sideChat: {
+          version: 1,
+          id: 'side-chat-\u0000-invalid',
+          lifecycle: 'open',
+          frameworkId: 'claude-code',
+          historyPreamble: '',
+          entries: [],
+          createdAt: 10,
+          updatedAt: 20
+        }
+      }
+    ])
+    await owner.invalidateProject('project-deleted')
+
+    await expect(owner.completeProjectDeletion('project-deleted')).rejects.toThrow(
+      'Side chat Project cleanup failed: project-deleted'
+    )
+
+    owner.restoreProject('project-deleted')
+    expect(owner.list().chats).toEqual([
+      expect.objectContaining({
+        parentSessionId: 'parent-deleted',
+        projectId: 'project-deleted'
+      })
     ])
   })
 

--- a/src/main/side-chat/runtime-owner.ts
+++ b/src/main/side-chat/runtime-owner.ts
@@ -336,11 +336,21 @@ class SideChatRuntimeOwner {
       revision: this.revision,
       chats: [
         ...[...this.startingByParent.values()]
-          .filter((starting) => !this.activeByParent.has(starting.parentSessionId))
+          .filter(
+            (starting) =>
+              !this.invalidatedProjects.has(starting.projectId) &&
+              !this.activeByParent.has(starting.parentSessionId)
+          )
           .map((starting) => this.snapshotStarting(starting)),
-        ...[...this.activeByParent.values()].map((active) => this.snapshotActive(active)),
+        ...[...this.activeByParent.values()]
+          .filter((active) => !this.invalidatedProjects.has(active.projectId))
+          .map((active) => this.snapshotActive(active)),
         ...[...this.dormantByParent.values()]
-          .filter((dormant) => !this.activeByParent.has(dormant.parentSessionId))
+          .filter(
+            (dormant) =>
+              !this.invalidatedProjects.has(dormant.projectId) &&
+              !this.activeByParent.has(dormant.parentSessionId)
+          )
           .map((dormant) => this.snapshotDormant(dormant))
       ]
     }
@@ -489,7 +499,11 @@ class SideChatRuntimeOwner {
       this.activeByParent.set(request.parentSessionId, activeChat)
       this.touch(activeChat)
       if (this.closeRequestedParents.delete(request.parentSessionId)) {
-        await this.closeActive(activeChat)
+        if (this.invalidatedProjects.has(request.projectId)) {
+          await this.suspendActive(activeChat, 'interrupted')
+        } else {
+          await this.closeActive(activeChat)
+        }
         throw new Error('Side chat closed before startup completed.')
       }
       await this.dispatch({
@@ -645,17 +659,56 @@ class SideChatRuntimeOwner {
 
   async invalidateProject(projectId: string): Promise<void> {
     this.invalidatedProjects.add(projectId)
-    const parentSessionIds = new Set<string>()
-    for (const starting of this.startingByParent.values()) {
-      if (starting.projectId === projectId) parentSessionIds.add(starting.parentSessionId)
+    const starting = [...this.startingByParent.values()].filter(
+      (candidate) => candidate.projectId === projectId
+    )
+    const activating = [...this.dormantByParent.values()].filter(
+      (candidate) => candidate.projectId === projectId && candidate.activating
+    )
+    for (const candidate of [...starting, ...activating]) {
+      this.closeRequestedParents.add(candidate.parentSessionId)
     }
-    for (const active of this.activeByParent.values()) {
-      if (active.projectId === projectId) parentSessionIds.add(active.parentSessionId)
+    const operations = [
+      ...[...this.activeByParent.values()]
+        .filter((active) => active.projectId === projectId)
+        .map((active) => this.suspendActive(active, 'interrupted')),
+      ...starting.map((candidate) => candidate.done.promise),
+      ...activating.map((candidate) =>
+        candidate.activating!.then(
+          () => undefined,
+          () => undefined
+        )
+      )
+    ]
+    const results = await Promise.allSettled(operations)
+    const failures = results.flatMap((result) =>
+      result.status === 'rejected' ? [result.reason] : []
+    )
+    if (failures.length > 0) {
+      throw new AggregateError(failures, `Side chat Project invalidation failed: ${projectId}`)
     }
+  }
+
+  restoreProject(projectId: string): void {
+    if (!this.invalidatedProjects.delete(projectId)) return
     for (const dormant of this.dormantByParent.values()) {
-      if (dormant.projectId === projectId) parentSessionIds.add(dormant.parentSessionId)
+      if (dormant.projectId !== projectId) continue
+      dormant.revision = ++this.revision
+      this.closeRequestedParents.delete(dormant.parentSessionId)
+      this.setParentInteractionsPaused(dormant.parentSessionId, true)
     }
-    await this.invalidateParents([...parentSessionIds])
+  }
+
+  completeProjectDeletion(projectId: string): void {
+    for (const dormant of [...this.dormantByParent.values()]) {
+      if (dormant.projectId !== projectId) continue
+      this.dormantByParent.delete(dormant.parentSessionId)
+      this.closeRequestedParents.delete(dormant.parentSessionId)
+      this.setParentInteractionsPaused(dormant.parentSessionId, false)
+      void rm(join(this.root, dormant.sideChat.id), { recursive: true, force: true }).catch(
+        () => undefined
+      )
+    }
   }
 
   async shutdown(): Promise<void> {
@@ -920,7 +973,11 @@ class SideChatRuntimeOwner {
       this.activeByParent.set(dormant.parentSessionId, activeChat)
       this.touch(activeChat)
       if (this.closeRequestedParents.delete(dormant.parentSessionId)) {
-        await this.closeActive(activeChat)
+        if (this.invalidatedProjects.has(dormant.projectId)) {
+          await this.suspendActive(activeChat, 'interrupted')
+        } else {
+          await this.closeActive(activeChat)
+        }
         throw new Error('Side chat closed while reconnecting.')
       }
       await this.persistActive(activeChat, 'open')
@@ -1371,7 +1428,10 @@ class SideChatRuntimeOwner {
   private async destroyActive(active: ActiveSideChat): Promise<void> {
     await this.flushQueuedPersistence(active)
     await active.persistTail.catch(() => undefined)
-    if (!this.invalidatedParents.has(active.parentSessionId)) {
+    if (
+      !this.invalidatedParents.has(active.parentSessionId) &&
+      !this.invalidatedProjects.has(active.projectId)
+    ) {
       await this.options.persistence.clear({
         projectId: active.projectId,
         parentSessionId: active.parentSessionId,
@@ -1398,7 +1458,10 @@ class SideChatRuntimeOwner {
     if (existing) return existing
     dormant.revision = ++this.revision
     const closing = (async (): Promise<void> => {
-      if (!this.invalidatedParents.has(dormant.parentSessionId)) {
+      if (
+        !this.invalidatedParents.has(dormant.parentSessionId) &&
+        !this.invalidatedProjects.has(dormant.projectId)
+      ) {
         await this.options.persistence.clear({
           projectId: dormant.projectId,
           parentSessionId: dormant.parentSessionId,

--- a/src/main/side-chat/runtime-owner.ts
+++ b/src/main/side-chat/runtime-owner.ts
@@ -1396,6 +1396,8 @@ class SideChatRuntimeOwner {
     active: ActiveSideChat,
     lifecycle: PersistedSideChat['lifecycle'] = active.turn ? 'interrupted' : 'open'
   ): Promise<void> {
+    const existing = this.closingByParent.get(active.parentSessionId)
+    if (existing) return existing
     if (active.closing || this.activeByParent.get(active.parentSessionId) !== active) return
     active.closing = true
     active.turnAccepted?.reject(new Error('Side chat runtime stopped.'))

--- a/src/main/side-chat/runtime-owner.ts
+++ b/src/main/side-chat/runtime-owner.ts
@@ -716,6 +716,7 @@ class SideChatRuntimeOwner {
     }
 
     for (const dormant of dormantChats) {
+      this.options.relay.releaseParent(dormant.parentSessionId)
       this.dormantByParent.delete(dormant.parentSessionId)
       this.closeRequestedParents.delete(dormant.parentSessionId)
       this.setParentInteractionsPaused(dormant.parentSessionId, false)

--- a/src/main/side-chat/runtime-owner.ts
+++ b/src/main/side-chat/runtime-owner.ts
@@ -645,9 +645,15 @@ class SideChatRuntimeOwner {
   }
 
   async invalidateParents(parentSessionIds: readonly string[]): Promise<void> {
-    for (const parentSessionId of parentSessionIds) this.invalidatedParents.add(parentSessionId)
+    const parentSessionIdsToInvalidate = parentSessionIds.filter((parentSessionId) => {
+      const dormant = this.dormantByParent.get(parentSessionId)
+      return !dormant || !this.invalidatedProjects.has(dormant.projectId)
+    })
+    for (const parentSessionId of parentSessionIdsToInvalidate) {
+      this.invalidatedParents.add(parentSessionId)
+    }
     await Promise.all(
-      parentSessionIds.map(async (parentSessionId) => {
+      parentSessionIdsToInvalidate.map(async (parentSessionId) => {
         try {
           await this.closeActiveForParent(parentSessionId)
         } finally {

--- a/src/main/side-chat/runtime-owner.ts
+++ b/src/main/side-chat/runtime-owner.ts
@@ -699,15 +699,26 @@ class SideChatRuntimeOwner {
     }
   }
 
-  completeProjectDeletion(projectId: string): void {
-    for (const dormant of [...this.dormantByParent.values()]) {
-      if (dormant.projectId !== projectId) continue
+  async completeProjectDeletion(projectId: string): Promise<void> {
+    const dormantChats = [...this.dormantByParent.values()].filter(
+      (dormant) => dormant.projectId === projectId
+    )
+    const cleanupResults = await Promise.allSettled(
+      dormantChats.map((dormant) =>
+        rm(join(this.root, dormant.sideChat.id), { recursive: true, force: true })
+      )
+    )
+    const cleanupFailures = cleanupResults.flatMap((result) =>
+      result.status === 'rejected' ? [result.reason] : []
+    )
+    if (cleanupFailures.length > 0) {
+      throw new AggregateError(cleanupFailures, `Side chat Project cleanup failed: ${projectId}`)
+    }
+
+    for (const dormant of dormantChats) {
       this.dormantByParent.delete(dormant.parentSessionId)
       this.closeRequestedParents.delete(dormant.parentSessionId)
       this.setParentInteractionsPaused(dormant.parentSessionId, false)
-      void rm(join(this.root, dormant.sideChat.id), { recursive: true, force: true }).catch(
-        () => undefined
-      )
     }
   }
 

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -506,6 +506,7 @@
   "Delete project?": "删除项目？",
   "Delete {{name}}": "删除 {{name}}",
   "Delete “{{name}}”?": "删除“{{name}}”？",
+  "Deleting this project will stop its running tasks and notebooks.": "删除此项目将停止其正在运行的任务和 Notebook。",
   "Deleting…": "删除中…",
   "Deny": "拒绝",
   "Dependency impact": "依赖影响",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -505,6 +505,7 @@
   "Delete project?": "刪除專案？",
   "Delete {{name}}": "刪除 {{name}}",
   "Delete “{{name}}”?": "刪除「{{name}}」？",
+  "Deleting this project will stop its running tasks and notebooks.": "刪除此專案將停止其正在執行的任務和 Notebook。",
   "Deleting…": "刪除中…",
   "Deny": "拒絕",
   "Dependency impact": "相依影響",

--- a/src/renderer/src/pages/home/DeleteProjectDialog.tsx
+++ b/src/renderer/src/pages/home/DeleteProjectDialog.tsx
@@ -104,7 +104,8 @@ const DeleteProjectDialog = ({
                     {
                       name: dialogProject?.name
                     }
-                  )}
+                  )}{' '}
+              {t('Deleting this project will stop its running tasks and notebooks.')}
             </AlertDialog.Description>
             {error ? (
               <p className="mt-4 text-sm text-danger-000" role="alert">

--- a/src/renderer/src/pages/home/home-dialogs.render.test.tsx
+++ b/src/renderer/src/pages/home/home-dialogs.render.test.tsx
@@ -251,6 +251,7 @@ describe('home dialogs shared chrome', () => {
     expect(text).toContain(
       'Generated artifacts and uploaded files stored by Open Science will also be deleted.'
     )
+    expect(text).toContain('Deleting this project will stop its running tasks and notebooks.')
     expect(text).toContain("Files in the project's working folder are not deleted.")
     expect(text).not.toContain('Generated artifacts remain on disk')
   })

--- a/src/renderer/src/pages/settings/ArchivedPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ArchivedPanel.render.test.tsx
@@ -37,6 +37,7 @@ describe('ArchivedPanel', () => {
   let container: HTMLDivElement
   let root: Root
   const updateArchive = vi.fn()
+  const deleteProject = vi.fn()
   const deleteSession = vi.fn()
 
   beforeEach(() => {
@@ -44,6 +45,7 @@ describe('ArchivedPanel', () => {
     document.body.appendChild(container)
     root = createRoot(container)
     updateArchive.mockReset().mockResolvedValue({ ...session, archivedAt: undefined })
+    deleteProject.mockReset().mockResolvedValue(undefined)
     deleteSession.mockReset().mockResolvedValue(undefined)
     window.api = {
       sessions: { updateArchive, deleteSession },
@@ -52,7 +54,8 @@ describe('ArchivedPanel', () => {
     useProjectStore.setState({
       ...createInitialProjectState(),
       projects: [project],
-      isLoaded: true
+      isLoaded: true,
+      deleteProject
     })
     useSessionStore.setState({ ...createInitialSessionState(), sessions: [session] })
     useArchiveUndoStore.setState({ notices: [], restoringKey: undefined })
@@ -157,5 +160,39 @@ describe('ArchivedPanel', () => {
     dialog = document.body.querySelector<HTMLElement>('[role="alertdialog"]')
 
     expect(dialog?.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  it('delegates archived Project runtime cleanup to the main deletion coordinator', async () => {
+    const archivedProject = { ...project, archivedAt: 2 }
+    useProjectStore.setState({
+      ...createInitialProjectState(),
+      projects: [archivedProject],
+      isLoaded: true,
+      deleteProject
+    })
+    const onNavigate = vi.fn()
+    await act(async () =>
+      root.render(
+        <ArchivedPanel
+          view={{ kind: 'project', projectId: archivedProject.id }}
+          onNavigate={onNavigate}
+        />
+      )
+    )
+
+    const openDelete = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.includes('Delete project')
+    )
+    await act(async () => openDelete?.click())
+    const dialog = document.body.querySelector<HTMLElement>('[role=alertdialog]')
+    const confirmDelete = Array.from(
+      dialog?.querySelectorAll<HTMLButtonElement>('button') ?? []
+    ).find((button) => button.textContent === 'Delete')
+    await act(async () => confirmDelete?.click())
+
+    expect(deleteProject).toHaveBeenCalledWith(project.id)
+    expect(window.api.acp.getState).not.toHaveBeenCalled()
+    expect(window.api.acp.deleteSession).not.toHaveBeenCalled()
+    expect(onNavigate).toHaveBeenCalledWith({ kind: 'list' })
   })
 })

--- a/src/renderer/src/pages/settings/ArchivedPanel.tsx
+++ b/src/renderer/src/pages/settings/ArchivedPanel.tsx
@@ -137,13 +137,6 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
     setBusyKey(`project:${project.id}`)
     setProjectDeleteError(undefined)
     void (async () => {
-      const state = await window.api.acp.getState()
-      const liveIds = new Set(state.sessionIds)
-      for (const session of sessions) {
-        if (session.projectId === project.id && liveIds.has(session.id)) {
-          await window.api.acp.deleteSession({ sessionId: session.id })
-        }
-      }
       await deleteProject(project.id)
       useSessionStore.getState().removeSessionsForProject(project.id)
       useArchiveUndoStore.getState().dismissProject(project.id)


### PR DESCRIPTION
## Problem

Project deletion did not have one main-process runtime boundary:

- Home deletion called the Project deletion coordinator directly.
- Archived Settings deletion first closed only renderer-visible ACP sessions, then called the coordinator.
- Delegation work, idle Notebook kernels, Notebook Frame lanes, and other main-process owners could therefore outlive durable Project/Session authority.

This occurs when a Project has live work during deletion, especially when deletion starts outside Archived Settings or when the renderer session catalog is incomplete. The result can be a deleted Project whose task, subprocess, kernel, or side effect continues to run.

The initial coordinator fix also exposed admission and drain races. Concurrent ACP create/resume/prompt, app-owned continuation, late Delegation child, Notebook lane creation, restart, or execution could publish or write after shutdown began.

The renderer-facing ACP snapshot intentionally hides idle sessions in retired runtime generations, and the active Delegation projection excludes dormant persisted Frame workspaces. Deletion could therefore miss owned ACP/provider sessions and copied Delegation inputs or Frame files. Delegation permission restoration also needed to treat symbolic links as leaves so cleanup could not chmod caller-owned targets outside the Project subtree.

Side Chat invalidation originally became permanent as soon as pre-delete quiescence started. A later quiescence failure could leave the visible Project unable to use its existing Side Chat.

The irreversible deletion tail swallowed Preview and Review cleanup errors after the Project row had been removed. It then completed the Session tombstone and removed ProjectDeletionIntent, leaving no durable retry anchor for orphan rows.

A subsequent ordering exposed another crash boundary: destructive runtime and Delegation workspace cleanup ran before ProjectDeletionIntent was persisted. A crash or intent/session failure could leave a visible Project with deleted runtime data and no retry authority. Conversely, durable recovery did not replay runtime/Delegation cleanup.

## Proposed change

- Persist the existing ProjectDeletionIntent before any destructive runtime cleanup.
- Restore all existing Project admission barriers from that intent, then run one fail-closed ProjectRuntimeQuiescenceOwner before deleting Project/Session authority.
- Make the Archive Project deletion fence re-entrant for recovery and retain it after teardown failures.
- Replay runtime quiescence for every pending intent and adopted incomplete Session tombstone before recovery continues durable deletion. Start the background recovery module only after ACP, Delegation, Notebook, Side Chat, and the composed quiescence owner are initialized; early barrier restoration remains unchanged.
- Serialize ACP Session create/resume and final provider dispatch with the Project fence. User prompts keep their existing archive and Side Chat checks; app-owned continuations receive only the deletion fence so existing recovery semantics remain unchanged.
- Route direct Electron ACP reset/compact through the same Session admission and hold it through the runtime mutation so context reset cannot recreate providers after quiescence.
- Enumerate ACP cleanup from the coordinator's complete owned-session set so idle sessions in retired generations are also torn down.
- After ACP teardown closes the source of new delegated work, settle cached Delegation work and remove the authoritative Project workspace subtree. Retain failed owners and permission routes for retry.
- Filter cached Delegation work by Project identity before awaiting initialization, so another Project's pending or rejected work cannot block this deletion.
- Treat Delegation workspace symlinks as leaf entries while restoring delete permissions, then unlink them without traversing or chmodding their targets.
- Hold delegated parent-message delivery in the Project deletion admission queue through durable validation, optional ACP resume, and provider acceptance, then re-enumerate ACP ownership after Delegation cleanup.
- Add Notebook Project admission fencing, synchronously register per-Project operation leases, drain admitted restart/execution/state/binding operations, then shut down all in-memory root and Frame lanes.
- Make Side Chat Project invalidation provisional: suspend and hide chats during quiescence, restore dormant chats only when deletion authority is explicitly aborted, and discard them after deletion completes.
- Run fallible Side Chat profile cleanup in a dedicated finalization phase before removing the existing Session tombstone and ProjectDeletionIntent; release Archive and Notebook fences only after both durable retry markers are gone.
- Retain the existing Compute orphan reconciliation in the same boundary.
- Remove the Archived Settings ACP-only workaround so every Project deletion entry uses the coordinator.
- Attempt both Preview and Review cleanup; if either fails, reject and retain ProjectDeletionIntent and the Session tombstone for retry.
- Tell users in the confirmation dialog that deletion stops running tasks and notebooks, with Simplified and Traditional Chinese translations.

## Scope and non-goals

- Forward-only: no scan or migration is added for historical orphan Preview/Review or runtime data; existing historical orphans without an intent/tombstone remain.
- Existing incomplete ProjectDeletionIntent and Session tombstones continue their existing recovery and now replay runtime/Delegation cleanup before completing.
- No new database fields, tables, indexes, foreign keys, migrations, or data-model relationships.
- No new persisted or public status/enum values.
- New transient state is limited to in-memory Project deletion fences and a per-Project set of pending Notebook operation promises. Side Chat reuses its existing invalidation and dormant projections.
- No IPC contract or renderer data-model change.
- The internal ProjectDeletionLifecycle gains one asynchronous finalization hook that may reject before durable retry markers are removed; the existing completion hook remains the post-commit fence release.
- Persistence behavior changes only through existing records and formats: ProjectDeletionIntent is now written before runtime cleanup and retained after every post-intent failure; existing Side Chat projections may use their existing interrupted lifecycle during quiescence; existing Session tombstones remain until all derived cleanup succeeds. No new persistent record or format is introduced.
- The existing confirmation dialog, pending state, inline error, and retry UI remain. Interaction semantics after failure are fail-closed: if intent creation fails no runtime teardown starts; after intent exists, a still-visible Project remains unavailable while explicit or background recovery retries and may later complete deletion.

## Acceptance criteria and validation

Passing focused checks after the latest material implementation:

- Delegation Project isolation, Side Chat cleanup propagation, durable finalization ordering, runtime quiescence, and production wiring architecture -> 5 module files -> 113 passed.
- Direct ACP reset/compact Session admission and production adapter wiring -> 4 module files -> 74 passed.
- Recovery startup ordering and existing barrier/recovery composition contract -> Compute architecture module -> 10 passed.
- Intent-first ordering, retryable Archive fence, recovery-time runtime cleanup, Project runtime quiescence, Side Chat rollback, and Notebook operation draining -> 5 module files -> 269 passed, 5 skipped.
- Final coordinator rerun after the recovery-block simplification -> 29 passed.
- Previous review-specific Delegation, Side Chat, Project lifecycle, and Notebook validation -> 4 module files -> 253 passed, 6 skipped.
- Earlier cumulative admission-fencing, ACP ownership, ACP dispatch, Delegation cleanup, Notebook creation, rollback/completion, and derived retry validation -> 8 module files -> 345 passed, 5 skipped.
- Earlier adjacent Project IPC, ACP workflows/IPC/Task port, Notebook commands/IPC/application, and application command wiring -> 8 module files -> 98 passed.
- Targeted ESLint for the latest changed files -> passed.
- Formatting -> changed files pass Prettier check.
- Whitespace -> git diff --check -> passed.

Earlier focused validation retained by this PR:

- Confirmation interaction -> targeted home dialog test -> 1 passed.
- Locale persistence -> both locale catalogs parsed and the new key/value was asserted -> passed.

Local verification boundaries:

- Node TypeScript check reports only the existing stale Prisma assessmentSnapshot generated type and missing local sharp/i18next dependencies in unchanged files; no changed-file errors.
- Exact-head impact classification selects the complete suite because src/main/ipc.ts has no module owner mapping. Per maintainer direction, the complete npm test suite is left to PR CI.

## Review focus

- Confirm ProjectDeletionIntent is durable before any destructive runtime or Delegation cleanup.
- Confirm both online deletion and pending-intent recovery establish barriers and replay quiescence before Session/Project authority is removed.
- Confirm a post-intent failure retains the intent and admission fence, while an intent-write failure performs no runtime teardown.
- Confirm ACP dispatch and delegated parent-message paths cannot publish new Project work after the fence.
- Confirm Project teardown covers coordinator-owned ACP sessions, dormant Delegation workspaces, and symlink-safe cleanup.
- Confirm Notebook admitted operations drain before lane shutdown.
- Confirm Side Chat remains recoverable only for an explicitly aborted deletion and is discarded after successful deletion.
- Confirm Preview/Review failure retains ProjectDeletionIntent and the Session tombstone after Project hard delete.

