### PR TITLE
ci(build): raise Vite heap limit for macos-x64 packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,12 @@ on:
           notarization in isolation; release/nightly leave it false so builds stay gated on tests.
         type: boolean
         default: false
+      platform_name:
+        description: >-
+          If set, emit only this matrix name (macos-arm64, macos-x64, linux-x64, or windows-x64).
+          Used by the Nightly macos-x64 packaging dry-run; release/nightly leave it empty.
+        type: string
+        default: ''
 jobs:
   # Run the quality suite once on Apple Silicon beside the native package matrix. The reusable
   # workflow still fails when this job fails, so every caller's publish boundary remains fail closed
@@ -81,6 +87,8 @@ jobs:
     steps:
       - id: set
         shell: bash
+        env:
+          PLATFORM_NAME: ${{ inputs.platform_name }}
         run: |
           # Build each macOS package on its native macOS 26 architecture while Xcode 26 compiles
           # build/icon.icon. Downstream validation uses the same native runner mapping. Windows'
@@ -101,6 +109,13 @@ jobs:
             include=$(jq -c '.' <<<"$mac")
           else
             include=$(jq -c '. + $rest' --argjson rest "$rest" <<<"$mac")
+          fi
+          if [ -n "$PLATFORM_NAME" ]; then
+            include=$(jq -c --arg name "$PLATFORM_NAME" '[.[] | select(.name == $name)]' <<<"$include")
+            if [ "$include" = "[]" ]; then
+              echo "::error::unknown platform_name '$PLATFORM_NAME'"
+              exit 1
+            fi
           fi
           echo "matrix={\"include\":$include}" >> "$GITHUB_OUTPUT"
 
@@ -269,6 +284,9 @@ jobs:
           # Windows remains unsigned until a code-signing certificate is provisioned. Stable macOS
           # jobs consume the explicitly prepared keychain without exposing CSC_LINK to electron-builder.
           CSC_KEYCHAIN: ${{ steps.mac_signing.outputs.keychain }}
+          # macos-26-intel Node 22 x64 defaults to a ~2 GB old-space. The renderer production graph
+          # (~6400 modules) OOMs during emit at that limit. This is a ceiling, not a reservation.
+          NODE_OPTIONS: --max-old-space-size=8192
         run: |
           npm run build:e2e
           npm run build:web

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,7 @@ on:
         options:
           - full
           - runtime-source
+          - macos-x64
 
 # Build and publication preparation run without write access. Only the separate workflow_run
 # publisher receives contents:write, and it never checks out or executes the triggering revision.
@@ -53,19 +54,24 @@ jobs:
     secrets: inherit
     with:
       nightly: true
+      # A manual `macos-x64` dispatch runs only the Intel packaging job (the heap-sensitive Vite
+      # renderer build) and skips verify. Smoke, certification, and publish stay skipped below.
+      skip_verify: ${{ inputs.dry_run == 'macos-x64' }}
+      platform_name: ${{ inputs.dry_run == 'macos-x64' && 'macos-x64' || '' }}
 
   # Scheduled coverage remains advisory during burn-in and is deliberately absent from prepare.needs.
   # A manual `runtime-source` dispatch runs this exact reusable job as a blocking focused dry-run while
   # build/package/publish preparation stay skipped.
   runtime-certification:
     needs: plan
-    if: needs.plan.outputs.should_build == 'true'
+    if: needs.plan.outputs.should_build == 'true' && inputs.dry_run != 'macos-x64'
     uses: ./.github/workflows/runtime-certification.yml
     with:
       allow_failure: ${{ github.event_name != 'workflow_dispatch' }}
 
   package-smoke:
     needs: build
+    if: inputs.dry_run != 'macos-x64'
     uses: ./.github/workflows/package-smoke.yml
 
   # Run advisory desktop behavior checks inside the same read-only Nightly run. Failures remain

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -100,12 +100,25 @@ describe('release and scheduled workflow topology', () => {
       needs: 'plan',
       if: "needs.plan.outputs.should_build == 'true' && inputs.dry_run != 'runtime-source'",
       uses: './.github/workflows/build.yml',
-      with: { nightly: true }
+      with: {
+        nightly: true,
+        skip_verify: "${{ inputs.dry_run == 'macos-x64' }}",
+        platform_name: "${{ inputs.dry_run == 'macos-x64' && 'macos-x64' || '' }}"
+      }
     })
     expect(step(nightly.jobs.plan, 'Compare main with the rolling nightly tag').run).toContain(
       'repos/$GITHUB_REPOSITORY/commits/nightly'
     )
     expect(nightly.jobs).not.toHaveProperty('publish-dry-run')
+    const dispatch = nightly.on?.workflow_dispatch as {
+      inputs?: { dry_run?: { default?: string; options?: string[] } }
+    }
+    expect(dispatch.inputs?.dry_run).toMatchObject({
+      default: 'full',
+      options: ['full', 'runtime-source', 'macos-x64']
+    })
+    expect(nightly.jobs['package-smoke'].if).toBe("inputs.dry_run != 'macos-x64'")
+    expect(nightly.jobs['runtime-certification'].if).toContain("inputs.dry_run != 'macos-x64'")
     expect(prepare).toMatchObject({
       needs: ['plan', 'build', 'package-smoke'],
       if: "needs.build.result == 'success' && needs.package-smoke.result == 'success'",

--- a/scripts/ci/runtime-certification-workflow.test.ts
+++ b/scripts/ci/runtime-certification-workflow.test.ts
@@ -108,12 +108,12 @@ describe('runtime certification workflow', () => {
 
     expect(dispatch.inputs?.dry_run).toMatchObject({
       default: 'full',
-      options: ['full', 'runtime-source']
+      options: ['full', 'runtime-source', 'macos-x64']
     })
     expect(nightly.jobs.build.if).toContain("inputs.dry_run != 'runtime-source'")
     expect(runtime).toMatchObject({
       needs: 'plan',
-      if: "needs.plan.outputs.should_build == 'true'",
+      if: "needs.plan.outputs.should_build == 'true' && inputs.dry_run != 'macos-x64'",
       uses: './.github/workflows/runtime-certification.yml',
       with: { allow_failure: "${{ github.event_name != 'workflow_dispatch' }}" }
     })

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -119,7 +119,8 @@ describe('post-merge Windows validation', () => {
     expect(prepareMacSigning.run).toContain('-k "$keychain_password"')
     expect(prepareMacSigning.run).toContain("grep -q 'Developer ID Application:'")
     expect(packageStep.env).toEqual({
-      CSC_KEYCHAIN: '${{ steps.mac_signing.outputs.keychain }}'
+      CSC_KEYCHAIN: '${{ steps.mac_signing.outputs.keychain }}',
+      NODE_OPTIONS: '--max-old-space-size=8192'
     })
     expect(packageStep.run).toContain(
       'if [ "${{ steps.mac_signing.outputs.enabled }}" = "true" ]; then'
@@ -164,8 +165,13 @@ describe('post-merge Windows validation', () => {
     const finalMacos = findStep(notarize, 'Smoke test final macOS packages')
     const refreshedMacosEvidence = findStep(notarize, 'Refresh macOS certification evidence')
 
+    expect(setup.env).toEqual({ PLATFORM_NAME: '${{ inputs.platform_name }}' })
     expect(setup.run).toContain('"name":"macos-arm64","os":"macos-26"')
     expect(setup.run).toContain('"name":"macos-x64","os":"macos-26-intel"')
+    expect(setup.run).toContain(
+      'include=$(jq -c --arg name "$PLATFORM_NAME" \'[.[] | select(.name == $name)]\' <<<"$include")'
+    )
+    expect(setup.run).toContain("unknown platform_name '$PLATFORM_NAME'")
     expect(build.env?.MACOSX_DEPLOYMENT_TARGET).toBe(
       "${{ matrix.platform == 'mac' && '12.0' || '' }}"
     )
@@ -261,6 +267,7 @@ describe('post-merge Windows validation', () => {
     expect(nightly.jobs.build.uses).toBe('./.github/workflows/build.yml')
     expect(nightly.jobs['package-smoke']).toMatchObject({
       needs: 'build',
+      if: "inputs.dry_run != 'macos-x64'",
       uses: './.github/workflows/package-smoke.yml'
     })
     expect(nightly.jobs.prepare.needs).toEqual(['plan', 'build', 'package-smoke'])
@@ -291,6 +298,7 @@ describe('post-merge Windows validation', () => {
 
     expect(verifyTypecheck.run).toBe('npm run typecheck')
     expect(verifyTypecheck.env).toEqual({ NODE_OPTIONS: '--max-old-space-size=4096' })
+    expect(build.env).toMatchObject({ NODE_OPTIONS: '--max-old-space-size=8192' })
     expect(commands).toContain('npm run build:e2e')
     expect(commands).toContain('npm run build:web')
     expect(commands).not.toContain('npm run build')


### PR DESCRIPTION
## Problem

Scheduled Nightly failed on `main` at [Build macos-x64](https://github.com/aipoch/open-science/actions/runs/32206553111/job/95930871271) (`macos-26-intel`).

`npm run build:e2e` completed the main and preload Vite graphs, then OOM'd while emitting the renderer production graph (~6387 modules):

```text
Scavenge (reduce) 1925.1 (2011.9) -> 1925.1 (2012.2) MB
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

Node 22 on that Intel runner defaults to a ~2 GB old-space. The same commit packaged successfully on `macos-arm64`, Linux, and Windows. The failure has recurred on recent Nightly Intel jobs.

## Proposed change

- Set `NODE_OPTIONS=--max-old-space-size=8192` on the shared `Build & package` step. This is a heap ceiling, not a reservation; Apple Silicon runners (7 GB) keep using only what the build needs.
- Add a Nightly `workflow_dispatch` dry-run option `macos-x64` that reuses `build.yml` for only the Intel packaging job and skips verify, package-smoke, runtime certification, and publish preparation.

## Scope and non-goals

- CI packaging memory only. No product, protocol, or renderer behavior change.
- Does not split the electron-vite main/preload/renderer graphs into separate processes.
- Does not change PR Gate or desktop-regression `build:e2e` jobs (those run on `macos-14` ARM and were not the failing lane).

## Compatibility notes

- **Historical data:** none. No persisted formats or migrations change.
- **New enum / state values:** none. The new Nightly dry-run value is a CI dispatch input, not an application state.
- **Data persistence:** none.

## Acceptance criteria and validation

- Nightly `Build macos-x64` completes `electron-vite build` without a V8 heap OOM.
- Scheduled Nightly still builds the full platform matrix and still gates publish on verify + package-smoke.
- Manual `dry_run=macos-x64` builds only Intel, skips verify/smoke/publish, and has no release side effects.

### Test Impact Set (ran after the last material edit)

| Behavior | Command | Result |
| --- | --- | --- |
| Release/Nightly topology, including the new dry-run wiring | `npm test -- scripts/ci/release-workflows.test.ts` | pass |
| Runtime-certification dry-run contract | `npm test -- scripts/ci/runtime-certification-workflow.test.ts` | pass |
| Package-step env, matrix filter, and Nightly smoke skip | `npm test -- scripts/windows-release-workflows.test.ts` | pass |
| Lint of the three contract test files | `npx eslint scripts/windows-release-workflows.test.ts scripts/ci/release-workflows.test.ts scripts/ci/runtime-certification-workflow.test.ts` | pass |

PR Gate remains the authority for the portable suite. After this PR is open, Nightly will be dispatched on this branch with `dry_run=macos-x64` to exercise the real `macos-26-intel` packaging job.

Excluded: local `npm test` of the full portable suite (workflow YAML + contract tests only); local `electron-vite` on Intel hardware (not available). Uncovered risk: if renderer emit grows past ~8 GB later, this ceiling will need another increase or a split Vite build.

## Review focus

- `NODE_OPTIONS` on `Build & package` is the actual fix; 8192 is a ceiling.
- `platform_name` is empty on scheduled Nightly/Release, so the matrix is unchanged unless the new dry-run is selected.
- `package-smoke` / `runtime-certification` / `prepare` stay skipped for `macos-x64` so the dry-run cannot publish.