### PR TITLE
fix(notebook): preserve runtime lifecycle fences

### DIFF
--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -622,6 +622,37 @@ describe('notebook runtime service', () => {
     service.releaseProjectDeletion('project-1')
   })
 
+  it('rejects session-scoped installs during deletion when projectId is omitted', async () => {
+    const root = await createStorageRoot()
+    const installPackagesImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      needsRestart: false,
+      log: 'installed',
+      method: 'pip'
+    })
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectId: 'default-project',
+      repository: new NotebookRunRepository(root),
+      environmentStateTracker: verifiedPackageMutationTracker(),
+      installPackagesImpl
+    })
+
+    service.beginProjectDeletion('default-project')
+
+    await expect(
+      service.managePackages({
+        sessionId: 'session-1',
+        language: 'python',
+        packages: ['numpy']
+      })
+    ).rejects.toThrow('Project is being deleted.')
+    expect(installPackagesImpl).not.toHaveBeenCalled()
+
+    service.releaseProjectDeletion('default-project')
+  })
+
   it('peeks only actionable in-memory handoff state without creating or reloading a Session', async () => {
     const root = await createStorageRoot()
     const { service } = lifecycleCallbackHarness(root)
@@ -3408,6 +3439,82 @@ describe('notebook runtime service', () => {
     const settled = await restarting
 
     expect(settled.kernelStatus).toBe('idle')
+  })
+
+  it('reports and persists error when an in-place restart fails', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectId: 'default-project',
+      repository,
+      executorFactory: () => ({
+        execute: async (request): Promise<NotebookExecutionResult> => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: request.cwd,
+          outputs: []
+        }),
+        shutdown: async () => ({ reaped: true }),
+        restart: async () => {
+          throw new Error('restart failed')
+        }
+      })
+    })
+    const request = { sessionId: 'session-1', workspaceCwd: root }
+    await service.execute({ ...request, code: '1' })
+
+    await expect(service.restart(request)).rejects.toThrow('restart failed')
+
+    expect((await service.state(request)).kernelStatus).toBe('error')
+    expect(
+      (await new NotebookRunRepository(root).findExisting('default-project', 'session-1'))?.kernel
+    ).toMatchObject({ lastKnownStatus: 'error' })
+  })
+
+  it('preserves terminated kernel evidence when restart fails', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    let lifecycle!: NotebookExecutorLifecycleCallbacks
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectId: 'default-project',
+      repository,
+      executorFactory: (_sessionId, callbacks) => {
+        lifecycle = callbacks
+        return {
+          execute: async (request): Promise<NotebookExecutionResult> => ({
+            status: 'completed',
+            stdout: '',
+            stderr: '',
+            traceback: '',
+            cwdAfter: request.cwd,
+            outputs: []
+          }),
+          shutdown: async () => ({ reaped: true }),
+          restart: async () => {
+            throw new Error('restart failed')
+          }
+        }
+      }
+    })
+    const request = { sessionId: 'session-1', workspaceCwd: root }
+    await service.execute({ ...request, code: '1' })
+    await lifecycle.onTerminated('python', DEFAULT_PY_ENV)
+
+    await expect(service.restart(request)).rejects.toThrow('restart failed')
+
+    expect((await service.state(request)).kernelStatus).toBe('terminated')
+    expect(
+      (await new NotebookRunRepository(root).findExisting('default-project', 'session-1'))?.kernel
+    ).toMatchObject({
+      lastKnownStatus: 'terminated',
+      terminatedKernelInstances: [{ kind: 'python', environment: DEFAULT_PY_ENV }]
+    })
   })
 
   it('does not create a live environment entry when restarting before any kernel spawned', async () => {

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -884,7 +884,9 @@ class NotebookRuntimeService {
   // Replaces the interpreter process while preserving cells and durable run history. Prefers the
   // executor's own in-place restart (keeps the same instance, e.g. NotebookKernelExecutor tears down
   // and lazily respawns its loops) and only shuts down + recreates for executors that don't support it.
-  // Reports 'restarting' for the duration and settles back to 'idle' once the fresh process is ready.
+  // Reports 'restarting' for the duration. A successful restart clears stale termination evidence and
+  // settles to 'idle'; a failed restart keeps that evidence and reports 'error' for kernels that were
+  // not already known to be terminated.
   async restart(request: NotebookSessionRequest): Promise<NotebookSessionState> {
     return this.sessionLifecycle.runProjectOperation(request, async () => {
       const session = await this.sessionLifecycle.ensure(request)
@@ -892,28 +894,48 @@ class NotebookRuntimeService {
       // A restart respawns fresh loops, so any pending R-restart recommendation for this session's envs
       // is cleared. Snapshot the keys before teardown drops them from kernelStatuses.
       const envKeys = session.kernelProcessKeys()
+      const statusesBeforeRestart = new Map(
+        envKeys.map((processKey) => [processKey, session.kernelStatus(processKey)] as const)
+      )
 
       envKeys.forEach((processKey) => session.setKernelStatus(processKey, 'restarting'))
-      await this.repository.clearKernelTerminations({
+      const restartingDocument = await this.repository.updateKernelStatus({
         projectId: session.projectId,
         sessionId: session.sessionId,
         lane: session.lane,
         status: 'restarting'
       })
-      session.clearAllDurableKernelTerminations()
+      const hadDurableTerminations =
+        session.hasUnknownDurableKernelTermination() ||
+        (restartingDocument.kernel.terminatedKernelInstances?.length ?? 0) > 0
       this.sessionLifecycle.notifyChanged(session)
 
       try {
         await session.restartExecutor(() => this.sessionLifecycle.createExecutor(session.lane))
         this.environmentOperations.clearRestartRecommendations(envKeys)
-      } finally {
-        envKeys.forEach((processKey) => session.setKernelStatus(processKey, 'idle'))
-        await this.repository.updateKernelStatus({
+        await this.repository.clearKernelTerminations({
           projectId: session.projectId,
           sessionId: session.sessionId,
           lane: session.lane,
           status: 'idle'
         })
+        session.clearAllDurableKernelTerminations()
+        envKeys.forEach((processKey) => session.setKernelStatus(processKey, 'idle'))
+      } catch (error) {
+        await this.repository.updateKernelStatus({
+          projectId: session.projectId,
+          sessionId: session.sessionId,
+          lane: session.lane,
+          status: hadDurableTerminations ? 'terminated' : 'error'
+        })
+        envKeys.forEach((processKey) =>
+          session.setKernelStatus(
+            processKey,
+            statusesBeforeRestart.get(processKey) === 'terminated' ? 'terminated' : 'error'
+          )
+        )
+        this.sessionLifecycle.notifyChanged(session)
+        throw error
       }
       this.sessionLifecycle.notifyChanged(session)
 
@@ -940,7 +962,7 @@ class NotebookRuntimeService {
   // DIFFERENT envs proceed concurrently (the lock is keyed by resolved env name, not language).
   async managePackages(request: InstallRequest): Promise<InstallResult> {
     const manage = (): Promise<InstallResult> => this.packageOperations.manage(request)
-    if (request.projectId === undefined && request.projectId === undefined) return manage()
+    if (request.projectId === undefined && request.sessionId === undefined) return manage()
 
     // Project admission is keyed only by project identity. InstallRequest intentionally keeps the
     // session fields optional because settings and repair flows can manage a global environment.


### PR DESCRIPTION
## Problem

Notebook package management bypasses the Project deletion fence when a request carries `sessionId` but omits `projectId`. Kernel restart failures also settle runtime and durable state to `idle` after clearing prior termination evidence.

## Proposed change

- Treat package mutations as global only when both `projectId` and `sessionId` are absent.
- Preserve durable kernel termination evidence while restart is in flight.
- Clear termination evidence and persist `idle` only after restart succeeds.
- Persist the existing `error` state when restart fails without prior termination evidence; retain `terminated` and exact instance evidence when it already exists.

## Scope and non-goals

- No Prisma, database schema, migration, or new data fields.
- No new enum values, API shapes, architecture boundaries, or user interaction changes.
- Existing historical documents remain readable; termination evidence already lost by earlier failed restarts cannot be reconstructed.

## Acceptance criteria and validation

Checks ran after the last material edit:

- session-scoped package mutation deletion admission -> `npm test -- src/main/notebook/runtime-service.test.ts` -> passed
- successful and failed Kernel restart state/persistence -> `npm test -- src/main/notebook/runtime-service.test.ts` -> 206 passed, 5 skipped
- affected main-process types -> `npm run typecheck:node` -> passed
- source lint -> `npm run lint` -> passed
- patch whitespace -> `git diff --check` -> passed

The module-impact manifest does not define a Notebook module ID, so the complete Notebook runtime-service owner test file was used as the focused module-level check. Full portable and platform suites are left to exact-head PR CI as requested.

## Review focus

- Project deletion admission for package requests that contain only Session scope.
- The success/failure commit boundary for `lastKnownStatus` and `terminatedKernelInstances`.
- Conservative behavior when restart fails after a prior Kernel termination.