### PR TITLE
fix(resource-budget): bound local Artifact and Reviewer resources

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -590,7 +590,8 @@
         "src/main/artifacts/provenance-staging-recovery.ts",
         "src/main/artifacts/provenance-storage.ts",
         "src/main/artifacts/provenance-unindexed-recovery.ts",
-        "src/main/artifacts/provenance-version-writer.ts"
+        "src/main/artifacts/provenance-version-writer.ts",
+        "src/main/artifacts/write-budget-owner.ts"
       ],
       "interfacePaths": [
         "src/main/artifacts/provenance-message-snapshot.ts",
@@ -604,7 +605,8 @@
           "src/main/artifacts/provenance-message-snapshot.test.ts",
           "src/main/artifacts/provenance-repository.architecture.test.ts",
           "src/main/artifacts/provenance-repository.test.ts",
-          "src/main/artifacts/provenance-write-contract.test.ts"
+          "src/main/artifacts/provenance-write-contract.test.ts",
+          "src/main/artifacts/write-budget-owner.test.ts"
         ],
         "contract": [
           "src/main/artifacts/ipc.test.ts",

--- a/src/main/acp/artifact-turn-owner.test.ts
+++ b/src/main/acp/artifact-turn-owner.test.ts
@@ -242,12 +242,22 @@ describe('ArtifactTurnOwner', () => {
       expect.objectContaining({
         executionId: 'root-execution',
         artifactRunId: 'artifact-run-100-1',
-        allowedMethods: ['artifactCreateVersion', 'artifactReplayVersion']
+        allowedMethods: [
+          'artifactReserveWrite',
+          'artifactReleaseWrite',
+          'artifactCreateVersion',
+          'artifactReplayVersion'
+        ]
       }),
       expect.objectContaining({
         executionId: 'parallel-execution',
         artifactRunId: 'artifact-run-100-2',
-        allowedMethods: ['artifactCreateVersion', 'artifactReplayVersion']
+        allowedMethods: [
+          'artifactReserveWrite',
+          'artifactReleaseWrite',
+          'artifactCreateVersion',
+          'artifactReplayVersion'
+        ]
       })
     ])
     expect(owner.activeRunIds()).toEqual(['artifact-run-100-2'])
@@ -408,7 +418,12 @@ describe('ArtifactTurnOwner', () => {
         artifactStorageSessionId: 'artifact-session-1',
         artifactRunId: 'artifact-run-123-1',
         notebookSessionId: 'session-1',
-        allowedMethods: ['artifactCreateVersion', 'artifactReplayVersion']
+        allowedMethods: [
+          'artifactReserveWrite',
+          'artifactReleaseWrite',
+          'artifactCreateVersion',
+          'artifactReplayVersion'
+        ]
       })
     ])
     expect(notebookContexts).toEqual([

--- a/src/main/acp/artifact-turn-owner.ts
+++ b/src/main/acp/artifact-turn-owner.ts
@@ -219,7 +219,12 @@ class ArtifactTurnOwner {
         ...(turn.notebookArtifactSourceScope
           ? { notebookSessionId: turn.notebookArtifactSourceScope.notebookSessionId }
           : {}),
-        allowedMethods: ['artifactCreateVersion', 'artifactReplayVersion']
+        allowedMethods: [
+          'artifactReserveWrite',
+          'artifactReleaseWrite',
+          'artifactCreateVersion',
+          'artifactReplayVersion'
+        ]
       })
       if (turn.rpcCapabilityToken) runContext.rpcCapabilityToken = turn.rpcCapabilityToken
 

--- a/src/main/acp/mcp-http-host.test.ts
+++ b/src/main/acp/mcp-http-host.test.ts
@@ -307,6 +307,24 @@ describe('AgentMcpHttpHost', () => {
     expect(response.status).toBe(401)
   })
 
+  it('rejects an authenticated request body above the host budget', async () => {
+    host = new AgentMcpHttpHost({ requestBytes: 2 })
+    const { endpoint, token } = await host.ensureStarted()
+    host.registerHostMessage('bounded', { sendMessage: vi.fn() })
+
+    const response = await fetch(`${endpoint}/mcp/host-message/bounded`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json'
+      },
+      body: '{} '
+    })
+
+    expect(response.status).toBe(413)
+    expect(response.headers.get('connection')).toBe('close')
+  })
+
   it('serves one trusted side-chat host-message handler over its bound route', async () => {
     host = new AgentMcpHttpHost()
     const { token } = await host.ensureStarted()

--- a/src/main/acp/mcp-http-host.ts
+++ b/src/main/acp/mcp-http-host.ts
@@ -22,6 +22,11 @@ import {
   type HostMessageMcpHandler
 } from '../side-chat/host-message-mcp-server'
 import { createLogger } from '../logger'
+import {
+  LOCAL_RESOURCE_BUDGETS,
+  ResourceBudgetExceededError,
+  readBoundedJsonBody
+} from '../resource-budget'
 
 const log = createLogger('mcp-http-host')
 
@@ -46,19 +51,6 @@ type SessionEntry = {
   hostMessage?: HostMessageMcpHandler
 }
 
-// Reads and JSON-parses a POST body so it can be handed to the transport as a pre-parsed payload.
-const readJsonBody = async (request: IncomingMessage): Promise<unknown> => {
-  const chunks: Buffer[] = []
-
-  for await (const chunk of request) {
-    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
-  }
-
-  if (chunks.length === 0) return undefined
-
-  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown
-}
-
 const writeJson = (response: ServerResponse, statusCode: number, payload: unknown): void => {
   response.writeHead(statusCode, { 'content-type': 'application/json' })
   response.end(`${JSON.stringify(payload)}\n`)
@@ -72,14 +64,16 @@ const writeJson = (response: ServerResponse, statusCode: number, payload: unknow
 class AgentMcpHttpHost {
   private readonly token: string
   private readonly host: string
+  private readonly requestBytes: number
   private server: Server | undefined
   private startPromise: Promise<HostConnection> | undefined
   private endpoint: string | undefined
   private readonly sessions = new Map<string, SessionEntry>()
 
-  constructor(options: { token?: string; host?: string } = {}) {
+  constructor(options: { token?: string; host?: string; requestBytes?: number } = {}) {
     this.token = options.token ?? randomUUID()
     this.host = options.host ?? '127.0.0.1'
+    this.requestBytes = options.requestBytes ?? LOCAL_RESOURCE_BUDGETS.requestBytes
   }
 
   // Starts the HTTP server once on an ephemeral port and returns its connection details.
@@ -257,13 +251,23 @@ class AgentMcpHttpHost {
 
     try {
       await server.connect(transport)
-      const body = request.method === 'POST' ? await readJsonBody(request) : undefined
+      const body =
+        request.method === 'POST'
+          ? await readBoundedJsonBody<unknown>(request, this.requestBytes, {
+              emptyValue: undefined
+            })
+          : undefined
       await transport.handleRequest(request, response, body)
     } catch (error) {
       log.error('MCP host request failed', { kind, error })
 
       if (!response.headersSent) {
-        writeJson(response, 500, {
+        if (error instanceof ResourceBudgetExceededError) {
+          response.shouldKeepAlive = false
+          response.setHeader('connection', 'close')
+          response.once('finish', () => request.destroy())
+        }
+        writeJson(response, error instanceof ResourceBudgetExceededError ? 413 : 500, {
           error: error instanceof Error ? error.message : String(error)
         })
       }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -9169,7 +9169,12 @@ describe('ACP runtime session management', () => {
         appSessionId: session.sessionId,
         artifactRunId: capturedContext?.artifactRunId,
         rootFrameId: 'root-frame-1',
-        allowedMethods: ['artifactCreateVersion', 'artifactReplayVersion']
+        allowedMethods: [
+          'artifactReserveWrite',
+          'artifactReleaseWrite',
+          'artifactCreateVersion',
+          'artifactReplayVersion'
+        ]
       })
     ])
     expect(revokedTokens).toEqual(['run-capability-1'])
@@ -19983,11 +19988,16 @@ describe('ACP runtime session management', () => {
     const rpcServer = new NotebookLocalRpcServer(notebookService, {
       transport: 'tcp',
       artifactProvenance: {
-        createVersion: async (request) => {
+        createVersion: async (request, signal) => {
           rpcWriteStarted.resolve()
           await releaseRpcWrite.promise
-          return durableProvenance.createVersion(request)
-        }
+          return durableProvenance.createVersion(request, signal)
+        },
+        reserveWrite: (request) => durableProvenance.reserveWrite(request),
+        releaseWriteReservation: (request) => durableProvenance.releaseWriteReservation(request),
+        releaseRunWriteReservations: (request) =>
+          durableProvenance.releaseRunWriteReservations(request),
+        releaseAllWriteReservations: () => durableProvenance.releaseAllWriteReservations()
       }
     })
     const rpcConnection = await rpcServer.ensureStarted()
@@ -19995,6 +20005,10 @@ describe('ACP runtime session management', () => {
     let rpcWrite: Promise<Response> | undefined
     let artifactClaimId: string | undefined
     let currentRunFile = ''
+    const rpcFilename = 'rpc-late.txt'
+    const rpcContent = 'accepted RPC bytes'
+    const rpcSizeBytes = Buffer.byteLength(rpcContent)
+    const rpcChecksum = createHash('sha256').update(rpcContent).digest('hex')
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['remote-session-1'], {
       onPrompt: async ({ sessionId }) => {
@@ -20016,9 +20030,30 @@ describe('ACP runtime session management', () => {
           projectName: 'project-1',
           sessionId: artifactStorageSessionId,
           runId: context.artifactRunId,
-          filename: 'rpc-late.txt',
-          source: { kind: 'inline', content: 'accepted RPC bytes', encoding: 'utf8' }
+          filename: rpcFilename,
+          source: { kind: 'inline', content: rpcContent, encoding: 'utf8' }
         })
+        const reservationResponse = await fetch(rpcConnection.endpoint, {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${context.rpcCapabilityToken}`,
+            'content-type': 'application/json'
+          },
+          body: JSON.stringify({
+            method: 'artifactReserveWrite',
+            params: {
+              projectId: 'project-1',
+              appSessionId: sessionId,
+              artifactStorageSessionId,
+              artifactRunId: context.artifactRunId,
+              writeOperationId: 'write-rpc-late',
+              filename: rpcFilename,
+              fileBytes: rpcSizeBytes
+            }
+          })
+        })
+        expect(reservationResponse.status).toBe(200)
+        const reservation = (await reservationResponse.json()) as { result: { id: string } }
         rpcWrite = fetch(rpcConnection.endpoint, {
           method: 'POST',
           headers: {
@@ -20034,12 +20069,15 @@ describe('ACP runtime session management', () => {
               artifactRunId: context.artifactRunId,
               writeOperationId: 'write-rpc-late',
               writeRequestChecksum: 'c'.repeat(64),
+              resourceReservationId: reservation.result.id,
+              resourceSizeBytes: rpcSizeBytes,
+              resourceChecksum: rpcChecksum,
               rootFrameId: context.rootFrameId,
               agentFrameId: context.agentFrameId,
               messageBranchId: context.messageBranchId,
               runtimeSegmentId: context.runtimeSegmentId,
               promptMessageId: context.promptMessageId,
-              filename: 'rpc-late.txt',
+              filename: rpcFilename,
               contentType: 'text/plain'
             }
           })

--- a/src/main/acp/session-capability-owner.test.ts
+++ b/src/main/acp/session-capability-owner.test.ts
@@ -714,13 +714,34 @@ describe('ACP session capability owner', () => {
   })
 
   it.each([
-    ['claude-code', claudeCodeFramework, true, false, 'open-science-notebook'],
-    ['opencode', opencodeFramework, true, false, 'open_science_notebook'],
-    ['codex-response', codexFramework, true, false, 'open-science-notebook'],
-    ['codex-bridge', codexFramework, false, true, 'open-science-notebook']
+    [
+      'claude-code',
+      claudeCodeFramework,
+      true,
+      false,
+      'open-science-artifacts',
+      'open-science-notebook'
+    ],
+    ['opencode', opencodeFramework, true, false, 'open_science_artifacts', 'open_science_notebook'],
+    [
+      'codex-response',
+      codexFramework,
+      true,
+      false,
+      'open-science-artifacts',
+      'open-science-notebook'
+    ],
+    ['codex-bridge', codexFramework, false, true, 'open-science-artifacts', 'open-science-notebook']
   ] as const)(
-    'publishes the shared Host control plane through the %s primary descriptor',
-    async (_route, framework, nativeMcpEnabled, bridgeMcpAliasesEnabled, notebookServerName) => {
+    'publishes the bounded Artifact/Notebook control plane through the %s primary descriptor',
+    async (
+      _route,
+      framework,
+      nativeMcpEnabled,
+      bridgeMcpAliasesEnabled,
+      artifactServerName,
+      notebookServerName
+    ) => {
       const owner = createOwner()
       const built = await owner.provision({
         stableAppSessionId: 'session-1',
@@ -744,6 +765,8 @@ describe('ACP session capability owner', () => {
       expect(built.descriptor.capabilities).toEqual(
         expect.arrayContaining(['notebook', 'host-skills', 'host-frames', 'host-llm'])
       )
+      expect(built.descriptor.transport).toBe('stdio')
+      expect(built.descriptor.modelFacingMcpServerNames).toContain(artifactServerName)
       expect(built.descriptor.modelFacingMcpServerNames).toContain(notebookServerName)
     }
   )

--- a/src/main/artifacts/mcp-server.test.ts
+++ b/src/main/artifacts/mcp-server.test.ts
@@ -506,7 +506,12 @@ describe('artifact MCP server', () => {
       'fetch',
       vi.fn(async (url: string, init: RequestInit) => {
         calls.push({ url, init })
-        return new Response(JSON.stringify({ result: persisted }), {
+        const body = JSON.parse(String(init.body)) as { method: string }
+        const result =
+          body.method === 'artifactReserveWrite'
+            ? { id: `reservation-${calls.length}`, fileBytes: 4, expiresAt: Date.now() + 60_000 }
+            : persisted
+        return new Response(JSON.stringify({ result }), {
           status: 200,
           headers: { 'content-type': 'application/json' }
         })
@@ -537,10 +542,23 @@ describe('artifact MCP server', () => {
     )
 
     expect(result).toEqual(persisted)
-    expect(calls).toHaveLength(2)
+    expect(calls).toHaveLength(4)
     expect(calls[0].url).toBe(environment.rpcEndpoint)
     expect(calls[0].init.headers).toMatchObject({ authorization: 'Bearer run-capability' })
-    const body = JSON.parse(String(calls[0].init.body)) as {
+    const bodies = calls.map(
+      (call) =>
+        JSON.parse(String(call.init.body)) as {
+          method: string
+          params: Record<string, unknown>
+        }
+    )
+    expect(bodies.map((body) => body.method)).toEqual([
+      'artifactReserveWrite',
+      'artifactCreateVersion',
+      'artifactReserveWrite',
+      'artifactCreateVersion'
+    ])
+    const body = bodies[1] as {
       method: string
       params: Record<string, unknown>
     }
@@ -560,10 +578,13 @@ describe('artifact MCP server', () => {
       filename: 'sin.png',
       contentType: 'image/png'
     })
-    const retryBody = JSON.parse(String(calls[1].init.body)) as {
-      params: Record<string, unknown>
-    }
+    const retryBody = bodies[3]!
     expect(retryBody.params.writeOperationId).toBe(body.params.writeOperationId)
+    expect(body.params).toMatchObject({
+      resourceReservationId: 'reservation-1',
+      resourceSizeBytes: expect.any(Number),
+      resourceChecksum: expect.stringMatching(/^[a-f0-9]{64}$/u)
+    })
     expect(body.params.writeRequestChecksum).toMatch(/^[a-f0-9]{64}$/)
     expect(toWriteArtifactToolResult(result)).toEqual({
       artifact: {
@@ -603,8 +624,11 @@ describe('artifact MCP server', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async (_url: string, init: RequestInit) => {
-        const body = JSON.parse(String(init.body)) as { params: Record<string, unknown> }
-        rpcRequests.push(body.params)
+        const body = JSON.parse(String(init.body)) as {
+          method: string
+          params: Record<string, unknown>
+        }
+        rpcRequests.push({ method: body.method, ...body.params })
         for (const sessionId of ['parent-session-1', 'child-routing-session']) {
           const pendingPath = join(
             root,
@@ -623,27 +647,26 @@ describe('artifact MCP server', () => {
             pendingSessionsObserved.push(sessionId)
           }
         }
-        return new Response(
-          JSON.stringify({
-            result: {
-              id: 'version-delegated',
-              artifactId: 'artifact-delegated',
-              versionId: 'version-delegated',
-              versionNumber: 1,
-              checksum: 'b'.repeat(64),
-              createdAt: '2026-08-07T00:00:00.000Z',
-              projectName: 'default-project',
-              sessionId: 'parent-session-1',
-              runId: 'artifact-run-delegated',
-              name: 'delegated.txt',
-              path: join(root, 'immutable-delegated'),
-              fileUrl: 'file:///immutable-delegated',
-              size: 17,
-              mtimeMs: 1
-            }
-          }),
-          { status: 200 }
-        )
+        const result =
+          body.method === 'artifactReserveWrite'
+            ? { id: 'reservation-delegated', fileBytes: 17, expiresAt: Date.now() + 60_000 }
+            : {
+                id: 'version-delegated',
+                artifactId: 'artifact-delegated',
+                versionId: 'version-delegated',
+                versionNumber: 1,
+                checksum: 'b'.repeat(64),
+                createdAt: '2026-08-07T00:00:00.000Z',
+                projectName: 'default-project',
+                sessionId: 'parent-session-1',
+                runId: 'artifact-run-delegated',
+                name: 'delegated.txt',
+                path: join(root, 'immutable-delegated'),
+                fileUrl: 'file:///immutable-delegated',
+                size: 17,
+                mtimeMs: 1
+              }
+        return new Response(JSON.stringify({ result }), { status: 200 })
       })
     )
 
@@ -654,8 +677,17 @@ describe('artifact MCP server', () => {
 
     expect(result).toMatchObject({ sessionId: 'parent-session-1' })
     expect(pendingSessionsObserved).toEqual(['parent-session-1'])
-    expect(rpcRequests).toHaveLength(1)
-    expect(rpcRequests[0]).toMatchObject({ artifactStorageSessionId: 'parent-session-1' })
+    expect(rpcRequests).toHaveLength(2)
+    expect(rpcRequests).toEqual([
+      expect.objectContaining({
+        method: 'artifactReserveWrite',
+        artifactStorageSessionId: 'parent-session-1'
+      }),
+      expect.objectContaining({
+        method: 'artifactCreateVersion',
+        artifactStorageSessionId: 'parent-session-1'
+      })
+    ])
   })
 
   it('returns a compact legacy artifact receipt without echoing local paths', () => {
@@ -709,12 +741,28 @@ describe('artifact MCP server', () => {
       'artifact-run-1',
       'sin.png'
     )
-    let callCount = 0
+    let createCallCount = 0
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => {
-        callCount += 1
-        if (callCount === 2) {
+      vi.fn(async (_url: string, init: RequestInit) => {
+        const body = JSON.parse(String(init.body)) as { method: string }
+        if (body.method === 'artifactReserveWrite') {
+          return new Response(
+            JSON.stringify({
+              result: {
+                id: `reservation-${createCallCount + 1}`,
+                fileBytes: 8,
+                expiresAt: Date.now() + 60_000
+              }
+            }),
+            { status: 200 }
+          )
+        }
+        if (body.method === 'artifactReleaseWrite') {
+          return new Response(JSON.stringify({ result: null }), { status: 200 })
+        }
+        createCallCount += 1
+        if (createCallCount === 2) {
           return new Response(JSON.stringify({ error: 'idempotency conflict' }), { status: 409 })
         }
         return new Response(
@@ -815,7 +863,15 @@ describe('artifact MCP server', () => {
         requests.push(body)
         methods.push(body.method)
         const result =
-          body.method === 'artifactReplayVersion' && methods.length === 1 ? null : persisted
+          body.method === 'artifactReplayVersion' && methods.length === 1
+            ? null
+            : body.method === 'artifactReserveWrite'
+              ? {
+                  id: 'reservation-local-path',
+                  fileBytes: body.params.fileBytes,
+                  expiresAt: Date.now() + 60_000
+                }
+              : persisted
         return new Response(JSON.stringify({ result }), {
           status: 200,
           headers: { 'content-type': 'application/json' }
@@ -843,14 +899,15 @@ describe('artifact MCP server', () => {
 
     expect(methods).toEqual([
       'artifactReplayVersion',
+      'artifactReserveWrite',
       'artifactCreateVersion',
       'artifactReplayVersion'
     ])
-    expect(requests[1]?.params.sourceFileObservation).toEqual({
+    expect(requests[2]?.params.sourceFileObservation).toEqual({
       path: resolvedSourcePath,
       sizeBytes: sourceStat.size,
       mtimeMs: sourceStat.mtimeMs
     })
-    expect(requests[1]?.params.sourceKind).toBe('localPath')
+    expect(requests[2]?.params.sourceKind).toBe('localPath')
   })
 })

--- a/src/main/artifacts/mcp-server.ts
+++ b/src/main/artifacts/mcp-server.ts
@@ -11,14 +11,18 @@ import type {
   ArtifactWriteSource
 } from '../../shared/artifacts'
 import type {
+  ArtifactWriteReservation,
   ArtifactVersionFile,
   CreateArtifactVersionRequest,
+  ReleaseArtifactWriteReservationRequest,
+  ReserveArtifactWriteRequest,
   ReplayArtifactVersionRequest
 } from '../../shared/artifact-provenance'
 import { resolveProjectId } from '../../shared/project-scope'
 import type { ProjectIdScope } from '../../shared/project-scope'
 import { ARTIFACT_MCP_SERVER_ARG } from '../mcp-server-args'
 import { fetchLocalRpc } from '../local-rpc-transport'
+import { LOCAL_RESOURCE_BUDGETS } from '../resource-budget'
 import { ArtifactRepository } from './repository'
 
 const ARTIFACT_MCP_SERVER_NAME = 'open-science-artifacts'
@@ -72,6 +76,7 @@ type ArtifactToolWriteInput = {
 type ArtifactWriteInvocation = {
   writeOperationId?: string
   requestId?: string | number
+  signal?: AbortSignal
 }
 
 // Some MCP clients serialize nested tool arguments before sending them. Accept a valid JSON string
@@ -196,12 +201,13 @@ const readCurrentRunContext = async (currentRunFile: string): Promise<ArtifactRu
   }
 }
 
-type ArtifactRpcResponse = { result?: ArtifactVersionFile | null; error?: string }
+type ArtifactRpcResponse<Result> = { result?: Result | null; error?: string }
 
 const callArtifactRpc = async (
   environment: ArtifactMcpEnvironment,
   capabilityToken: string,
-  request: CreateArtifactVersionRequest
+  request: CreateArtifactVersionRequest,
+  signal?: AbortSignal
 ): Promise<ArtifactVersionFile> => {
   if (!environment.rpcEndpoint) {
     throw new Error('Artifact Provenance RPC connection is not configured.')
@@ -218,11 +224,12 @@ const callArtifactRpc = async (
         authorization: `Bearer ${capabilityToken}`,
         'content-type': 'application/json'
       },
-      body: JSON.stringify({ method: 'artifactCreateVersion', params: request })
+      body: JSON.stringify({ method: 'artifactCreateVersion', params: request }),
+      signal
     },
     'Artifact Provenance RPC'
   )
-  const payload = (await response.json()) as ArtifactRpcResponse
+  const payload = (await response.json()) as ArtifactRpcResponse<ArtifactVersionFile>
 
   if (!response.ok || payload.error || !payload.result) {
     throw new Error(
@@ -235,7 +242,8 @@ const callArtifactRpc = async (
 const callArtifactReplayRpc = async (
   environment: ArtifactMcpEnvironment,
   capabilityToken: string,
-  request: ReplayArtifactVersionRequest
+  request: ReplayArtifactVersionRequest,
+  signal?: AbortSignal
 ): Promise<ArtifactVersionFile | undefined> => {
   if (!environment.rpcEndpoint) {
     throw new Error('Artifact Provenance RPC connection is not configured.')
@@ -251,17 +259,75 @@ const callArtifactReplayRpc = async (
         authorization: `Bearer ${capabilityToken}`,
         'content-type': 'application/json'
       },
-      body: JSON.stringify({ method: 'artifactReplayVersion', params: request })
+      body: JSON.stringify({ method: 'artifactReplayVersion', params: request }),
+      signal
     },
     'Artifact Provenance RPC'
   )
-  const payload = (await response.json()) as ArtifactRpcResponse
+  const payload = (await response.json()) as ArtifactRpcResponse<ArtifactVersionFile>
   if (!response.ok || payload.error) {
     throw new Error(
       payload.error ?? `Artifact Provenance RPC failed with status ${response.status}`
     )
   }
   return payload.result ?? undefined
+}
+
+const callArtifactReserveRpc = async (
+  environment: ArtifactMcpEnvironment,
+  capabilityToken: string,
+  request: ReserveArtifactWriteRequest,
+  signal?: AbortSignal
+): Promise<ArtifactWriteReservation> => {
+  if (!environment.rpcEndpoint) {
+    throw new Error('Artifact Provenance RPC connection is not configured.')
+  }
+  const response = await fetchLocalRpc(
+    { endpoint: environment.rpcEndpoint, socketPath: environment.rpcSocketPath },
+    {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${capabilityToken}`,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ method: 'artifactReserveWrite', params: request }),
+      signal
+    },
+    'Artifact write reservation RPC'
+  )
+  const payload = (await response.json()) as ArtifactRpcResponse<ArtifactWriteReservation>
+  if (!response.ok || payload.error || !payload.result) {
+    throw new Error(
+      payload.error ?? `Artifact reservation RPC failed with status ${response.status}`
+    )
+  }
+  return payload.result
+}
+
+const callArtifactReleaseRpc = async (
+  environment: ArtifactMcpEnvironment,
+  capabilityToken: string,
+  request: ReleaseArtifactWriteReservationRequest
+): Promise<void> => {
+  if (!environment.rpcEndpoint) return
+  const response = await fetchLocalRpc(
+    { endpoint: environment.rpcEndpoint, socketPath: environment.rpcSocketPath },
+    {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${capabilityToken}`,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ method: 'artifactReleaseWrite', params: request })
+    },
+    'Artifact write reservation release RPC'
+  )
+  if (!response.ok) {
+    const payload = (await response.json()) as ArtifactRpcResponse<never>
+    throw new Error(
+      payload.error ?? `Artifact reservation release RPC failed with status ${response.status}`
+    )
+  }
 }
 
 // Normalizes the legacy content/encoding shape and the new source shape into one repository input.
@@ -358,7 +424,8 @@ const writeArtifactFileForCurrentRun = async (
     allowedImportRoots: context.notebookSessionRoot
       ? [...environment.allowedImportRoots, context.notebookSessionRoot]
       : environment.allowedImportRoots,
-    relativeBaseDirs
+    relativeBaseDirs,
+    signal: invocation.signal
   }
 
   // Old handoff files remain writable during migration. New production handoffs always include the
@@ -402,26 +469,57 @@ const writeArtifactFileForCurrentRun = async (
   // app-owned operation already committed before copying or reading that path. Inline content remains
   // byte-checked below so reusing an operation with different inline bytes is still a hard conflict.
   if (source.kind === 'localPath') {
-    const replay = await callArtifactReplayRpc(environment, rpcCapabilityToken, {
-      projectId,
-      appSessionId,
-      artifactStorageSessionId,
-      artifactRunId: context.artifactRunId,
-      writeOperationId,
-      filename: input.filename,
-      contentType: input.mimeType,
-      producerRunId: input.producerRunId
-    })
+    const replay = await callArtifactReplayRpc(
+      environment,
+      rpcCapabilityToken,
+      {
+        projectId,
+        appSessionId,
+        artifactStorageSessionId,
+        artifactRunId: context.artifactRunId,
+        writeOperationId,
+        filename: input.filename,
+        contentType: input.mimeType,
+        producerRunId: input.producerRunId
+      },
+      invocation.signal
+    )
     if (replay) return replay
+  }
+
+  const nativeWriteOptions = {
+    ...writeOptions,
+    reserveFile: (fileBytes: number) =>
+      callArtifactReserveRpc(
+        environment,
+        rpcCapabilityToken,
+        {
+          projectId,
+          appSessionId,
+          artifactStorageSessionId,
+          artifactRunId: context.artifactRunId,
+          writeOperationId,
+          filename: input.filename,
+          fileBytes
+        },
+        invocation.signal
+      ),
+    releaseFileReservation: (reservationId: string) =>
+      callArtifactReleaseRpc(environment, rpcCapabilityToken, {
+        projectId,
+        appSessionId,
+        artifactStorageSessionId,
+        artifactRunId: context.artifactRunId,
+        reservationId
+      })
   }
 
   return repository.withPendingFileTransaction(
     writeRequest,
-    writeOptions,
-    async (pendingFile, sourceFileObservation) => {
-      const contentChecksum = createHash('sha256')
-        .update(await readFile(pendingFile.path))
-        .digest('hex')
+    nativeWriteOptions,
+    async (_pendingFile, sourceFileObservation, _bindVersionRouting, fileDigest, reservation) => {
+      if (!reservation) throw new Error('Artifact write reservation was not created.')
+      const contentChecksum = fileDigest.checksum
       const writeRequestChecksum = createHash('sha256')
         .update(
           JSON.stringify({
@@ -435,28 +533,36 @@ const writeArtifactFileForCurrentRun = async (
         )
         .digest('hex')
 
-      return callArtifactRpc(environment, rpcCapabilityToken, {
-        projectId,
-        appSessionId,
-        artifactStorageSessionId,
-        artifactRunId: context.artifactRunId,
-        writeOperationId,
-        writeRequestChecksum,
-        rootFrameId,
-        agentFrameId,
-        messageBranchId,
-        messageBranchAncestry: context.messageBranchAncestry,
-        messageAncestry: context.messageAncestry,
-        runtimeSegmentId,
-        promptMessageId,
-        agentName: context.agentName,
-        notebookSessionId: context.notebookSessionId,
-        producerRunId: input.producerRunId,
-        sourceKind: source.kind,
-        sourceFileObservation,
-        filename: input.filename,
-        contentType: input.mimeType
-      })
+      return callArtifactRpc(
+        environment,
+        rpcCapabilityToken,
+        {
+          projectId,
+          appSessionId,
+          artifactStorageSessionId,
+          artifactRunId: context.artifactRunId,
+          writeOperationId,
+          writeRequestChecksum,
+          rootFrameId,
+          agentFrameId,
+          messageBranchId,
+          messageBranchAncestry: context.messageBranchAncestry,
+          messageAncestry: context.messageAncestry,
+          runtimeSegmentId,
+          promptMessageId,
+          agentName: context.agentName,
+          notebookSessionId: context.notebookSessionId,
+          producerRunId: input.producerRunId,
+          sourceKind: source.kind,
+          sourceFileObservation,
+          filename: input.filename,
+          contentType: input.mimeType,
+          resourceReservationId: reservation.id,
+          resourceSizeBytes: fileDigest.sizeBytes,
+          resourceChecksum: fileDigest.checksum
+        },
+        invocation.signal
+      )
     }
   )
 }
@@ -503,7 +609,8 @@ const createArtifactMcpServer = (
     async (input, extra) => {
       // Echo the stored artifact metadata so the model can mention filenames without inventing paths.
       const artifact = await writeArtifactFileForCurrentRun(repository, environment, input, {
-        requestId: extra.requestId
+        requestId: extra.requestId,
+        signal: extra.signal
       })
 
       return {
@@ -592,7 +699,11 @@ const runArtifactMcpServer = async (
   const repository = new ArtifactRepository(environment.storageRoot)
   const server = createArtifactMcpServer(repository, environment)
 
-  await server.connect(new StdioServerTransport())
+  await server.connect(
+    new StdioServerTransport(process.stdin, process.stdout, {
+      maxBufferSize: LOCAL_RESOURCE_BUDGETS.requestBytes
+    })
+  )
 }
 
 export {

--- a/src/main/artifacts/pending-file-transaction.ts
+++ b/src/main/artifacts/pending-file-transaction.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, rename, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdir, open, rename, rm } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { dirname, join } from 'node:path'
 
@@ -8,10 +8,30 @@ import type {
   WritePendingArtifactFileRequest
 } from '../../shared/artifacts'
 import { validateArtifactContentType } from './content-type'
+import {
+  assertDiskReserve,
+  copyOpenFileWithinBudget,
+  inlineDecodedSize,
+  writeInlineWithinBudget
+} from '../bounded-file-io'
+import type { FileDigest } from '../bounded-file-io'
+import { LOCAL_RESOURCE_BUDGETS, assertWithinResourceBudget } from '../resource-budget'
+import { availableBytes } from '../storage/usage'
 
 type PendingFileTransactionOptions = {
   allowedImportRoots?: string[]
   relativeBaseDirs?: string[]
+  maxFileBytes?: number
+  maxInlineBytes?: number
+  diskReserveBytes?: number
+  signal?: AbortSignal
+  reserveFile?: (fileBytes: number) => Promise<{ id: string; fileBytes: number }>
+  releaseFileReservation?: (reservationId: string) => Promise<void>
+}
+
+type PendingFileBudgetReservation = {
+  id: string
+  fileBytes: number
 }
 
 type PendingFileTransactionStorage = {
@@ -53,7 +73,9 @@ const runPendingFileTransaction = async <Result, Routing>(options: {
   operation: (
     artifact: ArtifactFile,
     sourceFileObservation: ArtifactSourceFileObservation | undefined,
-    bindVersionRouting: BindPendingArtifactVersionRouting<Routing>
+    bindVersionRouting: BindPendingArtifactVersionRouting<Routing>,
+    fileDigest: FileDigest,
+    reservation: PendingFileBudgetReservation | undefined
   ) => Promise<Result>
 }): Promise<Result> => {
   const { request, storage } = options
@@ -72,6 +94,8 @@ const runPendingFileTransaction = async <Result, Routing>(options: {
   let replacementPublished = false
   let versionRoutingPublished = false
   let sourceFileObservation: ArtifactSourceFileObservation | undefined
+  let fileDigest: FileDigest | undefined
+  let reservation: PendingFileBudgetReservation | undefined
 
   await mkdir(directory, { recursive: true })
   try {
@@ -81,28 +105,61 @@ const runPendingFileTransaction = async <Result, Routing>(options: {
         options.writeOptions.allowedImportRoots ?? [],
         options.writeOptions.relativeBaseDirs
       )
-      const beforeCopy = await stat(sourcePath)
-      if (!beforeCopy.isFile()) {
-        throw new Error(`Artifact local source is not a regular file: "${sourcePath}".`)
-      }
-      await copyFile(sourcePath, temporaryPath)
-      const afterCopy = await stat(sourcePath)
-      if (afterCopy.size !== beforeCopy.size || afterCopy.mtimeMs !== beforeCopy.mtimeMs) {
-        throw new Error(
-          `Artifact local source changed while it was being imported: "${sourcePath}".`
+      const sourceHandle = await open(sourcePath, 'r')
+      try {
+        const beforeCopy = await sourceHandle.stat()
+        if (!beforeCopy.isFile()) {
+          throw new Error(`Artifact local source is not a regular file: "${sourcePath}".`)
+        }
+        const maxFileBytes =
+          options.writeOptions.maxFileBytes ?? LOCAL_RESOURCE_BUDGETS.artifactFileBytes
+        assertWithinResourceBudget('file', beforeCopy.size, maxFileBytes)
+        reservation = await options.writeOptions.reserveFile?.(beforeCopy.size)
+        if (reservation && reservation.fileBytes !== beforeCopy.size) {
+          throw new Error('Artifact file reservation does not match the preflight source size.')
+        }
+        assertDiskReserve(
+          await availableBytes(directory),
+          beforeCopy.size,
+          options.writeOptions.diskReserveBytes ?? LOCAL_RESOURCE_BUDGETS.diskReserveBytes
         )
-      }
-      sourceFileObservation = {
-        path: sourcePath,
-        sizeBytes: afterCopy.size,
-        mtimeMs: afterCopy.mtimeMs
+        fileDigest = await copyOpenFileWithinBudget(
+          sourceHandle,
+          temporaryPath,
+          reservation ? Math.min(maxFileBytes, reservation.fileBytes) : maxFileBytes,
+          options.writeOptions.signal
+        )
+        const afterCopy = await sourceHandle.stat()
+        if (afterCopy.size !== beforeCopy.size || afterCopy.mtimeMs !== beforeCopy.mtimeMs) {
+          throw new Error(
+            `Artifact local source changed while it was being imported: "${sourcePath}".`
+          )
+        }
+        sourceFileObservation = {
+          path: sourcePath,
+          sizeBytes: afterCopy.size,
+          mtimeMs: afterCopy.mtimeMs
+        }
+      } finally {
+        await sourceHandle.close()
       }
     } else {
-      await writeFile(
+      const maxInlineBytes =
+        options.writeOptions.maxInlineBytes ?? LOCAL_RESOURCE_BUDGETS.artifactInlineBytes
+      const decodedBytes = inlineDecodedSize(request.source.content, request.source.encoding)
+      assertWithinResourceBudget('file', decodedBytes, maxInlineBytes)
+      reservation = await options.writeOptions.reserveFile?.(decodedBytes)
+      assertDiskReserve(
+        await availableBytes(directory),
+        decodedBytes,
+        options.writeOptions.diskReserveBytes ?? LOCAL_RESOURCE_BUDGETS.diskReserveBytes
+      )
+      fileDigest = await writeInlineWithinBudget(
         temporaryPath,
-        request.source.encoding === 'base64'
-          ? Buffer.from(request.source.content, 'base64')
-          : Buffer.from(request.source.content, 'utf8')
+        request.source.content,
+        request.source.encoding,
+        maxInlineBytes,
+        options.writeOptions.signal
       )
     }
 
@@ -136,7 +193,14 @@ const runPendingFileTransaction = async <Result, Routing>(options: {
       await options.publishRouting(routing, sourcePath)
       versionRoutingPublished = true
     }
-    const result = await options.operation(artifact, sourceFileObservation, bindVersionRouting)
+    if (!fileDigest) throw new Error('Artifact pending write completed without a file digest.')
+    const result = await options.operation(
+      artifact,
+      sourceFileObservation,
+      bindVersionRouting,
+      fileDigest,
+      reservation
+    )
     await Promise.all([
       rm(backupPath, { force: true }).catch(() => undefined),
       rm(metadataBackupPath, { force: true }).catch(() => undefined)
@@ -144,6 +208,13 @@ const runPendingFileTransaction = async <Result, Routing>(options: {
     return result
   } catch (error) {
     const recoveryErrors: unknown[] = []
+    if (reservation && options.writeOptions.releaseFileReservation) {
+      try {
+        await options.writeOptions.releaseFileReservation(reservation.id)
+      } catch (releaseError) {
+        recoveryErrors.push(releaseError)
+      }
+    }
     await rm(temporaryPath, { force: true }).catch(() => undefined)
     if (replacementPublished && !versionRoutingPublished) {
       await Promise.all([
@@ -171,7 +242,7 @@ const runPendingFileTransaction = async <Result, Routing>(options: {
     if (recoveryErrors.length > 0) {
       throw new AggregateError(
         [error, ...recoveryErrors],
-        `Artifact pending-file rollback failed; preserved backup files for recovery: ${recoveryErrors
+        `Artifact pending-file rollback or reservation release failed: ${recoveryErrors
           .map((recoveryError) =>
             recoveryError instanceof Error ? recoveryError.message : String(recoveryError)
           )
@@ -193,4 +264,8 @@ const runPendingFileTransaction = async <Result, Routing>(options: {
 }
 
 export { runPendingFileTransaction }
-export type { PendingFileTransactionOptions, PendingFileTransactionStorage }
+export type {
+  PendingFileBudgetReservation,
+  PendingFileTransactionOptions,
+  PendingFileTransactionStorage
+}

--- a/src/main/artifacts/provenance-repository.architecture.test.ts
+++ b/src/main/artifacts/provenance-repository.architecture.test.ts
@@ -40,7 +40,8 @@ const productionFiles = [
   'provenance-staging-recovery.ts',
   'provenance-storage.ts',
   'provenance-unindexed-recovery.ts',
-  'provenance-version-writer.ts'
+  'provenance-version-writer.ts',
+  'write-budget-owner.ts'
 ] as const
 const deepOwnerFiles = productionFiles.filter(
   (file) => file !== 'provenance-repository.ts' && file !== 'provenance-message-snapshot.ts'
@@ -239,8 +240,13 @@ describe('Artifact Provenance repository architecture', () => {
         'prepareProjectReconciliation',
         'readCodeReconstructionCache',
         'reconcileSession',
+        'releaseAllWriteReservations',
+        'releaseRunWriteReservations',
+        'releaseWriteReservation',
         'replayVersion',
+        'reserveWrite',
         'resolveVersionContent',
+        'resolveVersionContentForStreamingVerification',
         'resolveVersionDescriptors',
         'validateFinalizationOwnership',
         'writeAppGeneratedVersion',
@@ -248,7 +254,12 @@ describe('Artifact Provenance repository architecture', () => {
       ].sort()
     )
     expect(methods(facade, 'private')).toEqual(
-      ['resolveVersionDerivedPath', 'toArtifactVersionFile', 'toDescriptor'].sort()
+      [
+        'resolveVersionContentMetadata',
+        'resolveVersionDerivedPath',
+        'toArtifactVersionFile',
+        'toDescriptor'
+      ].sort()
     )
   })
 
@@ -261,7 +272,8 @@ describe('Artifact Provenance repository architecture', () => {
       'ArtifactProvenanceReadModel',
       'ArtifactProvenanceStagingRecovery',
       'ArtifactProvenanceUnindexedRecovery',
-      'ArtifactProvenanceVersionWriter'
+      'ArtifactProvenanceVersionWriter',
+      'ArtifactWriteBudgetOwner'
     ]) {
       expect(newExpressionSites(owner), owner).toEqual(['provenance-repository.ts:constructor'])
     }
@@ -279,7 +291,8 @@ describe('Artifact Provenance repository architecture', () => {
         'readModel',
         'stagingRecovery',
         'unindexedRecovery',
-        'versionWriter'
+        'versionWriter',
+        'writeBudgetOwner'
       ].sort()
     )
     expect(mutableFields(facade)).toEqual([])
@@ -307,6 +320,10 @@ describe('Artifact Provenance repository architecture', () => {
           'getVersionProvenance',
           'getVersionReview',
           'readCodeReconstructionCache',
+          'releaseAllWriteReservations',
+          'releaseRunWriteReservations',
+          'releaseWriteReservation',
+          'reserveWrite',
           'validateFinalizationOwnership',
           'writeCodeReconstructionCache'
         ].map((method) => [method, delegationTarget(facade, facadeFile, method)])
@@ -322,6 +339,10 @@ describe('Artifact Provenance repository architecture', () => {
       getVersionProvenance: 'this.readModel.getVersionProvenance',
       getVersionReview: 'this.readModel.getVersionReview',
       readCodeReconstructionCache: 'this.readModel.readCodeReconstructionCache',
+      releaseAllWriteReservations: 'this.writeBudgetOwner.releaseAll',
+      releaseRunWriteReservations: 'this.writeBudgetOwner.releaseRun',
+      releaseWriteReservation: 'this.writeBudgetOwner.release',
+      reserveWrite: 'this.writeBudgetOwner.reserve',
       validateFinalizationOwnership: 'this.messageFinalizer.validateOwnership',
       writeCodeReconstructionCache: 'this.readModel.writeCodeReconstructionCache'
     })
@@ -397,7 +418,8 @@ describe('Artifact Provenance repository architecture', () => {
         'src/main/artifacts/provenance-message-snapshot.test.ts',
         'src/main/artifacts/provenance-repository.architecture.test.ts',
         'src/main/artifacts/provenance-repository.test.ts',
-        'src/main/artifacts/provenance-write-contract.test.ts'
+        'src/main/artifacts/provenance-write-contract.test.ts',
+        'src/main/artifacts/write-budget-owner.test.ts'
       ].sort()
     )
     expect(module.testFiles.contract).toEqual(

--- a/src/main/artifacts/provenance-repository.test.ts
+++ b/src/main/artifacts/provenance-repository.test.ts
@@ -27,6 +27,7 @@ import {
   ArtifactProvenanceRepository
 } from './provenance-repository'
 import { ArtifactRepository } from './repository'
+import { ArtifactWriteBudgetOwner } from './write-budget-owner'
 
 let storageRoot: string | undefined
 let disconnect: (() => Promise<void>) | undefined
@@ -202,6 +203,181 @@ describe('artifact provenance repository', () => {
     await repository.reconcileSession('project-1', 'session-1')
 
     await expect(stat(stagingDirectory)).resolves.toBeDefined()
+  })
+
+  it('serializes same-session writes so concurrent calls cannot exceed the turn budget', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-artifact-turn-budget-'))
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+    await migrateApplicationDatabase(client)
+    const compatibilityRepository = new ArtifactRepository(storageRoot)
+    const content = createPngBytes('budgeted')
+    const repository = new ArtifactProvenanceRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client),
+      compatibilityRepository,
+      resourceBudgets: {
+        artifactTurnBytes: content.byteLength,
+        artifactSessionBytes: content.byteLength * 10
+      }
+    })
+    const common = {
+      projectId: 'project-1',
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-1',
+      artifactRunId: 'artifact-run-1',
+      rootFrameId: 'root-frame-1',
+      agentFrameId: 'agent-frame-1',
+      messageBranchId: 'branch-1',
+      runtimeSegmentId: 'runtime-segment-1',
+      promptMessageId: 'prompt-1',
+      agentName: 'Codex',
+      contentType: 'image/png'
+    } as const
+    for (const filename of ['a.png', 'b.png']) {
+      await compatibilityRepository.writePendingFile({
+        projectName: common.projectId,
+        sessionId: common.artifactStorageSessionId,
+        runId: common.artifactRunId,
+        filename,
+        mimeType: common.contentType,
+        source: { kind: 'inline', content: content.toString('base64'), encoding: 'base64' }
+      })
+    }
+
+    const results = await Promise.allSettled(
+      ['a.png', 'b.png'].map((filename, index) =>
+        repository.createVersion({
+          ...common,
+          filename,
+          writeOperationId: `write-${index}`,
+          writeRequestChecksum: String(index).repeat(64)
+        })
+      )
+    )
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1)
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1)
+    expect(results.find((result) => result.status === 'rejected')).toMatchObject({
+      reason: { dimension: 'turn' }
+    })
+  })
+
+  it('counts durable bytes across runs in the same Session', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-artifact-session-budget-'))
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+    await migrateApplicationDatabase(client)
+    const compatibilityRepository = new ArtifactRepository(storageRoot)
+    const content = createPngBytes('session-budgeted')
+    const repository = new ArtifactProvenanceRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client),
+      compatibilityRepository,
+      resourceBudgets: {
+        artifactTurnBytes: content.byteLength * 10,
+        artifactSessionBytes: content.byteLength
+      }
+    })
+    const common = {
+      projectId: 'project-1',
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-1',
+      rootFrameId: 'root-frame-1',
+      agentFrameId: 'agent-frame-1',
+      messageBranchId: 'branch-1',
+      runtimeSegmentId: 'runtime-segment-1',
+      promptMessageId: 'prompt-1',
+      agentName: 'Codex',
+      contentType: 'image/png'
+    } as const
+
+    for (const [filename, artifactRunId] of [
+      ['first.png', 'artifact-run-1'],
+      ['second.png', 'artifact-run-2']
+    ] as const) {
+      await compatibilityRepository.writePendingFile({
+        projectName: common.projectId,
+        sessionId: common.artifactStorageSessionId,
+        runId: artifactRunId,
+        filename,
+        mimeType: common.contentType,
+        source: { kind: 'inline', content: content.toString('base64'), encoding: 'base64' }
+      })
+    }
+    await repository.createVersion({
+      ...common,
+      artifactRunId: 'artifact-run-1',
+      filename: 'first.png',
+      writeOperationId: 'write-first',
+      writeRequestChecksum: 'a'.repeat(64)
+    })
+
+    await expect(
+      repository.createVersion({
+        ...common,
+        artifactRunId: 'artifact-run-2',
+        filename: 'second.png',
+        writeOperationId: 'write-second',
+        writeRequestChecksum: 'b'.repeat(64)
+      })
+    ).rejects.toMatchObject({ dimension: 'session' })
+  })
+
+  it('releases a write reservation after a successful Version write', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-artifact-reservation-success-'))
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+    await migrateApplicationDatabase(client)
+    const compatibilityRepository = new ArtifactRepository(storageRoot)
+    const repository = new ArtifactProvenanceRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client),
+      compatibilityRepository
+    })
+    const content = createPngBytes('reserved success')
+    const reservationRequest = {
+      projectId: 'project-1',
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-1',
+      artifactRunId: 'artifact-run-1',
+      writeOperationId: 'write-reserved-success',
+      filename: 'reserved.png',
+      fileBytes: content.byteLength
+    } as const
+    const reservation = await repository.reserveWrite(reservationRequest)
+    await compatibilityRepository.writePendingFile({
+      projectName: reservationRequest.projectId,
+      sessionId: reservationRequest.artifactStorageSessionId,
+      runId: reservationRequest.artifactRunId,
+      filename: reservationRequest.filename,
+      mimeType: 'image/png',
+      source: { kind: 'inline', content: content.toString('base64'), encoding: 'base64' }
+    })
+
+    await repository.createVersion({
+      ...reservationRequest,
+      writeRequestChecksum: 'a'.repeat(64),
+      rootFrameId: 'root-frame-1',
+      agentFrameId: 'agent-frame-1',
+      messageBranchId: 'branch-1',
+      runtimeSegmentId: 'runtime-segment-1',
+      promptMessageId: 'prompt-1',
+      contentType: 'image/png',
+      resourceReservationId: reservation.id,
+      resourceSizeBytes: content.byteLength,
+      resourceChecksum: createHash('sha256').update(content).digest('hex')
+    })
+
+    const replacement = await repository.reserveWrite(reservationRequest)
+    expect(replacement.id).not.toBe(reservation.id)
+    await repository.releaseWriteReservation({
+      projectId: reservationRequest.projectId,
+      appSessionId: reservationRequest.appSessionId,
+      artifactStorageSessionId: reservationRequest.artifactStorageSessionId,
+      artifactRunId: reservationRequest.artifactRunId,
+      reservationId: replacement.id
+    })
   })
 
   it('keeps immutable bytes while same-session same-name saves advance one lineage', async () => {
@@ -699,18 +875,55 @@ describe('artifact provenance repository', () => {
       filename: 'sin.png',
       contentType: 'image/png'
     } as const
+    const content = createPngBytes('durable file failure')
+    const reservationRequest = {
+      projectId: request.projectId,
+      appSessionId: request.appSessionId,
+      artifactStorageSessionId: request.artifactStorageSessionId,
+      artifactRunId: request.artifactRunId,
+      writeOperationId: request.writeOperationId,
+      filename: request.filename,
+      fileBytes: content.byteLength
+    }
+    const reservation = await repository.reserveWrite(reservationRequest)
     await compatibilityRepository.writePendingFile({
       projectName: request.projectId,
       sessionId: request.artifactStorageSessionId,
       runId: request.artifactRunId,
       filename: request.filename,
       mimeType: request.contentType,
-      source: createPngInlineSource('durable file failure')
+      source: { kind: 'inline', content: content.toString('base64'), encoding: 'base64' }
     })
 
-    await expect(repository.createVersion(request)).rejects.toThrow(
-      'simulated durable file failure'
-    )
+    const originalRelease = ArtifactWriteBudgetOwner.prototype.release
+    const release = vi
+      .spyOn(ArtifactWriteBudgetOwner.prototype, 'release')
+      .mockImplementationOnce(async function (this: ArtifactWriteBudgetOwner, releaseRequest) {
+        await originalRelease.call(this, releaseRequest)
+        throw new Error('simulated reservation release failure')
+      })
+    try {
+      await expect(
+        repository.createVersion({
+          ...request,
+          resourceReservationId: reservation.id,
+          resourceSizeBytes: content.byteLength,
+          resourceChecksum: createHash('sha256').update(content).digest('hex')
+        })
+      ).rejects.toThrow('simulated durable file failure')
+      expect(release).toHaveBeenCalledOnce()
+    } finally {
+      release.mockRestore()
+    }
+    const replacement = await repository.reserveWrite(reservationRequest)
+    expect(replacement.id).not.toBe(reservation.id)
+    await repository.releaseWriteReservation({
+      projectId: request.projectId,
+      appSessionId: request.appSessionId,
+      artifactStorageSessionId: request.artifactStorageSessionId,
+      artifactRunId: request.artifactRunId,
+      reservationId: replacement.id
+    })
 
     const row = await client.artifactVersion.findUniqueOrThrow({
       where: { writeOperationId: request.writeOperationId }

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { readFile, rm, stat } from 'node:fs/promises'
+import { rm, stat } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
@@ -10,10 +10,13 @@ import type {
   ArtifactVersionDescriptor,
   ArtifactVersionFile,
   ArtifactVersionProvenance,
+  ArtifactWriteReservation,
   CreateArtifactVersionRequest,
   FinalizeArtifactVersionsRequest,
   GetArtifactLineageRequest,
   GetArtifactVersionProvenanceRequest,
+  ReleaseArtifactWriteReservationRequest,
+  ReserveArtifactWriteRequest,
   ReplayArtifactVersionRequest
 } from '../../shared/artifact-provenance'
 import {
@@ -48,6 +51,9 @@ import { ArtifactProvenanceReadModel } from './provenance-read-model'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { ArtifactProvenanceDependencyReader } from './provenance-dependency-reader'
 import type { HostLineageDependencyRelation, HostLineageDirection } from '../../shared/host-lineage'
+import { LOCAL_RESOURCE_BUDGETS, type LocalResourceBudgetOverrides } from '../resource-budget'
+import { ArtifactWriteBudgetOwner } from './write-budget-owner'
+import { digestFileWithinBudget } from '../bounded-file-io'
 
 const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
 
@@ -64,6 +70,7 @@ type ArtifactProvenanceRepositoryOptions = {
   createId?: () => string
   now?: () => Date
   durability?: ArtifactDurability
+  resourceBudgets?: LocalResourceBudgetOverrides
 }
 
 export type WriteAppGeneratedArtifactVersionRequest = Omit<
@@ -124,6 +131,7 @@ class ArtifactProvenanceRepository {
   private readonly stagingRecovery: ArtifactProvenanceStagingRecovery
   private readonly unindexedRecovery: ArtifactProvenanceUnindexedRecovery
   private readonly versionWriter: ArtifactProvenanceVersionWriter
+  private readonly writeBudgetOwner: ArtifactWriteBudgetOwner
 
   constructor(private readonly options: ArtifactProvenanceRepositoryOptions) {
     this.compatibilityRepository =
@@ -133,6 +141,13 @@ class ArtifactProvenanceRepository {
     this.createId = options.createId ?? randomUUID
     this.now = options.now ?? (() => new Date())
     this.durability = options.durability ?? defaultArtifactDurability
+    this.writeBudgetOwner = new ArtifactWriteBudgetOwner({
+      storageRoot: options.storageRoot,
+      getClient: options.getClient,
+      compatibilityRepository: this.compatibilityRepository,
+      resourceBudgets: options.resourceBudgets,
+      now: () => this.now().getTime()
+    })
     const inputAuthority =
       options.inputAuthority ??
       new ImmutableInputAuthority({
@@ -192,6 +207,8 @@ class ArtifactProvenanceRepository {
       createId: this.createId,
       now: this.now,
       durability: this.durability,
+      resourceBudgets: options.resourceBudgets,
+      writeBudgetOwner: this.writeBudgetOwner,
       captureProducer: (request, createdAt, checksum) =>
         this.producerCapture.captureProducer(request, createdAt, checksum),
       prepareVersionPersistence: (input) => this.producerCapture.prepareVersionPersistence(input),
@@ -210,6 +227,12 @@ class ArtifactProvenanceRepository {
   ): Promise<ArtifactVersionFile> {
     const { content, kind, ...versionRequest } = request
     const writeOperationId = `artifact-app-write-${this.createId()}`
+    const reservationScope = {
+      projectId: request.projectId,
+      appSessionId: request.appSessionId,
+      artifactStorageSessionId: request.artifactStorageSessionId,
+      artifactRunId: request.artifactRunId
+    }
 
     return this.compatibilityRepository.withPendingFileTransaction(
       {
@@ -221,9 +244,20 @@ class ArtifactProvenanceRepository {
         kind,
         source: { kind: 'inline', content, encoding: 'utf8' }
       },
-      {},
-      async (pendingFile, _sourceFileObservation, bindVersionRouting) => {
-        const contentChecksum = sha256(await readFile(pendingFile.path))
+      {
+        reserveFile: (fileBytes) =>
+          this.writeBudgetOwner.reserve({
+            ...reservationScope,
+            writeOperationId,
+            filename: request.filename,
+            fileBytes
+          }),
+        releaseFileReservation: (reservationId) =>
+          this.writeBudgetOwner.release({ ...reservationScope, reservationId })
+      },
+      async (_pendingFile, _sourceFileObservation, bindVersionRouting, fileDigest, reservation) => {
+        if (!reservation) throw new Error('App-owned Artifact write reservation was not created.')
+        const contentChecksum = fileDigest.checksum
         const writeRequestChecksum = sha256(
           canonicalJson({
             contentChecksum,
@@ -235,12 +269,15 @@ class ArtifactProvenanceRepository {
           })
         )
 
-        const version = await this.versionWriter.writeVersion(
+        return this.versionWriter.writeVersion(
           {
             ...versionRequest,
             writeOperationId,
             writeRequestChecksum,
-            sourceKind: 'inline'
+            sourceKind: 'inline',
+            resourceReservationId: reservation.id,
+            resourceSizeBytes: fileDigest.sizeBytes,
+            resourceChecksum: fileDigest.checksum
           },
           async (version) =>
             bindVersionRouting(
@@ -255,20 +292,44 @@ class ArtifactProvenanceRepository {
               resolveStorageKey(this.options.storageRoot, version.contentStorageKey)
             )
         )
-        return version
       }
     )
   }
 
-  async createVersion(request: CreateArtifactVersionRequest): Promise<ArtifactVersionFile> {
+  async createVersion(
+    request: CreateArtifactVersionRequest,
+    signal?: AbortSignal
+  ): Promise<ArtifactVersionFile> {
     return this.versionWriter.writeVersion(
       request,
       this.stagingRecovery.routingPublisher(
         request.projectId,
         request.artifactStorageSessionId,
         request.filename
-      )
+      ),
+      signal
     )
+  }
+
+  reserveWrite(request: ReserveArtifactWriteRequest): Promise<ArtifactWriteReservation> {
+    return this.writeBudgetOwner.reserve(request)
+  }
+
+  releaseWriteReservation(request: ReleaseArtifactWriteReservationRequest): Promise<void> {
+    return this.writeBudgetOwner.release(request)
+  }
+
+  releaseRunWriteReservations(request: {
+    projectId: string
+    appSessionId: string
+    artifactStorageSessionId: string
+    artifactRunId: string
+  }): Promise<void> {
+    return this.writeBudgetOwner.releaseRun(request)
+  }
+
+  releaseAllWriteReservations(): Promise<void> {
+    return this.writeBudgetOwner.releaseAll()
   }
 
   async replayVersion(
@@ -542,9 +603,7 @@ class ArtifactProvenanceRepository {
     )
   }
 
-  // Resolves reviewer/preview reads through the Version authority rather than reconstructing a
-  // legacy session path from an id. The checksum is verified before the caller receives the path.
-  async resolveVersionContent(request: {
+  private async resolveVersionContentMetadata(request: {
     projectId: string
     versionId: string
     appSessionId?: string
@@ -570,17 +629,42 @@ class ArtifactProvenanceRepository {
     })
     if (!version) throw new Error(`Artifact Version not found: ${versionId}`)
 
-    const path = resolveStorageKey(this.options.storageRoot, version.contentStorageKey)
-    const bytes = await readFile(path)
-    if (sha256(bytes) !== version.checksum) {
-      throw new Error(`Artifact Version content checksum mismatch: ${versionId}`)
-    }
     return {
-      path,
+      path: resolveStorageKey(this.options.storageRoot, version.contentStorageKey),
       filename: version.filename,
       contentType: version.contentType ?? undefined,
       checksum: version.checksum
     }
+  }
+
+  // Reviewer reads hash the full source while retaining only one page, so they request metadata
+  // without a redundant verification pass. The Reviewer host compares this checksum itself.
+  resolveVersionContentForStreamingVerification(request: {
+    projectId: string
+    versionId: string
+    appSessionId?: string
+    artifactId?: string
+  }): Promise<{ path: string; filename: string; contentType?: string; checksum?: string }> {
+    return this.resolveVersionContentMetadata(request)
+  }
+
+  // Resolves preview/consumer reads through the Version authority. Callers that do not stream and
+  // verify content themselves keep the existing verified-path contract.
+  async resolveVersionContent(request: {
+    projectId: string
+    versionId: string
+    appSessionId?: string
+    artifactId?: string
+  }): Promise<{ path: string; filename: string; contentType?: string; checksum?: string }> {
+    const resolved = await this.resolveVersionContentMetadata(request)
+    const digest = await digestFileWithinBudget(
+      resolved.path,
+      LOCAL_RESOURCE_BUDGETS.artifactFileBytes
+    )
+    if (digest.checksum !== resolved.checksum) {
+      throw new Error(`Artifact Version content checksum mismatch: ${request.versionId}`)
+    }
+    return resolved
   }
 
   // Project deletion is the terminal provenance boundary. Session deletion intentionally keeps this

--- a/src/main/artifacts/provenance-version-writer.ts
+++ b/src/main/artifacts/provenance-version-writer.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { mkdir, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
 import type { PrismaClient } from '@prisma/client'
@@ -8,12 +8,19 @@ import type {
   CreateArtifactVersionRequest
 } from '../../shared/artifact-provenance'
 import type { ArtifactDurability } from './durability'
-import { sha256 } from './provenance-canonical'
 import type {
   ArtifactVersionProducerCapture,
   PreparedArtifactVersionPersistence
 } from './provenance-producer-capture'
 import type { ArtifactRepository } from './repository'
+import type { ArtifactWriteBudgetOwner } from './write-budget-owner'
+import { assertDiskReserve, copyFileWithinBudget, digestFileWithinBudget } from '../bounded-file-io'
+import {
+  LOCAL_RESOURCE_BUDGETS,
+  assertWithinResourceBudget,
+  type LocalResourceBudgetOverrides
+} from '../resource-budget'
+import { availableBytes } from '../storage/usage'
 
 const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
 const SHA256_PATTERN = /^[a-f0-9]{64}$/
@@ -76,6 +83,7 @@ const withVersionAllocationRetry = async <T>(operation: () => Promise<T>): Promi
 type CompatibilityRoutingPublicationOptions = {
   allowRoutingReplacement?: boolean
   replaceUnroutedBytes?: boolean
+  signal?: AbortSignal
 }
 type PersistedVersionFileRecord = {
   id: string
@@ -112,6 +120,8 @@ type ArtifactProvenanceVersionWriterOptions = {
   createId: () => string
   now: () => Date
   durability: ArtifactDurability
+  resourceBudgets?: LocalResourceBudgetOverrides
+  writeBudgetOwner: Pick<ArtifactWriteBudgetOwner, 'assertReserved' | 'release'>
   captureProducer: (
     request: CreateArtifactVersionRequest,
     createdAt: Date,
@@ -143,39 +153,101 @@ type ArtifactProvenanceVersionWriterOptions = {
 
 class ArtifactProvenanceVersionWriter {
   // Repository instances can coexist over separate Prisma clients for the same database. Serialize
-  // lineage identity allocation process-wide so those clients cannot race a case-folded filename.
-  private static readonly lineageWrites = new Map<string, Promise<void>>()
+  // writes per app Session process-wide so lineage allocation and aggregate byte budgets cannot race.
+  private static readonly sessionWrites = new Map<string, Promise<void>>()
 
   constructor(private readonly options: ArtifactProvenanceVersionWriterOptions) {}
 
   async writeVersion(
     request: CreateArtifactVersionRequest,
-    publishCompatibilityRouting: PublishCompatibilityRouting
+    publishCompatibilityRouting: PublishCompatibilityRouting,
+    signal?: AbortSignal
   ): Promise<ArtifactVersionFile> {
-    const lineageKey = `${this.options.storageRoot}\0${request.projectId}\0${request.appSessionId}\0${normalizeArtifactFilename(request.filename)}`
+    if (request.resourceReservationId) {
+      if (
+        request.resourceSizeBytes === undefined ||
+        !Number.isSafeInteger(request.resourceSizeBytes) ||
+        request.resourceSizeBytes < 0
+      ) {
+        throw new Error('Artifact write reservation requires a valid streamed byte count.')
+      }
+      if (!request.resourceChecksum || !SHA256_PATTERN.test(request.resourceChecksum)) {
+        throw new Error('Artifact write reservation requires a valid streamed checksum.')
+      }
+      await this.options.writeBudgetOwner.assertReserved({
+        reservationId: request.resourceReservationId,
+        projectId: request.projectId,
+        appSessionId: request.appSessionId,
+        artifactStorageSessionId: request.artifactStorageSessionId,
+        artifactRunId: request.artifactRunId,
+        writeOperationId: request.writeOperationId,
+        filename: request.filename,
+        actualBytes: request.resourceSizeBytes
+      })
+    }
+
+    let version: ArtifactVersionFile
+    try {
+      version = await this.writeVersionWithinSession(request, publishCompatibilityRouting, signal)
+    } catch (error) {
+      if (request.resourceReservationId) {
+        try {
+          await this.options.writeBudgetOwner.release({
+            projectId: request.projectId,
+            appSessionId: request.appSessionId,
+            artifactStorageSessionId: request.artifactStorageSessionId,
+            artifactRunId: request.artifactRunId,
+            reservationId: request.resourceReservationId
+          })
+        } catch {
+          // Preserve the write failure; run/session cleanup can retry reservation release.
+        }
+      }
+      throw error
+    }
+
+    if (request.resourceReservationId) {
+      await this.options.writeBudgetOwner.release({
+        projectId: request.projectId,
+        appSessionId: request.appSessionId,
+        artifactStorageSessionId: request.artifactStorageSessionId,
+        artifactRunId: request.artifactRunId,
+        reservationId: request.resourceReservationId
+      })
+    }
+    return version
+  }
+
+  private async writeVersionWithinSession(
+    request: CreateArtifactVersionRequest,
+    publishCompatibilityRouting: PublishCompatibilityRouting,
+    signal?: AbortSignal
+  ): Promise<ArtifactVersionFile> {
+    const sessionKey = `${this.options.storageRoot}\0${request.projectId}\0${request.appSessionId}`
     const previous =
-      ArtifactProvenanceVersionWriter.lineageWrites.get(lineageKey) ?? Promise.resolve()
+      ArtifactProvenanceVersionWriter.sessionWrites.get(sessionKey) ?? Promise.resolve()
     let release = (): void => undefined
     const current = new Promise<void>((resolveCurrent) => {
       release = resolveCurrent
     })
     const tail = previous.then(() => current)
-    ArtifactProvenanceVersionWriter.lineageWrites.set(lineageKey, tail)
+    ArtifactProvenanceVersionWriter.sessionWrites.set(sessionKey, tail)
     await previous
 
     try {
-      return await this.writeVersionSerialized(request, publishCompatibilityRouting)
+      return await this.writeVersionSerialized(request, publishCompatibilityRouting, signal)
     } finally {
       release()
-      if (ArtifactProvenanceVersionWriter.lineageWrites.get(lineageKey) === tail) {
-        ArtifactProvenanceVersionWriter.lineageWrites.delete(lineageKey)
+      if (ArtifactProvenanceVersionWriter.sessionWrites.get(sessionKey) === tail) {
+        ArtifactProvenanceVersionWriter.sessionWrites.delete(sessionKey)
       }
     }
   }
 
   private async writeVersionSerialized(
     request: CreateArtifactVersionRequest,
-    publishCompatibilityRouting: PublishCompatibilityRouting
+    publishCompatibilityRouting: PublishCompatibilityRouting,
+    signal?: AbortSignal
   ): Promise<ArtifactVersionFile> {
     const projectId = assertSafeSegment(request.projectId, 'project id')
     const appSessionId = assertSafeSegment(request.appSessionId, 'session id')
@@ -224,7 +296,7 @@ class ArtifactProvenanceVersionWriter {
       }
 
       if (existing.state === 'pending') {
-        await publishCompatibilityRouting(existing, { replaceUnroutedBytes: true })
+        await publishCompatibilityRouting(existing, { replaceUnroutedBytes: true, signal })
       }
       return this.options.projectVersionFile(existing, projectId, appSessionId)
     }
@@ -261,14 +333,26 @@ class ArtifactProvenanceVersionWriter {
     const stagingDirectory = join(this.options.storageRoot, ...stagingStorageKey.split('/'))
     const stagingContentPath = join(stagingDirectory, 'content')
 
-    await mkdir(stagingDirectory, { recursive: true })
-    await copyFile(pendingFile.path, stagingContentPath)
-
     let stagingRowPersisted = false
     try {
+      await mkdir(stagingDirectory, { recursive: true })
+      const pendingStat = await stat(pendingFile.path)
+      assertDiskReserve(
+        await availableBytes(stagingDirectory),
+        pendingStat.size,
+        this.options.resourceBudgets?.diskReserveBytes ?? LOCAL_RESOURCE_BUDGETS.diskReserveBytes
+      )
+      const contentDigest = await copyFileWithinBudget(
+        pendingFile.path,
+        stagingContentPath,
+        this.options.resourceBudgets?.artifactFileBytes ?? LOCAL_RESOURCE_BUDGETS.artifactFileBytes,
+        signal
+      )
       await this.options.durability.syncFile(stagingContentPath)
-      const content = await readFile(stagingContentPath)
-      const checksum = sha256(content)
+      const { checksum, sizeBytes } = contentDigest
+      if (request.resourceChecksum && request.resourceChecksum !== checksum) {
+        throw new Error('Artifact write reservation checksum does not match staged content.')
+      }
       const createdAt = this.options.now()
       const producer = await this.options.captureProducer(request, createdAt, checksum)
       const persisted = await withVersionAllocationRetry(() =>
@@ -339,7 +423,7 @@ class ArtifactProvenanceVersionWriter {
             versionId,
             versionNumber,
             checksum,
-            sizeBytes: content.byteLength,
+            sizeBytes,
             createdAt
           })
           const executionSnapshotStorageKey = prepared.executionSnapshotJson
@@ -354,6 +438,33 @@ class ArtifactProvenanceVersionWriter {
                 'execution.json'
               )
             : undefined
+
+          const countedStates = ['staging', 'pending', 'finalized']
+          const [turnUsage, sessionUsage] = await Promise.all([
+            transaction.artifactVersion.aggregate({
+              where: { artifactRunId, state: { in: countedStates } },
+              _sum: { sizeBytes: true }
+            }),
+            transaction.artifactVersion.aggregate({
+              where: {
+                artifact: { projectId, sessionId: appSessionId },
+                state: { in: countedStates }
+              },
+              _sum: { sizeBytes: true }
+            })
+          ])
+          assertWithinResourceBudget(
+            'turn',
+            Number(turnUsage._sum.sizeBytes ?? 0n) + sizeBytes,
+            this.options.resourceBudgets?.artifactTurnBytes ??
+              LOCAL_RESOURCE_BUDGETS.artifactTurnBytes
+          )
+          assertWithinResourceBudget(
+            'session',
+            Number(sessionUsage._sum.sizeBytes ?? 0n) + sizeBytes,
+            this.options.resourceBudgets?.artifactSessionBytes ??
+              LOCAL_RESOURCE_BUDGETS.artifactSessionBytes
+          )
 
           return transaction.artifactVersion.create({
             data: {
@@ -376,7 +487,7 @@ class ArtifactProvenanceVersionWriter {
               contentStorageKey,
               evidenceStorageKey,
               contentType: request.contentType,
-              sizeBytes: BigInt(content.byteLength),
+              sizeBytes: BigInt(sizeBytes),
               checksum,
               evidenceJson: prepared.evidenceJson,
               evidenceChecksum: prepared.evidenceChecksum,
@@ -397,7 +508,8 @@ class ArtifactProvenanceVersionWriter {
       await this.syncAndVerifyFile(
         evidencePath,
         persisted.evidenceChecksum,
-        `Artifact Version evidence mirror is corrupt: ${persisted.id}`
+        `Artifact Version evidence mirror is corrupt: ${persisted.id}`,
+        signal
       )
       if (persisted.executionSnapshotJson) {
         const executionPath = join(stagingDirectory, 'execution.json')
@@ -405,7 +517,8 @@ class ArtifactProvenanceVersionWriter {
         await this.syncAndVerifyFile(
           executionPath,
           persisted.executionSnapshotChecksum!,
-          `Artifact Version execution mirror is corrupt: ${persisted.id}`
+          `Artifact Version execution mirror is corrupt: ${persisted.id}`,
+          signal
         )
       }
       const finalContentPath = join(
@@ -418,7 +531,7 @@ class ArtifactProvenanceVersionWriter {
       await rename(stagingDirectory, finalDirectory)
       await this.options.durability.syncDirectory(dirname(finalDirectory))
 
-      await publishCompatibilityRouting(persisted, { allowRoutingReplacement: true })
+      await publishCompatibilityRouting(persisted, { allowRoutingReplacement: true, signal })
       const finalized = await client.$transaction(async (transaction) => {
         await transaction.artifactLineage.update({
           where: { id: persisted.artifactId },
@@ -443,11 +556,16 @@ class ArtifactProvenanceVersionWriter {
   private async syncAndVerifyFile(
     path: string,
     expectedChecksum: string,
-    corruptMessage: string
+    corruptMessage: string,
+    signal?: AbortSignal
   ): Promise<void> {
     await this.options.durability.syncFile(path)
-    const bytes = await readFile(path)
-    if (sha256(bytes) !== expectedChecksum) throw new Error(corruptMessage)
+    const { checksum } = await digestFileWithinBudget(
+      path,
+      this.options.resourceBudgets?.artifactFileBytes ?? LOCAL_RESOURCE_BUDGETS.artifactFileBytes,
+      signal
+    )
+    if (checksum !== expectedChecksum) throw new Error(corruptMessage)
   }
 }
 

--- a/src/main/artifacts/provenance-write-contract.test.ts
+++ b/src/main/artifacts/provenance-write-contract.test.ts
@@ -44,6 +44,10 @@ const canonicalize = (value: unknown): unknown => {
 const PUBLIC_METHODS = [
   'writeAppGeneratedVersion',
   'createVersion',
+  'reserveWrite',
+  'releaseWriteReservation',
+  'releaseRunWriteReservations',
+  'releaseAllWriteReservations',
   'replayVersion',
   'validateFinalizationOwnership',
   'finalizeRun',
@@ -60,6 +64,7 @@ const PUBLIC_METHODS = [
   'getVersionReview',
   'readCodeReconstructionCache',
   'writeCodeReconstructionCache',
+  'resolveVersionContentForStreamingVerification',
   'resolveVersionContent',
   'deleteProjectProvenance'
 ] as const satisfies readonly (keyof ArtifactProvenanceRepository)[]

--- a/src/main/artifacts/publication-owner.ts
+++ b/src/main/artifacts/publication-owner.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { basename, dirname, join } from 'node:path'
 
@@ -24,6 +24,11 @@ import type {
   PendingFileTransactionOptions,
   PrepareArtifactRunFinalizationRequest
 } from './publication-types'
+import type { FileDigest } from '../bounded-file-io'
+import type { PendingFileBudgetReservation } from './pending-file-transaction'
+import { assertDiskReserve, copyFileWithinBudget, digestFileWithinBudget } from '../bounded-file-io'
+import { LOCAL_RESOURCE_BUDGETS } from '../resource-budget'
+import { availableBytes } from '../storage/usage'
 
 class ArtifactCompatibilityScanIncompleteError extends Error {
   constructor(cause: unknown) {
@@ -99,16 +104,33 @@ class ArtifactPublicationOwner {
     ) {
       throw new Error('Artifact pending routing conflicts with an existing Version.')
     }
-    let bytes: Buffer
+    let checksum: string
     try {
-      bytes = await readFile(filePath)
+      checksum = (
+        await digestFileWithinBudget(
+          filePath,
+          LOCAL_RESOURCE_BUDGETS.artifactFileBytes,
+          request.signal
+        )
+      ).checksum
     } catch (error) {
       if (!this.storage.isMissingFileError(error)) throw error
       const temporaryPath = `${filePath}.${randomUUID()}.tmp`
       try {
-        await copyFile(request.sourcePath, temporaryPath)
-        bytes = await readFile(temporaryPath)
-        if (this.storage.sha256(bytes) !== routing.checksum) {
+        const source = await stat(request.sourcePath)
+        assertDiskReserve(
+          await availableBytes(directory),
+          source.size,
+          LOCAL_RESOURCE_BUDGETS.diskReserveBytes
+        )
+        const copied = await copyFileWithinBudget(
+          request.sourcePath,
+          temporaryPath,
+          LOCAL_RESOURCE_BUDGETS.artifactFileBytes,
+          request.signal
+        )
+        checksum = copied.checksum
+        if (checksum !== routing.checksum) {
           throw new Error('Artifact routing source checksum mismatch.')
         }
         await this.storage.durability.syncFile(temporaryPath)
@@ -118,15 +140,25 @@ class ArtifactPublicationOwner {
         await rm(temporaryPath, { force: true }).catch(() => undefined)
       }
     }
-    if (this.storage.sha256(bytes) !== routing.checksum) {
+    if (checksum !== routing.checksum) {
       if (existingRouting || !request.replaceUnroutedBytes) {
         throw new Error('Artifact pending bytes conflict with Version routing.')
       }
       const replacementPath = `${filePath}.${randomUUID()}.tmp`
       try {
-        await copyFile(request.sourcePath, replacementPath)
-        const replacement = await readFile(replacementPath)
-        if (this.storage.sha256(replacement) !== routing.checksum) {
+        const source = await stat(request.sourcePath)
+        assertDiskReserve(
+          await availableBytes(directory),
+          source.size,
+          LOCAL_RESOURCE_BUDGETS.diskReserveBytes
+        )
+        const replacement = await copyFileWithinBudget(
+          request.sourcePath,
+          replacementPath,
+          LOCAL_RESOURCE_BUDGETS.artifactFileBytes,
+          request.signal
+        )
+        if (replacement.checksum !== routing.checksum) {
           throw new Error('Artifact routing source checksum mismatch.')
         }
         await this.storage.durability.syncFile(replacementPath)
@@ -178,7 +210,12 @@ class ArtifactPublicationOwner {
               continue
             }
             const path = join(runDirectory, entry.name)
-            if (this.storage.sha256(await readFile(path)) !== routing.checksum) continue
+            if (
+              (await digestFileWithinBudget(path, LOCAL_RESOURCE_BUDGETS.artifactFileBytes))
+                .checksum !== routing.checksum
+            ) {
+              continue
+            }
             matches.push({ ...routing, storageSessionId, filename: entry.name, path })
           }
         }
@@ -208,7 +245,10 @@ class ArtifactPublicationOwner {
         if (!SAFE_SEGMENT_PATTERN.test(storageSessionId)) continue
         const path = join(projectDirectory, storageSessionId, PENDING_DIR, runId, filename)
         try {
-          if (this.storage.sha256(await readFile(path)) === request.checksum) {
+          if (
+            (await digestFileWithinBudget(path, LOCAL_RESOURCE_BUDGETS.artifactFileBytes))
+              .checksum === request.checksum
+          ) {
             matches.push({ storageSessionId, path })
           }
         } catch (error) {
@@ -230,7 +270,9 @@ class ArtifactPublicationOwner {
     operation: (
       artifact: ArtifactFile,
       sourceFileObservation: ArtifactSourceFileObservation | undefined,
-      bindVersionRouting: BindPendingArtifactVersionRouting
+      bindVersionRouting: BindPendingArtifactVersionRouting,
+      fileDigest: FileDigest,
+      reservation: PendingFileBudgetReservation | undefined
     ) => Promise<Result>
   ): Promise<Result> {
     const normalized = {
@@ -246,7 +288,12 @@ class ArtifactPublicationOwner {
         writeOptions: options,
         storage: this.storage,
         publishRouting: (routing, sourcePath) =>
-          this.publishPendingVersionRoutingLocked({ ...normalized, sourcePath, routing }),
+          this.publishPendingVersionRoutingLocked({
+            ...normalized,
+            sourcePath,
+            routing,
+            signal: options.signal
+          }),
         operation
       })
     )

--- a/src/main/artifacts/publication-types.ts
+++ b/src/main/artifacts/publication-types.ts
@@ -65,6 +65,7 @@ type PendingArtifactVersionRoutingRequest = {
   routing: PendingArtifactVersionRouting
   allowRoutingReplacement?: boolean
   replaceUnroutedBytes?: boolean
+  signal?: AbortSignal
 }
 
 type BindPendingArtifactVersionRouting = (

--- a/src/main/artifacts/repository.test.ts
+++ b/src/main/artifacts/repository.test.ts
@@ -1,4 +1,5 @@
 import {
+  appendFile,
   mkdir,
   mkdtemp,
   readFile,
@@ -6,13 +7,15 @@ import {
   realpath,
   rename,
   rm,
+  stat,
   symlink,
+  utimes,
   writeFile
 } from 'node:fs/promises'
 import { createHash } from 'node:crypto'
 import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { ArtifactWriteSource } from '../../shared/artifacts'
 import { createPngBytes, createPngInlineSource } from './artifact-test-fixtures'
@@ -148,6 +151,142 @@ describe('artifact repository', () => {
 
     await expect(readFile(artifact.path)).resolves.toEqual(png)
     await expect(readFile(sourcePath)).resolves.toEqual(png)
+  })
+
+  it('rejects inline content above the configured application file budget', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+
+    await expect(
+      repository.writePendingFile(
+        {
+          projectName: 'default-project',
+          sessionId: 'session-1',
+          runId: 'run-1',
+          filename: 'too-large.txt',
+          source: { kind: 'inline', content: '12345', encoding: 'utf8' }
+        },
+        { maxInlineBytes: 4 }
+      )
+    ).rejects.toMatchObject({ dimension: 'file', observedBytes: 5, limitBytes: 4 })
+  })
+
+  it('rejects a local source above the configured application file budget before copying', async () => {
+    const root = await createStorageRoot()
+    const allowedRoot = join(root, 'notebook-session')
+    const sourcePath = join(allowedRoot, 'too-large.bin')
+    await mkdir(allowedRoot, { recursive: true })
+    await writeFile(sourcePath, '12345')
+    const repository = new ArtifactRepository(root)
+
+    await expect(
+      repository.writePendingFile(
+        {
+          projectName: 'default-project',
+          sessionId: 'session-1',
+          runId: 'run-1',
+          filename: 'too-large.bin',
+          source: { kind: 'localPath', path: sourcePath }
+        },
+        { allowedImportRoots: [allowedRoot], maxFileBytes: 4 }
+      )
+    ).rejects.toMatchObject({ dimension: 'file', observedBytes: 5, limitBytes: 4 })
+  })
+
+  it('stops a local source that grows beyond its reservation while copying', async () => {
+    const root = await createStorageRoot()
+    const allowedRoot = join(root, 'notebook-session')
+    const sourcePath = join(allowedRoot, 'growing.bin')
+    await mkdir(allowedRoot, { recursive: true })
+    await writeFile(sourcePath, '1234')
+    const releaseFileReservation = vi.fn(async () => undefined)
+    const repository = new ArtifactRepository(root)
+
+    await expect(
+      repository.writePendingFile(
+        {
+          projectName: 'default-project',
+          sessionId: 'session-1',
+          runId: 'run-1',
+          filename: 'growing.bin',
+          source: { kind: 'localPath', path: sourcePath }
+        },
+        {
+          allowedImportRoots: [allowedRoot],
+          reserveFile: async (fileBytes) => {
+            await appendFile(sourcePath, '5')
+            return { id: 'reservation-1', fileBytes }
+          },
+          releaseFileReservation
+        }
+      )
+    ).rejects.toMatchObject({ dimension: 'file', observedBytes: 5, limitBytes: 4 })
+    expect(releaseFileReservation).toHaveBeenCalledWith('reservation-1')
+    await expect(
+      readFile(
+        join(root, 'artifacts', 'default-project', 'session-1', '.pending', 'run-1', 'growing.bin')
+      )
+    ).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('copies the file opened during preflight when the source path is replaced', async () => {
+    const root = await createStorageRoot()
+    const allowedRoot = join(root, 'notebook-session')
+    const sourcePath = join(allowedRoot, 'pinned.bin')
+    const replacementPath = join(allowedRoot, 'replacement.bin')
+    const displacedPath = join(allowedRoot, 'displaced.bin')
+    await mkdir(allowedRoot, { recursive: true })
+    await writeFile(sourcePath, 'old!')
+    const fixedTimestamp = new Date('2020-01-01T00:00:00.000Z')
+    await utimes(sourcePath, fixedTimestamp, fixedTimestamp)
+    const sourceStat = await stat(sourcePath)
+    await writeFile(replacementPath, 'new!')
+    await utimes(replacementPath, fixedTimestamp, fixedTimestamp)
+    await expect(stat(replacementPath)).resolves.toMatchObject({
+      size: sourceStat.size,
+      mtimeMs: sourceStat.mtimeMs
+    })
+    const repository = new ArtifactRepository(root)
+
+    const artifact = await repository.writePendingFile(
+      {
+        projectName: 'default-project',
+        sessionId: 'session-1',
+        runId: 'run-1',
+        filename: 'pinned.bin',
+        source: { kind: 'localPath', path: sourcePath }
+      },
+      {
+        allowedImportRoots: [allowedRoot],
+        reserveFile: async (fileBytes) => {
+          await rename(sourcePath, displacedPath)
+          await rename(replacementPath, sourcePath)
+          return { id: 'reservation-1', fileBytes }
+        },
+        releaseFileReservation: async () => undefined
+      }
+    )
+
+    await expect(readFile(artifact.path, 'utf8')).resolves.toBe('old!')
+    await expect(readFile(sourcePath, 'utf8')).resolves.toBe('new!')
+  })
+
+  it('rejects a write that would consume the configured disk reserve', async () => {
+    const root = await createStorageRoot()
+    const repository = new ArtifactRepository(root)
+
+    await expect(
+      repository.writePendingFile(
+        {
+          projectName: 'default-project',
+          sessionId: 'session-1',
+          runId: 'run-1',
+          filename: 'reserve.txt',
+          source: { kind: 'inline', content: 'x', encoding: 'utf8' }
+        },
+        { diskReserveBytes: 1_000_000_000_000_000 }
+      )
+    ).rejects.toMatchObject({ dimension: 'disk-reserve' })
   })
 
   it('rejects a declared MIME type that conflicts with the source signature', async () => {

--- a/src/main/artifacts/repository.ts
+++ b/src/main/artifacts/repository.ts
@@ -33,6 +33,8 @@ import {
   getProjectArtifactDir,
   type ArtifactStorageAccessDurability
 } from './storage-access'
+import type { FileDigest } from '../bounded-file-io'
+import type { PendingFileBudgetReservation } from './pending-file-transaction'
 
 type ArtifactRepositoryWriteOptions = PendingFileTransactionOptions
 type ArtifactRepositoryStorage = ArtifactStorageAccessDurability
@@ -96,7 +98,9 @@ class ArtifactRepository {
     operation: (
       artifact: ArtifactFile,
       sourceFileObservation: ArtifactSourceFileObservation | undefined,
-      bindVersionRouting: BindPendingArtifactVersionRouting
+      bindVersionRouting: BindPendingArtifactVersionRouting,
+      fileDigest: FileDigest,
+      reservation: PendingFileBudgetReservation | undefined
     ) => Promise<Result>
   ): Promise<Result> {
     return this.publicationOwner.withPendingFileTransaction(request, options, operation)

--- a/src/main/artifacts/write-budget-owner.test.ts
+++ b/src/main/artifacts/write-budget-owner.test.ts
@@ -1,0 +1,227 @@
+import type { PrismaClient } from '@prisma/client'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ArtifactFile } from '../../shared/artifacts'
+import type { ReserveArtifactWriteRequest } from '../../shared/artifact-provenance'
+import { ArtifactWriteBudgetOwner } from './write-budget-owner'
+
+const request = (
+  overrides: Partial<ReserveArtifactWriteRequest> = {}
+): ReserveArtifactWriteRequest => ({
+  projectId: 'project-1',
+  appSessionId: 'app-session-1',
+  artifactStorageSessionId: 'storage-session-1',
+  artifactRunId: 'run-1',
+  writeOperationId: 'operation-1',
+  filename: 'report.txt',
+  fileBytes: 6,
+  ...overrides
+})
+
+const artifactFile = (overrides: Partial<ArtifactFile> = {}): ArtifactFile => ({
+  id: 'legacy-file-1',
+  projectId: 'project-1',
+  sessionId: 'storage-session-1',
+  runId: 'run-1',
+  name: 'legacy.txt',
+  path: '/managed/legacy.txt',
+  fileUrl: 'file:///managed/legacy.txt',
+  size: 3,
+  mtimeMs: 1,
+  ...overrides
+})
+
+const createOwner = (
+  options: {
+    findUnique?: (args: unknown) => Promise<{ sizeBytes: bigint } | null>
+    findMany?: (args: unknown) => Promise<Array<{ writeOperationId: string }>>
+    aggregate?: (args: { where: Record<string, unknown> }) => Promise<{
+      _sum: { sizeBytes: bigint | null }
+    }>
+    publications?: Array<{
+      sourceSessionId: string
+      runId: string
+      marker?: { sessionId: string }
+    }>
+    files?: ArtifactFile[]
+    availableBytes?: number
+    now?: () => number
+    reservationTtlMs?: number
+    budgets?: {
+      artifactFileBytes: number
+      artifactTurnBytes: number
+      artifactSessionBytes: number
+      diskReserveBytes: number
+    }
+  } = {}
+): ArtifactWriteBudgetOwner => {
+  const client = {
+    artifactVersion: {
+      findUnique: options.findUnique ?? vi.fn(async () => null),
+      findMany: options.findMany ?? vi.fn(async () => []),
+      aggregate: options.aggregate ?? vi.fn(async () => ({ _sum: { sizeBytes: 0n } }))
+    }
+  } as unknown as PrismaClient
+  const compatibilityRepository = {
+    listPendingRunPublications: vi.fn(async () => options.publications ?? []),
+    listPendingRunFiles: vi.fn(async () => options.files ?? [])
+  }
+
+  return new ArtifactWriteBudgetOwner({
+    storageRoot: '/managed',
+    getClient: async () => client,
+    compatibilityRepository: compatibilityRepository as never,
+    getAvailableBytes: async () => options.availableBytes ?? 1_000_000,
+    now: options.now,
+    reservationTtlMs: options.reservationTtlMs,
+    resourceBudgets: options.budgets ?? {
+      artifactFileBytes: 100,
+      artifactTurnBytes: 10,
+      artifactSessionBytes: 20,
+      diskReserveBytes: 1_000
+    }
+  })
+}
+
+describe('ArtifactWriteBudgetOwner', () => {
+  it('serializes concurrent reservations and includes outstanding bytes in the turn budget', async () => {
+    const owner = createOwner()
+    const first = await owner.reserve(request())
+
+    await expect(
+      owner.reserve(
+        request({ writeOperationId: 'operation-2', filename: 'second.txt', fileBytes: 5 })
+      )
+    ).rejects.toMatchObject({ dimension: 'turn' })
+
+    await owner.release({
+      projectId: 'project-1',
+      appSessionId: 'app-session-1',
+      artifactStorageSessionId: 'storage-session-1',
+      artifactRunId: 'run-1',
+      reservationId: first.id
+    })
+    await expect(
+      owner.reserve(
+        request({ writeOperationId: 'operation-2', filename: 'second.txt', fileBytes: 5 })
+      )
+    ).resolves.toMatchObject({ fileBytes: 5 })
+  })
+
+  it('does not count a persisted Version and its outstanding reservation twice', async () => {
+    let persisted = false
+    const owner = createOwner({
+      aggregate: vi.fn(async () => ({
+        _sum: { sizeBytes: persisted ? 6n : 0n }
+      })),
+      findMany: vi.fn(async () => (persisted ? [{ writeOperationId: 'operation-1' }] : [])),
+      budgets: {
+        artifactFileBytes: 100,
+        artifactTurnBytes: 11,
+        artifactSessionBytes: 11,
+        diskReserveBytes: 1_000
+      }
+    })
+    await owner.reserve(request())
+    persisted = true
+
+    await expect(
+      owner.reserve(
+        request({ writeOperationId: 'operation-2', filename: 'second.txt', fileBytes: 5 })
+      )
+    ).resolves.toMatchObject({ fileBytes: 5 })
+  })
+
+  it('counts native rows and unversioned compatibility files against the Session budget', async () => {
+    const owner = createOwner({
+      aggregate: vi.fn(async ({ where }) => ({
+        _sum: { sizeBytes: 'artifactRunId' in where ? 1n : 4n }
+      })),
+      publications: [
+        { sourceSessionId: 'storage-session-1', runId: 'run-1' },
+        { sourceSessionId: 'other-storage-session', runId: 'run-1' }
+      ],
+      files: [artifactFile(), artifactFile({ id: 'native', name: 'native.txt', versionId: 'v1' })],
+      budgets: {
+        artifactFileBytes: 100,
+        artifactTurnBytes: 100,
+        artifactSessionBytes: 10,
+        diskReserveBytes: 1_000
+      }
+    })
+
+    await expect(
+      owner.reserve(request({ artifactRunId: 'run-2', fileBytes: 5 }))
+    ).rejects.toMatchObject({ dimension: 'session', observedBytes: 12, limitBytes: 10 })
+  })
+
+  it('counts marked compatibility files from another storage handoff in the logical Session', async () => {
+    const owner = createOwner({
+      aggregate: vi.fn(async ({ where }) => ({
+        _sum: { sizeBytes: 'artifactRunId' in where ? 0n : 4n }
+      })),
+      publications: [
+        {
+          sourceSessionId: 'delegated-storage-session',
+          runId: 'legacy-run',
+          marker: { sessionId: 'app-session-1' }
+        }
+      ],
+      files: [artifactFile({ sessionId: 'delegated-storage-session', runId: 'legacy-run' })],
+      budgets: {
+        artifactFileBytes: 100,
+        artifactTurnBytes: 100,
+        artifactSessionBytes: 10,
+        diskReserveBytes: 1_000
+      }
+    })
+
+    await expect(
+      owner.reserve(request({ artifactRunId: 'run-2', fileBytes: 5 }))
+    ).rejects.toMatchObject({ dimension: 'session', observedBytes: 12, limitBytes: 10 })
+  })
+
+  it('reserves physical amplification and disk headroom across concurrent writes', async () => {
+    const owner = createOwner({
+      availableBytes: 200_000,
+      budgets: {
+        artifactFileBytes: 100_000,
+        artifactTurnBytes: 1_000_000,
+        artifactSessionBytes: 1_000_000,
+        diskReserveBytes: 1_000
+      }
+    })
+    await owner.reserve(request({ fileBytes: 50_000 }))
+
+    await expect(
+      owner.reserve(
+        request({ writeOperationId: 'operation-2', filename: 'second.bin', fileBytes: 50_000 })
+      )
+    ).rejects.toMatchObject({ dimension: 'disk-reserve' })
+  })
+
+  it('replays one operation reservation, rejects identity drift, and prunes expired ownership', async () => {
+    let now = 100
+    const owner = createOwner({ now: () => now, reservationTtlMs: 10 })
+    const first = await owner.reserve(request())
+    await expect(owner.reserve(request())).resolves.toEqual(first)
+    await expect(owner.reserve(request({ filename: 'different.txt' }))).rejects.toThrow(
+      /reused for a different reservation/u
+    )
+
+    now = 111
+    await expect(
+      owner.assertReserved({
+        reservationId: first.id,
+        projectId: 'project-1',
+        appSessionId: 'app-session-1',
+        artifactStorageSessionId: 'storage-session-1',
+        artifactRunId: 'run-1',
+        writeOperationId: 'operation-1',
+        filename: 'report.txt',
+        actualBytes: 6
+      })
+    ).rejects.toThrow(/missing or expired/u)
+    await expect(owner.reserve(request())).resolves.not.toEqual(first)
+  })
+})

--- a/src/main/artifacts/write-budget-owner.ts
+++ b/src/main/artifacts/write-budget-owner.ts
@@ -1,0 +1,323 @@
+import { randomUUID } from 'node:crypto'
+
+import type { PrismaClient } from '@prisma/client'
+
+import type {
+  ArtifactWriteReservation,
+  ReleaseArtifactWriteReservationRequest,
+  ReserveArtifactWriteRequest
+} from '../../shared/artifact-provenance'
+import { availableBytes } from '../storage/usage'
+import {
+  LOCAL_RESOURCE_BUDGETS,
+  assertWithinResourceBudget,
+  type LocalResourceBudgetOverrides
+} from '../resource-budget'
+import { assertDiskReserve } from '../bounded-file-io'
+import type { ArtifactRepository } from './repository'
+
+const RESERVATION_METADATA_BYTES = 64 * 1024
+const DEFAULT_RESERVATION_TTL_MS = 2 * 60 * 60 * 1_000
+const COUNTED_VERSION_STATES = ['staging', 'pending', 'finalized']
+
+const usageBytes = (value: bigint | null | undefined): number =>
+  value !== undefined && value !== null && value > BigInt(Number.MAX_SAFE_INTEGER)
+    ? Number.MAX_SAFE_INTEGER
+    : Number(value ?? 0n)
+
+type ReservationRecord = ArtifactWriteReservation &
+  ReserveArtifactWriteRequest & {
+    physicalBytes: number
+  }
+
+type ArtifactWriteBudgetOwnerOptions = {
+  storageRoot: string
+  getClient: () => Promise<PrismaClient>
+  compatibilityRepository: Pick<
+    ArtifactRepository,
+    'listPendingRunFiles' | 'listPendingRunPublications'
+  >
+  resourceBudgets?: LocalResourceBudgetOverrides
+  getAvailableBytes?: (path: string) => Promise<number>
+  now?: () => number
+  reservationTtlMs?: number
+}
+
+class ArtifactWriteBudgetOwner {
+  private readonly reservations = new Map<string, ReservationRecord>()
+  private tail = Promise.resolve()
+
+  constructor(private readonly options: ArtifactWriteBudgetOwnerOptions) {}
+
+  reserve(request: ReserveArtifactWriteRequest): Promise<ArtifactWriteReservation> {
+    return this.serialized(async () => {
+      this.pruneExpired()
+      const budgets = { ...LOCAL_RESOURCE_BUDGETS, ...this.options.resourceBudgets }
+      assertWithinResourceBudget('file', request.fileBytes, budgets.artifactFileBytes)
+
+      const duplicate = [...this.reservations.values()].find(
+        (reservation) =>
+          reservation.projectId === request.projectId &&
+          reservation.appSessionId === request.appSessionId &&
+          reservation.writeOperationId === request.writeOperationId
+      )
+      if (duplicate) {
+        if (
+          duplicate.fileBytes !== request.fileBytes ||
+          duplicate.filename !== request.filename ||
+          duplicate.artifactRunId !== request.artifactRunId
+        ) {
+          throw new Error(
+            `Artifact write operation was reused for a different reservation: ${request.writeOperationId}`
+          )
+        }
+        return this.publicReservation(duplicate)
+      }
+
+      const client = await this.options.getClient()
+      const existing = await client.artifactVersion.findUnique({
+        where: { writeOperationId: request.writeOperationId }
+      })
+      if (existing && Number(existing.sizeBytes) !== request.fileBytes) {
+        throw new Error(
+          `Artifact write operation was reused with a different size: ${request.writeOperationId}`
+        )
+      }
+
+      const outstanding = [...this.reservations.values()].filter(
+        (reservation) =>
+          reservation.projectId === request.projectId &&
+          reservation.appSessionId === request.appSessionId
+      )
+      // Read persisted ownership before aggregate totals. If a Version becomes counted between
+      // these reads, the result is conservatively double-counted rather than under-counted.
+      const persistedOutstanding =
+        outstanding.length === 0
+          ? []
+          : await client.artifactVersion.findMany({
+              where: {
+                writeOperationId: {
+                  in: outstanding.map((reservation) => reservation.writeOperationId)
+                },
+                state: { in: COUNTED_VERSION_STATES }
+              },
+              select: { writeOperationId: true }
+            })
+      const [turnUsage, sessionUsage, compatibility] = await Promise.all([
+        client.artifactVersion.aggregate({
+          where: {
+            artifactRunId: request.artifactRunId,
+            state: { in: COUNTED_VERSION_STATES }
+          },
+          _sum: { sizeBytes: true }
+        }),
+        client.artifactVersion.aggregate({
+          where: {
+            artifact: {
+              projectId: request.projectId,
+              sessionId: request.appSessionId
+            },
+            state: { in: COUNTED_VERSION_STATES }
+          },
+          _sum: { sizeBytes: true }
+        }),
+        this.compatibilityUsage(request)
+      ])
+      const persistedOperationIds = new Set(
+        persistedOutstanding.map((version) => version.writeOperationId)
+      )
+      const logicalOutstanding = outstanding.filter(
+        (reservation) => !persistedOperationIds.has(reservation.writeOperationId)
+      )
+      const incomingLogicalBytes = existing ? 0 : request.fileBytes
+      const outstandingSessionBytes = logicalOutstanding.reduce(
+        (total, reservation) => total + reservation.fileBytes,
+        0
+      )
+      const outstandingTurnBytes = logicalOutstanding
+        .filter((reservation) => reservation.artifactRunId === request.artifactRunId)
+        .reduce((total, reservation) => total + reservation.fileBytes, 0)
+      assertWithinResourceBudget(
+        'turn',
+        usageBytes(turnUsage._sum.sizeBytes) +
+          compatibility.turnBytes +
+          outstandingTurnBytes +
+          incomingLogicalBytes,
+        budgets.artifactTurnBytes
+      )
+      assertWithinResourceBudget(
+        'session',
+        usageBytes(sessionUsage._sum.sizeBytes) +
+          compatibility.sessionBytes +
+          outstandingSessionBytes +
+          incomingLogicalBytes,
+        budgets.artifactSessionBytes
+      )
+
+      const physicalBytes = request.fileBytes * (existing ? 1 : 2) + RESERVATION_METADATA_BYTES
+      const outstandingPhysicalBytes = [...this.reservations.values()].reduce(
+        (total, reservation) => total + reservation.physicalBytes,
+        0
+      )
+      const diskAvailable = await (this.options.getAvailableBytes ?? availableBytes)(
+        this.options.storageRoot
+      )
+      assertDiskReserve(
+        diskAvailable - outstandingPhysicalBytes,
+        physicalBytes,
+        budgets.diskReserveBytes
+      )
+
+      const record: ReservationRecord = {
+        ...request,
+        id: randomUUID(),
+        expiresAt:
+          (this.options.now ?? Date.now)() +
+          (this.options.reservationTtlMs ?? DEFAULT_RESERVATION_TTL_MS),
+        physicalBytes
+      }
+      this.reservations.set(record.id, record)
+      return this.publicReservation(record)
+    })
+  }
+
+  assertReserved(request: {
+    reservationId: string
+    projectId: string
+    appSessionId: string
+    artifactStorageSessionId: string
+    artifactRunId: string
+    writeOperationId: string
+    filename: string
+    actualBytes: number
+  }): Promise<void> {
+    return this.serialized(async () => {
+      this.pruneExpired()
+      const reservation = this.reservations.get(request.reservationId)
+      if (!reservation) throw new Error('Artifact write reservation is missing or expired.')
+      for (const field of [
+        'projectId',
+        'appSessionId',
+        'artifactStorageSessionId',
+        'artifactRunId',
+        'writeOperationId',
+        'filename'
+      ] as const) {
+        if (reservation[field] !== request[field]) {
+          throw new Error(`Artifact write reservation does not match ${field}.`)
+        }
+      }
+      if (reservation.fileBytes !== request.actualBytes) {
+        throw new Error('Artifact write reservation does not match the streamed byte count.')
+      }
+    })
+  }
+
+  release(request: ReleaseArtifactWriteReservationRequest): Promise<void> {
+    return this.serialized(async () => {
+      const reservation = this.reservations.get(request.reservationId)
+      if (!reservation) return
+      if (
+        reservation.projectId !== request.projectId ||
+        reservation.appSessionId !== request.appSessionId ||
+        reservation.artifactStorageSessionId !== request.artifactStorageSessionId ||
+        reservation.artifactRunId !== request.artifactRunId
+      ) {
+        throw new Error('Artifact write reservation release scope does not match.')
+      }
+      this.reservations.delete(request.reservationId)
+    })
+  }
+
+  releaseRun(request: {
+    projectId: string
+    appSessionId: string
+    artifactStorageSessionId: string
+    artifactRunId: string
+  }): Promise<void> {
+    return this.serialized(async () => {
+      for (const [id, reservation] of this.reservations) {
+        if (
+          reservation.projectId === request.projectId &&
+          reservation.appSessionId === request.appSessionId &&
+          reservation.artifactStorageSessionId === request.artifactStorageSessionId &&
+          reservation.artifactRunId === request.artifactRunId
+        ) {
+          this.reservations.delete(id)
+        }
+      }
+    })
+  }
+
+  releaseAll(): Promise<void> {
+    return this.serialized(async () => {
+      this.reservations.clear()
+    })
+  }
+
+  private async compatibilityUsage(
+    request: ReserveArtifactWriteRequest
+  ): Promise<{ turnBytes: number; sessionBytes: number }> {
+    let turnBytes = 0
+    let sessionBytes = 0
+    const outstandingKeys = new Set(
+      [...this.reservations.values()].map(
+        (reservation) =>
+          `${reservation.artifactStorageSessionId}\0${reservation.artifactRunId}\0${reservation.filename}`
+      )
+    )
+    const publications = await this.options.compatibilityRepository.listPendingRunPublications(
+      request.projectId
+    )
+    for (const publication of publications) {
+      // Marked handoffs carry their logical app Session and may live under a delegated storage
+      // Session. Markerless legacy layouts have no stronger ownership signal, so preserve their
+      // historical current-storage fallback instead of charging an unrelated Session.
+      const belongsToSession = publication.marker
+        ? publication.marker.sessionId === request.appSessionId
+        : publication.sourceSessionId === request.artifactStorageSessionId
+      if (!belongsToSession) continue
+      const files = await this.options.compatibilityRepository.listPendingRunFiles({
+        projectName: request.projectId,
+        sessionId: publication.sourceSessionId,
+        runId: publication.runId
+      })
+      for (const file of files) {
+        if (file.versionId) continue
+        const key = `${publication.sourceSessionId}\0${publication.runId}\0${file.name}`
+        if (outstandingKeys.has(key)) continue
+        sessionBytes += file.size
+        if (publication.runId === request.artifactRunId) turnBytes += file.size
+      }
+    }
+    return { turnBytes, sessionBytes }
+  }
+
+  private pruneExpired(): void {
+    const now = (this.options.now ?? Date.now)()
+    for (const [id, reservation] of this.reservations) {
+      if (reservation.expiresAt <= now) this.reservations.delete(id)
+    }
+  }
+
+  private publicReservation(record: ReservationRecord): ArtifactWriteReservation {
+    return { id: record.id, fileBytes: record.fileBytes, expiresAt: record.expiresAt }
+  }
+
+  private async serialized<Result>(operation: () => Promise<Result>): Promise<Result> {
+    const previous = this.tail
+    let release = (): void => undefined
+    this.tail = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    await previous
+    try {
+      return await operation()
+    } finally {
+      release()
+    }
+  }
+}
+
+export { ArtifactWriteBudgetOwner }
+export type { ArtifactWriteBudgetOwnerOptions }

--- a/src/main/bounded-file-io.test.ts
+++ b/src/main/bounded-file-io.test.ts
@@ -1,0 +1,177 @@
+import { mkdtemp, open, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  copyFileWithinBudget,
+  copyOpenFileWithinBudget,
+  readFilePageAndDigest,
+  readVerifiedFilePage,
+  writeInlineWithinBudget
+} from './bounded-file-io'
+import { ResourceBudgetExceededError } from './resource-budget'
+
+let root: string | undefined
+
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true })
+  root = undefined
+})
+
+describe('bounded file IO', () => {
+  it('stops a streaming copy at the file limit', async () => {
+    root = await mkdtemp(join(tmpdir(), 'bounded-file-io-'))
+    const source = join(root, 'source')
+    await writeFile(source, '0123456789')
+
+    await expect(copyFileWithinBudget(source, join(root, 'target'), 5)).rejects.toBeInstanceOf(
+      ResourceBudgetExceededError
+    )
+    await expect(readFile(join(root, 'target'))).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('removes a partial copy when the caller aborts', async () => {
+    root = await mkdtemp(join(tmpdir(), 'bounded-file-io-'))
+    const source = join(root, 'source')
+    const target = join(root, 'target')
+    await writeFile(source, '0123456789')
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(copyFileWithinBudget(source, target, 10, controller.signal)).rejects.toMatchObject(
+      {
+        name: 'AbortError'
+      }
+    )
+    await expect(readFile(target)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('does not remove a pre-existing target when exclusive creation fails', async () => {
+    root = await mkdtemp(join(tmpdir(), 'bounded-file-io-'))
+    const source = join(root, 'source')
+    const target = join(root, 'target')
+    await writeFile(source, 'replacement')
+    await writeFile(target, 'existing')
+
+    await expect(copyFileWithinBudget(source, target, 32)).rejects.toMatchObject({ code: 'EEXIST' })
+    await expect(readFile(target, 'utf8')).resolves.toBe('existing')
+  })
+
+  it('leaves an open source handle owned by the caller after a budget failure', async () => {
+    root = await mkdtemp(join(tmpdir(), 'bounded-file-io-'))
+    const source = join(root, 'source')
+    const target = join(root, 'target')
+    await writeFile(source, '0123456789')
+    const sourceHandle = await open(source, 'r')
+
+    try {
+      await expect(copyOpenFileWithinBudget(sourceHandle, target, 5)).rejects.toBeInstanceOf(
+        ResourceBudgetExceededError
+      )
+      await expect(sourceHandle.stat()).resolves.toMatchObject({ size: 10 })
+      await expect(readFile(target)).rejects.toMatchObject({ code: 'ENOENT' })
+    } finally {
+      await sourceHandle.close()
+    }
+  })
+
+  it('leaves an open source handle owned by the caller after cancellation', async () => {
+    root = await mkdtemp(join(tmpdir(), 'bounded-file-io-'))
+    const source = join(root, 'source')
+    const target = join(root, 'target')
+    await writeFile(source, '0123456789')
+    const sourceHandle = await open(source, 'r')
+    const controller = new AbortController()
+    controller.abort()
+
+    try {
+      await expect(
+        copyOpenFileWithinBudget(sourceHandle, target, 10, controller.signal)
+      ).rejects.toMatchObject({ name: 'AbortError' })
+      await expect(sourceHandle.stat()).resolves.toMatchObject({ size: 10 })
+      await expect(readFile(target)).rejects.toMatchObject({ code: 'ENOENT' })
+    } finally {
+      await sourceHandle.close()
+    }
+  })
+
+  it('preserves an existing target when copying from an open source handle', async () => {
+    root = await mkdtemp(join(tmpdir(), 'bounded-file-io-'))
+    const source = join(root, 'source')
+    const target = join(root, 'target')
+    await writeFile(source, 'replacement')
+    await writeFile(target, 'existing')
+    const sourceHandle = await open(source, 'r')
+
+    try {
+      await expect(copyOpenFileWithinBudget(sourceHandle, target, 32)).rejects.toMatchObject({
+        code: 'EEXIST'
+      })
+      await expect(sourceHandle.stat()).resolves.toMatchObject({ size: 11 })
+      await expect(readFile(target, 'utf8')).resolves.toBe('existing')
+    } finally {
+      await sourceHandle.close()
+    }
+  })
+
+  it('writes UTF-8 inline content in chunks without splitting surrogate pairs', async () => {
+    root = await mkdtemp(join(tmpdir(), 'bounded-file-io-'))
+    const target = join(root, 'target')
+    const content = `${'a'.repeat(16 * 1024 - 1)}😀tail`
+
+    const digest = await writeInlineWithinBudget(target, content, 'utf8', 32 * 1024)
+
+    expect(await readFile(target, 'utf8')).toBe(content)
+    expect(digest.sizeBytes).toBe(Buffer.byteLength(content))
+  })
+
+  it('decodes multiline base64 across chunk boundaries', async () => {
+    root = await mkdtemp(join(tmpdir(), 'bounded-file-io-'))
+    const target = join(root, 'target')
+    const bytes = Buffer.from('x'.repeat(128 * 1024))
+    const encoded = bytes.toString('base64').replace(/.{73}/gu, (line) => `${line}\n`)
+
+    const digest = await writeInlineWithinBudget(target, encoded, 'base64', bytes.byteLength)
+
+    expect(await readFile(target)).toEqual(bytes)
+    expect(digest.sizeBytes).toBe(bytes.byteLength)
+  })
+
+  it('hashes the whole file while retaining only the requested prefix', async () => {
+    root = await mkdtemp(join(tmpdir(), 'bounded-file-io-'))
+    const source = join(root, 'source')
+    await writeFile(source, 'abcdefghij')
+
+    await expect(readFilePageAndDigest(source, 2, 4)).resolves.toMatchObject({
+      page: Buffer.from('cdef'),
+      sizeBytes: 10,
+      offset: 2,
+      returnedBytes: 4,
+      truncated: true
+    })
+  })
+
+  it('reads bounded pages only while the verified file observation remains stable', async () => {
+    root = await mkdtemp(join(tmpdir(), 'bounded-file-io-'))
+    const source = join(root, 'source')
+    const replacement = join(root, 'replacement')
+    const displaced = join(root, 'displaced')
+    await writeFile(source, 'abcdefghij')
+    const verified = await readFilePageAndDigest(source, 0, 0)
+
+    await expect(readVerifiedFilePage(source, 4, 3, verified.observation)).resolves.toMatchObject({
+      page: Buffer.from('efg'),
+      offset: 4,
+      returnedBytes: 3,
+      truncated: true
+    })
+
+    await writeFile(replacement, '0123456789')
+    await rename(source, displaced)
+    await rename(replacement, source)
+    await expect(readVerifiedFilePage(source, 4, 3, verified.observation)).rejects.toThrow(
+      /changed since verification/u
+    )
+  })
+})

--- a/src/main/bounded-file-io.ts
+++ b/src/main/bounded-file-io.ts
@@ -1,0 +1,372 @@
+import { createHash } from 'node:crypto'
+import { createReadStream, createWriteStream, type Stats } from 'node:fs'
+import { open, rm, type FileHandle } from 'node:fs/promises'
+import { pipeline } from 'node:stream/promises'
+import { Readable, Transform } from 'node:stream'
+
+import { ResourceBudgetExceededError, assertWithinResourceBudget } from './resource-budget'
+
+type FileDigest = {
+  sizeBytes: number
+  checksum: string
+}
+
+type FileObservation = {
+  device: number
+  inode: number
+  sizeBytes: number
+  modifiedAtMs: number
+  changedAtMs: number
+}
+
+type FilePage = {
+  page: Buffer
+  offset: number
+  returnedBytes: number
+  truncated: boolean
+}
+
+const observeFile = (stats: Stats): FileObservation => ({
+  device: stats.dev,
+  inode: stats.ino,
+  sizeBytes: stats.size,
+  modifiedAtMs: stats.mtimeMs,
+  changedAtMs: stats.ctimeMs
+})
+
+const sameFileObservation = (left: FileObservation, right: FileObservation): boolean =>
+  left.device === right.device &&
+  left.inode === right.inode &&
+  left.sizeBytes === right.sizeBytes &&
+  left.modifiedAtMs === right.modifiedAtMs &&
+  left.changedAtMs === right.changedAtMs
+
+const assertFileObservation = (
+  actual: FileObservation,
+  expected: FileObservation,
+  message: string
+): void => {
+  if (!sameFileObservation(actual, expected)) throw new Error(message)
+}
+
+const countingHashTransform = (
+  maxBytes: number,
+  onComplete: (digest: FileDigest) => void
+): Transform => {
+  const hash = createHash('sha256')
+  let sizeBytes = 0
+
+  return new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      sizeBytes += chunk.byteLength
+      try {
+        assertWithinResourceBudget('file', sizeBytes, maxBytes)
+        hash.update(chunk)
+        callback(null, chunk)
+      } catch (error) {
+        callback(error as Error)
+      }
+    },
+    flush(callback) {
+      onComplete({ sizeBytes, checksum: hash.digest('hex') })
+      callback()
+    }
+  })
+}
+
+const copyFileWithinBudget = async (
+  sourcePath: string,
+  targetPath: string,
+  maxBytes: number,
+  signal?: AbortSignal
+): Promise<FileDigest> => {
+  let digest: FileDigest | undefined
+  let targetOpened = false
+  const target = createWriteStream(targetPath, { flags: 'wx' })
+  target.once('open', () => {
+    targetOpened = true
+  })
+  try {
+    await pipeline(
+      createReadStream(sourcePath),
+      countingHashTransform(maxBytes, (value) => {
+        digest = value
+      }),
+      target,
+      { signal }
+    )
+  } catch (error) {
+    if (targetOpened) await rm(targetPath, { force: true }).catch(() => undefined)
+    throw error
+  }
+  if (!digest) throw new Error('Artifact file copy completed without a digest.')
+  return digest
+}
+
+const copyOpenFileWithinBudget = async (
+  sourceHandle: Pick<FileHandle, 'read'>,
+  targetPath: string,
+  maxBytes: number,
+  signal?: AbortSignal
+): Promise<FileDigest> => {
+  let digest: FileDigest | undefined
+  let targetOpened = false
+  const target = createWriteStream(targetPath, { flags: 'wx' })
+  target.once('open', () => {
+    targetOpened = true
+  })
+  try {
+    await pipeline(
+      Readable.from(readOpenFileChunks(sourceHandle)),
+      countingHashTransform(maxBytes, (value) => {
+        digest = value
+      }),
+      target,
+      { signal }
+    )
+  } catch (error) {
+    if (targetOpened) await rm(targetPath, { force: true }).catch(() => undefined)
+    throw error
+  }
+  if (!digest) throw new Error('Artifact file copy completed without a digest.')
+  return digest
+}
+
+const readOpenFileChunks = async function* (
+  sourceHandle: Pick<FileHandle, 'read'>,
+  signal?: AbortSignal
+): AsyncGenerator<Buffer> {
+  const chunkBytes = 64 * 1024
+  let position = 0
+  while (true) {
+    signal?.throwIfAborted()
+    const chunk = Buffer.allocUnsafe(chunkBytes)
+    const { bytesRead } = await sourceHandle.read(chunk, 0, chunk.byteLength, position)
+    signal?.throwIfAborted()
+    if (bytesRead === 0) return
+    position += bytesRead
+    yield chunk.subarray(0, bytesRead)
+  }
+}
+
+const inlineChunks = function* (content: string, encoding: 'utf8' | 'base64'): Generator<Buffer> {
+  if (encoding === 'utf8') {
+    const chunkCharacters = 16 * 1024
+    for (let offset = 0; offset < content.length;) {
+      let end = Math.min(offset + chunkCharacters, content.length)
+      if (end < content.length && end > offset && /[\uD800-\uDBFF]/u.test(content[end - 1]!)) {
+        end += 1
+      }
+      yield Buffer.from(content.slice(offset, end), 'utf8')
+      offset = end
+    }
+    return
+  }
+
+  let carry = ''
+  for (let offset = 0; offset < content.length; offset += 64 * 1024) {
+    const normalized = carry + content.slice(offset, offset + 64 * 1024).replace(/\s/gu, '')
+    const completeLength = normalized.length - (normalized.length % 4)
+    if (completeLength > 0) {
+      yield Buffer.from(normalized.slice(0, completeLength), 'base64')
+    }
+    carry = normalized.slice(completeLength)
+  }
+  if (carry) yield Buffer.from(carry, 'base64')
+}
+
+const inlineDecodedSize = (content: string, encoding: 'utf8' | 'base64'): number => {
+  let sizeBytes = 0
+  for (const chunk of inlineChunks(content, encoding)) sizeBytes += chunk.byteLength
+  return sizeBytes
+}
+
+const writeInlineWithinBudget = async (
+  targetPath: string,
+  content: string,
+  encoding: 'utf8' | 'base64',
+  maxBytes: number,
+  signal?: AbortSignal
+): Promise<FileDigest> => {
+  const declaredBytes = inlineDecodedSize(content, encoding)
+  assertWithinResourceBudget('file', declaredBytes, maxBytes)
+
+  let digest: FileDigest | undefined
+  let targetOpened = false
+  const target = createWriteStream(targetPath, { flags: 'wx' })
+  target.once('open', () => {
+    targetOpened = true
+  })
+  try {
+    await pipeline(
+      Readable.from(inlineChunks(content, encoding)),
+      countingHashTransform(maxBytes, (value) => {
+        digest = value
+      }),
+      target,
+      { signal }
+    )
+  } catch (error) {
+    if (targetOpened) await rm(targetPath, { force: true }).catch(() => undefined)
+    throw error
+  }
+  if (!digest) throw new Error('Artifact inline write completed without a digest.')
+  return digest
+}
+
+const digestFileWithinBudget = async (
+  path: string,
+  maxBytes: number,
+  signal?: AbortSignal
+): Promise<FileDigest> => {
+  const hash = createHash('sha256')
+  let sizeBytes = 0
+  for await (const chunk of createReadStream(path, { signal })) {
+    sizeBytes += chunk.byteLength
+    assertWithinResourceBudget('file', sizeBytes, maxBytes)
+    hash.update(chunk)
+  }
+  return { sizeBytes, checksum: hash.digest('hex') }
+}
+
+const readFilePageAndDigest = async (
+  path: string,
+  offset: number,
+  maxReturnedBytes: number,
+  signal?: AbortSignal
+): Promise<
+  FileDigest & {
+    page: Buffer
+    sample: Buffer
+    observation: FileObservation
+    offset: number
+    returnedBytes: number
+    truncated: boolean
+  }
+> => {
+  const hash = createHash('sha256')
+  const chunks: Buffer[] = []
+  const sampleChunks: Buffer[] = []
+  let sizeBytes = 0
+  let returnedBytes = 0
+  let sampleBytes = 0
+
+  const sourceHandle = await open(path, 'r')
+  try {
+    const observation = observeFile(await sourceHandle.stat())
+    for await (const chunk of readOpenFileChunks(sourceHandle, signal)) {
+      const chunkStart = sizeBytes
+      sizeBytes += chunk.byteLength
+      hash.update(chunk)
+      if (sampleBytes < 512) {
+        const sample = chunk.subarray(0, Math.min(chunk.byteLength, 512 - sampleBytes))
+        sampleChunks.push(sample)
+        sampleBytes += sample.byteLength
+      }
+      const chunkEnd = sizeBytes
+      const pageEnd = offset + maxReturnedBytes
+      if (chunkEnd > offset && chunkStart < pageEnd) {
+        const retained = chunk.subarray(
+          Math.max(0, offset - chunkStart),
+          Math.min(chunk.byteLength, pageEnd - chunkStart)
+        )
+        chunks.push(retained)
+        returnedBytes += retained.byteLength
+      }
+    }
+
+    const completedObservation = observeFile(await sourceHandle.stat())
+    assertFileObservation(
+      completedObservation,
+      observation,
+      'Artifact file changed while being verified.'
+    )
+    if (sizeBytes !== completedObservation.sizeBytes) {
+      throw new Error('Artifact file size changed while being verified.')
+    }
+
+    return {
+      page: Buffer.concat(chunks, returnedBytes),
+      sample: Buffer.concat(sampleChunks, sampleBytes),
+      sizeBytes,
+      observation: completedObservation,
+      offset,
+      returnedBytes,
+      truncated: offset + returnedBytes < sizeBytes,
+      checksum: hash.digest('hex')
+    }
+  } finally {
+    await sourceHandle.close()
+  }
+}
+
+const readVerifiedFilePage = async (
+  path: string,
+  offset: number,
+  maxReturnedBytes: number,
+  observation: FileObservation,
+  signal?: AbortSignal
+): Promise<FilePage> => {
+  const sourceHandle = await open(path, 'r')
+  try {
+    assertFileObservation(
+      observeFile(await sourceHandle.stat()),
+      observation,
+      'Artifact file changed since verification.'
+    )
+    const returnedLimit = Math.min(maxReturnedBytes, Math.max(0, observation.sizeBytes - offset))
+    const page = Buffer.allocUnsafe(returnedLimit)
+    let returnedBytes = 0
+    while (returnedBytes < returnedLimit) {
+      signal?.throwIfAborted()
+      const read = await sourceHandle.read(
+        page,
+        returnedBytes,
+        returnedLimit - returnedBytes,
+        offset + returnedBytes
+      )
+      signal?.throwIfAborted()
+      if (read.bytesRead === 0) break
+      returnedBytes += read.bytesRead
+    }
+    assertFileObservation(
+      observeFile(await sourceHandle.stat()),
+      observation,
+      'Artifact file changed while reading a verified page.'
+    )
+    if (returnedBytes !== returnedLimit) {
+      throw new Error('Artifact file ended before the verified page was read.')
+    }
+    return {
+      page: page.subarray(0, returnedBytes),
+      offset,
+      returnedBytes,
+      truncated: offset + returnedBytes < observation.sizeBytes
+    }
+  } finally {
+    await sourceHandle.close()
+  }
+}
+
+const assertDiskReserve = (
+  availableBytes: number,
+  writeBytes: number,
+  reserveBytes: number
+): void => {
+  const requiredBytes = writeBytes + reserveBytes
+  if (availableBytes < requiredBytes) {
+    throw new ResourceBudgetExceededError('disk-reserve', requiredBytes, availableBytes)
+  }
+}
+
+export {
+  assertDiskReserve,
+  copyFileWithinBudget,
+  copyOpenFileWithinBudget,
+  digestFileWithinBudget,
+  inlineDecodedSize,
+  readFilePageAndDigest,
+  readVerifiedFilePage,
+  writeInlineWithinBudget
+}
+export type { FileDigest, FileObservation, FilePage }

--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -1809,8 +1809,12 @@ describe('production delegated-work composition', () => {
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
       transport: 'tcp',
       artifactProvenance: {
-        createVersion: (request) => provenance.createVersion(request),
-        replayVersion: (request) => provenance.replayVersion(request)
+        createVersion: (request, signal) => provenance.createVersion(request, signal),
+        replayVersion: (request) => provenance.replayVersion(request),
+        reserveWrite: (request) => provenance.reserveWrite(request),
+        releaseWriteReservation: (request) => provenance.releaseWriteReservation(request),
+        releaseRunWriteReservations: (request) => provenance.releaseRunWriteReservations(request),
+        releaseAllWriteReservations: () => provenance.releaseAllWriteReservations()
       }
     })
     const connection = await server.ensureStarted()

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1667,11 +1667,18 @@ const createApplicationModules = async (
         return runtime.requestUserInput(request)
       },
       artifactProvenance: {
-        createVersion: (request) =>
+        reserveWrite: (request) => artifactProvenanceRepository.reserveWrite(request),
+        releaseWriteReservation: (request) =>
+          artifactProvenanceRepository.releaseWriteReservation(request),
+        releaseRunWriteReservations: (request) =>
+          artifactProvenanceRepository.releaseRunWriteReservations(request),
+        releaseAllWriteReservations: () =>
+          artifactProvenanceRepository.releaseAllWriteReservations(),
+        createVersion: (request, signal) =>
           sessionPersistenceCoordinator.runSessionMutation(
             request.projectId,
             request.appSessionId,
-            () => artifactProvenanceRepository.createVersion(request)
+            () => artifactProvenanceRepository.createVersion(request, signal)
           ),
         replayVersion: (request) =>
           sessionPersistenceCoordinator.runSessionMutation(

--- a/src/main/notebook/local-rpc-server.test.ts
+++ b/src/main/notebook/local-rpc-server.test.ts
@@ -77,6 +77,31 @@ afterEach(async () => {
 })
 
 describe('notebook local RPC server', () => {
+  it('rejects an authenticated request body above the local RPC budget', async () => {
+    const server = new NotebookLocalRpcServer({} as never, {
+      transport: 'tcp',
+      token: 'secret-token',
+      requestBytes: 2
+    })
+    const connection = await server.ensureStarted()
+
+    try {
+      const response = await fetch(connection.endpoint, {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer secret-token',
+          'content-type': 'application/json'
+        },
+        body: '{} '
+      })
+
+      expect(response.status).toBe(413)
+      expect(response.headers.get('connection')).toBe('close')
+    } finally {
+      await server.close()
+    }
+  })
+
   it('binds viewImage to the trusted active control invocation and execution workspace', async () => {
     const stage = vi.fn(async (_source, _options, trusted) => trusted)
     const isAvailable = vi.fn(async () => true)
@@ -1975,6 +2000,9 @@ describe('notebook local RPC server', () => {
       artifactRunId: 'artifact-run-1',
       writeOperationId: 'write-1',
       writeRequestChecksum: 'b'.repeat(64),
+      resourceReservationId: 'reservation-1',
+      resourceSizeBytes: 12,
+      resourceChecksum: 'a'.repeat(64),
       rootFrameId: 'frame-root',
       agentFrameId: 'frame-root',
       messageBranchId: 'branch-root',
@@ -2014,6 +2042,106 @@ describe('notebook local RPC server', () => {
       ])
     } finally {
       await server.close()
+    }
+  })
+
+  it('binds Artifact reservations to the capability and releases ownership on revoke and close', async () => {
+    const reserveWrite = vi.fn(async () => ({
+      id: 'reservation-1',
+      fileBytes: 12,
+      expiresAt: Date.now() + 60_000
+    }))
+    const releaseWriteReservation = vi.fn(async () => undefined)
+    const releaseRunWriteReservations = vi.fn(async () => undefined)
+    const releaseAllWriteReservations = vi.fn(async () => undefined)
+    const createVersion = vi.fn()
+    const server = new NotebookLocalRpcServer({} as never, {
+      transport: 'tcp',
+      token: 'secret-token',
+      artifactProvenance: {
+        createVersion,
+        reserveWrite,
+        releaseWriteReservation,
+        releaseRunWriteReservations,
+        releaseAllWriteReservations
+      }
+    })
+    const connection = await server.ensureStarted()
+    const token = server.issueArtifactRunCapability(artifactCapabilityBinding)
+    let closed = false
+    const call = (method: string, params: Record<string, unknown>): Promise<Response> =>
+      fetch(connection.endpoint, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ method, params })
+      })
+
+    try {
+      const reserved = await call('artifactReserveWrite', {
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactStorageSessionId: 'artifact-session-1',
+        artifactRunId: 'artifact-run-1',
+        writeOperationId: 'write-1',
+        filename: 'sin.png',
+        fileBytes: 12
+      })
+      await expect(reserved.json()).resolves.toEqual({
+        result: expect.objectContaining({ id: 'reservation-1', fileBytes: 12 })
+      })
+      expect(reserveWrite).toHaveBeenCalledWith({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactStorageSessionId: 'artifact-session-1',
+        artifactRunId: 'artifact-run-1',
+        writeOperationId: 'write-1',
+        filename: 'sin.png',
+        fileBytes: 12
+      })
+
+      const released = await call('artifactReleaseWrite', {
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactStorageSessionId: 'artifact-session-1',
+        artifactRunId: 'artifact-run-1',
+        reservationId: 'reservation-1'
+      })
+      expect(released.status).toBe(200)
+      expect(releaseWriteReservation).toHaveBeenCalledWith({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactStorageSessionId: 'artifact-session-1',
+        artifactRunId: 'artifact-run-1',
+        reservationId: 'reservation-1'
+      })
+
+      const bypass = await call('artifactCreateVersion', {
+        ...artifactCapabilityBinding,
+        writeOperationId: 'write-without-reservation',
+        writeRequestChecksum: 'a'.repeat(64),
+        filename: 'bypass.txt'
+      })
+      expect(bypass.status).toBe(500)
+      await expect(bypass.json()).resolves.toEqual({
+        error: 'Artifact Version creation requires a write reservation.'
+      })
+      expect(createVersion).not.toHaveBeenCalled()
+
+      await server.revokeArtifactRunCapability(token)
+      expect(releaseRunWriteReservations).toHaveBeenCalledWith({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactStorageSessionId: 'artifact-session-1',
+        artifactRunId: 'artifact-run-1'
+      })
+      await server.close()
+      closed = true
+      expect(releaseAllWriteReservations).toHaveBeenCalledOnce()
+    } finally {
+      if (!closed) await server.close()
     }
   })
 
@@ -2071,6 +2199,9 @@ describe('notebook local RPC server', () => {
             ...artifactCapabilityBinding,
             writeOperationId: 'write-drain',
             writeRequestChecksum: 'a'.repeat(64),
+            resourceReservationId: 'reservation-drain',
+            resourceSizeBytes: 12,
+            resourceChecksum: 'a'.repeat(64),
             filename: 'sin.png'
           }
         })
@@ -2253,6 +2384,9 @@ describe('notebook local RPC server', () => {
             ...artifactCapabilityBinding,
             writeOperationId: 'write-long-turn',
             writeRequestChecksum: 'a'.repeat(64),
+            resourceReservationId: 'reservation-long-turn',
+            resourceSizeBytes: 12,
+            resourceChecksum: 'a'.repeat(64),
             filename: 'sin.png'
           }
         })

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -24,8 +24,11 @@ import type {
 import type {
   ArtifactRpcCapabilityBinding,
   ArtifactRpcMethod,
+  ArtifactWriteReservation,
   ArtifactVersionFile,
   CreateArtifactVersionRequest,
+  ReleaseArtifactWriteReservationRequest,
+  ReserveArtifactWriteRequest,
   ReplayArtifactVersionRequest
 } from '../../shared/artifact-provenance'
 import {
@@ -49,6 +52,11 @@ import {
   type LocalRpcListenOptions
 } from '../local-rpc-transport'
 import { createLogger, errorLogFields } from '../logger'
+import {
+  LOCAL_RESOURCE_BUDGETS,
+  ResourceBudgetExceededError,
+  readBoundedJsonBody
+} from '../resource-budget'
 import { PlanCommandError } from '../../shared/session-plan/contract'
 import type { HostLlmCallInput, HostLlmResult, HostLlmBatchItem } from './host-llm-service'
 import type {
@@ -74,6 +82,7 @@ const log = createLogger('notebook:local-rpc')
 type NotebookLocalRpcServerOptions = {
   token?: string
   host?: string
+  requestBytes?: number
   now?: () => number
   onSessionReleased?: (sessionId: string) => void
   transport?: LocalRpcListenOptions['transport']
@@ -152,8 +161,20 @@ type NotebookLocalRpcServerOptions = {
   }
   requestUserInput?: (request: AgentUserChoiceRequest) => Promise<AgentUserChoiceResult>
   artifactProvenance?: {
-    createVersion(request: CreateArtifactVersionRequest): Promise<ArtifactVersionFile>
+    createVersion(
+      request: CreateArtifactVersionRequest,
+      signal?: AbortSignal
+    ): Promise<ArtifactVersionFile>
     replayVersion?(request: ReplayArtifactVersionRequest): Promise<ArtifactVersionFile | undefined>
+    reserveWrite?(request: ReserveArtifactWriteRequest): Promise<ArtifactWriteReservation>
+    releaseWriteReservation?(request: ReleaseArtifactWriteReservationRequest): Promise<void>
+    releaseRunWriteReservations?(request: {
+      projectId: string
+      appSessionId: string
+      artifactStorageSessionId: string
+      artifactRunId: string
+    }): Promise<void>
+    releaseAllWriteReservations?(): Promise<void>
   }
   inputRegistry?: Pick<NotebookInputRegistry, 'registerTurn' | 'getTurnInputs' | 'clearSession'> &
     Partial<Pick<NotebookInputRegistry, 'openRun'>>
@@ -311,6 +332,8 @@ class RpcHttpError extends Error {
 }
 
 const ARTIFACT_RPC_METHODS = new Set<ArtifactRpcMethod>([
+  'artifactReserveWrite',
+  'artifactReleaseWrite',
   'artifactCreateVersion',
   'artifactReplayVersion'
 ])
@@ -385,17 +408,6 @@ const notebookExecutionInputFingerprint = (
     .digest('hex')
 }
 
-// Reads the full HTTP request body and parses it as the notebook RPC payload.
-const readJsonBody = async (request: IncomingMessage): Promise<NotebookRpcPayload> => {
-  const chunks: Buffer[] = []
-
-  for await (const chunk of request) {
-    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
-  }
-
-  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as NotebookRpcPayload
-}
-
 // Writes one JSON response with an explicit HTTP status code.
 const writeJson = (response: ServerResponse, statusCode: number, payload: unknown): void => {
   response.writeHead(statusCode, { 'content-type': 'application/json' })
@@ -414,6 +426,7 @@ const closeRequestAfterResponse = (request: IncomingMessage, response: ServerRes
 class NotebookLocalRpcServer {
   private readonly token: string
   private readonly host: string
+  private readonly requestBytes: number
   private readonly now: () => number
   private readonly onSessionReleased: NotebookLocalRpcServerOptions['onSessionReleased']
   private readonly transport: NotebookLocalRpcServerOptions['transport']
@@ -463,6 +476,7 @@ class NotebookLocalRpcServer {
   ) {
     this.token = options.token ?? randomUUID()
     this.host = options.host ?? '127.0.0.1'
+    this.requestBytes = options.requestBytes ?? LOCAL_RESOURCE_BUDGETS.requestBytes
     this.now = options.now ?? Date.now
     this.onSessionReleased = options.onSessionReleased
     this.transport = options.transport
@@ -498,7 +512,12 @@ class NotebookLocalRpcServer {
         : undefined,
       messageAncestry: binding.messageAncestry ? [...binding.messageAncestry] : undefined,
       allowedMethods: new Set(
-        binding.allowedMethods ?? ['artifactCreateVersion', 'artifactReplayVersion']
+        binding.allowedMethods ?? [
+          'artifactReserveWrite',
+          'artifactReleaseWrite',
+          'artifactCreateVersion',
+          'artifactReplayVersion'
+        ]
       ),
       expiresAt: this.now() + ttlMs,
       inFlightRequests: 0,
@@ -507,13 +526,24 @@ class NotebookLocalRpcServer {
     return token
   }
 
-  revokeArtifactRunCapability(token: string): Promise<void> {
+  async revokeArtifactRunCapability(token: string): Promise<void> {
     const draining = this.drainingArtifactRpcCapabilities.get(token)
     if (draining) return draining
 
     const capability = this.artifactRpcCapabilities.get(token)
     this.artifactRpcCapabilities.delete(token)
-    if (!capability || capability.inFlightRequests === 0) return Promise.resolve()
+    if (!capability) return
+    const releaseReservations = (): Promise<void> =>
+      this.artifactProvenance?.releaseRunWriteReservations?.({
+        projectId: capability.projectId,
+        appSessionId: capability.appSessionId,
+        artifactStorageSessionId: capability.artifactStorageSessionId,
+        artifactRunId: capability.artifactRunId
+      }) ?? Promise.resolve()
+    if (capability.inFlightRequests === 0) {
+      await releaseReservations()
+      return
+    }
 
     const drain = new Promise<void>((resolve) => {
       capability.drainWaiters.add(resolve)
@@ -524,7 +554,8 @@ class NotebookLocalRpcServer {
         this.drainingArtifactRpcCapabilities.delete(token)
       }
     })
-    return drain
+    await drain
+    await releaseReservations()
   }
 
   // Starts the server once on an ephemeral port and returns the connection details for MCP env.
@@ -594,7 +625,9 @@ class NotebookLocalRpcServer {
     this.executionAuthorizations.clear()
     this.consumedExecutionToolCalls.clear()
 
-    if (!server || !lifecycle) return Promise.resolve()
+    if (!server || !lifecycle) {
+      return this.artifactProvenance?.releaseAllWriteReservations?.() ?? Promise.resolve()
+    }
 
     lifecycle.closing = true
 
@@ -643,7 +676,10 @@ class NotebookLocalRpcServer {
         }
       }
     })
-    const ownedClose = operation.finally(() => {
+    const operationWithReservationCleanup = operation.finally(() =>
+      this.artifactProvenance?.releaseAllWriteReservations?.()
+    )
+    const ownedClose = operationWithReservationCleanup.finally(() => {
       if (forceCloseTimer) clearTimeout(forceCloseTimer)
       if (this.closePromise === ownedClose) this.closePromise = undefined
     })
@@ -1318,7 +1354,7 @@ class NotebookLocalRpcServer {
         writeJson(response, 401, { error: 'Invalid notebook RPC token.' })
         return
       }
-      const payload = await readJsonBody(request)
+      const payload = await readBoundedJsonBody<NotebookRpcPayload>(request, this.requestBytes)
       activeRequest.bodyComplete = true
       const method = typeof payload.method === 'string' ? payload.method : ''
       activeRequest.method = method
@@ -1604,9 +1640,19 @@ class NotebookLocalRpcServer {
               }
             : message
 
-      writeJson(response, error instanceof RpcHttpError ? error.statusCode : 500, {
-        error: serializedError
-      })
+      if (error instanceof ResourceBudgetExceededError) {
+        closeRequestAfterResponse(request, response)
+      }
+
+      writeJson(
+        response,
+        error instanceof RpcHttpError
+          ? error.statusCode
+          : error instanceof ResourceBudgetExceededError
+            ? 413
+            : 500,
+        { error: serializedError }
+      )
     } finally {
       request.off('aborted', abortDisconnectedRequest)
       response.off('close', abortDisconnectedResponse)
@@ -1629,8 +1675,26 @@ class NotebookLocalRpcServer {
       if (!this.artifactProvenance) {
         throw new Error('Artifact Provenance persistence is not configured.')
       }
-
-      return this.artifactProvenance.createVersion(params as CreateArtifactVersionRequest)
+      const request = params as CreateArtifactVersionRequest
+      if (!request.resourceReservationId) {
+        throw new Error('Artifact Version creation requires a write reservation.')
+      }
+      return this.artifactProvenance.createVersion(request, signal)
+    }
+    if (method === 'artifactReserveWrite') {
+      if (!this.artifactProvenance?.reserveWrite) {
+        throw new Error('Artifact write reservation is not configured.')
+      }
+      return this.artifactProvenance.reserveWrite(params as ReserveArtifactWriteRequest)
+    }
+    if (method === 'artifactReleaseWrite') {
+      if (!this.artifactProvenance?.releaseWriteReservation) {
+        throw new Error('Artifact write reservation is not configured.')
+      }
+      await this.artifactProvenance.releaseWriteReservation(
+        params as ReleaseArtifactWriteReservationRequest
+      )
+      return { released: true }
     }
     if (method === 'artifactReplayVersion') {
       if (!this.artifactProvenance?.replayVersion) {

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -11,6 +11,7 @@ import {
   MIN_AGENT_USER_CHOICE_OPTIONS
 } from '../../shared/elicitation'
 import { NOTEBOOK_MCP_SERVER_ARG } from '../mcp-server-args'
+import { LOCAL_RESOURCE_BUDGETS } from '../resource-budget'
 import {
   fetchLocalRpc,
   fetchLongLivedLocalRpc,
@@ -1139,7 +1140,11 @@ const runNotebookMcpServer = async (
 ): Promise<void> => {
   const server = createNotebookMcpServer(environment)
 
-  await server.connect(new StdioServerTransport())
+  await server.connect(
+    new StdioServerTransport(process.stdin, process.stdout, {
+      maxBufferSize: LOCAL_RESOURCE_BUDGETS.requestBytes
+    })
+  )
 }
 
 export {

--- a/src/main/resource-budget.test.ts
+++ b/src/main/resource-budget.test.ts
@@ -1,0 +1,62 @@
+import type { IncomingMessage } from 'node:http'
+import { readFile } from 'node:fs/promises'
+import { Readable } from 'node:stream'
+import { describe, expect, it } from 'vitest'
+
+import {
+  ResourceBudgetExceededError,
+  assertWithinResourceBudget,
+  readBoundedJsonBody
+} from './resource-budget'
+
+describe('resource budget', () => {
+  it('allows the exact limit and rejects the first byte above it', () => {
+    expect(() => assertWithinResourceBudget('file', 4, 4)).not.toThrow()
+    expect(() => assertWithinResourceBudget('file', 5, 4)).toThrow(ResourceBudgetExceededError)
+  })
+
+  it('rejects a declared request before reading its body', async () => {
+    const request = Readable.from(['{}']) as IncomingMessage
+    request.headers = { 'content-length': '3' }
+
+    await expect(readBoundedJsonBody(request, 2)).rejects.toThrow(ResourceBudgetExceededError)
+  })
+
+  it('rejects a chunked request on the first byte above the limit', async () => {
+    const request = {
+      headers: {},
+      async *[Symbol.asyncIterator]() {
+        yield Buffer.from([0x7b, 0x22, 0x61, 0x22])
+        yield Buffer.from(':1}')
+      }
+    } as unknown as IncomingMessage
+
+    await expect(readBoundedJsonBody(request, 6)).rejects.toMatchObject({
+      dimension: 'request',
+      observedBytes: 7,
+      limitBytes: 6
+    })
+  })
+
+  it('returns the configured value for an empty body', async () => {
+    const request = Readable.from([]) as IncomingMessage
+    request.headers = {}
+
+    await expect(
+      readBoundedJsonBody<undefined>(request, 1, { emptyValue: undefined })
+    ).resolves.toBeUndefined()
+  })
+
+  it('wires the shared request limit into both normal stdio MCP entry points', async () => {
+    for (const path of [
+      'src/main/artifacts/mcp-server.ts',
+      'src/main/notebook/mcp-server.ts',
+      'src/main/reviewer/mcp-stdio-proxy.ts',
+      'src/main/session-plan/plan-mcp-server.ts',
+      'src/main/skills/mcp-server.ts'
+    ]) {
+      const source = await readFile(path, 'utf8')
+      expect(source, path).toContain('maxBufferSize: LOCAL_RESOURCE_BUDGETS.requestBytes')
+    }
+  })
+})

--- a/src/main/resource-budget.ts
+++ b/src/main/resource-budget.ts
@@ -1,0 +1,87 @@
+import type { IncomingMessage } from 'node:http'
+
+const MIB = 1024 * 1024
+const GIB = 1024 * MIB
+
+const LOCAL_RESOURCE_BUDGETS = Object.freeze({
+  requestBytes: 64 * MIB,
+  artifactInlineBytes: 32 * MIB,
+  artifactFileBytes: 1 * GIB,
+  artifactTurnBytes: 2 * GIB,
+  artifactSessionBytes: 10 * GIB,
+  diskReserveBytes: 2 * GIB,
+  reviewerReadBytes: 256 * 1024,
+  reviewerSessionBytes: 2 * MIB
+})
+
+type LocalResourceBudgetOverrides = Partial<typeof LOCAL_RESOURCE_BUDGETS>
+
+type ResourceBudgetDimension =
+  'request' | 'file' | 'turn' | 'session' | 'disk-reserve' | 'reviewer-session'
+
+class ResourceBudgetExceededError extends Error {
+  readonly name = 'ResourceBudgetExceededError'
+
+  constructor(
+    readonly dimension: ResourceBudgetDimension,
+    readonly observedBytes: number,
+    readonly limitBytes: number
+  ) {
+    super(
+      `Local resource ${dimension} budget exceeded: ${observedBytes} bytes exceeds ${limitBytes} bytes.`
+    )
+  }
+}
+
+const assertWithinResourceBudget = (
+  dimension: ResourceBudgetDimension,
+  observedBytes: number,
+  limitBytes: number
+): void => {
+  if (!Number.isSafeInteger(observedBytes) || observedBytes < 0) {
+    throw new TypeError('Resource budget observations must be non-negative safe integers.')
+  }
+  if (!Number.isSafeInteger(limitBytes) || limitBytes < 0) {
+    throw new TypeError('Resource budget limits must be non-negative safe integers.')
+  }
+  if (observedBytes > limitBytes) {
+    throw new ResourceBudgetExceededError(dimension, observedBytes, limitBytes)
+  }
+}
+
+const declaredContentLength = (request: IncomingMessage): number | undefined => {
+  const value = request.headers['content-length']
+  if (typeof value !== 'string' || !/^\d+$/u.test(value)) return undefined
+  const length = Number(value)
+  return Number.isSafeInteger(length) ? length : undefined
+}
+
+const readBoundedJsonBody = async <Result = unknown>(
+  request: IncomingMessage,
+  maxBytes = LOCAL_RESOURCE_BUDGETS.requestBytes,
+  options?: { emptyValue: Result }
+): Promise<Result> => {
+  const declared = declaredContentLength(request)
+  if (declared !== undefined) assertWithinResourceBudget('request', declared, maxBytes)
+
+  const chunks: Buffer[] = []
+  let observedBytes = 0
+  for await (const chunk of request) {
+    const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : Buffer.from(chunk)
+    observedBytes += buffer.byteLength
+    assertWithinResourceBudget('request', observedBytes, maxBytes)
+    chunks.push(buffer)
+  }
+
+  if (chunks.length === 0 && options) return options.emptyValue
+  return JSON.parse(Buffer.concat(chunks, observedBytes).toString('utf8')) as Result
+}
+
+export {
+  LOCAL_RESOURCE_BUDGETS,
+  ResourceBudgetExceededError,
+  assertWithinResourceBudget,
+  readBoundedJsonBody
+}
+export type { ResourceBudgetDimension }
+export type { LocalResourceBudgetOverrides }

--- a/src/main/reviewer/host-sdk.test.ts
+++ b/src/main/reviewer/host-sdk.test.ts
@@ -8,11 +8,13 @@
 import { writeFile, mkdtemp, mkdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ReviewerHostServer, buildReviewerHostPythonBootstrap } from './host-sdk'
+import * as boundedFileIo from '../bounded-file-io'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import type { TurnScope } from '../../shared/reviewer'
+import { ResourceBudgetExceededError } from '../resource-budget'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -113,6 +115,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
+  vi.restoreAllMocks()
   await server?.stop().catch(() => undefined)
   await rm(tmpDir, { recursive: true, force: true })
 })
@@ -127,6 +130,27 @@ describe('host.read_turn — frozen evidence', () => {
 
     expect(server.readTurn()).toEqual(before)
     expect(server.readTurn()[0]).toMatchObject({ content: 'Run the analysis' })
+  })
+})
+
+describe('reviewer host request budget', () => {
+  it('returns 413 for an authenticated compatibility request above the limit', async () => {
+    server = new ReviewerHostServer(makeSession(), makeScope(), tmpDir, undefined, undefined, {
+      requestBytes: 2
+    })
+    ;({ endpoint, token } = await server.start())
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json'
+      },
+      body: '{} '
+    })
+
+    expect(response.status).toBe(413)
+    expect(response.headers.get('connection')).toBe('close')
   })
 })
 
@@ -177,6 +201,178 @@ describe('host.read_artifact — tabular CSV', () => {
     )
 
     await expect(server.readArtifact(nativeVersionId)).rejects.toThrow(/checksum mismatch/i)
+  })
+
+  it('verifies the whole Artifact once while returning bounded pages', async () => {
+    const nativeVersionId = 'native-version-truncated'
+    const nativePath = join(tmpDir, 'immutable-truncated', 'content')
+    await mkdir(join(tmpDir, 'immutable-truncated'), { recursive: true })
+    await writeFile(nativePath, 'abcdefghij')
+    const verify = vi.spyOn(boundedFileIo, 'readFilePageAndDigest')
+    server = new ReviewerHostServer(
+      makeSession({ artifacts: [] }),
+      makeScope([nativeVersionId]),
+      tmpDir,
+      async () => ({
+        path: nativePath,
+        filename: 'native.txt',
+        contentType: 'text/plain'
+      }),
+      undefined,
+      { readBytes: 4, sessionBytes: 320 }
+    )
+
+    await expect(server.readArtifact(nativeVersionId)).resolves.toMatchObject({
+      kind: 'raw',
+      content: 'abcd',
+      sizeBytes: 10,
+      returnedBytes: 4,
+      truncated: true
+    })
+    await expect(
+      server.readArtifact(nativeVersionId, { offset: 4, maxBytes: 2 })
+    ).resolves.toMatchObject({
+      content: 'ef',
+      offset: 4,
+      returnedBytes: 2,
+      truncated: true
+    })
+    expect(verify).toHaveBeenCalledTimes(1)
+    await expect(server.readArtifact(nativeVersionId)).rejects.toBeInstanceOf(
+      ResourceBudgetExceededError
+    )
+  })
+
+  it('paginates UTF-8 text on code-point boundaries without replacement characters', async () => {
+    const nativeVersionId = 'native-version-utf8'
+    const nativePath = join(tmpDir, 'immutable-utf8', 'content')
+    await mkdir(join(tmpDir, 'immutable-utf8'), { recursive: true })
+    await writeFile(nativePath, 'a你b')
+    server = new ReviewerHostServer(
+      makeSession({ artifacts: [] }),
+      makeScope([nativeVersionId]),
+      tmpDir,
+      async () => ({ path: nativePath, filename: 'native.txt', contentType: 'text/plain' }),
+      undefined,
+      { readBytes: 4, sessionBytes: 1_000 }
+    )
+
+    await expect(server.readArtifact(nativeVersionId, { maxBytes: 2 })).resolves.toMatchObject({
+      content: 'a',
+      offset: 0,
+      returnedBytes: 1,
+      nextOffset: 1,
+      truncated: true
+    })
+    await expect(server.readArtifact(nativeVersionId, { offset: 1 })).resolves.toMatchObject({
+      content: '你b',
+      offset: 1,
+      returnedBytes: 4,
+      truncated: false
+    })
+  })
+
+  it('falls back to advancing base64 pages when text-classified bytes are invalid UTF-8', async () => {
+    const nativeVersionId = 'native-version-invalid-utf8'
+    const nativePath = join(tmpDir, 'immutable-invalid-utf8', 'content')
+    const bytes = Buffer.from([0xff, 0xfe, 0x61])
+    await mkdir(join(tmpDir, 'immutable-invalid-utf8'), { recursive: true })
+    await writeFile(nativePath, bytes)
+    server = new ReviewerHostServer(
+      makeSession({ artifacts: [] }),
+      makeScope([nativeVersionId]),
+      tmpDir,
+      async () => ({ path: nativePath, filename: 'native.txt', contentType: 'text/plain' }),
+      undefined,
+      { readBytes: 2, sessionBytes: 1_000 }
+    )
+
+    const first = await server.readArtifact(nativeVersionId)
+    expect(first).toMatchObject({
+      kind: 'raw',
+      encoding: 'base64',
+      content: bytes.subarray(0, 2).toString('base64'),
+      offset: 0,
+      returnedBytes: 2,
+      nextOffset: 2,
+      truncated: true
+    })
+    await expect(
+      server.readArtifact(nativeVersionId, { offset: first.nextOffset })
+    ).resolves.toMatchObject({
+      kind: 'raw',
+      encoding: 'utf8',
+      content: 'a',
+      offset: 2,
+      returnedBytes: 1,
+      truncated: false
+    })
+  })
+
+  it('preserves invalid UTF-8 prefixes before valid text in the same page', async () => {
+    const nativeVersionId = 'native-version-invalid-utf8-prefix'
+    const nativePath = join(tmpDir, 'immutable-invalid-utf8-prefix', 'content')
+    const bytes = Buffer.from([0x80, 0x61, 0x62])
+    await mkdir(join(tmpDir, 'immutable-invalid-utf8-prefix'), { recursive: true })
+    await writeFile(nativePath, bytes)
+    server = new ReviewerHostServer(
+      makeSession({ artifacts: [] }),
+      makeScope([nativeVersionId]),
+      tmpDir,
+      async () => ({ path: nativePath, filename: 'native.txt', contentType: 'text/plain' }),
+      undefined,
+      { readBytes: 2, sessionBytes: 1_000 }
+    )
+
+    const first = await server.readArtifact(nativeVersionId)
+    expect(first).toMatchObject({
+      kind: 'raw',
+      encoding: 'base64',
+      content: bytes.subarray(0, 2).toString('base64'),
+      offset: 0,
+      returnedBytes: 2,
+      nextOffset: 2,
+      truncated: true
+    })
+    await expect(
+      server.readArtifact(nativeVersionId, { offset: first.nextOffset })
+    ).resolves.toMatchObject({
+      kind: 'raw',
+      encoding: 'utf8',
+      content: 'b',
+      offset: 2,
+      returnedBytes: 1,
+      truncated: false
+    })
+  })
+
+  it('returns paged CSV as reconstructable raw windows across quoted records', async () => {
+    const quote = String.fromCharCode(34)
+    const content = [
+      'name,value',
+      `alpha,${quote}one`,
+      `two${quote}`,
+      `beta,${quote}escaped ${quote}${quote}quote${quote}${quote}${quote}`,
+      ''
+    ].join('\n')
+    await writeArtifact(tmpDir, V1, content)
+    server = new ReviewerHostServer(makeSession(), makeScope(), tmpDir, undefined, undefined, {
+      readBytes: 8,
+      sessionBytes: 10_000
+    })
+
+    let offset = 0
+    let reconstructed = ''
+    for (;;) {
+      const page = await server.readArtifact(V1, { offset })
+      expect(page).toMatchObject({ kind: 'raw', encoding: 'utf8', offset })
+      if (page.kind !== 'raw') throw new Error('Expected a raw CSV byte window.')
+      reconstructed += page.content
+      if (!page.truncated) break
+      expect(page.nextOffset).toBeGreaterThan(offset)
+      offset = page.nextOffset!
+    }
+    expect(reconstructed).toBe(content)
   })
 
   it('returns kind=tabular with column-addressable structure for a simple CSV', async () => {

--- a/src/main/reviewer/host-sdk.ts
+++ b/src/main/reviewer/host-sdk.ts
@@ -4,14 +4,24 @@
 // longer receives its endpoint/token or executes a Python bootstrap.
 
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
-import { readFile } from 'node:fs/promises'
 import { extname, join } from 'node:path'
-import { createHash, randomUUID } from 'node:crypto'
+import { randomUUID } from 'node:crypto'
 
 import { getProjectArtifactDir } from '../artifacts/repository'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import type { ReviewScopeSnapshotBlock, TurnScope, ScopeBlock } from '../../shared/reviewer'
 import { buildReviewScopeSnapshot as buildPersistedScopeSnapshot } from './scope-snapshot'
+import {
+  readFilePageAndDigest,
+  readVerifiedFilePage,
+  type FileObservation
+} from '../bounded-file-io'
+import {
+  LOCAL_RESOURCE_BUDGETS,
+  ResourceBudgetExceededError,
+  assertWithinResourceBudget,
+  readBoundedJsonBody
+} from '../resource-budget'
 
 // One readable block as returned by host.read_turn().
 export type OrderedBlock = {
@@ -45,18 +55,30 @@ export type ExecRecord = {
   terminalExitCode?: number | null
 }
 
+// Every Artifact read is one bounded byte window. Fields stay optional in the exported contract so
+// older in-process consumers can deserialize pre-pagination results during a rolling app update.
+export type ArtifactContentWindow = {
+  sizeBytes?: number
+  offset?: number
+  returnedBytes?: number
+  truncated?: boolean
+  nextOffset?: number
+}
+
 // Column-addressable structure returned for tabular (CSV/TSV) artifacts so the reviewer can
 // match by column name instead of aligning rows visually.
-export type TabularArtifactContent = {
+export type TabularArtifactContent = ArtifactContentWindow & {
   id: string
   kind: 'tabular'
   // Each key is a column header; the array contains the string values of that column across all rows.
   columns: Record<string, string[]>
-  rowCount: number
+  rowCount: number | null
+  rowsReturned?: number
+  rowCountComplete?: boolean
 }
 
 // Raw content for non-tabular artifacts (text UTF-8 or base64-encoded binary).
-export type RawArtifactContent = {
+export type RawArtifactContent = ArtifactContentWindow & {
   id: string
   kind: 'raw'
   content: string
@@ -71,6 +93,33 @@ export type ArtifactVersionContentResolver = (request: {
   versionId: string
 }) => Promise<{ path: string; filename: string; contentType?: string; checksum?: string }>
 
+export type ReviewerResourceBudgetOptions = {
+  requestBytes?: number
+  readBytes?: number
+  sessionBytes?: number
+}
+
+export type ReviewerArtifactReadOptions = {
+  offset?: number
+  maxBytes?: number
+}
+
+type ArtifactVerification = {
+  path: string
+  checksum: string
+  sizeBytes: number
+  sample: Buffer
+  observation: FileObservation
+}
+
+type ArtifactVerificationEntry = {
+  path: string
+  expectedChecksum?: string
+  verification: Promise<ArtifactVerification>
+}
+
+class ArtifactVersionChecksumMismatchError extends Error {}
+
 // The complete set of RPC methods the host exposes. Single-sourced so the unknown-method error can
 // tell a guessing reviewer exactly what IS available (it likes to try e.g. `list_artifacts`).
 export const SUPPORTED_HOST_METHODS = ['read_turn', 'query_execution_log', 'read_artifact'] as const
@@ -79,6 +128,9 @@ export const SUPPORTED_HOST_METHODS = ['read_turn', 'query_execution_log', 'read
 export class ReviewerHostServer {
   private server: Server
   private readonly frozenScopeSnapshot: ReviewScopeSnapshotBlock[]
+  private readonly resourceBudget: Required<ReviewerResourceBudgetOptions>
+  private readonly artifactVerifications = new Map<string, ArtifactVerificationEntry>()
+  private reviewerBytesReturned = 0
   readonly token: string
   private _endpoint: string | undefined
 
@@ -87,13 +139,26 @@ export class ReviewerHostServer {
     private readonly scope: TurnScope,
     private readonly artifactStorageRoot: string,
     private readonly resolveArtifactVersion?: ArtifactVersionContentResolver,
-    frozenScopeSnapshot?: ReviewScopeSnapshotBlock[]
+    frozenScopeSnapshot?: ReviewScopeSnapshotBlock[],
+    resourceBudget: ReviewerResourceBudgetOptions = {}
   ) {
     this.frozenScopeSnapshot = frozenScopeSnapshot ?? buildPersistedScopeSnapshot(session, scope)
     this.token = randomUUID()
+    this.resourceBudget = {
+      requestBytes: resourceBudget.requestBytes ?? LOCAL_RESOURCE_BUDGETS.requestBytes,
+      readBytes: resourceBudget.readBytes ?? LOCAL_RESOURCE_BUDGETS.reviewerReadBytes,
+      sessionBytes: resourceBudget.sessionBytes ?? LOCAL_RESOURCE_BUDGETS.reviewerSessionBytes
+    }
     this.server = createServer((req, res) => {
       void this.handleRequest(req, res).catch((error) => {
-        res.writeHead(500, { 'content-type': 'application/json' })
+        if (error instanceof ResourceBudgetExceededError) {
+          res.shouldKeepAlive = false
+          res.setHeader('connection', 'close')
+          res.once('finish', () => req.destroy())
+        }
+        res.writeHead(error instanceof ResourceBudgetExceededError ? 413 : 500, {
+          'content-type': 'application/json'
+        })
         res.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }))
       })
     })
@@ -115,6 +180,7 @@ export class ReviewerHostServer {
   // Shuts down the server; called after the reviewer session disposes.
   async stop(): Promise<void> {
     await new Promise<void>((resolve) => this.server.close(() => resolve()))
+    this.artifactVerifications.clear()
   }
 
   get endpoint(): string {
@@ -134,12 +200,12 @@ export class ReviewerHostServer {
     }
 
     // Read body.
-    const body = await readBody(req)
     let parsed: { method?: string; params?: Record<string, unknown> }
 
     try {
-      parsed = JSON.parse(body) as typeof parsed
-    } catch {
+      parsed = await readBoundedJsonBody<typeof parsed>(req, this.resourceBudget.requestBytes)
+    } catch (error) {
+      if (error instanceof ResourceBudgetExceededError) throw error
       res.writeHead(400, { 'content-type': 'application/json' })
       res.end(JSON.stringify({ error: 'Invalid JSON body' }))
       return
@@ -158,7 +224,10 @@ export class ReviewerHostServer {
         result = this.queryExecutionLog(params.activityId as string | undefined)
         break
       case 'read_artifact':
-        result = await this.readArtifact(params.id as string)
+        result = await this.readArtifact(params.id as string, {
+          offset: params.offset as number | undefined,
+          maxBytes: params.maxBytes as number | undefined
+        })
         break
       default:
         res.writeHead(400, { 'content-type': 'application/json' })
@@ -217,7 +286,11 @@ export class ReviewerHostServer {
   // Tabular artifacts (CSV/TSV) are returned as { kind:'tabular'; columns; rowCount } so the
   // reviewer can address by column name without visual row alignment. Non-tabular artifacts
   // return { kind:'raw'; content; encoding }.
-  async readArtifact(id: string): Promise<ArtifactContent> {
+  async readArtifact(
+    id: string,
+    options: ReviewerArtifactReadOptions = {},
+    signal?: AbortSignal
+  ): Promise<ArtifactContent> {
     if (!this.scope.artifactVersionIds.includes(id)) {
       throw new Error(
         `Artifact id ${JSON.stringify(id)} is not in this turn's scope. ` +
@@ -238,51 +311,188 @@ export class ReviewerHostServer {
       resolvedVersion?.path ??
       resolveArtifactPath(this.artifactStorageRoot, this.session.projectId, id)
 
-    let bytes: Buffer
+    const offset = options.offset ?? 0
+    const requestedBytes = options.maxBytes ?? this.resourceBudget.readBytes
+    if (!Number.isSafeInteger(offset) || offset < 0) {
+      throw new Error('Reviewer Artifact offset must be a non-negative integer.')
+    }
+    if (!Number.isSafeInteger(requestedBytes) || requestedBytes <= 0) {
+      throw new Error('Reviewer Artifact maxBytes must be a positive integer.')
+    }
+    const remainingSessionBytes = this.resourceBudget.sessionBytes - this.reviewerBytesReturned
+    if (remainingSessionBytes <= 0) {
+      throw new ResourceBudgetExceededError(
+        'reviewer-session',
+        this.reviewerBytesReturned + 1,
+        this.resourceBudget.sessionBytes
+      )
+    }
+    const returnedLimit = Math.min(
+      requestedBytes,
+      this.resourceBudget.readBytes,
+      remainingSessionBytes
+    )
+    let verification: ArtifactVerification
     try {
-      bytes = await readFile(artifactPath)
+      verification = await this.verifyArtifact(id, artifactPath, resolvedVersion?.checksum, signal)
     } catch (error) {
+      if (error instanceof ArtifactVersionChecksumMismatchError) throw error
       throw new Error(
         `Failed to read artifact ${JSON.stringify(id)} at ${artifactPath}: ` +
           `${error instanceof Error ? error.message : String(error)}`
       )
     }
-    if (
-      resolvedVersion?.checksum &&
-      createHash('sha256').update(bytes).digest('hex') !== resolvedVersion.checksum
-    ) {
-      throw new Error(`Artifact Version checksum mismatch while reading ${JSON.stringify(id)}.`)
-    }
 
-    const isText = isLikelyText(bytes)
+    if (offset > verification.sizeBytes) {
+      throw new Error(
+        `Reviewer Artifact offset ${offset} exceeds file size ${verification.sizeBytes}.`
+      )
+    }
+    let page: Awaited<ReturnType<typeof readVerifiedFilePage>>
+    try {
+      page = await readVerifiedFilePage(
+        artifactPath,
+        offset,
+        returnedLimit,
+        verification.observation,
+        signal
+      )
+    } catch (error) {
+      this.artifactVerifications.delete(id)
+      throw new Error(
+        `Failed to read artifact ${JSON.stringify(id)} at ${artifactPath}: ` +
+          `${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+    const read = {
+      ...page,
+      sizeBytes: verification.sizeBytes,
+      sample: verification.sample
+    }
+    const isText = isLikelyText(read.sample)
+    let result: ArtifactContent
+    const base64Window = (): RawArtifactContent => {
+      const truncated = offset + read.returnedBytes < read.sizeBytes
+      return {
+        id,
+        kind: 'raw',
+        content: read.page.toString('base64'),
+        encoding: 'base64',
+        sizeBytes: read.sizeBytes,
+        offset,
+        returnedBytes: read.returnedBytes,
+        truncated,
+        ...(truncated ? { nextOffset: offset + read.returnedBytes } : {})
+      }
+    }
 
     if (isText) {
-      const text = bytes.toString('utf8')
+      const safePage = decodeUtf8Page(read.page, offset)
+      if (read.returnedBytes > 0 && (safePage.offset !== offset || safePage.returnedBytes === 0)) {
+        result = base64Window()
+      } else {
+        const text = safePage.content
+        const truncated = safePage.offset + safePage.returnedBytes < read.sizeBytes
+        const window = {
+          sizeBytes: read.sizeBytes,
+          offset: safePage.offset,
+          returnedBytes: safePage.returnedBytes,
+          truncated,
+          ...(truncated ? { nextOffset: safePage.offset + safePage.returnedBytes } : {})
+        }
 
-      // Determine if this artifact is a tabular format (CSV/TSV) by mimeType or path extension.
-      const contentType = resolvedVersion?.contentType ?? artifactMeta?.mimeType
-      const filename = resolvedVersion?.filename ?? artifactMeta?.path
-      if (isTabularArtifact(contentType, filename)) {
-        const parsed = parseTabular(text, detectDelimiter(contentType, filename))
-        return { id, kind: 'tabular', columns: parsed.columns, rowCount: parsed.rowCount }
+        // A byte page can split a quoted record, escaped quote, or header. Return incomplete tabular
+        // files as raw UTF-8 windows so following nextOffset reconstructs exact source bytes; only a
+        // complete table is safe to project into column-addressable data.
+        const contentType = resolvedVersion?.contentType ?? artifactMeta?.mimeType
+        const filename = resolvedVersion?.filename ?? artifactMeta?.path
+        if (isTabularArtifact(contentType, filename) && window.offset === 0 && !window.truncated) {
+          const parsed = parseTabular(text, detectDelimiter(contentType, filename))
+          result = {
+            id,
+            kind: 'tabular',
+            columns: parsed.columns,
+            rowCount: parsed.rowCount,
+            rowsReturned: parsed.rowCount,
+            rowCountComplete: true,
+            ...window
+          }
+        } else {
+          result = { id, kind: 'raw', content: text, encoding: 'utf8', ...window }
+        }
       }
-
-      return { id, kind: 'raw', content: text, encoding: 'utf8' }
+    } else {
+      result = base64Window()
     }
 
-    return { id, kind: 'raw', content: bytes.toString('base64'), encoding: 'base64' }
+    const responseBytes = Buffer.byteLength(JSON.stringify(result), 'utf8')
+    assertWithinResourceBudget(
+      'reviewer-session',
+      this.reviewerBytesReturned + responseBytes,
+      this.resourceBudget.sessionBytes
+    )
+    this.reviewerBytesReturned += responseBytes
+    return result
+  }
+
+  private async verifyArtifact(
+    id: string,
+    path: string,
+    expectedChecksum: string | undefined,
+    signal: AbortSignal | undefined
+  ): Promise<ArtifactVerification> {
+    const cached = this.artifactVerifications.get(id)
+    if (cached?.path === path && cached.expectedChecksum === expectedChecksum) {
+      return cached.verification
+    }
+
+    const verification = readFilePageAndDigest(path, 0, 0, signal).then((read) => {
+      if (expectedChecksum && read.checksum !== expectedChecksum) {
+        throw new ArtifactVersionChecksumMismatchError(
+          `Artifact Version checksum mismatch while reading ${JSON.stringify(id)}.`
+        )
+      }
+      return {
+        path,
+        checksum: read.checksum,
+        sizeBytes: read.sizeBytes,
+        sample: read.sample,
+        observation: read.observation
+      }
+    })
+    const entry = { path, expectedChecksum, verification }
+    this.artifactVerifications.set(id, entry)
+    try {
+      return await verification
+    } catch (error) {
+      if (this.artifactVerifications.get(id) === entry) this.artifactVerifications.delete(id)
+      throw error
+    }
   }
 }
 
-// Reads the full HTTP request body as a string.
-const readBody = (req: IncomingMessage): Promise<string> =>
-  new Promise((resolve, reject) => {
-    const chunks: Buffer[] = []
-
-    req.on('data', (chunk: Buffer) => chunks.push(chunk))
-    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
-    req.on('error', reject)
-  })
+const decodeUtf8Page = (
+  page: Buffer,
+  requestedOffset: number
+): { content: string; offset: number; returnedBytes: number } => {
+  let start = 0
+  while (start < page.length && (page[start]! & 0xc0) === 0x80) start += 1
+  let end = page.length
+  const decoder = new TextDecoder('utf-8', { fatal: true })
+  while (end >= start) {
+    try {
+      const bytes = page.subarray(start, end)
+      return {
+        content: decoder.decode(bytes),
+        offset: requestedOffset + start,
+        returnedBytes: bytes.byteLength
+      }
+    } catch {
+      end -= 1
+    }
+  }
+  return { content: '', offset: requestedOffset + page.length, returnedBytes: 0 }
+}
 
 // Heuristic to distinguish text from binary artifact content.
 const isLikelyText = (bytes: Buffer): boolean => {

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -81,7 +81,10 @@ type ReviewerIpcOptions = {
   storageRoot?: string
   // Optional override for the data root (artifacts) (for testing).
   dataRoot?: string
-  artifactProvenanceRepository?: Pick<ArtifactProvenanceRepository, 'resolveVersionContent'>
+  artifactProvenanceRepository?: Pick<
+    ArtifactProvenanceRepository,
+    'resolveVersionContent' | 'resolveVersionContentForStreamingVerification'
+  >
   withSessionMutation?: <Result>(
     projectId: string,
     sessionId: string,
@@ -340,7 +343,7 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
         // Artifacts live under the relocatable data root; DB/sessions stay on the config root.
         artifactStorageRoot: dataRoot,
         artifactVersionContentResolver: (request) =>
-          artifactProvenanceRepository.resolveVersionContent(request),
+          artifactProvenanceRepository.resolveVersionContentForStreamingVerification(request),
         reviewerMcpEntryPath: options.mcpEntryPath,
         onStarted: () => settle({ started: true }),
         onReviewUpdate: (review: ReviewWithChecks) => {

--- a/src/main/reviewer/mcp-server.test.ts
+++ b/src/main/reviewer/mcp-server.test.ts
@@ -7,6 +7,7 @@
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { request as httpRequest } from 'node:http'
 import { describe, it, expect, vi } from 'vitest'
 
 import {
@@ -520,6 +521,65 @@ describe('ReviewerMcpServer HTTP transport', () => {
     }
   }
 
+  it('bounds declared and chunked HTTP bodies while accepting the exact request limit', async () => {
+    const evidence = createReviewerEvidence()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const initializeBody = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'budget-test', version: '1.0' }
+      }
+    })
+    const server = new ReviewerMcpServer(scope, onSubmit, evidence, [], {
+      requestBytes: Buffer.byteLength(initializeBody)
+    })
+    const { endpoint, token } = await server.start()
+    const headers = {
+      authorization: `Bearer ${token}`,
+      accept: MCP_ACCEPT,
+      'content-type': 'application/json'
+    }
+
+    try {
+      const declared = await fetch(endpoint, {
+        method: 'POST',
+        headers,
+        body: `${initializeBody} `
+      })
+      expect(declared.status).toBe(413)
+      expect(declared.headers.get('connection')).toBe('close')
+
+      const chunked = await new Promise<{
+        status: number | undefined
+        connection: string | undefined
+      }>((resolve, reject) => {
+        const request = httpRequest(endpoint, { method: 'POST', headers }, (response) => {
+          response.resume()
+          response.once('end', () =>
+            resolve({ status: response.statusCode, connection: response.headers.connection })
+          )
+        })
+        request.once('error', reject)
+        request.write(initializeBody)
+        request.end(' ')
+      })
+      expect(chunked).toEqual({ status: 413, connection: 'close' })
+      expect(evidence.readTurn).not.toHaveBeenCalled()
+      expect(onSubmit).not.toHaveBeenCalled()
+
+      const exact = await fetch(endpoint, { method: 'POST', headers, body: initializeBody })
+      expect(exact.status).toBe(200)
+      expect(exact.headers.get('mcp-session-id')).toBeTruthy()
+      await exact.text()
+    } finally {
+      await server.stop()
+    }
+  })
+
   it('reuses the session transport for the GET SSE stream and still serves tool calls', async () => {
     const server = new ReviewerMcpServer(scope, async () => undefined, createReviewerEvidence())
     const { endpoint, token } = await server.start()
@@ -667,7 +727,11 @@ describe('ReviewerMcpServer HTTP transport', () => {
         expect.objectContaining({ id: 'artifact-csv', kind: 'tabular', rowCount: 1 })
       )
       expect(evidence.queryExecutionLog).toHaveBeenCalledWith('act-9')
-      expect(evidence.readArtifact).toHaveBeenCalledWith('artifact-csv')
+      expect(evidence.readArtifact).toHaveBeenCalledWith(
+        'artifact-csv',
+        { offset: undefined, maxBytes: undefined },
+        expect.any(AbortSignal)
+      )
       expect(submitted.result?.isError).not.toBe(true)
       expect(onSubmit).toHaveBeenCalledOnce()
     } finally {

--- a/src/main/reviewer/mcp-server.ts
+++ b/src/main/reviewer/mcp-server.ts
@@ -25,6 +25,11 @@ import {
 import { assertBlockInScope, type ReviewerHostServer } from './host-sdk'
 import { createLogger } from '../logger'
 import { listenForLocalRpc, localRpcServerLogFields } from '../local-rpc-transport'
+import {
+  LOCAL_RESOURCE_BUDGETS,
+  ResourceBudgetExceededError,
+  readBoundedJsonBody
+} from '../resource-budget'
 import { createReviewerMcpStdioProxyConfig } from './mcp-stdio-proxy'
 
 const log = createLogger('reviewer:mcp')
@@ -155,6 +160,7 @@ type ReviewerMcpServerOptions = {
   command?: string
   entryPath?: string
   transport?: 'tcp' | 'pipe'
+  requestBytes?: number
 }
 
 // Maps model-submitted checks onto the turn scope, enforcing the single-sourcing contract
@@ -368,13 +374,25 @@ export class ReviewerMcpServer {
         {
           title: 'Read audited artifact',
           description:
-            'Read one artifact attached to the audited turn. CSV/TSV data is returned by column; ' +
-            'an out-of-scope artifact id is rejected.',
-          inputSchema: { id: z.string().min(1).describe('In-scope artifact version id') }
+            'Read one artifact attached to the audited turn. Complete CSV/TSV data is returned by ' +
+            'column; paged CSV/TSV is returned as raw UTF-8 byte windows so record and quoting ' +
+            'semantics are not corrupted. When truncated is true, continue from nextOffset while ' +
+            'the review budget remains and report that the evidence was partial. An out-of-scope ' +
+            'artifact id is rejected.',
+          inputSchema: {
+            id: z.string().min(1).describe('In-scope artifact version id'),
+            offset: z.number().int().min(0).optional().describe('Byte offset for a bounded page'),
+            maxBytes: z
+              .number()
+              .int()
+              .positive()
+              .optional()
+              .describe('Requested source bytes; the host clamps this to its page limit')
+          }
         },
-        async ({ id }) => {
+        async ({ id, offset, maxBytes }, extra) => {
           try {
-            const artifact = await evidence.readArtifact(id)
+            const artifact = await evidence.readArtifact(id, { offset, maxBytes }, extra.signal)
             this.evidenceAccess.artifactVersionIds.add(id)
             return {
               content: [{ type: 'text', text: JSON.stringify(artifact) }]
@@ -535,6 +553,27 @@ export class ReviewerMcpServer {
       return
     }
 
+    let parsedBody: unknown
+    if (req.method === 'POST') {
+      try {
+        parsedBody = await readBoundedJsonBody(
+          req,
+          this.options.requestBytes ?? LOCAL_RESOURCE_BUDGETS.requestBytes,
+          { emptyValue: undefined }
+        )
+      } catch (error) {
+        const exceeded = error instanceof ResourceBudgetExceededError
+        if (exceeded) {
+          res.shouldKeepAlive = false
+          res.setHeader('connection', 'close')
+          res.once('finish', () => req.destroy())
+        }
+        res.writeHead(exceeded ? 413 : 400, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }))
+        return
+      }
+    }
+
     const sessionId = req.headers['mcp-session-id'] as string | undefined
 
     let transport: StreamableHTTPServerTransport
@@ -564,6 +603,6 @@ export class ReviewerMcpServer {
       return
     }
 
-    await transport.handleRequest(req, res)
+    await transport.handleRequest(req, res, parsedBody)
   }
 }

--- a/src/main/reviewer/mcp-stdio-proxy.ts
+++ b/src/main/reviewer/mcp-stdio-proxy.ts
@@ -8,6 +8,7 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprot
 import { REVIEWER_MCP_SERVER_NAME } from '../../shared/reviewer'
 import { fetchOverSocket } from '../local-rpc-transport'
 import { REVIEWER_MCP_PROXY_ARG } from '../mcp-server-args'
+import { LOCAL_RESOURCE_BUDGETS } from '../resource-budget'
 
 type ReviewerMcpProxyEnvironment = {
   socketPath: string
@@ -80,7 +81,11 @@ const runReviewerMcpStdioProxy = async (
   environment = createReviewerMcpProxyEnvironmentFromProcess()
 ): Promise<void> => {
   const downstream = await createReviewerMcpStdioProxy(environment)
-  await downstream.connect(new StdioServerTransport())
+  await downstream.connect(
+    new StdioServerTransport(process.stdin, process.stdout, {
+      maxBufferSize: LOCAL_RESOURCE_BUDGETS.requestBytes
+    })
+  )
 }
 
 export {

--- a/src/main/session-plan/plan-mcp-server.ts
+++ b/src/main/session-plan/plan-mcp-server.ts
@@ -12,6 +12,7 @@ import {
   type PlanCommandErrorCode
 } from '../../shared/session-plan/contract'
 import type { SessionPlanStepStatus } from '../../shared/session-persistence'
+import { LOCAL_RESOURCE_BUDGETS } from '../resource-budget'
 import {
   fetchLocalRpc,
   fetchLongLivedLocalRpc,
@@ -291,7 +292,11 @@ const runPlanMcpServer = async (): Promise<void> => {
     projectId: requireEnvironment('OPEN_SCIENCE_PLAN_PROJECT_ID'),
     sessionId: requireEnvironment('OPEN_SCIENCE_PLAN_SESSION_ID')
   })
-  await server.connect(new StdioServerTransport())
+  await server.connect(
+    new StdioServerTransport(process.stdin, process.stdout, {
+      maxBufferSize: LOCAL_RESOURCE_BUDGETS.requestBytes
+    })
+  )
 }
 
 export {

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -631,6 +631,8 @@ describe('Settings backend ownership architecture', () => {
 
   it('locks the complete Notebook local-RPC capability inventory', () => {
     expect(stringSetValues(settingsPaths.notebookLocalRpcServer, 'ARTIFACT_RPC_METHODS')).toEqual([
+      'artifactReserveWrite',
+      'artifactReleaseWrite',
       'artifactCreateVersion',
       'artifactReplayVersion'
     ])

--- a/src/main/skills/mcp-server.ts
+++ b/src/main/skills/mcp-server.ts
@@ -11,6 +11,7 @@ import {
 } from '../../shared/skill-import'
 import { SKILL_IMPORT_MCP_SERVER_ARG } from '../mcp-server-args'
 import { fetchLocalRpc, type LocalRpcTransport } from '../local-rpc-transport'
+import { LOCAL_RESOURCE_BUDGETS } from '../resource-budget'
 import { parseGitHubSkillUrl } from './github-import'
 
 const requestSkillImportToolSchema = {
@@ -192,7 +193,11 @@ const runSkillImportMcpServer = async (
       callSkillImportRpc(environment, attachmentUri, turnToken),
     requestGitHubImport: (githubUrl) => callGitHubSkillImportRpc(environment, githubUrl)
   })
-  await server.connect(new StdioServerTransport())
+  await server.connect(
+    new StdioServerTransport(process.stdin, process.stdout, {
+      maxBufferSize: LOCAL_RESOURCE_BUDGETS.requestBytes
+    })
+  )
 }
 
 export {

--- a/src/shared/artifact-provenance.ts
+++ b/src/shared/artifact-provenance.ts
@@ -42,6 +42,33 @@ export type CreateArtifactVersionRequest = {
   filename: string
   contentType?: string
   titleSnapshot?: string
+  resourceReservationId?: string
+  resourceSizeBytes?: number
+  resourceChecksum?: string
+}
+
+export type ReserveArtifactWriteRequest = {
+  projectId: string
+  appSessionId: string
+  artifactStorageSessionId: string
+  artifactRunId: string
+  writeOperationId: string
+  filename: string
+  fileBytes: number
+}
+
+export type ArtifactWriteReservation = {
+  id: string
+  fileBytes: number
+  expiresAt: number
+}
+
+export type ReleaseArtifactWriteReservationRequest = {
+  projectId: string
+  appSessionId: string
+  artifactStorageSessionId: string
+  artifactRunId: string
+  reservationId: string
 }
 
 export type ReplayArtifactVersionRequest = {
@@ -55,7 +82,11 @@ export type ReplayArtifactVersionRequest = {
   producerRunId?: string
 }
 
-export type ArtifactRpcMethod = 'artifactCreateVersion' | 'artifactReplayVersion'
+export type ArtifactRpcMethod =
+  | 'artifactReserveWrite'
+  | 'artifactReleaseWrite'
+  | 'artifactCreateVersion'
+  | 'artifactReplayVersion'
 
 // App-issued capability scope for one active assistant turn. These fields are runtime-owned and
 // must match every durable Artifact RPC call; the model and MCP process cannot widen the scope.


### PR DESCRIPTION
## Problem

Authenticated local MCP HTTP, Notebook RPC, Artifact ingestion, and Reviewer reads could buffer or copy attacker-controlled payloads without one application-level resource policy. Oversized or concurrent workloads could exhaust main-process memory, consume disk headroom, leave partial staging files, or make Reviewer load a complete large Artifact merely to return a preview.

This is reachable when a local authenticated client sends a declared or chunked oversized JSON body, writes large inline/local Artifact content, performs concurrent writes that share free disk, accumulates output across a turn or Session, or asks Reviewer to inspect a large Version.

## Proposed change

- Define one local resource policy: 64 MiB request, 32 MiB inline Artifact, 1 GiB file, 2 GiB turn, 10 GiB Session, 2 GiB disk reserve, 256 KiB Reviewer page, and 2 MiB cumulative Reviewer return budget.
- Bound authenticated HTTP/RPC and stdio MCP inputs. HTTP rejects both declared and streaming overflow with 413 and closes unread connections.
- Add a main-process Artifact write-budget owner with serialized reserve/release admission, physical-copy amplification, disk reserve checks, TTL cleanup, capability revocation cleanup, and shutdown cleanup.
- Stream local/inline writes, staging copies, SHA-256 calculation, publication routing, and Reviewer reads with cancellation and partial-output cleanup. Local imports pin one FileHandle across preflight stat, copying, and post-copy stat.
- Return bounded Reviewer pages with `offset`, `returnedBytes`, `truncated`, and `nextOffset`; hash the full source while retaining only the requested window. Complete tables retain structured projection; partial CSV/TSV pages return reconstructable raw UTF-8 windows.
- Count existing Version bytes plus unversioned compatibility files toward turn/Session admission. Marked legacy handoffs use their logical Session owner; markerless legacy layouts retain the current storage-Session fallback.

```mermaid
flowchart LR
  Client -->|bounded request| LocalTransport
  LocalTransport -->|reserve| BudgetOwner
  BudgetOwner -->|admit with turn, Session, disk checks| StreamedWrite
  StreamedWrite -->|commit or release| ArtifactVersion
  ArtifactVersion -->|bounded page plus full digest| Reviewer
```

### Compatibility

- Existing persisted Artifact/Version records require no migration.
- Existing Sessions above the new cumulative limits remain readable; the limits apply to new writes.
- Historical unversioned files participate in compatibility scanning without rewriting them.
- Reviewer paging/truncation fields are optional/nullable additions. Existing callers that omit `offset` and `maxBytes` retain first-page behavior.
- In-flight legacy Artifact creation cannot bypass the new native reservation contract; capability cleanup releases orphaned in-memory reservations.

### State, schema, and persistence

- No Prisma/schema migration, durable enum value, or new persisted status is added.
- The only new state is process-local reservation and Reviewer cumulative-budget state; it is bounded, TTL-managed, revoked with capabilities, and cleared on shutdown.
- An internal resource-budget dimension union and optional Reviewer wire metadata are added; no user-visible workflow enum or renderer interaction state changes.
- Existing persisted Version rows and publication markers are read for accounting, but their data model is unchanged.

### Interaction and API changes

- Oversized local HTTP/RPC requests now fail with HTTP 413 instead of being fully buffered.
- Internal Artifact RPC adds reserve/release calls and requires reservation identity, size, and checksum for Version creation.
- Reviewer supports page continuation and explicitly reports truncation. There is no new renderer UI or setting.

## Scope and non-goals

- No configurable budget UI, per-project overrides, upload/cloud transport policy, Artifact format redesign, database migration, or historical backfill.
- No full local `npm test` run, per the requested workflow; exact-head PR CI remains authoritative for the complete portable and platform suites.
- No related issue.

## Acceptance criteria and validation

All listed checks ran after the last material edit and after rebasing onto `origin/main`.

- Local request limits, Artifact reservation lifecycle, streaming/cleanup, historical accounting, Reviewer paging, and affected consumers -> `npm exec -- vitest run` with the 15 impacted test files -> **15 files passed; 312 passed, 1 skipped**.
- Main-process and shared TypeScript contracts -> `npm run typecheck:node` -> **passed**.
- All changed TypeScript files -> `npm exec -- eslint <base-to-head changed TS files>` -> **passed**.
- Rebase conflict integration -> `npm exec -- vitest run src/main/notebook/local-rpc-server.test.ts` -> **50 passed**.
- Patch hygiene -> `git diff --check origin/main...HEAD` -> **passed**.

The impact set includes the owner modules, changed RPC/MCP adapters, capability consumers, provenance/publication contracts, and Reviewer consumers. Renderer/E2E lanes are excluded locally because no renderer interaction or UI contract changed. Cross-platform filesystem and complete portable-suite behavior remain the primary uncovered local risk and are delegated to exact-head PR CI.

Independent Standards and Spec reviews found no remaining P0, P1, or P2 findings after the final FileHandle ownership and path-swap coverage was added.

## Review focus

- Reservation accounting under concurrent writes, physical-copy amplification, TTL/revoke/shutdown cleanup, and legacy Session ownership.
- Request rejection before dispatch across HTTP, RPC, and stdio adapters.
- Pinned-handle copy semantics, abort behavior, and cleanup of temporary outputs.
- Reviewer byte-window semantics, UTF-8 boundaries, CSV/TSV partial behavior, and cumulative serialized-response charging.
