### PR TITLE
test(notebook): remove teardown timing race

### DIFF
--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -6741,19 +6741,7 @@ describe('v4 runtime bindings & agent tools', () => {
         runtimeId: userPyA.envId
       })
       const close = teardown === 'shutdown' ? service.shutdownAll() : service.dispose()
-      let timeout: ReturnType<typeof setTimeout> | undefined
-      const outcome = await Promise.race([
-        Promise.all([bind, close]).then(
-          () => 'completed' as const,
-          () => 'rejected' as const
-        ),
-        new Promise<'timed-out'>((resolve) => {
-          timeout = setTimeout(() => resolve('timed-out'), 250)
-        })
-      ])
-      if (timeout) clearTimeout(timeout)
-
-      expect(outcome).toBe('completed')
+      await Promise.all([bind, close])
     }
   )
 


### PR DESCRIPTION
## Problem

Windows Full Test run 31928162294 intermittently failed the fresh-session immediate teardown test because the test imposed its own 250 ms wall-clock deadline. The workflow already gives Windows tests a 60 second timeout for I/O variance.

## Proposed change

Remove the private timer race and await bind plus shutdown or dispose directly. Promise rejection still fails immediately, while a real deadlock remains bounded by Vitest and job timeouts.

## Scope and non-goals

Test-only change. No production runtime behavior, schema, migration, persistence format, status, or enum changes. This does not address the separate Nightly typecheck heap OOM.

## Acceptance criteria and validation

- Fresh bind plus shutdown/dispose settles: npm test -- src/main/notebook/runtime-service.test.ts -> 203 passed, 5 skipped.
- Node test contracts: npm run typecheck:node -> passed.
- Linted test source: npm run lint -> passed.
- Patch hygiene: git diff --check -> passed.
- The checks above ran after the final material edit.
- The file has no concrete module-impact owner; per maintainer direction the complete local npm test was not run. Exact-head PR CI and Windows lanes are authoritative for the full portable and platform test plan.

## Review focus

Confirm that removing the arbitrary 250 ms performance assertion preserves rejection and deadlock detection through Promise.all and the existing test timeout.