### PR TITLE
perf(session-plan): reduce model context overhead

### DIFF
--- a/src/main/acp/prompt-turn-workflow.test.ts
+++ b/src/main/acp/prompt-turn-workflow.test.ts
@@ -724,7 +724,9 @@ describe('AcpPromptTurnWorkflow', () => {
 
     expect(harness.preparation).toHaveBeenCalledWith(
       expect.objectContaining({
-        protectedContext: expect.stringContaining('artifact_version_id=plan-version-1'),
+        protectedContext: expect.stringContaining(
+          'approval=approved lifecycle=approved\ntask=Analyze the result\n- Analyze: not_started'
+        ),
         turnPromptReminders: [expect.stringContaining('Plan mode (ACTIVE')]
       })
     )

--- a/src/main/acp/runtime-plan-composition.test.ts
+++ b/src/main/acp/runtime-plan-composition.test.ts
@@ -147,10 +147,15 @@ const createHarness = (): {
           }
     return { projection: current, changed: true, continuationCommandId: 'receipt-1' }
   })
-  const updateStepStatus = vi.fn(async () => {
-    current = approvedProjection(current.revision + 1)
-    return { projection: current, changed: true }
-  })
+  const updateStepStatus = vi.fn(
+    async (input: {
+      authorizeUpdate?: (projection: ActivePlanProjection) => void | Promise<void>
+    }) => {
+      await input.authorizeUpdate?.(current)
+      current = approvedProjection(current.revision + 1)
+      return { projection: current, changed: true }
+    }
+  )
   const queueSettledDecisionContinuation = vi.fn(async () => {
     current = { ...current, continuationState: 'queued' as const }
     return { projection: current, changed: true }
@@ -580,6 +585,206 @@ describe('ACP Session Plan approval causality', () => {
 })
 
 describe('ACP Runtime Session Plan composition', () => {
+  it('loads the authoritative Plan once when updating a step', async () => {
+    const interactions = new SessionPlanInteractionOwner()
+    const sessionInteractions = new AcpSessionInteractionOwner()
+    const interaction = sessionInteractions.claim({
+      sessionId: 'session-1',
+      kind: 'prompt',
+      promptMessageId: 'prompt-1'
+    })
+    const document = approvedProjection(4).document
+    const content = JSON.stringify(document)
+    const checksum = createHash('sha256').update(content).digest('hex')
+    let context: SessionRuntimeContext = {
+      version: 1,
+      revision: 4,
+      plan: {
+        artifactId: 'artifact-1',
+        artifactVersionId: 'version-1',
+        artifactChecksum: checksum,
+        originatingPromptMessageId: 'prompt-1',
+        materializedAt: 1,
+        approval: 'approved',
+        stepStatuses: {}
+      }
+    }
+    const readRuntimeContext = vi.fn(async () => context)
+    const readArtifactVersion = vi.fn(async () => ({ content, checksum }))
+    const service = new PlanService({
+      interactions,
+      writeArtifactForExecution: vi.fn(),
+      readArtifactVersion,
+      readRuntimeContext,
+      patchRuntimeContext: vi.fn(async ({ expectedRevision, plan }) => {
+        if (expectedRevision !== context.revision) throw new Error('revision conflict')
+        context = { version: 1, revision: context.revision + 1, plan }
+        return context
+      }),
+      isRevisionConflict: (error) =>
+        error instanceof Error && error.message === 'revision conflict',
+      persistUserMessage: vi.fn(),
+      now: () => 42
+    })
+    interactions.bindExecution({
+      sessionId: 'session-1',
+      interactionSequence: interaction.sequence,
+      artifactVersionId: 'version-1'
+    })
+    const publication = { pushEvent: vi.fn() }
+    const workflow = composeAcpRuntimePlanWorkflow(
+      {
+        plan: { sessions: { containsMessageOnActiveBranch: vi.fn(async () => true) } }
+      } as unknown as Parameters<typeof composeAcpRuntimePlanWorkflow>[0],
+      {
+        planService: service,
+        planInteractions: interactions,
+        sessionInteractions
+      } as unknown as Parameters<typeof composeAcpRuntimePlanWorkflow>[1],
+      {
+        publication,
+        sessionEnvironment: { projectId: vi.fn(() => 'project-1') }
+      } as unknown as Parameters<typeof composeAcpRuntimePlanWorkflow>[2]
+    )
+
+    await expect(
+      workflow.call({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        operation: 'updateStepStatus',
+        input: { title: 'private-step-title-marker', status: 'in_progress' }
+      })
+    ).resolves.toMatchObject({
+      changed: true,
+      projection: {
+        revision: 5,
+        stepStatuses: { 'private-step-title-marker': { status: 'in_progress' } }
+      }
+    })
+    expect(readRuntimeContext).toHaveBeenCalledOnce()
+    expect(readArtifactVersion).toHaveBeenCalledOnce()
+    expect(publication.pushEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'plan',
+        planProjection: expect.objectContaining({ revision: 5 })
+      })
+    )
+  })
+
+  it('publishes the latest Plan after an authorized terminal update becomes idempotent concurrently', async () => {
+    const interactions = new SessionPlanInteractionOwner()
+    const sessionInteractions = new AcpSessionInteractionOwner()
+    const interaction = sessionInteractions.claim({
+      sessionId: 'session-1',
+      kind: 'prompt',
+      promptMessageId: 'prompt-1'
+    })
+    const document = approvedProjection(4).document
+    const content = JSON.stringify(document)
+    const checksum = createHash('sha256').update(content).digest('hex')
+    const completedStatus = { status: 'completed' as const, updatedAt: 40 }
+    let context: SessionRuntimeContext = {
+      version: 1,
+      revision: 4,
+      plan: {
+        artifactId: 'artifact-1',
+        artifactVersionId: 'version-1',
+        artifactChecksum: checksum,
+        originatingPromptMessageId: 'prompt-1',
+        materializedAt: 1,
+        approval: 'approved',
+        stepStatuses: { 'private-step-title-marker': completedStatus }
+      }
+    }
+    const readRuntimeContext = vi.fn(async () => context)
+    const readArtifactVersion = vi.fn(async () => ({ content, checksum }))
+    const patchRuntimeContext = vi.fn()
+    const service = new PlanService({
+      interactions,
+      writeArtifactForExecution: vi.fn(),
+      readArtifactVersion,
+      readRuntimeContext,
+      patchRuntimeContext,
+      isRevisionConflict: (error) =>
+        error instanceof Error && error.message === 'revision conflict',
+      persistUserMessage: vi.fn(),
+      now: () => 42
+    })
+    interactions.bindExecution({
+      sessionId: 'session-1',
+      interactionSequence: interaction.sequence,
+      artifactVersionId: 'version-1'
+    })
+    const containsMessageOnActiveBranch = vi.fn(async () => {
+      context = {
+        ...context,
+        revision: 5,
+        plan: {
+          ...context.plan!,
+          stepStatuses: {
+            'private-step-title-marker': {
+              ...completedStatus,
+              notes: 'Recorded by the concurrent writer.'
+            }
+          }
+        }
+      }
+      return true
+    })
+    const publication = { pushEvent: vi.fn() }
+    const workflow = composeAcpRuntimePlanWorkflow(
+      {
+        plan: { sessions: { containsMessageOnActiveBranch } }
+      } as unknown as Parameters<typeof composeAcpRuntimePlanWorkflow>[0],
+      {
+        planService: service,
+        planInteractions: interactions,
+        sessionInteractions
+      } as unknown as Parameters<typeof composeAcpRuntimePlanWorkflow>[1],
+      {
+        publication,
+        sessionEnvironment: { projectId: vi.fn(() => 'project-1') }
+      } as unknown as Parameters<typeof composeAcpRuntimePlanWorkflow>[2]
+    )
+
+    await expect(
+      workflow.call({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        operation: 'updateStepStatus',
+        input: { title: 'private-step-title-marker', status: 'completed' }
+      })
+    ).resolves.toMatchObject({
+      changed: false,
+      projection: {
+        revision: 5,
+        stepStatuses: {
+          'private-step-title-marker': {
+            status: 'completed',
+            notes: 'Recorded by the concurrent writer.'
+          }
+        }
+      }
+    })
+    expect(readRuntimeContext).toHaveBeenCalledTimes(2)
+    expect(readArtifactVersion).toHaveBeenCalledOnce()
+    expect(patchRuntimeContext).not.toHaveBeenCalled()
+    expect(context.revision).toBe(5)
+    expect(publication.pushEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'plan',
+        planProjection: expect.objectContaining({
+          revision: 5,
+          stepStatuses: {
+            'private-step-title-marker': expect.objectContaining({
+              notes: 'Recorded by the concurrent writer.'
+            })
+          }
+        })
+      })
+    )
+  })
+
   it('atomically records detached feedback before allowing a revised Plan generation', async () => {
     const interactions = new SessionPlanInteractionOwner()
     const sessionInteractions = new AcpSessionInteractionOwner()

--- a/src/main/acp/runtime-plan-composition.ts
+++ b/src/main/acp/runtime-plan-composition.ts
@@ -216,18 +216,18 @@ const composeAcpRuntimePlanWorkflow = (
         )
       )
     }
-    const projection = await service.getProjection(input.projectId, input.sessionId, {
-      interactionIsLive: sessionInteractions.current(input.sessionId) !== undefined
-    })
-    if (!projection) throw new Error('The Session has no active Plan.')
-    await assertVisibleToDurableBranch(input.projectId, input.sessionId, projection)
-    const identity = {
-      projectId: input.projectId,
-      sessionId: input.sessionId,
-      artifactVersionId: projection.artifactVersionId,
-      expectedRevision: projection.revision
-    }
     if (input.operation === 'approve' || input.operation === 'reject') {
+      const projection = await service.getProjection(input.projectId, input.sessionId, {
+        interactionIsLive: sessionInteractions.current(input.sessionId) !== undefined
+      })
+      if (!projection) throw new Error('The Session has no active Plan.')
+      await assertVisibleToDurableBranch(input.projectId, input.sessionId, projection)
+      const identity = {
+        projectId: input.projectId,
+        sessionId: input.sessionId,
+        artifactVersionId: projection.artifactVersionId,
+        expectedRevision: projection.revision
+      }
       const interaction = sessionInteractions.current(input.sessionId)
       const interactionIsLive = interaction !== undefined
       const decision = input.operation === 'approve' ? 'approved' : 'rejected'
@@ -352,43 +352,57 @@ const composeAcpRuntimePlanWorkflow = (
       notes?: string
       expectedArtifactVersionId?: string
     }
-    if (projection.approval !== 'approved') {
-      throw new PlanCommandError(
-        'plan-not-approved',
-        'The Plan is still pending. Interpret the user Message, then call generate_plan with decision:"approved" or decision:"rejected" before updating steps.'
-      )
+    let result: Awaited<ReturnType<NonNullable<typeof service>['updateStepStatus']>>
+    try {
+      result = await service.updateStepStatus({
+        projectId: input.projectId,
+        sessionId: input.sessionId,
+        title: update.title,
+        status: update.status,
+        ...(update.notes ? { notes: update.notes } : {}),
+        authorizeUpdate: async (projection) => {
+          await assertVisibleToDurableBranch(input.projectId, input.sessionId, projection)
+          if (projection.approval !== 'approved') {
+            throw new PlanCommandError(
+              'plan-not-approved',
+              'The Plan is still pending. Interpret the user Message, then call generate_plan with decision:"approved" or decision:"rejected" before updating steps.'
+            )
+          }
+          const currentInteraction = sessionInteractions.current(input.sessionId)
+          const currentBinding = interactions.executionBindingFor(input.sessionId)
+          if (!currentBinding) {
+            throw new PlanCommandError(
+              'continuation-required',
+              'Continuing this Plan requires an explicit user continuation.'
+            )
+          }
+          if (
+            !currentInteraction ||
+            currentBinding.interactionSequence !== currentInteraction.sequence
+          ) {
+            throw new PlanCommandError(
+              'interaction-mismatch',
+              'This interaction is not authorized to execute the active Plan.'
+            )
+          }
+          if (
+            currentBinding.artifactVersionId !== projection.artifactVersionId ||
+            (update.expectedArtifactVersionId !== undefined &&
+              update.expectedArtifactVersionId !== currentBinding.artifactVersionId)
+          ) {
+            throw new PlanCommandError(
+              'interaction-mismatch',
+              'This interaction is bound to a different Plan Artifact Version.'
+            )
+          }
+        }
+      })
+    } catch (error) {
+      if (error instanceof PlanCommandError && error.code === 'no-active-plan') {
+        throw new Error('The Session has no active Plan.')
+      }
+      throw error
     }
-    const interaction = sessionInteractions.current(input.sessionId)
-    const binding = interactions.executionBindingFor(input.sessionId)
-    if (!binding) {
-      throw new PlanCommandError(
-        'continuation-required',
-        'Continuing this Plan requires an explicit user continuation.'
-      )
-    }
-    if (!interaction || binding.interactionSequence !== interaction.sequence) {
-      throw new PlanCommandError(
-        'interaction-mismatch',
-        'This interaction is not authorized to execute the active Plan.'
-      )
-    }
-    if (
-      binding.artifactVersionId !== projection.artifactVersionId ||
-      (update.expectedArtifactVersionId !== undefined &&
-        update.expectedArtifactVersionId !== binding.artifactVersionId)
-    ) {
-      throw new PlanCommandError(
-        'interaction-mismatch',
-        'This interaction is bound to a different Plan Artifact Version.'
-      )
-    }
-    const result = await service.updateStepStatus({
-      ...identity,
-      artifactVersionId: update.expectedArtifactVersionId ?? identity.artifactVersionId,
-      title: update.title,
-      status: update.status,
-      ...(update.notes ? { notes: update.notes } : {})
-    })
     safeLogInfo('Session Plan step status updated', {
       projectId: input.projectId,
       sessionId: input.sessionId,

--- a/src/main/acp/runtime-session-plan.test.ts
+++ b/src/main/acp/runtime-session-plan.test.ts
@@ -62,7 +62,14 @@ const createRuntimeHarness = (options: {
   const generated = projection('version-1')
   const approved = { ...generated, approval: 'approved' as const, lifecycle: 'approved' as const }
   let currentProjection = options.activeProjection ?? generated
-  const updateStepStatus = vi.fn(async () => ({ projection: approved, changed: true }))
+  const updateStepStatus = vi.fn(
+    async (input: {
+      authorizeUpdate?: (projection: ActivePlanProjection) => void | Promise<void>
+    }) => {
+      await input.authorizeUpdate?.(currentProjection)
+      return { projection: approved, changed: true }
+    }
+  )
   const interactions = new SessionPlanInteractionOwner()
   const service = {
     generate: vi.fn(async () => ({ projection: generated, pauseInteraction: true as const })),
@@ -449,7 +456,7 @@ describe('AcpRuntime Session Plan seam', () => {
         }
       })
     ).rejects.toMatchObject({ code: 'interaction-mismatch' })
-    expect(updateStepStatus).not.toHaveBeenCalled()
+    expect(updateStepStatus).toHaveBeenCalledOnce()
   })
 
   it('rejects an MCP Plan decision when the Plan originated on a sibling Message Branch', async () => {
@@ -543,7 +550,7 @@ describe('AcpRuntime Session Plan seam', () => {
         input: { title: 'Analyze the data', status: 'in_progress' }
       })
     ).rejects.toMatchObject({ code: 'continuation-required' })
-    expect(updateStepStatus).not.toHaveBeenCalled()
+    expect(updateStepStatus).toHaveBeenCalledOnce()
   })
 
   it('rejects a Plan version bound to a different interaction', async () => {
@@ -569,7 +576,7 @@ describe('AcpRuntime Session Plan seam', () => {
         input: { title: 'Analyze the data', status: 'in_progress' }
       })
     ).rejects.toMatchObject({ code: 'interaction-mismatch' })
-    expect(updateStepStatus).not.toHaveBeenCalled()
+    expect(updateStepStatus).toHaveBeenCalledOnce()
   })
 
   it('does not release a successor execution when an older rejection finishes late', async () => {
@@ -1005,7 +1012,7 @@ describe('AcpRuntime Session Plan seam', () => {
         input: { title: 'Analyze the data', status: 'in_progress' }
       })
     ).rejects.toMatchObject({ code: 'plan-not-approved' })
-    expect(updateStepStatus).not.toHaveBeenCalled()
+    expect(updateStepStatus).toHaveBeenCalledOnce()
   })
 
   it('marks approval as passive when restart left no in-process approval waiter', async () => {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -3876,7 +3876,7 @@ describe('ACP runtime session management', () => {
 
     await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
     expect(fakeAgent.prompts[0]?.text).toContain('approved the pending Session Plan')
-    expect(fakeAgent.prompts[0]?.text).toContain('artifact_version_id=version-1')
+    expect(fakeAgent.prompts[0]?.text).toContain('approval=approved lifecycle=approved')
     expect(promptAttempts).toEqual([undefined])
     await vi.waitFor(() => expect(runtimeContext.plan?.continuation).toBeUndefined())
   })
@@ -4253,7 +4253,8 @@ describe('ACP runtime session management', () => {
         expectedRevision: 4
       })
     )
-    expect(fakeAgent.prompts[0]?.text).toContain('artifact_version_id=version-1')
+    expect(fakeAgent.prompts[0]?.text).toContain('approval=approved lifecycle=approved')
+    expect(fakeAgent.prompts[0]?.text).not.toContain('artifact_version_id=')
     expect(events).toContainEqual(
       expect.objectContaining({
         kind: 'plan',
@@ -5201,14 +5202,13 @@ describe('ACP runtime session management', () => {
     const planPrompt = fakeAgent.prompts[0].text
     expect(planPrompt).toContain('## Plan mode (ACTIVE — MANDATORY)')
     expect(planPrompt).toContain(
-      'Review the Skills available in the current session to confirm the catalog has what the task needs.'
+      'Review the Skills available in the current session to confirm the catalog covers the task.'
     )
     expect(planPrompt).toContain('directly ask the user in an ordinary response')
     expect(planPrompt).toContain('complete revised plan')
-    expect(planPrompt).toContain('creates a new immutable plan and re-requests approval')
-    expect(planPrompt).toContain(
-      'Do NOT run code without an approved plan. Always call `mcp__open-science-plan__generate_plan` first.'
-    )
+    expect(planPrompt).toContain('short exact `title`')
+    expect(planPrompt).toContain('Execution starts only after approval.')
+    expect(planPrompt).not.toContain('The plan is presented to the user for review')
     for (const forbidden of [
       'search_skills',
       'ask_user',
@@ -17291,7 +17291,8 @@ describe('ACP runtime session management', () => {
         expectedRevision: 11
       })
       expect(fakeAgent.prompts[0]?.text).toContain('<open_science_protected_plan_context>')
-      expect(fakeAgent.prompts[0]?.text).toContain('artifact_version_id=version-7')
+      expect(fakeAgent.prompts[0]?.text).toContain('approval=approved lifecycle=approved')
+      expect(fakeAgent.prompts[0]?.text).not.toContain('artifact_version_id=')
       expect(fakeAgent.prompts[0]?.text).toContain('Analyze data: not_started')
       expect(fakeAgent.prompts[0]?.text).toContain('continue')
     }

--- a/src/main/agent-framework/app-mcp-names.test.ts
+++ b/src/main/agent-framework/app-mcp-names.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import { PRE_REGISTERED_PERMISSION_IDENTITIES } from '../permission-grants/identity-catalog'
-import { SESSION_PLAN_SYSTEM_PROMPT_APPEND } from '../session-plan/guidance'
+import {
+  PLAN_FIRST_TURN_PROMPT_REMINDER,
+  SESSION_PLAN_SYSTEM_PROMPT_APPEND
+} from '../session-plan/guidance'
 import {
   appMcpToolIdentities,
   appMcpServerAliases,
@@ -42,6 +45,29 @@ describe('resolveCanonicalMcpToolIdentity', () => {
     )
   })
 
+  it('keeps Plan-first guidance focused on turn-specific preparation', () => {
+    expect(PLAN_FIRST_TURN_PROMPT_REMINDER).toContain('Plan mode (ACTIVE')
+    expect(PLAN_FIRST_TURN_PROMPT_REMINDER).toContain('Review the Skills available')
+    expect(PLAN_FIRST_TURN_PROMPT_REMINDER).toContain('Assess feasibility')
+    expect(PLAN_FIRST_TURN_PROMPT_REMINDER).toContain('Clarify requirements')
+    expect(PLAN_FIRST_TURN_PROMPT_REMINDER).toContain('Identify desired outputs')
+    expect(PLAN_FIRST_TURN_PROMPT_REMINDER).toContain('complete revised plan')
+    expect(PLAN_FIRST_TURN_PROMPT_REMINDER).not.toContain(
+      'The plan is presented to the user for review'
+    )
+    expect(PLAN_FIRST_TURN_PROMPT_REMINDER).not.toContain('Only after the user approves the plan')
+    expect(PLAN_FIRST_TURN_PROMPT_REMINDER).not.toContain(
+      'Do NOT run code without an approved plan'
+    )
+  })
+
+  it('states the feedback-to-decision policy once in stable Plan guidance', () => {
+    expect(SESSION_PLAN_SYSTEM_PROMPT_APPEND.match(/kind: feedback/g)).toHaveLength(1)
+    expect(SESSION_PLAN_SYSTEM_PROMPT_APPEND).toContain(
+      'for ambiguous or conditional language, do not grant execution authority'
+    )
+  })
+
   it('keeps Conversation Turn completion independent from Session Plan status', () => {
     expect(SESSION_PLAN_SYSTEM_PROMPT_APPEND).not.toContain('Do not call `end_turn`')
     expect(SESSION_PLAN_SYSTEM_PROMPT_APPEND).not.toContain('do not end the turn')
@@ -67,7 +93,7 @@ describe('resolveCanonicalMcpToolIdentity', () => {
       expect(guidance).toContain('discover applicable skills before generating')
       expect(guidance).toContain(generateTool)
       expect(guidance).toContain(updateTool)
-      expect(guidance).toContain('Do not generate a Plan for simple')
+      expect(guidance).toContain('not for simple lookups')
       expect(guidance).not.toContain('get_active_plan')
       expect(guidance).not.toContain('Plan mode')
     }

--- a/src/main/session-plan/guidance.ts
+++ b/src/main/session-plan/guidance.ts
@@ -1,12 +1,10 @@
 const SESSION_PLAN_SYSTEM_PROMPT_APPEND = [
   '<open_science_session_plan_instructions>',
-  'Generate a Session Plan only for genuinely multi-stage work where the user benefits from reviewing phases, independent work tracks, or execution scope before work begins.',
-  'Do not generate a Plan for simple lookups, single computations, basic file inspection, or other straightforward tasks.',
+  'Generate a Session Plan only for genuinely multi-stage work where the user benefits from reviewing phases, independent work tracks, or execution scope before work begins; not for simple lookups, single computations, basic file inspection, or other straightforward tasks.',
   'For work that may need a Plan, discover applicable skills before generating it.',
   'When a Plan is useful, generation supplies all four Plan fields (`task_summary`, `phases`, `desired_outputs`, and `feasibility`) in one call to `generate_plan` from the `open-science-plan` server.',
   'After generating a Plan, wait inside the `generate_plan` call until Open Science returns the user response. Do not report the Plan separately or execute any Plan step while waiting.',
-  'Every text entered into the Plan card returns as `kind: feedback` and is a normal user Message, never an automatic Plan decision. Interpret the full meaning yourself: for an unambiguous approval or dismissal, call `generate_plan` again with only `decision: "approved"` or `decision: "rejected"`; for requested changes, revise and regenerate the Plan; for ambiguous or conditional language, do not grant execution authority.',
-  'After `kind: feedback`, if the Message is not an unambiguous decision, address it and call `generate_plan` again when a fresh Plan review interaction is appropriate.',
+  'Every text entered into the Plan card returns as `kind: feedback` and is a normal user Message, never an automatic Plan decision. Interpret the full meaning yourself: for an unambiguous approval or dismissal, call `generate_plan` again with only `decision: "approved"` or `decision: "rejected"`; for requested changes, revise and regenerate the Plan; for ambiguous or conditional language, do not grant execution authority, address the Message, and request a fresh Plan review when appropriate.',
   'Only a Plan projection with `approval: approved` grants execution authority. Never call `update_step_status` while approval is pending, even if the feedback text sounds approving.',
   'After a restart or interruption, do not resume an approved unfinished Plan from an unrelated user Message. If the user explicitly asks to continue or resume that Plan, call `generate_plan` with only `decision: "approved"` to bind it to the current interaction before updating steps.',
   'After approval, call `update_step_status` with the exact step title when work starts and when it completes, is blocked, or is skipped.',
@@ -16,25 +14,19 @@ const SESSION_PLAN_SYSTEM_PROMPT_APPEND = [
 
 const PLAN_FIRST_TURN_PROMPT_REMINDER = `## Plan mode (ACTIVE — MANDATORY)
 
-The user has enabled plan mode. You MUST create a plan before doing any work. Do NOT execute code until a plan has been approved.
+This turn must create a Plan before doing work. Execution starts only after approval.
 
 **Required workflow:**
 
-1. **Discover skills**: Review the Skills available in the current session to confirm the catalog has what the task needs. You don't need to load skills yet — just verify coverage so the plan's steps are grounded in capabilities that actually exist.
+1. **Discover skills**: Review the Skills available in the current session to confirm the catalog covers the task. You do not need to load them yet.
 2. **Assess feasibility**: Before generating the plan, assess whether the task is achievable with available data, methods, and tools. Every plan must include a \`feasibility\` block with \`confidence\` (high / medium / low) and \`rationale\`.
-   - For straightforward tasks, set \`confidence: "high"\` with a brief rationale.
-   - For tasks with genuine uncertainty — open research questions, low-resolution data, novel methodology — set \`confidence\` to "medium" or "low" and write an honest rationale covering the specific risks and what deliverable would still be useful if the primary approach fails. It is better to surface uncertainty than to deliver a confident-looking result that does not hold up.
+   - For medium or low confidence, identify the material risks and a useful fallback deliverable.
    - If \`confidence\` is "low", directly ask the user in an ordinary response BEFORE calling \`generate_plan\` to confirm the user wants an attempt despite the risks, and to ask what fallback deliverable they would accept. Wait for the user's reply before continuing.
-   - The rationale is shown to the user above the plan when confidence is medium or low. Keep it to two sentences at most — highlight the one or two most important limitations, not an exhaustive list. Address the user directly.
-   - Example of a good rationale (medium confidence): "The available XRD pattern has broad peaks (~0.3° FWHM), which supports phase identification but not precise lattice-parameter refinement. Resulting models should be treated as plausible interpretations rather than definitively determined structures."
+   - Keep the user-facing rationale to at most two sentences and the most important limitations.
 3. **Clarify requirements**: If the request has ambiguous aspects, directly ask the user in an ordinary response with specific choices that would affect the plan structure (e.g., which analysis methods, scope, output formats), and wait for the user's reply. Skip clarification only if the request is fully unambiguous.
 4. **Identify desired outputs**: Directly ask the user in an ordinary response what **final deliverables** they want (e.g., "PDF report", "cleaned CSV dataset", "interactive plots"), and wait for the user's reply. Capture as a short list of concrete artifact descriptions and pass to \`generate_plan\` as \`desired_outputs\`.
-5. **Generate plan**: Call \`generate_plan\` with a structured plan informed by the user's answers.
+5. **Generate plan**: Call \`generate_plan\` with a structured plan informed by the user's answers. For requested revisions, submit the complete revised plan and preserve unchanged \`phases\`/\`delegations\`/\`steps\`.
 
-Each step should have a short \`title\` (≤10 words) and a \`description\` (1-3 sentences). Steps should be sequential, actionable, and specific — not vague summaries.
-
-The plan is presented to the user for review. The user may provide feedback via follow-up messages. To **revise the current plan** in response to feedback, call \`generate_plan\` with the complete revised plan, preserving the same nested \`phases\`/\`delegations\`/\`steps\` structure where it has not changed. That creates a new immutable plan and re-requests approval, so the user sees exactly what changed. Ask additional clarifying questions in an ordinary response first if the feedback is ambiguous, and wait for the user's reply. Only after the user approves the plan should you begin execution.
-
-**CRITICAL: Do NOT run code without an approved plan. Always call \`generate_plan\` first.**`
+Each step needs a short exact \`title\` (≤10 words) and a sequential, actionable \`description\` (1-3 sentences).`
 
 export { PLAN_FIRST_TURN_PROMPT_REMINDER, SESSION_PLAN_SYSTEM_PROMPT_APPEND }

--- a/src/main/session-plan/plan-mcp-server.test.ts
+++ b/src/main/session-plan/plan-mcp-server.test.ts
@@ -12,6 +12,24 @@ import {
   createPlanMcpServerForEnvironment
 } from './plan-mcp-server'
 
+const withPlanMcpClient = async <Result>(
+  name: string,
+  handler: Parameters<typeof createPlanMcpServer>[0],
+  call: (client: Client) => Promise<Result>
+): Promise<Result> => {
+  const server = createPlanMcpServer(handler)
+  const client = new Client({ name, version: '1.0.0' })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+
+  try {
+    return await call(client)
+  } finally {
+    await client.close()
+    await server.close()
+  }
+}
+
 describe('Session Plan MCP server', () => {
   it('advertises the complete nested Plan content schema', async () => {
     const server = createPlanMcpServer({
@@ -172,6 +190,345 @@ describe('Session Plan MCP server', () => {
       vi.unstubAllGlobals()
       await new Promise<void>((resolve) => server.close(() => resolve()))
     }
+  })
+
+  it('returns a compact step receipt without exposing the internal Plan projection', async () => {
+    const updateStepStatus = vi.fn().mockResolvedValue({
+      changed: true,
+      projection: {
+        artifactId: 'artifact-1',
+        artifactVersionId: 'version-1',
+        artifactChecksum: 'private-checksum',
+        revision: 12,
+        approval: 'approved',
+        lifecycle: 'completed',
+        document: {
+          schema_version: 1,
+          task_summary: 'private-task-summary',
+          phases: [],
+          desired_outputs: [],
+          feasibility: { confidence: 'high', rationale: 'private-rationale' }
+        },
+        stepStatuses: {},
+        stepStates: { 'Analyze the data': { status: 'completed' } },
+        counts: { phases: 1, delegations: 1, steps: 1, completed: 1, inProgress: 0 }
+      }
+    })
+    await withPlanMcpClient(
+      'plan-step-receipt-test',
+      {
+        generate: vi.fn(),
+        approve: vi.fn(),
+        reject: vi.fn(),
+        updateStepStatus
+      },
+      async (client) => {
+        const result = await client.callTool({
+          name: 'update_step_status',
+          arguments: { title: 'Analyze the data', status: 'completed', notes: 'Dataset verified.' }
+        })
+        const content = (result as { content: Array<{ text: string }> }).content
+        const receipt = JSON.parse(content[0].text)
+
+        expect(receipt).toEqual({
+          changed: true,
+          step: { title: 'Analyze the data', status: 'completed' },
+          revision: 12,
+          lifecycle: 'completed'
+        })
+        expect(content[0].text).not.toContain('projection')
+        expect(content[0].text).not.toContain('private-task-summary')
+        expect(content[0].text).not.toContain('private-checksum')
+        expect(updateStepStatus).toHaveBeenCalledWith({
+          title: 'Analyze the data',
+          status: 'completed',
+          notes: 'Dataset verified.',
+          expectedArtifactVersionId: undefined
+        })
+      }
+    )
+  })
+
+  it('returns compact approval and rejection receipts without exposing their projections', async () => {
+    const projection = (
+      approval: 'approved' | 'rejected',
+      revision: number
+    ): Record<string, unknown> => ({
+      artifactId: 'artifact-1',
+      artifactVersionId: 'version-1',
+      artifactChecksum: 'private-decision-checksum',
+      revision,
+      approval,
+      lifecycle: approval,
+      document: { task_summary: 'private-decision-summary' },
+      stepStatuses: {},
+      stepStates: {},
+      counts: {}
+    })
+    await withPlanMcpClient(
+      'plan-decision-receipt-test',
+      {
+        generate: vi.fn(),
+        approve: vi
+          .fn()
+          .mockResolvedValue({ changed: true, projection: projection('approved', 7) }),
+        reject: vi.fn().mockResolvedValue({ changed: true, projection: projection('rejected', 8) }),
+        updateStepStatus: vi.fn()
+      },
+      async (client) => {
+        const approved = await client.callTool({
+          name: 'generate_plan',
+          arguments: { decision: 'approved' }
+        })
+        const rejected = await client.callTool({
+          name: 'generate_plan',
+          arguments: { decision: 'rejected' }
+        })
+        const approvedText = (approved as { content: Array<{ text: string }> }).content[0].text
+        const rejectedText = (rejected as { content: Array<{ text: string }> }).content[0].text
+
+        expect(JSON.parse(approvedText)).toEqual({
+          kind: 'decision',
+          decision: 'approved',
+          changed: true,
+          revision: 7,
+          lifecycle: 'approved'
+        })
+        expect(JSON.parse(rejectedText)).toEqual({
+          kind: 'decision',
+          decision: 'rejected',
+          changed: true,
+          revision: 8,
+          lifecycle: 'rejected'
+        })
+        expect(`${approvedText}${rejectedText}`).not.toContain('projection')
+        expect(`${approvedText}${rejectedText}`).not.toContain('private-decision-summary')
+        expect(`${approvedText}${rejectedText}`).not.toContain('private-decision-checksum')
+      }
+    )
+  })
+
+  it('returns only the human feedback needed to revise a generated Plan', async () => {
+    const generate = vi.fn().mockResolvedValue({
+      kind: 'feedback',
+      routeToInteractionId: 'private-interaction-id',
+      artifactVersionId: 'private-artifact-version',
+      text: 'Split the analysis by cohort.',
+      message: {
+        id: 'private-message-id',
+        content: 'Split the analysis by cohort.',
+        createdAt: 123
+      },
+      planRevision: 9,
+      continuationCommandId: 'private-continuation-command',
+      continuationProjection: {
+        document: { task_summary: 'private-feedback-summary' }
+      }
+    })
+    await withPlanMcpClient(
+      'plan-feedback-receipt-test',
+      { generate, approve: vi.fn(), reject: vi.fn(), updateStepStatus: vi.fn() },
+      async (client) => {
+        const result = await client.callTool({
+          name: 'generate_plan',
+          arguments: {
+            task_summary: 'Analyze one dataset',
+            phases: [
+              {
+                name: 'Analysis',
+                delegations: [
+                  {
+                    name: 'Primary agent',
+                    steps: [{ title: 'Analyze the data', description: 'Produce the result.' }]
+                  }
+                ]
+              }
+            ],
+            desired_outputs: [],
+            feasibility: { confidence: 'high', rationale: 'Inputs are available.' }
+          }
+        })
+        const text = (result as { content: Array<{ text: string }> }).content[0].text
+
+        expect(JSON.parse(text)).toEqual({
+          kind: 'feedback',
+          text: 'Split the analysis by cohort.'
+        })
+        expect(text).not.toContain('private-interaction-id')
+        expect(text).not.toContain('private-message-id')
+        expect(text).not.toContain('private-continuation-command')
+        expect(text).not.toContain('private-feedback-summary')
+      }
+    )
+  })
+
+  it('returns a compact decision receipt when generated Plan review completes', async () => {
+    const generate = vi.fn().mockResolvedValue({
+      changed: true,
+      projection: {
+        artifactVersionId: 'version-1',
+        artifactChecksum: 'private-generated-plan-checksum',
+        revision: 10,
+        approval: 'approved',
+        lifecycle: 'approved',
+        document: { task_summary: 'private-generated-plan-summary' },
+        stepStates: {}
+      }
+    })
+    await withPlanMcpClient(
+      'generated-plan-decision-receipt-test',
+      { generate, approve: vi.fn(), reject: vi.fn(), updateStepStatus: vi.fn() },
+      async (client) => {
+        const result = await client.callTool({
+          name: 'generate_plan',
+          arguments: {
+            task_summary: 'Analyze one dataset',
+            phases: [
+              {
+                name: 'Analysis',
+                delegations: [
+                  {
+                    name: 'Primary agent',
+                    steps: [{ title: 'Analyze the data', description: 'Produce the result.' }]
+                  }
+                ]
+              }
+            ],
+            desired_outputs: [],
+            feasibility: { confidence: 'high', rationale: 'Inputs are available.' }
+          }
+        })
+        const text = (result as { content: Array<{ text: string }> }).content[0].text
+
+        expect(JSON.parse(text)).toEqual({
+          kind: 'decision',
+          decision: 'approved',
+          changed: true,
+          revision: 10,
+          lifecycle: 'approved'
+        })
+        expect(text).not.toContain('private-generated-plan-checksum')
+        expect(text).not.toContain('private-generated-plan-summary')
+      }
+    )
+  })
+
+  it('fails closed when a Plan handler returns an unknown success shape', async () => {
+    await withPlanMcpClient(
+      'invalid-plan-receipt-test',
+      {
+        generate: vi.fn(),
+        approve: vi.fn(),
+        reject: vi.fn(),
+        updateStepStatus: vi.fn().mockResolvedValue({ lifecycle: 'completed' })
+      },
+      async (client) => {
+        const result = await client.callTool({
+          name: 'update_step_status',
+          arguments: { title: 'Analyze the data', status: 'completed' }
+        })
+
+        expect(result).toMatchObject({
+          isError: true,
+          structuredContent: {
+            error: {
+              code: 'invalid-plan',
+              message: 'The Session Plan service returned an invalid success result.'
+            }
+          }
+        })
+      }
+    )
+  })
+
+  it('fails closed when a decision result contradicts the requested decision', async () => {
+    await withPlanMcpClient(
+      'contradictory-plan-receipt-test',
+      {
+        generate: vi.fn(),
+        approve: vi.fn().mockResolvedValue({
+          changed: true,
+          projection: { approval: 'rejected', revision: 4, lifecycle: 'rejected' }
+        }),
+        reject: vi.fn(),
+        updateStepStatus: vi.fn()
+      },
+      async (client) => {
+        const result = await client.callTool({
+          name: 'generate_plan',
+          arguments: { decision: 'approved' }
+        })
+
+        expect(result).toMatchObject({
+          isError: true,
+          structuredContent: { error: { code: 'invalid-plan' } }
+        })
+      }
+    )
+  })
+
+  it.each([
+    [
+      'lifecycle',
+      {
+        approval: 'approved',
+        revision: 4,
+        lifecycle: 'unknown',
+        stepStates: { 'Analyze the data': { status: 'in_progress' } }
+      }
+    ],
+    [
+      'approval',
+      {
+        approval: 'unknown',
+        revision: 4,
+        lifecycle: 'in_progress',
+        stepStates: { 'Analyze the data': { status: 'in_progress' } }
+      }
+    ],
+    [
+      'revision',
+      {
+        approval: 'approved',
+        revision: -1,
+        lifecycle: 'in_progress',
+        stepStates: { 'Analyze the data': { status: 'in_progress' } }
+      }
+    ],
+    [
+      'step status',
+      {
+        approval: 'approved',
+        revision: 4,
+        lifecycle: 'in_progress',
+        stepStates: { 'Analyze the data': { status: 'unknown' } }
+      }
+    ]
+  ])('fails closed when a step result contains an invalid %s', async (_field, projection) => {
+    const result = await withPlanMcpClient(
+      `invalid-plan-${_field}`,
+      {
+        generate: vi.fn(),
+        approve: vi.fn(),
+        reject: vi.fn(),
+        updateStepStatus: vi.fn().mockResolvedValue({ changed: true, projection })
+      },
+      (client) =>
+        client.callTool({
+          name: 'update_step_status',
+          arguments: { title: 'Analyze the data', status: 'in_progress' }
+        })
+    )
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: {
+        error: {
+          code: 'invalid-plan',
+          message: 'The Session Plan service returned an invalid success result.'
+        }
+      }
+    })
   })
 
   it('preserves approval-already-pending as a structured MCP error', async () => {

--- a/src/main/session-plan/plan-mcp-server.ts
+++ b/src/main/session-plan/plan-mcp-server.ts
@@ -9,9 +9,10 @@ import {
   isPlanCommandErrorCode,
   PlanCommandError,
   type GeneratePlanContent,
+  type PlanLifecycle,
   type PlanCommandErrorCode
 } from '../../shared/session-plan/contract'
-import type { SessionPlanStepStatus } from '../../shared/session-persistence'
+import type { SessionPlanApproval, SessionPlanStepStatus } from '../../shared/session-persistence'
 import { LOCAL_RESOURCE_BUDGETS } from '../resource-budget'
 import {
   fetchLocalRpc,
@@ -32,11 +33,36 @@ const generatePlanToolSchema = {
   ...generatePlanContentToolSchema.shape
 }
 
+const sessionPlanStepStatusSchema = z.enum([
+  'in_progress',
+  'completed',
+  'blocked',
+  'skipped'
+] satisfies readonly SessionPlanStepStatus[])
+
 const updateStepStatusToolSchema = {
   title: z.string().min(1),
-  status: z.enum(['in_progress', 'completed', 'blocked', 'skipped']),
+  status: sessionPlanStepStatusSchema,
   notes: z.string().min(1).optional()
 }
+
+const sessionPlanApprovalSchema = z.enum([
+  'pending',
+  'approved',
+  'rejected'
+] satisfies readonly SessionPlanApproval[])
+
+const planLifecycleSchema = z.enum([
+  'awaiting_approval',
+  'approved',
+  'in_progress',
+  'interrupted',
+  'blocked',
+  'completed',
+  'rejected'
+] satisfies readonly PlanLifecycle[])
+
+const planRevisionSchema = z.number().int().nonnegative()
 
 type PlanMcpHandler = Readonly<{
   generate: (content: GeneratePlanContent, signal?: AbortSignal) => Promise<unknown>
@@ -69,7 +95,7 @@ type PlanToolCallResult = Readonly<{
 }>
 
 const toolResult = (result: unknown): PlanToolCallResult => ({
-  content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }]
+  content: [{ type: 'text' as const, text: JSON.stringify(result) }]
 })
 
 const structuredPlanErrorResult = (error: PlanCommandError): PlanToolCallResult => {
@@ -81,12 +107,103 @@ const structuredPlanErrorResult = (error: PlanCommandError): PlanToolCallResult 
   }
 }
 
-const handlePlanToolCall = async (call: () => Promise<unknown>): Promise<PlanToolCallResult> => {
+const handlePlanToolCall = async (
+  call: () => Promise<unknown>,
+  present: (result: unknown) => unknown = (result) => result
+): Promise<PlanToolCallResult> => {
   try {
-    return toolResult(await call())
+    return toolResult(present(await call()))
   } catch (error) {
     if (error instanceof PlanCommandError) return structuredPlanErrorResult(error)
     throw error
+  }
+}
+
+const recordOf = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : undefined
+
+const invalidPlanToolSuccess = (): PlanCommandError =>
+  new PlanCommandError(
+    'invalid-plan',
+    'The Session Plan service returned an invalid success result.'
+  )
+
+const requirePlanToolState = (
+  result: unknown
+): Readonly<{
+  outcome: Record<string, unknown>
+  projection: Record<string, unknown>
+  changed: boolean
+  revision: number
+  approval: SessionPlanApproval
+  lifecycle: PlanLifecycle
+}> => {
+  const outcome = recordOf(result)
+  const projection = recordOf(outcome?.projection)
+  const approval = sessionPlanApprovalSchema.safeParse(projection?.approval)
+  const revision = planRevisionSchema.safeParse(projection?.revision)
+  const lifecycle = planLifecycleSchema.safeParse(projection?.lifecycle)
+  if (
+    !outcome ||
+    !projection ||
+    typeof outcome.changed !== 'boolean' ||
+    !approval.success ||
+    !revision.success ||
+    !lifecycle.success
+  ) {
+    throw invalidPlanToolSuccess()
+  }
+  return {
+    outcome,
+    projection,
+    changed: outcome.changed,
+    revision: revision.data,
+    approval: approval.data,
+    lifecycle: lifecycle.data
+  }
+}
+
+type PlanToolOutcomeContext =
+  | Readonly<{
+      kind: 'step-update'
+      title: string
+      status: SessionPlanStepStatus
+    }>
+  | Readonly<{ kind: 'decision'; decision: 'approved' | 'rejected' }>
+  | Readonly<{ kind: 'generation-result' }>
+
+const presentPlanToolOutcome = (result: unknown, context: PlanToolOutcomeContext): unknown => {
+  const outcome = recordOf(result)
+  if (context.kind === 'generation-result') {
+    if (outcome?.kind === 'feedback' && typeof outcome.text === 'string') {
+      return { kind: 'feedback', text: outcome.text }
+    }
+  }
+  const { projection, changed, revision, approval, lifecycle } = requirePlanToolState(result)
+  const state = { changed, revision, lifecycle }
+  if (context.kind === 'step-update') {
+    const step = recordOf(recordOf(projection.stepStates)?.[context.title])
+    const stepStatus = sessionPlanStepStatusSchema.safeParse(step?.status)
+    if (approval !== 'approved' || !stepStatus.success || stepStatus.data !== context.status) {
+      throw invalidPlanToolSuccess()
+    }
+    return {
+      ...state,
+      step: { title: context.title, status: context.status }
+    }
+  }
+  if (context.kind === 'generation-result') {
+    const decision = approval
+    if (decision === 'approved' || decision === 'rejected') {
+      return { kind: 'decision', decision, ...state }
+    }
+    return { kind: 'plan', ...state }
+  }
+  if (approval !== context.decision) throw invalidPlanToolSuccess()
+  return {
+    kind: 'decision',
+    decision: context.decision,
+    ...state
   }
 }
 
@@ -128,33 +245,40 @@ const createPlanMcpServer = (handler: PlanMcpHandler): ModelContextProtocolServe
       }
       const resolvedDecision = decision ?? (approve === true ? 'approved' : undefined)
       if (resolvedDecision !== undefined) {
-        return handlePlanToolCall(async () => {
-          if (hasContent) {
-            throw new PlanCommandError(
-              'invalid-plan',
-              'A Plan decision cannot be combined with Plan content.'
-            )
-          }
-          const result =
-            resolvedDecision === 'approved' ? await handler.approve() : await handler.reject()
-          executionArtifactVersionId =
-            resolvedDecision === 'approved'
-              ? (projectionVersionId(result) ?? executionArtifactVersionId)
-              : undefined
-          return result
-        })
+        return handlePlanToolCall(
+          async () => {
+            if (hasContent) {
+              throw new PlanCommandError(
+                'invalid-plan',
+                'A Plan decision cannot be combined with Plan content.'
+              )
+            }
+            const result =
+              resolvedDecision === 'approved' ? await handler.approve() : await handler.reject()
+            executionArtifactVersionId =
+              resolvedDecision === 'approved'
+                ? (projectionVersionId(result) ?? executionArtifactVersionId)
+                : undefined
+            return result
+          },
+          (result) =>
+            presentPlanToolOutcome(result, { kind: 'decision', decision: resolvedDecision })
+        )
       }
-      return handlePlanToolCall(async () => {
-        const document = createPlanDocumentV1({
-          task_summary,
-          phases,
-          desired_outputs,
-          feasibility
-        })
-        const result = await handler.generate(document, extra.signal)
-        executionArtifactVersionId = projectionVersionId(result) ?? executionArtifactVersionId
-        return result
-      })
+      return handlePlanToolCall(
+        async () => {
+          const document = createPlanDocumentV1({
+            task_summary,
+            phases,
+            desired_outputs,
+            feasibility
+          })
+          const result = await handler.generate(document, extra.signal)
+          executionArtifactVersionId = projectionVersionId(result) ?? executionArtifactVersionId
+          return result
+        },
+        (result) => presentPlanToolOutcome(result, { kind: 'generation-result' })
+      )
     }
   )
   server.registerTool(
@@ -165,11 +289,18 @@ const createPlanMcpServer = (handler: PlanMcpHandler): ModelContextProtocolServe
       inputSchema: updateStepStatusToolSchema
     },
     async (input) =>
-      handlePlanToolCall(() =>
-        handler.updateStepStatus({
-          ...input,
-          expectedArtifactVersionId: executionArtifactVersionId
-        })
+      handlePlanToolCall(
+        () =>
+          handler.updateStepStatus({
+            ...input,
+            expectedArtifactVersionId: executionArtifactVersionId
+          }),
+        (result) =>
+          presentPlanToolOutcome(result, {
+            kind: 'step-update',
+            title: input.title,
+            status: input.status
+          })
       )
   )
   return server

--- a/src/main/session-plan/plan-service.test.ts
+++ b/src/main/session-plan/plan-service.test.ts
@@ -306,6 +306,45 @@ describe('PlanService', () => {
     ).rejects.toMatchObject({ code: 'approval-already-decided' })
   })
 
+  it('rejects an authorized step update when the Plan revision changes before commit', async () => {
+    const { service, context, setContext, dependencies } = setup()
+    const generated = await service.generate({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      executionId: 'execution-1',
+      interactionId: 'interaction-1',
+      content
+    })
+    const approved = await service.respond({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      artifactVersionId: generated.projection.artifactVersionId,
+      expectedRevision: generated.projection.revision,
+      decision: 'approved'
+    })
+    vi.mocked(dependencies.readRuntimeContext).mockClear()
+    vi.mocked(dependencies.readArtifactVersion).mockClear()
+    vi.mocked(dependencies.patchRuntimeContext).mockClear()
+
+    await expect(
+      service.updateStepStatus({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        title: 'Analyze the data',
+        status: 'in_progress',
+        authorizeUpdate: (projection) => {
+          expect(projection.revision).toBe(approved.projection.revision)
+          setContext({ ...context(), revision: context().revision + 1 })
+        }
+      })
+    ).rejects.toMatchObject({ code: 'revision-conflict' })
+
+    expect(dependencies.readRuntimeContext).toHaveBeenCalledOnce()
+    expect(dependencies.readArtifactVersion).toHaveBeenCalledOnce()
+    expect(dependencies.patchRuntimeContext).toHaveBeenCalledOnce()
+    expect(context().plan?.stepStatuses).toEqual({})
+  })
+
   it('does not persist a Plan decision when its commit precondition is revoked', async () => {
     const { service, context, dependencies } = setup()
     const generated = await service.generate({

--- a/src/main/session-plan/plan-service.ts
+++ b/src/main/session-plan/plan-service.ts
@@ -92,6 +92,19 @@ type PlanIdentityCommand = Readonly<{
   expectedRevision: number
 }>
 
+type PlanStepStatusUpdate = Readonly<{
+  title: string
+  status: SessionPlanStepStatus
+  notes?: string
+}>
+
+type ActivePlanStepStatusCommand = Readonly<{
+  projectId: string
+  sessionId: string
+  authorizeUpdate: (projection: ActivePlanProjection) => void | Promise<void>
+}> &
+  PlanStepStatusUpdate
+
 type PlanDecisionCommitPrecondition = Readonly<{
   beforeDecisionCommit?: () => boolean
 }>
@@ -572,13 +585,38 @@ class PlanService {
   }
 
   async updateStepStatus(
-    input: PlanIdentityCommand &
-      Readonly<{ title: string; status: SessionPlanStepStatus; notes?: string }>
+    input: PlanIdentityCommand & PlanStepStatusUpdate
+  ): Promise<{ projection: ActivePlanProjection; changed: boolean }>
+  async updateStepStatus(
+    input: ActivePlanStepStatusCommand
+  ): Promise<{ projection: ActivePlanProjection; changed: boolean }>
+  async updateStepStatus(
+    input: (PlanIdentityCommand & PlanStepStatusUpdate) | ActivePlanStepStatusCommand
   ): Promise<{ projection: ActivePlanProjection; changed: boolean }> {
-    const { context, plan, document } = await this.loadActive(input, undefined, {
-      title: input.title,
-      status: input.status
-    })
+    let loaded: Awaited<ReturnType<PlanService['loadActive']>>
+    let identity: PlanIdentityCommand
+    if ('authorizeUpdate' in input) {
+      const current = await this.loadCurrent(input.projectId, input.sessionId)
+      if (!current) {
+        throw new PlanCommandError('no-active-plan', 'The Session has no active Plan.')
+      }
+      loaded = current
+      const { context, plan, document } = current
+      identity = {
+        projectId: input.projectId,
+        sessionId: input.sessionId,
+        artifactVersionId: plan.artifactVersionId,
+        expectedRevision: context.revision
+      }
+      await input.authorizeUpdate(this.project(document, plan, context.revision, true))
+    } else {
+      identity = input
+      loaded = await this.loadActive(input, undefined, {
+        title: input.title,
+        status: input.status
+      })
+    }
+    const { plan, document } = loaded
     if (plan.approval !== 'approved') {
       throw new PlanCommandError('plan-not-approved', 'The Plan must be approved before execution.')
     }
@@ -588,7 +626,26 @@ class PlanService {
     const previous = runtimeStatusFor(plan, input.title)?.status
     const sameTerminal = previous === input.status && isTerminalStepStatus(input.status)
     if (sameTerminal) {
-      return { projection: this.project(document, plan, context.revision, true), changed: false }
+      const latestContext = await this.dependencies.readRuntimeContext(
+        input.projectId,
+        input.sessionId
+      )
+      const latestPlan = latestContext.plan
+      const sameAuthority =
+        latestPlan?.artifactId === plan.artifactId &&
+        latestPlan.artifactVersionId === plan.artifactVersionId &&
+        latestPlan.artifactChecksum === plan.artifactChecksum
+      if (
+        !sameAuthority ||
+        latestPlan.approval !== 'approved' ||
+        runtimeStatusFor(latestPlan, input.title)?.status !== input.status
+      ) {
+        throw new PlanCommandError('revision-conflict', 'The Plan revision changed concurrently.')
+      }
+      return {
+        projection: this.project(document, latestPlan, latestContext.revision, true),
+        changed: false
+      }
     }
     const startsStep = !previous && (input.status === 'in_progress' || input.status === 'skipped')
     const valid =
@@ -610,7 +667,7 @@ class PlanService {
     const settled = isPlanTerminalOutcome(document, updated.stepStatuses)
       ? withoutContinuation(updated)
       : updated
-    const next = await this.patch(input, settled, 'running')
+    const next = await this.patch(identity, settled, 'running')
     return { projection: this.project(document, settled, next.revision, true), changed: true }
   }
 
@@ -619,21 +676,14 @@ class PlanService {
     sessionId: string,
     options: Readonly<{ interactionIsLive?: boolean }> = {}
   ): Promise<ActivePlanProjection | null> {
-    const context = await this.dependencies.readRuntimeContext(projectId, sessionId)
-    if (!context.plan) return null
-    try {
-      const document = await this.readDocument(projectId, sessionId, context.plan)
-      return this.project(
-        document,
-        context.plan,
-        context.revision,
-        options.interactionIsLive ?? false
-      )
-    } catch (error) {
-      if (!(error instanceof PlanCommandError) || error.code !== 'artifact-unavailable') throw error
-      await this.dropUnavailableAuthority(projectId, sessionId, context)
-      return null
-    }
+    const current = await this.loadCurrent(projectId, sessionId)
+    if (!current) return null
+    return this.project(
+      current.document,
+      current.plan,
+      current.context.revision,
+      options.interactionIsLive ?? false
+    )
   }
 
   async authorizeContinuation(input: PlanIdentityCommand): Promise<ActivePlanProjection> {
@@ -685,6 +735,29 @@ class PlanService {
       context,
       plan,
       document: await this.readDocument(input.projectId, input.sessionId, plan)
+    }
+  }
+
+  private async loadCurrent(
+    projectId: string,
+    sessionId: string
+  ): Promise<{
+    context: SessionRuntimeContext
+    plan: SessionPlanRuntimeContext
+    document: PlanDocumentV1
+  } | null> {
+    const context = await this.dependencies.readRuntimeContext(projectId, sessionId)
+    if (!context.plan) return null
+    try {
+      return {
+        context,
+        plan: context.plan,
+        document: await this.readDocument(projectId, sessionId, context.plan)
+      }
+    } catch (error) {
+      if (!(error instanceof PlanCommandError) || error.code !== 'artifact-unavailable') throw error
+      await this.dropUnavailableAuthority(projectId, sessionId, context)
+      return null
     }
   }
 

--- a/src/shared/session-plan/contract.test.ts
+++ b/src/shared/session-plan/contract.test.ts
@@ -24,7 +24,7 @@ describe('Plan command errors', () => {
 })
 
 describe('protected Plan context', () => {
-  it('retains immutable identity, approval, lifecycle, and the latest step notes', () => {
+  it('keeps decision state and exact step titles without model-irrelevant storage identity', () => {
     const summary = formatPlanProtectedContext({
       artifactId: 'artifact-1',
       artifactVersionId: 'version-3',
@@ -41,7 +41,10 @@ describe('protected Plan context', () => {
             delegations: [
               {
                 name: 'Main Agent',
-                steps: [{ title: 'Analyze', description: 'Analyze the data.' }]
+                steps: [
+                  { title: 'Inspect exact input title', description: 'Inspect the data.' },
+                  { title: 'Analyze', description: 'Analyze the data.' }
+                ]
               }
             ]
           }
@@ -49,16 +52,35 @@ describe('protected Plan context', () => {
         desired_outputs: ['Result'],
         feasibility: { confidence: 'high', rationale: 'Ready.' }
       }),
-      stepStatuses: { Analyze: { status: 'blocked', updatedAt: 42, notes: 'Input missing' } },
-      stepStates: { Analyze: { status: 'blocked', notes: 'Input missing' } },
-      counts: { phases: 1, delegations: 1, steps: 1, completed: 0, inProgress: 0 }
+      stepStatuses: {
+        'Inspect exact input title': {
+          status: 'completed',
+          updatedAt: 41,
+          notes: 'A long completed-step implementation log that is no longer actionable.'
+        },
+        Analyze: { status: 'blocked', updatedAt: 42, notes: 'Input missing' }
+      },
+      stepStates: {
+        'Inspect exact input title': {
+          status: 'completed',
+          notes: 'A long completed-step implementation log that is no longer actionable.'
+        },
+        Analyze: { status: 'blocked', notes: 'Input missing' }
+      },
+      counts: { phases: 1, delegations: 1, steps: 2, completed: 1, inProgress: 0 }
     })
 
-    expect(summary).toContain('artifact_id=artifact-1')
-    expect(summary).toContain('artifact_version_id=version-3')
-    expect(summary).toContain('revision=8 approval=approved lifecycle=blocked')
-    expect(summary).toContain('Analyze: blocked — Input missing')
-    expect(summary).toContain('Do not execute this Plan without interaction-bound authority')
+    expect(summary).toBe(
+      [
+        '<open_science_protected_plan_context>',
+        'approval=approved lifecycle=blocked',
+        'task=Analyze data',
+        '- Inspect exact input title: completed',
+        '- Analyze: blocked — Input missing',
+        'Do not execute this Plan without interaction-bound authority from Open Science.',
+        '</open_science_protected_plan_context>'
+      ].join('\n')
+    )
   })
 })
 

--- a/src/shared/session-plan/contract.ts
+++ b/src/shared/session-plan/contract.ts
@@ -121,15 +121,13 @@ const compactPlanContextText = (value: string): string =>
 export const formatPlanProtectedContext = (projection: ActivePlanProjection): string => {
   const steps = planStepTitles(projection.document).map((title) => {
     const state = projection.stepStates[title] ?? { status: 'not_started' as const }
-    const notes = state.notes ? ` — ${compactPlanContextText(state.notes)}` : ''
+    const notes =
+      state.status !== 'completed' && state.notes ? ` — ${compactPlanContextText(state.notes)}` : ''
     return `- ${compactPlanContextText(title)}: ${state.status}${notes}`
   })
   return [
     '<open_science_protected_plan_context>',
-    `artifact_id=${projection.artifactId}`,
-    `artifact_version_id=${projection.artifactVersionId}`,
-    `artifact_checksum=${projection.artifactChecksum}`,
-    `revision=${projection.revision} approval=${projection.approval} lifecycle=${projection.lifecycle}`,
+    `approval=${projection.approval} lifecycle=${projection.lifecycle}`,
     `task=${compactPlanContextText(projection.document.task_summary)}`,
     ...steps,
     'Do not execute this Plan without interaction-bound authority from Open Science.',


### PR DESCRIPTION
## Problem

Session Plan MCP operations returned complete internal projections to the model, and step updates loaded the authoritative Plan more than needed. This inflated model context and repeated local work.

## Proposed change

- Return compact model-facing receipts for step updates, decisions, and feedback while keeping full projections on the Runtime and UI path.
- Load the Plan artifact once for normal state-changing updates while retaining authority checks, revision CAS, and idempotent concurrency safety.
- Remove model-irrelevant internal identity and completed-step notes from protected Plan context.
- Deduplicate stable Session Plan guidance and the Plan-first reminder.
- Fail closed when internal success payloads do not match the expected Plan domain shape.

Observed fixture reductions: step receipt 85%, decision receipt 76%, feedback receipt 88%, protected context 44%, and combined system guidance plus Plan-first reminder 30%. These are representative character measurements, not production limits.

## Scope and non-goals

- No changes to tool names, input schemas, exact-title matching, call order, structured error contract, UI projection, or persistence format.
- No dynamic step selection and no strict character or token limit.
- Existing full Plan projections remain available to internal consumers.

## Acceptance criteria and validation

All checks ran after the final code edit.

- MCP receipt and error behavior: targeted Plan MCP tests passed.
- Runtime load, CAS, idempotent concurrency, and UI publication: targeted Runtime and PlanService tests passed.
- Protected context and guidance consumers: formatter, prompt workflow, Runtime, and app MCP naming tests passed.
- `npm run typecheck`: passed.
- `npm run lint`: passed.
- `npm test`: 1,073 test files passed, 14 skipped; 15,917 tests passed, 213 skipped.

UI E2E was not run because the change does not alter renderer behavior; full projection publication remains covered by Runtime contract tests.

## Review focus

- Confirm model-facing receipts expose only the state needed for the next decision.
- Confirm authority, revision CAS, and same-terminal idempotent behavior remain concurrency-safe.
- Confirm protected context and guidance retain approval, feedback, continuation, exact-title, and blocker rules.