### PR TITLE
fix(notebook): validate run.json ownership before mutation

### DIFF
--- a/src/main/notebook/repository.test.ts
+++ b/src/main/notebook/repository.test.ts
@@ -615,6 +615,158 @@ describe('notebook run repository', () => {
     expect(reloaded?.runs[0].artifacts[0]).toMatchObject({ projectId: 'canonical-project' })
   })
 
+  it('keeps a matching legacy projectName document readable through loadOrCreate', async () => {
+    const root = await createStorageRoot()
+    const runJsonPath = join(root, 'notebooks', 'default-project', 'session-1', 'run.json')
+    const lane = createRootNotebookLane('default-project', 'session-1', 'root-frame-session-1')
+    await new NotebookRunRepository(root).loadOrCreate({
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      lane,
+      workspaceCwd: '/workspace'
+    })
+    const legacyDocument = JSON.parse(await readFile(runJsonPath, 'utf8'))
+    delete legacyDocument.projectId
+    legacyDocument.projectName = 'default-project'
+    legacyDocument.artifactSessionId = 'artifact-session-1'
+    await writeFile(runJsonPath, JSON.stringify(legacyDocument, null, 2), 'utf8')
+
+    const document = await new NotebookRunRepository(root).loadOrCreate({
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      lane,
+      workspaceCwd: '/relocated-workspace'
+    })
+
+    expect(document).toMatchObject({
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      artifactSessionId: 'artifact-session-1',
+      workspaceCwd: '/relocated-workspace'
+    })
+  })
+
+  it('rejects a project ownership mismatch before caching or changing the root document', async () => {
+    const root = await createStorageRoot()
+    const runJsonPath = join(root, 'notebooks', 'default-project', 'session-1', 'run.json')
+    await new NotebookRunRepository(root).loadOrCreate({
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      lane: createRootNotebookLane('default-project', 'session-1', 'root-frame-session-1'),
+      workspaceCwd: '/workspace'
+    })
+    const misplacedDocument = JSON.parse(await readFile(runJsonPath, 'utf8'))
+    misplacedDocument.projectId = 'other-project'
+    const original = JSON.stringify(misplacedDocument, null, 2)
+    await writeFile(runJsonPath, original, 'utf8')
+    const repository = new NotebookRunRepository(root)
+
+    await expect(repository.findExisting('default-project', 'session-1')).rejects.toThrow(
+      'Notebook run document ownership mismatch: requested projectId "default-project", but run.json declares "other-project".'
+    )
+
+    expect(await readFile(runJsonPath, 'utf8')).toBe(original)
+    const cache = repository as unknown as { documentCache: Map<string, unknown> }
+    expect(cache.documentCache.size).toBe(0)
+  })
+
+  it('does not treat a session ownership mismatch as ENOENT in loadOrCreate', async () => {
+    const root = await createStorageRoot()
+    const runJsonPath = join(root, 'notebooks', 'default-project', 'session-1', 'run.json')
+    const lane = createRootNotebookLane('default-project', 'session-1', 'root-frame-session-1')
+    await new NotebookRunRepository(root).loadOrCreate({
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      lane,
+      workspaceCwd: '/workspace'
+    })
+    const misplacedDocument = JSON.parse(await readFile(runJsonPath, 'utf8'))
+    misplacedDocument.sessionId = 'other-session'
+    misplacedDocument.runs = [{ sentinel: 'must-not-be-replaced' }]
+    const original = JSON.stringify(misplacedDocument, null, 2)
+    await writeFile(runJsonPath, original, 'utf8')
+    const repository = new NotebookRunRepository(root)
+
+    await expect(
+      repository.loadOrCreate({
+        projectId: 'default-project',
+        sessionId: 'session-1',
+        lane,
+        workspaceCwd: '/workspace'
+      })
+    ).rejects.toThrow(
+      'Notebook run document ownership mismatch: requested sessionId "session-1", but run.json declares "other-session".'
+    )
+
+    expect(await readFile(runJsonPath, 'utf8')).toBe(original)
+  })
+
+  it('rejects a canonical projectId mismatch even when legacy projectName matches', async () => {
+    const root = await createStorageRoot()
+    const runJsonPath = join(root, 'notebooks', 'default-project', 'session-1', 'run.json')
+    await new NotebookRunRepository(root).loadOrCreate({
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      lane: createRootNotebookLane('default-project', 'session-1', 'root-frame-session-1'),
+      workspaceCwd: '/workspace'
+    })
+    const misplacedDocument = JSON.parse(await readFile(runJsonPath, 'utf8'))
+    misplacedDocument.projectId = 'canonical-other-project'
+    misplacedDocument.projectName = 'default-project'
+    await writeFile(runJsonPath, JSON.stringify(misplacedDocument, null, 2), 'utf8')
+
+    await expect(
+      new NotebookRunRepository(root).findExisting('default-project', 'session-1')
+    ).rejects.toThrow(/requested projectId "default-project".*"canonical-other-project"/)
+  })
+
+  it('rejects a mismatched Frame document before continuing a mutation', async () => {
+    const root = await createStorageRoot()
+    const lane = createFrameNotebookLane('default-project', 'session-1', 'child-frame-1')
+    const runJsonPath = join(
+      root,
+      'notebooks',
+      'default-project',
+      'session-1',
+      'frames',
+      'child-frame-1',
+      'run.json'
+    )
+    await new NotebookRunRepository(root).loadOrCreate({
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      lane,
+      workspaceCwd: '/workspace'
+    })
+    const misplacedDocument = JSON.parse(await readFile(runJsonPath, 'utf8'))
+    misplacedDocument.sessionId = 'other-session'
+    const original = JSON.stringify(misplacedDocument, null, 2)
+    await writeFile(runJsonPath, original, 'utf8')
+
+    await expect(
+      new NotebookRunRepository(root).appendRun({
+        projectId: 'default-project',
+        sessionId: 'session-1',
+        lane,
+        run: {
+          runId: 'must-not-be-appended',
+          cellId: 'cell-1',
+          source: 'agent',
+          kernelKind: 'python',
+          script: '1',
+          status: 'completed',
+          startedAt: 1,
+          text: { stdout: '', stderr: '', traceback: '', plain: [] },
+          outputs: [],
+          artifacts: [],
+          workingFiles: []
+        }
+      })
+    ).rejects.toThrow(/requested sessionId "session-1".*"other-session"/)
+
+    expect(await readFile(runJsonPath, 'utf8')).toBe(original)
+  })
+
   it('keeps an explicit kernelKind when loading a run record from disk', async () => {
     const root = await createStorageRoot()
     const repository = new NotebookRunRepository(root)

--- a/src/main/notebook/repository.ts
+++ b/src/main/notebook/repository.ts
@@ -25,6 +25,12 @@ const MAX_DOCUMENT_READ_ATTEMPTS = 2
 
 type DocumentFileIdentity = { mtimeMs: number; size: number; ino: number }
 
+type PersistedNotebookDocumentScope = {
+  projectId?: unknown
+  projectName?: unknown
+  sessionId?: unknown
+}
+
 const sameDocumentFileIdentity = (
   left: DocumentFileIdentity,
   right: DocumentFileIdentity
@@ -84,6 +90,37 @@ const isMissingFileError = (error: unknown): boolean =>
   error !== null &&
   'code' in error &&
   (error as { code?: unknown }).code === 'ENOENT'
+
+const persistedScopeValue = (value: unknown): string =>
+  value === undefined || value === null ? '<missing>' : (JSON.stringify(value) ?? String(value))
+
+// The physical notebooks/<projectId>/<sessionId>/run.json path is the ownership boundary. Validate
+// the persisted identity before decoding paths or normalizing request-derived fields so a misplaced
+// document can never be silently adopted by its containing directory.
+function assertNotebookDocumentOwnership(
+  document: unknown,
+  projectId: string,
+  sessionId: string
+): asserts document is NotebookRunDocument {
+  if (!document || typeof document !== 'object') {
+    throw new Error('Notebook run document ownership mismatch: run.json has no document scope.')
+  }
+
+  const scope = document as PersistedNotebookDocumentScope
+  const documentProjectId = scope.projectId ?? scope.projectName
+  if (documentProjectId !== projectId) {
+    throw new Error(
+      `Notebook run document ownership mismatch: requested projectId ${JSON.stringify(projectId)}, ` +
+        `but run.json declares ${persistedScopeValue(documentProjectId)}.`
+    )
+  }
+  if (scope.sessionId !== sessionId) {
+    throw new Error(
+      `Notebook run document ownership mismatch: requested sessionId ${JSON.stringify(sessionId)}, ` +
+        `but run.json declares ${persistedScopeValue(scope.sessionId)}.`
+    )
+  }
+}
 
 // Returns the shared runtime installation root used by notebook system instructions.
 const getRuntimeRoot = (storageRoot: string): string => join(storageRoot, 'runtime')
@@ -228,6 +265,7 @@ const normalizeDocument = (
   request: NormalizeNotebookRunDocumentRequest,
   document: NotebookRunDocument
 ): NotebookRunDocument => {
+  assertNotebookDocumentOwnership(document, request.projectId, request.sessionId)
   const storageProjectId = assertSafeNotebookPathSegment(request.projectId)
   const projectId = assertSafeNotebookPathSegment(document.projectId)
   const sessionId = assertSafeNotebookPathSegment(request.sessionId)
@@ -287,7 +325,8 @@ class NotebookRunRepository {
 
     try {
       const rawDocument = await readFile(filePath, 'utf8')
-      const document = JSON.parse(rawDocument) as NotebookRunDocument
+      const document: unknown = JSON.parse(rawDocument)
+      assertNotebookDocumentOwnership(document, projectId, sessionId)
       // Decode $DATA sentinels against the current data root before recomputing session roots,
       // so a relocated data root and the decoded working-file paths agree.
       const decoded = decodeRunDocumentDataPaths(document, this.storageRoot)
@@ -635,13 +674,15 @@ class NotebookRunRepository {
       const fileInfo = await stat(filePath)
       const cached = this.documentCache.get(filePath)
       if (cached && sameDocumentFileIdentity(cached, fileInfo)) {
+        assertNotebookDocumentOwnership(cached.document, safeProjectId, safeSessionId)
         // Refresh insertion order so the Map also acts as a small LRU.
         this.documentCache.delete(filePath)
         this.documentCache.set(filePath, cached)
         return cached.document
       }
       const rawDocument = await readFile(filePath, 'utf8')
-      const document = JSON.parse(rawDocument) as NotebookRunDocument
+      const document: unknown = JSON.parse(rawDocument)
+      assertNotebookDocumentOwnership(document, safeProjectId, safeSessionId)
       // Decode before normalization for the same reason as loadOrCreate above.
       const decoded = decodeRunDocumentDataPaths(document, this.storageRoot)
 


### PR DESCRIPTION
## Summary

- validate persisted Notebook project/session ownership before path decoding, normalization, caching, or mutation
- keep legacy projectName fallback while giving canonical projectId precedence
- fail closed for root and Frame lane mismatches without rewriting or recreating run.json
- preserve independent artifactSessionId compatibility

## Testing

- npm test -- --run src/main/notebook/repository.test.ts src/main/notebook/repository-cache-consistency.test.ts (21 passed)
- npm run typecheck:node
- eslint src/main/notebook/repository.ts src/main/notebook/repository.test.ts
- full npm test attempted; the local Windows environment reported 54 unrelated failures dominated by symlink EPERM, storage-root usability checks, and existing timeouts