### PR TITLE
test(delegation): settle child launches before teardown

### DIFF
--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -737,6 +737,8 @@ describe('production delegated-work composition', () => {
   it('records the admitted cross-provider model on every child Runtime Segment', async () => {
     root = await mkdtemp(join(tmpdir(), 'delegated-production-model-snapshot-'))
     const execution = createDeterministicDelegateExecution()
+    execution.plan({ status: 'completed', response: 'first complete' })
+    execution.plan({ status: 'completed', response: 'second complete' })
     const resolveExecutionModel = vi.fn(async () => ({
       snapshot: {
         frameworkId: 'opencode' as const,
@@ -757,16 +759,10 @@ describe('production delegated-work composition', () => {
       resolveExecutionModel
     )
 
-    await harness.composition.host.delegate(
-      harness.caller,
-      [
-        { task: 'first', name: 'first' },
-        { task: 'second', name: 'second' }
-      ],
-      { wait: false }
-    )
-    await expect.poll(() => harness.execution.controls()).toHaveLength(2)
-    await expect.poll(() => harness.durable().conversationGraph?.runtimeSegments.length).toBe(3)
+    await harness.composition.host.delegate(harness.caller, [
+      { task: 'first', name: 'first' },
+      { task: 'second', name: 'second' }
+    ])
 
     expect(resolveExecutionModel).toHaveBeenCalledOnce()
     expect(harness.durable().conversationGraph?.runtimeSegments.slice(-2)).toEqual([


### PR DESCRIPTION
## Problem

Windows Full Test run 31935986637 timed out while polling for two delegation execution controls in production-composition.test.ts. The test used wait:false and Vitest's default one-second expect.poll budget. On a loaded Windows runner, child launch persistence had not reached execution.run before the poll expired. Teardown then removed the temporary session root while background launches were still writing, producing a secondary ENOTEMPTY error.

## Proposed change

- Pre-plan two deterministic completed child outcomes.
- Use the default waiting delegation path.
- Remove the wall-clock control and Runtime Segment polls.
- Assert the admitted model after both child launches have settled.

## Scope and non-goals

- Test-only synchronization change.
- No production timeout or delegated-work behavior changes.
- Does not increase an arbitrary poll timeout.

## Validation

| Behavior | Command or run | Result |
| --- | --- | --- |
| Both delegated child launches settle before assertions and teardown | [PR Gate 31940214473](https://github.com/aipoch/open-science/actions/runs/31940214473), Module tests and coverage | Passed; production-composition.test.ts passed 40/40 |
| Final diff satisfies formatting, lint, type contracts, and interface contracts | [PR Gate 31940214473](https://github.com/aipoch/open-science/actions/runs/31940214473), Static checks | Passed |
| Windows full-suite no longer times out or races teardown | [Windows Full Test 31940240071](https://github.com/aipoch/open-science/actions/runs/31940240071) | Passed; shards 1/3, 2/3, and 3/3 all succeeded |
| Final integrated PR plan | [PR Gate 31940214473](https://github.com/aipoch/open-science/actions/runs/31940214473) | Passed |

Independent Standards and Spec reviews found no correctness or scope findings. The only process finding was missing final validation evidence; this table closes it.

The independent worktree has no node_modules. Dependencies were not installed or linked, so local Vitest, typecheck, and lint were not run. Targeted PR CI and the exact-head Windows Full run are authoritative. git diff --check passed.

## Explicit impact classification

- Historical compatibility: none.
- New state or enum values: none.
- Persistence impact: none; this changes only test synchronization and cleanup timing.