### PR TITLE
fix(session-delete): register deletion through validated composition

### DIFF
--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -186,7 +186,7 @@ const invocation = (
 }
 
 describe('application command composition', () => {
-  it('joins the six runtime-validated Project contracts into the Electron view', () => {
+  it('joins the runtime-validated contracts into the Electron view', () => {
     const composition = createApplicationCommandComposition(dependencies())
 
     expect(composition.electron.commandNames()).toEqual([
@@ -195,7 +195,8 @@ describe('application command composition', () => {
       'projects:get',
       'projects:list',
       'projects:update',
-      'projects:update-archive'
+      'projects:update-archive',
+      'sessions:delete-session'
     ])
   })
 

--- a/src/main/application-command-electron-adapter.test.ts
+++ b/src/main/application-command-electron-adapter.test.ts
@@ -18,13 +18,14 @@ vi.mock('./ipc-handler-registry', () => ({
 }))
 import { registerApplicationCommandElectronAdapter } from './application-command-electron-adapter'
 
-const projectChannels = [
+const validatedChannels = [
   'projects:create',
   'projects:delete',
   'projects:get',
   'projects:list',
   'projects:update',
-  'projects:update-archive'
+  'projects:update-archive',
+  'sessions:delete-session'
 ] as const
 
 const eventWithLease = (): IpcMainInvokeEvent => {
@@ -42,7 +43,7 @@ const eventWithLease = (): IpcMainInvokeEvent => {
 const dispatcher = (
   invoke: ApplicationCommandByNameDispatcher['invoke']
 ): ApplicationCommandByNameDispatcher => ({
-  commandNames: () => projectChannels,
+  commandNames: () => validatedChannels,
   invoke
 })
 
@@ -52,14 +53,14 @@ beforeEach(() => {
 })
 
 describe('Electron Application Command adapter', () => {
-  it('installs the catalog-selected Project slice with caller context and lease', async () => {
+  it('installs the catalog-selected validated slice with caller context and lease', async () => {
     const result = [{ id: 'project-1' }]
     const invoke = vi.fn().mockResolvedValue(result)
     registerApplicationCommandElectronAdapter(dispatcher(invoke), { warn })
     const event = eventWithLease()
 
     await expect(handlers.get('projects:list')?.(event)).resolves.toEqual({ ok: true, result })
-    expect([...handlers.keys()]).toEqual(projectChannels)
+    expect([...handlers.keys()]).toEqual(validatedChannels)
     expect(invoke).toHaveBeenCalledWith(
       'projects:list',
       expect.objectContaining({

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -779,10 +779,9 @@ describe('Data and content application commands', () => {
       const deps = createDependencies()
       registerDataContentApplicationCommands(router.registrar, deps.dependencies)
 
-      const dispatched = router.dispatcher.invoke(
-        dataContentApplicationCommands.sessionDelete,
-        invocation([request] as const)
-      )
+      // Malformed payloads are intentionally outside the command's static arg type; dispatch
+      // through the type-widened harness so the runtime codec is what rejects them.
+      const { result: dispatched } = dispatchCommand(router, 'sessionDelete', [request])
 
       const error = await dispatched.catch((error: unknown) => error)
       expect(error).toBeInstanceOf(ApplicationCommandError)

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -14,6 +14,7 @@ import {
   type DataContentApplicationCommandDependencies
 } from './data-content-application-commands'
 import type { SessionDeletionResult } from '../shared/session-persistence'
+import { ApplicationCommandError } from '../shared/application-command-contract'
 
 const callerContext = createCallerContext({
   clientId: 'renderer-1',
@@ -762,6 +763,55 @@ describe('Data and content application commands', () => {
     expect(deps.sessions.deleteSession).toHaveBeenCalledWith(request)
     expect(deps.withDataRootWrite).not.toHaveBeenCalled()
     expect(deps.events.publish).not.toHaveBeenCalledWith('session:deleted', request)
+  })
+
+  it.each([
+    {
+      label: 'unknown extra field',
+      request: { projectId: 'project-1', sessionId: 'session-1', force: true }
+    },
+    { label: 'missing session id', request: { projectId: 'project-1' } },
+    { label: 'scalar payload', request: 'session-1' }
+  ])(
+    'rejects a malformed Session deletion request ($label) before reaching the owner',
+    async ({ request }) => {
+      const router = createApplicationCommandRouter()
+      const deps = createDependencies()
+      registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+
+      const dispatched = router.dispatcher.invoke(
+        dataContentApplicationCommands.sessionDelete,
+        invocation([request] as const)
+      )
+
+      const error = await dispatched.catch((error: unknown) => error)
+      expect(error).toBeInstanceOf(ApplicationCommandError)
+      expect(error).toMatchObject({ code: 'invalid-command-arguments' })
+      expect(deps.sessions.deleteSession).not.toHaveBeenCalled()
+      expect(deps.events.publish).not.toHaveBeenCalled()
+    }
+  )
+
+  it('rejects a malformed Session deletion owner result without publishing deletion', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    deps.sessions.deleteSession.mockResolvedValueOnce({
+      status: 'failed',
+      reason: 'runtime',
+      runtimeDetached: 'yes'
+    } as unknown as SessionDeletionResult)
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+
+    const dispatched = router.dispatcher.invoke(
+      dataContentApplicationCommands.sessionDelete,
+      invocation([{ projectId: 'project-1', sessionId: 'session-1' }] as const)
+    )
+
+    const error = await dispatched.catch((error: unknown) => error)
+    expect(error).toBeInstanceOf(ApplicationCommandError)
+    expect(error).toMatchObject({ code: 'invalid-command-result' })
+    expect(deps.sessions.deleteSession).toHaveBeenCalledTimes(1)
+    expect(deps.events.publish).not.toHaveBeenCalled()
   })
 
   it('keeps native and local upload/export capability restrictions and standalone invalidation', async () => {

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -20,7 +20,7 @@ import { LIFECYCLE_CHANNELS } from '../shared/lifecycle-events'
 import type * as PreviewResources from '../shared/preview-resources'
 import type * as PreviewState from '../shared/preview-state'
 import * as Projects from '../shared/projects'
-import type * as SessionPersistence from '../shared/session-persistence'
+import * as SessionPersistence from '../shared/session-persistence'
 import * as Uploads from '../shared/uploads'
 
 type OwnerArgs<Owner, Method extends keyof Owner> = Owner[Method] extends (
@@ -248,7 +248,11 @@ const dataContentApplicationCommands = Object.freeze({
     'update',
     Projects.projectApplicationCommandContracts.update
   ),
-  sessionDelete: sessionCommand('sessions:delete-session', 'deleteSession'),
+  sessionDelete: sessionCommand(
+    'sessions:delete-session',
+    'deleteSession',
+    SessionPersistence.sessionApplicationCommandContracts.delete
+  ),
   sessionExportConversation: electronCommand(
     'sessions:export-conversation',
     'exportConversationFromInvokingWindow'

--- a/src/shared/application-command-contract.ts
+++ b/src/shared/application-command-contract.ts
@@ -24,6 +24,13 @@ export type ApplicationCommandContract<Args extends readonly unknown[], Result> 
   result: RuntimeCodec<Result>
 }>
 
+// Domain modules compose runtime-validated command contracts with this helper so arg/result codecs
+// stay colocated with the shared domain types they parse.
+export const defineApplicationCommandContract = <Args extends readonly unknown[], Result>(
+  args: ApplicationCommandContract<Args, Result>['args'],
+  result: ApplicationCommandContract<Args, Result>['result']
+): ApplicationCommandContract<Args, Result> => Object.freeze({ args, result })
+
 export type ApplicationCommandErrorEnvelope = Readonly<{
   code: ApplicationCommandErrorCode
   message: string

--- a/src/shared/projects.ts
+++ b/src/shared/projects.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { validationCodec, type ApplicationCommandContract } from './application-command-contract'
+import { defineApplicationCommandContract, validationCodec } from './application-command-contract'
 
 // Shared project types crossing the main <-> renderer IPC boundary.
 //
@@ -67,27 +67,28 @@ export type UpdateProjectRequest = z.infer<typeof updateProjectRequestSchema>
 export type DeleteProjectRequest = z.infer<typeof deleteProjectRequestSchema>
 export type UpdateProjectArchiveRequest = z.infer<typeof updateProjectArchiveRequestSchema>
 
-const contract = <Args extends readonly unknown[], Result>(
-  args: ApplicationCommandContract<Args, Result>['args'],
-  result: ApplicationCommandContract<Args, Result>['result']
-): ApplicationCommandContract<Args, Result> => Object.freeze({ args, result })
-
 export const projectApplicationCommandContracts = Object.freeze({
-  list: contract(validationCodec(z.tuple([])), validationCodec(z.array(projectSchema))),
-  get: contract(validationCodec(z.tuple([z.string()])), validationCodec(projectSchema.nullable())),
-  create: contract(
+  list: defineApplicationCommandContract(
+    validationCodec(z.tuple([])),
+    validationCodec(z.array(projectSchema))
+  ),
+  get: defineApplicationCommandContract(
+    validationCodec(z.tuple([z.string()])),
+    validationCodec(projectSchema.nullable())
+  ),
+  create: defineApplicationCommandContract(
     validationCodec(z.tuple([createProjectRequestSchema])),
     validationCodec(projectSchema)
   ),
-  update: contract(
+  update: defineApplicationCommandContract(
     validationCodec(z.tuple([updateProjectRequestSchema])),
     validationCodec(projectSchema)
   ),
-  updateArchive: contract(
+  updateArchive: defineApplicationCommandContract(
     validationCodec(z.tuple([updateProjectArchiveRequestSchema])),
     validationCodec(projectSchema)
   ),
-  delete: contract(
+  delete: defineApplicationCommandContract(
     validationCodec(z.tuple([deleteProjectRequestSchema])),
     validationCodec(z.undefined())
   )

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -195,14 +195,15 @@ describe('renderer contract catalog', () => {
     })
   })
 
-  it('marks only the runtime-validated Project command slice', () => {
+  it('marks the runtime-validated command slice', () => {
     expect(paths(({ applicationCommand }) => applicationCommand === 'runtime-validated')).toEqual([
       'projects.create',
       'projects.delete',
       'projects.get',
       'projects.list',
       'projects.update',
-      'projects.updateArchive'
+      'projects.updateArchive',
+      'sessions.deleteSession'
     ])
     expect(ELECTRON_APPLICATION_COMMAND_CHANNELS).toEqual([
       'projects:create',
@@ -210,7 +211,8 @@ describe('renderer contract catalog', () => {
       'projects:get',
       'projects:list',
       'projects:update',
-      'projects:update-archive'
+      'projects:update-archive',
+      'sessions:delete-session'
     ])
   })
 })

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -307,7 +307,7 @@ export const RENDERER_CONTRACT_GROUPS = Object.freeze([
   ]),
   group('sessions', 'sessions', [
     ['exportConversation', 'sessions:export-conversation', MAPPED_ELECTRON], ['onCreated', 'session:created', EVENT], ['onDeleted', 'session:deleted', EVENT],
-    ['onFlushRequest', 'sessions:flush-request', ELECTRON_EVENT], ['onUpdated', 'session:updated', EVENT], ['deleteSession', 'sessions:delete-session'],
+    ['onFlushRequest', 'sessions:flush-request', ELECTRON_EVENT], ['onUpdated', 'session:updated', EVENT], ['deleteSession', 'sessions:delete-session', WEB, undefined, undefined, RUNTIME_VALIDATED],
     ['loadAll', 'sessions:load-all'], ['loadOne', 'sessions:load-one'], ['saveManifest', 'sessions:save-manifest'],
     ['saveSession', 'sessions:save-session', WEB, SESSION_SAVE, SESSION_SAVE_JSON], ['updateArchive', 'sessions:update-archive'], ['sendFlushResponse', 'sessions:flush-response', SEND],
   ]),

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -1,3 +1,6 @@
+import { z } from 'zod'
+
+import { defineApplicationCommandContract, validationCodec } from './application-command-contract'
 import type { PersistedUploadedAttachment } from './uploads'
 import type { FileReference } from './artifacts'
 import {
@@ -3708,15 +3711,33 @@ export type LoadSessionRequest = {
   sessionId: string
 }
 
-export type DeleteSessionRequest = {
-  projectId: string
-  sessionId: string
-}
+export const deleteSessionRequestSchema = z
+  .object({ projectId: z.string(), sessionId: z.string() })
+  .strict()
 
-export type SessionDeletionResult =
-  | { status: 'deleted'; runtimeDetached: true }
-  | { status: 'failed'; reason: 'runtime'; runtimeDetached: false }
-  | { status: 'failed'; reason: 'persistence'; runtimeDetached: true }
+export type DeleteSessionRequest = z.infer<typeof deleteSessionRequestSchema>
+
+// zod v4 requires unique discriminator values, and both failure branches share status 'failed',
+// so this stays a plain union over the exact owner-produced shapes.
+export const sessionDeletionResultSchema = z.union([
+  z.object({ status: z.literal('deleted'), runtimeDetached: z.literal(true) }).strict(),
+  z
+    .object({
+      status: z.literal('failed'),
+      reason: z.literal('runtime'),
+      runtimeDetached: z.literal(false)
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal('failed'),
+      reason: z.literal('persistence'),
+      runtimeDetached: z.literal(true)
+    })
+    .strict()
+])
+
+export type SessionDeletionResult = z.infer<typeof sessionDeletionResultSchema>
 
 export type UpdateSessionArchiveRequest = {
   projectId: string
@@ -3729,3 +3750,13 @@ export type SaveSessionManifestRequest = {
   lastProjectId?: string
   lastSessionId?: string
 }
+
+// Runtime-validated contract for the Electron-facing terminal Session deletion command. The request
+// and result schemas double as the wire types so the router enforces exactly the union the
+// SessionDeletionOwner can produce.
+export const sessionApplicationCommandContracts = Object.freeze({
+  delete: defineApplicationCommandContract(
+    validationCodec(z.tuple([deleteSessionRequestSchema])),
+    validationCodec(sessionDeletionResultSchema)
+  )
+})


### PR DESCRIPTION
## Problem

Deleting a Session from the Electron app fails with `No handler registered for 'sessions:delete-session'`, breaking every deletion entry point (Workspace delete and the archived Sessions panel).

#1303 removed the only `ipcMainHandle('sessions:delete-session', ...)` registration under the assumption that the application-command composition covered the Electron surface. That assumption did not hold: the Electron adapter only installs channels marked `runtime-validated` in the renderer contract catalog, and only the `projects:*` slice carried the mark. The command was defined for the Web surface, so nothing registered the Electron channel.

## Proposed change

Complete the migration started by #1303, following the existing `projects:*` validated-command precedent:

- Mark `sessions:delete-session` as `runtime-validated` in the renderer contract catalog, so the Electron adapter installs it through the validated composition (single registration point).
- Give the command a runtime codec: `DeleteSessionRequest` and `SessionDeletionResult` are now zod schemas whose inferred types double as the wire types (`shared/session-persistence.ts`). The router now validates both the request and the owner result at the command boundary.
- Lift the local contract helper from `shared/projects.ts` into a shared `defineApplicationCommandContract` export, so each domain module composes contracts the same way.
- No preload change: the renderer contract adapter already unwraps the validated `ApplicationCommandOutcome` envelope for marked channels, so marking the catalog entry makes the existing preload path correct.

## Scope and non-goals

- Terminal-deletion behavior (runtime teardown ordering, dedup, project identity checks) is unchanged — it stays behind `SessionDeletionOwner` from #1303; only the Electron registration path changes.
- Not migrating the remaining `sessions:*` channels or other domains to `runtime-validated`; each of those still has its direct registration.
- Not building a repo-wide "every cataloged channel has a registration" inventory. The exploration in this PR showed ~36 channels register through varied indirect shapes (shared constants, injected `ipcMain`, group iteration); a reliable reconciliation needs a dedicated channel-inventory effort. This PR's regression surface is covered by the existing five-layer reconciliation (catalog exact-inventory test, `certifyInventory` codec enforcement, declared-vs-installed certification, adapter inventory mismatch check, adaptive preload tests).

## Acceptance criteria and validation

Final handoff mapping (`behavior -> command -> result`). History: the full suite ran after the source commit (8117aa84); the first CI round then failed `typecheck:node` (TS2345) because the initial test commit (beb94d8d) was followed only by vitest+eslint, not typecheck — the narrowed static arg type from the new contract rejected the malformed-payload fixtures. c038fa32 routes those fixtures through the widened `dispatchCommand` harness; after that last material edit the affected-process typechecks, the file's tests, and eslint all reran clean:

- Electron registration of `sessions:delete-session` via validated composition -> `npm test -- src/main/application-command-composition.test.ts src/main/application-command-electron-adapter.test.ts src/shared/renderer-contract-catalog.test.ts` -> 13 + 11 + catalog tests, all passed
- Deletion command dispatch and lifecycle publication through the owner -> `npm test -- src/main/data-content-application-commands.test.ts` -> 15 passed, including new codec boundary tests (`invalid-command-arguments` before the owner is invoked; `invalid-command-result` on a malformed owner result without publishing `sessionDeleted`)
- Full portable suite (cross-area inventory assertions, preload envelope, renderer consumers) -> `npx vitest run --root <worktree>` -> 1073 files / 15902 tests passed
- Related surface recheck after the test commit -> data-content + composition + electron-adapter + router + `src/shared` -> 591 passed
- Both runtime processes -> `npm run typecheck` (node + web) -> passed
- Lint -> `npm run lint` -> passed
- Generated Web map consistency -> `npm run check:web-api-map` -> in sync, no regeneration needed

Consumer/platform notes: no renderer or preload source changed, so UI E2E lanes were excluded; the renderer-visible behavior change (outcome envelope unwrapping) is covered by the adaptive preload bridge tests. The 20 renderer test files that failed inside the git worktree were confirmed environment-only (identical files pass on the main checkout and in the worktree after dependency resolution was fixed), not regressions.

Uncovered risks: no manual on-device verification of a real deletion yet — recommend one interactive check (Workspace delete + archived panel delete) before release.

## Review focus

- `shared/session-persistence.ts`: the zod schemas must match the exact union `SessionDeletionOwner` produces; note the plain `z.union` (zod v4 rejects `discriminatedUnion` when two branches share the `failed` discriminator value).
- `shared/renderer-contract-catalog.ts`: the single-line catalog entry gaining the `RUNTIME_VALIDATED` mark is the actual bug fix; everything else is plumbing that the mark makes mandatory (codec) or deduplication (shared contract helper).
- The result-codec test deliberately uses a `status: 'failed'` malformation, because the handler publishes `sessionDeleted` before the router parses the result — a `deleted`-shaped malformation would publish first and muddy the no-side-effect assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
