### PR TITLE
test(test-impact): certify declared module coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,7 @@ Run installation, development, and validation commands from the repository root:
 | Run            | `npm run dev`                                              |
 | Target test    | `npm test -- <affected-test-path> [-t '<test pattern>']`   |
 | Module tests   | `npm run test:module -- <module-id>`                       |
+| Affected tests | `npm run test:affected -- --base <base> --head <head>`     |
 | Node typecheck | `npm run typecheck:node`                                   |
 | Web typecheck  | `npm run typecheck:web`                                    |
 | Lint           | `npm run lint`                                             |
@@ -174,6 +175,11 @@ Before handoff, derive the minimum set from the final material diff:
 
 Directory proximity alone is not impact evidence. If a file mixes responsibilities, treat it as
 Interface-affecting or use the full fallback.
+
+`test:module` supports only the Module IDs declared in `scripts/ci/module-impact.json`. It runs that
+Module's curated owner, contract, and representative consumer tests; it is not complete downstream
+verification for an Interface change. Use `test:affected` or the exact-head PR Gate plan when an
+Interface or its consumers may have changed.
 
 ### Full fallback
 

--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -658,7 +658,8 @@
       "testFiles": {
         "owner": [
           "src/main/session-persistence/coordinator.architecture.test.ts",
-          "src/main/session-persistence/coordinator.test.ts"
+          "src/main/session-persistence/coordinator.test.ts",
+          "src/main/session-persistence/delegated-work-records.test.ts"
         ],
         "contract": [
           "src/shared/session-persistence.test.ts",

--- a/scripts/ci/module-test-impact.mjs
+++ b/scripts/ci/module-test-impact.mjs
@@ -198,12 +198,25 @@ export function formatModuleTestPlan(plan) {
 
 export function executeModuleTestPlan(
   plan,
-  { cwd = process.cwd(), spawn = spawnSync, environment = process.env } = {}
+  {
+    cwd = process.cwd(),
+    spawn = spawnSync,
+    environment = process.env,
+    platform = process.platform,
+    nodeExecutable = process.execPath
+  } = {}
 ) {
   process.stdout.write(formatModuleTestPlan(plan))
   if (plan.mode === 'selective' && plan.testFiles.length === 0) return 0
-  const command = process.platform === 'win32' ? 'npm.cmd' : 'npm'
-  const arguments_ = plan.mode === 'full' ? ['test'] : ['test', '--', ...plan.testFiles]
+  const npmArguments = plan.mode === 'full' ? ['test'] : ['test', '--', ...plan.testFiles]
+  const npmExecPath = environment.npm_execpath
+  if (platform === 'win32' && !npmExecPath) {
+    throw new Error(
+      'npm_execpath is unavailable on Windows; run this command through npm run test:module or npm run test:affected'
+    )
+  }
+  const command = npmExecPath ? nodeExecutable : 'npm'
+  const arguments_ = npmExecPath ? [npmExecPath, ...npmArguments] : npmArguments
   const result = spawn(command, arguments_, { cwd, env: environment, stdio: 'inherit' })
   if (result.error) throw result.error
   return result.status ?? 1

--- a/scripts/ci/module-test-impact.test.ts
+++ b/scripts/ci/module-test-impact.test.ts
@@ -441,14 +441,64 @@ describe('module test impact commands', () => {
     const spawn = vi.fn(() => ({ status: 0 }))
     const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
 
-    expect(executeModuleTestPlan(plan, { cwd: '/repo', spawn })).toBe(0)
+    expect(
+      executeModuleTestPlan(plan, {
+        cwd: '/repo',
+        spawn,
+        environment: { npm_execpath: '/npm/bin/npm-cli.js' },
+        nodeExecutable: '/node'
+      })
+    ).toBe(0)
     expect(write).toHaveBeenCalledWith(formatModuleTestPlan(plan))
     expect(spawn).toHaveBeenCalledWith(
-      process.platform === 'win32' ? 'npm.cmd' : 'npm',
+      '/node',
+      ['/npm/bin/npm-cli.js', 'test', '--', ...plan.testFiles],
+      expect.objectContaining({ cwd: '/repo', stdio: 'inherit' })
+    )
+    write.mockRestore()
+  })
+
+  it('fails with an actionable error instead of spawning a Windows command shim', () => {
+    const plan = createModuleTestPlan('artifact_storage')
+    const spawn = vi.fn()
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    expect(() =>
+      executeModuleTestPlan(plan, {
+        spawn,
+        environment: {},
+        platform: 'win32'
+      })
+    ).toThrow('run this command through npm run test:module or npm run test:affected')
+    expect(spawn).not.toHaveBeenCalled()
+    write.mockRestore()
+  })
+
+  it('retains the PATH-based npm fallback for direct POSIX execution', () => {
+    const plan = createModuleTestPlan('artifact_storage')
+    const spawn = vi.fn(() => ({ status: 0 }))
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    expect(
+      executeModuleTestPlan(plan, {
+        cwd: '/repo',
+        spawn,
+        environment: {},
+        platform: 'linux'
+      })
+    ).toBe(0)
+    expect(spawn).toHaveBeenCalledWith(
+      'npm',
       ['test', '--', ...plan.testFiles],
       expect.objectContaining({ cwd: '/repo', stdio: 'inherit' })
     )
     write.mockRestore()
+  })
+
+  it('keeps delegated-work behavior in the Session persistence Module plan', () => {
+    expect(createModuleTestPlan('session_persistence').testFiles).toContain(
+      'src/main/session-persistence/delegated-work-records.test.ts'
+    )
   })
 
   it('keeps npm test as the complete portable suite', () => {

--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -958,7 +958,8 @@ describe('Session persistence coordinator architecture', () => {
     expect(sessionPersistence.consumerModules).toEqual([])
     expect(sessionPersistence.testFiles.owner).toEqual([
       'src/main/session-persistence/coordinator.architecture.test.ts',
-      'src/main/session-persistence/coordinator.test.ts'
+      'src/main/session-persistence/coordinator.test.ts',
+      'src/main/session-persistence/delegated-work-records.test.ts'
     ])
     expect(sessionPersistence.testFiles.contract).toEqual([
       'src/shared/session-persistence.test.ts',

--- a/src/main/settings/provider-accounts.test.ts
+++ b/src/main/settings/provider-accounts.test.ts
@@ -159,6 +159,15 @@ describe('ProviderAccountsModule', () => {
       provider: { model: 'lab-model', key: 'secret-key' },
       needsChatResponsesBridge: true
     })
+    expect(module.resolveProviderApiEndpoints(stored)).toEqual(['openai'])
+    expect(module.resolveProvider(stored)).toMatchObject({
+      baseUrl: 'https://lab.example/v1',
+      model: 'lab-model',
+      key: 'secret-key'
+    })
+    expect(module.resolveRuntimeModelCatalog(stored, getAgentFramework('codex'))).toEqual([
+      expect.objectContaining({ providerId: stored.id, effectiveModel: 'lab-model' })
+    ])
     expect(module.resolveRuntimeReasoningEffortProfile(stored, 'lab-model')).toMatchObject({
       supported: true
     })
@@ -270,5 +279,82 @@ describe('ProviderAccountsModule', () => {
     expect(claudeIsolatedAuth.cancelLogin).toHaveBeenCalledOnce()
     expect(claudeSharedAuth.cancelLogin).toHaveBeenCalledOnce()
     expect((await repository.getSettings()).providers).toEqual([])
+  })
+
+  it('exposes authentication lifecycle operations through the Module Interface', async () => {
+    await module.upsertProvider({ type: 'codex-isolated' })
+
+    module.cancelCodexLogin()
+    expect(codexAuth.cancelLogin).toHaveBeenCalledOnce()
+    await expect(module.loginIsolatedCodex()).resolves.toMatchObject({
+      ok: true,
+      category: 'ok',
+      applied: true
+    })
+
+    await module.upsertProvider({ type: 'claude-isolated' })
+    vi.mocked(claudeIsolatedAuth.loginIsolated).mockResolvedValueOnce({
+      supported: true,
+      authenticated: true
+    })
+    vi.mocked(claudeIsolatedAuth.loginIsolatedBrowser).mockResolvedValueOnce({
+      supported: true,
+      authenticated: false,
+      cancelled: true,
+      message: 'Sign-in cancelled.'
+    })
+
+    await expect(module.loginIsolatedClaude('setup-token')).resolves.toMatchObject({
+      ok: true,
+      category: 'ok',
+      applied: true
+    })
+    await expect(module.loginIsolatedClaudeBrowser()).resolves.toMatchObject({
+      ok: false,
+      applied: false,
+      cancelled: true
+    })
+    await module.cancelClaudeIsolatedLogin()
+    expect(claudeIsolatedAuth.cancelLogin).toHaveBeenCalledOnce()
+
+    module.cancelClaudeLogin()
+    expect(claudeSharedAuth.cancelLogin).toHaveBeenCalledOnce()
+  })
+
+  it('returns bounded failures for missing model catalogs and incompatible drafts', async () => {
+    await expect(module.refreshProviderModels({ providerId: 'missing-provider' })).resolves.toEqual(
+      {
+        ok: false,
+        category: 'unknown',
+        message: 'Provider not found.'
+      }
+    )
+
+    await module.upsertProvider({
+      type: 'custom',
+      name: 'No catalog',
+      baseUrl: 'https://lab.example/v1',
+      model: 'lab-model',
+      key: 'secret-key',
+      apiEndpoints: ['openai']
+    })
+    const providerId = (await repository.getSettings()).providers[0].id
+    await expect(module.refreshProviderModels({ providerId })).resolves.toEqual({
+      ok: false,
+      category: 'unknown',
+      message: 'This provider has no model-list endpoint.'
+    })
+
+    await expect(
+      module.validateProvider({
+        draft: {
+          type: 'custom',
+          baseUrl: 'https://lab.example/v1',
+          model: 'lab-model',
+          key: 'secret-key',
+          apiEndpoints: ['openai']
+        }
+      })
+    ).resolves.toMatchObject({ ok: false, category: 'incompatible' })
   })
 })

--- a/src/main/settings/provider-auth-lifecycle.test.ts
+++ b/src/main/settings/provider-auth-lifecycle.test.ts
@@ -284,4 +284,67 @@ describe('ProviderAuthLifecycleOwner', () => {
     await expect(owner.isProviderKeyUsable(stored)).resolves.toBe(true)
     expect(claudeSharedAuth.getStatus).toHaveBeenCalledTimes(2)
   })
+
+  it('reports shared and isolated Claude status through the lifecycle Interface', async () => {
+    await expect(owner.getClaudeSharedStatus()).resolves.toMatchObject({
+      ok: true,
+      category: 'ok'
+    })
+    expect(runClaudeSubscriptionProbe).toHaveBeenCalledOnce()
+
+    await repository.deleteProvider(CLAUDE_SHARED_PROVIDER_ID)
+    await expect(owner.getClaudeSharedStatus()).resolves.toEqual({
+      ok: false,
+      category: 'unknown',
+      message: 'Claude subscription provider is not configured.'
+    })
+
+    await repository.upsertProvider({
+      id: CLAUDE_ISOLATED_PROVIDER_ID,
+      type: 'claude-isolated',
+      name: 'Open Science Claude login',
+      apiEndpoints: ['anthropic'],
+      keyRef: 'plain:setup-token'
+    })
+    vi.mocked(claudeIsolatedAuth.getStatus).mockResolvedValueOnce({
+      supported: true,
+      authenticated: true
+    })
+    await expect(owner.getClaudeIsolatedStatus()).resolves.toMatchObject({
+      ok: true,
+      category: 'ok'
+    })
+    expect(runClaudeSubscriptionProbe).toHaveBeenCalledTimes(2)
+  })
+
+  it('owns browser cancellation and explicit login cancellation', async () => {
+    await repository.deleteProvider(CLAUDE_SHARED_PROVIDER_ID)
+    await repository.upsertProvider({
+      id: CLAUDE_ISOLATED_PROVIDER_ID,
+      type: 'claude-isolated',
+      name: 'Open Science Claude login',
+      apiEndpoints: ['anthropic']
+    })
+    vi.mocked(claudeIsolatedAuth.loginIsolatedBrowser).mockResolvedValueOnce({
+      supported: true,
+      authenticated: false,
+      cancelled: true,
+      message: 'Sign-in cancelled.'
+    })
+
+    await expect(owner.loginIsolatedClaudeBrowser()).resolves.toEqual({
+      ok: false,
+      category: 'unknown',
+      message: 'Sign-in cancelled.',
+      applied: false,
+      cancelled: true
+    })
+
+    owner.cancelCodexLogin()
+    owner.cancelClaudeLogin()
+    await owner.cancelClaudeIsolatedLogin()
+    expect(codexAuth.cancelLogin).toHaveBeenCalledOnce()
+    expect(claudeSharedAuth.cancelLogin).toHaveBeenCalledOnce()
+    expect(claudeIsolatedAuth.cancelLogin).toHaveBeenCalledOnce()
+  })
 })


### PR DESCRIPTION
## Problem

The declared Module test layer had three concrete gaps: `test:module` could not launch Vitest on Windows because it spawned `npm.cmd` directly, Session persistence omitted its existing delegated-work behavior suite, and Provider Accounts coverage fell below the repository baseline. The Module manifest also needed clearer documentation about its partial, curated scope versus complete Interface-consumer verification.

## Proposed change

- launch npm through the current Node executable and `npm_execpath`, with an actionable Windows error for undocumented direct invocation
- add Windows/POSIX command construction tests
- add `delegated-work-records.test.ts` to the `session_persistence` owner evidence and architecture contract
- add Interface-level Provider authentication, status, cancellation, model-catalog, and incompatible-draft tests
- document `test:module` as a declared-Module check and direct Interface changes to `test:affected` or exact-head PR Gate verification

## Scope and non-goals

This PR certifies the 16 Modules already declared in `scripts/ci/module-impact.json`. It does not classify the remaining repository source tree, promote the non-blocking Module shadow into the authoritative PR Gate, or replace Vitest `--changed` selection.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Windows Module launcher -> `npm run test:module -- artifact_storage` -> 125 passed, 1 skipped
- Session persistence ownership and delegated work -> `npm run test:module -- session_persistence` -> 293 passed
- Provider Accounts Interface behavior -> `npm run test:module -- settings_provider_accounts` -> 342 passed
- CI/manifest contracts -> targeted Vitest set for module impact, PR Gate, Session architecture, and Provider tests -> 98 passed
- Node process types -> `npm run typecheck:node` -> passed
- lint -> `npm run lint` -> passed
- formatting and whitespace -> targeted Prettier check plus `git diff --check` -> passed

Focused V8 owner-path coverage:

| Module | Lines | Branches | Functions | Statements |
| --- | ---: | ---: | ---: | ---: |
| `session_persistence` | 77.10% | 59.59% | 71.96% | 72.83% |
| `settings_provider_accounts` | 78.00% | 60.93% | 82.17% | 75.05% |

Both now exceed the repository baseline. The complete local `npm test` suite was intentionally not run; this PR changes global CI inputs, so exact-head PR Gate CI is authoritative for the complete plan.

## Compatibility and persistence

- Historical data compatibility: none required
- Runtime state or enum additions: none
- Product persistence/schema/migration impact: none

## Review focus

Please review the npm launcher portability seam, the distinction between Module-local and Interface-consumer verification, and whether the two repaired Module evidence sets match their declared Interfaces.