### PR TITLE
fix(workspace): allow composer model picker to shrink

### DIFF
--- a/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx
@@ -402,7 +402,7 @@ describe('ComposerModelPicker', () => {
     expect(trigger?.textContent).not.toContain('OpenAI')
   })
 
-  it('keeps the effort suffix fully visible and ellipsizes only the model name on the trigger', () => {
+  it('lets the trigger shrink while preserving the effort suffix and ellipsizing the model', () => {
     // Long model names must not swallow the effort suffix: the model span truncates, the suffix
     // span is shrink-protected and never wraps.
     useSettingsStore.setState({
@@ -424,6 +424,10 @@ describe('ComposerModelPicker', () => {
     const trigger = container.querySelector('[aria-label="Select model"]')
     expect(trigger).not.toBeNull()
     expect(trigger?.textContent).toContain('· High')
+    const triggerClasses = trigger?.className.split(/\s+/) ?? []
+    expect(triggerClasses).toContain('min-w-0')
+    expect(triggerClasses).toContain('shrink')
+    expect(triggerClasses).not.toContain('shrink-0')
     const suffix = Array.from(trigger!.querySelectorAll('span')).find(
       (el) => el.textContent?.trim() === '· High'
     )

--- a/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerModelPicker.tsx
@@ -31,7 +31,7 @@ import { resolveReasoningEffortControl } from '../../../../shared/reasoning-effo
 import { incompatibilityReason } from './composer-model-picker-utils'
 
 const triggerClassName =
-  'flex h-8 max-w-[220px] items-center gap-1 rounded-md px-2.5 text-sm text-text-300 hover:bg-bg-200 hover:text-text-100 disabled:cursor-not-allowed disabled:opacity-50 transition-colors'
+  'flex h-8 min-w-0 max-w-[220px] shrink items-center gap-1 rounded-md px-2.5 text-sm text-text-300 hover:bg-bg-200 hover:text-text-100 disabled:cursor-not-allowed disabled:opacity-50 transition-colors'
 
 // Label for an option: the model name, or the provider name when the option carries no concrete model.
 const optionLabel = (option: ConfiguredModelCatalogEntry): string => option.label


### PR DESCRIPTION
## Problem

The composer model picker inherits `shrink-0` from the shared Button component. When the workspace column becomes narrow, the picker keeps its full intrinsic width and can push the send controls outside the composer.

## Proposed change

- allow only the composer model picker trigger to shrink within its existing 220px maximum
- keep the model label ellipsized while preserving the provider icon, effort suffix, and dropdown affordance
- add a render regression assertion for the final merged Tailwind classes

## Scope and non-goals

- no changes to the shared Button component or other controls
- no new user-visible copy or translation keys
- no historical-data compatibility requirements
- no new enum or persisted state

## Acceptance criteria and validation

All checks below ran after the final production-code edit:

- model picker shrink and label priority -> `npm test -- src/renderer/src/pages/workspace/ComposerModelPicker.render.test.tsx src/renderer/src/pages/workspace/workspace-components.test.tsx` -> 45 tests passed
- renderer type safety -> `npm run typecheck:web` -> passed
- repository lint -> `npm run lint` -> passed
- patch integrity -> `git diff --check` -> passed

The change is renderer-only. Main/preload, platform-specific, ACP, persistence, migration, and packaging lanes are excluded because no related interface or runtime behavior changed. Full portable and platform coverage remains authoritative in PR CI.

## Review focus

Please verify that the local `shrink` override wins over Button's base `shrink-0`, while the nested effort suffix remains shrink-protected and the model label remains the only ellipsized content.
