### PR TITLE
fix(cli): protect unmanaged launcher files

### DIFF
--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -1,11 +1,22 @@
 import { spawnSync } from 'node:child_process'
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import {
+  link,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 const pdescribe = describe.skipIf(process.platform === 'win32')
+const symlinkDescribe = describe.skipIf(process.platform === 'win32')
 
 import {
   buildWindowsPathCommand,
@@ -216,6 +227,85 @@ describe.each([
     await expect(readFile(plan.target, 'utf8')).resolves.toBe(plan.shim)
     await uninstallCliLauncher(env)
     await expect(readFile(plan.target, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+})
+
+symlinkDescribe('symlinked launcher safety', () => {
+  const arrangeManagedTargetSymlink = async (): Promise<{
+    env: CliLauncherEnv
+    target: string
+    userFile: string
+    userContent: string
+  }> => {
+    const env = posixEnv()
+    const plan = planCliLauncher(env)
+    const userFile = join(home, 'user-script')
+    const userContent = 'Open Science command-line launcher. Managed by the app\nuser content\n'
+    await mkdir(plan.binDir, { recursive: true })
+    await writeFile(userFile, userContent)
+    await symlink(userFile, plan.target, 'file')
+    return { env, target: plan.target, userFile, userContent }
+  }
+
+  it('does not report a symlink to marker-bearing user content as installed', async () => {
+    const { env } = await arrangeManagedTargetSymlink()
+
+    await expect(getCliLauncherStatus(env)).resolves.toMatchObject({ installed: false })
+  })
+
+  it('refuses to follow a symlink during install', async () => {
+    const { env, target, userFile, userContent } = await arrangeManagedTargetSymlink()
+
+    await expect(installCliLauncher(env)).rejects.toThrow('not managed by Open Science')
+    await expect(readFile(userFile, 'utf8')).resolves.toBe(userContent)
+    expect((await lstat(target)).isSymbolicLink()).toBe(true)
+  })
+
+  it('refuses to remove a symlink during uninstall', async () => {
+    const { env, target, userFile, userContent } = await arrangeManagedTargetSymlink()
+
+    await expect(uninstallCliLauncher(env)).rejects.toThrow('not managed by Open Science')
+    await expect(readFile(userFile, 'utf8')).resolves.toBe(userContent)
+    expect((await lstat(target)).isSymbolicLink()).toBe(true)
+  })
+})
+
+describe('hard-linked launcher safety', () => {
+  const arrangeManagedTargetHardLink = async (): Promise<{
+    env: CliLauncherEnv
+    target: string
+    userFile: string
+    userContent: string
+  }> => {
+    const env = posixEnv()
+    const plan = planCliLauncher(env)
+    const userFile = join(home, 'user-script')
+    const userContent = 'Open Science command-line launcher. Managed by the app\nuser content\n'
+    await mkdir(plan.binDir, { recursive: true })
+    await writeFile(userFile, userContent)
+    await link(userFile, plan.target)
+    return { env, target: plan.target, userFile, userContent }
+  }
+
+  it('does not report a hard link to marker-bearing user content as installed', async () => {
+    const { env } = await arrangeManagedTargetHardLink()
+
+    await expect(getCliLauncherStatus(env)).resolves.toMatchObject({ installed: false })
+  })
+
+  it('refuses to follow a hard link during install', async () => {
+    const { env, userFile, userContent } = await arrangeManagedTargetHardLink()
+
+    await expect(installCliLauncher(env)).rejects.toThrow('not managed by Open Science')
+    await expect(readFile(userFile, 'utf8')).resolves.toBe(userContent)
+  })
+
+  it('refuses to remove a hard link during uninstall', async () => {
+    const { env, target, userFile, userContent } = await arrangeManagedTargetHardLink()
+
+    await expect(uninstallCliLauncher(env)).rejects.toThrow('not managed by Open Science')
+    await expect(readFile(userFile, 'utf8')).resolves.toBe(userContent)
+    await expect(lstat(target)).resolves.toMatchObject({ nlink: 2 })
   })
 })
 

--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -160,6 +160,65 @@ pdescribe('installCliLauncher / status / uninstall (POSIX)', () => {
   })
 })
 
+describe.each([
+  ['POSIX', () => posixEnv()],
+  ['Windows', () => winEnv()]
+])('unmanaged same-name launcher safety (%s)', (_platform, createEnv) => {
+  it('refuses to overwrite an unmanaged launcher during install', async () => {
+    const env = createEnv()
+    const plan = planCliLauncher(env)
+    const userContent = 'user-managed launcher\n'
+    await mkdir(plan.binDir, { recursive: true })
+    await writeFile(plan.target, userContent)
+
+    await expect(installCliLauncher(env, () => true)).rejects.toThrow(
+      'because it is not managed by Open Science'
+    )
+    await expect(readFile(plan.target, 'utf8')).resolves.toBe(userContent)
+  })
+
+  it('refuses to remove an unmanaged launcher during uninstall', async () => {
+    const env = createEnv()
+    const plan = planCliLauncher(env)
+    const userContent = 'user-managed launcher\n'
+    await mkdir(plan.binDir, { recursive: true })
+    await writeFile(plan.target, userContent)
+
+    await expect(uninstallCliLauncher(env)).rejects.toThrow(
+      'because it is not managed by Open Science'
+    )
+    await expect(readFile(plan.target, 'utf8')).resolves.toBe(userContent)
+  })
+
+  it('does not report an unmanaged launcher as installed', async () => {
+    const env = createEnv()
+    const plan = planCliLauncher(env)
+    await mkdir(plan.binDir, { recursive: true })
+    await writeFile(plan.target, 'user-managed launcher\n')
+
+    await expect(getCliLauncherStatus(env)).resolves.toMatchObject({
+      installed: false,
+      target: plan.target
+    })
+  })
+
+  it('continues to update and remove launchers carrying the historical ownership marker', async () => {
+    const env = createEnv()
+    const plan = planCliLauncher(env)
+    await mkdir(plan.binDir, { recursive: true })
+    await writeFile(
+      plan.target,
+      'Open Science command-line launcher. Managed by the app\nlegacy launcher\n'
+    )
+
+    await expect(getCliLauncherStatus(env)).resolves.toMatchObject({ installed: true })
+    await installCliLauncher(env, () => true)
+    await expect(readFile(plan.target, 'utf8')).resolves.toBe(plan.shim)
+    await uninstallCliLauncher(env)
+    await expect(readFile(plan.target, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+})
+
 describe('buildWindowsPathCommand', () => {
   it('embeds the bin dir as a PowerShell literal, not via -args', () => {
     const { command, args } = buildWindowsPathCommand(

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process'
-import { access, chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { join, posix } from 'node:path'
 
 import type { CliLauncherStatus } from '../../shared/cli'
@@ -159,15 +159,6 @@ export const planCliLauncher = (env: CliLauncherEnv): CliLauncherPlan => {
   }
 }
 
-const exists = async (path: string): Promise<boolean> => {
-  try {
-    await access(path)
-    return true
-  } catch {
-    return false
-  }
-}
-
 // Runs a command synchronously and reports success (exit 0). Injectable so the Windows PATH edit can
 // be asserted in tests without invoking a real shell.
 export type CommandRunner = (command: string, args: string[]) => boolean
@@ -195,6 +186,25 @@ export const buildWindowsPathCommand = (binDir: string): { command: string; args
   return { command: 'powershell', args: ['-NoProfile', '-NonInteractive', '-Command', script] }
 }
 
+const readCliLauncher = async (target: string): Promise<string | undefined> => {
+  try {
+    return await readFile(target, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw error
+  }
+}
+
+const isManagedCliLauncher = (content: string): boolean =>
+  content.includes('Open Science command-line launcher. Managed by the app')
+
+const refuseUnmanagedCliLauncher = (target: string): never => {
+  throw new Error(
+    `Refusing to modify ${target} because it is not managed by Open Science. ` +
+      'Move or rename the existing file, then try again.'
+  )
+}
+
 // Writes the launcher shim and, on Windows, ensures its dir is on the user PATH. Returns the resulting
 // status (installed + whether `open-science` is callable, with a hint when a manual step remains).
 export const installCliLauncher = async (
@@ -203,6 +213,10 @@ export const installCliLauncher = async (
 ): Promise<CliLauncherStatus> => {
   const plan = planCliLauncher(env)
   await mkdir(plan.binDir, { recursive: true })
+  const existing = await readCliLauncher(plan.target)
+  if (existing !== undefined && !isManagedCliLauncher(existing)) {
+    refuseUnmanagedCliLauncher(plan.target)
+  }
   await writeFile(plan.target, plan.shim, plan.mode !== undefined ? { mode: plan.mode } : {})
   if (plan.mode !== undefined) await chmod(plan.target, plan.mode)
 
@@ -224,29 +238,22 @@ export const installCliLauncher = async (
 
 export const uninstallCliLauncher = async (env: CliLauncherEnv): Promise<CliLauncherStatus> => {
   const plan = planCliLauncher(env)
+  const existing = await readCliLauncher(plan.target)
+  if (existing !== undefined && !isManagedCliLauncher(existing)) {
+    refuseUnmanagedCliLauncher(plan.target)
+  }
   await rm(plan.target, { force: true })
   return { installed: false, target: plan.target, onPath: false }
 }
 
-const readCliLauncher = async (target: string): Promise<string | undefined> => {
-  try {
-    return await readFile(target, 'utf8')
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
-    throw error
-  }
-}
-
-const isManagedCliLauncher = (content: string): boolean =>
-  content.includes('Open Science command-line launcher. Managed by the app')
-
 // AppImage status is content-aware: a legacy shim can exist while still pointing at an unmounted
-// FUSE path. Other packages retain the existing existence-only status contract.
+// FUSE path. Other packages report installed only when the existing launcher is app-managed.
 export const getCliLauncherStatus = async (env: CliLauncherEnv): Promise<CliLauncherStatus> => {
   const plan = planCliLauncher(env)
+  const content = await readCliLauncher(plan.target)
   const installed = isLinuxAppImage(env)
-    ? (await readCliLauncher(plan.target)) === plan.shim
-    : await exists(plan.target)
+    ? content === plan.shim
+    : content !== undefined && isManagedCliLauncher(content)
   return {
     installed,
     target: plan.target,

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process'
-import { chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { constants, type Stats } from 'node:fs'
+import { lstat, mkdir, open, rm, type FileHandle } from 'node:fs/promises'
 import { join, posix } from 'node:path'
 
 import type { CliLauncherStatus } from '../../shared/cli'
@@ -186,23 +187,132 @@ export const buildWindowsPathCommand = (binDir: string): { command: string; args
   return { command: 'powershell', args: ['-NoProfile', '-NonInteractive', '-Command', script] }
 }
 
-const readCliLauncher = async (target: string): Promise<string | undefined> => {
+class UnmanagedCliLauncherError extends Error {}
+
+const refuseUnmanagedCliLauncher = (target: string): never => {
+  throw new UnmanagedCliLauncherError(
+    `Refusing to modify ${target} because it is not managed by Open Science. ` +
+      'Move or rename the existing file, then try again.'
+  )
+}
+
+const statCliLauncher = async (target: string): Promise<Stats | undefined> => {
   try {
-    return await readFile(target, 'utf8')
+    return await lstat(target)
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
     throw error
   }
 }
 
+const isDirectRegularFile = (stats: Stats): boolean =>
+  stats.isFile() && !stats.isSymbolicLink() && stats.nlink === 1
+
+const isSameFile = (left: Stats, right: Stats): boolean =>
+  left.dev === right.dev && left.ino === right.ino
+
+type OpenCliLauncher = { handle: FileHandle; stats: Stats }
+
+// Open only a direct, single-link regular file and verify that the path still resolves to the same
+// inode after opening it. O_NOFOLLOW closes the lstat/open gap on POSIX; the identity checks provide
+// the equivalent guard on platforms where Node does not expose that flag.
+const openStableCliLauncher = async (
+  target: string,
+  flags: number
+): Promise<OpenCliLauncher | undefined> => {
+  const before = await statCliLauncher(target)
+  if (before === undefined) return undefined
+  if (!isDirectRegularFile(before)) refuseUnmanagedCliLauncher(target)
+
+  let handle: FileHandle
+  try {
+    handle = await open(target, flags | (constants.O_NOFOLLOW ?? 0))
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ENOENT') return undefined
+    if (code === 'ELOOP') refuseUnmanagedCliLauncher(target)
+    throw error
+  }
+
+  try {
+    const [opened, current] = await Promise.all([handle.stat(), statCliLauncher(target)])
+    if (
+      current === undefined ||
+      !isDirectRegularFile(opened) ||
+      !isDirectRegularFile(current) ||
+      !isSameFile(before, opened) ||
+      !isSameFile(opened, current)
+    ) {
+      refuseUnmanagedCliLauncher(target)
+    }
+    return { handle, stats: opened }
+  } catch (error) {
+    await handle.close()
+    throw error
+  }
+}
+
+const isOpenCliLauncherCurrent = async (target: string, opened: Stats): Promise<boolean> => {
+  const current = await statCliLauncher(target)
+  return current !== undefined && isDirectRegularFile(current) && isSameFile(opened, current)
+}
+
+const readCliLauncher = async (target: string): Promise<string | undefined> => {
+  let opened: OpenCliLauncher | undefined
+  try {
+    opened = await openStableCliLauncher(target, constants.O_RDONLY)
+  } catch (error) {
+    if (error instanceof UnmanagedCliLauncherError) return undefined
+    throw error
+  }
+  if (opened === undefined) return undefined
+
+  try {
+    const content = await opened.handle.readFile('utf8')
+    return (await isOpenCliLauncherCurrent(target, opened.stats)) ? content : undefined
+  } finally {
+    await opened.handle.close()
+  }
+}
+
 const isManagedCliLauncher = (content: string): boolean =>
   content.includes('Open Science command-line launcher. Managed by the app')
 
-const refuseUnmanagedCliLauncher = (target: string): never => {
-  throw new Error(
-    `Refusing to modify ${target} because it is not managed by Open Science. ` +
-      'Move or rename the existing file, then try again.'
-  )
+const writeCliLauncher = async (handle: FileHandle, plan: CliLauncherPlan): Promise<void> => {
+  const content = Buffer.from(plan.shim)
+  await handle.truncate(0)
+  let offset = 0
+  while (offset < content.length) {
+    const { bytesWritten } = await handle.write(content, offset, content.length - offset, offset)
+    if (bytesWritten === 0) throw new Error(`Could not write the CLI launcher at ${plan.target}.`)
+    offset += bytesWritten
+  }
+  if (plan.mode !== undefined) await handle.chmod(plan.mode)
+}
+
+const tryCreateCliLauncher = async (plan: CliLauncherPlan): Promise<boolean> => {
+  let handle: FileHandle
+  try {
+    handle = await open(
+      plan.target,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | (constants.O_NOFOLLOW ?? 0),
+      plan.mode ?? 0o666
+    )
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return false
+    throw error
+  }
+
+  try {
+    await writeCliLauncher(handle, plan)
+    const created = await handle.stat()
+    if (!(await isOpenCliLauncherCurrent(plan.target, created))) {
+      refuseUnmanagedCliLauncher(plan.target)
+    }
+    return true
+  } finally {
+    await handle.close()
+  }
 }
 
 // Writes the launcher shim and, on Windows, ensures its dir is on the user PATH. Returns the resulting
@@ -213,12 +323,29 @@ export const installCliLauncher = async (
 ): Promise<CliLauncherStatus> => {
   const plan = planCliLauncher(env)
   await mkdir(plan.binDir, { recursive: true })
-  const existing = await readCliLauncher(plan.target)
-  if (existing !== undefined && !isManagedCliLauncher(existing)) {
-    refuseUnmanagedCliLauncher(plan.target)
+
+  let written = false
+  for (let attempt = 0; attempt < 3 && !written; attempt += 1) {
+    if (await tryCreateCliLauncher(plan)) {
+      written = true
+      break
+    }
+
+    const opened = await openStableCliLauncher(plan.target, constants.O_RDWR)
+    if (opened === undefined) continue
+    try {
+      const existing = await opened.handle.readFile('utf8')
+      if (!isManagedCliLauncher(existing)) refuseUnmanagedCliLauncher(plan.target)
+      await writeCliLauncher(opened.handle, plan)
+      if (!(await isOpenCliLauncherCurrent(plan.target, opened.stats))) {
+        refuseUnmanagedCliLauncher(plan.target)
+      }
+      written = true
+    } finally {
+      await opened.handle.close()
+    }
   }
-  await writeFile(plan.target, plan.shim, plan.mode !== undefined ? { mode: plan.mode } : {})
-  if (plan.mode !== undefined) await chmod(plan.target, plan.mode)
+  if (!written) throw new Error(`The CLI launcher path kept changing: ${plan.target}`)
 
   let onPath = plan.onPath
   let pathHint: string | undefined
@@ -238,11 +365,26 @@ export const installCliLauncher = async (
 
 export const uninstallCliLauncher = async (env: CliLauncherEnv): Promise<CliLauncherStatus> => {
   const plan = planCliLauncher(env)
-  const existing = await readCliLauncher(plan.target)
-  if (existing !== undefined && !isManagedCliLauncher(existing)) {
-    refuseUnmanagedCliLauncher(plan.target)
+  const opened = await openStableCliLauncher(plan.target, constants.O_RDONLY)
+  if (opened !== undefined) {
+    try {
+      const existing = await opened.handle.readFile('utf8')
+      if (!isManagedCliLauncher(existing)) refuseUnmanagedCliLauncher(plan.target)
+      if (!(await isOpenCliLauncherCurrent(plan.target, opened.stats))) {
+        refuseUnmanagedCliLauncher(plan.target)
+      }
+    } finally {
+      await opened.handle.close()
+    }
+
+    const final = await statCliLauncher(plan.target)
+    if (final !== undefined) {
+      if (!isDirectRegularFile(final) || !isSameFile(opened.stats, final)) {
+        refuseUnmanagedCliLauncher(plan.target)
+      }
+      await rm(plan.target)
+    }
   }
-  await rm(plan.target, { force: true })
   return { installed: false, target: plan.target, onPath: false }
 }
 

--- a/src/shared/cli.ts
+++ b/src/shared/cli.ts
@@ -2,7 +2,7 @@
 // The launcher is a tiny shim that runs the bundled CLI via the app's own Electron in Node mode, so no
 // separate Node install is needed. Shared between the main-process installer and the settings UI.
 export type CliLauncherStatus = {
-  // Whether the shim currently exists on disk at `target`.
+  // Whether an app-managed shim currently exists on disk at `target`.
   installed: boolean
   // Absolute path where the shim is (or would be) written.
   target: string


### PR DESCRIPTION
## Problem

CLI launcher installation writes directly to the planned `open-science` path, and uninstall removes that path unconditionally. A user-managed or third-party file with the same name can therefore be overwritten or deleted. Outside the AppImage reconciliation path, status also treated any existing file as an installed app launcher and could present an uninstall action for an unmanaged file.

A path-based read followed by a path-based write is also unsafe for linked paths: a symlink or hard link can redirect an apparently managed launcher update into another user file.

## Proposed change

- Read the existing launcher before install and uninstall.
- Permit replacement or removal only when the existing content carries the stable Open Science ownership marker.
- Refuse to modify an unmanaged same-name file and tell the user to move or rename it.
- Report `installed` only for an app-managed launcher, while preserving the stricter exact-content check for current AppImage launchers.
- Exclusively create new launchers and update existing launchers through the same verified file handle used for ownership validation.
- Reject symlinks, non-regular paths, multiply linked files, and paths whose filesystem identity changes during validation.
- Cover POSIX and Windows planning paths, historical marker compatibility, real POSIX symlinks, and cross-platform hard links.

## Scope and non-goals

- No database or application-data migration.
- No new persisted ownership record, sidecar file, public status field, or enum value.
- No IPC shape or renderer architecture change; the existing error path surfaces conflicts.
- Historical app-managed launchers remain recognized through the marker present since the launcher feature was introduced.
- The portable uninstall path revalidates filesystem identity immediately before removal; it does not claim protection against an adversarial same-user replacement in the final unlink interval.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Unmanaged install, uninstall, and status safety on POSIX and Windows planning paths -> `npm test -- src/main/cli-install/launcher.test.ts` -> passed.
- Hard-link status/install/uninstall safety on the Windows development host -> `npm test -- src/main/cli-install/launcher.test.ts` -> passed.
- Historical marker upgrades/removal and AppImage reconciliation -> `npm test -- src/main/cli-install/launcher.test.ts` -> passed.
- Complete launcher owner test file -> `npm test -- src/main/cli-install/launcher.test.ts` -> passed (25 passed, 14 host-inapplicable POSIX/symlink tests skipped on Windows).
- Main-process and shared TypeScript consumers -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed with no warnings.
- Diff formatting -> `git diff --check` -> passed.

The launcher owner and its direct tests are covered locally. No IPC or renderer data shape changed, so preload/renderer consumer tests were excluded. The launcher is classified as Windows-sensitive; PR Gate and platform CI are authoritative for the real POSIX symlink and platform-specific execution lanes. Per maintainer direction, the complete local `npm test` suite was not run.

Uncovered local risk: real file symlink creation requires privileges unavailable on the Windows development host, so those tests run only on macOS/Linux CI. The equivalent multiply linked user-file behavior is exercised locally with hard links.

## Review focus

- Ownership-marker handling at install, uninstall, and status boundaries.
- Linked-path rejection and same-handle validation/write behavior.
- Preservation of unmanaged content and compatibility with launchers generated by older releases.
