### PR TITLE
fix(web): localize connection recovery copy

### DIFF
--- a/src/renderer/src/i18n/resources.test.ts
+++ b/src/renderer/src/i18n/resources.test.ts
@@ -376,13 +376,14 @@ describe('Trans tag names', () => {
 // Orphan guard
 // ---------------------------------------------------------------------------
 
-// src/. Both the renderer and src/shared are scanned: shared modules have no i18n access, so they
-// carry English copy the renderer resolves through t() (install-source labels, download progress).
-// Leaving shared out is what let ten of these strings look orphaned when their call sites were live.
+// src/. Both renderer entry trees and src/shared are scanned: shared modules have no i18n access, so
+// they carry English copy the renderer resolves through t() (install-source labels, download
+// progress). Leaving either shared or renderer/web out makes live keys look orphaned.
 const SRC_ROOT = join(__dirname, '../../..')
 
 const SCAN_ROOTS = [
   join(SRC_ROOT, 'renderer', 'src'),
+  join(SRC_ROOT, 'renderer', 'web'),
   join(SRC_ROOT, 'shared'),
   join(SRC_ROOT, 'main')
 ]

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -2565,5 +2565,9 @@
   "Reload required": "需要重新加载",
   "Controls are paused while Open Science restores updates that may have arrived during the interruption.": "Open Science 正在恢复中断期间可能到达的更新，控件已暂时停用。",
   "This page can no longer safely recover all updates. Reload to fetch a complete, current view.": "此页面无法再安全恢复所有更新。请重新加载以获取完整的最新视图。",
-  "Reviewer requested corrections": "审查员已请求更正"
+  "Reviewer requested corrections": "审查员已请求更正",
+  "Connecting to remote computer…": "正在连接远程计算机…",
+  "Reconnecting to remote computer… ({{attempt}}/{{maxAttempts}})": "正在重新连接远程计算机…（{{attempt}}/{{maxAttempts}}）",
+  "Remote access is off on the home computer. Re-enable a remote access mode in Open Science, then try again.": "主电脑上的远程访问已关闭。请在 Open Science 中重新启用远程访问模式，然后重试。",
+  "This computer did not finish responding. {{detail}}": "这台电脑未能完成响应。{{detail}}"
 }

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -2565,5 +2565,9 @@
   "Reload required": "需要重新載入",
   "Controls are paused while Open Science restores updates that may have arrived during the interruption.": "Open Science 正在還原中斷期間可能抵達的更新，控制項已暫停使用。",
   "This page can no longer safely recover all updates. Reload to fetch a complete, current view.": "此頁面已無法安全還原所有更新。請重新載入以取得完整的最新檢視。",
-  "Reviewer requested corrections": "審查員已要求修正"
+  "Reviewer requested corrections": "審查員已要求修正",
+  "Connecting to remote computer…": "正在連線至遠端電腦…",
+  "Reconnecting to remote computer… ({{attempt}}/{{maxAttempts}})": "正在重新連線至遠端電腦…（{{attempt}}/{{maxAttempts}}）",
+  "Remote access is off on the home computer. Re-enable a remote access mode in Open Science, then try again.": "主電腦上的遠端存取已關閉。請在 Open Science 中重新啟用遠端存取模式，然後重試。",
+  "This computer did not finish responding. {{detail}}": "這台電腦未能完成回應。{{detail}}"
 }

--- a/src/renderer/web/bootstrap.test.ts
+++ b/src/renderer/web/bootstrap.test.ts
@@ -99,6 +99,14 @@ beforeEach(() => {
   vi.useFakeTimers()
   vi.resetModules()
   FakeWebSocket.instances = []
+  document.body.innerHTML = `
+    <div id=open-science-connection-state role=status>
+      <div class=open-science-connection-panel>
+        <span id=open-science-connection-logo></span>
+        <p id=open-science-connection-message>Connecting to remote computer…</p>
+      </div>
+    </div>
+  `
   sessionStorage.clear()
   sessionStorage.setItem('open-science-web-client', 'web-client-1')
   delete (window as unknown as { api?: unknown }).api
@@ -120,10 +128,70 @@ afterEach(() => {
   vi.useRealTimers()
   vi.unstubAllGlobals()
   sessionStorage.clear()
+  localStorage.clear()
+  document.body.innerHTML = ''
   delete (window as unknown as { api?: unknown }).api
 })
 
 describe('Web bootstrap event connection', () => {
+  // Bootstrap owns this pre-React connection surface, so its copy must use the initialized i18n.
+  it('localizes the initial connection message with the initialized locale', async () => {
+    localStorage.setItem('open-science-language', 'zh-Hans')
+
+    const bootstrapImport = import('./bootstrap')
+    await vi.waitFor(() => expect((window as unknown as { api?: WebApi }).api).toBeDefined())
+
+    expect(document.getElementById('open-science-connection-message')?.textContent).toBe(
+      '正在连接远程计算机…'
+    )
+    window.dispatchEvent(new Event(WEB_EVENT_CONSUMERS_READY_EVENT))
+    await bootstrapImport
+  })
+
+  it('localizes bootstrap reconnect progress with the initialized locale', async () => {
+    localStorage.setItem('open-science-language', 'zh-Hans')
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValue(
+        new Response(JSON.stringify(bootstrapPayload), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        })
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const bootstrapImport = import('./bootstrap')
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
+    await vi.waitFor(() =>
+      expect(document.getElementById('open-science-connection-message')?.textContent).toBe(
+        '正在重新连接远程计算机…（2/8）'
+      )
+    )
+    await vi.advanceTimersByTimeAsync(500)
+    await vi.waitFor(() => expect((window as unknown as { api?: WebApi }).api).toBeDefined())
+    window.dispatchEvent(new Event(WEB_EVENT_CONSUMERS_READY_EVENT))
+    await bootstrapImport
+  })
+
+  it('localizes bootstrap failure and retry controls with the initialized locale', async () => {
+    localStorage.setItem('open-science-language', 'zh-Hans')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('', { status: 401 }))
+    )
+
+    await import('./bootstrap')
+
+    expect(document.getElementById('open-science-connection-state')?.getAttribute('role')).toBe(
+      'alert'
+    )
+    expect(document.getElementById('open-science-connection-message')?.textContent).toBe(
+      '主电脑上的远程访问已关闭。请在 Open Science 中重新启用远程访问模式，然后重试。'
+    )
+    expect(document.querySelector('button')?.textContent).toBe('重试')
+  })
+
   it('reconstructs Application Command errors returned by Web RPC', async () => {
     vi.stubGlobal(
       'fetch',

--- a/src/renderer/web/bootstrap.ts
+++ b/src/renderer/web/bootstrap.ts
@@ -17,7 +17,7 @@ import {
   type WebEventConnectionPhase
 } from '../../shared/web-event-connection'
 import { installWebRendererContracts } from './api-installer'
-import { initI18n } from '@/i18n'
+import { i18next, initI18n } from '@/i18n'
 import { applyHtmlLang, resolveInitialLocale } from '@/lib/locale-preference'
 import { applyTheme, resolveInitialTheme } from '@/lib/theme'
 import openScienceLogoSvg from '../../main/remote-access/openscience-logo.svg?raw'
@@ -34,8 +34,9 @@ initI18n(initialLocale)
 applyHtmlLang(initialLocale)
 document.documentElement.setAttribute(WEB_EVENT_SURFACE_ATTRIBUTE, 'true')
 
-const REMOTE_ACCESS_OFF_MESSAGE =
+const REMOTE_ACCESS_OFF_MESSAGE = i18next.t(
   'Remote access is off on the home computer. Re-enable a remote access mode in Open Science, then try again.'
+)
 
 class RemoteAccessOffError extends Error {}
 
@@ -56,6 +57,8 @@ const setConnectionMessage = (message: string): void => {
   const element = connectionMessage()
   if (element) element.textContent = message
 }
+
+setConnectionMessage(i18next.t('Connecting to remote computer…'))
 
 const connectionLogo = document.getElementById('open-science-connection-logo')
 if (connectionLogo) {
@@ -90,7 +93,12 @@ const fetchBootstrap = async (): Promise<unknown> => {
   let lastError: unknown
   for (let attempt = 1; attempt <= BOOTSTRAP_ATTEMPTS; attempt += 1) {
     if (attempt > 1) {
-      setConnectionMessage(`Reconnecting to remote computer… (${attempt}/${BOOTSTRAP_ATTEMPTS})`)
+      setConnectionMessage(
+        i18next.t('Reconnecting to remote computer… ({{attempt}}/{{maxAttempts}})', {
+          attempt,
+          maxAttempts: BOOTSTRAP_ATTEMPTS
+        })
+      )
       await wait(Math.min(500 * 2 ** (attempt - 2), 5_000))
     }
     const controller = new AbortController()
@@ -131,11 +139,11 @@ const showConnectionFailure = (error: unknown): void => {
     message.textContent =
       error instanceof RemoteAccessOffError
         ? detail
-        : `This computer did not finish responding. ${detail}`
+        : i18next.t('This computer did not finish responding. {{detail}}', { detail })
   }
   const retry = document.createElement('button')
   retry.type = 'button'
-  retry.textContent = 'Try again'
+  retry.textContent = i18next.t('Try again')
   retry.style.cssText =
     'margin-top:18px;border:1px solid #737373;border-radius:8px;background:var(--connection-background);color:var(--connection-foreground);padding:9px 14px;font:inherit;cursor:pointer'
   retry.addEventListener('click', () => window.location.reload())

--- a/src/renderer/web/bootstrap.ts
+++ b/src/renderer/web/bootstrap.ts
@@ -31,10 +31,11 @@ applyTheme(resolveInitialTheme())
 // person reading the page — the backend host's OS locale may be something else entirely.
 const initialLocale = resolveInitialLocale()
 initI18n(initialLocale)
+const t = i18next.t.bind(i18next)
 applyHtmlLang(initialLocale)
 document.documentElement.setAttribute(WEB_EVENT_SURFACE_ATTRIBUTE, 'true')
 
-const REMOTE_ACCESS_OFF_MESSAGE = i18next.t(
+const REMOTE_ACCESS_OFF_MESSAGE = t(
   'Remote access is off on the home computer. Re-enable a remote access mode in Open Science, then try again.'
 )
 
@@ -58,7 +59,7 @@ const setConnectionMessage = (message: string): void => {
   if (element) element.textContent = message
 }
 
-setConnectionMessage(i18next.t('Connecting to remote computer…'))
+setConnectionMessage(t('Connecting to remote computer…'))
 
 const connectionLogo = document.getElementById('open-science-connection-logo')
 if (connectionLogo) {
@@ -94,7 +95,7 @@ const fetchBootstrap = async (): Promise<unknown> => {
   for (let attempt = 1; attempt <= BOOTSTRAP_ATTEMPTS; attempt += 1) {
     if (attempt > 1) {
       setConnectionMessage(
-        i18next.t('Reconnecting to remote computer… ({{attempt}}/{{maxAttempts}})', {
+        t('Reconnecting to remote computer… ({{attempt}}/{{maxAttempts}})', {
           attempt,
           maxAttempts: BOOTSTRAP_ATTEMPTS
         })
@@ -139,11 +140,11 @@ const showConnectionFailure = (error: unknown): void => {
     message.textContent =
       error instanceof RemoteAccessOffError
         ? detail
-        : i18next.t('This computer did not finish responding. {{detail}}', { detail })
+        : t('This computer did not finish responding. {{detail}}', { detail })
   }
   const retry = document.createElement('button')
   retry.type = 'button'
-  retry.textContent = i18next.t('Try again')
+  retry.textContent = t('Try again')
   retry.style.cssText =
     'margin-top:18px;border:1px solid #737373;border-radius:8px;background:var(--connection-background);color:var(--connection-foreground);padding:9px 14px;font:inherit;cursor:pointer'
   retry.addEventListener('click', () => window.location.reload())


### PR DESCRIPTION
## Problem

The Web bootstrap initializes i18n before rendering, but its pre-React connection shell writes startup, reconnect, failure, and retry copy directly as English strings. Chinese browsers therefore keep English text during connection recovery.

## Proposed change

- Route the Web bootstrap connection shell through the initialized i18next instance.
- Add Simplified and Traditional Chinese catalog entries for connection, reconnect, remote-access failure, and generic failure copy.
- Include `src/renderer/web` in the i18n orphan-key guard.
- Add regression coverage for initial connection, retry backoff, remote-access failure, and the retry action.

## Scope and non-goals

This does not change bootstrap retry counts, backoff timing, event-stream recovery, or reload behavior.

## Acceptance criteria and validation

The listed checks ran after the last material edit:

- Web bootstrap localization -> `npm test -- src/renderer/web/bootstrap.test.ts` -> 11 passed
- Catalog coverage, placeholders, and script purity -> `npm test -- src/renderer/src/i18n/resources.test.ts` -> 67 passed
- Web type safety -> `npm run typecheck:web` -> passed
- Lint -> `npm run lint` -> 0 errors; 17 pre-existing Prettier warnings in unrelated Main files
- Full portable suite -> `npm test` -> not green in this Windows environment: 12,311 tests passed and 49 failed; 155 suites could not load because Electron/native dependencies could not be built without Visual Studio C++ tools, with additional Windows symlink `EPERM` failures. The targeted renderer/i18n checks above are unaffected; exact-head CI remains authoritative for uncovered Main/native lanes.

## Review focus

Please verify that all pre-React connection-shell copy now uses the already-initialized i18n instance and that adding `renderer/web` to the orphan scan does not over-collect test-only strings.
