### PR TITLE
test(skills): stabilize hash race coverage on Windows

### DIFF
--- a/src/main/skills/user-skill-compatibility-index.test.ts
+++ b/src/main/skills/user-skill-compatibility-index.test.ts
@@ -198,7 +198,7 @@ describe('UserSkillCompatibilityIndex', () => {
       const bytes = await readFile(path)
       if (path === assetPath && !changed) {
         changed = true
-        await writeFile(path, 'after!')
+        await writeFile(path, 'after!!')
       }
       return createHash('sha256').update(bytes).digest('hex')
     })


### PR DESCRIPTION
## Problem

Windows Full Test [run 31858171141](https://github.com/aipoch/open-science/actions/runs/31858171141) failed because the hash-race regression test expected three hash calls but observed two.

The fixture changed `before` to the same-length value `after!`. On Windows, the write could leave the compared size, mtime, and ctime metadata observationally unchanged, so the test did not reliably enter the retry branch.

## Proposed change

Change the post-mutation fixture value to `after!!`. The size difference deterministically exercises the existing retry behavior without changing production logic.

## Scope and non-goals

- Test-only, one-character fixture change.
- No compatibility hash, cache format, persistence, state, or runtime behavior changes.
- No production retry-policy changes.

## Acceptance criteria and validation

Checks run after the final edit:

- Hash race and complete owner test file -> `npm test -- src/main/skills/user-skill-compatibility-index.test.ts` -> 9 passed.
- Module-impact manifest contracts -> `npm test -- scripts/ci/validate-module-impact.test.ts scripts/ci/module-test-impact.test.ts` -> 34 passed.
- Lint -> `npm run lint` -> passed with 0 errors; 17 existing warnings remain in unrelated files.
- Patch hygiene -> `git diff --check` -> passed.

Local module/typecheck coverage was limited by the available Windows environment: the host has Node 24 instead of the required Node 22, native/postinstall generation could not complete, and the module wrapper hit `spawnSync npm.cmd EINVAL`. A direct run of the module plan completed 340 tests successfully before unrelated Electron, Prisma-generation, symlink-permission, and worker-startup failures. Exact-head CI remains authoritative for the complete module and Windows lanes.

## Review focus

Confirm that using a different-length mutation makes the race test deterministic across filesystem timestamp implementations while preserving the intended three-call assertion.
