### PR TITLE
fix(updater): preserve completed downloads during checks

### DIFF
--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -227,8 +227,38 @@ describe('ElectronUpdaterStrategy', () => {
 
     const readyStatus = strategy.getStatus()
     expect(await strategy.check()).toBe(readyStatus)
-    expect(checkCalls).toBe(1)
+    expect(checkCalls).toBe(2)
     expect(strategy.getStatus().state).toBe('ready')
+  })
+
+  it('preserves in-place ready on check failure but accepts a strictly newer update', async () => {
+    const updater = new FakeUpdater()
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+    await strategy.check()
+    await strategy.download()
+    const readyStatus = strategy.getStatus()
+
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('error', new Error('offline'))
+    })
+    expect(await strategy.check()).toBe(readyStatus)
+
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('checking-for-update')
+      updater.emit('update-available', {
+        version: '0.4.0',
+        releaseNotes: 'newer notes',
+        files: [{ url: 'https://cdn/Open-Science-0.4.0.zip', size: 12000 }]
+      })
+    })
+    expect(await strategy.check()).toEqual(
+      expect.objectContaining({ state: 'available', latest: '0.4.0', totalBytes: 12000 })
+    )
   })
 
   it('does not start an in-place download while a provider check is active', async () => {

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -181,6 +181,84 @@ describe('ElectronUpdaterStrategy', () => {
     )
   })
 
+  it('preserves a completed in-place download when a check is requested during transfer', async () => {
+    const updater = new FakeUpdater()
+    let checkCalls = 0
+    let releaseLateCheck: (() => void) | undefined
+    const lateCheckGate = new Promise<void>((resolve) => {
+      releaseLateCheck = resolve
+    })
+    updater.checkForUpdates = vi.fn(async () => {
+      checkCalls += 1
+      updater.emit('checking-for-update')
+      if (checkCalls === 1) {
+        updater.emit('update-available', {
+          version: '0.3.0',
+          releaseNotes: 'notes',
+          files: [{ url: 'https://cdn/Open-Science-0.3.0.zip', size: 10000 }]
+        })
+        return
+      }
+      await lateCheckGate
+      updater.emit('update-not-available', { version: '0.2.0' })
+    })
+    let releaseDownload: (() => void) | undefined
+    const downloadGate = new Promise<void>((resolve) => {
+      releaseDownload = resolve
+    })
+    updater.runDownload = async () => {
+      await downloadGate
+      updater.emit('update-downloaded', { version: '0.3.0' })
+    }
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+
+    await strategy.check()
+    const downloading = strategy.download()
+    const checking = strategy.check()
+    releaseDownload?.()
+    await downloading
+    releaseLateCheck?.()
+    await checking
+
+    const readyStatus = strategy.getStatus()
+    expect(await strategy.check()).toBe(readyStatus)
+    expect(checkCalls).toBe(1)
+    expect(strategy.getStatus().state).toBe('ready')
+  })
+
+  it('does not start an in-place download while a provider check is active', async () => {
+    const updater = new FakeUpdater()
+    let releaseCheck: (() => void) | undefined
+    const checkGate = new Promise<void>((resolve) => {
+      releaseCheck = resolve
+    })
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('checking-for-update')
+      await checkGate
+      updater.emit('update-available', { version: '0.3.0', releaseNotes: 'notes' })
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+
+    const checking = strategy.check()
+    const checkingStatus = strategy.getStatus()
+    expect(checkingStatus.state).toBe('checking')
+    expect(await strategy.download()).toBe(checkingStatus)
+    expect(updater.downloadUpdate).not.toHaveBeenCalled()
+
+    releaseCheck?.()
+    expect((await checking).state).toBe('available')
+  })
+
   it('records a failed in-place download without the provider error message', async () => {
     const updater = new FakeUpdater()
     updater.runDownload = async () => {

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -185,6 +185,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   // latest, so an older (drained) download can't clear a newer one's lifecycle.
   private downloadGeneration = 0
   private downloadOperation?: DiagnosticOperation
+  private checkInFlight = false
   private status: UpdateStatus
   private applying = false
   private installerStarted = false
@@ -337,36 +338,50 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   }
 
   async check(): Promise<UpdateStatus> {
-    if (this.applying) return this.status
+    // Keep provider checks mutually exclusive with downloads. A late check event can otherwise replace
+    // ready with checking/available/up-to-date and make apply() reject the completed update.
+    if (
+      this.applying ||
+      this.checkInFlight ||
+      this.downloadLifecycle ||
+      this.status.state === 'ready'
+    ) {
+      return this.status
+    }
     const operation = startDiagnosticOperation(this.log, {
       operation: 'update-check',
       fields: { strategy: 'in-place' }
     })
-    operation.phase('query-provider')
+    this.checkInFlight = true
     try {
-      await this.updater.checkForUpdates()
-    } catch (error) {
-      this.setStatus({
-        state: 'error',
-        error: error instanceof Error ? error.message : 'Update check failed'
-      })
-      operation.fail(error, { result: 'error' })
+      operation.phase('query-provider')
+      try {
+        await this.updater.checkForUpdates()
+      } catch (error) {
+        this.setStatus({
+          state: 'error',
+          error: error instanceof Error ? error.message : 'Update check failed'
+        })
+        operation.fail(error, { result: 'error' })
+      }
+      // Wait for the notes fetch triggered by update-available so the returned status carries them.
+      await this.notesHydration
+      if (this.status.state === 'error') {
+        operation.fail(new Error('Updater check failed'), { result: 'error' })
+      } else {
+        operation.complete({ result: this.status.state })
+      }
+      return this.status
+    } finally {
+      this.checkInFlight = false
     }
-    // Wait for the notes fetch triggered by update-available so the returned status carries them.
-    await this.notesHydration
-    if (this.status.state === 'error') {
-      operation.fail(new Error('Updater check failed'), { result: 'error' })
-    } else {
-      operation.complete({ result: this.status.state })
-    }
-    return this.status
   }
 
   async download(): Promise<UpdateStatus> {
     // An active download is in flight; ignore repeat clicks / concurrent renderers. Starting a second
     // would overwrite downloadToken and orphan the first (cancel() could no longer stop it). This guard
     // and the token claim below are synchronous so a racing download()/cancel() sees a consistent slot.
-    if (this.applying || this.downloadToken) return this.status
+    if (this.applying || this.checkInFlight || this.downloadToken) return this.status
 
     const operation = startDiagnosticOperation(this.log, {
       operation: 'update-download',

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -3,7 +3,7 @@ import { spawnSync } from 'node:child_process'
 import { autoUpdater, CancellationToken } from 'electron-updater'
 
 import { APP } from '../../shared/app-config'
-import type { UpdateStatus } from '../../shared/update'
+import { isNewer, type UpdateStatus } from '../../shared/update'
 import { startDiagnosticOperation, type DiagnosticOperation } from '../diagnostics/operation'
 import type { Logger } from '../logger'
 import { fetchManifest } from './manifest'
@@ -186,6 +186,8 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   private downloadGeneration = 0
   private downloadOperation?: DiagnosticOperation
   private checkInFlight = false
+  private readyCheckStatus?: UpdateStatus
+  private readyCheckError?: unknown
   private status: UpdateStatus
   private applying = false
   private installerStarted = false
@@ -232,9 +234,20 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   }
 
   private subscribe(): void {
-    this.updater.on('checking-for-update', () => this.setStatus({ state: 'checking' }))
+    this.updater.on('checking-for-update', () => {
+      if (this.readyCheckStatus && this.status === this.readyCheckStatus) return
+      this.setStatus({ state: 'checking' })
+    })
     this.updater.on('update-available', (info) => {
       const i = info as { version?: string; releaseNotes?: unknown; files?: UpdateFeedFile[] }
+      const readyStatus = this.readyCheckStatus
+      if (
+        readyStatus &&
+        this.status === readyStatus &&
+        (!i.version || !isNewer(i.version, readyStatus.latest ?? this.currentVersion))
+      ) {
+        return
+      }
       const totalBytes = extractArtifactSize(i.files, this.platform, this.arch)
       this.setStatus({
         state: 'available',
@@ -248,6 +261,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
       if (i.version) this.notesHydration = this.hydrateNotes(i.version)
     })
     this.updater.on('update-not-available', (info) => {
+      if (this.readyCheckStatus && this.status === this.readyCheckStatus) return
       const i = info as { version?: string }
       this.setStatus({ state: 'up-to-date', latest: i.version })
     })
@@ -286,6 +300,10 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     })
     this.updater.on('error', (err) => {
       if (this.applying && !this.installerStarted) return
+      if (this.readyCheckStatus && this.status === this.readyCheckStatus) {
+        this.readyCheckError = err
+        return
+      }
       if (this.installerStarted) {
         this.pendingInstallRollback?.()
         this.pendingInstallRollback = undefined
@@ -338,35 +356,39 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   }
 
   async check(): Promise<UpdateStatus> {
-    // Keep provider checks mutually exclusive with downloads. A late check event can otherwise replace
-    // ready with checking/available/up-to-date and make apply() reject the completed update.
-    if (
-      this.applying ||
-      this.checkInFlight ||
-      this.downloadLifecycle ||
-      this.status.state === 'ready'
-    ) {
+    // Keep provider checks mutually exclusive with downloads. A ready update may still be refreshed,
+    // but its events are reconciled against the downloaded version by the subscribers above.
+    if (this.applying || this.checkInFlight || this.downloadLifecycle) {
       return this.status
     }
+    const readyStatus = this.status.state === 'ready' ? this.status : undefined
     const operation = startDiagnosticOperation(this.log, {
       operation: 'update-check',
       fields: { strategy: 'in-place' }
     })
     this.checkInFlight = true
+    this.readyCheckStatus = readyStatus
+    this.readyCheckError = undefined
     try {
       operation.phase('query-provider')
+      let providerFailure: unknown
       try {
         await this.updater.checkForUpdates()
       } catch (error) {
-        this.setStatus({
-          state: 'error',
-          error: error instanceof Error ? error.message : 'Update check failed'
-        })
-        operation.fail(error, { result: 'error' })
+        providerFailure = error
+        if (!readyStatus || this.status !== readyStatus) {
+          this.setStatus({
+            state: 'error',
+            error: error instanceof Error ? error.message : 'Update check failed'
+          })
+        }
       }
       // Wait for the notes fetch triggered by update-available so the returned status carries them.
       await this.notesHydration
-      if (this.status.state === 'error') {
+      providerFailure ??= this.readyCheckError
+      if (providerFailure) {
+        operation.fail(providerFailure, { result: 'error' })
+      } else if (this.status.state === 'error') {
         operation.fail(new Error('Updater check failed'), { result: 'error' })
       } else {
         operation.complete({ result: this.status.state })
@@ -374,6 +396,8 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
       return this.status
     } finally {
       this.checkInFlight = false
+      this.readyCheckStatus = undefined
+      this.readyCheckError = undefined
     }
   }
 

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -208,6 +208,64 @@ describe('UpdateService.download', () => {
     expect(existsSync(target)).toBe(true)
   })
 
+  it('preserves a completed download when a check is requested during the transfer', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'svc-'))
+    const target = join(dir, 'installer.dmg')
+    const body = Buffer.from('installer-bytes')
+    const manifestForCheck = downloadManifest(
+      body.byteLength,
+      createHash('sha256').update(body).digest('hex')
+    )
+    let manifestFetches = 0
+    let resolveLateCheck: ((response: Response) => void) | undefined
+    const lateCheck = new Promise<Response>((resolve) => {
+      resolveLateCheck = resolve
+    })
+    let releaseInstaller: (() => void) | undefined
+    const installerGate = new Promise<void>((resolve) => {
+      releaseInstaller = resolve
+    })
+    let markInstallerStarted: (() => void) | undefined
+    const installerStarted = new Promise<void>((resolve) => {
+      markInstallerStarted = resolve
+    })
+    const fetchImpl = (async (input: unknown) => {
+      if (String(input).endsWith('version.json')) {
+        manifestFetches += 1
+        return manifestFetches === 1 ? jsonResponse(manifestForCheck) : lateCheck
+      }
+      markInstallerStarted?.()
+      await installerGate
+      return new Response(body, { status: 200 })
+    }) as unknown as typeof fetch
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast: vi.fn(),
+      promptSavePath: () => Promise.resolve(target)
+    })
+
+    await service.check()
+    const downloading = service.download()
+    await installerStarted
+    const checking = service.check()
+    releaseInstaller?.()
+    await downloading
+    resolveLateCheck?.(jsonResponse(manifestForCheck))
+    await checking
+
+    const readyStatus = service.getStatus()
+    expect(await service.check()).toBe(readyStatus)
+
+    expect(manifestFetches).toBe(1)
+    expect(service.getStatus()).toEqual(
+      expect.objectContaining({ state: 'ready', localPath: target, progress: 100 })
+    )
+  })
+
   it('records a completed installer download without its URL or local path', async () => {
     dir = await mkdtemp(join(tmpdir(), 'diagnostic-private-'))
     const target = join(dir, 'private-installer.dmg')

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -260,10 +260,59 @@ describe('UpdateService.download', () => {
     const readyStatus = service.getStatus()
     expect(await service.check()).toBe(readyStatus)
 
-    expect(manifestFetches).toBe(1)
+    expect(manifestFetches).toBe(2)
     expect(service.getStatus()).toEqual(
       expect.objectContaining({ state: 'ready', localPath: target, progress: 100 })
     )
+  })
+
+  it('preserves ready on check failure but accepts a strictly newer manifest', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'svc-'))
+    const target = join(dir, 'installer.dmg')
+    const body = Buffer.from('installer-bytes')
+    const checksum = createHash('sha256').update(body).digest('hex')
+    let manifestForCheck = downloadManifest(body.byteLength, checksum)
+    let checkFailure: Error | undefined
+    const fetchImpl = ((input: unknown) => {
+      if (String(input).endsWith('version.json')) {
+        return checkFailure
+          ? Promise.reject(checkFailure)
+          : Promise.resolve(jsonResponse(manifestForCheck))
+      }
+      return Promise.resolve(new Response(body, { status: 200 }))
+    }) as unknown as typeof fetch
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast: vi.fn(),
+      promptSavePath: () => Promise.resolve(target)
+    })
+
+    await service.check()
+    await service.download()
+    const readyStatus = service.getStatus()
+
+    checkFailure = new Error('offline')
+    expect(await service.check()).toBe(readyStatus)
+
+    checkFailure = undefined
+    manifestForCheck = {
+      ...downloadManifest(body.byteLength, checksum),
+      version: '0.4.0',
+      downloads: {
+        'mac-arm64': {
+          url: 'https://statics.aipoch.com/releases/0.4.0/installer.dmg',
+          size: body.byteLength,
+          sha256: checksum
+        }
+      }
+    }
+    const newerStatus = await service.check()
+    expect(newerStatus).toEqual(expect.objectContaining({ state: 'available', latest: '0.4.0' }))
+    expect(newerStatus.localPath).toBeUndefined()
   })
 
   it('records a completed installer download without its URL or local path', async () => {

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -77,6 +77,7 @@ export class UpdateService implements UpdateStrategy {
   // latest, so an older (drained) download can't clear a newer one's lifecycle.
   private downloadGeneration = 0
   private downloadOperation?: DiagnosticOperation
+  private checkInFlight = false
   private readonly fetchImpl?: typeof fetch
   private readonly platform: NodeJS.Platform
   private readonly arch: string
@@ -144,54 +145,75 @@ export class UpdateService implements UpdateStrategy {
   }
 
   async check(): Promise<UpdateStatus> {
-    // Preserve the installer once a download owns the lifecycle or has completed. A scheduled/manual
-    // check can otherwise finish after the transfer and replace ready + localPath with its manifest
-    // result. apply() already validates the saved file and returns to available when it is missing.
-    if (this.downloadLifecycle || this.status.state === 'ready') return this.status
+    // A transfer and a manifest check cannot own the status concurrently. Once ready, checks still run
+    // but only a strictly newer release may supersede the downloaded installer.
+    if (this.downloadLifecycle || this.checkInFlight) return this.status
 
+    const readyStatus = this.status.state === 'ready' ? this.status : undefined
     const operation = startDiagnosticOperation(this.log, {
       operation: 'update-check',
       fields: { strategy: 'manifest' }
     })
-    this.setStatus({ state: 'checking', current: this.currentVersion })
-    operation.phase('fetch-manifest')
+    this.checkInFlight = true
     try {
-      const manifest = await fetchManifest(this.manifestUrl, this.fetchImpl)
-      if (!isNewer(manifest.version, this.currentVersion)) {
+      if (!readyStatus) this.setStatus({ state: 'checking', current: this.currentVersion })
+      operation.phase('fetch-manifest')
+      try {
+        const manifest = await fetchManifest(this.manifestUrl, this.fetchImpl)
+        if (readyStatus) {
+          // Another operation (for example apply() discovering a missing file) already moved the
+          // lifecycle forward; this check no longer owns the snapshot it started from.
+          if (this.status !== readyStatus) {
+            operation.complete({ result: 'superseded' })
+            return this.status
+          }
+          if (!isNewer(manifest.version, readyStatus.latest ?? this.currentVersion)) {
+            operation.complete({ result: 'ready-preserved' })
+            return this.status
+          }
+        }
+        if (!isNewer(manifest.version, this.currentVersion)) {
+          this.setStatus({
+            state: 'up-to-date',
+            current: this.currentVersion,
+            latest: manifest.version
+          })
+          operation.complete({ result: 'up-to-date' })
+          return this.status
+        }
+        const download = selectDownload(manifest, this.platform, this.arch) ?? undefined
         this.setStatus({
-          state: 'up-to-date',
+          state: 'available',
           current: this.currentVersion,
-          latest: manifest.version
+          latest: manifest.version,
+          notes: manifest.notes,
+          download,
+          totalBytes: download?.size
         })
-        operation.complete({ result: 'up-to-date' })
-        return this.status
+        operation.complete({ result: 'available', artifactAvailable: download !== undefined })
+      } catch (error) {
+        // A failed refresh must not discard an already downloaded installer. Ordinary checks continue
+        // to surface the provider error as before.
+        if (!readyStatus) {
+          this.setStatus({
+            state: 'error',
+            current: this.currentVersion,
+            error: error instanceof Error ? error.message : 'Update check failed'
+          })
+        }
+        operation.fail(error, { result: 'error' })
       }
-      const download = selectDownload(manifest, this.platform, this.arch) ?? undefined
-      this.setStatus({
-        state: 'available',
-        current: this.currentVersion,
-        latest: manifest.version,
-        notes: manifest.notes,
-        download,
-        totalBytes: download?.size
-      })
-      operation.complete({ result: 'available', artifactAvailable: download !== undefined })
-    } catch (error) {
-      this.setStatus({
-        state: 'error',
-        current: this.currentVersion,
-        error: error instanceof Error ? error.message : 'Update check failed'
-      })
-      operation.fail(error, { result: 'error' })
+      return this.status
+    } finally {
+      this.checkInFlight = false
     }
-    return this.status
   }
 
   async download(): Promise<UpdateStatus> {
     // An active download is in flight; ignore repeat clicks / concurrent renderers. The abort claim
     // below is synchronous (before any await) so this guard and a cancel() during the drain both target
     // a consistent slot — a cancel while a retry is still draining must abort it, not be a no-op.
-    if (this.downloadAbort) return this.status
+    if (this.checkInFlight || this.downloadAbort) return this.status
 
     const { download } = this.status
     if (!download) return this.status

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -144,6 +144,11 @@ export class UpdateService implements UpdateStrategy {
   }
 
   async check(): Promise<UpdateStatus> {
+    // Preserve the installer once a download owns the lifecycle or has completed. A scheduled/manual
+    // check can otherwise finish after the transfer and replace ready + localPath with its manifest
+    // result. apply() already validates the saved file and returns to available when it is missing.
+    if (this.downloadLifecycle || this.status.state === 'ready') return this.status
+
     const operation = startDiagnosticOperation(this.log, {
       operation: 'update-check',
       fields: { strategy: 'manifest' }

--- a/src/renderer/src/pages/settings/AppVersionSection.render.test.tsx
+++ b/src/renderer/src/pages/settings/AppVersionSection.render.test.tsx
@@ -99,4 +99,22 @@ describe('AppVersionSection', () => {
 
     expect(button).toBeDefined()
   })
+
+  it.each(['downloading', 'ready'] as const)(
+    'disables update checks while the update is %s',
+    (state) => {
+      useUpdateStore.setState({
+        status: { state, current: '0.2.0', latest: '0.3.0' }
+      })
+
+      act(() => {
+        root.render(<AppVersionSection />)
+      })
+
+      const checkButton = Array.from(container.querySelectorAll('button')).find((element) =>
+        /check now/i.test(element.textContent ?? '')
+      )
+      expect(checkButton?.disabled).toBe(true)
+    }
+  )
 })

--- a/src/renderer/src/pages/settings/AppVersionSection.render.test.tsx
+++ b/src/renderer/src/pages/settings/AppVersionSection.render.test.tsx
@@ -100,21 +100,21 @@ describe('AppVersionSection', () => {
     expect(button).toBeDefined()
   })
 
-  it.each(['downloading', 'ready'] as const)(
-    'disables update checks while the update is %s',
-    (state) => {
-      useUpdateStore.setState({
-        status: { state, current: '0.2.0', latest: '0.3.0' }
-      })
+  it.each([
+    ['downloading', true],
+    ['ready', false]
+  ] as const)('sets check availability while the update is %s', (state, disabled) => {
+    useUpdateStore.setState({
+      status: { state, current: '0.2.0', latest: '0.3.0' }
+    })
 
-      act(() => {
-        root.render(<AppVersionSection />)
-      })
+    act(() => {
+      root.render(<AppVersionSection />)
+    })
 
-      const checkButton = Array.from(container.querySelectorAll('button')).find((element) =>
-        /check now/i.test(element.textContent ?? '')
-      )
-      expect(checkButton?.disabled).toBe(true)
-    }
-  )
+    const checkButton = Array.from(container.querySelectorAll('button')).find((element) =>
+      /check now/i.test(element.textContent ?? '')
+    )
+    expect(checkButton?.disabled).toBe(disabled)
+  })
 })

--- a/src/renderer/src/pages/settings/AppVersionSection.tsx
+++ b/src/renderer/src/pages/settings/AppVersionSection.tsx
@@ -20,6 +20,7 @@ const AppVersionSection = (): React.JSX.Element => {
   const version = appInfo?.version ?? status.current
   const isChecking = status.state === 'checking'
   const isDownloading = status.state === 'downloading'
+  const canCheck = !isChecking && !isDownloading && status.state !== 'ready'
   const hasUpdate = status.state === 'available' || isDownloading || status.state === 'ready'
 
   const statusLine = ((): string => {
@@ -60,12 +61,7 @@ const AppVersionSection = (): React.JSX.Element => {
         controlClassName="w-auto justify-self-end"
       >
         <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => void check()}
-            disabled={isChecking}
-          >
+          <Button type="button" variant="outline" onClick={() => void check()} disabled={!canCheck}>
             <RefreshCw
               className={isChecking ? 'size-4 animate-spin' : 'size-4'}
               aria-hidden="true"

--- a/src/renderer/src/pages/settings/AppVersionSection.tsx
+++ b/src/renderer/src/pages/settings/AppVersionSection.tsx
@@ -20,7 +20,7 @@ const AppVersionSection = (): React.JSX.Element => {
   const version = appInfo?.version ?? status.current
   const isChecking = status.state === 'checking'
   const isDownloading = status.state === 'downloading'
-  const canCheck = !isChecking && !isDownloading && status.state !== 'ready'
+  const canCheck = !isChecking && !isDownloading
   const hasUpdate = status.state === 'available' || isDownloading || status.state === 'ready'
 
   const statusLine = ((): string => {


### PR DESCRIPTION
## Problem

Scheduled and manual checks can overlap an update download. A check that completes after the transfer can replace `ready` with `available`, `up-to-date`, or `error`; the manifest strategy also loses `localPath`, while the in-place strategy then fails the guarded `apply()` readiness requirement.

## Proposed change

- Serialize checks against active downloads in both updater strategies.
- Continue scheduled/manual checks after an update is ready, but reconcile results by version:
  - same/older release or check failure preserves the ready artifact;
  - a strictly newer release supersedes it with a new available update.
- Keep Settings → “Check now” enabled for ready updates and disable it only while checking/downloading.
- Add deterministic ordering, ready-preservation, failure, and newer-version coverage for both strategies.

## Scope and non-goals

- Covers both manifest and in-place updater strategies; the scheduler interface and composition are unchanged.
- Adds private, in-memory coordination fields only; no public or persisted update metadata changes.
- No shared update states, enum values, database changes, migrations, or persistence changes.
- No historical-data compatibility work is required.
- A superseded user-selected installer remains at its existing filesystem path; this PR does not delete user files.

## Acceptance criteria and validation

All checks below ran against the final material implementation:

- In-place mutual exclusion and version reconciliation → `npm test -- src/main/update/electron-updater-strategy.test.ts` → 44 passed.
- Manifest mutual exclusion and version reconciliation → `npm test -- src/main/update/service.test.ts` → 28 passed.
- Settings check-action availability → `npm test -- src/renderer/src/pages/settings/AppVersionSection.render.test.tsx` → 6 passed.
- Main-process types → `npm run typecheck:node` → passed.
- Renderer types → `npm run typecheck:web` → passed.
- Source lint/format contract → `npm run lint` → passed with no warnings.

The complete portable and platform suites were intentionally left to PR CI.

## Review focus

- Whether same/older/error results correctly preserve the ready artifact while strictly newer versions supersede it.
- Whether the event reconciliation in ElectronUpdaterStrategy covers provider-driven state transitions without changing the shared model.
- Whether leaving a superseded installer at its user-selected path is the correct non-destructive behavior.