### PR TITLE
test(session-store): register run marks consumer

### DIFF
--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -4494,6 +4494,7 @@ describe('session store public contract', () => {
       'src/renderer/src/pages/workspace/visible-project-sessions.ts',
       'src/renderer/src/pages/workspace/workspace-conversation-controller.ts',
       'src/renderer/src/pages/workspace/workspace-conversation-items.ts',
+      'src/renderer/src/pages/workspace/workspace-run-marks.ts',
       'src/renderer/src/pages/workspace/workspace-session-controller.ts',
       'src/renderer/src/pages/workspace/workspace-tool-activity-details.ts',
       'src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts',


### PR DESCRIPTION
## Problem

Nightly run 31872234511 failed the Session Store public-facade consumer contract because workspace-run-marks.ts added a legitimate type-only import from the public facade without updating the exact consumer baseline.

## Proposed solution

Register workspace-run-marks.ts in the ordered direct-consumer allowlist. The production import remains on the public Session Store facade; no boundary is relaxed.

## Scope

- Test-contract update only.
- No production behavior change.
- No dependency or schema change.

## Validation

- Target contract test: 1 passed.
- session_renderer equivalent module set: 4 files, 409 tests passed.
- workspace_page equivalent module set: 23 files, 392 tests passed.
- Module-impact manifest tests: 9 passed.
- npm run typecheck:web passed.
- npm run lint completed with 0 errors; 17 pre-existing formatting warnings outside this diff.
- Full npm test was intentionally not run; PR CI is authoritative.

## Review focus

Confirm workspace-run-marks.ts is a valid direct consumer of the public Session Store facade and that the baseline remains exact and alphabetically ordered.

## CI evidence

- Failing Nightly: https://github.com/aipoch/open-science/actions/runs/31872234511

## Compatibility and persistence

- Historical data compatibility: not affected.
- New status or enum values: none.
- Data persistence: not affected.