### PR TITLE
fix(web-service): prevent remote information disclosure

### DIFF
--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -185,6 +185,28 @@ describe('startWebHttpServer', () => {
       error: { code: 'invalid-command-arguments', message: 'Invalid project request.' }
     })
 
+    directInvoke.mockRejectedValueOnce(
+      new Error('SQLITE_CANTOPEN: /Users/private/.open-science/open-science.db')
+    )
+    const internalErrorResponse = await fetch(
+      `http://127.0.0.1:${server.port}/rpc/projects%3Alist`,
+      {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer test-token',
+          'content-type': 'application/json',
+          'x-open-science-client': 'direct-client'
+        },
+        body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
+      }
+    )
+    expect(internalErrorResponse.status).toBe(500)
+    expect(await internalErrorResponse.json()).toEqual({
+      protocolVersion: WEB_RPC_PROTOCOL_VERSION,
+      ok: false,
+      error: { code: 'command-failed', message: 'Internal server error' }
+    })
+
     const directSignal = directInvoke.mock.calls[0]?.[1].callerLease.signal
     firstSocket.close()
     await new Promise<void>((resolve) => firstSocket.once('close', () => resolve()))
@@ -931,6 +953,7 @@ describe('startWebHttpServer', () => {
       releaseClient: vi.fn(),
       dispose: vi.fn()
     }
+    const authorizeHttp = vi.fn().mockResolvedValue(authorizedExternalAccess())
     const server = await startTestWebHttpServer({
       host: '127.0.0.1',
       port: 0,
@@ -946,7 +969,7 @@ describe('startWebHttpServer', () => {
         }
       },
       externalAccess: {
-        authorizeHttp: vi.fn().mockResolvedValue(authorizedExternalAccess()),
+        authorizeHttp,
         authorizeWebSocket: vi.fn().mockResolvedValue({})
       },
       bootstrap: {
@@ -984,16 +1007,29 @@ describe('startWebHttpServer', () => {
     }
     const remoteBootstrap = await fetch(bootstrapUrl)
     expect(remoteBootstrap.status).toBe(200)
-    expect(await remoteBootstrap.json()).toMatchObject({
+    const remoteBootstrapBody = await remoteBootstrap.json()
+    expect(remoteBootstrapBody).toMatchObject({
       rpcChannels: [remotelyAvailableChannel],
       restrictedRpcChannels: localOnlyChannels
     })
+    expect(remoteBootstrapBody).not.toHaveProperty('configRoot')
 
     const localBootstrap = await fetch(bootstrapUrl, {
       headers: { authorization: 'Bearer local-token' }
     })
     expect(localBootstrap.status).toBe(200)
-    expect(await localBootstrap.json()).toMatchObject({ rpcChannels, restrictedRpcChannels: [] })
+    expect(await localBootstrap.json()).toMatchObject({
+      configRoot: '/fake/root',
+      rpcChannels,
+      restrictedRpcChannels: []
+    })
+
+    authorizeHttp.mockRejectedValueOnce(
+      new Error('EACCES: /Users/private/.open-science/remote-access.json')
+    )
+    const failedBootstrap = await fetch(bootstrapUrl)
+    expect(failedBootstrap.status).toBe(500)
+    expect(await failedBootstrap.json()).toEqual({ error: 'Internal server error' })
 
     for (const channel of localOnlyChannels) {
       const remoteResponse = await fetch(rpcUrl(channel), {
@@ -1643,6 +1679,19 @@ describe('startWebHttpServer', () => {
     expect(missingProject.status).toBe(404)
     expect(await missingProject.json()).toEqual({
       error: { code: 'project_not_found', message: 'Project not found: missing' }
+    })
+
+    tasks.startRun.mockRejectedValueOnce(
+      new Error('SQLITE_CANTOPEN: /Users/private/.open-science/open-science.db')
+    )
+    const internalError = await fetch(`${base}/api/v1/runs`, {
+      method: 'POST',
+      headers: { ...headers, 'content-type': 'application/json' },
+      body: JSON.stringify({ project: 'project-1', prompt: 'Research this.' })
+    })
+    expect(internalError.status).toBe(500)
+    expect(await internalError.json()).toEqual({
+      error: { code: 'internal_error', message: 'Internal server error' }
     })
 
     const malformed = await fetch(`${base}/api/v1/runs`, {

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -10,7 +10,10 @@ import { gzip } from 'node:zlib'
 import { net } from 'electron'
 import { WebSocket, WebSocketServer } from 'ws'
 
-import { toApplicationCommandErrorEnvelope } from '../../shared/application-command-contract'
+import {
+  ApplicationCommandError,
+  toApplicationCommandErrorEnvelope
+} from '../../shared/application-command-contract'
 import { PlanCommandError } from '../../shared/session-plan/contract'
 import type { WebRpcErrorCode } from '../../shared/web-rpc-contract'
 import {
@@ -41,6 +44,7 @@ import { TaskApiError, type HeadlessTaskApi } from './task-api'
 
 const MAX_RPC_BODY_BYTES = 64 * 1024 * 1024
 const MIN_GZIP_BYTES = 1_024
+const INTERNAL_SERVER_ERROR_MESSAGE = 'Internal server error'
 const gzipAsync = promisify(gzip)
 
 // Remote Browser access is an application session, not authority over native host lifecycle and
@@ -102,6 +106,26 @@ type WebServerOptions = {
     versions: { electron: string; chrome: string; node: string }
   }
 }
+
+// Keep the remote payload allowlisted: the full bootstrap also carries host-local diagnostics.
+const remoteWebBootstrap = ({
+  appName,
+  appVersion,
+  platform,
+  versions
+}: WebServerOptions['bootstrap']): Omit<WebServerOptions['bootstrap'], 'configRoot'> => ({
+  appName,
+  appVersion,
+  platform,
+  versions
+})
+
+const publicApplicationCommandError = (
+  error: unknown
+): ReturnType<typeof toApplicationCommandErrorEnvelope> =>
+  error instanceof ApplicationCommandError
+    ? toApplicationCommandErrorEnvelope(error)
+    : { code: 'command-failed', message: INTERNAL_SERVER_ERROR_MESSAGE }
 
 export type ExternalWebAccessAuthorization = {
   kind: 'authorized' | 'authorized-pairing-manager'
@@ -281,7 +305,7 @@ const taskError = (response: ServerResponse, error: unknown): void => {
   json(response, 500, {
     error: {
       code: 'internal_error',
-      message: error instanceof Error ? error.message : 'Internal server error'
+      message: INTERNAL_SERVER_ERROR_MESSAGE
     }
   })
 }
@@ -553,7 +577,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
           ? []
           : options.applicationCommands.remoteWeb.rejectedCommandNames()
         json(response, 200, {
-          ...options.bootstrap,
+          ...(auth.ok ? options.bootstrap : remoteWebBootstrap(options.bootstrap)),
           rpcProtocolVersion: WEB_RPC_PROTOCOL_VERSION,
           rpcChannels,
           eventStream: internalEventStream.cursor(),
@@ -689,7 +713,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
             webRpcError(response, 401, 'invalid_request', error.message)
             return
           }
-          const publicError = toApplicationCommandErrorEnvelope(error)
+          const publicError = publicApplicationCommandError(error)
           webRpcError(response, 500, publicError.code, publicError.message)
         }
         return
@@ -709,9 +733,9 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       }
 
       response.writeHead(404).end()
-    } catch (error) {
+    } catch {
       json(response, 500, {
-        error: error instanceof Error ? error.message : 'Internal server error'
+        error: INTERNAL_SERVER_ERROR_MESSAGE
       })
     }
   })


### PR DESCRIPTION
## Problem

Remote Web bootstrap responses included the host's absolute config root. Unexpected failures in the Task API, Web RPC, and top-level HTTP handler also returned internal exception messages, which could disclose host paths and runtime or database details to an authorized remote browser.

## Proposed change

- Build remote bootstrap payloads from an explicit allowlist and retain configRoot only for locally authenticated Web clients.
- Return a stable Internal server error message for unclassified HTTP 500 responses.
- Preserve explicit public TaskApiError, PlanCommandError, and ApplicationCommandError codes and messages.
- Add regression coverage for remote bootstrap filtering, each unclassified 500 path, and local/public-error compatibility.

## Scope and non-goals

- No response fields are added. Remote bootstrap removes configRoot; local bootstrap is unchanged.
- No database schema, persisted format, data model, enum/status, or user interaction changes.
- No change to 4xx validation/authentication errors or explicitly classified domain errors.

## Acceptance criteria and validation

Final checks were run after the last material edit.

- Remote bootstrap filtering and local compatibility -> npm test -- src/main/web-service/http-server.test.ts -> passed (18/18).
- Unclassified Task API, Web RPC, and top-level HTTP 500 redaction -> npm test -- src/main/web-service/http-server.test.ts -> passed (18/18).
- Public domain-error compatibility -> npm test -- src/main/web-service/http-server.test.ts -> passed (18/18).
- Main-process types -> npm run typecheck:node -> passed.
- Lint -> npm run lint -> passed.
- Test impact selection -> npm run test:affected:explain -- --base origin/main --head HEAD -> selected the full suite because src/main/web-service/http-server.ts has no registered module owner. The full local suite was intentionally not run; PR Gate is the final authority.

## Review focus

- Confirm configRoot remains available only to locally token-authenticated bootstrap requests.
- Confirm only explicitly typed domain errors retain their messages while unexpected exceptions use the stable generic message.
- Confirm the focused test set covers the final diff; CI covers the fail-closed full plan and platform lanes.

Remaining local uncertainty: no live tunnel/browser E2E was run; the HTTP integration tests exercise both local-token and external-authorization request paths directly.
