### PR TITLE
fix(database): enforce SQLite domain constraints

### DIFF
--- a/prisma/sqlite-check-constraints.json
+++ b/prisma/sqlite-check-constraints.json
@@ -64,6 +64,151 @@
       "tableName": "ReviewScopeSnapshot",
       "name": "ReviewScopeSnapshot_state_check",
       "expression": "\"state\" IN ('staging', 'ready')"
+    },
+    {
+      "tableName": "Review",
+      "name": "Review_lifecycle_check",
+      "expression": "\"lifecycle\" IN ('running', 'complete', 'error')"
+    },
+    {
+      "tableName": "Review",
+      "name": "Review_outcome_check",
+      "expression": "\"outcome\" IS NULL OR \"outcome\" IN ('pass', 'flagged')"
+    },
+    {
+      "tableName": "Review",
+      "name": "Review_state_check",
+      "expression": "((\"lifecycle\" = 'running' AND \"outcome\" IS NULL AND \"errorMessage\" IS NULL) OR (\"lifecycle\" = 'complete' AND \"outcome\" IS NOT NULL AND \"errorMessage\" IS NULL) OR (\"lifecycle\" = 'error' AND \"outcome\" IS NULL AND \"errorMessage\" IS NOT NULL))"
+    },
+    {
+      "tableName": "Finding",
+      "name": "Finding_status_check",
+      "expression": "\"status\" IN ('pass', 'warn', 'fail')"
+    },
+    {
+      "tableName": "Finding",
+      "name": "Finding_resolution_check",
+      "expression": "\"resolution\" IN ('open', 'resolved', 'unaddressed')"
+    },
+    {
+      "tableName": "Finding",
+      "name": "Finding_artifactBindingState_check",
+      "expression": "\"artifactBindingState\" IN ('scope_validated', 'legacy_unverified')"
+    },
+    {
+      "tableName": "Finding",
+      "name": "Finding_sortIndex_check",
+      "expression": "\"sortIndex\" >= 0"
+    },
+    {
+      "tableName": "Finding",
+      "name": "Finding_reflagCount_check",
+      "expression": "\"reflagCount\" >= 0"
+    },
+    {
+      "tableName": "Finding",
+      "name": "Finding_statusResolution_check",
+      "expression": "\"status\" <> 'pass' OR \"resolution\" = 'open'"
+    },
+    {
+      "tableName": "Finding",
+      "name": "Finding_artifactBinding_check",
+      "expression": "\"artifactBindingState\" <> 'scope_validated' OR \"artifactVersionId\" IS NOT NULL"
+    },
+    {
+      "tableName": "ReviewFindingDisposition",
+      "name": "ReviewFindingDisposition_sequence_check",
+      "expression": "\"sequence\" >= 1"
+    },
+    {
+      "tableName": "ReviewFindingDisposition",
+      "name": "ReviewFindingDisposition_trigger_check",
+      "expression": "\"trigger\" IN ('review_submission', 'loop_terminated', 'correction_failed', 'aborted')"
+    },
+    {
+      "tableName": "ReviewFindingDisposition",
+      "name": "ReviewFindingDisposition_outcome_check",
+      "expression": "\"outcome\" IN ('still_open', 'resolved', 'unaddressed')"
+    },
+    {
+      "tableName": "ReviewFindingDisposition",
+      "name": "ReviewFindingDisposition_state_check",
+      "expression": "((\"trigger\" = 'review_submission' AND \"causeReviewId\" IS NOT NULL AND \"outcome\" IN ('still_open', 'resolved')) OR (\"trigger\" IN ('loop_terminated', 'correction_failed', 'aborted') AND \"causeReviewId\" IS NULL AND \"outcome\" = 'unaddressed'))"
+    },
+    {
+      "tableName": "ComputeJob",
+      "name": "ComputeJob_shape_check",
+      "expression": "\"shape\" IN ('direct_ssh', 'scheduler_cluster', 'bridge_runner')"
+    },
+    {
+      "tableName": "ComputeJob",
+      "name": "ComputeJob_status_check",
+      "expression": "\"status\" IN ('queued', 'submitted', 'running', 'success', 'failed', 'timeout', 'error')"
+    },
+    {
+      "tableName": "ComputeJob",
+      "name": "ComputeJob_errorCode_check",
+      "expression": "\"errorCode\" IS NULL OR \"errorCode\" IN ('approval_denied', 'host_unreachable', 'dispatch_failed', 'job_failed', 'timeout', 'process_vanished')"
+    },
+    {
+      "tableName": "ComputeJob",
+      "name": "ComputeJob_timeoutSeconds_check",
+      "expression": "\"timeoutSeconds\" IS NULL OR \"timeoutSeconds\" BETWEEN 1 AND 604800"
+    },
+    {
+      "tableName": "ComputeJob",
+      "name": "ComputeJob_notification_check",
+      "expression": "\"notificationConsumedAt\" IS NULL OR \"notifiedAt\" IS NOT NULL"
+    },
+    {
+      "tableName": "ComputeJob",
+      "name": "ComputeJob_harvestPayload_check",
+      "expression": "(\"harvestError\" IS NULL AND \"leftOnRemote\" IS NULL) OR \"harvestedAt\" IS NOT NULL"
+    },
+    {
+      "tableName": "ComputeJob",
+      "name": "ComputeJob_harvestState_check",
+      "expression": "\"harvestedAt\" IS NULL OR \"status\" IN ('success', 'failed', 'timeout')"
+    },
+    {
+      "tableName": "ComputeJob",
+      "name": "ComputeJob_errorState_check",
+      "expression": "((\"errorCode\" IS NULL OR \"status\" IN ('failed', 'timeout', 'error')) AND (\"status\" <> 'error' OR \"errorCode\" IS NOT NULL))"
+    },
+    {
+      "tableName": "ComputeHost",
+      "name": "ComputeHost_shape_check",
+      "expression": "\"shape\" IN ('direct_ssh', 'scheduler_cluster', 'bridge_runner')"
+    },
+    {
+      "tableName": "ComputeHost",
+      "name": "ComputeHost_scratchPinned_check",
+      "expression": "\"scratchPinned\" IN (false, true)"
+    },
+    {
+      "tableName": "ComputeHost",
+      "name": "ComputeHost_concurrencyLimit_check",
+      "expression": "\"concurrencyLimit\" IS NULL OR \"concurrencyLimit\" BETWEEN 1 AND 500"
+    },
+    {
+      "tableName": "ComputeHost",
+      "name": "ComputeHost_detailsUpdatedBy_check",
+      "expression": "\"detailsUpdatedBy\" IS NULL OR \"detailsUpdatedBy\" IN ('user', 'agent')"
+    },
+    {
+      "tableName": "ComputeHost",
+      "name": "ComputeHost_detailsUpdate_check",
+      "expression": "(\"detailsUpdatedAt\" IS NULL AND \"detailsUpdatedBy\" IS NULL) OR (\"detailsUpdatedAt\" IS NOT NULL AND \"detailsUpdatedBy\" IS NOT NULL)"
+    },
+    {
+      "tableName": "ComputeHost",
+      "name": "ComputeHost_scratchRoot_check",
+      "expression": "\"scratchPinned\" = false OR \"scratchRoot\" IS NOT NULL"
+    },
+    {
+      "tableName": "GrantedLocalRoot",
+      "name": "GrantedLocalRoot_access_check",
+      "expression": "\"access\" IN ('ro', 'rw')"
     }
   ]
 }

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -24,6 +24,10 @@ const EXPECTED_MIGRATION_LEDGER = [
   {
     id: '0005_project_preview_state_owner_fk',
     checksum: '09a04241d1ff56a81ec574dc0259db4f689503cf641094b9c197eda8a82cd631'
+  },
+  {
+    id: '0006_database_domain_constraints',
+    checksum: '3cb84b96954d412b7d68bf3b2b21a5de8ad428b1e6b5d57c69919118e660b904'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/src/main/artifacts/provenance-repository.test.ts
+++ b/src/main/artifacts/provenance-repository.test.ts
@@ -1881,7 +1881,7 @@ describe('artifact provenance repository', () => {
         id: 'disposition-direct-pass',
         sourceFindingId: 'finding-direct-flagged',
         causeReviewId: 'review-direct-pass',
-        sequence: 0,
+        sequence: 1,
         trigger: 'review_submission',
         outcome: 'resolved',
         assessedArtifactVersionId: version.versionId,

--- a/src/main/compute/concurrency-integration.test.ts
+++ b/src/main/compute/concurrency-integration.test.ts
@@ -185,8 +185,7 @@ describe('ConcurrencyManager integration with ComputeService', () => {
   it('should throw queue_full error when 100 jobs are already queued', async () => {
     const providerId = computeProviderId('test-host')
 
-    // Set provider ceiling to 0 by setting a very high session limit and low provider limit
-    // First set provider limit to 1, then submit a job, then reduce to 0 so remaining jobs queue
+    // Keep one active job in the provider's only slot so all future jobs queue.
     await hostRepo.updateConcurrencyLimit(providerId, 1)
 
     // Submit first job (will be submitted)
@@ -197,9 +196,6 @@ describe('ConcurrencyManager integration with ComputeService', () => {
       {},
       { sessionId: 'session-1', projectId: 'project-1' }
     )
-
-    // Now set provider limit to 0 so all future jobs queue
-    await hostRepo.updateConcurrencyLimit(providerId, 0)
 
     // Queue 100 jobs
     for (let i = 0; i < 100; i++) {
@@ -451,6 +447,7 @@ describe('ConcurrencyManager integration with ComputeService', () => {
       // Complete first job with terminal state
       await jobRepo.update(result1.job_id, {
         status: terminalState,
+        ...(terminalState === 'error' ? { errorCode: 'dispatch_failed' } : {}),
         finishedAt: new Date()
       })
 

--- a/src/main/compute/job-repository.test.ts
+++ b/src/main/compute/job-repository.test.ts
@@ -184,7 +184,8 @@ describe('ComputeJob schema migration (integration)', () => {
         '0002_project_agent_context',
         '0003_granted_local_roots',
         '0004_review_assessment_snapshots',
-        '0005_project_preview_state_owner_fk'
+        '0005_project_preview_state_owner_fk',
+        '0006_database_domain_constraints'
       ]
     })
     // Idempotent second run.
@@ -262,7 +263,8 @@ describe('ComputeJob schema migration (integration)', () => {
         '0002_project_agent_context',
         '0003_granted_local_roots',
         '0004_review_assessment_snapshots',
-        '0005_project_preview_state_owner_fk'
+        '0005_project_preview_state_owner_fk',
+        '0006_database_domain_constraints'
       ]
     })
     // Idempotent second run.

--- a/src/main/compute/prisma-client.test.ts
+++ b/src/main/compute/prisma-client.test.ts
@@ -123,7 +123,8 @@ describe('compute host prisma client (integration)', () => {
         '0002_project_agent_context',
         '0003_granted_local_roots',
         '0004_review_assessment_snapshots',
-        '0005_project_preview_state_owner_fk'
+        '0005_project_preview_state_owner_fk',
+        '0006_database_domain_constraints'
       ]
     })
     // Idempotent second run.

--- a/src/main/database/database-domain-constraints.test.ts
+++ b/src/main/database/database-domain-constraints.test.ts
@@ -1,0 +1,210 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { PrismaClient } from '@prisma/client'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createProjectDbClient } from '../projects/prisma-client'
+import { migrateApplicationDatabase } from './migration-service'
+
+describe('database domain constraints', () => {
+  let client: PrismaClient | undefined
+  let storageRoot: string | undefined
+
+  afterEach(async () => {
+    await client?.$disconnect()
+    if (storageRoot) await rm(storageRoot, { force: true, recursive: true })
+  })
+
+  it('rejects domain values that bypass the TypeScript write boundaries', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-domain-constraints-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Review" ("id","projectId","sessionId","turnMessageId","lifecycle","updatedAt") VALUES ('base-review','p','s','m','running',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Finding" ("id","reviewId","status") VALUES ('base-finding','base-review','warn')`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ReviewFindingDisposition" ("id","sourceFindingId","sequence","trigger","outcome") VALUES ('base-disposition','base-finding',1,'aborted','unaddressed')`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ComputeJob" ("id","providerId","shape","sessionId","projectId","status","intent","command","commandHash") VALUES ('base-job','ssh:h','direct_ssh','s','p','submitted','i','c','h')`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ComputeHost" ("id","providerId","displayName","sshAlias","updatedAt") VALUES ('base-host','ssh:h','h','h',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "GrantedLocalRoot" ("id","path","name","access","updatedAt") VALUES ('base-root','/tmp/base','base','ro',CURRENT_TIMESTAMP)`
+    )
+
+    const invalidWrites = [
+      {
+        name: 'Review.lifecycle',
+        sql: `UPDATE "Review" SET "lifecycle" = 'unknown' WHERE "id" = 'base-review'`
+      },
+      {
+        name: 'Review.outcome',
+        sql: `UPDATE "Review" SET "outcome" = 'unknown' WHERE "id" = 'base-review'`
+      },
+      {
+        name: 'Review running state',
+        sql: `UPDATE "Review" SET "outcome" = 'pass' WHERE "id" = 'base-review'`
+      },
+      {
+        name: 'Review complete state',
+        sql: `UPDATE "Review" SET "lifecycle" = 'complete' WHERE "id" = 'base-review'`
+      },
+      {
+        name: 'Review error state',
+        sql: `UPDATE "Review" SET "lifecycle" = 'error' WHERE "id" = 'base-review'`
+      },
+      {
+        name: 'Finding.status',
+        sql: `UPDATE "Finding" SET "status" = 'unknown' WHERE "id" = 'base-finding'`
+      },
+      {
+        name: 'Finding.resolution',
+        sql: `UPDATE "Finding" SET "resolution" = 'unknown' WHERE "id" = 'base-finding'`
+      },
+      {
+        name: 'Finding.artifactBindingState',
+        sql: `UPDATE "Finding" SET "artifactBindingState" = 'unknown' WHERE "id" = 'base-finding'`
+      },
+      {
+        name: 'Finding.sortIndex',
+        sql: `UPDATE "Finding" SET "sortIndex" = -1 WHERE "id" = 'base-finding'`
+      },
+      {
+        name: 'Finding.reflagCount',
+        sql: `UPDATE "Finding" SET "reflagCount" = -1 WHERE "id" = 'base-finding'`
+      },
+      {
+        name: 'Finding pass resolution',
+        sql: `UPDATE "Finding" SET "status" = 'pass', "resolution" = 'resolved' WHERE "id" = 'base-finding'`
+      },
+      {
+        name: 'Finding validated artifact binding',
+        sql: `UPDATE "Finding" SET "artifactBindingState" = 'scope_validated' WHERE "id" = 'base-finding'`
+      },
+      {
+        name: 'ReviewFindingDisposition.sequence',
+        sql: `UPDATE "ReviewFindingDisposition" SET "sequence" = 0 WHERE "id" = 'base-disposition'`
+      },
+      {
+        name: 'ReviewFindingDisposition.trigger',
+        sql: `UPDATE "ReviewFindingDisposition" SET "trigger" = 'unknown' WHERE "id" = 'base-disposition'`
+      },
+      {
+        name: 'ReviewFindingDisposition.outcome',
+        sql: `UPDATE "ReviewFindingDisposition" SET "outcome" = 'unknown' WHERE "id" = 'base-disposition'`
+      },
+      {
+        name: 'ReviewFindingDisposition review submission cause',
+        sql: `UPDATE "ReviewFindingDisposition" SET "trigger" = 'review_submission', "outcome" = 'resolved' WHERE "id" = 'base-disposition'`
+      },
+      {
+        name: 'ReviewFindingDisposition review submission outcome',
+        sql: `UPDATE "ReviewFindingDisposition" SET "trigger" = 'review_submission', "causeReviewId" = 'base-review' WHERE "id" = 'base-disposition'`
+      },
+      {
+        name: 'ReviewFindingDisposition terminal cause',
+        sql: `UPDATE "ReviewFindingDisposition" SET "causeReviewId" = 'base-review' WHERE "id" = 'base-disposition'`
+      },
+      {
+        name: 'ReviewFindingDisposition terminal outcome',
+        sql: `UPDATE "ReviewFindingDisposition" SET "outcome" = 'resolved' WHERE "id" = 'base-disposition'`
+      },
+      {
+        name: 'ComputeJob.shape',
+        sql: `UPDATE "ComputeJob" SET "shape" = 'unknown' WHERE "id" = 'base-job'`
+      },
+      {
+        name: 'ComputeJob.status',
+        sql: `UPDATE "ComputeJob" SET "status" = 'unknown' WHERE "id" = 'base-job'`
+      },
+      {
+        name: 'ComputeJob.errorCode',
+        sql: `UPDATE "ComputeJob" SET "errorCode" = 'unknown' WHERE "id" = 'base-job'`
+      },
+      {
+        name: 'ComputeJob.timeoutSeconds lower bound',
+        sql: `UPDATE "ComputeJob" SET "timeoutSeconds" = 0 WHERE "id" = 'base-job'`
+      },
+      {
+        name: 'ComputeJob.timeoutSeconds upper bound',
+        sql: `UPDATE "ComputeJob" SET "timeoutSeconds" = 604801 WHERE "id" = 'base-job'`
+      },
+      {
+        name: 'ComputeJob notification state',
+        sql: `UPDATE "ComputeJob" SET "notificationConsumedAt" = CURRENT_TIMESTAMP WHERE "id" = 'base-job'`
+      },
+      {
+        name: 'ComputeJob harvest payload',
+        sql: `UPDATE "ComputeJob" SET "harvestError" = 'failed' WHERE "id" = 'base-job'`
+      },
+      {
+        name: 'ComputeJob harvest state',
+        sql: `UPDATE "ComputeJob" SET "harvestedAt" = CURRENT_TIMESTAMP WHERE "id" = 'base-job'`
+      },
+      {
+        name: 'ComputeJob error code state',
+        sql: `UPDATE "ComputeJob" SET "errorCode" = 'dispatch_failed' WHERE "id" = 'base-job'`
+      },
+      {
+        name: 'ComputeJob error status state',
+        sql: `UPDATE "ComputeJob" SET "status" = 'error' WHERE "id" = 'base-job'`
+      },
+      {
+        name: 'ComputeHost.shape',
+        sql: `UPDATE "ComputeHost" SET "shape" = 'unknown' WHERE "id" = 'base-host'`
+      },
+      {
+        name: 'ComputeHost.scratchPinned',
+        sql: `UPDATE "ComputeHost" SET "scratchPinned" = 2 WHERE "id" = 'base-host'`
+      },
+      {
+        name: 'ComputeHost.concurrencyLimit',
+        sql: `UPDATE "ComputeHost" SET "concurrencyLimit" = 0 WHERE "id" = 'base-host'`
+      },
+      {
+        name: 'ComputeHost.concurrencyLimit upper bound',
+        sql: `UPDATE "ComputeHost" SET "concurrencyLimit" = 501 WHERE "id" = 'base-host'`
+      },
+      {
+        name: 'ComputeHost.detailsUpdatedBy',
+        sql: `UPDATE "ComputeHost" SET "detailsUpdatedBy" = 'unknown' WHERE "id" = 'base-host'`
+      },
+      {
+        name: 'ComputeHost details author without time',
+        sql: `UPDATE "ComputeHost" SET "detailsUpdatedBy" = 'agent' WHERE "id" = 'base-host'`
+      },
+      {
+        name: 'ComputeHost details time without author',
+        sql: `UPDATE "ComputeHost" SET "detailsUpdatedAt" = CURRENT_TIMESTAMP WHERE "id" = 'base-host'`
+      },
+      {
+        name: 'ComputeHost pinned scratch root',
+        sql: `UPDATE "ComputeHost" SET "scratchPinned" = true WHERE "id" = 'base-host'`
+      },
+      {
+        name: 'GrantedLocalRoot.access',
+        sql: `UPDATE "GrantedLocalRoot" SET "access" = 'admin' WHERE "id" = 'base-root'`
+      }
+    ]
+
+    const accepted: string[] = []
+    for (const invalidWrite of invalidWrites) {
+      try {
+        await client.$executeRawUnsafe(invalidWrite.sql)
+        accepted.push(invalidWrite.name)
+      } catch {
+        // Expected: the SQLite CHECK contract rejects the write.
+      }
+    }
+    expect(accepted).toEqual([])
+  })
+})

--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -102,7 +102,8 @@ describe('database startup logging', () => {
               '0002_project_agent_context',
               '0003_granted_local_roots',
               '0004_review_assessment_snapshots',
-              '0005_project_preview_state_owner_fk'
+              '0005_project_preview_state_owner_fk',
+              '0006_database_domain_constraints'
             ],
             adoptedLegacy: true
           })

--- a/src/main/database/generated/runtime-schema.ts
+++ b/src/main/database/generated/runtime-schema.ts
@@ -75,7 +75,10 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "model" TEXT NOT NULL DEFAULT '',
     "reviewerLog" TEXT NOT NULL DEFAULT '[]',
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" DATETIME NOT NULL
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Review_lifecycle_check" CHECK ("lifecycle" IN ('running', 'complete', 'error')),
+    CONSTRAINT "Review_outcome_check" CHECK ("outcome" IS NULL OR "outcome" IN ('pass', 'flagged')),
+    CONSTRAINT "Review_state_check" CHECK ((("lifecycle" = 'running' AND "outcome" IS NULL AND "errorMessage" IS NULL) OR ("lifecycle" = 'complete' AND "outcome" IS NOT NULL AND "errorMessage" IS NULL) OR ("lifecycle" = 'error' AND "outcome" IS NULL AND "errorMessage" IS NOT NULL)))
 );`,
   `CREATE TABLE IF NOT EXISTS "Finding" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -89,7 +92,14 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "artifactBindingState" TEXT NOT NULL DEFAULT 'legacy_unverified',
     "sortIndex" INTEGER NOT NULL DEFAULT 0,
     "reflagCount" INTEGER NOT NULL DEFAULT 0,
-    CONSTRAINT "Finding_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "Review" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+    CONSTRAINT "Finding_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "Review" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Finding_status_check" CHECK ("status" IN ('pass', 'warn', 'fail')),
+    CONSTRAINT "Finding_resolution_check" CHECK ("resolution" IN ('open', 'resolved', 'unaddressed')),
+    CONSTRAINT "Finding_artifactBindingState_check" CHECK ("artifactBindingState" IN ('scope_validated', 'legacy_unverified')),
+    CONSTRAINT "Finding_sortIndex_check" CHECK ("sortIndex" >= 0),
+    CONSTRAINT "Finding_reflagCount_check" CHECK ("reflagCount" >= 0),
+    CONSTRAINT "Finding_statusResolution_check" CHECK ("status" <> 'pass' OR "resolution" = 'open'),
+    CONSTRAINT "Finding_artifactBinding_check" CHECK ("artifactBindingState" <> 'scope_validated' OR "artifactVersionId" IS NOT NULL)
 );`,
   `CREATE TABLE IF NOT EXISTS "ProjectDeletionIntent" (
     "projectId" TEXT NOT NULL PRIMARY KEY,
@@ -272,7 +282,11 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "assessmentSnapshot" TEXT,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT "ReviewFindingDisposition_sourceFindingId_fkey" FOREIGN KEY ("sourceFindingId") REFERENCES "Finding" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
-    CONSTRAINT "ReviewFindingDisposition_causeReviewId_fkey" FOREIGN KEY ("causeReviewId") REFERENCES "Review" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+    CONSTRAINT "ReviewFindingDisposition_causeReviewId_fkey" FOREIGN KEY ("causeReviewId") REFERENCES "Review" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ReviewFindingDisposition_sequence_check" CHECK ("sequence" >= 1),
+    CONSTRAINT "ReviewFindingDisposition_trigger_check" CHECK ("trigger" IN ('review_submission', 'loop_terminated', 'correction_failed', 'aborted')),
+    CONSTRAINT "ReviewFindingDisposition_outcome_check" CHECK ("outcome" IN ('still_open', 'resolved', 'unaddressed')),
+    CONSTRAINT "ReviewFindingDisposition_state_check" CHECK ((("trigger" = 'review_submission' AND "causeReviewId" IS NOT NULL AND "outcome" IN ('still_open', 'resolved')) OR ("trigger" IN ('loop_terminated', 'correction_failed', 'aborted') AND "causeReviewId" IS NULL AND "outcome" = 'unaddressed')))
 );`,
   `CREATE TABLE IF NOT EXISTS "ReviewScopeSnapshot" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -321,7 +335,15 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "submittedAt" DATETIME,
     "startedAt" DATETIME,
     "finishedAt" DATETIME,
-    "harvestedAt" DATETIME
+    "harvestedAt" DATETIME,
+    CONSTRAINT "ComputeJob_shape_check" CHECK ("shape" IN ('direct_ssh', 'scheduler_cluster', 'bridge_runner')),
+    CONSTRAINT "ComputeJob_status_check" CHECK ("status" IN ('queued', 'submitted', 'running', 'success', 'failed', 'timeout', 'error')),
+    CONSTRAINT "ComputeJob_errorCode_check" CHECK ("errorCode" IS NULL OR "errorCode" IN ('approval_denied', 'host_unreachable', 'dispatch_failed', 'job_failed', 'timeout', 'process_vanished')),
+    CONSTRAINT "ComputeJob_timeoutSeconds_check" CHECK ("timeoutSeconds" IS NULL OR "timeoutSeconds" BETWEEN 1 AND 604800),
+    CONSTRAINT "ComputeJob_notification_check" CHECK ("notificationConsumedAt" IS NULL OR "notifiedAt" IS NOT NULL),
+    CONSTRAINT "ComputeJob_harvestPayload_check" CHECK (("harvestError" IS NULL AND "leftOnRemote" IS NULL) OR "harvestedAt" IS NOT NULL),
+    CONSTRAINT "ComputeJob_harvestState_check" CHECK ("harvestedAt" IS NULL OR "status" IN ('success', 'failed', 'timeout')),
+    CONSTRAINT "ComputeJob_errorState_check" CHECK ((("errorCode" IS NULL OR "status" IN ('failed', 'timeout', 'error')) AND ("status" <> 'error' OR "errorCode" IS NOT NULL)))
 );`,
   `CREATE TABLE IF NOT EXISTS "ComputeHost" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -338,7 +360,13 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "detailsUpdatedAt" DATETIME,
     "detailsUpdatedBy" TEXT,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" DATETIME NOT NULL
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ComputeHost_shape_check" CHECK ("shape" IN ('direct_ssh', 'scheduler_cluster', 'bridge_runner')),
+    CONSTRAINT "ComputeHost_scratchPinned_check" CHECK ("scratchPinned" IN (false, true)),
+    CONSTRAINT "ComputeHost_concurrencyLimit_check" CHECK ("concurrencyLimit" IS NULL OR "concurrencyLimit" BETWEEN 1 AND 500),
+    CONSTRAINT "ComputeHost_detailsUpdatedBy_check" CHECK ("detailsUpdatedBy" IS NULL OR "detailsUpdatedBy" IN ('user', 'agent')),
+    CONSTRAINT "ComputeHost_detailsUpdate_check" CHECK (("detailsUpdatedAt" IS NULL AND "detailsUpdatedBy" IS NULL) OR ("detailsUpdatedAt" IS NOT NULL AND "detailsUpdatedBy" IS NOT NULL)),
+    CONSTRAINT "ComputeHost_scratchRoot_check" CHECK ("scratchPinned" = false OR "scratchRoot" IS NOT NULL)
 );`,
   `CREATE TABLE IF NOT EXISTS "GrantedLocalRoot" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -346,7 +374,8 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "name" TEXT NOT NULL,
     "access" TEXT NOT NULL,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" DATETIME NOT NULL
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "GrantedLocalRoot_access_check" CHECK ("access" IN ('ro', 'rw'))
 );`
 ] as const
 

--- a/src/main/database/legacy-baseline-adapter.ts
+++ b/src/main/database/legacy-baseline-adapter.ts
@@ -94,6 +94,7 @@ type TargetIndex = {
   columns: readonly string[]
   unique: boolean
 }
+type AllowedSuffixCheckConstraints = Readonly<Record<string, Readonly<Record<string, string>>>>
 
 const splitSqlDefinitions = (ddl: string): string[] => {
   const open = ddl.indexOf('(')
@@ -541,7 +542,8 @@ const prepareRuntimeSchemaBaseline = async (
 const verifyRuntimeSchemaTarget = async (
   client: PrismaClient,
   target: RuntimeSchemaTarget,
-  exact: boolean = false
+  exact: boolean = false,
+  allowedSuffixChecks: AllowedSuffixCheckConstraints = {}
 ): Promise<void> => {
   const tables = await migrationSqlExecutor.query<SqliteSchemaName[]>(
     client,
@@ -699,13 +701,25 @@ const verifyRuntimeSchemaTarget = async (
         }
       )
     }
-    if (actualTable.checks.size !== expectedTable.checks.size) {
+    const allowedChecks = allowedSuffixChecks[tableName] ?? {}
+    const incompatibleSuffixCheck = [...actualTable.checks].find(
+      ([name, expression]) =>
+        !expectedTable.checks.has(name) &&
+        (!Object.hasOwn(allowedChecks, name) ||
+          !checkExpressionsMatch(
+            tableName,
+            name,
+            expression,
+            normalizeSqlFragment(allowedChecks[name]!)!
+          ))
+    )
+    if (incompatibleSuffixCheck) {
       throw new DatabaseValidationError(
         `Database baseline verification found an incompatible CHECK constraint set for ${tableName}.`,
         {
           kind: 'check-constraint-set-mismatch',
           table: tableName,
-          expected: [...expectedTable.checks.keys()],
+          expected: [...expectedTable.checks.keys(), ...Object.keys(allowedChecks)],
           actual: [...actualTable.checks.keys()]
         }
       )
@@ -855,8 +869,11 @@ const verifyRuntimeSchemaTarget = async (
   }
 }
 
-const verifyRuntimeSchemaBaseline = (client: PrismaClient): Promise<void> =>
-  verifyRuntimeSchemaTarget(client, BASELINE_SCHEMA_TARGET)
+const verifyRuntimeSchemaBaseline = (
+  client: PrismaClient,
+  allowedSuffixChecks: AllowedSuffixCheckConstraints = {}
+): Promise<void> =>
+  verifyRuntimeSchemaTarget(client, BASELINE_SCHEMA_TARGET, false, allowedSuffixChecks)
 
 const verifyCurrentRuntimeSchema = (client: PrismaClient): Promise<void> =>
   verifyRuntimeSchemaTarget(client, CURRENT_SCHEMA_TARGET, true)
@@ -928,4 +945,4 @@ export {
   verifyCurrentRuntimeSchema,
   verifyRuntimeSchemaBaseline
 }
-export type { PreparedRuntimeSchemaBaseline }
+export type { AllowedSuffixCheckConstraints, PreparedRuntimeSchemaBaseline }

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -20,7 +20,7 @@ import {
 } from './migration-service'
 
 const futureTestMigration = (): MigrationManifestEntry => {
-  const id = '0006_test_suffix'
+  const id = '0007_test_suffix'
   const statements = [`UPDATE "Project" SET "name" = "name" WHERE 0`] as const
   const verifiers = [{ kind: 'table-exists', version: 1, table: 'Project' }] as const
   return {
@@ -30,6 +30,30 @@ const futureTestMigration = (): MigrationManifestEntry => {
     checksum: checksumMigrationPayload(id, statements, verifiers),
     backupOnApply: 'none',
     backupRetention: 'retain'
+  }
+}
+
+const createDatabaseAtMigration0005 = async (client: PrismaClient): Promise<void> => {
+  const prefix = MIGRATION_MANIFEST.slice(0, -1)
+  for (const migration of prefix) {
+    if ('operations' in migration && migration.operations.length > 0) {
+      throw new Error(`Unexpected operation in ${migration.id} test prefix.`)
+    }
+    for (const statement of migration.statements) await client.$executeRawUnsafe(statement)
+  }
+  await client.$executeRawUnsafe(`CREATE TABLE "_open_science_migrations" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "checksum" TEXT NOT NULL,
+    "appliedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "_open_science_migrations_checksum_check"
+      CHECK (length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*')
+  )`)
+  for (const migration of prefix) {
+    await client.$executeRawUnsafe(
+      `INSERT INTO "_open_science_migrations" ("id", "checksum") VALUES (?, ?)`,
+      migration.id,
+      migration.checksum
+    )
   }
 }
 
@@ -158,6 +182,19 @@ describe('application database migrations', () => {
         [{ kind: 'table-exists', version: 1, table: 'probe\nname' }]
       )
     )
+    const operation = (canonicalTableDdl: string) =>
+      [
+        {
+          kind: 'rebuild-table-set',
+          version: 1,
+          tables: [{ tableName: 'Probe', canonicalTableDdl, columns: ['id'] }],
+          dropOrder: ['Probe'],
+          indexes: []
+        }
+      ] as const
+    expect(checksumMigrationPayload('0001_test', [], verifier, operation('one\r\ntwo'))).toBe(
+      checksumMigrationPayload('0001_test', [], verifier, operation('one\ntwo'))
+    )
   })
 
   it('records the runtime baseline once for a fresh database', async () => {
@@ -176,10 +213,11 @@ describe('application database migrations', () => {
         '0002_project_agent_context',
         '0003_granted_local_roots',
         '0004_review_assessment_snapshots',
-        '0005_project_preview_state_owner_fk'
+        '0005_project_preview_state_owner_fk',
+        '0006_database_domain_constraints'
       ],
       from: null,
-      to: '0005_project_preview_state_owner_fk'
+      to: '0006_database_domain_constraints'
     })
     expect(compatibility).toEqual([{ sqliteVersion: expect.stringMatching(/^\d+\.\d+\.\d+$/) }])
     await expect(
@@ -192,8 +230,8 @@ describe('application database migrations', () => {
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
       applied: [],
-      from: '0005_project_preview_state_owner_fk',
-      to: '0005_project_preview_state_owner_fk'
+      from: '0006_database_domain_constraints',
+      to: '0006_database_domain_constraints'
     })
   })
 
@@ -204,6 +242,144 @@ describe('application database migrations', () => {
     await migrateApplicationDatabase(client)
 
     await expect(verifyCurrentRuntimeSchema(client)).resolves.toBeUndefined()
+  })
+
+  it('replays 0006 when its constraint indexes are incomplete', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-0006-index-replay-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.$executeRawUnsafe('DROP INDEX "ComputeJob_status_idx"')
+    await client.$executeRawUnsafe(
+      `DELETE FROM "_open_science_migrations" WHERE "id" = '0006_database_domain_constraints'`
+    )
+
+    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
+      applied: ['0006_database_domain_constraints'],
+      from: '0005_project_preview_state_owner_fk',
+      to: '0006_database_domain_constraints'
+    })
+    await expect(verifyCurrentRuntimeSchema(client)).resolves.toBeUndefined()
+  })
+
+  it('upgrades valid 0005 rows while preserving known retired columns', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-0006-upgrade-'))
+    client = createProjectDbClient(storageRoot)
+    await createDatabaseAtMigration0005(client)
+    await client.$executeRawUnsafe('ALTER TABLE "Review" ADD COLUMN "summary" TEXT')
+    await client.$executeRawUnsafe('ALTER TABLE "Review" ADD COLUMN "checks" TEXT')
+    await client.$executeRawUnsafe('ALTER TABLE "Review" ADD COLUMN "reasoning" TEXT')
+    await client.$executeRawUnsafe('ALTER TABLE "Finding" ADD COLUMN "severity" TEXT')
+    await client.$executeRawUnsafe(`INSERT INTO "Review" (
+      "id", "projectId", "sessionId", "turnMessageId", "lifecycle", "outcome",
+      "updatedAt", "summary", "checks", "reasoning"
+    ) VALUES (
+      'review-1', 'project-1', 'session-1', 'message-1', 'complete', 'pass',
+      CURRENT_TIMESTAMP, 'summary', 'checks', 'reasoning'
+    )`)
+    await client.$executeRawUnsafe(`INSERT INTO "Finding" (
+      "id", "reviewId", "status", "resolution", "sortIndex", "reflagCount", "severity"
+    ) VALUES ('finding-1', 'review-1', 'warn', 'resolved', 2, 1, 'legacy')`)
+    await client.$executeRawUnsafe(`INSERT INTO "ReviewFindingDisposition" (
+      "id", "sourceFindingId", "causeReviewId", "sequence", "trigger", "outcome"
+    ) VALUES (
+      'disposition-1', 'finding-1', 'review-1', 1, 'review_submission', 'resolved'
+    )`)
+    await client.$executeRawUnsafe(`INSERT INTO "ReviewScopeSnapshot" (
+      "id", "projectId", "sessionId", "reviewId", "scopeTurnMessageId", "state",
+      "snapshotJson", "checksum", "storageKey", "blockCount"
+    ) VALUES (
+      'snapshot-1', 'project-1', 'session-1', 'review-1', 'message-1', 'ready',
+      '{}', 'checksum', 'snapshot-key', 0
+    )`)
+    await client.$executeRawUnsafe(`INSERT INTO "ComputeJob" (
+      "id", "providerId", "shape", "sessionId", "projectId", "status", "intent",
+      "command", "commandHash", "errorCode", "timeoutSeconds", "notifiedAt",
+      "notificationConsumedAt"
+    ) VALUES (
+      'job-1', 'ssh:host', 'direct_ssh', 'session-1', 'project-1', 'failed', 'intent',
+      'command', 'hash', 'job_failed', 60, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+    )`)
+    await client.$executeRawUnsafe(`INSERT INTO "ComputeHost" (
+      "id", "providerId", "displayName", "shape", "sshAlias", "scratchRoot",
+      "scratchPinned", "concurrencyLimit", "detailsUpdatedAt", "detailsUpdatedBy", "updatedAt"
+    ) VALUES (
+      'host-1', 'ssh:host', 'Host', 'direct_ssh', 'host', '/scratch', true, 2,
+      CURRENT_TIMESTAMP, 'user', CURRENT_TIMESTAMP
+    )`)
+    await client.$executeRawUnsafe(`INSERT INTO "GrantedLocalRoot" (
+      "id", "path", "name", "access", "updatedAt"
+    ) VALUES ('root-1', '/data', 'Data', 'rw', CURRENT_TIMESTAMP)`)
+
+    await expect(migrateApplicationDatabase(client)).resolves.toEqual({
+      adoptedLegacy: false,
+      applied: ['0006_database_domain_constraints'],
+      from: '0005_project_preview_state_owner_fk',
+      to: '0006_database_domain_constraints'
+    })
+    await expect(
+      client.$queryRaw<
+        Array<{
+          summary: string
+          checks: string
+          reasoning: string
+          severity: string
+          dispositionCount: bigint
+          snapshotCount: bigint
+          jobCount: bigint
+          hostCount: bigint
+          rootCount: bigint
+        }>
+      >`SELECT
+        "Review"."summary", "Review"."checks", "Review"."reasoning", "Finding"."severity",
+        (SELECT COUNT(*) FROM "ReviewFindingDisposition") AS "dispositionCount",
+        (SELECT COUNT(*) FROM "ReviewScopeSnapshot") AS "snapshotCount",
+        (SELECT COUNT(*) FROM "ComputeJob") AS "jobCount",
+        (SELECT COUNT(*) FROM "ComputeHost") AS "hostCount",
+        (SELECT COUNT(*) FROM "GrantedLocalRoot") AS "rootCount"
+      FROM "Review" JOIN "Finding" ON "Finding"."reviewId" = "Review"."id"`
+    ).resolves.toEqual([
+      {
+        summary: 'summary',
+        checks: 'checks',
+        reasoning: 'reasoning',
+        severity: 'legacy',
+        dispositionCount: 1n,
+        snapshotCount: 1n,
+        jobCount: 1n,
+        hostCount: 1n,
+        rootCount: 1n
+      }
+    ])
+    await expect(verifyCurrentRuntimeSchema(client)).resolves.toBeUndefined()
+  })
+
+  it('rolls back 0006 when historical rows violate the new contract', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-0006-invalid-'))
+    client = createProjectDbClient(storageRoot)
+    await createDatabaseAtMigration0005(client)
+    await client.$executeRawUnsafe(`INSERT INTO "Review" (
+      "id", "projectId", "sessionId", "turnMessageId", "lifecycle", "updatedAt"
+    ) VALUES ('invalid-review', 'project-1', 'session-1', 'message-1', 'unknown', CURRENT_TIMESTAMP)`)
+
+    await expect(migrateApplicationDatabase(client)).rejects.toMatchObject({
+      code: 'database_validation_failed',
+      migrationId: '0006_database_domain_constraints'
+    })
+    await expect(
+      client.$queryRaw<Array<{ id: string }>>`
+        SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1
+      `
+    ).resolves.toEqual([{ id: '0005_project_preview_state_owner_fk' }])
+    await expect(
+      client.$queryRaw<Array<{ lifecycle: string }>>`
+        SELECT "lifecycle" FROM "Review" WHERE "id" = 'invalid-review'
+      `
+    ).resolves.toEqual([{ lifecycle: 'unknown' }])
+    await expect(
+      client.$queryRaw<Array<{ sql: string }>>`
+        SELECT "sql" FROM "sqlite_schema" WHERE "type" = 'table' AND "name" = 'Review'
+      `
+    ).resolves.toEqual([{ sql: expect.not.stringContaining('Review_lifecycle_check') }])
   })
 
   it('rejects schema objects outside the generated current target', async () => {
@@ -237,7 +413,7 @@ describe('application database migrations', () => {
       })
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0005_project_preview_state_owner_fk'
+      migrationId: '0006_database_domain_constraints'
     })
     expect(retired).toEqual([])
     await expect(access(backupPath)).resolves.toBeUndefined()
@@ -253,9 +429,9 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).resolves.toEqual({
       adoptedLegacy: false,
-      applied: ['0006_test_suffix'],
-      from: '0005_project_preview_state_owner_fk',
-      to: '0006_test_suffix'
+      applied: ['0007_test_suffix'],
+      from: '0006_database_domain_constraints',
+      to: '0007_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ id: string }>>`
@@ -267,7 +443,8 @@ describe('application database migrations', () => {
       { id: '0003_granted_local_roots' },
       { id: '0004_review_assessment_snapshots' },
       { id: '0005_project_preview_state_owner_fk' },
-      { id: '0006_test_suffix' }
+      { id: '0006_database_domain_constraints' },
+      { id: '0007_test_suffix' }
     ])
   })
 
@@ -324,10 +501,11 @@ describe('application database migrations', () => {
         '0002_project_agent_context',
         '0003_granted_local_roots',
         '0004_review_assessment_snapshots',
-        '0005_project_preview_state_owner_fk'
+        '0005_project_preview_state_owner_fk',
+        '0006_database_domain_constraints'
       ],
       from: '0001_runtime_schema_baseline',
-      to: '0005_project_preview_state_owner_fk'
+      to: '0006_database_domain_constraints'
     })
     expect(backupEvents).toEqual([
       {
@@ -348,6 +526,11 @@ describe('application database migrations', () => {
       {
         migrationId: '0005_project_preview_state_owner_fk',
         path: `${databasePath}.before-0005_project_preview_state_owner_fk.backup`,
+        reused: false
+      },
+      {
+        migrationId: '0006_database_domain_constraints',
+        path: `${databasePath}.before-0006_database_domain_constraints.backup`,
         reused: false
       }
     ])
@@ -381,7 +564,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0006_test_suffix'
+      migrationId: '0007_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ name: string }>>`
@@ -398,7 +581,8 @@ describe('application database migrations', () => {
       { id: '0002_project_agent_context' },
       { id: '0003_granted_local_roots' },
       { id: '0004_review_assessment_snapshots' },
-      { id: '0005_project_preview_state_owner_fk' }
+      { id: '0005_project_preview_state_owner_fk' },
+      { id: '0006_database_domain_constraints' }
     ])
   })
 
@@ -420,7 +604,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0006_test_suffix'
+      migrationId: '0007_test_suffix'
     })
   })
 
@@ -451,9 +635,10 @@ describe('application database migrations', () => {
         '0003_granted_local_roots',
         '0004_review_assessment_snapshots',
         '0005_project_preview_state_owner_fk',
-        '0006_test_suffix'
+        '0006_database_domain_constraints',
+        '0007_test_suffix'
       ],
-      to: '0006_test_suffix'
+      to: '0007_test_suffix'
     })
     await expect(
       client.project.findUniqueOrThrow({ where: { id: 'legacy-project' } })
@@ -671,7 +856,8 @@ describe('application database migrations', () => {
         '0002_project_agent_context',
         '0003_granted_local_roots',
         '0004_review_assessment_snapshots',
-        '0005_project_preview_state_owner_fk'
+        '0005_project_preview_state_owner_fk',
+        '0006_database_domain_constraints'
       ]
     })
     await expect(
@@ -712,7 +898,8 @@ describe('application database migrations', () => {
         '0002_project_agent_context',
         '0003_granted_local_roots',
         '0004_review_assessment_snapshots',
-        '0005_project_preview_state_owner_fk'
+        '0005_project_preview_state_owner_fk',
+        '0006_database_domain_constraints'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -766,7 +953,8 @@ describe('application database migrations', () => {
         '0002_project_agent_context',
         '0003_granted_local_roots',
         '0004_review_assessment_snapshots',
-        '0005_project_preview_state_owner_fk'
+        '0005_project_preview_state_owner_fk',
+        '0006_database_domain_constraints'
       ]
     })
     await expect(
@@ -823,7 +1011,8 @@ describe('application database migrations', () => {
         '0002_project_agent_context',
         '0003_granted_local_roots',
         '0004_review_assessment_snapshots',
-        '0005_project_preview_state_owner_fk'
+        '0005_project_preview_state_owner_fk',
+        '0006_database_domain_constraints'
       ]
     })
     await expect(verifyCurrentRuntimeSchema(client)).resolves.toBeUndefined()
@@ -914,7 +1103,8 @@ describe('application database migrations', () => {
         '0002_project_agent_context',
         '0003_granted_local_roots',
         '0004_review_assessment_snapshots',
-        '0005_project_preview_state_owner_fk'
+        '0005_project_preview_state_owner_fk',
+        '0006_database_domain_constraints'
       ]
     })
     await expect(
@@ -958,7 +1148,8 @@ describe('application database migrations', () => {
         '0002_project_agent_context',
         '0003_granted_local_roots',
         '0004_review_assessment_snapshots',
-        '0005_project_preview_state_owner_fk'
+        '0005_project_preview_state_owner_fk',
+        '0006_database_domain_constraints'
       ]
     })
     expect(backupEvents).toEqual([
@@ -985,6 +1176,11 @@ describe('application database migrations', () => {
       {
         migrationId: '0005_project_preview_state_owner_fk',
         path: `${databasePath}.before-0005_project_preview_state_owner_fk.backup`,
+        reused: false
+      },
+      {
+        migrationId: '0006_database_domain_constraints',
+        path: `${databasePath}.before-0006_database_domain_constraints.backup`,
         reused: false
       }
     ])
@@ -1378,6 +1574,11 @@ describe('application database migrations', () => {
         migrationId: '0005_project_preview_state_owner_fk',
         path: `${databasePath}.before-0005_project_preview_state_owner_fk.backup`,
         reused: false
+      }),
+      expect.objectContaining({
+        migrationId: '0006_database_domain_constraints',
+        path: `${databasePath}.before-0006_database_domain_constraints.backup`,
+        reused: false
       })
     ])
     expect(retired).toEqual([
@@ -1394,6 +1595,10 @@ describe('application database migrations', () => {
       {
         migrationId: '0005_project_preview_state_owner_fk',
         path: `${databasePath}.before-0005_project_preview_state_owner_fk.backup`
+      },
+      {
+        migrationId: '0006_database_domain_constraints',
+        path: `${databasePath}.before-0006_database_domain_constraints.backup`
       }
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -9,7 +9,8 @@ import {
   applyRuntimeSchemaBaseline,
   prepareRuntimeSchemaBaseline,
   verifyCurrentRuntimeSchema,
-  verifyRuntimeSchemaBaseline
+  verifyRuntimeSchemaBaseline,
+  type AllowedSuffixCheckConstraints
 } from './legacy-baseline-adapter'
 import { DatabaseValidationError } from './database-validation-error'
 import { migrationSqlExecutor } from './migration-sql-executor'
@@ -18,6 +19,11 @@ import { projectAgentContextMigration } from './migrations/0002-project-agent-co
 import { grantedLocalRootsMigration } from './migrations/0003-granted-local-roots'
 import { reviewAssessmentSnapshotsMigration } from './migrations/0004-review-assessment-snapshots'
 import { projectPreviewStateOwnerFkMigration } from './migrations/0005-project-preview-state-owner-fk'
+import { databaseDomainConstraintsMigration } from './migrations/0006-database-domain-constraints'
+import {
+  applySqliteMigrationOperations,
+  type SqliteMigrationOperation
+} from './sqlite-schema-migrations'
 
 type MigrationVerifierDescriptor =
   | {
@@ -45,6 +51,19 @@ type MigrationVerifierDescriptor =
       referencedColumn: string
       onDelete: string
       onUpdate: string
+    }
+  | {
+      kind: 'check-constraints-exist'
+      version: 1
+      tables: readonly {
+        table: string
+        constraints: readonly { name: string; expression: string }[]
+      }[]
+    }
+  | {
+      kind: 'indexes-exist'
+      version: 1
+      indexes: readonly { name: string; sql: string }[]
     }
 
 type MigrationVerifiers = readonly [MigrationVerifierDescriptor, ...MigrationVerifierDescriptor[]]
@@ -78,6 +97,19 @@ const serializeMigrationVerifier = (verifier: MigrationVerifierDescriptor): stri
       ]
         .map(lengthPrefixedChecksumText)
         .join('')}`
+    case 'check-constraints-exist':
+      return `check-constraints-exist:v${verifier.version}:${verifier.tables
+        .flatMap(({ table, constraints }) => [
+          table,
+          ...constraints.flatMap(({ name, expression }) => [name, expression])
+        ])
+        .map(lengthPrefixedChecksumText)
+        .join('')}`
+    case 'indexes-exist':
+      return `indexes-exist:v${verifier.version}:${verifier.indexes
+        .flatMap(({ name, sql }) => [name, sql])
+        .map(lengthPrefixedChecksumText)
+        .join('')}`
   }
 }
 
@@ -86,7 +118,8 @@ const BASELINE_ID = runtimeSchemaBaselineMigration.id
 const checksumMigrationPayload = (
   id: string,
   statements: readonly string[],
-  verifiers: MigrationVerifiers
+  verifiers: MigrationVerifiers,
+  operations: readonly SqliteMigrationOperation[] = []
 ): string => {
   const hash = createHash('sha256')
   for (const [kind, values] of [
@@ -99,6 +132,13 @@ const checksumMigrationPayload = (
       hash.update(`${kind}:${Buffer.byteLength(normalized, 'utf8')}:`, 'utf8')
       hash.update(normalized, 'utf8')
     }
+  }
+  for (const operation of operations) {
+    const serialized = JSON.stringify(operation, (_key, value: unknown) =>
+      typeof value === 'string' ? normalizeChecksumText(value) : value
+    )
+    hash.update(`operation:${Buffer.byteLength(serialized, 'utf8')}:`, 'utf8')
+    hash.update(serialized, 'utf8')
   }
   return hash.digest('hex')
 }
@@ -128,6 +168,18 @@ const PROJECT_PREVIEW_STATE_OWNER_FK_CHECKSUM = checksumMigrationPayload(
   projectPreviewStateOwnerFkMigration.statements,
   projectPreviewStateOwnerFkMigration.verifiers
 )
+const DATABASE_DOMAIN_CONSTRAINTS_CHECKSUM = checksumMigrationPayload(
+  databaseDomainConstraintsMigration.id,
+  databaseDomainConstraintsMigration.statements,
+  databaseDomainConstraintsMigration.verifiers,
+  databaseDomainConstraintsMigration.operations
+)
+const DATABASE_DOMAIN_ALLOWED_SUFFIX_CHECKS: AllowedSuffixCheckConstraints = Object.fromEntries(
+  databaseDomainConstraintsMigration.verifiers[0].tables.map(({ table, constraints }) => [
+    table,
+    Object.fromEntries(constraints.map(({ name, expression }) => [name, expression]))
+  ])
+)
 const MIGRATION_MANIFEST = [
   {
     ...runtimeSchemaBaselineMigration,
@@ -156,6 +208,12 @@ const MIGRATION_MANIFEST = [
   {
     ...projectPreviewStateOwnerFkMigration,
     checksum: PROJECT_PREVIEW_STATE_OWNER_FK_CHECKSUM,
+    backupOnApply: 'required',
+    backupRetention: 'retain'
+  },
+  {
+    ...databaseDomainConstraintsMigration,
+    checksum: DATABASE_DOMAIN_CONSTRAINTS_CHECKSUM,
     backupOnApply: 'required',
     backupRetention: 'retain'
   }
@@ -240,6 +298,7 @@ type MigrationManifestEntry = {
   id: string
   checksum: string
   statements: readonly string[]
+  operations?: readonly SqliteMigrationOperation[]
   verifiers: MigrationVerifiers
   backupOnApply: 'required' | 'none'
   backupRetention: 'retain' | 'delete-after-success'
@@ -247,7 +306,8 @@ type MigrationManifestEntry = {
 
 const runMigrationVerifiers = async (
   client: PrismaClient,
-  verifiers: MigrationVerifiers
+  verifiers: MigrationVerifiers,
+  allowedSuffixChecks: AllowedSuffixCheckConstraints = {}
 ): Promise<void> => {
   for (const verifier of verifiers) {
     switch (verifier.kind) {
@@ -258,7 +318,7 @@ const runMigrationVerifiers = async (
         ) {
           throw new Error('Migration verification found an unsupported baseline contract.')
         }
-        await verifyRuntimeSchemaBaseline(client)
+        await verifyRuntimeSchemaBaseline(client, allowedSuffixChecks)
         break
       case 'table-exists': {
         const rows = await client.$queryRaw<Array<{ name: string }>>`
@@ -310,6 +370,50 @@ const runMigrationVerifiers = async (
           throw new Error(
             `Migration verification found foreign-key violations in ${verifier.table}.`
           )
+        }
+        break
+      }
+      case 'check-constraints-exist': {
+        for (const table of verifier.tables) {
+          const rows = await migrationSqlExecutor.query<Array<{ sql: string | null }>>(
+            client,
+            `SELECT "sql" FROM "sqlite_schema" WHERE "type" = 'table' AND "name" = ?`,
+            table.table
+          )
+          const tableSql = rows[0]?.sql
+          if (
+            !tableSql ||
+            table.constraints.some(
+              ({ name, expression }) =>
+                !tableSql.includes(`CONSTRAINT "${name}" CHECK (${expression})`)
+            )
+          ) {
+            throw new Error(
+              `Migration verification found missing CHECK constraints in ${table.table}.`
+            )
+          }
+        }
+        break
+      }
+      case 'indexes-exist': {
+        const normalizeIndexSql = (value: string): string =>
+          value
+            .replace(
+              /^CREATE (UNIQUE )?INDEX IF NOT EXISTS /i,
+              (_match, unique: string | undefined) => `CREATE ${unique ?? ''}INDEX `
+            )
+            .replaceAll(/\s+/g, ' ')
+            .replace(/;$/, '')
+            .trim()
+        for (const index of verifier.indexes) {
+          const rows = await migrationSqlExecutor.query<Array<{ sql: string | null }>>(
+            client,
+            `SELECT "sql" FROM "sqlite_schema" WHERE "type" = 'index' AND "name" = ?`,
+            index.name
+          )
+          if (!rows[0]?.sql || normalizeIndexSql(rows[0].sql) !== normalizeIndexSql(index.sql)) {
+            throw new Error(`Migration verification found missing index ${index.name}.`)
+          }
         }
         break
       }
@@ -630,6 +734,8 @@ const classifyDatabaseFailure = (
     )
   const validationFailure =
     phase === 'validation' ||
+    (error instanceof DatabaseValidationError &&
+      error.data.kind === 'check-constraint-violation') ||
     /classification blocked|unsupported value|unknown columns?|row-count mismatch|foreign-key violation|baseline verification/i.test(
       detail
     )
@@ -709,7 +815,8 @@ const hasOnlyDeferredPreviewStateForeignKeyViolations = async (
 const applyBaselineMigration = async (
   client: PrismaClient,
   migration: MigrationManifestEntry,
-  deferPreviewStateForeignKeyViolations: boolean
+  deferPreviewStateForeignKeyViolations: boolean,
+  allowedSuffixChecks: AllowedSuffixCheckConstraints
 ): Promise<void> => {
   let prepared: Awaited<ReturnType<typeof prepareRuntimeSchemaBaseline>>
   try {
@@ -736,7 +843,7 @@ const applyBaselineMigration = async (
         }
         // The pinned 0005 suffix owns pruning these rows before the migration run completes.
       }
-      await runMigrationVerifiers(transactionClient, migration.verifiers)
+      await runMigrationVerifiers(transactionClient, migration.verifiers, allowedSuffixChecks)
       await insertLedgerRow(transactionClient, migration)
     })
   } catch (error) {
@@ -787,6 +894,7 @@ const applyManifestMigration = async (
         for (const statement of migration.statements) {
           await migrationSqlExecutor.execute(transaction, statement)
         }
+        await applySqliteMigrationOperations(transactionClient, migration.operations ?? [])
       }
       try {
         await runMigrationVerifiers(transactionClient, migration.verifiers)
@@ -899,15 +1007,28 @@ const migrateApplicationDatabaseWithManifest = async (
       candidate.id === projectPreviewStateOwnerFkMigration.id &&
       candidate.checksum === PROJECT_PREVIEW_STATE_OWNER_FK_CHECKSUM
   )
-
+  const adoptsDatabaseDomainConstraints = manifest.some(
+    (candidate) =>
+      candidate.id === databaseDomainConstraintsMigration.id &&
+      candidate.checksum === DATABASE_DOMAIN_CONSTRAINTS_CHECKSUM
+  )
   const applied: string[] = []
   const adoptedLegacy = appliedCount === 0 && hadApplicationTablesAtStart
+  const allowedSuffixChecks = adoptsDatabaseDomainConstraints
+    ? DATABASE_DOMAIN_ALLOWED_SUFFIX_CHECKS
+    : {}
+
   let nextIndex = appliedCount
   if (nextIndex === 0) {
     const baseline = manifest[0]!
     options.onProgress?.({ phase: 'migrating', migrationId: baseline.id })
     await backupBeforeMigration(baseline)
-    await applyBaselineMigration(client, baseline, repairsPreviewStateForeignKeyViolations)
+    await applyBaselineMigration(
+      client,
+      baseline,
+      repairsPreviewStateForeignKeyViolations,
+      allowedSuffixChecks
+    )
     applied.push(baseline.id)
     nextIndex = 1
   }
@@ -931,6 +1052,7 @@ const migrateApplicationDatabase = (
 export {
   BASELINE_CHECKSUM,
   PROJECT_AGENT_CONTEXT_CHECKSUM,
+  DATABASE_DOMAIN_CONSTRAINTS_CHECKSUM,
   DatabaseMigrationError,
   checksumMigrationPayload,
   classifyDatabaseFailure,

--- a/src/main/database/migrations/0006-database-domain-constraints.ts
+++ b/src/main/database/migrations/0006-database-domain-constraints.ts
@@ -1,0 +1,507 @@
+/* Immutable 0006 migration snapshot. Do not regenerate after release. */
+
+const databaseDomainConstraintsMigration = {
+  id: '0006_database_domain_constraints',
+  statements: [] as const,
+  operations: [
+    {
+      kind: 'rebuild-table-set',
+      version: 1,
+      tables: [
+        {
+          tableName: 'Review',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "Review" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "projectId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "turnMessageId" TEXT NOT NULL,
+    "scope" TEXT NOT NULL DEFAULT '{}',
+    "lifecycle" TEXT NOT NULL DEFAULT 'running',
+    "outcome" TEXT,
+    "errorMessage" TEXT,
+    "model" TEXT NOT NULL DEFAULT '',
+    "reviewerLog" TEXT NOT NULL DEFAULT '[]',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Review_lifecycle_check" CHECK ("lifecycle" IN ('running', 'complete', 'error')),
+    CONSTRAINT "Review_outcome_check" CHECK ("outcome" IS NULL OR "outcome" IN ('pass', 'flagged')),
+    CONSTRAINT "Review_state_check" CHECK ((("lifecycle" = 'running' AND "outcome" IS NULL AND "errorMessage" IS NULL) OR ("lifecycle" = 'complete' AND "outcome" IS NOT NULL AND "errorMessage" IS NULL) OR ("lifecycle" = 'error' AND "outcome" IS NULL AND "errorMessage" IS NOT NULL)))
+);`,
+          columns: [
+            'id',
+            'projectId',
+            'sessionId',
+            'turnMessageId',
+            'scope',
+            'lifecycle',
+            'outcome',
+            'errorMessage',
+            'model',
+            'reviewerLog',
+            'createdAt',
+            'updatedAt'
+          ],
+          optionalLegacyColumns: [
+            { name: 'summary', definition: '"summary" TEXT' },
+            { name: 'checks', definition: '"checks" TEXT' },
+            { name: 'reasoning', definition: '"reasoning" TEXT' }
+          ]
+        },
+        {
+          tableName: 'Finding',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "Finding" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "reviewId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pass',
+    "resolution" TEXT NOT NULL DEFAULT 'open',
+    "claim" TEXT NOT NULL DEFAULT '',
+    "evidence" TEXT NOT NULL DEFAULT '',
+    "locator" TEXT NOT NULL DEFAULT '{}',
+    "artifactVersionId" TEXT,
+    "artifactBindingState" TEXT NOT NULL DEFAULT 'legacy_unverified',
+    "sortIndex" INTEGER NOT NULL DEFAULT 0,
+    "reflagCount" INTEGER NOT NULL DEFAULT 0,
+    CONSTRAINT "Finding_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "Review" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Finding_status_check" CHECK ("status" IN ('pass', 'warn', 'fail')),
+    CONSTRAINT "Finding_resolution_check" CHECK ("resolution" IN ('open', 'resolved', 'unaddressed')),
+    CONSTRAINT "Finding_artifactBindingState_check" CHECK ("artifactBindingState" IN ('scope_validated', 'legacy_unverified')),
+    CONSTRAINT "Finding_sortIndex_check" CHECK ("sortIndex" >= 0),
+    CONSTRAINT "Finding_reflagCount_check" CHECK ("reflagCount" >= 0),
+    CONSTRAINT "Finding_statusResolution_check" CHECK ("status" <> 'pass' OR "resolution" = 'open'),
+    CONSTRAINT "Finding_artifactBinding_check" CHECK ("artifactBindingState" <> 'scope_validated' OR "artifactVersionId" IS NOT NULL)
+);`,
+          columns: [
+            'id',
+            'reviewId',
+            'status',
+            'resolution',
+            'claim',
+            'evidence',
+            'locator',
+            'artifactVersionId',
+            'artifactBindingState',
+            'sortIndex',
+            'reflagCount'
+          ],
+          optionalLegacyColumns: [{ name: 'severity', definition: '"severity" TEXT' }]
+        },
+        {
+          tableName: 'ReviewFindingDisposition',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ReviewFindingDisposition" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "sourceFindingId" TEXT NOT NULL,
+    "causeReviewId" TEXT,
+    "sequence" INTEGER NOT NULL,
+    "trigger" TEXT NOT NULL,
+    "outcome" TEXT NOT NULL,
+    "note" TEXT,
+    "assessedArtifactVersionId" TEXT,
+    "assessmentSnapshot" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ReviewFindingDisposition_sourceFindingId_fkey" FOREIGN KEY ("sourceFindingId") REFERENCES "Finding" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ReviewFindingDisposition_causeReviewId_fkey" FOREIGN KEY ("causeReviewId") REFERENCES "Review" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ReviewFindingDisposition_sequence_check" CHECK ("sequence" >= 1),
+    CONSTRAINT "ReviewFindingDisposition_trigger_check" CHECK ("trigger" IN ('review_submission', 'loop_terminated', 'correction_failed', 'aborted')),
+    CONSTRAINT "ReviewFindingDisposition_outcome_check" CHECK ("outcome" IN ('still_open', 'resolved', 'unaddressed')),
+    CONSTRAINT "ReviewFindingDisposition_state_check" CHECK ((("trigger" = 'review_submission' AND "causeReviewId" IS NOT NULL AND "outcome" IN ('still_open', 'resolved')) OR ("trigger" IN ('loop_terminated', 'correction_failed', 'aborted') AND "causeReviewId" IS NULL AND "outcome" = 'unaddressed')))
+);`,
+          columns: [
+            'id',
+            'sourceFindingId',
+            'causeReviewId',
+            'sequence',
+            'trigger',
+            'outcome',
+            'note',
+            'assessedArtifactVersionId',
+            'assessmentSnapshot',
+            'createdAt'
+          ]
+        },
+        {
+          tableName: 'ReviewScopeSnapshot',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ReviewScopeSnapshot" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "projectId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "reviewId" TEXT NOT NULL,
+    "scopeTurnMessageId" TEXT NOT NULL,
+    "state" TEXT NOT NULL DEFAULT 'staging',
+    "snapshotJson" TEXT NOT NULL,
+    "checksum" TEXT NOT NULL,
+    "storageKey" TEXT NOT NULL,
+    "schemaVersion" INTEGER NOT NULL DEFAULT 1,
+    "blockCount" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ReviewScopeSnapshot_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "Review" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ReviewScopeSnapshot_state_check" CHECK ("state" IN ('staging', 'ready'))
+);`,
+          columns: [
+            'id',
+            'projectId',
+            'sessionId',
+            'reviewId',
+            'scopeTurnMessageId',
+            'state',
+            'snapshotJson',
+            'checksum',
+            'storageKey',
+            'schemaVersion',
+            'blockCount',
+            'createdAt'
+          ]
+        },
+        {
+          tableName: 'ComputeJob',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ComputeJob" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "providerId" TEXT NOT NULL,
+    "shape" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'submitted',
+    "intent" TEXT NOT NULL,
+    "command" TEXT NOT NULL,
+    "commandHash" TEXT NOT NULL,
+    "environment" TEXT,
+    "resourceRequest" TEXT,
+    "inputManifest" TEXT,
+    "outputManifest" TEXT,
+    "harvestConfig" TEXT,
+    "timeoutSeconds" INTEGER,
+    "remoteWorkdir" TEXT,
+    "remoteHandle" TEXT,
+    "exitCode" INTEGER,
+    "stdoutTail" TEXT,
+    "stderrTail" TEXT,
+    "errorCode" TEXT,
+    "lastPollError" TEXT,
+    "harvestError" TEXT,
+    "leftOnRemote" TEXT,
+    "notifiedAt" DATETIME,
+    "notificationConsumedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "submittedAt" DATETIME,
+    "startedAt" DATETIME,
+    "finishedAt" DATETIME,
+    "harvestedAt" DATETIME,
+    CONSTRAINT "ComputeJob_shape_check" CHECK ("shape" IN ('direct_ssh', 'scheduler_cluster', 'bridge_runner')),
+    CONSTRAINT "ComputeJob_status_check" CHECK ("status" IN ('queued', 'submitted', 'running', 'success', 'failed', 'timeout', 'error')),
+    CONSTRAINT "ComputeJob_errorCode_check" CHECK ("errorCode" IS NULL OR "errorCode" IN ('approval_denied', 'host_unreachable', 'dispatch_failed', 'job_failed', 'timeout', 'process_vanished')),
+    CONSTRAINT "ComputeJob_timeoutSeconds_check" CHECK ("timeoutSeconds" IS NULL OR "timeoutSeconds" BETWEEN 1 AND 604800),
+    CONSTRAINT "ComputeJob_notification_check" CHECK ("notificationConsumedAt" IS NULL OR "notifiedAt" IS NOT NULL),
+    CONSTRAINT "ComputeJob_harvestPayload_check" CHECK (("harvestError" IS NULL AND "leftOnRemote" IS NULL) OR "harvestedAt" IS NOT NULL),
+    CONSTRAINT "ComputeJob_harvestState_check" CHECK ("harvestedAt" IS NULL OR "status" IN ('success', 'failed', 'timeout')),
+    CONSTRAINT "ComputeJob_errorState_check" CHECK ((("errorCode" IS NULL OR "status" IN ('failed', 'timeout', 'error')) AND ("status" <> 'error' OR "errorCode" IS NOT NULL)))
+);`,
+          columns: [
+            'id',
+            'providerId',
+            'shape',
+            'sessionId',
+            'projectId',
+            'status',
+            'intent',
+            'command',
+            'commandHash',
+            'environment',
+            'resourceRequest',
+            'inputManifest',
+            'outputManifest',
+            'harvestConfig',
+            'timeoutSeconds',
+            'remoteWorkdir',
+            'remoteHandle',
+            'exitCode',
+            'stdoutTail',
+            'stderrTail',
+            'errorCode',
+            'lastPollError',
+            'harvestError',
+            'leftOnRemote',
+            'notifiedAt',
+            'notificationConsumedAt',
+            'createdAt',
+            'submittedAt',
+            'startedAt',
+            'finishedAt',
+            'harvestedAt'
+          ]
+        },
+        {
+          tableName: 'ComputeHost',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ComputeHost" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "providerId" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "shape" TEXT NOT NULL DEFAULT 'direct_ssh',
+    "sshAlias" TEXT NOT NULL,
+    "sshOverrides" TEXT,
+    "scratchRoot" TEXT,
+    "scratchPinned" BOOLEAN NOT NULL DEFAULT false,
+    "concurrencyLimit" INTEGER,
+    "probeResult" TEXT,
+    "detailsDoc" TEXT NOT NULL DEFAULT '',
+    "detailsUpdatedAt" DATETIME,
+    "detailsUpdatedBy" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ComputeHost_shape_check" CHECK ("shape" IN ('direct_ssh', 'scheduler_cluster', 'bridge_runner')),
+    CONSTRAINT "ComputeHost_scratchPinned_check" CHECK ("scratchPinned" IN (false, true)),
+    CONSTRAINT "ComputeHost_concurrencyLimit_check" CHECK ("concurrencyLimit" IS NULL OR "concurrencyLimit" BETWEEN 1 AND 500),
+    CONSTRAINT "ComputeHost_detailsUpdatedBy_check" CHECK ("detailsUpdatedBy" IS NULL OR "detailsUpdatedBy" IN ('user', 'agent')),
+    CONSTRAINT "ComputeHost_detailsUpdate_check" CHECK (("detailsUpdatedAt" IS NULL AND "detailsUpdatedBy" IS NULL) OR ("detailsUpdatedAt" IS NOT NULL AND "detailsUpdatedBy" IS NOT NULL)),
+    CONSTRAINT "ComputeHost_scratchRoot_check" CHECK ("scratchPinned" = false OR "scratchRoot" IS NOT NULL)
+);`,
+          columns: [
+            'id',
+            'providerId',
+            'displayName',
+            'shape',
+            'sshAlias',
+            'sshOverrides',
+            'scratchRoot',
+            'scratchPinned',
+            'concurrencyLimit',
+            'probeResult',
+            'detailsDoc',
+            'detailsUpdatedAt',
+            'detailsUpdatedBy',
+            'createdAt',
+            'updatedAt'
+          ]
+        },
+        {
+          tableName: 'GrantedLocalRoot',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "GrantedLocalRoot" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "path" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "access" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "GrantedLocalRoot_access_check" CHECK ("access" IN ('ro', 'rw'))
+);`,
+          columns: ['id', 'path', 'name', 'access', 'createdAt', 'updatedAt']
+        }
+      ],
+      dropOrder: [
+        'ReviewFindingDisposition',
+        'ReviewScopeSnapshot',
+        'Finding',
+        'Review',
+        'ComputeJob',
+        'ComputeHost',
+        'GrantedLocalRoot'
+      ],
+      indexes: [
+        `CREATE INDEX IF NOT EXISTS "ReviewFindingDisposition_causeReviewId_createdAt_idx" ON "ReviewFindingDisposition"("causeReviewId", "createdAt");`,
+        `CREATE INDEX IF NOT EXISTS "ReviewFindingDisposition_assessedArtifactVersionId_idx" ON "ReviewFindingDisposition"("assessedArtifactVersionId");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ReviewFindingDisposition_sourceFindingId_sequence_key" ON "ReviewFindingDisposition"("sourceFindingId", "sequence");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ReviewScopeSnapshot_reviewId_key" ON "ReviewScopeSnapshot"("reviewId");`,
+        `CREATE INDEX IF NOT EXISTS "ReviewScopeSnapshot_projectId_sessionId_state_idx" ON "ReviewScopeSnapshot"("projectId", "sessionId", "state");`,
+        `CREATE INDEX IF NOT EXISTS "ComputeJob_providerId_idx" ON "ComputeJob"("providerId");`,
+        `CREATE INDEX IF NOT EXISTS "ComputeJob_sessionId_idx" ON "ComputeJob"("sessionId");`,
+        `CREATE INDEX IF NOT EXISTS "ComputeJob_status_idx" ON "ComputeJob"("status");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ComputeHost_providerId_key" ON "ComputeHost"("providerId");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "GrantedLocalRoot_path_key" ON "GrantedLocalRoot"("path");`
+      ]
+    }
+  ] as const,
+  verifiers: [
+    {
+      kind: 'check-constraints-exist',
+      version: 1,
+      tables: [
+        {
+          table: 'Review',
+          constraints: [
+            {
+              name: 'Review_lifecycle_check',
+              expression: `"lifecycle" IN ('running', 'complete', 'error')`
+            },
+            {
+              name: 'Review_outcome_check',
+              expression: `"outcome" IS NULL OR "outcome" IN ('pass', 'flagged')`
+            },
+            {
+              name: 'Review_state_check',
+              expression: `(("lifecycle" = 'running' AND "outcome" IS NULL AND "errorMessage" IS NULL) OR ("lifecycle" = 'complete' AND "outcome" IS NOT NULL AND "errorMessage" IS NULL) OR ("lifecycle" = 'error' AND "outcome" IS NULL AND "errorMessage" IS NOT NULL))`
+            }
+          ]
+        },
+        {
+          table: 'Finding',
+          constraints: [
+            {
+              name: 'Finding_status_check',
+              expression: `"status" IN ('pass', 'warn', 'fail')`
+            },
+            {
+              name: 'Finding_resolution_check',
+              expression: `"resolution" IN ('open', 'resolved', 'unaddressed')`
+            },
+            {
+              name: 'Finding_artifactBindingState_check',
+              expression: `"artifactBindingState" IN ('scope_validated', 'legacy_unverified')`
+            },
+            { name: 'Finding_sortIndex_check', expression: `"sortIndex" >= 0` },
+            { name: 'Finding_reflagCount_check', expression: `"reflagCount" >= 0` },
+            {
+              name: 'Finding_statusResolution_check',
+              expression: `"status" <> 'pass' OR "resolution" = 'open'`
+            },
+            {
+              name: 'Finding_artifactBinding_check',
+              expression: `"artifactBindingState" <> 'scope_validated' OR "artifactVersionId" IS NOT NULL`
+            }
+          ]
+        },
+        {
+          table: 'ReviewFindingDisposition',
+          constraints: [
+            {
+              name: 'ReviewFindingDisposition_sequence_check',
+              expression: `"sequence" >= 1`
+            },
+            {
+              name: 'ReviewFindingDisposition_trigger_check',
+              expression: `"trigger" IN ('review_submission', 'loop_terminated', 'correction_failed', 'aborted')`
+            },
+            {
+              name: 'ReviewFindingDisposition_outcome_check',
+              expression: `"outcome" IN ('still_open', 'resolved', 'unaddressed')`
+            },
+            {
+              name: 'ReviewFindingDisposition_state_check',
+              expression: `(("trigger" = 'review_submission' AND "causeReviewId" IS NOT NULL AND "outcome" IN ('still_open', 'resolved')) OR ("trigger" IN ('loop_terminated', 'correction_failed', 'aborted') AND "causeReviewId" IS NULL AND "outcome" = 'unaddressed'))`
+            }
+          ]
+        },
+        {
+          table: 'ComputeJob',
+          constraints: [
+            {
+              name: 'ComputeJob_shape_check',
+              expression: `"shape" IN ('direct_ssh', 'scheduler_cluster', 'bridge_runner')`
+            },
+            {
+              name: 'ComputeJob_status_check',
+              expression: `"status" IN ('queued', 'submitted', 'running', 'success', 'failed', 'timeout', 'error')`
+            },
+            {
+              name: 'ComputeJob_errorCode_check',
+              expression: `"errorCode" IS NULL OR "errorCode" IN ('approval_denied', 'host_unreachable', 'dispatch_failed', 'job_failed', 'timeout', 'process_vanished')`
+            },
+            {
+              name: 'ComputeJob_timeoutSeconds_check',
+              expression: `"timeoutSeconds" IS NULL OR "timeoutSeconds" BETWEEN 1 AND 604800`
+            },
+            {
+              name: 'ComputeJob_notification_check',
+              expression: `"notificationConsumedAt" IS NULL OR "notifiedAt" IS NOT NULL`
+            },
+            {
+              name: 'ComputeJob_harvestPayload_check',
+              expression: `("harvestError" IS NULL AND "leftOnRemote" IS NULL) OR "harvestedAt" IS NOT NULL`
+            },
+            {
+              name: 'ComputeJob_harvestState_check',
+              expression: `"harvestedAt" IS NULL OR "status" IN ('success', 'failed', 'timeout')`
+            },
+            {
+              name: 'ComputeJob_errorState_check',
+              expression: `(("errorCode" IS NULL OR "status" IN ('failed', 'timeout', 'error')) AND ("status" <> 'error' OR "errorCode" IS NOT NULL))`
+            }
+          ]
+        },
+        {
+          table: 'ComputeHost',
+          constraints: [
+            {
+              name: 'ComputeHost_shape_check',
+              expression: `"shape" IN ('direct_ssh', 'scheduler_cluster', 'bridge_runner')`
+            },
+            {
+              name: 'ComputeHost_scratchPinned_check',
+              expression: `"scratchPinned" IN (false, true)`
+            },
+            {
+              name: 'ComputeHost_concurrencyLimit_check',
+              expression: `"concurrencyLimit" IS NULL OR "concurrencyLimit" BETWEEN 1 AND 500`
+            },
+            {
+              name: 'ComputeHost_detailsUpdatedBy_check',
+              expression: `"detailsUpdatedBy" IS NULL OR "detailsUpdatedBy" IN ('user', 'agent')`
+            },
+            {
+              name: 'ComputeHost_detailsUpdate_check',
+              expression: `("detailsUpdatedAt" IS NULL AND "detailsUpdatedBy" IS NULL) OR ("detailsUpdatedAt" IS NOT NULL AND "detailsUpdatedBy" IS NOT NULL)`
+            },
+            {
+              name: 'ComputeHost_scratchRoot_check',
+              expression: `"scratchPinned" = false OR "scratchRoot" IS NOT NULL`
+            }
+          ]
+        },
+        {
+          table: 'GrantedLocalRoot',
+          constraints: [
+            {
+              name: 'GrantedLocalRoot_access_check',
+              expression: `"access" IN ('ro', 'rw')`
+            }
+          ]
+        }
+      ]
+    },
+    {
+      kind: 'indexes-exist',
+      version: 1,
+      indexes: [
+        {
+          name: 'ReviewFindingDisposition_causeReviewId_createdAt_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ReviewFindingDisposition_causeReviewId_createdAt_idx" ON "ReviewFindingDisposition"("causeReviewId", "createdAt");`
+        },
+        {
+          name: 'ReviewFindingDisposition_assessedArtifactVersionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ReviewFindingDisposition_assessedArtifactVersionId_idx" ON "ReviewFindingDisposition"("assessedArtifactVersionId");`
+        },
+        {
+          name: 'ReviewFindingDisposition_sourceFindingId_sequence_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ReviewFindingDisposition_sourceFindingId_sequence_key" ON "ReviewFindingDisposition"("sourceFindingId", "sequence");`
+        },
+        {
+          name: 'ReviewScopeSnapshot_reviewId_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ReviewScopeSnapshot_reviewId_key" ON "ReviewScopeSnapshot"("reviewId");`
+        },
+        {
+          name: 'ReviewScopeSnapshot_projectId_sessionId_state_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ReviewScopeSnapshot_projectId_sessionId_state_idx" ON "ReviewScopeSnapshot"("projectId", "sessionId", "state");`
+        },
+        {
+          name: 'ComputeJob_providerId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ComputeJob_providerId_idx" ON "ComputeJob"("providerId");`
+        },
+        {
+          name: 'ComputeJob_sessionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ComputeJob_sessionId_idx" ON "ComputeJob"("sessionId");`
+        },
+        {
+          name: 'ComputeJob_status_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ComputeJob_status_idx" ON "ComputeJob"("status");`
+        },
+        {
+          name: 'ComputeHost_providerId_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ComputeHost_providerId_key" ON "ComputeHost"("providerId");`
+        },
+        {
+          name: 'GrantedLocalRoot_path_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "GrantedLocalRoot_path_key" ON "GrantedLocalRoot"("path");`
+        }
+      ]
+    }
+  ] as const
+}
+
+export { databaseDomainConstraintsMigration }

--- a/src/main/database/sqlite-schema-migrations.ts
+++ b/src/main/database/sqlite-schema-migrations.ts
@@ -21,6 +21,23 @@ type SqliteCheckConstraintMigration = {
   canonicalTableDdl: string
 }
 
+type SqliteMigrationTable = {
+  tableName: string
+  canonicalTableDdl: string
+  columns: readonly string[]
+  optionalLegacyColumns?: readonly { name: string; definition: string }[]
+}
+
+type SqliteRebuildTableSetOperation = {
+  kind: 'rebuild-table-set'
+  version: 1
+  tables: readonly SqliteMigrationTable[]
+  dropOrder: readonly string[]
+  indexes: readonly string[]
+}
+
+type SqliteMigrationOperation = SqliteRebuildTableSetOperation
+
 const quoteIdentifier = (value: string): string => `"${value.replaceAll('"', '""')}"`
 const quoteLiteral = (value: string): string => `'${value.replaceAll("'", "''")}'`
 
@@ -89,6 +106,155 @@ const countRows = async (client: SqliteExecutor, tableName: string): Promise<big
     `SELECT COUNT(*) AS count FROM ${quoteIdentifier(tableName)}`
   )
   return BigInt(rows[0]?.count ?? 0)
+}
+
+const withOptionalLegacyColumns = (
+  canonicalTableDdl: string,
+  columns: readonly { name: string; definition: string }[]
+): string => {
+  if (columns.length === 0) return canonicalTableDdl
+  const constraintMarker = '\n    CONSTRAINT '
+  const markerIndex = canonicalTableDdl.indexOf(constraintMarker)
+  if (markerIndex === -1) {
+    throw new Error('Canonical SQLite DDL cannot preserve optional columns without constraints.')
+  }
+  const definitions = columns.map(({ definition }) => `    ${definition},`).join('\n')
+  return `${canonicalTableDdl.slice(0, markerIndex)}\n${definitions}${canonicalTableDdl.slice(markerIndex)}`
+}
+
+const applyRebuildTableSet = async (
+  client: SqliteExecutor,
+  operation: SqliteRebuildTableSetOperation
+): Promise<void> => {
+  const tableNames = new Set(operation.tables.map(({ tableName }) => tableName))
+  if (
+    tableNames.size !== operation.tables.length ||
+    operation.dropOrder.length !== tableNames.size ||
+    new Set(operation.dropOrder).size !== tableNames.size ||
+    operation.dropOrder.some((tableName) => !tableNames.has(tableName))
+  ) {
+    throw new Error('SQLite rebuild-table-set operation has an invalid table order.')
+  }
+
+  const prepared: Array<{
+    tableName: string
+    backupTableName: string
+    targetDdl: string
+    copyColumns: string[]
+    sourceRowCount: bigint
+  }> = []
+  for (const table of operation.tables) {
+    const sourceColumns = new Set(await readTableColumns(client, table.tableName))
+    const missingColumns = table.columns.filter((column) => !sourceColumns.has(column))
+    if (missingColumns.length > 0) {
+      throw new DatabaseValidationError(
+        `SQLite schema migration found missing columns in ${table.tableName}.`,
+        { kind: 'missing-columns', table: table.tableName, expected: missingColumns }
+      )
+    }
+    const optionalColumns = (table.optionalLegacyColumns ?? []).filter(({ name }) =>
+      sourceColumns.has(name)
+    )
+    const allowedColumns = new Set([
+      ...table.columns,
+      ...(table.optionalLegacyColumns ?? []).map(({ name }) => name)
+    ])
+    const unknownColumns = [...sourceColumns].filter((column) => !allowedColumns.has(column))
+    if (unknownColumns.length > 0) {
+      throw new DatabaseValidationError(
+        `SQLite schema migration blocked by unknown columns in ${table.tableName}.`,
+        { kind: 'unknown-columns', table: table.tableName, actual: unknownColumns }
+      )
+    }
+    prepared.push({
+      tableName: table.tableName,
+      backupTableName: `__open_science_rebuild_${table.tableName}`,
+      targetDdl: withOptionalLegacyColumns(table.canonicalTableDdl, optionalColumns),
+      copyColumns: [...table.columns, ...optionalColumns.map(({ name }) => name)],
+      sourceRowCount: await countRows(client, table.tableName)
+    })
+  }
+
+  for (const table of prepared) {
+    await migrationSqlExecutor.execute(
+      client,
+      `ALTER TABLE ${quoteIdentifier(table.tableName)} RENAME TO ${quoteIdentifier(table.backupTableName)}`
+    )
+  }
+  for (const table of prepared) await migrationSqlExecutor.execute(client, table.targetDdl)
+
+  for (const table of prepared) {
+    const quotedColumns = table.copyColumns.map(quoteIdentifier).join(', ')
+    try {
+      await migrationSqlExecutor.execute(
+        client,
+        `INSERT INTO ${quoteIdentifier(table.tableName)} (${quotedColumns}) SELECT ${quotedColumns} FROM ${quoteIdentifier(table.backupTableName)}`
+      )
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      if (!/CHECK constraint failed/i.test(detail)) throw error
+      throw new DatabaseValidationError(
+        `SQLite schema migration blocked by a CHECK constraint in ${table.tableName}.`,
+        {
+          kind: 'check-constraint-violation',
+          table: table.tableName
+        }
+      )
+    }
+    const targetRowCount = await countRows(client, table.tableName)
+    if (targetRowCount !== table.sourceRowCount) {
+      throw new DatabaseValidationError(
+        `SQLite schema migration found a row-count mismatch for ${table.tableName}.`,
+        {
+          kind: 'row-count-mismatch',
+          table: table.tableName,
+          expected: table.sourceRowCount,
+          actual: targetRowCount
+        }
+      )
+    }
+  }
+
+  const preparedByName = new Map(prepared.map((table) => [table.tableName, table]))
+  for (const tableName of operation.dropOrder) {
+    const table = preparedByName.get(tableName)!
+    await migrationSqlExecutor.execute(
+      client,
+      `DROP TABLE ${quoteIdentifier(table.backupTableName)}`
+    )
+  }
+  for (const index of operation.indexes) await migrationSqlExecutor.execute(client, index)
+
+  const violations = await migrationSqlExecutor.query<SqliteForeignKeyViolationRow[]>(
+    client,
+    'PRAGMA foreign_key_check'
+  )
+  if (violations.length > 0) {
+    const violation = violations[0]!
+    throw new DatabaseValidationError(
+      `SQLite schema migration introduced a foreign-key violation in ${violation.table}.`,
+      {
+        kind: 'foreign-key-violation',
+        table: violation.table,
+        constraint: String(violation.fkid),
+        expected: { parent: violation.parent },
+        actual: { rowid: violation.rowid }
+      }
+    )
+  }
+}
+
+const applySqliteMigrationOperations = async (
+  client: SqliteExecutor,
+  operations: readonly SqliteMigrationOperation[]
+): Promise<void> => {
+  for (const operation of operations) {
+    switch (operation.kind) {
+      case 'rebuild-table-set':
+        await applyRebuildTableSet(client, operation)
+        break
+    }
+  }
 }
 
 const rebuildTable = async (
@@ -196,5 +362,9 @@ const applySqliteCheckConstraints = async (
   }
 }
 
-export { applySqliteCheckConstraints, findPendingSqliteCheckConstraints }
-export type { SqliteCheckConstraintMigration }
+export {
+  applySqliteCheckConstraints,
+  applySqliteMigrationOperations,
+  findPendingSqliteCheckConstraints
+}
+export type { SqliteCheckConstraintMigration, SqliteMigrationOperation }

--- a/src/main/projects/prisma-client.test.ts
+++ b/src/main/projects/prisma-client.test.ts
@@ -106,7 +106,8 @@ describe('project prisma client (integration)', () => {
         '0002_project_agent_context',
         '0003_granted_local_roots',
         '0004_review_assessment_snapshots',
-        '0005_project_preview_state_owner_fk'
+        '0005_project_preview_state_owner_fk',
+        '0006_database_domain_constraints'
       ]
     })
 
@@ -1014,7 +1015,8 @@ describe('project prisma client (integration)', () => {
         '0002_project_agent_context',
         '0003_granted_local_roots',
         '0004_review_assessment_snapshots',
-        '0005_project_preview_state_owner_fk'
+        '0005_project_preview_state_owner_fk',
+        '0006_database_domain_constraints'
       ]
     })
 

--- a/src/main/reviewer/repository.ts
+++ b/src/main/reviewer/repository.ts
@@ -760,13 +760,16 @@ class ReviewRepository {
             )
           }
         }
+        const causeReviewId =
+          input.causeReviewId ??
+          (input.trigger === 'review_submission' ? assessmentReview.id : null)
         const eventId =
           input.eventId ??
           `review-disposition-${sha256(
             stableJson({
               reviewId: input.reviewId,
               sourceFindingId: input.sourceFindingId,
-              causeReviewId: input.causeReviewId ?? null,
+              causeReviewId,
               trigger: input.trigger
             })
           )}`
@@ -776,7 +779,7 @@ class ReviewRepository {
         if (existing) {
           if (
             existing.sourceFindingId !== finding.id ||
-            existing.causeReviewId !== (input.causeReviewId ?? null) ||
+            existing.causeReviewId !== causeReviewId ||
             existing.trigger !== input.trigger ||
             existing.outcome !== input.outcome ||
             existing.note !== (input.note ?? null) ||
@@ -804,7 +807,7 @@ class ReviewRepository {
             data: {
               id: eventId,
               sourceFindingId: finding.id,
-              causeReviewId: input.causeReviewId ?? null,
+              causeReviewId,
               sequence: (latest?.sequence ?? 0) + 1,
               trigger: input.trigger,
               outcome: input.outcome,


### PR DESCRIPTION
## Summary

- enforce SQLite `CHECK` constraints for Review, Finding, ReviewFindingDisposition, ComputeJob, ComputeHost, and GrantedLocalRoot domain state
- add migration 0006 with an atomic, backup-protected table-set rebuild for the related foreign-key graph
- verify constraints, indexes, row counts, foreign keys, migration checksums, and raw-write rejection behavior
- persist the inferred source review as `causeReviewId` for `review_submission` dispositions so existing repository behavior satisfies the new combination invariant

## Motivation and failure mode

These invariants were previously enforced mainly by TypeScript. Raw SQL, older/custom builds, unsafe casts, or database corruption could therefore persist unknown enum values, negative counters, or contradictory field combinations. Readers often fail closed or use fallbacks, which can hide the corrupt row, leave compute jobs outside polling/recovery queries, misclassify hosts or root access, and make reviewer audit history inconsistent.

## Compatibility

### Historical data

- valid existing rows are copied unchanged
- known retired Review columns (`summary`, `checks`, `reasoning`) and Finding `severity` are preserved when present
- invalid historical rows are not normalized silently: migration 0006 fails with a validation error, rolls back atomically, and leaves the migration ledger at 0005
- the migration requires and retains a pre-migration backup

### Enum values

No enum values are added or removed. This PR only makes the existing TypeScript value sets enforceable by SQLite. A future enum addition will require a schema/migration update.

### Persistence and product surface

- persistence schema and migration ledger change through migration 0006
- no new data fields and no renderer/API interaction changes
- the only write-path adjustment canonicalizes the already implied `causeReviewId` for review-submission dispositions

## Verification

- `npm run db:schema:check`
- `npm run lint`
- database/migration targeted tests: 8 files, 135 tests passed
- `npm run test:module -- compute_service`: 605 passed, 5 skipped
- `npm run test:module -- reviewer_orchestrator`: 450 passed
- `npm run test:module -- artifact_provenance`: 1268 passed
- full `npm test` intentionally not run; PR CI provides the complete suite

`npm run typecheck:node` currently fails in the latest default branch at `src/main/acp/runtime-coordinator.test.ts` because two fixtures still pass the removed `projectName` property. This PR does not modify that file or the related request types.
