### PR TITLE
feat(host-artifacts)!: align frame-scoped JavaScript contract

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -1352,17 +1352,21 @@ async function hostViewImage(source, options = undefined) {
 const HOST_ARTIFACT_REQUIRED_KEYS = [
   'id',
   'filename',
-  'size_bytes',
-  'latest_version_id',
-  'session_id',
-  'root_frame_id',
-  'is_user_upload',
-  'latest_version_created_at'
+  'contentType',
+  'sizeBytes',
+  'latestVersionId',
+  'checksum',
+  'projectId',
+  'sessionId',
+  'rootFrameId',
+  'agentFrameId',
+  'isUserUpload',
+  'createdAt',
+  'latestVersionCreatedAt'
 ]
-const HOST_ARTIFACT_OPTIONAL_KEYS = ['content_type', 'checksum']
 const HOST_ARTIFACT_INPUT_KEYS = {
   versionId: 'version_id',
-  sessionId: 'session_id',
+  frameId: 'frame_id',
   filename: 'filename',
   exact: 'exact',
   search: 'search',
@@ -1373,37 +1377,34 @@ const HOST_ARTIFACT_INPUT_KEYS = {
   limit: 'limit'
 }
 
-const validatedHostArtifact = (value) => {
+const nullableHostArtifactString = (value) => value === null || typeof value === 'string'
+
+const validatedHostArtifact = (value, projectId) => {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     throw new Error('host.artifacts returned an invalid Artifact')
   }
   const keys = Object.keys(value)
   if (
     HOST_ARTIFACT_REQUIRED_KEYS.some((key) => !keys.includes(key)) ||
-    keys.some(
-      (key) =>
-        !HOST_ARTIFACT_REQUIRED_KEYS.includes(key) && !HOST_ARTIFACT_OPTIONAL_KEYS.includes(key)
-    ) ||
     typeof value.id !== 'string' ||
     typeof value.filename !== 'string' ||
-    typeof value.size_bytes !== 'number' ||
-    !Number.isSafeInteger(value.size_bytes) ||
-    typeof value.latest_version_id !== 'string' ||
-    typeof value.session_id !== 'string' ||
-    (value.root_frame_id !== null && typeof value.root_frame_id !== 'string') ||
-    typeof value.is_user_upload !== 'boolean' ||
-    typeof value.latest_version_created_at !== 'string' ||
-    (value.content_type !== undefined && typeof value.content_type !== 'string') ||
-    (value.checksum !== undefined && typeof value.checksum !== 'string')
+    !nullableHostArtifactString(value.contentType) ||
+    !Number.isSafeInteger(value.sizeBytes) ||
+    value.sizeBytes < 0 ||
+    typeof value.latestVersionId !== 'string' ||
+    !nullableHostArtifactString(value.checksum) ||
+    value.projectId !== projectId ||
+    typeof value.sessionId !== 'string' ||
+    !nullableHostArtifactString(value.rootFrameId) ||
+    !nullableHostArtifactString(value.agentFrameId) ||
+    typeof value.isUserUpload !== 'boolean' ||
+    typeof value.createdAt !== 'string' ||
+    typeof value.latestVersionCreatedAt !== 'string'
   ) {
     throw new Error('host.artifacts returned an invalid Artifact')
   }
   return Object.freeze(
-    Object.fromEntries(
-      [...HOST_ARTIFACT_REQUIRED_KEYS, ...HOST_ARTIFACT_OPTIONAL_KEYS]
-        .filter((key) => value[key] !== undefined)
-        .map((key) => [key, value[key]])
-    )
+    Object.fromEntries(HOST_ARTIFACT_REQUIRED_KEYS.map((key) => [key, value[key]]))
   )
 }
 
@@ -1417,24 +1418,24 @@ async function hostArtifacts(options = {}) {
     typeof result !== 'object' ||
     Array.isArray(result) ||
     !Number.isSafeInteger(result.count) ||
-    typeof result.project_id !== 'string' ||
+    result.count < 0 ||
+    typeof result.projectId !== 'string' ||
     typeof result.truncated !== 'boolean' ||
-    (result.next_cursor !== undefined && typeof result.next_cursor !== 'string') ||
+    (result.nextCursor !== undefined && typeof result.nextCursor !== 'string') ||
     !Array.isArray(result.artifacts) ||
-    result.count !== result.artifacts.length ||
-    result.truncated !== (result.next_cursor !== undefined) ||
-    Object.keys(result).some(
-      (key) => !['count', 'project_id', 'truncated', 'next_cursor', 'artifacts'].includes(key)
-    )
+    result.count < result.artifacts.length ||
+    result.truncated !== (result.nextCursor !== undefined)
   ) {
     throw new Error('host.artifacts returned an invalid result')
   }
-  const artifacts = Object.freeze(result.artifacts.map(validatedHostArtifact))
+  const artifacts = Object.freeze(
+    result.artifacts.map((artifact) => validatedHostArtifact(artifact, result.projectId))
+  )
   return Object.freeze({
     count: result.count,
-    project_id: result.project_id,
+    projectId: result.projectId,
     truncated: result.truncated,
-    ...(result.next_cursor !== undefined ? { next_cursor: result.next_cursor } : {}),
+    ...(result.nextCursor !== undefined ? { nextCursor: result.nextCursor } : {}),
     artifacts
   })
 }

--- a/resources/skills/self-awareness/SKILL.md
+++ b/resources/skills/self-awareness/SKILL.md
@@ -70,20 +70,39 @@ call returns a fresh frozen projection.
 ## Discover managed Project files
 
 When `caps.artifacts === true`, use `await host.artifacts(options)` to list generated Artifacts and
-user Uploads across the current Project. Optional camelCase fields are `versionId`, `sessionId`,
+user Uploads across the current Project. Optional camelCase fields are `versionId`, `frameId`,
 `filename`, `exact`, `search`, `contentType`, `after`, `before`, `cursor`, and `limit` (default 20,
 maximum 100). `versionId` is exclusive; `exact` requires `filename`; `search` and `filename` cannot
-be combined. Bare dates are UTC midnight, `after` is inclusive, and `before` is exclusive.
+be combined. `contentType` accepts an exact MIME type or a top-level prefix such as `text/`. Bare
+dates are UTC midnight, `after` is inclusive, and `before` is exclusive.
 
 ```javascript
 const page = await host.artifacts({ search: 'report', limit: 20 })
 const localPath = page.artifacts[0]
-  ? await host.artifactPath(page.artifacts[0].latest_version_id)
+  ? await host.artifactPath(page.artifacts[0].latestVersionId)
   : undefined
 ```
 
-`sessionId` only narrows the token-owned current Project. There is no Project override or all-
-Projects scope. Results contain metadata and immutable Version identity, never content; use
+`frameId` matches only the exact producer Frame of a generated Artifact's latest Version. It does
+not expand to a root's descendants or the whole Session, and Uploads without trusted Frame
+provenance are excluded while this filter is present. There is no Session or Project override and
+no all-Projects scope. `count` is the total number of matches before cursor pagination; the current
+page size is `artifacts.length`. `nextCursor` is absent on the last page.
+
+```javascript
+{
+  count, projectId, truncated, nextCursor,
+  artifacts: [{
+    id, filename, contentType, sizeBytes, latestVersionId, checksum,
+    projectId, sessionId, rootFrameId, agentFrameId, isUserUpload,
+    createdAt, latestVersionCreatedAt
+  }]
+}
+```
+
+Result and Artifact fields use camelCase. `contentType`, `checksum`, `rootFrameId`, and
+`agentFrameId` are always present and may be `null`. Results contain metadata and immutable Version
+identity, never content; use
 `host.artifactPath(versionId)` to resolve a checksum-validated local absolute path for an exact
 generated Artifact Version or Upload Version, then use the existing file workflow. Version ID
 collisions, missing Versions, cross-Project ownership, and checksum mismatches fail closed.

--- a/src/main/notebook/host-artifacts-service.test.ts
+++ b/src/main/notebook/host-artifacts-service.test.ts
@@ -14,7 +14,10 @@ const artifact = (overrides: Partial<HostArtifactCatalogItem> = {}): HostArtifac
   contentType: 'text/csv',
   sizeBytes: 42,
   sortAtMs: Date.parse('2026-08-01T00:00:00.000Z'),
+  createdAt: '2026-08-01T00:00:00.000Z',
+  sourceCreatedAt: '2026-07-01T00:00:00.000Z',
   rootFrameId: 'root-a',
+  agentFrameId: 'frame-a',
   ...overrides
 })
 
@@ -27,7 +30,10 @@ const upload = (overrides: Partial<HostArtifactCatalogItem> = {}): HostArtifactC
     filename: 'report.pdf',
     contentType: 'application/pdf',
     sortAtMs: Date.parse('2026-08-02T00:00:00.000Z'),
+    createdAt: '2026-08-02T00:00:00.000Z',
+    sourceCreatedAt: '2026-07-02T00:00:00.000Z',
     rootFrameId: null,
+    agentFrameId: null,
     ...overrides
   })
 
@@ -58,36 +64,84 @@ const harness = (
 const context = { projectId: 'project-a', sessionId: 'calling-session' }
 
 describe('HostArtifactsService', () => {
-  it('returns the current Project catalog across Sessions with the stable snake_case projection', async () => {
+  it('returns the current Project catalog across Sessions with a fixed camelCase projection', async () => {
     const { service, readHostArtifactCatalog } = harness()
 
     await expect(service.list({}, context)).resolves.toEqual({
       count: 2,
-      project_id: 'project-a',
+      projectId: 'project-a',
       truncated: false,
       artifacts: [
-        expect.objectContaining({
+        {
           id: 'upload-1',
           filename: 'report.pdf',
-          latest_version_id: 'upload-version-1',
-          session_id: 'session-b',
-          root_frame_id: null,
-          is_user_upload: true,
-          latest_version_created_at: '2026-08-02T00:00:00.000Z'
-        }),
-        expect.objectContaining({
+          contentType: 'application/pdf',
+          sizeBytes: 42,
+          latestVersionId: 'upload-version-1',
+          checksum: 'a'.repeat(64),
+          projectId: 'project-a',
+          sessionId: 'session-b',
+          rootFrameId: null,
+          agentFrameId: null,
+          isUserUpload: true,
+          createdAt: '2026-07-02T00:00:00.000Z',
+          latestVersionCreatedAt: '2026-08-02T00:00:00.000Z'
+        },
+        {
           id: 'artifact-1',
-          latest_version_id: 'artifact-version-1',
-          session_id: 'session-a',
-          root_frame_id: 'root-a',
-          is_user_upload: false
-        })
+          filename: 'clinical-genomics.csv',
+          contentType: 'text/csv',
+          sizeBytes: 42,
+          latestVersionId: 'artifact-version-1',
+          checksum: 'a'.repeat(64),
+          projectId: 'project-a',
+          sessionId: 'session-a',
+          rootFrameId: 'root-a',
+          agentFrameId: 'frame-a',
+          isUserUpload: false,
+          createdAt: '2026-07-01T00:00:00.000Z',
+          latestVersionCreatedAt: '2026-08-01T00:00:00.000Z'
+        }
       ]
     })
     expect(readHostArtifactCatalog).toHaveBeenCalledWith({ projectId: 'project-a' })
   })
 
-  it('narrows by Session, filename/exact, content type, and UTC half-open time bounds', async () => {
+  it('narrows by exact producer Frame without expanding a shared root or including Uploads', async () => {
+    const { service } = harness([
+      upload(),
+      artifact({ sourceFileId: 'root', rootFrameId: 'root-a', agentFrameId: 'root-a' }),
+      artifact({
+        sourceFileId: 'child-a',
+        versionId: 'child-a-v1',
+        rootFrameId: 'root-a',
+        agentFrameId: 'child-a'
+      }),
+      artifact({
+        sourceFileId: 'child-b',
+        versionId: 'child-b-v1',
+        rootFrameId: 'root-a',
+        agentFrameId: 'child-b'
+      })
+    ])
+
+    await expect(service.list({ frame_id: 'child-a' }, context)).resolves.toMatchObject({
+      count: 1,
+      artifacts: [{ id: 'child-a', rootFrameId: 'root-a', agentFrameId: 'child-a' }]
+    })
+    await expect(service.list({ frame_id: 'root-a' }, context)).resolves.toMatchObject({
+      count: 1,
+      artifacts: [{ id: 'root', agentFrameId: 'root-a' }]
+    })
+    await expect(service.list({ frame_id: 'historical-producer' }, context)).resolves.toMatchObject(
+      {
+        count: 0,
+        artifacts: []
+      }
+    )
+  })
+
+  it('narrows by filename/exact, MIME prefix, and UTC half-open time bounds', async () => {
     const { service } = harness([
       upload({ filename: 'Final Report.pdf', sortAtMs: Date.parse('2026-08-02T00:00:00Z') }),
       artifact({ filename: 'report.csv', sortAtMs: Date.parse('2026-08-03T00:00:00Z') })
@@ -96,10 +150,9 @@ describe('HostArtifactsService', () => {
     await expect(
       service.list(
         {
-          session_id: 'session-b',
           filename: 'Report',
           exact: false,
-          content_type: 'APPLICATION/PDF',
+          content_type: 'APPLICATION/',
           after: '2026-08-02',
           before: '2026-08-03'
         },
@@ -116,6 +169,47 @@ describe('HostArtifactsService', () => {
     await expect(
       nested.service.list({ filename: 'Final Report.pdf', exact: true }, context)
     ).resolves.toMatchObject({ count: 1 })
+    await expect(service.list({ content_type: 'text/csv' }, context)).resolves.toMatchObject({
+      count: 1,
+      artifacts: [{ contentType: 'text/csv' }]
+    })
+    await expect(service.list({ content_type: ' text/ ' }, context)).resolves.toMatchObject({
+      count: 1,
+      artifacts: [{ contentType: 'text/csv' }]
+    })
+    for (const contentType of ['bogus/', 'text', 'text/csv/']) {
+      await expect(service.list({ content_type: contentType }, context)).rejects.toThrow(
+        'valid MIME type'
+      )
+    }
+  })
+
+  it('matches only the latest producer when one lineage was updated by another Frame', async () => {
+    const historical = artifact({ versionId: 'shared-v1', agentFrameId: 'frame-a' })
+    const latest = artifact({ versionId: 'shared-v2', agentFrameId: 'frame-b' })
+    const readHostArtifactCatalog: HostArtifactCatalog['readHostArtifactCatalog'] = async ({
+      versionId
+    }) => (versionId === historical.versionId ? [historical] : [latest])
+    const service = new HostArtifactsService(
+      { readHostArtifactCatalog },
+      {
+        artifact: { resolveVersionContent: vi.fn() },
+        upload: { resolveManagedUploadPath: vi.fn() }
+      }
+    )
+
+    await expect(service.list({ frame_id: 'frame-a' }, context)).resolves.toMatchObject({
+      count: 0,
+      artifacts: []
+    })
+    await expect(service.list({ frame_id: 'frame-b' }, context)).resolves.toMatchObject({
+      count: 1,
+      artifacts: [{ latestVersionId: 'shared-v2', agentFrameId: 'frame-b' }]
+    })
+    await expect(service.list({ version_id: 'shared-v1' }, context)).resolves.toMatchObject({
+      count: 1,
+      artifacts: [{ latestVersionId: 'shared-v1', agentFrameId: 'frame-a' }]
+    })
   })
 
   it('uses the shared fuzzy score for ordering without exposing scores', async () => {
@@ -138,14 +232,18 @@ describe('HostArtifactsService', () => {
     ])
 
     const first = await service.list({ filename: '.pdf', limit: 2 }, context)
-    expect(first).toMatchObject({ count: 2, truncated: true })
+    expect(first).toMatchObject({ count: 3, truncated: true })
     const second = await service.list(
-      { filename: '.pdf', limit: 2, cursor: first.next_cursor },
+      { filename: '.pdf', limit: 2, cursor: first.nextCursor },
       context
     )
-    expect(second).toMatchObject({ count: 1, truncated: false })
+    expect(second).toMatchObject({ count: 3, truncated: false })
+    expect(second.artifacts).toHaveLength(1)
     await expect(
-      service.list({ filename: 'different', cursor: first.next_cursor }, context)
+      service.list({ filename: 'different', cursor: first.nextCursor }, context)
+    ).rejects.toThrow('cursor does not match')
+    await expect(
+      service.list({ filename: '.pdf', frame_id: 'frame-a', cursor: first.nextCursor }, context)
     ).rejects.toThrow('cursor does not match')
     await expect(service.list({ limit: 0 }, context)).rejects.toThrow('between 1 and 100')
     await expect(service.list({ limit: 101 }, context)).rejects.toThrow('between 1 and 100')
@@ -158,7 +256,7 @@ describe('HostArtifactsService', () => {
       service.list({ version_id: 'artifact-version-1' }, context)
     ).resolves.toMatchObject({
       count: 1,
-      artifacts: [{ latest_version_id: 'artifact-version-1' }]
+      artifacts: [{ latestVersionId: 'artifact-version-1' }]
     })
     expect(readHostArtifactCatalog).toHaveBeenLastCalledWith({
       projectId: 'project-a',
@@ -175,7 +273,10 @@ describe('HostArtifactsService', () => {
       { after: '2026-08-03', before: '2026-08-03' },
       { after: '2026-08-03T10:00:00' },
       { exact: 'yes', filename: 'x' },
-      { session_id: 1 }
+      { frame_id: 1 },
+      { frame_id: '   ' },
+      { session_id: 'session-a' },
+      { sessionId: 'session-a' }
     ]) {
       await expect(service.list(options, context)).rejects.toThrow(/host\.artifacts/u)
     }

--- a/src/main/notebook/host-artifacts-service.test.ts
+++ b/src/main/notebook/host-artifacts-service.test.ts
@@ -15,7 +15,8 @@ const artifact = (overrides: Partial<HostArtifactCatalogItem> = {}): HostArtifac
   sizeBytes: 42,
   sortAtMs: Date.parse('2026-08-01T00:00:00.000Z'),
   createdAt: '2026-08-01T00:00:00.000Z',
-  sourceCreatedAt: '2026-07-01T00:00:00.000Z',
+  sourceCreatedAt: '2026-08-01T00:00:00.000Z',
+  sourceFileCreatedAt: '2026-07-01T00:00:00.000Z',
   rootFrameId: 'root-a',
   agentFrameId: 'frame-a',
   ...overrides
@@ -31,7 +32,8 @@ const upload = (overrides: Partial<HostArtifactCatalogItem> = {}): HostArtifactC
     contentType: 'application/pdf',
     sortAtMs: Date.parse('2026-08-02T00:00:00.000Z'),
     createdAt: '2026-08-02T00:00:00.000Z',
-    sourceCreatedAt: '2026-07-02T00:00:00.000Z',
+    sourceCreatedAt: '2026-08-02T00:00:00.000Z',
+    sourceFileCreatedAt: '2026-07-02T00:00:00.000Z',
     rootFrameId: null,
     agentFrameId: null,
     ...overrides
@@ -280,6 +282,14 @@ describe('HostArtifactsService', () => {
     ]) {
       await expect(service.list(options, context)).rejects.toThrow(/host\.artifacts/u)
     }
+  })
+
+  it('fails closed when the Catalog omits source file creation metadata', async () => {
+    const { service } = harness([artifact({ sourceFileCreatedAt: undefined })])
+
+    await expect(service.list({}, context)).rejects.toThrow(
+      'Host Artifact source file metadata is incomplete'
+    )
   })
 
   it('resolves Artifact and Upload Versions through their existing checksum-validating resolvers', async () => {

--- a/src/main/notebook/host-artifacts-service.ts
+++ b/src/main/notebook/host-artifacts-service.ts
@@ -192,21 +192,26 @@ const decodeCursor = (value: string, queryKey: string): Cursor => {
   return cursor as Cursor
 }
 
-const toHostArtifact = (item: HostArtifactCatalogItem): HostArtifact => ({
-  id: item.sourceFileId,
-  filename: item.filename,
-  contentType: item.contentType ?? null,
-  sizeBytes: item.sizeBytes,
-  latestVersionId: item.versionId,
-  checksum: item.checksum ?? null,
-  projectId: item.projectId,
-  sessionId: item.sessionId,
-  rootFrameId: item.rootFrameId,
-  agentFrameId: item.agentFrameId,
-  isUserUpload: item.source === 'upload',
-  createdAt: item.sourceCreatedAt,
-  latestVersionCreatedAt: item.createdAt
-})
+const toHostArtifact = (item: HostArtifactCatalogItem): HostArtifact => {
+  if (!item.sourceFileCreatedAt) {
+    throw new Error(`Host Artifact source file metadata is incomplete: ${item.versionId}`)
+  }
+  return {
+    id: item.sourceFileId,
+    filename: item.filename,
+    contentType: item.contentType ?? null,
+    sizeBytes: item.sizeBytes,
+    latestVersionId: item.versionId,
+    checksum: item.checksum ?? null,
+    projectId: item.projectId,
+    sessionId: item.sessionId,
+    rootFrameId: item.rootFrameId,
+    agentFrameId: item.agentFrameId,
+    isUserUpload: item.source === 'upload',
+    createdAt: item.sourceFileCreatedAt,
+    latestVersionCreatedAt: item.createdAt
+  }
+}
 
 const matchesContentType = (actual: string | undefined, requested: string): boolean => {
   if (!actual) return false

--- a/src/main/notebook/host-artifacts-service.ts
+++ b/src/main/notebook/host-artifacts-service.ts
@@ -36,7 +36,7 @@ type HostArtifactReadContext = { projectId: string; sessionId: string }
 
 type NormalizedOptions = {
   versionId?: string
-  sessionId?: string
+  frameId?: string
   filename?: string
   exact: boolean
   search?: string
@@ -51,7 +51,7 @@ type Cursor = { version: 1; queryKey: string; offset: number }
 
 const OPTION_KEYS = new Set([
   'version_id',
-  'session_id',
+  'frame_id',
   'filename',
   'exact',
   'search',
@@ -63,6 +63,19 @@ const OPTION_KEYS = new Set([
 ])
 const DEFAULT_LIMIT = 20
 const MAX_LIMIT = 100
+const VALID_MIME_TOP_LEVELS = new Set([
+  'application',
+  'audio',
+  'chemical',
+  'font',
+  'image',
+  'message',
+  'model',
+  'multipart',
+  'text',
+  'video'
+])
+const MIME_FILTER_PATTERN = /^[a-z0-9][a-z0-9!#$&^_.+-]*\/(?:[a-z0-9][a-z0-9!#$&^_.+-]*)?$/u
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -74,7 +87,7 @@ const optionalString = (
 ): string | undefined => {
   const value = options[key]
   if (value === undefined) return undefined
-  if (typeof value !== 'string' || value.length === 0 || value.length > maxLength) {
+  if (typeof value !== 'string' || value.trim().length === 0 || value.length > maxLength) {
     throw new Error(
       `host.artifacts ${key} must be a non-empty string of at most ${maxLength} characters.`
     )
@@ -99,6 +112,18 @@ const parseUtcTime = (value: string, key: 'after' | 'before'): number => {
   return parsed
 }
 
+const normalizeContentType = (value: Record<string, unknown>): string | undefined => {
+  const contentType = optionalString(value, 'content_type')?.trim().toLowerCase()
+  if (contentType === undefined) return undefined
+  const topLevel = contentType.split('/', 1)[0]
+  if (!MIME_FILTER_PATTERN.test(contentType) || !VALID_MIME_TOP_LEVELS.has(topLevel)) {
+    throw new Error(
+      'host.artifacts contentType must be a valid MIME type or top-level prefix such as "text/csv" or "image/".'
+    )
+  }
+  return contentType
+}
+
 const normalizeOptions = (value: unknown): NormalizedOptions => {
   if (value === undefined) value = {}
   if (!isRecord(value)) throw new Error('host.artifacts options must be an object.')
@@ -110,10 +135,10 @@ const normalizeOptions = (value: unknown): NormalizedOptions => {
     throw new Error('host.artifacts version_id cannot be combined with other options.')
   }
 
-  const sessionId = optionalString(value, 'session_id', 512)
+  const frameId = optionalString(value, 'frame_id', 512)
   const filename = optionalString(value, 'filename')
   const search = optionalString(value, 'search')
-  const contentType = optionalString(value, 'content_type')
+  const contentType = normalizeContentType(value)
   const after = optionalString(value, 'after', 64)
   const before = optionalString(value, 'before', 64)
   const cursor = optionalString(value, 'cursor', 4096)
@@ -133,7 +158,7 @@ const normalizeOptions = (value: unknown): NormalizedOptions => {
 
   return {
     versionId,
-    sessionId,
+    frameId,
     filename,
     exact,
     search,
@@ -170,15 +195,27 @@ const decodeCursor = (value: string, queryKey: string): Cursor => {
 const toHostArtifact = (item: HostArtifactCatalogItem): HostArtifact => ({
   id: item.sourceFileId,
   filename: item.filename,
-  ...(item.contentType ? { content_type: item.contentType } : {}),
-  size_bytes: item.sizeBytes,
-  latest_version_id: item.versionId,
-  ...(item.checksum ? { checksum: item.checksum } : {}),
-  session_id: item.sessionId,
-  root_frame_id: item.rootFrameId,
-  is_user_upload: item.source === 'upload',
-  latest_version_created_at: new Date(item.sortAtMs).toISOString()
+  contentType: item.contentType ?? null,
+  sizeBytes: item.sizeBytes,
+  latestVersionId: item.versionId,
+  checksum: item.checksum ?? null,
+  projectId: item.projectId,
+  sessionId: item.sessionId,
+  rootFrameId: item.rootFrameId,
+  agentFrameId: item.agentFrameId,
+  isUserUpload: item.source === 'upload',
+  createdAt: item.sourceCreatedAt,
+  latestVersionCreatedAt: item.createdAt
 })
+
+const matchesContentType = (actual: string | undefined, requested: string): boolean => {
+  if (!actual) return false
+  const normalizedActual = actual.toLowerCase()
+  const normalizedRequested = requested.toLowerCase()
+  return normalizedRequested.endsWith('/')
+    ? normalizedActual.startsWith(normalizedRequested)
+    : normalizedActual === normalizedRequested
+}
 
 class HostArtifactsService {
   constructor(
@@ -193,17 +230,19 @@ class HostArtifactsService {
       ...(normalized.versionId ? { versionId: normalized.versionId } : {})
     })
     const ranked = candidates.flatMap((item) => {
-      if (normalized.sessionId && item.sessionId !== normalized.sessionId) return []
+      if (
+        normalized.frameId &&
+        (item.source !== 'artifact' || item.agentFrameId !== normalized.frameId)
+      ) {
+        return []
+      }
       if (normalized.filename) {
         const matches = normalized.exact
           ? basename(item.filename) === normalized.filename
           : item.filename.toLowerCase().includes(normalized.filename.toLowerCase())
         if (!matches) return []
       }
-      if (
-        normalized.contentType &&
-        item.contentType?.toLowerCase() !== normalized.contentType.toLowerCase()
-      ) {
+      if (normalized.contentType && !matchesContentType(item.contentType, normalized.contentType)) {
         return []
       }
       if (normalized.afterMs !== undefined && item.sortAtMs < normalized.afterMs) return []
@@ -226,7 +265,7 @@ class HostArtifactsService {
 
     const queryKey = JSON.stringify({
       projectId: context.projectId,
-      sessionId: normalized.sessionId,
+      frameId: normalized.frameId,
       filename: normalized.filename,
       exact: normalized.exact,
       search: normalized.search,
@@ -241,11 +280,11 @@ class HostArtifactsService {
     const truncated = nextOffset < ranked.length
     const artifacts = page.map(({ item }) => toHostArtifact(item))
     return {
-      count: artifacts.length,
-      project_id: context.projectId,
+      count: ranked.length,
+      projectId: context.projectId,
       truncated,
       ...(truncated
-        ? { next_cursor: encodeCursor({ version: 1, queryKey, offset: nextOffset }) }
+        ? { nextCursor: encodeCursor({ version: 1, queryKey, offset: nextOffset }) }
         : {}),
       artifacts
     }

--- a/src/main/notebook/host-view-image-service.test.ts
+++ b/src/main/notebook/host-view-image-service.test.ts
@@ -36,7 +36,10 @@ const catalogItem = (
   contentType: 'image/png',
   sizeBytes: 42,
   sortAtMs: 1,
+  createdAt: '2026-08-01T00:00:00.000Z',
+  sourceCreatedAt: '2026-07-01T00:00:00.000Z',
   rootFrameId: source === 'artifact' ? 'root-frame' : null,
+  agentFrameId: source === 'artifact' ? 'agent-frame' : null,
   ...overrides
 })
 

--- a/src/main/notebook/local-rpc-server.artifacts.test.ts
+++ b/src/main/notebook/local-rpc-server.artifacts.test.ts
@@ -25,7 +25,7 @@ afterEach(async () => {
 })
 
 describe('artifactsCall RPC', () => {
-  it('uses only the control token Project and Session for list and path operations', async () => {
+  it('binds list and path scope to the control token without synthesizing a Frame filter', async () => {
     const list = vi.fn(async () => ({ artifacts: [] }))
     const resolvePath = vi.fn(async () => '/managed/report.csv')
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
@@ -40,15 +40,35 @@ describe('artifactsCall RPC', () => {
 
     const listed = await callArtifacts(control, control.token, {
       op: 'list',
-      options: { session_id: 'narrow-session' },
+      options: { frame_id: 'requested-producer-frame' },
       projectId: 'forged-project',
       sessionId: 'forged-session',
-      project_id: 'all'
+      project_id: 'all',
+      session_id: 'forged-session',
+      frame_id: 'forged-top-level-frame'
     })
     expect(listed).toMatchObject({ response: { status: 200 } })
-    expect(list).toHaveBeenCalledWith(
-      { session_id: 'narrow-session' },
+    expect(list).toHaveBeenNthCalledWith(
+      1,
+      { frame_id: 'requested-producer-frame' },
       { projectId: 'trusted-project', sessionId: 'trusted-session' }
+    )
+
+    const listedWithoutFrame = await callArtifacts(control, control.token, {
+      op: 'list',
+      options: {},
+      projectId: 'forged-project',
+      sessionId: 'forged-session',
+      frame_id: 'forged-top-level-frame'
+    })
+    expect(listedWithoutFrame).toMatchObject({ response: { status: 200 } })
+    expect(list).toHaveBeenNthCalledWith(
+      2,
+      {},
+      {
+        projectId: 'trusted-project',
+        sessionId: 'trusted-session'
+      }
     )
 
     const resolved = await callArtifacts(control, control.token, {

--- a/src/main/notebook/repl-loop.integration.test.ts
+++ b/src/main/notebook/repl-loop.integration.test.ts
@@ -1736,31 +1736,42 @@ describe('repl_loop local RPC transport', () => {
           parsed.params?.op === 'path'
             ? managedPath
             : {
-                count: 2,
-                project_id: 'project-a',
-                truncated: false,
+                count: 3,
+                projectId: 'project-a',
+                truncated: true,
+                nextCursor: 'next-page',
+                ignoredFutureField: 'not-public',
                 artifacts: [
                   {
                     id: 'artifact-1',
                     filename: 'result.csv',
-                    content_type: 'text/csv',
-                    size_bytes: 12,
-                    latest_version_id: 'artifact-version-1',
+                    contentType: 'text/csv',
+                    sizeBytes: 12,
+                    latestVersionId: 'artifact-version-1',
                     checksum: 'a'.repeat(64),
-                    session_id: 'session-a',
-                    root_frame_id: 'root-1',
-                    is_user_upload: false,
-                    latest_version_created_at: '2026-08-01T00:00:00.000Z'
+                    projectId: 'project-a',
+                    sessionId: 'session-a',
+                    rootFrameId: 'root-1',
+                    agentFrameId: 'frame-1',
+                    isUserUpload: false,
+                    createdAt: '2026-07-31T00:00:00.000Z',
+                    latestVersionCreatedAt: '2026-08-01T00:00:00.000Z',
+                    ignoredFutureField: 'not-public'
                   },
                   {
                     id: 'upload-1',
                     filename: 'report.pdf',
-                    size_bytes: 24,
-                    latest_version_id: 'upload-version-1',
-                    session_id: 'session-b',
-                    root_frame_id: null,
-                    is_user_upload: true,
-                    latest_version_created_at: '2026-08-02T00:00:00.000Z'
+                    contentType: null,
+                    sizeBytes: 24,
+                    latestVersionId: 'upload-version-1',
+                    checksum: null,
+                    projectId: 'project-a',
+                    sessionId: 'session-b',
+                    rootFrameId: null,
+                    agentFrameId: null,
+                    isUserUpload: true,
+                    createdAt: '2026-08-01T00:00:00.000Z',
+                    latestVersionCreatedAt: '2026-08-02T00:00:00.000Z'
                   }
                 ]
               }
@@ -1781,9 +1792,9 @@ describe('repl_loop local RPC transport', () => {
 
     try {
       const projection = await send(
-        "const page = await host.artifacts({ search: 'report', sessionId: 'session-a', contentType: 'text/csv', limit: 2 }); " +
+        "const page = await host.artifacts({ search: 'report', frameId: 'frame-1', contentType: 'text/csv', limit: 2 }); " +
           "await host.artifacts({ versionId: 'artifact-version-1' }); " +
-          'const localPath = await host.artifactPath(page.artifacts[1].latest_version_id); ' +
+          'const localPath = await host.artifactPath(page.artifacts[1].latestVersionId); ' +
           'return JSON.stringify({ page, localPath, pageFrozen: Object.isFrozen(page), ' +
           'artifactsFrozen: Object.isFrozen(page.artifacts), itemFrozen: Object.isFrozen(page.artifacts[0]) })'
       )
@@ -1791,16 +1802,45 @@ describe('repl_loop local RPC transport', () => {
       const projected = JSON.parse(projection.result ?? '{}')
       expect(projected).toMatchObject({
         page: {
-          count: 2,
-          project_id: 'project-a',
-          truncated: false
+          count: 3,
+          projectId: 'project-a',
+          truncated: true,
+          nextCursor: 'next-page'
         },
         localPath: managedPath,
         pageFrozen: true,
         artifactsFrozen: true,
         itemFrozen: true
       })
-      expect(projected.page.artifacts[0].latest_version_id).toBe('artifact-version-1')
+      expect(projected.page.artifacts[0].latestVersionId).toBe('artifact-version-1')
+      expect(Object.keys(projected.page)).toEqual([
+        'count',
+        'projectId',
+        'truncated',
+        'nextCursor',
+        'artifacts'
+      ])
+      expect(Object.keys(projected.page.artifacts[0])).toEqual([
+        'id',
+        'filename',
+        'contentType',
+        'sizeBytes',
+        'latestVersionId',
+        'checksum',
+        'projectId',
+        'sessionId',
+        'rootFrameId',
+        'agentFrameId',
+        'isUserUpload',
+        'createdAt',
+        'latestVersionCreatedAt'
+      ])
+      expect(projected.page.artifacts[1]).toMatchObject({
+        contentType: null,
+        checksum: null,
+        rootFrameId: null,
+        agentFrameId: null
+      })
       expect(requests).toEqual([
         {
           method: 'artifactsCall',
@@ -1808,7 +1848,7 @@ describe('repl_loop local RPC transport', () => {
             op: 'list',
             options: {
               search: 'report',
-              session_id: 'session-a',
+              frame_id: 'frame-1',
               content_type: 'text/csv',
               limit: 2
             }
@@ -1822,13 +1862,15 @@ describe('repl_loop local RPC transport', () => {
       ])
 
       const oldOptions = await send(
-        "const errors = []; for (const [key, value] of [['version_id', 'artifact-version-1'], ['session_id', 'session-a'], ['content_type', 'text/csv']]) { " +
+        "const errors = []; for (const [key, value] of [['sessionId', 'session-a'], ['version_id', 'artifact-version-1'], ['frame_id', 'frame-1'], ['session_id', 'session-a'], ['content_type', 'text/csv']]) { " +
           'try { await host.artifacts({ [key]: value }) } ' +
           "catch (error) { errors.push(error.name + ': ' + error.message) } } " +
           'return JSON.stringify(errors)'
       )
       expect(JSON.parse(oldOptions.result ?? '[]')).toEqual([
+        'TypeError: host.artifacts options unknown option: sessionId',
         'TypeError: host.artifacts options unknown option: version_id',
+        'TypeError: host.artifacts options unknown option: frame_id',
         'TypeError: host.artifacts options unknown option: session_id',
         'TypeError: host.artifacts options unknown option: content_type'
       ])

--- a/src/main/project-files/host-artifact-catalog.test.ts
+++ b/src/main/project-files/host-artifact-catalog.test.ts
@@ -40,7 +40,9 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
     sessionId: string,
     artifactId: string,
     versionId: string,
-    versionNumber = 1
+    versionNumber = 1,
+    agentFrameId = 'agent-frame',
+    rootFrameId = `root-${versionId}`
   ): Promise<void> => {
     await client.artifactLineage.upsert({
       where: {
@@ -55,7 +57,8 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
         projectId,
         sessionId,
         normalizedFilename: `${artifactId}.csv`,
-        filename: `${artifactId}.csv`
+        filename: `${artifactId}.csv`,
+        createdAt: new Date('2026-07-01T00:00:00.000Z')
       },
       update: {}
     })
@@ -67,8 +70,8 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
       artifactRunId: `run-${versionId}`,
       writeOperationId: `write-${versionId}`,
       writeRequestChecksum: 'a'.repeat(64),
-      rootFrameId: `root-${versionId}`,
-      agentFrameId: 'agent-frame',
+      rootFrameId,
+      agentFrameId,
       messageBranchId: 'branch',
       runtimeSegmentId: 'runtime',
       promptMessageId: 'prompt',
@@ -99,6 +102,7 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
         sessionId,
         filename: `${uploadId}.pdf`,
         originalFilename: `${uploadId}.pdf`,
+        createdAt: new Date('2026-07-02T00:00:00.000Z'),
         versions: {
           create: {
             id: versionId,
@@ -170,12 +174,18 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
       expect.objectContaining({
         source: 'upload',
         sourceFileId: 'upload-a',
-        rootFrameId: null
+        createdAt: '2026-08-03T00:00:00.000Z',
+        sourceCreatedAt: '2026-07-02T00:00:00.000Z',
+        rootFrameId: null,
+        agentFrameId: null
       }),
       expect.objectContaining({
         source: 'artifact',
         sourceFileId: 'artifact-a',
-        rootFrameId: 'root-artifact-version-a'
+        createdAt: '2026-08-01T00:00:00.000Z',
+        sourceCreatedAt: '2026-07-01T00:00:00.000Z',
+        rootFrameId: 'root-artifact-version-a',
+        agentFrameId: 'agent-frame'
       })
     ])
   })
@@ -193,7 +203,7 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
         versionId: 'history-v1',
         versionNumber: 1,
         createdAt: '2026-08-01T00:00:00.000Z',
-        sourceCreatedAt: '2026-08-01T00:00:00.000Z',
+        sourceCreatedAt: '2026-07-01T00:00:00.000Z',
         rootFrameId: 'root-history-v1',
         agentFrameId: 'agent-frame'
       })
@@ -216,15 +226,70 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
     expect(nullableUpload).toEqual([
       expect.objectContaining({
         versionId: 'upload-null-created-at-v1',
-        createdAt: '2026-08-04T00:00:00.000Z'
+        createdAt: '2026-08-04T00:00:00.000Z',
+        sourceCreatedAt: '2026-07-02T00:00:00.000Z'
       })
     ])
-    expect(nullableUpload[0]).not.toHaveProperty('sourceCreatedAt')
 
     await createArtifactVersion('project-a', 'session-a', 'collision-artifact', 'collision')
     await createUploadVersion('project-a', 'session-b', 'collision-upload', 'collision')
     await expect(
       repository.readHostArtifactCatalog({ projectId: 'project-a', versionId: 'collision' })
     ).rejects.toThrow('ambiguous across generated Artifacts and Uploads')
+  })
+
+  it('projects producer provenance from the latest generated Version only', async () => {
+    await createArtifactVersion(
+      'project-a',
+      'session-a',
+      'artifact-a',
+      'artifact-a-v1',
+      1,
+      'frame-a',
+      'shared-root'
+    )
+    await createArtifactVersion(
+      'project-a',
+      'session-a',
+      'artifact-a',
+      'artifact-a-v2',
+      2,
+      'frame-b',
+      'shared-root'
+    )
+    await client.managedFile.create({
+      data: {
+        source: 'artifact',
+        sourceFileId: 'artifact-a',
+        sourceVersionId: 'artifact-a-v2',
+        checksum: checksum('artifact-a-v2'),
+        projectId: 'project-a',
+        sessionId: 'session-a',
+        displayName: 'artifact-a.csv',
+        storageKey: 'artifact-a',
+        mimeType: 'text/csv',
+        sizeBytes: 10n,
+        sortAtMs: BigInt(Date.parse('2026-08-02T00:00:00.000Z'))
+      }
+    })
+
+    await expect(repository.readHostArtifactCatalog({ projectId: 'project-a' })).resolves.toEqual([
+      expect.objectContaining({
+        versionId: 'artifact-a-v2',
+        rootFrameId: 'shared-root',
+        agentFrameId: 'frame-b',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        sourceCreatedAt: '2026-07-01T00:00:00.000Z'
+      })
+    ])
+    await expect(
+      repository.readHostArtifactCatalog({ projectId: 'project-a', versionId: 'artifact-a-v1' })
+    ).resolves.toEqual([
+      expect.objectContaining({
+        versionId: 'artifact-a-v1',
+        rootFrameId: 'shared-root',
+        agentFrameId: 'frame-a'
+      })
+    ])
   })
 })

--- a/src/main/project-files/host-artifact-catalog.test.ts
+++ b/src/main/project-files/host-artifact-catalog.test.ts
@@ -175,7 +175,8 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
         source: 'upload',
         sourceFileId: 'upload-a',
         createdAt: '2026-08-03T00:00:00.000Z',
-        sourceCreatedAt: '2026-07-02T00:00:00.000Z',
+        sourceCreatedAt: '2026-08-03T00:00:00.000Z',
+        sourceFileCreatedAt: '2026-07-02T00:00:00.000Z',
         rootFrameId: null,
         agentFrameId: null
       }),
@@ -183,7 +184,8 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
         source: 'artifact',
         sourceFileId: 'artifact-a',
         createdAt: '2026-08-01T00:00:00.000Z',
-        sourceCreatedAt: '2026-07-01T00:00:00.000Z',
+        sourceCreatedAt: '2026-08-01T00:00:00.000Z',
+        sourceFileCreatedAt: '2026-07-01T00:00:00.000Z',
         rootFrameId: 'root-artifact-version-a',
         agentFrameId: 'agent-frame'
       })
@@ -203,7 +205,8 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
         versionId: 'history-v1',
         versionNumber: 1,
         createdAt: '2026-08-01T00:00:00.000Z',
-        sourceCreatedAt: '2026-07-01T00:00:00.000Z',
+        sourceCreatedAt: '2026-08-01T00:00:00.000Z',
+        sourceFileCreatedAt: '2026-07-01T00:00:00.000Z',
         rootFrameId: 'root-history-v1',
         agentFrameId: 'agent-frame'
       })
@@ -227,9 +230,10 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
       expect.objectContaining({
         versionId: 'upload-null-created-at-v1',
         createdAt: '2026-08-04T00:00:00.000Z',
-        sourceCreatedAt: '2026-07-02T00:00:00.000Z'
+        sourceFileCreatedAt: '2026-07-02T00:00:00.000Z'
       })
     ])
+    expect(nullableUpload[0]).not.toHaveProperty('sourceCreatedAt')
 
     await createArtifactVersion('project-a', 'session-a', 'collision-artifact', 'collision')
     await createUploadVersion('project-a', 'session-b', 'collision-upload', 'collision')
@@ -279,7 +283,8 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
         rootFrameId: 'shared-root',
         agentFrameId: 'frame-b',
         createdAt: '2026-08-02T00:00:00.000Z',
-        sourceCreatedAt: '2026-07-01T00:00:00.000Z'
+        sourceCreatedAt: '2026-08-02T00:00:00.000Z',
+        sourceFileCreatedAt: '2026-07-01T00:00:00.000Z'
       })
     ])
     await expect(

--- a/src/main/project-files/query-owner.ts
+++ b/src/main/project-files/query-owner.ts
@@ -305,7 +305,7 @@ class ProjectFilesQueryOwner {
             sizeBytes: toSafeCount(artifactVersion.sizeBytes, 'host Artifact size'),
             sortAtMs: artifactVersion.createdAt.getTime(),
             createdAt: artifactVersion.createdAt.toISOString(),
-            sourceCreatedAt: artifactVersion.createdAt.toISOString(),
+            sourceCreatedAt: artifactVersion.artifact.createdAt.toISOString(),
             rootFrameId: artifactVersion.rootFrameId,
             agentFrameId: artifactVersion.agentFrameId
           }
@@ -328,9 +328,7 @@ class ProjectFilesQueryOwner {
               sizeBytes: toSafeCount(uploadVersion.sizeBytes, 'host Upload size'),
               sortAtMs: uploadTime.getTime(),
               createdAt: uploadTime.toISOString(),
-              ...(uploadVersion.createdAt
-                ? { sourceCreatedAt: uploadVersion.createdAt.toISOString() }
-                : {}),
+              sourceCreatedAt: uploadVersion.uploadFile.createdAt.toISOString(),
               rootFrameId: null,
               agentFrameId: null
             }
@@ -352,25 +350,75 @@ class ProjectFilesQueryOwner {
     const artifactVersionIds = rows.flatMap((row) =>
       row.source === 'artifact' && row.sourceVersionId ? [row.sourceVersionId] : []
     )
-    const artifactVersions =
+    const uploadVersionIds = rows.flatMap((row) =>
+      row.source === 'upload' && row.sourceVersionId ? [row.sourceVersionId] : []
+    )
+    const [artifactVersions, uploadVersions] = await Promise.all([
       artifactVersionIds.length === 0
-        ? []
-        : await client.artifactVersion.findMany({
+        ? Promise.resolve([])
+        : client.artifactVersion.findMany({
             where: {
               id: { in: artifactVersionIds },
               state: { in: ['pending', 'finalized'] },
               artifact: { is: { projectId: request.projectId } }
             },
-            select: { id: true, rootFrameId: true }
+            select: {
+              id: true,
+              rootFrameId: true,
+              agentFrameId: true,
+              createdAt: true,
+              artifact: { select: { createdAt: true } }
+            }
+          }),
+      uploadVersionIds.length === 0
+        ? Promise.resolve([])
+        : client.uploadVersion.findMany({
+            where: {
+              id: { in: uploadVersionIds },
+              state: 'ready',
+              uploadFile: { is: { projectId: request.projectId } }
+            },
+            select: {
+              id: true,
+              createdAt: true,
+              registeredAt: true,
+              uploadFile: { select: { createdAt: true } }
+            }
           })
-    const rootFrameIds = new Map(
-      artifactVersions.map((version) => [version.id, version.rootFrameId])
+    ])
+    const artifactMetadata = new Map(
+      artifactVersions.map(
+        (version) =>
+          [
+            version.id,
+            {
+              rootFrameId: version.rootFrameId,
+              agentFrameId: version.agentFrameId,
+              createdAt: version.createdAt.toISOString(),
+              sourceCreatedAt: version.artifact.createdAt.toISOString()
+            }
+          ] as const
+      )
+    )
+    const uploadMetadata = new Map(
+      uploadVersions.map(
+        (version) =>
+          [
+            version.id,
+            {
+              createdAt: (version.createdAt ?? version.registeredAt).toISOString(),
+              sourceCreatedAt: version.uploadFile.createdAt.toISOString()
+            }
+          ] as const
+      )
     )
 
     return rows.flatMap((row) => {
       if (!row.sourceVersionId) return []
-      const rootFrameId = row.source === 'artifact' ? rootFrameIds.get(row.sourceVersionId) : null
-      if (row.source === 'artifact' && rootFrameId === undefined) return []
+      const artifact =
+        row.source === 'artifact' ? artifactMetadata.get(row.sourceVersionId) : undefined
+      const upload = row.source === 'upload' ? uploadMetadata.get(row.sourceVersionId) : undefined
+      if (row.source === 'artifact' ? !artifact : !upload) return []
       return [
         {
           source: row.source as 'artifact' | 'upload',
@@ -383,7 +431,10 @@ class ProjectFilesQueryOwner {
           contentType: row.mimeType ?? undefined,
           sizeBytes: toSafeCount(row.sizeBytes, 'host managed file size'),
           sortAtMs: toSafeCount(row.sortAtMs, 'host managed file sort time'),
-          rootFrameId: rootFrameId ?? null
+          createdAt: artifact?.createdAt ?? upload!.createdAt,
+          sourceCreatedAt: artifact?.sourceCreatedAt ?? upload!.sourceCreatedAt,
+          rootFrameId: artifact?.rootFrameId ?? null,
+          agentFrameId: artifact?.agentFrameId ?? null
         }
       ]
     })

--- a/src/main/project-files/query-owner.ts
+++ b/src/main/project-files/query-owner.ts
@@ -305,7 +305,8 @@ class ProjectFilesQueryOwner {
             sizeBytes: toSafeCount(artifactVersion.sizeBytes, 'host Artifact size'),
             sortAtMs: artifactVersion.createdAt.getTime(),
             createdAt: artifactVersion.createdAt.toISOString(),
-            sourceCreatedAt: artifactVersion.artifact.createdAt.toISOString(),
+            sourceCreatedAt: artifactVersion.createdAt.toISOString(),
+            sourceFileCreatedAt: artifactVersion.artifact.createdAt.toISOString(),
             rootFrameId: artifactVersion.rootFrameId,
             agentFrameId: artifactVersion.agentFrameId
           }
@@ -328,7 +329,10 @@ class ProjectFilesQueryOwner {
               sizeBytes: toSafeCount(uploadVersion.sizeBytes, 'host Upload size'),
               sortAtMs: uploadTime.getTime(),
               createdAt: uploadTime.toISOString(),
-              sourceCreatedAt: uploadVersion.uploadFile.createdAt.toISOString(),
+              ...(uploadVersion.createdAt
+                ? { sourceCreatedAt: uploadVersion.createdAt.toISOString() }
+                : {}),
+              sourceFileCreatedAt: uploadVersion.uploadFile.createdAt.toISOString(),
               rootFrameId: null,
               agentFrameId: null
             }
@@ -395,7 +399,8 @@ class ProjectFilesQueryOwner {
               rootFrameId: version.rootFrameId,
               agentFrameId: version.agentFrameId,
               createdAt: version.createdAt.toISOString(),
-              sourceCreatedAt: version.artifact.createdAt.toISOString()
+              sourceCreatedAt: version.createdAt.toISOString(),
+              sourceFileCreatedAt: version.artifact.createdAt.toISOString()
             }
           ] as const
       )
@@ -407,7 +412,8 @@ class ProjectFilesQueryOwner {
             version.id,
             {
               createdAt: (version.createdAt ?? version.registeredAt).toISOString(),
-              sourceCreatedAt: version.uploadFile.createdAt.toISOString()
+              ...(version.createdAt ? { sourceCreatedAt: version.createdAt.toISOString() } : {}),
+              sourceFileCreatedAt: version.uploadFile.createdAt.toISOString()
             }
           ] as const
       )
@@ -418,7 +424,8 @@ class ProjectFilesQueryOwner {
       const artifact =
         row.source === 'artifact' ? artifactMetadata.get(row.sourceVersionId) : undefined
       const upload = row.source === 'upload' ? uploadMetadata.get(row.sourceVersionId) : undefined
-      if (row.source === 'artifact' ? !artifact : !upload) return []
+      const metadata = artifact ?? upload
+      if (!metadata) return []
       return [
         {
           source: row.source as 'artifact' | 'upload',
@@ -431,8 +438,9 @@ class ProjectFilesQueryOwner {
           contentType: row.mimeType ?? undefined,
           sizeBytes: toSafeCount(row.sizeBytes, 'host managed file size'),
           sortAtMs: toSafeCount(row.sortAtMs, 'host managed file sort time'),
-          createdAt: artifact?.createdAt ?? upload!.createdAt,
-          sourceCreatedAt: artifact?.sourceCreatedAt ?? upload!.sourceCreatedAt,
+          createdAt: metadata.createdAt,
+          ...(metadata.sourceCreatedAt ? { sourceCreatedAt: metadata.sourceCreatedAt } : {}),
+          sourceFileCreatedAt: metadata.sourceFileCreatedAt,
           rootFrameId: artifact?.rootFrameId ?? null,
           agentFrameId: artifact?.agentFrameId ?? null
         }

--- a/src/main/skills/self-awareness-skill.test.ts
+++ b/src/main/skills/self-awareness-skill.test.ts
@@ -55,6 +55,9 @@ describe('self-awareness bundled Skill', () => {
       'await host.frames.list(options)',
       'await host.frames.get(frameId, options)',
       'current Project',
+      'producer Frame',
+      'Uploads without trusted Frame',
+      'provenance are excluded',
       'exact full Frame ID',
       'active Branch',
       'private reasoning',
@@ -70,8 +73,13 @@ describe('self-awareness bundled Skill', () => {
       'await host.lineage.graph(versionId)',
       'await host.lineage.get(versionId)',
       '`versionId`',
+      '`frameId`',
       '`sessionId`',
       '`contentType`',
+      'latestVersionId',
+      'agentFrameId',
+      'latestVersionCreatedAt',
+      '`count` is the total number of matches',
       '`maxDepth`',
       '`maxNodes`',
       '`rootsOnly`',
@@ -87,8 +95,9 @@ describe('self-awareness bundled Skill', () => {
       expect(body).toContain(phrase)
     }
     expect(body).not.toMatch(
-      /host\.artifact_path|`(?:version_id|session_id|content_type|max_depth|max_nodes|roots_only|branch_id)`/
+      /host\.artifact_path|`(?:version_id|session_id|content_type|latest_version_id|root_frame_id|agent_frame_id|latest_version_created_at|max_depth|max_nodes|roots_only|branch_id)`/
     )
+    expect(body).not.toMatch(/Optional camelCase fields are[^.]*`sessionId`/)
     expect(body).not.toMatch(/host\.(query|artifact_read)/)
   })
 })

--- a/src/shared/project-files.ts
+++ b/src/shared/project-files.ts
@@ -127,8 +127,12 @@ export type HostArtifactCatalogItem = {
   contentType?: string
   sizeBytes: number
   sortAtMs: number
+  // Selected Version creation/registration time. Lineage nodes compare this with core provenance.
   createdAt: string
-  sourceCreatedAt: string
+  // Input Version time captured in dependency provenance; legacy Uploads may not have one.
+  sourceCreatedAt?: string
+  // Parent ArtifactLineage/UploadFile creation time for the Host Artifacts public projection.
+  sourceFileCreatedAt?: string
   rootFrameId: string | null
   agentFrameId: string | null
 }

--- a/src/shared/project-files.ts
+++ b/src/shared/project-files.ts
@@ -127,29 +127,32 @@ export type HostArtifactCatalogItem = {
   contentType?: string
   sizeBytes: number
   sortAtMs: number
-  createdAt?: string
-  sourceCreatedAt?: string
+  createdAt: string
+  sourceCreatedAt: string
   rootFrameId: string | null
-  agentFrameId?: string | null
+  agentFrameId: string | null
 }
 
 export type HostArtifact = {
   id: string
   filename: string
-  content_type?: string
-  size_bytes: number
-  latest_version_id: string
-  checksum?: string
-  session_id: string
-  root_frame_id: string | null
-  is_user_upload: boolean
-  latest_version_created_at: string
+  contentType: string | null
+  sizeBytes: number
+  latestVersionId: string
+  checksum: string | null
+  projectId: string
+  sessionId: string
+  rootFrameId: string | null
+  agentFrameId: string | null
+  isUserUpload: boolean
+  createdAt: string
+  latestVersionCreatedAt: string
 }
 
 export type HostArtifactsResult = {
   count: number
-  project_id: string
+  projectId: string
   truncated: boolean
-  next_cursor?: string
+  nextCursor?: string
   artifacts: HostArtifact[]
 }


### PR DESCRIPTION
## What changed

- replace the public `host.artifacts({ sessionId })` filter with exact latest-producer `frameId` filtering
- keep Project ownership token-bound while excluding Uploads from Frame-filtered results
- return a fixed camelCase JavaScript projection, including nullable provenance fields and separate source/Version timestamps
- make `count` the total pre-pagination match count and bind cursors to all filters
- support exact MIME types and validated top-level prefixes such as `text/`
- batch Artifact/Upload provenance metadata reads without adding a new state owner or database schema
- update the JavaScript REPL adapter and bundled self-awareness Skill contract

## Breaking change

`host.artifacts` no longer accepts `sessionId`. Callers must use `frameId` for exact producer filtering. Result fields such as `projectId`, `latestVersionId`, `agentFrameId`, and `nextCursor` are camelCase.

## Scope

- current Project only; no caller-controlled Project override
- exact producer Frame only; no root/descendant expansion and no Session fallback
- no content grep, cross-Project search, Artifact marker, database migration, UI, or ACP framework-specific behavior
- all four ACP frameworks consume the same JavaScript REPL/local-RPC path

## Validation

- exact Frame isolation, latest-vs-historical producer behavior, Upload exclusion, MIME validation, total count, and cursor binding: `host-artifacts-service.test.ts`
- batched latest provenance and exact historical Version reads: `host-artifact-catalog.test.ts`
- token-bound Project/Session context and no synthesized Frame filter: `local-rpc-server.artifacts.test.ts`
- camelCase input/output projection, fixed nullable fields, forward-compatible unknown response fields, and deep freezing: `repl-loop.integration.test.ts`
- bundled Skill contract: `self-awareness-skill.test.ts`
- focused impact set: 7 files passed, 67 tests passed, 30 skipped
- Node typecheck: passed
- Web typecheck: passed
- lint: passed
- Prettier and `git diff --check`: passed
- independent Spec review: no findings
- independent Standards review: no findings

Full `npm test` completed with 1,047 files and 15,365 tests passing. Its only failure is an existing `origin/main` renderer contract mismatch: `session-store.test.ts` does not list the already tracked `workspace-run-marks.ts` direct store consumer. This PR does not modify renderer files, and that unrelated baseline fix is intentionally outside this PR's approved scope.

## Review focus

- confirm exact latest producer semantics for `frameId`
- confirm the public JavaScript projection is consistently camelCase
- confirm Catalog timestamps preserve source creation vs selected Version creation semantics
- confirm cursor and Project ownership remain fail-closed
