### PR TITLE
fix(workspace): place settings before notifications

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -118,6 +118,16 @@ describe('WorkspaceSidebar accessible render', () => {
     expect(html).toContain('aria-label="Messages, no unread messages"')
   })
 
+  it('places Settings before notifications in the footer controls', async () => {
+    const html = await renderSidebar([createSession({ id: 'session-a' })])
+    const settingsIndex = html.indexOf('aria-label="Settings"')
+    const notificationsIndex = html.indexOf('aria-label="Messages, no unread messages"')
+
+    expect(settingsIndex).toBeGreaterThanOrEqual(0)
+    expect(notificationsIndex).toBeGreaterThanOrEqual(0)
+    expect(settingsIndex).toBeLessThan(notificationsIndex)
+  })
+
   it('softens the session list behind the footer controls', async () => {
     const html = await renderSidebar([createSession({ id: 'session-a' })])
 

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -656,12 +656,6 @@ const WorkspaceSidebarView = ({
             />
             <UpdateCapsule variant="session" className="mb-1.5" />
             <div className="flex items-center gap-1 pb-2">
-              <NotificationBell
-                side="top"
-                align="start"
-                className="size-8 rounded-md"
-                onOpen={mobileMode ? onMobileClose : undefined}
-              />
               <button
                 type="button"
                 onClick={onOpenSettings}
@@ -673,6 +667,12 @@ const WorkspaceSidebarView = ({
               >
                 <Settings className="size-4" strokeWidth={2} aria-hidden="true" />
               </button>
+              <NotificationBell
+                side="top"
+                align="start"
+                className="size-8 rounded-md"
+                onOpen={mobileMode ? onMobileClose : undefined}
+              />
               <GitHubStarBadge />
               <NetworkStatusIndicator variant="icon" />
             </div>


### PR DESCRIPTION
## Problem

The Workspace sidebar footer placed notifications before Settings, while Settings should be the first control at the lower left.

## Proposed change

- Move the Settings button before the notification bell.
- Add a render regression test that asserts the DOM order.

## Scope and non-goals

This only changes the footer control order. It does not change Settings navigation, notification behavior, user-visible copy, i18n catalogs, or cross-process contracts.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Workspace footer order -> `npm run test:module -- workspace_page` -> passed (23 files, 392 tests).
- Renderer type safety -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint` -> passed with 0 errors; 17 pre-existing formatting warnings remain in unrelated main/notebook files.

Consumer and platform lanes are excluded locally because the change only reorders sibling renderer controls without changing callbacks, interfaces, persistence, IPC, or platform-specific behavior. The complete and platform CI suites remain authoritative on the PR.

## Review focus

Confirm the footer order is Settings, notifications, GitHub, then network status, and that the regression test captures the intended Settings-before-notifications requirement.
