### PR TITLE
fix(side-chat): retry initial hydration once

### DIFF
--- a/src/renderer/src/pages/workspace/use-side-chat-controller.test.ts
+++ b/src/renderer/src/pages/workspace/use-side-chat-controller.test.ts
@@ -300,6 +300,53 @@ describe('Side chat renderer controller', () => {
     act(() => root.unmount())
   })
 
+  it('retries hydration once when the initial Side chat list fails', async () => {
+    const list = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Temporary IPC failure'))
+      .mockResolvedValueOnce({ revision: 0, chats: [] })
+    const start = vi.fn(async () => ({
+      sideSessionId: 'side-after-retry',
+      frameworkId: 'claude-code' as const
+    }))
+    window.api = {
+      sideChat: {
+        list,
+        start,
+        send: vi.fn(async () => undefined),
+        cancel: vi.fn(async () => undefined),
+        close: vi.fn(async () => undefined),
+        onEvent: vi.fn(() => () => undefined),
+        onRelayDelivered: vi.fn(() => () => undefined)
+      }
+    } as unknown as Window['api']
+
+    const root = createRoot(document.createElement('div'))
+    const result = {
+      current: undefined as unknown as ReturnType<typeof useSideChatController>
+    }
+    const Harness = (): null => {
+      result.current = useSideChatController({ sessionId: 'main-retry', projectId: 'project-1' })
+      return null
+    }
+
+    await act(async () => {
+      root.render(createElement(SideChatProvider, null, createElement(Harness)))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(list).toHaveBeenCalledTimes(2)
+    expect(result.current.unavailableReason).toBeUndefined()
+    await act(async () => expect(await result.current.start('Recovered')).toBe(true))
+    expect(start).toHaveBeenCalledWith({
+      parentSessionId: 'main-retry',
+      projectId: 'project-1',
+      text: 'Recovered'
+    })
+    act(() => root.unmount())
+  })
+
   it('hydrates every live Side chat and routes background events by parent Session', async () => {
     let eventListener: ((event: never) => void) | undefined
     const list = vi.fn(async () => ({

--- a/src/renderer/src/pages/workspace/use-side-chat-controller.ts
+++ b/src/renderer/src/pages/workspace/use-side-chat-controller.ts
@@ -206,11 +206,13 @@ const useOwnedSideChatRuntime = (): SideChatRuntimeController => {
       })
     })
 
-    if (!api.list) {
+    const list = api.list
+    if (!list) {
       setHydrated(true)
       return removeListener
     }
-    void api.list().then(
+    const restoredList = list().catch(() => list())
+    void restoredList.then(
       (snapshotList) => {
         if (disposed) return
         const next = new Map(viewsRef.current)


### PR DESCRIPTION
## Problem

A rejected first `side-chat:list` hydration request left the renderer with `hydrated=false` for the rest of the app lifetime. The Side Chat action stayed unavailable until the renderer or app restarted.

## Proposed change

Retry the local, read-only, idempotent Side Chat list request once. If the retry also rejects, preserve the existing fail-closed error state.

Add a controller regression test that rejects the first list request, succeeds on the second, and verifies that a Side Chat can then start.

## Scope and non-goals

- Renderer controller and its unit test only.
- No UI or interaction changes.
- No data fields, enums, persistence, schema, IPC contract, or data-model changes.
- No historical-data compatibility work is required.
- No backoff loop or manual retry surface.

## Acceptance criteria and validation

Checks ran after the last material edit.

- Initial hydration failure recovers after one retry -> `npm test -- src/renderer/src/pages/workspace/use-side-chat-controller.test.ts` -> 7/7 passed.
- Workspace renderer owner and contract coverage -> the 23 Vitest files selected by `npm run test:module -- workspace_page` were run directly -> 393/393 passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Changed-file lint -> `npx eslint src/renderer/src/pages/workspace/use-side-chat-controller.ts src/renderer/src/pages/workspace/use-side-chat-controller.test.ts` -> passed.
- Repository lint -> `npm run lint` -> 0 errors; 15 pre-existing Prettier warnings in `src/main/host-sdk/capability-projection.test.ts`.

The module selector produced the expected selective plan, but its Windows child-process launch failed with `spawnSync npm.cmd EINVAL`; the exact selected file set was therefore executed directly. PR CI remains authoritative for the complete exact-head plan.

## Review focus

Confirm that one immediate retry is sufficient for this local IPC read and that the second rejection still reaches the existing fail-closed error handler.
