### PR TITLE
fix(skills): synthesize canonical Claude Skill frontmatter

### DIFF
--- a/src/main/settings/claude-runtime-provisioner.test.ts
+++ b/src/main/settings/claude-runtime-provisioner.test.ts
@@ -14,6 +14,9 @@ import { join, relative } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ClaudeCodeSkillMaterializer } from '../skills/materializer'
+import type { BundledSkill } from '../skills/registry'
+
 const renameSourceModes = vi.hoisted(() => [] as number[])
 
 vi.mock('node:fs/promises', async (importOriginal) => {
@@ -422,6 +425,43 @@ describe('provisionClaudeRuntime', () => {
     ).rejects.toThrow('Skill projection')
 
     expect(await readdir(getClaudeSkillProjectionRevisionsDir(root))).toEqual([])
+  })
+
+  it('publishes a canonical projection for a legacy imported Skill without frontmatter', async () => {
+    const root = await createStorageRoot()
+    const sourceDir = join(root, 'legacy-imported-skill')
+    await mkdir(sourceDir)
+    await writeFile(join(sourceDir, 'SKILL.md'), '# BioFlow transcriptomics\n', 'utf8')
+    const skill: BundledSkill = {
+      id: 'imported-bioflow-transcriptom',
+      name: 'bioflow-transcriptom',
+      displayName: 'BioFlow transcriptomics',
+      description: '',
+      source: 'imported',
+      updatedAt: 'legacy',
+      sourceDir
+    }
+
+    const assets = await provisionClaudeRuntime({
+      storageRoot: root,
+      materializeProjection: async (projectionRoot) => {
+        await new ClaudeCodeSkillMaterializer().sync(join(projectionRoot, '.claude'), [skill], {
+          directoryLayout: 'agent-facing'
+        })
+      }
+    })
+
+    await expect(
+      readFile(
+        join(assets.skillProjection.root, '.claude', 'skills', 'bioflow-transcriptom', 'SKILL.md'),
+        'utf8'
+      )
+    ).resolves.toBe(
+      '---\nname: bioflow-transcriptom\ndescription: BioFlow transcriptomics\n---\n# BioFlow transcriptomics\n'
+    )
+    await expect(readFile(join(sourceDir, 'SKILL.md'), 'utf8')).resolves.toBe(
+      '# BioFlow transcriptomics\n'
+    )
   })
 
   it.each(['root CLAUDE.md', 'root hooks', '.claude settings.json', '.claude hooks'])(

--- a/src/main/settings/claude-runtime-provisioner.test.ts
+++ b/src/main/settings/claude-runtime-provisioner.test.ts
@@ -427,11 +427,16 @@ describe('provisionClaudeRuntime', () => {
     expect(await readdir(getClaudeSkillProjectionRevisionsDir(root))).toEqual([])
   })
 
-  it('publishes a canonical projection for a legacy imported Skill without frontmatter', async () => {
+  it.each([
+    ['without frontmatter', '# BioFlow transcriptomics\n'],
+    ['with scalar frontmatter', '---\nlegacy\n---\n# BioFlow transcriptomics\n'],
+    ['with array frontmatter', '---\n- legacy\n---\n# BioFlow transcriptomics\n'],
+    ['with malformed frontmatter', '---\nname: [\n---\n# BioFlow transcriptomics\n']
+  ])('publishes a canonical projection for a legacy imported Skill %s', async (_, document) => {
     const root = await createStorageRoot()
     const sourceDir = join(root, 'legacy-imported-skill')
     await mkdir(sourceDir)
-    await writeFile(join(sourceDir, 'SKILL.md'), '# BioFlow transcriptomics\n', 'utf8')
+    await writeFile(join(sourceDir, 'SKILL.md'), document, 'utf8')
     const skill: BundledSkill = {
       id: 'imported-bioflow-transcriptom',
       name: 'bioflow-transcriptom',
@@ -459,9 +464,7 @@ describe('provisionClaudeRuntime', () => {
     ).resolves.toBe(
       '---\nname: bioflow-transcriptom\ndescription: BioFlow transcriptomics\n---\n# BioFlow transcriptomics\n'
     )
-    await expect(readFile(join(sourceDir, 'SKILL.md'), 'utf8')).resolves.toBe(
-      '# BioFlow transcriptomics\n'
-    )
+    await expect(readFile(join(sourceDir, 'SKILL.md'), 'utf8')).resolves.toBe(document)
   })
 
   it.each(['root CLAUDE.md', 'root hooks', '.claude settings.json', '.claude hooks'])(

--- a/src/main/skills/materializer.ts
+++ b/src/main/skills/materializer.ts
@@ -196,7 +196,7 @@ class ClaudeCodeSkillMaterializer implements SkillMaterializer {
           skill.id === COMPUTE_SKILL_ID
             ? await readFile(join(target, 'SKILL.md'), 'utf8').catch(() => undefined)
             : undefined
-        await this.copySkill(target, skill, priorComputeDocument)
+        await this.copySkill(target, skill, { priorComputeDocument })
         versions[name] = version
       } catch (error) {
         await rm(target, { recursive: true, force: true }).catch(() => undefined)
@@ -239,7 +239,7 @@ class ClaudeCodeSkillMaterializer implements SkillMaterializer {
 
       const target = join(skillsDir, skill.name)
       try {
-        await this.copySkill(target, skill)
+        await this.copySkill(target, skill, { synthesizeFrontmatter: true })
       } catch (error) {
         await rm(target, { recursive: true, force: true }).catch(() => undefined)
         log.warn('failed to materialize Agent-facing Skill', {
@@ -254,7 +254,10 @@ class ClaudeCodeSkillMaterializer implements SkillMaterializer {
   private async copySkill(
     target: string,
     skill: BundledSkill,
-    priorComputeDocument?: string
+    options: Readonly<{
+      priorComputeDocument?: string
+      synthesizeFrontmatter?: boolean
+    }> = {}
   ): Promise<void> {
     // Restore write bits before removal in case a prior sync left the dir read-only.
     await chmodTree(target, 'writable')
@@ -269,12 +272,16 @@ class ClaudeCodeSkillMaterializer implements SkillMaterializer {
         return true
       }
     })
-    await normalizeSkillDocumentName(join(target, 'SKILL.md'), skill.name)
-    if (priorComputeDocument !== undefined) {
+    await normalizeSkillDocumentName(join(target, 'SKILL.md'), skill.name, {
+      ...(options.synthesizeFrontmatter
+        ? { synthesizeFrontmatter: { description: skill.description || skill.displayName } }
+        : {})
+    })
+    if (options.priorComputeDocument !== undefined) {
       const current = await readFile(join(target, 'SKILL.md'), 'utf8')
       await writeFile(
         join(target, 'SKILL.md'),
-        preserveComputeHostProjection(current, priorComputeDocument),
+        preserveComputeHostProjection(current, options.priorComputeDocument),
         'utf8'
       )
     }

--- a/src/main/skills/skill-document-name.ts
+++ b/src/main/skills/skill-document-name.ts
@@ -11,18 +11,29 @@ const canonicalSkillDocument = (
   } = {}
 ): string => {
   const normalized = raw.replace(/\r\n?/g, '\n')
+  const synthesize = (body: string): string => {
+    const frontmatter = {
+      name,
+      description: options.synthesizeFrontmatter?.description.trim() || name
+    }
+    return `---\n${dumpYaml(frontmatter, { lineWidth: -1 }).trimEnd()}\n---\n${body}`
+  }
   const match = /^---\n([\s\S]*?)\n---\n?/.exec(normalized)
   if (!match) {
     if (!options.synthesizeFrontmatter) return raw
-    const frontmatter = {
-      name,
-      description: options.synthesizeFrontmatter.description.trim() || name
-    }
-    return `---\n${dumpYaml(frontmatter, { lineWidth: -1 }).trimEnd()}\n---\n${normalized}`
+    return synthesize(normalized)
   }
 
-  const parsed = loadYaml(match[1], { schema: FAILSAFE_SCHEMA })
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return raw
+  let parsed: unknown
+  try {
+    parsed = loadYaml(match[1], { schema: FAILSAFE_SCHEMA })
+  } catch (error) {
+    if (!options.synthesizeFrontmatter) throw error
+    return synthesize(normalized.slice(match[0].length))
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return options.synthesizeFrontmatter ? synthesize(normalized.slice(match[0].length)) : raw
+  }
   const fields = Object.entries(parsed as Record<string, unknown>)
   const frontmatter = {
     ...Object.fromEntries(

--- a/src/main/skills/skill-document-name.ts
+++ b/src/main/skills/skill-document-name.ts
@@ -5,11 +5,21 @@ import { dump as dumpYaml, load as loadYaml, FAILSAFE_SCHEMA } from 'js-yaml'
 const canonicalSkillDocument = (
   raw: string,
   name: string,
-  options: { omitDisplayName?: boolean } = {}
+  options: {
+    omitDisplayName?: boolean
+    synthesizeFrontmatter?: { description: string }
+  } = {}
 ): string => {
   const normalized = raw.replace(/\r\n?/g, '\n')
   const match = /^---\n([\s\S]*?)\n---\n?/.exec(normalized)
-  if (!match) return raw
+  if (!match) {
+    if (!options.synthesizeFrontmatter) return raw
+    const frontmatter = {
+      name,
+      description: options.synthesizeFrontmatter.description.trim() || name
+    }
+    return `---\n${dumpYaml(frontmatter, { lineWidth: -1 }).trimEnd()}\n---\n${normalized}`
+  }
 
   const parsed = loadYaml(match[1], { schema: FAILSAFE_SCHEMA })
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return raw
@@ -44,9 +54,13 @@ export const hasCanonicalSkillDocumentName = (raw: string, name: string): boolea
   )
 }
 
-export const normalizeSkillDocumentName = async (path: string, name: string): Promise<void> => {
+export const normalizeSkillDocumentName = async (
+  path: string,
+  name: string,
+  options: { synthesizeFrontmatter?: { description: string } } = {}
+): Promise<void> => {
   const raw = await readFile(path, 'utf8')
-  const normalized = canonicalSkillDocument(raw, name)
+  const normalized = canonicalSkillDocument(raw, name, options)
   if (normalized !== raw) await writeFile(path, normalized, 'utf8')
 }
 


### PR DESCRIPTION
## Problem

Session resume can fail with Claude Skill projection entry must use its canonical frontmatter name when an enabled historical Imported or Personal Skill has missing, scalar, array, or malformed SKILL.md frontmatter. The local package directory remains the canonical invocation name, but the projection normalizer previously left non-object documents unchanged or threw on invalid YAML; the strict Claude projection publisher then rejected the missing frontmatter name and aborted runtime provisioning, or the materializer omitted the Skill.

## Proposed change

When building the Claude-only agent-facing projection, synthesize canonical name and a non-empty description for a Skill document that has no usable frontmatter. Preserve the instruction body and leave the authoritative source package unchanged.

## Scope and non-goals

- Applies only to Claude agent-facing, content-addressed projection copies.
- OpenCode, Codex Response, and Codex Bridge retain their existing app-owned projection behavior.
- Does not migrate or rewrite Personal or Imported source packages.
- Does not add persisted fields, schema changes, migrations, or enum/state values.
- Does not weaken the projection publisher canonical-name validation.

## Acceptance criteria and validation

- Legacy missing/malformed frontmatter resumes through Claude projection -> npm test -- src/main/settings/claude-runtime-provisioner.test.ts -t "publishes a canonical projection for a legacy imported Skill" -> 4 passed.
- Skills and Settings materialization/runtime behavior -> npm test -- src/main/skills/materializer.test.ts src/main/skills/export.test.ts src/main/settings/claude-runtime-provisioner.test.ts src/main/settings/agent-runtime-manager.test.ts src/main/settings/backend-resolver.test.ts src/main/settings/skill-catalog.test.ts -> 159 passed, 4 skipped.
- Main-process types -> npm run typecheck:node -> passed.
- Lint -> npm run lint -> passed.

All listed checks ran after the last material edit. The focused backend resolver and runtime manager tests cover route separation; complete portable and platform coverage remains authoritative in PR CI. The changed legacy Skills helper files are not currently assigned to a module-impact owner, so PR Gate may fail closed to its full plan.

## Review focus

- Confirm synthetic frontmatter is limited to the rebuildable Claude projection.
- Confirm missing, scalar, array, and malformed frontmatter all preserve only the instruction body.
- Confirm the source Skill remains byte-for-byte unchanged.
- Confirm canonical validation still rejects unsafe or mismatched published entries.