### PR TITLE
fix(notebook): surface environment status query failures

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -303,7 +303,9 @@ vi.mock('@/pages/settings/SettingsPage', () => ({
   )
 }))
 vi.mock('@/pages/workspace/EnvStatusBanner', () => ({
-  EnvStatusBanner: (): React.JSX.Element => <div data-testid="env-banner" />
+  EnvStatusBanner: ({ onRetry }: { onRetry?: () => void }): React.JSX.Element => (
+    <button type="button" data-testid="env-banner" onClick={onRetry} />
+  )
 }))
 vi.mock('@/pages/workspace/WorkspacePage', () => ({
   WorkspacePage: ({
@@ -380,6 +382,8 @@ describe('App startup routing', () => {
     mocks.preview.panelState = 'collapsed'
     mocks.deepLinkNavigation.mockClear()
     mocks.lifecycleSync.mockClear()
+    mocks.environment.init.mockClear()
+    mocks.environment.retry.mockClear()
     mocks.syncWindowFindAppearance.mockClear()
     mocks.syncUnreadTaskView.mockClear()
     mocks.getInfo.mockReset().mockResolvedValue({
@@ -968,6 +972,10 @@ describe('App startup routing', () => {
     await render()
 
     expect(container.querySelector('[data-testid="onboarding-page"]')).not.toBeNull()
+    const envBanner = container.querySelector<HTMLButtonElement>('[data-testid="env-banner"]')
+    expect(envBanner).not.toBeNull()
+    await act(async () => envBanner?.click())
+    expect(mocks.environment.retry).toHaveBeenCalledOnce()
     expect(container.querySelector('[data-testid="home-page"]')).toBeNull()
   })
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -537,7 +537,12 @@ const AppContent = (): React.JSX.Element | null => {
   }
 
   if (startupView === 'onboarding') {
-    return <OnboardingWizard loadStorageInfo={loadStorageInfo} />
+    return (
+      <>
+        <EnvStatusBanner ui={envUi} onRetry={() => void retryEnv()} />
+        <OnboardingWizard loadStorageInfo={loadStorageInfo} />
+      </>
+    )
   }
 
   if (!isSessionPersistenceHydrated && isSessionPersistenceLoading) {

--- a/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
@@ -359,6 +359,23 @@ describe('RuntimesPanel', () => {
     expect(registerInterpreter).not.toHaveBeenCalled()
   })
 
+  it('blocks app-managed setup while the authoritative environment status is unavailable', async () => {
+    ;(window.api.notebookEnv.getStatus as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('status unavailable')
+    )
+    useNotebookEnvStore.setState({ statusError: 'status unavailable' })
+    await render()
+
+    const rSection = container.querySelector('section[aria-label="R runtime"]')
+    const setupButton = Array.from(rSection?.querySelectorAll('button') ?? []).find((button) =>
+      /download and set up/i.test(button.textContent ?? '')
+    )
+
+    expect(setupButton?.disabled).toBe(true)
+    await click(setupButton ?? null)
+    expect(provision).not.toHaveBeenCalled()
+  })
+
   it('shows a determinate progress bar + Cancel in the app-managed setup card while downloading', async () => {
     await render()
     // R has no provisioned managed env, so its section shows the app-managed SETUP card (which carries

--- a/src/renderer/src/pages/settings/RuntimesPanel.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.tsx
@@ -96,6 +96,7 @@ const RuntimesPanel = ({ title, description }: RuntimesPanelProps): React.JSX.El
   const provisionEnv = useNotebookEnvStore((state) => state.provision)
   const cancelEnv = useNotebookEnvStore((state) => state.cancel)
   const resetEnv = useNotebookEnvStore((state) => state.reset)
+  const statusError = useNotebookEnvStore((state) => state.statusError)
   // Per-language provisioning state: python and R each track their own progress/preparing/error, so
   // requesting one never makes the other's card look cancelled (the provisioner serializes the runs).
   const byLang = useNotebookEnvStore((state) => state.byLang)
@@ -310,6 +311,7 @@ const RuntimesPanel = ({ title, description }: RuntimesPanelProps): React.JSX.El
   }
 
   const provisionManaged = async (language: NotebookLanguage): Promise<void> => {
+    if (statusError) return
     // Provisioning deliberately avoids the panel-wide busy flag. Per-language store state marks only
     // the active runtime as preparing and leaves its Cancel action available throughout the download.
     setManagedOperations((current) => ({ ...current, [language]: true }))
@@ -329,6 +331,7 @@ const RuntimesPanel = ({ title, description }: RuntimesPanelProps): React.JSX.El
   // Explicit recovery for a recovery-BLOCKED runtime (a prior setup's worker couldn't be confirmed
   // stopped, so plain provision keeps refusing). Reset force-clears the quarantine and rebuilds.
   const resetManaged = async (language: NotebookLanguage): Promise<void> => {
+    if (statusError) return
     setManagedOperations((current) => ({ ...current, [language]: true }))
     setError(null)
     try {
@@ -568,7 +571,7 @@ const RuntimesPanel = ({ title, description }: RuntimesPanelProps): React.JSX.El
                             variant="default"
                             size="sm"
                             className="shrink-0"
-                            disabled={busy}
+                            disabled={busy || Boolean(statusError)}
                             onClick={() => void resetManaged(id)}
                           >
                             {t('Reset runtime')}
@@ -652,7 +655,7 @@ const RuntimesPanel = ({ title, description }: RuntimesPanelProps): React.JSX.El
                             variant="default"
                             size="sm"
                             className="shrink-0"
-                            disabled={busy}
+                            disabled={busy || Boolean(statusError)}
                             onClick={() =>
                               langError?.includes('RUNTIME_RECOVERY_BLOCKED')
                                 ? void resetManaged(id)

--- a/src/renderer/src/pages/workspace/provisioning-view.test.ts
+++ b/src/renderer/src/pages/workspace/provisioning-view.test.ts
@@ -102,6 +102,13 @@ describe('notebookGated', () => {
     expect(notebookGated(s, { kind: 'error', message: 'status unavailable' })).toBe(true)
   })
 
+  it('gates an upgrade-scoped status error before the cached status observes provisioning', () => {
+    const s = status({ pythonReady: true, provisioning: false })
+    expect(
+      notebookGated(s, { kind: 'error', message: 'status unavailable', scope: 'upgrade' })
+    ).toBe(true)
+  })
+
   it('does not gate Python while an R-only status refresh error is shown', () => {
     const s = status({ pythonReady: true, provisioning: true })
     expect(notebookGated(s, { kind: 'error', message: 'status unavailable', scope: 'r' })).toBe(

--- a/src/renderer/src/pages/workspace/provisioning-view.test.ts
+++ b/src/renderer/src/pages/workspace/provisioning-view.test.ts
@@ -102,6 +102,26 @@ describe('notebookGated', () => {
     expect(notebookGated(s, { kind: 'error', message: 'status unavailable' })).toBe(true)
   })
 
+  it('does not gate Python while an R-only status refresh error is shown', () => {
+    const s = status({ pythonReady: true, provisioning: true })
+    expect(notebookGated(s, { kind: 'error', message: 'status unavailable', scope: 'r' })).toBe(
+      false
+    )
+  })
+
+  it('limits a session-scoped status refresh error to its owning notebook', () => {
+    const s = status({ pythonReady: true, provisioning: true })
+    const ui = {
+      kind: 'error' as const,
+      message: 'status unavailable',
+      scope: 'python' as const,
+      sessionId: 'session-a'
+    }
+
+    expect(notebookGated(s, ui, 'session-a')).toBe(true)
+    expect(notebookGated(s, ui, 'session-b')).toBe(false)
+  })
+
   it('does NOT gate while only R is preparing (Python stays usable)', () => {
     const s = status({ pythonReady: true, provisioning: true })
     expect(notebookGated(s, deriveProvisionUi(s, 'r', undefined, undefined))).toBe(false)

--- a/src/renderer/src/pages/workspace/provisioning-view.test.ts
+++ b/src/renderer/src/pages/workspace/provisioning-view.test.ts
@@ -97,6 +97,11 @@ describe('notebookGated', () => {
     expect(notebookGated(s, deriveProvisionUi(s, undefined, undefined, undefined))).toBe(true)
   })
 
+  it('keeps the gate closed when an active upgrade status refresh fails', () => {
+    const s = status({ pythonReady: true, provisioning: true })
+    expect(notebookGated(s, { kind: 'error', message: 'status unavailable' })).toBe(true)
+  })
+
   it('does NOT gate while only R is preparing (Python stays usable)', () => {
     const s = status({ pythonReady: true, provisioning: true })
     expect(notebookGated(s, deriveProvisionUi(s, 'r', undefined, undefined))).toBe(false)

--- a/src/renderer/src/pages/workspace/provisioning-view.ts
+++ b/src/renderer/src/pages/workspace/provisioning-view.ts
@@ -73,7 +73,7 @@ export function notebookGated(
   // A status-read error makes the active operation's exact scope unknown. If the last authoritative
   // snapshot was still provisioning, fail closed so an additive upgrade cannot become interactive
   // merely because its follow-up status refresh failed. The error overlay still exposes Retry.
-  if (ui.kind === 'error' && status.provisioning) return true
+  if (ui.kind === 'error' && status.provisioning) return ui.scope !== 'r'
   if (!status.pythonReady) return true
   return ui.kind === 'preparing' && ui.scope === 'upgrade'
 }

--- a/src/renderer/src/pages/workspace/provisioning-view.ts
+++ b/src/renderer/src/pages/workspace/provisioning-view.ts
@@ -70,10 +70,12 @@ export function notebookGated(
   if (ui.kind !== 'ready' && ui.sessionId && sessionId && ui.sessionId !== sessionId) {
     return false
   }
-  // A status-read error makes the active operation's exact scope unknown. If the last authoritative
-  // snapshot was still provisioning, fail closed so an additive upgrade cannot become interactive
-  // merely because its follow-up status refresh failed. The error overlay still exposes Retry.
-  if (ui.kind === 'error' && status.provisioning) return ui.scope !== 'r'
+  // A progress event can identify Python/upgrade work before its follow-up status refresh observes
+  // provisioning=true. Fail closed from either signal so a refresh failure never opens the gate;
+  // R-only work stays additive, and the error overlay still exposes Retry.
+  if (ui.kind === 'error' && ui.scope !== 'r' && (status.provisioning || ui.scope !== undefined)) {
+    return true
+  }
   if (!status.pythonReady) return true
   return ui.kind === 'preparing' && ui.scope === 'upgrade'
 }

--- a/src/renderer/src/pages/workspace/provisioning-view.ts
+++ b/src/renderer/src/pages/workspace/provisioning-view.ts
@@ -70,6 +70,10 @@ export function notebookGated(
   if (ui.kind !== 'ready' && ui.sessionId && sessionId && ui.sessionId !== sessionId) {
     return false
   }
+  // A status-read error makes the active operation's exact scope unknown. If the last authoritative
+  // snapshot was still provisioning, fail closed so an additive upgrade cannot become interactive
+  // merely because its follow-up status refresh failed. The error overlay still exposes Retry.
+  if (ui.kind === 'error' && status.provisioning) return true
   if (!status.pythonReady) return true
   return ui.kind === 'preparing' && ui.scope === 'upgrade'
 }

--- a/src/renderer/src/stores/notebook-env-store.test.ts
+++ b/src/renderer/src/stores/notebook-env-store.test.ts
@@ -166,6 +166,18 @@ describe('notebook-env-store', () => {
     expect(useNotebookEnvStore.getState().scope).toBe('r')
   })
 
+  it('does not provision or reset while the authoritative status is unavailable', async () => {
+    const { api } = installApi()
+    useNotebookEnvStore.setState({ statusError: 'status unavailable' })
+
+    await useNotebookEnvStore.getState().provision('r')
+    await useNotebookEnvStore.getState().reset('python')
+
+    expect(api.provision).not.toHaveBeenCalled()
+    expect(api.repair).not.toHaveBeenCalled()
+    expect(useNotebookEnvStore.getState().statusError).toBe('status unavailable')
+  })
+
   it('applies a broadcast progress event and refreshes status', async () => {
     const status: ProvisionStatus = {
       pythonReady: false,
@@ -194,12 +206,20 @@ describe('notebook-env-store', () => {
     const { emit } = installApi({ getStatus })
     await useNotebookEnvStore.getState().init()
 
-    emit({ phase: 'download', message: 'Fetching bundle…', progress: 0.25 })
+    emit({
+      phase: 'download',
+      message: 'Fetching bundle…',
+      progress: 0.25,
+      scope: 'r',
+      sessionId: 'session-r'
+    })
 
     await vi.waitFor(() => {
       expect(useNotebookEnvStore.getState().ui).toEqual({
         kind: 'error',
-        message: 'refresh unavailable'
+        message: 'refresh unavailable',
+        scope: 'r',
+        sessionId: 'session-r'
       })
     })
   })

--- a/src/renderer/src/stores/notebook-env-store.test.ts
+++ b/src/renderer/src/stores/notebook-env-store.test.ts
@@ -55,6 +55,27 @@ describe('notebook-env-store', () => {
     expect(useNotebookEnvStore.getState().status.pythonReady).toBe(true)
   })
 
+  it('surfaces an initial status query failure and retries the query without provisioning', async () => {
+    const getStatus = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('status unavailable'))
+      .mockResolvedValueOnce(READY)
+    const { api } = installApi({ getStatus })
+
+    await useNotebookEnvStore.getState().init()
+
+    expect(useNotebookEnvStore.getState().ui).toEqual({
+      kind: 'error',
+      message: 'status unavailable'
+    })
+
+    await useNotebookEnvStore.getState().retry()
+
+    expect(api.getStatus).toHaveBeenCalledTimes(2)
+    expect(api.provision).not.toHaveBeenCalled()
+    expect(useNotebookEnvStore.getState().ui).toEqual({ kind: 'ready' })
+  })
+
   it('maps a recovery-blocked status flag to a RUNTIME_RECOVERY_BLOCKED langError (surfaces Reset)', async () => {
     // Recovery blocks a prefix in the main process WITHOUT touching the ready marker, so status can read
     // ready. The store must translate the *RecoveryBlocked flag into a langError so the UI shows Reset.
@@ -118,6 +139,25 @@ describe('notebook-env-store', () => {
     })
     // status is re-hydrated after each progress tick so provisioning/ready flip in lockstep.
     expect(api.getStatus).toHaveBeenCalledTimes(2)
+  })
+
+  it('surfaces a rejected status refresh after progress without leaking the rejection', async () => {
+    const preparing = { ...createInitialNotebookEnvState().status, provisioning: true }
+    const getStatus = vi
+      .fn()
+      .mockResolvedValueOnce(preparing)
+      .mockRejectedValueOnce(new Error('refresh unavailable'))
+    const { emit } = installApi({ getStatus })
+    await useNotebookEnvStore.getState().init()
+
+    emit({ phase: 'download', message: 'Fetching bundle…', progress: 0.25 })
+
+    await vi.waitFor(() => {
+      expect(useNotebookEnvStore.getState().ui).toEqual({
+        kind: 'error',
+        message: 'refresh unavailable'
+      })
+    })
   })
 
   it('maps language progress scopes and clears the scope for a global upgrade', async () => {

--- a/src/renderer/src/stores/notebook-env-store.test.ts
+++ b/src/renderer/src/stores/notebook-env-store.test.ts
@@ -115,6 +115,50 @@ describe('notebook-env-store', () => {
     expect(api.getStatus).toHaveBeenCalledTimes(2)
   })
 
+  it('ignores an older status failure after a newer refresh succeeds', async () => {
+    let rejectOlder!: (error: Error) => void
+    let resolveNewer!: (status: ProvisionStatus) => void
+    const older = new Promise<ProvisionStatus>((_resolve, reject) => {
+      rejectOlder = reject
+    })
+    const newer = new Promise<ProvisionStatus>((resolve) => {
+      resolveNewer = resolve
+    })
+    installApi({ getStatus: vi.fn().mockReturnValueOnce(older).mockReturnValueOnce(newer) })
+
+    const olderInit = useNotebookEnvStore.getState().init()
+    const newerInit = useNotebookEnvStore.getState().init()
+    resolveNewer(READY)
+    await newerInit
+    rejectOlder(new Error('stale failure'))
+    await olderInit
+
+    expect(useNotebookEnvStore.getState().status).toEqual(READY)
+    expect(useNotebookEnvStore.getState().statusError).toBeUndefined()
+  })
+
+  it('ignores an older status success after a newer refresh fails', async () => {
+    let resolveOlder!: (status: ProvisionStatus) => void
+    let rejectNewer!: (error: Error) => void
+    const older = new Promise<ProvisionStatus>((resolve) => {
+      resolveOlder = resolve
+    })
+    const newer = new Promise<ProvisionStatus>((_resolve, reject) => {
+      rejectNewer = reject
+    })
+    installApi({ getStatus: vi.fn().mockReturnValueOnce(older).mockReturnValueOnce(newer) })
+
+    const olderInit = useNotebookEnvStore.getState().init()
+    const newerInit = useNotebookEnvStore.getState().init()
+    rejectNewer(new Error('current failure'))
+    await newerInit
+    resolveOlder(READY)
+    await olderInit
+
+    expect(useNotebookEnvStore.getState().status.pythonReady).toBe(false)
+    expect(useNotebookEnvStore.getState().statusError).toBe('current failure')
+  })
+
   it('records the scope and forwards provision(lang) to the bridge', async () => {
     const { api } = installApi()
     await useNotebookEnvStore.getState().provision('r')

--- a/src/renderer/src/stores/notebook-env-store.ts
+++ b/src/renderer/src/stores/notebook-env-store.ts
@@ -141,10 +141,17 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
   const applyUi = (partial: Partial<NotebookEnvState>): void =>
     set((s) => {
       const next = { ...s, ...partial }
+      const statusErrorScope = next.progress?.scope ?? next.scope
+      const statusErrorSessionId = next.progress?.sessionId
       return {
         ...partial,
         ui: next.statusError
-          ? ({ kind: 'error', message: next.statusError } as const)
+          ? ({
+              kind: 'error',
+              message: next.statusError,
+              ...(statusErrorScope ? { scope: statusErrorScope } : {}),
+              ...(statusErrorSessionId ? { sessionId: statusErrorSessionId } : {})
+            } as const)
           : deriveProvisionUi(next.status, next.scope, next.progress, next.error)
       }
     })
@@ -261,6 +268,7 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
     },
 
     provision: async (lang) => {
+      if (get().statusError) return
       const bridge = window.api?.notebookEnv
       const scope: ProvisionScope = lang
       applyUi({ scope, progress: undefined, error: undefined })
@@ -326,6 +334,7 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
     // confirmed stopped). Repair force-clears the quarantine and rebuilds — the reachable "Reset" entry
     // for a block that won't clear on its own. Tracked per-language like provision.
     reset: async (lang) => {
+      if (get().statusError) return
       const bridge = window.api?.notebookEnv
       applyUi({ scope: lang, error: undefined })
       applyLang(lang, { preparing: true, error: undefined })

--- a/src/renderer/src/stores/notebook-env-store.ts
+++ b/src/renderer/src/stores/notebook-env-store.ts
@@ -82,6 +82,7 @@ const subscribedBridges = new WeakSet<object>()
 export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
   type ExplicitRun = { operationId: string; startProgressRevision: number }
   type ProgressCursor = { revision: number; operationId?: string; terminal: boolean }
+  let statusRefreshRevision = 0
   const latestProgress = new Map<NotebookLanguage, ProgressCursor>()
   const explicitRuns = new Map<NotebookLanguage, ExplicitRun[]>()
   const localOperationIds = new Map<NotebookLanguage, Set<string>>()
@@ -188,12 +189,15 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
   const refreshStatus = async (
     bridge: typeof window.api.notebookEnv
   ): Promise<ProvisionStatus | undefined> => {
+    const revision = ++statusRefreshRevision
     try {
       const status = await bridge.getStatus()
+      if (revision !== statusRefreshRevision) return undefined
       applyUi({ status, statusError: undefined })
       applyRecoveryBlocks(status)
       return status
     } catch (e) {
+      if (revision !== statusRefreshRevision) return undefined
       applyUi({ statusError: errorText(e) })
       return undefined
     }

--- a/src/renderer/src/stores/notebook-env-store.ts
+++ b/src/renderer/src/stores/notebook-env-store.ts
@@ -21,6 +21,9 @@ export type NotebookEnvState = {
   status: ProvisionStatus
   progress?: ProvisionProgress
   error?: string
+  // A failed authoritative status read is distinct from a failed provision operation: Retry must
+  // re-read status rather than starting a runtime setup while the current environment is unknown.
+  statusError?: string
   // Last explicit provision request; used when an older progress sender omits its operation scope.
   scope?: ProvisionScope
   // Derived view state (contract §4 UI): recomputed from status/scope/progress/error on every update.
@@ -53,6 +56,7 @@ export const createInitialNotebookEnvState = (): NotebookEnvState => {
     status,
     progress: undefined,
     error: undefined,
+    statusError: undefined,
     scope: undefined,
     ui: deriveProvisionUi(status, undefined, undefined, undefined),
     byLang: {}
@@ -131,12 +135,16 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
   // Merges a partial update into state, then re-derives `ui` from the resulting status/scope/
   // progress/error so every consumer of `ui` (onboarding step, launch banner, notebook gate) sees a
   // view that always matches the latest mirrored state (reuses provisioning-view's pure reducer).
+  // An authoritative status-read failure takes precedence over an older operation error until a
+  // later status snapshot succeeds.
   const applyUi = (partial: Partial<NotebookEnvState>): void =>
     set((s) => {
       const next = { ...s, ...partial }
       return {
         ...partial,
-        ui: deriveProvisionUi(next.status, next.scope, next.progress, next.error)
+        ui: next.statusError
+          ? ({ kind: 'error', message: next.statusError } as const)
+          : deriveProvisionUi(next.status, next.scope, next.progress, next.error)
       }
     })
 
@@ -172,6 +180,23 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
       }
       return { byLang }
     })
+  }
+
+  // Every getStatus call crosses a renderer transport and can fail independently of provisioning.
+  // Keep that failure inside the store so fire-and-forget init/progress callers never leak an
+  // unhandled rejection, and so Retry can safely re-read instead of mutating an unknown runtime.
+  const refreshStatus = async (
+    bridge: typeof window.api.notebookEnv
+  ): Promise<ProvisionStatus | undefined> => {
+    try {
+      const status = await bridge.getStatus()
+      applyUi({ status, statusError: undefined })
+      applyRecoveryBlocks(status)
+      return status
+    } catch (e) {
+      applyUi({ statusError: errorText(e) })
+      return undefined
+    }
   }
 
   return {
@@ -225,15 +250,10 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
               )
             }))
           }
-          void bridge.getStatus().then((status) => {
-            applyUi({ status })
-            applyRecoveryBlocks(status)
-          })
+          void refreshStatus(bridge)
         })
       }
-      const status = await bridge.getStatus()
-      applyUi({ status })
-      applyRecoveryBlocks(status)
+      await refreshStatus(bridge)
     },
 
     provision: async (lang) => {
@@ -252,8 +272,7 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
       let failure: string | undefined
       try {
         await bridge.provision(lang, run.operationId)
-        status = await bridge.getStatus()
-        applyUi({ status })
+        status = await refreshStatus(bridge)
       } catch (e) {
         failure = errorText(e)
       } finally {
@@ -284,18 +303,17 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
       try {
         // Forward the language so cancelling this card never aborts the OTHER language's in-flight run.
         await bridge.cancel(lang)
-        const status = await bridge.getStatus()
-        applyUi({ status })
-        // Reapply recovery blocks: if the cancelled run was a queued Reset whose block was never cleared,
-        // status.*RecoveryBlocked is still true and the Reset button must stay visible — not be replaced
-        // by an empty/cancelled state that hides it.
-        applyRecoveryBlocks(status)
+        await refreshStatus(bridge)
       } catch (e) {
         applyUi({ error: errorText(e) })
       }
     },
 
     retry: async () => {
+      if (get().statusError) {
+        await get().init()
+        return
+      }
       const scope = get().scope
       await get().provision(scope === 'r' ? 'r' : 'python')
     },
@@ -316,8 +334,7 @@ export const useNotebookEnvStore = create<NotebookEnvStore>((set, get) => {
       let failure: string | undefined
       try {
         await bridge.repair(lang, run.operationId)
-        status = await bridge.getStatus()
-        applyUi({ status })
+        status = await refreshStatus(bridge)
       } catch (e) {
         failure = errorText(e)
       } finally {


### PR DESCRIPTION
## Problem

When the initial `notebookEnv.getStatus()` call rejected, the renderer kept `pythonReady: false` while its derived UI remained `ready`. Notebook controls were therefore gated, but both the Notebook overlay and global environment banner stayed hidden, leaving no explanation or Retry action. Fire-and-forget initialization also leaked the rejected promise.

## Proposed change

- Track authoritative status-read failures separately from provisioning failures in transient renderer state.
- Route every renderer `getStatus()` refresh through one failure-safe helper.
- Apply status refresh results with latest-request-wins ordering so stale concurrent responses cannot replace newer state.
- Preserve operation scope and Session metadata when projecting a status-read error.
- Surface status-read failures through the existing environment error banner and Notebook overlay, including during onboarding.
- Make Retry re-run status initialization while a status-read error is active, rather than provisioning an environment whose state is unknown.
- Block provision/reset at the store boundary until status is known; an in-flight Cancel remains available.
- Keep Python/upgrade work fail-closed while R-only and unrelated Session work retains its prior availability, including when progress arrives before the cached status observes provisioning.
- Clear the transient error after the next successful authoritative snapshot.

## Scope and non-goals

- No IPC, shared contract, database schema, architecture, or persisted data changes.
- No new enum values and no historical-data compatibility work.
- Normal missing/corrupt readiness markers and unavailable micromamba behavior are unchanged.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Initial query failure is explained and query-Retry recovers without provisioning -> notebook environment store tests -> passed.
- Concurrent status refreshes are latest-request-wins in both success/failure orderings -> notebook environment store tests -> passed.
- Status errors retain R-only and Session scope while Python/upgrade work stays gated, including before cached provisioning catches up -> store and provisioning-view tests -> passed.
- Every provision/reset entry point blocks while authoritative status is unavailable -> store and RuntimesPanel tests -> passed.
- Onboarding mounts the shared status error/Retry surface -> App and NotebookStep tests -> passed.
- Existing global banner, Notebook gate, onboarding, and runtime settings consumers remain compatible -> targeted seven-file renderer test set -> 158 passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- User-visible string/catalog guard -> `npx vitest run src/renderer/src/i18n/resources.test.ts` -> 67 passed.
- Source lint -> `npm run lint` -> passed with no warnings.

The module-impact manifest does not currently assign `notebook-env-store` to an owner module, so there is no valid local `test:module` ID for this path. Per maintainer direction, the complete `npm test` suite was not run locally; exact-head PR CI is authoritative and will fail closed for unknown ownership.

## Review focus

- Status-query errors remain renderer-only, transient, and non-persistent.
- Latest-request-wins ordering covers overlapping App, onboarding, Settings, and progress refreshes.
- Retry branches on the explicit transient status error and cannot accidentally start provisioning.
- Status errors preserve operation scope/Session: Python and upgrade work remain gated, R-only and unrelated Sessions retain availability, and setup/reset stays blocked until status recovers.