### PR TITLE
fix(notebook): set cache owner in Windows ACL fallback

### DIFF
--- a/src/main/notebook/micromamba-cache-powershell.test.ts
+++ b/src/main/notebook/micromamba-cache-powershell.test.ts
@@ -4,7 +4,11 @@ const childProcessMocks = vi.hoisted(() => ({ execFileSync: vi.fn() }))
 
 vi.mock('node:child_process', () => childProcessMocks)
 
-import { hardenWindowsCacheAcl, readWindowsCacheAcl } from './micromamba-cache'
+import {
+  hardenWindowsCacheAcl,
+  hardenWindowsCacheAclWithIcacls,
+  readWindowsCacheAcl
+} from './micromamba-cache'
 
 const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
 
@@ -44,7 +48,7 @@ describe('Windows micromamba cache PowerShell invocation', () => {
 
     expect(hardenWindowsCacheAcl('D:\\osp-cache')).toBe(true)
 
-    expect(childProcessMocks.execFileSync).toHaveBeenCalledTimes(3)
+    expect(childProcessMocks.execFileSync).toHaveBeenCalledTimes(4)
     expect(childProcessMocks.execFileSync).toHaveBeenNthCalledWith(
       2,
       'C:\\Windows\\System32\\whoami.exe',
@@ -53,6 +57,12 @@ describe('Windows micromamba cache PowerShell invocation', () => {
     )
     expect(childProcessMocks.execFileSync).toHaveBeenNthCalledWith(
       3,
+      'C:\\Windows\\System32\\icacls.exe',
+      ['D:\\osp-cache', '/setowner', '*S-1-5-21-1000'],
+      { encoding: 'utf8', windowsHide: true }
+    )
+    expect(childProcessMocks.execFileSync).toHaveBeenNthCalledWith(
+      4,
       'C:\\Windows\\System32\\icacls.exe',
       [
         'D:\\osp-cache',
@@ -64,6 +74,29 @@ describe('Windows micromamba cache PowerShell invocation', () => {
       ],
       { encoding: 'utf8', windowsHide: true }
     )
+  })
+
+  it('propagates owner update failures from the fallback ACL tool', () => {
+    childProcessMocks.execFileSync.mockReset()
+    childProcessMocks.execFileSync.mockReturnValueOnce('CONTOSO\\alice,S-1-5-21-1000\r\n')
+    childProcessMocks.execFileSync.mockImplementationOnce(() => {
+      throw new Error('icacls failed')
+    })
+
+    expect(() => hardenWindowsCacheAclWithIcacls('D:\\osp-cache')).toThrow('icacls failed')
+    expect(childProcessMocks.execFileSync).toHaveBeenCalledTimes(2)
+  })
+
+  it('propagates DACL update failures from the fallback ACL tool', () => {
+    childProcessMocks.execFileSync.mockReset()
+    childProcessMocks.execFileSync.mockReturnValueOnce('CONTOSO\\alice,S-1-5-21-1000\r\n')
+    childProcessMocks.execFileSync.mockReturnValueOnce('owner updated')
+    childProcessMocks.execFileSync.mockImplementationOnce(() => {
+      throw new Error('icacls failed')
+    })
+
+    expect(() => hardenWindowsCacheAclWithIcacls('D:\\osp-cache')).toThrow('icacls failed')
+    expect(childProcessMocks.execFileSync).toHaveBeenCalledTimes(3)
   })
 
   it('does not hide PowerShell script failures behind the fallback', () => {

--- a/src/main/notebook/micromamba-cache.ts
+++ b/src/main/notebook/micromamba-cache.ts
@@ -123,6 +123,11 @@ export const hardenWindowsCacheAclWithIcacls = (path: string): void => {
   const currentSid = currentWindowsUserSid()
   execFileSync(
     resolveWindowsSystemExecutable('icacls.exe'),
+    [path, '/setowner', `*${currentSid}`],
+    { encoding: 'utf8', windowsHide: true }
+  )
+  execFileSync(
+    resolveWindowsSystemExecutable('icacls.exe'),
     [
       path,
       '/inheritance:r',


### PR DESCRIPTION
## Problem

Windows Full Test run 31872234513 consistently failed the real Windows micromamba cache ACL integration. The PowerShell path set the cache owner to the current SID, but the icacls fallback only rebuilt the DACL. The strict verifier therefore rejected directories whose inherited owner was Administrators or another runner provisioner identity.

## Proposed solution

Set the directory owner with icacls /setowner and the resolved current-user SID before applying the existing fail-closed DACL hardening. Keep the strict verifier unchanged and propagate failures from both owner and DACL operations.

## Scope

- Windows micromamba cache ACL fallback only.
- Mock coverage for command order and both failure stages.
- No dependency, database, or schema change.

## Validation

- Four focused files passed: 32 tests total.
- Includes the real Windows ACL integration test against the production verifier.
- npm run typecheck:node passed.
- Focused ESLint on both changed files passed.
- git diff --check passed.
- Full npm test was intentionally not run; PR Windows CI is authoritative.

## Review focus

Confirm the fallback now matches the PowerShell path's owner semantics while preserving strict fail-closed verification and cleanup behavior.

## CI evidence

- Failing Windows Full Test: https://github.com/aipoch/open-science/actions/runs/31872234513

## Compatibility and persistence

- Historical data compatibility: no migration; existing untrusted caches remain fail-closed.
- New status or enum values: none.
- Data persistence: no application data change. The intended NTFS owner plus existing DACL security metadata is persisted on newly prepared app-managed cache directories.