### PR TITLE
fix(responses-bridge): isolate reasoning cache by Session

### DIFF
--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -1276,6 +1276,191 @@ describe('Responses-compatible bridge conversion', () => {
     }
   })
 
+  it('keeps cached reasoning isolated when Sessions reuse the same provider call id', async () => {
+    const upstreamRequests: Array<Record<string, unknown>> = []
+    const upstreamResponses = [
+      {
+        id: 'session-a-call',
+        model: 'model-a',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              reasoning_content: 'session-a reasoning',
+              tool_calls: [
+                {
+                  id: 'reused-call-id',
+                  type: 'function',
+                  function: { name: 'lookup', arguments: '{"session":"a"}' }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        id: 'session-b-call',
+        model: 'model-a',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              reasoning_content: 'session-b reasoning',
+              tool_calls: [
+                {
+                  id: 'reused-call-id',
+                  type: 'function',
+                  function: { name: 'lookup', arguments: '{"session":"b"}' }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        id: 'session-a-complete',
+        model: 'model-a',
+        choices: [{ message: { role: 'assistant', content: 'done' } }]
+      }
+    ]
+    const upstreamFetch = vi.fn(
+      async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        upstreamRequests.push(JSON.parse(String(init?.body)) as Record<string, unknown>)
+        return Response.json(upstreamResponses[upstreamRequests.length - 1])
+      }
+    )
+    const bridge = new ResponsesBridge(
+      { baseUrl: 'https://vendor.example/v1', key: 'k' },
+      upstreamFetch
+    )
+    const connection = await bridge.start()
+    const post = async (promptCacheKey: string, input: unknown): Promise<void> => {
+      const response = await fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: 'model-a',
+          prompt_cache_key: promptCacheKey,
+          input,
+          stream: false
+        })
+      })
+      expect(response.ok).toBe(true)
+      await response.json()
+    }
+
+    try {
+      await post('session-a', 'start a')
+      await post('session-b', 'start b')
+      const invalidResponse = await fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: 'model-a',
+          prompt_cache_key: 'session-a',
+          previous_response_id: 'unsupported',
+          input: 'invalid retry',
+          stream: false
+        })
+      })
+      expect(invalidResponse.status).toBe(400)
+      await post('session-a', [
+        {
+          type: 'function_call',
+          call_id: 'reused-call-id',
+          name: 'lookup',
+          arguments: '{"session":"a"}'
+        },
+        { type: 'function_call_output', call_id: 'reused-call-id', output: 'a-result' }
+      ])
+
+      expect(upstreamRequests[2]?.messages).toEqual([
+        {
+          role: 'assistant',
+          reasoning_content: 'session-a reasoning',
+          tool_calls: [
+            {
+              id: 'reused-call-id',
+              type: 'function',
+              function: { name: 'lookup', arguments: '{"session":"a"}' }
+            }
+          ]
+        },
+        { role: 'tool', tool_call_id: 'reused-call-id', content: 'a-result' }
+      ])
+    } finally {
+      await bridge.close()
+    }
+  })
+
+  it('fails closed without a Session scope and bounds cached reasoning by LRU Session', () => {
+    type ReasoningCacheHarness = {
+      cacheReasoning: (
+        promptCacheKey: string | undefined,
+        reasoning: string,
+        callIds: string[]
+      ) => void
+      reconcileReasoningForRequest: (promptCacheKey: string | undefined, input: unknown) => void
+      reasoningByPromptCacheKey: Map<string, Map<string, string>>
+      reasoningCacheEntryCount: number
+      reasoningCacheCharacterCount: number
+    }
+    const harness = (options: {
+      reasoningCacheMaxEntries: number
+      reasoningCacheMaxCharacters: number
+    }): ReasoningCacheHarness =>
+      new ResponsesBridge(
+        { baseUrl: 'https://vendor.example/v1' },
+        fetch,
+        options
+      ) as unknown as ReasoningCacheHarness
+    const fill = (cache: ReasoningCacheHarness): void => {
+      cache.cacheReasoning(undefined, 'unsafe', ['unscoped-call'])
+      cache.cacheReasoning('session-a', 'aaa', ['call-a'])
+      cache.cacheReasoning('session-b', 'bbb', ['call-b'])
+      cache.cacheReasoning('session-c', 'ccc', ['call-c'])
+    }
+
+    const entryBounded = harness({
+      reasoningCacheMaxEntries: 2,
+      reasoningCacheMaxCharacters: 100
+    })
+    fill(entryBounded)
+    expect([...entryBounded.reasoningByPromptCacheKey.keys()]).toEqual(['session-b', 'session-c'])
+    expect(entryBounded.reasoningCacheEntryCount).toBe(2)
+
+    const characterBounded = harness({
+      reasoningCacheMaxEntries: 100,
+      reasoningCacheMaxCharacters: 6
+    })
+    fill(characterBounded)
+    expect([...characterBounded.reasoningByPromptCacheKey.keys()]).toEqual([
+      'session-b',
+      'session-c'
+    ])
+    expect(characterBounded.reasoningCacheCharacterCount).toBe(6)
+
+    const reconciled = harness({
+      reasoningCacheMaxEntries: 100,
+      reasoningCacheMaxCharacters: 100
+    })
+    reconciled.cacheReasoning('session-a', 'aaa', ['retained-call', 'compacted-call'])
+    reconciled.reconcileReasoningForRequest('session-a', [
+      { type: 'function_call', call_id: 'retained-call' }
+    ])
+    expect(reconciled.reasoningByPromptCacheKey.get('session-a')).toEqual(
+      new Map([['retained-call', 'aaa']])
+    )
+    expect(reconciled.reasoningCacheEntryCount).toBe(1)
+    expect(reconciled.reasoningCacheCharacterCount).toBe(3)
+  })
+
   it('reports streamed upstream image output as unsupported', async () => {
     const upstreamFetch = vi.fn(async () => {
       const chunk = (delta: Record<string, unknown>, finish_reason: string | null = null): string =>
@@ -1639,12 +1824,15 @@ describe('Responses-compatible bridge conversion', () => {
 
   it('clears the reasoning cache only when the upstream target actually changes', () => {
     const bridge = new ResponsesBridge({ baseUrl: 'https://a.example/v1', model: 'm1', key: 'k1' })
-    const cache = (bridge as unknown as { reasoningByCallId: Map<string, string> })
-      .reasoningByCallId
-    cache.set('call-1', 'thinking')
+    const cache = (
+      bridge as unknown as {
+        reasoningByPromptCacheKey: Map<string, Map<string, string>>
+      }
+    ).reasoningByPromptCacheKey
+    cache.set('session-1', new Map([['call-1', 'thinking']]))
     // Same target (e.g. a skill-reload reconnect): cache is preserved so a resumed thinking session works.
     bridge.setTarget({ baseUrl: 'https://a.example/v1', model: 'm1', key: 'k1' })
-    expect(cache.has('call-1')).toBe(true)
+    expect(cache.get('session-1')?.has('call-1')).toBe(true)
     // Real provider switch: cache is cleared so stale reasoning can't leak across providers.
     bridge.setTarget({ baseUrl: 'https://b.example/v1', model: 'm2', key: 'k2' })
     expect(cache.size).toBe(0)

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -83,9 +83,14 @@ export type ResponsesBridgeSkillInput = Pick<ResponsesBridgeSkillCandidate, 'nam
 
 type ResponsesBridgeOptions = {
   skillSelectorTimeoutMs?: number
+  reasoningCacheMaxEntries?: number
+  reasoningCacheMaxCharacters?: number
 }
 
 type BridgeFetch = typeof fetch
+
+const DEFAULT_REASONING_CACHE_MAX_ENTRIES = 4_096
+const DEFAULT_REASONING_CACHE_MAX_CHARACTERS = 8 * 1024 * 1024
 
 // The upstream Chat Completions endpoint. `target.baseUrl` is already the resolved OpenAI base (an
 // official vendor's exact versioned base, or a custom root normalized to `<root>/v1`), so this only
@@ -95,10 +100,12 @@ const chatUrl = (value: string): string => appendChatCompletions(value)
 export class ResponsesBridge {
   private readonly host: ProviderLoopbackHttpHost<ResponsesBridgeConnection>
   private target: ResponsesBridgeTarget
-  // reasoning_content produced with each tool call, keyed by call_id, so a follow-up request can pass
-  // it back to thinking-mode providers that require it. Grows within a session; cleared on close (a
-  // provider switch / disconnect). Keyed by call_id, which Codex round-trips, so lookups stay stable.
-  private readonly reasoningByCallId = new Map<string, string>()
+  // reasoning_content produced with each tool call, partitioned by Codex's prompt_cache_key (its
+  // provider Session id) before call_id. The bridge is shared across Sessions, and providers may
+  // reuse call ids, so a bridge-global call-id map would mix otherwise unrelated histories.
+  private readonly reasoningByPromptCacheKey = new Map<string, Map<string, string>>()
+  private reasoningCacheEntryCount = 0
+  private reasoningCacheCharacterCount = 0
   private readonly reviewerSessionKeys = new Set<string>()
   private readonly scopedReviewerSessionKeys = new Set<string>()
   private readonly toolLessSessionKeys = new Set<string>()
@@ -260,7 +267,7 @@ export class ResponsesBridge {
       this.target.reasoningEffortTransport !== target.reasoningEffortTransport ||
       this.target.key !== target.key
     this.target = target
-    if (changed) this.reasoningByCallId.clear()
+    if (changed) this.clearReasoningCache()
   }
 
   setModelTarget(target: ResponsesBridgeModelTarget): void {
@@ -315,7 +322,7 @@ export class ResponsesBridge {
   }
 
   async close(): Promise<void> {
-    this.reasoningByCallId.clear()
+    this.clearReasoningCache()
     this.reviewerSessionKeys.clear()
     this.scopedReviewerSessionKeys.clear()
     this.toolLessSessionKeys.clear()
@@ -326,11 +333,102 @@ export class ResponsesBridge {
     await this.host.close()
   }
 
-  // Records this turn's reasoning against its tool-call ids so the next request can pass it back to
-  // thinking-mode providers. No-op when the turn produced no reasoning or made no tool calls.
-  private cacheReasoning(reasoning: string, callIds: string[]): void {
-    if (!reasoning) return
-    for (const callId of callIds) this.reasoningByCallId.set(callId, reasoning)
+  private clearReasoningCache(): void {
+    this.reasoningByPromptCacheKey.clear()
+    this.reasoningCacheEntryCount = 0
+    this.reasoningCacheCharacterCount = 0
+  }
+
+  private reasoningForRequest(promptCacheKey: string | undefined): Map<string, string> | undefined {
+    if (!promptCacheKey) return undefined
+    return this.reasoningByPromptCacheKey.get(promptCacheKey)
+  }
+
+  private reconcileReasoningForRequest(promptCacheKey: string | undefined, input: unknown): void {
+    if (!promptCacheKey) return
+    const reasoningByCallId = this.reasoningByPromptCacheKey.get(promptCacheKey)
+    if (!reasoningByCallId) return
+
+    const retainedCallIds = new Set<string>()
+    if (Array.isArray(input)) {
+      for (const item of input) {
+        if (!item || typeof item !== 'object' || !('type' in item)) continue
+        if (item.type !== 'function_call') continue
+        const callId = 'call_id' in item ? item.call_id : 'id' in item ? item.id : undefined
+        if (callId !== undefined && callId !== null) retainedCallIds.add(String(callId))
+      }
+    }
+
+    for (const [callId, reasoning] of reasoningByCallId) {
+      if (retainedCallIds.has(callId)) continue
+      reasoningByCallId.delete(callId)
+      this.reasoningCacheEntryCount -= 1
+      this.reasoningCacheCharacterCount -= reasoning.length
+    }
+    if (reasoningByCallId.size === 0) {
+      this.reasoningByPromptCacheKey.delete(promptCacheKey)
+      return
+    }
+
+    // Refresh this Session's insertion order so overflow evicts the least recently used scope.
+    this.reasoningByPromptCacheKey.delete(promptCacheKey)
+    this.reasoningByPromptCacheKey.set(promptCacheKey, reasoningByCallId)
+  }
+
+  // Records this turn's reasoning against its Session-scoped tool-call ids so the next request can
+  // pass it back to thinking-mode providers. Missing prompt_cache_key fails closed: without a stable
+  // Session boundary, cached reasoning cannot be replayed safely.
+  private cacheReasoning(
+    promptCacheKey: string | undefined,
+    reasoning: string,
+    callIds: string[]
+  ): void {
+    if (!promptCacheKey || !reasoning || callIds.length === 0) return
+    let reasoningByCallId = this.reasoningByPromptCacheKey.get(promptCacheKey)
+    if (!reasoningByCallId) {
+      reasoningByCallId = new Map()
+    } else {
+      this.reasoningByPromptCacheKey.delete(promptCacheKey)
+    }
+    this.reasoningByPromptCacheKey.set(promptCacheKey, reasoningByCallId)
+
+    for (const callId of callIds) {
+      const previous = reasoningByCallId.get(callId)
+      if (previous !== undefined) {
+        this.reasoningCacheCharacterCount -= previous.length
+      } else {
+        this.reasoningCacheEntryCount += 1
+      }
+      reasoningByCallId.set(callId, reasoning)
+      this.reasoningCacheCharacterCount += reasoning.length
+    }
+    this.enforceReasoningCacheLimits()
+  }
+
+  private enforceReasoningCacheLimits(): void {
+    const maxEntries = Math.max(
+      1,
+      Math.floor(this.options.reasoningCacheMaxEntries ?? DEFAULT_REASONING_CACHE_MAX_ENTRIES)
+    )
+    const maxCharacters = Math.max(
+      1,
+      Math.floor(this.options.reasoningCacheMaxCharacters ?? DEFAULT_REASONING_CACHE_MAX_CHARACTERS)
+    )
+    while (
+      this.reasoningByPromptCacheKey.size > 0 &&
+      (this.reasoningCacheEntryCount > maxEntries ||
+        this.reasoningCacheCharacterCount > maxCharacters)
+    ) {
+      const oldestPromptCacheKey = this.reasoningByPromptCacheKey.keys().next().value
+      if (typeof oldestPromptCacheKey !== 'string') break
+      const oldest = this.reasoningByPromptCacheKey.get(oldestPromptCacheKey)
+      this.reasoningByPromptCacheKey.delete(oldestPromptCacheKey)
+      if (!oldest) continue
+      for (const reasoning of oldest.values()) {
+        this.reasoningCacheEntryCount -= 1
+        this.reasoningCacheCharacterCount -= reasoning.length
+      }
+    }
   }
 
   private async handle(
@@ -372,10 +470,11 @@ export class ResponsesBridge {
       reviewerScoped || toolLessScoped || hostMessageScoped || hostMessageBoundaryActive
         ? { ...body, tools: [], tool_choice: 'auto' }
         : body
+    const reasoningByCallId = this.reasoningForRequest(promptCacheKey)
     const chatRequest = responsesToChatRequest(
       scopedBody,
       this.target.model,
-      this.reasoningByCallId,
+      reasoningByCallId,
       namespacedTools,
       {
         reasoningEffortOverride: this.target.reasoningEffort,
@@ -383,6 +482,7 @@ export class ResponsesBridge {
         reasoningEffortTransport: this.target.reasoningEffortTransport
       }
     )
+    this.reconcileReasoningForRequest(promptCacheKey, body.input)
 
     // Reveals which real model actually serves the turn (Codex only ever sees the internal catalog
     // model, not the upstream) and whether Codex's advertised tools survived translation into Chat
@@ -440,7 +540,7 @@ export class ResponsesBridge {
         String(body.model ?? ''),
         namespacedTools
       )
-      this.cacheReasoning(reasoning, callIds)
+      this.cacheReasoning(promptCacheKey, reasoning, callIds)
       return
     }
     const completion = (await upstream.json()) as JsonObject
@@ -449,6 +549,7 @@ export class ResponsesBridge {
     const outputItems = Array.isArray(result.output) ? (result.output as JsonObject[]) : []
     const toolCalls = outputItems.filter((item) => item.type === 'function_call')
     this.cacheReasoning(
+      promptCacheKey,
       typeof message.reasoning_content === 'string' ? message.reasoning_content : '',
       toolCalls.map((item) => String(item.call_id))
     )

--- a/src/main/settings/responses-request-adapter.architecture.test.ts
+++ b/src/main/settings/responses-request-adapter.architecture.test.ts
@@ -165,7 +165,7 @@ describe('Responses request adapter ownership', () => {
     expect(bridge).toContain('new ProviderLoopbackHttpHost')
     expect(host).toContain('createServer(')
     expect(bridge).toContain('reviewerSessionKeys')
-    expect(bridge).toContain('reasoningByCallId')
+    expect(bridge).toContain('reasoningByPromptCacheKey')
     expect(bridge).toContain('streamChatToResponses(')
   })
 })


### PR DESCRIPTION
## Problem

The Responses-to-Chat bridge cached provider `reasoning_content` globally by `call_id`. A provider that reused a call id across concurrent Codex Sessions could overwrite another Session reasoning and replay it into the wrong request. The cache also grew for the lifetime of a bridge generation.

## Proposed change

- Partition cached reasoning by Codex `prompt_cache_key` before `call_id`.
- Fail closed when a request has no Session-scoped cache key.
- Reconcile each Session cache against the validated request history so compacted calls are removed.
- Bound the in-memory cache to 4,096 call entries and 8 Mi characters, evicting the least recently used Session scope on overflow.
- Preserve existing provider-switch and bridge-close cache invalidation.

## Scope and non-goals

- Affects only the `codex-bridge` Responses-to-Chat path.
- Does not change Claude Code, OpenCode, Codex native Responses compatibility, renderer behavior, IPC, persisted formats, domain data models, or enums.
- Adds no database migration or historical-data compatibility path.

## Acceptance criteria and validation

All commands below ran after the final material edit:

- Session isolation, cache bounds, compaction cleanup, invalid-request stability, bridge owner/contract/consumer behavior -> `npm run test:module -- settings_backend_resolution` -> 34 files passed, 1 skipped; 481 tests passed, 3 skipped.
- Main-process types -> `npm run typecheck:node` -> passed.
- Source style and static lint rules -> `npm run lint` -> passed with zero warnings.
- Patch whitespace -> `git diff --check` -> passed.

The full `npm test` suite was intentionally not run per maintainer instruction. Exact-head PR CI remains authoritative for the portable and Windows-sensitive lanes selected by the module manifest.

## Review focus

- Verify `prompt_cache_key` remains the correct Codex provider Session boundary.
- Verify overflow prefers dropping an entire least-recently-used Session scope instead of risking cross-Session replay.
- Extreme cache eviction can omit old reasoning and cause a provider to reject a continuation; this is an intentional fail-closed outcome and is preferable to replaying another Session reasoning.