### PR TITLE
fix(acp): reconcile runtime state after event drain

### DIFF
--- a/src/renderer/src/lib/acp/useAcpRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.test.ts
@@ -485,6 +485,21 @@ describe('useAcpRuntime state subscription', () => {
 
     expect(result.current.state).toEqual(terminal)
   })
+
+  it('reconciles a snapshot already accepted by another renderer ingress', async () => {
+    const { result } = await mountRuntime()
+    const pulled = createSnapshot({
+      revision: 2,
+      sessionIds: ['session-1'],
+      promptInFlight: false,
+      promptInFlightSessionIds: []
+    })
+
+    expect(acceptAcpRuntimeSnapshotRevision(pulled)).toBe(true)
+    act(() => result.current.reconcileSnapshot(pulled))
+
+    expect(result.current.state).toEqual(pulled)
+  })
 })
 
 describe('useAcpRuntime pending lifecycle', () => {

--- a/src/renderer/src/lib/acp/useAcpRuntime.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.ts
@@ -42,6 +42,7 @@ const getErrorMessage = (error: unknown): string => {
 // Centralizes renderer access to the main-process runtime IPC surface.
 const useAcpRuntime = (): {
   state: AcpStateSnapshot
+  reconcileSnapshot: (snapshot: AcpStateSnapshot) => void
   actionError: string | null
   isConnecting: boolean
   isDisconnecting: boolean
@@ -420,6 +421,7 @@ const useAcpRuntime = (): {
 
   return {
     state,
+    reconcileSnapshot: applySnapshot,
     actionError,
     isConnecting,
     isDisconnecting,

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -386,6 +386,20 @@ describe('workspace Agent Runtime hook contract', () => {
     expect(reconcileSnapshot).not.toHaveBeenCalled()
   })
 
+  it('reconciles live runtime state after durable drain projections settle', async () => {
+    const order: string[] = []
+    const setContextUsage = vi
+      .spyOn(useSessionStore.getState(), 'setContextUsage')
+      .mockImplementation(() => order.push('durable'))
+    const snapshot = createSnapshot({ revision: 2, sessionIds: ['session-1'] })
+    window.api = { acp: { getState: vi.fn().mockResolvedValue(snapshot) } } as never
+
+    await drainWorkspaceRuntimeEventsForPersistence(undefined, () => order.push('runtime'))
+
+    expect(order).toEqual(['durable', 'runtime'])
+    setContextUsage.mockRestore()
+  })
+
   it('routes permission commands through the runtime and persists its committed profile', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -372,6 +372,20 @@ describe('workspace Agent Runtime hook contract', () => {
     expect(runtime.reconcileSnapshot).toHaveBeenCalledWith(reconciledSnapshot)
   })
 
+  it('does not reconcile an unordered legacy drain snapshot into live runtime state', async () => {
+    const legacySnapshot = createSnapshot({
+      sessionIds: ['session-1'],
+      promptInFlight: true,
+      promptInFlightSessionIds: ['session-1']
+    })
+    const reconcileSnapshot = vi.fn()
+    window.api = { acp: { getState: vi.fn().mockResolvedValue(legacySnapshot) } } as never
+
+    await drainWorkspaceRuntimeEventsForPersistence(undefined, reconcileSnapshot)
+
+    expect(reconcileSnapshot).not.toHaveBeenCalled()
+  })
+
   it('routes permission commands through the runtime and persists its committed profile', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -59,6 +59,7 @@ const createSnapshot = (overrides: Partial<AcpStateSnapshot> = {}): AcpStateSnap
 
 type RuntimeMock = {
   state: AcpStateSnapshot
+  reconcileSnapshot: Mock
   actionError: string | null
   isConnecting: boolean
   createSession: Mock
@@ -76,6 +77,7 @@ type RuntimeMock = {
 
 const createRuntime = (state: AcpStateSnapshot): RuntimeMock => ({
   state,
+  reconcileSnapshot: vi.fn(),
   actionError: null as string | null,
   isConnecting: false,
   createSession: vi.fn(),
@@ -334,7 +336,13 @@ describe('workspace Agent Runtime hook contract', () => {
     const runtime = createRuntime(createSnapshot())
     runtime.resumeSession.mockReturnValue(resume.promise)
     runtimeMock.current = runtime
-    const getState = vi.fn().mockResolvedValue(createSnapshot({ sessionIds: ['session-1'] }))
+    const reconciledSnapshot = createSnapshot({
+      revision: 2,
+      sessionIds: ['session-1'],
+      promptInFlight: false,
+      promptInFlightSessionIds: []
+    })
+    const getState = vi.fn().mockResolvedValue(reconciledSnapshot)
     window.api = { acp: { getState } } as never
     await render()
 
@@ -361,6 +369,7 @@ describe('workspace Agent Runtime hook contract', () => {
     expect(getState.mock.invocationCallOrder[0]).toBeLessThan(
       runtime.sendPrompt.mock.invocationCallOrder[0]
     )
+    expect(runtime.reconcileSnapshot).toHaveBeenCalledWith(reconciledSnapshot)
   })
 
   it('routes permission commands through the runtime and persists its committed profile', async () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -45,7 +45,8 @@ import {
   syncWorkspaceContextUsage,
   syncWorkspaceElicitationState,
   syncWorkspaceInteractionState,
-  syncWorkspacePermissionState
+  syncWorkspacePermissionState,
+  useWorkspaceRuntimeEventDrain
 } from './workspace-runtime-event-owner'
 import { getResumeFailureMessage } from './workspace-runtime-prompt-preparation-owner'
 import {
@@ -127,7 +128,6 @@ type WorkspaceAgentRuntime = {
 
 const WorkspaceAgentRuntimeContext = createContext<WorkspaceAgentRuntime | null>(null)
 const RuntimeProvider = WorkspaceAgentRuntimeContext.Provider
-
 const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   const runtime = useAcpRuntime()
   const subagentRuntimeUpdateListeners = useRef(new Set<SubagentRuntimeListener>())
@@ -222,7 +222,7 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
     },
     []
   )
-  const drainRuntimeEvents = drainWorkspaceRuntimeEventsForPersistence
+  const drainRuntimeEvents = useWorkspaceRuntimeEventDrain(runtime.reconcileSnapshot)
   const previousStatusRef = useRef(runtime.state.status)
   const previousSessionStatusesRef = useRef(runtime.state.sessionConnectionStatuses)
   const previousDurablePermissionSessionIdsRef = useRef<ReadonlySet<string>>(new Set())

--- a/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
@@ -527,9 +527,10 @@ const drainWorkspaceRuntimeEventsForPersistence = async (
 ): Promise<void> => {
   const snapshot = await window.api.acp.getState()
   const accepted = await ingestWorkspaceRuntimeSnapshot(snapshot, false)
-  // A persistence drain shares the global revision watermark with the live React projection.
-  // Reconcile the same accepted snapshot so the drain cannot strand that projection behind it.
-  if (accepted) reconcileRuntimeSnapshot?.(snapshot)
+  // A versioned persistence drain shares the global revision watermark with the live React
+  // projection. Reconcile the same accepted snapshot so the drain cannot strand that projection
+  // behind it. Legacy unversioned pulls have no ordering proof and must not overwrite live state.
+  if (accepted && snapshot.revision !== undefined) reconcileRuntimeSnapshot?.(snapshot)
   await liveWorkspaceRuntimeEventProcessor.drain(sessionId)
   if (accepted) syncWorkspaceContextUsage(snapshot.sessionIds, snapshot.contextUsageBySession)
 }

--- a/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
@@ -11,6 +11,7 @@ import {
   type AcpStateSnapshot,
   type PendingElicitationRequest
 } from '../../../../shared/acp'
+import { useCallback } from 'react'
 import { useSessionStore } from '../../stores/session-store'
 import {
   acceptAcpRuntimeSnapshotRevision,
@@ -520,12 +521,27 @@ const refreshDelegatedWorkSessions = async (
   }
 }
 
-const drainWorkspaceRuntimeEventsForPersistence = async (sessionId?: string): Promise<void> => {
+const drainWorkspaceRuntimeEventsForPersistence = async (
+  sessionId?: string,
+  reconcileRuntimeSnapshot?: (snapshot: AcpStateSnapshot) => void
+): Promise<void> => {
   const snapshot = await window.api.acp.getState()
   const accepted = await ingestWorkspaceRuntimeSnapshot(snapshot, false)
+  // A persistence drain shares the global revision watermark with the live React projection.
+  // Reconcile the same accepted snapshot so the drain cannot strand that projection behind it.
+  if (accepted) reconcileRuntimeSnapshot?.(snapshot)
   await liveWorkspaceRuntimeEventProcessor.drain(sessionId)
   if (accepted) syncWorkspaceContextUsage(snapshot.sessionIds, snapshot.contextUsageBySession)
 }
+
+const useWorkspaceRuntimeEventDrain = (
+  reconcileRuntimeSnapshot: (snapshot: AcpStateSnapshot) => void
+): ((sessionId?: string) => Promise<void>) =>
+  useCallback(
+    (sessionId?: string) =>
+      drainWorkspaceRuntimeEventsForPersistence(sessionId, reconcileRuntimeSnapshot),
+    [reconcileRuntimeSnapshot]
+  )
 
 export {
   createWorkspaceRuntimeEventProcessor,
@@ -540,5 +556,6 @@ export {
   syncWorkspaceContextUsage,
   syncWorkspaceElicitationState,
   syncWorkspaceInteractionState,
-  syncWorkspacePermissionState
+  syncWorkspacePermissionState,
+  useWorkspaceRuntimeEventDrain
 }

--- a/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
@@ -527,12 +527,12 @@ const drainWorkspaceRuntimeEventsForPersistence = async (
 ): Promise<void> => {
   const snapshot = await window.api.acp.getState()
   const accepted = await ingestWorkspaceRuntimeSnapshot(snapshot, false)
+  await liveWorkspaceRuntimeEventProcessor.drain(sessionId)
+  if (accepted) syncWorkspaceContextUsage(snapshot.sessionIds, snapshot.contextUsageBySession)
   // A versioned persistence drain shares the global revision watermark with the live React
   // projection. Reconcile the same accepted snapshot so the drain cannot strand that projection
   // behind it. Legacy unversioned pulls have no ordering proof and must not overwrite live state.
   if (accepted && snapshot.revision !== undefined) reconcileRuntimeSnapshot?.(snapshot)
-  await liveWorkspaceRuntimeEventProcessor.drain(sessionId)
-  if (accepted) syncWorkspaceContextUsage(snapshot.sessionIds, snapshot.contextUsageBySession)
 }
 
 const useWorkspaceRuntimeEventDrain = (


### PR DESCRIPTION
## Problem

A renderer event drain can pull and accept a newer ACP runtime snapshot while only updating the durable event projection. That advances the shared snapshot revision watermark without updating the live React runtime projection. If the terminal state broadcast arrives afterward with a lower revision, it is correctly rejected as stale, but the UI remains on the older prompt-in-flight state.

Production evidence showed the Agent request ending normally and the persisted Session returning to idle with no pending permission or elicitation. The stale runtime ownership still disabled Send, while Queue remained unavailable because the Session was no longer running.

## Proposed change

Reconcile every accepted event-drain snapshot into the live ACP runtime projection as well as the durable event projection. A stable event-owner hook binds that reconciliation callback for resume, restored-interaction, and runtime-adoption drains.

The existing Send and Queue admission rules remain unchanged, including the guard that blocks duplicate prompts while a real runtime interaction owns an otherwise idle Session.

## Scope and non-goals

- No new IPC method, wire field, state enum, or dependency.
- No change to prompt concurrency, message queue admission, or Session actionability rules.
- No database or Session file format change.
- No attempt to repair or rewrite local persisted data.

## Historical compatibility and persistence

No migration or historical-data compatibility path is required. The affected ownership and revision values are renderer runtime state rather than persisted Session fields. Existing Session data remains readable without modification.

Older Main versions that omit snapshot revisions retain the previous drain behavior: their snapshots still update durable event projections but are not reconciled into live React state because cross-ingress ordering cannot be proven. This avoids regressing a newer pushed state with an older unversioned pull.

## Acceptance criteria and validation

The cumulative module suite, typecheck, lint, and formatting checks ran after the final material edit and after rebasing onto the latest origin/main. The targeted regression runs below record the test-first iterations that reproduced each defect before its fix.

- Workspace runtime owners, contracts, consumers, and renderer-state overlay -> npm run test:module -- workspace_runtime -> 7 files and 311 tests passed.
- Cross-ingress snapshot reconciliation and runtime-adoption regression coverage -> targeted Vitest run -> 3 files and 45 tests passed.
- Revisionless legacy pull ordering regression -> targeted Vitest test-first run -> 1 test passed after reproducing the failure.
- Event barrier ordering regression -> targeted Vitest test-first run -> 1 test passed after reproducing the durable/live projection inversion.
- Renderer TypeScript contract -> npm run typecheck:web -> passed.
- Repository lint -> npm run lint -> passed.
- Changed-file formatting -> Prettier check -> passed.

Per the requested workflow, the complete npm test suite was not run locally. Exact-head PR CI remains authoritative for the complete test matrix.

## Review focus

Please verify that an accepted persistence-drain snapshot should reconcile the live React runtime projection at the same revision boundary, and that preserving the existing Send and Queue gates avoids the prompt-admission race.
