### PR TITLE
fix(acp): preserve prefixes in bursty response streams

### DIFF
--- a/src/main/acp/runtime-publication-owner.test.ts
+++ b/src/main/acp/runtime-publication-owner.test.ts
@@ -41,6 +41,39 @@ describe('AcpRuntimePublicationOwner', () => {
     expect(order).toEqual(['event:one', 'event:two', 'state:2'])
   })
 
+  it('publishes a burst before retained events can evict unseen prefix chunks', () => {
+    let releaseScheduledState: (() => void) | undefined
+    const visibleChunks = new Map<string, string>()
+    const owner = new AcpRuntimePublicationOwner({
+      snapshotOwner: new AcpRuntimeSnapshotOwner('/workspace'),
+      interactions: new AcpSessionInteractionOwner(),
+      snapshotProjection: createProjection,
+      callbacks: {
+        onStateChanged: (snapshot) => {
+          for (const event of snapshot.events) {
+            if (event.kind === 'message' && event.role === 'assistant' && event.text) {
+              visibleChunks.set(event.id, event.text)
+            }
+          }
+        }
+      },
+      scheduleStatePublication: (publish) => {
+        releaseScheduledState = publish
+        return () => {
+          if (releaseScheduledState === publish) releaseScheduledState = undefined
+        }
+      }
+    })
+    const chunks = Array.from({ length: 600 }, (_, index) => `[${index}]`)
+
+    for (const text of chunks) {
+      owner.pushEvent({ kind: 'message', level: 'info', role: 'assistant', text })
+    }
+    releaseScheduledState?.()
+
+    expect([...visibleChunks.values()].join('')).toBe(chunks.join(''))
+  })
+
   it('flushes pending assistant text at a tool boundary without losing event order', () => {
     const order: string[] = []
     const owner = new AcpRuntimePublicationOwner({

--- a/src/main/acp/runtime-publication-owner.ts
+++ b/src/main/acp/runtime-publication-owner.ts
@@ -1,10 +1,11 @@
 import type { AcpPermissionRequest, AcpRuntimeEvent, AcpStateSnapshot } from '../../shared/acp'
 import { createLogger } from '../logger'
 import type { AcpSessionInteractionOwner } from './session-interaction-owner'
-import type {
-  AcpRuntimeSnapshotOwner,
-  RuntimeEventInput,
-  RuntimeSnapshotProjection
+import {
+  ACP_RUNTIME_EVENT_RETENTION_LIMIT,
+  type AcpRuntimeSnapshotOwner,
+  type RuntimeEventInput,
+  type RuntimeSnapshotProjection
 } from './runtime-snapshot-owner'
 
 // Dev-facing counters for the acp:state trailing-edge coalescer; a throttled debug summary rides
@@ -39,6 +40,10 @@ type AcpRuntimePublicationOwnerOptions = Readonly<{
 }>
 
 const STATE_PUBLICATION_INTERVAL_MS = 16
+// A fast provider can emit more than one retained window before the 16 ms timer runs. Publish
+// midway through that window so every prefix chunk reaches subscribers before bounded history can
+// evict it, while ordinary streams still receive the same frame-level coalescing.
+const MAX_COALESCED_ASSISTANT_TEXT_EVENTS = Math.floor(ACP_RUNTIME_EVENT_RETENTION_LIMIT / 2)
 
 const scheduleStatePublication = (publish: () => void): (() => void) => {
   const timer = setTimeout(publish, STATE_PUBLICATION_INTERVAL_MS)
@@ -62,6 +67,7 @@ const preservingFrozen = <Value extends object>(source: Value, copy: Value): Val
 // Every projection is read live from the authoritative owners; this owner caches no runtime facts.
 class AcpRuntimePublicationOwner {
   private cancelScheduledStatePublication?: () => void
+  private coalescedAssistantTextEvents = 0
 
   constructor(private readonly options: AcpRuntimePublicationOwnerOptions) {}
 
@@ -86,7 +92,12 @@ class AcpRuntimePublicationOwner {
     onAppended?.()
     this.options.callbacks.onEvent?.(runtimeEvent)
     if (isCoalescibleAssistantTextEvent(runtimeEvent)) {
-      this.scheduleStatePublication()
+      this.coalescedAssistantTextEvents += 1
+      if (this.coalescedAssistantTextEvents >= MAX_COALESCED_ASSISTANT_TEXT_EVENTS) {
+        this.emitState()
+      } else {
+        this.scheduleStatePublication()
+      }
     } else {
       this.emitState()
     }
@@ -108,6 +119,11 @@ class AcpRuntimePublicationOwner {
 
   emitState(): void {
     this.cancelPendingStatePublication()
+    this.publishState()
+  }
+
+  private publishState(): void {
+    this.coalescedAssistantTextEvents = 0
     recordAcpStateBroadcastSent()
     this.options.callbacks.onStateChanged?.(this.getSnapshot())
   }
@@ -126,8 +142,7 @@ class AcpRuntimePublicationOwner {
     const schedule = this.options.scheduleStatePublication ?? scheduleStatePublication
     this.cancelScheduledStatePublication = schedule(() => {
       this.cancelScheduledStatePublication = undefined
-      recordAcpStateBroadcastSent()
-      this.options.callbacks.onStateChanged?.(this.getSnapshot())
+      this.publishState()
     })
   }
 }

--- a/src/main/acp/runtime-snapshot-owner.ts
+++ b/src/main/acp/runtime-snapshot-owner.ts
@@ -1,11 +1,11 @@
 import type { AcpRuntimeEvent, AcpStateSnapshot } from '../../shared/acp'
 import { getAcpRuntimeEventImage, MAX_ACP_SESSION_IMAGE_BYTES } from '../../shared/acp'
 
-const MAX_EVENTS = 500
+const ACP_RUNTIME_EVENT_RETENTION_LIMIT = 500
 // Amortized eviction: trim only after a full cap of slack accumulates, so steady-state appends are
 // a plain push instead of an O(n) array rebuild per event. Reads always go through the last
-// MAX_EVENTS window, keeping the observable retention bound exact.
-const EVENT_TRIM_THRESHOLD = MAX_EVENTS * 2
+// ACP_RUNTIME_EVENT_RETENTION_LIMIT window, keeping the observable retention bound exact.
+const EVENT_TRIM_THRESHOLD = ACP_RUNTIME_EVENT_RETENTION_LIMIT * 2
 
 type RuntimeSnapshotFields = Pick<AcpStateSnapshot, 'status' | 'cwd' | 'error' | 'events'>
 type RuntimeSnapshotProjection = Omit<AcpStateSnapshot, keyof RuntimeSnapshotFields>
@@ -92,16 +92,16 @@ class AcpRuntimeSnapshotOwner {
     // gets a defensive clone so later caller mutation cannot rewrite history.
     this.retainedEvents.push(Object.isFrozen(event) ? runtimeEvent : cloneEvent(runtimeEvent))
     if (this.retainedEvents.length > EVENT_TRIM_THRESHOLD) {
-      this.retainedEvents = this.retainedEvents.slice(-MAX_EVENTS)
+      this.retainedEvents = this.retainedEvents.slice(-ACP_RUNTIME_EVENT_RETENTION_LIMIT)
     }
     return runtimeEvent
   }
 
   // The retained array may carry up to a cap of trim slack; every reader sees exactly the last
-  // MAX_EVENTS entries, in append order.
+  // ACP_RUNTIME_EVENT_RETENTION_LIMIT entries, in append order.
   private retainedWindow(): AcpRuntimeEvent[] {
-    return this.retainedEvents.length > MAX_EVENTS
-      ? this.retainedEvents.slice(-MAX_EVENTS)
+    return this.retainedEvents.length > ACP_RUNTIME_EVENT_RETENTION_LIMIT
+      ? this.retainedEvents.slice(-ACP_RUNTIME_EVENT_RETENTION_LIMIT)
       : this.retainedEvents
   }
 
@@ -116,5 +116,5 @@ class AcpRuntimeSnapshotOwner {
   }
 }
 
-export { AcpRuntimeSnapshotOwner }
+export { ACP_RUNTIME_EVENT_RETENTION_LIMIT, AcpRuntimeSnapshotOwner }
 export type { RuntimeEventInput, RuntimeSnapshotFields, RuntimeSnapshotProjection }


### PR DESCRIPTION
## Problem

DeepSeek can deliver a large assistant-text burst after a long upstream pause. ACP text state is normally coalesced for 16 ms, while each runtime snapshot retains only the latest 500 events. If more than one retained window arrives before the scheduled publication runs, the renderer's first snapshot starts in the middle of the answer and the completed transcript permanently loses its prefix.

The issue log contains no 0.16.0 runtime warning, error, disconnect, or failed persistence event during the reported window, which is consistent with a successfully completed response whose earliest transient chunks were evicted before presentation.

Fixes #1322.

## Proposed change

- expose the runtime snapshot retention limit to its publication owner;
- keep the existing frame-level coalescing for ordinary streams;
- force an intermediate state publication after half a retention window of assistant-text events, leaving headroom before bounded history can evict unseen chunks;
- add a deterministic 600-chunk regression that reproduced the missing prefix before the fix.

The publication owner is composed before provider/framework routing, so this behavior is shared by `claude-code`, `opencode`, `codex-response`, and `codex-bridge`.

## Scope and non-goals

- No provider-specific parsing or DeepSeek special case.
- No new status or enum value.
- No persistence schema, Session JSON, database, or migration change.
- No historical-data compatibility handling is required; the bug affected transient chunks that had already been lost before persistence, so previously truncated messages cannot be reconstructed by this change.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Bursty ACP text preserves the complete prefix -> `npm test -- src/main/acp/runtime-publication-owner.test.ts src/main/acp/runtime-snapshot-owner.test.ts` -> 15 passed.
- Native Responses proxy continues to forward supported responses -> `npm test -- src/main/settings/native-responses-compatibility.test.ts` -> 18 passed.
- Renderer event presentation retains complete ordered input -> `npm test -- src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts -t "workspace agent runtime event processing"` -> 18 passed, 139 skipped by filter.
- Main-process types remain valid -> `npm run typecheck:node` -> passed.
- Source lint remains valid -> `npm run lint` -> passed.

The full portable suite was intentionally left to PR CI per maintainer guidance. No platform-specific or persistence risk remains locally uncovered; PR CI is authoritative for the complete test matrix.

## Review focus

- Confirm the half-window forced publication provides sufficient headroom without materially regressing normal streaming broadcast volume.
- Confirm the regression models renderer observation across successive bounded snapshots rather than weakening the 500-event retention contract.
