### PR TITLE
ci(signpath): add Windows signing dry-run

### DIFF
--- a/.github/workflows/signpath-test.yml
+++ b/.github/workflows/signpath-test.yml
@@ -1,0 +1,100 @@
+name: SignPath Windows (dry-run)
+
+# Manual, no-publish Windows Authenticode integration check.
+#
+# Reuses the release build workflow for Windows x64 only, extracts exactly one NSIS setup EXE from
+# its immutable build artifact, and submits that raw PE file to SignPath's test-signing policy. The
+# signed installer is retained as a run artifact for inspection. This workflow never creates or
+# modifies a GitHub Release and does not change the release/nightly publishing path.
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: signpath-windows-dry-run-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      platform_name: windows-x64
+      skip_verify: true
+
+  sign-installer:
+    name: Sign Windows installer with SignPath test certificate
+    needs: build
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Download Windows build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: windows-x64
+          path: unsigned
+
+      - name: Select unsigned NSIS installer
+        id: installer
+        shell: pwsh
+        run: |
+          $installers = @(Get-ChildItem -Path unsigned -Filter '*-win-x64-setup.exe' -File -Recurse)
+          if ($installers.Count -ne 1) {
+            Write-Error "Expected exactly one Windows setup EXE, found $($installers.Count)."
+            exit 1
+          }
+          "path=$($installers[0].FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      # SignPath's artifact configuration is a raw <pe-file>. upload-artifact@v7's archive:false
+      # keeps the GitHub artifact as the EXE instead of wrapping it in the default ZIP container.
+      - name: Upload raw installer for SignPath
+        id: upload-unsigned-installer
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          path: ${{ steps.installer.outputs.path }}
+          archive: false
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Submit SignPath test signing request
+        uses: signpath/github-action-submit-signing-request@c92b958760219087e01f8d67a1669ed57afe2627 # v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: open-science
+          signing-policy-slug: test-signing
+          artifact-configuration-slug: windows-installer
+          github-artifact-id: ${{ steps.upload-unsigned-installer.outputs.artifact-id }}
+          skip-decompress: true
+          wait-for-completion: true
+          wait-for-completion-timeout-in-seconds: 900
+          output-artifact-directory: ${{ runner.temp }}/signpath-signed
+
+      - name: Verify Authenticode signature was added
+        id: signed-installer
+        shell: pwsh
+        run: |
+          $installers = @(Get-ChildItem -Path '${{ runner.temp }}/signpath-signed' -Filter '*.exe' -File -Recurse)
+          if ($installers.Count -ne 1) {
+            Write-Error "Expected exactly one signed EXE, found $($installers.Count)."
+            exit 1
+          }
+          $signature = Get-AuthenticodeSignature -FilePath $installers[0].FullName
+          $acceptableStatuses = @('Valid', 'NotTrusted')
+          if ($null -eq $signature.SignerCertificate -or $signature.Status.ToString() -notin $acceptableStatuses) {
+            Write-Error "SignPath returned an unacceptable Authenticode status: $($signature.Status)."
+            exit 1
+          }
+          Write-Host "Signature status: $($signature.Status)"
+          Write-Host "Signer: $($signature.SignerCertificate.Subject)"
+          "path=$($installers[0].FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Upload signed installer
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: signpath-test-windows-x64
+          path: ${{ steps.signed-installer.outputs.path }}
+          retention-days: 7
+          if-no-files-found: error

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -37,7 +37,9 @@ type Workflow = {
     push?: { branches?: string[]; tags?: string[] }
     schedule?: Array<{ cron: string }>
     workflow_run?: { workflows?: string[]; types?: string[] }
-    workflow_call?: unknown
+    workflow_call?: {
+      inputs?: Record<string, { default?: unknown; description?: string; type?: string }>
+    }
     workflow_dispatch?: unknown
   }
 }
@@ -142,6 +144,54 @@ describe('post-merge Windows validation', () => {
     )
     expect(packageStep.run).toContain('unsigned_args=(-c.dmg.sign=false)')
     expect(packageStep.run).not.toContain('publisherName')
+  })
+
+  it('provides an isolated Windows-only SignPath dry-run', () => {
+    const build = readWorkflow('build.yml')
+    const inputs = build.on?.workflow_call?.inputs
+    const workflow = readWorkflow('signpath-test.yml')
+    const sign = workflow.jobs['sign-installer']
+    const uploadUnsigned = findStep(sign, 'Upload raw installer for SignPath')
+    const submit = findStep(sign, 'Submit SignPath test signing request')
+    const verify = findStep(sign, 'Verify Authenticode signature was added')
+    const uploadSigned = findStep(sign, 'Upload signed installer')
+
+    expect(inputs?.platform_name).toMatchObject({ type: 'string', default: '' })
+    expect(workflow.on).toEqual({ workflow_dispatch: null })
+    expect(workflow).toMatchObject({ permissions: { actions: 'read', contents: 'read' } })
+    expect(workflow.jobs.build).toMatchObject({
+      uses: './.github/workflows/build.yml',
+      with: { platform_name: 'windows-x64', skip_verify: true }
+    })
+    expect(sign).toMatchObject({ needs: 'build', 'runs-on': 'windows-latest' })
+    expect(findStep(sign, 'Select unsigned NSIS installer').run).toContain('*-win-x64-setup.exe')
+    expect(uploadUnsigned).toMatchObject({
+      id: 'upload-unsigned-installer',
+      uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a',
+      with: expect.objectContaining({ archive: false, 'if-no-files-found': 'error' })
+    })
+    expect(submit).toMatchObject({
+      uses: 'signpath/github-action-submit-signing-request@c92b958760219087e01f8d67a1669ed57afe2627',
+      with: expect.objectContaining({
+        'api-token': '${{ secrets.SIGNPATH_API_TOKEN }}',
+        'organization-id': '${{ vars.SIGNPATH_ORGANIZATION_ID }}',
+        'project-slug': 'open-science',
+        'signing-policy-slug': 'test-signing',
+        'artifact-configuration-slug': 'windows-installer',
+        'github-artifact-id': '${{ steps.upload-unsigned-installer.outputs.artifact-id }}',
+        'skip-decompress': true,
+        'wait-for-completion': true
+      })
+    })
+    expect(verify.run).toContain('Get-AuthenticodeSignature')
+    expect(verify.run).toContain("$acceptableStatuses = @('Valid', 'NotTrusted')")
+    expect(verify.run).toContain('$signature.Status.ToString() -notin $acceptableStatuses')
+    expect(uploadSigned.with).toMatchObject({
+      name: 'signpath-test-windows-x64',
+      'retention-days': 7,
+      'if-no-files-found': 'error'
+    })
+    expect(workflow.jobs).not.toHaveProperty('publish')
   })
 
   it('separates immutable builds from blocking package smoke and advisory regressions', () => {
@@ -530,6 +580,7 @@ if ($artifactReservationBase -eq $artifactReservationCommit) {
       'notarize-mac.yml',
       'package-smoke.yml',
       'release.yml',
+      'signpath-test.yml',
       'mirror-to-website.yml',
       'windows-upgrade-smoke.yml'
     ]) {


### PR DESCRIPTION
## Problem

The project has a working SignPath test certificate and raw PE artifact configuration, but the repository has no isolated GitHub Actions path that builds and submits the Windows installer for test signing.

## Proposed change

- Add a manual, read-only `signpath-test.yml` workflow that reuses the existing `platform_name: windows-x64` focused build, submits the raw NSIS setup EXE to SignPath's `test-signing` policy, verifies that Authenticode was added, and retains the signed installer.
- Add structural tests for the focused build matrix and signing contract.

## Scope and non-goals

This is an isolated integration dry-run. It does not change release or nightly publishing, does not replace update metadata or blockmaps, and signs only the outer NSIS setup EXE. Signing embedded executables such as micromamba remains a separate production-signing decision.

## Acceptance criteria and validation

Final evidence after the last material edit:

- Windows-only matrix and SignPath workflow contract -> `npm test -- scripts/windows-release-workflows.test.ts` -> 12/12 passed.
- New workflow syntax and expressions -> `actionlint .github/workflows/signpath-test.yml` -> passed.
- Changed-file formatting -> focused `prettier --check` -> passed.
- Patch whitespace -> `git diff --check` -> passed before commit.

Per maintainer direction, the complete local `npm test` suite was not run. PR Gate is authoritative for the full portable and platform-aware plan. The external SignPath request cannot be exercised until the workflow exists on the default branch and the repository token/organization variable are configured.

## Review focus

- Confirm that the existing SignPath slugs are `open-science`, `test-signing`, and `windows-installer`.
- Confirm that `archive: false` plus `skip-decompress: true` preserves the raw EXE contract.
- Confirm that the test-certificate check should accept only `Valid` or `NotTrusted` and reject every other Authenticode status.
