### PR TITLE
fix(workspace): prevent stale Ask-User interactions

### DIFF
--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -1343,6 +1343,124 @@ describe('ConversationPanel composer intake', () => {
     })
   })
 
+  it('scopes live Ask-User requests to the active session', () => {
+    const fields = [
+      {
+        id: 'question_0',
+        label: 'Course priority',
+        kind: 'multi-select' as const,
+        options: [
+          { value: 'statistics', label: 'Statistics' },
+          { value: 'visualization', label: 'Visualization' }
+        ]
+      },
+      { id: 'question_0_custom', label: 'Other', kind: 'text' as const }
+    ]
+    const activeSession: ChatSession = {
+      id: 'session-active-choice',
+      projectId: 'project-a',
+      title: 'Active choice',
+      cwd: '/workspace',
+      status: 'waiting-for-user',
+      messages: [],
+      activities: [
+        {
+          id: 'tool-active-choice',
+          kind: 'tool',
+          title: 'Choose course priorities',
+          status: 'in_progress',
+          eventIds: [],
+          sortIndex: 1,
+          createdAt: 1,
+          updatedAt: 1,
+          elicitation: {
+            message: 'Which courses should be prioritized?',
+            fields,
+            state: 'pending',
+            durable: { kind: 'agent-user-choice', requestId: 'active-choice' }
+          }
+        }
+      ],
+      createdAt: 1,
+      updatedAt: 1
+    }
+
+    renderPanel({
+      view: { activeSession },
+      elicitation: {
+        requests: [
+          {
+            requestId: 'foreign-choice',
+            sessionId: 'session-foreign-choice',
+            toolCallId: 'tool-foreign-choice',
+            message: 'Choose a foreign option',
+            fields: [
+              {
+                id: 'foreign',
+                label: 'Foreign option',
+                kind: 'single-select',
+                required: true,
+                options: [{ value: 'foreign', label: 'Foreign' }]
+              }
+            ]
+          }
+        ]
+      }
+    })
+
+    expect(container.querySelector('[data-testid="elicitation-option-statistics"]')).not.toBeNull()
+    expect(container.textContent).not.toContain('Choose a foreign option')
+  })
+
+  it('does not block the composer for an orphaned non-durable Ask-User activity', () => {
+    const activeSession: ChatSession = {
+      id: 'session-orphaned-choice',
+      projectId: 'project-a',
+      title: 'Orphaned choice',
+      cwd: '/workspace',
+      status: 'idle',
+      messages: [],
+      activities: [
+        {
+          id: 'tool-orphaned-choice',
+          kind: 'tool',
+          title: 'Choose course priorities',
+          status: 'completed',
+          eventIds: [],
+          sortIndex: 1,
+          createdAt: 1,
+          updatedAt: 1,
+          elicitation: {
+            message: 'Which courses should be prioritized?',
+            fields: [
+              {
+                id: 'courses',
+                label: 'Courses',
+                kind: 'multi-select',
+                options: [
+                  { value: 'statistics', label: 'Statistics' },
+                  { value: 'visualization', label: 'Visualization' }
+                ]
+              }
+            ],
+            state: 'pending'
+          }
+        }
+      ],
+      createdAt: 1,
+      updatedAt: 1
+    }
+
+    renderPanel({
+      view: { activeSession },
+      elicitation: { requests: [] }
+    })
+
+    expect(container.querySelector('[data-testid="elicitation-composer"]')).toBeNull()
+    expect(getComposerForm().hidden).toBe(false)
+    expect(container.textContent).not.toContain('Waiting for a response')
+  })
+
   it('keeps attachment limits discoverable in the tooltip and touch fallback', () => {
     renderPanel()
 
@@ -2248,7 +2366,7 @@ describe('ConversationPanel composer intake', () => {
       updatedAt: 2
     }
     const pendingPermissions = [{} as never]
-    const pendingElicitations = [{} as never]
+    const pendingElicitations = [{ sessionId: activeSession.id } as never]
 
     renderPanel({
       view: {

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -525,17 +525,25 @@ const ConversationPanel = ({
         : undefined
 
   const sessionActivities = activeSession?.activities ?? []
+  const sessionPendingElicitations = activeSession
+    ? pendingElicitations.filter((request) => request.sessionId === activeSession.id)
+    : []
   // Runtime requests and activity events can reach the renderer in either order. Whichever arrives
   // first must reserve the single bottom interaction lane so the ordinary composer never competes
-  // with a question that is waiting for an answer.
-  const livePendingElicitationRequest = pendingElicitations.find((request) => {
+  // with a question that is waiting for an answer. A projection without a live request is
+  // actionable only when its durable context can reconstruct that request.
+  const livePendingElicitationRequest = sessionPendingElicitations.find((request) => {
     const state = sessionActivities.find((activity) => activity.id === request.toolCallId)
       ?.elicitation?.state
     return state === undefined || state === 'pending'
   })
   const pendingElicitationActivity = livePendingElicitationRequest
     ? sessionActivities.find((activity) => activity.id === livePendingElicitationRequest.toolCallId)
-    : sessionActivities.find((activity) => activity.elicitation?.state === 'pending')
+    : sessionActivities.find(
+        (activity) =>
+          activity.elicitation?.state === 'pending' &&
+          activity.elicitation.durable?.kind === 'agent-user-choice'
+      )
   const restoredElicitation = pendingElicitationActivity?.elicitation
   const pendingElicitationRequest: PendingElicitationRequest | undefined =
     livePendingElicitationRequest ??
@@ -731,7 +739,7 @@ const ConversationPanel = ({
             isResumingSession={isResuming}
             notebookReference={notebookReference}
             onSendEditedMessage={onSendEditedMessage}
-            pendingElicitations={sideChat ? [] : pendingElicitations}
+            pendingElicitations={sideChat ? [] : sessionPendingElicitations}
             handoffLifecycleSource={workspaceHandoffLifecycleClient}
             onRetryHandoff={(request) => workspaceHandoffLifecycleClient.retry(request)}
           />


### PR DESCRIPTION
﻿## Problem

Ask-User could leave the workspace blocked on a "Waiting for a response" card without rendering any choices. The supplied user log shows the reviewer completed successfully; the affected run instead had overlapping primary sessions. The renderer selected the first pending elicitation globally, so a request owned by another session could occupy the active session's interaction lane. A stale non-durable activity projection could also reserve that lane even though no live request remained to answer.

## Proposed change

- Scope live pending elicitation requests to the active session.
- Continue reconstructing durable `agent-user-choice` requests from the active session's activity projection.
- Ignore orphaned non-durable pending projections so they no longer hide the ordinary composer.
- Pass only active-session requests to the message scroller.
- Add regression coverage for cross-session request leakage and orphaned non-durable pending state.

## Scope and non-goals

This is a renderer-only selection fix. It does not change reviewer behavior, ACP protocol schemas, database/persistence models, or conversation graph / `activeBranchId` projection logic.

Claude Code, OpenCode, Codex Responses, and Codex Bridge all publish the shared `PendingElicitationRequest` shape and therefore consume the same corrected renderer path.

## Acceptance criteria and validation

- [x] A foreign session's live Ask-User request cannot replace the active session's choices.
- [x] Durable agent-user choices remain restorable when the live request is absent.
- [x] An orphaned non-durable projection no longer blocks the composer.
- [x] Side-chat and scroller behavior receives the same active-session request set.
- [x] Independent Standards review: 0 findings.
- [x] Independent Spec review: 0 findings.

Validation after the final material edit:

- `npm test -- src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx` ? 98 passed.
- `npm test -- src/main/acp/client-interaction-owner.test.ts` ? 10 passed (shared Claude Code / OpenCode / Codex routing).
- `npm test -- src/main/acp/session-update-projector.test.ts` ? 21 passed.
- `npm test -- src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts` ? 12 passed.
- `npx vitest run src/renderer/src/i18n/resources.test.ts` ? 67 passed.
- `npm run typecheck:web` ? passed.
- `npm run lint` ? passed with 0 errors and 17 warnings in unchanged files.
- Prettier and `git diff --check` ? passed.

The required full `npm test` was also run. It did not pass in this Windows environment: 215 tests failed outside the changed files, dominated by temp-directory usability/symlink `EPERM`, native-install limitations, and parallel timeouts. The one nearby renderer architecture timeout passed when rerun alone (12/12).

## Test impact set

Changed owner: workspace conversation renderer interaction selection.

Included consumers: shared ACP elicitation routing, durable session update projection, workspace runtime facade, and all four configured framework/backend lanes through the common request shape.

Excluded lanes: reviewer orchestration, protocol translation, persistence/database, and conversation-branch selection because this diff does not alter those boundaries.

Uncovered risk: no end-to-end reproduction was run against a live external Agent process; regression coverage uses the production renderer contracts and shared ACP route/projection tests.

## Review focus

Please focus on whether the interaction lane should ever treat a projection-only, non-durable pending activity as actionable, and whether the active-session filter belongs at this renderer boundary.
