### PR TITLE
fix(compute): reconcile queues after concurrency changes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -474,7 +474,7 @@ model ComputeHost {
   sshOverrides     String? // JSON: { user?, port?, identityFile? } — never credentials
   scratchRoot      String?
   scratchPinned    Boolean   @default(false)
-  concurrencyLimit Int? // provider admission ceiling; null uses the default of 10
+  concurrencyLimit Int? // stored but not enforced in Phase 1
   probeResult      String? // JSON probe snapshot, written by a later issue
   detailsDoc       String    @default("") // markdown notes, <= 32768 chars
   detailsUpdatedAt DateTime?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -474,7 +474,7 @@ model ComputeHost {
   sshOverrides     String? // JSON: { user?, port?, identityFile? } — never credentials
   scratchRoot      String?
   scratchPinned    Boolean   @default(false)
-  concurrencyLimit Int? // stored but not enforced in Phase 1
+  concurrencyLimit Int? // provider admission ceiling; null uses the default of 10
   probeResult      String? // JSON probe snapshot, written by a later issue
   detailsDoc       String    @default("") // markdown notes, <= 32768 chars
   detailsUpdatedAt DateTime?

--- a/src/main/compute/compute-job-workflow-owner.ts
+++ b/src/main/compute/compute-job-workflow-owner.ts
@@ -401,7 +401,7 @@ export class ComputeJobWorkflowOwner {
         `Session concurrency limit must be an integer in the range 1..500 (got ${limit}).`
       )
     }
-    this.concurrencyManager.setSessionLimit(sessionId, limit)
+    await this.concurrencyManager.setSessionLimit(sessionId, limit)
   }
 
   async getSessionConcurrencyStatus(sessionId: string): Promise<SessionStatus> {

--- a/src/main/compute/compute-service.ts
+++ b/src/main/compute/compute-service.ts
@@ -44,7 +44,7 @@ export class ComputeService {
     onJobUpdated?: (job: ComputeJob) => void,
     artifactResolver?: ArtifactResolver,
     storageRoot?: string,
-    concurrencyManager?: ConcurrencyManager
+    private readonly concurrencyManager?: ConcurrencyManager
   ) {
     const effectiveScpRunner = scpRunner ?? new SystemScpRunner()
     this.hostProfiles = new ComputeHostProfileOwner(runner, repository)
@@ -99,6 +99,9 @@ export class ComputeService {
   }
 
   async setConcurrencyLimit(providerId: string, limit: number): Promise<void> {
+    if (this.concurrencyManager) {
+      return this.concurrencyManager.setProviderLimit(providerId, limit)
+    }
     return this.hostProfiles.setConcurrencyLimit(providerId, limit)
   }
 

--- a/src/main/compute/concurrency-integration.test.ts
+++ b/src/main/compute/concurrency-integration.test.ts
@@ -182,6 +182,60 @@ describe('ConcurrencyManager integration with ComputeService', () => {
     expect(job2?.status).toBe('queued')
   })
 
+  it('promotes queued work when the provider ceiling is raised', async () => {
+    const providerId = computeProviderId('test-host')
+    await service.setConcurrencyLimit(providerId, 1)
+
+    await service.submitJob(
+      providerId,
+      'job 1',
+      'echo one',
+      {},
+      { sessionId: 'session-1', projectId: 'project-1' }
+    )
+    const queued = await service.submitJob(
+      providerId,
+      'job 2',
+      'echo two',
+      {},
+      { sessionId: 'session-2', projectId: 'project-1' }
+    )
+    expect(queued.status).toBe('queued')
+
+    await service.setConcurrencyLimit(providerId, 2)
+
+    await vi.waitFor(async () => {
+      expect((await jobRepo.get(queued.job_id))?.status).toBe('submitted')
+    })
+  })
+
+  it('promotes queued work when the session limit is raised', async () => {
+    const providerId = computeProviderId('test-host')
+    await service.setSessionConcurrencyLimit('session-1', 1)
+
+    await service.submitJob(
+      providerId,
+      'job 1',
+      'echo one',
+      {},
+      { sessionId: 'session-1', projectId: 'project-1' }
+    )
+    const queued = await service.submitJob(
+      providerId,
+      'job 2',
+      'echo two',
+      {},
+      { sessionId: 'session-1', projectId: 'project-1' }
+    )
+    expect(queued.status).toBe('queued')
+
+    await service.setSessionConcurrencyLimit('session-1', 2)
+
+    await vi.waitFor(async () => {
+      expect((await jobRepo.get(queued.job_id))?.status).toBe('submitted')
+    })
+  })
+
   it('should throw queue_full error when 100 jobs are already queued', async () => {
     const providerId = computeProviderId('test-host')
 

--- a/src/main/compute/concurrency-manager.test.ts
+++ b/src/main/compute/concurrency-manager.test.ts
@@ -31,7 +31,8 @@ const createMockHostRepo = (): ComputeHostRepository =>
     get: vi.fn(),
     list: vi.fn(),
     create: vi.fn(),
-    delete: vi.fn()
+    delete: vi.fn(),
+    updateConcurrencyLimit: vi.fn()
   }) as unknown as ComputeHostRepository
 
 const createMockDispatchJob = (): Mock<
@@ -61,20 +62,75 @@ describe('ConcurrencyManager', () => {
           submitted_at: updates.submittedAt?.getTime()
         }) as ComputeJob
     )
+    vi.mocked(jobRepo.findQueuedJobs).mockResolvedValue([])
     manager = new ConcurrencyManager(jobRepo, hostRepo, dispatchJob, onJobUpdated)
   })
 
   describe('setSessionLimit', () => {
-    it('stores session limit in memory', () => {
-      manager.setSessionLimit('session-1', 5)
+    it('stores session limit in memory', async () => {
+      await manager.setSessionLimit('session-1', 5)
       // Verify via getStatus
       expect(manager['sessionLimits'].get('session-1')).toBe(5)
     })
 
-    it('updates existing session limit', () => {
-      manager.setSessionLimit('session-1', 3)
-      manager.setSessionLimit('session-1', 7)
+    it('updates existing session limit', async () => {
+      await manager.setSessionLimit('session-1', 3)
+      await manager.setSessionLimit('session-1', 7)
       expect(manager['sessionLimits'].get('session-1')).toBe(7)
+    })
+  })
+
+  describe('setProviderLimit', () => {
+    it('serializes a decrease ahead of a concurrent admission', async () => {
+      let storedLimit = 2
+      let releaseUpdate: (() => void) | undefined
+      let updateStarted: (() => void) | undefined
+      const updateEntered = new Promise<void>((resolve) => {
+        updateStarted = resolve
+      })
+
+      vi.mocked(hostRepo.get).mockImplementation(async () => ({
+        providerId: 'ssh:cluster-a',
+        concurrencyLimit: storedLimit
+      }) as ComputeHost)
+      vi.mocked(hostRepo.updateConcurrencyLimit).mockImplementation(async (_providerId, limit) => {
+        updateStarted?.()
+        await new Promise<void>((resolve) => {
+          releaseUpdate = resolve
+        })
+        storedLimit = limit
+      })
+      vi.mocked(jobRepo.countQueuedJobs).mockResolvedValue(0)
+      vi.mocked(jobRepo.countActiveByProvider).mockResolvedValue(1)
+
+      const changingLimit = manager.setProviderLimit('ssh:cluster-a', 1)
+      await updateEntered
+      const commit = vi.fn().mockResolvedValue(undefined)
+      const admitting = manager.admit(
+        { sessionId: 'session-1', providerId: 'ssh:cluster-a' },
+        commit
+      )
+      releaseUpdate?.()
+
+      await changingLimit
+      await expect(admitting).resolves.toBe('queued')
+      expect(commit).toHaveBeenCalledWith('queued')
+    })
+
+    it('rejects invalid limits before persistence', async () => {
+      await expect(manager.setProviderLimit('ssh:cluster-a', 0)).rejects.toThrow(
+        /integer in the range 1\.\.500/
+      )
+      expect(hostRepo.updateConcurrencyLimit).not.toHaveBeenCalled()
+    })
+
+    it('rejects a missing provider before persistence', async () => {
+      vi.mocked(hostRepo.get).mockResolvedValue(null)
+
+      await expect(manager.setProviderLimit('ssh:missing', 10)).rejects.toThrow(
+        /No compute host found/
+      )
+      expect(hostRepo.updateConcurrencyLimit).not.toHaveBeenCalled()
     })
   })
 
@@ -107,7 +163,7 @@ describe('ConcurrencyManager', () => {
 
   describe('enqueue - session limit check', () => {
     it('returns should_queue when session limit reached', async () => {
-      manager.setSessionLimit('session-1', 2)
+      await manager.setSessionLimit('session-1', 2)
       vi.mocked(jobRepo.countQueuedJobs).mockResolvedValue(0)
       vi.mocked(jobRepo.countActiveBySession).mockResolvedValue(2)
       vi.mocked(jobRepo.countActiveByProvider).mockResolvedValue(1)
@@ -126,7 +182,7 @@ describe('ConcurrencyManager', () => {
     })
 
     it('returns can_dispatch when under session limit', async () => {
-      manager.setSessionLimit('session-1', 5)
+      await manager.setSessionLimit('session-1', 5)
       vi.mocked(jobRepo.countQueuedJobs).mockResolvedValue(0)
       vi.mocked(jobRepo.countActiveBySession).mockResolvedValue(3)
       vi.mocked(jobRepo.countActiveByProvider).mockResolvedValue(2)
@@ -217,7 +273,7 @@ describe('ConcurrencyManager', () => {
 
   describe('enqueue - combined limits', () => {
     it('requires both session limit and provider ceiling to be satisfied', async () => {
-      manager.setSessionLimit('session-1', 5)
+      await manager.setSessionLimit('session-1', 5)
       vi.mocked(jobRepo.countQueuedJobs).mockResolvedValue(0)
       vi.mocked(jobRepo.countActiveBySession).mockResolvedValue(2) // under session limit
       vi.mocked(jobRepo.countActiveByProvider).mockResolvedValue(10) // at provider ceiling
@@ -318,7 +374,7 @@ describe('ConcurrencyManager', () => {
     })
 
     it('re-checks both session limit and provider ceiling', async () => {
-      manager.setSessionLimit('session-1', 2)
+      await manager.setSessionLimit('session-1', 2)
       const queuedJobs: ComputeJob[] = [
         {
           job_id: 'job-1',
@@ -343,7 +399,7 @@ describe('ConcurrencyManager', () => {
     })
 
     it('skips jobs that still violate session limit', async () => {
-      manager.setSessionLimit('session-1', 2)
+      await manager.setSessionLimit('session-1', 2)
       const queuedJobs: ComputeJob[] = [
         {
           job_id: 'job-1',
@@ -392,7 +448,7 @@ describe('ConcurrencyManager', () => {
     })
 
     it('dispatches multiple jobs if both limits allow', async () => {
-      manager.setSessionLimit('session-1', 10)
+      await manager.setSessionLimit('session-1', 10)
       const queuedJobs: ComputeJob[] = [
         {
           job_id: 'job-1',
@@ -448,7 +504,7 @@ describe('ConcurrencyManager', () => {
 
   describe('getStatus', () => {
     it('returns accurate session status', async () => {
-      manager.setSessionLimit('session-1', 5)
+      await manager.setSessionLimit('session-1', 5)
       vi.mocked(jobRepo.countActiveBySession).mockResolvedValue(3)
       vi.mocked(jobRepo.findBySession).mockResolvedValue([
         { provider_id: 'ssh:cluster-a', status: 'queued' } as ComputeJob,
@@ -499,8 +555,8 @@ describe('ConcurrencyManager', () => {
 
   describe('multi-session scenarios', () => {
     it('enforces session limits independently', async () => {
-      manager.setSessionLimit('session-1', 2)
-      manager.setSessionLimit('session-2', 3)
+      await manager.setSessionLimit('session-1', 2)
+      await manager.setSessionLimit('session-2', 3)
 
       vi.mocked(jobRepo.countQueuedJobs).mockResolvedValue(0)
       vi.mocked(jobRepo.countActiveByProvider).mockResolvedValue(1)
@@ -606,7 +662,7 @@ describe('ConcurrencyManager', () => {
         } as ComputeJob
       ]
 
-      vi.mocked(jobRepo.findQueuedJobs).mockResolvedValue(queuedJobs)
+      vi.mocked(jobRepo.findQueuedJobs).mockResolvedValueOnce(queuedJobs).mockResolvedValue([])
       vi.mocked(jobRepo.countActiveBySession).mockResolvedValue(0)
       vi.mocked(jobRepo.countActiveByProvider).mockResolvedValue(0)
       vi.mocked(hostRepo.get).mockResolvedValue({
@@ -649,7 +705,7 @@ describe('ConcurrencyManager', () => {
         } as ComputeJob
       ]
 
-      vi.mocked(jobRepo.findQueuedJobs).mockResolvedValue(queuedJobs)
+      vi.mocked(jobRepo.findQueuedJobs).mockResolvedValueOnce(queuedJobs).mockResolvedValue([])
       vi.mocked(jobRepo.countActiveBySession).mockResolvedValue(0)
       vi.mocked(jobRepo.countActiveByProvider).mockResolvedValue(0)
       vi.mocked(hostRepo.get).mockResolvedValue({
@@ -674,7 +730,7 @@ describe('ConcurrencyManager', () => {
       expect(dispatchJob).toHaveBeenCalledWith('job-2', expect.any(Function))
     })
 
-    it('prevents concurrent tryDispatchNext execution', async () => {
+    it('coalesces concurrent reconciliation without dispatching the same job twice', async () => {
       const queuedJobs: ComputeJob[] = [
         {
           job_id: 'job-1',
@@ -685,7 +741,7 @@ describe('ConcurrencyManager', () => {
         } as ComputeJob
       ]
 
-      vi.mocked(jobRepo.findQueuedJobs).mockResolvedValue(queuedJobs)
+      vi.mocked(jobRepo.findQueuedJobs).mockResolvedValueOnce(queuedJobs).mockResolvedValue([])
       vi.mocked(jobRepo.countActiveBySession).mockResolvedValue(0)
       vi.mocked(jobRepo.countActiveByProvider).mockResolvedValue(0)
       vi.mocked(hostRepo.get).mockResolvedValue({
@@ -703,9 +759,8 @@ describe('ConcurrencyManager', () => {
       // Fire two concurrent onJobCompleted calls
       await Promise.all([manager.onJobCompleted(), manager.onJobCompleted()])
 
-      // findQueuedJobs should only be called once (second call returns early)
-      expect(jobRepo.findQueuedJobs).toHaveBeenCalledOnce()
-      // dispatchJob should only be called once
+      // The concurrent request is retained as one follow-up scan, without a second dispatch.
+      expect(jobRepo.findQueuedJobs).toHaveBeenCalledTimes(2)
       expect(dispatchStarted).toBe(1)
     })
   })
@@ -725,7 +780,7 @@ describe('ConcurrencyManager', () => {
     })
 
     it('calls commit with queued when session limit is reached', async () => {
-      manager.setSessionLimit('s1', 2)
+      await manager.setSessionLimit('s1', 2)
       vi.mocked(jobRepo.countQueuedJobs).mockResolvedValue(0)
       vi.mocked(jobRepo.countActiveBySession).mockResolvedValue(2)
       vi.mocked(jobRepo.countActiveByProvider).mockResolvedValue(0)
@@ -751,7 +806,7 @@ describe('ConcurrencyManager', () => {
     it('serializes concurrent admits so both cannot pass the same slot', async () => {
       // Two concurrent calls see activeByProvider=0 individually, but admit serializes them so
       // the second sees activeByProvider=1 (as committed by the first).
-      manager.setSessionLimit('s1', 10)
+      await manager.setSessionLimit('s1', 10)
       vi.mocked(jobRepo.countQueuedJobs).mockResolvedValue(0)
       vi.mocked(hostRepo.get).mockResolvedValue({ concurrencyLimit: 1 } as ComputeHost)
 

--- a/src/main/compute/concurrency-manager.test.ts
+++ b/src/main/compute/concurrency-manager.test.ts
@@ -89,10 +89,13 @@ describe('ConcurrencyManager', () => {
         updateStarted = resolve
       })
 
-      vi.mocked(hostRepo.get).mockImplementation(async () => ({
-        providerId: 'ssh:cluster-a',
-        concurrencyLimit: storedLimit
-      }) as ComputeHost)
+      vi.mocked(hostRepo.get).mockImplementation(
+        async () =>
+          ({
+            providerId: 'ssh:cluster-a',
+            concurrencyLimit: storedLimit
+          }) as ComputeHost
+      )
       vi.mocked(hostRepo.updateConcurrencyLimit).mockImplementation(async (_providerId, limit) => {
         updateStarted?.()
         await new Promise<void>((resolve) => {

--- a/src/main/compute/concurrency-manager.ts
+++ b/src/main/compute/concurrency-manager.ts
@@ -1,6 +1,7 @@
 import type { ComputeJobOwner, ComputeJobRepository } from './job-repository'
 import type { ComputeHostRepository } from './repository'
 import type { ComputeJob } from '../../shared/compute'
+import { createLogger, errorLogFields } from '../logger'
 import { ComputeJobLifecycle } from './compute-job-lifecycle'
 
 export type SessionStatus = {
@@ -15,6 +16,7 @@ const DEFAULT_PROVIDER_CEILING = 10
 
 // Global queue limit (max queued jobs across all sessions).
 const GLOBAL_QUEUE_LIMIT = 100
+const log = createLogger('compute-concurrency')
 const TERMINAL_JOB_STATUSES: ReadonlySet<ComputeJob['status']> = new Set([
   'success',
   'failed',
@@ -33,6 +35,7 @@ export class ConcurrencyManager {
 
   // Flag to prevent concurrent execution of tryDispatchNext
   private dispatching: boolean = false
+  private reconciliationRequested: boolean = false
 
   // In-process serialization lock for admit(). The decision (read counts → pick status) and the
   // job-row commit must be atomic: without this, two concurrent submitJob calls could both read the
@@ -60,12 +63,45 @@ export class ConcurrencyManager {
   // handler, and the manager's own fallback persistence uses it below.
   handleJobUpdated = (job: ComputeJob): void => {
     this.publishJobUpdated(job)
-    if (TERMINAL_JOB_STATUSES.has(job.status)) void this.onJobCompleted()
+    if (TERMINAL_JOB_STATUSES.has(job.status)) this.requestQueueReconciliation()
   }
 
-  // Set session-level concurrency limit (stored in memory, not persisted).
-  setSessionLimit(sessionId: string, limit: number): void {
-    this.sessionLimits.set(sessionId, limit)
+  // Session limits are process-local by design. Serialize updates with admissions so a limit saved by
+  // the caller cannot be followed by a late admission made against the previous value.
+  async setSessionLimit(sessionId: string, limit: number): Promise<void> {
+    if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+      throw new Error(
+        `Session concurrency limit must be an integer in the range 1..500 (got ${limit}).`
+      )
+    }
+
+    let previousLimit: number | undefined
+    await this.runExclusive(async () => {
+      previousLimit = this.sessionLimits.get(sessionId)
+      this.sessionLimits.set(sessionId, limit)
+    })
+
+    if (previousLimit !== undefined && limit > previousLimit) {
+      this.requestQueueReconciliation()
+    }
+  }
+
+  // Provider limits are durable host configuration. Own the production mutation here so it shares
+  // the same lock as admission and queued-job promotion; raising the ceiling then wakes the FIFO queue.
+  async setProviderLimit(providerId: string, limit: number): Promise<void> {
+    if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+      throw new Error(`Concurrent job limit must be an integer in the range 1..500 (got ${limit}).`)
+    }
+
+    let previousLimit = DEFAULT_PROVIDER_CEILING
+    await this.runExclusive(async () => {
+      const host = await this.hostRepository.get(providerId)
+      if (!host) throw new Error(`No compute host found with provider id "${providerId}".`)
+      previousLimit = host.concurrencyLimit ?? DEFAULT_PROVIDER_CEILING
+      await this.hostRepository.updateConcurrencyLimit(providerId, limit)
+    })
+
+    if (limit > previousLimit) this.requestQueueReconciliation()
   }
 
   async pauseOwner(owner: ComputeJobOwner): Promise<void> {
@@ -84,7 +120,7 @@ export class ConcurrencyManager {
   resumeOwner(owner: ComputeJobOwner): void {
     if (owner.sessionId === undefined) this.pausedProjects.delete(owner.projectId)
     else this.pausedSessions.delete(this.sessionOwnerKey(owner.projectId, owner.sessionId))
-    void this.onJobCompleted()
+    this.requestQueueReconciliation()
   }
 
   // Runs `fn` while holding the admit lock, serializing it against every other runExclusive call.
@@ -174,7 +210,14 @@ export class ConcurrencyManager {
 
   // Called when a job reaches a terminal state. Attempts to dispatch the next eligible queued job.
   async onJobCompleted(): Promise<void> {
+    this.reconciliationRequested = true
     await this.tryDispatchNext()
+  }
+
+  private requestQueueReconciliation(): void {
+    void this.onJobCompleted().catch((error) => {
+      log.warn('compute queue reconciliation failed', errorLogFields(error))
+    })
   }
 
   // Query session status (active/queued counts, limits, provider ceilings).
@@ -214,44 +257,47 @@ export class ConcurrencyManager {
 
     this.dispatching = true
     try {
-      const queuedJobs = await this.jobRepository.findQueuedJobs()
+      do {
+        this.reconciliationRequested = false
+        const queuedJobs = await this.jobRepository.findQueuedJobs()
 
-      for (const job of queuedJobs) {
-        const owner = { projectId: job.project_id, sessionId: job.session_id }
-        if (this.isOwnerPaused(owner)) continue
-        const operation = (async (): Promise<void> => {
-          // Reserve the slot atomically against admit() and other promotions: the re-check of both
-          // limits and the status flip to 'submitted' run inside the SAME admitLock as admit(), so a
-          // concurrent new submission cannot also claim this slot and overrun a provider ceiling /
-          // session limit. Without this shared lock the promotion and an admission each read the same
-          // active count and both become 'submitted' (the race admit() was added to close).
-          //
-          // The slow dispatchJob (SSH staging/launch) runs OUTSIDE the lock: once the row is
-          // 'submitted' it counts as active, so any later admit()/promotion sees it. Holding the lock
-          // across SSH work would serialize every submission behind network latency.
-          const reserved = await this.runExclusive(async () => {
-            if (this.isOwnerPaused(owner)) return false
-            if (await this.overActiveLimits(job.session_id, job.provider_id)) return false
-            if (this.isOwnerPaused(owner)) return false
-            const promotion = await this.lifecycle.promoteQueued(job.job_id)
-            return promotion.kind === 'applied'
-          })
-          if (!reserved) return
+        for (const job of queuedJobs) {
+          const owner = { projectId: job.project_id, sessionId: job.session_id }
+          if (this.isOwnerPaused(owner)) continue
+          const operation = (async (): Promise<void> => {
+            // Reserve the slot atomically against admit() and other promotions: the re-check of both
+            // limits and the status flip to 'submitted' run inside the SAME admitLock as admit(), so a
+            // concurrent new submission cannot also claim this slot and overrun a provider ceiling /
+            // session limit. Without this shared lock the promotion and an admission each read the same
+            // active count and both become 'submitted' (the race admit() was added to close).
+            //
+            // The slow dispatchJob (SSH staging/launch) runs OUTSIDE the lock: once the row is
+            // 'submitted' it counts as active, so any later admit()/promotion sees it. Holding the lock
+            // across SSH work would serialize every submission behind network latency.
+            const reserved = await this.runExclusive(async () => {
+              if (this.isOwnerPaused(owner)) return false
+              if (await this.overActiveLimits(job.session_id, job.provider_id)) return false
+              if (this.isOwnerPaused(owner)) return false
+              const promotion = await this.lifecycle.promoteQueued(job.job_id)
+              return promotion.kind === 'applied'
+            })
+            if (!reserved) return
 
+            try {
+              await this.dispatchJob(job.job_id, this.handleJobUpdated)
+            } catch {
+              // If dispatch fails, mark job as error and continue to next queued job.
+              await this.lifecycle.dispatchError(job.job_id, { errorCode: 'dispatch_failed' })
+            }
+          })()
+          this.ownerOperations.set(operation, owner)
           try {
-            await this.dispatchJob(job.job_id, this.handleJobUpdated)
-          } catch {
-            // If dispatch fails, mark job as error and continue to next queued job.
-            await this.lifecycle.dispatchError(job.job_id, { errorCode: 'dispatch_failed' })
+            await operation
+          } finally {
+            this.ownerOperations.delete(operation)
           }
-        })()
-        this.ownerOperations.set(operation, owner)
-        try {
-          await operation
-        } finally {
-          this.ownerOperations.delete(operation)
         }
-      }
+      } while (this.reconciliationRequested)
     } finally {
       this.dispatching = false
     }

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -149,7 +149,7 @@ type ComputeHandlers = {
   ) => Promise<void>
   // Scratch root: set path and mark pinned.
   scratchSet: (providerId: string, path: string) => Promise<void>
-  // Concurrent job limit: store 1..500 (not enforced in Phase 1).
+  // Enforced concurrent job limit: set 1..500.
   concurrencySet: (providerId: string, limit: number) => Promise<void>
   // Session-level concurrency control (Phase 3c, issue 04).
   setSessionConcurrencyLimit: (sessionId: string, limit: number) => Promise<void>

--- a/src/main/compute/repository.ts
+++ b/src/main/compute/repository.ts
@@ -205,8 +205,8 @@ class ComputeHostRepository {
     })
   }
 
-  // Persists the concurrent job limit (1..500). Phase 1 stores the value but does not enforce it
-  // (no job runner). Callers must validate the range before calling.
+  // Persists the concurrent job limit (1..500). ConcurrencyManager validates and enforces it in the
+  // production job path; repository-only callers must validate the range before calling.
   async updateConcurrencyLimit(providerId: string, concurrencyLimit: number): Promise<void> {
     const client = await this.getClient()
 

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -681,7 +681,7 @@ export interface OpenScienceAPI {
     ): Promise<void>
     // Scratch root: set path and mark pinned.
     scratchSet(providerId: string, path: string): Promise<void>
-    // Concurrent job limit: store 1..500 (not enforced in Phase 1).
+    // Enforced concurrent job limit: set 1..500.
     concurrencySet(providerId: string, limit: number): Promise<void>
     // Fires when a compute call needs user approval (runs before any SSH is made).
     onApprovalRequest(listener: (request: ComputeApprovalRequest) => void): () => void

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -2456,7 +2456,7 @@
   "Open {{name}} in split view beside the session": "在会话旁的拆分视图中打开 {{name}}",
   "Preview uploaded file {{name}}": "预览上传的文件 {{name}}",
   "Skills aren't available with {{name}}; use Claude Code for skill-based workflows.": "{{name}} 不支持 Skill；请使用 Claude Code 运行基于 Skill 的工作流。",
-  "Maximum jobs running at the same time on this host (1–500).": "此主机上可同时运行的最大任务数（1–500）。",
+  "New jobs wait when this host reaches the limit (1–500). Lowering the limit does not stop running jobs.": "此主机达到上限（1–500）后，新任务将等待。降低上限不会停止正在运行的任务。",
   "Remote access couldn't be loaded.": "无法加载远程访问。",
   "{{fileName}} was saved. No location is shown here.": "已保存 {{fileName}}。此处不会显示保存位置。",
   "Only checked Skills are bundled. Connector names are imported as selected references; full access can only be chosen later in the configuration page.": "仅打包选中的 Skill。连接器名称会作为选中的引用导入；完整访问权限只能稍后在配置页面中选择。",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -2456,7 +2456,7 @@
   "Open {{name}} in split view beside the session": "在工作階段旁的分割檢視中開啟 {{name}}",
   "Preview uploaded file {{name}}": "預覽已上傳的檔案 {{name}}",
   "Skills aren't available with {{name}}; use Claude Code for skill-based workflows.": "{{name}} 不支援 Skill；請使用 Claude Code 執行以 Skill 為基礎的工作流程。",
-  "Maximum jobs running at the same time on this host (1–500).": "此主機上可同時執行的工作數上限（1–500）。",
+  "New jobs wait when this host reaches the limit (1–500). Lowering the limit does not stop running jobs.": "此主機達到上限（1–500）後，新工作將等待。降低上限不會停止執行中的工作。",
   "Remote access couldn't be loaded.": "無法載入遠端存取。",
   "{{fileName}} was saved. No location is shown here.": "已儲存 {{fileName}}。此處不會顯示儲存位置。",
   "Only checked Skills are bundled. Connector names are imported as selected references; full access can only be chosen later in the configuration page.": "僅封裝選取的 Skill。連接器名稱會作為選取的參照匯入；完整存取權只能稍後在設定頁面中選擇。",

--- a/src/renderer/src/pages/settings/ComputeHostDetail.render.test.tsx
+++ b/src/renderer/src/pages/settings/ComputeHostDetail.render.test.tsx
@@ -107,6 +107,9 @@ describe('ComputeHostDetail', () => {
     expect(container.textContent).toContain('Details')
     expect(container.textContent).toContain('Scratch root')
     expect(container.textContent).toContain('Concurrent job limit')
+    expect(container.textContent).toContain(
+      'New jobs wait when this host reaches the limit (1–500). Lowering the limit does not stop running jobs.'
+    )
   })
 
   it('shows PINNED badge when scratchPinned is true', () => {

--- a/src/renderer/src/pages/settings/ComputeHostDetail.tsx
+++ b/src/renderer/src/pages/settings/ComputeHostDetail.tsx
@@ -618,7 +618,9 @@ export function ComputeHostDetail({
           <div className="min-w-0">
             <h4 className="text-sm font-medium text-foreground">{t('Concurrent job limit')}</h4>
             <p className="mt-0.5 text-xs text-muted-foreground">
-              {t('Maximum jobs running at the same time on this host (1–500).')}
+              {t(
+                'New jobs wait when this host reaches the limit (1–500). Lowering the limit does not stop running jobs.'
+              )}
             </p>
           </div>
           {!isEditingConcurrency ? (

--- a/src/renderer/src/pages/settings/compute-i18n.render.test.tsx
+++ b/src/renderer/src/pages/settings/compute-i18n.render.test.tsx
@@ -201,6 +201,9 @@ describe('ComputeHostDetail i18n', () => {
     expect(container.textContent).toContain('临时目录')
     expect(container.textContent).toContain('已固定')
     expect(container.textContent).toContain('并发作业上限')
+    expect(container.textContent).toContain(
+      '此主机达到上限（1–500）后，新任务将等待。降低上限不会停止正在运行的任务。'
+    )
     expect(container.textContent).toContain('10（默认）')
     expect(container.textContent).not.toContain('Concurrent job limit')
 
@@ -208,6 +211,9 @@ describe('ComputeHostDetail i18n', () => {
     expect(container.textContent).toContain('暫存目錄')
     expect(container.textContent).toContain('已釘選')
     expect(container.textContent).toContain('並行工作上限')
+    expect(container.textContent).toContain(
+      '此主機達到上限（1–500）後，新工作將等待。降低上限不會停止執行中的工作。'
+    )
     expect(container.textContent).toContain('10（預設）')
     expect(container.textContent).not.toContain('{{')
 

--- a/src/renderer/src/stores/compute-store.ts
+++ b/src/renderer/src/stores/compute-store.ts
@@ -32,7 +32,7 @@ type ComputeStore = ComputeStoreData & {
   saveDetails: (providerId: string, text: string, oldText: string) => Promise<void>
   // Sets the scratch root path and marks the host as pinned.
   setScratch: (providerId: string, path: string) => Promise<void>
-  // Sets the concurrent job limit (1..500). Phase 1 stores but does not enforce.
+  // Sets the enforced concurrent job limit (1..500).
   setConcurrency: (providerId: string, limit: number) => Promise<void>
   // Queues an incoming approval request (from the main-process compute gate).
   enqueueApproval: (request: ComputeApprovalRequest) => void
@@ -160,7 +160,7 @@ export const useComputeStore = create<ComputeStore>((set) => ({
     }
   },
 
-  // Stores the concurrent job limit. Merges the updated host into cache.
+  // Updates the concurrent job limit. Merges the updated host into cache.
   setConcurrency: async (providerId, limit) => {
     await window.api.compute.concurrencySet(providerId, limit)
     const updatedHost = await window.api.compute.get(providerId)

--- a/src/shared/compute.ts
+++ b/src/shared/compute.ts
@@ -127,7 +127,7 @@ export type ComputeApprovalRequest = {
   remote_workdir?: string
 }
 
-// The job status values for the Phase 3a state machine. 'queued' is reserved for Phase 3c.
+// Job status values, including concurrency-managed queued work.
 export type ComputeJobStatus =
   'queued' | 'submitted' | 'running' | 'success' | 'failed' | 'timeout' | 'error'
 


### PR DESCRIPTION
## Problem

The Compute host concurrency limit is enforced for new submissions, but changing a limit does not
fully participate in the runtime scheduling contract. Raising a provider or session limit leaves
already queued work idle until another terminal job update happens. Provider limit writes also occur
outside the admission lock, so a concurrent admission can finish against the previous ceiling after a
lower value has been saved. Several Phase 1 runtime comments still incorrectly say the provider limit
is only stored and not enforced.

## Proposed change

- Serialize durable provider-limit writes and process-local session-limit changes with job admission
  and queued-job promotion.
- Request FIFO queue reconciliation when a higher limit creates capacity.
- Retain reconciliation requests that arrive while a queue scan is already running, without
  dispatching the same queued row twice.
- Keep Settings saves independent of remote SSH launch latency by running reconciliation in the
  background and logging reconciliation failures.
- Clarify in Settings that lowering a limit does not stop jobs that are already running.
- Replace stale runtime Phase 1 comments with the current enforced contract. The released Prisma
  schema file remains byte-identical because repository policy requires a migration for any schema
  contract diff, including a comment-only edit.

## Scope and non-goals

- No new database field, schema shape, migration, cross-process method, or public Compute host field.
- No new job status; the existing `queued` and `submitted` states cover the behavior.
- `ComputeHost.concurrencyLimit` remains the durable SQLite source of truth; `null` still means the
  default provider ceiling of 10. Session limits remain process-local.
- Existing host rows and queued job rows require no data rewrite. After this change, raising a limit
  can start an already-persisted eligible queued job sooner.
- Lowering a limit is non-preemptive: submitted/running remote jobs are not cancelled.
- Startup-time recovery of an otherwise stranded historical queue remains out of scope.

## Acceptance criteria and validation

All listed checks ran after the last material code edit. The follow-up commit only restored a Prisma
comment so the final diff contains no schema contract change.

- Provider/session limit increases wake queued work -> targeted regression tests in
  `concurrency-integration.test.ts` -> 2 passed.
- Configuration changes serialize with admission and reconciliation remains coalesced ->
  `concurrency-manager.test.ts` -> 36 passed.
- Compute owner, contract, and consumer behavior -> the exact 24-file `compute_service` module-impact
  plan -> 600 passed, 15 skipped. The project wrapper generated this plan but could not spawn
  `npm.cmd` locally on Windows (`spawnSync EINVAL`), so the same explicit file list was run directly.
- Settings interaction and Simplified/Traditional Chinese resources ->
  `ComputeHostDetail.render.test.tsx`, `compute-i18n.render.test.tsx`, and `resources.test.ts` ->
  82 passed.
- Main-process types -> `npm run typecheck:node` -> passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Source and test lint -> `npm run lint` -> passed.

The `compute_service` manifest has no downstream consumer modules; its declared owner, contract, and
consumer tests were all included. Renderer tests were added because visible helper copy changed.
Database migration checks were excluded because the final diff does not touch schema contracts. The
module's Windows-sensitive and full portable/platform lanes remain authoritative in PR CI. Real SSH
launches are mocked locally and remain an uncovered runtime risk handled by CI and normal integration
testing.

## Review focus

- Provider/session configuration changes sharing the admission lock.
- Reconciliation requests that arrive during an active queue scan.
- Non-preemptive lowering semantics and the updated Settings explanation.
