### PR TITLE
feat(composer): emphasize active Specialist

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -570,13 +570,16 @@ colors communicate a successful or failed probe/migration result.
 - Icon buttons: `Button variant="ghost" size="icon"`, `size-8`.
 - Workspace composer shell: `px-4 pb-2`; center content in `mx-auto w-full max-w-4xl`, then use `px-1 md:px-3` so the composer text track aligns with the message content after the form's own `px-3`.
 - Workspace composer form: `relative z-10 flex flex-col gap-2 rounded-2xl bg-bg-000 px-3 py-2 shadow-card-opaque`.
-- When a runnable Specialist is bound, keep the composer at its normal height and add a persistent
-  two-pixel multicolor edge. Mount one finite exterior bloom when the selected Specialist changes;
-  suppress that bloom under `prefers-reduced-motion` while retaining the static edge.
+- When a runnable Specialist is bound, keep the composer at its normal height and use a two-pixel
+  edge in the exact color of that Specialist's avatar tile. When the selection changes, fade only
+  that edge from transparent to opaque; do not add a multicolor gradient, glow, or geometry motion.
+  Under `prefers-reduced-motion`, show the final edge immediately.
 - Show the active Specialist as a compact, truncating toolbar control rather than a new composer row.
   Its popover searches display name, stable name, and description; supports Arrow Up/Down, Home/End,
   Enter, and ordinary pointer selection; fits within the viewport on narrow screens; and exposes the
-  full untruncated name through the control's accessible label.
+  full untruncated name through the control's accessible label. Cap the expanded control at `10rem`
+  and collapse it to the avatar alone when the composer container is `32rem` wide or narrower. Keep
+  the popover at or below `16rem` so it does not dominate compressed three-column layouts.
 - During a normal running root turn, the primary composer submit action captures the current doc,
   attachments, permission profile, Specialist, Session, Agent Frame, and Message Branch into a
   renderer-memory queue instead of overlapping the active runtime prompt. The queue drains one item

--- a/docs/design.md
+++ b/docs/design.md
@@ -570,6 +570,13 @@ colors communicate a successful or failed probe/migration result.
 - Icon buttons: `Button variant="ghost" size="icon"`, `size-8`.
 - Workspace composer shell: `px-4 pb-2`; center content in `mx-auto w-full max-w-4xl`, then use `px-1 md:px-3` so the composer text track aligns with the message content after the form's own `px-3`.
 - Workspace composer form: `relative z-10 flex flex-col gap-2 rounded-2xl bg-bg-000 px-3 py-2 shadow-card-opaque`.
+- When a runnable Specialist is bound, keep the composer at its normal height and add a persistent
+  two-pixel multicolor edge. Mount one finite exterior bloom when the selected Specialist changes;
+  suppress that bloom under `prefers-reduced-motion` while retaining the static edge.
+- Show the active Specialist as a compact, truncating toolbar control rather than a new composer row.
+  Its popover searches display name, stable name, and description; supports Arrow Up/Down, Home/End,
+  Enter, and ordinary pointer selection; fits within the viewport on narrow screens; and exposes the
+  full untruncated name through the control's accessible label.
 - During a normal running root turn, the primary composer submit action captures the current doc,
   attachments, permission profile, Specialist, Session, Agent Frame, and Message Branch into a
   renderer-memory queue instead of overlapping the active runtime prompt. The queue drains one item

--- a/docs/design.md
+++ b/docs/design.md
@@ -574,12 +574,11 @@ colors communicate a successful or failed probe/migration result.
   edge in the exact color of that Specialist's avatar tile. When the selection changes, fade only
   that edge from transparent to opaque; do not add a multicolor gradient, glow, or geometry motion.
   Under `prefers-reduced-motion`, show the final edge immediately.
-- Show the active Specialist as a compact, truncating toolbar control rather than a new composer row.
-  Its popover searches display name, stable name, and description; supports Arrow Up/Down, Home/End,
-  Enter, and ordinary pointer selection; fits within the viewport on narrow screens; and exposes the
-  full untruncated name through the control's accessible label. Cap the expanded control at `10rem`
-  and collapse it to the avatar alone when the composer container is `32rem` wide or narrower. Keep
-  the popover at or below `16rem` so it does not dominate compressed three-column layouts.
+- Show the active Specialist as its avatar tile in a standard `size-8` composer icon button, with no
+  separate label, arrow, border, or persistent gray container. The button's accessible label exposes
+  the full Specialist name. Its popover searches display name, stable name, and description; supports
+  Arrow Up/Down, Home/End, Enter, and ordinary pointer selection; fits within the viewport on narrow
+  screens; and stays at or below `16rem` so it does not dominate compressed three-column layouts.
 - During a normal running root turn, the primary composer submit action captures the current doc,
   attachments, permission profile, Specialist, Session, Agent Frame, and Message Branch into a
   renderer-memory queue instead of overlapping the active runtime prompt. The queue drains one item

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -295,66 +295,25 @@
 }
 
 @layer components {
-  @keyframes composer-specialist-activation {
-    0% {
+  @keyframes composer-specialist-color-in {
+    from {
       opacity: 0;
-      transform: scale(0.985);
     }
-    24% {
-      opacity: 0.82;
-    }
-    62% {
-      opacity: 0.32;
-      transform: scale(1.012);
-    }
-    100% {
-      opacity: 0;
-      transform: scale(1.025);
+    to {
+      opacity: 1;
     }
   }
 
-  /* Active Specialist: a persistent two-pixel edge plus one finite activation bloom. */
-  .composer-specialist-enhanced {
-    isolation: isolate;
-  }
-
-  .composer-specialist-enhanced::after {
+  /* Match the composer edge to the selected Specialist avatar with one quiet color fade. */
+  .composer-specialist-color-in {
     position: absolute;
     z-index: 2;
-    inset: -1px;
-    border-radius: inherit;
-    padding: 2px;
-    background: linear-gradient(
-      112deg,
-      var(--chart-2),
-      var(--chart-1) 32%,
-      var(--chart-4) 68%,
-      var(--chart-3)
-    );
-    content: '';
-    pointer-events: none;
-    -webkit-mask:
-      linear-gradient(#000 0 0) content-box,
-      linear-gradient(#000 0 0);
-    mask:
-      linear-gradient(#000 0 0) content-box,
-      linear-gradient(#000 0 0);
-    -webkit-mask-composite: xor;
-    mask-composite: exclude;
-  }
-
-  .composer-specialist-activation {
-    position: absolute;
-    z-index: 0;
     inset: 0;
+    border-width: 2px;
+    border-style: solid;
     border-radius: inherit;
-    box-shadow:
-      -0.6rem 0 1.5rem color-mix(in srgb, var(--chart-1) 52%, transparent),
-      0.6rem 0 1.5rem color-mix(in srgb, var(--chart-4) 48%, transparent),
-      0 0 0.9rem color-mix(in srgb, var(--chart-2) 42%, transparent);
-    content: '';
     pointer-events: none;
-    animation: composer-specialist-activation 1.35s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+    animation: composer-specialist-color-in 480ms ease-out both;
   }
 
   /* Theme-independent edge treatment for compact horizontal navigation and chip rails. */
@@ -729,9 +688,9 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .composer-specialist-activation {
-      display: none;
+    .composer-specialist-color-in {
       animation: none;
+      opacity: 1;
     }
 
     .home-session-title-running::after {

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -295,6 +295,68 @@
 }
 
 @layer components {
+  @keyframes composer-specialist-activation {
+    0% {
+      opacity: 0;
+      transform: scale(0.985);
+    }
+    24% {
+      opacity: 0.82;
+    }
+    62% {
+      opacity: 0.32;
+      transform: scale(1.012);
+    }
+    100% {
+      opacity: 0;
+      transform: scale(1.025);
+    }
+  }
+
+  /* Active Specialist: a persistent two-pixel edge plus one finite activation bloom. */
+  .composer-specialist-enhanced {
+    isolation: isolate;
+  }
+
+  .composer-specialist-enhanced::after {
+    position: absolute;
+    z-index: 2;
+    inset: -1px;
+    border-radius: inherit;
+    padding: 2px;
+    background: linear-gradient(
+      112deg,
+      var(--chart-2),
+      var(--chart-1) 32%,
+      var(--chart-4) 68%,
+      var(--chart-3)
+    );
+    content: '';
+    pointer-events: none;
+    -webkit-mask:
+      linear-gradient(#000 0 0) content-box,
+      linear-gradient(#000 0 0);
+    mask:
+      linear-gradient(#000 0 0) content-box,
+      linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+  }
+
+  .composer-specialist-activation {
+    position: absolute;
+    z-index: 0;
+    inset: 0;
+    border-radius: inherit;
+    box-shadow:
+      -0.6rem 0 1.5rem color-mix(in srgb, var(--chart-1) 52%, transparent),
+      0.6rem 0 1.5rem color-mix(in srgb, var(--chart-4) 48%, transparent),
+      0 0 0.9rem color-mix(in srgb, var(--chart-2) 42%, transparent);
+    content: '';
+    pointer-events: none;
+    animation: composer-specialist-activation 1.35s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  }
+
   /* Theme-independent edge treatment for compact horizontal navigation and chip rails. */
   .scroll-fade-x {
     -webkit-mask-image: var(--scroll-fade-x-mask, none);
@@ -667,6 +729,11 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
+    .composer-specialist-activation {
+      display: none;
+      animation: none;
+    }
+
     .home-session-title-running::after {
       animation: none;
       display: none;

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -1976,6 +1976,7 @@
   "Choose another Specialist before sending a message.": "メッセージを送信する前に、別のスペシャリストを選択してください。",
   "Your draft is preserved.": "下書きは保持されています。",
   "Choose Specialist": "スペシャリストを選択",
+  "Choose Specialist: {{name}}": "Specialist を選択：{{name}}",
   "Package verified": "パッケージを検証済み",
   "The download, checksum, and package structure passed verification. You can continue with installation.": "ダウンロード、チェックサム、パッケージ構造の検証に合格しました。インストールを続行できます。",
   "Verify and save": "確認して保存する",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -2037,6 +2037,7 @@
   "Choose another Specialist before sending a message.": "请先切换到其他 Specialist，再发送消息。",
   "Your draft is preserved.": "你的草稿已保留。",
   "Choose Specialist": "选择 Specialist",
+  "Choose Specialist: {{name}}": "选择 Specialist：{{name}}",
   "Package verified": "包验证成功",
   "The download, checksum, and package structure passed verification. You can continue with installation.": "下载内容、校验和与包结构均已通过验证，可以继续安装。",
   "Verify and save": "验证并保存",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -2034,6 +2034,7 @@
   "Choose another Specialist before sending a message.": "請先切換至其他 Specialist，再傳送訊息。",
   "Your draft is preserved.": "你的草稿已保留。",
   "Choose Specialist": "選擇 Specialist",
+  "Choose Specialist: {{name}}": "選擇 Specialist：{{name}}",
   "Package verified": "套件驗證成功",
   "The download, checksum, and package structure passed verification. You can continue with installation.": "下載內容、校驗和與套件結構均已通過驗證，可以繼續安裝。",
   "Verify and save": "驗證並儲存",

--- a/src/renderer/src/pages/settings/specialist-icons.ts
+++ b/src/renderer/src/pages/settings/specialist-icons.ts
@@ -21,6 +21,9 @@ export const AVATAR_COLORS: Record<string, string> = {
 }
 export const DEFAULT_AVATAR_COLOR = '#ececea'
 
+export const getAvatarColor = (colorKey?: string): string =>
+  colorKey ? (AVATAR_COLORS[colorKey] ?? DEFAULT_AVATAR_COLOR) : DEFAULT_AVATAR_COLOR
+
 export const AVATAR_ICONS: Record<string, LucideIcon> = {
   brain: Brain,
   beaker: Beaker,
@@ -31,5 +34,5 @@ export const AVATAR_ICONS: Record<string, LucideIcon> = {
 }
 
 export const getAvatarStyle = (colorKey?: string): CSSProperties => ({
-  background: colorKey ? (AVATAR_COLORS[colorKey] ?? DEFAULT_AVATAR_COLOR) : DEFAULT_AVATAR_COLOR
+  background: getAvatarColor(colorKey)
 })

--- a/src/renderer/src/pages/workspace/ComposerSpecialistPicker.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerSpecialistPicker.interaction.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { act, type PropsWithChildren } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { fireEvent } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SpecialistListItem } from '../../../../shared/specialist'
+import { useSpecialistStore } from '@/stores/specialist-store'
+import { ComposerSpecialistPicker } from './ComposerSpecialistPicker'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// The picker behavior is owned by this component; flatten the Radix portal so keyboard and
+// filtering semantics can be exercised directly in jsdom.
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: PropsWithChildren): React.JSX.Element => <div>{children}</div>,
+  PopoverTrigger: ({ children }: PropsWithChildren): React.JSX.Element => <>{children}</>,
+  PopoverContent: ({
+    children
+  }: PropsWithChildren<{
+    side?: string
+    align?: string
+    sideOffset?: number
+    collisionPadding?: number
+    onOpenAutoFocus?: (event: Event) => void
+  }>): React.JSX.Element => <div>{children}</div>
+}))
+
+const specialist = (id: string, name: string, displayName?: string): SpecialistListItem => ({
+  kind: 'custom',
+  id,
+  name,
+  displayName,
+  description: `${displayName ?? name} description`,
+  systemPrompt: 'Help the user.',
+  enabled: true,
+  capabilityMode: 'full',
+  fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+  selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+  revision: 1
+})
+
+let container: HTMLDivElement
+let root: Root
+
+const renderPicker = (props?: {
+  selectedId?: string
+  readOnly?: boolean
+  onChange?: (id: string | undefined) => void
+}): void => {
+  act(() => {
+    root.render(
+      <ComposerSpecialistPicker
+        selectedId={props?.selectedId ?? 'researcher'}
+        readOnly={props?.readOnly}
+        onChange={props?.onChange ?? vi.fn()}
+      />
+    )
+  })
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  useSpecialistStore.setState({
+    items: [
+      specialist(
+        'researcher',
+        'RESEARCHER',
+        'A deliberately long Specialist display name that must never widen the composer'
+      ),
+      specialist('statistician', 'STATISTICIAN', 'Statistician')
+    ],
+    isLoaded: true
+  })
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('ComposerSpecialistPicker', () => {
+  it('truncates the visual label while preserving the full accessible name', () => {
+    renderPicker()
+
+    const trigger = container.querySelector<HTMLButtonElement>(
+      '[data-testid="composer-specialist-picker-trigger"]'
+    )!
+    expect(trigger.getAttribute('aria-label')).toContain(
+      'A deliberately long Specialist display name that must never widen the composer'
+    )
+    expect(trigger.className).toContain('max-w-[min(46cqw,15rem)]')
+    expect(trigger.querySelector('.truncate')?.textContent).toContain('deliberately long')
+  })
+
+  it('filters by Specialist metadata and selects the result with Enter', () => {
+    const onChange = vi.fn()
+    renderPicker({ onChange })
+    const input = container.querySelector<HTMLInputElement>('[role="combobox"]')!
+
+    act(() => {
+      fireEvent.change(input, { target: { value: 'STATISTICIAN' } })
+    })
+
+    expect(
+      container.querySelector('[data-testid="composer-specialist-option-researcher"]')
+    ).toBeNull()
+    expect(
+      container.querySelector('[data-testid="composer-specialist-option-statistician"]')
+    ).not.toBeNull()
+
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+    expect(onChange).toHaveBeenCalledWith('statistician')
+  })
+
+  it('supports Arrow navigation and exposes a mobile-safe touch target without adding height', () => {
+    const onChange = vi.fn()
+    renderPicker({ onChange })
+    const input = container.querySelector<HTMLInputElement>('[role="combobox"]')!
+
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    })
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+
+    expect(onChange).toHaveBeenCalledWith('researcher')
+    const trigger = container.querySelector<HTMLButtonElement>(
+      '[data-testid="composer-specialist-picker-trigger"]'
+    )!
+    expect(trigger.className).toContain('h-8')
+    expect(trigger.className).toContain('[@media(pointer:coarse)]:before:-inset-y-1.5')
+  })
+
+  it('disables the switcher when Agent controls are read-only', () => {
+    renderPicker({ readOnly: true })
+    expect(
+      container.querySelector<HTMLButtonElement>(
+        '[data-testid="composer-specialist-picker-trigger"]'
+      )?.disabled
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/pages/workspace/ComposerSpecialistPicker.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerSpecialistPicker.interaction.test.tsx
@@ -82,7 +82,7 @@ afterEach(() => {
 })
 
 describe('ComposerSpecialistPicker', () => {
-  it('truncates the visual label while preserving the full accessible name', () => {
+  it('shows only the avatar while preserving the full accessible name', () => {
     renderPicker()
 
     const trigger = container.querySelector<HTMLButtonElement>(
@@ -91,9 +91,9 @@ describe('ComposerSpecialistPicker', () => {
     expect(trigger.getAttribute('aria-label')).toContain(
       'A deliberately long Specialist display name that must never widen the composer'
     )
-    expect(trigger.className).toContain('max-w-40')
-    expect(trigger.querySelector('.truncate')?.textContent).toContain('deliberately long')
-    expect(trigger.querySelector('.truncate')?.className).toContain('@max-[32rem]/composer:hidden')
+    expect(trigger.className).toContain('w-8')
+    expect(trigger.className.split(' ')).not.toContain('bg-bg-200')
+    expect(trigger.textContent).toBe('')
   })
 
   it('filters by Specialist metadata and selects the result with Enter', () => {
@@ -135,7 +135,6 @@ describe('ComposerSpecialistPicker', () => {
       '[data-testid="composer-specialist-picker-trigger"]'
     )!
     expect(trigger.className).toContain('h-8')
-    expect(trigger.className).toContain('@max-[32rem]/composer:w-8')
     expect(trigger.className).toContain('[@media(pointer:coarse)]:before:-inset-y-1.5')
   })
 

--- a/src/renderer/src/pages/workspace/ComposerSpecialistPicker.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerSpecialistPicker.interaction.test.tsx
@@ -147,4 +147,23 @@ describe('ComposerSpecialistPicker', () => {
       )?.disabled
     ).toBe(true)
   })
+
+  it('namespaces the synthetic Main Agent option away from valid Specialist ids', () => {
+    useSpecialistStore.setState((state) => ({
+      items: [...state.items, specialist('main-agent', 'MAIN_AGENT_SPECIALIST')]
+    }))
+    const onChange = vi.fn()
+    renderPicker({ onChange })
+
+    const mainOption = container.querySelector<HTMLButtonElement>(
+      '[data-testid="composer-specialist-option-__main-agent-option"]'
+    )!
+    const specialistOption = container.querySelector<HTMLButtonElement>(
+      '[data-testid="composer-specialist-option-main-agent"]'
+    )!
+    expect(mainOption.id).not.toBe(specialistOption.id)
+
+    act(() => mainOption.click())
+    expect(onChange).toHaveBeenCalledWith(undefined)
+  })
 })

--- a/src/renderer/src/pages/workspace/ComposerSpecialistPicker.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerSpecialistPicker.interaction.test.tsx
@@ -91,8 +91,9 @@ describe('ComposerSpecialistPicker', () => {
     expect(trigger.getAttribute('aria-label')).toContain(
       'A deliberately long Specialist display name that must never widen the composer'
     )
-    expect(trigger.className).toContain('max-w-[min(46cqw,15rem)]')
+    expect(trigger.className).toContain('max-w-40')
     expect(trigger.querySelector('.truncate')?.textContent).toContain('deliberately long')
+    expect(trigger.querySelector('.truncate')?.className).toContain('@max-[32rem]/composer:hidden')
   })
 
   it('filters by Specialist metadata and selects the result with Enter', () => {
@@ -134,6 +135,7 @@ describe('ComposerSpecialistPicker', () => {
       '[data-testid="composer-specialist-picker-trigger"]'
     )!
     expect(trigger.className).toContain('h-8')
+    expect(trigger.className).toContain('@max-[32rem]/composer:w-8')
     expect(trigger.className).toContain('[@media(pointer:coarse)]:before:-inset-y-1.5')
   })
 

--- a/src/renderer/src/pages/workspace/ComposerSpecialistPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerSpecialistPicker.tsx
@@ -1,0 +1,253 @@
+import { Check, ChevronDown, Search } from 'lucide-react'
+import { useEffect, useId, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+import { useSpecialistStore } from '@/stores/specialist-store'
+import type { SpecialistListItem } from '../../../../shared/specialist'
+import { SpecialistAvatar } from '../settings/specialist-avatar'
+
+type RunnableSpecialistItem = Exclude<SpecialistListItem, { kind: 'reviewer' }>
+
+type ComposerSpecialistPickerProps = {
+  selectedId: string | undefined
+  unavailable?: boolean
+  readOnly?: boolean
+  onChange: (specialistId: string | undefined) => void
+}
+
+type PickerOption = {
+  key: string
+  id: string | undefined
+  name: string
+  searchText: string
+  specialist?: RunnableSpecialistItem
+}
+
+const ComposerSpecialistPicker = ({
+  selectedId,
+  unavailable = false,
+  readOnly = false,
+  onChange
+}: ComposerSpecialistPickerProps): React.JSX.Element | null => {
+  const { t } = useTranslation()
+  const items = useSpecialistStore((state) => state.items)
+  const isLoaded = useSpecialistStore((state) => state.isLoaded)
+  const load = useSpecialistStore((state) => state.load)
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [activeIndex, setActiveIndex] = useState(0)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const listboxId = useId()
+
+  useEffect(() => {
+    if (open && !isLoaded && typeof window.api?.specialist?.list === 'function') {
+      void load()
+    }
+  }, [isLoaded, load, open])
+
+  useEffect(() => {
+    if (typeof window.api?.specialist?.onCatalogChanged !== 'function') return
+    return window.api.specialist.onCatalogChanged(() => {
+      void load()
+    })
+  }, [load])
+
+  if (!selectedId) return null
+
+  const selected = items.find(
+    (item): item is RunnableSpecialistItem => item.kind !== 'reviewer' && item.id === selectedId
+  )
+  const selectedName = selected ? (selected.displayName ?? selected.name) : t('Unavailable')
+  const enabledSpecialists = items.filter(
+    (item): item is RunnableSpecialistItem => item.kind !== 'reviewer' && item.enabled
+  )
+  const options: PickerOption[] = [
+    {
+      key: 'main-agent',
+      id: undefined,
+      name: t('Main Agent'),
+      searchText: t('Main Agent')
+    },
+    ...enabledSpecialists.map((specialist) => ({
+      key: specialist.id,
+      id: specialist.id,
+      name: specialist.displayName ?? specialist.name,
+      searchText: `${specialist.displayName ?? ''} ${specialist.name} ${specialist.description}`,
+      specialist
+    }))
+  ]
+  const normalizedQuery = query.trim().toLocaleLowerCase()
+  const filteredOptions = normalizedQuery
+    ? options.filter((option) => option.searchText.toLocaleLowerCase().includes(normalizedQuery))
+    : options
+  const safeActiveIndex = Math.min(activeIndex, Math.max(filteredOptions.length - 1, 0))
+  const activeOption = filteredOptions[safeActiveIndex]
+
+  const chooseOption = (option: PickerOption): void => {
+    onChange(option.id)
+    setOpen(false)
+  }
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen)
+        if (nextOpen) {
+          setQuery('')
+          const selectedIndex = options.findIndex((option) => option.id === selectedId)
+          setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0)
+        }
+      }}
+    >
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={readOnly}
+          className={cn(
+            "relative flex h-8 min-w-0 max-w-[min(46cqw,15rem)] shrink items-center gap-1.5 rounded-lg border bg-bg-200 px-1.5 text-left text-[12px] font-medium text-text-100 transition-colors before:absolute before:content-[''] hover:bg-bg-300 hover:text-text-000 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 [@media(pointer:coarse)]:before:-inset-y-1.5 [@media(pointer:coarse)]:before:inset-x-0",
+            unavailable ? 'border-warning-100 text-warning-900' : 'border-border-200'
+          )}
+          aria-label={t('Choose Specialist: {{name}}', { name: selectedName })}
+          data-testid="composer-specialist-picker-trigger"
+        >
+          {selected ? (
+            <SpecialistAvatar iconKey={selected.iconKey} colorKey={selected.colorKey} />
+          ) : (
+            <span
+              className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-bg-300 text-[11px]"
+              aria-hidden="true"
+            >
+              —
+            </span>
+          )}
+          <span className="min-w-0 truncate">{selectedName}</span>
+          <ChevronDown
+            className="size-3.5 shrink-0 opacity-60"
+            strokeWidth={2}
+            aria-hidden="true"
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="start"
+        sideOffset={8}
+        collisionPadding={8}
+        className="w-[min(22rem,calc(100vw-1rem))] rounded-xl border border-border-200 bg-bg-000 p-1.5 text-text-000 shadow-menu"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          inputRef.current?.focus()
+        }}
+      >
+        <div className="px-2 pt-1 pb-1.5 text-[11px] font-medium text-text-300">
+          {t('Choose Specialist')}
+        </div>
+        <div className="relative">
+          <Search
+            className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-text-300"
+            strokeWidth={2}
+            aria-hidden="true"
+          />
+          <input
+            ref={inputRef}
+            type="search"
+            role="combobox"
+            value={query}
+            onChange={(event) => {
+              setQuery(event.currentTarget.value)
+              setActiveIndex(0)
+            }}
+            onKeyDown={(event) => {
+              if (filteredOptions.length === 0) return
+              if (event.key === 'ArrowDown') {
+                event.preventDefault()
+                setActiveIndex((safeActiveIndex + 1) % filteredOptions.length)
+              } else if (event.key === 'ArrowUp') {
+                event.preventDefault()
+                setActiveIndex(
+                  (safeActiveIndex - 1 + filteredOptions.length) % filteredOptions.length
+                )
+              } else if (event.key === 'Home') {
+                event.preventDefault()
+                setActiveIndex(0)
+              } else if (event.key === 'End') {
+                event.preventDefault()
+                setActiveIndex(filteredOptions.length - 1)
+              } else if (event.key === 'Enter' && activeOption) {
+                event.preventDefault()
+                chooseOption(activeOption)
+              }
+            }}
+            placeholder={t('Search specialists…')}
+            aria-label={t('Search specialists')}
+            aria-expanded={open}
+            aria-controls={listboxId}
+            aria-activedescendant={activeOption ? `${listboxId}-${activeOption.key}` : undefined}
+            autoComplete="off"
+            className="h-9 w-full rounded-lg border border-border-200 bg-bg-000 pr-2 pl-8 text-[13px] text-text-000 outline-none placeholder:text-text-300 focus:border-ring focus:ring-[3px] focus:ring-ring/20 [@media(pointer:coarse)]:h-11"
+          />
+        </div>
+        <div
+          id={listboxId}
+          role="listbox"
+          aria-label={t('Choose Specialist')}
+          className="mt-1 max-h-[min(45vh,18rem)] overflow-y-auto overscroll-contain"
+        >
+          {filteredOptions.length > 0 ? (
+            filteredOptions.map((option, index) => {
+              const isActive = index === safeActiveIndex
+              const isSelected = option.id === selectedId
+              return (
+                <button
+                  key={option.key}
+                  id={`${listboxId}-${option.key}`}
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  className={cn(
+                    'flex min-h-9 w-full items-center gap-2 rounded-lg px-2 py-1 text-left text-[13px] text-text-100 outline-none [@media(pointer:coarse)]:min-h-11',
+                    isActive && 'bg-bg-200 text-text-000'
+                  )}
+                  onPointerMove={() => setActiveIndex(index)}
+                  onClick={() => chooseOption(option)}
+                  data-testid={`composer-specialist-option-${option.key}`}
+                >
+                  {option.specialist ? (
+                    <SpecialistAvatar
+                      iconKey={option.specialist.iconKey}
+                      colorKey={option.specialist.colorKey}
+                    />
+                  ) : (
+                    <span
+                      className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-bg-300 text-[11px]"
+                      aria-hidden="true"
+                    >
+                      —
+                    </span>
+                  )}
+                  <span className="min-w-0 flex-1 truncate">{option.name}</span>
+                  {isSelected ? (
+                    <Check
+                      className="size-4 shrink-0 text-primary"
+                      strokeWidth={2}
+                      aria-hidden="true"
+                    />
+                  ) : null}
+                </button>
+              )
+            })
+          ) : (
+            <div role="status" className="px-2 py-5 text-center text-[12px] text-text-300">
+              {t('No Specialists match “{{query}}”.', { query: query.trim() })}
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export { ComposerSpecialistPicker }

--- a/src/renderer/src/pages/workspace/ComposerSpecialistPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerSpecialistPicker.tsx
@@ -65,7 +65,7 @@ const ComposerSpecialistPicker = ({
   )
   const options: PickerOption[] = [
     {
-      key: 'main-agent',
+      key: '__main-agent-option',
       id: undefined,
       name: t('Main Agent'),
       searchText: t('Main Agent')

--- a/src/renderer/src/pages/workspace/ComposerSpecialistPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerSpecialistPicker.tsx
@@ -107,7 +107,7 @@ const ComposerSpecialistPicker = ({
           type="button"
           disabled={readOnly}
           className={cn(
-            "relative flex h-8 min-w-0 max-w-[min(46cqw,15rem)] shrink items-center gap-1.5 rounded-lg border bg-bg-200 px-1.5 text-left text-[12px] font-medium text-text-100 transition-colors before:absolute before:content-[''] hover:bg-bg-300 hover:text-text-000 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 [@media(pointer:coarse)]:before:-inset-y-1.5 [@media(pointer:coarse)]:before:inset-x-0",
+            "relative flex h-8 min-w-0 max-w-40 shrink items-center gap-1.5 rounded-lg border bg-bg-200 px-1.5 text-left text-[12px] font-medium text-text-100 transition-colors before:absolute before:content-[''] hover:bg-bg-300 hover:text-text-000 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 [@media(pointer:coarse)]:before:-inset-y-1.5 [@media(pointer:coarse)]:before:inset-x-0 @max-[32rem]/composer:w-8 @max-[32rem]/composer:shrink-0 @max-[32rem]/composer:justify-center @max-[32rem]/composer:px-0",
             unavailable ? 'border-warning-100 text-warning-900' : 'border-border-200'
           )}
           aria-label={t('Choose Specialist: {{name}}', { name: selectedName })}
@@ -123,9 +123,9 @@ const ComposerSpecialistPicker = ({
               —
             </span>
           )}
-          <span className="min-w-0 truncate">{selectedName}</span>
+          <span className="min-w-0 truncate @max-[32rem]/composer:hidden">{selectedName}</span>
           <ChevronDown
-            className="size-3.5 shrink-0 opacity-60"
+            className="size-3.5 shrink-0 opacity-60 @max-[32rem]/composer:hidden"
             strokeWidth={2}
             aria-hidden="true"
           />
@@ -136,7 +136,7 @@ const ComposerSpecialistPicker = ({
         align="start"
         sideOffset={8}
         collisionPadding={8}
-        className="w-[min(22rem,calc(100vw-1rem))] rounded-xl border border-border-200 bg-bg-000 p-1.5 text-text-000 shadow-menu"
+        className="w-[min(16rem,calc(100vw-1rem))] rounded-xl border border-border-200 bg-bg-000 p-1.5 text-text-000 shadow-menu"
         onOpenAutoFocus={(event) => {
           event.preventDefault()
           inputRef.current?.focus()

--- a/src/renderer/src/pages/workspace/ComposerSpecialistPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerSpecialistPicker.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronDown, Search } from 'lucide-react'
+import { Check, Search } from 'lucide-react'
 import { useEffect, useId, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -12,7 +12,6 @@ type RunnableSpecialistItem = Exclude<SpecialistListItem, { kind: 'reviewer' }>
 
 type ComposerSpecialistPickerProps = {
   selectedId: string | undefined
-  unavailable?: boolean
   readOnly?: boolean
   onChange: (specialistId: string | undefined) => void
 }
@@ -27,7 +26,6 @@ type PickerOption = {
 
 const ComposerSpecialistPicker = ({
   selectedId,
-  unavailable = false,
   readOnly = false,
   onChange
 }: ComposerSpecialistPickerProps): React.JSX.Element | null => {
@@ -106,10 +104,7 @@ const ComposerSpecialistPicker = ({
         <button
           type="button"
           disabled={readOnly}
-          className={cn(
-            "relative flex h-8 min-w-0 max-w-40 shrink items-center gap-1.5 rounded-lg border bg-bg-200 px-1.5 text-left text-[12px] font-medium text-text-100 transition-colors before:absolute before:content-[''] hover:bg-bg-300 hover:text-text-000 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 [@media(pointer:coarse)]:before:-inset-y-1.5 [@media(pointer:coarse)]:before:inset-x-0 @max-[32rem]/composer:w-8 @max-[32rem]/composer:shrink-0 @max-[32rem]/composer:justify-center @max-[32rem]/composer:px-0",
-            unavailable ? 'border-warning-100 text-warning-900' : 'border-border-200'
-          )}
+          className="relative flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-text-300 transition-colors before:absolute before:content-[''] hover:bg-bg-200 hover:text-text-100 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 [@media(pointer:coarse)]:before:-inset-y-1.5 [@media(pointer:coarse)]:before:inset-x-0"
           aria-label={t('Choose Specialist: {{name}}', { name: selectedName })}
           data-testid="composer-specialist-picker-trigger"
         >
@@ -123,12 +118,6 @@ const ComposerSpecialistPicker = ({
               —
             </span>
           )}
-          <span className="min-w-0 truncate @max-[32rem]/composer:hidden">{selectedName}</span>
-          <ChevronDown
-            className="size-3.5 shrink-0 opacity-60 @max-[32rem]/composer:hidden"
-            strokeWidth={2}
-            aria-hidden="true"
-          />
         </button>
       </PopoverTrigger>
       <PopoverContent

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -3841,6 +3841,7 @@ describe('ConversationPanel fix loop lock', () => {
           id: 'available-specialist',
           name: 'AVAILABLE_SPECIALIST',
           displayName: 'Available Specialist',
+          colorKey: 'purple',
           description: 'Available for this session.',
           systemPrompt: 'Help the user.',
           enabled: true,
@@ -3859,9 +3860,9 @@ describe('ConversationPanel fix loop lock', () => {
       }
     })
 
-    const composer = container.querySelector<HTMLFormElement>('[data-specialist-enhanced="true"]')
-    expect(composer?.classList.contains('composer-specialist-enhanced')).toBe(true)
-    expect(composer?.querySelector('.composer-specialist-activation')).not.toBeNull()
+    const composer = container.querySelector<HTMLFormElement>('[data-specialist-color="#ede9fe"]')
+    const specialistEdge = composer?.querySelector<HTMLElement>('.composer-specialist-color-in')
+    expect(specialistEdge?.style.borderColor).toBe('rgb(237, 233, 254)')
     expect(
       container
         .querySelector('[data-testid="composer-specialist-picker-trigger"]')

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -20,6 +20,7 @@ import type { ActivePlanProjection } from '../../../../shared/session-plan/contr
 import type { DelegatedQuestionRequest } from '../../../../shared/session-persistence'
 import { VISION_MODEL_NOT_CONFIGURED_MESSAGE } from '../../../../shared/run-error-classification'
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+import { useSpecialistStore } from '@/stores/specialist-store'
 
 // React's act() refuses to run unless the environment opts in to act-aware scheduling.
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -596,6 +597,7 @@ beforeEach(() => {
   respondToSessionPlanMock.mockReset().mockResolvedValue(undefined)
   usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
   useSettingsStore.setState(createInitialSettingsState())
+  useSpecialistStore.setState({ items: [], isLoaded: true })
   mockHasRunningJobs = false
   mockAllJobs = []
 })
@@ -3829,6 +3831,42 @@ describe('ConversationPanel fix loop lock', () => {
     })
 
     expect(container.querySelector('[data-testid="specialist-unavailable-notice"]')).toBeNull()
+  })
+
+  it('adds the enhanced composer edge and compact picker for an available Specialist', () => {
+    useSpecialistStore.setState({
+      items: [
+        {
+          kind: 'custom',
+          id: 'available-specialist',
+          name: 'AVAILABLE_SPECIALIST',
+          displayName: 'Available Specialist',
+          description: 'Available for this session.',
+          systemPrompt: 'Help the user.',
+          enabled: true,
+          capabilityMode: 'full',
+          fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+          selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+          revision: 1
+        }
+      ],
+      isLoaded: true
+    })
+
+    renderPanel({
+      view: {
+        activeSession: { ...idleSession, specialistId: 'available-specialist' }
+      }
+    })
+
+    const composer = container.querySelector<HTMLFormElement>('[data-specialist-enhanced="true"]')
+    expect(composer?.classList.contains('composer-specialist-enhanced')).toBe(true)
+    expect(composer?.querySelector('.composer-specialist-activation')).not.toBeNull()
+    expect(
+      container
+        .querySelector('[data-testid="composer-specialist-picker-trigger"]')
+        ?.getAttribute('aria-label')
+    ).toContain('Available Specialist')
   })
 
   it('cancel button is visible when session is running and calls onCancelRun', () => {

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -1635,7 +1635,6 @@ const ConversationPanel = ({
 
                         <ComposerSpecialistPicker
                           selectedId={specialistId}
-                          unavailable={specialistUnavailable}
                           readOnly={!canChangeAgentControls}
                           onChange={onSpecialistChange}
                         />

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -78,6 +78,7 @@ import { ComposerContextUsage } from './ComposerContextUsage'
 import { ComposerMessageQueueContent, ComposerMessageQueueTrigger } from './ComposerMessageQueue'
 import { ContextWindowDialog } from './ContextWindowDialog'
 import { ComposerModelPicker } from './ComposerModelPicker'
+import { ComposerSpecialistPicker } from './ComposerSpecialistPicker'
 import { ComposerYourFilesMenu } from './ComposerYourFilesMenu'
 import { PermissionApprovalControls } from './PermissionApprovalControls'
 import { normalizeRunFailureError } from './error-report'
@@ -555,6 +556,10 @@ const ConversationPanel = ({
   const activeSpecialist = specialistId
     ? specialistItems.find((item) => item.kind === 'custom' && item.id === specialistId)
     : undefined
+  const selectedSpecialist = specialistId
+    ? specialistItems.find((item) => item.kind !== 'reviewer' && item.id === specialistId)
+    : undefined
+  const specialistComposerEnhanced = Boolean(selectedSpecialist && !specialistUnavailable)
   const effectiveSpecialistSkills = resolveEffectiveSpecialistSkills(
     activeSpecialist?.kind === 'custom' ? activeSpecialist : undefined,
     catalogSkills.map((skill) => ({
@@ -1199,11 +1204,20 @@ const ConversationPanel = ({
                     hidden={ordinaryComposerBlocked}
                     className={cn(
                       'relative z-10 flex flex-col gap-2 rounded-2xl border border-border-200 bg-bg-000 px-3 py-2',
+                      specialistComposerEnhanced && 'composer-specialist-enhanced',
                       ordinaryComposerBlocked && 'hidden'
                     )}
+                    data-specialist-enhanced={specialistComposerEnhanced || undefined}
                     onSubmit={(event) => event.preventDefault()}
                     {...dropZoneProps}
                   >
+                    {specialistComposerEnhanced && selectedSpecialist ? (
+                      <span
+                        key={selectedSpecialist.id}
+                        className="composer-specialist-activation"
+                        aria-hidden="true"
+                      />
+                    ) : null}
                     {/* File-drag overlay is scoped to the composer input card only. */}
                     {isDragging ? (
                       <FileDropOverlay label={t('Drop files to attach')} className="rounded-2xl" />
@@ -1613,6 +1627,13 @@ const ConversationPanel = ({
                           specialistUnavailable={specialistUnavailable}
                           onSpecialistChange={onSpecialistChange}
                           openRequest={agentControlsOpenRequest}
+                        />
+
+                        <ComposerSpecialistPicker
+                          selectedId={specialistId}
+                          unavailable={specialistUnavailable}
+                          readOnly={!canChangeAgentControls}
+                          onChange={onSpecialistChange}
                         />
 
                         {/* Compatibility indicator for an explicit user selection while a turn is

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -107,6 +107,7 @@ import { hasMainConversation, type SideChatController } from './use-side-chat-co
 import type { WorkspaceComposerController } from './workspace-composer-controller'
 import type { WorkspaceConversationController } from './workspace-conversation-controller'
 import type { WorkspaceSessionController } from './workspace-session-controller'
+import { getAvatarColor } from '../settings/specialist-icons'
 
 const localizeVisionRunFailure = (
   error: string | null | undefined,
@@ -559,7 +560,10 @@ const ConversationPanel = ({
   const selectedSpecialist = specialistId
     ? specialistItems.find((item) => item.kind !== 'reviewer' && item.id === specialistId)
     : undefined
-  const specialistComposerEnhanced = Boolean(selectedSpecialist && !specialistUnavailable)
+  const specialistComposerColor =
+    selectedSpecialist && selectedSpecialist.kind !== 'reviewer' && !specialistUnavailable
+      ? getAvatarColor(selectedSpecialist.colorKey)
+      : undefined
   const effectiveSpecialistSkills = resolveEffectiveSpecialistSkills(
     activeSpecialist?.kind === 'custom' ? activeSpecialist : undefined,
     catalogSkills.map((skill) => ({
@@ -1204,17 +1208,17 @@ const ConversationPanel = ({
                     hidden={ordinaryComposerBlocked}
                     className={cn(
                       'relative z-10 flex flex-col gap-2 rounded-2xl border border-border-200 bg-bg-000 px-3 py-2',
-                      specialistComposerEnhanced && 'composer-specialist-enhanced',
                       ordinaryComposerBlocked && 'hidden'
                     )}
-                    data-specialist-enhanced={specialistComposerEnhanced || undefined}
+                    data-specialist-color={specialistComposerColor}
                     onSubmit={(event) => event.preventDefault()}
                     {...dropZoneProps}
                   >
-                    {specialistComposerEnhanced && selectedSpecialist ? (
+                    {specialistComposerColor && selectedSpecialist ? (
                       <span
                         key={selectedSpecialist.id}
-                        className="composer-specialist-activation"
+                        className="composer-specialist-color-in"
+                        style={{ borderColor: specialistComposerColor }}
                         aria-hidden="true"
                       />
                     ) : null}


### PR DESCRIPTION
## Problem

Switching to a Specialist is easy to miss at the Session level. The existing Specialist entry is nested in Agent controls, and a permanently expanded selector would make the composer taller and becomes difficult to scan with a large Specialist catalog.

## Proposed change

- Give the composer a two-pixel edge in the selected Specialist avatar's exact tile color. Switching fades only that color from transparent to opaque, with no gradient, glow, or geometry motion.
- Add a logo-only Specialist icon button to the existing toolbar, with no persistent gray container, visible name, or arrow. Its popover searches display name, stable name, and description, and can switch back to Main Agent.
- Keep the same `size-8` control on desktop and narrow screens: 16rem viewport-constrained popover, bounded result list, and coarse-pointer hit-area expansion without increasing toolbar height.
- Support combobox/listbox semantics, full accessible naming for truncated labels, Arrow Up/Down, Home/End, Enter, focus restoration, and `prefers-reduced-motion`.

## Scope and non-goals

- Reuses the existing Specialist catalog and `selectSpecialist` action.
- No persistence, schema, session-data, or historical-data compatibility changes.
- No new enum or state-machine values.
- Does not change Specialist runtime selection semantics or run-time mutability rules.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Picker filtering, keyboard selection, logo-only accessible naming, touch sizing, composer activation, key/ARIA collision handling, and existing composer interactions -> `npx vitest run src/renderer/src/pages/workspace/ComposerSpecialistPicker.interaction.test.tsx src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx src/renderer/src/i18n/resources.test.ts` -> 204 passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint` -> passed.
- Formatting -> targeted `npx prettier --check ...` -> passed.
- Web/Tailwind production integration -> `npm run build:web` -> passed; generated CSS contains the new edge/activation rules.

`test:affected:explain` conservatively selected full mode because `docs/design.md` has no module owner. Per maintainer direction, the complete local `npm test` suite was not run; PR Gate is authoritative for the full test plan.

Uncovered locally: Electron visual and accessibility E2E were not run. The responsive dimensions and edge alignment were refined from maintainer screenshots; PR CI remains the final authority for platform lanes.

## Review focus

- Whether the avatar-color edge is clear enough without competing with focus/error states.
- Keyboard and screen-reader behavior of the searchable popover.
- Toolbar spacing and icon affordance in narrow three-column layouts.
