### PR TITLE
fix(acp): renew resume timeout after reconnect

### DIFF
--- a/src/main/acp/provider-session-resumer.test.ts
+++ b/src/main/acp/provider-session-resumer.test.ts
@@ -269,7 +269,7 @@ const createHarness = (options: HarnessOptions = {}): ResumerHarness => {
       order.push('state callback')
       if (options.observerError) throw options.observerError
     },
-    resumeTimeoutMs: 30_000,
+    resumeTimeoutMs: 60_000,
     setTimer,
     clearTimer: () => undefined,
     diagnosticContext: () => ({})
@@ -486,6 +486,21 @@ describe('AcpProviderSessionResumer', () => {
     await expect(resumed).rejects.toThrow('ACP session resume timed out.')
     expect(harness.disconnectTimedOutConnection).toHaveBeenCalledOnce()
     expect(harness.registry.isIdentityClaimed('stable-app-session')).toBe(false)
+  })
+
+  it('starts a fresh timeout budget after reconnecting before provider resume stalls', async () => {
+    const harness = createHarness()
+    harness.request.mockImplementationOnce(() => new Promise<never>(() => undefined))
+
+    const resumed = harness.resume()
+    await vi.waitFor(() => expect(harness.request).toHaveBeenCalledOnce())
+    harness.fireTimeout()
+
+    await expect(resumed).rejects.toThrow('ACP session resume timed out.')
+    expect(harness.setTimer).toHaveBeenCalledTimes(2)
+    expect(harness.setTimer).toHaveBeenNthCalledWith(1, expect.any(Function), 60_000)
+    expect(harness.setTimer).toHaveBeenNthCalledWith(2, expect.any(Function), 60_000)
+    expect(harness.disconnectTimedOutConnection).toHaveBeenCalledOnce()
   })
 
   it('transfers its reservation to fresh adoption when Resume Policy rejects the backend', async () => {

--- a/src/main/acp/provider-session-resumer.ts
+++ b/src/main/acp/provider-session-resumer.ts
@@ -93,7 +93,12 @@ export class AcpProviderSessionResumer {
     const identity = reserved.reservation
 
     try {
-      return await this.withTimeout(() => this.resumeReserved(request, cwd, projectId, identity))
+      const connection = await this.withTimeout(() => this.deps.ensureConnected(cwd))
+      this.deps.assertCurrentConnection(connection)
+      identity.renew()
+      return await this.withTimeout(() =>
+        this.resumeConnected(request, connection, cwd, projectId, identity)
+      )
     } finally {
       identity.release()
     }
@@ -150,9 +155,7 @@ export class AcpProviderSessionResumer {
     }
   }
 
-  private async withTimeout(
-    operation: () => Promise<AcpCreateSessionResponse>
-  ): Promise<AcpCreateSessionResponse> {
+  private async withTimeout<Result>(operation: () => Promise<Result>): Promise<Result> {
     let timer: ReturnType<typeof setTimeout> | undefined
     let timedOut = false
     const timeout = new Promise<never>((_resolve, reject) => {
@@ -172,16 +175,13 @@ export class AcpProviderSessionResumer {
     }
   }
 
-  private async resumeReserved(
+  private async resumeConnected(
     request: AcpResumeSessionRequest,
+    connection: ClientConnection,
     cwd: string,
     projectId: string,
     identity: AcpPrimarySessionIdentityReservation
   ): Promise<AcpCreateSessionResponse> {
-    const connection = await this.deps.ensureConnected(cwd)
-    this.deps.assertCurrentConnection(connection)
-    identity.renew()
-
     const affinity = this.deps.registry.lookup(request.sessionId)?.aggregate.snapshot()
     const persistedProviderSessionId = affinity?.providerSessionId ?? request.providerSessionId
     const backend = this.deps.currentBackend()

--- a/src/main/acp/runtime-provider-session-composition.ts
+++ b/src/main/acp/runtime-provider-session-composition.ts
@@ -174,7 +174,7 @@ const composeAcpRuntimeProviderSessionOwners = (
     updateCwd,
     pushEvent: (event) => session.publication.pushEvent(event),
     emitState,
-    resumeTimeoutMs: options.resumeTimeoutMs ?? 30_000,
+    resumeTimeoutMs: options.resumeTimeoutMs ?? 60_000,
     setTimer: base.setTimer,
     clearTimer: base.clearTimer,
     diagnosticContext


### PR DESCRIPTION
## Problem

Provider Session resume used one 30-second deadline for the entire cold path: starting and connecting the Agent, provisioning Session capabilities, issuing `session/resume`, and configuring the restored Session.

The reported trace spent about 10 seconds establishing the Agent connection, then reached the deadline while the provider resume was still pending. The timeout tore down the otherwise healthy Agent process. Clicking Resume immediately afterward completed the same Session restore in about 18 seconds.

## Change

- Give Agent reconnect and post-connect Provider Session restoration independent timeout budgets.
- Raise the default budget for each phase from 30 seconds to 60 seconds.
- Preserve timeout teardown so a genuinely stalled phase still disconnects the half-open Agent and releases the stable Session identity.
- Add a regression test proving that a successful reconnect starts a fresh timeout before a stalled provider resume.

The longest user-visible wait can now be about 120 seconds when both phases consume their full budgets. This timing change was explicitly approved for the reported cold-start behavior.

## Scope

- No UI copy, IPC, wire contract, persistence, data-model, or architecture-state change.
- No automatic retry or new background state.
- Existing attached-Session refresh and timeout error presentation remain unchanged.

## Validation

- `npx vitest run src/main/acp/provider-session-resumer.test.ts` — 21/21 passed.
- Runtime timeout regression — 1/1 passed.
- `npm run typecheck:node` — passed.
- Targeted ESLint and Prettier checks — passed.
- Full `npm test` outside the restricted socket sandbox — 1,071 test files and 15,887 tests passed; one unrelated real-R cancellation timing test failed, then passed when rerun alone.

## Review focus

- The timeout boundary now renews only after a current Agent connection is established and the stable Session identity is renewed.
- Either timeout still tears down the connection through the existing `disconnectTimedOutConnection` path.
