### PR TITLE
fix(agents): keep updates in one CAS write

### DIFF
--- a/src/main/agents/agents-dispatch.test.ts
+++ b/src/main/agents/agents-dispatch.test.ts
@@ -589,15 +589,11 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
     expect(invalidateCatalog).not.toHaveBeenCalled()
   })
 
-  // A displayName patch that also toggles `enabled` must land both. The
-  // ordinary update path applies `enabled` via a separate ProfileService.setEnabled(...) call after
-  // the identity/capability update.
-  it('a displayName patch that also toggles enabled applies both changes', async () => {
-    const renamed = specialist({ displayName: 'Biology', revision: 4, enabled: true })
-    const afterToggle = specialist({ displayName: 'Biology', revision: 5, enabled: false })
+  // A displayName patch that also toggles `enabled` must land both in one CAS-backed update.
+  it('a displayName patch that also toggles enabled applies both changes atomically', async () => {
+    const updated = specialist({ displayName: 'Biology', revision: 4, enabled: false })
     const { service, profileService } = buildService({ profiles: [specialist()] })
-    ;(profileService.update as ReturnType<typeof vi.fn>).mockResolvedValue(renamed)
-    ;(profileService.setEnabled as ReturnType<typeof vi.fn>) = vi.fn(async () => afterToggle)
+    ;(profileService.update as ReturnType<typeof vi.fn>).mockResolvedValue(updated)
 
     const result = (await service.dispatch({
       op: 'update',
@@ -607,11 +603,9 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
     expect(result.name).toBe('Bio')
     expect(result.displayName).toBe('Biology')
     expect(result.enabled).toBe(false)
-    expect(result.revision).toBe(5)
-    // setEnabled was invoked with the toggled value, after the atomic rename committed.
-    expect(profileService.setEnabled as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
-      'sp-1',
-      false
+    expect(result.revision).toBe(4)
+    expect(profileService.update as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'sp-1', revision: 3, displayName: 'Biology', enabled: false })
     )
   })
 

--- a/src/main/agents/agents-mutations.test.ts
+++ b/src/main/agents/agents-mutations.test.ts
@@ -96,6 +96,7 @@ const makeProfileService = (
       if (input.systemPrompt !== undefined) merged.systemPrompt = input.systemPrompt
       if (input.iconKey !== undefined) merged.iconKey = input.iconKey
       if (input.colorKey !== undefined) merged.colorKey = input.colorKey
+      if (input.enabled !== undefined) merged.enabled = input.enabled
       if (input.capabilityMode !== undefined) merged.capabilityMode = input.capabilityMode
       if (input.fullAccess !== undefined) merged.fullAccess = input.fullAccess
       if (input.selectedCapabilities !== undefined) {
@@ -510,13 +511,15 @@ describe('executeAgentsMutation — update', () => {
     expect(passed.systemPrompt).toBe('new prompt')
     expect(passed.iconKey).toBe('flask')
     expect(passed.colorKey).toBe('blue')
+    expect(passed.enabled).toBe(false)
     expect(passed.capabilityMode).toBe('selected')
     expect(passed.selectedCapabilities?.skillIds).toEqual(['sk1'])
     expect(passed.selectedCapabilities?.connectorIds).toEqual(['c1'])
-    // read-back is the real returned view, not echoed input. revision reflects both mutations
-    // (update bumps 1->2, setEnabled bumps 2->3) since enabled lives on a separate service method.
+    expect(svc.calls.map((call) => call.method)).toEqual(['update'])
+    // A single public update is one CAS-backed persistence request and advances one revision.
     expect(result.id).toBe('sp-1')
-    expect(result.revision).toBe(3)
+    expect(result.enabled).toBe(false)
+    expect(result.revision).toBe(2)
   })
 
   it('update({ unrestricted: true }) switches to Full without destroying the stored Selected config', async () => {

--- a/src/main/agents/agents-mutations.ts
+++ b/src/main/agents/agents-mutations.ts
@@ -27,12 +27,13 @@
 import type { ConnectorReadModel, SkillCatalogReadModel } from './agents-service'
 import { applyNameOrIdFilter } from './agents-service'
 import type { ProfileService } from '../specialist/service'
-import type { SpecialistProfileView } from '../../shared/specialist'
 import type {
   CreateSpecialistInput,
   SpecialistCapabilityMode,
   SpecialistFullAccessConfig,
-  SpecialistSelectedConfig
+  SpecialistProfileView,
+  SpecialistSelectedConfig,
+  UpdateSpecialistInput
 } from '../../shared/specialist'
 import { emptyFullAccessConfig, emptySelectedConfig } from '../../shared/specialist'
 import type { ApprovalGateway } from '../../shared/agents-contract'
@@ -350,18 +351,7 @@ const handleUpdate = async (
     throw agentsPublicError('revision does not match the current specialist revision.')
   }
 
-  const input: {
-    id: string
-    revision: number
-    displayName?: string
-    description?: string
-    systemPrompt?: string
-    iconKey?: string
-    colorKey?: string
-    capabilityMode?: SpecialistCapabilityMode
-    fullAccess?: SpecialistFullAccessConfig
-    selectedCapabilities?: SpecialistSelectedConfig
-  } = { id: current.id, revision }
+  const input: UpdateSpecialistInput = { id: current.id, revision }
 
   const displayName = optionalStringOrThrow(patch.display_name, 'display name')
   if (displayName !== undefined) input.displayName = displayName
@@ -377,6 +367,7 @@ const handleUpdate = async (
   if (patch.enabled !== undefined && !isBoolean(patch.enabled)) {
     throw agentsPublicError('enabled must be a boolean.')
   }
+  if (patch.enabled !== undefined) input.enabled = patch.enabled
 
   // Capability projection centralizes the Selected/Full + collection-replacement semantics.
   const capability = await projectCapabilityFields(patch, current, deps.catalog, 'update')
@@ -390,15 +381,7 @@ const handleUpdate = async (
     input.fullAccess = capability.fullAccess
   }
 
-  // enabled lives on a separate ProfileService method (update() does not carry it). When the
-  // requested state differs from the current, we toggle AFTER the identity/capability update so the
-  // optimistic-concurrency check (revision) gates the whole mutation first, then setEnabled flips the
-  // enabled flag. setEnabled is not revision-guarded, so ordering update-first is safe.
-  let readBack = await deps.profileService.update(input)
-  if (patch.enabled !== undefined && patch.enabled !== readBack.enabled) {
-    readBack = await deps.profileService.setEnabled(current.id, patch.enabled)
-  }
-  return readBack
+  return deps.profileService.update(input)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main/agents/agents-repl.mutations.integration.test.ts
+++ b/src/main/agents/agents-repl.mutations.integration.test.ts
@@ -242,7 +242,7 @@ gate('host.agents repl mutation integration', () => {
         ).result ?? '{}'
       )
       const r = await send(
-        `return JSON.stringify(await host.agents.update('UpdBot', { revision: ${created.revision}, displayName: 'Updated Bot', description: 'after', systemPrompt: 'updated prompt', iconKey: 'flask', colorKey: 'blue', skillNames: ['demo'], connectorNames: ['my-server'] }))`
+        `return JSON.stringify(await host.agents.update('UpdBot', { revision: ${created.revision}, displayName: 'Updated Bot', description: 'after', systemPrompt: 'updated prompt', iconKey: 'flask', colorKey: 'blue', enabled: false, skillNames: ['demo'], connectorNames: ['my-server'] }))`
       )
       expect(r.error).toBeNull()
       const updated = JSON.parse(r.result ?? '{}')
@@ -252,6 +252,7 @@ gate('host.agents repl mutation integration', () => {
       expect(updated.systemPrompt).toBe('updated prompt')
       expect(updated.iconKey).toBe('flask')
       expect(updated.colorKey).toBe('blue')
+      expect(updated.enabled).toBe(false)
       expect(updated.capabilityMode).toBe('selected')
       expect(updated.selectedCapabilities.skillIds).toEqual(['demo'])
       expect(updated.selectedCapabilities.connectorIds).toEqual(['cust-1'])


### PR DESCRIPTION
## Problem

`host.agents.update` validated `enabled` but omitted it from the existing `UpdateSpecialistInput`. When the requested enabled state differed, the mutation first called the CAS-backed `ProfileService.update` and then called unguarded `setEnabled`, producing two persisted writes, two notifications, and two revision increments. A crash, write failure, or concurrent mutation between those calls could expose a partially applied update.

## Proposed change

- Pass `enabled` through the existing `ProfileService.update` input.
- Remove the follow-up `setEnabled` mutation.
- Lock the behavior down at the mutation, dispatcher, service-persistence, and host SDK integration seams.

## Scope and non-goals

- No database/schema change, migration, new persisted field, enum, or data-model change.
- No renderer or user-interaction change.
- Existing `specialists.json` data remains valid; previously consumed revision numbers are not rewritten.
- `setEnabled` remains available for its existing Settings IPC callers.
- Claude Code, OpenCode, Codex Responses, and Codex Bridge all use the shared host SDK -> local RPC -> `AgentsService` route; no framework-specific translation, replay, lifecycle, error, or subscription contract changes are required. The successful update now emits one final notification instead of an intermediate and final notification.

## Acceptance criteria and validation

Checks below ran after the last material edit:

- One Agent update -> one service mutation and one revision increment -> `npm test -- src/main/agents/agents-mutations.test.ts src/main/agents/agents-dispatch.test.ts src/main/specialist/service.test.ts` -> passed (128 tests).
- Main-process type safety -> `npm run typecheck:node` -> passed.
- Source/test lint -> `npm run lint` -> passed.
- Host SDK representative integration -> `npm test -- src/main/agents/agents-repl.mutations.integration.test.ts` -> locally gated/skipped (13 tests); PR CI is authoritative.

The full portable and cross-platform suites were intentionally left to PR Gate per maintainer direction.

## Review focus

Please verify that the ordinary Agent update forwards `enabled` through the already-atomic `ProfileService.update` path and that no second persistence call remains.