### PR TITLE
ci(change-impact): register compute Windows runtime files

### DIFF
--- a/scripts/ci/change-impact.json
+++ b/scripts/ci/change-impact.json
@@ -119,6 +119,8 @@
         "src/main/app-lifecycle.ts",
         "src/main/artifacts/durability.ts",
         "src/main/cli-install/launcher.ts",
+        "src/main/compute/connection-adapters.ts",
+        "src/main/compute/credential-vault.ts",
         "src/main/compute/scp-runner.ts",
         "src/main/compute/ssh-runner.ts",
         "src/main/crash-diagnostics.ts",


### PR DESCRIPTION
## Summary

- register `src/main/compute/connection-adapters.ts` as Windows-sensitive runtime code
- register `src/main/compute/credential-vault.ts` as Windows-sensitive runtime code
- restore explicit Windows runtime signal coverage after PR #1375

## Verification

- Baseline reproduction: `npm test -- scripts/ci/classify-pr-changes.test.ts -t "covers every production source file with an explicit Windows runtime signal"` (failed with exactly the two uncovered files above)
- `npm test -- scripts/ci/classify-pr-changes.test.ts -t "covers every production source file with an explicit Windows runtime signal"`
- `npm test -- scripts/ci/validate-module-impact.test.ts`

## Maintainer note

`scripts/ci/change-impact.json` is a protected CI control-plane file. Merging this PR requires a maintainer ruleset bypass.