### PR TITLE
fix(skill-authoring): accept normalized context-reset replay

### DIFF
--- a/src/main/acp/handler-workflows.test.ts
+++ b/src/main/acp/handler-workflows.test.ts
@@ -6,7 +6,9 @@ import {
   synchronizeActiveConversationMessages
 } from '../../shared/conversation-graph'
 import {
+  createSessionFile,
   materializeSessionConversationGraph,
+  normalizeSessionFile,
   type PersistedChatSession
 } from '../../shared/session-persistence'
 import type { AgentFrameworkId } from '../../shared/settings'
@@ -361,10 +363,69 @@ describe('ACP Save as skill workflow', () => {
     )
   })
 
-  it('rejects pending full replay without a fresh durable Runtime Segment', async () => {
+  it.each<readonly [string, AgentFrameworkId, AgentModelRoute]>([
+    ['Claude Code', 'claude-code', 'claude-anthropic'],
+    ['OpenCode', 'opencode', 'opencode-openai'],
+    ['Codex Responses', 'codex', 'codex-responses'],
+    ['Codex Bridge', 'codex', 'codex-bridge']
+  ])(
+    'accepts pending context-reset replay after the prepared control is normalized on read for %s',
+    async (_name, frameworkId, modelRoute) => {
+      const harness = createHarness((session) => {
+        session.agentFrameworkId = frameworkId
+        session.pendingHistoryReplay = { kind: 'all' }
+        session.conversationGraph = ensureConversationRuntimeSegment(session.conversationGraph!, {
+          id: 'runtime-segment-after-context-reset',
+          frameworkId,
+          startedAt: 3,
+          forceNew: true
+        })
+      })
+      const normalized = normalizeSessionFile(createSessionFile(harness.session))
+      expect(normalized).toMatchObject({
+        status: 'error',
+        pendingHistoryReplay: { kind: 'all' },
+        resumeRecovery: {
+          kind: 'resume-required',
+          promptMessageId: harness.request.promptMessageId
+        }
+      })
+      const normalizedFrame = normalized?.conversationGraph?.frames.find(
+        ({ id }) => id === normalized.conversationGraph?.activeFrameId
+      )
+      const normalizedMessages =
+        normalized?.conversationGraph && normalizedFrame
+          ? resolveMessageBranchPath(normalized.conversationGraph, normalizedFrame.activeBranchId)
+          : []
+      expect(normalizedMessages.slice(-2).map(({ runtimeSegmentId }) => runtimeSegmentId)).toEqual([
+        expect.not.stringMatching('runtime-segment-after-context-reset'),
+        'runtime-segment-after-context-reset'
+      ])
+      Object.assign(harness.session, normalized)
+      harness.captureSessionBackend.mockReturnValue({
+        framework: { id: frameworkId },
+        modelRoute,
+        context: { window: 100_000, supportsImageInput: true }
+      } as never)
+
+      await harness.workflows.saveAsSkill(harness.request)
+
+      expect(harness.startContinuation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contextReset: true,
+          provenanceContext: expect.objectContaining({
+            runtimeSegmentId: 'runtime-segment-after-context-reset'
+          })
+        })
+      )
+    }
+  )
+
+  it('rejects normalized pending full replay without a fresh durable Runtime Segment', async () => {
     const harness = createHarness((session) => {
       session.pendingHistoryReplay = { kind: 'all' }
     })
+    Object.assign(harness.session, normalizeSessionFile(createSessionFile(harness.session)))
 
     await expect(harness.workflows.saveAsSkill(harness.request)).rejects.toThrow(
       'requires a prepared Session'
@@ -372,7 +433,7 @@ describe('ACP Save as skill workflow', () => {
     expect(harness.startContinuation).not.toHaveBeenCalled()
   })
 
-  it('rejects pending interrupted-turn replay after a context reset', async () => {
+  it('rejects normalized pending interrupted-turn replay after a context reset', async () => {
     const harness = createHarness((session) => {
       session.pendingHistoryReplay = { kind: 'before-message', messageId: 'prompt-1' }
       session.conversationGraph = ensureConversationRuntimeSegment(session.conversationGraph!, {
@@ -382,6 +443,7 @@ describe('ACP Save as skill workflow', () => {
         forceNew: true
       })
     })
+    Object.assign(harness.session, normalizeSessionFile(createSessionFile(harness.session)))
 
     await expect(harness.workflows.saveAsSkill(harness.request)).rejects.toThrow(
       'requires a prepared Session'

--- a/src/main/acp/handler-workflows.ts
+++ b/src/main/acp/handler-workflows.ts
@@ -120,10 +120,11 @@ const prepareSaveAsSkillContinuation = (
   }
   const preparedControlRun =
     session.status === 'running' && session.activeRun?.promptMessageId === request.promptMessageId
+  // Repository reads normalize a persisted prepared control into recovery before runtime admission.
+  // A simultaneous replay is accepted only when it passes the verified context-reset checks below.
   const recoveredPreparedControlRun =
     session.resumeRecovery?.kind === 'resume-required' &&
     session.resumeRecovery.promptMessageId === request.promptMessageId &&
-    !session.pendingHistoryReplay &&
     runtime.hasLiveSession(session.projectId, session.id)
   const graph = session.conversationGraph
   const frame = graph?.frames.find(({ id }) => id === graph.activeFrameId)
@@ -155,7 +156,7 @@ const prepareSaveAsSkillContinuation = (
     (!session.agentFrameworkId || session.agentFrameworkId === sessionBackend.framework.id)
   )
   const preparedContextResetReplay = Boolean(
-    preparedControlRun &&
+    (preparedControlRun || recoveredPreparedControlRun) &&
     preparedControlTurn &&
     session.pendingHistoryReplay?.kind === 'all' &&
     verifiedContextReset


### PR DESCRIPTION
## Summary

- allow Save as skill after Branch in new session when the prepared control was normalized on repository read
- keep context-reset admission fail-closed by requiring the matching control turn, a live provider Session, full replay, and a verified fresh Runtime Segment
- cover Claude Code, OpenCode, Codex Responses, and Codex Bridge

## Root cause

Before provider admission, repository reads normalize the persisted running Save-as-skill control into `resume-required`. A branched Session also retains `pendingHistoryReplay: { kind: 'all' }`. The admission guard treated recovery and pending replay as mutually exclusive, so it rejected an otherwise valid prepared Session.

## Validation

- `npm test -- src/main/acp/handler-workflows.test.ts` (32 passed)
- `npm test -- src/main/acp/ipc.test.ts` (44 passed)
- `npm run typecheck:node`
- `npx eslint src/main/acp/handler-workflows.ts src/main/acp/handler-workflows.test.ts`

The complete local test suite was intentionally not run; PR CI provides full coverage.

## Compatibility and persistence

- no historical data migration or compatibility branch is required
- no enum or state value is added
- no persistence schema, stored field, or write path changes; the fix only accepts an existing valid normalized state combination
