### PR TITLE
fix(preview): collapse full-screen panel on view in context

### DIFF
--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -9,6 +9,9 @@ import {
   type PreviewFileItem,
   type PreviewToolItem
 } from '@/stores/preview-workbench-store'
+import { useNavigationStore } from '@/stores/navigation-store'
+import { useProjectStore } from '@/stores/project-store'
+import { useSessionStore, type ChatSession } from '@/stores/session-store'
 
 vi.mock('@/components/ui/resizable', () => ({
   ResizablePanel: ({ children }: { children: React.ReactNode }): React.JSX.Element => (
@@ -710,5 +713,81 @@ describe('PreviewPanel', () => {
 
     await act(async () => usePreviewWorkbenchStore.getState().togglePanel())
     expect(container.querySelector('[data-testid="file-content"]')).not.toBeNull()
+  })
+
+  it('collapses the panel full-screen preview after View in context navigates', async () => {
+    const name = 'figure.png'
+    // The managed-artifact identity and a live origin session make View in context actionable.
+    usePreviewWorkbenchStore.getState().activateProject('project-1')
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(
+      createFileItem({
+        title: name,
+        name,
+        path: `/workspace/${name}`,
+        artifactId: 'artifact-1',
+        sessionId: 'session-1'
+      })
+    )
+    useProjectStore.setState({
+      projects: [
+        {
+          id: 'project-1',
+          name: 'Project One',
+          description: '',
+          isExample: false,
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      isLoaded: true
+    })
+    const session = (id: string, updatedAt: number): ChatSession => ({
+      id,
+      projectId: 'project-1',
+      title: id,
+      cwd: '/workspace',
+      status: 'idle',
+      messages: [],
+      artifacts: [],
+      filesRevision: 1,
+      createdAt: 1,
+      updatedAt
+    })
+    useSessionStore.setState({
+      sessions: [session('session-1', 1), session('session-2', 2)],
+      selectedSessionId: 'session-2'
+    })
+    useNavigationStore.setState({ view: 'workspace', activeProjectId: 'project-1' })
+    window.api = {
+      saveManagedFile: vi.fn().mockResolvedValue({ saved: true }),
+      artifacts: {
+        getLineage: vi.fn().mockResolvedValue({
+          artifactId: 'artifact-1',
+          filename: name,
+          originSession: { sessionId: 'session-1', state: 'active', title: 'Sine' },
+          versions: []
+        })
+      }
+    } as unknown as Window['api']
+
+    await renderPanel()
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(`[aria-label="Open full screen preview of ${name}"]`)
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull()
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(`[aria-label="View in context for ${name}"]`)
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(useSessionStore.getState().selectedSessionId).toBe('session-1')
+    // The floating preview must step aside so the switched conversation is visible.
+    expect(container.querySelector('[role="dialog"]')).toBeNull()
+    expect(container.querySelector('[role="tabpanel"]')).not.toBeNull()
+    expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('item-1')
   })
 })

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -412,6 +412,10 @@ const PreviewFilePanel = ({
           tooltipClassName={isFullScreenOpen ? 'z-[70]' : undefined}
           onClose={isFullScreenOpen ? closeFullScreen : () => onClose(item.id)}
           onOpenFullScreen={isFullScreenOpen ? undefined : openFullScreen}
+          // The floating surface covers the conversation panel, so a View in context navigation
+          // must collapse it for the switched session to become visible. The inline panel keeps
+          // its place in the workbench and needs no exit.
+          onViewInContextNavigate={isFullScreenOpen ? closeFullScreen : undefined}
           provenanceEntry={isFullScreenOpen ? 'trailing' : 'menu'}
         />
       </section>


### PR DESCRIPTION
## Problem

Follow-up to #1256. The artifact preview has two full-screen surfaces:

- the workspace-level `FilePreviewDialog` (z-[60]) — wired `onViewInContextNavigate={onClose}` in #1256
- the side panel's own maximize mode (`PreviewPanel` `isFullScreenOpen`, z-[61] floating surface) — **not** wired

Activating View in context from the panel's full-screen surface switched the conversation underneath, but the floating preview kept covering it, so the switch looked like a no-op.

## Proposed change

Pass `closeFullScreen` as `onViewInContextNavigate` while the panel surface floats, mirroring the dialog wiring. The inline (non-full-screen) panel keeps its placement in the workbench and passes nothing, so menu activation does not disturb it.

## Scope and non-goals

- One-line wiring in `PreviewPanel.tsx` plus a regression test; no store, IPC, or schema changes
- `FilePreviewDialog` behavior unchanged

## Acceptance criteria and validation

New regression test in `PreviewPanel.test.tsx`: open the panel full-screen, activate View in context, assert the conversation switched, the dialog role collapses back to the inline tabpanel, and the workbench tab survives.

Evidence mapping (run after the last material edit, from the worktree root):

| Behavior | Command | Result |
| --- | --- | --- |
| Panel full-screen exit + navigation | `vitest run src/renderer/src/pages/workspace/PreviewPanel.test.tsx` | 22 passed |
| Shared-UI regression sweep | full `vitest run` | 15539 passed, 0 failed |
| Renderer type safety | `tsc --noEmit -p tsconfig.web.json --composite false` | pass |
| Lint on changed files | `eslint PreviewPanel.tsx PreviewPanel.test.tsx` | 0 errors, 0 warnings |

Consumers/platform lanes excluded: renderer-only wiring change with no interface or main-process impact. Uncovered risks: E2E suites left to CI.

## Review focus

The single prop wiring in `PreviewPanel.tsx` and whether the inline panel should stay put on View in context (current choice: it does, since it does not cover the conversation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)