### PR TITLE
ci(windows): generate Prisma client for upgrade smoke

### DIFF
--- a/.github/workflows/windows-upgrade-smoke.yml
+++ b/.github/workflows/windows-upgrade-smoke.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts --no-audit --no-fund
 
+      - name: Generate Prisma client
+        run: npx prisma generate
+
       - name: Download current Windows installer
         shell: pwsh
         env:

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -311,6 +311,7 @@ describe('post-merge Windows validation', () => {
     expect(findStep(upgrade, 'Install dependencies').run).toBe(
       'npm ci --ignore-scripts --no-audit --no-fund'
     )
+    expect(findStep(upgrade, 'Generate Prisma client').run).toBe('npx prisma generate')
     const current = findStep(upgrade, 'Download current Windows installer')
     expect(current.run).toContain('gh release download $env:CURRENT_TAG')
     expect(current.run).toContain("--pattern 'latest.yml'")


### PR DESCRIPTION
## Problem

The advisory Windows upgrade smoke installs dependencies with `npm ci --ignore-scripts` so it avoids the repository's heavyweight postinstall work. That also skips `prisma generate`.

Both the updater and installer smoke paths import `scripts/database-migration-ledger-smoke.mjs`. Without a generated client, Node 22 fails while loading its named `PrismaClient` import, before the updater, installer, or persistence checks execute.

Observed in Windows Upgrade Smoke run 31820343638 / job 94831816096 for release v0.15.0 (`a840ff4d0e32d1a646dcd4119f1fe9c93210e9dd`).

## Proposed change

- Keep `npm ci --ignore-scripts --no-audit --no-fund`.
- Generate only the Prisma Client in a separate, observable `npx prisma generate` step.
- Add a workflow contract assertion for the new step.

This does not re-enable patch-package, Electron native dependency installation, or the other repository postinstall actions.

## Scope and non-goals

- No application runtime code changes.
- No database schema, migration, ledger checksum, historical-data rewrite, or persistence format changes.
- No new application state or enum values.
- This restores the existing legacy-data and migration-ledger certification path; it does not change its acceptance criteria.

## Acceptance criteria and validation

Checks ran after the final material edit:

- Windows workflow contract -> `npm test -- scripts/windows-release-workflows.test.ts scripts/ci/release-workflows.test.ts` -> **18/18 passed**
- Migration-ledger helper -> `npm test -- scripts/database-migration-ledger-smoke.test.ts` -> **4/4 passed**
- Generated client/load boundary -> `npx.cmd prisma generate`, then direct import of `database-migration-ledger-smoke.mjs` -> **passed**
- Lint -> `npm run lint` -> **0 errors**, 17 pre-existing Prettier warnings in unrelated files
- Patch integrity -> `git diff --check` -> **passed**

The complete portable suite was also attempted: **12,286 passed, 56 failed, 185 skipped**. It is not clean in this local Windows environment because the intentionally script-free install leaves Electron's binary uninstalled, Windows symlink creation returns `EPERM`, and unrelated timeout/concurrency-sensitive tests fail. The focused owner tests above pass.

## Review focus

- Confirm the Prisma generation step remains immediately after the script-free install.
- Confirm keeping the remaining postinstall actions disabled is appropriate for this advisory smoke.
- Exact-head Windows `workflow_dispatch` with `tag=v0.15.0` remains the authoritative platform validation and has not yet been dispatched.