### PR TITLE
fix(settings): recover rejected optimistic actions

### DIFF
--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -460,6 +460,7 @@
   "Could not sign in to Codex.": "无法登录 Codex。",
   "Could not sign out of Claude.": "无法退出 Claude。",
   "Could not sign out of Codex.": "无法退出 Codex。",
+  "Could not submit this approval. Try again.": "无法提交此批准。请重试。",
   "Could not switch to this folder.": "无法切换到该文件夹。",
   "Could not switch to {{name}}": "无法切换到 {{name}}",
   "Could not test the provider connection.": "无法测试模型服务商连接。",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -459,6 +459,7 @@
   "Could not sign in to Codex.": "無法登入 Codex。",
   "Could not sign out of Claude.": "無法登出 Claude。",
   "Could not sign out of Codex.": "無法登出 Codex。",
+  "Could not submit this approval. Try again.": "無法提交此核准。請重試。",
   "Could not switch to this folder.": "無法切換到該資料夾。",
   "Could not switch to {{name}}": "無法切換到 {{name}}",
   "Could not test the provider connection.": "無法測試模型服務商連線。",

--- a/src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx
@@ -227,4 +227,49 @@ describe('ConnectorApprovalDialog', () => {
     act(() => button('Deny')?.click())
     expect(useSettingsStore.getState().respondApproval).toHaveBeenCalledWith('r1', 'deny')
   })
+
+  it('disables decisions while submitting and keeps a failed response retryable', async () => {
+    let rejectResponse!: (error: Error) => void
+    const respondApproval = vi
+      .fn()
+      .mockReturnValueOnce(
+        new Promise<void>((_, reject) => {
+          rejectResponse = reject
+        })
+      )
+      .mockResolvedValueOnce(undefined)
+    useSettingsStore.setState({
+      pendingApprovals: [
+        {
+          id: 'r1',
+          connector: 'biomart',
+          method: 'get_data',
+          argsPreview: '{}',
+          availableScopes: ['once', 'session']
+        }
+      ],
+      respondApproval
+    })
+    act(() => root.render(<ConnectorApprovalDialog />))
+
+    act(() => button('Allow once')?.click())
+
+    expect(button('Deny')?.disabled).toBe(true)
+    expect(button('This session')?.disabled).toBe(true)
+    expect(button('Allow once')?.disabled).toBe(true)
+    expect(document.body.querySelector('[role="dialog"]')?.getAttribute('aria-busy')).toBe('true')
+
+    await act(async () => {
+      rejectResponse(new Error('IPC unavailable'))
+      await Promise.resolve()
+    })
+
+    expect(document.body.querySelector('[role="alert"]')?.textContent).toContain(
+      'Could not submit this approval. Try again.'
+    )
+    expect(button('Allow once')?.disabled).toBe(false)
+
+    act(() => button('Allow once')?.click())
+    expect(respondApproval).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx
@@ -2,6 +2,7 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ConnectorApprovalRequest } from '../../../../shared/settings'
 
 import { ConnectorApprovalDialog } from './ConnectorApprovalDialog'
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
@@ -271,5 +272,44 @@ describe('ConnectorApprovalDialog', () => {
 
     act(() => button('Allow once')?.click())
     expect(respondApproval).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not carry a response failure to the next queued approval', async () => {
+    let rejectResponse!: (error: Error) => void
+    const respondApproval = vi.fn().mockReturnValue(
+      new Promise<void>((_, reject) => {
+        rejectResponse = reject
+      })
+    )
+    const nextRequest: ConnectorApprovalRequest = {
+      id: 'r2',
+      connector: 'pubmed',
+      method: 'search',
+      argsPreview: '{}',
+      availableScopes: ['once']
+    }
+    useSettingsStore.setState({
+      pendingApprovals: [
+        {
+          id: 'r1',
+          connector: 'biomart',
+          method: 'get_data',
+          argsPreview: '{}',
+          availableScopes: ['once']
+        }
+      ],
+      respondApproval
+    })
+    act(() => root.render(<ConnectorApprovalDialog />))
+
+    act(() => button('Allow once')?.click())
+    await act(async () => {
+      rejectResponse(new Error('IPC unavailable'))
+      await Promise.resolve()
+    })
+    expect(document.body.querySelector('[role="alert"]')).not.toBeNull()
+
+    act(() => useSettingsStore.setState({ pendingApprovals: [nextRequest] }))
+    expect(document.body.querySelector('[role="alert"]')).toBeNull()
   })
 })

--- a/src/renderer/src/pages/settings/ConnectorApprovalDialog.tsx
+++ b/src/renderer/src/pages/settings/ConnectorApprovalDialog.tsx
@@ -41,7 +41,7 @@ export function ConnectorApprovalDialog({
   const respondApproval = useSettingsStore((state) => state.respondApproval)
   const [pendingBroadScope, setPendingBroadScope] = useState<BroadPermissionScope>()
   const [responding, setResponding] = useState(false)
-  const [responseError, setResponseError] = useState(false)
+  const [responseErrorRequestId, setResponseErrorRequestId] = useState<string>()
 
   if (!request) return null
   const availableScopes = request.availableScopes ?? ['once']
@@ -53,10 +53,11 @@ export function ConnectorApprovalDialog({
 
   const submitResponse = (decision: 'once' | 'session' | 'project' | 'global' | 'deny'): void => {
     if (responding) return
+    const requestId = request.id
     setResponding(true)
-    setResponseError(false)
-    void respondApproval(request.id, decision)
-      .catch(() => setResponseError(true))
+    setResponseErrorRequestId(undefined)
+    void respondApproval(requestId, decision)
+      .catch(() => setResponseErrorRequestId(requestId))
       .finally(() => setResponding(false))
   }
   const allow = (scope: 'once' | 'session' | 'project' | 'global'): void => {
@@ -119,7 +120,7 @@ export function ConnectorApprovalDialog({
                 </span>
               </div>
             </div>
-            {responseError ? (
+            {responseErrorRequestId === request.id ? (
               <div
                 role="alert"
                 className="mt-3 flex items-start gap-2 rounded-lg border border-danger-000/30 bg-danger-000/10 px-3 py-2 text-xs text-danger-000"

--- a/src/renderer/src/pages/settings/ConnectorApprovalDialog.tsx
+++ b/src/renderer/src/pages/settings/ConnectorApprovalDialog.tsx
@@ -1,4 +1,4 @@
-import { ShieldAlert } from 'lucide-react'
+import { AlertTriangle, ShieldAlert } from 'lucide-react'
 import { Dialog } from 'radix-ui'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -40,6 +40,8 @@ export function ConnectorApprovalDialog({
   const customServers = useSettingsStore((state) => state.customServers)
   const respondApproval = useSettingsStore((state) => state.respondApproval)
   const [pendingBroadScope, setPendingBroadScope] = useState<BroadPermissionScope>()
+  const [responding, setResponding] = useState(false)
+  const [responseError, setResponseError] = useState(false)
 
   if (!request) return null
   const availableScopes = request.availableScopes ?? ['once']
@@ -49,26 +51,35 @@ export function ConnectorApprovalDialog({
     customServers.find((s) => s.name === request.connector)?.name ??
     request.connector
 
+  const submitResponse = (decision: 'once' | 'session' | 'project' | 'global' | 'deny'): void => {
+    if (responding) return
+    setResponding(true)
+    setResponseError(false)
+    void respondApproval(request.id, decision)
+      .catch(() => setResponseError(true))
+      .finally(() => setResponding(false))
+  }
   const allow = (scope: 'once' | 'session' | 'project' | 'global'): void => {
     if (scope === 'project' || scope === 'global') {
       setPendingBroadScope(scope)
       return
     }
-    void respondApproval(request.id, scope)
+    submitResponse(scope)
   }
   const confirmBroadScope = (): void => {
     if (!pendingBroadScope) return
     const scope = pendingBroadScope
     setPendingBroadScope(undefined)
-    void respondApproval(request.id, scope)
+    submitResponse(scope)
   }
-  const deny = (): void => void respondApproval(request.id, 'deny')
+  const deny = (): void => submitResponse('deny')
 
   return (
     <Dialog.Root open={active}>
       <Dialog.Portal>
         <Dialog.Overlay className={cn(dialogOverlayClassName, 'z-[60]')} />
         <Dialog.Content
+          aria-busy={responding}
           onInteractOutside={(event) => event.preventDefault()}
           onEscapeKeyDown={(event) => event.preventDefault()}
           className={dialogPanelClassName(
@@ -108,28 +119,52 @@ export function ConnectorApprovalDialog({
                 </span>
               </div>
             </div>
+            {responseError ? (
+              <div
+                role="alert"
+                className="mt-3 flex items-start gap-2 rounded-lg border border-danger-000/30 bg-danger-000/10 px-3 py-2 text-xs text-danger-000"
+              >
+                <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+                <span>{t('Could not submit this approval. Try again.')}</span>
+              </div>
+            ) : null}
           </div>
 
           <div className={cn(dialogFooterClassName, 'flex-wrap')}>
-            <Button type="button" variant="destructive" onClick={deny}>
+            <Button type="button" variant="destructive" disabled={responding} onClick={deny}>
               {t('Deny')}
             </Button>
             {availableScopes.includes('session') ? (
-              <Button type="button" variant="outline" onClick={() => allow('session')}>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={responding}
+                onClick={() => allow('session')}
+              >
                 {t('This session')}
               </Button>
             ) : null}
             {availableScopes.includes('project') ? (
-              <Button type="button" variant="outline" onClick={() => allow('project')}>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={responding}
+                onClick={() => allow('project')}
+              >
                 {t('This project')}
               </Button>
             ) : null}
             {availableScopes.includes('global') ? (
-              <Button type="button" variant="outline" onClick={() => allow('global')}>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={responding}
+                onClick={() => allow('global')}
+              >
                 {t('Global')}
               </Button>
             ) : null}
-            <Button type="button" onClick={() => allow('once')}>
+            <Button type="button" disabled={responding} onClick={() => allow('once')}>
               {t('Allow once')}
             </Button>
           </div>

--- a/src/renderer/src/pages/settings/ConnectorDetailView.tsx
+++ b/src/renderer/src/pages/settings/ConnectorDetailView.tsx
@@ -104,7 +104,7 @@ const ConnectorDetailView = ({
         <SettingsToggle
           enabled={enabled}
           aria-label={t('Toggle {{name}}', { name: detail.displayName })}
-          onToggle={() => void setConnectorEnabled(id, !enabled)}
+          onToggle={() => void setConnectorEnabled(id, !enabled).catch(() => undefined)}
         />
       </div>
 
@@ -127,7 +127,7 @@ const ConnectorDetailView = ({
         <SettingsToggle
           enabled={autoAllow}
           aria-label={t('Skip approvals for {{name}}', { name: id })}
-          onToggle={() => void setConnectorAutoAllow(id, !autoAllow)}
+          onToggle={() => void setConnectorAutoAllow(id, !autoAllow).catch(() => undefined)}
         />
       </div>
 

--- a/src/renderer/src/pages/settings/ConnectorsPanel.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.tsx
@@ -299,7 +299,11 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
                   <SettingsToggle
                     enabled={connector.enabled}
                     aria-label={connector.displayName}
-                    onToggle={() => void setConnectorEnabled(connector.id, !connector.enabled)}
+                    onToggle={() =>
+                      void setConnectorEnabled(connector.id, !connector.enabled).catch(
+                        () => undefined
+                      )
+                    }
                   />
                 </li>
               ))}
@@ -617,7 +621,9 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
                         }
                         onToggle={() => {
                           if (requiresSignInBeforeEnable(server)) return
-                          void setCustomServerEnabled(server.id, !server.enabled)
+                          void setCustomServerEnabled(server.id, !server.enabled).catch(
+                            () => undefined
+                          )
                         }}
                       />
                     </li>

--- a/src/renderer/src/pages/settings/SkillDetailView.tsx
+++ b/src/renderer/src/pages/settings/SkillDetailView.tsx
@@ -95,7 +95,7 @@ const SkillDetailView = ({ skillId }: SkillDetailViewProps): React.JSX.Element =
         <SettingsToggle
           enabled={enabled}
           aria-label={t('Toggle {{name}}', { name })}
-          onToggle={() => void setSkillEnabled(skillId, !enabled)}
+          onToggle={() => void setSkillEnabled(skillId, !enabled).catch(() => undefined)}
         />
       </div>
 

--- a/src/renderer/src/pages/settings/SkillsPanel.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.tsx
@@ -429,7 +429,9 @@ const SkillsPanel = ({
                         <SettingsToggle
                           enabled={skill.enabled}
                           aria-label={t('Toggle {{name}}', { name: skill.displayName })}
-                          onToggle={() => void setSkillEnabled(skill.id, !skill.enabled)}
+                          onToggle={() =>
+                            void setSkillEnabled(skill.id, !skill.enabled).catch(() => undefined)
+                          }
                         />
                       </li>
                     ))}

--- a/src/renderer/src/stores/settings-connectors-slice.test.ts
+++ b/src/renderer/src/stores/settings-connectors-slice.test.ts
@@ -229,7 +229,7 @@ describe('settings Connectors slice', () => {
     expect(store.getState().connectors).toEqual([connector('authoritative')])
   })
 
-  it('retains an optimistic Connector toggle when main rejects it', async () => {
+  it('rolls back an optimistic Connector toggle when main rejects it', async () => {
     vi.mocked(commands.setConnectorEnabled).mockRejectedValue(new Error('toggle failed'))
     store.setState({ connectors: [connector('pubmed')] })
 
@@ -237,10 +237,65 @@ describe('settings Connectors slice', () => {
       'toggle failed'
     )
 
-    expect(store.getState().connectors).toEqual([connector('pubmed', { enabled: false })])
+    expect(store.getState().connectors).toEqual([connector('pubmed')])
   })
 
-  it('optimistically changes auto-allow and retains it after rejection', async () => {
+  it('does not let an older rejected Connector toggle overwrite a newer success', async () => {
+    let rejectOlder!: (error: Error) => void
+    let settleNewer!: (result: ConnectorsSnapshot) => void
+    vi.mocked(commands.setConnectorEnabled)
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          rejectOlder = reject
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          settleNewer = resolve
+        })
+      )
+    store.setState({ connectors: [connector('pubmed')] })
+
+    const older = store.getState().setConnectorEnabled('pubmed', false)
+    const newer = store.getState().setConnectorEnabled('pubmed', true)
+
+    settleNewer(snapshot([connector('pubmed')]))
+    await newer
+    rejectOlder(new Error('older toggle failed'))
+    await expect(older).rejects.toThrow('older toggle failed')
+
+    expect(store.getState().connectors).toEqual([connector('pubmed')])
+  })
+
+  it('returns to the confirmed Connector value when overlapping toggles all fail', async () => {
+    let rejectOlder!: (error: Error) => void
+    let rejectNewer!: (error: Error) => void
+    vi.mocked(commands.setConnectorEnabled)
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          rejectOlder = reject
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          rejectNewer = reject
+        })
+      )
+    store.setState({ connectors: [connector('pubmed')] })
+
+    const older = store.getState().setConnectorEnabled('pubmed', false)
+    const newer = store.getState().setConnectorEnabled('pubmed', true)
+
+    rejectNewer(new Error('newer toggle failed'))
+    await expect(newer).rejects.toThrow('newer toggle failed')
+    expect(store.getState().connectors).toEqual([connector('pubmed', { enabled: false })])
+
+    rejectOlder(new Error('older toggle failed'))
+    await expect(older).rejects.toThrow('older toggle failed')
+    expect(store.getState().connectors).toEqual([connector('pubmed')])
+  })
+
+  it('rolls back an optimistic auto-allow change when main rejects it', async () => {
     vi.mocked(commands.setConnectorAutoAllow).mockRejectedValue(new Error('policy failed'))
     store.setState({ connectors: [connector('pubmed')] })
 
@@ -252,7 +307,7 @@ describe('settings Connectors slice', () => {
       id: 'pubmed',
       autoAllow: true
     })
-    expect(store.getState().connectors).toEqual([connector('pubmed', { autoAllow: true })])
+    expect(store.getState().connectors).toEqual([connector('pubmed')])
   })
 
   it('returns tool permission detail without adding component-owned detail state', async () => {
@@ -382,7 +437,7 @@ describe('settings Connectors slice', () => {
     expect(store.getState().customServers).toEqual([server('authoritative', false)])
   })
 
-  it('retains an optimistic custom-server toggle when main rejects it', async () => {
+  it('rolls back an optimistic custom-server toggle when main rejects it', async () => {
     vi.mocked(commands.setCustomServerEnabled).mockRejectedValue(new Error('toggle failed'))
     store.setState({ customServers: [server('custom')] })
 
@@ -390,10 +445,10 @@ describe('settings Connectors slice', () => {
       'toggle failed'
     )
 
-    expect(store.getState().customServers).toEqual([server('custom', false)])
+    expect(store.getState().customServers).toEqual([server('custom')])
   })
 
-  it('keeps approval ordering, ignores duplicates, and removes a response immediately', async () => {
+  it('keeps approval ordering, ignores duplicates, and removes a response after main confirms', async () => {
     const first: ConnectorApprovalRequest = {
       id: 'first',
       connector: 'pubmed',
@@ -414,7 +469,7 @@ describe('settings Connectors slice', () => {
     expect(store.getState().pendingApprovals).toEqual([first, second])
 
     const pending = store.getState().respondApproval('first', 'session')
-    expect(store.getState().pendingApprovals).toEqual([second])
+    expect(store.getState().pendingApprovals).toEqual([first, second])
     expect(commands.respondConnectorApproval).toHaveBeenCalledWith({
       id: 'first',
       decision: 'session'
@@ -422,9 +477,10 @@ describe('settings Connectors slice', () => {
 
     settle()
     await pending
+    expect(store.getState().pendingApprovals).toEqual([second])
   })
 
-  it('retains immediate approval removal when main rejects the response', async () => {
+  it('retains an approval when main rejects the response', async () => {
     const request: ConnectorApprovalRequest = {
       id: 'request',
       connector: 'pubmed',
@@ -438,6 +494,6 @@ describe('settings Connectors slice', () => {
       'response failed'
     )
 
-    expect(store.getState().pendingApprovals).toEqual([])
+    expect(store.getState().pendingApprovals).toEqual([request])
   })
 })

--- a/src/renderer/src/stores/settings-connectors-slice.test.ts
+++ b/src/renderer/src/stores/settings-connectors-slice.test.ts
@@ -267,6 +267,25 @@ describe('settings Connectors slice', () => {
     expect(store.getState().connectors).toEqual([connector('pubmed')])
   })
 
+  it('does not let an older Connector toggle overwrite a newer authoritative refresh', async () => {
+    let settleOlder!: (result: ConnectorsSnapshot) => void
+    vi.mocked(commands.setConnectorEnabled).mockReturnValue(
+      new Promise((resolve) => {
+        settleOlder = resolve
+      })
+    )
+    vi.mocked(commands.listConnectors).mockResolvedValue(snapshot([connector('pubmed')]))
+    store.setState({ connectors: [connector('pubmed')] })
+
+    const older = store.getState().setConnectorEnabled('pubmed', false)
+    await store.getState().loadConnectors()
+
+    settleOlder(snapshot([connector('pubmed', { enabled: false })]))
+    await older
+
+    expect(store.getState().connectors).toEqual([connector('pubmed')])
+  })
+
   it('returns to the confirmed Connector value when overlapping toggles all fail', async () => {
     let rejectOlder!: (error: Error) => void
     let rejectNewer!: (error: Error) => void

--- a/src/renderer/src/stores/settings-connectors-slice.ts
+++ b/src/renderer/src/stores/settings-connectors-slice.ts
@@ -86,17 +86,26 @@ export const createSettingsConnectorsSlice = ({
   const connectorAutoAllowKey = (id: string): string => `connector:${id}:autoAllow`
   const customServerEnabledKey = (id: string): string => `custom-server:${id}:enabled`
   const projectOptimisticToggles = (
-    projection: SettingsConnectorsProjection
+    projection: SettingsConnectorsProjection,
+    generation: number
   ): SettingsConnectorsProjection => ({
     ...projection,
     connectors: projection.connectors.map((connector) => ({
       ...connector,
-      enabled: toggleWrites.project(connectorEnabledKey(connector.id), connector.enabled),
-      autoAllow: toggleWrites.project(connectorAutoAllowKey(connector.id), connector.autoAllow)
+      enabled: toggleWrites.project(
+        connectorEnabledKey(connector.id),
+        connector.enabled,
+        generation
+      ),
+      autoAllow: toggleWrites.project(
+        connectorAutoAllowKey(connector.id),
+        connector.autoAllow,
+        generation
+      )
     })),
     customServers: projection.customServers.map((server) => ({
       ...server,
-      enabled: toggleWrites.project(customServerEnabledKey(server.id), server.enabled)
+      enabled: toggleWrites.project(customServerEnabledKey(server.id), server.enabled, generation)
     }))
   })
   let reconcileGeneration = 0
@@ -104,8 +113,10 @@ export const createSettingsConnectorsSlice = ({
     command: () => Promise<SettingsConnectorsProjection>
   ): Promise<SettingsConnectorsProjection> => {
     const generation = ++reconcileGeneration
+    const projectionGeneration = toggleWrites.beginProjection()
     const projection = await command()
-    if (generation === reconcileGeneration) setState(projectOptimisticToggles(projection))
+    if (generation === reconcileGeneration)
+      setState(projectOptimisticToggles(projection, projectionGeneration))
     return projection
   }
   let mutationsInFlight = 0

--- a/src/renderer/src/stores/settings-connectors-slice.ts
+++ b/src/renderer/src/stores/settings-connectors-slice.ts
@@ -12,6 +12,8 @@ import type {
   UpdateCustomServerRequest
 } from '../../../shared/settings'
 
+import { createOptimisticBooleanCoordinator } from './settings-optimistic-boolean'
+
 type SettingsConnectorsProjection = {
   connectors: ConnectorView[]
   customServers: CustomServerView[]
@@ -79,11 +81,32 @@ export const createSettingsConnectorsSlice = ({
   setState,
   getCommands
 }: SettingsConnectorsSliceOptions): SettingsConnectorsActions => {
+  const toggleWrites = createOptimisticBooleanCoordinator()
+  const connectorEnabledKey = (id: string): string => `connector:${id}:enabled`
+  const connectorAutoAllowKey = (id: string): string => `connector:${id}:autoAllow`
+  const customServerEnabledKey = (id: string): string => `custom-server:${id}:enabled`
+  const projectOptimisticToggles = (
+    projection: SettingsConnectorsProjection
+  ): SettingsConnectorsProjection => ({
+    ...projection,
+    connectors: projection.connectors.map((connector) => ({
+      ...connector,
+      enabled: toggleWrites.project(connectorEnabledKey(connector.id), connector.enabled),
+      autoAllow: toggleWrites.project(connectorAutoAllowKey(connector.id), connector.autoAllow)
+    })),
+    customServers: projection.customServers.map((server) => ({
+      ...server,
+      enabled: toggleWrites.project(customServerEnabledKey(server.id), server.enabled)
+    }))
+  })
   let reconcileGeneration = 0
-  const reconcile = async (command: () => Promise<SettingsConnectorsProjection>): Promise<void> => {
+  const reconcile = async (
+    command: () => Promise<SettingsConnectorsProjection>
+  ): Promise<SettingsConnectorsProjection> => {
     const generation = ++reconcileGeneration
     const projection = await command()
-    if (generation === reconcileGeneration) setState(projection)
+    if (generation === reconcileGeneration) setState(projectOptimisticToggles(projection))
+    return projection
   }
   let mutationsInFlight = 0
   let runtimeRefreshPending = false
@@ -94,10 +117,10 @@ export const createSettingsConnectorsSlice = ({
     }
     void reconcile(() => getCommands().listConnectors()).catch(() => undefined)
   }
-  const runMutation = async (mutation: () => Promise<void>): Promise<void> => {
+  const runMutation = async <Result>(mutation: () => Promise<Result>): Promise<Result> => {
     mutationsInFlight += 1
     try {
-      await mutation()
+      return await mutation()
     } finally {
       mutationsInFlight -= 1
       if (mutationsInFlight === 0 && runtimeRefreshPending) {
@@ -106,8 +129,11 @@ export const createSettingsConnectorsSlice = ({
       }
     }
   }
-  const reconcileMutation = (command: () => Promise<SettingsConnectorsProjection>): Promise<void> =>
-    runMutation(() => reconcile(command))
+  const reconcileMutation = async (
+    command: () => Promise<SettingsConnectorsProjection>
+  ): Promise<void> => {
+    await runMutation(() => reconcile(command))
+  }
   let removeRuntimeChangedListener: (() => void) | undefined
   const subscribeToRuntimeChanges = (): void => {
     removeRuntimeChangedListener ??= getCommands().onConnectorRuntimeChanged(() => {
@@ -116,25 +142,85 @@ export const createSettingsConnectorsSlice = ({
   }
 
   return {
-    loadConnectors: () => {
+    loadConnectors: async () => {
       subscribeToRuntimeChanges()
-      return reconcile(() => getCommands().listConnectors())
+      await reconcile(() => getCommands().listConnectors())
     },
     setConnectorEnabled: async (id, enabled) => {
+      const key = connectorEnabledKey(id)
+      let confirmed: boolean | undefined
       setState((state) => ({
-        connectors: state.connectors.map((connector) =>
-          connector.id === id ? { ...connector, enabled } : connector
-        )
+        connectors: state.connectors.map((connector) => {
+          if (connector.id !== id) return connector
+          confirmed = connector.enabled
+          return { ...connector, enabled }
+        })
       }))
-      await reconcileMutation(() => getCommands().setConnectorEnabled({ id, enabled }))
+      if (confirmed === undefined) {
+        await reconcileMutation(() => getCommands().setConnectorEnabled({ id, enabled }))
+        return
+      }
+
+      const token = toggleWrites.begin(key, confirmed, enabled)
+      try {
+        const projection = await runMutation(() =>
+          reconcile(() => getCommands().setConnectorEnabled({ id, enabled }))
+        )
+        const authoritative =
+          projection.connectors.find((connector) => connector.id === id)?.enabled ?? confirmed
+        const projected = toggleWrites.succeed(token, authoritative)
+        setState((state) => ({
+          connectors: state.connectors.map((connector) =>
+            connector.id === id ? { ...connector, enabled: projected } : connector
+          )
+        }))
+      } catch (error) {
+        const projected = toggleWrites.fail(token)
+        setState((state) => ({
+          connectors: state.connectors.map((connector) =>
+            connector.id === id ? { ...connector, enabled: projected } : connector
+          )
+        }))
+        throw error
+      }
     },
     setConnectorAutoAllow: async (id, autoAllow) => {
+      const key = connectorAutoAllowKey(id)
+      let confirmed: boolean | undefined
       setState((state) => ({
-        connectors: state.connectors.map((connector) =>
-          connector.id === id ? { ...connector, autoAllow } : connector
-        )
+        connectors: state.connectors.map((connector) => {
+          if (connector.id !== id) return connector
+          confirmed = connector.autoAllow
+          return { ...connector, autoAllow }
+        })
       }))
-      await reconcileMutation(() => getCommands().setConnectorAutoAllow({ id, autoAllow }))
+      if (confirmed === undefined) {
+        await reconcileMutation(() => getCommands().setConnectorAutoAllow({ id, autoAllow }))
+        return
+      }
+
+      const token = toggleWrites.begin(key, confirmed, autoAllow)
+      try {
+        const projection = await runMutation(() =>
+          reconcile(() => getCommands().setConnectorAutoAllow({ id, autoAllow }))
+        )
+        const authoritative =
+          projection.connectors.find((connector) => connector.id === id)?.autoAllow ?? confirmed
+        const projected = toggleWrites.succeed(token, authoritative)
+        setState((state) => ({
+          connectors: state.connectors.map((connector) =>
+            connector.id === id ? { ...connector, autoAllow: projected } : connector
+          )
+        }))
+      } catch (error) {
+        const projected = toggleWrites.fail(token)
+        setState((state) => ({
+          connectors: state.connectors.map((connector) =>
+            connector.id === id ? { ...connector, autoAllow: projected } : connector
+          )
+        }))
+        throw error
+      }
     },
     setToolPermission: async (toolId, permission) =>
       getCommands().setToolPermission({ toolId, permission }),
@@ -158,12 +244,42 @@ export const createSettingsConnectorsSlice = ({
       getCommands().cancelCustomServerAuthentication(request),
     retryCustomServer: (id) => reconcileMutation(() => getCommands().retryCustomServer({ id })),
     setCustomServerEnabled: async (id, enabled) => {
+      const key = customServerEnabledKey(id)
+      let confirmed: boolean | undefined
       setState((state) => ({
-        customServers: state.customServers.map((server) =>
-          server.id === id ? { ...server, enabled } : server
-        )
+        customServers: state.customServers.map((server) => {
+          if (server.id !== id) return server
+          confirmed = server.enabled
+          return { ...server, enabled }
+        })
       }))
-      await reconcileMutation(() => getCommands().setCustomServerEnabled({ id, enabled }))
+      if (confirmed === undefined) {
+        await reconcileMutation(() => getCommands().setCustomServerEnabled({ id, enabled }))
+        return
+      }
+
+      const token = toggleWrites.begin(key, confirmed, enabled)
+      try {
+        const projection = await runMutation(() =>
+          reconcile(() => getCommands().setCustomServerEnabled({ id, enabled }))
+        )
+        const authoritative =
+          projection.customServers.find((server) => server.id === id)?.enabled ?? confirmed
+        const projected = toggleWrites.succeed(token, authoritative)
+        setState((state) => ({
+          customServers: state.customServers.map((server) =>
+            server.id === id ? { ...server, enabled: projected } : server
+          )
+        }))
+      } catch (error) {
+        const projected = toggleWrites.fail(token)
+        setState((state) => ({
+          customServers: state.customServers.map((server) =>
+            server.id === id ? { ...server, enabled: projected } : server
+          )
+        }))
+        throw error
+      }
     },
     removeCustomServer: (id) => reconcileMutation(() => getCommands().removeCustomServer({ id })),
     enqueueApproval: (request) => {
@@ -174,10 +290,10 @@ export const createSettingsConnectorsSlice = ({
       )
     },
     respondApproval: async (id, decision) => {
+      await getCommands().respondConnectorApproval({ id, decision })
       setState((state) => ({
         pendingApprovals: state.pendingApprovals.filter((request) => request.id !== id)
       }))
-      await getCommands().respondConnectorApproval({ id, decision })
     }
   }
 }

--- a/src/renderer/src/stores/settings-optimistic-boolean.ts
+++ b/src/renderer/src/stores/settings-optimistic-boolean.ts
@@ -6,13 +6,13 @@ type OptimisticBooleanToken = Readonly<{
 type OptimisticBooleanEntry = {
   confirmedGeneration: number
   confirmedValue: boolean
-  nextGeneration: number
   pending: Map<number, boolean>
 }
 
 type OptimisticBooleanCoordinator = {
   begin: (key: string, confirmedValue: boolean, optimisticValue: boolean) => OptimisticBooleanToken
-  project: (key: string, authoritativeValue: boolean) => boolean
+  beginProjection: () => number
+  project: (key: string, authoritativeValue: boolean, generation: number) => boolean
   succeed: (token: OptimisticBooleanToken, authoritativeValue: boolean) => boolean
   fail: (token: OptimisticBooleanToken) => boolean
 }
@@ -31,10 +31,12 @@ const projectedValue = (entry: OptimisticBooleanEntry): boolean => {
 }
 
 // Coordinates one or more optimistic boolean fields without exposing pending state through Zustand.
-// A field retains its last confirmed value while requests overlap, so rejected older writes cannot
-// overwrite newer intent and a run of rejected writes returns to the original confirmed value.
+// Pending writes and authoritative projections share one sequence, so older settlements cannot
+// overwrite newer intent or snapshots. A run of rejected writes still returns to the original
+// confirmed value.
 export const createOptimisticBooleanCoordinator = (): OptimisticBooleanCoordinator => {
   const entries = new Map<string, OptimisticBooleanEntry>()
+  let nextGeneration = 0
 
   const finish = (token: OptimisticBooleanToken, authoritativeValue?: boolean): boolean => {
     const entry = entries.get(token.key)
@@ -58,20 +60,23 @@ export const createOptimisticBooleanCoordinator = (): OptimisticBooleanCoordinat
         entry = {
           confirmedGeneration: 0,
           confirmedValue,
-          nextGeneration: 0,
           pending: new Map()
         }
         entries.set(key, entry)
       }
 
-      const generation = ++entry.nextGeneration
+      const generation = ++nextGeneration
       entry.pending.set(generation, optimisticValue)
       return { key, generation }
     },
-    project: (key, authoritativeValue) => {
+    beginProjection: () => ++nextGeneration,
+    project: (key, authoritativeValue, generation) => {
       const entry = entries.get(key)
       if (!entry) return authoritativeValue
-      entry.confirmedValue = authoritativeValue
+      if (generation > entry.confirmedGeneration) {
+        entry.confirmedGeneration = generation
+        entry.confirmedValue = authoritativeValue
+      }
       return projectedValue(entry)
     },
     succeed: (token, authoritativeValue) => finish(token, authoritativeValue),

--- a/src/renderer/src/stores/settings-optimistic-boolean.ts
+++ b/src/renderer/src/stores/settings-optimistic-boolean.ts
@@ -1,0 +1,80 @@
+type OptimisticBooleanToken = Readonly<{
+  key: string
+  generation: number
+}>
+
+type OptimisticBooleanEntry = {
+  confirmedGeneration: number
+  confirmedValue: boolean
+  nextGeneration: number
+  pending: Map<number, boolean>
+}
+
+type OptimisticBooleanCoordinator = {
+  begin: (key: string, confirmedValue: boolean, optimisticValue: boolean) => OptimisticBooleanToken
+  project: (key: string, authoritativeValue: boolean) => boolean
+  succeed: (token: OptimisticBooleanToken, authoritativeValue: boolean) => boolean
+  fail: (token: OptimisticBooleanToken) => boolean
+}
+
+const projectedValue = (entry: OptimisticBooleanEntry): boolean => {
+  let generation = entry.confirmedGeneration
+  let value = entry.confirmedValue
+
+  for (const [pendingGeneration, pendingValue] of entry.pending) {
+    if (pendingGeneration <= generation) continue
+    generation = pendingGeneration
+    value = pendingValue
+  }
+
+  return value
+}
+
+// Coordinates one or more optimistic boolean fields without exposing pending state through Zustand.
+// A field retains its last confirmed value while requests overlap, so rejected older writes cannot
+// overwrite newer intent and a run of rejected writes returns to the original confirmed value.
+export const createOptimisticBooleanCoordinator = (): OptimisticBooleanCoordinator => {
+  const entries = new Map<string, OptimisticBooleanEntry>()
+
+  const finish = (token: OptimisticBooleanToken, authoritativeValue?: boolean): boolean => {
+    const entry = entries.get(token.key)
+    if (!entry) return authoritativeValue ?? false
+
+    entry.pending.delete(token.generation)
+    if (authoritativeValue !== undefined && token.generation > entry.confirmedGeneration) {
+      entry.confirmedGeneration = token.generation
+      entry.confirmedValue = authoritativeValue
+    }
+
+    const value = projectedValue(entry)
+    if (entry.pending.size === 0) entries.delete(token.key)
+    return value
+  }
+
+  return {
+    begin: (key, confirmedValue, optimisticValue) => {
+      let entry = entries.get(key)
+      if (!entry) {
+        entry = {
+          confirmedGeneration: 0,
+          confirmedValue,
+          nextGeneration: 0,
+          pending: new Map()
+        }
+        entries.set(key, entry)
+      }
+
+      const generation = ++entry.nextGeneration
+      entry.pending.set(generation, optimisticValue)
+      return { key, generation }
+    },
+    project: (key, authoritativeValue) => {
+      const entry = entries.get(key)
+      if (!entry) return authoritativeValue
+      entry.confirmedValue = authoritativeValue
+      return projectedValue(entry)
+    },
+    succeed: (token, authoritativeValue) => finish(token, authoritativeValue),
+    fail: (token) => finish(token)
+  }
+}

--- a/src/renderer/src/stores/settings-skills-slice.test.ts
+++ b/src/renderer/src/stores/settings-skills-slice.test.ts
@@ -149,13 +149,40 @@ describe('settings Skills slice', () => {
     expect(store.getState().skills).toEqual([skill('authoritative', false)])
   })
 
-  it('propagates a toggle failure without rolling back the existing optimistic behavior', async () => {
+  it('rolls back an optimistic toggle when main rejects it', async () => {
     vi.mocked(commands.setSkillEnabled).mockRejectedValue(new Error('toggle failed'))
     store.setState({ skills: [skill('target')] })
 
     await expect(store.getState().setSkillEnabled('target', false)).rejects.toThrow('toggle failed')
 
-    expect(store.getState().skills).toEqual([skill('target', false)])
+    expect(store.getState().skills).toEqual([skill('target')])
+  })
+
+  it('does not let an older rejected Skill toggle overwrite a newer success', async () => {
+    let rejectOlder!: (error: Error) => void
+    let settleNewer!: (skills: SkillView[]) => void
+    vi.mocked(commands.setSkillEnabled)
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          rejectOlder = reject
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          settleNewer = resolve
+        })
+      )
+    store.setState({ skills: [skill('target')] })
+
+    const older = store.getState().setSkillEnabled('target', false)
+    const newer = store.getState().setSkillEnabled('target', true)
+
+    settleNewer([skill('target')])
+    await newer
+    rejectOlder(new Error('older toggle failed'))
+    await expect(older).rejects.toThrow('older toggle failed')
+
+    expect(store.getState().skills).toEqual([skill('target')])
   })
 
   it('reconciles the authoritative catalog after changing Skill enablement in bulk', async () => {

--- a/src/renderer/src/stores/settings-skills-slice.test.ts
+++ b/src/renderer/src/stores/settings-skills-slice.test.ts
@@ -185,6 +185,25 @@ describe('settings Skills slice', () => {
     expect(store.getState().skills).toEqual([skill('target')])
   })
 
+  it('does not let an older Skill toggle overwrite a newer bulk snapshot', async () => {
+    let settleOlder!: (skills: SkillView[]) => void
+    vi.mocked(commands.setSkillEnabled).mockReturnValue(
+      new Promise((resolve) => {
+        settleOlder = resolve
+      })
+    )
+    vi.mocked(commands.setSkillsEnabled).mockResolvedValue([skill('target')])
+    store.setState({ skills: [skill('target')] })
+
+    const older = store.getState().setSkillEnabled('target', false)
+    await store.getState().setSkillsEnabled(['target'], true)
+
+    settleOlder([skill('target', false)])
+    await older
+
+    expect(store.getState().skills).toEqual([skill('target')])
+  })
+
   it('reconciles the authoritative catalog after changing Skill enablement in bulk', async () => {
     vi.mocked(commands.setSkillsEnabled).mockResolvedValue([skill('authoritative', false)])
     store.setState({ skills: [skill('target')] })

--- a/src/renderer/src/stores/settings-skills-slice.ts
+++ b/src/renderer/src/stores/settings-skills-slice.ts
@@ -76,17 +76,18 @@ export const createSettingsSkillsSlice = ({
   getCommands
 }: SettingsSkillsSliceOptions): SettingsSkillsActions => {
   const skillEnabledWrites = createOptimisticBooleanCoordinator()
-  const projectOptimisticEnablement = (skills: SkillView[]): SkillView[] =>
+  const projectOptimisticEnablement = (skills: SkillView[], generation: number): SkillView[] =>
     skills.map((skill) => ({
       ...skill,
-      enabled: skillEnabledWrites.project(skill.id, skill.enabled)
+      enabled: skillEnabledWrites.project(skill.id, skill.enabled, generation)
     }))
   let reconcileGeneration = 0
   const reconcileCatalog = async (command: () => Promise<SkillView[]>): Promise<SkillView[]> => {
     const generation = ++reconcileGeneration
+    const projectionGeneration = skillEnabledWrites.beginProjection()
     const skills = await command()
     if (generation === reconcileGeneration)
-      setState({ skills: projectOptimisticEnablement(skills) })
+      setState({ skills: projectOptimisticEnablement(skills, projectionGeneration) })
     return skills
   }
 
@@ -98,8 +99,10 @@ export const createSettingsSkillsSlice = ({
     command: () => Promise<Result>
   ): Promise<Result> => {
     const generation = ++reconcileGeneration
+    const projectionGeneration = skillEnabledWrites.beginProjection()
     const result = await command()
-    if (generation === reconcileGeneration) setState({ skills: result.skills })
+    if (generation === reconcileGeneration)
+      setState({ skills: projectOptimisticEnablement(result.skills, projectionGeneration) })
     return result
   }
 

--- a/src/renderer/src/stores/settings-skills-slice.ts
+++ b/src/renderer/src/stores/settings-skills-slice.ts
@@ -12,6 +12,8 @@ import type {
   UpdateSkillRequest
 } from '../../../shared/settings'
 
+import { createOptimisticBooleanCoordinator } from './settings-optimistic-boolean'
+
 export type SettingsSkillsState = { skills: SkillView[] }
 
 export type SettingsSkillsActions = {
@@ -73,11 +75,23 @@ export const createSettingsSkillsSlice = ({
   setState,
   getCommands
 }: SettingsSkillsSliceOptions): SettingsSkillsActions => {
+  const skillEnabledWrites = createOptimisticBooleanCoordinator()
+  const projectOptimisticEnablement = (skills: SkillView[]): SkillView[] =>
+    skills.map((skill) => ({
+      ...skill,
+      enabled: skillEnabledWrites.project(skill.id, skill.enabled)
+    }))
   let reconcileGeneration = 0
-  const reconcileCatalog = async (command: () => Promise<SkillView[]>): Promise<void> => {
+  const reconcileCatalog = async (command: () => Promise<SkillView[]>): Promise<SkillView[]> => {
     const generation = ++reconcileGeneration
     const skills = await command()
-    if (generation === reconcileGeneration) setState({ skills })
+    if (generation === reconcileGeneration)
+      setState({ skills: projectOptimisticEnablement(skills) })
+    return skills
+  }
+
+  const reconcileCatalogMutation = async (command: () => Promise<SkillView[]>): Promise<void> => {
+    await reconcileCatalog(command)
   }
 
   const reconcileImport = async <Result extends { skills: SkillView[] }>(
@@ -100,21 +114,45 @@ export const createSettingsSkillsSlice = ({
   }
 
   return {
-    loadSkills: () => {
+    loadSkills: async () => {
       subscribeToCatalogChanges()
-      return reconcileCatalog(() => getCommands().listSkills())
+      await reconcileCatalog(() => getCommands().listSkills())
     },
     setSkillEnabled: async (id, enabled) => {
+      const current = getState().skills.find((skill) => skill.id === id)
+      if (!current) {
+        await reconcileCatalog(() => getCommands().setSkillEnabled({ id, enabled }))
+        return
+      }
+
+      const token = skillEnabledWrites.begin(id, current.enabled, enabled)
       setState({
         skills: getState().skills.map((skill) => (skill.id === id ? { ...skill, enabled } : skill))
       })
-      await reconcileCatalog(() => getCommands().setSkillEnabled({ id, enabled }))
+      try {
+        const skills = await reconcileCatalog(() => getCommands().setSkillEnabled({ id, enabled }))
+        const confirmed = skills.find((skill) => skill.id === id)?.enabled ?? current.enabled
+        const projected = skillEnabledWrites.succeed(token, confirmed)
+        setState({
+          skills: getState().skills.map((skill) =>
+            skill.id === id ? { ...skill, enabled: projected } : skill
+          )
+        })
+      } catch (error) {
+        const projected = skillEnabledWrites.fail(token)
+        setState({
+          skills: getState().skills.map((skill) =>
+            skill.id === id ? { ...skill, enabled: projected } : skill
+          )
+        })
+        throw error
+      }
     },
     setSkillsEnabled: (ids, enabled) =>
-      reconcileCatalog(() => getCommands().setSkillsEnabled({ ids, enabled })),
-    createSkill: (request) => reconcileCatalog(() => getCommands().createSkill(request)),
-    updateSkill: (request) => reconcileCatalog(() => getCommands().updateSkill(request)),
-    deleteSkill: (id) => reconcileCatalog(() => getCommands().deleteSkill({ id })),
+      reconcileCatalogMutation(() => getCommands().setSkillsEnabled({ ids, enabled })),
+    createSkill: (request) => reconcileCatalogMutation(() => getCommands().createSkill(request)),
+    updateSkill: (request) => reconcileCatalogMutation(() => getCommands().updateSkill(request)),
+    deleteSkill: (id) => reconcileCatalogMutation(() => getCommands().deleteSkill({ id })),
     importSkill: (url) => reconcileImport(() => getCommands().importSkill({ url })),
     importSkillZip: (dataBase64, opts) =>
       reconcileImport(() =>

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -1363,7 +1363,7 @@ describe('settings store: connectors slice', () => {
     expect(useSettingsStore.getState().connectors[0].enabled).toBe(false)
   })
 
-  it('keeps the optimistic connector value when main rejects the write', async () => {
+  it('rolls back the optimistic Connector value when main rejects the write', async () => {
     useSettingsStore.setState({ connectors: [connectorView('pubmed', true)] })
     api.setConnectorEnabled.mockRejectedValue(new Error('IPC unavailable'))
 
@@ -1371,7 +1371,7 @@ describe('settings store: connectors slice', () => {
       'IPC unavailable'
     )
 
-    expect(useSettingsStore.getState().connectors[0].enabled).toBe(false)
+    expect(useSettingsStore.getState().connectors[0].enabled).toBe(true)
   })
 
   it('setNcbiCredentials reconciles the ncbi credential state', async () => {


### PR DESCRIPTION
## Problem

Connector and Skill toggles were projected optimistically, but rejected Main-process writes neither rolled the renderer state back nor triggered an authoritative refresh. Connector approvals were removed from the local queue before Main confirmed the response, so an IPC failure left no local retry path.

## Proposed change

- Track confirmed and pending boolean generations inside the renderer slices so failed writes restore confirmed state without an older failure overwriting newer intent.
- Keep Connector approvals queued until Main confirms the response.
- Disable approval decisions while a response is pending and show a localized retryable error after failure.
- Consume expected toggle rejections at UI call sites after the store has visibly reconciled them.
- Add regression coverage for rollback, overlapping requests, confirmation ordering, and retry interaction.

## Scope and non-goals

- Renderer-only change.
- No shared or IPC contract changes.
- No schema, persisted field, data-model, or enum additions.
- No historical-data migration or compatibility path is required.
- Existing settings.json persistence and Main's in-memory approval queue are unchanged.

## Acceptance criteria and validation

- Rejected Connector enabled, auto-allow, custom-server, and Skill enabled writes restore the last confirmed value.
- Older rejected writes cannot overwrite a newer successful intent.
- Approval requests remain visible while submitting and after failure, then disappear after Main confirmation.
- Retry controls are disabled only while a response is in flight, with Simplified and Traditional Chinese error copy.

Validation after the final material edit:

- npm test -- settings-connectors-slice.test.ts settings-skills-slice.test.ts settings-store.test.ts ConnectorApprovalDialog.render.test.tsx ConnectorDetailView.render.test.tsx ConnectorsPanel.render.test.tsx SkillDetailView.render.test.tsx SkillsPanel.render.test.tsx resources.test.ts — 11 files, 333 tests passed
- npm run typecheck:web — passed
- npm run lint — 0 errors; 15 pre-existing Prettier warnings in src/main/host-sdk/capability-projection.test.ts
- git diff --cached --check — passed

The module-impact planner falls back to the complete suite because locale catalogs have no module owner mapping. Per task scope, the complete local npm test was not run; exact-head PR CI is authoritative.

## Review focus

- Generation settlement when same-field writes resolve out of order.
- Approval retention and retry behavior across IPC rejection.