### PR TITLE
fix(local-fs): sort directory entries before truncating

### DIFF
--- a/src/main/local-fs/service.test.ts
+++ b/src/main/local-fs/service.test.ts
@@ -65,9 +65,14 @@ describe('LocalFsService.listDir', () => {
   it('sorts the complete readdir result before applying the entry cap', async () => {
     const fileDirents = Array.from({ length: LOCAL_DIR_ENTRY_CAP }, (_, index) => ({
       name: `file-${String(index).padStart(4, '0')}`,
-      isDirectory: () => false
+      isDirectory: () => false,
+      isSymbolicLink: () => false
     }))
-    const directoryDirent = { name: 'zzz-directory', isDirectory: () => true }
+    const directoryDirent = {
+      name: 'zzz-directory',
+      isDirectory: () => true,
+      isSymbolicLink: () => false
+    }
     vi.mocked(readdir).mockResolvedValueOnce([...fileDirents, directoryDirent] as never)
     vi.mocked(stat).mockResolvedValue({
       isDirectory: () => false,
@@ -80,6 +85,36 @@ describe('LocalFsService.listDir', () => {
     expect(listing.truncated).toBe(true)
     expect(listing.entries).toHaveLength(LOCAL_DIR_ENTRY_CAP)
     expect(listing.entries[0]).toMatchObject({ name: 'zzz-directory', isDirectory: true })
+    expect(listing.entries.at(-1)?.name).toBe('file-4998')
+    expect(listing.entries.some((entry) => entry.name === 'file-4999')).toBe(false)
+  })
+
+  it('classifies directory symlinks before applying the entry cap', async () => {
+    const fileDirents = Array.from({ length: LOCAL_DIR_ENTRY_CAP }, (_, index) => ({
+      name: `file-${String(index).padStart(4, '0')}`,
+      isDirectory: () => false,
+      isSymbolicLink: () => false
+    }))
+    const directoryLinkDirent = {
+      name: 'zzz-directory-link',
+      isDirectory: () => false,
+      isSymbolicLink: () => true
+    }
+    vi.mocked(readdir).mockResolvedValueOnce([...fileDirents, directoryLinkDirent] as never)
+    vi.mocked(stat).mockImplementation(
+      async (path) =>
+        ({
+          isDirectory: () => String(path).endsWith(directoryLinkDirent.name),
+          size: 1,
+          mtimeMs: 1
+        }) as never
+    )
+
+    const listing = await service.listDir(root)
+
+    expect(listing.truncated).toBe(true)
+    expect(listing.entries).toHaveLength(LOCAL_DIR_ENTRY_CAP)
+    expect(listing.entries[0]).toMatchObject({ name: 'zzz-directory-link', isDirectory: true })
     expect(listing.entries.at(-1)?.name).toBe('file-4998')
     expect(listing.entries.some((entry) => entry.name === 'file-4999')).toBe(false)
   })

--- a/src/main/local-fs/service.test.ts
+++ b/src/main/local-fs/service.test.ts
@@ -89,7 +89,7 @@ describe('LocalFsService.listDir', () => {
     expect(listing.entries.some((entry) => entry.name === 'file-4999')).toBe(false)
   })
 
-  it('classifies directory symlinks before applying the entry cap', async () => {
+  it('keeps directory symlink candidates eligible before applying the entry cap', async () => {
     const fileDirents = Array.from({ length: LOCAL_DIR_ENTRY_CAP }, (_, index) => ({
       name: `file-${String(index).padStart(4, '0')}`,
       isDirectory: () => false,

--- a/src/main/local-fs/service.test.ts
+++ b/src/main/local-fs/service.test.ts
@@ -11,7 +11,7 @@ vi.mock('electron', () => ({
   shell: { showItemInFolder: vi.fn(), openPath: vi.fn(async () => '') }
 }))
 
-// access/readdir/realpath start as delegating wrappers so listDrives tests can substitute
+// access/readdir/realpath/stat start as delegating wrappers so tests can substitute
 // per-platform fakes; every other export stays real for the listDir/preview tests above.
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>()
@@ -19,15 +19,16 @@ vi.mock('node:fs/promises', async (importOriginal) => {
     ...actual,
     access: vi.fn(actual.access),
     readdir: vi.fn(actual.readdir),
-    realpath: vi.fn(actual.realpath)
+    realpath: vi.fn(actual.realpath),
+    stat: vi.fn(actual.stat)
   }
 })
 
-import { access, readdir } from 'node:fs/promises'
+import { access, readdir, stat } from 'node:fs/promises'
 
 import { app } from 'electron'
 
-import type { GrantedLocalRoot } from '../../shared/local-fs'
+import { LOCAL_DIR_ENTRY_CAP, type GrantedLocalRoot } from '../../shared/local-fs'
 import { LocalFsService, type GrantedLocalRootsStore } from './service'
 
 // The unmocked fs/promises, for restoring the delegating wrappers after each listDrives test.
@@ -49,11 +50,38 @@ afterAll(() => {
 })
 
 describe('LocalFsService.listDir', () => {
+  afterEach(() => {
+    vi.mocked(readdir).mockImplementation(realFsPromises.readdir as never)
+    vi.mocked(stat).mockImplementation(realFsPromises.stat)
+  })
+
   it('lists entries directories-first, alphabetical', async () => {
     const listing = await service.listDir(root)
     expect(listing.entries.map((e) => e.name)).toEqual(['Alpha', 'sub', 'data.csv', 'notes.md'])
     expect(listing.entries[0].isDirectory).toBe(true)
     expect(listing.entries.find((e) => e.name === 'notes.md')?.size).toBeGreaterThan(0)
+  })
+
+  it('sorts the complete readdir result before applying the entry cap', async () => {
+    const fileDirents = Array.from({ length: LOCAL_DIR_ENTRY_CAP }, (_, index) => ({
+      name: `file-${String(index).padStart(4, '0')}`,
+      isDirectory: () => false
+    }))
+    const directoryDirent = { name: 'zzz-directory', isDirectory: () => true }
+    vi.mocked(readdir).mockResolvedValueOnce([...fileDirents, directoryDirent] as never)
+    vi.mocked(stat).mockResolvedValue({
+      isDirectory: () => false,
+      size: 1,
+      mtimeMs: 1
+    } as never)
+
+    const listing = await service.listDir(root)
+
+    expect(listing.truncated).toBe(true)
+    expect(listing.entries).toHaveLength(LOCAL_DIR_ENTRY_CAP)
+    expect(listing.entries[0]).toMatchObject({ name: 'zzz-directory', isDirectory: true })
+    expect(listing.entries.at(-1)?.name).toBe('file-4998')
+    expect(listing.entries.some((entry) => entry.name === 'file-4999')).toBe(false)
   })
 
   it('resolves symlinks and .. via realpath', async () => {

--- a/src/main/local-fs/service.ts
+++ b/src/main/local-fs/service.ts
@@ -1,6 +1,5 @@
 import { hostname, userInfo } from 'node:os'
 import { randomUUID } from 'node:crypto'
-import type { Stats } from 'node:fs'
 import { readdir, realpath, stat } from 'node:fs/promises'
 import { basename, join, posix } from 'node:path'
 
@@ -192,39 +191,23 @@ export class LocalFsService {
     const dirents = await readdir(resolvedPath, { withFileTypes: true })
     const truncated = dirents.length > LOCAL_DIR_ENTRY_CAP
     // readdir order is filesystem-dependent. Sort the inexpensive Dirent metadata before applying
-    // the cap so repeated listings select the same visible subset. Resolve only symlinks up front so
-    // directory targets participate in the directory-first selection without stat'ing every entry.
-    const isDirectoryByName = new Map<string, boolean>()
-    const symlinkStatsByName = new Map<string, Stats>()
-    for (const dirent of dirents) {
-      let isDirectory = dirent.isDirectory()
-      if (!isDirectory && dirent.isSymbolicLink()) {
-        try {
-          const entryStat = await stat(join(resolvedPath, dirent.name))
-          symlinkStatsByName.set(dirent.name, entryStat)
-          isDirectory = entryStat.isDirectory()
-        } catch {
-          // Broken or unreadable symlinks remain file-like and use the existing fallback metadata.
-        }
-      }
-      isDirectoryByName.set(dirent.name, isDirectory)
-    }
+    // the cap so repeated listings select the same visible subset. Keep symlinks ahead of ordinary
+    // files so directory targets remain eligible, then resolve only the selected entries below.
     dirents.sort((a, b) => {
-      const aIsDirectory = isDirectoryByName.get(a.name) ?? false
-      const bIsDirectory = isDirectoryByName.get(b.name) ?? false
-      if (aIsDirectory !== bIsDirectory) return aIsDirectory ? -1 : 1
+      const aRank = a.isDirectory() ? 0 : a.isSymbolicLink() ? 1 : 2
+      const bRank = b.isDirectory() ? 0 : b.isSymbolicLink() ? 1 : 2
+      if (aRank !== bRank) return aRank - bRank
       return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
     })
     const capped = truncated ? dirents.slice(0, LOCAL_DIR_ENTRY_CAP) : dirents
 
     const entries: LocalDirEntry[] = []
     for (const dirent of capped) {
-      const isDirectory = isDirectoryByName.get(dirent.name) ?? dirent.isDirectory()
+      const isDirectory = dirent.isDirectory()
       // Stat each entry for size/mtime; skip entries that vanish or deny access mid-listing so one
       // unreadable file never fails the whole directory.
       try {
-        const entryStat =
-          symlinkStatsByName.get(dirent.name) ?? (await stat(join(resolvedPath, dirent.name)))
+        const entryStat = await stat(join(resolvedPath, dirent.name))
         entries.push({
           name: dirent.name,
           isDirectory: isDirectory || entryStat.isDirectory(),

--- a/src/main/local-fs/service.ts
+++ b/src/main/local-fs/service.ts
@@ -1,5 +1,6 @@
 import { hostname, userInfo } from 'node:os'
 import { randomUUID } from 'node:crypto'
+import type { Stats } from 'node:fs'
 import { readdir, realpath, stat } from 'node:fs/promises'
 import { basename, join, posix } from 'node:path'
 
@@ -191,21 +192,39 @@ export class LocalFsService {
     const dirents = await readdir(resolvedPath, { withFileTypes: true })
     const truncated = dirents.length > LOCAL_DIR_ENTRY_CAP
     // readdir order is filesystem-dependent. Sort the inexpensive Dirent metadata before applying
-    // the cap so repeated listings select the same visible subset without stat'ing every entry in
-    // an arbitrarily large directory.
+    // the cap so repeated listings select the same visible subset. Resolve only symlinks up front so
+    // directory targets participate in the directory-first selection without stat'ing every entry.
+    const isDirectoryByName = new Map<string, boolean>()
+    const symlinkStatsByName = new Map<string, Stats>()
+    for (const dirent of dirents) {
+      let isDirectory = dirent.isDirectory()
+      if (!isDirectory && dirent.isSymbolicLink()) {
+        try {
+          const entryStat = await stat(join(resolvedPath, dirent.name))
+          symlinkStatsByName.set(dirent.name, entryStat)
+          isDirectory = entryStat.isDirectory()
+        } catch {
+          // Broken or unreadable symlinks remain file-like and use the existing fallback metadata.
+        }
+      }
+      isDirectoryByName.set(dirent.name, isDirectory)
+    }
     dirents.sort((a, b) => {
-      if (a.isDirectory() !== b.isDirectory()) return a.isDirectory() ? -1 : 1
+      const aIsDirectory = isDirectoryByName.get(a.name) ?? false
+      const bIsDirectory = isDirectoryByName.get(b.name) ?? false
+      if (aIsDirectory !== bIsDirectory) return aIsDirectory ? -1 : 1
       return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
     })
     const capped = truncated ? dirents.slice(0, LOCAL_DIR_ENTRY_CAP) : dirents
 
     const entries: LocalDirEntry[] = []
     for (const dirent of capped) {
-      const isDirectory = dirent.isDirectory()
+      const isDirectory = isDirectoryByName.get(dirent.name) ?? dirent.isDirectory()
       // Stat each entry for size/mtime; skip entries that vanish or deny access mid-listing so one
       // unreadable file never fails the whole directory.
       try {
-        const entryStat = await stat(join(resolvedPath, dirent.name))
+        const entryStat =
+          symlinkStatsByName.get(dirent.name) ?? (await stat(join(resolvedPath, dirent.name)))
         entries.push({
           name: dirent.name,
           isDirectory: isDirectory || entryStat.isDirectory(),

--- a/src/main/local-fs/service.ts
+++ b/src/main/local-fs/service.ts
@@ -190,6 +190,13 @@ export class LocalFsService {
     const resolvedPath = await realpath(path)
     const dirents = await readdir(resolvedPath, { withFileTypes: true })
     const truncated = dirents.length > LOCAL_DIR_ENTRY_CAP
+    // readdir order is filesystem-dependent. Sort the inexpensive Dirent metadata before applying
+    // the cap so repeated listings select the same visible subset without stat'ing every entry in
+    // an arbitrarily large directory.
+    dirents.sort((a, b) => {
+      if (a.isDirectory() !== b.isDirectory()) return a.isDirectory() ? -1 : 1
+      return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+    })
     const capped = truncated ? dirents.slice(0, LOCAL_DIR_ENTRY_CAP) : dirents
 
     const entries: LocalDirEntry[] = []


### PR DESCRIPTION
## Problem

Local directory listings read the complete directory but applied the 5,000-entry cap before sorting. Because Node.js does not guarantee `readdir` order, large directories could expose an unstable arbitrary subset, and entries that belong at the front of the sorted listing could be omitted.

## Proposed change

- Sort the full `Dirent` result directories-first and case-insensitively by name before applying the existing cap.
- Continue to `stat` only the selected entries so large directories do not gain unbounded metadata I/O.
- Add a 5,001-entry regression test where a directory returned last must remain visible and the final alphabetical file must be omitted.

## Scope and non-goals

- No pagination or change to the existing 5,000-entry limit/truncation notice.
- No IPC, preload, renderer interaction, shared data shape, enum, architecture, persistence, migration, or historical-data change.
- Symlinks retain existing behavior: target metadata can reclassify selected symlinks after the cap; the fix does not `stat` every entry before selection.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Stable capped subset -> `npm test -- src/main/local-fs/service.test.ts -t "lists entries directories-first|sorts the complete readdir result"` -> passed (2 tests).
- Local FS service behavior -> `npm test -- src/main/local-fs/service.test.ts -t '^(?!.*(resolves symlinks|home itself sits behind a symlink)).*$'` -> passed (19 tests, 2 existing symlink-permission tests skipped locally).
- Main-process types -> `npm run typecheck:node` -> passed.
- Lint -> `npm run lint -- --no-cache` -> passed.

The full service-file run reached 19 passing tests; its two failures were existing Windows symlink setup calls rejected with `EPERM` before product code ran. PR CI remains authoritative for the complete portable and platform suites.

## Review focus

- Confirm the pre-cap comparator remains aligned with the public directories-first, case-insensitive listing order.
- Confirm retaining bounded `stat` work is preferable to fully resolving symlink targets before subset selection.