### PR TITLE
feat(host-llm)!: return camelCase result fields

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -1104,8 +1104,8 @@ const validatedHostLlmUsage = (value) => {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     throw new Error('host.llm returned invalid usage')
   }
-  const required = ['input_tokens', 'cache_tokens', 'output_tokens']
-  const optional = ['cached_read_tokens', 'cached_write_tokens', 'turn_count']
+  const required = ['inputTokens', 'cacheTokens', 'outputTokens']
+  const optional = ['cachedReadTokens', 'cachedWriteTokens', 'turnCount']
   const keys = Object.keys(value)
   if (
     required.some((key) => !keys.includes(key)) ||
@@ -1115,7 +1115,7 @@ const validatedHostLlmUsage = (value) => {
         value[key] !== undefined &&
         (typeof value[key] !== 'number' || !Number.isSafeInteger(value[key]) || value[key] < 0)
     ) ||
-    (value.turn_count !== undefined && value.turn_count < 1)
+    (value.turnCount !== undefined && value.turnCount < 1)
   ) {
     throw new Error('host.llm returned invalid usage')
   }
@@ -1128,18 +1128,18 @@ const validatedHostLlmResult = (value) => {
   }
   const keys = Object.keys(value)
   if (
-    !['text', 'model', 'stop_reason'].every((key) => keys.includes(key)) ||
-    keys.some((key) => !['text', 'model', 'stop_reason', 'usage'].includes(key)) ||
+    !['text', 'model', 'stopReason'].every((key) => keys.includes(key)) ||
+    keys.some((key) => !['text', 'model', 'stopReason', 'usage'].includes(key)) ||
     typeof value.text !== 'string' ||
     typeof value.model !== 'string' ||
-    !HOST_LLM_STOP_REASONS.has(value.stop_reason)
+    !HOST_LLM_STOP_REASONS.has(value.stopReason)
   ) {
     throw new Error('host.llm returned an invalid result')
   }
   return Object.freeze({
     text: value.text,
     model: value.model,
-    stop_reason: value.stop_reason,
+    stopReason: value.stopReason,
     ...(value.usage === undefined ? {} : { usage: validatedHostLlmUsage(value.usage) })
   })
 }

--- a/src/main/notebook/host-llm-service.test.ts
+++ b/src/main/notebook/host-llm-service.test.ts
@@ -91,14 +91,14 @@ describe('HostLlmService', () => {
     expect(first).toEqual({
       text: 'answer:one',
       model: 'model-a',
-      stop_reason: 'end_turn',
+      stopReason: 'end_turn',
       usage: {
-        input_tokens: 10,
-        cache_tokens: 3,
-        output_tokens: 4,
-        cached_read_tokens: 2,
-        cached_write_tokens: 1,
-        turn_count: 1
+        inputTokens: 10,
+        cacheTokens: 3,
+        outputTokens: 4,
+        cachedReadTokens: 2,
+        cachedWriteTokens: 1,
+        turnCount: 1
       }
     })
     expect(second).toMatchObject({ text: 'answer:two' })
@@ -129,8 +129,8 @@ describe('HostLlmService', () => {
         options: { max_concurrency: 2 }
       })
     ).resolves.toEqual([
-      { text: 'SLOW', model: 'model-a', stop_reason: 'end_turn' },
-      { text: 'FAST', model: 'model-a', stop_reason: 'end_turn' },
+      { text: 'SLOW', model: 'model-a', stopReason: 'end_turn' },
+      { text: 'FAST', model: 'model-a', stopReason: 'end_turn' },
       { error: 'host.llm requests must be a prompt string or an exact { prompt } object.' },
       { error: 'host.llm stopped because the selected agent attempted to use a tool.' }
     ])

--- a/src/main/notebook/host-llm-service.ts
+++ b/src/main/notebook/host-llm-service.ts
@@ -21,18 +21,18 @@ const HOST_LLM_SYSTEM_PROMPT = [
 type HostLlmRequest = string | Readonly<{ prompt: string }>
 
 type HostLlmUsage = Readonly<{
-  input_tokens: number
-  cache_tokens: number
-  output_tokens: number
-  cached_read_tokens?: number
-  cached_write_tokens?: number
-  turn_count?: number
+  inputTokens: number
+  cacheTokens: number
+  outputTokens: number
+  cachedReadTokens?: number
+  cachedWriteTokens?: number
+  turnCount?: number
 }>
 
 type HostLlmResult = Readonly<{
   text: string
   model: string
-  stop_reason: RestrictedInferenceResult['stopReason']
+  stopReason: RestrictedInferenceResult['stopReason']
   usage?: HostLlmUsage
 }>
 
@@ -125,22 +125,22 @@ const publicError = (error: unknown): string => {
 const projectResult = (result: RestrictedInferenceResult): HostLlmResult => {
   const usage = result.usage
     ? Object.freeze({
-        input_tokens: result.usage.inputTokens,
-        cache_tokens: result.usage.cacheTokens,
-        output_tokens: result.usage.outputTokens,
+        inputTokens: result.usage.inputTokens,
+        cacheTokens: result.usage.cacheTokens,
+        outputTokens: result.usage.outputTokens,
         ...(result.usage.cachedReadTokens === undefined
           ? {}
-          : { cached_read_tokens: result.usage.cachedReadTokens }),
+          : { cachedReadTokens: result.usage.cachedReadTokens }),
         ...(result.usage.cachedWriteTokens === undefined
           ? {}
-          : { cached_write_tokens: result.usage.cachedWriteTokens }),
-        ...(result.usage.turnCount === undefined ? {} : { turn_count: result.usage.turnCount })
+          : { cachedWriteTokens: result.usage.cachedWriteTokens }),
+        ...(result.usage.turnCount === undefined ? {} : { turnCount: result.usage.turnCount })
       })
     : undefined
   return Object.freeze({
     text: result.text,
     model: result.model,
-    stop_reason: result.stopReason,
+    stopReason: result.stopReason,
     ...(usage ? { usage } : {})
   })
 }

--- a/src/main/notebook/local-rpc-server.llm.test.ts
+++ b/src/main/notebook/local-rpc-server.llm.test.ts
@@ -27,7 +27,7 @@ describe('llmCall RPC', () => {
   it('routes only through a control capability and strips trusted identity fields', async () => {
     const hostLlmCall = vi.fn<
       (input: HostLlmCallInput, signal?: AbortSignal) => Promise<HostLlmResult>
-    >(async () => ({ text: 'PONG', model: 'model-a', stop_reason: 'end_turn' }))
+    >(async () => ({ text: 'PONG', model: 'model-a', stopReason: 'end_turn' }))
     const hostLlm = {
       isAvailable: vi.fn(async () => true),
       call: hostLlmCall
@@ -50,7 +50,7 @@ describe('llmCall RPC', () => {
 
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({
-      result: { text: 'PONG', model: 'model-a', stop_reason: 'end_turn' }
+      result: { text: 'PONG', model: 'model-a', stopReason: 'end_turn' }
     })
     expect(hostLlmCall).toHaveBeenCalledOnce()
     expect(hostLlmCall.mock.calls[0]?.[0]).toEqual({ request: 'PING' })

--- a/src/main/notebook/repl-loop.integration.test.ts
+++ b/src/main/notebook/repl-loop.integration.test.ts
@@ -1542,30 +1542,39 @@ describe('repl_loop local RPC transport', () => {
                   }
                 : index === 1
                   ? { error: 'provider unavailable' }
-                  : { text: 'A', model: 'model-a', stop_reason: 'end_turn' }
+                  : { text: 'A', model: 'model-a', stopReason: 'end_turn' }
             )
           : parsed.params?.request === 'INVALID_RESULT'
-            ? { text: 'leak', model: 'model-a', stop_reason: 'end_turn', raw: 'private' }
-            : parsed.params?.request === 'INVALID_USAGE'
-              ? {
-                  text: 'leak',
-                  model: 'model-a',
-                  stop_reason: 'end_turn',
-                  usage: { input_tokens: 1, output_tokens: 1 }
-                }
-              : {
-                  text: 'PONG',
-                  model: 'model-a',
-                  stop_reason: 'end_turn',
-                  usage: {
-                    input_tokens: 10,
-                    cache_tokens: 3,
-                    output_tokens: 4,
-                    cached_read_tokens: 2,
-                    cached_write_tokens: 1,
-                    turn_count: 1
+            ? { text: 'leak', model: 'model-a', stopReason: 'end_turn', raw: 'private' }
+            : parsed.params?.request === 'LEGACY_RESULT'
+              ? { text: 'legacy', model: 'model-a', stop_reason: 'end_turn' }
+              : parsed.params?.request === 'LEGACY_USAGE'
+                ? {
+                    text: 'legacy',
+                    model: 'model-a',
+                    stopReason: 'end_turn',
+                    usage: { input_tokens: 1, cache_tokens: 0, output_tokens: 1 }
                   }
-                }
+                : parsed.params?.request === 'INVALID_USAGE'
+                  ? {
+                      text: 'leak',
+                      model: 'model-a',
+                      stopReason: 'end_turn',
+                      usage: { inputTokens: 1, outputTokens: 1 }
+                    }
+                  : {
+                      text: 'PONG',
+                      model: 'model-a',
+                      stopReason: 'end_turn',
+                      usage: {
+                        inputTokens: 10,
+                        cacheTokens: 3,
+                        outputTokens: 4,
+                        cachedReadTokens: 2,
+                        cachedWriteTokens: 1,
+                        turnCount: 1
+                      }
+                    }
         response
           .writeHead(200, { 'content-type': 'application/json' })
           .end(JSON.stringify({ result }))
@@ -1591,14 +1600,14 @@ describe('repl_loop local RPC transport', () => {
         value: {
           text: 'PONG',
           model: 'model-a',
-          stop_reason: 'end_turn',
+          stopReason: 'end_turn',
           usage: {
-            input_tokens: 10,
-            cache_tokens: 3,
-            output_tokens: 4,
-            cached_read_tokens: 2,
-            cached_write_tokens: 1,
-            turn_count: 1
+            inputTokens: 10,
+            cacheTokens: 3,
+            outputTokens: 4,
+            cachedReadTokens: 2,
+            cachedWriteTokens: 1,
+            turnCount: 1
           }
         },
         frozen: true,
@@ -1612,7 +1621,7 @@ describe('repl_loop local RPC transport', () => {
       expect(batch.error).toBeNull()
       expect(JSON.parse(batch.result ?? '{}')).toEqual({
         value: [
-          { text: 'A', model: 'model-a', stop_reason: 'end_turn' },
+          { text: 'A', model: 'model-a', stopReason: 'end_turn' },
           { error: 'provider unavailable' }
         ],
         frozen: true,
@@ -1668,7 +1677,7 @@ describe('repl_loop local RPC transport', () => {
       )
       expect(isolatedInvalidItems.error).toBeNull()
       expect(JSON.parse(isolatedInvalidItems.result ?? '[]')).toEqual([
-        { text: 'A', model: 'model-a', stop_reason: 'end_turn' },
+        { text: 'A', model: 'model-a', stopReason: 'end_turn' },
         { error: 'host.llm requests must be a prompt string or an exact { prompt } object.' },
         { error: 'host.llm requests must be a prompt string or an exact { prompt } object.' }
       ])
@@ -1683,7 +1692,7 @@ describe('repl_loop local RPC transport', () => {
       )
       expect(snapshottedAccessor.error).toBeNull()
       expect(JSON.parse(snapshottedAccessor.result ?? '{}')).toEqual({
-        value: [{ text: 'A', model: 'model-a', stop_reason: 'end_turn' }],
+        value: [{ text: 'A', model: 'model-a', stopReason: 'end_turn' }],
         reads: 1
       })
       expect(requests.at(-1)).toEqual({
@@ -1712,6 +1721,18 @@ describe('repl_loop local RPC transport', () => {
           'catch (error) { return error.message }'
       )
       expect(invalidUsage.result).toBe('host.llm returned invalid usage')
+
+      const legacyResult = await send(
+        "try { await host.llm('LEGACY_RESULT'); return 'no error' } " +
+          'catch (error) { return error.message }'
+      )
+      expect(legacyResult.result).toBe('host.llm returned an invalid result')
+
+      const legacyUsage = await send(
+        "try { await host.llm('LEGACY_USAGE'); return 'no error' } " +
+          'catch (error) { return error.message }'
+      )
+      expect(legacyUsage.result).toBe('host.llm returned invalid usage')
     } finally {
       child.kill()
       await new Promise<void>((resolve, reject) =>


### PR DESCRIPTION
## Problem

The JavaScript `host.llm()` API returned snake_case fields such as `stop_reason` and `input_tokens`, which violated the project's camelCase contract for JavaScript and TypeScript APIs.

## Proposed change

- Return `stopReason` from single and batch `host.llm()` calls.
- Return camelCase usage fields: `inputTokens`, `cacheTokens`, `outputTokens`, `cachedReadTokens`, `cachedWriteTokens`, and `turnCount`.
- Update the main-process result type, local RPC contract coverage, and JS KERNEL validation/projection together.
- Reject legacy snake_case result bodies instead of retaining compatibility aliases.
- Preserve deep freezing, strict result validation, batch ordering, item-level errors, and existing stop-reason string values such as `end_turn`.

## Scope and non-goals

This is a breaking JavaScript contract migration limited to the `host.llm()` response body. It does not change request fields, model selection, inference behavior, tools, persistence, database state, architecture, or UI behavior.

## Acceptance criteria and validation

- Focused Host LLM service, local RPC, and JS REPL tests: 36 passed, 30 skipped.
- `npm run typecheck`: passed for Node and Web.
- `npm run lint`: 0 errors; 15 pre-existing formatting warnings in `src/main/host-sdk/capability-projection.test.ts`.
- Independent standards and spec reviews: no findings.
- Full `npm test`: 15,566 passed, 197 skipped, with two unrelated failures:
  - `scripts/ci/classify-pr-changes.test.ts` reports the existing `src/main/notebook/package-manager.ts` Windows-classification manifest gap; none of the involved files differ from `origin/main`.
  - The real-R cancellation timing test failed in the full parallel run and passed on isolated rerun.

## Review focus

- Confirm the public result body is consistently camelCase across service, RPC, and JS KERNEL boundaries.
- Confirm legacy snake_case bodies fail closed and no compatibility surface remains.
