### PR TITLE
feat(host-sessions): add session diagnostics

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -1039,6 +1039,7 @@ const HOST_CAPABILITY_KNOWN_KEYS = Object.freeze([
   'artifacts',
   'lineage',
   'frames',
+  'sessions',
   'llm',
   'currentModel',
   'listModels',
@@ -1744,6 +1745,131 @@ const validatedHostRuntimeSegment = (value) => {
     throw new Error('host.frames.get returned an invalid runtime segment')
   }
   return frozenProjection(value, [...required, ...optional])
+}
+
+const HOST_SESSION_CONNECTION_STATUSES = ['idle', 'connecting', 'connected', 'error', 'closed']
+const HOST_SESSION_OBSERVATION_KINDS = [
+  'system',
+  'message',
+  'thought',
+  'tool',
+  'plan',
+  'permission',
+  'artifact',
+  'compaction',
+  'error',
+  'stop',
+  'raw'
+]
+const HOST_SESSION_OBSERVATION_LEVELS = ['info', 'warning', 'error']
+
+const validatedHostSessionRuntime = (value) => {
+  const required = [
+    'attached',
+    'prompt_in_flight',
+    'agent_prompt_in_flight',
+    'permission_pending',
+    'user_input_pending'
+  ]
+  const optional = ['connection_status']
+  if (
+    !exactObject(value, required, optional) ||
+    required.some((key) => typeof value[key] !== 'boolean') ||
+    (value.connection_status !== undefined &&
+      !HOST_SESSION_CONNECTION_STATUSES.includes(value.connection_status))
+  ) {
+    throw new Error('host.sessions returned an invalid runtime projection')
+  }
+  return Object.freeze({
+    attached: value.attached,
+    ...(value.connection_status !== undefined ? { connectionStatus: value.connection_status } : {}),
+    promptInFlight: value.prompt_in_flight,
+    agentPromptInFlight: value.agent_prompt_in_flight,
+    permissionPending: value.permission_pending,
+    userInputPending: value.user_input_pending
+  })
+}
+
+const validatedHostSessionConversation = (value) => {
+  const keys = ['frame_id', 'branch_id', 'message_count']
+  if (
+    !exactObject(value, keys) ||
+    !hostFrameString(value.frame_id) ||
+    !hostFrameString(value.branch_id) ||
+    !hostFrameCount(value.message_count)
+  ) {
+    throw new Error('host.sessions returned an invalid active conversation')
+  }
+  return Object.freeze({
+    frameId: value.frame_id,
+    branchId: value.branch_id,
+    messageCount: value.message_count
+  })
+}
+
+const validatedHostSessionObservation = (value) => {
+  const required = ['timestamp', 'kind', 'level']
+  const optional = ['status', 'title']
+  if (
+    !exactObject(value, required, optional) ||
+    !hostFrameString(value.timestamp) ||
+    !HOST_SESSION_OBSERVATION_KINDS.includes(value.kind) ||
+    !HOST_SESSION_OBSERVATION_LEVELS.includes(value.level) ||
+    !hostFrameOptionalString(value.status) ||
+    !hostFrameOptionalString(value.title)
+  ) {
+    throw new Error('host.sessions returned an invalid latest observation')
+  }
+  return Object.freeze({
+    timestamp: value.timestamp,
+    kind: value.kind,
+    level: value.level,
+    ...(value.status !== undefined ? { status: value.status } : {}),
+    ...(value.title !== undefined ? { title: value.title } : {})
+  })
+}
+
+const validatedHostSession = (value) => {
+  const required = ['session_id', 'title', 'status', 'created_at', 'updated_at', 'runtime']
+  const optional = [
+    'archived_at',
+    'active_run_started_at',
+    'active_conversation',
+    'latest_observation'
+  ]
+  if (
+    !exactObject(value, required, optional) ||
+    !hostFrameString(value.session_id) ||
+    !hostFrameString(value.title) ||
+    !HOST_SESSION_STATUSES.includes(value.status) ||
+    !hostFrameString(value.created_at) ||
+    !hostFrameString(value.updated_at) ||
+    !hostFrameOptionalString(value.archived_at) ||
+    !hostFrameOptionalString(value.active_run_started_at) ||
+    !value.runtime ||
+    typeof value.runtime !== 'object' ||
+    Array.isArray(value.runtime)
+  ) {
+    throw new Error('host.sessions returned an invalid Session')
+  }
+  return Object.freeze({
+    sessionId: value.session_id,
+    title: value.title,
+    status: value.status,
+    createdAt: value.created_at,
+    updatedAt: value.updated_at,
+    ...(value.archived_at !== undefined ? { archivedAt: value.archived_at } : {}),
+    ...(value.active_run_started_at !== undefined
+      ? { activeRunStartedAt: value.active_run_started_at }
+      : {}),
+    runtime: validatedHostSessionRuntime(value.runtime),
+    ...(value.active_conversation !== undefined
+      ? { activeConversation: validatedHostSessionConversation(value.active_conversation) }
+      : {}),
+    ...(value.latest_observation !== undefined
+      ? { latestObservation: validatedHostSessionObservation(value.latest_observation) }
+      : {})
+  })
 }
 
 async function framesRpc(op, params) {
@@ -2513,6 +2639,63 @@ async function hostFramesGet(frameId, options = {}) {
 
 const hostFrames = Object.freeze({ list: hostFramesList, get: hostFramesGet })
 
+const sessionsRpc = async (op, params) => {
+  if (!RPC_ENDPOINT) throw new Error(`host.sessions.${op} is unavailable: RPC endpoint not set`)
+  const res = await capturedRpcFetch(RPC_ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: 'Bearer ' + (RPC_TOKEN || '') },
+    body: JSON.stringify({ method: 'sessionsCall', params: { op, ...params } })
+  })
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok || body.error) {
+    throw new Error(`host.sessions.${op}: ${body.error || 'HTTP ' + res.status}`)
+  }
+  return body.result
+}
+
+async function hostSessionsList(options = {}) {
+  if (arguments.length > 1) {
+    throw new TypeError('host.sessions.list accepts at most one options object')
+  }
+  const result = await sessionsRpc('list', {
+    options: remappedHostObject(options, 'host.sessions.list options', {
+      archived: 'archived',
+      search: 'search',
+      limit: 'limit',
+      cursor: 'cursor'
+    })
+  })
+  const required = ['total_count', 'sessions']
+  const optional = ['next_cursor']
+  if (
+    !exactObject(result, required, optional) ||
+    !hostFrameCount(result.total_count) ||
+    !Array.isArray(result.sessions) ||
+    result.total_count < result.sessions.length ||
+    !hostFrameOptionalString(result.next_cursor)
+  ) {
+    throw new Error('host.sessions.list returned an invalid result')
+  }
+  return Object.freeze({
+    totalCount: result.total_count,
+    ...(result.next_cursor !== undefined ? { nextCursor: result.next_cursor } : {}),
+    sessions: Object.freeze(result.sessions.map(validatedHostSession))
+  })
+}
+
+async function hostSessionsInspect(sessionId) {
+  if (arguments.length !== 1) {
+    throw new TypeError('host.sessions.inspect accepts one sessionId')
+  }
+  return validatedHostSession(
+    await sessionsRpc('inspect', {
+      session_id: sessionId
+    })
+  )
+}
+
+const hostSessions = Object.freeze({ list: hostSessionsList, inspect: hostSessionsInspect })
+
 // host.compute: async remote-compute calls over the SAME app-local RPC endpoint as host.mcp, routed to
 // the main-process ComputeService via {method:'computeCall'}. Like host.mcp, this is only injected in
 // the trusted control plane — the python/r data kernels have no host.compute, so SSH/approval always
@@ -3212,6 +3395,7 @@ const sandbox = {
     viewImage: hostViewImage,
     lineage: hostLineage,
     frames: hostFrames,
+    sessions: hostSessions,
     mcp: hostMcp,
     compute: hostCompute,
     agents: hostAgents,

--- a/resources/skills/self-awareness/SKILL.md
+++ b/resources/skills/self-awareness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: self-awareness
-description: Inspect Open Science's JavaScript control REPL, discover managed Project files and Agent Frames, and safely feature-gate host.* calls with host.capabilities(). Use when an Agent needs to discover available host APIs, locate an Artifact or Upload Version, or read a Frame transcript in the current Project.
+description: Inspect Open Science's JavaScript control REPL, discover managed Project files, Sessions, and Agent Frames, and safely feature-gate host.* calls with host.capabilities(). Use when an Agent needs to discover available host APIs, locate an Artifact or Upload Version, diagnose a Session, or read a Frame transcript in the current Project.
 ---
 
 # Self-awareness
@@ -14,7 +14,7 @@ JavaScript control REPL; Python and R data kernels do not receive it.
 const caps = await host.capabilities()
 ```
 
-The current project-native result contains 19 known boolean keys:
+The current project-native result contains 20 known boolean keys:
 
 - `mcp` gates connector calls through `host.mcp(server, method, args?)`.
 - `compute` gates the `host.compute` namespace.
@@ -24,6 +24,8 @@ The current project-native result contains 19 known boolean keys:
   resolution through `host.artifactPath(versionId)`.
 - `lineage` gates the read-only `host.lineage` namespace.
 - `frames` gates the read-only `host.frames` namespace.
+- `sessions` gates Main-only, read-only Session diagnostics through `host.sessions.list(options?)`
+  and exact lookup through `host.sessions.inspect(sessionId)` in the current Project.
 - `llm` gates one-shot, tool-less inference through `host.llm(request, options?)`.
 - `currentModel` gates exact current-model lookup through `host.currentModel()`. It returns the
   calling Session's exact current model id and fails when the live backend cannot establish one.
@@ -67,6 +69,10 @@ if (caps.currentModel === true) {
 
 if (caps.listModels === true) {
   const hostLlmModels = await host.listModels()
+}
+
+if (caps.sessions === true) {
+  const recentSessions = await host.sessions.list({ limit: 20 })
 }
 
 if (caps.viewImage === true) {
@@ -178,6 +184,29 @@ response never returns private reasoning, tool activities and raw inputs/outputs
 image bytes, local paths, storage and provider identifiers, internal event/stream identifiers, cost,
 or synthesized summaries. Missing, ambiguous, wrong-Session, invalid-Branch, and stale-cursor reads fail
 explicitly without enabling cross-Project discovery.
+
+## Diagnose Project Sessions
+
+When `caps.sessions === true`, use `await host.sessions.list(options)` to inspect durable Session
+metadata and bounded live runtime evidence across the token-owned current Project. This capability
+is available only to Main through its session-bound control route. Optional camelCase fields are
+`archived` (`exclude`/`include`/`only`, default `exclude`), `search`, `cursor`, and `limit` (default
+20, maximum 100). Search fuzzily matches Session title and exact Session identity. Results are
+ordered by most recent update and return `totalCount`, frozen Session projections, and `nextCursor`
+when another page exists.
+
+Use `await host.sessions.inspect(sessionId)` for one exact Session in the current Project. Both
+operations report durable identity, title, status, timestamps, archive/run metadata, current runtime
+attachment and pending-work flags, and the latest bounded runtime observation when available. Live
+runtime fields are current evidence only: a detached Session or an omitted observation does not
+rewrite or infer historical state. Missing or unreadable Sessions fail explicitly, and an incomplete
+Project catalog fails closed rather than returning a partial list.
+
+`activeConversation` contains only `frameId`, `branchId`, and `messageCount` navigation metadata.
+It never returns messages, transcripts, private reasoning, tool payloads, terminal output, or
+synthesized diagnosis. Use `host.frames.get(frameId, { sessionId, branchId })` when transcript detail
+is required. There is no Project override, mutation, recovery, cancellation, or message-send API in
+`host.sessions`; all returned projections are fresh and frozen.
 
 ## Continue with the owning Skill
 

--- a/src/main/acp/session-capability-owner.test.ts
+++ b/src/main/acp/session-capability-owner.test.ts
@@ -680,6 +680,7 @@ describe('ACP session capability owner', () => {
       'host-agents',
       'host-skills',
       'host-frames',
+      'host-sessions',
       'host-llm'
     ])
     expect(primary.descriptor.modelFacingMcpServerNames).toEqual([
@@ -700,6 +701,7 @@ describe('ACP session capability owner', () => {
       'agentsCall',
       'skillsCall',
       'framesCall',
+      'sessionsCall',
       'currentModelCall',
       'listModelsCall',
       'llmCall',
@@ -761,13 +763,20 @@ describe('ACP session capability owner', () => {
           'lineageCall',
           'skillsCall',
           'framesCall',
+          'sessionsCall',
           'currentModelCall',
           'listModelsCall',
           'llmCall'
         ])
       )
       expect(built.descriptor.capabilities).toEqual(
-        expect.arrayContaining(['notebook', 'host-skills', 'host-frames', 'host-llm'])
+        expect.arrayContaining([
+          'notebook',
+          'host-skills',
+          'host-frames',
+          'host-sessions',
+          'host-llm'
+        ])
       )
       expect(built.descriptor.transport).toBe('stdio')
       expect(built.descriptor.modelFacingMcpServerNames).toContain(artifactServerName)

--- a/src/main/acp/session-capability-owner.ts
+++ b/src/main/acp/session-capability-owner.ts
@@ -43,6 +43,7 @@ const CURRENT_PRIMARY_CAPABILITIES = [
   'host-agents',
   'host-skills',
   'host-frames',
+  'host-sessions',
   'host-llm',
   'host-message'
 ] as const
@@ -54,6 +55,7 @@ const NOTEBOOK_CONTROL_RPC_METHODS = [
   'agentsCall',
   'skillsCall',
   'framesCall',
+  'sessionsCall',
   'currentModelCall',
   'listModelsCall',
   'llmCall',
@@ -525,6 +527,12 @@ export class AcpSessionCapabilityOwner {
     }
     if (
       capabilities.includes('notebook') &&
+      policyAllowsSessionCapability(request.policy, 'host-sessions')
+    ) {
+      capabilities.push('host-sessions')
+    }
+    if (
+      capabilities.includes('notebook') &&
       policyAllowsSessionCapability(request.policy, 'host-llm')
     ) {
       capabilities.push('host-llm')
@@ -541,6 +549,7 @@ export class AcpSessionCapabilityOwner {
         capabilities.includes('host-agents') ||
         capabilities.includes('host-skills') ||
         capabilities.includes('host-frames') ||
+        capabilities.includes('host-sessions') ||
         capabilities.includes('host-llm')
           ? [...NOTEBOOK_CONTROL_RPC_METHODS]
           : []

--- a/src/main/host-sdk/capability-projection.test.ts
+++ b/src/main/host-sdk/capability-projection.test.ts
@@ -17,6 +17,7 @@ const allServices = {
   artifacts: true,
   lineage: true,
   frames: true,
+  sessions: true,
   llm: true,
   currentModel: true,
   listModels: true,
@@ -46,7 +47,7 @@ const project = (
   })
 
 describe('Host capability projection', () => {
-  it('owns the complete 19-key project-native catalog', () => {
+  it('owns the complete 20-key project-native catalog', () => {
     expect(HOST_CAPABILITY_KEYS).toEqual([
       'mcp',
       'compute',
@@ -55,6 +56,7 @@ describe('Host capability projection', () => {
       'artifacts',
       'lineage',
       'frames',
+      'sessions',
       'llm',
       'currentModel',
       'listModels',
@@ -82,6 +84,7 @@ describe('Host capability projection', () => {
       submitOutput: false
     })
     expect(project({ callerRole: 'delegate' })).toMatchObject({
+      sessions: false,
       delegate: false,
       children: false,
       collect: false,
@@ -100,6 +103,18 @@ describe('Host capability projection', () => {
       messageReceipt: false,
       resolveMessage: false,
       submitOutput: false
+    })
+  })
+
+  it('advertises Session diagnostics only through the Main control route', () => {
+    expect(project()).toMatchObject({ sessions: true })
+    expect(project({ callerRole: 'delegate' })).toMatchObject({ sessions: false })
+    expect(project({ isControl: false })).toMatchObject({ sessions: false })
+    expect(project({ allowsMethod: (method) => method !== 'sessionsCall' })).toMatchObject({
+      sessions: false
+    })
+    expect(project({ services: { ...allServices, sessions: false } })).toMatchObject({
+      sessions: false
     })
   })
 

--- a/src/main/host-sdk/capability-projection.ts
+++ b/src/main/host-sdk/capability-projection.ts
@@ -6,6 +6,7 @@ const HOST_CAPABILITY_BASE_KEYS = [
   'artifacts',
   'lineage',
   'frames',
+  'sessions',
   'llm',
   'currentModel',
   'listModels',
@@ -48,6 +49,7 @@ type HostCapabilityProjectionContext = Readonly<{
     artifacts: boolean
     lineage: boolean
     frames: boolean
+    sessions: boolean
     llm: boolean
     currentModel: boolean
     listModels: boolean
@@ -83,6 +85,11 @@ const projectHostCapabilities = (
     artifacts: allows('artifactsCall') && context.services.artifacts,
     lineage: allows('lineageCall') && context.services.lineage,
     frames: context.isControl && allows('framesCall') && context.services.frames,
+    sessions:
+      context.callerRole === 'main' &&
+      context.isControl &&
+      allows('sessionsCall') &&
+      context.services.sessions,
     llm: context.isControl && allows('llmCall') && context.services.llm,
     currentModel: context.isControl && allows('currentModelCall') && context.services.currentModel,
     listModels: context.isControl && allows('listModelsCall') && context.services.listModels,

--- a/src/main/host-sdk/help.test.ts
+++ b/src/main/host-sdk/help.test.ts
@@ -64,13 +64,13 @@ describe('Host SDK help', () => {
         aliases: [id.slice('host.'.length)]
       }))
     )
-    expect(JSON.stringify(catalog).length).toBeLessThanOrEqual(2_700)
+    expect(JSON.stringify(catalog).length).toBeLessThanOrEqual(2_900)
 
     const unavailableCatalog = hostSdkHelp.query(undefined, {
       callerRole: 'main',
       capabilities: unprovisioned
     })
-    expect(JSON.stringify(unavailableCatalog).length).toBeLessThanOrEqual(2_700)
+    expect(JSON.stringify(unavailableCatalog).length).toBeLessThanOrEqual(2_900)
   })
 
   it('documents the transient visual-model-gated viewImage contract', () => {
@@ -158,6 +158,27 @@ describe('Host SDK help', () => {
       hostSdkHelp.query('llm', {
         ...mainContext,
         capabilities: { ...mainContext.capabilities, llm: false }
+      })
+    ).toMatchObject({ availability: { status: 'unavailable' } })
+  })
+
+  it('documents Main-only Project Session diagnostics through one namespace topic', () => {
+    const capabilities = { ...mainContext.capabilities, sessions: true }
+    const help = hostSdkHelp.query('sessions', { ...mainContext, capabilities })
+    expect(help).toMatchObject({
+      kind: 'operation',
+      id: 'host.sessions',
+      availability: { status: 'available' },
+      call_forms: [
+        { signature: 'await host.sessions.list(options?)' },
+        { signature: 'await host.sessions.inspect(sessionId)' }
+      ]
+    })
+    expect(hostSdkHelp.query('host.sessions', { ...mainContext, capabilities })).toEqual(help)
+    expect(
+      hostSdkHelp.query('sessions', {
+        ...delegateContext,
+        capabilities
       })
     ).toMatchObject({ availability: { status: 'unavailable' } })
   })

--- a/src/main/host-sdk/help.ts
+++ b/src/main/host-sdk/help.ts
@@ -12,6 +12,7 @@ const HOST_SDK_OPERATION_IDS = Object.freeze(
     'host.currentModel',
     'host.llm',
     'host.listModels',
+    'host.sessions',
     'host.viewImage'
   ].sort()
 )
@@ -25,6 +26,7 @@ type HostSdkHelpContext = Readonly<{
       currentModel?: boolean
       llm?: boolean
       listModels?: boolean
+      sessions?: boolean
       viewImage?: boolean
     }
   >
@@ -901,6 +903,103 @@ const LIST_MODELS_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
       : { status: 'unavailable', reason: 'The active Host LLM model catalog is unavailable.' }
 }
 
+const SESSIONS_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
+  kind: 'operation',
+  id: 'host.sessions',
+  path: 'host.sessions',
+  aliases: ['sessions'],
+  summary: 'List or inspect read-only Session diagnostics in the current Project.',
+  call_forms: [
+    { signature: 'await host.sessions.list(options?)', accepts: 'optional_list_options' },
+    { signature: 'await host.sessions.inspect(sessionId)', accepts: 'exact_session_id' }
+  ],
+  request: {
+    fields: [
+      {
+        name: 'sessionId',
+        type: 'string',
+        required: true,
+        when: 'inspect',
+        description: 'Exact Session id in the token-owned current Project.'
+      }
+    ]
+  },
+  options: {
+    fields: [
+      {
+        name: 'archived',
+        type: "'exclude' | 'include' | 'only'",
+        required: false,
+        default: 'exclude',
+        description: 'List-only archive filter.'
+      },
+      {
+        name: 'search',
+        type: 'string',
+        required: false,
+        description: 'Fuzzy title or exact Session id match.'
+      },
+      {
+        name: 'cursor',
+        type: 'string',
+        required: false,
+        description: 'List-only cursor from the same filters and snapshot.'
+      },
+      {
+        name: 'limit',
+        type: 'integer',
+        required: false,
+        default: 20,
+        range: '1..100',
+        description: 'Maximum Sessions returned by list.'
+      }
+    ]
+  },
+  returns: {
+    type: 'SessionDiagnostic | SessionDiagnosticPage',
+    list_fields: [
+      { name: 'totalCount', type: 'integer', required: true, description: 'Total matches.' },
+      { name: 'nextCursor', type: 'string', required: false, description: 'Next page.' },
+      { name: 'sessions', type: 'SessionDiagnostic[]', required: true, description: 'Page.' }
+    ],
+    session_fields: [
+      { name: 'sessionId', type: 'string', required: true, description: 'Exact Session id.' },
+      { name: 'title', type: 'string', required: true, description: 'Durable title.' },
+      { name: 'status', type: 'string', required: true, description: 'Durable Session status.' },
+      { name: 'createdAt', type: 'string', required: true, description: 'ISO timestamp.' },
+      { name: 'updatedAt', type: 'string', required: true, description: 'ISO timestamp.' },
+      { name: 'runtime', type: 'object', required: true, description: 'Bounded live evidence.' },
+      {
+        name: 'activeConversation',
+        type: 'object',
+        required: false,
+        description: 'Frame, Branch, and message-count navigation metadata.'
+      },
+      {
+        name: 'latestObservation',
+        type: 'object',
+        required: false,
+        description: 'Latest bounded runtime observation.'
+      }
+    ]
+  },
+  constraints: [
+    'Main JavaScript control REPL only; Project scope comes from the session-bound token.',
+    'Read-only and metadata-only; use host.frames for transcript content and Branch traversal.',
+    'Live runtime fields are current evidence, not inferred historical state.'
+  ],
+  examples: [
+    { title: 'List recent Sessions', code: 'await host.sessions.list({ limit: 20 })' },
+    { title: 'Inspect one Session', code: 'await host.sessions.inspect(sessionId)' }
+  ],
+  resolveAvailability: ({ callerRole, capabilities }) =>
+    callerRole === 'delegate'
+      ? { status: 'unavailable', reason: 'host.sessions is available only to Main.' }
+      : capabilities.sessions
+        ? { status: 'available' }
+        : { status: 'unavailable', reason: 'host.sessions is not provisioned for this Session.' }
+}
+
 const OPERATION_DESCRIPTORS: readonly HostSdkHelpOperationDescriptor[] = [
   CHILDREN_DESCRIPTOR,
   COLLECT_DESCRIPTOR,
@@ -911,6 +1010,7 @@ const OPERATION_DESCRIPTORS: readonly HostSdkHelpOperationDescriptor[] = [
   MESSAGE_RECEIPT_DESCRIPTOR,
   RESOLVE_MESSAGE_DESCRIPTOR,
   SEND_FRAME_MESSAGE_DESCRIPTOR,
+  SESSIONS_DESCRIPTOR,
   STOP_CHILD_DESCRIPTOR,
   SUBMIT_OUTPUT_DESCRIPTOR,
   VIEW_IMAGE_DESCRIPTOR
@@ -927,7 +1027,7 @@ if (JSON.stringify(registeredOperationIds) !== JSON.stringify(HOST_SDK_SUBAGENT_
 }
 
 const MAX_HELP_QUERY_CHARS = 128
-const MAX_CATALOG_RESULT_CHARS = 2_700
+const MAX_CATALOG_RESULT_CHARS = 2_900
 const MAX_OPERATION_RESULT_CHARS = 3_600
 const MAX_DELEGATE_RESULT_CHARS = 3_200
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -137,6 +137,7 @@ import { runtimeRoot } from './notebook/runtime-paths'
 import { HostArtifactsService } from './notebook/host-artifacts-service'
 import { HostLineageService } from './notebook/host-lineage-service'
 import { HostFramesService } from './notebook/host-frames-service'
+import { HostSessionsService } from './notebook/host-sessions-service'
 import { HostModelService } from './notebook/host-model-service'
 import { HostViewImageService } from './notebook/host-view-image-service'
 import type { NotebookEnvironmentManager } from './notebook/runtime-service'
@@ -1710,6 +1711,17 @@ const createApplicationModules = async (
             mode: 'read-only'
           })
       }),
+      hostSessions: new HostSessionsService(
+        {
+          readProject: (projectId) =>
+            sessionRepository.loadProjectWithDiagnostics(projectId, { mode: 'read-only' }),
+          readSession: (projectId, sessionId) =>
+            sessionRepository.loadSessionWithDiagnostics(projectId, sessionId, {
+              mode: 'read-only'
+            })
+        },
+        { getSnapshot: () => runtimeRef.current?.getSnapshot() }
+      ),
       inputRegistry: notebookInputRegistry,
       agentsService,
       delegatedWorkService: delegatedWork.host,

--- a/src/main/notebook/host-sessions-service.test.ts
+++ b/src/main/notebook/host-sessions-service.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createLinearConversationGraph } from '../../shared/conversation-graph'
+import type { AcpStateSnapshot } from '../../shared/acp'
+import {
+  normalizeSessionFile,
+  type PersistedChatMessage,
+  type PersistedChatSession
+} from '../../shared/session-persistence'
+import { HostSessionsService, type HostSessionsRepository } from './host-sessions-service'
+
+const message = (id: string, createdAt: number): PersistedChatMessage => ({
+  id,
+  role: 'user',
+  content: `message ${id}`,
+  status: 'complete',
+  eventIds: [],
+  createdAt,
+  updatedAt: createdAt
+})
+
+const session = (overrides: Partial<PersistedChatSession> = {}): PersistedChatSession => {
+  const id = overrides.id ?? 'session-1'
+  const messages = overrides.messages ?? [message('message-1', 100)]
+  return {
+    id,
+    projectId: 'project-a',
+    title: 'Literature review',
+    cwd: '/private/workspace',
+    status: 'running',
+    messages,
+    conversationGraph: createLinearConversationGraph({
+      sessionId: id,
+      messages,
+      frameworkId: 'claude-code',
+      createdAt: 100,
+      updatedAt: 200
+    }),
+    activeRun: { promptMessageId: messages[0].id, startedAt: 150 },
+    createdAt: 100,
+    updatedAt: 200,
+    ...overrides
+  }
+}
+
+const snapshot = (overrides: Partial<AcpStateSnapshot> = {}): AcpStateSnapshot => ({
+  status: 'connected',
+  cwd: '/private/workspace',
+  sessionIds: ['session-1'],
+  events: [
+    {
+      id: 'event-1',
+      sessionId: 'session-1',
+      timestamp: 175,
+      kind: 'tool',
+      level: 'info',
+      status: 'in_progress',
+      title: '/private/SECRET command',
+      rawInput: { token: 'SECRET' }
+    }
+  ],
+  pendingPermissions: [
+    {
+      requestId: 'permission-1',
+      sessionId: 'session-1',
+      toolCallId: 'tool-1',
+      title: 'Private permission',
+      options: []
+    }
+  ],
+  pendingElicitations: [],
+  permissionProfiles: {},
+  permissionGrants: {},
+  contextUsageBySession: {},
+  promptInFlight: true,
+  agentPromptInFlightSessionIds: ['session-1'],
+  promptInFlightSessionIds: ['session-1'],
+  sessionConnectionStatuses: { 'session-1': 'connected' },
+  ...overrides
+})
+
+const context = {
+  projectId: 'project-a',
+  sessionId: 'calling-session',
+  callerRole: 'main' as const
+}
+
+const repository = (sessions: PersistedChatSession[]): HostSessionsRepository => ({
+  readProject: vi.fn(async () => ({ sessions, isComplete: true })),
+  readSession: vi.fn(async (_projectId, sessionId) => {
+    const found = sessions.find((candidate) => candidate.id === sessionId)
+    return found ? { status: 'found' as const, session: found } : { status: 'missing' as const }
+  })
+})
+
+describe('HostSessionsService', () => {
+  it('lists current-Project Sessions with live evidence and host.frames navigation only', async () => {
+    const service = new HostSessionsService(repository([session()]), {
+      getSnapshot: () => snapshot()
+    })
+
+    await expect(service.list({}, context)).resolves.toEqual({
+      total_count: 1,
+      sessions: [
+        {
+          session_id: 'session-1',
+          title: 'Literature review',
+          status: 'running',
+          created_at: new Date(100).toISOString(),
+          updated_at: new Date(200).toISOString(),
+          active_run_started_at: new Date(150).toISOString(),
+          runtime: {
+            attached: true,
+            connection_status: 'connected',
+            prompt_in_flight: true,
+            agent_prompt_in_flight: true,
+            permission_pending: true,
+            user_input_pending: false
+          },
+          active_conversation: {
+            frame_id: 'root-frame-session-1',
+            branch_id: 'message-branch-session-1',
+            message_count: 1
+          },
+          latest_observation: {
+            timestamp: new Date(175).toISOString(),
+            kind: 'tool',
+            level: 'info',
+            status: 'in_progress'
+          }
+        }
+      ]
+    })
+    expect(JSON.stringify(await service.list({}, context))).not.toMatch(/SECRET|\/private/u)
+  })
+
+  it('filters, orders, and paginates the Session catalog with snapshot-bound cursors', async () => {
+    const sessions = [
+      session({ id: 'session-b', title: 'Genomics beta', updatedAt: 300 }),
+      session({ id: 'session-a', title: 'Genomics alpha', updatedAt: 300 }),
+      session({ id: 'session-c', title: 'Unrelated', updatedAt: 100 }),
+      session({
+        id: 'session-archived',
+        title: 'Genomics archive',
+        archivedAt: 400,
+        updatedAt: 400
+      })
+    ]
+    const service = new HostSessionsService(repository(sessions), {
+      getSnapshot: () => snapshot({ sessionIds: [], events: [], pendingPermissions: [] })
+    })
+
+    const first = (await service.list({ search: 'gen', limit: 1 }, context)) as {
+      total_count: number
+      next_cursor?: string
+      sessions: Array<{ session_id: string }>
+    }
+    expect(first).toMatchObject({ total_count: 2, next_cursor: expect.any(String) })
+    expect(first.sessions.map((item) => item.session_id)).toEqual(['session-a'])
+
+    await expect(
+      service.list({ search: 'gen', limit: 1, cursor: first.next_cursor }, context)
+    ).resolves.toMatchObject({
+      total_count: 2,
+      sessions: [expect.objectContaining({ session_id: 'session-b' })]
+    })
+    await expect(service.list({ archived: 'only', search: 'gen' }, context)).resolves.toMatchObject(
+      {
+        total_count: 1,
+        sessions: [expect.objectContaining({ session_id: 'session-archived' })]
+      }
+    )
+    await expect(
+      service.list({ archived: 'include', search: 'gen' }, context)
+    ).resolves.toMatchObject({ total_count: 3 })
+    await expect(service.list({ limit: 2, cursor: first.next_cursor }, context)).rejects.toThrow(
+      'cursor does not match'
+    )
+
+    sessions[1].updatedAt += 1
+    await expect(
+      service.list({ search: 'gen', limit: 1, cursor: first.next_cursor }, context)
+    ).rejects.toThrow('cursor is no longer valid')
+  })
+
+  it('inspects one exact Session without scanning or returning transcript content', async () => {
+    const target = session({ id: 'target-session' })
+    const repo = repository([target])
+    const service = new HostSessionsService(repo, {
+      getSnapshot: () => snapshot({ sessionIds: [], events: [], pendingPermissions: [] })
+    })
+
+    const result = await service.inspect('target-session', context)
+
+    expect(result).toMatchObject({
+      session_id: 'target-session',
+      active_conversation: {
+        frame_id: 'root-frame-target-session',
+        branch_id: 'message-branch-target-session'
+      },
+      runtime: { attached: false }
+    })
+    expect(repo.readSession).toHaveBeenCalledWith('project-a', 'target-session')
+    expect(repo.readProject).not.toHaveBeenCalled()
+    expect(JSON.stringify(result)).not.toMatch(/message message-1|transcript|messages/u)
+  })
+
+  it('fails closed for incomplete authority, unreadable exact Sessions, and non-Main callers', async () => {
+    const target = session()
+    const incomplete = new HostSessionsService(
+      {
+        readProject: vi.fn(async () => ({ sessions: [target], isComplete: false })),
+        readSession: vi.fn(async () => ({ status: 'unreadable' as const }))
+      },
+      { getSnapshot: () => undefined }
+    )
+
+    await expect(incomplete.list({}, context)).rejects.toThrow('cannot complete')
+    await expect(incomplete.inspect('session-1', context)).rejects.toThrow('unreadable')
+    await expect(incomplete.list({}, { ...context, callerRole: 'delegate' })).rejects.toThrow(
+      'Main only'
+    )
+    await expect(
+      incomplete.inspect('session-1', { ...context, callerRole: 'delegate' })
+    ).rejects.toThrow('Main only')
+
+    const missing = new HostSessionsService(
+      {
+        readProject: vi.fn(),
+        readSession: vi.fn(async () => ({ status: 'missing' as const }))
+      },
+      { getSnapshot: () => undefined }
+    )
+    await expect(missing.inspect('session-1', context)).rejects.toThrow(
+      'not found in the current Project'
+    )
+  })
+
+  it('rejects malformed and authority-bearing inputs at the Module boundary', async () => {
+    const service = new HostSessionsService(repository([session()]), {
+      getSnapshot: () => undefined
+    })
+    for (const options of [
+      null,
+      { project_id: 'other' },
+      { archived: 'invalid' },
+      { search: '' },
+      { limit: 0 },
+      { limit: 101 },
+      { cursor: 'not-a-cursor' }
+    ]) {
+      await expect(service.list(options, context)).rejects.toThrow(/host\.sessions\.list/u)
+    }
+    for (const sessionId of ['', 1, 'x'.repeat(513)]) {
+      await expect(service.inspect(sessionId, context)).rejects.toThrow(/session_id/u)
+    }
+  })
+
+  it('omits provider-defined observation status values instead of exporting payload text', async () => {
+    const service = new HostSessionsService(repository([session()]), {
+      getSnapshot: () =>
+        snapshot({
+          events: [
+            {
+              id: 'event-private-status',
+              sessionId: 'session-1',
+              timestamp: 200,
+              kind: 'raw',
+              level: 'warning',
+              status: 'SECRET_PROVIDER_VALUE'
+            }
+          ],
+          pendingPermissions: []
+        })
+    })
+
+    const result = await service.inspect('session-1', context)
+
+    expect(result).toMatchObject({
+      latest_observation: {
+        timestamp: new Date(200).toISOString(),
+        kind: 'raw',
+        level: 'warning'
+      }
+    })
+    expect(JSON.stringify(result)).not.toContain('SECRET_PROVIDER_VALUE')
+  })
+
+  it('uses the existing legacy Session normalization for host.frames navigation identifiers', async () => {
+    const legacy = session()
+    delete legacy.conversationGraph
+    const normalized = normalizeSessionFile(legacy, { preserveRuntimeState: true })
+    expect(normalized).toBeDefined()
+    const service = new HostSessionsService(repository([normalized!]), {
+      getSnapshot: () => undefined
+    })
+
+    await expect(service.inspect('session-1', context)).resolves.toMatchObject({
+      active_conversation: {
+        frame_id: 'root-frame-session-1',
+        branch_id: 'message-branch-session-1',
+        message_count: 1
+      }
+    })
+  })
+})

--- a/src/main/notebook/host-sessions-service.test.ts
+++ b/src/main/notebook/host-sessions-service.test.ts
@@ -134,11 +134,51 @@ describe('HostSessionsService', () => {
     expect(JSON.stringify(await service.list({}, context))).not.toMatch(/SECRET|\/private/u)
   })
 
+  it('projects the graph active Frame instead of forcing root Frame navigation', async () => {
+    const target = session()
+    const graph = target.conversationGraph!
+    graph.frames.push({
+      id: 'reviewer-frame',
+      parentFrameId: graph.rootFrameId,
+      originMessageId: 'message-1',
+      originBindingState: 'validated',
+      kind: 'reviewer',
+      status: 'running',
+      activeBranchId: 'reviewer-branch',
+      createdAt: 201
+    })
+    graph.branches.push({
+      id: 'reviewer-branch',
+      agentFrameId: 'reviewer-frame',
+      headMessageId: 'reviewer-message',
+      createdAt: 201,
+      updatedAt: 202
+    })
+    graph.messages.push({
+      ...message('reviewer-message', 202),
+      agentFrameId: 'reviewer-frame',
+      introducedOnBranchId: 'reviewer-branch'
+    })
+    graph.activeFrameId = 'reviewer-frame'
+    const service = new HostSessionsService(repository([target]), {
+      getSnapshot: () => undefined
+    })
+
+    await expect(service.inspect('session-1', context)).resolves.toMatchObject({
+      active_conversation: {
+        frame_id: 'reviewer-frame',
+        branch_id: 'reviewer-branch',
+        message_count: 1
+      }
+    })
+  })
+
   it('filters, orders, and paginates the Session catalog with snapshot-bound cursors', async () => {
     const sessions = [
       session({ id: 'session-b', title: 'Genomics beta', updatedAt: 300 }),
       session({ id: 'session-a', title: 'Genomics alpha', updatedAt: 300 }),
       session({ id: 'session-c', title: 'Unrelated', updatedAt: 100 }),
+      session({ id: 'session-special-identity', title: 'Identity only', updatedAt: 100 }),
       session({
         id: 'session-archived',
         title: 'Genomics archive',
@@ -173,6 +213,16 @@ describe('HostSessionsService', () => {
     await expect(
       service.list({ archived: 'include', search: 'gen' }, context)
     ).resolves.toMatchObject({ total_count: 3 })
+    await expect(service.list({ search: 'special' }, context)).resolves.toMatchObject({
+      total_count: 0,
+      sessions: []
+    })
+    await expect(
+      service.list({ search: 'session-special-identity' }, context)
+    ).resolves.toMatchObject({
+      total_count: 1,
+      sessions: [expect.objectContaining({ session_id: 'session-special-identity' })]
+    })
     await expect(service.list({ limit: 2, cursor: first.next_cursor }, context)).rejects.toThrow(
       'cursor does not match'
     )

--- a/src/main/notebook/host-sessions-service.ts
+++ b/src/main/notebook/host-sessions-service.ts
@@ -144,7 +144,7 @@ const latestSessionEvent = (
 const activeConversation = (session: PersistedChatSession): unknown => {
   const graph = session.conversationGraph
   if (!graph) return undefined
-  const frame = graph.frames.find((candidate) => candidate.id === graph.rootFrameId)
+  const frame = graph.frames.find((candidate) => candidate.id === graph.activeFrameId)
   if (!frame) return undefined
   const branch = graph.branches.find(
     (candidate) => candidate.id === frame.activeBranchId && candidate.agentFrameId === frame.id
@@ -224,7 +224,8 @@ class HostSessionsService {
         if (normalized.archived === 'only' && session.archivedAt === undefined) return false
         if (
           normalized.search &&
-          ![session.title, session.id].some((value) => fuzzyScore(normalized.search!, value))
+          session.id !== normalized.search &&
+          !fuzzyScore(normalized.search, session.title)
         ) {
           return false
         }

--- a/src/main/notebook/host-sessions-service.ts
+++ b/src/main/notebook/host-sessions-service.ts
@@ -1,0 +1,296 @@
+import { createHash } from 'node:crypto'
+
+import type { AcpRuntimeEvent, AcpStateSnapshot } from '../../shared/acp'
+import { resolveMessageBranchPath } from '../../shared/conversation-graph'
+import { fuzzyScore } from '../../shared/fuzzy-match'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+
+type HostSessionReadContext = Readonly<{
+  projectId: string
+  sessionId: string
+  callerRole: 'main' | 'delegate'
+}>
+
+type HostSessionsSessionDiagnostic =
+  | { status: 'found'; session: PersistedChatSession }
+  | { status: 'missing' }
+  | { status: 'unreadable' }
+
+type HostSessionsRepository = {
+  readProject(projectId: string): Promise<{
+    sessions: PersistedChatSession[]
+    isComplete: boolean
+  }>
+  readSession(projectId: string, sessionId: string): Promise<HostSessionsSessionDiagnostic>
+}
+
+type HostSessionsRuntime = {
+  getSnapshot(): AcpStateSnapshot | undefined
+}
+
+type ArchivedFilter = 'exclude' | 'include' | 'only'
+
+type NormalizedListOptions = {
+  archived: ArchivedFilter
+  search?: string
+  limit: number
+  cursor?: string
+}
+
+type ListCursor = {
+  version: 1
+  queryKey: string
+  snapshotKey: string
+  offset: number
+}
+
+const DEFAULT_LIST_LIMIT = 20
+const MAX_LIST_LIMIT = 100
+const LIST_OPTION_KEYS = new Set(['archived', 'search', 'limit', 'cursor'])
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const optionalString = (
+  value: Record<string, unknown>,
+  key: string,
+  maxLength: number
+): string | undefined => {
+  const candidate = value[key]
+  if (candidate === undefined) return undefined
+  if (typeof candidate !== 'string' || candidate.length === 0 || candidate.length > maxLength) {
+    throw new Error(`host.sessions.list ${key} must be a non-empty string.`)
+  }
+  return candidate
+}
+
+const normalizeListOptions = (value: unknown): NormalizedListOptions => {
+  if (value === undefined) value = {}
+  if (!isRecord(value)) throw new Error('host.sessions.list options must be an object.')
+  const unknown = Object.keys(value).find((key) => !LIST_OPTION_KEYS.has(key))
+  if (unknown) throw new Error(`host.sessions.list unknown option: ${unknown}`)
+  const archived = value.archived ?? 'exclude'
+  if (!['exclude', 'include', 'only'].includes(archived as string)) {
+    throw new Error('host.sessions.list archived must be exclude, include, or only.')
+  }
+  const search = optionalString(value, 'search', 256)
+  const cursor = optionalString(value, 'cursor', 4096)
+  const limit = value.limit ?? DEFAULT_LIST_LIMIT
+  if (!Number.isInteger(limit) || (limit as number) < 1 || (limit as number) > MAX_LIST_LIMIT) {
+    throw new Error(`host.sessions.list limit must be an integer between 1 and ${MAX_LIST_LIMIT}.`)
+  }
+  return { archived: archived as ArchivedFilter, search, limit: limit as number, cursor }
+}
+
+const fingerprint = (value: unknown): string =>
+  createHash('sha256').update(JSON.stringify(value)).digest('base64url')
+
+const encodeCursor = (cursor: ListCursor): string =>
+  Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url')
+
+const decodeCursor = (value: string, queryKey: string): ListCursor => {
+  let cursor: unknown
+  try {
+    cursor = JSON.parse(Buffer.from(value, 'base64url').toString('utf8')) as unknown
+  } catch {
+    throw new Error('host.sessions.list cursor is invalid.')
+  }
+  if (
+    !isRecord(cursor) ||
+    cursor.version !== 1 ||
+    cursor.queryKey !== queryKey ||
+    typeof cursor.snapshotKey !== 'string' ||
+    !Number.isInteger(cursor.offset) ||
+    (cursor.offset as number) < 0
+  ) {
+    throw new Error('host.sessions.list cursor does not match the requested filters.')
+  }
+  return cursor as ListCursor
+}
+
+const toIso = (timestamp: number): string => new Date(timestamp).toISOString()
+
+const SAFE_OBSERVATION_STATUSES = new Set([
+  'pending',
+  'in_progress',
+  'completed',
+  'failed',
+  'cancelled',
+  'running',
+  'idle',
+  'error',
+  'waiting',
+  'approved',
+  'declined',
+  'queued',
+  'confirmed'
+])
+
+const safeObservationStatus = (value: string | undefined): string | undefined =>
+  value && SAFE_OBSERVATION_STATUSES.has(value) ? value : undefined
+
+const latestSessionEvent = (
+  events: readonly AcpRuntimeEvent[],
+  sessionId: string
+): AcpRuntimeEvent | undefined => {
+  let latest: AcpRuntimeEvent | undefined
+  for (const event of events) {
+    if (event.sessionId !== sessionId) continue
+    if (!latest || event.timestamp >= latest.timestamp) latest = event
+  }
+  return latest
+}
+
+const activeConversation = (session: PersistedChatSession): unknown => {
+  const graph = session.conversationGraph
+  if (!graph) return undefined
+  const frame = graph.frames.find((candidate) => candidate.id === graph.rootFrameId)
+  if (!frame) return undefined
+  const branch = graph.branches.find(
+    (candidate) => candidate.id === frame.activeBranchId && candidate.agentFrameId === frame.id
+  )
+  if (!branch) return undefined
+  return {
+    frame_id: frame.id,
+    branch_id: branch.id,
+    message_count: resolveMessageBranchPath(graph, branch.id).length
+  }
+}
+
+const sessionProjection = (
+  session: PersistedChatSession,
+  snapshot: AcpStateSnapshot | undefined
+): unknown => {
+  const sessionIds = snapshot?.sessionIds ?? []
+  const promptInFlightSessionIds = snapshot?.promptInFlightSessionIds ?? []
+  const agentPromptInFlightSessionIds = snapshot?.agentPromptInFlightSessionIds ?? []
+  const event = latestSessionEvent(snapshot?.events ?? [], session.id)
+  const observationStatus = safeObservationStatus(event?.status)
+  const conversation = activeConversation(session)
+
+  return {
+    session_id: session.id,
+    title: session.title,
+    status: session.status,
+    created_at: toIso(session.createdAt),
+    updated_at: toIso(session.updatedAt),
+    ...(session.archivedAt === undefined ? {} : { archived_at: toIso(session.archivedAt) }),
+    ...(session.activeRun ? { active_run_started_at: toIso(session.activeRun.startedAt) } : {}),
+    runtime: {
+      attached: sessionIds.includes(session.id),
+      ...(snapshot?.sessionConnectionStatuses?.[session.id]
+        ? { connection_status: snapshot.sessionConnectionStatuses[session.id] }
+        : {}),
+      prompt_in_flight: promptInFlightSessionIds.includes(session.id),
+      agent_prompt_in_flight: agentPromptInFlightSessionIds.includes(session.id),
+      permission_pending:
+        snapshot?.pendingPermissions.some((request) => request.sessionId === session.id) ?? false,
+      user_input_pending:
+        snapshot?.pendingElicitations?.some((request) => request.sessionId === session.id) ?? false
+    },
+    ...(conversation ? { active_conversation: conversation } : {}),
+    ...(event
+      ? {
+          latest_observation: {
+            timestamp: toIso(event.timestamp),
+            kind: event.kind,
+            level: event.level,
+            ...(observationStatus ? { status: observationStatus } : {})
+          }
+        }
+      : {})
+  }
+}
+
+class HostSessionsService {
+  constructor(
+    private readonly repository: HostSessionsRepository,
+    private readonly runtime: HostSessionsRuntime
+  ) {}
+
+  async list(options: unknown, context: HostSessionReadContext): Promise<unknown> {
+    if (context.callerRole !== 'main') throw new Error('host.sessions is available to Main only.')
+    const normalized = normalizeListOptions(options)
+
+    const project = await this.repository.readProject(context.projectId)
+    if (!project.isComplete) {
+      throw new Error(
+        'host.sessions.list cannot complete because a current Project Session is unreadable.'
+      )
+    }
+    const sessions = project.sessions
+      .filter((session) => {
+        if (normalized.archived === 'exclude' && session.archivedAt !== undefined) return false
+        if (normalized.archived === 'only' && session.archivedAt === undefined) return false
+        if (
+          normalized.search &&
+          ![session.title, session.id].some((value) => fuzzyScore(normalized.search!, value))
+        ) {
+          return false
+        }
+        return true
+      })
+      .sort(
+        (left, right) =>
+          right.updatedAt - left.updatedAt ||
+          (left.id === right.id ? 0 : left.id < right.id ? -1 : 1)
+      )
+    const snapshot = this.runtime.getSnapshot()
+    const projections = sessions.map((session) => sessionProjection(session, snapshot))
+    const queryKey = JSON.stringify({
+      projectId: context.projectId,
+      archived: normalized.archived,
+      search: normalized.search
+    })
+    const snapshotKey = fingerprint(projections)
+    const cursor = normalized.cursor ? decodeCursor(normalized.cursor, queryKey) : undefined
+    if (cursor && cursor.snapshotKey !== snapshotKey) {
+      throw new Error('host.sessions.list cursor is no longer valid.')
+    }
+    const offset = cursor?.offset ?? 0
+    if (offset > projections.length) {
+      throw new Error('host.sessions.list cursor is no longer valid.')
+    }
+    const page = projections.slice(offset, offset + normalized.limit)
+    const nextOffset = offset + page.length
+    return {
+      total_count: projections.length,
+      ...(nextOffset < projections.length
+        ? {
+            next_cursor: encodeCursor({
+              version: 1,
+              queryKey,
+              snapshotKey,
+              offset: nextOffset
+            })
+          }
+        : {}),
+      sessions: page
+    }
+  }
+
+  async inspect(sessionId: unknown, context: HostSessionReadContext): Promise<unknown> {
+    if (context.callerRole !== 'main') throw new Error('host.sessions is available to Main only.')
+    if (typeof sessionId !== 'string' || sessionId.length === 0 || sessionId.length > 512) {
+      throw new Error(
+        'host.sessions.inspect session_id must be a non-empty string of at most 512 characters.'
+      )
+    }
+    const diagnostic = await this.repository.readSession(context.projectId, sessionId)
+    if (diagnostic.status === 'unreadable') {
+      throw new Error(`Session is unreadable in the current Project: ${sessionId}`)
+    }
+    if (diagnostic.status === 'missing') {
+      throw new Error(`Session not found in the current Project: ${sessionId}`)
+    }
+    return sessionProjection(diagnostic.session, this.runtime.getSnapshot())
+  }
+}
+
+export { HostSessionsService }
+export type {
+  HostSessionReadContext,
+  HostSessionsRepository,
+  HostSessionsRuntime,
+  HostSessionsSessionDiagnostic
+}

--- a/src/main/notebook/local-rpc-server.capabilities.test.ts
+++ b/src/main/notebook/local-rpc-server.capabilities.test.ts
@@ -56,6 +56,7 @@ describe('capabilitiesCall RPC', () => {
       hostArtifacts: {} as never,
       hostLineage: {} as never,
       hostFrames: {} as never,
+      hostSessions: {} as never,
       hostModel: {
         isLlmAvailable: async () => true,
         isCurrentModelAvailable: async () => true,
@@ -87,6 +88,7 @@ describe('capabilitiesCall RPC', () => {
         artifacts: true,
         lineage: true,
         frames: true,
+        sessions: true,
         llm: true,
         currentModel: true,
         listModels: true,
@@ -172,6 +174,31 @@ describe('capabilitiesCall RPC', () => {
 
     await expect(callCapabilities(connection)).resolves.toMatchObject({
       payload: { result: { frames: false } }
+    })
+  })
+
+  it('does not advertise Host Session diagnostics to ordinary or delegate control tokens', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostSessions: {} as never
+    })
+    const ordinary = await server.issueSessionConnection(
+      'trusted-session',
+      'trusted-project',
+      'root-frame-trusted-session'
+    )
+    const delegate = await server.issueControlConnection(
+      'trusted-session',
+      'trusted-project',
+      'delegate-frame',
+      { role: 'delegate', attemptId: 'attempt-1' }
+    )
+
+    await expect(callCapabilities(ordinary)).resolves.toMatchObject({
+      payload: { result: { sessions: false } }
+    })
+    await expect(callCapabilities(delegate)).resolves.toMatchObject({
+      payload: { result: { sessions: false } }
     })
   })
 

--- a/src/main/notebook/local-rpc-server.capabilities.test.ts
+++ b/src/main/notebook/local-rpc-server.capabilities.test.ts
@@ -278,6 +278,29 @@ describe('capabilitiesCall RPC', () => {
     })
   })
 
+  it('reports host.sessions as available through authenticated host.help', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostSessions: {} as never
+    })
+    const connection = await server.issueControlConnection(
+      'trusted-session',
+      'trusted-project',
+      'root-frame-trusted-session'
+    )
+
+    await expect(callHostSdkHelp(connection, 'sessions')).resolves.toMatchObject({
+      response: { status: 200 },
+      payload: {
+        result: {
+          kind: 'operation',
+          id: 'host.sessions',
+          availability: { status: 'available' }
+        }
+      }
+    })
+  })
+
   it('does not advertise host.viewImage without a trusted execution workspace', async () => {
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
       transport: 'tcp',

--- a/src/main/notebook/local-rpc-server.delegated-work.test.ts
+++ b/src/main/notebook/local-rpc-server.delegated-work.test.ts
@@ -132,6 +132,7 @@ describe('authenticated delegatedWorkCall route', () => {
       'host.llm': 'unavailable',
       'host.messageReceipt': 'unavailable',
       'host.resolveMessage': 'unavailable',
+      'host.sessions': 'unavailable',
       'host.sendFrameMessage': 'unavailable',
       'host.stopChild': 'unavailable',
       'host.submitOutput': 'unavailable',

--- a/src/main/notebook/local-rpc-server.sessions.test.ts
+++ b/src/main/notebook/local-rpc-server.sessions.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { NotebookLocalRpcServer } from './local-rpc-server'
+
+type RpcConnection = { endpoint: string; token: string; release?: () => void }
+
+const callSessions = async (
+  connection: RpcConnection,
+  token: string,
+  params: Record<string, unknown>
+): Promise<{ response: Response; payload: Record<string, unknown> }> => {
+  const response = await fetch(connection.endpoint, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ method: 'sessionsCall', params })
+  })
+  return { response, payload: (await response.json()) as Record<string, unknown> }
+}
+
+let server: NotebookLocalRpcServer | undefined
+
+afterEach(async () => {
+  await server?.close()
+  server = undefined
+})
+
+describe('sessionsCall RPC', () => {
+  it('uses only the Main control token identity for list and inspect operations', async () => {
+    const list = vi.fn(async () => ({ sessions: [] }))
+    const inspect = vi.fn(async () => ({ session_id: 'target-session' }))
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostSessions: { list, inspect }
+    })
+    const control = await server.issueControlConnection(
+      'trusted-session',
+      'trusted-project',
+      'root-frame-trusted-session'
+    )
+
+    await expect(
+      callSessions(control, control.token, {
+        op: 'list',
+        options: { archived: 'include' },
+        projectId: 'forged-project',
+        sessionId: 'forged-session',
+        callerRole: 'delegate'
+      })
+    ).resolves.toMatchObject({ response: { status: 200 }, payload: { result: { sessions: [] } } })
+    expect(list).toHaveBeenCalledWith(
+      { archived: 'include' },
+      { projectId: 'trusted-project', sessionId: 'trusted-session', callerRole: 'main' }
+    )
+
+    await expect(
+      callSessions(control, control.token, {
+        op: 'inspect',
+        session_id: 'target-session',
+        projectId: 'forged-project'
+      })
+    ).resolves.toMatchObject({ response: { status: 200 } })
+    expect(inspect).toHaveBeenCalledWith('target-session', {
+      projectId: 'trusted-project',
+      sessionId: 'trusted-session',
+      callerRole: 'main'
+    })
+  })
+
+  it('rejects bootstrap, ordinary Session, delegate control, and released capabilities', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostSessions: { list: vi.fn(), inspect: vi.fn() }
+    })
+    const bootstrap = await server.ensureStarted()
+    const ordinary = await server.issueSessionConnection(
+      'trusted-session',
+      'trusted-project',
+      'root-frame-trusted-session'
+    )
+    const main = await server.issueControlConnection(
+      'trusted-session',
+      'trusted-project',
+      'root-frame-trusted-session'
+    )
+    const delegate = await server.issueControlConnection(
+      'trusted-session',
+      'trusted-project',
+      'delegate-frame',
+      { role: 'delegate', attemptId: 'attempt-1' }
+    )
+    const params = { op: 'list', options: {} }
+
+    await expect(callSessions(main, bootstrap.token, params)).resolves.toMatchObject({
+      response: { status: 401 },
+      payload: { error: 'A session-bound notebook RPC token is required.' }
+    })
+    await expect(callSessions(main, ordinary.token, params)).resolves.toMatchObject({
+      response: { status: 403 },
+      payload: { error: 'host.sessions requires a Main control-plane REPL capability.' }
+    })
+    await expect(callSessions(delegate, delegate.token, params)).resolves.toMatchObject({
+      response: { status: 403 },
+      payload: { error: 'host.sessions requires a Main control-plane REPL capability.' }
+    })
+
+    main.release()
+    await expect(callSessions(main, main.token, params)).resolves.toMatchObject({
+      response: { status: 401 },
+      payload: { error: 'Invalid notebook RPC token.' }
+    })
+    ordinary.release?.()
+    delegate.release()
+  })
+
+  it('fails closed and does not advertise Session diagnostics when the service is unavailable', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp'
+    })
+    const control = await server.issueControlConnection(
+      'trusted-session',
+      'trusted-project',
+      'root-frame-trusted-session'
+    )
+
+    const capabilityResponse = await fetch(control.endpoint, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${control.token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ method: 'capabilitiesCall', params: {} })
+    })
+    await expect(capabilityResponse.json()).resolves.toMatchObject({
+      result: { sessions: false }
+    })
+    await expect(
+      callSessions(control, control.token, { op: 'list', options: {} })
+    ).resolves.toMatchObject({
+      response: { status: 500 },
+      payload: { error: 'Host Session diagnostics are not configured.' }
+    })
+  })
+})

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -204,6 +204,16 @@ type NotebookLocalRpcServerOptions = {
       context: { projectId: string; sessionId: string }
     ): Promise<unknown>
   }
+  hostSessions?: {
+    list(
+      options: unknown,
+      context: { projectId: string; sessionId: string; callerRole: 'main' }
+    ): Promise<unknown>
+    inspect(
+      sessionId: unknown,
+      context: { projectId: string; sessionId: string; callerRole: 'main' }
+    ): Promise<unknown>
+  }
   // host.agents control-plane SDK (issue 02): exposes the Specialist/catalog surface to the
   // JavaScript control-plane REPL via the extensible dispatcher. Never routed through host.mcp();
   // carries the trusted calling session identity captured outside the sandbox so switch()
@@ -353,6 +363,7 @@ const CONTROL_RPC_METHODS = new Set([
   'artifactsCall',
   'lineageCall',
   'framesCall',
+  'sessionsCall',
   'mcpCall',
   'computeCall',
   'agentsCall',
@@ -446,6 +457,7 @@ class NotebookLocalRpcServer {
   private readonly hostArtifacts: NotebookLocalRpcServerOptions['hostArtifacts']
   private readonly hostLineage: NotebookLocalRpcServerOptions['hostLineage']
   private readonly hostFrames: NotebookLocalRpcServerOptions['hostFrames']
+  private readonly hostSessions: NotebookLocalRpcServerOptions['hostSessions']
   private readonly agentsService: NotebookLocalRpcServerOptions['agentsService']
   private readonly delegatedWorkService: NotebookLocalRpcServerOptions['delegatedWorkService']
   private readonly skillsService: NotebookLocalRpcServerOptions['skillsService']
@@ -496,6 +508,7 @@ class NotebookLocalRpcServer {
     this.hostArtifacts = options.hostArtifacts
     this.hostLineage = options.hostLineage
     this.hostFrames = options.hostFrames
+    this.hostSessions = options.hostSessions
     this.agentsService = options.agentsService
     this.delegatedWorkService = options.delegatedWorkService
     this.skillsService = options.skillsService
@@ -1286,6 +1299,7 @@ class NotebookLocalRpcServer {
         artifacts: Boolean(this.hostArtifacts),
         lineage: Boolean(this.hostLineage),
         frames: Boolean(this.hostFrames),
+        sessions: Boolean(this.hostSessions),
         llm: Boolean(this.hostModel) && (await this.hostModel!.isLlmAvailable()),
         currentModel:
           Boolean(this.hostModel) &&
@@ -1404,6 +1418,15 @@ class NotebookLocalRpcServer {
           }
           if (method === 'framesCall' && !sessionBinding.isControl) {
             throw new RpcHttpError(403, 'host.frames requires a control-plane REPL capability.')
+          }
+          if (
+            method === 'sessionsCall' &&
+            (!sessionBinding.isControl || sessionBinding.delegatedWorkRole === 'delegate')
+          ) {
+            throw new RpcHttpError(
+              403,
+              'host.sessions requires a Main control-plane REPL capability.'
+            )
           }
           if (
             (method === 'llmCall' ||
@@ -1867,6 +1890,19 @@ class NotebookLocalRpcServer {
       if (params.op === 'list') return this.hostFrames.list(params.options, context)
       if (params.op === 'get') return this.hostFrames.get(params.frame_id, params.options, context)
       throw new Error('Unknown host Frame operation.')
+    }
+
+    if (method === 'sessionsCall') {
+      if (!this.hostSessions) throw new Error('Host Session diagnostics are not configured.')
+      const projectId = typeof params.projectId === 'string' ? params.projectId : ''
+      const sessionId = typeof params.sessionId === 'string' ? params.sessionId : ''
+      if (!projectId || !sessionId) {
+        throw new Error('Host Session diagnostics require a session-bound Project scope.')
+      }
+      const context = { projectId, sessionId, callerRole: 'main' as const }
+      if (params.op === 'list') return this.hostSessions.list(params.options, context)
+      if (params.op === 'inspect') return this.hostSessions.inspect(params.session_id, context)
+      throw new Error('Unknown host Session operation.')
     }
 
     if (method === 'llmCall') {

--- a/src/main/notebook/repl-loop.integration.test.ts
+++ b/src/main/notebook/repl-loop.integration.test.ts
@@ -2200,6 +2200,139 @@ describe('repl_loop local RPC transport', () => {
     }
   }, 60_000)
 
+  it('validates and freezes camelCase host.sessions list and inspect projections', async () => {
+    const requests: Array<{ method?: string; params?: Record<string, unknown> }> = []
+    const session = {
+      session_id: 'session-a',
+      title: 'Research session',
+      status: 'running',
+      created_at: '2026-08-01T00:00:00.000Z',
+      updated_at: '2026-08-01T00:01:00.000Z',
+      active_run_started_at: '2026-08-01T00:00:30.000Z',
+      runtime: {
+        attached: true,
+        connection_status: 'connected',
+        prompt_in_flight: true,
+        agent_prompt_in_flight: true,
+        permission_pending: false,
+        user_input_pending: false
+      },
+      active_conversation: {
+        frame_id: 'frame-1',
+        branch_id: 'branch-1',
+        message_count: 2
+      },
+      latest_observation: {
+        timestamp: '2026-08-01T00:00:45.000Z',
+        kind: 'tool',
+        level: 'info',
+        status: 'in_progress'
+      }
+    }
+    const server = createServer((request, response) => {
+      let body = ''
+      request.on('data', (chunk) => (body += chunk))
+      request.on('end', () => {
+        const parsed = JSON.parse(body) as {
+          method?: string
+          params?: Record<string, unknown>
+        }
+        requests.push(parsed)
+        const result =
+          requests.length === 3
+            ? { total_count: 0, sessions: [], private_path: '/private' }
+            : parsed.params?.op === 'inspect'
+              ? session
+              : { total_count: 1, next_cursor: 'next', sessions: [session] }
+        response
+          .writeHead(200, { 'content-type': 'application/json' })
+          .end(JSON.stringify({ result }))
+      })
+    })
+    const connection = await listenForLocalRpc(server, {
+      name: 'repl-loop-sessions-test',
+      transport: 'pipe'
+    })
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: connection.endpoint,
+      OPEN_SCIENCE_MCP_RPC_SOCKET_PATH: connection.socketPath,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: 'test-token'
+    })
+
+    try {
+      const projection = await send(
+        "const page = await host.sessions.list({ archived: 'include', search: 'research', limit: 2 }); " +
+          "const detail = await host.sessions.inspect('session-a'); " +
+          'return JSON.stringify({ page, detail, pageFrozen: Object.isFrozen(page), ' +
+          'sessionsFrozen: Object.isFrozen(page.sessions), sessionFrozen: Object.isFrozen(page.sessions[0]), ' +
+          'detailFrozen: Object.isFrozen(detail), runtimeFrozen: Object.isFrozen(detail.runtime), ' +
+          'conversationFrozen: Object.isFrozen(detail.activeConversation), ' +
+          'observationFrozen: Object.isFrozen(detail.latestObservation) })'
+      )
+      expect(projection.error).toBeNull()
+      expect(JSON.parse(projection.result ?? '{}')).toMatchObject({
+        page: {
+          totalCount: 1,
+          nextCursor: 'next',
+          sessions: [{ sessionId: 'session-a', activeRunStartedAt: expect.any(String) }]
+        },
+        detail: {
+          sessionId: 'session-a',
+          runtime: { connectionStatus: 'connected', promptInFlight: true },
+          activeConversation: { frameId: 'frame-1', branchId: 'branch-1', messageCount: 2 },
+          latestObservation: { kind: 'tool', status: 'in_progress' }
+        },
+        pageFrozen: true,
+        sessionsFrozen: true,
+        sessionFrozen: true,
+        detailFrozen: true,
+        runtimeFrozen: true,
+        conversationFrozen: true,
+        observationFrozen: true
+      })
+      expect(requests).toEqual([
+        {
+          method: 'sessionsCall',
+          params: {
+            op: 'list',
+            options: { archived: 'include', search: 'research', limit: 2 }
+          }
+        },
+        {
+          method: 'sessionsCall',
+          params: { op: 'inspect', session_id: 'session-a' }
+        }
+      ])
+
+      const oldOptions = await send(
+        'const errors = []; for (const call of [' +
+          "() => host.sessions.list({ projectId: 'project-a' }), " +
+          "() => host.sessions.list({ project_id: 'project-a' }), " +
+          "() => host.sessions.inspect('session-a', {})]) { " +
+          "try { await call() } catch (error) { errors.push(error.name + ': ' + error.message) } } " +
+          'return JSON.stringify(errors)'
+      )
+      expect(JSON.parse(oldOptions.result ?? '[]')).toEqual([
+        'TypeError: host.sessions.list options unknown option: projectId',
+        'TypeError: host.sessions.list options unknown option: project_id',
+        'TypeError: host.sessions.inspect accepts one sessionId'
+      ])
+      expect(requests).toHaveLength(2)
+
+      const invalid = await send(
+        "try { await host.sessions.list(); return 'no error' } " +
+          'catch (error) { return error.message }'
+      )
+      expect(invalid.result).toBe('host.sessions.list returned an invalid result')
+      expect(requests).toHaveLength(3)
+    } finally {
+      child.kill()
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      )
+    }
+  }, 60_000)
+
   it('routes host.skills through its native skillsCall method', async () => {
     const requests: { method?: string; params?: Record<string, unknown> }[] = []
     const server = createServer((request, response) => {

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -641,6 +641,7 @@ describe('Settings backend ownership architecture', () => {
       'artifactsCall',
       'lineageCall',
       'framesCall',
+      'sessionsCall',
       'mcpCall',
       'computeCall',
       'agentsCall',

--- a/src/main/skills/self-awareness-skill.test.ts
+++ b/src/main/skills/self-awareness-skill.test.ts
@@ -23,13 +23,13 @@ describe('self-awareness bundled Skill', () => {
     expect(skill?.description).toMatch(/JavaScript control REPL/i)
   })
 
-  it('documents the shipped 19-key JavaScript contract and read limits', async () => {
+  it('documents the shipped 20-key JavaScript contract and read limits', async () => {
     const body = await new SkillRegistry(skillsRoot).body('self-awareness')
 
     for (const phrase of [
       'repl_execute',
       'await host.capabilities()',
-      '19 known boolean keys',
+      '20 known boolean keys',
       '`mcp`',
       '`compute`',
       '`agents`',
@@ -37,6 +37,7 @@ describe('self-awareness bundled Skill', () => {
       '`artifacts`',
       '`lineage`',
       '`frames`',
+      '`sessions`',
       '`llm`',
       '`currentModel`',
       '`listModels`',
@@ -52,6 +53,8 @@ describe('self-awareness bundled Skill', () => {
       '`host.mcp(server, method, args?)`',
       '`host.artifacts(options?)`',
       '`host.artifactPath(versionId)`',
+      '`host.sessions.list(options?)`',
+      '`host.sessions.inspect(sessionId)`',
       '`host.llm(request, options?)`',
       '`host.currentModel()`',
       '`host.listModels()`',
@@ -59,10 +62,13 @@ describe('self-awareness bundled Skill', () => {
       'caps.compute === true',
       'caps.artifacts === true',
       'caps.frames === true',
+      'caps.sessions === true',
       'await host.artifacts(options)',
       'await host.artifactPath',
       'await host.frames.list(options)',
       'await host.frames.get(frameId, options)',
+      'await host.sessions.list(options)',
+      'await host.sessions.inspect(sessionId)',
       'current Project',
       'producer Frame',
       'Uploads without trusted Frame',
@@ -98,6 +104,7 @@ describe('self-awareness bundled Skill', () => {
       '`maxNodes`',
       '`rootsOnly`',
       '`branchId`',
+      '`activeConversation`',
       'graph discovery',
       'session-bound control token',
       'another Session',


### PR DESCRIPTION
## Problem

The Host SDK can inspect Frames and transcript structure, but it has no Project-scoped read model for discovering Sessions or understanding their current runtime state.

## Proposed change

- Add read-only `host.sessions.list(options?)` and `host.sessions.inspect(sessionId)`.
- Combine durable Session metadata with a bounded, sanitized ACP runtime overlay.
- Expose the capability only to the Main Agent through the shared Notebook control path.
- Keep transcript and branch traversal in `host.frames`.

## Scope and non-goals

- Session discovery is limited to the current Project; inspection is limited to the requested Session.
- No recovery, cancellation, message mutation, cross-project access, or delegate access.
- No new Session status enum values.
- No persistence, schema change, migration, or write path.
- Existing historical message data continues through the current graph normalization. Historical Sessions without live runtime evidence report that evidence as unavailable.

## Acceptance criteria and validation

- Session catalog/runtime overlay and RPC boundary: focused module suite — 75 passed, 53 skipped.
- REPL camelCase API and `host.frames` boundary: dedicated integration selection — 2 passed, 51 skipped.
- `npm run typecheck:node` — passed.
- `npm run lint` — passed.
- The affected-test classifier selects the full suite because `resources/notebook/repl_loop.js` is classified as unknown. Per maintainer guidance, the full suite is left to PR CI.
- The shared capability-owner matrix covers claude-code, opencode, codex-response, and codex-bridge.
- Local validation was performed on macOS; platform-specific transport/package lanes remain covered by PR CI.

## Review focus

- Sanitization and evidence bounds in `HostSessionsService`.
- Trusted Project/Session identity and Main-Agent-only authorization in the RPC layer.
- The boundary between Session diagnostics and transcript traversal through `host.frames`.
