### PR TITLE
refactor(session-state): centralize actionability projection

### DIFF
--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -1776,6 +1776,87 @@ describe('workspace agent message sending', () => {
     })
   })
 
+  it('rejects an ordinary runtime prompt while Plan approval owns the Session', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Create a plan',
+      cwd: '/workspace/project',
+      projectId: 'project-1'
+    })
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        status: 'waiting-plan-approval'
+      }))
+    }))
+    const runtime = {
+      state: createSnapshot(['transport-session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn()
+    }
+
+    const sent = await sendWorkspaceMessage(runtime, {
+      sessionId: 'transport-session-1',
+      text: 'start another turn',
+      cwd: '/workspace/project',
+      projectId: 'project-1'
+    })
+
+    expect(sent).toBeUndefined()
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
+  })
+
+  it('admits a main runtime prompt while only a delegated Permission is pending', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'transport-session-1',
+      content: 'Delegate research',
+      cwd: '/workspace/project',
+      projectId: 'project-1'
+    })
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        status: 'waiting-permission',
+        interactionState: { permission: true, elicitation: false, plan: false }
+      }))
+    }))
+    const snapshot = createSnapshot(['transport-session-1'])
+    snapshot.pendingPermissions = [
+      {
+        requestId: 'delegated-permission',
+        sessionId: 'transport-session-1',
+        toolCallId: 'delegated-tool',
+        title: 'Run delegated command',
+        options: [],
+        delegated: {
+          frameId: 'child-frame',
+          attemptId: 'attempt-1',
+          childTitle: 'Researcher',
+          riskScope: 'This call only'
+        }
+      }
+    ]
+    const runtime = {
+      state: snapshot,
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockResolvedValue(snapshot)
+    }
+
+    const sent = await sendWorkspaceMessage(runtime, {
+      sessionId: 'transport-session-1',
+      text: 'continue the main work',
+      cwd: '/workspace/project',
+      projectId: 'project-1'
+    })
+
+    expect(sent).toMatchObject({ sessionId: 'transport-session-1' })
+    expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+  })
+
   it('keeps the original Specialist replay clearing when the provider rejects the prompt', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -22,7 +22,7 @@ import {
   type HistoryReplayDescriptor
 } from './history-preamble'
 import {
-  isWorkspacePromptPreparationInFlight,
+  canPrepareExistingWorkspacePrompt,
   prepareExistingWorkspacePrompt
 } from './workspace-runtime-prompt-preparation-owner'
 import {
@@ -428,17 +428,15 @@ const sendWorkspaceMessage = async (
     const sessionId = input.sessionId
     const session = useSessionStore.getState().sessions.find((item) => item.id === sessionId)
     if (input.requireExistingSession && !session) return undefined
-    if (isWorkspacePromptPreparationInFlight(sessionId)) return undefined
     if (
-      runtime.state.promptInFlightSessionIds.includes(sessionId) ||
-      (session?.isPending && session.status === 'idle' && Boolean(session.branchSource)) ||
-      (session?.compacting && !input.allowCompactionRecovery) ||
-      session?.status === 'running' ||
-      session?.status === 'waiting-for-user' ||
-      session?.status === 'waiting-permission'
-    ) {
+      !canPrepareExistingWorkspacePrompt({
+        sessionId,
+        session,
+        runtimeState: runtime.state,
+        allowCompactionRecovery: input.allowCompactionRecovery === true
+      })
+    )
       return undefined
-    }
     const projectId = input.projectId ?? session?.projectId
     if (input.planContinuation && !projectId) return undefined
 

--- a/src/renderer/src/lib/acp/workspace-runtime-prompt-preparation-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-prompt-preparation-owner.ts
@@ -1,4 +1,4 @@
-import type { AcpMessageImage } from '../../../../shared/acp'
+import type { AcpMessageImage, AcpStateSnapshot } from '../../../../shared/acp'
 import type { AgentFrameworkId } from '../../../../shared/settings'
 import type { PermissionProfileId } from '../../../../shared/permission-profiles'
 import {
@@ -9,7 +9,13 @@ import {
   RESUME_WORKSPACE_MISSING_MESSAGE
 } from '../../../../shared/run-error-classification'
 import { imageAttachmentMimeType, type UploadedAttachment } from '../../../../shared/uploads'
-import { useSessionStore, type ChatMessage } from '../../stores/session-store'
+import {
+  projectSessionActionability,
+  resolveRootPermissionPending,
+  useSessionStore,
+  type ChatMessage,
+  type ChatSession
+} from '../../stores/session-store'
 import {
   buildWorkspaceHistoryReplay,
   resolveHistoryReplayTarget,
@@ -67,6 +73,33 @@ type PreparedExistingWorkspacePrompt = {
   replay: () => PreparedWorkspacePromptReplay
   acceptPrompt: (messageId: string) => void
 }
+
+type ExistingWorkspacePromptAdmission = Readonly<{
+  sessionId: string
+  session: ChatSession | undefined
+  runtimeState: Pick<AcpStateSnapshot, 'pendingPermissions' | 'promptInFlightSessionIds'>
+  allowCompactionRecovery: boolean
+}>
+
+const canPrepareExistingWorkspacePrompt = ({
+  sessionId,
+  session,
+  runtimeState,
+  allowCompactionRecovery
+}: ExistingWorkspacePromptAdmission): boolean =>
+  !isWorkspacePromptPreparationInFlight(sessionId) &&
+  !runtimeState.promptInFlightSessionIds.includes(sessionId) &&
+  (!session?.compacting || allowCompactionRecovery) &&
+  (!session ||
+    projectSessionActionability(session, {
+      rootPermissionPending: resolveRootPermissionPending(
+        runtimeState.pendingPermissions,
+        sessionId
+      ),
+      allowPendingSessionRetry: Boolean(
+        session.isPending && (session.status !== 'idle' || !session.branchSource)
+      )
+    }).actions.startTurn.allowed)
 
 const isReplayImage = (attachment: Pick<UploadedAttachment, 'name' | 'mimeType'>): boolean =>
   imageAttachmentMimeType(attachment.name, attachment.mimeType) !== undefined
@@ -385,6 +418,7 @@ const prepareExistingWorkspacePrompt = async (
 
 export {
   acquireWorkspacePromptPreparation,
+  canPrepareExistingWorkspacePrompt,
   getResumeFailureMessage,
   isWorkspacePromptPreparationInFlight,
   prepareExistingWorkspacePrompt,

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -46,16 +46,13 @@ import { NotificationBell } from '@/components/NotificationBell'
 import { ThemePreferenceMenu } from '@/components/ThemeControls'
 import { UpdateCapsule } from '@/components/UpdateCapsule'
 import { APP } from '../../../../shared/app-config'
-import {
-  earliestCurrentDelegatedAttemptStartedAt,
-  hasCurrentRunningDelegatedAttempt
-} from '../../../../shared/delegated-work-projection'
+import { earliestCurrentDelegatedAttemptStartedAt } from '../../../../shared/delegated-work-projection'
 import type { Project } from '../../../../shared/projects'
 import type { EnvironmentCheckItem, EnvironmentCheckResult } from '../../../../shared/settings'
 import { getEnvironmentRepairPanel } from '../settings/settings-navigation'
 import {
   isSessionWaitReason,
-  resolveSessionWaitReason,
+  projectPresentedSessionActionability,
   sessionWaitReasonLabelKeys,
   type SessionWaitReason
 } from '../workspace/session-wait-reason'
@@ -117,9 +114,9 @@ const getRequiredEnvironmentFailures = (
 ): EnvironmentCheckItem[] => environment?.checks.filter((check) => check.status === 'failed') ?? []
 
 const getHomeSessionActivity = (session: ChatSession): HomeSessionActivity | undefined => {
-  const waitReason = resolveSessionWaitReason(session)
-  if (waitReason) return waitReason
-  if (session.status === 'running' || hasCurrentRunningDelegatedAttempt(session)) return 'running'
+  const actionability = projectPresentedSessionActionability(session)
+  if (actionability.waitReason) return actionability.waitReason
+  if (actionability.activity === 'running') return 'running'
   return undefined
 }
 
@@ -403,11 +400,7 @@ const HomePage = ({
     !sessions.some(
       (session) =>
         session.projectId === project.id &&
-        (hasCurrentRunningDelegatedAttempt(session) ||
-          session.status === 'running' ||
-          session.status === 'waiting-for-user' ||
-          session.status === 'waiting-permission' ||
-          session.status === 'waiting-plan-approval')
+        projectPresentedSessionActionability(session).activity !== 'inactive'
     )
 
   const archiveUnavailableReason = (project: Project): string | undefined => {

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -677,6 +677,46 @@ describe('ConversationPanel composer intake', () => {
     expect(getComposerForm().contains(getComposerEditor())).toBe(true)
   })
 
+  it('keeps delegated Permission in the transcript without taking the main Composer lane', () => {
+    const activeSession: ChatSession = {
+      id: 'session-delegated-permission',
+      projectId: 'project-a',
+      title: 'Delegated permission',
+      cwd: '/workspace',
+      status: 'waiting-permission',
+      interactionState: { permission: true, elicitation: false, plan: false },
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    renderPanel({
+      view: { activeSession },
+      conversation: { availability: { submit: true } },
+      permissions: {
+        requests: [
+          {
+            requestId: 'permission-delegated',
+            sessionId: activeSession.id,
+            toolCallId: 'tool-delegated',
+            title: 'Run delegated command',
+            options: [],
+            delegated: {
+              frameId: 'child-frame',
+              attemptId: 'attempt-1',
+              childTitle: 'Researcher',
+              riskScope: 'This call only'
+            }
+          }
+        ]
+      }
+    })
+
+    expect(container.querySelector('[data-testid="permission-composer"]')).toBeNull()
+    expect(container.querySelector('[data-testid="permission-approval-controls"]')).not.toBeNull()
+    expect(getComposerForm().hidden).toBe(false)
+    expect(getComposerEditor().getAttribute('contenteditable')).toBe('true')
+  })
+
   it('advances to the next Subagent request after Finish and removes an empty queue', async () => {
     const firstSession = delegatedQuestionSession()
     const graph = firstSession.conversationGraph!

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -57,7 +57,11 @@ import {
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useFileDropZone } from '@/hooks/useFileDropZone'
 import { cn } from '@/lib/utils'
-import { useSessionStore, type ChatSession } from '@/stores/session-store'
+import {
+  projectSessionActionability,
+  useSessionStore,
+  type ChatSession
+} from '@/stores/session-store'
 import { useSessionJobStore } from '@/stores/session-job-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import { useSpecialistStore } from '@/stores/specialist-store'
@@ -486,14 +490,6 @@ const ConversationPanel = ({
     ? t('Wait for all subagents to finish.')
     : saveAsSkillDisabledReasonFromParent
   const effectiveCanSend = canSendMessage && !isStopping
-  const rootTurnBusy =
-    activeSession?.status === 'running' ||
-    activeSession?.status === 'waiting-for-user' ||
-    (activeSession?.status === 'waiting-permission' &&
-      (pendingPermissions.length === 0 ||
-        pendingPermissions.some((permission) => !permission.delegated))) ||
-    activeSession?.compacting === true ||
-    activeSession?.fixLoopActive === true
   const activePendingPlan = activeBranchPlan?.approval === 'pending' ? activeBranchPlan : undefined
   const activePendingPlanKey = activePendingPlan
     ? `${activePendingPlan.artifactVersionId}:${activePendingPlan.revision}`
@@ -577,10 +573,38 @@ const ConversationPanel = ({
             state: 'pending'
           }
         : undefined
-  const hasPendingPermission = pendingPermissions.length > 0
+  const rootPermissionRequests = pendingPermissions.filter((request) => !request.delegated)
+  const rootPermissionPending =
+    rootPermissionRequests.length > 0 ? true : pendingPermissions.length > 0 ? false : undefined
+  const actionability = activeSession
+    ? projectSessionActionability(activeSession, {
+        rootPermissionPending,
+        elicitationPending: pendingElicitation ? true : undefined,
+        planPending:
+          pendingPlan !== undefined
+            ? true
+            : activePendingPlanKey && resolvedPlanKey === activePendingPlanKey
+              ? false
+              : undefined
+      })
+    : undefined
+  const blockingInteraction =
+    actionability?.blockingInteraction ??
+    (rootPermissionRequests.length > 0
+      ? 'permission'
+      : pendingElicitation
+        ? 'elicitation'
+        : pendingPlan
+          ? 'plan'
+          : undefined)
+  const hasPendingPermission = blockingInteraction === 'permission'
   const delegatedQuestion = projectDelegatedQuestionQueue(activeSession)[0]
-  const ordinaryComposerBlocked = Boolean(
-    sideChat || hasPendingPermission || pendingElicitation || pendingPlan
+  const ordinaryComposerBlocked = Boolean(sideChat || blockingInteraction)
+  const rootTurnBusy = Boolean(
+    blockingInteraction ||
+    actionability?.activity === 'running' ||
+    activeSession?.compacting ||
+    activeSession?.fixLoopActive
   )
 
   // Re-attaches the interrupted session; on success the banner unmounts, so guard the state update.
@@ -654,9 +678,7 @@ const ConversationPanel = ({
   const canStartSideChat =
     Boolean(activeSession) &&
     hasMainConversation(activeSession) &&
-    activeSession?.status !== 'waiting-for-user' &&
-    activeSession?.status !== 'waiting-permission' &&
-    activeSession?.status !== 'waiting-plan-approval' &&
+    actionability?.actions.startSideChat.allowed !== false &&
     canEditDraft &&
     hasTextDraft &&
     attachments.length === 0 &&
@@ -1009,9 +1031,9 @@ const ConversationPanel = ({
                       }
                     />
                   ) : hasPendingPermission ? (
-                    <ResizablePermissionComposer key={pendingPermissions[0]?.requestId}>
+                    <ResizablePermissionComposer key={rootPermissionRequests[0]?.requestId}>
                       <PermissionApprovalControls
-                        requests={pendingPermissions}
+                        requests={rootPermissionRequests}
                         onRespond={onRespondToPermission}
                         embedded
                         notebookLookup={

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -19,7 +19,11 @@ import {
   PROJECT_FILES_PREVIEW_ID,
   usePreviewWorkbenchStore
 } from '@/stores/preview-workbench-store'
-import { useSessionStore } from '@/stores/session-store'
+import {
+  projectSessionActionability,
+  resolveRootPermissionPending,
+  useSessionStore
+} from '@/stores/session-store'
 import { useSpecialistStore } from '@/stores/specialist-store'
 import { selectProjectSessionReviews, useReviewStore } from '@/stores/review-store'
 import {
@@ -51,10 +55,7 @@ import { SessionNotebookDialog } from './SessionNotebookDialog'
 import { JobDetailModal } from '@/components/JobDetailModal'
 import { useProjectFormDialog } from '@/hooks/useProjectFormDialog'
 import { ProjectFormDialog } from '../home/ProjectFormDialog'
-import {
-  getVisiblePermissionRequests,
-  hasBlockingRootPermissionRequest
-} from './session-permissions'
+import { getVisiblePermissionRequests } from './session-permissions'
 import { WorkspaceSidebarContainer } from './WorkspaceSidebarContainer'
 import { useJobAnalysisEffect } from '@/lib/compute/useJobAnalysisEffect'
 import { WorkspacePanelLayout } from './workspace-panel-layout'
@@ -421,6 +422,11 @@ const WorkspacePage = ({
     () => pendingWorkspaceElicitations(activeSession),
     [activeSession]
   )
+  const activeSessionActionability = activeSession
+    ? projectSessionActionability(activeSession, {
+        rootPermissionPending: resolveRootPermissionPending(pendingPermissions, activeSession.id)
+      })
+    : undefined
   const activeNotebookReference = activeSession ? notebookReferences[activeSession.id] : undefined
   const activePermissionProfile =
     activeSession?.permissionProfile ?? newConversationPermissionProfile
@@ -468,10 +474,7 @@ const WorkspacePage = ({
     promptInFlightSessionIds,
     sendPreparationInFlightSessionIds,
     saveAsSkillInFlightSessionIds,
-    hasBlockingRootPermissionRequest: hasBlockingRootPermissionRequest(
-      pendingPermissions,
-      activeSession?.id
-    ),
+    actionability: activeSessionActionability,
     newConversationAutoReviewEnabled,
     newConversationEnabledComputeHosts,
     composer,
@@ -566,9 +569,7 @@ const WorkspacePage = ({
   }, [activeSession?.id, activeSessionSaveAsSkillPending, canEditMessage])
   const canChangeAgentControls =
     isSessionPersistenceReady &&
-    activeSession?.status !== 'running' &&
-    activeSession?.status !== 'waiting-for-user' &&
-    activeSession?.status !== 'waiting-permission' &&
+    activeSessionActionability?.actions.changeAgentControls.allowed !== false &&
     !activeSessionHasRuntimeInteraction &&
     !activeSession?.compacting
   const canChangePermissionProfile =

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -39,7 +39,10 @@ import type { ChatSession, SessionStatus } from '@/stores/session-store'
 import type { ConversationExportFormat } from '../../../../shared/conversation-export'
 import { NotificationBell } from '@/components/NotificationBell'
 
-import { resolveSessionWaitReason, sessionWaitReasonLabelKeys } from './session-wait-reason'
+import {
+  projectPresentedSessionActionability,
+  sessionWaitReasonLabelKeys
+} from './session-wait-reason'
 
 type WorkspaceSidebarProps = {
   projectName: string
@@ -113,16 +116,11 @@ const OPEN_DIALOG_SELECTOR =
   '[role="dialog"]:not([data-state="closed"]), [role="alertdialog"]:not([data-state="closed"])'
 
 const getPresentedSessionStatus = (session: ChatSession): SessionStatus =>
-  resolveSessionWaitReason(session) ?? session.status
+  projectPresentedSessionActionability(session).presentedStatus
 
 const isLiveSession = (session: ChatSession): boolean => {
-  const status = getPresentedSessionStatus(session)
-  return (
-    status === 'running' ||
-    status === 'waiting-for-user' ||
-    status === 'waiting-permission' ||
-    status === 'waiting-plan-approval'
-  )
+  const activity = projectPresentedSessionActionability(session).activity
+  return activity === 'running' || activity === 'waiting'
 }
 
 // The label is English source text that travels to the header as data, so it is translated where it

--- a/src/renderer/src/pages/workspace/agent-loading-message.ts
+++ b/src/renderer/src/pages/workspace/agent-loading-message.ts
@@ -1,4 +1,9 @@
-import type { ChatMessage, ChatSession, ToolActivity } from '@/stores/session-store'
+import {
+  projectSessionActionability,
+  type ChatMessage,
+  type ChatSession,
+  type ToolActivity
+} from '@/stores/session-store'
 
 type TimelinePosition = {
   updatedAt: number
@@ -61,12 +66,16 @@ const getAgentThinkingStartedAt = (session: ChatSession | undefined): number | u
 // own indicator phases.
 const getAgentLoadingPhase = (session: ChatSession | undefined): AgentLoadingPhase => {
   if (!session) return 'hidden'
-  if (session.status === 'waiting-for-user') return 'waiting-for-response'
-  if (session.status === 'waiting-permission' || session.status === 'waiting-plan-approval') {
+  const actionability = projectSessionActionability(session)
+  if (actionability.waitReason === 'waiting-for-user') return 'waiting-for-response'
+  if (
+    actionability.waitReason === 'waiting-permission' ||
+    actionability.waitReason === 'waiting-plan-approval'
+  ) {
     return 'waiting-for-approval'
   }
 
-  const hasLocalRun = Boolean(session.activeRun) && session.status === 'running'
+  const hasLocalRun = Boolean(session.activeRun) && actionability.activity === 'running'
   if (!hasLocalRun && !session.agentPromptInFlight) return 'hidden'
 
   const { prompt, tools: currentRunTools } = getCurrentRunTimeline(session)

--- a/src/renderer/src/pages/workspace/session-permissions.test.ts
+++ b/src/renderer/src/pages/workspace/session-permissions.test.ts
@@ -1,10 +1,8 @@
 import type { AcpPermissionRequest } from '../../../../shared/acp'
 import { describe, expect, it } from 'vitest'
+import { resolveRootPermissionPending } from '@/stores/session-store'
 
-import {
-  getVisiblePermissionRequests,
-  hasBlockingRootPermissionRequest
-} from './session-permissions'
+import { getVisiblePermissionRequests } from './session-permissions'
 import { createLinearConversationGraph } from '../../../../shared/conversation-graph'
 
 // Creates a permission request with ids derived from the target session.
@@ -84,9 +82,10 @@ describe('workspace session permissions', () => {
         riskScope: 'This call only'
       }
     }
-    expect(hasBlockingRootPermissionRequest([delegated], 'session-1')).toBe(false)
-    expect(
-      hasBlockingRootPermissionRequest([createPermissionRequest('session-1')], 'session-1')
-    ).toBe(true)
+    expect(resolveRootPermissionPending([delegated], 'session-1')).toBe(false)
+    expect(resolveRootPermissionPending([createPermissionRequest('session-1')], 'session-1')).toBe(
+      true
+    )
+    expect(resolveRootPermissionPending([], 'session-1')).toBeUndefined()
   })
 })

--- a/src/renderer/src/pages/workspace/session-permissions.ts
+++ b/src/renderer/src/pages/workspace/session-permissions.ts
@@ -26,15 +26,4 @@ const getVisiblePermissionRequests = (
   })
 }
 
-const hasBlockingRootPermissionRequest = (
-  pendingPermissions: readonly AcpPermissionRequest[],
-  activeSessionId: string | undefined
-): boolean =>
-  Boolean(
-    activeSessionId &&
-    pendingPermissions.some(
-      (request) => request.sessionId === activeSessionId && request.delegated === undefined
-    )
-  )
-
-export { getVisiblePermissionRequests, hasBlockingRootPermissionRequest }
+export { getVisiblePermissionRequests }

--- a/src/renderer/src/pages/workspace/session-wait-reason.ts
+++ b/src/renderer/src/pages/workspace/session-wait-reason.ts
@@ -1,14 +1,15 @@
-import type {
-  PersistedChatSession,
-  PersistedSessionStatus
-} from '../../../../shared/session-persistence'
+import type { PersistedChatSession } from '../../../../shared/session-persistence'
+import {
+  isSessionWaitReason,
+  projectSessionActionability,
+  type SessionActionabilityProjection,
+  type SessionWaitReason as StoreSessionWaitReason
+} from '@/stores/session-store'
+import { hasCurrentRunningDelegatedAttempt } from '../../../../shared/delegated-work-projection'
 
 import { hasAnswerableDelegatedQuestion } from './subagent-release-projection'
 
-export type SessionWaitReason = Extract<
-  PersistedSessionStatus,
-  'waiting-for-user' | 'waiting-permission' | 'waiting-plan-approval'
->
+export type SessionWaitReason = StoreSessionWaitReason
 
 export const sessionWaitReasonLabelKeys = {
   'waiting-for-user': 'Waiting for your answer',
@@ -16,14 +17,16 @@ export const sessionWaitReasonLabelKeys = {
   'waiting-plan-approval': 'Waiting for plan approval'
 } as const satisfies Record<SessionWaitReason, string>
 
-export const isSessionWaitReason = (status: string): status is SessionWaitReason =>
-  status === 'waiting-for-user' ||
-  status === 'waiting-permission' ||
-  status === 'waiting-plan-approval'
+export { isSessionWaitReason }
+
+export const projectPresentedSessionActionability = (
+  session: PersistedChatSession
+): SessionActionabilityProjection =>
+  projectSessionActionability(session, {
+    presentedWaitReason: hasAnswerableDelegatedQuestion(session) ? 'waiting-for-user' : undefined,
+    hasRunningWork: hasCurrentRunningDelegatedAttempt(session)
+  })
 
 export const resolveSessionWaitReason = (
   session: PersistedChatSession
-): SessionWaitReason | undefined => {
-  if (isSessionWaitReason(session.status)) return session.status
-  return hasAnswerableDelegatedQuestion(session) ? 'waiting-for-user' : undefined
-}
+): SessionWaitReason | undefined => projectPresentedSessionActionability(session).waitReason

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
@@ -3,8 +3,11 @@ import { act, createElement } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import type { ChatSession } from '@/stores/session-store'
-import { useSessionStore } from '@/stores/session-store'
+import {
+  projectSessionActionability,
+  type ChatSession,
+  useSessionStore
+} from '@/stores/session-store'
 
 import type { ComposerDoc } from './composer/composer-doc'
 import {
@@ -43,8 +46,9 @@ const options = (
   overrides: Partial<WorkspaceConversationControllerOptions> = {}
 ): WorkspaceConversationControllerOptions => {
   const doc = textDoc('hello')
+  const activeSession = overrides.activeSession ?? session()
   return {
-    activeSession: session(),
+    activeSession,
     projectId: 'project-a',
     currentDraftKey: 'session-a',
     isPersistenceReady: true,
@@ -54,7 +58,7 @@ const options = (
     promptInFlightSessionIds: [],
     sendPreparationInFlightSessionIds: [],
     saveAsSkillInFlightSessionIds: [],
-    hasBlockingRootPermissionRequest: false,
+    actionability: projectSessionActionability(activeSession),
     newConversationAutoReviewEnabled: false,
     newConversationEnabledComputeHosts: [],
     composer: {
@@ -312,13 +316,34 @@ describe('workspace conversation controller', () => {
   })
 
   it('blocks submit while a selected branched Session is still binding', () => {
-    const input = options({ activeSession: session({ isPending: true }) })
+    const pendingSession = session({ isPending: true })
+    const input = options({
+      activeSession: pendingSession,
+      actionability: projectSessionActionability(pendingSession)
+    })
     const hook = renderController(input)
     mounted.push(hook)
 
     expect(hook.result.current.availability.submit).toBe(false)
     act(() => hook.result.current.actions.submit.draft({ forcedSkillIds: [] }))
     expect(input.runtime.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('keeps the main Turn available for a delegated Permission', () => {
+    const delegatedWait = session({
+      status: 'waiting-permission',
+      interactionState: { permission: true, elicitation: false, plan: false }
+    })
+    const input = options({
+      activeSession: delegatedWait,
+      actionability: projectSessionActionability(delegatedWait, {
+        rootPermissionPending: false
+      })
+    })
+    const hook = renderController(input)
+    mounted.push(hook)
+
+    expect(hook.result.current.availability).toMatchObject({ submit: true, revise: true })
   })
 
   it('blocks submit and revision while Save as skill owns prompt admission', () => {
@@ -512,6 +537,7 @@ describe('workspace conversation controller', () => {
     const blocked = options({
       ...input,
       activeSession: session({ status: 'running' }),
+      actionability: projectSessionActionability(session({ status: 'running' })),
       runtime: input.runtime,
       composer: input.composer,
       session: input.session

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
@@ -1,7 +1,7 @@
 import { useLayoutEffect, useRef, useState } from 'react'
 
 import type { PermissionProfileId } from '../../../../shared/permission-profiles'
-import type { ChatSession } from '@/stores/session-store'
+import type { ChatSession, SessionActionabilityProjection } from '@/stores/session-store'
 import type { WorkspaceAgentRuntime } from '@/lib/acp/useWorkspaceAgentRuntime'
 
 import {
@@ -71,7 +71,7 @@ type WorkspaceConversationControllerOptions = {
   promptInFlightSessionIds: string[]
   sendPreparationInFlightSessionIds: string[]
   saveAsSkillInFlightSessionIds: string[]
-  hasBlockingRootPermissionRequest: boolean
+  actionability: SessionActionabilityProjection | undefined
   newConversationAutoReviewEnabled: boolean
   newConversationEnabledComputeHosts: string[]
   composer: ConversationComposer
@@ -126,10 +126,7 @@ const canSubmit = (options: WorkspaceConversationControllerOptions): boolean => 
     !options.sideChatOpen &&
     composer.view.transfers.length === 0 &&
     (!docIsEmpty(composer.view.doc) || composer.view.attachments.length > 0) &&
-    !activeSession?.isPending &&
-    activeSession?.status !== 'running' &&
-    activeSession?.status !== 'waiting-for-user' &&
-    (activeSession?.status !== 'waiting-permission' || !options.hasBlockingRootPermissionRequest) &&
+    (options.actionability?.actions.startTurn.allowed ?? true) &&
     !hasRuntimeInteraction(options) &&
     !activeSession?.fixLoopActive &&
     !activeSession?.conversationGraphSyncBlocked &&
@@ -144,9 +141,7 @@ const canRevise = (options: WorkspaceConversationControllerOptions): boolean => 
     options.isPersistenceReady &&
     !options.sideChatOpen &&
     composer.view.transfers.length === 0 &&
-    activeSession?.status !== 'running' &&
-    activeSession?.status !== 'waiting-for-user' &&
-    activeSession?.status !== 'waiting-permission' &&
+    (options.actionability?.actions.revise.allowed ?? true) &&
     !hasRuntimeInteraction(options) &&
     !options.isReviewing &&
     !activeSession?.fixLoopActive &&
@@ -160,12 +155,8 @@ const canBranch = (options: WorkspaceConversationControllerOptions): boolean =>
   Boolean(
     options.isPersistenceReady &&
     options.activeSession &&
-    !options.activeSession.isPending &&
     !options.activeSession.activeRun &&
-    options.activeSession.status !== 'running' &&
-    options.activeSession.status !== 'waiting-for-user' &&
-    options.activeSession.status !== 'waiting-permission' &&
-    options.activeSession.status !== 'waiting-plan-approval' &&
+    options.actionability?.actions.branchFromMessage.allowed !== false &&
     !options.activeSession.fixLoopActive &&
     !options.activeSession.compacting &&
     !options.activeSession.branchSwitchBlocked &&
@@ -183,9 +174,7 @@ const canStartSideChat = (options: WorkspaceConversationControllerOptions): bool
     hasMainConversation(options.activeSession) &&
     !options.sideChatOpen &&
     options.isPersistenceReady &&
-    options.activeSession.status !== 'waiting-for-user' &&
-    options.activeSession.status !== 'waiting-permission' &&
-    options.activeSession.status !== 'waiting-plan-approval' &&
+    options.actionability?.actions.startSideChat.allowed !== false &&
     options.composer.view.transfers.length === 0 &&
     options.composer.view.attachments.length === 0 &&
     docToText(options.composer.view.doc).trim()

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -8,7 +8,7 @@ import type {
 import { hasCurrentRunningDelegatedAttempt } from '../../../../shared/delegated-work-projection'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useArchiveUndoStore } from '@/stores/archive-undo-store'
-import type { ChatSession } from '@/stores/session-store'
+import { projectSessionActionability, type ChatSession } from '@/stores/session-store'
 import { useSessionStore } from '@/stores/session-store'
 
 type ReconfigureError = {
@@ -192,9 +192,7 @@ const useWorkspaceSessionController = ({
   const activeHasPendingSwitch = Boolean(
     activeSession &&
     activeHasPending &&
-    (activeSession.status === 'running' ||
-      activeSession.status === 'waiting-for-user' ||
-      activeSession.status === 'waiting-permission')
+    projectSessionActionability(activeSession).activity !== 'inactive'
   )
 
   const setBarrier = useCallback((sessionId: string, inFlight: boolean): void => {
@@ -225,11 +223,9 @@ const useWorkspaceSessionController = ({
     !promptInFlightSessionIds.includes(session.id) &&
     !sendPreparationInFlightSessionIds.includes(session.id) &&
     !saveAsSkillInFlightSessionIds.includes(session.id) &&
-    session.status !== 'running' &&
-    session.status !== 'waiting-for-user' &&
-    session.status !== 'waiting-permission' &&
-    session.status !== 'waiting-plan-approval' &&
-    !hasCurrentRunningDelegatedAttempt(session) &&
+    projectSessionActionability(session, {
+      hasRunningWork: hasCurrentRunningDelegatedAttempt(session)
+    }).actions.archive.allowed &&
     !hasUnfinishedTransfers(session.id)
 
   const openRename = (session: ChatSession): void => {
@@ -309,10 +305,7 @@ const useWorkspaceSessionController = ({
     }
     const sessionId = activeSession.id
     if (barrierInFlightRef.current.has(sessionId)) return
-    const running =
-      activeSession.status === 'running' ||
-      activeSession.status === 'waiting-for-user' ||
-      activeSession.status === 'waiting-permission'
+    const running = projectSessionActionability(activeSession).activity !== 'inactive'
     if (running) {
       setPendingSpecialists((current) => ({ ...current, [sessionId]: specialistId }))
     } else {

--- a/src/renderer/src/stores/session-store-interaction-state.ts
+++ b/src/renderer/src/stores/session-store-interaction-state.ts
@@ -6,12 +6,86 @@ export type SessionInteractionState = Readonly<{
   plan: boolean
 }>
 
-const isWaitingStatus = (status: SessionStatus): boolean =>
+export type SessionWaitReason = Extract<
+  SessionStatus,
+  'waiting-for-user' | 'waiting-permission' | 'waiting-plan-approval'
+>
+
+export type SessionBlockingInteraction = 'permission' | 'elicitation' | 'plan'
+
+export type SessionActionDisabledReason =
+  | 'session-running'
+  | 'session-pending'
+  | 'permission-pending'
+  | 'elicitation-pending'
+  | 'plan-approval-pending'
+
+export type SessionActionAvailability = Readonly<{
+  allowed: boolean
+  disabledReason?: SessionActionDisabledReason
+}>
+
+export type SessionActionabilityFacts = Readonly<{
+  presentedWaitReason?: SessionWaitReason
+  hasRunningWork?: boolean
+  rootPermissionPending?: boolean
+  elicitationPending?: boolean
+  planPending?: boolean
+  allowPendingSessionRetry?: boolean
+}>
+
+export type SessionActionabilityProjection = Readonly<{
+  presentedStatus: SessionStatus
+  activity: 'inactive' | 'running' | 'waiting'
+  attentionOwner: 'none' | 'agent' | 'user'
+  waitReason?: SessionWaitReason
+  blockingInteraction?: SessionBlockingInteraction
+  actions: Readonly<{
+    startTurn: SessionActionAvailability
+    revise: SessionActionAvailability
+    branchFromMessage: SessionActionAvailability
+    startSideChat: SessionActionAvailability
+    changeAgentControls: SessionActionAvailability
+    archive: SessionActionAvailability
+  }>
+}>
+
+type SessionInteractionSource = Readonly<{
+  status: SessionStatus
+  interactionState?: SessionInteractionState
+  runtimeContext?: ChatSession['runtimeContext']
+  activities?: readonly {
+    elicitation?: {
+      state: string
+      durable?: { kind: string }
+    }
+  }[]
+  activeRun?: unknown
+  agentPromptInFlight?: boolean
+  isPending?: boolean
+}>
+
+type SessionPermissionRequest = Readonly<{
+  sessionId: string
+  delegated?: unknown
+}>
+
+export const resolveRootPermissionPending = (
+  pendingPermissions: readonly SessionPermissionRequest[],
+  sessionId: string | undefined
+): boolean | undefined => {
+  if (!sessionId) return undefined
+  const sessionRequests = pendingPermissions.filter((request) => request.sessionId === sessionId)
+  if (sessionRequests.length === 0) return undefined
+  return sessionRequests.some((request) => request.delegated === undefined)
+}
+
+export const isSessionWaitReason = (status: string): status is SessionWaitReason =>
   status === 'waiting-permission' ||
   status === 'waiting-for-user' ||
   status === 'waiting-plan-approval'
 
-const hasPendingDurableElicitation = (session: ChatSession): boolean =>
+const hasPendingDurableElicitation = (session: SessionInteractionSource): boolean =>
   (session.status === 'waiting-for-user' || session.status === 'waiting-permission') &&
   session.activities?.some(
     (activity) =>
@@ -19,8 +93,10 @@ const hasPendingDurableElicitation = (session: ChatSession): boolean =>
       activity.elicitation.durable?.kind === 'agent-user-choice'
   ) === true
 
-export const inferSessionInteractionState = (session: ChatSession): SessionInteractionState =>
-  session.interactionState && isWaitingStatus(session.status)
+export const inferSessionInteractionState = (
+  session: SessionInteractionSource
+): SessionInteractionState =>
+  session.interactionState && isSessionWaitReason(session.status)
     ? session.interactionState
     : {
         permission:
@@ -34,14 +110,90 @@ export const inferSessionInteractionState = (session: ChatSession): SessionInter
       }
 
 export const resolveSessionInteractionStatus = (
-  session: ChatSession,
+  session: SessionInteractionSource,
   interactionState: SessionInteractionState = inferSessionInteractionState(session)
 ): SessionStatus => {
   if (interactionState.permission) return 'waiting-permission'
   if (interactionState.elicitation) return 'waiting-for-user'
   if (interactionState.plan) return 'waiting-plan-approval'
-  if (!isWaitingStatus(session.status)) return session.status
+  if (!isSessionWaitReason(session.status)) return session.status
   return session.activeRun || session.agentPromptInFlight ? 'running' : 'idle'
+}
+
+const actionAvailability = (
+  disabledReason: SessionActionDisabledReason | undefined
+): SessionActionAvailability =>
+  disabledReason ? { allowed: false, disabledReason } : { allowed: true }
+
+const disabledReasonForInteraction = (
+  interaction: SessionBlockingInteraction | undefined
+): SessionActionDisabledReason | undefined => {
+  if (interaction === 'permission') return 'permission-pending'
+  if (interaction === 'elicitation') return 'elicitation-pending'
+  if (interaction === 'plan') return 'plan-approval-pending'
+  return undefined
+}
+
+export const projectSessionActionability = (
+  session: SessionInteractionSource,
+  facts: SessionActionabilityFacts = {}
+): SessionActionabilityProjection => {
+  const interactionState = inferSessionInteractionState(session)
+  const status = resolveSessionInteractionStatus(session, interactionState)
+  const waitReason = isSessionWaitReason(status) ? status : facts.presentedWaitReason
+  const running = !waitReason && (status === 'running' || facts.hasRunningWork === true)
+  const durableRootPermissionPending = session.runtimeContext?.permission?.state === 'pending'
+  const permissionPending =
+    durableRootPermissionPending || (facts.rootPermissionPending ?? interactionState.permission)
+  const elicitationPending = facts.elicitationPending ?? interactionState.elicitation
+  const planPending = facts.planPending ?? interactionState.plan
+  const blockingInteraction: SessionBlockingInteraction | undefined = permissionPending
+    ? 'permission'
+    : elicitationPending
+      ? 'elicitation'
+      : planPending
+        ? 'plan'
+        : undefined
+  const interactionDisabledReason = disabledReasonForInteraction(blockingInteraction)
+  const turnDisabledReason =
+    session.isPending && !facts.allowPendingSessionRetry
+      ? 'session-pending'
+      : running
+        ? 'session-running'
+        : interactionDisabledReason
+  const revisionDisabledReason = running ? 'session-running' : interactionDisabledReason
+  const attentionDisabledReason = waitReason
+    ? waitReason === 'waiting-permission'
+      ? 'permission-pending'
+      : waitReason === 'waiting-for-user'
+        ? 'elicitation-pending'
+        : 'plan-approval-pending'
+    : undefined
+  const activity = waitReason ? 'waiting' : running ? 'running' : 'inactive'
+
+  return {
+    presentedStatus: waitReason ?? (running ? 'running' : status),
+    activity,
+    attentionOwner: waitReason ? 'user' : running ? 'agent' : 'none',
+    waitReason,
+    blockingInteraction,
+    actions: {
+      startTurn: actionAvailability(turnDisabledReason),
+      revise: actionAvailability(revisionDisabledReason),
+      branchFromMessage: actionAvailability(
+        session.isPending
+          ? 'session-pending'
+          : running
+            ? 'session-running'
+            : attentionDisabledReason
+      ),
+      startSideChat: actionAvailability(attentionDisabledReason),
+      changeAgentControls: actionAvailability(
+        running ? 'session-running' : (attentionDisabledReason ?? interactionDisabledReason)
+      ),
+      archive: actionAvailability(running ? 'session-running' : attentionDisabledReason)
+    }
+  }
 }
 
 export const projectSessionInteractionState = (

--- a/src/renderer/src/stores/session-store.architecture.test.ts
+++ b/src/renderer/src/stores/session-store.architecture.test.ts
@@ -106,6 +106,9 @@ const publicValueExports = [
   'createInitialSessionState',
   'createSessionStore',
   'isExternallyHydratedSession',
+  'isSessionWaitReason',
+  'projectSessionActionability',
+  'resolveRootPermissionPending',
   'toPersistedSession',
   'useSessionStore'
 ].sort()
@@ -116,10 +119,16 @@ const publicTypeExports = [
   'ChatMessageRole',
   'ChatMessageStatus',
   'ChatSession',
+  'SessionActionAvailability',
+  'SessionActionDisabledReason',
+  'SessionActionabilityFacts',
+  'SessionActionabilityProjection',
+  'SessionBlockingInteraction',
   'SessionHydrationSelection',
   'SessionStatus',
   'SessionStore',
   'SessionStoreApi',
+  'SessionWaitReason',
   'ToolActivity',
   'ToolActivityStatus'
 ].sort()

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -28,6 +28,7 @@ import type { ActivePlanProjection } from '../../../shared/session-plan/contract
 import { createLinearConversationGraph } from '../../../shared/conversation-graph'
 import {
   createInitialSessionState,
+  projectSessionActionability,
   toPersistedSession,
   useSessionStore,
   type ChatMessage,
@@ -103,6 +104,144 @@ describe('session store', () => {
   it('starts empty so New can stay outside store state', () => {
     expect(useSessionStore.getState().sessions).toEqual([])
     expect(useSessionStore.getState().selectedSessionId).toBeUndefined()
+  })
+
+  it('projects one priority for simultaneous Session interactions', () => {
+    const actionability = projectSessionActionability({
+      id: 'session-actionability',
+      projectId: 'project-1',
+      title: 'Actionability',
+      cwd: '/workspace',
+      status: 'waiting-plan-approval',
+      interactionState: { permission: true, elicitation: true, plan: true },
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1
+    } as ChatSession)
+
+    expect(actionability).toMatchObject({
+      presentedStatus: 'waiting-permission',
+      activity: 'waiting',
+      attentionOwner: 'user',
+      waitReason: 'waiting-permission',
+      blockingInteraction: 'permission',
+      actions: {
+        startTurn: { allowed: false, disabledReason: 'permission-pending' },
+        revise: { allowed: false, disabledReason: 'permission-pending' },
+        branchFromMessage: { allowed: false, disabledReason: 'permission-pending' },
+        startSideChat: { allowed: false, disabledReason: 'permission-pending' }
+      }
+    })
+  })
+
+  it('keeps delegated Permission actionable without giving it the main Composer lane', () => {
+    const actionability = projectSessionActionability(
+      {
+        id: 'session-delegated-permission',
+        projectId: 'project-1',
+        title: 'Delegated permission',
+        cwd: '/workspace',
+        status: 'waiting-permission',
+        interactionState: { permission: true, elicitation: false, plan: false },
+        messages: [],
+        createdAt: 1,
+        updatedAt: 1
+      } as ChatSession,
+      { rootPermissionPending: false }
+    )
+
+    expect(actionability).toMatchObject({
+      activity: 'waiting',
+      attentionOwner: 'user',
+      waitReason: 'waiting-permission',
+      blockingInteraction: undefined,
+      actions: {
+        startTurn: { allowed: true },
+        revise: { allowed: true },
+        branchFromMessage: { allowed: false, disabledReason: 'permission-pending' },
+        startSideChat: { allowed: false, disabledReason: 'permission-pending' }
+      }
+    })
+  })
+
+  it('projects a pending Session as unavailable for a new Turn or Message branch', () => {
+    const actionability = projectSessionActionability({
+      id: 'session-pending',
+      projectId: 'project-1',
+      title: 'Pending Session',
+      cwd: '/workspace',
+      status: 'idle',
+      isPending: true,
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1
+    } as ChatSession)
+
+    expect(actionability.actions).toMatchObject({
+      startTurn: { allowed: false, disabledReason: 'session-pending' },
+      revise: { allowed: true },
+      branchFromMessage: { allowed: false, disabledReason: 'session-pending' }
+    })
+  })
+
+  it('keeps restored durable root Permission authoritative over a delegated live hint', () => {
+    const actionability = projectSessionActionability(
+      {
+        id: 'session-restored-root-permission',
+        projectId: 'project-1',
+        title: 'Restored root permission',
+        cwd: '/workspace',
+        status: 'waiting-permission',
+        runtimeContext: {
+          version: 1,
+          revision: 1,
+          permission: {
+            state: 'pending',
+            request: {
+              requestId: 'permission-root',
+              sessionId: 'session-restored-root-permission',
+              toolCallId: 'tool-root',
+              title: 'Run root command',
+              options: []
+            },
+            originatingPromptMessageId: 'prompt-root',
+            fingerprint: 'a'.repeat(64),
+            createdAt: 1
+          }
+        },
+        messages: [],
+        createdAt: 1,
+        updatedAt: 1
+      } as ChatSession,
+      { rootPermissionPending: false }
+    )
+
+    expect(actionability).toMatchObject({
+      blockingInteraction: 'permission',
+      actions: { startTurn: { allowed: false, disabledReason: 'permission-pending' } }
+    })
+  })
+
+  it('gives a projected user wait priority over concurrent delegated work', () => {
+    const actionability = projectSessionActionability(
+      {
+        id: 'session-delegated-question',
+        projectId: 'project-1',
+        title: 'Delegated question',
+        cwd: '/workspace',
+        status: 'idle',
+        messages: [],
+        createdAt: 1,
+        updatedAt: 1
+      } as ChatSession,
+      { presentedWaitReason: 'waiting-for-user', hasRunningWork: true }
+    )
+
+    expect(actionability).toMatchObject({
+      presentedStatus: 'waiting-for-user',
+      activity: 'waiting',
+      attentionOwner: 'user'
+    })
   })
 
   it('keeps a Side chat relay distinct from a local user message with matching text', () => {
@@ -4490,6 +4629,7 @@ describe('session store public contract', () => {
       'src/renderer/src/pages/workspace/session-notebook-projection.ts',
       'src/renderer/src/pages/workspace/session-plan/active-branch-plan.ts',
       'src/renderer/src/pages/workspace/session-plan/respond-to-session-plan.ts',
+      'src/renderer/src/pages/workspace/session-wait-reason.ts',
       'src/renderer/src/pages/workspace/tool-execution-phase.ts',
       'src/renderer/src/pages/workspace/use-project-artifact-files.ts',
       'src/renderer/src/pages/workspace/use-side-chat-controller.ts',

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -37,6 +37,18 @@ export {
 
 export type { BranchInNewSessionInput } from './session-store-message-graph-helpers'
 
+export {
+  isSessionWaitReason,
+  projectSessionActionability,
+  resolveRootPermissionPending,
+  type SessionActionabilityFacts,
+  type SessionActionabilityProjection,
+  type SessionActionAvailability,
+  type SessionActionDisabledReason,
+  type SessionBlockingInteraction,
+  type SessionWaitReason
+} from './session-store-interaction-state'
+
 type SessionStore = SessionStoreData &
   SessionPersistenceActions &
   SessionMessageGraphActions &


### PR DESCRIPTION
## Problem

Home, Workspace, Composer, and runtime prompt admission independently interpreted `running`, `waiting-*`, Plan approval, Permission, and elicitation state. Their precedence and root-versus-delegated Permission handling could drift, producing contradictory status labels and enabled actions for the same Session.

Persisted waiting Sessions belong to Projects and must remain actionable after reload, including records written before the richer interaction metadata existed.

## Proposed change

Add one read-time Session actionability projection that returns the presented status, activity, attention owner, wait reason, blocking interaction, allowed actions, and stable disabled reasons. The projection applies one precedence:

```mermaid
flowchart LR
  P["Permission"] --> E["Elicitation"] --> L["Plan approval"] --> R["Running"] --> I["Inactive"]
```

Home, Workspace/sidebar presentation, Composer admission, Agent controls, archive behavior, message branching, and runtime prompt admission now consume that projection. Live runtime facts still distinguish root Permission from delegated Permission, and pending Session retry is an explicit admission fact so failed unbound Sessions remain recoverable.

## Scope and non-goals

- No database, Session JSON, IPC, preload, ACP provider, or main-process contract changes.
- No new persisted fields or migration. The projection is derived in the renderer from existing Session state plus live runtime facts.
- Historical compatibility covers Sessions persisted under a Project while still in `waiting-for-user`, `waiting-permission`, or `waiting-plan-approval`. Existing `runtimeContext`/`interactionState` is used when present; older records fall back to their persisted status and existing durable activity data.
- No user-visible copy or interaction layout changes; this aligns status/action behavior behind the existing UI.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Interaction priority, disabled reasons, delegated/root Permission behavior, pending binding, and historical waiting inference -> explicit affected Vitest set below -> 26 files passed, 715 tests passed.
- Home, Workspace, Sidebar, Composer, message-branch, and runtime consumers -> included in the same affected test set -> passed.
- Renderer type safety -> `npm run typecheck:web` -> passed.
- Source style -> `npm run lint` -> passed with no warnings.
- Repository-wide typecheck -> `npm run typecheck` -> blocked by two pre-existing errors on current `main`: `src/main/acp/runtime-coordinator.test.ts:1224` and `:1238` still pass removed `projectName` properties. This branch does not touch those files or ACP request types.

<details>
<summary>Exact affected Vitest command</summary>

```text
npm exec vitest run -- src/renderer/src/stores/session-store.test.ts src/renderer/src/stores/session-store.architecture.test.ts src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts src/renderer/src/lib/acp/useWorkspaceAgentRuntime.first-output.render.test.tsx src/renderer/src/lib/acp/workspace-runtime-event-owner.test.ts src/renderer/src/lib/acp/workspace-runtime-save-as-skill-owner.test.tsx src/renderer/src/pages/home/HomePage.render.test.tsx src/renderer/src/pages/home/HomePage.persistence.test.tsx src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts src/renderer/src/pages/workspace/workspace-session-controller.test.ts src/renderer/src/pages/workspace/session-permissions.test.ts src/renderer/src/pages/workspace/agent-loading-message.test.ts src/renderer/src/pages/workspace/WorkspaceSidebar.test.ts src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx src/renderer/src/pages/workspace/WorkspacePage.pending-switch.test.tsx src/renderer/src/pages/workspace/WorkspacePage.notebook-hydration.test.tsx src/renderer/src/pages/workspace/WorkspacePage.image-staging.test.tsx src/renderer/src/pages/workspace/WorkspacePage.specialist-barrier.test.tsx src/renderer/src/pages/workspace/WorkspacePage.edit-message.test.tsx src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx src/renderer/src/pages/workspace/WorkspacePage.customize-prefill.test.tsx
```

</details>

The impact set includes all changed renderer owners and consumers. Main-process, persistence migration, platform, packaging, and E2E lanes are excluded locally because this diff does not change their files or contracts. Exact-head CI and independent review remain authoritative; this PR is not marked fully verified until that review confirms the mapping.

## Review focus

- Confirm the precedence `Permission > Elicitation > Plan approval > Running` matches product intent.
- Check that delegated Permission remains visible in the transcript without blocking the main Composer, while root Permission remains blocking.
- Check that persisted Project Sessions in legacy waiting states need no migration and that failed pending Session retry remains admitted.
- Look for any remaining consumer that directly reimplements status/actionability precedence instead of using the projection.
