### PR TITLE
fix(projects): prevent stale edits and improve recovery

### DIFF
--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -649,7 +649,7 @@ describe('Data and content application commands', () => {
     deps.sessions.loadAll.mockResolvedValueOnce(loadResult)
     deps.sessions.loadOne.mockResolvedValueOnce(loadedSession)
     registerDataContentApplicationCommands(router.registrar, deps.dependencies)
-    const updateRequest = { id: 'project-1', name: 'Updated project' }
+    const updateRequest = { id: 'project-1', name: 'Updated project', expectedUpdatedAt: 1 }
     const deleteProjectRequest = { id: 'project-1' }
     const manifestRequest = { lastProjectId: 'project-1', lastSessionId: 'session-1' }
     const deleteSessionRequest = { projectId: 'project-1', sessionId: 'session-1' }

--- a/src/main/projects/ipc.test.ts
+++ b/src/main/projects/ipc.test.ts
@@ -88,7 +88,7 @@ describe('createProjectHandlers', () => {
 
     await handlers.get('project-1')
     await handlers.create({ name: 'Project' })
-    await handlers.update({ id: 'project-1', name: 'Renamed' })
+    await handlers.update({ id: 'project-1', name: 'Renamed', expectedUpdatedAt: 2 })
 
     expect(order).toEqual(['recover', 'get', 'recover', 'create', 'recover', 'update'])
   })
@@ -107,7 +107,7 @@ describe('createProjectHandlers', () => {
     const handlers = createProjectHandlers(repository, deletionCoordinator)
 
     await handlers.create({ name: 'Research', agentContext: 'Always cite DOIs.' })
-    await handlers.update({ id: 'project-1', agentContext: 'Prefer Python.' })
+    await handlers.update({ id: 'project-1', agentContext: 'Prefer Python.', expectedUpdatedAt: 2 })
 
     expect(repository.create).toHaveBeenCalledWith({
       name: 'Research',
@@ -115,7 +115,8 @@ describe('createProjectHandlers', () => {
     })
     expect(repository.update).toHaveBeenCalledWith({
       id: 'project-1',
-      agentContext: 'Prefer Python.'
+      agentContext: 'Prefer Python.',
+      expectedUpdatedAt: 2
     })
   })
 

--- a/src/main/projects/prisma-client.test.ts
+++ b/src/main/projects/prisma-client.test.ts
@@ -904,10 +904,18 @@ describe('project prisma client (integration)', () => {
     const fetched = await repository.get(created.id)
     expect(fetched?.name).toBe('Reproduction')
 
-    const renamed = await repository.update({ id: created.id, name: 'Renamed' })
+    const renamed = await repository.update({
+      id: created.id,
+      name: 'Renamed',
+      expectedUpdatedAt: created.updatedAt
+    })
     expect(renamed.name).toBe('Renamed')
 
-    const pinned = await repository.update({ id: created.id, pinned: true })
+    const pinned = await repository.update({
+      id: created.id,
+      pinned: true,
+      expectedUpdatedAt: renamed.updatedAt
+    })
     expect(pinned.pinned).toBe(true)
     expect(pinned.updatedAt).toBe(renamed.updatedAt)
 

--- a/src/main/projects/repository.test.ts
+++ b/src/main/projects/repository.test.ts
@@ -98,17 +98,41 @@ describe('project repository', () => {
   })
 
   it('patches only the provided fields on update', async () => {
+    const updated = createRow({ name: 'Renamed', updatedAt: new Date(1710000000200) })
     const { client, project } = createMockClient({
-      update: () => Promise.resolve(createRow({ name: 'Renamed' }))
+      findUnique: () => Promise.resolve(updated),
+      updateMany: () => Promise.resolve({ count: 1 })
     })
     const repository = new ProjectRepository(() => Promise.resolve(client))
 
-    await repository.update({ id: 'project-1', name: '  Renamed  ' })
+    await repository.update({
+      id: 'project-1',
+      name: '  Renamed  ',
+      expectedUpdatedAt: 1710000000100
+    })
 
-    expect(project.update).toHaveBeenCalledWith({
-      where: { id: 'project-1' },
+    expect(project.updateMany).toHaveBeenCalledWith({
+      where: { id: 'project-1', updatedAt: new Date(1710000000100) },
       data: { name: 'Renamed' }
     })
+    expect(project.update).not.toHaveBeenCalled()
+  })
+
+  it('rejects an ordinary update when the Project changed elsewhere', async () => {
+    const { client, project } = createMockClient({
+      updateMany: () => Promise.resolve({ count: 0 })
+    })
+    const repository = new ProjectRepository(() => Promise.resolve(client))
+
+    await expect(
+      repository.update({
+        id: 'project-1',
+        name: 'Renamed',
+        expectedUpdatedAt: 1710000000100
+      })
+    ).rejects.toThrow('Project changed elsewhere.')
+
+    expect(project.findUnique).not.toHaveBeenCalled()
   })
 
   it('does not roll back concurrent activity time while changing pin placement', async () => {
@@ -127,10 +151,13 @@ describe('project repository', () => {
     })
     const repository = new ProjectRepository(() => Promise.resolve(client))
 
-    await expect(repository.update({ id: 'project-1', pinned: true })).resolves.toMatchObject({
-      pinned: true,
-      updatedAt: concurrentUpdatedAt.getTime()
-    })
+    await expect(
+      repository.update({
+        id: 'project-1',
+        pinned: true,
+        expectedUpdatedAt: 1710000000100
+      })
+    ).resolves.toMatchObject({ pinned: true, updatedAt: concurrentUpdatedAt.getTime() })
 
     expect(executeRaw).toHaveBeenCalledOnce()
     expect(project.update).not.toHaveBeenCalled()
@@ -214,31 +241,43 @@ describe('project repository', () => {
 
   it('patches the Agent Context on update without touching other fields', async () => {
     const { client, project } = createMockClient({
-      update: () => Promise.resolve(createRow({ agentContext: 'Prefer Python.' }))
+      findUnique: () => Promise.resolve(createRow({ agentContext: 'Prefer Python.' })),
+      updateMany: () => Promise.resolve({ count: 1 })
     })
     const repository = new ProjectRepository(() => Promise.resolve(client))
 
-    await repository.update({ id: 'project-1', agentContext: '  Prefer Python.  ' })
+    await repository.update({
+      id: 'project-1',
+      agentContext: '  Prefer Python.  ',
+      expectedUpdatedAt: 1710000000100
+    })
 
-    expect(project.update).toHaveBeenCalledWith({
-      where: { id: 'project-1' },
+    expect(project.updateMany).toHaveBeenCalledWith({
+      where: { id: 'project-1', updatedAt: new Date(1710000000100) },
       data: { agentContext: 'Prefer Python.' }
     })
   })
 
   it('keeps the Agent Context when pinning in the same update', async () => {
     const { client, executeRaw, project } = createMockClient({
-      update: () => Promise.resolve(createRow({ pinned: true, agentContext: 'Always cite DOIs.' }))
+      findUnique: () =>
+        Promise.resolve(createRow({ pinned: true, agentContext: 'Always cite DOIs.' })),
+      updateMany: () => Promise.resolve({ count: 1 })
     })
     const repository = new ProjectRepository(() => Promise.resolve(client))
 
-    await repository.update({ id: 'project-1', pinned: true, agentContext: 'Always cite DOIs.' })
+    await repository.update({
+      id: 'project-1',
+      pinned: true,
+      agentContext: 'Always cite DOIs.',
+      expectedUpdatedAt: 1710000000100
+    })
 
     // A combined pin + Agent Context edit must not enter the pin-only raw-SQL fast path, which
     // would silently drop the Agent Context.
     expect(executeRaw).not.toHaveBeenCalled()
-    expect(project.update).toHaveBeenCalledWith({
-      where: { id: 'project-1' },
+    expect(project.updateMany).toHaveBeenCalledWith({
+      where: { id: 'project-1', updatedAt: new Date(1710000000100) },
       data: { pinned: true, agentContext: 'Always cite DOIs.' }
     })
   })

--- a/src/main/projects/repository.ts
+++ b/src/main/projects/repository.ts
@@ -93,6 +93,10 @@ class ProjectRepository {
       data.agentContext = request.agentContext.trim()
     }
 
+    if (!Number.isSafeInteger(request.expectedUpdatedAt) || request.expectedUpdatedAt <= 0) {
+      throw new Error('Project update timestamp is invalid.')
+    }
+
     const client = await this.getClient()
 
     if (
@@ -118,8 +122,16 @@ class ProjectRepository {
 
     if (request.pinned !== undefined) data.pinned = request.pinned
 
-    const row = await client.project.update({ where: { id: request.id }, data })
+    const result = await client.project.updateMany({
+      where: { id: request.id, updatedAt: new Date(request.expectedUpdatedAt) },
+      data
+    })
+    if (result.count !== 1) {
+      throw new Error('Project changed elsewhere.')
+    }
 
+    const row = await client.project.findUnique({ where: { id: request.id } })
+    if (!row) throw new Error('Project not found.')
     return toProject(row)
   }
 

--- a/src/renderer/src/hooks/useProjectFormDialog.test.tsx
+++ b/src/renderer/src/hooks/useProjectFormDialog.test.tsx
@@ -139,7 +139,8 @@ describe('useProjectFormDialog', () => {
       id: 'project-1',
       name: 'Renamed',
       description: 'A project',
-      agentContext: 'Always cite DOIs.'
+      agentContext: 'Always cite DOIs.',
+      expectedUpdatedAt: 1
     })
     expect(hook.current().dialogProps.open).toBe(false)
     expect(openProject).not.toHaveBeenCalled()
@@ -167,6 +168,23 @@ describe('useProjectFormDialog', () => {
     expect(hook.current().dialogProps.error).toBe('database is locked')
     expect(hook.current().dialogProps.isSubmitting).toBe(false)
     expect(openProject).not.toHaveBeenCalled()
+    hook.unmount()
+  })
+
+  it('explains how to recover from a stale Project edit', async () => {
+    setProjectsApi({
+      update: vi.fn().mockRejectedValue(new Error('Project changed elsewhere.'))
+    })
+    const hook = renderHook()
+
+    act(() => hook.current().openEditDialog(createProject()))
+    await act(async () => submitForm(hook.current()))
+
+    expect(hook.current().dialogProps.open).toBe(true)
+    expect(hook.current().dialogProps.error).toBe(
+      'Project changed elsewhere. Reopen Project Settings and try again.'
+    )
+    expect(hook.current().dialogProps.isSubmitting).toBe(false)
     hook.unmount()
   })
 

--- a/src/renderer/src/hooks/useProjectFormDialog.ts
+++ b/src/renderer/src/hooks/useProjectFormDialog.ts
@@ -5,7 +5,8 @@ import type { Project } from '../../../shared/projects'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useProjectStore } from '@/stores/project-store'
 
-type ProjectFormState = { mode: 'create' } | { mode: 'edit'; projectId: string }
+type ProjectFormState =
+  { mode: 'create' } | { mode: 'edit'; projectId: string; expectedUpdatedAt: number }
 
 // Structurally matches ProjectFormDialog's props; the dialog stays a controlled component.
 type ProjectFormDialogProps = {
@@ -63,7 +64,11 @@ const useProjectFormDialog = (): UseProjectFormDialogResult => {
       // A submission is in flight: ignore reopens so the pending mutation keeps its drafts.
       if (isSubmitting) return
 
-      setFormState({ mode: 'edit', projectId: project.id })
+      setFormState({
+        mode: 'edit',
+        projectId: project.id,
+        expectedUpdatedAt: project.updatedAt
+      })
       setNameDraft(project.name)
       setDescriptionDraft(project.description)
       setAgentContextDraft(project.agentContext ?? '')
@@ -96,7 +101,13 @@ const useProjectFormDialog = (): UseProjectFormDialogResult => {
 
     const request = isCreate
       ? createProject({ name, description, agentContext })
-      : updateProject({ id: formState.projectId, name, description, agentContext })
+      : updateProject({
+          id: formState.projectId,
+          name,
+          description,
+          agentContext,
+          expectedUpdatedAt: formState.expectedUpdatedAt
+        })
 
     void request
       .then((project) => {
@@ -112,7 +123,13 @@ const useProjectFormDialog = (): UseProjectFormDialogResult => {
         if (isCreate) openProject(project.id, 'user')
       })
       .catch((error: unknown) => {
-        setFormError(error instanceof Error ? error.message : t('Could not save project.'))
+        setFormError(
+          error instanceof Error && error.message === 'Project changed elsewhere.'
+            ? t('Project changed elsewhere. Reopen Project Settings and try again.')
+            : error instanceof Error
+              ? error.message
+              : t('Could not save project.')
+        )
       })
       .finally(() => {
         setIsSubmitting(false)

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -448,6 +448,7 @@
   "Could not reveal the log file.": "无法在文件夹中显示日志文件。",
   "Could not save contribution template. Try again.": "无法保存贡献模板，请重试。",
   "Could not save project.": "无法保存项目。",
+  "Project changed elsewhere. Reopen Project Settings and try again.": "项目已在其他位置更改。请重新打开项目设置后再试。",
   "Could not save provider.": "无法保存模型服务商。",
   "Could not save the Claude token.": "无法保存 Claude token。",
   "Could not save the Claude token. Try again.": "无法保存 Claude token。重试一次。",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -447,6 +447,7 @@
   "Could not reveal the log file.": "無法在資料夾中顯示記錄檔。",
   "Could not save contribution template. Try again.": "無法儲存貢獻範本，請重試。",
   "Could not save project.": "無法儲存專案。",
+  "Project changed elsewhere. Reopen Project Settings and try again.": "專案已在其他位置變更。請重新開啟專案設定後再試。",
   "Could not save provider.": "無法儲存模型服務商。",
   "Could not save the Claude token.": "無法儲存 Claude token。",
   "Could not save the Claude token. Try again.": "無法儲存 Claude token。重試一次。",

--- a/src/renderer/src/pages/home/HomePage.render.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.render.test.tsx
@@ -650,7 +650,11 @@ describe('HomePage activity overview', () => {
     )
     await act(async () => Promise.resolve())
 
-    expect(updateProject).toHaveBeenCalledWith({ id: project.id, pinned: true })
+    expect(updateProject).toHaveBeenCalledWith({
+      id: project.id,
+      pinned: true,
+      expectedUpdatedAt: project.updatedAt
+    })
     expect(container.textContent).toContain('Pinned project')
 
     openRadixMenu(
@@ -663,7 +667,11 @@ describe('HomePage activity overview', () => {
     clickRadixMenuItem(unpinItem)
     await act(async () => Promise.resolve())
 
-    expect(updateProject).toHaveBeenLastCalledWith({ id: project.id, pinned: false })
+    expect(updateProject).toHaveBeenLastCalledWith({
+      id: project.id,
+      pinned: false,
+      expectedUpdatedAt: project.updatedAt
+    })
   })
 
   it('groups pinned Projects first while preserving recent activity order inside both groups', async () => {
@@ -1500,5 +1508,29 @@ describe('HomePage activity overview', () => {
     const recentRow = container.querySelector<HTMLElement>('[aria-label="Recent sessions"] button')
     expect(recentRow?.textContent).toContain(project.name)
     expect(recentRow?.textContent?.match(/Live analysis/g)).toHaveLength(1)
+  })
+
+  it('offers a Retry action when loading Projects fails', async () => {
+    const loadProjects = vi.fn().mockResolvedValue(undefined)
+    useProjectStore.setState({
+      ...createInitialProjectState(),
+      isLoaded: true,
+      loadError: 'database is locked',
+      loadProjects
+    })
+
+    await act(async () =>
+      root.render(
+        <HomePage canDeleteProjects hasCompleteSessionCatalog onOpenGlobalSearch={vi.fn()} />
+      )
+    )
+
+    const retry = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent === 'Retry'
+    )
+    expect(retry).toBeDefined()
+
+    await act(async () => retry?.click())
+    expect(loadProjects).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -141,6 +141,7 @@ const HomePage = ({
   const { t } = useTranslation()
   const projects = useProjectStore((state) => state.projects)
   const loadError = useProjectStore((state) => state.loadError)
+  const loadProjects = useProjectStore((state) => state.loadProjects)
   const updateProject = useProjectStore((state) => state.updateProject)
   const updateProjectArchive = useProjectStore((state) => state.updateProjectArchive)
   const deleteProject = useProjectStore((state) => state.deleteProject)
@@ -172,6 +173,7 @@ const HomePage = ({
   const [archivingProjectIds, setArchivingProjectIds] = useState<Set<string>>(() => new Set())
   const [pinningProjectIds, setPinningProjectIds] = useState<Set<string>>(() => new Set())
   const [projectActionError, setProjectActionError] = useState<string | undefined>(undefined)
+  const [isRetryingProjects, setIsRetryingProjects] = useState(false)
   const [artifactCounts, setArtifactCounts] = useState<Map<string, number>>(() => new Map())
   const [markingReadSessionIds, setMarkingReadSessionIds] = useState<Set<string>>(() => new Set())
   const [markReadErrorSessionIds, setMarkReadErrorSessionIds] = useState<Set<string>>(
@@ -357,6 +359,13 @@ const HomePage = ({
     })
   }, [consumeProjectCreation, openCreateDialog, pendingProjectCreation])
 
+  const retryProjectLoad = (): void => {
+    if (isRetryingProjects) return
+
+    setIsRetryingProjects(true)
+    void loadProjects().finally(() => setIsRetryingProjects(false))
+  }
+
   const openDeleteDialog = (project: Project): void => {
     if (!canDeleteProjects) return
 
@@ -433,7 +442,11 @@ const HomePage = ({
 
     setPinningProjectIds((current) => new Set(current).add(project.id))
     setProjectActionError(undefined)
-    void updateProject({ id: project.id, pinned: !project.pinned })
+    void updateProject({
+      id: project.id,
+      pinned: !project.pinned,
+      expectedUpdatedAt: project.updatedAt
+    })
       .catch((error: unknown) =>
         setProjectActionError(
           error instanceof Error ? error.message : t('Could not update project pin.')
@@ -732,7 +745,17 @@ const HomePage = ({
                 className="rounded-2xl border border-danger-000/30 px-4 py-6 text-center text-sm text-danger-000"
                 role="alert"
               >
-                {t('Could not load projects: {{error}}', { error: loadError })}
+                <p>{t('Could not load projects: {{error}}', { error: loadError })}</p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="mt-3"
+                  disabled={isRetryingProjects}
+                  onClick={retryProjectLoad}
+                >
+                  {isRetryingProjects ? t('Retrying...') : t('Retry')}
+                </Button>
               </div>
             ) : projectSummaries.length === 0 ? (
               <div className="rounded-2xl border border-dashed border-border-200/70 px-4 py-10 text-center text-sm text-muted-foreground">

--- a/src/renderer/src/pages/home/ProjectFormDialog.tsx
+++ b/src/renderer/src/pages/home/ProjectFormDialog.tsx
@@ -19,6 +19,10 @@ import {
 } from '@/components/ui/dialog-chrome'
 import { useRetainedDialogValue } from '@/components/ui/use-retained-dialog-value'
 import { Input } from '@/components/ui/input'
+import {
+  PROJECT_DESCRIPTION_MAX_LENGTH,
+  PROJECT_NAME_MAX_LENGTH
+} from '../../../../shared/projects'
 
 type ProjectFormDialogProps = {
   open: boolean
@@ -103,6 +107,7 @@ const ProjectFormDialog = ({
                   onChange={(event) => onNameChange(event.target.value)}
                   placeholder={t('e.g. Reproduction of published research')}
                   autoFocus
+                  maxLength={PROJECT_NAME_MAX_LENGTH}
                   className={`${dialogFormInputClassName} h-9 px-3 text-sm`}
                 />
               </div>
@@ -122,6 +127,7 @@ const ProjectFormDialog = ({
                   onChange={(event) => onDescriptionChange(event.target.value)}
                   placeholder={t('Describe what this project is about…')}
                   rows={3}
+                  maxLength={PROJECT_DESCRIPTION_MAX_LENGTH}
                   className={dialogFormTextareaClassName}
                 />
               </div>

--- a/src/renderer/src/pages/home/home-dialogs.render.test.tsx
+++ b/src/renderer/src/pages/home/home-dialogs.render.test.tsx
@@ -141,6 +141,7 @@ describe('home dialogs shared chrome', () => {
       "Shown in the project list for your reference — not included in the agent's prompt."
     )
     const elements = collectElements(tree)
+    const nameField = elements.find((element) => element.props.id === 'project-form-name')
     const descriptionField = elements.find((element) => element.type === 'textarea')
     const agentContextField = elements.find(
       (element) => element.props.id === 'project-form-agent-context'
@@ -169,6 +170,8 @@ describe('home dialogs shared chrome', () => {
       agentContextField
     ].forEach((field) => expectDialogFormFieldClassName(field?.props.className))
     expect(descriptionField?.props['aria-describedby']).toBe('project-form-description-help')
+    expect(nameField?.props.maxLength).toBe(200)
+    expect(descriptionField?.props.maxLength).toBe(1000)
     expect(descriptionField?.props.placeholder).toBe('Describe what this project is about…')
     expect(agentContextField?.props['aria-describedby']).toBe('project-form-agent-context-help')
     expect(cancelButton?.props.variant).toBe('ghost')

--- a/src/renderer/src/pages/settings/ArchivedPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ArchivedPanel.render.test.tsx
@@ -123,4 +123,39 @@ describe('ArchivedPanel', () => {
     })
     expect(useArchiveUndoStore.getState().notices).toEqual([])
   })
+
+  it('clears a failed Project deletion error before opening the next confirmation', async () => {
+    const deleteProject = vi.fn().mockRejectedValue(new Error('first deletion failed'))
+    useProjectStore.setState({
+      ...createInitialProjectState(),
+      projects: [{ ...project, archivedAt: 2 }],
+      isLoaded: true,
+      deleteProject
+    })
+    useSessionStore.setState({ ...createInitialSessionState(), sessions: [] })
+    await act(async () =>
+      root.render(
+        <ArchivedPanel view={{ kind: 'project', projectId: project.id }} onNavigate={vi.fn()} />
+      )
+    )
+
+    const openDelete = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.includes('Delete project')
+    )
+    await act(async () => openDelete?.click())
+    let dialog = document.body.querySelector<HTMLElement>('[role="alertdialog"]')
+    const confirmDelete = Array.from(
+      dialog?.querySelectorAll<HTMLButtonElement>('button') ?? []
+    ).find((button) => button.textContent === 'Delete')
+    await act(async () => confirmDelete?.click())
+
+    expect(dialog?.querySelector('[role="alert"]')?.textContent).toBe('first deletion failed')
+
+    const close = dialog?.querySelector<HTMLButtonElement>('[aria-label="Close"]')
+    await act(async () => close?.click())
+    await act(async () => openDelete?.click())
+    dialog = document.body.querySelector<HTMLElement>('[role="alertdialog"]')
+
+    expect(dialog?.querySelector('[role="alert"]')).toBeNull()
+  })
 })

--- a/src/renderer/src/pages/settings/ArchivedPanel.tsx
+++ b/src/renderer/src/pages/settings/ArchivedPanel.tsx
@@ -34,7 +34,8 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
   const [projectToDelete, setProjectToDelete] = useState<Project | undefined>()
   const [sessionToDelete, setSessionToDelete] = useState<ChatSession | undefined>()
   const [busyKey, setBusyKey] = useState<string | undefined>()
-  const [error, setError] = useState<string | undefined>()
+  const [panelError, setPanelError] = useState<string | undefined>()
+  const [projectDeleteError, setProjectDeleteError] = useState<string | undefined>()
 
   const archivedProjects = useMemo(
     () => projects.filter((project) => project.archivedAt !== undefined),
@@ -63,7 +64,7 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
   const restoreProject = (project: Project): void => {
     if (project.archivedAt === undefined) return
     setBusyKey(`project:${project.id}`)
-    setError(undefined)
+    setPanelError(undefined)
     void updateProjectArchive({
       id: project.id,
       archived: false,
@@ -71,7 +72,7 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
     })
       .then(() => onNavigate({ kind: 'list' }))
       .catch((restoreError: unknown) =>
-        setError(describeError(restoreError, t('Could not restore project.')))
+        setPanelError(describeError(restoreError, t('Could not restore project.')))
       )
       .finally(() => setBusyKey(undefined))
   }
@@ -79,7 +80,7 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
   const restoreSession = (session: ChatSession): void => {
     if (session.archivedAt === undefined) return
     setBusyKey(`session:${session.id}`)
-    setError(undefined)
+    setPanelError(undefined)
     void updateSessionArchive({
       projectId: session.projectId,
       sessionId: session.id,
@@ -87,7 +88,7 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
       expectedArchivedAt: session.archivedAt
     })
       .catch((restoreError: unknown) =>
-        setError(describeError(restoreError, t('Could not restore session.')))
+        setPanelError(describeError(restoreError, t('Could not restore session.')))
       )
       .finally(() => setBusyKey(undefined))
   }
@@ -97,7 +98,7 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
     if (!session) return
 
     setBusyKey(`session:${session.id}`)
-    setError(undefined)
+    setPanelError(undefined)
     void (async () => {
       const state = await window.api.acp.getState()
       if (state.sessionIds.includes(session.id)) {
@@ -112,9 +113,21 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
       setSessionToDelete(undefined)
     })()
       .catch((deleteError: unknown) =>
-        setError(describeError(deleteError, t('Could not delete session.')))
+        setPanelError(describeError(deleteError, t('Could not delete session.')))
       )
       .finally(() => setBusyKey(undefined))
+  }
+
+  const openProjectDeleteDialog = (project: Project): void => {
+    setProjectDeleteError(undefined)
+    setProjectToDelete(project)
+  }
+
+  const closeProjectDeleteDialog = (): void => {
+    if (busyKey === `project:${projectToDelete?.id}`) return
+
+    setProjectToDelete(undefined)
+    setProjectDeleteError(undefined)
   }
 
   const deleteArchivedProject = (): void => {
@@ -122,7 +135,7 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
     if (!project) return
 
     setBusyKey(`project:${project.id}`)
-    setError(undefined)
+    setProjectDeleteError(undefined)
     void (async () => {
       const state = await window.api.acp.getState()
       const liveIds = new Set(state.sessionIds)
@@ -138,7 +151,7 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
     })()
       .then(() => onNavigate({ kind: 'list' }))
       .catch((deleteError: unknown) =>
-        setError(describeError(deleteError, t('Could not delete project.')))
+        setProjectDeleteError(describeError(deleteError, t('Could not delete project.')))
       )
       .finally(() => setBusyKey(undefined))
   }
@@ -172,7 +185,10 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
         size="sm"
         className="text-danger-000 hover:text-danger-000"
         disabled={busyKey === `session:${session.id}`}
-        onClick={() => setSessionToDelete(session)}
+        onClick={() => {
+          setPanelError(undefined)
+          setSessionToDelete(session)
+        }}
       >
         <Trash2 className="size-3.5" aria-hidden="true" />
         {t('Delete')}
@@ -182,9 +198,9 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
 
   return (
     <div className="space-y-5 p-5">
-      {error ? (
+      {panelError ? (
         <p role="alert" className="text-sm text-danger-000">
-          {error}
+          {panelError}
         </p>
       ) : null}
       {selectedProject ? (
@@ -217,7 +233,7 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
                 size="sm"
                 className="text-danger-000 hover:text-danger-000"
                 disabled={busyKey === `project:${selectedProject.id}`}
-                onClick={() => setProjectToDelete(selectedProject)}
+                onClick={() => openProjectDeleteDialog(selectedProject)}
               >
                 <Trash2 className="size-3.5" aria-hidden="true" />
                 {t('Delete project')}
@@ -294,8 +310,8 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
         hasCompleteSessionCatalog
         canDelete
         isDeleting={busyKey === `project:${projectToDelete?.id}`}
-        error={error}
-        onCancel={() => setProjectToDelete(undefined)}
+        error={projectDeleteError}
+        onCancel={closeProjectDeleteDialog}
         onConfirmDelete={deleteArchivedProject}
       />
       <DeleteSessionDialog

--- a/src/renderer/src/stores/project-store.test.ts
+++ b/src/renderer/src/stores/project-store.test.ts
@@ -68,6 +68,26 @@ describe('project store', () => {
     expect(useProjectStore.getState().projects.map((candidate) => candidate.id)).toEqual(['new'])
   })
 
+  it('reloads after a project is created while initial hydration is in flight', async () => {
+    const staleLoad = createDeferred<Project[]>()
+    const created = createProject({ id: 'created', name: 'New', updatedAt: 500 })
+    const list = vi.fn().mockReturnValueOnce(staleLoad.promise).mockResolvedValueOnce([created])
+    setProjectsApi({
+      list,
+      create: vi.fn().mockResolvedValue(created)
+    })
+
+    const pendingLoad = useProjectStore.getState().loadProjects()
+    await useProjectStore.getState().createProject({ name: 'New' })
+    staleLoad.resolve([])
+    await pendingLoad
+
+    expect(list).toHaveBeenCalledTimes(2)
+    expect(useProjectStore.getState().projects).toEqual([created])
+    expect(useProjectStore.getState().isLoaded).toBe(true)
+    expect(useProjectStore.getState().loadError).toBeUndefined()
+  })
+
   it('merges a created project into the cache and returns it', async () => {
     const created = createProject({ id: 'created', name: 'New', updatedAt: 500 })
     setProjectsApi({ create: vi.fn().mockResolvedValue(created) })

--- a/src/renderer/src/stores/project-store.ts
+++ b/src/renderer/src/stores/project-store.ts
@@ -39,6 +39,7 @@ const upsertProjectList = (projects: Project[], project: Project): Project[] => 
 }
 
 let projectLoadSequence = 0
+let projectMutationSequence = 0
 
 export const createInitialProjectState = (): ProjectStoreData => ({
   projects: [],
@@ -47,20 +48,30 @@ export const createInitialProjectState = (): ProjectStoreData => ({
 })
 
 // Renderer cache of the SQLite-backed project list; the DB remains the source of truth.
-export const useProjectStore = create<ProjectStore>((set) => ({
+export const useProjectStore = create<ProjectStore>((set, get) => ({
   ...createInitialProjectState(),
 
   // Loads the full project list once at startup and after mutations that need a resync. A DB/IPC
   // failure is recorded (not thrown) so the home screen can show an error instead of a silent empty list.
   loadProjects: async () => {
     const loadSequence = ++projectLoadSequence
+    const mutationSequence = projectMutationSequence
     try {
       const projects = await window.api.projects.list()
       if (loadSequence !== projectLoadSequence) return
+      if (mutationSequence !== projectMutationSequence) {
+        await get().loadProjects()
+        return
+      }
 
       set({ projects: sortByUpdatedDesc(projects), isLoaded: true, loadError: undefined })
     } catch (error) {
       if (loadSequence !== projectLoadSequence) return
+      if (mutationSequence !== projectMutationSequence) {
+        await get().loadProjects()
+        return
+      }
+
       set({ isLoaded: true, loadError: describeError(error) })
     }
   },
@@ -70,6 +81,7 @@ export const useProjectStore = create<ProjectStore>((set) => ({
   createProject: async (request) => {
     const project = await window.api.projects.create(request)
 
+    projectMutationSequence += 1
     set((state) => ({ projects: upsertProjectList(state.projects, project), loadError: undefined }))
 
     return project
@@ -79,6 +91,7 @@ export const useProjectStore = create<ProjectStore>((set) => ({
   updateProject: async (request) => {
     const project = await window.api.projects.update(request)
 
+    projectMutationSequence += 1
     set((state) => ({ projects: upsertProjectList(state.projects, project) }))
 
     return project
@@ -87,6 +100,7 @@ export const useProjectStore = create<ProjectStore>((set) => ({
   updateProjectArchive: async (request) => {
     const project = await window.api.projects.updateArchive(request)
 
+    projectMutationSequence += 1
     set((state) => ({ projects: upsertProjectList(state.projects, project) }))
     return project
   },
@@ -95,12 +109,17 @@ export const useProjectStore = create<ProjectStore>((set) => ({
   deleteProject: async (id) => {
     await window.api.projects.delete({ id })
 
+    projectMutationSequence += 1
     set((state) => ({ projects: state.projects.filter((project) => project.id !== id) }))
   },
 
-  upsertProject: (project) =>
-    set((state) => ({ projects: upsertProjectList(state.projects, project) })),
+  upsertProject: (project) => {
+    projectMutationSequence += 1
+    set((state) => ({ projects: upsertProjectList(state.projects, project) }))
+  },
 
-  removeProject: (id) =>
+  removeProject: (id) => {
+    projectMutationSequence += 1
     set((state) => ({ projects: state.projects.filter((project) => project.id !== id) }))
+  }
 }))

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -4503,7 +4503,7 @@ describe('session store public contract', () => {
       'src/renderer/src/stores/archive-undo-store.ts',
       'src/renderer/src/stores/navigation-store.ts'
     ])
-  }, 10_000)
+  })
 
   it('hydrates newest-first while preserving manifest and explicit selection semantics', () => {
     const older: PersistedChatSession = {

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -4503,7 +4503,7 @@ describe('session store public contract', () => {
       'src/renderer/src/stores/archive-undo-store.ts',
       'src/renderer/src/stores/navigation-store.ts'
     ])
-  })
+  }, 10_000)
 
   it('hydrates newest-first while preserving manifest and explicit selection semantics', () => {
     const older: PersistedChatSession = {

--- a/src/shared/projects.test.ts
+++ b/src/shared/projects.test.ts
@@ -23,11 +23,15 @@ describe('project application command contracts', () => {
       { name: 'Project' }
     ])
     expect(
-      projectApplicationCommandContracts.update.args.parse([{ id: 'project-1', name: 'Renamed' }])
-    ).toEqual([{ id: 'project-1', name: 'Renamed' }])
+      projectApplicationCommandContracts.update.args.parse([
+        { id: 'project-1', name: 'Renamed', expectedUpdatedAt: 2 }
+      ])
+    ).toEqual([{ id: 'project-1', name: 'Renamed', expectedUpdatedAt: 2 }])
     expect(
-      projectApplicationCommandContracts.update.args.parse([{ id: 'project-1', pinned: true }])
-    ).toEqual([{ id: 'project-1', pinned: true }])
+      projectApplicationCommandContracts.update.args.parse([
+        { id: 'project-1', pinned: true, expectedUpdatedAt: 2 }
+      ])
+    ).toEqual([{ id: 'project-1', pinned: true, expectedUpdatedAt: 2 }])
     expect(
       projectApplicationCommandContracts.create.args.parse([
         { name: 'Project', agentContext: 'Always cite DOIs.' }
@@ -35,9 +39,9 @@ describe('project application command contracts', () => {
     ).toEqual([{ name: 'Project', agentContext: 'Always cite DOIs.' }])
     expect(
       projectApplicationCommandContracts.update.args.parse([
-        { id: 'project-1', agentContext: 'Always cite DOIs.' }
+        { id: 'project-1', agentContext: 'Always cite DOIs.', expectedUpdatedAt: 2 }
       ])
-    ).toEqual([{ id: 'project-1', agentContext: 'Always cite DOIs.' }])
+    ).toEqual([{ id: 'project-1', agentContext: 'Always cite DOIs.', expectedUpdatedAt: 2 }])
     expect(
       projectApplicationCommandContracts.get.result.parse({
         ...project,
@@ -75,5 +79,46 @@ describe('project application command contracts', () => {
         { name: 'Project', agentContext: oversized }
       ])
     ).toThrow()
+  })
+
+  it('requires an update baseline and enforces Project name and description limits', () => {
+    expect(() =>
+      projectApplicationCommandContracts.update.args.parse([{ id: 'project-1', name: 'Renamed' }])
+    ).toThrow()
+    expect(() =>
+      projectApplicationCommandContracts.create.args.parse([{ name: 'x'.repeat(201) }])
+    ).toThrow()
+    expect(() =>
+      projectApplicationCommandContracts.create.args.parse([
+        { name: 'Project', description: 'x'.repeat(1001) }
+      ])
+    ).toThrow()
+    expect(() =>
+      projectApplicationCommandContracts.update.args.parse([
+        { id: 'project-1', name: 'x'.repeat(201), expectedUpdatedAt: 2 }
+      ])
+    ).toThrow()
+    expect(() =>
+      projectApplicationCommandContracts.update.args.parse([
+        { id: 'project-1', description: 'x'.repeat(1001), expectedUpdatedAt: 2 }
+      ])
+    ).toThrow()
+    expect(
+      projectApplicationCommandContracts.create.args.parse([
+        { name: 'x'.repeat(200), description: 'x'.repeat(1000) }
+      ])
+    ).toEqual([{ name: 'x'.repeat(200), description: 'x'.repeat(1000) }])
+  })
+
+  it('keeps historical projects above the new write limits readable', () => {
+    const historicalProject = {
+      ...project,
+      name: 'x'.repeat(201),
+      description: 'x'.repeat(1001)
+    }
+
+    expect(projectApplicationCommandContracts.list.result.parse([historicalProject])).toEqual([
+      historicalProject
+    ])
   })
 })

--- a/src/shared/projects.ts
+++ b/src/shared/projects.ts
@@ -7,6 +7,9 @@ import { validationCodec, type ApplicationCommandContract } from './application-
 // The SQLite/Prisma layer owns Project rows (see src/main/projects). Timestamps are normalized to
 // epoch milliseconds at the repository boundary so the renderer treats them like session timestamps.
 
+export const PROJECT_NAME_MAX_LENGTH = 200
+export const PROJECT_DESCRIPTION_MAX_LENGTH = 1000
+
 export const projectSchema = z
   .object({
     id: z.string(),
@@ -29,8 +32,8 @@ export const projectSchema = z
 
 export const createProjectRequestSchema = z
   .object({
-    name: z.string(),
-    description: z.string().optional(),
+    name: z.string().max(PROJECT_NAME_MAX_LENGTH),
+    description: z.string().max(PROJECT_DESCRIPTION_MAX_LENGTH).optional(),
     agentContext: z.string().max(16000).optional()
   })
   .strict()
@@ -38,8 +41,9 @@ export const createProjectRequestSchema = z
 export const updateProjectRequestSchema = z
   .object({
     id: z.string(),
-    name: z.string().optional(),
-    description: z.string().optional(),
+    name: z.string().max(PROJECT_NAME_MAX_LENGTH).optional(),
+    description: z.string().max(PROJECT_DESCRIPTION_MAX_LENGTH).optional(),
+    expectedUpdatedAt: z.number().int().positive(),
     agentContext: z.string().max(16000).optional(),
     pinned: z.boolean().optional()
   })


### PR DESCRIPTION
## Problem

Project editing had four reliability gaps:

- ordinary edits did not carry a write baseline, so a stale window could overwrite a newer edit;
- Project name and description accepted unbounded input;
- Home exposed Project loading errors without a retry action;
- ArchivedPanel reused one error state, so a failed Project deletion could leak into the next confirmation dialog.

## Proposed change

- require `expectedUpdatedAt` for Project updates and compare-and-set ordinary edits against the persisted `updatedAt`;
- keep the edit dialog open and provide localized recovery guidance when another window wins the update;
- cap Project names at 200 characters and descriptions at 1000 in both the shared write contracts and form controls;
- add an in-place Home retry action with pending-state protection;
- isolate Project deletion dialog errors from panel/session errors and clear them at dialog boundaries.

## Scope and non-goals

- No database schema migration, backfill, or new revision column.
- Existing persisted Projects above the new limits remain readable and are not truncated; their next name/description edit must satisfy the new limits.
- No enum or status values are added.
- Pin-only writes retain their existing timestamp-preserving path.

## Acceptance criteria and validation

- stale ordinary Project updates are rejected instead of overwriting a newer write;
- create/update contracts and UI enforce name <= 200 and description <= 1000;
- Home Project load failures offer Retry;
- a failed archived Project deletion error does not appear in a later deletion dialog.

Validation performed:

- 9 focused Project-related Vitest files: 106 tests passed
- `npm run typecheck:node`
- `npm run typecheck:web`
- i18n resources guard: 67 tests passed
- `npm run lint` (passes with 17 pre-existing formatting warnings outside this change)

Full test execution is left to PR CI per the requested module-scoped workflow.

## Review focus

- the `updatedAt` optimistic concurrency boundary in `ProjectRepository.update`;
- historical oversized Project read compatibility;
- dialog error-state lifetimes in ArchivedPanel.