### PR TITLE
fix(reviewer): load artifact source session reviews

### DIFF
--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -882,6 +882,7 @@
   "Loading notebook…": "正在加载 Notebook……",
   "Loading permissions": "正在加载权限",
   "Loading preview…": "正在加载预览…",
+  "Loading review history…": "正在加载审查历史…",
   "Loading project files…": "正在加载项目文件……",
   "Loading remote access…": "正在加载远程访问…",
   "Loading saved conversations…": "正在加载已保存的对话…",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -880,6 +880,7 @@
   "Loading notebook…": "正在載入 Notebook……",
   "Loading permissions": "正在載入權限",
   "Loading preview…": "正在載入預覽…",
+  "Loading review history…": "正在載入審查歷史…",
   "Loading project files…": "正在載入專案檔案……",
   "Loading remote access…": "正在載入遠端存取…",
   "Loading saved conversations…": "正在載入已儲存的對話…",

--- a/src/renderer/src/pages/workspace/previews/PreviewToolContent.reviewer.integration.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewToolContent.reviewer.integration.test.tsx
@@ -15,9 +15,20 @@ vi.mock('@/stores/navigation-store', () => ({
     selector({ activeProjectId: mocks.activeProjectId })
 }))
 vi.mock('@/stores/review-store', () => ({
-  selectProjectSessionReviews: () => mocks.reviews,
-  useReviewStore: <T,>(selector: (state: { reviewsBySession: Record<string, never[]> }) => T): T =>
-    selector({ reviewsBySession: {} })
+  selectProjectSessionReviewSnapshot: () => mocks.reviews,
+  selectProjectSessionReviewLoadError: () => undefined,
+  useReviewStore: <T,>(
+    selector: (state: {
+      reviewsBySession: Record<string, never[]>
+      loadErrorsBySession: Record<string, string>
+      loadReviewsForSession: ReturnType<typeof vi.fn>
+    }) => T
+  ): T =>
+    selector({
+      reviewsBySession: {},
+      loadErrorsBySession: {},
+      loadReviewsForSession: vi.fn(() => Promise.resolve())
+    })
 }))
 vi.mock('../NotebookPreview', () => ({
   NotebookPreview: (): React.JSX.Element => <div />

--- a/src/renderer/src/pages/workspace/previews/PreviewToolContent.reviewer.integration.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewToolContent.reviewer.integration.test.tsx
@@ -20,12 +20,14 @@ vi.mock('@/stores/review-store', () => ({
   useReviewStore: <T,>(
     selector: (state: {
       reviewsBySession: Record<string, never[]>
+      loadedReviewSessions: Record<string, boolean>
       loadErrorsBySession: Record<string, string>
       loadReviewsForSession: ReturnType<typeof vi.fn>
     }) => T
   ): T =>
     selector({
       reviewsBySession: {},
+      loadedReviewSessions: {},
       loadErrorsBySession: {},
       loadReviewsForSession: vi.fn(() => Promise.resolve())
     })

--- a/src/renderer/src/pages/workspace/previews/PreviewToolContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewToolContent.test.tsx
@@ -1,11 +1,17 @@
+// @vitest-environment jsdom
+
+import { act } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
+import { createRoot } from 'react-dom/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { PreviewToolItem } from '@/stores/preview-workbench-store'
 
 const mocks = vi.hoisted(() => ({
   activeProjectId: 'project-1' as string | undefined,
-  getReviewsForSession: vi.fn()
+  getReviewSnapshot: vi.fn(),
+  loadError: undefined as string | undefined,
+  loadReviewsForSession: vi.fn<() => Promise<void>>()
 }))
 
 vi.mock('@/stores/navigation-store', () => ({
@@ -13,13 +19,24 @@ vi.mock('@/stores/navigation-store', () => ({
     selector({ activeProjectId: mocks.activeProjectId })
 }))
 vi.mock('@/stores/review-store', () => ({
-  selectProjectSessionReviews: (
+  selectProjectSessionReviewSnapshot: (
     _reviewsBySession: Record<string, never[]>,
     projectId: string | undefined,
     sessionId: string
-  ) => mocks.getReviewsForSession(sessionId, projectId),
-  useReviewStore: <T,>(selector: (state: { reviewsBySession: Record<string, never[]> }) => T): T =>
-    selector({ reviewsBySession: {} })
+  ) => mocks.getReviewSnapshot(sessionId, projectId),
+  selectProjectSessionReviewLoadError: () => mocks.loadError,
+  useReviewStore: <T,>(
+    selector: (state: {
+      reviewsBySession: Record<string, never[]>
+      loadErrorsBySession: Record<string, string>
+      loadReviewsForSession: () => Promise<void>
+    }) => T
+  ): T =>
+    selector({
+      reviewsBySession: {},
+      loadErrorsBySession: {},
+      loadReviewsForSession: mocks.loadReviewsForSession
+    })
 }))
 vi.mock('../NotebookPreview', () => ({
   NotebookPreview: ({ item }: { item: PreviewToolItem }): React.JSX.Element => (
@@ -59,7 +76,9 @@ const render = (item: PreviewToolItem): string =>
 describe('PreviewToolContent', () => {
   beforeEach(() => {
     mocks.activeProjectId = 'project-1'
-    mocks.getReviewsForSession.mockReturnValue([])
+    mocks.getReviewSnapshot.mockReturnValue([])
+    mocks.loadError = undefined
+    mocks.loadReviewsForSession.mockReset().mockResolvedValue(undefined)
   })
 
   it('routes project file tools through a project-scoped remount boundary', () => {
@@ -69,12 +88,78 @@ describe('PreviewToolContent', () => {
   it('shows the reviewer empty state when the requested session has no reviews', () => {
     const html = render(createItem({ toolKind: 'reviewer', reviewerSessionId: 'review-session' }))
 
-    expect(mocks.getReviewsForSession).toHaveBeenCalledWith('review-session', 'project-1')
+    expect(mocks.getReviewSnapshot).toHaveBeenCalledWith('review-session', 'project-1')
     expect(html).toContain('No review available for this session.')
   })
 
+  it('does not report a missing review before the artifact source session is loaded', () => {
+    mocks.getReviewSnapshot.mockReturnValue(undefined)
+
+    const html = render(
+      createItem({
+        toolKind: 'reviewer',
+        reviewerSessionId: 'artifact-source-session',
+        reviewerReviewId: 'review-from-artifact-provenance'
+      })
+    )
+
+    expect(html).toContain('Loading review history…')
+    expect(html).not.toContain('No review available for this session.')
+  })
+
+  it('loads review history for the artifact source session', async () => {
+    mocks.getReviewSnapshot.mockReturnValue(undefined)
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(
+        <PreviewToolContent
+          item={createItem({
+            toolKind: 'reviewer',
+            reviewerSessionId: 'artifact-source-session',
+            reviewerReviewId: 'review-from-artifact-provenance'
+          })}
+        />
+      )
+    })
+
+    expect(mocks.loadReviewsForSession).toHaveBeenCalledWith('artifact-source-session', 'project-1')
+
+    act(() => root.unmount())
+  })
+
+  it('shows a working retry action when the artifact source review history fails to load', async () => {
+    mocks.getReviewSnapshot.mockReturnValue(undefined)
+    mocks.loadError = 'read failed'
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(
+        <PreviewToolContent
+          item={createItem({
+            toolKind: 'reviewer',
+            reviewerSessionId: 'artifact-source-session',
+            reviewerReviewId: 'review-from-artifact-provenance'
+          })}
+        />
+      )
+    })
+
+    expect(container.textContent).toContain('Could not load review history.')
+    expect(container.textContent).not.toContain('No review available for this session.')
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('button')?.click()
+    })
+    expect(mocks.loadReviewsForSession).toHaveBeenCalledWith('artifact-source-session', 'project-1')
+
+    act(() => root.unmount())
+  })
+
   it('selects the requested review and forwards the active finding', () => {
-    mocks.getReviewsForSession.mockReturnValue([{ id: 'older' }, { id: 'target' }])
+    mocks.getReviewSnapshot.mockReturnValue([{ id: 'older' }, { id: 'target' }])
 
     const html = render(
       createItem({

--- a/src/renderer/src/pages/workspace/previews/PreviewToolContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewToolContent.test.tsx
@@ -22,18 +22,24 @@ vi.mock('@/stores/review-store', () => ({
   selectProjectSessionReviewSnapshot: (
     _reviewsBySession: Record<string, never[]>,
     projectId: string | undefined,
-    sessionId: string
-  ) => mocks.getReviewSnapshot(sessionId, projectId),
+    sessionId: string,
+    loadedReviewSessions: Record<string, boolean>
+  ) => {
+    void loadedReviewSessions
+    return mocks.getReviewSnapshot(sessionId, projectId)
+  },
   selectProjectSessionReviewLoadError: () => mocks.loadError,
   useReviewStore: <T,>(
     selector: (state: {
       reviewsBySession: Record<string, never[]>
+      loadedReviewSessions: Record<string, boolean>
       loadErrorsBySession: Record<string, string>
       loadReviewsForSession: () => Promise<void>
     }) => T
   ): T =>
     selector({
       reviewsBySession: {},
+      loadedReviewSessions: {},
       loadErrorsBySession: {},
       loadReviewsForSession: mocks.loadReviewsForSession
     })

--- a/src/renderer/src/pages/workspace/previews/PreviewToolContent.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewToolContent.tsx
@@ -1,6 +1,13 @@
+import { LoaderCircle } from 'lucide-react'
+import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { selectProjectSessionReviews, useReviewStore } from '@/stores/review-store'
+import { Button } from '@/components/ui/button'
+import {
+  selectProjectSessionReviewLoadError,
+  selectProjectSessionReviewSnapshot,
+  useReviewStore
+} from '@/stores/review-store'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { type PreviewToolItem, usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
 import { useSessionStore } from '@/stores/session-store'
@@ -28,11 +35,58 @@ const SessionReviewerContent = ({
   const { t } = useTranslation()
   const sessionId = item.reviewerSessionId ?? ''
   const reviews = useReviewStore((state) =>
-    selectProjectSessionReviews(state.reviewsBySession, projectId, sessionId)
+    selectProjectSessionReviewSnapshot(state.reviewsBySession, projectId, sessionId)
   )
+  const loadError = useReviewStore((state) =>
+    selectProjectSessionReviewLoadError(state.loadErrorsBySession, projectId, sessionId)
+  )
+  const loadReviewsForSession = useReviewStore((state) => state.loadReviewsForSession)
+
+  useEffect(() => {
+    if (!sessionId || reviews !== undefined || loadError) return
+    void loadReviewsForSession(sessionId, projectId)
+  }, [loadError, loadReviewsForSession, projectId, reviews, sessionId])
+
+  if (sessionId && reviews === undefined) {
+    if (loadError) {
+      return (
+        <div className="flex size-full items-center justify-center px-6 py-8">
+          <div role="alert" className="text-center">
+            <p className="text-[12px] text-danger-000">{t('Could not load review history.')}</p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-3"
+              onClick={() => void loadReviewsForSession(sessionId, projectId)}
+            >
+              {t('Retry')}
+            </Button>
+          </div>
+        </div>
+      )
+    }
+
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex size-full items-center justify-center gap-2 text-[12px] text-text-300"
+      >
+        <LoaderCircle
+          className="size-4 animate-spin motion-reduce:animate-none"
+          aria-hidden="true"
+        />
+        {t('Loading review history…')}
+      </div>
+    )
+  }
+
+  const loadedReviews = reviews ?? []
   // Select the review the finding actually points at; fall back to the newest when the item carries
   // no reviewId (e.g. a session-level entry point) or that review is gone.
-  const review = reviews.find((r) => r.id === item.reviewerReviewId) ?? reviews[0]
+  const review =
+    loadedReviews.find((candidate) => candidate.id === item.reviewerReviewId) ?? loadedReviews[0]
 
   if (!review) {
     return (

--- a/src/renderer/src/pages/workspace/previews/PreviewToolContent.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewToolContent.tsx
@@ -35,7 +35,12 @@ const SessionReviewerContent = ({
   const { t } = useTranslation()
   const sessionId = item.reviewerSessionId ?? ''
   const reviews = useReviewStore((state) =>
-    selectProjectSessionReviewSnapshot(state.reviewsBySession, projectId, sessionId)
+    selectProjectSessionReviewSnapshot(
+      state.reviewsBySession,
+      projectId,
+      sessionId,
+      state.loadedReviewSessions
+    )
   )
   const loadError = useReviewStore((state) =>
     selectProjectSessionReviewLoadError(state.loadErrorsBySession, projectId, sessionId)

--- a/src/renderer/src/stores/review-store.test.ts
+++ b/src/renderer/src/stores/review-store.test.ts
@@ -3,8 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReviewCheck, ReviewWithChecks, TurnScope } from '../../../shared/reviewer'
 import {
   createInitialReviewState,
-  selectReviewRunsForMessage,
   selectProjectSessionReviewLoadError,
+  selectProjectSessionReviewSnapshot,
+  selectReviewRunsForMessage,
   useReviewStore
 } from './review-store'
 
@@ -105,6 +106,13 @@ describe('review store', () => {
   it('starts empty and returns [] for an unknown session', () => {
     expect(useReviewStore.getState().reviewsBySession).toEqual({})
     expect(useReviewStore.getState().getReviewsForSession('missing')).toEqual([])
+  })
+
+  it('distinguishes an unloaded session from a loaded empty review snapshot', () => {
+    expect(selectProjectSessionReviewSnapshot({}, 'project-1', 'session-1')).toBeUndefined()
+    expect(
+      selectProjectSessionReviewSnapshot({ 'project-1\0session-1': [] }, 'project-1', 'session-1')
+    ).toEqual([])
   })
 
   it('stores a pushed review under its session id', () => {

--- a/src/renderer/src/stores/review-store.test.ts
+++ b/src/renderer/src/stores/review-store.test.ts
@@ -109,9 +109,11 @@ describe('review store', () => {
   })
 
   it('distinguishes an unloaded session from a loaded empty review snapshot', () => {
-    expect(selectProjectSessionReviewSnapshot({}, 'project-1', 'session-1')).toBeUndefined()
+    expect(selectProjectSessionReviewSnapshot({}, 'project-1', 'session-1', {})).toBeUndefined()
     expect(
-      selectProjectSessionReviewSnapshot({ 'project-1\0session-1': [] }, 'project-1', 'session-1')
+      selectProjectSessionReviewSnapshot({ 'project-1\0session-1': [] }, 'project-1', 'session-1', {
+        'project-1\0session-1': true
+      })
     ).toEqual([])
   })
 
@@ -122,6 +124,38 @@ describe('review store', () => {
     const stored = useReviewStore.getState().getReviewsForSession('session-1')
     expect(stored).toHaveLength(1)
     expect(stored[0]).toBe(review)
+  })
+
+  it('keeps push-only reviews provisional until persisted history loads', async () => {
+    const pushed = makeReview({ id: 'pushed-newest', createdAt: 2_000, updatedAt: 2_000 })
+    useReviewStore.getState().handleReviewUpdate({ review: pushed })
+
+    const pushOnlyState = useReviewStore.getState()
+    expect(
+      selectProjectSessionReviewSnapshot(
+        pushOnlyState.reviewsBySession,
+        'project-1',
+        'session-1',
+        pushOnlyState.loadedReviewSessions
+      )
+    ).toBeUndefined()
+
+    const persisted = makeReview({ id: 'persisted-older', createdAt: 1_000, updatedAt: 1_000 })
+    const getForSession = vi.fn().mockResolvedValue([persisted])
+    vi.stubGlobal('window', { api: { reviewer: { getForSession } } })
+
+    await useReviewStore.getState().loadReviewsForSession('session-1', 'project-1')
+
+    const loadedState = useReviewStore.getState()
+    expect(
+      selectProjectSessionReviewSnapshot(
+        loadedState.reviewsBySession,
+        'project-1',
+        'session-1',
+        loadedState.loadedReviewSessions
+      )?.map((review) => review.id)
+    ).toEqual(['pushed-newest', 'persisted-older'])
+    vi.unstubAllGlobals()
   })
 
   it('replaces a review with the same id instead of appending a duplicate', () => {

--- a/src/renderer/src/stores/review-store.ts
+++ b/src/renderer/src/stores/review-store.ts
@@ -8,6 +8,8 @@ import type { ReviewWithChecks, ReviewUpdateEvent } from '../../../shared/review
 type ReviewStoreData = {
   // Map from projectId + sessionId to that session's reviews (newest first).
   reviewsBySession: Record<string, ReviewWithChecks[]>
+  // Successful history loads, tracked separately because a push can create a provisional review list.
+  loadedReviewSessions: Record<string, boolean>
   loadErrorsBySession: Record<string, string>
 }
 
@@ -75,6 +77,7 @@ const mergeLoadedReviews = (
 
 export const createInitialReviewState = (): ReviewStoreData => ({
   reviewsBySession: {},
+  loadedReviewSessions: {},
   loadErrorsBySession: {}
 })
 
@@ -94,18 +97,21 @@ export const selectProjectSessionReviews = (
   sessionId: string | undefined
 ): ReviewWithChecks[] => {
   if (!sessionId) return EMPTY_REVIEWS
-  return selectProjectSessionReviewSnapshot(reviewsBySession, projectId, sessionId) ?? EMPTY_REVIEWS
+  return reviewsBySession[reviewSessionKey(projectId ?? '', sessionId)] ?? EMPTY_REVIEWS
 }
 
 // Unlike selectProjectSessionReviews, this preserves the distinction between a Session that has
-// loaded an empty review snapshot and one that has not loaded at all.
+// loaded an empty review snapshot and one that only has provisional reviews delivered by a push.
 export const selectProjectSessionReviewSnapshot = (
   reviewsBySession: Record<string, ReviewWithChecks[]>,
   projectId: string | undefined,
-  sessionId: string | undefined
+  sessionId: string | undefined,
+  loadedReviewSessions: Record<string, boolean>
 ): ReviewWithChecks[] | undefined => {
   if (!sessionId) return undefined
-  return reviewsBySession[reviewSessionKey(projectId ?? '', sessionId)]
+  const key = reviewSessionKey(projectId ?? '', sessionId)
+  if (loadedReviewSessions[key] !== true) return undefined
+  return reviewsBySession[key] ?? EMPTY_REVIEWS
 }
 
 export const selectProjectSessionReviewLoadError = (
@@ -167,6 +173,10 @@ export const useReviewStore = create<ReviewStore>((set, get) => ({
           reviewsBySession: {
             ...state.reviewsBySession,
             [key]: mergeLoadedReviews(state.reviewsBySession[key] ?? [], reviews)
+          },
+          loadedReviewSessions: {
+            ...state.loadedReviewSessions,
+            [key]: true
           },
           loadErrorsBySession
         }

--- a/src/renderer/src/stores/review-store.ts
+++ b/src/renderer/src/stores/review-store.ts
@@ -94,7 +94,18 @@ export const selectProjectSessionReviews = (
   sessionId: string | undefined
 ): ReviewWithChecks[] => {
   if (!sessionId) return EMPTY_REVIEWS
-  return reviewsBySession[reviewSessionKey(projectId ?? '', sessionId)] ?? EMPTY_REVIEWS
+  return selectProjectSessionReviewSnapshot(reviewsBySession, projectId, sessionId) ?? EMPTY_REVIEWS
+}
+
+// Unlike selectProjectSessionReviews, this preserves the distinction between a Session that has
+// loaded an empty review snapshot and one that has not loaded at all.
+export const selectProjectSessionReviewSnapshot = (
+  reviewsBySession: Record<string, ReviewWithChecks[]>,
+  projectId: string | undefined,
+  sessionId: string | undefined
+): ReviewWithChecks[] | undefined => {
+  if (!sessionId) return undefined
+  return reviewsBySession[reviewSessionKey(projectId ?? '', sessionId)]
 }
 
 export const selectProjectSessionReviewLoadError = (


### PR DESCRIPTION
## Problem

Reviewer history is hydrated by the active Session's message scroller. Opening an Artifact from another Session can therefore reach a reviewer preview before that source Session has loaded. The renderer previously collapsed an absent Project + Session snapshot and a loaded empty snapshot to the same empty array, so the preview incorrectly reported that no Review was available.

## Proposed change

- Preserve the distinction between an unloaded review snapshot and a loaded empty snapshot.
- Let the reviewer preview load the target Artifact source Session on demand.
- Render a localized loading state while that snapshot is unavailable.
- Render the existing load failure message with a Retry action when loading fails.
- Keep the existing empty state after a successful load genuinely returns no reviews.

## Scope and non-goals

- No database, Prisma schema, migration, or persisted data changes.
- No IPC contract changes; this reuses the existing reviewer Session read API.
- No Review, Artifact, Session, or preview item model changes.
- No new status enum values.
- No historical-data migration is required.

## Acceptance criteria and validation

Checks below ran after the last material production edit. The focused suite and lint were rerun after the final test-only edit.

- Unloaded source Session no longer renders the empty state -> `npm test -- src/renderer/src/pages/workspace/previews/PreviewToolContent.test.tsx src/renderer/src/stores/review-store.test.ts src/renderer/src/i18n/resources.test.ts` -> 3 files, 92 tests passed.
- Review store and reviewer consumer contract -> `npm run test:module -- reviewer_orchestrator` test set, executed directly from `scripts/ci/module-impact.json` because the Windows launcher returned `spawnSync npm.cmd EINVAL` -> 27 files, 453 tests passed.
- Workspace preview consumers -> `npm run test:module -- workspace_page` test set, executed directly from `scripts/ci/module-impact.json` for the same Windows launcher limitation -> 25 files, 445 tests passed.
- Renderer type safety -> `npm run typecheck:web` -> passed.
- Source and test lint -> `npm run lint` -> passed with no warnings.

The complete portable and platform suites remain authoritative in PR CI; a full local `npm test` was intentionally not run.

## Review focus

- Confirm that map-key absence is the correct existing signal for an unloaded Session snapshot.
- Confirm that loading and retry remain owned by the reviewer preview rather than Artifact provenance or the persisted preview model.
