### PR TITLE
fix(windows-smoke): sync certification harness contracts

### DIFF
--- a/.github/workflows/windows-upgrade-smoke.yml
+++ b/.github/workflows/windows-upgrade-smoke.yml
@@ -65,14 +65,15 @@ jobs:
             }
           }
           $artifactReservationCommit = 'f12fd1f871022c7a9b771d193202d9ecf98aca96'
-          git merge-base --is-ancestor $artifactReservationCommit $releasedSha
-          if ($LASTEXITCODE -eq 0) {
-            $artifactRpcContract = 'reservation'
-          } elseif ($LASTEXITCODE -eq 1) {
-            $artifactRpcContract = 'legacy'
-          } else {
+          $artifactReservationBase = git merge-base $artifactReservationCommit $releasedSha
+          if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($artifactReservationBase)) {
             Write-Error "Could not resolve the released Artifact RPC contract at $releasedSha."
             exit 1
+          }
+          if ($artifactReservationBase -eq $artifactReservationCommit) {
+            $artifactRpcContract = 'reservation'
+          } else {
+            $artifactRpcContract = 'legacy'
           }
           "sha=$releasedSha" >> $env:GITHUB_OUTPUT
           "migration_count=$($migrationFiles.Count)" >> $env:GITHUB_OUTPUT

--- a/.github/workflows/windows-upgrade-smoke.yml
+++ b/.github/workflows/windows-upgrade-smoke.yml
@@ -64,8 +64,19 @@ jobs:
               exit 1
             }
           }
+          $artifactReservationCommit = 'f12fd1f871022c7a9b771d193202d9ecf98aca96'
+          git merge-base --is-ancestor $artifactReservationCommit $releasedSha
+          if ($LASTEXITCODE -eq 0) {
+            $artifactRpcContract = 'reservation'
+          } elseif ($LASTEXITCODE -eq 1) {
+            $artifactRpcContract = 'legacy'
+          } else {
+            Write-Error "Could not resolve the released Artifact RPC contract at $releasedSha."
+            exit 1
+          }
           "sha=$releasedSha" >> $env:GITHUB_OUTPUT
           "migration_count=$($migrationFiles.Count)" >> $env:GITHUB_OUTPUT
+          "artifact_rpc_contract=$artifactRpcContract" >> $env:GITHUB_OUTPUT
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -134,6 +145,7 @@ jobs:
           node scripts/windows-installer-smoke.mjs `
             --installer-dir current `
             --previous-installer-dir previous `
+            --artifact-rpc-contract '${{ steps.current.outputs.artifact_rpc_contract }}' `
             --expected-migration-count '${{ steps.current.outputs.migration_count }}' 2>&1 |
             Tee-Object -FilePath windows-installer-certification.log
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/windows-upgrade-smoke.yml
+++ b/.github/workflows/windows-upgrade-smoke.yml
@@ -40,7 +40,32 @@ jobs:
           if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($releasedSha)) {
             exit 1
           }
+          git merge-base --is-ancestor $releasedSha $env:GITHUB_SHA
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Released revision $releasedSha is not an ancestor of smoke harness $env:GITHUB_SHA."
+            exit 1
+          }
+          $migrationFiles = @(
+            git ls-tree -r --name-only $releasedSha -- src/main/database/migrations
+          )
+          if ($LASTEXITCODE -ne 0 -or $migrationFiles.Count -eq 0) {
+            Write-Error "Released revision $releasedSha has no application migrations."
+            exit 1
+          }
+          $migrationPattern = '^src/main/database/migrations/(?<sequence>\d{4})-[a-z0-9]+(?:-[a-z0-9]+)*\.ts$'
+          for ($index = 0; $index -lt $migrationFiles.Count; $index += 1) {
+            if ($migrationFiles[$index] -notmatch $migrationPattern) {
+              Write-Error "Unexpected released migration path: $($migrationFiles[$index])"
+              exit 1
+            }
+            $expectedSequence = $index + 1
+            if ([int]$Matches.sequence -ne $expectedSequence) {
+              Write-Error "Released migrations are not a continuous prefix at $($migrationFiles[$index])."
+              exit 1
+            }
+          }
           "sha=$releasedSha" >> $env:GITHUB_OUTPUT
+          "migration_count=$($migrationFiles.Count)" >> $env:GITHUB_OUTPUT
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -108,7 +133,8 @@ jobs:
         run: |
           node scripts/windows-installer-smoke.mjs `
             --installer-dir current `
-            --previous-installer-dir previous 2>&1 |
+            --previous-installer-dir previous `
+            --expected-migration-count '${{ steps.current.outputs.migration_count }}' 2>&1 |
             Tee-Object -FilePath windows-installer-certification.log
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -221,6 +221,15 @@ describe('release and scheduled workflow topology', () => {
     expect(released.run).toContain('Released migrations are not a continuous prefix')
     expect(released.run).toContain('"sha=$releasedSha"')
     expect(released.run).toContain('"migration_count=$($migrationFiles.Count)"')
+    expect(released.run).toContain('f12fd1f871022c7a9b771d193202d9ecf98aca96')
+    expect(released.run)
+      .toContain(`git merge-base --is-ancestor $artifactReservationCommit $releasedSha
+if ($LASTEXITCODE -eq 0) {
+  $artifactRpcContract = 'reservation'
+} elseif ($LASTEXITCODE -eq 1) {
+  $artifactRpcContract = 'legacy'
+}`)
+    expect(released.run).toContain('"artifact_rpc_contract=$artifactRpcContract"')
     const updaterRoot = step(smoke, 'Certify Windows electron-updater differential update').env
       ?.OPEN_SCIENCE_E2E_STORAGE_ROOT
     const installerRoot = step(
@@ -233,6 +242,9 @@ describe('release and scheduled workflow topology', () => {
     expect(
       step(smoke, 'Drill Windows silent upgrade, process lock, rollback, and restart').run
     ).toContain("--expected-migration-count '${{ steps.current.outputs.migration_count }}'")
+    expect(
+      step(smoke, 'Drill Windows silent upgrade, process lock, rollback, and restart').run
+    ).toContain("--artifact-rpc-contract '${{ steps.current.outputs.artifact_rpc_contract }}'")
     expect(step(smoke, 'Record Windows update-drill evidence')).toMatchObject({
       env: { GITHUB_SHA: '${{ steps.current.outputs.sha }}' }
     })

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -223,10 +223,14 @@ describe('release and scheduled workflow topology', () => {
     expect(released.run).toContain('"migration_count=$($migrationFiles.Count)"')
     expect(released.run).toContain('f12fd1f871022c7a9b771d193202d9ecf98aca96')
     expect(released.run)
-      .toContain(`git merge-base --is-ancestor $artifactReservationCommit $releasedSha
-if ($LASTEXITCODE -eq 0) {
+      .toContain(`$artifactReservationBase = git merge-base $artifactReservationCommit $releasedSha
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($artifactReservationBase)) {
+  Write-Error "Could not resolve the released Artifact RPC contract at $releasedSha."
+  exit 1
+}
+if ($artifactReservationBase -eq $artifactReservationCommit) {
   $artifactRpcContract = 'reservation'
-} elseif ($LASTEXITCODE -eq 1) {
+} else {
   $artifactRpcContract = 'legacy'
 }`)
     expect(released.run).toContain('"artifact_rpc_contract=$artifactRpcContract"')

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -212,7 +212,15 @@ describe('release and scheduled workflow topology', () => {
     expect(checkout.with).not.toHaveProperty('ref')
     const released = step(smoke, 'Resolve released revision')
     expect(released.run).toContain('git rev-parse "$($env:CURRENT_TAG)^{commit}"')
+    expect(released.run).toContain('git merge-base --is-ancestor $releasedSha $env:GITHUB_SHA')
+    expect(released.run).toContain(
+      'git ls-tree -r --name-only $releasedSha -- src/main/database/migrations'
+    )
+    expect(released.run).toContain('$migrationPattern')
+    expect(released.run).toContain('Unexpected released migration path')
+    expect(released.run).toContain('Released migrations are not a continuous prefix')
     expect(released.run).toContain('"sha=$releasedSha"')
+    expect(released.run).toContain('"migration_count=$($migrationFiles.Count)"')
     const updaterRoot = step(smoke, 'Certify Windows electron-updater differential update').env
       ?.OPEN_SCIENCE_E2E_STORAGE_ROOT
     const installerRoot = step(
@@ -222,6 +230,9 @@ describe('release and scheduled workflow topology', () => {
     expect(updaterRoot).toBe('${{ runner.temp }}\\open-science-updater-certification')
     expect(installerRoot).toBe('${{ runner.temp }}\\open-science-installer-certification')
     expect(updaterRoot).not.toBe(installerRoot)
+    expect(
+      step(smoke, 'Drill Windows silent upgrade, process lock, rollback, and restart').run
+    ).toContain("--expected-migration-count '${{ steps.current.outputs.migration_count }}'")
     expect(step(smoke, 'Record Windows update-drill evidence')).toMatchObject({
       env: { GITHUB_SHA: '${{ steps.current.outputs.sha }}' }
     })

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -29,10 +29,21 @@ const EXPECTED_MIGRATION_LEDGER = [
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'
 const SQLITE_VERSION_PATTERN = /^\d+\.\d+\.\d+$/
 
-const assertApplicationMigrationLedger = (rows) => {
+const assertApplicationMigrationLedger = (
+  rows,
+  expectedMigrationCount = EXPECTED_MIGRATION_LEDGER.length
+) => {
   if (
-    rows.length !== EXPECTED_MIGRATION_LEDGER.length ||
-    EXPECTED_MIGRATION_LEDGER.some(
+    !Number.isSafeInteger(expectedMigrationCount) ||
+    expectedMigrationCount < 1 ||
+    expectedMigrationCount > EXPECTED_MIGRATION_LEDGER.length
+  ) {
+    throw new Error('Expected migration count is outside the supported application ledger.')
+  }
+  const expectedLedger = EXPECTED_MIGRATION_LEDGER.slice(0, expectedMigrationCount)
+  if (
+    rows.length !== expectedLedger.length ||
+    expectedLedger.some(
       (expected, index) =>
         rows[index]?.id !== expected.id || rows[index]?.checksum !== expected.checksum
     )
@@ -59,10 +70,10 @@ const readDatabaseMigrationLedger = async (configRoot) => {
   }
 }
 
-const verifyDatabaseMigrationLedger = async (configRoot) => {
+const verifyDatabaseMigrationLedger = async (configRoot, expectedMigrationCount) => {
   const rows = await readDatabaseMigrationLedger(configRoot)
   if (!rows) throw new Error('Packaged application did not create the database migration ledger.')
-  assertApplicationMigrationLedger(rows)
+  assertApplicationMigrationLedger(rows, expectedMigrationCount)
 }
 
 const seedLegacyDatabase = async (configRoot) => {

--- a/scripts/database-migration-ledger-smoke.test.ts
+++ b/scripts/database-migration-ledger-smoke.test.ts
@@ -22,6 +22,36 @@ describe('packaged database migration ledger smoke', () => {
     )
   })
 
+  it('accepts only an explicitly selected immutable released migration prefix', () => {
+    const releasedLedger = MIGRATION_MANIFEST.slice(0, -1)
+    expect(() =>
+      assertApplicationMigrationLedger(releasedLedger, releasedLedger.length)
+    ).not.toThrow()
+    expect(() => assertApplicationMigrationLedger(releasedLedger)).toThrow(
+      /expected application database migration ledger/
+    )
+    expect(() =>
+      assertApplicationMigrationLedger(
+        releasedLedger.map((entry, index) =>
+          index === releasedLedger.length - 1 ? { ...entry, checksum: '0'.repeat(64) } : entry
+        ),
+        releasedLedger.length
+      )
+    ).toThrow(/expected application database migration ledger/)
+    expect(() =>
+      assertApplicationMigrationLedger(MIGRATION_MANIFEST, releasedLedger.length)
+    ).toThrow(/expected application database migration ledger/)
+  })
+
+  it.each([0, 1.5, Number.NaN, MIGRATION_MANIFEST.length + 1])(
+    'rejects unsupported expected migration count %s',
+    (expectedMigrationCount) => {
+      expect(() =>
+        assertApplicationMigrationLedger(MIGRATION_MANIFEST, expectedMigrationCount)
+      ).toThrow(/migration count is outside the supported application ledger/)
+    }
+  )
+
   it('records the packaged SQLite compatibility floor and certified matrix', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-ledger-smoke-evidence-'))
     const output = join(root, 'database-migration-certification.json')

--- a/scripts/windows-installer-smoke.mjs
+++ b/scripts/windows-installer-smoke.mjs
@@ -423,10 +423,13 @@ const assertPackagedArtifactScope = (params, requireWriteOperationId) => {
   }
 }
 
-const packagedArtifactSmokeRpcResult = (body, workspace) => {
+const packagedArtifactSmokeRpcResult = (body, workspace, artifactRpcContract = 'reservation') => {
   const params = body.params ?? {}
   const fileBytes = Buffer.byteLength(RPC_SMOKE_CONTENT)
   if (body.method === 'artifactReserveWrite') {
+    if (artifactRpcContract !== 'reservation') {
+      throw new Error('Legacy packaged Artifact RPC must not reserve a write.')
+    }
     assertPackagedArtifactScope(params, true)
     if (params.filename !== 'windows-rpc-smoke.txt' || params.fileBytes !== fileBytes) {
       throw new Error('Unexpected packaged Artifact write reservation request.')
@@ -440,7 +443,15 @@ const packagedArtifactSmokeRpcResult = (body, workspace) => {
   if (body.method === 'artifactCreateVersion') {
     assertPackagedArtifactScope(params, true)
     const checksum = createHash('sha256').update(RPC_SMOKE_CONTENT).digest('hex')
-    if (
+    if (artifactRpcContract === 'legacy') {
+      if (
+        params.resourceReservationId !== undefined ||
+        params.resourceSizeBytes !== undefined ||
+        params.resourceChecksum !== undefined
+      ) {
+        throw new Error('Legacy packaged Artifact Version must omit reservation metadata.')
+      }
+    } else if (
       params.resourceReservationId !== RPC_SMOKE_RESERVATION_ID ||
       params.resourceSizeBytes !== fileBytes ||
       params.resourceChecksum !== checksum
@@ -467,6 +478,9 @@ const packagedArtifactSmokeRpcResult = (body, workspace) => {
     }
   }
   if (body.method === 'artifactReleaseWrite') {
+    if (artifactRpcContract !== 'reservation') {
+      throw new Error('Legacy packaged Artifact RPC must not release a write reservation.')
+    }
     assertPackagedArtifactScope(params, false)
     if (params.reservationId !== RPC_SMOKE_RESERVATION_ID) {
       throw new Error('Unexpected packaged Artifact reservation release request.')
@@ -524,7 +538,11 @@ const connectPackagedMcp = async ({ executable, entryPath, serverArg, env, cwd }
   return { client, stderr: () => stderr }
 }
 
-const runPackagedLocalRpcSmoke = async ({ installDirectory, env }) => {
+const runPackagedLocalRpcSmoke = async ({
+  installDirectory,
+  env,
+  artifactRpcContract = 'reservation'
+}) => {
   const root = await mkdtemp(join(env.TEMP, RPC_SMOKE_ROOT_PREFIX))
   const workspace = join(root, 'workspace')
   const artifactStorage = join(root, 'artifacts')
@@ -570,7 +588,7 @@ const runPackagedLocalRpcSmoke = async ({ installDirectory, env }) => {
         })
         return
       }
-      const artifactResult = packagedArtifactSmokeRpcResult(body, workspace)
+      const artifactResult = packagedArtifactSmokeRpcResult(body, workspace, artifactRpcContract)
       if (artifactResult !== undefined) {
         sendJson(response, 200, { result: artifactResult })
         return
@@ -669,12 +687,10 @@ const runPackagedLocalRpcSmoke = async ({ installDirectory, env }) => {
     )
     assertToolResult('write_artifact_file', artifact, 'installer-smoke-version')
 
-    const expectedMethods = [
-      'state',
-      'executeShell',
-      'artifactReserveWrite',
-      'artifactCreateVersion'
-    ]
+    const expectedMethods =
+      artifactRpcContract === 'legacy'
+        ? ['state', 'executeShell', 'artifactCreateVersion']
+        : ['state', 'executeShell', 'artifactReserveWrite', 'artifactCreateVersion']
     if (JSON.stringify(methods) !== JSON.stringify(expectedMethods)) {
       throw new Error(`Unexpected packaged local RPC sequence: ${methods.join(' -> ')}`)
     }
@@ -960,6 +976,7 @@ const installAndProbe = async ({
   phase,
   env,
   legacyConfigRoots,
+  artifactRpcContract,
   expectedMigrationCount,
   onSqliteVersion
 }) => {
@@ -967,7 +984,8 @@ const installAndProbe = async ({
   await runProcess(installer, ['/S', `/D=${installDirectory}`], { env })
   await assertPackagedResources(installDirectory)
   await runProcess(join(installDirectory, 'resources', 'micromamba.exe'), ['--version'], { env })
-  if (phase === 'current') await runPackagedLocalRpcSmoke({ installDirectory, env })
+  if (phase === 'current')
+    await runPackagedLocalRpcSmoke({ installDirectory, env, artifactRpcContract })
   return launchAndProbe({
     installDirectory,
     expectedVersion: installerVersion(installer),
@@ -986,6 +1004,7 @@ const installOverRunningApp = async ({
   phase,
   env,
   legacyConfigRoots,
+  artifactRpcContract,
   launchInstalledApp = true,
   expectedMigrationCount,
   onSqliteVersion
@@ -1006,7 +1025,8 @@ const installOverRunningApp = async ({
 
   await assertPackagedResources(installDirectory)
   await runProcess(join(installDirectory, 'resources', 'micromamba.exe'), ['--version'], { env })
-  if (phase === 'current') await runPackagedLocalRpcSmoke({ installDirectory, env })
+  if (phase === 'current')
+    await runPackagedLocalRpcSmoke({ installDirectory, env, artifactRpcContract })
   if (!launchInstalledApp) return undefined
   return launchAndProbe({
     installDirectory,
@@ -1054,8 +1074,14 @@ const parseArguments = (argv) => {
   const installerDirectory = valueFor('--installer-dir')
   if (!installerDirectory)
     throw new Error(
-      'Usage: --installer-dir <path> [--previous-installer-dir <path>] [--expected-migration-count <count>]'
+      'Usage: --installer-dir <path> [--previous-installer-dir <path>] [--artifact-rpc-contract <legacy|reservation>] [--expected-migration-count <count>]'
     )
+  const artifactRpcContractIndex = argv.indexOf('--artifact-rpc-contract')
+  const artifactRpcContract =
+    artifactRpcContractIndex === -1 ? 'reservation' : argv[artifactRpcContractIndex + 1]
+  if (artifactRpcContract !== 'legacy' && artifactRpcContract !== 'reservation') {
+    throw new Error('Artifact RPC contract must be legacy or reservation.')
+  }
   const expectedMigrationCountIndex = argv.indexOf('--expected-migration-count')
   const expectedMigrationCountValue =
     expectedMigrationCountIndex === -1 ? undefined : argv[expectedMigrationCountIndex + 1]
@@ -1075,6 +1101,7 @@ const parseArguments = (argv) => {
     previousInstallerDirectory: valueFor('--previous-installer-dir')
       ? resolve(valueFor('--previous-installer-dir'))
       : undefined,
+    artifactRpcContract,
     expectedMigrationCount
   }
 }
@@ -1133,6 +1160,7 @@ const main = async () => {
               installDirectory,
               env,
               legacyConfigRoots,
+              artifactRpcContract: options.artifactRpcContract,
               expectedMigrationCount: releasedMigrationCountForPhase(
                 cycle.phase,
                 options.expectedMigrationCount
@@ -1144,6 +1172,7 @@ const main = async () => {
               installDirectory,
               env,
               legacyConfigRoots,
+              artifactRpcContract: options.artifactRpcContract,
               expectedMigrationCount: releasedMigrationCountForPhase(
                 cycle.phase,
                 options.expectedMigrationCount

--- a/scripts/windows-installer-smoke.mjs
+++ b/scripts/windows-installer-smoke.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
 import { spawn } from 'node:child_process'
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { createServer } from 'node:http'
 import { homedir, tmpdir } from 'node:os'
@@ -35,6 +35,13 @@ const RPC_SMOKE_ROOT_PREFIX = 'open-science-rpc-smoke-'
 const UPGRADE_SENTINEL_PREFIX = 'installer-smoke-upgrade-sentinel-'
 const UPGRADE_SENTINEL_CONTENT = 'previous-version-profile-preserved\n'
 const RPC_SMOKE_CONTENT = 'windows-rpc-smoke\n'
+const RPC_SMOKE_RESERVATION_ID = 'installer-smoke-reservation'
+const RPC_SMOKE_ARTIFACT_SCOPE = {
+  projectId: 'installer-smoke-project',
+  appSessionId: 'installer-smoke-session',
+  artifactStorageSessionId: 'installer-smoke-session',
+  artifactRunId: 'installer-smoke-artifact-run'
+}
 
 const delay = (milliseconds) =>
   new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds))
@@ -404,6 +411,74 @@ const sendJson = (response, statusCode, payload) => {
   response.end(JSON.stringify(payload))
 }
 
+const assertPackagedArtifactScope = (params, requireWriteOperationId) => {
+  if (
+    Object.entries(RPC_SMOKE_ARTIFACT_SCOPE).some(
+      ([key, expectedValue]) => params[key] !== expectedValue
+    ) ||
+    (requireWriteOperationId &&
+      !/^artifact-write-[0-9a-f]{64}$/.test(params.writeOperationId ?? ''))
+  ) {
+    throw new Error('Unexpected packaged Artifact write scope.')
+  }
+}
+
+const packagedArtifactSmokeRpcResult = (body, workspace) => {
+  const params = body.params ?? {}
+  const fileBytes = Buffer.byteLength(RPC_SMOKE_CONTENT)
+  if (body.method === 'artifactReserveWrite') {
+    assertPackagedArtifactScope(params, true)
+    if (params.filename !== 'windows-rpc-smoke.txt' || params.fileBytes !== fileBytes) {
+      throw new Error('Unexpected packaged Artifact write reservation request.')
+    }
+    return {
+      id: RPC_SMOKE_RESERVATION_ID,
+      fileBytes,
+      expiresAt: Date.now() + PROCESS_TIMEOUT_MS
+    }
+  }
+  if (body.method === 'artifactCreateVersion') {
+    assertPackagedArtifactScope(params, true)
+    const checksum = createHash('sha256').update(RPC_SMOKE_CONTENT).digest('hex')
+    if (
+      params.resourceReservationId !== RPC_SMOKE_RESERVATION_ID ||
+      params.resourceSizeBytes !== fileBytes ||
+      params.resourceChecksum !== checksum
+    ) {
+      throw new Error('Unexpected packaged Artifact Version reservation metadata.')
+    }
+    return {
+      id: 'installer-smoke-version',
+      artifactId: 'installer-smoke-artifact',
+      versionId: 'installer-smoke-version',
+      versionNumber: 1,
+      checksum,
+      createdAt: new Date(0).toISOString(),
+      projectName: 'installer-smoke-project',
+      sessionId: 'installer-smoke-session',
+      runId: 'installer-smoke-artifact-run',
+      name: 'windows-rpc-smoke.txt',
+      path: join(workspace, 'windows-rpc-smoke.txt'),
+      fileUrl: 'file:///windows-rpc-smoke.txt',
+      mimeType: 'text/plain',
+      size: fileBytes,
+      mtimeMs: 0,
+      producerRunId: 'installer-smoke-shell-run'
+    }
+  }
+  if (body.method === 'artifactReleaseWrite') {
+    assertPackagedArtifactScope(params, false)
+    if (params.reservationId !== RPC_SMOKE_RESERVATION_ID) {
+      throw new Error('Unexpected packaged Artifact reservation release request.')
+    }
+    return { released: true }
+  }
+  return undefined
+}
+
+const releasedMigrationCountForPhase = (phase, expectedMigrationCount) =>
+  phase === 'current' || phase === 'restart' ? expectedMigrationCount : undefined
+
 const toolResultText = (result) =>
   result.content
     .filter((item) => item.type === 'text')
@@ -495,27 +570,9 @@ const runPackagedLocalRpcSmoke = async ({ installDirectory, env }) => {
         })
         return
       }
-      if (body.method === 'artifactCreateVersion') {
-        sendJson(response, 200, {
-          result: {
-            id: 'installer-smoke-version',
-            artifactId: 'installer-smoke-artifact',
-            versionId: 'installer-smoke-version',
-            versionNumber: 1,
-            checksum: 'a'.repeat(64),
-            createdAt: new Date(0).toISOString(),
-            projectName: 'installer-smoke-project',
-            sessionId: 'installer-smoke-session',
-            runId: 'installer-smoke-artifact-run',
-            name: 'windows-rpc-smoke.txt',
-            path: join(workspace, 'windows-rpc-smoke.txt'),
-            fileUrl: 'file:///windows-rpc-smoke.txt',
-            mimeType: 'text/plain',
-            size: Buffer.byteLength(RPC_SMOKE_CONTENT),
-            mtimeMs: 0,
-            producerRunId: 'installer-smoke-shell-run'
-          }
-        })
+      const artifactResult = packagedArtifactSmokeRpcResult(body, workspace)
+      if (artifactResult !== undefined) {
+        sendJson(response, 200, { result: artifactResult })
         return
       }
       sendJson(response, 400, { error: `Unexpected installer smoke RPC method: ${body.method}` })
@@ -612,7 +669,12 @@ const runPackagedLocalRpcSmoke = async ({ installDirectory, env }) => {
     )
     assertToolResult('write_artifact_file', artifact, 'installer-smoke-version')
 
-    const expectedMethods = ['state', 'executeShell', 'artifactCreateVersion']
+    const expectedMethods = [
+      'state',
+      'executeShell',
+      'artifactReserveWrite',
+      'artifactCreateVersion'
+    ]
     if (JSON.stringify(methods) !== JSON.stringify(expectedMethods)) {
       throw new Error(`Unexpected packaged local RPC sequence: ${methods.join(' -> ')}`)
     }
@@ -736,6 +798,7 @@ const launchAndProbe = async ({
   env,
   legacyConfigRoots,
   verifyLedger = false,
+  expectedMigrationCount,
   onSqliteVersion
 }) => {
   const executable = join(installDirectory, APP_EXECUTABLE)
@@ -781,7 +844,7 @@ const launchAndProbe = async ({
     await requestPackagedAppShutdown(endpoint, auth)
     const exitCode = await waitForShutdownExit(exit, child, output)
     if (exitCode !== 0) throw new Error(`Installed app exited with ${exitCode}.\n${output()}`)
-    if (verifyLedger) await verifyDatabaseMigrationLedger(configRoot)
+    if (verifyLedger) await verifyDatabaseMigrationLedger(configRoot, expectedMigrationCount)
     if (onSqliteVersion) onSqliteVersion(parsePackagedSqliteVersion(output()))
     return configRoot
   } catch (error) {
@@ -897,6 +960,7 @@ const installAndProbe = async ({
   phase,
   env,
   legacyConfigRoots,
+  expectedMigrationCount,
   onSqliteVersion
 }) => {
   console.log(`Smoke testing ${phase} installer: ${basename(installer)}`)
@@ -910,6 +974,7 @@ const installAndProbe = async ({
     env,
     legacyConfigRoots,
     verifyLedger: phase !== 'previous',
+    expectedMigrationCount,
     onSqliteVersion
   })
 }
@@ -922,6 +987,7 @@ const installOverRunningApp = async ({
   env,
   legacyConfigRoots,
   launchInstalledApp = true,
+  expectedMigrationCount,
   onSqliteVersion
 }) => {
   const running = await launchForProcessLock({
@@ -948,6 +1014,7 @@ const installOverRunningApp = async ({
     env,
     legacyConfigRoots,
     verifyLedger: true,
+    expectedMigrationCount,
     onSqliteVersion
   })
 }
@@ -986,12 +1053,29 @@ const parseArguments = (argv) => {
   }
   const installerDirectory = valueFor('--installer-dir')
   if (!installerDirectory)
-    throw new Error('Usage: --installer-dir <path> [--previous-installer-dir <path>]')
+    throw new Error(
+      'Usage: --installer-dir <path> [--previous-installer-dir <path>] [--expected-migration-count <count>]'
+    )
+  const expectedMigrationCountIndex = argv.indexOf('--expected-migration-count')
+  const expectedMigrationCountValue =
+    expectedMigrationCountIndex === -1 ? undefined : argv[expectedMigrationCountIndex + 1]
+  if (
+    expectedMigrationCountIndex !== -1 &&
+    (expectedMigrationCountValue === undefined || !/^[1-9]\d*$/.test(expectedMigrationCountValue))
+  ) {
+    throw new Error('Expected migration count must be a positive integer.')
+  }
+  const expectedMigrationCount =
+    expectedMigrationCountValue === undefined ? undefined : Number(expectedMigrationCountValue)
+  if (expectedMigrationCount !== undefined && !Number.isSafeInteger(expectedMigrationCount)) {
+    throw new Error('Expected migration count must be a positive safe integer.')
+  }
   return {
     installerDirectory: resolve(installerDirectory),
     previousInstallerDirectory: valueFor('--previous-installer-dir')
       ? resolve(valueFor('--previous-installer-dir'))
-      : undefined
+      : undefined,
+    expectedMigrationCount
   }
 }
 
@@ -1049,6 +1133,10 @@ const main = async () => {
               installDirectory,
               env,
               legacyConfigRoots,
+              expectedMigrationCount: releasedMigrationCountForPhase(
+                cycle.phase,
+                options.expectedMigrationCount
+              ),
               onSqliteVersion: cycle.phase === 'rollback' ? undefined : onSqliteVersion
             })
           : await installAndProbe({
@@ -1056,6 +1144,10 @@ const main = async () => {
               installDirectory,
               env,
               legacyConfigRoots,
+              expectedMigrationCount: releasedMigrationCountForPhase(
+                cycle.phase,
+                options.expectedMigrationCount
+              ),
               onSqliteVersion: cycle.phase === 'previous' ? undefined : onSqliteVersion
             })
         if (cycle.phase === 'rollback' && upgradeProfileGuard.shouldExpectDowngradeBlock()) {
@@ -1072,6 +1164,7 @@ const main = async () => {
           expectedVersion: installerVersion(currentInstaller),
           env: isolatedEnv,
           verifyLedger: true,
+          expectedMigrationCount: options.expectedMigrationCount,
           onSqliteVersion
         })
         if (resolve(configRoot).toLowerCase() !== resolve(storageRoot).toLowerCase()) {
@@ -1134,12 +1227,15 @@ export {
   launchAndExpectDatabaseBlocked,
   installAndProbe,
   launchAndProbe,
+  packagedArtifactSmokeRpcResult,
   packagedMainEntryPath,
   observeChildClose,
+  parseArguments,
   packagedResourcePaths,
   parsePackagedAppEndpoint,
   readPackagedAppConfigRoot,
   requestPackagedAppShutdown,
+  releasedMigrationCountForPhase,
   runProcess,
   terminateProcessTree,
   uninstallAndVerify,

--- a/scripts/windows-installer-smoke.test.ts
+++ b/scripts/windows-installer-smoke.test.ts
@@ -57,7 +57,10 @@ describe('Windows installer smoke plan', () => {
   })
 
   it('parses an optional positive released migration count', () => {
-    expect(parseArguments(['--installer-dir', 'dist']).expectedMigrationCount).toBeUndefined()
+    expect(parseArguments(['--installer-dir', 'dist'])).toMatchObject({
+      artifactRpcContract: 'reservation',
+      expectedMigrationCount: undefined
+    })
     expect(
       parseArguments([
         '--installer-dir',
@@ -84,6 +87,23 @@ describe('Windows installer smoke plan', () => {
           ...(value === undefined ? [] : [value])
         ])
       ).toThrow(/migration count must be a positive/)
+    }
+  })
+
+  it('accepts only explicit packaged Artifact RPC contracts', () => {
+    expect(
+      parseArguments(['--installer-dir', 'dist', '--artifact-rpc-contract', 'legacy'])
+        .artifactRpcContract
+    ).toBe('legacy')
+    for (const value of [undefined, 'automatic']) {
+      expect(() =>
+        parseArguments([
+          '--installer-dir',
+          'dist',
+          '--artifact-rpc-contract',
+          ...(value === undefined ? [] : [value])
+        ])
+      ).toThrow(/Artifact RPC contract must be legacy or reservation/)
     }
   })
 
@@ -173,6 +193,41 @@ describe('Windows installer smoke plan', () => {
         workspace
       )
     ).toThrow(/write scope/)
+  })
+
+  it('supports the released legacy Artifact contract without weakening reservation enforcement', () => {
+    const workspace = 'C:\\smoke\\workspace'
+    const legacyRequest = {
+      method: 'artifactCreateVersion',
+      params: {
+        projectId: 'installer-smoke-project',
+        appSessionId: 'installer-smoke-session',
+        artifactStorageSessionId: 'installer-smoke-session',
+        artifactRunId: 'installer-smoke-artifact-run',
+        writeOperationId: `artifact-write-${'a'.repeat(64)}`
+      }
+    }
+
+    expect(packagedArtifactSmokeRpcResult(legacyRequest, workspace, 'legacy')).toMatchObject({
+      versionId: 'installer-smoke-version',
+      path: join(workspace, 'windows-rpc-smoke.txt')
+    })
+    expect(() => packagedArtifactSmokeRpcResult(legacyRequest, workspace, 'reservation')).toThrow(
+      /reservation metadata/
+    )
+    expect(() =>
+      packagedArtifactSmokeRpcResult(
+        {
+          ...legacyRequest,
+          params: {
+            ...legacyRequest.params,
+            resourceReservationId: 'partial-reservation'
+          }
+        },
+        workspace,
+        'legacy'
+      )
+    ).toThrow(/must omit reservation metadata/)
   })
 
   it('uses the released migration prefix only for current-version launch phases', () => {

--- a/scripts/windows-installer-smoke.test.ts
+++ b/scripts/windows-installer-smoke.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { EventEmitter } from 'node:events'
 import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -18,10 +19,13 @@ import {
   findSetupInstaller,
   installerVersion,
   observeChildClose,
+  packagedArtifactSmokeRpcResult,
   packagedMainEntryPath,
   packagedResourcePaths,
+  parseArguments,
   parsePackagedAppEndpoint,
   readPackagedAppConfigRoot,
+  releasedMigrationCountForPhase,
   requestPackagedAppShutdown,
   runProcess,
   terminateProcessTree,
@@ -50,6 +54,133 @@ describe('Windows installer smoke plan', () => {
     expect(installerVersion('aipoch-open-science-0.8.0-nightly.abc1234-win-x64-setup.exe')).toBe(
       '0.8.0-nightly.abc1234'
     )
+  })
+
+  it('parses an optional positive released migration count', () => {
+    expect(parseArguments(['--installer-dir', 'dist']).expectedMigrationCount).toBeUndefined()
+    expect(
+      parseArguments([
+        '--installer-dir',
+        'dist',
+        '--previous-installer-dir',
+        'previous',
+        '--expected-migration-count',
+        '4'
+      ]).expectedMigrationCount
+    ).toBe(4)
+    for (const value of [
+      undefined,
+      '0',
+      '-1',
+      '1.5',
+      'not-a-number',
+      String(Number.MAX_SAFE_INTEGER + 1)
+    ]) {
+      expect(() =>
+        parseArguments([
+          '--installer-dir',
+          'dist',
+          '--expected-migration-count',
+          ...(value === undefined ? [] : [value])
+        ])
+      ).toThrow(/migration count must be a positive/)
+    }
+  })
+
+  it('models the packaged Artifact reservation, Version, and release RPC contract', () => {
+    const workspace = 'C:\\smoke\\workspace'
+    const fileBytes = Buffer.byteLength('windows-rpc-smoke\n')
+    const checksum = createHash('sha256').update('windows-rpc-smoke\n').digest('hex')
+    const artifactScope = {
+      projectId: 'installer-smoke-project',
+      appSessionId: 'installer-smoke-session',
+      artifactStorageSessionId: 'installer-smoke-session',
+      artifactRunId: 'installer-smoke-artifact-run'
+    }
+    const writeOperationId = `artifact-write-${'a'.repeat(64)}`
+    const reservation = packagedArtifactSmokeRpcResult(
+      {
+        method: 'artifactReserveWrite',
+        params: {
+          ...artifactScope,
+          writeOperationId,
+          filename: 'windows-rpc-smoke.txt',
+          fileBytes
+        }
+      },
+      workspace
+    )
+    expect(reservation).toMatchObject({
+      id: 'installer-smoke-reservation',
+      fileBytes,
+      expiresAt: expect.any(Number)
+    })
+
+    const version = packagedArtifactSmokeRpcResult(
+      {
+        method: 'artifactCreateVersion',
+        params: {
+          ...artifactScope,
+          writeOperationId,
+          resourceReservationId: reservation.id,
+          resourceSizeBytes: fileBytes,
+          resourceChecksum: checksum
+        }
+      },
+      workspace
+    )
+    expect(version).toMatchObject({
+      versionId: 'installer-smoke-version',
+      path: join(workspace, 'windows-rpc-smoke.txt'),
+      size: fileBytes
+    })
+    expect(
+      packagedArtifactSmokeRpcResult(
+        {
+          method: 'artifactReleaseWrite',
+          params: { ...artifactScope, reservationId: reservation.id }
+        },
+        workspace
+      )
+    ).toEqual({ released: true })
+    expect(() =>
+      packagedArtifactSmokeRpcResult(
+        {
+          method: 'artifactCreateVersion',
+          params: {
+            ...artifactScope,
+            writeOperationId,
+            resourceReservationId: 'wrong-reservation',
+            resourceSizeBytes: fileBytes,
+            resourceChecksum: checksum
+          }
+        },
+        workspace
+      )
+    ).toThrow(/reservation metadata/)
+    expect(() =>
+      packagedArtifactSmokeRpcResult(
+        {
+          method: 'artifactReserveWrite',
+          params: {
+            ...artifactScope,
+            appSessionId: 'wrong-session',
+            writeOperationId,
+            filename: 'windows-rpc-smoke.txt',
+            fileBytes
+          }
+        },
+        workspace
+      )
+    ).toThrow(/write scope/)
+  })
+
+  it('uses the released migration prefix only for current-version launch phases', () => {
+    expect(
+      ['previous', 'current', 'rollback', 'restart'].map((phase) =>
+        releasedMigrationCountForPhase(phase, 4)
+      )
+    ).toEqual([undefined, 4, undefined, 4])
   })
 
   it('drills upgrade, process-lock rollback without old-app health, and final restart', async () => {

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -332,10 +332,14 @@ describe('post-merge Windows validation', () => {
     expect(released.run).toContain('"migration_count=$($migrationFiles.Count)"')
     expect(released.run).toContain('f12fd1f871022c7a9b771d193202d9ecf98aca96')
     expect(released.run)
-      .toContain(`git merge-base --is-ancestor $artifactReservationCommit $releasedSha
-if ($LASTEXITCODE -eq 0) {
+      .toContain(`$artifactReservationBase = git merge-base $artifactReservationCommit $releasedSha
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($artifactReservationBase)) {
+  Write-Error "Could not resolve the released Artifact RPC contract at $releasedSha."
+  exit 1
+}
+if ($artifactReservationBase -eq $artifactReservationCommit) {
   $artifactRpcContract = 'reservation'
-} elseif ($LASTEXITCODE -eq 1) {
+} else {
   $artifactRpcContract = 'legacy'
 }`)
     expect(released.run).toContain('"artifact_rpc_contract=$artifactRpcContract"')

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -330,6 +330,15 @@ describe('post-merge Windows validation', () => {
     expect(released.run).toContain('Released migrations are not a continuous prefix')
     expect(released.run).toContain('"sha=$releasedSha"')
     expect(released.run).toContain('"migration_count=$($migrationFiles.Count)"')
+    expect(released.run).toContain('f12fd1f871022c7a9b771d193202d9ecf98aca96')
+    expect(released.run)
+      .toContain(`git merge-base --is-ancestor $artifactReservationCommit $releasedSha
+if ($LASTEXITCODE -eq 0) {
+  $artifactRpcContract = 'reservation'
+} elseif ($LASTEXITCODE -eq 1) {
+  $artifactRpcContract = 'legacy'
+}`)
+    expect(released.run).toContain('"artifact_rpc_contract=$artifactRpcContract"')
 
     const updaterStep = findStep(upgrade, 'Certify Windows electron-updater differential update')
     const installerStep = findStep(
@@ -376,6 +385,9 @@ describe('post-merge Windows validation', () => {
     expect(
       findStep(upgrade, 'Drill Windows silent upgrade, process lock, rollback, and restart').run
     ).toContain("--expected-migration-count '${{ steps.current.outputs.migration_count }}'")
+    expect(
+      findStep(upgrade, 'Drill Windows silent upgrade, process lock, rollback, and restart').run
+    ).toContain("--artifact-rpc-contract '${{ steps.current.outputs.artifact_rpc_contract }}'")
     expect(
       findStep(upgrade, 'Drill Windows silent upgrade, process lock, rollback, and restart')
     ).toMatchObject({ id: 'installer', 'continue-on-error': true })

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -321,7 +321,15 @@ describe('post-merge Windows validation', () => {
 
     const released = findStep(upgrade, 'Resolve released revision')
     expect(released.run).toContain('git rev-parse "$($env:CURRENT_TAG)^{commit}"')
+    expect(released.run).toContain('git merge-base --is-ancestor $releasedSha $env:GITHUB_SHA')
+    expect(released.run).toContain(
+      'git ls-tree -r --name-only $releasedSha -- src/main/database/migrations'
+    )
+    expect(released.run).toContain('$migrationPattern')
+    expect(released.run).toContain('Unexpected released migration path')
+    expect(released.run).toContain('Released migrations are not a continuous prefix')
     expect(released.run).toContain('"sha=$releasedSha"')
+    expect(released.run).toContain('"migration_count=$($migrationFiles.Count)"')
 
     const updaterStep = findStep(upgrade, 'Certify Windows electron-updater differential update')
     const installerStep = findStep(
@@ -365,6 +373,9 @@ describe('post-merge Windows validation', () => {
     expect(
       findStep(upgrade, 'Drill Windows silent upgrade, process lock, rollback, and restart').run
     ).toContain('--previous-installer-dir previous')
+    expect(
+      findStep(upgrade, 'Drill Windows silent upgrade, process lock, rollback, and restart').run
+    ).toContain("--expected-migration-count '${{ steps.current.outputs.migration_count }}'")
     expect(
       findStep(upgrade, 'Drill Windows silent upgrade, process lock, rollback, and restart')
     ).toMatchObject({ id: 'installer', 'continue-on-error': true })


### PR DESCRIPTION
## Problem

Nightly Windows package smoke rejected the new Artifact reservation RPC introduced on main. Windows Upgrade Smoke also compared the v0.15.1 database against the newer main migration ledger instead of the released ledger prefix.

## Proposed change

- teach the packaged Windows RPC fixture the reserve, create, and release contract with strict scope, reservation, size, and checksum validation
- derive the released migration count from the tagged commit after verifying ancestry, filename shape, and continuous numbering
- verify current-release launch phases against that immutable ledger prefix while retaining full-ledger checks everywhere else

## Scope and non-goals

This changes certification harness behavior only. It does not change production migrations, schema, downgrade policy, application state, or persistence. Historical forward-only compatibility remains unchanged.

## Acceptance criteria and validation

Final evidence mapping after the last material edit:

- Artifact RPC contract: scripts/windows-installer-smoke.test.ts
- released ledger prefix contract: scripts/database-migration-ledger-smoke.test.ts
- workflow wiring and fail-closed release-tree checks: scripts/windows-release-workflows.test.ts and scripts/ci/release-workflows.test.ts
- focused tests: 4 files, 56 tests passed
- npm run typecheck:node passed
- npm run lint passed
- git diff --check passed

No full local npm test was run per the requested CI workflow. PR CI and exact-head Windows certification workflows are the final authority.

## Review focus

Please verify that only current and restart phases receive the released migration count, and that the Artifact fixture stays aligned with the runtime-owned reservation scope.