### PR TITLE
fix(workspace): gate follow-on actions until branched Session replay

### DIFF
--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -1420,6 +1420,7 @@
   "Resize left panel": "左パネルのサイズを変更する",
   "Resize notebook and terminal": "Notebook と端末のサイズを変更する",
   "Resize right panel": "右パネルのサイズを変更する",
+  "Resolve the current Session operation first.": "先に現在のセッション操作を完了してください。",
   "Resolve the items marked Action needed, then choose Check again.": "「アクションが必要」とマークされた項目を解決し、[もう一度確認] を選択します。",
   "Resolved": "解決済み",
   "Resolving…": "解決中…",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -1481,6 +1481,7 @@
   "Resize left panel": "调整左侧面板大小",
   "Resize notebook and terminal": "调整 Notebook 与终端大小",
   "Resize right panel": "调整右侧面板大小",
+  "Resolve the current Session operation first.": "请先完成当前会话操作。",
   "Resolve the items marked Action needed, then choose Check again.": "请先处理标记为「需要处理」的项目，然后点击「重新检查」。",
   "Resolved": "已解决",
   "Resolving…": "解析中…",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -1478,6 +1478,7 @@
   "Resize left panel": "調整左側面板大小",
   "Resize notebook and terminal": "調整 Notebook 與終端大小",
   "Resize right panel": "調整右側面板大小",
+  "Resolve the current Session operation first.": "請先完成目前會話操作。",
   "Resolve the items marked Action needed, then choose Check again.": "請先處理標記為「需要處理」的項目，然後點擊「重新檢查」。",
   "Resolved": "已解決",
   "Resolving…": "解析中…",

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -1783,6 +1783,49 @@ describe('ConversationPanel composer intake', () => {
     ).toBe(false)
   })
 
+  it('keeps send and Plan first available while Branch stays disabled for a pending replay', () => {
+    const session: ChatSession = {
+      id: 'session-replay',
+      projectId: 'project-a',
+      title: 'Replay pending',
+      cwd: '/workspace',
+      status: 'idle',
+      pendingHistoryReplay: { kind: 'all' },
+      messages: planOriginMessages(),
+      createdAt: 1,
+      updatedAt: 2
+    }
+    renderPanel({
+      view: {
+        activeSession: session
+      },
+      conversation: {
+        availability: {
+          submit: true,
+          branch: false
+        },
+        actions: {
+          submit: {
+            draft: routeDraftSubmit({ planFirst: vi.fn(), branch: vi.fn() })
+          }
+        }
+      },
+      composer: {
+        view: {
+          doc: { nodes: [{ type: 'text', text: 'continue from this branch' }] }
+        }
+      }
+    })
+
+    expect(
+      (container.querySelector('[data-testid="menu-plan-first"]') as HTMLButtonElement).disabled
+    ).toBe(false)
+    expect(
+      (container.querySelector('[data-testid="menu-branch-in-new-session"]') as HTMLButtonElement)
+        .disabled
+    ).toBe(true)
+  })
+
   it('offers Side chat between Plan first and Branch for a text-only existing Session draft', () => {
     const onStartSideChat = vi.fn()
     const session: ChatSession = {

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -683,7 +683,7 @@ const ConversationPanel = ({
   }
 
   const handleBranchInNewSession = (): void => {
-    if (!effectiveCanSend || !onBranchInNewSession) return
+    if (!effectiveCanSend || !onBranchInNewSession || !canBranchInNewSession) return
     onBranchInNewSession(docToSkillIds(draftDoc))
   }
 
@@ -1788,7 +1788,9 @@ const ConversationPanel = ({
                                           !canPlanFirst &&
                                           !canStartSideChat &&
                                           !canRetrySideChatHydration &&
-                                          (!effectiveCanSend || !onBranchInNewSession)
+                                          (!effectiveCanSend ||
+                                            !onBranchInNewSession ||
+                                            !canBranchInNewSession)
                                         }
                                         className={composerSplitSendMenuButtonClassName}
                                         aria-label={t('More send options')}
@@ -1844,7 +1846,11 @@ const ConversationPanel = ({
                                   </DropdownMenuItem>
                                   <DropdownMenuItem
                                     data-testid="menu-branch-in-new-session"
-                                    disabled={!effectiveCanSend || !onBranchInNewSession}
+                                    disabled={
+                                      !effectiveCanSend ||
+                                      !onBranchInNewSession ||
+                                      !canBranchInNewSession
+                                    }
                                     onSelect={handleBranchInNewSession}
                                     className="whitespace-nowrap [@media(pointer:coarse)]:min-h-11"
                                   >

--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -636,6 +636,55 @@ describe('WorkspacePage send gate while compacting', () => {
     expect(conversationProps.conversation.availability.revise).toBe(false)
   })
 
+  it('blocks follow-on Session actions until a pending history replay is sent', async () => {
+    useSessionStore.setState({
+      sessions: [
+        createSession({
+          pendingHistoryReplay: { kind: 'all' },
+          messages: [
+            {
+              id: 'user-1',
+              role: 'user',
+              content: 'Inspect the data',
+              status: 'complete',
+              eventIds: [],
+              createdAt: 1,
+              updatedAt: 1
+            },
+            {
+              id: 'agent-1',
+              role: 'agent',
+              content: 'The analysis is complete.',
+              status: 'complete',
+              eventIds: [],
+              createdAt: 2,
+              updatedAt: 2
+            }
+          ]
+        })
+      ],
+      selectedSessionId: 'sess-a'
+    })
+    await renderPage()
+    await act(async () => {
+      conversationProps.composer.actions.changeDoc(textDoc('continue from this branch'))
+    })
+
+    expect(conversationProps.conversation.availability.submit).toBe(true)
+    expect(conversationProps.conversation.availability.branch).toBe(false)
+    expect(conversationProps.workflows.review.disabled).toBe(true)
+    expect(conversationProps.workflows.saveAsSkill.disabled).toBe(true)
+    expect(conversationProps.contextWindow.canCompact).toBe(false)
+    expect(conversationProps.contextWindow.compactDisabledReason).toBe(
+      'Send a message to reconnect this session before compacting.'
+    )
+    expect(conversationProps.agentControls.canChange).toBe(false)
+    expect(conversationProps.permissions.canChangePermissionProfile).toBe(false)
+    expect(conversationProps.view.sideChatDisabledReason).toBe(
+      'Resolve the current Session operation first.'
+    )
+  })
+
   it('allows manual compaction only for an idle session, not an unresolved error', async () => {
     await renderPage()
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -376,7 +376,7 @@ const WorkspacePage = ({
   )
   const awaitsHistoryReplay = sessionAwaitsHistoryReplay(activeSession)
   const sideChatDisabledReason = awaitsHistoryReplay
-    ? 'Resolve the current Session operation first.'
+    ? t('Resolve the current Session operation first.')
     : (sideChat.unavailableReason ??
       (activeProviderType !== undefined && isCodexSubscriptionProvider(activeProviderType)
         ? 'Side chat is unavailable for Codex subscription because strict tool isolation cannot be enforced.'

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -22,6 +22,7 @@ import {
 import {
   projectSessionActionability,
   resolveRootPermissionPending,
+  sessionAwaitsHistoryReplay,
   useSessionStore
 } from '@/stores/session-store'
 import { useSpecialistStore } from '@/stores/specialist-store'
@@ -373,11 +374,13 @@ const WorkspacePage = ({
   const sideChat = useSideChatController(
     activeSession ? { sessionId: activeSession.id, projectId: activeSession.projectId } : undefined
   )
-  const sideChatDisabledReason =
-    sideChat.unavailableReason ??
-    (activeProviderType !== undefined && isCodexSubscriptionProvider(activeProviderType)
-      ? 'Side chat is unavailable for Codex subscription because strict tool isolation cannot be enforced.'
-      : undefined)
+  const awaitsHistoryReplay = sessionAwaitsHistoryReplay(activeSession)
+  const sideChatDisabledReason = awaitsHistoryReplay
+    ? 'Resolve the current Session operation first.'
+    : (sideChat.unavailableReason ??
+      (activeProviderType !== undefined && isCodexSubscriptionProvider(activeProviderType)
+        ? 'Side chat is unavailable for Codex subscription because strict tool isolation cannot be enforced.'
+        : undefined))
 
   useEffect(() => {
     const getPlanProjection = window.api.acp?.getPlanProjection
@@ -504,6 +507,7 @@ const WorkspacePage = ({
   const isRequestReviewDisabled = useReviewStore((state) => {
     if (!activeSessionId) return true
     if (!activeSession) return true
+    if (sessionAwaitsHistoryReplay(activeSession)) return true
     const lastAgentMessage = [...activeSession.messages].reverse().find((m) => m.role === 'agent')
     if (!lastAgentMessage) return true
     if (isReviewing) return true
@@ -577,6 +581,7 @@ const WorkspacePage = ({
     isSessionPersistenceReady &&
     !activeSessionHasSendPreparation &&
     !activeSession?.compacting &&
+    !awaitsHistoryReplay &&
     conversation.queue.items.length === 0
   const canCompactContext =
     isSessionPersistenceReady &&
@@ -585,7 +590,8 @@ const WorkspacePage = ({
     !activeSessionHasRuntimeInteraction &&
     !activeSession.interrupted &&
     !activeSession.fixLoopActive &&
-    !activeSession.compacting
+    !activeSession.compacting &&
+    !awaitsHistoryReplay
   const customizeAvailable =
     catalogSkillIds.has('customize') &&
     !sessionController.view.specialist.unavailable &&
@@ -602,11 +608,12 @@ const WorkspacePage = ({
     hasRunningSubagents: hasCurrentRunningDelegatedAttempt(activeSession),
     sideChatOpen: sideChat.view !== undefined
   })
-  const compactContextDisabledReason = !activeSessionSupportsNativeCompaction
-    ? 'Send a message to reconnect this session before compacting.'
-    : activeSession?.status === 'error'
-      ? 'Resolve the current session error before compacting.'
-      : 'Wait for the current agent activity to finish.'
+  const compactContextDisabledReason =
+    !activeSessionSupportsNativeCompaction || awaitsHistoryReplay
+      ? 'Send a message to reconnect this session before compacting.'
+      : activeSession?.status === 'error'
+        ? 'Resolve the current session error before compacting.'
+        : 'Wait for the current agent activity to finish.'
   const durablePermissionError =
     activeSession?.status === 'waiting-permission' &&
     activeSession.runtimeContext?.permission?.state === 'pending'

--- a/src/renderer/src/pages/workspace/save-as-skill-availability.test.ts
+++ b/src/renderer/src/pages/workspace/save-as-skill-availability.test.ts
@@ -107,6 +107,10 @@ describe('Save as skill availability', () => {
       availability({ session: { ...session(), specialistSwitchResetRequired: true } })
         .disabledReason
     ).toContain('Session operation')
+    expect(
+      availability({ session: { ...session(), pendingHistoryReplay: { kind: 'all' } } })
+        .disabledReason
+    ).toContain('Session operation')
   })
 
   it('describes a cancelled turn as interrupted instead of still running', () => {

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
@@ -352,6 +352,36 @@ describe('workspace conversation controller', () => {
     expect(input.runtime.resendEditedMessage).not.toHaveBeenCalled()
   })
 
+  it('keeps send available and blocks branch while history replay is pending', () => {
+    const replaySession = session({ pendingHistoryReplay: { kind: 'all' } })
+    const startSideChat = vi.fn(async () => true)
+    const input = options({
+      activeSession: replaySession,
+      actionability: projectSessionActionability(replaySession),
+      sideChat: { start: startSideChat }
+    })
+    const hook = renderController(input)
+    mounted.push(hook)
+
+    expect(hook.result.current.availability).toMatchObject({
+      submit: true,
+      branch: false
+    })
+    act(() => hook.result.current.actions.branch('agent-message-a'))
+    act(() => hook.result.current.actions.sideChat.start())
+    act(() => hook.result.current.actions.submit.draft({ forcedSkillIds: [], mode: 'branch' }))
+    expect(input.runtime.sendMessage).not.toHaveBeenCalled()
+    expect(startSideChat).not.toHaveBeenCalled()
+
+    act(() => hook.result.current.actions.submit.draft({ forcedSkillIds: [] }))
+    expect(input.runtime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-a',
+        text: 'hello'
+      })
+    )
+  })
+
   it('blocks submit while a selected branched Session is still binding', () => {
     const pendingSession = session({ isPending: true })
     const input = options({

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
@@ -253,6 +253,7 @@ const useWorkspaceConversationController = (
 
       const branchInNewSession = mode === 'branch'
       if (branchInNewSession && !activeSession) return
+      if (branchInNewSession && !canBranch(current)) return
       if (activeSession && session.lifecycle.isBarrierInFlight(activeSession.id)) return
       if (
         current.supportsImageInput !== true &&

--- a/src/renderer/src/pages/workspace/workspace-page.architecture.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-page.architecture.test.ts
@@ -140,8 +140,8 @@ const conversationPanelPropNames = (): string[] => {
 
 describe('workspace page architecture', () => {
   it('keeps the page and extracted owners within their completion gates', () => {
-    // The i18n and queue subscriptions add wiring without adding a page responsibility.
-    expect(rawLineCount(readSource(ownerPaths.page))).toBeLessThanOrEqual(1_207)
+    // History-replay follow-on gates add wiring without adding a page-owned behavior.
+    expect(rawLineCount(readSource(ownerPaths.page))).toBeLessThanOrEqual(1_214)
     for (const ownerPath of [
       ownerPaths.layout,
       ownerPaths.composer,

--- a/src/renderer/src/stores/session-store-interaction-state.ts
+++ b/src/renderer/src/stores/session-store-interaction-state.ts
@@ -61,6 +61,7 @@ type SessionInteractionSource = Readonly<{
   activeRun?: unknown
   agentPromptInFlight?: boolean
   isPending?: boolean
+  pendingHistoryReplay?: unknown
 }>
 
 type SessionPermissionRequest = Readonly<{
@@ -82,6 +83,10 @@ export const isSessionWaitReason = (status: string): status is SessionWaitReason
   status === 'waiting-permission' ||
   status === 'waiting-for-user' ||
   status === 'waiting-plan-approval'
+
+export const sessionAwaitsHistoryReplay = (
+  session: Pick<SessionInteractionSource, 'isPending' | 'pendingHistoryReplay'> | undefined
+): boolean => Boolean(session?.isPending || session?.pendingHistoryReplay)
 
 const hasPendingDurableElicitation = (session: SessionInteractionSource): boolean =>
   (session.status === 'waiting-for-user' || session.status === 'waiting-permission') &&
@@ -153,6 +158,8 @@ export const projectSessionActionability = (
         ? 'plan'
         : undefined
   const interactionDisabledReason = disabledReasonForInteraction(blockingInteraction)
+  const historyReplayPending = Boolean(session.pendingHistoryReplay)
+  const sessionPending = Boolean(session.isPending) || historyReplayPending
   const turnDisabledReason =
     session.isPending && !facts.allowPendingSessionRetry
       ? 'session-pending'
@@ -167,6 +174,7 @@ export const projectSessionActionability = (
         ? 'elicitation-pending'
         : 'plan-approval-pending'
     : undefined
+  const replayOrPendingReason = sessionPending ? 'session-pending' : undefined
   const activity = waitReason ? 'waiting' : running ? 'running' : 'inactive'
 
   return {
@@ -179,15 +187,12 @@ export const projectSessionActionability = (
       startTurn: actionAvailability(turnDisabledReason),
       revise: actionAvailability(revisionDisabledReason),
       branchFromMessage: actionAvailability(
-        session.isPending
-          ? 'session-pending'
-          : running
-            ? 'session-running'
-            : attentionDisabledReason
+        replayOrPendingReason ?? (running ? 'session-running' : attentionDisabledReason)
       ),
-      startSideChat: actionAvailability(attentionDisabledReason),
+      startSideChat: actionAvailability(replayOrPendingReason ?? attentionDisabledReason),
       changeAgentControls: actionAvailability(
-        running ? 'session-running' : (attentionDisabledReason ?? interactionDisabledReason)
+        replayOrPendingReason ??
+          (running ? 'session-running' : (attentionDisabledReason ?? interactionDisabledReason))
       ),
       archive: actionAvailability(running ? 'session-running' : attentionDisabledReason)
     }

--- a/src/renderer/src/stores/session-store-message-graph-helpers.ts
+++ b/src/renderer/src/stores/session-store-message-graph-helpers.ts
@@ -430,6 +430,7 @@ export const projectSessionBranchSnapshot = (
 
 export const canBranchInNewSession = (session: ChatSession): boolean =>
   !session.isPending &&
+  !session.pendingHistoryReplay &&
   !session.activeRun &&
   session.status !== 'running' &&
   session.status !== 'waiting-for-user' &&

--- a/src/renderer/src/stores/session-store.architecture.test.ts
+++ b/src/renderer/src/stores/session-store.architecture.test.ts
@@ -109,6 +109,7 @@ const publicValueExports = [
   'isSessionWaitReason',
   'projectSessionActionability',
   'resolveRootPermissionPending',
+  'sessionAwaitsHistoryReplay',
   'toPersistedSession',
   'useSessionStore'
 ].sort()

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -180,7 +180,31 @@ describe('session store', () => {
     expect(actionability.actions).toMatchObject({
       startTurn: { allowed: false, disabledReason: 'session-pending' },
       revise: { allowed: true },
-      branchFromMessage: { allowed: false, disabledReason: 'session-pending' }
+      branchFromMessage: { allowed: false, disabledReason: 'session-pending' },
+      startSideChat: { allowed: false, disabledReason: 'session-pending' },
+      changeAgentControls: { allowed: false, disabledReason: 'session-pending' }
+    })
+  })
+
+  it('keeps a new Turn available while history replay is pending and blocks other Session actions', () => {
+    const actionability = projectSessionActionability({
+      id: 'session-replay',
+      projectId: 'project-1',
+      title: 'Replay pending',
+      cwd: '/workspace',
+      status: 'idle',
+      pendingHistoryReplay: { kind: 'all' },
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1
+    } as ChatSession)
+
+    expect(actionability.actions).toMatchObject({
+      startTurn: { allowed: true },
+      revise: { allowed: true },
+      branchFromMessage: { allowed: false, disabledReason: 'session-pending' },
+      startSideChat: { allowed: false, disabledReason: 'session-pending' },
+      changeAgentControls: { allowed: false, disabledReason: 'session-pending' }
     })
   })
 
@@ -5275,6 +5299,30 @@ describe('branchInNewSession', () => {
       useSessionStore.getState().branchInNewSession({
         sourceSessionId: 'source-session',
         content: 'bypass the pending Plan'
+      })
+    ).toBeUndefined()
+    expect(useSessionStore.getState().sessions).toEqual([sourceBefore])
+  })
+
+  it('refuses a source that still needs history replay', () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'source-session',
+      content: 'stable source'
+    })
+    useSessionStore.getState().finishRun('source-session')
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === 'source-session'
+          ? { ...session, pendingHistoryReplay: { kind: 'all' as const } }
+          : session
+      )
+    }))
+    const sourceBefore = structuredClone(useSessionStore.getState().sessions[0])
+
+    expect(
+      useSessionStore.getState().branchInNewSession({
+        sourceSessionId: 'source-session',
+        content: 'must not nest an unreplayed Session'
       })
     ).toBeUndefined()
     expect(useSessionStore.getState().sessions).toEqual([sourceBefore])

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -41,6 +41,7 @@ export {
   isSessionWaitReason,
   projectSessionActionability,
   resolveRootPermissionPending,
+  sessionAwaitsHistoryReplay,
   type SessionActionabilityFacts,
   type SessionActionabilityProjection,
   type SessionActionAvailability,


### PR DESCRIPTION
## Problem

Branch in new session has two triggers. Composer branch immediately sends and replays history into the new ACP session. Clicking Branch on an Agent message only copies the transcript, creates an empty ACP session, and sets `pendingHistoryReplay: { kind: 'all' }`.

The UI then looks like a complete idle Session. Follow-on actions that talk to ACP (review fix-loop, side-chat start, compact, nested branch, specialist switch, save as skill) treated “ACP session id is live” as “context is reconstructed.” That is false until the next user send goes through `prepareExistingWorkspacePrompt`.

## Proposed change

Minimal product rule: after a message-click branch, the user must send a message (or plan-first send) to reconstruct ACP before any other Session action.

- Keep send and plan-first available after bind.
- Disable side-chat, request review, compact, save as skill, nested branch, agent controls, and permission-profile changes while the Session is `isPending` or has `pendingHistoryReplay`.
- Reuse the existing `session-pending` actionability reason. No new persisted enum, no persistence format change, no historical migration.

## Scope and non-goals

- Renderer admission only. Main-process review/side-chat IPC is not fail-closed in this PR.
- Does not eagerly reconstruct ACP after the click.
- Does not copy Plan or Review rows onto the child Session.
- Trigger 1 mid-flight reload (`pendingContextReplayMessageId` is transient) is out of scope.

## Acceptance criteria and validation

- After a message-click branch, composer send remains available and reconstructs context as today.
- Review, side-chat, compact, save as skill, nested branch, and agent controls stay disabled until that send clears `pendingHistoryReplay`.
- Composer plan-first remains a valid reconstruct send.

Validation after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Session actionability + branch refusal | `npm run test:module -- session_renderer` | pass (441 tests) |
| Workspace follow-on gates | `npm run test:module -- workspace_page` | pass (455 tests) |
| Renderer types | `npm run typecheck:web` | pass |

Full portable `npm test` was not run locally; PR Gate CI is authoritative.

## Review focus

- Send and plan-first must stay available after bind; other ACP-facing actions must not.
- `pendingHistoryReplay` and `isPending` should use the same follow-on gate.
- No new persisted state.