### PR TITLE
fix(web-service): bound shutdown with active HTTP requests

### DIFF
--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -1,5 +1,5 @@
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
-import { request as httpRequest } from 'node:http'
+import { request as httpRequest, ServerResponse } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -1387,6 +1387,61 @@ describe('startWebHttpServer', () => {
     expect(response.status).toBe(202)
     expect(await response.json()).toEqual({ ok: true })
     await vi.waitFor(() => expect(onShutdownRequest).toHaveBeenCalledOnce())
+  })
+
+  it('delivers the shutdown acknowledgement before closing an attached server', async () => {
+    const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
+    roots.push(staticRoot)
+    await writeFile(join(staticRoot, 'index.html'), '<!doctype html>')
+    let shutdownClose: Promise<void> | undefined
+    const onShutdownRequest = (): void => {
+      shutdownClose = server.close()
+    }
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot,
+      rpc: {
+        channels: () => [],
+        invoke: vi.fn(),
+        releaseClient: vi.fn(),
+        dispose: vi.fn()
+      },
+      onShutdownRequest,
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+
+    const originalEnd = ServerResponse.prototype.end
+    ServerResponse.prototype.end = function (
+      this: ServerResponse,
+      ...args: unknown[]
+    ): ServerResponse {
+      setTimeout(() => Reflect.apply(originalEnd, this, args), 25)
+      return this
+    } as typeof ServerResponse.prototype.end
+    let response: Response
+    try {
+      response = await fetch(`http://127.0.0.1:${server.port}/api/shutdown`, {
+        method: 'POST',
+        headers: { authorization: 'Bearer test-token' }
+      })
+    } finally {
+      ServerResponse.prototype.end = originalEnd
+    }
+
+    expect(response.status).toBe(202)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    await vi.waitFor(() => expect(shutdownClose).toBeDefined())
+    await shutdownClose
+    servers.splice(servers.indexOf(server), 1)
   })
 
   it('keeps shutdown local even when remote Browser access is authorized', async () => {

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -707,6 +707,80 @@ describe('startWebHttpServer', () => {
     expect(directSignals[0]?.aborted).toBe(true)
   })
 
+  it('bounds close when an active HTTP request does not finish', async () => {
+    const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
+    roots.push(staticRoot)
+    await writeFile(join(staticRoot, 'index.html'), '<!doctype html>')
+    let markInvocationStarted: (() => void) | undefined
+    const invocationStarted = new Promise<void>((resolve) => {
+      markInvocationStarted = resolve
+    })
+    let releaseInvocation: (() => void) | undefined
+    const invocationGate = new Promise<void>((resolve) => {
+      releaseInvocation = resolve
+    })
+    let callerSignal: AbortSignal | undefined
+    const directInvoke = vi.fn(async (_channel, invocation) => {
+      callerSignal = invocation.callerLease.signal
+      markInvocationStarted?.()
+      await invocationGate
+      return []
+    })
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot,
+      rpc: {
+        channels: () => ['projects:list'],
+        invoke: vi.fn(),
+        dispose: vi.fn()
+      },
+      applicationCommands: {
+        localWeb: { commandNames: () => ['projects:list'], invoke: directInvoke },
+        remoteWeb: { commandNames: () => [], rejectedCommandNames: () => [], invoke: vi.fn() }
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+
+    const request = httpRequest({
+      host: '127.0.0.1',
+      port: server.port,
+      path: '/rpc/projects%3Alist',
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        connection: 'close',
+        'content-type': 'application/json',
+        'x-open-science-client': 'test-client'
+      }
+    })
+    request.on('error', () => undefined)
+    request.end(JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] }))
+    await invocationStarted
+
+    const closePromise = server.close()
+    const closeOutcome = await Promise.race([
+      closePromise.then(() => 'closed' as const),
+      new Promise<'timed-out'>((resolve) => setTimeout(() => resolve('timed-out'), 250))
+    ])
+
+    releaseInvocation?.()
+    await closePromise
+    request.destroy()
+    servers.splice(servers.indexOf(server), 1)
+
+    expect(closeOutcome).toBe('closed')
+    expect(callerSignal?.aborted).toBe(true)
+  })
+
   it('passes pairing authority only for trusted-browser Web RPC calls', async () => {
     const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
     roots.push(staticRoot)

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -845,12 +845,25 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       removeTaskProgressSink?.()
       for (const socket of sockets) socket.close()
       wsServer.close()
-      await new Promise<void>((resolveClose) => server.close(() => resolveClose()))
+      // Stop accepting connections before force-closing handlers that ignore caller cancellation.
+      const closePromise = new Promise<void>((resolveClose) => server.close(() => resolveClose()))
+      let cleanupError: unknown
       try {
         clientLeases.dispose()
+      } catch (error) {
+        cleanupError = error
       } finally {
-        commandClient.dispose()
+        try {
+          commandClient.dispose()
+        } catch (error) {
+          cleanupError = cleanupError
+            ? new AggregateError([cleanupError, error], 'Web command client cleanup failed.')
+            : error
+        }
       }
+      server.closeAllConnections()
+      await closePromise
+      if (cleanupError) throw cleanupError
     }
   }
 }

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -571,8 +571,16 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
           json(response, 404, { ok: false, error: 'Shutdown is not available.' })
           return
         }
+        const onShutdownRequest = options.onShutdownRequest
+        let shutdownScheduled = false
+        const scheduleShutdown = (): void => {
+          if (shutdownScheduled) return
+          shutdownScheduled = true
+          setImmediate(onShutdownRequest)
+        }
+        response.once('finish', scheduleShutdown)
+        response.once('close', scheduleShutdown)
         json(response, 202, { ok: true })
-        setImmediate(options.onShutdownRequest)
         return
       }
 


### PR DESCRIPTION
## Problem

The Web HTTP controller awaited `server.close()` before releasing application caller leases. Node waits for active HTTP requests to finish before completing that callback, so a request whose handler never settles could strand ordinary quit, update installation, and migration relaunch indefinitely.

## Proposed change

- stop accepting new HTTP connections before teardown;
- dispose the Web caller leases and command client so active application commands receive cancellation;
- call `closeAllConnections()` after `server.close()` has started, forcing handlers that ignore cancellation off their HTTP connections;
- preserve cleanup failures while still waiting for the server close callback;
- start `/api/shutdown` teardown only after its 202 acknowledgement finishes, or after that client disconnects, so attached shutdown callers receive the response before connections are forced closed;
- add real HTTP regression tests for both a deliberately blocked RPC handler and a delayed shutdown acknowledgement.

## Scope and non-goals

- No public interface or module-boundary changes.
- No persistence schema, migration, data-model, status-enum, or renderer interaction changes.
- Existing WebSocket shutdown behavior remains unchanged.
- Intentional Web service shutdown now cancels unfinished HTTP work instead of waiting without a bound.

## Acceptance criteria and validation

Checks below ran after the last material edit:

- stuck request cancellation and shutdown acknowledgement delivery -> `npm test -- src/main/web-service/http-server.test.ts -t "bounds close when an active HTTP request does not finish|delivers the shutdown acknowledgement before closing an attached server"` -> passed (2 tests);
- Web HTTP, controller, and application shutdown integration -> `npm test -- src/main/web-service/http-server.test.ts src/main/web-service/controller.test.ts src/main/application-runtime.test.ts` -> passed (48 tests);
- affected main-process types -> `npm run typecheck:node` -> passed;
- linted source -> `npm run lint` -> passed.

The exact-head impact classifier selects the full plan because `src/main/web-service/http-server.ts` has no declared module owner. The complete portable and platform suites are therefore intentionally delegated to blocking PR CI; no complete local `npm test` was run.

## Review focus

- Ordering of `server.close()`, caller cancellation, and `closeAllConnections()`.
- Delivery of the `/api/shutdown` acknowledgement before attached teardown begins.
- Preservation of cleanup errors without allowing an active connection to strand close.
- The regression tests' use of the real Node HTTP lifecycle with a controlled delayed response finish.

Uncovered local risk: packaged update and migration-relaunch workflows were not exercised end-to-end; their exact-head CI lanes remain authoritative.
