### PR TITLE
fix(updater): guard install by ready state

### DIFF
--- a/src/main/update/create-strategy.test.ts
+++ b/src/main/update/create-strategy.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const spawnSync = vi.hoisted(() => vi.fn())
 const quitAndInstall = vi.hoisted(() => vi.fn())
+const updaterListeners = vi.hoisted(() => new Map<string, (...args: unknown[]) => void>())
 const loggerMocks = vi.hoisted(() => {
   const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
   return { log, createLogger: vi.fn(() => log) }
@@ -27,7 +28,9 @@ vi.mock('electron', () => ({
 }))
 vi.mock('electron-updater', () => ({
   autoUpdater: {
-    on: () => {},
+    on: (event: string, listener: (...args: unknown[]) => void) => {
+      updaterListeners.set(event, listener)
+    },
     autoDownload: true,
     autoInstallOnAppQuit: true,
     quitAndInstall
@@ -42,6 +45,7 @@ describe('createUpdateStrategy', () => {
   beforeEach(() => {
     spawnSync.mockReset()
     quitAndInstall.mockReset()
+    updaterListeners.clear()
     loggerMocks.createLogger.mockClear()
     for (const log of Object.values(loggerMocks.log)) log.mockClear()
     spawnSync.mockReturnValue({
@@ -66,6 +70,9 @@ describe('createUpdateStrategy', () => {
     'injects the production update logger into the %s strategy',
     async (_, platform, opts) => {
       const strategy = createUpdateStrategy(platform, opts)
+      if (strategy instanceof ElectronUpdaterStrategy) {
+        updaterListeners.get('update-downloaded')?.()
+      }
 
       await strategy.apply()
 
@@ -80,6 +87,7 @@ describe('createUpdateStrategy', () => {
   it('constructs the in-place strategy with its install gate', async () => {
     const installGate = vi.fn(async () => ({ completed: true, reaped: true }))
     const strategy = createUpdateStrategy('win32', { installGate })
+    updaterListeners.get('update-downloaded')?.()
 
     await strategy.apply()
 

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -65,6 +65,10 @@ class FakeUpdater extends EventEmitter {
   quitAndInstall = vi.fn()
 }
 
+const markUpdateReady = (updater: FakeUpdater): void => {
+  updater.emit('update-downloaded', { version: '0.3.0' })
+}
+
 // Fake fetch returning a version.json manifest, so notes hydration never touches the network.
 const manifestFetch = (manifest: object): typeof fetch =>
   vi.fn(async () => ({ ok: true, json: async () => manifest })) as unknown as typeof fetch
@@ -379,6 +383,44 @@ describe('ElectronUpdaterStrategy', () => {
     expect(JSON.stringify(records)).not.toContain('raw provider diagnostic detail')
   })
 
+  it.each([
+    ['idle', () => {}],
+    ['checking', (updater: FakeUpdater) => updater.emit('checking-for-update')],
+    ['up-to-date', (updater: FakeUpdater) => updater.emit('update-not-available', {})],
+    ['available', (updater: FakeUpdater) => updater.emit('update-available', {})],
+    [
+      'downloading',
+      (updater: FakeUpdater) =>
+        updater.emit('download-progress', { percent: 10, transferred: 1000, total: 10000 })
+    ],
+    ['error', (updater: FakeUpdater) => updater.emit('error', new Error('download failed'))]
+  ])('ignores apply while the update state is %s', async (state, enterState) => {
+    const updater = new FakeUpdater()
+    const broadcast = vi.fn()
+    const installGate = vi.fn(async () => ({ completed: true, reaped: true }))
+    const markUpdateShutdown = vi.fn(() => vi.fn())
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast,
+      installGate,
+      markUpdateShutdown
+    })
+    enterState(updater)
+    expect(strategy.getStatus().state).toBe(state)
+    const statusBeforeApply = strategy.getStatus()
+    broadcast.mockClear()
+
+    const status = await strategy.apply()
+
+    expect(status).toBe(statusBeforeApply)
+    expect(strategy.getStatus()).toBe(statusBeforeApply)
+    expect(broadcast).not.toHaveBeenCalled()
+    expect(installGate).not.toHaveBeenCalled()
+    expect(markUpdateShutdown).not.toHaveBeenCalled()
+    expect(updater.quitAndInstall).not.toHaveBeenCalled()
+  })
+
   it('apply installs silently and relaunches (quitAndInstall(true, true))', async () => {
     const updater = new FakeUpdater()
     const log = createLogSpy()
@@ -388,6 +430,7 @@ describe('ElectronUpdaterStrategy', () => {
       broadcast: vi.fn(),
       log
     })
+    markUpdateReady(updater)
     await strategy.apply()
     expect(updater.quitAndInstall).toHaveBeenCalledTimes(1)
     expect(updater.quitAndInstall).toHaveBeenCalledWith(true, true)
@@ -413,6 +456,7 @@ describe('ElectronUpdaterStrategy', () => {
       currentVersion: '0.2.0',
       broadcast: vi.fn()
     })
+    markUpdateReady(updater)
 
     const status = await strategy.apply()
     expect(updater.quitAndInstall).toHaveBeenCalledTimes(1)
@@ -430,6 +474,7 @@ describe('ElectronUpdaterStrategy', () => {
       broadcast: vi.fn(),
       installGate: gate
     })
+    markUpdateReady(updater)
 
     await strategy.apply()
 
@@ -446,6 +491,7 @@ describe('ElectronUpdaterStrategy', () => {
       broadcast: vi.fn(),
       installGate: createDelegatedSafeInstallGate(() => true, backendTeardownGate)
     })
+    markUpdateReady(updater)
 
     const status = await strategy.apply()
 
@@ -473,6 +519,7 @@ describe('ElectronUpdaterStrategy', () => {
       broadcast,
       installGate: gate
     })
+    markUpdateReady(updater)
 
     const applying = strategy.apply()
     expect(strategy.getStatus().state).toBe('applying')
@@ -507,6 +554,7 @@ describe('ElectronUpdaterStrategy', () => {
       installGate: gate,
       log
     })
+    markUpdateReady(updater)
 
     const status = await strategy.apply()
 
@@ -536,6 +584,7 @@ describe('ElectronUpdaterStrategy', () => {
       installGate: () => Promise.reject(new Error('private teardown diagnostic detail')),
       log
     })
+    markUpdateReady(updater)
 
     const status = await strategy.apply()
 
@@ -567,6 +616,7 @@ describe('ElectronUpdaterStrategy', () => {
           finishGate = () => resolve({ completed: true, reaped: true })
         })
     })
+    markUpdateReady(updater)
 
     const applying = strategy.apply()
     updater.emit('error', new Error('stale download failure'))
@@ -587,6 +637,7 @@ describe('ElectronUpdaterStrategy', () => {
       broadcast: vi.fn(),
       log
     })
+    markUpdateReady(updater)
 
     await strategy.apply()
     expect(currentApplicationShutdownTrigger()).toBe('update')
@@ -617,6 +668,7 @@ describe('ElectronUpdaterStrategy', () => {
       currentVersion: '0.2.0',
       broadcast: vi.fn()
     })
+    markUpdateReady(updater)
 
     const status = await strategy.apply()
 
@@ -634,6 +686,7 @@ describe('ElectronUpdaterStrategy', () => {
       installGate: vi.fn(async () => Promise.reject(new Error('teardown failed')))
     })
     await strategy.check()
+    markUpdateReady(updater)
 
     const status = await strategy.apply()
 
@@ -652,6 +705,7 @@ describe('ElectronUpdaterStrategy', () => {
       broadcast: vi.fn(),
       installGate: gate
     })
+    markUpdateReady(updater)
 
     const status = await strategy.apply()
 

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -446,10 +446,11 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   // isSilent=true bypasses the assisted NSIS wizard and isForceRunAfter=true relaunches into the new
   // version. Other updaters ignore isSilent.
   async apply(): Promise<UpdateStatus> {
-    // Claim the update synchronously so repeat clicks or concurrent renderers cannot start a second
-    // teardown/install. The broadcast also gives the renderer immediate feedback during the shutdown
-    // gate, which can take up to 15 seconds on Windows.
-    if (this.applying) return this.status
+    // Ignore stale/out-of-order renderer calls until electron-updater reports a completed download,
+    // then claim the update synchronously so repeat clicks or concurrent renderers cannot start a
+    // second teardown/install. The broadcast also gives the renderer immediate feedback during the
+    // shutdown gate, which can take up to 15 seconds on Windows.
+    if (this.status.state !== 'ready' || this.applying) return this.status
     this.applying = true
     this.installerStarted = false
     this.setStatus({ ...this.status, state: 'applying' })


### PR DESCRIPTION
## Problem

The in-place updater exposed update:apply through IPC but apply() only rejected an already-running apply. A stale, out-of-order, or direct renderer call from idle, checking, up-to-date, available, downloading, or error could therefore enter applying, stop Agent and Notebook backends, set the update shutdown trigger, and invoke quitAndInstall without a ready download.

## Proposed change

Require ElectronUpdaterStrategy to be in ready before it synchronously claims applying. Calls from every other state return the existing status without broadcasts, backend teardown, shutdown-trigger changes, or installer handoff.

Regression coverage exercises all six non-ready states and updates existing apply tests to enter ready through the updater download-complete event.

## Scope and non-goals

- No new UpdateState enum value or data field.
- No IPC, architecture, data-model, or user-interaction change.
- No persistence or migration change.
- No historical-data compatibility work is required.
- The manifest-based installer strategy is unchanged.

## Acceptance criteria and validation

All listed checks ran after the last material behavior/test edit.

- Non-ready apply calls preserve status and trigger no install side effects -> npm test -- src/main/update -> 8 files, 93 tests passed.
- Main-process TypeScript remains valid -> npm run typecheck:node -> passed.
- Source and tests satisfy repository lint rules -> npm run lint -> passed.

Per maintainer direction, the complete npm test suite was not run locally. PR CI is authoritative for complete portable and platform coverage. No additional persistence, migration, or UI risk is known.

## Review focus

Please verify that the ready-state check remains before every apply side effect and that returning the current status is the appropriate no-op contract for stale IPC calls.