### PR TITLE
fix(projects): prevent preview state recreation after deletion

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model Project {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
   permissionGrants PermissionGrant[]
+  previewState     ProjectPreviewState?
 }
 
 model PermissionGrant {
@@ -65,6 +66,7 @@ model ProjectPreviewState {
   activeItemId String?
   items        String   @default("[]")
   updatedAt    DateTime @updatedAt
+  project      Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
 }
 
 // Legacy unread-task rows retained only as the source for the message-center startup migration.

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -23,7 +23,7 @@ const EXPECTED_MIGRATION_LEDGER = [
   },
   {
     id: '0005_project_preview_state_owner_fk',
-    checksum: 'a4196768cb2da04a12627786baba91f407a9f8d5b5ba0db9fb75128a29faec12'
+    checksum: '09a04241d1ff56a81ec574dc0259db4f689503cf641094b9c197eda8a82cd631'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -20,6 +20,10 @@ const EXPECTED_MIGRATION_LEDGER = [
   {
     id: '0004_review_assessment_snapshots',
     checksum: '03422aa2279cbbe4d26cee14f7cd1d17dcce54243ddad8981e760b61ad87214f'
+  },
+  {
+    id: '0005_project_preview_state_owner_fk',
+    checksum: 'a4196768cb2da04a12627786baba91f407a9f8d5b5ba0db9fb75128a29faec12'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/src/main/compute/job-repository.test.ts
+++ b/src/main/compute/job-repository.test.ts
@@ -183,7 +183,8 @@ describe('ComputeJob schema migration (integration)', () => {
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
         '0003_granted_local_roots',
-        '0004_review_assessment_snapshots'
+        '0004_review_assessment_snapshots',
+        '0005_project_preview_state_owner_fk'
       ]
     })
     // Idempotent second run.
@@ -260,7 +261,8 @@ describe('ComputeJob schema migration (integration)', () => {
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
         '0003_granted_local_roots',
-        '0004_review_assessment_snapshots'
+        '0004_review_assessment_snapshots',
+        '0005_project_preview_state_owner_fk'
       ]
     })
     // Idempotent second run.

--- a/src/main/compute/prisma-client.test.ts
+++ b/src/main/compute/prisma-client.test.ts
@@ -122,7 +122,8 @@ describe('compute host prisma client (integration)', () => {
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
         '0003_granted_local_roots',
-        '0004_review_assessment_snapshots'
+        '0004_review_assessment_snapshots',
+        '0005_project_preview_state_owner_fk'
       ]
     })
     // Idempotent second run.

--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -101,7 +101,8 @@ describe('database startup logging', () => {
               '0001_runtime_schema_baseline',
               '0002_project_agent_context',
               '0003_granted_local_roots',
-              '0004_review_assessment_snapshots'
+              '0004_review_assessment_snapshots',
+              '0005_project_preview_state_owner_fk'
             ],
             adoptedLegacy: true
           })

--- a/src/main/database/generated/runtime-schema.ts
+++ b/src/main/database/generated/runtime-schema.ts
@@ -40,7 +40,8 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "panelState" TEXT NOT NULL,
     "activeItemId" TEXT,
     "items" TEXT NOT NULL DEFAULT '[]',
-    "updatedAt" DATETIME NOT NULL
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ProjectPreviewState_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );`,
   `CREATE TABLE IF NOT EXISTS "UnreadTaskSession" (
     "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,

--- a/src/main/database/legacy-baseline-adapter.ts
+++ b/src/main/database/legacy-baseline-adapter.ts
@@ -341,6 +341,24 @@ const TARGET_TABLES = createTargetTables(RUNTIME_SCHEMA_BASELINE_TARGET_SQL)
 const TARGET_INDEXES = createTargetIndexes(RUNTIME_SCHEMA_BASELINE_TARGET_SQL)
 const CURRENT_TARGET_TABLES = createTargetTables(CURRENT_RUNTIME_SCHEMA_TARGET_SQL)
 const CURRENT_TARGET_INDEXES = createTargetIndexes(CURRENT_RUNTIME_SCHEMA_TARGET_SQL)
+// Non-exact baseline adoption may recognize only released suffix FKs named here. Do not derive this
+// list from the generated current target: doing so would silently admit every future suffix FK.
+const NON_EXACT_BASELINE_FOREIGN_KEY_ALLOWLIST: ReadonlyMap<string, readonly TargetForeignKey[]> =
+  new Map([
+    [
+      'ProjectPreviewState',
+      [
+        {
+          name: 'ProjectPreviewState_projectId_fkey',
+          columns: ['projectId'],
+          targetColumns: ['id'],
+          targetTable: 'Project',
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE'
+        }
+      ]
+    ]
+  ])
 // Post-baseline migrations can add indexes (e.g. 0003's GrantedLocalRoot_path_key), so a pre-ledger
 // database carrying them must still classify: known indexes are the baseline ∪ current target union,
 // mirroring the unknown-table check, which already classifies against the current target.
@@ -560,6 +578,20 @@ const verifyRuntimeSchemaTarget = async (
       foreignKey.onDelete,
       foreignKey.onUpdate
     ].join('|')
+  const findUnmatchedOccurrences = (
+    candidates: readonly string[],
+    available: readonly string[]
+  ): string[] => {
+    const remaining = new Map<string, number>()
+    for (const value of available) remaining.set(value, (remaining.get(value) ?? 0) + 1)
+
+    return candidates.filter((candidate) => {
+      const count = remaining.get(candidate) ?? 0
+      if (count === 0) return true
+      remaining.set(candidate, count - 1)
+      return false
+    })
+  }
 
   for (const [tableName, expectedTable] of target.tables) {
     const columns = await migrationSqlExecutor.query<SqliteTableColumn[]>(
@@ -679,19 +711,18 @@ const verifyRuntimeSchemaTarget = async (
       )
     }
     const expectedForeignKeys = expectedTable.foreignKeys.map(foreignKeyKey).sort()
-    // A pre-ledger database can already contain a released suffix FK. Require every baseline FK,
-    // allow only FKs present in the current generated target, and keep exact current verification.
-    const knownForeignKeyTable =
-      (exact ? expectedTable : CURRENT_TARGET_TABLES.get(tableName)) ?? expectedTable
-    const knownForeignKeys = new Set(knownForeignKeyTable.foreignKeys.map(foreignKeyKey))
+    // A pre-ledger database can already contain an explicitly released suffix FK. Require every
+    // baseline FK, admit only the narrow allowlist above, and keep exact current verification.
+    const allowedSuffixForeignKeys = exact
+      ? []
+      : (NON_EXACT_BASELINE_FOREIGN_KEY_ALLOWLIST.get(tableName) ?? [])
+    const knownForeignKeys = [
+      ...expectedForeignKeys,
+      ...allowedSuffixForeignKeys.map(foreignKeyKey)
+    ]
     const parsedForeignKeys = actualTable.foreignKeys.map(foreignKeyKey).sort()
-    const parsedForeignKeySet = new Set(parsedForeignKeys)
-    const missingForeignKeys = expectedForeignKeys.filter(
-      (foreignKey) => !parsedForeignKeySet.has(foreignKey)
-    )
-    const unknownForeignKeys = parsedForeignKeys.filter(
-      (foreignKey) => !knownForeignKeys.has(foreignKey)
-    )
+    const missingForeignKeys = findUnmatchedOccurrences(expectedForeignKeys, parsedForeignKeys)
+    const unknownForeignKeys = findUnmatchedOccurrences(parsedForeignKeys, knownForeignKeys)
     if (missingForeignKeys.length > 0 || unknownForeignKeys.length > 0) {
       throw new DatabaseValidationError(
         `Database baseline verification found incompatible foreign-key definitions for ${tableName}.`,
@@ -725,17 +756,19 @@ const verifyRuntimeSchemaTarget = async (
         foreignKey.columns.map((column, index) => pragmaForeignKeyKey(foreignKey, column, index))
       )
       .sort()
-    const knownPragmaForeignKeys = new Set(
-      knownForeignKeyTable.foreignKeys.flatMap((foreignKey) =>
+    const knownPragmaForeignKeys = [
+      ...targetPragmaForeignKeys,
+      ...allowedSuffixForeignKeys.flatMap((foreignKey) =>
         foreignKey.columns.map((column, index) => pragmaForeignKeyKey(foreignKey, column, index))
       )
+    ]
+    const missingPragmaForeignKeys = findUnmatchedOccurrences(
+      targetPragmaForeignKeys,
+      pragmaForeignKeys
     )
-    const pragmaForeignKeySet = new Set(pragmaForeignKeys)
-    const missingPragmaForeignKeys = targetPragmaForeignKeys.filter(
-      (foreignKey) => !pragmaForeignKeySet.has(foreignKey)
-    )
-    const unknownPragmaForeignKeys = pragmaForeignKeys.filter(
-      (foreignKey) => !knownPragmaForeignKeys.has(foreignKey)
+    const unknownPragmaForeignKeys = findUnmatchedOccurrences(
+      pragmaForeignKeys,
+      knownPragmaForeignKeys
     )
     if (missingPragmaForeignKeys.length > 0 || unknownPragmaForeignKeys.length > 0) {
       throw new DatabaseValidationError(

--- a/src/main/database/legacy-baseline-adapter.ts
+++ b/src/main/database/legacy-baseline-adapter.ts
@@ -679,8 +679,20 @@ const verifyRuntimeSchemaTarget = async (
       )
     }
     const expectedForeignKeys = expectedTable.foreignKeys.map(foreignKeyKey).sort()
+    // A pre-ledger database can already contain a released suffix FK. Require every baseline FK,
+    // allow only FKs present in the current generated target, and keep exact current verification.
+    const knownForeignKeyTable =
+      (exact ? expectedTable : CURRENT_TARGET_TABLES.get(tableName)) ?? expectedTable
+    const knownForeignKeys = new Set(knownForeignKeyTable.foreignKeys.map(foreignKeyKey))
     const parsedForeignKeys = actualTable.foreignKeys.map(foreignKeyKey).sort()
-    if (parsedForeignKeys.join('\n') !== expectedForeignKeys.join('\n')) {
+    const parsedForeignKeySet = new Set(parsedForeignKeys)
+    const missingForeignKeys = expectedForeignKeys.filter(
+      (foreignKey) => !parsedForeignKeySet.has(foreignKey)
+    )
+    const unknownForeignKeys = parsedForeignKeys.filter(
+      (foreignKey) => !knownForeignKeys.has(foreignKey)
+    )
+    if (missingForeignKeys.length > 0 || unknownForeignKeys.length > 0) {
       throw new DatabaseValidationError(
         `Database baseline verification found incompatible foreign-key definitions for ${tableName}.`,
         {
@@ -702,15 +714,30 @@ const verifyRuntimeSchemaTarget = async (
           `${row.from}|${row.table}|${row.to}|${row.on_delete.toUpperCase()}|${row.on_update.toUpperCase()}`
       )
       .sort()
+    const pragmaForeignKeyKey = (
+      foreignKey: TargetForeignKey,
+      column: string,
+      index: number
+    ): string =>
+      `${column}|${foreignKey.targetTable}|${foreignKey.targetColumns[index]}|${foreignKey.onDelete}|${foreignKey.onUpdate}`
     const targetPragmaForeignKeys = expectedTable.foreignKeys
       .flatMap((foreignKey) =>
-        foreignKey.columns.map(
-          (column, index) =>
-            `${column}|${foreignKey.targetTable}|${foreignKey.targetColumns[index]}|${foreignKey.onDelete}|${foreignKey.onUpdate}`
-        )
+        foreignKey.columns.map((column, index) => pragmaForeignKeyKey(foreignKey, column, index))
       )
       .sort()
-    if (pragmaForeignKeys.join('\n') !== targetPragmaForeignKeys.join('\n')) {
+    const knownPragmaForeignKeys = new Set(
+      knownForeignKeyTable.foreignKeys.flatMap((foreignKey) =>
+        foreignKey.columns.map((column, index) => pragmaForeignKeyKey(foreignKey, column, index))
+      )
+    )
+    const pragmaForeignKeySet = new Set(pragmaForeignKeys)
+    const missingPragmaForeignKeys = targetPragmaForeignKeys.filter(
+      (foreignKey) => !pragmaForeignKeySet.has(foreignKey)
+    )
+    const unknownPragmaForeignKeys = pragmaForeignKeys.filter(
+      (foreignKey) => !knownPragmaForeignKeys.has(foreignKey)
+    )
+    if (missingPragmaForeignKeys.length > 0 || unknownPragmaForeignKeys.length > 0) {
       throw new DatabaseValidationError(
         `Database baseline verification found incompatible foreign-key metadata for ${tableName}.`,
         {

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -19,7 +19,7 @@ import {
 } from './migration-service'
 
 const futureTestMigration = (): MigrationManifestEntry => {
-  const id = '0005_test_suffix'
+  const id = '0006_test_suffix'
   const statements = [`UPDATE "Project" SET "name" = "name" WHERE 0`] as const
   const verifiers = [{ kind: 'table-exists', version: 1, table: 'Project' }] as const
   return {
@@ -174,10 +174,11 @@ describe('application database migrations', () => {
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
         '0003_granted_local_roots',
-        '0004_review_assessment_snapshots'
+        '0004_review_assessment_snapshots',
+        '0005_project_preview_state_owner_fk'
       ],
       from: null,
-      to: '0004_review_assessment_snapshots'
+      to: '0005_project_preview_state_owner_fk'
     })
     expect(compatibility).toEqual([{ sqliteVersion: expect.stringMatching(/^\d+\.\d+\.\d+$/) }])
     await expect(
@@ -190,8 +191,8 @@ describe('application database migrations', () => {
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
       applied: [],
-      from: '0004_review_assessment_snapshots',
-      to: '0004_review_assessment_snapshots'
+      from: '0005_project_preview_state_owner_fk',
+      to: '0005_project_preview_state_owner_fk'
     })
   })
 
@@ -235,7 +236,7 @@ describe('application database migrations', () => {
       })
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0004_review_assessment_snapshots'
+      migrationId: '0005_project_preview_state_owner_fk'
     })
     expect(retired).toEqual([])
     await expect(access(backupPath)).resolves.toBeUndefined()
@@ -251,9 +252,9 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).resolves.toEqual({
       adoptedLegacy: false,
-      applied: ['0005_test_suffix'],
-      from: '0004_review_assessment_snapshots',
-      to: '0005_test_suffix'
+      applied: ['0006_test_suffix'],
+      from: '0005_project_preview_state_owner_fk',
+      to: '0006_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ id: string }>>`
@@ -264,7 +265,8 @@ describe('application database migrations', () => {
       { id: '0002_project_agent_context' },
       { id: '0003_granted_local_roots' },
       { id: '0004_review_assessment_snapshots' },
-      { id: '0005_test_suffix' }
+      { id: '0005_project_preview_state_owner_fk' },
+      { id: '0006_test_suffix' }
     ])
   })
 
@@ -320,10 +322,11 @@ describe('application database migrations', () => {
       applied: [
         '0002_project_agent_context',
         '0003_granted_local_roots',
-        '0004_review_assessment_snapshots'
+        '0004_review_assessment_snapshots',
+        '0005_project_preview_state_owner_fk'
       ],
       from: '0001_runtime_schema_baseline',
-      to: '0004_review_assessment_snapshots'
+      to: '0005_project_preview_state_owner_fk'
     })
     expect(backupEvents).toEqual([
       {
@@ -339,6 +342,11 @@ describe('application database migrations', () => {
       {
         migrationId: '0004_review_assessment_snapshots',
         path: `${databasePath}.before-0004_review_assessment_snapshots.backup`,
+        reused: false
+      },
+      {
+        migrationId: '0005_project_preview_state_owner_fk',
+        path: `${databasePath}.before-0005_project_preview_state_owner_fk.backup`,
         reused: false
       }
     ])
@@ -372,7 +380,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0005_test_suffix'
+      migrationId: '0006_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ name: string }>>`
@@ -388,7 +396,8 @@ describe('application database migrations', () => {
       { id: '0001_runtime_schema_baseline' },
       { id: '0002_project_agent_context' },
       { id: '0003_granted_local_roots' },
-      { id: '0004_review_assessment_snapshots' }
+      { id: '0004_review_assessment_snapshots' },
+      { id: '0005_project_preview_state_owner_fk' }
     ])
   })
 
@@ -410,7 +419,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0005_test_suffix'
+      migrationId: '0006_test_suffix'
     })
   })
 
@@ -440,15 +449,77 @@ describe('application database migrations', () => {
         '0002_project_agent_context',
         '0003_granted_local_roots',
         '0004_review_assessment_snapshots',
-        '0005_test_suffix'
+        '0005_project_preview_state_owner_fk',
+        '0006_test_suffix'
       ],
-      to: '0005_test_suffix'
+      to: '0006_test_suffix'
     })
     await expect(
       client.project.findUniqueOrThrow({ where: { id: 'legacy-project' } })
     ).resolves.toMatchObject({ name: 'Preserved' })
   })
 
+  it('migrates legacy Preview ownership while pruning orphan rows', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-preview-owner-fk-'))
+    client = createProjectDbClient(storageRoot)
+    await client.$executeRawUnsafe(`CREATE TABLE "Project" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "name" TEXT NOT NULL,
+      "description" TEXT NOT NULL DEFAULT '',
+      "isExample" BOOLEAN NOT NULL DEFAULT false,
+      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updatedAt" DATETIME NOT NULL
+    )`)
+    await client.$executeRawUnsafe(`CREATE TABLE "ProjectPreviewState" (
+      "projectId" TEXT NOT NULL PRIMARY KEY,
+      "panelState" TEXT NOT NULL,
+      "activeItemId" TEXT,
+      "items" TEXT NOT NULL DEFAULT '[]',
+      "updatedAt" DATETIME NOT NULL
+    )`)
+    const updatedAt = new Date('2026-01-02T03:04:05Z')
+    await client.$executeRaw`
+      INSERT INTO "Project" ("id", "name", "updatedAt")
+      VALUES (${'legacy-project'}, ${'Preserved'}, ${updatedAt})
+    `
+    await client.$executeRaw`
+      INSERT INTO "ProjectPreviewState" (
+        "projectId", "panelState", "activeItemId", "items", "updatedAt"
+      ) VALUES
+        (${'legacy-project'}, ${'open'}, ${null}, ${'[]'}, ${updatedAt}),
+        (${'orphan-project'}, ${'collapsed'}, ${null}, ${'[]'}, ${updatedAt})
+    `
+
+    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
+      applied: expect.arrayContaining(['0005_project_preview_state_owner_fk'])
+    })
+    await expect(
+      client.$queryRaw<Array<{ projectId: string }>>`
+        SELECT "projectId" FROM "ProjectPreviewState" ORDER BY "projectId"
+      `
+    ).resolves.toEqual([{ projectId: 'legacy-project' }])
+    await expect(
+      client.$queryRawUnsafe<
+        Array<{ table: string; from: string; to: string; on_delete: string; on_update: string }>
+      >('PRAGMA foreign_key_list("ProjectPreviewState")')
+    ).resolves.toContainEqual(
+      expect.objectContaining({
+        table: 'Project',
+        from: 'projectId',
+        to: 'id',
+        on_delete: 'CASCADE',
+        on_update: 'CASCADE'
+      })
+    )
+
+    await client.project.delete({ where: { id: 'legacy-project' } })
+    await expect(client.projectPreviewState.count()).resolves.toBe(0)
+    await expect(
+      client.projectPreviewState.create({
+        data: { projectId: 'missing-project', panelState: 'collapsed', items: '[]' }
+      })
+    ).rejects.toThrow()
+  })
   it('blocks a database containing a migration from a newer application', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-newer-'))
     client = createProjectDbClient(storageRoot)
@@ -456,7 +527,7 @@ describe('application database migrations', () => {
     await client.project.create({ data: { id: 'project-1', name: 'Preserved' } })
     await client.$executeRaw`
       INSERT INTO "_open_science_migrations" ("id", "checksum")
-      VALUES (${'0005_future_schema'}, ${'f'.repeat(64)})
+      VALUES (${'0006_future_schema'}, ${'f'.repeat(64)})
     `
 
     await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
@@ -528,7 +599,8 @@ describe('application database migrations', () => {
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
         '0003_granted_local_roots',
-        '0004_review_assessment_snapshots'
+        '0004_review_assessment_snapshots',
+        '0005_project_preview_state_owner_fk'
       ]
     })
     await expect(
@@ -568,7 +640,8 @@ describe('application database migrations', () => {
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
         '0003_granted_local_roots',
-        '0004_review_assessment_snapshots'
+        '0004_review_assessment_snapshots',
+        '0005_project_preview_state_owner_fk'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -621,7 +694,8 @@ describe('application database migrations', () => {
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
         '0003_granted_local_roots',
-        '0004_review_assessment_snapshots'
+        '0004_review_assessment_snapshots',
+        '0005_project_preview_state_owner_fk'
       ]
     })
     await expect(
@@ -677,7 +751,8 @@ describe('application database migrations', () => {
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
         '0003_granted_local_roots',
-        '0004_review_assessment_snapshots'
+        '0004_review_assessment_snapshots',
+        '0005_project_preview_state_owner_fk'
       ]
     })
     await expect(verifyCurrentRuntimeSchema(client)).resolves.toBeUndefined()
@@ -767,7 +842,8 @@ describe('application database migrations', () => {
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
         '0003_granted_local_roots',
-        '0004_review_assessment_snapshots'
+        '0004_review_assessment_snapshots',
+        '0005_project_preview_state_owner_fk'
       ]
     })
     await expect(
@@ -810,7 +886,8 @@ describe('application database migrations', () => {
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
         '0003_granted_local_roots',
-        '0004_review_assessment_snapshots'
+        '0004_review_assessment_snapshots',
+        '0005_project_preview_state_owner_fk'
       ]
     })
     expect(backupEvents).toEqual([
@@ -832,6 +909,11 @@ describe('application database migrations', () => {
       {
         migrationId: '0004_review_assessment_snapshots',
         path: `${databasePath}.before-0004_review_assessment_snapshots.backup`,
+        reused: false
+      },
+      {
+        migrationId: '0005_project_preview_state_owner_fk',
+        path: `${databasePath}.before-0005_project_preview_state_owner_fk.backup`,
         reused: false
       }
     ])
@@ -1220,6 +1302,11 @@ describe('application database migrations', () => {
         migrationId: '0004_review_assessment_snapshots',
         path: `${databasePath}.before-0004_review_assessment_snapshots.backup`,
         reused: false
+      }),
+      expect.objectContaining({
+        migrationId: '0005_project_preview_state_owner_fk',
+        path: `${databasePath}.before-0005_project_preview_state_owner_fk.backup`,
+        reused: false
       })
     ])
     expect(retired).toEqual([
@@ -1232,6 +1319,10 @@ describe('application database migrations', () => {
       {
         migrationId: '0004_review_assessment_snapshots',
         path: `${databasePath}.before-0004_review_assessment_snapshots.backup`
+      },
+      {
+        migrationId: '0005_project_preview_state_owner_fk',
+        path: `${databasePath}.before-0005_project_preview_state_owner_fk.backup`
       }
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -486,8 +486,8 @@ describe('application database migrations', () => {
       INSERT INTO "ProjectPreviewState" (
         "projectId", "panelState", "activeItemId", "items", "updatedAt"
       ) VALUES
-        (${'legacy-project'}, ${'open'}, ${null}, ${'[]'}, ${updatedAt}),
-        (${'orphan-project'}, ${'collapsed'}, ${null}, ${'[]'}, ${updatedAt})
+        (${'legacy-project'}, ${'open'}, NULL, ${'[]'}, ${updatedAt}),
+        (${'orphan-project'}, ${'collapsed'}, NULL, ${'[]'}, ${updatedAt})
     `
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
@@ -519,6 +519,49 @@ describe('application database migrations', () => {
         data: { projectId: 'missing-project', panelState: 'collapsed', items: '[]' }
       })
     ).rejects.toThrow()
+  })
+
+  it('replays preview ownership migration when an adopted FK table contains orphan rows', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-preview-owner-adoption-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'legacy-project', name: 'Preserved' } })
+    await client.projectPreviewState.create({
+      data: { projectId: 'legacy-project', panelState: 'open', items: '[]' }
+    })
+
+    await client.$executeRawUnsafe('PRAGMA foreign_keys = OFF')
+    await client.$executeRaw`
+      INSERT INTO "ProjectPreviewState" (
+        "projectId", "panelState", "activeItemId", "items", "updatedAt"
+      ) VALUES (
+        ${'orphan-project'}, ${'collapsed'}, NULL, ${'[]'}, ${new Date('2026-01-02T03:04:05Z')}
+      )
+    `
+    await client.$executeRawUnsafe('PRAGMA foreign_keys = ON')
+    await client.$executeRawUnsafe('DROP TABLE "_open_science_migrations"')
+
+    await expect(
+      migrateApplicationDatabaseWithManifest(client, MIGRATION_MANIFEST.slice(0, -1))
+    ).rejects.toMatchObject({
+      code: 'database_validation_failed',
+      migrationId: '0001_runtime_schema_baseline'
+    })
+
+    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
+      adoptedLegacy: true,
+      applied: expect.arrayContaining(['0005_project_preview_state_owner_fk'])
+    })
+    await expect(
+      client.$queryRaw<Array<{ projectId: string }>>`
+        SELECT "projectId" FROM "ProjectPreviewState" ORDER BY "projectId"
+      `
+    ).resolves.toEqual([{ projectId: 'legacy-project' }])
+    await expect(
+      client.$queryRawUnsafe<Array<{ table: string }>>(
+        'PRAGMA foreign_key_check("ProjectPreviewState")'
+      )
+    ).resolves.toEqual([])
   })
   it('blocks a database containing a migration from a newer application', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-newer-'))

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import { createProjectDbClient } from '../projects/prisma-client'
 import { verifyCurrentRuntimeSchema } from './legacy-baseline-adapter'
+import { RUNTIME_SCHEMA_TABLE_DDL_BY_NAME } from './migrations/0001-runtime-schema-baseline'
 import {
   BASELINE_CHECKSUM,
   MIGRATION_MANIFEST,
@@ -457,6 +458,33 @@ describe('application database migrations', () => {
     await expect(
       client.project.findUniqueOrThrow({ where: { id: 'legacy-project' } })
     ).resolves.toMatchObject({ name: 'Preserved' })
+  })
+
+  it('rejects an extra current-shaped foreign key on another pre-ledger table', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-unknown-suffix-fk-'))
+    client = createProjectDbClient(storageRoot)
+    const findingDdl = RUNTIME_SCHEMA_TABLE_DDL_BY_NAME.Finding
+    const currentForeignKey = findingDdl.match(/(CONSTRAINT[\s\S]+)\n\);$/)?.[1]
+    if (!currentForeignKey) throw new Error('Finding baseline FK fixture is unavailable.')
+    await client.$executeRawUnsafe(findingDdl.replace(/\n\);$/, `,\n    ${currentForeignKey}\n);`))
+
+    await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
+      code: 'database_validation_failed',
+      migrationId: '0001_runtime_schema_baseline',
+      cause: {
+        name: 'DatabaseValidationError',
+        data: {
+          kind: 'foreign-key-definition-mismatch',
+          table: 'Finding'
+        }
+      }
+    })
+    await expect(
+      client.$queryRaw<Array<{ name: string }>>`
+        SELECT name FROM sqlite_schema
+        WHERE name = '_open_science_migrations'
+      `
+    ).resolves.toEqual([])
   })
 
   it('migrates legacy Preview ownership while pruning orphan rows', async () => {

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -685,6 +685,8 @@ const hasOnlyDeferredPreviewStateForeignKeyViolations = async (
   client: PrismaClient,
   error: unknown
 ): Promise<boolean> => {
+  // This is a one-off bridge to the checksum-pinned 0005 repair below. Future suffix FKs must not
+  // copy this deferral: they need their own explicit migration and fail-closed adoption contract.
   if (
     !(error instanceof DatabaseValidationError) ||
     error.data.kind !== 'foreign-key-violation' ||

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -38,7 +38,7 @@ type MigrationVerifierDescriptor =
     }
   | {
       kind: 'foreign-key-exists'
-      version: 1
+      version: 2
       table: string
       column: string
       referencedTable: string
@@ -181,6 +181,10 @@ type SqliteForeignKeyListRow = {
   on_delete: string
   on_update: string
 }
+type SqliteForeignKeyViolationRow = {
+  table: string
+  parent: string
+}
 type SqliteSchemaObjectRow = { type: string; name: string; tableName: string; sql: string | null }
 type SqliteDifferenceRow = { different: bigint | number }
 type DatabaseMigrationErrorCode = DatabaseStartupErrorCode
@@ -296,6 +300,15 @@ const runMigrationVerifiers = async (
         if (!exists) {
           throw new Error(
             `Migration verification found missing foreign key ${verifier.table}.${verifier.column} -> ${verifier.referencedTable}.${verifier.referencedColumn}.`
+          )
+        }
+        const violations = await migrationSqlExecutor.query<Array<{ table: string }>>(
+          client,
+          `PRAGMA foreign_key_check(${quotedTable})`
+        )
+        if (violations.length > 0) {
+          throw new Error(
+            `Migration verification found foreign-key violations in ${verifier.table}.`
           )
         }
         break
@@ -668,9 +681,33 @@ const insertLedgerRow = async (
   `
 }
 
+const hasOnlyDeferredPreviewStateForeignKeyViolations = async (
+  client: PrismaClient,
+  error: unknown
+): Promise<boolean> => {
+  if (
+    !(error instanceof DatabaseValidationError) ||
+    error.data.kind !== 'foreign-key-violation' ||
+    error.data.table !== 'ProjectPreviewState'
+  ) {
+    return false
+  }
+  const violations = await migrationSqlExecutor.query<SqliteForeignKeyViolationRow[]>(
+    client,
+    'PRAGMA foreign_key_check'
+  )
+  return (
+    violations.length > 0 &&
+    violations.every(
+      (violation) => violation.table === 'ProjectPreviewState' && violation.parent === 'Project'
+    )
+  )
+}
+
 const applyBaselineMigration = async (
   client: PrismaClient,
-  migration: MigrationManifestEntry
+  migration: MigrationManifestEntry,
+  deferPreviewStateForeignKeyViolations: boolean
 ): Promise<void> => {
   let prepared: Awaited<ReturnType<typeof prepareRuntimeSchemaBaseline>>
   try {
@@ -686,7 +723,17 @@ const applyBaselineMigration = async (
     if (foreignKeysWereEnabled) await setForeignKeys(client, false)
     await client.$transaction(async (transaction) => {
       const transactionClient = transaction as unknown as PrismaClient
-      await applyRuntimeSchemaBaseline(transactionClient, prepared)
+      try {
+        await applyRuntimeSchemaBaseline(transactionClient, prepared)
+      } catch (error) {
+        if (
+          !deferPreviewStateForeignKeyViolations ||
+          !(await hasOnlyDeferredPreviewStateForeignKeyViolations(transactionClient, error))
+        ) {
+          throw error
+        }
+        // The pinned 0005 suffix owns pruning these rows before the migration run completes.
+      }
       await runMigrationVerifiers(transactionClient, migration.verifiers)
       await insertLedgerRow(transactionClient, migration)
     })
@@ -845,6 +892,11 @@ const migrateApplicationDatabaseWithManifest = async (
       // A diagnostic sink failure must not invalidate a durable database backup.
     }
   }
+  const repairsPreviewStateForeignKeyViolations = manifest.some(
+    (candidate) =>
+      candidate.id === projectPreviewStateOwnerFkMigration.id &&
+      candidate.checksum === PROJECT_PREVIEW_STATE_OWNER_FK_CHECKSUM
+  )
 
   const applied: string[] = []
   const adoptedLegacy = appliedCount === 0 && hadApplicationTablesAtStart
@@ -853,7 +905,7 @@ const migrateApplicationDatabaseWithManifest = async (
     const baseline = manifest[0]!
     options.onProgress?.({ phase: 'migrating', migrationId: baseline.id })
     await backupBeforeMigration(baseline)
-    await applyBaselineMigration(client, baseline)
+    await applyBaselineMigration(client, baseline, repairsPreviewStateForeignKeyViolations)
     applied.push(baseline.id)
     nextIndex = 1
   }

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -17,6 +17,7 @@ import { runtimeSchemaBaselineMigration } from './migrations/0001-runtime-schema
 import { projectAgentContextMigration } from './migrations/0002-project-agent-context'
 import { grantedLocalRootsMigration } from './migrations/0003-granted-local-roots'
 import { reviewAssessmentSnapshotsMigration } from './migrations/0004-review-assessment-snapshots'
+import { projectPreviewStateOwnerFkMigration } from './migrations/0005-project-preview-state-owner-fk'
 
 type MigrationVerifierDescriptor =
   | {
@@ -34,6 +35,16 @@ type MigrationVerifierDescriptor =
       version: 1
       table: string
       column: string
+    }
+  | {
+      kind: 'foreign-key-exists'
+      version: 1
+      table: string
+      column: string
+      referencedTable: string
+      referencedColumn: string
+      onDelete: string
+      onUpdate: string
     }
 
 type MigrationVerifiers = readonly [MigrationVerifierDescriptor, ...MigrationVerifierDescriptor[]]
@@ -56,6 +67,17 @@ const serializeMigrationVerifier = (verifier: MigrationVerifierDescriptor): stri
       return `table-exists:v${verifier.version}:${lengthPrefixedChecksumText(verifier.table)}`
     case 'column-exists':
       return `column-exists:v${verifier.version}:${lengthPrefixedChecksumText(verifier.table)}${lengthPrefixedChecksumText(verifier.column)}`
+    case 'foreign-key-exists':
+      return `foreign-key-exists:v${verifier.version}:${[
+        verifier.table,
+        verifier.column,
+        verifier.referencedTable,
+        verifier.referencedColumn,
+        verifier.onDelete,
+        verifier.onUpdate
+      ]
+        .map(lengthPrefixedChecksumText)
+        .join('')}`
   }
 }
 
@@ -101,6 +123,11 @@ const REVIEW_ASSESSMENT_SNAPSHOTS_CHECKSUM = checksumMigrationPayload(
   reviewAssessmentSnapshotsMigration.statements,
   reviewAssessmentSnapshotsMigration.verifiers
 )
+const PROJECT_PREVIEW_STATE_OWNER_FK_CHECKSUM = checksumMigrationPayload(
+  projectPreviewStateOwnerFkMigration.id,
+  projectPreviewStateOwnerFkMigration.statements,
+  projectPreviewStateOwnerFkMigration.verifiers
+)
 const MIGRATION_MANIFEST = [
   {
     ...runtimeSchemaBaselineMigration,
@@ -125,6 +152,12 @@ const MIGRATION_MANIFEST = [
     checksum: REVIEW_ASSESSMENT_SNAPSHOTS_CHECKSUM,
     backupOnApply: 'required',
     backupRetention: 'retain'
+  },
+  {
+    ...projectPreviewStateOwnerFkMigration,
+    checksum: PROJECT_PREVIEW_STATE_OWNER_FK_CHECKSUM,
+    backupOnApply: 'required',
+    backupRetention: 'retain'
   }
 ] as const satisfies readonly MigrationManifestEntry[]
 // schema-locality: begin frozen-0001-repairs
@@ -141,6 +174,13 @@ type LedgerRow = { id: string; checksum: string }
 type SqliteForeignKeyStateRow = { foreign_keys: bigint | number }
 type SqliteDatabaseListRow = { name: string; file: string }
 type SqliteIntegrityCheckRow = { integrity_check: string }
+type SqliteForeignKeyListRow = {
+  table: string
+  from: string
+  to: string
+  on_delete: string
+  on_update: string
+}
 type SqliteSchemaObjectRow = { type: string; name: string; tableName: string; sql: string | null }
 type SqliteDifferenceRow = { different: bigint | number }
 type DatabaseMigrationErrorCode = DatabaseStartupErrorCode
@@ -235,6 +275,27 @@ const runMigrationVerifiers = async (
         if (!columns.some((column) => column.name === verifier.column)) {
           throw new Error(
             `Migration verification found missing column ${verifier.table}.${verifier.column}.`
+          )
+        }
+        break
+      }
+      case 'foreign-key-exists': {
+        const quotedTable = `"${verifier.table.replaceAll('"', '""')}"`
+        const foreignKeys = await migrationSqlExecutor.query<SqliteForeignKeyListRow[]>(
+          client,
+          `PRAGMA foreign_key_list(${quotedTable})`
+        )
+        const exists = foreignKeys.some(
+          (foreignKey) =>
+            foreignKey.from === verifier.column &&
+            foreignKey.table === verifier.referencedTable &&
+            foreignKey.to === verifier.referencedColumn &&
+            foreignKey.on_delete.toUpperCase() === verifier.onDelete.toUpperCase() &&
+            foreignKey.on_update.toUpperCase() === verifier.onUpdate.toUpperCase()
+        )
+        if (!exists) {
+          throw new Error(
+            `Migration verification found missing foreign key ${verifier.table}.${verifier.column} -> ${verifier.referencedTable}.${verifier.referencedColumn}.`
           )
         }
         break

--- a/src/main/database/migrations/0005-project-preview-state-owner-fk.ts
+++ b/src/main/database/migrations/0005-project-preview-state-owner-fk.ts
@@ -1,0 +1,38 @@
+/* Immutable 0005 migration snapshot. Do not regenerate after release. */
+
+// ProjectPreviewState used to be an unowned derived table, so a delayed renderer save could recreate
+// it after Project deletion. Rebuild the table with an owner FK, preserve valid rows, and deliberately
+// discard legacy rows whose Project is already absent.
+const projectPreviewStateOwnerFkMigration = {
+  id: '0005_project_preview_state_owner_fk',
+  statements: [
+    `ALTER TABLE "ProjectPreviewState" RENAME TO "_ProjectPreviewState_without_project_fk"`,
+    `CREATE TABLE "ProjectPreviewState" (
+    "projectId" TEXT NOT NULL PRIMARY KEY,
+    "panelState" TEXT NOT NULL,
+    "activeItemId" TEXT,
+    "items" TEXT NOT NULL DEFAULT '[]',
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ProjectPreviewState_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+)`,
+    `INSERT INTO "ProjectPreviewState" ("projectId", "panelState", "activeItemId", "items", "updatedAt")
+SELECT "preview"."projectId", "preview"."panelState", "preview"."activeItemId", "preview"."items", "preview"."updatedAt"
+FROM "_ProjectPreviewState_without_project_fk" AS "preview"
+INNER JOIN "Project" AS "project" ON "project"."id" = "preview"."projectId"`,
+    `DROP TABLE "_ProjectPreviewState_without_project_fk"`
+  ] as const,
+  verifiers: [
+    {
+      kind: 'foreign-key-exists',
+      version: 1,
+      table: 'ProjectPreviewState',
+      column: 'projectId',
+      referencedTable: 'Project',
+      referencedColumn: 'id',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE'
+    }
+  ] as const
+}
+
+export { projectPreviewStateOwnerFkMigration }

--- a/src/main/database/migrations/0005-project-preview-state-owner-fk.ts
+++ b/src/main/database/migrations/0005-project-preview-state-owner-fk.ts
@@ -24,7 +24,7 @@ INNER JOIN "Project" AS "project" ON "project"."id" = "preview"."projectId"`,
   verifiers: [
     {
       kind: 'foreign-key-exists',
-      version: 1,
+      version: 2,
       table: 'ProjectPreviewState',
       column: 'projectId',
       referencedTable: 'Project',

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -723,7 +723,6 @@ const createApplicationModules = async (
   const projectDeletionCoordinator = new ProjectDeletionCoordinator(
     projectRepository,
     sessionPersistenceCoordinator,
-    previewStateRepository,
     reviewRepository,
     artifactProvenanceRepository,
     permissionGrantRegistry,

--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -25,19 +25,16 @@ const project = {
 describe('ProjectDeletionCoordinator', () => {
   it('rejects deletion recovery while a data-root migration is pending', async () => {
     const projects = createProjects()
-    const coordinator = new ProjectDeletionCoordinator(projects, createSessions(), {
-      delete: vi.fn().mockResolvedValue(undefined)
-    })
+    const coordinator = new ProjectDeletionCoordinator(projects, createSessions())
     beginMigration()
 
     await expect(coordinator.recoverPendingDeletions()).rejects.toThrow(/moving your data/i)
     expect(projects.listDeletionIntents).not.toHaveBeenCalled()
   })
 
-  it('deletes the project row, sessions, index, and preview state', async () => {
+  it('deletes the project row, sessions, index, reviews, and provenance', async () => {
     const projects = createProjects()
     const sessions = createSessions()
-    const preview = { delete: vi.fn().mockResolvedValue(undefined) }
     const reviews = { deleteReviewsForProject: vi.fn().mockResolvedValue(undefined) }
     const provenance = { deleteProjectProvenance: vi.fn().mockResolvedValue(undefined) }
     const permissionGrants = {
@@ -50,7 +47,6 @@ describe('ProjectDeletionCoordinator', () => {
     const coordinator = new ProjectDeletionCoordinator(
       projects,
       sessions,
-      preview,
       reviews,
       provenance,
       permissionGrants,
@@ -68,7 +64,6 @@ describe('ProjectDeletionCoordinator', () => {
     expect(projects.delete).toHaveBeenCalledWith('project-1')
     expect(sessions.deleteProjectSessions).toHaveBeenCalledWith('project-1')
     expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-1')
-    expect(preview.delete).toHaveBeenCalledWith('project-1')
     expect(reviews.deleteReviewsForProject).toHaveBeenCalledWith('project-1')
     expect(provenance.deleteProjectProvenance).toHaveBeenCalledWith('project-1')
     expect(permissionGrants.prune).toHaveBeenCalledWith({
@@ -99,7 +94,6 @@ describe('ProjectDeletionCoordinator', () => {
     const coordinator = new ProjectDeletionCoordinator(
       projects,
       sessions,
-      { delete: vi.fn().mockResolvedValue(undefined) },
       undefined,
       undefined,
       undefined,
@@ -135,7 +129,6 @@ describe('ProjectDeletionCoordinator', () => {
     const coordinator = new ProjectDeletionCoordinator(
       projects,
       createSessions(),
-      { delete: vi.fn().mockResolvedValue(undefined) },
       undefined,
       undefined,
       undefined,
@@ -178,7 +171,6 @@ describe('ProjectDeletionCoordinator', () => {
     const coordinator = new ProjectDeletionCoordinator(
       projects,
       createSessions(),
-      { delete: vi.fn().mockResolvedValue(undefined) },
       undefined,
       undefined,
       undefined,
@@ -222,7 +214,6 @@ describe('ProjectDeletionCoordinator', () => {
     const coordinator = new ProjectDeletionCoordinator(
       projects,
       sessions,
-      { delete: vi.fn().mockResolvedValue(undefined) },
       undefined,
       undefined,
       permissionGrants
@@ -257,7 +248,6 @@ describe('ProjectDeletionCoordinator', () => {
     const coordinator = new ProjectDeletionCoordinator(
       projects,
       sessions,
-      { delete: vi.fn().mockResolvedValue(undefined) },
       undefined,
       undefined,
       permissionGrants
@@ -270,96 +260,70 @@ describe('ProjectDeletionCoordinator', () => {
     expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-1')
   })
 
-  it.each([
-    {
-      name: 'Preview',
-      previewFailures: [new Error('preview unavailable'), undefined],
-      reviewFailures: [undefined, undefined]
-    },
-    {
-      name: 'Review',
-      previewFailures: [undefined, undefined],
-      reviewFailures: [new Error('review unavailable'), undefined]
+  it('retains the deletion intent when Review cleanup fails after the Project hard delete', async () => {
+    const reviewFailures = [new Error('review unavailable'), undefined]
+    let projectExists = true
+    let intentExists = false
+    const projects = createProjects()
+    projects.get = vi.fn(async () => (projectExists ? project : null))
+    projects.delete = vi.fn(async () => {
+      projectExists = false
+    })
+    projects.createDeletionIntent = vi.fn(async () => {
+      intentExists = true
+    })
+    projects.deleteDeletionIntent = vi.fn(async () => {
+      intentExists = false
+    })
+    projects.listDeletionIntents = vi.fn(async () => (intentExists ? ['project-1'] : []))
+    const sessions = createSessions()
+    const reviews = {
+      deleteReviewsForProject: vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          if (reviewFailures[0]) throw reviewFailures[0]
+        })
+        .mockImplementationOnce(async () => {
+          if (reviewFailures[1]) throw reviewFailures[1]
+        })
     }
-  ])(
-    'retains the deletion intent when $name cleanup fails after the Project hard delete',
-    async ({ previewFailures, reviewFailures }) => {
-      let projectExists = true
-      let intentExists = false
-      const projects = createProjects()
-      projects.get = vi.fn(async () => (projectExists ? project : null))
-      projects.delete = vi.fn(async () => {
-        projectExists = false
-      })
-      projects.createDeletionIntent = vi.fn(async () => {
-        intentExists = true
-      })
-      projects.deleteDeletionIntent = vi.fn(async () => {
-        intentExists = false
-      })
-      projects.listDeletionIntents = vi.fn(async () => (intentExists ? ['project-1'] : []))
-      const sessions = createSessions()
-      const preview = {
-        delete: vi
-          .fn()
-          .mockImplementationOnce(async () => {
-            if (previewFailures[0]) throw previewFailures[0]
-          })
-          .mockImplementationOnce(async () => {
-            if (previewFailures[1]) throw previewFailures[1]
-          })
+    const provenance = { deleteProjectProvenance: vi.fn().mockResolvedValue(undefined) }
+    const completeProjectDeletion = vi.fn()
+    const abortProjectDeletion = vi.fn()
+    const coordinator = new ProjectDeletionCoordinator(
+      projects,
+      sessions,
+      reviews,
+      provenance,
+      undefined,
+      {
+        beforeProjectDelete: vi.fn().mockResolvedValue(undefined),
+        completeProjectDeletion,
+        abortProjectDeletion
       }
-      const reviews = {
-        deleteReviewsForProject: vi
-          .fn()
-          .mockImplementationOnce(async () => {
-            if (reviewFailures[0]) throw reviewFailures[0]
-          })
-          .mockImplementationOnce(async () => {
-            if (reviewFailures[1]) throw reviewFailures[1]
-          })
-      }
-      const provenance = { deleteProjectProvenance: vi.fn().mockResolvedValue(undefined) }
-      const completeProjectDeletion = vi.fn()
-      const abortProjectDeletion = vi.fn()
-      const coordinator = new ProjectDeletionCoordinator(
-        projects,
-        sessions,
-        preview,
-        reviews,
-        provenance,
-        undefined,
-        {
-          beforeProjectDelete: vi.fn().mockResolvedValue(undefined),
-          completeProjectDeletion,
-          abortProjectDeletion
-        }
-      )
+    )
 
-      await expect(coordinator.deleteProject('project-1')).rejects.toThrow(
-        'Project derived cleanup failed: project-1'
-      )
+    await expect(coordinator.deleteProject('project-1')).rejects.toThrow(
+      'Project derived cleanup failed: project-1'
+    )
 
-      expect(projectExists).toBe(false)
-      expect(intentExists).toBe(true)
-      expect(preview.delete).toHaveBeenCalledOnce()
-      expect(reviews.deleteReviewsForProject).toHaveBeenCalledOnce()
-      expect(provenance.deleteProjectProvenance).not.toHaveBeenCalled()
-      expect(sessions.completeProjectSessionDeletion).not.toHaveBeenCalled()
-      expect(completeProjectDeletion).not.toHaveBeenCalled()
-      expect(abortProjectDeletion).not.toHaveBeenCalled()
+    expect(projectExists).toBe(false)
+    expect(intentExists).toBe(true)
+    expect(reviews.deleteReviewsForProject).toHaveBeenCalledOnce()
+    expect(provenance.deleteProjectProvenance).not.toHaveBeenCalled()
+    expect(sessions.completeProjectSessionDeletion).not.toHaveBeenCalled()
+    expect(completeProjectDeletion).not.toHaveBeenCalled()
+    expect(abortProjectDeletion).not.toHaveBeenCalled()
 
-      await expect(coordinator.recoverPendingDeletions()).resolves.toBeUndefined()
+    await expect(coordinator.recoverPendingDeletions()).resolves.toBeUndefined()
 
-      expect(preview.delete).toHaveBeenCalledTimes(2)
-      expect(reviews.deleteReviewsForProject).toHaveBeenCalledTimes(2)
-      expect(provenance.deleteProjectProvenance).toHaveBeenCalledWith('project-1')
-      expect(sessions.completeProjectSessionDeletion).toHaveBeenCalledWith('project-1')
-      expect(intentExists).toBe(false)
-      expect(completeProjectDeletion).toHaveBeenCalledWith('project-1')
-      expect(abortProjectDeletion).not.toHaveBeenCalled()
-    }
-  )
+    expect(reviews.deleteReviewsForProject).toHaveBeenCalledTimes(2)
+    expect(provenance.deleteProjectProvenance).toHaveBeenCalledWith('project-1')
+    expect(sessions.completeProjectSessionDeletion).toHaveBeenCalledWith('project-1')
+    expect(intentExists).toBe(false)
+    expect(completeProjectDeletion).toHaveBeenCalledWith('project-1')
+    expect(abortProjectDeletion).not.toHaveBeenCalled()
+  })
 
   it('keeps the project row, intent, and fence when session cleanup fails', async () => {
     const projects = createProjects()
@@ -370,7 +334,6 @@ describe('ProjectDeletionCoordinator', () => {
     const coordinator = new ProjectDeletionCoordinator(
       projects,
       sessions,
-      { delete: vi.fn().mockResolvedValue(undefined) },
       undefined,
       undefined,
       undefined,
@@ -393,9 +356,7 @@ describe('ProjectDeletionCoordinator', () => {
       deleteProjectSessions: vi.fn().mockRejectedValue(new Error('index unavailable')),
       getProjectSessionDeletionState: vi.fn().mockResolvedValue('prepared')
     })
-    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
-      delete: vi.fn().mockResolvedValue(undefined)
-    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions)
 
     await expect(coordinator.deleteProject('project-1')).rejects.toThrow('index unavailable')
 
@@ -413,7 +374,6 @@ describe('ProjectDeletionCoordinator', () => {
     const coordinator = new ProjectDeletionCoordinator(
       projects,
       sessions,
-      { delete: vi.fn().mockResolvedValue(undefined) },
       reviews,
       undefined,
       undefined,
@@ -446,7 +406,6 @@ describe('ProjectDeletionCoordinator', () => {
     const coordinator = new ProjectDeletionCoordinator(
       projects,
       sessions,
-      { delete: vi.fn().mockResolvedValue(undefined) },
       undefined,
       undefined,
       undefined,
@@ -538,13 +497,7 @@ describe('ProjectDeletionCoordinator', () => {
         order.push('provenance-removed')
       })
     }
-    const coordinator = new ProjectDeletionCoordinator(
-      projects,
-      sessions,
-      { delete: vi.fn().mockResolvedValue(undefined) },
-      undefined,
-      provenance
-    )
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions, undefined, provenance)
 
     await coordinator.recoverPendingDeletions()
 
@@ -564,9 +517,7 @@ describe('ProjectDeletionCoordinator', () => {
       listLegacyProjectSessionTombstones: vi.fn().mockResolvedValue(['project-old']),
       deleteProjectSessions: vi.fn().mockRejectedValue(new Error('index temporarily unavailable'))
     })
-    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
-      delete: vi.fn().mockResolvedValue(undefined)
-    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions)
 
     await expect(coordinator.recoverPendingDeletions()).rejects.toThrow(
       'index temporarily unavailable'
@@ -587,9 +538,7 @@ describe('ProjectDeletionCoordinator', () => {
         reason: 'missing-upload-authority'
       })
     })
-    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
-      delete: vi.fn().mockResolvedValue(undefined)
-    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions)
 
     await expect(coordinator.recoverPendingDeletions()).resolves.toBeUndefined()
 
@@ -605,9 +554,7 @@ describe('ProjectDeletionCoordinator', () => {
     const sessions = createSessions({
       getProjectSessionDeletionState: vi.fn().mockResolvedValue('legacy-committed')
     })
-    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
-      delete: vi.fn().mockResolvedValue(undefined)
-    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions)
 
     await coordinator.recoverPendingDeletions()
 
@@ -628,9 +575,7 @@ describe('ProjectDeletionCoordinator', () => {
         reason: 'missing-upload-authority'
       })
     })
-    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
-      delete: vi.fn().mockResolvedValue(undefined)
-    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions)
 
     await expect(coordinator.recoverPendingDeletions()).resolves.toBeUndefined()
 
@@ -651,9 +596,7 @@ describe('ProjectDeletionCoordinator', () => {
         return { status: 'completed' as const }
       })
     })
-    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
-      delete: vi.fn().mockResolvedValue(undefined)
-    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions)
 
     await expect(coordinator.recoverPendingDeletions()).rejects.toThrow(
       'transient session cleanup failure'
@@ -679,9 +622,7 @@ describe('ProjectDeletionCoordinator', () => {
       deleteProjectSessions: vi.fn().mockRejectedValue(new Error('tail cleanup unavailable')),
       getProjectSessionDeletionState: vi.fn().mockResolvedValue('prepared')
     })
-    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
-      delete: vi.fn().mockResolvedValue(undefined)
-    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions)
 
     await expect(coordinator.recoverPendingDeletions()).rejects.toThrow('tail cleanup unavailable')
 
@@ -696,9 +637,7 @@ describe('ProjectDeletionCoordinator', () => {
       deleteProjectSessions: vi.fn().mockRejectedValue(replayFailure),
       getProjectSessionDeletionState: vi.fn().mockRejectedValue(new Error('marker unreadable'))
     })
-    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
-      delete: vi.fn().mockResolvedValue(undefined)
-    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions)
 
     await expect(coordinator.recoverPendingDeletions()).rejects.toBe(replayFailure)
 
@@ -712,9 +651,7 @@ describe('ProjectDeletionCoordinator', () => {
       deleteProjectSessions: vi.fn().mockRejectedValue(new Error('session replay failed')),
       getProjectSessionDeletionState: vi.fn().mockResolvedValue('absent')
     })
-    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
-      delete: vi.fn().mockResolvedValue(undefined)
-    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions)
 
     await expect(coordinator.recoverPendingDeletions()).rejects.toThrow('session replay failed')
 
@@ -726,9 +663,7 @@ describe('ProjectDeletionCoordinator', () => {
     const sessions = createSessions({
       completeProjectSessionDeletion: vi.fn().mockRejectedValue(new Error('tombstone busy'))
     })
-    const coordinator = new ProjectDeletionCoordinator(projects, sessions, {
-      delete: vi.fn().mockResolvedValue(undefined)
-    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions)
 
     await expect(coordinator.deleteProject('project-1')).rejects.toThrow('tombstone busy')
 
@@ -761,7 +696,6 @@ describe('ProjectDeletionCoordinator', () => {
     const coordinator = new ProjectDeletionCoordinator(
       projects,
       sessions,
-      { delete: vi.fn().mockResolvedValue(undefined) },
       undefined,
       undefined,
       undefined,
@@ -806,11 +740,6 @@ describe('ProjectDeletionCoordinator', () => {
       projects,
       sessions,
       {
-        delete: vi.fn(async () => {
-          order.push('preview')
-        })
-      },
-      {
         deleteReviewsForProject: vi.fn(async () => {
           order.push('reviews')
         })
@@ -836,7 +765,6 @@ describe('ProjectDeletionCoordinator', () => {
 
     expect(order).toEqual([
       'project',
-      'preview',
       'reviews',
       'provenance',
       'finalize',
@@ -848,9 +776,7 @@ describe('ProjectDeletionCoordinator', () => {
 
   it('reuses a successful recovery gate for later operations', async () => {
     const projects = createProjects()
-    const coordinator = new ProjectDeletionCoordinator(projects, createSessions(), {
-      delete: vi.fn().mockResolvedValue(undefined)
-    })
+    const coordinator = new ProjectDeletionCoordinator(projects, createSessions())
 
     await coordinator.recoverPendingDeletions()
     await coordinator.recoverPendingDeletions()
@@ -867,8 +793,7 @@ describe('ProjectDeletionCoordinator', () => {
           await deletionGate.promise
           return { status: 'completed' as const }
         })
-      }),
-      { delete: vi.fn().mockResolvedValue(undefined) }
+      })
     )
     await coordinator.recoverPendingDeletions()
 
@@ -895,9 +820,7 @@ describe('ProjectDeletionCoordinator', () => {
         return { status: 'completed' as const }
       })
     })
-    const coordinator = new ProjectDeletionCoordinator(createProjects(), sessions, {
-      delete: vi.fn().mockResolvedValue(undefined)
-    })
+    const coordinator = new ProjectDeletionCoordinator(createProjects(), sessions)
     await coordinator.recoverPendingDeletions()
 
     const firstDeletion = coordinator.deleteProject('project-1')

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -23,10 +23,6 @@ type ProjectSessionDeletion = {
   listLegacyProjectSessionTombstones(): Promise<string[]>
 }
 
-type PreviewDeletion = {
-  delete(projectId: string): Promise<void>
-}
-
 type ProjectReviewDeletion = {
   deleteReviewsForProject(projectId: string): Promise<void>
 }
@@ -122,7 +118,6 @@ class ProjectDeletionCoordinator {
   constructor(
     private readonly projects: ProjectDeletionRepository,
     private readonly sessions: ProjectSessionDeletion,
-    private readonly preview: PreviewDeletion,
     private readonly reviews?: ProjectReviewDeletion,
     private readonly provenance?: ProjectProvenanceDeletion,
     private readonly permissionGrants?: ProjectPermissionGrantDeletion,
@@ -289,21 +284,12 @@ class ProjectDeletionCoordinator {
       ?.finalizeOwnerDeletion?.({ kind: 'project', projectId })
       .catch(() => undefined)
 
-    // Preview and Review rows have no Project FK cascade. Attempt both independent tails, then retain
-    // the durable intent on any failure so startup or an explicit retry can finish their cleanup.
-    const reviews = this.reviews
-    const derivedCleanup = [
-      () => this.preview.delete(projectId),
-      ...(reviews ? [() => reviews.deleteReviewsForProject(projectId)] : [])
-    ]
-    const derivedResults = await Promise.allSettled(
-      derivedCleanup.map((cleanup) => Promise.resolve().then(cleanup))
-    )
-    const derivedFailures = derivedResults.flatMap((result) =>
-      result.status === 'rejected' ? [result.reason] : []
-    )
-    if (derivedFailures.length > 0) {
-      throw new AggregateError(derivedFailures, 'Project derived cleanup failed: ' + projectId)
+    // Review rows still have no Project FK cascade. Retain the durable intent on failure so startup
+    // or an explicit retry can finish their cleanup; Preview rows are removed by the Project cascade.
+    try {
+      await this.reviews?.deleteReviewsForProject(projectId)
+    } catch (error) {
+      throw new AggregateError([error], 'Project derived cleanup failed: ' + projectId)
     }
 
     // Session deletion retains provenance, but Project deletion is terminal. This tail is replayed
@@ -328,7 +314,6 @@ class ProjectDeletionCoordinator {
 
 export { ProjectDeletionCoordinator, ProjectDeletionRecoveryLoop }
 export type {
-  PreviewDeletion,
   ProjectDeletionRecoveryLoopOptions,
   ProjectDeletionRepository,
   ProjectReviewDeletion,

--- a/src/main/projects/preview-repository.test.ts
+++ b/src/main/projects/preview-repository.test.ts
@@ -9,7 +9,7 @@ vi.mock('electron', () => ({
 }))
 
 import type { PersistedPreviewState } from '../../shared/preview-state'
-import { PreviewStateRepository } from './preview-repository'
+import { PreviewStateRepository, type PreviewStateClient } from './preview-repository'
 import { createProjectDbClient, migrateApplicationDatabase } from './prisma-client'
 
 // Matches the mocked app.getPath('home') + isPackaged resolution in storage-root.ts: with no
@@ -51,7 +51,7 @@ afterEach(async () => {
 })
 
 describe('preview state repository (integration)', () => {
-  it('rejects a late save after its project has been deleted', async () => {
+  it('treats a late save after Project deletion as a no-op without touching another Project', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-preview-'))
 
     const client = createProjectDbClient(storageRoot)
@@ -59,13 +59,60 @@ describe('preview state repository (integration)', () => {
 
     await migrateApplicationDatabase(client)
     await client.project.create({ data: { id: 'project-a', name: 'Project A' } })
+    const otherProjectUpdatedAt = new Date('2026-01-02T03:04:05Z')
+    await client.project.create({
+      data: { id: 'project-b', name: 'Project B', updatedAt: otherProjectUpdatedAt }
+    })
 
     const repository = new PreviewStateRepository(() => Promise.resolve(client))
     await repository.save('project-a', createState())
+    await repository.save(
+      'project-b',
+      createState({ panelState: 'collapsed', activeItemId: undefined, items: [] })
+    )
+    const otherProjectBefore = await client.project.findUniqueOrThrow({
+      where: { id: 'project-b' }
+    })
+    const otherPreviewBefore = await client.projectPreviewState.findUniqueOrThrow({
+      where: { projectId: 'project-b' }
+    })
     await client.project.delete({ where: { id: 'project-a' } })
 
-    await expect(repository.save('project-a', createState())).rejects.toThrow()
+    let directFailure: unknown
+    try {
+      await client.projectPreviewState.upsert({
+        where: { projectId: 'project-a' },
+        create: { projectId: 'project-a', panelState: 'open', items: '[]' },
+        update: { panelState: 'open', items: '[]' }
+      })
+    } catch (error) {
+      directFailure = error
+    }
+    expect(directFailure).toMatchObject({ code: 'P2003' })
+
+    await expect(repository.save('project-a', createState())).resolves.toBeUndefined()
     await expect(repository.get('project-a')).resolves.toBeNull()
+    await expect(client.project.findUniqueOrThrow({ where: { id: 'project-b' } })).resolves.toEqual(
+      otherProjectBefore
+    )
+    await expect(
+      client.projectPreviewState.findUniqueOrThrow({ where: { projectId: 'project-b' } })
+    ).resolves.toEqual(otherPreviewBefore)
+  })
+
+  it('swallows a raw SQLite owner FK failure but propagates unrelated write errors', async () => {
+    const upsert = vi.fn()
+    const client = {
+      projectPreviewState: { upsert }
+    } as unknown as PreviewStateClient
+    const repository = new PreviewStateRepository(() => Promise.resolve(client))
+
+    upsert.mockRejectedValueOnce(new Error('FOREIGN KEY constraint failed'))
+    await expect(repository.save('deleted-project', createState())).resolves.toBeUndefined()
+
+    const writeFailure = new Error('disk I/O error')
+    upsert.mockRejectedValueOnce(writeFailure)
+    await expect(repository.save('project-a', createState())).rejects.toBe(writeFailure)
   })
 
   it('does not update the owning Project timestamp when saving preview state', async () => {

--- a/src/main/projects/preview-repository.test.ts
+++ b/src/main/projects/preview-repository.test.ts
@@ -68,6 +68,26 @@ describe('preview state repository (integration)', () => {
     await expect(repository.get('project-a')).resolves.toBeNull()
   })
 
+  it('does not update the owning Project timestamp when saving preview state', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-preview-'))
+
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+
+    await migrateApplicationDatabase(client)
+    const updatedAt = new Date('2026-01-02T03:04:05Z')
+    await client.project.create({
+      data: { id: 'project-a', name: 'Project A', updatedAt }
+    })
+
+    const repository = new PreviewStateRepository(() => Promise.resolve(client))
+    await repository.save('project-a', createState())
+
+    await expect(
+      client.project.findUniqueOrThrow({ where: { id: 'project-a' } })
+    ).resolves.toMatchObject({ updatedAt })
+  })
+
   it('round-trips per-project preview state and deletes it', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-preview-'))
 

--- a/src/main/projects/preview-repository.test.ts
+++ b/src/main/projects/preview-repository.test.ts
@@ -51,6 +51,23 @@ afterEach(async () => {
 })
 
 describe('preview state repository (integration)', () => {
+  it('rejects a late save after its project has been deleted', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-preview-'))
+
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-a', name: 'Project A' } })
+
+    const repository = new PreviewStateRepository(() => Promise.resolve(client))
+    await repository.save('project-a', createState())
+    await client.project.delete({ where: { id: 'project-a' } })
+
+    await expect(repository.save('project-a', createState())).rejects.toThrow()
+    await expect(repository.get('project-a')).resolves.toBeNull()
+  })
+
   it('round-trips per-project preview state and deletes it', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-preview-'))
 
@@ -58,6 +75,7 @@ describe('preview state repository (integration)', () => {
     disconnect = () => client.$disconnect()
 
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-a', name: 'Project A' } })
 
     const repository = new PreviewStateRepository(() => Promise.resolve(client))
 
@@ -93,6 +111,7 @@ describe('preview state repository (integration)', () => {
     disconnect = () => client.$disconnect()
 
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-a', name: 'Project A' } })
 
     const repository = new PreviewStateRepository(() => Promise.resolve(client))
     const absolutePath = join(DATA_ROOT, 'artifacts/p/s/m/plot.png')
@@ -132,6 +151,7 @@ describe('preview state repository (integration)', () => {
     disconnect = () => client.$disconnect()
 
     await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-a', name: 'Project A' } })
 
     const state = createState()
     await client.projectPreviewState.create({

--- a/src/main/projects/preview-repository.ts
+++ b/src/main/projects/preview-repository.ts
@@ -9,7 +9,7 @@ import { decodeDataPath, encodeDataPath } from '../storage/data-path'
 
 // Only the preview-state delegate is needed; typing to this subset keeps the repository unit-testable
 // with a lightweight mock instead of a real (engine-backed) PrismaClient.
-type PreviewStateClient = Pick<PrismaClient, 'project' | 'projectPreviewState'>
+type PreviewStateClient = Pick<PrismaClient, 'projectPreviewState'>
 
 // Parses the JSON items column defensively; a corrupt value degrades to an empty preview state.
 const parseItems = (items: string): unknown => {
@@ -65,19 +65,12 @@ class PreviewStateRepository {
     }
     const client = await this.getClient()
 
-    // Writing through the parent makes Project liveness validation and the child upsert atomic.
-    // If this write wins first, a later Project delete cascades it; if deletion wins first, update
-    // rejects instead of recreating an orphan Preview row.
-    await client.project.update({
-      where: { id: projectId },
-      data: {
-        previewState: {
-          upsert: {
-            create: data,
-            update: data
-          }
-        }
-      }
+    // The owner FK is the deletion fence: if this write wins first, a later Project delete cascades
+    // it; if deletion wins first, the FK rejects this upsert without touching Project.updatedAt.
+    await client.projectPreviewState.upsert({
+      where: { projectId },
+      create: { projectId, ...data },
+      update: data
     })
   }
 

--- a/src/main/projects/preview-repository.ts
+++ b/src/main/projects/preview-repository.ts
@@ -1,4 +1,4 @@
-import type { PrismaClient } from '@prisma/client'
+import { Prisma, type PrismaClient } from '@prisma/client'
 
 import {
   PREVIEW_STATE_VERSION,
@@ -22,6 +22,10 @@ const parseItems = (items: string): unknown => {
 
 // Resolves the Prisma client on demand so a failed initialization is not held forever (see repository.ts).
 type PreviewStateClientProvider = () => Promise<PreviewStateClient>
+
+const isMissingPreviewOwnerError = (error: unknown): boolean =>
+  (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2003') ||
+  (error instanceof Error && /FOREIGN KEY constraint failed/i.test(error.message))
 
 // Owns per-project preview panel state reads/writes. The client is resolved lazily per call.
 class PreviewStateRepository {
@@ -66,12 +70,17 @@ class PreviewStateRepository {
     const client = await this.getClient()
 
     // The owner FK is the deletion fence: if this write wins first, a later Project delete cascades
-    // it; if deletion wins first, the FK rejects this upsert without touching Project.updatedAt.
-    await client.projectPreviewState.upsert({
-      where: { projectId },
-      create: { projectId, ...data },
-      update: data
-    })
+    // it; if deletion wins first, the rejected autosave is an expected no-op for renderer and Web.
+    try {
+      await client.projectPreviewState.upsert({
+        where: { projectId },
+        create: { projectId, ...data },
+        update: data
+      })
+    } catch (error) {
+      if (isMissingPreviewOwnerError(error)) return
+      throw error
+    }
   }
 
   // Removes a project's preview state (used when the project is deleted). Missing rows are ignored.

--- a/src/main/projects/preview-repository.ts
+++ b/src/main/projects/preview-repository.ts
@@ -9,7 +9,7 @@ import { decodeDataPath, encodeDataPath } from '../storage/data-path'
 
 // Only the preview-state delegate is needed; typing to this subset keeps the repository unit-testable
 // with a lightweight mock instead of a real (engine-backed) PrismaClient.
-type PreviewStateClient = Pick<PrismaClient, 'projectPreviewState'>
+type PreviewStateClient = Pick<PrismaClient, 'project' | 'projectPreviewState'>
 
 // Parses the JSON items column defensively; a corrupt value degrades to an empty preview state.
 const parseItems = (items: string): unknown => {
@@ -65,10 +65,19 @@ class PreviewStateRepository {
     }
     const client = await this.getClient()
 
-    await client.projectPreviewState.upsert({
-      where: { projectId },
-      create: { projectId, ...data },
-      update: data
+    // Writing through the parent makes Project liveness validation and the child upsert atomic.
+    // If this write wins first, a later Project delete cascades it; if deletion wins first, update
+    // rejects instead of recreating an orphan Preview row.
+    await client.project.update({
+      where: { id: projectId },
+      data: {
+        previewState: {
+          upsert: {
+            create: data,
+            update: data
+          }
+        }
+      }
     })
   }
 

--- a/src/main/projects/prisma-client.test.ts
+++ b/src/main/projects/prisma-client.test.ts
@@ -105,7 +105,8 @@ describe('project prisma client (integration)', () => {
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
         '0003_granted_local_roots',
-        '0004_review_assessment_snapshots'
+        '0004_review_assessment_snapshots',
+        '0005_project_preview_state_owner_fk'
       ]
     })
 
@@ -1012,7 +1013,8 @@ describe('project prisma client (integration)', () => {
         '0001_runtime_schema_baseline',
         '0002_project_agent_context',
         '0003_granted_local_roots',
-        '0004_review_assessment_snapshots'
+        '0004_review_assessment_snapshots',
+        '0005_project_preview_state_owner_fk'
       ]
     })
 

--- a/src/main/session-persistence/deletion-integration.test.ts
+++ b/src/main/session-persistence/deletion-integration.test.ts
@@ -214,7 +214,6 @@ describe('managed-file deletion integration', () => {
     const projectDeletion = new ProjectDeletionCoordinator(
       projects,
       coordinator,
-      { delete: vi.fn().mockResolvedValue(undefined) },
       undefined,
       provenance
     )
@@ -262,7 +261,6 @@ describe('managed-file deletion integration', () => {
     const projectDeletion = new ProjectDeletionCoordinator(
       projects,
       coordinator,
-      { delete: vi.fn().mockResolvedValue(undefined) },
       undefined,
       new ArtifactProvenanceRepository({
         storageRoot,
@@ -344,7 +342,6 @@ describe('managed-file deletion integration', () => {
     const projectDeletion = new ProjectDeletionCoordinator(
       projects,
       coordinator,
-      { delete: vi.fn().mockResolvedValue(undefined) },
       undefined,
       new ArtifactProvenanceRepository({
         storageRoot,
@@ -404,7 +401,6 @@ describe('managed-file deletion integration', () => {
     const projectDeletion = new ProjectDeletionCoordinator(
       projects,
       coordinator,
-      { delete: vi.fn().mockResolvedValue(undefined) },
       undefined,
       new ArtifactProvenanceRepository({
         storageRoot,
@@ -442,7 +438,6 @@ describe('managed-file deletion integration', () => {
     const projectDeletion = new ProjectDeletionCoordinator(
       projects,
       failingSessions,
-      { delete: vi.fn().mockResolvedValue(undefined) },
       undefined,
       new ArtifactProvenanceRepository({
         storageRoot,


### PR DESCRIPTION
## Problem

`ProjectPreviewState` had no owner foreign key, and Preview saves used a direct upsert. A renderer or Web client save that arrived after Project deletion could therefore recreate an orphan Preview row. The orphan did not recreate the Project, but it could retain stale panel state, file paths, titles, and session references indefinitely.

## Proposed change

- Make `ProjectPreviewState.projectId` an owner foreign key to `Project.id` with `ON DELETE CASCADE`.
- Keep Preview writes on the child table and use the owner FK as the deletion fence. SQLite serializes the competing writes: if save wins, a later delete cascades it; if delete wins, the FK rejects the upsert and the Preview repository treats that owner-deletion result as an expected no-op for both renderer and Web callers.
- Add immutable migration `0005_project_preview_state_owner_fk`, including FK verification and retained pre-migration backup.
- Rebuild the legacy table with an inner join so valid Preview rows are preserved and existing orphan rows are pruned.
- Remove the redundant explicit Preview cleanup tail from `ProjectDeletionCoordinator`; Review cleanup remains replayable.
- Restrict non-exact pre-ledger adoption to an explicit allowlist containing only the released Preview owner FK. Unknown, duplicate, and future suffix foreign keys remain fail-closed.

## Scope and non-goals

- No IPC payload, Web API shape, new physical data column, or new enum/state value.
- Observable autosave behavior changes only when Project deletion has already won: the stale save is silently discarded instead of surfacing a foreign-key error.
- The existing `projectId` column gains ownership semantics; no additional persisted state is introduced.
- Preview saves do not update `Project.updatedAt`.
- No attempt to recreate Projects or recover orphan Preview rows.
- No change to Review cleanup or other Project deletion tails.
- No unrelated module-impact classifier change is included.

## Historical data compatibility

- Preview rows whose `projectId` still exists are copied unchanged.
- Existing orphan Preview rows are intentionally deleted during migration.
- The migration requires and retains a pre-migration database backup for recovery if needed.
- No manual backfill is required.

## Persistence impact

This changes the persisted SQLite schema and Prisma relation model. Project deletion now owns Preview cleanup through the database cascade, and late writes are fenced by the foreign-key constraint. The repository converts only owner-missing FK failures (`P2003` or SQLite's corresponding constraint error) to a no-op; unrelated persistence errors still propagate.

## Acceptance criteria and validation

Checks after the final material edit:

- Late-save no-op, cascade behavior, deleted-row absence, unrelated Project/Preview stability, raw SQLite FK handling, and Project timestamp stability
  -> `npm test -- src/main/projects/preview-repository.test.ts`
  -> passed.
- 0005 rebuild, valid-row copy, orphan prune, retained backup, checksum-pinned adoption deferral, missing-0005 fail-closed behavior, and explicit non-exact FK allowlist
  -> `npm test -- src/main/database/migration-service.test.ts`
  -> passed.
- Packaged migration ledger/checksum coverage
  -> `npm test -- scripts/database-migration-ledger-smoke.test.ts`
  -> passed.
- Combined focused rerun
  -> `npm test -- src/main/database/migration-service.test.ts scripts/database-migration-ledger-smoke.test.ts src/main/projects/preview-repository.test.ts`
  -> 61 tests passed.
- Prisma schema and checked-in runtime DDL
  -> `npm run db:schema:check`
  -> passed.
- Changed source and tests
  -> targeted ESLint and `npm run lint`
  -> passed with 0 errors; remaining warnings are in unrelated `src/main/host-sdk/capability-projection.test.ts`.
- Project deletion coordinator
  -> `npm test -- src/main/projects/deletion-coordinator.test.ts`
  -> local collection was blocked because the shared Electron package has no installed executable; no assertion ran. PR CI remains the authoritative clean-install coverage.
- Node typecheck
  -> `npm run typecheck:node`
  -> local checkout is blocked by unrelated dependency drift in `src/main/acp/claude-agent-acp-patch.test.ts` (`waitForMcpServers` is absent from the installed package).

The previous macOS full-module shard failure was traced to the newly merged `src/main/notebook/package-manager.ts` lacking a module-impact signal on the target branch. That file is not in this PR diff, so the unrelated classifier repair is intentionally not bundled here.

## Review feedback addressed

- Non-exact baseline FK recognition is now a one-entry allowlist for `ProjectPreviewState.projectId -> Project.id` with exact cascade actions; an extra current-shaped FK on another table still fails closed.
- Late Preview owner-FK failures are expected no-ops, while unrelated persistence failures continue to reject.
- The deletion-race regression asserts the deleted Preview row stays absent and an unrelated Project and Preview row remain unchanged.
- The adoption-deferral helper is documented as a checksum-pinned 0005 exception that future suffix FKs must not copy.
- The handoff maps migration rebuild/orphan/backup, missing-0005 fail-closed behavior, schema generation, and deletion-coordinator coverage.

## Review focus

- FK-backed ordering between Preview save and Project deletion.
- Narrow classification of owner-deletion errors versus unrelated persistence errors.
- Legacy-row copy/prune semantics and retained backup policy.
- The explicit, one-entry non-exact baseline FK allowlist.