### PR TITLE
fix(notebook): fall back when PowerShell ACL launch is denied

### DIFF
--- a/src/main/notebook/micromamba-cache-acl.integration.test.ts
+++ b/src/main/notebook/micromamba-cache-acl.integration.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   hardenWindowsCacheAcl,
+  hardenWindowsCacheAclWithIcacls,
   isTrustedWindowsCacheAcl,
   readWindowsCacheAcl
 } from './micromamba-cache'
@@ -21,6 +22,21 @@ describe.runIf(process.platform === 'win32')('Windows micromamba cache ACL integ
       const directory = mkdtempSync(join(tmpdir(), 'os-cache-acl-'))
       try {
         hardenWindowsCacheAcl(directory)
+
+        expect(isTrustedWindowsCacheAcl(readWindowsCacheAcl(directory))).toBe(true)
+      } finally {
+        rmSync(directory, { recursive: true, force: true })
+      }
+    },
+    ACL_INTEGRATION_TIMEOUT_MS
+  )
+
+  it(
+    'applies a fallback ACL accepted by the production trust verifier',
+    () => {
+      const directory = mkdtempSync(join(tmpdir(), 'os-cache-icacls-'))
+      try {
+        hardenWindowsCacheAclWithIcacls(directory)
 
         expect(isTrustedWindowsCacheAcl(readWindowsCacheAcl(directory))).toBe(true)
       } finally {

--- a/src/main/notebook/micromamba-cache-powershell.test.ts
+++ b/src/main/notebook/micromamba-cache-powershell.test.ts
@@ -35,4 +35,43 @@ describe('Windows micromamba cache PowerShell invocation', () => {
       expect(executable).toBe('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe')
     }
   })
+
+  it('falls back to the system ACL tool when PowerShell execution is denied', () => {
+    childProcessMocks.execFileSync.mockImplementationOnce(() => {
+      throw Object.assign(new Error('spawnSync powershell.exe EPERM'), { code: 'EPERM' })
+    })
+    childProcessMocks.execFileSync.mockReturnValueOnce('CONTOSO\\alice,S-1-5-21-1000\r\n')
+
+    expect(hardenWindowsCacheAcl('D:\\osp-cache')).toBe(true)
+
+    expect(childProcessMocks.execFileSync).toHaveBeenCalledTimes(3)
+    expect(childProcessMocks.execFileSync).toHaveBeenNthCalledWith(
+      2,
+      'C:\\Windows\\System32\\whoami.exe',
+      ['/user', '/fo', 'csv', '/nh'],
+      { encoding: 'utf8', windowsHide: true }
+    )
+    expect(childProcessMocks.execFileSync).toHaveBeenNthCalledWith(
+      3,
+      'C:\\Windows\\System32\\icacls.exe',
+      [
+        'D:\\osp-cache',
+        '/inheritance:r',
+        '/grant:r',
+        '*S-1-5-21-1000:(OI)(CI)F',
+        '*S-1-5-18:(OI)(CI)F',
+        '*S-1-5-32-544:(OI)(CI)F'
+      ],
+      { encoding: 'utf8', windowsHide: true }
+    )
+  })
+
+  it('does not hide PowerShell script failures behind the fallback', () => {
+    childProcessMocks.execFileSync.mockImplementationOnce(() => {
+      throw Object.assign(new Error('PowerShell command failed'), { code: 'UNKNOWN' })
+    })
+
+    expect(() => hardenWindowsCacheAcl('D:\\osp-cache')).toThrow('PowerShell command failed')
+    expect(childProcessMocks.execFileSync).toHaveBeenCalledOnce()
+  })
 })

--- a/src/main/notebook/micromamba-cache-preparation.test.ts
+++ b/src/main/notebook/micromamba-cache-preparation.test.ts
@@ -61,6 +61,27 @@ describe('Windows micromamba cache preparation', () => {
     )
   })
 
+  it('does not require a PowerShell ACL read after a new cache was securely hardened', () => {
+    const hardenOwnership = vi.fn(() => true)
+    const verifyOwnership = vi.fn(() => false)
+
+    const cache = selectMicromambaCache(
+      'D:\\OpenScience\\runtime',
+      DEFAULT_MAX_CACHE_RELATIVE_PATH,
+      {
+        platform: 'win32',
+        env: { USERNAME: 'alice', USERPROFILE: 'C:\\Users\\alice' },
+        canonicalize: (path) => win32.normalize(path),
+        hardenOwnership,
+        verifyOwnership
+      }
+    )
+
+    expect(cache.path).toMatch(/^D:\\osp[0-9a-f]{10}$/)
+    expect(hardenOwnership).toHaveBeenCalledOnce()
+    expect(verifyOwnership).not.toHaveBeenCalled()
+  })
+
   it('removes newly created candidates when ACL hardening fails', () => {
     const hardenOwnership = vi.fn(() => {
       throw new Error('Set-Acl denied')
@@ -115,5 +136,41 @@ describe('Windows micromamba cache preparation', () => {
 
     expect(cache.path).toMatch(/^D:\\osp/)
     expect(hardenOwnership).not.toHaveBeenCalled()
+  })
+
+  it('rejects an untrusted existing cache before accepting a newly hardened fallback', () => {
+    fsMocks.lstatSync.mockImplementationOnce(
+      () =>
+        ({
+          isDirectory: () => true,
+          isSymbolicLink: () => false
+        }) as never
+    )
+    fsMocks.readFileSync.mockImplementationOnce(() =>
+      JSON.stringify({
+        schema: 1,
+        canonicalRoot: 'd:\\openscience\\runtime',
+        userIdentity: 'alice'
+      })
+    )
+    const hardenOwnership = vi.fn(() => true)
+    const verifyOwnership = vi.fn(() => false)
+
+    const cache = selectMicromambaCache(
+      'D:\\OpenScience\\runtime',
+      DEFAULT_MAX_CACHE_RELATIVE_PATH,
+      {
+        platform: 'win32',
+        env: { USERNAME: 'alice', USERPROFILE: 'C:\\Users\\alice' },
+        canonicalize: (path) => win32.normalize(path),
+        hardenOwnership,
+        verifyOwnership
+      }
+    )
+
+    expect(cache.path).toMatch(/^C:\\Users\\alice\\osp[0-9a-f]{10}$/)
+    expect(verifyOwnership).toHaveBeenCalledOnce()
+    expect(hardenOwnership).toHaveBeenCalledOnce()
+    expect(hardenOwnership).toHaveBeenCalledWith(cache.path)
   })
 })

--- a/src/main/notebook/micromamba-cache.ts
+++ b/src/main/notebook/micromamba-cache.ts
@@ -30,7 +30,7 @@ export type MicromambaCacheDeps = {
   platform?: NodeJS.Platform
   env?: NodeJS.ProcessEnv
   canonicalize?: (path: string) => string
-  hardenOwnership?: (path: string) => void
+  hardenOwnership?: (path: string) => boolean | void
   prepare?: (
     path: string,
     ownership: CacheOwnership
@@ -103,13 +103,52 @@ export const windowsCacheAclHardeningScript = (path: string): string => {
   )
 }
 
-export const hardenWindowsCacheAcl = (path: string): void => {
-  if (process.platform !== 'win32') return
-  execFileSync(
-    resolveWindowsPowerShellExecutable(),
-    ['-NoProfile', '-NonInteractive', '-Command', windowsCacheAclHardeningScript(path)],
+const resolveWindowsSystemExecutable = (name: string): string => {
+  const windowsRoot = process.env.SystemRoot || process.env.WINDIR
+  return windowsRoot ? win32.join(windowsRoot, 'System32', name) : name
+}
+
+const currentWindowsUserSid = (): string => {
+  const raw = execFileSync(
+    resolveWindowsSystemExecutable('whoami.exe'),
+    ['/user', '/fo', 'csv', '/nh'],
     { encoding: 'utf8', windowsHide: true }
   )
+  const sid = raw.match(/\bS-\d-(?:\d+-)+\d+\b/i)?.[0]
+  if (!sid) throw new Error('Could not determine the current Windows user SID.')
+  return sid
+}
+
+export const hardenWindowsCacheAclWithIcacls = (path: string): void => {
+  const currentSid = currentWindowsUserSid()
+  execFileSync(
+    resolveWindowsSystemExecutable('icacls.exe'),
+    [
+      path,
+      '/inheritance:r',
+      '/grant:r',
+      `*${currentSid}:(OI)(CI)F`,
+      '*S-1-5-18:(OI)(CI)F',
+      '*S-1-5-32-544:(OI)(CI)F'
+    ],
+    { encoding: 'utf8', windowsHide: true }
+  )
+}
+
+export const hardenWindowsCacheAcl = (path: string): boolean => {
+  if (process.platform !== 'win32') return false
+  try {
+    execFileSync(
+      resolveWindowsPowerShellExecutable(),
+      ['-NoProfile', '-NonInteractive', '-Command', windowsCacheAclHardeningScript(path)],
+      { encoding: 'utf8', windowsHide: true }
+    )
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code !== 'EPERM' && code !== 'EACCES') throw error
+    hardenWindowsCacheAclWithIcacls(path)
+  }
+  return true
 }
 
 export type WindowsCacheAcl = {
@@ -201,10 +240,11 @@ const defaultVerifyOwnership = (path: string, userIdentity: string): boolean => 
 const defaultPrepare = (
   path: string,
   ownership: CacheOwnership,
-  hardenOwnership: (path: string) => void,
+  hardenOwnership: (path: string) => boolean | void,
   verifyOwnership: (path: string, userIdentity: string) => boolean
 ): MicromambaCachePreparation => {
   let created = false
+  let verifiedByHardening = false
   const reject = (rejection: string): MicromambaCachePreparation => {
     if (created) {
       try {
@@ -232,7 +272,7 @@ const defaultPrepare = (
       mkdirSync(path, { mode: 0o700 })
       created = true
       try {
-        hardenOwnership(path)
+        verifiedByHardening = hardenOwnership(path) === true
       } catch (error) {
         return reject(`cache ACL could not be hardened (${errorDetail(error)})`)
       }
@@ -272,7 +312,7 @@ const defaultPrepare = (
     ) {
       return reject('path resolves outside the Windows user profile')
     }
-    if (!verifyOwnership(physical, ownership.userIdentity)) {
+    if (!verifiedByHardening && !verifyOwnership(physical, ownership.userIdentity)) {
       return reject('ownership or permissions are not trusted')
     }
 


### PR DESCRIPTION
## Problem

Managed Python environment provisioning can fail on Windows when endpoint policy denies direct PowerShell process creation with `EPERM`. Cache selection then rejects every path before micromamba creates the environment. The later Python/pip `ENOENT` messages in the supplied user log are downstream symptoms.

## Proposed change

- Fall back only for PowerShell launch-denied errors (`EPERM`/`EACCES`).
- Resolve the current user SID with the System32 `whoami.exe`, then apply a protected least-privilege DACL with System32 `icacls.exe`.
- Treat a successful hardening operation on a cache created by the current call as ownership proof, avoiding a redundant PowerShell ACL read.
- Keep existing cache directories on the original fail-closed verification path.
- Add unit coverage for fallback routing and error classification, plus a real Windows integration test proving the fallback ACL is accepted by the production trust verifier.

## Scope and non-goals

- No change to cache path identity, path-budget calculation, or candidate ordering.
- No database, settings, or schema changes.
- No new persisted state. The existing `.open-science-cache.json` marker remains schema 1 and unchanged.
- No new status or enum values.
- Historical compatibility: existing trusted cache markers remain usable; existing untrusted/unverifiable caches remain rejected. No migration or compatibility shim is required.

## Acceptance criteria and validation

All listed checks ran after the last material edit:

- PowerShell `EPERM` fallback, existing-cache fail-closed behavior, cache selection, and ACL trust -> `npm test -- src/main/notebook/micromamba-cache.test.ts src/main/notebook/micromamba-cache-preparation.test.ts src/main/notebook/micromamba-cache-powershell.test.ts src/main/notebook/micromamba-cache-acl.integration.test.ts src/main/notebook/micromamba-cache-recovery.test.ts` -> 5 files, 42 tests passed.
- Main-process type safety -> `npm run typecheck:node` -> passed.
- Changed-file lint -> `npx eslint src/main/notebook/micromamba-cache.ts src/main/notebook/micromamba-cache-powershell.test.ts src/main/notebook/micromamba-cache-preparation.test.ts src/main/notebook/micromamba-cache-acl.integration.test.ts` -> passed.

Per maintainer direction, the complete local `npm test` suite was not run. PR CI is authoritative for the complete portable and Windows-sensitive lanes.

## Review focus

Please focus on the security boundary around trusting only newly created directories after successful exact ACL hardening, and on the restricted fallback condition that preserves fail-closed behavior for all other errors.