### PR TITLE
fix(session-persistence): preserve quarantined session ownership

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -163,6 +163,7 @@ import {
 import { ReviewerModelRuntimeOwner } from './reviewer/model-runtime-owner'
 import { ReviewerProjectRuntimeOwner } from './reviewer/project-runtime-owner'
 import {
+  canReconcileSessionAbsences,
   createDefaultReviewRepository,
   createDefaultSessionRepository,
   createSessionPersistenceHandlersWithAttributionAuthority,
@@ -862,7 +863,7 @@ const createApplicationModules = async (
         ...result,
         sessions: await sessionEnabledComputeHostsOwnerRef.current.reconcile(
           result.sessions,
-          result.diagnostics?.isComplete === true
+          canReconcileSessionAbsences(result)
         )
       }
     },

--- a/src/main/session-persistence/catalog-authority.ts
+++ b/src/main/session-persistence/catalog-authority.ts
@@ -1,0 +1,14 @@
+import type { SessionLoadWarning } from '../../shared/session-persistence'
+
+type SessionCatalogDiagnostics = {
+  isComplete: boolean
+  warnings?: readonly SessionLoadWarning[]
+}
+
+const isSessionCatalogAuthoritative = (
+  diagnostics: SessionCatalogDiagnostics | undefined
+): boolean =>
+  diagnostics?.isComplete === true &&
+  !diagnostics.warnings?.some((warning) => warning.kind === 'corrupt')
+
+export { isSessionCatalogAuthoritative }

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -2459,6 +2459,56 @@ describe('SessionPersistenceCoordinator', () => {
     expect(fileIndex.reconcileActiveSessions).toHaveBeenCalledWith([session])
   })
 
+  it('keeps startup cleanup closed after quarantining corrupt Session authority', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-corrupt-session-reconciliation-'))
+    const projectDir = join(root, 'sessions', 'project-1')
+    await mkdir(projectDir, { recursive: true })
+    await writeFile(join(projectDir, 'corrupt-session.json'), '{broken json', 'utf8')
+    const repository = new SessionRepository(root)
+    const fileIndex = createFileIndex()
+    const provenance = createProvenancePersistence()
+    const permissionGrants = { reconcileSessions: vi.fn().mockResolvedValue(undefined) }
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      fileIndex,
+      undefined,
+      provenance,
+      undefined,
+      undefined,
+      permissionGrants
+    )
+    const deletionHandlers = createSessionDeletionHandlers()
+    coordinator.setSessionDeletionHandlers(deletionHandlers)
+
+    try {
+      const loaded = await coordinator.loadAll()
+
+      expect(loaded.sessions).toEqual([])
+      expect(loaded.diagnostics).toMatchObject({
+        isComplete: true,
+        warnings: [
+          {
+            kind: 'corrupt',
+            projectId: 'project-1',
+            fileName: 'corrupt-session.json',
+            recovered: true
+          }
+        ]
+      })
+      expect(fileIndex.markReconciliationIncomplete).toHaveBeenCalledOnce()
+      await expect(coordinator.sessionMetadataSnapshot()).resolves.toEqual({
+        sessions: [],
+        isComplete: false
+      })
+      expect(deletionHandlers.reconcile).not.toHaveBeenCalled()
+      expect(permissionGrants.reconcileSessions).not.toHaveBeenCalled()
+      expect(provenance.reconcileSessionDeletions).not.toHaveBeenCalled()
+      expect(fileIndex.reconcileActiveSessions).not.toHaveBeenCalled()
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it('preserves a main-owned permission wait when another client hydrates in the same process', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-live-permission-hydration-'))
     const repository = new SessionRepository(root, { hasActiveRuntimePrompt: () => true })

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -2459,7 +2459,7 @@ describe('SessionPersistenceCoordinator', () => {
     expect(fileIndex.reconcileActiveSessions).toHaveBeenCalledWith([session])
   })
 
-  it('keeps startup cleanup closed after quarantining corrupt Session authority', async () => {
+  it('keeps cleanup closed across scans after quarantining corrupt Session authority', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-corrupt-session-reconciliation-'))
     const projectDir = join(root, 'sessions', 'project-1')
     await mkdir(projectDir, { recursive: true })
@@ -2482,6 +2482,7 @@ describe('SessionPersistenceCoordinator', () => {
 
     try {
       const loaded = await coordinator.loadAll()
+      const replayed = await coordinator.loadAll()
 
       expect(loaded.sessions).toEqual([])
       expect(loaded.diagnostics).toMatchObject({
@@ -2495,7 +2496,8 @@ describe('SessionPersistenceCoordinator', () => {
           }
         ]
       })
-      expect(fileIndex.markReconciliationIncomplete).toHaveBeenCalledOnce()
+      expect(replayed.diagnostics).toEqual(loaded.diagnostics)
+      expect(fileIndex.markReconciliationIncomplete).toHaveBeenCalledTimes(2)
       await expect(coordinator.sessionMetadataSnapshot()).resolves.toEqual({
         sessions: [],
         isComplete: false

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -71,6 +71,7 @@ import {
   SessionDelegatedWorkPersistenceOwner
 } from './delegated-work-owner'
 import { SessionPersistenceOperationScheduler } from './operation-scheduler'
+import { isSessionCatalogAuthoritative } from './catalog-authority'
 
 type SessionMutationRepository = {
   loadAllWithDiagnostics(options?: { mode?: 'repair' | 'read-only' }): Promise<{
@@ -375,8 +376,7 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
         operation.fail(error, { status: 'failed', hydrationAvailable: false })
         throw error
       }
-      const hasAuthoritativeSessionCatalog =
-        scan.isComplete && !scan.warnings?.some((warning) => warning.kind === 'corrupt')
+      const hasAuthoritativeSessionCatalog = isSessionCatalogAuthoritative(scan)
       this.stateOwner.replaceMetadata(scan.result.sessions, hasAuthoritativeSessionCatalog)
       operation.phase('authority-loaded', {
         sessionCount: scan.result.sessions.length,

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -375,7 +375,9 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
         operation.fail(error, { status: 'failed', hydrationAvailable: false })
         throw error
       }
-      this.stateOwner.replaceMetadata(scan.result.sessions, scan.isComplete)
+      const hasAuthoritativeSessionCatalog =
+        scan.isComplete && !scan.warnings?.some((warning) => warning.kind === 'corrupt')
+      this.stateOwner.replaceMetadata(scan.result.sessions, hasAuthoritativeSessionCatalog)
       operation.phase('authority-loaded', {
         sessionCount: scan.result.sessions.length,
         warningCount: scan.warnings?.length ?? 0,
@@ -389,9 +391,9 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
       let result = scan.result
       let sessions = scan.result.sessions
 
-      if (!scan.isComplete) {
-        // Without the full active-session set, syncing could let a readable duplicate steal a row from
-        // a soft-deleted owner whose JSON was merely unreadable during this scan.
+      if (!hasAuthoritativeSessionCatalog) {
+        // Without the full active-session set, absent rows may still be owned by unreadable or
+        // quarantined JSON, so every derived owner must remain incomplete and untouched.
         this.fileIndex.markReconciliationIncomplete()
         operation.complete({
           status: 'partial',

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 
 import {
+  createEmptySessionManifest,
   materializeSessionConversationGraph,
   type PersistedChatSession
 } from '../../shared/session-persistence'
@@ -34,6 +35,7 @@ vi.mock('../lifecycle-broadcast', () => ({
 }))
 
 import {
+  canReconcileSessionAbsences,
   createSessionPersistenceHandlers,
   createSessionPersistenceHandlersWithAttributionAuthority,
   loadSessionMetadataAfterProjectRecovery,
@@ -73,6 +75,47 @@ const createMockReviewRepository = (): ReviewRepository =>
   }) as unknown as ReviewRepository
 
 describe('session persistence IPC handlers', () => {
+  it('keeps absence-based reconciliation closed for quarantined Session authority', () => {
+    expect(
+      canReconcileSessionAbsences({
+        sessions: [],
+        manifest: createEmptySessionManifest(),
+        diagnostics: {
+          isComplete: true,
+          warnings: [
+            {
+              kind: 'corrupt',
+              projectId: 'project-1',
+              fileName: 'session-1.invalid-1.json',
+              recovered: true
+            }
+          ],
+          isProjectDeletionRecoveryComplete: true
+        }
+      })
+    ).toBe(false)
+  })
+
+  it('opens absence-based reconciliation only after both authorities are complete', () => {
+    const result = {
+      sessions: [],
+      manifest: createEmptySessionManifest(),
+      diagnostics: {
+        isComplete: true,
+        warnings: [],
+        isProjectDeletionRecoveryComplete: true
+      }
+    }
+
+    expect(canReconcileSessionAbsences(result)).toBe(true)
+    expect(
+      canReconcileSessionAbsences({
+        ...result,
+        diagnostics: { ...result.diagnostics, isProjectDeletionRecoveryComplete: false }
+      })
+    ).toBe(false)
+  })
+
   it('reads cached Session metadata only after Project deletion recovery', async () => {
     const order: string[] = []
     const projectRecovery = {

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -20,6 +20,7 @@ import { getProjectDbClient } from '../projects/prisma-client'
 import { withDataRootWrite } from '../storage/migration-state'
 import type { SessionMetadataSnapshot } from './coordinator'
 import { MainMessageAttributionAuthority } from './message-attribution-authority'
+import { isSessionCatalogAuthoritative } from './catalog-authority'
 
 type SessionPersistenceBackend = {
   loadAll: () => Promise<LoadAllSessionsResult>
@@ -80,6 +81,10 @@ const withProjectDeletionRecoveryStatus = (
     isProjectDeletionRecoveryComplete
   }
 })
+
+const canReconcileSessionAbsences = (result: LoadAllSessionsResult): boolean =>
+  result.diagnostics?.isProjectDeletionRecoveryComplete === true &&
+  isSessionCatalogAuthoritative(result.diagnostics)
 
 // Cached metadata must not overtake queued Project deletion work. Let recovery failures reject so
 // Permissions reports the Session store as incomplete instead of publishing stale navigation labels.
@@ -225,6 +230,7 @@ const registerSessionPersistenceIpcHandlers = (
 }
 
 export {
+  canReconcileSessionAbsences,
   createDefaultReviewRepository,
   createDefaultSessionRepository,
   createSessionPersistenceHandlers,


### PR DESCRIPTION
## Problem

A corrupt Session that was successfully renamed to an invalid backup was omitted from the loaded catalog while the scan remained complete. The first startup load could then reconcile that omission as a real deletion and prune Session-scoped permissions, Reviews/provenance, notification targets, VisionEvidence, derived file ownership, and enabled Compute Host selections.

## Proposed change

- Treat any Session corrupt warning as unresolved authority for Main-side startup reconciliation.
- Keep renderer-facing scan completeness unchanged so readable Sessions retain the existing damaged-authority interaction.
- Mark the internal Session metadata and file projection incomplete, then return before absence-based reconciliation.
- Require both authoritative Session catalog state and completed Project deletion recovery before Compute Host reconciliation may prune missing selections.
- Cover the real Repository-to-Coordinator path and the internal IPC reconciliation gate with regression tests.

## Scope and non-goals

- No database migration or schema change.
- No Session JSON format or shared data-model change.
- No new enum or persisted status.
- No renderer copy or interaction change.
- Does not reconstruct permissions, Reviews, notifications, VisionEvidence, Compute Host selections, or derived rows already removed by an earlier affected startup.

## Compatibility and persistence

Existing invalid backup files require no migration. An unresolved backup now retains related durable rows until valid Session authority returns or an explicit deletion flow owns cleanup. A valid current primary continues to supersede its retained historical backup and permits normal reconciliation.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Retained `.invalid-*` authority keeps Main cleanup closed across repeated scans, while renderer diagnostics retain the recovered-corruption signal -> targeted repository and coordinator regressions -> 2 files and 2 tests passed.
- Quarantined Session and incomplete Project recovery cannot authorize Compute Host pruning -> targeted Session IPC regressions -> passed.
- Session IPC and Compute Host owner coverage -> `npx vitest run src/main/session-persistence/ipc.test.ts src/main/compute/session-enabled-hosts-owner.test.ts` -> 2 files and 33 tests passed.
- Session persistence owner, contract, architecture, and consumer coverage -> `npm run test:module -- session_persistence` -> 7 files and 309 tests passed.
- Main-process type safety -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed.
- Changed-file formatting -> targeted `npx prettier --check` -> passed.

The full local `npm test` suite was intentionally not run. Exact-head PR CI remains authoritative for portable and platform coverage. No renderer or migration lane is required because the final diff changes only Main-side authority and reconciliation gates plus their tests.

## Review focus

Please focus on the distinction between renderer hydration completeness and stricter Main-side authority completeness, and on every absence-based reconciliation consumer using the stricter authority gate.
