### PR TITLE
fix(uploads): retry staging initialization after failure

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -566,6 +566,7 @@
       "consumerModules": ["session_persistence"],
       "testFiles": {
         "owner": [
+          "src/main/uploads/active-transfer-owner.test.ts",
           "src/main/uploads/repository.test.ts",
           "src/main/uploads/repository.characterization.test.ts",
           "src/main/uploads/repository.architecture.test.ts"

--- a/src/main/uploads/active-transfer-owner.test.ts
+++ b/src/main/uploads/active-transfer-owner.test.ts
@@ -1,0 +1,46 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return {
+    ...actual,
+    rm: vi.fn(actual.rm)
+  }
+})
+
+import { ActiveTransferOwner } from './active-transfer-owner'
+
+const actualFsPromises =
+  await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+
+let storageRoot: string | undefined
+
+afterEach(async () => {
+  vi.mocked(rm).mockReset().mockImplementation(actualFsPromises.rm)
+  if (storageRoot) await actualFsPromises.rm(storageRoot, { recursive: true, force: true })
+  storageRoot = undefined
+})
+
+describe('ActiveTransferOwner staging initialization', () => {
+  it('retries initialization after a transient filesystem failure', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-active-transfer-'))
+    const owner = new ActiveTransferOwner(storageRoot)
+    const transientFailure = new Error('transient staging cleanup failure')
+    vi.mocked(rm).mockRejectedValueOnce(transientFailure)
+
+    const request = { transferId: 'retry-transfer', name: 'data.csv', size: 1 }
+
+    await expect(owner.beginTransfer(request)).rejects.toBe(transientFailure)
+    await expect(owner.beginTransfer(request)).resolves.toMatchObject({
+      transferId: request.transferId,
+      receivedBytes: 0,
+      totalBytes: request.size
+    })
+    expect(rm).toHaveBeenCalledTimes(2)
+
+    await owner.abortTransfer({ transferId: request.transferId })
+  })
+})

--- a/src/main/uploads/active-transfer-owner.ts
+++ b/src/main/uploads/active-transfer-owner.ts
@@ -365,7 +365,10 @@ class ActiveTransferOwner {
       this.stagingReady = (async () => {
         await rm(stagingDir, { recursive: true, force: true })
         await mkdir(stagingDir, { recursive: true })
-      })()
+      })().catch((error) => {
+        this.stagingReady = undefined
+        throw error
+      })
     }
 
     return this.stagingReady


### PR DESCRIPTION
## Problem

`ActiveTransferOwner` cached the first staging-directory initialization promise for the lifetime of the repository. If staging cleanup or directory creation rejected once, the rejected promise remained cached and every later upload failed with the same error until the main process restarted.

## Proposed change

- Clear the cached staging initialization promise only when initialization rejects, allowing the next upload to retry.
- Preserve successful one-time initialization and concurrent first-call promise sharing.
- Add a deterministic regression test that injects one transient filesystem failure and verifies the same upload can be retried.
- Register the regression test in the `upload_repository` module impact set.

## Scope and non-goals

- No database or schema changes.
- No new persisted fields, status values, or enum members.
- No data-model, architecture, IPC contract, or user-interaction changes.
- No historical-data compatibility path is required because staging readiness exists only in process memory and partial transfers do not survive restart.

## Acceptance criteria and validation

All listed checks ran after the last material implementation edit.

- Transient staging initialization failure can be retried -> `npm test -- src/main/uploads/active-transfer-owner.test.ts` -> passed (1/1).
- Upload owner, contracts, and declared consumers remain compatible -> `npm run test:module -- upload_repository` -> 129/131 passed; the two remaining tests failed while creating Windows symlink fixtures with local `EPERM`, before exercising product code. PR CI is authoritative for those environment-dependent cases.
- Module impact manifest remains valid -> `npm test -- scripts/ci/module-test-impact.test.ts scripts/ci/module-impact-shadow.test.ts` -> passed (41/41).
- Main-process types remain valid -> `npm run typecheck:node` -> passed.
- Source and test lint -> `npm run lint` -> passed with no errors or warnings.

Per maintainer request, the complete `npm test` suite was not run locally; PR CI provides the full test result.

## Review focus

- Confirm rejection clears only the failed initialization cache.
- Confirm successful initialization and concurrent first-call deduplication remain unchanged.
