### PR TITLE
fix(compute): restore password-auth CI after follow-up

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -221,6 +221,7 @@
         "src/main/compute/concurrency-manager.ts",
         "src/main/compute/job-dispatcher.ts",
         "src/main/compute/job-poller.ts",
+        "src/main/compute/job-poll-output.ts",
         "src/main/compute/job-repository.ts",
         "src/main/compute/enabled-hosts-registry.ts",
         "src/main/compute/session-enabled-hosts-owner.ts",

--- a/src/main/compute/compute-service.architecture.test.ts
+++ b/src/main/compute/compute-service.architecture.test.ts
@@ -520,6 +520,7 @@ describe('Compute service architecture', () => {
       'src/main/compute/concurrency-manager.ts',
       'src/main/compute/job-dispatcher.ts',
       'src/main/compute/job-poller.ts',
+      'src/main/compute/job-poll-output.ts',
       'src/main/compute/job-repository.ts',
       'src/main/compute/enabled-hosts-registry.ts',
       'src/main/compute/session-enabled-hosts-owner.ts',

--- a/src/main/compute/connection-broker.test.ts
+++ b/src/main/compute/connection-broker.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { createConnection } from 'node:net'
+import { platform } from 'node:os'
 
 vi.mock('electron', () => ({
   app: { isPackaged: false, getAppPath: () => process.cwd() }
@@ -30,6 +31,20 @@ const target: ResolvedSshTarget = {
   extraArgs: ['-o', 'BatchMode=yes']
 }
 
+const unixSocketAskpass = it.skipIf(platform() === 'win32')
+
+const answeredAskpass = (): {
+  env: NodeJS.ProcessEnv
+  wasAnswered: () => boolean
+  wasUnsupportedPromptRejected: () => boolean
+  dispose: () => Promise<void>
+} => ({
+  env: { SSH_ASKPASS: '/constrained/helper' },
+  wasAnswered: () => true,
+  wasUnsupportedPromptRejected: () => false,
+  dispose: async () => undefined
+})
+
 const askAskpass = (env: NodeJS.ProcessEnv, prompt: string): Promise<Record<string, string>> =>
   new Promise((resolve, reject) => {
     const socket = createConnection(env['OPEN_SCIENCE_ASKPASS_SOCKET'] as string)
@@ -51,18 +66,32 @@ const askAskpass = (env: NodeJS.ProcessEnv, prompt: string): Promise<Record<stri
   })
 
 describe('ComputeConnectionBroker SSH configuration compatibility', () => {
-  it('does not inherit unrelated process environment values into the askpass child', async () => {
-    const distinctiveSecret = 'release gate secret "quoted"\nUnicode 密码'
-    vi.stubEnv('OPEN_SCIENCE_RELEASE_GATE_SECRET', distinctiveSecret)
-
-    const askpass = await createAskpassEnvironment(distinctiveSecret, ['researcher@cluster'])
-    try {
-      expect(askpass.env['OPEN_SCIENCE_RELEASE_GATE_SECRET']).toBeUndefined()
-      expect(JSON.stringify(askpass.env)).not.toContain(distinctiveSecret)
-    } finally {
-      await askpass.dispose()
+  it.runIf(platform() === 'win32')(
+    'rejects Unix-socket askpass construction on Windows',
+    async () => {
+      await expect(
+        createAskpassEnvironment('must-not-open-a-socket', ['researcher@cluster'])
+      ).rejects.toMatchObject({
+        code: 'unsupported_auth_configuration'
+      })
     }
-  })
+  )
+
+  unixSocketAskpass(
+    'does not inherit unrelated process environment values into the askpass child',
+    async () => {
+      const distinctiveSecret = 'release gate secret "quoted"\nUnicode 密码'
+      vi.stubEnv('OPEN_SCIENCE_RELEASE_GATE_SECRET', distinctiveSecret)
+
+      const askpass = await createAskpassEnvironment(distinctiveSecret, ['researcher@cluster'])
+      try {
+        expect(askpass.env['OPEN_SCIENCE_RELEASE_GATE_SECRET']).toBeUndefined()
+        expect(JSON.stringify(askpass.env)).not.toContain(distinctiveSecret)
+      } finally {
+        await askpass.dispose()
+      }
+    }
+  )
 
   it('suppresses background authentication retries per Host after a confirmed failure', async () => {
     const otherHost = { ...host, id: 'host-2', providerId: 'ssh:other', sshAlias: 'other' }
@@ -1239,63 +1268,66 @@ describe('ComputeConnectionBroker SSH configuration compatibility', () => {
     )
   })
 
-  it('fails closed after rejecting any interactive variant or repeated target prompt', async () => {
-    const secret = 'distinctive target-only secret'
-    const responses: Array<Record<string, string>> = []
-    const runner: SshRunner = {
-      run: vi
-        .fn()
-        .mockResolvedValueOnce({
-          exitCode: 255,
-          stdout: '',
-          stderr: 'Permission denied',
-          truncated: false,
-          timedOut: false
-        })
-        .mockImplementationOnce(async (_target, _command, options) => {
-          for (const prompt of [
-            "Enter passphrase for key '/tmp/id_ed25519':",
-            "intruder@other-host's password:",
-            "proxy@bastion's password:",
-            'Keyboard-interactive authentication:',
-            'One-time password (OTP):',
-            'MFA verification code:'
-          ]) {
-            responses.push(await askAskpass(options.env ?? {}, prompt))
-          }
-          responses.push(await askAskpass(options.env ?? {}, "researcher@cluster's password:"))
-          responses.push(await askAskpass(options.env ?? {}, "researcher@cluster's password:"))
-          return {
-            exitCode: 0,
-            stdout: 'ok',
-            stderr: '',
+  unixSocketAskpass(
+    'fails closed after rejecting any interactive variant or repeated target prompt',
+    async () => {
+      const secret = 'distinctive target-only secret'
+      const responses: Array<Record<string, string>> = []
+      const runner: SshRunner = {
+        run: vi
+          .fn()
+          .mockResolvedValueOnce({
+            exitCode: 255,
+            stdout: '',
+            stderr: 'Permission denied',
             truncated: false,
             timedOut: false
-          }
-        })
+          })
+          .mockImplementationOnce(async (_target, _command, options) => {
+            for (const prompt of [
+              "Enter passphrase for key '/tmp/id_ed25519':",
+              "intruder@other-host's password:",
+              "proxy@bastion's password:",
+              'Keyboard-interactive authentication:',
+              'One-time password (OTP):',
+              'MFA verification code:'
+            ]) {
+              responses.push(await askAskpass(options.env ?? {}, prompt))
+            }
+            responses.push(await askAskpass(options.env ?? {}, "researcher@cluster's password:"))
+            responses.push(await askAskpass(options.env ?? {}, "researcher@cluster's password:"))
+            return {
+              exitCode: 0,
+              stdout: 'ok',
+              stderr: '',
+              truncated: false,
+              timedOut: false
+            }
+          })
+      }
+      const adapter = new PasswordSshAdapter(
+        {
+          acquirePasswordLease: vi.fn(async () => ({
+            withPassword: (operation: (password: string) => Promise<unknown>) => operation(secret)
+          }))
+        } as unknown as CredentialVault,
+        runner,
+        vi.fn(async () => target),
+        vi.fn(async () => ({}))
+      )
+
+      const lease = await adapter.acquire(host, { intent: 'direct_command' })
+      await expect(lease.run('true', { timeoutMs: 1000 })).rejects.toMatchObject({
+        code: 'unsupported_auth_configuration'
+      })
+
+      expect(responses.slice(0, 6)).toEqual([{}, {}, {}, {}, {}, {}])
+      expect(responses[6]).toEqual({ password: secret })
+      expect(responses[7]).toEqual({})
     }
-    const adapter = new PasswordSshAdapter(
-      {
-        acquirePasswordLease: vi.fn(async () => ({
-          withPassword: (operation: (password: string) => Promise<unknown>) => operation(secret)
-        }))
-      } as unknown as CredentialVault,
-      runner,
-      vi.fn(async () => target),
-      vi.fn(async () => ({}))
-    )
+  )
 
-    const lease = await adapter.acquire(host, { intent: 'direct_command' })
-    await expect(lease.run('true', { timeoutMs: 1000 })).rejects.toMatchObject({
-      code: 'unsupported_auth_configuration'
-    })
-
-    expect(responses.slice(0, 6)).toEqual([{}, {}, {}, {}, {}, {}])
-    expect(responses[6]).toEqual({ password: secret })
-    expect(responses[7]).toEqual({})
-  })
-
-  it.each([
+  unixSocketAskpass.each([
     ['passphrase', ["Enter passphrase for key '/tmp/id_ed25519':"]],
     ['other-account password', ["proxy@bastion's password:"]],
     ['keyboard-interactive', ['Keyboard-interactive authentication:']],
@@ -1396,7 +1428,8 @@ describe('ComputeConnectionBroker SSH configuration compatibility', () => {
         } as unknown as CredentialVault,
         runner,
         vi.fn(async () => target),
-        vi.fn(async () => ({}))
+        vi.fn(async () => ({})),
+        vi.fn(async () => answeredAskpass())
       )
 
       const lease = await adapter.acquire(host, { intent: 'direct_command' })
@@ -1493,121 +1526,127 @@ describe('ComputeConnectionBroker SSH configuration compatibility', () => {
     await expect(lease.redactSensitiveOutputs?.(['tail 1'])).resolves.toEqual(['tail [redacted]'])
   })
 
-  it('keeps an answered target-password failure classified and persisted as authentication_failed', async () => {
-    const passwordHost = {
-      ...host,
-      authentication: {
-        mode: 'password' as const,
-        credentialStatus: 'configured' as const,
-        revision: 1,
-        lastVerifiedAt: undefined
+  unixSocketAskpass(
+    'keeps an answered target-password failure classified and persisted as authentication_failed',
+    async () => {
+      const passwordHost = {
+        ...host,
+        authentication: {
+          mode: 'password' as const,
+          credentialStatus: 'configured' as const,
+          revision: 1,
+          lastVerifiedAt: undefined
+        }
       }
-    }
-    const runner: SshRunner = {
-      run: vi
-        .fn()
-        .mockResolvedValueOnce({
-          exitCode: 255,
-          stdout: '',
-          stderr: 'Permission denied',
-          truncated: false,
-          timedOut: false
-        })
-        .mockImplementationOnce(async (_target, _command, options) => {
-          await askAskpass(options.env ?? {}, "researcher@cluster's password:")
-          return {
+      const runner: SshRunner = {
+        run: vi
+          .fn()
+          .mockResolvedValueOnce({
             exitCode: 255,
             stdout: '',
-            stderr: 'Permission denied (password).',
+            stderr: 'Permission denied',
             truncated: false,
             timedOut: false
-          }
-        })
-    }
-    const passwordAdapter = new PasswordSshAdapter(
-      {
-        acquirePasswordLease: vi.fn(async () => ({
-          withPassword: (operation: (password: string) => Promise<unknown>) =>
-            operation('incorrect-target-password')
-        }))
-      } as unknown as CredentialVault,
-      runner,
-      vi.fn(async () => target),
-      vi.fn(async () => ({}))
-    )
-    const persistAuthenticationFailure = vi.fn(async () => undefined)
-    const broker = new SshConfigComputeConnectionBroker({
-      getHost: vi.fn(async () => passwordHost),
-      runner,
-      passwordAdapter,
-      persistAuthenticationFailure
-    })
-
-    const lease = await broker.acquire(host.providerId, { intent: 'direct_command' })
-
-    await expect(lease.run('true', { timeoutMs: 1000 })).rejects.toMatchObject({
-      code: 'authentication_failed'
-    })
-    expect(persistAuthenticationFailure).toHaveBeenCalledWith(passwordHost)
-  })
-
-  it('does not persist a rejected proxy prompt as an authentication failure', async () => {
-    const passwordHost = {
-      ...host,
-      authentication: {
-        mode: 'password' as const,
-        credentialStatus: 'configured' as const,
-        revision: 1,
-        lastVerifiedAt: undefined
+          })
+          .mockImplementationOnce(async (_target, _command, options) => {
+            await askAskpass(options.env ?? {}, "researcher@cluster's password:")
+            return {
+              exitCode: 255,
+              stdout: '',
+              stderr: 'Permission denied (password).',
+              truncated: false,
+              timedOut: false
+            }
+          })
       }
+      const passwordAdapter = new PasswordSshAdapter(
+        {
+          acquirePasswordLease: vi.fn(async () => ({
+            withPassword: (operation: (password: string) => Promise<unknown>) =>
+              operation('incorrect-target-password')
+          }))
+        } as unknown as CredentialVault,
+        runner,
+        vi.fn(async () => target),
+        vi.fn(async () => ({}))
+      )
+      const persistAuthenticationFailure = vi.fn(async () => undefined)
+      const broker = new SshConfigComputeConnectionBroker({
+        getHost: vi.fn(async () => passwordHost),
+        runner,
+        passwordAdapter,
+        persistAuthenticationFailure
+      })
+
+      const lease = await broker.acquire(host.providerId, { intent: 'direct_command' })
+
+      await expect(lease.run('true', { timeoutMs: 1000 })).rejects.toMatchObject({
+        code: 'authentication_failed'
+      })
+      expect(persistAuthenticationFailure).toHaveBeenCalledWith(passwordHost)
     }
-    const runner: SshRunner = {
-      run: vi
-        .fn()
-        .mockResolvedValueOnce({
-          exitCode: 255,
-          stdout: '',
-          stderr: 'Permission denied',
-          truncated: false,
-          timedOut: false
-        })
-        .mockImplementationOnce(async (_target, _command, options) => {
-          await askAskpass(options.env ?? {}, "proxy@bastion's password:")
-          return {
+  )
+
+  unixSocketAskpass(
+    'does not persist a rejected proxy prompt as an authentication failure',
+    async () => {
+      const passwordHost = {
+        ...host,
+        authentication: {
+          mode: 'password' as const,
+          credentialStatus: 'configured' as const,
+          revision: 1,
+          lastVerifiedAt: undefined
+        }
+      }
+      const runner: SshRunner = {
+        run: vi
+          .fn()
+          .mockResolvedValueOnce({
             exitCode: 255,
             stdout: '',
-            stderr: 'Permission denied (password).',
+            stderr: 'Permission denied',
             truncated: false,
             timedOut: false
-          }
-        })
+          })
+          .mockImplementationOnce(async (_target, _command, options) => {
+            await askAskpass(options.env ?? {}, "proxy@bastion's password:")
+            return {
+              exitCode: 255,
+              stdout: '',
+              stderr: 'Permission denied (password).',
+              truncated: false,
+              timedOut: false
+            }
+          })
+      }
+      const passwordAdapter = new PasswordSshAdapter(
+        {
+          acquirePasswordLease: vi.fn(async () => ({
+            withPassword: (operation: (password: string) => Promise<unknown>) =>
+              operation('must-not-be-released')
+          }))
+        } as unknown as CredentialVault,
+        runner,
+        vi.fn(async () => target),
+        vi.fn(async () => ({}))
+      )
+      const persistAuthenticationFailure = vi.fn(async () => undefined)
+      const broker = new SshConfigComputeConnectionBroker({
+        getHost: vi.fn(async () => passwordHost),
+        runner,
+        passwordAdapter,
+        persistAuthenticationFailure
+      })
+
+      const lease = await broker.acquire(host.providerId, { intent: 'direct_command' })
+
+      await expect(lease.run('true', { timeoutMs: 1000 })).rejects.toMatchObject({
+        code: 'unsupported_auth_configuration'
+      })
+      expect(persistAuthenticationFailure).not.toHaveBeenCalled()
     }
-    const passwordAdapter = new PasswordSshAdapter(
-      {
-        acquirePasswordLease: vi.fn(async () => ({
-          withPassword: (operation: (password: string) => Promise<unknown>) =>
-            operation('must-not-be-released')
-        }))
-      } as unknown as CredentialVault,
-      runner,
-      vi.fn(async () => target),
-      vi.fn(async () => ({}))
-    )
-    const persistAuthenticationFailure = vi.fn(async () => undefined)
-    const broker = new SshConfigComputeConnectionBroker({
-      getHost: vi.fn(async () => passwordHost),
-      runner,
-      passwordAdapter,
-      persistAuthenticationFailure
-    })
-
-    const lease = await broker.acquire(host.providerId, { intent: 'direct_command' })
-
-    await expect(lease.run('true', { timeoutMs: 1000 })).rejects.toMatchObject({
-      code: 'unsupported_auth_configuration'
-    })
-    expect(persistAuthenticationFailure).not.toHaveBeenCalled()
-  })
+  )
 
   it('returns a stable authentication error without raw transfer diagnostics', async () => {
     const rawDiagnostic = 'Permission denied (password). helper=/private/path secret=do-not-leak'

--- a/src/main/compute/credential-vault.test.ts
+++ b/src/main/compute/credential-vault.test.ts
@@ -10,6 +10,22 @@ const cipher = (backend: string): ComputeCredentialCipher => ({
 })
 
 describe('Compute password secure-storage capability', () => {
+  it('fails closed on Windows regardless of the OS cipher backend', () => {
+    const vault = new CredentialVault(
+      { getCredential: vi.fn(async () => null) },
+      cipher('os_crypt'),
+      'win32'
+    )
+
+    expect(vault.capability()).toEqual({
+      available: false,
+      reason: 'unsupported_platform'
+    })
+    expect(() => vault.encrypt('must not persist')).toThrowError(
+      expect.objectContaining({ code: 'secure_storage_unavailable' })
+    )
+  })
+
   it('fails closed for Electron basic_text on Linux', () => {
     const vault = new CredentialVault(
       { getCredential: vi.fn(async () => null) },

--- a/src/main/compute/job-poll-output.ts
+++ b/src/main/compute/job-poll-output.ts
@@ -1,0 +1,64 @@
+import type { ComputeJob } from '../../shared/compute'
+
+export type ParsedPollObservation = {
+  job: ComputeJob
+  alive: boolean
+  exitCode: number | null
+  hasExitCode: boolean
+  stdoutTail: string
+  stderrTail: string
+}
+
+// Parses nonce-prefixed poll SSH stdout into per-job observations. Structural markers carry the
+// per-tick nonce so adversarial job tail content cannot collide with them.
+export const parsePollOutput = (
+  output: string,
+  jobs: readonly ComputeJob[],
+  nonce: string
+): ParsedPollObservation[] => {
+  const escapedNonce = nonce.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const sections = output.split(new RegExp(`^${escapedNonce}JOB_START:`, 'm'))
+  const parsedResults: ParsedPollObservation[] = []
+
+  for (const section of sections) {
+    if (!section.trim()) continue
+    const firstNewline = section.indexOf('\n')
+    if (firstNewline === -1) continue
+    const jobId = section.slice(0, firstNewline).trim()
+    const body = section.slice(firstNewline + 1)
+
+    const job = jobs.find((candidate) => candidate.job_id === jobId)
+    if (!job) continue
+
+    const aliveMatch = body.match(new RegExp(`^${escapedNonce}alive:([01])`, 'm'))
+    const alive = aliveMatch?.[1] === '1'
+
+    const alivePrefix = `${nonce}alive:`
+    const lines = body.split('\n')
+    let exitCodeRaw = ''
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i]?.startsWith(alivePrefix)) {
+        exitCodeRaw = lines[i + 1]?.trim() ?? ''
+        break
+      }
+    }
+    const exitCode = exitCodeRaw.trim() === '' ? null : Number.parseInt(exitCodeRaw.trim(), 10)
+    const hasExitCode = exitCode !== null && Number.isFinite(exitCode)
+
+    const stdoutEndMarker = `${nonce}STDOUT_END:${jobId}`
+    const stderrEndMarker = `${nonce}STDERR_END:${jobId}`
+    const stdoutStart = body.indexOf('\n', body.indexOf('\n', body.indexOf('\n') + 1) + 1) + 1
+    const stdoutEnd = body.indexOf(stdoutEndMarker)
+    const stdoutTail =
+      stdoutEnd > stdoutStart ? body.slice(stdoutStart, stdoutEnd).replace(/\n$/, '') : ''
+
+    const stderrStart = body.indexOf('\n', stdoutEnd + stdoutEndMarker.length) + 1
+    const stderrEnd = body.indexOf(stderrEndMarker)
+    const stderrTail =
+      stderrEnd > stderrStart ? body.slice(stderrStart, stderrEnd).replace(/\n$/, '') : ''
+
+    parsedResults.push({ job, alive, exitCode, hasExitCode, stdoutTail, stderrTail })
+  }
+
+  return parsedResults
+}

--- a/src/main/compute/job-poller.ts
+++ b/src/main/compute/job-poller.ts
@@ -11,6 +11,7 @@ import {
   type ComputeConnectionLease
 } from './connection-broker'
 import { quoteRemotePath, type RemoteHandle } from './job-dispatcher'
+import { parsePollOutput } from './job-poll-output'
 import { sharedDispatchTracker, type DispatchTracker } from './dispatch-tracker'
 import { emitJobNotification } from './job-notifier'
 import { ComputeJobLifecycle } from './compute-job-lifecycle'
@@ -443,60 +444,7 @@ export class JobPoller {
     nonce: string,
     connection: ComputeConnectionLease
   ): Promise<void> {
-    // Split output into per-job sections by the nonce-prefixed JOB_START marker.
-    const escapedNonce = nonce.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    const sections = output.split(new RegExp(`^${escapedNonce}JOB_START:`, 'm'))
-    const parsedResults: Array<{
-      job: ComputeJob
-      alive: boolean
-      exitCode: number | null
-      hasExitCode: boolean
-      stdoutTail: string
-      stderrTail: string
-    }> = []
-
-    for (const section of sections) {
-      if (!section.trim()) continue
-      const firstNewline = section.indexOf('\n')
-      if (firstNewline === -1) continue
-      const jobId = section.slice(0, firstNewline).trim()
-      const body = section.slice(firstNewline + 1)
-
-      const job = jobs.find((j) => j.job_id === jobId)
-      if (!job) continue
-
-      // Extract alive line (nonce-prefixed).
-      const aliveMatch = body.match(new RegExp(`^${escapedNonce}alive:([01])`, 'm'))
-      const alive = aliveMatch?.[1] === '1'
-
-      // Extract exit code (line after the nonce-prefixed alive line).
-      const alivePrefix = `${nonce}alive:`
-      const lines = body.split('\n')
-      let exitCodeRaw = ''
-      for (let i = 0; i < lines.length; i++) {
-        if (lines[i]?.startsWith(alivePrefix)) {
-          exitCodeRaw = lines[i + 1]?.trim() ?? ''
-          break
-        }
-      }
-      const exitCode = exitCodeRaw.trim() === '' ? null : Number.parseInt(exitCodeRaw.trim(), 10)
-      const hasExitCode = exitCode !== null && Number.isFinite(exitCode)
-
-      // Extract stdout tail (between the third line after JOB_START and STDOUT_END marker).
-      const stdoutEndMarker = `${nonce}STDOUT_END:${jobId}`
-      const stderrEndMarker = `${nonce}STDERR_END:${jobId}`
-      const stdoutStart = body.indexOf('\n', body.indexOf('\n', body.indexOf('\n') + 1) + 1) + 1
-      const stdoutEnd = body.indexOf(stdoutEndMarker)
-      const stdoutTail =
-        stdoutEnd > stdoutStart ? body.slice(stdoutStart, stdoutEnd).replace(/\n$/, '') : ''
-
-      const stderrStart = body.indexOf('\n', stdoutEnd + stdoutEndMarker.length) + 1
-      const stderrEnd = body.indexOf(stderrEndMarker)
-      const stderrTail =
-        stderrEnd > stderrStart ? body.slice(stderrStart, stderrEnd).replace(/\n$/, '') : ''
-
-      parsedResults.push({ job, alive, exitCode, hasExitCode, stdoutTail, stderrTail })
-    }
+    const parsedResults = parsePollOutput(output, jobs, nonce)
 
     const safeTails = await redactConnectionOutputs(
       connection,


### PR DESCRIPTION
## Problem

Nightly, Windows Full Test, and PR Gate started failing after the Compute password-auth work ([#1375](https://github.com/aipoch/open-science/pull/1375), [#1380](https://github.com/aipoch/open-science/pull/1380)):

- `job-poller.ts` grew to 676 lines and failed the 660-line architecture gate (`compute-service.architecture.test.ts`). This broke Nightly, Windows Full Test shard 3, and any PR Gate lane that runs the Compute module suite.
- Windows Full Test shard 2 failed in `connection-broker.test.ts` because several password-mode tests still constructed the real Unix-socket askpass helper. Production already fail-closes that path on Windows with `unsupported_auth_configuration`.

## Proposed change

- Extract the nonce-prefixed poll-output parser into `job-poll-output.ts` so `job-poller.ts` stays a Job-lifecycle owner under the architecture gate (624 lines).
- Register the parser as a `compute_service` owner path.
- Keep Unix-socket askpass coverage on non-Windows hosts.
- Inject a portable answered askpass double into classification tests that do not need a real socket, so timeout and network-failure assertions run on Windows.
- Add explicit Windows fail-closed coverage for askpass construction and Credential Vault capability.

## Scope and non-goals

- No Windows password-authentication implementation. Settings already reports `unsupported_platform`; this PR only makes tests and the poller size gate match that product behavior.
- No change to SSH askpass protocol, password classification, or Job poll semantics.

## Historical compatibility

None required. Password authentication remains unavailable on Windows. Existing Hosts stay on `ssh_config` unless they were created as password Hosts on macOS/Linux. This PR does not migrate or rewrite stored Hosts.

## New state / enum values

None. Existing values continue to be used:

- `ComputePasswordCapability.reason: 'unsupported_platform'`
- `ComputeConnectionError` code `unsupported_auth_configuration`

## Data persistence

None. No Prisma/schema, migration, ciphertext, or Host-record format change.

## Acceptance criteria and validation

- Architecture gate accepts `job-poller.ts`.
- Windows runners no longer call Unix-socket askpass setup.
- Unix runners keep prompt-classification and env-isolation coverage.

Final Test Impact Set, run after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Poller size gate and owner inventory | `npm test -- src/main/compute/compute-service.architecture.test.ts` | pass |
| Password-auth architecture guards | `npm test -- src/main/compute/compute-password-auth.architecture.test.ts` | pass |
| Askpass / broker compatibility, including skipped Windows-only case on macOS | `npm test -- src/main/compute/connection-broker.test.ts` | pass (1 skipped: Windows-only askpass construction) |
| Vault Windows capability | `npm test -- src/main/compute/credential-vault.test.ts` | pass |
| Poller behavior after parser extraction | `npm test -- src/main/compute/job-poller.test.ts` | pass |
| Compute module suite | `npm run test:module -- compute_service` | 730 passed, 6 skipped |
| Manifest ownership | `npm test -- scripts/ci/validate-module-impact.test.ts` | pass |
| Node typecheck | `npm run typecheck:node` | pass |
| Lint of edited files | `npx eslint` on the changed Compute files | pass |

Consumers outside Compute were excluded because the public Broker, Host, and Job contracts are unchanged. Platform lanes: Windows-sensitive Compute tests are included in `compute_service`; live Windows Full Test remains the authority for the `it.runIf(win32)` askpass assertion. Full `npm test` was not run locally.

Uncovered risks: this checkout cannot execute the Windows-only `createAskpassEnvironment` assertion; PR Gate / Windows Full Test must confirm that path.

## Review focus

- Whether extracting `parsePollOutput` is the right seam versus raising the poller line gate.
- Whether skipping Unix-socket tests on Windows is acceptable versus implementing Windows askpass.