### PR TITLE
fix(skill-authoring): avoid save-as-skill admission deadlock

### DIFF
--- a/src/main/acp/handler-workflows.test.ts
+++ b/src/main/acp/handler-workflows.test.ts
@@ -80,7 +80,7 @@ const createHarness = (
 ): {
   workflows: ReturnType<typeof createAcpHandlerWorkflows>
   startContinuation: ReturnType<typeof vi.fn>
-  startContinuationWhen: ReturnType<typeof vi.fn>
+  startContinuationWhenDispatchAdmitted: ReturnType<typeof vi.fn>
   hasLiveSession: ReturnType<typeof vi.fn>
   captureSessionBackend: ReturnType<typeof vi.fn>
   session: PersistedChatSession
@@ -112,10 +112,12 @@ const createHarness = (
       }) as never
   )
   const snapshot = { status: 'connected' } as never
-  const startContinuationWhen = vi.fn(async (request: unknown, validate: () => Promise<void>) => {
-    await validate()
-    return startContinuation(request)
-  })
+  const startContinuationWhenDispatchAdmitted = vi.fn(
+    async (request: unknown, validate: () => Promise<void>) => {
+      await validate()
+      return startContinuation(request)
+    }
+  )
   const workflows = createAcpHandlerWorkflows(
     {
       getSnapshot: () => snapshot,
@@ -125,7 +127,7 @@ const createHarness = (
       sendPrompt: vi.fn(),
       getLatestUserPrompt: vi.fn(),
       startContinuation,
-      startContinuationWhen
+      startContinuationWhenDispatchAdmitted
     },
     { create: vi.fn() } as never,
     taskNotifications,
@@ -138,7 +140,7 @@ const createHarness = (
   return {
     workflows,
     startContinuation,
-    startContinuationWhen,
+    startContinuationWhenDispatchAdmitted,
     hasLiveSession,
     captureSessionBackend,
     session,
@@ -153,6 +155,14 @@ const createHarness = (
 }
 
 describe('ACP Save as skill workflow', () => {
+  it('dispatches through the Session admission already held by the workflow', async () => {
+    const harness = createHarness()
+
+    await harness.workflows.saveAsSkill(harness.request)
+
+    expect(harness.startContinuationWhenDispatchAdmitted).toHaveBeenCalledOnce()
+  })
+
   it('holds archive admission until the hidden turn is accepted', async () => {
     let admissionActive = false
     const admitted = vi.fn()
@@ -381,7 +391,7 @@ describe('ACP Save as skill workflow', () => {
 
   it('rejects when the prepared control changes before runtime admission', async () => {
     const harness = createHarness()
-    harness.startContinuationWhen.mockImplementationOnce(
+    harness.startContinuationWhenDispatchAdmitted.mockImplementationOnce(
       async (_request: unknown, validate: () => Promise<void>) => {
         harness.session.activeRun = { promptMessageId: 'newer-prompt', startedAt: 4 }
         await validate()

--- a/src/main/acp/handler-workflows.ts
+++ b/src/main/acp/handler-workflows.ts
@@ -46,7 +46,10 @@ type AcpHandlerWorkflowRuntime = {
   sendPrompt(request: AcpPromptRequest): Promise<unknown>
   getLatestUserPrompt(sessionId: string, promptMessageId: string): AcpPromptRequest | undefined
   startContinuation(request: AcpPromptRequest): Promise<void>
-  startContinuationWhen(request: AcpPromptRequest, validate: () => Promise<void>): Promise<unknown>
+  startContinuationWhenDispatchAdmitted(
+    request: AcpPromptRequest,
+    validate: () => Promise<void>
+  ): Promise<unknown>
 }
 
 type PromptNotifications = Pick<TaskNotificationService, 'trackPrompt' | 'untrackPrompt'>
@@ -348,7 +351,7 @@ const createAcpHandlerWorkflows = (
         text: 'Save as skill'
       })
       try {
-        await runtime.startContinuationWhen(prepared.continuation, async () => {
+        await runtime.startContinuationWhenDispatchAdmitted(prepared.continuation, async () => {
           await saveAsSkillAdmission?.(request.sessionId)
           const admitted = prepareSaveAsSkillContinuation(
             runtime,


### PR DESCRIPTION
## Problem

After a completed Agent turn, choosing **Save as skill** could leave the Session showing `Thinking · taking longer than usual` indefinitely. The captured log shows the preceding prompt stopped with `end_turn` at 15:12, while the persisted Session later contains a `save-as-skill` control message and `activeRun` in `running` state without any corresponding `prompt start`.

The Save-as-skill workflow already runs inside `ArchiveCoordinator.withSessionAvailable`. It then used the ordinary continuation dispatch, which re-entered the same archive/deletion admission queue. The outer queue item waited for dispatch, while the nested dispatch admission waited behind the outer item: a self-deadlock.

## Proposed change

- Dispatch the hidden Save-as-skill continuation through the existing `startContinuationWhenDispatchAdmitted` path because the workflow already owns the required Session admission.
- Add a regression test that requires Save-as-skill to use the already-admitted dispatch path.
- Keep the existing second read/validation immediately before provider admission.

## Scope and non-goals

- No renderer interaction or copy changes.
- No ACP wire-shape or renderer contract changes.
- No new status/enum values.
- No persisted schema or data-format changes.
- No historical-data compatibility handling is required.
- The Electron Save-as-skill command is affected. Claude Code, OpenCode, Codex Responses, and Codex Bridge share this workflow/coordinator path; the existing parameterized framework coverage remains green.

## Acceptance criteria and validation

Checks below ran after the final material edit:

- Save-as-skill uses the already-held Session admission and retains pre-provider revalidation -> `npm test -- src/main/acp/handler-workflows.test.ts src/main/acp/runtime-coordinator.test.ts src/main/archive/coordinator.test.ts src/main/acp/ipc.test.ts` -> 4 files, 165 tests passed.
- Main-process type contract accepts the admitted continuation method -> `npm run typecheck:node` -> passed.
- Changed source and tests satisfy repository lint rules -> `npm run lint` -> passed.
- Final Test Impact Set explanation -> `npm run test:affected -- --base origin/main --head HEAD --explain` -> full fallback selected because `src/main/acp/handler-workflows.test.ts` has no Module owner. Per maintainer request, the complete local `npm test` suite was not run; exact-head PR CI is the final authority.

Platform scope: the defect is queue/admission ordering in shared TypeScript and has no OS-specific branch. Local validation covered the shared behavior on macOS; PR CI owns the remaining platform lanes.

## Review focus

- Confirm the outer `withSessionAvailable` admission makes the nested dispatch guard redundant.
- Confirm the validation callback still runs immediately before provider dispatch.
- Confirm the final Test Impact Set/CI plan covers the final diff despite the missing Module ownership entry.

## Uncovered risks

- No local live-provider UI replay was run; the deterministic workflow regression covers the exact blocking edge, while PR CI remains authoritative for broader integration coverage.
