### PR TITLE
fix(web): replay missed events after reconnect

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -386,10 +386,10 @@ colors communicate a successful or failed probe/migration result.
 - The App Shell presentation owner selects the only root presentation allowed to be interactive.
   Feature stores retain their own requested/open state; they do not coordinate presentation order
   with one another.
-- Root presentation priority is fixed: close confirmation, missing data-root recovery, legacy data
-  move, update, compute approval, Connector approval, Skill import approval, global search, Settings,
-  preview, then base content. A covered presentation stays requested and resumes when higher-priority
-  work clears.
+- Root presentation priority is fixed: close confirmation, Web event recovery, missing data-root
+  recovery, legacy data move, update, compute approval, Connector approval, Skill import approval,
+  global search, Settings, preview, then base content. A covered presentation stays requested and
+  resumes when higher-priority work clears.
 - Session visibility, App Shell shortcut eligibility, and `Cmd/Ctrl+W` routing must consume that
   projection. Do not rebuild parallel Boolean gate lists in `AppContent` or feature components.
 - When a presentation above preview/base owns the shell, base content is `inert` and

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -14,7 +14,11 @@ vi.mock('electron', () => ({
 
 import { WEB_INVOKE_CHANNELS } from '../../shared/web-api-map.generated'
 import { ApplicationCommandError } from '../../shared/application-command-contract'
-import { isWebRpcChannel, WEB_RPC_PROTOCOL_VERSION } from '../../shared/web-rpc-contract'
+import {
+  isWebRpcChannel,
+  WEB_EVENT_STREAM_PROTOCOL_VERSION,
+  WEB_RPC_PROTOCOL_VERSION
+} from '../../shared/web-rpc-contract'
 import { ApplicationEventHub } from '../application-events'
 import type { CallerContext } from '../caller-context'
 import {
@@ -472,6 +476,118 @@ describe('startWebHttpServer', () => {
         }
       ])
     })
+    publicSocket.close()
+  })
+
+  it('replays internal renderer events published while the Web client is disconnected', async () => {
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      rpc: {
+        channels: () => [],
+        invoke: vi.fn(),
+        releaseClient: vi.fn(),
+        dispose: vi.fn()
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const base = `http://127.0.0.1:${server.port}`
+    const bootstrap = (await (
+      await fetch(`${base}/api/bootstrap`, {
+        headers: { authorization: 'Bearer test-token' }
+      })
+    ).json()) as {
+      eventStream: {
+        protocolVersion: number
+        streamId: string
+        latestSequence: number
+      }
+    }
+    expect(bootstrap.eventStream).toMatchObject({
+      protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+      latestSequence: 0
+    })
+
+    const eventSocketUrl = (after: number): string => {
+      const url = new URL(`${base.replace('http:', 'ws:')}/events`)
+      url.searchParams.set('token', 'test-token')
+      url.searchParams.set('client', 'replay-client')
+      url.searchParams.set('eventProtocol', String(WEB_EVENT_STREAM_PROTOCOL_VERSION))
+      url.searchParams.set('stream', bootstrap.eventStream.streamId)
+      url.searchParams.set('after', String(after))
+      return url.toString()
+    }
+
+    const firstSocket = new WebSocket(eventSocketUrl(0))
+    const firstMessage = new Promise<unknown>((resolve) =>
+      firstSocket.once('message', (data) => resolve(JSON.parse(data.toString())))
+    )
+    await new Promise<void>((resolve) => firstSocket.once('open', resolve))
+    await expect(firstMessage).resolves.toMatchObject({ kind: 'ready', latestSequence: 0 })
+    const firstClosed = new Promise<void>((resolve) => firstSocket.once('close', () => resolve()))
+    firstSocket.close()
+    await firstClosed
+
+    applicationEvents.publish('acp:permission-request', {
+      sessionId: 'session-1',
+      requestId: 'permission-1',
+      toolCallId: 'tool-1',
+      title: 'Run command',
+      options: []
+    })
+    applicationEvents.publish('settings:connector-runtime-changed', undefined)
+
+    const replayed: unknown[] = []
+    const secondSocket = new WebSocket(eventSocketUrl(0))
+    secondSocket.on('message', (data) => replayed.push(JSON.parse(data.toString())))
+    await new Promise<void>((resolve) => secondSocket.once('open', resolve))
+    await vi.waitFor(() => expect(replayed).toHaveLength(3))
+    expect(replayed).toEqual([
+      expect.objectContaining({
+        kind: 'event',
+        sequence: 1,
+        channel: 'acp:permission-request',
+        payload: expect.objectContaining({ requestId: 'permission-1' })
+      }),
+      expect.objectContaining({
+        kind: 'event',
+        sequence: 2,
+        channel: 'settings:connector-runtime-changed',
+        payload: null
+      }),
+      expect.objectContaining({ kind: 'ready', latestSequence: 2 })
+    ])
+    secondSocket.close()
+
+    const publicMessages: unknown[] = []
+    const publicSocket = new WebSocket(
+      `${base.replace('http:', 'ws:')}/api/v1/events?token=test-token`
+    )
+    publicSocket.on('message', (data) => publicMessages.push(JSON.parse(data.toString())))
+    await new Promise<void>((resolve) => publicSocket.once('open', resolve))
+    applicationEvents.publish('acp:permission-request', {
+      sessionId: 'session-1',
+      requestId: 'permission-live',
+      toolCallId: 'tool-live',
+      title: 'Run another command',
+      options: []
+    })
+    await vi.waitFor(() => expect(publicMessages).toHaveLength(1))
+    expect(publicMessages).toEqual([
+      expect.objectContaining({
+        type: 'permission.requested',
+        data: expect.objectContaining({ requestId: 'permission-live' })
+      })
+    ])
     publicSocket.close()
   })
 

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -22,6 +22,7 @@ import { createApplicationCommandClient } from '../application-command-client'
 import type { ApplicationCommandComposition } from '../application-command-composition'
 import type { ApplicationEventSource } from '../application-events'
 import {
+  WEB_EVENT_STREAM_PROTOCOL_VERSION,
   isWebRpcChannel,
   WEB_RPC_PROTOCOL_VERSION,
   webRpcRequestSchema
@@ -32,6 +33,7 @@ import {
   projectPublicTaskProgressEvent,
   projectWebRendererEvent
 } from './application-event-projections'
+import { InternalWebEventStream } from './internal-web-event-stream'
 import { authenticateRequest, persistAuthCookie } from './auth'
 import type { StartTaskRunRequest } from '../../shared/task-api'
 import { TaskApiError, type HeadlessTaskApi } from './task-api'
@@ -438,6 +440,8 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
   const sockets = new Set<WebSocket>()
   const externalSockets = new Map<WebSocket, string | undefined>()
   const publicEventSockets = new Set<WebSocket>()
+  const internalEventSockets = new Map<WebSocket, 'legacy' | 'replay'>()
+  const internalEventStream = new InternalWebEventStream()
   const commandClient = createApplicationCommandClient()
   const clientLeases = new ClientLeaseRegistry((clientId) => {
     commandClient.releaseClient('web', clientId)
@@ -483,6 +487,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
           ...options.bootstrap,
           rpcProtocolVersion: WEB_RPC_PROTOCOL_VERSION,
           rpcChannels,
+          eventStream: internalEventStream.cursor(),
           restrictedRpcChannels
         })
         return
@@ -676,27 +681,55 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
     const url = new URL(request.url ?? '/', `http://${request.headers.host ?? '127.0.0.1'}`)
     const clientId = url.searchParams.get('client') ?? 'web'
     const lease = clientLeases.acquire(clientId)
-    sockets.add(socket)
-    if (url.pathname === '/api/v1/events') publicEventSockets.add(socket)
     socket.on('close', () => {
       sockets.delete(socket)
       externalSockets.delete(socket)
       publicEventSockets.delete(socket)
+      internalEventSockets.delete(socket)
       lease.release()
     })
+    if (url.pathname === '/api/v1/events') {
+      publicEventSockets.add(socket)
+    } else {
+      const requestedProtocol = url.searchParams.get('eventProtocol')
+      // A page loaded before this server upgrade has no cursor query. Keep it live-only until its
+      // next reload instead of breaking an already-open Web surface.
+      if (requestedProtocol === null) {
+        internalEventSockets.set(socket, 'legacy')
+      } else if (requestedProtocol !== String(WEB_EVENT_STREAM_PROTOCOL_VERSION)) {
+        socket.close(1002, 'Unsupported event stream protocol')
+        return
+      } else {
+        internalEventSockets.set(socket, 'replay')
+        const streamId = url.searchParams.get('stream') ?? ''
+        const afterValue = url.searchParams.get('after')
+        const after = afterValue === null ? Number.NaN : Number(afterValue)
+        for (const message of internalEventStream.resume({ streamId, after })) {
+          socket.send(message)
+        }
+      }
+    }
+    sockets.add(socket)
   })
 
   const removeBroadcastSink = options.applicationEvents.subscribe((event) => {
     const internalProjection = projectWebRendererEvent(event)
     const publicProjection = projectPublicTaskEvent(event)
-    const internalMessage = internalProjection ? JSON.stringify(internalProjection) : undefined
+    const legacyInternalMessage = internalProjection
+      ? JSON.stringify(internalProjection)
+      : undefined
+    const replayInternalMessage = internalProjection
+      ? internalEventStream.publish(internalProjection)
+      : undefined
     const publicMessage = publicProjection ? JSON.stringify(publicProjection) : undefined
     for (const socket of sockets) {
       if (socket.readyState !== WebSocket.OPEN) continue
       if (publicEventSockets.has(socket)) {
         if (publicMessage) socket.send(publicMessage)
-      } else if (internalMessage) {
-        socket.send(internalMessage)
+      } else if (internalEventSockets.get(socket) === 'replay') {
+        if (replayInternalMessage) socket.send(replayInternalMessage)
+      } else if (legacyInternalMessage) {
+        socket.send(legacyInternalMessage)
       }
     }
   })

--- a/src/main/web-service/internal-web-event-stream.test.ts
+++ b/src/main/web-service/internal-web-event-stream.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+
+import { WEB_EVENT_STREAM_PROTOCOL_VERSION } from '../../shared/web-rpc-contract'
+import { InternalWebEventStream } from './internal-web-event-stream'
+
+const parseFrames = (frames: readonly string[]): unknown[] =>
+  frames.map((frame) => JSON.parse(frame))
+
+describe('InternalWebEventStream', () => {
+  it('replays retained event frames in sequence before declaring the stream live', () => {
+    const stream = new InternalWebEventStream({
+      streamId: 'stream-1',
+      maxFrames: 10,
+      maxBytes: 10_000
+    })
+
+    stream.publish({ channel: 'project:created', payload: { id: 'project-1' } })
+    stream.publish({ channel: 'settings:changed', payload: undefined })
+
+    expect(parseFrames(stream.resume({ streamId: 'stream-1', after: 0 }))).toEqual([
+      {
+        kind: 'event',
+        protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+        streamId: 'stream-1',
+        sequence: 1,
+        channel: 'project:created',
+        payload: { id: 'project-1' }
+      },
+      {
+        kind: 'event',
+        protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+        streamId: 'stream-1',
+        sequence: 2,
+        channel: 'settings:changed',
+        payload: null
+      },
+      {
+        kind: 'ready',
+        protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+        streamId: 'stream-1',
+        latestSequence: 2
+      }
+    ])
+  })
+
+  it('requires resynchronization when the requested suffix was evicted by frame count', () => {
+    const stream = new InternalWebEventStream({
+      streamId: 'stream-1',
+      maxFrames: 2,
+      maxBytes: 10_000
+    })
+
+    stream.publish({ channel: 'settings:changed', payload: { revision: 1 } })
+    stream.publish({ channel: 'settings:changed', payload: { revision: 2 } })
+    stream.publish({ channel: 'settings:changed', payload: { revision: 3 } })
+
+    expect(parseFrames(stream.resume({ streamId: 'stream-1', after: 0 }))).toEqual([
+      {
+        kind: 'resync-required',
+        protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+        streamId: 'stream-1',
+        latestSequence: 3,
+        reason: 'cursor-expired'
+      }
+    ])
+  })
+
+  it('evicts by aggregate serialized bytes while retaining a contiguous suffix', () => {
+    const event = { channel: 'settings:changed', payload: { revision: 1 } }
+    const probe = new InternalWebEventStream({
+      streamId: 'stream-1',
+      maxFrames: 10,
+      maxBytes: 10_000
+    })
+    const frameBytes = Buffer.byteLength(probe.publish(event))
+    const stream = new InternalWebEventStream({
+      streamId: 'stream-1',
+      maxFrames: 10,
+      maxBytes: frameBytes * 2 - 1
+    })
+
+    stream.publish(event)
+    stream.publish({ ...event, payload: { revision: 2 } })
+
+    expect(parseFrames(stream.resume({ streamId: 'stream-1', after: 0 }))).toEqual([
+      expect.objectContaining({ kind: 'resync-required', reason: 'cursor-expired' })
+    ])
+    expect(parseFrames(stream.resume({ streamId: 'stream-1', after: 1 }))).toEqual([
+      expect.objectContaining({ kind: 'event', sequence: 2 }),
+      expect.objectContaining({ kind: 'ready', latestSequence: 2 })
+    ])
+  })
+
+  it('requires resynchronization when a frame is too large to retain', () => {
+    const stream = new InternalWebEventStream({
+      streamId: 'stream-1',
+      maxFrames: 10,
+      maxBytes: 1
+    })
+
+    stream.publish({ channel: 'settings:changed', payload: { value: 'not-retained' } })
+
+    expect(parseFrames(stream.resume({ streamId: 'stream-1', after: 0 }))).toEqual([
+      {
+        kind: 'resync-required',
+        protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+        streamId: 'stream-1',
+        latestSequence: 1,
+        reason: 'cursor-expired'
+      }
+    ])
+  })
+
+  it('requires resynchronization when the server process stream changes', () => {
+    const stream = new InternalWebEventStream({
+      streamId: 'stream-new',
+      maxFrames: 10,
+      maxBytes: 10_000
+    })
+
+    expect(parseFrames(stream.resume({ streamId: 'stream-old', after: 4 }))).toEqual([
+      {
+        kind: 'resync-required',
+        protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+        streamId: 'stream-new',
+        latestSequence: 0,
+        reason: 'stream-changed'
+      }
+    ])
+  })
+})

--- a/src/main/web-service/internal-web-event-stream.ts
+++ b/src/main/web-service/internal-web-event-stream.ts
@@ -1,0 +1,124 @@
+import { randomUUID } from 'node:crypto'
+
+import { WEB_EVENT_STREAM_PROTOCOL_VERSION } from '../../shared/web-rpc-contract'
+
+const DEFAULT_MAX_FRAMES = 2_048
+// This buffer is deliberately process-local. A restart creates a new stream id, which makes clients
+// stop and reload instead of assuming an in-memory suffix survived.
+const DEFAULT_MAX_BYTES = 16 * 1024 * 1024
+
+type InternalWebEvent = Readonly<{
+  channel: string
+  payload: unknown
+}>
+
+type InternalWebEventStreamOptions = Readonly<{
+  streamId?: string
+  maxFrames?: number
+  maxBytes?: number
+}>
+
+type ResumeCursor = Readonly<{
+  streamId: string
+  after: number
+}>
+
+type RetainedFrame = Readonly<{
+  sequence: number
+  serialized: string
+  bytes: number
+}>
+
+class InternalWebEventStream {
+  readonly #streamId: string
+  readonly #maxFrames: number
+  readonly #maxBytes: number
+  readonly #frames: RetainedFrame[] = []
+  #latestSequence = 0
+  #retainedBytes = 0
+
+  constructor(options: InternalWebEventStreamOptions = {}) {
+    this.#streamId = options.streamId ?? randomUUID()
+    this.#maxFrames = options.maxFrames ?? DEFAULT_MAX_FRAMES
+    this.#maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES
+  }
+
+  cursor(): Readonly<{
+    protocolVersion: typeof WEB_EVENT_STREAM_PROTOCOL_VERSION
+    streamId: string
+    latestSequence: number
+  }> {
+    return {
+      protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+      streamId: this.#streamId,
+      latestSequence: this.#latestSequence
+    }
+  }
+
+  publish(event: InternalWebEvent): string {
+    const sequence = ++this.#latestSequence
+    const serialized = JSON.stringify({
+      kind: 'event',
+      protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+      streamId: this.#streamId,
+      sequence,
+      channel: event.channel,
+      payload: event.payload ?? null
+    })
+    const bytes = Buffer.byteLength(serialized)
+
+    if (bytes > this.#maxBytes || this.#maxFrames === 0) {
+      this.#frames.splice(0)
+      this.#retainedBytes = 0
+      return serialized
+    }
+
+    this.#frames.push({ sequence, serialized, bytes })
+    this.#retainedBytes += bytes
+    while (this.#frames.length > this.#maxFrames || this.#retainedBytes > this.#maxBytes) {
+      const removed = this.#frames.shift()
+      if (removed) this.#retainedBytes -= removed.bytes
+    }
+    return serialized
+  }
+
+  resume(cursor: ResumeCursor): readonly string[] {
+    if (cursor.streamId !== this.#streamId) return [this.#resyncRequired('stream-changed')]
+
+    const oldestSequence = this.#frames[0]?.sequence
+    if (
+      !Number.isSafeInteger(cursor.after) ||
+      cursor.after < 0 ||
+      cursor.after > this.#latestSequence ||
+      (cursor.after < this.#latestSequence &&
+        (oldestSequence === undefined || cursor.after < oldestSequence - 1))
+    ) {
+      return [this.#resyncRequired('cursor-expired')]
+    }
+
+    return [
+      ...this.#frames
+        .filter(({ sequence }) => sequence > cursor.after)
+        .map(({ serialized }) => serialized),
+      JSON.stringify({
+        kind: 'ready',
+        protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+        streamId: this.#streamId,
+        latestSequence: this.#latestSequence
+      })
+    ]
+  }
+
+  #resyncRequired(reason: 'stream-changed' | 'cursor-expired'): string {
+    return JSON.stringify({
+      kind: 'resync-required',
+      protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+      streamId: this.#streamId,
+      latestSequence: this.#latestSequence,
+      reason
+    })
+  }
+}
+
+export { InternalWebEventStream }
+export type { InternalWebEventStreamOptions, ResumeCursor }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -16,6 +16,7 @@ import { PermissionUndoSnackbar } from '@/components/PermissionUndoSnackbar'
 import { SessionPersistenceAlert } from '@/components/SessionPersistenceAlert'
 import { UpdateDialog } from '@/components/UpdateDialog'
 import { GlobalSearchDialog } from '@/components/global-search/GlobalSearchDialog'
+import { WebEventRecoveryDialog } from '@/components/WebEventRecoveryDialog'
 import { Button } from '@/components/ui/button'
 import { resolveAppShellPresentation } from '@/app-shell-presentation-owner'
 import { HomePage } from '@/pages/home/HomePage'
@@ -39,6 +40,7 @@ import { useLifecycleSync } from '@/hooks/useLifecycleSync'
 import { useQuitPersistenceFlush } from '@/hooks/useQuitPersistenceFlush'
 import { useUnreadTaskViewSync } from '@/hooks/useUnreadTaskViewSync'
 import { useWindowFindAppearanceSync } from '@/hooks/useWindowFindAppearanceSync'
+import { useWebEventConnection } from '@/hooks/useWebEventConnection'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useNotebookEnvStore } from '@/stores/notebook-env-store'
 import { useProjectStore } from '@/stores/project-store'
@@ -185,6 +187,9 @@ const AppContent = (): React.JSX.Element | null => {
   const startupView = isSettingsLoaded
     ? resolveStartupView({ onboardingDone: onboardingCompletedAt !== undefined })
     : undefined
+  const webEventConnectionPhase = useWebEventConnection(
+    startupView === 'app' && isSessionPersistenceHydrated
+  )
   const appShellPresentation = useMemo(
     () =>
       resolveAppShellPresentation({
@@ -194,6 +199,7 @@ const AppContent = (): React.JSX.Element | null => {
         view,
         presentations: {
           closeConfirmation: isCloseConfirmOpen,
+          webEventRecovery: webEventConnectionPhase !== 'live',
           dataRootRecovery: missingDataRoot !== undefined,
           legacyDataMove: legacyMove !== undefined,
           update: isUpdateDialogOpen,
@@ -219,6 +225,7 @@ const AppContent = (): React.JSX.Element | null => {
       legacyMove,
       missingDataRoot,
       startupView,
+      webEventConnectionPhase,
       view
     ]
   )
@@ -623,6 +630,10 @@ const AppContent = (): React.JSX.Element | null => {
         />
         <PermissionUndoSnackbar />
       </div>
+      <WebEventRecoveryDialog
+        active={activePresentation === 'webEventRecovery'}
+        phase={webEventConnectionPhase}
+      />
       <SettingsPage
         ref={settingsPageRef}
         open={activePresentation === 'settings'}

--- a/src/renderer/src/app-shell-presentation-owner.test.ts
+++ b/src/renderer/src/app-shell-presentation-owner.test.ts
@@ -9,6 +9,7 @@ import {
 
 const noPresentations = (): AppShellPresentationState => ({
   closeConfirmation: false,
+  webEventRecovery: false,
   dataRootRecovery: false,
   legacyDataMove: false,
   update: false,
@@ -36,6 +37,7 @@ describe('App Shell presentation owner', () => {
   it('selects one presentation from the fixed semantic priority', () => {
     const priority: Array<keyof AppShellPresentationState> = [
       'closeConfirmation',
+      'webEventRecovery',
       'dataRootRecovery',
       'legacyDataMove',
       'update',
@@ -125,6 +127,7 @@ describe('App Shell presentation owner', () => {
     ['computeApproval', { computeApproval: true }, {}, 'consume'],
     ['connectorApproval', { connectorApproval: true }, {}, 'consume'],
     ['skillImportApproval', { skillImportApproval: true }, {}, 'consume'],
+    ['webEventRecovery', { webEventRecovery: true }, {}, 'consume'],
     ['globalSearch', { globalSearch: true }, {}, 'close-global-search'],
     ['settings', { settings: true }, {}, 'close-settings'],
     ['preview', { preview: true }, {}, 'close-preview'],

--- a/src/renderer/src/app-shell-presentation-owner.ts
+++ b/src/renderer/src/app-shell-presentation-owner.ts
@@ -3,6 +3,7 @@ import type { NavigationView } from '@/stores/navigation-store'
 
 export type AppShellPresentationState = Readonly<{
   closeConfirmation: boolean
+  webEventRecovery: boolean
   dataRootRecovery: boolean
   legacyDataMove: boolean
   update: boolean
@@ -43,6 +44,7 @@ export type AppShellPresentationProjection = Readonly<{
 
 const PRESENTATION_PRIORITY: ReadonlyArray<keyof AppShellPresentationState> = [
   'closeConfirmation',
+  'webEventRecovery',
   'dataRootRecovery',
   'legacyDataMove',
   'update',

--- a/src/renderer/src/components/WebEventRecoveryDialog.test.tsx
+++ b/src/renderer/src/components/WebEventRecoveryDialog.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { WebEventRecoveryDialog } from './WebEventRecoveryDialog'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('WebEventRecoveryDialog', () => {
+  it('blocks stale interaction while replay is in progress without offering an unsafe bypass', async () => {
+    await act(async () => {
+      root.render(<WebEventRecoveryDialog active phase="replaying" />)
+    })
+
+    const dialog = document.body.querySelector<HTMLElement>('[role="alertdialog"]')
+    expect(dialog?.textContent).toContain('Restoring missed updates')
+    expect(dialog?.textContent).not.toContain('Reload')
+  })
+
+  it('offers an explicit reload when the event suffix cannot be recovered', async () => {
+    await act(async () => {
+      root.render(<WebEventRecoveryDialog active phase="reload-required" />)
+    })
+
+    const dialog = document.body.querySelector<HTMLElement>('[role="alertdialog"]')
+    expect(dialog?.textContent).toContain('Reload required')
+    expect(
+      Array.from(dialog?.querySelectorAll('button') ?? []).some(
+        (button) => button.textContent === 'Reload'
+      )
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/components/WebEventRecoveryDialog.tsx
+++ b/src/renderer/src/components/WebEventRecoveryDialog.tsx
@@ -1,0 +1,81 @@
+import { AlertDialog } from 'radix-ui'
+import { RefreshCw } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import type { WebEventConnectionPhase } from '../../../shared/web-event-connection'
+import { Button } from '@/components/ui/button'
+import {
+  dialogBodyClassName,
+  dialogDescriptionClassName,
+  dialogFooterClassName,
+  dialogHeaderClassName,
+  dialogOverlayClassName,
+  dialogPanelClassName,
+  dialogTitleClassName
+} from '@/components/ui/dialog-chrome'
+
+type WebEventRecoveryDialogProps = {
+  active: boolean
+  phase: WebEventConnectionPhase
+}
+
+const WebEventRecoveryDialog = ({
+  active,
+  phase
+}: WebEventRecoveryDialogProps): React.JSX.Element => {
+  const { t } = useTranslation()
+  const reloadRequired = phase === 'reload-required'
+  const title =
+    phase === 'connecting'
+      ? t('Connecting to Open Science')
+      : phase === 'reconnecting'
+        ? t('Reconnecting to Open Science')
+        : phase === 'replaying'
+          ? t('Restoring missed updates')
+          : t('Reload required')
+  const description = reloadRequired
+    ? t(
+        'This page can no longer safely recover all updates. Reload to fetch a complete, current view.'
+      )
+    : t(
+        'Controls are paused while Open Science restores updates that may have arrived during the interruption.'
+      )
+
+  return (
+    <AlertDialog.Root open={active}>
+      <AlertDialog.Portal>
+        <AlertDialog.Overlay className={dialogOverlayClassName} />
+        <AlertDialog.Content
+          className={dialogPanelClassName('w-[min(420px,calc(100vw-2rem))] p-0')}
+        >
+          <div className={dialogHeaderClassName}>
+            <AlertDialog.Title className={dialogTitleClassName}>
+              <span className="inline-flex items-center gap-2">
+                <RefreshCw
+                  aria-hidden="true"
+                  className={reloadRequired ? 'size-4' : 'size-4 animate-spin'}
+                />
+                {title}
+              </span>
+            </AlertDialog.Title>
+          </div>
+          <div className={dialogBodyClassName}>
+            <AlertDialog.Description className={dialogDescriptionClassName}>
+              {description}
+            </AlertDialog.Description>
+          </div>
+          {reloadRequired ? (
+            <div className={dialogFooterClassName}>
+              <Button type="button" onClick={() => window.location.reload()}>
+                <RefreshCw aria-hidden="true" />
+                {t('Reload')}
+              </Button>
+            </div>
+          ) : null}
+        </AlertDialog.Content>
+      </AlertDialog.Portal>
+    </AlertDialog.Root>
+  )
+}
+
+export { WebEventRecoveryDialog }

--- a/src/renderer/src/hooks/useWebEventConnection.test.ts
+++ b/src/renderer/src/hooks/useWebEventConnection.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { act, createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  WEB_EVENT_CONNECTION_STATE_EVENT,
+  WEB_EVENT_CONSUMERS_READY_EVENT,
+  WEB_EVENT_SURFACE_ATTRIBUTE
+} from '../../../shared/web-event-connection'
+import { useWebEventConnection } from './useWebEventConnection'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const renderHook = <Value>(
+  hook: () => Value
+): {
+  result: { current: Value }
+  unmount: () => void
+} => {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+  const result = { current: undefined as unknown as Value }
+  const HookHarness = (): null => {
+    result.current = hook()
+    return null
+  }
+  act(() => root.render(createElement(HookHarness)))
+  return {
+    result,
+    unmount: () => act(() => root.unmount())
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  document.documentElement.removeAttribute(WEB_EVENT_SURFACE_ATTRIBUTE)
+})
+
+afterEach(() => {
+  document.documentElement.removeAttribute(WEB_EVENT_SURFACE_ATTRIBUTE)
+  vi.useRealTimers()
+})
+
+describe('useWebEventConnection', () => {
+  it('stays live and does not announce consumers on non-Web renderers', () => {
+    const ready = vi.fn()
+    window.addEventListener(WEB_EVENT_CONSUMERS_READY_EVENT, ready)
+    const hook = renderHook(() => useWebEventConnection(true))
+
+    act(() => vi.runAllTimers())
+    expect(hook.result.current).toBe('live')
+    expect(ready).not.toHaveBeenCalled()
+    hook.unmount()
+    window.removeEventListener(WEB_EVENT_CONSUMERS_READY_EVENT, ready)
+  })
+
+  it('announces mounted consumers and follows bootstrap connection phases on Web', () => {
+    document.documentElement.setAttribute(WEB_EVENT_SURFACE_ATTRIBUTE, 'true')
+    const ready = vi.fn()
+    window.addEventListener(WEB_EVENT_CONSUMERS_READY_EVENT, ready)
+    const hook = renderHook(() => useWebEventConnection(true))
+
+    expect(hook.result.current).toBe('connecting')
+    act(() => vi.runAllTimers())
+    expect(ready).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(WEB_EVENT_CONNECTION_STATE_EVENT, {
+          detail: { phase: 'replaying' }
+        })
+      )
+    })
+    expect(hook.result.current).toBe('replaying')
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(WEB_EVENT_CONNECTION_STATE_EVENT, {
+          detail: { phase: 'reload-required' }
+        })
+      )
+    })
+    expect(hook.result.current).toBe('reload-required')
+    hook.unmount()
+    window.removeEventListener(WEB_EVENT_CONSUMERS_READY_EVENT, ready)
+  })
+})

--- a/src/renderer/src/hooks/useWebEventConnection.ts
+++ b/src/renderer/src/hooks/useWebEventConnection.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+
+import {
+  WEB_EVENT_CONNECTION_STATE_EVENT,
+  WEB_EVENT_CONSUMERS_READY_EVENT,
+  WEB_EVENT_SURFACE_ATTRIBUTE,
+  type WebEventConnectionPhase,
+  type WebEventConnectionState
+} from '../../../shared/web-event-connection'
+
+const useWebEventConnection = (consumersReady: boolean): WebEventConnectionPhase => {
+  const isWebEventSurface =
+    document.documentElement.getAttribute(WEB_EVENT_SURFACE_ATTRIBUTE) === 'true'
+  const [phase, setPhase] = useState<WebEventConnectionPhase>(() =>
+    isWebEventSurface ? 'connecting' : 'live'
+  )
+
+  useEffect(() => {
+    if (!isWebEventSurface) return
+    const handleState = (event: Event): void => {
+      setPhase((event as CustomEvent<WebEventConnectionState>).detail.phase)
+    }
+    window.addEventListener(WEB_EVENT_CONNECTION_STATE_EVENT, handleState)
+    return () => window.removeEventListener(WEB_EVENT_CONNECTION_STATE_EVENT, handleState)
+  }, [isWebEventSurface])
+
+  useEffect(() => {
+    if (!isWebEventSurface || !consumersReady) return
+    const timeout = window.setTimeout(() => {
+      window.dispatchEvent(new Event(WEB_EVENT_CONSUMERS_READY_EVENT))
+    }, 0)
+    return () => window.clearTimeout(timeout)
+  }, [consumersReady, isWebEventSurface])
+
+  return phase
+}
+
+export { useWebEventConnection }

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -2547,5 +2547,11 @@
   "Agent is addressing the feedback": "Agent 正在处理反馈",
   "Corrections requested": "已请求更正",
   "Handed off to the Agent · response started": "已交给 Agent · 已开始响应",
+  "Connecting to Open Science": "\u6b63\u5728\u8fde\u63a5 Open Science",
+  "Reconnecting to Open Science": "\u6b63\u5728\u91cd\u65b0\u8fde\u63a5 Open Science",
+  "Restoring missed updates": "\u6b63\u5728\u6062\u590d\u9519\u8fc7\u7684\u66f4\u65b0",
+  "Reload required": "\u9700\u8981\u91cd\u65b0\u52a0\u8f7d",
+  "Controls are paused while Open Science restores updates that may have arrived during the interruption.": "Open Science \u6b63\u5728\u6062\u590d\u4e2d\u65ad\u671f\u95f4\u53ef\u80fd\u5230\u8fbe\u7684\u66f4\u65b0\uff0c\u63a7\u4ef6\u5df2\u6682\u65f6\u505c\u7528\u3002",
+  "This page can no longer safely recover all updates. Reload to fetch a complete, current view.": "\u6b64\u9875\u9762\u65e0\u6cd5\u518d\u5b89\u5168\u6062\u590d\u6240\u6709\u66f4\u65b0\u3002\u8bf7\u91cd\u65b0\u52a0\u8f7d\u4ee5\u83b7\u53d6\u5b8c\u6574\u7684\u6700\u65b0\u89c6\u56fe\u3002",
   "Reviewer requested corrections": "审查员已请求更正"
 }

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -2547,11 +2547,11 @@
   "Agent is addressing the feedback": "Agent 正在处理反馈",
   "Corrections requested": "已请求更正",
   "Handed off to the Agent · response started": "已交给 Agent · 已开始响应",
-  "Connecting to Open Science": "\u6b63\u5728\u8fde\u63a5 Open Science",
-  "Reconnecting to Open Science": "\u6b63\u5728\u91cd\u65b0\u8fde\u63a5 Open Science",
-  "Restoring missed updates": "\u6b63\u5728\u6062\u590d\u9519\u8fc7\u7684\u66f4\u65b0",
-  "Reload required": "\u9700\u8981\u91cd\u65b0\u52a0\u8f7d",
-  "Controls are paused while Open Science restores updates that may have arrived during the interruption.": "Open Science \u6b63\u5728\u6062\u590d\u4e2d\u65ad\u671f\u95f4\u53ef\u80fd\u5230\u8fbe\u7684\u66f4\u65b0\uff0c\u63a7\u4ef6\u5df2\u6682\u65f6\u505c\u7528\u3002",
-  "This page can no longer safely recover all updates. Reload to fetch a complete, current view.": "\u6b64\u9875\u9762\u65e0\u6cd5\u518d\u5b89\u5168\u6062\u590d\u6240\u6709\u66f4\u65b0\u3002\u8bf7\u91cd\u65b0\u52a0\u8f7d\u4ee5\u83b7\u53d6\u5b8c\u6574\u7684\u6700\u65b0\u89c6\u56fe\u3002",
+  "Connecting to Open Science": "正在连接 Open Science",
+  "Reconnecting to Open Science": "正在重新连接 Open Science",
+  "Restoring missed updates": "正在恢复错过的更新",
+  "Reload required": "需要重新加载",
+  "Controls are paused while Open Science restores updates that may have arrived during the interruption.": "Open Science 正在恢复中断期间可能到达的更新，控件已暂时停用。",
+  "This page can no longer safely recover all updates. Reload to fetch a complete, current view.": "此页面无法再安全恢复所有更新。请重新加载以获取完整的最新视图。",
   "Reviewer requested corrections": "审查员已请求更正"
 }

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -2547,5 +2547,11 @@
   "Agent is addressing the feedback": "Agent 正在處理意見",
   "Corrections requested": "已要求修正",
   "Handed off to the Agent · response started": "已交給 Agent · 已開始回應",
+  "Connecting to Open Science": "\u6b63\u5728\u9023\u7dda\u81f3 Open Science",
+  "Reconnecting to Open Science": "\u6b63\u5728\u91cd\u65b0\u9023\u7dda\u81f3 Open Science",
+  "Restoring missed updates": "\u6b63\u5728\u9084\u539f\u907a\u6f0f\u7684\u66f4\u65b0",
+  "Reload required": "\u9700\u8981\u91cd\u65b0\u8f09\u5165",
+  "Controls are paused while Open Science restores updates that may have arrived during the interruption.": "Open Science \u6b63\u5728\u9084\u539f\u4e2d\u65b7\u671f\u9593\u53ef\u80fd\u62b5\u9054\u7684\u66f4\u65b0\uff0c\u63a7\u5236\u9805\u5df2\u66ab\u505c\u4f7f\u7528\u3002",
+  "This page can no longer safely recover all updates. Reload to fetch a complete, current view.": "\u6b64\u9801\u9762\u5df2\u7121\u6cd5\u5b89\u5168\u9084\u539f\u6240\u6709\u66f4\u65b0\u3002\u8acb\u91cd\u65b0\u8f09\u5165\u4ee5\u53d6\u5f97\u5b8c\u6574\u7684\u6700\u65b0\u6aa2\u8996\u3002",
   "Reviewer requested corrections": "審查員已要求修正"
 }

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -2547,11 +2547,11 @@
   "Agent is addressing the feedback": "Agent 正在處理意見",
   "Corrections requested": "已要求修正",
   "Handed off to the Agent · response started": "已交給 Agent · 已開始回應",
-  "Connecting to Open Science": "\u6b63\u5728\u9023\u7dda\u81f3 Open Science",
-  "Reconnecting to Open Science": "\u6b63\u5728\u91cd\u65b0\u9023\u7dda\u81f3 Open Science",
-  "Restoring missed updates": "\u6b63\u5728\u9084\u539f\u907a\u6f0f\u7684\u66f4\u65b0",
-  "Reload required": "\u9700\u8981\u91cd\u65b0\u8f09\u5165",
-  "Controls are paused while Open Science restores updates that may have arrived during the interruption.": "Open Science \u6b63\u5728\u9084\u539f\u4e2d\u65b7\u671f\u9593\u53ef\u80fd\u62b5\u9054\u7684\u66f4\u65b0\uff0c\u63a7\u5236\u9805\u5df2\u66ab\u505c\u4f7f\u7528\u3002",
-  "This page can no longer safely recover all updates. Reload to fetch a complete, current view.": "\u6b64\u9801\u9762\u5df2\u7121\u6cd5\u5b89\u5168\u9084\u539f\u6240\u6709\u66f4\u65b0\u3002\u8acb\u91cd\u65b0\u8f09\u5165\u4ee5\u53d6\u5f97\u5b8c\u6574\u7684\u6700\u65b0\u6aa2\u8996\u3002",
+  "Connecting to Open Science": "正在連線至 Open Science",
+  "Reconnecting to Open Science": "正在重新連線至 Open Science",
+  "Restoring missed updates": "正在還原遺漏的更新",
+  "Reload required": "需要重新載入",
+  "Controls are paused while Open Science restores updates that may have arrived during the interruption.": "Open Science 正在還原中斷期間可能抵達的更新，控制項已暫停使用。",
+  "This page can no longer safely recover all updates. Reload to fetch a complete, current view.": "此頁面已無法安全還原所有更新。請重新載入以取得完整的最新檢視。",
   "Reviewer requested corrections": "審查員已要求修正"
 }

--- a/src/renderer/src/stores/compute-store.test.ts
+++ b/src/renderer/src/stores/compute-store.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ComputeHost } from '../../../shared/compute'
+import type { ComputeApprovalRequest, ComputeHost } from '../../../shared/compute'
 import { createInitialComputeState, useComputeStore } from './compute-store'
 
 const createHost = (overrides: Partial<ComputeHost> = {}): ComputeHost => ({
@@ -164,5 +164,23 @@ describe('compute store — concurrency limit', () => {
 
     expect(concurrencySet).toHaveBeenCalledWith('ssh:biowulf', 20)
     expect(useComputeStore.getState().hosts[0].concurrencyLimit).toBe(20)
+  })
+})
+
+describe('compute store - approval replay', () => {
+  it('deduplicates a replayed approval request by its stable id', () => {
+    const request: ComputeApprovalRequest = {
+      id: 'approval-1',
+      session_id: 'session-1',
+      provider_id: 'ssh:lab',
+      provider_name: 'Lab',
+      shape: 'direct_ssh',
+      intent: 'Run analysis'
+    }
+
+    useComputeStore.getState().enqueueApproval(request)
+    useComputeStore.getState().enqueueApproval(request)
+
+    expect(useComputeStore.getState().pendingApprovals).toEqual([request])
   })
 })

--- a/src/renderer/src/stores/compute-store.ts
+++ b/src/renderer/src/stores/compute-store.ts
@@ -173,7 +173,11 @@ export const useComputeStore = create<ComputeStore>((set) => ({
 
   // Queues an incoming compute approval request (pushed from main before each SSH call).
   enqueueApproval: (request) => {
-    set((state) => ({ pendingApprovals: [...state.pendingApprovals, request] }))
+    set((state) =>
+      state.pendingApprovals.some(({ id }) => id === request.id)
+        ? state
+        : { pendingApprovals: [...state.pendingApprovals, request] }
+    )
   },
 
   // Sends the user's scoped decision back to main and removes the head request from the queue.

--- a/src/renderer/web/bootstrap.test.ts
+++ b/src/renderer/web/bootstrap.test.ts
@@ -2,7 +2,15 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { WEB_RPC_PROTOCOL_VERSION } from '../../shared/web-rpc-contract'
+import {
+  WEB_EVENT_STREAM_PROTOCOL_VERSION,
+  WEB_RPC_PROTOCOL_VERSION
+} from '../../shared/web-rpc-contract'
+import {
+  WEB_EVENT_CONNECTION_STATE_EVENT,
+  WEB_EVENT_CONSUMERS_READY_EVENT,
+  WEB_EVENTS_OPEN_EVENT
+} from '../../shared/web-event-connection'
 
 const themeMocks = vi.hoisted(() => ({
   applyTheme: vi.fn(),
@@ -34,6 +42,9 @@ class FakeWebSocket {
     this.listeners.set(name, listeners)
   }
 
+  close(): void {
+    this.emit('close')
+  }
   emit(name: SocketEventName, event: SocketEvent = {}): void {
     for (const listener of this.listeners.get(name) ?? []) listener(event)
   }
@@ -47,14 +58,40 @@ type WebApi = {
 }
 
 const bootstrapPayload = {
+  eventStream: {
+    protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+    streamId: 'stream-1',
+    latestSequence: 0
+  },
   platform: 'test',
   versions: { electron: '1', chrome: '1', node: '1' },
   rpcProtocolVersion: WEB_RPC_PROTOCOL_VERSION,
   rpcChannels: []
 }
 
+const eventFrame = (sequence: number, channel: string, payload: unknown): string =>
+  JSON.stringify({
+    kind: 'event',
+    protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+    streamId: 'stream-1',
+    sequence,
+    channel,
+    payload
+  })
+
+const readyFrame = (latestSequence: number): string =>
+  JSON.stringify({
+    kind: 'ready',
+    protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+    streamId: 'stream-1',
+    latestSequence
+  })
+
 const loadBootstrap = async (): Promise<WebApi> => {
-  await import('./bootstrap')
+  const bootstrapImport = import('./bootstrap')
+  await vi.waitFor(() => expect((window as unknown as { api?: WebApi }).api).toBeDefined())
+  window.dispatchEvent(new Event(WEB_EVENT_CONSUMERS_READY_EVENT))
+  await bootstrapImport
   return (window as unknown as { api: WebApi }).api
 }
 
@@ -122,12 +159,27 @@ describe('Web bootstrap event connection', () => {
     })
   })
 
+  it('waits for renderer consumers before opening the event stream', async () => {
+    const bootstrapImport = import('./bootstrap')
+    await vi.waitFor(() => expect((window as unknown as { api?: WebApi }).api).toBeDefined())
+
+    expect(FakeWebSocket.instances).toHaveLength(0)
+    window.dispatchEvent(new Event(WEB_EVENT_CONSUMERS_READY_EVENT))
+    await bootstrapImport
+    expect(FakeWebSocket.instances).toHaveLength(1)
+  })
+
   it('opens the initial event socket with the stable Web client id', async () => {
     await loadBootstrap()
 
-    expect(FakeWebSocket.instances.map((socket) => socket.url)).toEqual([
-      `ws://${location.host}/events?client=web-client-1`
-    ])
+    const url = new URL(FakeWebSocket.instances[0].url)
+    expect(url.pathname).toBe('/events')
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      client: 'web-client-1',
+      eventProtocol: String(WEB_EVENT_STREAM_PROTOCOL_VERSION),
+      stream: 'stream-1',
+      after: '0'
+    })
   })
 
   it('reconnects with exponential backoff after consecutive closes', async () => {
@@ -146,12 +198,13 @@ describe('Web bootstrap event connection', () => {
     expect(FakeWebSocket.instances).toHaveLength(3)
   })
 
-  it('resets reconnect backoff after a socket opens', async () => {
+  it('resets reconnect backoff after a socket becomes ready', async () => {
     await loadBootstrap()
 
     FakeWebSocket.instances[0].emit('close')
     await vi.advanceTimersByTimeAsync(1_000)
     FakeWebSocket.instances[1].emit('open')
+    FakeWebSocket.instances[1].emit('message', { data: readyFrame(0) })
     FakeWebSocket.instances[1].emit('close')
 
     await vi.advanceTimersByTimeAsync(999)
@@ -160,18 +213,22 @@ describe('Web bootstrap event connection', () => {
     expect(FakeWebSocket.instances).toHaveLength(3)
   })
 
-  it('signals stores to refresh whenever the event socket opens', async () => {
+  it('signals stores to refresh only after replay reaches the live cursor', async () => {
     const listener = vi.fn()
-    window.addEventListener('open-science:web-events-open', listener)
+    window.addEventListener(WEB_EVENTS_OPEN_EVENT, listener)
     await loadBootstrap()
 
     FakeWebSocket.instances[0].emit('open')
+    expect(listener).not.toHaveBeenCalled()
+    FakeWebSocket.instances[0].emit('message', { data: readyFrame(0) })
+    expect(listener).toHaveBeenCalledTimes(1)
     FakeWebSocket.instances[0].emit('close')
     await vi.advanceTimersByTimeAsync(1_000)
     FakeWebSocket.instances[1].emit('open')
-
+    expect(listener).toHaveBeenCalledTimes(1)
+    FakeWebSocket.instances[1].emit('message', { data: readyFrame(0) })
     expect(listener).toHaveBeenCalledTimes(2)
-    window.removeEventListener('open-science:web-events-open', listener)
+    window.removeEventListener(WEB_EVENTS_OPEN_EVENT, listener)
   })
 
   it('keeps existing event subscriptions active after reconnecting', async () => {
@@ -182,14 +239,39 @@ describe('Web bootstrap event connection', () => {
     FakeWebSocket.instances[0].emit('close')
     await vi.advanceTimersByTimeAsync(1_000)
     FakeWebSocket.instances[1].emit('message', {
-      data: JSON.stringify({
-        protocolVersion: WEB_RPC_PROTOCOL_VERSION,
-        channel: 'project:created',
-        payload: { id: 'project-1' }
-      })
+      data: eventFrame(1, 'project:created', { id: 'project-1' })
     })
 
     expect(listener).toHaveBeenCalledWith({ id: 'project-1' })
     unsubscribe()
+    FakeWebSocket.instances[1].emit('message', { data: readyFrame(1) })
+    FakeWebSocket.instances[1].emit('close')
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(new URL(FakeWebSocket.instances[2].url).searchParams.get('after')).toBe('1')
+  })
+
+  it('stops reconnecting and requests a reload when replay cannot satisfy the cursor', async () => {
+    const phases: string[] = []
+    const stateListener = (event: Event): void => {
+      phases.push((event as CustomEvent<{ phase: string }>).detail.phase)
+    }
+    window.addEventListener(WEB_EVENT_CONNECTION_STATE_EVENT, stateListener)
+    await loadBootstrap()
+
+    FakeWebSocket.instances[0].emit('open')
+    FakeWebSocket.instances[0].emit('message', {
+      data: JSON.stringify({
+        kind: 'resync-required',
+        protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+        streamId: 'stream-1',
+        latestSequence: 4,
+        reason: 'cursor-expired'
+      })
+    })
+    await vi.advanceTimersByTimeAsync(20_000)
+
+    expect(phases).toContain('reload-required')
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    window.removeEventListener(WEB_EVENT_CONNECTION_STATE_EVENT, stateListener)
   })
 })

--- a/src/renderer/web/bootstrap.ts
+++ b/src/renderer/web/bootstrap.ts
@@ -3,11 +3,19 @@ import {
   isApplicationCommandErrorCode
 } from '../../shared/application-command-contract'
 import {
+  WEB_EVENT_STREAM_PROTOCOL_VERSION,
   WEB_RPC_PROTOCOL_VERSION,
   webRpcBootstrapSchema,
-  webRpcEventSchema,
+  webRpcEventMessageSchema,
   webRpcResponseSchema
 } from '../../shared/web-rpc-contract'
+import {
+  WEB_EVENT_CONNECTION_STATE_EVENT,
+  WEB_EVENT_CONSUMERS_READY_EVENT,
+  WEB_EVENTS_OPEN_EVENT,
+  WEB_EVENT_SURFACE_ATTRIBUTE,
+  type WebEventConnectionPhase
+} from '../../shared/web-event-connection'
 import { installWebRendererContracts } from './api-installer'
 import { initI18n } from '@/i18n'
 import { applyHtmlLang, resolveInitialLocale } from '@/lib/locale-preference'
@@ -24,6 +32,7 @@ applyTheme(resolveInitialTheme())
 const initialLocale = resolveInitialLocale()
 initI18n(initialLocale)
 applyHtmlLang(initialLocale)
+document.documentElement.setAttribute(WEB_EVENT_SURFACE_ATTRIBUTE, 'true')
 
 const REMOTE_ACCESS_OFF_MESSAGE =
   'Remote access is off on the home computer. Re-enable a remote access mode in Open Science, then try again.'
@@ -202,22 +211,91 @@ const rewritePreviewUrls = (value: unknown): unknown => {
   return value
 }
 
+type EventCursor = {
+  streamId: string
+  latestSequence: number
+}
+
+let eventCursor: EventCursor
 let eventReconnectAttempt = 0
+let eventRecoveryRequired = false
+
+const publishEventConnectionPhase = (phase: WebEventConnectionPhase): void => {
+  window.dispatchEvent(
+    new CustomEvent(WEB_EVENT_CONNECTION_STATE_EVENT, {
+      detail: { phase }
+    })
+  )
+}
+
+const requireEventReload = (socket: WebSocket): void => {
+  if (eventRecoveryRequired) return
+  eventRecoveryRequired = true
+  publishEventConnectionPhase('reload-required')
+  socket.close(1000, 'Event stream resynchronization required')
+}
 
 const connectEvents = (): void => {
+  if (eventRecoveryRequired) return
   const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
-  const socket = new WebSocket(
-    `${protocol}//${location.host}/events?client=${encodeURIComponent(clientId)}`
-  )
+  const url = new URL(`${protocol}//${location.host}/events`)
+  url.searchParams.set('client', clientId)
+  url.searchParams.set('eventProtocol', String(WEB_EVENT_STREAM_PROTOCOL_VERSION))
+  url.searchParams.set('stream', eventCursor.streamId)
+  url.searchParams.set('after', String(eventCursor.latestSequence))
+  const socket = new WebSocket(url.toString())
+
   socket.addEventListener('open', () => {
-    eventReconnectAttempt = 0
-    window.dispatchEvent(new Event('open-science:web-events-open'))
+    publishEventConnectionPhase('replaying')
   })
   socket.addEventListener('message', (event) => {
-    const message = webRpcEventSchema.parse(JSON.parse(String(event.data), reviveBinary))
-    for (const listener of listeners.get(message.channel) ?? []) listener(message.payload)
+    let decoded: unknown
+    try {
+      decoded = JSON.parse(String(event.data), reviveBinary)
+    } catch {
+      requireEventReload(socket)
+      return
+    }
+    const parsed = webRpcEventMessageSchema.safeParse(decoded)
+    if (!parsed.success) {
+      requireEventReload(socket)
+      return
+    }
+    const message = parsed.data
+    if (message.kind === 'resync-required') {
+      requireEventReload(socket)
+      return
+    }
+    if (message.streamId !== eventCursor.streamId) {
+      requireEventReload(socket)
+      return
+    }
+    if (message.kind === 'event') {
+      if (message.sequence !== eventCursor.latestSequence + 1) {
+        requireEventReload(socket)
+        return
+      }
+      try {
+        for (const listener of listeners.get(message.channel) ?? []) listener(message.payload)
+      } catch (error) {
+        console.error('Failed to apply a Web event frame.', error)
+        requireEventReload(socket)
+        return
+      }
+      eventCursor.latestSequence = message.sequence
+      return
+    }
+    if (message.latestSequence !== eventCursor.latestSequence) {
+      requireEventReload(socket)
+      return
+    }
+    eventReconnectAttempt = 0
+    publishEventConnectionPhase('live')
+    window.dispatchEvent(new Event(WEB_EVENTS_OPEN_EVENT))
   })
   socket.addEventListener('close', () => {
+    if (eventRecoveryRequired) return
+    publishEventConnectionPhase('reconnecting')
     const delay = Math.min(1_000 * 2 ** eventReconnectAttempt, 10_000)
     eventReconnectAttempt += 1
     window.setTimeout(connectEvents, delay)
@@ -243,7 +321,7 @@ const downloadBlob = (blob: Blob, name: string): void => {
   window.setTimeout(() => URL.revokeObjectURL(url), 0)
 }
 
-const installWebApi = async (): Promise<void> => {
+const installWebApi = async (): Promise<EventCursor> => {
   const parsedBootstrap = webRpcBootstrapSchema.safeParse(await fetchBootstrap())
   if (!parsedBootstrap.success) {
     throw new Error(
@@ -291,12 +369,24 @@ const installWebApi = async (): Promise<void> => {
   })
 
   ;(window as unknown as { api: unknown }).api = api
-  connectEvents()
+  return {
+    streamId: bootstrap.eventStream.streamId,
+    latestSequence: bootstrap.eventStream.latestSequence
+  }
 }
 
+const eventConsumersReady = new Promise<void>((resolve) => {
+  window.addEventListener(WEB_EVENT_CONSUMERS_READY_EVENT, () => resolve(), {
+    once: true
+  })
+})
+
 try {
-  await installWebApi()
+  eventCursor = await installWebApi()
   await import('../src/main')
+  await eventConsumersReady
+  publishEventConnectionPhase('connecting')
+  connectEvents()
 } catch (error) {
   showConnectionFailure(error)
 }

--- a/src/renderer/web/renderer-argument-shape-characterization.test.ts
+++ b/src/renderer/web/renderer-argument-shape-characterization.test.ts
@@ -4,7 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { RENDERER_CONTRACT_CATALOG } from '../../shared/renderer-contract-catalog'
 import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from '../../shared/web-api-map.generated'
-import { WEB_RPC_ALLOWED_CHANNELS, WEB_RPC_PROTOCOL_VERSION } from '../../shared/web-rpc-contract'
+import {
+  WEB_EVENT_STREAM_PROTOCOL_VERSION,
+  WEB_RPC_ALLOWED_CHANNELS,
+  WEB_RPC_PROTOCOL_VERSION
+} from '../../shared/web-rpc-contract'
+import { WEB_EVENT_CONSUMERS_READY_EVENT } from '../../shared/web-event-connection'
 
 const electronMocks = vi.hoisted(() => ({
   exposeInMainWorld: vi.fn(),
@@ -92,7 +97,10 @@ const loadElectronApi = async (): Promise<ApiRoot> => {
 }
 
 const loadWebApi = async (): Promise<ApiRoot> => {
-  await import('./bootstrap')
+  const bootstrapImport = import('./bootstrap')
+  await vi.waitFor(() => expect((window as unknown as { api?: ApiRoot }).api).toBeDefined())
+  window.dispatchEvent(new Event(WEB_EVENT_CONSUMERS_READY_EVENT))
+  await bootstrapImport
   return (window as unknown as { api: ApiRoot }).api
 }
 
@@ -142,7 +150,12 @@ beforeEach(async () => {
             platform: 'test',
             versions: { electron: '1', chrome: '1', node: '1' },
             rpcProtocolVersion: WEB_RPC_PROTOCOL_VERSION,
-            rpcChannels: WEB_RPC_ALLOWED_CHANNELS
+            rpcChannels: WEB_RPC_ALLOWED_CHANNELS,
+            eventStream: {
+              protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+              streamId: 'stream-1',
+              latestSequence: 0
+            }
           }),
           { status: 200, headers: { 'content-type': 'application/json' } }
         )

--- a/src/shared/web-event-connection.ts
+++ b/src/shared/web-event-connection.ts
@@ -1,0 +1,26 @@
+const WEB_EVENT_CONSUMERS_READY_EVENT = 'open-science:web-event-consumers-ready'
+const WEB_EVENT_CONNECTION_STATE_EVENT = 'open-science:web-event-connection-state'
+const WEB_EVENTS_OPEN_EVENT = 'open-science:web-events-open'
+const WEB_EVENT_SURFACE_ATTRIBUTE = 'data-open-science-web-events'
+
+const WEB_EVENT_CONNECTION_PHASES = [
+  'connecting',
+  'reconnecting',
+  'replaying',
+  'live',
+  'reload-required'
+] as const
+
+type WebEventConnectionPhase = (typeof WEB_EVENT_CONNECTION_PHASES)[number]
+type WebEventConnectionState = Readonly<{
+  phase: WebEventConnectionPhase
+}>
+
+export {
+  WEB_EVENT_CONNECTION_PHASES,
+  WEB_EVENT_CONNECTION_STATE_EVENT,
+  WEB_EVENT_CONSUMERS_READY_EVENT,
+  WEB_EVENT_SURFACE_ATTRIBUTE,
+  WEB_EVENTS_OPEN_EVENT
+}
+export type { WebEventConnectionPhase, WebEventConnectionState }

--- a/src/shared/web-rpc-contract.ts
+++ b/src/shared/web-rpc-contract.ts
@@ -4,6 +4,7 @@ import { APPLICATION_COMMAND_ERROR_CODES } from './application-command-contract'
 import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from './web-api-map.generated'
 
 export const WEB_RPC_PROTOCOL_VERSION = 1 as const
+export const WEB_EVENT_STREAM_PROTOCOL_VERSION = 2 as const
 export const WEB_RPC_TRANSPORT_ERROR_CODES = [
   'invalid_request',
   'method_not_found',
@@ -97,6 +98,13 @@ export const webRpcBootstrapSchema = z
     platform: z.string(),
     versions: z.object({ electron: z.string(), chrome: z.string(), node: z.string() }).strict(),
     rpcProtocolVersion: z.literal(WEB_RPC_PROTOCOL_VERSION),
+    eventStream: z
+      .object({
+        protocolVersion: z.literal(WEB_EVENT_STREAM_PROTOCOL_VERSION),
+        streamId: z.string().min(1),
+        latestSequence: z.number().int().nonnegative()
+      })
+      .strict(),
     restrictedRpcChannels: z.array(z.string()).optional(),
     rpcChannels: z.array(z.string()).superRefine((channels, context) => {
       for (const channel of channels) {
@@ -112,11 +120,40 @@ export const webRpcBootstrapSchema = z
 
 export const webRpcEventSchema = z
   .object({
-    protocolVersion: z.literal(WEB_RPC_PROTOCOL_VERSION),
+    kind: z.literal('event'),
+    protocolVersion: z.literal(WEB_EVENT_STREAM_PROTOCOL_VERSION),
+    streamId: z.string().min(1),
+    sequence: z.number().int().positive(),
     channel: z.string().refine(isWebRpcEventChannel, 'Unknown Web RPC event channel'),
     payload: webRpcValueSchema
   })
   .strict()
 
+export const webRpcEventReadySchema = z
+  .object({
+    kind: z.literal('ready'),
+    protocolVersion: z.literal(WEB_EVENT_STREAM_PROTOCOL_VERSION),
+    streamId: z.string().min(1),
+    latestSequence: z.number().int().nonnegative()
+  })
+  .strict()
+
+export const webRpcEventResyncRequiredSchema = z
+  .object({
+    kind: z.literal('resync-required'),
+    protocolVersion: z.literal(WEB_EVENT_STREAM_PROTOCOL_VERSION),
+    streamId: z.string().min(1),
+    latestSequence: z.number().int().nonnegative(),
+    reason: z.enum(['stream-changed', 'cursor-expired'])
+  })
+  .strict()
+
+export const webRpcEventMessageSchema = z.discriminatedUnion('kind', [
+  webRpcEventSchema,
+  webRpcEventReadySchema,
+  webRpcEventResyncRequiredSchema
+])
+
 export type WebRpcRequest = z.infer<typeof webRpcRequestSchema>
 export type WebRpcResponse = z.infer<typeof webRpcResponseSchema>
+export type WebRpcEventMessage = z.infer<typeof webRpcEventMessageSchema>


### PR DESCRIPTION
## Problem

The internal Web renderer WebSocket was live-only: it reconnected after a close but had no process stream id, event sequence, replay cursor, or resynchronization signal. ACP permissions/runtime state, Connector and Skill approvals, Compute updates, Settings changes, and other renderer events published during the gap could therefore be lost. The same gap also existed between `/api/bootstrap` and React consumer subscription setup.

This is event-frame recovery between the Web renderer and the Open Science server. It does not replay model/provider requests, turns, or messages.

## Proposed change

- Add a Web-service-owned, process-local internal event stream with a generation `streamId`, monotonic sequence, and a ring bounded by both 2,048 frames and 16 MiB of serialized data.
- Return the initial cursor from `/api/bootstrap`, wait until renderer consumers are mounted, then connect with `stream` + `after` and replay the missing ordered suffix.
- Emit `ready` only after the client reaches the live cursor. Emit `resync-required` when the server generation changed or the cursor expired.
- Route reconnect/replay/reload-required through the App Shell presentation owner. Base content is inert while recovery is active; unrecoverable cursors show a non-dismissible dialog with an explicit Reload action.
- Make Compute approval enqueue idempotent by stable request id (Connector and Skill queues were already keyed).

### Interaction

Normal reconnect is automatic: the page shows a compact blocking recovery dialog, replays missed frames, then restores interaction. If replay cannot be proven complete, automatic reconnect stops and the dialog offers Reload.

## Scope and non-goals

- Internal `/events` only. Public `/api/v1/events` remains live-only and its payload contract is unchanged.
- No Server-to-model/provider replay and no turn/message reconstruction.
- No durable audit/event log, database table, or persisted cursor.
- No domain model changes and no changes to `activeBranchId` semantics; existing event consumers continue to own branch filtering.
- All ACP implementations (`claude-code`, `opencode`, `codex-response`, and `codex-bridge`) publish through the same application event hub, so the transport recovery applies uniformly.

### Compatibility

- No historical data migration is required.
- Existing pages that connect without the new event protocol query remain on the previous live-only wire shape until reload.
- New transport/control values are `event`, `ready`, and `resync-required`; new renderer connection phases are `connecting`, `reconnecting`, `replaying`, `live`, and `reload-required`. No persisted/domain enum is added.

### Persistence

None. The replay ring and cursor exist only in Web-service process memory. Restarting the process creates a new `streamId` and intentionally requires page recovery.

## Acceptance criteria and validation

- [x] Events published after bootstrap or during a socket disconnect are replayed once, in sequence, before the connection becomes live.
- [x] Count eviction, byte eviction, oversized frames, cursor expiry, and server-generation changes fail closed with `resync-required`.
- [x] Existing consumer subscriptions survive reconnect and the cursor advances only after synchronous delivery.
- [x] Public Task events remain live-only.
- [x] Recovery owns App Shell interaction and cannot be dismissed around stale approval controls.
- [x] Connector, Skill, Compute, Settings, and ACP replay paths were evaluated; Compute gained missing request-id deduplication.

### Test Impact Set

Interfaces: internal Web bootstrap/event protocol, WebSocket routing, App Shell presentation projection, Compute approval queue.

Targeted validation:

- `vitest`: 10 affected files, 191 tests passed.
- Targeted ESLint on all changed TypeScript/TSX files passed.
- Locale JSON parsed and decoded to the intended Simplified/Traditional Chinese values.
- Full `npm test` was intentionally not run; PR CI is authoritative.
- Local process typechecks are blocked by the shared worktree dependency tree's unrelated stale generated types (`assessmentSnapshot` in Prisma, plus Node's `waitForMcpServers` package export). No typecheck diagnostic points to a changed file.

## Review focus

- Cursor boundary at `/api/bootstrap` and the consumer-ready startup barrier.
- Ring eviction math and fail-closed behavior.
- Ordering between replay frames, `ready`, live publication, and App Shell interaction restoration.
- Intentional separation between internal replay and the public Task event stream.