### PR TITLE
feat(workspace): branch from completed Agent messages

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -33,6 +33,7 @@
         "src/renderer/src/lib/acp/workspace-events.ts",
         "src/renderer/src/lib/acp/workspace-runtime-event-owner.ts",
         "src/renderer/src/lib/acp/workspace-runtime-prompt-preparation-owner.ts",
+        "src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.ts",
         "src/renderer/src/lib/acp/workspace-runtime-command-owner.ts",
         "src/renderer/src/lib/acp/workspace-runtime-session-lifecycle-owner.ts",
         "src/renderer/src/lib/acp/workspace-runtime-save-as-skill-owner.ts",

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
@@ -72,10 +72,14 @@ const productionSources = (): readonly string[] => {
 const ownerNames = [
   'workspace-runtime-event-owner',
   'workspace-runtime-prompt-preparation-owner',
+  'workspace-runtime-session-branch-owner',
   'workspace-runtime-command-owner',
   'workspace-runtime-session-lifecycle-owner',
   'workspace-runtime-save-as-skill-owner'
 ] as const
+const facadeOwnerNames = ownerNames.filter(
+  (name) => name !== 'workspace-runtime-session-branch-owner'
+)
 const ownerTargets = new Map(ownerNames.map((name) => [name, modulePath(resolve(__dirname, name))]))
 const ownerFilePath = (name: (typeof ownerNames)[number]): string => `${ownerTargets.get(name)}.ts`
 const privateOwnerTargets = new Set(ownerTargets.values())
@@ -471,6 +475,7 @@ const hookKeys = [
 const sendIntentKeys = [
   'sessionId',
   'branchSourceSessionId',
+  'branchSourceMessageId',
   'text',
   'turnIntent',
   'planContinuation',
@@ -598,7 +603,7 @@ describe('workspace runtime architecture', () => {
     expect(readSource(facadePath)).toContain('window.api?.acp?.onAgentRuntimeUpdate')
   })
   it('keeps the owner dependency DAG explicit and acyclic', () => {
-    expect(ownerDependencyNames(facadePath)).toEqual(ownerNames)
+    expect(ownerDependencyNames(facadePath)).toEqual(facadeOwnerNames)
     expect(
       Object.fromEntries(
         ownerNames.map((name) => [name, ownerDependencyNames(ownerFilePath(name))])
@@ -606,7 +611,11 @@ describe('workspace runtime architecture', () => {
     ).toEqual({
       'workspace-runtime-event-owner': [],
       'workspace-runtime-prompt-preparation-owner': [],
-      'workspace-runtime-command-owner': ['workspace-runtime-prompt-preparation-owner'],
+      'workspace-runtime-session-branch-owner': [],
+      'workspace-runtime-command-owner': [
+        'workspace-runtime-prompt-preparation-owner',
+        'workspace-runtime-session-branch-owner'
+      ],
       'workspace-runtime-session-lifecycle-owner': [
         'workspace-runtime-prompt-preparation-owner',
         'workspace-runtime-command-owner'

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -2635,6 +2635,62 @@ describe('workspace agent message sending', () => {
     expect(useSessionStore.getState().selectedSessionId).toBe('branched-session')
   })
 
+  it('rejects a prompt while an idle branched Session is still binding', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'source-session',
+      content: 'Inspect the original data',
+      cwd: '/workspace/project',
+      projectId: 'project-1'
+    })
+    const firstAnswer = useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'source-session',
+      streamId: 'source-stream',
+      eventId: 'source-event',
+      content: 'The original analysis is complete.'
+    })
+    useSessionStore.getState().finishRun('source-session')
+    const created = createDeferred<{ sessionId: string; cwd?: string }>()
+    const saveSession = vi.fn(async (session: PersistedChatSession) => session)
+    vi.stubGlobal('window', { api: { sessions: { saveSession } } })
+    const runtime = {
+      state: createSnapshot(['source-session']),
+      createSession: vi.fn(() => created.promise),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      deleteSession: vi.fn(),
+      sendPrompt: vi.fn()
+    }
+
+    const branchPromise = sendWorkspaceMessage(runtime, {
+      branchSourceSessionId: 'source-session',
+      branchSourceMessageId: firstAnswer?.messageId ?? '',
+      text: ''
+    })
+    await vi.waitFor(() => expect(runtime.createSession).toHaveBeenCalledOnce())
+    const pending = useSessionStore.getState().sessions.find((session) => session.isPending)
+    expect(pending).toBeDefined()
+    if (!pending) throw new Error('Expected a pending branched Session')
+
+    const immediateSend = await sendWorkspaceMessage(runtime, {
+      sessionId: pending.id,
+      text: 'Follow up before binding completes'
+    })
+
+    expect(immediateSend).toBeUndefined()
+    expect(pending.messages.map((message) => message.content)).toEqual([
+      'Inspect the original data',
+      'The original analysis is complete.'
+    ])
+    expect(runtime.createSession).toHaveBeenCalledOnce()
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+
+    created.resolve({ sessionId: 'branched-session', cwd: '/workspace/project' })
+    await expect(branchPromise).resolves.toEqual({
+      sessionId: 'branched-session',
+      messageId: firstAnswer?.messageId
+    })
+  })
+
   it('omits history images when branching into a text-only model', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'source-session',

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -2557,6 +2557,84 @@ describe('workspace agent message sending', () => {
     )
   })
 
+  it('creates and persists an idle branched Session without sending a prompt', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'source-session',
+      content: 'Inspect the original data',
+      cwd: '/workspace/project',
+      projectId: 'project-1'
+    })
+    const firstAnswer = useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'source-session',
+      streamId: 'source-stream',
+      eventId: 'source-event',
+      content: 'The original analysis is complete.'
+    })
+    useSessionStore.getState().finishRun('source-session')
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'source-session',
+      content: 'Continue in the source Session'
+    })
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'source-session',
+      streamId: 'later-stream',
+      eventId: 'later-event',
+      content: 'Later answer'
+    })
+    useSessionStore.getState().finishRun('source-session')
+    const saveSession = vi.fn(async (session: PersistedChatSession) => session)
+    vi.stubGlobal('window', { api: { sessions: { saveSession } } })
+    const runtime = {
+      state: createSnapshot(['source-session']),
+      createSession: vi.fn().mockResolvedValue({
+        sessionId: 'branched-session',
+        cwd: '/workspace/project'
+      }),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      deleteSession: vi.fn(),
+      sendPrompt: vi.fn()
+    }
+
+    const branched = await sendWorkspaceMessage(runtime, {
+      branchSourceSessionId: 'source-session',
+      branchSourceMessageId: firstAnswer?.messageId ?? '',
+      text: '',
+      agentFrameworkId: 'codex',
+      agentBackendId: 'codex:shared',
+      agentModel: 'gpt-5.4',
+      specialistId: 'specialist-b'
+    })
+
+    expect(branched).toEqual({
+      sessionId: 'branched-session',
+      messageId: firstAnswer?.messageId
+    })
+    expect(runtime.createSession).toHaveBeenCalledWith(
+      '/workspace/project',
+      'project-1',
+      'ask',
+      'specialist-b'
+    )
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+    expect(saveSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'branched-session',
+        status: 'idle',
+        agentFrameworkId: 'codex',
+        agentBackendId: 'codex:shared',
+        agentModel: 'gpt-5.4',
+        specialistId: 'specialist-b',
+        pendingHistoryReplay: { kind: 'all' },
+        messages: [
+          expect.objectContaining({ content: 'Inspect the original data' }),
+          expect.objectContaining({ content: 'The original analysis is complete.' })
+        ]
+      })
+    )
+    expect(useSessionStore.getState().selectedSessionId).toBe('branched-session')
+  })
+
   it('omits history images when branching into a text-only model', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'source-session',

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -432,6 +432,7 @@ const sendWorkspaceMessage = async (
     if (isWorkspacePromptPreparationInFlight(sessionId)) return undefined
     if (
       runtime.state.promptInFlightSessionIds.includes(sessionId) ||
+      (session?.isPending && session.status === 'idle' && Boolean(session.branchSource)) ||
       (session?.compacting && !input.allowCompactionRecovery) ||
       session?.status === 'running' ||
       session?.status === 'waiting-for-user' ||

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -25,11 +25,16 @@ import {
   isWorkspacePromptPreparationInFlight,
   prepareExistingWorkspacePrompt
 } from './workspace-runtime-prompt-preparation-owner'
+import {
+  branchWorkspaceSessionFromMessage,
+  reconcileBranchedAttachments
+} from './workspace-runtime-session-branch-owner'
 import type { useAcpRuntime } from './useAcpRuntime'
 
 type SendWorkspaceMessageIntent = {
   sessionId?: string
   branchSourceSessionId?: string
+  branchSourceMessageId?: string
   text: string
   turnIntent?: 'plan-first'
   planContinuation?: Pick<ActivePlanProjection, 'artifactVersionId' | 'revision'> & {
@@ -147,48 +152,6 @@ const finalizeAttachments = async (
   })
   usePreviewWorkbenchStore.getState().reconcileFinalizedUploads(finalized)
   return finalized
-}
-
-const reconcileBranchedAttachments = async (
-  sourceSessionId: string,
-  childSessionId: string,
-  messages: ChatMessage[],
-  projectId?: string
-): Promise<void> => {
-  const stagedById = new Map<string, UploadedAttachment>()
-  for (const message of messages) {
-    for (const upload of message.uploads ?? []) {
-      if (!upload.versionId && !stagedById.has(upload.id)) {
-        stagedById.set(upload.id, toRuntimeUploadedAttachment(upload, projectId))
-      }
-    }
-  }
-  if (stagedById.size === 0) return
-
-  const finalized = await window.api.uploads.finalizeSession({
-    projectId,
-    sessionId: sourceSessionId,
-    attachments: [...stagedById.values()]
-  })
-  const finalizedById = new Map(finalized.map((upload) => [upload.id, upload]))
-  for (const stagedId of stagedById.keys()) {
-    if (!finalizedById.has(stagedId)) {
-      throw new Error(`Upload finalization did not return the staged attachment: ${stagedId}`)
-    }
-  }
-  for (const message of messages) {
-    if (!message.uploads?.some((upload) => stagedById.has(upload.id))) continue
-    const uploads = message.uploads.map((upload) => {
-      const replacement = finalizedById.get(upload.id)
-      return replacement ? toPersistedUploadedAttachment(replacement) : upload
-    })
-    for (const sessionId of [sourceSessionId, childSessionId]) {
-      useSessionStore
-        .getState()
-        .replaceMessageUploads({ sessionId, messageId: message.id, uploads })
-    }
-  }
-  usePreviewWorkbenchStore.getState().reconcileFinalizedUploads(finalized)
 }
 
 const replayHistory = (
@@ -314,13 +277,14 @@ const startPendingPrompt = (
       providerSessionId: created.providerSessionId,
       providerContinuityToken: created.providerContinuityToken
     })
-    if (!bound || !ownsPrompt(created.sessionId, bound.messageId)) return
+    const boundMessageId = bound?.messageId
+    if (!boundMessageId || !ownsPrompt(created.sessionId, boundMessageId)) return
 
     let attachments = request.attachments
     try {
       attachments = await finalizeAttachments(
         created.sessionId,
-        bound.messageId,
+        boundMessageId,
         attachments,
         request.projectName
       )
@@ -328,7 +292,7 @@ const startPendingPrompt = (
       useSessionStore.getState().failRun(created.sessionId, errorMessage(error))
       return
     }
-    if (!ownsPrompt(created.sessionId, bound.messageId)) return
+    if (!ownsPrompt(created.sessionId, boundMessageId)) return
 
     const boundSession = useSessionStore
       .getState()
@@ -348,17 +312,17 @@ const startPendingPrompt = (
         } catch (cleanupError) {
           console.warn('Agent Session cleanup after persistence failure failed', cleanupError)
         }
-        if (ownsPrompt(created.sessionId, bound.messageId)) {
+        if (ownsPrompt(created.sessionId, boundMessageId)) {
           useSessionStore.getState().failRun(created.sessionId, errorMessage(error))
         }
         return
       }
-      if (!ownsPrompt(created.sessionId, bound.messageId)) return
+      if (!ownsPrompt(created.sessionId, boundMessageId)) return
     }
 
     dispatchPrompt(runtime, {
       sessionId: created.sessionId,
-      messageId: bound.messageId,
+      messageId: boundMessageId,
       content: request.content,
       attachments,
       forcedSkillIds: request.forcedSkillIds,
@@ -366,7 +330,7 @@ const startPendingPrompt = (
       replay: { ...request.replay, contextReset: Boolean(request.contextReset) },
       turnIntent: request.turnIntent,
       accepted: () =>
-        useSessionStore.getState().clearPendingContextReplay(created.sessionId, bound.messageId)
+        useSessionStore.getState().clearPendingContextReplay(created.sessionId, boundMessageId)
     })
   })()
 }
@@ -376,6 +340,16 @@ const sendWorkspaceMessage = async (
   input: SendWorkspaceMessageCommand,
   lifecycle: WorkspaceCommandLifecycle = {}
 ): Promise<SendWorkspaceMessageResult | undefined> => {
+  if (input.branchSourceSessionId && input.branchSourceMessageId) {
+    return branchWorkspaceSessionFromMessage(runtime, {
+      sourceSessionId: input.branchSourceSessionId,
+      sourceMessageId: input.branchSourceMessageId,
+      agentFrameworkId: input.agentFrameworkId,
+      agentBackendId: input.agentBackendId,
+      agentModel: input.agentModel,
+      specialistId: input.specialistId
+    })
+  }
   const content = input.text.trim()
   const replaySession = input.sessionId
     ? useSessionStore.getState().sessions.find((item) => item.id === input.sessionId)
@@ -405,12 +379,13 @@ const sendWorkspaceMessage = async (
       agentModel: input.agentModel,
       specialistId: input.specialistId
     })
-    if (!pending) return undefined
+    if (!pending?.messageId) return undefined
+    const pendingPrompt = { sessionId: pending.sessionId, messageId: pending.messageId }
     const session = useSessionStore
       .getState()
       .sessions.find((item) => item.id === pending.sessionId)
     if (!session) return undefined
-    let history = session.messages.filter((message) => message.id !== pending.messageId)
+    let history = session.messages.filter((message) => message.id !== pendingPrompt.messageId)
     try {
       await reconcileBranchedAttachments(
         input.branchSourceSessionId,
@@ -422,22 +397,22 @@ const sendWorkspaceMessage = async (
         .getState()
         .sessions.find((item) => item.id === pending.sessionId)
       if (!reconciled) return undefined
-      if (!ownsPrompt(pending.sessionId, pending.messageId)) return pending
-      history = reconciled.messages.filter((message) => message.id !== pending.messageId)
+      if (!ownsPrompt(pendingPrompt.sessionId, pendingPrompt.messageId)) return pendingPrompt
+      history = reconciled.messages.filter((message) => message.id !== pendingPrompt.messageId)
     } catch (error) {
       useSessionStore.getState().failRun(pending.sessionId, errorMessage(error))
-      return pending
+      return pendingPrompt
     }
     let replay: HistoryReplayContext | undefined
     try {
       replay = replayHistory(history, input, session.projectId)
     } catch (error) {
       useSessionStore.getState().failRun(pending.sessionId, errorMessage(error))
-      return pending
+      return pendingPrompt
     }
     startPendingPrompt(runtime, {
       ...input,
-      pending,
+      pending: pendingPrompt,
       content,
       attachments,
       cwd: session.cwd || input.cwd,
@@ -447,7 +422,7 @@ const sendWorkspaceMessage = async (
       replay,
       contextReset: true
     })
-    return pending
+    return pendingPrompt
   }
 
   if (input.sessionId) {

--- a/src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.ts
@@ -1,0 +1,127 @@
+import { DEFAULT_PERMISSION_PROFILE } from '../../../../shared/permission-profiles'
+import {
+  toPersistedUploadedAttachment,
+  toRuntimeUploadedAttachment,
+  type UploadedAttachment
+} from '../../../../shared/uploads'
+import type { AgentFrameworkId } from '../../../../shared/settings'
+import { saveSessionInOrder } from '../session-persistence/session-persistence'
+import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
+import { toPersistedSession, useSessionStore, type ChatMessage } from '../../stores/session-store'
+import type { useAcpRuntime } from './useAcpRuntime'
+
+export type BranchWorkspaceSessionFromMessageIntent = {
+  sourceSessionId: string
+  sourceMessageId: string
+  agentFrameworkId?: AgentFrameworkId
+  agentBackendId?: string
+  agentModel?: string
+  specialistId?: string | null
+}
+
+export type BranchWorkspaceSessionFromMessageResult = {
+  sessionId: string
+  messageId: string
+}
+
+type WorkspaceSessionBranchRuntime = Pick<ReturnType<typeof useAcpRuntime>, 'createSession'> &
+  Partial<Pick<ReturnType<typeof useAcpRuntime>, 'deleteSession'>>
+
+export const reconcileBranchedAttachments = async (
+  sourceSessionId: string,
+  childSessionId: string,
+  messages: ChatMessage[],
+  projectId?: string
+): Promise<void> => {
+  const stagedById = new Map<string, UploadedAttachment>()
+  for (const message of messages) {
+    for (const upload of message.uploads ?? []) {
+      if (!upload.versionId && !stagedById.has(upload.id)) {
+        stagedById.set(upload.id, toRuntimeUploadedAttachment(upload, projectId))
+      }
+    }
+  }
+  if (stagedById.size === 0) return
+
+  const finalized = await window.api.uploads.finalizeSession({
+    projectId,
+    sessionId: sourceSessionId,
+    attachments: [...stagedById.values()]
+  })
+  const finalizedById = new Map(finalized.map((upload) => [upload.id, upload]))
+  for (const stagedId of stagedById.keys()) {
+    if (!finalizedById.has(stagedId)) {
+      throw new Error(`Upload finalization did not return the staged attachment: ${stagedId}`)
+    }
+  }
+  for (const message of messages) {
+    if (!message.uploads?.some((upload) => stagedById.has(upload.id))) continue
+    const uploads = message.uploads.map((upload) => {
+      const replacement = finalizedById.get(upload.id)
+      return replacement ? toPersistedUploadedAttachment(replacement) : upload
+    })
+    for (const sessionId of [sourceSessionId, childSessionId]) {
+      useSessionStore
+        .getState()
+        .replaceMessageUploads({ sessionId, messageId: message.id, uploads })
+    }
+  }
+  usePreviewWorkbenchStore.getState().reconcileFinalizedUploads(finalized)
+}
+
+export const branchWorkspaceSessionFromMessage = async (
+  runtime: WorkspaceSessionBranchRuntime,
+  input: BranchWorkspaceSessionFromMessageIntent
+): Promise<BranchWorkspaceSessionFromMessageResult | undefined> => {
+  const pending = useSessionStore.getState().branchInNewSession(input)
+  if (!pending || pending.messageId) return undefined
+
+  const pendingSession = useSessionStore
+    .getState()
+    .sessions.find((session) => session.id === pending.sessionId)
+  if (!pendingSession) return undefined
+
+  let createdSessionId: string | undefined
+  try {
+    await reconcileBranchedAttachments(
+      input.sourceSessionId,
+      pending.sessionId,
+      pendingSession.messages,
+      pendingSession.projectId
+    )
+    const created = await runtime.createSession(
+      pendingSession.cwd || undefined,
+      pendingSession.projectId,
+      pendingSession.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
+      pendingSession.specialistId
+    )
+    const sessionId = created?.sessionId
+    if (!sessionId) throw new Error('Agent session could not be created.')
+    createdSessionId = sessionId
+
+    const bound = useSessionStore.getState().bindPendingSession({
+      pendingSessionId: pending.sessionId,
+      sessionId,
+      cwd: created.cwd,
+      agentFrameworkId: created.frameworkId,
+      agentBackendId: created.backendId,
+      providerSessionId: created.providerSessionId,
+      providerContinuityToken: created.providerContinuityToken
+    })
+    if (!bound) throw new Error('Branched Session could not be created.')
+
+    const boundSession = useSessionStore
+      .getState()
+      .sessions.find((session) => session.id === sessionId)
+    if (!boundSession) throw new Error('Branched Session could not be created.')
+    await saveSessionInOrder(toPersistedSession(boundSession))
+    return { sessionId, messageId: input.sourceMessageId }
+  } catch (error) {
+    const failedSessionId = createdSessionId ?? pending.sessionId
+    useSessionStore.getState().deleteSession(failedSessionId)
+    if (createdSessionId && runtime.deleteSession) {
+      await runtime.deleteSession(createdSessionId).catch(() => undefined)
+    }
+    throw error
+  }
+}

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -387,7 +387,8 @@ const createPanelDefaults = (): PanelProps => ({
     availability: {
       submit: false,
       revise: true,
-      resume: true
+      resume: true,
+      branch: true
     },
     actions: {
       submit: {
@@ -395,6 +396,7 @@ const createPanelDefaults = (): PanelProps => ({
         restoredPlan: vi.fn().mockResolvedValue(undefined)
       },
       revise: vi.fn(),
+      branch: vi.fn(),
       sideChat: { start: vi.fn() },
       resume: vi.fn().mockResolvedValue(undefined),
       cancel: vi.fn(),
@@ -417,6 +419,7 @@ const createPanelDefaults = (): PanelProps => ({
         unavailable: false,
         hasPendingSwitch: false,
         barrierInFlight: false,
+        sendAvailable: true,
         reconfigureError: null
       }
     },

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -329,10 +329,16 @@ const ConversationPanel = ({
     }
   } = composer
   const {
-    availability: { submit: canSendMessage, revise: canEditMessage, resume: canResumeSession },
+    availability: {
+      submit: canSendMessage,
+      revise: canEditMessage,
+      resume: canResumeSession,
+      branch: canBranchInNewSession
+    },
     actions: {
       submit: { draft: submitDraft, restoredPlan: onRespondToRestoredPlan },
       revise: onSendEditedMessage,
+      branch: onBranchFromAgentMessage,
       sideChat: { start: onStartSideChat },
       resume: onResumeSession,
       cancel: onCancelRun
@@ -739,6 +745,8 @@ const ConversationPanel = ({
             isResumingSession={isResuming}
             notebookReference={notebookReference}
             onSendEditedMessage={onSendEditedMessage}
+            canBranchInNewSession={canBranchInNewSession}
+            onBranchInNewSession={onBranchFromAgentMessage}
             pendingElicitations={sideChat ? [] : sessionPendingElicitations}
             handoffLifecycleSource={workspaceHandoffLifecycleClient}
             onRetryHandoff={(request) => workspaceHandoffLifecycleClient.retry(request)}

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
@@ -51,6 +51,8 @@ const renderItem = async (
     canEditMessage?: boolean
     showUserActions?: boolean
     onSendEditedMessage?: (messageId: string, doc: ComposerDoc) => void
+    canBranchInNewSession?: boolean
+    onBranchInNewSession?: (messageId: string) => void
     subsequentTurns?: number
     revisionNavigation?: {
       index: number
@@ -72,6 +74,8 @@ const renderItem = async (
         canEditMessage={options.canEditMessage ?? false}
         showUserActions={options.showUserActions}
         onSendEditedMessage={options.onSendEditedMessage}
+        canBranchInNewSession={options.canBranchInNewSession}
+        onBranchInNewSession={options.onBranchInNewSession}
         subsequentTurns={options.subsequentTurns ?? 0}
         revisionNavigation={options.revisionNavigation}
         reviewerCorrectionActive={options.reviewerCorrectionActive}
@@ -145,6 +149,43 @@ afterEach(() => {
 })
 
 describe('WorkspaceMessageItem user message actions', () => {
+  it('keeps Branch in new session first in a completed Agent Message footer', async () => {
+    const onBranchInNewSession = vi.fn()
+    await renderItem(
+      createMessage({
+        id: 'agent-message',
+        role: 'agent',
+        content: 'Completed analysis',
+        completedAt: 1710000001000
+      }),
+      { canBranchInNewSession: true, onBranchInNewSession }
+    )
+
+    const footer = container.querySelector('[data-slot="assistant-message-footer"]')
+    const branchButton = getButton('Branch in new session')
+    const completedTime = footer?.querySelector('time')
+    if (!footer || !completedTime) throw new Error('completed Agent Message footer not found')
+
+    expect(
+      branchButton.compareDocumentPosition(completedTime) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    await click(branchButton)
+    expect(onBranchInNewSession).toHaveBeenCalledWith('agent-message')
+  })
+
+  it('keeps the completed Agent Message branch action visible but disabled when unavailable', async () => {
+    const onBranchInNewSession = vi.fn()
+    await renderItem(
+      createMessage({ role: 'agent', content: 'Completed analysis', completedAt: 1710000001000 }),
+      { canBranchInNewSession: false, onBranchInNewSession }
+    )
+
+    const branchButton = getButton('Branch in new session')
+    expect(branchButton.disabled).toBe(true)
+    await click(branchButton)
+    expect(onBranchInNewSession).not.toHaveBeenCalled()
+  })
+
   it('presents a settled Reviewer Correction as a compact content-free status row', async () => {
     await renderItem(
       createMessage({

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
@@ -149,7 +149,7 @@ afterEach(() => {
 })
 
 describe('WorkspaceMessageItem user message actions', () => {
-  it('keeps Copy before Branch in a completed Agent Message footer', async () => {
+  it('groups Copy tightly before Branch in a completed Agent Message footer', async () => {
     const onBranchInNewSession = vi.fn()
     await renderItem(
       createMessage({
@@ -162,11 +162,17 @@ describe('WorkspaceMessageItem user message actions', () => {
     )
 
     const footer = container.querySelector('[data-slot="assistant-message-footer"]')
+    const actionGroup = footer?.querySelector('[data-slot="assistant-message-actions"]')
     const copyButton = getButton('Copy message')
     const branchButton = getButton('Branch in new session')
     const completedTime = footer?.querySelector('time')
-    if (!footer || !completedTime) throw new Error('completed Agent Message footer not found')
+    if (!footer || !actionGroup || !completedTime) {
+      throw new Error('completed Agent Message footer not found')
+    }
 
+    expect(actionGroup.classList.contains('gap-0.5')).toBe(true)
+    expect(actionGroup.contains(copyButton)).toBe(true)
+    expect(actionGroup.contains(branchButton)).toBe(true)
     expect(
       copyButton.compareDocumentPosition(branchButton) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING)

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
@@ -149,7 +149,7 @@ afterEach(() => {
 })
 
 describe('WorkspaceMessageItem user message actions', () => {
-  it('keeps Branch in new session first in a completed Agent Message footer', async () => {
+  it('keeps Copy before Branch in a completed Agent Message footer', async () => {
     const onBranchInNewSession = vi.fn()
     await renderItem(
       createMessage({
@@ -162,13 +162,19 @@ describe('WorkspaceMessageItem user message actions', () => {
     )
 
     const footer = container.querySelector('[data-slot="assistant-message-footer"]')
+    const copyButton = getButton('Copy message')
     const branchButton = getButton('Branch in new session')
     const completedTime = footer?.querySelector('time')
     if (!footer || !completedTime) throw new Error('completed Agent Message footer not found')
 
     expect(
+      copyButton.compareDocumentPosition(branchButton) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(
       branchButton.compareDocumentPosition(completedTime) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    await click(copyButton)
+    expect(writeText).toHaveBeenCalledWith('Completed analysis')
     await click(branchButton)
     expect(onBranchInNewSession).toHaveBeenCalledWith('agent-message')
   })

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -1162,31 +1162,36 @@ const WorkspaceMessageItemImpl = ({
               >
                 {message.status === 'complete' && onBranchInNewSession ? (
                   <TooltipProvider delayDuration={200}>
-                    <UserMessageActionTooltip label={copied ? t('Copied') : t('Copy message')}>
-                      <button
-                        type="button"
-                        className={userMessageActionButtonClassName}
-                        aria-label={copied ? t('Copied') : t('Copy message')}
-                        onClick={handleCopyMessage}
-                      >
-                        {copied ? (
-                          <Check className="size-3.5" strokeWidth={2} aria-hidden="true" />
-                        ) : (
-                          <Copy className="size-3.5" strokeWidth={2} aria-hidden="true" />
-                        )}
-                      </button>
-                    </UserMessageActionTooltip>
-                    <UserMessageActionTooltip label={t('Branch in new session')}>
-                      <button
-                        type="button"
-                        className={userMessageActionButtonClassName}
-                        aria-label={t('Branch in new session')}
-                        disabled={!canBranchInNewSession}
-                        onClick={() => onBranchInNewSession(message.id)}
-                      >
-                        <GitBranch className="size-3.5" strokeWidth={2} aria-hidden="true" />
-                      </button>
-                    </UserMessageActionTooltip>
+                    <div
+                      data-slot="assistant-message-actions"
+                      className="flex items-center gap-0.5"
+                    >
+                      <UserMessageActionTooltip label={copied ? t('Copied') : t('Copy message')}>
+                        <button
+                          type="button"
+                          className={userMessageActionButtonClassName}
+                          aria-label={copied ? t('Copied') : t('Copy message')}
+                          onClick={handleCopyMessage}
+                        >
+                          {copied ? (
+                            <Check className="size-3.5" strokeWidth={2} aria-hidden="true" />
+                          ) : (
+                            <Copy className="size-3.5" strokeWidth={2} aria-hidden="true" />
+                          )}
+                        </button>
+                      </UserMessageActionTooltip>
+                      <UserMessageActionTooltip label={t('Branch in new session')}>
+                        <button
+                          type="button"
+                          className={userMessageActionButtonClassName}
+                          aria-label={t('Branch in new session')}
+                          disabled={!canBranchInNewSession}
+                          onClick={() => onBranchInNewSession(message.id)}
+                        >
+                          <GitBranch className="size-3.5" strokeWidth={2} aria-hidden="true" />
+                        </button>
+                      </UserMessageActionTooltip>
+                    </div>
                   </TooltipProvider>
                 ) : null}
                 {terminalDate ? (

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -80,6 +80,8 @@ type WorkspaceMessageItemProps = {
   // Embedded transcript surfaces can supply their own horizontal gutter without changing live chat.
   contentPaddingClassName?: string
   onSendEditedMessage?: (messageId: string, doc: ComposerDoc) => void
+  canBranchInNewSession?: boolean
+  onBranchInNewSession?: (messageId: string) => void
   // Prompt send time for an Agent response; paired with its completion time for elapsed duration.
   turnStartedAt?: number
   // Per-turn runtime codes come from the Conversation Graph; names and icons resolve from Settings.
@@ -817,6 +819,8 @@ const WorkspaceMessageItemImpl = ({
   showUserActions = true,
   contentPaddingClassName,
   onSendEditedMessage,
+  canBranchInNewSession = false,
+  onBranchInNewSession,
   turnStartedAt,
   runtimeIdentity,
   showAssistantFooter = true,
@@ -1156,6 +1160,21 @@ const WorkspaceMessageItemImpl = ({
                 data-slot="assistant-message-footer"
                 className="mt-3 flex items-center gap-x-3 whitespace-nowrap text-[11px] leading-4 text-text-000/70 tabular-nums"
               >
+                {message.status === 'complete' && onBranchInNewSession ? (
+                  <TooltipProvider delayDuration={200}>
+                    <UserMessageActionTooltip label={t('Branch in new session')}>
+                      <button
+                        type="button"
+                        className={userMessageActionButtonClassName}
+                        aria-label={t('Branch in new session')}
+                        disabled={!canBranchInNewSession}
+                        onClick={() => onBranchInNewSession(message.id)}
+                      >
+                        <GitBranch className="size-3.5" strokeWidth={2} aria-hidden="true" />
+                      </button>
+                    </UserMessageActionTooltip>
+                  </TooltipProvider>
+                ) : null}
                 {terminalDate ? (
                   <MessageTimestamp label={terminalLabel} date={terminalDate} />
                 ) : null}
@@ -1243,6 +1262,8 @@ const areWorkspaceMessageItemPropsEqual = (
   previous.onOpenSkillMention === next.onOpenSkillMention &&
   previous.onPreviewMentionArtifact === next.onPreviewMentionArtifact &&
   previous.onSendEditedMessage === next.onSendEditedMessage &&
+  (previous.canBranchInNewSession ?? false) === (next.canBranchInNewSession ?? false) &&
+  previous.onBranchInNewSession === next.onBranchInNewSession &&
   (previous.canEditMessage ?? false) === (next.canEditMessage ?? false) &&
   (previous.showUserActions ?? true) === (next.showUserActions ?? true) &&
   previous.contentPaddingClassName === next.contentPaddingClassName &&

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -889,7 +889,7 @@ const WorkspaceMessageItemImpl = ({
     []
   )
 
-  // Copies the prompt text and briefly swaps the icon to confirm the clipboard write succeeded.
+  // Copies the message text and briefly swaps the icon to confirm the clipboard write succeeded.
   const handleCopyMessage = (): void => {
     void navigator.clipboard.writeText(message.content).then(() => {
       setCopied(true)
@@ -1162,6 +1162,20 @@ const WorkspaceMessageItemImpl = ({
               >
                 {message.status === 'complete' && onBranchInNewSession ? (
                   <TooltipProvider delayDuration={200}>
+                    <UserMessageActionTooltip label={copied ? t('Copied') : t('Copy message')}>
+                      <button
+                        type="button"
+                        className={userMessageActionButtonClassName}
+                        aria-label={copied ? t('Copied') : t('Copy message')}
+                        onClick={handleCopyMessage}
+                      >
+                        {copied ? (
+                          <Check className="size-3.5" strokeWidth={2} aria-hidden="true" />
+                        ) : (
+                          <Copy className="size-3.5" strokeWidth={2} aria-hidden="true" />
+                        )}
+                      </button>
+                    </UserMessageActionTooltip>
                     <UserMessageActionTooltip label={t('Branch in new session')}>
                       <button
                         type="button"

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -91,6 +91,8 @@ type WorkspaceMessageScrollerProps = {
   isResumingSession?: boolean
   notebookReference?: NotebookSessionReference
   onSendEditedMessage: (messageId: string, doc: ComposerDoc) => void
+  canBranchInNewSession?: boolean
+  onBranchInNewSession?: (messageId: string) => void
   trailingContent?: ReactNode
   pendingElicitations?: PendingElicitationRequest[]
   // Events are read-only projections; retry sends an intent that main validates against its state.
@@ -336,6 +338,8 @@ const WorkspaceMessageScrollerImpl = ({
   isResumingSession = false,
   notebookReference,
   onSendEditedMessage,
+  canBranchInNewSession = false,
+  onBranchInNewSession,
   trailingContent,
   pendingElicitations = [],
   handoffLifecycleSource,
@@ -1103,6 +1107,8 @@ const WorkspaceMessageScrollerImpl = ({
                     onOpenSkillMention,
                     onPreviewMentionArtifact,
                     onSendEditedMessage,
+                    canBranchInNewSession,
+                    onBranchInNewSession,
                     turnStartedAt: item.message.responseToMessageId
                       ? messageCreatedAtById.get(item.message.responseToMessageId)
                       : undefined,
@@ -1426,6 +1432,8 @@ const areWorkspaceMessageScrollerPropsEqual = (
   next: WorkspaceMessageScrollerProps
 ): boolean =>
   previous.onSendEditedMessage === next.onSendEditedMessage &&
+  (previous.canBranchInNewSession ?? false) === (next.canBranchInNewSession ?? false) &&
+  previous.onBranchInNewSession === next.onBranchInNewSession &&
   previous.trailingContent === next.trailingContent &&
   previous.isResumingSession === next.isResumingSession &&
   previous.notebookReference?.sessionId === next.notebookReference?.sessionId &&

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
@@ -195,6 +195,18 @@ describe('workspace conversation controller', () => {
     expect(input.runtime.sendMessage).not.toHaveBeenCalled()
   })
 
+  it('disables Agent Message branching while the source Session awaits Plan approval', () => {
+    const input = options({
+      activeSession: session({ status: 'waiting-plan-approval' })
+    })
+    const hook = renderController(input)
+    mounted.push(hook)
+
+    expect(hook.result.current.availability.branch).toBe(false)
+    act(() => hook.result.current.actions.branch('agent-message-a'))
+    expect(input.runtime.sendMessage).not.toHaveBeenCalled()
+  })
+
   it('disables Agent Message branching while the Specialist barrier is in flight', () => {
     const input = options()
     input.session.view.specialist.barrierInFlight = true
@@ -297,6 +309,16 @@ describe('workspace conversation controller', () => {
     act(() => hook.result.current.actions.revise('message-a', textDoc('changed')))
     expect(input.runtime.sendMessage).not.toHaveBeenCalled()
     expect(input.runtime.resendEditedMessage).not.toHaveBeenCalled()
+  })
+
+  it('blocks submit while a selected branched Session is still binding', () => {
+    const input = options({ activeSession: session({ isPending: true }) })
+    const hook = renderController(input)
+    mounted.push(hook)
+
+    expect(hook.result.current.availability.submit).toBe(false)
+    act(() => hook.result.current.actions.submit.draft({ forcedSkillIds: [] }))
+    expect(input.runtime.sendMessage).not.toHaveBeenCalled()
   })
 
   it('blocks submit and revision while Save as skill owns prompt admission', () => {

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
@@ -72,7 +72,10 @@ const options = (
       }
     },
     session: {
-      view: { deletingIds: new Set(), specialist: { barrierInFlight: false } },
+      view: {
+        deletingIds: new Set(),
+        specialist: { barrierInFlight: false, sendAvailable: true }
+      },
       actions: {
         beginReconfigureRetry: vi.fn(() => true),
         resetNewConversationSpecialist: vi.fn(),
@@ -140,6 +143,92 @@ afterEach(() => {
 })
 
 describe('workspace conversation controller', () => {
+  it('branches from a completed Agent Message without consuming the composer draft', async () => {
+    const input = options()
+    const hook = renderController(input)
+    mounted.push(hook)
+
+    expect(hook.result.current.availability.branch).toBe(true)
+    act(() => hook.result.current.actions.branch('agent-message-a'))
+    await vi.waitFor(() => expect(input.runtime.sendMessage).toHaveBeenCalledOnce())
+
+    expect(input.runtime.sendMessage).toHaveBeenCalledWith({
+      branchSourceSessionId: 'session-a',
+      branchSourceMessageId: 'agent-message-a',
+      text: '',
+      specialistId: undefined
+    })
+    expect(input.composer.lifecycle.captureSend).not.toHaveBeenCalled()
+  })
+
+  it('uses the pending Specialist intent for the branched child Session', async () => {
+    const input = options()
+    input.session.lifecycle.captureSendIntent = vi.fn(() => ({
+      draftSpecialistId: 'specialist-b',
+      hasPendingSwitch: false,
+      pendingSpecialistId: 'specialist-b'
+    }))
+    const hook = renderController(input)
+    mounted.push(hook)
+
+    act(() => hook.result.current.actions.branch('agent-message-a'))
+    await vi.waitFor(() => expect(input.runtime.sendMessage).toHaveBeenCalledOnce())
+
+    expect(input.session.lifecycle.captureSendIntent).toHaveBeenCalledWith(true)
+    expect(input.runtime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ specialistId: 'specialist-b' })
+    )
+  })
+
+  it('disables Agent Message branching while the source Session is running', () => {
+    const input = options({
+      activeSession: session({
+        status: 'running',
+        activeRun: { promptMessageId: 'message-user-a', startedAt: 2 }
+      })
+    })
+    const hook = renderController(input)
+    mounted.push(hook)
+
+    expect(hook.result.current.availability.branch).toBe(false)
+    act(() => hook.result.current.actions.branch('agent-message-a'))
+    expect(input.runtime.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('disables Agent Message branching while the Specialist barrier is in flight', () => {
+    const input = options()
+    input.session.view.specialist.barrierInFlight = true
+    const hook = renderController(input)
+    mounted.push(hook)
+
+    expect(hook.result.current.availability.branch).toBe(false)
+    act(() => hook.result.current.actions.branch('agent-message-a'))
+    expect(input.runtime.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('checks Specialist admission again before creating the branched Session', () => {
+    const input = options()
+    input.session.lifecycle.canStartSend = vi.fn(() => false)
+    const hook = renderController(input)
+    mounted.push(hook)
+
+    expect(hook.result.current.availability.branch).toBe(true)
+    act(() => hook.result.current.actions.branch('agent-message-a'))
+    expect(input.session.lifecycle.canStartSend).toHaveBeenCalledOnce()
+    expect(input.runtime.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('disables Agent Message branching when the Specialist is not ready to send', () => {
+    const input = options()
+    input.session.view.specialist.sendAvailable = false
+    const hook = renderController(input)
+    mounted.push(hook)
+
+    expect(hook.result.current.availability.branch).toBe(false)
+    act(() => hook.result.current.actions.branch('agent-message-a'))
+    expect(input.runtime.sendMessage).not.toHaveBeenCalled()
+  })
+
   it('submits a restored Plan approval through the human-gated Plan command', async () => {
     const pendingPlan = {
       artifactId: 'artifact-plan-a',

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
@@ -126,6 +126,7 @@ const canSubmit = (options: WorkspaceConversationControllerOptions): boolean => 
     !options.sideChatOpen &&
     composer.view.transfers.length === 0 &&
     (!docIsEmpty(composer.view.doc) || composer.view.attachments.length > 0) &&
+    !activeSession?.isPending &&
     activeSession?.status !== 'running' &&
     activeSession?.status !== 'waiting-for-user' &&
     (activeSession?.status !== 'waiting-permission' || !options.hasBlockingRootPermissionRequest) &&
@@ -164,6 +165,7 @@ const canBranch = (options: WorkspaceConversationControllerOptions): boolean =>
     options.activeSession.status !== 'running' &&
     options.activeSession.status !== 'waiting-for-user' &&
     options.activeSession.status !== 'waiting-permission' &&
+    options.activeSession.status !== 'waiting-plan-approval' &&
     !options.activeSession.fixLoopActive &&
     !options.activeSession.compacting &&
     !options.activeSession.branchSwitchBlocked &&

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
@@ -45,7 +45,10 @@ type ConversationComposer = {
 type ConversationSession = {
   view: {
     deletingIds: WorkspaceSessionController['view']['deletingIds']
-    specialist: Pick<WorkspaceSessionController['view']['specialist'], 'barrierInFlight'>
+    specialist: Pick<
+      WorkspaceSessionController['view']['specialist'],
+      'barrierInFlight' | 'sendAvailable'
+    >
   }
   actions: Pick<
     WorkspaceSessionController['actions'],
@@ -87,6 +90,7 @@ type WorkspaceConversationController = {
     submit: boolean
     revise: boolean
     resume: boolean
+    branch: boolean
   }
   actions: {
     submit: {
@@ -94,6 +98,7 @@ type WorkspaceConversationController = {
       restoredPlan: (response: RestoredPlanResponse) => Promise<void>
     }
     revise: (messageId: string, doc: ComposerDoc) => void
+    branch: (messageId: string) => void
     sideChat: { start: () => void }
     resume: () => Promise<void>
     cancel: () => Promise<void>
@@ -149,6 +154,25 @@ const canRevise = (options: WorkspaceConversationControllerOptions): boolean => 
     !session.view.deletingIds.has(activeSession?.id ?? '')
   )
 }
+
+const canBranch = (options: WorkspaceConversationControllerOptions): boolean =>
+  Boolean(
+    options.isPersistenceReady &&
+    options.activeSession &&
+    !options.activeSession.isPending &&
+    !options.activeSession.activeRun &&
+    options.activeSession.status !== 'running' &&
+    options.activeSession.status !== 'waiting-for-user' &&
+    options.activeSession.status !== 'waiting-permission' &&
+    !options.activeSession.fixLoopActive &&
+    !options.activeSession.compacting &&
+    !options.activeSession.branchSwitchBlocked &&
+    !options.activeSession.conversationGraphSyncBlocked &&
+    !options.session.view.specialist.barrierInFlight &&
+    options.session.view.specialist.sendAvailable &&
+    !hasRuntimeInteraction(options) &&
+    !options.session.view.deletingIds.has(options.activeSession.id)
+  )
 
 const canStartSideChat = (options: WorkspaceConversationControllerOptions): boolean =>
   Boolean(
@@ -287,6 +311,22 @@ const useWorkspaceConversationController = (
           referencedArtifacts: docToArtifactRefs(doc)
         })
       },
+      branch: (messageId): void => {
+        const current = optionsRef.current
+        const sourceSessionId = current.activeSession?.id
+        if (!sourceSessionId || !canBranch(current)) return
+        if (current.session.lifecycle.isBarrierInFlight(sourceSessionId)) return
+        if (!current.session.lifecycle.canStartSend()) return
+        const { draftSpecialistId } = current.session.lifecycle.captureSendIntent(true)
+        void current.runtime
+          .sendMessage({
+            branchSourceSessionId: sourceSessionId,
+            branchSourceMessageId: messageId,
+            text: '',
+            specialistId: draftSpecialistId
+          })
+          .catch((error: unknown) => current.composer.actions.setError(errorMessage(error)))
+      },
       sideChat: {
         start: (): void => {
           const current = optionsRef.current
@@ -327,7 +367,8 @@ const useWorkspaceConversationController = (
     availability: {
       submit: canSubmit(options),
       revise: canRevise(options),
-      resume: options.isPersistenceReady && !options.sideChatOpen
+      resume: options.isPersistenceReady && !options.sideChatOpen,
+      branch: canBranch(options)
     },
     actions
   }

--- a/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
@@ -195,6 +195,19 @@ describe('workspace session controller', () => {
     expect(hook.result.current.view.specialist.hasPendingSwitch).toBe(true)
   })
 
+  it('exposes Specialist send admission while the active catalog is unresolved', () => {
+    const active = session({ specialistId: 'specialist-a' })
+    const hook = renderController({
+      activeSession: active,
+      specialistCatalogLoaded: false,
+      specialistItems: []
+    })
+    mounted.push(hook)
+
+    expect(hook.result.current.view.specialist.sendAvailable).toBe(false)
+    expect(hook.result.current.lifecycle.canStartSend()).toBe(false)
+  })
+
   it('archives durably before enqueueing undo and clearing the active selection', async () => {
     const active = session()
     const order: string[] = []

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -58,6 +58,7 @@ type WorkspaceSessionController = {
       unavailable: boolean
       hasPendingSwitch: boolean
       barrierInFlight: boolean
+      sendAvailable: boolean
       reconfigureError: ReconfigureError | null
     }
   }
@@ -184,6 +185,10 @@ const useWorkspaceSessionController = ({
         (item) => item.kind === 'custom' && item.enabled && item.id === activeSession.specialistId
       )
     : newConversationSpecialistUnavailable
+  const specialistSendAvailable = activeSession
+    ? activeSession.specialistId === undefined ||
+      (specialistCatalogLoaded && (activeHasPending || !activeSpecialistUnavailable))
+    : !newConversationSpecialistUnavailable
   const activeHasPendingSwitch = Boolean(
     activeSession &&
     activeHasPending &&
@@ -330,12 +335,12 @@ const useWorkspaceSessionController = ({
   const canStartSend = (): boolean => {
     if (!activeSession) return !newConversationSpecialistUnavailable
     if (barrierInFlightRef.current.has(activeSession.id)) return false
-    if (activeSession.specialistId === undefined) return true
+    if (activeSession.specialistId === undefined) return specialistSendAvailable
     if (!specialistCatalogLoaded) {
       void loadSpecialists()
       return false
     }
-    return activeHasPending || !activeSpecialistUnavailable
+    return specialistSendAvailable
   }
 
   const captureSendIntent = (branchInNewSession: boolean): SpecialistSendIntent => {
@@ -524,6 +529,7 @@ const useWorkspaceSessionController = ({
         unavailable: activeSpecialistUnavailable,
         hasPendingSwitch: activeHasPendingSwitch,
         barrierInFlight: barrierInFlightIds.has(activeSession?.id ?? ''),
+        sendAvailable: specialistSendAvailable && !barrierInFlightIds.has(activeSession?.id ?? ''),
         reconfigureError:
           reconfigureError?.sessionId === activeSession?.id ? reconfigureError : null
       }

--- a/src/renderer/src/stores/session-store-message-graph-helpers.ts
+++ b/src/renderer/src/stores/session-store-message-graph-helpers.ts
@@ -47,7 +47,8 @@ export type AppendPendingUserMessageInput = Omit<AppendUserMessageInput, 'sessio
 
 export type BranchInNewSessionInput = {
   sourceSessionId: string
-  content: string
+  sourceMessageId?: string
+  content?: string
   attachments?: PersistedUploadedAttachment[]
   parts?: MessagePart[]
   turnIntent?: PersistedChatMessage['turnIntent']
@@ -73,6 +74,11 @@ export type AppendMessageResult = {
   messageId: string
 }
 
+export type BranchInNewSessionResult = {
+  sessionId: string
+  messageId?: string
+}
+
 export type AppendRoutedUserMessageInput = {
   sessionId: string
   messageId: string
@@ -90,8 +96,8 @@ export type SessionMessageGraphActions = {
   appendPendingUserMessage: (
     input: AppendPendingUserMessageInput
   ) => AppendMessageResult | undefined
-  branchInNewSession: (input: BranchInNewSessionInput) => AppendMessageResult | undefined
-  bindPendingSession: (input: BindPendingSessionInput) => AppendMessageResult | undefined
+  branchInNewSession: (input: BranchInNewSessionInput) => BranchInNewSessionResult | undefined
+  bindPendingSession: (input: BindPendingSessionInput) => BranchInNewSessionResult | undefined
   clearPendingContextReplay: (sessionId: string, messageId: string) => void
   removeMessage: (sessionId: string, messageId: string) => void
   truncateSessionFromMessage: (sessionId: string, messageId: string) => void
@@ -377,7 +383,53 @@ export const copySnapshotActivityGroup = (
   activityIds: group.activityIds.map((id) => createSnapshotActivityId(sessionId, id))
 })
 
+export const projectSessionBranchSnapshot = (
+  source: ChatSession,
+  sourceMessageId?: string
+):
+  | {
+      sourceMessage: ChatMessage | undefined
+      messages: Array<{ message: PersistedChatMessage; sortIndex: number }>
+      activities: PersistedToolActivity[]
+      activityGroups: PersistedActivityGroup[]
+    }
+  | undefined => {
+  const sourceMessageIndex = sourceMessageId
+    ? source.messages.findIndex((message) => message.id === sourceMessageId)
+    : -1
+  const sourceMessage = source.messages[sourceMessageIndex]
+  if (
+    sourceMessageId &&
+    (!sourceMessage || sourceMessage.role !== 'agent' || sourceMessage.status !== 'complete')
+  ) {
+    return undefined
+  }
+
+  const messages = (
+    sourceMessage ? source.messages.slice(0, sourceMessageIndex + 1) : source.messages
+  ).map((message, index) => ({
+    message: stripTransientMessageState(message),
+    sortIndex: message.sortIndex ?? index
+  }))
+  const activities = (source.activities ?? [])
+    .map(sanitizeToolActivity)
+    .filter((activity): activity is PersistedToolActivity => Boolean(activity))
+    .filter((activity) => !sourceMessage || isBeforeTimelineItem(activity, sourceMessage))
+  const activityIds = new Set(activities.map((activity) => activity.id))
+  const activityGroups = (source.activityGroups ?? [])
+    .map(sanitizeActivityGroup)
+    .filter((group): group is PersistedActivityGroup => Boolean(group))
+    .map((group) => ({
+      ...group,
+      activityIds: group.activityIds.filter((id) => activityIds.has(id))
+    }))
+    .filter((group) => group.activityIds.length > 0)
+
+  return { sourceMessage, messages, activities, activityGroups }
+}
+
 export const canBranchInNewSession = (session: ChatSession): boolean =>
+  !session.isPending &&
   !session.activeRun &&
   session.status !== 'running' &&
   session.status !== 'waiting-for-user' &&

--- a/src/renderer/src/stores/session-store-message-graph-helpers.ts
+++ b/src/renderer/src/stores/session-store-message-graph-helpers.ts
@@ -434,6 +434,7 @@ export const canBranchInNewSession = (session: ChatSession): boolean =>
   session.status !== 'running' &&
   session.status !== 'waiting-for-user' &&
   session.status !== 'waiting-permission' &&
+  session.status !== 'waiting-plan-approval' &&
   !session.fixLoopActive &&
   !session.compacting &&
   !session.branchSwitchBlocked &&

--- a/src/renderer/src/stores/session-store-message-graph-owner.ts
+++ b/src/renderer/src/stores/session-store-message-graph-owner.ts
@@ -7,14 +7,7 @@ import {
   resolveActiveConversationMessages
 } from '../../../shared/conversation-graph'
 import { DEFAULT_PERMISSION_PROFILE } from '../../../shared/permission-profiles'
-import {
-  sanitizeActivityGroup,
-  sanitizeToolActivity,
-  type MessagePart,
-  type PersistedActivityGroup,
-  type PersistedToolActivity,
-  type PersistedUploadedAttachment
-} from '../../../shared/session-persistence'
+import type { MessagePart, PersistedUploadedAttachment } from '../../../shared/session-persistence'
 import {
   buildMessage,
   canBranchInNewSession,
@@ -26,13 +19,13 @@ import {
   createTitleFromMessage,
   createTitleFromUploads,
   isBeforeTimelineItem,
+  projectSessionBranchSnapshot,
   projectElicitationRevision,
   synchronizeSessionGraph,
   type SessionMessageGraphActions
 } from './session-store-message-graph-helpers'
 import {
   hydrateToolActivity,
-  stripTransientMessageState,
   type ActiveRun,
   type ChatMessage,
   type ChatMessageRole,
@@ -55,7 +48,8 @@ const createPendingSessionId = (): string => {
 }
 
 const createSessionBranchSource = (
-  source: ChatSession
+  source: ChatSession,
+  headMessageId?: string
 ): NonNullable<ChatSession['branchSource']> => {
   const graph = source.conversationGraph
   const frame = graph?.frames.find((candidate) => candidate.id === graph.activeFrameId)
@@ -65,7 +59,9 @@ const createSessionBranchSource = (
     sessionId: source.id,
     ...(frame ? { agentFrameId: frame.id } : {}),
     ...(branch ? { messageBranchId: branch.id } : {}),
-    ...(branch?.headMessageId ? { headMessageId: branch.headMessageId } : {})
+    ...((headMessageId ?? branch?.headMessageId)
+      ? { headMessageId: headMessageId ?? branch?.headMessageId }
+      : {})
   }
 }
 
@@ -342,6 +338,7 @@ export const createSessionMessageGraphOwner = <
     }),
   branchInNewSession: ({
     sourceSessionId,
+    sourceMessageId,
     content,
     attachments = [],
     parts,
@@ -352,40 +349,33 @@ export const createSessionMessageGraphOwner = <
     agentModel,
     specialistId
   }) => {
-    const trimmedContent = content.trim()
+    const trimmedContent = content?.trim() ?? ''
     const uploads = attachments.map(createPersistedUpload)
-    if (!sourceSessionId || (!trimmedContent && uploads.length === 0)) return undefined
+    if (!sourceSessionId || (!sourceMessageId && !trimmedContent && uploads.length === 0)) {
+      return undefined
+    }
 
     const state = get()
     const source = state.sessions.find((session) => session.id === sourceSessionId)
     if (!source || !canBranchInNewSession(source)) return undefined
 
-    const sourceMessages = source.messages.map((message, index) => ({
-      message: stripTransientMessageState(message),
-      sortIndex: message.sortIndex ?? index
-    }))
-    const sourceActivities = (source.activities ?? [])
-      .map(sanitizeToolActivity)
-      .filter((activity): activity is PersistedToolActivity => Boolean(activity))
-    const sourceActivityGroups = (source.activityGroups ?? [])
-      .map(sanitizeActivityGroup)
-      .filter((group): group is PersistedActivityGroup => Boolean(group))
+    const snapshot = projectSessionBranchSnapshot(source, sourceMessageId)
+    if (!snapshot) return undefined
+    const {
+      sourceMessage,
+      messages: sourceMessages,
+      activities: sourceActivities,
+      activityGroups: sourceActivityGroups
+    } = snapshot
 
     const now = Date.now()
     const sessionId = createPendingSessionId()
-    const userMessage = createMessage(
-      'user',
-      trimmedContent,
-      'complete',
-      undefined,
-      [],
-      uploads,
-      parts,
-      turnIntent
-    )
+    const userMessage = sourceMessage
+      ? undefined
+      : createMessage('user', trimmedContent, 'complete', undefined, [], uploads, parts, turnIntent)
     const messages = [
       ...sourceMessages.map(({ message, sortIndex }) => copySnapshotMessage(message, sortIndex)),
-      userMessage
+      ...(userMessage ? [userMessage] : [])
     ]
     const normalizedAgentBackendId = agentBackendId?.trim() || source.agentBackendId
     const normalizedAgentModel = agentModel?.trim() || source.agentModel
@@ -395,13 +385,15 @@ export const createSessionMessageGraphOwner = <
     const newSession: ChatSession = {
       id: sessionId,
       projectId: source.projectId,
-      branchSource: createSessionBranchSource(source),
+      branchSource: createSessionBranchSource(source, sourceMessage?.id),
       isPending: true,
-      title: trimmedContent
-        ? createBranchTitleFromMessage(trimmedContent)
-        : createTitleFromUploads(uploads),
+      title: sourceMessage
+        ? source.title
+        : trimmedContent
+          ? createBranchTitleFromMessage(trimmedContent)
+          : createTitleFromUploads(uploads),
       cwd: source.cwd,
-      status: 'running',
+      status: userMessage ? 'running' : 'idle',
       permissionProfile:
         permissionProfile ?? source.permissionProfile ?? DEFAULT_PERMISSION_PROFILE,
       agentFrameworkId: normalizedFrameworkId,
@@ -419,8 +411,12 @@ export const createSessionMessageGraphOwner = <
       activityGroups: sourceActivityGroups.map((group) =>
         copySnapshotActivityGroup(group, sessionId)
       ),
-      pendingContextReplayMessageId: userMessage.id,
-      activeRun: { promptMessageId: userMessage.id, startedAt: now },
+      ...(userMessage
+        ? {
+            pendingContextReplayMessageId: userMessage.id,
+            activeRun: { promptMessageId: userMessage.id, startedAt: now }
+          }
+        : { pendingHistoryReplay: { kind: 'all' as const } }),
       createdAt: now,
       updatedAt: now
     }
@@ -438,7 +434,7 @@ export const createSessionMessageGraphOwner = <
       sessions: [newSession, ...state.sessions]
     } as Partial<State>)
 
-    return { sessionId, messageId: userMessage.id }
+    return userMessage ? { sessionId, messageId: userMessage.id } : { sessionId }
   },
 
   bindPendingSession: ({
@@ -456,7 +452,7 @@ export const createSessionMessageGraphOwner = <
     const pendingSession = state.sessions.find(
       (session) => session.id === pendingSessionId && session.isPending
     )
-    if (!pendingSession?.activeRun) return undefined
+    if (!pendingSession) return undefined
 
     const now = Date.now()
     set({
@@ -479,7 +475,9 @@ export const createSessionMessageGraphOwner = <
       )
     } as Partial<State>)
 
-    return { sessionId, messageId: pendingSession.activeRun.promptMessageId }
+    return pendingSession.activeRun
+      ? { sessionId, messageId: pendingSession.activeRun.promptMessageId }
+      : { sessionId }
   },
 
   clearPendingContextReplay: (sessionId, messageId) => {

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -4443,6 +4443,7 @@ describe('session store public contract', () => {
       'src/renderer/src/lib/acp/workspace-runtime-event-owner.ts',
       'src/renderer/src/lib/acp/workspace-runtime-prompt-preparation-owner.ts',
       'src/renderer/src/lib/acp/workspace-runtime-save-as-skill-owner.ts',
+      'src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.ts',
       'src/renderer/src/lib/acp/workspace-runtime-session-lifecycle-owner.ts',
       'src/renderer/src/lib/acp/workspace-subagent-runtime-presentation.ts',
       'src/renderer/src/lib/active-session-display.ts',
@@ -4638,6 +4639,57 @@ describe('branchInNewSession', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-07-04T08:00:00.000Z'))
     useSessionStore.setState(createInitialSessionState())
+  })
+
+  it('copies history through a completed Agent Message into a selected idle Session', () => {
+    const firstPrompt = useSessionStore.getState().appendUserMessage({
+      sessionId: 'source-session',
+      content: 'first question',
+      cwd: '/workspace/project',
+      projectId: 'default-project'
+    })
+    const firstAnswer = useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'source-session',
+      streamId: 'first-stream',
+      eventId: 'first-event',
+      content: 'first answer'
+    })
+    useSessionStore.getState().finishRun('source-session')
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'source-session',
+      content: 'second question'
+    })
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: 'source-session',
+      streamId: 'second-stream',
+      eventId: 'second-event',
+      content: 'second answer'
+    })
+    useSessionStore.getState().finishRun('source-session')
+
+    const result = useSessionStore.getState().branchInNewSession({
+      sourceSessionId: 'source-session',
+      sourceMessageId: firstAnswer?.messageId ?? ''
+    })
+
+    expect(result).toEqual({ sessionId: expect.stringMatching(/^pending-session-/) })
+    expect(useSessionStore.getState().selectedSessionId).toBe(result?.sessionId)
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      id: result?.sessionId,
+      isPending: true,
+      title: 'first question',
+      status: 'idle',
+      pendingHistoryReplay: { kind: 'all' },
+      branchSource: {
+        sessionId: 'source-session',
+        headMessageId: firstAnswer?.messageId
+      }
+    })
+    expect(useSessionStore.getState().sessions[0].activeRun).toBeUndefined()
+    expect(useSessionStore.getState().sessions[0].messages.map((message) => message.id)).toEqual([
+      firstPrompt?.messageId,
+      firstAnswer?.messageId
+    ])
   })
 
   it('copies only the active path into a fresh pending graph without mutating the source', () => {

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -5061,6 +5061,28 @@ describe('branchInNewSession', () => {
     ).toBeUndefined()
     expect(useSessionStore.getState().sessions).toEqual([sourceBefore])
   })
+
+  it('refuses a source that is waiting for Plan approval', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'source-session',
+      content: 'prepare a Plan'
+    })
+    useSessionStore.getState().finishRun('source-session')
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === 'source-session' ? { ...session, status: 'waiting-plan-approval' } : session
+      )
+    }))
+    const sourceBefore = structuredClone(useSessionStore.getState().sessions[0])
+
+    expect(
+      useSessionStore.getState().branchInNewSession({
+        sourceSessionId: 'source-session',
+        content: 'bypass the pending Plan'
+      })
+    ).toBeUndefined()
+    expect(useSessionStore.getState().sessions).toEqual([sourceBefore])
+  })
 })
 
 describe('truncateSessionFromMessage', () => {


### PR DESCRIPTION
## Problem

Completed Agent Messages do not expose the existing “Branch in new session” workflow at the point where users decide to continue from a specific answer.

## Proposed change

- Add persistent `Copy` and `GitBranch` actions to every completed Agent Message footer in the live conversation, grouped with the same tight spacing as user-message actions while preserving the wider separation from completion metadata.
- Reuse the user-message clipboard interaction, including the transient `Copied` check state, to copy the Agent Message content.
- Copy the conversation graph and activity history through the selected Agent Message, then create, bind, select, and persist a new idle Session.
- Do not send a prompt or start an Agent run; the new Session waits for the next user message.
- Keep the action visible but disabled while the source Session is running or another existing admission barrier is active.
- Reuse the existing composer branch store/runtime path, including pending Specialist intent and attachment reconciliation.

## Scope and non-goals

- No user-message footer action changes.
- No database/schema migration, new dependency, or locale key; the existing `Branch in new session` translation key is reused.
- No new Session status or enum value; the child uses the existing `idle` status.
- Historical compatibility requires no migration: existing completed messages are normalized with their durable terminal timestamp and can use the new action.
- Persistence uses existing `branchSource`, conversation graph, copied message/activity records, and `pendingHistoryReplay`; no new persisted field is introduced.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Footer Copy/Branch placement, clipboard behavior, visibility, disabled state, and i18n -> `npx vitest run src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx src/renderer/src/i18n/resources.test.ts` -> passed.
- Snapshot truncation, idle child state, graph/persistence contracts -> `npm run test:module -- session_renderer` -> 4 files, 412 tests passed.
- Runtime create/bind/save transaction and no prompt dispatch -> `npm run test:module -- workspace_runtime` -> 7 files, 298 tests passed.
- Workspace consumer flow, source-running gate, Specialist admission and pending Specialist inheritance -> `npm run test:module -- workspace_page` -> 23 files, 401 tests passed.
- Module impact manifest -> `npx vitest run scripts/ci/validate-module-impact.test.ts scripts/ci/module-impact-shadow.test.ts scripts/ci/module-test-impact.test.ts` -> 3 files, 47 tests passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Lint -> `npm run lint` -> passed.
- Independent Standards and Spec reviews -> passed with no remaining findings.
- Exact-head PR Gate after the final spacing edit -> Static checks, Windows core/E2E, both full Module shards, and Module tests/coverage passed. macOS accessibility and visual remain blocked by the shared `main` recovery fixture: both wait for the missing `Saved conversation data was damaged` alert. The same failure is present on the concurrent `refactor/project-id-routing` PR Gate, and rerunning this PR's failed job reproduced it without any footer/snapshot mismatch.

Per maintainer direction, the full local `npm test` suite was not run. PR Gate and its selected/full platform lanes are authoritative for uncovered full-suite and platform risks.

## Review focus

- The selected-message snapshot boundary in `session-store-message-graph-helpers.ts`.
- The idle runtime Session transaction in `workspace-runtime-session-branch-owner.ts`.
- Footer Copy/Branch ordering, compact action-group spacing, availability, and pending Specialist intent parity with composer branching.
