### PR TITLE
ci(nightly): raise typecheck heap limit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,8 @@ jobs:
         run: npm run lint
 
       - name: Typecheck
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
         run: npm run typecheck
 
       - name: Test (with coverage)

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -290,6 +290,7 @@ describe('post-merge Windows validation', () => {
     const commands = build.run?.split('\n').map((line) => line.trim()) ?? []
 
     expect(verifyTypecheck.run).toBe('npm run typecheck')
+    expect(verifyTypecheck.env).toEqual({ NODE_OPTIONS: '--max-old-space-size=4096' })
     expect(commands).toContain('npm run build:e2e')
     expect(commands).toContain('npm run build:web')
     expect(commands).not.toContain('npm run build')


### PR DESCRIPTION
## Problem

Nightly Verify typechecking exhausted the default V8 heap and exited 134 in runs 31929710156 and 31932778696. The typecheck itself remains valid; the process needs more headroom on the macOS runner.

## Proposed change

- Set NODE_OPTIONS to --max-old-space-size=4096 only on the reusable Build workflow Typecheck step.
- Add an exact workflow-contract assertion for that step.

## Scope and non-goals

- Does not change package scripts or TypeScript settings.
- Does not relax or skip typechecking.
- Does not apply the memory limit to lint, tests, builds, or packaging.

## Acceptance criteria and validation

Test Impact Set:

- Nightly Verify heap policy -> npm test -- scripts/windows-release-workflows.test.ts -> not run locally: the isolated worktree has no node_modules and no dependency install or junction was authorized.
- Node typecheck with 4 GB heap -> NODE_OPTIONS=--max-old-space-size=4096 npm run typecheck:node -> not run locally for the same environment reason.
- Web typecheck with 4 GB heap -> NODE_OPTIONS=--max-old-space-size=4096 npm run typecheck:web -> not run locally for the same environment reason.
- Lint -> npm run lint -> not run locally for the same environment reason.
- Patch hygiene -> git diff --check -> passed after the last material edit.

The exact-head PR Gate is the final complete verification authority. An exact-head Nightly run after merge remains the macOS runtime confirmation.

Uncovered local risk: the Windows host cannot reproduce the macOS runner memory profile.

## Review focus

Confirm the increased heap applies only to the Verify Typecheck step and the contract test prevents accidental removal.

## Data and compatibility impact

- Historical data compatibility: none.
- New states or enum values: none.
- Data persistence: none.

Full npm test was intentionally not run.