### PR TITLE
fix(delegation): allow legacy sessions to adopt framework identity

### DIFF
--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -558,6 +558,38 @@ afterEach(async () => {
 })
 
 describe('production delegated-work composition', () => {
+  it('lets a legacy Session without delegated history establish its durable framework identity', async () => {
+    root = await mkdtemp(join(tmpdir(), 'delegated-production-legacy-identity-'))
+    const harness = await createCompositionHarness(root, 'claude-code')
+    const legacy = structuredClone(harness.session)
+    delete legacy.agentFrameworkId
+    harness.replaceDurable(legacy)
+
+    await expect(harness.composition.root.wakeMessages?.(legacy.id)).resolves.toBeUndefined()
+    expect(harness.selected).toEqual([])
+
+    harness.replaceDurable({ ...harness.durable(), agentFrameworkId: 'claude-code' })
+    await expect(harness.composition.root.wakeMessages?.(legacy.id)).resolves.toBeUndefined()
+    expect(harness.selected).toEqual(['claude-code'])
+  })
+
+  it('rejects a missing framework identity when delegated history already exists', async () => {
+    root = await mkdtemp(join(tmpdir(), 'delegated-production-invalid-identity-'))
+    const harness = await createCompositionHarness(root, 'opencode')
+    const invalid = structuredClone(harness.session)
+    delete invalid.agentFrameworkId
+    invalid.runtimeContext = {
+      version: 1,
+      revision: 1,
+      delegatedWork: { records: [] }
+    }
+    harness.replaceDurable(invalid)
+
+    await expect(harness.composition.root.wakeMessages?.(invalid.id)).rejects.toThrow(
+      'Delegated Work requires a durable Session framework identity.'
+    )
+  })
+
   it('rejects a removed own context field before reservation, workspace, or durable mutation', async () => {
     root = await mkdtemp(join(tmpdir(), 'delegated-production-removed-context-'))
     const harness = await createCompositionHarness(root, 'codex')

--- a/src/main/delegation/production-composition.ts
+++ b/src/main/delegation/production-composition.ts
@@ -405,6 +405,15 @@ const createProductionDelegatedWorkComposition = (
       await Promise.all(
         durableSessions
           .filter((session) => session.id === sessionId)
+          // A pre-framework-identity Session cannot contain app-owned delegated work. Let its ACP
+          // resume return the resolved framework so the existing renderer persistence path can
+          // durably adopt it. If delegated state exists, keep createScopedWork's strict identity
+          // check because guessing would risk replaying work through the wrong framework.
+          .filter(
+            (session) =>
+              session.agentFrameworkId !== undefined ||
+              session.runtimeContext?.delegatedWork !== undefined
+          )
           .map((session) => workFor({ projectId: session.projectId, sessionId: session.id }))
       )
       const scoped = await worksForSession(sessionId)


### PR DESCRIPTION
## Problem

Historical Sessions can omit `agentFrameworkId`. ACP can still resolve and attach the selected runtime, but the post-resume delegated-message wake reads the durable Session before the renderer can persist that resolved identity. Production delegation then throws `Delegated Work requires a durable Session framework identity.`, causing both `acp:resume-session` and otherwise successful `acp:send-prompt` calls to reject.

## Proposed change

Skip cold delegated-message wake only when a Session has neither a durable framework identity nor any delegated-work history. This lets ACP resume return the framework it actually used, after which the existing renderer persistence path records that identity. Sessions that already contain delegated state still require an explicit durable identity and continue to fail closed.

Add regression coverage for both the compatible historical path and the inconsistent-data rejection path.

## Scope and non-goals

- No framework identity is guessed from current Settings or conversation order.
- No delegated-message delivery failure is broadly swallowed.
- No new state or enum value is introduced.
- No database schema or migration is added. The compatible path reuses the existing optional `agentFrameworkId` Session field and existing resume persistence flow.
- Framework-specific execution is unchanged. Claude Code, OpenCode, Codex Responses, and Codex Bridge all pass through this shared pre-composition guard; both Codex routes use the durable `codex` framework identity at this boundary.

## Acceptance criteria and validation

- Historical Session recovery -> `npm test -- src/main/delegation/production-composition.test.ts -t "legacy Session without delegated history|missing framework identity when delegated history"` -> passed, 2 tests.
- Main-process type safety -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed.
- Diff hygiene -> `git diff --check` -> passed.

The listed checks ran after the last material source edit. Full `npm test` was intentionally not run per maintainer request; PR CI remains authoritative for the complete portable and platform test plan. The final targeted rerun was later blocked by the Windows sandbox's `spawn EPERM` after the approval service hit its usage limit; the final test content was restored to the exact state that produced the passing targeted result.

## Review focus

- Confirm that absence of `runtimeContext.delegatedWork` is the correct compatibility boundary for pre-delegation Sessions.
- Confirm that retaining the strict failure when delegated history exists prevents replay through an inferred or changed framework.
