### PR TITLE
fix(notebook): preserve kernel state on persistence failure

### DIFF
--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -64,6 +64,7 @@ import {
 } from './runtime-paths'
 import type { NotebookShellProcess } from './shell-process'
 import { NOTEBOOK_CODE_LIMIT_BYTES } from './content-limits'
+import type { RuntimeDiagnosticLogger } from './runtime-diagnostics'
 
 let storageRoot: string | undefined
 
@@ -125,6 +126,7 @@ const lifecycleCallbackHarness = (
     inPlaceRestart?: boolean
     repository?: NotebookRunRepository
     shutdown?: () => Promise<{ reaped: boolean }>
+    logger?: RuntimeDiagnosticLogger
   } = {}
 ): {
   service: NotebookRuntimeService
@@ -138,6 +140,7 @@ const lifecycleCallbackHarness = (
     dataRoot: root,
     projectId: 'default-project',
     repository: options.repository ?? new NotebookRunRepository(root),
+    logger: options.logger,
     callbacks: {
       onNotebookChanged: (event) => changedSessions.push(event.sessionId)
     },
@@ -3911,6 +3914,44 @@ describe('notebook runtime service', () => {
 
     const afterRespawn = await service.state({ sessionId: 'session-1', workspaceCwd: root })
     expect(afterRespawn.kernelStatus).toBe('idle')
+  })
+
+  it('keeps a recovered execution successful when clearing durable termination fails', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    const { service, lifecycles } = lifecycleCallbackHarness(root, { repository, logger })
+
+    await service.execute({ sessionId: 'session-1', workspaceCwd: root, code: '1' })
+    await lifecycles[0].onIdleShutdown('python', DEFAULT_PY_ENV)
+    const persistenceError = new Error('could not clear durable termination')
+    vi.spyOn(repository, 'clearKernelTermination').mockRejectedValueOnce(persistenceError)
+
+    const recovered = await service.execute({
+      sessionId: 'session-1',
+      workspaceCwd: root,
+      code: '2'
+    })
+
+    expect(recovered.status).toBe('completed')
+    expect((await service.state({ sessionId: 'session-1', workspaceCwd: root })).kernelStatus).toBe(
+      'idle'
+    )
+    expect(
+      (await new NotebookRunRepository(root).findExisting('default-project', 'session-1'))?.kernel
+    ).toMatchObject({
+      lastKnownStatus: 'terminated',
+      terminatedKernelInstances: [{ kind: 'python', environment: DEFAULT_PY_ENV }]
+    })
+    expect(logger.error).toHaveBeenCalledWith(
+      'notebook kernel lifecycle persistence failed',
+      expect.objectContaining({
+        error: persistenceError.message,
+        operation: 'recovered-idle',
+        kind: 'python',
+        environment: DEFAULT_PY_ENV
+      })
+    )
   })
 
   it('persists idle after recovering a terminated kernel in a recreated runtime service', async () => {

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -3645,6 +3645,45 @@ describe('notebook runtime service', () => {
     }
   )
 
+  it('orders a new execution after delayed idle-shutdown persistence', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    const { service, lifecycles } = lifecycleCallbackHarness(root, { repository })
+
+    await service.execute({ sessionId: 'session-1', workspaceCwd: root, code: '1' })
+    const persistenceGate = createDeferred<void>()
+    const markKernelTerminated = repository.markKernelTerminated.bind(repository)
+    const persistenceSpy = vi
+      .spyOn(repository, 'markKernelTerminated')
+      .mockImplementation(async (request) => {
+        await persistenceGate.promise
+        return markKernelTerminated(request)
+      })
+
+    const idleShutdown = lifecycles[0].onIdleShutdown('python', DEFAULT_PY_ENV)
+    await vi.waitFor(() => expect(persistenceSpy).toHaveBeenCalledTimes(1))
+    let nextExecutionSettled = false
+    const nextExecution = service
+      .execute({ sessionId: 'session-1', workspaceCwd: root, code: '2' })
+      .finally(() => {
+        nextExecutionSettled = true
+      })
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(nextExecutionSettled).toBe(false)
+
+    persistenceGate.resolve()
+    await idleShutdown
+    await nextExecution
+
+    expect((await service.state({ sessionId: 'session-1', workspaceCwd: root })).kernelStatus).toBe(
+      'idle'
+    )
+    expect(
+      (await new NotebookRunRepository(root).findExisting('default-project', 'session-1'))?.kernel
+    ).toMatchObject({ lastKnownStatus: 'idle' })
+  })
+
   it('ignores an idle-shutdown callback from a session replaced under the same id', async () => {
     const root = await createStorageRoot()
     const { service, lifecycles, changedSessions } = lifecycleCallbackHarness(root)

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -3613,6 +3613,38 @@ describe('notebook runtime service', () => {
     expect(changedSessions).toContain('session-1')
   })
 
+  it.each(['idle-shutdown', 'termination'] as const)(
+    'keeps live and durable kernel state unchanged when %s persistence fails',
+    async (callback) => {
+      const root = await createStorageRoot()
+      const repository = new NotebookRunRepository(root)
+      const { service, lifecycles, changedSessions } = lifecycleCallbackHarness(root, {
+        repository
+      })
+
+      await service.execute({ sessionId: 'session-1', workspaceCwd: root, code: '1' })
+      const before = await service.state({ sessionId: 'session-1', workspaceCwd: root })
+      const runJsonBefore = await readFile(before.runJsonPath, 'utf8')
+      const changedCountBefore = changedSessions.length
+      const persistenceError = new Error('kernel status persistence failed')
+      vi.spyOn(repository, 'markKernelTerminated').mockRejectedValueOnce(persistenceError)
+
+      const lifecycle = lifecycles[0]
+      const statusUpdate =
+        callback === 'idle-shutdown'
+          ? lifecycle.onIdleShutdown('python', DEFAULT_PY_ENV)
+          : lifecycle.onTerminated('python', DEFAULT_PY_ENV)
+      const failure = await statusUpdate.catch((error: unknown) => error)
+
+      expect(failure).toBe(persistenceError)
+      expect(
+        (await service.state({ sessionId: 'session-1', workspaceCwd: root })).kernelStatus
+      ).toBe('idle')
+      expect(await readFile(before.runJsonPath, 'utf8')).toBe(runJsonBefore)
+      expect(changedSessions).toHaveLength(changedCountBefore)
+    }
+  )
+
   it('ignores an idle-shutdown callback from a session replaced under the same id', async () => {
     const root = await createStorageRoot()
     const { service, lifecycles, changedSessions } = lifecycleCallbackHarness(root)

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -88,7 +88,7 @@ import {
   type NotebookSessionRuntimeBinding
 } from './session-aggregate'
 import { NotebookSessionRegistry } from './session-registry'
-import { createLogger, getLogFilePath } from '../logger'
+import { createLogger, errorLogFields, getLogFilePath } from '../logger'
 import { EnvironmentStateTracker, type EnvironmentCaptureTarget } from './environment-state-tracker'
 import { NotebookRuntimeBindingOwner } from './runtime-binding'
 import type { RuntimeDiagnosticLogger } from './runtime-diagnostics'
@@ -410,7 +410,19 @@ class NotebookRuntimeService {
       defaultExecutorOptions: resolveDefaultExecutorOptions,
       platform: options.platform,
       callbacks: options.callbacks,
-      toSessionReference: (session) => this.sessionReadModel.toSessionReference(session)
+      toSessionReference: (session) => this.sessionReadModel.toSessionReference(session),
+      onExecutorLifecycleFailure: ({ operation, lane, kind, env, error }) => {
+        const message = 'notebook kernel lifecycle persistence failed'
+        const fields = {
+          ...errorLogFields(error),
+          operation,
+          lane: notebookLaneKey(lane),
+          kind,
+          environment: env
+        }
+        if (this.runtimeLogger) this.runtimeLogger.error(message, fields)
+        else console.error(`[notebook] ${message}`, fields)
+      }
     })
     this.runtimeRepair = new NotebookRuntimeRepairOwner({
       runtimeRoot,

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -411,7 +411,7 @@ class NotebookRuntimeService {
       platform: options.platform,
       callbacks: options.callbacks,
       toSessionReference: (session) => this.sessionReadModel.toSessionReference(session),
-      onExecutorLifecycleFailure: ({ operation, lane, kind, env, error }) => {
+      onKernelStatusPersistenceFailure: ({ operation, lane, kind, env, error }) => {
         const message = 'notebook kernel lifecycle persistence failed'
         const fields = {
           ...errorLogFields(error),
@@ -492,7 +492,7 @@ class NotebookRuntimeService {
       createEnvironmentCaptureTarget: (...args) => this.environmentCaptureTarget(...args),
       setKernelStatus: (session, status, processKey) => session.setKernelStatus(processKey, status),
       persistRecoveredKernelIdle: (session, processKey) =>
-        this.sessionLifecycle.persistKernelStatus(session as RuntimeSession, 'idle', processKey),
+        this.sessionLifecycle.persistRecoveredKernelIdle(session as RuntimeSession, processKey),
       getMcpRpcConnectionResolver: () => this.mcpRpcConnectionResolver,
       notifyAvailable: (session, source) =>
         this.sessionLifecycle.notifyAvailable(session as RuntimeSession, source),

--- a/src/main/notebook/session-aggregate.ts
+++ b/src/main/notebook/session-aggregate.ts
@@ -377,6 +377,23 @@ export class NotebookSessionAggregate<
     return run
   }
 
+  // Reserves the next execution turn behind an executor lifecycle projection without making the
+  // current execution wait on its own queue tail. This matters for onTerminated callbacks fired from
+  // inside execute(): the callback may be awaited by an injected executor, while later work must not
+  // start until its durable kernel-state transition settles.
+  blockKernelExecutionUntil(processKey: string, transition: Promise<unknown>): void {
+    const current =
+      processKey === 'repl'
+        ? this.controlQueue
+        : (this.executionQueues.get(processKey) ?? Promise.resolve())
+    const barrier = Promise.all([current, transition]).then(
+      () => undefined,
+      () => undefined
+    )
+    if (processKey === 'repl') this.controlQueue = barrier
+    else this.executionQueues.set(processKey, barrier)
+  }
+
   clearProcessState(processKey: string): void {
     this.kernelStatuses.delete(processKey)
     this.terminatedKernels.delete(processKey)

--- a/src/main/notebook/session-lifecycle.ts
+++ b/src/main/notebook/session-lifecycle.ts
@@ -38,8 +38,8 @@ type NotebookSessionLifecycleCallbacks = {
   onNotebookChanged?: (event: NotebookSessionReference) => void
 }
 
-type NotebookExecutorLifecycleFailure = {
-  operation: 'idle-shutdown' | 'terminated'
+type NotebookKernelStatusPersistenceFailure = {
+  operation: 'idle-shutdown' | 'terminated' | 'recovered-idle'
   lane: NotebookLaneIdentity
   kind?: KernelProcessKind
   env?: string
@@ -61,7 +61,7 @@ type NotebookSessionLifecycleOptions = {
   platform?: NodeJS.Platform
   callbacks?: NotebookSessionLifecycleCallbacks
   toSessionReference: (session: RuntimeSession) => NotebookSessionReference
-  onExecutorLifecycleFailure?: (failure: NotebookExecutorLifecycleFailure) => void
+  onKernelStatusPersistenceFailure?: (failure: NotebookKernelStatusPersistenceFailure) => void
 }
 
 type InternalNotebookSessionRequest = NotebookSessionRequest & {
@@ -252,7 +252,7 @@ class NotebookSessionLifecycleOwner {
         platform: this.options.platform,
         onIdleShutdown: (kind, env) => {
           void lifecycle.onIdleShutdown(kind, env).catch((error: unknown) => {
-            this.options.onExecutorLifecycleFailure?.({
+            this.options.onKernelStatusPersistenceFailure?.({
               operation: 'idle-shutdown',
               lane,
               kind,
@@ -263,7 +263,7 @@ class NotebookSessionLifecycleOwner {
         },
         onTerminated: (kind, env) => {
           void lifecycle.onTerminated(kind, env).catch((error: unknown) => {
-            this.options.onExecutorLifecycleFailure?.({
+            this.options.onKernelStatusPersistenceFailure?.({
               operation: 'terminated',
               lane,
               kind,
@@ -402,6 +402,21 @@ class NotebookSessionLifecycleOwner {
       })
     }
     session.setKernelStatus(processKey, status)
+  }
+
+  async persistRecoveredKernelIdle(session: RuntimeSession, processKey: string): Promise<void> {
+    try {
+      await this.persistKernelStatus(session, 'idle', processKey)
+    } catch (error) {
+      const kernelInstance = kernelInstanceForProcessKey(processKey)
+      this.options.onKernelStatusPersistenceFailure?.({
+        operation: 'recovered-idle',
+        lane: session.lane,
+        kind: kernelInstance.kind,
+        env: 'environment' in kernelInstance ? kernelInstance.environment : undefined,
+        error
+      })
+    }
   }
 
   async clearPersistedKernelTermination(

--- a/src/main/notebook/session-lifecycle.ts
+++ b/src/main/notebook/session-lifecycle.ts
@@ -450,9 +450,12 @@ class NotebookSessionLifecycleOwner {
   ): Promise<void> {
     const session = this.options.sessions.get(lane)
     if (!session) return
-    await session.runExecutorLifecycleCallback(generation, async () => {
+    const processKey = processKeyFor(kind, env)
+    const projection = session.runExecutorLifecycleCallback(generation, async () => {
       await this.projectKernelIdleShutdown(lane, kind, env)
     })
+    session.blockKernelExecutionUntil(processKey, projection)
+    await projection
   }
 
   private async handleTerminated(
@@ -463,9 +466,12 @@ class NotebookSessionLifecycleOwner {
   ): Promise<void> {
     const session = this.options.sessions.get(lane)
     if (!session) return
-    await session.runExecutorLifecycleCallback(generation, async () => {
+    const processKey = processKeyFor(kind, env)
+    const projection = session.runExecutorLifecycleCallback(generation, async () => {
       await this.projectKernelTerminated(lane, kind, env)
     })
+    session.blockKernelExecutionUntil(processKey, projection)
+    await projection
   }
 }
 

--- a/src/main/notebook/session-lifecycle.ts
+++ b/src/main/notebook/session-lifecycle.ts
@@ -38,6 +38,14 @@ type NotebookSessionLifecycleCallbacks = {
   onNotebookChanged?: (event: NotebookSessionReference) => void
 }
 
+type NotebookExecutorLifecycleFailure = {
+  operation: 'idle-shutdown' | 'terminated'
+  lane: NotebookLaneIdentity
+  kind?: KernelProcessKind
+  env?: string
+  error: unknown
+}
+
 type NotebookSessionLifecycleOptions = {
   storageRoot: string
   defaultProjectId: string
@@ -53,6 +61,7 @@ type NotebookSessionLifecycleOptions = {
   platform?: NodeJS.Platform
   callbacks?: NotebookSessionLifecycleCallbacks
   toSessionReference: (session: RuntimeSession) => NotebookSessionReference
+  onExecutorLifecycleFailure?: (failure: NotebookExecutorLifecycleFailure) => void
 }
 
 type InternalNotebookSessionRequest = NotebookSessionRequest & {
@@ -241,8 +250,28 @@ class NotebookSessionLifecycleOwner {
       executor: new NotebookKernelExecutor({
         ...this.options.defaultExecutorOptions(),
         platform: this.options.platform,
-        onIdleShutdown: (kind, env) => void lifecycle.onIdleShutdown(kind, env),
-        onTerminated: (kind, env) => void lifecycle.onTerminated(kind, env)
+        onIdleShutdown: (kind, env) => {
+          void lifecycle.onIdleShutdown(kind, env).catch((error: unknown) => {
+            this.options.onExecutorLifecycleFailure?.({
+              operation: 'idle-shutdown',
+              lane,
+              kind,
+              env,
+              error
+            })
+          })
+        },
+        onTerminated: (kind, env) => {
+          void lifecycle.onTerminated(kind, env).catch((error: unknown) => {
+            this.options.onExecutorLifecycleFailure?.({
+              operation: 'terminated',
+              lane,
+              kind,
+              env,
+              error
+            })
+          })
+        }
       })
     }
   }
@@ -341,13 +370,11 @@ class NotebookSessionLifecycleOwner {
     status: NotebookKernelMetadata['lastKnownStatus'],
     processKey: string
   ): Promise<void> {
-    session.setKernelStatus(processKey, status)
     const kernelInstance = kernelInstanceForProcessKey(processKey)
-    try {
-      if (status === 'terminated') {
-        // A legacy coarse terminated status has unknown ownership. Keep it conservative until an
-        // explicit restart instead of replacing the ambiguity with a partial known-instance set.
-        if (session.hasUnknownDurableKernelTermination()) return
+    if (status === 'terminated') {
+      // A legacy coarse terminated status has unknown ownership. Keep it conservative until an
+      // explicit restart instead of replacing the ambiguity with a partial known-instance set.
+      if (!session.hasUnknownDurableKernelTermination()) {
         await this.options.repository.markKernelTerminated({
           projectId: session.projectId,
           sessionId: session.sessionId,
@@ -355,8 +382,9 @@ class NotebookSessionLifecycleOwner {
           kernelInstance
         })
         session.markDurableKernelTermination(processKey)
-      } else if (status === 'idle') {
-        if (!session.hasDurableKernelTermination(processKey)) return
+      }
+    } else if (status === 'idle') {
+      if (session.hasDurableKernelTermination(processKey)) {
         await this.options.repository.clearKernelTermination({
           projectId: session.projectId,
           sessionId: session.sessionId,
@@ -364,17 +392,16 @@ class NotebookSessionLifecycleOwner {
           kernelInstance
         })
         session.clearDurableKernelTermination(processKey)
-      } else {
-        await this.options.repository.updateKernelStatus({
-          projectId: session.projectId,
-          sessionId: session.sessionId,
-          lane: session.lane,
-          status
-        })
       }
-    } catch {
-      return
+    } else {
+      await this.options.repository.updateKernelStatus({
+        projectId: session.projectId,
+        sessionId: session.sessionId,
+        lane: session.lane,
+        status
+      })
     }
+    session.setKernelStatus(processKey, status)
   }
 
   async clearPersistedKernelTermination(


### PR DESCRIPTION
## Problem

Notebook executor lifecycle callbacks updated the live kernel status before persisting the matching `run.json` metadata. `NotebookSessionLifecycleOwner.persistKernelStatus()` then silently swallowed repository failures, allowing callers to publish a changed event for state that was never durable.

Moving the live update after persistence also requires ordering the next execution behind that lifecycle projection. Otherwise a slow terminated-state write can land after a newly respawned kernel has already returned to idle. Conversely, failure to clear an old durable termination after a successful respawn is retryable bookkeeping and must not turn the completed execution into a failure.

## Proposed change

- Persist kernel lifecycle metadata before committing the live status projection.
- Propagate termination/idle-shutdown repository failures to callers that await lifecycle callbacks.
- Log failures at the production executor's fire-and-forget boundary with the operation and lane context.
- Publish changed events only after lifecycle persistence succeeds.
- Reuse the existing per-kernel execution/control queues to reserve subsequent execution behind an in-flight lifecycle projection, without making the current execution wait on its own queue tail.
- Treat recovered-idle durable cleanup failures as logged, retryable bookkeeping: preserve the durable termination marker and the already-completed execution result.
- Add regression coverage for idle shutdown, unexpected termination, delayed persistence racing a new execution, and recovered-idle cleanup failure.

## Scope and non-goals

- No database or `run.json` schema changes.
- No new kernel status values or shared contract changes.
- No renderer or interaction changes on the successful path.
- No historical-data migration or compatibility adapter is required.
- When recovered-idle cleanup fails, live state truthfully remains idle while `run.json` retains the conservative terminated marker until a later execution successfully retries the cleanup.

## Acceptance criteria and validation

- Failed idle-shutdown/termination persistence leaves the public live projection and durable document unchanged and emits no changed event -> `npm test -- src/main/notebook/runtime-service.test.ts -t "keeps live and durable kernel state unchanged"` -> 2 passed.
- A new execution waits for delayed idle-shutdown persistence and then clears the durable termination after respawn -> `npm test -- src/main/notebook/runtime-service.test.ts -t "orders a new execution after delayed idle-shutdown persistence"` -> passed.
- Failed recovered-idle cleanup is logged, retains the durable marker for retry, and does not reject the completed execution -> `npm test -- src/main/notebook/runtime-service.test.ts -t "keeps a recovered execution successful when clearing durable termination fails"` -> passed.
- Notebook runtime ownership, aggregate queue behavior, and architecture remain intact -> `npm test -- src/main/notebook/runtime-service.test.ts src/main/notebook/runtime-service.architecture.test.ts src/main/notebook/session-aggregate.test.ts` -> 219 passed, 5 skipped.
- Main-process types remain valid -> `npm run typecheck:node` -> passed.
- Changed source linting -> targeted ESLint -> no issues.
- Formatting and patch hygiene -> targeted Prettier check and `git diff --check` -> passed.

The listed checks ran after the last material edit. The full portable suite was intentionally left to PR CI. Consumer tests were excluded locally because no shared interface or transport contract changed. Platform lanes were excluded because the change contains no platform-dependent I/O or path behavior. The remaining uncovered risk is a real filesystem failure during an executor-owned fire-and-forget callback; deterministic regression tests inject failures and latency at the repository boundary.

## Review focus

- Persistence-before-projection ordering in `NotebookSessionLifecycleOwner.persistKernelStatus()`.
- Error ownership between awaitable lifecycle callbacks, recovered execution bookkeeping, and the fire-and-forget executor adapter.
- Per-kernel barrier ordering between lifecycle persistence and subsequent execution, including callbacks raised by the current execution.
- Guarantee that failed termination persistence cannot publish a notebook changed event or corrupt an already-completed execution result.
