### PR TITLE
fix(remote-access): fail closed on unreadable configuration

### DIFF
--- a/src/main/remote-access/pairing.ts
+++ b/src/main/remote-access/pairing.ts
@@ -13,6 +13,7 @@ import type {
 } from '../web-service/http-server'
 import { REMOTE_PAIR_STATUS_PATH, renderPairingPage } from './pairing-page'
 import {
+  defaultRemoteAccessState,
   RemoteAccessRepository,
   type StoredRemoteAccess,
   type StoredTrustedBrowser
@@ -169,6 +170,10 @@ export class RemoteSessionPairingManager {
 
   static async create(options: PairingManagerOptions): Promise<RemoteSessionPairingManager> {
     return new RemoteSessionPairingManager(options, await options.repository.load())
+  }
+
+  static createUnavailable(options: PairingManagerOptions): RemoteSessionPairingManager {
+    return new RemoteSessionPairingManager(options, defaultRemoteAccessState())
   }
 
   get preferences(): Pick<

--- a/src/main/remote-access/repository.test.ts
+++ b/src/main/remote-access/repository.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -63,6 +63,36 @@ describe('RemoteAccessRepository', () => {
         trustedBrowsers: []
       })
     ).toEqual({ version: 4, mode: 'off', trustedBrowsers: [] })
+  })
+
+  it.each([1, 2, 3, 4])('accepts supported configuration version %i', (version) => {
+    expect(parseStored({ version, mode: 'off', trustedBrowsers: [] })).toEqual({
+      version: 4,
+      mode: 'off',
+      trustedBrowsers: []
+    })
+  })
+
+  it.each([
+    ['malformed JSON', '{'],
+    [
+      'a future schema version',
+      JSON.stringify({ version: 5, mode: 'remoteit-public', trustedBrowsers: [] })
+    ]
+  ])('rejects %s instead of treating it as first-run state', async (_case, contents) => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-remote-repository-invalid-'))
+    roots.push(root)
+    await writeFile(join(root, 'remote-access.json'), contents)
+
+    await expect(new RemoteAccessRepository(root).load()).rejects.toThrow()
+  })
+
+  it('rejects filesystem read errors instead of treating them as first-run state', async () => {
+    const configRoot = await mkdtemp(join(tmpdir(), 'open-science-remote-repository-read-error-'))
+    roots.push(configRoot)
+    await mkdir(join(configRoot, 'remote-access.json'))
+
+    await expect(new RemoteAccessRepository(configRoot).load()).rejects.toThrow()
   })
 
   it('migrates the legacy shared service identifier to App access', () => {

--- a/src/main/remote-access/repository.ts
+++ b/src/main/remote-access/repository.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path'
 import type { RemoteAccessMode } from '../../shared/remote-access'
 
 const REMOTE_ACCESS_FILE = 'remote-access.json'
+const REMOTE_ACCESS_VERSION = 4 as const
 
 export type StoredTrustedBrowser = {
   id: string
@@ -15,7 +16,7 @@ export type StoredTrustedBrowser = {
 }
 
 export type StoredRemoteAccess = {
-  version: 4
+  version: typeof REMOTE_ACCESS_VERSION
   mode: RemoteAccessMode
   remoteItAppServiceId?: string
   remoteItBrowserServiceId?: string
@@ -24,7 +25,7 @@ export type StoredRemoteAccess = {
 }
 
 const defaults = (): StoredRemoteAccess => ({
-  version: 4,
+  version: REMOTE_ACCESS_VERSION,
   mode: 'off',
   trustedBrowsers: []
 })
@@ -46,15 +47,25 @@ const parseBrowser = (value: unknown): StoredTrustedBrowser | undefined => {
 }
 
 const parseStored = (value: unknown): StoredRemoteAccess => {
-  if (!value || typeof value !== 'object') return defaults()
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid remote access configuration.')
+  }
   const input = value as Record<string, unknown>
+  if (typeof input.version !== 'number' || !Number.isInteger(input.version) || input.version < 1) {
+    throw new Error('Invalid remote access configuration version.')
+  }
+  if (input.version > REMOTE_ACCESS_VERSION) {
+    throw new Error(
+      `Remote access configuration version ${input.version} was created by a newer version of Open Science.`
+    )
+  }
   const mode: RemoteAccessMode =
     input.mode === 'remoteit' || input.mode === 'remoteit-public' || input.mode === 'off'
       ? input.mode
       : 'off'
   const legacyServiceId = optionalString(input.remoteItServiceId)
   return {
-    version: 4,
+    version: REMOTE_ACCESS_VERSION,
     mode,
     // Before v4 both App and Browser access shared one service. Preserve that service as the
     // private App entry; Browser access creates its own managed service on first use.
@@ -82,11 +93,14 @@ export class RemoteAccessRepository {
   }
 
   async load(): Promise<StoredRemoteAccess> {
+    let contents: string
     try {
-      return parseStored(JSON.parse(await readFile(this.path, 'utf8')))
-    } catch {
-      return defaults()
+      contents = await readFile(this.path, 'utf8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return defaults()
+      throw error
     }
+    return parseStored(JSON.parse(contents))
   }
 
   save(value: StoredRemoteAccess): Promise<void> {

--- a/src/main/remote-access/service.test.ts
+++ b/src/main/remote-access/service.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -107,6 +107,48 @@ const createReadyDeps = (): {
 }
 
 describe('RemoteAccessService', () => {
+  it('keeps the app available and blocks mutations when persisted configuration cannot load', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-remote-service-invalid-config-'))
+    roots.push(root)
+    const path = join(root, 'remote-access.json')
+    await writeFile(path, '{')
+    const repository = new RemoteAccessRepository(root)
+    const save = vi.spyOn(repository, 'save')
+    const deps = createReadyDeps()
+
+    const service = await RemoteAccessService.create({
+      repository,
+      ...deps,
+      broadcast: vi.fn()
+    })
+
+    expect(service.snapshot(true, true)).toMatchObject({
+      canManage: false,
+      canManagePairing: false,
+      mode: 'off',
+      enabled: false,
+      lifecycle: 'error',
+      error: expect.stringContaining('Remote access configuration could not be loaded')
+    })
+    await expect(service.detect()).resolves.toMatchObject({ lifecycle: 'error' })
+    await expect(service.setMode('remoteit')).rejects.toThrow(
+      'Remote access configuration could not be loaded'
+    )
+    await expect(service.approve({ requestId: 'request-1', decision: 'always' })).rejects.toThrow(
+      'Remote access configuration could not be loaded'
+    )
+    expect(() => service.reject('request-1')).toThrow(
+      'Remote access configuration could not be loaded'
+    )
+    await expect(service.revoke('browser-1')).rejects.toThrow(
+      'Remote access configuration could not be loaded'
+    )
+    expect(deps.detectRemoteIt).not.toHaveBeenCalled()
+    expect(deps.enableRemoteIt).not.toHaveBeenCalled()
+    expect(save).not.toHaveBeenCalled()
+    await expect(readFile(path, 'utf8')).resolves.toBe('{')
+  })
+
   it('creates a private App service and explicitly disables its Persistent Public URL', async () => {
     const repository = await createRepository()
     const deps = createReadyDeps()

--- a/src/main/remote-access/service.ts
+++ b/src/main/remote-access/service.ts
@@ -62,6 +62,13 @@ const normalizeRemoteItPublicUrl = (value: string): string => {
   return `${parsed.origin}/`
 }
 
+const configurationLoadError = (error: unknown): Error => {
+  const detail = error instanceof Error ? error.message : String(error)
+  return new Error(
+    `Remote access configuration could not be loaded. Fix or remove remote-access.json, then restart Open Science. ${detail}`
+  )
+}
+
 export class RemoteAccessService {
   private lifecycle: RemoteAccessSnapshot['lifecycle'] = 'disabled'
   private remoteIt: RemoteItInstallation = {
@@ -96,30 +103,52 @@ export class RemoteAccessService {
         | 'disableRemoteItLink'
         | 'broadcast'
       >
-    >
+    >,
+    private readonly configurationError?: Error
   ) {
     this.remoteItAppServiceId = pairing.preferences.remoteItAppServiceId
     this.remoteItBrowserServiceId = pairing.preferences.remoteItBrowserServiceId
+    if (configurationError) {
+      this.lifecycle = 'error'
+      this.error = configurationError.message
+    }
   }
 
   static async create(options: RemoteAccessServiceDeps = {}): Promise<RemoteAccessService> {
     const repository = options.repository ?? new RemoteAccessRepository(resolveConfigRoot())
     const context: { service?: RemoteAccessService } = {}
-    const pairing = await RemoteSessionPairingManager.create({
+    const pairingOptions = {
       repository,
       isAllowedRemoteHost: (hostname) => context.service?.isAllowedRemoteHost(hostname) === true,
       isEnabled: () => context.service?.runtimeEnabled === true,
       authorizationGeneration: () => context.service?.authorizationGeneration ?? 0,
       onChanged: () => context.service?.notifyChanged()
-    })
-    const service = new RemoteAccessService(pairing, {
-      detectRemoteIt: options.detectRemoteIt ?? detectRemoteIt,
-      enableRemoteIt: options.enableRemoteIt ?? enableRemoteItServices,
-      ensureRemoteItLink: options.ensureRemoteItLink ?? ensureRemoteItConnectLink,
-      disableRemoteItLink: options.disableRemoteItLink ?? disableRemoteItConnectLink,
-      broadcast: options.broadcast ?? broadcastToRenderers
-    })
+    }
+    let configurationError: Error | undefined
+    let loadFailure: unknown
+    let pairing: RemoteSessionPairingManager
+    try {
+      pairing = await RemoteSessionPairingManager.create(pairingOptions)
+    } catch (error) {
+      loadFailure = error
+      configurationError = configurationLoadError(error)
+      pairing = RemoteSessionPairingManager.createUnavailable(pairingOptions)
+    }
+    const service = new RemoteAccessService(
+      pairing,
+      {
+        detectRemoteIt: options.detectRemoteIt ?? detectRemoteIt,
+        enableRemoteIt: options.enableRemoteIt ?? enableRemoteItServices,
+        ensureRemoteItLink: options.ensureRemoteItLink ?? ensureRemoteItConnectLink,
+        disableRemoteItLink: options.disableRemoteItLink ?? disableRemoteItConnectLink,
+        broadcast: options.broadcast ?? broadcastToRenderers
+      },
+      configurationError
+    )
     context.service = service
+    if (configurationError) {
+      service.log.error('Remote access configuration load failed', loadFailure)
+    }
     return service
   }
 
@@ -143,9 +172,10 @@ export class RemoteAccessService {
   }
 
   snapshot(canManage: boolean, canManagePairing = canManage): RemoteAccessSnapshot {
+    const configurationAvailable = this.configurationError === undefined
     return {
-      canManage,
-      canManagePairing,
+      canManage: configurationAvailable && canManage,
+      canManagePairing: configurationAvailable && canManagePairing,
       mode: this.activeMode,
       enabled: this.runtimeEnabled,
       lifecycle: this.lifecycle,
@@ -161,6 +191,7 @@ export class RemoteAccessService {
   }
 
   async restore(): Promise<void> {
+    if (this.configurationError) return
     if (this.pairing.preferences.mode === 'off') return
     await this.setMode(this.pairing.preferences.mode, {
       persistPreference: false,
@@ -173,7 +204,7 @@ export class RemoteAccessService {
   }
 
   private async detectSerialized(): Promise<RemoteAccessSnapshot> {
-    if (this.shutdownStarted) return this.snapshot(true)
+    if (this.shutdownStarted || this.configurationError) return this.snapshot(true)
     try {
       await this.refreshInstallation()
       if (this.shutdownStarted) return this.snapshot(true)
@@ -232,6 +263,7 @@ export class RemoteAccessService {
     }
   ): Promise<RemoteAccessSnapshot> {
     if (this.shutdownStarted) return this.snapshot(true)
+    this.assertConfigurationAvailable()
     if (
       mode === this.activeMode &&
       this.lifecycle === 'running' &&
@@ -334,11 +366,13 @@ export class RemoteAccessService {
     canManage = true,
     canManagePairing = canManage
   ): Promise<RemoteAccessSnapshot> {
+    this.assertConfigurationAvailable()
     await this.pairing.approve(request.requestId, request.decision)
     return this.snapshot(canManage, canManagePairing)
   }
 
   reject(requestId: string, canManage = true, canManagePairing = canManage): RemoteAccessSnapshot {
+    this.assertConfigurationAvailable()
     this.pairing.reject(requestId)
     return this.snapshot(canManage, canManagePairing)
   }
@@ -348,6 +382,7 @@ export class RemoteAccessService {
     canManage = true,
     canManagePairing = canManage
   ): Promise<RemoteAccessSnapshot> {
+    this.assertConfigurationAvailable()
     const revocation = this.pairing.revoke(browserId)
     this.authorizationGeneration += 1
     this.webController?.closeExternalConnections(browserId)
@@ -373,6 +408,10 @@ export class RemoteAccessService {
 
   private notifyChanged(): void {
     this.deps.broadcast(REMOTE_ACCESS_CHANGED_CHANNEL, {})
+  }
+
+  private assertConfigurationAvailable(): void {
+    if (this.configurationError) throw this.configurationError
   }
 
   private invalidateExternalAccess(closeConnections = true): void {


### PR DESCRIPTION
## Problem

remote-access.json load failures were all treated as first-run state. Malformed JSON, permission or I/O errors, and files written by a future schema version could therefore become an empty in-memory configuration and be overwritten by a later remote-access mutation.

## Proposed change

- Treat only ENOENT as first run.
- Validate the persisted schema version and accept versions 1 through 4 while rejecting future versions.
- Keep the optional remote-access service available in an existing error lifecycle when configuration loading fails.
- Disable all remote-access management and pairing mutations until the file is fixed or removed and the app restarts.
- Preserve the unreadable file byte-for-byte.

## Scope and non-goals

- No new persisted fields, database changes, JSON schema version, or enum values.
- No renderer or shared data-model changes.
- No automatic quarantine, backup, repair, or downgrade of future-version files.
- Existing v1-v4 normalization and legacy shared-service migration remain supported.

## Acceptance criteria and validation

Checks ran after the last material edit:

- strict missing/error/version load behavior -> npm test -- src/main/remote-access/repository.test.ts -> passed
- fail-closed service startup and mutation blocking -> npm test -- src/main/remote-access/service.test.ts -t "keeps the app available and blocks mutations when persisted configuration cannot load" -> passed
- repository, service, pairing, IPC, and Remote.It module behavior -> npm test -- src/main/remote-access -> 5 files / 67 tests passed
- main-process type safety -> npm run typecheck:node -> passed
- linted source and tests -> npm run lint -> passed

The module-impact manifest does not assign src/main/remote-access to a module ID, so no test:module command is available. Full portable and cross-platform selection is delegated to the PR Gate CI as requested.

## Review focus

- Only ENOENT may create default state; all other read and parse failures must preserve the file.
- A configuration failure must not block application startup or permit later persistence.
- Future schema versions must remain untouched by older application versions.
- Uncovered locally: OS-specific EACCES/EPERM injection; the implementation rethrows every non-ENOENT error, and PR CI remains authoritative for platform coverage.