### PR TITLE
fix(persistence): surface catalog repair before project actions

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -1120,6 +1120,33 @@ describe('App startup routing', () => {
     expect(mocks.sessionPersistence.retryWrites).toHaveBeenCalledOnce()
   })
 
+  it('keeps failed writes retryable while catalog recovery is visible', async () => {
+    mocks.settings.isLoaded = true
+    mocks.sessionPersistence.hasCompleteSessionCatalog = false
+    mocks.sessionPersistence.catalogRecovery = { kind: 'repairable', reason: 'session-scan' }
+    mocks.sessionPersistence.writeError =
+      'Open Science could not save the latest conversation changes. Retry before closing the app.'
+
+    await render()
+
+    const alerts = Array.from(
+      container.querySelectorAll('[data-testid="session-persistence-alert"]')
+    )
+    expect(alerts).toHaveLength(2)
+    expect(alerts[0]?.textContent).toContain('Project index needs repair')
+    expect(alerts[1]?.textContent).toContain('Conversation storage needs attention')
+
+    const retries = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[data-testid="session-persistence-retry"]')
+    )
+    const repairIndex = retries.find((button) => button.textContent === 'Repair index')
+    const retryWrites = retries.find((button) => button.textContent === 'Retry')
+    repairIndex?.click()
+    retryWrites?.click()
+    expect(mocks.sessionPersistence.retryLoad).toHaveBeenCalledOnce()
+    expect(mocks.sessionPersistence.retryWrites).toHaveBeenCalledOnce()
+  })
+
   it('reports quarantined corrupt conversation files without blocking healthy sessions', async () => {
     mocks.settings.isLoaded = true
     mocks.sessionPersistence.hasCompleteSessionCatalog = false

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -70,6 +70,14 @@ const mocks = vi.hoisted(() => {
       isLoading: false,
       isReady: true,
       hasCompleteSessionCatalog: true,
+      catalogRecovery: { kind: 'ready' } as
+        | { kind: 'ready' }
+        | { kind: 'repairable'; reason: 'session-scan' | 'startup-reconciliation' }
+        | {
+            kind: 'damaged-authority'
+            affectedFileCount: number
+          }
+        | { kind: 'project-deletion-recovery' },
       canDeleteSessionsAndProjects: true,
       loadError: undefined as string | undefined,
       loadWarning: undefined as string | undefined,
@@ -352,6 +360,7 @@ describe('App startup routing', () => {
     mocks.sessionPersistence.isHydrated = true
     mocks.sessionPersistence.isLoading = false
     mocks.sessionPersistence.hasCompleteSessionCatalog = true
+    mocks.sessionPersistence.catalogRecovery = { kind: 'ready' }
     mocks.sessionPersistence.canDeleteSessionsAndProjects = true
     mocks.sessionPersistence.loadError = undefined
     mocks.sessionPersistence.loadWarning = undefined
@@ -810,6 +819,7 @@ describe('App startup routing', () => {
     mocks.sessionPersistence.isHydrated = true
     mocks.sessionPersistence.isReady = false
     mocks.sessionPersistence.hasCompleteSessionCatalog = false
+    mocks.sessionPersistence.catalogRecovery = { kind: 'repairable', reason: 'session-scan' }
     mocks.sessionPersistence.canDeleteSessionsAndProjects = true
 
     await render()
@@ -835,12 +845,18 @@ describe('App startup routing', () => {
     mocks.sessionPersistence.isHydrated = true
     mocks.sessionPersistence.isReady = false
     mocks.sessionPersistence.canDeleteSessionsAndProjects = false
+    mocks.sessionPersistence.catalogRecovery = { kind: 'project-deletion-recovery' }
 
     await render()
 
     expect(
       container.querySelector<HTMLElement>('[data-testid="home-page"]')?.dataset.canDeleteProjects
     ).toBe('false')
+    expect(container.textContent).toContain('Project recovery needs attention')
+    expect(
+      container.querySelector<HTMLButtonElement>('[data-testid="session-persistence-retry"]')
+        ?.textContent
+    ).toBe('Retry recovery')
   })
 
   it('renders the partial session recovery alert on an opaque semantic surface', async () => {
@@ -848,6 +864,7 @@ describe('App startup routing', () => {
     mocks.sessionPersistence.isHydrated = true
     mocks.sessionPersistence.isReady = false
     mocks.sessionPersistence.loadError = 'one saved conversation could not be read'
+    mocks.sessionPersistence.catalogRecovery = { kind: 'repairable', reason: 'session-scan' }
 
     await render()
 
@@ -1106,19 +1123,21 @@ describe('App startup routing', () => {
   it('reports quarantined corrupt conversation files without blocking healthy sessions', async () => {
     mocks.settings.isLoaded = true
     mocks.sessionPersistence.hasCompleteSessionCatalog = false
+    mocks.sessionPersistence.catalogRecovery = {
+      kind: 'damaged-authority',
+      affectedFileCount: 1
+    }
     mocks.sessionPersistence.loadWarning =
       '1 saved conversation file was damaged and moved aside. The remaining conversations were loaded.'
 
     await render()
 
     const alert = container.querySelector('[data-testid="session-persistence-alert"]')
-    expect(alert?.textContent).toContain('Saved conversation data was damaged')
-    expect(alert?.textContent).toContain('damaged and moved aside')
+    expect(alert?.textContent).toContain('Project archive needs attention')
+    expect(alert?.textContent).toContain('A damaged saved conversation was moved aside')
+    expect(alert?.textContent).toContain('You can still permanently delete the project')
     expect(container.querySelector('[data-testid="session-persistence-retry"]')).toBeNull()
-    container
-      .querySelector<HTMLButtonElement>('[data-testid="session-persistence-dismiss"]')
-      ?.click()
-    expect(mocks.sessionPersistence.dismissLoadWarning).toHaveBeenCalledOnce()
+    expect(container.querySelector('[data-testid="session-persistence-dismiss"]')).toBeNull()
     expect(container.querySelector('[data-testid="home-page"]')).not.toBeNull()
     expect(
       container.querySelector<HTMLElement>('[data-testid="home-page"]')?.dataset

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -575,6 +575,13 @@ const AppContent = (): React.JSX.Element | null => {
 
   const activePresentation = appShellPresentation.active
   const isBasePresentationActive = activePresentation === 'base' || activePresentation === 'preview'
+  const writeErrorAlert = sessionPersistence.writeError ? (
+    <SessionPersistenceAlert
+      title={t('Conversation storage needs attention')}
+      message={sessionPersistence.writeError}
+      onRetry={sessionPersistence.retryWrites}
+    />
+  ) : null
 
   return (
     <>
@@ -595,12 +602,8 @@ const AppContent = (): React.JSX.Element | null => {
             message={sessionPersistence.loadError}
             onRetry={sessionPersistence.retryLoad}
           />
-        ) : sessionPersistence.writeError ? (
-          <SessionPersistenceAlert
-            title={t('Conversation storage needs attention')}
-            message={sessionPersistence.writeError}
-            onRetry={sessionPersistence.retryWrites}
-          />
+        ) : writeErrorAlert ? (
+          writeErrorAlert
         ) : sessionPersistence.loadWarning ? (
           <SessionPersistenceAlert
             title={t('Saved conversation data was damaged')}
@@ -609,6 +612,7 @@ const AppContent = (): React.JSX.Element | null => {
             onDismiss={sessionPersistence.dismissLoadWarning}
           />
         ) : null}
+        {sessionPersistence.catalogRecovery.kind !== 'ready' ? writeErrorAlert : null}
         <WorkspaceAgentRuntimeProvider>
           {view === 'home' ? (
             <HomePage

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -13,6 +13,7 @@ import { LegacyDataMoveDialog } from '@/components/LegacyDataMoveDialog'
 import { LifecycleToast } from '@/components/LifecycleToast'
 import { OpenScienceLogoLoader } from '@/components/OpenScienceLogoLoader'
 import { PermissionUndoSnackbar } from '@/components/PermissionUndoSnackbar'
+import { SessionCatalogRecoveryAlert } from '@/components/SessionCatalogRecoveryAlert'
 import { SessionPersistenceAlert } from '@/components/SessionPersistenceAlert'
 import { UpdateDialog } from '@/components/UpdateDialog'
 import { GlobalSearchDialog } from '@/components/global-search/GlobalSearchDialog'
@@ -583,7 +584,12 @@ const AppContent = (): React.JSX.Element | null => {
         aria-hidden={isBasePresentationActive ? undefined : true}
       >
         <EnvStatusBanner ui={envUi} onRetry={() => void retryEnv()} />
-        {sessionPersistence.loadError ? (
+        {sessionPersistence.catalogRecovery.kind !== 'ready' ? (
+          <SessionCatalogRecoveryAlert
+            recovery={sessionPersistence.catalogRecovery}
+            onRetry={sessionPersistence.retryLoad}
+          />
+        ) : sessionPersistence.loadError ? (
           <SessionPersistenceAlert
             title={t('Saved conversations could not be loaded')}
             message={sessionPersistence.loadError}
@@ -608,6 +614,7 @@ const AppContent = (): React.JSX.Element | null => {
             <HomePage
               canDeleteProjects={sessionPersistence.canDeleteSessionsAndProjects}
               hasCompleteSessionCatalog={sessionPersistence.hasCompleteSessionCatalog}
+              catalogRecovery={sessionPersistence.catalogRecovery}
               onOpenGlobalSearch={() => {
                 if (appShellPresentation.allowsShortcut('globalSearch')) {
                   setIsGlobalSearchOpen(true)
@@ -639,6 +646,10 @@ const AppContent = (): React.JSX.Element | null => {
         open={activePresentation === 'settings'}
         onClose={closeSettings}
         onOpenSession={openPermissionSession}
+        canDeleteProjects={sessionPersistence.canDeleteSessionsAndProjects}
+        hasCompleteSessionCatalog={sessionPersistence.hasCompleteSessionCatalog}
+        catalogRecovery={sessionPersistence.catalogRecovery}
+        onRetryCatalogRecovery={sessionPersistence.retryLoad}
       />
       <ConnectorApprovalDialog
         active={activePresentation === 'connectorApproval'}

--- a/src/renderer/src/components/SessionCatalogRecoveryAlert.render.test.tsx
+++ b/src/renderer/src/components/SessionCatalogRecoveryAlert.render.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SessionCatalogRecoveryAlert } from './SessionCatalogRecoveryAlert'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+describe('SessionCatalogRecoveryAlert', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('presents a partial Session scan as index repair before a Project action', () => {
+    const onRetry = vi.fn()
+    act(() =>
+      root.render(
+        <SessionCatalogRecoveryAlert
+          recovery={{ kind: 'repairable', reason: 'session-scan' }}
+          onRetry={onRetry}
+        />
+      )
+    )
+
+    expect(container.textContent).toContain('Project index needs repair')
+    expect(container.textContent).toContain('Repair the index before archiving projects')
+    const repair = container.querySelector<HTMLButtonElement>(
+      '[data-testid="session-persistence-retry"]'
+    )
+    expect(repair?.textContent).toBe('Repair index')
+    act(() => repair?.click())
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+
+  it('does not promise automatic repair for quarantined Session authority', () => {
+    act(() =>
+      root.render(
+        <SessionCatalogRecoveryAlert
+          recovery={{
+            kind: 'damaged-authority',
+            affectedFileCount: 1
+          }}
+          onRetry={vi.fn()}
+        />
+      )
+    )
+
+    expect(container.textContent).toContain('Project archive needs attention')
+    expect(container.textContent).toContain('A damaged saved conversation was moved aside')
+    expect(container.textContent).toContain('You can still permanently delete the project')
+    expect(container.querySelector('[data-testid="session-persistence-retry"]')).toBeNull()
+  })
+
+  it('keeps unfinished Project deletion recovery distinct from index repair', () => {
+    act(() =>
+      root.render(
+        <SessionCatalogRecoveryAlert
+          recovery={{ kind: 'project-deletion-recovery' }}
+          onRetry={vi.fn()}
+        />
+      )
+    )
+
+    expect(container.textContent).toContain('Project recovery needs attention')
+    expect(container.textContent).toContain('previous project deletion')
+    expect(
+      container.querySelector<HTMLButtonElement>('[data-testid="session-persistence-retry"]')
+        ?.textContent
+    ).toBe('Retry recovery')
+  })
+})

--- a/src/renderer/src/components/SessionCatalogRecoveryAlert.tsx
+++ b/src/renderer/src/components/SessionCatalogRecoveryAlert.tsx
@@ -1,0 +1,72 @@
+import { useTranslation } from 'react-i18next'
+
+import type { SessionCatalogRecovery } from '@/lib/session-persistence/session-persistence'
+import { SessionPersistenceAlert } from './SessionPersistenceAlert'
+
+type SessionCatalogRecoveryAlertProps = {
+  recovery: SessionCatalogRecovery
+  inline?: boolean
+  onRetry?: () => void
+}
+
+// Catalog recovery is a storage concern shown before a Project command is attempted. Keep it
+// distinct from command failures and from the Project Files index, which cannot restore Session JSON.
+const SessionCatalogRecoveryAlert = ({
+  recovery,
+  inline,
+  onRetry
+}: SessionCatalogRecoveryAlertProps): React.JSX.Element | null => {
+  const { t } = useTranslation()
+
+  if (recovery.kind === 'ready') return null
+  if (recovery.kind === 'project-deletion-recovery') {
+    return (
+      <SessionPersistenceAlert
+        title={t('Project recovery needs attention')}
+        message={t(
+          'Open Science could not finish recovering a previous project deletion. Retry recovery before archiving or deleting projects.'
+        )}
+        inline={inline}
+        onRetry={onRetry}
+        retryLabel={t('Retry recovery')}
+      />
+    )
+  }
+  if (recovery.kind === 'damaged-authority') {
+    return (
+      <SessionPersistenceAlert
+        title={t('Project archive needs attention')}
+        message={t(
+          '{{count}} damaged saved conversations were moved aside. Project archive stays unavailable because their state cannot be verified. You can still permanently delete the project.',
+          {
+            count: recovery.affectedFileCount,
+            defaultValue_one:
+              'A damaged saved conversation was moved aside. Project archive stays unavailable because its state cannot be verified. You can still permanently delete the project.'
+          }
+        )}
+        variant="warning"
+        inline={inline}
+      />
+    )
+  }
+
+  return (
+    <SessionPersistenceAlert
+      title={t('Project index needs repair')}
+      message={
+        recovery.reason === 'startup-reconciliation'
+          ? t(
+              'Saved conversations loaded, but the project index could not be rebuilt. Repair the index before archiving projects.'
+            )
+          : t(
+              'Some saved conversations could not be indexed. Repair the index before archiving projects.'
+            )
+      }
+      inline={inline}
+      onRetry={onRetry}
+      retryLabel={t('Repair index')}
+    />
+  )
+}
+
+export { SessionCatalogRecoveryAlert }

--- a/src/renderer/src/components/SessionPersistenceAlert.tsx
+++ b/src/renderer/src/components/SessionPersistenceAlert.tsx
@@ -10,6 +10,7 @@ type SessionPersistenceAlertProps = {
   inline?: boolean
   onDismiss?: () => void
   onRetry?: () => void
+  retryLabel?: string
 }
 
 const SessionPersistenceAlert = ({
@@ -18,7 +19,8 @@ const SessionPersistenceAlert = ({
   variant = 'error',
   inline = false,
   onDismiss,
-  onRetry
+  onRetry,
+  retryLabel
 }: SessionPersistenceAlertProps): React.JSX.Element => {
   const { t } = useTranslation()
 
@@ -43,7 +45,7 @@ const SessionPersistenceAlert = ({
           onClick={onRetry}
           className="shrink-0"
         >
-          {t('Retry')}
+          {retryLabel ?? t('Retry')}
         </Button>
       ) : null}
       {onDismiss ? (

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -88,6 +88,12 @@ describe('session persistence startup', () => {
         data-loading={String(persistence.isLoading)}
         data-ready={String(persistence.isReady)}
         data-catalog-complete={String(persistence.hasCompleteSessionCatalog)}
+        data-catalog-recovery={persistence.catalogRecovery.kind}
+        data-catalog-recovery-reason={
+          persistence.catalogRecovery.kind === 'repairable'
+            ? persistence.catalogRecovery.reason
+            : undefined
+        }
         data-deletion-ready={String(persistence.canDeleteSessionsAndProjects)}
       >
         <span data-testid="load-error">{persistence.loadError ?? 'sessions available'}</span>
@@ -311,6 +317,8 @@ describe('session persistence startup', () => {
     expect(container.querySelector('div')?.dataset.ready).toBe('false')
     expect(container.querySelector('div')?.dataset.hydrated).toBe('true')
     expect(container.querySelector('div')?.dataset.deletionReady).toBe('true')
+    expect(container.querySelector('div')?.dataset.catalogRecovery).toBe('repairable')
+    expect(container.querySelector('div')?.dataset.catalogRecoveryReason).toBe('session-scan')
     expect(container.querySelector('[data-testid="load-error"]')?.textContent).toContain(
       'could not be read'
     )
@@ -505,6 +513,9 @@ describe('session persistence startup', () => {
 
     expect(container.querySelector('div')?.dataset.ready).toBe('false')
     expect(container.querySelector('div')?.dataset.deletionReady).toBe('false')
+    expect(container.querySelector('div')?.dataset.catalogRecovery).toBe(
+      'project-deletion-recovery'
+    )
     expect(container.querySelector('[data-testid="load-error"]')?.textContent).toContain(
       'storage recovery could not finish'
     )
@@ -530,6 +541,7 @@ describe('session persistence startup', () => {
 
     expect(container.querySelector('div')?.dataset.ready).toBe('true')
     expect(container.querySelector('div')?.dataset.catalogComplete).toBe('false')
+    expect(container.querySelector('div')?.dataset.catalogRecovery).toBe('damaged-authority')
     expect(container.querySelector('[data-testid="load-warning"]')?.textContent).toContain(
       'damaged and moved aside'
     )

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -9,6 +9,7 @@ import {
   type PersistedChatSession,
   type SaveSessionOptions,
   type SessionConflictRebaseField,
+  type SessionLoadDiagnostics,
   type SaveSessionManifestRequest
 } from '../../../../shared/session-persistence'
 import { PENDING_UPLOAD_SESSION_ID } from '../../../../shared/uploads'
@@ -205,11 +206,63 @@ type SessionStoreSnapshot = {
   selectedSessionId: string | undefined
 }
 
+type SessionCatalogRecovery =
+  | { kind: 'ready' }
+  | {
+      kind: 'repairable'
+      reason: 'session-scan' | 'startup-reconciliation'
+    }
+  | {
+      kind: 'damaged-authority'
+      affectedFileCount: number
+    }
+  | { kind: 'project-deletion-recovery' }
+
+const READY_SESSION_CATALOG_RECOVERY: SessionCatalogRecovery = Object.freeze({ kind: 'ready' })
+
+const deriveSessionCatalogRecovery = (
+  diagnostics: SessionLoadDiagnostics | undefined
+): SessionCatalogRecovery => {
+  if (!diagnostics) return READY_SESSION_CATALOG_RECOVERY
+  if (diagnostics.isProjectDeletionRecoveryComplete === false) {
+    return { kind: 'project-deletion-recovery' }
+  }
+
+  const sessionWarnings = diagnostics.warnings.filter((warning) => 'projectId' in warning)
+  if (diagnostics.isComplete === false) {
+    return {
+      kind: 'repairable',
+      reason:
+        diagnostics.failure === 'startup-reconciliation-failed'
+          ? 'startup-reconciliation'
+          : 'session-scan'
+    }
+  }
+
+  const damagedWarnings = sessionWarnings.filter(
+    (warning) => warning.kind === 'corrupt' && warning.recovered
+  )
+  if (damagedWarnings.length > 0) {
+    return {
+      kind: 'damaged-authority',
+      affectedFileCount: damagedWarnings.length
+    }
+  }
+
+  // A warning outside a partial scan should remain recoverable rather than being collapsed into a
+  // healthy catalog if a future Main diagnostic can report a readable-but-unresolved Session.
+  if (sessionWarnings.length > 0) {
+    return { kind: 'repairable', reason: 'session-scan' }
+  }
+  return READY_SESSION_CATALOG_RECOVERY
+}
+
 type SessionPersistenceState = {
   isHydrated: boolean
   isLoading: boolean
   isReady: boolean
   hasCompleteSessionCatalog: boolean
+  catalogRecovery: SessionCatalogRecovery
   canDeleteSessionsAndProjects: boolean
   loadError: string | undefined
   loadWarning: string | undefined
@@ -508,6 +561,9 @@ const useSessionPersistence = (): SessionPersistenceState => {
   const [isLoading, setIsLoading] = useState(true)
   const [isReady, setIsReady] = useState(false)
   const [hasCompleteSessionCatalog, setHasCompleteSessionCatalog] = useState(false)
+  const [catalogRecovery, setCatalogRecovery] = useState<SessionCatalogRecovery>(
+    READY_SESSION_CATALOG_RECOVERY
+  )
   const [canDeleteSessionsAndProjects, setCanDeleteSessionsAndProjects] = useState(false)
   const [loadError, setLoadError] = useState<string | undefined>(undefined)
   const [loadWarning, setLoadWarning] = useState<string | undefined>(undefined)
@@ -529,6 +585,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
     setIsLoading(true)
     setIsReady(false)
     setHasCompleteSessionCatalog(false)
+    setCatalogRecovery(READY_SESSION_CATALOG_RECOVERY)
     setCanDeleteSessionsAndProjects(false)
     setLoadError(undefined)
     setLoadWarning(undefined)
@@ -580,6 +637,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
         const sessionWarningCount = loadWarnings.filter(
           (warning) => warning.kind !== 'manifest-corrupt' && warning.kind !== 'manifest-unreadable'
         ).length
+        setCatalogRecovery(deriveSessionCatalogRecovery(result.diagnostics))
         setHasCompleteSessionCatalog(
           result.diagnostics?.isComplete !== false && sessionWarningCount === 0
         )
@@ -628,6 +686,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
         reportPersistenceError(error, 'session-load')
         if (isMounted) {
           setHasCompleteSessionCatalog(false)
+          setCatalogRecovery(READY_SESSION_CATALOG_RECOVERY)
           setCanDeleteSessionsAndProjects(false)
           setLoadError(SAFE_SESSION_LOAD_ERROR)
           setIsLoading(false)
@@ -737,6 +796,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
     isLoading,
     isReady,
     hasCompleteSessionCatalog,
+    catalogRecovery,
     canDeleteSessionsAndProjects,
     loadError,
     loadWarning,
@@ -753,12 +813,14 @@ export {
   flushSessionPersistence,
   loadPersistedSessions,
   reconcilePendingArtifacts,
+  deriveSessionCatalogRecovery,
   saveSessionInOrder,
   useSessionPersistence
 }
 export type {
   ArtifactReconcileApi,
   OrderedSessionPersistence,
+  SessionCatalogRecovery,
   SessionPersistenceApi,
   SessionPersistenceState
 }

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -2633,5 +2633,19 @@
   "Input (uncached)": "输入（未命中缓存）",
   "Start a conversation to see token usage here.": "开始一个会话后即可在这里查看 Token 用量。",
   "No token usage has been reported in the last 30 days.": "近 30 天内没有已报告的 Token 用量。",
-  "Stacked daily token usage for the last 30 days": "近 30 天每日 Token 用量叠加图"
+  "Stacked daily token usage for the last 30 days": "近 30 天每日 Token 用量叠加图",
+  "Project recovery needs attention": "项目恢复需要处理",
+  "Open Science could not finish recovering a previous project deletion. Retry recovery before archiving or deleting projects.": "Open Science 无法完成之前项目删除的恢复。请先重试恢复，再归档或删除项目。",
+  "Retry recovery": "重试恢复",
+  "Project archive needs attention": "项目归档需要处理",
+  "{{count}} damaged saved conversations were moved aside. Project archive stays unavailable because their state cannot be verified. You can still permanently delete the project._other": "已移出 {{count}} 个损坏的已保存会话。由于无法验证它们的状态，项目归档仍不可用。你仍可永久删除该项目。",
+  "Project index needs repair": "项目索引需要修复",
+  "Saved conversations loaded, but the project index could not be rebuilt. Repair the index before archiving projects.": "已保存的会话已加载，但无法重建项目索引。请先修复索引，再归档项目。",
+  "Some saved conversations could not be indexed. Repair the index before archiving projects.": "部分已保存的会话无法建立索引。请先修复索引，再归档项目。",
+  "Repair index": "修复索引",
+  "Retry project recovery before archiving.": "归档前请先重试项目恢复。",
+  "Project archive is unavailable because a damaged conversation cannot be verified.": "由于无法验证损坏的会话，项目归档不可用。",
+  "Repair the project index before archiving.": "归档前请先修复项目索引。",
+  "Retry project recovery before deleting projects.": "删除项目前请先重试项目恢复。",
+  "Finish or stop active sessions before archiving this project.": "归档项目前，请先完成或停止活动会话。"
 }

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -2633,5 +2633,19 @@
   "Input (uncached)": "輸入（未命中快取）",
   "Start a conversation to see token usage here.": "開始一個對話後即可在這裡檢視 Token 用量。",
   "No token usage has been reported in the last 30 days.": "最近 30 天內沒有已回報的 Token 用量。",
-  "Stacked daily token usage for the last 30 days": "最近 30 天每日 Token 用量堆疊圖"
+  "Stacked daily token usage for the last 30 days": "最近 30 天每日 Token 用量堆疊圖",
+  "Project recovery needs attention": "專案復原需要處理",
+  "Open Science could not finish recovering a previous project deletion. Retry recovery before archiving or deleting projects.": "Open Science 無法完成先前專案刪除的復原。請先重試復原，再封存或刪除專案。",
+  "Retry recovery": "重試復原",
+  "Project archive needs attention": "專案封存需要處理",
+  "{{count}} damaged saved conversations were moved aside. Project archive stays unavailable because their state cannot be verified. You can still permanently delete the project._other": "已移出 {{count}} 個損壞的已儲存對話。由於無法驗證它們的狀態，專案封存仍無法使用。你仍可永久刪除該專案。",
+  "Project index needs repair": "專案索引需要修復",
+  "Saved conversations loaded, but the project index could not be rebuilt. Repair the index before archiving projects.": "已儲存的對話已載入，但無法重建專案索引。請先修復索引，再封存專案。",
+  "Some saved conversations could not be indexed. Repair the index before archiving projects.": "部分已儲存的對話無法建立索引。請先修復索引，再封存專案。",
+  "Repair index": "修復索引",
+  "Retry project recovery before archiving.": "封存前請先重試專案復原。",
+  "Project archive is unavailable because a damaged conversation cannot be verified.": "由於無法驗證損壞的對話，專案封存無法使用。",
+  "Repair the project index before archiving.": "封存前請先修復專案索引。",
+  "Retry project recovery before deleting projects.": "刪除專案前請先重試專案復原。",
+  "Finish or stop active sessions before archiving this project.": "封存專案前，請先完成或停止進行中的工作階段。"
 }

--- a/src/renderer/src/pages/home/HomePage.persistence.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.persistence.test.tsx
@@ -194,6 +194,38 @@ describe('HomePage persistence recovery', () => {
     expect(container.textContent).not.toContain('1 session')
   })
 
+  it('maps a raced incomplete-catalog archive rejection to index repair guidance', async () => {
+    const updateProjectArchive = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          "Error invoking remote method 'projects:update-archive': Error: Cannot archive a Project while its Session catalog is incomplete."
+        )
+      )
+    useProjectStore.setState({ updateProjectArchive } as never)
+
+    await act(async () =>
+      root.render(
+        <HomePage canDeleteProjects hasCompleteSessionCatalog onOpenGlobalSearch={vi.fn()} />
+      )
+    )
+
+    const archive = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent?.trim() === 'Archive'
+    )
+    await act(async () => archive?.click())
+
+    expect(updateProjectArchive).toHaveBeenCalledWith({
+      id: project.id,
+      archived: true,
+      expectedArchivedAt: null
+    })
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+      'Repair the project index before archiving.'
+    )
+    expect(container.textContent).not.toContain('Session catalog is incomplete')
+  })
+
   it('guards confirmation when persistence becomes unavailable after the dialog opens', async () => {
     await act(async () =>
       root.render(

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -21,6 +21,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { relativeTimeParts, type RelativeTimeUnit } from '@/lib/format-relative-time'
+import type { SessionCatalogRecovery } from '@/lib/session-persistence/session-persistence'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import {
@@ -91,8 +92,12 @@ type HomeSessionUpdate = {
 type HomePageProps = {
   canDeleteProjects: boolean
   hasCompleteSessionCatalog: boolean
+  catalogRecovery?: SessionCatalogRecovery
   onOpenGlobalSearch: () => void
 }
+
+const INCOMPLETE_PROJECT_SESSION_CATALOG_ERROR =
+  'Cannot archive a Project while its Session catalog is incomplete.'
 
 // Optional warnings (currently Python and reduced key protection) never create a Home alert. Only a
 // failed check that blocks the core flow asks an existing user to revisit environment setup.
@@ -136,6 +141,7 @@ const rowActionClassName =
 const HomePage = ({
   canDeleteProjects,
   hasCompleteSessionCatalog,
+  catalogRecovery,
   onOpenGlobalSearch
 }: HomePageProps): React.JSX.Element => {
   const { t } = useTranslation()
@@ -179,6 +185,9 @@ const HomePage = ({
   const [markReadErrorSessionIds, setMarkReadErrorSessionIds] = useState<Set<string>>(
     () => new Set()
   )
+  const effectiveCatalogRecovery: SessionCatalogRecovery =
+    catalogRecovery ??
+    (hasCompleteSessionCatalog ? { kind: 'ready' } : { kind: 'repairable', reason: 'session-scan' })
 
   const activeProjects = useMemo(
     () => projects.filter((project) => project.archivedAt === undefined),
@@ -394,6 +403,19 @@ const HomePage = ({
           session.status === 'waiting-plan-approval')
     )
 
+  const archiveUnavailableReason = (project: Project): string | undefined => {
+    if (!canDeleteProjects) return t('Retry project recovery before archiving.')
+    if (!hasCompleteSessionCatalog) {
+      return effectiveCatalogRecovery.kind === 'damaged-authority'
+        ? t('Project archive is unavailable because a damaged conversation cannot be verified.')
+        : t('Repair the project index before archiving.')
+    }
+    if (!canArchiveProject(project)) {
+      return t('Finish or stop active sessions before archiving this project.')
+    }
+    return undefined
+  }
+
   const archiveProject = (project: Project): void => {
     if (!canArchiveProject(project) || archivingProjectIds.has(project.id)) return
 
@@ -403,7 +425,11 @@ const HomePage = ({
       .then((archived) => enqueueProjectArchive(archived))
       .catch((error: unknown) =>
         setProjectActionError(
-          error instanceof Error ? error.message : t('Could not archive project.')
+          error instanceof Error && error.message.includes(INCOMPLETE_PROJECT_SESSION_CATALOG_ERROR)
+            ? t('Repair the project index before archiving.')
+            : error instanceof Error
+              ? error.message
+              : t('Could not archive project.')
         )
       )
       .finally(() => {
@@ -878,6 +904,7 @@ const HomePage = ({
                             disabled={
                               !canArchiveProject(project) || archivingProjectIds.has(project.id)
                             }
+                            title={archiveUnavailableReason(project)}
                             onSelect={() => archiveProject(project)}
                           >
                             <Archive className="size-4" strokeWidth={2} aria-hidden="true" />
@@ -890,6 +917,11 @@ const HomePage = ({
                           <DropdownMenuItem
                             className="gap-2 text-danger-000 data-[highlighted]:bg-danger-900 data-[highlighted]:text-danger-000"
                             disabled={!canDeleteProjects}
+                            title={
+                              canDeleteProjects
+                                ? undefined
+                                : t('Retry project recovery before deleting projects.')
+                            }
                             onSelect={() => openDeleteDialog(project)}
                           >
                             <Trash2 className="size-4" strokeWidth={2} aria-hidden="true" />

--- a/src/renderer/src/pages/settings/ArchivedPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ArchivedPanel.render.test.tsx
@@ -195,4 +195,76 @@ describe('ArchivedPanel', () => {
     expect(window.api.acp.deleteSession).not.toHaveBeenCalled()
     expect(onNavigate).toHaveBeenCalledWith({ kind: 'list' })
   })
+
+  it('shows Project recovery in Settings and keeps deletion unavailable until retry succeeds', async () => {
+    const archivedProject = { ...project, archivedAt: 2 }
+    useProjectStore.setState({
+      ...createInitialProjectState(),
+      projects: [archivedProject],
+      isLoaded: true,
+      deleteProject
+    })
+    const onRetryCatalogRecovery = vi.fn()
+
+    await act(async () =>
+      root.render(
+        <ArchivedPanel
+          view={{ kind: 'project', projectId: archivedProject.id }}
+          onNavigate={vi.fn()}
+          canDeleteProjects={false}
+          hasCompleteSessionCatalog={false}
+          catalogRecovery={{ kind: 'project-deletion-recovery' }}
+          onRetryCatalogRecovery={onRetryCatalogRecovery}
+        />
+      )
+    )
+
+    expect(container.textContent).toContain('Project recovery needs attention')
+    const retry = container.querySelector<HTMLButtonElement>(
+      '[data-testid="session-persistence-retry"]'
+    )
+    await act(async () => retry?.click())
+    expect(onRetryCatalogRecovery).toHaveBeenCalledOnce()
+
+    const deleteButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.includes('Delete project')
+    )
+    expect(deleteButton?.disabled).toBe(true)
+  })
+
+  it('keeps whole-Project deletion available with conservative copy for damaged authority', async () => {
+    const archivedProject = { ...project, archivedAt: 2 }
+    useProjectStore.setState({
+      ...createInitialProjectState(),
+      projects: [archivedProject],
+      isLoaded: true,
+      deleteProject
+    })
+
+    await act(async () =>
+      root.render(
+        <ArchivedPanel
+          view={{ kind: 'project', projectId: archivedProject.id }}
+          onNavigate={vi.fn()}
+          canDeleteProjects
+          hasCompleteSessionCatalog={false}
+          catalogRecovery={{
+            kind: 'damaged-authority',
+            affectedFileCount: 1
+          }}
+        />
+      )
+    )
+
+    const openDelete = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.includes('Delete project')
+    )
+    expect(openDelete?.disabled).toBe(false)
+    await act(async () => openDelete?.click())
+
+    const dialog = document.body.querySelector<HTMLElement>('[role="alertdialog"]')
+    expect(dialog?.textContent).toContain(
+      'all of its saved conversations, including any that could not be loaded during recovery'
+    )
+  })
 })

--- a/src/renderer/src/pages/settings/ArchivedPanel.tsx
+++ b/src/renderer/src/pages/settings/ArchivedPanel.tsx
@@ -3,6 +3,8 @@ import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
+import { SessionCatalogRecoveryAlert } from '@/components/SessionCatalogRecoveryAlert'
+import type { SessionCatalogRecovery } from '@/lib/session-persistence/session-persistence'
 import { DeleteProjectDialog } from '@/pages/home/DeleteProjectDialog'
 import { useDateTimeFormat } from '@/hooks/useDateTimeFormat'
 import { DeleteSessionDialog } from '@/pages/workspace/DeleteSessionDialog'
@@ -17,13 +19,24 @@ export type ArchivedView = { kind: 'list' } | { kind: 'project'; projectId: stri
 type ArchivedPanelProps = {
   view: ArchivedView
   onNavigate: (view: ArchivedView) => void
+  catalogRecovery?: SessionCatalogRecovery
+  hasCompleteSessionCatalog?: boolean
+  canDeleteProjects?: boolean
+  onRetryCatalogRecovery?: () => void
 }
 
 const describeError = (error: unknown, fallback: string): string =>
   error instanceof Error ? error.message : fallback
 
 // Archive recovery stays in Settings so active workspace surfaces only need to reason about active data.
-const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Element => {
+const ArchivedPanel = ({
+  view,
+  onNavigate,
+  catalogRecovery = { kind: 'ready' },
+  hasCompleteSessionCatalog = true,
+  canDeleteProjects = true,
+  onRetryCatalogRecovery
+}: ArchivedPanelProps): React.JSX.Element => {
   const { t } = useTranslation()
   const formatDate = useDateTimeFormat()
   const projects = useProjectStore((state) => state.projects)
@@ -95,7 +108,7 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
 
   const deleteArchivedSession = (): void => {
     const session = sessionToDelete
-    if (!session) return
+    if (!session || !canDeleteProjects) return
 
     setBusyKey(`session:${session.id}`)
     setPanelError(undefined)
@@ -119,6 +132,7 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
   }
 
   const openProjectDeleteDialog = (project: Project): void => {
+    if (!canDeleteProjects) return
     setProjectDeleteError(undefined)
     setProjectToDelete(project)
   }
@@ -132,7 +146,7 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
 
   const deleteArchivedProject = (): void => {
     const project = projectToDelete
-    if (!project) return
+    if (!project || !canDeleteProjects) return
 
     setBusyKey(`project:${project.id}`)
     setProjectDeleteError(undefined)
@@ -177,7 +191,10 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
         variant="outline"
         size="sm"
         className="text-danger-000 hover:text-danger-000"
-        disabled={busyKey === `session:${session.id}`}
+        disabled={!canDeleteProjects || busyKey === `session:${session.id}`}
+        title={
+          canDeleteProjects ? undefined : t('Retry project recovery before deleting projects.')
+        }
         onClick={() => {
           setPanelError(undefined)
           setSessionToDelete(session)
@@ -191,6 +208,11 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
 
   return (
     <div className="space-y-5 p-5">
+      <SessionCatalogRecoveryAlert
+        recovery={catalogRecovery}
+        inline
+        onRetry={onRetryCatalogRecovery}
+      />
       {panelError ? (
         <p role="alert" className="text-sm text-danger-000">
           {panelError}
@@ -225,7 +247,12 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
                 variant="outline"
                 size="sm"
                 className="text-danger-000 hover:text-danger-000"
-                disabled={busyKey === `project:${selectedProject.id}`}
+                disabled={!canDeleteProjects || busyKey === `project:${selectedProject.id}`}
+                title={
+                  canDeleteProjects
+                    ? undefined
+                    : t('Retry project recovery before deleting projects.')
+                }
                 onClick={() => openProjectDeleteDialog(selectedProject)}
               >
                 <Trash2 className="size-3.5" aria-hidden="true" />
@@ -300,8 +327,8 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
         sessionCount={
           sessions.filter((session) => session.projectId === projectToDelete?.id).length
         }
-        hasCompleteSessionCatalog
-        canDelete
+        hasCompleteSessionCatalog={hasCompleteSessionCatalog}
+        canDelete={canDeleteProjects}
         isDeleting={busyKey === `project:${projectToDelete?.id}`}
         error={projectDeleteError}
         onCancel={closeProjectDeleteDialog}
@@ -309,7 +336,7 @@ const ArchivedPanel = ({ view, onNavigate }: ArchivedPanelProps): React.JSX.Elem
       />
       <DeleteSessionDialog
         session={sessionToDelete}
-        canDelete
+        canDelete={canDeleteProjects}
         onCancel={() => setSessionToDelete(undefined)}
         onConfirmDelete={deleteArchivedSession}
       />

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -34,6 +34,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { cn } from '@/lib/utils'
+import type { SessionCatalogRecovery } from '@/lib/session-persistence/session-persistence'
 import { useComputeStore } from '@/stores/compute-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useSessionStore } from '@/stores/session-store'
@@ -78,6 +79,10 @@ type SettingsPageProps = {
   open: boolean
   onClose: () => void
   onOpenSession?: (sessionId: string) => void
+  canDeleteProjects?: boolean
+  hasCompleteSessionCatalog?: boolean
+  catalogRecovery?: SessionCatalogRecovery
+  onRetryCatalogRecovery?: () => void
 }
 
 type SettingsPageHandle = {
@@ -241,7 +246,15 @@ const INITIAL_LOCATION: NavLocation = {
 // App-level model settings surface. Reuses the onboarding cards/form; manages providers (CRUD +
 // activate + test). Opened from the Home/Workspace gear entry.
 const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function SettingsPage(
-  { open, onClose, onOpenSession },
+  {
+    open,
+    onClose,
+    onOpenSession,
+    canDeleteProjects = true,
+    hasCompleteSessionCatalog = true,
+    catalogRecovery = { kind: 'ready' },
+    onRetryCatalogRecovery
+  },
   ref
 ): React.JSX.Element {
   const { t } = useTranslation()
@@ -1095,7 +1108,14 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                     }
                   />
                 ) : activePanel === 'archived' ? (
-                  <ArchivedPanel view={archivedView} onNavigate={navigateArchived} />
+                  <ArchivedPanel
+                    view={archivedView}
+                    onNavigate={navigateArchived}
+                    canDeleteProjects={canDeleteProjects}
+                    hasCompleteSessionCatalog={hasCompleteSessionCatalog}
+                    catalogRecovery={catalogRecovery}
+                    onRetryCatalogRecovery={onRetryCatalogRecovery}
+                  />
                 ) : activePanel === 'runtimes' ? (
                   <RuntimesPanel
                     title={t('Notebook runtimes')}


### PR DESCRIPTION
## Problem

An incomplete Session catalog prevents safe Project archive operations, but the current UI can present the resulting rejection as a generic Project operation failure. Unfinished Project deletion recovery and quarantined damaged Session authority also need distinct guidance.

## Proposed change

- derive a renderer-only catalog recovery state from existing startup diagnostics
- present repairable catalog failures as Project index repair before an archive attempt
- keep quarantined damaged Session authority distinct because retry cannot restore it
- keep unfinished Project deletion recovery distinct from index repair
- apply the same recovery guidance and deletion gates to Home and Settings > Archived
- map Electron-wrapped incomplete-catalog archive errors to localized index-repair guidance

## Scope and non-goals

- no database or storage schema changes
- no persisted fields, persisted enum values, IPC contracts, or shared data-model changes
- no migration or historical-data rewrite; existing diagnostics are classified on the next load
- the new recovery union is transient renderer state only
- quarantined damaged Session files still cannot be automatically restored; whole-Project permanent deletion remains available when deletion recovery is otherwise ready
- Project activity history is intentionally out of scope because it requires a separate durable event model and migration

## Acceptance criteria and validation

- partial Session scans and startup reconciliation failures show Project index repair guidance
- quarantined damaged authority explains why archive remains unavailable without promising repair
- unfinished Project deletion recovery shows recovery-specific guidance and gates deletion
- Simplified and Traditional Chinese catalogs cover every new user-visible string

Final Test Impact Set, run after the last material edit:

- session persistence diagnostics and recovery classification: session-persistence.render.test.tsx
- shared recovery presentation: SessionPersistenceAlert.render.test.tsx and SessionCatalogRecoveryAlert.render.test.tsx
- Home archive race and action guidance: HomePage.persistence.test.tsx, HomePage.render.test.tsx, and home-dialogs.render.test.tsx
- archived Project and Session deletion gates: ArchivedPanel.render.test.tsx and SettingsPage.render.test.tsx
- App routing and alert precedence: App.test.tsx
- localization contracts: i18n/resources.test.ts
- renderer interfaces: npm run typecheck:web
- source validation: npm run lint

The 10 targeted test files passed with 253 tests. Web typecheck and lint passed. The complete portable and platform suites are intentionally left to exact-head PR CI.

Uncovered local risk: independent review and full cross-platform execution are not reproduced locally; PR CI remains authoritative.

## Review focus

- whether the diagnostic precedence correctly distinguishes repairable indexing, quarantined authority, and unfinished deletion recovery
- whether permanent Project deletion remains available only in the intended quarantined-authority case
- whether the recovery copy accurately describes the available action without implying a Project Files index repair
