### PR TITLE
fix(vision-evidence): accept null uncertainty

### DIFF
--- a/src/main/acp/image-input-compatibility-owner.test.ts
+++ b/src/main/acp/image-input-compatibility-owner.test.ts
@@ -141,6 +141,31 @@ describe('ImageInputCompatibilityOwner', () => {
     ])
   })
 
+  it('rejects Vision evidence with a missing uncertainty field', async () => {
+    const owner = new ImageInputCompatibilityOwner({
+      captureTarget: vi.fn(async () => target),
+      runner: {
+        run: vi.fn(async () => ({
+          text: JSON.stringify({
+            summary: 'An incomplete response.',
+            findings: [],
+            transcription: '',
+            regions: [],
+            entities: [],
+            relations: []
+          }),
+          frameworkId: 'opencode' as const,
+          model: 'vision-model',
+          stopReason: 'end_turn' as const
+        }))
+      }
+    })
+
+    await expect(
+      owner.prepare({ content: [image], supportsImageInput: false })
+    ).rejects.toMatchObject({ code: 'invalid-evidence' })
+  })
+
   it('bypasses the relay for a native visual active model', async () => {
     const captureTarget = vi.fn(async () => target)
     const run = vi.fn()

--- a/src/main/acp/image-input-compatibility-owner.test.ts
+++ b/src/main/acp/image-input-compatibility-owner.test.ts
@@ -107,6 +107,40 @@ describe('ImageInputCompatibilityOwner', () => {
     ])
   })
 
+  it('accepts a null uncertainty from the Vision model', async () => {
+    const owner = new ImageInputCompatibilityOwner({
+      captureTarget: vi.fn(async () => target),
+      runner: {
+        run: vi.fn(async () => ({
+          text: JSON.stringify({
+            summary: 'A clear screenshot.',
+            findings: [],
+            transcription: '',
+            regions: [],
+            entities: [],
+            relations: [],
+            uncertainty: null
+          }),
+          frameworkId: 'opencode' as const,
+          model: 'vision-model',
+          stopReason: 'end_turn' as const
+        }))
+      }
+    })
+
+    const prepared = await owner.prepare({
+      content: [image],
+      supportsImageInput: false
+    })
+
+    expect(prepared).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('Uncertainty: []')
+      })
+    ])
+  })
+
   it('bypasses the relay for a native visual active model', async () => {
     const captureTarget = vi.fn(async () => target)
     const run = vi.fn()

--- a/src/main/acp/image-input-compatibility-owner.ts
+++ b/src/main/acp/image-input-compatibility-owner.ts
@@ -179,7 +179,7 @@ const parseEvidence = (raw: string): ImageEvidence => {
     regions,
     entities,
     relations,
-    uncertainty: stringArray(value.uncertainty ?? [])
+    uncertainty: stringArray(value.uncertainty === null ? [] : value.uncertainty)
   })
 }
 

--- a/src/main/acp/image-input-compatibility-owner.ts
+++ b/src/main/acp/image-input-compatibility-owner.ts
@@ -179,7 +179,7 @@ const parseEvidence = (raw: string): ImageEvidence => {
     regions,
     entities,
     relations,
-    uncertainty: stringArray(value.uncertainty)
+    uncertainty: stringArray(value.uncertainty ?? [])
   })
 }
 


### PR DESCRIPTION
## Problem

MiniMax-M3 completed the tool-less Vision request successfully, but the active prompt then failed with `The Vision model returned invalid image evidence.` The production stack resolves to the `uncertainty` array parser, after the upstream HTTP 200 and ACP `end_turn`, so the failure is evidence normalization rather than image transport, SQL, or persistence.

The evidence contract requests an empty array when uncertainty is absent. Some model responses represent that empty value as `null`, while the parser only accepted a string or string array.

## Proposed change

- Normalize an explicit `null` `uncertainty` field to the canonical empty array before the existing strict string-array validator.
- Add regression tests that reproduce the production error path with `uncertainty: null`, verify the rendered evidence contains `Uncertainty: []`, and keep a missing required field invalid.
- Continue rejecting objects, mixed arrays, and other invalid evidence shapes.

## Scope and non-goals

- No prompt, provider, transport, renderer, or public interface changes.
- No retry or structured-output framework is added.
- No full local `npm test` run; exact-head PR CI remains the complete-suite authority as requested.

## Historical compatibility

- No historical data migration is required.
- Existing persisted Vision evidence remains valid because the evidence schema version and canonical JSON shape are unchanged.

## State and enum impact

- No status or enum values are added or changed.

## Persistence impact

- No database schema, migration, or persisted format changes.
- A successfully normalized response is persisted in the existing canonical form with `uncertainty: []`; failed responses were not persisted previously.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

| Behavior | Command | Result |
| --- | --- | --- |
| Null Vision uncertainty reproduces and is normalized | `npm test -- src/main/acp/image-input-compatibility-owner.test.ts -t 'accepts a null uncertainty'` | failed before fix with the production `parseEvidence -> stringArray` path; passed after fix |
| Vision relay owner, contracts, and representative consumers | `npm run test:module -- image_input_compatibility` | 7 files, 232 tests passed |
| Main-process TypeScript surface | `npm run typecheck:node` | passed |
| Linted source and tests | `npm run lint` | passed |
| Patch hygiene | `git diff --check` | passed |

The module plan includes prompt content/preparation, restricted inference, evidence persistence, renderer history replay, and Workspace runtime consumers. No platform lane is expected: this is platform-neutral JSON normalization. The live MiniMax response body was not retained by the intentionally ephemeral restricted Session, so no external-model replay was performed locally.

## Review focus

- Confirm that treating explicit null `uncertainty` as the documented empty-list representation is the correct narrow compatibility boundary.
- Confirm that strict rejection remains intact for non-null invalid evidence shapes.

Follow-up to #1314.
