### PR TITLE
[Archive] perf(message-scroller): transcript virtualization (A+B) — evaluated, deferred

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ Use one of these standard type prefixes:
 - Formatting is handled by Prettier. `npm run format` is optional; review its
   changes before committing because it rewrites files across the repository.
 - Linting is enforced by ESLint; run `npm run lint`.
-- Keep user-facing strings, comments, and documentation in English.
+- Wrap user-facing strings with the `t()` translation function from `react-i18next`. Add corresponding translations to `src/renderer/src/locales/zh-Hans.json` (Simplified Chinese) and `src/renderer/src/locales/zh-Hant.json` (Traditional Chinese). Use the English text as the translation key. Keep code comments and documentation in English.
 
 ## Verification Policy
 

--- a/e2e/message-scroller-performance.spec.ts
+++ b/e2e/message-scroller-performance.spec.ts
@@ -1,0 +1,351 @@
+import { expect } from '@playwright/test'
+import type { Page } from 'playwright'
+
+import { test } from './fixtures/electron-app'
+
+const ROW_SELECTOR = '[data-slot="message-scroller-item"]'
+const VIEWPORT_SELECTOR = '[data-slot="message-scroller-viewport"]'
+const LONG_STREAM_PROMPT = 'Stream the long scroll journey.'
+const LONG_STREAM_FINAL_SEGMENT = 'Segment 3 paragraph 7'
+const SCROLL_STEPS = 20
+const RAF_FALLBACK_MS = 500
+
+type SeedMessage = {
+  id: string
+  role: 'user' | 'agent'
+  content: string
+  status: 'complete'
+  eventIds: string[]
+  createdAt: number
+  updatedAt: number
+}
+
+type FrameSummary = {
+  count: number
+  p50: number
+  p95: number
+  max: number
+  over50ms: number
+}
+
+type LongTaskSummary = {
+  count: number
+  totalMs: number
+  max: number
+}
+
+const round = (value: number): number => Math.round(value * 100) / 100
+
+const summarizeFrames = (frames: number[]): FrameSummary => {
+  const sorted = [...frames].sort((a, b) => a - b)
+  const percentile = (p: number): number =>
+    sorted.length === 0
+      ? 0
+      : sorted[Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1))]
+  return {
+    count: sorted.length,
+    p50: round(percentile(50)),
+    p95: round(percentile(95)),
+    max: round(sorted.at(-1) ?? 0),
+    over50ms: sorted.filter((frame) => frame > 50).length
+  }
+}
+
+const summarizeLongTasks = (durations: number[]): LongTaskSummary => ({
+  count: durations.length,
+  totalMs: round(durations.reduce((total, duration) => total + duration, 0)),
+  max: round(Math.max(0, ...durations))
+})
+
+const USER_TOPICS = [
+  'Compare the benchmark runs for the parser rewrite.',
+  'Why does the index rebuild take longer on cold cache?',
+  'Summarize the flame graph from the latest profile.',
+  'Draft the rollout plan for the streaming change.',
+  'Explain the regression in the scroll anchoring test.',
+  'What changed in the persistence envelope format?',
+  'Review the memory numbers from the stress run.',
+  'How should we shard the transcript fixture data?'
+]
+
+const AGENT_PARAGRAPHS = [
+  'The profile shows layout work dominating the main thread while the transcript grows. Most of the cost comes from style recalculation on rows that are far outside the viewport, which suggests containment is not applied uniformly.',
+  'Breaking the run into phases makes the pattern clearer. Hydration is cheap, the first paint is bounded by the rows near the anchor, and the expensive tail is markdown re-parsing for messages that have not changed since the last render.',
+  'The scroll samples tell a consistent story. Median frames stay near the vsync budget, but the p95 spikes line up with the moments the scroller crosses rows that carry code fences, because those rows re-measure once syntax highlighting resolves.',
+  'A reasonable mitigation is to memoize the rendered markdown per message id and revision. The transcript is append-mostly, so a cache keyed by id plus updatedAt should collapse almost all of the repeated parse work without changing the rendering pipeline.',
+  'Long tasks cluster around streaming bursts. Each chunk notification triggers a re-render of the streaming row, and when the chunk cadence is faster than the frame budget the main thread never gets back below fifty milliseconds between chunks.',
+  'The manifest-driven restore path is linear in the number of messages. Normalization is tolerant and cheap, but the downstream React tree construction is not, so the open-time cost scales with transcript length rather than with viewport size.',
+  'Containment with an estimated intrinsic size keeps offscreen rows from participating in layout, but the estimate has to be close to the real row height or the scrollbar thumb drifts while rows resolve their actual size during fast scrolls.',
+  'None of these costs are inherent to the data model. They are all rendering-pipeline costs, which means the fix belongs in the scroller and the message row components rather than in persistence or in the agent bridge.'
+]
+
+const agentContent = (index: number): string => {
+  const paragraphCount = 3 + (index % 6)
+  const parts: string[] = []
+  for (let paragraph = 0; paragraph < paragraphCount; paragraph += 1) {
+    parts.push(AGENT_PARAGRAPHS[(index + paragraph) % AGENT_PARAGRAPHS.length])
+  }
+  if (index % 14 === 1) {
+    parts.push(
+      [
+        '```ts',
+        `const sample = frames[${index} % SCROLL_STEPS]`,
+        'if (sample > 50) reportLongFrame(sample)',
+        '```'
+      ].join('\n')
+    )
+  } else if (index % 14 === 7) {
+    parts.push(
+      [
+        `- Median frame stayed under budget in run ${index % 5}`,
+        '- P95 spiked near the code-fence rows',
+        '- Long tasks clustered around streaming bursts'
+      ].join('\n')
+    )
+  }
+  return parts.join('\n\n')
+}
+
+const buildMessages = (count: number): SeedMessage[] => {
+  const base = Date.now() - count * 1_000
+  return Array.from({ length: count }, (_, index) => {
+    const createdAt = base + index * 1_000
+    const isUser = index % 2 === 0
+    return {
+      id: `perf-message-${index}`,
+      role: isUser ? 'user' : 'agent',
+      content: isUser
+        ? `${USER_TOPICS[(index / 2) % USER_TOPICS.length]} (turn ${index / 2})`
+        : agentContent(index),
+      status: 'complete',
+      eventIds: [],
+      createdAt,
+      updatedAt: createdAt
+    }
+  })
+}
+
+const seedSession = async (page: Page, messages: SeedMessage[]): Promise<void> => {
+  await page.evaluate(async (seededMessages) => {
+    const bridge = globalThis as unknown as {
+      api: {
+        projects: {
+          create: (request: { name: string; description: string }) => Promise<{ id: string }>
+        }
+        sessions: {
+          saveManifest: (request: { lastProjectId: string; lastSessionId: string }) => Promise<void>
+          saveSession: (session: Record<string, unknown>) => Promise<void>
+        }
+      }
+    }
+    const project = await bridge.api.projects.create({
+      name: 'Transcript perf project',
+      description: 'Seeded long transcript for performance measurement.'
+    })
+    const now = Date.now()
+    await bridge.api.sessions.saveSession({
+      id: 'perf-seed-session',
+      projectId: project.id,
+      title: 'Transcript performance session',
+      cwd: '/tmp/transcript-perf',
+      status: 'idle',
+      agentFrameworkId: 'opencode',
+      messages: seededMessages,
+      createdAt: now - seededMessages.length * 1_000,
+      updatedAt: now
+    })
+    await bridge.api.sessions.saveManifest({
+      lastProjectId: project.id,
+      lastSessionId: 'perf-seed-session'
+    })
+  }, messages)
+}
+
+const measureScroll = (
+  page: Page
+): Promise<{
+  frames: number[]
+  longTasks: number[]
+  startTop: number
+  endTop: number
+  minTop: number
+}> =>
+  page.evaluate(
+    async ({ viewportSelector, steps, rafFallbackMs }) => {
+      const viewport = document.querySelector(viewportSelector)
+      if (!(viewport instanceof HTMLElement)) {
+        throw new Error('Message scroller viewport not found.')
+      }
+      viewport.style.scrollBehavior = 'auto'
+      const frames: number[] = []
+      const longTasks: number[] = []
+      let collecting = true
+      let last = performance.now()
+      const collect = (now: number): void => {
+        if (!collecting) return
+        frames.push(now - last)
+        last = now
+        requestAnimationFrame(collect)
+      }
+      requestAnimationFrame(collect)
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) longTasks.push(entry.duration)
+      })
+      observer.observe({ type: 'longtask' })
+      const nextFrame = (): Promise<void> =>
+        new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, rafFallbackMs)
+          requestAnimationFrame(() => {
+            clearTimeout(timer)
+            resolve()
+          })
+        })
+      const stepTo = async (target: number): Promise<void> => {
+        const origin = viewport.scrollTop
+        for (let step = 1; step <= steps; step += 1) {
+          viewport.scrollTop = origin + ((target - origin) * step) / steps
+          await nextFrame()
+        }
+      }
+      const startTop = viewport.scrollTop
+      // Offscreen rows resolve their real heights during the upward pass and scroll anchoring can
+      // nudge scrollTop off an exact target, so track the minimum reached instead of the endpoint.
+      let minTop = startTop
+      const trackMin = async (target: number): Promise<void> => {
+        const origin = viewport.scrollTop
+        for (let step = 1; step <= steps; step += 1) {
+          viewport.scrollTop = origin + ((target - origin) * step) / steps
+          await nextFrame()
+          minTop = Math.min(minTop, viewport.scrollTop)
+        }
+      }
+      await trackMin(0)
+      await stepTo(viewport.scrollHeight)
+      collecting = false
+      observer.disconnect()
+      return { frames, longTasks, startTop, endTop: viewport.scrollTop, minTop }
+    },
+    {
+      viewportSelector: VIEWPORT_SELECTOR,
+      steps: SCROLL_STEPS,
+      rafFallbackMs: RAF_FALLBACK_MS
+    }
+  )
+
+const startStreamingCollector = (page: Page): Promise<void> =>
+  page.evaluate(() => {
+    const frames: number[] = []
+    const longTasks: number[] = []
+    let active = true
+    let last = performance.now()
+    const collect = (now: number): void => {
+      if (!active) return
+      frames.push(now - last)
+      last = now
+      requestAnimationFrame(collect)
+    }
+    requestAnimationFrame(collect)
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) longTasks.push(entry.duration)
+    })
+    observer.observe({ type: 'longtask' })
+    ;(globalThis as unknown as { __perfStreamCollector: unknown }).__perfStreamCollector = {
+      stop: () => {
+        active = false
+        observer.disconnect()
+        return { frames, longTasks }
+      }
+    }
+  })
+
+const stopStreamingCollector = (page: Page): Promise<{ frames: number[]; longTasks: number[] }> =>
+  page.evaluate(() =>
+    (
+      globalThis as unknown as {
+        __perfStreamCollector: { stop: () => { frames: number[]; longTasks: number[] } }
+      }
+    ).__perfStreamCollector.stop()
+  )
+
+for (const messageCount of [500, 2000]) {
+  test(`transcript performance with ${messageCount} messages`, async ({ app }) => {
+    test.setTimeout(600_000)
+    let page = await app.completeOnboarding()
+    page = await app.configureFakeAgent()
+    await seedSession(page, buildMessages(messageCount))
+
+    const relaunchStartedAt = Date.now()
+    page = await app.restart()
+    // The app restores to home; open the seeded session like message-scroll-reanchor does.
+    await page
+      .getByRole('region', { name: 'Recent sessions' })
+      .getByRole('button', { name: 'Transcript performance session' })
+      .click()
+
+    // The transcript is virtualized past 100 rows: only the window around the reopen position
+    // (last user-message anchor) is mounted, so wait for the final message row specifically.
+    const lastRow = page.locator(`[data-message-id="perf-message-${messageCount - 1}"]`)
+    await expect(lastRow).toBeVisible({ timeout: 300_000 })
+    const ttiFromNavigationMs = await page.evaluate(async () => {
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, 1_000)
+        requestAnimationFrame(() =>
+          requestAnimationFrame(() => {
+            clearTimeout(timer)
+            resolve()
+          })
+        )
+      })
+      return performance.now()
+    })
+    const ttiWallMs = Date.now() - relaunchStartedAt
+
+    const dom = await page.evaluate(
+      ({ rowSelector }) => ({
+        messageRows: document.querySelectorAll(rowSelector).length,
+        totalElements: document.querySelectorAll('*').length
+      }),
+      { rowSelector: ROW_SELECTOR }
+    )
+
+    const scroll = await measureScroll(page)
+
+    await page.getByRole('textbox', { name: 'Ask anything' }).fill(LONG_STREAM_PROMPT)
+    await page.getByRole('button', { name: 'Send message' }).click()
+    // Start collecting after the click so Playwright's actionability checks stay out of the
+    // window; the fixed wait covers the deterministic ~2.5s fake-agent stream without polling.
+    await startStreamingCollector(page)
+    await page.waitForTimeout(4_000)
+    const streaming = await stopStreamingCollector(page)
+    await expect(page.getByText(LONG_STREAM_FINAL_SEGMENT)).toBeVisible({ timeout: 120_000 })
+
+    console.log(
+      `PERF_RESULT ${JSON.stringify({
+        scenario: `${messageCount}-messages`,
+        tti: { wallMs: ttiWallMs, fromNavigationMs: round(ttiFromNavigationMs) },
+        dom,
+        scroll: {
+          startTop: round(scroll.startTop),
+          endTop: round(scroll.endTop),
+          minTop: round(scroll.minTop),
+          frames: summarizeFrames(scroll.frames),
+          longTasks: summarizeLongTasks(scroll.longTasks)
+        },
+        streaming: {
+          frames: summarizeFrames(streaming.frames),
+          longTasks: summarizeLongTasks(streaming.longTasks)
+        }
+      })}`
+    )
+
+    expect(dom.messageRows).toBeGreaterThan(0)
+    // Virtualization must actually window the transcript: far fewer rows mounted than exist.
+    expect(dom.messageRows).toBeLessThan(messageCount)
+    expect(scroll.startTop).toBeGreaterThan(0)
+    // Scroll anchoring compensates while offscreen rows resolve real heights, so an exact top
+    // landing is not guaranteed; reaching the top quartile proves the upward sweep happened.
+    expect(scroll.minTop).toBeLessThan(scroll.startTop * 0.25)
+    expect(scroll.endTop).toBeGreaterThan(scroll.minTop)
+    expect(scroll.frames.length).toBeGreaterThan(0)
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@prisma/client": "^6.19.3",
         "@radix-ui/react-focus-scope": "^1.1.11",
         "@rc-component/qrcode": "^2.0.0",
+        "@tanstack/react-virtual": "^3.14.9",
         "ajv": "^8.20.0",
         "electron-updater": "^6.3.9",
         "fflate": "0.8.3",
@@ -7710,6 +7711,33 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
+      "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
+      "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@prisma/client": "^6.19.3",
     "@radix-ui/react-focus-scope": "^1.1.11",
     "@rc-component/qrcode": "^2.0.0",
+    "@tanstack/react-virtual": "^3.14.9",
     "ajv": "^8.20.0",
     "electron-updater": "^6.3.9",
     "fflate": "0.8.3",

--- a/scripts/fix-electron-path.cjs
+++ b/scripts/fix-electron-path.cjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/explicit-function-return-type */
+/* eslint-disable @typescript-eslint/no-require-imports */
 // Normalize node_modules/electron/path.txt so the electron binary resolves without a trailing
 // newline. Different npmmirror CDNs / extraction paths have shipped this 32-byte file with an
 // appended LF; electron's own index.js reads it via fs.readFileSync(pathFile, 'utf-8') without
@@ -30,5 +30,4 @@ if (normalized === raw) {
 
 fs.writeFileSync(pathFile, normalized, 'utf-8')
 
-// eslint-disable-next-line no-console
 console.log('fix-electron-path: stripped trailing newline from node_modules/electron/path.txt')

--- a/src/main/compute/job-notifier.test.ts
+++ b/src/main/compute/job-notifier.test.ts
@@ -215,7 +215,12 @@ describe('emitJobNotification', () => {
     const hostRepo: Pick<ComputeHostRepository, 'get'> = { get: vi.fn() }
     const broadcast = vi.fn()
 
-    await emitJobNotification(job, { jobRepository: jobRepo, hostRepository: hostRepo, storageRoot, broadcast })
+    await emitJobNotification(job, {
+      jobRepository: jobRepo,
+      hostRepository: hostRepo,
+      storageRoot,
+      broadcast
+    })
 
     // Neither update nor broadcast should be called
     expect(mockUpdate).not.toHaveBeenCalled()

--- a/src/renderer/src/components/RemoteJobBadge.tsx
+++ b/src/renderer/src/components/RemoteJobBadge.tsx
@@ -16,7 +16,10 @@ type RemoteJobBadgeProps = {
 // Shows running count + elapsed time when jobs are running; shows gray "N jobs" when all finished.
 // Hidden only when session has no jobs at all.
 // Hover reveals a tooltip listing each running job's host + intent + duration.
-export const RemoteJobBadge = ({ sessionId, onOpenJobList }: RemoteJobBadgeProps): React.JSX.Element | null => {
+export const RemoteJobBadge = ({
+  sessionId,
+  onOpenJobList
+}: RemoteJobBadgeProps): React.JSX.Element | null => {
   const allJobsForSession = useSessionJobStore((state) => state.allJobsForSession)
   const [now, setNow] = useState(() => Date.now())
 

--- a/src/renderer/src/components/ui/message-scroller.tsx
+++ b/src/renderer/src/components/ui/message-scroller.tsx
@@ -64,10 +64,14 @@ function MessageScrollerContent({
 function MessageScrollerItem({
   className,
   disableContainment = false,
+  containmentEstimate = '[contain-intrinsic-size:auto_10rem]',
   scrollAnchor = false,
   ...props
 }: React.ComponentProps<typeof MessageScrollerPrimitive.Item> & {
   disableContainment?: boolean
+  // Offscreen-size estimate for content-visibility rows; closer per-row-type estimates keep the
+  // scrollbar stable while rows resolve their real height.
+  containmentEstimate?: string
 }) {
   return (
     <MessageScrollerPrimitive.Item
@@ -75,7 +79,7 @@ function MessageScrollerItem({
       scrollAnchor={scrollAnchor}
       className={cn(
         'min-w-0 shrink-0',
-        !disableContainment && '[contain-intrinsic-size:auto_10rem] [content-visibility:auto]',
+        !disableContainment && `${containmentEstimate} [content-visibility:auto]`,
         className
       )}
       {...props}

--- a/src/renderer/src/pages/settings/ComputeAddForm.tsx
+++ b/src/renderer/src/pages/settings/ComputeAddForm.tsx
@@ -5,7 +5,13 @@ import type { CreateComputeHostRequest, SshOverrides } from '../../../../shared/
 import { DETAILS_DOC_MAX_LENGTH } from '../../../../shared/compute'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
 import { useComputeStore } from '@/stores/compute-store'
 
@@ -100,9 +106,7 @@ export function ComputeAddForm({ onCreated, onCancel }: ComputeAddFormProps): Re
           >
             <SelectTrigger aria-label="Pick a host from ~/.ssh/config">
               <SelectValue
-                placeholder={
-                  sshAliases.length === 0 ? 'No hosts in ~/.ssh/config' : 'Pick a host…'
-                }
+                placeholder={sshAliases.length === 0 ? 'No hosts in ~/.ssh/config' : 'Pick a host…'}
               />
             </SelectTrigger>
             <SelectContent>

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -899,6 +899,9 @@ const WorkspaceMessageItemImpl = ({
       key={message.id}
       messageId={message.id}
       disableContainment={message.status === 'streaming' || isAssistantPresenting}
+      containmentEstimate={
+        isUserMessage ? '[contain-intrinsic-size:auto_3rem]' : '[contain-intrinsic-size:auto_21rem]'
+      }
       scrollAnchor={message.role === 'user'}
       className="min-w-0"
     >

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -625,6 +625,52 @@ const WorkspaceMessageScrollerImpl = ({
         : undefined,
     [legacyAgentBackendId, legacyAgentModel]
   )
+  const sessionMessages = activeSession?.messages
+  const messageCreatedAtById = useMemo(
+    () => new Map(sessionMessages?.map((message) => [message.id, message.createdAt]) ?? []),
+    [sessionMessages]
+  )
+
+  // Counts the user turns after each message; the destructive-resend warning keys off turns, not
+  // raw message count, so a single follow-up turn stays warning-free.
+  const subsequentTurnCountByMessageId = useMemo(() => {
+    const counts = new Map<string, number>()
+    let subsequentTurns = 0
+    for (let index = (sessionMessages?.length ?? 0) - 1; index >= 0; index -= 1) {
+      const message = sessionMessages?.[index]
+      if (!message) continue
+      counts.set(message.id, subsequentTurns)
+      if (message.role === 'user') subsequentTurns += 1
+    }
+    return counts
+  }, [sessionMessages])
+
+  // Streaming rebuilds the transcript once per chunk. Index the conversation graph once per render
+  // so the per-row lookups in the item map below stay O(1) instead of scanning the graph per row.
+  const conversationGraph = activeSession?.conversationGraph
+  const graphMessageNodeById = useMemo(
+    () => new Map(conversationGraph?.messages.map((message) => [message.id, message]) ?? []),
+    [conversationGraph]
+  )
+  const graphRuntimeSegmentById = useMemo(
+    () => new Map(conversationGraph?.runtimeSegments.map((segment) => [segment.id, segment]) ?? []),
+    [conversationGraph]
+  )
+  const revisionMessagesByRootId = useMemo(() => {
+    const byRootId = new Map<string, NonNullable<typeof conversationGraph>['messages']>()
+    for (const message of conversationGraph?.messages ?? []) {
+      if (message.role !== 'user' || message.revisionRootMessageId === undefined) continue
+      const revisions = byRootId.get(message.revisionRootMessageId) ?? []
+      revisions.push(message)
+      byRootId.set(message.revisionRootMessageId, revisions)
+    }
+    for (const revisions of byRootId.values()) {
+      revisions.sort(
+        (left, right) => left.createdAt - right.createdAt || left.id.localeCompare(right.id)
+      )
+    }
+    return byRootId
+  }, [conversationGraph])
 
   // Build a map from job_id → JobSummary for all session jobs (used in binding)
   const sessionJobs = useMemo((): JobSummary[] => {
@@ -889,22 +935,6 @@ const WorkspaceMessageScrollerImpl = ({
   // window the virtualizer covers. Kept memoized so virtualizer window shifts during scrolling
   // do not rebuild descriptors for the whole transcript.
   const transcriptRows = useMemo<readonly TranscriptRow[]>(() => {
-    const messageCreatedAtById = new Map(
-      activeSession?.messages.map((message) => [message.id, message.createdAt]) ?? []
-    )
-
-    // Counts the user turns after each message; the destructive-resend warning keys off turns, not
-    // raw message count, so a single follow-up turn stays warning-free.
-    const subsequentTurnCountByMessageId = new Map<string, number>()
-    if (activeSession) {
-      let subsequentTurns = 0
-      for (let index = activeSession.messages.length - 1; index >= 0; index -= 1) {
-        const message = activeSession.messages[index]
-        subsequentTurnCountByMessageId.set(message.id, subsequentTurns)
-        if (message.role === 'user') subsequentTurns += 1
-      }
-    }
-
     const rows: TranscriptRow[] = []
     // Messages and tool activities share one sorted transcript timeline.
     conversationItems.forEach((item, itemIndex) => {
@@ -923,10 +953,9 @@ const WorkspaceMessageScrollerImpl = ({
         const artifacts = artifactsForMessage(item.message)
         // Jobs pre-assigned to this slot: each job appears in exactly one slot.
         const jobsBeforeMessage = jobSlotsByItemIndex.get(itemIndex) ?? []
-        const graph = activeSession?.conversationGraph
-        const messageNode = graph?.messages.find((message) => message.id === item.message.id)
+        const messageNode = graphMessageNodeById.get(item.message.id)
         const runtimeSegment = messageNode?.runtimeSegmentId
-          ? graph?.runtimeSegments.find((segment) => segment.id === messageNode.runtimeSegmentId)
+          ? graphRuntimeSegmentById.get(messageNode.runtimeSegmentId)
           : undefined
         // Legacy sessions synthesize this segment with a fallback framework. Keep only
         // the session-level values that were actually persisted.
@@ -936,14 +965,7 @@ const WorkspaceMessageScrollerImpl = ({
         const runtimeIdentity = synthesizedLegacyRuntime ? legacyRuntimeIdentity : runtimeSegment
         const revisionRootMessageId = messageNode?.revisionRootMessageId
         const revisions = revisionRootMessageId
-          ? (graph?.messages
-              .filter(
-                (message) =>
-                  message.role === 'user' && message.revisionRootMessageId === revisionRootMessageId
-              )
-              .sort(
-                (left, right) => left.createdAt - right.createdAt || left.id.localeCompare(right.id)
-              ) ?? [])
+          ? (revisionMessagesByRootId.get(revisionRootMessageId) ?? [])
           : []
         const revisionIndex = revisions.findIndex((message) => message.id === item.message.id)
         const activateRevision = (index: number): (() => void) | undefined => {
@@ -1251,6 +1273,8 @@ const WorkspaceMessageScrollerImpl = ({
     currentProjectId,
     currentSessionId,
     durablePlanOwnerActivityId,
+    graphMessageNodeById,
+    graphRuntimeSegmentById,
     handleGoToTranscript,
     handleMessagePresentationChange,
     handleOpenJobDetail,
@@ -1259,6 +1283,7 @@ const WorkspaceMessageScrollerImpl = ({
     jobSlotsByItemIndex,
     jobsByActivityId,
     legacyRuntimeIdentity,
+    messageCreatedAtById,
     notebookRunsById,
     onPreviewArtifact,
     onPreviewMentionArtifact,
@@ -1270,6 +1295,8 @@ const WorkspaceMessageScrollerImpl = ({
     presentationBarrierIndex,
     presentationScopeRemainedVisible,
     presentingMessageIds,
+    revisionMessagesByRootId,
+    subsequentTurnCountByMessageId,
     toggleActivityGroup,
     toggleActivityRow,
     trailingContent,

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -27,6 +27,7 @@ import {
   type ReactNode
 } from 'react'
 import { ArrowDownIcon } from 'lucide-react'
+import { useVirtualizer } from '@tanstack/react-virtual'
 
 import { getAgentLoadingPhase } from './agent-loading-message'
 import {
@@ -140,6 +141,24 @@ const SCROLL_TO_FIRST_MESSAGE_MIN_DISTANCE_VIEWPORTS = 1
 const SCROLL_TO_FIRST_MESSAGE_IDLE_TIMEOUT_MS = 3000
 // How long a "no longer available" mention notice stays visible before auto-dismissing.
 const MENTION_NOTICE_TIMEOUT_MS = 3000
+// Transcripts larger than this render through a virtualizer-owned window; smaller ones keep the
+// primitive's direct-children measurement path, which owns anchoring for them.
+const VIRTUALIZATION_ROW_THRESHOLD = 100
+const SCROLL_PREVIOUS_ITEM_PEEK = 64
+const SCROLL_FOLLOW_EDGE_PX = 8
+// Stable fallbacks keep memoized transcript rows from rebuilding when session-scoped UI state
+// belongs to a different session/scope.
+const EMPTY_ID_SET: ReadonlySet<string> = new Set<string>()
+const EMPTY_EXPANSION_OVERRIDES: ActivityExpansionOverrides = {}
+
+// One flattened transcript row. The virtualized path positions these absolutely; the classic path
+// renders them as direct content children in the same order.
+type TranscriptRow = {
+  key: string
+  estimatedSize: number
+  scrollAnchor: boolean
+  node: () => React.JSX.Element | null
+}
 
 const structurallyMatches = (left: unknown, right: unknown): boolean =>
   JSON.stringify(left) === JSON.stringify(right)
@@ -307,6 +326,14 @@ const WorkspaceMessageScrollerImpl = ({
   const scrollToFirstMessageButtonRef = useRef<HTMLButtonElement | null>(null)
   const previousMessageScrollerScrollTopRef = useRef(0)
   const scrollToFirstMessageHideTimeoutRef = useRef<number | undefined>(undefined)
+  // Virtualized-path scroll engine state (used only past VIRTUALIZATION_ROW_THRESHOLD rows).
+  const virtualizationEnabledRef = useRef(false)
+  const virtualScrollStateRef = useRef<{
+    scopeId: string | undefined
+    initialized: boolean
+    follow: boolean
+    handledAnchorKeys: Set<string>
+  }>({ scopeId: undefined, initialized: false, follow: true, handledAnchorKeys: new Set() })
   const [scrollThresholdAllowsFirstMessage, setScrollThresholdAllowsFirstMessage] = useState(false)
   const activeConversationFrame = activeSession?.conversationGraph?.frames.find(
     (frame) => frame.id === activeSession.conversationGraph?.activeFrameId
@@ -315,6 +342,7 @@ const WorkspaceMessageScrollerImpl = ({
     ? JSON.stringify([currentSessionId, activeConversationFrame?.activeBranchId ?? 'legacy'])
     : undefined
   const artifactVisibility = useWorkspaceArtifactVisibility(activeSession)
+  const artifactsForMessage = artifactVisibility.artifactsForMessage
   const notebookRunsById = useNotebookRunsById(notebookReference)
   const handoffEvents = useHandoffLifecycleEvents(handoffLifecycleSource, currentSessionId)
   // The whole-window find bar is an Electron overlay owned by main; the Workspace only needs to tell
@@ -391,11 +419,11 @@ const WorkspaceMessageScrollerImpl = ({
   const collapsedActivityGroups =
     collapsedActivityGroupState.sessionId === currentSessionId
       ? collapsedActivityGroupState.groupIds
-      : new Set<string>()
+      : EMPTY_ID_SET
   const activityExpansionOverrides =
     activityExpansionOverrideState.sessionId === currentSessionId
       ? activityExpansionOverrideState.overrides
-      : {}
+      : EMPTY_EXPANSION_OVERRIDES
   const rawConversationItems = useMemo(
     () => createConversationItems(activeSession, handoffEvents),
     [activeSession, handoffEvents]
@@ -412,7 +440,7 @@ const WorkspaceMessageScrollerImpl = ({
   const presentingMessageIds =
     messagePresentationState.scopeId === currentPresentationScopeId
       ? messagePresentationState.messageIds
-      : new Set<string>()
+      : EMPTY_ID_SET
   const presentationBarrierIndex = conversationItems.findIndex(
     (item) => item.type === 'message' && presentingMessageIds.has(item.message.id)
   )
@@ -478,6 +506,14 @@ const WorkspaceMessageScrollerImpl = ({
 
     const previousScrollTop = previousMessageScrollerScrollTopRef.current
     previousMessageScrollerScrollTopRef.current = viewport.scrollTop
+    if (virtualizationEnabledRef.current) {
+      // The virtualized path owns follow-output: release on any upward scroll, re-engage at the
+      // live edge. Downward programmatic pins never release.
+      const followState = virtualScrollStateRef.current
+      const maximumScrollTop = viewport.scrollHeight - viewport.clientHeight
+      if (viewport.scrollTop >= maximumScrollTop - SCROLL_FOLLOW_EDGE_PX) followState.follow = true
+      else if (viewport.scrollTop < previousScrollTop) followState.follow = false
+    }
     const eligible = updateScrollToFirstMessageEligibility()
     if (viewport.scrollTop < previousScrollTop && eligible) revealScrollToFirstMessage()
     else if (viewport.scrollTop > previousScrollTop) hideScrollToFirstMessage()
@@ -589,21 +625,6 @@ const WorkspaceMessageScrollerImpl = ({
         : undefined,
     [legacyAgentBackendId, legacyAgentModel]
   )
-  const messageCreatedAtById = new Map(
-    activeSession?.messages.map((message) => [message.id, message.createdAt]) ?? []
-  )
-
-  // Counts the user turns after each message; the destructive-resend warning keys off turns, not
-  // raw message count, so a single follow-up turn stays warning-free.
-  const subsequentTurnCountByMessageId = new Map<string, number>()
-  if (activeSession) {
-    let subsequentTurns = 0
-    for (let index = activeSession.messages.length - 1; index >= 0; index -= 1) {
-      const message = activeSession.messages[index]
-      subsequentTurnCountByMessageId.set(message.id, subsequentTurns)
-      if (message.role === 'user') subsequentTurns += 1
-    }
-  }
 
   // Build a map from job_id → JobSummary for all session jobs (used in binding)
   const sessionJobs = useMemo((): JobSummary[] => {
@@ -788,54 +809,63 @@ const WorkspaceMessageScrollerImpl = ({
   )
 
   // Toggles a whole adjacent tool-activity group without affecting other sessions.
-  const toggleActivityGroup = (groupId: string): void => {
-    setCollapsedActivityGroupState((currentState) => {
-      const currentGroupIds =
-        currentState.sessionId === currentSessionId ? currentState.groupIds : new Set<string>()
-      const nextGroupIds = new Set(currentGroupIds)
+  const toggleActivityGroup = useCallback(
+    (groupId: string): void => {
+      setCollapsedActivityGroupState((currentState) => {
+        const currentGroupIds =
+          currentState.sessionId === currentSessionId ? currentState.groupIds : new Set<string>()
+        const nextGroupIds = new Set(currentGroupIds)
 
-      if (nextGroupIds.has(groupId)) {
-        nextGroupIds.delete(groupId)
-      } else {
-        nextGroupIds.add(groupId)
-      }
+        if (nextGroupIds.has(groupId)) {
+          nextGroupIds.delete(groupId)
+        } else {
+          nextGroupIds.add(groupId)
+        }
 
-      return {
-        sessionId: currentSessionId,
-        groupIds: nextGroupIds
-      }
-    })
-  }
+        return {
+          sessionId: currentSessionId,
+          groupIds: nextGroupIds
+        }
+      })
+    },
+    [currentSessionId]
+  )
 
   // Records the user's explicit expansion choice for a single tool-activity detail row.
-  const toggleActivityRow = (activityId: string, nextExpanded: boolean): void => {
-    setActivityExpansionOverrideState((currentState) => {
-      const currentOverrides =
-        currentState.sessionId === currentSessionId ? currentState.overrides : {}
+  const toggleActivityRow = useCallback(
+    (activityId: string, nextExpanded: boolean): void => {
+      setActivityExpansionOverrideState((currentState) => {
+        const currentOverrides =
+          currentState.sessionId === currentSessionId ? currentState.overrides : {}
 
-      return {
-        sessionId: currentSessionId,
-        overrides: {
-          ...currentOverrides,
-          [activityId]: nextExpanded
+        return {
+          sessionId: currentSessionId,
+          overrides: {
+            ...currentOverrides,
+            [activityId]: nextExpanded
+          }
         }
-      }
-    })
-  }
+      })
+    },
+    [currentSessionId]
+  )
 
   // Opens the Session reviewer panel positioned at the finding the user clicked.
   // Only the "Go to transcript" button on a finding fires this; clicking the card itself does not.
-  const handleGoToTranscript = (intent: GoToTranscriptIntent): void => {
-    if (!currentSessionId) return
-    openSessionReviewer(currentSessionId, intent)
-  }
+  const handleGoToTranscript = useCallback(
+    (intent: GoToTranscriptIntent): void => {
+      if (!currentSessionId) return
+      openSessionReviewer(currentSessionId, intent)
+    },
+    [currentSessionId]
+  )
 
   // Re-runs the review for a specific (stale) turn — the actionable refresh the stale notice offers.
   // Unlike the composer's last-turn-only "Request review", this reaches any turn's review. The row is
   // grouped under review.turnMessageId (so a fix-loop review refreshes in place), but the audited
   // content is review.scope.turnMessageId — the turn whose bytes actually changed. Fire-and-forget:
   // a fresh review supersedes the stale one via reviewer:updated; concurrent runs are deduped in main.
-  const handleRerunReview = async (review: ReviewWithChecks): Promise<boolean> => {
+  const handleRerunReview = useCallback(async (review: ReviewWithChecks): Promise<boolean> => {
     try {
       const result = await window.api.reviewer.run({
         sessionId: review.sessionId,
@@ -852,7 +882,468 @@ const WorkspaceMessageScrollerImpl = ({
     } catch {
       return false
     }
-  }
+  }, [])
+
+  // Flatten the transcript timeline into row descriptors. The classic path renders them as
+  // direct content children (identical DOM to before); the virtualized path mounts only the
+  // window the virtualizer covers. Kept memoized so virtualizer window shifts during scrolling
+  // do not rebuild descriptors for the whole transcript.
+  const transcriptRows = useMemo<readonly TranscriptRow[]>(() => {
+    const messageCreatedAtById = new Map(
+      activeSession?.messages.map((message) => [message.id, message.createdAt]) ?? []
+    )
+
+    // Counts the user turns after each message; the destructive-resend warning keys off turns, not
+    // raw message count, so a single follow-up turn stays warning-free.
+    const subsequentTurnCountByMessageId = new Map<string, number>()
+    if (activeSession) {
+      let subsequentTurns = 0
+      for (let index = activeSession.messages.length - 1; index >= 0; index -= 1) {
+        const message = activeSession.messages[index]
+        subsequentTurnCountByMessageId.set(message.id, subsequentTurns)
+        if (message.role === 'user') subsequentTurns += 1
+      }
+    }
+
+    const rows: TranscriptRow[] = []
+    // Messages and tool activities share one sorted transcript timeline.
+    conversationItems.forEach((item, itemIndex) => {
+      // Only later text messages stay behind the presentation barrier; tool,
+      // activity, and other non-message rows render in real time so their
+      // running state stays visible while the reply paces above them.
+      if (
+        presentationBarrierIndex >= 0 &&
+        itemIndex > presentationBarrierIndex &&
+        (item.type === 'message' || item.type === 'subagent-message')
+      ) {
+        return
+      }
+
+      if (item.type === 'message') {
+        const artifacts = artifactsForMessage(item.message)
+        // Jobs pre-assigned to this slot: each job appears in exactly one slot.
+        const jobsBeforeMessage = jobSlotsByItemIndex.get(itemIndex) ?? []
+        const graph = activeSession?.conversationGraph
+        const messageNode = graph?.messages.find((message) => message.id === item.message.id)
+        const runtimeSegment = messageNode?.runtimeSegmentId
+          ? graph?.runtimeSegments.find((segment) => segment.id === messageNode.runtimeSegmentId)
+          : undefined
+        // Legacy sessions synthesize this segment with a fallback framework. Keep only
+        // the session-level values that were actually persisted.
+        const synthesizedLegacyRuntime =
+          runtimeSegment?.id === `runtime-segment-${activeSession?.id}` &&
+          !activeSession?.agentFrameworkId
+        const runtimeIdentity = synthesizedLegacyRuntime ? legacyRuntimeIdentity : runtimeSegment
+        const revisionRootMessageId = messageNode?.revisionRootMessageId
+        const revisions = revisionRootMessageId
+          ? (graph?.messages
+              .filter(
+                (message) =>
+                  message.role === 'user' && message.revisionRootMessageId === revisionRootMessageId
+              )
+              .sort(
+                (left, right) => left.createdAt - right.createdAt || left.id.localeCompare(right.id)
+              ) ?? [])
+          : []
+        const revisionIndex = revisions.findIndex((message) => message.id === item.message.id)
+        const activateRevision = (index: number): (() => void) | undefined => {
+          const revision = revisions[index]
+          return revision && activeSession
+            ? () =>
+                useSessionStore
+                  .getState()
+                  .activateMessageBranch(activeSession.id, revision.introducedOnBranchId)
+            : undefined
+        }
+        const messageItemProps: EditableWorkspaceMessageItemProps = {
+          message: item.message,
+          onPreviewArtifact,
+          onPreviewUploadAttachment,
+          onOpenSkillMention,
+          onPreviewMentionArtifact,
+          onSendEditedMessage,
+          turnStartedAt: item.message.responseToMessageId
+            ? messageCreatedAtById.get(item.message.responseToMessageId)
+            : undefined,
+          runtimeIdentity,
+          showAssistantFooter:
+            item.message.role !== 'agent' || assistantFooterMessageIds.has(item.message.id),
+          subsequentTurns: subsequentTurnCountByMessageId.get(item.message.id) ?? 0,
+          revisionNavigation:
+            revisionIndex >= 0 && revisions.length > 1
+              ? {
+                  index: revisionIndex,
+                  total: revisions.length,
+                  onPrevious: activateRevision(revisionIndex - 1),
+                  onNext: activateRevision(revisionIndex + 1)
+                }
+              : undefined,
+          artifacts
+        }
+        if (item.message.role === 'agent') {
+          messageItemProps.onPresentationChange = handleMessagePresentationChange
+          messageItemProps.presentationSourceOpen = itemIndex === conversationItems.length - 1
+          messageItemProps.presentationAnimateOnMount =
+            presentationScopeRemainedVisible &&
+            !visibleMessageSnapshot.messageIds.has(item.message.id)
+        }
+
+        // Unbound completed jobs that belong chronologically before this message.
+        for (const job of jobsBeforeMessage) {
+          rows.push({
+            key: `completed-job-${job.job_id}`,
+            estimatedSize: 96,
+            scrollAnchor: false,
+            node: () => (
+              <MessageScrollerItem messageId={`completed-job-${job.job_id}`} className="min-w-0">
+                <div className="px-4 py-1 md:px-6">
+                  <div className="mx-auto w-full max-w-4xl">
+                    <CompletedJobCard job={job} onOpen={handleOpenJobDetail} />
+                  </div>
+                </div>
+              </MessageScrollerItem>
+            )
+          })
+        }
+        // #1124: the composite key remounts the message row when the presentation scope changes.
+        const messageRowKey = JSON.stringify([currentPresentationScopeId, item.id])
+        rows.push({
+          key: messageRowKey,
+          estimatedSize: item.message.role === 'user' ? 46 : 336,
+          scrollAnchor: item.message.role === 'user',
+          node: () =>
+            item.message.role === 'user' ? (
+              <EditableWorkspaceMessageItem key={messageRowKey} {...messageItemProps} />
+            ) : (
+              <WorkspaceMessageItem
+                key={messageRowKey}
+                {...messageItemProps}
+                canEditMessage={false}
+              />
+            )
+        })
+        if (
+          currentSessionId &&
+          item.message.role === 'agent' &&
+          !presentingMessageIds.has(item.message.id)
+        ) {
+          const reviewSessionId = currentSessionId
+          rows.push({
+            key: `${messageRowKey}:review`,
+            estimatedSize: 200,
+            scrollAnchor: false,
+            node: () => (
+              <WorkspaceMessageReview
+                projectId={currentProjectId}
+                sessionId={reviewSessionId}
+                turnMessageId={item.message.id}
+                onGoToTranscript={handleGoToTranscript}
+                onRerun={handleRerunReview}
+              />
+            )
+          })
+        }
+        return
+      }
+
+      if (item.type === 'subagent-message') {
+        rows.push({
+          key: item.id,
+          estimatedSize: 96,
+          scrollAnchor: false,
+          node: () => (
+            <MessageScrollerItem messageId={item.id} className="min-w-0">
+              <div className="px-4 pb-1 pt-3 md:px-6">
+                <div className="mx-auto w-full max-w-[56rem]">
+                  <WorkspaceSubagentMessageRow
+                    message={item.message}
+                    onOpenSource={() => {
+                      if (!currentSessionId) return
+                      usePreviewWorkbenchStore
+                        .getState()
+                        .upsertAndActivateItem(
+                          createSessionSubagentsPreviewItem(
+                            currentSessionId,
+                            currentProjectId,
+                            item.message.sourceFrameId
+                          )
+                        )
+                    }}
+                  />
+                </div>
+              </div>
+            </MessageScrollerItem>
+          )
+        })
+        return
+      }
+
+      if (item.type === 'handoff') {
+        rows.push({
+          key: item.id,
+          estimatedSize: 96,
+          scrollAnchor: false,
+          node: () => (
+            <MessageScrollerItem messageId={item.id} className="min-w-0">
+              <div className="px-4 pb-1 pt-3 md:px-6">
+                <div className="mx-auto w-full max-w-[56rem]">
+                  <HandoffLifecycleStatus
+                    handoff={item}
+                    onRetry={
+                      item.phase === 'failed' && onRetryHandoff
+                        ? async () =>
+                            onRetryHandoff({
+                              sessionId: item.sessionId,
+                              originatingTurnId: item.originatingTurnId
+                            })
+                        : undefined
+                    }
+                  />
+                </div>
+              </div>
+            </MessageScrollerItem>
+          )
+        })
+        return
+      }
+
+      if (item.type === 'plan-activity') {
+        rows.push({
+          key: item.id,
+          estimatedSize: 96,
+          scrollAnchor: false,
+          node: () => (
+            <WorkspacePlanActivityRecord
+              activity={item.activity}
+              hasDurablePlanAuthority={item.activity.id === durablePlanOwnerActivityId}
+            />
+          )
+        })
+        return
+      }
+
+      if (item.type === 'compaction-activity') {
+        rows.push({
+          key: item.id,
+          estimatedSize: 48,
+          scrollAnchor: false,
+          node: () => <WorkspaceContextCompactionActivityRow activity={item.activity} />
+        })
+        return
+      }
+
+      if (item.type === 'activity') {
+        const elicitation = item.activity.elicitation
+        if (!elicitation) return
+        const elicitationRequest =
+          pendingElicitations.find((request) => request.toolCallId === item.activity.id) ??
+          (activeSession && elicitation.durable
+            ? {
+                requestId: elicitation.durable.requestId,
+                sessionId: activeSession.id,
+                toolCallId: item.activity.id,
+                message: elicitation.message,
+                fields: elicitation.fields,
+                durable: elicitation.durable
+              }
+            : undefined)
+        rows.push({
+          key: item.id,
+          estimatedSize: 200,
+          scrollAnchor: false,
+          node: () => (
+            <MessageScrollerItem messageId={item.id} className="min-w-0">
+              <div className="px-4 pb-1 pt-3 md:px-6">
+                <div className="mx-auto w-full max-w-4xl">
+                  <WorkspaceElicitationCard
+                    key={elicitationRequest?.requestId ?? item.activity.id}
+                    elicitation={elicitation}
+                    request={elicitationRequest}
+                    variant={elicitation.state === 'pending' ? 'pending-placeholder' : 'default'}
+                  />
+                </div>
+              </div>
+            </MessageScrollerItem>
+          )
+        })
+        return
+      }
+
+      rows.push({
+        key: item.id,
+        estimatedSize: 96,
+        scrollAnchor: false,
+        node: () => (
+          <WorkspaceActivityGroup
+            group={item}
+            isExpanded={!collapsedActivityGroups.has(item.id)}
+            onToggleGroup={toggleActivityGroup}
+            expansionOverrides={activityExpansionOverrides}
+            onToggleRow={toggleActivityRow}
+            notebookRunsById={notebookRunsById}
+            permission={activeSession?.runtimeContext?.permission}
+            jobsByActivityId={jobsByActivityId}
+            onOpenJobDetail={handleOpenJobDetail}
+          />
+        )
+      })
+    })
+
+    // Render any remaining unbound completed jobs after all conversation items.
+    for (const job of trailingJobs) {
+      rows.push({
+        key: `completed-job-${job.job_id}`,
+        estimatedSize: 96,
+        scrollAnchor: false,
+        node: () => (
+          <MessageScrollerItem messageId={`completed-job-${job.job_id}`} className="min-w-0">
+            <div className="px-4 py-1 md:px-6">
+              <div className="mx-auto w-full max-w-4xl">
+                <CompletedJobCard job={job} onOpen={handleOpenJobDetail} />
+              </div>
+            </div>
+          </MessageScrollerItem>
+        )
+      })
+    }
+
+    if (presentationBarrierIndex < 0 && trailingContent != null) {
+      rows.push({
+        key: 'trailing-content',
+        estimatedSize: 200,
+        scrollAnchor: false,
+        node: () => <>{trailingContent}</>
+      })
+    }
+
+    if (isResumingSession && activeSession) {
+      rows.push({
+        key: 'agent-loading-resuming',
+        estimatedSize: 64,
+        scrollAnchor: false,
+        node: () => <WorkspaceAgentLoadingRow sessionId={activeSession.id} phase="resuming" />
+      })
+    } else if (agentLoadingPhase !== 'hidden' && activeSession) {
+      rows.push({
+        key: 'agent-loading',
+        estimatedSize: 64,
+        scrollAnchor: false,
+        node: () => (
+          <WorkspaceAgentLoadingRow
+            sessionId={activeSession.id}
+            phase={agentLoadingPhase}
+            agentStatus={activeSession.agentStatus}
+          />
+        )
+      })
+    }
+
+    return rows
+  }, [
+    activeSession,
+    activityExpansionOverrides,
+    agentLoadingPhase,
+    artifactsForMessage,
+    assistantFooterMessageIds,
+    collapsedActivityGroups,
+    conversationItems,
+    currentPresentationScopeId,
+    currentProjectId,
+    currentSessionId,
+    durablePlanOwnerActivityId,
+    handleGoToTranscript,
+    handleMessagePresentationChange,
+    handleOpenJobDetail,
+    handleRerunReview,
+    isResumingSession,
+    jobSlotsByItemIndex,
+    jobsByActivityId,
+    legacyRuntimeIdentity,
+    notebookRunsById,
+    onPreviewArtifact,
+    onPreviewMentionArtifact,
+    onPreviewUploadAttachment,
+    onOpenSkillMention,
+    onRetryHandoff,
+    onSendEditedMessage,
+    pendingElicitations,
+    presentationBarrierIndex,
+    presentationScopeRemainedVisible,
+    presentingMessageIds,
+    toggleActivityGroup,
+    toggleActivityRow,
+    trailingContent,
+    trailingJobs,
+    visibleMessageSnapshot
+  ])
+
+  const virtualizationEnabled = transcriptRows.length > VIRTUALIZATION_ROW_THRESHOLD
+  virtualizationEnabledRef.current = virtualizationEnabled
+  const transcriptVirtualizer = useVirtualizer({
+    count: transcriptRows.length,
+    getScrollElement: () => messageScrollerViewportRef.current,
+    estimateSize: (index) => transcriptRows[index]?.estimatedSize ?? 160,
+    getItemKey: (index) => transcriptRows[index]?.key ?? index,
+    overscan: 8
+  })
+  const transcriptVirtualSize = transcriptVirtualizer.getTotalSize()
+
+  // With virtualization the primitive only sees the total-size wrapper as Content's child, so its
+  // MutationObserver-driven behaviors never fire for transcript rows. Re-drive them against the
+  // virtualizer: initial last-anchor position, new-turn anchoring, and follow-output pinning.
+  // Follow state itself is maintained by handleMessageScrollerScroll.
+  useLayoutEffect(() => {
+    if (!virtualizationEnabled || transcriptVirtualSize <= 0) return
+    const viewport = messageScrollerViewportRef.current
+    if (!viewport) return
+    const state = virtualScrollStateRef.current
+    if (state.scopeId !== currentPresentationScopeId) {
+      state.scopeId = currentPresentationScopeId
+      state.initialized = false
+      state.follow = true
+      state.handledAnchorKeys = new Set()
+    }
+    const anchorIndexes: number[] = []
+    transcriptRows.forEach((row, index) => {
+      if (row.scrollAnchor) anchorIndexes.push(index)
+    })
+    // Land an anchor row at the viewport top with the previous-item peek above it. The offset
+    // clamps to the scrollable range, so an anchor whose remaining content fits the viewport
+    // naturally lands at the end, matching the primitive's last-anchor fallback.
+    const scrollToAnchorIndex = (index: number): void => {
+      const offset = transcriptVirtualizer.getOffsetForIndex(index, 'start')?.[0]
+      if (offset === undefined) {
+        transcriptVirtualizer.scrollToIndex(index, { align: 'start' })
+        return
+      }
+      transcriptVirtualizer.scrollToOffset(Math.max(0, offset - SCROLL_PREVIOUS_ITEM_PEEK))
+    }
+    if (!state.initialized) {
+      if (transcriptRows.length === 0) return
+      state.initialized = true
+      for (const index of anchorIndexes) state.handledAnchorKeys.add(transcriptRows[index].key)
+      const lastAnchorIndex = anchorIndexes.at(-1)
+      if (lastAnchorIndex === undefined) viewport.scrollTop = viewport.scrollHeight
+      else scrollToAnchorIndex(lastAnchorIndex)
+      return
+    }
+    const newAnchorIndexes = anchorIndexes.filter(
+      (index) => !state.handledAnchorKeys.has(transcriptRows[index].key)
+    )
+    for (const index of anchorIndexes) state.handledAnchorKeys.add(transcriptRows[index].key)
+    if (newAnchorIndexes.length > 0) {
+      if (state.follow && newAnchorIndexes.length > 1) viewport.scrollTop = viewport.scrollHeight
+      else scrollToAnchorIndex(newAnchorIndexes[0])
+      return
+    }
+    if (state.follow) viewport.scrollTop = viewport.scrollHeight
+  }, [
+    currentPresentationScopeId,
+    transcriptRows,
+    transcriptVirtualSize,
+    transcriptVirtualizer,
+    virtualizationEnabled
+  ])
 
   return (
     <>
@@ -860,7 +1351,7 @@ const WorkspaceMessageScrollerImpl = ({
         key={activeSession?.id ?? 'empty-conversation'}
         autoScroll
         defaultScrollPosition="last-anchor"
-        scrollPreviousItemPeek={64}
+        scrollPreviousItemPeek={SCROLL_PREVIOUS_ITEM_PEEK}
       >
         <MessageScroller className="relative min-h-0 flex-1 bg-bg-10">
           <div
@@ -872,298 +1363,44 @@ const WorkspaceMessageScrollerImpl = ({
             aria-label="Conversation"
             onScroll={handleMessageScrollerScroll}
           >
-            {/* No wrapper div: message-scroller only measures/anchors Content's direct children. */}
             <MessageScrollerContent
               ref={messageScrollerContentRef}
-              className="gap-0 px-4 pb-[56px]"
+              className={
+                virtualizationEnabled
+                  ? 'block min-h-full gap-0 px-4 pb-[56px]'
+                  : 'gap-0 px-4 pb-[56px]'
+              }
             >
               <VisibleMessageSnapshotCommit
                 scopeId={currentPresentationScopeId}
                 messageIdsKey={visibleMessageIdsKey}
                 onCommit={handleVisibleMessageSnapshotCommit}
               />
-              {/* Messages and tool activities share one sorted transcript timeline. */}
-              {conversationItems.map((item, itemIndex) => {
-                // Only later text messages stay behind the presentation barrier; tool,
-                // activity, and other non-message rows render in real time so their
-                // running state stays visible while the reply paces above them.
-                if (
-                  presentationBarrierIndex >= 0 &&
-                  itemIndex > presentationBarrierIndex &&
-                  (item.type === 'message' || item.type === 'subagent-message')
-                ) {
-                  return null
-                }
-
-                if (item.type === 'message') {
-                  const artifacts = artifactVisibility.artifactsForMessage(item.message)
-                  // Jobs pre-assigned to this slot: each job appears in exactly one slot.
-                  const jobsBeforeMessage = jobSlotsByItemIndex.get(itemIndex) ?? []
-                  const graph = activeSession?.conversationGraph
-                  const messageNode = graph?.messages.find(
-                    (message) => message.id === item.message.id
-                  )
-                  const runtimeSegment = messageNode?.runtimeSegmentId
-                    ? graph?.runtimeSegments.find(
-                        (segment) => segment.id === messageNode.runtimeSegmentId
-                      )
-                    : undefined
-                  // Legacy sessions synthesize this segment with a fallback framework. Keep only
-                  // the session-level values that were actually persisted.
-                  const synthesizedLegacyRuntime =
-                    runtimeSegment?.id === `runtime-segment-${activeSession?.id}` &&
-                    !activeSession?.agentFrameworkId
-                  const runtimeIdentity = synthesizedLegacyRuntime
-                    ? legacyRuntimeIdentity
-                    : runtimeSegment
-                  const revisionRootMessageId = messageNode?.revisionRootMessageId
-                  const revisions = revisionRootMessageId
-                    ? (graph?.messages
-                        .filter(
-                          (message) =>
-                            message.role === 'user' &&
-                            message.revisionRootMessageId === revisionRootMessageId
-                        )
-                        .sort(
-                          (left, right) =>
-                            left.createdAt - right.createdAt || left.id.localeCompare(right.id)
-                        ) ?? [])
-                    : []
-                  const revisionIndex = revisions.findIndex(
-                    (message) => message.id === item.message.id
-                  )
-                  const activateRevision = (index: number): (() => void) | undefined => {
-                    const revision = revisions[index]
-                    return revision && activeSession
-                      ? () =>
-                          useSessionStore
-                            .getState()
-                            .activateMessageBranch(activeSession.id, revision.introducedOnBranchId)
-                      : undefined
-                  }
-                  const messageItemProps: EditableWorkspaceMessageItemProps = {
-                    message: item.message,
-                    onPreviewArtifact,
-                    onPreviewUploadAttachment,
-                    onOpenSkillMention,
-                    onPreviewMentionArtifact,
-                    onSendEditedMessage,
-                    turnStartedAt: item.message.responseToMessageId
-                      ? messageCreatedAtById.get(item.message.responseToMessageId)
-                      : undefined,
-                    runtimeIdentity,
-                    showAssistantFooter:
-                      item.message.role !== 'agent' ||
-                      assistantFooterMessageIds.has(item.message.id),
-                    subsequentTurns: subsequentTurnCountByMessageId.get(item.message.id) ?? 0,
-                    revisionNavigation:
-                      revisionIndex >= 0 && revisions.length > 1
-                        ? {
-                            index: revisionIndex,
-                            total: revisions.length,
-                            onPrevious: activateRevision(revisionIndex - 1),
-                            onNext: activateRevision(revisionIndex + 1)
-                          }
-                        : undefined,
-                    artifacts
-                  }
-                  if (item.message.role === 'agent') {
-                    messageItemProps.onPresentationChange = handleMessagePresentationChange
-                    messageItemProps.presentationSourceOpen =
-                      itemIndex === conversationItems.length - 1
-                    messageItemProps.presentationAnimateOnMount =
-                      presentationScopeRemainedVisible &&
-                      !visibleMessageSnapshot.messageIds.has(item.message.id)
-                  }
-
-                  return (
-                    <Fragment key={item.id}>
-                      {/* Unbound completed jobs that belong chronologically before this message */}
-                      {jobsBeforeMessage.map((job) => (
-                        <MessageScrollerItem
-                          key={`completed-job-${job.job_id}`}
-                          messageId={`completed-job-${job.job_id}`}
-                          className="min-w-0"
-                        >
-                          <div className="px-4 py-1 md:px-6">
-                            <div className="mx-auto w-full max-w-4xl">
-                              <CompletedJobCard job={job} onOpen={handleOpenJobDetail} />
-                            </div>
-                          </div>
-                        </MessageScrollerItem>
-                      ))}
-                      {/* #1124: the composite key remounts the message row when the presentation
-                          scope changes; the surrounding fragment keeps sibling rows stable. */}
-                      {item.message.role === 'user' ? (
-                        <EditableWorkspaceMessageItem
-                          key={JSON.stringify([currentPresentationScopeId, item.id])}
-                          {...messageItemProps}
-                        />
-                      ) : (
-                        <WorkspaceMessageItem
-                          key={JSON.stringify([currentPresentationScopeId, item.id])}
-                          {...messageItemProps}
-                          canEditMessage={false}
-                        />
-                      )}
-                      {currentSessionId &&
-                      item.message.role === 'agent' &&
-                      !presentingMessageIds.has(item.message.id) ? (
-                        <WorkspaceMessageReview
-                          projectId={currentProjectId}
-                          sessionId={currentSessionId}
-                          turnMessageId={item.message.id}
-                          onGoToTranscript={handleGoToTranscript}
-                          onRerun={handleRerunReview}
-                        />
-                      ) : null}
-                    </Fragment>
-                  )
-                }
-
-                if (item.type === 'subagent-message') {
-                  return (
-                    <MessageScrollerItem key={item.id} messageId={item.id} className="min-w-0">
-                      <div className="px-4 pb-1 pt-3 md:px-6">
-                        <div className="mx-auto w-full max-w-[56rem]">
-                          <WorkspaceSubagentMessageRow
-                            message={item.message}
-                            onOpenSource={() => {
-                              if (!currentSessionId) return
-                              usePreviewWorkbenchStore
-                                .getState()
-                                .upsertAndActivateItem(
-                                  createSessionSubagentsPreviewItem(
-                                    currentSessionId,
-                                    currentProjectId,
-                                    item.message.sourceFrameId
-                                  )
-                                )
-                            }}
-                          />
-                        </div>
+              {virtualizationEnabled ? (
+                // The primitive's MutationObserver only watches Content's direct children, so the
+                // virtualizer owns row mounting inside one total-size wrapper; scroll behaviors are
+                // re-driven by the layout effect above.
+                <div className="relative w-full" style={{ height: transcriptVirtualSize }}>
+                  {transcriptVirtualizer.getVirtualItems().map((virtualItem) => {
+                    const row = transcriptRows[virtualItem.index]
+                    if (!row) return null
+                    return (
+                      <div
+                        key={virtualItem.key}
+                        ref={transcriptVirtualizer.measureElement}
+                        data-index={virtualItem.index}
+                        className="absolute start-0 top-0 w-full"
+                        style={{ transform: `translateY(${virtualItem.start}px)` }}
+                      >
+                        {row.node()}
                       </div>
-                    </MessageScrollerItem>
-                  )
-                }
-
-                if (item.type === 'handoff') {
-                  return (
-                    <MessageScrollerItem key={item.id} messageId={item.id} className="min-w-0">
-                      <div className="px-4 pb-1 pt-3 md:px-6">
-                        <div className="mx-auto w-full max-w-[56rem]">
-                          <HandoffLifecycleStatus
-                            handoff={item}
-                            onRetry={
-                              item.phase === 'failed' && onRetryHandoff
-                                ? async () =>
-                                    onRetryHandoff({
-                                      sessionId: item.sessionId,
-                                      originatingTurnId: item.originatingTurnId
-                                    })
-                                : undefined
-                            }
-                          />
-                        </div>
-                      </div>
-                    </MessageScrollerItem>
-                  )
-                }
-
-                if (item.type === 'plan-activity') {
-                  return (
-                    <WorkspacePlanActivityRecord
-                      key={item.id}
-                      activity={item.activity}
-                      hasDurablePlanAuthority={item.activity.id === durablePlanOwnerActivityId}
-                    />
-                  )
-                }
-
-                if (item.type === 'compaction-activity') {
-                  return (
-                    <WorkspaceContextCompactionActivityRow key={item.id} activity={item.activity} />
-                  )
-                }
-
-                if (item.type === 'activity') {
-                  if (!item.activity.elicitation) return null
-                  const elicitationRequest =
-                    pendingElicitations.find(
-                      (request) => request.toolCallId === item.activity.id
-                    ) ??
-                    (activeSession && item.activity.elicitation.durable
-                      ? {
-                          requestId: item.activity.elicitation.durable.requestId,
-                          sessionId: activeSession.id,
-                          toolCallId: item.activity.id,
-                          message: item.activity.elicitation.message,
-                          fields: item.activity.elicitation.fields,
-                          durable: item.activity.elicitation.durable
-                        }
-                      : undefined)
-                  return (
-                    <MessageScrollerItem key={item.id} messageId={item.id} className="min-w-0">
-                      <div className="px-4 pb-1 pt-3 md:px-6">
-                        <div className="mx-auto w-full max-w-4xl">
-                          <WorkspaceElicitationCard
-                            key={elicitationRequest?.requestId ?? item.activity.id}
-                            elicitation={item.activity.elicitation}
-                            request={elicitationRequest}
-                            variant={
-                              item.activity.elicitation.state === 'pending'
-                                ? 'pending-placeholder'
-                                : 'default'
-                            }
-                          />
-                        </div>
-                      </div>
-                    </MessageScrollerItem>
-                  )
-                }
-
-                return (
-                  <WorkspaceActivityGroup
-                    key={item.id}
-                    group={item}
-                    isExpanded={!collapsedActivityGroups.has(item.id)}
-                    onToggleGroup={toggleActivityGroup}
-                    expansionOverrides={activityExpansionOverrides}
-                    onToggleRow={toggleActivityRow}
-                    notebookRunsById={notebookRunsById}
-                    permission={activeSession?.runtimeContext?.permission}
-                    jobsByActivityId={jobsByActivityId}
-                    onOpenJobDetail={handleOpenJobDetail}
-                  />
-                )
-              })}
-
-              {/* Render any remaining unbound completed jobs after all conversation items */}
-              {trailingJobs.map((job) => (
-                <MessageScrollerItem
-                  key={`completed-job-${job.job_id}`}
-                  messageId={`completed-job-${job.job_id}`}
-                  className="min-w-0"
-                >
-                  <div className="px-4 py-1 md:px-6">
-                    <div className="mx-auto w-full max-w-4xl">
-                      <CompletedJobCard job={job} onOpen={handleOpenJobDetail} />
-                    </div>
-                  </div>
-                </MessageScrollerItem>
-              ))}
-
-              {presentationBarrierIndex < 0 ? trailingContent : null}
-
-              {isResumingSession && activeSession ? (
-                <WorkspaceAgentLoadingRow sessionId={activeSession.id} phase="resuming" />
-              ) : agentLoadingPhase !== 'hidden' && activeSession ? (
-                <WorkspaceAgentLoadingRow
-                  sessionId={activeSession.id}
-                  phase={agentLoadingPhase}
-                  agentStatus={activeSession.agentStatus}
-                />
-              ) : null}
+                    )
+                  })}
+                </div>
+              ) : (
+                // No wrapper div: message-scroller only measures/anchors Content's direct children.
+                transcriptRows.map((row) => <Fragment key={row.key}>{row.node()}</Fragment>)
+              )}
             </MessageScrollerContent>
           </MessageScrollerViewport>
 

--- a/src/renderer/src/stores/session-job-store.test.ts
+++ b/src/renderer/src/stores/session-job-store.test.ts
@@ -112,10 +112,25 @@ describe('session job store — runningJobsForSession', () => {
 
 describe('session job store — allJobsForSession', () => {
   it('returns all jobs for the session regardless of status, sorted by created_at descending', () => {
-    const job1 = makeJob({ job_id: 'j1', session_id: 'sess-A', status: 'success', created_at: 1000 })
-    const job2 = makeJob({ job_id: 'j2', session_id: 'sess-A', status: 'running', created_at: 3000 })
+    const job1 = makeJob({
+      job_id: 'j1',
+      session_id: 'sess-A',
+      status: 'success',
+      created_at: 1000
+    })
+    const job2 = makeJob({
+      job_id: 'j2',
+      session_id: 'sess-A',
+      status: 'running',
+      created_at: 3000
+    })
     const job3 = makeJob({ job_id: 'j3', session_id: 'sess-A', status: 'failed', created_at: 2000 })
-    const otherSession = makeJob({ job_id: 'o', session_id: 'sess-B', status: 'success', created_at: 4000 })
+    const otherSession = makeJob({
+      job_id: 'o',
+      session_id: 'sess-B',
+      status: 'success',
+      created_at: 4000
+    })
 
     useSessionJobStore.getState().applyUpdate(job1)
     useSessionJobStore.getState().applyUpdate(job2)

--- a/src/shared/remote-fs.ts
+++ b/src/shared/remote-fs.ts
@@ -262,7 +262,9 @@ export const decodeRemoteFsError = (message: string): SerializableRemoteFsError 
   const idx = message.lastIndexOf(REMOTE_FS_ERROR_MARKER)
   if (idx === -1) return null
   try {
-    return JSON.parse(message.slice(idx + REMOTE_FS_ERROR_MARKER.length)) as SerializableRemoteFsError
+    return JSON.parse(
+      message.slice(idx + REMOTE_FS_ERROR_MARKER.length)
+    ) as SerializableRemoteFsError
   } catch {
     return null
   }


### PR DESCRIPTION
**Archived for reference — not intended for merge.** Evaluation branch for transcript virtualization per the shadcn [Message Scroller Virtualization](https://ui.shadcn.com/docs/components/base/message-scroller#virtualization) recipe, combined with the indexing fix from #1210 (A+B).

## Contents

- `ac2664f0` — virtualize transcript rows past a 100-row threshold with `@tanstack/react-virtual@3.14.9`; app-side anchoring/follow-output engine replaces the primitive's MutationObserver-based behavior on the virtualized path.
- `c07a45b1` — cherry-pick of the per-row graph-lookup indexing fix from #1210, adapted to consume the memoized indexes inside the virtualized `transcriptRows` descriptor builder.

## Benchmark (2000 messages, same protocol as #1210)

| Metric | main | #1210 (A) | A+B (this branch) |
|---|---|---|---|
| TTI from navigation | 2876–4785ms | 3076–3817ms | 2416ms |
| DOM rows / elements | 2000 / 50,892 | 2000 / 50,892 | 9 / 419 |
| Streaming frame p95 / max | 134–172 / 320–453ms | 66–68 / 241–267ms | **26.6 / 52.9ms** |
| Streaming longtasks | 16 / ~1.9s | 5 / ~0.5s | **0 / 0** |
| Scroll frame p95 | 14.3–26.7ms | 27.6ms | 40ms (within run variance) |

## Why deferred

- Scroll performance is flat across all configs — `content-visibility` already covers the 500–2000 row range; virtualization's streaming win only completes when combined with A.
- Costs: the >100-row path bypasses the primitive's anchoring/follow behavior (~70 lines of app-side engine, covered only by the perf spec), dual code paths, `scrollToMessage` returns false for unmounted rows, and find-in-page / cross-range selection / accessibility tree cover only mounted rows.
- Revisit if transcripts routinely exceed several thousand rows; the correct shape then is A+B with a higher threshold and dedicated scroll e2e coverage for the virtualized path.

## Verification (final combined build)

Perf spec 2 passed; message-scroll anchor/reanchor/release e2e 3 passed; 189 related unit tests pass unmodified; tsc (web+node) and eslint clean (one informational `react-hooks/incompatible-library` warning for `useVirtualizer`).