### PR TITLE
fix(shutdown): limit task and reviewer cleanup waits

### DIFF
--- a/src/main/application-runtime.test.ts
+++ b/src/main/application-runtime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import {
+  APPLICATION_SURFACE_SHUTDOWN_BUDGET_MS,
   composeApplicationRuntime,
   composeApplicationRuntimeWithAdapters,
   shutdownApplicationSurfaces,
@@ -275,6 +276,28 @@ describe('application runtime composition', () => {
 })
 
 describe('application surface shutdown', () => {
+  it('returns a timeout when an application surface never settles', async () => {
+    vi.useFakeTimers()
+    let outcome: Awaited<ReturnType<typeof shutdownApplicationSurfaces>> | undefined
+
+    try {
+      void shutdownApplicationSurfaces({
+        disposeApplicationRuntime: vi.fn(),
+        shutdownRemoteAccess: vi.fn(),
+        disposeWebController: () => new Promise<void>(() => undefined),
+        disposeIpcHandlers: vi.fn()
+      }).then((result) => {
+        outcome = result
+      })
+
+      await vi.advanceTimersByTimeAsync(APPLICATION_SURFACE_SHUTDOWN_BUDGET_MS)
+
+      expect(outcome).toBe('timeout')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('keeps one ordered quit path from the composed backend through web surfaces', async () => {
     const order: string[] = []
 

--- a/src/main/application-runtime.test.ts
+++ b/src/main/application-runtime.test.ts
@@ -276,16 +276,29 @@ describe('application runtime composition', () => {
 })
 
 describe('application surface shutdown', () => {
-  it('returns a timeout when an application surface never settles', async () => {
+  it('times out a hung surface and still attempts every later surface', async () => {
     vi.useFakeTimers()
     let outcome: Awaited<ReturnType<typeof shutdownApplicationSurfaces>> | undefined
+    const order: string[] = []
+    const disposeApplicationRuntime = vi.fn(() => {
+      order.push('application-runtime')
+    })
+    const shutdownRemoteAccess = vi.fn(() => {
+      order.push('remote-access')
+    })
+    const disposeIpcHandlers = vi.fn(() => {
+      order.push('ipc-handlers')
+    })
 
     try {
       void shutdownApplicationSurfaces({
-        disposeApplicationRuntime: vi.fn(),
-        shutdownRemoteAccess: vi.fn(),
-        disposeWebController: () => new Promise<void>(() => undefined),
-        disposeIpcHandlers: vi.fn()
+        disposeApplicationRuntime,
+        shutdownRemoteAccess,
+        disposeWebController: () => {
+          order.push('web-controller')
+          return new Promise<void>(() => undefined)
+        },
+        disposeIpcHandlers
       }).then((result) => {
         outcome = result
       })
@@ -293,6 +306,15 @@ describe('application surface shutdown', () => {
       await vi.advanceTimersByTimeAsync(APPLICATION_SURFACE_SHUTDOWN_BUDGET_MS)
 
       expect(outcome).toBe('timeout')
+      expect(disposeApplicationRuntime).toHaveBeenCalledOnce()
+      expect(shutdownRemoteAccess).toHaveBeenCalledOnce()
+      expect(disposeIpcHandlers).toHaveBeenCalledOnce()
+      expect(order).toEqual([
+        'web-controller',
+        'application-runtime',
+        'remote-access',
+        'ipc-handlers'
+      ])
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/application-runtime.ts
+++ b/src/main/application-runtime.ts
@@ -4,6 +4,7 @@ import { BackendShutdownOutcomeError, type ShutdownStepOutcome } from './lifecyc
 type Awaitable<T> = T | Promise<T>
 
 export const APPLICATION_MODULE_DISPOSAL_BUDGET_MS = 1000
+export const APPLICATION_SURFACE_SHUTDOWN_BUDGET_MS = 5000
 
 export class ApplicationModuleDisposalTimeoutError extends Error {
   constructor(
@@ -60,7 +61,8 @@ export type ApplicationLifecycleShutdownDependencies = {
 
 // Direct Web/Task adapters close before the application command router, which in turn closes before
 // its underlying RemoteAccess owner. Closing Web first can publish RemoteAccess's stopped state, but
-// this path runs only while the app is quitting. A failed surface still cannot strand a later one.
+// this path runs only while the app is quitting. A failed surface still cannot strand a later one, and
+// the enclosing deadline guarantees a surface that never settles cannot strand app.exit().
 export const shutdownApplicationSurfaces = async ({
   disposeApplicationRuntime,
   shutdownRemoteAccess,
@@ -88,7 +90,9 @@ export const shutdownApplicationSurfaces = async ({
     return priority[next] > priority[current] ? next : current
   }
   let overallOutcome: ShutdownStepOutcome = 'completed'
+  let activeSurface: string | undefined
   const dispose = async (surface: string, operation: () => Awaitable<void>): Promise<void> => {
+    activeSurface = surface
     try {
       await operation()
     } catch (error) {
@@ -108,10 +112,31 @@ export const shutdownApplicationSurfaces = async ({
     }
   }
 
-  await dispose('web-controller', disposeWebController)
-  await dispose('application-runtime', disposeApplicationRuntime)
-  await dispose('remote-access', shutdownRemoteAccess)
-  await dispose('ipc-handlers', disposeIpcHandlers)
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<'timeout'>((resolve) => {
+    timer = setTimeout(() => resolve('timeout'), APPLICATION_SURFACE_SHUTDOWN_BUDGET_MS)
+    timer.unref?.()
+  })
+  const disposal = (async () => {
+    await dispose('web-controller', disposeWebController)
+    await dispose('application-runtime', disposeApplicationRuntime)
+    await dispose('remote-access', shutdownRemoteAccess)
+    await dispose('ipc-handlers', disposeIpcHandlers)
+  })()
+  const result = await Promise.race([disposal.then(() => 'completed' as const), deadline])
+  if (timer) clearTimeout(timer)
+  if (result === 'timeout') {
+    overallOutcome = combineOutcomes(overallOutcome, 'timeout')
+    try {
+      log?.error('application surface shutdown failed', {
+        surface: activeSurface ?? 'unknown',
+        result: 'timeout',
+        errorCategory: 'timeout'
+      })
+    } catch {
+      // The hard deadline remains authoritative when the diagnostic sink also fails.
+    }
+  }
   return overallOutcome
 }
 

--- a/src/main/application-runtime.ts
+++ b/src/main/application-runtime.ts
@@ -62,7 +62,7 @@ export type ApplicationLifecycleShutdownDependencies = {
 // Direct Web/Task adapters close before the application command router, which in turn closes before
 // its underlying RemoteAccess owner. Closing Web first can publish RemoteAccess's stopped state, but
 // this path runs only while the app is quitting. A failed surface still cannot strand a later one, and
-// the enclosing deadline guarantees a surface that never settles cannot strand app.exit().
+// the shared deadline reserves time for every later surface before app.exit().
 export const shutdownApplicationSurfaces = async ({
   disposeApplicationRuntime,
   shutdownRemoteAccess,
@@ -90,52 +90,66 @@ export const shutdownApplicationSurfaces = async ({
     return priority[next] > priority[current] ? next : current
   }
   let overallOutcome: ShutdownStepOutcome = 'completed'
-  let activeSurface: string | undefined
-  const dispose = async (surface: string, operation: () => Awaitable<void>): Promise<void> => {
-    activeSurface = surface
-    try {
-      await operation()
-    } catch (error) {
-      for (const cause of flattenErrors(error)) {
-        const result = classifyError(cause)
-        overallOutcome = combineOutcomes(overallOutcome, result)
-        try {
-          log?.error('application surface shutdown failed', {
-            surface,
-            result,
-            ...diagnosticErrorFields(cause)
-          })
-        } catch {
-          // A diagnostic sink failure must not prevent the remaining surfaces from closing.
-        }
+  const dispose = async (
+    surface: string,
+    operation: () => Awaitable<void>,
+    timeoutMs: number
+  ): Promise<void> => {
+    const observed = Promise.resolve()
+      .then(operation)
+      .then(
+        () => ({ status: 'fulfilled' as const }),
+        (reason: unknown) => ({ status: 'rejected' as const, reason })
+      )
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const deadline = new Promise<{ status: 'timeout' }>((resolve) => {
+      timer = setTimeout(() => resolve({ status: 'timeout' }), timeoutMs)
+      timer.unref?.()
+    })
+    const outcome = await Promise.race([observed, deadline])
+    if (timer) clearTimeout(timer)
+
+    if (outcome.status === 'timeout') {
+      overallOutcome = combineOutcomes(overallOutcome, 'timeout')
+      try {
+        log?.error('application surface shutdown failed', {
+          surface,
+          result: 'timeout',
+          errorCategory: 'timeout'
+        })
+      } catch {
+        // The timeout remains authoritative when the diagnostic sink also fails.
+      }
+      return
+    }
+    if (outcome.status === 'fulfilled') return
+
+    for (const cause of flattenErrors(outcome.reason)) {
+      const result = classifyError(cause)
+      overallOutcome = combineOutcomes(overallOutcome, result)
+      try {
+        log?.error('application surface shutdown failed', {
+          surface,
+          result,
+          ...diagnosticErrorFields(cause)
+        })
+      } catch {
+        // A diagnostic sink failure must not prevent the remaining surfaces from closing.
       }
     }
   }
 
-  let timer: ReturnType<typeof setTimeout> | undefined
-  const deadline = new Promise<'timeout'>((resolve) => {
-    timer = setTimeout(() => resolve('timeout'), APPLICATION_SURFACE_SHUTDOWN_BUDGET_MS)
-    timer.unref?.()
-  })
-  const disposal = (async () => {
-    await dispose('web-controller', disposeWebController)
-    await dispose('application-runtime', disposeApplicationRuntime)
-    await dispose('remote-access', shutdownRemoteAccess)
-    await dispose('ipc-handlers', disposeIpcHandlers)
-  })()
-  const result = await Promise.race([disposal.then(() => 'completed' as const), deadline])
-  if (timer) clearTimeout(timer)
-  if (result === 'timeout') {
-    overallOutcome = combineOutcomes(overallOutcome, 'timeout')
-    try {
-      log?.error('application surface shutdown failed', {
-        surface: activeSurface ?? 'unknown',
-        result: 'timeout',
-        errorCategory: 'timeout'
-      })
-    } catch {
-      // The hard deadline remains authoritative when the diagnostic sink also fails.
-    }
+  const surfaces: ReadonlyArray<readonly [string, () => Awaitable<void>]> = [
+    ['web-controller', disposeWebController],
+    ['application-runtime', disposeApplicationRuntime],
+    ['remote-access', shutdownRemoteAccess],
+    ['ipc-handlers', disposeIpcHandlers]
+  ]
+  const shutdownDeadline = Date.now() + APPLICATION_SURFACE_SHUTDOWN_BUDGET_MS
+  for (const [index, [surface, operation]] of surfaces.entries()) {
+    const remainingBudgetMs = Math.max(0, shutdownDeadline - Date.now())
+    const remainingSurfaceCount = surfaces.length - index
+    await dispose(surface, operation, Math.floor(remainingBudgetMs / remainingSurfaceCount))
   }
   return overallOutcome
 }

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -9,6 +9,7 @@ import { ARTIFACT_OWNERSHIP_PERSISTENCE_RACE } from '../../shared/artifacts'
 import type { Project } from '../../shared/projects'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import {
+  TASK_REVIEW_DISPOSAL_BUDGET_MS,
   TaskRunner,
   type TaskPreviewResourcePort,
   type TaskProjectPort,
@@ -738,6 +739,75 @@ describe('TaskRunner', () => {
     releaseReviewCleanup?.()
     await disposal
     expect(disposed).toBe(true)
+  })
+
+  it('bounds disposal when an automatic reviewer ignores abort', async () => {
+    vi.useFakeTimers()
+    let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+    let markReviewStarted: (() => void) | undefined
+    const reviewStarted = new Promise<void>((resolve) => {
+      markReviewStarted = resolve
+    })
+    const review = vi.fn(
+      (...args: [PersistedChatSession, string, AbortSignal]) =>
+        new Promise<never>(() => {
+          args[2].addEventListener('abort', () => undefined, { once: true })
+          markReviewStarted?.()
+        })
+    )
+    const ids = ['hung-review-user', 'hung-review-run', 'hung-review-agent']
+    const runner = createRunner({
+      sessions: {
+        list: async () => [],
+        save: async () => undefined
+      },
+      agent: {
+        withSessionAvailable: async (_projectId, _sessionId, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => ({ sessionId: 'session-hung-review-dispose' }),
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => undefined,
+        cancelPrompt: async () => undefined,
+        prompt: async () => {
+          emitEvent?.({
+            id: 'hung-review-message-event',
+            timestamp: 10,
+            kind: 'message',
+            level: 'info',
+            sessionId: 'session-hung-review-dispose',
+            role: 'assistant',
+            text: 'Review never settles.'
+          })
+        }
+      },
+      reviewer: { review },
+      runtimeEvents: {
+        subscribe: (listener) => {
+          emitEvent = listener
+          return () => undefined
+        }
+      },
+      createId: () => ids.shift() ?? 'generated-id'
+    })
+
+    try {
+      await runner.startRun({
+        project: project.id,
+        prompt: 'Produce a review that never settles.',
+        autoReviewEnabled: true
+      })
+      await reviewStarted
+      let disposed = false
+      void runner.dispose().then(() => {
+        disposed = true
+      })
+
+      expect(review.mock.calls[0]?.[2].aborted).toBe(true)
+      await vi.advanceTimersByTimeAsync(TASK_REVIEW_DISPOSAL_BUDGET_MS)
+      expect(disposed).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('uses the dedicated policy mutation for an existing Session', async () => {

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -187,6 +187,7 @@ class PartialTaskCompletionError extends Error {
 
 const MAX_RETAINED_RUNS = 200
 const TASK_RUN_HEARTBEAT_INTERVAL_MS = 10_000
+export const TASK_REVIEW_DISPOSAL_BUDGET_MS = 1000
 const VISIBLE_PROVIDER_EVENT_KINDS = new Set<AcpRuntimeEvent['kind']>([
   'message',
   'thought',
@@ -393,7 +394,15 @@ class TaskRunner {
       activeReviewCompletions.push(run.completion)
     }
     this.progressListeners.clear()
-    this.disposal = Promise.allSettled(activeReviewCompletions).then(() => undefined)
+    const settleReviews = Promise.allSettled(activeReviewCompletions).then(() => undefined)
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const deadline = new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, TASK_REVIEW_DISPOSAL_BUDGET_MS)
+      timer.unref?.()
+    })
+    this.disposal = Promise.race([settleReviews, deadline]).finally(() => {
+      if (timer) clearTimeout(timer)
+    })
     return this.disposal
   }
 


### PR DESCRIPTION
## Problem

Application quit can wait forever when the Web Task adapter is disposing an automatic Reviewer. `TaskRunner.dispose()` aborts the review but then awaits its completion without a deadline; the Web controller awaits Task disposal, and the ordered application-surface shutdown had no enclosing budget. A hung Reviewer command, runtime cleanup, pending Web start, or server close could therefore prevent `app.exit(0)` indefinitely.

## Proposed change

- Give an aborted automatic Reviewer one second to settle before Task disposal proceeds.
- Give the complete ordered application-surface shutdown sequence a five-second hard deadline.
- Preserve shutdown order while reserving an equal share of the remaining global time for every surface still to be attempted, so one hung surface cannot skip later cleanup.
- Return the existing `timeout` shutdown outcome and record the surface whose allocated time expires.
- Keep abandoned promises observed so a late rejection cannot become unhandled.
- Add regressions for a Reviewer that ignores abort and a Web surface that never settles while later surfaces still run.

## Scope and non-goals

- Preserve the existing Web controller -> application runtime -> Remote Access -> IPC shutdown order, including after a timeout.
- Do not add schema fields, migrations, persistent domain data, relationships, or lifecycle enum values.
- Do not change UI copy, dialogs, or normal quit interaction.
- Keep the existing startup recovery that converts interrupted persisted Reviews from `running` to `error`.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Hung Reviewer abort -> `npm test -- src/main/application-runtime.test.ts src/main/tasks/task-runner.test.ts src/main/web-service/task-api.test.ts src/main/web-service/controller.test.ts src/main/app-lifecycle.test.ts` -> passed, 136 tests.
- Hung application surface, later-surface ordering, and shutdown outcome propagation -> same focused test set -> passed.
- Task API, Web controller, and Electron lifecycle consumers -> same focused test set -> passed.
- Main-process type safety -> `npm run typecheck:node` -> passed.
- Source and test lint -> `npm run lint` -> passed.

The two original focused regressions failed before the implementation (`undefined` instead of `timeout`, and Task disposal still pending after one second) and pass with the fix. The timeout regression also verifies that application runtime, Remote Access, and IPC cleanup are attempted after a hung Web controller.

The complete local `npm test` suite was intentionally not run per maintainer request; exact-head PR CI remains authoritative for the portable and platform lanes. A synchronous event-loop block cannot be preempted by a JavaScript timer and remains outside this fix.

## Review focus

- Whether one second is an appropriate graceful Reviewer-abort window.
- Whether sharing the five-second hard budget across the remaining ordered surfaces gives the right cleanup/exit tradeoff.
- Promise observation and timer cleanup on both the normal and timeout paths.
