### PR TITLE
fix(connectors): propagate notebook RPC cancellation

### DIFF
--- a/src/main/connectors/approval-broker.test.ts
+++ b/src/main/connectors/approval-broker.test.ts
@@ -62,6 +62,31 @@ describe('ApprovalBroker', () => {
     await expect(decision).resolves.toBe('deny')
   })
 
+  it('cancels and removes a pending request when its caller aborts', async () => {
+    const timer = makeTimer()
+    const onSettled = vi.fn()
+    const broker = new ApprovalBroker({
+      generateId: () => 'id-1',
+      broadcast: () => undefined,
+      setTimer: timer.set,
+      clearTimer: timer.clear,
+      onSettled
+    })
+    const cancellation = new AbortController()
+
+    const decision = broker.request(
+      { connector: 'biomart', method: 'get_data', argsPreview: '{}' },
+      cancellation.signal
+    )
+    cancellation.abort()
+
+    await expect(decision).resolves.toBe('deny')
+    expect(broker.getPending('id-1')).toBeNull()
+    expect(onSettled).toHaveBeenCalledWith('id-1', 'cancelled')
+    timer.fire()
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
   it('pauses a Session timeout while Side chat owns the composer', async () => {
     let now = 0
     const timers: Array<{ fn: () => void; ms: number }> = []

--- a/src/main/connectors/approval-broker.ts
+++ b/src/main/connectors/approval-broker.ts
@@ -27,7 +27,7 @@ type ApprovalBrokerDeps = {
   setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>
   clearTimer?: (handle: ReturnType<typeof setTimeout>) => void
   now?: () => number
-  onSettled?: (id: string, state: 'resolved' | 'rejected' | 'expired') => void
+  onSettled?: (id: string, state: 'resolved' | 'rejected' | 'expired' | 'cancelled') => void
 }
 
 type PendingApproval = {
@@ -36,6 +36,8 @@ type PendingApproval = {
   timer?: ReturnType<typeof setTimeout>
   remainingMs: number
   timerStartedAt?: number
+  signal?: AbortSignal
+  abortListener?: () => void
 }
 
 // Bridges the main-process connector gate to the renderer approval card: it holds a connector call
@@ -57,13 +59,22 @@ export class ApprovalBroker {
   }
 
   // Broadcasts an approval request and resolves once the renderer responds (or the timeout denies it).
-  request(info: ApprovalInfo): Promise<ApprovalDecision> {
+  request(info: ApprovalInfo, signal?: AbortSignal): Promise<ApprovalDecision> {
+    signal?.throwIfAborted()
     const id = this.deps.generateId()
     const request = { id, ...info, availableScopes: info.availableScopes ?? ['once'] }
 
     return new Promise<ApprovalDecision>((resolve) => {
-      const entry: PendingApproval = { request, resolve, remainingMs: this.timeoutMs }
+      const entry: PendingApproval = { request, resolve, remainingMs: this.timeoutMs, signal }
       this.pending.set(id, entry)
+      if (signal) {
+        entry.abortListener = () => this.settle(id, 'deny', 'cancelled')
+        signal.addEventListener('abort', entry.abortListener, { once: true })
+        if (signal.aborted) {
+          entry.abortListener()
+          return
+        }
+      }
       this.schedule(id, entry)
       this.deps.broadcast(request)
     })
@@ -119,11 +130,14 @@ export class ApprovalBroker {
   private settle(
     id: string,
     decision: ApprovalDecision,
-    state: 'resolved' | 'rejected' | 'expired'
+    state: 'resolved' | 'rejected' | 'expired' | 'cancelled'
   ): void {
     const entry = this.pending.get(id)
     if (!entry) return
     if (entry.timer !== undefined) this.clearTimer(entry.timer)
+    if (entry.signal && entry.abortListener) {
+      entry.signal.removeEventListener('abort', entry.abortListener)
+    }
     this.pending.delete(id)
     entry.resolve(decision)
     try {

--- a/src/main/connectors/descriptors/genes-reactome.test.ts
+++ b/src/main/connectors/descriptors/genes-reactome.test.ts
@@ -108,6 +108,34 @@ afterEach(() => {
 })
 
 describe('genes / map_reactome_pathways', () => {
+  it('aborts its direct Reactome request when the tool context is cancelled', async () => {
+    let observedSignal: AbortSignal | undefined
+    const fetchImpl = vi.fn(
+      async (_url: string, init?: RequestInit): Promise<Response> =>
+        new Promise((_, reject) => {
+          observedSignal = init?.signal ?? undefined
+          observedSignal?.addEventListener('abort', () => reject(observedSignal?.reason), {
+            once: true
+          })
+        })
+    )
+    vi.stubGlobal('fetch', fetchImpl)
+    const cancellation = new AbortController()
+
+    const pending = tool.run!(
+      { ...ctx, signal: cancellation.signal },
+      {
+        identifiers: ['TP53'],
+        id_type: 'symbol'
+      }
+    )
+    await vi.waitFor(() => expect(observedSignal).toBeInstanceOf(AbortSignal))
+    cancellation.abort()
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
   it('POSTs a newline-joined text/plain body with species/resource/includeDisease params', async () => {
     const fetchImpl = makeFetch()
     vi.stubGlobal('fetch', fetchImpl)

--- a/src/main/connectors/descriptors/genes-reactome.ts
+++ b/src/main/connectors/descriptors/genes-reactome.ts
@@ -1,4 +1,4 @@
-import type { ToolDescriptor } from '../types'
+import type { ToolContext, ToolDescriptor } from '../types'
 import { netFetchStandard } from '../../skills/net-fetch'
 
 // Reactome AnalysisService (over-representation / pathway projection).
@@ -45,14 +45,20 @@ type RxNotFoundRow = { id?: string }
 
 // Global-fetch wrapper with the shared User-Agent and an abort timeout (ctx methods can't set the
 // text/plain content-type Reactome requires — see the file header).
-async function reactomeFetch(url: string, init?: RequestInit): Promise<Response> {
+async function reactomeFetch(
+  url: string,
+  init?: RequestInit,
+  signal?: AbortSignal
+): Promise<Response> {
+  signal?.throwIfAborted()
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), HTTP_TIMEOUT_MS)
+  const requestSignal = signal ? AbortSignal.any([controller.signal, signal]) : controller.signal
   try {
     return await netFetchStandard(url, {
       ...init,
       headers: { 'user-agent': USER_AGENT, accept: 'application/json', ...init?.headers },
-      signal: controller.signal
+      signal: requestSignal
     })
   } finally {
     clearTimeout(timer)
@@ -70,19 +76,27 @@ function projectionUrl(species: string, resource: string, includeDisease: boolea
 }
 
 // POST a newline-joined identifier body as text/plain and parse the analysis result.
-async function submitProjection(url: string, body: string): Promise<RxAnalysis> {
-  const res = await reactomeFetch(url, {
-    method: 'POST',
-    headers: { 'content-type': 'text/plain' },
-    body
-  })
+async function submitProjection(
+  url: string,
+  body: string,
+  signal?: AbortSignal
+): Promise<RxAnalysis> {
+  const res = await reactomeFetch(
+    url,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+      body
+    },
+    signal
+  )
   if (!res.ok) throw new Error(`Reactome AnalysisService projection failed (HTTP ${res.status})`)
   return (await res.json()) as RxAnalysis
 }
 
 // The token from summary.token is already percent-encoded; use it verbatim in the path.
-async function fetchNotFound(token: string): Promise<string[]> {
-  const res = await reactomeFetch(`${BASE}/token/${token}/notFound`)
+async function fetchNotFound(token: string, signal?: AbortSignal): Promise<string[]> {
+  const res = await reactomeFetch(`${BASE}/token/${token}/notFound`, undefined, signal)
   if (!res.ok) return []
   const rows = (await res.json()) as RxNotFoundRow[]
   return (Array.isArray(rows) ? rows : [])
@@ -91,15 +105,20 @@ async function fetchNotFound(token: string): Promise<string[]> {
 }
 
 // Reactome database release (e.g. "97") as plain text; null when unavailable (never fails the tool).
-async function fetchVersion(): Promise<string | null> {
+async function fetchVersion(signal?: AbortSignal): Promise<string | null> {
   try {
-    const res = await reactomeFetch(`${BASE}/database/version`, {
-      headers: { accept: 'text/plain' }
-    })
+    const res = await reactomeFetch(
+      `${BASE}/database/version`,
+      {
+        headers: { accept: 'text/plain' }
+      },
+      signal
+    )
     if (!res.ok) return null
     const text = (await res.text()).trim()
     return text || null
-  } catch {
+  } catch (error) {
+    if (signal?.aborted) throw error
     return null
   }
 }
@@ -163,7 +182,7 @@ export const GENES_REACTOME_TOOLS: ToolDescriptor[] = [
       'compact {tool, reactome_version, id_type, species, resource, include_disease, n_input, genes:{identifier:{found, n_lowlevel_pathways, pathways:[{stId,name,species}]}}}; full replaces each pathways[] with full stats {stId,name,species,low_level,in_disease,entities:{total,found,ratio,p_value,fdr},reactions:{total,found,ratio}} and adds batch_summary {n_input, n_found, n_not_found, identifiers_not_found, distinct_lowlevel_pathways, batch_pathways_found}.',
     example:
       'const result = await host.mcp("genes", "map_reactome_pathways", {"identifiers": ["TP53", "EGFR", "BRCA1"], "id_type": "symbol"})',
-    run: async (_ctx, a) => {
+    run: async (ctx: ToolContext, a) => {
       const rawIds = a.identifiers
       if (!Array.isArray(rawIds)) throw new Error('identifiers must be an array of strings')
       const identifiers = rawIds.map((v) => String(v).trim()).filter((v) => v.length > 0)
@@ -186,10 +205,10 @@ export const GENES_REACTOME_TOOLS: ToolDescriptor[] = [
 
       // Batch submission: one text/plain POST of all identifiers newline-joined. Its token yields the
       // authoritative not-found split; batch.pathwaysFound is the pooled pathway count.
-      const version = await fetchVersion()
-      const batch = await submitProjection(url, identifiers.join('\n'))
+      const version = await fetchVersion(ctx.signal)
+      const batch = await submitProjection(url, identifiers.join('\n'), ctx.signal)
       const token = batch.summary?.token
-      const batchNotFound = new Set(token ? await fetchNotFound(token) : [])
+      const batchNotFound = new Set(token ? await fetchNotFound(token, ctx.signal) : [])
 
       const genes: Record<string, unknown> = {}
       const notFoundIds: string[] = []
@@ -202,7 +221,7 @@ export const GENES_REACTOME_TOOLS: ToolDescriptor[] = [
           notFoundIds.push(id)
           continue
         }
-        const single = await submitProjection(url, id)
+        const single = await submitProjection(url, id, ctx.signal)
         // Robust fallback: an identifier is found only if its own submission mapped it.
         if ((single.identifiersNotFound ?? 0) !== 0) {
           genes[id] = notFoundEntry(compact)

--- a/src/main/connectors/descriptors/regulation.test.ts
+++ b/src/main/connectors/descriptors/regulation.test.ts
@@ -72,6 +72,50 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
+describe('regulation / ENCODE cancellation', () => {
+  it('aborts an active direct ENCODE request', async () => {
+    let observedSignal: AbortSignal | undefined
+    const fetchImpl = vi.fn(
+      async (_url: string, init?: RequestInit): Promise<Response> =>
+        new Promise((_, reject) => {
+          observedSignal = init?.signal ?? undefined
+          observedSignal?.addEventListener('abort', () => reject(observedSignal?.reason), {
+            once: true
+          })
+        })
+    )
+    vi.stubGlobal('fetch', fetchImpl)
+    const cancellation = new AbortController()
+
+    const pending = tool('encode_get_experiment').run!(
+      { ...ENCODE_CTX, signal: cancellation.signal },
+      { accession: 'ENCSR000AKP' }
+    )
+    await vi.waitFor(() => expect(observedSignal).toBeInstanceOf(AbortSignal))
+    cancellation.abort()
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
+  it('aborts ENCODE retry backoff before another request starts', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('ECONNRESET'))
+    vi.stubGlobal('fetch', fetchImpl)
+    const cancellation = new AbortController()
+
+    const pending = tool('encode_get_experiment').run!(
+      { ...ENCODE_CTX, signal: cancellation.signal },
+      { accession: 'ENCSR000AKP' }
+    )
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledOnce())
+    await Promise.resolve()
+    cancellation.abort()
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+})
+
 describe('regulation / all 16 tools are registered', () => {
   it('exposes the exact ENCODE + JASPAR + UniBind tool ids', () => {
     expect(REGULATION_TOOLS.map((t) => t.id).sort()).toEqual(

--- a/src/main/connectors/descriptors/regulation.ts
+++ b/src/main/connectors/descriptors/regulation.ts
@@ -45,30 +45,51 @@ const ENCODE_UA = 'OpenScience/1.0 (+https://github.com/aipoch/open-science)'
 const ENCODE_TIMEOUT_MS = 60_000
 const ENCODE_RETRIES = 3
 const ENCODE_RETRYABLE = new Set([429, 500, 502, 503, 504])
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+const sleep = (ms: number, signal?: AbortSignal): Promise<void> => {
+  signal?.throwIfAborted()
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms))
+  return new Promise((resolve, reject) => {
+    const finish = (): void => {
+      signal.removeEventListener('abort', abort)
+      resolve()
+    }
+    const abort = (): void => {
+      clearTimeout(timer)
+      reject(signal.reason)
+    }
+    const timer = setTimeout(finish, ms)
+    signal.addEventListener('abort', abort, { once: true })
+  })
+}
 
-async function encodeFetchJson(url: string): Promise<unknown> {
+async function encodeFetchJson(url: string, signal?: AbortSignal): Promise<unknown> {
   for (let attempt = 0; ; attempt++) {
+    signal?.throwIfAborted()
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), ENCODE_TIMEOUT_MS)
+    const requestSignal = signal ? AbortSignal.any([controller.signal, signal]) : controller.signal
     let res: Response
     try {
       res = await netFetchStandard(url, {
         headers: { accept: 'application/json', 'user-agent': ENCODE_UA },
-        signal: controller.signal
+        signal: requestSignal
       })
     } catch (err) {
+      if (signal?.aborted) throw err
       if (attempt < ENCODE_RETRIES) {
-        await sleep(Math.min(400 * 2 ** attempt, 4000))
+        await sleep(Math.min(400 * 2 ** attempt, 4000), signal)
         continue
       }
       throw err
     } finally {
       clearTimeout(timer)
     }
-    if (res.ok) return res.json()
+    if (res.ok) {
+      signal?.throwIfAborted()
+      return res.json()
+    }
     if (attempt < ENCODE_RETRIES && ENCODE_RETRYABLE.has(res.status)) {
-      await sleep(Math.min(400 * 2 ** attempt, 4000))
+      await sleep(Math.min(400 * 2 ** attempt, 4000), signal)
       continue
     }
     throw new Error(`HTTP ${res.status} for ${url}`)
@@ -223,7 +244,8 @@ async function encodeSearchAll(
   filters: Record<string, unknown>,
   fields: string[],
   dateCutoff: string | undefined,
-  dateField: string
+  dateField: string,
+  signal?: AbortSignal
 ): Promise<{ total: number; rows: Record<string, unknown>[]; accessions: string[] }> {
   const rows: Record<string, unknown>[] = []
   const seen = new Set<unknown>()
@@ -233,7 +255,8 @@ async function encodeSearchAll(
     let doc: EncodeReport
     try {
       doc = (await encodeFetchJson(
-        encodeReportUrl(type, filters, fields, dateCutoff, dateField, offset)
+        encodeReportUrl(type, filters, fields, dateCutoff, dateField, offset),
+        signal
       )) as EncodeReport
     } catch (err) {
       // Documented zero-hit 404 on an empty search — surface as an empty, count-verified result.
@@ -426,7 +449,7 @@ export const REGULATION_TOOLS: ToolDescriptor[] = [
       '`{ total (exact), returned, truncated, accessions: [every matching accession, sorted], experiments: [ report rows: accession, assay_title, assay_term_name, target.label, biosample_ontology.term_name, status, date_released, lab.title ] }`.',
     example:
       'const result = await host.mcp("regulation", "encode_search_experiments", {"target": "CTCF", "assay_title": "TF ChIP-seq", "max_rows": 50})',
-    run: async (_ctx, a) => {
+    run: async (ctx, a) => {
       const filters = withExtraFilters(
         {
           status: a.status ?? 'released',
@@ -441,7 +464,8 @@ export const REGULATION_TOOLS: ToolDescriptor[] = [
         filters,
         EXPERIMENT_FIELDS,
         a.date_released_before ? String(a.date_released_before) : undefined,
-        'date_released'
+        'date_released',
+        ctx.signal
       )
       return encodeTruncate(out, 'experiments', Math.max(0, Number(a.max_rows ?? 100)))
     }
@@ -467,7 +491,7 @@ export const REGULATION_TOOLS: ToolDescriptor[] = [
       '`{ total, returned, truncated, accessions: [...], biosamples: [ report rows: accession, biosample_ontology.term_name/classification, organism.scientific_name, status, lab.title, summary, date_created ] }`.',
     example:
       'const result = await host.mcp("regulation", "encode_search_biosamples", {"term_name": "K562", "classification": "cell line", "max_rows": 25})',
-    run: async (_ctx, a) => {
+    run: async (ctx, a) => {
       const filters = withExtraFilters(
         {
           status: a.status ?? 'released',
@@ -482,7 +506,8 @@ export const REGULATION_TOOLS: ToolDescriptor[] = [
         filters,
         BIOSAMPLE_FIELDS,
         a.date_created_before ? String(a.date_created_before) : undefined,
-        'date_created'
+        'date_created',
+        ctx.signal
       )
       return encodeTruncate(out, 'biosamples', Math.max(0, Number(a.max_rows ?? 100)))
     }
@@ -508,7 +533,7 @@ export const REGULATION_TOOLS: ToolDescriptor[] = [
       '`{ total, returned, truncated, accessions: [...], files: [ report rows: accession, file_format, output_type, assay_term_name, assembly, dataset, status, file_size, date_created ] }`.',
     example:
       'const result = await host.mcp("regulation", "encode_list_files", {"file_format": "bed", "assay_term_name": "ChIP-seq", "biosample_term_name": "K562", "extra_filters": {"output_type": "peaks", "assembly": "GRCh38"}, "max_rows": 50})',
-    run: async (_ctx, a) => {
+    run: async (ctx, a) => {
       const filters = withExtraFilters(
         {
           status: a.status ?? 'released',
@@ -523,7 +548,8 @@ export const REGULATION_TOOLS: ToolDescriptor[] = [
         filters,
         FILE_FIELDS,
         a.date_created_before ? String(a.date_created_before) : undefined,
-        'date_created'
+        'date_created',
+        ctx.signal
       )
       return encodeTruncate(out, 'files', Math.max(0, Number(a.max_rows ?? 100)))
     }
@@ -543,9 +569,10 @@ export const REGULATION_TOOLS: ToolDescriptor[] = [
       '`{ record_type: "experiment", accession, status, assay_term_name, assay_title, target_label, biosample_term_name, biosample_classification, biosample_summary, description, lab, award_project, date_released, date_submitted, assembly: [...], bio_replicate_count, tech_replicate_count, replication_type, dbxrefs: [...], doi, uuid }`.',
     example:
       'const result = await host.mcp("regulation", "encode_get_experiment", {"accession": "ENCSR000AKP"})',
-    run: async (_ctx, a) => {
+    run: async (ctx, a) => {
       const raw = await encodeFetchJson(
-        `${ENCODE}/${encodeURIComponent(String(a.accession))}/?format=json`
+        `${ENCODE}/${encodeURIComponent(String(a.accession))}/?format=json`,
+        ctx.signal
       )
       return experimentRecord(asRecord(raw))
     }
@@ -565,9 +592,10 @@ export const REGULATION_TOOLS: ToolDescriptor[] = [
       '`{ record_type: "file", accession, status, file_format, file_format_type, output_type, output_category, assay_term_name, assembly, dataset, biological_replicates: [...], file_size, md5sum, content_md5sum, run_type, read_length, lab, date_created, href, uuid }`.',
     example:
       'const result = await host.mcp("regulation", "encode_get_file", {"accession": "ENCFF002JUR"})',
-    run: async (_ctx, a) => {
+    run: async (ctx, a) => {
       const raw = await encodeFetchJson(
-        `${ENCODE}/${encodeURIComponent(String(a.accession))}/?format=json`
+        `${ENCODE}/${encodeURIComponent(String(a.accession))}/?format=json`,
+        ctx.signal
       )
       return fileRecord(asRecord(raw))
     }
@@ -587,9 +615,10 @@ export const REGULATION_TOOLS: ToolDescriptor[] = [
       '`{ record_type: "biosample", accession, status, term_name, classification, organism, donor, source, lab, summary, life_stage, age_display, sex, treatments: [...], genetic_modifications: [...], date_created, uuid }`.',
     example:
       'const result = await host.mcp("regulation", "encode_get_biosample", {"accession": "ENCBS013JZP"})',
-    run: async (_ctx, a) => {
+    run: async (ctx, a) => {
       const raw = await encodeFetchJson(
-        `${ENCODE}/${encodeURIComponent(String(a.accession))}/?format=json`
+        `${ENCODE}/${encodeURIComponent(String(a.accession))}/?format=json`,
+        ctx.signal
       )
       return biosampleRecord(asRecord(raw))
     }

--- a/src/main/connectors/descriptors/zinc.test.ts
+++ b/src/main/connectors/descriptors/zinc.test.ts
@@ -72,6 +72,57 @@ describe('zinc / registration', () => {
   })
 })
 
+describe('zinc / cancellation', () => {
+  it('aborts an active direct ZINC request', async () => {
+    let observedSignal: AbortSignal | undefined
+    const fetchImpl = vi.fn(
+      async (_url: string, init?: RequestInit): Promise<Response> =>
+        new Promise((_, reject) => {
+          observedSignal = init?.signal ?? undefined
+          observedSignal?.addEventListener('abort', () => reject(observedSignal?.reason), {
+            once: true
+          })
+        })
+    )
+    vi.stubGlobal('fetch', fetchImpl)
+    const cancellation = new AbortController()
+
+    const pending = byId.run!(
+      { ...ctx, signal: cancellation.signal },
+      {
+        zinc_ids: ['ZINC000000000012']
+      }
+    )
+    await vi.waitFor(() => expect(observedSignal).toBeInstanceOf(AbortSignal))
+    cancellation.abort()
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
+  it('aborts polling backoff before another request starts', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(textRes(200, { task: 'ZTASK-CANCEL' }))
+      .mockResolvedValueOnce(textRes(200, { status: 'PENDING' }))
+    vi.stubGlobal('fetch', fetchImpl)
+    const cancellation = new AbortController()
+
+    const pending = byId.run!(
+      { ...ctx, signal: cancellation.signal },
+      {
+        zinc_ids: ['ZINC000000000012']
+      }
+    )
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2))
+    await Promise.resolve()
+    cancellation.abort()
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+})
+
 describe('zinc / zinc_search_by_id', () => {
   it('POSTs form-encoded fields to substances.txt, polls to SUCCESS, and returns the bounded shape', async () => {
     const { out, fetchImpl } = await drive(byId, { zinc_ids: ['ZINC000000000012'] }, [

--- a/src/main/connectors/descriptors/zinc.ts
+++ b/src/main/connectors/descriptors/zinc.ts
@@ -176,18 +176,38 @@ function bodyExcerpt(text: string, n = 200): string {
   return excerpt || '<empty body>'
 }
 
+const sleep = (ms: number, signal?: AbortSignal): Promise<void> => {
+  signal?.throwIfAborted()
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms))
+  return new Promise((resolve, reject) => {
+    const finish = (): void => {
+      signal.removeEventListener('abort', abort)
+      resolve()
+    }
+    const abort = (): void => {
+      clearTimeout(timer)
+      reject(signal.reason)
+    }
+    const timer = setTimeout(finish, ms)
+    signal.addEventListener('abort', abort, { once: true })
+  })
+}
+
 async function fetchWithTimeout(
   url: string,
   init: RequestInit,
-  timeoutMs: number
+  timeoutMs: number,
+  signal?: AbortSignal
 ): Promise<Response> {
+  signal?.throwIfAborted()
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), Math.max(1, timeoutMs))
+  const requestSignal = signal ? AbortSignal.any([controller.signal, signal]) : controller.signal
   try {
     return await netFetchStandard(url, {
       ...init,
       headers: { 'user-agent': USER_AGENT, ...init.headers },
-      signal: controller.signal
+      signal: requestSignal
     })
   } finally {
     clearTimeout(timer)
@@ -198,7 +218,8 @@ async function fetchWithTimeout(
 async function submit(
   endpoint: string,
   data: Record<string, string>,
-  deadline: number
+  deadline: number,
+  signal?: AbortSignal
 ): Promise<string> {
   const url = `${BASE_URL}/${endpoint}`
   const budgetMs = Math.min(HTTP_TIMEOUT_MS, Math.max(1000, deadline - Date.now()))
@@ -209,7 +230,8 @@ async function submit(
       headers: { 'content-type': 'application/x-www-form-urlencoded', accept: 'application/json' },
       body: new URLSearchParams(data).toString()
     },
-    budgetMs
+    budgetMs,
+    signal
   )
   const text = await res.text()
   if (res.status === 400) {
@@ -246,11 +268,16 @@ const PENDING_STATUSES = new Set(['PENDING', 'STARTED', 'PROGRESS', 'RETRY'])
 // Poll /search/result/<task> until completion (SUCCESS, or a status-less body whose `result` key
 // is present); throws a ZINC-task-timeout error naming the task uuid for manual re-poll once the
 // deadline passes, mirroring upstream ZincTaskTimeout.
-async function poll(task: string, deadline: number): Promise<PollResponse> {
+async function poll(task: string, deadline: number, signal?: AbortSignal): Promise<PollResponse> {
   const url = `${BASE_URL}/search/result/${encodeURIComponent(task)}`
   for (;;) {
     const budgetMs = Math.min(HTTP_TIMEOUT_MS, Math.max(1000, deadline - Date.now()))
-    const res = await fetchWithTimeout(url, { headers: { accept: 'application/json' } }, budgetMs)
+    const res = await fetchWithTimeout(
+      url,
+      { headers: { accept: 'application/json' } },
+      budgetMs,
+      signal
+    )
     const text = await res.text()
     if (!res.ok) {
       throw new Error(`polling ZINC task ${task} returned HTTP ${res.status}: ${bodyExcerpt(text)}`)
@@ -285,7 +312,7 @@ async function poll(task: string, deadline: number): Promise<PollResponse> {
       )
     }
     const wait = Math.min(POLL_INTERVAL_MS, Math.max(0, deadline - Date.now()))
-    await new Promise((resolve) => setTimeout(resolve, wait))
+    await sleep(wait, signal)
   }
 }
 
@@ -325,11 +352,12 @@ function flattenResult(result: unknown): FlatResult {
 async function runSearch(
   endpoint: string,
   data: Record<string, string>,
-  timeoutS: number
+  timeoutS: number,
+  signal?: AbortSignal
 ): Promise<FlatResult> {
   const deadline = Date.now() + timeoutS * 1000
-  const task = await submit(endpoint, data, deadline)
-  const payload = await poll(task, deadline)
+  const task = await submit(endpoint, data, deadline, signal)
+  const payload = await poll(task, deadline, signal)
   return flattenResult(payload.result)
 }
 
@@ -395,13 +423,14 @@ export const ZINC_TOOLS: ToolDescriptor[] = [
       '`{ "query", "total_available", "returned_count", "truncated", "source_counts": { "zinc22": int, ... }, "records": [ { "zinc_id", "smiles", "tranche_name", "catalogs", "source", "tranche_properties": { "heavy_atoms", "logp" } } ] }` — records capped at `max_results` (default 50, cap 500); `truncated` true when more were available. `source` is "zinc22"/"zinc20"; ids with no match simply have no record.',
     example:
       'const result = await host.mcp("zinc", "zinc_search_by_id", {"zinc_ids": ["ZINC000000000012"]})',
-    run: async (_ctx, a) => {
+    run: async (ctx, a) => {
       const ids = requireIds(a.zinc_ids, MAX_IDS_PER_CALL, 'ZINC id', ZINC_ID_RE)
       const cap = clampMaxResults(a.max_results)
       const { records, counts } = await runSearch(
         'substances.txt',
         { zinc_ids: ids.join(','), output_fields: OUTPUT_FIELDS },
-        clampTimeoutS(a.timeout_s)
+        clampTimeoutS(a.timeout_s),
+        ctx.signal
       )
       return pageResult(records, counts, cap, { zinc_ids: ids })
     }
@@ -447,7 +476,7 @@ export const ZINC_TOOLS: ToolDescriptor[] = [
       'The standard bounded shape (`query`, `total_available`, `returned_count`, `truncated`, `source_counts`, `records`) with records as in `zinc_search_by_id`. `query` echoes the resolved `{ smiles, dist, adist }`.',
     example:
       'const result = await host.mcp("zinc", "zinc_search_by_smiles", {"smiles": "CC(=O)Oc1ccccc1C(=O)O", "dist": 2})',
-    run: async (_ctx, a) => {
+    run: async (ctx, a) => {
       const smiles = typeof a.smiles === 'string' ? a.smiles.trim() : ''
       if (!smiles) throw new Error('smiles must be a non-empty SMILES string')
       const dist = requireDistance(a.dist, 0, 'dist must be 0-10 (Tanimoto distance; 0 = exact)')
@@ -459,7 +488,8 @@ export const ZINC_TOOLS: ToolDescriptor[] = [
       const { records, counts } = await runSearch(
         'smiles.txt',
         { smiles, dist: String(dist), adist: String(adist), output_fields: OUTPUT_FIELDS },
-        clampTimeoutS(a.timeout_s)
+        clampTimeoutS(a.timeout_s),
+        ctx.signal
       )
       return pageResult(records, counts, cap, { smiles, dist, adist })
     }
@@ -495,7 +525,7 @@ export const ZINC_TOOLS: ToolDescriptor[] = [
       'The standard bounded shape; records additionally carry `supplier_code` alongside `zinc_id`/`smiles`/`catalogs`/`tranche_name`/`tranche_properties`.',
     example:
       'const result = await host.mcp("zinc", "zinc_search_by_supplier", {"supplier_codes": ["MCULE-2311834287"]})',
-    run: async (_ctx, a) => {
+    run: async (ctx, a) => {
       const codes = requireIds(a.supplier_codes, MAX_IDS_PER_CALL, 'supplier code')
       const cap = clampMaxResults(a.max_results)
       const { records, counts } = await runSearch(
@@ -504,7 +534,8 @@ export const ZINC_TOOLS: ToolDescriptor[] = [
           supplier_codes: codes.join(','),
           output_fields: 'zinc_id,smiles,supplier_code,catalogs,tranche_name'
         },
-        clampTimeoutS(a.timeout_s)
+        clampTimeoutS(a.timeout_s),
+        ctx.signal
       )
       return pageResult(records, counts, cap, { supplier_codes: codes })
     }
@@ -539,7 +570,7 @@ export const ZINC_TOOLS: ToolDescriptor[] = [
       'The standard bounded shape with records as in `zinc_search_by_id` (random order). `query` echoes `{ count, subset, known_subsets }`.',
     example:
       'const result = await host.mcp("zinc", "zinc_random_sample", {"count": 25, "subset": "lead-like"})',
-    run: async (_ctx, a) => {
+    run: async (ctx, a) => {
       const cap = clampMaxResults(a.count)
       const subset = typeof a.subset === 'string' && a.subset.trim() ? a.subset.trim() : undefined
       const data: Record<string, string> = { count: String(cap), output_fields: OUTPUT_FIELDS }
@@ -547,7 +578,8 @@ export const ZINC_TOOLS: ToolDescriptor[] = [
       const { records, counts } = await runSearch(
         'substance/random.txt',
         data,
-        clampTimeoutS(a.timeout_s)
+        clampTimeoutS(a.timeout_s),
+        ctx.signal
       )
       return pageResult(records, counts, cap, {
         count: cap,
@@ -582,13 +614,14 @@ export const ZINC_TOOLS: ToolDescriptor[] = [
       '`{ "query", "returned_count", "structures", "repository_note" }`; each structure carries `zinc_id`, `found`, `smiles`, `source`, `tranche_name` + `tranche_properties`, and (when the tranche decodes) `download`: `{ repository, tranche_path_pattern: "zinc-22*/H##/<tranche>/", formats }`. Sub-release directories (zinc-22a, zinc-22b, …) must be browsed for exact file names — the repository has no per-compound fetch URL.',
     example:
       'const result = await host.mcp("zinc", "zinc_get_3d", {"zinc_ids": ["ZINC000000000012"]})',
-    run: async (_ctx, a) => {
+    run: async (ctx, a) => {
       const ids = requireIds(a.zinc_ids, MAX_IDS_3D, 'ZINC id', ZINC_ID_RE)
       const canonical = ids.map(normalizeZincId)
       const { records } = await runSearch(
         'substances.txt',
         { zinc_ids: canonical.join(','), output_fields: OUTPUT_FIELDS },
-        clampTimeoutS(a.timeout_s)
+        clampTimeoutS(a.timeout_s),
+        ctx.signal
       )
       // Key the result map by NORMALIZED id: upstream returns zero-padded ids, so a short-form
       // input would otherwise miss its own result and report an authoritative-looking found:false.

--- a/src/main/connectors/engine.test.ts
+++ b/src/main/connectors/engine.test.ts
@@ -144,6 +144,20 @@ describe('ParserEngine declarative path', () => {
     expect(fetchImpl).toHaveBeenCalledOnce()
   })
 
+  it('exposes the caller signal to run-style descriptors', async () => {
+    const engine = new ParserEngine({ fetchImpl: vi.fn() })
+    const cancellation = new AbortController()
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      run: async (ctx) => ctx.signal
+    }
+
+    await expect(engine.call(desc, {}, {}, cancellation.signal)).resolves.toBe(cancellation.signal)
+  })
+
   it('does not retry a client error (4xx other than 429)', async () => {
     const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 400 } as Response)
     const engine = new ParserEngine({ fetchImpl, retryBackoffMs: 0 })

--- a/src/main/connectors/engine.test.ts
+++ b/src/main/connectors/engine.test.ts
@@ -92,6 +92,58 @@ describe('ParserEngine declarative path', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2)
   })
 
+  it('aborts an active request without retrying it', async () => {
+    let observedSignal: AbortSignal | undefined
+    const fetchImpl = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit): Promise<Response> =>
+        new Promise((_, reject) => {
+          observedSignal = init?.signal ?? undefined
+          observedSignal?.addEventListener('abort', () => reject(observedSignal?.reason), {
+            once: true
+          })
+        })
+    )
+    const engine = new ParserEngine({ fetchImpl, retries: 2, retryBackoffMs: 0 })
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      url: () => 'https://x.test',
+      parse: (raw) => raw
+    }
+    const cancellation = new AbortController()
+
+    const call = engine.call(desc, {}, {}, cancellation.signal)
+    await vi.waitFor(() => expect(observedSignal).toBeInstanceOf(AbortSignal))
+    cancellation.abort()
+
+    await expect(call).rejects.toMatchObject({ name: 'AbortError' })
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
+  it('aborts retry backoff before another request starts', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('ECONNRESET'))
+    const engine = new ParserEngine({ fetchImpl, retries: 2, retryBackoffMs: 60_000 })
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      url: () => 'https://x.test',
+      parse: (raw) => raw
+    }
+    const cancellation = new AbortController()
+
+    const call = engine.call(desc, {}, {}, cancellation.signal)
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledOnce())
+    await Promise.resolve()
+    cancellation.abort()
+
+    await expect(call).rejects.toMatchObject({ name: 'AbortError' })
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
   it('does not retry a client error (4xx other than 429)', async () => {
     const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 400 } as Response)
     const engine = new ParserEngine({ fetchImpl, retryBackoffMs: 0 })

--- a/src/main/connectors/engine.ts
+++ b/src/main/connectors/engine.ts
@@ -142,6 +142,7 @@ export class ParserEngine {
       }
     }
     return {
+      ...(signal ? { signal } : {}),
       credentials,
       fetchJson: async (url) => (await doFetch(url, 'application/json')).json(),
       fetchJsonWithHeaders: async (url) => {

--- a/src/main/connectors/engine.ts
+++ b/src/main/connectors/engine.ts
@@ -9,7 +9,23 @@ const DEFAULT_RETRIES = 2
 const DEFAULT_BACKOFF_MS = 400
 const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504])
 
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+const sleep = (ms: number, signal?: AbortSignal): Promise<void> => {
+  signal?.throwIfAborted()
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms))
+
+  return new Promise((resolve, reject) => {
+    const finish = (): void => {
+      signal.removeEventListener('abort', abort)
+      resolve()
+    }
+    const abort = (): void => {
+      clearTimeout(timer)
+      reject(signal.reason)
+    }
+    const timer = setTimeout(finish, ms)
+    signal.addEventListener('abort', abort, { once: true })
+  })
+}
 
 // Some public APIs (e.g. AlphaFold EBI) reject requests without a User-Agent; send a stable one.
 const USER_AGENT =
@@ -58,13 +74,19 @@ export class ParserEngine {
   async call(
     descriptor: ToolDescriptor,
     args: Record<string, unknown>,
-    credentials: ConnectorCredentials
+    credentials: ConnectorCredentials,
+    signal?: AbortSignal
   ): Promise<unknown> {
+    signal?.throwIfAborted()
     for (const key of descriptor.required ?? []) {
       if (args[key] == null) throw new Error(`missing required arg: ${key}`)
     }
-    const ctx = this.makeContext(credentials)
-    if (descriptor.run) return descriptor.run(ctx, args)
+    const ctx = this.makeContext(credentials, signal)
+    if (descriptor.run) {
+      const result = await descriptor.run(ctx, args)
+      signal?.throwIfAborted()
+      return result
+    }
     if (!descriptor.url || !descriptor.parse) {
       throw new Error(`descriptor ${descriptor.id} needs either run() or url()+parse()`)
     }
@@ -73,7 +95,7 @@ export class ParserEngine {
     return descriptor.parse(raw, args)
   }
 
-  private makeContext(credentials: ConnectorCredentials): ToolContext {
+  private makeContext(credentials: ConnectorCredentials, signal?: AbortSignal): ToolContext {
     // Delay before the next attempt: honour a numeric Retry-After (seconds, capped), else exponential
     // backoff with jitter off the configured base.
     const nextDelay = (attempt: number, retryAfter: string | null): number => {
@@ -86,27 +108,34 @@ export class ParserEngine {
       for (let attempt = 0; ; attempt++) {
         const controller = new AbortController()
         const timer = setTimeout(() => controller.abort(), this.timeoutMs)
+        const requestSignal = signal
+          ? AbortSignal.any([controller.signal, signal])
+          : controller.signal
         let res: Response
         try {
           res = await this.fetchImpl(url, {
             ...init,
             headers: { accept, 'user-agent': USER_AGENT, ...init?.headers },
-            signal: controller.signal
+            signal: requestSignal
           })
         } catch (err) {
+          if (signal?.aborted) throw err
           // Network failure or timeout abort — retry a bounded number of times, then give up.
           if (attempt < this.retries) {
-            await sleep(nextDelay(attempt, null))
+            await sleep(nextDelay(attempt, null), signal)
             continue
           }
           throw err
         } finally {
           clearTimeout(timer)
         }
-        if (res.ok) return res
+        if (res.ok) {
+          signal?.throwIfAborted()
+          return res
+        }
         // Retry only transient upstream statuses; client errors (4xx except 429) fail fast.
         if (attempt < this.retries && RETRYABLE_STATUS.has(res.status)) {
-          await sleep(nextDelay(attempt, res.headers?.get?.('retry-after') ?? null))
+          await sleep(nextDelay(attempt, res.headers?.get?.('retry-after') ?? null), signal)
           continue
         }
         throw new Error(`HTTP ${res.status} for ${redactUrl(url)}`)

--- a/src/main/connectors/mcp-client-manager.test.ts
+++ b/src/main/connectors/mcp-client-manager.test.ts
@@ -88,6 +88,87 @@ describe('McpClientManager', () => {
     )
   })
 
+  it('cancels a sole initial connection and discards a client that resolves afterward', async () => {
+    let resolveFirst!: (client: Client) => void
+    const firstConnection = new Promise<Client>((resolve) => {
+      resolveFirst = resolve
+    })
+    const firstClient = {
+      close: vi.fn(async () => undefined),
+      listTools: vi.fn(async () => ({ tools: [] }))
+    } as unknown as Client
+    const secondClient = {
+      close: vi.fn(async () => undefined),
+      listTools: vi.fn(async () => ({ tools: [{ name: 'echo' }] }))
+    } as unknown as Client
+    const connectionSignals: AbortSignal[] = []
+    const createClient = vi.fn(
+      async (
+        _config: CustomMcpServerConfig,
+        _authProvider?: PersistentOAuthClientProvider,
+        signal?: AbortSignal
+      ) => {
+        if (signal) connectionSignals.push(signal)
+        return createClient.mock.calls.length === 1 ? firstConnection : secondClient
+      }
+    )
+    const manager = new McpClientManager({ createClient })
+    const cancellation = new AbortController()
+
+    const pending = manager.listTools(config, cancellation.signal)
+    await vi.waitFor(() => expect(createClient).toHaveBeenCalledOnce())
+    cancellation.abort()
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+    expect(connectionSignals[0]?.aborted).toBe(true)
+
+    await expect(manager.listTools(config)).resolves.toEqual([{ name: 'echo' }])
+    expect(createClient).toHaveBeenCalledTimes(2)
+
+    resolveFirst(firstClient)
+    await vi.waitFor(() => expect(firstClient.close).toHaveBeenCalledOnce())
+    await manager.closeAll()
+  })
+
+  it('keeps a shared initial connection alive while another caller is still waiting', async () => {
+    let resolveConnection!: (client: Client) => void
+    const connection = new Promise<Client>((resolve) => {
+      resolveConnection = resolve
+    })
+    const client = {
+      close: vi.fn(async () => undefined),
+      listTools: vi.fn(async () => ({ tools: [{ name: 'echo' }] }))
+    } as unknown as Client
+    let connectionSignal: AbortSignal | undefined
+    const createClient = vi.fn(
+      async (
+        _config: CustomMcpServerConfig,
+        _authProvider?: PersistentOAuthClientProvider,
+        signal?: AbortSignal
+      ) => {
+        connectionSignal = signal
+        return connection
+      }
+    )
+    const manager = new McpClientManager({ createClient })
+    const cancelledCaller = new AbortController()
+    const activeCaller = new AbortController()
+
+    const cancelled = manager.listTools(config, cancelledCaller.signal)
+    const active = manager.listTools(config, activeCaller.signal)
+    await vi.waitFor(() => expect(createClient).toHaveBeenCalledOnce())
+    cancelledCaller.abort()
+
+    await expect(cancelled).rejects.toMatchObject({ name: 'AbortError' })
+    expect(connectionSignal?.aborted).toBe(false)
+
+    resolveConnection(client)
+    await expect(active).resolves.toEqual([{ name: 'echo' }])
+    expect(createClient).toHaveBeenCalledOnce()
+    expect(client.close).not.toHaveBeenCalled()
+    await manager.closeAll()
+  })
+
   it('throws when the tool result has isError set', async () => {
     const { createClient } = makeTestServer()
     const manager = new McpClientManager({ createClient: () => createClient() })

--- a/src/main/connectors/mcp-client-manager.test.ts
+++ b/src/main/connectors/mcp-client-manager.test.ts
@@ -70,6 +70,24 @@ describe('McpClientManager', () => {
     expect(out).toEqual({ value: 'hello' })
   })
 
+  it('passes the caller signal to MCP discovery and tool requests', async () => {
+    const { createClient } = makeTestServer()
+    const listTools = vi.spyOn(Client.prototype, 'listTools')
+    const callTool = vi.spyOn(Client.prototype, 'callTool')
+    const manager = new McpClientManager({ createClient: () => createClient() })
+    const cancellation = new AbortController()
+
+    await manager.listTools(config, cancellation.signal)
+    await manager.call(config, 'echo', { value: 'hello' }, cancellation.signal)
+
+    expect(listTools).toHaveBeenCalledWith(undefined, { signal: cancellation.signal })
+    expect(callTool).toHaveBeenCalledWith(
+      { name: 'echo', arguments: { value: 'hello' } },
+      undefined,
+      { signal: cancellation.signal }
+    )
+  })
+
   it('throws when the tool result has isError set', async () => {
     const { createClient } = makeTestServer()
     const manager = new McpClientManager({ createClient: () => createClient() })

--- a/src/main/connectors/mcp-client-manager.ts
+++ b/src/main/connectors/mcp-client-manager.ts
@@ -138,19 +138,32 @@ export class McpClientManager {
     this.saveOAuthState = deps?.saveOAuthState
   }
 
-  async listTools(config: CustomMcpServerConfig): Promise<McpClientManagerTool[]> {
+  async listTools(
+    config: CustomMcpServerConfig,
+    signal?: AbortSignal
+  ): Promise<McpClientManagerTool[]> {
+    signal?.throwIfAborted()
     const client = await this.connect(config)
-    const { tools } = await client.listTools()
+    signal?.throwIfAborted()
+    const { tools } = signal
+      ? await client.listTools(undefined, { signal })
+      : await client.listTools()
     return tools
   }
 
   async call(
     config: CustomMcpServerConfig,
     method: string,
-    args: Record<string, unknown>
+    args: Record<string, unknown>,
+    signal?: AbortSignal
   ): Promise<unknown> {
+    signal?.throwIfAborted()
     const client = await this.connect(config)
-    const result = await client.callTool({ name: method, arguments: args })
+    signal?.throwIfAborted()
+    const input = { name: method, arguments: args }
+    const result = signal
+      ? await client.callTool(input, undefined, { signal })
+      : await client.callTool(input)
     return unwrapToolResult(result)
   }
 

--- a/src/main/connectors/mcp-client-manager.ts
+++ b/src/main/connectors/mcp-client-manager.ts
@@ -51,10 +51,43 @@ export class McpToolCallError extends Error {
 type McpClientManagerDeps = {
   createClient?: (
     config: CustomMcpServerConfig,
-    authProvider?: PersistentOAuthClientProvider
+    authProvider?: PersistentOAuthClientProvider,
+    signal?: AbortSignal
   ) => Promise<Client>
   openExternal?: (url: string) => Promise<void> | void
   saveOAuthState?: (serverId: string, state: StoredCustomMcpOAuthState) => Promise<void>
+}
+
+type ConnectionAttempt = {
+  controller: AbortController
+  promise: Promise<Client>
+  waiters: number
+  settled: boolean
+}
+
+function waitForConnection(promise: Promise<Client>, signal?: AbortSignal): Promise<Client> {
+  if (!signal) return promise
+  signal.throwIfAborted()
+
+  return new Promise((resolve, reject) => {
+    const cleanup = (): void => signal.removeEventListener('abort', abort)
+    const abort = (): void => {
+      cleanup()
+      reject(signal.reason)
+    }
+    signal.addEventListener('abort', abort, { once: true })
+    promise.then(
+      (client) => {
+        cleanup()
+        resolve(client)
+      },
+      (error) => {
+        cleanup()
+        reject(error)
+      }
+    )
+    if (signal.aborted) abort()
+  })
 }
 
 // Pure factory: picks the transport for a custom server config. Exported so callers/tests can
@@ -101,11 +134,12 @@ export function buildTransport(
 // Default factory: build the transport for the server's configured type and connect an MCP client.
 async function defaultCreateClient(
   config: CustomMcpServerConfig,
-  authProvider?: PersistentOAuthClientProvider
+  authProvider?: PersistentOAuthClientProvider,
+  signal?: AbortSignal
 ): Promise<Client> {
   const transport = buildTransport(config, authProvider)
   const client = new Client({ name: 'open-science', version: '0.0.0' })
-  await client.connect(transport)
+  await client.connect(transport, signal ? { signal } : undefined)
   return client
 }
 
@@ -115,10 +149,11 @@ async function defaultCreateClient(
 export class McpClientManager {
   private readonly createClient: (
     config: CustomMcpServerConfig,
-    authProvider?: PersistentOAuthClientProvider
+    authProvider?: PersistentOAuthClientProvider,
+    signal?: AbortSignal
   ) => Promise<Client>
   private readonly clients = new Map<string, Client>()
-  private readonly connecting = new Map<string, Promise<Client>>()
+  private readonly connecting = new Map<string, ConnectionAttempt>()
   private readonly authenticationCancels = new Map<string, () => Promise<void>>()
   private readonly generations = new Map<string, number>()
   private readonly callbackServer = new OAuthCallbackServer()
@@ -143,7 +178,7 @@ export class McpClientManager {
     signal?: AbortSignal
   ): Promise<McpClientManagerTool[]> {
     signal?.throwIfAborted()
-    const client = await this.connect(config)
+    const client = await this.connect(config, signal)
     signal?.throwIfAborted()
     const { tools } = signal
       ? await client.listTools(undefined, { signal })
@@ -158,7 +193,7 @@ export class McpClientManager {
     signal?: AbortSignal
   ): Promise<unknown> {
     signal?.throwIfAborted()
-    const client = await this.connect(config)
+    const client = await this.connect(config, signal)
     signal?.throwIfAborted()
     const input = { name: method, arguments: args }
     const result = signal
@@ -169,12 +204,14 @@ export class McpClientManager {
 
   async close(id: string): Promise<void> {
     this.generations.set(id, this.generation(id) + 1)
+    const attempt = this.connecting.get(id)
+    this.connecting.delete(id)
+    attempt?.controller.abort()
     const cancelAuthentication = this.authenticationCancels.get(id)
     this.authenticationCancels.delete(id)
     await cancelAuthentication?.()
     const client = this.clients.get(id)
     this.clients.delete(id)
-    this.connecting.delete(id)
     if (client) await client.close()
   }
 
@@ -270,40 +307,67 @@ export class McpClientManager {
     }
   }
 
-  // Lazily connects, caching the client by server id and deduping concurrent connect calls.
-  private async connect(config: CustomMcpServerConfig): Promise<Client> {
+  // Lazily connects, caching the client by server id and deduping concurrent connect calls. Each
+  // caller can stop waiting independently; the underlying connection is cancelled only once no
+  // callers remain, so one disconnected RPC cannot interrupt another caller sharing the attempt.
+  private async connect(config: CustomMcpServerConfig, signal?: AbortSignal): Promise<Client> {
+    signal?.throwIfAborted()
     const cached = this.clients.get(config.id)
     if (cached) return cached
 
-    const inFlight = this.connecting.get(config.id)
-    if (inFlight) return inFlight
+    let attempt = this.connecting.get(config.id)
+    if (!attempt) {
+      const generation = this.generation(config.id)
+      const controller = new AbortController()
+      const promise = this.createClientWithOAuth(config, generation, controller.signal)
+        .then(async (client) => {
+          if (generation !== this.generation(config.id)) {
+            await client.close().catch(() => undefined)
+            throw new Error(`custom MCP server "${config.name}" connection was superseded`)
+          }
+          if (controller.signal.aborted) {
+            await client.close().catch(() => undefined)
+            controller.signal.throwIfAborted()
+          }
+          this.clients.set(config.id, client)
+          return client
+        })
+        .finally(() => {
+          const current = this.connecting.get(config.id)
+          if (current?.promise === promise) {
+            current.settled = true
+            this.connecting.delete(config.id)
+          }
+        })
+      const entry: ConnectionAttempt = { controller, promise, waiters: 0, settled: false }
+      this.connecting.set(config.id, entry)
+      attempt = entry
+    }
 
-    const generation = this.generation(config.id)
-    const connectPromise = this.createClientWithOAuth(config, generation)
-      .then(async (client) => {
-        if (generation !== this.generation(config.id)) {
-          await client.close().catch(() => undefined)
-          throw new Error(`custom MCP server "${config.name}" connection was superseded`)
-        }
-        this.clients.set(config.id, client)
-        return client
-      })
-      .finally(() => {
-        if (this.connecting.get(config.id) === connectPromise) {
+    attempt.waiters += 1
+    try {
+      return await waitForConnection(attempt.promise, signal)
+    } finally {
+      attempt.waiters -= 1
+      if (attempt.waiters === 0 && !attempt.settled) {
+        if (this.connecting.get(config.id) === attempt) {
           this.connecting.delete(config.id)
         }
-      })
-    this.connecting.set(config.id, connectPromise)
-    return connectPromise
+        attempt.controller.abort(signal?.reason)
+      }
+    }
   }
 
   private async createClientWithOAuth(
     config: CustomMcpServerConfig,
-    generation: number
+    generation: number,
+    signal: AbortSignal
   ): Promise<Client> {
-    if (!config.oauth) return this.createClient(config)
+    signal.throwIfAborted()
+    if (!config.oauth) return this.createClient(config, undefined, signal)
     const redirectUrl = await this.callbackServer.ensureStarted()
-    return this.createClient(config, this.oauthProvider(config, redirectUrl, generation))
+    signal.throwIfAborted()
+    return this.createClient(config, this.oauthProvider(config, redirectUrl, generation), signal)
   }
 
   private oauthProvider(

--- a/src/main/connectors/molecule-preview.test.ts
+++ b/src/main/connectors/molecule-preview.test.ts
@@ -47,4 +47,20 @@ describe('molecule preview handler', () => {
     )
     expect(writeArtifactForCurrentRun).not.toHaveBeenCalled()
   })
+
+  it('does not publish an Artifact after its connector call is cancelled', async () => {
+    const writeArtifactForCurrentRun = vi.fn()
+    const handler = createMoleculePreviewHandler({ writeArtifactForCurrentRun })
+    const cancellation = new AbortController()
+    cancellation.abort()
+
+    await expect(
+      handler(
+        { smiles: ASPIRIN_SMILES, filename: 'aspirin' },
+        { sessionId: 's-1' },
+        cancellation.signal
+      )
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(writeArtifactForCurrentRun).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/connectors/molecule-preview.ts
+++ b/src/main/connectors/molecule-preview.ts
@@ -20,8 +20,14 @@ const MOLFILE_MIME = 'chemical/x-mdl-molfile'
 // auto-opened in the preview panel by the renderer (workspace-events), so no extra IPC is needed.
 export const createMoleculePreviewHandler =
   (writer: MoleculeArtifactWriter) =>
-  async (args: Record<string, unknown>, context: { sessionId?: string } = {}): Promise<unknown> => {
+  async (
+    args: Record<string, unknown>,
+    context: { sessionId?: string } = {},
+    signal?: AbortSignal
+  ): Promise<unknown> => {
+    signal?.throwIfAborted()
     const result = await renderMoleculeStructure(args)
+    signal?.throwIfAborted()
     if (!result.valid) return result
 
     // The artifact must attach to the calling session's run; without a session id it would fall back to
@@ -30,6 +36,7 @@ export const createMoleculePreviewHandler =
       throw new Error('molecule preview requires an active session to attach the structure to.')
     }
 
+    signal?.throwIfAborted()
     const artifact = await writer.writeArtifactForCurrentRun(context.sessionId, {
       filename: result.filename_suggestion,
       content: result.molfile,

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -78,6 +78,29 @@ describe('ConnectorService', () => {
     expect(out).toEqual({ ok: true })
     expect(engine.call).not.toHaveBeenCalled()
   })
+  it('passes the caller signal to a bundled local handler', async () => {
+    const localHandler = vi.fn().mockResolvedValue({ ok: true })
+    const svc = new ConnectorService({
+      getConnectors: () => ({ enabledIds: ['molecule'], autoAllowIds: [] }),
+      resolveApiKey: () => undefined,
+      localToolHandlers: { 'molecule/preview_molecule': localHandler }
+    })
+    const cancellation = new AbortController()
+
+    await svc.call(
+      'molecule',
+      'preview_molecule',
+      { smiles: 'C' },
+      { origin: 'internal', sessionId: 's-1' },
+      cancellation.signal
+    )
+
+    expect(localHandler).toHaveBeenCalledWith(
+      { smiles: 'C' },
+      { origin: 'internal', sessionId: 's-1' },
+      cancellation.signal
+    )
+  })
   it('falls through to the engine when no local handler is registered', async () => {
     const svc = new ConnectorService({
       getConnectors: () => ({ enabledIds: ['molecule'], autoAllowIds: [] }),
@@ -159,6 +182,83 @@ describe('ConnectorService', () => {
 
     await expect(call).rejects.toThrow(/blocked by policy/)
     expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('does not dispatch a bundled call after its pending approval is cancelled', async () => {
+    const fetchImpl = vi.fn()
+    let approvalSignal: AbortSignal | undefined
+    const requestApproval = vi.fn(
+      async (_info: unknown, signal?: AbortSignal): Promise<'deny'> =>
+        new Promise((resolve) => {
+          approvalSignal = signal
+          signal?.addEventListener('abort', () => resolve('deny'), { once: true })
+        })
+    )
+    const svc = new ConnectorService({
+      engine: new ParserEngine({ fetchImpl }),
+      getConnectors: () => ({
+        enabledIds: [],
+        autoAllowIds: [],
+        askToolIds: ['chemistry/pubchem_get_compounds']
+      }),
+      resolveApiKey: () => undefined,
+      requestApproval
+    })
+    const cancellation = new AbortController()
+
+    const call = svc.call(
+      'chemistry',
+      'pubchem_get_compounds',
+      { cids: [1] },
+      internal,
+      cancellation.signal
+    )
+    await vi.waitFor(() => expect(approvalSignal).toBe(cancellation.signal))
+    cancellation.abort()
+
+    await expect(call).rejects.toMatchObject({ name: 'AbortError' })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('does not mark a custom MCP server unavailable when discovery is cancelled', async () => {
+    let discoverySignal: AbortSignal | undefined
+    const listTools = vi.fn(
+      async (_config: CustomMcpServerConfig, signal?: AbortSignal) =>
+        new Promise<Array<{ name: string }>>((_, reject) => {
+          discoverySignal = signal
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+        })
+    )
+    const callTool = vi.fn()
+    const onCustomServerAvailabilityChanged = vi.fn()
+    const svc = new ConnectorService({
+      mcpClientManager: { listTools, call: callTool },
+      getConnectors: () => ({
+        enabledIds: [],
+        autoAllowIds: ['myserver'],
+        customMcpServers: [
+          {
+            id: 'srv-1',
+            name: 'myserver',
+            displayName: 'My server',
+            transport: 'stdio',
+            command: 'npx',
+            enabled: true
+          }
+        ]
+      }),
+      resolveApiKey: () => undefined,
+      onCustomServerAvailabilityChanged
+    })
+    const cancellation = new AbortController()
+
+    const call = svc.call('myserver', 'do_thing', {}, internal, cancellation.signal)
+    await vi.waitFor(() => expect(discoverySignal).toBe(cancellation.signal))
+    cancellation.abort()
+
+    await expect(call).rejects.toMatchObject({ name: 'AbortError' })
+    expect(callTool).not.toHaveBeenCalled()
+    expect(onCustomServerAvailabilityChanged).not.toHaveBeenCalled()
   })
 
   it('does not dispatch from a stale cached Allow after durable policy becomes Block', async () => {

--- a/src/main/connectors/service.ts
+++ b/src/main/connectors/service.ts
@@ -19,11 +19,12 @@ import type { ApprovalDecision, ConnectorApprovalScope } from '../../shared/sett
 import type { SpecialistProfileView } from '../../shared/specialist'
 
 type McpClientManagerLike = {
-  listTools(config: CustomMcpServerConfig): Promise<Array<{ name: string }>>
+  listTools(config: CustomMcpServerConfig, signal?: AbortSignal): Promise<Array<{ name: string }>>
   call(
     config: CustomMcpServerConfig,
     method: string,
-    args: Record<string, unknown>
+    args: Record<string, unknown>,
+    signal?: AbortSignal
   ): Promise<unknown>
 }
 
@@ -39,15 +40,18 @@ type ConnectorServiceDeps = {
   // Human approval gate for a tool call that isn't pre-approved. A connector call sends data to an
   // external service, so a call that is neither pre-allowed nor skip-approved fails closed when this
   // transport is absent.
-  requestApproval?: (info: {
-    connector: string
-    method: string
-    args: Record<string, unknown>
-    // The session that triggered the call, when one is known, so the resulting notification can
-    // open the right conversation.
-    sessionId?: string
-    availableScopes: ConnectorApprovalScope[]
-  }) => Promise<ApprovalDecision>
+  requestApproval?: (
+    info: {
+      connector: string
+      method: string
+      args: Record<string, unknown>
+      // The session that triggered the call, when one is known, so the resulting notification can
+      // open the right conversation.
+      sessionId?: string
+      availableScopes: ConnectorApprovalScope[]
+    },
+    signal?: AbortSignal
+  ) => Promise<ApprovalDecision>
   // Handlers for bundled tools that run privileged local code (e.g. write an artifact, open a preview)
   // instead of the read-only HTTP ParserEngine. Keyed by `${connector}/${method}`; invoked after the
   // same enable/policy/approval gate as any other bundled call. The call context carries the id of the
@@ -55,7 +59,11 @@ type ConnectorServiceDeps = {
   // to the right session instead of a global "current" one.
   localToolHandlers?: Record<
     string,
-    (args: Record<string, unknown>, context: ConnectorCallContext) => Promise<unknown>
+    (
+      args: Record<string, unknown>,
+      context: ConnectorCallContext,
+      signal?: AbortSignal
+    ) => Promise<unknown>
   >
   // Resolves the current specialist profile immediately before agent dispatch. This is intentionally
   // a function (rather than a session-start snapshot) so edited/deleted profiles take effect on the
@@ -206,21 +214,25 @@ export class ConnectorService {
     connector: string,
     method: string,
     args: Record<string, unknown>,
-    context: ConnectorCallContext = {}
+    context: ConnectorCallContext = {},
+    signal?: AbortSignal
   ): Promise<unknown> {
+    signal?.throwIfAborted()
     const descriptor = getDescriptor(connector, method)
     const isBundled = descriptor !== undefined || ALL_CONNECTOR_IDS.includes(connector)
     if (isBundled) {
-      const access = await this.resolveAccess(connector, context)
-      return this.callBundled(connector, method, args, descriptor, context, access)
+      const access = await this.resolveAccess(connector, context, [connector], signal)
+      return this.callBundled(connector, method, args, descriptor, context, access, signal)
     }
 
     const customServers = (await this.currentConnectors())?.customMcpServers ?? []
+    signal?.throwIfAborted()
     const custom = customServers.find((server) => server.name === connector)
     const access = await this.resolveAccess(
       connector,
       context,
-      custom ? [custom.id, custom.name] : [connector]
+      custom ? [custom.id, custom.name] : [connector],
+      signal
     )
     if (!custom) {
       throw new ConnectorGateError(
@@ -228,14 +240,16 @@ export class ConnectorService {
         access.specialistScoped ? undefined : `connector not enabled: ${connector}`
       )
     }
-    return this.callCustom(custom, customServers, method, args, context, access)
+    return this.callCustom(custom, customServers, method, args, context, access, signal)
   }
 
   private async resolveAccess(
     connector: string,
     context: ConnectorCallContext,
-    aliases: readonly string[] = [connector]
+    aliases: readonly string[] = [connector],
+    signal?: AbortSignal
   ): Promise<ConnectorAccess> {
+    signal?.throwIfAborted()
     if (context.origin === 'internal') {
       return { bypassMainEnablement: false, bypassMainPolicy: false, specialistScoped: false }
     }
@@ -248,6 +262,7 @@ export class ConnectorService {
     if (!this.deps.resolveSpecialistProfile) throw new ConnectorGateError('specialist_unavailable')
 
     const profile = await this.deps.resolveSpecialistProfile(context.specialistId)
+    signal?.throwIfAborted()
     if (!profile || !profile.enabled) throw new ConnectorGateError('specialist_unavailable')
 
     const allowed =
@@ -267,21 +282,36 @@ export class ConnectorService {
     args: Record<string, unknown>,
     descriptor: ToolDescriptor | undefined,
     context: ConnectorCallContext,
-    access: ConnectorAccess
+    access: ConnectorAccess,
+    signal?: AbortSignal
   ): Promise<unknown> {
     if (!descriptor)
       throw new ConnectorGateError('connector_unavailable', `unknown tool: ${connector}/${method}`)
 
     const authorizedConnectors = access.bypassMainPolicy
       ? undefined
-      : await this.ensureAuthorized(connector, connector, [connector], method, args, context)
+      : await this.ensureAuthorized(
+          connector,
+          connector,
+          [connector],
+          method,
+          args,
+          context,
+          signal
+        )
 
     // Bundled tools that need privileged local behavior run here, after the same gate, instead of the
     // read-only HTTP engine.
+    signal?.throwIfAborted()
     const localHandler = this.deps.localToolHandlers?.[`${connector}/${method}`]
-    if (localHandler) return localHandler(args, context)
+    if (localHandler) {
+      return signal ? localHandler(args, context, signal) : localHandler(args, context)
+    }
 
-    return this.engine.call(descriptor, args, this.credentials(authorizedConnectors))
+    const credentials = this.credentials(authorizedConnectors)
+    return signal
+      ? this.engine.call(descriptor, args, credentials, signal)
+      : this.engine.call(descriptor, args, credentials)
   }
 
   private async callCustom(
@@ -290,8 +320,10 @@ export class ConnectorService {
     method: string,
     args: Record<string, unknown>,
     context: ConnectorCallContext,
-    access: ConnectorAccess
+    access: ConnectorAccess,
+    signal?: AbortSignal
   ): Promise<unknown> {
+    signal?.throwIfAborted()
     const generation = this.assertCustomServerCurrent(custom)
     const failureEpoch = this.customServerFailureEpochs.get(custom.id) ?? 0
     const physicalFailure = this.unavailableCustomConnectors.get(custom.id)
@@ -319,14 +351,18 @@ export class ConnectorService {
       args,
       context,
       access,
-      generation
+      generation,
+      signal
     )
     const config = toCustomMcpConfig(authorization.custom)
 
     let tools: Array<{ name: string }>
     try {
-      tools = await this.deps.mcpClientManager.listTools(config)
+      tools = signal
+        ? await this.deps.mcpClientManager.listTools(config, signal)
+        : await this.deps.mcpClientManager.listTools(config)
     } catch (error) {
+      if (signal?.aborted) throw error
       // Never relay a transport error: custom server URLs, headers, or server-provided diagnostics
       // can contain credentials. Record only the availability category for subsequent fail-closed
       // dispatches; a successful connection clears the transient state.
@@ -348,10 +384,13 @@ export class ConnectorService {
       context,
       access,
       generation,
+      signal,
       authorization
     )
     if (authorization.deferredScope) {
+      signal?.throwIfAborted()
       await this.permissionBroker.remember(authorization.request, authorization.deferredScope)
+      signal?.throwIfAborted()
     }
 
     await this.authorizeCustomForCurrentPolicy(
@@ -361,11 +400,14 @@ export class ConnectorService {
       context,
       access,
       generation,
+      signal,
       authorization
     )
 
     try {
-      const result = await this.deps.mcpClientManager.call(config, method, args)
+      const result = signal
+        ? await this.deps.mcpClientManager.call(config, method, args, signal)
+        : await this.deps.mcpClientManager.call(config, method, args)
       if ((this.customServerFailureEpochs.get(custom.id) ?? 0) === failureEpoch) {
         if (this.unavailableCustomConnectors.delete(custom.id)) {
           this.deps.onCustomServerAvailabilityChanged?.(custom.id, undefined)
@@ -373,6 +415,7 @@ export class ConnectorService {
       }
       return result
     } catch (error) {
+      if (signal?.aborted) throw error
       const availability = classifyCustomMcpFailure(error)
       // A structured tool error proves the MCP server is reachable. Keep connector-managed login
       // tools callable, but publish stale host-managed OAuth so Settings can offer sign-in recovery.
@@ -436,11 +479,14 @@ export class ConnectorService {
     policyIds: readonly string[],
     method: string,
     args: Record<string, unknown>,
-    context: ConnectorCallContext
+    context: ConnectorCallContext,
+    signal?: AbortSignal
   ): Promise<StoredConnectors | undefined> {
     let requireApprovalSatisfied = false
     for (;;) {
+      signal?.throwIfAborted()
       const connectors = await this.currentConnectors()
+      signal?.throwIfAborted()
       if (!this.isEnabled(connectorLabel, connectors)) {
         throw new ConnectorGateError(
           'connector_disabled',
@@ -459,7 +505,7 @@ export class ConnectorService {
       const policyDecision = this.permissionBroker.preflight(request)
       if (policyDecision === 'allow' || requireApprovalSatisfied) return connectors
 
-      await this.permissionBroker.authorize(request, policyDecision)
+      await this.permissionBroker.authorize(request, policyDecision, { signal })
       requireApprovalSatisfied = true
     }
   }
@@ -471,6 +517,7 @@ export class ConnectorService {
     context: ConnectorCallContext,
     access: ConnectorAccess,
     generation: number,
+    signal?: AbortSignal,
     prior?: {
       requireApprovalSatisfied: boolean
       deferredScope?: PermissionGrantScope
@@ -485,7 +532,9 @@ export class ConnectorService {
     let deferredScope = prior?.deferredScope
 
     for (;;) {
+      signal?.throwIfAborted()
       const connectors = await this.currentConnectors()
+      signal?.throwIfAborted()
       const customServers = connectors?.customMcpServers ?? []
       const current = customServers.find((server) => server.id === custom.id)
       if (!current) throw new ConnectorGateError('connector_unavailable')
@@ -527,7 +576,8 @@ export class ConnectorService {
       }
 
       deferredScope = await this.permissionBroker.authorize(request, policyDecision, {
-        deferRemember: true
+        deferRemember: true,
+        signal
       })
       requireApprovalSatisfied = true
     }

--- a/src/main/connectors/types.ts
+++ b/src/main/connectors/types.ts
@@ -1,6 +1,7 @@
 export type ConnectorCredentials = { ncbiEmail?: string; ncbiApiKey?: string }
 
 export type ToolContext = {
+  signal?: AbortSignal
   fetchJson(url: string): Promise<unknown>
   fetchText(url: string): Promise<string>
   // GET JSON plus the response headers — for APIs that report totals/pagination in headers rather than

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1271,14 +1271,17 @@ const createApplicationModules = async (
     resolveApiKey: (ref) => tryDecryptKey(ref),
     mcpClientManager,
     permissionGrantRegistry,
-    requestApproval: ({ connector, method, args, sessionId, availableScopes }) =>
-      approvalBroker.request({
-        connector,
-        method,
-        argsPreview: previewArgs(args),
-        ...(sessionId ? { sessionId } : {}),
-        availableScopes
-      }),
+    requestApproval: ({ connector, method, args, sessionId, availableScopes }, signal) =>
+      approvalBroker.request(
+        {
+          connector,
+          method,
+          argsPreview: previewArgs(args),
+          ...(sessionId ? { sessionId } : {}),
+          availableScopes
+        },
+        signal
+      ),
     resolveSpecialistProfile: async (specialistId) => {
       try {
         return await profileService.resolveRunnableById(specialistId)

--- a/src/main/notebook/local-rpc-server.mcpcall.test.ts
+++ b/src/main/notebook/local-rpc-server.mcpcall.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { NotebookLocalRpcServer } from './local-rpc-server'
 
 const fakeConnector = {
@@ -116,6 +116,56 @@ describe('mcpCall RPC', () => {
     expect(await res.json()).toEqual({
       result: { s: 'chemistry', m: 'pubchem_get_properties', a: { cids: [1] } }
     })
+  })
+
+  it('aborts the connector call when the RPC client disconnects', async () => {
+    let observedSignal: AbortSignal | undefined
+    let markCallStarted!: () => void
+    let releaseCall!: (value: { ok: true }) => void
+    const callStarted = new Promise<void>((resolve) => {
+      markCallStarted = resolve
+    })
+    const callPending = new Promise<{ ok: true }>((resolve) => {
+      releaseCall = resolve
+    })
+    const connector = {
+      call: async (
+        _server: string,
+        _method: string,
+        _args: Record<string, unknown>,
+        _context?: Record<string, unknown>,
+        signal?: AbortSignal
+      ) => {
+        observedSignal = signal
+        markCallStarted()
+        return callPending
+      }
+    }
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      connectorService: connector
+    })
+    const { endpoint, token } = await sessionConnection(server)
+    const disconnect = new AbortController()
+    const request = fetch(endpoint, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        method: 'mcpCall',
+        params: { server: 'chemistry', method: 'pubchem_get_properties', args: { cids: [1] } }
+      }),
+      signal: disconnect.signal
+    })
+
+    await callStarted
+    disconnect.abort()
+    try {
+      await expect(request).rejects.toThrow()
+      expect(observedSignal).toBeInstanceOf(AbortSignal)
+      await vi.waitFor(() => expect(observedSignal?.aborted).toBe(true))
+    } finally {
+      releaseCall({ ok: true })
+    }
   })
 
   it('uses the session-bound owner and ignores forged RPC owner fields', async () => {

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -96,7 +96,8 @@ type NotebookLocalRpcServerOptions = {
         projectId?: string
         origin?: 'agent' | 'internal'
         specialistId?: string
-      }
+      },
+      signal?: AbortSignal
     ): Promise<unknown>
   }
   computeService?: {
@@ -1995,14 +1996,20 @@ class NotebookLocalRpcServer {
       const args = isRecord(params.args) ? params.args : {}
       const sessionId = typeof params.sessionId === 'string' ? params.sessionId : undefined
       const projectId = typeof params.projectId === 'string' ? params.projectId : undefined
-      return this.connectorService.call(server, toolMethod, args, {
-        sessionId,
-        ...(projectId ? { projectId } : {}),
-        origin: 'agent',
-        ...(sessionId && this.sessionSpecialists.get(sessionId)
-          ? { specialistId: this.sessionSpecialists.get(sessionId) }
-          : {})
-      })
+      return this.connectorService.call(
+        server,
+        toolMethod,
+        args,
+        {
+          sessionId,
+          ...(projectId ? { projectId } : {}),
+          origin: 'agent',
+          ...(sessionId && this.sessionSpecialists.get(sessionId)
+            ? { specialistId: this.sessionSpecialists.get(sessionId) }
+            : {})
+        },
+        signal
+      )
     }
 
     // computeCall routes compute API operations to ComputeService. Ownership comes only from the

--- a/src/main/permission-grants/connector-broker.test.ts
+++ b/src/main/permission-grants/connector-broker.test.ts
@@ -135,6 +135,29 @@ describe('ConnectorPermissionBroker', () => {
     expect(remember).not.toHaveBeenCalled()
   })
 
+  it('passes the caller signal to an approval prompt and stops when it aborts', async () => {
+    const { registry, remember } = createRegistry()
+    let observedSignal: AbortSignal | undefined
+    const prompt = vi.fn(
+      async (_info: unknown, signal?: AbortSignal): Promise<'once'> =>
+        new Promise((_, reject) => {
+          observedSignal = signal
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+        })
+    )
+    const broker = new ConnectorPermissionBroker(registry, prompt)
+    const cancellation = new AbortController()
+
+    const authorization = broker.authorize(createRequest(), 'require_approval', {
+      signal: cancellation.signal
+    })
+    await vi.waitFor(() => expect(observedSignal).toBe(cancellation.signal))
+    cancellation.abort()
+
+    await expect(authorization).rejects.toMatchObject({ name: 'AbortError' })
+    expect(remember).not.toHaveBeenCalled()
+  })
+
   it('fails closed when approval is denied or durable grant storage fails', async () => {
     const denied = new ConnectorPermissionBroker(
       createRegistry().registry,

--- a/src/main/permission-grants/connector-broker.ts
+++ b/src/main/permission-grants/connector-broker.ts
@@ -6,13 +6,16 @@ import type {
 } from '../../shared/permission-grants'
 import type { PermissionGrantRegistry } from './registry'
 
-type ConnectorPermissionPrompt = (info: {
-  connector: string
-  method: string
-  args: Record<string, unknown>
-  sessionId?: string
-  availableScopes: ConnectorApprovalScope[]
-}) => Promise<ApprovalDecision>
+type ConnectorPermissionPrompt = (
+  info: {
+    connector: string
+    method: string
+    args: Record<string, unknown>
+    sessionId?: string
+    availableScopes: ConnectorApprovalScope[]
+  },
+  signal?: AbortSignal
+) => Promise<ApprovalDecision>
 
 type ConnectorPolicyInput = {
   aliases: readonly string[]
@@ -31,7 +34,7 @@ type ConnectorPermissionRequest = {
 }
 
 type ConnectorPolicyDecision = 'allow' | 'require_approval'
-type ConnectorAuthorizationOptions = { deferRemember?: boolean }
+type ConnectorAuthorizationOptions = { deferRemember?: boolean; signal?: AbortSignal }
 
 class ConnectorPermissionBroker {
   constructor(
@@ -62,9 +65,11 @@ class ConnectorPermissionBroker {
     policyDecision: ConnectorPolicyDecision = this.preflight(request),
     options: ConnectorAuthorizationOptions = {}
   ): Promise<PermissionGrantScope | undefined> {
+    options.signal?.throwIfAborted()
     if (policyDecision === 'allow') return undefined
 
     if (await this.registry?.resolve(request.capability, request.context)) return undefined
+    options.signal?.throwIfAborted()
     if (!this.prompt) {
       throw new Error(`approval unavailable: ${request.connector}/${request.method}`)
     }
@@ -76,13 +81,17 @@ class ConnectorPermissionBroker {
       availableScopes.push('global')
     }
 
-    const decision = await this.prompt({
+    const prompt = {
       connector: request.connector,
       method: request.method,
       args: request.args,
       ...(request.context.sessionId ? { sessionId: request.context.sessionId } : {}),
       availableScopes
-    })
+    }
+    const decision = options.signal
+      ? await this.prompt(prompt, options.signal)
+      : await this.prompt(prompt)
+    options.signal?.throwIfAborted()
     if (decision === 'deny' || !availableScopes.includes(decision)) {
       throw new Error(`tool call denied by user: ${request.connector}/${request.method}`)
     }
@@ -101,6 +110,7 @@ class ConnectorPermissionBroker {
 
     if (options.deferRemember) return scope
 
+    options.signal?.throwIfAborted()
     await this.remember(request, scope)
     return undefined
   }


### PR DESCRIPTION
## Problem

Notebook local RPC creates a request-scoped `AbortSignal`, but `mcpCall` dropped it at the
`ConnectorService` boundary. A cancelled or disconnected Notebook caller could therefore leave an
approval pending, continue bundled HTTP requests and retry backoff, keep a custom MCP request alive,
or cross a connector-local side-effect boundary after the result had no consumer.

## Proposed change

- carry the request signal from Notebook RPC through connector policy/approval and dispatch
- cancel pending approval UI and notifications with the existing `cancelled` action state
- combine caller cancellation with bundled HTTP attempt timeouts and make retry backoff abortable
- pass the signal to custom MCP `listTools` and `callTool` request options without recording caller
  cancellation as connector unavailability
- check cancellation before connector-local Artifact publication

## Scope and non-goals

- no RPC payload, Settings, database, migration, persisted data-model, or historical compatibility
  change
- no new shared status value; `NotificationActionState.cancelled` already exists
- no rollback of a remote side effect or atomic Artifact write that completed before cancellation was
  observed
- no retry-count, timeout, connector-policy, or permission-grant semantic change

## Acceptance criteria and validation

The listed checks ran after the last material edit.

- RPC disconnect propagates an aborted signal to connector dispatch ->
  `npm test -- src/main/notebook/local-rpc-server.mcpcall.test.ts` -> passed
- connector approval, HTTP retry/backoff, custom MCP, and local-handler cancellation ->
  `npm test -- src/main/connectors src/main/permission-grants/connector-broker.test.ts src/main/notebook/local-rpc-server.mcpcall.test.ts`
  -> 57 files passed; 770 tests passed, 39 skipped
- affected main-process contracts type-check -> `npm run typecheck:node` -> passed
- changed source follows repository lint rules -> `npm run lint` -> passed

PR CI remains authoritative for the complete portable and platform lanes; the full local `npm test`
suite was intentionally not run.

## Review focus

- cancellation is checked after asynchronous policy/profile reads and before external or
  side-effecting boundaries
- caller aborts bypass custom connector availability classification
- approval settlement removes abort listeners and emits the existing `cancelled` lifecycle state
- an Artifact write already in progress remains atomic rather than gaining cancellation rollback
