### PR TITLE
test(acp): align reviewer scope fixture with project ids

### DIFF
--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -1221,7 +1221,7 @@ describe('AcpRuntimeCoordinator', () => {
       })
       const session = await coordinator.createSession({
         cwd: '/workspace',
-        projectName: 'project-1'
+        projectId: 'project-1'
       })
 
       const userPrompt = coordinator.sendPrompt({
@@ -1235,7 +1235,7 @@ describe('AcpRuntimeCoordinator', () => {
           session: {
             sessionId: session.sessionId,
             cwd: '/workspace',
-            projectName: 'project-1',
+            projectId: 'project-1',
             previousFrameworkId: frameworkId
           }
         },


### PR DESCRIPTION
## Problem

PR #1282 added a Reviewer linearization test using the removed `projectName` session field. PR #1278 had already made `projectId` the canonical project identity, so current-main `typecheck:node` fails with TS2353 at both fixture sites.

## Proposed change

Use `projectId: 'project-1'` in the session creation and scoped activity fixture. This keeps the test's project scope intact without restoring a compatibility alias or changing production code.

## Scope and non-goals

- Test-only two-line fixture correction.
- No production behavior, public interface, compatibility alias, schema, or persisted data changes.
- No historical-data compatibility impact.
- No new state or enum values.
- No data-persistence impact.

## Acceptance criteria and validation

Final Test Impact Set after the last material edit:

- Reviewer correction remains scoped by canonical project identity -> `npm test -- src/main/acp/runtime-coordinator.test.ts -t "linearizes a scoped Reviewer correction"` -> PR CI authoritative; local worktree dependencies unavailable.
- ACP main-process types accept the fixture -> `npm run typecheck:node` -> PR CI authoritative; local worktree dependencies unavailable.
- Linted test source -> `npm run lint` -> PR CI authoritative; local worktree dependencies unavailable.
- Diff integrity -> `git diff --check` -> passed locally after the final edit.

The changed test file is not registered to a concrete Module in `scripts/ci/module-impact.json`, so no module ID is invented; PR Gate may conservatively select the full plan. No consumer or platform behavior changed. The remaining uncovered local risk is dependency-backed execution, covered by exact-head PR CI.

## Review focus

Confirm the fixture follows the project identity migration from PR #1278 and that no legacy `projectName` alias is reintroduced.