### PR TITLE
fix(projects): isolate failed deletion recovery

### DIFF
--- a/src/main/project-files/ipc.test.ts
+++ b/src/main/project-files/ipc.test.ts
@@ -58,7 +58,7 @@ describe('project files IPC handlers', () => {
         repairProjectFiles: vi.fn().mockResolvedValue(undefined)
       },
       {
-        recoverPendingDeletions: vi.fn().mockResolvedValue(undefined)
+        waitForProjectOperations: vi.fn().mockResolvedValue(undefined)
       }
     )
     const filesRequest = {
@@ -98,7 +98,7 @@ describe('project files IPC handlers', () => {
     }
     const repair = { repairProjectFiles: vi.fn().mockResolvedValue(undefined) }
     const handlers = createProjectFilesHandlers(repository, repair, {
-      recoverPendingDeletions: vi.fn().mockResolvedValue(undefined)
+      waitForProjectOperations: vi.fn().mockResolvedValue(undefined)
     })
 
     await handlers.repairIndex({ projectId: 'project-1' })
@@ -138,7 +138,7 @@ describe('project files IPC handlers', () => {
       })
     }
     const recovery = {
-      recoverPendingDeletions: vi.fn(async () => {
+      waitForProjectOperations: vi.fn(async () => {
         order.push('recover')
       })
     }
@@ -153,7 +153,7 @@ describe('project files IPC handlers', () => {
     await handlers.listArtifactGroups({ projectId: 'project-1', limit: 10 })
     await handlers.searchArtifacts({
       primaryProjectId: 'project-1',
-      otherProjectIds: [],
+      otherProjectIds: ['project-2'],
       primaryLimit: 8,
       otherLimit: 0
     })
@@ -171,6 +171,11 @@ describe('project files IPC handlers', () => {
       'recover',
       'repair'
     ])
+    expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(1, ['project-1'])
+    expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(2, ['project-1'])
+    expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(3, ['project-1'])
+    expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(4, ['project-1', 'project-2'])
+    expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(5, ['project-1'])
   })
 })
 
@@ -200,7 +205,7 @@ describe('registerProjectFilesIpcHandlers', () => {
       })
     }
     repairBackend = { repairProjectFiles: vi.fn().mockResolvedValue(undefined) }
-    recoveryBackend = { recoverPendingDeletions: vi.fn().mockResolvedValue(undefined) }
+    recoveryBackend = { waitForProjectOperations: vi.fn().mockResolvedValue(undefined) }
   })
 
   it('registers every project-files IPC channel', () => {
@@ -236,7 +241,7 @@ describe('registerProjectFilesIpcHandlers', () => {
     )
     expect(injected.getOverview).toHaveBeenCalledWith({ projectId: 'project-1' })
     expect(repository.getOverview).not.toHaveBeenCalled()
-    expect(recoveryBackend.recoverPendingDeletions).not.toHaveBeenCalled()
+    expect(recoveryBackend.waitForProjectOperations).not.toHaveBeenCalled()
   })
 
   it('preserves an injected handler identity when registration fails', async () => {
@@ -289,7 +294,7 @@ describe('registerProjectFilesIpcHandlers', () => {
       repairProjectFiles: vi.fn()
     }
     const localRecovery: ProjectFilesRecoveryBackend = {
-      recoverPendingDeletions: vi.fn(async () => {
+      waitForProjectOperations: vi.fn(async () => {
         order.push('recover')
       })
     }
@@ -316,7 +321,7 @@ describe('registerProjectFilesIpcHandlers', () => {
       repairProjectFiles: vi.fn()
     }
     const localRecovery: ProjectFilesRecoveryBackend = {
-      recoverPendingDeletions: vi.fn(async () => {
+      waitForProjectOperations: vi.fn(async () => {
         order.push('recover')
       })
     }
@@ -348,7 +353,7 @@ describe('registerProjectFilesIpcHandlers', () => {
       repairProjectFiles: vi.fn()
     }
     const localRecovery: ProjectFilesRecoveryBackend = {
-      recoverPendingDeletions: vi.fn(async () => {
+      waitForProjectOperations: vi.fn(async () => {
         order.push('recover')
       })
     }
@@ -375,7 +380,7 @@ describe('registerProjectFilesIpcHandlers', () => {
       })
     }
     const localRecovery: ProjectFilesRecoveryBackend = {
-      recoverPendingDeletions: vi.fn(async () => {
+      waitForProjectOperations: vi.fn(async () => {
         order.push('recover')
       })
     }
@@ -391,7 +396,7 @@ describe('registerProjectFilesIpcHandlers', () => {
     // Each handler in the registered table must go through the same gate; this protects against
     // accidentally bypassing recovery by registering a handler that calls the backend directly.
     registerProjectFilesIpcHandlers(repository, repairBackend, recoveryBackend)
-    ;(recoveryBackend.recoverPendingDeletions as ReturnType<typeof vi.fn>).mockClear()
+    ;(recoveryBackend.waitForProjectOperations as ReturnType<typeof vi.fn>).mockClear()
 
     await invoke('project-files:get-overview', { projectId: 'p1' })
     await invoke('project-files:list-files', {
@@ -402,7 +407,7 @@ describe('registerProjectFilesIpcHandlers', () => {
     await invoke('project-files:list-artifact-groups', { projectId: 'p1', limit: 1 })
     await invoke('project-files:repair-index', { projectId: 'p1' })
 
-    expect(recoveryBackend.recoverPendingDeletions).toHaveBeenCalledTimes(4)
+    expect(recoveryBackend.waitForProjectOperations).toHaveBeenCalledTimes(4)
   })
 })
 

--- a/src/main/project-files/ipc.test.ts
+++ b/src/main/project-files/ipc.test.ts
@@ -58,6 +58,7 @@ describe('project files IPC handlers', () => {
         repairProjectFiles: vi.fn().mockResolvedValue(undefined)
       },
       {
+        recoverPendingDeletions: vi.fn().mockResolvedValue(undefined),
         waitForProjectOperations: vi.fn().mockResolvedValue(undefined)
       }
     )
@@ -98,12 +99,34 @@ describe('project files IPC handlers', () => {
     }
     const repair = { repairProjectFiles: vi.fn().mockResolvedValue(undefined) }
     const handlers = createProjectFilesHandlers(repository, repair, {
+      recoverPendingDeletions: vi.fn().mockResolvedValue(undefined),
       waitForProjectOperations: vi.fn().mockResolvedValue(undefined)
     })
 
     await handlers.repairIndex({ projectId: 'project-1' })
 
     expect(repair.repairProjectFiles).toHaveBeenCalledWith('project-1')
+  })
+
+  it('keeps global index repair behind strict deletion recovery', async () => {
+    const recoveryFailure = new Error('another Project deletion is incomplete')
+    const repository = {
+      getOverview: vi.fn(),
+      listFiles: vi.fn(),
+      listArtifactGroups: vi.fn(),
+      searchArtifacts: vi.fn()
+    }
+    const repair = { repairProjectFiles: vi.fn().mockResolvedValue(undefined) }
+    const recovery = {
+      waitForProjectOperations: vi.fn().mockResolvedValue(undefined),
+      recoverPendingDeletions: vi.fn().mockRejectedValue(recoveryFailure)
+    }
+    const handlers = createProjectFilesHandlers(repository, repair, recovery)
+
+    await expect(handlers.repairIndex({ projectId: 'project-1' })).rejects.toBe(recoveryFailure)
+
+    expect(recovery.waitForProjectOperations).not.toHaveBeenCalled()
+    expect(repair.repairProjectFiles).not.toHaveBeenCalled()
   })
 
   it('waits for deletion recovery before every files query or repair', async () => {
@@ -138,6 +161,9 @@ describe('project files IPC handlers', () => {
       })
     }
     const recovery = {
+      recoverPendingDeletions: vi.fn(async () => {
+        order.push('recover')
+      }),
       waitForProjectOperations: vi.fn(async () => {
         order.push('recover')
       })
@@ -175,7 +201,7 @@ describe('project files IPC handlers', () => {
     expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(2, ['project-1'])
     expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(3, ['project-1'])
     expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(4, ['project-1', 'project-2'])
-    expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(5, ['project-1'])
+    expect(recovery.recoverPendingDeletions).toHaveBeenCalledOnce()
   })
 })
 
@@ -205,7 +231,10 @@ describe('registerProjectFilesIpcHandlers', () => {
       })
     }
     repairBackend = { repairProjectFiles: vi.fn().mockResolvedValue(undefined) }
-    recoveryBackend = { waitForProjectOperations: vi.fn().mockResolvedValue(undefined) }
+    recoveryBackend = {
+      recoverPendingDeletions: vi.fn().mockResolvedValue(undefined),
+      waitForProjectOperations: vi.fn().mockResolvedValue(undefined)
+    }
   })
 
   it('registers every project-files IPC channel', () => {
@@ -294,6 +323,7 @@ describe('registerProjectFilesIpcHandlers', () => {
       repairProjectFiles: vi.fn()
     }
     const localRecovery: ProjectFilesRecoveryBackend = {
+      recoverPendingDeletions: vi.fn().mockResolvedValue(undefined),
       waitForProjectOperations: vi.fn(async () => {
         order.push('recover')
       })
@@ -321,6 +351,7 @@ describe('registerProjectFilesIpcHandlers', () => {
       repairProjectFiles: vi.fn()
     }
     const localRecovery: ProjectFilesRecoveryBackend = {
+      recoverPendingDeletions: vi.fn().mockResolvedValue(undefined),
       waitForProjectOperations: vi.fn(async () => {
         order.push('recover')
       })
@@ -353,6 +384,7 @@ describe('registerProjectFilesIpcHandlers', () => {
       repairProjectFiles: vi.fn()
     }
     const localRecovery: ProjectFilesRecoveryBackend = {
+      recoverPendingDeletions: vi.fn().mockResolvedValue(undefined),
       waitForProjectOperations: vi.fn(async () => {
         order.push('recover')
       })
@@ -380,9 +412,10 @@ describe('registerProjectFilesIpcHandlers', () => {
       })
     }
     const localRecovery: ProjectFilesRecoveryBackend = {
-      waitForProjectOperations: vi.fn(async () => {
+      recoverPendingDeletions: vi.fn(async () => {
         order.push('recover')
-      })
+      }),
+      waitForProjectOperations: vi.fn().mockResolvedValue(undefined)
     }
     registerProjectFilesIpcHandlers(localRepository, localRepair, localRecovery)
 
@@ -397,6 +430,7 @@ describe('registerProjectFilesIpcHandlers', () => {
     // accidentally bypassing recovery by registering a handler that calls the backend directly.
     registerProjectFilesIpcHandlers(repository, repairBackend, recoveryBackend)
     ;(recoveryBackend.waitForProjectOperations as ReturnType<typeof vi.fn>).mockClear()
+    ;(recoveryBackend.recoverPendingDeletions as ReturnType<typeof vi.fn>).mockClear()
 
     await invoke('project-files:get-overview', { projectId: 'p1' })
     await invoke('project-files:list-files', {
@@ -407,7 +441,8 @@ describe('registerProjectFilesIpcHandlers', () => {
     await invoke('project-files:list-artifact-groups', { projectId: 'p1', limit: 1 })
     await invoke('project-files:repair-index', { projectId: 'p1' })
 
-    expect(recoveryBackend.waitForProjectOperations).toHaveBeenCalledTimes(4)
+    expect(recoveryBackend.waitForProjectOperations).toHaveBeenCalledTimes(3)
+    expect(recoveryBackend.recoverPendingDeletions).toHaveBeenCalledOnce()
   })
 })
 

--- a/src/main/project-files/ipc.ts
+++ b/src/main/project-files/ipc.ts
@@ -23,6 +23,7 @@ type ProjectFilesRepairBackend = {
 }
 
 type ProjectFilesRecoveryBackend = {
+  recoverPendingDeletions(): Promise<void>
   waitForProjectOperations(projectIds: readonly string[]): Promise<void>
 }
 
@@ -61,7 +62,9 @@ const createProjectFilesHandlers = (
     return repository.searchArtifacts(request)
   },
   repairIndex: async ({ projectId }) => {
-    await recoveryBackend.waitForProjectOperations([projectId])
+    // repairProjectFiles performs a complete Session scan and global projection reconciliation.
+    // Keep it behind strict recovery so it cannot touch another Project with a failed deletion tail.
+    await recoveryBackend.recoverPendingDeletions()
     return repairBackend.repairProjectFiles(projectId)
   }
 })

--- a/src/main/project-files/ipc.ts
+++ b/src/main/project-files/ipc.ts
@@ -23,7 +23,7 @@ type ProjectFilesRepairBackend = {
 }
 
 type ProjectFilesRecoveryBackend = {
-  recoverPendingDeletions(): Promise<void>
+  waitForProjectOperations(projectIds: readonly string[]): Promise<void>
 }
 
 type ProjectFilesHandlers = {
@@ -34,37 +34,41 @@ type ProjectFilesHandlers = {
   repairIndex(request: { projectId: string }): Promise<void>
 }
 
-// Keep recovery waiting inside the testable handler layer so direct IPC registration cannot bypass the
-// sticky deletion gate for reads or repair.
+// Keep Project-scoped recovery admission inside the testable handler layer so direct IPC registration
+// cannot bypass the deletion gate for reads or repair.
 const createProjectFilesHandlers = (
   repository: ProjectFilesQueryRepository,
   repairBackend: ProjectFilesRepairBackend,
   recoveryBackend: ProjectFilesRecoveryBackend
 ): ProjectFilesHandlers => ({
   getOverview: async (request) => {
-    await recoveryBackend.recoverPendingDeletions()
+    await recoveryBackend.waitForProjectOperations([request.projectId])
     return repository.getOverview(request)
   },
   listFiles: async (request) => {
-    await recoveryBackend.recoverPendingDeletions()
+    await recoveryBackend.waitForProjectOperations([request.projectId])
     return repository.listFiles(request)
   },
   listArtifactGroups: async (request) => {
-    await recoveryBackend.recoverPendingDeletions()
+    await recoveryBackend.waitForProjectOperations([request.projectId])
     return repository.listArtifactGroups(request)
   },
   searchArtifacts: async (request) => {
-    await recoveryBackend.recoverPendingDeletions()
+    await recoveryBackend.waitForProjectOperations([
+      request.primaryProjectId,
+      ...request.otherProjectIds
+    ])
     return repository.searchArtifacts(request)
   },
   repairIndex: async ({ projectId }) => {
-    await recoveryBackend.recoverPendingDeletions()
+    await recoveryBackend.waitForProjectOperations([projectId])
     return repairBackend.repairProjectFiles(projectId)
   }
 })
 
-// All Files operations wait on the same project-deletion recovery gate before reading or repairing
-// metadata. This prevents a query from observing rows midway through crash recovery.
+// All Files operations wait on Project-scoped deletion recovery before reading or repairing metadata.
+// This prevents a query from observing its Project midway through crash recovery without coupling it
+// to failed deletion tails owned by other Projects.
 const registerProjectFilesIpcHandlers = (
   repository: ProjectFilesQueryRepository,
   repairBackend: ProjectFilesRepairBackend,

--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -859,6 +859,16 @@ describe('ProjectDeletionCoordinator', () => {
     expect(projects.listDeletionIntents).toHaveBeenCalledOnce()
   })
 
+  it('restores sticky recovery completion after deletion without suppressed failures', async () => {
+    const projects = createProjects()
+    const coordinator = new ProjectDeletionCoordinator(projects, createSessions())
+
+    await coordinator.deleteProject('project-1')
+    await coordinator.waitForProjectOperations([])
+
+    expect(projects.listDeletionIntents).toHaveBeenCalledOnce()
+  })
+
   it('makes concurrent recovery wait for a newly started deletion', async () => {
     const deletionGate = createDeferred<void>()
     const coordinator = new ProjectDeletionCoordinator(

--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -680,8 +680,14 @@ describe('ProjectDeletionCoordinator', () => {
 
     await expect(coordinator.deleteProject('project-2')).resolves.toBeUndefined()
 
+    await expect(coordinator.waitForProjectOperations(['project-1'])).rejects.toThrow(
+      'tail cleanup unavailable'
+    )
+
     expect(projects.createDeletionIntent).toHaveBeenCalledWith('project-2')
     expect(projects.delete).toHaveBeenCalledWith('project-2')
+    expect(sessions.deleteProjectSessions).toHaveBeenCalledWith('project-1')
+    expect(sessions.deleteProjectSessions).toHaveBeenCalledTimes(3)
   })
 
   it('keeps a committed recovery intent when the Project row still exists and replay fails', async () => {

--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -528,6 +528,30 @@ describe('ProjectDeletionCoordinator', () => {
     expect(sessions.completeProjectSessionDeletion).not.toHaveBeenCalled()
   })
 
+  it('continues adopting unrelated legacy tombstones after one cleanup fails', async () => {
+    const projects = createProjects()
+    projects.get = vi.fn().mockResolvedValue(null)
+    const sessions = createSessions({
+      listLegacyProjectSessionTombstones: vi
+        .fn()
+        .mockResolvedValue(['project-old-1', 'project-old-2']),
+      deleteProjectSessions: vi.fn(async (projectId: string) => {
+        if (projectId === 'project-old-1') throw new Error('index temporarily unavailable')
+        return { status: 'completed' as const }
+      })
+    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions)
+
+    await expect(coordinator.recoverPendingDeletions()).rejects.toThrow(
+      'index temporarily unavailable'
+    )
+
+    expect(projects.createDeletionIntent).toHaveBeenCalledWith('project-old-1')
+    expect(projects.createDeletionIntent).toHaveBeenCalledWith('project-old-2')
+    expect(projects.deleteDeletionIntent).not.toHaveBeenCalledWith('project-old-1')
+    expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-old-2')
+  })
+
   it('drops the temporary intent and continues when an adopted orphan must be retained', async () => {
     const projects = createProjects()
     projects.get = vi.fn().mockResolvedValue(null)
@@ -584,9 +608,13 @@ describe('ProjectDeletionCoordinator', () => {
     expect(sessions.completeProjectSessionDeletion).not.toHaveBeenCalled()
   })
 
-  it('retains a failed recovery intent before continuing on the next retry', async () => {
+  it('retains a failed recovery intent while continuing unrelated recovery', async () => {
     const projects = createProjects()
-    projects.listDeletionIntents = vi.fn().mockResolvedValue(['project-1', 'project-2'])
+    const pendingIntents = new Set(['project-1', 'project-2'])
+    projects.listDeletionIntents = vi.fn(async () => [...pendingIntents])
+    projects.deleteDeletionIntent = vi.fn(async (projectId: string) => {
+      pendingIntents.delete(projectId)
+    })
     let projectOneAttempts = 0
     const sessions = createSessions({
       deleteProjectSessions: vi.fn(async (projectId: string) => {
@@ -602,17 +630,58 @@ describe('ProjectDeletionCoordinator', () => {
       'transient session cleanup failure'
     )
 
-    expect(sessions.deleteProjectSessions).toHaveBeenCalledOnce()
-    expect(projects.deleteDeletionIntent).not.toHaveBeenCalled()
+    expect(sessions.deleteProjectSessions).toHaveBeenCalledTimes(2)
+    expect(projects.deleteDeletionIntent).not.toHaveBeenCalledWith('project-1')
     expect(projects.delete).not.toHaveBeenCalledWith('project-1')
-    expect(projects.delete).not.toHaveBeenCalledWith('project-2')
+    expect(projects.delete).toHaveBeenCalledWith('project-2')
+    expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-2')
 
     await expect(coordinator.recoverPendingDeletions()).resolves.toBeUndefined()
 
     expect(sessions.deleteProjectSessions).toHaveBeenCalledTimes(3)
     expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-1')
+  })
+
+  it('admits unrelated Project operations while keeping the failed Project closed', async () => {
+    const projects = createProjects()
+    projects.listDeletionIntents = vi.fn().mockResolvedValue(['project-1'])
+    const sessions = createSessions({
+      deleteProjectSessions: vi.fn().mockRejectedValue(new Error('tail cleanup unavailable'))
+    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions)
+
+    await expect(coordinator.waitForProjectOperations([])).resolves.toBeUndefined()
+    await expect(coordinator.waitForProjectOperations(['project-2'])).resolves.toBeUndefined()
+    await expect(coordinator.waitForProjectOperations(['project-1'])).rejects.toThrow(
+      'tail cleanup unavailable'
+    )
+  })
+
+  it('keeps infrastructure recovery failures global', async () => {
+    const projects = createProjects()
+    projects.listDeletionIntents = vi.fn().mockRejectedValue(new Error('intent store unavailable'))
+    const coordinator = new ProjectDeletionCoordinator(projects, createSessions())
+
+    await expect(coordinator.waitForProjectOperations(['project-2'])).rejects.toThrow(
+      'intent store unavailable'
+    )
+  })
+
+  it('deletes an unrelated Project while another deletion tail remains failed', async () => {
+    const projects = createProjects()
+    projects.listDeletionIntents = vi.fn().mockResolvedValue(['project-1'])
+    const sessions = createSessions({
+      deleteProjectSessions: vi.fn(async (projectId: string) => {
+        if (projectId === 'project-1') throw new Error('tail cleanup unavailable')
+        return { status: 'completed' as const }
+      })
+    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions)
+
+    await expect(coordinator.deleteProject('project-2')).resolves.toBeUndefined()
+
+    expect(projects.createDeletionIntent).toHaveBeenCalledWith('project-2')
     expect(projects.delete).toHaveBeenCalledWith('project-2')
-    expect(projects.deleteDeletionIntent).toHaveBeenCalledWith('project-2')
   })
 
   it('keeps a committed recovery intent when the Project row still exists and replay fails', async () => {
@@ -639,7 +708,7 @@ describe('ProjectDeletionCoordinator', () => {
     })
     const coordinator = new ProjectDeletionCoordinator(projects, sessions)
 
-    await expect(coordinator.recoverPendingDeletions()).rejects.toBe(replayFailure)
+    await expect(coordinator.recoverPendingDeletions()).rejects.toThrow(replayFailure.message)
 
     expect(projects.deleteDeletionIntent).not.toHaveBeenCalled()
   })

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -157,14 +157,10 @@ class ProjectDeletionCoordinator {
     const deletion = this.operationQueue.then(() =>
       withDataRootWrite(async () => {
         await this.waitForProjectOperationsNow([projectId])
+        // A scoped wait may have suppressed failures owned by other Projects. Keep recovery
+        // incomplete after this deletion so those durable intents remain eligible for retry.
         this.isRecoveryComplete = false
-        try {
-          await this.runDeletion(projectId)
-          this.isRecoveryComplete = true
-        } catch (error) {
-          this.isRecoveryComplete = false
-          throw error
-        }
+        await this.runDeletion(projectId)
       })
     )
     this.operationQueue = deletion.catch(() => undefined)

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -49,6 +49,31 @@ type ProjectDeletionRecoveryLoopOptions = {
   onError?: (error: unknown) => void
 }
 
+type ProjectDeletionFailure = {
+  projectId: string
+  error: unknown
+}
+
+class ProjectDeletionRecoveryError extends AggregateError {
+  readonly failures: readonly ProjectDeletionFailure[]
+
+  constructor(failures: readonly ProjectDeletionFailure[]) {
+    const firstError = failures[0]?.error
+    super(
+      failures.map(({ error }) => error),
+      firstError instanceof Error
+        ? firstError.message
+        : `Project deletion recovery failed: ${failures[0]?.projectId ?? 'unknown'}`
+    )
+    this.name = 'ProjectDeletionRecoveryError'
+    this.failures = failures
+  }
+
+  affectsAny(projectIds: ReadonlySet<string>): boolean {
+    return this.failures.some(({ projectId }) => projectIds.has(projectId))
+  }
+}
+
 class ProjectDeletionRecoveryLoop {
   private readonly retryDelayMs: number
   private readonly onError: (error: unknown) => void
@@ -109,7 +134,9 @@ class ProjectDeletionRecoveryLoop {
 }
 
 // Persists deletion intent so a crash cannot strand an absent project with active session data. The
-// same sticky recovery gate is shared by project CRUD, session persistence, and Files queries.
+// the same recovery work is shared by project CRUD, session persistence, and Files queries. Strict
+// recovery reports every failure for background retry; foreground Project/Files admission filters
+// those failures by durable Project ownership.
 class ProjectDeletionCoordinator {
   private operationQueue: Promise<void> = Promise.resolve()
   private recoveryPromise: Promise<void> | undefined
@@ -129,7 +156,7 @@ class ProjectDeletionCoordinator {
   deleteProject(projectId: string): Promise<void> {
     const deletion = this.operationQueue.then(() =>
       withDataRootWrite(async () => {
-        await this.recoverPendingDeletionsNow()
+        await this.waitForProjectOperationsNow([projectId])
         this.isRecoveryComplete = false
         try {
           await this.runDeletion(projectId)
@@ -149,6 +176,14 @@ class ProjectDeletionCoordinator {
   async recoverPendingDeletions(): Promise<void> {
     await this.operationQueue
     return withDataRootWrite(() => this.recoverPendingDeletionsNow())
+  }
+
+  // Foreground operations still drive durable recovery, but a failed tail only denies access to the
+  // Project(s) that own that intent. Infrastructure failures remain global because intent ownership
+  // could not be established safely. An empty set represents Project list/create operations.
+  async waitForProjectOperations(projectIds: readonly string[]): Promise<void> {
+    await this.operationQueue
+    return withDataRootWrite(() => this.waitForProjectOperationsNow(projectIds))
   }
 
   // Restores fail-closed in-memory barriers from local durable authority only. Startup waits for this
@@ -173,9 +208,7 @@ class ProjectDeletionCoordinator {
     if (this.recoveryPromise) return this.recoveryPromise
     if (this.isRecoveryComplete) return
 
-    const recovery = this.runPendingDeletionRecovery().then((retainedProjectIds) =>
-      this.adoptLegacyProjectSessionTombstones(retainedProjectIds)
-    )
+    const recovery = this.recoverEveryPendingDeletion()
     this.recoveryPromise = recovery
     try {
       await recovery
@@ -186,6 +219,25 @@ class ProjectDeletionCoordinator {
     } finally {
       if (this.recoveryPromise === recovery) this.recoveryPromise = undefined
     }
+  }
+
+  private async waitForProjectOperationsNow(projectIds: readonly string[]): Promise<void> {
+    try {
+      await this.recoverPendingDeletionsNow()
+    } catch (error) {
+      if (!(error instanceof ProjectDeletionRecoveryError)) throw error
+      if (error.affectsAny(new Set(projectIds))) throw error
+    }
+  }
+
+  private async recoverEveryPendingDeletion(): Promise<void> {
+    const { projectIds, retainedProjectIds, failures } = await this.runPendingDeletionRecovery()
+    failures.push(
+      ...(await this.adoptLegacyProjectSessionTombstones(
+        new Set([...projectIds, ...retainedProjectIds])
+      ))
+    )
+    if (failures.length > 0) throw new ProjectDeletionRecoveryError(failures)
   }
 
   // Install the non-destructive admission fence before committing deletion intent, then persist
@@ -218,55 +270,70 @@ class ProjectDeletionCoordinator {
   }
 
   // Replays intents serially so crash recovery follows the same ordering as an online deletion.
-  private async runPendingDeletionRecovery(): Promise<Set<string>> {
+  private async runPendingDeletionRecovery(): Promise<{
+    projectIds: readonly string[]
+    retainedProjectIds: Set<string>
+    failures: ProjectDeletionFailure[]
+  }> {
     const projectIds = await this.projects.listDeletionIntents()
     const retainedProjectIds = new Set<string>()
+    const failures: ProjectDeletionFailure[] = []
     for (const projectId of projectIds) {
-      await this.prepareDeletion(projectId)
-      // An absent Project plus an unmarked tombstone identifies a cross-version orphan adoption.
-      // Re-derive its conservative policy from durable state so a crash immediately after intent
-      // creation cannot turn the next retry into authority-creating normal deletion. Any rejection
-      // naturally retains the intent because runtime cleanup may already have removed resources.
-      const requireExistingUploadAuthority =
-        !(await this.projects.get(projectId)) &&
-        (await this.sessions.getProjectSessionDeletionState(projectId)) === 'legacy-committed'
-      const result: ProjectSessionDeletionResult = requireExistingUploadAuthority
-        ? await this.sessions.deleteProjectSessions(projectId, {
-            requireExistingUploadAuthority: true
-          })
-        : await this.sessions.deleteProjectSessions(projectId)
-      if (result.status === 'orphan-retained') {
-        await this.projects.deleteDeletionIntent(projectId)
-        await this.lifecycle?.abortProjectDeletion?.(projectId)
-        retainedProjectIds.add(projectId)
-        continue
+      try {
+        await this.prepareDeletion(projectId)
+        // An absent Project plus an unmarked tombstone identifies a cross-version orphan adoption.
+        // Re-derive its conservative policy from durable state so a crash immediately after intent
+        // creation cannot turn the next retry into authority-creating normal deletion. Any rejection
+        // naturally retains the intent because runtime cleanup may already have removed resources.
+        const requireExistingUploadAuthority =
+          !(await this.projects.get(projectId)) &&
+          (await this.sessions.getProjectSessionDeletionState(projectId)) === 'legacy-committed'
+        const result: ProjectSessionDeletionResult = requireExistingUploadAuthority
+          ? await this.sessions.deleteProjectSessions(projectId, {
+              requireExistingUploadAuthority: true
+            })
+          : await this.sessions.deleteProjectSessions(projectId)
+        if (result.status === 'orphan-retained') {
+          await this.projects.deleteDeletionIntent(projectId)
+          await this.lifecycle?.abortProjectDeletion?.(projectId)
+          retainedProjectIds.add(projectId)
+          continue
+        }
+        await this.finishDeletion(projectId)
+      } catch (error) {
+        failures.push({ projectId, error })
       }
-      await this.finishDeletion(projectId)
     }
-    return retainedProjectIds
+    return { projectIds, retainedProjectIds, failures }
   }
 
   // Older releases could remove the Project row and intent before their best-effort physical
   // tombstone cleanup. Adopt every surviving unmarked tombstone into the durable intent protocol
   // before its Session migration can write a prepared marker or create new Version authority.
   private async adoptLegacyProjectSessionTombstones(
-    retainedProjectIds: ReadonlySet<string>
-  ): Promise<void> {
+    skippedProjectIds: ReadonlySet<string>
+  ): Promise<ProjectDeletionFailure[]> {
     const projectIds = await this.sessions.listLegacyProjectSessionTombstones()
+    const failures: ProjectDeletionFailure[] = []
     for (const projectId of projectIds) {
-      if (retainedProjectIds.has(projectId)) continue
-      await this.createDeletionIntentWithFence(projectId)
-      await this.lifecycle?.beforeProjectDelete(projectId)
-      const result = await this.sessions.deleteProjectSessions(projectId, {
-        requireExistingUploadAuthority: true
-      })
-      if (result.status === 'orphan-retained') {
-        await this.projects.deleteDeletionIntent(projectId)
-        await this.lifecycle?.abortProjectDeletion?.(projectId)
-        continue
+      if (skippedProjectIds.has(projectId)) continue
+      try {
+        await this.createDeletionIntentWithFence(projectId)
+        await this.lifecycle?.beforeProjectDelete(projectId)
+        const result = await this.sessions.deleteProjectSessions(projectId, {
+          requireExistingUploadAuthority: true
+        })
+        if (result.status === 'orphan-retained') {
+          await this.projects.deleteDeletionIntent(projectId)
+          await this.lifecycle?.abortProjectDeletion?.(projectId)
+          continue
+        }
+        await this.finishDeletion(projectId)
+      } catch (error) {
+        failures.push({ projectId, error })
       }
-      await this.finishDeletion(projectId)
     }
+    return failures
   }
 
   // The Project row is removed only after every fallible authority cleanup succeeds. Keeping both

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -156,11 +156,17 @@ class ProjectDeletionCoordinator {
   deleteProject(projectId: string): Promise<void> {
     const deletion = this.operationQueue.then(() =>
       withDataRootWrite(async () => {
-        await this.waitForProjectOperationsNow([projectId])
-        // A scoped wait may have suppressed failures owned by other Projects. Keep recovery
-        // incomplete after this deletion so those durable intents remain eligible for retry.
+        const recoveryComplete = await this.waitForProjectOperationsNow([projectId])
         this.isRecoveryComplete = false
-        await this.runDeletion(projectId)
+        try {
+          await this.runDeletion(projectId)
+          // Preserve sticky completion only when scoped admission did not suppress failures owned by
+          // other Projects. Suppressed durable intents must remain eligible for retry.
+          this.isRecoveryComplete = recoveryComplete
+        } catch (error) {
+          this.isRecoveryComplete = false
+          throw error
+        }
       })
     )
     this.operationQueue = deletion.catch(() => undefined)
@@ -179,7 +185,7 @@ class ProjectDeletionCoordinator {
   // could not be established safely. An empty set represents Project list/create operations.
   async waitForProjectOperations(projectIds: readonly string[]): Promise<void> {
     await this.operationQueue
-    return withDataRootWrite(() => this.waitForProjectOperationsNow(projectIds))
+    await withDataRootWrite(() => this.waitForProjectOperationsNow(projectIds))
   }
 
   // Restores fail-closed in-memory barriers from local durable authority only. Startup waits for this
@@ -217,12 +223,14 @@ class ProjectDeletionCoordinator {
     }
   }
 
-  private async waitForProjectOperationsNow(projectIds: readonly string[]): Promise<void> {
+  private async waitForProjectOperationsNow(projectIds: readonly string[]): Promise<boolean> {
     try {
       await this.recoverPendingDeletionsNow()
+      return true
     } catch (error) {
       if (!(error instanceof ProjectDeletionRecoveryError)) throw error
       if (error.affectsAny(new Set(projectIds))) throw error
+      return false
     }
   }
 

--- a/src/main/projects/ipc.test.ts
+++ b/src/main/projects/ipc.test.ts
@@ -32,7 +32,7 @@ describe('createProjectHandlers', () => {
     }
     const deletionCoordinator = {
       deleteProject: vi.fn().mockResolvedValue(undefined),
-      recoverPendingDeletions: vi.fn().mockResolvedValue(undefined)
+      waitForProjectOperations: vi.fn().mockResolvedValue(undefined)
     }
     const handlers = createProjectHandlers(repository, deletionCoordinator)
 
@@ -51,14 +51,46 @@ describe('createProjectHandlers', () => {
     }
     const deletionCoordinator = {
       deleteProject: vi.fn(),
-      recoverPendingDeletions: vi.fn().mockResolvedValue(undefined)
+      waitForProjectOperations: vi.fn().mockResolvedValue(undefined)
     }
     const handlers = createProjectHandlers(repository, deletionCoordinator)
 
     await handlers.list()
 
-    expect(deletionCoordinator.recoverPendingDeletions).toHaveBeenCalledOnce()
+    expect(deletionCoordinator.waitForProjectOperations).toHaveBeenCalledWith([])
     expect(repository.list).toHaveBeenCalledOnce()
+  })
+
+  it('keeps unrelated Project CRUD available when another deletion tail fails', async () => {
+    const deletionFailure = new Error('project-1 tail cleanup unavailable')
+    const unrelatedProject = { ...project, id: 'project-2' }
+    const repository = {
+      list: vi.fn().mockResolvedValue([unrelatedProject]),
+      get: vi.fn().mockResolvedValue(unrelatedProject),
+      create: vi.fn().mockResolvedValue(unrelatedProject),
+      update: vi.fn().mockResolvedValue(unrelatedProject)
+    }
+    const deletionCoordinator = {
+      deleteProject: vi.fn(),
+      waitForProjectOperations: vi.fn(async (projectIds: readonly string[]) => {
+        if (projectIds.includes('project-1')) throw deletionFailure
+      })
+    }
+    const handlers = createProjectHandlers(repository, deletionCoordinator)
+
+    await expect(handlers.list()).resolves.toEqual([unrelatedProject])
+    await expect(handlers.get('project-2')).resolves.toBe(unrelatedProject)
+    await expect(handlers.create({ name: 'Other Project' })).resolves.toBe(unrelatedProject)
+    await expect(
+      handlers.update({ id: 'project-2', name: 'Renamed', expectedUpdatedAt: 2 })
+    ).resolves.toBe(unrelatedProject)
+    await expect(handlers.get('project-1')).rejects.toBe(deletionFailure)
+
+    expect(repository.list).toHaveBeenCalledOnce()
+    expect(repository.get).toHaveBeenCalledOnce()
+    expect(deletionCoordinator.waitForProjectOperations).toHaveBeenCalledWith([])
+    expect(deletionCoordinator.waitForProjectOperations).toHaveBeenCalledWith(['project-2'])
+    expect(deletionCoordinator.waitForProjectOperations).toHaveBeenCalledWith(['project-1'])
   })
 
   it('recovers durable deletions before every project read or mutation', async () => {
@@ -80,7 +112,7 @@ describe('createProjectHandlers', () => {
     }
     const deletionCoordinator = {
       deleteProject: vi.fn(),
-      recoverPendingDeletions: vi.fn(async () => {
+      waitForProjectOperations: vi.fn(async () => {
         order.push('recover')
       })
     }
@@ -102,7 +134,7 @@ describe('createProjectHandlers', () => {
     }
     const deletionCoordinator = {
       deleteProject: vi.fn(),
-      recoverPendingDeletions: vi.fn().mockResolvedValue(undefined)
+      waitForProjectOperations: vi.fn().mockResolvedValue(undefined)
     }
     const handlers = createProjectHandlers(repository, deletionCoordinator)
 

--- a/src/main/projects/ipc.ts
+++ b/src/main/projects/ipc.ts
@@ -38,14 +38,14 @@ const createDefaultPreviewStateRepository = (): PreviewStateRepository =>
 
 type ProjectDeleteHandler = Pick<
   ProjectDeletionCoordinator,
-  'deleteProject' | 'recoverPendingDeletions'
+  'deleteProject' | 'waitForProjectOperations'
 >
 type ProjectCrudRepository = Pick<ProjectRepository, 'list' | 'get' | 'create' | 'update'> &
   Partial<Pick<ProjectRepository, 'updateArchive'>>
 type ProjectArchiveHandler = Pick<ProjectHandlers, 'updateArchive'>
 
-// Adapts repository operations into thin handlers while enforcing one shared recovery gate. CRUD
-// cannot observe or mutate projects until every durable deletion intent has finished replaying.
+// Adapts repository operations into thin handlers while enforcing Project-scoped recovery admission.
+// A failed durable deletion intent remains closed without denying unrelated Project operations.
 const createProjectHandlers = (
   repository: ProjectCrudRepository,
   deletionCoordinator: ProjectDeleteHandler,
@@ -57,27 +57,27 @@ const createProjectHandlers = (
   }
 ): ProjectHandlers => ({
   list: async () => {
-    await deletionCoordinator.recoverPendingDeletions()
+    await deletionCoordinator.waitForProjectOperations([])
     return repository.list()
   },
   get: async (id) => {
-    await deletionCoordinator.recoverPendingDeletions()
+    await deletionCoordinator.waitForProjectOperations([id])
     return repository.get(id)
   },
   create: async (request) => {
-    await deletionCoordinator.recoverPendingDeletions()
+    await deletionCoordinator.waitForProjectOperations([])
     return repository.create(request)
   },
   update: async (request) => {
-    await deletionCoordinator.recoverPendingDeletions()
+    await deletionCoordinator.waitForProjectOperations([request.id])
     return repository.update(request)
   },
   updateArchive: async (request) => {
-    await deletionCoordinator.recoverPendingDeletions()
+    await deletionCoordinator.waitForProjectOperations([request.id])
     return archiveHandler.updateArchive(request)
   },
   delete: async (id) => {
-    await deletionCoordinator.recoverPendingDeletions()
+    await deletionCoordinator.waitForProjectOperations([id])
     await deletionCoordinator.deleteProject(id)
   }
 })


### PR DESCRIPTION
## Problem

A failed tail step while replaying one durable Project deletion intent rejected the shared recovery gate. Every Project CRUD handler and every Files query awaited that unscoped gate, so one problematic Project denied otherwise independent work. Recovery also stopped at the first failed intent, leaving later Project deletions untouched until another retry.

## Proposed change

- Keep strict recovery failures visible to the background retry loop.
- Attribute recoverable tail failures to their durable Project ids and use Project-scoped admission for foreground Project CRUD and read-only Files operations.
- Continue serial recovery for unrelated current intents and legacy Session tombstones after one Project fails.
- Keep the failed Project fail-closed and retain its existing durable deletion intent/tombstone for retry, including after an unrelated Project deletion succeeds.
- Preserve sticky recovery completion after normal deletion when no failures were suppressed.
- Keep Files index repair behind strict global recovery because its backend performs a complete Session scan and global projection reconciliation.

## Scope and non-goals

- No database column, schema, migration, persisted format, enum value, or domain-model change.
- No renderer or interaction change. A failed Project may remain visible while its row exists, but operations touching it continue to reject.
- Existing Project deletion intents and Session tombstones remain the persistence authority; historical data needs no migration. Legacy tombstone adoption remains covered and now continues across unrelated failures.
- Session persistence call sites retain their existing strict global recovery gate; this PR scopes only the reported Project CRUD and read-only Files surfaces.
- Infrastructure failures that prevent intent ownership from being established remain global fail-closed errors.

## Acceptance criteria and validation

The listed checks ran after the last material edit.

- Unrelated Project CRUD remains available, the failed Project remains denied/retryable after unrelated deletion, normal deletion restores sticky recovery, unrelated replay continues, legacy tombstone adoption continues, and global Files repair remains strict -> `npm test -- src/main/projects/ipc.test.ts src/main/projects/deletion-coordinator.test.ts src/main/project-files/ipc.test.ts` -> 3 files passed, 52 tests passed.
- Files adapter plus declared owner/consumer impact set -> `npm run test:module -- project_files_repository` -> 6 files passed, 217 tests passed, 1 skipped.
- Main-process types -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed.

The complete `npm test` suite was intentionally not run locally; exact-head PR CI is authoritative for the full portable and platform plan. Exact-head PR CI and independent Codex review passed; the review reported no actionable findings and marked the PR ready to merge.

## Review focus

- `ProjectDeletionRecoveryError` preserves strict background retry while allowing foreground filtering only for failures with known Project ownership.
- Successful unrelated deletion cannot mark suppressed failures complete; normal deletion still restores sticky completion.
- Multi-Project Files searches include the primary and all comparison Project ids in admission, while global Files repair uses strict recovery.
- Serial replay retains failed intents but continues later current and legacy deletion work.
