### PR TITLE
fix(storage): recover staged migrations after restart

### DIFF
--- a/src/main/storage/command-owner.ts
+++ b/src/main/storage/command-owner.ts
@@ -315,10 +315,9 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
   // boundary before commit/discard receives it. A fresh correlation id starts the recovery attempt's
   // diagnostics because the original process-local operation is gone.
   const recoverStagedFromMarker = async (
-    request: StorageParentRequest,
+    target: string,
     allowedStatuses: ReadonlySet<'copying' | 'verified'>
   ): Promise<NonNullable<typeof activeStaged> | undefined> => {
-    const target = dataRootForPicked(request.parent)
     const marker = await readMigrationMarker(target)
     if (
       !marker ||
@@ -350,14 +349,23 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
       logger.warn('staged data root discard ignored', { reason: 'resolution-in-progress' })
       return { ok: false, error: 'A migration is already being resolved.' }
     }
+    let target: string
+    try {
+      target = dataRootForPicked(request.parent)
+    } catch (err) {
+      logger.warn('staged data root discard ignored', {
+        reason: 'invalid-request',
+        ...diagnosticErrorFields(err)
+      })
+      return { ok: false, error: err instanceof Error ? err.message : String(err) }
+    }
     resolutionInProgress = true
     try {
-      const target = dataRootForPicked(request.parent)
       const staged = activeStaged
         ? samePath(activeStaged.target, target)
           ? activeStaged
           : undefined
-        : await recoverStagedFromMarker(request, new Set(['copying', 'verified']))
+        : await recoverStagedFromMarker(target, new Set(['copying', 'verified']))
       if (!staged) {
         logger.warn('staged data root discard ignored', { reason: 'no-matching-copy' })
         return { ok: false, error: 'No matching staged data copy was found.' }
@@ -423,13 +431,22 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
     if (resolutionInProgress) {
       return { ok: false, error: 'A migration is already being resolved.' }
     }
+    let target: string
+    try {
+      target = dataRootForPicked(request.parent)
+    } catch (err) {
+      logger.warn('staged data root commit refused', {
+        reason: 'invalid-request',
+        ...diagnosticErrorFields(err)
+      })
+      return { ok: false, error: err instanceof Error ? err.message : String(err) }
+    }
     resolutionInProgress = true
-    const target = dataRootForPicked(request.parent)
     const staged = activeStaged
       ? samePath(activeStaged.target, target)
         ? activeStaged
         : undefined
-      : await recoverStagedFromMarker(request, new Set(['verified']))
+      : await recoverStagedFromMarker(target, new Set(['verified']))
     if (!staged) {
       resolutionInProgress = false
       return { ok: false, error: 'No completed migration copy was found.' }

--- a/src/main/storage/command-owner.ts
+++ b/src/main/storage/command-owner.ts
@@ -34,10 +34,12 @@ import {
   classifyDataRoot,
   commitDataRootSwitch,
   discardStagedCopy,
+  pauseDataRootWriters,
   runDataRootMigration,
   validateNewDataRoot,
   type ValidateResult
 } from './migration-service'
+import { readMigrationMarker } from './migration-marker'
 import { availableBytes, computeStorageUsage } from './usage'
 import { broadcastToRenderers } from '../renderer-broadcast'
 import { RELOCATABLE_DATA_DIRS } from './data-directories'
@@ -87,6 +89,7 @@ type StorageCommandOwnerDeps = {
   exportRuntimeLocks?: typeof exportRuntimeLocks
   discardStagedCopy?: typeof discardStagedCopy
   runDataRootMigration?: typeof runDataRootMigration
+  pauseDataRootWriters?: typeof pauseDataRootWriters
 }
 
 type StorageParentRequest = Readonly<{ parent: string }>
@@ -103,13 +106,15 @@ const defaultBroadcast = (progress: MigrationProgress): void => {
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
   let activeMigration: AbortController | undefined
-  // The token + target of the copy THIS session staged (set when a copy verifies, cleared when the
-  // migration resolves). commit/discard require it so a stale renderer call can't act on a foreign copy.
-  let activeStaged: { token: string; target: string; correlationId: string } | undefined
+  // The token + target of the active staged copy (set when this process verifies a copy, or recovered
+  // from its durable marker after restart; cleared when the migration resolves).
+  let activeStaged:
+    { token: string; target: string; correlationId: string; recovered: boolean } | undefined
   let resolutionInProgress = false
   const cleanupRuntimeCache = deps.cleanupRuntimeCache ?? removeMicromambaCacheForRoot
   const discardStagedCopyImpl = deps.discardStagedCopy ?? discardStagedCopy
   const runDataRootMigrationImpl = deps.runDataRootMigration ?? runDataRootMigration
+  const pauseDataRootWritersImpl = deps.pauseDataRootWriters ?? pauseDataRootWriters
   const unsafeLogger = deps.logger ?? createLogger('storage:ipc')
   const emitSafely = (level: keyof Logger, message: string, data?: unknown): void => {
     try {
@@ -273,7 +278,7 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
           signal: controller.signal,
           onProgress: (progress) => (deps.broadcastProgress ?? defaultBroadcast)(progress),
           onVerified: (staged) => {
-            activeStaged = { ...staged, correlationId }
+            activeStaged = { ...staged, correlationId, recovered: false }
           }
         }
       )
@@ -305,6 +310,28 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
     activeMigration?.abort()
   }
 
+  // Rehydrates the durable authority for a staging copy after process restart. The marker token is
+  // never exposed to the renderer; source, target, and status are checked again at this command
+  // boundary before commit/discard receives it. A fresh correlation id starts the recovery attempt's
+  // diagnostics because the original process-local operation is gone.
+  const recoverStagedFromMarker = async (
+    request: StorageParentRequest,
+    allowedStatuses: ReadonlySet<'copying' | 'verified'>
+  ): Promise<NonNullable<typeof activeStaged> | undefined> => {
+    const target = dataRootForPicked(request.parent)
+    const marker = await readMigrationMarker(target)
+    if (
+      !marker ||
+      !allowedStatuses.has(marker.status) ||
+      !samePath(marker.source, resolveDataRoot()) ||
+      !samePath(marker.target, target) ||
+      samePath(target, resolveDataRoot())
+    ) {
+      return undefined
+    }
+    return { token: marker.token, target, correlationId: randomUUID(), recovered: true }
+  }
+
   // Discards a completed-but-uncommitted copy at `<parent>/OpenScience` when the user picks "Keep
   // current location" on the done stage. Since the copy phase never touched settings.dataRoot or the
   // old root, this just removes the new copy and leaves the app on its current root. discardStagedCopy
@@ -323,15 +350,25 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
       logger.warn('staged data root discard ignored', { reason: 'resolution-in-progress' })
       return { ok: false, error: 'A migration is already being resolved.' }
     }
-    if (!activeStaged || !samePath(activeStaged.target, dataRootForPicked(request.parent))) {
-      logger.warn('staged data root discard ignored', { reason: 'no-matching-copy' })
-      return { ok: false, error: 'No matching staged data copy was found.' }
-    }
-    const staged = activeStaged
     resolutionInProgress = true
     try {
+      const target = dataRootForPicked(request.parent)
+      const staged = activeStaged
+        ? samePath(activeStaged.target, target)
+          ? activeStaged
+          : undefined
+        : await recoverStagedFromMarker(request, new Set(['copying', 'verified']))
+      if (!staged) {
+        logger.warn('staged data root discard ignored', { reason: 'no-matching-copy' })
+        return { ok: false, error: 'No matching staged data copy was found.' }
+      }
+      activeStaged = staged
       const result = await discardStagedCopyImpl(
-        { currentDataRoot: resolveDataRoot(), expectedToken: staged.token },
+        {
+          currentDataRoot: resolveDataRoot(),
+          expectedToken: staged.token,
+          allowIncomplete: staged.recovered
+        },
         request.parent
       )
       if (result.ok) {
@@ -383,14 +420,56 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
     if (activeMigration) {
       return { ok: false, error: 'A migration copy is still in progress.' }
     }
-    if (!activeStaged || !samePath(activeStaged.target, dataRootForPicked(request.parent))) {
-      return { ok: false, error: 'No completed migration from this app session was found.' }
-    }
     if (resolutionInProgress) {
       return { ok: false, error: 'A migration is already being resolved.' }
     }
-    const staged = activeStaged
     resolutionInProgress = true
+    const target = dataRootForPicked(request.parent)
+    const staged = activeStaged
+      ? samePath(activeStaged.target, target)
+        ? activeStaged
+        : undefined
+      : await recoverStagedFromMarker(request, new Set(['verified']))
+    if (!staged) {
+      resolutionInProgress = false
+      return { ok: false, error: 'No completed migration copy was found.' }
+    }
+
+    if (staged.recovered) {
+      // Recovery happens in a fresh process: the original write gate and paused runtimes are gone.
+      // Re-establish those invariants before inventory verification and pointer persistence.
+      if (deps.getActiveDelegatedSessions().length > 0) {
+        resolutionInProgress = false
+        return {
+          ok: false,
+          error:
+            'Subagents are still running. Return to their tasks and stop them before finishing the move.'
+        }
+      }
+      beginMigration()
+      try {
+        await pauseDataRootWritersImpl({
+          logger,
+          runtime: deps.runtime,
+          notebook: deps.notebook
+        })
+        activeStaged = staged
+      } catch (err) {
+        logger.error('recovered data root pause failed', diagnosticErrorFields(err))
+        clearMigrationPending()
+        activeStaged = undefined
+        resolutionInProgress = false
+        return {
+          ok: false,
+          error: 'Could not pause running work to finish moving your data safely. Please try again.'
+        }
+      } finally {
+        // Keep the write gate pending through commit, but avoid treating the subsequent clean
+        // relaunch as an in-progress copy in the quit guard.
+        endMigrationCopy()
+      }
+    }
+
     const previousDataRoot = resolveDataRoot()
     let outcome: MigrationOutcome
     try {
@@ -453,8 +532,8 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
 
   // Settings + onboarding recovery: classify a candidate parent without committing to it, so the
   // caller can route to the right UI (migrate confirm for 'move', adopt confirm for 'adopt',
-  // inline error for 'invalid') and display the derived `<parent>/OpenScience` path regardless of
-  // kind. Never throws.
+  // staged-copy resolution for 'recover', inline error for 'invalid') and display the derived
+  // `<parent>/OpenScience` path regardless of kind. Never throws.
   const inspectDataRoot = async (request: StorageParentRequest): Promise<DataRootInspection> => {
     const dataRoot = dataRootForPicked(request.parent)
     try {
@@ -474,8 +553,9 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
   // - used both for onboarding's first-run apply (no data exists yet to move) and for adopting an
   // existing data folder from Settings (data already lives at the derived target; only the
   // pointer changes).
-  // Unlike storage:migrate there is no copy phase and no session-interrupt step. Accepts both
-  // 'move' and 'adopt' targets (classify != 'invalid') - the migration engine's own
+  // Unlike storage:migrate there is no copy phase and no session-interrupt step. Accepts only
+  // 'move' and 'adopt' targets; a 'recover' target must use the marker-gated resolution flow. The
+  // migration engine's own
   // validateNewDataRoot is stricter (move-only) and is never called here.
   //
   // `markOnboarding` is stamped here (not by a separate renderer completeOnboarding() call) so it
@@ -492,8 +572,10 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
     operation.phase('classify-target')
     try {
       const classification = await classifyDataRoot(request.parent, resolveDataRoot())
-      if (classification.kind === 'invalid') {
-        operation.fail(new Error(classification.error ?? 'invalid target'), { mode: 'invalid' })
+      if (classification.kind !== 'move' && classification.kind !== 'adopt') {
+        operation.fail(new Error(classification.error ?? 'invalid target'), {
+          mode: classification.kind
+        })
         return { ok: false, error: classification.error ?? 'The selected folder is not usable.' }
       }
 

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -216,6 +216,23 @@ describe('storage IPC handlers', () => {
     expect(deps.relaunch).toHaveBeenCalledTimes(1)
   })
 
+  it('does not lock staged-copy resolution after a malformed recovered commit request', async () => {
+    initDataRoot(dataRoot)
+    await seedVerifiedMarker(target, dataRoot)
+    registerStorageIpcHandlers(fakeDeps())
+
+    await expect(invoke('storage:commit-and-relaunch', { parent: null })).resolves.toMatchObject({
+      ok: false
+    })
+    await expect(invoke('storage:discard-migrated-copy', { parent: null })).resolves.toMatchObject({
+      ok: false
+    })
+    await expect(
+      invoke('storage:discard-migrated-copy', { parent: targetParent })
+    ).resolves.toEqual({ ok: true })
+    expect(existsSync(target)).toBe(false)
+  })
+
   it('keeps a recovered marker and clears the write gate when writers cannot be paused', async () => {
     initDataRoot(dataRoot)
     await seedVerifiedMarker(target, dataRoot)

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -153,7 +153,106 @@ describe('storage IPC handlers', () => {
     await expect(owner.commitAndRelaunch({ parent: targetParent })).resolves.toEqual({ ok: true })
 
     expect(deps.settingsService.setDataRoot).toHaveBeenCalledWith(target)
+    expect(deps.runtime.disconnect).toHaveBeenCalledOnce()
+    expect(deps.notebook.shutdownAll).toHaveBeenCalledOnce()
     expect(deps.relaunch).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses a recovered commit when the source changed after verification', async () => {
+    initDataRoot(dataRoot)
+    await seedVerifiedMarker(target, dataRoot)
+    await mkdir(join(dataRoot, 'artifacts'), { recursive: true })
+    await writeFile(join(dataRoot, 'artifacts', 'new-after-restart.txt'), 'new')
+    const deps = fakeDeps()
+    const restartedOwner = createStorageCommandOwner(deps)
+
+    await expect(restartedOwner.commitAndRelaunch({ parent: targetParent })).resolves.toEqual({
+      ok: false,
+      error: 'The staged copy changed after verification. Run the move again.'
+    })
+
+    expect(deps.settingsService.setDataRoot).not.toHaveBeenCalled()
+    expect(deps.relaunch).not.toHaveBeenCalled()
+    expect(isMigrationPending()).toBe(false)
+  })
+
+  it.each(['copying', 'verified'] as const)(
+    'discards a %s marker after the command owner is recreated',
+    async (status) => {
+      initDataRoot(dataRoot)
+      await seedVerifiedMarker(target, dataRoot)
+      const marker = await readMigrationMarker(target)
+      await writeMigrationMarker(target, { ...marker!, status })
+      const restartedOwner = createStorageCommandOwner(fakeDeps())
+
+      await expect(restartedOwner.discardMigratedCopy({ parent: targetParent })).resolves.toEqual({
+        ok: true
+      })
+
+      expect(existsSync(target)).toBe(false)
+    }
+  )
+
+  it('recovers a verified staged copy after the command owner is recreated', async () => {
+    initDataRoot(dataRoot)
+    await seedVerifiedMarker(target, dataRoot)
+    const deps = fakeDeps()
+
+    // Recreating the owner models a fresh main process after the copy verified but before the user
+    // chose Restart now. The verified marker is durable, so the staged copy should remain resolvable.
+    const restartedOwner = createStorageCommandOwner(deps)
+    await expect(readMigrationMarker(target)).resolves.toMatchObject({
+      status: 'verified',
+      source: dataRoot,
+      target
+    })
+    await expect(restartedOwner.commitAndRelaunch({ parent: targetParent })).resolves.toEqual({
+      ok: true
+    })
+
+    expect(deps.settingsService.setDataRoot).toHaveBeenCalledWith(target)
+    expect(deps.runtime.disconnect).toHaveBeenCalledOnce()
+    expect(deps.notebook.shutdownAll).toHaveBeenCalledOnce()
+    expect(deps.relaunch).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps a recovered marker and clears the write gate when writers cannot be paused', async () => {
+    initDataRoot(dataRoot)
+    await seedVerifiedMarker(target, dataRoot)
+    const pauseDataRootWriters = vi.fn().mockRejectedValue(new Error('busy'))
+    const deps = fakeDeps({ pauseDataRootWriters })
+    const restartedOwner = createStorageCommandOwner(deps)
+
+    await expect(restartedOwner.commitAndRelaunch({ parent: targetParent })).resolves.toEqual({
+      ok: false,
+      error: 'Could not pause running work to finish moving your data safely. Please try again.'
+    })
+
+    expect(await readMigrationMarker(target)).toMatchObject({ status: 'verified' })
+    expect(deps.settingsService.setDataRoot).not.toHaveBeenCalled()
+    expect(isMigrationPending()).toBe(false)
+  })
+
+  it('blocks recovered commit while delegated work is still running', async () => {
+    initDataRoot(dataRoot)
+    await seedVerifiedMarker(target, dataRoot)
+    const pauseDataRootWriters = vi.fn()
+    const deps = fakeDeps({
+      getActiveDelegatedSessions: vi
+        .fn()
+        .mockReturnValue([{ projectId: 'project-1', sessionId: 'session-1' }]),
+      pauseDataRootWriters
+    })
+    const restartedOwner = createStorageCommandOwner(deps)
+
+    await expect(restartedOwner.commitAndRelaunch({ parent: targetParent })).resolves.toEqual({
+      ok: false,
+      error:
+        'Subagents are still running. Return to their tasks and stop them before finishing the move.'
+    })
+
+    expect(pauseDataRootWriters).not.toHaveBeenCalled()
+    expect(deps.settingsService.setDataRoot).not.toHaveBeenCalled()
   })
 
   it('registers every storage channel', () => {
@@ -535,9 +634,9 @@ describe('storage IPC handlers', () => {
     expect(JSON.stringify(diagnosticRecords(logger))).not.toContain(markerToken)
   })
 
-  it('commit-and-relaunch refuses a verified marker not staged by this process', async () => {
+  it('commit-and-relaunch refuses a recovered marker staged from another data root', async () => {
     initDataRoot(dataRoot)
-    await seedVerifiedMarker(target, dataRoot)
+    await seedVerifiedMarker(target, join(dataRoot, 'other'))
     const deps = fakeDeps()
     registerStorageIpcHandlers(deps)
 

--- a/src/main/storage/migration-service.test.ts
+++ b/src/main/storage/migration-service.test.ts
@@ -435,11 +435,37 @@ describe('classifyDataRoot', () => {
       error: 'A different folder named OpenScience already exists here. Choose another location.'
     })
   })
-  it('rejects a marker-bearing staging dir as invalid, even when it already holds data', async () => {
-    // A crashed/uncommitted copy carries a marker and may hold a partial data dir; it must never
-    // classify 'adopt' (bypassing the commit gate) — the user must finish or discard the move first.
+  it('classifies a verified marker-bearing staging dir as recoverable, never adoptable', async () => {
+    // A crashed/uncommitted copy carries a marker and may hold user data; recovery must still pass
+    // through the commit gate rather than silently adopting the snapshot.
     const target = await seedVerifiedMarker(emptyParent, currentDataRoot)
     await mkdir(join(target, 'artifacts'), { recursive: true })
+
+    const result = await classifyDataRoot(emptyParent, currentDataRoot)
+
+    expect(result).toMatchObject({ kind: 'recover', recoveryStatus: 'verified' })
+  })
+
+  it('classifies an interrupted copying marker as discard-only recovery', async () => {
+    await seedVerifiedMarker(emptyParent, currentDataRoot, { status: 'copying' })
+
+    const result = await classifyDataRoot(emptyParent, currentDataRoot)
+
+    expect(result).toMatchObject({ kind: 'recover', recoveryStatus: 'copying' })
+  })
+
+  it('keeps a marker for another source invalid', async () => {
+    await seedVerifiedMarker(emptyParent, join(currentDataRoot, 'other'))
+
+    const result = await classifyDataRoot(emptyParent, currentDataRoot)
+
+    expect(result.kind).toBe('invalid')
+  })
+
+  it('keeps a corrupt marker invalid instead of offering destructive recovery', async () => {
+    const target = dataRootFor(emptyParent)
+    await mkdir(target, { recursive: true })
+    await writeFile(join(target, MIGRATION_MARKER_FILENAME), '{not-json')
 
     const result = await classifyDataRoot(emptyParent, currentDataRoot)
 
@@ -483,6 +509,18 @@ describe('validateNewDataRoot', () => {
     const result = await validateNewDataRoot(emptyParent, currentDataRoot)
 
     expect(result).toEqual({ ok: true })
+  })
+
+  it('rejects a recoverable marker as a new copy target', async () => {
+    await seedVerifiedMarker(emptyParent, currentDataRoot)
+
+    const result = await validateNewDataRoot(emptyParent, currentDataRoot)
+
+    expect(result).toEqual({
+      ok: false,
+      error:
+        'This folder holds an unfinished data move. Finish or discard that move before using it here.'
+    })
   })
 
   it('is ok only for move - an OpenScience folder that already holds our data (adopt) is rejected', async () => {
@@ -1697,7 +1735,7 @@ describe('discardStagedCopy', () => {
     expect(existsSync(target)).toBe(true)
   })
 
-  it('refuses a mid-copy ("copying") marker so a dir being written is never deleted', async () => {
+  it('refuses a "copying" marker unless the caller confirms its owner process has exited', async () => {
     const target = await seedVerifiedMarker(emptyParent, currentDataRoot, { status: 'copying' })
 
     const result = await discardStagedCopy(
@@ -1707,6 +1745,18 @@ describe('discardStagedCopy', () => {
 
     expect(result).toEqual({ ok: false, error: 'Refused: not a completed, matching staged copy.' })
     expect(existsSync(target)).toBe(true)
+  })
+
+  it('discards an interrupted "copying" marker after its owner process has exited', async () => {
+    const target = await seedVerifiedMarker(emptyParent, currentDataRoot, { status: 'copying' })
+
+    const result = await discardStagedCopy(
+      { currentDataRoot, expectedToken: 'tok-test', allowIncomplete: true },
+      emptyParent
+    )
+
+    expect(result).toEqual({ ok: true })
+    expect(existsSync(target)).toBe(false)
   })
 
   it('refuses when the staged token does not match the session token', async () => {

--- a/src/main/storage/migration-service.ts
+++ b/src/main/storage/migration-service.ts
@@ -46,9 +46,17 @@ export type ValidateResult = { ok: true } | { ok: false; error: string }
 // Classification of a candidate data root relative to the current one. 'move' = empty and
 // writable, safe for the copy-in migration engine. 'adopt' = already holds our data (a prior
 // migration, or the user's own pre-existing folder) - the pointer should switch to it as-is,
-// never be moved into. 'invalid' carries a user-facing reason.
-export type DataRootKind = 'move' | 'adopt' | 'invalid'
-export type ClassifyResult = { kind: DataRootKind; error?: string }
+// never be moved into. 'recover' is a marker-confirmed copy left by an interrupted migration;
+// 'invalid' carries a user-facing reason.
+export type DataRootKind = 'move' | 'adopt' | 'recover' | 'invalid'
+export type DataRootRecoveryStatus = 'copying' | 'verified'
+export type ClassifyResult =
+  | { kind: 'recover'; recoveryStatus: DataRootRecoveryStatus; error?: string }
+  | {
+      kind: Exclude<DataRootKind, 'recover'>
+      recoveryStatus?: never
+      error?: string
+    }
 
 // Windows' historical MAX_PATH. Long-path opt-outs exist but aren't something we can rely on across
 // every tool a user's Python/R environment might shell out to, so the app guards against it directly.
@@ -257,10 +265,24 @@ export const classifyDataRoot = async (
     return { kind: 'invalid', error: 'The selected folder is not usable.' }
   }
 
-  // A marker means this folder is an in-progress/uncommitted staging copy from a migration that never
-  // finished (e.g. a crash). Never adopt it — that would bypass the commit gate and switch to a possibly
-  // incomplete snapshot — and never populate over it; the user must finish or discard that move first.
+  // A trustworthy marker identifies an interrupted staging copy. Surface it as an explicit recovery
+  // state rather than adopt (which would bypass commit validation) or move (which would overwrite it).
+  // Corrupt/foreign markers remain invalid and are never made actionable.
   if (entries.some((entry) => entry.name === MIGRATION_MARKER_FILENAME)) {
+    const marker = await readMigrationMarker(target)
+    if (
+      marker &&
+      samePath(marker.source, current) &&
+      samePath(marker.target, target) &&
+      !samePath(target, current)
+    ) {
+      return {
+        kind: 'recover',
+        recoveryStatus: marker.status,
+        error:
+          'This folder holds an unfinished data move. Finish or discard that move before using it here.'
+      }
+    }
     return {
       kind: 'invalid',
       error:
@@ -298,6 +320,14 @@ export const validateNewDataRoot = async (
     return {
       ok: false,
       error: 'The selected folder already contains Open Science data. Pick an empty folder.'
+    }
+  }
+  if (result.kind === 'recover') {
+    return {
+      ok: false,
+      error:
+        result.error ??
+        'This folder holds an unfinished data move. Finish or discard that move before using it here.'
     }
   }
 
@@ -339,10 +369,8 @@ const sameInventory = (left: MigrationInventory, right: MigrationInventory): boo
   left.dirs.length === right.dirs.length &&
   left.dirs.every((dir, index) => dir === right.dirs[index])
 
-type MigrationCopyDeps = {
-  currentDataRoot: string
+type DataRootWriterPauseDeps = {
   logger?: Logger
-  diagnosticCorrelationId?: string
   runtime: { disconnect: () => Promise<unknown> }
   // Return ignored (awaited only), so kept as Promise<unknown> — mirrors runtime.disconnect above and
   // stays compatible with both the real service (now returns { reaped }) and void test fakes.
@@ -350,6 +378,21 @@ type MigrationCopyDeps = {
   // Releases the shared SQLite authority connection before migration validation opens its dedicated
   // checkpoint client. Injectable so ordering remains testable without module-level state.
   disconnectProjectDb?: () => Promise<void>
+}
+
+// Re-establishes the quiescent-data-root invariant used by both a fresh copy and a recovered commit.
+// The caller raises the migration write gate before invoking this helper so no new writer can enter
+// while existing leases drain.
+export const pauseDataRootWriters = async (deps: DataRootWriterPauseDeps): Promise<void> => {
+  await deps.runtime.disconnect()
+  await deps.notebook.shutdownAll()
+  await (deps.disconnectProjectDb ?? disconnectProjectDbClient)()
+  await waitForDataRootWriters()
+}
+
+type MigrationCopyDeps = DataRootWriterPauseDeps & {
+  currentDataRoot: string
+  diagnosticCorrelationId?: string
   // Exports each conda env under the old runtime to an @EXPLICIT lock at the new root (offline
   // reconstruction bundle). Returns the env names preserved; [] when nothing could be exported.
   // Injectable/optional so tests and non-notebook contexts skip it. Best-effort (must not throw).
@@ -442,10 +485,7 @@ export const runDataRootMigration = async (
   // clean up the staging dir and abort rather than swallow the failure and press on.
   operation.phase('pause-writers')
   try {
-    await deps.runtime.disconnect()
-    await deps.notebook.shutdownAll()
-    await (deps.disconnectProjectDb ?? disconnectProjectDbClient)()
-    await waitForDataRootWriters()
+    await pauseDataRootWriters(deps)
   } catch (err) {
     await rm(target, { recursive: true, force: true }).catch(() => undefined)
     operation.fail(err)
@@ -746,9 +786,11 @@ export const commitDataRootSwitch = async (
 // Throws away an uncommitted staged copy at `<parent>/OpenScience` (the user chose "Keep current
 // location" on the done stage). Refuses unless the target is genuinely a staging copy for the current
 // root — never the live data location, and only when a marker confirms this source→target pair — so a
-// misrouted parent can never rm the folder the app is actively using.
+// misrouted parent can never rm the folder the app is actively using. A fresh process may also discard
+// a 'copying' marker: no writer from that dead process remains, and an incomplete copy is never
+// committable, so deletion is the only safe recovery.
 export const discardStagedCopy = async (
-  deps: { currentDataRoot: string; expectedToken: string },
+  deps: { currentDataRoot: string; expectedToken: string; allowIncomplete?: boolean },
   parent: string
 ): Promise<{ ok: boolean; error?: string }> => {
   const target = dataRootForPicked(parent)
@@ -760,14 +802,15 @@ export const discardStagedCopy = async (
   const marker = await readMigrationMarker(target)
   if (
     !marker ||
-    marker.status !== 'verified' ||
+    (marker.status !== 'verified' &&
+      !(deps.allowIncomplete === true && marker.status === 'copying')) ||
     !samePath(marker.target, target) ||
     !samePath(marker.source, deps.currentDataRoot) ||
     !deps.expectedToken ||
     marker.token !== deps.expectedToken
   ) {
-    // status must be 'verified' (never delete a dir mid-copy) and the token must match this session's
-    // staged copy — a stale renderer call for another/earlier path is refused rather than obeyed.
+    // The owner blocks discard while its own copy is active. Source, target, and token still have to
+    // match so a stale renderer call for another/earlier path is refused rather than obeyed.
     return { ok: false, error: 'Refused: not a completed, matching staged copy.' }
   }
 

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -891,8 +891,8 @@ export interface OpenScienceAPI {
     // Onboarding location step: check a candidate parent before letting the user commit to it.
     // The final data root is always `<parent>/OpenScience`, never the parent itself.
     validateDataRoot(parent: string): Promise<DataRootValidationResult>
-    // Settings + onboarding: classify a candidate parent (move/adopt/invalid) without committing;
-    // `dataRoot` on the result is the derived `<parent>/OpenScience` path.
+    // Settings + onboarding: classify a candidate parent (move/adopt/recover/invalid) without
+    // committing; `dataRoot` on the result is the derived `<parent>/OpenScience` path.
     inspectDataRoot(parent: string): Promise<DataRootInspection>
     migrate(parent: string): Promise<MigrationOutcome>
     // No-move pointer switch: set dataRoot then relaunch. Accepts both a 'move' (first-run, no

--- a/src/renderer/src/components/DataRootMissingDialog.tsx
+++ b/src/renderer/src/components/DataRootMissingDialog.tsx
@@ -67,7 +67,7 @@ const DataRootMissingDialog = ({
 
       setIsChoosing(true)
       const inspection = await window.api.storage.inspectDataRoot(picked)
-      if (inspection.kind === 'invalid') {
+      if (inspection.kind !== 'move' && inspection.kind !== 'adopt') {
         setOperationError(inspection.error ?? t('The selected folder is not usable.'))
         return
       }

--- a/src/renderer/src/components/LegacyDataMoveDialog.render.test.tsx
+++ b/src/renderer/src/components/LegacyDataMoveDialog.render.test.tsx
@@ -14,6 +14,9 @@ type MockStorageApi = {
   dismissLegacyMovePrompt: ReturnType<typeof vi.fn>
   detectActive: ReturnType<typeof vi.fn>
   migrate: ReturnType<typeof vi.fn>
+  cancelMigrate: ReturnType<typeof vi.fn>
+  commitAndRelaunch: ReturnType<typeof vi.fn>
+  discardMigratedCopy: ReturnType<typeof vi.fn>
   onProgress: ReturnType<typeof vi.fn>
 }
 
@@ -25,6 +28,9 @@ const installApi = (overrides: Partial<MockStorageApi> = {}): MockStorageApi => 
     dismissLegacyMovePrompt: vi.fn().mockResolvedValue(undefined),
     detectActive: vi.fn().mockResolvedValue([]),
     migrate: vi.fn().mockResolvedValue({ ok: true }),
+    cancelMigrate: vi.fn().mockResolvedValue(undefined),
+    commitAndRelaunch: vi.fn().mockResolvedValue({ ok: true }),
+    discardMigratedCopy: vi.fn().mockResolvedValue({ ok: true }),
     onProgress: vi.fn(() => () => {}),
     ...overrides
   }
@@ -167,6 +173,52 @@ describe('LegacyDataMoveDialog', () => {
     expect(api.detectActive).toHaveBeenCalled()
     // Declining/moving never wrote a dismissal here — moving sets dataRoot instead.
     expect(api.dismissLegacyMovePrompt).not.toHaveBeenCalled()
+  })
+
+  it('resumes a verified interrupted move at the default destination without recopying', async () => {
+    const api = installApi({
+      inspectDataRoot: vi.fn().mockResolvedValue({
+        kind: 'recover',
+        recoveryStatus: 'verified',
+        dataRoot: '/home/u/OpenScience'
+      })
+    })
+    await renderDialog()
+
+    await act(async () => {
+      clickButton(/Move to OpenScience/)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain('Verified data copy found')
+    expect(api.migrate).not.toHaveBeenCalled()
+  })
+
+  it('offers discard-only recovery for an interrupted chosen-folder copy', async () => {
+    const api = installApi({
+      pickDirectory: vi.fn().mockResolvedValue('/mnt/interrupted'),
+      inspectDataRoot: vi
+        .fn()
+        .mockResolvedValueOnce({ kind: 'move', dataRoot: '/home/u/OpenScience' })
+        .mockResolvedValueOnce({
+          kind: 'recover',
+          recoveryStatus: 'copying',
+          dataRoot: '/mnt/interrupted/OpenScience'
+        })
+    })
+    await renderDialog()
+
+    await act(async () => {
+      clickButton(/Choose another folder/)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain('Incomplete data copy found')
+    expect(document.body.textContent).toContain('Discard incomplete copy')
+    expect(document.body.textContent).not.toContain('Finish move')
+    expect(api.migrate).not.toHaveBeenCalled()
   })
 
   it('a chosen empty folder starts the move; an unusable pick shows an inline error', async () => {

--- a/src/renderer/src/components/LegacyDataMoveDialog.render.test.tsx
+++ b/src/renderer/src/components/LegacyDataMoveDialog.render.test.tsx
@@ -175,13 +175,16 @@ describe('LegacyDataMoveDialog', () => {
     expect(api.dismissLegacyMovePrompt).not.toHaveBeenCalled()
   })
 
-  it('resumes a verified interrupted move at the default destination without recopying', async () => {
+  it('resumes a verified default move and refreshes the destination after discard', async () => {
     const api = installApi({
-      inspectDataRoot: vi.fn().mockResolvedValue({
-        kind: 'recover',
-        recoveryStatus: 'verified',
-        dataRoot: '/home/u/OpenScience'
-      })
+      inspectDataRoot: vi
+        .fn()
+        .mockResolvedValueOnce({
+          kind: 'recover',
+          recoveryStatus: 'verified',
+          dataRoot: '/home/u/OpenScience'
+        })
+        .mockResolvedValue({ kind: 'move', dataRoot: '/home/u/OpenScience' })
     })
     await renderDialog()
 
@@ -193,6 +196,55 @@ describe('LegacyDataMoveDialog', () => {
 
     expect(document.body.textContent).toContain('Verified data copy found')
     expect(api.migrate).not.toHaveBeenCalled()
+
+    await act(async () => {
+      clickButton(/Discard copy/)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).not.toContain('Verified data copy found')
+    expect(document.body.textContent).toContain('Move your data to a visible folder?')
+    expect(api.inspectDataRoot).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      clickButton(/Move to OpenScience/)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(api.migrate).toHaveBeenCalledWith('/home/u')
+  })
+
+  it('waits for default inspection before enabling the move action', async () => {
+    let resolveInspection!: (result: {
+      kind: 'recover'
+      recoveryStatus: 'verified'
+      dataRoot: string
+    }) => void
+    installApi({
+      inspectDataRoot: vi.fn().mockReturnValue(
+        new Promise((resolve) => {
+          resolveInspection = resolve
+        })
+      )
+    })
+    await renderDialog()
+
+    const moveButton = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'Move to OpenScience'
+    )
+    expect(moveButton?.disabled).toBe(true)
+
+    await act(async () => {
+      resolveInspection({
+        kind: 'recover',
+        recoveryStatus: 'verified',
+        dataRoot: '/home/u/OpenScience'
+      })
+      await Promise.resolve()
+    })
+
+    expect(moveButton?.disabled).toBe(false)
   })
 
   it('offers discard-only recovery for an interrupted chosen-folder copy', async () => {

--- a/src/renderer/src/components/LegacyDataMoveDialog.tsx
+++ b/src/renderer/src/components/LegacyDataMoveDialog.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/ui/dialog-chrome'
 import { cn } from '@/lib/utils'
 import { StorageMigrationModal } from '@/pages/settings/StorageMigrationModal'
+import type { DataRootInspection, DataRootRecoveryStatus } from '../../../shared/storage'
 
 type LegacyDataMoveDialogProps = {
   // App Shell presentation ownership may temporarily cover this prompt without discarding its state.
@@ -41,24 +42,36 @@ const LegacyDataMoveDialog = ({
   onDismiss
 }: LegacyDataMoveDialogProps): React.JSX.Element => {
   const { t } = useTranslation()
-  // When set, hand off to the shared migration modal targeting this parent; null returns to the prompt.
-  const [migrationTarget, setMigrationTarget] = useState<string | null>(null)
+  // When set, hand off to the shared migration modal targeting this parent; a durable interrupted
+  // copy carries its recovery status so the modal resumes instead of recopying.
+  const [migrationTarget, setMigrationTarget] = useState<{
+    path: string
+    recoveryStatus?: DataRootRecoveryStatus
+  } | null>(null)
   // The exact <home>/OpenScience path "Move to OpenScience" would create. Resolved server-side via
   // inspectDataRoot(defaultParent) rather than getInfo's dataRoot, which for a legacy install is the
   // hidden config root itself.
   const [destination, setDestination] = useState<string | undefined>(undefined)
+  const [defaultInspection, setDefaultInspection] = useState<DataRootInspection | undefined>(
+    undefined
+  )
   const [pickError, setPickError] = useState<string | undefined>(undefined)
   const [isPicking, setIsPicking] = useState(false)
 
   useEffect(() => {
     void window.api.storage.inspectDataRoot(defaultParent).then((result) => {
       setDestination(result.dataRoot)
+      setDefaultInspection(result)
     })
   }, [defaultParent])
 
   const handleMoveToDefault = (): void => {
     setPickError(undefined)
-    setMigrationTarget(defaultParent)
+    setMigrationTarget({
+      path: defaultParent,
+      recoveryStatus:
+        defaultInspection?.kind === 'recover' ? defaultInspection.recoveryStatus : undefined
+    })
   }
 
   const handleChooseFolder = async (): Promise<void> => {
@@ -69,12 +82,16 @@ const LegacyDataMoveDialog = ({
     setIsPicking(true)
     try {
       const inspection = await window.api.storage.inspectDataRoot(picked)
-      if (inspection.kind === 'move') {
-        setMigrationTarget(picked)
+      if (inspection.kind === 'move' || inspection.kind === 'recover') {
+        setMigrationTarget({
+          path: picked,
+          recoveryStatus: inspection.kind === 'recover' ? inspection.recoveryStatus : undefined
+        })
         return
       }
-      // This prompt only moves data into a fresh location; an 'adopt' target (already holds data)
-      // would mean abandoning the legacy data, which isn't what "move it out" should do here.
+      // This prompt moves data into a fresh location or resumes the same interrupted move. An
+      // 'adopt' target (already holds unrelated data) would mean abandoning the legacy data, which
+      // isn't what "move it out" should do here.
       setPickError(
         inspection.kind === 'adopt'
           ? t(
@@ -96,7 +113,8 @@ const LegacyDataMoveDialog = ({
     return (
       <StorageMigrationModal
         active={active}
-        targetPath={migrationTarget}
+        targetPath={migrationTarget.path}
+        recoveryStatus={migrationTarget.recoveryStatus}
         onClose={() => setMigrationTarget(null)}
       />
     )

--- a/src/renderer/src/components/LegacyDataMoveDialog.tsx
+++ b/src/renderer/src/components/LegacyDataMoveDialog.tsx
@@ -51,27 +51,53 @@ const LegacyDataMoveDialog = ({
   // The exact <home>/OpenScience path "Move to OpenScience" would create. Resolved server-side via
   // inspectDataRoot(defaultParent) rather than getInfo's dataRoot, which for a legacy install is the
   // hidden config root itself.
-  const [destination, setDestination] = useState<string | undefined>(undefined)
-  const [defaultInspection, setDefaultInspection] = useState<DataRootInspection | undefined>(
-    undefined
-  )
+  const [defaultInspectionState, setDefaultInspectionState] = useState<
+    { parent: string; result: DataRootInspection } | undefined
+  >(undefined)
+  const defaultInspection =
+    defaultInspectionState?.parent === defaultParent ? defaultInspectionState.result : undefined
   const [pickError, setPickError] = useState<string | undefined>(undefined)
   const [isPicking, setIsPicking] = useState(false)
 
   useEffect(() => {
     void window.api.storage.inspectDataRoot(defaultParent).then((result) => {
-      setDestination(result.dataRoot)
-      setDefaultInspection(result)
+      setDefaultInspectionState({ parent: defaultParent, result })
     })
   }, [defaultParent])
 
+  const refreshDefaultDestination = (): void => {
+    setDefaultInspectionState(undefined)
+    void window.api.storage.inspectDataRoot(defaultParent).then((result) => {
+      setDefaultInspectionState({ parent: defaultParent, result })
+    })
+  }
+
+  const handleMigrationClose = (): void => {
+    const resolvedTarget = migrationTarget
+    setMigrationTarget(null)
+    if (resolvedTarget?.path === defaultParent) {
+      refreshDefaultDestination()
+    }
+  }
+
   const handleMoveToDefault = (): void => {
     setPickError(undefined)
-    setMigrationTarget({
-      path: defaultParent,
-      recoveryStatus:
-        defaultInspection?.kind === 'recover' ? defaultInspection.recoveryStatus : undefined
-    })
+    if (!defaultInspection) return
+    if (defaultInspection.kind === 'move' || defaultInspection.kind === 'recover') {
+      setMigrationTarget({
+        path: defaultParent,
+        recoveryStatus:
+          defaultInspection.kind === 'recover' ? defaultInspection.recoveryStatus : undefined
+      })
+      return
+    }
+    setPickError(
+      defaultInspection.kind === 'adopt'
+        ? t(
+            'That folder already contains Open Science data. Pick an empty folder, or use the default location.'
+          )
+        : (defaultInspection.error ?? t('That folder can’t be used. Pick another one.'))
+    )
   }
 
   const handleChooseFolder = async (): Promise<void> => {
@@ -115,7 +141,7 @@ const LegacyDataMoveDialog = ({
         active={active}
         targetPath={migrationTarget.path}
         recoveryStatus={migrationTarget.recoveryStatus}
-        onClose={() => setMigrationTarget(null)}
+        onClose={handleMigrationClose}
       />
     )
   }
@@ -154,7 +180,7 @@ const LegacyDataMoveDialog = ({
                 className="mt-1 overflow-x-auto whitespace-pre-wrap break-all rounded-lg border border-border-200 bg-bg-10 px-2.5 py-1.5 font-mono text-xs text-text-000"
                 aria-label={t('New data location')}
               >
-                {destination ?? t('Resolving…')}
+                {defaultInspection?.dataRoot ?? t('Resolving…')}
               </pre>
             </div>
 
@@ -166,7 +192,11 @@ const LegacyDataMoveDialog = ({
           </div>
 
           <div className={cn(dialogFooterClassName, 'flex-col items-stretch')}>
-            <Button type="button" disabled={isPicking} onClick={handleMoveToDefault}>
+            <Button
+              type="button"
+              disabled={isPicking || defaultInspection === undefined}
+              onClick={handleMoveToDefault}
+            >
               <FolderInput aria-hidden="true" />
               {t('Move to OpenScience')}
             </Button>

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -2743,6 +2743,18 @@
   "Content changed but the package version was not increased. Update the version before publishing.": "内容已更改，但软件包版本未提升。发布前请更新版本。",
   "Export validation failed": "导出验证失败",
   "The current Specialist or selected Skills contain blocking validation errors.": "当前 Specialist 或所选 Skill 存在阻断性验证错误。",
+  "Finishing this recovered move will interrupt the running sessions below and restart the app.": "完成此恢复的迁移会中断以下运行中的会话并重启应用。",
+  "Continue to recovery": "继续恢复",
+  "Incomplete data copy found": "发现未完成的数据副本",
+  "Open Science exited before this copy finished. Your current data is untouched. Discard the incomplete copy to use this location again.": "Open Science 在复制完成前退出了。当前数据未受影响。请丢弃未完成的副本，以便再次使用此位置。",
+  "Discard incomplete copy": "丢弃未完成的副本",
+  "Verified data copy found": "发现已验证的数据副本",
+  "A completed copy from an interrupted move is ready. Finish the move to switch locations and restart, or discard the copy to stay where you are.": "中断的迁移留下了一个已完成的副本。完成迁移即可切换位置并重启，或丢弃副本并保留当前位置。",
+  "Discard copy": "丢弃副本",
+  "Finish move": "完成迁移",
+  "A verified copy from an interrupted move was found here. You can finish the move without copying everything again, or discard it.": "此处发现了中断迁移留下的已验证副本。你可以直接完成迁移，无需重新复制全部数据，也可以将其丢弃。",
+  "An incomplete copy from an interrupted move was found here. Discard it before using this location again.": "此处发现了中断迁移留下的未完成副本。再次使用此位置前，请先将其丢弃。",
+  "Resolve unfinished move": "处理未完成的迁移",
   "tokens": "tokens",
   "/ {{size}} tokens": "/ {{size}} 个 token"
 }

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -2743,6 +2743,18 @@
   "Content changed but the package version was not increased. Update the version before publishing.": "內容已變更，但套件版本未提升。發布前請更新版本。",
   "Export validation failed": "匯出驗證失敗",
   "The current Specialist or selected Skills contain blocking validation errors.": "目前 Specialist 或所選 Skill 存在阻斷性驗證錯誤。",
+  "Finishing this recovered move will interrupt the running sessions below and restart the app.": "完成此復原的移動會中斷以下執行中的工作階段並重新啟動應用程式。",
+  "Continue to recovery": "繼續復原",
+  "Incomplete data copy found": "發現未完成的資料副本",
+  "Open Science exited before this copy finished. Your current data is untouched. Discard the incomplete copy to use this location again.": "Open Science 在複製完成前退出了。目前資料未受影響。請丟棄未完成的副本，以便再次使用此位置。",
+  "Discard incomplete copy": "丟棄未完成的副本",
+  "Verified data copy found": "發現已驗證的資料副本",
+  "A completed copy from an interrupted move is ready. Finish the move to switch locations and restart, or discard the copy to stay where you are.": "中斷的移動留下了一個已完成的副本。完成移動即可切換位置並重新啟動，或丟棄副本並保留目前位置。",
+  "Discard copy": "丟棄副本",
+  "Finish move": "完成移動",
+  "A verified copy from an interrupted move was found here. You can finish the move without copying everything again, or discard it.": "此處發現了中斷移動留下的已驗證副本。你可以直接完成移動，無需重新複製全部資料，也可以將其丟棄。",
+  "An incomplete copy from an interrupted move was found here. Discard it before using this location again.": "此處發現了中斷移動留下的未完成副本。再次使用此位置前，請先將其丟棄。",
+  "Resolve unfinished move": "處理未完成的移動",
   "tokens": "tokens",
   "/ {{size}} tokens": "/ {{size}} 個 token"
 }

--- a/src/renderer/src/pages/onboarding/LocationStep.tsx
+++ b/src/renderer/src/pages/onboarding/LocationStep.tsx
@@ -74,8 +74,8 @@ const LocationStep = ({
       if (!picked) return
 
       const result = await window.api.storage.inspectDataRoot(picked)
-      if (result.kind === 'invalid') {
-        setLocationError(result.error)
+      if (result.kind !== 'move' && result.kind !== 'adopt') {
+        setLocationError(result.error ?? t('The selected folder is not usable.'))
         return
       }
 

--- a/src/renderer/src/pages/settings/StorageMigrationModal.render.test.tsx
+++ b/src/renderer/src/pages/settings/StorageMigrationModal.render.test.tsx
@@ -194,6 +194,79 @@ describe('StorageMigrationModal', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
+  it('resumes a verified copy without copying again and can finish the move', async () => {
+    const api = installApi()
+
+    await act(async () => {
+      root.render(
+        <StorageMigrationModal targetPath="/mnt/data" recoveryStatus="verified" onClose={vi.fn()} />
+      )
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain('Verified data copy found')
+    expect(api.migrate).not.toHaveBeenCalled()
+
+    await act(async () => {
+      clickButton((button) => button.textContent?.trim() === 'Finish move')
+      await Promise.resolve()
+    })
+
+    expect(api.commitAndRelaunch).toHaveBeenCalledWith('/mnt/data')
+  })
+
+  it('offers discard only for an incomplete recovered copy', async () => {
+    const onClose = vi.fn()
+    const api = installApi()
+
+    await act(async () => {
+      root.render(
+        <StorageMigrationModal targetPath="/mnt/data" recoveryStatus="copying" onClose={onClose} />
+      )
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain('Incomplete data copy found')
+    expect(document.body.textContent).not.toContain('Finish move')
+    expect(api.detectActive).not.toHaveBeenCalled()
+    expect(api.migrate).not.toHaveBeenCalled()
+
+    await act(async () => {
+      clickButton((button) => button.textContent?.trim() === 'Discard incomplete copy')
+      await Promise.resolve()
+    })
+
+    expect(api.discardMigratedCopy).toHaveBeenCalledWith('/mnt/data')
+    expect(api.commitAndRelaunch).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('confirms active-session interruption before finishing a recovered copy', async () => {
+    const api = installApi({
+      detectActive: vi
+        .fn()
+        .mockResolvedValue([{ projectId: 'proj-a', sessionId: 'sess-1', kind: 'agent' }])
+    })
+
+    await act(async () => {
+      root.render(
+        <StorageMigrationModal targetPath="/mnt/data" recoveryStatus="verified" onClose={vi.fn()} />
+      )
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain('Finishing this recovered move will interrupt')
+    expect(document.body.textContent).not.toContain('Verified data copy found')
+
+    await act(async () => {
+      clickButton((button) => button.textContent?.trim() === 'Continue to recovery')
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain('Verified data copy found')
+    expect(api.migrate).not.toHaveBeenCalled()
+  })
+
   it('keeps the current location usable and warns when copied-data cleanup fails', async () => {
     const onClose = vi.fn()
     installApi({

--- a/src/renderer/src/pages/settings/StorageMigrationModal.tsx
+++ b/src/renderer/src/pages/settings/StorageMigrationModal.tsx
@@ -10,6 +10,7 @@ import { cn } from '@/lib/utils'
 import {
   hasDelegatedActiveSession,
   type ActiveSessionInfo,
+  type DataRootRecoveryStatus,
   type MigrationOutcome,
   type MigrationPhase,
   type MigrationProgress
@@ -20,6 +21,7 @@ type Stage = 'detecting' | 'confirm' | 'migrating' | 'done' | 'committing' | 'er
 type StorageMigrationModalProps = {
   active?: boolean
   targetPath: string
+  recoveryStatus?: DataRootRecoveryStatus
   onClose: () => void
 }
 
@@ -56,11 +58,12 @@ const formatElapsed = (ms: number): string => {
 const StorageMigrationModal = ({
   active: isPresentationActive = true,
   targetPath,
+  recoveryStatus,
   onClose
 }: StorageMigrationModalProps): React.JSX.Element => {
   const { t } = useTranslation()
   const { t: tCommon } = useTranslation()
-  const [stage, setStage] = useState<Stage>('detecting')
+  const [stage, setStage] = useState<Stage>(recoveryStatus === 'copying' ? 'done' : 'detecting')
   const [active, setActive] = useState<ActiveSessionInfo[]>([])
   const [progress, setProgress] = useState<MigrationProgress | null>(null)
   const [outcome, setOutcome] = useState<MigrationOutcome | null>(null)
@@ -95,10 +98,13 @@ const StorageMigrationModal = ({
     }
   }, [])
 
-  // Detect running sessions once on open; skip straight to migrating when nothing is running.
+  // Detect running sessions once on open; skip straight to migrating when nothing is running. A
+  // verified recovery skips the copy and returns to the already-completed decision stage. An
+  // incomplete ('copying') recovery has no commit path, so it starts directly at discard-only done.
   // A rejected call would otherwise strand the modal on "Checking…" forever, since it's
   // non-dismissable until a stage transition happens.
   useEffect(() => {
+    if (recoveryStatus === 'copying') return
     void window.api.storage
       .detectActive()
       .then((sessions) => {
@@ -106,6 +112,8 @@ const StorageMigrationModal = ({
         if (sessions.length > 0) {
           setActive(sessions)
           setStage('confirm')
+        } else if (recoveryStatus === 'verified') {
+          setStage('done')
         } else {
           setStartedAt(Date.now())
           setStage('migrating')
@@ -116,7 +124,7 @@ const StorageMigrationModal = ({
         setIpcError(true)
         setStage('error')
       })
-  }, [])
+  }, [recoveryStatus])
 
   // Runs the move once we enter the migrating stage: subscribe to progress and call migrate,
   // routing its outcome to done / cancelled (close, no error) / error.
@@ -164,6 +172,10 @@ const StorageMigrationModal = ({
   }, [stage])
 
   const startMigration = (): void => {
+    if (recoveryStatus === 'verified') {
+      setStage('done')
+      return
+    }
     setStartedAt(Date.now())
     setStage('migrating')
   }
@@ -272,9 +284,13 @@ const StorageMigrationModal = ({
                   ? t(
                       'Subagents are still running. Return to each task below, stop its subagents, then try moving app data again.'
                     )
-                  : t(
-                      'Starting this move will interrupt the running sessions below and restart the app.'
-                    )}
+                  : recoveryStatus === 'verified'
+                    ? t(
+                        'Finishing this recovered move will interrupt the running sessions below and restart the app.'
+                      )
+                    : t(
+                        'Starting this move will interrupt the running sessions below and restart the app.'
+                      )}
               </Dialog.Description>
               <ul className="mt-3 max-h-40 space-y-1 overflow-auto rounded-lg border border-border bg-muted/40 p-2 font-mono text-xs text-foreground">
                 {active.map((session) => (
@@ -294,7 +310,9 @@ const StorageMigrationModal = ({
                 </Button>
                 {!hasDelegatedWork ? (
                   <Button type="button" onClick={startMigration}>
-                    {t('Interrupt and move')}
+                    {recoveryStatus === 'verified'
+                      ? t('Continue to recovery')
+                      : t('Interrupt and move')}
                   </Button>
                 ) : null}
               </div>
@@ -375,7 +393,48 @@ const StorageMigrationModal = ({
             </>
           ) : null}
 
-          {stage === 'done' && !cleanupWarning ? (
+          {stage === 'done' && recoveryStatus === 'copying' && !cleanupWarning ? (
+            <>
+              <div className="flex items-start gap-3">
+                <span
+                  className="flex size-9 shrink-0 items-center justify-center rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400"
+                  aria-hidden="true"
+                >
+                  <TriangleAlert className="size-[18px]" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <Dialog.Title className="text-sm font-semibold text-foreground">
+                    {t('Incomplete data copy found')}
+                  </Dialog.Title>
+                  <Dialog.Description className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                    {t(
+                      'Open Science exited before this copy finished. Your current data is untouched. Discard the incomplete copy to use this location again.'
+                    )}
+                  </Dialog.Description>
+                </div>
+              </div>
+              {discardError ? (
+                <p
+                  role="alert"
+                  className="mt-3 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive"
+                >
+                  {discardError}
+                </p>
+              ) : null}
+              <div className="mt-5 flex justify-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={isDiscarding}
+                  onClick={handleKeepCurrent}
+                >
+                  {isDiscarding ? t('Discarding…') : t('Discard incomplete copy')}
+                </Button>
+              </div>
+            </>
+          ) : null}
+
+          {stage === 'done' && recoveryStatus !== 'copying' && !cleanupWarning ? (
             <>
               <div className="flex items-start gap-3">
                 <span
@@ -386,12 +445,18 @@ const StorageMigrationModal = ({
                 </span>
                 <div className="min-w-0 flex-1">
                   <Dialog.Title className="text-sm font-semibold text-foreground">
-                    {t('Data copied')}
+                    {recoveryStatus === 'verified'
+                      ? t('Verified data copy found')
+                      : t('Data copied')}
                   </Dialog.Title>
                   <Dialog.Description className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                    {t(
-                      'Restart to switch to the new location. Nothing is changed until you do — choose Keep current location to stay where you are and discard the copy.'
-                    )}
+                    {recoveryStatus === 'verified'
+                      ? t(
+                          'A completed copy from an interrupted move is ready. Finish the move to switch locations and restart, or discard the copy to stay where you are.'
+                        )
+                      : t(
+                          'Restart to switch to the new location. Nothing is changed until you do — choose Keep current location to stay where you are and discard the copy.'
+                        )}
                   </Dialog.Description>
                 </div>
               </div>
@@ -422,11 +487,15 @@ const StorageMigrationModal = ({
                     disabled={isDiscarding}
                     onClick={handleKeepCurrent}
                   >
-                    {isDiscarding ? t('Discarding…') : t('Keep current location')}
+                    {isDiscarding
+                      ? t('Discarding…')
+                      : recoveryStatus === 'verified'
+                        ? t('Discard copy')
+                        : t('Keep current location')}
                   </Button>
                   <Button type="button" disabled={isDiscarding} onClick={handleRestart}>
                     <RefreshCw aria-hidden="true" />
-                    {t('Restart now')}
+                    {recoveryStatus === 'verified' ? t('Finish move') : t('Restart now')}
                   </Button>
                 </div>
               )}

--- a/src/renderer/src/pages/settings/StoragePanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/StoragePanel.render.test.tsx
@@ -92,6 +92,8 @@ beforeEach(() => {
       detectActive: vi.fn().mockResolvedValue([]),
       migrate: vi.fn().mockResolvedValue({ ok: true }),
       cancelMigrate: vi.fn().mockResolvedValue(undefined),
+      commitAndRelaunch: vi.fn().mockResolvedValue({ ok: true }),
+      discardMigratedCopy: vi.fn().mockResolvedValue({ ok: true }),
       onProgress: vi.fn(() => () => {})
     }
   }
@@ -786,6 +788,43 @@ describe('StoragePanel', () => {
         (button) => button.textContent?.trim() === 'Use this folder'
       )
     ).toBe(false)
+  })
+
+  it('a recoverable verified copy opens finish-or-discard recovery instead of migration', async () => {
+    ;(
+      window as unknown as { api: { storage: { pickDirectory: ReturnType<typeof vi.fn> } } }
+    ).api.storage.pickDirectory.mockResolvedValue('/mnt/interrupted')
+    ;(
+      window as unknown as { api: { storage: { inspectDataRoot: ReturnType<typeof vi.fn> } } }
+    ).api.storage.inspectDataRoot.mockResolvedValue({
+      kind: 'recover',
+      recoveryStatus: 'verified',
+      dataRoot: '/mnt/interrupted/OpenScience'
+    })
+
+    await act(async () => {
+      root.render(<StoragePanel />)
+      await Promise.resolve()
+    })
+    await openEditor()
+    await act(async () => {
+      clickButton((button) => button.textContent?.includes('Browse') ?? false)
+      await Promise.resolve()
+    })
+
+    expect(container.textContent).toContain('verified copy from an interrupted move')
+    expect(container.textContent).toContain('/mnt/interrupted/OpenScience')
+
+    await act(async () => {
+      clickButton((button) => button.textContent?.trim() === 'Resolve unfinished move')
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain('Verified data copy found')
+    expect(
+      (window as unknown as { api: { storage: { migrate: ReturnType<typeof vi.fn> } } }).api.storage
+        .migrate
+    ).not.toHaveBeenCalled()
   })
 
   it('offers return-to-default inside the editor only when the current root is custom', async () => {

--- a/src/renderer/src/pages/settings/StoragePanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/StoragePanel.render.test.tsx
@@ -790,17 +790,22 @@ describe('StoragePanel', () => {
     ).toBe(false)
   })
 
-  it('a recoverable verified copy opens finish-or-discard recovery instead of migration', async () => {
+  it('a recoverable verified copy opens recovery and refreshes the target after discard', async () => {
     ;(
       window as unknown as { api: { storage: { pickDirectory: ReturnType<typeof vi.fn> } } }
     ).api.storage.pickDirectory.mockResolvedValue('/mnt/interrupted')
     ;(
       window as unknown as { api: { storage: { inspectDataRoot: ReturnType<typeof vi.fn> } } }
-    ).api.storage.inspectDataRoot.mockResolvedValue({
-      kind: 'recover',
-      recoveryStatus: 'verified',
-      dataRoot: '/mnt/interrupted/OpenScience'
-    })
+    ).api.storage.inspectDataRoot
+      .mockResolvedValueOnce({
+        kind: 'recover',
+        recoveryStatus: 'verified',
+        dataRoot: '/mnt/interrupted/OpenScience'
+      })
+      .mockResolvedValue({
+        kind: 'move',
+        dataRoot: '/mnt/interrupted/OpenScience'
+      })
 
     await act(async () => {
       root.render(<StoragePanel />)
@@ -825,6 +830,25 @@ describe('StoragePanel', () => {
       (window as unknown as { api: { storage: { migrate: ReturnType<typeof vi.fn> } } }).api.storage
         .migrate
     ).not.toHaveBeenCalled()
+
+    await act(async () => {
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((button) => button.textContent?.trim() === 'Discard copy')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).not.toContain('Verified data copy found')
+    expect(container.textContent).not.toContain('verified copy from an interrupted move')
+    expect(container.textContent).toContain('Your existing data')
+    expect(
+      (
+        window as unknown as {
+          api: { storage: { inspectDataRoot: ReturnType<typeof vi.fn> } }
+        }
+      ).api.storage.inspectDataRoot
+    ).toHaveBeenCalledTimes(2)
   })
 
   it('offers return-to-default inside the editor only when the current root is custom', async () => {

--- a/src/renderer/src/pages/settings/StoragePanel.tsx
+++ b/src/renderer/src/pages/settings/StoragePanel.tsx
@@ -27,7 +27,13 @@ import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
 import { DataRootWarning } from '@/components/DataRootWarning'
 import { useSettingsStore } from '@/stores/settings-store'
-import type { DataRootKind, StorageInfo, UsageCategoryKey } from '../../../../shared/storage'
+import type {
+  DataRootKind,
+  DataRootInspection,
+  DataRootRecoveryStatus,
+  StorageInfo,
+  UsageCategoryKey
+} from '../../../../shared/storage'
 import { SettingsSection } from './SettingsLayout'
 import { isAgentRepairCheck } from './settings-navigation'
 import { StorageMigrationModal } from './StorageMigrationModal'
@@ -80,7 +86,8 @@ const PATH_PILL =
 // "Change location" (opens StorageMigrationModal, which detects running sessions, confirms the
 // interrupt+restart when needed, and drives the actual move); a folder that already contains our
 // data offers "Use this folder" instead, which only switches the dataRoot pointer and relaunches -
-// no files are moved. An invalid target shows an inline error and disables both actions.
+// no files are moved. A marker-bearing target offers explicit recovery; an invalid target shows an
+// inline error and disables both actions.
 type StoragePanelProps = {
   onContinueToAgent?: () => void
 }
@@ -102,13 +109,11 @@ const StoragePanel = ({ onContinueToAgent }: StoragePanelProps): React.JSX.Eleme
   // The classification of `newPath` (a PARENT the user typed/picked), keyed by the exact path it
   // was computed for so a stale response for an already-superseded path never drives the action
   // buttons. `dataRoot` is the derived `<newPath>/OpenScience` the app will actually use.
-  const [inspection, setInspection] = useState<{
+  const [inspection, setInspection] = useState<(DataRootInspection & { path: string }) | null>(null)
+  const [migrationTarget, setMigrationTarget] = useState<{
     path: string
-    kind: DataRootKind
-    dataRoot: string
-    error?: string
+    recoveryStatus?: DataRootRecoveryStatus
   } | null>(null)
-  const [migrationTarget, setMigrationTarget] = useState<string | null>(null)
   const [adoptConfirmOpen, setAdoptConfirmOpen] = useState(false)
   const [isAdopting, setIsAdopting] = useState(false)
   const [adoptError, setAdoptError] = useState<string | undefined>(undefined)
@@ -221,7 +226,7 @@ const StoragePanel = ({ onContinueToAgent }: StoragePanelProps): React.JSX.Eleme
     setDefaultError(undefined)
     const result = await window.api.storage.inspectDataRoot(info.defaultParent)
     if (result.kind === 'move') {
-      setMigrationTarget(info.defaultParent)
+      setMigrationTarget({ path: info.defaultParent })
       return
     }
     if (result.kind === 'adopt') {
@@ -229,6 +234,13 @@ const StoragePanel = ({ onContinueToAgent }: StoragePanelProps): React.JSX.Eleme
       setInspection({ path: info.defaultParent, ...result })
       setIsEditing(true)
       setAdoptConfirmOpen(true)
+      return
+    }
+    if (result.kind === 'recover' && result.recoveryStatus) {
+      setMigrationTarget({
+        path: info.defaultParent,
+        recoveryStatus: result.recoveryStatus
+      })
       return
     }
     setDefaultError(result.error ?? t('The default location is not usable.'))
@@ -403,7 +415,7 @@ const StoragePanel = ({ onContinueToAgent }: StoragePanelProps): React.JSX.Eleme
                   </p>
                 ) : null}
 
-                {(kind === 'move' || kind === 'adopt') && inspection ? (
+                {(kind === 'move' || kind === 'adopt' || kind === 'recover') && inspection ? (
                   <p className="mt-2 text-xs text-muted-foreground">
                     <Trans
                       i18nKey="Data will be stored in <path>{{path}}</path>"
@@ -420,7 +432,7 @@ const StoragePanel = ({ onContinueToAgent }: StoragePanelProps): React.JSX.Eleme
                       components={{ em: <strong className="font-semibold text-foreground" /> }}
                     />
                   </p>
-                ) : (
+                ) : kind === 'move' ? (
                   <>
                     <p className="mt-2 text-xs text-muted-foreground">
                       <Trans
@@ -435,7 +447,17 @@ const StoragePanel = ({ onContinueToAgent }: StoragePanelProps): React.JSX.Eleme
                       )}
                     </p>
                   </>
-                )}
+                ) : kind === 'recover' ? (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {inspection?.recoveryStatus === 'verified'
+                      ? t(
+                          'A verified copy from an interrupted move was found here. You can finish the move without copying everything again, or discard it.'
+                        )
+                      : t(
+                          'An incomplete copy from an interrupted move was found here. Discard it before using this location again.'
+                        )}
+                  </p>
+                ) : null}
 
                 {kind === 'invalid' && inspection?.error ? (
                   <p className="mt-2 text-xs text-destructive" role="alert">
@@ -459,11 +481,24 @@ const StoragePanel = ({ onContinueToAgent }: StoragePanelProps): React.JSX.Eleme
                       <FolderInput className="size-4" aria-hidden="true" />
                       {isAdopting ? t('Switching…') : t('Use this folder')}
                     </Button>
+                  ) : kind === 'recover' && inspection?.recoveryStatus ? (
+                    <Button
+                      type="button"
+                      onClick={() =>
+                        setMigrationTarget({
+                          path: trimmedNewPath,
+                          recoveryStatus: inspection.recoveryStatus
+                        })
+                      }
+                    >
+                      <FolderInput className="size-4" aria-hidden="true" />
+                      {t('Resolve unfinished move')}
+                    </Button>
                   ) : (
                     <Button
                       type="button"
                       disabled={!canChangeLocation}
-                      onClick={() => setMigrationTarget(trimmedNewPath)}
+                      onClick={() => setMigrationTarget({ path: trimmedNewPath })}
                     >
                       <FolderInput className="size-4" aria-hidden="true" />
                       {t('Change location')}
@@ -682,7 +717,8 @@ const StoragePanel = ({ onContinueToAgent }: StoragePanelProps): React.JSX.Eleme
 
       {migrationTarget !== null ? (
         <StorageMigrationModal
-          targetPath={migrationTarget}
+          targetPath={migrationTarget.path}
+          recoveryStatus={migrationTarget.recoveryStatus}
           onClose={() => setMigrationTarget(null)}
         />
       ) : null}

--- a/src/renderer/src/pages/settings/StoragePanel.tsx
+++ b/src/renderer/src/pages/settings/StoragePanel.tsx
@@ -203,6 +203,16 @@ const StoragePanel = ({ onContinueToAgent }: StoragePanelProps): React.JSX.Eleme
     setIsEditing(false)
   }
 
+  const handleMigrationClose = (): void => {
+    const resolvedTarget = migrationTarget
+    setMigrationTarget(null)
+    // Discarding a recovered copy changes its on-disk classification. Refresh the editor instead of
+    // leaving a stale `recover` action that would reopen a modal for a marker that no longer exists.
+    if (resolvedTarget && inspection?.path === resolvedTarget.path) {
+      void inspectPath(resolvedTarget.path)
+    }
+  }
+
   const handleAdopt = async (): Promise<void> => {
     setAdoptConfirmOpen(false)
     setIsAdopting(true)
@@ -432,7 +442,17 @@ const StoragePanel = ({ onContinueToAgent }: StoragePanelProps): React.JSX.Eleme
                       components={{ em: <strong className="font-semibold text-foreground" /> }}
                     />
                   </p>
-                ) : kind === 'move' ? (
+                ) : kind === 'recover' ? (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {inspection?.recoveryStatus === 'verified'
+                      ? t(
+                          'A verified copy from an interrupted move was found here. You can finish the move without copying everything again, or discard it.'
+                        )
+                      : t(
+                          'An incomplete copy from an interrupted move was found here. Discard it before using this location again.'
+                        )}
+                  </p>
+                ) : (
                   <>
                     <p className="mt-2 text-xs text-muted-foreground">
                       <Trans
@@ -447,17 +467,7 @@ const StoragePanel = ({ onContinueToAgent }: StoragePanelProps): React.JSX.Eleme
                       )}
                     </p>
                   </>
-                ) : kind === 'recover' ? (
-                  <p className="mt-2 text-xs text-muted-foreground">
-                    {inspection?.recoveryStatus === 'verified'
-                      ? t(
-                          'A verified copy from an interrupted move was found here. You can finish the move without copying everything again, or discard it.'
-                        )
-                      : t(
-                          'An incomplete copy from an interrupted move was found here. Discard it before using this location again.'
-                        )}
-                  </p>
-                ) : null}
+                )}
 
                 {kind === 'invalid' && inspection?.error ? (
                   <p className="mt-2 text-xs text-destructive" role="alert">
@@ -719,7 +729,7 @@ const StoragePanel = ({ onContinueToAgent }: StoragePanelProps): React.JSX.Eleme
         <StorageMigrationModal
           targetPath={migrationTarget.path}
           recoveryStatus={migrationTarget.recoveryStatus}
-          onClose={() => setMigrationTarget(null)}
+          onClose={handleMigrationClose}
         />
       ) : null}
     </div>

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -67,12 +67,22 @@ export type DataRootValidationResult = { ok: true } | { ok: false; error: string
 
 // Classification of a candidate data root, mirroring main's ClassifyResult
 // (src/main/storage/migration-service.ts). 'move' = empty writable target (copy-in migration).
-// 'adopt' = already contains our data (pointer switch only, no move). 'invalid' carries a reason.
+// 'adopt' = already contains our data (pointer switch only, no move). 'recover' = a durable marker
+// from an interrupted copy that Settings can explicitly finish or discard. 'invalid' carries a reason.
 // `dataRoot` is the derived `<parent>/OpenScience` path, always present so the caller can display
 // the final location regardless of kind.
-export type DataRootKind = 'move' | 'adopt' | 'invalid'
-export type DataRootInspection = {
-  kind: DataRootKind
-  dataRoot: string
-  error?: string
-}
+export type DataRootKind = 'move' | 'adopt' | 'recover' | 'invalid'
+export type DataRootRecoveryStatus = 'copying' | 'verified'
+export type DataRootInspection =
+  | {
+      kind: 'recover'
+      dataRoot: string
+      recoveryStatus: DataRootRecoveryStatus
+      error?: string
+    }
+  | {
+      kind: Exclude<DataRootKind, 'recover'>
+      dataRoot: string
+      recoveryStatus?: never
+      error?: string
+    }


### PR DESCRIPTION
## Problem

The storage move authority was held only in `command-owner.ts` memory after a copy reached the durable `verified` marker. If the main process exited before commit or discard, the next process could see the marker but could neither resolve it nor select that destination again.

This left a safe but orphaned snapshot on disk, consumed storage, and permanently blocked that destination without manual marker manipulation.

## Proposed change

- Classify a valid marker for the current source and derived target as an explicit `recover` result.
- Rehydrate the marker token only inside the main-process command owner; it is never exposed to the renderer.
- Allow a recovered `verified` copy to be finished or discarded, and a recovered `copying` copy to be discarded only.
- Before finishing a recovered copy, restore the write gate, reject delegated work, disconnect data-root writers, and rerun the existing inventory/provenance checks.
- Route Settings to a dedicated recovery decision while preventing onboarding, missing-root recovery, and direct pointer switching from adopting a staged copy.
- Add Simplified and Traditional Chinese strings for the new interaction.

## Scope and non-goals

- No settings field, database schema, marker version, or persisted marker field changes.
- Existing valid version-1 `copying` and `verified` markers are recovered in place; corrupt markers and markers for another source remain invalid.
- The shared IPC read model adds the transient `recover` kind and `recoveryStatus: copying | verified` discriminator. No persisted enum is added.
- No automatic commit or automatic deletion occurs on startup; the user must explicitly finish or discard in Settings.

## Acceptance criteria and validation

- Recreated command owner + verified marker -> commit pauses writers, rechecks the snapshot, switches the pointer, and relaunches.
- Source mutation after verification -> recovered commit is refused and the old root remains writable.
- Recreated command owner + copying/verified marker -> explicit discard removes only the marker-matched staging target.
- Pause failure or active delegated work -> recovered commit is refused without switching roots.
- Settings -> verified recovery offers finish/discard; copying recovery offers discard only and never starts a new copy.
- Other pointer-switch surfaces -> `recover` cannot be treated as `move` or `adopt`.

Validation run:

- `npm run typecheck:node`
- `npm run typecheck:web`
- `npm run lint`
- `npm test -- src/main/storage/migration-service.test.ts` (81 passed, 4 skipped)
- `npm test -- src/main/storage/ipc.test.ts -t "recovered|command owner is recreated"` (7 passed)
- `npm test -- src/main/storage/migration-state.test.ts` (11 passed)
- `npm test -- src/renderer/src/pages/settings/StorageMigrationModal.render.test.tsx src/renderer/src/pages/settings/StoragePanel.render.test.tsx src/renderer/src/components/DataRootMissingDialog.render.test.tsx src/renderer/src/components/LegacyDataMoveDialog.render.test.tsx src/renderer/src/pages/onboarding/LocationStep.render.test.tsx` (81 passed)
- `npx vitest run src/renderer/src/i18n/resources.test.ts` (67 passed)

The full `src/main/storage/ipc.test.ts` file was not used as local evidence because this Windows dependency tree does not contain the built `safe_file_publisher_native.node`, and rebuilding it requires a Visual Studio C++ workload not present on this machine. The targeted recovery cases do not require that binding and pass; PR CI remains authoritative for the complete suite.

## Review focus

- Marker source/target/token validation at the recovered command boundary.
- Re-establishing writer quiescence before a recovered commit.
- Keeping `copying` recovery discard-only and preventing pointer-switch bypasses.
