### PR TITLE
fix(specialists): recover catalog load failures

### DIFF
--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -1094,6 +1094,7 @@
   "Open Open Science from the signed-in mobile app with two-step verification.": "从已登录的移动应用使用两步验证打开 Open Science。",
   "Open Provenance for {{title}}": "打开 {{title}} 的 Provenance",
   "Open Science confirms its core requirements before your first research session.": "Open Science 会在你的第一次研究会话前确认其核心依赖。",
+  "Open Science could not load Specialists. Retry to continue.": "Open Science 无法加载 Specialist。请重试。",
   "Open Science couldn't remove the unused copy. Normal work has resumed. You can delete the copy later.": "Open Science 无法删除未使用的副本。正常工作已恢复，你可以稍后删除该副本。",
   "Open Science couldn't start": "Open Science 无法启动",
   "Open Science is stopping background tasks and will close to finish installing. The update may take a moment; please don't reopen the app during this step. The updated app will reopen automatically.": "Open Science 正在停止后台任务，并将关闭以完成安装。更新可能需要一些时间，请勿在此期间重新打开应用。更新完成后应用会自动重新打开。",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -1092,6 +1092,7 @@
   "Open Open Science from the signed-in mobile app with two-step verification.": "從已登入的移動應用程式使用兩步驟驗證開啟 Open Science。",
   "Open Provenance for {{title}}": "開啟 {{title}} 的 Provenance",
   "Open Science confirms its core requirements before your first research session.": "Open Science 會在你的第一次研究會話前確認其核心依賴。",
+  "Open Science could not load Specialists. Retry to continue.": "Open Science 無法載入 Specialist。請重試。",
   "Open Science couldn't remove the unused copy. Normal work has resumed. You can delete the copy later.": "Open Science 無法刪除未使用的副本。正常工作已恢復，你可以稍後刪除該副本。",
   "Open Science couldn't start": "Open Science 無法啟動",
   "Open Science is stopping background tasks and will close to finish installing. The update may take a moment; please don't reopen the app during this step. The updated app will reopen automatically.": "Open Science 正在停止背景工作，並將關閉以完成安裝。更新可能需要一些時間，請勿在此期間重新開啟應用程式。更新完成後應用程式會自動重新開啟。",

--- a/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
@@ -140,6 +140,33 @@ describe('SpecialistsPanel', () => {
     }
   })
 
+  it('replaces a failed initial load with an actionable retry', async () => {
+    const list = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('specialist database unavailable'))
+      .mockResolvedValueOnce(specialistItems)
+    window.api.specialist.list = list
+    useSpecialistStore.setState({ items: [], isLoaded: false })
+
+    await act(async () => {
+      root.render(<SpecialistsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+    })
+
+    expect(document.body.textContent).toContain(
+      'Open Science could not load Specialists. Retry to continue.'
+    )
+    expect(document.body.textContent).not.toContain('Loading…')
+
+    const retry = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Retry'
+    )
+    expect(retry).toBeDefined()
+    await act(async () => fireEvent.click(retry!))
+
+    await vi.waitFor(() => expect(document.body.textContent).toContain('RNA Reviewer'))
+    expect(list).toHaveBeenCalledTimes(2)
+  })
+
   // Shared preview fixture: builtin + owned selected by default, referenced skill unchecked.
   const exportPreviewFixture = (
     overrides: Partial<{

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -133,6 +133,7 @@ const SpecialistsPanel = ({ view, onNavigate }: SpecialistsPanelProps): React.JS
 
   const items = useSpecialistStore((s) => s.items)
   const isLoaded = useSpecialistStore((s) => s.isLoaded)
+  const loadError = useSpecialistStore((s) => s.loadError)
   const load = useSpecialistStore((s) => s.load)
   const setEnabled = useSpecialistStore((s) => s.setEnabled)
   const createSpecialist = useSpecialistStore((s) => s.create)
@@ -1189,9 +1190,30 @@ const SpecialistsPanel = ({ view, onNavigate }: SpecialistsPanelProps): React.JS
         </DropdownMenu>
       </div>
 
-      {!isLoaded ? (
+      {loadError ? (
+        <div
+          role="alert"
+          className="mb-4 rounded-lg border border-danger-000/30 bg-danger-000/10 px-3 py-2 text-sm text-danger-000"
+        >
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+            <p>{t('Open Science could not load Specialists. Retry to continue.')}</p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="mt-3"
+            onClick={() => void load()}
+          >
+            {t('Retry')}
+          </Button>
+        </div>
+      ) : null}
+
+      {!isLoaded && !loadError ? (
         <p className="text-sm text-muted-foreground">{t('Loading…')}</p>
-      ) : (
+      ) : isLoaded ? (
         <div className="flex flex-col gap-6">
           {/* Custom specialists group */}
           {filter !== 'builtin' ? (
@@ -1415,7 +1437,7 @@ const SpecialistsPanel = ({ view, onNavigate }: SpecialistsPanelProps): React.JS
             </div>
           ) : null}
         </div>
-      )}
+      ) : null}
 
       {/* Delete confirmation dialog */}
       <AlertDialog.Root

--- a/src/renderer/src/stores/specialist-store.test.ts
+++ b/src/renderer/src/stores/specialist-store.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
   useSpecialistStore.setState({
     items: [],
     isLoaded: false,
+    loadError: undefined,
     packagePreview: undefined,
     exportPreview: undefined
   })
@@ -24,6 +25,79 @@ describe('specialist store catalog', () => {
 
     await expect(useSpecialistStore.getState().load()).resolves.toBeUndefined()
     expect(useSpecialistStore.getState()).toMatchObject({ items: [], isLoaded: true })
+  })
+
+  it('surfaces an initial load failure and recovers when the catalog is retried', async () => {
+    const items = [{ kind: 'reviewer' as const, id: 'reviewer' }]
+    const list = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('specialist database unavailable'))
+      .mockResolvedValueOnce(items)
+    setSpecialistApi({ list })
+
+    await expect(useSpecialistStore.getState().load()).rejects.toThrow(
+      'specialist database unavailable'
+    )
+    expect(useSpecialistStore.getState()).toMatchObject({
+      items: [],
+      isLoaded: false,
+      loadError: 'Open Science could not load Specialists. Retry to continue.'
+    })
+
+    await expect(useSpecialistStore.getState().load()).resolves.toBeUndefined()
+    expect(useSpecialistStore.getState()).toMatchObject({
+      items,
+      isLoaded: true,
+      loadError: undefined
+    })
+  })
+
+  it('keeps the latest overlapping catalog refresh authoritative', async () => {
+    let resolveFirst: ((items: [{ kind: 'reviewer'; id: string }]) => void) | undefined
+    let resolveSecond: ((items: [{ kind: 'reviewer'; id: string }]) => void) | undefined
+    setSpecialistApi({
+      list: vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<[{ kind: 'reviewer'; id: string }]>((resolve) => (resolveFirst = resolve))
+        )
+        .mockImplementationOnce(
+          () =>
+            new Promise<[{ kind: 'reviewer'; id: string }]>((resolve) => (resolveSecond = resolve))
+        )
+    })
+
+    const firstLoad = useSpecialistStore.getState().load()
+    const secondLoad = useSpecialistStore.getState().load()
+    resolveSecond?.([{ kind: 'reviewer', id: 'new-catalog' }])
+    await secondLoad
+    resolveFirst?.([{ kind: 'reviewer', id: 'stale-catalog' }])
+    await firstLoad
+
+    expect(useSpecialistStore.getState().items).toEqual([{ kind: 'reviewer', id: 'new-catalog' }])
+  })
+
+  it('prevents a pre-mutation load from overwriting the mutation refresh', async () => {
+    let resolveInitial: ((items: [{ kind: 'reviewer'; id: string }]) => void) | undefined
+    const refreshedItems = [{ kind: 'reviewer' as const, id: 'after-mutation' }]
+    setSpecialistApi({
+      list: vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<[{ kind: 'reviewer'; id: string }]>((resolve) => (resolveInitial = resolve))
+        )
+        .mockResolvedValueOnce(refreshedItems),
+      setEnabled: vi.fn().mockResolvedValue(undefined)
+    })
+
+    const initialLoad = useSpecialistStore.getState().load()
+    await useSpecialistStore.getState().setEnabled('researcher', true)
+    resolveInitial?.([{ kind: 'reviewer', id: 'before-mutation' }])
+    await initialLoad
+
+    expect(useSpecialistStore.getState().items).toEqual(refreshedItems)
   })
 })
 

--- a/src/renderer/src/stores/specialist-store.ts
+++ b/src/renderer/src/stores/specialist-store.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand'
+import { create, type StoreApi } from 'zustand'
 import type {
   SpecialistListItem,
   SpecialistProfileView,
@@ -17,6 +17,7 @@ import type {
 type SpecialistStoreData = {
   items: SpecialistListItem[]
   isLoaded: boolean
+  loadError: string | undefined
   packagePreview?: SpecialistPackageCandidatePreview
   exportPreview?: SpecialistExportPreview
 }
@@ -46,44 +47,66 @@ type SpecialistStoreActions = {
 
 type SpecialistStore = SpecialistStoreData & SpecialistStoreActions
 
+const SAFE_SPECIALIST_LOAD_ERROR = 'Open Science could not load Specialists. Retry to continue.'
+
+let latestCatalogRequest = 0
 let latestExportPreviewRequest = 0
+
+const refreshCatalog = async (set: StoreApi<SpecialistStore>['setState']): Promise<void> => {
+  const requestId = ++latestCatalogRequest
+  set({ loadError: undefined })
+  try {
+    const items = await window.api.specialist.list()
+    if (requestId === latestCatalogRequest) {
+      set({ items, isLoaded: true, loadError: undefined })
+    }
+  } catch (error) {
+    if (requestId === latestCatalogRequest) {
+      console.warn('Specialist catalog loading failed', error)
+      set({ loadError: SAFE_SPECIALIST_LOAD_ERROR })
+    }
+    throw error
+  }
+}
 
 const useSpecialistStore = create<SpecialistStore>((set) => ({
   items: [],
   isLoaded: false,
+  loadError: undefined,
   packagePreview: undefined,
   exportPreview: undefined,
 
-  load: async () => {
+  load: () => {
     // Guard: specialist.list is Electron-only and unavailable in the web gateway.
     if (typeof window.api?.specialist?.list !== 'function') {
-      set({ items: [], isLoaded: true })
-      return
+      latestCatalogRequest += 1
+      set({ items: [], isLoaded: true, loadError: undefined })
+      return Promise.resolve()
     }
-    const items = await window.api.specialist.list()
-    set({ items, isLoaded: true })
+    const request = refreshCatalog(set)
+    // Keep ignored startup/event refreshes handled while preserving rejection for
+    // callers that await load() before consuming the catalog.
+    void request.catch(() => undefined)
+    return request
   },
 
   create: async (input: CreateSpecialistInput) => {
     const view = await window.api.specialist.create(input)
     // Reload the full list so Reviewer and ordering stay consistent.
-    const items = await window.api.specialist.list()
-    set({ items })
+    await refreshCatalog(set)
     return view
   },
 
   update: async (input: UpdateSpecialistInput) => {
     const view = await window.api.specialist.update(input)
     // Reload the full list so Reviewer and ordering stay consistent.
-    const items = await window.api.specialist.list()
-    set({ items })
+    await refreshCatalog(set)
     return view
   },
 
   setEnabled: async (id: string, enabled: boolean) => {
     await window.api.specialist.setEnabled({ id, enabled })
-    const items = await window.api.specialist.list()
-    set({ items })
+    await refreshCatalog(set)
   },
 
   previewDelete: async (id: string) => window.api.specialist.previewDelete({ id }),
@@ -91,8 +114,7 @@ const useSpecialistStore = create<SpecialistStore>((set) => ({
   delete: async (id: string, expectedRevision: number, deleteSkillIds: readonly string[]) => {
     const result = await window.api.specialist.delete({ id, expectedRevision, deleteSkillIds })
     if (result.status === 'deleted') {
-      const items = await window.api.specialist.list()
-      set({ items })
+      await refreshCatalog(set)
     }
     return result
   },
@@ -113,8 +135,8 @@ const useSpecialistStore = create<SpecialistStore>((set) => ({
       ...(confirmOverwrite ? { confirmOverwrite: true as const } : {})
     })
     if (result.status === 'installed') {
-      const items = await window.api.specialist.list()
-      set({ items, packagePreview: undefined })
+      await refreshCatalog(set)
+      set({ packagePreview: undefined })
     }
     return result
   },


### PR DESCRIPTION
## Problem

The Specialist renderer store left `isLoaded` false when the initial catalog IPC request rejected, so the Settings panel stayed on its loading state with no error or recovery action. Catalog reads also committed unconditionally, allowing an older overlapping request to overwrite a newer snapshot.

## Proposed change

- Record a path-safe transient catalog load error and consume startup failures inside the store.
- Show an accessible Settings error with an explicit Retry action while preserving the fail-closed `isLoaded` contract.
- Fence every catalog read, including post-mutation refreshes, with one latest-request generation.
- Add store and render regression coverage for failure recovery, overlapping loads, and load-versus-mutation refresh races.
- Add Simplified and Traditional Chinese translations for the new user-visible message.

## Scope and non-goals

- No persistence, schema, migration, IPC, or shared domain-model changes.
- No new enum values and no historical-data compatibility requirements.
- Existing mutation rejection behavior remains unchanged.
- A failed refresh after a successful load preserves the last known catalog while exposing Retry.

## Acceptance criteria and validation

The following checks ran after the last material edit:

- `npm test -- src/renderer/src/stores/specialist-store.test.ts src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx` — 46 tests passed.
- `npx vitest run src/renderer/src/i18n/resources.test.ts` — 67 tests passed.
- `npm run typecheck:web` — passed.
- `npm run lint` — passed with 0 errors; it reported 15 existing Prettier warnings in the untouched `src/main/host-sdk/capability-projection.test.ts`.

The complete portable and platform suites remain delegated to PR CI as requested.

## Review focus

- Confirm `isLoaded` remains false after an initial failure so Specialist-dependent barriers do not fail open.
- Confirm the shared generation covers both ordinary loads and mutation-triggered catalog refreshes.
- Confirm stale successes and failures cannot replace the latest visible catalog state.
