### PR TITLE
fix(session-persistence): reject stale session snapshots

### DIFF
--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -1220,6 +1220,27 @@ describe('AcpRuntimeCoordinator', () => {
     expect(created.compactSession).not.toHaveBeenCalled()
   })
 
+  it('reopens prompt admission when quit preparation is aborted', async () => {
+    let created!: ReturnType<typeof createFakeRuntime>
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      created = createFakeRuntime({
+        frameworkId: 'claude-code',
+        sessionIds: ['session-1'],
+        callbacks
+      })
+      return created.runtime
+    })
+    const session = await coordinator.createSession({ cwd: '/workspace' })
+
+    await expect(coordinator.prepareForQuit()).resolves.toBe('completed')
+    coordinator.abortQuitPreparation()
+
+    await expect(
+      coordinator.sendPrompt({ sessionId: session.sessionId, text: 'retry after conflict' })
+    ).resolves.toBeDefined()
+    expect(created.sendPrompt).toHaveBeenCalledOnce()
+  })
+
   it('linearizes real user prompts and upward continuations through one root admission lock', async () => {
     const prompts = [
       createDeferred<unknown>(),

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -1220,27 +1220,6 @@ describe('AcpRuntimeCoordinator', () => {
     expect(created.compactSession).not.toHaveBeenCalled()
   })
 
-  it('reopens prompt admission when quit preparation is aborted', async () => {
-    let created!: ReturnType<typeof createFakeRuntime>
-    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
-      created = createFakeRuntime({
-        frameworkId: 'claude-code',
-        sessionIds: ['session-1'],
-        callbacks
-      })
-      return created.runtime
-    })
-    const session = await coordinator.createSession({ cwd: '/workspace' })
-
-    await expect(coordinator.prepareForQuit()).resolves.toBe('completed')
-    coordinator.abortQuitPreparation()
-
-    await expect(
-      coordinator.sendPrompt({ sessionId: session.sessionId, text: 'retry after conflict' })
-    ).resolves.toBeDefined()
-    expect(created.sendPrompt).toHaveBeenCalledOnce()
-  })
-
   it('linearizes real user prompts and upward continuations through one root admission lock', async () => {
     const prompts = [
       createDeferred<unknown>(),

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -461,12 +461,6 @@ class AcpRuntimeCoordinator {
     })
   }
 
-  abortQuitPreparation(): void {
-    if (this.providerShutdownStartedForQuit) return
-    this.promptAdmissionClosedForQuit = false
-    this.durableQuitDetachedSessionIds.clear()
-  }
-
   async shutdownForUpdateGate(): Promise<{ reaped: boolean }> {
     this.invalidateAllSessionTurns()
     this.supersedeInitializationRequests()

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -461,6 +461,12 @@ class AcpRuntimeCoordinator {
     })
   }
 
+  abortQuitPreparation(): void {
+    if (this.providerShutdownStartedForQuit) return
+    this.promptAdmissionClosedForQuit = false
+    this.durableQuitDetachedSessionIds.clear()
+  }
+
   async shutdownForUpdateGate(): Promise<{ reaped: boolean }> {
     this.invalidateAllSessionTurns()
     this.supersedeInitializationRequests()

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -440,10 +440,11 @@ describe('installAppLifecycle', () => {
   it('records a degraded renderer persistence flush and drains terminal logs before exit', async () => {
     const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
     const flushLogs = vi.fn(async () => undefined)
+    const flushSessionPersistence = vi.fn(async () => 'timeout' as const)
     const { app, closeOpts } = setup({
       log,
       flushLogs,
-      flushSessionPersistence: vi.fn(async () => 'timeout' as const)
+      flushSessionPersistence
     })
     closeOpts[0].requestQuit()
 
@@ -462,6 +463,7 @@ describe('installAppLifecycle', () => {
       })
     )
     expect(flushLogs).toHaveBeenCalledOnce()
+    expect(flushSessionPersistence).toHaveBeenCalledOnce()
     expect(flushLogs.mock.invocationCallOrder[0]).toBeLessThan(app.exit.mock.invocationCallOrder[0])
   })
 

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -123,7 +123,9 @@ type Harness = {
   trayHandlers: TrayHandlers | undefined
   shutdownBackends: () => Promise<ShutdownStepOutcome | void>
   prepareForQuit: () => Promise<ShutdownStepOutcome | void>
-  flushSessionPersistence: () => Promise<RendererSessionPersistenceFlushOutcome | void>
+  flushSessionPersistence: (
+    timeoutMs?: number
+  ) => Promise<RendererSessionPersistenceFlushOutcome | void>
   quit: ReturnType<typeof vi.fn>
   showMainWindow: () => void
   getMainWindow: () => import('electron').BrowserWindow | undefined
@@ -142,6 +144,7 @@ const setup = (
       | 'log'
       | 'flushLogs'
       | 'logFlushTimeoutMs'
+      | 'rendererFlushTimeoutMs'
       | 'shutdownTrigger'
       | 'isMigrationInProgress'
       | 'platform'
@@ -195,6 +198,7 @@ const setup = (
     log: overrides.log,
     flushLogs: overrides.flushLogs,
     logFlushTimeoutMs: overrides.logFlushTimeoutMs,
+    rendererFlushTimeoutMs: overrides.rendererFlushTimeoutMs,
     shutdownTrigger: overrides.shutdownTrigger,
     isMigrationInProgress: overrides.isMigrationInProgress ?? ((): boolean => false),
     quit,
@@ -437,7 +441,7 @@ describe('installAppLifecycle', () => {
     expect(app.exit).toHaveBeenCalledWith(0)
   })
 
-  it('records a degraded renderer persistence flush and drains terminal logs before exit', async () => {
+  it('bounds both renderer persistence attempts and drains terminal logs before exit', async () => {
     const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
     const flushLogs = vi.fn(async () => undefined)
     const flushSessionPersistence = vi.fn(async () => 'timeout' as const)
@@ -463,7 +467,7 @@ describe('installAppLifecycle', () => {
       })
     )
     expect(flushLogs).toHaveBeenCalledOnce()
-    expect(flushSessionPersistence).toHaveBeenCalledOnce()
+    expect(flushSessionPersistence.mock.calls).toEqual([[2_500], [2_500]])
     expect(flushLogs.mock.invocationCallOrder[0]).toBeLessThan(app.exit.mock.invocationCallOrder[0])
   })
 

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -529,6 +529,24 @@ describe('installAppLifecycle', () => {
     )
   })
 
+  it('keeps the app open when the renderer reports an unresolved Session revision conflict', async () => {
+    const flushSessionPersistence = vi.fn(async () => 'conflict' as const)
+    const { app, closeOpts, shutdownBackends, tray, windows } = setup({
+      flushSessionPersistence
+    })
+    closeOpts[0].requestQuit()
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(flushSessionPersistence).toHaveBeenCalledOnce()
+    expect(shutdownBackends).not.toHaveBeenCalled()
+    expect(tray?.destroy).not.toHaveBeenCalled()
+    expect(app.exit).not.toHaveBeenCalled()
+    expect(windows[0].visible).toBe(true)
+    expect(windows[0].focused).toBe(true)
+  })
+
   it('quits on window-all-closed only when non-darwin and no tray host', () => {
     const noTray = setup({ trayHost: false, platform: 'linux' })
     noTray.app.emit('window-all-closed')

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -123,6 +123,7 @@ type Harness = {
   trayHandlers: TrayHandlers | undefined
   shutdownBackends: () => Promise<ShutdownStepOutcome | void>
   prepareForQuit: () => Promise<ShutdownStepOutcome | void>
+  abortQuitPreparation: ReturnType<typeof vi.fn>
   flushSessionPersistence: () => Promise<RendererSessionPersistenceFlushOutcome | void>
   quit: ReturnType<typeof vi.fn>
   showMainWindow: () => void
@@ -138,6 +139,7 @@ const setup = (
       AppLifecycleDeps,
       | 'shutdownBackends'
       | 'prepareForQuit'
+      | 'abortQuitPreparation'
       | 'flushSessionPersistence'
       | 'log'
       | 'flushLogs'
@@ -166,6 +168,7 @@ const setup = (
   let trayHandlers: TrayHandlers | undefined
   const shutdownBackends = overrides.shutdownBackends ?? vi.fn(async () => undefined)
   const prepareForQuit = overrides.prepareForQuit ?? vi.fn(async () => undefined)
+  const abortQuitPreparation = vi.fn(overrides.abortQuitPreparation ?? (() => undefined))
   const flushSessionPersistence =
     overrides.flushSessionPersistence ?? vi.fn(async () => 'completed' as const)
   const quit = vi.fn()
@@ -191,6 +194,7 @@ const setup = (
     },
     shutdownBackends,
     prepareForQuit,
+    abortQuitPreparation,
     flushSessionPersistence,
     log: overrides.log,
     flushLogs: overrides.flushLogs,
@@ -212,6 +216,7 @@ const setup = (
     trayHandlers,
     shutdownBackends,
     prepareForQuit,
+    abortQuitPreparation,
     flushSessionPersistence,
     quit,
     showMainWindow,
@@ -355,6 +360,7 @@ describe('installAppLifecycle', () => {
       createTray: () => ({ destroy: vi.fn() }) as unknown as import('electron').Tray,
       shutdownBackends,
       prepareForQuit: async () => undefined,
+      abortQuitPreparation: () => undefined,
       flushSessionPersistence: async () => undefined,
       isMigrationInProgress: (): boolean => false,
       quit: vi.fn(),
@@ -531,7 +537,7 @@ describe('installAppLifecycle', () => {
 
   it('keeps the app open when the renderer reports an unresolved Session revision conflict', async () => {
     const flushSessionPersistence = vi.fn(async () => 'conflict' as const)
-    const { app, closeOpts, shutdownBackends, tray, windows } = setup({
+    const { app, closeOpts, shutdownBackends, abortQuitPreparation, tray, windows } = setup({
       flushSessionPersistence
     })
     closeOpts[0].requestQuit()
@@ -541,6 +547,7 @@ describe('installAppLifecycle', () => {
 
     expect(flushSessionPersistence).toHaveBeenCalledOnce()
     expect(shutdownBackends).not.toHaveBeenCalled()
+    expect(abortQuitPreparation).toHaveBeenCalledOnce()
     expect(tray?.destroy).not.toHaveBeenCalled()
     expect(app.exit).not.toHaveBeenCalled()
     expect(windows[0].visible).toBe(true)

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -123,7 +123,6 @@ type Harness = {
   trayHandlers: TrayHandlers | undefined
   shutdownBackends: () => Promise<ShutdownStepOutcome | void>
   prepareForQuit: () => Promise<ShutdownStepOutcome | void>
-  abortQuitPreparation: ReturnType<typeof vi.fn>
   flushSessionPersistence: () => Promise<RendererSessionPersistenceFlushOutcome | void>
   quit: ReturnType<typeof vi.fn>
   showMainWindow: () => void
@@ -139,7 +138,6 @@ const setup = (
       AppLifecycleDeps,
       | 'shutdownBackends'
       | 'prepareForQuit'
-      | 'abortQuitPreparation'
       | 'flushSessionPersistence'
       | 'log'
       | 'flushLogs'
@@ -168,7 +166,6 @@ const setup = (
   let trayHandlers: TrayHandlers | undefined
   const shutdownBackends = overrides.shutdownBackends ?? vi.fn(async () => undefined)
   const prepareForQuit = overrides.prepareForQuit ?? vi.fn(async () => undefined)
-  const abortQuitPreparation = vi.fn(overrides.abortQuitPreparation ?? (() => undefined))
   const flushSessionPersistence =
     overrides.flushSessionPersistence ?? vi.fn(async () => 'completed' as const)
   const quit = vi.fn()
@@ -194,7 +191,6 @@ const setup = (
     },
     shutdownBackends,
     prepareForQuit,
-    abortQuitPreparation,
     flushSessionPersistence,
     log: overrides.log,
     flushLogs: overrides.flushLogs,
@@ -216,7 +212,6 @@ const setup = (
     trayHandlers,
     shutdownBackends,
     prepareForQuit,
-    abortQuitPreparation,
     flushSessionPersistence,
     quit,
     showMainWindow,
@@ -360,7 +355,6 @@ describe('installAppLifecycle', () => {
       createTray: () => ({ destroy: vi.fn() }) as unknown as import('electron').Tray,
       shutdownBackends,
       prepareForQuit: async () => undefined,
-      abortQuitPreparation: () => undefined,
       flushSessionPersistence: async () => undefined,
       isMigrationInProgress: (): boolean => false,
       quit: vi.fn(),
@@ -439,7 +433,7 @@ describe('installAppLifecycle', () => {
     app.emit('before-quit')
     await flush()
 
-    expect(calls).toEqual(['prepare', 'flush', 'shutdown'])
+    expect(calls).toEqual(['flush', 'prepare', 'flush', 'shutdown'])
     expect(app.exit).toHaveBeenCalledWith(0)
   })
 
@@ -537,7 +531,7 @@ describe('installAppLifecycle', () => {
 
   it('keeps the app open when the renderer reports an unresolved Session revision conflict', async () => {
     const flushSessionPersistence = vi.fn(async () => 'conflict' as const)
-    const { app, closeOpts, shutdownBackends, abortQuitPreparation, tray, windows } = setup({
+    const { app, closeOpts, prepareForQuit, shutdownBackends, tray, windows } = setup({
       flushSessionPersistence
     })
     closeOpts[0].requestQuit()
@@ -546,12 +540,31 @@ describe('installAppLifecycle', () => {
     await flush()
 
     expect(flushSessionPersistence).toHaveBeenCalledOnce()
+    expect(prepareForQuit).not.toHaveBeenCalled()
     expect(shutdownBackends).not.toHaveBeenCalled()
-    expect(abortQuitPreparation).toHaveBeenCalledOnce()
     expect(tray?.destroy).not.toHaveBeenCalled()
     expect(app.exit).not.toHaveBeenCalled()
     expect(windows[0].visible).toBe(true)
     expect(windows[0].focused).toBe(true)
+  })
+
+  it('finishes quit from the durable preflight snapshot when the terminal flush conflicts', async () => {
+    const flushSessionPersistence = vi
+      .fn()
+      .mockResolvedValueOnce('completed' as const)
+      .mockResolvedValueOnce('conflict' as const)
+    const { app, closeOpts, prepareForQuit, shutdownBackends } = setup({
+      flushSessionPersistence
+    })
+    closeOpts[0].requestQuit()
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(flushSessionPersistence).toHaveBeenCalledTimes(2)
+    expect(prepareForQuit).toHaveBeenCalledOnce()
+    expect(shutdownBackends).toHaveBeenCalledOnce()
+    expect(app.exit).toHaveBeenCalledWith(0)
   })
 
   it('quits on window-all-closed only when non-darwin and no tray host', () => {

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -56,12 +56,16 @@ export type AppLifecycleDeps = {
   // Requests active ACP turns to cancel, then waits a bounded interval for terminal usage events.
   prepareForQuit: () => Promise<ShutdownStepOutcome | void>
   // Drains renderer runtime events and its ordered Session write queue before the window disappears.
-  flushSessionPersistence: () => Promise<RendererSessionPersistenceFlushOutcome | void>
+  flushSessionPersistence: (
+    timeoutMs?: number
+  ) => Promise<RendererSessionPersistenceFlushOutcome | void>
   // Local structured diagnostics remain optional for the dependency-injected lifecycle tests.
   log?: Logger
   // Drains the logger's serialized write queue after the shutdown terminal record.
   flushLogs?: () => Promise<void>
   logFlushTimeoutMs?: number
+  // Shared timeout budget for the preflight and post-drain renderer persistence attempts.
+  rendererFlushTimeoutMs?: number
   // Classifies an orderly shutdown without changing its cleanup sequence.
   shutdownTrigger?: () => ApplicationShutdownTrigger
   // True while a data-root migration is copying; a quit during it is owned by the migration guard.
@@ -97,6 +101,9 @@ export const installAppLifecycle = (
 } => {
   const platform = deps.platform ?? process.platform
   const logFlushTimeoutMs = deps.logFlushTimeoutMs ?? 1_000
+  const rendererFlushTimeoutMs = Math.max(2, deps.rendererFlushTimeoutMs ?? 5_000)
+  const rendererPreflightTimeoutMs = Math.floor(rendererFlushTimeoutMs / 2)
+  const rendererFinalFlushTimeoutMs = rendererFlushTimeoutMs - rendererPreflightTimeoutMs
 
   let mainWindow: BrowserWindow | undefined
   const hiddenWindows = new WeakSet<BrowserWindow>()
@@ -310,14 +317,15 @@ export const installAppLifecycle = (
       let backendTeardownResult: ShutdownStepOutcome
       let shutdownAbortedForSessionConflict = false
       const flushRendererSessionPersistence = async (
-        phase: 'renderer-session-preflight' | 'renderer-session-flush'
+        phase: 'renderer-session-preflight' | 'renderer-session-flush',
+        timeoutMs: number
       ): Promise<{
         outcome: RendererSessionPersistenceFlushOutcome
         result: ShutdownStepOutcome
       }> => {
         diagnostics?.phase(phase)
         try {
-          const outcome = (await deps.flushSessionPersistence()) ?? 'completed'
+          const outcome = (await deps.flushSessionPersistence(timeoutMs)) ?? 'completed'
           const result = rendererStepOutcome(outcome)
           diagnostics?.phase(phase, { result })
           return { outcome, result }
@@ -327,7 +335,10 @@ export const installAppLifecycle = (
         }
       }
       try {
-        const preflight = await flushRendererSessionPersistence('renderer-session-preflight')
+        const preflight = await flushRendererSessionPersistence(
+          'renderer-session-preflight',
+          rendererPreflightTimeoutMs
+        )
         rendererPreflightOutcome = preflight.outcome
         rendererPreflightResult = preflight.result
         if (rendererPreflightOutcome === 'conflict') {
@@ -358,18 +369,12 @@ export const installAppLifecycle = (
           })
         }
 
-        if (rendererPreflightOutcome === 'timeout') {
-          rendererFlushOutcome = 'timeout'
-          rendererFlushResult = 'timeout'
-          diagnostics?.phase('renderer-session-flush', {
-            result: rendererFlushResult,
-            skippedAfterPreflightTimeout: true
-          })
-        } else {
-          const finalFlush = await flushRendererSessionPersistence('renderer-session-flush')
-          rendererFlushOutcome = finalFlush.outcome
-          rendererFlushResult = finalFlush.result
-        }
+        const finalFlush = await flushRendererSessionPersistence(
+          'renderer-session-flush',
+          rendererFinalFlushTimeoutMs
+        )
+        rendererFlushOutcome = finalFlush.outcome
+        rendererFlushResult = finalFlush.result
 
         diagnostics?.phase('backend-teardown')
         try {

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -358,9 +358,18 @@ export const installAppLifecycle = (
           })
         }
 
-        const finalFlush = await flushRendererSessionPersistence('renderer-session-flush')
-        rendererFlushOutcome = finalFlush.outcome
-        rendererFlushResult = finalFlush.result
+        if (rendererPreflightOutcome === 'timeout') {
+          rendererFlushOutcome = 'timeout'
+          rendererFlushResult = 'timeout'
+          diagnostics?.phase('renderer-session-flush', {
+            result: rendererFlushResult,
+            skippedAfterPreflightTimeout: true
+          })
+        } else {
+          const finalFlush = await flushRendererSessionPersistence('renderer-session-flush')
+          rendererFlushOutcome = finalFlush.outcome
+          rendererFlushResult = finalFlush.result
+        }
 
         diagnostics?.phase('backend-teardown')
         try {

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -55,8 +55,6 @@ export type AppLifecycleDeps = {
   shutdownBackends: () => Promise<ShutdownStepOutcome | void>
   // Requests active ACP turns to cancel, then waits a bounded interval for terminal usage events.
   prepareForQuit: () => Promise<ShutdownStepOutcome | void>
-  // Reopens runtime admission when a persistence conflict aborts the quit before backend teardown.
-  abortQuitPreparation: () => void
   // Drains renderer runtime events and its ordered Session write queue before the window disappears.
   flushSessionPersistence: () => Promise<RendererSessionPersistenceFlushOutcome | void>
   // Local structured diagnostics remain optional for the dependency-injected lifecycle tests.
@@ -305,11 +303,49 @@ export const installAppLifecycle = (
           })
         : undefined
       let usageDrainResult: ShutdownStepOutcome
+      let rendererPreflightOutcome: RendererSessionPersistenceFlushOutcome
+      let rendererPreflightResult: ShutdownStepOutcome
       let rendererFlushOutcome: RendererSessionPersistenceFlushOutcome
       let rendererFlushResult: ShutdownStepOutcome
       let backendTeardownResult: ShutdownStepOutcome
       let shutdownAbortedForSessionConflict = false
+      const flushRendererSessionPersistence = async (
+        phase: 'renderer-session-preflight' | 'renderer-session-flush'
+      ): Promise<{
+        outcome: RendererSessionPersistenceFlushOutcome
+        result: ShutdownStepOutcome
+      }> => {
+        diagnostics?.phase(phase)
+        try {
+          const outcome = (await deps.flushSessionPersistence()) ?? 'completed'
+          const result = rendererStepOutcome(outcome)
+          diagnostics?.phase(phase, { result })
+          return { outcome, result }
+        } catch (error) {
+          diagnostics?.phase(phase, { result: 'failed', ...diagnosticErrorFields(error) })
+          return { outcome: 'send-failed', result: 'failed' }
+        }
+      }
       try {
+        const preflight = await flushRendererSessionPersistence('renderer-session-preflight')
+        rendererPreflightOutcome = preflight.outcome
+        rendererPreflightResult = preflight.result
+        if (rendererPreflightOutcome === 'conflict') {
+          shutdownAbortedForSessionConflict = true
+          diagnostics?.complete({
+            degraded: true,
+            rendererPreflightOutcome,
+            rendererPreflightResult,
+            usageDrainResult: 'degraded',
+            rendererFlushResult: 'degraded',
+            backendTeardownResult: 'degraded'
+          })
+          if (deps.flushLogs) {
+            await flushDiagnosticsWithTimeout(deps.flushLogs, logFlushTimeoutMs)
+          }
+          return
+        }
+
         diagnostics?.phase('usage-drain')
         try {
           usageDrainResult = normalizeStepOutcome(await deps.prepareForQuit())
@@ -322,34 +358,9 @@ export const installAppLifecycle = (
           })
         }
 
-        diagnostics?.phase('renderer-session-flush')
-        try {
-          rendererFlushOutcome = (await deps.flushSessionPersistence()) ?? 'completed'
-          rendererFlushResult = rendererStepOutcome(rendererFlushOutcome)
-          diagnostics?.phase('renderer-session-flush', { result: rendererFlushResult })
-        } catch (error) {
-          rendererFlushOutcome = 'send-failed'
-          rendererFlushResult = 'failed'
-          diagnostics?.phase('renderer-session-flush', {
-            result: rendererFlushResult,
-            ...diagnosticErrorFields(error)
-          })
-        }
-
-        if (rendererFlushOutcome === 'conflict') {
-          shutdownAbortedForSessionConflict = true
-          diagnostics?.complete({
-            degraded: true,
-            usageDrainResult,
-            rendererFlushResult,
-            rendererFlushOutcome,
-            backendTeardownResult: 'degraded'
-          })
-          if (deps.flushLogs) {
-            await flushDiagnosticsWithTimeout(deps.flushLogs, logFlushTimeoutMs)
-          }
-          return
-        }
+        const finalFlush = await flushRendererSessionPersistence('renderer-session-flush')
+        rendererFlushOutcome = finalFlush.outcome
+        rendererFlushResult = finalFlush.result
 
         diagnostics?.phase('backend-teardown')
         try {
@@ -368,6 +379,8 @@ export const installAppLifecycle = (
           backendTeardownResult !== 'completed'
         diagnostics?.complete({
           degraded,
+          rendererPreflightResult,
+          rendererPreflightOutcome,
           usageDrainResult,
           rendererFlushResult,
           rendererFlushOutcome,
@@ -380,11 +393,6 @@ export const installAppLifecycle = (
         }
       } finally {
         if (shutdownAbortedForSessionConflict) {
-          try {
-            deps.abortQuitPreparation()
-          } catch (error) {
-            deps.log?.warn('failed to abort quit preparation', diagnosticErrorFields(error))
-          }
           shutdownStarted = false
           quitConfirmed = false
           clearApplicationShutdownTrigger()

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -120,7 +120,8 @@ export const installAppLifecycle = (
     outcome: RendererSessionPersistenceFlushOutcome
   ): ShutdownStepOutcome => {
     if (outcome === 'timeout') return 'timeout'
-    if (outcome === 'send-failed') return 'failed'
+    if (outcome === 'send-failed' || outcome === 'renderer-failed' || outcome === 'conflict')
+      return 'failed'
     if (outcome === 'renderer-gone') return 'degraded'
     return 'completed'
   }
@@ -305,6 +306,7 @@ export const installAppLifecycle = (
       let rendererFlushOutcome: RendererSessionPersistenceFlushOutcome
       let rendererFlushResult: ShutdownStepOutcome
       let backendTeardownResult: ShutdownStepOutcome
+      let shutdownAbortedForSessionConflict = false
       try {
         diagnostics?.phase('usage-drain')
         try {
@@ -330,6 +332,21 @@ export const installAppLifecycle = (
             result: rendererFlushResult,
             ...diagnosticErrorFields(error)
           })
+        }
+
+        if (rendererFlushOutcome === 'conflict') {
+          shutdownAbortedForSessionConflict = true
+          diagnostics?.complete({
+            degraded: true,
+            usageDrainResult,
+            rendererFlushResult,
+            rendererFlushOutcome,
+            backendTeardownResult: 'degraded'
+          })
+          if (deps.flushLogs) {
+            await flushDiagnosticsWithTimeout(deps.flushLogs, logFlushTimeoutMs)
+          }
+          return
         }
 
         diagnostics?.phase('backend-teardown')
@@ -360,9 +377,16 @@ export const installAppLifecycle = (
           if (result === 'timeout') console.warn('[shutdown] final log flush timed out')
         }
       } finally {
-        trayBox.current?.destroy()
-        shutdownFinished = true
-        deps.app.exit(0)
+        if (shutdownAbortedForSessionConflict) {
+          shutdownStarted = false
+          quitConfirmed = false
+          clearApplicationShutdownTrigger()
+          showMainWindow()
+        } else {
+          trayBox.current?.destroy()
+          shutdownFinished = true
+          deps.app.exit(0)
+        }
       }
     })()
   })

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -55,6 +55,8 @@ export type AppLifecycleDeps = {
   shutdownBackends: () => Promise<ShutdownStepOutcome | void>
   // Requests active ACP turns to cancel, then waits a bounded interval for terminal usage events.
   prepareForQuit: () => Promise<ShutdownStepOutcome | void>
+  // Reopens runtime admission when a persistence conflict aborts the quit before backend teardown.
+  abortQuitPreparation: () => void
   // Drains renderer runtime events and its ordered Session write queue before the window disappears.
   flushSessionPersistence: () => Promise<RendererSessionPersistenceFlushOutcome | void>
   // Local structured diagnostics remain optional for the dependency-injected lifecycle tests.
@@ -378,6 +380,11 @@ export const installAppLifecycle = (
         }
       } finally {
         if (shutdownAbortedForSessionConflict) {
+          try {
+            deps.abortQuitPreparation()
+          } catch (error) {
+            deps.log?.warn('failed to abort quit preparation', diagnosticErrorFields(error))
+          }
           shutdownStarted = false
           quitConfirmed = false
           clearApplicationShutdownTrigger()

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -13,7 +13,10 @@ import {
   registerDataContentApplicationCommands,
   type DataContentApplicationCommandDependencies
 } from './data-content-application-commands'
-import type { SessionDeletionResult } from '../shared/session-persistence'
+import {
+  SessionRevisionConflictError,
+  type SessionDeletionResult
+} from '../shared/session-persistence'
 import { ApplicationCommandError } from '../shared/application-command-contract'
 
 const callerContext = createCallerContext({
@@ -647,6 +650,24 @@ describe('Data and content application commands', () => {
       session: deps.session,
       originClientId: 'web:renderer-1'
     })
+  })
+
+  it('preserves the Session revision conflict code across the application command boundary', async () => {
+    const router = createApplicationCommandRouter()
+    const deps = createDependencies()
+    deps.sessions.saveSession.mockRejectedValueOnce(new SessionRevisionConflictError(1, 2))
+    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+
+    await expect(
+      router.dispatcher.invoke(
+        dataContentApplicationCommands.sessionSave,
+        invocation([deps.session] as const)
+      )
+    ).rejects.toMatchObject({
+      code: 'session-revision-conflict',
+      message: expect.stringContaining('expected 1, actual 2')
+    })
+    expect(deps.events.publish).not.toHaveBeenCalled()
   })
 
   it('allows only current Task automation to update main-owned delegation policy', async () => {

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -13,7 +13,10 @@ import type { ProjectHandlers } from './projects/ipc'
 import type { SessionPersistenceHandlers } from './session-persistence/ipc'
 import type { ManagedPreviewOwnerRegistry } from './managed-preview-ipc'
 
-import type { ApplicationCommandContract } from '../shared/application-command-contract'
+import {
+  ApplicationCommandError,
+  type ApplicationCommandContract
+} from '../shared/application-command-contract'
 import * as Artifacts from '../shared/artifacts'
 import type * as ConversationExport from '../shared/conversation-export'
 import { LIFECYCLE_CHANNELS } from '../shared/lifecycle-events'
@@ -538,10 +541,18 @@ const registerDataContentApplicationCommands = (
       'sessions:save-session': (invocation) => {
         const originClientId = invocation.callerContext.lifecycleClientId
         return dependencies.withDataRootWrite(async () => {
-          const result = await dependencies.sessions.saveSession(
-            invocation.args[0],
-            invocation.args[1]
-          )
+          let result: Awaited<ReturnType<SessionPersistenceHandlers['saveSession']>>
+          try {
+            result = await dependencies.sessions.saveSession(invocation.args[0], invocation.args[1])
+          } catch (error) {
+            if (SessionPersistence.isSessionRevisionConflictError(error)) {
+              throw new ApplicationCommandError(
+                SessionPersistence.SESSION_REVISION_CONFLICT_ERROR_CODE,
+                error instanceof Error ? error.message : 'Session revision conflict.'
+              )
+            }
+            throw error
+          }
           publishLifecycle(
             dependencies.events,
             result.created ? LIFECYCLE_CHANNELS.sessionCreated : LIFECYCLE_CHANNELS.sessionUpdated,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -409,7 +409,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           taskControls,
           detectActiveSessions,
           prepareForQuit,
-          abortQuitPreparation,
           dispose: disposeApplicationRuntime
         } = await registerIpcHandlers({
           mainEntryPath,
@@ -515,7 +514,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           disposeApplicationRuntime,
           detectActiveSessions,
           prepareForQuit,
-          abortQuitPreparation,
           createSessionPersistenceFlush: (
             getWindow: () => InstanceType<typeof BrowserWindow> | undefined
           ) => createElectronSessionPersistenceFlush(getWindow),
@@ -608,7 +606,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             createInitialWindow: !ctx.webMode.headless,
             detectActiveSessions: ctx.detectActiveSessions,
             prepareForQuit: ctx.prepareForQuit,
-            abortQuitPreparation: ctx.abortQuitPreparation,
             flushSessionPersistence: ctx.createSessionPersistenceFlush(() =>
               ctx.mainWindowGetterBox.current?.()
             ),

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -409,6 +409,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           taskControls,
           detectActiveSessions,
           prepareForQuit,
+          abortQuitPreparation,
           dispose: disposeApplicationRuntime
         } = await registerIpcHandlers({
           mainEntryPath,
@@ -514,6 +515,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           disposeApplicationRuntime,
           detectActiveSessions,
           prepareForQuit,
+          abortQuitPreparation,
           createSessionPersistenceFlush: (
             getWindow: () => InstanceType<typeof BrowserWindow> | undefined
           ) => createElectronSessionPersistenceFlush(getWindow),
@@ -606,6 +608,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             createInitialWindow: !ctx.webMode.headless,
             detectActiveSessions: ctx.detectActiveSessions,
             prepareForQuit: ctx.prepareForQuit,
+            abortQuitPreparation: ctx.abortQuitPreparation,
             flushSessionPersistence: ctx.createSessionPersistenceFlush(() =>
               ctx.mainWindowGetterBox.current?.()
             ),

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -31,7 +31,8 @@ import type { ApplicationInvocation } from './application-command-router'
 import { createApplicationEventModule, type ApplicationEventSource } from './application-events'
 import {
   LIFECYCLE_CHANNELS,
-  MAIN_DELEGATED_WORK_LIFECYCLE_CLIENT_ID
+  MAIN_DELEGATED_WORK_LIFECYCLE_CLIENT_ID,
+  MAIN_RUNTIME_CONTEXT_LIFECYCLE_CLIENT_ID
 } from '../shared/lifecycle-events'
 
 import { createAcpRuntime } from './acp/runtime-composition'
@@ -711,7 +712,14 @@ const createApplicationModules = async (
     },
     undefined,
     computeJobDeletionPort,
-    (session) => {
+    (session, owner) => {
+      if (owner === 'runtime-context') {
+        broadcastToRenderers(LIFECYCLE_CHANNELS.sessionUpdated, {
+          session,
+          originClientId: MAIN_RUNTIME_CONTEXT_LIFECYCLE_CLIENT_ID
+        })
+        return
+      }
       delegatedActivity.recordSession(session)
       broadcastToRenderers(LIFECYCLE_CHANNELS.sessionUpdated, {
         session,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -351,6 +351,7 @@ export type ApplicationRuntimeInterfaces = {
   archiveCapability: Pick<ArchiveCoordinator, 'isSessionAvailableById' | 'setMarkReadSessions'>
   detectActiveSessions: () => ReturnType<typeof detectActiveSessions>
   prepareForQuit: () => Promise<Extract<ShutdownStepOutcome, 'completed' | 'timeout' | 'failed'>>
+  abortQuitPreparation: () => void
 }
 
 type ApplicationModuleInterfaces = ApplicationRuntimeInterfaces & {
@@ -3092,6 +3093,7 @@ const createApplicationModules = async (
         notebook: notebookService
       }),
     prepareForQuit: () => runtime.prepareForQuit(),
+    abortQuitPreparation: () => runtime.abortQuitPreparation(),
     electronAdapters: {
       beforeCompute: beforeComputeAdapters,
       compute: {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -351,7 +351,6 @@ export type ApplicationRuntimeInterfaces = {
   archiveCapability: Pick<ArchiveCoordinator, 'isSessionAvailableById' | 'setMarkReadSessions'>
   detectActiveSessions: () => ReturnType<typeof detectActiveSessions>
   prepareForQuit: () => Promise<Extract<ShutdownStepOutcome, 'completed' | 'timeout' | 'failed'>>
-  abortQuitPreparation: () => void
 }
 
 type ApplicationModuleInterfaces = ApplicationRuntimeInterfaces & {
@@ -3093,7 +3092,6 @@ const createApplicationModules = async (
         notebook: notebookService
       }),
     prepareForQuit: () => runtime.prepareForQuit(),
-    abortQuitPreparation: () => runtime.abortQuitPreparation(),
     electronAdapters: {
       beforeCompute: beforeComputeAdapters,
       compute: {

--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -521,7 +521,6 @@ describe('Session persistence coordinator architecture', () => {
         'fileIndex',
         'log',
         'delegatedWorkOwner',
-        'onDelegatedWorkSessionUpdated',
         'onFilesChanged',
         'operationScheduler',
         'reconciliationOwner',

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -927,6 +927,113 @@ describe('SessionPersistenceCoordinator', () => {
     expect(durable.updatedAt).toBeGreaterThan(previousUpdatedAt)
   })
 
+  it('rejects a stale whole-session snapshot before it replaces newer renderer-owned fields', async () => {
+    const olderMessage: PersistedChatMessage = {
+      id: 'older-message',
+      role: 'user',
+      content: 'Older prompt',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const newerMessage: PersistedChatMessage = {
+      id: 'newer-message',
+      role: 'agent',
+      content: 'Newer response',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 3,
+      updatedAt: 3
+    }
+    let durable = materializeSessionConversationGraph(
+      createSession({
+        revision: 1,
+        title: 'Newer title',
+        messages: [olderMessage, newerMessage],
+        updatedAt: 4
+      })
+    )
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      })),
+      saveSession: vi.fn(async (session) => {
+        durable = structuredClone(session)
+      })
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+    const staleSnapshot = materializeSessionConversationGraph(
+      createSession({ revision: 0, title: 'Older title', messages: [olderMessage], updatedAt: 2 })
+    )
+
+    await expect(coordinator.saveSession(staleSnapshot)).rejects.toMatchObject({
+      code: 'session-revision-conflict',
+      expectedRevision: 0,
+      actualRevision: 1
+    })
+
+    expect.soft(durable.title).toBe('Newer title')
+    expect
+      .soft(durable.messages.map((message) => message.id))
+      .toEqual([olderMessage.id, newerMessage.id])
+    expect
+      .soft(durable.conversationGraph?.messages.map((message) => message.id))
+      .toEqual([olderMessage.id, newerMessage.id])
+  })
+
+  it('rebases explicit renderer fields when a stale save carries the unchanged durable graph', async () => {
+    const message: PersistedChatMessage = {
+      id: 'message-1',
+      role: 'user',
+      content: 'Keep this graph',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    let durable = materializeSessionConversationGraph(
+      createSession({
+        revision: 2,
+        title: 'Remote title',
+        pinned: true,
+        messages: [message],
+        updatedAt: 3
+      })
+    )
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      })),
+      saveSession: vi.fn(async (session, expectedRevision) => {
+        durable = structuredClone({
+          ...session,
+          revision: (expectedRevision ?? session.revision ?? 0) + 1
+        })
+        return durable
+      })
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+    const staleTitleEdit = materializeSessionConversationGraph(
+      createSession({
+        revision: 1,
+        title: 'Local title',
+        messages: [message],
+        updatedAt: 3
+      })
+    )
+
+    await expect(
+      coordinator.saveSession(staleTitleEdit, { conflictRebaseFields: ['title'] })
+    ).resolves.toMatchObject({ revision: 3, title: 'Local title', pinned: true })
+    expect(durable.conversationGraph?.messages.map(({ id }) => id)).toEqual([message.id])
+    expect(durable.conversationGraph?.branches.map(({ id }) => id)).toEqual(
+      staleTitleEdit.conversationGraph?.branches.map(({ id }) => id)
+    )
+  })
+
   it('rejects saving a globally identified Session under another Project', async () => {
     const existing = createSession({ id: 'session-1', projectId: 'project-a' })
     const repository = createSessionRepository({
@@ -1217,8 +1324,12 @@ describe('SessionPersistenceCoordinator', () => {
         status: 'found' as const,
         session: durable
       })),
-      saveSession: vi.fn(async (session) => {
-        durable = structuredClone(session)
+      saveSession: vi.fn(async (session, expectedRevision) => {
+        durable = structuredClone({
+          ...session,
+          revision: (expectedRevision ?? session.revision ?? 0) + 1
+        })
+        return durable
       })
     })
     const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
@@ -1830,12 +1941,15 @@ describe('SessionPersistenceCoordinator', () => {
       uploads
     )
 
-    await expect(coordinator.saveSession(legacySession)).resolves.toBe(durableSession)
+    await expect(coordinator.saveSession(legacySession)).resolves.toEqual({
+      ...durableSession,
+      revision: 1
+    })
     expect(uploads.upgradeLegacySessionUploads).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'session-1' }),
       { mode: 'live-save' }
     )
-    expect(repository.saveSession).toHaveBeenCalledWith(durableSession)
+    expect(repository.saveSession).toHaveBeenCalledWith(expect.objectContaining(durableSession), 0)
   })
 
   it('does not overwrite Session JSON when finalized Artifact bindings reject the snapshot', async () => {
@@ -2064,7 +2178,14 @@ describe('SessionPersistenceCoordinator', () => {
     expect(result.updatedAt).toBeGreaterThan(authoritativeSession.updatedAt)
     expect(result.updatedAt).toBeGreaterThan(submittedSession.updatedAt)
     expect(result.messages).toEqual(authoritativeSession.messages)
-    expect(repository.saveSession).toHaveBeenCalledWith(result)
+    expect(repository.saveSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: result.title,
+        pinned: result.pinned,
+        messages: result.messages
+      }),
+      0
+    )
     expect(provenance.validateFinalizedMessageBindings).toHaveBeenCalledTimes(2)
     expect(provenance.captureFinalizedMessages).toHaveBeenCalledWith(result)
   })
@@ -2092,7 +2213,13 @@ describe('SessionPersistenceCoordinator', () => {
       specialistBindingPending: true
     })
     expect(result.updatedAt).toBeGreaterThan(authoritativeSession.updatedAt)
-    expect(repository.saveSession).toHaveBeenCalledWith(result)
+    expect(repository.saveSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        specialistId: result.specialistId,
+        specialistBindingPending: result.specialistBindingPending
+      }),
+      0
+    )
   })
 
   it('rebases a specialist binding onto the latest durable graph after a conflict', async () => {
@@ -2152,7 +2279,14 @@ describe('SessionPersistenceCoordinator', () => {
     expect(result.specialistId).toBe('specialist-new')
     expect(result.specialistBindingPending).toBe(true)
     expect(result.messages).toEqual(authoritativeSession.messages)
-    expect(repository.saveSession).toHaveBeenCalledWith(result)
+    expect(repository.saveSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        specialistId: result.specialistId,
+        specialistBindingPending: result.specialistBindingPending,
+        messages: result.messages
+      }),
+      0
+    )
   })
 
   it('restores DB visibility and clears the tombstone when JSON deletion fails', async () => {
@@ -2518,10 +2652,11 @@ describe('SessionPersistenceCoordinator', () => {
 
     try {
       await repository.saveSession(createSession())
-      await coordinator.loadAll()
+      const initialHydration = await coordinator.loadAll()
 
       await coordinator.saveSession(
         createSession({
+          revision: initialHydration.sessions[0].revision,
           status: 'running',
           activeRun: { promptMessageId: 'prompt-1', startedAt: 3 },
           messages: [

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -478,7 +478,19 @@ describe('SessionPersistenceCoordinator', () => {
         durable = structuredClone(session)
       })
     })
-    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+    const publishRuntimeContextSession = vi.fn()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      publishRuntimeContextSession
+    )
 
     const message = await coordinator.appendUserMessageToInteraction({
       projectId: 'project-1',
@@ -507,6 +519,14 @@ describe('SessionPersistenceCoordinator', () => {
       }
     })
     expect(durable.status).toBe('waiting-plan-approval')
+    expect(publishRuntimeContextSession).toHaveBeenCalledOnce()
+    expect(publishRuntimeContextSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [expect.objectContaining({ content: 'Split the analysis by cohort.' })],
+        runtimeContext: expect.objectContaining({ revision: 3 })
+      }),
+      'runtime-context'
+    )
   })
 
   it('persists Side chat projection and relays without overwriting concurrent authority', async () => {
@@ -781,10 +801,26 @@ describe('SessionPersistenceCoordinator', () => {
         session: durable
       })),
       saveSession: vi.fn(async (session) => {
-        durable = structuredClone(session)
+        durable = {
+          ...structuredClone(session),
+          revision: (session.revision ?? 0) + 1
+        }
+        return structuredClone(durable)
       })
     })
-    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+    const publishRuntimeContextSession = vi.fn()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      publishRuntimeContextSession
+    )
 
     await expect(coordinator.readSessionRuntimeContext('project-1', 'session-1')).resolves.toEqual({
       version: 1,
@@ -808,6 +844,15 @@ describe('SessionPersistenceCoordinator', () => {
       plan: createRuntimePlan()
     })
     expect(durable.updatedAt).toBeGreaterThan(previousUpdatedAt)
+    expect(publishRuntimeContextSession).toHaveBeenCalledOnce()
+    expect(publishRuntimeContextSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'session-1',
+        revision: 1,
+        runtimeContext: expect.objectContaining({ revision: 1 })
+      }),
+      'runtime-context'
+    )
   })
 
   it('does not persist a runtime context patch when its commit precondition fails', async () => {

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -40,6 +40,7 @@ import type { ManagedFileSoftDeleteToken } from '../project-files/repository'
 import type { ProjectSessionDeletionState } from './repository'
 import { createLogger, diagnosticErrorFields, type Logger } from '../logger'
 import { startDiagnosticOperation } from '../diagnostics/operation'
+import { saveSessionWithRevision } from './save-session'
 import {
   SessionPersistenceStateOwner,
   SessionRuntimeContextRevisionConflictError,
@@ -102,7 +103,10 @@ type SessionMutationRepository = {
     | { status: 'unreadable' }
   >
   assertSessionIdentityOwnership(sessionId: string, expectedProjectId: string): Promise<void>
-  saveSession(session: PersistedChatSession): Promise<void>
+  saveSession(
+    session: PersistedChatSession,
+    expectedRevision?: number
+  ): Promise<PersistedChatSession | void>
   saveCommittedProjectSession(session: PersistedChatSession): Promise<void>
   deleteSession(projectId: string, sessionId: string): Promise<void>
   deleteProjectSessions(projectId: string): Promise<void>
@@ -411,9 +415,12 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
           try {
             const recovery = recoverInterruptedDelegatedWorkSession(sessions[index])
             if (recovery.interrupted.length === 0) continue
-            await this.repository.saveSession(recovery.session)
+            const persistedRecovery = await saveSessionWithRevision(
+              this.repository,
+              recovery.session
+            )
             sessions = sessions.map((candidate, candidateIndex) =>
-              candidateIndex === index ? recovery.session : candidate
+              candidateIndex === index ? persistedRecovery : candidate
             )
             result = { ...result, sessions }
           } catch (error) {

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -1,5 +1,4 @@
-import type { ProjectFilesChangedEvent } from '../../shared/project-files'
-import type { ProjectFileSource } from '../../shared/project-files'
+import type { ProjectFileSource, ProjectFilesChangedEvent } from '../../shared/project-files'
 import type {
   DelegationPolicy,
   LoadAllSessionsResult,

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -73,6 +73,10 @@ import {
 } from './delegated-work-owner'
 import { SessionPersistenceOperationScheduler } from './operation-scheduler'
 import { isSessionCatalogAuthoritative } from './catalog-authority'
+import {
+  createSafeSessionUpdatePublisher as safeSessionUpdates,
+  type SessionUpdatePublisher
+} from './session-update-publication'
 
 type SessionMutationRepository = {
   loadAllWithDiagnostics(options?: { mode?: 'repair' | 'read-only' }): Promise<{
@@ -200,8 +204,9 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
     permissionGrants?: SessionPermissionGrantReconciliation,
     private readonly log: Logger = createLogger('session-persistence'),
     private readonly computeJobs?: ComputeJobDeletionParticipant,
-    private readonly onDelegatedWorkSessionUpdated?: (session: PersistedChatSession) => void
+    onDelegatedWorkSessionUpdated?: SessionUpdatePublisher
   ) {
+    const publishSessionUpdate = safeSessionUpdates(onDelegatedWorkSessionUpdated, log)
     const assertMutable = (
       projectId: string,
       sessionId: string,
@@ -221,7 +226,9 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
       uploads,
       log,
       assertMutable,
-      notifyFilesChanged: (event) => this.notifyFilesChanged(event)
+      notifyFilesChanged: (event) => this.notifyFilesChanged(event),
+      notifyRuntimeContextSessionUpdated: (session) =>
+        publishSessionUpdate(session, 'runtime-context')
     })
     this.sideChatOwner = new SessionSideChatPersistenceOwner({
       repository,
@@ -264,15 +271,7 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
       markStartupRecoveryComplete: () => {
         this.delegatedStartupRecoveryComplete = true
       },
-      notifySessionUpdated: (session) => {
-        try {
-          this.onDelegatedWorkSessionUpdated?.(session)
-        } catch (error) {
-          this.log.warn('delegated work Session publication failed', {
-            errorCategory: error instanceof Error ? error.name : typeof error
-          })
-        }
-      }
+      notifySessionUpdated: (session) => publishSessionUpdate(session, 'delegated-work')
     })
   }
 

--- a/src/main/session-persistence/delegated-work-store.ts
+++ b/src/main/session-persistence/delegated-work-store.ts
@@ -21,6 +21,7 @@ import type {
   ChildRecord,
   SessionKey
 } from '../delegation/session-records'
+import { saveSessionWithRevision } from './save-session'
 import { SessionRuntimeContextRevisionConflictError } from './state-owner'
 
 type DelegatedWorkSessionRepository = {
@@ -38,7 +39,7 @@ type DelegatedWorkSessionRepository = {
     | { status: 'missing' }
     | { status: 'unreadable' }
   >
-  saveSession(session: PersistedChatSession): Promise<void>
+  saveSession(session: PersistedChatSession): Promise<PersistedChatSession | void>
 }
 
 type SessionDelegatedWorkStoreOptions = {
@@ -231,8 +232,8 @@ class SessionDelegatedWorkStore {
         runtimeContext,
         updatedAt
       }
-      await this.options.repository.saveSession(updated)
-      this.options.notifySessionUpdated(updated)
+      const persisted = await saveSessionWithRevision(this.options.repository, updated)
+      this.options.notifySessionUpdated(persisted)
       return result
     })
   }
@@ -313,8 +314,8 @@ class SessionDelegatedWorkStore {
         filesRevision: (materialized.filesRevision ?? 0) + 1,
         updatedAt: Math.max(materialized.updatedAt + 1, Date.now())
       }
-      await this.options.repository.saveSession(updated)
-      this.options.notifySessionUpdated(updated)
+      const persisted = await saveSessionWithRevision(this.options.repository, updated)
+      this.options.notifySessionUpdated(persisted)
     })
   }
 
@@ -355,8 +356,8 @@ class SessionDelegatedWorkStore {
       for (const session of scan.result.sessions) {
         const recovery = recoverInterruptedDelegatedWorkSession(session)
         if (recovery.interrupted.length === 0) continue
-        await this.options.repository.saveSession(recovery.session)
-        this.options.notifySessionUpdated(recovery.session)
+        const persisted = await saveSessionWithRevision(this.options.repository, recovery.session)
+        this.options.notifySessionUpdated(persisted)
         interrupted.push(...recovery.interrupted)
       }
       this.options.markStartupRecoveryComplete()

--- a/src/main/session-persistence/deletion-owner.ts
+++ b/src/main/session-persistence/deletion-owner.ts
@@ -15,6 +15,7 @@ import {
   UnsafeLegacyUploadResidualError
 } from '../uploads/repository'
 import type { ProjectSessionDeletionState } from './repository'
+import { saveSessionWithRevision } from './save-session'
 import type { SessionPersistenceStateOwner } from './state-owner'
 import { hasLegacySessionUpload } from './legacy-upload'
 
@@ -44,7 +45,7 @@ type SessionDeletionRepository = {
     | { status: 'missing' }
     | { status: 'unreadable' }
   >
-  saveSession(session: PersistedChatSession): Promise<void>
+  saveSession(session: PersistedChatSession): Promise<PersistedChatSession | void>
   saveCommittedProjectSession(session: PersistedChatSession): Promise<void>
   deleteSession(projectId: string, sessionId: string): Promise<void>
   deleteProjectSessions(projectId: string): Promise<void>
@@ -204,9 +205,9 @@ class SessionPersistenceDeletionOwner {
     const next: PersistedChatSession = { ...loaded.session }
     if (request.archived) next.archivedAt = Date.now()
     else delete next.archivedAt
-    await this.repository.saveSession(next)
-    this.stateOwner.recordSession(next)
-    return next
+    const persisted = await saveSessionWithRevision(this.repository, next)
+    this.stateOwner.recordSession(persisted)
+    return persisted
   }
 
   private async prepareSessionUploadsForTerminalDelete(
@@ -221,16 +222,17 @@ class SessionPersistenceDeletionOwner {
     const upgradedSession = await this.uploads.upgradeLegacySessionUploads(session, {
       mode: 'live-save'
     })
-    await this.repository.saveSession(upgradedSession)
-    return this.uploads.upgradeLegacySessionUploads(upgradedSession, {
+    const persisted = await saveSessionWithRevision(this.repository, upgradedSession)
+    return this.uploads.upgradeLegacySessionUploads(persisted, {
       mode: 'terminal-delete'
     })
   }
 
   private async prepareProjectSessionUploadsForTerminalDelete(
     session: PersistedChatSession,
-    saveUpgradedSession: (session: PersistedChatSession) => Promise<void> = (upgraded) =>
-      this.repository.saveSession(upgraded),
+    saveUpgradedSession: (session: PersistedChatSession) => Promise<void> = async (upgraded) => {
+      await saveSessionWithRevision(this.repository, upgraded)
+    },
     requireExistingUploadAuthority = false
   ): Promise<{ hasUnsafeResidual: boolean }> {
     if (!this.uploads) return { hasUnsafeResidual: false }

--- a/src/main/session-persistence/reconciliation-owner.ts
+++ b/src/main/session-persistence/reconciliation-owner.ts
@@ -10,9 +10,10 @@ import {
 import type { ArtifactProjectReconciliationSnapshot } from '../artifacts/provenance-repository'
 import { repairHistoricalArtifactAliases } from './artifact-alias-repair'
 import { hasLegacySessionUpload } from './legacy-upload'
+import { saveSessionWithRevision } from './save-session'
 
 type SessionReconciliationRepository = {
-  saveSession(session: PersistedChatSession): Promise<void>
+  saveSession(session: PersistedChatSession): Promise<PersistedChatSession | void>
 }
 
 type SessionReconciliationFileIndex = {
@@ -243,9 +244,13 @@ class SessionPersistenceReconciliationOwner {
               candidateIndex === index ? upgradedSession : candidate
             )
             result = { ...result, sessions }
-            await this.repository.saveSession(upgradedSession)
+            const persisted = await saveSessionWithRevision(this.repository, upgradedSession)
+            sessions = sessions.map((candidate, candidateIndex) =>
+              candidateIndex === index ? persisted : candidate
+            )
+            result = { ...result, sessions }
             if (input.allowDestructiveCleanup) {
-              await this.uploads.upgradeLegacySessionUploads(upgradedSession, {
+              await this.uploads.upgradeLegacySessionUploads(persisted, {
                 mode: 'reconcile'
               })
             }
@@ -286,13 +291,17 @@ class SessionPersistenceReconciliationOwner {
           advanceFilesRevision: attachedSession === session
         })
         if (recoveredSession !== session) {
+          // Capture immutable Message evidence before JSON so a failure leaves an attachment witness.
           sessions = sessions.map((candidate, candidateIndex) =>
             candidateIndex === index ? recoveredSession : candidate
           )
           result = { ...result, sessions }
-          // Capture immutable Message evidence before JSON so a failure leaves an attachment witness.
           await this.provenance?.captureFinalizedMessages(recoveredSession)
-          await this.repository.saveSession(recoveredSession)
+          const persisted = await saveSessionWithRevision(this.repository, recoveredSession)
+          sessions = sessions.map((candidate, candidateIndex) =>
+            candidateIndex === index ? persisted : candidate
+          )
+          result = { ...result, sessions }
         }
       }
       // Restore active owners before scan-order-dependent sync offers canonical rows elsewhere.

--- a/src/main/session-persistence/renderer-flush.test.ts
+++ b/src/main/session-persistence/renderer-flush.test.ts
@@ -98,6 +98,13 @@ describe('requestRendererSessionPersistenceFlush', () => {
     await expect(request).resolves.toBe('conflict')
   })
 
+  it('fails closed when the renderer returns an invalid status', async () => {
+    const harness = createHarness()
+    const request = harness.request()
+    harness.respond('flush-1', 'invalid' as SessionPersistenceFlushResponse['status'])
+    await expect(request).resolves.toBe('renderer-failed')
+  })
+
   it('releases the quit when the renderer disappears', async () => {
     const harness = createHarness()
     const request = harness.request()

--- a/src/main/session-persistence/renderer-flush.test.ts
+++ b/src/main/session-persistence/renderer-flush.test.ts
@@ -4,6 +4,7 @@ import {
   SESSION_PERSISTENCE_FLUSH_REQUEST_CHANNEL,
   SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL
 } from '../../shared/session-persistence-flush'
+import type { SessionPersistenceFlushResponse } from '../../shared/session-persistence-flush'
 import {
   createElectronSessionPersistenceFlush,
   requestRendererSessionPersistenceFlush
@@ -22,13 +23,13 @@ vi.mock('electron', () => ({
   }
 }))
 
-type Listener = (requestId: string) => void
+type Listener = (response: SessionPersistenceFlushResponse) => void
 
 const createHarness = (
   available = true
 ): {
   sendRequest: ReturnType<typeof vi.fn>
-  respond: Listener
+  respond: (requestId: string, status?: SessionPersistenceFlushResponse['status']) => void
   rendererGone: () => void
   cleanupResponse: ReturnType<typeof vi.fn>
   cleanupGone: ReturnType<typeof vi.fn>
@@ -42,7 +43,7 @@ const createHarness = (
 
   return {
     sendRequest,
-    respond: (requestId) => responseListener(requestId),
+    respond: (requestId, status = 'completed') => responseListener({ requestId, status }),
     rendererGone: () => goneListener(),
     cleanupResponse,
     cleanupGone,
@@ -88,6 +89,13 @@ describe('requestRendererSessionPersistenceFlush', () => {
     const harness = createHarness(false)
     await expect(harness.request()).resolves.toBe('unavailable')
     expect(harness.sendRequest).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an unresolved renderer revision conflict to the quit owner', async () => {
+    const harness = createHarness()
+    const request = harness.request()
+    harness.respond('flush-1', 'conflict')
+    await expect(request).resolves.toBe('conflict')
   })
 
   it('releases the quit when the renderer disappears', async () => {
@@ -187,7 +195,7 @@ describe('createElectronSessionPersistenceFlush', () => {
       ([channel]) => channel === SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL
     )
     const responseHandler = responseRegistration?.[1] as
-      ((event: { sender: unknown }, response: { requestId: string }) => void) | undefined
+      ((event: { sender: unknown }, response: SessionPersistenceFlushResponse) => void) | undefined
     expect(responseHandler).toBeTypeOf('function')
     const rendererGoneRegistration = webContents.on.mock.calls.find(
       ([event]) => event === 'render-process-gone'
@@ -195,15 +203,18 @@ describe('createElectronSessionPersistenceFlush', () => {
     const rendererGoneListener = rendererGoneRegistration?.[1] as (() => void) | undefined
     expect(rendererGoneListener).toBeTypeOf('function')
 
-    responseHandler?.({ sender: {} }, { requestId: sentRequest.requestId })
+    responseHandler?.({ sender: {} }, { requestId: sentRequest.requestId, status: 'completed' })
     await Promise.resolve()
     expect(settled).toBe(false)
 
-    responseHandler?.({ sender: webContents }, { requestId: 'other-request' })
+    responseHandler?.({ sender: webContents }, { requestId: 'other-request', status: 'completed' })
     await Promise.resolve()
     expect(settled).toBe(false)
 
-    responseHandler?.({ sender: webContents }, { requestId: sentRequest.requestId })
+    responseHandler?.(
+      { sender: webContents },
+      { requestId: sentRequest.requestId, status: 'completed' }
+    )
     await expect(request).resolves.toBe('completed')
     expect(electronMocks.removeListener).toHaveBeenCalledWith(
       SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL,

--- a/src/main/session-persistence/renderer-flush.ts
+++ b/src/main/session-persistence/renderer-flush.ts
@@ -49,7 +49,11 @@ export const requestRendererSessionPersistenceFlush = async (
     const timer = setTimeout(() => finish('timeout'), deps.timeoutMs)
     removeResponse = deps.onResponse((response) => {
       if (response.requestId !== requestId) return
-      finish(response.status === 'failed' ? 'renderer-failed' : response.status)
+      if (response.status === 'completed' || response.status === 'conflict') {
+        finish(response.status)
+        return
+      }
+      finish('renderer-failed')
     })
     removeRendererGone = deps.onRendererGone(() => finish('renderer-gone'))
 

--- a/src/main/session-persistence/renderer-flush.ts
+++ b/src/main/session-persistence/renderer-flush.ts
@@ -11,7 +11,7 @@ import {
 type RendererSessionPersistenceFlushDeps = {
   isRendererAvailable: () => boolean
   sendRequest: (requestId: string) => void
-  onResponse: (listener: (requestId: string) => void) => () => void
+  onResponse: (listener: (response: SessionPersistenceFlushResponse) => void) => () => void
   onRendererGone: (listener: () => void) => () => void
   createRequestId: () => string
   timeoutMs: number
@@ -20,7 +20,13 @@ type RendererSessionPersistenceFlushDeps = {
 const DEFAULT_RENDERER_FLUSH_TIMEOUT_MS = 5_000
 
 export type RendererSessionPersistenceFlushOutcome =
-  'completed' | 'unavailable' | 'renderer-gone' | 'send-failed' | 'timeout'
+  | 'completed'
+  | 'conflict'
+  | 'renderer-failed'
+  | 'unavailable'
+  | 'renderer-gone'
+  | 'send-failed'
+  | 'timeout'
 
 export const requestRendererSessionPersistenceFlush = async (
   deps: RendererSessionPersistenceFlushDeps
@@ -41,8 +47,9 @@ export const requestRendererSessionPersistenceFlush = async (
       resolve(outcome)
     }
     const timer = setTimeout(() => finish('timeout'), deps.timeoutMs)
-    removeResponse = deps.onResponse((responseId) => {
-      if (responseId === requestId) finish('completed')
+    removeResponse = deps.onResponse((response) => {
+      if (response.requestId !== requestId) return
+      finish(response.status === 'failed' ? 'renderer-failed' : response.status)
     })
     removeRendererGone = deps.onRendererGone(() => finish('renderer-gone'))
 
@@ -74,7 +81,7 @@ export const createElectronSessionPersistenceFlush = (
           response: SessionPersistenceFlushResponse | undefined
         ): void => {
           if (event.sender !== webContents || typeof response?.requestId !== 'string') return
-          listener(response.requestId)
+          listener(response)
         }
         ipcMain.on(SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL, handler)
         return () => ipcMain.removeListener(SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL, handler)

--- a/src/main/session-persistence/renderer-flush.ts
+++ b/src/main/session-persistence/renderer-flush.ts
@@ -68,8 +68,8 @@ export const requestRendererSessionPersistenceFlush = async (
 export const createElectronSessionPersistenceFlush = (
   getWindow: () => BrowserWindow | undefined,
   timeoutMs = DEFAULT_RENDERER_FLUSH_TIMEOUT_MS
-): (() => Promise<RendererSessionPersistenceFlushOutcome>) => {
-  return () => {
+): ((timeoutOverrideMs?: number) => Promise<RendererSessionPersistenceFlushOutcome>) => {
+  return (timeoutOverrideMs) => {
     const window = getWindow()
     const webContents = window?.webContents
     return requestRendererSessionPersistenceFlush({
@@ -95,7 +95,7 @@ export const createElectronSessionPersistenceFlush = (
         return () => webContents?.removeListener('render-process-gone', listener)
       },
       createRequestId: randomUUID,
-      timeoutMs
+      timeoutMs: timeoutOverrideMs ?? timeoutMs
     })
   }
 }

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -369,7 +369,7 @@ describe('session persistence repository (per-session files)', () => {
     const wait = vi.fn(async () => undefined)
     const repository = new SessionRepository(await createStorageRoot(), { renameFile, wait })
 
-    await expect(repository.saveSession(createSession())).resolves.toBeUndefined()
+    await expect(repository.saveSession(createSession())).resolves.toMatchObject({ revision: 1 })
 
     expect(renameFile).toHaveBeenCalledTimes(2)
     expect(wait).toHaveBeenCalledTimes(1)
@@ -427,6 +427,34 @@ describe('session persistence repository (per-session files)', () => {
     await expect(repository.loadSessionWithDiagnostics('project-a', 'missing')).resolves.toEqual({
       status: 'missing'
     })
+  })
+
+  it('compares and advances Session revisions inside the atomic write lane', async () => {
+    const repository = new SessionRepository(await createStorageRoot())
+    const first = await repository.saveSession(createSession(), 0)
+    expect(first.revision).toBe(1)
+
+    await expect(
+      repository.saveSession(
+        createSession({ revision: 0, title: 'Stale replacement', updatedAt: 1710000000200 }),
+        0
+      )
+    ).rejects.toMatchObject({
+      code: 'session-revision-conflict',
+      expectedRevision: 0,
+      actualRevision: 1
+    })
+    await expect(repository.loadSession('project-a', 'session-1')).resolves.toMatchObject({
+      revision: 1,
+      title: 'Saved conversation'
+    })
+
+    await expect(
+      repository.saveSession(
+        { ...first, title: 'Accepted replacement', updatedAt: 1710000000300 },
+        1
+      )
+    ).resolves.toMatchObject({ revision: 2, title: 'Accepted replacement' })
   })
 
   it('never writes finalized upload absolute paths into Session JSON', async () => {

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -6,7 +6,9 @@ import {
   createEmptySessionManifest,
   createSessionFile,
   decodeSessionFile,
+  SessionRevisionConflictError,
   sanitizeSessionUploadedAttachments,
+  sessionRevision,
   normalizeSessionManifest,
   type LoadAllSessionsResult,
   type PersistedChatSession,
@@ -187,6 +189,7 @@ const assertSafeSegment = (segment: string): string => {
 // at their Project/Session scope, while malformed JSON is backed up for later recovery.
 class SessionRepository {
   private readonly operationScheduler = new SessionPersistenceOperationScheduler()
+  private readonly sessionRevisions = new Map<string, number>()
   private writeSequence = 0
   private backupSequence = 0
   private readonly dependencies: SessionRepositoryDependencies
@@ -405,11 +408,40 @@ class SessionRepository {
     )
   }
 
-  // Writes one Session file behind its Project/Session lane to preserve authority order.
-  async saveSession(session: PersistedChatSession): Promise<void> {
-    return this.operationScheduler.runSession(session.projectId, session.id, () =>
-      this.writeSession(session)
-    )
+  // Compares and advances whole-Session authority inside the same Project/Session lane as the atomic
+  // replacement. Callers that own a stale renderer projection pass expectedRevision; trusted Main
+  // mutations omit it after loading within the coordinator's matching Session lane.
+  async saveSession(
+    session: PersistedChatSession,
+    expectedRevision?: number
+  ): Promise<PersistedChatSession> {
+    return this.operationScheduler.runSession(session.projectId, session.id, async () => {
+      const key = `${session.projectId}:${session.id}`
+      let actualRevision = Math.max(sessionRevision(session), this.sessionRevisions.get(key) ?? 0)
+      if (expectedRevision !== undefined) {
+        if (!Number.isSafeInteger(expectedRevision) || expectedRevision < 0) {
+          throw new Error('Session expected revision must be a non-negative integer.')
+        }
+        const current = await this.loadSessionWithDiagnostics(session.projectId, session.id, {
+          mode: 'read-only'
+        })
+        if (current.status === 'unreadable') {
+          throw new Error('Cannot compare Session revision because durable JSON is unreadable.')
+        }
+        actualRevision = current.status === 'found' ? sessionRevision(current.session) : 0
+        if (actualRevision !== expectedRevision) {
+          throw new SessionRevisionConflictError(expectedRevision, actualRevision)
+        }
+      }
+
+      const durableSession: PersistedChatSession = {
+        ...session,
+        revision: actualRevision + 1
+      }
+      await this.writeSession(durableSession)
+      this.sessionRevisions.set(key, durableSession.revision!)
+      return durableSession
+    })
   }
 
   async saveCommittedProjectSession(session: PersistedChatSession): Promise<void> {
@@ -417,7 +449,13 @@ class SessionRepository {
       if ((await this.getProjectSessionDeletionState(session.projectId)) !== 'legacy-committed') {
         throw new Error('Cannot save a Session outside committed Project deletion authority.')
       }
-      await this.writeSessionToDirectory(session, this.deletedProjectDir(session.projectId))
+      const key = `${session.projectId}:${session.id}`
+      const durableSession: PersistedChatSession = {
+        ...session,
+        revision: Math.max(sessionRevision(session), this.sessionRevisions.get(key) ?? 0) + 1
+      }
+      await this.writeSessionToDirectory(durableSession, this.deletedProjectDir(session.projectId))
+      this.sessionRevisions.set(key, durableSession.revision!)
     })
   }
 

--- a/src/main/session-persistence/revision-conflict.ts
+++ b/src/main/session-persistence/revision-conflict.ts
@@ -1,0 +1,66 @@
+import { isDeepStrictEqual } from 'node:util'
+
+import {
+  materializeSessionConversationGraph,
+  SessionRevisionConflictError,
+  sessionRevision,
+  type PersistedChatSession,
+  type SaveSessionOptions
+} from '../../shared/session-persistence'
+
+type RebaseFields = NonNullable<SaveSessionOptions['conflictRebaseFields']>
+
+export const rebaseSafeSessionFields = (
+  authoritative: PersistedChatSession,
+  submitted: PersistedChatSession,
+  fields: RebaseFields
+): PersistedChatSession => {
+  const rebased = { ...authoritative }
+  for (const field of fields) {
+    switch (field) {
+      case 'title':
+        rebased.title = submitted.title
+        break
+      case 'permissionProfile':
+        rebased.permissionProfile = submitted.permissionProfile
+        break
+      case 'autoReviewEnabled':
+        rebased.autoReviewEnabled = submitted.autoReviewEnabled
+        break
+      case 'enabledComputeHosts':
+        // Retained in the wire-compatible enum, but this field is now changed only by its command.
+        break
+      case 'pinned':
+        rebased.pinned = submitted.pinned
+        break
+      case 'specialistId':
+        rebased.specialistId = submitted.specialistId
+        break
+      case 'specialistBindingPending':
+        rebased.specialistBindingPending = submitted.specialistBindingPending
+        break
+    }
+  }
+  rebased.updatedAt = Math.max(authoritative.updatedAt, submitted.updatedAt) + 1
+  return rebased
+}
+
+export const resolveRevisionedSessionSave = (
+  authoritative: PersistedChatSession | undefined,
+  submitted: PersistedChatSession,
+  conflictRebaseFields: RebaseFields = []
+): Readonly<{ session: PersistedChatSession; expectedRevision: number }> => {
+  const expectedRevision = sessionRevision(submitted)
+  if (!authoritative || expectedRevision === sessionRevision(authoritative)) {
+    return { session: submitted, expectedRevision }
+  }
+  const submittedGraph = materializeSessionConversationGraph(submitted).conversationGraph
+  const authoritativeGraph = materializeSessionConversationGraph(authoritative).conversationGraph
+  if (conflictRebaseFields.length === 0 || !isDeepStrictEqual(submittedGraph, authoritativeGraph)) {
+    throw new SessionRevisionConflictError(expectedRevision, sessionRevision(authoritative))
+  }
+  return {
+    session: rebaseSafeSessionFields(authoritative, submitted, conflictRebaseFields),
+    expectedRevision: sessionRevision(authoritative)
+  }
+}

--- a/src/main/session-persistence/save-session.ts
+++ b/src/main/session-persistence/save-session.ts
@@ -1,0 +1,22 @@
+import { sessionRevision, type PersistedChatSession } from '../../shared/session-persistence'
+
+type RevisionedSessionRepository = {
+  saveSession(
+    session: PersistedChatSession,
+    expectedRevision?: number
+  ): Promise<PersistedChatSession | void>
+}
+
+export const saveSessionWithRevision = async (
+  repository: RevisionedSessionRepository,
+  session: PersistedChatSession,
+  expectedRevision?: number
+): Promise<PersistedChatSession> => {
+  const revision = expectedRevision ?? sessionRevision(session)
+  const persisted = await (expectedRevision === undefined
+    ? repository.saveSession(session)
+    : repository.saveSession(session, expectedRevision))
+  if (persisted) return persisted
+  if (expectedRevision === undefined) return session
+  return { ...session, revision: revision + 1 }
+}

--- a/src/main/session-persistence/session-update-publication.ts
+++ b/src/main/session-persistence/session-update-publication.ts
@@ -1,0 +1,20 @@
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import type { Logger } from '../logger'
+
+type SessionUpdateOwner = 'delegated-work' | 'runtime-context'
+type SessionUpdatePublisher = (session: PersistedChatSession, owner: SessionUpdateOwner) => void
+
+const createSafeSessionUpdatePublisher =
+  (publish: SessionUpdatePublisher | undefined, log: Logger): SessionUpdatePublisher =>
+  (session, owner) => {
+    try {
+      publish?.(structuredClone(session), owner)
+    } catch (error) {
+      log.warn(`${owner} Session publication failed`, {
+        errorCategory: error instanceof Error ? error.name : typeof error
+      })
+    }
+  }
+
+export { createSafeSessionUpdatePublisher }
+export type { SessionUpdateOwner, SessionUpdatePublisher }

--- a/src/main/session-persistence/side-chat-owner.ts
+++ b/src/main/session-persistence/side-chat-owner.ts
@@ -9,6 +9,7 @@ import {
   type PersistedSideChatRelay,
   type SessionRuntimeContext
 } from '../../shared/session-persistence'
+import { saveSessionWithRevision } from './save-session'
 
 type PersistedSideChatProjection = PersistedSideChat
 
@@ -51,7 +52,7 @@ type SideChatStateRepository = Readonly<{
     | { status: 'missing' }
     | { status: 'unreadable' }
   >
-  saveSession(session: PersistedChatSession): Promise<void>
+  saveSession(session: PersistedChatSession): Promise<PersistedChatSession | void>
 }>
 
 type SessionSideChatPersistenceOwnerOptions = Readonly<{
@@ -192,8 +193,8 @@ class SessionSideChatPersistenceOwner {
       messages: [...session.messages, ...messages],
       updatedAt: timestamp + messages.length - 1
     })
-    await this.options.repository.saveSession(durable)
-    this.options.recordSession(durable)
+    const persisted = await saveSessionWithRevision(this.options.repository, durable)
+    this.options.recordSession(persisted)
     return messages
   }
 
@@ -242,8 +243,8 @@ class SessionSideChatPersistenceOwner {
       runtimeContext,
       updatedAt: Math.max(session.updatedAt + 1, Date.now())
     }
-    await this.options.repository.saveSession(durable)
-    this.options.recordSession(durable)
+    const persisted = await saveSessionWithRevision(this.options.repository, durable)
+    this.options.recordSession(persisted)
   }
 }
 

--- a/src/main/session-persistence/state-owner.ts
+++ b/src/main/session-persistence/state-owner.ts
@@ -6,6 +6,7 @@ import type { ProjectFilesChangedEvent, ProjectFileSource } from '../../shared/p
 import {
   materializeSessionConversationGraph,
   sanitizeSessionRuntimeContext,
+  sessionRevision,
   type DelegationPolicy,
   type PersistedChatMessage,
   type PersistedChatSession,
@@ -16,6 +17,8 @@ import {
 } from '../../shared/session-persistence'
 import { FinalizedArtifactBindingConflictError } from '../artifacts/provenance-message-snapshot'
 import { diagnosticErrorFields, type Logger } from '../logger'
+import { rebaseSafeSessionFields, resolveRevisionedSessionSave } from './revision-conflict'
+import { saveSessionWithRevision } from './save-session'
 
 type SessionMetadata = Readonly<Pick<PersistedChatSession, 'id' | 'projectId' | 'title'>>
 
@@ -56,7 +59,10 @@ type SessionStateRepository = {
     | { status: 'missing' }
     | { status: 'unreadable' }
   >
-  saveSession(session: PersistedChatSession): Promise<void>
+  saveSession(
+    session: PersistedChatSession,
+    expectedRevision?: number
+  ): Promise<PersistedChatSession | void>
 }
 
 type SessionStateFileIndex = {
@@ -103,41 +109,6 @@ const emptySessionRuntimeContext = (): SessionRuntimeContext => ({ version: 1, r
 
 const cloneRuntimeContext = (context: SessionRuntimeContext): SessionRuntimeContext =>
   structuredClone(context)
-
-const rebaseSafeSessionFields = (
-  authoritative: PersistedChatSession,
-  submitted: PersistedChatSession,
-  fields: NonNullable<SaveSessionOptions['conflictRebaseFields']>
-): PersistedChatSession => {
-  const rebased = { ...authoritative }
-  for (const field of fields) {
-    switch (field) {
-      case 'title':
-        rebased.title = submitted.title
-        break
-      case 'permissionProfile':
-        rebased.permissionProfile = submitted.permissionProfile
-        break
-      case 'autoReviewEnabled':
-        rebased.autoReviewEnabled = submitted.autoReviewEnabled
-        break
-      case 'enabledComputeHosts':
-        // Retained in the wire-compatible enum, but this field is now changed only by its command.
-        break
-      case 'pinned':
-        rebased.pinned = submitted.pinned
-        break
-      case 'specialistId':
-        rebased.specialistId = submitted.specialistId
-        break
-      case 'specialistBindingPending':
-        rebased.specialistBindingPending = submitted.specialistBindingPending
-        break
-    }
-  }
-  rebased.updatedAt = Math.max(authoritative.updatedAt, submitted.updatedAt) + 1
-  return rebased
-}
 
 const sessionBindingTopologyHash = (session: PersistedChatSession): string => {
   const graph = session.conversationGraph
@@ -375,7 +346,7 @@ class SessionPersistenceStateOwner {
     const runtimeContext = sanitizeSessionRuntimeContext(candidate)
     if (!runtimeContext) throw new Error('Session runtime context patch is not JSON-safe.')
 
-    await this.options.repository.saveSession({
+    await saveSessionWithRevision(this.options.repository, {
       ...session,
       ...(sessionStatus ? { status: sessionStatus } : {}),
       runtimeContext,
@@ -445,8 +416,8 @@ class SessionPersistenceStateOwner {
       ...(runtimeContext ? { runtimeContext } : {}),
       updatedAt: timestamp
     })
-    await this.options.repository.saveSession(durable)
-    this.recordSession(durable)
+    const persisted = await saveSessionWithRevision(this.options.repository, durable)
+    this.recordSession(persisted)
     return message
   }
 
@@ -468,9 +439,9 @@ class SessionPersistenceStateOwner {
       delegationPolicy: policy,
       updatedAt: Math.max(loaded.session.updatedAt + 1, Date.now())
     }
-    await this.options.repository.saveSession(durableSession)
-    this.recordSession(durableSession)
-    return durableSession
+    const persisted = await saveSessionWithRevision(this.options.repository, durableSession)
+    this.recordSession(persisted)
+    return persisted
   }
 
   async setEnabledComputeHosts(
@@ -488,9 +459,9 @@ class SessionPersistenceStateOwner {
       enabledComputeHosts: [...providerIds],
       updatedAt: Math.max(loaded.session.updatedAt + 1, Date.now())
     }
-    await this.options.repository.saveSession(durableSession)
-    this.recordSession(durableSession)
-    return durableSession
+    const persisted = await saveSessionWithRevision(this.options.repository, durableSession)
+    this.recordSession(persisted)
+    return persisted
   }
 
   async pruneEnabledComputeHosts(
@@ -498,7 +469,10 @@ class SessionPersistenceStateOwner {
     validProviderIds: ReadonlySet<string>
   ): Promise<PersistedChatSession[]> {
     const durableSessions: PersistedChatSession[] = []
-    const attemptedSessions: PersistedChatSession[] = []
+    const attemptedSessions: Array<{
+      session: PersistedChatSession
+      rollbackRevision: number
+    }> = []
     try {
       for (const session of sessions) {
         const current = session.enabledComputeHosts ?? []
@@ -513,18 +487,24 @@ class SessionPersistenceStateOwner {
           enabledComputeHosts,
           updatedAt: Math.max(session.updatedAt + 1, Date.now())
         }
-        attemptedSessions.push(session)
-        await this.options.repository.saveSession(durableSession)
-        this.recordSession(durableSession)
-        durableSessions.push(durableSession)
+        const rollback = { session, rollbackRevision: sessionRevision(session) }
+        attemptedSessions.push(rollback)
+        const persisted = await saveSessionWithRevision(this.options.repository, durableSession)
+        rollback.rollbackRevision = sessionRevision(persisted)
+        this.recordSession(persisted)
+        durableSessions.push(persisted)
       }
       return durableSessions
     } catch (error) {
       const rollbackErrors: unknown[] = []
-      for (const session of attemptedSessions) {
+      for (const { session, rollbackRevision } of attemptedSessions) {
         try {
-          await this.options.repository.saveSession(session)
-          this.recordSession(session)
+          const persisted = await saveSessionWithRevision(
+            this.options.repository,
+            session,
+            rollbackRevision
+          )
+          this.recordSession(persisted)
         } catch (rollbackError) {
           rollbackErrors.push(rollbackError)
         }
@@ -553,10 +533,16 @@ class SessionPersistenceStateOwner {
         'Cannot save Session projection because main-owned runtime context is unreadable.'
       )
     }
-    const rendererOwnedSession: PersistedChatSession = { ...session }
+    const authority = authoritative.status === 'found' ? authoritative.session : undefined
+    const { session: submittedSession, expectedRevision } = resolveRevisionedSessionSave(
+      authority,
+      session,
+      options.conflictRebaseFields
+    )
+
+    const rendererOwnedSession: PersistedChatSession = { ...submittedSession }
     delete rendererOwnedSession.runtimeContext
     delete rendererOwnedSession.archivedAt
-    const authority = authoritative.status === 'found' ? authoritative.session : undefined
     const specialistBindingOwnedByCaller =
       options.conflictRebaseFields?.includes('specialistId') === true &&
       options.conflictRebaseFields.includes('specialistBindingPending')
@@ -641,7 +627,7 @@ class SessionPersistenceStateOwner {
           mode: 'live-save'
         })
       : materializedSession
-    const key = `${session.projectId}:${session.id}`
+    const key = `${submittedSession.projectId}:${submittedSession.id}`
     let bindingTopology = sessionBindingTopologyHash(durableSession)
     let bindingValidation: FinalizedArtifactBindingValidation =
       this.validatedBindingTopologies.get(key) === bindingTopology
@@ -656,8 +642,8 @@ class SessionPersistenceStateOwner {
       if (conflictRebaseFields.length === 0) throw bindingValidation.error
 
       const latest = await this.options.repository.loadSessionWithDiagnostics(
-        session.projectId,
-        session.id
+        submittedSession.projectId,
+        submittedSession.id
       )
       if (latest.status !== 'found') throw bindingValidation.error
       const rebasedSession = rebaseSafeSessionFields(
@@ -682,19 +668,23 @@ class SessionPersistenceStateOwner {
       if (bindingValidation.status === 'conflict') throw bindingValidation.error
     }
 
-    await this.options.repository.saveSession(durableSession)
-    this.recordSession(durableSession)
+    const persistedSession = await saveSessionWithRevision(
+      this.options.repository,
+      durableSession,
+      expectedRevision
+    )
+    this.recordSession(persistedSession)
     if (bindingValidation.status === 'valid') {
       this.validatedBindingTopologies.set(key, bindingTopology)
     }
-    await this.options.provenance?.captureFinalizedMessages(durableSession)
+    await this.options.provenance?.captureFinalizedMessages(persistedSession)
     let changedSources: ProjectFileSource[]
     try {
-      changedSources = await this.options.fileIndex.syncSession(durableSession)
+      changedSources = await this.options.fileIndex.syncSession(persistedSession)
     } catch (error) {
       this.markMetadataIncomplete()
       this.options.notifyFilesChanged({
-        projectId: session.projectId,
+        projectId: submittedSession.projectId,
         sources: ['artifact', 'upload'],
         kind: 'reset'
       })
@@ -702,13 +692,13 @@ class SessionPersistenceStateOwner {
     }
     if (changedSources.length > 0) {
       this.options.notifyFilesChanged({
-        projectId: session.projectId,
-        sessionId: session.id,
+        projectId: submittedSession.projectId,
+        sessionId: submittedSession.id,
         sources: changedSources,
         kind: 'upsert'
       })
     }
-    return durableSession
+    return persistedSession
   }
 }
 

--- a/src/main/session-persistence/state-owner.ts
+++ b/src/main/session-persistence/state-owner.ts
@@ -86,6 +86,7 @@ type SessionPersistenceStateOwnerOptions = {
   fileIndex: SessionStateFileIndex
   assertMutable(projectId: string, sessionId: string, operation: 'save' | 'mutate'): void
   notifyFilesChanged(event: ProjectFilesChangedEvent): void
+  notifyRuntimeContextSessionUpdated(session: PersistedChatSession): void
   provenance?: SessionStateProvenance
   uploads?: SessionStateUploads
   log: Logger
@@ -346,12 +347,14 @@ class SessionPersistenceStateOwner {
     const runtimeContext = sanitizeSessionRuntimeContext(candidate)
     if (!runtimeContext) throw new Error('Session runtime context patch is not JSON-safe.')
 
-    await saveSessionWithRevision(this.options.repository, {
+    const persisted = await saveSessionWithRevision(this.options.repository, {
       ...session,
       ...(sessionStatus ? { status: sessionStatus } : {}),
       runtimeContext,
       updatedAt: Math.max(session.updatedAt + 1, Date.now())
     })
+    this.recordSession(persisted)
+    this.options.notifyRuntimeContextSessionUpdated(persisted)
     return cloneRuntimeContext(runtimeContext)
   }
 
@@ -418,6 +421,7 @@ class SessionPersistenceStateOwner {
     })
     const persisted = await saveSessionWithRevision(this.options.repository, durable)
     this.recordSession(persisted)
+    if (runtimeContextPatch) this.options.notifyRuntimeContextSessionUpdated(persisted)
     return message
   }
 

--- a/src/renderer/src/hooks/useLifecycleSync.test.tsx
+++ b/src/renderer/src/hooks/useLifecycleSync.test.tsx
@@ -8,6 +8,7 @@ import {
   MAIN_DURABLE_CONTINUATION_LIFECYCLE_CLIENT_ID,
   MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID,
   MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID,
+  MAIN_RUNTIME_CONTEXT_LIFECYCLE_CLIENT_ID,
   type ProjectDeletedEvent,
   type SessionDeletedEvent,
   type SessionUpsertEvent
@@ -739,6 +740,57 @@ describe('useLifecycleSync', () => {
       'Run the verification',
       'Preparing the command.'
     ])
+  })
+
+  it('applies a Main-owned runtime revision without replacing live chat state', async () => {
+    useSessionStore.getState().hydrateSessions([{ ...session, revision: 2 }])
+    const prompt = useSessionStore.getState().appendUserMessage({
+      sessionId: session.id,
+      content: 'Keep this live prompt'
+    })
+    const durableBeforeOutput = toPersistedSession(useSessionStore.getState().sessions[0])
+    useSessionStore.getState().appendAgentMessageChunk({
+      sessionId: session.id,
+      streamId: 'run-1',
+      eventId: 'agent-message-1',
+      promptMessageId: prompt?.messageId,
+      content: 'Keep this live output.'
+    })
+
+    await act(async () => {
+      listeners.sessionUpdated?.({
+        originClientId: MAIN_RUNTIME_CONTEXT_LIFECYCLE_CLIENT_ID,
+        session: {
+          ...durableBeforeOutput,
+          revision: 3,
+          status: 'waiting-plan-approval',
+          updatedAt: durableBeforeOutput.updatedAt + 1,
+          runtimeContext: {
+            version: 1,
+            revision: 1,
+            plan: {
+              artifactId: 'plan-1',
+              artifactVersionId: 'plan-version-1',
+              artifactChecksum: 'a'.repeat(64),
+              approval: 'pending',
+              stepStatuses: {}
+            }
+          }
+        }
+      })
+    })
+
+    const projected = useSessionStore.getState().sessions[0]
+    expect(projected).toMatchObject({
+      revision: 3,
+      status: 'waiting-plan-approval',
+      runtimeContext: { revision: 1, plan: { approval: 'pending' } }
+    })
+    expect(projected.messages.map((message) => message.content)).toEqual([
+      'Keep this live prompt',
+      'Keep this live output.'
+    ])
+    expect(projected.activeRun?.promptMessageId).toBe(prompt?.messageId)
   })
 
   it('applies a Main-owned continuation prompt before projecting later artifact events', async () => {

--- a/src/renderer/src/hooks/useLifecycleSync.test.tsx
+++ b/src/renderer/src/hooks/useLifecycleSync.test.tsx
@@ -756,15 +756,36 @@ describe('useLifecycleSync', () => {
       promptMessageId: prompt?.messageId,
       content: 'Keep this live output.'
     })
+    const replyTimestamp = durableBeforeOutput.updatedAt + 1
+    const mainAppendedReply = {
+      id: 'main-appended-reply',
+      role: 'user' as const,
+      content: 'Keep this Main-owned reply',
+      status: 'complete' as const,
+      eventIds: [],
+      responseToMessageId: prompt?.messageId,
+      createdAt: replyTimestamp,
+      updatedAt: replyTimestamp
+    }
+    if (!durableBeforeOutput.conversationGraph) throw new Error('Expected a durable graph.')
+    const durableWithReply = {
+      ...durableBeforeOutput,
+      messages: [...durableBeforeOutput.messages, mainAppendedReply],
+      conversationGraph: synchronizeActiveConversationMessages(
+        durableBeforeOutput.conversationGraph,
+        [...durableBeforeOutput.messages, mainAppendedReply],
+        replyTimestamp
+      )
+    }
 
     await act(async () => {
       listeners.sessionUpdated?.({
         originClientId: MAIN_RUNTIME_CONTEXT_LIFECYCLE_CLIENT_ID,
         session: {
-          ...durableBeforeOutput,
+          ...durableWithReply,
           revision: 3,
           status: 'waiting-plan-approval',
-          updatedAt: durableBeforeOutput.updatedAt + 1,
+          updatedAt: replyTimestamp,
           runtimeContext: {
             version: 1,
             revision: 1,
@@ -788,7 +809,12 @@ describe('useLifecycleSync', () => {
     })
     expect(projected.messages.map((message) => message.content)).toEqual([
       'Keep this live prompt',
-      'Keep this live output.'
+      'Keep this live output.',
+      'Keep this Main-owned reply'
+    ])
+    expect(projected.conversationGraph?.messages.map((message) => message.content)).toEqual([
+      'Keep this live prompt',
+      'Keep this Main-owned reply'
     ])
     expect(projected.activeRun?.promptMessageId).toBe(prompt?.messageId)
   })

--- a/src/renderer/src/hooks/useLifecycleSync.ts
+++ b/src/renderer/src/hooks/useLifecycleSync.ts
@@ -5,6 +5,7 @@ import {
   MAIN_DURABLE_CONTINUATION_LIFECYCLE_CLIENT_ID,
   MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID,
   MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID,
+  MAIN_RUNTIME_CONTEXT_LIFECYCLE_CLIENT_ID,
   type SessionUpsertEvent
 } from '../../../shared/lifecycle-events'
 import { useNavigationStore } from '@/stores/navigation-store'
@@ -129,6 +130,18 @@ const useLifecycleSync = ({
               source,
               session,
               mode: 'replace-persisted-if-current'
+            })
+          } else {
+            store.upsertPersistedSession(session)
+          }
+        } else if (originClientId === MAIN_RUNTIME_CONTEXT_LIFECYCLE_CLIENT_ID) {
+          const store = useSessionStore.getState()
+          const source = store.sessions.find((candidate) => candidate.id === session.id)
+          if (source) {
+            store.applyDurableSessionProjection({
+              source,
+              session,
+              mode: 'runtime-context-authority'
             })
           } else {
             store.upsertPersistedSession(session)

--- a/src/renderer/src/hooks/useQuitPersistenceFlush.test.ts
+++ b/src/renderer/src/hooks/useQuitPersistenceFlush.test.ts
@@ -43,6 +43,26 @@ describe('completeQuitPersistenceFlush', () => {
         }
       )
     ).rejects.toThrow('renderer unavailable')
-    expect(acknowledge).toHaveBeenCalledWith({ requestId: 'flush-1' })
+    expect(acknowledge).toHaveBeenCalledWith({ requestId: 'flush-1', status: 'failed' })
+  })
+
+  it('acknowledges an unresolved revision conflict without classifying the flush as completed', async () => {
+    const acknowledge = vi.fn()
+    const conflict = Object.assign(new Error('revision changed'), {
+      code: 'session-revision-conflict'
+    })
+
+    await expect(
+      completeQuitPersistenceFlush(
+        { requestId: 'flush-1' },
+        {
+          suppressAutoReviews: () => undefined,
+          drainRuntimeEvents: async () => undefined,
+          flushPersistence: async () => Promise.reject(conflict),
+          acknowledge
+        }
+      )
+    ).rejects.toBe(conflict)
+    expect(acknowledge).toHaveBeenCalledWith({ requestId: 'flush-1', status: 'conflict' })
   })
 })

--- a/src/renderer/src/hooks/useQuitPersistenceFlush.ts
+++ b/src/renderer/src/hooks/useQuitPersistenceFlush.ts
@@ -4,6 +4,7 @@ import type {
   SessionPersistenceFlushRequest,
   SessionPersistenceFlushResponse
 } from '../../../shared/session-persistence-flush'
+import { isSessionRevisionConflictError } from '../../../shared/session-persistence'
 import { suppressAutoReviewsForQuit } from '../lib/acp/workspace-events'
 import { drainWorkspaceRuntimeEventsForPersistence } from '../lib/acp/useWorkspaceAgentRuntime'
 import { flushSessionPersistence } from '../lib/session-persistence/session-persistence'
@@ -19,13 +20,19 @@ export const completeQuitPersistenceFlush = async (
   request: SessionPersistenceFlushRequest,
   deps: QuitPersistenceFlushDeps
 ): Promise<void> => {
+  let failure: unknown
+  let status: SessionPersistenceFlushResponse['status'] = 'completed'
   try {
     deps.suppressAutoReviews()
     await deps.drainRuntimeEvents()
     await deps.flushPersistence()
+  } catch (error) {
+    failure = error
+    status = isSessionRevisionConflictError(error) ? 'conflict' : 'failed'
   } finally {
-    deps.acknowledge({ requestId: request.requestId })
+    deps.acknowledge({ requestId: request.requestId, status })
   }
+  if (failure !== undefined) throw failure
 }
 
 export const useQuitPersistenceFlush = (): void => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -8,6 +8,7 @@ import {
   type LoadAllSessionsResult,
   type PersistedChatSession
 } from '../../../../shared/session-persistence'
+import { i18next } from '@/i18n'
 import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
 import { useSessionPersistence, type SessionPersistenceState } from './session-persistence'
 
@@ -44,7 +45,8 @@ describe('session persistence startup', () => {
   let reconcilePendingArtifactsApi: ReturnType<typeof vi.fn>
   let reportRendererFailure: ReturnType<typeof vi.fn>
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18next.changeLanguage('en')
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -75,7 +77,10 @@ describe('session persistence startup', () => {
   })
 
   afterEach(async () => {
-    await act(async () => root.unmount())
+    await act(async () => {
+      root.unmount()
+      await i18next.changeLanguage('en')
+    })
     container.remove()
   })
 
@@ -115,6 +120,17 @@ describe('session persistence startup', () => {
       </div>
     )
   }
+
+  it('does not reload persisted sessions when the locale changes', async () => {
+    loadAll.mockReset().mockResolvedValue(emptyLoadResult())
+    await act(async () => root.render(<Probe />))
+
+    expect(loadAll).toHaveBeenCalledOnce()
+
+    await act(async () => i18next.changeLanguage('ja'))
+
+    expect(loadAll).toHaveBeenCalledOnce()
+  })
 
   it('keeps session actions blocked after a load failure and recovers on retry', async () => {
     await act(async () => root.render(<Probe />))

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -230,6 +230,39 @@ describe('session persistence startup', () => {
     )
   })
 
+  it('reloads after a Session revision conflict instead of resending stale JSON', async () => {
+    const restored = createPersistedSession({ revision: 1 })
+    loadAll.mockReset().mockResolvedValue({
+      ...emptyLoadResult(),
+      sessions: [restored]
+    })
+    saveSession.mockRejectedValue(
+      Object.assign(new Error('Session revision conflict: expected 1, actual 2.'), {
+        code: 'session-revision-conflict'
+      })
+    )
+
+    await act(async () => root.render(<Probe />))
+    await act(async () => {
+      useSessionStore.getState().renameSession('session-1', 'Local title')
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[data-testid="write-error"]')?.textContent).toBe(
+      'This conversation changed in another window. Your local changes were not saved. Retry to reload the latest version before closing the app.'
+    )
+    expect(saveSession).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="retry-writes"]')?.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(loadAll).toHaveBeenCalledTimes(2)
+    expect(saveSession).toHaveBeenCalledOnce()
+  })
+
   it('automatically clears a failed write target after its session is durably deleted', async () => {
     loadAll.mockReset().mockResolvedValue(emptyLoadResult())
     saveSession.mockRejectedValue(new Error('disk full'))

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -10,7 +10,11 @@ import {
 } from '../../../../shared/session-persistence'
 import { i18next } from '@/i18n'
 import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
-import { useSessionPersistence, type SessionPersistenceState } from './session-persistence'
+import {
+  flushSessionPersistence,
+  useSessionPersistence,
+  type SessionPersistenceState
+} from './session-persistence'
 
 const emptyLoadResult = (): LoadAllSessionsResult => ({
   sessions: [],
@@ -277,6 +281,39 @@ describe('session persistence startup', () => {
 
     expect(loadAll).toHaveBeenCalledTimes(2)
     expect(saveSession).toHaveBeenCalledOnce()
+  })
+
+  it('clears an unresolved revision conflict after its Session is durably deleted', async () => {
+    const restored = createPersistedSession({ revision: 1 })
+    loadAll.mockReset().mockResolvedValue({
+      ...emptyLoadResult(),
+      sessions: [restored]
+    })
+    saveSession.mockRejectedValue(
+      Object.assign(new Error('Session revision conflict: expected 1, actual 2.'), {
+        code: 'session-revision-conflict'
+      })
+    )
+
+    await act(async () => root.render(<Probe />))
+    await act(async () => {
+      useSessionStore.getState().renameSession('session-1', 'Conflicting title')
+      await Promise.resolve()
+    })
+    await expect(flushSessionPersistence()).rejects.toMatchObject({
+      code: 'session-revision-conflict'
+    })
+
+    await act(async () => {
+      // Production removes renderer state only after the authoritative delete IPC succeeds.
+      useSessionStore.getState().deleteSession('session-1')
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[data-testid="write-error"]')?.textContent).toContain(
+      'changes saved'
+    )
+    await expect(flushSessionPersistence()).resolves.toBeUndefined()
   })
 
   it('automatically clears a failed write target after its session is durably deleted', async () => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -747,6 +747,43 @@ describe('renderer session persistence bridge', () => {
     expect(saveSession.mock.calls[1][1]).toEqual({ conflictRebaseFields: ['title'] })
   })
 
+  it('chains queued local saves from the last acknowledged durable revision', async () => {
+    const firstSave = createDeferred<PersistedChatSession>()
+    const saveSession = vi
+      .fn<SessionPersistenceApi['saveSession']>()
+      .mockImplementationOnce(() => firstSave.promise)
+      .mockImplementationOnce(async (submitted) => ({ ...submitted, revision: 6 }))
+    const api = createApi({ saveSession })
+
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'First',
+      cwd: '/workspace/project',
+      projectId: 'project-a'
+    })
+    const source = useSessionStore.getState().sessions[0]
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: { ...toPersistedSession(source), revision: 4 }
+    })
+    const save = createStoreSaver(api, useSessionStore.getState())
+
+    useSessionStore.getState().renameSession('session-1', 'First queued')
+    const first = save(useSessionStore.getState())
+    await flushMicrotasks()
+    expect(saveSession.mock.calls[0][0].revision).toBe(4)
+
+    useSessionStore.getState().renameSession('session-1', 'Second queued')
+    const second = save(useSessionStore.getState())
+    firstSave.resolve({ ...saveSession.mock.calls[0][0], revision: 5 })
+    await Promise.all([first, second])
+
+    expect(saveSession.mock.calls[1][0]).toMatchObject({
+      revision: 5,
+      title: 'Second queued'
+    })
+  })
+
   it('reports an earlier failed write even when a later queued write succeeds', async () => {
     const api = createApi({
       saveSession: vi.fn().mockRejectedValue(new Error('disk full')),

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -704,8 +704,7 @@ describe('renderer session persistence bridge', () => {
     expect(saveSession).toHaveBeenCalledTimes(1)
 
     firstSave.resolve(saveSession.mock.calls[0][0])
-    await flushMicrotasks()
-    expect(saveSession).toHaveBeenCalledTimes(2)
+    await vi.waitFor(() => expect(saveSession).toHaveBeenCalledTimes(2))
 
     secondSave.resolve(saveSession.mock.calls[1][0])
     await flushMicrotasks()
@@ -903,6 +902,69 @@ describe('renderer session persistence bridge', () => {
     expect(saveSession).toHaveBeenCalledOnce()
   })
 
+  it('rebases from the exact externally published authority after a later revision conflict', async () => {
+    const base = materializeSessionConversationGraph(
+      createPersistedSession({ projectId: 'project-a', revision: 1 })
+    )
+    const published = materializeSessionConversationGraph({
+      ...base,
+      revision: 2,
+      messages: [
+        {
+          id: 'published-message',
+          role: 'agent',
+          content: 'Published by Main',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 2,
+          updatedAt: 2
+        }
+      ],
+      updatedAt: base.updatedAt + 1
+    })
+    const latest = materializeSessionConversationGraph({
+      ...published,
+      revision: 3,
+      messages: [
+        ...published.messages,
+        {
+          id: 'latest-message',
+          role: 'agent',
+          content: 'Newer authoritative graph',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 3,
+          updatedAt: 3
+        }
+      ],
+      updatedAt: published.updatedAt + 1
+    })
+    const saveSession = vi
+      .fn<SessionPersistenceApi['saveSession']>()
+      .mockRejectedValueOnce(new SessionRevisionConflictError(2, 3))
+      .mockImplementationOnce(async (submitted) => ({ ...submitted, revision: 4 }))
+    const api = createApi({
+      loadOne: vi.fn().mockResolvedValue(latest),
+      saveSession
+    })
+
+    useSessionStore.getState().hydrateSessions([base])
+    const save = createStoreSaver(api, useSessionStore.getState())
+    useSessionStore.getState().upsertPersistedSession(published)
+    await save(useSessionStore.getState())
+    expect(toPersistedSession(useSessionStore.getState().sessions[0]).conversationGraph).toEqual(
+      published.conversationGraph
+    )
+    useSessionStore.getState().renameSession(base.id, 'Local title')
+
+    await expect(save(useSessionStore.getState())).resolves.toBeUndefined()
+
+    expect(saveSession).toHaveBeenCalledTimes(2)
+    expect(saveSession.mock.calls[0][0]).toMatchObject({ revision: 2, title: 'Local title' })
+    expect(saveSession.mock.calls[1][0]).toMatchObject({ revision: 3, title: 'Local title' })
+    expect(saveSession.mock.calls[1][0].messages).toEqual(latest.messages)
+  })
+
   it('reports an earlier failed write even when a later queued write succeeds', async () => {
     const api = createApi({
       saveSession: vi.fn().mockRejectedValue(new Error('disk full')),
@@ -958,6 +1020,27 @@ describe('renderer session persistence bridge', () => {
 
     expect(saveSession).toHaveBeenCalledTimes(3)
     expect(durableTitle).toBe('Artifact latest')
+  })
+
+  it('stamps an explicit queued save with the last durable revision', async () => {
+    const firstSave = createDeferred<PersistedChatSession>()
+    const saveSession = vi.fn<SessionPersistenceApi['saveSession']>(async (submitted) => ({
+      ...submitted,
+      revision: 3
+    }))
+    const persistence = createOrderedSessionPersistence(createApi({ saveSession }))
+    const session = createPersistedSession({ revision: 1 })
+
+    const storeSave = persistence.saveLatestSession('session:session-1', () => firstSave.promise)
+    const explicitSave = persistence.saveSession({ ...session, title: 'Explicit latest' })
+    firstSave.resolve({ ...session, revision: 2 })
+    await Promise.all([storeSave, explicitSave])
+
+    expect(saveSession).toHaveBeenCalledOnce()
+    expect(saveSession.mock.calls[0][0]).toMatchObject({
+      revision: 2,
+      title: 'Explicit latest'
+    })
   })
 
   it('flushes only after explicit and coalesced queued writes settle', async () => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -309,6 +309,39 @@ describe('renderer session persistence bridge', () => {
     )
   })
 
+  it('recovers a forced revision conflict without re-entering the ordered save queue', async () => {
+    const persisted = createPersistedSession({
+      projectId: 'project-a',
+      revision: 1,
+      title: 'Original'
+    })
+    useSessionStore.getState().hydrateSessions([persisted])
+    const durableBase = toPersistedSession(useSessionStore.getState().sessions[0])
+    const authoritative = { ...durableBase, revision: 2, updatedAt: persisted.updatedAt + 1 }
+    const saveSession = vi
+      .fn<SessionPersistenceApi['saveSession']>()
+      .mockRejectedValueOnce(new SessionRevisionConflictError(1, 2))
+      .mockImplementationOnce(async (submitted) => ({ ...submitted, revision: 3 }))
+    const api = createApi({
+      loadOne: vi.fn().mockResolvedValue(authoritative),
+      saveSession
+    })
+    const save = createStoreSaver(api, useSessionStore.getState())
+
+    useSessionStore.getState().renameSession('session-1', 'Local rename')
+    await expect(
+      save(useSessionStore.getState(), {
+        forceTargets: new Set(['session:session-1'])
+      })
+    ).resolves.toBeUndefined()
+
+    expect(saveSession).toHaveBeenCalledTimes(2)
+    expect(saveSession.mock.calls[1]).toEqual([
+      expect.objectContaining({ revision: 2, title: 'Local rename' }),
+      { conflictRebaseFields: ['title'] }
+    ])
+  })
+
   it('does not persist unbound pending sessions', async () => {
     const api = createApi()
     const save = createStoreSaver(api)

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -17,8 +17,10 @@ import {
 import {
   createOrderedSessionPersistence,
   createStoreSaver,
+  flushSessionPersistence,
   loadPersistedSessions,
   reconcilePendingArtifacts,
+  saveSessionInOrder,
   type SessionPersistenceApi
 } from './session-persistence'
 
@@ -985,6 +987,36 @@ describe('renderer session persistence bridge', () => {
     await savingLatest
     await flushing
     expect(flushed).toBe(true)
+  })
+
+  it('keeps an explicit save revision conflict unresolved until that Session saves successfully', async () => {
+    const session = createPersistedSession({ revision: 1 })
+    const conflict = new SessionRevisionConflictError(1, 2)
+    const saveSession = vi
+      .fn()
+      .mockRejectedValueOnce(conflict)
+      .mockResolvedValueOnce({ ...session, revision: 3 })
+    vi.stubGlobal('window', {
+      api: {
+        sessions: {
+          saveSession,
+          saveManifest: vi.fn().mockResolvedValue(undefined)
+        }
+      }
+    })
+    try {
+      await expect(saveSessionInOrder(session)).rejects.toBe(conflict)
+      await expect(flushSessionPersistence()).rejects.toMatchObject({
+        code: 'session-revision-conflict'
+      })
+
+      await expect(saveSessionInOrder({ ...session, revision: 2 })).resolves.toMatchObject({
+        revision: 3
+      })
+      await expect(flushSessionPersistence()).resolves.toBeUndefined()
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 })
 

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   materializeSessionConversationGraph,
   SESSION_MANIFEST_VERSION,
+  SessionRevisionConflictError,
   type LoadAllSessionsResult,
   type PersistedChatSession
 } from '../../../../shared/session-persistence'
@@ -45,6 +46,7 @@ const createLoadResult = (
 
 const createApi = (overrides: Partial<SessionPersistenceApi> = {}): SessionPersistenceApi => ({
   loadAll: vi.fn().mockResolvedValue(createLoadResult()),
+  loadOne: vi.fn().mockResolvedValue(undefined),
   saveSession: vi.fn(async (session: PersistedChatSession) => session),
   deleteSession: vi.fn().mockResolvedValue(undefined),
   saveManifest: vi.fn().mockResolvedValue(undefined),
@@ -782,6 +784,121 @@ describe('renderer session persistence bridge', () => {
       revision: 5,
       title: 'Second queued'
     })
+  })
+
+  it('retries a local graph save over a concurrent main-owned permission revision', async () => {
+    const base = materializeSessionConversationGraph(
+      createPersistedSession({
+        projectId: 'project-a',
+        revision: 1,
+        messages: [
+          {
+            id: 'prompt-1',
+            role: 'user',
+            content: 'Run the command',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ]
+      })
+    )
+    const authoritative = {
+      ...base,
+      revision: 2,
+      status: 'waiting-permission' as const,
+      runtimeContext: {
+        version: 1 as const,
+        revision: 1,
+        permission: {
+          state: 'pending' as const,
+          request: {
+            requestId: 'permission-1',
+            sessionId: base.id,
+            toolCallId: 'tool-1',
+            title: 'Run the command',
+            options: [{ optionId: 'allow', name: 'Allow', kind: 'allow_once' as const }]
+          },
+          originatingPromptMessageId: 'prompt-1',
+          fingerprint: 'a'.repeat(64),
+          createdAt: 2
+        }
+      },
+      updatedAt: base.updatedAt + 1
+    }
+    const saveSession = vi
+      .fn<SessionPersistenceApi['saveSession']>()
+      .mockRejectedValueOnce(new SessionRevisionConflictError(1, 2))
+      .mockImplementationOnce(async (submitted) => ({ ...submitted, revision: 3 }))
+    const api = createApi({
+      loadOne: vi.fn().mockResolvedValue(authoritative),
+      saveSession
+    })
+
+    useSessionStore.getState().hydrateSessions([base])
+    const save = createStoreSaver(api, useSessionStore.getState())
+    useSessionStore.getState().appendUserMessage({
+      sessionId: base.id,
+      content: 'Keep this local graph update',
+      cwd: base.cwd,
+      projectId: base.projectId
+    })
+
+    await expect(save(useSessionStore.getState())).resolves.toBeUndefined()
+
+    expect(api.loadOne).toHaveBeenCalledWith({ projectId: base.projectId, sessionId: base.id })
+    expect(saveSession).toHaveBeenCalledTimes(2)
+    expect(saveSession.mock.calls[1][0]).toMatchObject({
+      revision: 2,
+      status: 'waiting-permission',
+      runtimeContext: authoritative.runtimeContext
+    })
+    expect(saveSession.mock.calls[1][0].messages.map(({ content }) => content)).toEqual([
+      'Run the command',
+      'Keep this local graph update'
+    ])
+  })
+
+  it('does not retry when both the local and authoritative conversation graphs changed', async () => {
+    const base = materializeSessionConversationGraph(
+      createPersistedSession({ projectId: 'project-a', revision: 1 })
+    )
+    const authoritative = materializeSessionConversationGraph({
+      ...base,
+      revision: 2,
+      messages: [
+        {
+          id: 'remote-message',
+          role: 'user',
+          content: 'Changed in another window',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 2,
+          updatedAt: 2
+        }
+      ],
+      updatedAt: base.updatedAt + 1
+    })
+    const conflict = new SessionRevisionConflictError(1, 2)
+    const saveSession = vi.fn<SessionPersistenceApi['saveSession']>().mockRejectedValue(conflict)
+    const api = createApi({
+      loadOne: vi.fn().mockResolvedValue(authoritative),
+      saveSession
+    })
+
+    useSessionStore.getState().hydrateSessions([base])
+    const save = createStoreSaver(api, useSessionStore.getState())
+    useSessionStore.getState().appendUserMessage({
+      sessionId: base.id,
+      content: 'Different local update',
+      cwd: base.cwd,
+      projectId: base.projectId
+    })
+
+    await expect(save(useSessionStore.getState())).rejects.toBe(conflict)
+    expect(api.loadOne).toHaveBeenCalledOnce()
+    expect(saveSession).toHaveBeenCalledOnce()
   })
 
   it('reports an earlier failed write even when a later queued write succeeds', async () => {

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -310,14 +310,26 @@ describe('renderer session persistence bridge', () => {
   })
 
   it('recovers a forced revision conflict without re-entering the ordered save queue', async () => {
-    const persisted = createPersistedSession({
-      projectId: 'project-a',
-      revision: 1,
-      title: 'Original'
-    })
+    const persisted = materializeSessionConversationGraph(
+      createPersistedSession({ projectId: 'project-a', revision: 1, title: 'Original' })
+    )
     useSessionStore.getState().hydrateSessions([persisted])
     const durableBase = toPersistedSession(useSessionStore.getState().sessions[0])
-    const authoritative = { ...durableBase, revision: 2, updatedAt: persisted.updatedAt + 1 }
+    const remoteMessage = {
+      id: 'remote-message',
+      role: 'agent' as const,
+      content: 'Saved in another window',
+      status: 'complete' as const,
+      eventIds: [],
+      createdAt: persisted.updatedAt + 1,
+      updatedAt: persisted.updatedAt + 1
+    }
+    const authoritative = materializeSessionConversationGraph({
+      ...durableBase,
+      revision: 2,
+      messages: [remoteMessage],
+      updatedAt: persisted.updatedAt + 1
+    })
     const saveSession = vi
       .fn<SessionPersistenceApi['saveSession']>()
       .mockRejectedValueOnce(new SessionRevisionConflictError(1, 2))
@@ -339,6 +351,10 @@ describe('renderer session persistence bridge', () => {
     expect(saveSession.mock.calls[1]).toEqual([
       expect.objectContaining({ revision: 2, title: 'Local rename' }),
       { conflictRebaseFields: ['title'] }
+    ])
+    expect(useSessionStore.getState().sessions[0].messages).toEqual([remoteMessage])
+    expect(useSessionStore.getState().sessions[0].conversationGraph?.messages).toEqual([
+      expect.objectContaining(remoteMessage)
     ])
   })
 

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import type { ArtifactFile, ReconcilePendingArtifactsRequest } from '../../../../shared/artifacts'
 import type { RendererFailureContext } from '../../../../shared/diagnostics'
 import {
   ConversationGraphMaterializationError,
+  isSessionRevisionConflictError,
+  sessionRevision,
   type DeleteSessionRequest,
   type LoadAllSessionsResult,
   type PersistedChatSession,
@@ -149,7 +152,23 @@ const liveSessionPersistence = createOrderedSessionPersistence({
 const saveSessionInOrder = (session: PersistedChatSession): Promise<PersistedChatSession> =>
   liveSessionPersistence.saveSession(session)
 
-const flushSessionPersistence = (): Promise<void> => liveSessionPersistence.flush()
+const unresolvedSessionRevisionConflictTargets = new Set<string>()
+
+class SessionPersistenceFlushConflictError extends Error {
+  readonly code = 'session-revision-conflict' as const
+
+  constructor() {
+    super('Session persistence has an unresolved revision conflict.')
+    this.name = 'SessionPersistenceFlushConflictError'
+  }
+}
+
+const flushSessionPersistence = async (): Promise<void> => {
+  await liveSessionPersistence.flush()
+  if (unresolvedSessionRevisionConflictTargets.size > 0) {
+    throw new SessionPersistenceFlushConflictError()
+  }
+}
 
 // The one artifact command startup reconciliation needs; kept narrow so it is trivial to fake in tests.
 type ArtifactReconcileApi = {
@@ -378,6 +397,8 @@ const SAFE_SESSION_LOAD_ERROR =
   'Open Science could not read saved conversation data. Retry to continue.'
 const SAFE_SESSION_WRITE_ERROR =
   'Open Science could not save the latest conversation changes. Retry before closing the app.'
+const SESSION_REVISION_CONFLICT_WRITE_ERROR =
+  'This conversation changed in another window. Your local changes were not saved. Retry to reload the latest version before closing the app.'
 
 // Hydrates the in-memory session store from the per-session files loaded by the main process.
 const loadPersistedSessions = async (
@@ -420,6 +441,9 @@ const createStoreSaver = (
 ): StoreSaver => {
   let previousSessions = initial.sessions
   let previousSelection = initial.selectedSessionId
+  const acknowledgedRevisions = new Map(
+    initial.sessions.map((session) => [session.id, sessionRevision(session)])
+  )
 
   return (state, options) => {
     const nextSessions = state.sessions
@@ -439,6 +463,12 @@ const createStoreSaver = (
 
       const target = `session:${session.id}`
       const isForced = options?.forceTargets?.has(target) === true
+      if (isExternallyHydratedSession(session)) {
+        acknowledgedRevisions.set(
+          session.id,
+          Math.max(acknowledgedRevisions.get(session.id) ?? 0, sessionRevision(session))
+        )
+      }
 
       if (
         (previousById.get(session.id) !== session || isForced) &&
@@ -484,6 +514,8 @@ const createStoreSaver = (
                 const persisted = observePersistencePhase('session-serialize', () =>
                   toPersistedSession(session)
                 )
+                persisted.revision =
+                  acknowledgedRevisions.get(session.id) ?? sessionRevision(persisted)
                 let durableSession: PersistedChatSession
                 try {
                   durableSession = await persistence.saveSession(persisted, saveOptions)
@@ -491,6 +523,7 @@ const createStoreSaver = (
                   reportPersistenceError(error, 'session-save')
                   throw error
                 }
+                acknowledgedRevisions.set(session.id, sessionRevision(durableSession))
                 observePersistencePhase('session-apply-durable', () =>
                   applyDurableSession(durableSession, saveOptions)
                 )
@@ -502,6 +535,8 @@ const createStoreSaver = (
                     const persisted = observePersistencePhase('session-serialize', () =>
                       toPersistedSession(session)
                     )
+                    persisted.revision =
+                      acknowledgedRevisions.get(session.id) ?? sessionRevision(persisted)
                     let durableSession: PersistedChatSession
                     try {
                       durableSession = await (coalescedOptions
@@ -511,6 +546,7 @@ const createStoreSaver = (
                       reportPersistenceError(error, 'session-save')
                       throw error
                     }
+                    acknowledgedRevisions.set(session.id, sessionRevision(durableSession))
                     observePersistencePhase('session-apply-durable', () =>
                       applyDurableSession(durableSession, coalescedOptions)
                     )
@@ -573,6 +609,7 @@ const createStoreSaver = (
 
 // Starts session persistence and returns health/recovery state so App can gate input and surface failures.
 const useSessionPersistence = (): SessionPersistenceState => {
+  const { t } = useTranslation()
   const [isHydrated, setIsHydrated] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [isReady, setIsReady] = useState(false)
@@ -588,6 +625,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
   const retrySelection = useRef<SessionHydrationSelection | undefined>(undefined)
   const failedWriteTargets = useRef(new Set<string>())
   const failedConflictRebaseFields = useRef(new Map<string, SessionConflictRebaseField[]>())
+  const revisionConflictTargets = useRef(new Set<string>())
   const retryManifestWritePending = useRef(false)
   const saverRef = useRef<StoreSaver | undefined>(undefined)
   const dismissLoadWarning = useCallback(() => setLoadWarning(undefined), [])
@@ -610,6 +648,10 @@ const useSessionPersistence = (): SessionPersistenceState => {
     setLoadAttempt((attempt) => attempt + 1)
   }, [isHydrated])
   const retryWrites = useCallback(() => {
+    if (revisionConflictTargets.current.size > 0) {
+      retryLoad()
+      return
+    }
     const saver = saverRef.current
     if (!saver || failedWriteTargets.current.size === 0) return
 
@@ -628,7 +670,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
       forceTargets: new Set(failedWriteTargets.current),
       conflictRebaseFieldsByTarget: new Map(failedConflictRebaseFields.current)
     }).catch(reportPersistenceError)
-  }, [])
+  }, [retryLoad])
 
   useEffect(() => {
     let isMounted = true
@@ -648,6 +690,8 @@ const useSessionPersistence = (): SessionPersistenceState => {
           preferredSelection
         )
         if (!result || !isMounted) return
+        unresolvedSessionRevisionConflictTargets.clear()
+        revisionConflictTargets.current.clear()
         setIsHydrated(true)
         const loadWarnings = result.diagnostics?.warnings ?? []
         const sessionWarningCount = loadWarnings.filter(
@@ -727,6 +771,12 @@ const useSessionPersistence = (): SessionPersistenceState => {
           onFailure: (target, _error, context) => {
             if (!isMounted) return
             failedWriteTargets.current.add(target)
+            if (isSessionRevisionConflictError(_error)) {
+              revisionConflictTargets.current.add(target)
+              unresolvedSessionRevisionConflictTargets.add(target)
+              setWriteError(t(SESSION_REVISION_CONFLICT_WRITE_ERROR))
+              return
+            }
             const conflictRebaseFields = context.conflictRebaseFields
             if (conflictRebaseFields && conflictRebaseFields.length > 0) {
               failedConflictRebaseFields.current.set(target, [
@@ -753,6 +803,8 @@ const useSessionPersistence = (): SessionPersistenceState => {
             if (!isMounted) return
             failedWriteTargets.current.delete(target)
             failedConflictRebaseFields.current.delete(target)
+            revisionConflictTargets.current.delete(target)
+            unresolvedSessionRevisionConflictTargets.delete(target)
             if (target === 'manifest' && retryManifestWritePending.current) {
               retryManifestWritePending.current = false
               setIsReady(true)
@@ -805,7 +857,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
       if (saverRef.current === activeSaver) saverRef.current = undefined
       unsubscribe?.()
     }
-  }, [loadAttempt])
+  }, [loadAttempt, t])
 
   return {
     isHydrated,

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -9,6 +9,7 @@ import {
   sessionRevision,
   type DeleteSessionRequest,
   type LoadAllSessionsResult,
+  type LoadSessionRequest,
   type PersistedChatSession,
   type SaveSessionOptions,
   type SessionConflictRebaseField,
@@ -27,6 +28,7 @@ import { projectRendererFailure } from '../../renderer-diagnostics'
 
 type SessionPersistenceApi = {
   loadAll: () => Promise<LoadAllSessionsResult>
+  loadOne: (request: LoadSessionRequest) => Promise<PersistedChatSession | undefined>
   saveSession: (
     session: PersistedChatSession,
     options?: SaveSessionOptions
@@ -62,6 +64,83 @@ const conflictRebaseFieldChanged = (
   field: SessionConflictRebaseField
 ): boolean => {
   return previous[field] !== next[field]
+}
+
+const MAIN_OWNED_SESSION_FIELDS = new Set<keyof PersistedChatSession>([
+  'revision',
+  'runtimeContext',
+  'archivedAt',
+  'branchSource',
+  'delegationPolicy',
+  'enabledComputeHosts',
+  'specialistId',
+  'specialistBindingPending'
+])
+
+const jsonValuesEqual = (left: unknown, right: unknown): boolean => {
+  if (Object.is(left, right)) return true
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => jsonValuesEqual(value, right[index]))
+    )
+  }
+  if (!left || !right || typeof left !== 'object' || typeof right !== 'object') return false
+  const leftRecord = left as Record<string, unknown>
+  const rightRecord = right as Record<string, unknown>
+  const leftKeys = Object.keys(leftRecord)
+  const rightKeys = Object.keys(rightRecord)
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key) => Object.hasOwn(rightRecord, key) && jsonValuesEqual(leftRecord[key], rightRecord[key])
+    )
+  )
+}
+
+const rebaseSessionAfterRevisionConflict = (
+  base: PersistedChatSession,
+  submitted: PersistedChatSession,
+  latest: PersistedChatSession
+): PersistedChatSession | undefined => {
+  const rebased: PersistedChatSession = structuredClone(latest)
+  const keys = new Set([
+    ...Object.keys(base),
+    ...Object.keys(submitted),
+    ...Object.keys(latest)
+  ] as Array<keyof PersistedChatSession>)
+  const mainOwnsStatus =
+    latest.runtimeContext?.permission?.state === 'pending' ||
+    latest.status === 'waiting-plan-approval'
+
+  for (const key of keys) {
+    if (
+      MAIN_OWNED_SESSION_FIELDS.has(key) ||
+      key === 'updatedAt' ||
+      (key === 'status' && mainOwnsStatus)
+    ) {
+      continue
+    }
+    const baseValue = base[key]
+    const submittedValue = submitted[key]
+    const latestValue = latest[key]
+    const localChanged = !jsonValuesEqual(submittedValue, baseValue)
+    if (!localChanged) continue
+    const remoteChanged = !jsonValuesEqual(latestValue, baseValue)
+    if (remoteChanged && !jsonValuesEqual(submittedValue, latestValue)) return undefined
+
+    if (Object.hasOwn(submitted, key)) {
+      Object.assign(rebased, { [key]: structuredClone(submittedValue) })
+    } else {
+      Reflect.deleteProperty(rebased, key)
+    }
+  }
+
+  rebased.revision = sessionRevision(latest)
+  rebased.updatedAt = Math.max(base.updatedAt, submitted.updatedAt, latest.updatedAt) + 1
+  return rebased
 }
 
 const mergeSaveSessionOptions = (
@@ -444,6 +523,28 @@ const createStoreSaver = (
   const acknowledgedRevisions = new Map(
     initial.sessions.map((session) => [session.id, sessionRevision(session)])
   )
+  const acknowledgedSessions = new Map(
+    initial.sessions.map((session) => [session.id, toPersistedSession(session)])
+  )
+
+  const recoverRevisionConflict = async (
+    error: unknown,
+    submitted: PersistedChatSession,
+    options: SaveSessionOptions | undefined,
+    save: SessionPersistenceApi['saveSession']
+  ): Promise<PersistedChatSession> => {
+    if (!isSessionRevisionConflictError(error)) throw error
+    const base = acknowledgedSessions.get(submitted.id)
+    if (!base) throw error
+    const latest = await api.loadOne({
+      projectId: submitted.projectId,
+      sessionId: submitted.id
+    })
+    if (!latest) throw error
+    const rebased = rebaseSessionAfterRevisionConflict(base, submitted, latest)
+    if (!rebased) throw error
+    return options ? save(rebased, options) : save(rebased)
+  }
 
   return (state, options) => {
     const nextSessions = state.sessions
@@ -518,12 +619,24 @@ const createStoreSaver = (
                   acknowledgedRevisions.get(session.id) ?? sessionRevision(persisted)
                 let durableSession: PersistedChatSession
                 try {
-                  durableSession = await persistence.saveSession(persisted, saveOptions)
+                  durableSession = saveOptions
+                    ? await persistence.saveSession(persisted, saveOptions)
+                    : await persistence.saveSession(persisted)
                 } catch (error) {
-                  reportPersistenceError(error, 'session-save')
-                  throw error
+                  try {
+                    durableSession = await recoverRevisionConflict(
+                      error,
+                      persisted,
+                      saveOptions,
+                      persistence.saveSession
+                    )
+                  } catch (finalError) {
+                    reportPersistenceError(finalError, 'session-save')
+                    throw finalError
+                  }
                 }
                 acknowledgedRevisions.set(session.id, sessionRevision(durableSession))
+                acknowledgedSessions.set(session.id, durableSession)
                 observePersistencePhase('session-apply-durable', () =>
                   applyDurableSession(durableSession, saveOptions)
                 )
@@ -539,14 +652,24 @@ const createStoreSaver = (
                       acknowledgedRevisions.get(session.id) ?? sessionRevision(persisted)
                     let durableSession: PersistedChatSession
                     try {
-                      durableSession = await (coalescedOptions
-                        ? api.saveSession(persisted, coalescedOptions)
-                        : api.saveSession(persisted))
+                      durableSession = coalescedOptions
+                        ? await api.saveSession(persisted, coalescedOptions)
+                        : await api.saveSession(persisted)
                     } catch (error) {
-                      reportPersistenceError(error, 'session-save')
-                      throw error
+                      try {
+                        durableSession = await recoverRevisionConflict(
+                          error,
+                          persisted,
+                          coalescedOptions,
+                          api.saveSession
+                        )
+                      } catch (finalError) {
+                        reportPersistenceError(finalError, 'session-save')
+                        throw finalError
+                      }
                     }
                     acknowledgedRevisions.set(session.id, sessionRevision(durableSession))
+                    acknowledgedSessions.set(session.id, durableSession)
                     observePersistencePhase('session-apply-durable', () =>
                       applyDurableSession(durableSession, coalescedOptions)
                     )

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -672,13 +672,14 @@ const createStoreSaver = (
         const saveOptions = conflictRebaseFields.length > 0 ? { conflictRebaseFields } : undefined
         const applyDurableSession = (
           durableSession: PersistedChatSession,
-          options: SaveSessionOptions | undefined
+          options: SaveSessionOptions | undefined,
+          recoveredRevisionConflict = false
         ): void => {
           useSessionStore.getState().applyDurableSessionProjection({
             source: session,
             session: durableSession,
             mode:
-              (options?.conflictRebaseFields?.length ?? 0) > 0
+              recoveredRevisionConflict || (options?.conflictRebaseFields?.length ?? 0) > 0
                 ? 'replace-persisted-if-current'
                 : 'merge-upload-identities'
           })
@@ -695,6 +696,7 @@ const createStoreSaver = (
                 persisted.revision =
                   acknowledgedRevisions.get(session.id) ?? sessionRevision(persisted)
                 let durableSession: PersistedChatSession
+                let recoveredRevisionConflict = false
                 try {
                   durableSession = saveOptions
                     ? await persistence.saveSession(persisted, saveOptions)
@@ -707,6 +709,7 @@ const createStoreSaver = (
                       saveOptions,
                       api.saveSession
                     )
+                    recoveredRevisionConflict = true
                   } catch (finalError) {
                     reportPersistenceError(finalError, 'session-save')
                     throw finalError
@@ -715,7 +718,7 @@ const createStoreSaver = (
                 acknowledgedRevisions.set(session.id, sessionRevision(durableSession))
                 acknowledgedSessions.set(session.id, durableSession)
                 observePersistencePhase('session-apply-durable', () =>
-                  applyDurableSession(durableSession, saveOptions)
+                  applyDurableSession(durableSession, saveOptions, recoveredRevisionConflict)
                 )
               }
             : () =>
@@ -728,6 +731,7 @@ const createStoreSaver = (
                     persisted.revision =
                       acknowledgedRevisions.get(session.id) ?? sessionRevision(persisted)
                     let durableSession: PersistedChatSession
+                    let recoveredRevisionConflict = false
                     try {
                       durableSession = coalescedOptions
                         ? await api.saveSession(persisted, coalescedOptions)
@@ -740,6 +744,7 @@ const createStoreSaver = (
                           coalescedOptions,
                           api.saveSession
                         )
+                        recoveredRevisionConflict = true
                       } catch (finalError) {
                         reportPersistenceError(finalError, 'session-save')
                         throw finalError
@@ -748,7 +753,11 @@ const createStoreSaver = (
                     acknowledgedRevisions.set(session.id, sessionRevision(durableSession))
                     acknowledgedSessions.set(session.id, durableSession)
                     observePersistencePhase('session-apply-durable', () =>
-                      applyDurableSession(durableSession, coalescedOptions)
+                      applyDurableSession(
+                        durableSession,
+                        coalescedOptions,
+                        recoveredRevisionConflict
+                      )
                     )
                     return durableSession
                   },

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../../shared/session-persistence'
 import { PENDING_UPLOAD_SESSION_ID } from '../../../../shared/uploads'
 import {
+  getExternallyHydratedSessionAuthority,
   isExternallyHydratedSession,
   toPersistedSession,
   useSessionStore
@@ -100,6 +101,32 @@ const jsonValuesEqual = (left: unknown, right: unknown): boolean => {
   )
 }
 
+const conversationGraphsEqualIgnoringBranchTimestamps = (
+  left: PersistedChatSession['conversationGraph'],
+  right: PersistedChatSession['conversationGraph']
+): boolean => {
+  if (!left || !right) return left === right
+  const withoutBranchTimestamps = (
+    graph: NonNullable<PersistedChatSession['conversationGraph']>
+  ): PersistedChatSession['conversationGraph'] => ({
+    ...graph,
+    branches: graph.branches.map((branch) => ({ ...branch, updatedAt: 0 }))
+  })
+  return jsonValuesEqual(withoutBranchTimestamps(left), withoutBranchTimestamps(right))
+}
+
+const sessionFieldValuesEqual = (
+  key: keyof PersistedChatSession,
+  left: unknown,
+  right: unknown
+): boolean =>
+  key === 'conversationGraph'
+    ? conversationGraphsEqualIgnoringBranchTimestamps(
+        left as PersistedChatSession['conversationGraph'],
+        right as PersistedChatSession['conversationGraph']
+      )
+    : jsonValuesEqual(left, right)
+
 const rebaseSessionAfterRevisionConflict = (
   base: PersistedChatSession,
   submitted: PersistedChatSession,
@@ -126,10 +153,11 @@ const rebaseSessionAfterRevisionConflict = (
     const baseValue = base[key]
     const submittedValue = submitted[key]
     const latestValue = latest[key]
-    const localChanged = !jsonValuesEqual(submittedValue, baseValue)
+    const localChanged = !sessionFieldValuesEqual(key, submittedValue, baseValue)
     if (!localChanged) continue
-    const remoteChanged = !jsonValuesEqual(latestValue, baseValue)
-    if (remoteChanged && !jsonValuesEqual(submittedValue, latestValue)) return undefined
+    const remoteChanged = !sessionFieldValuesEqual(key, latestValue, baseValue)
+    if (remoteChanged && !sessionFieldValuesEqual(key, submittedValue, latestValue))
+      return undefined
 
     if (Object.hasOwn(submitted, key)) {
       Object.assign(rebased, { [key]: structuredClone(submittedValue) })
@@ -160,6 +188,7 @@ const createOrderedSessionPersistence = (
   api: Pick<SessionPersistenceApi, 'saveSession' | 'saveManifest'>
 ): OrderedSessionPersistence => {
   let queue: Promise<unknown> = Promise.resolve()
+  const acknowledgedRevisions = new Map<string, number>()
   let pendingLatest:
     | {
         target: string
@@ -197,7 +226,13 @@ const createOrderedSessionPersistence = (
         pendingLatest = undefined
         pendingLatestPromise = undefined
       }
-      return entry.task(entry.options)
+      return entry.task(entry.options).then((durable) => {
+        acknowledgedRevisions.set(
+          durable.id,
+          Math.max(acknowledgedRevisions.get(durable.id) ?? 0, sessionRevision(durable))
+        )
+        return durable
+      })
     }
     const run = queue.then(runTask, runTask)
     pendingLatest = entry
@@ -212,7 +247,21 @@ const createOrderedSessionPersistence = (
   return {
     saveLatestSession,
     saveSession: (session, options) =>
-      enqueue(() => (options ? api.saveSession(session, options) : api.saveSession(session))),
+      enqueue(async () => {
+        const submitted = structuredClone(session)
+        submitted.revision = Math.max(
+          sessionRevision(submitted),
+          acknowledgedRevisions.get(submitted.id) ?? 0
+        )
+        const durable = options
+          ? await api.saveSession(submitted, options)
+          : await api.saveSession(submitted)
+        acknowledgedRevisions.set(
+          durable.id,
+          Math.max(acknowledgedRevisions.get(durable.id) ?? 0, sessionRevision(durable))
+        )
+        return durable
+      }),
     saveManifest: (request) => enqueue(() => api.saveManifest(request)),
     flush: () => queue.then(() => undefined)
   }
@@ -576,10 +625,20 @@ const createStoreSaver = (
       const target = `session:${session.id}`
       const isForced = options?.forceTargets?.has(target) === true
       if (isExternallyHydratedSession(session)) {
-        acknowledgedRevisions.set(
-          session.id,
-          Math.max(acknowledgedRevisions.get(session.id) ?? 0, sessionRevision(session))
-        )
+        const authority = getExternallyHydratedSessionAuthority(session)
+        if (authority) {
+          const previousAuthority = acknowledgedSessions.get(session.id)
+          const authorityIsNewer =
+            !previousAuthority ||
+            sessionRevision(authority) > sessionRevision(previousAuthority) ||
+            (sessionRevision(authority) === sessionRevision(previousAuthority) &&
+              authority.updatedAt >= previousAuthority.updatedAt)
+          acknowledgedRevisions.set(
+            session.id,
+            Math.max(acknowledgedRevisions.get(session.id) ?? 0, sessionRevision(authority))
+          )
+          if (authorityIsNewer) acknowledgedSessions.set(session.id, authority)
+        }
       }
 
       if (

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -465,13 +465,15 @@ type StoreSaver = (state: SessionStoreSnapshot, options?: StoreSaverOptions) => 
 const pruneRemovedSessionWriteTargets = (
   targets: Set<string>,
   sessions: readonly Pick<ChatSession, 'id'>[],
-  conflictRebaseFields?: Map<string, SessionConflictRebaseField[]>
+  conflictRebaseFields?: Map<string, SessionConflictRebaseField[]>,
+  ...relatedTargets: Set<string>[]
 ): void => {
   const activeSessionTargets = new Set(sessions.map((session) => `session:${session.id}`))
   for (const target of targets) {
     if (target.startsWith('session:') && !activeSessionTargets.has(target)) {
       targets.delete(target)
       conflictRebaseFields?.delete(target)
+      for (const related of relatedTargets) related.delete(target)
     }
   }
 }
@@ -861,7 +863,9 @@ const useSessionPersistence = (): SessionPersistenceState => {
     pruneRemovedSessionWriteTargets(
       failedWriteTargets.current,
       state.sessions,
-      failedConflictRebaseFields.current
+      failedConflictRebaseFields.current,
+      revisionConflictTargets.current,
+      unresolvedSessionRevisionConflictTargets
     )
     if (failedWriteTargets.current.size === 0) {
       setWriteError(undefined)
@@ -976,6 +980,17 @@ const useSessionPersistence = (): SessionPersistenceState => {
             if (isSessionRevisionConflictError(_error)) {
               revisionConflictTargets.current.add(target)
               unresolvedSessionRevisionConflictTargets.add(target)
+              pruneRemovedSessionWriteTargets(
+                failedWriteTargets.current,
+                useSessionStore.getState().sessions,
+                failedConflictRebaseFields.current,
+                revisionConflictTargets.current,
+                unresolvedSessionRevisionConflictTargets
+              )
+              if (!failedWriteTargets.current.has(target)) {
+                if (failedWriteTargets.current.size === 0) setWriteError(undefined)
+                return
+              }
               setWriteError(translateRef.current(SESSION_REVISION_CONFLICT_WRITE_ERROR))
               return
             }
@@ -991,7 +1006,9 @@ const useSessionPersistence = (): SessionPersistenceState => {
             pruneRemovedSessionWriteTargets(
               failedWriteTargets.current,
               useSessionStore.getState().sessions,
-              failedConflictRebaseFields.current
+              failedConflictRebaseFields.current,
+              revisionConflictTargets.current,
+              unresolvedSessionRevisionConflictTargets
             )
             // A queued save can lose a race with an authoritative deletion. Its tombstone rejection
             // must not resurrect a retry target for a Session that no longer exists in the store.
@@ -1024,7 +1041,9 @@ const useSessionPersistence = (): SessionPersistenceState => {
         pruneRemovedSessionWriteTargets(
           failedWriteTargets.current,
           state.sessions,
-          failedConflictRebaseFields.current
+          failedConflictRebaseFields.current,
+          revisionConflictTargets.current,
+          unresolvedSessionRevisionConflictTargets
         )
         if (failedWriteTargets.current.size === 0) setWriteError(undefined)
         void save(state).catch(reportPersistenceError)

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -705,7 +705,7 @@ const createStoreSaver = (
                       error,
                       persisted,
                       saveOptions,
-                      persistence.saveSession
+                      api.saveSession
                     )
                   } catch (finalError) {
                     reportPersistenceError(finalError, 'session-save')

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -808,6 +808,10 @@ const createStoreSaver = (
 // Starts session persistence and returns health/recovery state so App can gate input and surface failures.
 const useSessionPersistence = (): SessionPersistenceState => {
   const { t } = useTranslation()
+  const translateRef = useRef(t)
+  useEffect(() => {
+    translateRef.current = t
+  }, [t])
   const [isHydrated, setIsHydrated] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [isReady, setIsReady] = useState(false)
@@ -972,7 +976,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
             if (isSessionRevisionConflictError(_error)) {
               revisionConflictTargets.current.add(target)
               unresolvedSessionRevisionConflictTargets.add(target)
-              setWriteError(t(SESSION_REVISION_CONFLICT_WRITE_ERROR))
+              setWriteError(translateRef.current(SESSION_REVISION_CONFLICT_WRITE_ERROR))
               return
             }
             const conflictRebaseFields = context.conflictRebaseFields
@@ -1055,7 +1059,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
       if (saverRef.current === activeSaver) saverRef.current = undefined
       unsubscribe?.()
     }
-  }, [loadAttempt, t])
+  }, [loadAttempt])
 
   return {
     isHydrated,

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -228,10 +228,21 @@ const liveSessionPersistence = createOrderedSessionPersistence({
   saveManifest: (request) => window.api.sessions.saveManifest(request)
 })
 
-const saveSessionInOrder = (session: PersistedChatSession): Promise<PersistedChatSession> =>
-  liveSessionPersistence.saveSession(session)
-
 const unresolvedSessionRevisionConflictTargets = new Set<string>()
+
+const saveSessionInOrder = async (session: PersistedChatSession): Promise<PersistedChatSession> => {
+  const target = `session:${session.id}`
+  try {
+    const durable = await liveSessionPersistence.saveSession(session)
+    unresolvedSessionRevisionConflictTargets.delete(target)
+    return durable
+  } catch (error) {
+    if (isSessionRevisionConflictError(error)) {
+      unresolvedSessionRevisionConflictTargets.add(target)
+    }
+    throw error
+  }
+}
 
 class SessionPersistenceFlushConflictError extends Error {
   readonly code = 'session-revision-conflict' as const

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -596,10 +596,15 @@ const createStoreSaver = (
     if (!isSessionRevisionConflictError(error)) throw error
     const base = acknowledgedSessions.get(submitted.id)
     if (!base) throw error
-    const latest = await api.loadOne({
-      projectId: submitted.projectId,
-      sessionId: submitted.id
-    })
+    let latest: PersistedChatSession | undefined
+    try {
+      latest = await api.loadOne({
+        projectId: submitted.projectId,
+        sessionId: submitted.id
+      })
+    } catch {
+      throw error
+    }
     if (!latest) throw error
     const rebased = rebaseSessionAfterRevisionConflict(base, submitted, latest)
     if (!rebased) throw error

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -397,6 +397,7 @@
   "Conversation": "会話",
   "Conversation imports": "会話のインポート",
   "Conversation storage needs attention": "会話のストレージには注意が必要です",
+  "This conversation changed in another window. Your local changes were not saved. Retry to reload the latest version before closing the app.": "この会話は別のウィンドウで変更されました。ローカルの変更は保存されていません。アプリを閉じる前に再試行して、最新バージョンを再読み込みしてください。",
   "Conversations still bound to <name>{{name}}</name> will become <em>unavailable</em> and will <em>not</em> be switched to Main Agent automatically. For each affected conversation you'll explicitly choose a new specialist or Main Agent before it can send again.": "<name>{{name}}</name> に紐づいている会話は<em>利用できなくなり</em>、メイン Agent へ<em>自動的には切り替わりません</em>。影響を受ける各会話は、再送信する前に新しいスペシャリストまたはメイン Agent を明示的に選択してください。",
   "Copied": "コピー済み",
   "Copied!": "コピーしました。",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -458,6 +458,7 @@
   "Conversation": "对话",
   "Conversation imports": "对话导入",
   "Conversation storage needs attention": "对话存储需要处理",
+  "This conversation changed in another window. Your local changes were not saved. Retry to reload the latest version before closing the app.": "此对话已在另一个窗口中更改。你的本地更改尚未保存。请在关闭应用前重试，以重新加载最新版本。",
   "Conversations still bound to <name>{{name}}</name> will become <em>unavailable</em> and will <em>not</em> be switched to Main Agent automatically. For each affected conversation you'll explicitly choose a new specialist or Main Agent before it can send again.": "仍绑定到 <name>{{name}}</name> 的对话将变为<em>不可用</em>，并且<em>不会</em>自动切换到主 Agent。对每个受影响的对话，你需要先明确选择一个新专家或主 Agent，之后它才能继续发送消息。",
   "Copied": "已复制",
   "Copied!": "已复制！",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -457,6 +457,7 @@
   "Conversation": "對話",
   "Conversation imports": "對話匯入",
   "Conversation storage needs attention": "對話儲存需要處理",
+  "This conversation changed in another window. Your local changes were not saved. Retry to reload the latest version before closing the app.": "此對話已在另一個視窗中變更。你的本機變更尚未儲存。請在關閉應用程式前重試，以重新載入最新版本。",
   "Conversations still bound to <name>{{name}}</name> will become <em>unavailable</em> and will <em>not</em> be switched to Main Agent automatically. For each affected conversation you'll explicitly choose a new specialist or Main Agent before it can send again.": "仍綁定到 <name>{{name}}</name> 的對話將變為<em>不可用</em>，並且<em>不會</em>自動切換到主 Agent。對每個受影響的對話，你需要先明確選擇一個新專家或主 Agent，之後它才能繼續傳送訊息。",
   "Copied": "已複製",
   "Copied!": "已複製！",

--- a/src/renderer/src/stores/session-store-persistence-merge.ts
+++ b/src/renderer/src/stores/session-store-persistence-merge.ts
@@ -3,6 +3,7 @@ import type {
   SessionDelegatedWorkRuntimeContext,
   SessionRuntimeContext
 } from '../../../shared/session-persistence'
+import type { ActivePlanProjection } from '../../../shared/session-plan/contract'
 
 const collectDirectDelegateFrameIds = (
   graph: NonNullable<PersistedChatSession['conversationGraph']>
@@ -285,6 +286,38 @@ export const mergeRuntimeConversationAuthority = (
       ? { conversationGraph: structuredClone(current.conversationGraph) }
       : {})
 })
+
+const planProjectionMatchesRuntimePlan = (
+  projection: ActivePlanProjection | undefined,
+  plan: NonNullable<SessionRuntimeContext['plan']> | undefined
+): projection is ActivePlanProjection =>
+  Boolean(
+    projection &&
+    plan &&
+    projection.artifactId === plan.artifactId &&
+    projection.artifactVersionId === plan.artifactVersionId &&
+    projection.artifactChecksum === plan.artifactChecksum &&
+    projection.originatingPromptMessageId === plan.originatingPromptMessageId &&
+    projection.materializedAt === plan.materializedAt &&
+    projection.approval === plan.approval &&
+    projection.continuationState === plan.continuation?.state &&
+    JSON.stringify(projection.stepStatuses) === JSON.stringify(plan.stepStatuses)
+  )
+
+export const retainRuntimePlanProjection = (
+  current: Pick<PersistedChatSession, 'runtimeContext'> & {
+    activePlanProjection?: ActivePlanProjection
+  },
+  incoming: Pick<PersistedChatSession, 'runtimeContext'>
+): ActivePlanProjection | undefined => {
+  const projection = current.activePlanProjection
+  const currentPlan = current.runtimeContext?.plan
+  const incomingPlan = incoming.runtimeContext?.plan
+  return planProjectionMatchesRuntimePlan(projection, currentPlan) &&
+    JSON.stringify(currentPlan) === JSON.stringify(incomingPlan)
+    ? projection
+    : undefined
+}
 
 export const mergePersistedRuntimeIdentityProjection = (
   current: Pick<PersistedChatSession, 'conversationGraph' | 'runtimeContext'>,

--- a/src/renderer/src/stores/session-store-persistence-merge.ts
+++ b/src/renderer/src/stores/session-store-persistence-merge.ts
@@ -265,6 +265,27 @@ type PersistedIdentityState = Pick<
   'artifacts' | 'conversationGraph' | 'filesRevision' | 'messages' | 'runtimeContext'
 >
 
+export const mergeRuntimeConversationAuthority = (
+  current: Pick<PersistedChatSession, 'conversationGraph' | 'messages'>,
+  incoming: Pick<PersistedChatSession, 'conversationGraph' | 'messages'>
+): Pick<PersistedChatSession, 'conversationGraph' | 'messages'> => ({
+  messages: mergeCollectionByIdentity(
+    current.messages,
+    incoming.messages,
+    ({ id }) => id,
+    (currentMessage) => currentMessage
+  ),
+  ...(incoming.conversationGraph
+    ? {
+        conversationGraph: current.conversationGraph
+          ? mergeConversationGraphByIdentity(current.conversationGraph, incoming.conversationGraph)
+          : structuredClone(incoming.conversationGraph)
+      }
+    : current.conversationGraph
+      ? { conversationGraph: structuredClone(current.conversationGraph) }
+      : {})
+})
+
 export const mergePersistedRuntimeIdentityProjection = (
   current: Pick<PersistedChatSession, 'conversationGraph' | 'runtimeContext'>,
   incoming: Pick<PersistedChatSession, 'conversationGraph' | 'runtimeContext'>,

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -119,6 +119,7 @@ export type ApplyDurableSessionProjectionInput = {
     | 'merge-upload-identities'
     | 'replace-persisted-if-current'
     | 'permission-authority'
+    | 'runtime-context-authority'
     | 'enabled-compute-hosts-authority'
     | 'delegated-authority'
 }
@@ -547,6 +548,50 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
           status,
           interactionState,
           runtimeContext: session.runtimeContext,
+          updatedAt: Math.max(current.updatedAt, session.updatedAt)
+        }
+        externallyHydratedSessions.add(projected)
+        return {
+          sessions: state.sessions.map((candidate) =>
+            candidate.id === session.id ? projected : candidate
+          )
+        } as Partial<State>
+      }
+
+      if (mode === 'runtime-context-authority') {
+        const currentRevision = current.runtimeContext?.revision
+        const incomingRevision = session.runtimeContext?.revision
+        if (
+          currentRevision !== undefined &&
+          incomingRevision !== undefined &&
+          incomingRevision < currentRevision
+        ) {
+          return state
+        }
+
+        const interactionState = {
+          ...inferSessionInteractionState(current),
+          permission: session.runtimeContext?.permission?.state === 'pending',
+          plan: session.runtimeContext?.plan?.approval === 'pending'
+        }
+        const status = current.compacting
+          ? current.status
+          : resolveSessionInteractionStatus(
+              { ...current, runtimeContext: session.runtimeContext },
+              interactionState
+            )
+        const projected: ChatSession = {
+          ...current,
+          revision: Math.max(sessionRevision(current), sessionRevision(session)),
+          status,
+          interactionState,
+          runtimeContext: session.runtimeContext,
+          activePlanProjection: matchesPersistedPlanProjection(
+            current.activePlanProjection,
+            session
+          )
+            ? current.activePlanProjection
+            : undefined,
           updatedAt: Math.max(current.updatedAt, session.updatedAt)
         }
         externallyHydratedSessions.add(projected)

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -38,7 +38,8 @@ import {
 import {
   mergeDelegatedWorkAuthorityProjection,
   mergeNewerPersistedSessionByIdentity,
-  mergePersistedRuntimeIdentityProjection
+  mergePersistedRuntimeIdentityProjection,
+  mergeRuntimeConversationAuthority
 } from './session-store-persistence-merge'
 
 export type SessionStatus = PersistedSessionStatus
@@ -536,9 +537,8 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
           currentRevision !== undefined &&
           incomingRevision !== undefined &&
           incomingRevision < currentRevision
-        ) {
+        )
           return state
-        }
 
         const permissionPending = session.runtimeContext?.permission?.state === 'pending'
         const interactionState = {
@@ -589,6 +589,7 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
             )
         const projected: ChatSession = {
           ...current,
+          ...mergeRuntimeConversationAuthority(current, session),
           revision: Math.max(sessionRevision(current), sessionRevision(session)),
           status,
           interactionState,

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -134,7 +134,14 @@ export type SessionPersistenceActions = {
   applyDurableSessionProjection: (input: ApplyDurableSessionProjectionInput) => void
 }
 
-const externallyHydratedSessions = new WeakSet<ChatSession>()
+const externallyHydratedSessionAuthorities = new WeakMap<ChatSession, PersistedChatSession>()
+
+const markExternallyHydratedSession = (
+  session: ChatSession,
+  authority: PersistedChatSession
+): void => {
+  externallyHydratedSessionAuthorities.set(session, structuredClone(authority))
+}
 
 // Builds the empty in-memory state used by the app and isolated tests.
 export const createInitialSessionState = (): SessionStoreData => ({
@@ -457,7 +464,7 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
               }
             : {})
         }
-        externallyHydratedSessions.add(projected)
+        markExternallyHydratedSession(projected, session)
         return {
           sessions: state.sessions.map((candidate) =>
             candidate.id === session.id ? projected : candidate
@@ -490,7 +497,7 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
         ...retainedPlanHistory,
         ...currentPlanProjection
       }
-      externallyHydratedSessions.add(hydratedWithTransientState)
+      markExternallyHydratedSession(hydratedWithTransientState, session)
       const nextSessions = [
         hydratedWithTransientState,
         ...state.sessions.filter((candidate) => candidate.id !== session.id)
@@ -514,7 +521,7 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
             : undefined,
           updatedAt: Math.max(current.updatedAt, session.updatedAt)
         }
-        externallyHydratedSessions.add(projected)
+        markExternallyHydratedSession(projected, session)
         return {
           sessions: state.sessions.map((candidate) =>
             candidate.id === session.id ? projected : candidate
@@ -550,7 +557,7 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
           runtimeContext: session.runtimeContext,
           updatedAt: Math.max(current.updatedAt, session.updatedAt)
         }
-        externallyHydratedSessions.add(projected)
+        markExternallyHydratedSession(projected, session)
         return {
           sessions: state.sessions.map((candidate) =>
             candidate.id === session.id ? projected : candidate
@@ -594,7 +601,7 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
             : undefined,
           updatedAt: Math.max(current.updatedAt, session.updatedAt)
         }
-        externallyHydratedSessions.add(projected)
+        markExternallyHydratedSession(projected, session)
         return {
           sessions: state.sessions.map((candidate) =>
             candidate.id === session.id ? projected : candidate
@@ -609,7 +616,7 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
           ...authority,
           revision: Math.max(sessionRevision(current), sessionRevision(session))
         }
-        externallyHydratedSessions.add(projected)
+        markExternallyHydratedSession(projected, session)
         return {
           sessions: state.sessions.map((candidate) =>
             candidate.id === session.id ? projected : candidate
@@ -684,7 +691,7 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
         ...projected,
         revision: Math.max(sessionRevision(projected), sessionRevision(session))
       }
-      externallyHydratedSessions.add(projected)
+      markExternallyHydratedSession(projected, session)
       return {
         sessions: state.sessions.map((candidate) =>
           candidate.id === session.id ? projected : candidate
@@ -695,4 +702,8 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
 })
 
 export const isExternallyHydratedSession = (session: ChatSession): boolean =>
-  externallyHydratedSessions.has(session)
+  externallyHydratedSessionAuthorities.has(session)
+
+export const getExternallyHydratedSessionAuthority = (
+  session: ChatSession
+): PersistedChatSession | undefined => externallyHydratedSessionAuthorities.get(session)

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -39,15 +39,14 @@ import {
   mergeDelegatedWorkAuthorityProjection,
   mergeNewerPersistedSessionByIdentity,
   mergePersistedRuntimeIdentityProjection,
-  mergeRuntimeConversationAuthority
+  mergeRuntimeConversationAuthority,
+  retainRuntimePlanProjection
 } from './session-store-persistence-merge'
 
 export type SessionStatus = PersistedSessionStatus
 export type ChatMessageRole = PersistedMessageRole
 export type ChatMessageStatus = PersistedMessageStatus
-export type ChatMessage = PersistedChatMessage & {
-  sortIndex?: number
-}
+export type ChatMessage = PersistedChatMessage & { sortIndex?: number }
 export type ActiveRun = PersistedActiveRun
 export type ToolActivityStatus = ToolCallStatus
 export type ToolActivity = {
@@ -587,6 +586,12 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
               { ...current, runtimeContext: session.runtimeContext },
               interactionState
             )
+        const activePlanProjection = matchesPersistedPlanProjection(
+          current.activePlanProjection,
+          session
+        )
+          ? current.activePlanProjection
+          : retainRuntimePlanProjection(current, session)
         const projected: ChatSession = {
           ...current,
           ...mergeRuntimeConversationAuthority(current, session),
@@ -594,12 +599,7 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
           status,
           interactionState,
           runtimeContext: session.runtimeContext,
-          activePlanProjection: matchesPersistedPlanProjection(
-            current.activePlanProjection,
-            session
-          )
-            ? current.activePlanProjection
-            : undefined,
+          activePlanProjection,
           updatedAt: Math.max(current.updatedAt, session.updatedAt)
         }
         markExternallyHydratedSession(projected, session)

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -17,6 +17,7 @@ import {
   materializeSessionConversationGraph,
   sanitizeActivityGroup,
   sanitizePlanHistoryProjections,
+  sessionRevision,
   sanitizeToolActivity,
   type PersistedActiveRun,
   type PersistedActivityGroup,
@@ -398,7 +399,14 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
   upsertPersistedSession: (session) => {
     set((state) => {
       const existing = state.sessions.find((candidate) => candidate.id === session.id)
-      if (existing && existing.updatedAt >= session.updatedAt) {
+      const incomingSessionRevision = sessionRevision(session)
+      const existingSessionRevision = existing ? sessionRevision(existing) : -1
+      if (
+        existing &&
+        (existingSessionRevision > incomingSessionRevision ||
+          (existingSessionRevision === incomingSessionRevision &&
+            existing.updatedAt >= session.updatedAt))
+      ) {
         const incomingRuntimeRevision = session.runtimeContext?.revision ?? -1
         const existingRuntimeRevision = existing.runtimeContext?.revision ?? -1
         const runtimeAdvanced = incomingRuntimeRevision > existingRuntimeRevision
@@ -457,7 +465,10 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
       }
 
       const incomingProjection =
-        existing && session.updatedAt > existing.updatedAt
+        existing &&
+        (incomingSessionRevision > existingSessionRevision ||
+          (incomingSessionRevision === existingSessionRevision &&
+            session.updatedAt > existing.updatedAt))
           ? mergeNewerPersistedSessionByIdentity(existing, session)
           : session
       const hydratedSession = existing
@@ -496,6 +507,7 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
       if (mode === 'enabled-compute-hosts-authority') {
         const projected: ChatSession = {
           ...current,
+          revision: Math.max(sessionRevision(current), sessionRevision(session)),
           enabledComputeHosts: session.enabledComputeHosts
             ? [...session.enabledComputeHosts]
             : undefined,
@@ -531,6 +543,7 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
         )
         const projected: ChatSession = {
           ...current,
+          revision: Math.max(sessionRevision(current), sessionRevision(session)),
           status,
           interactionState,
           runtimeContext: session.runtimeContext,
@@ -546,7 +559,11 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
 
       if (mode === 'delegated-authority') {
         const authority = mergeDelegatedWorkAuthorityProjection(current, session)
-        const projected: ChatSession = { ...current, ...authority }
+        const projected: ChatSession = {
+          ...current,
+          ...authority,
+          revision: Math.max(sessionRevision(current), sessionRevision(session))
+        }
         externallyHydratedSessions.add(projected)
         return {
           sessions: state.sessions.map((candidate) =>
@@ -572,7 +589,13 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
             )
           : undefined
         const authorityProjected = projectDurablePlanAuthority(current, session)
-        if (!flat.changed && !graph?.changed && authorityProjected === current) return state
+        if (
+          !flat.changed &&
+          !graph?.changed &&
+          authorityProjected === current &&
+          sessionRevision(session) <= sessionRevision(current)
+        )
+          return state
         projected =
           flat.changed || graph?.changed
             ? projectDurablePlanAuthority(withTransientSessionState(session, current), session)
@@ -603,9 +626,19 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
             : {})
         }
         projected = projectDurablePlanAuthority(merged, session)
-        if (!flat.changed && !graph?.changed && projected === merged) return state
+        if (
+          !flat.changed &&
+          !graph?.changed &&
+          projected === merged &&
+          sessionRevision(session) <= sessionRevision(current)
+        )
+          return state
       }
 
+      projected = {
+        ...projected,
+        revision: Math.max(sessionRevision(projected), sessionRevision(session))
+      }
       externallyHydratedSessions.add(projected)
       return {
         sessions: state.sessions.map((candidate) =>

--- a/src/renderer/src/stores/session-store.architecture.test.ts
+++ b/src/renderer/src/stores/session-store.architecture.test.ts
@@ -105,6 +105,7 @@ const publicStoreTarget = modulePath(facadePath)
 const publicValueExports = [
   'createInitialSessionState',
   'createSessionStore',
+  'getExternallyHydratedSessionAuthority',
   'isExternallyHydratedSession',
   'isSessionWaitReason',
   'projectSessionActionability',

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -831,6 +831,66 @@ describe('session store', () => {
     expect(useSessionStore.getState().sessions[0].activePlanProjection).toBe(projection)
   })
 
+  it('keeps the active Plan projection when Permission advances the runtime revision', () => {
+    useSessionStore.getState().hydrateSessions([
+      {
+        id: 'session-1',
+        projectId: 'project-1',
+        title: 'Plan approval',
+        cwd: '/workspace',
+        status: 'waiting-plan-approval',
+        runtimeContext: {
+          version: 1,
+          revision: 1,
+          plan: {
+            artifactId: 'artifact-version-1',
+            artifactVersionId: 'version-1',
+            artifactChecksum: 'a'.repeat(64),
+            approval: 'pending',
+            stepStatuses: {}
+          }
+        },
+        messages: [],
+        createdAt: 1,
+        updatedAt: 2
+      }
+    ])
+    const projection = createPlanProjection('version-1')
+    useSessionStore.getState().setActivePlanProjection('session-1', projection)
+    const source = useSessionStore.getState().sessions[0]
+
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: {
+        ...toPersistedSession(source),
+        status: 'waiting-permission',
+        runtimeContext: {
+          ...source.runtimeContext!,
+          revision: 2,
+          permission: {
+            state: 'pending',
+            request: {
+              requestId: 'permission-1',
+              sessionId: 'session-1',
+              toolCallId: 'tool-1',
+              title: 'Run tests',
+              options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+            },
+            originatingPromptMessageId: 'prompt-1',
+            fingerprint: 'b'.repeat(64),
+            createdAt: 3
+          }
+        },
+        updatedAt: 3
+      },
+      mode: 'runtime-context-authority'
+    })
+
+    const updated = useSessionStore.getState().sessions[0]
+    expect(updated.activePlanProjection).toBe(projection)
+    expect(updated.runtimeContext).toMatchObject({ revision: 2, permission: { state: 'pending' } })
+  })
+
   it('does not replace newer local conversation state when a durable Plan authority arrives', () => {
     const prompt = useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -22,6 +22,7 @@ import {
 
 export {
   createInitialSessionState,
+  getExternallyHydratedSessionAuthority,
   isExternallyHydratedSession,
   toPersistedSession,
   type ActiveRun,

--- a/src/shared/application-command-contract.ts
+++ b/src/shared/application-command-contract.ts
@@ -2,7 +2,8 @@ export const APPLICATION_COMMAND_ERROR_CODES = [
   'invalid-command-arguments',
   'invalid-command-result',
   'command-unavailable',
-  'command-failed'
+  'command-failed',
+  'session-revision-conflict'
 ] as const
 
 export type ApplicationCommandErrorCode = (typeof APPLICATION_COMMAND_ERROR_CODES)[number]

--- a/src/shared/lifecycle-events.ts
+++ b/src/shared/lifecycle-events.ts
@@ -9,6 +9,7 @@ type SessionUpsertEvent = {
 // Main-owned permission authority is projected through the existing Session lifecycle channel,
 // but it must merge into the live renderer Session instead of replacing in-flight chat state.
 const MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID = 'main:permission-wait'
+const MAIN_RUNTIME_CONTEXT_LIFECYCLE_CLIENT_ID = 'main:runtime-context'
 const MAIN_DURABLE_CONTINUATION_LIFECYCLE_CLIENT_ID = 'main:durable-continuation'
 const MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID = 'main:enabled-compute-hosts'
 const MAIN_DELEGATED_WORK_LIFECYCLE_CLIENT_ID = 'main:delegated-work'
@@ -37,6 +38,7 @@ export {
   MAIN_DELEGATED_WORK_LIFECYCLE_CLIENT_ID,
   MAIN_DURABLE_CONTINUATION_LIFECYCLE_CLIENT_ID,
   MAIN_ENABLED_COMPUTE_HOSTS_LIFECYCLE_CLIENT_ID,
-  MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID
+  MAIN_PERMISSION_WAIT_LIFECYCLE_CLIENT_ID,
+  MAIN_RUNTIME_CONTEXT_LIFECYCLE_CLIENT_ID
 }
 export type { Project, ProjectDeletedEvent, SessionDeletedEvent, SessionUpsertEvent }

--- a/src/shared/session-persistence-flush.ts
+++ b/src/shared/session-persistence-flush.ts
@@ -2,4 +2,8 @@ export const SESSION_PERSISTENCE_FLUSH_REQUEST_CHANNEL = 'sessions:flush-request
 export const SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL = 'sessions:flush-response'
 
 export type SessionPersistenceFlushRequest = { requestId: string }
-export type SessionPersistenceFlushResponse = { requestId: string }
+export type SessionPersistenceFlushStatus = 'completed' | 'conflict' | 'failed'
+export type SessionPersistenceFlushResponse = {
+  requestId: string
+  status: SessionPersistenceFlushStatus
+}

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -72,6 +72,13 @@ describe('Session file envelope versions', () => {
     expect(decodeSessionFile(value)).toEqual({ status: 'invalid' })
     expect(normalizeSessionFile(value)).toBeUndefined()
   })
+
+  it('restores historical and malformed whole-Session revisions as zero', () => {
+    expect(normalizeSessionFile(legacySession())?.revision).toBe(0)
+    expect(normalizeSessionFile({ ...legacySession(), revision: 7 })?.revision).toBe(7)
+    expect(normalizeSessionFile({ ...legacySession(), revision: -1 })?.revision).toBe(0)
+    expect(normalizeSessionFile({ ...legacySession(), revision: '7' })?.revision).toBe(0)
+  })
 })
 
 describe('Session Specialist binding persistence', () => {

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -480,6 +480,9 @@ export type PersistedChatSession = {
   id: string
   // Owning project. On load this is authoritative from the file's directory (sessions/<projectId>/).
   projectId: string
+  // Whole-Session durable revision used for optimistic concurrency. Historical files omit it and
+  // restore as revision 0; Main stamps revision 1 on their next successful state transition.
+  revision?: number
   // Immutable snapshot of the direct Session and active conversation path copied by
   // Branch in new session. Historical Sessions omit it and remain unrelated.
   branchSource?: PersistedSessionBranchSource
@@ -578,6 +581,35 @@ export type SessionConflictRebaseField =
 export type SaveSessionOptions = {
   conflictRebaseFields?: SessionConflictRebaseField[]
 }
+
+export const SESSION_REVISION_CONFLICT_ERROR_CODE = 'session-revision-conflict' as const
+
+export class SessionRevisionConflictError extends Error {
+  readonly code = SESSION_REVISION_CONFLICT_ERROR_CODE
+
+  constructor(
+    readonly expectedRevision: number,
+    readonly actualRevision: number
+  ) {
+    super(
+      `Session revision conflict: expected ${expectedRevision}, actual ${actualRevision}. Reload the latest conversation before retrying.`
+    )
+    this.name = 'SessionRevisionConflictError'
+  }
+}
+
+export const sessionRevision = (session: Pick<PersistedChatSession, 'revision'>): number =>
+  Number.isSafeInteger(session.revision) && (session.revision ?? -1) >= 0 ? session.revision! : 0
+
+export const isSessionRevisionConflictError = (
+  error: unknown
+): error is Readonly<{ code: typeof SESSION_REVISION_CONFLICT_ERROR_CODE }> =>
+  error instanceof SessionRevisionConflictError ||
+  (typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === SESSION_REVISION_CONFLICT_ERROR_CODE) ||
+  (error instanceof Error && error.message.includes('Session revision conflict:'))
 
 // Restored interrupted sessions carry this error verbatim; the renderer keys its resume banner off it.
 export const INTERRUPTED_SESSION_ERROR = 'Session was interrupted before the app closed.'
@@ -3278,10 +3310,12 @@ const sanitizeSession = (
           options.preserveRuntimeState ? group : normalizeActivityGroupAfterRestore(group)
         )
     : []
+  const revision = asNumber(session.revision)
   let sanitized: PersistedChatSession = {
     id,
     // Content value is a hint; the repository overrides it with the session file's directory on load.
     projectId: asString(session.projectId) ?? '',
+    revision: Number.isSafeInteger(revision) && (revision ?? -1) >= 0 ? revision : 0,
     title: asString(session.title) ?? id,
     cwd: asString(session.cwd) ?? '',
     status: asSessionStatus(session.status),


### PR DESCRIPTION
## Problem

Session persistence replaced the whole JSON document without a revision precondition. Two clients that hydrated the same Session could therefore commit in this order: a newer save succeeds, then an older desktop/Web snapshot or quit flush succeeds last and silently removes newer messages, title changes, or Conversation Graph state.

## Proposed change

- Add a whole-Session `revision` and compare the caller's expected revision with durable JSON inside the repository's per-Session write lane. A successful state transition writes `revision + 1` and returns that durable revision to the caller.
- Chain acknowledged revisions through renderer saves and prefer revision over `updatedAt` when applying durable/external projections.
- Permit a stale save to rebase only explicitly declared safe fields and only when its Conversation Graph is identical to current authority. Reject every other stale snapshot with `session-revision-conflict`.
- Recover one Main-owned revision race by loading current authority and performing one three-way rebase. Concurrent renderer and authoritative graph changes remain a conflict.
- Publish Main-owned runtime-context revisions to renderers without replacing live Messages or Conversation Graph state.
- Preserve the conflict code across Electron/Web command boundaries, show a translated reload-before-close error, and make Retry hydrate current authority instead of resending stale JSON.
- Return explicit renderer flush outcomes. Any unresolved store or explicit ordered-save conflict aborts shutdown before backend teardown, resets the quit latch, and surfaces the main window.

## Scope and non-goals

- No automatic merge of concurrent Messages, Artifacts, activities, or Conversation Graph topology.
- No change to the atomic JSON replacement mechanism or project deletion authority.
- No Prisma/database schema change.

### Historical compatibility

- Historical Session JSON without `revision` loads as revision `0`; its next successful save writes revision `1`.
- Missing, malformed, negative, or non-integer revisions normalize to `0`.
- There is no eager migration or startup rewrite.

### State and protocol additions

- No new Session status/business-state enum value.
- Add application-command error code `session-revision-conflict`.
- Extend the renderer flush response status with `conflict` and `failed` in addition to `completed`.
- Add an internal Main lifecycle origin for runtime-context authority; this is not persisted state.

### Persistence changes

- Add optional top-level `revision` to persisted Session JSON and the shared Session model.
- Every accepted whole-Session state transition stamps the next revision; rejected stale writes do not modify JSON.
- Main-owned recovery, archive, delegated-work, side-chat, upload-upgrade, reconciliation, runtime-context, and Plan-feedback paths retain and publish the repository-returned durable revision.
- Explicit ordered saves record unresolved CAS conflicts so quit flush cannot report success until that Session saves successfully or reload replaces local authority.

## Acceptance criteria and validation

Checks run against the latest committed state:

- `npm run test:module -- session_persistence` - 7 files / 311 tests passed.
- Focused renderer persistence, lifecycle sync, and Session store tests - 3 files / 206 tests passed.
- `npm run typecheck:node` and `npm run typecheck:web` - passed.
- `npm run lint` - passed.

The earlier committed-diff affected-test planner fell back to the complete Vitest suite because `src/main/app-lifecycle.test.ts` has no module owner. That local Windows run reported 10 unrelated ACL/symlink/environment failures in host image, upload media, Compute Host askpass, and Skill repository tests. The focused owner/contract/consumer tests above pass; PR CI remains authoritative for those platform lanes.

## Review focus

- The compare-and-increment boundary in `SessionRepository.saveSession`.
- The graph-equality requirement before safe-field or three-way rebase.
- Revision propagation through queued renderer writes and Main-owned runtime mutations.
- The conflict-specific quit abort path and its latch reset.
