### PR TITLE
fix(acp): preserve durable elicitation after session resume

### DIFF
--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -3,7 +3,9 @@ import type {
   AcpRuntimeEvent,
   AcpStateSnapshot
 } from '../../../../shared/acp'
+import type { HistoryReplayTarget } from '../../../../shared/history-preamble'
 import type { PersistedChatSession } from '../../../../shared/session-persistence'
+import type { AgentFrameworkId } from '../../../../shared/settings'
 import type { UploadedAttachment } from '../../../../shared/uploads'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -1221,60 +1223,92 @@ describe('workspace durable elicitation', () => {
     })
   })
 
-  it('reattaches a restored session before submitting its durable answer', async () => {
-    const resumeSession = vi.fn().mockResolvedValue({
-      sessionId: 'session-choice-1',
-      cwd: '/workspace/project',
-      contextReset: false,
-      frameworkId: 'opencode',
-      backendId: 'opencode:provider-1'
-    })
-    const respondToElicitation = vi.fn().mockResolvedValue(createSnapshot(['session-choice-1']))
-    const response = {
-      requestId: 'choice-1',
-      action: 'accept' as const,
-      answers: [{ fieldId: 'question_0', value: 'Minimal' }],
-      request: {
-        requestId: 'choice-1',
+  it.each<readonly [string, AgentFrameworkId, string, HistoryReplayTarget]>([
+    ['Claude Code', 'claude-code', 'claude-code:anthropic', 'claude-code'],
+    ['OpenCode', 'opencode', 'opencode:provider-1', 'opencode'],
+    ['Codex Responses', 'codex', 'codex:responses-provider', 'codex-response'],
+    ['Codex Bridge', 'codex', 'codex:bridge-provider', 'codex-bridge']
+  ])(
+    'reattaches a restored session before submitting its durable answer through %s',
+    async (_path, frameworkId, backendId, historyReplayTarget) => {
+      useSessionStore.setState((state) => ({
+        sessions: state.sessions.map((session) => ({
+          ...session,
+          agentFrameworkId: frameworkId,
+          agentBackendId: backendId
+        }))
+      }))
+      const resumeSession = vi.fn().mockResolvedValue({
         sessionId: 'session-choice-1',
-        toolCallId: 'tool-choice-1',
-        message: 'Choose an approach',
-        fields: [
-          {
-            id: 'question_0',
-            label: 'Approach',
-            kind: 'single-select' as const,
-            options: [
-              { value: 'Minimal', label: 'Minimal' },
-              { value: 'Expanded', label: 'Expanded' }
-            ]
-          }
-        ],
-        durable: { kind: 'agent-user-choice' as const, requestId: 'choice-1' }
+        cwd: '/workspace/project',
+        contextReset: true,
+        frameworkId,
+        backendId
+      })
+      const response = {
+        requestId: 'choice-1',
+        action: 'accept' as const,
+        answers: [{ fieldId: 'question_0', value: 'Minimal' }],
+        request: {
+          requestId: 'choice-1',
+          sessionId: 'session-choice-1',
+          toolCallId: 'tool-choice-1',
+          message: 'Choose an approach',
+          fields: [
+            {
+              id: 'question_0',
+              label: 'Approach',
+              kind: 'single-select' as const,
+              options: [
+                { value: 'Minimal', label: 'Minimal' },
+                { value: 'Expanded', label: 'Expanded' }
+              ]
+            }
+          ],
+          durable: { kind: 'agent-user-choice' as const, requestId: 'choice-1' }
+        }
       }
+      useSessionStore.getState().setElicitationPending(response.request.sessionId, true)
+      const respondToElicitation = vi.fn(async () => {
+        const persisted = useSessionStore
+          .getState()
+          .sessions.find((session) => session.id === response.request.sessionId)
+        if (persisted?.status !== 'waiting-for-user') {
+          throw new Error('Durable elicitation no longer matches the pending Session activity.')
+        }
+        return createSnapshot(['session-choice-1'])
+      })
+
+      await respondToWorkspaceElicitation(
+        { state: createSnapshot(), resumeSession, respondToElicitation },
+        response,
+        { historyReplayDescriptor: { target: historyReplayTarget } }
+      )
+
+      expect(resumeSession).toHaveBeenCalledWith(
+        'session-choice-1',
+        '/workspace/project',
+        'project-1',
+        'ask',
+        frameworkId,
+        backendId,
+        undefined,
+        undefined,
+        undefined
+      )
+      expect(resumeSession.mock.invocationCallOrder[0]).toBeLessThan(
+        respondToElicitation.mock.invocationCallOrder[0]
+      )
+      expect(respondToElicitation).toHaveBeenCalledWith({
+        ...response,
+        historyReplay: {
+          historyPreamble: expect.stringContaining('Build something'),
+          historyAttachments: [],
+          historyImages: []
+        }
+      })
     }
-
-    await respondToWorkspaceElicitation(
-      { state: createSnapshot(), resumeSession, respondToElicitation },
-      response
-    )
-
-    expect(resumeSession).toHaveBeenCalledWith(
-      'session-choice-1',
-      '/workspace/project',
-      'project-1',
-      'ask',
-      'opencode',
-      'opencode:provider-1',
-      undefined,
-      undefined,
-      undefined
-    )
-    expect(resumeSession.mock.invocationCallOrder[0]).toBeLessThan(
-      respondToElicitation.mock.invocationCallOrder[0]
-    )
-    expect(respondToElicitation).toHaveBeenCalledWith(response)
-  })
+  )
 
   it('replays prior history when restoring the provider resets its context', async () => {
     const resumeSession = vi.fn().mockResolvedValue({

--- a/src/renderer/src/lib/acp/workspace-elicitation-runtime.ts
+++ b/src/renderer/src/lib/acp/workspace-elicitation-runtime.ts
@@ -325,6 +325,7 @@ const respondToWorkspaceElicitation = async (
           }
         : undefined
     )
+    useSessionStore.getState().setElicitationPending(session.id, true)
     session = useSessionStore
       .getState()
       .sessions.find((candidate) => candidate.id === restoredRequest.sessionId)


### PR DESCRIPTION
## Problem

When a durable ask_user_question is waiting and its runtime detaches, the renderer resumes the Session before submitting the answer. markResumed changes the persisted Session status to idle. Main then reloads that Session and correctly rejects the durable response because its authority is no longer waiting-for-user. A framework change makes this especially visible because fresh adoption guarantees the resume path and a context reset.

Production evidence showed the flat activity and active conversation graph still agreed on the same pending durable elicitation; only the Session status had been cleared.

## Proposed change

Reassert the existing elicitation-pending projection immediately after runtime reattachment and before submitting the durable answer. This preserves waiting-for-user in Session persistence while retaining all Main-owned request, tool-call, prompt, and active-Branch correlation checks.

The regression contract is parameterized across Claude Code, OpenCode, Codex Responses, and Codex Bridge with context reset enabled. The renderer-to-Main request shape is unchanged.

## Scope and non-goals

- No new IPC method, wire field, subscription behavior, state enum, or dependency.
- No change to live elicitation handling, answer revision, permission settlement, or Main fail-closed validation.
- No database or Session file format change.

## Historical compatibility and persistence

Existing 0.16.0 Session files that contain idle plus a still-pending durable elicitation recover on runtime reattachment: the existing Session status and interaction projection are corrected before Main reloads the authority. No migration is required and no historical field is rewritten into a new format.

## Acceptance criteria and validation

All commands below ran after the final material edit.

- Restored durable elicitation remains waiting through reattachment for Claude Code, OpenCode, Codex Responses, and Codex Bridge -> npm test -- src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts -t "reattaches a restored session before submitting its durable answer" -> 4 passed.
- Workspace runtime owner, contracts, consumers, and renderer-state overlay -> npm run test:module -- workspace_runtime -> 7 files and 309 tests passed.
- Renderer TypeScript contract -> npm run typecheck:web -> passed.
- Source lint -> npm run lint -> passed.

Included compatibility dimensions: all four supported execution paths, detached Session reattachment, context reset, history replay preparation, and the shared renderer command path. The Electron/local Web/remote Web renderer command contract is unchanged, so no surface-specific registration test is required.

Uncovered local risks: no live provider E2E or packaged-platform run was performed. The change contains no platform-specific behavior; exact-head PR CI remains authoritative for complete portable and platform lanes.

## Review focus

Please verify that reasserting the pending interaction immediately after markResumed is the correct ordering boundary and that the four-path matrix covers the final diff.