### PR TITLE
fix(session-persistence): extend renderer flush timeout

### DIFF
--- a/src/main/session-persistence/renderer-flush.test.ts
+++ b/src/main/session-persistence/renderer-flush.test.ts
@@ -122,6 +122,41 @@ describe('requestRendererSessionPersistenceFlush', () => {
 })
 
 describe('createElectronSessionPersistenceFlush', () => {
+  it('uses a five-second default timeout for a live renderer that never acknowledges', async () => {
+    vi.useFakeTimers()
+    electronMocks.on.mockClear()
+    electronMocks.removeListener.mockClear()
+
+    try {
+      const webContents = {
+        isDestroyed: vi.fn(() => false),
+        send: vi.fn(),
+        on: vi.fn(),
+        removeListener: vi.fn()
+      }
+      const window = {
+        isDestroyed: vi.fn(() => false),
+        webContents
+      }
+      const flush = createElectronSessionPersistenceFlush(() => window as never)
+      const request = flush()
+      let settled = false
+      void request.then(() => {
+        settled = true
+      })
+
+      await vi.advanceTimersByTimeAsync(4_999)
+      expect(settled).toBe(false)
+
+      await vi.advanceTimersByTimeAsync(1)
+      await expect(request).resolves.toBe('timeout')
+      expect(electronMocks.removeListener).toHaveBeenCalledOnce()
+      expect(webContents.removeListener).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('accepts only the target renderer acknowledgement with the matching request ID', async () => {
     electronMocks.on.mockClear()
     electronMocks.removeListener.mockClear()

--- a/src/main/session-persistence/renderer-flush.ts
+++ b/src/main/session-persistence/renderer-flush.ts
@@ -17,7 +17,7 @@ type RendererSessionPersistenceFlushDeps = {
   timeoutMs: number
 }
 
-const DEFAULT_RENDERER_FLUSH_TIMEOUT_MS = 1_500
+const DEFAULT_RENDERER_FLUSH_TIMEOUT_MS = 5_000
 
 export type RendererSessionPersistenceFlushOutcome =
   'completed' | 'unavailable' | 'renderer-gone' | 'send-failed' | 'timeout'


### PR DESCRIPTION
## Problem

Application shutdown allowed only 1.5 seconds for the renderer to fetch the final runtime snapshot,
drain runtime events, and empty the ordered Session persistence queue. A large Session or temporarily
slow disk could exceed that shared deadline, after which shutdown continued to `app.exit(0)` with the
last Session projection still pending.

## Proposed change

- Extend the existing renderer Session flush hard timeout from 1.5 seconds to 5 seconds.
- Add a fake-timer boundary test proving that the default remains pending at 4,999 ms and resolves as a
  timeout at 5,000 ms.

## Scope and non-goals

- Keep the existing bounded, best-effort shutdown behavior; this PR does not introduce a timeout prompt
  or unbounded wait.
- Do not change persisted fields, enum values, Session/Artifact schemas, storage layout, persistence
  ownership, or user interaction.
- No historical-data migration or compatibility path is required.

## Acceptance criteria and validation

The checks below ran after the last material edit:

- Default flush timeout boundary -> `npm test -- src/main/session-persistence/renderer-flush.test.ts`
  -> passed (1 file, 7 tests).
- Session persistence owner/contract/consumer coverage ->
  `npm run test:module -- session_persistence` -> passed (7 files, 308 tests).
- Main-process TypeScript contract -> `npm run typecheck:node` -> passed.
- Linted source/test changes -> `npm run lint` -> passed.
- Diff whitespace validation -> `git diff --check` -> passed.

No Renderer, preload, shared IPC, storage schema, or persistence interface changed, so Web typecheck and
additional consumer lanes were excluded locally. Full `npm test` was intentionally left to PR CI per
maintainer direction; PR CI remains authoritative for portable and platform coverage.

## Review focus

- Confirm that five seconds is the intended maximum shutdown delay.
- Confirm that the test protects the production default rather than only an injected test timeout.
- Note the residual behavior: a live renderer that still has not flushed after five seconds remains a
  degraded timeout and shutdown continues.
