### PR TITLE
fix(onboarding): preserve custom location on dialog dismissal

### DIFF
--- a/src/renderer/src/pages/onboarding/LocationStep.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/LocationStep.render.test.tsx
@@ -331,4 +331,43 @@ describe('LocationStep', () => {
     expect(useSettingsStore.getState().completeOnboarding).toHaveBeenCalledTimes(1)
     expect(window.api.storage.setDataRootAndRelaunch).not.toHaveBeenCalled()
   })
+
+  it('closing the confirm dialog keeps the chosen path without completing onboarding', async () => {
+    window.api.storage.pickDirectory = vi.fn().mockResolvedValue('/mnt/data')
+    window.api.storage.inspectDataRoot = vi
+      .fn()
+      .mockResolvedValue({ kind: 'move', dataRoot: '/mnt/data/OpenScience' })
+    await renderStep()
+    await clickButton(/browse/i)
+    await clickButton(/finish/i)
+
+    const closeButton = document.body.querySelector<HTMLButtonElement>('button[aria-label="Close"]')
+    expect(closeButton).not.toBeNull()
+    await act(async () => {
+      closeButton?.click()
+    })
+
+    expect(useSettingsStore.getState().completeOnboarding).not.toHaveBeenCalled()
+    expect(window.api.storage.setDataRootAndRelaunch).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('/mnt/data/OpenScience')
+  })
+
+  it('pressing Escape keeps the chosen path without completing onboarding', async () => {
+    window.api.storage.pickDirectory = vi.fn().mockResolvedValue('/mnt/data')
+    window.api.storage.inspectDataRoot = vi
+      .fn()
+      .mockResolvedValue({ kind: 'move', dataRoot: '/mnt/data/OpenScience' })
+    await renderStep()
+    await clickButton(/browse/i)
+    await clickButton(/finish/i)
+
+    expect(document.body.querySelector('[role="alertdialog"]')).not.toBeNull()
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+
+    expect(useSettingsStore.getState().completeOnboarding).not.toHaveBeenCalled()
+    expect(window.api.storage.setDataRootAndRelaunch).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('/mnt/data/OpenScience')
+  })
 })

--- a/src/renderer/src/pages/onboarding/LocationStep.tsx
+++ b/src/renderer/src/pages/onboarding/LocationStep.tsx
@@ -1,6 +1,6 @@
 import { X } from 'lucide-react'
 import { AlertDialog } from 'radix-ui'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
@@ -66,11 +66,6 @@ const LocationStep = ({
   const { chosenParent, chosenDataRoot, chosenKind } = locationDraft
   const [locationError, setLocationError] = useState<string | undefined>(undefined)
   const [confirmRestart, setConfirmRestart] = useState(false)
-  // Guards against handleKeepDefault's completeOnboarding firing spuriously after Restart:
-  // AlertDialog.Action fires onOpenChange(false) on click (same as Cancel), and closures inside
-  // that handler can't see isRelaunching's update from the same synchronous batch, so a ref is
-  // used instead of state for this check.
-  const isRestartingRef = useRef(false)
 
   const handleBrowseLocation = async (): Promise<void> => {
     setLocationError(undefined)
@@ -127,18 +122,11 @@ const LocationStep = ({
   }
 
   const handleKeepDefault = async (): Promise<void> => {
-    // AlertDialog.Action also fires onOpenChange(false) on click (it closes the dialog like Cancel
-    // does), which would otherwise call this a second time right after handleRestart. A ref (not
-    // isRelaunching state) is required here: both handlers run synchronously in the same click
-    // event, so a state-based check would still read the pre-update closure value.
-    if (isRestartingRef.current) return
-
     setConfirmRestart(false)
     await completeWithDefaultLocation()
   }
 
   const handleRestart = async (): Promise<void> => {
-    isRestartingRef.current = true
     setConfirmRestart(false)
     onRelaunchErrorChange(undefined)
     setIsRelaunching(true)
@@ -155,11 +143,9 @@ const LocationStep = ({
 
       // The app is not relaunching; the gate was never flipped, so we're still on the wizard -
       // surface the error here and let the user retry or fall back to Keep default.
-      isRestartingRef.current = false
       setIsRelaunching(false)
       onRelaunchErrorChange(result.error ?? 'Could not restart to apply the new location.')
     } catch (error) {
-      isRestartingRef.current = false
       setIsRelaunching(false)
       onRelaunchErrorChange(
         onboardingErrorMessage(error, 'Could not restart to apply the new location.')
@@ -279,12 +265,7 @@ const LocationStep = ({
         </Button>
       </CardFooter>
 
-      <AlertDialog.Root
-        open={confirmRestart}
-        onOpenChange={(open) => {
-          if (!open) void handleKeepDefault()
-        }}
-      >
+      <AlertDialog.Root open={confirmRestart} onOpenChange={setConfirmRestart}>
         <AlertDialog.Portal>
           <AlertDialog.Overlay className={dialogOverlayClassName} />
           <AlertDialog.Content
@@ -321,7 +302,7 @@ const LocationStep = ({
 
             <div className={dialogFooterClassName}>
               <AlertDialog.Cancel asChild>
-                <Button type="button" variant="outline">
+                <Button type="button" variant="outline" onClick={() => void handleKeepDefault()}>
                   {t('Keep default')}
                 </Button>
               </AlertDialog.Cancel>


### PR DESCRIPTION
## Problem

Dismissing the onboarding location restart confirmation with the Close button or Escape currently calls completeOnboarding. That persists onboarding completion, unmounts the wizard, and silently discards the in-memory custom location without applying it.

## Proposed change

- Treat AlertDialog onOpenChange as dialog-state synchronization only.
- Keep onboarding completion on the explicit Keep default button.
- Remove the restart ref that was only needed to guard the old close side effect.
- Cover Close and Escape dismissal with renderer regression tests.

## Scope and non-goals

- No settings fields, schema changes, migrations, enum values, IPC contracts, or i18n copy changes.
- No change to the existing Keep default or Restart persistence flows.
- No historical remediation: abandoned custom paths were never persisted, so affected intent cannot be reconstructed safely.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Close and Escape preserve the selected path and do not complete onboarding -> npm test -- src/renderer/src/pages/onboarding/LocationStep.render.test.tsx -> 20 tests passed.
- Explicit Keep default, Restart, and restart-failure recovery remain covered by the same module test -> passed.
- Renderer types -> npm run typecheck:web -> passed.
- Linted source -> npm run lint -> passed.
- Target-file formatting -> npx prettier --check src/renderer/src/pages/onboarding/LocationStep.tsx src/renderer/src/pages/onboarding/LocationStep.render.test.tsx -> passed.

CI remains authoritative for the selected renderer build, macOS unit, functional E2E, accessibility, and visual lanes. No platform-specific or persistence implementation changed locally.

## Review focus

Please verify the intent boundary: passive dismissal only closes the confirmation, while the explicit Keep default action remains the sole default-location completion path.