### PR TITLE
fix(workspace): retain message queue across project navigation

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -236,7 +236,13 @@ vi.mock('@/components/PermissionUndoSnackbar', () => ({
   PermissionUndoSnackbar: (): React.JSX.Element => <div data-testid="permission-undo" />
 }))
 vi.mock('@/lib/acp/useWorkspaceAgentRuntime', () => ({
-  WorkspaceAgentRuntimeProvider: ({ children }: { children: ReactNode }): ReactNode => children
+  WorkspaceAgentRuntimeProvider: ({ children }: { children: ReactNode }): ReactNode => children,
+  useWorkspaceAgentRuntime: () => ({
+    pendingPermissions: [],
+    promptInFlightSessionIds: [],
+    sendPreparationInFlightSessionIds: [],
+    saveAsSkillInFlightSessionIds: []
+  })
 }))
 vi.mock('@/pages/home/HomePage', () => ({
   HomePage: ({

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -30,6 +30,10 @@ import { SettingsPage, type SettingsPageHandle } from '@/pages/settings/Settings
 import { EnvStatusBanner } from '@/pages/workspace/EnvStatusBanner'
 import { WorkspacePage } from '@/pages/workspace/WorkspacePage'
 import {
+  WorkspaceMessageQueueProvider,
+  WorkspaceMessageQueueRuntimeBridge
+} from '@/pages/workspace/workspace-message-queue-controller'
+import {
   SideChatProvider,
   useOpenSideChatParentSessionIds
 } from '@/pages/workspace/use-side-chat-controller'
@@ -619,25 +623,28 @@ const AppContent = (): React.JSX.Element | null => {
         ) : null}
         {sessionPersistence.catalogRecovery.kind !== 'ready' ? writeErrorAlert : null}
         <WorkspaceAgentRuntimeProvider>
-          {view === 'home' ? (
-            <HomePage
-              canDeleteProjects={sessionPersistence.canDeleteSessionsAndProjects}
-              hasCompleteSessionCatalog={sessionPersistence.hasCompleteSessionCatalog}
-              catalogRecovery={sessionPersistence.catalogRecovery}
-              onOpenGlobalSearch={() => {
-                if (appShellPresentation.allowsShortcut('globalSearch')) {
-                  setIsGlobalSearchOpen(true)
-                }
-              }}
-            />
-          ) : (
-            <WorkspacePage
-              isSessionPersistenceHydrated={isSessionPersistenceHydrated}
-              isSessionPersistenceReady={isSessionPersistenceReady}
-              canDeleteConversations={sessionPersistence.canDeleteSessionsAndProjects}
-              isPreviewPresentationActive={isBasePresentationActive}
-            />
-          )}
+          <WorkspaceMessageQueueProvider>
+            <WorkspaceMessageQueueRuntimeBridge />
+            {view === 'home' ? (
+              <HomePage
+                canDeleteProjects={sessionPersistence.canDeleteSessionsAndProjects}
+                hasCompleteSessionCatalog={sessionPersistence.hasCompleteSessionCatalog}
+                catalogRecovery={sessionPersistence.catalogRecovery}
+                onOpenGlobalSearch={() => {
+                  if (appShellPresentation.allowsShortcut('globalSearch')) {
+                    setIsGlobalSearchOpen(true)
+                  }
+                }}
+              />
+            ) : (
+              <WorkspacePage
+                isSessionPersistenceHydrated={isSessionPersistenceHydrated}
+                isSessionPersistenceReady={isSessionPersistenceReady}
+                canDeleteConversations={sessionPersistence.canDeleteSessionsAndProjects}
+                isPreviewPresentationActive={isBasePresentationActive}
+              />
+            )}
+          </WorkspaceMessageQueueProvider>
         </WorkspaceAgentRuntimeProvider>
         <LifecycleToast
           notice={lifecycleSync.notice}

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
@@ -643,7 +643,10 @@ describe('workspace runtime architecture', () => {
       }
     }
     expect(unsupportedFacadeImports).toEqual([])
-    expect(hookConsumers).toEqual(['pages/workspace/WorkspacePage.tsx'])
+    expect(hookConsumers).toEqual([
+      'pages/workspace/WorkspacePage.tsx',
+      'pages/workspace/workspace-message-queue-controller.ts'
+    ])
   })
   it('keeps the delegated runtime transport subscription in the App-level owner', () => {
     expect(

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
@@ -218,7 +218,8 @@ const useWorkspaceConversationController = (
     promptInFlightSessionIds: options.promptInFlightSessionIds,
     sendPreparationInFlightSessionIds: options.sendPreparationInFlightSessionIds,
     saveAsSkillInFlightSessionIds: options.saveAsSkillInFlightSessionIds,
-    sideChatOpen: options.sideChatOpen,
+    isSideChatOpen: (sessionId) =>
+      optionsRef.current.activeSession?.id === sessionId && optionsRef.current.sideChatOpen,
     composer: {
       setError: options.composer.actions.setError,
       restoreQueuedDraft: (snapshot) =>

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
@@ -193,6 +193,7 @@ describe('workspace message queue controller', () => {
     await vi.waitFor(() => expect(input.runtime.sendMessage).toHaveBeenCalledOnce())
     workspace.returnToWorkspace()
     await vi.waitFor(() => expect(workspace.result.current.items).toEqual([]))
+    expect(workspace.result.current.lifecycle.blocksImmediateSend(currentSession.id)).toBe(false)
   })
 
   it('resumes background draining when a Specialist barrier settles', async () => {

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
@@ -8,6 +8,7 @@ import type { ChatSession } from '@/stores/session-store'
 import { type ComposerDoc } from './composer/composer-doc'
 import {
   useWorkspaceMessageQueueController,
+  WorkspaceMessageQueueProvider,
   type MessageQueueAdmission,
   type WorkspaceMessageQueueController,
   type WorkspaceMessageQueueControllerOptions
@@ -96,23 +97,43 @@ const options = (
 type Hook = {
   result: { current: WorkspaceMessageQueueController }
   rerender: (next: WorkspaceMessageQueueControllerOptions) => void
+  leaveWorkspace: () => void
+  returnToWorkspace: () => void
   unmount: () => void
 }
 
 const renderController = (initial: WorkspaceMessageQueueControllerOptions): Hook => {
   let current = initial
+  let workspaceOpen = true
   const root: Root = createRoot(document.createElement('div'))
   const result = { current: undefined as unknown as WorkspaceMessageQueueController }
   const Harness = (): null => {
     result.current = useWorkspaceMessageQueueController(current)
     return null
   }
-  const render = (): void => act(() => root.render(createElement(Harness)))
+  const render = (): void =>
+    act(() =>
+      root.render(
+        createElement(
+          WorkspaceMessageQueueProvider,
+          null,
+          workspaceOpen ? createElement(Harness) : null
+        )
+      )
+    )
   render()
   return {
     result,
     rerender: (next): void => {
       current = next
+      render()
+    },
+    leaveWorkspace: (): void => {
+      workspaceOpen = false
+      render()
+    },
+    returnToWorkspace: (): void => {
+      workspaceOpen = true
       render()
     },
     unmount: (): void => act(() => root.unmount())
@@ -127,6 +148,48 @@ afterEach(() => {
 })
 
 describe('workspace message queue controller', () => {
+  it('retains queued messages when the Workspace unmounts for Project navigation', () => {
+    const input = options(session())
+    const workspace = renderController(input)
+    mounted.push(workspace)
+
+    act(() => workspace.result.current.lifecycle.enqueue(admission('keep across navigation')))
+    workspace.leaveWorkspace()
+    workspace.returnToWorkspace()
+
+    expect(workspace.result.current.items.map((item) => item.text)).toEqual([
+      'keep across navigation'
+    ])
+    expect(input.composer.discardSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('continues draining queued messages while Project navigation is open', async () => {
+    let currentSession = session()
+    let notifySessionChanged: (() => void) | undefined
+    const input = options(currentSession, {
+      promptInFlightSessionIds: [],
+      getSession: () => currentSession,
+      subscribeSessionChanges: (listener) => {
+        notifySessionChanged = listener
+        return () => {
+          notifySessionChanged = undefined
+        }
+      }
+    })
+    const workspace = renderController(input)
+    mounted.push(workspace)
+
+    act(() => workspace.result.current.lifecycle.enqueue(admission('send in background')))
+    workspace.leaveWorkspace()
+
+    currentSession = session('idle')
+    act(() => notifySessionChanged?.())
+
+    await vi.waitFor(() => expect(input.runtime.sendMessage).toHaveBeenCalledOnce())
+    workspace.returnToWorkspace()
+    await vi.waitFor(() => expect(workspace.result.current.items).toEqual([]))
+  })
+
   it('reorders, restores for editing, and discards removed snapshots', () => {
     const input = options(session())
     const hook = renderController(input)

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
@@ -13,6 +13,10 @@ import {
   type WorkspaceMessageQueueController,
   type WorkspaceMessageQueueControllerOptions
 } from './workspace-message-queue-controller'
+import {
+  isWorkspaceSpecialistBarrierInFlight,
+  setWorkspaceSpecialistBarrier
+} from './workspace-specialist-barrier'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -75,7 +79,7 @@ const options = (
   promptInFlightSessionIds: activeSession.status === 'running' ? ['session-a'] : [],
   sendPreparationInFlightSessionIds: [],
   saveAsSkillInFlightSessionIds: [],
-  sideChatOpen: false,
+  isSideChatOpen: vi.fn(() => false),
   composer: {
     setError: vi.fn(),
     restoreQueuedDraft: vi.fn(() => true),
@@ -144,6 +148,7 @@ const mounted: Hook[] = []
 
 afterEach(() => {
   for (const hook of mounted.splice(0)) hook.unmount()
+  setWorkspaceSpecialistBarrier('session-a', false)
   vi.restoreAllMocks()
 })
 
@@ -188,6 +193,35 @@ describe('workspace message queue controller', () => {
     await vi.waitFor(() => expect(input.runtime.sendMessage).toHaveBeenCalledOnce())
     workspace.returnToWorkspace()
     await vi.waitFor(() => expect(workspace.result.current.items).toEqual([]))
+  })
+
+  it('resumes background draining when a Specialist barrier settles', async () => {
+    let currentSession = session()
+    let notifySessionChanged: (() => void) | undefined
+    setWorkspaceSpecialistBarrier(currentSession.id, true)
+    const input = options(currentSession, {
+      promptInFlightSessionIds: [],
+      isBarrierInFlight: isWorkspaceSpecialistBarrierInFlight,
+      getSession: () => currentSession,
+      subscribeSessionChanges: (listener) => {
+        notifySessionChanged = listener
+        return () => {
+          notifySessionChanged = undefined
+        }
+      }
+    })
+    const workspace = renderController(input)
+    mounted.push(workspace)
+
+    act(() => workspace.result.current.lifecycle.enqueue(admission('send after barrier')))
+    workspace.leaveWorkspace()
+    currentSession = session('idle')
+    act(() => notifySessionChanged?.())
+    expect(input.runtime.sendMessage).not.toHaveBeenCalled()
+
+    act(() => setWorkspaceSpecialistBarrier(currentSession.id, false))
+
+    await vi.waitFor(() => expect(input.runtime.sendMessage).toHaveBeenCalledOnce())
   })
 
   it('reorders, restores for editing, and discards removed snapshots', () => {

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
@@ -1,11 +1,26 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import {
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type PropsWithChildren,
+  type ReactElement
+} from 'react'
 
 import {
   DEFAULT_PERMISSION_PROFILE,
   type PermissionProfileId
 } from '../../../../shared/permission-profiles'
-import type { ChatSession } from '@/stores/session-store'
-import type { WorkspaceAgentRuntime } from '@/lib/acp/useWorkspaceAgentRuntime'
+import { useSessionStore, type ChatSession } from '@/stores/session-store'
+import {
+  useWorkspaceAgentRuntime,
+  type WorkspaceAgentRuntime
+} from '@/lib/acp/useWorkspaceAgentRuntime'
 
 import { docToArtifactRefs } from './composer/composer-doc'
 import type { ComposerSendSnapshot } from './workspace-composer-controller'
@@ -89,6 +104,151 @@ type WorkspaceMessageQueueController = {
   }
 }
 
+type MessageQueueSnapshot = {
+  queues: Map<string, MessageQueueItem[]>
+  announcement: string
+}
+
+type WorkspaceMessageQueueRuntimeOptions = Pick<
+  WorkspaceMessageQueueControllerOptions,
+  | 'promptInFlightSessionIds'
+  | 'sendPreparationInFlightSessionIds'
+  | 'saveAsSkillInFlightSessionIds'
+  | 'runtime'
+  | 'hasPendingPermissionRequest'
+  | 'abortFixLoop'
+  | 'getSession'
+  | 'subscribeSessionChanges'
+>
+
+class WorkspaceMessageQueueOwner {
+  readonly queues = new Map<string, MessageQueueItem[]>()
+  readonly dispatches = new Map<string, MessageQueueDispatch>()
+  nextQueueId = 0
+  private listeners = new Set<() => void>()
+  private snapshot: MessageQueueSnapshot = { queues: new Map(), announcement: '' }
+  private sessionSubscription:
+    | {
+        source: WorkspaceMessageQueueControllerOptions['subscribeSessionChanges']
+        drain: () => void
+        unsubscribe: () => void
+      }
+    | undefined
+  private discardSnapshot:
+    WorkspaceMessageQueueControllerOptions['composer']['discardSnapshot'] | undefined
+  private runtimeOptions: WorkspaceMessageQueueRuntimeOptions | undefined
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  getSnapshot = (): MessageQueueSnapshot => this.snapshot
+
+  emit = (announcement?: string): void => {
+    this.snapshot = {
+      queues: new Map(this.queues),
+      announcement: announcement ?? this.snapshot.announcement
+    }
+    for (const listener of this.listeners) listener()
+  }
+
+  connect(
+    source: WorkspaceMessageQueueControllerOptions['subscribeSessionChanges'],
+    drain: () => void,
+    discardSnapshot: WorkspaceMessageQueueControllerOptions['composer']['discardSnapshot']
+  ): void {
+    this.discardSnapshot = discardSnapshot
+    const liveSource = this.runtimeOptions?.subscribeSessionChanges ?? source
+    if (
+      this.sessionSubscription?.source === liveSource &&
+      this.sessionSubscription.drain === drain
+    ) {
+      return
+    }
+    this.sessionSubscription?.unsubscribe()
+    this.sessionSubscription = { source: liveSource, drain, unsubscribe: liveSource(drain) }
+  }
+
+  updateRuntime(options: WorkspaceMessageQueueRuntimeOptions): void {
+    this.runtimeOptions = options
+    const current = this.sessionSubscription
+    if (current && current.source !== options.subscribeSessionChanges) {
+      current.unsubscribe()
+      this.sessionSubscription = {
+        source: options.subscribeSessionChanges,
+        drain: current.drain,
+        unsubscribe: options.subscribeSessionChanges(current.drain)
+      }
+    }
+    this.sessionSubscription?.drain()
+  }
+
+  resolveOptions(
+    fallback: WorkspaceMessageQueueControllerOptions
+  ): WorkspaceMessageQueueControllerOptions {
+    return this.runtimeOptions ? { ...fallback, ...this.runtimeOptions } : fallback
+  }
+
+  dispose(): void {
+    this.sessionSubscription?.unsubscribe()
+    this.sessionSubscription = undefined
+    this.runtimeOptions = undefined
+    for (const items of this.queues.values()) {
+      for (const item of items) {
+        if (item.phase !== 'sending') this.discardSnapshot?.(item.snapshot)
+      }
+    }
+    this.queues.clear()
+    this.dispatches.clear()
+    this.emit()
+  }
+}
+
+const WorkspaceMessageQueueContext = createContext<WorkspaceMessageQueueOwner | null>(null)
+
+const useWorkspaceMessageQueueOwner = (): WorkspaceMessageQueueOwner => {
+  const providedOwner = useContext(WorkspaceMessageQueueContext)
+  const [localOwner] = useState(() => new WorkspaceMessageQueueOwner())
+  useEffect(
+    () => (providedOwner ? undefined : () => localOwner.dispose()),
+    [localOwner, providedOwner]
+  )
+  return providedOwner ?? localOwner
+}
+
+const useProvidedWorkspaceMessageQueueOwner = (): WorkspaceMessageQueueOwner => {
+  const owner = useContext(WorkspaceMessageQueueContext)
+  if (!owner) throw new Error('Workspace message queue provider is missing.')
+  return owner
+}
+
+const WorkspaceMessageQueueProvider = ({ children }: PropsWithChildren): ReactElement => {
+  const [owner] = useState(() => new WorkspaceMessageQueueOwner())
+  useEffect(() => () => owner.dispose(), [owner])
+  return createElement(WorkspaceMessageQueueContext.Provider, { value: owner }, children)
+}
+
+const WorkspaceMessageQueueRuntimeBridge = (): null => {
+  const owner = useProvidedWorkspaceMessageQueueOwner()
+  const runtime = useWorkspaceAgentRuntime()
+  useLayoutEffect(() => {
+    owner.updateRuntime({
+      promptInFlightSessionIds: runtime.promptInFlightSessionIds,
+      sendPreparationInFlightSessionIds: runtime.sendPreparationInFlightSessionIds,
+      saveAsSkillInFlightSessionIds: runtime.saveAsSkillInFlightSessionIds,
+      runtime,
+      hasPendingPermissionRequest: (sessionId) =>
+        runtime.pendingPermissions.some((request) => request.sessionId === sessionId),
+      abortFixLoop: (request) => window.api.reviewer.abortFixLoop(request),
+      getSession: (sessionId) =>
+        useSessionStore.getState().sessions.find((candidate) => candidate.id === sessionId),
+      subscribeSessionChanges: useSessionStore.subscribe
+    })
+  }, [owner, runtime])
+  return null
+}
+
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
 
@@ -127,24 +287,27 @@ const queueSessionIsSendable = (
 const useWorkspaceMessageQueueController = (
   options: WorkspaceMessageQueueControllerOptions
 ): WorkspaceMessageQueueController => {
+  const owner = useWorkspaceMessageQueueOwner()
   const { subscribeSessionChanges } = options
   const optionsRef = useRef(options)
   useLayoutEffect(() => {
     optionsRef.current = options
   }, [options])
-  const queueBySessionRef = useRef(new Map<string, MessageQueueItem[]>())
-  const dispatchBySessionRef = useRef(new Map<string, MessageQueueDispatch>())
-  const nextQueueIdRef = useRef(0)
-  const [queueSnapshot, setQueueSnapshot] = useState(new Map<string, MessageQueueItem[]>())
-  const [announcement, setAnnouncement] = useState('')
+  const { queues: queueSnapshot, announcement } = useSyncExternalStore(
+    owner.subscribe,
+    owner.getSnapshot,
+    owner.getSnapshot
+  )
 
-  const emit = useCallback((message?: string): void => {
-    if (message) setAnnouncement(message)
-    setQueueSnapshot(new Map(queueBySessionRef.current))
-  }, [])
+  const emit = useCallback(
+    (message?: string): void => {
+      owner.emit(message)
+    },
+    [owner]
+  )
   const itemsFor = useCallback(
-    (sessionId: string): MessageQueueItem[] => queueBySessionRef.current.get(sessionId) ?? [],
-    []
+    (sessionId: string): MessageQueueItem[] => owner.queues.get(sessionId) ?? [],
+    [owner]
   )
   const replaceItem = useCallback(
     (
@@ -157,38 +320,38 @@ const useWorkspaceMessageQueueController = (
       if (index < 0) return
       const next = [...items]
       next[index] = { ...next[index], ...update }
-      queueBySessionRef.current.set(sessionId, next)
+      owner.queues.set(sessionId, next)
       emit()
     },
-    [emit, itemsFor]
+    [emit, itemsFor, owner]
   )
   const discardSession = useCallback(
     (sessionId: string): void => {
-      const current = optionsRef.current
+      const current = owner.resolveOptions(optionsRef.current)
       for (const item of itemsFor(sessionId)) current.composer.discardSnapshot(item.snapshot)
-      queueBySessionRef.current.delete(sessionId)
+      owner.queues.delete(sessionId)
       emit()
     },
-    [emit, itemsFor]
+    [emit, itemsFor, owner]
   )
   const dispatch = useCallback(
     (sessionId: string): void => {
-      const current = optionsRef.current
-      const existingDispatch = dispatchBySessionRef.current.get(sessionId)
+      const current = owner.resolveOptions(optionsRef.current)
+      const existingDispatch = owner.dispatches.get(sessionId)
       const session = current.getSession(sessionId)
       if (!session) {
         if (existingDispatch && !existingDispatch.settled) return
-        dispatchBySessionRef.current.delete(sessionId)
+        owner.dispatches.delete(sessionId)
         discardSession(sessionId)
         return
       }
       if (existingDispatch) {
         if (!existingDispatch.settled) return
         if (session.status === 'error') {
-          dispatchBySessionRef.current.delete(sessionId)
+          owner.dispatches.delete(sessionId)
         } else {
           if (!queueSessionIsSendable(current, session)) {
-            dispatchBySessionRef.current.delete(sessionId)
+            owner.dispatches.delete(sessionId)
           }
           return
         }
@@ -225,7 +388,7 @@ const useWorkspaceMessageQueueController = (
           resolveCompletion = resolve
         })
       }
-      dispatchBySessionRef.current.set(sessionId, activeDispatch)
+      owner.dispatches.set(sessionId, activeDispatch)
       void (async (): Promise<void> => {
         try {
           const result = await current.runtime.sendMessage({
@@ -245,12 +408,12 @@ const useWorkspaceMessageQueueController = (
           }
           const latest = itemsFor(sessionId)
           const remaining = latest.filter((candidate) => candidate.id !== item.id)
-          if (remaining.length === 0) queueBySessionRef.current.delete(sessionId)
-          else queueBySessionRef.current.set(sessionId, remaining)
+          if (remaining.length === 0) owner.queues.delete(sessionId)
+          else owner.queues.set(sessionId, remaining)
           emit('Queued message sent.')
         } catch (error) {
-          if (dispatchBySessionRef.current.get(sessionId) === activeDispatch) {
-            dispatchBySessionRef.current.delete(sessionId)
+          if (owner.dispatches.get(sessionId) === activeDispatch) {
+            owner.dispatches.delete(sessionId)
           }
           replaceItem(sessionId, item.id, {
             phase: 'error',
@@ -259,20 +422,20 @@ const useWorkspaceMessageQueueController = (
         } finally {
           activeDispatch.settled = true
           resolveCompletion()
-          if (!optionsRef.current.getSession(sessionId)) {
-            if (dispatchBySessionRef.current.get(sessionId) === activeDispatch) {
-              dispatchBySessionRef.current.delete(sessionId)
+          if (!owner.resolveOptions(optionsRef.current).getSession(sessionId)) {
+            if (owner.dispatches.get(sessionId) === activeDispatch) {
+              owner.dispatches.delete(sessionId)
             }
             discardSession(sessionId)
           }
         }
       })()
     },
-    [discardSession, emit, itemsFor, replaceItem]
+    [discardSession, emit, itemsFor, owner, replaceItem]
   )
   const drainQueues = useCallback((): void => {
-    for (const sessionId of queueBySessionRef.current.keys()) dispatch(sessionId)
-  }, [dispatch])
+    for (const sessionId of owner.queues.keys()) dispatch(sessionId)
+  }, [dispatch, owner])
   const currentSessionQueue = useCallback(():
     { sessionId: string; items: MessageQueueItem[] } | undefined => {
     const sessionId = optionsRef.current.activeSession?.id
@@ -280,16 +443,19 @@ const useWorkspaceMessageQueueController = (
   }, [itemsFor])
   const blocksImmediateSend = useCallback(
     (sessionId: string): boolean => {
-      const activeDispatch = dispatchBySessionRef.current.get(sessionId)
+      const activeDispatch = owner.dispatches.get(sessionId)
       return (
         itemsFor(sessionId).length > 0 ||
         Boolean(
           activeDispatch &&
-          !(activeDispatch.settled && optionsRef.current.getSession(sessionId)?.status === 'error')
+          !(
+            activeDispatch.settled &&
+            owner.resolveOptions(optionsRef.current).getSession(sessionId)?.status === 'error'
+          )
         )
       )
     },
-    [itemsFor]
+    [itemsFor, owner]
   )
 
   const enqueue = useCallback(
@@ -302,7 +468,7 @@ const useWorkspaceMessageQueueController = (
         return false
       }
       const item: MessageQueueItem = {
-        id: `queued-message-${Date.now()}-${++nextQueueIdRef.current}`,
+        id: `queued-message-${Date.now()}-${++owner.nextQueueId}`,
         sessionId: session.id,
         ...identity,
         snapshot,
@@ -312,11 +478,11 @@ const useWorkspaceMessageQueueController = (
         phase: 'queued',
         ...intent
       }
-      queueBySessionRef.current.set(session.id, [...itemsFor(session.id), item])
+      owner.queues.set(session.id, [...itemsFor(session.id), item])
       emit('Message added to queue.')
       return true
     },
-    [emit, itemsFor]
+    [emit, itemsFor, owner]
   )
   const move = useCallback(
     (itemId: string, direction: 'up' | 'down'): void => {
@@ -327,10 +493,10 @@ const useWorkspaceMessageQueueController = (
       const target = direction === 'up' ? index - 1 : index + 1
       if (index < 0 || target < 0 || target >= items.length) return
       ;[items[index], items[target]] = [items[target], items[index]]
-      queueBySessionRef.current.set(queue.sessionId, items)
+      owner.queues.set(queue.sessionId, items)
       emit(`Queued message moved ${direction}.`)
     },
-    [currentSessionQueue, emit]
+    [currentSessionQueue, emit, owner]
   )
   const moveTo = useCallback(
     (itemId: string, targetId: string, edge: 'before' | 'after'): void => {
@@ -342,10 +508,10 @@ const useWorkspaceMessageQueueController = (
       const [moved] = items.splice(from, 1)
       const target = items.findIndex((item) => item.id === targetId)
       items.splice(edge === 'after' ? target + 1 : target, 0, moved)
-      queueBySessionRef.current.set(queue.sessionId, items)
+      owner.queues.set(queue.sessionId, items)
       emit('Queued messages reordered.')
     },
-    [currentSessionQueue, emit]
+    [currentSessionQueue, emit, owner]
   )
   const remove = useCallback(
     (itemId: string): void => {
@@ -355,11 +521,11 @@ const useWorkspaceMessageQueueController = (
       if (!item || item.phase === 'sending' || item.phase === 'interrupting') return
       optionsRef.current.composer.discardSnapshot(item.snapshot)
       const remaining = queue.items.filter((candidate) => candidate.id !== itemId)
-      if (remaining.length === 0) queueBySessionRef.current.delete(queue.sessionId)
-      else queueBySessionRef.current.set(queue.sessionId, remaining)
+      if (remaining.length === 0) owner.queues.delete(queue.sessionId)
+      else owner.queues.set(queue.sessionId, remaining)
       emit('Queued message removed.')
     },
-    [currentSessionQueue, emit]
+    [currentSessionQueue, emit, owner]
   )
   const edit = useCallback(
     (itemId: string): void => {
@@ -375,11 +541,11 @@ const useWorkspaceMessageQueueController = (
         return
       }
       const remaining = queue.items.filter((candidate) => candidate.id !== itemId)
-      if (remaining.length === 0) queueBySessionRef.current.delete(queue.sessionId)
-      else queueBySessionRef.current.set(queue.sessionId, remaining)
+      if (remaining.length === 0) owner.queues.delete(queue.sessionId)
+      else owner.queues.set(queue.sessionId, remaining)
       emit('Queued message moved to the composer for editing.')
     },
-    [currentSessionQueue, emit, replaceItem]
+    [currentSessionQueue, emit, owner, replaceItem]
   )
   const sendNow = useCallback(
     async (itemId: string): Promise<void> => {
@@ -387,17 +553,17 @@ const useWorkspaceMessageQueueController = (
       if (!queue) return
       const item = queue.items.find((candidate) => candidate.id === itemId)
       if (!item) return
-      queueBySessionRef.current.set(queue.sessionId, [
+      owner.queues.set(queue.sessionId, [
         { ...item, phase: 'interrupting', error: undefined },
         ...queue.items.filter((candidate) => candidate.id !== itemId)
       ])
       emit('Stopping the current run before sending the queued message.')
       try {
-        const displacedDispatch = dispatchBySessionRef.current.get(queue.sessionId)
+        const displacedDispatch = owner.dispatches.get(queue.sessionId)
         if (displacedDispatch && displacedDispatch.itemId !== itemId) {
           await displacedDispatch.completion
         }
-        const current = optionsRef.current
+        const current = owner.resolveOptions(optionsRef.current)
         const session = current.getSession(queue.sessionId)
         if (session?.fixLoopActive) {
           await current.abortFixLoop({
@@ -412,8 +578,8 @@ const useWorkspaceMessageQueueController = (
         ) {
           await current.runtime.cancelRun(queue.sessionId)
         }
-        if (dispatchBySessionRef.current.get(queue.sessionId) === displacedDispatch) {
-          dispatchBySessionRef.current.delete(queue.sessionId)
+        if (owner.dispatches.get(queue.sessionId) === displacedDispatch) {
+          owner.dispatches.delete(queue.sessionId)
         }
         drainQueues()
       } catch (error) {
@@ -423,22 +589,14 @@ const useWorkspaceMessageQueueController = (
         })
       }
     },
-    [currentSessionQueue, drainQueues, emit, replaceItem]
+    [currentSessionQueue, drainQueues, emit, owner, replaceItem]
   )
 
-  useEffect(() => subscribeSessionChanges(drainQueues), [drainQueues, subscribeSessionChanges])
-  useEffect(() => drainQueues(), [drainQueues, options, queueSnapshot])
   useEffect(
-    () => () => {
-      for (const items of queueBySessionRef.current.values()) {
-        for (const item of items) {
-          if (item.phase !== 'sending') optionsRef.current.composer.discardSnapshot(item.snapshot)
-        }
-      }
-      queueBySessionRef.current.clear()
-    },
-    []
+    () => owner.connect(subscribeSessionChanges, drainQueues, options.composer.discardSnapshot),
+    [drainQueues, options.composer.discardSnapshot, owner, subscribeSessionChanges]
   )
+  useEffect(() => drainQueues(), [drainQueues, options, queueSnapshot])
 
   const activeItems = options.activeSession
     ? (queueSnapshot.get(options.activeSession.id) ?? [])
@@ -457,7 +615,11 @@ const useWorkspaceMessageQueueController = (
   }
 }
 
-export { useWorkspaceMessageQueueController }
+export {
+  useWorkspaceMessageQueueController,
+  WorkspaceMessageQueueProvider,
+  WorkspaceMessageQueueRuntimeBridge
+}
 export type {
   MessageQueueAdmission,
   MessageQueueItemView,

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
@@ -124,7 +124,7 @@ type WorkspaceMessageQueueRuntimeOptions = Pick<
 class WorkspaceMessageQueueOwner {
   readonly queues = new Map<string, MessageQueueItem[]>()
   readonly dispatches = new Map<string, MessageQueueDispatch>()
-  nextQueueId = 0
+  private nextQueueId = 0
   private listeners = new Set<() => void>()
   private snapshot: MessageQueueSnapshot = { queues: new Map(), announcement: '' }
   private sessionSubscription:
@@ -144,6 +144,11 @@ class WorkspaceMessageQueueOwner {
   }
 
   getSnapshot = (): MessageQueueSnapshot => this.snapshot
+
+  createQueueItemId(): string {
+    this.nextQueueId += 1
+    return `queued-message-${Date.now()}-${this.nextQueueId}`
+  }
 
   emit = (announcement?: string): void => {
     this.snapshot = {
@@ -468,7 +473,7 @@ const useWorkspaceMessageQueueController = (
         return false
       }
       const item: MessageQueueItem = {
-        id: `queued-message-${Date.now()}-${++owner.nextQueueId}`,
+        id: owner.createQueueItemId(),
         sessionId: session.id,
         ...identity,
         snapshot,

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
@@ -457,8 +457,14 @@ const useWorkspaceMessageQueueController = (
           }
           const latest = itemsFor(sessionId)
           const remaining = latest.filter((candidate) => candidate.id !== item.id)
-          if (remaining.length === 0) owner.queues.delete(sessionId)
-          else owner.queues.set(sessionId, remaining)
+          if (remaining.length === 0) {
+            owner.queues.delete(sessionId)
+            if (owner.dispatches.get(sessionId) === activeDispatch) {
+              owner.dispatches.delete(sessionId)
+            }
+          } else {
+            owner.queues.set(sessionId, remaining)
+          }
           emit('Queued message sent.')
         } catch (error) {
           if (owner.dispatches.get(sessionId) === activeDispatch) {

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
@@ -17,12 +17,18 @@ import {
   type PermissionProfileId
 } from '../../../../shared/permission-profiles'
 import { useSessionStore, type ChatSession } from '@/stores/session-store'
+import { useSpecialistStore } from '@/stores/specialist-store'
 import {
   useWorkspaceAgentRuntime,
   type WorkspaceAgentRuntime
 } from '@/lib/acp/useWorkspaceAgentRuntime'
 
 import { docToArtifactRefs } from './composer/composer-doc'
+import {
+  isWorkspaceSpecialistBarrierInFlight,
+  subscribeWorkspaceSpecialistBarriers
+} from './workspace-specialist-barrier'
+import { useOpenSideChatParentSessionIds } from './use-side-chat-controller'
 import type { ComposerSendSnapshot } from './workspace-composer-controller'
 
 type MessageQueuePhase = 'queued' | 'interrupting' | 'sending' | 'error'
@@ -73,7 +79,7 @@ type WorkspaceMessageQueueControllerOptions = {
   promptInFlightSessionIds: string[]
   sendPreparationInFlightSessionIds: string[]
   saveAsSkillInFlightSessionIds: string[]
-  sideChatOpen: boolean
+  isSideChatOpen: (sessionId: string) => boolean
   composer: {
     setError: (error: string | null) => void
     restoreQueuedDraft: (snapshot: ComposerSendSnapshot) => boolean
@@ -115,6 +121,9 @@ type WorkspaceMessageQueueRuntimeOptions = Pick<
   | 'sendPreparationInFlightSessionIds'
   | 'saveAsSkillInFlightSessionIds'
   | 'runtime'
+  | 'isBarrierInFlight'
+  | 'isSpecialistReady'
+  | 'isSideChatOpen'
   | 'hasPendingPermissionRequest'
   | 'abortFixLoop'
   | 'getSession'
@@ -144,6 +153,8 @@ class WorkspaceMessageQueueOwner {
   }
 
   getSnapshot = (): MessageQueueSnapshot => this.snapshot
+
+  requestDrain = (): void => this.sessionSubscription?.drain()
 
   createQueueItemId(): string {
     this.nextQueueId += 1
@@ -230,19 +241,45 @@ const useProvidedWorkspaceMessageQueueOwner = (): WorkspaceMessageQueueOwner => 
 
 const WorkspaceMessageQueueProvider = ({ children }: PropsWithChildren): ReactElement => {
   const [owner] = useState(() => new WorkspaceMessageQueueOwner())
-  useEffect(() => () => owner.dispose(), [owner])
+  useEffect(() => {
+    const unsubscribeBarriers = subscribeWorkspaceSpecialistBarriers(owner.requestDrain)
+    return () => {
+      unsubscribeBarriers()
+      owner.dispose()
+    }
+  }, [owner])
   return createElement(WorkspaceMessageQueueContext.Provider, { value: owner }, children)
 }
 
 const WorkspaceMessageQueueRuntimeBridge = (): null => {
   const owner = useProvidedWorkspaceMessageQueueOwner()
   const runtime = useWorkspaceAgentRuntime()
+  const specialistCatalogLoaded = useSpecialistStore((state) => state.isLoaded)
+  const specialistItems = useSpecialistStore((state) => state.items)
+  const loadSpecialists = useSpecialistStore((state) => state.load)
+  const openSideChatParentSessionIds = useOpenSideChatParentSessionIds()
   useLayoutEffect(() => {
     owner.updateRuntime({
       promptInFlightSessionIds: runtime.promptInFlightSessionIds,
       sendPreparationInFlightSessionIds: runtime.sendPreparationInFlightSessionIds,
       saveAsSkillInFlightSessionIds: runtime.saveAsSkillInFlightSessionIds,
       runtime,
+      isBarrierInFlight: isWorkspaceSpecialistBarrierInFlight,
+      isSpecialistReady: (sessionId) => {
+        const session = useSessionStore
+          .getState()
+          .sessions.find((candidate) => candidate.id === sessionId)
+        if (!session) return false
+        if (session.specialistId === undefined) return true
+        if (!specialistCatalogLoaded) {
+          void loadSpecialists()
+          return false
+        }
+        return specialistItems.some(
+          (item) => item.kind === 'custom' && item.enabled && item.id === session.specialistId
+        )
+      },
+      isSideChatOpen: (sessionId) => openSideChatParentSessionIds.has(sessionId),
       hasPendingPermissionRequest: (sessionId) =>
         runtime.pendingPermissions.some((request) => request.sessionId === sessionId),
       abortFixLoop: (request) => window.api.reviewer.abortFixLoop(request),
@@ -250,7 +287,14 @@ const WorkspaceMessageQueueRuntimeBridge = (): null => {
         useSessionStore.getState().sessions.find((candidate) => candidate.id === sessionId),
       subscribeSessionChanges: useSessionStore.subscribe
     })
-  }, [owner, runtime])
+  }, [
+    loadSpecialists,
+    openSideChatParentSessionIds,
+    owner,
+    runtime,
+    specialistCatalogLoaded,
+    specialistItems
+  ])
   return null
 }
 
@@ -287,7 +331,7 @@ const queueSessionIsSendable = (
   !session.conversationGraphSyncBlocked &&
   !session.compacting &&
   !options.isBarrierInFlight(session.id) &&
-  !(options.activeSession?.id === session.id && options.sideChatOpen)
+  !options.isSideChatOpen(session.id)
 
 const useWorkspaceMessageQueueController = (
   options: WorkspaceMessageQueueControllerOptions

--- a/src/renderer/src/pages/workspace/workspace-page.architecture.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-page.architecture.test.ts
@@ -163,6 +163,7 @@ describe('workspace page architecture', () => {
       'pages/workspace/workspace-message-queue-controller.ts'
     ])
     expect(importersOf(ownerPaths.messageQueue)).toEqual([
+      'App.tsx',
       'pages/workspace/ComposerMessageQueue.tsx',
       'pages/workspace/workspace-conversation-controller.ts'
     ])

--- a/src/renderer/src/pages/workspace/workspace-page.architecture.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-page.architecture.test.ts
@@ -183,7 +183,8 @@ describe('workspace page architecture', () => {
       'pages/workspace/SideChatPanel.tsx',
       'pages/workspace/WorkspacePage.tsx',
       'pages/workspace/previews/PreviewToolContent.tsx',
-      'pages/workspace/workspace-conversation-controller.ts'
+      'pages/workspace/workspace-conversation-controller.ts',
+      'pages/workspace/workspace-message-queue-controller.ts'
     ])
   })
 

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type FormEvent
+} from 'react'
 
 import type { ConversationExportFormat } from '../../../../shared/conversation-export'
 import type {
@@ -14,6 +21,13 @@ import type {
   DeleteWorkspaceSessionOptions,
   WorkspaceSessionDeletionResult
 } from '@/lib/acp/workspace-session-deletion'
+
+import {
+  getWorkspaceSpecialistBarrierSnapshot,
+  isWorkspaceSpecialistBarrierInFlight,
+  setWorkspaceSpecialistBarrier,
+  subscribeWorkspaceSpecialistBarriers
+} from './workspace-specialist-barrier'
 
 type ReconfigureError = {
   sessionId: string
@@ -166,8 +180,11 @@ const useWorkspaceSessionController = ({
     {}
   )
   const [reconfigureError, setReconfigureError] = useState<ReconfigureError | null>(null)
-  const [barrierInFlightIds, setBarrierInFlightIds] = useState<ReadonlySet<string>>(new Set())
-  const barrierInFlightRef = useRef(new Set<string>())
+  const barrierInFlightIds = useSyncExternalStore(
+    subscribeWorkspaceSpecialistBarriers,
+    getWorkspaceSpecialistBarrierSnapshot,
+    getWorkspaceSpecialistBarrierSnapshot
+  )
   const specialistItemsRef = useRef(specialistItems)
 
   const [exportError, setExportError] = useState<string | null>(null)
@@ -216,14 +233,7 @@ const useWorkspaceSessionController = ({
   )
 
   const setBarrier = useCallback((sessionId: string, inFlight: boolean): void => {
-    if (inFlight) barrierInFlightRef.current.add(sessionId)
-    else barrierInFlightRef.current.delete(sessionId)
-    setBarrierInFlightIds((current) => {
-      const next = new Set(current)
-      if (inFlight) next.add(sessionId)
-      else next.delete(sessionId)
-      return next
-    })
+    setWorkspaceSpecialistBarrier(sessionId, inFlight)
   }, [])
 
   const clearPending = useCallback((sessionId: string): void => {
@@ -363,7 +373,7 @@ const useWorkspaceSessionController = ({
       return
     }
     const sessionId = activeSession.id
-    if (barrierInFlightRef.current.has(sessionId)) return
+    if (isWorkspaceSpecialistBarrierInFlight(sessionId)) return
     const running = projectSessionActionability(activeSession).activity !== 'inactive'
     if (running) {
       setPendingSpecialists((current) => ({ ...current, [sessionId]: specialistId }))
@@ -389,7 +399,7 @@ const useWorkspaceSessionController = ({
       const session = useSessionStore
         .getState()
         .sessions.find((candidate) => candidate.id === sessionId)
-      if (!session || barrierInFlightRef.current.has(sessionId)) return false
+      if (!session || isWorkspaceSpecialistBarrierInFlight(sessionId)) return false
       if (session.specialistId === undefined) return true
       if (!specialistCatalogLoaded) {
         void loadSpecialists()
@@ -400,7 +410,7 @@ const useWorkspaceSessionController = ({
       )
     }
     if (!activeSession) return !newConversationSpecialistUnavailable
-    if (barrierInFlightRef.current.has(activeSession.id)) return false
+    if (isWorkspaceSpecialistBarrierInFlight(activeSession.id)) return false
     if (activeSession.specialistId === undefined) return specialistSendAvailable
     if (!specialistCatalogLoaded) {
       void loadSpecialists()
@@ -429,7 +439,7 @@ const useWorkspaceSessionController = ({
     sessionId: string,
     specialistId: string | undefined
   ): Promise<boolean> => {
-    if (barrierInFlightRef.current.has(sessionId)) return false
+    if (isWorkspaceSpecialistBarrierInFlight(sessionId)) return false
     setBarrier(sessionId, true)
     try {
       const result = await window.api?.specialist?.setSessionSpecialist?.({
@@ -480,7 +490,7 @@ const useWorkspaceSessionController = ({
     if (!activeSession || !reconfigureError) return
     const sessionId = activeSession.id
     const setter = window.api?.specialist?.setSessionSpecialist
-    if (!setter || barrierInFlightRef.current.has(sessionId)) return
+    if (!setter || isWorkspaceSpecialistBarrierInFlight(sessionId)) return
     setBarrier(sessionId, true)
     void setter({ sessionId, specialistId: undefined })
       .then((result) => {
@@ -632,7 +642,7 @@ const useWorkspaceSessionController = ({
       canStartSend,
       captureSendIntent,
       prepareSpecialistSend,
-      isBarrierInFlight: (sessionId: string) => barrierInFlightRef.current.has(sessionId)
+      isBarrierInFlight: isWorkspaceSpecialistBarrierInFlight
     }
   }
 }

--- a/src/renderer/src/pages/workspace/workspace-specialist-barrier.ts
+++ b/src/renderer/src/pages/workspace/workspace-specialist-barrier.ts
@@ -1,0 +1,28 @@
+let inFlightSessionIds: ReadonlySet<string> = new Set()
+const listeners = new Set<() => void>()
+
+const getWorkspaceSpecialistBarrierSnapshot = (): ReadonlySet<string> => inFlightSessionIds
+
+const subscribeWorkspaceSpecialistBarriers = (listener: () => void): (() => void) => {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+const setWorkspaceSpecialistBarrier = (sessionId: string, inFlight: boolean): void => {
+  if (inFlightSessionIds.has(sessionId) === inFlight) return
+  const next = new Set(inFlightSessionIds)
+  if (inFlight) next.add(sessionId)
+  else next.delete(sessionId)
+  inFlightSessionIds = next
+  for (const listener of listeners) listener()
+}
+
+const isWorkspaceSpecialistBarrierInFlight = (sessionId: string): boolean =>
+  inFlightSessionIds.has(sessionId)
+
+export {
+  getWorkspaceSpecialistBarrierSnapshot,
+  isWorkspaceSpecialistBarrierInFlight,
+  setWorkspaceSpecialistBarrier,
+  subscribeWorkspaceSpecialistBarriers
+}


### PR DESCRIPTION
## Problem

Queued prompts are owned by a hook inside `WorkspacePage`. Returning to the Project list unmounts that page, disposes the queue snapshots, and loses queued work before the user reopens the Project.

## Proposed change

- Own the renderer-memory message queue above the Home/Workspace route switch.
- Keep the queue connected to live Session and ACP runtime projections while Home is visible, allowing sendable queued work to continue draining.
- Read Specialist availability and open Side chat gates from their app-scoped stores, and keep the transient Specialist barrier in a shared renderer-memory owner so gate changes wake background draining.
- Preserve the local-controller fallback for focused component tests and non-App consumers.
- Cover Workspace unmount/remount retention, background draining, and post-navigation Specialist barrier release with regression tests.

## Scope and non-goals

- The queue and Specialist barrier remain renderer-memory only. They are not written to Session JSON, SQLite, localStorage, or another durable format.
- App or renderer restart still clears the queue.
- No persisted schema, migration, historical-data compatibility path, or enum value changes are introduced.
- No renderer-facing IPC/API contract or ACP protocol behavior changes. All agent framework adapters continue through the existing `sendMessage` abstraction.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Queue survives Project navigation, continues draining, and re-evaluates live gates -> `npm run test:module -- workspace_page` -> 25 files, 448 tests passed.
- App-level Home/Workspace ownership remains valid -> `npm test -- src/renderer/src/App.test.tsx` -> 49 tests passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint -- --concurrency auto --no-cache` -> passed.
- Formatting and whitespace -> targeted `prettier --check` and `git diff --check` -> passed.

The complete local `npm test` suite was intentionally not run per maintainer direction; exact-head PR CI is the final authority. ACP framework/model and platform-specific lanes are excluded from the local set because no protocol, transport, filesystem, or platform behavior changed.

## Review focus

- Application-level owner lifecycle across Home/Workspace route changes.
- Live Session, Specialist, Side chat, and barrier gates during background dispatch.
- Cleanup behavior when the application-level provider itself unmounts.

## Uncovered risks

- No manual packaged-app navigation journey was run locally.
- CodeGraph post-change analysis was unavailable for this worktree because the configured index points at the main worktree; manifest-driven module tests and direct import/architecture tests were used instead.