### PR TITLE
test(projects): guard project-owned data lifecycle

### DIFF
--- a/src/main/projects/project-owned-data.catalog.architecture.test.ts
+++ b/src/main/projects/project-owned-data.catalog.architecture.test.ts
@@ -1,0 +1,578 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { Prisma } from '@prisma/client'
+import {
+  createSourceFile,
+  forEachChild,
+  isCallExpression,
+  isClassDeclaration,
+  isFunctionDeclaration,
+  isIdentifier,
+  isMethodDeclaration,
+  isNewExpression,
+  isObjectLiteralExpression,
+  isPropertyAssignment,
+  isShorthandPropertyAssignment,
+  isVariableDeclaration,
+  ScriptTarget,
+  type CallExpression,
+  type MethodDeclaration,
+  type Node,
+  type ObjectLiteralElementLike,
+  type ObjectLiteralExpression,
+  type SourceFile
+} from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+import { MAX_NOTIFICATION_INBOX_ITEMS } from '../notifications/notification-inbox-repository'
+import { PROJECT_OWNED_DATA_CATALOG } from './project-owned-data.catalog'
+
+const projectRoot = resolve(__dirname, '../../..')
+const sourcePath = (relativePath: string): string => resolve(projectRoot, relativePath)
+const sourceFile = (relativePath: string): SourceFile => {
+  const path = sourcePath(relativePath)
+  return createSourceFile(path, readFileSync(path, 'utf8'), ScriptTarget.Latest, true)
+}
+
+type SourceScope = Readonly<{ file: SourceFile; node: Node }>
+type CallRecord = Readonly<{ callee: string; position: number; call: CallExpression }>
+
+const normalized = (value: string): string => value.replaceAll('?.', '.').replaceAll(/\s+/gu, '')
+
+const visit = (root: Node, inspect: (node: Node) => void): void => {
+  inspect(root)
+  forEachChild(root, (child) => visit(child, inspect))
+}
+
+const classMethod = (relativePath: string, className: string, methodName: string): SourceScope => {
+  const file = sourceFile(relativePath)
+  let method: MethodDeclaration | undefined
+  visit(file, (node) => {
+    if (!isClassDeclaration(node) || node.name?.text !== className) return
+    method = node.members.find(
+      (member): member is MethodDeclaration =>
+        isMethodDeclaration(member) && member.name.getText(file) === methodName
+    )
+  })
+  if (!method) throw new Error(`Method not found: ${className}.${methodName}`)
+  return { file, node: method }
+}
+
+const functionScope = (relativePath: string, functionName: string): SourceScope => {
+  const file = sourceFile(relativePath)
+  let declaration: Node | undefined
+  visit(file, (node) => {
+    if (isFunctionDeclaration(node) && node.name?.text === functionName) declaration = node
+  })
+  if (!declaration) {
+    visit(file, (node) => {
+      if (
+        isIdentifier(node) &&
+        node.text === functionName &&
+        node.parent &&
+        (isPropertyAssignment(node.parent) || isVariableDeclaration(node.parent))
+      ) {
+        declaration = node.parent.initializer
+      }
+    })
+  }
+  if (!declaration) throw new Error(`Function not found: ${functionName}`)
+  return { file, node: declaration }
+}
+
+const callsIn = ({ file, node }: SourceScope): CallRecord[] => {
+  const calls: CallRecord[] = []
+  visit(node, (candidate) => {
+    if (!isCallExpression(candidate)) return
+    calls.push({
+      callee: normalized(candidate.expression.getText(file)),
+      position: candidate.getStart(file),
+      call: candidate
+    })
+  })
+  return calls.sort((left, right) => left.position - right.position)
+}
+
+const expectCallsInOrder = (scope: SourceScope, expected: readonly string[]): void => {
+  const calls = callsIn(scope)
+  let cursor = -1
+  for (const rawExpected of expected) {
+    const callee = normalized(rawExpected)
+    const next = calls.findIndex((call, index) => index > cursor && call.callee === callee)
+    expect(next, `${callee} after call index ${cursor}`).toBeGreaterThan(cursor)
+    cursor = next
+  }
+}
+
+const expectCall = (scope: SourceScope, expected: string): CallRecord => {
+  const callee = normalized(expected)
+  const match = callsIn(scope).find((call) => call.callee === callee)
+  expect(match, callee).toBeDefined()
+  return match!
+}
+
+const newExpression = (relativePath: string, className: string): SourceScope => {
+  const file = sourceFile(relativePath)
+  let expression: Node | undefined
+  visit(file, (node) => {
+    if (isNewExpression(node) && normalized(node.expression.getText(file)) === className) {
+      expression = node
+    }
+  })
+  if (!expression) throw new Error(`Constructor call not found: ${className}`)
+  return { file, node: expression }
+}
+
+const objectMethod = (
+  file: SourceFile,
+  object: ObjectLiteralExpression,
+  methodName: string
+): SourceScope => {
+  const property = object.properties.find(
+    (candidate) => 'name' in candidate && candidate.name?.getText(file) === methodName
+  )
+  if (!property) throw new Error(`Object method not found: ${methodName}`)
+  if (isMethodDeclaration(property)) return { file, node: property }
+  if (isPropertyAssignment(property)) return { file, node: property.initializer }
+  throw new Error(`Object property is not callable: ${methodName}`)
+}
+
+const objectProperty = (
+  file: SourceFile,
+  object: ObjectLiteralExpression,
+  propertyName: string
+): ObjectLiteralElementLike => {
+  const property = object.properties.find((candidate) => {
+    if (!('name' in candidate) || !candidate.name) return false
+    return candidate.name.getText(file) === propertyName
+  })
+  if (!property) throw new Error(`Object property not found: ${propertyName}`)
+  return property
+}
+
+const nestedMethod = (scope: SourceScope, methodName: string): SourceScope => {
+  let method: MethodDeclaration | undefined
+  visit(scope.node, (node) => {
+    if (isMethodDeclaration(node) && node.name.getText(scope.file) === methodName) method = node
+  })
+  if (!method) throw new Error(`Nested method not found: ${methodName}`)
+  return { file: scope.file, node: method }
+}
+
+const isProjectOwnerField = (name: string): boolean => /(?:^projectId$|ProjectId$)/u.test(name)
+const isProjectOrSessionOwnerField = (name: string): boolean =>
+  /(?:^(?:project|session)Id$|(?:Project|Session)Id$)/u.test(name)
+
+const dmmfOwnerInventory = (): Array<{
+  name: string
+  ownerFields: Array<{ name: string; required: boolean }>
+}> =>
+  Prisma.dmmf.datamodel.models
+    .filter((model) =>
+      model.fields.some((field) => field.kind === 'scalar' && isProjectOwnerField(field.name))
+    )
+    .map((model) => ({
+      name: model.name,
+      ownerFields: model.fields
+        .filter((field) => field.kind === 'scalar' && isProjectOrSessionOwnerField(field.name))
+        .map((field) => ({ name: field.name, required: field.isRequired }))
+        .sort((left, right) => left.name.localeCompare(right.name))
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name))
+
+const catalogOwnerInventory = (): ReturnType<typeof dmmfOwnerInventory> =>
+  PROJECT_OWNED_DATA_CATALOG.flatMap((entry) => entry.prismaModels ?? [])
+    .map((model) => ({
+      name: model.name,
+      ownerFields: [...model.ownerFields]
+        .map((field) => ({ name: field.name, required: field.required }))
+        .sort((left, right) => left.name.localeCompare(right.name))
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name))
+
+describe('Project-owned data catalog architecture', () => {
+  it('forces every Prisma Project owner model to choose an explicit lifecycle policy', () => {
+    expect(catalogOwnerInventory()).toEqual(dmmfOwnerInventory())
+  })
+
+  it('locks the curated SQL, filesystem, and runtime ownership inventory', () => {
+    expect(PROJECT_OWNED_DATA_CATALOG.map((entry) => entry.id)).toEqual([
+      'permission-grants',
+      'project-preview-state',
+      'notification-inbox-history',
+      'review-persistence',
+      'project-deletion-intent',
+      'managed-file-projection',
+      'artifact-provenance',
+      'compute-jobs',
+      'compute-job-remote-workdirs',
+      'project-session-json',
+      'artifact-bytes',
+      'upload-bytes',
+      'delegated-frame-workspaces',
+      'acp-runtime-state',
+      'reviewer-runtime-state',
+      'side-chat-runtime-state',
+      'notebook-kernel-runtime-state',
+      'compute-runtime-state',
+      'notebook-project-workspace'
+    ])
+    expect(
+      [
+        ...new Set(
+          PROJECT_OWNED_DATA_CATALOG.flatMap((entry) =>
+            'path' in entry.policy && entry.policy.path ? [entry.policy.path] : []
+          )
+        )
+      ].sort()
+    ).toEqual([
+      'compute-job-project-delete',
+      'delegated-runtime-quiescence',
+      'notification-session-invalidation',
+      'project-deletion-intent-protocol',
+      'project-file-projection-delete',
+      'project-runtime-quiescence',
+      'project-session-json-delete',
+      'provenance-tail',
+      'review-tail'
+    ])
+  })
+
+  it('checks declared Prisma cascades and Restrict boundaries through generated DMMF', () => {
+    for (const entry of PROJECT_OWNED_DATA_CATALOG) {
+      for (const modelContract of entry.prismaModels ?? []) {
+        const model = Prisma.dmmf.datamodel.models.find(
+          (candidate) => candidate.name === modelContract.name
+        )
+        expect(model, modelContract.name).toBeDefined()
+        for (const relationContract of modelContract.relationContracts ?? []) {
+          const relation = model?.fields.find(
+            (field) => field.kind === 'object' && field.name === relationContract.field
+          )
+          expect(relation, `${modelContract.name}.${relationContract.field}`).toMatchObject({
+            type: relationContract.target,
+            relationFromFields: relationContract.fromFields,
+            relationOnDelete: relationContract.onDelete
+          })
+        }
+        if (entry.policy.kind === 'foreign-key-cascade') {
+          expect(
+            modelContract.relationContracts?.some(
+              (relation) => relation.target === 'Project' && relation.onDelete === 'Cascade'
+            ),
+            `${modelContract.name} Project cascade`
+          ).toBe(true)
+        }
+      }
+    }
+  })
+
+  it('requires complete policy metadata without registering shared Runtime or Skill packages', () => {
+    const ids = new Set<string>()
+    for (const entry of PROJECT_OWNED_DATA_CATALOG) {
+      expect(ids.has(entry.id), entry.id).toBe(false)
+      ids.add(entry.id)
+      expect(entry.resources.length, entry.id).toBeGreaterThan(0)
+
+      if (entry.policy.kind === 'coordinator-cleanup') {
+        expect(entry.policy.operation.trim(), entry.id).not.toBe('')
+        expect(entry.policy.note.trim(), entry.id).not.toBe('')
+      } else if (entry.policy.kind === 'retained-history') {
+        expect(entry.policy.reason.trim(), entry.id).not.toBe('')
+        expect(entry.policy.retention.trim(), entry.id).not.toBe('')
+      } else if (entry.policy.kind === 'deletion-protocol') {
+        expect(entry.policy.purpose.trim(), entry.id).not.toBe('')
+      }
+    }
+    expect([...ids].filter((id) => /(?:runtime-package|skill-package)/u.test(id))).toEqual([])
+
+    const notification = Prisma.dmmf.datamodel.models.find(
+      (model) => model.name === 'NotificationInboxItem'
+    )
+    expect(
+      notification?.fields.find((field) => field.name === 'targetInvalidatedAt')
+    ).toMatchObject({
+      kind: 'scalar',
+      type: 'DateTime',
+      isRequired: false
+    })
+    expect(
+      notification?.fields.some((field) => field.kind === 'object' && field.type === 'Project')
+    ).toBe(false)
+  })
+
+  it('locks the durable Project deletion composition and tail order', () => {
+    const constructor = newExpression('src/main/ipc.ts', 'ProjectDeletionCoordinator')
+    if (!isNewExpression(constructor.node)) throw new Error('Expected constructor expression.')
+    expect(
+      constructor.node.arguments?.slice(0, 5).map((argument) => argument.getText(constructor.file))
+    ).toEqual([
+      'projectRepository',
+      'sessionPersistenceCoordinator',
+      'reviewRepository',
+      'artifactProvenanceRepository',
+      'permissionGrantRegistry'
+    ])
+    const lifecycle = constructor.node.arguments?.[5]
+    if (!lifecycle || !isObjectLiteralExpression(lifecycle)) {
+      throw new Error('Project deletion lifecycle wiring is not an object literal.')
+    }
+    expectCall(
+      objectMethod(constructor.file, lifecycle, 'beforeProjectDelete'),
+      'owner.quiesceProject'
+    )
+
+    expectCallsInOrder(
+      classMethod(
+        'src/main/projects/deletion-coordinator.ts',
+        'ProjectDeletionCoordinator',
+        'runDeletion'
+      ),
+      [
+        'this.createDeletionIntentWithFence',
+        'this.lifecycle?.beforeProjectDelete',
+        'this.sessions.deleteProjectSessions',
+        'this.finishDeletion'
+      ]
+    )
+    expectCall(
+      classMethod(
+        'src/main/projects/deletion-coordinator.ts',
+        'ProjectDeletionCoordinator',
+        'createDeletionIntentWithFence'
+      ),
+      'this.projects.createDeletionIntent'
+    )
+    expectCallsInOrder(
+      classMethod(
+        'src/main/projects/deletion-coordinator.ts',
+        'ProjectDeletionCoordinator',
+        'finishDeletion'
+      ),
+      [
+        'this.permissionGrants?.prune',
+        'this.projects.get',
+        'this.projects.delete',
+        'this.permissionGrants?.finalizeOwnerDeletion',
+        'this.reviews?.deleteReviewsForProject',
+        'this.provenance?.deleteProjectProvenance',
+        'this.lifecycle?.finalizeProjectDeletion',
+        'this.sessions.completeProjectSessionDeletion',
+        'this.projects.deleteDeletionIntent'
+      ]
+    )
+  })
+
+  it('proves every live subsystem is wired through pre-authority runtime quiescence', () => {
+    const quiescence = classMethod(
+      'src/main/projects/project-runtime-quiescence-owner.ts',
+      'ProjectRuntimeQuiescenceOwner',
+      'quiesceProject'
+    )
+    expectCallsInOrder(quiescence, [
+      'this.options.reviewer.quiesceProject',
+      'this.options.sideChat.invalidateProject',
+      'this.options.acp.deleteSession',
+      'this.options.notebook.shutdownProject',
+      'this.options.delegation.deleteProject',
+      'this.options.compute.reconcileProject'
+    ])
+    const acpDeletes = callsIn(quiescence).filter(
+      (call) => call.callee === 'this.options.acp.deleteSession'
+    )
+    const delegatedDelete = expectCall(quiescence, 'this.options.delegation.deleteProject')
+    expect(acpDeletes).toHaveLength(2)
+    expect(acpDeletes[1]!.position).toBeGreaterThan(delegatedDelete.position)
+
+    const composition = newExpression('src/main/ipc.ts', 'ProjectRuntimeQuiescenceOwner')
+    if (!isNewExpression(composition.node)) throw new Error('Expected quiescence constructor.')
+    const options = composition.node.arguments?.[0]
+    if (!options || !isObjectLiteralExpression(options)) {
+      throw new Error('Project runtime quiescence wiring is not an object literal.')
+    }
+    const reviewer = objectProperty(composition.file, options, 'reviewer')
+    const sideChat = objectProperty(composition.file, options, 'sideChat')
+    expect(isPropertyAssignment(reviewer) && reviewer.initializer.getText(composition.file)).toBe(
+      'reviewerProjectRuntime'
+    )
+    expect(isPropertyAssignment(sideChat) && sideChat.initializer.getText(composition.file)).toBe(
+      'sideChatRuntime'
+    )
+
+    for (const [ownerName, methodName, callName] of [
+      ['acp', 'deleteSession', 'runtime.deleteSession'],
+      ['delegation', 'deleteProject', 'delegatedWork.root.deleteProject'],
+      ['notebook', 'shutdownProject', 'notebookService.shutdownProject']
+    ] as const) {
+      const owner = objectProperty(composition.file, options, ownerName)
+      if (!isPropertyAssignment(owner) || !isObjectLiteralExpression(owner.initializer)) {
+        throw new Error(`Quiescence owner wiring is not an object: ${ownerName}`)
+      }
+      expectCall(objectMethod(composition.file, owner.initializer, methodName), callName)
+    }
+    const compute = objectProperty(composition.file, options, 'compute')
+    if (!isPropertyAssignment(compute) || !isObjectLiteralExpression(compute.initializer)) {
+      throw new Error('Compute quiescence wiring is not an object.')
+    }
+    expectCall(
+      objectMethod(composition.file, compute.initializer, 'reconcileProject'),
+      'deletionOwner.reconcileProjectOrphanJobs'
+    )
+  })
+
+  it('proves Session JSON, Compute Jobs, and Managed File projection share the durable delete path', () => {
+    const deletion = classMethod(
+      'src/main/session-persistence/deletion-owner.ts',
+      'SessionPersistenceDeletionOwner',
+      'deleteProjectSessions'
+    )
+    expectCall(deletion, 'this.computeJobs?.prepareProjectJobDeletion')
+    const repositoryDelete = expectCall(deletion, 'this.repository.deleteProjectSessions')
+    const calls = callsIn(deletion)
+    const commitAfterAuthority = calls.find(
+      (call) =>
+        call.position > repositoryDelete.position &&
+        call.callee === 'this.computeJobs.commitProjectJobDeletion'
+    )
+    const projectionAfterCommit = calls.find(
+      (call) =>
+        commitAfterAuthority &&
+        call.position > commitAfterAuthority.position &&
+        call.callee === 'this.fileIndex.softDeleteProject'
+    )
+    const notificationAfterProjection = calls.find(
+      (call) =>
+        projectionAfterCommit &&
+        call.position > projectionAfterCommit.position &&
+        call.callee === 'this.notifySessionsDeleted'
+    )
+    expect(commitAfterAuthority).toBeDefined()
+    expect(projectionAfterCommit).toBeDefined()
+    expect(notificationAfterProjection).toBeDefined()
+
+    expectCall(
+      classMethod(
+        'src/main/projects/deletion-coordinator.ts',
+        'ProjectDeletionCoordinator',
+        'finishDeletion'
+      ),
+      'this.sessions.completeProjectSessionDeletion'
+    )
+  })
+
+  it('proves retained notifications are invalidated through the committed Session deletion path', () => {
+    expect(MAX_NOTIFICATION_INBOX_ITEMS).toBe(1000)
+    expectCall(
+      classMethod(
+        'src/main/session-persistence/coordinator.ts',
+        'SessionPersistenceCoordinator',
+        'notifySessionsDeleted'
+      ),
+      'this.sessionDeletionHandlers?.commit'
+    )
+    const binding = functionScope(
+      'src/main/notifications/notification-inbox-runtime.ts',
+      'bindNotificationInboxDeletionRuntime'
+    )
+    expectCall(binding, 'dependencies.sessionPersistenceCoordinator.setSessionDeletionHandlers')
+    expectCall(binding, 'dependencies.inbox.invalidateSessions')
+
+    const ipc = sourceFile('src/main/ipc.ts')
+    let bindCall: CallExpression | undefined
+    visit(ipc, (node) => {
+      if (
+        isCallExpression(node) &&
+        normalized(node.expression.getText(ipc)) === 'bindNotificationInboxDeletionRuntime'
+      ) {
+        bindCall = node
+      }
+    })
+    const options = bindCall?.arguments[0]
+    if (!options || !isObjectLiteralExpression(options)) {
+      throw new Error('Notification deletion runtime is not wired from the composition root.')
+    }
+    const inbox = objectProperty(ipc, options, 'inbox')
+    expect(isPropertyAssignment(inbox) && inbox.initializer.getText(ipc)).toBe('notificationInbox')
+    expect(
+      isShorthandPropertyAssignment(objectProperty(ipc, options, 'sessionPersistenceCoordinator'))
+    ).toBe(true)
+  })
+
+  it('proves Compute cleanup removes remote work before deleting owner rows', () => {
+    expectCall(
+      classMethod(
+        'src/main/compute/job-deletion-owner.ts',
+        'ComputeJobDeletionOwner',
+        'commitProjectJobDeletion'
+      ),
+      'this.commitOwner'
+    )
+    expectCallsInOrder(
+      classMethod(
+        'src/main/compute/job-deletion-owner.ts',
+        'ComputeJobDeletionOwner',
+        'commitOwner'
+      ),
+      ['this.runRemoteCleanup', 'this.deps.lifecycle.deleteOwnerRows']
+    )
+    expectCall(
+      classMethod(
+        'src/main/compute/compute-job-lifecycle.ts',
+        'ComputeJobLifecycle',
+        'deleteOwnerRows'
+      ),
+      'this.repository.deleteByOwner'
+    )
+  })
+
+  it('proves Session tombstones and delegated workspaces perform their declared filesystem cleanup', () => {
+    expectCallsInOrder(
+      classMethod(
+        'src/main/session-persistence/repository.ts',
+        'SessionRepository',
+        'deleteProjectSessions'
+      ),
+      ['writeFile', 'rename']
+    )
+    expectCall(
+      classMethod(
+        'src/main/session-persistence/repository.ts',
+        'SessionRepository',
+        'completeProjectSessionDeletion'
+      ),
+      'this.dependencies.remove'
+    )
+
+    const delegated = functionScope(
+      'src/main/delegation/production-composition.ts',
+      'createProductionDelegatedWorkComposition'
+    )
+    expectCall(nestedMethod(delegated, 'deleteProject'), 'workspace.deleteProject')
+    const workspace = functionScope(
+      'src/main/delegation/frame-workspace.ts',
+      'createProductionFrameWorkspace'
+    )
+    const workspaceDelete = nestedMethod(workspace, 'deleteProject')
+    expectCallsInOrder(workspaceDelete, ['makeTreeRemovable', 'rm'])
+  })
+
+  it('proves provenance cleanup owns Restrict-ordered rows and managed bytes', () => {
+    const cleanup = classMethod(
+      'src/main/artifacts/provenance-repository.ts',
+      'ArtifactProvenanceRepository',
+      'deleteProjectProvenance'
+    )
+    expectCallsInOrder(cleanup, [
+      'client.uploadVersion.findMany',
+      'rm',
+      'client.$transaction',
+      'tx.artifactVersionInput.deleteMany',
+      'tx.artifactLineage.deleteMany',
+      'tx.uploadFile.deleteMany',
+      'tx.artifactMessageSnapshot.deleteMany',
+      'tx.fileOriginSession.deleteMany',
+      'rm'
+    ])
+  })
+})

--- a/src/main/projects/project-owned-data.catalog.architecture.test.ts
+++ b/src/main/projects/project-owned-data.catalog.architecture.test.ts
@@ -81,6 +81,18 @@ const functionScope = (relativePath: string, functionName: string): SourceScope 
   return { file, node: declaration }
 }
 
+const variableInitializer = (relativePath: string, variableName: string): SourceScope => {
+  const file = sourceFile(relativePath)
+  let initializer: Node | undefined
+  visit(file, (node) => {
+    if (isVariableDeclaration(node) && node.name.getText(file) === variableName) {
+      initializer = node.initializer
+    }
+  })
+  if (!initializer) throw new Error(`Variable initializer not found: ${variableName}`)
+  return { file, node: initializer }
+}
+
 const callsIn = ({ file, node }: SourceScope): CallRecord[] => {
   const calls: CallRecord[] = []
   visit(node, (candidate) => {
@@ -527,6 +539,17 @@ describe('Project-owned data catalog architecture', () => {
   })
 
   it('proves Session tombstones and delegated workspaces perform their declared filesystem cleanup', () => {
+    expect(
+      PROJECT_OWNED_DATA_CATALOG.find((entry) => entry.id === 'project-session-json')?.resources
+    ).toEqual(['sessions/<projectId>/', 'deleted-sessions/<projectId>/'])
+    expect(
+      normalized(
+        variableInitializer(
+          'src/main/session-persistence/repository.ts',
+          'DELETED_SESSIONS_DIR'
+        ).node.getText()
+      )
+    ).toBe("'deleted-sessions'")
     expectCallsInOrder(
       classMethod(
         'src/main/session-persistence/repository.ts',
@@ -548,6 +571,22 @@ describe('Project-owned data catalog architecture', () => {
       'src/main/delegation/production-composition.ts',
       'createProductionDelegatedWorkComposition'
     )
+    expect(
+      PROJECT_OWNED_DATA_CATALOG.find((entry) => entry.id === 'delegated-frame-workspaces')
+        ?.resources
+    ).toEqual(['delegation/<projectId>/'])
+    const workspaceConstruction = expectCall(delegated, 'createProductionFrameWorkspace').call
+      .arguments[0]
+    expect(workspaceConstruction && isObjectLiteralExpression(workspaceConstruction)).toBe(true)
+    expect(
+      normalized(
+        objectProperty(
+          delegated.file,
+          workspaceConstruction as ObjectLiteralExpression,
+          'root'
+        ).getText(delegated.file)
+      )
+    ).toBe("root:join(options.dataRoot,'delegation')")
     expectCall(nestedMethod(delegated, 'deleteProject'), 'workspace.deleteProject')
     const workspace = functionScope(
       'src/main/delegation/frame-workspace.ts',

--- a/src/main/projects/project-owned-data.catalog.ts
+++ b/src/main/projects/project-owned-data.catalog.ts
@@ -1,0 +1,449 @@
+// Test-only architecture metadata. Runtime deletion must continue to flow through
+// ProjectDeletionCoordinator and the subsystem owners named below; this catalog never executes it.
+
+type ProjectOwnerFieldName = 'projectId' | 'sessionId' | 'sourceProjectId' | 'sourceSessionId'
+
+type ProjectOwnerField = Readonly<{
+  name: ProjectOwnerFieldName
+  required: boolean
+}>
+
+type PrismaRelationContract = Readonly<{
+  field: string
+  target: string
+  fromFields: readonly string[]
+  onDelete: 'Cascade' | 'Restrict'
+}>
+
+type PrismaOwnerModel = Readonly<{
+  name: string
+  ownerFields: readonly ProjectOwnerField[]
+  relationContracts?: readonly PrismaRelationContract[]
+}>
+
+type ProjectDeletionPath =
+  | 'compute-job-project-delete'
+  | 'delegated-runtime-quiescence'
+  | 'notification-session-invalidation'
+  | 'project-deletion-intent-protocol'
+  | 'project-file-projection-delete'
+  | 'project-runtime-quiescence'
+  | 'project-session-json-delete'
+  | 'provenance-tail'
+  | 'review-tail'
+
+type ForeignKeyCascadePolicy = Readonly<{
+  kind: 'foreign-key-cascade'
+  note: string
+}>
+
+type CoordinatorCleanupPolicy = Readonly<{
+  kind: 'coordinator-cleanup'
+  effect: 'hard-delete' | 'logical-delete' | 'invalidate' | 'drain'
+  path: ProjectDeletionPath
+  operation: string
+  note: string
+}>
+
+type RetainedHistoryPolicy = Readonly<{
+  kind: 'retained-history'
+  effect: 'invalidate' | 'retain'
+  path?: ProjectDeletionPath
+  operation?: string
+  retention: string
+  reason: string
+}>
+
+type DeletionProtocolPolicy = Readonly<{
+  kind: 'deletion-protocol'
+  path: 'project-deletion-intent-protocol'
+  operation: string
+  purpose: string
+}>
+
+type ProjectOwnedDataPolicy =
+  | ForeignKeyCascadePolicy
+  | CoordinatorCleanupPolicy
+  | RetainedHistoryPolicy
+  | DeletionProtocolPolicy
+
+type ProjectOwnedDataCatalogEntry = Readonly<{
+  id: string
+  medium: 'sqlite' | 'filesystem' | 'remote-runtime' | 'runtime-state'
+  resources: readonly string[]
+  prismaModels?: readonly PrismaOwnerModel[]
+  policy: ProjectOwnedDataPolicy
+}>
+
+const requiredOwner = (name: ProjectOwnerFieldName): ProjectOwnerField => ({
+  name,
+  required: true
+})
+
+const optionalOwner = (name: ProjectOwnerFieldName): ProjectOwnerField => ({
+  name,
+  required: false
+})
+
+const PROJECT_OWNED_DATA_CATALOG: readonly ProjectOwnedDataCatalogEntry[] = [
+  {
+    id: 'permission-grants',
+    medium: 'sqlite',
+    resources: ['PermissionGrant'],
+    prismaModels: [
+      {
+        name: 'PermissionGrant',
+        ownerFields: [optionalOwner('projectId'), optionalOwner('sessionId')],
+        relationContracts: [
+          {
+            field: 'project',
+            target: 'Project',
+            fromFields: ['projectId'],
+            onDelete: 'Cascade'
+          }
+        ]
+      }
+    ],
+    policy: {
+      kind: 'foreign-key-cascade',
+      note: 'Project deletion also prunes the permission registry before deleting the Project row.'
+    }
+  },
+  {
+    id: 'project-preview-state',
+    medium: 'sqlite',
+    resources: ['ProjectPreviewState'],
+    prismaModels: [
+      {
+        name: 'ProjectPreviewState',
+        ownerFields: [requiredOwner('projectId')],
+        relationContracts: [
+          {
+            field: 'project',
+            target: 'Project',
+            fromFields: ['projectId'],
+            onDelete: 'Cascade'
+          }
+        ]
+      }
+    ],
+    policy: {
+      kind: 'foreign-key-cascade',
+      note: 'The preview projection has no lifecycle outside its Project.'
+    }
+  },
+  {
+    id: 'notification-inbox-history',
+    medium: 'sqlite',
+    resources: ['NotificationInboxItem'],
+    prismaModels: [
+      {
+        name: 'NotificationInboxItem',
+        ownerFields: [optionalOwner('projectId'), optionalOwner('sessionId')]
+      }
+    ],
+    policy: {
+      kind: 'retained-history',
+      effect: 'invalidate',
+      path: 'notification-session-invalidation',
+      operation: 'NotificationInboxController.invalidateSessions',
+      retention: 'Bounded to MAX_NOTIFICATION_INBOX_ITEMS rows and removed by age/order pressure.',
+      reason: 'Deletion invalidates navigation targets while preserving bounded attention history.'
+    }
+  },
+  {
+    id: 'review-persistence',
+    medium: 'sqlite',
+    resources: ['Review', 'ReviewScopeSnapshot'],
+    prismaModels: [
+      {
+        name: 'Review',
+        ownerFields: [requiredOwner('projectId'), requiredOwner('sessionId')]
+      },
+      {
+        name: 'ReviewScopeSnapshot',
+        ownerFields: [requiredOwner('projectId'), requiredOwner('sessionId')],
+        relationContracts: [
+          {
+            field: 'review',
+            target: 'Review',
+            fromFields: ['reviewId'],
+            onDelete: 'Cascade'
+          }
+        ]
+      }
+    ],
+    policy: {
+      kind: 'coordinator-cleanup',
+      effect: 'hard-delete',
+      path: 'review-tail',
+      operation: 'ReviewRepository.deleteReviewsForProject',
+      note: 'The Project tail deletes Review roots; Review-owned rows cascade from those roots.'
+    }
+  },
+  {
+    id: 'project-deletion-intent',
+    medium: 'sqlite',
+    resources: ['ProjectDeletionIntent'],
+    prismaModels: [
+      {
+        name: 'ProjectDeletionIntent',
+        ownerFields: [requiredOwner('projectId')]
+      }
+    ],
+    policy: {
+      kind: 'deletion-protocol',
+      path: 'project-deletion-intent-protocol',
+      operation: 'ProjectDeletionCoordinator.finishDeletion',
+      purpose:
+        'Durable retry authority intentionally outlives the Project row until every fallible tail completes.'
+    }
+  },
+  {
+    id: 'managed-file-projection',
+    medium: 'sqlite',
+    resources: ['ManagedFile', 'ManagedFileSessionSync'],
+    prismaModels: [
+      {
+        name: 'ManagedFile',
+        ownerFields: [requiredOwner('projectId'), requiredOwner('sessionId')]
+      },
+      {
+        name: 'ManagedFileSessionSync',
+        ownerFields: [requiredOwner('projectId'), requiredOwner('sessionId')]
+      }
+    ],
+    policy: {
+      kind: 'coordinator-cleanup',
+      effect: 'logical-delete',
+      path: 'project-file-projection-delete',
+      operation: 'ManagedFileIndexRepository.softDeleteProject',
+      note: 'The rebuildable query projection uses deletion tombstones instead of a Project FK.'
+    }
+  },
+  {
+    id: 'artifact-provenance',
+    medium: 'sqlite',
+    resources: [
+      'FileOriginSession',
+      'ArtifactLineage',
+      'UploadFile',
+      'ArtifactMessageSnapshot',
+      'ArtifactVersionInput'
+    ],
+    prismaModels: [
+      {
+        name: 'FileOriginSession',
+        ownerFields: [requiredOwner('projectId'), requiredOwner('sessionId')]
+      },
+      {
+        name: 'ArtifactLineage',
+        ownerFields: [requiredOwner('projectId'), requiredOwner('sessionId')],
+        relationContracts: [
+          {
+            field: 'originSession',
+            target: 'FileOriginSession',
+            fromFields: ['projectId', 'sessionId'],
+            onDelete: 'Restrict'
+          }
+        ]
+      },
+      {
+        name: 'UploadFile',
+        ownerFields: [requiredOwner('projectId'), requiredOwner('sessionId')],
+        relationContracts: [
+          {
+            field: 'originSession',
+            target: 'FileOriginSession',
+            fromFields: ['projectId', 'sessionId'],
+            onDelete: 'Restrict'
+          }
+        ]
+      },
+      {
+        name: 'ArtifactMessageSnapshot',
+        ownerFields: [requiredOwner('projectId'), requiredOwner('sessionId')],
+        relationContracts: [
+          {
+            field: 'originSession',
+            target: 'FileOriginSession',
+            fromFields: ['projectId', 'sessionId'],
+            onDelete: 'Restrict'
+          }
+        ]
+      },
+      {
+        name: 'ArtifactVersionInput',
+        ownerFields: [requiredOwner('sourceProjectId'), requiredOwner('sourceSessionId')],
+        relationContracts: [
+          {
+            field: 'sourceOrigin',
+            target: 'FileOriginSession',
+            fromFields: ['sourceProjectId', 'sourceSessionId'],
+            onDelete: 'Restrict'
+          }
+        ]
+      }
+    ],
+    policy: {
+      kind: 'coordinator-cleanup',
+      effect: 'hard-delete',
+      path: 'provenance-tail',
+      operation: 'ArtifactProvenanceRepository.deleteProjectProvenance',
+      note: 'Restrict protects the graph until the provenance owner deletes children before roots.'
+    }
+  },
+  {
+    id: 'compute-jobs',
+    medium: 'sqlite',
+    resources: ['ComputeJob'],
+    prismaModels: [
+      {
+        name: 'ComputeJob',
+        ownerFields: [requiredOwner('projectId'), requiredOwner('sessionId')]
+      }
+    ],
+    policy: {
+      kind: 'coordinator-cleanup',
+      effect: 'hard-delete',
+      path: 'compute-job-project-delete',
+      operation: 'ComputeJobDeletionOwner.commitProjectJobDeletion',
+      note: 'The owner removes remote workdirs before rows. leftOnRemote is live-job metadata, not a Project-deletion retention exemption.'
+    }
+  },
+  {
+    id: 'compute-job-remote-workdirs',
+    medium: 'remote-runtime',
+    resources: ['remote Compute Job workdirs'],
+    policy: {
+      kind: 'coordinator-cleanup',
+      effect: 'hard-delete',
+      path: 'compute-job-project-delete',
+      operation: 'ComputeJobDeletionOwner.commitProjectJobDeletion',
+      note: 'Prepared remote cleanup removes the workdir before its ComputeJob row; failures retain deletion authority for retry.'
+    }
+  },
+  {
+    id: 'project-session-json',
+    medium: 'filesystem',
+    resources: ['sessions/<projectId>/', 'sessions/.deleted/<projectId>/'],
+    policy: {
+      kind: 'coordinator-cleanup',
+      effect: 'hard-delete',
+      path: 'project-session-json-delete',
+      operation: 'SessionRepository.deleteProjectSessions',
+      note: 'The live directory is first renamed into a durable tombstone used by crash recovery.'
+    }
+  },
+  {
+    id: 'artifact-bytes',
+    medium: 'filesystem',
+    resources: ['artifacts/<projectId>/'],
+    policy: {
+      kind: 'coordinator-cleanup',
+      effect: 'hard-delete',
+      path: 'provenance-tail',
+      operation: 'ArtifactProvenanceRepository.deleteProjectProvenance',
+      note: 'The Project Artifact root is removed only while durable deletion intent remains.'
+    }
+  },
+  {
+    id: 'upload-bytes',
+    medium: 'filesystem',
+    resources: ['managed Upload version bytes addressed by storage keys under uploads/'],
+    policy: {
+      kind: 'coordinator-cleanup',
+      effect: 'hard-delete',
+      path: 'provenance-tail',
+      operation: 'ArtifactProvenanceRepository.deleteProjectProvenance',
+      note: 'Authoritative Upload storage keys are removed before their provenance rows.'
+    }
+  },
+  {
+    id: 'delegated-frame-workspaces',
+    medium: 'filesystem',
+    resources: ['delegation workspaces/<projectId>/'],
+    policy: {
+      kind: 'coordinator-cleanup',
+      effect: 'hard-delete',
+      path: 'delegated-runtime-quiescence',
+      operation: 'ProductionFrameWorkspace.deleteProject',
+      note: 'The delegated owner removes both live work and dormant Project workspace directories.'
+    }
+  },
+  {
+    id: 'acp-runtime-state',
+    medium: 'runtime-state',
+    resources: ['ACP sessions and generations'],
+    policy: {
+      kind: 'coordinator-cleanup',
+      effect: 'drain',
+      path: 'project-runtime-quiescence',
+      operation: 'ProjectRuntimeQuiescenceOwner.quiesceProject',
+      note: 'Both pre- and post-delegation ACP ownership snapshots are deleted before authority removal.'
+    }
+  },
+  {
+    id: 'reviewer-runtime-state',
+    medium: 'runtime-state',
+    resources: ['Reviewer passes and correction loops'],
+    policy: {
+      kind: 'coordinator-cleanup',
+      effect: 'drain',
+      path: 'project-runtime-quiescence',
+      operation: 'ReviewerProjectRuntimeOwner.quiesceProject',
+      note: 'Reviewer publication is fenced before the first ACP ownership snapshot.'
+    }
+  },
+  {
+    id: 'side-chat-runtime-state',
+    medium: 'runtime-state',
+    resources: ['Side Chat parents, relays, and completions'],
+    policy: {
+      kind: 'coordinator-cleanup',
+      effect: 'invalidate',
+      path: 'project-runtime-quiescence',
+      operation: 'SideChatRuntimeOwner.invalidateProject',
+      note: 'Project runtime quiescence invalidates live work before Session authority is removed.'
+    }
+  },
+  {
+    id: 'notebook-kernel-runtime-state',
+    medium: 'runtime-state',
+    resources: ['Notebook kernels and pending Project operations'],
+    policy: {
+      kind: 'coordinator-cleanup',
+      effect: 'drain',
+      path: 'project-runtime-quiescence',
+      operation: 'NotebookRuntimeService.shutdownProject',
+      note: 'Kernel shutdown fences new operations but deliberately does not remove workspace bytes.'
+    }
+  },
+  {
+    id: 'compute-runtime-state',
+    medium: 'remote-runtime',
+    resources: ['Compute dispatch, polling, queues, and remote jobs'],
+    policy: {
+      kind: 'coordinator-cleanup',
+      effect: 'drain',
+      path: 'project-runtime-quiescence',
+      operation: 'ComputeJobDeletionOwner.reconcileProjectOrphanJobs',
+      note: 'Quiescence reconciles Project jobs after ACP, Notebook, and delegated work stop producing them.'
+    }
+  },
+  {
+    id: 'notebook-project-workspace',
+    medium: 'filesystem',
+    resources: ['notebooks/<projectId>/'],
+    policy: {
+      kind: 'retained-history',
+      effect: 'retain',
+      retention:
+        'Retained until the user removes the Project working folder outside Project deletion.',
+      reason:
+        'The delete confirmation promises that files in the Project working folder are not deleted.'
+    }
+  }
+]
+
+export { PROJECT_OWNED_DATA_CATALOG }

--- a/src/main/projects/project-owned-data.catalog.ts
+++ b/src/main/projects/project-owned-data.catalog.ts
@@ -326,7 +326,7 @@ const PROJECT_OWNED_DATA_CATALOG: readonly ProjectOwnedDataCatalogEntry[] = [
   {
     id: 'project-session-json',
     medium: 'filesystem',
-    resources: ['sessions/<projectId>/', 'sessions/.deleted/<projectId>/'],
+    resources: ['sessions/<projectId>/', 'deleted-sessions/<projectId>/'],
     policy: {
       kind: 'coordinator-cleanup',
       effect: 'hard-delete',
@@ -362,7 +362,7 @@ const PROJECT_OWNED_DATA_CATALOG: readonly ProjectOwnedDataCatalogEntry[] = [
   {
     id: 'delegated-frame-workspaces',
     medium: 'filesystem',
-    resources: ['delegation workspaces/<projectId>/'],
+    resources: ['delegation/<projectId>/'],
     policy: {
       kind: 'coordinator-cleanup',
       effect: 'hard-delete',


### PR DESCRIPTION
## Problem

Project-owned data spans SQLite, Session JSON, managed Artifact/Upload storage, remote Compute workdirs, and live runtime owners. Most SQLite models carry scalar `projectId` / `sessionId` fields rather than a direct Project FK, so a new owner can compile and persist correctly while being omitted from Project deletion.

## Proposed change

- Add a test-only Project-owned data catalog that requires every resource to declare FK cascade, coordinator cleanup (with hard/logical/invalidate/drain effect), retained history, or the narrow deletion-protocol policy used by `ProjectDeletionIntent`.
- Inventory Project owner models from generated Prisma DMMF, including nullable owner fields and `sourceProjectId` / `sourceSessionId`.
- Verify declared Project cascades and provenance `Restrict` boundaries from DMMF.
- Lock the curated non-SQL inventory for Session JSON, Artifact/Upload bytes, delegated workspaces, retained Notebook workspace data, and live ACP/Reviewer/Side Chat/Notebook/Compute state.
- Use TypeScript AST assertions to prove the catalogued operations are wired through the actual composition root and Project deletion path, including critical quiescence and durable-tail ordering.

## Scope and non-goals

- No runtime deletion executor or second cleanup path.
- No Prisma schema, migration, persisted field, public status, or data relationship change.
- No renderer, IPC, Web, interaction, copy, or i18n change.
- No repair or migration for existing orphaned data.
- No change to Notification retention, Managed File logical deletion, Notebook workspace retention, or shared Runtime/Skill package ownership.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Prisma owner inventory, relation policy, non-SQL catalog, and real deletion call paths -> `npm test -- src/main/projects/project-owned-data.catalog.architecture.test.ts src/main/projects/deletion-coordinator.test.ts src/main/projects/project-runtime-quiescence-owner.test.ts` -> passed (3 files, 45 tests).
- Main-process catalog/test types -> `npm run typecheck:node` -> passed.
- Repository lint contract -> `npm run lint` -> passed.

No full local `npm test` was run. The change adds test-only metadata and an architecture test without modifying production behavior or interfaces, so no renderer/Web/E2E consumer lane was included locally. Exact-head PR Gate remains authoritative and may conservatively select broader coverage for the new paths.

Uncovered by design: the catalog does not repair existing orphans, and non-SQL stores remain a reviewed explicit inventory rather than being inferred from every TypeScript `projectId` parameter.

## Review focus

- Confirm `ProjectDeletionIntent` remains deletion-protocol authority rather than business data.
- Confirm Notification is invalidate-and-retain, Managed File is logical delete, Notebook workspace is retained, and shared Runtime/Skill packages are excluded.
- Confirm AST checks prove composition and order without creating a runtime dependency on the catalog.
