### PR TITLE
fix(responses-compatibility): time out stalled provider streams

### DIFF
--- a/src/main/settings/native-responses-compatibility.test.ts
+++ b/src/main/settings/native-responses-compatibility.test.ts
@@ -246,6 +246,201 @@ describe('native Responses compatibility', () => {
     })
   })
 
+  it('aborts a native Responses stream after the configured idle period', async () => {
+    let upstreamSignal: AbortSignal | undefined
+    let failUpstream: ((reason?: unknown) => void) | undefined
+    const upstreamRequested = Promise.withResolvers<void>()
+    const fetchImpl = vi.fn(
+      async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        upstreamSignal = init?.signal ?? undefined
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode(
+                'data: {"type":"response.output_text.delta","delta":"working"}\n\n'
+              )
+            )
+            failUpstream = (reason) => controller.error(reason)
+            upstreamSignal?.addEventListener(
+              'abort',
+              () => failUpstream?.(upstreamSignal?.reason),
+              {
+                once: true
+              }
+            )
+          }
+        })
+        upstreamRequested.resolve()
+        return new Response(body, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' }
+        })
+      }
+    )
+    const proxy = new NativeResponsesCompatibilityProxy(
+      { baseUrl: 'https://api.deepseek.com/v1', model: 'deepseek-v4-pro' },
+      fetchImpl,
+      { streamIdleTimeoutMs: 25 }
+    )
+    const connection = await proxy.start()
+
+    try {
+      const responsePromise = fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'deepseek-v4-pro', input: 'analyze', stream: true })
+      })
+      await upstreamRequested.promise
+      const response = await responsePromise
+      const body = response.text()
+
+      const outcome = await Promise.race([
+        body.then(
+          () => 'completed',
+          (error: unknown) => error
+        ),
+        new Promise<'still-pending'>((resolve) => setTimeout(() => resolve('still-pending'), 500))
+      ])
+
+      expect(outcome).toBeInstanceOf(Error)
+      expect(upstreamSignal?.aborted).toBe(true)
+      expect(logSpies.warn.mock.calls).toContainEqual([
+        'native Responses compatibility request failed',
+        expect.objectContaining({
+          phase: 'forward-response',
+          outcome: 'error',
+          errorCategory: 'timeout'
+        })
+      ])
+    } finally {
+      failUpstream?.()
+      await proxy.close()
+    }
+  })
+
+  it('keeps a native Responses stream open while upstream events continue', async () => {
+    let upstreamSignal: AbortSignal | undefined
+    let upstreamController: ReadableStreamDefaultController<Uint8Array> | undefined
+    const encoder = new TextEncoder()
+    const fetchImpl = vi.fn(
+      async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        upstreamSignal = init?.signal ?? undefined
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              upstreamController = controller
+              controller.enqueue(encoder.encode('data: {"type":"response.created"}\n\n'))
+              upstreamSignal?.addEventListener(
+                'abort',
+                () => controller.error(upstreamSignal?.reason),
+                { once: true }
+              )
+            }
+          }),
+          { status: 200, headers: { 'content-type': 'text/event-stream' } }
+        )
+      }
+    )
+    const proxy = new NativeResponsesCompatibilityProxy(
+      { baseUrl: 'https://api.deepseek.com/v1', model: 'deepseek-v4-pro' },
+      fetchImpl,
+      { streamIdleTimeoutMs: 200 }
+    )
+    const connection = await proxy.start()
+    let eventIndex = 0
+    let interval: ReturnType<typeof setInterval> | undefined
+    let completion: ReturnType<typeof setTimeout> | undefined
+
+    try {
+      const response = await fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'deepseek-v4-pro', input: 'analyze', stream: true })
+      })
+      interval = setInterval(() => {
+        eventIndex += 1
+        upstreamController?.enqueue(
+          encoder.encode(`data: {"type":"response.output_text.delta","delta":"${eventIndex}"}\n\n`)
+        )
+      }, 20)
+      completion = setTimeout(() => {
+        if (interval) clearInterval(interval)
+        upstreamController?.close()
+      }, 300)
+
+      const body = await response.text()
+
+      expect(body).toContain('response.output_text.delta')
+      expect(upstreamSignal?.aborted).toBe(false)
+    } finally {
+      if (interval) clearInterval(interval)
+      if (completion) clearTimeout(completion)
+      await proxy.close()
+    }
+  })
+
+  it('aborts a native Responses request when upstream headers do not arrive in time', async () => {
+    let upstreamSignal: AbortSignal | undefined
+    const fetchImpl = vi.fn(
+      async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) =>
+        new Promise<Response>((_resolve, reject) => {
+          upstreamSignal = init?.signal ?? undefined
+          upstreamSignal?.addEventListener(
+            'abort',
+            () => reject(upstreamSignal?.reason ?? new Error('aborted')),
+            { once: true }
+          )
+        })
+    )
+    const proxy = new NativeResponsesCompatibilityProxy(
+      { baseUrl: 'https://api.deepseek.com/v1', model: 'deepseek-v4-pro' },
+      fetchImpl,
+      { responseHeaderTimeoutMs: 25 }
+    )
+    const connection = await proxy.start()
+
+    try {
+      const outcome = await Promise.race([
+        fetch(`${connection.baseUrl}/responses`, {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${connection.token}`,
+            'content-type': 'application/json'
+          },
+          body: JSON.stringify({ model: 'deepseek-v4-pro', input: 'analyze', stream: true })
+        }),
+        new Promise<'still-pending'>((resolve) => setTimeout(() => resolve('still-pending'), 500))
+      ])
+
+      expect(outcome).toBeInstanceOf(Response)
+      const response = outcome as Response
+      expect(response.status).toBe(400)
+      expect(await response.json()).toEqual({
+        error: {
+          type: 'invalid_request_error',
+          message: 'Native Responses compatibility request failed'
+        }
+      })
+      expect(upstreamSignal?.aborted).toBe(true)
+      expect(logSpies.warn.mock.calls).toContainEqual([
+        'native Responses compatibility request failed',
+        expect.objectContaining({
+          phase: 'upstream-fetch',
+          outcome: 'error',
+          errorCategory: 'timeout'
+        })
+      ])
+    } finally {
+      await proxy.close()
+    }
+  })
+
   it('selects matching Skills through the native Responses endpoint', async () => {
     const fetchImpl = vi.fn(
       async (url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -36,7 +36,9 @@ type NativeResponsesCompatibilityTarget = {
 }
 
 type NativeResponsesCompatibilityOptions = {
+  responseHeaderTimeoutMs?: number
   skillSelectorTimeoutMs?: number
+  streamIdleTimeoutMs?: number
 }
 
 export type NativeResponsesToolIdentity = {
@@ -49,6 +51,8 @@ export type NativeResponsesToolAliases = Map<string, NativeResponsesToolIdentity
 type NativeFetch = typeof fetch
 
 const log = createLogger('native-responses-compatibility')
+const DEFAULT_RESPONSE_HEADER_TIMEOUT_MS = 2 * 60_000
+const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 5 * 60_000
 const SAFE_NETWORK_ERROR_CODES = new Set([
   'EAI_AGAIN',
   'ECONNREFUSED',
@@ -58,6 +62,15 @@ const SAFE_NETWORK_ERROR_CODES = new Set([
   'ESOCKETTIMEDOUT',
   'ETIMEDOUT'
 ])
+
+class NativeResponsesTimeoutError extends Error {
+  readonly code = 'ETIMEDOUT'
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'TimeoutError'
+  }
+}
 
 const safeRead = (value: object, key: string): unknown => {
   try {
@@ -270,13 +283,15 @@ const rewriteSseLine = (line: string, aliases: NativeResponsesToolAliases): stri
 const streamResponse = async (
   upstream: Response,
   response: ServerResponse,
-  aliases: NativeResponsesToolAliases
+  aliases: NativeResponsesToolAliases,
+  onActivity: () => void
 ): Promise<void> => {
   if (!upstream.body) throw new Error('native Responses upstream returned no body')
   response.writeHead(upstream.status, copyResponseHeaders(upstream))
   const decoder = new TextDecoder()
   let buffered = ''
   for await (const chunk of upstream.body) {
+    onActivity()
     buffered += decoder.decode(chunk, { stream: true })
     const lines = buffered.split('\n')
     buffered = lines.pop() ?? ''
@@ -516,6 +531,26 @@ export class NativeResponsesCompatibilityProxy {
 
     const requestId = randomUUID()
     const startedAt = Date.now()
+    const upstreamAbort = new AbortController()
+    let upstreamTimer: ReturnType<typeof setTimeout> | undefined
+    let timeoutError: NativeResponsesTimeoutError | undefined
+    const clearUpstreamTimeout = (): void => {
+      if (upstreamTimer) clearTimeout(upstreamTimer)
+      upstreamTimer = undefined
+    }
+    const armUpstreamTimeout = (timeoutMs: number, message: string): void => {
+      clearUpstreamTimeout()
+      upstreamTimer = setTimeout(() => {
+        timeoutError = new NativeResponsesTimeoutError(message)
+        upstreamAbort.abort(timeoutError)
+      }, timeoutMs)
+      upstreamTimer.unref?.()
+    }
+    const armStreamIdleTimeout = (): void =>
+      armUpstreamTimeout(
+        this.options.streamIdleTimeoutMs ?? DEFAULT_STREAM_IDLE_TIMEOUT_MS,
+        'Native Responses upstream stream became idle.'
+      )
     let phase = 'read-request'
 
     try {
@@ -562,12 +597,17 @@ export class NativeResponsesCompatibilityProxy {
         toolLessScoped
       })
       phase = 'upstream-fetch'
+      armUpstreamTimeout(
+        this.options.responseHeaderTimeoutMs ?? DEFAULT_RESPONSE_HEADER_TIMEOUT_MS,
+        'Native Responses upstream did not return response headers in time.'
+      )
       const upstream = await this.fetchImpl(responsesUrl(this.target.baseUrl), {
         method: 'POST',
         headers: upstreamHeaders(request, this.target.key),
         body: JSON.stringify(upstreamRequest),
-        signal: request.signal
+        signal: AbortSignal.any([request.signal, upstreamAbort.signal])
       })
+      clearUpstreamTimeout()
       const contentType = upstream.headers.get('content-type') ?? ''
       const responseType = upstreamResponseType(contentType)
       log.info('native Responses compatibility upstream response', {
@@ -578,7 +618,8 @@ export class NativeResponsesCompatibilityProxy {
       })
       phase = 'forward-response'
       if (responseType === 'event-stream') {
-        await streamResponse(upstream, response, aliases)
+        armStreamIdleTimeout()
+        await streamResponse(upstream, response, aliases, armStreamIdleTimeout)
       } else if (responseType === 'json') {
         const payload = restoreNativeResponsesPayload(await upstream.json(), aliases)
         response.writeHead(upstream.status, copyResponseHeaders(upstream))
@@ -593,16 +634,19 @@ export class NativeResponsesCompatibilityProxy {
         durationMs: Math.max(0, Date.now() - startedAt)
       })
     } catch (error) {
-      const errorCode = safeNetworkErrorCode(error)
+      const failure = timeoutError ?? error
+      const errorCode = safeNetworkErrorCode(failure)
       log.warn('native Responses compatibility request failed', {
         requestId,
         phase,
         outcome: request.signal.aborted ? 'aborted' : 'error',
         durationMs: Math.max(0, Date.now() - startedAt),
-        ...diagnosticErrorFields(error),
+        ...diagnosticErrorFields(failure),
         ...(errorCode ? { errorCode } : {})
       })
-      throw error
+      throw failure
+    } finally {
+      clearUpstreamTimeout()
     }
   }
 }


### PR DESCRIPTION
## Problem

The native Responses compatibility proxy could wait forever when an upstream provider never returned response headers or stopped emitting an SSE body. The downstream Codex turn therefore remained in the thinking state indefinitely.

## Proposed change

- Abort the current upstream request if response headers do not arrive within 2 minutes.
- Abort an SSE request after 5 minutes without upstream bytes, resetting the idle timer on every chunk.
- Keep long-running active streams alive and do not add a total turn timeout.
- Preserve downstream cancellation by combining the existing request signal with the timeout signal.

## Scope and non-goals

- Limited to the codex-responses-compatibility transport.
- Claude, OpenCode, Codex Chat, native Responses, and subscription paths are unchanged.
- No historical-data compatibility or migration is required.
- No state or enum value is added.
- No persistence format or persisted data is changed.

## Acceptance and validation

- settings_backend_resolution module impact set: 478 passed, 3 skipped.
- Native Responses compatibility suite: 21 passed.
- Node typecheck passed.
- Targeted ESLint and Prettier checks passed.
- Independent Standards and Spec reviews: no findings.

## Review focus

- Timeout and AbortSignal lifecycle at the provider transport boundary.
- SSE activity resetting the idle timer without imposing a total duration cap.
- Error propagation after response headers have already been forwarded.