### PR TITLE
fix(host-help): register host.llm documentation

### DIFF
--- a/resources/skills/self-awareness/SKILL.md
+++ b/resources/skills/self-awareness/SKILL.md
@@ -82,6 +82,9 @@ Do not infer capabilities by reflecting over `host`, and do not treat this resul
 credential, permission, or readiness inventory. Call it again when current availability matters; each
 call returns a fresh frozen projection.
 
+`host.help()` documents registered topics only. A `not_found` result identifies missing Help
+documentation: `not_found` does not override `host.capabilities()` or prove that a method is absent.
+
 ## Discover managed Project files
 
 When `caps.artifacts === true`, use `await host.artifacts(options)` to list generated Artifacts and

--- a/src/main/host-sdk/help.test.ts
+++ b/src/main/host-sdk/help.test.ts
@@ -64,13 +64,13 @@ describe('Host SDK help', () => {
         aliases: [id.slice('host.'.length)]
       }))
     )
-    expect(JSON.stringify(catalog).length).toBeLessThanOrEqual(2_500)
+    expect(JSON.stringify(catalog).length).toBeLessThanOrEqual(2_700)
 
     const unavailableCatalog = hostSdkHelp.query(undefined, {
       callerRole: 'main',
       capabilities: unprovisioned
     })
-    expect(JSON.stringify(unavailableCatalog).length).toBeLessThanOrEqual(2_500)
+    expect(JSON.stringify(unavailableCatalog).length).toBeLessThanOrEqual(2_700)
   })
 
   it('documents the transient visual-model-gated viewImage contract', () => {
@@ -112,6 +112,54 @@ describe('Host SDK help', () => {
       call_forms: [{ signature: 'await host.listModels()' }],
       returns: { type: 'string[]' }
     })
+  })
+
+  it('documents host.llm through its JavaScript topic', () => {
+    const capabilities = { ...mainContext.capabilities, llm: true }
+    const help = hostSdkHelp.query('llm', {
+      ...mainContext,
+      capabilities
+    })
+    expect(help).toMatchObject({
+      kind: 'operation',
+      id: 'host.llm',
+      availability: { status: 'available' },
+      call_forms: [{ signature: 'await host.llm(request, options?)' }]
+    })
+    expect(hostSdkHelp.query('host.llm', { ...mainContext, capabilities })).toEqual(help)
+    if (help.kind !== 'operation') throw new Error('expected operation help')
+    expect(named(fields(help.request), 'prompt')).toMatchObject({
+      type: 'string',
+      required: true
+    })
+    expect(named(fields(help.options), 'maxConcurrency')).toMatchObject({
+      type: 'integer',
+      default: 2,
+      range: '1..4'
+    })
+    expect(fields(help.returns, 'success_fields').map(({ name }) => name)).toEqual([
+      'text',
+      'model',
+      'stopReason',
+      'usage'
+    ])
+    expect(fields(help.returns, 'batch_error_fields').map(({ name }) => name)).toEqual(['error'])
+    expect(
+      fields(help.returns, 'usage_fields').map(({ name, required }) => ({ name, required }))
+    ).toEqual([
+      { name: 'inputTokens', required: true },
+      { name: 'cacheTokens', required: true },
+      { name: 'outputTokens', required: true },
+      { name: 'cachedReadTokens', required: false },
+      { name: 'cachedWriteTokens', required: false },
+      { name: 'turnCount', required: false }
+    ])
+    expect(
+      hostSdkHelp.query('llm', {
+        ...mainContext,
+        capabilities: { ...mainContext.capabilities, llm: false }
+      })
+    ).toMatchObject({ availability: { status: 'unavailable' } })
   })
 
   it('keeps the published REPL subagent surface and Help registry in lockstep', () => {
@@ -327,7 +375,7 @@ describe('Host SDK help', () => {
     expect(hostSdkHelp.query('delegte', mainContext)).toEqual({
       kind: 'not_found',
       query: 'delegte',
-      suggestions: ['host.delegate', 'host.collect', 'host.children']
+      suggestions: ['host.delegate', 'host.collect', 'host.llm']
     })
     for (const unpublished of [
       'delegate.request',

--- a/src/main/host-sdk/help.ts
+++ b/src/main/host-sdk/help.ts
@@ -10,6 +10,7 @@ const HOST_SDK_OPERATION_IDS = Object.freeze(
   [
     ...HOST_SDK_SUBAGENT_OPERATION_IDS,
     'host.currentModel',
+    'host.llm',
     'host.listModels',
     'host.viewImage'
   ].sort()
@@ -22,6 +23,7 @@ type HostSdkHelpContext = Readonly<{
   capabilities: Readonly<
     Record<HostSdkSubagentOperation, boolean> & {
       currentModel?: boolean
+      llm?: boolean
       listModels?: boolean
       viewImage?: boolean
     }
@@ -767,6 +769,114 @@ const CURRENT_MODEL_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
       : { status: 'unavailable', reason: 'The calling Session model is unavailable.' }
 }
 
+const LLM_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
+  kind: 'operation',
+  id: 'host.llm',
+  path: 'host.llm',
+  aliases: ['llm'],
+  summary: 'Run bounded, one-shot, tool-less inference through the active Host LLM backend.',
+  call_forms: [{ signature: 'await host.llm(request, options?)', accepts: 'request_options' }],
+  request: {
+    accepts: ['prompt_string', 'exact_prompt_object', 'request_array'],
+    fields: [
+      {
+        name: 'prompt',
+        type: 'string',
+        required: true,
+        description: 'Non-empty prompt; an object request accepts no other fields.'
+      }
+    ]
+  },
+  options: {
+    fields: [
+      {
+        name: 'maxConcurrency',
+        type: 'integer',
+        required: false,
+        default: 2,
+        range: '1..4',
+        description: 'Batch-only concurrency bound.'
+      }
+    ]
+  },
+  returns: {
+    mirrorsInput: true,
+    success_fields: [
+      { name: 'text', type: 'string', required: true, description: 'Generated text.' },
+      { name: 'model', type: 'string', required: true, description: 'Observed model id.' },
+      {
+        name: 'stopReason',
+        type: 'string',
+        required: true,
+        description: 'end_turn, max_tokens, max_turn_requests, refusal, or cancelled.'
+      },
+      {
+        name: 'usage',
+        type: 'object',
+        required: false,
+        description: 'Provider-neutral camelCase token usage when available.'
+      }
+    ],
+    usage_fields: [
+      {
+        name: 'inputTokens',
+        type: 'integer',
+        required: true,
+        description: 'Non-negative input-token count.'
+      },
+      {
+        name: 'cacheTokens',
+        type: 'integer',
+        required: true,
+        description: 'Non-negative aggregate cache-token count.'
+      },
+      {
+        name: 'outputTokens',
+        type: 'integer',
+        required: true,
+        description: 'Non-negative output-token count.'
+      },
+      {
+        name: 'cachedReadTokens',
+        type: 'integer',
+        required: false,
+        description: 'Non-negative cache-read token count when available.'
+      },
+      {
+        name: 'cachedWriteTokens',
+        type: 'integer',
+        required: false,
+        description: 'Non-negative cache-write token count when available.'
+      },
+      {
+        name: 'turnCount',
+        type: 'integer',
+        required: false,
+        description: 'Positive provider-turn count when available.'
+      }
+    ],
+    batch_error_fields: [
+      { name: 'error', type: 'string', required: true, description: 'Public per-item failure.' }
+    ]
+  },
+  constraints: [
+    'JavaScript control REPL only; no caller-supplied model, tools, files, network, or system prompt.',
+    'Options are accepted only for batch calls; batches preserve request order and item count.',
+    'Each prompt is limited to 64 KiB; a batch is limited to 32 items and 512 KiB.'
+  ],
+  examples: [
+    { title: 'One-shot inference', code: "await host.llm('Summarize the findings.')" },
+    {
+      title: 'Bounded fan-out',
+      code: "await host.llm(['Classify A.', 'Classify B.'], { maxConcurrency: 2 })"
+    }
+  ],
+  resolveAvailability: ({ capabilities }) =>
+    capabilities.llm
+      ? { status: 'available' }
+      : { status: 'unavailable', reason: 'The active Host LLM route is unavailable.' }
+}
+
 const LIST_MODELS_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   kind: 'operation',
   id: 'host.listModels',
@@ -796,6 +906,7 @@ const OPERATION_DESCRIPTORS: readonly HostSdkHelpOperationDescriptor[] = [
   COLLECT_DESCRIPTOR,
   CURRENT_MODEL_DESCRIPTOR,
   DELEGATE_DESCRIPTOR,
+  LLM_DESCRIPTOR,
   LIST_MODELS_DESCRIPTOR,
   MESSAGE_RECEIPT_DESCRIPTOR,
   RESOLVE_MESSAGE_DESCRIPTOR,
@@ -816,7 +927,7 @@ if (JSON.stringify(registeredOperationIds) !== JSON.stringify(HOST_SDK_SUBAGENT_
 }
 
 const MAX_HELP_QUERY_CHARS = 128
-const MAX_CATALOG_RESULT_CHARS = 2_500
+const MAX_CATALOG_RESULT_CHARS = 2_700
 const MAX_OPERATION_RESULT_CHARS = 3_600
 const MAX_DELEGATE_RESULT_CHARS = 3_200
 

--- a/src/main/notebook/local-rpc-server.capabilities.test.ts
+++ b/src/main/notebook/local-rpc-server.capabilities.test.ts
@@ -221,6 +221,36 @@ describe('capabilitiesCall RPC', () => {
     })
   })
 
+  it('reports host.llm as available through authenticated host.help', async () => {
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      hostModel: {
+        isLlmAvailable: async () => true,
+        isCurrentModelAvailable: async () => false,
+        isListModelsAvailable: async () => false,
+        currentModel: async () => 'model-a',
+        listModels: async () => [],
+        call: async () => ({}) as never
+      }
+    })
+    const connection = await server.issueControlConnection(
+      'trusted-session',
+      'trusted-project',
+      'root-frame-trusted-session'
+    )
+
+    await expect(callHostSdkHelp(connection, 'llm')).resolves.toMatchObject({
+      response: { status: 200 },
+      payload: {
+        result: {
+          kind: 'operation',
+          id: 'host.llm',
+          availability: { status: 'available' }
+        }
+      }
+    })
+  })
+
   it('does not advertise host.viewImage without a trusted execution workspace', async () => {
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
       transport: 'tcp',

--- a/src/main/notebook/local-rpc-server.delegated-work.test.ts
+++ b/src/main/notebook/local-rpc-server.delegated-work.test.ts
@@ -126,7 +126,10 @@ describe('authenticated delegatedWorkCall route', () => {
     ).toEqual({
       'host.children': 'unavailable',
       'host.collect': 'unavailable',
+      'host.currentModel': 'unavailable',
       'host.delegate': 'unavailable',
+      'host.listModels': 'unavailable',
+      'host.llm': 'unavailable',
       'host.messageReceipt': 'unavailable',
       'host.resolveMessage': 'unavailable',
       'host.sendFrameMessage': 'unavailable',

--- a/src/main/skills/self-awareness-skill.test.ts
+++ b/src/main/skills/self-awareness-skill.test.ts
@@ -93,6 +93,7 @@ describe('self-awareness bundled Skill', () => {
       'agentFrameId',
       'latestVersionCreatedAt',
       '`count` is the total number of matches',
+      '`not_found` does not override `host.capabilities()`',
       '`maxDepth`',
       '`maxNodes`',
       '`rootsOnly`',


### PR DESCRIPTION
## Problem

`host.llm()` was callable and advertised by `host.capabilities()`, but it was absent from the Host SDK Help registry. Agents could therefore interpret `host.help("llm")` returning `not_found` as proof that the method did not exist.

## Proposed change

- Register `host.llm` and its `llm` alias in `host.help()`.
- Document the JavaScript request, batch option, result, nested usage, and per-item error fields with camelCase public names.
- Project availability from the authenticated Host LLM capability.
- Clarify in the bundled self-awareness Skill that missing Help documentation cannot override `host.capabilities()`.
- Synchronize the delegated-session exact Help catalog expectation with `host.currentModel`, `host.listModels`, and `host.llm`.

## Scope and non-goals

- No change to Host LLM execution, model routing, capability projection, or compatibility behavior.
- No architecture, database, data relationship, persistence, renderer, or user-interaction change.
- No historical alias or schema compatibility layer.

## Acceptance criteria and validation

All listed checks ran after the final material edit:

- Help topic, aliases, camelCase body, availability, catalog bounds, and Skill contract: focused Vitest set passed, 6 files with 131 tests passed and 30 skipped.
- Authenticated local RPC Help projection and delegated catalog behavior: included in the focused Vitest set and passed.
- Node main-process types: `npm run typecheck:node` passed.
- Repository lint: `npm run lint` passed.
- Formatting and patch integrity: Prettier check and `git diff --check` passed.
- Independent Standards and Spec reviews: no findings.

Web typecheck and platform-specific lanes are excluded locally because this change does not touch renderer, preload, shared wire types, persistence, native, or platform-specific behavior. PR CI is authoritative for the complete portable and platform test plan.

## Review focus

- Accuracy of the `host.llm` Help request/result schema against the JavaScript REPL adapter.
- Capability-derived availability and `not_found` guidance.
- The bounded catalog size increase required by the newly registered topic.