### PR TITLE
fix(remote-access): fence shutdown from in-flight operations

### DIFF
--- a/src/main/remote-access/service.test.ts
+++ b/src/main/remote-access/service.test.ts
@@ -429,6 +429,103 @@ describe('RemoteAccessService', () => {
     expect(service.snapshot(true).error).toMatch(/web service stopped/i)
   })
 
+  it('does not republish running state when shutdown interrupts provider setup', async () => {
+    const repository = await createRepository()
+    const deps = createReadyDeps()
+    let releaseProvider: (() => void) | undefined
+    const providerGate = new Promise<void>((resolve) => {
+      releaseProvider = resolve
+    })
+    deps.enableRemoteIt.mockImplementation(async () => {
+      await providerGate
+      return {
+        installation: readyInstallation('app-service'),
+        appServiceId: 'app-service',
+        browserServiceId: 'browser-service'
+      }
+    })
+    const published: ReturnType<RemoteAccessService['snapshot']>[] = []
+    const serviceHolder: { current?: RemoteAccessService } = {}
+    const service = await RemoteAccessService.create({
+      repository,
+      ...deps,
+      broadcast: vi.fn(() => published.push(serviceHolder.current!.snapshot(true)))
+    })
+    serviceHolder.current = service
+    service.attachWebController(webController())
+
+    const starting = service.setMode('remoteit')
+    await vi.waitFor(() => expect(deps.enableRemoteIt).toHaveBeenCalledOnce())
+    let shutdownSettled = false
+    const shutdown = service.shutdown().then(() => {
+      shutdownSettled = true
+    })
+    const postShutdownPublication = published.length
+
+    await Promise.resolve()
+    expect(shutdownSettled).toBe(false)
+    releaseProvider?.()
+    await shutdown
+
+    await expect(starting).resolves.toMatchObject({
+      mode: 'off',
+      enabled: false,
+      lifecycle: 'disabled'
+    })
+    expect(service.snapshot(true)).toMatchObject({
+      mode: 'off',
+      enabled: false,
+      lifecycle: 'disabled'
+    })
+    expect(published.slice(postShutdownPublication)).not.toContainEqual(
+      expect.objectContaining({ enabled: true, lifecycle: 'running' })
+    )
+  })
+
+  it('does not restart remote access when shutdown interrupts detection', async () => {
+    const repository = await createRepository()
+    const deps = createReadyDeps()
+    const published: ReturnType<RemoteAccessService['snapshot']>[] = []
+    const serviceHolder: { current?: RemoteAccessService } = {}
+    const service = await RemoteAccessService.create({
+      repository,
+      ...deps,
+      broadcast: vi.fn(() => published.push(serviceHolder.current!.snapshot(true)))
+    })
+    serviceHolder.current = service
+    service.attachWebController(webController())
+    await service.setMode('remoteit')
+    let releaseDetection: (() => void) | undefined
+    const detectionGate = new Promise<void>((resolve) => {
+      releaseDetection = resolve
+    })
+    deps.detectRemoteIt.mockImplementationOnce(async () => {
+      await detectionGate
+      return readyInstallation('app-service')
+    })
+
+    const detecting = service.detect()
+    await vi.waitFor(() => expect(deps.detectRemoteIt).toHaveBeenCalledTimes(2))
+    const shutdown = service.shutdown()
+    const postShutdownPublication = published.length
+    releaseDetection?.()
+    await shutdown
+
+    await expect(detecting).resolves.toMatchObject({
+      mode: 'off',
+      enabled: false,
+      lifecycle: 'disabled'
+    })
+    expect(service.snapshot(true)).toMatchObject({
+      mode: 'off',
+      enabled: false,
+      lifecycle: 'disabled'
+    })
+    expect(published.slice(postShutdownPublication)).not.toContainEqual(
+      expect.objectContaining({ enabled: true, lifecycle: 'running' })
+    )
+  })
+
   it('fails closed and keeps the setup error attached to the selected mode', async () => {
     const repository = await createRepository()
     const service = await RemoteAccessService.create({

--- a/src/main/remote-access/service.ts
+++ b/src/main/remote-access/service.ts
@@ -81,6 +81,8 @@ export class RemoteAccessService {
   private webController: WebServiceController | undefined
   private detachWebController: (() => void) | undefined
   private mutationQueue: Promise<void> = Promise.resolve()
+  private shutdownStarted = false
+  private shutdownPromise: Promise<void> | undefined
   private readonly log = createLogger('remote-access')
 
   private constructor(
@@ -130,6 +132,7 @@ export class RemoteAccessService {
     this.webController = controller
     this.detachWebController = controller.onStopped(() => {
       this.webStopGeneration += 1
+      if (this.shutdownStarted) return
       const shouldReportFailure = this.runtimeEnabled && this.activeMode !== 'off'
       this.invalidateExternalAccess(false)
       if (!shouldReportFailure) return
@@ -165,11 +168,18 @@ export class RemoteAccessService {
     })
   }
 
-  async detect(): Promise<RemoteAccessSnapshot> {
+  detect(): Promise<RemoteAccessSnapshot> {
+    return this.serialize(() => this.detectSerialized())
+  }
+
+  private async detectSerialized(): Promise<RemoteAccessSnapshot> {
+    if (this.shutdownStarted) return this.snapshot(true)
     try {
       await this.refreshInstallation()
+      if (this.shutdownStarted) return this.snapshot(true)
       if (this.activeMode !== 'off') this.assertProviderReady()
     } catch (error) {
+      if (this.shutdownStarted) return this.snapshot(true)
       this.invalidateExternalAccess()
       this.lifecycle = 'error'
       this.error = error instanceof Error ? error.message : String(error)
@@ -193,7 +203,7 @@ export class RemoteAccessService {
       routeNeedsRepair ||
       browserRouteNeedsRefresh
     ) {
-      return this.setMode(this.activeMode, {
+      return this.setModeSerialized(this.activeMode, {
         forceReconcile: routeNeedsRepair || browserRouteNeedsRefresh
       })
     }
@@ -211,89 +221,108 @@ export class RemoteAccessService {
       forceReconcile?: boolean
     } = {}
   ): Promise<RemoteAccessSnapshot> {
-    return this.serialize(async () => {
-      if (
-        mode === this.activeMode &&
-        this.lifecycle === 'running' &&
-        options.forceReconcile !== true
-      ) {
-        return this.snapshot(true)
-      }
-      if (mode === 'off') return this.stopActiveRoute(options.persistPreference !== false)
-      if (!this.webController) throw new Error('Remote access is not initialized yet.')
-      const webStopGeneration = this.webStopGeneration
+    return this.serialize(() => this.setModeSerialized(mode, options))
+  }
 
-      this.lifecycle = 'starting'
-      this.invalidateExternalAccess(this.runtimeEnabled)
-      this.error = undefined
+  private async setModeSerialized(
+    mode: RemoteAccessMode,
+    options: {
+      persistPreference?: boolean
+      forceReconcile?: boolean
+    }
+  ): Promise<RemoteAccessSnapshot> {
+    if (this.shutdownStarted) return this.snapshot(true)
+    if (
+      mode === this.activeMode &&
+      this.lifecycle === 'running' &&
+      options.forceReconcile !== true
+    ) {
+      return this.snapshot(true)
+    }
+    if (mode === 'off') return this.stopActiveRoute(options.persistPreference !== false)
+    if (!this.webController) throw new Error('Remote access is not initialized yet.')
+    const webStopGeneration = this.webStopGeneration
+
+    this.lifecycle = 'starting'
+    this.invalidateExternalAccess(this.runtimeEnabled)
+    this.error = undefined
+    this.notifyChanged()
+
+    try {
+      await this.refreshInstallation()
+      if (this.shutdownStarted) return this.snapshot(true)
+      this.assertProviderReady()
+
+      const web = await this.webController.ensureStarted(DEFAULT_WEB_PORT, { attached: true })
+      if (this.shutdownStarted) return this.snapshot(true)
+      const binaryPath = this.remoteIt.binaryPath
+      if (!binaryPath) throw new Error('The remote access app is unavailable.')
+
+      const enabled = await this.deps.enableRemoteIt(binaryPath, web.port, {
+        active: mode === 'remoteit' ? 'app' : 'browser',
+        appServiceId: this.remoteItAppServiceId,
+        browserServiceId: this.remoteItBrowserServiceId,
+        onServiceIdsDiscovered: async (services) => {
+          await this.rememberRemoteItServiceIds(services)
+        }
+      })
+      if (this.shutdownStarted) return this.snapshot(true)
+      this.remoteIt = enabled.installation
+      await this.rememberRemoteItServiceIds(enabled)
+      if (this.shutdownStarted) return this.snapshot(true)
+      // App is always private. App mode also closes Browser's Persistent Public URL so a link
+      // issued by an earlier Browser session cannot keep reaching the loopback service.
+      await this.deps.disableRemoteItLink(binaryPath, enabled.appServiceId)
+      if (this.shutdownStarted) return this.snapshot(true)
+
+      if (mode === 'remoteit-public') {
+        const connectLinkUrl = normalizeRemoteItPublicUrl(
+          await this.deps.ensureRemoteItLink(binaryPath, enabled.browserServiceId)
+        )
+        if (this.shutdownStarted) return this.snapshot(true)
+        if (this.pairing.preferences.remoteItPublicUrl !== connectLinkUrl) {
+          await this.pairing.setRemoteItPublicUrl(connectLinkUrl)
+          if (this.shutdownStarted) return this.snapshot(true)
+        }
+        this.accessUrl = connectLinkUrl
+        this.remoteHost = new URL(connectLinkUrl).hostname.toLowerCase()
+      } else {
+        await this.deps.disableRemoteItLink(binaryPath, enabled.browserServiceId)
+        if (this.shutdownStarted) return this.snapshot(true)
+      }
+
+      if (options.persistPreference !== false) await this.pairing.setModePreference(mode)
+      if (this.shutdownStarted) return this.snapshot(true)
+      if (webStopGeneration !== this.webStopGeneration || !this.webController.isRunning()) {
+        throw new Error('The local web service stopped. Detect again to restore remote access.')
+      }
+      this.activeMode = mode
+      this.runtimeEnabled = true
+      this.lifecycle = 'running'
+      this.log.info('Remote access enabled', {
+        mode,
+        accessUrl: this.accessUrl,
+        remoteItAppServiceId: enabled.appServiceId,
+        remoteItBrowserServiceId: enabled.browserServiceId,
+        port: web.port
+      })
       this.notifyChanged()
-
-      try {
-        await this.refreshInstallation()
-        this.assertProviderReady()
-
-        const web = await this.webController.ensureStarted(DEFAULT_WEB_PORT, { attached: true })
-        const binaryPath = this.remoteIt.binaryPath
-        if (!binaryPath) throw new Error('The remote access app is unavailable.')
-
-        const enabled = await this.deps.enableRemoteIt(binaryPath, web.port, {
-          active: mode === 'remoteit' ? 'app' : 'browser',
-          appServiceId: this.remoteItAppServiceId,
-          browserServiceId: this.remoteItBrowserServiceId,
-          onServiceIdsDiscovered: async (services) => {
-            await this.rememberRemoteItServiceIds(services)
-          }
-        })
-        this.remoteIt = enabled.installation
-        await this.rememberRemoteItServiceIds(enabled)
-        // App is always private. App mode also closes Browser's Persistent Public URL so a link
-        // issued by an earlier Browser session cannot keep reaching the loopback service.
-        await this.deps.disableRemoteItLink(binaryPath, enabled.appServiceId)
-
-        if (mode === 'remoteit-public') {
-          const connectLinkUrl = normalizeRemoteItPublicUrl(
-            await this.deps.ensureRemoteItLink(binaryPath, enabled.browserServiceId)
-          )
-          if (this.pairing.preferences.remoteItPublicUrl !== connectLinkUrl) {
-            await this.pairing.setRemoteItPublicUrl(connectLinkUrl)
-          }
-          this.accessUrl = connectLinkUrl
-          this.remoteHost = new URL(connectLinkUrl).hostname.toLowerCase()
-        } else {
-          await this.deps.disableRemoteItLink(binaryPath, enabled.browserServiceId)
-        }
-
-        if (options.persistPreference !== false) await this.pairing.setModePreference(mode)
-        if (webStopGeneration !== this.webStopGeneration || !this.webController.isRunning()) {
-          throw new Error('The local web service stopped. Detect again to restore remote access.')
-        }
-        this.activeMode = mode
-        this.runtimeEnabled = true
-        this.lifecycle = 'running'
-        this.log.info('Remote access enabled', {
-          mode,
-          accessUrl: this.accessUrl,
-          remoteItAppServiceId: enabled.appServiceId,
-          remoteItBrowserServiceId: enabled.browserServiceId,
-          port: web.port
-        })
-        this.notifyChanged()
-        return this.snapshot(true)
-      } catch (error) {
-        this.runtimeEnabled = false
-        this.activeMode = mode
-        this.remoteHost = undefined
-        this.accessUrl = undefined
-        if (options.persistPreference !== false) {
-          await this.pairing.setModePreference('off').catch(() => undefined)
-        }
-        this.lifecycle = 'error'
-        this.error = error instanceof Error ? error.message : String(error)
-        this.log.error(`Remote access ${mode} enable failed`, error)
-        this.notifyChanged()
-        return this.snapshot(true)
+      return this.snapshot(true)
+    } catch (error) {
+      if (this.shutdownStarted) return this.snapshot(true)
+      this.runtimeEnabled = false
+      this.activeMode = mode
+      this.remoteHost = undefined
+      this.accessUrl = undefined
+      if (options.persistPreference !== false) {
+        await this.pairing.setModePreference('off').catch(() => undefined)
       }
-    })
+      this.lifecycle = 'error'
+      this.error = error instanceof Error ? error.message : String(error)
+      this.log.error(`Remote access ${mode} enable failed`, error)
+      this.notifyChanged()
+      return this.snapshot(true)
+    }
   }
 
   disable(): Promise<RemoteAccessSnapshot> {
@@ -327,8 +356,19 @@ export class RemoteAccessService {
   }
 
   shutdown(): Promise<void> {
+    if (this.shutdownPromise) return this.shutdownPromise
+    this.shutdownStarted = true
+    this.detachWebController?.()
+    this.detachWebController = undefined
     this.invalidateExternalAccess()
-    return Promise.resolve()
+    this.activeMode = 'off'
+    this.lifecycle = 'disabled'
+    this.error = undefined
+    this.notifyChanged()
+    this.shutdownPromise = this.serialize(async () => {
+      this.webController = undefined
+    })
+    return this.shutdownPromise
   }
 
   private notifyChanged(): void {


### PR DESCRIPTION
## Problem

`RemoteAccessService.detect()`, `setMode()`, and `shutdown()` did not share one terminal lifecycle. `setMode()` was serialized, but `detect()` performed asynchronous provider work outside that queue and `shutdown()` returned immediately after clearing runtime access. An in-flight operation could therefore resume after shutdown and publish `running` again; the deterministic regression captured an internally inconsistent `mode: remoteit`, `lifecycle: running`, `enabled: false` snapshot as well.

## Proposed change

- Serialize detection with mode mutations through the existing Remote Access mutation queue.
- Make shutdown an irreversible in-memory terminal state and reuse one shutdown promise for idempotence.
- Publish `off` / `disabled` synchronously when shutdown begins, detach the Web stop listener, and wait for queued work to drain.
- Fence every asynchronous setup boundary so deferred provider work cannot commit runtime fields or republish `running` after shutdown.
- Add deterministic regression coverage for in-flight provider setup and detection.

## Scope and non-goals

- No public API, IPC, renderer, or interaction changes.
- No new shared lifecycle or mode enum values.
- No database, repository schema, or persisted-field changes; no historical migration is required.
- Provider service IDs already persisted before the terminal fence remain saved. Mode or public-URL writes that have not reached their commit point when shutdown starts are not newly committed.
- This does not attempt to cancel an already-running provider process; shutdown fences its result and waits for the owned operation to settle.

## Acceptance criteria and validation

The checks below ran after the final material edit:

- In-flight provider setup cannot republish running after shutdown -> `npm test -- src/main/remote-access/service.test.ts` -> passed (18/18).
- In-flight detection cannot restart Remote Access after shutdown -> `npm test -- src/main/remote-access/service.test.ts` -> passed (18/18).
- Main-process TypeScript contracts remain valid -> `npm run typecheck:node` -> passed.
- Changed source and tests satisfy repository lint rules -> `npm run lint` -> passed.

Remote Access does not currently have a declared Module ID in `scripts/ci/module-impact.json`, so an exact owner test was used instead of claiming `test:module` coverage. No shared Interface changed, so renderer/preload consumer tests and UI/platform lanes were excluded locally. PR Gate remains authoritative for the exact-head portable and platform plan. A complete local `npm test` was intentionally not run.

## Review focus

- The shutdown flag is set synchronously before queue drain begins.
- `detect()` calls the non-queuing internal mode transition while it already owns the mutation queue, avoiding nested-queue deadlock.
- Every asynchronous setup continuation checks the terminal fence before mutating runtime state.
- Existing preference and provider-service persistence semantics outside interrupted shutdown remain unchanged.