### PR TITLE
fix(sdk): include waiting-for-user session status

### DIFF
--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -117,7 +117,7 @@ export type Run = {
 }
 
 export type SessionStatus =
-  'idle' | 'running' | 'waiting-permission' | 'waiting-plan-approval' | 'error'
+  'idle' | 'running' | 'waiting-for-user' | 'waiting-permission' | 'waiting-plan-approval' | 'error'
 
 export type Session = {
   id: string


### PR DESCRIPTION
## Problem

The public SDK SessionStatus declaration omits waiting-for-user even though the Task API can return that persisted session state.

## Proposed change

Add waiting-for-user to the SDK SessionStatus union so the published type matches the server response contract.

## Scope and non-goals

- Type declaration only; runtime response handling is unchanged.
- No renderer, ACP, persistence, platform, or user-interaction behavior changes.

## Acceptance criteria and validation

All local checks below ran after the final material edit:

- SDK and CLI behavior -> npm run test:cli -> passed (4 files, 52 tests).
- Published package contains the updated declaration -> npm run check:cli-package -> passed.
- Declaration formatting and repository lint rules -> npm run lint -> passed.

The local Test Impact Set excludes Electron E2E and platform-specific suites because the change only corrects a publishable TypeScript declaration. PR Gate remains the final authority and may select broader CI checks. The repository does not currently have a dedicated compile-time consumer test for this declaration; review should confirm the union now mirrors PersistedSessionStatus.

## Review focus

Confirm waiting-for-user is the only missing real Session status and that the public union matches src/shared/session-persistence.ts.