### PR TITLE
fix(notebook): bound package installation logs

### DIFF
--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -657,6 +657,23 @@ describe('manage_packages tool', () => {
     )
   })
 
+  it('preserves bounded installer-log truncation metadata in the compact result', () => {
+    expect(
+      compactManagePackagesResult({
+        ok: true,
+        needsRestart: false,
+        method: 'pip',
+        log: 'latest retained output',
+        logTruncation: { droppedBytes: 524_321 }
+      })
+    ).toEqual({
+      ok: true,
+      needsRestart: false,
+      method: 'pip',
+      logTruncation: { droppedBytes: 524_321 }
+    })
+  })
+
   it('has no per-call environment param — installs target the session-bound runtime (v4)', () => {
     // The env is the session's bound runtime, not a per-call argument, so the schema has no
     // `environment` key and strips it if passed.

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -956,6 +956,13 @@ const compactManageEnvironmentsResult = (raw: unknown, input: unknown = {}): unk
 const compactManagePackagesResult = (raw: unknown): unknown => {
   if (typeof raw !== 'object' || raw === null) return raw
   const result = raw as Record<string, unknown>
+  const logTruncation = asRecord(result.logTruncation)
+  const droppedLogBytes =
+    logTruncation &&
+    Number.isSafeInteger(logTruncation.droppedBytes) &&
+    Number(logTruncation.droppedBytes) > 0
+      ? Number(logTruncation.droppedBytes)
+      : undefined
   const packageChanges = Array.isArray(result.packageChanges)
     ? result.packageChanges.slice(0, MAX_PACKAGE_RESULTS).flatMap((change) => {
         const item = asRecord(change)
@@ -978,6 +985,7 @@ const compactManagePackagesResult = (raw: unknown): unknown => {
     needsRestart: result.needsRestart,
     ...(result.method !== undefined ? { method: result.method } : {}),
     ...(result.fallbackUsed !== undefined ? { fallbackUsed: result.fallbackUsed } : {}),
+    ...(droppedLogBytes !== undefined ? { logTruncation: { droppedBytes: droppedLogBytes } } : {}),
     ...(packageChanges !== undefined ? { packageChanges } : {}),
     ...(Array.isArray(result.packageChanges) &&
     result.packageChanges.length > (packageChanges?.length ?? 0)

--- a/src/main/notebook/package-manager.test.ts
+++ b/src/main/notebook/package-manager.test.ts
@@ -14,6 +14,7 @@ vi.mock('./micromamba', async (importActual) => ({
 
 import {
   defaultSpawn,
+  INSTALLER_STREAM_LOG_LIMIT_BYTES,
   installPackages,
   type InstallSpawn,
   type SpawnResult
@@ -139,9 +140,51 @@ describe('defaultSpawn (fail-closed spawn hooks)', () => {
     expect(killedPid).toBeGreaterThan(0)
     await vi.waitFor(() => expect(() => process.kill(killedPid as number, 0)).toThrow())
   })
+
+  it('retains bounded stdout/stderr tails and reports the exact discarded byte counts', async () => {
+    const stdoutPrefix = 'stdout-old\n'
+    const stdoutTail = '\nstdout-tail'
+    const stderrPrefix = 'stderr-old\n'
+    const stderrTail = '\nstderr-tail'
+    const result = await defaultSpawn(process.execPath, [
+      '-e',
+      [
+        `process.stdout.write(${JSON.stringify(stdoutPrefix)} + 'x'.repeat(${INSTALLER_STREAM_LOG_LIMIT_BYTES}) + ${JSON.stringify(stdoutTail)});`,
+        `process.stderr.write(${JSON.stringify(stderrPrefix)} + 'y'.repeat(${INSTALLER_STREAM_LOG_LIMIT_BYTES}) + ${JSON.stringify(stderrTail)});`
+      ].join('')
+    ])
+
+    expect(result.code).toBe(0)
+    expect(Buffer.byteLength(result.stdout, 'utf8')).toBe(INSTALLER_STREAM_LOG_LIMIT_BYTES)
+    expect(Buffer.byteLength(result.stderr, 'utf8')).toBe(INSTALLER_STREAM_LOG_LIMIT_BYTES)
+    expect(result.stdout).not.toContain(stdoutPrefix)
+    expect(result.stderr).not.toContain(stderrPrefix)
+    expect(result.stdout.endsWith(stdoutTail)).toBe(true)
+    expect(result.stderr.endsWith(stderrTail)).toBe(true)
+    expect(result.stdoutDroppedBytes).toBe(Buffer.byteLength(stdoutPrefix + stdoutTail, 'utf8'))
+    expect(result.stderrDroppedBytes).toBe(Buffer.byteLength(stderrPrefix + stderrTail, 'utf8'))
+  })
 })
 
 describe('installPackages', () => {
+  it('aggregates discarded stream bytes into structured install-log truncation metadata', async () => {
+    const truncated: SpawnResult = {
+      code: 0,
+      stdout: 'latest output',
+      stderr: 'latest warning',
+      stdoutDroppedBytes: 23,
+      stderrDroppedBytes: 19
+    }
+    const { spawn } = scriptedSpawn([truncated])
+    const result = await installPackages(
+      { language: 'python', packages: ['numpy'], usePip: true },
+      { spawn, ...base }
+    )
+
+    expect(result.log).toContain('latest output')
+    expect(result.logTruncation).toEqual({ droppedBytes: 42 })
+  })
+
   it('forwards the installer child PID through onChild (for crash-recovery journaling)', async () => {
     // A spawn that reports a pid via its 4th (onChild) argument, as the real defaultSpawn does.
     const spawn: InstallSpawn = async (_command, _args, _env, onChild) => {

--- a/src/main/notebook/package-manager.test.ts
+++ b/src/main/notebook/package-manager.test.ts
@@ -13,6 +13,7 @@ vi.mock('./micromamba', async (importActual) => ({
 }))
 
 import {
+  CONDA_JSON_CAPTURE_LIMIT_BYTES,
   defaultSpawn,
   INSTALLER_STREAM_LOG_LIMIT_BYTES,
   installPackages,
@@ -194,6 +195,24 @@ describe('defaultSpawn (fail-closed spawn hooks)', () => {
     })
     expect(result.maxPathRecoveryEvidence).toMatch(/Invalid package cache/)
     expect(result.maxPathRecoveryEvidence).toContain('broken-package-1.0-0.conda')
+  })
+
+  it('fails closed when micromamba JSON exceeds the bounded temporary capture', async () => {
+    const result = await defaultSpawn(process.execPath, [
+      '-e',
+      [
+        `const value = { padding: 'x'.repeat(${CONDA_JSON_CAPTURE_LIMIT_BYTES}), actions: { LINK: [{ name: 'r-base', version: '4.5.0' }], UNLINK: [] } };`,
+        `process.stdout.write(JSON.stringify(value));`
+      ].join(''),
+      '--',
+      '--json'
+    ])
+
+    expect(result.code).toBe(0)
+    expect(result.stdoutDroppedBytes).toBeGreaterThan(0)
+    expect(Buffer.byteLength(result.stdout, 'utf8')).toBe(INSTALLER_STREAM_LOG_LIMIT_BYTES)
+    expect(result.structuredCondaResult).toBeUndefined()
+    expect(result.maxPathRecoveryEvidence).toBeUndefined()
   })
 })
 

--- a/src/main/notebook/package-manager.test.ts
+++ b/src/main/notebook/package-manager.test.ts
@@ -170,6 +170,7 @@ describe('defaultSpawn (fail-closed spawn hooks)', () => {
       '-e',
       [
         `const value = {`,
+        `error: ['Invalid package cache; file is missing; Package cache error', String.fromCharCode(39) + 'C:/cache/' + 'p'.repeat(280) + String.fromCharCode(39), 'for ' + String.fromCharCode(39) + 'broken-package-1.0-0.conda' + String.fromCharCode(39)],`,
         `padding: 'x'.repeat(${INSTALLER_STREAM_LOG_LIMIT_BYTES}),`,
         `solver_problems: ['unsatisfiable dependency constraints'],`,
         `actions: { LINK: [{ name: 'r-base', version: '4.5.0' }], UNLINK: [] }`,
@@ -191,6 +192,8 @@ describe('defaultSpawn (fail-closed spawn hooks)', () => {
       },
       diagnostics: ['solver failed']
     })
+    expect(result.maxPathRecoveryEvidence).toMatch(/Invalid package cache/)
+    expect(result.maxPathRecoveryEvidence).toContain('broken-package-1.0-0.conda')
   })
 })
 
@@ -833,7 +836,11 @@ describe('installPackages', () => {
       {
         code: 1,
         stdout: 'original install stdout',
-        stderr: `Invalid package cache, file '${missing}' is missing for '${leaf}.conda'; Package cache error`
+        stderr: 'truncated diagnostic tail',
+        stderrDroppedBytes: INSTALLER_STREAM_LOG_LIMIT_BYTES,
+        maxPathRecoveryEvidence:
+          `Invalid package cache; file is missing; Package cache error.\n` +
+          `for '${leaf}.conda'\n'${missing}'`
       },
       { code: 1, stdout: 'retry install stdout', stderr: 'retry install failed' }
     ]
@@ -864,6 +871,7 @@ describe('installPackages', () => {
     expect(result.log).toContain('Retry failure after MAX_PATH recovery')
     expect(result.log).toContain('original install stdout')
     expect(result.log).toContain('retry install stdout')
+    expect(result.logTruncation).toEqual({ droppedBytes: INSTALLER_STREAM_LOG_LIMIT_BYTES })
     expect(result.error).toMatch(/short Windows package cache[^]*shorter data location/i)
     expect(result.error).not.toMatch(/LongPathsEnabled|administrator/i)
   })

--- a/src/main/notebook/package-manager.test.ts
+++ b/src/main/notebook/package-manager.test.ts
@@ -164,6 +164,34 @@ describe('defaultSpawn (fail-closed spawn hooks)', () => {
     expect(result.stdoutDroppedBytes).toBe(Buffer.byteLength(stdoutPrefix + stdoutTail, 'utf8'))
     expect(result.stderrDroppedBytes).toBe(Buffer.byteLength(stderrPrefix + stderrTail, 'utf8'))
   })
+
+  it('reduces oversized micromamba JSON without retaining the complete document in memory', async () => {
+    const result = await defaultSpawn(process.execPath, [
+      '-e',
+      [
+        `const value = {`,
+        `padding: 'x'.repeat(${INSTALLER_STREAM_LOG_LIMIT_BYTES}),`,
+        `solver_problems: ['unsatisfiable dependency constraints'],`,
+        `actions: { LINK: [{ name: 'r-base', version: '4.5.0' }], UNLINK: [] }`,
+        `};`,
+        `process.stdout.write(JSON.stringify(value));`
+      ].join(''),
+      '--',
+      '--json'
+    ])
+
+    expect(result.code).toBe(0)
+    expect(result.stdoutDroppedBytes).toBeGreaterThan(0)
+    expect(Buffer.byteLength(result.stdout, 'utf8')).toBe(INSTALLER_STREAM_LOG_LIMIT_BYTES)
+    expect(result.structuredCondaResult).toEqual({
+      transaction: true,
+      actions: {
+        LINK: [{ name: 'r-base', version: '4.5.0' }],
+        UNLINK: []
+      },
+      diagnostics: ['solver failed']
+    })
+  })
 })
 
 describe('installPackages', () => {
@@ -639,6 +667,39 @@ describe('installPackages', () => {
       expect.objectContaining({ installer: 'conda', reason: 'solver-failed' }),
       expect.objectContaining({ installer: 'pip', status: 'succeeded' })
     ])
+  })
+
+  it('falls back using the reduced summary when bounded logs truncate structured output', async () => {
+    const solverFailure: SpawnResult = {
+      code: 1,
+      stdout: 'truncated-json-tail',
+      stderr: 'solver failed',
+      stdoutDroppedBytes: INSTALLER_STREAM_LOG_LIMIT_BYTES,
+      structuredCondaResult: {
+        transaction: false,
+        actions: { LINK: [], UNLINK: [] },
+        diagnostics: ['solver failed']
+      }
+    }
+    const { spawn, calls } = scriptedSpawn([solverFailure, ok])
+
+    const result = await installPackages(
+      { language: 'python', packages: ['special-wheel'] },
+      { spawn, ...base, pypiIndex: 'https://pypi.example/simple' }
+    )
+
+    expect(calls).toHaveLength(2)
+    expect(result).toMatchObject({
+      ok: true,
+      method: 'pip',
+      fallbackUsed: true,
+      logTruncation: { droppedBytes: INSTALLER_STREAM_LOG_LIMIT_BYTES }
+    })
+    expect(result.attempts?.[0]).toMatchObject({
+      installer: 'conda',
+      reason: 'solver-failed',
+      mutationRisk: 'none'
+    })
   })
 
   it('refuses fallback when structured conda actions show possible mutation', async () => {

--- a/src/main/notebook/package-manager.ts
+++ b/src/main/notebook/package-manager.ts
@@ -1,7 +1,15 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import {
+  createWriteStream,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync
+} from 'node:fs'
 import { spawn as nodeSpawn } from 'node:child_process'
-import { homedir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { finished } from 'node:stream/promises'
 
 import { PROD_SESSION_DIR_NAME } from '../session-persistence/repository'
 import type { OptionalProjectIdScope } from '../../shared/project-scope'
@@ -84,6 +92,15 @@ export type InstallResult = {
   error?: string
 }
 
+type CondaStructuredResult = {
+  transaction: boolean
+  actions: {
+    LINK: Array<{ name: 'r-base'; version?: string }>
+    UNLINK: Array<{ name: 'r-base'; version?: string }>
+  }
+  diagnostics: string[]
+}
+
 // One spawned install command's outcome; injected so tests never launch micromamba/pip/R.
 export type SpawnResult = {
   code: number
@@ -91,6 +108,9 @@ export type SpawnResult = {
   stderr: string
   stdoutDroppedBytes?: number
   stderrDroppedBytes?: number
+  // When a bounded stream truncated micromamba --json output, a short-lived parser subprocess
+  // reduces the complete temporary capture to only the facts needed for fail-closed decisions.
+  structuredCondaResult?: CondaStructuredResult
 }
 export type InstallSpawn = (
   command: string,
@@ -187,6 +207,7 @@ const condaMatchSpecName = (spec: string): string | undefined => {
 type CondaFailureClassification = Pick<NotebookPackageInstallerAttempt, 'mutationRisk' | 'reason'>
 
 const parseStructuredCondaResult = (result: SpawnResult): Record<string, unknown> | undefined => {
+  if (result.structuredCondaResult) return result.structuredCondaResult
   for (const candidate of [result.stdout, result.stderr]) {
     try {
       const parsed = JSON.parse(candidate) as unknown
@@ -539,13 +560,226 @@ class InstallerLogTailBuffer {
   }
 }
 
+type CondaJsonCapture = {
+  directory: string
+  stdoutPath: string
+  stderrPath: string
+  stdoutStream: ReturnType<typeof createWriteStream>
+  stderrStream: ReturnType<typeof createWriteStream>
+}
+
+const CONDA_JSON_SUMMARIZER_SOURCE = String.raw`
+const { readFileSync } = require('node:fs')
+
+const strings = (value) =>
+  Array.isArray(value)
+    ? value.flatMap(strings)
+    : typeof value === 'string'
+      ? [value]
+      : typeof value === 'object' && value !== null
+        ? Object.values(value).flatMap(strings)
+        : []
+
+const summarize = (value) => {
+  let transaction = false
+  const actions = { LINK: [], UNLINK: [] }
+  const visit = (nested) => {
+    if (Array.isArray(nested)) {
+      nested.forEach(visit)
+      return
+    }
+    if (typeof nested !== 'object' || nested === null) return
+    for (const [key, child] of Object.entries(nested)) {
+      const normalized = key.toUpperCase()
+      if (/^(?:LINK|UNLINK|FETCH|PREFIX_ACTIONS|TRANSACTION)$/.test(normalized)) {
+        transaction ||= Array.isArray(child) ? child.length > 0 : Boolean(child)
+      }
+      if ((normalized === 'LINK' || normalized === 'UNLINK') && Array.isArray(child)) {
+        for (const record of child) {
+          if (
+            actions[normalized].length < 16 &&
+            typeof record === 'object' &&
+            record !== null &&
+            typeof record.name === 'string' &&
+            record.name.toLowerCase() === 'r-base'
+          ) {
+            actions[normalized].push({
+              name: 'r-base',
+              ...(typeof record.version === 'string' ? { version: record.version } : {})
+            })
+          }
+        }
+      }
+      visit(child)
+    }
+  }
+  visit(value)
+  const diagnostics = strings(value).join('\n')
+  const canonicalDiagnostic =
+    /nothing provides|package(?:s)?[^\n]*not found|does not exist|not installed/iu.test(diagnostics)
+      ? 'package not found'
+      : /solver|unsatisfiable|conflict/iu.test(diagnostics)
+        ? 'solver failed'
+        : /permission|access denied/iu.test(diagnostics)
+          ? 'permission denied'
+          : /network|timeout|tls|ssl|http/iu.test(diagnostics)
+            ? 'network timeout'
+            : undefined
+  return {
+    transaction,
+    actions,
+    diagnostics: canonicalDiagnostic ? [canonicalDiagnostic] : []
+  }
+}
+
+for (const path of process.argv.slice(1)) {
+  try {
+    const value = JSON.parse(readFileSync(path, 'utf8'))
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      process.stdout.write(JSON.stringify(summarize(value)))
+      process.exit(0)
+    }
+  } catch {
+    // Try the other captured stream.
+  }
+}
+process.exit(2)
+`
+
+const createCondaJsonCapture = (): CondaJsonCapture => {
+  const directory = mkdtempSync(join(tmpdir(), 'open-science-conda-json-'))
+  const stdoutPath = join(directory, 'stdout.json')
+  const stderrPath = join(directory, 'stderr.json')
+  const stdoutStream = createWriteStream(stdoutPath, { mode: 0o600 })
+  const stderrStream = createWriteStream(stderrPath, { mode: 0o600 })
+  // Keep late disk errors from becoming unhandled events; finished() below observes the failure and
+  // makes the structured decision fail closed.
+  stdoutStream.on('error', () => {})
+  stderrStream.on('error', () => {})
+  return {
+    directory,
+    stdoutPath,
+    stderrPath,
+    stdoutStream,
+    stderrStream
+  }
+}
+
+const isCondaStructuredResult = (value: unknown): value is CondaStructuredResult => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  const candidate = value as Partial<CondaStructuredResult>
+  if (
+    typeof candidate.transaction !== 'boolean' ||
+    !candidate.actions ||
+    !Array.isArray(candidate.actions.LINK) ||
+    !Array.isArray(candidate.actions.UNLINK) ||
+    !Array.isArray(candidate.diagnostics) ||
+    !candidate.diagnostics.every((diagnostic) => typeof diagnostic === 'string')
+  ) {
+    return false
+  }
+  return [...candidate.actions.LINK, ...candidate.actions.UNLINK].every(
+    (action) =>
+      typeof action === 'object' &&
+      action !== null &&
+      action.name === 'r-base' &&
+      (action.version === undefined || typeof action.version === 'string')
+  )
+}
+
+const summarizeCondaJsonCapture = (
+  capture: CondaJsonCapture
+): Promise<CondaStructuredResult | undefined> =>
+  new Promise((resolve) => {
+    const stdout = new InstallerLogTailBuffer(64 * 1024)
+    const parser = nodeSpawn(
+      process.execPath,
+      ['-e', CONDA_JSON_SUMMARIZER_SOURCE, capture.stdoutPath, capture.stderrPath],
+      {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        windowsHide: true,
+        env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' }
+      }
+    )
+    parser.stdout?.on('data', (chunk) => stdout.push(chunk))
+    let settled = false
+    const settle = (result?: CondaStructuredResult): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      resolve(result)
+    }
+    const timeout = setTimeout(() => {
+      parser.kill()
+      settle()
+    }, 30_000)
+    timeout.unref()
+    parser.on('error', () => settle())
+    parser.on('close', (code) => {
+      if (code !== 0) {
+        settle()
+        return
+      }
+      try {
+        const snapshot = stdout.snapshot()
+        if (snapshot.droppedBytes > 0) {
+          settle()
+          return
+        }
+        const parsed = JSON.parse(snapshot.text) as unknown
+        settle(isCondaStructuredResult(parsed) ? parsed : undefined)
+      } catch {
+        settle()
+      }
+    })
+  })
+
+const finalizeCondaJsonCapture = async (
+  capture: CondaJsonCapture | undefined,
+  summarize: boolean
+): Promise<CondaStructuredResult | undefined> => {
+  if (!capture) return undefined
+  try {
+    await Promise.all([finished(capture.stdoutStream), finished(capture.stderrStream)])
+    return summarize ? await summarizeCondaJsonCapture(capture) : undefined
+  } catch {
+    return undefined
+  } finally {
+    try {
+      rmSync(capture.directory, { recursive: true, force: true })
+    } catch {
+      // The installer result must still settle; the OS temp directory remains best-effort cleanup.
+    }
+  }
+}
+
+const discardCondaJsonCapture = async (capture: CondaJsonCapture | undefined): Promise<void> => {
+  if (!capture) return
+  capture.stdoutStream.end()
+  capture.stderrStream.end()
+  await finalizeCondaJsonCapture(capture, false)
+}
+
 // Real spawn wrapper collecting stdout/stderr and the exit code; replaced by an injected spawn in tests.
 // Exported so its fail-closed spawn-intent / kill-on-record-failure branches are directly testable.
-export const defaultSpawn: InstallSpawn = (command, args, env, onChild, onBeforeSpawn) =>
-  new Promise((resolve, reject) => {
+export const defaultSpawn: InstallSpawn = (command, args, env, onChild, onBeforeSpawn) => {
+  let condaJsonCapture: CondaJsonCapture | undefined
+  try {
+    if (args.includes('--json')) condaJsonCapture = createCondaJsonCapture()
+  } catch (error) {
+    return Promise.resolve({
+      code: 1,
+      stdout: '',
+      stderr: `Failed to create the temporary micromamba JSON capture; not spawning: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    })
+  }
+  return new Promise((resolve, reject) => {
     try {
       onBeforeSpawn?.() // re-arm the per-spawn intent; fail closed if it can't be recorded
     } catch (error) {
+      void discardCondaJsonCapture(condaJsonCapture)
       resolve({
         code: 1,
         stdout: '',
@@ -555,7 +789,18 @@ export const defaultSpawn: InstallSpawn = (command, args, env, onChild, onBefore
       })
       return
     }
-    const child = nodeSpawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'], env })
+    let child: ReturnType<typeof nodeSpawn>
+    try {
+      child = nodeSpawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'], env })
+    } catch (error) {
+      void discardCondaJsonCapture(condaJsonCapture)
+      resolve({
+        code: 1,
+        stdout: '',
+        stderr: error instanceof Error ? error.message : String(error)
+      })
+      return
+    }
     if (child.pid !== undefined) {
       try {
         onChild?.(child.pid)
@@ -564,6 +809,7 @@ export const defaultSpawn: InstallSpawn = (command, args, env, onChild, onBefore
         // If it can't be confirmed, REJECT with the CHILD_UNCONFIRMED marker so the caller retains the
         // recovery evidence (a worker may still be writing) instead of clearing it.
         void killAndConfirmExit(child).then((confirmed) => {
+          void discardCondaJsonCapture(condaJsonCapture)
           if (confirmed) {
             resolve({
               code: 1,
@@ -591,10 +837,18 @@ export const defaultSpawn: InstallSpawn = (command, args, env, onChild, onBefore
     child.stderr?.on('data', (chunk) => {
       stderr.push(chunk)
     })
+    if (condaJsonCapture) {
+      child.stdout?.pipe(condaJsonCapture.stdoutStream)
+      child.stderr?.pipe(condaJsonCapture.stderrStream)
+    }
     let settled = false
-    const result = (code: number): SpawnResult => {
+    const result = async (code: number): Promise<SpawnResult> => {
       const stdoutSnapshot = stdout.snapshot()
       const stderrSnapshot = stderr.snapshot()
+      const structuredCondaResult = await finalizeCondaJsonCapture(
+        condaJsonCapture,
+        stdoutSnapshot.droppedBytes > 0 || stderrSnapshot.droppedBytes > 0
+      )
       return {
         code,
         stdout: stdoutSnapshot.text,
@@ -604,20 +858,28 @@ export const defaultSpawn: InstallSpawn = (command, args, env, onChild, onBefore
           : {}),
         ...(stderrSnapshot.droppedBytes > 0
           ? { stderrDroppedBytes: stderrSnapshot.droppedBytes }
-          : {})
+          : {}),
+        ...(structuredCondaResult ? { structuredCondaResult } : {})
       }
     }
     const settle = (code: number): void => {
       if (settled) return
       settled = true
-      resolve(result(code))
+      void result(code).then(resolve)
     }
     child.on('error', (error) => {
       stderr.push(String(error))
+      if (condaJsonCapture) {
+        child.stdout?.unpipe(condaJsonCapture.stdoutStream)
+        child.stderr?.unpipe(condaJsonCapture.stderrStream)
+        condaJsonCapture.stdoutStream.end()
+        condaJsonCapture.stderrStream.end()
+      }
       settle(1)
     })
     child.on('close', (code) => settle(code ?? 1))
   })
+}
 
 // Flattens one command's output into a single log string for the agent to read as install facts.
 const mergeLog = (result: SpawnResult): string =>

--- a/src/main/notebook/package-manager.ts
+++ b/src/main/notebook/package-manager.ts
@@ -111,6 +111,9 @@ export type SpawnResult = {
   // When a bounded stream truncated micromamba --json output, a short-lived parser subprocess
   // reduces the complete temporary capture to only the facts needed for fail-closed decisions.
   structuredCondaResult?: CondaStructuredResult
+  // Bounded recovery-only evidence reduced from the complete capture. It is never merged into the
+  // user-facing log or persisted activity result.
+  maxPathRecoveryEvidence?: string
 }
 export type InstallSpawn = (
   command: string,
@@ -568,6 +571,11 @@ type CondaJsonCapture = {
   stderrStream: ReturnType<typeof createWriteStream>
 }
 
+type CondaJsonCaptureSummary = Pick<
+  SpawnResult,
+  'structuredCondaResult' | 'maxPathRecoveryEvidence'
+>
+
 const CONDA_JSON_SUMMARIZER_SOURCE = String.raw`
 const { readFileSync } = require('node:fs')
 
@@ -632,18 +640,72 @@ const summarize = (value) => {
   }
 }
 
-for (const path of process.argv.slice(1)) {
+const maxPathEvidence = (texts) => {
+  const diagnosticText = texts.join('\n')
+  const hasMissingContext =
+    /invalid package cache/i.test(diagnosticText) &&
+    /(?:is missing|package cache error)/i.test(diagnosticText)
+  const hasRemoveContext =
+    /error when extracting package/i.test(diagnosticText) &&
+    /remove_all[^]*(?:not empty|directory)/i.test(diagnosticText)
+  if (!hasMissingContext && !hasRemoveContext) return undefined
+  const archiveMatch = diagnosticText.match(
+    /(?:for|cache for)\s+[\x27\x22]([^\x27\x22]+\.(?:conda|tar\.bz2))[\x27\x22]/i
+  )
+  const archive = archiveMatch?.[1]
+  const paths = [
+    ...diagnosticText.matchAll(/[\x27\x22]([^\x27\x22\r\n]+)[\x27\x22]/g)
+  ]
+    .map((match) => match[1])
+    .filter((value) => value !== archive && value.length > 240)
+  if (paths.length === 0) return undefined
+  const parts = []
+  if (hasMissingContext) {
+    parts.push('Invalid package cache; file is missing; Package cache error.')
+  }
+  if (hasRemoveContext) {
+    parts.push('Error when extracting package; remove_all: not empty.')
+  }
+  const quote = String.fromCharCode(39)
+  if (archive) parts.push('for ' + quote + archive.slice(0, 4096) + quote)
+  let remaining = 60_000 - parts.join('\n').length
+  for (const path of paths) {
+    const quoted = quote + path.slice(0, 32_768) + quote
+    if (quoted.length > remaining) break
+    parts.push(quoted)
+    remaining -= quoted.length + 1
+  }
+  return parts.join('\n')
+}
+
+const texts = process.argv.slice(1).map((path) => {
   try {
-    const value = JSON.parse(readFileSync(path, 'utf8'))
+    return readFileSync(path, 'utf8')
+  } catch {
+    return ''
+  }
+})
+let structuredCondaResult
+const decodedDiagnosticTexts = []
+for (const text of texts) {
+  try {
+    const value = JSON.parse(text)
     if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
-      process.stdout.write(JSON.stringify(summarize(value)))
-      process.exit(0)
+      decodedDiagnosticTexts.push(strings(value).join('\n'))
+      structuredCondaResult ??= summarize(value)
     }
   } catch {
     // Try the other captured stream.
   }
 }
-process.exit(2)
+const maxPathRecoveryEvidence = maxPathEvidence([...decodedDiagnosticTexts, ...texts])
+process.stdout.write(
+  JSON.stringify({
+    ...(structuredCondaResult ? { structuredCondaResult } : {}),
+    ...(maxPathRecoveryEvidence ? { maxPathRecoveryEvidence } : {})
+  })
+)
+process.exitCode = 0
 `
 
 const createCondaJsonCapture = (): CondaJsonCapture => {
@@ -687,11 +749,23 @@ const isCondaStructuredResult = (value: unknown): value is CondaStructuredResult
   )
 }
 
+const isCondaJsonCaptureSummary = (value: unknown): value is CondaJsonCaptureSummary => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  const candidate = value as CondaJsonCaptureSummary
+  return (
+    (candidate.structuredCondaResult === undefined ||
+      isCondaStructuredResult(candidate.structuredCondaResult)) &&
+    (candidate.maxPathRecoveryEvidence === undefined ||
+      (typeof candidate.maxPathRecoveryEvidence === 'string' &&
+        candidate.maxPathRecoveryEvidence.length <= 60_000))
+  )
+}
+
 const summarizeCondaJsonCapture = (
   capture: CondaJsonCapture
-): Promise<CondaStructuredResult | undefined> =>
+): Promise<CondaJsonCaptureSummary | undefined> =>
   new Promise((resolve) => {
-    const stdout = new InstallerLogTailBuffer(64 * 1024)
+    const stdout = new InstallerLogTailBuffer(INSTALLER_STREAM_LOG_LIMIT_BYTES)
     const parser = nodeSpawn(
       process.execPath,
       ['-e', CONDA_JSON_SUMMARIZER_SOURCE, capture.stdoutPath, capture.stderrPath],
@@ -703,7 +777,7 @@ const summarizeCondaJsonCapture = (
     )
     parser.stdout?.on('data', (chunk) => stdout.push(chunk))
     let settled = false
-    const settle = (result?: CondaStructuredResult): void => {
+    const settle = (result?: CondaJsonCaptureSummary): void => {
       if (settled) return
       settled = true
       clearTimeout(timeout)
@@ -727,7 +801,7 @@ const summarizeCondaJsonCapture = (
           return
         }
         const parsed = JSON.parse(snapshot.text) as unknown
-        settle(isCondaStructuredResult(parsed) ? parsed : undefined)
+        settle(isCondaJsonCaptureSummary(parsed) ? parsed : undefined)
       } catch {
         settle()
       }
@@ -737,7 +811,7 @@ const summarizeCondaJsonCapture = (
 const finalizeCondaJsonCapture = async (
   capture: CondaJsonCapture | undefined,
   summarize: boolean
-): Promise<CondaStructuredResult | undefined> => {
+): Promise<CondaJsonCaptureSummary | undefined> => {
   if (!capture) return undefined
   try {
     await Promise.all([finished(capture.stdoutStream), finished(capture.stderrStream)])
@@ -845,7 +919,7 @@ export const defaultSpawn: InstallSpawn = (command, args, env, onChild, onBefore
     const result = async (code: number): Promise<SpawnResult> => {
       const stdoutSnapshot = stdout.snapshot()
       const stderrSnapshot = stderr.snapshot()
-      const structuredCondaResult = await finalizeCondaJsonCapture(
+      const condaJsonSummary = await finalizeCondaJsonCapture(
         condaJsonCapture,
         stdoutSnapshot.droppedBytes > 0 || stderrSnapshot.droppedBytes > 0
       )
@@ -859,7 +933,7 @@ export const defaultSpawn: InstallSpawn = (command, args, env, onChild, onBefore
         ...(stderrSnapshot.droppedBytes > 0
           ? { stderrDroppedBytes: stderrSnapshot.droppedBytes }
           : {}),
-        ...(structuredCondaResult ? { structuredCondaResult } : {})
+        ...(condaJsonSummary ?? {})
       }
     }
     const settle = (code: number): void => {
@@ -1043,7 +1117,9 @@ export async function installPackages(
     )
     if (await stopAfterSpawn?.(result)) return result
     if (result.code === 0) return result
-    const evidence = `${result.stdout}\n${result.stderr}`
+    const evidence = [result.maxPathRecoveryEvidence, result.stdout, result.stderr]
+      .filter(Boolean)
+      .join('\n')
     let recovered = false
     let cleanupError: unknown
     try {

--- a/src/main/notebook/package-manager.ts
+++ b/src/main/notebook/package-manager.ts
@@ -748,6 +748,14 @@ const createCondaJsonCapture = (): CondaJsonCapture => {
     stderrLimiter.unpipe(stderrStream)
     stderrLimiter.resume()
   })
+  stdoutLimiter.on('error', (error) => {
+    state.truncated = true
+    stdoutStream.destroy(error)
+  })
+  stderrLimiter.on('error', (error) => {
+    state.truncated = true
+    stderrStream.destroy(error)
+  })
   stdoutLimiter.pipe(stdoutStream)
   stderrLimiter.pipe(stderrStream)
   return {

--- a/src/main/notebook/package-manager.ts
+++ b/src/main/notebook/package-manager.ts
@@ -9,6 +9,7 @@ import {
 import { spawn as nodeSpawn } from 'node:child_process'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { Transform, type TransformCallback } from 'node:stream'
 import { finished } from 'node:stream/promises'
 
 import { PROD_SESSION_DIR_NAME } from '../session-persistence/repository'
@@ -508,6 +509,7 @@ const condaFallbackIsAuthorized = (classification: CondaFailureClassification): 
   (classification.reason === 'package-not-found' || classification.reason === 'solver-failed')
 
 export const INSTALLER_STREAM_LOG_LIMIT_BYTES = 512 * 1024
+export const CONDA_JSON_CAPTURE_LIMIT_BYTES = 32 * 1024 * 1024
 
 // Fixed-capacity byte ring retaining the newest installer output. Byte accounting happens before
 // UTF-8 decoding so the reported discard count is exact even when a process splits a code point
@@ -567,8 +569,11 @@ type CondaJsonCapture = {
   directory: string
   stdoutPath: string
   stderrPath: string
+  stdoutLimiter: Transform
+  stderrLimiter: Transform
   stdoutStream: ReturnType<typeof createWriteStream>
   stderrStream: ReturnType<typeof createWriteStream>
+  state: { truncated: boolean }
 }
 
 type CondaJsonCaptureSummary = Pick<
@@ -708,22 +713,52 @@ process.stdout.write(
 process.exitCode = 0
 `
 
+const createCondaJsonCaptureLimiter = (state: { truncated: boolean }): Transform => {
+  let writtenBytes = 0
+  return new Transform({
+    transform(chunk: Buffer, _encoding: BufferEncoding, callback: TransformCallback) {
+      const retainedBytes = Math.min(
+        chunk.length,
+        Math.max(0, CONDA_JSON_CAPTURE_LIMIT_BYTES - writtenBytes)
+      )
+      writtenBytes += retainedBytes
+      if (retainedBytes < chunk.length) state.truncated = true
+      callback(null, retainedBytes > 0 ? chunk.subarray(0, retainedBytes) : undefined)
+    }
+  })
+}
+
 const createCondaJsonCapture = (): CondaJsonCapture => {
   const directory = mkdtempSync(join(tmpdir(), 'open-science-conda-json-'))
   const stdoutPath = join(directory, 'stdout.json')
   const stderrPath = join(directory, 'stderr.json')
+  const state = { truncated: false }
+  const stdoutLimiter = createCondaJsonCaptureLimiter(state)
+  const stderrLimiter = createCondaJsonCaptureLimiter(state)
   const stdoutStream = createWriteStream(stdoutPath, { mode: 0o600 })
   const stderrStream = createWriteStream(stderrPath, { mode: 0o600 })
   // Keep late disk errors from becoming unhandled events; finished() below observes the failure and
-  // makes the structured decision fail closed.
-  stdoutStream.on('error', () => {})
-  stderrStream.on('error', () => {})
+  // makes the structured decision fail closed. Drain the limiter after a disk error so capture
+  // failure cannot stall the installer child.
+  stdoutStream.on('error', () => {
+    stdoutLimiter.unpipe(stdoutStream)
+    stdoutLimiter.resume()
+  })
+  stderrStream.on('error', () => {
+    stderrLimiter.unpipe(stderrStream)
+    stderrLimiter.resume()
+  })
+  stdoutLimiter.pipe(stdoutStream)
+  stderrLimiter.pipe(stderrStream)
   return {
     directory,
     stdoutPath,
     stderrPath,
+    stdoutLimiter,
+    stderrLimiter,
     stdoutStream,
-    stderrStream
+    stderrStream,
+    state
   }
 }
 
@@ -815,7 +850,9 @@ const finalizeCondaJsonCapture = async (
   if (!capture) return undefined
   try {
     await Promise.all([finished(capture.stdoutStream), finished(capture.stderrStream)])
-    return summarize ? await summarizeCondaJsonCapture(capture) : undefined
+    return summarize && !capture.state.truncated
+      ? await summarizeCondaJsonCapture(capture)
+      : undefined
   } catch {
     return undefined
   } finally {
@@ -829,8 +866,8 @@ const finalizeCondaJsonCapture = async (
 
 const discardCondaJsonCapture = async (capture: CondaJsonCapture | undefined): Promise<void> => {
   if (!capture) return
-  capture.stdoutStream.end()
-  capture.stderrStream.end()
+  capture.stdoutLimiter.end()
+  capture.stderrLimiter.end()
   await finalizeCondaJsonCapture(capture, false)
 }
 
@@ -912,8 +949,10 @@ export const defaultSpawn: InstallSpawn = (command, args, env, onChild, onBefore
       stderr.push(chunk)
     })
     if (condaJsonCapture) {
-      child.stdout?.pipe(condaJsonCapture.stdoutStream)
-      child.stderr?.pipe(condaJsonCapture.stderrStream)
+      if (child.stdout) child.stdout.pipe(condaJsonCapture.stdoutLimiter)
+      else condaJsonCapture.stdoutLimiter.end()
+      if (child.stderr) child.stderr.pipe(condaJsonCapture.stderrLimiter)
+      else condaJsonCapture.stderrLimiter.end()
     }
     let settled = false
     const result = async (code: number): Promise<SpawnResult> => {
@@ -944,10 +983,10 @@ export const defaultSpawn: InstallSpawn = (command, args, env, onChild, onBefore
     child.on('error', (error) => {
       stderr.push(String(error))
       if (condaJsonCapture) {
-        child.stdout?.unpipe(condaJsonCapture.stdoutStream)
-        child.stderr?.unpipe(condaJsonCapture.stderrStream)
-        condaJsonCapture.stdoutStream.end()
-        condaJsonCapture.stderrStream.end()
+        child.stdout?.unpipe(condaJsonCapture.stdoutLimiter)
+        child.stderr?.unpipe(condaJsonCapture.stderrLimiter)
+        condaJsonCapture.stdoutLimiter.end()
+        condaJsonCapture.stderrLimiter.end()
       }
       settle(1)
     })

--- a/src/main/notebook/package-manager.ts
+++ b/src/main/notebook/package-manager.ts
@@ -66,6 +66,9 @@ export type InstallResult = {
   ok: boolean
   needsRestart: boolean
   log: string
+  // Present when the bounded installer stdout/stderr collectors discarded older bytes. The count is
+  // aggregated across every command whose retained output contributes to `log`.
+  logTruncation?: { droppedBytes: number }
   method?: 'conda' | 'pip' | 'cran'
   attempts?: NotebookPackageInstallerAttempt[]
   fallbackUsed?: boolean
@@ -82,7 +85,13 @@ export type InstallResult = {
 }
 
 // One spawned install command's outcome; injected so tests never launch micromamba/pip/R.
-export type SpawnResult = { code: number; stdout: string; stderr: string }
+export type SpawnResult = {
+  code: number
+  stdout: string
+  stderr: string
+  stdoutDroppedBytes?: number
+  stderrDroppedBytes?: number
+}
 export type InstallSpawn = (
   command: string,
   args: string[],
@@ -350,6 +359,7 @@ const executeCondaWithRBaseProtection = async (options: {
         ok: false,
         needsRestart: false,
         log: [mergeLog(preflight), planError].filter(Boolean).join('\n'),
+        ...installLogTruncation(preflight),
         method: 'conda',
         attempts: [
           {
@@ -385,6 +395,7 @@ const executeCondaWithRBaseProtection = async (options: {
         ok: false,
         needsRestart: false,
         log: [mergeLog(preflight), mergeLog(conda)].filter(Boolean).join('\n'),
+        ...installLogTruncation(preflight, conda),
         method: 'conda',
         attempts: [installerAttempt(0, 'conda', options.packages, conda)],
         fallbackUsed: false,
@@ -472,6 +483,62 @@ const condaFallbackIsAuthorized = (classification: CondaFailureClassification): 
   classification.mutationRisk === 'none' &&
   (classification.reason === 'package-not-found' || classification.reason === 'solver-failed')
 
+export const INSTALLER_STREAM_LOG_LIMIT_BYTES = 512 * 1024
+
+// Fixed-capacity byte ring retaining the newest installer output. Byte accounting happens before
+// UTF-8 decoding so the reported discard count is exact even when a process splits a code point
+// across chunks.
+class InstallerLogTailBuffer {
+  private readonly buffer: Buffer
+  private start = 0
+  private length = 0
+  private droppedBytes = 0
+
+  constructor(private readonly capacity: number) {
+    this.buffer = Buffer.allocUnsafe(capacity)
+  }
+
+  push(value: unknown): void {
+    const chunk = Buffer.isBuffer(value) ? value : Buffer.from(String(value), 'utf8')
+    if (chunk.length === 0) return
+
+    if (chunk.length >= this.capacity) {
+      this.addDroppedBytes(this.length + chunk.length - this.capacity)
+      chunk.copy(this.buffer, 0, chunk.length - this.capacity)
+      this.start = 0
+      this.length = this.capacity
+      return
+    }
+
+    const overflow = Math.max(0, this.length + chunk.length - this.capacity)
+    if (overflow > 0) {
+      this.start = (this.start + overflow) % this.capacity
+      this.length -= overflow
+      this.addDroppedBytes(overflow)
+    }
+
+    const writeStart = (this.start + this.length) % this.capacity
+    const firstLength = Math.min(chunk.length, this.capacity - writeStart)
+    chunk.copy(this.buffer, writeStart, 0, firstLength)
+    if (firstLength < chunk.length) chunk.copy(this.buffer, 0, firstLength)
+    this.length += chunk.length
+  }
+
+  snapshot(): { text: string; droppedBytes: number } {
+    if (this.length === 0) return { text: '', droppedBytes: this.droppedBytes }
+    const firstLength = Math.min(this.length, this.capacity - this.start)
+    const bytes = Buffer.allocUnsafe(this.length)
+    this.buffer.copy(bytes, 0, this.start, this.start + firstLength)
+    if (firstLength < this.length)
+      this.buffer.copy(bytes, firstLength, 0, this.length - firstLength)
+    return { text: bytes.toString('utf8'), droppedBytes: this.droppedBytes }
+  }
+
+  private addDroppedBytes(count: number): void {
+    this.droppedBytes = Math.min(Number.MAX_SAFE_INTEGER, this.droppedBytes + count)
+  }
+}
+
 // Real spawn wrapper collecting stdout/stderr and the exit code; replaced by an injected spawn in tests.
 // Exported so its fail-closed spawn-intent / kill-on-record-failure branches are directly testable.
 export const defaultSpawn: InstallSpawn = (command, args, env, onChild, onBeforeSpawn) =>
@@ -516,21 +583,75 @@ export const defaultSpawn: InstallSpawn = (command, args, env, onChild, onBefore
         return
       }
     }
-    let stdout = ''
-    let stderr = ''
+    const stdout = new InstallerLogTailBuffer(INSTALLER_STREAM_LOG_LIMIT_BYTES)
+    const stderr = new InstallerLogTailBuffer(INSTALLER_STREAM_LOG_LIMIT_BYTES)
     child.stdout?.on('data', (chunk) => {
-      stdout += String(chunk)
+      stdout.push(chunk)
     })
     child.stderr?.on('data', (chunk) => {
-      stderr += String(chunk)
+      stderr.push(chunk)
     })
-    child.on('error', (error) => resolve({ code: 1, stdout, stderr: `${stderr}${String(error)}` }))
-    child.on('close', (code) => resolve({ code: code ?? 1, stdout, stderr }))
+    let settled = false
+    const result = (code: number): SpawnResult => {
+      const stdoutSnapshot = stdout.snapshot()
+      const stderrSnapshot = stderr.snapshot()
+      return {
+        code,
+        stdout: stdoutSnapshot.text,
+        stderr: stderrSnapshot.text,
+        ...(stdoutSnapshot.droppedBytes > 0
+          ? { stdoutDroppedBytes: stdoutSnapshot.droppedBytes }
+          : {}),
+        ...(stderrSnapshot.droppedBytes > 0
+          ? { stderrDroppedBytes: stderrSnapshot.droppedBytes }
+          : {})
+      }
+    }
+    const settle = (code: number): void => {
+      if (settled) return
+      settled = true
+      resolve(result(code))
+    }
+    child.on('error', (error) => {
+      stderr.push(String(error))
+      settle(1)
+    })
+    child.on('close', (code) => settle(code ?? 1))
   })
 
 // Flattens one command's output into a single log string for the agent to read as install facts.
 const mergeLog = (result: SpawnResult): string =>
   [result.stdout, result.stderr].filter((part) => part.length > 0).join('\n')
+
+const spawnLogTruncation = (
+  ...results: Array<SpawnResult | undefined>
+): Pick<SpawnResult, 'stdoutDroppedBytes' | 'stderrDroppedBytes'> => {
+  const sum = (field: 'stdoutDroppedBytes' | 'stderrDroppedBytes'): number =>
+    results.reduce(
+      (total, result) => Math.min(Number.MAX_SAFE_INTEGER, total + (result?.[field] ?? 0)),
+      0
+    )
+  const stdoutDroppedBytes = sum('stdoutDroppedBytes')
+  const stderrDroppedBytes = sum('stderrDroppedBytes')
+  return {
+    ...(stdoutDroppedBytes > 0 ? { stdoutDroppedBytes } : {}),
+    ...(stderrDroppedBytes > 0 ? { stderrDroppedBytes } : {})
+  }
+}
+
+const installLogTruncation = (
+  ...results: Array<SpawnResult | undefined>
+): Pick<InstallResult, 'logTruncation'> => {
+  const droppedBytes = results.reduce(
+    (total, result) =>
+      Math.min(
+        Number.MAX_SAFE_INTEGER,
+        total + (result?.stdoutDroppedBytes ?? 0) + (result?.stderrDroppedBytes ?? 0)
+      ),
+    0
+  )
+  return droppedBytes > 0 ? { logTruncation: { droppedBytes } } : {}
+}
 
 const condaFailureMessage = (action: 'install' | 'remove', result: SpawnResult): string =>
   /Retry failure after MAX_PATH recovery/i.test(mergeLog(result))
@@ -695,6 +816,7 @@ export async function installPackages(
     if (await stopAfterSpawn?.(retry)) {
       return {
         ...retry,
+        ...spawnLogTruncation(result, retry),
         stdout:
           `Original failure before MAX_PATH recovery (stdout):\n${result.stdout}\n` +
           `Retry result after MAX_PATH recovery (stdout):\n${retry.stdout}`,
@@ -706,6 +828,7 @@ export async function installPackages(
     if (retry.code === 0) return retry
     return {
       ...retry,
+      ...spawnLogTruncation(result, retry),
       stdout:
         `Original failure before MAX_PATH recovery (stdout):\n${result.stdout}\n` +
         `Retry failure after MAX_PATH recovery (stdout):\n${retry.stdout}`,
@@ -744,6 +867,7 @@ export async function installPackages(
       ok: result.code === 0,
       needsRestart: false,
       log: mergeLog(result),
+      ...installLogTruncation(result),
       method: 'pip',
       attempts: [installerAttempt(0, 'pip', req.packages, result)],
       fallbackUsed: false,
@@ -816,6 +940,7 @@ export async function installPackages(
         ok: result.code === 0,
         needsRestart: false,
         log: mergeLog(result),
+        ...installLogTruncation(result),
         method: 'pip',
         attempts: [installerAttempt(0, 'pip', req.packages, result)],
         fallbackUsed: false,
@@ -879,6 +1004,7 @@ export async function installPackages(
         ok: true,
         needsRestart: false,
         log: [preflight ? mergeLog(preflight) : '', mergeLog(result)].filter(Boolean).join('\n'),
+        ...installLogTruncation(preflight, result),
         method: 'conda',
         attempts: [installerAttempt(0, 'conda', req.packages, result)],
         fallbackUsed: false,
@@ -900,6 +1026,7 @@ export async function installPackages(
         log: [preflight ? mergeLog(preflight) : '', mergeLog(result), mergeLog(fallback)]
           .filter(Boolean)
           .join('\n'),
+        ...installLogTruncation(preflight, result, fallback),
         method: 'pip',
         attempts: [condaAttempt, installerAttempt(1, 'pip', req.packages, fallback)],
         fallbackUsed: true,
@@ -911,6 +1038,7 @@ export async function installPackages(
       ok: false,
       needsRestart: false,
       log: [preflight ? mergeLog(preflight) : '', mergeLog(result)].filter(Boolean).join('\n'),
+      ...installLogTruncation(preflight, result),
       method: 'conda',
       attempts: [condaAttempt],
       fallbackUsed: false,
@@ -971,6 +1099,7 @@ export async function installPackages(
       log: [approvedPlan ? mergeLog(approvedPlan) : '', condaLog, mergeLog(fallback)]
         .filter(Boolean)
         .join('\n'),
+      ...installLogTruncation(approvedPlan, conda, fallback),
       method: 'cran',
       attempts: [condaAttempt, installerAttempt(1, 'r-install-packages', req.packages, fallback)],
       fallbackUsed: true,
@@ -1006,6 +1135,7 @@ export async function installPackages(
       ok: false,
       needsRestart: false,
       log: mergeLog(preflight),
+      ...installLogTruncation(preflight),
       method: 'conda',
       attempts: [condaAttempt],
       fallbackUsed: false,
@@ -1019,12 +1149,14 @@ export async function installPackages(
     const rejectedPlan: SpawnResult = {
       code: 1,
       stdout: preflight.stdout,
-      stderr: [preflight.stderr, planError].filter(Boolean).join('\n')
+      stderr: [preflight.stderr, planError].filter(Boolean).join('\n'),
+      ...spawnLogTruncation(preflight)
     }
     return {
       ok: false,
       needsRestart: false,
       log: mergeLog(rejectedPlan),
+      ...installLogTruncation(rejectedPlan),
       method: 'conda',
       attempts: [
         {
@@ -1070,6 +1202,7 @@ export async function installPackages(
       ok: false,
       needsRestart: false,
       log: [mergeLog(preflight), mergeLog(conda)].filter(Boolean).join('\n'),
+      ...installLogTruncation(preflight, conda),
       method: 'conda',
       attempts: [installerAttempt(0, 'conda', condaPkgs, conda)],
       fallbackUsed: false,
@@ -1086,6 +1219,7 @@ export async function installPackages(
       ok: true,
       needsRestart: true,
       log: [mergeLog(preflight), mergeLog(conda)].filter(Boolean).join('\n'),
+      ...installLogTruncation(preflight, conda),
       method: 'conda',
       attempts: [installerAttempt(0, 'conda', condaPkgs, conda)],
       fallbackUsed: false,
@@ -1101,6 +1235,7 @@ export async function installPackages(
       ok: false,
       needsRestart: false,
       log: condaLog,
+      ...installLogTruncation(preflight, conda),
       method: 'conda',
       attempts: [condaAttempt],
       fallbackUsed: false,
@@ -1154,6 +1289,7 @@ async function uninstallPackages(
         ok: result.code === 0,
         needsRestart: false,
         log: mergeLog(result),
+        ...installLogTruncation(result),
         method: 'pip',
         attempts: [installerAttempt(0, 'pip', req.packages, result)],
         fallbackUsed: false,
@@ -1218,6 +1354,7 @@ async function uninstallPackages(
       ok: result.code === 0,
       needsRestart: false,
       log: [preflight ? mergeLog(preflight) : '', mergeLog(result)].filter(Boolean).join('\n'),
+      ...installLogTruncation(preflight, result),
       method: 'conda',
       attempts: [
         installerAttempt(
@@ -1294,6 +1431,7 @@ async function uninstallPackages(
       ok,
       needsRestart: ok,
       log: `${condaLog}\n${mergeLog(fallback)}`,
+      ...installLogTruncation(approvedPlan, condaResult, fallback),
       method: 'cran',
       attempts: [condaAttempt, installerAttempt(1, 'r-install-packages', req.packages, fallback)],
       fallbackUsed: true,
@@ -1317,6 +1455,7 @@ async function uninstallPackages(
       ok: false,
       needsRestart: false,
       log: mergeLog(preflight),
+      ...installLogTruncation(preflight),
       method: 'conda',
       attempts: [condaAttempt],
       fallbackUsed: false,
@@ -1330,6 +1469,7 @@ async function uninstallPackages(
       ok: false,
       needsRestart: false,
       log: [mergeLog(preflight), planError].filter(Boolean).join('\n'),
+      ...installLogTruncation(preflight),
       method: 'conda',
       attempts: [
         {
@@ -1367,6 +1507,7 @@ async function uninstallPackages(
       ok: false,
       needsRestart: false,
       log: [mergeLog(preflight), mergeLog(conda)].filter(Boolean).join('\n'),
+      ...installLogTruncation(preflight, conda),
       method: 'conda',
       attempts: [installerAttempt(0, 'conda', condaPkgs, conda)],
       fallbackUsed: false,
@@ -1383,6 +1524,7 @@ async function uninstallPackages(
       ok: true,
       needsRestart: true,
       log: [mergeLog(preflight), mergeLog(conda)].filter(Boolean).join('\n'),
+      ...installLogTruncation(preflight, conda),
       method: 'conda',
       attempts: [installerAttempt(0, 'conda', condaPkgs, conda)],
       fallbackUsed: false,
@@ -1400,6 +1542,7 @@ async function uninstallPackages(
       ok: false,
       needsRestart: false,
       log: condaLog,
+      ...installLogTruncation(preflight, conda),
       method: 'conda',
       attempts: [condaAttempt],
       fallbackUsed: false,

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -2559,6 +2559,7 @@
   "Notebook restart": "Notebook 重启",
   "Notebook shutdown": "Notebook 关闭",
   "restart needed": "需要重启",
+  "log truncated ({{size}} dropped)": "日志已截断（已丢弃 {{size}}）",
   "Agent SDK": "Agent SDK",
   "Web Fetch": "网页获取",
   "Subagent workspaces": "子 Agent 工作区",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -2559,6 +2559,7 @@
   "Notebook restart": "Notebook 重新啟動",
   "Notebook shutdown": "Notebook 關閉",
   "restart needed": "需要重新啟動",
+  "log truncated ({{size}} dropped)": "日誌已截斷（已捨棄 {{size}}）",
   "Agent SDK": "Agent SDK",
   "Web Fetch": "網頁擷取",
   "Subagent workspaces": "子 Agent 工作區",

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
@@ -497,6 +497,23 @@ describe('workspace tool activity details', () => {
     expect(details?.metaLabel).toBe('conda · restart needed')
   })
 
+  it('shows the discarded byte count when a manage_packages log was truncated', () => {
+    const result = {
+      ok: true,
+      needsRestart: false,
+      method: 'pip',
+      logTruncation: { droppedBytes: 1536 }
+    }
+    const activity = createActivity({
+      providerToolName: 'mcp__open-science-notebook__manage_packages',
+      toolKind: 'other',
+      rawInput: { language: 'python', packages: ['numpy'] },
+      toolContent: [{ type: 'content', content: { type: 'text', text: JSON.stringify(result) } }]
+    })
+
+    expect(buildToolActivityDetails(activity)?.metaLabel).toBe('pip · log truncated (2 KB dropped)')
+  })
+
   it('shows verified requested-package version changes from manage_packages', () => {
     const activity = createActivity({
       providerToolName: 'mcp__open-science-notebook__manage_packages',

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.ts
@@ -874,13 +874,23 @@ const buildManagePackagesDetails = (
   const needsRestart = result.needsRestart === true
   const prefix = typeof result.prefix === 'string' ? trimDetail(result.prefix) : undefined
   const log = typeof result.log === 'string' ? cleanInstallLog(result.log) : ''
+  const logTruncation = isRecord(result.logTruncation) ? result.logTruncation : undefined
+  const droppedLogBytes =
+    logTruncation &&
+    Number.isSafeInteger(logTruncation.droppedBytes) &&
+    Number(logTruncation.droppedBytes) > 0
+      ? Number(logTruncation.droppedBytes)
+      : undefined
   const error = typeof result.error === 'string' ? trimDetail(result.error) : undefined
   const packageChanges = Array.isArray(result.packageChanges)
     ? result.packageChanges.map(formatPackageChange).filter((change): change is string => !!change)
     : []
   const metaLabel = [
     ok === false ? t('failed') : method,
-    needsRestart ? t('restart needed') : undefined
+    needsRestart ? t('restart needed') : undefined,
+    droppedLogBytes !== undefined
+      ? t('log truncated ({{size}} dropped)', { size: formatByteSize(droppedLogBytes) })
+      : undefined
   ]
     .filter(Boolean)
     .join(' · ')


### PR DESCRIPTION
## Problem

Notebook package installation subprocesses appended `stdout` and `stderr` to unbounded strings until exit. A verbose or stuck pip, conda, or CRAN install could therefore keep growing the main process heap.

## Proposed change

- retain only the newest 512 KiB from each installer stream with fixed-capacity byte ring buffers
- count dropped bytes exactly and aggregate them across fallback/retry attempts included in the final result
- preserve optional truncation metadata in the compact `manage_packages` activity payload
- show a localized `log truncated (… dropped)` marker in workspace activity details

## Scope and non-goals

- Installer selection, fallback order, exit handling, and the existing combined log format are unchanged.
- This does not add full-log persistence, download/export, a database migration, or a new status/enum value.
- Historical activities remain readable because the metadata is optional. Activities created before this change cannot retroactively indicate truncation.

## Acceptance criteria and validation

- **Bounded streams and exact accounting:** `npm test -- src/main/notebook/package-manager.test.ts` — 76 tests passed.
- **Compact MCP projection:** `npm test -- src/main/notebook/mcp-server.test.ts` — 66 tests passed.
- **Visible UI marker:** `npm test -- src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts` — 38 tests passed.
- **Translation catalogs:** `npx vitest run src/renderer/src/i18n/resources.test.ts` — 67 tests passed.
- **Lint:** targeted ESLint passed; repository `npm run lint` passed with pre-existing warnings outside this change.
- **Type checks:** `typecheck:node` and `typecheck:web` remain blocked by pre-existing unrelated generated/API mismatches: missing `waitForMcpServers` in the ACP patch fixture and missing Prisma `assessmentSnapshot` members. No reported error points to a changed file.
- **Full suite:** intentionally left to PR CI. The affected-test planner falls back to full because `src/main/notebook/mcp-server.ts` has no module owner.

All checks above were run after the final material edit.

## Review focus

- ring-buffer wraparound and UTF-8 byte accounting
- metadata aggregation through retry/fallback paths
- optional contract compatibility
- activity-detail truncation wording and translations
