### PR TITLE
fix(acp): bound runtime event snapshots

### DIFF
--- a/src/main/acp/runtime-events.test.ts
+++ b/src/main/acp/runtime-events.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { MAX_ACP_MESSAGE_IMAGE_BYTES } from '../../shared/acp'
 import { sanitizeToolActivity } from '../../shared/session-persistence'
 import { extractToolFailureText, toAcpRuntimeEvent } from './runtime-events'
+import { AcpRuntimeSnapshotOwner } from './runtime-snapshot-owner'
 
 describe('ACP runtime event normalization', () => {
   it('maps assistant text chunks into readable runtime events', () => {
@@ -282,6 +283,36 @@ describe('ACP runtime event normalization', () => {
       rawInput: { command: 'ls -la' },
       rawOutput: { stdout: 'total 8' }
     })
+  })
+
+  it('bounds large tool detail fields before they enter runtime snapshots', () => {
+    const event = new AcpRuntimeSnapshotOwner('/workspace').appendEvent(
+      toAcpRuntimeEvent(
+        {
+          sessionId: 'session-1',
+          update: {
+            sessionUpdate: 'tool_call_update',
+            toolCallId: 'tool-large-output',
+            status: 'in_progress',
+            content: [
+              { type: 'content', content: { type: 'text', text: 'a'.repeat(20_000) } },
+              { type: 'content', content: { type: 'text', text: 'b'.repeat(20_000) } }
+            ],
+            _meta: { terminal_output: { data: 'c'.repeat(20_000) } }
+          }
+        },
+        'event-large-output'
+      )
+    )
+
+    expect(event.toolContent).toEqual([
+      {
+        type: 'content',
+        content: { type: 'text', text: `${'a'.repeat(16_000)}\n…` }
+      }
+    ])
+    expect(event.terminalOutput).toBe(`${'c'.repeat(16_000)}\n…`)
+    expect(JSON.stringify(event.toolContent).length).toBeLessThanOrEqual(32_000)
   })
 
   it('projects ACP tool-result images without retaining bytes in runtime or Session JSON', () => {

--- a/src/main/acp/runtime-publication-owner.test.ts
+++ b/src/main/acp/runtime-publication-owner.test.ts
@@ -16,6 +16,49 @@ const createProjection = (): RuntimeSnapshotProjection => ({
 })
 
 describe('AcpRuntimePublicationOwner', () => {
+  it('publishes coalesced state on the renderer 33 ms presentation cadence', () => {
+    vi.useFakeTimers()
+    try {
+      const onStateChanged = vi.fn()
+      const owner = new AcpRuntimePublicationOwner({
+        snapshotOwner: new AcpRuntimeSnapshotOwner('/workspace'),
+        interactions: new AcpSessionInteractionOwner(),
+        snapshotProjection: createProjection,
+        callbacks: { onStateChanged }
+      })
+
+      owner.pushEvent({ kind: 'message', level: 'info', role: 'assistant', text: 'chunk' })
+      vi.advanceTimersByTime(32)
+      expect(onStateChanged).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(1)
+      expect(onStateChanged).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('cancels a pending state publication without a late callback', () => {
+    vi.useFakeTimers()
+    try {
+      const onStateChanged = vi.fn()
+      const owner = new AcpRuntimePublicationOwner({
+        snapshotOwner: new AcpRuntimeSnapshotOwner('/workspace'),
+        interactions: new AcpSessionInteractionOwner(),
+        snapshotProjection: createProjection,
+        callbacks: { onStateChanged }
+      })
+
+      owner.pushEvent({ kind: 'message', level: 'info', role: 'assistant', text: 'chunk' })
+      owner.cancelPendingStatePublication()
+      vi.advanceTimersByTime(33)
+
+      expect(onStateChanged).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('coalesces assistant text state while publishing every event immediately', () => {
     const order: string[] = []
     let releaseScheduledState: (() => void) | undefined
@@ -39,6 +82,28 @@ describe('AcpRuntimePublicationOwner', () => {
     expect(order).toEqual(['event:one', 'event:two'])
     releaseScheduledState?.()
     expect(order).toEqual(['event:one', 'event:two', 'state:2'])
+  })
+
+  it('coalesces streamed assistant thought state', () => {
+    let releaseScheduledState: (() => void) | undefined
+    const onStateChanged = vi.fn()
+    const owner = new AcpRuntimePublicationOwner({
+      snapshotOwner: new AcpRuntimeSnapshotOwner('/workspace'),
+      interactions: new AcpSessionInteractionOwner(),
+      snapshotProjection: createProjection,
+      callbacks: { onStateChanged },
+      scheduleStatePublication: (publish) => {
+        releaseScheduledState = publish
+        return () => (releaseScheduledState = undefined)
+      }
+    })
+
+    owner.pushEvent({ kind: 'thought', level: 'info', role: 'assistant', text: 'one' })
+    owner.pushEvent({ kind: 'thought', level: 'info', role: 'assistant', text: 'two' })
+
+    expect(onStateChanged).not.toHaveBeenCalled()
+    releaseScheduledState?.()
+    expect(onStateChanged).toHaveBeenCalledOnce()
   })
 
   it('publishes a burst before retained events can evict unseen prefix chunks', () => {
@@ -91,6 +156,102 @@ describe('AcpRuntimePublicationOwner', () => {
     owner.pushEvent({ kind: 'tool', level: 'info', toolCallId: 'tool-1', status: 'in_progress' })
 
     expect(order).toEqual(['event:message', 'event:tool', 'state:2'])
+  })
+
+  it('coalesces progressive tool output but publishes completion immediately', () => {
+    const snapshots: string[][] = []
+    const owner = new AcpRuntimePublicationOwner({
+      snapshotOwner: new AcpRuntimeSnapshotOwner('/workspace'),
+      interactions: new AcpSessionInteractionOwner(),
+      snapshotProjection: createProjection,
+      callbacks: {
+        onStateChanged: (snapshot) =>
+          snapshots.push(snapshot.events.map((event) => event.status ?? 'updating'))
+      },
+      scheduleStatePublication: () => () => undefined
+    })
+
+    owner.pushEvent({
+      kind: 'tool',
+      level: 'info',
+      toolCallId: 'tool-1',
+      status: 'in_progress',
+      terminalOutput: 'one'
+    })
+    expect(snapshots).toEqual([['in_progress']])
+
+    owner.pushEvent({
+      kind: 'tool',
+      level: 'info',
+      toolCallId: 'tool-1',
+      status: 'in_progress',
+      rawInput: { command: 'echo repeated provider input' },
+      terminalOutput: 'two'
+    })
+    expect(snapshots).toEqual([['in_progress']])
+
+    owner.pushEvent({
+      kind: 'tool',
+      level: 'info',
+      toolCallId: 'tool-1',
+      status: 'completed',
+      terminalOutput: 'done'
+    })
+    expect(snapshots).toEqual([['in_progress'], ['in_progress', 'in_progress', 'completed']])
+  })
+
+  it('isolates tool lifecycles by session and resets abandoned calls at lifecycle boundaries', () => {
+    const snapshots: number[] = []
+    const owner = new AcpRuntimePublicationOwner({
+      snapshotOwner: new AcpRuntimeSnapshotOwner('/workspace'),
+      interactions: new AcpSessionInteractionOwner(),
+      snapshotProjection: createProjection,
+      callbacks: { onStateChanged: (snapshot) => snapshots.push(snapshot.events.length) },
+      scheduleStatePublication: () => () => undefined
+    })
+
+    owner.pushEvent({
+      kind: 'tool',
+      level: 'info',
+      sessionId: 'session-1',
+      toolCallId: 'reused-call',
+      terminalOutput: 'first session start'
+    })
+    owner.pushEvent({
+      kind: 'tool',
+      level: 'info',
+      sessionId: 'session-2',
+      toolCallId: 'reused-call',
+      terminalOutput: 'second session start'
+    })
+    owner.pushEvent({
+      kind: 'tool',
+      level: 'info',
+      sessionId: 'session-1',
+      toolCallId: 'reused-call',
+      terminalOutput: 'progressive output'
+    })
+    expect(snapshots).toEqual([1, 2])
+
+    owner.pushEvent({ kind: 'stop', level: 'info', sessionId: 'session-1' })
+    owner.pushEvent({
+      kind: 'tool',
+      level: 'info',
+      sessionId: 'session-1',
+      toolCallId: 'reused-call',
+      terminalOutput: 'next run start'
+    })
+    expect(snapshots).toEqual([1, 2, 4, 5])
+
+    owner.cancelPendingStatePublication()
+    owner.pushEvent({
+      kind: 'tool',
+      level: 'info',
+      sessionId: 'session-2',
+      toolCallId: 'reused-call',
+      terminalOutput: 'next connection start'
+    })
+    expect(snapshots).toEqual([1, 2, 4, 5, 6])
   })
 
   it('keeps a mixed 121-event burst within the frame and boundary publication budget', () => {

--- a/src/main/acp/runtime-publication-owner.ts
+++ b/src/main/acp/runtime-publication-owner.ts
@@ -8,19 +8,24 @@ import {
   type RuntimeSnapshotProjection
 } from './runtime-snapshot-owner'
 
-// Dev-facing counters for the acp:state trailing-edge coalescer; a throttled debug summary rides
+// Dev-facing counters for the acp:state window coalescer; a throttled debug summary rides
 // the existing logger level gating (debug is dev-only), leaving production unaffected.
 const log = createLogger('acp')
 let acpStateBroadcastsSent = 0
 let acpStateBroadcastsSuppressed = 0
+const acpRuntimeEventsPublished = new Map<AcpRuntimeEvent['kind'], number>()
 
-const recordAcpStateBroadcastSent = (): void => {
+const recordAcpStateBroadcastSent = (snapshot: AcpStateSnapshot): void => {
   acpStateBroadcastsSent += 1
-  // Streaming still emits ~one broadcast per frame, so log a periodic summary instead.
+  // Streaming still emits ~one broadcast per renderer presentation tick, so summarize periodically.
   if (acpStateBroadcastsSent % 100 === 0) {
     log.debug('acp:state broadcasts', {
       sent: acpStateBroadcastsSent,
-      suppressed: acpStateBroadcastsSuppressed
+      suppressed: acpStateBroadcastsSuppressed,
+      eventKinds: Object.fromEntries(acpRuntimeEventsPublished),
+      ...(process.env.NODE_ENV === 'development'
+        ? { snapshotChars: JSON.stringify(snapshot).length }
+        : {})
     })
   }
 }
@@ -39,19 +44,19 @@ type AcpRuntimePublicationOwnerOptions = Readonly<{
   scheduleStatePublication?: (publish: () => void) => () => void
 }>
 
-const STATE_PUBLICATION_INTERVAL_MS = 16
-// A fast provider can emit more than one retained window before the 16 ms timer runs. Publish
+const STATE_PUBLICATION_INTERVAL_MS = 33
+// A fast provider can emit more than one retained window before the 33 ms timer runs. Publish
 // midway through that window so every prefix chunk reaches subscribers before bounded history can
 // evict it, while ordinary streams still receive the same frame-level coalescing.
-const MAX_COALESCED_ASSISTANT_TEXT_EVENTS = Math.floor(ACP_RUNTIME_EVENT_RETENTION_LIMIT / 2)
+const MAX_COALESCED_EVENTS = Math.floor(ACP_RUNTIME_EVENT_RETENTION_LIMIT / 2)
 
 const scheduleStatePublication = (publish: () => void): (() => void) => {
   const timer = setTimeout(publish, STATE_PUBLICATION_INTERVAL_MS)
   return () => clearTimeout(timer)
 }
 
-const isCoalescibleAssistantTextEvent = (event: AcpRuntimeEvent): boolean =>
-  event.kind === 'message' &&
+const isCoalescibleAssistantStreamEvent = (event: AcpRuntimeEvent): boolean =>
+  (event.kind === 'message' || event.kind === 'thought') &&
   event.role === 'assistant' &&
   typeof event.text === 'string' &&
   event.text.length > 0 &&
@@ -67,7 +72,8 @@ const preservingFrozen = <Value extends object>(source: Value, copy: Value): Val
 // Every projection is read live from the authoritative owners; this owner caches no runtime facts.
 class AcpRuntimePublicationOwner {
   private cancelScheduledStatePublication?: () => void
-  private coalescedAssistantTextEvents = 0
+  private coalescedEvents = 0
+  private readonly activeToolCallIdsBySession = new Map<string | undefined, Set<string>>()
 
   constructor(private readonly options: AcpRuntimePublicationOwnerOptions) {}
 
@@ -90,10 +96,14 @@ class AcpRuntimePublicationOwner {
         : event
     const runtimeEvent = this.options.snapshotOwner.appendEvent(scopedEvent)
     onAppended?.()
+    acpRuntimeEventsPublished.set(
+      runtimeEvent.kind,
+      (acpRuntimeEventsPublished.get(runtimeEvent.kind) ?? 0) + 1
+    )
     this.options.callbacks.onEvent?.(runtimeEvent)
-    if (isCoalescibleAssistantTextEvent(runtimeEvent)) {
-      this.coalescedAssistantTextEvents += 1
-      if (this.coalescedAssistantTextEvents >= MAX_COALESCED_ASSISTANT_TEXT_EVENTS) {
+    if (this.isCoalescibleRuntimeEvent(runtimeEvent)) {
+      this.coalescedEvents += 1
+      if (this.coalescedEvents >= MAX_COALESCED_EVENTS) {
         this.emitState()
       } else {
         this.scheduleStatePublication()
@@ -101,6 +111,37 @@ class AcpRuntimePublicationOwner {
     } else {
       this.emitState()
     }
+  }
+
+  private isCoalescibleRuntimeEvent(event: AcpRuntimeEvent): boolean {
+    if (isCoalescibleAssistantStreamEvent(event)) return true
+    if (event.kind === 'stop' || event.kind === 'error') {
+      this.activeToolCallIdsBySession.delete(event.sessionId)
+      return false
+    }
+    if (event.kind !== 'tool' || !event.toolCallId) return false
+
+    const activeToolCallIds = this.activeToolCallIdsBySession.get(event.sessionId)
+    const wasActive = activeToolCallIds?.has(event.toolCallId) === true
+    if (event.status === 'completed' || event.status === 'failed') {
+      activeToolCallIds?.delete(event.toolCallId)
+      if (activeToolCallIds?.size === 0) {
+        this.activeToolCallIdsBySession.delete(event.sessionId)
+      }
+      return false
+    }
+    if (activeToolCallIds) {
+      activeToolCallIds.add(event.toolCallId)
+    } else {
+      this.activeToolCallIdsBySession.set(event.sessionId, new Set([event.toolCallId]))
+    }
+
+    return (
+      wasActive &&
+      (event.toolContent !== undefined ||
+        event.terminalOutput !== undefined ||
+        event.rawOutput !== undefined)
+    )
   }
 
   publishPermissionRequest(request: AcpPermissionRequest): void {
@@ -118,17 +159,26 @@ class AcpRuntimePublicationOwner {
   }
 
   emitState(): void {
-    this.cancelPendingStatePublication()
+    this.cancelScheduledPublication()
     this.publishState()
   }
 
   private publishState(): void {
-    this.coalescedAssistantTextEvents = 0
-    recordAcpStateBroadcastSent()
-    this.options.callbacks.onStateChanged?.(this.getSnapshot())
+    this.coalescedEvents = 0
+    const onStateChanged = this.options.callbacks.onStateChanged
+    if (!onStateChanged) return
+
+    const snapshot = this.getSnapshot()
+    recordAcpStateBroadcastSent(snapshot)
+    onStateChanged(snapshot)
   }
 
   cancelPendingStatePublication(): void {
+    this.cancelScheduledPublication()
+    this.activeToolCallIdsBySession.clear()
+  }
+
+  private cancelScheduledPublication(): void {
     this.cancelScheduledStatePublication?.()
     this.cancelScheduledStatePublication = undefined
   }

--- a/src/main/acp/runtime-snapshot-owner.ts
+++ b/src/main/acp/runtime-snapshot-owner.ts
@@ -1,5 +1,6 @@
 import type { AcpRuntimeEvent, AcpStateSnapshot } from '../../shared/acp'
 import { getAcpRuntimeEventImage, MAX_ACP_SESSION_IMAGE_BYTES } from '../../shared/acp'
+import { capToolDetailText, sanitizeToolContent } from '../../shared/tool-detail-sanitizer'
 
 const ACP_RUNTIME_EVENT_RETENTION_LIMIT = 500
 // Amortized eviction: trim only after a full cap of slack accumulates, so steady-state appends are
@@ -59,6 +60,11 @@ class AcpRuntimeSnapshotOwner {
     let image = event.image
     let raw = event.raw
     let text = event.text
+    const toolContent = sanitizeToolContent(event.toolContent) as
+      AcpRuntimeEvent['toolContent'] | undefined
+    const terminalOutput = event.terminalOutput
+      ? capToolDetailText(event.terminalOutput)
+      : undefined
     if (image && event.sessionId) {
       const retainedBytes = this.retainedWindow()
         .filter((candidate) => candidate.sessionId === event.sessionId)
@@ -83,6 +89,8 @@ class AcpRuntimeSnapshotOwner {
       level: event.level ?? 'info',
       text,
       image,
+      toolContent,
+      terminalOutput,
       promptMessageId: event.promptMessageId,
       raw
     }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -4672,7 +4672,7 @@ describe('ACP runtime session management', () => {
       expect(onStateChanged).not.toHaveBeenCalled()
 
       runtime.shutdown()
-      vi.advanceTimersByTime(16)
+      vi.advanceTimersByTime(33)
 
       expect(onStateChanged).not.toHaveBeenCalled()
     } finally {

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -58,6 +58,7 @@ import {
 } from './permission-grants'
 import { SIDE_CHAT_MESSAGE_LIMIT, type SideChatEntry } from './side-chat'
 import { sanitizeAgentUserChoiceRequest, type AgentUserChoicePrompt } from './elicitation'
+import { capToolDetailText, sanitizeToolContent } from './tool-detail-sanitizer'
 
 // One JSON file per session (sessions/<projectId>/<sessionId>.json) carries this envelope version.
 export const SESSION_FILE_VERSION = 2
@@ -2340,113 +2341,13 @@ const sanitizeUploadedAttachment = (
   return sanitized
 }
 
-// Persisting more than the UI shows is wasteful, so bound the large text-bearing fields.
-const MAX_PERSISTED_TEXT_CHARS = 16_000
-const MAX_PERSISTED_TOOL_CONTENT_CHARS = 32_000
 const MAX_PERSISTED_RAW_CHARS = 8_000
 
-// Truncates oversized text with a trailing marker; a no-op when already within bounds (idempotent).
-const capText = (text: string, max: number): string =>
-  text.length > max ? `${text.slice(0, max)}\n…` : text
-
 // Reads a bounded string field, returning undefined when empty.
-const asCappedString = (value: unknown, max: number): string | undefined => {
+const asCappedString = (value: unknown): string | undefined => {
   const text = asString(value)
 
-  return text ? capText(text, max) : undefined
-}
-
-// Rebuilds a displayable content block (text/resource/link), dropping heavy binary payloads.
-const sanitizeContentBlock = (block: unknown): Record<string, unknown> | undefined => {
-  if (!isRecord(block)) return undefined
-
-  switch (asString(block.type)) {
-    case 'text': {
-      const text = asCappedString(block.text, MAX_PERSISTED_TEXT_CHARS)
-
-      return text !== undefined ? { type: 'text', text } : undefined
-    }
-    case 'resource_link': {
-      const uri = asString(block.uri)
-
-      if (!uri) return undefined
-
-      const link: Record<string, unknown> = { type: 'resource_link', uri }
-      const name = asString(block.name)
-      const title = asString(block.title)
-
-      if (name) link.name = name
-      if (title) link.title = title
-
-      return link
-    }
-    case 'resource': {
-      if (!isRecord(block.resource)) return undefined
-
-      const uri = asString(block.resource.uri)
-      const text = asCappedString(block.resource.text, MAX_PERSISTED_TEXT_CHARS)
-      const resource: Record<string, unknown> = {}
-
-      if (uri) resource.uri = uri
-      if (text !== undefined) resource.text = text
-
-      return Object.keys(resource).length > 0 ? { type: 'resource', resource } : undefined
-    }
-    default:
-      return undefined
-  }
-}
-
-// Rebuilds one ToolCallContent entry, keeping only the text/diff shapes the detail views read.
-const sanitizeToolContentEntry = (entry: unknown): Record<string, unknown> | undefined => {
-  if (!isRecord(entry)) return undefined
-
-  const type = asString(entry.type)
-
-  if (type === 'content') {
-    const content = sanitizeContentBlock(entry.content)
-
-    return content ? { type: 'content', content } : undefined
-  }
-  if (type === 'diff') {
-    const path = asString(entry.path)
-
-    if (!path) return undefined
-
-    const oldText = asString(entry.oldText)
-
-    return {
-      type: 'diff',
-      path,
-      oldText: oldText !== undefined ? capText(oldText, MAX_PERSISTED_TEXT_CHARS) : null,
-      newText: capText(asString(entry.newText) ?? '', MAX_PERSISTED_TEXT_CHARS)
-    }
-  }
-
-  // Terminal references carry no data in this app and other shapes are not rendered; drop them.
-  return undefined
-}
-
-// Sanitizes tool content into a bounded array, stopping once the total budget is exhausted.
-const sanitizeToolContent = (value: unknown): unknown[] | undefined => {
-  if (!Array.isArray(value)) return undefined
-
-  const entries: unknown[] = []
-  let usedChars = 0
-
-  for (const rawEntry of value) {
-    const entry = sanitizeToolContentEntry(rawEntry)
-
-    if (!entry) continue
-
-    usedChars += JSON.stringify(entry).length
-
-    if (usedChars > MAX_PERSISTED_TOOL_CONTENT_CHARS) break
-
-    entries.push(entry)
-  }
-
-  return entries.length > 0 ? entries : undefined
+  return text ? capToolDetailText(text) : undefined
 }
 
 // Keeps small raw input/output payloads verbatim but drops oversized ones (e.g. base64 file bytes).
@@ -2553,7 +2454,7 @@ export const sanitizeToolActivity = (activity: unknown): PersistedToolActivity |
   const toolLocations = sanitizeToolLocations(activity.toolLocations)
   const rawInput = sanitizeRawPayload(activity.rawInput)
   const rawOutput = sanitizeRawPayload(activity.rawOutput)
-  const terminalOutput = asCappedString(activity.terminalOutput, MAX_PERSISTED_TEXT_CHARS)
+  const terminalOutput = asCappedString(activity.terminalOutput)
   const terminalExitCode = asNumber(activity.terminalExitCode)
   const elicitation = sanitizeElicitationProjection(activity.elicitation)
   const toolDisposition = asToolActivityDisposition(activity.toolDisposition)

--- a/src/shared/tool-detail-sanitizer.ts
+++ b/src/shared/tool-detail-sanitizer.ts
@@ -1,0 +1,96 @@
+const MAX_TOOL_DETAIL_TEXT_CHARS = 16_000
+const MAX_TOOL_DETAIL_CONTENT_CHARS = 32_000
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined
+
+const capToolDetailText = (text: string): string =>
+  text.length > MAX_TOOL_DETAIL_TEXT_CHARS
+    ? `${text.slice(0, MAX_TOOL_DETAIL_TEXT_CHARS)}\n…`
+    : text
+
+const asCappedString = (value: unknown): string | undefined => {
+  const text = asString(value)
+  return text ? capToolDetailText(text) : undefined
+}
+
+const sanitizeContentBlock = (block: unknown): Record<string, unknown> | undefined => {
+  if (!isRecord(block)) return undefined
+
+  switch (asString(block.type)) {
+    case 'text': {
+      const text = asCappedString(block.text)
+      return text !== undefined ? { type: 'text', text } : undefined
+    }
+    case 'resource_link': {
+      const uri = asString(block.uri)
+      if (!uri) return undefined
+
+      const link: Record<string, unknown> = { type: 'resource_link', uri }
+      const name = asString(block.name)
+      const title = asString(block.title)
+      if (name) link.name = name
+      if (title) link.title = title
+      return link
+    }
+    case 'resource': {
+      if (!isRecord(block.resource)) return undefined
+
+      const uri = asString(block.resource.uri)
+      const text = asCappedString(block.resource.text)
+      const resource: Record<string, unknown> = {}
+      if (uri) resource.uri = uri
+      if (text !== undefined) resource.text = text
+      return Object.keys(resource).length > 0 ? { type: 'resource', resource } : undefined
+    }
+    default:
+      return undefined
+  }
+}
+
+const sanitizeToolContentEntry = (entry: unknown): Record<string, unknown> | undefined => {
+  if (!isRecord(entry)) return undefined
+
+  const type = asString(entry.type)
+  if (type === 'content') {
+    const content = sanitizeContentBlock(entry.content)
+    return content ? { type: 'content', content } : undefined
+  }
+  if (type === 'diff') {
+    const path = asString(entry.path)
+    if (!path) return undefined
+
+    const oldText = asString(entry.oldText)
+    return {
+      type: 'diff',
+      path,
+      oldText: oldText !== undefined ? capToolDetailText(oldText) : null,
+      newText: capToolDetailText(asString(entry.newText) ?? '')
+    }
+  }
+
+  return undefined
+}
+
+// Bounds the same live and persisted tool-detail projection before it reaches IPC or disk.
+const sanitizeToolContent = (value: unknown): unknown[] | undefined => {
+  if (!Array.isArray(value)) return undefined
+
+  const entries: unknown[] = []
+  let usedChars = 0
+  for (const rawEntry of value) {
+    const entry = sanitizeToolContentEntry(rawEntry)
+    if (!entry) continue
+
+    usedChars += JSON.stringify(entry).length
+    if (usedChars > MAX_TOOL_DETAIL_CONTENT_CHARS) break
+    entries.push(entry)
+  }
+
+  return entries.length > 0 ? entries : undefined
+}
+
+export { capToolDetailText, sanitizeToolContent }


### PR DESCRIPTION
## Problem

Long-running ACP sessions can repeatedly retain and serialize large tool detail payloads in the full `acp:state` snapshot. The visible event window is limited to 500 events, but unbounded `toolContent` and terminal output can still make each retained snapshot expensive. Streaming thought and tool updates also bypassed the existing assistant-text coalescer, causing additional full-state broadcasts.

Fixes #1358.

## Proposed change

- Bound live tool detail text and terminal output to 16,000 characters and aggregate tool content to 32,000 characters before runtime snapshot retention.
- Reuse the same sanitizer for live snapshots and persisted tool activities without changing the persisted schema or format.
- Align `acp:state` publication with the renderer's 33 ms presentation cadence.
- Coalesce assistant text, assistant thought, and progressive tool output while keeping tool start, completion, failure, permission, stop, and error boundaries immediate.
- Scope progressive tool lifecycle tracking by Session and clear it on terminal events, stop/error boundaries, and connection teardown.
- Add throttled diagnostics for broadcast counts, suppressed broadcasts, event kinds, and development-only snapshot size.

## Scope and non-goals

- The 500-event retention contract and the 250-event safety flush remain unchanged.
- `acp:event` publication remains immediate and unchanged; only full `acp:state` snapshot publication is coalesced.
- No enum values, persistence schema/version, migration, or historical-data compatibility path is added.
- The longer-term split between live `acp:event` delivery and slim runtime state is intentionally deferred to the ignored internal TODO and is not part of this PR.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Payload bounds and publication semantics -> shared snapshot/publication contracts -> `npx vitest run src/main/acp/runtime-publication-owner.test.ts src/main/acp/runtime-events.test.ts src/main/acp/runtime-snapshot-owner.test.ts src/shared/session-persistence.test.ts src/main/acp/provider-session-creator.test.ts src/renderer/src/lib/acp/useAcpRuntime.test.ts src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts src/renderer/src/lib/acp/workspace-runtime-event-owner.test.ts` -> 345 passed.
- Claude Code, OpenCode, Codex Responses, and Codex Bridge launcher/transport behavior plus runtime cleanup -> `npx vitest run src/main/acp/runtime.test.ts` -> 549 passed.
- Node contracts -> `npm run typecheck:node` -> passed.
- Renderer contracts -> `npm run typecheck:web` -> passed.
- Repository lint -> `npm run lint` -> passed.
- Low-memory reproduction -> temporary 128 MB heap harness with 96 repeated 1 MiB tool-content and terminal updates -> passed; final serialized snapshot remained below 4 MB. The same workload exhausted the 128 MB heap before the fix.

An independent standards/spec review confirmed the final behavior-to-test mapping and four-framework compatibility matrix. Per issue scope, the complete local `npm test` suite was not run; exact-head PR CI is the final authority.

Uncovered risk: this was not reproduced as a 20-hour Ubuntu XFCE/xrdp AppImage run. The changed bounds and timing are platform-independent; no model-specific protocol shape is involved, so no model matrix was added. Platform and complete portable-suite coverage are left to PR CI.

## Review focus

- Whether the shared snapshot boundary is the correct invariant for every ACP source.
- Whether first/terminal tool events remain immediate while only subsequent output is coalesced.
- Whether Session and connection cleanup fully bound the tool lifecycle tracker.
- Whether extracting the existing persistence sanitizer preserves on-disk behavior.
