### PR TITLE
ci(gate): restore main certification coverage

### DIFF
--- a/scripts/ci/change-impact.json
+++ b/scripts/ci/change-impact.json
@@ -134,6 +134,7 @@
         "src/main/notebook/micromamba-cache.ts",
         "src/main/notebook/micromamba.ts",
         "src/main/notebook/package-listing.ts",
+        "src/main/notebook/package-manager.ts",
         "src/main/notebook/provisioner-runtime.ts",
         "src/main/notebook/provisioner.ts",
         "src/main/notebook/python-command.ts",

--- a/src/main/settings/claude-runtime-provisioner.test.ts
+++ b/src/main/settings/claude-runtime-provisioner.test.ts
@@ -121,14 +121,17 @@ describe('provisionClaudeRuntime', () => {
       (await stat(join(assets.skillProjection.root, '.claude', 'skills', 'demo', 'SKILL.md')))
         .mode & 0o222
     ).toBe(0)
-    expect(
-      (
-        await stat(
-          join(assets.skillProjection.root, '.claude', 'skills', 'demo', 'scripts', 'run.sh')
-        )
-      ).mode & 0o111
-    ).not.toBe(0)
-    expect(renameSourceModes).toEqual([0o755])
+    if (process.platform !== 'win32') {
+      expect(
+        (
+          await stat(
+            join(assets.skillProjection.root, '.claude', 'skills', 'demo', 'scripts', 'run.sh')
+          )
+        ).mode & 0o111
+      ).not.toBe(0)
+    }
+    expect(renameSourceModes).toHaveLength(1)
+    expect(renameSourceModes[0] & 0o200).not.toBe(0)
   })
 
   it('rejects a symbolic-link private profile without changing its victim', async () => {


### PR DESCRIPTION
## Problem

Recent main and PR CI runs exposed two independent certification regressions:

- `src/main/notebook/package-manager.ts`, added by #1257, contains Windows runtime behavior but was missing from the PR Gate Windows-sensitive overlay. This caused the exhaustive classifier guard to fail in full-suite shards.
- `claude-runtime-provisioner.test.ts` asserted complete POSIX mode values and executable bits on Windows, where Node/NTFS does not expose those semantics.

## Proposed change

- Register `package-manager.ts` in the `windows_sensitive` change-impact overlay.
- Keep executable-bit preservation asserted on POSIX platforms.
- Assert the actual cross-platform rename contract everywhere: the projection source is made owner-writable and renamed exactly once.

## Scope and non-goals

- No production runtime behavior changes.
- No workflow topology or lane changes.
- No attempt to address unrelated existing full-suite failures.

## Acceptance criteria and validation

Checks ran after the last material edit:

- Windows-sensitive production-source coverage and CI gate consumers -> `npm test -- scripts/ci` -> 14 files, 209 tests passed.
- Classifier regression plus Claude projection portability -> `npm test -- scripts/ci/classify-pr-changes.test.ts src/main/settings/claude-runtime-provisioner.test.ts` -> 2 files, 67 tests passed.
- Repository lint -> `npm run lint` -> passed with 0 errors; 15 pre-existing Prettier warnings remain in `src/main/host-sdk/capability-projection.test.ts`.
- Full fallback typecheck -> attempted; blocked by the locally installed `@agentclientprotocol/claude-agent-acp` lacking the `waitForMcpServers` export referenced by current main.
- Full portable suite -> attempted; the two targeted regressions passed, while unrelated local Windows failures remained (notably symlink privilege errors, storage temp-directory validation failures, and existing renderer timing/cache assertions).

The classifier manifest is a global validation input, so exact-head PR CI remains authoritative for full portable and platform coverage.

## Review focus

- Whether `package-manager.ts` belongs in the existing Windows-sensitive overlay.
- Whether the revised test preserves the POSIX executable-bit contract without imposing POSIX mode semantics on Windows.