### PR TITLE
fix(acp): renew session resume timeout on provider progress

### DIFF
--- a/src/main/acp/provider-session-resumer.test.ts
+++ b/src/main/acp/provider-session-resumer.test.ts
@@ -67,6 +67,7 @@ type ResumerHarness = {
   attachSession: ReturnType<typeof vi.fn>
   commit: ReturnType<typeof vi.fn>
   clearLivePermissionProfile: ReturnType<typeof vi.fn>
+  clearTimer: ReturnType<typeof vi.fn>
   configure: ReturnType<typeof vi.fn>
   configurePermissionProfile: ReturnType<typeof vi.fn>
   connection: ClientConnection
@@ -74,6 +75,7 @@ type ResumerHarness = {
   fireTimeout: () => void
   identityClaimedAtAdoption: () => boolean
   order: string[]
+  observeProgress: (providerSessionId: string) => void
   providerSession: ActiveSession
   provision: ReturnType<typeof vi.fn>
   registry: AcpSessionRegistry
@@ -211,6 +213,7 @@ const createHarness = (options: HarnessOptions = {}): ResumerHarness => {
     timerCallback = callback
     return {} as ReturnType<typeof setTimeout>
   })
+  const clearTimer = vi.fn()
   const assertCurrentConnection = vi.fn()
   const clearLivePermissionProfile = vi.fn()
   const provision = vi.fn(async () => {
@@ -271,7 +274,7 @@ const createHarness = (options: HarnessOptions = {}): ResumerHarness => {
     },
     resumeTimeoutMs: 60_000,
     setTimer,
-    clearTimer: () => undefined,
+    clearTimer,
     diagnosticContext: () => ({})
   })
   const resume = (
@@ -291,6 +294,7 @@ const createHarness = (options: HarnessOptions = {}): ResumerHarness => {
     backend: capturingBackend,
     commit,
     clearLivePermissionProfile,
+    clearTimer,
     configure,
     configurePermissionProfile,
     connection,
@@ -298,6 +302,7 @@ const createHarness = (options: HarnessOptions = {}): ResumerHarness => {
     fireTimeout: () => timerCallback?.(),
     identityClaimedAtAdoption: () => identityClaimedAtAdoption,
     order,
+    observeProgress: (providerSessionId) => resumer.observeProgress(providerSessionId),
     providerSession,
     provision,
     registry,
@@ -501,6 +506,39 @@ describe('AcpProviderSessionResumer', () => {
     expect(harness.setTimer).toHaveBeenNthCalledWith(1, expect.any(Function), 60_000)
     expect(harness.setTimer).toHaveBeenNthCalledWith(2, expect.any(Function), 60_000)
     expect(harness.disconnectTimedOutConnection).toHaveBeenCalledOnce()
+  })
+
+  it('renews only the matching provider resume inactivity budget', async () => {
+    const harness = createHarness()
+    const finishResume = Promise.withResolvers<{ sessionId: string }>()
+    harness.request.mockImplementationOnce(() => finishResume.promise)
+
+    const resumed = harness.resume({ providerSessionId: 'provider-session' })
+    await vi.waitFor(() => expect(harness.request).toHaveBeenCalledOnce())
+    expect(harness.setTimer).toHaveBeenCalledTimes(2)
+
+    harness.observeProgress('unrelated-session')
+    expect(harness.setTimer).toHaveBeenCalledTimes(2)
+
+    harness.observeProgress('provider-session')
+    expect(harness.setTimer).toHaveBeenCalledTimes(3)
+    expect(harness.setTimer).toHaveBeenLastCalledWith(expect.any(Function), 60_000)
+
+    finishResume.resolve({ sessionId: 'provider-session' })
+    await expect(resumed).resolves.toMatchObject({ sessionId: 'stable-app-session' })
+  })
+
+  it('stops observing provider progress after resume settles', async () => {
+    const harness = createHarness()
+
+    await harness.resume({ providerSessionId: 'provider-session' })
+    const timerCount = harness.setTimer.mock.calls.length
+    const clearCount = harness.clearTimer.mock.calls.length
+
+    harness.observeProgress('provider-session')
+
+    expect(harness.setTimer).toHaveBeenCalledTimes(timerCount)
+    expect(harness.clearTimer).toHaveBeenCalledTimes(clearCount)
   })
 
   it('transfers its reservation to fresh adoption when Resume Policy rejects the backend', async () => {

--- a/src/main/acp/provider-session-resumer.ts
+++ b/src/main/acp/provider-session-resumer.ts
@@ -79,8 +79,15 @@ type AcpProviderSessionResumerDependencies = Readonly<{
 export class AcpProviderSessionResumer {
   private readonly policy = new AcpSessionResumePolicy()
   private readonly presentation = new AcpSessionPresentationPolicy()
+  private readonly progressObservers = new Map<string, Set<() => void>>()
 
   constructor(private readonly deps: AcpProviderSessionResumerDependencies) {}
+
+  observeProgress(providerSessionId: string): void {
+    const observers = this.progressObservers.get(providerSessionId)
+    if (!observers) return
+    for (const observer of observers) observer()
+  }
 
   async resume(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse> {
     const attached = this.deps.registry.lookup(request.sessionId)?.attachment
@@ -96,8 +103,9 @@ export class AcpProviderSessionResumer {
       const connection = await this.withTimeout(() => this.deps.ensureConnected(cwd))
       this.deps.assertCurrentConnection(connection)
       identity.renew()
-      return await this.withTimeout(() =>
-        this.resumeConnected(request, connection, cwd, projectId, identity)
+      return await this.withTimeout(
+        () => this.resumeConnected(request, connection, cwd, projectId, identity),
+        this.progressSessionIds(request)
       )
     } finally {
       identity.release()
@@ -155,15 +163,27 @@ export class AcpProviderSessionResumer {
     }
   }
 
-  private async withTimeout<Result>(operation: () => Promise<Result>): Promise<Result> {
+  private async withTimeout<Result>(
+    operation: () => Promise<Result>,
+    progressSessionIds: readonly string[] = []
+  ): Promise<Result> {
     let timer: ReturnType<typeof setTimeout> | undefined
     let timedOut = false
+    let settled = false
+    let rejectTimeout!: (error: Error) => void
     const timeout = new Promise<never>((_resolve, reject) => {
+      rejectTimeout = reject
+    })
+    const renewTimeout = (): void => {
+      if (settled || timedOut) return
+      if (timer !== undefined) this.deps.clearTimer(timer)
       timer = this.deps.setTimer(() => {
         timedOut = true
-        reject(new Error('ACP session resume timed out.'))
+        rejectTimeout(new Error('ACP session resume timed out.'))
       }, this.deps.resumeTimeoutMs)
-    })
+    }
+    const unsubscribe = this.subscribeToProgress(progressSessionIds, renewTimeout)
+    renewTimeout()
 
     try {
       return await Promise.race([operation(), timeout])
@@ -171,7 +191,35 @@ export class AcpProviderSessionResumer {
       if (timedOut) await this.deps.disconnectTimedOutConnection()
       throw error
     } finally {
+      settled = true
+      unsubscribe()
       if (timer !== undefined) this.deps.clearTimer(timer)
+    }
+  }
+
+  private progressSessionIds(request: AcpResumeSessionRequest): string[] {
+    const registeredProviderSessionId = this.deps.registry
+      .lookup(request.sessionId)
+      ?.aggregate.snapshot().providerSessionId
+    return [request.sessionId, request.providerSessionId, registeredProviderSessionId].filter(
+      (sessionId): sessionId is string => typeof sessionId === 'string' && sessionId.length > 0
+    )
+  }
+
+  private subscribeToProgress(sessionIds: readonly string[], observer: () => void): () => void {
+    const subscribedIds = [...new Set(sessionIds)]
+    for (const sessionId of subscribedIds) {
+      const observers = this.progressObservers.get(sessionId) ?? new Set<() => void>()
+      observers.add(observer)
+      this.progressObservers.set(sessionId, observers)
+    }
+    return () => {
+      for (const sessionId of subscribedIds) {
+        const observers = this.progressObservers.get(sessionId)
+        if (!observers) continue
+        observers.delete(observer)
+        if (observers.size === 0) this.progressObservers.delete(sessionId)
+      }
     }
   }
 

--- a/src/main/acp/runtime-provider-session-composition.test.ts
+++ b/src/main/acp/runtime-provider-session-composition.test.ts
@@ -10,6 +10,27 @@ import {
 import { composeAcpRuntimeSessionOwners } from './runtime-session-composition'
 
 describe('ACP Runtime Provider Session composition', () => {
+  it('uses a five-minute default resume inactivity budget', () => {
+    const options = { appVersion: 'test', defaultCwd: '/workspace' }
+    const base = composeAcpRuntimeBaseOwners(options)
+    const session = composeAcpRuntimeSessionOwners(options, base)
+    const lifecycle = composeAcpRuntimeLifecycleOwners(options, base, session, {
+      connect: vi.fn(async () => session.publication.getSnapshot()),
+      disconnect: vi.fn(async () => session.publication.getSnapshot()),
+      openAgentConnection: vi.fn(async () => {
+        throw new Error('not called during composition')
+      })
+    })
+    const owners = composeAcpRuntimeProviderSessionOwners(options, base, session, lifecycle, {
+      clearUserChoiceProvenanceForSession: vi.fn()
+    })
+    const dependencies = (
+      owners.providerSessionResumer as unknown as { deps: { resumeTimeoutMs: number } }
+    ).deps
+
+    expect(dependencies.resumeTimeoutMs).toBe(5 * 60_000)
+  })
+
   it('builds a fresh frozen graph without invoking host operations', async () => {
     const options = { appVersion: 'test', defaultCwd: '/workspace' }
     const create = (): {

--- a/src/main/acp/runtime-provider-session-composition.ts
+++ b/src/main/acp/runtime-provider-session-composition.ts
@@ -174,7 +174,7 @@ const composeAcpRuntimeProviderSessionOwners = (
     updateCwd,
     pushEvent: (event) => session.publication.pushEvent(event),
     emitState,
-    resumeTimeoutMs: options.resumeTimeoutMs ?? 60_000,
+    resumeTimeoutMs: options.resumeTimeoutMs ?? 5 * 60_000,
     setTimer: base.setTimer,
     clearTimer: base.clearTimer,
     diagnosticContext

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -15804,6 +15804,94 @@ describe('ACP runtime session management', () => {
     expect(process.killed).toBe(true)
   })
 
+  it.each(['session-update', 'claude-sdk-message'] as const)(
+    'keeps a pending session/resume alive on %s progress',
+    async (progressKind) => {
+      const process = new FakeAgentProcess()
+      const resumeReceived = createDeferred()
+      const emitProgress = createDeferred()
+      const progressSent = createDeferred()
+      const finishResume = createDeferred<Record<string, never>>()
+
+      acp
+        .agent({ name: 'progressing-agent' })
+        .onRequest(acp.methods.agent.initialize, () => ({
+          protocolVersion: acp.PROTOCOL_VERSION,
+          agentCapabilities: {
+            loadSession: false,
+            sessionCapabilities: { close: {}, resume: {} }
+          },
+          authMethods: []
+        }))
+        .onRequest(acp.methods.agent.session.resume, async (ctx) => {
+          resumeReceived.resolve(undefined)
+          await emitProgress.promise
+          if (progressKind === 'session-update') {
+            await ctx.client.notify(acp.methods.client.session.update, {
+              sessionId: ctx.params.sessionId,
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'restoring history' }
+              }
+            })
+          } else {
+            await ctx.client.notify('_claude/sdkMessage', {
+              sessionId: ctx.params.sessionId,
+              message: { type: 'progress', text: 'restoring history' }
+            })
+          }
+          progressSent.resolve(undefined)
+          return finishResume.promise
+        })
+        .connect(
+          acp.ndJsonStream(
+            Writable.toWeb(process.stdout) as WritableStream<Uint8Array>,
+            Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+          )
+        )
+
+      let now = 0
+      const timers: Array<{ active: boolean; deadline: number; fire: () => void }> = []
+      const advanceBy = (elapsedMs: number): void => {
+        now += elapsedMs
+        for (const timer of timers) {
+          if (timer.active && timer.deadline <= now) {
+            timer.active = false
+            timer.fire()
+          }
+        }
+      }
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process),
+        resumeTimeoutMs: 1000,
+        setTimer: (fire, timeoutMs) => {
+          const handle = timers.length
+          timers.push({ active: true, deadline: now + timeoutMs, fire })
+          return handle as unknown as ReturnType<typeof setTimeout>
+        },
+        clearTimer: (handle) => {
+          const timer = timers[handle as unknown as number]
+          if (timer) timer.active = false
+        }
+      })
+
+      const resume = runtime.resumeSession({ sessionId: 'streaming-session', cwd: '/workspace' })
+      await resumeReceived.promise
+      advanceBy(900)
+      emitProgress.resolve(undefined)
+      await progressSent.promise
+
+      // The original deadline has passed, but provider activity renewed the inactivity budget.
+      advanceBy(200)
+      finishResume.resolve({})
+
+      await expect(resume).resolves.toMatchObject({ sessionId: 'streaming-session' })
+      expect(process.killed).toBe(false)
+    }
+  )
+
   it('adopts a fresh session under the same id when a replaced agent no longer holds it', async () => {
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['adopted-session-1'], { resumeNotFound: true })

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -215,8 +215,9 @@ type AcpRuntimeOptions = {
   // Local http host for app-owned session MCP servers, used for frameworks that reject stdio MCP.
   // Absent ⇒ those frameworks run without the corresponding app tooling.
   mcpHttpHost?: AgentMcpHttpHost
-  // Bounds the network-bound reconnect+resume so Resume always resolves; the fast attached-session
-  // path is never timed. Injectable timer mirrors the approval broker so tests stay deterministic.
+  // Bounds inactivity while reconnecting or resuming. Target-session provider events renew the
+  // resume deadline; the fast attached-session path is never timed. Injectable timers keep tests
+  // deterministic.
   resumeTimeoutMs?: number
   cancelTimeoutMs?: number
   setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
@@ -986,8 +987,10 @@ class AcpRuntime {
     const hooks: AcpAgentConnectionHooks = {
       createElicitation: (params) => this.clientInteractions.createElicitation(params),
       requestPermission: (params) => this.clientInteractions.requestPermission(params),
-      observeSessionUpdate: (notification) =>
-        this.permissionContext.observeProviderUpdate(notification),
+      observeSessionUpdate: (notification) => {
+        this.providerSessionResumer.observeProgress(notification.sessionId)
+        this.permissionContext.observeProviderUpdate(notification)
+      },
       observeClaudeSdkMessage: (params) => this.observeClaudeSdkMessage(params),
       filesystem: {
         resolveSessionCwd: (sessionId) => this.resolveSessionCwd(sessionId),
@@ -2101,6 +2104,9 @@ class AcpRuntime {
   }
 
   private observeClaudeSdkMessage(params: Record<string, unknown>): void {
+    if (typeof params.sessionId === 'string') {
+      this.providerSessionResumer.observeProgress(params.sessionId)
+    }
     this.providerPromptExecutor.observeProviderMessage(params)
   }
 


### PR DESCRIPTION
## Problem

Session resume used a fixed 60-second deadline. Blocking providers could legitimately need longer to restore history, while streaming provider activity did not renew the deadline, so a live resume could be disconnected as timed out.

## Proposed change

- Treat the resume deadline as an inactivity budget.
- Raise the default reconnect/resume inactivity budget to five minutes.
- Renew the budget only for standard ACP session updates or Claude SDK messages belonging to the target application/provider Session.
- Remove progress observers when resume settles; preserve immediate provider, process, and connection failures.

The shared ACP runtime applies this behavior to Claude Code, OpenCode, Codex Responses, and Codex Bridge.

## Scope and non-goals

- No persistence or schema changes.
- No historical-data compatibility path.
- No new enum or durable status values.
- A progress event proves liveness but does not mark resume successful before the formal session/resume response arrives.

## Acceptance criteria and validation

Checks below ran after the final material edit:

- Resume timeout behavior, matching/unrelated Session progress, observer cleanup, standard ACP updates, Claude SDK progress, and five-minute composition default -> npm test -- src/main/acp/provider-session-resumer.test.ts src/main/acp/runtime-provider-session-composition.test.ts src/main/acp/runtime.test.ts -> 575 passed.
- Main-process TypeScript contracts -> npm run typecheck:node -> passed.
- Source lint -> npm run lint -> passed.
- Final affected-test classification -> npm run test:affected:explain -- --base origin/main --head HEAD -> full fallback because core ACP files are not assigned to a module owner. Per maintainer direction, the complete suite is left to PR CI.

No renderer, persistence, database, platform-specific path, or public wire contract changed, so web typecheck, persistence/migration, and local platform lanes were excluded.

## Review focus

- Progress is scoped to the target stable/provider Session ids.
- Timer renewal and observer cleanup remain race-safe when resume settles or times out.
- Blocking providers get a longer quiet period without weakening immediate transport failure handling.
