### PR TITLE
fix(notebook): reap micromamba trees before retry

### DIFF
--- a/src/main/notebook/package-mutation.test.ts
+++ b/src/main/notebook/package-mutation.test.ts
@@ -386,6 +386,7 @@ describe('NotebookPackageMutationOwner', () => {
       },
       installPackages: vi.fn(async (_request, deps) => {
         deps?.onBeforeSpawn?.()
+        deps?.onChild?.(process.pid)
         throw childFailure
       })
     })

--- a/src/main/notebook/package-mutation.ts
+++ b/src/main/notebook/package-mutation.ts
@@ -245,6 +245,15 @@ class NotebookPackageMutationOwner {
       if (isRepairQuarantineError(error)) retainForRecovery = true
       if (isChildUnconfirmedError(error)) {
         retainForRecovery = true
+        // The direct installer PID may already be gone while an unenumerated/reparented descendant
+        // continues writing. Replace that stale identity with the existing no-verifiable-PID state so
+        // startup recovery blocks instead of clearing the journal after probing only the dead parent.
+        try {
+          recordSpawnIntentSync(runtimeRoot, operationId)
+        } catch {
+          // Retain the prior sidecar + journal as the best durable evidence still available. The
+          // in-process recovery block below remains authoritative for this app lifetime.
+        }
         this.options.blockUnconfirmedChild(target)
       }
       throw error

--- a/src/main/notebook/provisioner-runtime.test.ts
+++ b/src/main/notebook/provisioner-runtime.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -209,6 +209,70 @@ describe('runMicromamba', () => {
     await expect(running).rejects.toThrow(/^Runtime setup cancelled\.$/)
   })
 
+  it('does not settle cancellation while a descendant can still write the target prefix', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'os-mm-cancel-tree-'))
+    const descendantPidPath = join(dir, 'descendant.pid')
+    const prefixWritePath = join(dir, 'prefix-write.log')
+    const workerSource = [
+      "const { appendFileSync } = require('node:fs')",
+      "setInterval(() => appendFileSync(process.env.MM_PREFIX_WRITE_PATH, 'write\\n'), 20)"
+    ].join(';')
+    const supervisorSource = [
+      "const { spawn } = require('node:child_process')",
+      "const { writeFileSync } = require('node:fs')",
+      "const worker = spawn(process.execPath, ['-e', process.env.MM_WORKER_SOURCE], { detached: true, env: process.env, stdio: 'ignore' })",
+      'writeFileSync(process.env.MM_DESCENDANT_PID_PATH, String(worker.pid))',
+      'worker.unref()',
+      'setInterval(() => {}, 1000)'
+    ].join(';')
+    const abort = new AbortController()
+    const running = runMicromamba(
+      [process.execPath, '-e', supervisorSource],
+      {
+        MM_DESCENDANT_PID_PATH: descendantPidPath,
+        MM_PREFIX_WRITE_PATH: prefixWritePath,
+        MM_WORKER_SOURCE: workerSource
+      },
+      abort.signal
+    )
+    let descendantPid: number | undefined
+
+    try {
+      await vi.waitFor(() => {
+        expect(existsSync(descendantPidPath)).toBe(true)
+        descendantPid = Number(readFileSync(descendantPidPath, 'utf8'))
+        expect(descendantPid).toBeGreaterThan(0)
+        expect(readFileSync(prefixWritePath, 'utf8')).toContain('write')
+      })
+
+      abort.abort()
+      const error = await running.catch((reason: unknown) => reason)
+      expect(error).toBeInstanceOf(Error)
+
+      const writesWhenCancellationSettled = readFileSync(prefixWritePath, 'utf8')
+      await new Promise((resolve) => setTimeout(resolve, 150))
+      if ((error as Error).message === 'Runtime setup cancelled.') {
+        // A normal cancellation is safe only after every discovered writer has stopped.
+        expect(readFileSync(prefixWritePath, 'utf8')).toBe(writesWhenCancellationSettled)
+        expect(() => process.kill(descendantPid as number, 0)).toThrow()
+      } else {
+        // If the platform cannot prove the tree is gone, fail closed so the journal is retained and a
+        // retry cannot race this still-possible writer.
+        expect((error as Error).message).toContain('RUNTIME_CHILD_UNCONFIRMED')
+      }
+    } finally {
+      abort.abort()
+      await running.catch(() => undefined)
+      if (descendantPid !== undefined) {
+        try {
+          process.kill(descendantPid, 'SIGKILL')
+        } catch {
+          // The fixed path already reaped it.
+        }
+      }
+    }
+  })
+
   it('kills the child and rejects (fail-closed) when onChild throws (PID recording failed)', async () => {
     // If recording the child fails, running on would strand an unrecorded orphan. runMicromamba must
     // kill the just-spawned child and reject rather than proceed. A long-lived child proves the kill.
@@ -261,31 +325,26 @@ describe('runMicromamba', () => {
 })
 
 describe('killAndConfirmExit', () => {
-  it('resolves true once the child actually exits', async () => {
-    const listeners: Record<string, () => void> = {}
-    const fake = {
-      exitCode: null,
-      signalCode: null,
-      kill: () => true,
-      once: (event: string, cb: () => void) => {
-        listeners[event] = cb
-      }
-    } as never
-    const pending = killAndConfirmExit(fake, 1000)
-    listeners.exit?.() // the child exits
-    expect(await pending).toBe(true)
+  it('resolves true when the whole process tree is confirmed reaped', async () => {
+    const terminateTree = vi.fn(async () => ({ reaped: true }))
+    const child = { exitCode: null, signalCode: null } as never
+
+    await expect(killAndConfirmExit(child, terminateTree)).resolves.toBe(true)
+    expect(terminateTree).toHaveBeenCalledWith(child)
   })
 
-  it('resolves false when exit cannot be confirmed within the deadline (SIGTERM ignored)', async () => {
-    // A child that never emits exit (kill ignored) — the deadline elapses and we report UNconfirmed so
-    // the caller retains the recovery evidence rather than clearing it under a possibly-live worker.
-    const fake = {
-      exitCode: null,
-      signalCode: null,
-      kill: () => false,
-      once: () => undefined // never fires exit
-    } as never
-    expect(await killAndConfirmExit(fake, 40)).toBe(false)
+  it('resolves false when the whole process tree cannot be confirmed reaped', async () => {
+    const terminateTree = vi.fn(async () => ({ reaped: false }))
+    const child = { exitCode: null, signalCode: null } as never
+    expect(await killAndConfirmExit(child, terminateTree)).toBe(false)
+  })
+
+  it('fails closed without probing a stale PID once the direct child has already exited', async () => {
+    const terminateTree = vi.fn(async () => ({ reaped: true }))
+    const child = { exitCode: 0, signalCode: null } as never
+
+    await expect(killAndConfirmExit(child, terminateTree)).resolves.toBe(false)
+    expect(terminateTree).not.toHaveBeenCalled()
   })
 })
 

--- a/src/main/notebook/provisioner-runtime.ts
+++ b/src/main/notebook/provisioner-runtime.ts
@@ -4,13 +4,14 @@ import { createReadStream, realpathSync } from 'node:fs'
 import { basename, resolve, sep, win32 } from 'node:path'
 import { promisify } from 'node:util'
 
+import { terminateProcessTree } from '../process-tree'
 import { condaActivatedPath } from './runtime-paths'
 
 const execFileAsync = promisify(execFile)
 
-// Marker on the error thrown when a child could NOT be confirmed stopped after a recording failure. The
-// caller must then RETAIN the crash-recovery evidence (sidecar + journal) rather than clearing it, since
-// a live worker may still be writing the prefix. See killAndConfirmExit / runMicromamba.
+// Marker on the error thrown when a child tree could NOT be confirmed stopped after cancellation,
+// timeout, or a recording failure. The caller must then RETAIN the crash-recovery evidence (sidecar +
+// journal) rather than clearing it, since a live worker may still be writing the prefix.
 export const CHILD_UNCONFIRMED = 'RUNTIME_CHILD_UNCONFIRMED'
 export const isChildUnconfirmedError = (error: unknown): boolean =>
   error instanceof Error && error.message.includes(CHILD_UNCONFIRMED)
@@ -48,42 +49,19 @@ export const micromambaDiagnosticText = (error: unknown): string => {
     .join('\n')
 }
 
-// Kills a child and resolves ONLY once it has actually exited, escalating SIGTERM -> SIGKILL. Resolves
-// true when exit is confirmed, false when it can't be confirmed within the deadline (SIGTERM can be
-// ignored/delayed and kill() can return false, so a single kill() is not proof of exit). The caller
-// decides what an unconfirmed exit means (here: retain recovery evidence, fail closed).
-export const killAndConfirmExit = (child: ChildProcess, deadlineMs = 5000): Promise<boolean> =>
-  new Promise((resolve) => {
-    if (child.exitCode !== null || child.signalCode !== null) {
-      resolve(true)
-      return
-    }
-    let done = false
-    const finish = (confirmed: boolean): void => {
-      if (done) return
-      done = true
-      clearTimeout(escalate)
-      clearTimeout(giveUp)
-      resolve(confirmed)
-    }
-    child.once('exit', () => finish(true))
-    try {
-      child.kill('SIGTERM')
-    } catch {
-      // Already gone or un-signalable; the exit listener / timeout below still resolves.
-    }
-    const escalate = setTimeout(
-      () => {
-        try {
-          child.kill('SIGKILL')
-        } catch {
-          // Best-effort escalation.
-        }
-      },
-      Math.floor(deadlineMs / 2)
-    )
-    const giveUp = setTimeout(() => finish(false), deadlineMs)
-  })
+// Kills the whole child process tree and resolves true ONLY when the shared cross-platform reaper can
+// confirm it is gone. The caller decides what an unconfirmed teardown means (here: retain recovery
+// evidence and fail closed so no second writer can race the surviving tree).
+export const killAndConfirmExit = (
+  child: ChildProcess,
+  terminateTree: typeof terminateProcessTree = terminateProcessTree
+): Promise<boolean> => {
+  // Once the root has exited, its descendants may already be reparented and the original PID may be
+  // reused. We can no longer enumerate that tree safely, so fail closed instead of probing/killing by a
+  // stale PID or claiming the descendants are gone.
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(false)
+  return terminateTree(child).then(({ reaped }) => reaped)
+}
 
 // Merges extra vars over the current process env for a subprocess (used to inject the CA-bundle vars
 // so an online provision behind an enterprise TLS proxy verifies HTTPS). Undefined → inherit as-is.
@@ -247,6 +225,7 @@ export const runMicromamba = (
     let timedOut = false
     let cancelled = false
     let settled = false
+    let termination: Promise<boolean> | undefined
     const startedAt = Date.now()
     const appendTail = (current: string, chunk: unknown): string =>
       `${current}${String(chunk)}`.slice(-maxTail)
@@ -257,20 +236,38 @@ export const runMicromamba = (
       stderr = appendTail(stderr, chunk)
     })
 
-    const timeout = setTimeout(() => {
-      timedOut = true
-      child.kill()
-    }, timeoutMs)
-    const onAbort = (): void => {
-      cancelled = true
-      child.kill()
-    }
-    signal?.addEventListener('abort', onAbort, { once: true })
-
     const cleanup = (): void => {
       clearTimeout(timeout)
       signal?.removeEventListener('abort', onAbort)
     }
+    const rejectUnconfirmed = (): void => {
+      if (settled) return
+      settled = true
+      cleanup()
+      const reason = cancelled ? 'cancellation' : timedOut ? 'timeout' : 'PID recording failure'
+      reject(
+        new Error(
+          `${CHILD_UNCONFIRMED}: the micromamba process tree could not be confirmed stopped after ` +
+            `${reason}; leaving the operation for recovery to block.`
+        )
+      )
+    }
+    const terminateTree = (): Promise<boolean> => {
+      termination ??= killAndConfirmExit(child)
+      void termination.then((confirmed) => {
+        if (!confirmed) rejectUnconfirmed()
+      })
+      return termination
+    }
+    const timeout = setTimeout(() => {
+      timedOut = true
+      void terminateTree()
+    }, timeoutMs)
+    const onAbort = (): void => {
+      cancelled = true
+      void terminateTree()
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
     // Full tails go into the error's structured `data` for the logs; the user-facing message gets only
     // this short excerpt. micromamba writes its package plan (thousands of pinned specs) to stdout, so
     // embedding the raw tails in the message floods the provisioning banner — prefer the stderr reason,
@@ -283,7 +280,7 @@ export const runMicromamba = (
     }
 
     // Record the spawned PID for crash-recovery supervision. If recording FAILS, fail closed: kill the
-    // child and only settle once it is CONFIRMED gone — the close handler then rejects with
+    // whole tree and only settle once it is CONFIRMED gone — the close handler then rejects with
     // recordingError. If it can't be confirmed, reject with the CHILD_UNCONFIRMED marker so the caller
     // RETAINS the recovery evidence (a worker may still be writing) instead of clearing it.
     let recordingError: Error | undefined
@@ -296,29 +293,29 @@ export const runMicromamba = (
             error instanceof Error ? error.message : String(error)
           }`
         )
-        void killAndConfirmExit(child).then((confirmed) => {
-          if (!confirmed && !settled) {
-            settled = true
-            cleanup()
-            reject(
-              new Error(
-                `${CHILD_UNCONFIRMED}: recording failed and the runtime worker could not be confirmed ` +
-                  'stopped; leaving the operation for recovery to block.'
-              )
-            )
-          }
-          // If confirmed, the close handler below rejects with recordingError.
-        })
+        void terminateTree()
+        // If confirmed, the close handler below rejects with recordingError. If not, terminateTree's
+        // shared rejection path retains the operation for recovery.
       }
     }
 
-    child.once('error', (error) => {
+    child.once('error', async (error) => {
+      if (settled) return
+      if (termination && !(await termination)) {
+        rejectUnconfirmed()
+        return
+      }
       if (settled) return
       settled = true
       cleanup()
       reject(new Error(`micromamba failed to start (${argv.join(' ')}): ${error.message}`))
     })
-    child.once('close', (code, closeSignal) => {
+    child.once('close', async (code, closeSignal) => {
+      if (settled) return
+      if (termination && !(await termination)) {
+        rejectUnconfirmed()
+        return
+      }
       if (settled) return
       settled = true
       cleanup()

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -40,6 +40,7 @@ import { validateAndSeedPack } from './pack-content'
 import { micromambaCacheLockKey, selectMicromambaCache } from './micromamba-cache'
 import {
   operationJournalPath,
+  readOperationChild,
   recordOperationChildSync,
   recordSpawnIntentSync,
   RuntimeOperationJournal,
@@ -2103,9 +2104,10 @@ describe('DefaultRuntimeProvisioner prefix-block self-guard (startup gate path)'
     const prefix = envPrefix(root, DEFAULT_PY_ENV)
     const blocked = new Set<string>()
     let attempts = 0
-    const runArgv = vi.fn(async (_argv: string[], _s, _c, onBeforeSpawn) => {
+    const runArgv = vi.fn(async (_argv: string[], _s, onChild, onBeforeSpawn) => {
       attempts += 1
       onBeforeSpawn?.()
+      onChild?.(4242) // convert the sidecar to a PID before the tree becomes unconfirmed
       throw new Error(`create failed: ${CHILD_UNCONFIRMED}`) // worker could not be confirmed stopped
     })
     const deps = makeDeps(root, {
@@ -2118,10 +2120,11 @@ describe('DefaultRuntimeProvisioner prefix-block self-guard (startup gate path)'
     // First attempt fails unconfirmed and blocks the prefix in-process.
     await expect(provisioner.provisionPython(() => {})).rejects.toThrow(CHILD_UNCONFIRMED)
     expect(blocked.has(prefix)).toBe(true)
-    // The retained journal record is kept (guards next boot); the sidecar intent is not cleared.
-    expect(
-      (await RuntimeOperationJournal.forPath(operationJournalPath(root)).pending()).length
-    ).toBe(1)
+    // The retained journal record is kept (guards next boot); the sidecar is downgraded from the dead
+    // direct PID to the existing no-verifiable-PID state because a descendant may still be alive.
+    const retained = await RuntimeOperationJournal.forPath(operationJournalPath(root)).pending()
+    expect(retained).toHaveLength(1)
+    expect(readOperationChild(root, retained[0].operationId)).toMatchObject({ spawning: true })
 
     // An in-session retry is now REFUSED by the block — it never spawns a second, racing create.
     await expect(provisioner.provisionPython(() => {})).rejects.toThrow(/RUNTIME_RECOVERY_BLOCKED/)
@@ -2129,11 +2132,10 @@ describe('DefaultRuntimeProvisioner prefix-block self-guard (startup gate path)'
   })
 
   it('force Reset refuses a prefix this process left live-unconfirmed (no PID to kill)', async () => {
-    // After an unconfirmed-child failure THIS process recorded, the orphan's PID never landed, so there is
-    // nothing to probe/kill. A force Reset would rm + rebuild the prefix — potentially out from under that
-    // still-live orphan — so it must REFUSE this session (the block only clears on restart, when the
-    // spawning process is provably gone). Distinct from the {spawning}-sidecar test above, where the
-    // intent was injected WITHOUT this process attempting the spawn, so Reset proceeds.
+    // After an unconfirmed-child failure THIS process recorded, there is no PID that proves the whole tree
+    // is gone. A force Reset would rm + rebuild the prefix — potentially out from under a still-live
+    // descendant — so it must REFUSE this session. The retained {spawning} sidecar also guards later
+    // startups until recovery has authoritative evidence. Distinct from the injected sidecar case above.
     const root = makeRoot()
     const blocked = new Set<string>()
     const runArgv = vi.fn(async (_argv: string[], _s, _c, onBeforeSpawn) => {

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -304,11 +304,10 @@ export interface RuntimeProvisioner {
 export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
   private provisioning = false
   private legacyCacheCleanupComplete = false
-  // Prefixes whose write in THIS process failed with a child we could not confirm stopped (a worker MAY
-  // still be live). A force Reset must NOT delete+rebuild such a prefix — its orphan can't be probed
-  // (its PID never landed) and could still be writing. Per-process (not persisted), so it is empty after
-  // a restart: post-restart the spawning process is provably gone, and a force Reset then proceeds (the
-  // documented escape hatch for an otherwise-stuck µs-window orphan). See clearQuarantine.
+  // Prefixes whose write in THIS process failed with a child tree we could not confirm stopped (a worker
+  // MAY still be live). A force Reset must NOT delete+rebuild such a prefix. This in-memory set guards the
+  // current app lifetime; the retained journal plus downgraded {spawning} sidecar guard later startups
+  // until recovery has authoritative evidence that the unknown writer is gone. See clearQuarantine.
   private readonly liveUnconfirmedPrefixes = new Set<string>()
 
   constructor(private readonly deps: ProvisionerDeps) {}
@@ -549,10 +548,20 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     try {
       await run(onBeforeSpawn, onChild)
     } catch (error) {
-      // A recording failure whose child could NOT be confirmed stopped: a worker may still be writing
-      // the prefix, so KEEP the sidecar + journal record (recovery blocks) instead of clearing them.
+      // A teardown whose child tree could NOT be confirmed stopped: a worker may still be writing the
+      // prefix, so KEEP the sidecar + journal record (recovery blocks) instead of clearing them.
       if (isChildUnconfirmedError(error)) {
         retainForRecovery = true
+        // The recorded direct PID is no longer sufficient evidence: it may already be gone while an
+        // unenumerated/reparented descendant keeps writing. Convert the sidecar back to the existing
+        // no-verifiable-PID state so startup recovery also blocks until a machine reboot proves the
+        // unknown tree gone, instead of probing the dead parent and reconciling under its survivor.
+        try {
+          recordSpawnIntentSync(this.deps.root, operationId)
+        } catch {
+          // Keep the prior sidecar + journal as the best evidence still available. The in-process block
+          // below remains authoritative for this app lifetime when the filesystem cannot be updated.
+        }
         // Block the prefix IN THIS PROCESS now — not just via the retained journal entry, which only
         // gates the next boot. Otherwise an in-session Retry would pass assertPrefixWritable and begin()
         // a SECOND op (begin() does not reject a same-runtime record), spawning a worker that races the

--- a/src/main/process-tree.test.ts
+++ b/src/main/process-tree.test.ts
@@ -227,7 +227,7 @@ describe('terminateProcessTree (posix)', () => {
     expect(killSpy).toHaveBeenCalledWith(1000, 'SIGKILL')
   })
 
-  it('still kills the direct child when ps fails to produce a tree', async () => {
+  it('kills the direct child but reports unconfirmed when ps fails to produce a tree', async () => {
     setPlatform('darwin')
     const ps = new FakePs()
     spawnMock.mockReturnValueOnce(ps)
@@ -242,9 +242,28 @@ describe('terminateProcessTree (posix)', () => {
     await Promise.resolve()
 
     child.emit('exit', 0, null)
-    // No descendants discovered and the child exited, so the (degenerate) tree counts as reaped.
-    await expect(pending).resolves.toEqual({ reaped: true })
+    // The direct child exited, but failed discovery cannot prove there were no surviving descendants.
+    await expect(pending).resolves.toEqual({ reaped: false })
     expect(killSpy).not.toHaveBeenCalledWith(expect.any(Number), 'SIGTERM')
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('reports unconfirmed when ps exits non-zero without a process snapshot', async () => {
+    setPlatform('linux')
+    const ps = new FakePs()
+    spawnMock.mockReturnValueOnce(ps)
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw esrch()
+    })
+    const child = new FakeChild(1234)
+
+    const pending = terminateProcessTree(child as never)
+    ps.emit('close', 1)
+    await Promise.resolve()
+    await Promise.resolve()
+    child.emit('exit', 0, null)
+
+    await expect(pending).resolves.toEqual({ reaped: false })
     expect(child.kill).toHaveBeenCalledWith('SIGTERM')
   })
 

--- a/src/main/process-tree.ts
+++ b/src/main/process-tree.ts
@@ -91,26 +91,29 @@ const waitForExit = (child: ChildProcess, ms: number): Promise<boolean> =>
     })
   })
 
-// Best-effort descendant discovery on POSIX. Node's child.kill() signals only the immediate child, so a
+type DescendantSnapshot = { pids: number[]; complete: boolean }
+
+// Descendant discovery on POSIX. Node's child.kill() signals only the immediate child, so a
 // grandchild (conda, the claude CLI, a package manager) would otherwise be orphaned exactly as it would
 // on Windows without taskkill /T. `ps -A -o pid=,ppid=` is available on both macOS (BSD) and Linux
-// (procps); any failure resolves to an empty list so we still fall back to killing the direct child.
-const collectDescendantPids = (rootPid: number): Promise<number[]> =>
-  new Promise<number[]>((resolve) => {
+// (procps). A failed snapshot is marked incomplete: we still kill the direct child, but MUST NOT report
+// the whole tree reaped when we could not enumerate it.
+const collectDescendantPids = (rootPid: number): Promise<DescendantSnapshot> =>
+  new Promise<DescendantSnapshot>((resolve) => {
     let ps: ChildProcess
     try {
       ps = spawn('ps', ['-A', '-o', 'pid=,ppid='], { windowsHide: true })
     } catch {
-      resolve([])
+      resolve({ pids: [], complete: false })
       return
     }
 
     let out = ''
     let settled = false
-    const finish = (pids: number[]): void => {
+    const finish = (snapshot: DescendantSnapshot): void => {
       if (settled) return
       settled = true
-      resolve(pids)
+      resolve(snapshot)
     }
 
     // A hung ps must not stall teardown; abandon it after the grace and fall back to the direct kill.
@@ -121,7 +124,7 @@ const collectDescendantPids = (rootPid: number): Promise<number[]> =>
       } catch {
         // ps may have already exited.
       }
-      finish([])
+      finish({ pids: [], complete: false })
     }, TERMINATE_GRACE_MS)
     timer.unref?.()
 
@@ -130,10 +133,14 @@ const collectDescendantPids = (rootPid: number): Promise<number[]> =>
     })
     ps.on('error', () => {
       clearTimeout(timer)
-      finish([])
+      finish({ pids: [], complete: false })
     })
-    ps.on('close', () => {
+    ps.on('close', (code) => {
       clearTimeout(timer)
+      if (code !== 0) {
+        finish({ pids: [], complete: false })
+        return
+      }
       try {
         const childrenByParent = new Map<number, number[]>()
         for (const line of out.split('\n')) {
@@ -156,9 +163,9 @@ const collectDescendantPids = (rootPid: number): Promise<number[]> =>
             stack.push(kid)
           }
         }
-        finish(descendants)
+        finish({ pids: descendants, complete: true })
       } catch {
-        finish([])
+        finish({ pids: [], complete: false })
       }
     })
   })
@@ -236,7 +243,9 @@ const terminatePosixTree = async (
   log: ProcessTreeLogger | undefined
 ): Promise<ProcessTreeKillResult> => {
   const gracefulSignal = signal ?? 'SIGTERM'
-  const descendants = child.pid === undefined ? [] : await collectDescendantPids(child.pid)
+  const snapshot =
+    child.pid === undefined ? { pids: [], complete: true } : await collectDescendantPids(child.pid)
+  const descendants = snapshot.pids
 
   signalPids(descendants, gracefulSignal)
   killDirectChild(child, gracefulSignal)
@@ -244,7 +253,7 @@ const terminatePosixTree = async (
   const exited = await waitForExit(child, TERMINATE_GRACE_MS)
   const survivors = descendants.filter(isProcessAlive)
 
-  if (exited && survivors.length === 0) return { reaped: true }
+  if (exited && survivors.length === 0) return { reaped: snapshot.complete }
 
   let childExited = exited
   if (survivors.length > 0) {
@@ -262,7 +271,9 @@ const terminatePosixTree = async (
   }
 
   // Re-check after SIGKILL: reaped only if the direct child exited and no descendant is still alive.
-  return { reaped: childExited && descendants.filter(isProcessAlive).length === 0 }
+  return {
+    reaped: snapshot.complete && childExited && descendants.filter(isProcessAlive).length === 0
+  }
 }
 
 // Terminates a child process and every descendant it spawned, then waits for the direct child to actually


### PR DESCRIPTION
## Problem

Micromamba timeout and cancellation called `child.kill()` and waited only for the direct process to close. A detached descendant could keep writing the same Conda prefix after `runMicromamba` rejected. `withJournaledPrefixWrite` then cleared the operation journal and PID sidecar, so an in-session Retry could start a second writer against the same prefix.

## Proposed change

- route micromamba timeout, cancellation, and PID-recording failure through the existing cross-platform `terminateProcessTree` helper;
- deduplicate and await tree teardown before returning the ordinary timeout/cancellation result;
- treat failed POSIX descendant discovery as `reaped: false` instead of silently accepting an empty tree;
- retain the operation journal when teardown is unconfirmed and downgrade the existing child sidecar to `{ spawning: true, bootToken? }`, because a dead direct PID cannot prove that a reparented descendant is gone;
- keep the current in-process prefix block so Retry and Reset cannot race a possible surviving writer.

## Scope and non-goals

- No database/schema, domain data model, or historical-data migration.
- No new persisted field or format; this reuses the existing spawn-intent sidecar variant.
- No new status or enum value.
- No renderer, interaction, or user-facing copy change.
- No dependency change.
- Successful micromamba completion and `captureMicromamba` are unchanged.

## Acceptance criteria and validation

All listed checks ran after the last material code edit.

- cancellation waits for a real descendant that continuously writes the target prefix, or fails closed when the platform cannot prove teardown -> `npm test -- src/main/notebook/provisioner-runtime.test.ts src/main/process-tree.test.ts src/main/notebook/provisioner.test.ts src/main/notebook/package-manager.test.ts` -> PASS (4 files, 201 tests);
- POSIX snapshot failure/non-zero exit reports an unconfirmed tree -> same targeted command -> PASS;
- an unconfirmed tree retains the journal, converts the PID sidecar to the existing unprobeable state, and blocks Retry -> same targeted command -> PASS;
- affected main-process types -> `npm run typecheck:node` -> PASS;
- linted source/config -> `npm run lint` -> PASS;
- touched-file formatting and diff whitespace -> `npx prettier --check <6 touched files>` and `git diff --check` -> PASS.

`npm run test:affected:explain -- --base origin/main --head HEAD` selected full mode because `src/main/notebook/provisioner-runtime.test.ts` has no registered Module owner. Per maintainer direction, the complete local `npm test` suite was not run; PR Gate is the final complete-suite authority.

## Persistence and compatibility

There is no historical compatibility work. Existing journals and sidecars remain readable without migration. The only persistence behavior change is cleanup timing: confirmed teardown clears the existing records as before, while unconfirmed teardown retains them and rewrites the sidecar to the already-supported no-verifiable-PID state.

## Review focus

- `runMicromamba` must not settle ordinary timeout/cancellation until tree teardown reports `reaped: true`.
- `reaped: false` must retain recovery evidence both in-process and across restart.
- The stricter POSIX `reaped` result should remain fail-closed for all existing callers.

## Uncovered risks

- The real descendant-writing integration test was exercised locally on macOS. Windows `taskkill /T /F` and Linux `ps` behavior have deterministic unit coverage and rely on PR platform CI for real-host confirmation.
- If platform tree discovery is unavailable, the environment intentionally stays blocked instead of permitting a concurrent writer. On platforms without an authoritative persisted boot token, that degraded case may require manual recovery; this PR does not change recovery UI.
