### PR TITLE
fix(local-fs): snapshot read-only Agent file references

### DIFF
--- a/src/main/acp/connection-close-workflow.test.ts
+++ b/src/main/acp/connection-close-workflow.test.ts
@@ -8,6 +8,7 @@ type TestHarness = {
   workflow: AcpConnectionCloseWorkflow
   actions: string[]
   generation: () => number
+  advanceGeneration: () => void
   state: Record<string, ReturnType<typeof vi.fn>>
   resources: Record<string, ReturnType<typeof vi.fn>>
   transitions: Record<string, ReturnType<typeof vi.fn>>
@@ -95,6 +96,9 @@ const createWorkflow = (overrides: Record<string, unknown> = {}): TestHarness =>
     workflow,
     actions,
     generation: () => generation,
+    advanceGeneration: () => {
+      generation += 1
+    },
     state,
     resources,
     transitions,
@@ -112,6 +116,7 @@ describe('AcpConnectionCloseWorkflow', () => {
     expect(resources.supersede).toHaveBeenCalledOnce()
     expect(resources.teardown).toHaveBeenCalledOnce()
     expect(resources.closeMcp).toHaveBeenCalledOnce()
+    expect(state.clearPromptContent).toHaveBeenCalledWith(2)
     expect(state.cancelPendingStatePublication).toHaveBeenCalledOnce()
     expect(actions).toEqual([
       'model-cancel',
@@ -157,6 +162,7 @@ describe('AcpConnectionCloseWorkflow', () => {
     workflow.handleUnexpectedClose()
 
     expect(resources.cleanupUnexpectedClose).toHaveBeenCalledOnce()
+    expect(state.clearPromptContent).toHaveBeenCalledWith(2)
     expect(state.settleActivePrompts).toHaveBeenCalledOnce()
     expect(state.publishInterruptedPromptFailures).toHaveBeenCalledWith(['prompt'])
     expect(transitions.resetReconnect).toHaveBeenCalledOnce()
@@ -211,12 +217,42 @@ describe('AcpConnectionCloseWorkflow', () => {
     expect(state.cancelPendingStatePublication).toHaveBeenCalledOnce()
   })
 
-  it('clears prompt snapshots after recovering a failed deferred disconnect', async () => {
-    const { workflow, state } = createWorkflow()
+  it('clears only the disconnected generation after recovering a failed deferred disconnect', async () => {
+    let finishTeardown: (() => void) | undefined
+    const { workflow, state, resources, advanceGeneration } = createWorkflow()
+    resources.teardown.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishTeardown = resolve
+        })
+    )
 
     workflow.recoverFailedDeferredDisconnect()
+    await vi.waitFor(() => expect(resources.teardown).toHaveBeenCalledOnce())
+    advanceGeneration()
+    finishTeardown?.()
 
     await vi.waitFor(() => expect(state.clearPromptContent).toHaveBeenCalledOnce())
+    expect(state.clearPromptContent).toHaveBeenCalledWith(2)
+  })
+
+  it('keeps successor prompt snapshots outside an older disconnect cleanup scope', async () => {
+    let finishTeardown: (() => void) | undefined
+    const { workflow, state, resources, advanceGeneration } = createWorkflow()
+    resources.teardown.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishTeardown = resolve
+        })
+    )
+
+    const disconnect = workflow.disconnect()
+    await vi.waitFor(() => expect(resources.teardown).toHaveBeenCalledOnce())
+    advanceGeneration()
+    finishTeardown?.()
+    await disconnect
+
+    expect(state.clearPromptContent).toHaveBeenCalledWith(2)
   })
 
   it('clears usage before deferring provider reconnect and delegates intent ownership', async () => {

--- a/src/main/acp/connection-close-workflow.test.ts
+++ b/src/main/acp/connection-close-workflow.test.ts
@@ -127,10 +127,10 @@ describe('AcpConnectionCloseWorkflow', () => {
       'capabilities',
       'sessions',
       'detach',
-      'prompt-content',
       'projection-clear',
       'routes',
       'select',
+      'prompt-content',
       'closed',
       'backend:2',
       'publication-cancel'
@@ -207,7 +207,16 @@ describe('AcpConnectionCloseWorkflow', () => {
     workflow.shutdown()
 
     expect(state.clearPlanInteractions).toHaveBeenCalledOnce()
+    expect(state.clearPromptContent).toHaveBeenCalledOnce()
     expect(state.cancelPendingStatePublication).toHaveBeenCalledOnce()
+  })
+
+  it('clears prompt snapshots after recovering a failed deferred disconnect', async () => {
+    const { workflow, state } = createWorkflow()
+
+    workflow.recoverFailedDeferredDisconnect()
+
+    await vi.waitFor(() => expect(state.clearPromptContent).toHaveBeenCalledOnce())
   })
 
   it('clears usage before deferring provider reconnect and delegates intent ownership', async () => {

--- a/src/main/acp/connection-close-workflow.test.ts
+++ b/src/main/acp/connection-close-workflow.test.ts
@@ -227,7 +227,7 @@ describe('AcpConnectionCloseWorkflow', () => {
         })
     )
 
-    workflow.recoverFailedDeferredDisconnect()
+    workflow.recoverFailedDeferredDisconnect(2)
     await vi.waitFor(() => expect(resources.teardown).toHaveBeenCalledOnce())
     advanceGeneration()
     finishTeardown?.()

--- a/src/main/acp/connection-close-workflow.ts
+++ b/src/main/acp/connection-close-workflow.ts
@@ -210,14 +210,14 @@ class AcpConnectionCloseWorkflow {
     await this.options.modelChanges.cancelAndDrain()
     await this.options.transitions.requestRetirement()
   }
-  recoverFailedDeferredDisconnect(): void {
+  recoverFailedDeferredDisconnect(disconnectedGeneration: number): void {
     const teardownGeneration = this.options.resources.supersede()
     this.options.backendGeneration.supersede(teardownGeneration - 1)
     void this.options.resources
       .teardown(teardownGeneration, (stage, error) => {
         this.reportFailure(`${stage} cleanup after failed deferred disconnect failed`, error)
       })
-      .finally(() => this.options.state.clearPromptContent(teardownGeneration - 1))
+      .finally(() => this.options.state.clearPromptContent(disconnectedGeneration))
     this.options.state.transitionStatus('closed')
     try {
       this.options.state.emitState()

--- a/src/main/acp/connection-close-workflow.ts
+++ b/src/main/acp/connection-close-workflow.ts
@@ -120,11 +120,11 @@ class AcpConnectionCloseWorkflow {
     this.options.state.disposeSessionCapabilities(activeSessionIds)
     this.options.state.disposeActiveSessions((stage, error) => recordFailure(stage, error))
     this.options.state.detachSessionConnections(true)
-    this.options.state.clearPromptContent()
     this.options.state.clearSessionProjection()
     runCleanup('MCP HTTP routes', this.options.state.clearHttpRoutes)
     this.options.state.selectSession()
     await this.options.resources.teardown(teardownGeneration, recordFailure)
+    this.options.state.clearPromptContent()
     if (emitClosedStatus && teardownGeneration === this.options.currentGeneration()) {
       runCleanup('closed-status', () => this.options.state.setStatus('closed'))
     }
@@ -178,6 +178,7 @@ class AcpConnectionCloseWorkflow {
     })
     this.options.transitions.resetReconnect()
     this.options.state.clearPlanInteractions()
+    this.options.state.clearPromptContent()
     this.options.state.clearSessionProjection()
     this.options.state.clearContextUsage()
     this.options.state.clearAppliedSessionModels()
@@ -212,9 +213,11 @@ class AcpConnectionCloseWorkflow {
   recoverFailedDeferredDisconnect(): void {
     const teardownGeneration = this.options.resources.supersede()
     this.options.backendGeneration.supersede(teardownGeneration - 1)
-    void this.options.resources.teardown(teardownGeneration, (stage, error) => {
-      this.reportFailure(`${stage} cleanup after failed deferred disconnect failed`, error)
-    })
+    void this.options.resources
+      .teardown(teardownGeneration, (stage, error) => {
+        this.reportFailure(`${stage} cleanup after failed deferred disconnect failed`, error)
+      })
+      .finally(() => this.options.state.clearPromptContent())
     this.options.state.transitionStatus('closed')
     try {
       this.options.state.emitState()

--- a/src/main/acp/connection-close-workflow.ts
+++ b/src/main/acp/connection-close-workflow.ts
@@ -22,7 +22,7 @@ type CloseState = Readonly<{
   disposeSessionCapabilities: (sessionIds: string[]) => void
   disposeActiveSessions: (recordFailure: CleanupFailure) => void
   detachSessionConnections: (clearPermissionProfile: boolean) => void
-  clearPromptContent: () => void
+  clearPromptContent: (connectionGeneration?: number) => void
   clearHandoffContinuity: () => void
   clearSessionProjection: () => void
   disposeSessionProjection: () => void
@@ -124,7 +124,7 @@ class AcpConnectionCloseWorkflow {
     runCleanup('MCP HTTP routes', this.options.state.clearHttpRoutes)
     this.options.state.selectSession()
     await this.options.resources.teardown(teardownGeneration, recordFailure)
-    this.options.state.clearPromptContent()
+    this.options.state.clearPromptContent(teardownGeneration - 1)
     if (emitClosedStatus && teardownGeneration === this.options.currentGeneration()) {
       runCleanup('closed-status', () => this.options.state.setStatus('closed'))
     }
@@ -153,7 +153,7 @@ class AcpConnectionCloseWorkflow {
     this.options.backendGeneration.supersede(teardownGeneration)
     this.options.state.disposeSessionCapabilities(this.options.state.activeSessionIds())
     this.options.state.detachSessionConnections(false)
-    this.options.state.clearPromptContent()
+    this.options.state.clearPromptContent(teardownGeneration)
     this.options.state.clearHandoffContinuity()
     this.options.state.disposeSessionProjection()
     this.options.state.clearContextUsage()
@@ -217,7 +217,7 @@ class AcpConnectionCloseWorkflow {
       .teardown(teardownGeneration, (stage, error) => {
         this.reportFailure(`${stage} cleanup after failed deferred disconnect failed`, error)
       })
-      .finally(() => this.options.state.clearPromptContent())
+      .finally(() => this.options.state.clearPromptContent(teardownGeneration - 1))
     this.options.state.transitionStatus('closed')
     try {
       this.options.state.emitState()

--- a/src/main/acp/connection-transition-owner.test.ts
+++ b/src/main/acp/connection-transition-owner.test.ts
@@ -97,13 +97,15 @@ describe('AcpConnectionTransitionOwner', () => {
 
   it('recovers a failed deferred disconnect and always releases its barrier', async () => {
     let blocked = true
+    let connectionGeneration = 1
     const disconnectFailure = new Error('disconnect failed')
     const recoverFailedDeferredDisconnect = vi.fn(async () => undefined)
     const reportFailure = vi.fn()
     const owner = new AcpConnectionTransitionOwner({
       blockers: () => ({ reconnect: blocked, retirement: blocked }),
-      connectionGeneration: () => 1,
+      connectionGeneration: () => connectionGeneration,
       disconnect: vi.fn(async () => {
+        connectionGeneration += 1
         throw disconnectFailure
       }),
       onRetired: vi.fn(),
@@ -118,7 +120,7 @@ describe('AcpConnectionTransitionOwner', () => {
     await vi.waitFor(() => expect(owner.barrier).toBeUndefined())
 
     expect(recoverFailedDeferredDisconnect).toHaveBeenCalledOnce()
-    expect(recoverFailedDeferredDisconnect).toHaveBeenCalledWith(disconnectFailure)
+    expect(recoverFailedDeferredDisconnect).toHaveBeenCalledWith(disconnectFailure, 1)
     expect(reportFailure).toHaveBeenCalledWith(
       'deferred reconnect disconnect failed',
       disconnectFailure

--- a/src/main/acp/connection-transition-owner.ts
+++ b/src/main/acp/connection-transition-owner.ts
@@ -9,7 +9,10 @@ type AcpConnectionTransitionOwnerOptions = Readonly<{
   disconnect: (emitClosedStatus: boolean) => Promise<unknown>
   onRetired: () => void
   publishIdle: () => void
-  recoverFailedDeferredDisconnect: (error: unknown) => void | Promise<void>
+  recoverFailedDeferredDisconnect: (
+    error: unknown,
+    disconnectedGeneration: number
+  ) => void | Promise<void>
   reportFailure: (message: string, error: unknown) => void
 }>
 
@@ -88,12 +91,13 @@ export class AcpConnectionTransitionOwner {
 
   private async disconnectDeferred(): Promise<void> {
     const expectedBarrierGeneration = this.barrierGeneration
+    const disconnectedGeneration = this.options.connectionGeneration()
     try {
       await this.disconnectPlanned()
     } catch (error) {
       this.reportFailure('deferred reconnect disconnect failed', error)
       try {
-        await this.options.recoverFailedDeferredDisconnect(error)
+        await this.options.recoverFailedDeferredDisconnect(error, disconnectedGeneration)
       } catch (recoveryError) {
         this.reportFailure('failed deferred reconnect recovery failed', recoveryError)
       }

--- a/src/main/acp/file-reference-resolver.test.ts
+++ b/src/main/acp/file-reference-resolver.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -190,7 +190,10 @@ describe('managed file reference resolver', () => {
     await mkdir(join(root, 'data'))
     await writeFile(join(root, 'data', 'study.csv'), 'id,value\n1,2\n')
     const resolver = createManagedFileReferenceResolver({
-      grantedRoots: { resolveRootPath: async (rootId) => (rootId === 'root-1' ? root : undefined) }
+      grantedRoots: {
+        resolveRoot: async (rootId) =>
+          rootId === 'root-1' ? { path: root!, access: 'rw' } : undefined
+      }
     })
 
     const resolved = await resolver.resolve(
@@ -214,10 +217,38 @@ describe('managed file reference resolver', () => {
     expect(resolved.uri).toMatch(/^file:/u)
   })
 
+  it('does not expose a read-only linked-folder source path to the Agent', async () => {
+    root = await mkdtemp(join(tmpdir(), 'file-reference-resolver-'))
+    const sourcePath = join(root, 'study.csv')
+    await writeFile(sourcePath, 'id,value\n1,2\n')
+    const resolver = createManagedFileReferenceResolver({
+      grantedRoots: { resolveRoot: async () => ({ path: root!, access: 'ro' }) }
+    })
+
+    const resolved = await resolver.resolve(
+      { projectId: 'default-project', sessionId: 'session-1' },
+      {
+        id: 'linked-1',
+        name: 'study.csv',
+        source: 'linked-folder',
+        rootId: 'root-1',
+        relativePath: 'study.csv',
+        mimeType: 'text/csv'
+      }
+    )
+
+    expect(resolved.absolutePath).not.toBe(await realpath(sourcePath))
+    expect(await readFile(resolved.absolutePath, 'utf8')).toBe('id,value\n1,2\n')
+    resolver.resetSession('session-1')
+    await vi.waitFor(async () => {
+      await expect(stat(resolved.absolutePath)).rejects.toMatchObject({ code: 'ENOENT' })
+    })
+  })
+
   it('rejects a linked-folder reference with an unknown root id', async () => {
     root = await mkdtemp(join(tmpdir(), 'file-reference-resolver-'))
     const resolver = createManagedFileReferenceResolver({
-      grantedRoots: { resolveRootPath: async () => undefined }
+      grantedRoots: { resolveRoot: async () => undefined }
     })
 
     await expect(
@@ -240,7 +271,7 @@ describe('managed file reference resolver', () => {
     await mkdir(granted)
     await writeFile(join(root, 'secret.txt'), 'outside\n')
     const resolver = createManagedFileReferenceResolver({
-      grantedRoots: { resolveRootPath: async () => granted }
+      grantedRoots: { resolveRoot: async () => ({ path: granted, access: 'ro' }) }
     })
 
     await expect(
@@ -264,7 +295,7 @@ describe('managed file reference resolver', () => {
     await writeFile(join(root, 'secret.txt'), 'outside\n')
     await symlink(join(root, 'secret.txt'), join(granted, 'leak.txt'))
     const resolver = createManagedFileReferenceResolver({
-      grantedRoots: { resolveRootPath: async () => granted }
+      grantedRoots: { resolveRoot: async () => ({ path: granted, access: 'ro' }) }
     })
 
     await expect(

--- a/src/main/acp/file-reference-resolver.test.ts
+++ b/src/main/acp/file-reference-resolver.test.ts
@@ -245,6 +245,57 @@ describe('managed file reference resolver', () => {
     })
   })
 
+  it('removes every read-only snapshot synchronously during terminal cleanup', async () => {
+    root = await mkdtemp(join(tmpdir(), 'file-reference-resolver-'))
+    await writeFile(join(root, 'study.csv'), 'data\n')
+    const resolver = createManagedFileReferenceResolver({
+      grantedRoots: { resolveRoot: async () => ({ path: root!, access: 'ro' }) }
+    })
+    const resolved = await resolver.resolve(
+      { projectId: 'default-project', sessionId: 'session-1' },
+      {
+        id: 'linked-1',
+        name: 'study.csv',
+        source: 'linked-folder',
+        rootId: 'root-1',
+        relativePath: 'study.csv'
+      }
+    )
+
+    resolver.clear()
+
+    await expect(stat(resolved.absolutePath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('bounds cumulative read-only snapshot storage for a Session', async () => {
+    root = await mkdtemp(join(tmpdir(), 'file-reference-resolver-'))
+    await writeFile(join(root, 'first.txt'), '123')
+    await writeFile(join(root, 'second.txt'), '456')
+    const resolver = createManagedFileReferenceResolver({
+      grantedRoots: { resolveRoot: async () => ({ path: root!, access: 'ro' }) },
+      readOnlyProjectionMaxSessionBytes: 5
+    })
+    const context = { projectId: 'default-project', sessionId: 'session-1' }
+    await resolver.resolve(context, {
+      id: 'linked-1',
+      name: 'first.txt',
+      source: 'linked-folder',
+      rootId: 'root-1',
+      relativePath: 'first.txt'
+    })
+
+    await expect(
+      resolver.resolve(context, {
+        id: 'linked-2',
+        name: 'second.txt',
+        source: 'linked-folder',
+        rootId: 'root-1',
+        relativePath: 'second.txt'
+      })
+    ).rejects.toThrow(/Session storage limit/i)
+    resolver.clear()
+  })
+
   it('rejects a linked-folder reference with an unknown root id', async () => {
     root = await mkdtemp(join(tmpdir(), 'file-reference-resolver-'))
     const resolver = createManagedFileReferenceResolver({

--- a/src/main/acp/file-reference-resolver.test.ts
+++ b/src/main/acp/file-reference-resolver.test.ts
@@ -272,6 +272,35 @@ describe('managed file reference resolver', () => {
     await expect(stat(resolved.absolutePath)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
+  it('clears only snapshots owned by the disconnected connection generation', async () => {
+    root = await mkdtemp(join(tmpdir(), 'file-reference-resolver-'))
+    await writeFile(join(root, 'study.csv'), 'data\n')
+    const resolver = createManagedFileReferenceResolver({
+      grantedRoots: { resolveRoot: async () => ({ path: root!, access: 'ro' }) }
+    })
+    const reference = {
+      id: 'linked-1',
+      name: 'study.csv',
+      source: 'linked-folder' as const,
+      rootId: 'root-1',
+      relativePath: 'study.csv'
+    }
+    const oldSnapshot = await resolver.resolve(
+      { projectId: 'default-project', sessionId: 'session-1', connectionGeneration: 1 },
+      reference
+    )
+    const successorSnapshot = await resolver.resolve(
+      { projectId: 'default-project', sessionId: 'session-1', connectionGeneration: 2 },
+      reference
+    )
+
+    resolver.clearGeneration(1)
+
+    await expect(stat(oldSnapshot.absolutePath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(stat(successorSnapshot.absolutePath)).resolves.toMatchObject({ size: 5 })
+    resolver.clear()
+  })
+
   it('bounds cumulative read-only snapshot storage for a Session', async () => {
     root = await mkdtemp(join(tmpdir(), 'file-reference-resolver-'))
     await writeFile(join(root, 'first.txt'), '123')

--- a/src/main/acp/file-reference-resolver.test.ts
+++ b/src/main/acp/file-reference-resolver.test.ts
@@ -11,6 +11,11 @@ import { UploadRepository } from '../uploads/repository'
 import { stageUploadFixtures } from '../uploads/repository.test-utils'
 import { createManagedFileReferenceResolver } from './file-reference-resolver'
 
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return { ...actual, stat: vi.fn(actual.stat) }
+})
+
 let root: string | undefined
 let disconnect: (() => Promise<void>) | undefined
 
@@ -293,6 +298,36 @@ describe('managed file reference resolver', () => {
         relativePath: 'second.txt'
       })
     ).rejects.toThrow(/Session storage limit/i)
+    resolver.clear()
+  })
+
+  it('bounds the bytes actually copied into a read-only snapshot', async () => {
+    root = await mkdtemp(join(tmpdir(), 'file-reference-resolver-'))
+    const sourcePath = join(root, 'growing.txt')
+    await writeFile(sourcePath, '1234')
+    const resolver = createManagedFileReferenceResolver({
+      grantedRoots: { resolveRoot: async () => ({ path: root!, access: 'ro' }) },
+      readOnlyProjectionMaxSessionBytes: 5
+    })
+    const context = { projectId: 'default-project', sessionId: 'session-1' }
+    const reference = {
+      id: 'linked-1',
+      name: 'growing.txt',
+      source: 'linked-folder' as const,
+      rootId: 'root-1',
+      relativePath: 'growing.txt'
+    }
+    const actualFs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+    vi.mocked(stat).mockImplementationOnce(async (path) => {
+      const beforeGrowth = await actualFs.stat(path)
+      await writeFile(sourcePath, '123456')
+      return beforeGrowth
+    })
+
+    await expect(resolver.resolve(context, reference)).rejects.toThrow(/Session storage limit/i)
+
+    await writeFile(sourcePath, '12345')
+    await expect(resolver.resolve(context, reference)).resolves.toMatchObject({ size: 5 })
     resolver.clear()
   })
 

--- a/src/main/acp/file-reference-resolver.ts
+++ b/src/main/acp/file-reference-resolver.ts
@@ -1,7 +1,9 @@
-import { rmSync } from 'node:fs'
-import { copyFile, mkdtemp, realpath, rm, stat } from 'node:fs/promises'
+import { createReadStream, createWriteStream, rmSync } from 'node:fs'
+import { mkdtemp, realpath, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
+import { Transform } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
 import { pathToFileURL } from 'node:url'
 
 import type { FileReference } from '../../shared/artifacts'
@@ -61,12 +63,11 @@ class ReadOnlyLinkedFileProjection implements FileReferenceResolverLifecycle {
   async materialize(sessionId: string, sourcePath: string, sourceSize: number): Promise<string> {
     const generation = this.generation
     const sessionGeneration = this.sessionGenerations.get(sessionId) ?? 0
-    const reservedBytes = this.bytesBySession.get(sessionId) ?? 0
-    if (sourceSize > this.maxSessionBytes || reservedBytes + sourceSize > this.maxSessionBytes) {
+    const sessionBytes = this.bytesBySession.get(sessionId) ?? 0
+    if (sourceSize > this.maxSessionBytes - sessionBytes) {
       throw new Error('Read-only linked-folder snapshots exceed the Session storage limit.')
     }
-    this.bytesBySession.set(sessionId, reservedBytes + sourceSize)
-
+    let copiedBytes = 0
     let directory: string | undefined
     try {
       directory = await mkdtemp(join(tmpdir(), 'open-science-linked-ro-'))
@@ -81,7 +82,28 @@ class ReadOnlyLinkedFileProjection implements FileReferenceResolverLifecycle {
       directories.add(directory)
 
       const snapshotPath = join(directory, basename(sourcePath))
-      await copyFile(sourcePath, snapshotPath)
+      await pipeline(
+        createReadStream(sourcePath),
+        new Transform({
+          transform: (chunk: Buffer, _encoding, callback) => {
+            if (!this.isCurrent(sessionId, generation, sessionGeneration)) {
+              callback(new Error('Read-only linked-folder projection was superseded.'))
+              return
+            }
+            const sessionBytes = this.bytesBySession.get(sessionId) ?? 0
+            if (sessionBytes + chunk.length > this.maxSessionBytes) {
+              callback(
+                new Error('Read-only linked-folder snapshots exceed the Session storage limit.')
+              )
+              return
+            }
+            copiedBytes += chunk.length
+            this.bytesBySession.set(sessionId, sessionBytes + chunk.length)
+            callback(null, chunk)
+          }
+        }),
+        createWriteStream(snapshotPath, { flags: 'wx' })
+      )
       if (!this.isCurrent(sessionId, generation, sessionGeneration)) {
         throw new Error('Read-only linked-folder projection was superseded.')
       }
@@ -89,7 +111,7 @@ class ReadOnlyLinkedFileProjection implements FileReferenceResolverLifecycle {
     } catch (error) {
       const current = this.isCurrent(sessionId, generation, sessionGeneration)
       if (current) {
-        this.releaseReservation(sessionId, sourceSize)
+        this.releaseReservation(sessionId, copiedBytes)
       }
       if (directory) {
         const directories = this.directoriesBySession.get(sessionId)

--- a/src/main/acp/file-reference-resolver.ts
+++ b/src/main/acp/file-reference-resolver.ts
@@ -21,6 +21,7 @@ const log = createLogger('acp-file-reference-resolver')
 export type FileReferenceContext = {
   projectId: string
   sessionId: string
+  connectionGeneration?: number
 }
 
 export type ResolvedFileReference = {
@@ -44,6 +45,7 @@ export type FileReferenceAdapter = {
 
 type FileReferenceResolverLifecycle = {
   resetSession: (sessionId: string) => void
+  clearGeneration: (connectionGeneration: number) => void
   clear: () => void
 }
 
@@ -54,16 +56,28 @@ type FileReferenceResolverLifecycle = {
 class ReadOnlyLinkedFileProjection implements FileReferenceResolverLifecycle {
   private generation = 0
   private readonly sessionGenerations = new Map<string, number>()
-  private readonly directoriesBySession = new Map<string, Set<string>>()
-  private readonly bytesBySession = new Map<string, number>()
-  private readonly pendingRemovalDirectories = new Set<string>()
+  private readonly connectionGenerations = new Map<number, number>()
+  private readonly directoriesByScope = new Map<string, Set<string>>()
+  private readonly bytesByScope = new Map<string, number>()
+  private readonly scopes = new Map<
+    string,
+    Readonly<{ connectionGeneration: number; sessionId: string }>
+  >()
+  private readonly pendingRemovalDirectories = new Map<string, number>()
 
   constructor(private readonly maxSessionBytes = MAX_UPLOAD_FILE_BYTES) {}
 
-  async materialize(sessionId: string, sourcePath: string, sourceSize: number): Promise<string> {
+  async materialize(
+    connectionGeneration: number,
+    sessionId: string,
+    sourcePath: string,
+    sourceSize: number
+  ): Promise<string> {
     const generation = this.generation
     const sessionGeneration = this.sessionGenerations.get(sessionId) ?? 0
-    const sessionBytes = this.bytesBySession.get(sessionId) ?? 0
+    const connectionProjectionGeneration = this.connectionGenerations.get(connectionGeneration) ?? 0
+    const scopeKey = this.scopeKey(connectionGeneration, sessionId)
+    const sessionBytes = this.bytesByScope.get(scopeKey) ?? 0
     if (sourceSize > this.maxSessionBytes - sessionBytes) {
       throw new Error('Read-only linked-folder snapshots exceed the Session storage limit.')
     }
@@ -71,13 +85,22 @@ class ReadOnlyLinkedFileProjection implements FileReferenceResolverLifecycle {
     let directory: string | undefined
     try {
       directory = await mkdtemp(join(tmpdir(), 'open-science-linked-ro-'))
-      if (!this.isCurrent(sessionId, generation, sessionGeneration)) {
+      if (
+        !this.isCurrent(
+          connectionGeneration,
+          sessionId,
+          generation,
+          connectionProjectionGeneration,
+          sessionGeneration
+        )
+      ) {
         throw new Error('Read-only linked-folder projection was superseded.')
       }
-      let directories = this.directoriesBySession.get(sessionId)
+      this.scopes.set(scopeKey, { connectionGeneration, sessionId })
+      let directories = this.directoriesByScope.get(scopeKey)
       if (!directories) {
         directories = new Set()
-        this.directoriesBySession.set(sessionId, directories)
+        this.directoriesByScope.set(scopeKey, directories)
       }
       directories.add(directory)
 
@@ -86,11 +109,19 @@ class ReadOnlyLinkedFileProjection implements FileReferenceResolverLifecycle {
         createReadStream(sourcePath),
         new Transform({
           transform: (chunk: Buffer, _encoding, callback) => {
-            if (!this.isCurrent(sessionId, generation, sessionGeneration)) {
+            if (
+              !this.isCurrent(
+                connectionGeneration,
+                sessionId,
+                generation,
+                connectionProjectionGeneration,
+                sessionGeneration
+              )
+            ) {
               callback(new Error('Read-only linked-folder projection was superseded.'))
               return
             }
-            const sessionBytes = this.bytesBySession.get(sessionId) ?? 0
+            const sessionBytes = this.bytesByScope.get(scopeKey) ?? 0
             if (sessionBytes + chunk.length > this.maxSessionBytes) {
               callback(
                 new Error('Read-only linked-folder snapshots exceed the Session storage limit.')
@@ -98,64 +129,101 @@ class ReadOnlyLinkedFileProjection implements FileReferenceResolverLifecycle {
               return
             }
             copiedBytes += chunk.length
-            this.bytesBySession.set(sessionId, sessionBytes + chunk.length)
+            this.bytesByScope.set(scopeKey, sessionBytes + chunk.length)
             callback(null, chunk)
           }
         }),
         createWriteStream(snapshotPath, { flags: 'wx' })
       )
-      if (!this.isCurrent(sessionId, generation, sessionGeneration)) {
+      if (
+        !this.isCurrent(
+          connectionGeneration,
+          sessionId,
+          generation,
+          connectionProjectionGeneration,
+          sessionGeneration
+        )
+      ) {
         throw new Error('Read-only linked-folder projection was superseded.')
       }
       return snapshotPath
     } catch (error) {
-      const current = this.isCurrent(sessionId, generation, sessionGeneration)
+      const current = this.isCurrent(
+        connectionGeneration,
+        sessionId,
+        generation,
+        connectionProjectionGeneration,
+        sessionGeneration
+      )
       if (current) {
-        this.releaseReservation(sessionId, copiedBytes)
+        this.releaseReservation(scopeKey, copiedBytes)
       }
       if (directory) {
-        const directories = this.directoriesBySession.get(sessionId)
+        const directories = this.directoriesByScope.get(scopeKey)
         directories?.delete(directory)
-        if (directories?.size === 0) this.directoriesBySession.delete(sessionId)
-        if (current) this.removeDirectory(directory)
+        if (directories?.size === 0) this.directoriesByScope.delete(scopeKey)
+        if (current) this.removeDirectory(directory, connectionGeneration)
         else this.removeDirectorySynchronously(directory)
       }
+      this.deleteScopeIfEmpty(scopeKey)
       throw error
     }
   }
 
   resetSession(sessionId: string): void {
     this.sessionGenerations.set(sessionId, (this.sessionGenerations.get(sessionId) ?? 0) + 1)
-    const directories = this.directoriesBySession.get(sessionId)
-    this.directoriesBySession.delete(sessionId)
-    this.bytesBySession.delete(sessionId)
-    if (directories) {
-      for (const directory of directories) this.removeDirectory(directory)
+    for (const [scopeKey, scope] of this.scopes) {
+      if (scope.sessionId === sessionId) this.removeScope(scopeKey, false)
+    }
+  }
+
+  clearGeneration(connectionGeneration: number): void {
+    this.connectionGenerations.set(
+      connectionGeneration,
+      (this.connectionGenerations.get(connectionGeneration) ?? 0) + 1
+    )
+    for (const [scopeKey, scope] of this.scopes) {
+      if (scope.connectionGeneration === connectionGeneration) this.removeScope(scopeKey, true)
+    }
+    for (const [directory, pendingGeneration] of this.pendingRemovalDirectories) {
+      if (pendingGeneration !== connectionGeneration) continue
+      this.pendingRemovalDirectories.delete(directory)
+      this.removeDirectorySynchronously(directory)
     }
   }
 
   clear(): void {
     this.generation += 1
     this.sessionGenerations.clear()
+    this.connectionGenerations.clear()
     const directories = new Set([
-      ...[...this.directoriesBySession.values()].flatMap((value) => [...value]),
-      ...this.pendingRemovalDirectories
+      ...[...this.directoriesByScope.values()].flatMap((value) => [...value]),
+      ...this.pendingRemovalDirectories.keys()
     ])
-    this.directoriesBySession.clear()
-    this.bytesBySession.clear()
+    this.directoriesByScope.clear()
+    this.bytesByScope.clear()
+    this.scopes.clear()
     this.pendingRemovalDirectories.clear()
     for (const directory of directories) this.removeDirectorySynchronously(directory)
   }
 
-  private isCurrent(sessionId: string, generation: number, sessionGeneration: number): boolean {
+  private isCurrent(
+    connectionGeneration: number,
+    sessionId: string,
+    generation: number,
+    connectionProjectionGeneration: number,
+    sessionGeneration: number
+  ): boolean {
     return (
       this.generation === generation &&
+      (this.connectionGenerations.get(connectionGeneration) ?? 0) ===
+        connectionProjectionGeneration &&
       (this.sessionGenerations.get(sessionId) ?? 0) === sessionGeneration
     )
   }
 
-  private removeDirectory(directory: string): void {
-    this.pendingRemovalDirectories.add(directory)
+  private removeDirectory(directory: string, connectionGeneration: number): void {
+    this.pendingRemovalDirectories.set(directory, connectionGeneration)
     void rm(directory, { recursive: true, force: true })
       .catch((error) => {
         log.warn('read-only linked-folder projection cleanup failed', errorLogFields(error))
@@ -171,10 +239,34 @@ class ReadOnlyLinkedFileProjection implements FileReferenceResolverLifecycle {
     }
   }
 
-  private releaseReservation(sessionId: string, size: number): void {
-    const next = Math.max(0, (this.bytesBySession.get(sessionId) ?? 0) - size)
-    if (next === 0) this.bytesBySession.delete(sessionId)
-    else this.bytesBySession.set(sessionId, next)
+  private removeScope(scopeKey: string, synchronously: boolean): void {
+    const scope = this.scopes.get(scopeKey)
+    if (!scope) return
+    const directories = this.directoriesByScope.get(scopeKey)
+    this.directoriesByScope.delete(scopeKey)
+    this.bytesByScope.delete(scopeKey)
+    this.scopes.delete(scopeKey)
+    if (!directories) return
+    for (const directory of directories) {
+      if (synchronously) this.removeDirectorySynchronously(directory)
+      else this.removeDirectory(directory, scope.connectionGeneration)
+    }
+  }
+
+  private releaseReservation(scopeKey: string, size: number): void {
+    const next = Math.max(0, (this.bytesByScope.get(scopeKey) ?? 0) - size)
+    if (next === 0) this.bytesByScope.delete(scopeKey)
+    else this.bytesByScope.set(scopeKey, next)
+  }
+
+  private deleteScopeIfEmpty(scopeKey: string): void {
+    if (!this.bytesByScope.has(scopeKey) && !this.directoriesByScope.has(scopeKey)) {
+      this.scopes.delete(scopeKey)
+    }
+  }
+
+  private scopeKey(connectionGeneration: number, sessionId: string): string {
+    return `${connectionGeneration}:${sessionId}`
   }
 }
 
@@ -208,6 +300,10 @@ export class FileReferenceResolver {
 
   resetSession(sessionId: string): void {
     this.lifecycle?.resetSession(sessionId)
+  }
+
+  clearGeneration(connectionGeneration: number): void {
+    this.lifecycle?.clearGeneration(connectionGeneration)
   }
 
   clear(): void {
@@ -299,7 +395,7 @@ export const createManagedFileReferenceResolver = (dependencies: {
   if (dependencies.grantedRoots) {
     adapters.push({
       source: 'linked-folder',
-      resolve: async ({ sessionId }, reference) => {
+      resolve: async ({ sessionId, connectionGeneration = 0 }, reference) => {
         if (reference.source !== 'linked-folder') {
           throw new Error('Invalid linked-folder reference.')
         }
@@ -320,7 +416,12 @@ export const createManagedFileReferenceResolver = (dependencies: {
         return {
           absolutePath:
             root.access === 'ro'
-              ? await readOnlyProjection!.materialize(sessionId, resolvedFile, fileInfo.size)
+              ? await readOnlyProjection!.materialize(
+                  connectionGeneration,
+                  sessionId,
+                  resolvedFile,
+                  fileInfo.size
+                )
               : resolvedFile,
           name: reference.name,
           mimeType: reference.mimeType,

--- a/src/main/acp/file-reference-resolver.ts
+++ b/src/main/acp/file-reference-resolver.ts
@@ -1,3 +1,4 @@
+import { rmSync } from 'node:fs'
 import { copyFile, mkdtemp, realpath, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
@@ -7,6 +8,7 @@ import type { FileReference } from '../../shared/artifacts'
 import { parseArtifactVersionLocator } from '../../shared/artifact-provenance'
 import type { GrantedLocalRoot } from '../../shared/local-fs'
 import { isPathWithin } from '../../shared/local-fs'
+import { MAX_UPLOAD_FILE_BYTES } from '../../shared/uploads'
 import type { ArtifactRepository } from '../artifacts/repository'
 import type { ArtifactProvenanceRepository } from '../artifacts/provenance-repository'
 import { createLogger, errorLogFields } from '../logger'
@@ -51,34 +53,51 @@ class ReadOnlyLinkedFileProjection implements FileReferenceResolverLifecycle {
   private generation = 0
   private readonly sessionGenerations = new Map<string, number>()
   private readonly directoriesBySession = new Map<string, Set<string>>()
+  private readonly bytesBySession = new Map<string, number>()
+  private readonly pendingRemovalDirectories = new Set<string>()
 
-  async materialize(sessionId: string, sourcePath: string): Promise<string> {
+  constructor(private readonly maxSessionBytes = MAX_UPLOAD_FILE_BYTES) {}
+
+  async materialize(sessionId: string, sourcePath: string, sourceSize: number): Promise<string> {
     const generation = this.generation
     const sessionGeneration = this.sessionGenerations.get(sessionId) ?? 0
-    const directory = await mkdtemp(join(tmpdir(), 'open-science-linked-ro-'))
-    if (!this.isCurrent(sessionId, generation, sessionGeneration)) {
-      this.removeDirectory(directory)
-      throw new Error('Read-only linked-folder projection was superseded.')
+    const reservedBytes = this.bytesBySession.get(sessionId) ?? 0
+    if (sourceSize > this.maxSessionBytes || reservedBytes + sourceSize > this.maxSessionBytes) {
+      throw new Error('Read-only linked-folder snapshots exceed the Session storage limit.')
     }
+    this.bytesBySession.set(sessionId, reservedBytes + sourceSize)
 
-    let directories = this.directoriesBySession.get(sessionId)
-    if (!directories) {
-      directories = new Set()
-      this.directoriesBySession.set(sessionId, directories)
-    }
-    directories.add(directory)
-
-    const snapshotPath = join(directory, basename(sourcePath))
+    let directory: string | undefined
     try {
+      directory = await mkdtemp(join(tmpdir(), 'open-science-linked-ro-'))
+      if (!this.isCurrent(sessionId, generation, sessionGeneration)) {
+        throw new Error('Read-only linked-folder projection was superseded.')
+      }
+      let directories = this.directoriesBySession.get(sessionId)
+      if (!directories) {
+        directories = new Set()
+        this.directoriesBySession.set(sessionId, directories)
+      }
+      directories.add(directory)
+
+      const snapshotPath = join(directory, basename(sourcePath))
       await copyFile(sourcePath, snapshotPath)
       if (!this.isCurrent(sessionId, generation, sessionGeneration)) {
         throw new Error('Read-only linked-folder projection was superseded.')
       }
       return snapshotPath
     } catch (error) {
-      directories.delete(directory)
-      if (directories.size === 0) this.directoriesBySession.delete(sessionId)
-      this.removeDirectory(directory)
+      const current = this.isCurrent(sessionId, generation, sessionGeneration)
+      if (current) {
+        this.releaseReservation(sessionId, sourceSize)
+      }
+      if (directory) {
+        const directories = this.directoriesBySession.get(sessionId)
+        directories?.delete(directory)
+        if (directories?.size === 0) this.directoriesBySession.delete(sessionId)
+        if (current) this.removeDirectory(directory)
+        else this.removeDirectorySynchronously(directory)
+      }
       throw error
     }
   }
@@ -87,6 +106,7 @@ class ReadOnlyLinkedFileProjection implements FileReferenceResolverLifecycle {
     this.sessionGenerations.set(sessionId, (this.sessionGenerations.get(sessionId) ?? 0) + 1)
     const directories = this.directoriesBySession.get(sessionId)
     this.directoriesBySession.delete(sessionId)
+    this.bytesBySession.delete(sessionId)
     if (directories) {
       for (const directory of directories) this.removeDirectory(directory)
     }
@@ -95,9 +115,14 @@ class ReadOnlyLinkedFileProjection implements FileReferenceResolverLifecycle {
   clear(): void {
     this.generation += 1
     this.sessionGenerations.clear()
-    const directories = [...this.directoriesBySession.values()].flatMap((value) => [...value])
+    const directories = new Set([
+      ...[...this.directoriesBySession.values()].flatMap((value) => [...value]),
+      ...this.pendingRemovalDirectories
+    ])
     this.directoriesBySession.clear()
-    for (const directory of directories) this.removeDirectory(directory)
+    this.bytesBySession.clear()
+    this.pendingRemovalDirectories.clear()
+    for (const directory of directories) this.removeDirectorySynchronously(directory)
   }
 
   private isCurrent(sessionId: string, generation: number, sessionGeneration: number): boolean {
@@ -108,9 +133,26 @@ class ReadOnlyLinkedFileProjection implements FileReferenceResolverLifecycle {
   }
 
   private removeDirectory(directory: string): void {
-    void rm(directory, { recursive: true, force: true }).catch((error) => {
+    this.pendingRemovalDirectories.add(directory)
+    void rm(directory, { recursive: true, force: true })
+      .catch((error) => {
+        log.warn('read-only linked-folder projection cleanup failed', errorLogFields(error))
+      })
+      .finally(() => this.pendingRemovalDirectories.delete(directory))
+  }
+
+  private removeDirectorySynchronously(directory: string): void {
+    try {
+      rmSync(directory, { recursive: true, force: true })
+    } catch (error) {
       log.warn('read-only linked-folder projection cleanup failed', errorLogFields(error))
-    })
+    }
+  }
+
+  private releaseReservation(sessionId: string, size: number): void {
+    const next = Math.max(0, (this.bytesBySession.get(sessionId) ?? 0) - size)
+    if (next === 0) this.bytesBySession.delete(sessionId)
+    else this.bytesBySession.set(sessionId, next)
   }
 }
 
@@ -155,6 +197,7 @@ export const createManagedFileReferenceResolver = (dependencies: {
   uploads?: UploadRepository
   artifacts?: ArtifactRepository
   artifactVersions?: Partial<Pick<ArtifactProvenanceRepository, 'resolveVersionContent'>>
+  readOnlyProjectionMaxSessionBytes?: number
   // Resolves a granted local root id and current access level (settings-backed). Absent ⇒
   // linked-folder references stay unavailable, matching the pre-grant behavior.
   grantedRoots?: {
@@ -163,7 +206,7 @@ export const createManagedFileReferenceResolver = (dependencies: {
 }): FileReferenceResolver => {
   const adapters: FileReferenceAdapter[] = []
   const readOnlyProjection = dependencies.grantedRoots
-    ? new ReadOnlyLinkedFileProjection()
+    ? new ReadOnlyLinkedFileProjection(dependencies.readOnlyProjectionMaxSessionBytes)
     : undefined
 
   if (dependencies.uploads) {
@@ -250,10 +293,12 @@ export const createManagedFileReferenceResolver = (dependencies: {
         if (!isPathWithin(resolvedFile, resolvedRoot)) {
           throw new Error('Linked-folder reference escapes the granted folder.')
         }
+        const fileInfo = await stat(resolvedFile)
+        if (!fileInfo.isFile()) throw new Error('Referenced path is not a file.')
         return {
           absolutePath:
             root.access === 'ro'
-              ? await readOnlyProjection!.materialize(sessionId, resolvedFile)
+              ? await readOnlyProjection!.materialize(sessionId, resolvedFile, fileInfo.size)
               : resolvedFile,
           name: reference.name,
           mimeType: reference.mimeType,

--- a/src/main/acp/file-reference-resolver.ts
+++ b/src/main/acp/file-reference-resolver.ts
@@ -1,13 +1,18 @@
-import { realpath, stat } from 'node:fs/promises'
-import { join } from 'node:path'
+import { copyFile, mkdtemp, realpath, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 import type { FileReference } from '../../shared/artifacts'
 import { parseArtifactVersionLocator } from '../../shared/artifact-provenance'
+import type { GrantedLocalRoot } from '../../shared/local-fs'
 import { isPathWithin } from '../../shared/local-fs'
 import type { ArtifactRepository } from '../artifacts/repository'
 import type { ArtifactProvenanceRepository } from '../artifacts/provenance-repository'
+import { createLogger, errorLogFields } from '../logger'
 import type { UploadRepository } from '../uploads/repository'
+
+const log = createLogger('acp-file-reference-resolver')
 
 export type FileReferenceContext = {
   projectId: string
@@ -33,10 +38,89 @@ export type FileReferenceAdapter = {
   ): Promise<Omit<ResolvedFileReference, 'uri' | 'size'>>
 }
 
+type FileReferenceResolverLifecycle = {
+  resetSession: (sessionId: string) => void
+  clear: () => void
+}
+
+// A read-only grant must not hand an Agent the user's source path. Each reference therefore gets a
+// private snapshot under the OS temporary directory. The Agent may mutate that disposable snapshot,
+// but the original remains outside the capability conveyed by the prompt. Random per-reference
+// directories also keep asynchronous cleanup from racing a replacement Session with the same id.
+class ReadOnlyLinkedFileProjection implements FileReferenceResolverLifecycle {
+  private generation = 0
+  private readonly sessionGenerations = new Map<string, number>()
+  private readonly directoriesBySession = new Map<string, Set<string>>()
+
+  async materialize(sessionId: string, sourcePath: string): Promise<string> {
+    const generation = this.generation
+    const sessionGeneration = this.sessionGenerations.get(sessionId) ?? 0
+    const directory = await mkdtemp(join(tmpdir(), 'open-science-linked-ro-'))
+    if (!this.isCurrent(sessionId, generation, sessionGeneration)) {
+      this.removeDirectory(directory)
+      throw new Error('Read-only linked-folder projection was superseded.')
+    }
+
+    let directories = this.directoriesBySession.get(sessionId)
+    if (!directories) {
+      directories = new Set()
+      this.directoriesBySession.set(sessionId, directories)
+    }
+    directories.add(directory)
+
+    const snapshotPath = join(directory, basename(sourcePath))
+    try {
+      await copyFile(sourcePath, snapshotPath)
+      if (!this.isCurrent(sessionId, generation, sessionGeneration)) {
+        throw new Error('Read-only linked-folder projection was superseded.')
+      }
+      return snapshotPath
+    } catch (error) {
+      directories.delete(directory)
+      if (directories.size === 0) this.directoriesBySession.delete(sessionId)
+      this.removeDirectory(directory)
+      throw error
+    }
+  }
+
+  resetSession(sessionId: string): void {
+    this.sessionGenerations.set(sessionId, (this.sessionGenerations.get(sessionId) ?? 0) + 1)
+    const directories = this.directoriesBySession.get(sessionId)
+    this.directoriesBySession.delete(sessionId)
+    if (directories) {
+      for (const directory of directories) this.removeDirectory(directory)
+    }
+  }
+
+  clear(): void {
+    this.generation += 1
+    this.sessionGenerations.clear()
+    const directories = [...this.directoriesBySession.values()].flatMap((value) => [...value])
+    this.directoriesBySession.clear()
+    for (const directory of directories) this.removeDirectory(directory)
+  }
+
+  private isCurrent(sessionId: string, generation: number, sessionGeneration: number): boolean {
+    return (
+      this.generation === generation &&
+      (this.sessionGenerations.get(sessionId) ?? 0) === sessionGeneration
+    )
+  }
+
+  private removeDirectory(directory: string): void {
+    void rm(directory, { recursive: true, force: true }).catch((error) => {
+      log.warn('read-only linked-folder projection cleanup failed', errorLogFields(error))
+    })
+  }
+}
+
 export class FileReferenceResolver {
   private readonly adapters = new Map<FileReference['source'], FileReferenceAdapter>()
 
-  constructor(adapters: FileReferenceAdapter[]) {
+  constructor(
+    adapters: FileReferenceAdapter[],
+    private readonly lifecycle?: FileReferenceResolverLifecycle
+  ) {
     for (const adapter of adapters) this.adapters.set(adapter.source, adapter)
   }
 
@@ -57,19 +141,30 @@ export class FileReferenceResolver {
       size: fileInfo.size
     }
   }
+
+  resetSession(sessionId: string): void {
+    this.lifecycle?.resetSession(sessionId)
+  }
+
+  clear(): void {
+    this.lifecycle?.clear()
+  }
 }
 
 export const createManagedFileReferenceResolver = (dependencies: {
   uploads?: UploadRepository
   artifacts?: ArtifactRepository
   artifactVersions?: Partial<Pick<ArtifactProvenanceRepository, 'resolveVersionContent'>>
-  // Resolves a granted local root id to its absolute path (settings-backed). Absent ⇒
+  // Resolves a granted local root id and current access level (settings-backed). Absent ⇒
   // linked-folder references stay unavailable, matching the pre-grant behavior.
   grantedRoots?: {
-    resolveRootPath: (rootId: string) => Promise<string | undefined>
+    resolveRoot: (rootId: string) => Promise<Pick<GrantedLocalRoot, 'path' | 'access'> | undefined>
   }
 }): FileReferenceResolver => {
   const adapters: FileReferenceAdapter[] = []
+  const readOnlyProjection = dependencies.grantedRoots
+    ? new ReadOnlyLinkedFileProjection()
+    : undefined
 
   if (dependencies.uploads) {
     adapters.push({
@@ -139,24 +234,27 @@ export const createManagedFileReferenceResolver = (dependencies: {
   if (dependencies.grantedRoots) {
     adapters.push({
       source: 'linked-folder',
-      resolve: async (_context, reference) => {
+      resolve: async ({ sessionId }, reference) => {
         if (reference.source !== 'linked-folder') {
           throw new Error('Invalid linked-folder reference.')
         }
-        const rootPath = await dependencies.grantedRoots!.resolveRootPath(reference.rootId)
-        if (!rootPath) throw new Error(`Unknown granted folder root: ${reference.rootId}`)
+        const root = await dependencies.grantedRoots!.resolveRoot(reference.rootId)
+        if (!root) throw new Error(`Unknown granted folder root: ${reference.rootId}`)
         // The join is only lexical — the confinement proof is the realpath comparison below:
         // canonicalizing both sides catches '..' segments AND symlinks that point outside the
         // granted root, so neither can be used to escape it.
         const [resolvedRoot, resolvedFile] = await Promise.all([
-          realpath(rootPath),
-          realpath(join(rootPath, reference.relativePath))
+          realpath(root.path),
+          realpath(join(root.path, reference.relativePath))
         ])
         if (!isPathWithin(resolvedFile, resolvedRoot)) {
           throw new Error('Linked-folder reference escapes the granted folder.')
         }
         return {
-          absolutePath: resolvedFile,
+          absolutePath:
+            root.access === 'ro'
+              ? await readOnlyProjection!.materialize(sessionId, resolvedFile)
+              : resolvedFile,
           name: reference.name,
           mimeType: reference.mimeType,
           allowSkillImportReference: false
@@ -165,5 +263,5 @@ export const createManagedFileReferenceResolver = (dependencies: {
     })
   }
 
-  return new FileReferenceResolver(adapters)
+  return new FileReferenceResolver(adapters, readOnlyProjection)
 }

--- a/src/main/acp/model-change-workflow.test.ts
+++ b/src/main/acp/model-change-workflow.test.ts
@@ -147,6 +147,7 @@ const createHarness = (): WorkflowHarness => {
 
   const setBridgeReasoningEffort = vi.fn()
   const connectionResources = {
+    epoch: 1,
     get connection() {
       return connected ? connection : undefined
     },
@@ -166,6 +167,7 @@ const createHarness = (): WorkflowHarness => {
     setBridgeReasoningEffort
   } as Pick<
     AcpConnectionResourceOwner,
+    | 'epoch'
     | 'connection'
     | 'isShuttingDown'
     | 'anthropicBridgeAvailable'
@@ -318,6 +320,7 @@ describe('ACP model-change workflow', () => {
 
     expect(harness.reportReconnectFailure).toHaveBeenCalledWith(failure)
     expect(harness.recoverFailedReconnect).toHaveBeenCalledOnce()
+    expect(harness.recoverFailedReconnect).toHaveBeenCalledWith(1)
     expect(harness.workflow.barrier).toBeUndefined()
   })
 

--- a/src/main/acp/model-change-workflow.ts
+++ b/src/main/acp/model-change-workflow.ts
@@ -21,6 +21,7 @@ type AcpModelChangeWorkflowOptions = Readonly<{
   >
   connectionResources: Pick<
     AcpConnectionResourceOwner,
+    | 'epoch'
     | 'connection'
     | 'isShuttingDown'
     | 'anthropicBridgeAvailable'
@@ -40,7 +41,7 @@ type AcpModelChangeWorkflowOptions = Readonly<{
   contextEstimateInput: (sessionId: string) => SessionEstimateInput
   emitState: () => void
   requestReconnect: () => Promise<void>
-  recoverFailedReconnect: () => void
+  recoverFailedReconnect: (disconnectedGeneration: number) => void
   reportReconnectFailure: (error: unknown) => void
   diagnosticContext: () => Readonly<Record<string, unknown>>
 }>
@@ -165,11 +166,12 @@ class AcpModelChangeWorkflow {
 
       if (!this.canApply(target) || !(await this.applyTarget(target))) {
         this.pending = undefined
+        const disconnectedGeneration = this.options.connectionResources.epoch
         try {
           await this.options.requestReconnect()
         } catch (error) {
           this.options.reportReconnectFailure(error)
-          this.options.recoverFailedReconnect()
+          this.options.recoverFailedReconnect(disconnectedGeneration)
         }
         return
       }

--- a/src/main/acp/prompt-content-owner.test.ts
+++ b/src/main/acp/prompt-content-owner.test.ts
@@ -1,7 +1,8 @@
 import type { ContentBlock } from '@agentclientprotocol/sdk'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { UploadedAttachment } from '../../shared/uploads'
@@ -29,6 +30,48 @@ afterEach(async () => {
 })
 
 describe('AcpPromptContentOwner', () => {
+  it('sends a read-only linked file from its disposable snapshot URI', async () => {
+    const root = await createRoot()
+    const sourcePath = join(root, 'study.csv')
+    await writeFile(sourcePath, 'id,value\n1,2\n')
+    const owner = new AcpPromptContentOwner({
+      fileReferenceResolver: createManagedFileReferenceResolver({
+        grantedRoots: { resolveRoot: async () => ({ path: root, access: 'ro' }) }
+      })
+    })
+
+    const prepared = await owner.prepare({
+      appSessionId: 'session-1',
+      projectId: 'default-project',
+      text: 'analyze this file',
+      historyImages: [],
+      historyUploads: [],
+      currentUploads: [],
+      references: [
+        {
+          id: 'linked-1',
+          name: 'study.csv',
+          source: 'linked-folder',
+          rootId: 'root-1',
+          relativePath: 'study.csv',
+          mimeType: 'text/csv'
+        }
+      ],
+      codexSkillInputs: [],
+      skillImportEnabled: false
+    })
+
+    const resource = contentBlocks(prepared.content).find((block) => block.type === 'resource')
+    expect(resource).toMatchObject({
+      type: 'resource',
+      resource: { text: 'id,value\n1,2\n' }
+    })
+    if (resource?.type === 'resource') {
+      expect(resource.resource.uri).not.toBe(pathToFileURL(sourcePath).href)
+    }
+    owner.clear()
+  })
+
   it('keeps the text fast path isolated from ambient resolvers and defensively owns Codex metadata', async () => {
     const resolver = createManagedFileReferenceResolver({})
     const resolveReference = vi.spyOn(resolver, 'resolve')

--- a/src/main/acp/prompt-content-owner.test.ts
+++ b/src/main/acp/prompt-content-owner.test.ts
@@ -34,15 +34,16 @@ describe('AcpPromptContentOwner', () => {
     const root = await createRoot()
     const sourcePath = join(root, 'study.csv')
     await writeFile(sourcePath, 'id,value\n1,2\n')
-    const owner = new AcpPromptContentOwner({
-      fileReferenceResolver: createManagedFileReferenceResolver({
-        grantedRoots: { resolveRoot: async () => ({ path: root, access: 'ro' }) }
-      })
+    const resolver = createManagedFileReferenceResolver({
+      grantedRoots: { resolveRoot: async () => ({ path: root, access: 'ro' }) }
     })
+    const resolveReference = vi.spyOn(resolver, 'resolve')
+    const owner = new AcpPromptContentOwner({ fileReferenceResolver: resolver })
 
     const prepared = await owner.prepare({
       appSessionId: 'session-1',
       projectId: 'default-project',
+      connectionGeneration: 2,
       text: 'analyze this file',
       historyImages: [],
       historyUploads: [],
@@ -69,6 +70,10 @@ describe('AcpPromptContentOwner', () => {
     if (resource?.type === 'resource') {
       expect(resource.resource.uri).not.toBe(pathToFileURL(sourcePath).href)
     }
+    expect(resolveReference).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionGeneration: 2 }),
+      expect.anything()
+    )
     owner.clear()
   })
 

--- a/src/main/acp/prompt-content-owner.ts
+++ b/src/main/acp/prompt-content-owner.ts
@@ -229,10 +229,12 @@ class AcpPromptContentOwner {
   }
 
   resetSession(sessionId: string): void {
+    this.options.fileReferenceResolver.resetSession(sessionId)
     this.sessionInlineImageBytes.delete(sessionId)
   }
 
   clear(): void {
+    this.options.fileReferenceResolver.clear()
     this.sessionInlineImageBytes.clear()
   }
 

--- a/src/main/acp/prompt-content-owner.ts
+++ b/src/main/acp/prompt-content-owner.ts
@@ -52,6 +52,7 @@ type AcpPromptContentOwnerOptions = {
 type PrepareAcpPromptContentInput = {
   appSessionId: string
   projectId: string
+  connectionGeneration?: number
   text: string
   historyImages: ReadonlyArray<AcpMessageImage>
   historyUploads: ReadonlyArray<UploadedAttachment>
@@ -102,7 +103,7 @@ const errorMessage = (error: unknown): string => {
 // Session/turn admission, authorization leases, Notebook registration, and provider dispatch remain
 // with the runtime; every piece of content resolved here is supplied explicitly by the caller.
 class AcpPromptContentOwner {
-  private readonly sessionInlineImageBytes = new Map<string, number>()
+  private readonly sessionInlineImageBytes = new Map<number, Map<string, number>>()
   private readonly inlineImageBudgetBytes: number
 
   constructor(private readonly options: AcpPromptContentOwnerOptions) {
@@ -151,7 +152,7 @@ class AcpPromptContentOwner {
         appendBlock({ type: 'image', data: image.data, mimeType: image.mimeType })
       }
       if (input.historyImages.length > 0) {
-        this.sessionInlineImageBytes.set(input.appSessionId, imageBudget.base64Bytes)
+        this.setSessionInlineImageBytes(input, imageBudget.base64Bytes)
       }
 
       if (hasUploads) {
@@ -230,12 +231,37 @@ class AcpPromptContentOwner {
 
   resetSession(sessionId: string): void {
     this.options.fileReferenceResolver.resetSession(sessionId)
-    this.sessionInlineImageBytes.delete(sessionId)
+    for (const [connectionGeneration, sessionBytes] of this.sessionInlineImageBytes) {
+      sessionBytes.delete(sessionId)
+      if (sessionBytes.size === 0) this.sessionInlineImageBytes.delete(connectionGeneration)
+    }
   }
 
   clear(): void {
     this.options.fileReferenceResolver.clear()
     this.sessionInlineImageBytes.clear()
+  }
+
+  clearGeneration(connectionGeneration: number): void {
+    this.options.fileReferenceResolver.clearGeneration(connectionGeneration)
+    this.sessionInlineImageBytes.delete(connectionGeneration)
+  }
+
+  private getSessionInlineImageBytes(input: PrepareAcpPromptContentInput): number {
+    return (
+      this.sessionInlineImageBytes.get(input.connectionGeneration ?? 0)?.get(input.appSessionId) ??
+      0
+    )
+  }
+
+  private setSessionInlineImageBytes(input: PrepareAcpPromptContentInput, bytes: number): void {
+    const connectionGeneration = input.connectionGeneration ?? 0
+    let sessionBytes = this.sessionInlineImageBytes.get(connectionGeneration)
+    if (!sessionBytes) {
+      sessionBytes = new Map()
+      this.sessionInlineImageBytes.set(connectionGeneration, sessionBytes)
+    }
+    sessionBytes.set(input.appSessionId, bytes)
   }
 
   private attachCodexSkillInputs(
@@ -305,7 +331,11 @@ class AcpPromptContentOwner {
     fileTextBudget: PromptFileTextBudget
   ): Promise<ContentBlock[]> {
     const resolvedReference = await this.options.fileReferenceResolver.resolve(
-      { sessionId: input.appSessionId, projectId: input.projectId },
+      {
+        sessionId: input.appSessionId,
+        projectId: input.projectId,
+        connectionGeneration: input.connectionGeneration
+      },
       reference
     )
 
@@ -408,14 +438,14 @@ class AcpPromptContentOwner {
         size
       )
 
-      const alreadyInlined = this.sessionInlineImageBytes.get(input.appSessionId) ?? 0
+      const alreadyInlined = this.getSessionInlineImageBytes(input)
       if (!canInlineImageInSession(alreadyInlined, data.length, this.inlineImageBudgetBytes)) {
         return [{ type: 'resource_link', uri, name, title: name, mimeType: imageMimeType, size }]
       }
 
       // Charge before the request-level append. Existing behavior retains this charge even if a later
       // reference fails or the request image budget rejects this block.
-      this.sessionInlineImageBytes.set(input.appSessionId, alreadyInlined + data.length)
+      this.setSessionInlineImageBytes(input, alreadyInlined + data.length)
       return [{ type: 'image', data, mimeType: outMimeType, uri }]
     }
 

--- a/src/main/acp/prompt-preparation-owner.ts
+++ b/src/main/acp/prompt-preparation-owner.ts
@@ -58,6 +58,7 @@ type AcpPromptPreparationOwnerOptions = Readonly<{
 }>
 type AcpPromptPreparationInput = Readonly<{
   request: AcpPromptRequest
+  connectionGeneration?: number
   backend: AcpBackendGenerationView
   tooling: AcpSessionToolingAvailability
   specialistPrefix?: string
@@ -201,6 +202,7 @@ class AcpPromptPreparationOwner {
       const prepared = await this.options.promptContent.prepare({
         appSessionId: input.request.sessionId,
         projectId: input.projectId,
+        connectionGeneration: input.connectionGeneration,
         text: promptText,
         historyImages: input.request.historyImages ?? [],
         historyUploads: input.request.historyAttachments ?? [],

--- a/src/main/acp/prompt-turn-workflow.ts
+++ b/src/main/acp/prompt-turn-workflow.ts
@@ -50,6 +50,7 @@ type AcpPromptTurnPlanContext = Readonly<{
 
 type AcpActivatedPromptTurn = Readonly<{
   request: AcpPromptRequest
+  connectionGeneration: number
   mode: AcpPromptTurnMode
   session: ActiveSession
   interaction: AcpPromptSessionInteractionScope
@@ -58,6 +59,7 @@ type AcpActivatedPromptTurn = Readonly<{
 }>
 
 type AcpPromptTurnEnvironment = Readonly<{
+  connectionGeneration?: () => number
   backend: () => AcpBackendGenerationView
   tooling: () => AcpSessionToolingAvailability
   bridgeSkillsAvailable: () => boolean
@@ -262,6 +264,7 @@ class AcpPromptTurnWorkflow {
     })
     return this.executeTurn({
       request,
+      connectionGeneration: this.options.environment.connectionGeneration?.() ?? 0,
       mode,
       session: activeSession,
       interaction,
@@ -337,6 +340,7 @@ class AcpPromptTurnWorkflow {
         turn.plan.authorized ?? turn.plan.protectedPending ?? turn.plan.protectedRejected
       prepared = await preparation.prepare({
         request: preparationRequest,
+        connectionGeneration: turn.connectionGeneration,
         backend,
         tooling: env.tooling(),
         specialistPrefix: snapshot?.specialistPrefix,

--- a/src/main/acp/runtime-base-composition.ts
+++ b/src/main/acp/runtime-base-composition.ts
@@ -100,8 +100,8 @@ const composeAcpRuntimeBaseOwners = (options: AcpRuntimeOptions) => {
     disconnect: (emitClosedStatus) => effects().connectionClose.disconnect(emitClosedStatus),
     onRetired: () => callbacks.onRetired?.(),
     publishIdle: () => effects().publishIdle(),
-    recoverFailedDeferredDisconnect: () =>
-      effects().connectionClose.recoverFailedDeferredDisconnect(),
+    recoverFailedDeferredDisconnect: (_error, disconnectedGeneration) =>
+      effects().connectionClose.recoverFailedDeferredDisconnect(disconnectedGeneration),
     reportFailure: safeLogError
   })
   const bindGenerationConnectionEffects = (next: AcpGenerationConnectionEffects): void => {

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -255,9 +255,9 @@ const createAcpRuntime = ({
         ...(delegatedNotebookConnection ? {} : { uploads: { repository: uploadRepository } }),
         grantedRoots: grantedRootsRepository
           ? {
-              // Read fresh per resolution so a just-removed root stops resolving immediately.
-              resolveRootPath: async (rootId) =>
-                (await grantedRootsRepository.list()).find((root) => root.id === rootId)?.path
+              // Read fresh so revocation and access changes govern every subsequent resolution.
+              resolveRoot: async (rootId) =>
+                (await grantedRootsRepository.list()).find((root) => root.id === rootId)
             }
           : undefined,
         notebook: {

--- a/src/main/acp/runtime-lifecycle-composition.ts
+++ b/src/main/acp/runtime-lifecycle-composition.ts
@@ -89,7 +89,10 @@ const composeAcpRuntimeLifecycleOwners = (
         if (clearPermissionProfile) entry.aggregate.setPermissionProfile(undefined)
       }
     },
-    clearPromptContent: () => base.promptContentOwner.clear(),
+    clearPromptContent: (connectionGeneration) => {
+      if (connectionGeneration === undefined) base.promptContentOwner.clear()
+      else base.promptContentOwner.clearGeneration(connectionGeneration)
+    },
     clearHandoffContinuity: () => base.handoffContinuity.clearGeneration(),
     clearSessionProjection: () => session.sessionUpdateProjector.clearGeneration(),
     disposeSessionProjection: () => session.sessionUpdateProjector.dispose(),

--- a/src/main/acp/runtime-lifecycle-composition.ts
+++ b/src/main/acp/runtime-lifecycle-composition.ts
@@ -138,7 +138,8 @@ const composeAcpRuntimeLifecycleOwners = (
       session.contextUsagePolicy.resolve(sessionId).estimateInput,
     emitState: () => session.publication.emitState(),
     requestReconnect: () => base.connectionTransitions.requestProviderReconnect(),
-    recoverFailedReconnect: () => connectionClose.recoverFailedDeferredDisconnect(),
+    recoverFailedReconnect: (disconnectedGeneration) =>
+      connectionClose.recoverFailedDeferredDisconnect(disconnectedGeneration),
     reportReconnectFailure: (error) =>
       safeLogError('model-change reconnect failed', errorLogFields(error)),
     diagnosticContext
@@ -160,7 +161,8 @@ const composeAcpRuntimeLifecycleOwners = (
     modelChanges,
     connectionClose: {
       disconnect: (emitClosedStatus) => host.disconnect(emitClosedStatus),
-      recoverFailedDeferredDisconnect: () => connectionClose.recoverFailedDeferredDisconnect()
+      recoverFailedDeferredDisconnect: (disconnectedGeneration) =>
+        connectionClose.recoverFailedDeferredDisconnect(disconnectedGeneration)
     },
     publishIdle: () => setStatus('idle')
   })

--- a/src/main/acp/runtime-prompt-composition.ts
+++ b/src/main/acp/runtime-prompt-composition.ts
@@ -185,6 +185,7 @@ const composeAcpRuntimePromptOwners = (
     finalizer: base.promptOutcomeFinalizer,
     permission: session.permissionContext,
     environment: {
+      connectionGeneration: () => base.connectionResources.epoch,
       backend: () => base.backendGeneration.current,
       tooling: () => session.sessionEnvironment.toolingAvailability(),
       bridgeSkillsAvailable: () => base.connectionResources.bridgeSkillsAvailable,

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -31,6 +31,7 @@ import {
   type AcpSetPermissionProfileRequest,
   type AcpStateSnapshot
 } from '../../shared/acp'
+import type { GrantedLocalRoot } from '../../shared/local-fs'
 import { type AgentFrameworkId } from '../../shared/settings'
 import type { MessageAttribution } from '../../shared/session-persistence'
 import {
@@ -167,11 +168,11 @@ type AcpRuntimeOptions = {
   }) => Promise<ResolvedAgentBackend> | ResolvedAgentBackend
   artifacts?: AcpRuntimeArtifactOptions
   uploads?: AcpRuntimeUploadOptions
-  // Resolves a granted local root id to its absolute path (backed by the GrantedLocalRoot table),
-  // enabling the linked-folder file-reference adapter. Absent ⇒ linked-folder references stay
-  // unavailable.
+  // Resolves a granted local root and its current access level (backed by the GrantedLocalRoot
+  // table), enabling the linked-folder file-reference adapter. Absent ⇒ linked-folder references
+  // stay unavailable.
   grantedRoots?: {
-    resolveRootPath: (rootId: string) => Promise<string | undefined>
+    resolveRoot: (rootId: string) => Promise<Pick<GrantedLocalRoot, 'path' | 'access'> | undefined>
   }
   notebook?: AcpRuntimeNotebookOptions
   skillImport?: AcpRuntimeSkillImportOptions

--- a/src/shared/local-fs.ts
+++ b/src/shared/local-fs.ts
@@ -54,7 +54,8 @@ export type GrantedLocalRoot = {
   path: string
   // Display label: basename of the granted path.
   name: string
-  // Persistence/display only this iteration — no write enforcement reads this yet.
+  // The Agent input resolver snapshots files from read-only roots and exposes source paths only for
+  // read/write roots.
   access: GrantedLocalRootAccess
 }
 


### PR DESCRIPTION
## Problem

Granted local roots persist and display an `ro` or `rw` access level, but the linked-folder Agent input adapter projected only the stored path. An `ro` reference therefore exposed the user's original `file://` URI to every Agent backend exactly like `rw`.

## Proposed change

- Resolve the complete granted-root capability, including its current access level.
- Materialize each `ro` reference as a session-owned snapshot under the OS temporary directory, while preserving the original path for `rw`.
- Bound cumulative snapshot storage to the existing 10 GB managed-file limit per Session, enforcing the limit against bytes actually copied even if a source grows after its initial `stat`.
- Retain snapshots for the owning connection generation and provider Session context, explicitly carry the original connected generation through failed reconnect recovery, clean on Session reset/delete and context reset, and synchronously remove only the disconnected generation after provider teardown (or all generations on process shutdown).
- Cover both the resolver and the common Prompt content boundary used by Claude Code, OpenCode, Codex Responses, and Codex Bridge.

## Scope and non-goals

- No Prisma schema, migration, database field, persisted Session field, UI interaction, or access enum change.
- This closes the source-path capability conveyed by linked-folder attachments. It is not a complete OS filesystem sandbox if an Agent independently knows and is otherwise authorized to access the source path.
- No subscription timing, update, or cleanup behavior changes.

## Historical compatibility

Existing `GrantedLocalRoot` rows and persisted linked-folder message references require no migration. Replayed references resolve the root's current access level and rematerialize `ro` snapshots. Changing a root from `rw` to `ro` governs subsequent resolutions; it cannot revoke a source URI already delivered to an existing provider context.

## Persistence

`ro` snapshots are temporary filesystem data only and are not registered in SQLite or Session JSON. Connection generation ownership is also runtime-only. Session-level cleanup is asynchronous, while connection shutdown cleanup is synchronous after the provider process releases file handles. A hard process crash can still leave files in the OS temporary directory for operating-system cleanup.

## Acceptance criteria and validation

Checks ran after the last material edit.

- `ro` source-path isolation, actual-byte quota (including `stat`/copy growth), generation propagation, teardown/successor races, and failed reconnect recovery -> `npm test -- src/main/acp/file-reference-resolver.test.ts src/main/acp/prompt-content-owner.test.ts src/main/acp/prompt-preparation-owner.test.ts src/main/acp/prompt-turn-workflow.test.ts src/main/acp/connection-close-workflow.test.ts src/main/acp/connection-transition-owner.test.ts src/main/acp/model-change-workflow.test.ts src/main/acp/runtime-base-composition.test.ts -t "^(?!.*via a symlink).*$"` -> 64 passed, 1 skipped.
- ACP runtime interface consumers -> `npm run typecheck:node` -> passed.
- Source quality -> `npm run lint` -> passed with no warnings.

The excluded existing symlink-confinement test could not create a Windows file symlink on this machine (`EPERM`) and failed before entering production code. Linux/macOS and suitably configured Windows CI remain authoritative for that platform lane. No full local `npm test` was run, as requested; PR CI is authoritative for the complete suite.

## Review focus

- Snapshot lifecycle and reset/teardown race handling.
- The intentional distinction between `ro` snapshot URIs and `rw` source URIs.
- Coverage at the shared pre-framework Prompt boundary rather than duplicated provider-specific branches.
