### PR TITLE
fix(connectors): keep OpenCode baseline within budget

### DIFF
--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -121,7 +121,7 @@ export function renderConnectorInstructions(skillNames: string[]): string {
     `# Open Science data connector conventions\n\n` +
     `Globally Enabled Connector Skills: ${availableSkills}.\n\n` +
     `A Specialist session may narrow this catalog. When an \`Allowed Specialist Skills for this session\` list is present, it is authoritative: do not load or call any \`mcp-*\` skill absent from that list.\n\n` +
-    `Detailed instructions, exact server/method names, schemas, return shapes, and examples are available through the matching \`mcp-*\` skill. Load the matching \`mcp-*\` skill before the first \`host.mcp\` call. Never guess a connector server or method name; if the matching skill is not loaded, do not call the connector.\n\n` +
+    `The matching \`mcp-*\` skill provides exact server/method names, schemas, return shapes, and examples. Load the matching \`mcp-*\` skill before the first \`host.mcp\` call. Never guess a connector server or method name; without that skill, do not call the connector.\n\n` +
     CONVENTIONS
   )
 }


### PR DESCRIPTION
## Problem

PR #1342 changed eight bundled Connector IDs from snake_case to kebab-case. Their `mcp-*` Skill names then passed the OpenCode baseline name filter for the first time, increasing the generated baseline from about 2349 to 2537 characters and failing the existing `< 2500` context-budget assertion.

## Proposed change

- compact the repeated Connector discovery sentence by 53 characters;
- keep the complete enabled Connector Skill list and all existing loading, routing, reuse, approval, and no-guessing constraints;
- keep the existing 2500-character budget unchanged. The full generated baseline is now 2484 characters.

## Scope and non-goals

- Changes one generated OpenCode instruction string only.
- Does not change Connector identities, schemas, runtime behavior, persisted data, protocol states, or historical compatibility.
- Does not change test thresholds or add dependencies.

## Acceptance criteria and validation

All checks ran after the final material edit:

- OpenCode baseline remains below the existing budget and retains the exact discovery constraints -> `npm test -- src/main/settings/service.test.ts -t 'keeps OpenCode connector details in on-demand skills instead of baseline context'` -> 1 passed;
- Connector instruction rendering and Settings integration -> `npm test -- src/main/connectors/skill-doc.test.ts src/main/settings/service.test.ts` -> 277 passed;
- Node type safety -> `npm run typecheck:node` -> passed;
- source lint -> `npm run lint` -> passed;
- whitespace/conflict markers -> `git diff --check` -> passed.

The dependency-aware selector explains a full fallback because `src/main/connectors/skill-doc.ts` has no registered module owner. Per maintainer request, the complete local `npm test` suite was not run; PR Gate remains the final authority for the complete and platform-specific plan. No platform-specific lane is required by the string-only implementation itself.

## Review focus

- the compressed sentence preserves the existing safety and Connector discovery semantics;
- the context budget is met without weakening the assertion.
