### PR TITLE
fix(database): bound retained migration backups

### DIFF
--- a/src/main/database/application-database.integration.test.ts
+++ b/src/main/database/application-database.integration.test.ts
@@ -721,7 +721,7 @@ describe('application database (integration)', () => {
   it('backs up legacy data through the shared client on a portable storage path', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open science 数据 legacy backup-'))
     const databasePath = join(storageRoot, 'open-science.db')
-    const backupPath = `${databasePath}.before-0001_runtime_schema_baseline.backup`
+    const backupPath = `${databasePath}.before-0010_compute_password_auth.backup`
     const seedClient = createProjectDbClient(storageRoot)
     try {
       await seedClient.$executeRawUnsafe(`CREATE TABLE "Project" (
@@ -758,11 +758,10 @@ describe('application database (integration)', () => {
         `
       ).resolves.toEqual([{ id: 'legacy-project', name: 'Preserved' }])
       await expect(
-        backupClient.$queryRaw<Array<{ name: string }>>`
-          SELECT "name" FROM "sqlite_schema"
-          WHERE "type" = 'table' AND "name" = '_open_science_migrations'
+        backupClient.$queryRaw<Array<{ id: string }>>`
+          SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1
         `
-      ).resolves.toEqual([])
+      ).resolves.toEqual([{ id: '0009_vision_evidence' }])
     } finally {
       await backupClient.$disconnect()
     }

--- a/src/main/database/database-json-constraints-migration.test.ts
+++ b/src/main/database/database-json-constraints-migration.test.ts
@@ -144,7 +144,15 @@ describe('database JSON constraints migration', () => {
       from: '0007_notification_attention_metadata',
       to: '0010_compute_password_auth'
     })
-    await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).resolves.toBeUndefined()
+    await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+    await expect(
+      access(`${databasePath}.before-0009_vision_evidence.backup`)
+    ).resolves.toBeUndefined()
+    await expect(
+      access(`${databasePath}.before-0010_compute_password_auth.backup`)
+    ).resolves.toBeUndefined()
 
     await expect(
       client.$queryRaw<Array<{ scope: string; reviewerLog: string }>>`

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -1,4 +1,4 @@
-import { access, copyFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { access, copyFile, mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -645,7 +645,7 @@ describe('application database migrations', () => {
     expect(backupEvents).toEqual([])
   })
 
-  it('retains a recovery snapshot before adding Agent Context to a ledger database', async () => {
+  it('creates recovery snapshots while retaining only the newest two for a ledger database', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-agent-context-backup-'))
     const databasePath = join(storageRoot, 'open-science.db')
     const backupPath = `${databasePath}.before-0002_project_agent_context.backup`
@@ -736,7 +736,13 @@ describe('application database migrations', () => {
         reused: false
       }
     ])
-    await expect(access(backupPath)).resolves.toBeUndefined()
+    await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(
+      access(`${databasePath}.before-0009_vision_evidence.backup`)
+    ).resolves.toBeUndefined()
+    await expect(
+      access(`${databasePath}.before-0010_compute_password_auth.backup`)
+    ).resolves.toBeUndefined()
     await expect(
       client.$queryRaw<Array<{ agentContext: string; name: string }>>`
         SELECT "agentContext", "name" FROM "Project" WHERE "id" = 'project-1'
@@ -789,6 +795,52 @@ describe('application database migrations', () => {
       { id: '0008_database_json_constraints' },
       { id: '0009_vision_evidence' },
       { id: '0010_compute_password_auth' }
+    ])
+  })
+
+  it('prunes to two recovery snapshots before a later migration fails', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-failed-bounded-backups-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client, { databasePath })
+    await client.$executeRawUnsafe(
+      'VACUUM INTO ?',
+      `${databasePath}.before-0009_vision_evidence.backup`
+    )
+    await client.$executeRawUnsafe(
+      'VACUUM INTO ?',
+      `${databasePath}.before-0010_compute_password_auth.backup`
+    )
+    const futureBase = futureTestMigration()
+    const statements = [
+      `CREATE TABLE "MigrationSuffixProbe" ("id" TEXT NOT NULL PRIMARY KEY)`
+    ] as const
+    const verifiers = [
+      { kind: 'table-exists', version: 1, table: 'MissingMigrationSuffixProbe' }
+    ] as const
+    const future = {
+      ...futureBase,
+      statements,
+      verifiers,
+      checksum: checksumMigrationPayload(futureBase.id, statements, verifiers),
+      backupOnApply: 'required' as const
+    }
+
+    await expect(
+      migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future], {
+        databasePath
+      })
+    ).rejects.toMatchObject({
+      code: 'database_validation_failed',
+      migrationId: future.id
+    })
+    await expect(
+      readdir(storageRoot).then((entries) =>
+        entries.filter((entry) => entry.endsWith('.backup')).sort()
+      )
+    ).resolves.toEqual([
+      'open-science.db.before-0010_compute_password_auth.backup',
+      `open-science.db.before-${future.id}.backup`
     ])
   })
 
@@ -1404,11 +1456,13 @@ describe('application database migrations', () => {
     await expect(verifyCurrentRuntimeSchema(client)).resolves.toBeUndefined()
   })
 
-  it('creates a restorable snapshot before adopting a legacy database', async () => {
+  it('retains only the two newest restorable snapshots after adopting a legacy database', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-backup-'))
     const databasePath = join(storageRoot, 'open-science.db')
     const backupPath = `${databasePath}.before-0001_runtime_schema_baseline.backup`
     const agentContextBackupPath = `${databasePath}.before-0002_project_agent_context.backup`
+    const visionEvidenceBackupPath = `${databasePath}.before-0009_vision_evidence.backup`
+    const computePasswordAuthBackupPath = `${databasePath}.before-0010_compute_password_auth.backup`
     const backupEvents: unknown[] = []
     client = createProjectDbClient(storageRoot)
     await client.$executeRawUnsafe(`CREATE TABLE "Project" (
@@ -1499,11 +1553,22 @@ describe('application database migrations', () => {
         reused: false
       }
     ])
-    await expect(access(agentContextBackupPath)).resolves.toBeUndefined()
+    await expect(
+      readdir(storageRoot).then((entries) =>
+        entries.filter((entry) => entry.endsWith('.backup')).sort()
+      )
+    ).resolves.toEqual([
+      'open-science.db.before-0009_vision_evidence.backup',
+      'open-science.db.before-0010_compute_password_auth.backup'
+    ])
+    await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(access(agentContextBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(access(visionEvidenceBackupPath)).resolves.toBeUndefined()
+    await expect(access(computePasswordAuthBackupPath)).resolves.toBeUndefined()
     await expect(client.project.count()).resolves.toBe(1)
 
     const backupClient = new PrismaClient({
-      datasources: { db: { url: `file:${backupPath.replaceAll('\\', '/')}` } }
+      datasources: { db: { url: `file:${computePasswordAuthBackupPath.replaceAll('\\', '/')}` } }
     })
     try {
       await expect(
@@ -1512,11 +1577,10 @@ describe('application database migrations', () => {
         `
       ).resolves.toEqual([{ id: 'legacy-project', name: 'Preserved' }])
       await expect(
-        backupClient.$queryRaw<Array<{ name: string }>>`
-          SELECT "name" FROM "sqlite_schema"
-          WHERE "type" = 'table' AND "name" = '_open_science_migrations'
+        backupClient.$queryRaw<Array<{ id: string }>>`
+          SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1
         `
-      ).resolves.toEqual([])
+      ).resolves.toEqual([{ id: '0009_vision_evidence' }])
     } finally {
       await backupClient.$disconnect()
     }
@@ -1959,6 +2023,44 @@ describe('application database migrations', () => {
     ).resolves.toEqual([{ id: 'legacy-project', name: 'Preserved' }])
   })
 
+  it('prunes historical retained backups to the newest two without deleting an unknown backup', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-bounded-backups-'))
+    const databasePath = join(storageRoot, 'open-science.db')
+    const unknownBackupName = 'open-science.db.before-9999_future.backup'
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client, { databasePath })
+    for (const migration of MIGRATION_MANIFEST) {
+      await writeFile(`${databasePath}.before-${migration.id}.backup`, migration.id, 'utf8')
+    }
+    await writeFile(join(storageRoot, unknownBackupName), 'future', 'utf8')
+    const retired: unknown[] = []
+
+    await expect(
+      migrateApplicationDatabase(client, {
+        databasePath,
+        onBackupRetired: (event) => retired.push(event)
+      })
+    ).resolves.toMatchObject({ applied: [] })
+
+    await expect(
+      readdir(storageRoot).then((entries) =>
+        entries.filter((entry) => entry.endsWith('.backup')).sort()
+      )
+    ).resolves.toEqual([
+      'open-science.db.before-0009_vision_evidence.backup',
+      'open-science.db.before-0010_compute_password_auth.backup',
+      unknownBackupName
+    ])
+    expect(retired).toHaveLength(8)
+    expect(retired).toEqual(
+      expect.arrayContaining(
+        MIGRATION_MANIFEST.slice(0, -2).map((migration) =>
+          expect.objectContaining({ migrationId: migration.id })
+        )
+      )
+    )
+  })
+
   it('does not report backup retirement when no backup exists', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-no-retired-backup-'))
     const databasePath = join(storageRoot, 'open-science.db')
@@ -1982,7 +2084,7 @@ describe('application database migrations', () => {
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
-  it('reports backup retirement failure without blocking a valid database', async () => {
+  it('reports retained backup pruning failure without blocking a valid database', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-database-retirement-failure-'))
     const databasePath = join(storageRoot, 'open-science.db')
     const backupPath = `${databasePath}.before-0001_runtime_schema_baseline.backup`
@@ -1990,15 +2092,10 @@ describe('application database migrations', () => {
     await migrateApplicationDatabase(client, { databasePath })
     await mkdir(backupPath)
     await writeFile(join(backupPath, 'keep'), 'occupied', 'utf8')
-    const retiredManifest = MIGRATION_MANIFEST.map((migration) => ({
-      ...migration,
-      backupOnApply: 'none' as const,
-      backupRetention: 'delete-after-success' as const
-    }))
     const failures: unknown[] = []
 
     await expect(
-      migrateApplicationDatabaseWithManifest(client, retiredManifest, {
+      migrateApplicationDatabase(client, {
         databasePath,
         onBackupRetirementFailed: (event) => failures.push(event)
       })

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -405,6 +405,13 @@ type MigrationManifestEntry = {
   backupRetention: 'retain' | 'delete-after-success'
 }
 
+const RETAINED_DATABASE_MIGRATION_BACKUP_LIMIT = 2
+
+type DatabaseMigrationBackupRetirementScope = {
+  throughMigrationId: string
+  includeDeleteAfterSuccess: boolean
+}
+
 const runMigrationVerifiers = async (
   client: PrismaClient,
   verifiers: MigrationVerifiers,
@@ -698,10 +705,29 @@ const createDatabaseMigrationBackup = async (
 const retireDatabaseMigrationBackups = async (
   client: PrismaClient,
   manifest: readonly MigrationManifestEntry[],
-  options: SchemaMigrationOptions
+  options: SchemaMigrationOptions,
+  scope: DatabaseMigrationBackupRetirementScope
 ): Promise<void> => {
+  const boundaryIndex = manifest.findIndex((migration) => migration.id === scope.throughMigrationId)
+  if (boundaryIndex < 0) {
+    throw new Error(`Unknown database backup retention boundary ${scope.throughMigrationId}.`)
+  }
+  const retainedMigrationIds = new Set(
+    manifest
+      .slice(0, boundaryIndex + 1)
+      .filter(
+        (migration) =>
+          migration.backupOnApply === 'required' && migration.backupRetention === 'retain'
+      )
+      .slice(-RETAINED_DATABASE_MIGRATION_BACKUP_LIMIT)
+      .map((migration) => migration.id)
+  )
   const retired = manifest.filter(
-    (migration) => migration.backupRetention === 'delete-after-success'
+    (migration) =>
+      (scope.includeDeleteAfterSuccess && migration.backupRetention === 'delete-after-success') ||
+      (migration.backupOnApply === 'required' &&
+        migration.backupRetention === 'retain' &&
+        !retainedMigrationIds.has(migration.id))
   )
   if (retired.length === 0) return
   let databasePath: string | undefined
@@ -1064,7 +1090,10 @@ const migrateApplicationDatabaseWithManifest = async (
       throw classifyDatabaseFailure(error, 'validation', latest.id)
     }
     await reportDatabaseCompatibility(client, options)
-    await retireDatabaseMigrationBackups(client, manifest, options)
+    await retireDatabaseMigrationBackups(client, manifest, options, {
+      throughMigrationId: latest.id,
+      includeDeleteAfterSuccess: true
+    })
     try {
       options.onCompleted?.(result)
     } catch {
@@ -1102,6 +1131,10 @@ const migrateApplicationDatabaseWithManifest = async (
     } catch {
       // A diagnostic sink failure must not invalidate a durable database backup.
     }
+    await retireDatabaseMigrationBackups(client, manifest, options, {
+      throughMigrationId: migrationId,
+      includeDeleteAfterSuccess: false
+    })
   }
   const repairsPreviewStateForeignKeyViolations = manifest.some(
     (candidate) =>

--- a/src/main/database/notification-attention-metadata-migration.test.ts
+++ b/src/main/database/notification-attention-metadata-migration.test.ts
@@ -76,6 +76,12 @@ describe('notification attention metadata migration', () => {
     })
     await expect(
       access(`${databasePath}.before-0007_notification_attention_metadata.backup`)
+    ).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(
+      access(`${databasePath}.before-0009_vision_evidence.backup`)
+    ).resolves.toBeUndefined()
+    await expect(
+      access(`${databasePath}.before-0010_compute_password_auth.backup`)
     ).resolves.toBeUndefined()
 
     await expect(


### PR DESCRIPTION
## Problem

Every released application migration from 0001 through 0010 requires and retains a full SQLite
snapshot. A non-empty database crossing the whole chain therefore kept ten complete recovery
copies permanently, and the retained set would continue growing with the manifest.

## Proposed change

- Keep the two newest `required` + `retain` snapshots through the current migration boundary.
- Prune older known snapshots after a newer backup is durably created and verified, so a later
  migration failure still leaves the two newest recovery points.
- Re-run the same pruning after final current-schema verification so already-current databases
  clean up historical excess snapshots without a new database migration.
- Preserve the existing best-effort retirement contract: deletion failures are logged and do not
  block a valid database.
- Leave backup files for migration ids unknown to the running manifest untouched.

## Scope and non-goals

- Released migration files and manifest entries remain byte-for-byte unchanged.
- No Prisma/SQLite schema, migration ledger, application data model, field, enum, IPC, or UI change.
- Filesystem persistence changes intentionally: excess known migration backup files are deleted
  irreversibly, leaving the newest two under normal filesystem conditions.
- This PR does not reduce the number of snapshots created during a successful multi-migration
  chain; it bounds the retained set as each verified snapshot becomes available.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Retain only 0009 and 0010 after a legacy-to-current chain, while keeping the newest snapshot
  restorable -> `npm test -- src/main/database scripts/ci/check-pr-policy.test.ts` -> passed.
- Keep the retained set at two even when a later migration fails -> same database module command ->
  passed.
- Prune an already-current database's historical 0001-0010 backups without deleting an unknown
  future backup -> same database module command -> passed.
- Preserve best-effort cleanup failure behavior and shared-client portable-path recovery -> same
  database module command -> passed.
- Preserve released migration manifest immutability -> `npm test -- src/main/database
  scripts/ci/check-pr-policy.test.ts` -> passed, 10 files / 114 tests.
- Main-process type contracts -> `npm run typecheck:node` -> passed.
- Source lint and formatting -> `npm run lint` -> passed with no warnings.

The full portable test suite was not run locally per maintainer direction; PR CI is authoritative.
Renderer/web checks and E2E were excluded because no renderer, preload, shared interface, schema, or
user interaction changed. Cross-platform filesystem behavior remains covered by PR CI; local
focused validation ran on Windows.

## Review focus

- Whether the retention boundary correctly preserves the two newest known required snapshots at
  every point in a migration chain.
- Whether pruning known later snapshot paths after a database rollback is the desired downgrade
  behavior while unknown future paths remain protected.
- Whether retirement failures should remain warning-only rather than becoming a startup gate.

Independent review of the final impact mapping and PR CI are still required before merge.
