### PR TITLE
fix(reviewer): recover interrupted runs and bound results

### DIFF
--- a/src/main/reviewer/bridge-tools.ts
+++ b/src/main/reviewer/bridge-tools.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import { REVIEWER_MCP_SERVER_NAME, REVIEWER_MCP_TOOLS } from '../../shared/reviewer'
 import type { ResponsesBridgeNamespacedTool } from '../settings/responses-bridge'
-import { submitFindingsInputSchema } from './mcp-server'
+import { submitFindingsBridgeInputSchema } from './mcp-server'
 
 export const REVIEWER_BRIDGE_TOOL_NAMESPACE = `mcp__${REVIEWER_MCP_SERVER_NAME.replace(
   /[^a-zA-Z0-9_]/g,
@@ -41,7 +41,7 @@ export const REVIEWER_BRIDGE_NAMESPACED_TOOLS: ResponsesBridgeNamespacedTool[] =
     name: REVIEWER_MCP_TOOLS.submitFindings,
     description:
       'Submit at least one structured pass, warn, or fail check exactly once, then stop. An empty checks array is invalid.',
-    parameters: z.toJSONSchema(submitFindingsInputSchema, {
+    parameters: z.toJSONSchema(submitFindingsBridgeInputSchema, {
       target: 'draft-7'
     }) as ResponsesBridgeNamespacedTool['parameters']
   }

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -42,12 +42,14 @@ vi.mock('./orchestrator', () => ({
 // invoke it directly and observe which storageRoot the thunk was constructed against.
 const reviewRepositoryThunks: Array<() => unknown> = []
 const getReviewsForSession = vi.fn().mockResolvedValue([])
+const recoverInterruptedReviews = vi.fn().mockResolvedValue(0)
 vi.mock('./repository', () => ({
   ReviewRepository: class {
     constructor(thunk: () => unknown) {
       reviewRepositoryThunks.push(thunk)
     }
     getReviewsForSession = getReviewsForSession
+    recoverInterruptedReviews = recoverInterruptedReviews
     getReviewsForProjectSession = getReviewsForSession
   }
 }))
@@ -123,6 +125,8 @@ beforeEach(() => {
   // Default: the requested session exists, so triggerReview proceeds to runReview.
   sessionLoadOne.mockResolvedValue({ id: 'session-1' })
   getReviewsForSession.mockReset()
+  recoverInterruptedReviews.mockReset()
+  recoverInterruptedReviews.mockResolvedValue(0)
   // Default: no prior review for the turn, so the auto-idempotency check lets the run proceed.
   getReviewsForSession.mockResolvedValue([])
 })
@@ -130,6 +134,24 @@ beforeEach(() => {
 afterEach(() => clearMigrationPending())
 
 describe('reviewer IPC handlers', () => {
+  it('waits for startup recovery before exposing persisted reviews', async () => {
+    let finishRecovery!: (count: number) => void
+    recoverInterruptedReviews.mockImplementationOnce(
+      () =>
+        new Promise<number>((resolve) => {
+          finishRecovery = resolve
+        })
+    )
+    const owner = createReviewerCommandOwner({ acpRuntime })
+    const pendingRead = owner.getForSession({ projectId: 'project-1', appSessionId: 'session-1' })
+
+    await Promise.resolve()
+    expect(getReviewsForSession).not.toHaveBeenCalled()
+    finishRecovery(1)
+    await expect(pendingRead).resolves.toEqual([])
+    expect(recoverInterruptedReviews).toHaveBeenCalledTimes(1)
+  })
+
   it('shares one in-flight arbitration owner between direct and IPC commands', async () => {
     let finishRun: (() => void) | undefined
     let backgroundRun: Promise<void> | undefined

--- a/src/main/reviewer/ipc.test.ts
+++ b/src/main/reviewer/ipc.test.ts
@@ -152,6 +152,23 @@ describe('reviewer IPC handlers', () => {
     expect(recoverInterruptedReviews).toHaveBeenCalledTimes(1)
   })
 
+  it('retries startup recovery after a failed attempt', async () => {
+    recoverInterruptedReviews
+      .mockRejectedValueOnce(new Error('database unavailable'))
+      .mockResolvedValueOnce(0)
+    const owner = createReviewerCommandOwner({ acpRuntime })
+
+    await expect(
+      owner.getForSession({ projectId: 'project-1', appSessionId: 'session-1' })
+    ).rejects.toThrow('database unavailable')
+    expect(getReviewsForSession).not.toHaveBeenCalled()
+    await expect(
+      owner.getForSession({ projectId: 'project-1', appSessionId: 'session-1' })
+    ).resolves.toEqual([])
+
+    expect(recoverInterruptedReviews).toHaveBeenCalledTimes(2)
+  })
+
   it('shares one in-flight arbitration owner between direct and IPC commands', async () => {
     let finishRun: (() => void) | undefined
     let backgroundRun: Promise<void> | undefined

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -112,6 +112,16 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
   const storageRoot = options.storageRoot ?? resolveStorageRoot()
   const dataRoot = options.dataRoot ?? resolveDataRoot()
   const reviewRepository = createDefaultReviewRepository(storageRoot, dataRoot)
+  const startupRecovery = reviewRepository.recoverInterruptedReviews().then((count) => {
+    if (count > 0) {
+      log.warn('recovered interrupted reviews during startup', { count })
+    }
+  })
+  void startupRecovery.catch((error: unknown) => {
+    log.error('review startup recovery failed', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+  })
   const sessionRepository = new SessionRepository(storageRoot)
   const artifactProvenanceRepository =
     options.artifactProvenanceRepository ??
@@ -136,6 +146,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
   // audited turn has since changed (e.g. an artifact was edited after the review completed) so the UI
   // does not present a stale verdict as current.
   const getForSession = async (request: ReviewSessionRequest): Promise<ReviewWithChecks[]> => {
+    await startupRecovery
     const reviews = await reviewRepository.getReviewsForProjectSession(
       request.projectId,
       request.appSessionId
@@ -195,6 +206,13 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
       return finishBeforeBackground({ started: false, reason: 'already-in-flight' })
     }
     inFlightReviewKeys.add(inFlightKey)
+
+    try {
+      await startupRecovery
+    } catch (error) {
+      inFlightReviewKeys.delete(inFlightKey)
+      throw error
+    }
 
     // Atomic per-turn idempotency for auto-review. The in-flight key (reserved synchronously above)
     // serializes concurrent starts; this DB check — running while we hold that key — covers the other

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -112,16 +112,26 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
   const storageRoot = options.storageRoot ?? resolveStorageRoot()
   const dataRoot = options.dataRoot ?? resolveDataRoot()
   const reviewRepository = createDefaultReviewRepository(storageRoot, dataRoot)
-  const startupRecovery = reviewRepository.recoverInterruptedReviews().then((count) => {
-    if (count > 0) {
-      log.warn('recovered interrupted reviews during startup', { count })
-    }
-  })
-  void startupRecovery.catch((error: unknown) => {
-    log.error('review startup recovery failed', {
-      error: error instanceof Error ? error.message : String(error)
+  let recoveryGate: Promise<void> | undefined
+  const ensureRecovery = (): Promise<void> => {
+    if (recoveryGate) return recoveryGate
+    const attempt = reviewRepository.recoverInterruptedReviews().then((count) => {
+      if (count > 0) {
+        log.warn('recovered interrupted reviews', { count })
+      }
     })
-  })
+    recoveryGate = attempt
+    void attempt.catch((error: unknown) => {
+      log.error('review recovery failed', {
+        error: error instanceof Error ? error.message : String(error)
+      })
+      if (recoveryGate === attempt) {
+        recoveryGate = undefined
+      }
+    })
+    return attempt
+  }
+  void ensureRecovery()
   const sessionRepository = new SessionRepository(storageRoot)
   const artifactProvenanceRepository =
     options.artifactProvenanceRepository ??
@@ -146,7 +156,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
   // audited turn has since changed (e.g. an artifact was edited after the review completed) so the UI
   // does not present a stale verdict as current.
   const getForSession = async (request: ReviewSessionRequest): Promise<ReviewWithChecks[]> => {
-    await startupRecovery
+    await ensureRecovery()
     const reviews = await reviewRepository.getReviewsForProjectSession(
       request.projectId,
       request.appSessionId
@@ -208,7 +218,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
     inFlightReviewKeys.add(inFlightKey)
 
     try {
-      await startupRecovery
+      await ensureRecovery()
     } catch (error) {
       inFlightReviewKeys.delete(inFlightKey)
       throw error

--- a/src/main/reviewer/mcp-server.test.ts
+++ b/src/main/reviewer/mcp-server.test.ts
@@ -785,6 +785,54 @@ describe('ReviewerMcpServer HTTP transport', () => {
     }
   })
 
+  it('allows historical tracked dispositions beyond the five-new-check limit', async () => {
+    const trackedFindingIds = Array.from({ length: 6 }, (_, index) => `finding-${index + 1}`)
+    const trackedChecks = trackedFindingIds.map((sourceFindingId, index) => ({
+      sourceFindingId,
+      status: 'pass' as const,
+      claim: `Tracked finding ${index + 1} is resolved`,
+      evidence: `Verified tracked finding ${index + 1}`
+    }))
+    const runSubmission = async (
+      checks: Array<Record<string, unknown>>
+    ): Promise<{
+      result: Awaited<ReturnType<typeof callTool>>
+      onSubmit: ReturnType<typeof vi.fn>
+    }> => {
+      const onSubmit = vi.fn().mockResolvedValue(undefined)
+      const server = new ReviewerMcpServer(
+        scope,
+        onSubmit,
+        createReviewerEvidence(),
+        trackedFindingIds
+      )
+      const { endpoint, token } = await server.start()
+
+      try {
+        const { sessionId, headers } = await initialize(endpoint, token)
+        await callTool(endpoint, sessionId, headers, 'read_turn', {})
+        const result = await callTool(endpoint, sessionId, headers, 'submit_findings', { checks })
+        return { result, onSubmit }
+      } finally {
+        await server.stop()
+      }
+    }
+
+    const accepted = await runSubmission(trackedChecks)
+    expect(accepted.result.result?.isError).not.toBe(true)
+    expect(accepted.onSubmit).toHaveBeenCalledOnce()
+    expect(accepted.onSubmit.mock.calls[0]?.[0]).toHaveLength(6)
+
+    const tooManyNewChecks = Array.from({ length: 6 }, (_, index) => ({
+      ...passingCheck,
+      claim: `New finding ${index + 1}`,
+      evidence: `New evidence ${index + 1}`
+    }))
+    const rejected = await runSubmission([...trackedChecks, ...tooManyNewChecks])
+    expect(rejected.result.result?.isError).toBe(true)
+    expect(rejected.onSubmit).not.toHaveBeenCalled()
+  })
+
   it('drops a model-invented sourceFindingId during an initial review', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined)
     const server = new ReviewerMcpServer(scope, onSubmit, createReviewerEvidence())

--- a/src/main/reviewer/mcp-server.test.ts
+++ b/src/main/reviewer/mcp-server.test.ts
@@ -15,6 +15,7 @@ import {
   validateReviewerEvidenceAccess,
   ReviewerMcpServer
 } from './mcp-server'
+import { REVIEWER_BRIDGE_NAMESPACED_TOOLS } from './bridge-tools'
 import { createReviewerMcpStdioProxy } from './mcp-stdio-proxy'
 import type { TurnScope } from '../../shared/reviewer'
 import type { ArtifactContent, ExecRecord, OrderedBlock, ReviewerHostServer } from './host-sdk'
@@ -225,6 +226,20 @@ describe('mapChecksToScope', () => {
 })
 
 describe('submitFindingsInputSchema — v3 unified checks[] (no reasoning)', () => {
+  it('leaves the bridge item count to the per-run MCP schema', () => {
+    const submitFindingsTool = REVIEWER_BRIDGE_NAMESPACED_TOOLS.find(
+      (tool) => tool.name === 'submit_findings'
+    )
+    const checksSchema = (
+      submitFindingsTool?.parameters as {
+        properties?: { checks?: { minItems?: number; maxItems?: number } }
+      }
+    ).properties?.checks
+
+    expect(checksSchema?.minItems).toBe(1)
+    expect(checksSchema?.maxItems).toBeUndefined()
+  })
+
   it('accepts checks[] with status pass|warn|fail (no reasoning field)', () => {
     const parsed = submitFindingsInputSchema.safeParse({
       checks: [

--- a/src/main/reviewer/mcp-server.ts
+++ b/src/main/reviewer/mcp-server.ts
@@ -26,6 +26,13 @@ import { assertBlockInScope, type ReviewerHostServer } from './host-sdk'
 import { createLogger } from '../logger'
 import { listenForLocalRpc, localRpcServerLogFields } from '../local-rpc-transport'
 import { createReviewerMcpStdioProxyConfig } from './mcp-stdio-proxy'
+import {
+  MAX_REVIEW_CHECKS,
+  MAX_REVIEW_CLAIM_CHARACTERS,
+  MAX_REVIEW_EVIDENCE_CHARACTERS,
+  MAX_REVIEW_SUBMISSION_BYTES,
+  reviewSubmissionByteLength
+} from './submission-limits'
 
 const log = createLogger('reviewer:mcp')
 
@@ -47,10 +54,15 @@ const checkLocatorSchema = z.object({
 })
 
 const checkFields = {
-  claim: z.string().min(1).describe('The specific claim or thing being checked'),
+  claim: z
+    .string()
+    .min(1)
+    .max(MAX_REVIEW_CLAIM_CHARACTERS)
+    .describe('The specific claim or thing being checked'),
   evidence: z
     .string()
     .min(1)
+    .max(MAX_REVIEW_EVIDENCE_CHARACTERS)
     .describe(
       'Supporting evidence from the turn (cite block ids / exec-log entries / artifact content you read). ' +
         'For pass checks: describe what you verified and why it passed. ' +
@@ -93,11 +105,12 @@ const checkSchema = z.discriminatedUnion('status', [
 // v2: a single `checks[]` replaces the old findings[]+summary+checks[] split.
 // v3: reasoning removed — the reviewer log is captured from the action stream, not self-authored.
 // summary is explicitly excluded — the panel no longer shows it.
-export const submitFindingsInputSchema = z
+const submitFindingsObjectSchema = z
   .object({
     checks: z
       .array(checkSchema)
       .min(1, 'Submit at least one explicit pass, warn, or fail check.')
+      .max(MAX_REVIEW_CHECKS, `At most ${MAX_REVIEW_CHECKS} findings are allowed`)
       .describe(
         'All checks you ran, each with status pass|warn|fail, claim, and evidence. ' +
           'A locator is required for warn/fail and optional for pass. ' +
@@ -105,6 +118,21 @@ export const submitFindingsInputSchema = z
       )
   })
   .strict() // Reject unknown fields including the old `summary`, old `findings`, and old `reasoning`
+
+export const submitFindingsInputSchema = submitFindingsObjectSchema.superRefine(
+  (input, context) => {
+    const bytes = reviewSubmissionByteLength(input.checks)
+    if (bytes > MAX_REVIEW_SUBMISSION_BYTES) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['checks'],
+        message:
+          `Reviewer result exceeds the ${MAX_REVIEW_SUBMISSION_BYTES}-byte limit ` +
+          `(got ${bytes} bytes)`
+      })
+    }
+  }
+)
 
 export type SubmitFindingsInput = z.infer<typeof submitFindingsInputSchema>
 
@@ -396,7 +424,7 @@ export class ReviewerMcpServer {
           'Each check has status (pass/warn/fail), claim, and evidence; locator is required for ' +
           'warn/fail and optional for pass. ' +
           'Do NOT include a reasoning or summary field — they are no longer accepted.',
-        inputSchema: submitFindingsInputSchema.shape
+        inputSchema: submitFindingsObjectSchema.shape
       },
       async (input) => {
         // Keep the idle check and the transition to `submitting` free of awaits. JavaScript's

--- a/src/main/reviewer/mcp-server.ts
+++ b/src/main/reviewer/mcp-server.ts
@@ -105,22 +105,34 @@ const checkSchema = z.discriminatedUnion('status', [
 // v2: a single `checks[]` replaces the old findings[]+summary+checks[] split.
 // v3: reasoning removed — the reviewer log is captured from the action stream, not self-authored.
 // summary is explicitly excluded — the panel no longer shows it.
-const submitFindingsObjectSchema = z
-  .object({
-    checks: z
-      .array(checkSchema)
-      .min(1, 'Submit at least one explicit pass, warn, or fail check.')
-      .max(MAX_REVIEW_CHECKS, `At most ${MAX_REVIEW_CHECKS} findings are allowed`)
-      .describe(
-        'All checks you ran, each with status pass|warn|fail, claim, and evidence. ' +
-          'A locator is required for warn/fail and optional for pass. ' +
-          'A completed review requires at least one explicit check; an empty array is never a pass.'
-      )
-  })
-  .strict() // Reject unknown fields including the old `summary`, old `findings`, and old `reasoning`
+type SubmitFindingsObjectSchema = z.ZodObject<{
+  checks: z.ZodArray<typeof checkSchema>
+}>
 
-export const submitFindingsInputSchema = submitFindingsObjectSchema.superRefine(
-  (input, context) => {
+export type SubmitFindingsInput = z.infer<SubmitFindingsObjectSchema>
+
+const createSubmitFindingsObjectSchema = (trackedCheckAllowance = 0): SubmitFindingsObjectSchema =>
+  z
+    .object({
+      checks: z
+        .array(checkSchema)
+        .min(1, 'Submit at least one explicit pass, warn, or fail check.')
+        .max(
+          MAX_REVIEW_CHECKS + trackedCheckAllowance,
+          `At most ${MAX_REVIEW_CHECKS} new findings are allowed beyond tracked dispositions`
+        )
+        .describe(
+          'All checks you ran, each with status pass|warn|fail, claim, and evidence. ' +
+            'A locator is required for warn/fail and optional for pass. ' +
+            'A completed review requires at least one explicit check; an empty array is never a pass.'
+        )
+    })
+    .strict() // Reject unknown fields including the old `summary`, old `findings`, and old `reasoning`
+
+const createSubmitFindingsInputSchema = (
+  trackedCheckAllowance = 0
+): z.ZodType<SubmitFindingsInput> =>
+  createSubmitFindingsObjectSchema(trackedCheckAllowance).superRefine((input, context) => {
     const bytes = reviewSubmissionByteLength(input.checks)
     if (bytes > MAX_REVIEW_SUBMISSION_BYTES) {
       context.addIssue({
@@ -131,10 +143,9 @@ export const submitFindingsInputSchema = submitFindingsObjectSchema.superRefine(
           `(got ${bytes} bytes)`
       })
     }
-  }
-)
+  })
 
-export type SubmitFindingsInput = z.infer<typeof submitFindingsInputSchema>
+export const submitFindingsInputSchema = createSubmitFindingsInputSchema()
 
 export type ReviewerEvidenceAccessLedger = {
   turnRead: boolean
@@ -342,6 +353,10 @@ export class ReviewerMcpServer {
       name: REVIEWER_MCP_SERVER_NAME,
       version: '1.0.0'
     })
+
+    const trackedCheckAllowance = this.trackedFindingIds.size
+    const submitFindingsObjectSchema = createSubmitFindingsObjectSchema(trackedCheckAllowance)
+    const submitFindingsInputSchema = createSubmitFindingsInputSchema(trackedCheckAllowance)
 
     const evidence = this.evidence
     if (evidence) {

--- a/src/main/reviewer/mcp-server.ts
+++ b/src/main/reviewer/mcp-server.ts
@@ -111,23 +111,30 @@ type SubmitFindingsObjectSchema = z.ZodObject<{
 
 export type SubmitFindingsInput = z.infer<SubmitFindingsObjectSchema>
 
-const createSubmitFindingsObjectSchema = (trackedCheckAllowance = 0): SubmitFindingsObjectSchema =>
-  z
-    .object({
-      checks: z
-        .array(checkSchema)
-        .min(1, 'Submit at least one explicit pass, warn, or fail check.')
-        .max(
+const createSubmitFindingsObjectSchema = (
+  trackedCheckAllowance: number | null = 0
+): SubmitFindingsObjectSchema => {
+  const checksSchema = z
+    .array(checkSchema)
+    .min(1, 'Submit at least one explicit pass, warn, or fail check.')
+  const boundedChecksSchema =
+    trackedCheckAllowance === null
+      ? checksSchema
+      : checksSchema.max(
           MAX_REVIEW_CHECKS + trackedCheckAllowance,
           `At most ${MAX_REVIEW_CHECKS} new findings are allowed beyond tracked dispositions`
         )
-        .describe(
-          'All checks you ran, each with status pass|warn|fail, claim, and evidence. ' +
-            'A locator is required for warn/fail and optional for pass. ' +
-            'A completed review requires at least one explicit check; an empty array is never a pass.'
-        )
+
+  return z
+    .object({
+      checks: boundedChecksSchema.describe(
+        'All checks you ran, each with status pass|warn|fail, claim, and evidence. ' +
+          'A locator is required for warn/fail and optional for pass. ' +
+          'A completed review requires at least one explicit check; an empty array is never a pass.'
+      )
     })
     .strict() // Reject unknown fields including the old `summary`, old `findings`, and old `reasoning`
+}
 
 const createSubmitFindingsInputSchema = (
   trackedCheckAllowance = 0
@@ -146,6 +153,7 @@ const createSubmitFindingsInputSchema = (
   })
 
 export const submitFindingsInputSchema = createSubmitFindingsInputSchema()
+export const submitFindingsBridgeInputSchema = createSubmitFindingsObjectSchema(null)
 
 export type ReviewerEvidenceAccessLedger = {
   turnRead: boolean

--- a/src/main/reviewer/repository.test.ts
+++ b/src/main/reviewer/repository.test.ts
@@ -460,6 +460,56 @@ describe('review repository (integration)', () => {
     ).rejects.toThrow(/Tracked Finding is unavailable/i)
   })
 
+  it('commits more than five historical tracked dispositions in one re-review', async () => {
+    const repository = await createRepository()
+    const sourceReview = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-history-limit',
+      turnMessageId: 'a1',
+      scope: scope('a1')
+    })
+    await client!.finding.createMany({
+      data: Array.from({ length: 6 }, (_, index) => ({
+        reviewId: sourceReview.id,
+        status: 'warn',
+        resolution: 'open',
+        claim: `Historical finding ${index + 1}`,
+        evidence: `Historical evidence ${index + 1}`,
+        locator: '{}',
+        sortIndex: index
+      }))
+    })
+    const source = (
+      await repository.getReviewsForProjectSession('project-1', 'session-history-limit')
+    ).find((review) => review.id === sourceReview.id)!
+    const assessmentReview = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-history-limit',
+      turnMessageId: 'a1',
+      scope: scope('a1')
+    })
+
+    const committed = await repository.commitScopedSubmission({
+      reviewId: assessmentReview.id,
+      checks: source.checks.map((finding, index) => ({
+        status: 'pass' as const,
+        claim: `Historical finding ${index + 1} is resolved`,
+        evidence: `Verified historical finding ${index + 1}`,
+        sourceFindingId: finding.id
+      })),
+      expectedSourceFindingIds: source.checks.map((finding) => finding.id),
+      outcome: 'pass'
+    })
+
+    expect(committed).toMatchObject({ lifecycle: 'complete', outcome: 'pass' })
+    expect(committed.submittedChecks).toHaveLength(6)
+    expect(committed.checks).toEqual([])
+    const reloadedSource = (
+      await repository.getReviewsForProjectSession('project-1', 'session-history-limit')
+    ).find((review) => review.id === sourceReview.id)
+    expect(reloadedSource?.checks.every((finding) => finding.resolution === 'resolved')).toBe(true)
+  })
+
   it('rolls back a scoped submission when any tracked disposition is invalid', async () => {
     const repository = await createRepository()
     const assessmentReview = await repository.createReview({

--- a/src/main/reviewer/repository.ts
+++ b/src/main/reviewer/repository.ts
@@ -22,6 +22,10 @@ import type {
   UpdateReviewPatch
 } from '../../shared/reviewer'
 import { loadReviewSubmissionProjection, toReviewCheck } from './review-submission-read-model'
+import { assertReviewSubmissionWithinLimits } from './submission-limits'
+
+const REVIEW_INTERRUPTED_ON_STARTUP_MESSAGE =
+  'Review was interrupted because Open Science exited before it completed.'
 
 // Legacy alias for callers still using FindingSeverity (now CheckStatus).
 type FindingSeverity = CheckStatus
@@ -179,6 +183,19 @@ class ReviewRepository {
     private readonly options: ReviewRepositoryOptions = {}
   ) {}
 
+  async recoverInterruptedReviews(): Promise<number> {
+    const client = await this.getClient()
+    const result = await client.review.updateMany({
+      where: { lifecycle: 'running' },
+      data: {
+        lifecycle: 'error',
+        outcome: null,
+        errorMessage: REVIEW_INTERRUPTED_ON_STARTUP_MESSAGE
+      }
+    })
+    return result.count
+  }
+
   // Inserts a new review, defaulting a fresh audit to the 'running' lifecycle with no outcome yet.
   async createReview(input: CreateReviewInput): Promise<Review> {
     const client = await this.getClient()
@@ -304,6 +321,7 @@ class ReviewRepository {
   // Appends checks under a review, defaulting resolution to 'open' and preserving caller sort order.
   async addChecks(reviewId: string, checks: NewCheck[]): Promise<void> {
     if (checks.length === 0) return
+    assertReviewSubmissionWithinLimits(checks)
 
     const client = await this.getClient()
 
@@ -352,6 +370,7 @@ class ReviewRepository {
     if (input.checks.length === 0) {
       throw new Error('A completed Review submission requires at least one explicit check.')
     }
+    assertReviewSubmissionWithinLimits(input.checks)
     const trackedFindingIds = input.checks.flatMap((check) =>
       check.sourceFindingId ? [check.sourceFindingId] : []
     )
@@ -835,7 +854,7 @@ class ReviewRepository {
   }
 }
 
-export { ReviewRepository, toReview }
+export { REVIEW_INTERRUPTED_ON_STARTUP_MESSAGE, ReviewRepository, toReview }
 export type { ReviewClient, ReviewClientProvider, ReviewRepositoryOptions, FindingSeverity }
 
 // Legacy exports kept for callers that still reference toFinding.

--- a/src/main/reviewer/repository.ts
+++ b/src/main/reviewer/repository.ts
@@ -370,7 +370,7 @@ class ReviewRepository {
     if (input.checks.length === 0) {
       throw new Error('A completed Review submission requires at least one explicit check.')
     }
-    assertReviewSubmissionWithinLimits(input.checks)
+    assertReviewSubmissionWithinLimits(input.checks, input.expectedSourceFindingIds.length)
     const trackedFindingIds = input.checks.flatMap((check) =>
       check.sourceFindingId ? [check.sourceFindingId] : []
     )

--- a/src/main/reviewer/reviewer-resilience.test.ts
+++ b/src/main/reviewer/reviewer-resilience.test.ts
@@ -1,0 +1,102 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { disconnectProjectDbClient, getProjectDbClient } from '../projects/prisma-client'
+import { submitFindingsInputSchema } from './mcp-server'
+import { REVIEW_INTERRUPTED_ON_STARTUP_MESSAGE, ReviewRepository } from './repository'
+import {
+  MAX_REVIEW_CLAIM_CHARACTERS,
+  MAX_REVIEW_EVIDENCE_CHARACTERS,
+  MAX_REVIEW_SUBMISSION_BYTES
+} from './submission-limits'
+
+let storageRoot: string | undefined
+
+const check = {
+  status: 'pass' as const,
+  claim: 'claim',
+  evidence: 'evidence'
+}
+
+afterEach(async () => {
+  await disconnectProjectDbClient()
+  if (storageRoot) await rm(storageRoot, { recursive: true, force: true })
+  storageRoot = undefined
+})
+
+describe('Reviewer resilience', () => {
+  it('recovers a running Review as an error', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-reviewer-restart-'))
+    const repository = new ReviewRepository(() => getProjectDbClient(storageRoot!))
+    await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      turnMessageId: 'turn-1',
+      scope: { turnMessageId: 'turn-1', blocks: [], artifactVersionIds: [] }
+    })
+
+    expect(await repository.recoverInterruptedReviews()).toBe(1)
+    const [restored] = await repository.getReviewsForProjectSession('project-1', 'session-1')
+    expect(restored).toMatchObject({
+      lifecycle: 'error',
+      outcome: null,
+      errorMessage: REVIEW_INTERRUPTED_ON_STARTUP_MESSAGE
+    })
+  })
+
+  it('accepts no more than three checks in one Reviewer result', () => {
+    expect(submitFindingsInputSchema.safeParse({ checks: [check, check, check] }).success).toBe(
+      true
+    )
+    expect(
+      submitFindingsInputSchema.safeParse({ checks: [check, check, check, check] }).success
+    ).toBe(false)
+  })
+
+  it('bounds claim and evidence fields', () => {
+    expect(
+      submitFindingsInputSchema.safeParse({
+        checks: [{ ...check, claim: 'c'.repeat(MAX_REVIEW_CLAIM_CHARACTERS + 1) }]
+      }).success
+    ).toBe(false)
+    expect(
+      submitFindingsInputSchema.safeParse({
+        checks: [{ ...check, evidence: 'e'.repeat(MAX_REVIEW_EVIDENCE_CHARACTERS + 1) }]
+      }).success
+    ).toBe(false)
+  })
+
+  it('bounds the total serialized UTF-8 result size', () => {
+    expect(
+      submitFindingsInputSchema.safeParse({
+        checks: [
+          {
+            ...check,
+            locator: {
+              blockRef: { blockIndex: 0 },
+              contentHash: 'h'.repeat(MAX_REVIEW_SUBMISSION_BYTES)
+            }
+          }
+        ]
+      }).success
+    ).toBe(false)
+  })
+
+  it('rejects oversized submissions at the repository persistence boundary', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-reviewer-limits-'))
+    const repository = new ReviewRepository(() => getProjectDbClient(storageRoot!))
+    const review = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      turnMessageId: 'turn-1',
+      scope: { turnMessageId: 'turn-1', blocks: [], artifactVersionIds: [] }
+    })
+
+    await expect(repository.addChecks(review.id, [check, check, check, check])).rejects.toThrow(
+      'at most 3 checks'
+    )
+  })
+})

--- a/src/main/reviewer/reviewer-resilience.test.ts
+++ b/src/main/reviewer/reviewer-resilience.test.ts
@@ -47,12 +47,13 @@ describe('Reviewer resilience', () => {
     })
   })
 
-  it('accepts no more than three checks in one Reviewer result', () => {
-    expect(submitFindingsInputSchema.safeParse({ checks: [check, check, check] }).success).toBe(
-      true
-    )
+  it('accepts no more than five checks in one Reviewer result', () => {
     expect(
-      submitFindingsInputSchema.safeParse({ checks: [check, check, check, check] }).success
+      submitFindingsInputSchema.safeParse({ checks: [check, check, check, check, check] }).success
+    ).toBe(true)
+    expect(
+      submitFindingsInputSchema.safeParse({ checks: [check, check, check, check, check, check] })
+        .success
     ).toBe(false)
   })
 
@@ -95,8 +96,8 @@ describe('Reviewer resilience', () => {
       scope: { turnMessageId: 'turn-1', blocks: [], artifactVersionIds: [] }
     })
 
-    await expect(repository.addChecks(review.id, [check, check, check, check])).rejects.toThrow(
-      'at most 3 checks'
-    )
+    await expect(
+      repository.addChecks(review.id, [check, check, check, check, check, check])
+    ).rejects.toThrow('at most 5 checks')
   })
 })

--- a/src/main/reviewer/submission-limits.ts
+++ b/src/main/reviewer/submission-limits.ts
@@ -1,0 +1,44 @@
+import { Buffer } from 'node:buffer'
+
+import type { NewCheck } from '../../shared/reviewer'
+
+export const MAX_REVIEW_CHECKS = 3
+export const MAX_REVIEW_CLAIM_CHARACTERS = 4_096
+export const MAX_REVIEW_EVIDENCE_CHARACTERS = 16_384
+export const MAX_REVIEW_SUBMISSION_BYTES = 256 * 1_024
+
+type PersistableReviewCheck = Pick<NewCheck, 'claim' | 'evidence'> &
+  Partial<Omit<NewCheck, 'claim' | 'evidence'>>
+
+export const reviewSubmissionByteLength = (checks: readonly unknown[]): number =>
+  Buffer.byteLength(JSON.stringify({ checks }), 'utf8')
+
+const assertReviewSubmissionWithinLimits = (checks: readonly PersistableReviewCheck[]): void => {
+  if (checks.length > MAX_REVIEW_CHECKS) {
+    throw new RangeError(
+      `A Reviewer result may contain at most ${MAX_REVIEW_CHECKS} checks (got ${checks.length}).`
+    )
+  }
+
+  for (const check of checks) {
+    if (check.claim.length > MAX_REVIEW_CLAIM_CHARACTERS) {
+      throw new RangeError(
+        `A Reviewer claim may contain at most ${MAX_REVIEW_CLAIM_CHARACTERS} characters.`
+      )
+    }
+    if (check.evidence.length > MAX_REVIEW_EVIDENCE_CHARACTERS) {
+      throw new RangeError(
+        `Reviewer evidence may contain at most ${MAX_REVIEW_EVIDENCE_CHARACTERS} characters.`
+      )
+    }
+  }
+
+  const bytes = reviewSubmissionByteLength(checks)
+  if (bytes > MAX_REVIEW_SUBMISSION_BYTES) {
+    throw new RangeError(
+      `A Reviewer result may contain at most ${MAX_REVIEW_SUBMISSION_BYTES} serialized UTF-8 bytes (got ${bytes}).`
+    )
+  }
+}
+
+export { assertReviewSubmissionWithinLimits }

--- a/src/main/reviewer/submission-limits.ts
+++ b/src/main/reviewer/submission-limits.ts
@@ -2,7 +2,7 @@ import { Buffer } from 'node:buffer'
 
 import type { NewCheck } from '../../shared/reviewer'
 
-export const MAX_REVIEW_CHECKS = 3
+export const MAX_REVIEW_CHECKS = 5
 export const MAX_REVIEW_CLAIM_CHARACTERS = 4_096
 export const MAX_REVIEW_EVIDENCE_CHARACTERS = 16_384
 export const MAX_REVIEW_SUBMISSION_BYTES = 256 * 1_024

--- a/src/main/reviewer/submission-limits.ts
+++ b/src/main/reviewer/submission-limits.ts
@@ -13,10 +13,16 @@ type PersistableReviewCheck = Pick<NewCheck, 'claim' | 'evidence'> &
 export const reviewSubmissionByteLength = (checks: readonly unknown[]): number =>
   Buffer.byteLength(JSON.stringify({ checks }), 'utf8')
 
-const assertReviewSubmissionWithinLimits = (checks: readonly PersistableReviewCheck[]): void => {
-  if (checks.length > MAX_REVIEW_CHECKS) {
+// Required tracked dispositions expand only the item-count allowance; field and byte limits still
+// apply to the complete re-review submission.
+const assertReviewSubmissionWithinLimits = (
+  checks: readonly PersistableReviewCheck[],
+  trackedCheckAllowance = 0
+): void => {
+  const maxChecks = MAX_REVIEW_CHECKS + trackedCheckAllowance
+  if (checks.length > maxChecks) {
     throw new RangeError(
-      `A Reviewer result may contain at most ${MAX_REVIEW_CHECKS} checks (got ${checks.length}).`
+      `A Reviewer result may contain at most ${maxChecks} checks (got ${checks.length}).`
     )
   }
 

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -429,6 +429,7 @@
   "Could not load project artifacts.": "无法加载项目产物。",
   "Could not load project files": "无法加载项目文件",
   "Could not load projects: {{error}}": "无法加载项目：{{error}}",
+  "Could not load review history.": "无法加载审查历史。",
   "Could not mark as read. Try again.": "无法标记为已读。请重试。",
   "Could not mark this completed session as read. Try again.": "无法将此已完成的会话标记为已读。请重试。",
   "Could not open the log file.": "无法打开日志文件。",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -428,6 +428,7 @@
   "Could not load project artifacts.": "無法載入專案產物。",
   "Could not load project files": "無法載入專案檔案",
   "Could not load projects: {{error}}": "無法載入專案：{{error}}",
+  "Could not load review history.": "無法載入審查歷史。",
   "Could not mark as read. Try again.": "無法標記為已讀。請重試。",
   "Could not mark this completed session as read. Try again.": "無法將此已完成的工作階段標記為已讀。請重試。",
   "Could not open the log file.": "無法開啟記錄檔。",

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -13,6 +13,8 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { ToolActivityDetails } from './workspace-tool-activity-details'
 
+const reviewStoreMock = vi.hoisted(() => ({ loadError: undefined as string | undefined }))
+
 vi.mock('./WorkspaceRunMarks', () => ({
   WorkspaceRunMarks: ({ items }: { items: readonly unknown[] }) => (
     <div data-testid="workspace-run-marks" data-item-count={items.length} />
@@ -98,6 +100,7 @@ vi.mock('@/stores/preview-workbench-store', () => ({
 
 vi.mock('@/stores/review-store', () => ({
   selectProjectSessionReviews: () => [],
+  selectProjectSessionReviewLoadError: () => reviewStoreMock.loadError,
   selectReviewRunsForMessage: () => [],
   useReviewStore: (
     selector: (state: {
@@ -221,6 +224,22 @@ describe('WorkspaceMessageScroller Run Marks render', () => {
       })
     )
     expect(twoRuns).toContain('data-item-count="3"')
+  })
+})
+
+describe('WorkspaceMessageScroller Reviewer load error', () => {
+  it('renders an alert with a retry action', async () => {
+    reviewStoreMock.loadError = 'db down'
+    let html: string
+    try {
+      html = await renderScroller(createSession())
+    } finally {
+      reviewStoreMock.loadError = undefined
+    }
+
+    expect(html).toContain('role="alert"')
+    expect(html).toContain('Could not load review history.')
+    expect(html).toContain('Retry')
   })
 })
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -232,7 +232,7 @@ describe('WorkspaceMessageScroller Reviewer load error', () => {
     reviewStoreMock.loadError = 'db down'
     let html: string
     try {
-      html = await renderScroller(createSession())
+      html = await renderScroller(createSession({}))
     } finally {
       reviewStoreMock.loadError = undefined
     }

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/stores/preview-workbench-store'
 import {
   selectProjectSessionReviews,
+  selectProjectSessionReviewLoadError,
   selectReviewRunsForMessage,
   useReviewStore
 } from '@/stores/review-store'
@@ -50,6 +51,7 @@ import { CompletedJobCard } from '@/components/CompletedJobCard'
 import { JobDetailModal } from '@/components/JobDetailModal'
 import { extractJobIdFromActivity } from '@/components/job-binding-utils'
 import { MessageScrollerItem } from '@/components/ui/message-scroller'
+import { Button } from '@/components/ui/button'
 import { ReviewerCard } from '@/components/ReviewerCard'
 import { WorkspaceActivityGroup } from './WorkspaceActivityGroup'
 import { WorkspaceContextCompactionActivityRow } from './WorkspaceContextCompactionActivityRow'
@@ -376,6 +378,13 @@ const WorkspaceMessageScrollerImpl = ({
     return () => stop?.()
   }, [])
   const loadReviewsForSession = useReviewStore((state) => state.loadReviewsForSession)
+  const reviewLoadError = useReviewStore((state) =>
+    selectProjectSessionReviewLoadError(
+      state.loadErrorsBySession,
+      currentProjectId,
+      currentSessionId
+    )
+  )
 
   // Job store for binding and CompletedJobCard rendering
   const jobsById = useSessionJobStore((s) => s.jobsById)
@@ -995,6 +1004,31 @@ const WorkspaceMessageScrollerImpl = ({
               ref={messageScrollerContentRef}
               className="mx-auto w-full max-w-4xl gap-0 px-4 pb-[56px]"
             >
+              {reviewLoadError ? (
+                <MessageScrollerItem
+                  messageId={`review-load-error-${currentSessionId ?? 'unknown'}`}
+                  className="min-w-0"
+                >
+                  <div
+                    role="alert"
+                    className="mx-4 mb-2 flex items-center justify-between gap-3 rounded-lg bg-danger-900 px-3 py-2 text-xs text-danger-000 ring-1 ring-inset ring-danger-000/25 md:mx-6"
+                  >
+                    <span>{t('Could not load review history.')}</span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="xs"
+                      onClick={() => {
+                        if (currentSessionId) {
+                          void loadReviewsForSession(currentSessionId, currentProjectId)
+                        }
+                      }}
+                    >
+                      {t('Retry')}
+                    </Button>
+                  </div>
+                </MessageScrollerItem>
+              ) : null}
               <VisibleMessageSnapshotCommit
                 scopeId={currentPresentationScopeId}
                 messageIdsKey={visibleMessageIdsKey}

--- a/src/renderer/src/stores/review-store.test.ts
+++ b/src/renderer/src/stores/review-store.test.ts
@@ -4,6 +4,7 @@ import type { ReviewCheck, ReviewWithChecks, TurnScope } from '../../../shared/r
 import {
   createInitialReviewState,
   selectReviewRunsForMessage,
+  selectProjectSessionReviewLoadError,
   useReviewStore
 } from './review-store'
 
@@ -194,14 +195,37 @@ describe('review store', () => {
     vi.unstubAllGlobals()
   })
 
-  it('swallows load errors and leaves the session without reviews', async () => {
-    const getForSession = vi.fn().mockRejectedValue(new Error('db down'))
+  it('records load errors, preserves cached reviews, and clears the error after retry', async () => {
+    const cached = makeReview({ id: 'cached-1' })
+    useReviewStore.getState().handleReviewUpdate({ review: cached })
+    const getForSession = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('db down'))
+      .mockResolvedValueOnce([cached])
     vi.stubGlobal('window', { api: { reviewer: { getForSession } } })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
 
     await expect(
       useReviewStore.getState().loadReviewsForSession('session-1', 'project-1')
     ).resolves.toBeUndefined()
-    expect(useReviewStore.getState().getReviewsForSession('session-1')).toEqual([])
+    const failedState = useReviewStore.getState()
+    expect(failedState.getReviewsForSession('session-1').map((review) => review.id)).toEqual([
+      'cached-1'
+    ])
+    expect(
+      selectProjectSessionReviewLoadError(failedState.loadErrorsBySession, 'project-1', 'session-1')
+    ).toBe('db down')
+    expect(consoleError).toHaveBeenCalledWith('Failed to load review history:', expect.any(Error))
+
+    await useReviewStore.getState().loadReviewsForSession('session-1', 'project-1')
+    expect(
+      selectProjectSessionReviewLoadError(
+        useReviewStore.getState().loadErrorsBySession,
+        'project-1',
+        'session-1'
+      )
+    ).toBeUndefined()
+    consoleError.mockRestore()
     vi.unstubAllGlobals()
   })
 

--- a/src/renderer/src/stores/review-store.ts
+++ b/src/renderer/src/stores/review-store.ts
@@ -8,6 +8,7 @@ import type { ReviewWithChecks, ReviewUpdateEvent } from '../../../shared/review
 type ReviewStoreData = {
   // Map from projectId + sessionId to that session's reviews (newest first).
   reviewsBySession: Record<string, ReviewWithChecks[]>
+  loadErrorsBySession: Record<string, string>
 }
 
 type ReviewStore = ReviewStoreData & {
@@ -73,7 +74,8 @@ const mergeLoadedReviews = (
 }
 
 export const createInitialReviewState = (): ReviewStoreData => ({
-  reviewsBySession: {}
+  reviewsBySession: {},
+  loadErrorsBySession: {}
 })
 
 // Session ids with a load in flight, so repeated focus events don't launch overlapping loads. Kept
@@ -93,6 +95,15 @@ export const selectProjectSessionReviews = (
 ): ReviewWithChecks[] => {
   if (!sessionId) return EMPTY_REVIEWS
   return reviewsBySession[reviewSessionKey(projectId ?? '', sessionId)] ?? EMPTY_REVIEWS
+}
+
+export const selectProjectSessionReviewLoadError = (
+  loadErrorsBySession: Record<string, string>,
+  projectId: string | undefined,
+  sessionId: string | undefined
+): string | undefined => {
+  if (!sessionId) return undefined
+  return loadErrorsBySession[reviewSessionKey(projectId ?? '', sessionId)]
 }
 
 export const selectReviewRunsForMessage = (
@@ -138,14 +149,26 @@ export const useReviewStore = create<ReviewStore>((set, get) => ({
         appSessionId: sessionId
       })) as ReviewWithChecks[]
       // Merge (not replace): a slow load must not overwrite a newer review a push delivered meanwhile.
+      set((state) => {
+        const loadErrorsBySession = { ...state.loadErrorsBySession }
+        delete loadErrorsBySession[key]
+        return {
+          reviewsBySession: {
+            ...state.reviewsBySession,
+            [key]: mergeLoadedReviews(state.reviewsBySession[key] ?? [], reviews)
+          },
+          loadErrorsBySession
+        }
+      })
+    } catch (error) {
+      console.error('Failed to load review history:', error)
+      const message = error instanceof Error ? error.message : String(error)
       set((state) => ({
-        reviewsBySession: {
-          ...state.reviewsBySession,
-          [key]: mergeLoadedReviews(state.reviewsBySession[key] ?? [], reviews)
+        loadErrorsBySession: {
+          ...state.loadErrorsBySession,
+          [key]: message
         }
       }))
-    } catch {
-      // Silently ignore load errors — the card will just not appear until next push event.
     } finally {
       loadsInFlight.delete(key)
     }


### PR DESCRIPTION
## Problem

A hard Reviewer process/app interruption can leave a durable Review in `running` forever. Renderer load failures were silently discarded, and one `submit_findings` result had no count, field-size, or total-byte boundary.

## Proposed change

- Reconcile every durable `running` Review to the existing `error` lifecycle before Reviewer reads or starts new work.
- Enforce one Reviewer result as 1–5 checks, with 4,096-character claims, 16,384-character evidence, and a 256 KiB serialized UTF-8 ceiling.
- Apply the same limits at the MCP schema and repository persistence boundaries.
- Preserve cached review data when renderer loading fails, log the failure, and show a localized alert with a Retry action.

## Scope and non-goals

- No database columns, tables, constraints, migrations, or shared data-model fields are added.
- No lifecycle enum value is added; recovery uses the existing `error` state.
- Existing terminal or oversized historical records remain readable and are not truncated or migrated.
- Existing historical `running` rows are durably changed to `error` on the next startup.
- A historical re-review that requires more than five tracked checks can no longer submit one result under the new contract. This is the deliberate compatibility boundary for the strict five-check result limit.
- No full local `npm test` run; PR CI is authoritative for the complete and platform-selected suites.

## Acceptance criteria and validation

All listed successful checks ran after the final production-code edit.

- Startup recovery and the read barrier → Reviewer resilience + IPC tests → passed.
- MCP and repository limits → Reviewer MCP/repository/resilience tests → passed.
- Renderer error preservation and retry surface → review-store + MessageScroller render tests → passed.
- Translations → i18n resources guard → passed.
- Combined focused set: 7 files / 240 tests passed.
- Final MessageScroller SSR test after its test-only assertion was added: 65 tests passed.
- Node and web TypeScript checks passed.
- ESLint on all changed TypeScript/TSX files passed after fixing its only formatting warning; the final SSR test edit was subsequently Prettier-formatted and exercised by Vitest.

The project module runner produced the expected `reviewer_orchestrator` plan but failed before test execution with Windows `spawnSync npm.cmd EINVAL`. The existing local dependency tree then became unavailable, so the wider CodeGraph-indicated indirect consumers were left to PR Gate/CI. Locally uncovered risks are those indirect consumer lanes and cross-platform startup/persistence behavior.

## Review focus

- Recovery is atomic, idempotent, and blocks Reviewer reads/new runs if reconciliation fails.
- The five-check boundary is enforced before any persistence path.
- Renderer errors are session-scoped and successful retry clears only that session's error.
