### PR TITLE
fix(web): bound event reconnect recovery

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -395,6 +395,9 @@ colors communicate a successful or failed probe/migration result.
 - When a presentation above preview/base owns the shell, base content is `inert` and
   `aria-hidden`. Nested dialogs and fullscreen viewers retain local priority before base-pane or
   window close behavior.
+- Web event recovery keeps base content blocked until the event cursor is live. An ordinary
+  disconnect offers Reload immediately while retrying up to eight total connection attempts with
+  bounded backoff. Exhausted attempts and unsafe replay both stop reconnecting and require Reload.
 
 ### Button
 

--- a/src/renderer/src/components/WebEventRecoveryDialog.test.tsx
+++ b/src/renderer/src/components/WebEventRecoveryDialog.test.tsx
@@ -20,6 +20,20 @@ afterEach(() => {
 })
 
 describe('WebEventRecoveryDialog', () => {
+  it('offers a recovery action while an ordinary reconnect is pending', async () => {
+    await act(async () => {
+      root.render(<WebEventRecoveryDialog active phase="reconnecting" />)
+    })
+
+    const dialog = document.body.querySelector<HTMLElement>('[role="alertdialog"]')
+    expect(dialog?.textContent).toContain('Reconnecting to Open Science')
+    expect(
+      Array.from(dialog?.querySelectorAll('button') ?? []).some(
+        (button) => button.textContent === 'Reload'
+      )
+    ).toBe(true)
+  })
+
   it('blocks stale interaction while replay is in progress without offering an unsafe bypass', async () => {
     await act(async () => {
       root.render(<WebEventRecoveryDialog active phase="replaying" />)

--- a/src/renderer/src/components/WebEventRecoveryDialog.tsx
+++ b/src/renderer/src/components/WebEventRecoveryDialog.tsx
@@ -25,6 +25,7 @@ const WebEventRecoveryDialog = ({
 }: WebEventRecoveryDialogProps): React.JSX.Element => {
   const { t } = useTranslation()
   const reloadRequired = phase === 'reload-required'
+  const reloadAvailable = phase === 'reconnecting' || reloadRequired
   const title =
     phase === 'connecting'
       ? t('Connecting to Open Science')
@@ -35,7 +36,7 @@ const WebEventRecoveryDialog = ({
           : t('Reload required')
   const description = reloadRequired
     ? t(
-        'This page can no longer safely recover all updates. Reload to fetch a complete, current view.'
+        'Open Science could not restore a complete, current view. Reload this page to reconnect safely.'
       )
     : t(
         'Controls are paused while Open Science restores updates that may have arrived during the interruption.'
@@ -64,7 +65,7 @@ const WebEventRecoveryDialog = ({
               {description}
             </AlertDialog.Description>
           </div>
-          {reloadRequired ? (
+          {reloadAvailable ? (
             <div className={dialogFooterClassName}>
               <Button type="button" onClick={() => window.location.reload()}>
                 <RefreshCw aria-hidden="true" />

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -2599,7 +2599,7 @@
   "Restoring missed updates": "正在恢复错过的更新",
   "Reload required": "需要重新加载",
   "Controls are paused while Open Science restores updates that may have arrived during the interruption.": "Open Science 正在恢复中断期间可能到达的更新，控件已暂时停用。",
-  "This page can no longer safely recover all updates. Reload to fetch a complete, current view.": "此页面无法再安全恢复所有更新。请重新加载以获取完整的最新视图。",
+  "Open Science could not restore a complete, current view. Reload this page to reconnect safely.": "Open Science 无法恢复完整的最新视图。请重新加载此页面以安全地重新连接。",
   "Reviewer requested corrections": "审查员已请求更正",
   "Connecting to remote computer…": "正在连接远程计算机…",
   "Reconnecting to remote computer… ({{attempt}}/{{maxAttempts}})": "正在重新连接远程计算机…（{{attempt}}/{{maxAttempts}}）",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -2599,7 +2599,7 @@
   "Restoring missed updates": "正在還原遺漏的更新",
   "Reload required": "需要重新載入",
   "Controls are paused while Open Science restores updates that may have arrived during the interruption.": "Open Science 正在還原中斷期間可能抵達的更新，控制項已暫停使用。",
-  "This page can no longer safely recover all updates. Reload to fetch a complete, current view.": "此頁面已無法安全還原所有更新。請重新載入以取得完整的最新檢視。",
+  "Open Science could not restore a complete, current view. Reload this page to reconnect safely.": "Open Science 無法還原完整且最新的檢視。請重新載入此頁面以安全地重新連線。",
   "Reviewer requested corrections": "審查員已要求修正",
   "Connecting to remote computer…": "正在連線至遠端電腦…",
   "Reconnecting to remote computer… ({{attempt}}/{{maxAttempts}})": "正在重新連線至遠端電腦…（{{attempt}}/{{maxAttempts}}）",

--- a/src/renderer/web/bootstrap.test.ts
+++ b/src/renderer/web/bootstrap.test.ts
@@ -281,6 +281,29 @@ describe('Web bootstrap event connection', () => {
     expect(FakeWebSocket.instances).toHaveLength(3)
   })
 
+  it('stops reconnecting and requests a reload after eight consecutive closes', async () => {
+    const phases: string[] = []
+    const stateListener = (event: Event): void => {
+      phases.push((event as CustomEvent<{ phase: string }>).detail.phase)
+    }
+    window.addEventListener(WEB_EVENT_CONNECTION_STATE_EVENT, stateListener)
+    await loadBootstrap()
+
+    const reconnectDelays = [1_000, 2_000, 4_000, 8_000, 10_000, 10_000, 10_000]
+    for (const delay of reconnectDelays) {
+      FakeWebSocket.instances.at(-1)?.emit('close')
+      await vi.advanceTimersByTimeAsync(delay)
+    }
+    expect(FakeWebSocket.instances).toHaveLength(8)
+
+    FakeWebSocket.instances.at(-1)?.emit('close')
+    await vi.advanceTimersByTimeAsync(20_000)
+
+    expect(phases.at(-1)).toBe('reload-required')
+    expect(FakeWebSocket.instances).toHaveLength(8)
+    window.removeEventListener(WEB_EVENT_CONNECTION_STATE_EVENT, stateListener)
+  })
+
   it('signals stores to refresh only after replay reaches the live cursor', async () => {
     const listener = vi.fn()
     window.addEventListener(WEB_EVENTS_OPEN_EVENT, listener)

--- a/src/renderer/web/bootstrap.ts
+++ b/src/renderer/web/bootstrap.ts
@@ -45,6 +45,7 @@ type Listener = (payload: unknown) => void
 
 const BOOTSTRAP_ATTEMPTS = 8
 const BOOTSTRAP_TIMEOUT_MS = 8_000
+const EVENT_CONNECTION_ATTEMPTS = 8
 
 const clientId = sessionStorage.getItem('open-science-web-client') ?? crypto.randomUUID()
 sessionStorage.setItem('open-science-web-client', clientId)
@@ -304,9 +305,13 @@ const connectEvents = (): void => {
   })
   socket.addEventListener('close', () => {
     if (eventRecoveryRequired) return
-    publishEventConnectionPhase('reconnecting')
-    const delay = Math.min(1_000 * 2 ** eventReconnectAttempt, 10_000)
     eventReconnectAttempt += 1
+    if (eventReconnectAttempt >= EVENT_CONNECTION_ATTEMPTS) {
+      requireEventReload(socket)
+      return
+    }
+    publishEventConnectionPhase('reconnecting')
+    const delay = Math.min(1_000 * 2 ** (eventReconnectAttempt - 1), 10_000)
     window.setTimeout(connectEvents, delay)
   })
 }


### PR DESCRIPTION
## Problem

After the Web renderer has started, an ordinary event WebSocket close retries forever. The App Shell keeps the base UI `inert` during recovery, but the reconnecting dialog offers no in-app recovery action, so a persistent outage can trap the user on a permanently blocked surface.

## Proposed change

- Offer Reload immediately while an ordinary reconnect is pending.
- Bound automatic event connections to eight consecutive attempts while preserving the existing exponential backoff.
- Stop retrying and reuse `reload-required` when the limit is exhausted.
- Use reload guidance that applies to both an exhausted connection and an unsafe event replay.

## Scope and non-goals

- Web renderer event recovery only; Electron and the Web service protocol are unchanged.
- No new connection phase, data field, schema, data model, migration, or persistence behavior.
- No socket-only manual retry command; Reload is the explicit immediate recovery action.

## Acceptance criteria and validation

- Ordinary reconnect action -> `npm test -- src/renderer/web/bootstrap.test.ts src/renderer/src/components/WebEventRecoveryDialog.test.tsx src/renderer/src/i18n/resources.test.ts` -> 82 tests passed.
- Web renderer types -> `npm run typecheck:web` -> passed.
- Linted source and documentation -> `npm run lint` -> passed.
- Patch hygiene -> `git diff --check` -> passed.

These checks ran after the last material edit. The affected consumers are the Web bootstrap connection owner and its App Shell recovery dialog; Electron is excluded because it does not install the Web event surface. No platform-specific code or persistence path changed. A real tunnel outage was not exercised locally; PR CI remains authoritative for the complete portable and platform suites.

## Review focus

- Confirm that eight total connection attempts is an appropriate cutoff.
- Confirm that exposing Reload during backoff preserves the intended stale-interaction safety boundary.
