### PR TITLE
fix(acp): preserve positive context usage across zero updates

### DIFF
--- a/src/main/acp/context-usage-tracker.test.ts
+++ b/src/main/acp/context-usage-tracker.test.ts
@@ -703,6 +703,46 @@ describe('ContextUsageTracker', () => {
     })
   })
 
+  it('retains positive provider usage when a later update reports zero without a reset', () => {
+    const tracker = new ContextUsageTracker(wordCounter)
+    tracker.beginSession('s1', { frameworkId: 'opencode', model: 'glm-5.3' })
+    tracker.appendText('s1', 'messages', 'committed conversation history')
+    tracker.reconcileProviderUsage('s1', { used: 62_000, size: 1_000_000 })
+
+    tracker.reconcileProviderUsage('s1', { used: 0, size: 1_000_000 })
+
+    expect(tracker.usage('s1')).toMatchObject({
+      used: 62_000,
+      size: 1_000_000,
+      breakdown: { status: 'reconciled' }
+    })
+
+    tracker.deleteSession('s1')
+    tracker.beginSession('s1', { frameworkId: 'opencode', model: 'glm-5.3' })
+    tracker.appendText('s1', 'messages', 'new conversation')
+    tracker.reconcileProviderUsage('s1', { used: 0, size: 1_000_000 })
+
+    expect(tracker.usage('s1')).toMatchObject({
+      used: 0,
+      size: 1_000_000,
+      breakdown: { status: 'reconciled' }
+    })
+  })
+
+  it('rejects a zero terminal reading after positive provider usage', () => {
+    const tracker = new ContextUsageTracker(wordCounter)
+    tracker.beginSession('s1', { frameworkId: 'codex', model: 'gpt-5.6-sol' })
+    tracker.appendText('s1', 'messages', 'committed conversation history')
+    tracker.reconcileProviderUsage('s1', { used: 62_000, size: 1_000_000 })
+
+    expect(tracker.reconcileUsed('s1', 0)).toBe(false)
+    expect(tracker.usage('s1')).toMatchObject({
+      used: 62_000,
+      size: 1_000_000,
+      breakdown: { status: 'reconciled' }
+    })
+  })
+
   it('restores the last provider reading when a preflight estimate receives no fresh update', () => {
     const tracker = new ContextUsageTracker(wordCounter)
     tracker.beginSession('s1', { frameworkId: 'opencode', model: 'deepseek-v4' })

--- a/src/main/acp/context-usage-tracker.test.ts
+++ b/src/main/acp/context-usage-tracker.test.ts
@@ -1010,6 +1010,24 @@ describe('ContextUsageTracker', () => {
     })
   })
 
+  it('accepts a fresh zero provider reading after context compaction', () => {
+    const tracker = new ContextUsageTracker(wordCounter)
+    const input = { frameworkId: 'opencode' as const, model: 'glm-5.3' }
+    tracker.beginSession('s1', input)
+    tracker.appendText('s1', 'messages', 'conversation before compaction')
+    tracker.reconcileProviderUsage('s1', { used: 62_000, size: 1_000_000 })
+    const compactionCheckpoint = tracker.checkpointSession('s1')
+
+    tracker.reconcileProviderUsage('s1', { used: 0, size: 1_000_000 })
+    tracker.resetAfterCompaction('s1', input, compactionCheckpoint, 1_000_000)
+
+    expect(tracker.usage('s1')).toMatchObject({
+      used: 0,
+      size: 1_000_000,
+      breakdown: { status: 'reconciled', estimatedTokens: 0 }
+    })
+  })
+
   it('keeps only a fresh provider reading after context compaction', () => {
     const tracker = new ContextUsageTracker(wordCounter)
     const input = { frameworkId: 'claude-code' as const, model: 'claude-sonnet-4-5' }

--- a/src/main/acp/context-usage-tracker.test.ts
+++ b/src/main/acp/context-usage-tracker.test.ts
@@ -743,6 +743,39 @@ describe('ContextUsageTracker', () => {
     })
   })
 
+  it('accepts a deferred zero provider reading when provider compaction completes', () => {
+    const tracker = new ContextUsageTracker(wordCounter)
+    tracker.beginSession('s1', { frameworkId: 'codex', model: 'gpt-5.6-sol' })
+    tracker.appendText('s1', 'messages', 'committed conversation history')
+    tracker.reconcileProviderUsage('s1', { used: 62_000, size: 1_000_000 })
+    tracker.reconcileProviderUsage('s1', { used: 0, size: 1_000_000 })
+
+    expect(tracker.usage('s1')?.used).toBe(62_000)
+    expect(tracker.confirmProviderCompaction('s1')).toBe(true)
+    expect(tracker.usage('s1')).toMatchObject({
+      used: 0,
+      size: 1_000_000,
+      breakdown: { status: 'reconciled' }
+    })
+  })
+
+  it('accepts only the first zero provider reading after provider compaction completes', () => {
+    const tracker = new ContextUsageTracker(wordCounter)
+    tracker.beginSession('s1', { frameworkId: 'codex', model: 'gpt-5.6-sol' })
+    tracker.appendText('s1', 'messages', 'committed conversation history')
+    tracker.reconcileProviderUsage('s1', { used: 62_000, size: 1_000_000 })
+
+    expect(tracker.confirmProviderCompaction('s1')).toBe(false)
+    tracker.reconcileProviderUsage('s1', { used: 0, size: 1_000_000 })
+    expect(tracker.usage('s1')?.used).toBe(0)
+
+    tracker.reconcileProviderUsage('s1', { used: 10_000, size: 1_000_000 })
+    expect(tracker.confirmProviderCompaction('s1')).toBe(false)
+    tracker.reconcileProviderUsage('s1', { used: 8_000, size: 1_000_000 })
+    tracker.reconcileProviderUsage('s1', { used: 0, size: 1_000_000 })
+    expect(tracker.usage('s1')?.used).toBe(8_000)
+  })
+
   it('restores the last provider reading when a preflight estimate receives no fresh update', () => {
     const tracker = new ContextUsageTracker(wordCounter)
     tracker.beginSession('s1', { frameworkId: 'opencode', model: 'deepseek-v4' })

--- a/src/main/acp/context-usage-tracker.ts
+++ b/src/main/acp/context-usage-tracker.ts
@@ -356,6 +356,7 @@ class ContextUsageTracker {
   private readonly usageRevisions = new Map<string, number>()
   private readonly providerUsageRevisions = new Map<string, number>()
   private readonly pendingZeroProviderUsageBySession = new Map<string, PendingZeroProviderUsage>()
+  private readonly providerCompactionAwaitingUsageBySession = new Set<string>()
   private readonly activeTurnsBySession = new Map<string, ContextUsageTurn>()
   private nextTurnRevision = 0
   private nextProviderUsageRevision = 0
@@ -541,7 +542,9 @@ class ContextUsageTracker {
     selectedContextWindow?: number
   ): void {
     const revision = this.recordProviderUsage(sessionId)
-    if (this.isUnconfirmedZeroRegression(sessionId, usage.used)) {
+    const providerCompactionConfirmed =
+      this.providerCompactionAwaitingUsageBySession.delete(sessionId)
+    if (!providerCompactionConfirmed && this.isUnconfirmedZeroRegression(sessionId, usage.used)) {
       this.pendingZeroProviderUsageBySession.set(sessionId, {
         usage: this.cloneUsage(usage),
         ...(selectedContextWindow === undefined ? {} : { selectedContextWindow }),
@@ -550,6 +553,14 @@ class ContextUsageTracker {
       return
     }
     this.pendingZeroProviderUsageBySession.delete(sessionId)
+    this.acceptProviderUsage(sessionId, usage, selectedContextWindow)
+  }
+
+  private acceptProviderUsage(
+    sessionId: string,
+    usage: Readonly<AcpContextUsage>,
+    selectedContextWindow?: number
+  ): void {
     this.observeActiveTurn(sessionId)
     const activeTurn = this.activeTurnsBySession.get(sessionId)
     if (activeTurn && !activeTurn.outcome) activeTurn.providerUsageObserved = true
@@ -565,7 +576,9 @@ class ContextUsageTracker {
     const current = this.usageBySession.get(sessionId)
     if (!current || !Number.isSafeInteger(used)) return false
     const revision = this.recordProviderUsage(sessionId)
-    if (this.isUnconfirmedZeroRegression(sessionId, used)) {
+    const providerCompactionConfirmed =
+      this.providerCompactionAwaitingUsageBySession.delete(sessionId)
+    if (!providerCompactionConfirmed && this.isUnconfirmedZeroRegression(sessionId, used)) {
       this.pendingZeroProviderUsageBySession.set(sessionId, {
         usage: {
           used,
@@ -586,6 +599,19 @@ class ContextUsageTracker {
       ...(current.size === undefined ? {} : { size: current.size }),
       breakdown: this.compare(sessionId, used, 'reconciled')
     })
+    return true
+  }
+
+  confirmProviderCompaction(sessionId: string): boolean {
+    const pendingZero = this.pendingZeroProviderUsageBySession.get(sessionId)
+    if (!pendingZero) {
+      this.providerCompactionAwaitingUsageBySession.add(sessionId)
+      return false
+    }
+
+    this.pendingZeroProviderUsageBySession.delete(sessionId)
+    this.providerCompactionAwaitingUsageBySession.delete(sessionId)
+    this.acceptProviderUsage(sessionId, pendingZero.usage, pendingZero.selectedContextWindow)
     return true
   }
 
@@ -636,6 +662,7 @@ class ContextUsageTracker {
     const pendingZero = this.pendingZeroProviderUsageBySession.get(sessionId)
     this.resetSession(sessionId, input)
     this.pendingZeroProviderUsageBySession.delete(sessionId)
+    this.providerCompactionAwaitingUsageBySession.delete(sessionId)
     if (pendingZero && pendingZero.revision > checkpoint.providerUsageRevision) {
       const breakdown = this.compare(sessionId, pendingZero.usage.used, 'reconciled')
       this.replaceUsage(sessionId, {
@@ -974,6 +1001,7 @@ class ContextUsageTracker {
     this.usageRevisions.delete(sessionId)
     this.providerUsageRevisions.delete(sessionId)
     this.pendingZeroProviderUsageBySession.delete(sessionId)
+    this.providerCompactionAwaitingUsageBySession.delete(sessionId)
   }
 
   clear(): void {
@@ -984,6 +1012,7 @@ class ContextUsageTracker {
     this.usageRevisions.clear()
     this.providerUsageRevisions.clear()
     this.pendingZeroProviderUsageBySession.clear()
+    this.providerCompactionAwaitingUsageBySession.clear()
   }
 }
 

--- a/src/main/acp/context-usage-tracker.ts
+++ b/src/main/acp/context-usage-tracker.ts
@@ -525,6 +525,7 @@ class ContextUsageTracker {
     usage: AcpContextUsage,
     selectedContextWindow?: number
   ): void {
+    if (this.isUnconfirmedZeroRegression(sessionId, usage.used)) return
     this.observeActiveTurn(sessionId)
     const activeTurn = this.activeTurnsBySession.get(sessionId)
     if (activeTurn && !activeTurn.outcome) activeTurn.providerUsageObserved = true
@@ -538,7 +539,13 @@ class ContextUsageTracker {
 
   reconcileUsed(sessionId: string, used: number): boolean {
     const current = this.usageBySession.get(sessionId)
-    if (!current || !Number.isSafeInteger(used)) return false
+    if (
+      !current ||
+      !Number.isSafeInteger(used) ||
+      this.isUnconfirmedZeroRegression(sessionId, used)
+    ) {
+      return false
+    }
     this.observeActiveTurn(sessionId)
     const activeTurn = this.activeTurnsBySession.get(sessionId)
     if (activeTurn && !activeTurn.outcome) activeTurn.providerUsageObserved = true
@@ -902,6 +909,10 @@ class ContextUsageTracker {
   private replaceUsage(sessionId: string, usage: AcpContextUsage): void {
     this.usageBySession.set(sessionId, this.cloneUsage(usage))
     this.usageRevisions.set(sessionId, (this.usageRevisions.get(sessionId) ?? 0) + 1)
+  }
+
+  private isUnconfirmedZeroRegression(sessionId: string, used: number): boolean {
+    return used === 0 && (this.usageBySession.get(sessionId)?.used ?? 0) > 0
   }
 
   private deleteUsage(sessionId: string): void {

--- a/src/main/acp/context-usage-tracker.ts
+++ b/src/main/acp/context-usage-tracker.ts
@@ -51,7 +51,14 @@ type SessionEstimateCheckpoint = {
   state?: SessionEstimate
   usage?: AcpContextUsage
   usageRevision: number
+  providerUsageRevision: number
 }
+
+type PendingZeroProviderUsage = Readonly<{
+  usage: AcpContextUsage
+  selectedContextWindow?: number
+  revision: number
+}>
 
 type SessionUpdateObservation = {
   toolCategory?: Extract<EstimatedCategoryKey, 'tools' | 'mcp' | 'skills'>
@@ -347,8 +354,11 @@ class ContextUsageTracker {
   private readonly sessions = new Map<string, SessionEstimate>()
   private readonly usageBySession = new Map<string, AcpContextUsage>()
   private readonly usageRevisions = new Map<string, number>()
+  private readonly providerUsageRevisions = new Map<string, number>()
+  private readonly pendingZeroProviderUsageBySession = new Map<string, PendingZeroProviderUsage>()
   private readonly activeTurnsBySession = new Map<string, ContextUsageTurn>()
   private nextTurnRevision = 0
+  private nextProviderUsageRevision = 0
 
   constructor(private readonly counter: TokenCounter = defaultTokenCounter) {}
 
@@ -494,7 +504,8 @@ class ContextUsageTracker {
     return {
       ...(state ? { state: cloneSessionEstimate(state) } : {}),
       ...(usage ? { usage: this.cloneUsage(usage) } : {}),
-      usageRevision: this.usageRevisions.get(sessionId) ?? 0
+      usageRevision: this.usageRevisions.get(sessionId) ?? 0,
+      providerUsageRevision: this.providerUsageRevisions.get(sessionId) ?? 0
     }
   }
 
@@ -503,6 +514,10 @@ class ContextUsageTracker {
     else this.sessions.delete(sessionId)
     if (checkpoint.usage) this.replaceUsage(sessionId, checkpoint.usage)
     else this.deleteUsage(sessionId)
+    const pendingZero = this.pendingZeroProviderUsageBySession.get(sessionId)
+    if (pendingZero && pendingZero.revision > checkpoint.providerUsageRevision) {
+      this.pendingZeroProviderUsageBySession.delete(sessionId)
+    }
   }
 
   usage(sessionId: string): AcpContextUsage | undefined {
@@ -525,7 +540,16 @@ class ContextUsageTracker {
     usage: AcpContextUsage,
     selectedContextWindow?: number
   ): void {
-    if (this.isUnconfirmedZeroRegression(sessionId, usage.used)) return
+    const revision = this.recordProviderUsage(sessionId)
+    if (this.isUnconfirmedZeroRegression(sessionId, usage.used)) {
+      this.pendingZeroProviderUsageBySession.set(sessionId, {
+        usage: this.cloneUsage(usage),
+        ...(selectedContextWindow === undefined ? {} : { selectedContextWindow }),
+        revision
+      })
+      return
+    }
+    this.pendingZeroProviderUsageBySession.delete(sessionId)
     this.observeActiveTurn(sessionId)
     const activeTurn = this.activeTurnsBySession.get(sessionId)
     if (activeTurn && !activeTurn.outcome) activeTurn.providerUsageObserved = true
@@ -539,13 +563,19 @@ class ContextUsageTracker {
 
   reconcileUsed(sessionId: string, used: number): boolean {
     const current = this.usageBySession.get(sessionId)
-    if (
-      !current ||
-      !Number.isSafeInteger(used) ||
-      this.isUnconfirmedZeroRegression(sessionId, used)
-    ) {
+    if (!current || !Number.isSafeInteger(used)) return false
+    const revision = this.recordProviderUsage(sessionId)
+    if (this.isUnconfirmedZeroRegression(sessionId, used)) {
+      this.pendingZeroProviderUsageBySession.set(sessionId, {
+        usage: {
+          used,
+          ...(current.size === undefined ? {} : { size: current.size })
+        },
+        revision
+      })
       return false
     }
+    this.pendingZeroProviderUsageBySession.delete(sessionId)
     this.observeActiveTurn(sessionId)
     const activeTurn = this.activeTurnsBySession.get(sessionId)
     if (activeTurn && !activeTurn.outcome) activeTurn.providerUsageObserved = true
@@ -603,7 +633,18 @@ class ContextUsageTracker {
     checkpoint: SessionEstimateCheckpoint,
     size?: number
   ): void {
+    const pendingZero = this.pendingZeroProviderUsageBySession.get(sessionId)
     this.resetSession(sessionId, input)
+    this.pendingZeroProviderUsageBySession.delete(sessionId)
+    if (pendingZero && pendingZero.revision > checkpoint.providerUsageRevision) {
+      const breakdown = this.compare(sessionId, pendingZero.usage.used, 'reconciled')
+      this.replaceUsage(sessionId, {
+        ...pendingZero.usage,
+        size: size ?? pendingZero.selectedContextWindow ?? pendingZero.usage.size,
+        ...(breakdown ? { breakdown } : {})
+      })
+      return
+    }
     if ((this.usageRevisions.get(sessionId) ?? 0) === checkpoint.usageRevision) {
       this.deleteUsage(sessionId)
     } else {
@@ -915,6 +956,12 @@ class ContextUsageTracker {
     return used === 0 && (this.usageBySession.get(sessionId)?.used ?? 0) > 0
   }
 
+  private recordProviderUsage(sessionId: string): number {
+    const revision = ++this.nextProviderUsageRevision
+    this.providerUsageRevisions.set(sessionId, revision)
+    return revision
+  }
+
   private deleteUsage(sessionId: string): void {
     if (!this.usageBySession.delete(sessionId)) return
     this.usageRevisions.set(sessionId, (this.usageRevisions.get(sessionId) ?? 0) + 1)
@@ -925,6 +972,8 @@ class ContextUsageTracker {
     this.sessions.delete(sessionId)
     this.deleteUsage(sessionId)
     this.usageRevisions.delete(sessionId)
+    this.providerUsageRevisions.delete(sessionId)
+    this.pendingZeroProviderUsageBySession.delete(sessionId)
   }
 
   clear(): void {
@@ -933,6 +982,8 @@ class ContextUsageTracker {
     this.sessions.clear()
     this.usageBySession.clear()
     this.usageRevisions.clear()
+    this.providerUsageRevisions.clear()
+    this.pendingZeroProviderUsageBySession.clear()
   }
 }
 

--- a/src/main/acp/session-update-projector.test.ts
+++ b/src/main/acp/session-update-projector.test.ts
@@ -77,6 +77,10 @@ const createProjector = (
       beginSession: () => undefined,
       observeSessionUpdate: (sessionId, notification, observation) =>
         record({ kind: 'context-observation', sessionId, notification, observation }),
+      confirmProviderCompaction: (sessionId) => {
+        record({ kind: 'provider-compaction-completed', sessionId })
+        return true
+      },
       reconcileProviderUsage: (sessionId, usage) =>
         record({ kind: 'provider-usage', sessionId, usage }),
       refreshUsage: (sessionId) => {
@@ -176,6 +180,7 @@ describe('AcpSessionUpdateProjector', () => {
       },
       contextUsage: {
         beginSession,
+        confirmProviderCompaction: () => false,
         observeSessionUpdate,
         reconcileProviderUsage,
         refreshUsage: () => false,
@@ -527,6 +532,7 @@ describe('AcpSessionUpdateProjector', () => {
 
     expect(effects).toMatchObject([
       { kind: 'context-observation' },
+      { kind: 'provider-compaction-completed', sessionId: 'session-1' },
       { kind: 'context-refresh' },
       {
         kind: 'visible-event',
@@ -540,6 +546,50 @@ describe('AcpSessionUpdateProjector', () => {
       }
     ])
     expect(effects.at(-1)).not.toHaveProperty('event.text')
+  })
+
+  it('confirms a structured Codex compaction lifecycle before publishing completion', () => {
+    const projector = createProjector()
+    const notification: SessionNotification = {
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'provider-compaction',
+        status: 'completed',
+        _meta: { contextCompaction: true }
+      }
+    }
+    const effects = projector.route(notification, {
+      framework: 'codex',
+      eventId: 'event-compaction',
+      visible: true,
+      reconnectPending: false,
+      mcpServerNames: []
+    })
+
+    expect(effects).toMatchObject([
+      { kind: 'context-observation' },
+      { kind: 'provider-compaction-completed', sessionId: 'session-1' },
+      { kind: 'context-refresh' },
+      {
+        kind: 'visible-event',
+        event: {
+          kind: 'compaction',
+          status: 'completed',
+          toolCallId: 'provider-compaction'
+        }
+      }
+    ])
+
+    expect(
+      projector.route(notification, {
+        framework: 'codex',
+        eventId: 'event-replayed-compaction',
+        visible: true,
+        reconnectPending: true,
+        mcpServerNames: []
+      })
+    ).not.toContainEqual(expect.objectContaining({ kind: 'provider-compaction-completed' }))
   })
 
   it('projects usage to context state without a visible event and suppresses stale reconnect usage', () => {

--- a/src/main/acp/session-update-projector.ts
+++ b/src/main/acp/session-update-projector.ts
@@ -64,7 +64,12 @@ type AcpSessionUpdateProjectorOptions = Readonly<{
   registry: Pick<AcpSessionRegistry, 'lookup'>
   contextUsage: Pick<
     ContextUsageTracker,
-    'beginSession' | 'observeSessionUpdate' | 'reconcileProviderUsage' | 'refreshUsage' | 'usage'
+    | 'beginSession'
+    | 'confirmProviderCompaction'
+    | 'observeSessionUpdate'
+    | 'reconcileProviderUsage'
+    | 'refreshUsage'
+    | 'usage'
   >
   contextPolicy: Pick<AcpContextUsagePolicy, 'resolve'>
   hasActiveSession: (sessionId: string) => boolean
@@ -107,6 +112,10 @@ type AcpSessionUpdateEffect =
       kind: 'provider-usage'
       sessionId: string
       usage: Readonly<AcpContextUsage>
+    }>
+  | Readonly<{
+      kind: 'provider-compaction-completed'
+      sessionId: string
     }>
   | Readonly<{
       kind: 'current-mode'
@@ -279,6 +288,20 @@ class AcpSessionUpdateProjector {
       )
     }
 
+    if (
+      !routing.reconnectPending &&
+      routing.framework === 'codex' &&
+      event.kind === 'compaction' &&
+      event.status === 'completed'
+    ) {
+      effects.push(
+        deepFreeze({
+          kind: 'provider-compaction-completed' as const,
+          sessionId: routed.sessionId
+        })
+      )
+    }
+
     if (event.contextUsage) {
       effects.push(
         deepFreeze({
@@ -377,6 +400,9 @@ class AcpSessionUpdateProjector {
           this.options.contextPolicy.resolve(effect.sessionId).selectedWindow
         )
         emitState()
+        break
+      case 'provider-compaction-completed':
+        if (this.options.contextUsage.confirmProviderCompaction(effect.sessionId)) emitState()
         break
       case 'context-refresh':
         if (this.options.contextUsage.usage(effect.sessionId)?.breakdown?.status !== 'reconciled') {


### PR DESCRIPTION
## Problem

During an active session, a later provider context-usage update with `used: 0` can overwrite an established positive reading even though the context owner has not been reset, compacted, or replaced. The renderer then shows `0.0%` while the local estimate remains stable and the state is still marked `Reconciled`.

## Proposed change

- Reject an unconfirmed zero regression when the context tracker already owns a positive provider reading.
- Apply the same guard to streamed provider usage updates and terminal provider readings.
- Accept a zero that is confirmed by explicit compaction or a completed Codex provider compaction lifecycle, regardless of whether the zero arrives immediately before or after completion.
- Ignore reconnect replay as a compaction confirmation, and consume the one-shot confirmation on the next provider reading.
- Add regression coverage for the reported GLM-5.3 sequence, terminal Codex usage, explicit compaction, and provider-observed automatic compaction.

## Scope and non-goals

- No renderer or interaction changes.
- No persisted-data, database-schema, migration, or historical-data compatibility changes.
- One internal projector effect kind (`provider-compaction-completed`) and one transient in-memory session marker are added; no shared or persisted enum/status is changed.
- No provider adapter protocol changes; Claude Code, OpenCode, Codex Responses, and Codex Bridge converge on the same context-usage owner.

## Acceptance criteria and validation

The following checks ran after the last material edit:

- Positive usage does not regress to zero without reset; initial, replacement, explicit-compaction, and provider-compaction zero readings remain valid -> `npm test -- src/main/acp/context-usage-tracker.test.ts src/main/acp/context-compaction-workflow.test.ts src/main/acp/session-update-projector.test.ts src/main/acp/prompt-turn-workflow.test.ts src/main/acp/runtime-events.test.ts` -> 5 files, 114 tests passed.
- Main-process type contracts remain valid -> `npm run typecheck:node` -> passed.
- Source lint and formatting rules -> `npm run lint` and targeted `prettier --check` -> passed.
- Whitespace/error-marker check -> `git diff --check` -> passed.

The complete portable/platform suite is intentionally left to the exact-head PR Gate CI. No locally uncovered persistence or migration risk was identified.

## Review focus

Please verify that zero is rejected only while a positive reading is still owned, and remains valid once an explicit or provider-observed compaction lifecycle confirms the reset boundary.

Fixes #1371