### PR TITLE
fix(acp): acknowledge prompts after provider admission

### DIFF
--- a/src/main/acp/handler-workflows.test.ts
+++ b/src/main/acp/handler-workflows.test.ts
@@ -81,6 +81,7 @@ const createHarness = (
   saveAsSkillAdmission?: Parameters<typeof createAcpHandlerWorkflows>[5]
 ): {
   workflows: ReturnType<typeof createAcpHandlerWorkflows>
+  startPrompt: ReturnType<typeof vi.fn>
   startContinuation: ReturnType<typeof vi.fn>
   startContinuationWhenDispatchAdmitted: ReturnType<typeof vi.fn>
   hasLiveSession: ReturnType<typeof vi.fn>
@@ -97,6 +98,7 @@ const createHarness = (
   const session = createSession()
   mutate?.(session)
   prepareControlTurn(session)
+  const startPrompt = vi.fn(async (request: unknown) => void request)
   const startContinuation = vi.fn(async (request: unknown) => void request)
   const hasLiveSession = vi.fn(() => true)
   const captureSessionBackend = vi.fn(
@@ -126,7 +128,7 @@ const createHarness = (
       hasLiveSession,
       captureSessionBackend,
       resumeSession: vi.fn(),
-      sendPrompt: vi.fn(),
+      startPrompt,
       getLatestUserPrompt: vi.fn(),
       startContinuation,
       startContinuationWhenDispatchAdmitted
@@ -141,6 +143,7 @@ const createHarness = (
   const frame = graph.frames.find(({ id }) => id === graph.activeFrameId)!
   return {
     workflows,
+    startPrompt,
     startContinuation,
     startContinuationWhenDispatchAdmitted,
     hasLiveSession,
@@ -155,6 +158,35 @@ const createHarness = (
     }
   }
 }
+
+describe('ACP send prompt workflow', () => {
+  it('returns the current snapshot after provider admission', async () => {
+    const harness = createHarness()
+
+    await expect(
+      harness.workflows.sendPrompt({ sessionId: 'session-1', text: 'Research this.' })
+    ).resolves.toEqual({ status: 'connected' })
+
+    expect(harness.startPrompt).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      text: 'Research this.'
+    })
+  })
+
+  it('rolls back notification tracking when provider admission fails', async () => {
+    const trackPrompt = vi.fn(() => ({ token: 9 }))
+    const untrackPrompt = vi.fn()
+    const harness = createHarness(undefined, undefined, { trackPrompt, untrackPrompt })
+    const failure = new Error('Provider rejected prompt admission')
+    harness.startPrompt.mockRejectedValueOnce(failure)
+
+    await expect(
+      harness.workflows.sendPrompt({ sessionId: 'session-1', text: 'Research this.' })
+    ).rejects.toBe(failure)
+
+    expect(untrackPrompt).toHaveBeenCalledWith('session-1', { token: 9 })
+  })
+})
 
 describe('ACP Save as skill workflow', () => {
   it('dispatches through the Session admission already held by the workflow', async () => {

--- a/src/main/acp/handler-workflows.ts
+++ b/src/main/acp/handler-workflows.ts
@@ -43,7 +43,7 @@ type AcpHandlerWorkflowRuntime = {
   hasLiveSession(projectId: string, sessionId: string): boolean
   captureSessionBackend(sessionId: string): AcpBackendGenerationView | undefined
   resumeSession(request: AcpResumeSessionRequest): Promise<AcpCreateSessionResponse>
-  sendPrompt(request: AcpPromptRequest): Promise<unknown>
+  startPrompt(request: AcpPromptRequest): Promise<void>
   getLatestUserPrompt(sessionId: string, promptMessageId: string): AcpPromptRequest | undefined
   startContinuation(request: AcpPromptRequest): Promise<void>
   startContinuationWhenDispatchAdmitted(
@@ -379,7 +379,7 @@ const createAcpHandlerWorkflows = (
     // back only its own token, preserving any older in-flight prompt tracked for the same Session.
     const tracked = taskNotifications?.trackPrompt(request)
     try {
-      await runtime.sendPrompt(request)
+      await runtime.startPrompt(request)
     } catch (error) {
       if (tracked) taskNotifications?.untrackPrompt(request.sessionId, tracked)
       throw error

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -80,7 +80,13 @@ const {
         options.callbacks?.onProviderPromptAccepted?.(request.sessionId, promptAttemptId)
         return prompting
       },
-      sendPrompt,
+      sendPrompt: (request, promptAttemptId) => {
+        const prompting = sendPrompt(request, promptAttemptId)
+        return Promise.resolve(prompting).then((result) => {
+          options.callbacks?.onProviderPromptAccepted?.(request.sessionId, promptAttemptId)
+          return result
+        })
+      },
       getSnapshot: vi.fn().mockReturnValue({
         status: 'idle',
         cwd: '/workspace',

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -618,6 +618,41 @@ describe('AcpRuntimeCoordinator', () => {
     }
   )
 
+  it.each([
+    ['Claude Code', 'claude-code'],
+    ['OpenCode', 'opencode'],
+    ['Codex Responses', 'codex'],
+    ['Codex bridge', 'codex']
+  ] as const)(
+    'acknowledges a %s user prompt at provider acceptance before turn completion',
+    async (_route, frameworkId) => {
+      const completion = createDeferred<unknown>()
+      let created!: ReturnType<typeof createFakeRuntime>
+      const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+        created = createFakeRuntime({
+          frameworkId,
+          sessionIds: ['session-1'],
+          callbacks,
+          prompt: () => completion.promise
+        })
+        return created.runtime
+      })
+      const session = await coordinator.createSession()
+
+      await expect(
+        coordinator.startPrompt({ sessionId: session.sessionId, text: 'Research this.' })
+      ).resolves.toBeUndefined()
+
+      expect(created.sendPrompt).toHaveBeenCalledOnce()
+      expect(coordinator.getSnapshot().promptInFlightSessionIds).toContain(session.sessionId)
+
+      completion.resolve({ stopReason: 'end_turn' })
+      await vi.waitFor(() =>
+        expect(coordinator.getSnapshot().promptInFlightSessionIds).not.toContain(session.sessionId)
+      )
+    }
+  )
+
   it('does not report provider acceptance when dispatch fails before acceptance', async () => {
     const coordinator = new AcpRuntimeCoordinator(
       (callbacks) =>

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -653,6 +653,23 @@ describe('AcpRuntimeCoordinator', () => {
     }
   )
 
+  it('rejects prompt admission when the turn ends without provider acceptance', async () => {
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) =>
+        createFakeRuntime({
+          frameworkId: 'claude-code',
+          sessionIds: ['session-1'],
+          callbacks,
+          skipProviderPromptAccepted: true
+        }).runtime
+    )
+    const session = await coordinator.createSession()
+
+    await expect(
+      coordinator.startPrompt({ sessionId: session.sessionId, text: 'Research this.' })
+    ).rejects.toThrow('ACP prompt ended before provider acceptance.')
+  })
+
   it('does not report provider acceptance when dispatch fails before acceptance', async () => {
     const coordinator = new AcpRuntimeCoordinator(
       (callbacks) =>

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -704,6 +704,33 @@ class AcpRuntimeCoordinator {
     return this.sendObservedPrompt(request)
   }
 
+  // Interactive prompt dispatch is an admission RPC, while the authoritative turn lifecycle is
+  // streamed through runtime state/events. Settle the RPC as soon as the provider accepts the
+  // prompt so a long-running turn (or its terminal maintenance) does not retain an Electron reply
+  // channel until completion.
+  startPrompt(request: AcpPromptRequest): Promise<void> {
+    let settled = false
+    let resolve!: () => void
+    let reject!: (error: unknown) => void
+    const accepted = new Promise<void>((promiseResolve, promiseReject) => {
+      resolve = promiseResolve
+      reject = promiseReject
+    })
+    const settleAccepted = (): void => {
+      if (settled) return
+      settled = true
+      resolve()
+    }
+    const settleRejected = (error: unknown): void => {
+      if (settled) return
+      settled = true
+      reject(error)
+    }
+
+    void this.sendPromptObserved(request, settleAccepted).then(settleAccepted, settleRejected)
+    return accepted
+  }
+
   sendApplicationPrompt(
     request: AcpPromptRequest,
     attribution: MessageAttribution

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -727,7 +727,10 @@ class AcpRuntimeCoordinator {
       reject(error)
     }
 
-    void this.sendPromptObserved(request, settleAccepted).then(settleAccepted, settleRejected)
+    void this.sendPromptObserved(request, settleAccepted).then(
+      () => settleRejected(new Error('ACP prompt ended before provider acceptance.')),
+      settleRejected
+    )
     return accepted
   }
 


### PR DESCRIPTION
## Problem

The reporter-provided `main.log` shows that the configured DeepSeek route completed multiple turns normally, so this is not a model-compatibility failure. In the failing lifecycle, the provider logged `prompt stopped`, but the original `acp:send-prompt` handler was still unsettled when application shutdown reached backend teardown. The handler then rejected after about 711 seconds, after Electron had lost the renderer reply channel, producing `reply was never sent`.

This can happen when a long interactive turn, or maintenance performed after its terminal stop, keeps the invoke request open while the window exits or reloads. The secondary IPC failure can make a completed or already-terminal turn appear to have failed.

Fixes #1406.

## Proposed change

- Treat interactive prompt dispatch as an admission RPC and acknowledge it only when the provider explicitly accepts the prompt.
- Keep the authoritative prompt execution, session lock, terminal maintenance, and state/event publication running through the existing background lifecycle.
- Preserve synchronous admission failures: rejection or completion before provider acceptance still rejects the RPC and rolls back task-notification tracking.

## Scope and non-goals

- No new data fields, schema changes, enum values, or data-model changes.
- No persistence or migration changes; historical data compatibility is not applicable.
- No user-interface change. This only changes when the existing prompt-dispatch IPC response settles.
- No provider-specific behavior change. Claude Code, OpenCode, Codex Responses, and Codex bridge share the coordinator path covered by this change.
- Automatic compaction and Plan finalization behavior are not changed.

## Acceptance criteria and validation

The following checks ran after the last material edit:

- Interactive prompt admission settles before turn completion on Claude Code, OpenCode, Codex Responses, and Codex bridge; a turn ending without explicit provider acceptance rejects admission; pre-admission notification rollback remains intact -> `npx vitest run src/main/acp/runtime-coordinator.test.ts src/main/acp/handler-workflows.test.ts src/main/acp/ipc.test.ts` -> 161 tests passed.
- Main-process TypeScript contracts remain valid -> `npm run typecheck:node` -> passed.
- Repository lint rules remain valid -> `npm run lint` -> passed.
- Changed files retain repository formatting -> `npx prettier --check src/main/acp/runtime-coordinator.ts src/main/acp/runtime-coordinator.test.ts src/main/acp/handler-workflows.ts src/main/acp/handler-workflows.test.ts src/main/acp/ipc.test.ts` -> passed.
- Patch whitespace is valid -> `git diff --check` -> passed before commit.

Per the issue request, the complete local `npm test` suite was not run. Exact-head PR CI remains authoritative for the complete portable and platform test plan. A packaged Electron replay of the reporter's environment is not covered locally.

## Review focus

- Confirm that the admission promise resolves only from explicit provider acceptance and rejects if the turn ends first.
- Confirm that the detached completion promise remains observed, while the runtime retains prompt ownership and publishes terminal state or late errors through the existing event path.
- Confirm that failures before acceptance still reach the renderer as dispatch failures and roll back notification tracking.
