### PR TITLE
test(e2e): release follow-output before pinning files overlay

### DIFF
--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -50,6 +50,24 @@ const setVisualState = async (
   await setViewport(page, width)
 }
 
+// MessageScroller only leaves follow-output on reader input (wheel, touch, or
+// movement keys). Assigning scrollTop is treated as autoscroll and snaps back
+// to the end, which is ~500px under the narrow Files overlay.
+const pinConversationToStart = async (page: Page): Promise<void> => {
+  const conversationViewport = page.locator('[data-slot="message-scroller-viewport"]')
+  await expect
+    .poll(async () => {
+      await conversationViewport.evaluate((element) => {
+        element.dispatchEvent(
+          new WheelEvent('wheel', { deltaY: -120, bubbles: true, cancelable: true })
+        )
+        element.scrollTo({ top: 0 })
+      })
+      return conversationViewport.evaluate((element) => element.scrollTop)
+    })
+    .toBe(0)
+}
+
 const expectStableScreenshot = async (
   page: Page,
   name: string,
@@ -286,11 +304,7 @@ test('keeps representative conversation, project, and recovery states visually s
   await page.getByRole('button', { name: 'Files', exact: true }).click()
   await expect(page.locator('[data-testid="files-view"]')).toBeVisible()
   await setVisualState(page, { theme: 'Light', width: 767 })
-  const conversationViewport = page.locator('[data-slot="message-scroller-viewport"]')
-  await conversationViewport.evaluate((element) => {
-    element.scrollTop = 0
-  })
-  await expect.poll(() => conversationViewport.evaluate((element) => element.scrollTop)).toBe(0)
+  await pinConversationToStart(page)
   await expectStableScreenshot(page, 'files-narrow-light.png')
 
   await setViewport(page, 1280)


### PR DESCRIPTION
## Problem

Release visual regression failed on [`regression / visual (canonical macos-14 source build)`](https://github.com/aipoch/open-science/actions/runs/32118860383/job/95661120188) in `v0.17.0`.

`keeps representative conversation, project, and recovery states visually stable` timed out waiting for `[data-slot="message-scroller-viewport"]` `scrollTop` to stay at `0` after opening the narrow Files overlay. CI received `500` (the overlay conversation end) for 20s, then passed on retry. `--fail-on-flaky-tests` still failed the job.

The conversation scroller uses shadcn `MessageScroller` with `autoScroll`. Follow-output only releases on reader input (`wheel`, `touchmove`, or movement keys). Assigning `scrollTop = 0` is treated as autoscroll and snaps back to the end.

## Proposed change

Before taking `files-narrow-light.png`, dispatch a bubbling `wheel` on the conversation viewport and then `scrollTo({ top: 0 })`. Retry that pin inside `expect.poll` so a late resize/autoscroll frame cannot leave the transcript at the end.

No product behavior, screenshot baseline, or visual contract change.

## Scope and non-goals

- Test-only change in `e2e/visual-regression.spec.ts`.
- Does not change MessageScroller, Files overlay, or persisted session state.
- Does not update visual baselines.

## Compatibility and persistence

- **Historical data compatibility:** none. No stored session, project, or settings format is read or written differently.
- **New status / enum values:** none.
- **Data persistence:** none.

## Acceptance criteria and validation

- Narrow Files screenshot pins the background transcript at the first message (`scrollTop === 0`) instead of the follow-output end.
- Retrying the pin survives a late autoscroll/resize frame.
- Other visual cases in the same spec are unchanged.

### Evidence

Material change: `e2e/visual-regression.spec.ts` (helper `pinConversationToStart` used only for `files-narrow-light.png`).

| Behavior | Command | Result |
| --- | --- | --- |
| Release follow-output, then keep transcript at start | PR Gate `e2e_visual_macos` (`npm run test:e2e:visual -- --fail-on-flaky-tests`) | pending on this PR after the last material edit |
| File is an unowned `e2e/**` path | `classify-pr-changes` | `e2e/visual-regression.spec.ts -> unknown -> full` (fail-closed full plan) |

Local full `npm test` was not run, per request. There is no `test:module` owner for this e2e spec. ESLint ignores `e2e/**` from the repo root config.

Uncovered risks: Electron visual e2e was not re-run locally after the last edit; macOS-14 release/PR visual lane remains the authority. A `wheel` event that fails to reach the viewport listener would still flake the same assertion.

## Review focus

- Is dispatching `wheel` the right way to leave follow-output while the Files overlay owns pointer/focus?
- Should the retry live in `expect.poll`, or is a single wheel + `scrollTo(0)` enough once the overlay has settled?