### PR TITLE
fix(notebook): remove misleading document language

### DIFF
--- a/src/main/notebook/ipynb-export.test.ts
+++ b/src/main/notebook/ipynb-export.test.ts
@@ -32,7 +32,6 @@ const makeDocument = (runs: NotebookRunRecord[]): NotebookRunDocument => ({
   notebookSessionRoot: '/data/notebooks/default-project/session-123',
   dataRoot: '/data/notebooks/default-project/session-123/data',
   kernel: {
-    language: 'python',
     kernelName: 'python3',
     runtimeRoot: '/data/runtime',
     lastKnownStatus: 'idle'
@@ -311,7 +310,6 @@ describe('runDocumentToIpynbByKernel pre-data control run attribution', () => {
     notebookSessionRoot: '/data/notebooks/default-project/session-123',
     dataRoot: '/data/notebooks/default-project/session-123/data',
     kernel: {
-      language: 'python',
       kernelName: 'python3',
       runtimeRoot: '/data/runtime',
       lastKnownStatus: 'idle'

--- a/src/main/notebook/repository-kernel-metadata.test.ts
+++ b/src/main/notebook/repository-kernel-metadata.test.ts
@@ -1,0 +1,105 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { NotebookKernelKind, NotebookRunRecord } from '../../shared/notebook'
+import { createRootNotebookLane } from './lane-identity'
+import { NotebookRunRepository } from './repository'
+
+let storageRoot: string | undefined
+
+const createStorageRoot = async (): Promise<string> => {
+  storageRoot = await mkdtemp(join(tmpdir(), 'open-science-notebook-kernel-metadata-'))
+  return storageRoot
+}
+
+const runFor = (kernelKind: NotebookKernelKind): NotebookRunRecord => ({
+  runId: `run-${kernelKind}`,
+  cellId: `cell-${kernelKind}`,
+  source: 'agent',
+  kernelKind,
+  script: '1',
+  status: 'completed',
+  startedAt: 1,
+  text: { stdout: '', stderr: '', traceback: '', plain: [] },
+  outputs: [],
+  artifacts: [],
+  workingFiles: []
+})
+
+afterEach(async () => {
+  if (storageRoot) await rm(storageRoot, { recursive: true, force: true })
+  storageRoot = undefined
+})
+
+describe('notebook repository kernel metadata', () => {
+  it.each<NotebookKernelKind>(['r', 'repl', 'bash'])(
+    'does not persist a document-level language for %s-only history',
+    async (kernelKind) => {
+      const root = await createStorageRoot()
+      const repository = new NotebookRunRepository(root)
+      const lane = createRootNotebookLane('default-project', 'session-1', 'root-frame-session-1')
+
+      const created = await repository.loadOrCreate({
+        projectId: 'default-project',
+        sessionId: 'session-1',
+        workspaceCwd: '/workspace',
+        lane
+      })
+      expect(created.kernel).not.toHaveProperty('language')
+
+      await repository.appendRun({
+        projectId: 'default-project',
+        sessionId: 'session-1',
+        lane,
+        run: runFor(kernelKind)
+      })
+
+      const persisted = JSON.parse(
+        await readFile(join(root, 'notebooks', 'default-project', 'session-1', 'run.json'), 'utf8')
+      ) as { kernel: Record<string, unknown>; runs: NotebookRunRecord[] }
+      expect(persisted.kernel).not.toHaveProperty('language')
+      expect(persisted.runs).toEqual([expect.objectContaining({ kernelKind })])
+    }
+  )
+
+  it('reads legacy language metadata and removes it on the next write', async () => {
+    const root = await createStorageRoot()
+    const lane = createRootNotebookLane('default-project', 'session-1', 'root-frame-session-1')
+    const runJsonPath = join(root, 'notebooks', 'default-project', 'session-1', 'run.json')
+    const repository = new NotebookRunRepository(root)
+    await repository.loadOrCreate({
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      lane
+    })
+
+    const legacy = JSON.parse(await readFile(runJsonPath, 'utf8')) as {
+      kernel: Record<string, unknown>
+    }
+    legacy.kernel.language = 'python'
+    await writeFile(runJsonPath, JSON.stringify(legacy, null, 2), 'utf8')
+
+    const reloadedRepository = new NotebookRunRepository(root)
+    const loaded = await reloadedRepository.loadOrCreate({
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      lane
+    })
+    expect(loaded.kernel).not.toHaveProperty('language')
+
+    await reloadedRepository.appendRun({
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      lane,
+      run: runFor('r')
+    })
+    const persisted = JSON.parse(await readFile(runJsonPath, 'utf8')) as {
+      kernel: Record<string, unknown>
+    }
+    expect(persisted.kernel).not.toHaveProperty('language')
+  })
+})

--- a/src/main/notebook/repository.test.ts
+++ b/src/main/notebook/repository.test.ts
@@ -229,7 +229,6 @@ describe('notebook run repository', () => {
       notebookSessionRoot: join(root, 'notebooks', 'default-project', 'session-1'),
       dataRoot: join(root, 'notebooks', 'default-project', 'session-1', 'data'),
       kernel: {
-        language: 'python',
         pythonPath: '/usr/bin/python3',
         kernelName: 'python3',
         runtimeRoot: join(root, 'runtime'),

--- a/src/main/notebook/repository.ts
+++ b/src/main/notebook/repository.ts
@@ -243,10 +243,19 @@ const normalizeTerminatedKernelInstances = (
   return instances.size > 0 ? [...instances.values()] : undefined
 }
 
+const canonicalKernelMetadata = (kernel: NotebookKernelMetadata): NotebookKernelMetadata => {
+  // `language: 'python'` predates multi-kernel documents. It was never read and cannot represent a
+  // history containing Python, R, REPL, and Bash runs, so accept it from old run.json files but never
+  // return or persist it as canonical metadata.
+  const next = { ...kernel } as NotebookKernelMetadata & { language?: unknown }
+  delete next.language
+  return next
+}
+
 const withoutTerminatedKernelInstances = (
   kernel: NotebookKernelMetadata
 ): NotebookKernelMetadata => {
-  const next = { ...kernel }
+  const next = canonicalKernelMetadata(kernel)
   delete next.terminatedKernelInstances
   return next
 }
@@ -290,7 +299,6 @@ const normalizeDocument = (
     dataRoot: getNotebookDataRoot(storageRoot, storageProjectId, sessionId, request.lane),
     kernel: {
       ...withoutTerminatedKernelInstances(document.kernel),
-      language: 'python',
       pythonPath: request.pythonPath ?? document.kernel?.pythonPath,
       kernelName: request.kernelName ?? document.kernel?.kernelName ?? 'python3',
       runtimeRoot: getRuntimeRoot(storageRoot),
@@ -345,7 +353,6 @@ class NotebookRunRepository {
         notebookSessionRoot: '',
         dataRoot: '',
         kernel: {
-          language: 'python',
           pythonPath: request.pythonPath,
           kernelName: request.kernelName ?? 'python3',
           runtimeRoot: '',

--- a/src/main/notebook/run-document-data-paths.test.ts
+++ b/src/main/notebook/run-document-data-paths.test.ts
@@ -15,7 +15,6 @@ const buildDocument = (): NotebookRunDocument => ({
   notebookSessionRoot: `${ROOT}/notebooks/default-project/session-1`,
   dataRoot: `${ROOT}/notebooks/default-project/session-1/data`,
   kernel: {
-    language: 'python',
     kernelName: 'python3',
     runtimeRoot: `${ROOT}/runtime`,
     lastKnownStatus: 'idle'

--- a/src/main/notebook/run-terminalization.test.ts
+++ b/src/main/notebook/run-terminalization.test.ts
@@ -48,7 +48,6 @@ const documentWith = (runs: NotebookRunRecord[]): NotebookRunDocument => ({
   notebookSessionRoot: session.notebookSessionRoot,
   dataRoot: session.dataRoot,
   kernel: {
-    language: 'python',
     kernelName: 'python3',
     runtimeRoot: '/storage/runtime',
     lastKnownStatus: 'running'

--- a/src/main/notebook/runtime-service.export.test.ts
+++ b/src/main/notebook/runtime-service.export.test.ts
@@ -12,7 +12,6 @@ const document: NotebookRunDocument = {
   notebookSessionRoot: '/storage/notebooks/default-project/12345678-abcd',
   dataRoot: '/storage/notebooks/default-project/12345678-abcd/data',
   kernel: {
-    language: 'python',
     kernelName: 'python3',
     runtimeRoot: '/storage/runtime',
     lastKnownStatus: 'idle'

--- a/src/main/storage/normalize-legacy-paths.test.ts
+++ b/src/main/storage/normalize-legacy-paths.test.ts
@@ -50,7 +50,6 @@ const buildLegacyRunDocument = (root: string, projectId: string): NotebookRunDoc
     notebookSessionRoot: sessionRoot,
     dataRoot: join(sessionRoot, 'data'),
     kernel: {
-      language: 'python',
       kernelName: 'python3',
       runtimeRoot: join(root, 'runtime'),
       lastKnownStatus: 'idle'

--- a/src/shared/notebook.ts
+++ b/src/shared/notebook.ts
@@ -302,7 +302,6 @@ export type NotebookWorkingFile = {
 // and internal to the executor, and a kernel-level failure currently surfaces as a run-level 'failed'
 // status rather than a distinct kernel state.
 export type NotebookKernelMetadata = {
-  language: 'python'
   pythonPath?: string
   kernelName: string
   runtimeRoot: string


### PR DESCRIPTION
## Problem

`run.json` persisted `kernel.language` as `python` for every Notebook document, including R-, REPL-, and Bash-only histories. The scalar predates multi-kernel documents, has no current application consumer, and cannot truthfully describe a mixed-kernel history.

## Proposed change

- Remove the canonical document-level `kernel.language` field.
- Keep `runs[].kernelKind` as the per-execution source of truth.
- Continue reading historical `run.json` files that contain the legacy field, while dropping it from the in-memory canonical document and from the next normal repository write.
- Add repository regression coverage for R-, REPL-, Bash-only histories and legacy-data cleanup.

## Scope and non-goals

- No replacement field, status, or enum value.
- No UI or interaction change.
- No Prisma/SQLite schema change, migration, document-version bump, or eager history rewrite.
- No change to execution routing or `.ipynb` kernelspec selection.

## Acceptance criteria and validation

Checks below ran after the last material edit:

- Non-Python histories do not persist a misleading document language, and legacy metadata is cleaned on the next write -> `npm test -- src/main/notebook/repository-kernel-metadata.test.ts ...` (8 explicit repository/persistence/export test files) -> 65/65 passed.
- Shared Node model and all Node consumers remain type-safe -> `npm run typecheck:node` -> passed.
- Source and tests satisfy lint/format rules -> `npm run lint` -> passed.
- Staged patch has no whitespace errors -> `git diff --cached --check` -> passed.

The Notebook area has no `test:module` ID in `scripts/ci/module-impact.json`, so validation used explicit project-owned Notebook tests rather than claiming module-manifest coverage. Per maintainer direction, the complete `npm test` suite was not run locally; PR CI is authoritative for the complete portable and platform lanes.

Persistence coverage is included because the behavior changes canonical `run.json` output. Consumer/UI and platform-specific lanes are excluded locally because no code reads `kernel.language`, no interface behavior changes, and no path/platform logic changes. The remaining uncovered risk is an undocumented external reader depending on this app-internal legacy field.

## Review focus

- Confirm that removing the unrepresentative scalar is preferable to inventing a redundant document summary.
- Confirm the compatibility boundary: old files remain readable and are cleaned lazily on their next write.