### PR TITLE
fix(specialists): validate IDs while typing

### DIFF
--- a/src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx
@@ -425,7 +425,7 @@ describe('SpecialistEditor', () => {
     )
   })
 
-  it('blocks creation when a user-provided ID is invalid', async () => {
+  it('validates a user-provided ID while typing and blocks invalid creation', async () => {
     const onSave = vi.fn().mockResolvedValue(undefined)
     await act(async () => {
       root.render(<SpecialistEditor onCancel={vi.fn()} onSave={onSave} />)
@@ -443,8 +443,27 @@ describe('SpecialistEditor', () => {
     })
     await act(async () => {
       fireEvent.change(document.body.querySelector<HTMLInputElement>('#sp-specialist-id')!, {
-        target: { value: 'RNA Reviewer' }
+        target: { value: 'hello ee' }
       })
+    })
+
+    const idInput = document.body.querySelector<HTMLInputElement>('#sp-specialist-id')!
+    expect(idInput.getAttribute('aria-invalid')).toBe('true')
+    expect(document.body.textContent).toContain(
+      'ID may only contain lowercase letters, numbers, and hyphens.'
+    )
+
+    await act(async () => {
+      fireEvent.change(idInput, { target: { value: 'hello-ee' } })
+    })
+
+    expect(idInput.getAttribute('aria-invalid')).toBeNull()
+    expect(document.body.textContent).not.toContain(
+      'ID may only contain lowercase letters, numbers, and hyphens.'
+    )
+
+    await act(async () => {
+      fireEvent.change(idInput, { target: { value: 'hello ee' } })
       Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
         .find((button) => button.textContent === 'Create specialist')
         ?.click()

--- a/src/renderer/src/pages/settings/SpecialistEditor.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.tsx
@@ -786,9 +786,21 @@ const SpecialistEditor = ({
                     aria-invalid={idError ? true : undefined}
                     aria-describedby="sp-specialist-id-help"
                     onChange={(event) => {
+                      const id = event.target.value
+                      const idErrors = id.trim()
+                        ? validateCreateSpecialistInput(
+                            { id: id.trim(), name: form.name },
+                            existingNames,
+                            undefined,
+                            existingIds
+                          ).filter((error) => error.field === 'id')
+                        : []
                       setIdTouched(true)
-                      setForm((previous) => ({ ...previous, id: event.target.value }))
-                      setFieldErrors((previous) => previous.filter((error) => error.field !== 'id'))
+                      setForm((previous) => ({ ...previous, id }))
+                      setFieldErrors((previous) => [
+                        ...previous.filter((error) => error.field !== 'id'),
+                        ...idErrors
+                      ])
                     }}
                   />
                   <p


### PR DESCRIPTION
## Problem

The Specialist editor only validated a custom ID during submission. While the user was typing, it cleared the previous ID error without recalculating it, so invalid characters could appear valid until **Create specialist** was clicked.

## Proposed change

Validate edited Specialist IDs on every input change with the existing shared create validator. Surface only ID-specific errors, clear them immediately once the value becomes valid, and keep final submission validation authoritative.

## Scope and non-goals

- Reuses the existing format, reserved-prefix, and uniqueness rules.
- Adds no validation rules or user-visible strings.
- Keeps an empty ID equivalent to automatic generation.
- Requires no historical-data migration.
- Changes no persistent fields, schema versions, or lifecycle enum values.
- Leaves Connector ID generation to a separate PR.

## Acceptance criteria and validation

The following checks ran after the last material edit:

- Invalid custom IDs show an error immediately while typing.
- Replacing an invalid ID with a valid value clears the error immediately.
- An invalid ID still blocks final submission.
- `npm test -- src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx` — 18 tests passed.
- `npm run typecheck:web` — passed.
- `npm run lint` — passed.
- `git diff --check origin/main...HEAD` — passed.
- GitHub PR Gate and CodeQL checks — passed.

The change is confined to the Specialist renderer form and its render test. It does not modify shared interfaces, preload/main behavior, persistence, or platform-specific code.

## Review focus

Confirm that live validation matches final submission for ID format, reserved prefixes, and uniqueness, and that clearing the field still selects automatic ID generation.
