### PR TITLE
fix(agents): redact internal host errors

### DIFF
--- a/src/main/agents/agents-mutations.test.ts
+++ b/src/main/agents/agents-mutations.test.ts
@@ -853,7 +853,7 @@ describe('executeAgentsMutation — errors are sanitized', () => {
         { op: 'create', params: { name: 'Bio' } },
         { profileService: svc, catalog }
       )
-    ).rejects.toThrow(/host\.agents\.create:/)
+    ).rejects.toThrow('host.agents.create: Internal operation failed.')
   })
 
   it('a repo revision-conflict surfaces as a sanitized host.agents.update: error', async () => {

--- a/src/main/agents/agents-mutations.ts
+++ b/src/main/agents/agents-mutations.ts
@@ -36,6 +36,7 @@ import type {
 } from '../../shared/specialist'
 import { emptyFullAccessConfig, emptySelectedConfig } from '../../shared/specialist'
 import type { ApprovalGateway } from '../../shared/agents-contract'
+import { AgentsSafeError, agentsPublicError, formatAgentsError } from './agents-error'
 
 // The catalog resolution seam this module consumes. It receives the ALREADY-PROJECTED public read
 // models (the same models the read slice returns from list_skills/list_connectors), so this module
@@ -67,17 +68,9 @@ export type AgentsOrdinaryMutationRequest =
   | { op: 'attach_connector'; params: Record<string, unknown> }
   | { op: 'detach_connector'; params: Record<string, unknown> }
 
-const METHOD_PREFIX = 'host.agents'
-
-// Sanitizes an arbitrary error into its top-level message only. System instructions, connector args,
-// credentials, headers, environment values, internal stack detail, and tokens must never reach the
-// sandbox. We keep only the message string (no nested secret-bearing JSON).
-const sanitizeError = (value: unknown): string =>
-  value instanceof Error ? value.message : String(value)
-
-class AgentsMutationError extends Error {
+class AgentsMutationError extends AgentsSafeError {
   constructor(method: string, cause: unknown) {
-    super(`${METHOD_PREFIX}.${method}: ${sanitizeError(cause)}`)
+    super(formatAgentsError(method, cause))
     this.name = 'AgentsMutationError'
   }
 }
@@ -100,7 +93,7 @@ const isFinitePositiveInt = (value: unknown): value is number =>
 
 const optionalStringOrThrow = (value: unknown, label: string): string | undefined => {
   if (value === undefined) return undefined
-  if (!isString(value)) throw new Error(`${label} must be a string.`)
+  if (!isString(value)) throw agentsPublicError(`${label} must be a string.`)
   return value
 }
 
@@ -110,7 +103,7 @@ const optionalStringOrThrow = (value: unknown, label: string): string | undefine
 export const asStringArray = (value: unknown): string[] | undefined => {
   if (value === undefined) return undefined
   if (!Array.isArray(value) || !value.every((item) => isString(item) && item.length > 0)) {
-    throw new Error('Must be an array of non-empty strings.')
+    throw agentsPublicError('Must be an array of non-empty strings.')
   }
   return value as string[]
 }
@@ -130,7 +123,7 @@ export const resolveSkillRefs = async (
   for (const ref of refs) {
     const matched = applyNameOrIdFilter(entries, ref, method)
     if (matched.length === 0) {
-      throw new Error(`No skill matches "${ref}".`)
+      throw agentsPublicError(`No skill matches "${ref}".`)
     }
     ids.push(matched[0].id)
   }
@@ -153,11 +146,13 @@ export const resolveConnectorRefs = async (
   for (const ref of refs) {
     const matched = applyNameOrIdFilter(entries, ref, method)
     if (matched.length === 0) {
-      throw new Error(`No connector matches "${ref}".`)
+      throw agentsPublicError(`No connector matches "${ref}".`)
     }
     const model = matched[0]
     if (options.gateUnavailable && model.availability !== 'available') {
-      throw new Error(`Connector "${ref}" is ${model.availability} and cannot be newly attached.`)
+      throw agentsPublicError(
+        `Connector "${ref}" is ${model.availability} and cannot be newly attached.`
+      )
     }
     ids.push(model.id)
     models.push(model)
@@ -197,7 +192,7 @@ export const projectCapabilityFields = async (
   method: string
 ): Promise<CapabilityProjection> => {
   if (patch.unrestricted !== undefined && !isBoolean(patch.unrestricted)) {
-    throw new Error('unrestricted must be a boolean.')
+    throw agentsPublicError('unrestricted must be a boolean.')
   }
   const skillRefs = asStringArray(patch.skill_names)
   const connectorRefs = asStringArray(patch.connector_names)
@@ -252,7 +247,7 @@ const handleCreate = async (
   rejectUnknownKeys(params, CREATE_ALLOWED_KEYS, 'create')
 
   const name = isString(params.name) ? params.name : throwShape('name is required')
-  if (!name.trim()) throw new Error('name is required')
+  if (!name.trim()) throw agentsPublicError('name is required')
 
   const description = optionalStringOrThrow(params.description, 'description')
   const displayName = optionalStringOrThrow(params.display_name, 'display name')
@@ -264,11 +259,11 @@ const handleCreate = async (
   // new specialist enabled; the update op toggles it. We validate the shape and ignore the value so
   // a malformed boolean is rejected before reaching the repository.
   if (params.enabled !== undefined && !isBoolean(params.enabled)) {
-    throw new Error('enabled must be a boolean.')
+    throw agentsPublicError('enabled must be a boolean.')
   }
 
   if (params.unrestricted !== undefined && !isBoolean(params.unrestricted)) {
-    throw new Error('unrestricted must be a boolean.')
+    throw agentsPublicError('unrestricted must be a boolean.')
   }
   // `unrestricted` is validated for shape but does not change create semantics here: the presence of
   // a capability array always produces Selected, and the absence of both always produces Full (AC).
@@ -342,17 +337,17 @@ const handleUpdate = async (
 
   // params.name resolves the immutable Specialist name; every field in patch is a change.
   const patch = params.patch
-  if (!isRecord(patch)) throw new Error('patch is required and must be an object.')
+  if (!isRecord(patch)) throw agentsPublicError('patch is required and must be an object.')
   rejectUnknownKeys(patch, UPDATE_ALLOWED_KEYS, 'update')
 
   const revision = patch.revision
   if (!isFinitePositiveInt(revision)) {
-    throw new Error('revision must be a positive integer.')
+    throw agentsPublicError('revision must be a positive integer.')
   }
 
   const current = await deps.profileService.resolveCustomMutationByName(name)
   if (current.revision !== revision) {
-    throw new Error('revision does not match the current specialist revision.')
+    throw agentsPublicError('revision does not match the current specialist revision.')
   }
 
   const input: {
@@ -380,7 +375,7 @@ const handleUpdate = async (
   if (colorKey !== undefined) input.colorKey = colorKey
 
   if (patch.enabled !== undefined && !isBoolean(patch.enabled)) {
-    throw new Error('enabled must be a boolean.')
+    throw agentsPublicError('enabled must be a boolean.')
   }
 
   // Capability projection centralizes the Selected/Full + collection-replacement semantics.
@@ -424,7 +419,7 @@ const handleAttachDetach = async (
   const name = isString(params.name) ? params.name : throwShape('name is required')
   const revision = params.revision
   if (!isFinitePositiveInt(revision)) {
-    throw new Error('revision must be a positive integer.')
+    throw agentsPublicError('revision must be a positive integer.')
   }
 
   const refKey = op.endsWith('skill') ? 'skill_ref' : 'connector_ref'
@@ -434,7 +429,7 @@ const handleAttachDetach = async (
 
   const current = await deps.profileService.resolveCustomMutationByName(name)
   if (current.revision !== revision) {
-    throw new Error('revision does not match the current specialist revision.')
+    throw agentsPublicError('revision does not match the current specialist revision.')
   }
   const mode: SpecialistCapabilityMode = current.capabilityMode
 
@@ -496,14 +491,14 @@ export function rejectUnknownKeys(
 ): void {
   for (const key of Object.keys(params)) {
     if (!allowed.has(key)) {
-      throw new Error(`Unknown field "${key}".`)
+      throw agentsPublicError(`Unknown field "${key}".`)
     }
   }
   void method
 }
 
 function throwShape(message: string): never {
-  throw new Error(message)
+  throw agentsPublicError(message)
 }
 
 // ---------------------------------------------------------------------------
@@ -532,7 +527,7 @@ export async function executeAgentsMutation(
         return await handleAttachDetach(method, params, deps)
       default:
         // Exhaustiveness guard: the switch covers every ordinary-mutation op.
-        throw new Error(`Operation "${String(method)}" is not an ordinary mutation.`)
+        throw agentsPublicError(`Operation "${String(method)}" is not an ordinary mutation.`)
     }
   } catch (error) {
     throw new AgentsMutationError(method, error)

--- a/src/main/agents/agents-repl.integration.test.ts
+++ b/src/main/agents/agents-repl.integration.test.ts
@@ -15,7 +15,7 @@ import {
   type KernelLoopResponse
 } from '../notebook/kernel-protocol'
 import { AgentsService, type AgentsCatalogSource, type AgentsReadOp } from './agents-service'
-import { createProfileService } from '../specialist/service'
+import { createProfileService, type ProfileService } from '../specialist/service'
 import type { StoredConnectors } from '../settings/types'
 
 // Run with: RUN_KERNEL=1 npx vitest run src/main/agents/agents-repl.integration.test.ts
@@ -357,6 +357,33 @@ gate('host.agents repl integration', () => {
       // The error must not leak any internal secret string from another profile.
       expect(r.result).not.toMatch(/apikey/)
     } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('redacts dependency error details before they reach the Agent sandbox', async () => {
+    const originalService = agentsService
+    agentsService = new AgentsService({
+      profileService: {
+        list: async () => {
+          throw new Error(
+            'request failed: token=secret-token path=/Users/alice/project params={"prompt":"private"} HOME=/Users/alice'
+          )
+        }
+      } as unknown as ProfileService,
+      catalog: stubCatalog
+    })
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: token
+    })
+    try {
+      const response = await send(
+        "try { await host.agents.list(); return 'ok' } catch (error) { return error.message }"
+      )
+      expect(response.result).toBe('host.agents.list: Internal operation failed.')
+    } finally {
+      agentsService = originalService
       child.kill()
     }
   }, 60_000)

--- a/src/main/agents/agents-service.test.ts
+++ b/src/main/agents/agents-service.test.ts
@@ -199,16 +199,20 @@ describe('AgentsService read surface', () => {
   })
 
   it('surfaces internal failures as sanitized host.agents.<method>: errors', async () => {
+    const sensitiveMessage =
+      'request failed: token=secret-token path=/Users/alice/project params={"prompt":"private"} HOME=/Users/alice'
     const failing = {
       list: vi.fn(async () => {
-        throw new Error('internal secret: apikey=ABCDEF')
+        throw new Error(sensitiveMessage)
       })
     }
     const service = new AgentsService({
       profileService: failing as unknown as ProfileService,
       catalog: catalog()
     })
-    await expect(service.read({ op: 'list' })).rejects.toThrow(/host\.agents\.list:/)
+    await expect(service.read({ op: 'list' })).rejects.toThrow(
+      'host.agents.list: Internal operation failed.'
+    )
   })
 })
 

--- a/src/main/agents/agents-service.ts
+++ b/src/main/agents/agents-service.ts
@@ -38,6 +38,7 @@ import type {
   SpecialistDeleteRequest,
   SpecialistDeleteResult
 } from '../../shared/specialist-package'
+import { AgentsSafeError, agentsPublicError, formatAgentsError } from './agents-error'
 
 // The minimal read surface this adapter needs from the settings/connectors catalog. Keeping it
 // narrow avoids pulling the whole SettingsService into the SDK contract and lets tests stub it.
@@ -147,19 +148,9 @@ export type AgentsReadOp =
   | { op: 'list_skills'; params: { name_or_id?: unknown } }
   | { op: 'list_connectors'; params: { name_or_id?: unknown } }
 
-const METHOD_PREFIX = 'host.agents'
-
-// Sanitizes an arbitrary error into a stable message. Connector args, credentials, headers,
-// environment values, and internal stack detail must never reach the sandbox. We keep only the
-// top-level message and strip anything that looks like a secret-bearing JSON blob.
-const sanitizeError = (value: unknown): string => {
-  const raw = value instanceof Error ? value.message : String(value)
-  return raw
-}
-
-class AgentsCallError extends Error {
+class AgentsCallError extends AgentsSafeError {
   constructor(method: string, cause: unknown) {
-    super(`${METHOD_PREFIX}.${method}: ${sanitizeError(cause)}`)
+    super(formatAgentsError(method, cause))
     this.name = 'AgentsCallError'
   }
 }
@@ -202,11 +193,14 @@ export class AgentsService {
   // the op, and passes the trusted calling session as `context`.
   async dispatch(op: unknown, context: TrustedCallingSession = {}): Promise<unknown> {
     if (!op || typeof op !== 'object' || !('op' in op)) {
-      throw new AgentsCallError('unknown', 'Invalid request')
+      throw new AgentsCallError('unknown', agentsPublicError('Invalid request'))
     }
     const request = op as { op: unknown }
     if (!isAgentsOpName(request.op)) {
-      throw new AgentsCallError(String(request.op ?? 'unknown'), 'Unknown operation')
+      throw new AgentsCallError(
+        String(request.op ?? 'unknown'),
+        agentsPublicError('Unknown operation')
+      )
     }
     const opName = request.op
     // Defensive: strip any reserved routing/identity/switch keys a second time. The RPC route
@@ -245,7 +239,7 @@ export class AgentsService {
       // standalone SwitchOperation via runSwitch below.
       if (opName === 'switch') {
         if (context.callerRole !== 'main') {
-          throw new Error('Only Main Agent may switch Specialist profile.')
+          throw agentsPublicError('Only Main Agent may switch Specialist profile.')
         }
         return await this.runSwitch(params, context)
       }
@@ -256,7 +250,7 @@ export class AgentsService {
       if (opName === 'delete') return await this.runDelete(params, context)
       // The dispatcher covers every operation the contract names. An unrecognized op was already
       // rejected as unknown above, so this branch is unreachable for a validated op name.
-      throw new Error(`Operation "${opName}" is not implemented yet`)
+      throw agentsPublicError(`Operation "${opName}" is not implemented yet`)
     } catch (error) {
       throw new AgentsCallError(opName, error)
     }
@@ -291,7 +285,7 @@ export class AgentsService {
   ): Promise<unknown> {
     const { approvalGateway, switchNotifier, sessionBinding, persistSessionSpecialist } = this.deps
     if (!approvalGateway || !switchNotifier || !sessionBinding || !persistSessionSpecialist) {
-      throw new Error(
+      throw agentsPublicError(
         'Operation "switch" is not configured (approval/binding/persistence seams missing)'
       )
     }
@@ -325,10 +319,10 @@ export class AgentsService {
   ): Promise<unknown> {
     const { approvalGateway, invalidateCatalog } = this.deps
     if (!approvalGateway) {
-      throw new Error('Operation "delete" is not configured (approval gateway missing)')
+      throw agentsPublicError('Operation "delete" is not configured (approval gateway missing)')
     }
     const currentName = typeof params.name === 'string' ? params.name : undefined
-    if (!currentName) throw new Error('name is required')
+    if (!currentName) throw agentsPublicError('name is required')
     const revision = params.revision
     if (
       typeof revision !== 'number' ||
@@ -336,7 +330,7 @@ export class AgentsService {
       !Number.isInteger(revision) ||
       revision <= 0
     ) {
-      throw new Error('revision must be a positive integer.')
+      throw agentsPublicError('revision must be a positive integer.')
     }
     return applyDelete({
       profileService: this.deps.profileService,
@@ -359,7 +353,7 @@ export class AgentsService {
   // read model including stable id and revision.
   async get(params: { name?: unknown }): Promise<AgentReadModel> {
     const name = asString(params.name)
-    if (!name) throw new Error('name is required')
+    if (!name) throw agentsPublicError('name is required')
     const profile = await this.deps.profileService.getByName(name)
     return projectAgent(profile)
   }
@@ -479,14 +473,14 @@ export function applyNameOrIdFilter<T extends Nameable>(
   // 2. Otherwise match a unique immutable public name. Display labels are never references.
   const byName = entries.filter((entry) => entry.name === ref)
   if (byName.length === 0) {
-    throw new Error(
+    throw agentsPublicError(
       `No catalog entry matches "${ref}". Use the stable id from listSkills()/listConnectors().`
     )
   }
   if (byName.length > 1) {
     // Ambiguous immutable name: instruct the caller to use the stable id instead of guessing.
     const ids = byName.map((entry) => entry.id).join(', ')
-    throw new Error(
+    throw agentsPublicError(
       `Multiple catalog entries match name "${ref}" (${ids}). Use the stable id from ${method} instead.`
     )
   }

--- a/src/main/agents/specialist-privileged-ops.test.ts
+++ b/src/main/agents/specialist-privileged-ops.test.ts
@@ -161,7 +161,7 @@ describe('applyDelete — approved delete', () => {
         currentName: 'DATA_ANALYST',
         reviewedRevision: 3
       })
-    ).rejects.toThrow(/host\.agents\.delete:.*I\/O error/)
+    ).rejects.toThrow('host.agents.delete: Internal operation failed.')
   })
 
   it('fails closed with a sanitized error when revision drifted before approval', async () => {

--- a/src/main/agents/specialist-privileged-ops.test.ts
+++ b/src/main/agents/specialist-privileged-ops.test.ts
@@ -4,6 +4,7 @@ import { applyDelete } from './specialist-privileged-ops'
 import type { AgentDeletedResult, AgentDeclinedResult } from './specialist-privileged-ops'
 import type { ApprovalResult } from '../../shared/agents-contract'
 import type { SpecialistProfileView } from '../../shared/specialist'
+import type { SpecialistDeleteResult } from '../../shared/specialist-package'
 import type { ProfileService } from '../specialist/service'
 
 const profile = (overrides: Partial<SpecialistProfileView> = {}): SpecialistProfileView => ({
@@ -27,6 +28,18 @@ const fakeDeclined = (operation: 'update' | 'delete' | 'switch'): ApprovalResult
   status: 'declined',
   operation
 })
+
+type SpecialistDeleteFailureCode = Extract<SpecialistDeleteResult, { status: 'failed' }>['code']
+
+const specialistDeleteFailureCodes = [
+  'stale-preview',
+  'revision-conflict',
+  'protected-skill',
+  'protected-target',
+  'recovery-failed',
+  'rollback-failed',
+  'commit-failed'
+] as const satisfies readonly SpecialistDeleteFailureCode[]
 
 type FakeService = {
   service: ProfileService
@@ -160,6 +173,37 @@ describe('applyDelete — approved delete', () => {
         decide: async () => fakeApproved(),
         currentName: 'DATA_ANALYST',
         reviewedRevision: 3
+      })
+    ).rejects.toThrow('host.agents.delete: Internal operation failed.')
+  })
+
+  it.each(specialistDeleteFailureCodes)(
+    'preserves the typed delete failure code %s',
+    async (code) => {
+      const { service } = makeService({ initial: [profile()] })
+      await expect(
+        applyDelete({
+          profileService: service,
+          decide: async () => fakeApproved(),
+          currentName: 'DATA_ANALYST',
+          reviewedRevision: 3,
+          deleteSpecialist: async () => ({ status: 'failed', code })
+        })
+      ).rejects.toThrow(`host.agents.delete: ${code}`)
+    }
+  )
+
+  it('sanitizes an arbitrary delete dependency error', async () => {
+    const { service } = makeService({ initial: [profile()] })
+    await expect(
+      applyDelete({
+        profileService: service,
+        decide: async () => fakeApproved(),
+        currentName: 'DATA_ANALYST',
+        reviewedRevision: 3,
+        deleteSpecialist: async () => {
+          throw new Error('token=secret-token path=/Users/alice/project')
+        }
       })
     ).rejects.toThrow('host.agents.delete: Internal operation failed.')
   })

--- a/src/main/agents/specialist-privileged-ops.ts
+++ b/src/main/agents/specialist-privileged-ops.ts
@@ -29,17 +29,11 @@ import type {
   SpecialistDeleteResult
 } from '../../shared/specialist-package'
 import type { ProfileService } from '../specialist/service'
+import { AgentsSafeError, agentsPublicError, formatAgentsError } from './agents-error'
 
-const METHOD_PREFIX = 'host.agents'
-
-// Sanitizes an error into a stable, method-scoped message. System instructions, connector args,
-// credentials, and stack detail must never reach the sandbox. We keep only the top-level message.
-const sanitizeError = (value: unknown): string =>
-  value instanceof Error ? value.message : String(value)
-
-class PrivilegedOpError extends Error {
+class PrivilegedOpError extends AgentsSafeError {
   constructor(method: string, cause: unknown) {
-    super(`${METHOD_PREFIX}.${method}: ${sanitizeError(cause)}`)
+    super(formatAgentsError(method, cause))
     this.name = 'PrivilegedOpError'
   }
 }
@@ -85,7 +79,9 @@ const reResolveForMutation = async (
   if (current.revision !== reviewedRevision) {
     throw new PrivilegedOpError(
       method,
-      `reviewed revision ${reviewedRevision} no longer matches current revision ${current.revision}`
+      agentsPublicError(
+        `reviewed revision ${reviewedRevision} no longer matches current revision ${current.revision}`
+      )
     )
   }
   return current
@@ -185,7 +181,10 @@ export const applyDelete = async (deps: ApplyDeleteDeps): Promise<DeleteResult> 
     // Expected: getByName threw "not found" — absence verified.
   }
   if (stillPresent) {
-    throw new PrivilegedOpError('delete', `specialist "${currentName}" still present after delete`)
+    throw new PrivilegedOpError(
+      'delete',
+      agentsPublicError(`specialist "${currentName}" still present after delete`)
+    )
   }
 
   if (!deps.deleteSpecialist && deps.invalidateCatalog) await deps.invalidateCatalog()

--- a/src/main/agents/specialist-privileged-ops.ts
+++ b/src/main/agents/specialist-privileged-ops.ts
@@ -156,7 +156,7 @@ export const applyDelete = async (deps: ApplyDeleteDeps): Promise<DeleteResult> 
         expectedRevision: current.revision,
         deleteSkillIds: []
       })
-      if (result.status === 'failed') throw new Error(result.code)
+      if (result.status === 'failed') throw agentsPublicError(result.code)
     } else {
       await profileService.delete(current.id, current.revision)
     }

--- a/src/main/agents/switch-operation.test.ts
+++ b/src/main/agents/switch-operation.test.ts
@@ -465,7 +465,7 @@ describe('SwitchOperation — approval-time re-validation (fail closed)', () => 
       persistBinding: persist
     })
     await expect(op.run({ name: 'BIO_EXPERT' }, { sessionId: 'session-trusted' })).rejects.toThrow(
-      /host\.agents\.switch:/
+      'host.agents.switch: Specialist "BIO_EXPERT" was disabled before the switch committed'
     )
     expect(persist).not.toHaveBeenCalled()
   })
@@ -709,7 +709,7 @@ describe('SwitchOperation — sanitization and no-sensitive-data', () => {
       })
     })
     await expect(op.run({ name: 'BIO_EXPERT' }, { sessionId: 'session-trusted' })).rejects.toThrow(
-      /host\.agents\.switch:/
+      'host.agents.switch: Internal operation failed.'
     )
   })
 

--- a/src/main/agents/switch-operation.ts
+++ b/src/main/agents/switch-operation.ts
@@ -315,9 +315,7 @@ export class SwitchOperation {
       throw new SwitchError(error)
     }
     if (!profile.enabled) {
-      throw new SwitchError(
-        agentsPublicError(`Specialist "${targetName}" is not enabled`)
-      )
+      throw new SwitchError(agentsPublicError(`Specialist "${targetName}" is not enabled`))
     }
     return { kind: 'specialist', profile }
   }

--- a/src/main/agents/switch-operation.ts
+++ b/src/main/agents/switch-operation.ts
@@ -29,19 +29,15 @@ import type { HandoffApprovalContext } from '../../shared/handoff-lifecycle'
 import type { SpecialistProfileView } from '../../shared/specialist'
 import type { ProfileService } from '../specialist/service'
 import type { SessionBindingService } from '../specialist/session-binding'
+import { AgentsSafeError, agentsPublicError, formatAgentsError } from './agents-error'
 
 // The method name used to prefix sanitized errors and to echo in structured results.
 export const SWITCH_METHOD = 'switch' as const
 
-// Sanitizes an arbitrary cause into a top-level message. System instructions, connector args,
-// credentials, headers, environment values, and stack detail must never leak to the sandbox.
-const sanitizeCause = (cause: unknown): string =>
-  cause instanceof Error ? cause.message : String(cause)
-
-class SwitchError extends Error {
+class SwitchError extends AgentsSafeError {
   constructor(cause: unknown) {
-    super(`host.agents.${SWITCH_METHOD}: ${sanitizeCause(cause)}`)
-    this.name = 'AgentsCallError'
+    super(formatAgentsError(SWITCH_METHOD, cause))
+    this.name = 'SwitchError'
   }
 }
 
@@ -163,7 +159,7 @@ export class SwitchOperation {
     // session id fields are already stripped by the dispatcher; we read neither here.
     const sessionId = trustedSession.sessionId
     if (!sessionId) {
-      throw new SwitchError('Missing trusted calling-session identity')
+      throw new SwitchError(agentsPublicError('Missing trusted calling-session identity'))
     }
 
     // Phase 1 — pre-approval resolution. Resolve the exact public name to the live profile so the
@@ -319,7 +315,9 @@ export class SwitchOperation {
       throw new SwitchError(error)
     }
     if (!profile.enabled) {
-      throw new SwitchError(`Specialist "${targetName}" is not enabled`)
+      throw new SwitchError(
+        agentsPublicError(`Specialist "${targetName}" is not enabled`)
+      )
     }
     return { kind: 'specialist', profile }
   }
@@ -390,15 +388,21 @@ export class SwitchOperation {
       throw new SwitchError(error)
     }
     if (!profile.enabled) {
-      throw new SwitchError(`Specialist "${name}" was disabled before the switch committed`)
+      throw new SwitchError(
+        agentsPublicError(`Specialist "${name}" was disabled before the switch committed`)
+      )
     }
     if (profile.id !== preResolved.profile.id) {
-      throw new SwitchError(`Specialist "${name}" identity changed before the switch committed`)
+      throw new SwitchError(
+        agentsPublicError(`Specialist "${name}" identity changed before the switch committed`)
+      )
     }
     const approvedRevision = reviewedRevision ?? preResolved.profile.revision
     if (profile.revision !== approvedRevision) {
       throw new SwitchError(
-        `Specialist "${name}" revision changed (${approvedRevision} → ${profile.revision}) before the switch committed`
+        agentsPublicError(
+          `Specialist "${name}" revision changed (${approvedRevision} → ${profile.revision}) before the switch committed`
+        )
       )
     }
     return {


### PR DESCRIPTION
## Problem

`host.agents` claimed to sanitize failures but returned arbitrary dependency `Error.message` values unchanged. The local RPC server serialized that message and the control REPL rethrew it to the Agent sandbox, so tokens, paths, request parameters, environment values, or other host diagnostics could cross the trust boundary.

The repository already had a fail-closed `AgentsSafeError` mechanism, but the service, mutation, privileged-delete, and switch wrappers did not reuse it.

## Proposed change

- Reuse `AgentsSafeError`, `agentsPublicError`, and `formatAgentsError` across every production `host.agents` error wrapper.
- Preserve only host-authored validation/state messages and the existing finite
  `SpecialistDeleteResult` failure codes when they are explicitly marked safe.
- Replace unknown dependency failures with `host.agents.<method>: Internal operation failed.`
- Add unit coverage for service, mutation, delete, and switch failures plus an end-to-end control-REPL regression that verifies sensitive details never reach the Agent sandbox.

## Scope and non-goals

- All `claude-code`, `opencode`, `codex-response`, and `codex-bridge` executions converge on the same JavaScript control REPL, app-local `agentsCall` RPC, and `AgentsService` boundary. This change fixes that shared boundary and does not change framework adapters, ACP wire methods, history replay, lifecycle events, or subscriptions.
- No renderer interaction, API field, data model, data relationship, persistence format, or database migration changes.
- No enum/state value is added. Existing typed delete failure codes remain Agent-visible so expected
  failures such as `revision-conflict` and `protected-target` stay actionable.
- No compatibility migration is required. Previously persisted conversation/tool output is not retroactively scrubbed; any historical cleanup would be separate incident-response work.
- Python and R data kernels remain out of scope because they do not receive `host.agents`.

## Acceptance criteria and validation

The focused local rows below ran after the final material edit. PR CI then exercised the complete
selected module and platform lanes.

| Behavior | Framework/path | Command | Result |
| --- | --- | --- | --- |
| Arbitrary dependency messages fail closed while every existing typed delete failure code remains actionable | Shared `AgentsService` and privileged-delete boundary | `npm test -- src/main/agents/specialist-privileged-ops.test.ts src/main/agents/agents-service.test.ts` | 2 files, 28 tests passed |
| Privileged operations remain correct through the real Agent sandbox boundary | `repl_loop.js` -> `agentsCall` RPC -> `AgentsService`; shared by all Agent frameworks | `RUN_KERNEL=1 npm test -- src/main/agents/agents-repl.privileged.integration.test.ts` | 1 file, 15 tests passed |
| Main-process TypeScript contracts remain valid | Main process | `npm run typecheck:node` | passed |
| Final changed source follows repository style rules | Changed files | targeted ESLint, Prettier, and `git diff --check` | passed |
| Selected full module/platform coverage and independent review | PR head `0a956b54` | PR Gate, CodeQL, Codex Review | all passed; review verdict `mergeable` with no actionable findings |

Model-specific coverage is excluded because no model-dependent request or ACP protocol shape changed. Platform-specific local lanes are excluded because the change contains no path handling, process, packaging, or OS-specific behavior. PR Gate remains the final authority for complete portable and platform coverage; the full local `npm test` suite was intentionally not run per maintainer direction.

## Review focus

- Confirm every host-authored message that remains visible is intentionally wrapped with `agentsPublicError`.
- Confirm dependency errors cannot acquire the safe marker before reaching the shared dispatcher.
- Confirm the end-to-end REPL regression exercises the actual Agent-visible boundary rather than only a helper.
