### PR TITLE
fix(session-plan): prevent concurrent preview decisions

### DIFF
--- a/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.test.tsx
+++ b/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.test.tsx
@@ -208,11 +208,10 @@ describe('Session Plan renderer surfaces', () => {
       <PlanPreviewSurface projection={projection} onDownload={onDownload} onRespond={onRespond} />
     )
     fireEvent.click(screen.getByRole('button', { name: 'Download Plan' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
     fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
     expect(onDownload).toHaveBeenCalledOnce()
-    expect(onRespond).toHaveBeenNthCalledWith(1, 'rejected')
-    expect(onRespond).toHaveBeenNthCalledWith(2, 'approved')
+    expect(onRespond).toHaveBeenCalledOnce()
+    expect(onRespond).toHaveBeenCalledWith('approved')
 
     rerender(
       <PlanPreviewSurface
@@ -228,6 +227,23 @@ describe('Session Plan renderer surfaces', () => {
     expect(screen.getByRole('button', { name: 'Download Plan' })).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'Approve' })).toBeNull()
     expect(screen.queryByRole('button', { name: 'Dismiss' })).toBeNull()
+  })
+
+  it('submits only the first Preview decision while its response is pending', () => {
+    const onRespond = vi.fn(() => new Promise<void>(() => undefined))
+    render(<PlanPreviewSurface projection={projection} onRespond={onRespond} />)
+
+    const dismiss = screen.getByRole('button', { name: 'Dismiss' }) as HTMLButtonElement
+    const approve = screen.getByRole('button', { name: 'Approve' }) as HTMLButtonElement
+    fireEvent.click(dismiss)
+
+    expect(dismiss.disabled).toBe(true)
+    expect(approve.disabled).toBe(true)
+    expect(dismiss.closest('[aria-busy="true"]')).not.toBeNull()
+    fireEvent.click(approve)
+
+    expect(onRespond).toHaveBeenCalledOnce()
+    expect(onRespond).toHaveBeenCalledWith('rejected')
   })
 
   it('explains why a pending Preview without a live response handler is read-only', () => {
@@ -278,11 +294,10 @@ describe('Session Plan renderer surfaces', () => {
     expect(document.querySelector('header')?.className).toContain('h-9')
     fireEvent.click(screen.getByRole('button', { name: 'Download Plan' }))
     fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
     fireEvent.click(screen.getByRole('button', { name: 'Enter full screen' }))
     expect(onDownload).toHaveBeenCalledOnce()
-    expect(onRespond).toHaveBeenNthCalledWith(1, 'rejected')
-    expect(onRespond).toHaveBeenNthCalledWith(2, 'approved')
+    expect(onRespond).toHaveBeenCalledOnce()
+    expect(onRespond).toHaveBeenCalledWith('rejected')
     expect(onToggleFullScreen).toHaveBeenCalledOnce()
   })
 

--- a/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.tsx
+++ b/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.tsx
@@ -5,7 +5,7 @@
  * contrast: inherited from the shared Button, Textarea, and workspace surface tokens
  * slop test: pass · component scope, existing workspace chrome and tokens preserved
  */
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import type { TFunction } from 'i18next'
 import {
   CornerDownLeft,
@@ -338,6 +338,23 @@ const PlanPreviewSurface = ({
   const { t } = useTranslation()
 
   const planDocument = validatedPreviewDocument(projection.document)
+  const decisionInFlightRef = useRef(false)
+  const [decisionBusy, setDecisionBusy] = useState(false)
+  const projectionKey = `${projection.artifactVersionId}:${projection.revision}`
+  const [resolvedProjectionKey, setResolvedProjectionKey] = useState<string>()
+
+  const respond = async (decision: 'approved' | 'rejected'): Promise<void> => {
+    if (!onRespond || decisionInFlightRef.current) return
+    decisionInFlightRef.current = true
+    setDecisionBusy(true)
+    try {
+      await onRespond(decision)
+      setResolvedProjectionKey(projectionKey)
+    } finally {
+      decisionInFlightRef.current = false
+      setDecisionBusy(false)
+    }
+  }
 
   const download =
     onDownload ??
@@ -356,7 +373,7 @@ const PlanPreviewSurface = ({
     })
 
   return (
-    <div className="flex h-full min-h-0 flex-col bg-bg-10 text-foreground">
+    <div className="flex h-full min-h-0 flex-col bg-bg-10 text-foreground" aria-busy={decisionBusy}>
       <header className="flex h-9 shrink-0 items-center justify-between gap-2 border-b border-border px-3">
         <span className="truncate text-xs text-muted-foreground">
           plan-{projection.artifactVersionId}.json
@@ -371,12 +388,25 @@ const PlanPreviewSurface = ({
             <Download className="size-4" aria-hidden="true" />
             {t('Download')}
           </Button>
-          {planDocument && !stale && projection.approval === 'pending' && onRespond ? (
+          {planDocument &&
+          !stale &&
+          projection.approval === 'pending' &&
+          resolvedProjectionKey !== projectionKey &&
+          onRespond ? (
             <>
-              <Button type="button" variant="outline" onClick={() => void onRespond('rejected')}>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={decisionBusy}
+                onClick={() => void respond('rejected')}
+              >
                 {t('Dismiss')}
               </Button>
-              <Button type="button" onClick={() => void onRespond('approved')}>
+              <Button
+                type="button"
+                disabled={decisionBusy}
+                onClick={() => void respond('approved')}
+              >
                 {t('Approve')}
               </Button>
             </>


### PR DESCRIPTION
## Problem

Plan Preview rendered Dismiss and Approve as independent async actions. While the first response was still pending, the opposite action could submit with the same Plan revision. The durable revision guard prevented two commits, but the winner depended on async scheduling even though Plan decisions are irreversible.

## Proposed change

- Guard Preview decisions with a synchronous component-local single-flight lock.
- Disable both decision buttons and expose `aria-busy` while the response is pending.
- Hide the decision entry points after a successful response for the current Plan projection.
- Add a regression test that holds the first response open and attempts the opposite decision.

## Scope and non-goals

- No schema, persisted field, enum, protocol, architecture, or data-model changes.
- No historical-data compatibility or migration work is required.
- The existing main-process revision guard remains the authoritative persistence protection.
- No new user-visible strings were added.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Opposite Preview decisions cannot race; busy and disabled states are exposed -> `npm test -- src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.test.tsx src/renderer/src/pages/workspace/session-plan/plan-preview-i18n.render.test.tsx src/renderer/src/pages/workspace/previews/PreviewToolContent.plan.test.tsx` -> 3 files, 32 tests passed.
- Renderer types remain valid -> `npm run typecheck:web` -> passed.
- Source and tests satisfy lint/format rules -> `npm run lint` -> passed with no warnings after the formatting correction.
- Diff whitespace validation -> `git diff --check` -> passed.

The direct Preview consumer and i18n render surface were included because `PlanPreviewSurface` is rendered through `PreviewToolContent`. No persistence or platform lane was run locally because the final diff is renderer-only and does not change those contracts. The complete portable and platform suites remain CI-authoritative; the module-impact manifest does not currently declare an owner for `SessionPlanSurfaces.tsx`, so PR Gate may conservatively select the full plan.

## Review focus

- Confirm the synchronous ref closes the same-render race while React state drives accessible busy/disabled presentation.
- Confirm successful responses suppress only the matching `artifactVersionId:revision` projection and do not affect a newer Plan.
