### PR TITLE
fix(database): enforce remaining SQLite domain constraints

### DIFF
--- a/prisma/sqlite-check-constraints.json
+++ b/prisma/sqlite-check-constraints.json
@@ -11,9 +11,44 @@
       "expression": "\"attentionReason\" IS NULL OR \"attentionReason\" IN ('waiting-for-user', 'waiting-permission', 'waiting-plan-approval', 'task-max-tokens', 'task-max-turn-requests', 'task-refusal', 'task-unclean-stop')"
     },
     {
+      "tableName": "NotificationInboxItem",
+      "name": "NotificationInboxItem_kind_check",
+      "expression": "\"kind\" IN ('task.completed', 'task.needs-attention', 'task.failed', 'authorization.required')"
+    },
+    {
+      "tableName": "NotificationInboxItem",
+      "name": "NotificationInboxItem_actionState_check",
+      "expression": "\"actionState\" IS NULL OR \"actionState\" IN ('pending', 'resolved', 'rejected', 'expired', 'cancelled')"
+    },
+    {
+      "tableName": "NotificationInboxItem",
+      "name": "NotificationInboxItem_actionLifecycle_check",
+      "expression": "((\"actionState\" IS NULL AND \"settledAt\" IS NULL) OR (\"actionState\" IS NOT NULL AND ((\"actionState\" = 'pending' AND \"settledAt\" IS NULL) OR (\"actionState\" IN ('resolved', 'rejected', 'expired', 'cancelled') AND \"settledAt\" IS NOT NULL))))"
+    },
+    {
+      "tableName": "NotificationInboxItem",
+      "name": "NotificationInboxItem_actionKind_check",
+      "expression": "\"actionState\" IS NULL OR \"kind\" IN ('task.needs-attention', 'authorization.required')"
+    },
+    {
+      "tableName": "NotificationInboxItem",
+      "name": "NotificationInboxItem_targetInvalidated_check",
+      "expression": "\"targetInvalidatedAt\" IS NULL OR (\"sessionId\" IS NOT NULL AND \"readAt\" IS NOT NULL)"
+    },
+    {
       "tableName": "PermissionGrant",
       "name": "PermissionGrant_capabilityKind_check",
       "expression": "\"capabilityKind\" IN ('customize_mutation', 'mcp_tool', 'execution', 'file_operation', 'skill_operation', 'builtin_tool')"
+    },
+    {
+      "tableName": "ProjectPreviewState",
+      "name": "ProjectPreviewState_panelState_check",
+      "expression": "\"panelState\" IN ('open', 'collapsed')"
+    },
+    {
+      "tableName": "ProjectPreviewState",
+      "name": "ProjectPreviewState_itemsJson_check",
+      "expression": "json_valid(\"items\") AND json_type(\"items\") = 'array'"
     },
     {
       "tableName": "PermissionGrant",
@@ -41,6 +76,21 @@
       "expression": "\"state\" IN ('active', 'deleting', 'deleted')"
     },
     {
+      "tableName": "FileOriginSession",
+      "name": "FileOriginSession_retainedReviewIdsJson_check",
+      "expression": "\"retainedReviewIdsJson\" IS NULL OR (json_valid(\"retainedReviewIdsJson\") AND json_type(\"retainedReviewIdsJson\") = 'array')"
+    },
+    {
+      "tableName": "FileOriginSession",
+      "name": "FileOriginSession_lifecycle_check",
+      "expression": "((\"state\" = 'active' AND \"deletedAt\" IS NULL AND \"deletionOperationId\" IS NULL AND \"retainedReviewIdsJson\" IS NULL) OR (\"state\" = 'deleting' AND \"deletedAt\" IS NULL AND \"deletionOperationId\" IS NOT NULL AND \"retainedReviewIdsJson\" IS NOT NULL) OR (\"state\" = 'deleted' AND \"deletedAt\" IS NOT NULL AND \"deletionOperationId\" IS NULL AND \"retainedReviewIdsJson\" IS NULL))"
+    },
+    {
+      "tableName": "ManagedFile",
+      "name": "ManagedFile_source_check",
+      "expression": "\"source\" IN ('artifact', 'upload')"
+    },
+    {
       "tableName": "UploadVersion",
       "name": "UploadVersion_state_check",
       "expression": "\"state\" IN ('staging', 'ready')"
@@ -61,6 +111,21 @@
       "expression": "length(\"filename\") > 0"
     },
     {
+      "tableName": "ArtifactVersion",
+      "name": "ArtifactVersion_evidenceJson_check",
+      "expression": "json_valid(\"evidenceJson\") AND json_type(\"evidenceJson\") = 'object'"
+    },
+    {
+      "tableName": "ArtifactVersion",
+      "name": "ArtifactVersion_executionSnapshotJson_check",
+      "expression": "\"executionSnapshotJson\" IS NULL OR (json_valid(\"executionSnapshotJson\") AND json_type(\"executionSnapshotJson\") = 'object')"
+    },
+    {
+      "tableName": "ArtifactVersion",
+      "name": "ArtifactVersion_executionSnapshotBundle_check",
+      "expression": "((\"executionSnapshotJson\" IS NULL AND \"executionSnapshotChecksum\" IS NULL AND \"executionSnapshotStorageKey\" IS NULL AND \"executionSnapshotSchemaVersion\" IS NULL) OR (\"executionSnapshotJson\" IS NOT NULL AND \"executionSnapshotChecksum\" IS NOT NULL AND \"executionSnapshotStorageKey\" IS NOT NULL AND \"executionSnapshotSchemaVersion\" IS NOT NULL))"
+    },
+    {
       "tableName": "ArtifactVersionInput",
       "name": "ArtifactVersionInput_sourceKind_check",
       "expression": "\"sourceKind\" IN ('artifact-version', 'upload-version')"
@@ -71,9 +136,19 @@
       "expression": "((\"sourceKind\" = 'artifact-version' AND \"sourceArtifactVersionId\" IS NOT NULL AND \"sourceUploadVersionId\" IS NULL AND \"inputFileVersionId\" = \"sourceArtifactVersionId\") OR (\"sourceKind\" = 'upload-version' AND \"sourceArtifactVersionId\" IS NULL AND \"sourceUploadVersionId\" IS NOT NULL AND \"inputFileVersionId\" = \"sourceUploadVersionId\"))"
     },
     {
+      "tableName": "ArtifactVersionInput",
+      "name": "ArtifactVersionInput_strongestAssociation_check",
+      "expression": "\"strongestAssociation\" IN ('turn-attached', 'resolver-accessed', 'captured-version')"
+    },
+    {
       "tableName": "ReviewScopeSnapshot",
       "name": "ReviewScopeSnapshot_state_check",
       "expression": "\"state\" IN ('staging', 'ready')"
+    },
+    {
+      "tableName": "ReviewScopeSnapshot",
+      "name": "ReviewScopeSnapshot_snapshotJson_check",
+      "expression": "json_valid(\"snapshotJson\") AND json_type(\"snapshotJson\") = 'object'"
     },
     {
       "tableName": "Review",
@@ -89,6 +164,16 @@
       "tableName": "Review",
       "name": "Review_state_check",
       "expression": "((\"lifecycle\" = 'running' AND \"outcome\" IS NULL AND \"errorMessage\" IS NULL) OR (\"lifecycle\" = 'complete' AND \"outcome\" IS NOT NULL AND \"errorMessage\" IS NULL) OR (\"lifecycle\" = 'error' AND \"outcome\" IS NULL AND \"errorMessage\" IS NOT NULL))"
+    },
+    {
+      "tableName": "Review",
+      "name": "Review_scopeJson_check",
+      "expression": "json_valid(\"scope\") AND json_type(\"scope\") = 'object'"
+    },
+    {
+      "tableName": "Review",
+      "name": "Review_reviewerLogJson_check",
+      "expression": "json_valid(\"reviewerLog\") AND json_type(\"reviewerLog\") = 'array'"
     },
     {
       "tableName": "Finding",
@@ -126,6 +211,11 @@
       "expression": "\"artifactBindingState\" <> 'scope_validated' OR \"artifactVersionId\" IS NOT NULL"
     },
     {
+      "tableName": "Finding",
+      "name": "Finding_locatorJson_check",
+      "expression": "json_valid(\"locator\") AND json_type(\"locator\") = 'object'"
+    },
+    {
       "tableName": "ReviewFindingDisposition",
       "name": "ReviewFindingDisposition_sequence_check",
       "expression": "\"sequence\" >= 1"
@@ -144,6 +234,11 @@
       "tableName": "ReviewFindingDisposition",
       "name": "ReviewFindingDisposition_state_check",
       "expression": "((\"trigger\" = 'review_submission' AND \"causeReviewId\" IS NOT NULL AND \"outcome\" IN ('still_open', 'resolved')) OR (\"trigger\" IN ('loop_terminated', 'correction_failed', 'aborted') AND \"causeReviewId\" IS NULL AND \"outcome\" = 'unaddressed'))"
+    },
+    {
+      "tableName": "ReviewFindingDisposition",
+      "name": "ReviewFindingDisposition_assessmentSnapshotJson_check",
+      "expression": "\"assessmentSnapshot\" IS NULL OR (json_valid(\"assessmentSnapshot\") AND json_type(\"assessmentSnapshot\") = 'object')"
     },
     {
       "tableName": "ComputeJob",
@@ -186,6 +281,36 @@
       "expression": "((\"errorCode\" IS NULL OR \"status\" IN ('failed', 'timeout', 'error')) AND (\"status\" <> 'error' OR \"errorCode\" IS NOT NULL))"
     },
     {
+      "tableName": "ComputeJob",
+      "name": "ComputeJob_resourceRequestJson_check",
+      "expression": "\"resourceRequest\" IS NULL OR (json_valid(\"resourceRequest\") AND json_type(\"resourceRequest\") = 'object')"
+    },
+    {
+      "tableName": "ComputeJob",
+      "name": "ComputeJob_inputManifestJson_check",
+      "expression": "\"inputManifest\" IS NULL OR (json_valid(\"inputManifest\") AND json_type(\"inputManifest\") = 'array')"
+    },
+    {
+      "tableName": "ComputeJob",
+      "name": "ComputeJob_outputManifestJson_check",
+      "expression": "\"outputManifest\" IS NULL OR (json_valid(\"outputManifest\") AND json_type(\"outputManifest\") = 'array')"
+    },
+    {
+      "tableName": "ComputeJob",
+      "name": "ComputeJob_harvestConfigJson_check",
+      "expression": "\"harvestConfig\" IS NULL OR (json_valid(\"harvestConfig\") AND json_type(\"harvestConfig\") = 'object')"
+    },
+    {
+      "tableName": "ComputeJob",
+      "name": "ComputeJob_remoteHandleJson_check",
+      "expression": "\"remoteHandle\" IS NULL OR (json_valid(\"remoteHandle\") AND json_type(\"remoteHandle\") = 'object')"
+    },
+    {
+      "tableName": "ComputeJob",
+      "name": "ComputeJob_leftOnRemoteJson_check",
+      "expression": "\"leftOnRemote\" IS NULL OR (json_valid(\"leftOnRemote\") AND json_type(\"leftOnRemote\") = 'array')"
+    },
+    {
       "tableName": "ComputeHost",
       "name": "ComputeHost_shape_check",
       "expression": "\"shape\" IN ('direct_ssh', 'scheduler_cluster', 'bridge_runner')"
@@ -214,6 +339,16 @@
       "tableName": "ComputeHost",
       "name": "ComputeHost_scratchRoot_check",
       "expression": "\"scratchPinned\" = false OR \"scratchRoot\" IS NOT NULL"
+    },
+    {
+      "tableName": "ComputeHost",
+      "name": "ComputeHost_sshOverridesJson_check",
+      "expression": "\"sshOverrides\" IS NULL OR (json_valid(\"sshOverrides\") AND json_type(\"sshOverrides\") = 'object')"
+    },
+    {
+      "tableName": "ComputeHost",
+      "name": "ComputeHost_probeResultJson_check",
+      "expression": "\"probeResult\" IS NULL OR (json_valid(\"probeResult\") AND json_type(\"probeResult\") = 'object')"
     },
     {
       "tableName": "GrantedLocalRoot",

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -32,6 +32,10 @@ const EXPECTED_MIGRATION_LEDGER = [
   {
     id: '0007_notification_attention_metadata',
     checksum: 'fad3ef7da9f26b7d6da2321ca44674d5c96238ab65515714b51dfe76df7fe10a'
+  },
+  {
+    id: '0008_database_json_constraints',
+    checksum: 'c4e978ff2a0176b61cf9d07f80a521c5444ec716d11804c6d26b9d8757766423'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/scripts/database-migration-ledger-smoke.test.ts
+++ b/scripts/database-migration-ledger-smoke.test.ts
@@ -17,7 +17,7 @@ import { PrismaClient } from '@prisma/client'
 describe('packaged database migration ledger smoke', () => {
   it('pins every packaged application migration identity and checksum', () => {
     expect(MIGRATION_MANIFEST.at(-1)?.checksum).toBe(
-      'fad3ef7da9f26b7d6da2321ca44674d5c96238ab65515714b51dfe76df7fe10a'
+      'c4e978ff2a0176b61cf9d07f80a521c5444ec716d11804c6d26b9d8757766423'
     )
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST)).not.toThrow()
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST.slice(0, -1))).toThrow(

--- a/src/main/artifacts/ipc.test.ts
+++ b/src/main/artifacts/ipc.test.ts
@@ -452,7 +452,9 @@ describe('artifact IPC handlers', () => {
         where: { id: version.versionId },
         data: {
           executionSnapshotJson: '{"schemaVersion":2}',
-          executionSnapshotChecksum: '0'.repeat(64)
+          executionSnapshotChecksum: '0'.repeat(64),
+          executionSnapshotStorageKey: 'corrupt-execution.json',
+          executionSnapshotSchemaVersion: 2
         }
       })
       await compatibility.prepareRunFinalization({

--- a/src/main/artifacts/provenance-repository.test.ts
+++ b/src/main/artifacts/provenance-repository.test.ts
@@ -1075,7 +1075,8 @@ describe('artifact provenance repository', () => {
         projectId: 'project-1',
         sessionId: 'session-1',
         state: 'deleting',
-        deletionOperationId: 'delete-1'
+        deletionOperationId: 'delete-1',
+        retainedReviewIdsJson: '[]'
       }
     })
     await compatibilityRepository.writePendingFile({
@@ -2924,6 +2925,7 @@ describe('artifact provenance repository', () => {
       data: {
         executionSnapshotJson: invalidExecution,
         executionSnapshotChecksum: createHash('sha256').update(invalidExecution).digest('hex'),
+        executionSnapshotStorageKey: 'invalid-execution.json',
         executionSnapshotSchemaVersion: 2
       }
     })
@@ -2935,6 +2937,7 @@ describe('artifact provenance repository', () => {
       data: {
         executionSnapshotJson: ancestryProbe.executionSnapshotJson,
         executionSnapshotChecksum: ancestryProbe.executionSnapshotChecksum,
+        executionSnapshotStorageKey: ancestryProbe.executionSnapshotStorageKey,
         executionSnapshotSchemaVersion: ancestryProbe.executionSnapshotSchemaVersion
       }
     })
@@ -2982,6 +2985,7 @@ describe('artifact provenance repository', () => {
         producerRunIndex: 0,
         executionSnapshotJson: forgedExecution,
         executionSnapshotChecksum: forgedExecutionChecksum,
+        executionSnapshotStorageKey: 'forged-execution.json',
         executionSnapshotSchemaVersion: 2,
         evidenceJson: forgedEvidence,
         evidenceChecksum: createHash('sha256').update(forgedEvidence).digest('hex')
@@ -2998,6 +3002,7 @@ describe('artifact provenance repository', () => {
         producerRunIndex: ancestryProbe.producerRunIndex,
         executionSnapshotJson: ancestryProbe.executionSnapshotJson,
         executionSnapshotChecksum: ancestryProbe.executionSnapshotChecksum,
+        executionSnapshotStorageKey: ancestryProbe.executionSnapshotStorageKey,
         executionSnapshotSchemaVersion: ancestryProbe.executionSnapshotSchemaVersion,
         evidenceJson: ancestryProbe.evidenceJson,
         evidenceChecksum: ancestryProbe.evidenceChecksum

--- a/src/main/compute/job-repository.test.ts
+++ b/src/main/compute/job-repository.test.ts
@@ -186,7 +186,8 @@ describe('ComputeJob schema migration (integration)', () => {
         '0004_review_assessment_snapshots',
         '0005_project_preview_state_owner_fk',
         '0006_database_domain_constraints',
-        '0007_notification_attention_metadata'
+        '0007_notification_attention_metadata',
+        '0008_database_json_constraints'
       ]
     })
     // Idempotent second run.
@@ -266,7 +267,8 @@ describe('ComputeJob schema migration (integration)', () => {
         '0004_review_assessment_snapshots',
         '0005_project_preview_state_owner_fk',
         '0006_database_domain_constraints',
-        '0007_notification_attention_metadata'
+        '0007_notification_attention_metadata',
+        '0008_database_json_constraints'
       ]
     })
     // Idempotent second run.

--- a/src/main/compute/prisma-client.test.ts
+++ b/src/main/compute/prisma-client.test.ts
@@ -125,7 +125,8 @@ describe('compute host prisma client (integration)', () => {
         '0004_review_assessment_snapshots',
         '0005_project_preview_state_owner_fk',
         '0006_database_domain_constraints',
-        '0007_notification_attention_metadata'
+        '0007_notification_attention_metadata',
+        '0008_database_json_constraints'
       ]
     })
     // Idempotent second run.

--- a/src/main/database/database-json-constraints-migration.test.ts
+++ b/src/main/database/database-json-constraints-migration.test.ts
@@ -1,0 +1,214 @@
+import { access, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { PrismaClient } from '@prisma/client'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createProjectDbClient } from '../projects/prisma-client'
+import { MIGRATION_MANIFEST, migrateApplicationDatabase } from './migration-service'
+import { applySqliteMigrationOperations } from './sqlite-schema-migrations'
+
+const MIGRATION_ID = '0008_database_json_constraints'
+
+const createDatabaseAtMigration0007 = async (client: PrismaClient): Promise<void> => {
+  const migration0008Index = MIGRATION_MANIFEST.findIndex(
+    (migration) => migration.id === MIGRATION_ID
+  )
+  const prefix = MIGRATION_MANIFEST.slice(0, migration0008Index)
+  for (const migration of prefix) {
+    for (const statement of migration.statements) await client.$executeRawUnsafe(statement)
+    if ('operations' in migration) {
+      await client.$transaction((transaction) =>
+        applySqliteMigrationOperations(transaction, migration.operations)
+      )
+    }
+  }
+  await client.$executeRawUnsafe(`CREATE TABLE "_open_science_migrations" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "checksum" TEXT NOT NULL,
+    "appliedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "_open_science_migrations_checksum_check"
+      CHECK (length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*')
+  )`)
+  for (const migration of prefix) {
+    await client.$executeRawUnsafe(
+      `INSERT INTO "_open_science_migrations" ("id", "checksum") VALUES (?, ?)`,
+      migration.id,
+      migration.checksum
+    )
+  }
+}
+
+const seedValidAffectedRows = async (client: PrismaClient): Promise<void> => {
+  await client.$executeRawUnsafe(
+    `INSERT INTO "Project" ("id","name","updatedAt") VALUES ('project','Project',CURRENT_TIMESTAMP)`
+  )
+  await client.$executeRawUnsafe(
+    `INSERT INTO "ProjectPreviewState" ("projectId","panelState","items","updatedAt") VALUES ('project','collapsed','[{"id":"preview"}]',CURRENT_TIMESTAMP)`
+  )
+  await client.$executeRawUnsafe(
+    `INSERT INTO "NotificationInboxItem" ("sequence","id","dedupeKey","kind","sessionId","originId","title","summary") VALUES (11,'notification','notification','task.completed','session','origin','Title','Summary')`
+  )
+  await client.$executeRawUnsafe(
+    `INSERT INTO "Review" ("id","projectId","sessionId","turnMessageId","lifecycle","scope","reviewerLog","updatedAt") VALUES ('review','project','session','message','running','{"paths":["result.txt"]}','[{"event":"started"}]',CURRENT_TIMESTAMP)`
+  )
+  await client.$executeRawUnsafe(
+    `INSERT INTO "Finding" ("id","reviewId","status","locator") VALUES ('finding','review','warn','{"path":"result.txt"}')`
+  )
+  await client.$executeRawUnsafe(
+    `INSERT INTO "ReviewFindingDisposition" ("id","sourceFindingId","sequence","trigger","outcome","assessmentSnapshot") VALUES ('disposition','finding',1,'aborted','unaddressed','{"reason":"stopped"}')`
+  )
+  await client.$executeRawUnsafe(
+    `INSERT INTO "ReviewScopeSnapshot" ("id","projectId","sessionId","reviewId","scopeTurnMessageId","snapshotJson","checksum","storageKey","blockCount") VALUES ('scope-snapshot','project','session','review','message','{"blocks":[]}','checksum','snapshot.json',0)`
+  )
+  await client.$executeRawUnsafe(
+    `INSERT INTO "FileOriginSession" ("projectId","sessionId","updatedAt") VALUES ('project','session',CURRENT_TIMESTAMP)`
+  )
+  await client.$executeRawUnsafe(
+    `INSERT INTO "ArtifactLineage" ("id","projectId","sessionId","normalizedFilename","filename","updatedAt") VALUES ('lineage','project','session','result.txt','result.txt',CURRENT_TIMESTAMP)`
+  )
+  await client.$executeRawUnsafe(
+    `INSERT INTO "ArtifactVersion" (
+      "id","artifactId","versionNumber","filename","artifactRunId","rootFrameId","agentFrameId",
+      "messageBranchId","runtimeSegmentId","promptMessageId","state","contentStorageKey",
+      "evidenceStorageKey","sizeBytes","checksum","evidenceJson","evidenceChecksum","updatedAt"
+    ) VALUES (
+      'version','lineage',1,'result.txt','run','root','agent','branch','segment','prompt','staging',
+      'content','evidence.json',0,'checksum','{"sources":[]}','evidence-checksum',CURRENT_TIMESTAMP
+    )`
+  )
+  await client.$executeRawUnsafe(
+    `INSERT INTO "ArtifactVersionInput" (
+      "id","artifactVersionId","ordinal","inputFileVersionId","sourceKind","sourceFileId",
+      "sourceArtifactVersionId","sourceProjectId","sourceSessionId","filename","sizeBytes",
+      "checksum","storageKey","strongestAssociation"
+    ) VALUES (
+      'input','version',0,'version','artifact-version','lineage','version','project','session',
+      'result.txt',0,'checksum','content','turn-attached'
+    )`
+  )
+  await client.$executeRawUnsafe(
+    `INSERT INTO "ManagedFile" (
+      "seq","source","sourceFileId","projectId","sessionId","displayName","storageKey",
+      "sizeBytes","sortAtMs","updatedAt"
+    ) VALUES (13,'artifact','lineage','project','session','result.txt','content',0,0,CURRENT_TIMESTAMP)`
+  )
+  await client.$executeRawUnsafe(
+    `INSERT INTO "ComputeJob" (
+      "id","providerId","shape","sessionId","projectId","status","intent","command","commandHash",
+      "resourceRequest","inputManifest","outputManifest","harvestConfig","remoteHandle"
+    ) VALUES (
+      'job','ssh:host','direct_ssh','session','project','submitted','intent','command','hash',
+      '{"cpu":1}','[]','[]','{}','{"jobId":"remote"}'
+    )`
+  )
+  await client.$executeRawUnsafe(
+    `INSERT INTO "ComputeHost" ("id","providerId","displayName","sshAlias","sshOverrides","probeResult","updatedAt") VALUES ('host','ssh:host','Host','host','{}','{"reachable":true}',CURRENT_TIMESTAMP)`
+  )
+}
+
+describe('database JSON constraints migration', () => {
+  let storageRoot: string | undefined
+  let client: PrismaClient | undefined
+
+  afterEach(async () => {
+    await client?.$disconnect()
+    if (storageRoot) await rm(storageRoot, { recursive: true, force: true })
+  })
+
+  it('preserves valid rows, indexes, foreign keys, and AUTOINCREMENT boundaries', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-json-0008-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    client = createProjectDbClient(storageRoot)
+    await createDatabaseAtMigration0007(client)
+    await seedValidAffectedRows(client)
+
+    await expect(migrateApplicationDatabase(client, { databasePath })).resolves.toEqual({
+      adoptedLegacy: false,
+      applied: [MIGRATION_ID],
+      from: '0007_notification_attention_metadata',
+      to: MIGRATION_ID
+    })
+    await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).resolves.toBeUndefined()
+
+    await expect(
+      client.$queryRaw<Array<{ scope: string; reviewerLog: string }>>`
+        SELECT "scope", "reviewerLog" FROM "Review" WHERE "id" = 'review'
+      `
+    ).resolves.toEqual([
+      { scope: '{"paths":["result.txt"]}', reviewerLog: '[{"event":"started"}]' }
+    ])
+    await expect(
+      client.$queryRaw<Array<{ evidenceJson: string; strongestAssociation: string }>>`
+        SELECT "ArtifactVersion"."evidenceJson", "ArtifactVersionInput"."strongestAssociation"
+        FROM "ArtifactVersion"
+        JOIN "ArtifactVersionInput"
+          ON "ArtifactVersionInput"."artifactVersionId" = "ArtifactVersion"."id"
+        WHERE "ArtifactVersion"."id" = 'version'
+      `
+    ).resolves.toEqual([{ evidenceJson: '{"sources":[]}', strongestAssociation: 'turn-attached' }])
+    await expect(client.$queryRawUnsafe('PRAGMA foreign_key_check')).resolves.toEqual([])
+
+    await client.$executeRawUnsafe(
+      `INSERT INTO "NotificationInboxItem" ("id","dedupeKey","kind","originId","title","summary") VALUES ('next-notification','next-notification','task.completed','next-origin','Title','Summary')`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ManagedFile" (
+        "source","sourceFileId","projectId","sessionId","displayName","storageKey",
+        "sizeBytes","sortAtMs","updatedAt"
+      ) VALUES ('upload','next-file','project','session','next.txt','next-content',0,1,CURRENT_TIMESTAMP)`
+    )
+    await expect(
+      client.$queryRaw<Array<{ sequence: number }>>`
+        SELECT "sequence" FROM "NotificationInboxItem" WHERE "id" = 'next-notification'
+      `
+    ).resolves.toEqual([{ sequence: 12 }])
+    await expect(
+      client.$queryRaw<Array<{ seq: number }>>`
+        SELECT "seq" FROM "ManagedFile" WHERE "sourceFileId" = 'next-file'
+      `
+    ).resolves.toEqual([{ seq: 14 }])
+  })
+
+  it('fails closed and rolls back all rebuilt tables when historical data is invalid', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-json-0008-invalid-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    client = createProjectDbClient(storageRoot)
+    await createDatabaseAtMigration0007(client)
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Project" ("id","name","updatedAt") VALUES ('project','Project',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ProjectPreviewState" ("projectId","panelState","items","updatedAt") VALUES ('project','collapsed','[]',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "NotificationInboxItem" ("id","dedupeKey","kind","originId","title","summary") VALUES ('invalid','invalid','custom.kind','origin','Title','Summary')`
+    )
+
+    await expect(migrateApplicationDatabase(client, { databasePath })).rejects.toMatchObject({
+      code: 'database_validation_failed',
+      migrationId: MIGRATION_ID
+    })
+    await expect(
+      client.$queryRaw<Array<{ id: string }>>`
+        SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1
+      `
+    ).resolves.toEqual([{ id: '0007_notification_attention_metadata' }])
+    await expect(
+      client.$queryRaw<Array<{ kind: string }>>`
+        SELECT "kind" FROM "NotificationInboxItem" WHERE "id" = 'invalid'
+      `
+    ).resolves.toEqual([{ kind: 'custom.kind' }])
+    await expect(
+      client.$queryRaw<Array<{ sql: string }>>`
+        SELECT "sql" FROM "sqlite_schema" WHERE "type" = 'table' AND "name" = 'ProjectPreviewState'
+      `
+    ).resolves.not.toEqual([
+      expect.objectContaining({
+        sql: expect.stringContaining('ProjectPreviewState_panelState_check')
+      })
+    ])
+    await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).resolves.toBeUndefined()
+  })
+})

--- a/src/main/database/database-json-constraints-migration.test.ts
+++ b/src/main/database/database-json-constraints-migration.test.ts
@@ -123,6 +123,20 @@ describe('database JSON constraints migration', () => {
     client = createProjectDbClient(storageRoot)
     await createDatabaseAtMigration0007(client)
     await seedValidAffectedRows(client)
+    await client.$executeRawUnsafe(
+      `INSERT INTO "NotificationInboxItem" ("sequence","id","dedupeKey","kind","originId","title","summary") VALUES (41,'deleted-notification','deleted-notification','task.completed','deleted-origin','Title','Summary')`
+    )
+    await client.$executeRawUnsafe(
+      `DELETE FROM "NotificationInboxItem" WHERE "id" = 'deleted-notification'`
+    )
+    await client.$executeRawUnsafe(`DELETE FROM "ManagedFile"`)
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ManagedFile" (
+        "seq","source","sourceFileId","projectId","sessionId","displayName","storageKey",
+        "sizeBytes","sortAtMs","updatedAt"
+      ) VALUES (43,'upload','deleted-file','project','session','deleted.txt','deleted-content',0,0,CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(`DELETE FROM "ManagedFile"`)
 
     await expect(migrateApplicationDatabase(client, { databasePath })).resolves.toEqual({
       adoptedLegacy: false,
@@ -163,12 +177,12 @@ describe('database JSON constraints migration', () => {
       client.$queryRaw<Array<{ sequence: number }>>`
         SELECT "sequence" FROM "NotificationInboxItem" WHERE "id" = 'next-notification'
       `
-    ).resolves.toEqual([{ sequence: 12 }])
+    ).resolves.toEqual([{ sequence: 42 }])
     await expect(
       client.$queryRaw<Array<{ seq: number }>>`
         SELECT "seq" FROM "ManagedFile" WHERE "sourceFileId" = 'next-file'
       `
-    ).resolves.toEqual([{ seq: 14 }])
+    ).resolves.toEqual([{ seq: 44 }])
   })
 
   it('fails closed and rolls back all rebuilt tables when historical data is invalid', async () => {

--- a/src/main/database/database-json-constraints.test.ts
+++ b/src/main/database/database-json-constraints.test.ts
@@ -1,0 +1,250 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { PrismaClient } from '@prisma/client'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createProjectDbClient } from '../projects/prisma-client'
+import { migrateApplicationDatabase } from './migration-service'
+
+describe('database JSON and remaining domain constraints', () => {
+  let client: PrismaClient | undefined
+  let storageRoot: string | undefined
+
+  afterEach(async () => {
+    await client?.$disconnect()
+    if (storageRoot) await rm(storageRoot, { force: true, recursive: true })
+  })
+
+  it('rejects invalid closed values, JSON roots, and field combinations', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-json-constraints-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Project" ("id","name","updatedAt") VALUES ('project','Project',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ProjectPreviewState" ("projectId","panelState","items","updatedAt") VALUES ('project','collapsed','[]',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "NotificationInboxItem" ("id","dedupeKey","kind","sessionId","originId","title","summary") VALUES ('notification','notification','task.completed','session','origin','Title','Summary')`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Review" ("id","projectId","sessionId","turnMessageId","lifecycle","scope","reviewerLog","updatedAt") VALUES ('review','project','session','message','running','{}','[]',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "Finding" ("id","reviewId","status","locator") VALUES ('finding','review','warn','{}')`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ReviewFindingDisposition" ("id","sourceFindingId","sequence","trigger","outcome") VALUES ('disposition','finding',1,'aborted','unaddressed')`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ReviewScopeSnapshot" ("id","projectId","sessionId","reviewId","scopeTurnMessageId","snapshotJson","checksum","storageKey","blockCount") VALUES ('scope-snapshot','project','session','review','message','{}','checksum','snapshot.json',0)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "FileOriginSession" ("projectId","sessionId","updatedAt") VALUES ('project','session',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ArtifactLineage" ("id","projectId","sessionId","normalizedFilename","filename","updatedAt") VALUES ('lineage','project','session','result.txt','result.txt',CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ArtifactVersion" (
+        "id","artifactId","versionNumber","filename","artifactRunId","rootFrameId","agentFrameId",
+        "messageBranchId","runtimeSegmentId","promptMessageId","state","contentStorageKey",
+        "evidenceStorageKey","sizeBytes","checksum","evidenceJson","evidenceChecksum","updatedAt"
+      ) VALUES (
+        'version','lineage',1,'result.txt','run','root','agent','branch','segment','prompt','staging',
+        'content','evidence.json',0,'checksum','{}','evidence-checksum',CURRENT_TIMESTAMP
+      )`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ArtifactVersionInput" (
+        "id","artifactVersionId","ordinal","inputFileVersionId","sourceKind","sourceFileId",
+        "sourceArtifactVersionId","sourceProjectId","sourceSessionId","filename","sizeBytes",
+        "checksum","storageKey","strongestAssociation"
+      ) VALUES (
+        'input','version',0,'version','artifact-version','lineage','version','project','session',
+        'result.txt',0,'checksum','content','turn-attached'
+      )`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ManagedFile" (
+        "source","sourceFileId","projectId","sessionId","displayName","storageKey","sizeBytes",
+        "sortAtMs","updatedAt"
+      ) VALUES ('artifact','lineage','project','session','result.txt','content',0,0,CURRENT_TIMESTAMP)`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ComputeJob" (
+        "id","providerId","shape","sessionId","projectId","status","intent","command","commandHash"
+      ) VALUES ('job','ssh:host','direct_ssh','session','project','submitted','intent','command','hash')`
+    )
+    await client.$executeRawUnsafe(
+      `INSERT INTO "ComputeHost" ("id","providerId","displayName","sshAlias","updatedAt") VALUES ('host','ssh:host','Host','host',CURRENT_TIMESTAMP)`
+    )
+
+    const invalidWrites = [
+      ['ProjectPreviewState.panelState', `UPDATE "ProjectPreviewState" SET "panelState"='unknown'`],
+      ['ProjectPreviewState.items syntax', `UPDATE "ProjectPreviewState" SET "items"='not-json'`],
+      ['ProjectPreviewState.items root', `UPDATE "ProjectPreviewState" SET "items"='{}'`],
+      ['NotificationInboxItem.kind', `UPDATE "NotificationInboxItem" SET "kind"='unknown'`],
+      [
+        'NotificationInboxItem.actionState',
+        `UPDATE "NotificationInboxItem" SET "actionState"='unknown'`
+      ],
+      [
+        'NotificationInboxItem settled without action',
+        `UPDATE "NotificationInboxItem" SET "settledAt"=CURRENT_TIMESTAMP`
+      ],
+      [
+        'NotificationInboxItem terminal action without settlement',
+        `UPDATE "NotificationInboxItem" SET "actionState"='resolved'`
+      ],
+      [
+        'NotificationInboxItem non-actionable kind',
+        `UPDATE "NotificationInboxItem" SET "actionState"='pending'`
+      ],
+      [
+        'NotificationInboxItem invalidated without read time',
+        `UPDATE "NotificationInboxItem" SET "targetInvalidatedAt"=CURRENT_TIMESTAMP`
+      ],
+      ['Review.scope syntax', `UPDATE "Review" SET "scope"='not-json'`],
+      ['Review.scope root', `UPDATE "Review" SET "scope"='[]'`],
+      ['Review.reviewerLog syntax', `UPDATE "Review" SET "reviewerLog"='not-json'`],
+      ['Review.reviewerLog root', `UPDATE "Review" SET "reviewerLog"='{}'`],
+      ['Finding.locator syntax', `UPDATE "Finding" SET "locator"='not-json'`],
+      ['Finding.locator root', `UPDATE "Finding" SET "locator"='[]'`],
+      [
+        'ReviewFindingDisposition.assessmentSnapshot syntax',
+        `UPDATE "ReviewFindingDisposition" SET "assessmentSnapshot"='not-json'`
+      ],
+      [
+        'ReviewFindingDisposition.assessmentSnapshot root',
+        `UPDATE "ReviewFindingDisposition" SET "assessmentSnapshot"='[]'`
+      ],
+      [
+        'ReviewScopeSnapshot.snapshotJson syntax',
+        `UPDATE "ReviewScopeSnapshot" SET "snapshotJson"='not-json'`
+      ],
+      [
+        'ReviewScopeSnapshot.snapshotJson root',
+        `UPDATE "ReviewScopeSnapshot" SET "snapshotJson"='[]'`
+      ],
+      [
+        'FileOriginSession.retainedReviewIdsJson syntax',
+        `UPDATE "FileOriginSession" SET "retainedReviewIdsJson"='not-json'`
+      ],
+      [
+        'FileOriginSession.retainedReviewIdsJson root',
+        `UPDATE "FileOriginSession" SET "retainedReviewIdsJson"='{}'`
+      ],
+      [
+        'FileOriginSession active retention state',
+        `UPDATE "FileOriginSession" SET "retainedReviewIdsJson"='[]'`
+      ],
+      [
+        'FileOriginSession incomplete deleting state',
+        `UPDATE "FileOriginSession" SET "state"='deleting'`
+      ],
+      ['ManagedFile.source', `UPDATE "ManagedFile" SET "source"='unknown'`],
+      [
+        'ArtifactVersion.evidenceJson syntax',
+        `UPDATE "ArtifactVersion" SET "evidenceJson"='not-json'`
+      ],
+      ['ArtifactVersion.evidenceJson root', `UPDATE "ArtifactVersion" SET "evidenceJson"='[]'`],
+      [
+        'ArtifactVersion.executionSnapshotJson syntax',
+        `UPDATE "ArtifactVersion" SET "executionSnapshotJson"='not-json'`
+      ],
+      [
+        'ArtifactVersion.executionSnapshotJson root',
+        `UPDATE "ArtifactVersion" SET "executionSnapshotJson"='[]'`
+      ],
+      [
+        'ArtifactVersion incomplete execution snapshot',
+        `UPDATE "ArtifactVersion" SET "executionSnapshotJson"='{}'`
+      ],
+      [
+        'ArtifactVersionInput.strongestAssociation',
+        `UPDATE "ArtifactVersionInput" SET "strongestAssociation"='unknown'`
+      ],
+      ['ComputeJob.resourceRequest syntax', `UPDATE "ComputeJob" SET "resourceRequest"='not-json'`],
+      ['ComputeJob.resourceRequest root', `UPDATE "ComputeJob" SET "resourceRequest"='[]'`],
+      ['ComputeJob.inputManifest syntax', `UPDATE "ComputeJob" SET "inputManifest"='not-json'`],
+      ['ComputeJob.inputManifest root', `UPDATE "ComputeJob" SET "inputManifest"='{}'`],
+      ['ComputeJob.outputManifest syntax', `UPDATE "ComputeJob" SET "outputManifest"='not-json'`],
+      ['ComputeJob.outputManifest root', `UPDATE "ComputeJob" SET "outputManifest"='{}'`],
+      ['ComputeJob.harvestConfig syntax', `UPDATE "ComputeJob" SET "harvestConfig"='not-json'`],
+      ['ComputeJob.harvestConfig root', `UPDATE "ComputeJob" SET "harvestConfig"='[]'`],
+      ['ComputeJob.remoteHandle syntax', `UPDATE "ComputeJob" SET "remoteHandle"='not-json'`],
+      ['ComputeJob.remoteHandle root', `UPDATE "ComputeJob" SET "remoteHandle"='[]'`],
+      [
+        'ComputeJob.leftOnRemote syntax',
+        `UPDATE "ComputeJob" SET "leftOnRemote"='not-json',"harvestedAt"=CURRENT_TIMESTAMP,"status"='success'`
+      ],
+      [
+        'ComputeJob.leftOnRemote root',
+        `UPDATE "ComputeJob" SET "leftOnRemote"='{}',"harvestedAt"=CURRENT_TIMESTAMP,"status"='success'`
+      ],
+      ['ComputeHost.sshOverrides syntax', `UPDATE "ComputeHost" SET "sshOverrides"='not-json'`],
+      ['ComputeHost.sshOverrides root', `UPDATE "ComputeHost" SET "sshOverrides"='[]'`],
+      ['ComputeHost.probeResult syntax', `UPDATE "ComputeHost" SET "probeResult"='not-json'`],
+      ['ComputeHost.probeResult root', `UPDATE "ComputeHost" SET "probeResult"='[]'`]
+    ] as const
+
+    const accepted: string[] = []
+    for (const [name, sql] of invalidWrites) {
+      const acceptedWrite = new Error(`accepted: ${name}`)
+      try {
+        await client.$transaction(async (transaction) => {
+          await transaction.$executeRawUnsafe(sql)
+          throw acceptedWrite
+        })
+      } catch (error) {
+        if (error === acceptedWrite) accepted.push(name)
+      }
+    }
+    expect(accepted).toEqual([])
+
+    await expect(
+      client.$transaction([
+        client.notificationInboxItem.update({
+          where: { id: 'notification' },
+          data: { kind: 'task.needs-attention', actionState: 'pending' }
+        }),
+        client.fileOriginSession.update({
+          where: { projectId_sessionId: { projectId: 'project', sessionId: 'session' } },
+          data: {
+            state: 'deleting',
+            deletionOperationId: 'delete-operation',
+            retainedReviewIdsJson: '[]'
+          }
+        }),
+        client.artifactVersion.update({
+          where: { id: 'version' },
+          data: {
+            executionSnapshotJson: '{}',
+            executionSnapshotChecksum: 'execution-checksum',
+            executionSnapshotStorageKey: 'execution.json',
+            executionSnapshotSchemaVersion: 2
+          }
+        }),
+        client.computeJob.update({
+          where: { id: 'job' },
+          data: {
+            resourceRequest: '{}',
+            inputManifest: '[]',
+            outputManifest: '[]',
+            harvestConfig: '{}',
+            remoteHandle: '{}'
+          }
+        }),
+        client.computeHost.update({
+          where: { id: 'host' },
+          data: { sshOverrides: '{}', probeResult: '{}' }
+        })
+      ])
+    ).resolves.toBeDefined()
+  })
+})

--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -104,7 +104,8 @@ describe('database startup logging', () => {
               '0004_review_assessment_snapshots',
               '0005_project_preview_state_owner_fk',
               '0006_database_domain_constraints',
-              '0007_notification_attention_metadata'
+              '0007_notification_attention_metadata',
+              '0008_database_json_constraints'
             ],
             adoptedLegacy: true
           })

--- a/src/main/database/generated/runtime-schema.ts
+++ b/src/main/database/generated/runtime-schema.ts
@@ -41,7 +41,9 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "activeItemId" TEXT,
     "items" TEXT NOT NULL DEFAULT '[]',
     "updatedAt" DATETIME NOT NULL,
-    CONSTRAINT "ProjectPreviewState_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+    CONSTRAINT "ProjectPreviewState_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ProjectPreviewState_panelState_check" CHECK ("panelState" IN ('open', 'collapsed')),
+    CONSTRAINT "ProjectPreviewState_itemsJson_check" CHECK (json_valid("items") AND json_type("items") = 'array')
 );`,
   `CREATE TABLE IF NOT EXISTS "UnreadTaskSession" (
     "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
@@ -65,7 +67,12 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "settledAt" DATETIME,
     "targetInvalidatedAt" DATETIME,
     CONSTRAINT "NotificationInboxItem_source_check" CHECK ("source" IS NULL OR "source" IN ('agent-tool', 'agent-question', 'agent-runtime', 'connector', 'compute', 'skill-import', 'session-plan')),
-    CONSTRAINT "NotificationInboxItem_attentionReason_check" CHECK ("attentionReason" IS NULL OR "attentionReason" IN ('waiting-for-user', 'waiting-permission', 'waiting-plan-approval', 'task-max-tokens', 'task-max-turn-requests', 'task-refusal', 'task-unclean-stop'))
+    CONSTRAINT "NotificationInboxItem_attentionReason_check" CHECK ("attentionReason" IS NULL OR "attentionReason" IN ('waiting-for-user', 'waiting-permission', 'waiting-plan-approval', 'task-max-tokens', 'task-max-turn-requests', 'task-refusal', 'task-unclean-stop')),
+    CONSTRAINT "NotificationInboxItem_kind_check" CHECK ("kind" IN ('task.completed', 'task.needs-attention', 'task.failed', 'authorization.required')),
+    CONSTRAINT "NotificationInboxItem_actionState_check" CHECK ("actionState" IS NULL OR "actionState" IN ('pending', 'resolved', 'rejected', 'expired', 'cancelled')),
+    CONSTRAINT "NotificationInboxItem_actionLifecycle_check" CHECK ((("actionState" IS NULL AND "settledAt" IS NULL) OR ("actionState" IS NOT NULL AND (("actionState" = 'pending' AND "settledAt" IS NULL) OR ("actionState" IN ('resolved', 'rejected', 'expired', 'cancelled') AND "settledAt" IS NOT NULL))))),
+    CONSTRAINT "NotificationInboxItem_actionKind_check" CHECK ("actionState" IS NULL OR "kind" IN ('task.needs-attention', 'authorization.required')),
+    CONSTRAINT "NotificationInboxItem_targetInvalidated_check" CHECK ("targetInvalidatedAt" IS NULL OR ("sessionId" IS NOT NULL AND "readAt" IS NOT NULL))
 );`,
   `CREATE TABLE IF NOT EXISTS "Review" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -82,7 +89,9 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "updatedAt" DATETIME NOT NULL,
     CONSTRAINT "Review_lifecycle_check" CHECK ("lifecycle" IN ('running', 'complete', 'error')),
     CONSTRAINT "Review_outcome_check" CHECK ("outcome" IS NULL OR "outcome" IN ('pass', 'flagged')),
-    CONSTRAINT "Review_state_check" CHECK ((("lifecycle" = 'running' AND "outcome" IS NULL AND "errorMessage" IS NULL) OR ("lifecycle" = 'complete' AND "outcome" IS NOT NULL AND "errorMessage" IS NULL) OR ("lifecycle" = 'error' AND "outcome" IS NULL AND "errorMessage" IS NOT NULL)))
+    CONSTRAINT "Review_state_check" CHECK ((("lifecycle" = 'running' AND "outcome" IS NULL AND "errorMessage" IS NULL) OR ("lifecycle" = 'complete' AND "outcome" IS NOT NULL AND "errorMessage" IS NULL) OR ("lifecycle" = 'error' AND "outcome" IS NULL AND "errorMessage" IS NOT NULL))),
+    CONSTRAINT "Review_scopeJson_check" CHECK (json_valid("scope") AND json_type("scope") = 'object'),
+    CONSTRAINT "Review_reviewerLogJson_check" CHECK (json_valid("reviewerLog") AND json_type("reviewerLog") = 'array')
 );`,
   `CREATE TABLE IF NOT EXISTS "Finding" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -103,7 +112,8 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "Finding_sortIndex_check" CHECK ("sortIndex" >= 0),
     CONSTRAINT "Finding_reflagCount_check" CHECK ("reflagCount" >= 0),
     CONSTRAINT "Finding_statusResolution_check" CHECK ("status" <> 'pass' OR "resolution" = 'open'),
-    CONSTRAINT "Finding_artifactBinding_check" CHECK ("artifactBindingState" <> 'scope_validated' OR "artifactVersionId" IS NOT NULL)
+    CONSTRAINT "Finding_artifactBinding_check" CHECK ("artifactBindingState" <> 'scope_validated' OR "artifactVersionId" IS NOT NULL),
+    CONSTRAINT "Finding_locatorJson_check" CHECK (json_valid("locator") AND json_type("locator") = 'object')
 );`,
   `CREATE TABLE IF NOT EXISTS "ProjectDeletionIntent" (
     "projectId" TEXT NOT NULL PRIMARY KEY,
@@ -127,7 +137,8 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" DATETIME NOT NULL,
     "deletedAt" DATETIME,
-    "deleteOperationId" TEXT
+    "deleteOperationId" TEXT,
+    CONSTRAINT "ManagedFile_source_check" CHECK ("source" IN ('artifact', 'upload'))
 );`,
   `CREATE TABLE IF NOT EXISTS "ManagedFileSessionSync" (
     "projectId" TEXT NOT NULL,
@@ -154,7 +165,9 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "updatedAt" DATETIME NOT NULL,
 
     PRIMARY KEY ("projectId", "sessionId"),
-    CONSTRAINT "FileOriginSession_state_check" CHECK ("state" IN ('active', 'deleting', 'deleted'))
+    CONSTRAINT "FileOriginSession_state_check" CHECK ("state" IN ('active', 'deleting', 'deleted')),
+    CONSTRAINT "FileOriginSession_retainedReviewIdsJson_check" CHECK ("retainedReviewIdsJson" IS NULL OR (json_valid("retainedReviewIdsJson") AND json_type("retainedReviewIdsJson") = 'array')),
+    CONSTRAINT "FileOriginSession_lifecycle_check" CHECK ((("state" = 'active' AND "deletedAt" IS NULL AND "deletionOperationId" IS NULL AND "retainedReviewIdsJson" IS NULL) OR ("state" = 'deleting' AND "deletedAt" IS NULL AND "deletionOperationId" IS NOT NULL AND "retainedReviewIdsJson" IS NOT NULL) OR ("state" = 'deleted' AND "deletedAt" IS NOT NULL AND "deletionOperationId" IS NULL AND "retainedReviewIdsJson" IS NULL)))
 );`,
   `CREATE TABLE IF NOT EXISTS "ArtifactLineage" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -246,7 +259,10 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "ArtifactVersion_artifactId_fkey" FOREIGN KEY ("artifactId") REFERENCES "ArtifactLineage" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT "ArtifactVersion_messageSnapshotId_fkey" FOREIGN KEY ("messageSnapshotId") REFERENCES "ArtifactMessageSnapshot" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
     CONSTRAINT "ArtifactVersion_state_check" CHECK ("state" IN ('staging', 'pending', 'finalized')),
-    CONSTRAINT "ArtifactVersion_filename_check" CHECK (length("filename") > 0)
+    CONSTRAINT "ArtifactVersion_filename_check" CHECK (length("filename") > 0),
+    CONSTRAINT "ArtifactVersion_evidenceJson_check" CHECK (json_valid("evidenceJson") AND json_type("evidenceJson") = 'object'),
+    CONSTRAINT "ArtifactVersion_executionSnapshotJson_check" CHECK ("executionSnapshotJson" IS NULL OR (json_valid("executionSnapshotJson") AND json_type("executionSnapshotJson") = 'object')),
+    CONSTRAINT "ArtifactVersion_executionSnapshotBundle_check" CHECK ((("executionSnapshotJson" IS NULL AND "executionSnapshotChecksum" IS NULL AND "executionSnapshotStorageKey" IS NULL AND "executionSnapshotSchemaVersion" IS NULL) OR ("executionSnapshotJson" IS NOT NULL AND "executionSnapshotChecksum" IS NOT NULL AND "executionSnapshotStorageKey" IS NOT NULL AND "executionSnapshotSchemaVersion" IS NOT NULL)))
 );`,
   `CREATE TABLE IF NOT EXISTS "ArtifactVersionInput" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -272,7 +288,8 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "ArtifactVersionInput_sourceUploadVersionId_fkey" FOREIGN KEY ("sourceUploadVersionId") REFERENCES "UploadVersion" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
     CONSTRAINT "ArtifactVersionInput_sourceProjectId_sourceSessionId_fkey" FOREIGN KEY ("sourceProjectId", "sourceSessionId") REFERENCES "FileOriginSession" ("projectId", "sessionId") ON DELETE RESTRICT ON UPDATE CASCADE,
     CONSTRAINT "ArtifactVersionInput_sourceKind_check" CHECK ("sourceKind" IN ('artifact-version', 'upload-version')),
-    CONSTRAINT "ArtifactVersionInput_sourceIdentity_check" CHECK ((("sourceKind" = 'artifact-version' AND "sourceArtifactVersionId" IS NOT NULL AND "sourceUploadVersionId" IS NULL AND "inputFileVersionId" = "sourceArtifactVersionId") OR ("sourceKind" = 'upload-version' AND "sourceArtifactVersionId" IS NULL AND "sourceUploadVersionId" IS NOT NULL AND "inputFileVersionId" = "sourceUploadVersionId")))
+    CONSTRAINT "ArtifactVersionInput_sourceIdentity_check" CHECK ((("sourceKind" = 'artifact-version' AND "sourceArtifactVersionId" IS NOT NULL AND "sourceUploadVersionId" IS NULL AND "inputFileVersionId" = "sourceArtifactVersionId") OR ("sourceKind" = 'upload-version' AND "sourceArtifactVersionId" IS NULL AND "sourceUploadVersionId" IS NOT NULL AND "inputFileVersionId" = "sourceUploadVersionId"))),
+    CONSTRAINT "ArtifactVersionInput_strongestAssociation_check" CHECK ("strongestAssociation" IN ('turn-attached', 'resolver-accessed', 'captured-version'))
 );`,
   `CREATE TABLE IF NOT EXISTS "ReviewFindingDisposition" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -290,7 +307,8 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "ReviewFindingDisposition_sequence_check" CHECK ("sequence" >= 1),
     CONSTRAINT "ReviewFindingDisposition_trigger_check" CHECK ("trigger" IN ('review_submission', 'loop_terminated', 'correction_failed', 'aborted')),
     CONSTRAINT "ReviewFindingDisposition_outcome_check" CHECK ("outcome" IN ('still_open', 'resolved', 'unaddressed')),
-    CONSTRAINT "ReviewFindingDisposition_state_check" CHECK ((("trigger" = 'review_submission' AND "causeReviewId" IS NOT NULL AND "outcome" IN ('still_open', 'resolved')) OR ("trigger" IN ('loop_terminated', 'correction_failed', 'aborted') AND "causeReviewId" IS NULL AND "outcome" = 'unaddressed')))
+    CONSTRAINT "ReviewFindingDisposition_state_check" CHECK ((("trigger" = 'review_submission' AND "causeReviewId" IS NOT NULL AND "outcome" IN ('still_open', 'resolved')) OR ("trigger" IN ('loop_terminated', 'correction_failed', 'aborted') AND "causeReviewId" IS NULL AND "outcome" = 'unaddressed'))),
+    CONSTRAINT "ReviewFindingDisposition_assessmentSnapshotJson_check" CHECK ("assessmentSnapshot" IS NULL OR (json_valid("assessmentSnapshot") AND json_type("assessmentSnapshot") = 'object'))
 );`,
   `CREATE TABLE IF NOT EXISTS "ReviewScopeSnapshot" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -306,7 +324,8 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "blockCount" INTEGER NOT NULL,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT "ReviewScopeSnapshot_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "Review" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
-    CONSTRAINT "ReviewScopeSnapshot_state_check" CHECK ("state" IN ('staging', 'ready'))
+    CONSTRAINT "ReviewScopeSnapshot_state_check" CHECK ("state" IN ('staging', 'ready')),
+    CONSTRAINT "ReviewScopeSnapshot_snapshotJson_check" CHECK (json_valid("snapshotJson") AND json_type("snapshotJson") = 'object')
 );`,
   `CREATE TABLE IF NOT EXISTS "ComputeJob" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -347,7 +366,13 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "ComputeJob_notification_check" CHECK ("notificationConsumedAt" IS NULL OR "notifiedAt" IS NOT NULL),
     CONSTRAINT "ComputeJob_harvestPayload_check" CHECK (("harvestError" IS NULL AND "leftOnRemote" IS NULL) OR "harvestedAt" IS NOT NULL),
     CONSTRAINT "ComputeJob_harvestState_check" CHECK ("harvestedAt" IS NULL OR "status" IN ('success', 'failed', 'timeout')),
-    CONSTRAINT "ComputeJob_errorState_check" CHECK ((("errorCode" IS NULL OR "status" IN ('failed', 'timeout', 'error')) AND ("status" <> 'error' OR "errorCode" IS NOT NULL)))
+    CONSTRAINT "ComputeJob_errorState_check" CHECK ((("errorCode" IS NULL OR "status" IN ('failed', 'timeout', 'error')) AND ("status" <> 'error' OR "errorCode" IS NOT NULL))),
+    CONSTRAINT "ComputeJob_resourceRequestJson_check" CHECK ("resourceRequest" IS NULL OR (json_valid("resourceRequest") AND json_type("resourceRequest") = 'object')),
+    CONSTRAINT "ComputeJob_inputManifestJson_check" CHECK ("inputManifest" IS NULL OR (json_valid("inputManifest") AND json_type("inputManifest") = 'array')),
+    CONSTRAINT "ComputeJob_outputManifestJson_check" CHECK ("outputManifest" IS NULL OR (json_valid("outputManifest") AND json_type("outputManifest") = 'array')),
+    CONSTRAINT "ComputeJob_harvestConfigJson_check" CHECK ("harvestConfig" IS NULL OR (json_valid("harvestConfig") AND json_type("harvestConfig") = 'object')),
+    CONSTRAINT "ComputeJob_remoteHandleJson_check" CHECK ("remoteHandle" IS NULL OR (json_valid("remoteHandle") AND json_type("remoteHandle") = 'object')),
+    CONSTRAINT "ComputeJob_leftOnRemoteJson_check" CHECK ("leftOnRemote" IS NULL OR (json_valid("leftOnRemote") AND json_type("leftOnRemote") = 'array'))
 );`,
   `CREATE TABLE IF NOT EXISTS "ComputeHost" (
     "id" TEXT NOT NULL PRIMARY KEY,
@@ -370,7 +395,9 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "ComputeHost_concurrencyLimit_check" CHECK ("concurrencyLimit" IS NULL OR "concurrencyLimit" BETWEEN 1 AND 500),
     CONSTRAINT "ComputeHost_detailsUpdatedBy_check" CHECK ("detailsUpdatedBy" IS NULL OR "detailsUpdatedBy" IN ('user', 'agent')),
     CONSTRAINT "ComputeHost_detailsUpdate_check" CHECK (("detailsUpdatedAt" IS NULL AND "detailsUpdatedBy" IS NULL) OR ("detailsUpdatedAt" IS NOT NULL AND "detailsUpdatedBy" IS NOT NULL)),
-    CONSTRAINT "ComputeHost_scratchRoot_check" CHECK ("scratchPinned" = false OR "scratchRoot" IS NOT NULL)
+    CONSTRAINT "ComputeHost_scratchRoot_check" CHECK ("scratchPinned" = false OR "scratchRoot" IS NOT NULL),
+    CONSTRAINT "ComputeHost_sshOverridesJson_check" CHECK ("sshOverrides" IS NULL OR (json_valid("sshOverrides") AND json_type("sshOverrides") = 'object')),
+    CONSTRAINT "ComputeHost_probeResultJson_check" CHECK ("probeResult" IS NULL OR (json_valid("probeResult") AND json_type("probeResult") = 'object'))
 );`,
   `CREATE TABLE IF NOT EXISTS "GrantedLocalRoot" (
     "id" TEXT NOT NULL PRIMARY KEY,

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -20,7 +20,7 @@ import {
 } from './migration-service'
 
 const futureTestMigration = (): MigrationManifestEntry => {
-  const id = '0008_test_suffix'
+  const id = '0009_test_suffix'
   const statements = [`UPDATE "Project" SET "name" = "name" WHERE 0`] as const
   const verifiers = [{ kind: 'table-exists', version: 1, table: 'Project' }] as const
   return {
@@ -218,10 +218,11 @@ describe('application database migrations', () => {
         '0004_review_assessment_snapshots',
         '0005_project_preview_state_owner_fk',
         '0006_database_domain_constraints',
-        '0007_notification_attention_metadata'
+        '0007_notification_attention_metadata',
+        '0008_database_json_constraints'
       ],
       from: null,
-      to: '0007_notification_attention_metadata'
+      to: '0008_database_json_constraints'
     })
     expect(compatibility).toEqual([{ sqliteVersion: expect.stringMatching(/^\d+\.\d+\.\d+$/) }])
     await expect(
@@ -234,8 +235,8 @@ describe('application database migrations', () => {
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
       applied: [],
-      from: '0007_notification_attention_metadata',
-      to: '0007_notification_attention_metadata'
+      from: '0008_database_json_constraints',
+      to: '0008_database_json_constraints'
     })
   })
 
@@ -254,12 +255,16 @@ describe('application database migrations', () => {
     await migrateApplicationDatabase(client)
     await client.$executeRawUnsafe('DROP INDEX "ComputeJob_status_idx"')
     await client.$executeRawUnsafe(`DELETE FROM "_open_science_migrations"
-      WHERE "id" IN ('0006_database_domain_constraints', '0007_notification_attention_metadata')`)
+      WHERE "id" IN ('0006_database_domain_constraints', '0007_notification_attention_metadata', '0008_database_json_constraints')`)
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
-      applied: ['0006_database_domain_constraints', '0007_notification_attention_metadata'],
+      applied: [
+        '0006_database_domain_constraints',
+        '0007_notification_attention_metadata',
+        '0008_database_json_constraints'
+      ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0007_notification_attention_metadata'
+      to: '0008_database_json_constraints'
     })
     await expect(verifyCurrentRuntimeSchema(client)).resolves.toBeUndefined()
   })
@@ -315,9 +320,13 @@ describe('application database migrations', () => {
 
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
-      applied: ['0006_database_domain_constraints', '0007_notification_attention_metadata'],
+      applied: [
+        '0006_database_domain_constraints',
+        '0007_notification_attention_metadata',
+        '0008_database_json_constraints'
+      ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0007_notification_attention_metadata'
+      to: '0008_database_json_constraints'
     })
     await expect(
       client.$queryRaw<
@@ -416,7 +425,7 @@ describe('application database migrations', () => {
       })
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0007_notification_attention_metadata'
+      migrationId: '0008_database_json_constraints'
     })
     expect(retired).toEqual([])
     await expect(access(backupPath)).resolves.toBeUndefined()
@@ -432,9 +441,9 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).resolves.toEqual({
       adoptedLegacy: false,
-      applied: ['0008_test_suffix'],
-      from: '0007_notification_attention_metadata',
-      to: '0008_test_suffix'
+      applied: ['0009_test_suffix'],
+      from: '0008_database_json_constraints',
+      to: '0009_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ id: string }>>`
@@ -448,7 +457,8 @@ describe('application database migrations', () => {
       { id: '0005_project_preview_state_owner_fk' },
       { id: '0006_database_domain_constraints' },
       { id: '0007_notification_attention_metadata' },
-      { id: '0008_test_suffix' }
+      { id: '0008_database_json_constraints' },
+      { id: '0009_test_suffix' }
     ])
   })
 
@@ -507,10 +517,11 @@ describe('application database migrations', () => {
         '0004_review_assessment_snapshots',
         '0005_project_preview_state_owner_fk',
         '0006_database_domain_constraints',
-        '0007_notification_attention_metadata'
+        '0007_notification_attention_metadata',
+        '0008_database_json_constraints'
       ],
       from: '0001_runtime_schema_baseline',
-      to: '0007_notification_attention_metadata'
+      to: '0008_database_json_constraints'
     })
     expect(backupEvents).toEqual([
       {
@@ -541,6 +552,11 @@ describe('application database migrations', () => {
       {
         migrationId: '0007_notification_attention_metadata',
         path: `${databasePath}.before-0007_notification_attention_metadata.backup`,
+        reused: false
+      },
+      {
+        migrationId: '0008_database_json_constraints',
+        path: `${databasePath}.before-0008_database_json_constraints.backup`,
         reused: false
       }
     ])
@@ -574,7 +590,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0008_test_suffix'
+      migrationId: '0009_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ name: string }>>`
@@ -593,7 +609,8 @@ describe('application database migrations', () => {
       { id: '0004_review_assessment_snapshots' },
       { id: '0005_project_preview_state_owner_fk' },
       { id: '0006_database_domain_constraints' },
-      { id: '0007_notification_attention_metadata' }
+      { id: '0007_notification_attention_metadata' },
+      { id: '0008_database_json_constraints' }
     ])
   })
 
@@ -615,7 +632,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0008_test_suffix'
+      migrationId: '0009_test_suffix'
     })
   })
 
@@ -648,9 +665,10 @@ describe('application database migrations', () => {
         '0005_project_preview_state_owner_fk',
         '0006_database_domain_constraints',
         '0007_notification_attention_metadata',
-        '0008_test_suffix'
+        '0008_database_json_constraints',
+        '0009_test_suffix'
       ],
-      to: '0008_test_suffix'
+      to: '0009_test_suffix'
     })
     await expect(
       client.project.findUniqueOrThrow({ where: { id: 'legacy-project' } })
@@ -870,7 +888,8 @@ describe('application database migrations', () => {
         '0004_review_assessment_snapshots',
         '0005_project_preview_state_owner_fk',
         '0006_database_domain_constraints',
-        '0007_notification_attention_metadata'
+        '0007_notification_attention_metadata',
+        '0008_database_json_constraints'
       ]
     })
     await expect(
@@ -913,7 +932,8 @@ describe('application database migrations', () => {
         '0004_review_assessment_snapshots',
         '0005_project_preview_state_owner_fk',
         '0006_database_domain_constraints',
-        '0007_notification_attention_metadata'
+        '0007_notification_attention_metadata',
+        '0008_database_json_constraints'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -969,7 +989,8 @@ describe('application database migrations', () => {
         '0004_review_assessment_snapshots',
         '0005_project_preview_state_owner_fk',
         '0006_database_domain_constraints',
-        '0007_notification_attention_metadata'
+        '0007_notification_attention_metadata',
+        '0008_database_json_constraints'
       ]
     })
     await expect(
@@ -1014,7 +1035,7 @@ describe('application database migrations', () => {
     ).resolves.toEqual([])
   })
 
-  it('adopts the legacy artifact input identity check with equivalent conjunct order', async () => {
+  it('adopts the equivalent legacy artifact input identity check before canonical rebuild', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-legacy-input-check-'))
     client = createProjectDbClient(storageRoot)
     await client.$executeRawUnsafe(LEGACY_ARTIFACT_VERSION_INPUT_TABLE_DDL)
@@ -1028,7 +1049,8 @@ describe('application database migrations', () => {
         '0004_review_assessment_snapshots',
         '0005_project_preview_state_owner_fk',
         '0006_database_domain_constraints',
-        '0007_notification_attention_metadata'
+        '0007_notification_attention_metadata',
+        '0008_database_json_constraints'
       ]
     })
     await expect(verifyCurrentRuntimeSchema(client)).resolves.toBeUndefined()
@@ -1040,7 +1062,7 @@ describe('application database migrations', () => {
     ).resolves.toEqual([
       {
         sql: expect.stringContaining(
-          '"sourceUploadVersionId" IS NOT NULL AND "sourceArtifactVersionId" IS NULL'
+          '"sourceArtifactVersionId" IS NULL AND "sourceUploadVersionId" IS NOT NULL'
         )
       }
     ])
@@ -1121,7 +1143,8 @@ describe('application database migrations', () => {
         '0004_review_assessment_snapshots',
         '0005_project_preview_state_owner_fk',
         '0006_database_domain_constraints',
-        '0007_notification_attention_metadata'
+        '0007_notification_attention_metadata',
+        '0008_database_json_constraints'
       ]
     })
     await expect(
@@ -1167,7 +1190,8 @@ describe('application database migrations', () => {
         '0004_review_assessment_snapshots',
         '0005_project_preview_state_owner_fk',
         '0006_database_domain_constraints',
-        '0007_notification_attention_metadata'
+        '0007_notification_attention_metadata',
+        '0008_database_json_constraints'
       ]
     })
     expect(backupEvents).toEqual([
@@ -1204,6 +1228,11 @@ describe('application database migrations', () => {
       {
         migrationId: '0007_notification_attention_metadata',
         path: `${databasePath}.before-0007_notification_attention_metadata.backup`,
+        reused: false
+      },
+      {
+        migrationId: '0008_database_json_constraints',
+        path: `${databasePath}.before-0008_database_json_constraints.backup`,
         reused: false
       }
     ])
@@ -1607,6 +1636,11 @@ describe('application database migrations', () => {
         migrationId: '0007_notification_attention_metadata',
         path: `${databasePath}.before-0007_notification_attention_metadata.backup`,
         reused: false
+      }),
+      expect.objectContaining({
+        migrationId: '0008_database_json_constraints',
+        path: `${databasePath}.before-0008_database_json_constraints.backup`,
+        reused: false
       })
     ])
     expect(retired).toEqual([
@@ -1631,6 +1665,10 @@ describe('application database migrations', () => {
       {
         migrationId: '0007_notification_attention_metadata',
         path: `${databasePath}.before-0007_notification_attention_metadata.backup`
+      },
+      {
+        migrationId: '0008_database_json_constraints',
+        path: `${databasePath}.before-0008_database_json_constraints.backup`
       }
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -21,6 +21,7 @@ import { reviewAssessmentSnapshotsMigration } from './migrations/0004-review-ass
 import { projectPreviewStateOwnerFkMigration } from './migrations/0005-project-preview-state-owner-fk'
 import { databaseDomainConstraintsMigration } from './migrations/0006-database-domain-constraints'
 import { notificationAttentionMetadataMigration } from './migrations/0007-notification-attention-metadata'
+import { databaseJsonConstraintsMigration } from './migrations/0008-database-json-constraints'
 import {
   applySqliteMigrationOperations,
   type SqliteMigrationOperation
@@ -181,6 +182,12 @@ const NOTIFICATION_ATTENTION_METADATA_CHECKSUM = checksumMigrationPayload(
   notificationAttentionMetadataMigration.verifiers,
   notificationAttentionMetadataMigration.operations
 )
+const DATABASE_JSON_CONSTRAINTS_CHECKSUM = checksumMigrationPayload(
+  databaseJsonConstraintsMigration.id,
+  databaseJsonConstraintsMigration.statements,
+  databaseJsonConstraintsMigration.verifiers,
+  databaseJsonConstraintsMigration.operations
+)
 const DATABASE_DOMAIN_ALLOWED_SUFFIX_CHECKS: AllowedSuffixCheckConstraints = Object.fromEntries(
   databaseDomainConstraintsMigration.verifiers[0].tables.map(({ table, constraints }) => [
     table,
@@ -197,6 +204,26 @@ const NOTIFICATION_ATTENTION_ALLOWED_SUFFIX_CHECKS: AllowedSuffixCheckConstraint
         Object.fromEntries(constraints.map(({ name, expression }) => [name, expression]))
       ])
   )
+const DATABASE_JSON_ALLOWED_SUFFIX_CHECKS: AllowedSuffixCheckConstraints = Object.fromEntries(
+  databaseJsonConstraintsMigration.verifiers
+    .filter((verifier) => verifier.kind === 'check-constraints-exist')
+    .flatMap((verifier) => verifier.tables)
+    .map(({ table, constraints }) => [
+      table,
+      Object.fromEntries(constraints.map(({ name, expression }) => [name, expression]))
+    ])
+)
+const mergeAllowedSuffixChecks = (
+  ...contracts: readonly AllowedSuffixCheckConstraints[]
+): AllowedSuffixCheckConstraints => {
+  const merged: Record<string, Record<string, string>> = {}
+  for (const contract of contracts) {
+    for (const [table, constraints] of Object.entries(contract)) {
+      merged[table] = { ...merged[table], ...constraints }
+    }
+  }
+  return merged
+}
 const MIGRATION_MANIFEST = [
   {
     ...runtimeSchemaBaselineMigration,
@@ -237,6 +264,12 @@ const MIGRATION_MANIFEST = [
   {
     ...notificationAttentionMetadataMigration,
     checksum: NOTIFICATION_ATTENTION_METADATA_CHECKSUM,
+    backupOnApply: 'required',
+    backupRetention: 'retain'
+  },
+  {
+    ...databaseJsonConstraintsMigration,
+    checksum: DATABASE_JSON_CONSTRAINTS_CHECKSUM,
     backupOnApply: 'required',
     backupRetention: 'retain'
   }
@@ -1040,12 +1073,18 @@ const migrateApplicationDatabaseWithManifest = async (
       candidate.id === notificationAttentionMetadataMigration.id &&
       candidate.checksum === NOTIFICATION_ATTENTION_METADATA_CHECKSUM
   )
+  const adoptsDatabaseJsonConstraints = manifest.some(
+    (candidate) =>
+      candidate.id === databaseJsonConstraintsMigration.id &&
+      candidate.checksum === DATABASE_JSON_CONSTRAINTS_CHECKSUM
+  )
   const applied: string[] = []
   const adoptedLegacy = appliedCount === 0 && hadApplicationTablesAtStart
-  const allowedSuffixChecks = {
-    ...(adoptsDatabaseDomainConstraints ? DATABASE_DOMAIN_ALLOWED_SUFFIX_CHECKS : {}),
-    ...(adoptsNotificationAttentionMetadata ? NOTIFICATION_ATTENTION_ALLOWED_SUFFIX_CHECKS : {})
-  }
+  const allowedSuffixChecks = mergeAllowedSuffixChecks(
+    adoptsDatabaseDomainConstraints ? DATABASE_DOMAIN_ALLOWED_SUFFIX_CHECKS : {},
+    adoptsNotificationAttentionMetadata ? NOTIFICATION_ATTENTION_ALLOWED_SUFFIX_CHECKS : {},
+    adoptsDatabaseJsonConstraints ? DATABASE_JSON_ALLOWED_SUFFIX_CHECKS : {}
+  )
 
   let nextIndex = appliedCount
   if (nextIndex === 0) {
@@ -1083,6 +1122,7 @@ export {
   PROJECT_AGENT_CONTEXT_CHECKSUM,
   DATABASE_DOMAIN_CONSTRAINTS_CHECKSUM,
   NOTIFICATION_ATTENTION_METADATA_CHECKSUM,
+  DATABASE_JSON_CONSTRAINTS_CHECKSUM,
   DatabaseMigrationError,
   checksumMigrationPayload,
   classifyDatabaseFailure,

--- a/src/main/database/migrations/0008-database-json-constraints.ts
+++ b/src/main/database/migrations/0008-database-json-constraints.ts
@@ -1,0 +1,1110 @@
+/* Immutable 0008 migration snapshot. Do not regenerate after release. */
+
+const databaseJsonConstraintsMigration = {
+  id: '0008_database_json_constraints',
+  statements: [] as const,
+  operations: [
+    {
+      kind: 'rebuild-table-set',
+      version: 1,
+      tables: [
+        {
+          tableName: 'ProjectPreviewState',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ProjectPreviewState" (
+    "projectId" TEXT NOT NULL PRIMARY KEY,
+    "panelState" TEXT NOT NULL,
+    "activeItemId" TEXT,
+    "items" TEXT NOT NULL DEFAULT '[]',
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ProjectPreviewState_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ProjectPreviewState_panelState_check" CHECK ("panelState" IN ('open', 'collapsed')),
+    CONSTRAINT "ProjectPreviewState_itemsJson_check" CHECK (json_valid("items") AND json_type("items") = 'array')
+);`,
+          columns: ['projectId', 'panelState', 'activeItemId', 'items', 'updatedAt']
+        }
+      ],
+      dropOrder: ['ProjectPreviewState'],
+      indexes: []
+    },
+    {
+      kind: 'rebuild-table-set',
+      version: 1,
+      tables: [
+        {
+          tableName: 'NotificationInboxItem',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "NotificationInboxItem" (
+    "sequence" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "id" TEXT NOT NULL,
+    "dedupeKey" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "source" TEXT,
+    "attentionReason" TEXT,
+    "projectId" TEXT,
+    "sessionId" TEXT,
+    "originId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "summary" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "readAt" DATETIME,
+    "actionState" TEXT,
+    "settledAt" DATETIME,
+    "targetInvalidatedAt" DATETIME,
+    CONSTRAINT "NotificationInboxItem_source_check" CHECK ("source" IS NULL OR "source" IN ('agent-tool', 'agent-question', 'agent-runtime', 'connector', 'compute', 'skill-import', 'session-plan')),
+    CONSTRAINT "NotificationInboxItem_attentionReason_check" CHECK ("attentionReason" IS NULL OR "attentionReason" IN ('waiting-for-user', 'waiting-permission', 'waiting-plan-approval', 'task-max-tokens', 'task-max-turn-requests', 'task-refusal', 'task-unclean-stop')),
+    CONSTRAINT "NotificationInboxItem_kind_check" CHECK ("kind" IN ('task.completed', 'task.needs-attention', 'task.failed', 'authorization.required')),
+    CONSTRAINT "NotificationInboxItem_actionState_check" CHECK ("actionState" IS NULL OR "actionState" IN ('pending', 'resolved', 'rejected', 'expired', 'cancelled')),
+    CONSTRAINT "NotificationInboxItem_actionLifecycle_check" CHECK ((("actionState" IS NULL AND "settledAt" IS NULL) OR ("actionState" IS NOT NULL AND (("actionState" = 'pending' AND "settledAt" IS NULL) OR ("actionState" IN ('resolved', 'rejected', 'expired', 'cancelled') AND "settledAt" IS NOT NULL))))),
+    CONSTRAINT "NotificationInboxItem_actionKind_check" CHECK ("actionState" IS NULL OR "kind" IN ('task.needs-attention', 'authorization.required')),
+    CONSTRAINT "NotificationInboxItem_targetInvalidated_check" CHECK ("targetInvalidatedAt" IS NULL OR ("sessionId" IS NOT NULL AND "readAt" IS NOT NULL))
+);`,
+          columns: [
+            'sequence',
+            'id',
+            'dedupeKey',
+            'kind',
+            'source',
+            'attentionReason',
+            'projectId',
+            'sessionId',
+            'originId',
+            'title',
+            'summary',
+            'createdAt',
+            'readAt',
+            'actionState',
+            'settledAt',
+            'targetInvalidatedAt'
+          ]
+        }
+      ],
+      dropOrder: ['NotificationInboxItem'],
+      indexes: [
+        `CREATE UNIQUE INDEX IF NOT EXISTS "NotificationInboxItem_id_key" ON "NotificationInboxItem"("id");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "NotificationInboxItem_dedupeKey_key" ON "NotificationInboxItem"("dedupeKey");`,
+        `CREATE INDEX IF NOT EXISTS "NotificationInboxItem_readAt_sequence_idx" ON "NotificationInboxItem"("readAt", "sequence");`,
+        `CREATE INDEX IF NOT EXISTS "NotificationInboxItem_sessionId_idx" ON "NotificationInboxItem"("sessionId");`,
+        `CREATE INDEX IF NOT EXISTS "NotificationInboxItem_projectId_idx" ON "NotificationInboxItem"("projectId");`
+      ]
+    },
+    {
+      kind: 'rebuild-table-set',
+      version: 1,
+      tables: [
+        {
+          tableName: 'Review',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "Review" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "projectId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "turnMessageId" TEXT NOT NULL,
+    "scope" TEXT NOT NULL DEFAULT '{}',
+    "lifecycle" TEXT NOT NULL DEFAULT 'running',
+    "outcome" TEXT,
+    "errorMessage" TEXT,
+    "model" TEXT NOT NULL DEFAULT '',
+    "reviewerLog" TEXT NOT NULL DEFAULT '[]',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Review_lifecycle_check" CHECK ("lifecycle" IN ('running', 'complete', 'error')),
+    CONSTRAINT "Review_outcome_check" CHECK ("outcome" IS NULL OR "outcome" IN ('pass', 'flagged')),
+    CONSTRAINT "Review_state_check" CHECK ((("lifecycle" = 'running' AND "outcome" IS NULL AND "errorMessage" IS NULL) OR ("lifecycle" = 'complete' AND "outcome" IS NOT NULL AND "errorMessage" IS NULL) OR ("lifecycle" = 'error' AND "outcome" IS NULL AND "errorMessage" IS NOT NULL))),
+    CONSTRAINT "Review_scopeJson_check" CHECK (json_valid("scope") AND json_type("scope") = 'object'),
+    CONSTRAINT "Review_reviewerLogJson_check" CHECK (json_valid("reviewerLog") AND json_type("reviewerLog") = 'array')
+);`,
+          columns: [
+            'id',
+            'projectId',
+            'sessionId',
+            'turnMessageId',
+            'scope',
+            'lifecycle',
+            'outcome',
+            'errorMessage',
+            'model',
+            'reviewerLog',
+            'createdAt',
+            'updatedAt'
+          ],
+          optionalLegacyColumns: [
+            { name: 'summary', definition: '"summary" TEXT' },
+            { name: 'checks', definition: '"checks" TEXT' },
+            { name: 'reasoning', definition: '"reasoning" TEXT' }
+          ]
+        },
+        {
+          tableName: 'Finding',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "Finding" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "reviewId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pass',
+    "resolution" TEXT NOT NULL DEFAULT 'open',
+    "claim" TEXT NOT NULL DEFAULT '',
+    "evidence" TEXT NOT NULL DEFAULT '',
+    "locator" TEXT NOT NULL DEFAULT '{}',
+    "artifactVersionId" TEXT,
+    "artifactBindingState" TEXT NOT NULL DEFAULT 'legacy_unverified',
+    "sortIndex" INTEGER NOT NULL DEFAULT 0,
+    "reflagCount" INTEGER NOT NULL DEFAULT 0,
+    CONSTRAINT "Finding_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "Review" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Finding_status_check" CHECK ("status" IN ('pass', 'warn', 'fail')),
+    CONSTRAINT "Finding_resolution_check" CHECK ("resolution" IN ('open', 'resolved', 'unaddressed')),
+    CONSTRAINT "Finding_artifactBindingState_check" CHECK ("artifactBindingState" IN ('scope_validated', 'legacy_unverified')),
+    CONSTRAINT "Finding_sortIndex_check" CHECK ("sortIndex" >= 0),
+    CONSTRAINT "Finding_reflagCount_check" CHECK ("reflagCount" >= 0),
+    CONSTRAINT "Finding_statusResolution_check" CHECK ("status" <> 'pass' OR "resolution" = 'open'),
+    CONSTRAINT "Finding_artifactBinding_check" CHECK ("artifactBindingState" <> 'scope_validated' OR "artifactVersionId" IS NOT NULL),
+    CONSTRAINT "Finding_locatorJson_check" CHECK (json_valid("locator") AND json_type("locator") = 'object')
+);`,
+          columns: [
+            'id',
+            'reviewId',
+            'status',
+            'resolution',
+            'claim',
+            'evidence',
+            'locator',
+            'artifactVersionId',
+            'artifactBindingState',
+            'sortIndex',
+            'reflagCount'
+          ],
+          optionalLegacyColumns: [{ name: 'severity', definition: '"severity" TEXT' }]
+        },
+        {
+          tableName: 'ReviewFindingDisposition',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ReviewFindingDisposition" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "sourceFindingId" TEXT NOT NULL,
+    "causeReviewId" TEXT,
+    "sequence" INTEGER NOT NULL,
+    "trigger" TEXT NOT NULL,
+    "outcome" TEXT NOT NULL,
+    "note" TEXT,
+    "assessedArtifactVersionId" TEXT,
+    "assessmentSnapshot" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ReviewFindingDisposition_sourceFindingId_fkey" FOREIGN KEY ("sourceFindingId") REFERENCES "Finding" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ReviewFindingDisposition_causeReviewId_fkey" FOREIGN KEY ("causeReviewId") REFERENCES "Review" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ReviewFindingDisposition_sequence_check" CHECK ("sequence" >= 1),
+    CONSTRAINT "ReviewFindingDisposition_trigger_check" CHECK ("trigger" IN ('review_submission', 'loop_terminated', 'correction_failed', 'aborted')),
+    CONSTRAINT "ReviewFindingDisposition_outcome_check" CHECK ("outcome" IN ('still_open', 'resolved', 'unaddressed')),
+    CONSTRAINT "ReviewFindingDisposition_state_check" CHECK ((("trigger" = 'review_submission' AND "causeReviewId" IS NOT NULL AND "outcome" IN ('still_open', 'resolved')) OR ("trigger" IN ('loop_terminated', 'correction_failed', 'aborted') AND "causeReviewId" IS NULL AND "outcome" = 'unaddressed'))),
+    CONSTRAINT "ReviewFindingDisposition_assessmentSnapshotJson_check" CHECK ("assessmentSnapshot" IS NULL OR (json_valid("assessmentSnapshot") AND json_type("assessmentSnapshot") = 'object'))
+);`,
+          columns: [
+            'id',
+            'sourceFindingId',
+            'causeReviewId',
+            'sequence',
+            'trigger',
+            'outcome',
+            'note',
+            'assessedArtifactVersionId',
+            'assessmentSnapshot',
+            'createdAt'
+          ]
+        },
+        {
+          tableName: 'ReviewScopeSnapshot',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ReviewScopeSnapshot" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "projectId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "reviewId" TEXT NOT NULL,
+    "scopeTurnMessageId" TEXT NOT NULL,
+    "state" TEXT NOT NULL DEFAULT 'staging',
+    "snapshotJson" TEXT NOT NULL,
+    "checksum" TEXT NOT NULL,
+    "storageKey" TEXT NOT NULL,
+    "schemaVersion" INTEGER NOT NULL DEFAULT 1,
+    "blockCount" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ReviewScopeSnapshot_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "Review" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ReviewScopeSnapshot_state_check" CHECK ("state" IN ('staging', 'ready')),
+    CONSTRAINT "ReviewScopeSnapshot_snapshotJson_check" CHECK (json_valid("snapshotJson") AND json_type("snapshotJson") = 'object')
+);`,
+          columns: [
+            'id',
+            'projectId',
+            'sessionId',
+            'reviewId',
+            'scopeTurnMessageId',
+            'state',
+            'snapshotJson',
+            'checksum',
+            'storageKey',
+            'schemaVersion',
+            'blockCount',
+            'createdAt'
+          ]
+        }
+      ],
+      dropOrder: ['ReviewFindingDisposition', 'ReviewScopeSnapshot', 'Finding', 'Review'],
+      indexes: [
+        `CREATE INDEX IF NOT EXISTS "ReviewFindingDisposition_causeReviewId_createdAt_idx" ON "ReviewFindingDisposition"("causeReviewId", "createdAt");`,
+        `CREATE INDEX IF NOT EXISTS "ReviewFindingDisposition_assessedArtifactVersionId_idx" ON "ReviewFindingDisposition"("assessedArtifactVersionId");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ReviewFindingDisposition_sourceFindingId_sequence_key" ON "ReviewFindingDisposition"("sourceFindingId", "sequence");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ReviewScopeSnapshot_reviewId_key" ON "ReviewScopeSnapshot"("reviewId");`,
+        `CREATE INDEX IF NOT EXISTS "ReviewScopeSnapshot_projectId_sessionId_state_idx" ON "ReviewScopeSnapshot"("projectId", "sessionId", "state");`
+      ]
+    },
+    {
+      kind: 'rebuild-table-set',
+      version: 1,
+      tables: [
+        {
+          tableName: 'FileOriginSession',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "FileOriginSession" (
+    "projectId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "titleSnapshot" TEXT,
+    "state" TEXT NOT NULL DEFAULT 'active',
+    "deletedAt" DATETIME,
+    "deletionOperationId" TEXT,
+    "retainedReviewIdsJson" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+
+    PRIMARY KEY ("projectId", "sessionId"),
+    CONSTRAINT "FileOriginSession_state_check" CHECK ("state" IN ('active', 'deleting', 'deleted')),
+    CONSTRAINT "FileOriginSession_retainedReviewIdsJson_check" CHECK ("retainedReviewIdsJson" IS NULL OR (json_valid("retainedReviewIdsJson") AND json_type("retainedReviewIdsJson") = 'array')),
+    CONSTRAINT "FileOriginSession_lifecycle_check" CHECK ((("state" = 'active' AND "deletedAt" IS NULL AND "deletionOperationId" IS NULL AND "retainedReviewIdsJson" IS NULL) OR ("state" = 'deleting' AND "deletedAt" IS NULL AND "deletionOperationId" IS NOT NULL AND "retainedReviewIdsJson" IS NOT NULL) OR ("state" = 'deleted' AND "deletedAt" IS NOT NULL AND "deletionOperationId" IS NULL AND "retainedReviewIdsJson" IS NULL)))
+);`,
+          columns: [
+            'projectId',
+            'sessionId',
+            'titleSnapshot',
+            'state',
+            'deletedAt',
+            'deletionOperationId',
+            'retainedReviewIdsJson',
+            'createdAt',
+            'updatedAt'
+          ]
+        },
+        {
+          tableName: 'ArtifactLineage',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ArtifactLineage" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "projectId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "normalizedFilename" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ArtifactLineage_projectId_sessionId_fkey" FOREIGN KEY ("projectId", "sessionId") REFERENCES "FileOriginSession" ("projectId", "sessionId") ON DELETE RESTRICT ON UPDATE CASCADE
+);`,
+          columns: [
+            'id',
+            'projectId',
+            'sessionId',
+            'normalizedFilename',
+            'filename',
+            'createdAt',
+            'updatedAt'
+          ]
+        },
+        {
+          tableName: 'UploadFile',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "UploadFile" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "projectId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "originalFilename" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "UploadFile_projectId_sessionId_fkey" FOREIGN KEY ("projectId", "sessionId") REFERENCES "FileOriginSession" ("projectId", "sessionId") ON DELETE RESTRICT ON UPDATE CASCADE
+);`,
+          columns: [
+            'id',
+            'projectId',
+            'sessionId',
+            'filename',
+            'originalFilename',
+            'createdAt',
+            'updatedAt'
+          ]
+        },
+        {
+          tableName: 'UploadVersion',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "UploadVersion" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "uploadFileId" TEXT NOT NULL,
+    "versionNumber" INTEGER NOT NULL,
+    "state" TEXT NOT NULL DEFAULT 'staging',
+    "contentStorageKey" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "originalFilename" TEXT NOT NULL,
+    "contentType" TEXT,
+    "sizeBytes" BIGINT NOT NULL,
+    "checksum" TEXT NOT NULL,
+    "createdAt" DATETIME,
+    "registeredAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "UploadVersion_uploadFileId_fkey" FOREIGN KEY ("uploadFileId") REFERENCES "UploadFile" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "UploadVersion_state_check" CHECK ("state" IN ('staging', 'ready'))
+);`,
+          columns: [
+            'id',
+            'uploadFileId',
+            'versionNumber',
+            'state',
+            'contentStorageKey',
+            'filename',
+            'originalFilename',
+            'contentType',
+            'sizeBytes',
+            'checksum',
+            'createdAt',
+            'registeredAt',
+            'updatedAt'
+          ]
+        },
+        {
+          tableName: 'ArtifactMessageSnapshot',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ArtifactMessageSnapshot" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "projectId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "rootFrameId" TEXT NOT NULL,
+    "agentFrameId" TEXT NOT NULL,
+    "messageBranchId" TEXT NOT NULL,
+    "terminalMessageId" TEXT NOT NULL,
+    "state" TEXT NOT NULL DEFAULT 'staging',
+    "storageKey" TEXT NOT NULL,
+    "checksum" TEXT NOT NULL DEFAULT '',
+    "messageCount" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ArtifactMessageSnapshot_projectId_sessionId_fkey" FOREIGN KEY ("projectId", "sessionId") REFERENCES "FileOriginSession" ("projectId", "sessionId") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactMessageSnapshot_state_check" CHECK ("state" IN ('staging', 'ready'))
+);`,
+          columns: [
+            'id',
+            'projectId',
+            'sessionId',
+            'rootFrameId',
+            'agentFrameId',
+            'messageBranchId',
+            'terminalMessageId',
+            'state',
+            'storageKey',
+            'checksum',
+            'messageCount',
+            'createdAt',
+            'updatedAt'
+          ]
+        },
+        {
+          tableName: 'ArtifactVersion',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ArtifactVersion" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "artifactId" TEXT NOT NULL,
+    "versionNumber" INTEGER NOT NULL,
+    "filename" TEXT NOT NULL,
+    "artifactRunId" TEXT NOT NULL,
+    "writeOperationId" TEXT,
+    "writeRequestChecksum" TEXT,
+    "rootFrameId" TEXT NOT NULL,
+    "agentFrameId" TEXT NOT NULL,
+    "messageBranchId" TEXT NOT NULL,
+    "runtimeSegmentId" TEXT NOT NULL,
+    "promptMessageId" TEXT NOT NULL,
+    "notebookSessionId" TEXT,
+    "producerRunId" TEXT,
+    "producerRunIndex" INTEGER,
+    "messageId" TEXT,
+    "messageSnapshotId" TEXT,
+    "state" TEXT NOT NULL DEFAULT 'staging',
+    "contentStorageKey" TEXT NOT NULL,
+    "evidenceStorageKey" TEXT NOT NULL,
+    "contentType" TEXT,
+    "sizeBytes" BIGINT NOT NULL,
+    "checksum" TEXT NOT NULL,
+    "evidenceJson" TEXT NOT NULL,
+    "evidenceChecksum" TEXT NOT NULL,
+    "evidenceSchemaVersion" INTEGER NOT NULL DEFAULT 1,
+    "executionSnapshotJson" TEXT,
+    "executionSnapshotChecksum" TEXT,
+    "executionSnapshotStorageKey" TEXT,
+    "executionSnapshotSchemaVersion" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ArtifactVersion_artifactId_fkey" FOREIGN KEY ("artifactId") REFERENCES "ArtifactLineage" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersion_messageSnapshotId_fkey" FOREIGN KEY ("messageSnapshotId") REFERENCES "ArtifactMessageSnapshot" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersion_state_check" CHECK ("state" IN ('staging', 'pending', 'finalized')),
+    CONSTRAINT "ArtifactVersion_filename_check" CHECK (length("filename") > 0),
+    CONSTRAINT "ArtifactVersion_evidenceJson_check" CHECK (json_valid("evidenceJson") AND json_type("evidenceJson") = 'object'),
+    CONSTRAINT "ArtifactVersion_executionSnapshotJson_check" CHECK ("executionSnapshotJson" IS NULL OR (json_valid("executionSnapshotJson") AND json_type("executionSnapshotJson") = 'object')),
+    CONSTRAINT "ArtifactVersion_executionSnapshotBundle_check" CHECK ((("executionSnapshotJson" IS NULL AND "executionSnapshotChecksum" IS NULL AND "executionSnapshotStorageKey" IS NULL AND "executionSnapshotSchemaVersion" IS NULL) OR ("executionSnapshotJson" IS NOT NULL AND "executionSnapshotChecksum" IS NOT NULL AND "executionSnapshotStorageKey" IS NOT NULL AND "executionSnapshotSchemaVersion" IS NOT NULL)))
+);`,
+          columns: [
+            'id',
+            'artifactId',
+            'versionNumber',
+            'filename',
+            'artifactRunId',
+            'writeOperationId',
+            'writeRequestChecksum',
+            'rootFrameId',
+            'agentFrameId',
+            'messageBranchId',
+            'runtimeSegmentId',
+            'promptMessageId',
+            'notebookSessionId',
+            'producerRunId',
+            'producerRunIndex',
+            'messageId',
+            'messageSnapshotId',
+            'state',
+            'contentStorageKey',
+            'evidenceStorageKey',
+            'contentType',
+            'sizeBytes',
+            'checksum',
+            'evidenceJson',
+            'evidenceChecksum',
+            'evidenceSchemaVersion',
+            'executionSnapshotJson',
+            'executionSnapshotChecksum',
+            'executionSnapshotStorageKey',
+            'executionSnapshotSchemaVersion',
+            'createdAt',
+            'updatedAt'
+          ]
+        },
+        {
+          tableName: 'ArtifactVersionInput',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ArtifactVersionInput" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "artifactVersionId" TEXT NOT NULL,
+    "ordinal" INTEGER NOT NULL,
+    "inputFileVersionId" TEXT NOT NULL,
+    "sourceKind" TEXT NOT NULL,
+    "sourceFileId" TEXT NOT NULL,
+    "sourceArtifactVersionId" TEXT,
+    "sourceUploadVersionId" TEXT,
+    "sourceVersionNumber" INTEGER,
+    "sourceCreatedAt" DATETIME,
+    "sourceProjectId" TEXT NOT NULL,
+    "sourceSessionId" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "contentType" TEXT,
+    "sizeBytes" BIGINT NOT NULL,
+    "checksum" TEXT NOT NULL,
+    "storageKey" TEXT NOT NULL,
+    "strongestAssociation" TEXT NOT NULL,
+    CONSTRAINT "ArtifactVersionInput_artifactVersionId_fkey" FOREIGN KEY ("artifactVersionId") REFERENCES "ArtifactVersion" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersionInput_sourceArtifactVersionId_fkey" FOREIGN KEY ("sourceArtifactVersionId") REFERENCES "ArtifactVersion" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersionInput_sourceUploadVersionId_fkey" FOREIGN KEY ("sourceUploadVersionId") REFERENCES "UploadVersion" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersionInput_sourceProjectId_sourceSessionId_fkey" FOREIGN KEY ("sourceProjectId", "sourceSessionId") REFERENCES "FileOriginSession" ("projectId", "sessionId") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ArtifactVersionInput_sourceKind_check" CHECK ("sourceKind" IN ('artifact-version', 'upload-version')),
+    CONSTRAINT "ArtifactVersionInput_sourceIdentity_check" CHECK ((("sourceKind" = 'artifact-version' AND "sourceArtifactVersionId" IS NOT NULL AND "sourceUploadVersionId" IS NULL AND "inputFileVersionId" = "sourceArtifactVersionId") OR ("sourceKind" = 'upload-version' AND "sourceArtifactVersionId" IS NULL AND "sourceUploadVersionId" IS NOT NULL AND "inputFileVersionId" = "sourceUploadVersionId"))),
+    CONSTRAINT "ArtifactVersionInput_strongestAssociation_check" CHECK ("strongestAssociation" IN ('turn-attached', 'resolver-accessed', 'captured-version'))
+);`,
+          columns: [
+            'id',
+            'artifactVersionId',
+            'ordinal',
+            'inputFileVersionId',
+            'sourceKind',
+            'sourceFileId',
+            'sourceArtifactVersionId',
+            'sourceUploadVersionId',
+            'sourceVersionNumber',
+            'sourceCreatedAt',
+            'sourceProjectId',
+            'sourceSessionId',
+            'filename',
+            'contentType',
+            'sizeBytes',
+            'checksum',
+            'storageKey',
+            'strongestAssociation'
+          ]
+        }
+      ],
+      dropOrder: [
+        'ArtifactVersionInput',
+        'ArtifactVersion',
+        'ArtifactMessageSnapshot',
+        'UploadVersion',
+        'UploadFile',
+        'ArtifactLineage',
+        'FileOriginSession'
+      ],
+      indexes: [
+        `CREATE INDEX IF NOT EXISTS "FileOriginSession_projectId_state_idx" ON "FileOriginSession"("projectId", "state");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactLineage_projectId_sessionId_idx" ON "ArtifactLineage"("projectId", "sessionId");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactLineage_projectId_sessionId_normalizedFilename_key" ON "ArtifactLineage"("projectId", "sessionId", "normalizedFilename");`,
+        `CREATE INDEX IF NOT EXISTS "UploadFile_projectId_sessionId_idx" ON "UploadFile"("projectId", "sessionId");`,
+        `CREATE INDEX IF NOT EXISTS "UploadVersion_uploadFileId_state_registeredAt_idx" ON "UploadVersion"("uploadFileId", "state", "registeredAt");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "UploadVersion_uploadFileId_versionNumber_key" ON "UploadVersion"("uploadFileId", "versionNumber");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactMessageSnapshot_projectId_sessionId_state_idx" ON "ArtifactMessageSnapshot"("projectId", "sessionId", "state");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactMessageSnapshot_projectId_sessionId_agentFrameId_messageBranchId_terminalMessageId_key" ON "ArtifactMessageSnapshot"("projectId", "sessionId", "agentFrameId", "messageBranchId", "terminalMessageId");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersion_writeOperationId_key" ON "ArtifactVersion"("writeOperationId");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersion_artifactId_createdAt_idx" ON "ArtifactVersion"("artifactId", "createdAt");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersion_artifactRunId_state_idx" ON "ArtifactVersion"("artifactRunId", "state");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersion_rootFrameId_agentFrameId_messageBranchId_promptMessageId_idx" ON "ArtifactVersion"("rootFrameId", "agentFrameId", "messageBranchId", "promptMessageId");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersion_messageId_idx" ON "ArtifactVersion"("messageId");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersion_messageSnapshotId_idx" ON "ArtifactVersion"("messageSnapshotId");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersion_artifactId_versionNumber_key" ON "ArtifactVersion"("artifactId", "versionNumber");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceKind_inputFileVersionId_idx" ON "ArtifactVersionInput"("sourceKind", "inputFileVersionId");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceArtifactVersionId_idx" ON "ArtifactVersionInput"("sourceArtifactVersionId");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceUploadVersionId_idx" ON "ArtifactVersionInput"("sourceUploadVersionId");`,
+        `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceProjectId_sourceSessionId_idx" ON "ArtifactVersionInput"("sourceProjectId", "sourceSessionId");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersionInput_artifactVersionId_sourceKind_inputFileVersionId_key" ON "ArtifactVersionInput"("artifactVersionId", "sourceKind", "inputFileVersionId");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersionInput_artifactVersionId_ordinal_key" ON "ArtifactVersionInput"("artifactVersionId", "ordinal");`
+      ]
+    },
+    {
+      kind: 'rebuild-table-set',
+      version: 1,
+      tables: [
+        {
+          tableName: 'ManagedFile',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ManagedFile" (
+    "seq" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "source" TEXT NOT NULL,
+    "sourceFileId" TEXT NOT NULL,
+    "sourceVersionId" TEXT,
+    "checksum" TEXT,
+    "projectId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "messageId" TEXT,
+    "displayName" TEXT NOT NULL,
+    "storageKey" TEXT NOT NULL,
+    "mimeType" TEXT,
+    "sizeBytes" BIGINT NOT NULL,
+    "mtimeMs" BIGINT,
+    "sortAtMs" BIGINT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "deletedAt" DATETIME,
+    "deleteOperationId" TEXT,
+    CONSTRAINT "ManagedFile_source_check" CHECK ("source" IN ('artifact', 'upload'))
+);`,
+          columns: [
+            'seq',
+            'source',
+            'sourceFileId',
+            'sourceVersionId',
+            'checksum',
+            'projectId',
+            'sessionId',
+            'messageId',
+            'displayName',
+            'storageKey',
+            'mimeType',
+            'sizeBytes',
+            'mtimeMs',
+            'sortAtMs',
+            'createdAt',
+            'updatedAt',
+            'deletedAt',
+            'deleteOperationId'
+          ]
+        }
+      ],
+      dropOrder: ['ManagedFile'],
+      indexes: [
+        `CREATE INDEX IF NOT EXISTS "ManagedFile_projectId_deletedAt_sortAtMs_seq_idx" ON "ManagedFile"("projectId", "deletedAt", "sortAtMs", "seq");`,
+        `CREATE INDEX IF NOT EXISTS "ManagedFile_projectId_source_deletedAt_sortAtMs_seq_idx" ON "ManagedFile"("projectId", "source", "deletedAt", "sortAtMs", "seq");`,
+        `CREATE INDEX IF NOT EXISTS "ManagedFile_projectId_sessionId_source_deletedAt_sortAtMs_seq_idx" ON "ManagedFile"("projectId", "sessionId", "source", "deletedAt", "sortAtMs", "seq");`,
+        `CREATE INDEX IF NOT EXISTS "ManagedFile_sessionId_deletedAt_idx" ON "ManagedFile"("sessionId", "deletedAt");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ManagedFile_projectId_source_sourceFileId_key" ON "ManagedFile"("projectId", "source", "sourceFileId");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ManagedFile_projectId_source_storageKey_key" ON "ManagedFile"("projectId", "source", "storageKey");`
+      ]
+    },
+    {
+      kind: 'rebuild-table-set',
+      version: 1,
+      tables: [
+        {
+          tableName: 'ComputeJob',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ComputeJob" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "providerId" TEXT NOT NULL,
+    "shape" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'submitted',
+    "intent" TEXT NOT NULL,
+    "command" TEXT NOT NULL,
+    "commandHash" TEXT NOT NULL,
+    "environment" TEXT,
+    "resourceRequest" TEXT,
+    "inputManifest" TEXT,
+    "outputManifest" TEXT,
+    "harvestConfig" TEXT,
+    "timeoutSeconds" INTEGER,
+    "remoteWorkdir" TEXT,
+    "remoteHandle" TEXT,
+    "exitCode" INTEGER,
+    "stdoutTail" TEXT,
+    "stderrTail" TEXT,
+    "errorCode" TEXT,
+    "lastPollError" TEXT,
+    "harvestError" TEXT,
+    "leftOnRemote" TEXT,
+    "notifiedAt" DATETIME,
+    "notificationConsumedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "submittedAt" DATETIME,
+    "startedAt" DATETIME,
+    "finishedAt" DATETIME,
+    "harvestedAt" DATETIME,
+    CONSTRAINT "ComputeJob_shape_check" CHECK ("shape" IN ('direct_ssh', 'scheduler_cluster', 'bridge_runner')),
+    CONSTRAINT "ComputeJob_status_check" CHECK ("status" IN ('queued', 'submitted', 'running', 'success', 'failed', 'timeout', 'error')),
+    CONSTRAINT "ComputeJob_errorCode_check" CHECK ("errorCode" IS NULL OR "errorCode" IN ('approval_denied', 'host_unreachable', 'dispatch_failed', 'job_failed', 'timeout', 'process_vanished')),
+    CONSTRAINT "ComputeJob_timeoutSeconds_check" CHECK ("timeoutSeconds" IS NULL OR "timeoutSeconds" BETWEEN 1 AND 604800),
+    CONSTRAINT "ComputeJob_notification_check" CHECK ("notificationConsumedAt" IS NULL OR "notifiedAt" IS NOT NULL),
+    CONSTRAINT "ComputeJob_harvestPayload_check" CHECK (("harvestError" IS NULL AND "leftOnRemote" IS NULL) OR "harvestedAt" IS NOT NULL),
+    CONSTRAINT "ComputeJob_harvestState_check" CHECK ("harvestedAt" IS NULL OR "status" IN ('success', 'failed', 'timeout')),
+    CONSTRAINT "ComputeJob_errorState_check" CHECK ((("errorCode" IS NULL OR "status" IN ('failed', 'timeout', 'error')) AND ("status" <> 'error' OR "errorCode" IS NOT NULL))),
+    CONSTRAINT "ComputeJob_resourceRequestJson_check" CHECK ("resourceRequest" IS NULL OR (json_valid("resourceRequest") AND json_type("resourceRequest") = 'object')),
+    CONSTRAINT "ComputeJob_inputManifestJson_check" CHECK ("inputManifest" IS NULL OR (json_valid("inputManifest") AND json_type("inputManifest") = 'array')),
+    CONSTRAINT "ComputeJob_outputManifestJson_check" CHECK ("outputManifest" IS NULL OR (json_valid("outputManifest") AND json_type("outputManifest") = 'array')),
+    CONSTRAINT "ComputeJob_harvestConfigJson_check" CHECK ("harvestConfig" IS NULL OR (json_valid("harvestConfig") AND json_type("harvestConfig") = 'object')),
+    CONSTRAINT "ComputeJob_remoteHandleJson_check" CHECK ("remoteHandle" IS NULL OR (json_valid("remoteHandle") AND json_type("remoteHandle") = 'object')),
+    CONSTRAINT "ComputeJob_leftOnRemoteJson_check" CHECK ("leftOnRemote" IS NULL OR (json_valid("leftOnRemote") AND json_type("leftOnRemote") = 'array'))
+);`,
+          columns: [
+            'id',
+            'providerId',
+            'shape',
+            'sessionId',
+            'projectId',
+            'status',
+            'intent',
+            'command',
+            'commandHash',
+            'environment',
+            'resourceRequest',
+            'inputManifest',
+            'outputManifest',
+            'harvestConfig',
+            'timeoutSeconds',
+            'remoteWorkdir',
+            'remoteHandle',
+            'exitCode',
+            'stdoutTail',
+            'stderrTail',
+            'errorCode',
+            'lastPollError',
+            'harvestError',
+            'leftOnRemote',
+            'notifiedAt',
+            'notificationConsumedAt',
+            'createdAt',
+            'submittedAt',
+            'startedAt',
+            'finishedAt',
+            'harvestedAt'
+          ]
+        },
+        {
+          tableName: 'ComputeHost',
+          canonicalTableDdl: `CREATE TABLE IF NOT EXISTS "ComputeHost" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "providerId" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "shape" TEXT NOT NULL DEFAULT 'direct_ssh',
+    "sshAlias" TEXT NOT NULL,
+    "sshOverrides" TEXT,
+    "scratchRoot" TEXT,
+    "scratchPinned" BOOLEAN NOT NULL DEFAULT false,
+    "concurrencyLimit" INTEGER,
+    "probeResult" TEXT,
+    "detailsDoc" TEXT NOT NULL DEFAULT '',
+    "detailsUpdatedAt" DATETIME,
+    "detailsUpdatedBy" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ComputeHost_shape_check" CHECK ("shape" IN ('direct_ssh', 'scheduler_cluster', 'bridge_runner')),
+    CONSTRAINT "ComputeHost_scratchPinned_check" CHECK ("scratchPinned" IN (false, true)),
+    CONSTRAINT "ComputeHost_concurrencyLimit_check" CHECK ("concurrencyLimit" IS NULL OR "concurrencyLimit" BETWEEN 1 AND 500),
+    CONSTRAINT "ComputeHost_detailsUpdatedBy_check" CHECK ("detailsUpdatedBy" IS NULL OR "detailsUpdatedBy" IN ('user', 'agent')),
+    CONSTRAINT "ComputeHost_detailsUpdate_check" CHECK (("detailsUpdatedAt" IS NULL AND "detailsUpdatedBy" IS NULL) OR ("detailsUpdatedAt" IS NOT NULL AND "detailsUpdatedBy" IS NOT NULL)),
+    CONSTRAINT "ComputeHost_scratchRoot_check" CHECK ("scratchPinned" = false OR "scratchRoot" IS NOT NULL),
+    CONSTRAINT "ComputeHost_sshOverridesJson_check" CHECK ("sshOverrides" IS NULL OR (json_valid("sshOverrides") AND json_type("sshOverrides") = 'object')),
+    CONSTRAINT "ComputeHost_probeResultJson_check" CHECK ("probeResult" IS NULL OR (json_valid("probeResult") AND json_type("probeResult") = 'object'))
+);`,
+          columns: [
+            'id',
+            'providerId',
+            'displayName',
+            'shape',
+            'sshAlias',
+            'sshOverrides',
+            'scratchRoot',
+            'scratchPinned',
+            'concurrencyLimit',
+            'probeResult',
+            'detailsDoc',
+            'detailsUpdatedAt',
+            'detailsUpdatedBy',
+            'createdAt',
+            'updatedAt'
+          ]
+        }
+      ],
+      dropOrder: ['ComputeJob', 'ComputeHost'],
+      indexes: [
+        `CREATE INDEX IF NOT EXISTS "ComputeJob_providerId_idx" ON "ComputeJob"("providerId");`,
+        `CREATE INDEX IF NOT EXISTS "ComputeJob_sessionId_idx" ON "ComputeJob"("sessionId");`,
+        `CREATE INDEX IF NOT EXISTS "ComputeJob_status_idx" ON "ComputeJob"("status");`,
+        `CREATE UNIQUE INDEX IF NOT EXISTS "ComputeHost_providerId_key" ON "ComputeHost"("providerId");`
+      ]
+    }
+  ] as const,
+  verifiers: [
+    {
+      kind: 'check-constraints-exist',
+      version: 1,
+      tables: [
+        {
+          table: 'NotificationInboxItem',
+          constraints: [
+            {
+              name: 'NotificationInboxItem_kind_check',
+              expression: `"kind" IN ('task.completed', 'task.needs-attention', 'task.failed', 'authorization.required')`
+            },
+            {
+              name: 'NotificationInboxItem_actionState_check',
+              expression: `"actionState" IS NULL OR "actionState" IN ('pending', 'resolved', 'rejected', 'expired', 'cancelled')`
+            },
+            {
+              name: 'NotificationInboxItem_actionLifecycle_check',
+              expression: `(("actionState" IS NULL AND "settledAt" IS NULL) OR ("actionState" IS NOT NULL AND (("actionState" = 'pending' AND "settledAt" IS NULL) OR ("actionState" IN ('resolved', 'rejected', 'expired', 'cancelled') AND "settledAt" IS NOT NULL))))`
+            },
+            {
+              name: 'NotificationInboxItem_actionKind_check',
+              expression: `"actionState" IS NULL OR "kind" IN ('task.needs-attention', 'authorization.required')`
+            },
+            {
+              name: 'NotificationInboxItem_targetInvalidated_check',
+              expression: `"targetInvalidatedAt" IS NULL OR ("sessionId" IS NOT NULL AND "readAt" IS NOT NULL)`
+            }
+          ]
+        },
+        {
+          table: 'ProjectPreviewState',
+          constraints: [
+            {
+              name: 'ProjectPreviewState_panelState_check',
+              expression: `"panelState" IN ('open', 'collapsed')`
+            },
+            {
+              name: 'ProjectPreviewState_itemsJson_check',
+              expression: `json_valid("items") AND json_type("items") = 'array'`
+            }
+          ]
+        },
+        {
+          table: 'FileOriginSession',
+          constraints: [
+            {
+              name: 'FileOriginSession_retainedReviewIdsJson_check',
+              expression: `"retainedReviewIdsJson" IS NULL OR (json_valid("retainedReviewIdsJson") AND json_type("retainedReviewIdsJson") = 'array')`
+            },
+            {
+              name: 'FileOriginSession_lifecycle_check',
+              expression: `(("state" = 'active' AND "deletedAt" IS NULL AND "deletionOperationId" IS NULL AND "retainedReviewIdsJson" IS NULL) OR ("state" = 'deleting' AND "deletedAt" IS NULL AND "deletionOperationId" IS NOT NULL AND "retainedReviewIdsJson" IS NOT NULL) OR ("state" = 'deleted' AND "deletedAt" IS NOT NULL AND "deletionOperationId" IS NULL AND "retainedReviewIdsJson" IS NULL))`
+            }
+          ]
+        },
+        {
+          table: 'ManagedFile',
+          constraints: [
+            {
+              name: 'ManagedFile_source_check',
+              expression: `"source" IN ('artifact', 'upload')`
+            }
+          ]
+        },
+        {
+          table: 'ArtifactVersion',
+          constraints: [
+            {
+              name: 'ArtifactVersion_evidenceJson_check',
+              expression: `json_valid("evidenceJson") AND json_type("evidenceJson") = 'object'`
+            },
+            {
+              name: 'ArtifactVersion_executionSnapshotJson_check',
+              expression: `"executionSnapshotJson" IS NULL OR (json_valid("executionSnapshotJson") AND json_type("executionSnapshotJson") = 'object')`
+            },
+            {
+              name: 'ArtifactVersion_executionSnapshotBundle_check',
+              expression: `(("executionSnapshotJson" IS NULL AND "executionSnapshotChecksum" IS NULL AND "executionSnapshotStorageKey" IS NULL AND "executionSnapshotSchemaVersion" IS NULL) OR ("executionSnapshotJson" IS NOT NULL AND "executionSnapshotChecksum" IS NOT NULL AND "executionSnapshotStorageKey" IS NOT NULL AND "executionSnapshotSchemaVersion" IS NOT NULL))`
+            }
+          ]
+        },
+        {
+          table: 'ArtifactVersionInput',
+          constraints: [
+            {
+              name: 'ArtifactVersionInput_strongestAssociation_check',
+              expression: `"strongestAssociation" IN ('turn-attached', 'resolver-accessed', 'captured-version')`
+            }
+          ]
+        },
+        {
+          table: 'ReviewScopeSnapshot',
+          constraints: [
+            {
+              name: 'ReviewScopeSnapshot_snapshotJson_check',
+              expression: `json_valid("snapshotJson") AND json_type("snapshotJson") = 'object'`
+            }
+          ]
+        },
+        {
+          table: 'Review',
+          constraints: [
+            {
+              name: 'Review_scopeJson_check',
+              expression: `json_valid("scope") AND json_type("scope") = 'object'`
+            },
+            {
+              name: 'Review_reviewerLogJson_check',
+              expression: `json_valid("reviewerLog") AND json_type("reviewerLog") = 'array'`
+            }
+          ]
+        },
+        {
+          table: 'Finding',
+          constraints: [
+            {
+              name: 'Finding_locatorJson_check',
+              expression: `json_valid("locator") AND json_type("locator") = 'object'`
+            }
+          ]
+        },
+        {
+          table: 'ReviewFindingDisposition',
+          constraints: [
+            {
+              name: 'ReviewFindingDisposition_assessmentSnapshotJson_check',
+              expression: `"assessmentSnapshot" IS NULL OR (json_valid("assessmentSnapshot") AND json_type("assessmentSnapshot") = 'object')`
+            }
+          ]
+        },
+        {
+          table: 'ComputeJob',
+          constraints: [
+            {
+              name: 'ComputeJob_resourceRequestJson_check',
+              expression: `"resourceRequest" IS NULL OR (json_valid("resourceRequest") AND json_type("resourceRequest") = 'object')`
+            },
+            {
+              name: 'ComputeJob_inputManifestJson_check',
+              expression: `"inputManifest" IS NULL OR (json_valid("inputManifest") AND json_type("inputManifest") = 'array')`
+            },
+            {
+              name: 'ComputeJob_outputManifestJson_check',
+              expression: `"outputManifest" IS NULL OR (json_valid("outputManifest") AND json_type("outputManifest") = 'array')`
+            },
+            {
+              name: 'ComputeJob_harvestConfigJson_check',
+              expression: `"harvestConfig" IS NULL OR (json_valid("harvestConfig") AND json_type("harvestConfig") = 'object')`
+            },
+            {
+              name: 'ComputeJob_remoteHandleJson_check',
+              expression: `"remoteHandle" IS NULL OR (json_valid("remoteHandle") AND json_type("remoteHandle") = 'object')`
+            },
+            {
+              name: 'ComputeJob_leftOnRemoteJson_check',
+              expression: `"leftOnRemote" IS NULL OR (json_valid("leftOnRemote") AND json_type("leftOnRemote") = 'array')`
+            }
+          ]
+        },
+        {
+          table: 'ComputeHost',
+          constraints: [
+            {
+              name: 'ComputeHost_sshOverridesJson_check',
+              expression: `"sshOverrides" IS NULL OR (json_valid("sshOverrides") AND json_type("sshOverrides") = 'object')`
+            },
+            {
+              name: 'ComputeHost_probeResultJson_check',
+              expression: `"probeResult" IS NULL OR (json_valid("probeResult") AND json_type("probeResult") = 'object')`
+            }
+          ]
+        }
+      ]
+    },
+    {
+      kind: 'indexes-exist',
+      version: 1,
+      indexes: [
+        {
+          name: 'NotificationInboxItem_id_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "NotificationInboxItem_id_key" ON "NotificationInboxItem"("id");`
+        },
+        {
+          name: 'NotificationInboxItem_dedupeKey_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "NotificationInboxItem_dedupeKey_key" ON "NotificationInboxItem"("dedupeKey");`
+        },
+        {
+          name: 'NotificationInboxItem_readAt_sequence_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "NotificationInboxItem_readAt_sequence_idx" ON "NotificationInboxItem"("readAt", "sequence");`
+        },
+        {
+          name: 'NotificationInboxItem_sessionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "NotificationInboxItem_sessionId_idx" ON "NotificationInboxItem"("sessionId");`
+        },
+        {
+          name: 'NotificationInboxItem_projectId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "NotificationInboxItem_projectId_idx" ON "NotificationInboxItem"("projectId");`
+        },
+        {
+          name: 'ManagedFile_projectId_deletedAt_sortAtMs_seq_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ManagedFile_projectId_deletedAt_sortAtMs_seq_idx" ON "ManagedFile"("projectId", "deletedAt", "sortAtMs", "seq");`
+        },
+        {
+          name: 'ManagedFile_projectId_source_deletedAt_sortAtMs_seq_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ManagedFile_projectId_source_deletedAt_sortAtMs_seq_idx" ON "ManagedFile"("projectId", "source", "deletedAt", "sortAtMs", "seq");`
+        },
+        {
+          name: 'ManagedFile_projectId_sessionId_source_deletedAt_sortAtMs_seq_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ManagedFile_projectId_sessionId_source_deletedAt_sortAtMs_seq_idx" ON "ManagedFile"("projectId", "sessionId", "source", "deletedAt", "sortAtMs", "seq");`
+        },
+        {
+          name: 'ManagedFile_sessionId_deletedAt_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ManagedFile_sessionId_deletedAt_idx" ON "ManagedFile"("sessionId", "deletedAt");`
+        },
+        {
+          name: 'ManagedFile_projectId_source_sourceFileId_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ManagedFile_projectId_source_sourceFileId_key" ON "ManagedFile"("projectId", "source", "sourceFileId");`
+        },
+        {
+          name: 'ManagedFile_projectId_source_storageKey_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ManagedFile_projectId_source_storageKey_key" ON "ManagedFile"("projectId", "source", "storageKey");`
+        },
+        {
+          name: 'FileOriginSession_projectId_state_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "FileOriginSession_projectId_state_idx" ON "FileOriginSession"("projectId", "state");`
+        },
+        {
+          name: 'ArtifactLineage_projectId_sessionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactLineage_projectId_sessionId_idx" ON "ArtifactLineage"("projectId", "sessionId");`
+        },
+        {
+          name: 'ArtifactLineage_projectId_sessionId_normalizedFilename_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactLineage_projectId_sessionId_normalizedFilename_key" ON "ArtifactLineage"("projectId", "sessionId", "normalizedFilename");`
+        },
+        {
+          name: 'UploadFile_projectId_sessionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "UploadFile_projectId_sessionId_idx" ON "UploadFile"("projectId", "sessionId");`
+        },
+        {
+          name: 'UploadVersion_uploadFileId_state_registeredAt_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "UploadVersion_uploadFileId_state_registeredAt_idx" ON "UploadVersion"("uploadFileId", "state", "registeredAt");`
+        },
+        {
+          name: 'UploadVersion_uploadFileId_versionNumber_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "UploadVersion_uploadFileId_versionNumber_key" ON "UploadVersion"("uploadFileId", "versionNumber");`
+        },
+        {
+          name: 'ArtifactMessageSnapshot_projectId_sessionId_state_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactMessageSnapshot_projectId_sessionId_state_idx" ON "ArtifactMessageSnapshot"("projectId", "sessionId", "state");`
+        },
+        {
+          name: 'ArtifactMessageSnapshot_projectId_sessionId_agentFrameId_messageBranchId_terminalMessageId_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactMessageSnapshot_projectId_sessionId_agentFrameId_messageBranchId_terminalMessageId_key" ON "ArtifactMessageSnapshot"("projectId", "sessionId", "agentFrameId", "messageBranchId", "terminalMessageId");`
+        },
+        {
+          name: 'ArtifactVersion_writeOperationId_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersion_writeOperationId_key" ON "ArtifactVersion"("writeOperationId");`
+        },
+        {
+          name: 'ArtifactVersion_artifactId_createdAt_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersion_artifactId_createdAt_idx" ON "ArtifactVersion"("artifactId", "createdAt");`
+        },
+        {
+          name: 'ArtifactVersion_artifactRunId_state_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersion_artifactRunId_state_idx" ON "ArtifactVersion"("artifactRunId", "state");`
+        },
+        {
+          name: 'ArtifactVersion_rootFrameId_agentFrameId_messageBranchId_promptMessageId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersion_rootFrameId_agentFrameId_messageBranchId_promptMessageId_idx" ON "ArtifactVersion"("rootFrameId", "agentFrameId", "messageBranchId", "promptMessageId");`
+        },
+        {
+          name: 'ArtifactVersion_messageId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersion_messageId_idx" ON "ArtifactVersion"("messageId");`
+        },
+        {
+          name: 'ArtifactVersion_messageSnapshotId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersion_messageSnapshotId_idx" ON "ArtifactVersion"("messageSnapshotId");`
+        },
+        {
+          name: 'ArtifactVersion_artifactId_versionNumber_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersion_artifactId_versionNumber_key" ON "ArtifactVersion"("artifactId", "versionNumber");`
+        },
+        {
+          name: 'ArtifactVersionInput_sourceKind_inputFileVersionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceKind_inputFileVersionId_idx" ON "ArtifactVersionInput"("sourceKind", "inputFileVersionId");`
+        },
+        {
+          name: 'ArtifactVersionInput_sourceArtifactVersionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceArtifactVersionId_idx" ON "ArtifactVersionInput"("sourceArtifactVersionId");`
+        },
+        {
+          name: 'ArtifactVersionInput_sourceUploadVersionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceUploadVersionId_idx" ON "ArtifactVersionInput"("sourceUploadVersionId");`
+        },
+        {
+          name: 'ArtifactVersionInput_sourceProjectId_sourceSessionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ArtifactVersionInput_sourceProjectId_sourceSessionId_idx" ON "ArtifactVersionInput"("sourceProjectId", "sourceSessionId");`
+        },
+        {
+          name: 'ArtifactVersionInput_artifactVersionId_sourceKind_inputFileVersionId_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersionInput_artifactVersionId_sourceKind_inputFileVersionId_key" ON "ArtifactVersionInput"("artifactVersionId", "sourceKind", "inputFileVersionId");`
+        },
+        {
+          name: 'ArtifactVersionInput_artifactVersionId_ordinal_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ArtifactVersionInput_artifactVersionId_ordinal_key" ON "ArtifactVersionInput"("artifactVersionId", "ordinal");`
+        },
+        {
+          name: 'ReviewFindingDisposition_causeReviewId_createdAt_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ReviewFindingDisposition_causeReviewId_createdAt_idx" ON "ReviewFindingDisposition"("causeReviewId", "createdAt");`
+        },
+        {
+          name: 'ReviewFindingDisposition_assessedArtifactVersionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ReviewFindingDisposition_assessedArtifactVersionId_idx" ON "ReviewFindingDisposition"("assessedArtifactVersionId");`
+        },
+        {
+          name: 'ReviewFindingDisposition_sourceFindingId_sequence_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ReviewFindingDisposition_sourceFindingId_sequence_key" ON "ReviewFindingDisposition"("sourceFindingId", "sequence");`
+        },
+        {
+          name: 'ReviewScopeSnapshot_reviewId_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ReviewScopeSnapshot_reviewId_key" ON "ReviewScopeSnapshot"("reviewId");`
+        },
+        {
+          name: 'ReviewScopeSnapshot_projectId_sessionId_state_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ReviewScopeSnapshot_projectId_sessionId_state_idx" ON "ReviewScopeSnapshot"("projectId", "sessionId", "state");`
+        },
+        {
+          name: 'ComputeJob_providerId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ComputeJob_providerId_idx" ON "ComputeJob"("providerId");`
+        },
+        {
+          name: 'ComputeJob_sessionId_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ComputeJob_sessionId_idx" ON "ComputeJob"("sessionId");`
+        },
+        {
+          name: 'ComputeJob_status_idx',
+          sql: `CREATE INDEX IF NOT EXISTS "ComputeJob_status_idx" ON "ComputeJob"("status");`
+        },
+        {
+          name: 'ComputeHost_providerId_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "ComputeHost_providerId_key" ON "ComputeHost"("providerId");`
+        }
+      ]
+    }
+  ] as const
+}
+
+export { databaseJsonConstraintsMigration }

--- a/src/main/database/notification-attention-metadata-migration.test.ts
+++ b/src/main/database/notification-attention-metadata-migration.test.ts
@@ -65,9 +65,9 @@ describe('notification attention metadata migration', () => {
 
     await expect(migrateApplicationDatabase(client, { databasePath })).resolves.toEqual({
       adoptedLegacy: false,
-      applied: ['0007_notification_attention_metadata'],
+      applied: ['0007_notification_attention_metadata', '0008_database_json_constraints'],
       from: '0006_database_domain_constraints',
-      to: '0007_notification_attention_metadata'
+      to: '0008_database_json_constraints'
     })
     await expect(
       access(`${databasePath}.before-0007_notification_attention_metadata.backup`)

--- a/src/main/database/sqlite-schema-migrations.ts
+++ b/src/main/database/sqlite-schema-migrations.ts
@@ -6,6 +6,7 @@ import { DatabaseValidationError, summarizeDatabaseValue } from './database-vali
 
 type SqliteTableInfoRow = { name: string }
 type SqliteTableSqlRow = { sql: string | null }
+type SqliteSequenceRow = { seq: bigint | number | null }
 type SqliteForeignKeyViolationRow = {
   table: string
   rowid: bigint | number | null
@@ -108,6 +109,43 @@ const countRows = async (client: SqliteExecutor, tableName: string): Promise<big
   return BigInt(rows[0]?.count ?? 0)
 }
 
+const readAutoincrementSequence = async (
+  client: SqliteExecutor,
+  tableName: string,
+  targetDdl: string
+): Promise<bigint | number | undefined> => {
+  if (!/\bAUTOINCREMENT\b/i.test(targetDdl)) return undefined
+  const sequenceTable = await migrationSqlExecutor.query<Array<{ present: number }>>(
+    client,
+    `SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = 'sqlite_sequence'`
+  )
+  if (sequenceTable.length === 0) return undefined
+  const rows = await migrationSqlExecutor.query<SqliteSequenceRow[]>(
+    client,
+    `SELECT seq FROM sqlite_sequence WHERE name = ? LIMIT 1`,
+    tableName
+  )
+  return rows[0]?.seq ?? undefined
+}
+
+const restoreAutoincrementSequence = async (
+  client: SqliteExecutor,
+  tableName: string,
+  sequence: bigint | number
+): Promise<void> => {
+  await migrationSqlExecutor.execute(
+    client,
+    `DELETE FROM sqlite_sequence WHERE name = ?`,
+    tableName
+  )
+  await migrationSqlExecutor.execute(
+    client,
+    `INSERT INTO sqlite_sequence (name, seq) VALUES (?, ?)`,
+    tableName,
+    sequence
+  )
+}
+
 const withOptionalLegacyColumns = (
   canonicalTableDdl: string,
   columns: readonly { name: string; definition: string }[]
@@ -142,6 +180,7 @@ const applyRebuildTableSet = async (
     targetDdl: string
     copyColumns: string[]
     sourceRowCount: bigint
+    autoincrementSequence: bigint | number | undefined
   }> = []
   for (const table of operation.tables) {
     const sourceColumns = new Set(await readTableColumns(client, table.tableName))
@@ -166,12 +205,14 @@ const applyRebuildTableSet = async (
         { kind: 'unknown-columns', table: table.tableName, actual: unknownColumns }
       )
     }
+    const targetDdl = withOptionalLegacyColumns(table.canonicalTableDdl, optionalColumns)
     prepared.push({
       tableName: table.tableName,
       backupTableName: `__open_science_rebuild_${table.tableName}`,
-      targetDdl: withOptionalLegacyColumns(table.canonicalTableDdl, optionalColumns),
+      targetDdl,
       copyColumns: [...table.columns, ...optionalColumns.map(({ name }) => name)],
-      sourceRowCount: await countRows(client, table.tableName)
+      sourceRowCount: await countRows(client, table.tableName),
+      autoincrementSequence: await readAutoincrementSequence(client, table.tableName, targetDdl)
     })
   }
 
@@ -222,6 +263,10 @@ const applyRebuildTableSet = async (
       client,
       `DROP TABLE ${quoteIdentifier(table.backupTableName)}`
     )
+  }
+  for (const table of prepared) {
+    if (table.autoincrementSequence === undefined) continue
+    await restoreAutoincrementSequence(client, table.tableName, table.autoincrementSequence)
   }
   for (const index of operation.indexes) await migrationSqlExecutor.execute(client, index)
 

--- a/src/main/notifications/notification-inbox-repository.test.ts
+++ b/src/main/notifications/notification-inbox-repository.test.ts
@@ -105,7 +105,7 @@ describe('NotificationInboxDbRepository', () => {
     const repository = await createRepository()
     for (const [originId, actionState] of [
       ['stale', 'pending'],
-      ['settled', 'resolved']
+      ['settled', 'pending']
     ] as const) {
       await repository.record({
         id: `approval-${originId}`,
@@ -118,6 +118,7 @@ describe('NotificationInboxDbRepository', () => {
         actionState
       })
     }
+    await repository.settle('authorization:connector:settled', 'resolved', 2000)
     await repository.record({
       id: 'approval-plan',
       dedupeKey: 'authorization:session-plan:plan-1',

--- a/src/main/notifications/notification-inbox-repository.ts
+++ b/src/main/notifications/notification-inbox-repository.ts
@@ -67,16 +67,16 @@ const invalidateSessionRows = async (
   sessionIds: readonly string[],
   invalidatedAt: Date
 ): Promise<number> => {
-  const invalidated = await mutateInChunks(sessionIds, (sessionIdsChunk) =>
-    client.notificationInboxItem.updateMany({
-      where: { sessionId: { in: sessionIdsChunk }, targetInvalidatedAt: null },
-      data: { targetInvalidatedAt: invalidatedAt }
-    })
-  )
   const acknowledged = await mutateInChunks(sessionIds, (sessionIdsChunk) =>
     client.notificationInboxItem.updateMany({
       where: { sessionId: { in: sessionIdsChunk }, readAt: null },
       data: { readAt: invalidatedAt }
+    })
+  )
+  const invalidated = await mutateInChunks(sessionIds, (sessionIdsChunk) =>
+    client.notificationInboxItem.updateMany({
+      where: { sessionId: { in: sessionIdsChunk }, targetInvalidatedAt: null },
+      data: { targetInvalidatedAt: invalidatedAt }
     })
   )
   return invalidated + acknowledged

--- a/src/main/projects/prisma-client.test.ts
+++ b/src/main/projects/prisma-client.test.ts
@@ -108,7 +108,8 @@ describe('project prisma client (integration)', () => {
         '0004_review_assessment_snapshots',
         '0005_project_preview_state_owner_fk',
         '0006_database_domain_constraints',
-        '0007_notification_attention_metadata'
+        '0007_notification_attention_metadata',
+        '0008_database_json_constraints'
       ]
     })
 
@@ -1018,7 +1019,8 @@ describe('project prisma client (integration)', () => {
         '0004_review_assessment_snapshots',
         '0005_project_preview_state_owner_fk',
         '0006_database_domain_constraints',
-        '0007_notification_attention_metadata'
+        '0007_notification_attention_metadata',
+        '0008_database_json_constraints'
       ]
     })
 

--- a/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
+++ b/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
@@ -132,7 +132,9 @@ describe('artifact finalization startup recovery', () => {
       where: { id: version.versionId },
       data: {
         executionSnapshotJson: '{"schemaVersion":2}',
-        executionSnapshotChecksum: '0'.repeat(64)
+        executionSnapshotChecksum: '0'.repeat(64),
+        executionSnapshotStorageKey: 'corrupt-execution.json',
+        executionSnapshotSchemaVersion: 2
       }
     })
     const coordinator = new SessionPersistenceCoordinator(
@@ -282,14 +284,17 @@ describe('artifact finalization startup recovery', () => {
       client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
     ).resolves.toMatchObject({ state: 'pending', messageId: null })
 
-    // Even with unavailable producer evidence, a persisted snapshot-associated field must not be
+    // Even with unavailable producer evidence, a corrupt persisted snapshot bundle must not be
     // interpreted as the legitimate no-producer case.
     await client.artifactVersion.update({
       where: { id: version.versionId },
       data: {
         evidenceJson: persisted.evidenceJson,
         evidenceChecksum: persisted.evidenceChecksum,
-        executionSnapshotChecksum: '0'.repeat(64)
+        executionSnapshotJson: '{}',
+        executionSnapshotChecksum: '0'.repeat(64),
+        executionSnapshotStorageKey: 'missing-execution.json',
+        executionSnapshotSchemaVersion: 2
       }
     })
     await coordinator.loadAll()
@@ -305,7 +310,10 @@ describe('artifact finalization startup recovery', () => {
       data: {
         evidenceJson: malformedEvidenceJson,
         evidenceChecksum: createHash('sha256').update(malformedEvidenceJson).digest('hex'),
-        executionSnapshotChecksum: null
+        executionSnapshotJson: null,
+        executionSnapshotChecksum: null,
+        executionSnapshotStorageKey: null,
+        executionSnapshotSchemaVersion: null
       }
     })
     await coordinator.loadAll()


### PR DESCRIPTION
## Problem

PR #1287 added SQLite CHECK constraints for the previously identified Review/Finding/ComputeJob/ComputeHost/GrantedLocalRoot domain values, and PR #1292 added Notification source/attention metadata checks. Remaining closed values, JSON TEXT payloads, and cross-column lifecycle combinations were still accepted by SQLite when writes bypassed current TypeScript validation.

## Proposed change

- add the remaining closed-value, JSON validity/root-type, and field-combination CHECK contracts
- generate the canonical runtime schema and append immutable migration `0008_database_json_constraints`
- rebuild affected tables in foreign-key-safe groups, recreate indexes, and retain the required pre-migration backup
- preserve valid 0007 rows and fail closed with full rollback when historical rows violate the new contract
- order notification invalidation writes so `readAt` is persisted before `targetInvalidatedAt`

## Scope and non-goals

- no new tables, columns, or Prisma model fields
- no renderer, IPC, API, or user interaction changes
- no new public enum/status values; `captured-version` is an existing internal ArtifactVersionInput recovery sentinel now included in the database allow-list
- persistence schema and migration ledger change only; valid stored JSON text and row identities are copied unchanged

### Historical compatibility

Valid 0007 databases migrate without rewriting values. A database containing an unknown closed value, malformed JSON, a wrong JSON root type, or an invalid field combination is intentionally not normalized: migration 0008 rolls back, leaves the ledger at 0007, and retains `open-science.db.before-0008_database_json_constraints.backup` for inspection/recovery.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- remaining domain/JSON rejection and valid writes -> targeted database constraint tests -> 46 invalid-write cases rejected; pass
- valid 0007 upgrade, row/index/FK/AUTOINCREMENT preservation, invalid-history rollback and backup -> 0008 migration tests -> pass
- migration ledger, earlier domain migrations, runtime target, and immutable registration -> migration-service, ledger smoke, and PR-policy tests -> 109 tests pass
- notification/preview persistence paths -> targeted repository/runtime/controller/preview tests -> pass
- affected consumer modules -> module-impact Vitest file lists for compute, reviewer, project-files repository, and artifact provenance -> 2,521 tests pass; 16 existing conditional skips
- `npm run typecheck:node` -> pass
- `npm run lint` -> pass with no warnings
- `npm run db:schema:check` -> generated schema current

The Windows module wrapper printed the correct file plans but could not spawn `npm.cmd` (`EINVAL`), so the same file lists were passed directly to `npm test -- ...`. One artifact resolver symlink-escape case could not run locally because Windows denied symlink creation (`EPERM`); the other 1,259 artifact module tests passed. Per maintainer request, full `npm test` was not run locally; exact-head PR CI is authoritative for the full portable and platform lanes.

## Review focus

- whether each CHECK reflects the actual persisted domain invariant
- 0008 rebuild grouping/drop order and complete index restoration
- strict invalid-history behavior and retained-backup semantics
- notification invalidation write ordering under per-statement SQLite CHECK enforcement