### PR TITLE
fix(workspace): complete folder access radio semantics

### DIFF
--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -40,6 +40,7 @@
   "API key is required.": "API キーが必要です。",
   "API key — models provided": "API キー — 提供されるモデル",
   "About": "について",
+  "Access level": "アクセスレベル",
   "Action needed": "必要なアクション",
   "Actions for {{name}}": "{{name}} のアクション",
   "Active": "アクティブ",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -53,6 +53,7 @@
   "API key is required.": "必须填写 API 密钥。",
   "API key — models provided": "API 密钥 —— 已内置模型列表",
   "About": "关于",
+  "Access level": "访问级别",
   "Action needed": "需要处理",
   "Actions for {{name}}": "{{name}} 的操作",
   "Active": "活跃",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -53,6 +53,7 @@
   "API key is required.": "必須填寫 API 金鑰。",
   "API key — models provided": "API 金鑰 —— 已內建模型清單",
   "About": "關於",
+  "Access level": "存取層級",
   "Action needed": "需要處理",
   "Actions for {{name}}": "{{name}} 的操作",
   "Active": "活躍",

--- a/src/renderer/src/pages/workspace/GrantFolderAccessDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/GrantFolderAccessDialog.interaction.test.tsx
@@ -497,6 +497,42 @@ describe('GrantFolderAccessDialog', () => {
     expect(grantButton?.className).toContain('disabled:opacity-40')
   })
 
+  it('uses one access-level Tab stop and wraps selection with horizontal arrow keys', async () => {
+    renderDialog()
+    await flush()
+
+    const group = document.body.querySelector<HTMLElement>('[role="radiogroup"]')
+    const radios = Array.from(document.body.querySelectorAll<HTMLButtonElement>('[role="radio"]'))
+
+    expect(group).not.toBeNull()
+    expect(group?.getAttribute('aria-label')).toBe('Access level')
+    expect(group?.tabIndex).toBe(0)
+    expect(radios.map((radio) => radio.tabIndex)).toEqual([-1, -1])
+
+    act(() => group?.focus())
+    expect(document.activeElement).toBe(radios[0])
+
+    await act(async () => {
+      radios[0].dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, cancelable: true })
+      )
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(radios.map((radio) => radio.getAttribute('aria-checked'))).toEqual(['false', 'true'])
+    expect(document.activeElement).toBe(radios[1])
+
+    await act(async () => {
+      radios[1].dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true })
+      )
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(radios.map((radio) => radio.getAttribute('aria-checked'))).toEqual(['true', 'false'])
+    expect(document.activeElement).toBe(radios[0])
+  })
+
   it('shows "Directory could not be accessed." when the grant is rejected', async () => {
     grantRoot.mockRejectedValue(new Error('Directory is outside the granted scope.'))
     renderDialog()

--- a/src/renderer/src/pages/workspace/GrantFolderAccessDialog.tsx
+++ b/src/renderer/src/pages/workspace/GrantFolderAccessDialog.tsx
@@ -3,7 +3,7 @@
 // level, and grants the current folder. The breadcrumb bar doubles as a path field (click its
 // empty area to type a path), and its leading drive crumb opens a drive/volume switcher.
 import { ChevronDown, CircleAlert, Folder, Home, Info, X } from 'lucide-react'
-import { Dialog } from 'radix-ui'
+import { Dialog, RadioGroup } from 'radix-ui'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -50,20 +50,14 @@ type ListingState =
 // One custom-dot radio option for the access-level choice in the footer.
 const AccessRadio = ({
   label,
-  selected,
-  onSelect
+  value,
+  selected
 }: {
   label: string
+  value: GrantedLocalRootAccess
   selected: boolean
-  onSelect: () => void
 }): React.JSX.Element => (
-  <button
-    type="button"
-    role="radio"
-    aria-checked={selected}
-    onClick={onSelect}
-    className="flex items-center gap-1.5 text-[13px] text-text-000"
-  >
+  <RadioGroup.Item value={value} className="flex items-center gap-1.5 text-[13px] text-text-000">
     <span
       className={cn(
         'flex size-3.5 items-center justify-center rounded-full border-[1.5px]',
@@ -74,7 +68,7 @@ const AccessRadio = ({
       {selected ? <span className="size-[7px] rounded-full bg-primary" /> : null}
     </span>
     {label}
-  </button>
+  </RadioGroup.Item>
 )
 
 // The path input that replaces the breadcrumb while editing. Enter or blur submits, Escape
@@ -568,16 +562,16 @@ const GrantFolderAccessDialogContent = ({
             </div>
           ) : null}
           <div className="flex items-center gap-2.5">
-            <AccessRadio
-              label={t('Read-only')}
-              selected={access === 'ro'}
-              onSelect={() => setAccess('ro')}
-            />
-            <AccessRadio
-              label={t('Read & write')}
-              selected={access === 'rw'}
-              onSelect={() => setAccess('rw')}
-            />
+            <RadioGroup.Root
+              aria-label={t('Access level')}
+              value={access}
+              onValueChange={(value) => setAccess(value as GrantedLocalRootAccess)}
+              orientation="horizontal"
+              className="flex items-center gap-2.5"
+            >
+              <AccessRadio label={t('Read-only')} value="ro" selected={access === 'ro'} />
+              <AccessRadio label={t('Read & write')} value="rw" selected={access === 'rw'} />
+            </RadioGroup.Root>
             <span className="flex-1" />
             <Button
               type="button"


### PR DESCRIPTION
## Problem

Grant folder access rendered two standalone ARIA radio buttons without a common radiogroup, roving Tab stop, or horizontal arrow-key model. Screen-reader users lacked group context, and keyboard users had to Tab through both choices.

## Proposed change

- replace the standalone buttons with the existing Radix RadioGroup pattern
- give the group a localized Access level label
- preserve the current visual treatment and controlled ro/rw access state
- add a regression test for group semantics, one Tab stop, focus transfer, and wrapping Left/Right selection

## Scope and non-goals

This change does not add fields, enum values, persistence, dependencies, APIs, or data-model changes. Mouse interaction, grant payloads, and stored access values remain unchanged.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- radio semantics and keyboard behavior, dialog layering, and both renderer consumers -> targeted Vitest set -> 5 files and 212 tests passed
- translated accessible label and catalog contracts -> i18n resource guard within the targeted Vitest set -> passed
- renderer type safety -> npm run typecheck:web -> passed
- linted source and tests -> npm run lint -> passed
- whitespace and patch integrity -> git diff --check -> passed

The affected-test classifier intentionally fails closed to the complete Vitest plan because GrantFolderAccessDialog.interaction.test.tsx has no module owner. The complete portable suite, accessibility coverage, and platform lanes are left to PR CI as the authoritative evidence.

## Review focus

Please focus on the Radix RadioGroup semantics, horizontal wrapping behavior, and confirmation that the existing ro/rw grant state and visual layout remain unchanged.