### PR TITLE
fix(reviewer): recover incomplete reviews and serialize corrections

### DIFF
--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -1204,6 +1204,68 @@ describe('AcpRuntimeCoordinator', () => {
     await laterUser
   })
 
+  it.each(['claude-code', 'opencode', 'codex'] as const)(
+    'linearizes a scoped Reviewer correction behind an active %s user prompt',
+    async (frameworkId) => {
+      const prompts = [createDeferred<unknown>(), createDeferred<unknown>()]
+      let promptIndex = 0
+      let created!: ReturnType<typeof createFakeRuntime>
+      const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+        created = createFakeRuntime({
+          frameworkId,
+          sessionIds: ['session-1'],
+          callbacks,
+          prompt: () => prompts[promptIndex++].promise
+        })
+        return created.runtime
+      })
+      const session = await coordinator.createSession({
+        cwd: '/workspace',
+        projectName: 'project-1'
+      })
+
+      const userPrompt = coordinator.sendPrompt({
+        sessionId: session.sessionId,
+        text: 'active user turn'
+      })
+      await vi.waitFor(() => expect(created.sendPrompt).toHaveBeenCalledOnce())
+
+      const correction = coordinator.withActivity(
+        {
+          session: {
+            sessionId: session.sessionId,
+            cwd: '/workspace',
+            projectName: 'project-1',
+            previousFrameworkId: frameworkId
+          }
+        },
+        (runtime) =>
+          runtime.sendApplicationPrompt(
+            { sessionId: session.sessionId, text: '[Auditor] correct the reviewed turn' },
+            {
+              kind: 'application',
+              feature: 'reviewer',
+              purpose: 'correction',
+              causeReviewId: 'review-1'
+            }
+          )
+      )
+
+      await Promise.resolve()
+      await Promise.resolve()
+      expect(vi.mocked(created.runtime.sendApplicationPrompt)).not.toHaveBeenCalled()
+
+      prompts[0].resolve({ stopReason: 'end_turn' })
+      await userPrompt
+      await vi.waitFor(() =>
+        expect(vi.mocked(created.runtime.sendApplicationPrompt)).toHaveBeenCalledOnce()
+      )
+
+      prompts[1].resolve({ stopReason: 'end_turn' })
+      await correction
+    }
+  )
+
   it('revalidates a parked upward branch inside the root lock before any provider call', async () => {
     let created!: ReturnType<typeof createFakeRuntime>
     const coordinator = new AcpRuntimeCoordinator((callbacks) => {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -1192,25 +1192,26 @@ class AcpRuntimeCoordinator {
           false
         )
       },
-      sendApplicationPrompt: async (request, attribution) => {
-        this.assertPromptAdmissionOpen()
-        const contextReset = await ensureActivitySession(request.sessionId)
-        const historyPreamble = options.session?.historyPreamble
-        return this.dispatchPrompt(
-          contextReset
-            ? {
-                ...request,
-                contextReset: true,
-                ...(historyPreamble && !request.historyPreamble ? { historyPreamble } : {})
-              }
-            : request,
-          undefined,
-          'sendApplicationPrompt',
-          runtime,
-          false,
-          attribution
-        )
-      }
+      sendApplicationPrompt: (request, attribution) =>
+        this.linearizeRootAdmission(request.sessionId, async () => {
+          this.assertPromptAdmissionOpen()
+          const contextReset = await ensureActivitySession(request.sessionId)
+          const historyPreamble = options.session?.historyPreamble
+          return this.dispatchPrompt(
+            contextReset
+              ? {
+                  ...request,
+                  contextReset: true,
+                  ...(historyPreamble && !request.historyPreamble ? { historyPreamble } : {})
+                }
+              : request,
+            undefined,
+            'sendApplicationPrompt',
+            runtime,
+            false,
+            attribution
+          )
+        })
     }
   }
 

--- a/src/main/reviewer/mcp-server.test.ts
+++ b/src/main/reviewer/mcp-server.test.ts
@@ -767,6 +767,7 @@ describe('ReviewerMcpServer HTTP transport', () => {
       })
       expect(missing.result?.isError).toBe(true)
       expect(missing.result?.content?.[0]?.text).toContain('Missing disposition')
+      expect(server.submissionAttempted).toBe(true)
 
       const duplicatedDisposition = await callTool(
         endpoint,

--- a/src/main/reviewer/mcp-server.ts
+++ b/src/main/reviewer/mcp-server.ts
@@ -288,6 +288,7 @@ export class ReviewerMcpServer {
     executionLogActivityIds: new Set<string>(),
     artifactVersionIds: new Set<string>()
   }
+  private findingsSubmissionAttempted = false
   private findingsSubmissionState: 'idle' | 'submitting' | 'submitted' = 'idle'
 
   constructor(
@@ -336,6 +337,10 @@ export class ReviewerMcpServer {
       ...connection,
       listening: this.httpServer.listening
     })
+  }
+
+  get submissionAttempted(): boolean {
+    return this.findingsSubmissionAttempted
   }
 
   // Returns the native HTTP config, or the Windows stdio proxy config for a named pipe.
@@ -468,6 +473,7 @@ export class ReviewerMcpServer {
         inputSchema: submitFindingsObjectSchema.shape
       },
       async (input) => {
+        this.findingsSubmissionAttempted = true
         // Keep the idle check and the transition to `submitting` free of awaits. JavaScript's
         // run-to-completion semantics then make this a single-writer gate for concurrent tool calls.
         if (this.findingsSubmissionState !== 'idle') {

--- a/src/main/reviewer/orchestrator-prompt-prefix.test.ts
+++ b/src/main/reviewer/orchestrator-prompt-prefix.test.ts
@@ -26,6 +26,7 @@ import type { MessageAttribution, PersistedChatSession } from '../../shared/sess
 // The reviewer prompt built by buildReviewerPrompt always starts with this line (see orchestrator.ts).
 // It is the stable marker used to locate the reviewer prompt inside the text sent to the agent.
 const REVIEWER_PROMPT_HEAD = 'You are reviewing turn: msg-2'
+const RECOVERY_PROMPT_HEAD = 'Your previous turn ended without calling submit_findings.'
 
 const makeSession = (): PersistedChatSession => ({
   id: 'session-1',
@@ -145,8 +146,7 @@ describe('runReview — framework-neutral rubric delivery (promptPrefix)', () =>
       artifactStorageRoot: temporaryRoot!
     })
 
-    // Exactly one prompt was sent to the reviewer session.
-    expect(promptSink).toHaveLength(1)
+    expect(promptSink).toHaveLength(2)
     const sent = promptSink[0]!
 
     // The sent prompt begins with the prefix followed by a blank line, then the reviewer prompt.
@@ -157,6 +157,7 @@ describe('runReview — framework-neutral rubric delivery (promptPrefix)', () =>
     expect(sent.indexOf(openCodePrefix)).toBeLessThan(sent.indexOf(REVIEWER_PROMPT_HEAD))
     // Concretely: prefix + separator + the reviewer prompt (which starts with its known head line).
     expect(sent.startsWith(`${openCodePrefix}\n\n${REVIEWER_PROMPT_HEAD}`)).toBe(true)
+    expect(promptSink[1]).toContain(RECOVERY_PROMPT_HEAD)
 
     await client.$disconnect()
   })
@@ -180,13 +181,14 @@ describe('runReview — framework-neutral rubric delivery (promptPrefix)', () =>
       artifactStorageRoot: temporaryRoot!
     })
 
-    expect(promptSink).toHaveLength(1)
+    expect(promptSink).toHaveLength(2)
     const sent = promptSink[0]!
 
     // No prefix: the text sent is exactly the reviewer prompt, starting with its head line.
     expect(sent.startsWith(REVIEWER_PROMPT_HEAD)).toBe(true)
     // And nothing from the opencode-style prefix leaked in.
     expect(sent).not.toContain('OPENCODE-RUBRIC-PREFIX')
+    expect(promptSink[1]).toContain(RECOVERY_PROMPT_HEAD)
 
     await client.$disconnect()
   })
@@ -425,14 +427,15 @@ describe('runScopedReview — framework-neutral rubric delivery (fix-loop re-rev
 
     // The initial review + exactly one scoped re-review each built a reviewer session.
     expect(buildCall).toBe(2)
-    // The scoped re-review sent exactly one prompt, and it carries the prefix ahead of the reviewer
-    // prompt for the correction turn (msg-4-correction).
-    expect(scopedPromptSink).toHaveLength(1)
+    // The scoped re-review prompt carries the prefix ahead of the reviewer prompt for the correction
+    // turn (msg-4-correction); its one recovery prompt remains a separate protocol instruction.
+    expect(scopedPromptSink).toHaveLength(2)
     const scopedHead = 'You are reviewing turn: msg-4-correction'
     const sent = scopedPromptSink[0]!
     expect(sent.startsWith(`${scopedPrefix}\n\n`)).toBe(true)
     expect(sent).toContain(scopedHead)
     expect(sent.startsWith(`${scopedPrefix}\n\n${scopedHead}`)).toBe(true)
+    expect(scopedPromptSink[1]).toContain(RECOVERY_PROMPT_HEAD)
 
     await client.$disconnect()
   })

--- a/src/main/reviewer/orchestrator.test.ts
+++ b/src/main/reviewer/orchestrator.test.ts
@@ -135,7 +135,7 @@ const startFakeReviewerAgent = (
 
       // If requested, ask for a tool outside the reviewer allowlist; the runtime gate rejects it and
       // increments the session's rejected-tool-call counter.
-      if (options.emitRejectedToolCall) {
+      if (options.emitRejectedToolCall && prompts.length === 1) {
         await ctx.client.request(acp.methods.client.session.requestPermission, {
           sessionId: ctx.params.sessionId,
           toolCall: {
@@ -152,7 +152,11 @@ const startFakeReviewerAgent = (
       }
 
       // If requested, simulate the reviewer calling submit_findings via the HTTP MCP server.
-      if (options.simulateFindingsViaHttp && newSessions.length > 0) {
+      if (
+        options.simulateFindingsViaHttp &&
+        newSessions.length > 0 &&
+        (!options.emitRejectedToolCall || prompts.length > 1)
+      ) {
         const mcpServers = newSessions[newSessions.length - 1]?.mcpServers ?? []
         const reviewerMcp = (
           mcpServers as Array<{
@@ -282,7 +286,7 @@ describe('reviewer orchestrator', () => {
 
   it('fails closed when the reviewer stops without submitting findings', async () => {
     const process = new FakeAgentProcess()
-    startFakeReviewerAgent(process, 'reviewer-session-1')
+    const { prompts } = startFakeReviewerAgent(process, 'reviewer-session-1')
 
     const runtime = new AcpRuntime({
       appVersion: '0.1.0',
@@ -310,6 +314,7 @@ describe('reviewer orchestrator', () => {
     expect(review.outcome).toBeNull()
     expect(review.errorMessage).toContain('without calling submit_findings')
     expect(review.checks).toHaveLength(0)
+    expect(prompts).toHaveLength(2)
 
     await client.$disconnect()
   })
@@ -343,6 +348,41 @@ describe('reviewer orchestrator', () => {
     expect(review.errorMessage).toContain('rejected by the permission gate')
     expect(review.errorMessage).toContain('stopped without calling submit_findings')
     expect(review.checks).toHaveLength(0)
+
+    await client.$disconnect()
+  })
+
+  it('recovers a reviewer after the permission gate rejects its first tool call', async () => {
+    const process = new FakeAgentProcess()
+    const { prompts } = startFakeReviewerAgent(process, 'reviewer-session-1', {
+      emitRejectedToolCall: true,
+      simulateFindingsViaHttp: true
+    })
+
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const client = createProjectDbClient(temporaryRoot!)
+    await migrateApplicationDatabase(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const review = await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () => makeSession(),
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!
+    })
+
+    expect(review.lifecycle).toBe('complete')
+    expect(review.outcome).toBe('pass')
+    expect(review.checks).toHaveLength(1)
+    expect(prompts).toHaveLength(2)
 
     await client.$disconnect()
   })

--- a/src/main/reviewer/review-assessment-owner.test.ts
+++ b/src/main/reviewer/review-assessment-owner.test.ts
@@ -18,6 +18,7 @@ const harness = vi.hoisted(() => ({
   events: [] as string[],
   inMutation: false,
   submission: undefined as NewCheck[] | undefined,
+  submissionAttempted: false,
   submit: undefined as ((checks: NewCheck[]) => Promise<void>) | undefined,
   promptError: undefined as Error | undefined,
   nextUpdate: undefined as (() => Promise<{ kind: string; stopReason?: string }>) | undefined,
@@ -80,6 +81,10 @@ vi.mock('./mcp-server', () => ({
     async stop(): Promise<void> {
       outsideMutation('mcp:stop')
       if (harness.stopError) throw harness.stopError
+    }
+
+    get submissionAttempted(): boolean {
+      return harness.submissionAttempted
     }
 
     toAcpMcpServerConfig(): Record<string, never> {
@@ -245,6 +250,7 @@ describe('review assessment owner', () => {
     harness.events = []
     harness.inMutation = false
     harness.submission = [{ status: 'pass', claim: 'Pass', evidence: 'Verified' }]
+    harness.submissionAttempted = false
     harness.submit = undefined
     harness.promptError = undefined
     harness.nextUpdate = undefined
@@ -339,6 +345,30 @@ describe('review assessment owner', () => {
     expect(reviewRepository.updateReview).toHaveBeenCalledWith('assessment-review', {
       model: 'selected-runtime-model'
     })
+  })
+
+  it('does not retry after submit_findings was attempted', async () => {
+    harness.submission = undefined
+    harness.submissionAttempted = true
+    const result = await runReviewAssessment({
+      ...commonOptions(makeRepository()),
+      mode: 'initial'
+    })
+
+    expect(result.review.lifecycle).toBe('error')
+    expect(harness.events.filter((event) => event === 'acp:prompt')).toHaveLength(1)
+  })
+
+  it('does not retry a cancelled reviewer turn', async () => {
+    harness.submission = undefined
+    harness.nextUpdate = async () => ({ kind: 'stop', stopReason: 'cancelled' })
+    const result = await runReviewAssessment({
+      ...commonOptions(makeRepository()),
+      mode: 'initial'
+    })
+
+    expect(result.review.lifecycle).toBe('error')
+    expect(harness.events.filter((event) => event === 'acp:prompt')).toHaveLength(1)
   })
 
   it('disposes a built session when the pinned model cannot be persisted', async () => {

--- a/src/main/reviewer/review-assessment-owner.ts
+++ b/src/main/reviewer/review-assessment-owner.ts
@@ -80,6 +80,11 @@ const incompleteReviewMessage = (rejectedToolCalls: number): string =>
 const REVIEWER_BRIDGE_SCOPE_ERROR =
   'Reviewer request was not constrained to the reviewer-only tool scope.'
 
+const REVIEWER_PROTOCOL_RECOVERY_PROMPT =
+  'Your previous turn ended without calling submit_findings. Continue using only the provided ' +
+  'Reviewer MCP tools: call read_turn, then call submit_findings exactly once. Do not use any ' +
+  'other tools or write assistant prose.'
+
 type ReviewerCleanupResult = {
   rejectedToolCalls: number
   reviewerBridgeScoped: boolean | undefined
@@ -244,6 +249,22 @@ export const runReviewAssessment = async (
     )
     if (options.mode === 'initial') {
       log.info('reviewer session stopped', { reviewId: review.id, stopReason })
+    }
+    if (stopReason === 'end_turn' && !checksSubmitted && !mcpServer.submissionAttempted) {
+      log.warn('reviewer protocol incomplete; requesting one recovery turn', {
+        reviewId: review.id,
+        stopReason
+      })
+      reviewerSession.prompt([{ type: 'text', text: REVIEWER_PROTOCOL_RECOVERY_PROMPT }])
+      const recoveryStopReason = await driveReviewerToStop(
+        reviewerSession,
+        { timeoutMs: reviewerTimeoutMs, maxUpdates: reviewerMaxUpdates, signal: abortSignal },
+        { onUpdate: (entry) => capturedLog.push(entry) }
+      )
+      log.info('reviewer recovery session stopped', {
+        reviewId: review.id,
+        stopReason: recoveryStopReason
+      })
     }
   } catch (error) {
     reviewerSessionFailed = true


### PR DESCRIPTION
## Problem

The background Reviewer can end after the permission gate rejects a non-reviewer tool, leaving the Review in `error` without a `submit_findings` call. Separately, Reviewer correction prompts use an activity-scoped runtime facade that bypasses root prompt admission, so a correction can race an active user turn in the same ACP session.

## Proposed change

- Retry exactly one normally ended Reviewer turn when no findings submission was attempted.
- Serialize activity-scoped Reviewer correction prompts through the existing per-session root admission queue.
- Keep the Reviewer permission gate fail-closed and preserve invalid-submission and cancellation behavior.

## Scope and non-goals

- No permission broadening.
- No database schema, persisted data model, public API, renderer, or interaction-control changes.
- No new enum values or persistent queue.
- No retroactive retry or migration for historical Review records.
- Claude Code, OpenCode, and Codex share the coordinator admission path exercised here. Provider-specific request payloads are unchanged; Codex Responses and Codex Bridge split below this admission point.

## Acceptance criteria and validation

- Reviewer recovery, retry bounds, permission isolation, invalid submission, cancellation, and named-pipe transport coverage:
  - `npm run test:module -- reviewer_orchestrator`
  - PASS — 27 files, 448 tests
- Scoped correction serialization for Claude Code, OpenCode, and Codex:
  - `npm test -- src/main/acp/runtime-coordinator.test.ts src/main/acp/runtime-activity.test.ts`
  - PASS — 2 files, 80 tests
- Node type checking:
  - `npm run typecheck:node`
  - PASS
- Lint:
  - `npm run lint`
  - PASS

All listed checks ran after the final material edit. Per project guidance, the full local `npm test` suite was intentionally omitted; PR CI is authoritative for the full portable, runtime, and platform lanes.

## Review focus

- The one-recovery-prompt boundary and `submissionAttempted` signal.
- Admission queue lifetime and shutdown behavior for activity-scoped corrections.
- Windows platform behavior remains CI-owned; the transport unit coverage includes the named-pipe proxy path.

Fixes #1206
