### PR TITLE
ci(runtime): add source certification dry-run

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,15 @@ on:
   schedule:
     - cron: '17 * * * *'
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Focused no-side-effect validation plan
+        required: false
+        default: full
+        type: choice
+        options:
+          - full
+          - runtime-source
 
 # Build and publication preparation run without write access. Only the separate workflow_run
 # publisher receives contents:write, and it never checks out or executes the triggering revision.
@@ -39,11 +48,21 @@ jobs:
 
   build:
     needs: plan
-    if: needs.plan.outputs.should_build == 'true'
+    if: needs.plan.outputs.should_build == 'true' && inputs.dry_run != 'runtime-source'
     uses: ./.github/workflows/build.yml
     secrets: inherit
     with:
       nightly: true
+
+  # Scheduled coverage remains advisory during burn-in and is deliberately absent from prepare.needs.
+  # A manual `runtime-source` dispatch runs this exact reusable job as a blocking focused dry-run while
+  # build/package/publish preparation stay skipped.
+  runtime-certification:
+    needs: plan
+    if: needs.plan.outputs.should_build == 'true'
+    uses: ./.github/workflows/runtime-certification.yml
+    with:
+      allow_failure: ${{ github.event_name != 'workflow_dispatch' }}
 
   package-smoke:
     needs: build

--- a/.github/workflows/runtime-certification.yml
+++ b/.github/workflows/runtime-certification.yml
@@ -37,10 +37,12 @@ jobs:
           node-version: 22
           cache: npm
 
-      # The selected source suites use the JS/TS toolchain but do not build Electron or load generated
-      # Prisma clients. Skipping lifecycle scripts avoids the native rebuild performed by postinstall.
+      # Several control-plane suites import modules that cross the Electron boundary. Use the normal
+      # repository install so Electron, generated clients, patches, and native dependencies match the
+      # source path exercised by the rest of CI. The focused dry-run proved that --ignore-scripts leaves
+      # Electron intentionally uninstalled and causes those suites to fail during collection.
       - name: Install test dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci
 
       # Use the same pinned, digest-verified micromamba downloader as the packaged runtime. These are
       # ephemeral source-certification environments, not the immutable CDN packs certified later at

--- a/.github/workflows/runtime-certification.yml
+++ b/.github/workflows/runtime-certification.yml
@@ -1,0 +1,98 @@
+name: Runtime Certification
+
+# Real source-level runtime coverage. Nightly calls this workflow in advisory mode; a focused manual
+# Nightly dispatch calls the exact same job as a blocking, no-publish dry-run. Packaged-runtime and
+# bundle-materialization certification remain separate boundaries and are intentionally not modeled
+# as source coverage here.
+on:
+  workflow_call:
+    inputs:
+      allow_failure:
+        description: Keep the scheduled Nightly signal advisory during burn-in
+        required: false
+        type: boolean
+        default: true
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runtime-certification-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  source:
+    name: Source runtime chain (Linux)
+    continue-on-error: ${{ inputs.allow_failure }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+
+      # The selected source suites use the JS/TS toolchain but do not build Electron or load generated
+      # Prisma clients. Skipping lifecycle scripts avoids the native rebuild performed by postinstall.
+      - name: Install test dependencies
+        run: npm ci --ignore-scripts
+
+      # Use the same pinned, digest-verified micromamba downloader as the packaged runtime. These are
+      # ephemeral source-certification environments, not the immutable CDN packs certified later at
+      # the packaged boundary.
+      - name: Fetch pinned micromamba
+        shell: bash
+        run: |
+          set -euo pipefail
+          bin="$RUNNER_TEMP/micromamba"
+          node scripts/fetch-micromamba.mjs linux-64 "$bin"
+          echo "MICROMAMBA_BIN=$bin" >> "$GITHUB_ENV"
+
+      - name: Create real Python and R environments
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/micromamba-root"
+          python_prefix="$RUNNER_TEMP/runtime-python"
+          r_prefix="$RUNNER_TEMP/runtime-r"
+
+          "$MICROMAMBA_BIN" create --yes --root-prefix "$root" --prefix "$python_prefix" \
+            --channel conda-forge python=3.12 matplotlib-base nomkl
+          "$MICROMAMBA_BIN" create --yes --root-prefix "$root" --prefix "$r_prefix" \
+            --channel conda-forge r-base=4.4 r-jsonlite r-ggplot2
+
+          echo "OPEN_SCIENCE_TEST_PY_ENV=$python_prefix/bin/python" >> "$GITHUB_ENV"
+          echo "OPEN_SCIENCE_TEST_R_ENV=$r_prefix" >> "$GITHUB_ENV"
+
+      - name: Verify runtime prerequisites
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$OPEN_SCIENCE_TEST_PY_ENV" -c \
+            'import matplotlib; print("python=" + __import__("sys").version.split()[0] + " matplotlib=" + matplotlib.__version__)'
+          "$OPEN_SCIENCE_TEST_R_ENV/bin/Rscript" -e \
+            'library(jsonlite); library(ggplot2); cat("r=", as.character(getRversion()), " jsonlite=", as.character(packageVersion("jsonlite")), " ggplot2=", as.character(packageVersion("ggplot2")), "\n", sep="")'
+
+      - name: Test real source runtime chain
+        env:
+          RUN_KERNEL: '1'
+        run: >-
+          npx vitest run
+          src/main/notebook/repl-loop.integration.test.ts
+          src/main/notebook/host-compute.integration.test.ts
+          src/main/notebook/host-mcp.integration.test.ts
+          src/main/notebook/python-loop.integration.test.ts
+          src/main/notebook/r-loop.integration.test.ts
+          src/main/notebook/e2e.certification.test.ts
+          src/main/agents/agents-repl.integration.test.ts
+          src/main/agents/agents-repl.mutations.integration.test.ts
+          src/main/agents/agents-repl.privileged.integration.test.ts
+          src/main/agents/agents-repl.runtime-consumption.integration.test.ts
+          --maxWorkers=1
+          --testTimeout=60000
+          --hookTimeout=60000

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -98,7 +98,7 @@ describe('release and scheduled workflow topology', () => {
     })
     expect(nightly.jobs.build).toMatchObject({
       needs: 'plan',
-      if: "needs.plan.outputs.should_build == 'true'",
+      if: "needs.plan.outputs.should_build == 'true' && inputs.dry_run != 'runtime-source'",
       uses: './.github/workflows/build.yml',
       with: { nightly: true }
     })

--- a/scripts/ci/runtime-certification-workflow.test.ts
+++ b/scripts/ci/runtime-certification-workflow.test.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { load } from 'js-yaml'
+import { describe, expect, it } from 'vitest'
+
+type Step = {
+  env?: Record<string, string>
+  name?: string
+  run?: string
+  uses?: string
+  with?: Record<string, unknown>
+}
+
+type Job = {
+  'continue-on-error'?: string
+  if?: string
+  needs?: string | string[]
+  'runs-on'?: string
+  steps?: Step[]
+  'timeout-minutes'?: number
+  uses?: string
+  with?: Record<string, unknown>
+}
+
+type Workflow = {
+  concurrency?: { 'cancel-in-progress'?: boolean; group?: string }
+  jobs: Record<string, Job>
+  on?: Record<string, unknown>
+  permissions?: Record<string, string>
+}
+
+const workflow = (name: string): Workflow =>
+  load(readFileSync(join(process.cwd(), '.github/workflows', name), 'utf8')) as Workflow
+
+const step = (job: Job, name: string): Step => {
+  const result = job.steps?.find((candidate) => candidate.name === name)
+  if (!result) throw new Error(`Missing step: ${name}`)
+  return result
+}
+
+describe('runtime certification workflow', () => {
+  it('provides one reusable, manually dispatchable, read-only Linux source lane', () => {
+    const runtime = workflow('runtime-certification.yml')
+    const source = runtime.jobs.source
+
+    expect(runtime.on).toHaveProperty('workflow_call')
+    expect(runtime.on).toHaveProperty('workflow_dispatch')
+    expect(runtime.permissions).toEqual({ contents: 'read' })
+    expect(runtime.concurrency).toEqual({
+      group: 'runtime-certification-${{ github.workflow }}-${{ github.ref }}',
+      'cancel-in-progress': true
+    })
+    expect(source).toMatchObject({
+      'continue-on-error': '${{ inputs.allow_failure }}',
+      'runs-on': 'ubuntu-latest',
+      'timeout-minutes': 20
+    })
+  })
+
+  it('uses pinned micromamba to provision real Python and R prerequisites', () => {
+    const source = workflow('runtime-certification.yml').jobs.source
+    const fetch = step(source, 'Fetch pinned micromamba')
+    const create = step(source, 'Create real Python and R environments')
+    const verify = step(source, 'Verify runtime prerequisites')
+
+    expect(fetch.run).toContain('scripts/fetch-micromamba.mjs linux-64')
+    expect(create.run).toContain('python=3.12 matplotlib-base nomkl')
+    expect(create.run).toContain('r-base=4.4 r-jsonlite r-ggplot2')
+    expect(create.run).toContain('OPEN_SCIENCE_TEST_PY_ENV=')
+    expect(create.run).toContain('OPEN_SCIENCE_TEST_R_ENV=')
+    expect(verify.run).toContain('library(jsonlite)')
+    expect(verify.run).toContain('library(ggplot2)')
+  })
+
+  it('activates the explicit real runtime suites without package or publication side effects', () => {
+    const source = workflow('runtime-certification.yml').jobs.source
+    const test = step(source, 'Test real source runtime chain')
+    const allRuns = source.steps?.map(({ run }) => run ?? '').join('\n') ?? ''
+
+    expect(test.env).toEqual({ RUN_KERNEL: '1' })
+    for (const file of [
+      'repl-loop.integration.test.ts',
+      'host-compute.integration.test.ts',
+      'host-mcp.integration.test.ts',
+      'python-loop.integration.test.ts',
+      'r-loop.integration.test.ts',
+      'e2e.certification.test.ts',
+      'agents-repl.integration.test.ts',
+      'agents-repl.mutations.integration.test.ts',
+      'agents-repl.privileged.integration.test.ts',
+      'agents-repl.runtime-consumption.integration.test.ts'
+    ]) {
+      expect(test.run).toContain(file)
+    }
+    expect(test.run).not.toContain('full-stack.smoke.test.ts')
+    expect(allRuns).not.toMatch(/aws s3|gh release|npm publish|softprops\/action-gh-release/)
+  })
+
+  it('exposes the exact Nightly caller as a focused dry-run without gating publication', () => {
+    const nightly = workflow('nightly.yml')
+    const dispatch = nightly.on?.workflow_dispatch as {
+      inputs?: { dry_run?: { default?: string; options?: string[] } }
+    }
+    const runtime = nightly.jobs['runtime-certification']
+
+    expect(dispatch.inputs?.dry_run).toMatchObject({
+      default: 'full',
+      options: ['full', 'runtime-source']
+    })
+    expect(nightly.jobs.build.if).toContain("inputs.dry_run != 'runtime-source'")
+    expect(runtime).toMatchObject({
+      needs: 'plan',
+      if: "needs.plan.outputs.should_build == 'true'",
+      uses: './.github/workflows/runtime-certification.yml',
+      with: { allow_failure: "${{ github.event_name != 'workflow_dispatch' }}" }
+    })
+    expect(nightly.jobs.prepare.needs).toEqual(['plan', 'build', 'package-smoke'])
+    expect(workflow('release.yml').jobs).not.toHaveProperty('runtime-certification')
+  })
+})

--- a/scripts/ci/runtime-certification-workflow.test.ts
+++ b/scripts/ci/runtime-certification-workflow.test.ts
@@ -60,10 +60,12 @@ describe('runtime certification workflow', () => {
 
   it('uses pinned micromamba to provision real Python and R prerequisites', () => {
     const source = workflow('runtime-certification.yml').jobs.source
+    const install = step(source, 'Install test dependencies')
     const fetch = step(source, 'Fetch pinned micromamba')
     const create = step(source, 'Create real Python and R environments')
     const verify = step(source, 'Verify runtime prerequisites')
 
+    expect(install.run).toBe('npm ci')
     expect(fetch.run).toContain('scripts/fetch-micromamba.mjs linux-64')
     expect(create.run).toContain('python=3.12 matplotlib-base nomkl')
     expect(create.run).toContain('r-base=4.4 r-jsonlite r-ggplot2')


### PR DESCRIPTION
## Problem

Real Node REPL, Python, R, kernel, and Notebook capability suites are gated by environment variables that no checked-in CI workflow sets. They therefore remain skipped even in complete Vitest runs, leaving the real source runtime chain without continuous evidence.

## Proposed change

- add a reusable, read-only Linux source runtime certification workflow
- provision ephemeral Python 3.12 and R 4.4 environments with the repository's pinned, digest-verified micromamba downloader
- run the explicit Node REPL/host/Agent, Python/R loop, and Notebook capability certification suites
- add a focused `Nightly` manual dry-run option, `runtime-source`, that skips build, package smoke, regression, preparation, and publication
- run the same certification from scheduled Nightly as an advisory burn-in signal
- add workflow topology and no-side-effect contract tests

```mermaid
flowchart LR
  Main["Hourly Nightly"] --> Plan["Plan"]
  Plan --> Build["Existing build/package path"]
  Plan --> Runtime["Linux source runtime certification"]
  Runtime --> Advisory["Advisory during burn-in"]
  Manual["workflow_dispatch: runtime-source"] --> Runtime
  Manual -. skips .-> Build
```

## Scope and non-goals

- This PR does not add runtime work to ordinary PR lanes.
- This PR does not certify packaged applications or immutable CDN runtime packs.
- This PR does not change runtime-bundle upload behavior.
- This PR does not modify `.github/workflows/release.yml`.
- The source lane intentionally uses `r-ggplot2` because existing gated R certification cases exercise ggplot capture; aligning the future packaged baseline with the curated base-R pack remains separate work.

### Release hard gates

No Release hard gate is added by this PR. The existing stable Release chain remains unchanged: release preflight, reusable build verification/native builds, package smoke, and tag-only notarization must complete before `publish`; publication also aggregates the existing release-certification evidence.

A future packaged-runtime certification could become a Release hard gate only in a separate change after Nightly burn-in. That change should explicitly add the packaged result before `publish`; it must not make Release the first place the runtime chain is exercised.

## Acceptance criteria and validation

Final checks ran after the last material edit:

- workflow routing, read-only permissions, explicit suite list, Release non-integration, and Nightly topology -> `npx vitest run scripts/ci/runtime-certification-workflow.test.ts scripts/ci/release-workflows.test.ts scripts/ci/ci-integrity-workflow.test.ts scripts/ci/pr-gate-workflow.test.ts` -> 4 files / 35 tests passed
- changed TypeScript workflow contracts -> `npx eslint scripts/ci/runtime-certification-workflow.test.ts scripts/ci/release-workflows.test.ts` -> passed
- changed-file formatting -> `npx prettier --check ...` -> passed
- whitespace safety -> `git diff --check` -> passed
- real source runtime chain -> focused Nightly dry-run https://github.com/aipoch/open-science/actions/runs/31954336633 -> Python 3.12.13, R 4.4.3, 10 files / 166 tests passed; build/package/regression/prepare all skipped

The first focused dry-run https://github.com/aipoch/open-science/actions/runs/31954173486 correctly exposed that `npm ci --ignore-scripts` leaves Electron uninstalled. The workflow now uses the repository-standard `npm ci`; the second dry-run passed in 2m28s.

No full local `npm test` was run; exact-head PR CI remains authoritative for the complete suite and platform lanes.

Uncovered risks:

- scheduled runtime certification is advisory and does not block Nightly preparation/publication during burn-in
- packaged application + CDN bundle materialization/execution is not yet covered
- Windows real runtime smoke is not included in this Linux source-certification PR

## Review focus

- whether the 10-file source suite is the right initial ownership boundary
- whether a 2m28s parallel advisory Nightly job is acceptable during burn-in
- whether the explicit separation from Release and packaged certification is clear enough for later promotion

Related issue: none.