### PR TITLE
ci(windows): isolate upgrade smoke harness

### DIFF
--- a/.github/workflows/windows-upgrade-smoke.yml
+++ b/.github/workflows/windows-upgrade-smoke.yml
@@ -27,16 +27,20 @@ jobs:
     env:
       CURRENT_TAG: ${{ github.event.client_payload.tag || inputs.tag }}
     steps:
-      - name: Checkout released revision
+      - name: Checkout smoke harness
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-          ref: ${{ env.CURRENT_TAG }}
 
       - name: Resolve released revision
         id: current
         shell: pwsh
-        run: "'sha=' + (git rev-parse HEAD) >> $env:GITHUB_OUTPUT"
+        run: |
+          $releasedSha = git rev-parse "$($env:CURRENT_TAG)^{commit}"
+          if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($releasedSha)) {
+            exit 1
+          }
+          "sha=$releasedSha" >> $env:GITHUB_OUTPUT
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -81,6 +85,8 @@ jobs:
 
       - name: Certify Windows electron-updater differential update
         id: updater
+        env:
+          OPEN_SCIENCE_E2E_STORAGE_ROOT: ${{ runner.temp }}\open-science-updater-certification
         if: steps.previous.outputs.available == 'true'
         continue-on-error: true
         shell: pwsh
@@ -94,6 +100,8 @@ jobs:
 
       - name: Drill Windows silent upgrade, process lock, rollback, and restart
         id: installer
+        env:
+          OPEN_SCIENCE_E2E_STORAGE_ROOT: ${{ runner.temp }}\open-science-installer-certification
         if: always() && steps.previous.outputs.available == 'true'
         continue-on-error: true
         shell: pwsh

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -204,6 +204,27 @@ describe('release and scheduled workflow topology', () => {
     expect(smokeWorkflow.on).toHaveProperty('workflow_dispatch')
     expect(smokeWorkflow.concurrency?.['cancel-in-progress']).toBe(false)
     expect(smoke['continue-on-error']).toBeUndefined()
+    const checkout = step(smoke, 'Checkout smoke harness')
+    expect(checkout).toMatchObject({
+      uses: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1',
+      with: { 'fetch-depth': 0 }
+    })
+    expect(checkout.with).not.toHaveProperty('ref')
+    const released = step(smoke, 'Resolve released revision')
+    expect(released.run).toContain('git rev-parse "$($env:CURRENT_TAG)^{commit}"')
+    expect(released.run).toContain('"sha=$releasedSha"')
+    const updaterRoot = step(smoke, 'Certify Windows electron-updater differential update').env
+      ?.OPEN_SCIENCE_E2E_STORAGE_ROOT
+    const installerRoot = step(
+      smoke,
+      'Drill Windows silent upgrade, process lock, rollback, and restart'
+    ).env?.OPEN_SCIENCE_E2E_STORAGE_ROOT
+    expect(updaterRoot).toBe('${{ runner.temp }}\\open-science-updater-certification')
+    expect(installerRoot).toBe('${{ runner.temp }}\\open-science-installer-certification')
+    expect(updaterRoot).not.toBe(installerRoot)
+    expect(step(smoke, 'Record Windows update-drill evidence')).toMatchObject({
+      env: { GITHUB_SHA: '${{ steps.current.outputs.sha }}' }
+    })
     expect(step(smoke, 'Download current Windows installer').run).toContain(
       'gh release download $env:CURRENT_TAG'
     )

--- a/scripts/windows-installer-smoke.mjs
+++ b/scripts/windows-installer-smoke.mjs
@@ -322,6 +322,12 @@ const observeChildExit = (child) =>
     child.once('exit', resolveExit)
   })
 
+const observeChildClose = (child) =>
+  new Promise((resolveClose, rejectClose) => {
+    child.once('error', rejectClose)
+    child.once('close', resolveClose)
+  })
+
 const waitForShutdownExit = (
   exit,
   child,
@@ -788,6 +794,17 @@ const launchAndProbe = async ({
   }
 }
 
+const assertDatabaseDowngradeBlocked = ({ becameHealthy, output }) => {
+  if (becameHealthy) {
+    throw new Error(`Ledger-aware downgrade unexpectedly became healthy.\n${output}`)
+  }
+  if (!/database_newer_than_app|newer version of Open Science/i.test(output)) {
+    throw new Error(
+      `Ledger-aware downgrade did not report the expected compatibility error.\n${output}`
+    )
+  }
+}
+
 const launchAndExpectDatabaseBlocked = async ({ installDirectory, env }) => {
   const child = spawn(
     join(installDirectory, APP_EXECUTABLE),
@@ -801,24 +818,26 @@ const launchAndExpectDatabaseBlocked = async ({ installDirectory, env }) => {
   child.stdout?.on('data', (chunk) => (stdout += chunk))
   child.stderr?.on('data', (chunk) => (stderr += chunk))
   const output = () => `${stdout}${stderr ? `\n${stderr}` : ''}`
-  const exit = observeChildExit(child)
-  let exitCode
-  void exit.then((code) => {
-    exitCode = code
-  })
+  const close = observeChildClose(child)
+  let closed = false
+  let closeError
+  void close.then(
+    () => {
+      closed = true
+    },
+    (error) => {
+      closeError = error
+      closed = true
+    }
+  )
 
   try {
-    await waitFor('the ledger-aware downgrade to block', async () =>
-      exitCode === undefined ? undefined : true
-    )
-    if (exitCode === 0) {
-      throw new Error(`Ledger-aware downgrade unexpectedly became healthy.\n${output()}`)
-    }
-    if (!/database_newer_than_app|newer version of Open Science/i.test(output())) {
-      throw new Error(
-        `Ledger-aware downgrade did not report the expected compatibility error.\n${output()}`
-      )
-    }
+    await waitFor('the ledger-aware downgrade to block', async () => (closed ? true : undefined))
+    if (closeError) throw closeError
+    assertDatabaseDowngradeBlocked({
+      becameHealthy: parsePackagedAppEndpoint(output()) !== undefined,
+      output: output()
+    })
   } catch (error) {
     await terminateProcessTree(child)
     throw error
@@ -1102,6 +1121,7 @@ if (invokedAsScript) {
 
 export {
   authenticatePackagedAppEndpoint,
+  assertDatabaseDowngradeBlocked,
   assertPackagedResources,
   assertUpgradeProfilePreserved,
   buildSmokePlan,
@@ -1115,6 +1135,7 @@ export {
   installAndProbe,
   launchAndProbe,
   packagedMainEntryPath,
+  observeChildClose,
   packagedResourcePaths,
   parsePackagedAppEndpoint,
   readPackagedAppConfigRoot,

--- a/scripts/windows-installer-smoke.test.ts
+++ b/scripts/windows-installer-smoke.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   assertPackagedResources,
+  assertDatabaseDowngradeBlocked,
   authenticatePackagedAppEndpoint,
   assertUpgradeProfilePreserved,
   buildSmokePlan,
@@ -16,6 +17,7 @@ import {
   fetchWithTimeout,
   findSetupInstaller,
   installerVersion,
+  observeChildClose,
   packagedMainEntryPath,
   packagedResourcePaths,
   parsePackagedAppEndpoint,
@@ -131,6 +133,33 @@ Open Science Web: http://127.0.0.1:52378/?token=iUFHGSACwBz2k1kSJfPixHbclDywVg0C
     expect(parsePackagedAppEndpoint('[main] app starting')).toBeUndefined()
   })
 
+  it('accepts a blocked database downgrade regardless of process exit status', () => {
+    expect(
+      assertDatabaseDowngradeBlocked({
+        becameHealthy: false,
+        output: '[main] database_newer_than_app'
+      })
+    ).toBeUndefined()
+  })
+
+  it('rejects a database downgrade that became healthy', () => {
+    expect(() =>
+      assertDatabaseDowngradeBlocked({
+        becameHealthy: true,
+        output: '[main] database_newer_than_app'
+      })
+    ).toThrow(/unexpectedly became healthy/)
+  })
+
+  it('requires a compatibility diagnostic for a blocked database downgrade', () => {
+    expect(() =>
+      assertDatabaseDowngradeBlocked({
+        becameHealthy: false,
+        output: '[main] app exited'
+      })
+    ).toThrow(/expected compatibility error/)
+  })
+
   it('accepts only a packaged bootstrap that reports an absolute Windows config root', async () => {
     const configRoot = 'C:\\Users\\runneradmin\\.open-science'
     await expect(
@@ -175,6 +204,25 @@ Open Science Web: http://127.0.0.1:52378/?token=iUFHGSACwBz2k1kSJfPixHbclDywVg0C
       [`${runnerConfigRoot}\\web-token`, 'utf8'],
       [`${isolatedConfigRoot}\\web-token`, 'utf8']
     ])
+  })
+
+  it('waits for child stdio close after exit before evaluating downgrade output', async () => {
+    const child = new EventEmitter()
+    let output = ''
+    const close = observeChildClose(child)
+    let closed = false
+    void close.then(() => {
+      closed = true
+    })
+
+    child.emit('exit', 0)
+    output += '[main] database_newer_than_app'
+    await Promise.resolve()
+    expect(closed).toBe(false)
+
+    child.emit('close', 0)
+    await expect(close).resolves.toBe(0)
+    expect(output).toContain('database_newer_than_app')
   })
 
   it('gives shutdown its own timeout budget after startup completes', async () => {

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -312,6 +312,39 @@ describe('post-merge Windows validation', () => {
       'npm ci --ignore-scripts --no-audit --no-fund'
     )
     expect(findStep(upgrade, 'Generate Prisma client').run).toBe('npx prisma generate')
+    const checkout = findStep(upgrade, 'Checkout smoke harness')
+    expect(checkout).toMatchObject({
+      uses: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1',
+      with: { 'fetch-depth': 0 }
+    })
+    expect(checkout.with).not.toHaveProperty('ref')
+
+    const released = findStep(upgrade, 'Resolve released revision')
+    expect(released.run).toContain('git rev-parse "$($env:CURRENT_TAG)^{commit}"')
+    expect(released.run).toContain('"sha=$releasedSha"')
+
+    const updaterStep = findStep(upgrade, 'Certify Windows electron-updater differential update')
+    const installerStep = findStep(
+      upgrade,
+      'Drill Windows silent upgrade, process lock, rollback, and restart'
+    )
+    expect(updaterStep).toMatchObject({
+      env: {
+        OPEN_SCIENCE_E2E_STORAGE_ROOT: '${{ runner.temp }}\\open-science-updater-certification'
+      }
+    })
+    expect(installerStep).toMatchObject({
+      env: {
+        OPEN_SCIENCE_E2E_STORAGE_ROOT: '${{ runner.temp }}\\open-science-installer-certification'
+      }
+    })
+    expect(updaterStep.env?.OPEN_SCIENCE_E2E_STORAGE_ROOT).not.toBe(
+      installerStep.env?.OPEN_SCIENCE_E2E_STORAGE_ROOT
+    )
+    expect(findStep(upgrade, 'Record Windows update-drill evidence')).toMatchObject({
+      env: { GITHUB_SHA: '${{ steps.current.outputs.sha }}' }
+    })
+
     const current = findStep(upgrade, 'Download current Windows installer')
     expect(current.run).toContain('gh release download $env:CURRENT_TAG')
     expect(current.run).toContain("--pattern 'latest.yml'")


### PR DESCRIPTION
## Problem

Windows Upgrade Smoke run 31872233783 passed the v0.14.1 to v0.15.0 electron-updater certification, then failed when the installer drill launched the old app against the database left by the preceding step. Three harness defects combined:

- updater and installer certification shared the effective application storage;
- the downgrade helper treated exit code 0 as a healthy launch even when database_newer_than_app was logged;
- checkout switched to the released tag, so a harness fix on the dispatch revision could not revalidate an already published tag.

## Proposed solution

- Keep checkout on the workflow dispatch revision and resolve the released tag commit separately for evidence.
- Give updater and installer certification distinct runner.temp storage roots.
- Define a successful forward-only downgrade block as never becoming healthy plus an explicit compatibility diagnostic, independent of process exit status.
- Wait for child close so stdout and stderr are fully drained before evaluating the diagnostic.
- Add workflow contracts and helper regression tests.

Published installers and update metadata are still downloaded strictly from CURRENT_TAG and the resolved previous release.

## Scope

- Windows Upgrade Smoke workflow and certification harness only.
- No production database schema, migration, or application behavior change.
- No release publishing behavior change.

## Validation

- Four focused test files passed: 52 tests total.
- npm run typecheck:node passed.
- Focused ESLint on all changed scripts and tests passed.
- Prettier and git diff --check passed.
- Full npm test was intentionally not run; PR CI and a focused workflow dispatch are authoritative.

## Review focus

Confirm the harness revision remains separate from the released asset revision, storage roots cannot leak between certification phases, and downgrade protection is accepted only when the old app never reports a healthy endpoint and emits the forward-only compatibility diagnostic.

## CI evidence

- Failing Windows Upgrade Smoke: https://github.com/aipoch/open-science/actions/runs/31872233783

## Compatibility and persistence

- Historical data compatibility: the existing forward-only policy is preserved. v0.15.0 data must remain blocked in v0.14.1; runnable downgrade is not introduced.
- New status or enum values: none.
- Data persistence: no production persistence change. CI-only temporary databases are isolated under distinct runner.temp roots.