### PR TITLE
fix(remote-access): make browser revocation durable

### DIFF
--- a/src/main/remote-access/pairing.test.ts
+++ b/src/main/remote-access/pairing.test.ts
@@ -198,6 +198,115 @@ describe('RemoteSessionPairingManager', () => {
     ).resolves.toBe('denied')
   })
 
+  it('keeps a trusted browser authorized when revocation cannot be persisted', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
+    roots.push(root)
+    const repository = new RemoteAccessRepository(root)
+    const manager = await RemoteSessionPairingManager.create({
+      repository,
+      isAllowedRemoteHost: (hostname) => hostname === 'home.example.ts.net',
+      isEnabled: () => true,
+      onChanged: vi.fn()
+    })
+
+    const firstResponse = response()
+    await manager.webAccess.authorizeHttp(
+      request('/'),
+      firstResponse.response,
+      new URL('https://home.example.ts.net/')
+    )
+    const pendingCookie = cookiePair(firstResponse.headers.get('set-cookie') as string)
+    await manager.approve(manager.pendingViews()[0].id, 'always')
+    const statusResponse = response()
+    await manager.webAccess.authorizeHttp(
+      request('/__open_science_remote/pair/status', { cookie: pendingCookie }),
+      statusResponse.response,
+      new URL('https://home.example.ts.net/__open_science_remote/pair/status')
+    )
+    const sessionCookie = cookiePair((statusResponse.headers.get('set-cookie') as string[])[0])
+    const [trustedBrowser] = manager.trustedViews()
+
+    vi.spyOn(repository, 'save').mockRejectedValueOnce(new Error('disk full'))
+    await expect(manager.revoke(trustedBrowser.id)).rejects.toThrow('disk full')
+
+    expect(manager.trustedViews()).toHaveLength(1)
+    await expect(
+      manager.webAccess.authorizeHttp(
+        request('/', { cookie: sessionCookie }),
+        response().response,
+        new URL('https://home.example.ts.net/')
+      )
+    ).resolves.toMatchObject({ kind: 'authorized-pairing-manager' })
+
+    const restartedManager = await RemoteSessionPairingManager.create({
+      repository,
+      isAllowedRemoteHost: (hostname) => hostname === 'home.example.ts.net',
+      isEnabled: () => true,
+      onChanged: vi.fn()
+    })
+    await expect(
+      restartedManager.webAccess.authorizeHttp(
+        request('/', { cookie: sessionCookie }),
+        response().response,
+        new URL('https://home.example.ts.net/')
+      )
+    ).resolves.toMatchObject({ kind: 'authorized-pairing-manager' })
+  })
+
+  it('serializes concurrent trusted-browser revocations without losing an update', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
+    roots.push(root)
+    const repository = new RemoteAccessRepository(root)
+    await repository.save({
+      version: 4,
+      mode: 'remoteit-public',
+      trustedBrowsers: [
+        {
+          id: 'first-browser',
+          browser: 'Safari',
+          platform: 'macOS',
+          tokenHash: 'first-token',
+          createdAt: 1,
+          lastSeenAt: 1
+        },
+        {
+          id: 'second-browser',
+          browser: 'Chrome',
+          platform: 'Windows',
+          tokenHash: 'second-token',
+          createdAt: 2,
+          lastSeenAt: 2
+        }
+      ]
+    })
+    const manager = await RemoteSessionPairingManager.create({
+      repository,
+      isAllowedRemoteHost: (hostname) => hostname === 'home.example.ts.net',
+      isEnabled: () => true,
+      onChanged: vi.fn()
+    })
+    let releaseFirstSave: (() => void) | undefined
+    const firstSaveGate = new Promise<void>((resolve) => {
+      releaseFirstSave = resolve
+    })
+    const save = vi
+      .spyOn(repository, 'save')
+      .mockImplementationOnce(() => firstSaveGate)
+      .mockResolvedValue(undefined)
+
+    const firstRevocation = manager.revoke('first-browser')
+    await vi.waitFor(() => expect(save).toHaveBeenCalledOnce())
+    const secondRevocation = manager.revoke('second-browser')
+    await Promise.resolve()
+
+    expect(save).toHaveBeenCalledOnce()
+    releaseFirstSave?.()
+    await Promise.all([firstRevocation, secondRevocation])
+    expect(save).toHaveBeenCalledTimes(2)
+    expect(save.mock.calls[1][0].trustedBrowsers).toHaveLength(0)
+    expect(manager.trustedViews()).toHaveLength(0)
+  })
+
   it('rejects an invalid pairing decision without granting or persisting access', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
     roots.push(root)

--- a/src/main/remote-access/pairing.test.ts
+++ b/src/main/remote-access/pairing.test.ts
@@ -226,8 +226,25 @@ describe('RemoteSessionPairingManager', () => {
     const sessionCookie = cookiePair((statusResponse.headers.get('set-cookie') as string[])[0])
     const [trustedBrowser] = manager.trustedViews()
 
-    vi.spyOn(repository, 'save').mockRejectedValueOnce(new Error('disk full'))
-    await expect(manager.revoke(trustedBrowser.id)).rejects.toThrow('disk full')
+    let rejectSave: ((error: Error) => void) | undefined
+    const saveFailure = new Promise<void>((_resolve, reject) => {
+      rejectSave = reject
+    })
+    const save = vi.spyOn(repository, 'save').mockReturnValueOnce(saveFailure)
+    const revocation = manager.revoke(trustedBrowser.id)
+    void revocation.catch(() => undefined)
+    await vi.waitFor(() => expect(save).toHaveBeenCalledOnce())
+
+    await expect(
+      manager.webAccess.authorizeHttp(
+        request('/', { cookie: sessionCookie }),
+        response().response,
+        new URL('https://home.example.ts.net/')
+      )
+    ).resolves.toBe('handled')
+
+    rejectSave?.(new Error('disk full'))
+    await expect(revocation).rejects.toThrow('disk full')
 
     expect(manager.trustedViews()).toHaveLength(1)
     await expect(

--- a/src/main/remote-access/pairing.ts
+++ b/src/main/remote-access/pairing.ts
@@ -156,6 +156,7 @@ export class RemoteSessionPairingManager {
   private readonly pending = new Map<string, PendingPairing>()
   private readonly oneTimeSessions = new Map<string, OneTimeSession>()
   private readonly now: () => number
+  private storedMutationQueue: Promise<void> = Promise.resolve()
 
   private constructor(
     private readonly options: PairingManagerOptions,
@@ -182,8 +183,7 @@ export class RemoteSessionPairingManager {
   }
 
   async setModePreference(mode: StoredRemoteAccess['mode']): Promise<void> {
-    this.stored = { ...this.stored, mode }
-    await this.options.repository.save(this.stored)
+    await this.commitStoredMutation((stored) => ({ ...stored, mode }))
   }
 
   async setRemoteItServiceId(
@@ -199,26 +199,25 @@ export class RemoteSessionPairingManager {
     appServiceId?: string
     browserServiceId?: string
   }): Promise<void> {
-    const remoteItAppServiceId = services.appServiceId ?? this.stored.remoteItAppServiceId
-    const remoteItBrowserServiceId =
-      services.browserServiceId ?? this.stored.remoteItBrowserServiceId
-    if (
-      remoteItAppServiceId === this.stored.remoteItAppServiceId &&
-      remoteItBrowserServiceId === this.stored.remoteItBrowserServiceId
-    ) {
-      return
-    }
-    this.stored = {
-      ...this.stored,
-      remoteItAppServiceId,
-      remoteItBrowserServiceId
-    }
-    await this.options.repository.save(this.stored)
+    await this.commitStoredMutation((stored) => {
+      const remoteItAppServiceId = services.appServiceId ?? stored.remoteItAppServiceId
+      const remoteItBrowserServiceId = services.browserServiceId ?? stored.remoteItBrowserServiceId
+      if (
+        remoteItAppServiceId === stored.remoteItAppServiceId &&
+        remoteItBrowserServiceId === stored.remoteItBrowserServiceId
+      ) {
+        return undefined
+      }
+      return {
+        ...stored,
+        remoteItAppServiceId,
+        remoteItBrowserServiceId
+      }
+    })
   }
 
   async setRemoteItPublicUrl(url: string | undefined): Promise<void> {
-    this.stored = { ...this.stored, remoteItPublicUrl: url }
-    await this.options.repository.save(this.stored)
+    await this.commitStoredMutation((stored) => ({ ...stored, remoteItPublicUrl: url }))
   }
 
   pendingViews(): RemotePairingRequestView[] {
@@ -276,11 +275,10 @@ export class RemoteSessionPairingManager {
         createdAt: this.now(),
         lastSeenAt: this.now()
       }
-      this.stored = {
-        ...this.stored,
-        trustedBrowsers: [...this.stored.trustedBrowsers, trusted]
-      }
-      await this.options.repository.save(this.stored)
+      await this.commitStoredMutation((stored) => ({
+        ...stored,
+        trustedBrowsers: [...stored.trustedBrowsers, trusted]
+      }))
     }
     request.status = 'approved'
     request.grant = { decision, cookieValue }
@@ -298,12 +296,13 @@ export class RemoteSessionPairingManager {
   }
 
   async revoke(browserId: string): Promise<void> {
-    const next = this.stored.trustedBrowsers.filter((browser) => browser.id !== browserId)
-    if (next.length === this.stored.trustedBrowsers.length) {
-      throw new Error('Trusted browser not found.')
-    }
-    this.stored = { ...this.stored, trustedBrowsers: next }
-    await this.options.repository.save(this.stored)
+    await this.commitStoredMutation((stored) => {
+      const trustedBrowsers = stored.trustedBrowsers.filter((browser) => browser.id !== browserId)
+      if (trustedBrowsers.length === stored.trustedBrowsers.length) {
+        throw new Error('Trusted browser not found.')
+      }
+      return { ...stored, trustedBrowsers }
+    })
     this.options.onChanged()
   }
 
@@ -498,11 +497,41 @@ export class RemoteSessionPairingManager {
     const trusted = this.stored.trustedBrowsers.find((browser) => browser.id === id)
     if (!trusted || !safeHashEqual(trusted.tokenHash, tokenHash)) return undefined
     if (this.now() - trusted.lastSeenAt >= LAST_SEEN_WRITE_INTERVAL_MS) {
-      trusted.lastSeenAt = this.now()
-      await this.options.repository.save(this.stored)
-      this.options.onChanged()
+      let authorized = false
+      const changed = await this.commitStoredMutation((stored) => {
+        const current = stored.trustedBrowsers.find((browser) => browser.id === id)
+        if (!current || !safeHashEqual(current.tokenHash, tokenHash)) return undefined
+        authorized = true
+        const lastSeenAt = this.now()
+        if (lastSeenAt - current.lastSeenAt < LAST_SEEN_WRITE_INTERVAL_MS) return undefined
+        return {
+          ...stored,
+          trustedBrowsers: stored.trustedBrowsers.map((browser) =>
+            browser.id === id ? { ...browser, lastSeenAt } : browser
+          )
+        }
+      })
+      if (!authorized) return undefined
+      if (changed) this.options.onChanged()
     }
     return { kind: 'trusted', sessionId: id }
+  }
+
+  private commitStoredMutation(
+    update: (stored: StoredRemoteAccess) => StoredRemoteAccess | undefined
+  ): Promise<boolean> {
+    const operation = this.storedMutationQueue.then(async () => {
+      const stored = update(this.stored)
+      if (!stored) return false
+      await this.options.repository.save(stored)
+      this.stored = stored
+      return true
+    })
+    this.storedMutationQueue = operation.then(
+      () => undefined,
+      () => undefined
+    )
+    return operation
   }
 
   private pruneExpired(): void {

--- a/src/main/remote-access/pairing.ts
+++ b/src/main/remote-access/pairing.ts
@@ -155,6 +155,7 @@ export class RemoteSessionPairingManager {
   private stored: StoredRemoteAccess
   private readonly pending = new Map<string, PendingPairing>()
   private readonly oneTimeSessions = new Map<string, OneTimeSession>()
+  private readonly pendingRevocations = new Set<string>()
   private readonly now: () => number
   private storedMutationQueue: Promise<void> = Promise.resolve()
 
@@ -296,14 +297,25 @@ export class RemoteSessionPairingManager {
   }
 
   async revoke(browserId: string): Promise<void> {
-    await this.commitStoredMutation((stored) => {
-      const trustedBrowsers = stored.trustedBrowsers.filter((browser) => browser.id !== browserId)
-      if (trustedBrowsers.length === stored.trustedBrowsers.length) {
-        throw new Error('Trusted browser not found.')
-      }
-      return { ...stored, trustedBrowsers }
-    })
-    this.options.onChanged()
+    if (
+      this.pendingRevocations.has(browserId) ||
+      !this.stored.trustedBrowsers.some((browser) => browser.id === browserId)
+    ) {
+      throw new Error('Trusted browser not found.')
+    }
+    this.pendingRevocations.add(browserId)
+    try {
+      await this.commitStoredMutation((stored) => {
+        const trustedBrowsers = stored.trustedBrowsers.filter((browser) => browser.id !== browserId)
+        if (trustedBrowsers.length === stored.trustedBrowsers.length) {
+          throw new Error('Trusted browser not found.')
+        }
+        return { ...stored, trustedBrowsers }
+      })
+      this.options.onChanged()
+    } finally {
+      this.pendingRevocations.delete(browserId)
+    }
   }
 
   clearTransientAccess(): void {
@@ -493,6 +505,7 @@ export class RemoteSessionPairingManager {
     if (once && once.expiresAt > this.now() && safeHashEqual(once.tokenHash, tokenHash)) {
       return { kind: 'once', sessionId: id }
     }
+    if (this.pendingRevocations.has(id)) return undefined
 
     const trusted = this.stored.trustedBrowsers.find((browser) => browser.id === id)
     if (!trusted || !safeHashEqual(trusted.tokenHash, tokenHash)) return undefined


### PR DESCRIPTION
## Problem

Trusted-browser revocation updated the in-memory pairing state before saving remote-access.json. If the repository save failed, the running process denied the old token while a restart reloaded and accepted the still-persisted token.

## Proposed change

- Serialize persistent pairing-state mutations inside RemoteSessionPairingManager.
- Save each immutable candidate state before committing it to the in-memory snapshot.
- Route last-seen writes through the same queue so they cannot race with revocation and restore stale browser records.
- Preserve the trusted browser in memory when revocation persistence fails.
- Add regression coverage for save failure and concurrent revocations.

## Scope and non-goals

- No persistent fields, schema version, migration, or data-model changes.
- No new lifecycle or enum values.
- No UI or RPC contract changes.
- No historical-data compatibility work is required; existing version 4 remote-access.json files remain unchanged.

## Acceptance criteria and validation

- Failed revocation persistence keeps runtime and restart authorization consistent -> npm test -- src/main/remote-access/pairing.test.ts -t failed-revocation/concurrency cases -> passed.
- Remote-access behavior and adapters remain compatible -> npm test -- src/main/remote-access -> 5 files, 59 tests passed.
- Main-process types remain valid -> npm run typecheck:node -> passed.
- Source conforms to lint rules -> npm run lint -> passed.

All listed checks ran after the last material production-code edit. The module-impact manifest does not define a remote-access module ID, so the focused directory suite was used instead of test:module. No shared interface, renderer, schema, migration, path-handling, or build input changed; consumer and platform-specific local lanes were therefore excluded. PR CI remains authoritative for the full portable and cross-platform suites.

## Review focus

- Failure behavior when RemoteAccessRepository.save rejects.
- Ordering and recovery of the storedMutationQueue after success or failure.
- Interaction between trusted-browser revocation and lastSeenAt persistence.