### PR TITLE
fix(uploads): wait longer for transaction connections

### DIFF
--- a/src/main/uploads/legacy-recovery-owner.ts
+++ b/src/main/uploads/legacy-recovery-owner.ts
@@ -16,6 +16,7 @@ import {
 import type { PersistedChatMessage, PersistedChatSession } from '../../shared/session-persistence'
 import {
   OrphanLegacyUploadAuthorityMissingError,
+  runUploadTransaction,
   type PublicationOptions,
   type UploadVersionRecord
 } from './staged-publication-owner'
@@ -384,7 +385,7 @@ class LegacyRecoveryOwner {
       }
       if (!sourcePath || !(await validateContent(sourcePath))) {
         const client = await this.options.getClient!()
-        await client.$transaction(async (tx) => {
+        await runUploadTransaction(client, async (tx) => {
           await tx.uploadVersion.deleteMany({ where: { id: version.id, state: 'staging' } })
           await tx.uploadFile.deleteMany({
             where: { id: version.uploadFileId, versions: { none: {} } }
@@ -412,7 +413,7 @@ class LegacyRecoveryOwner {
 
     await rm(`${finalPath}${LIVE_COPY_TEMP_SUFFIX}`, { force: true })
     const client = await this.options.getClient!()
-    const ready = await client.$transaction(async (tx) => {
+    const ready = await runUploadTransaction(client, async (tx) => {
       const updated =
         version.state === 'ready'
           ? version

--- a/src/main/uploads/repository.architecture.test.ts
+++ b/src/main/uploads/repository.architecture.test.ts
@@ -138,6 +138,52 @@ const methodDeclarationSites = (methodName: string): string[] => {
   return sites.sort()
 }
 
+const interactiveTransactionOptions = (): string[] => {
+  const sites: string[] = []
+  for (const file of productionFiles) {
+    const sourceFile = sourceFileFor(file)
+    const visit = (node: Node): void => {
+      if (
+        isCallExpression(node) &&
+        isPropertyAccessExpression(node.expression) &&
+        node.expression.name.text === '$transaction'
+      ) {
+        sites.push(`${file}:${node.arguments[1]?.getText(sourceFile) ?? '<missing>'}`)
+      }
+      forEachChild(node, visit)
+    }
+    visit(sourceFile)
+  }
+  return sites.sort()
+}
+
+const functionCallSites = (functionName: string): string[] => {
+  const sites: string[] = []
+  for (const file of productionFiles) {
+    const sourceFile = sourceFileFor(file)
+    const visit = (node: Node): void => {
+      if (isCallExpression(node) && isIdentifier(node.expression)) {
+        if (node.expression.text === functionName) sites.push(file)
+      }
+      forEachChild(node, visit)
+    }
+    visit(sourceFile)
+  }
+  return sites.sort()
+}
+
+const variableInitializer = (file: string, variableName: string): string | undefined => {
+  const sourceFile = sourceFileFor(file)
+  for (const statement of sourceFile.statements) {
+    if (!isVariableStatement(statement)) continue
+    const declaration = statement.declarationList.declarations.find(
+      (candidate) => isIdentifier(candidate.name) && candidate.name.text === variableName
+    )
+    if (declaration) return declaration.initializer?.getText(sourceFile)
+  }
+  return undefined
+}
+
 const facadeDelegations = (
   facade: ClassDeclaration,
   facadeFile: SourceFile
@@ -352,5 +398,19 @@ describe('Upload repository architecture', () => {
       }
     }
     expect(recoverySource).toContain('cleanup: Pick<')
+  })
+
+  it('routes every interactive Upload transaction through the shared connection wait policy', () => {
+    expect(variableInitializer('staged-publication-owner.ts', 'UPLOAD_TRANSACTION_OPTIONS')).toBe(
+      '{ maxWait: 10_000 } as const'
+    )
+    expect(interactiveTransactionOptions()).toEqual([
+      'staged-publication-owner.ts:UPLOAD_TRANSACTION_OPTIONS'
+    ])
+    expect(functionCallSites('runUploadTransaction')).toEqual([
+      'legacy-recovery-owner.ts',
+      'legacy-recovery-owner.ts',
+      'staged-publication-owner.ts'
+    ])
   })
 })

--- a/src/main/uploads/staged-publication-owner.ts
+++ b/src/main/uploads/staged-publication-owner.ts
@@ -2,7 +2,7 @@ import { createReadStream } from 'node:fs'
 import { mkdir, realpath, stat } from 'node:fs/promises'
 import { createHash, randomUUID } from 'node:crypto'
 
-import type { PrismaClient } from '@prisma/client'
+import type { Prisma, PrismaClient } from '@prisma/client'
 
 import {
   DEFAULT_UPLOAD_PROJECT_ID,
@@ -50,6 +50,13 @@ type RemoveVerifiedLegacyCopyInput = {
   filename: string
   legacyPath?: string
 }
+
+const UPLOAD_TRANSACTION_OPTIONS = { maxWait: 10_000 } as const
+
+const runUploadTransaction = <Result>(
+  client: PrismaClient,
+  operation: (transaction: Prisma.TransactionClient) => Promise<Result>
+): Promise<Result> => client.$transaction(operation, UPLOAD_TRANSACTION_OPTIONS)
 
 type StagedPublicationDependencies = {
   resolver: ManagedUploadResolver
@@ -265,7 +272,7 @@ class StagedPublicationOwner {
         ? (requestedCreatedAt ?? new Date())
         : undefined
 
-    const registered = await client.$transaction(async (tx) => {
+    const registered = await runUploadTransaction(client, async (tx) => {
       await tx.fileOriginSession.upsert({
         where: { projectId_sessionId: { projectId, sessionId } },
         create: { projectId, sessionId },
@@ -303,5 +310,5 @@ class StagedPublicationOwner {
   }
 }
 
-export { OrphanLegacyUploadAuthorityMissingError, StagedPublicationOwner }
+export { OrphanLegacyUploadAuthorityMissingError, runUploadTransaction, StagedPublicationOwner }
 export type { PublicationOptions, UploadVersionRecord }


### PR DESCRIPTION
## Problem

Windows Full Test run 31931817779 failed the two-attachment upload repository test with Prisma P2028. Parallel attachment publication shares the project SQLite clients single connection, while Prisma interactive transactions default to a two-second connection acquisition wait.

## Proposed change

- route all three uploads interactive transactions through one shared transaction helper
- set the uploads-only acquisition maxWait to 10 seconds
- keep attachment hash/copy work and attachment publication parallel
- add an architecture contract that requires the single policy entry point and all three transaction call sites

## Scope and non-goals

This does not change the global Prisma client, serialize upload file work, change the UploadRepository interface, or relax any test.

Historical compatibility: none.
New state or enum values: none.
Persistence behavior: when the single SQLite connection is busy, uploads transactions may wait up to 10 seconds rather than two seconds. There is no schema, migration, data-format, or storage-path change.

## Acceptance criteria and validation

Test Impact Set:

- transaction policy and three call sites -> npm run test:module -- upload_repository -> not run locally because this worktree has no node_modules; PR Gate is authoritative
- original two-attachment SQLite path -> npm test -- src/main/uploads/repository.test.ts -t "registers each upload as an independent SQLite file with immutable v1 bytes" -> not run locally for the same dependency reason
- affected main-process types -> npm run typecheck:node -> not run locally for the same dependency reason
- linted source -> npm run lint -> not run locally for the same dependency reason
- patch integrity -> git diff --check -> passed after the final material edit

The changed files are owned by upload_repository. UploadRepository itself and its consumer-facing interface are unchanged, so session_persistence consumer tests are excluded. The Windows-sensitive behavior remains covered by PR CI; an exact-head Windows Full run has intentionally not been triggered yet.

## Review focus

Please verify that 10 seconds applies only to uploads interactive transaction acquisition and that the transaction bodies and parallel file work are otherwise unchanged.