### PR TITLE
fix(compute): bound SSH runner termination

### DIFF
--- a/src/main/compute/ssh-runner.test.ts
+++ b/src/main/compute/ssh-runner.test.ts
@@ -559,9 +559,15 @@ describe('SystemSshRunner', () => {
       timeoutMs: 5000,
       signal: controller.signal
     })
+    const settled = vi.fn()
+    void promise.then(settled, settled)
     controller.abort()
 
     child.emit('exit', null)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(settled).not.toHaveBeenCalled()
+
+    child.emit('close', null)
     await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
     expect(child.kill).toHaveBeenCalledWith('SIGTERM')
   })
@@ -585,6 +591,28 @@ describe('SystemSshRunner', () => {
 
     child.emit('close', null)
     await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('keeps a final boundary when an aborted child exits but its streams never close', async () => {
+    vi.useFakeTimers()
+    const child = new FakeChild()
+    execFileMock.mockReturnValueOnce(child as unknown as ReturnType<typeof execFileMock>)
+    const controller = new AbortController()
+    const settled = vi.fn()
+
+    void runner
+      .run(target(), 'leaves-streams-open', { timeoutMs: 5000, signal: controller.signal })
+      .then(settled, settled)
+
+    controller.abort()
+    child.emit('exit', null)
+    await vi.advanceTimersByTimeAsync(999)
+    expect(settled).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(settled).toHaveBeenCalledOnce()
+    expect(settled.mock.calls[0]?.[0]).toMatchObject({ name: 'AbortError' })
+    expect(child.kill.mock.calls).toEqual([['SIGTERM']])
   })
 
   it('rejects after a bounded grace period when an aborted child never closes', async () => {

--- a/src/main/compute/ssh-runner.test.ts
+++ b/src/main/compute/ssh-runner.test.ts
@@ -69,9 +69,10 @@ vi.mock('node:os', async (importOriginal) => ({
 // Controllable ChildProcess double matching execFile's surface used by
 // SystemSshRunner: stdout/stderr are EventEmitters, kill() records the signal.
 class FakeChild extends EventEmitter {
-  stdout = new EventEmitter()
-  stderr = new EventEmitter()
+  stdout = Object.assign(new EventEmitter(), { destroy: vi.fn() })
+  stderr = Object.assign(new EventEmitter(), { destroy: vi.fn() })
   kill = vi.fn(() => true)
+  unref = vi.fn(() => this)
 }
 
 // ---------------------------------------------------------------------------
@@ -523,6 +524,31 @@ describe('SystemSshRunner', () => {
     expect(child.kill).toHaveBeenCalledWith('SIGTERM')
   })
 
+  it('settles after a bounded grace period when a timed-out child never closes', async () => {
+    vi.useFakeTimers()
+    const child = new FakeChild()
+    execFileMock.mockReturnValueOnce(child as unknown as ReturnType<typeof execFileMock>)
+    const settled = vi.fn()
+
+    void runner.run(target(), 'ignores-signals', { timeoutMs: 1000 }).then(settled, settled)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(child.kill.mock.calls).toEqual([['SIGTERM']])
+    expect(settled).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(child.kill.mock.calls).toEqual([['SIGTERM'], ['SIGKILL']])
+    expect(settled).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(settled).toHaveBeenCalledOnce()
+    expect(settled).toHaveBeenCalledWith(expect.objectContaining({ timedOut: true }))
+    expect(child.stdout.destroy).toHaveBeenCalledOnce()
+    expect(child.stderr.destroy).toHaveBeenCalledOnce()
+    expect(child.unref).toHaveBeenCalledOnce()
+  })
+
   it('kills the child and preserves AbortSignal cancellation', async () => {
     vi.useFakeTimers()
     const child = new FakeChild()
@@ -535,8 +561,52 @@ describe('SystemSshRunner', () => {
     })
     controller.abort()
 
+    child.emit('exit', null)
     await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
     expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('does not reject an aborted run until the child has closed', async () => {
+    vi.useFakeTimers()
+    const child = new FakeChild()
+    execFileMock.mockReturnValueOnce(child as unknown as ReturnType<typeof execFileMock>)
+    const controller = new AbortController()
+    const settled = vi.fn()
+
+    const promise = runner.run(target(), 'long-running', {
+      timeoutMs: 5000,
+      signal: controller.signal
+    })
+    void promise.then(settled, settled)
+
+    controller.abort()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(settled).not.toHaveBeenCalled()
+
+    child.emit('close', null)
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('rejects after a bounded grace period when an aborted child never closes', async () => {
+    vi.useFakeTimers()
+    const child = new FakeChild()
+    execFileMock.mockReturnValueOnce(child as unknown as ReturnType<typeof execFileMock>)
+    const controller = new AbortController()
+    const settled = vi.fn()
+
+    void runner
+      .run(target(), 'ignores-signals', { timeoutMs: 5000, signal: controller.signal })
+      .then(settled, settled)
+
+    controller.abort()
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(child.kill.mock.calls).toEqual([['SIGTERM'], ['SIGKILL']])
+    expect(settled).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(settled).toHaveBeenCalledOnce()
+    expect(settled.mock.calls[0]?.[0]).toMatchObject({ name: 'AbortError' })
   })
 
   it('wraps the command in bash -lc when loginShell=true', async () => {

--- a/src/main/compute/ssh-runner.ts
+++ b/src/main/compute/ssh-runner.ts
@@ -9,6 +9,11 @@ import type { SshOverrides } from '../../shared/compute'
 // Maximum bytes captured per stream before we truncate. Caller can pass a smaller cap.
 const DEFAULT_MAX_OUTPUT_BYTES = 64 * 1024
 
+// Give ssh a short opportunity to shut down cleanly before forcing it to exit. A second, shorter
+// window lets Node deliver the exit/close events after SIGKILL while still bounding every run.
+const TERMINATION_GRACE_MS = 2_000
+const FORCE_KILL_EVENT_GRACE_MS = 1_000
+
 // Wraps a string in POSIX single quotes, escaping embedded single quotes via the '\'' idiom. Inside
 // single quotes the shell expands nothing, so this is the only safe way to hand an arbitrary command
 // string to an outer `bash -lc` layer. (scp-runner exports an identical helper; duplicated here to keep
@@ -279,57 +284,147 @@ export class SystemSshRunner implements SshRunner {
       const stdoutBuf = new CappedOutput(maxBytes)
       const stderrBuf = new CappedOutput(maxBytes)
       let timedOut = false
+      let aborted = false
+      let abortReason: unknown
+      let settled = false
+      let processExited = false
+      let observedExitCode: number | null = null
 
       const child = execFile(target.sshBinary, args, {
         timeout: 0,
         encoding: 'buffer',
         env: opts.env
       })
-      const timer = setTimeout(() => {
-        timedOut = true
-        child.kill('SIGTERM')
-      }, opts.timeoutMs)
-      const cleanup = (): void => {
-        clearTimeout(timer)
-        opts.signal?.removeEventListener('abort', abort)
+
+      let timeoutTimer: NodeJS.Timeout | undefined
+      let terminationTimer: NodeJS.Timeout | undefined
+      let finalBoundaryTimer: NodeJS.Timeout | undefined
+
+      const clearTimer = (timer: NodeJS.Timeout | undefined): void => {
+        if (timer !== undefined) clearTimeout(timer)
       }
 
-      const abort = (): void => {
-        cleanup()
-        child.kill('SIGTERM')
-        reject(opts.signal?.reason ?? new DOMException('The operation was aborted.', 'AbortError'))
-      }
-      opts.signal?.addEventListener('abort', abort, { once: true })
-
-      child.stdout?.on('data', (chunk: Buffer) => {
+      const onStdout = (chunk: Buffer): void => {
         stdoutBuf.push(chunk)
-      })
+      }
 
-      child.stderr?.on('data', (chunk: Buffer) => {
+      const onStderr = (chunk: Buffer): void => {
         stderrBuf.push(chunk)
-      })
+      }
 
-      child.on('close', (code) => {
-        cleanup()
+      const cleanup = (detachChild = false): void => {
+        clearTimer(timeoutTimer)
+        clearTimer(terminationTimer)
+        clearTimer(finalBoundaryTimer)
+        opts.signal?.removeEventListener('abort', onAbort)
+        child.stdout?.removeListener('data', onStdout)
+        child.stderr?.removeListener('data', onStderr)
+        child.removeListener('exit', onExit)
+        child.removeListener('close', onClose)
+        child.removeListener('error', onError)
+        if (detachChild) {
+          // A failed late signal delivery must not become an unhandled EventEmitter error after the
+          // caller has crossed the hard boundary and no longer owns this ChildProcess.
+          child.on('error', () => undefined)
+          child.stdout?.destroy()
+          child.stderr?.destroy()
+          child.unref()
+        }
+      }
+
+      const finish = (exitCode: number | null, spawnError?: Error, detachChild = false): void => {
+        if (settled) return
+        settled = true
+        cleanup(detachChild)
+        if (aborted) {
+          reject(abortReason)
+          return
+        }
         resolve({
-          exitCode: code,
-          stdout: stdoutBuf.toString(),
-          stderr: stderrBuf.toString(),
-          truncated: stdoutBuf.wasTruncated() || stderrBuf.wasTruncated(),
+          exitCode: spawnError ? null : exitCode,
+          stdout: spawnError ? '' : stdoutBuf.toString(),
+          stderr: spawnError ? spawnError.message : stderrBuf.toString(),
+          truncated: spawnError ? false : stdoutBuf.wasTruncated() || stderrBuf.wasTruncated(),
           timedOut
         })
-      })
+      }
 
-      child.on('error', (err) => {
-        cleanup()
-        resolve({
-          exitCode: null,
-          stdout: '',
-          stderr: err.message,
-          truncated: false,
-          timedOut
-        })
-      })
+      const scheduleFinalBoundary = (): void => {
+        if (finalBoundaryTimer !== undefined) return
+        finalBoundaryTimer = setTimeout(() => {
+          finalBoundaryTimer = undefined
+          finish(observedExitCode, undefined, true)
+        }, FORCE_KILL_EVENT_GRACE_MS)
+      }
+
+      const safeKill = (signal: NodeJS.Signals): void => {
+        try {
+          child.kill(signal)
+        } catch {
+          // A failed signal delivery must not defeat the final settlement boundary below.
+        }
+      }
+
+      const requestTermination = (): void => {
+        if (settled) return
+        if (processExited) {
+          finish(observedExitCode, undefined, true)
+          return
+        }
+        if (terminationTimer !== undefined || finalBoundaryTimer !== undefined) return
+        safeKill('SIGTERM')
+        terminationTimer = setTimeout(() => {
+          terminationTimer = undefined
+          safeKill('SIGKILL')
+          scheduleFinalBoundary()
+        }, TERMINATION_GRACE_MS)
+      }
+
+      const onAbort = (): void => {
+        if (settled || aborted) return
+        aborted = true
+        abortReason =
+          opts.signal?.reason ?? new DOMException('The operation was aborted.', 'AbortError')
+        clearTimer(timeoutTimer)
+        timeoutTimer = undefined
+        requestTermination()
+      }
+
+      const onExit = (code: number | null): void => {
+        processExited = true
+        observedExitCode = code
+        clearTimer(terminationTimer)
+        terminationTimer = undefined
+        if (aborted) finish(code, undefined, true)
+        else if (timedOut) scheduleFinalBoundary()
+      }
+
+      const onClose = (code: number | null): void => {
+        processExited = true
+        observedExitCode = code
+        finish(code)
+      }
+
+      const onError = (err: Error): void => {
+        // Signal delivery can itself emit an error without proving that the process exited. Preserve
+        // the hard boundary in that case; ordinary spawn/process errors retain the existing result.
+        if (timedOut || aborted) return
+        finish(null, err)
+      }
+
+      timeoutTimer = setTimeout(() => {
+        timedOut = true
+        requestTermination()
+      }, opts.timeoutMs)
+      opts.signal?.addEventListener('abort', onAbort, { once: true })
+      child.stdout?.on('data', onStdout)
+      child.stderr?.on('data', onStderr)
+      child.once('exit', onExit)
+      child.once('close', onClose)
+      child.once('error', onError)
+
+      // The signal may have changed between throwIfAborted() and listener registration.
+      if (opts.signal?.aborted) onAbort()
     })
   }
 }

--- a/src/main/compute/ssh-runner.ts
+++ b/src/main/compute/ssh-runner.ts
@@ -368,7 +368,7 @@ export class SystemSshRunner implements SshRunner {
       const requestTermination = (): void => {
         if (settled) return
         if (processExited) {
-          finish(observedExitCode, undefined, true)
+          scheduleFinalBoundary()
           return
         }
         if (terminationTimer !== undefined || finalBoundaryTimer !== undefined) return
@@ -395,8 +395,7 @@ export class SystemSshRunner implements SshRunner {
         observedExitCode = code
         clearTimer(terminationTimer)
         terminationTimer = undefined
-        if (aborted) finish(code, undefined, true)
-        else if (timedOut) scheduleFinalBoundary()
+        if (aborted || timedOut) scheduleFinalBoundary()
       }
 
       const onClose = (code: number | null): void => {


### PR DESCRIPTION
## Problem

`SystemSshRunner` timeout sent `SIGTERM` once and then depended on `close`/`error`, so a child that ignored termination or never closed its inherited streams could leave the Promise pending forever. Abort rejected immediately after `SIGTERM`, allowing broker operation accounting to drain before the SSH process had actually exited.

## Proposed change

- Route timeout and abort through one bounded termination lifecycle.
- Send `SIGTERM`, wait 2 seconds, escalate to `SIGKILL`, then allow 1 second for `exit`/`close` before the final settlement boundary.
- Record `exit` without settling until `close`, preserving trailing stdio, while retaining the final boundary when `close` never arrives.
- Guard event races and double settlement, and detach streams/handles only at the hard fallback boundary.
- Preserve the existing timeout result and `AbortError` contracts.

## Scope and non-goals

- No public interface, data field, enum, schema, persistence, architecture, or UI interaction changes.
- No historical-data compatibility work is required.
- This bounds the local SSH client lifecycle; it does not promise termination of deliberately detached remote commands.
- `SystemScpRunner` has a similar SIGTERM-only timeout pattern and is intentionally outside this SSH-runner-scoped change.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Timeout and abort lifecycle, including TERM → KILL escalation, exit-before-close, and hard-boundary behavior → `npm run test:module -- compute_service` → passed, 28 files selected, 27 passed / 1 skipped; 715 tests passed / 25 skipped.
- Main-process TypeScript contracts → `npm run typecheck:node` → passed.
- Source and test lint/formatting → `npm run lint` → passed with no warnings.
- Exact-head PR Gate → passed, including module coverage, static checks, Windows core, Windows E2E, macOS build/E2E, CodeQL, and CI Integrity.
- Independent review of final head → mergeable, no actionable findings.

The full `npm test` suite was not run locally per maintainer direction; exact-head PR Gate is authoritative for complete portable and platform coverage.

## Review focus

- TERM → KILL → final-boundary event ordering.
- Abort settlement waits for `close` after observed `exit`, except at the explicit hard fallback.
- Listener and timer cleanup under close, error, timeout, abort, and late-event races.
