### PR TITLE
fix(startup): recover the database gate after IPC rejection

### DIFF
--- a/src/main/database/database-startup-owner.test.ts
+++ b/src/main/database/database-startup-owner.test.ts
@@ -73,6 +73,35 @@ describe('database startup owner', () => {
     expect(verifyDatabase).toHaveBeenCalledTimes(2)
   })
 
+  it('blocks an unclassified verification failure so retry remains available', async () => {
+    let attempt = 0
+    const reportBlocked = vi.fn()
+    const verifyDatabase = vi.fn(async () => {
+      attempt += 1
+      if (attempt === 1) throw new Error('startup subscriber failed')
+    })
+    const owner = createDatabaseStartupOwner({ reportBlocked, verifyDatabase })
+
+    await expect(owner.start()).resolves.toMatchObject({
+      phase: 'blocked',
+      error: {
+        code: 'database_startup_unavailable',
+        message: 'Open Science could not finish checking its database.',
+        retryable: true
+      }
+    })
+    expect(reportBlocked).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'database_startup_unavailable',
+        retryable: true
+      })
+    )
+
+    await expect(owner.retry()).resolves.toEqual({ phase: 'checking' })
+    await expect(owner.whenVerified()).resolves.toBeUndefined()
+    expect(verifyDatabase).toHaveBeenCalledTimes(2)
+  })
+
   it('does not retry a non-retryable compatibility failure', async () => {
     const reportBlocked = vi.fn()
     const verifyDatabase = vi.fn(async () => {

--- a/src/main/database/database-startup-owner.ts
+++ b/src/main/database/database-startup-owner.ts
@@ -45,19 +45,28 @@ const createDatabaseStartupOwner = (deps: DatabaseStartupOwnerDeps): DatabaseSta
         return state
       })
       .catch((error: unknown) => {
-        if (!(error instanceof DatabaseMigrationError)) throw error
+        const classified =
+          error instanceof DatabaseMigrationError
+            ? error
+            : new DatabaseMigrationError(
+                'database_startup_unavailable',
+                'Open Science could not finish checking its database.',
+                true,
+                undefined,
+                { cause: error }
+              )
         try {
-          deps.reportBlocked(error)
+          deps.reportBlocked(classified)
         } catch {
           // A diagnostic sink failure must not bypass the database compatibility gate.
         }
         const blocked: DatabaseStartupState = {
           phase: 'blocked',
           error: {
-            code: error.code,
-            message: error.message,
-            retryable: error.retryable,
-            ...(error.migrationId ? { migrationId: error.migrationId } : {})
+            code: classified.code,
+            message: classified.message,
+            retryable: classified.retryable,
+            ...(classified.migrationId ? { migrationId: classified.migrationId } : {})
           }
         }
         publish(blocked)

--- a/src/renderer/src/components/database-startup-gate.test.tsx
+++ b/src/renderer/src/components/database-startup-gate.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { DatabaseStartupState } from '../../../shared/database-startup'
@@ -92,6 +92,79 @@ describe('DatabaseStartupGate', () => {
 
     expect(screen.getByText('Business application')).toBeTruthy()
     expect(screen.queryByText('Checking database…')).toBeNull()
+  })
+
+  it('surfaces a retryable block when the startup state IPC rejects', async () => {
+    getState.mockRejectedValue(new Error('No handler registered for database-startup:get-state'))
+
+    render(
+      <DatabaseStartupGate>
+        <div>Business application</div>
+      </DatabaseStartupGate>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("Open Science couldn't start")).toBeTruthy()
+    })
+    expect(screen.getByText('Open Science could not finish checking its database.')).toBeTruthy()
+    expect(screen.getByText(/database_startup_unavailable/)).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Quit' })).toBeTruthy()
+    expect(screen.queryByText('Business application')).toBeNull()
+  })
+
+  it('keeps a live startup event when the catch-up read later rejects', async () => {
+    let rejectGetState: ((error: Error) => void) | undefined
+    getState.mockImplementation(
+      () =>
+        new Promise<DatabaseStartupState>((_resolve, reject) => {
+          rejectGetState = reject
+        })
+    )
+
+    render(
+      <DatabaseStartupGate>
+        <div>Business application</div>
+      </DatabaseStartupGate>
+    )
+    act(() => publish({ phase: 'ready' }))
+    await act(async () => {
+      rejectGetState?.(new Error('No handler registered for database-startup:get-state'))
+    })
+
+    expect(screen.getByText('Business application')).toBeTruthy()
+    expect(screen.queryByText("Open Science couldn't start")).toBeNull()
+  })
+
+  it('restores retry after a retry IPC rejection', async () => {
+    retry.mockImplementation(async () => {
+      publish({ phase: 'checking' })
+      throw new Error('No handler registered for database-startup:retry')
+    })
+    render(
+      <DatabaseStartupGate>
+        <div>Business application</div>
+      </DatabaseStartupGate>
+    )
+    act(() =>
+      publish({
+        phase: 'blocked',
+        error: {
+          code: 'database_open_failed',
+          message: 'Open Science could not open its database.',
+          retryable: true
+        }
+      })
+    )
+
+    await act(async () => screen.getByRole('button', { name: 'Retry' }).click())
+
+    expect(screen.getByText("Open Science couldn't start")).toBeTruthy()
+    expect(screen.getByText('Open Science could not finish checking its database.')).toBeTruthy()
+    expect(screen.getByText(/database_startup_unavailable/)).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy()
+    expect(screen.queryByText('Checking database…')).toBeNull()
+    expect(screen.queryByText('Business application')).toBeNull()
   })
 
   it('offers retry only for a retryable database failure', async () => {

--- a/src/renderer/src/components/database-startup-gate.test.tsx
+++ b/src/renderer/src/components/database-startup-gate.test.tsx
@@ -3,6 +3,7 @@
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { i18next } from '@/i18n'
 import type { DatabaseStartupState } from '../../../shared/database-startup'
 import { DatabaseStartupGate } from './database-startup-gate'
 
@@ -12,9 +13,10 @@ describe('DatabaseStartupGate', () => {
   const retry = vi.fn<() => Promise<DatabaseStartupState>>()
   const quit = vi.fn<() => Promise<void>>()
 
-  afterEach(() => {
+  afterEach(async () => {
     cleanup()
     vi.restoreAllMocks()
+    await i18next.changeLanguage('en')
   })
 
   beforeEach(() => {
@@ -164,6 +166,51 @@ describe('DatabaseStartupGate', () => {
     expect(screen.getByText(/database_startup_unavailable/)).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy()
     expect(screen.queryByText('Checking database…')).toBeNull()
+    expect(screen.queryByText('Business application')).toBeNull()
+  })
+
+  it('keeps a ready application mounted when the locale changes', async () => {
+    getState.mockResolvedValue({ phase: 'ready' })
+
+    render(
+      <DatabaseStartupGate>
+        <div>Business application</div>
+      </DatabaseStartupGate>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Business application')).toBeTruthy()
+    })
+
+    getState.mockRejectedValue(new Error('No handler registered for database-startup:get-state'))
+    await act(async () => {
+      await i18next.changeLanguage('zh-Hans')
+    })
+
+    expect(screen.getByText('Business application')).toBeTruthy()
+    expect(screen.queryByText("Open Science couldn't start")).toBeNull()
+    expect(getState).toHaveBeenCalledOnce()
+  })
+
+  it('translates the unavailable startup copy when the locale changes', async () => {
+    getState.mockRejectedValue(new Error('No handler registered for database-startup:get-state'))
+
+    render(
+      <DatabaseStartupGate>
+        <div>Business application</div>
+      </DatabaseStartupGate>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Open Science could not finish checking its database.')).toBeTruthy()
+    })
+
+    await act(async () => {
+      await i18next.changeLanguage('zh-Hans')
+    })
+
+    expect(screen.getByText('Open Science 无法完成数据库检查。')).toBeTruthy()
+    expect(screen.getByRole('button', { name: '重试' })).toBeTruthy()
     expect(screen.queryByText('Business application')).toBeNull()
   })
 

--- a/src/renderer/src/components/database-startup-gate.tsx
+++ b/src/renderer/src/components/database-startup-gate.tsx
@@ -9,14 +9,22 @@ import type { DatabaseStartupState } from '../../../shared/database-startup'
 
 type DatabaseStartupGateProps = { children: ReactNode }
 
-const unavailableStartupState = (message: string): DatabaseStartupState => ({
+const UNAVAILABLE_STARTUP_MESSAGE = 'Open Science could not finish checking its database.'
+
+const unavailableStartupState: DatabaseStartupState = {
   phase: 'blocked',
   error: {
     code: 'database_startup_unavailable',
-    message,
+    message: UNAVAILABLE_STARTUP_MESSAGE,
     retryable: true
   }
-})
+}
+
+const applyUnavailableStartupFallback = (current: DatabaseStartupState): DatabaseStartupState =>
+  current.phase === 'checking' ? unavailableStartupState : current
+
+const restoreUnavailableUnlessReady = (current: DatabaseStartupState): DatabaseStartupState =>
+  current.phase === 'ready' ? current : unavailableStartupState
 
 const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.Element => {
   const { t } = useTranslation()
@@ -40,17 +48,13 @@ const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.
         if (!disposed && !receivedEvent) setState(current)
       })
       .catch(() => {
-        if (!disposed && !receivedEvent) {
-          setState(
-            unavailableStartupState(t('Open Science could not finish checking its database.'))
-          )
-        }
+        if (!disposed && !receivedEvent) setState(applyUnavailableStartupFallback)
       })
     return () => {
       disposed = true
       unsubscribe()
     }
-  }, [databaseStartup, t])
+  }, [databaseStartup])
 
   if (state.phase === 'ready') return <>{children}</>
 
@@ -61,7 +65,7 @@ const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.
       .retry()
       .then(setState)
       .catch(() => {
-        setState(unavailableStartupState(t('Open Science could not finish checking its database.')))
+        setState(restoreUnavailableUnlessReady)
       })
       .finally(() => setRetrying(false))
   }
@@ -84,7 +88,11 @@ const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.
             <h1 className="text-lg font-semibold text-card-foreground">
               {t("Open Science couldn't start")}
             </h1>
-            <p className="mt-3 text-sm leading-6 text-muted-foreground">{state.error.message}</p>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">
+              {state.error.code === 'database_startup_unavailable'
+                ? t('Open Science could not finish checking its database.')
+                : state.error.message}
+            </p>
             <p className="mt-4 font-mono text-xs text-muted-foreground">
               {t('Error code:')} {state.error.code}
               {state.error.migrationId

--- a/src/renderer/src/components/database-startup-gate.tsx
+++ b/src/renderer/src/components/database-startup-gate.tsx
@@ -9,6 +9,15 @@ import type { DatabaseStartupState } from '../../../shared/database-startup'
 
 type DatabaseStartupGateProps = { children: ReactNode }
 
+const unavailableStartupState = (message: string): DatabaseStartupState => ({
+  phase: 'blocked',
+  error: {
+    code: 'database_startup_unavailable',
+    message,
+    retryable: true
+  }
+})
+
 const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.Element => {
   const { t } = useTranslation()
   const databaseStartup = (window.api as Partial<Window['api']> | undefined)?.databaseStartup
@@ -25,14 +34,23 @@ const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.
       receivedEvent = true
       if (!disposed) setState(next)
     })
-    void databaseStartup.getState().then((current) => {
-      if (!disposed && !receivedEvent) setState(current)
-    })
+    void databaseStartup
+      .getState()
+      .then((current) => {
+        if (!disposed && !receivedEvent) setState(current)
+      })
+      .catch(() => {
+        if (!disposed && !receivedEvent) {
+          setState(
+            unavailableStartupState(t('Open Science could not finish checking its database.'))
+          )
+        }
+      })
     return () => {
       disposed = true
       unsubscribe()
     }
-  }, [databaseStartup])
+  }, [databaseStartup, t])
 
   if (state.phase === 'ready') return <>{children}</>
 
@@ -42,6 +60,9 @@ const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.
     void databaseStartup
       .retry()
       .then(setState)
+      .catch(() => {
+        setState(unavailableStartupState(t('Open Science could not finish checking its database.')))
+      })
       .finally(() => setRetrying(false))
   }
 

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -1118,6 +1118,7 @@
   "Some Specialist data could not be read.": "一部のスペシャリスト データを読み取れませんでした。",
   "Open Science couldn't remove the unused copy. Normal work has resumed. You can delete the copy later.": "Open Science は未使用のコピーを削除できませんでした。通常の作業が再開されました。コピーは後で削除できます。",
   "Open Science couldn't stop the agent for this Session. The Session was not deleted. Please try again.": "Open Science は、このセッションの Agent を停止できませんでした。セッションは削除されませんでした。もう一度試してください。",
+  "Open Science could not finish checking its database.": "Open Science はデータベースの確認を完了できませんでした。",
   "Open Science couldn't start": "Open Science を開始できませんでした",
   "Open Science is stopping background tasks and will close to finish installing. The update may take a moment; please don't reopen the app during this step. The updated app will reopen automatically.": "Open Science はバックグラウンド タスクを停止しているため、インストールを完了するために終了します。更新には少し時間がかかる場合があります。このステップ中にアプリを再度開かないでください。更新されたアプリは自動的に再度開きます。",
   "Open Science needs write access to its private configuration directory.": "Open Science には、プライベート構成ディレクトリへの書き込みアクセスが必要です。",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -1179,6 +1179,7 @@
   "Some Specialist data could not be read.": "部分 Specialist 数据无法读取。",
   "Open Science couldn't remove the unused copy. Normal work has resumed. You can delete the copy later.": "Open Science 无法删除未使用的副本。正常工作已恢复，你可以稍后删除该副本。",
   "Open Science couldn't stop the agent for this Session. The Session was not deleted. Please try again.": "Open Science 无法停止此会话的 Agent。会话未被删除，请重试。",
+  "Open Science could not finish checking its database.": "Open Science 无法完成数据库检查。",
   "Open Science couldn't start": "Open Science 无法启动",
   "Open Science is stopping background tasks and will close to finish installing. The update may take a moment; please don't reopen the app during this step. The updated app will reopen automatically.": "Open Science 正在停止后台任务，并将关闭以完成安装。更新可能需要一些时间，请勿在此期间重新打开应用。更新完成后应用会自动重新打开。",
   "Open Science needs write access to its private configuration directory.": "Open Science 需要对其私有配置目录的写入权限。",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -1177,6 +1177,7 @@
   "Some Specialist data could not be read.": "部分 Specialist 資料無法讀取。",
   "Open Science couldn't remove the unused copy. Normal work has resumed. You can delete the copy later.": "Open Science 無法刪除未使用的副本。正常工作已恢復，你可以稍後刪除該副本。",
   "Open Science couldn't stop the agent for this Session. The Session was not deleted. Please try again.": "Open Science 無法停止此會話的 Agent。會話未被刪除，請重試。",
+  "Open Science could not finish checking its database.": "Open Science 無法完成資料庫檢查。",
   "Open Science couldn't start": "Open Science 無法啟動",
   "Open Science is stopping background tasks and will close to finish installing. The update may take a moment; please don't reopen the app during this step. The updated app will reopen automatically.": "Open Science 正在停止背景工作，並將關閉以完成安裝。更新可能需要一些時間，請勿在此期間重新開啟應用程式。更新完成後應用程式會自動重新開啟。",
   "Open Science needs write access to its private configuration directory.": "Open Science 需要對其私有設定目錄的寫入權限。",

--- a/src/shared/database-startup.ts
+++ b/src/shared/database-startup.ts
@@ -5,6 +5,7 @@ type DatabaseStartupErrorCode =
   | 'database_history_invalid'
   | 'database_migration_failed'
   | 'database_validation_failed'
+  | 'database_startup_unavailable'
 
 type DatabaseStartupError = {
   code: DatabaseStartupErrorCode


### PR DESCRIPTION
## Problem

The Electron database-startup shell initialized to `checking` and only left that phase when `databaseStartup.getState()` resolved or `onStateChanged` delivered a later state. Both `getState()` and `retry()` were invoked without a rejection handler.

If the catch-up IPC read rejected after the live event was missed, the UI stayed on **Checking database…**, the business `App` never mounted, and Quit/Retry never appeared. If Retry itself rejected after the owner had already published `checking`, the loader returned with no recovery controls.

## Proposed change

- Add in-memory error code `database_startup_unavailable` (`retryable: true`).
- Treat unclassified `verifyDatabase` failures as that blocked state and **resolve** `start()` / `retry()` instead of rejecting, so Retry is a real second attempt.
- Catch renderer `getState()` / `retry()` rejections and show the existing blocked card (Quit + Retry). A later live event still wins over a late `getState()` rejection.

```mermaid
stateDiagram-v2
  [*] --> checking: renderer mount
  checking --> blocked: classified DB error or IPC/unclassified failure
  checking --> ready: owner.complete
  blocked --> checking: Retry
  blocked --> [*]: Quit
  ready --> App
```

## Scope and non-goals

- No Prisma / migration / settings persistence changes.
- No historical data compatibility work.
- No new `phase`, IPC channel, or contract-catalog entry.
- Web still has no `databaseStartup` API and still mounts immediately. Headless still awaits the owner directly.

### Explicit callouts

| Topic | Change |
| --- | --- |
| Historical data compatibility | None |
| New enum | `database_startup_unavailable` on `DatabaseStartupErrorCode` (process-local, not persisted) |
| Persistence | None |

First-launch unclassified errors no longer reject the compose `Promise.race` and `app.quit()`. They now stay on the startup shell, matching classified `blocked` failures.

## Acceptance criteria and validation

- `getState()` IPC reject shows the blocked card with Retry and Quit; `App` stays unmounted.
- A live `ready` / progress event is not overwritten by a later `getState()` rejection.
- `retry()` IPC reject after a `checking` event returns to the blocked card with Retry.
- Unclassified owner verification failures resolve to retryable `database_startup_unavailable`; a later Retry can verify successfully.

## Review focus

- Whether `database_startup_unavailable` is the right code for both IPC reject and unclassified owner failures.
- Whether resolving (not rejecting) unclassified `start()` is the intended first-launch lifecycle.

## Test Impact Set

These checks ran after the last material edit, from `.worktree/database-startup-gate-ipc-reject`:

| Behavior | Command | Result |
| --- | --- | --- |
| Gate IPC reject / retry restore | `npm test -- src/renderer/src/components/database-startup-gate.test.tsx` | pass (7) |
| Owner unclassified failure + retry | `npm test -- src/main/database/database-startup-owner.test.ts` | pass (4) |
| i18n catalogs for the new `t()` string | `npm test -- src/renderer/src/i18n/resources.test.ts` | pass (88) |
| IPC bridge and startup logging consumers | `npm test -- src/main/database/database-startup-ipc.test.ts src/main/database/database-startup-logging.test.ts` | pass (8) |
| Renderer types | `npm run typecheck:web` | pass |
| Main/shared types | `npm run typecheck:node` | pass |
| Changed TS files | `npx eslint --cache` on the 5 edited TS files | pass |

These files are not a named `module-impact.json` module. Full `npm test` was not run locally; exact-head CI is authoritative.

### Included / excluded

- Included: owner of the gate and startup owner, i18n guard for the new string, adjacent IPC/logging consumers, both process typechecks.
- Excluded: Web/headless startup (API absent / no UI gate), Prisma/migration suites (no schema change), E2E/platform packaging (no window/lifecycle contract change beyond staying on the existing blocked shell).

### Uncovered risks

- A permanent missing IPC handler still only offers in-app Retry/Quit; it cannot repair a disposed main handler.
- Existing classified `DatabaseMigrationError.message` values remain English from main and are still rendered raw.