### PR TITLE
fix(network): register connectivity IPC before renderer startup

### DIFF
--- a/src/main/application-command-wiring.test.ts
+++ b/src/main/application-command-wiring.test.ts
@@ -181,6 +181,16 @@ describe('production application command wiring', () => {
     expect(runtimeSource).toContain("await modules.dispose('rollback')")
   })
 
+  it('registers startup network IPC before creating the first renderer window', () => {
+    const preWindowStartup = compact(
+      between(indexSource, 'await app.whenReady()', 'const startupWindow = webMode.headless')
+    )
+
+    expect(preWindowStartup).toContain('registerNetworkIpcHandlers()')
+    expect(legacyAdapterBlock).not.toContain('registerNetworkIpcHandlers()')
+    expect(occurrences(indexSource + ipcSource, 'registerNetworkIpcHandlers()')).toBe(1)
+  })
+
   it('late-binds the unique Remote Access owner and passes only narrow views to Web and Task', () => {
     const startup = compact(
       between(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -247,6 +247,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         { createDesktopBadgeAdapter, createWindowsBadgeBitmap },
         { wireNotificationInboxController },
         { registerUnreadTaskIpc },
+        { registerNetworkIpcHandlers },
         { createDatabaseStartupLogging },
         { createDatabaseStartupOwner },
         { installDatabaseStartupQuitGuard, registerDatabaseStartupIpc },
@@ -271,6 +272,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         import('./notifications/desktop-badge'),
         import('./notifications/notification-inbox-controller'),
         import('./notifications/unread-task-ipc'),
+        import('./network-ipc'),
         import('./database/database-startup-logging'),
         import('./database/database-startup-owner'),
         import('./database/database-startup-ipc'),
@@ -305,6 +307,10 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         }
       })
       const startupWindowCloseOptions = createStartupWindowCloseOptions(() => app.quit())
+      // The renderer probes connectivity as soon as it mounts, before the full application runtime
+      // is composed. Install these handlers before creating the first BrowserWindow so that startup
+      // probe cannot race the desktop utility adapter installation.
+      registerNetworkIpcHandlers()
       const disposeDatabaseStartupIpc = registerDatabaseStartupIpc({
         ipcMain,
         owner: databaseStartupOwner,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -83,7 +83,6 @@ import {
 } from './lifecycle-shutdown'
 import { registerLifecycleIpcHandlers } from './lifecycle-broadcast'
 import { createLogsCommandOwner, registerLogsIpcHandlers } from './logs-ipc'
-import { registerNetworkIpcHandlers } from './network-ipc'
 import { registerWindowIpcHandlers } from './window-ipc'
 import { registerWindowFindIpcHandlers } from './window-find-ipc'
 import { TaskNotificationService } from './notifications/task-notifications'
@@ -1828,7 +1827,6 @@ const createApplicationModules = async (
     registerFileSaveHandlers({ resolveManagedFilePath, resolveSessionArtifactFilePath })
     registerLogsIpcHandlers(logsCommandOwner)
     registerGithubIpcHandlers({}, githubCommandOwner)
-    registerNetworkIpcHandlers()
     registerCliInstallIpcHandlers(cliCommandOwner)
     registerWindowIpcHandlers()
     registerWindowFindIpcHandlers()


### PR DESCRIPTION
## Problem

The renderer starts its connectivity probe as soon as the first window mounts, but the main process registered `network:check-connectivity` only after the full application runtime finished composing. On a cold development startup, the renderer could invoke the channel first and Electron logged `No handler registered for 'network:check-connectivity'` even when the network was healthy.

## Proposed change

- Register the network IPC handlers after Electron is ready and before creating the first `BrowserWindow`.
- Remove their later registration from the desktop utility adapter so the handlers remain installed exactly once.
- Add a startup wiring regression test that pins both the ordering and uniqueness invariants.

## Scope and non-goals

- No changes to the connectivity probe, renderer state, renderer/main contract, or UI.
- No new dependencies.
- No historical-data compatibility requirement, enum additions, or persistence changes.

## Acceptance criteria and validation

Final local Test Impact Set, run after the last material edit:

- Startup ordering and unique registration -> `npm test -- src/main/application-command-wiring.test.ts src/main/network-ipc.test.ts` -> 12 tests passed.
- Node/Electron types -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed.
- Changed-file formatting -> `npx prettier --check src/main/index.ts src/main/ipc.ts src/main/application-command-wiring.test.ts` -> passed.

The changed interface is registration timing only; IPC channel names, arguments, return values, preload exposure, renderer consumers, and network behavior are unchanged, so renderer and contract suites were excluded locally. `src/main/index.ts` is platform-sensitive startup code, so PR CI remains authoritative for macOS/Windows startup and the complete portable suite. Per maintainer direction, the full local `npm test` suite was not run.

## Review focus

- Confirm the network handlers are installed before any renderer can mount.
- Confirm there is exactly one production registration site.
