### PR TITLE
fix(runtime): encode Web runtime command requests

### DIFF
--- a/src/renderer/web/api-installer.ts
+++ b/src/renderer/web/api-installer.ts
@@ -32,6 +32,18 @@ const transformArguments = (contract: RendererContractDescriptor, args: unknown[
       return [{ parent: args[0] }]
     case 'storage-data-root-object':
       return [{ parent: args[0], markOnboarding: args[1] }]
+    case 'runtime-selection-object':
+      return [{ language: args[0], selection: args[1] }]
+    case 'runtime-language-environment-object':
+      return [{ language: args[0], envId: args[1] }]
+    case 'runtime-language-object':
+      return [{ language: args[0] }]
+    case 'runtime-enablement-object':
+      return [{ language: args[0], envId: args[1], enabled: args[2], force: args[3] }]
+    case 'runtime-install-authorization-object':
+      return [{ language: args[0], envId: args[1], authorized: args[2] }]
+    case 'runtime-interpreter-path-object':
+      return [{ language: args[0], path: args[1] }]
     default:
       return args
   }

--- a/src/renderer/web/renderer-argument-shape-characterization.test.ts
+++ b/src/renderer/web/renderer-argument-shape-characterization.test.ts
@@ -204,7 +204,7 @@ describe('renderer argument-shape characterization', () => {
     expect(actualPaths).toEqual(expectedPaths)
   })
 
-  it('records the nine known Runtime deviations without treating them as equivalences', async () => {
+  it('keeps Runtime request arguments equivalent across Electron and Web', async () => {
     const selection = { kind: 'interpreter', path: '/opt/python' }
     const cases = [
       {
@@ -271,11 +271,11 @@ describe('renderer argument-shape characterization', () => {
         channel: testCase.channel,
         args: testCase.electronArgs
       })
-      expect(web, `${testCase.path}: Web currently forwards positional arguments`).toEqual({
+      expect(web, `${testCase.path}: Web wraps the same request object`).toEqual({
         channel: testCase.channel,
-        args: testCase.args
+        args: testCase.electronArgs
       })
-      expect(web.args, `${testCase.path}: known deviation must remain explicit`).not.toEqual(
+      expect(web.args, `${testCase.path}: renderer transports stay equivalent`).toEqual(
         electron.args
       )
     }

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -99,21 +99,7 @@ describe('renderer contract catalog', () => {
           surfaceInstallation.localWeb === 'web-rpc' &&
           parameterCodec.electron !== parameterCodec.web
       )
-    ).toEqual([
-      'acp.connect',
-      'acp.createSession',
-      'notebookEnv.cancel',
-      'runtime.describeUsage',
-      'runtime.getEnablement',
-      'runtime.listPackageCounts',
-      'runtime.listPackages',
-      'runtime.registerInterpreter',
-      'runtime.setEnvironmentEnabled',
-      'runtime.setInstallAuthorized',
-      'runtime.setSelection',
-      'runtime.unregisterInterpreter',
-      'sessions.saveSession'
-    ])
+    ).toEqual(['acp.connect', 'acp.createSession', 'notebookEnv.cancel', 'sessions.saveSession'])
 
     const explicitEquivalentTransforms = paths(
       ({ parameterCodec }) =>
@@ -123,6 +109,15 @@ describe('renderer contract catalog', () => {
         parameterCodec.web !== 'surface-native'
     )
     expect(explicitEquivalentTransforms).toEqual([
+      'runtime.describeUsage',
+      'runtime.getEnablement',
+      'runtime.listPackageCounts',
+      'runtime.listPackages',
+      'runtime.registerInterpreter',
+      'runtime.setEnvironmentEnabled',
+      'runtime.setInstallAuthorized',
+      'runtime.setSelection',
+      'runtime.unregisterInterpreter',
       'storage.commitAndRelaunch',
       'storage.discardMigratedCopy',
       'storage.inspectDataRoot',

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -277,32 +277,29 @@ export const RENDERER_CONTRACT_GROUPS = Object.freeze([
     ['abortFixLoop', 'reviewer:abort-fix-loop'], ['getForSession', 'reviewer:get-for-session'], ['run', 'reviewer:run'],
   ]),
   group('runtime', 'runtime', [
-    ['describeUsage', 'runtime:describe-usage', WEB, RUNTIME_LANGUAGE_ENV, POSITIONAL],
-    ['getEnablement', 'runtime:get-enablement', WEB, RUNTIME_LANGUAGE, POSITIONAL], ['listEnvironments', 'runtime:list-environments'],
-    ['listPackageCounts', 'runtime:list-package-counts', WEB, RUNTIME_LANGUAGE, POSITIONAL],
-    ['listPackages', 'runtime:list-packages', WEB, RUNTIME_LANGUAGE_ENV, POSITIONAL], ['pickInterpreter', 'runtime:pick-interpreter', LOCAL],
-    ['registerInterpreter', 'runtime:register-interpreter', LOCAL, RUNTIME_INTERPRETER, POSITIONAL],
+    ['describeUsage', 'runtime:describe-usage', WEB, RUNTIME_LANGUAGE_ENV],
+    ['getEnablement', 'runtime:get-enablement', WEB, RUNTIME_LANGUAGE], ['listEnvironments', 'runtime:list-environments'],
+    ['listPackageCounts', 'runtime:list-package-counts', WEB, RUNTIME_LANGUAGE],
+    ['listPackages', 'runtime:list-packages', WEB, RUNTIME_LANGUAGE_ENV], ['pickInterpreter', 'runtime:pick-interpreter', LOCAL],
+    ['registerInterpreter', 'runtime:register-interpreter', LOCAL, RUNTIME_INTERPRETER],
     [
       'setEnvironmentEnabled',
       'runtime:set-environment-enabled',
       LOCAL,
-      RUNTIME_ENABLEMENT,
-      POSITIONAL
+      RUNTIME_ENABLEMENT
     ],
     [
       'setInstallAuthorized',
       'runtime:set-install-authorized',
       LOCAL,
-      RUNTIME_INSTALL_AUTH,
-      POSITIONAL
+      RUNTIME_INSTALL_AUTH
     ],
-    ['setSelection', 'runtime:set-selection', LOCAL, RUNTIME_SELECTION, POSITIONAL], ['survey', 'runtime:survey'],
+    ['setSelection', 'runtime:set-selection', LOCAL, RUNTIME_SELECTION], ['survey', 'runtime:survey'],
     [
       'unregisterInterpreter',
       'runtime:unregister-interpreter',
       LOCAL,
-      RUNTIME_INTERPRETER,
-      POSITIONAL
+      RUNTIME_INTERPRETER
     ],
   ]),
   group('sessions', 'sessions', [


### PR DESCRIPTION
## Problem

Enabling another Notebook runtime from the local Web Settings surface fails with `Cannot read properties of undefined (reading 'status')`, and the interpreter remains disabled.

The Web renderer forwarded the public Runtime API's positional arguments directly after Web dispatch moved from captured IPC to direct application commands. Runtime application commands accept one request object, so `language`, `envId`, and `enabled` were read as `undefined`. The missing `enabled` value incorrectly entered runtime revocation, where the missing binding produced the reported `status` dereference.

## Proposed change

- Apply the existing Runtime request-object codecs to the local Web renderer, matching Electron's transport shape.
- Mark all nine Runtime request transforms as equivalent across Electron and Web in the shared contract catalog.
- Replace the known-deviation characterization with a regression assertion that both transports emit the same request object.

## Scope and non-goals

- The public positional Runtime API remains unchanged.
- Electron transport behavior is unchanged.
- No new state or enum values are introduced.
- No database or settings schema changes are introduced, and no historical-data migration is required.
- Successful toggles continue to persist through the existing `notebookRuntimeEnablement` settings field.

## Acceptance criteria and validation

All listed checks ran after the last material edit:

- Runtime renderer argument encoding -> `npm test -- src/renderer/web/renderer-argument-shape-characterization.test.ts src/renderer/web/api-installer.test.ts src/shared/renderer-contract-catalog.test.ts src/shared/web-rpc-contract.test.ts src/preload/electron-renderer-contract-adapter.test.ts src/main/notebook/runtime-application-commands.test.ts` -> 6 files, 52 tests passed.
- Node contract types -> `npm run typecheck:node` -> passed.
- Web contract types -> `npm run typecheck:web` -> passed.
- Changed-file lint -> `npx eslint ...` for the four changed files -> passed.
- Changed-file formatting -> `npx prettier --check ...` for the four changed files -> passed.
- Generated Web API map -> `npm run check:web-api-map` -> passed.

The focused transport, contract, application-command, and both process type checks cover the changed adapter/interface. No platform-specific implementation changed, so no additional platform lane was run locally. The full portable suite was intentionally left to PR CI.

Uncovered local risk: the packaged local-Web UI was not exercised end-to-end against a real secondary interpreter.

## Review focus

- Confirm local Web Runtime calls now carry exactly one request object into direct application dispatch.
- Confirm keeping the public positional API while normalizing only the transport boundary is the intended compatibility seam.