### PR TITLE
fix(network): add connectivity probe diagnostics

### DIFF
--- a/src/main/network-ipc.test.ts
+++ b/src/main/network-ipc.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import type { Logger } from './logger'
+
 // Capture ipcMain.handle registrations so the handler can be invoked directly.
 const handlers = new Map<string, (event: unknown, payload: unknown) => unknown>()
 
@@ -16,6 +18,17 @@ type NetworkCommandOwner = import('./network-ipc').NetworkCommandOwner
 
 const invoke = (channel: string): unknown => handlers.get(channel)!(undefined, undefined)
 
+type DiagnosticLog = {
+  [Method in keyof Logger]: ReturnType<typeof vi.fn<Logger[Method]>>
+}
+
+const createDiagnosticLog = (): DiagnosticLog => ({
+  debug: vi.fn<Logger['debug']>(),
+  info: vi.fn<Logger['info']>(),
+  warn: vi.fn<Logger['warn']>(),
+  error: vi.fn<Logger['error']>()
+})
+
 describe('network IPC handler', () => {
   it('delegates to an injected owner instance', async () => {
     handlers.clear()
@@ -28,6 +41,59 @@ describe('network IPC handler', () => {
     expect(registerNetworkIpcHandlers(owner)).toBe(owner)
     await expect(invoke('network:get-info')).resolves.toEqual(info)
     await expect(invoke('network:check-connectivity')).resolves.toBe(false)
+  })
+
+  it('records connectivity probe start, outcome, and duration', async () => {
+    handlers.clear()
+    const owner: NetworkCommandOwner = {
+      getInfo: vi.fn(),
+      checkConnectivity: vi.fn().mockResolvedValue(true)
+    }
+    const log = createDiagnosticLog()
+    const now = vi.fn().mockReturnValueOnce(100).mockReturnValueOnce(137)
+
+    registerNetworkIpcHandlers(owner, { log, now })
+
+    await expect(invoke('network:check-connectivity')).resolves.toBe(true)
+    expect(log.info).toHaveBeenCalledTimes(2)
+    expect(log.info).toHaveBeenNthCalledWith(1, 'operation started', {
+      operation: 'connectivity-check',
+      operationId: expect.any(String),
+      outcome: 'started'
+    })
+    expect(log.info).toHaveBeenNthCalledWith(2, 'operation completed', {
+      operation: 'connectivity-check',
+      operationId: expect.any(String),
+      outcome: 'completed',
+      durationMs: 37,
+      reachable: true
+    })
+    const startedFields = log.info.mock.calls[0][1] as Record<string, unknown>
+    const completedFields = log.info.mock.calls[1][1] as Record<string, unknown>
+    expect(completedFields.operationId).toBe(startedFields.operationId)
+  })
+
+  it('records a sanitized failed probe and preserves the rejection', async () => {
+    handlers.clear()
+    const failure = new Error('private network details')
+    const owner: NetworkCommandOwner = {
+      getInfo: vi.fn(),
+      checkConnectivity: vi.fn().mockRejectedValue(failure)
+    }
+    const log = createDiagnosticLog()
+    const now = vi.fn().mockReturnValueOnce(200).mockReturnValueOnce(225)
+
+    registerNetworkIpcHandlers(owner, { log, now })
+
+    await expect(invoke('network:check-connectivity')).rejects.toBe(failure)
+    expect(log.error).toHaveBeenCalledWith('operation failed', {
+      operation: 'connectivity-check',
+      operationId: expect.any(String),
+      outcome: 'failed',
+      durationMs: 25,
+      errorCategory: 'error'
+    })
+    expect(JSON.stringify(log.error.mock.calls)).not.toContain('private network details')
   })
 
   it('registers both network channels', () => {

--- a/src/main/network-ipc.ts
+++ b/src/main/network-ipc.ts
@@ -1,5 +1,7 @@
 import { ipcMainHandle } from './ipc-handler-registry'
 
+import { startDiagnosticOperation } from './diagnostics/operation'
+import { createLogger, type Logger } from './logger'
 import { checkInternetReachability, getNetworkInfo } from './net/network-info'
 
 import type { NetworkInfo } from '../shared/network'
@@ -7,6 +9,11 @@ import type { NetworkInfo } from '../shared/network'
 type NetworkCommandOwner = Readonly<{
   getInfo: () => Promise<NetworkInfo>
   checkConnectivity: () => Promise<boolean>
+}>
+
+type NetworkIpcDiagnostics = Readonly<{
+  log?: Logger
+  now?: () => number
 }>
 
 // Network status for the settings Network panel. getInfo answers from local OS state (no
@@ -18,10 +25,25 @@ const createNetworkCommandOwner = (): NetworkCommandOwner => ({
 })
 
 const registerNetworkIpcHandlers = (
-  owner: NetworkCommandOwner = createNetworkCommandOwner()
+  owner: NetworkCommandOwner = createNetworkCommandOwner(),
+  diagnostics: NetworkIpcDiagnostics = {}
 ): NetworkCommandOwner => {
+  const log = diagnostics.log ?? createLogger('network')
   ipcMainHandle('network:get-info', () => owner.getInfo())
-  ipcMainHandle('network:check-connectivity', () => owner.checkConnectivity())
+  ipcMainHandle('network:check-connectivity', async () => {
+    const operation = startDiagnosticOperation(log, {
+      operation: 'connectivity-check',
+      now: diagnostics.now
+    })
+    try {
+      const reachable = await owner.checkConnectivity()
+      operation.complete({ reachable })
+      return reachable
+    } catch (error) {
+      operation.fail(error)
+      throw error
+    }
+  })
   return owner
 }
 


### PR DESCRIPTION
## Problem

The current `main.log` does not record the lifecycle of `network:check-connectivity`. A user can therefore remain on `Checking…` without support being able to distinguish whether the renderer never invoked Main, Main started a probe that never settled, Main rejected, or Main returned normally and the renderer failed to apply the result.

## Proposed change

Wrap each Main connectivity IPC invocation in the existing structured diagnostic-operation helper under the `network` scope.

- Log `operation started` with a generated `operationId`.
- Log `operation completed` with the same ID, `durationMs`, and the boolean `reachable` result.
- Log `operation failed` with the same ID, duration, and the existing fixed-vocabulary `errorCategory`, while preserving the original IPC rejection.

The records intentionally omit probe URLs, proxy settings, IP addresses, request payloads, and raw error messages.

## Scope and non-goals

- No renderer, preload, IPC argument, connectivity enum, or public data-model change.
- No database, migration, historical-data compatibility, or new persistence model. Records use the existing bounded/rotating `main.log` sink.
- No user interaction or i18n change.
- Main cannot identify whether an unchanged IPC call came from startup, an online event, panel mount, or user retry; adding that source would require an IPC contract change and is outside this PR.
- This change adds observability only; it does not add a new probe timeout or change connectivity behavior.

## Acceptance criteria and validation

The checks below ran after the last material edit.

- Successful and rejected connectivity probes emit correlated, duration-bearing, sanitized lifecycle records without changing their result/rejection -> `npm test -- src/main/network-ipc.test.ts src/main/diagnostics/operation.test.ts` -> 2 files, 16 tests passed.
- Main-process types remain valid -> `npm run typecheck:node` -> passed.
- Source and tests satisfy lint -> `npm run lint` -> exit 0; 15 existing Prettier warnings remain in unrelated `src/main/host-sdk/capability-projection.test.ts`.
- Patch contains no whitespace errors -> `git diff --check` -> passed.

No complete local `npm test` was run; the focused owner/diagnostic tests cover the changed behavior, Node typecheck covers the Main consumer, and exact-head PR Gate remains authoritative for broader and platform lanes.

## Review focus

- A started record without a matching terminal record is sufficient evidence of a Main-side non-settling probe.
- A completed record distinguishes Main success from renderer-side state convergence failures.
- Diagnostic failures cannot change the authoritative network result, and raw failure details are not retained.