### PR TITLE
test(database): centralize migration coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,11 @@ schema module is generated; do not edit it or add feature DDL to startup code.
 Prisma CLI is a development and CI tool only. Packaged applications execute the checked-in
 migration manifest and do not ship the Prisma migrate engine.
 
+Migration history is owned by `src/main/database/`. Module tests may run
+`migrateApplicationDatabase` to create a current-schema fixture, but handcrafted historical schemas,
+upgrade assertions, and migration-ledger expectations belong in the database migration tests rather
+than in feature-module suites.
+
 ### Branch names
 
 Use the format `<type>/<short-description>`, with a lowercase, hyphen-separated

--- a/src/main/compute/job-repository.test.ts
+++ b/src/main/compute/job-repository.test.ts
@@ -6,10 +6,8 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { ComputeJobRepository } from './job-repository'
 import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
 
-// Verifies ComputeJob schema migration is purely additive (CLAUDE.md requirement):
-// - The table + indexes can be created on a fresh DB.
-// - Re-running ensure is idempotent.
-// - The table can be added to a pre-existing DB (Project only) without disturbing existing rows.
+// Exercises ComputeJobRepository against the current application schema in a real SQLite database.
+// Schema migration behavior is owned by src/main/database/migration-service.test.ts.
 
 let storageRoot: string | undefined
 let disconnect: (() => Promise<void>) | undefined
@@ -24,8 +22,8 @@ afterEach(async () => {
   }
 })
 
-describe('ComputeJob schema migration (integration)', () => {
-  it('creates the ComputeJob table and round-trips CRUD', async () => {
+describe('ComputeJob repository (SQLite integration)', () => {
+  it('round-trips CRUD', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-jobs-'))
 
     const client = createProjectDbClient(storageRoot)
@@ -36,10 +34,6 @@ describe('ComputeJob schema migration (integration)', () => {
     const repo = new ComputeJobRepository(() => Promise.resolve(client))
 
     // Fresh DB: no jobs.
-    expect(await repo.findNonTerminal()).toEqual([])
-
-    // Idempotent second run.
-    await migrateApplicationDatabase(client)
     expect(await repo.findNonTerminal()).toEqual([])
 
     // Create a job with all required fields.
@@ -138,153 +132,6 @@ describe('ComputeJob schema migration (integration)', () => {
     const forHostB = await repo.findNonTerminalByProvider('ssh:host-b')
     expect(forHostB).toHaveLength(1)
     expect(forHostB[0]!.job_id).toBe('job-b')
-  })
-
-  it('adds ComputeJob to a pre-existing DB with Project table only (additive migration)', async () => {
-    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-jobs-migrate-'))
-
-    const client = createProjectDbClient(storageRoot)
-    disconnect = () => client.$disconnect()
-
-    // Simulate a pre-3a DB: only Project and ComputeHost tables exist.
-    await client.$executeRawUnsafe(`CREATE TABLE IF NOT EXISTS "Project" (
-      "id" TEXT NOT NULL PRIMARY KEY,
-      "name" TEXT NOT NULL,
-      "description" TEXT NOT NULL DEFAULT '',
-      "isExample" BOOLEAN NOT NULL DEFAULT false,
-      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-      "updatedAt" DATETIME NOT NULL
-    )`)
-    await client.$executeRawUnsafe(
-      `INSERT INTO "Project" ("id","name","updatedAt") VALUES ('p1','Existing',CURRENT_TIMESTAMP)`
-    )
-    await client.$executeRawUnsafe(`CREATE TABLE IF NOT EXISTS "ComputeHost" (
-      "id" TEXT NOT NULL PRIMARY KEY,
-      "providerId" TEXT NOT NULL,
-      "displayName" TEXT NOT NULL,
-      "shape" TEXT NOT NULL DEFAULT 'direct_ssh',
-      "sshAlias" TEXT NOT NULL,
-      "sshOverrides" TEXT,
-      "scratchRoot" TEXT,
-      "scratchPinned" BOOLEAN NOT NULL DEFAULT false,
-      "concurrencyLimit" INTEGER,
-      "probeResult" TEXT,
-      "detailsDoc" TEXT NOT NULL DEFAULT '',
-      "detailsUpdatedAt" DATETIME,
-      "detailsUpdatedBy" TEXT,
-      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-      "updatedAt" DATETIME NOT NULL
-    )`)
-
-    // migrateApplicationDatabase must add ComputeJob without disturbing existing rows.
-    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
-      adoptedLegacy: true,
-      applied: [
-        '0001_runtime_schema_baseline',
-        '0002_project_agent_context',
-        '0003_granted_local_roots',
-        '0004_review_assessment_snapshots',
-        '0005_project_preview_state_owner_fk',
-        '0006_database_domain_constraints',
-        '0007_notification_attention_metadata',
-        '0008_database_json_constraints'
-      ]
-    })
-    // Idempotent second run.
-    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
-
-    // Existing Project row is intact.
-    const projects = await client.project.findMany()
-    expect(projects).toHaveLength(1)
-    expect(projects[0]!.name).toBe('Existing')
-
-    // ComputeJob table is usable.
-    const repo = new ComputeJobRepository(() => Promise.resolve(client))
-    expect(await repo.findNonTerminal()).toHaveLength(0)
-
-    const created = await repo.create({
-      id: 'job-migrated',
-      providerId: 'ssh:test',
-      shape: 'direct_ssh',
-      sessionId: 's1',
-      projectId: 'p1',
-      intent: 'test',
-      command: 'echo ok',
-      commandHash: 'hash'
-    })
-    expect(created.job_id).toBe('job-migrated')
-  })
-
-  it('applies Phase 3b columns to a Phase 3a DB: old rows readable, new columns null', async () => {
-    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-jobs-3a-to-3b-'))
-
-    const client = createProjectDbClient(storageRoot)
-    disconnect = () => client.$disconnect()
-
-    // Simulate a Phase 3a DB: ComputeJob table WITHOUT the 4 new 3b columns.
-    await client.$executeRawUnsafe(`CREATE TABLE IF NOT EXISTS "ComputeJob" (
-      "id" TEXT NOT NULL PRIMARY KEY,
-      "providerId" TEXT NOT NULL,
-      "shape" TEXT NOT NULL,
-      "sessionId" TEXT NOT NULL,
-      "projectId" TEXT NOT NULL,
-      "status" TEXT NOT NULL DEFAULT 'submitted',
-      "intent" TEXT NOT NULL,
-      "command" TEXT NOT NULL,
-      "commandHash" TEXT NOT NULL,
-      "environment" TEXT,
-      "resourceRequest" TEXT,
-      "inputManifest" TEXT,
-      "outputManifest" TEXT,
-      "harvestConfig" TEXT,
-      "timeoutSeconds" INTEGER,
-      "remoteWorkdir" TEXT,
-      "remoteHandle" TEXT,
-      "exitCode" INTEGER,
-      "stdoutTail" TEXT,
-      "stderrTail" TEXT,
-      "errorCode" TEXT,
-      "lastPollError" TEXT,
-      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-      "submittedAt" DATETIME,
-      "startedAt" DATETIME,
-      "finishedAt" DATETIME,
-      "harvestedAt" DATETIME
-    )`)
-    // Insert a row with only 3a columns populated.
-    await client.$executeRawUnsafe(
-      `INSERT INTO "ComputeJob" ("id","providerId","shape","sessionId","projectId","intent","command","commandHash","status","createdAt")
-       VALUES ('old-job-1','ssh:test','direct_ssh','s1','p1','legacy intent','echo ok','hash123','submitted',CURRENT_TIMESTAMP)`
-    )
-
-    // Apply migrateApplicationDatabase — must add the 4 new columns without error.
-    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
-      adoptedLegacy: true,
-      applied: [
-        '0001_runtime_schema_baseline',
-        '0002_project_agent_context',
-        '0003_granted_local_roots',
-        '0004_review_assessment_snapshots',
-        '0005_project_preview_state_owner_fk',
-        '0006_database_domain_constraints',
-        '0007_notification_attention_metadata',
-        '0008_database_json_constraints'
-      ]
-    })
-    // Idempotent second run.
-    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
-
-    // Old row is readable via the repository; new columns default to null/undefined.
-    const repo = new ComputeJobRepository(() => Promise.resolve(client))
-    const jobs = await repo.findNonTerminal()
-    expect(jobs).toHaveLength(1)
-    expect(jobs[0]!.job_id).toBe('old-job-1')
-    expect(jobs[0]!.intent).toBe('legacy intent')
-    // New 3b columns must be undefined (null → undefined at repository boundary).
-    expect(jobs[0]!.harvest_error).toBeUndefined()
-    expect(jobs[0]!.left_on_remote).toBeUndefined()
-    expect(jobs[0]!.notified_at).toBeUndefined()
-    expect(jobs[0]!.notification_consumed_at).toBeUndefined()
   })
 
   it('round-trips the 4 new Phase 3b columns (harvestError, leftOnRemote, notifiedAt, notificationConsumedAt)', async () => {

--- a/src/main/compute/prisma-client.test.ts
+++ b/src/main/compute/prisma-client.test.ts
@@ -6,10 +6,8 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { ComputeHostRepository } from './repository'
 import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
 
-// Proves the runtime CREATE TABLE IF NOT EXISTS DDL for ComputeHost is byte-compatible with the
-// generated Prisma client against a real (temp) SQLite database, and that adding the table to an
-// existing (pre-compute) DB is a safe, purely-additive migration (CLAUDE.md schema-compat requirement).
-// Requires the query engine, which is present in dev installs.
+// Exercises ComputeHostRepository against the current application schema in a real SQLite database.
+// Schema migration behavior is owned by src/main/database/migration-service.test.ts.
 
 let storageRoot: string | undefined
 let disconnect: (() => Promise<void>) | undefined
@@ -25,7 +23,7 @@ afterEach(async () => {
 })
 
 describe('compute host prisma client (integration)', () => {
-  it('ensures the schema and round-trips CRUD (provider_id unique, JSON columns, timestamps)', async () => {
+  it('round-trips CRUD (provider_id unique, JSON columns, timestamps)', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-compute-'))
 
     const client = createProjectDbClient(storageRoot)
@@ -36,10 +34,6 @@ describe('compute host prisma client (integration)', () => {
     const repository = new ComputeHostRepository(() => Promise.resolve(client))
 
     // Fresh install starts with no hosts.
-    expect(await repository.list()).toEqual([])
-
-    // Ensuring again is idempotent (table + unique index already exist).
-    await migrateApplicationDatabase(client)
     expect(await repository.list()).toEqual([])
 
     // Create reads/writes every column type Prisma expects (TEXT, BOOLEAN, INTEGER, DATETIME, JSON).
@@ -92,53 +86,5 @@ describe('compute host prisma client (integration)', () => {
         data: { providerId: 'ssh:dup', displayName: 'dup2', sshAlias: 'dup' }
       })
     ).rejects.toThrow()
-  })
-
-  it('adds ComputeHost to a pre-existing DB without the table (additive migration)', async () => {
-    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-compute-migrate-'))
-
-    const client = createProjectDbClient(storageRoot)
-    disconnect = () => client.$disconnect()
-
-    // Simulate an old DB that predates the Compute feature: only the Project table exists, populated
-    // with a row that must survive the additive migration untouched.
-    await client.$executeRawUnsafe(`CREATE TABLE IF NOT EXISTS "Project" (
-      "id" TEXT NOT NULL PRIMARY KEY,
-      "name" TEXT NOT NULL,
-      "description" TEXT NOT NULL DEFAULT '',
-      "isExample" BOOLEAN NOT NULL DEFAULT false,
-      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-      "updatedAt" DATETIME NOT NULL
-    )`)
-    await client.$executeRawUnsafe(
-      `INSERT INTO "Project" ("id","name","updatedAt") VALUES ('p1','Existing',CURRENT_TIMESTAMP)`
-    )
-
-    // migrateApplicationDatabase must create ComputeHost (and its index) without error and without disturbing
-    // the existing Project row.
-    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
-      adoptedLegacy: true,
-      applied: [
-        '0001_runtime_schema_baseline',
-        '0002_project_agent_context',
-        '0003_granted_local_roots',
-        '0004_review_assessment_snapshots',
-        '0005_project_preview_state_owner_fk',
-        '0006_database_domain_constraints',
-        '0007_notification_attention_metadata',
-        '0008_database_json_constraints'
-      ]
-    })
-    // Idempotent second run.
-    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
-
-    const projects = await client.project.findMany()
-    expect(projects).toHaveLength(1)
-    expect(projects[0]!.name).toBe('Existing')
-
-    const repository = new ComputeHostRepository(() => Promise.resolve(client))
-    expect(await repository.list()).toEqual([])
-    const created = await repository.create({ sshAlias: 'lab-gpu' })
-    expect(created.providerId).toBe('ssh:lab-gpu')
   })
 })

--- a/src/main/database/application-database.integration.test.ts
+++ b/src/main/database/application-database.integration.test.ts
@@ -4,18 +4,18 @@ import { join } from 'node:path'
 import { Prisma, PrismaClient } from '@prisma/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { applyRuntimeSchemaBaseline } from '../database/legacy-baseline-adapter'
-import { ProjectRepository } from './repository'
+import { applyRuntimeSchemaBaseline } from './legacy-baseline-adapter'
+import { ProjectRepository } from '../projects/repository'
 import {
   createProjectDbClient,
   disconnectProjectDbClient,
   migrateApplicationDatabase,
   getProjectDbClient
-} from './prisma-client'
+} from '../projects/prisma-client'
 import { ReviewRepository } from '../reviewer/repository'
 
-// Proves the runtime CREATE TABLE IF NOT EXISTS DDL is byte-compatible with the generated Prisma client
-// against a real (temp) SQLite database. Requires the query engine, which is present in dev installs.
+// Proves the application database schema and migration adapters are compatible with the generated
+// Prisma client against a real SQLite database. Requires the query engine from development installs.
 
 let storageRoot: string | undefined
 let disconnect: (() => Promise<void>) | undefined
@@ -30,7 +30,7 @@ afterEach(async () => {
   }
 })
 
-describe('project prisma client (integration)', () => {
+describe('application database (integration)', () => {
   it('covers every Prisma scalar field in the runtime SQLite schema', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-project-schema-parity-'))
 

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -897,6 +897,65 @@ describe('application database migrations', () => {
     ).resolves.toMatchObject({ name: 'Preserved', archivedAt: null })
   })
 
+  it('repairs frozen pre-ledger ComputeJob columns without losing existing rows', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-legacy-compute-job-'))
+    client = createProjectDbClient(storageRoot)
+    await client.$executeRawUnsafe(`CREATE TABLE "ComputeJob" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "providerId" TEXT NOT NULL,
+      "shape" TEXT NOT NULL,
+      "sessionId" TEXT NOT NULL,
+      "projectId" TEXT NOT NULL,
+      "status" TEXT NOT NULL DEFAULT 'submitted',
+      "intent" TEXT NOT NULL,
+      "command" TEXT NOT NULL,
+      "commandHash" TEXT NOT NULL,
+      "environment" TEXT,
+      "resourceRequest" TEXT,
+      "inputManifest" TEXT,
+      "outputManifest" TEXT,
+      "harvestConfig" TEXT,
+      "timeoutSeconds" INTEGER,
+      "remoteWorkdir" TEXT,
+      "remoteHandle" TEXT,
+      "exitCode" INTEGER,
+      "stdoutTail" TEXT,
+      "stderrTail" TEXT,
+      "errorCode" TEXT,
+      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "submittedAt" DATETIME,
+      "startedAt" DATETIME,
+      "finishedAt" DATETIME,
+      "harvestedAt" DATETIME
+    )`)
+    await client.$executeRaw`
+      INSERT INTO "ComputeJob" (
+        "id", "providerId", "shape", "sessionId", "projectId", "intent", "command",
+        "commandHash", "status", "createdAt"
+      ) VALUES (
+        ${'legacy-job'}, ${'ssh:test'}, ${'direct_ssh'}, ${'legacy-session'},
+        ${'legacy-project'}, ${'preserved intent'}, ${'echo ok'}, ${'hash123'},
+        ${'submitted'}, ${new Date('2026-01-02T03:04:05Z')}
+      )
+    `
+
+    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
+      adoptedLegacy: true,
+      applied: MIGRATION_MANIFEST.map((migration) => migration.id)
+    })
+    await expect(
+      client.computeJob.findUniqueOrThrow({ where: { id: 'legacy-job' } })
+    ).resolves.toMatchObject({
+      intent: 'preserved intent',
+      lastPollError: null,
+      harvestError: null,
+      leftOnRemote: null,
+      notifiedAt: null,
+      notificationConsumedAt: null
+    })
+    await expect(verifyCurrentRuntimeSchema(client)).resolves.toBeUndefined()
+  })
+
   it('keeps explicitly retired Review and Finding columns after final verification', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-retired-columns-'))
     client = createProjectDbClient(storageRoot)


### PR DESCRIPTION
## Problem

Feature-module integration tests were asserting application database migration history directly. The
ComputeHost and ComputeJob suites duplicated the database owner's pre-ledger adoption coverage and
were coupled to every migration manifest ID. The broader application-database integration suite also
lived under `projects/`, obscuring its actual ownership.

## Proposed change

- move the application database integration suite from `projects/` to `database/`
- keep `migrateApplicationDatabase` in compute tests only as current-schema fixture setup
- remove duplicate module-owned legacy adoption and migration idempotency assertions
- retain the frozen pre-ledger ComputeJob repair coverage in the database migration suite, including
  preservation of an existing row and all five nullable repaired columns
- document that historical schema fixtures and migration-ledger assertions belong to the database
  owner

## Scope and non-goals

- no production migration, runtime schema, Prisma schema, or persisted-data behavior changes
- no migration compatibility route is removed
- no enum or state value is added
- no renderer or public interface changes

Historical compatibility note: the first released ComputeJob schema already contained the four
fields previously described as the Phase 3b upgrade (confirmed at `v0.8.1`). That fixture was not a
released schema transition. The existing frozen `0001` repair behavior is nevertheless retained and
now covered by the database migration owner, together with `lastPollError`.

## Acceptance criteria and validation

Checks ran after the last material edit:

- application database and compute repository behavior -> `npm test -- src/main/database/application-database.integration.test.ts src/main/database/migration-service.test.ts src/main/compute/prisma-client.test.ts src/main/compute/job-repository.test.ts` -> 89 passed
- compute owner, contract, and representative consumers -> `npm run test:module -- compute_service` -> 600 passed, 15 skipped
- Node test typing -> `npm run typecheck:node` -> passed
- linted source and configuration -> `npm run lint` -> passed

Consumer and platform lanes were not added locally because the diff changes tests and contributor
guidance only, without a runtime interface or platform behavior change. Full portable and platform
coverage is deferred to the exact-head PR Gate as requested.

## Review focus

- migration assertions now have a single database owner
- compute repository behavior remains covered against a real current-schema SQLite database
- the frozen pre-ledger ComputeJob repair path still preserves existing persisted rows
