### PR TITLE
fix(network): preserve connectivity after probe rejection

### DIFF
--- a/src/renderer/src/pages/settings/NetworkPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/NetworkPanel.render.test.tsx
@@ -22,6 +22,7 @@ afterEach(() => {
   act(() => root.unmount())
   container.remove()
   vi.useRealTimers()
+  delete (window as unknown as { api?: unknown }).api
   Object.defineProperty(window.navigator, 'onLine', { value: true, configurable: true })
   useNetworkStore.setState({ isOnline: true, connectivity: 'unknown' })
 })
@@ -52,5 +53,38 @@ describe('NetworkPanel offline retry', () => {
       await vi.advanceTimersByTimeAsync(1)
     })
     expect(container.textContent).toContain('This machine is offline.')
+  })
+
+  it('restores the last known status when an online retry probe rejects', async () => {
+    const checkConnectivity = vi.fn().mockRejectedValue(new Error('bridge gone'))
+    ;(window as unknown as { api: unknown }).api = {
+      network: {
+        getInfo: vi.fn().mockResolvedValue({ connectionType: 'wifi', ipAddress: '192.168.1.42' }),
+        checkConnectivity
+      }
+    }
+    Object.defineProperty(window.navigator, 'onLine', { value: true, configurable: true })
+    useNetworkStore.setState({ isOnline: true, connectivity: 'unreachable' })
+
+    await act(async () => {
+      root.render(<NetworkPanel view={{ kind: 'list' }} onNavigate={() => {}} />)
+    })
+    expect(container.textContent).toContain(
+      'The network link is up, but the internet is unreachable.'
+    )
+
+    await act(async () => {
+      buttonWithText('Check again').click()
+    })
+    expect(container.textContent).toContain('Checking…')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    expect(container.textContent).toContain(
+      'The network link is up, but the internet is unreachable.'
+    )
+    expect(buttonWithText('Check again')).not.toBeUndefined()
+    expect(checkConnectivity).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/src/stores/network-store.test.ts
+++ b/src/renderer/src/stores/network-store.test.ts
@@ -118,6 +118,31 @@ describe('probeConnectivity', () => {
     expect(useNetworkStore.getState().connectivity).toBe('unreachable')
   })
 
+  it('does not restore transient unknown when overlapping announced probes reject', async () => {
+    let resolveFirst!: (reachable: boolean) => void
+    const firstResult = new Promise<boolean>((resolve) => {
+      resolveFirst = resolve
+    })
+    const checkConnectivity = vi
+      .fn()
+      .mockReturnValueOnce(firstResult)
+      .mockRejectedValueOnce(new Error('bridge gone'))
+    stubCheckConnectivity(checkConnectivity)
+    useNetworkStore.setState({ isOnline: true, connectivity: 'unreachable' })
+
+    const firstProbe = useNetworkStore.getState().probeConnectivity({ announce: true })
+    const secondProbe = useNetworkStore.getState().probeConnectivity({ announce: true })
+
+    await vi.advanceTimersByTimeAsync(500)
+    await secondProbe
+    expect(useNetworkStore.getState().connectivity).toBe('unreachable')
+
+    resolveFirst(true)
+    await firstProbe
+    expect(useNetworkStore.getState().connectivity).toBe('unreachable')
+    expect(checkConnectivity).toHaveBeenCalledTimes(2)
+  })
+
   it('falls back to reachable when there is no probe bridge', async () => {
     stubCheckConnectivity()
     useNetworkStore.setState({ isOnline: true, connectivity: 'unknown' })

--- a/src/renderer/src/stores/network-store.test.ts
+++ b/src/renderer/src/stores/network-store.test.ts
@@ -118,6 +118,26 @@ describe('probeConnectivity', () => {
     expect(useNetworkStore.getState().connectivity).toBe('unreachable')
   })
 
+  it('keeps the offline state when a pending announced probe rejects', async () => {
+    let rejectProbe!: (reason: Error) => void
+    const probeResult = new Promise<boolean>((_resolve, reject) => {
+      rejectProbe = reject
+    })
+    stubCheckConnectivity(vi.fn().mockReturnValue(probeResult))
+    useNetworkStore.setState({ isOnline: true, connectivity: 'reachable' })
+
+    const probe = useNetworkStore.getState().probeConnectivity({ announce: true })
+    window.dispatchEvent(new Event('offline'))
+    rejectProbe(new Error('bridge gone'))
+
+    await vi.advanceTimersByTimeAsync(500)
+    await probe
+    expect(useNetworkStore.getState()).toMatchObject({
+      isOnline: false,
+      connectivity: 'unreachable'
+    })
+  })
+
   it('does not restore transient unknown when overlapping announced probes reject', async () => {
     let resolveFirst!: (reachable: boolean) => void
     const firstResult = new Promise<boolean>((resolve) => {

--- a/src/renderer/src/stores/network-store.test.ts
+++ b/src/renderer/src/stores/network-store.test.ts
@@ -102,6 +102,22 @@ describe('probeConnectivity', () => {
     expect(useNetworkStore.getState().connectivity).toBe('reachable')
   })
 
+  it('restores the last known state when an announced bridge call rejects', async () => {
+    const checkConnectivity = vi.fn().mockRejectedValue(new Error('bridge gone'))
+    stubCheckConnectivity(checkConnectivity)
+    useNetworkStore.setState({ isOnline: true, connectivity: 'unreachable' })
+
+    const probe = useNetworkStore.getState().probeConnectivity({ announce: true })
+    expect(useNetworkStore.getState().connectivity).toBe('unknown')
+
+    await vi.advanceTimersByTimeAsync(499)
+    expect(useNetworkStore.getState().connectivity).toBe('unknown')
+
+    await vi.advanceTimersByTimeAsync(1)
+    await probe
+    expect(useNetworkStore.getState().connectivity).toBe('unreachable')
+  })
+
   it('falls back to reachable when there is no probe bridge', async () => {
     stubCheckConnectivity()
     useNetworkStore.setState({ isOnline: true, connectivity: 'unknown' })

--- a/src/renderer/src/stores/network-store.ts
+++ b/src/renderer/src/stores/network-store.ts
@@ -27,12 +27,21 @@ type NetworkStore = {
 // re-check reads as a deliberate check instead of a flash.
 const MIN_CHECKING_MS = 500
 
-export const useNetworkStore = create<NetworkStore>((set) => {
+export const useNetworkStore = create<NetworkStore>((set, get) => {
   let probeGeneration = 0
 
   const probeConnectivity = async ({ announce = false } = {}): Promise<void> => {
     const generation = ++probeGeneration
     const startedAt = Date.now()
+    const previousConnectivity = get().connectivity
+
+    const holdAnnouncedState = async (): Promise<void> => {
+      if (!announce) return
+      const remaining = MIN_CHECKING_MS - (Date.now() - startedAt)
+      if (remaining > 0) {
+        await new Promise((resolve) => setTimeout(resolve, remaining))
+      }
+    }
 
     if (announce) set({ connectivity: 'unknown' })
 
@@ -48,18 +57,18 @@ export const useNetworkStore = create<NetworkStore>((set) => {
         try {
           reachable = await checkConnectivity()
         } catch {
-          // Bridge failure keeps the last known state rather than crying wolf.
+          // Bridge failure keeps the last known state rather than crying wolf. Announced probes
+          // still honor the minimum Checking… presentation before restoring that state.
+          await holdAnnouncedState()
+          if (announce && probeGeneration === generation) {
+            set({ connectivity: previousConnectivity })
+          }
           return
         }
       }
     }
 
-    if (announce) {
-      const remaining = MIN_CHECKING_MS - (Date.now() - startedAt)
-      if (remaining > 0) {
-        await new Promise((resolve) => setTimeout(resolve, remaining))
-      }
-    }
+    await holdAnnouncedState()
     if (probeGeneration === generation) {
       set({ connectivity: reachable ? 'reachable' : 'unreachable' })
     }

--- a/src/renderer/src/stores/network-store.ts
+++ b/src/renderer/src/stores/network-store.ts
@@ -64,7 +64,14 @@ export const useNetworkStore = create<NetworkStore>((set, get) => {
           // Bridge failure keeps the last known state rather than crying wolf. Announced probes
           // still honor the minimum Checking… presentation before restoring that state.
           await holdAnnouncedState()
-          if (announce && probeGeneration === generation && lastKnownConnectivity !== undefined) {
+          const currentState = get()
+          if (
+            announce &&
+            probeGeneration === generation &&
+            currentState.isOnline &&
+            currentState.connectivity === 'unknown' &&
+            lastKnownConnectivity !== undefined
+          ) {
             set({ connectivity: lastKnownConnectivity })
           }
           return
@@ -73,7 +80,7 @@ export const useNetworkStore = create<NetworkStore>((set, get) => {
     }
 
     await holdAnnouncedState()
-    if (probeGeneration === generation) {
+    if (probeGeneration === generation && (get().isOnline || !reachable)) {
       const connectivity = reachable ? 'reachable' : 'unreachable'
       lastKnownConnectivity = connectivity
       set({ connectivity })

--- a/src/renderer/src/stores/network-store.ts
+++ b/src/renderer/src/stores/network-store.ts
@@ -29,11 +29,15 @@ const MIN_CHECKING_MS = 500
 
 export const useNetworkStore = create<NetworkStore>((set, get) => {
   let probeGeneration = 0
+  let lastKnownConnectivity: Exclude<NetworkConnectivity, 'unknown'> | undefined
 
   const probeConnectivity = async ({ announce = false } = {}): Promise<void> => {
     const generation = ++probeGeneration
     const startedAt = Date.now()
-    const previousConnectivity = get().connectivity
+    const currentConnectivity = get().connectivity
+    if (currentConnectivity !== 'unknown') {
+      lastKnownConnectivity = currentConnectivity
+    }
 
     const holdAnnouncedState = async (): Promise<void> => {
       if (!announce) return
@@ -60,8 +64,8 @@ export const useNetworkStore = create<NetworkStore>((set, get) => {
           // Bridge failure keeps the last known state rather than crying wolf. Announced probes
           // still honor the minimum Checking… presentation before restoring that state.
           await holdAnnouncedState()
-          if (announce && probeGeneration === generation) {
-            set({ connectivity: previousConnectivity })
+          if (announce && probeGeneration === generation && lastKnownConnectivity !== undefined) {
+            set({ connectivity: lastKnownConnectivity })
           }
           return
         }
@@ -70,7 +74,9 @@ export const useNetworkStore = create<NetworkStore>((set, get) => {
 
     await holdAnnouncedState()
     if (probeGeneration === generation) {
-      set({ connectivity: reachable ? 'reachable' : 'unreachable' })
+      const connectivity = reachable ? 'reachable' : 'unreachable'
+      lastKnownConnectivity = connectivity
+      set({ connectivity })
     }
   }
 


### PR DESCRIPTION
## Problem

An announced connectivity probe replaced the last stable `reachable` or `unreachable` result with `unknown` before calling the preload bridge. If that bridge call rejected, the early return left the Network panel showing `Checking…` indefinitely and removed the user's retry path.

Normal network reachability failures still resolve to `false`; this change targets bridge/IPC rejection only.

## Proposed change

Track the most recent stable `reachable` or `unreachable` result outside the transient `unknown` checking presentation. On a current announced probe rejection, keep the existing 500 ms checking presentation and then restore that stable result only while the app still considers the link online and the probe still owns the transient state. This covers overlapping retries without allowing a pending probe to overwrite a newer offline transition. Stale probes remain unable to overwrite a newer probe.

Add store-level regressions for single and overlapping rejected probes, the offline-event race, plus a NetworkPanel interaction regression for the online/unreachable retry path.

## Scope and non-goals

- No new connectivity enum value or public store field.
- No IPC, architecture, database, persistence, migration, or historical-data compatibility change.
- No new user-visible copy or i18n catalog change.
- A cold-start rejection with no prior stable result remains `unknown`; the fix does not invent reachability when no last-known state exists.

## Acceptance criteria and validation

Checks ran after the last material edit.

- Single and overlapping announced rejections preserve the 500 ms checking state and restore the last stable result; a newer offline event remains authoritative -> `npm test -- src/renderer/src/stores/network-store.test.ts src/renderer/src/pages/settings/NetworkPanel.render.test.tsx` -> 2 files, 15 tests passed.
- Renderer types remain valid -> `npm run typecheck:web` -> passed.
- Changed source and tests satisfy lint -> `npm run lint` -> exit 0; 15 existing Prettier warnings remain in unrelated `src/main/host-sdk/capability-projection.test.ts`.
- Patch contains no whitespace errors -> `git diff --check` -> passed.

The network renderer files do not currently have a dedicated owner in `scripts/ci/module-impact.json`, so local validation used the store and actual NetworkPanel retry slice. PR Gate remains authoritative for the final consumer and platform plan. No platform-specific, persistence, migration, or build lane was added because the store interface and runtime boundaries are unchanged.

## Review focus

- Rejection restores only the most recent stable connectivity result, never transient `unknown`.
- A newer offline transition remains authoritative over a pending probe rejection or reachable result.
- The minimum checking interval remains unchanged.
- The generation guard prevents a stale rejection or success from overwriting a newer probe.