### PR TITLE
perf(agent-context): reduce connector round trips

### DIFF
--- a/src/main/connectors/skill-doc.test.ts
+++ b/src/main/connectors/skill-doc.test.ts
@@ -148,6 +148,16 @@ describe('renderSkillDoc', () => {
     expect(md).toMatch(/instead of running the call again/)
     expect(md).toMatch(/never re-(issue|call)/i)
   })
+  it('keeps planned connector work in fewer model round trips and bounds returned context', () => {
+    const baseline = renderConnectorInstructions(['mcp-pubmed'])
+    const skill = renderSkillDoc('pubmed')
+
+    for (const md of [baseline, skill]) {
+      expect(md).toMatch(/independent.*same `repl_execute`/i)
+      expect(md).toMatch(/keep large results.*globalThis/i)
+      expect(md).toMatch(/compact summary/i)
+    }
+  })
   it('gives custom MCP servers the same reuse guidance', () => {
     // Custom servers do not always receive the bundled connector baseline, so their compact Skill
     // still carries the minimum persistence rule without copying the full shared conventions.
@@ -159,6 +169,9 @@ describe('renderSkillDoc', () => {
     expect(md).toMatch(/instead of running the call again/)
     expect(md).toContain('Do not bypass `host.mcp` with raw HTTP')
     expect(md).toContain('approval')
+    expect(md).toMatch(/independent.*same `repl_execute`/i)
+    expect(md).toMatch(/keep large results.*globalThis/i)
+    expect(md).toMatch(/compact summary/i)
   })
 
   it('directs custom connector authentication failures to a listed login tool', () => {

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -5,6 +5,8 @@ const CONVENTIONS = [
   'Reach this service ONLY from the REPL control-plane kernel: call it inside the `repl_execute` tool as `const result = await host.mcp(server, method, {...})`. host.mcp is async — always `await` it. The python and r DATA cells have NO connector access; do not call host.mcp (or urllib / requests / fetch) from them — it will fail.',
   "The result is a ready-to-use native JavaScript value — an object or array for most tools, sometimes a string or number. It is already parsed (not a JSON string). Each tool's **Returns** block gives its exact shape and field meanings; how you inspect or process it is up to you.",
   'The REPL is a persistent session: assign a result you will reuse to `globalThis` (e.g. `globalThis.hits = result`) so later `repl_execute` calls can see it, instead of running the call again. Each call hits the rate-limited upstream — never re-issue the same call to look at or reprocess a result you already have.',
+  'When independent calls are known, run them in the same `repl_execute` (sequentially unless parallel execution is safe) to avoid model round trips.',
+  'Keep large results on `globalThis`; return only the compact summary needed for reasoning, not full arrays or documents.',
   'Do NOT reimplement these calls with raw HTTP (urllib / requests / httpx / fetch) or hit the upstream endpoints directly — that bypasses the approval gate, per-tool policy, credentials, and rate limits, and can leak project data.',
   'Prefer bulk/list tools over per-item loops — the upstream API is rate-limited and shared across subagents.',
   'To use a result in a python or r cell, have the REPL write it under `process.env.OPEN_SCIENCE_HANDOFF_DIR`, then read the same `OPEN_SCIENCE_HANDOFF_DIR` path from the data cell — not through the model context or a cwd-relative handoff path.'
@@ -13,7 +15,7 @@ const CONVENTIONS = [
 // A Skill may be loaded outside the bundled-connector baseline (notably for custom MCP servers), so
 // keep the minimum calling and reuse contract local without copying the full shared policy block.
 const SKILL_CONVENTIONS =
-  'Use from `repl_execute` as `const result = await host.mcp(server, method, {...})`. Results are native JavaScript in a persistent REPL; save reusable values on `globalThis` instead of running the call again, and never re-issue the same upstream call.'
+  'Use from `repl_execute` as `const result = await host.mcp(server, method, {...})`. Results are native JavaScript in a persistent REPL; save reusable values on `globalThis` instead of running the call again, and never re-issue the same upstream call. When independent calls are known, run them in the same `repl_execute` (sequentially unless parallel execution is safe) to avoid model round trips. Keep large results on `globalThis`; return only the compact summary needed for reasoning, not full arrays or documents.'
 
 const CUSTOM_SKILL_CONVENTIONS =
   `${SKILL_CONVENTIONS} Do not bypass \`host.mcp\` with raw HTTP or calls from Python/R: ` +

--- a/src/main/connectors/skill-doc.ts
+++ b/src/main/connectors/skill-doc.ts
@@ -2,14 +2,14 @@ import { CONNECTOR_CATALOG } from './catalog'
 import { getConnectorTools } from './registry'
 
 const CONVENTIONS = [
-  'Reach this service ONLY from the REPL control-plane kernel: call it inside the `repl_execute` tool as `const result = await host.mcp(server, method, {...})`. host.mcp is async — always `await` it. The python and r DATA cells have NO connector access; do not call host.mcp (or urllib / requests / fetch) from them — it will fail.',
-  "The result is a ready-to-use native JavaScript value — an object or array for most tools, sometimes a string or number. It is already parsed (not a JSON string). Each tool's **Returns** block gives its exact shape and field meanings; how you inspect or process it is up to you.",
-  'The REPL is a persistent session: assign a result you will reuse to `globalThis` (e.g. `globalThis.hits = result`) so later `repl_execute` calls can see it, instead of running the call again. Each call hits the rate-limited upstream — never re-issue the same call to look at or reprocess a result you already have.',
+  'Reach this service ONLY from the REPL control-plane kernel: inside `repl_execute`, use `const result = await host.mcp(server, method, {...})`. Python/R cells cannot call host.mcp or network clients.',
+  "Results are parsed native JavaScript values. Each tool's **Returns** block defines the shape.",
+  'The REPL persists. Keep large results and reusable values on `globalThis`; never repeat an upstream call to inspect or process it.',
   'When independent calls are known, run them in the same `repl_execute` (sequentially unless parallel execution is safe) to avoid model round trips.',
-  'Keep large results on `globalThis`; return only the compact summary needed for reasoning, not full arrays or documents.',
-  'Do NOT reimplement these calls with raw HTTP (urllib / requests / httpx / fetch) or hit the upstream endpoints directly — that bypasses the approval gate, per-tool policy, credentials, and rate limits, and can leak project data.',
-  'Prefer bulk/list tools over per-item loops — the upstream API is rate-limited and shared across subagents.',
-  'To use a result in a python or r cell, have the REPL write it under `process.env.OPEN_SCIENCE_HANDOFF_DIR`, then read the same `OPEN_SCIENCE_HANDOFF_DIR` path from the data cell — not through the model context or a cwd-relative handoff path.'
+  'Return only the compact summary needed for reasoning, not full arrays or documents.',
+  'Do NOT reimplement calls with raw HTTP (urllib / requests / httpx / fetch): it bypasses approval, policy, credentials, and rate limits.',
+  'Prefer bulk/list tools over per-item loops.',
+  'For Python/R, write results under `process.env.OPEN_SCIENCE_HANDOFF_DIR` in the REPL, then read that path from the data cell, not through model context or a cwd-relative path.'
 ].join('\n')
 
 // A Skill may be loaded outside the bundled-connector baseline (notably for custom MCP servers), so

--- a/src/main/settings/native-responses-compatibility.test.ts
+++ b/src/main/settings/native-responses-compatibility.test.ts
@@ -874,6 +874,8 @@ describe('native Responses compatibility', () => {
 
   it('logs a privacy-safe lifecycle that distinguishes an upstream 502', async () => {
     const privatePrompt = 'private medical prompt'
+    const privateInstructions = 'private medical instructions'
+    const privateToolName = 'private_medical_tool'
     const privateUpstreamDetail = 'private gateway diagnostic'
     const proxy = new NativeResponsesCompatibilityProxy(
       {
@@ -896,7 +898,19 @@ describe('native Responses compatibility', () => {
           authorization: `Bearer ${connection.token}`,
           'content-type': 'application/json'
         },
-        body: JSON.stringify({ model: 'deepseek-v4-flash', input: privatePrompt })
+        body: JSON.stringify({
+          model: 'deepseek-v4-flash',
+          prompt_cache_key: 'private-cache-key',
+          instructions: privateInstructions,
+          input: [{ type: 'message', role: 'user', content: privatePrompt }],
+          tools: [
+            {
+              type: 'function',
+              name: privateToolName,
+              parameters: { type: 'object' }
+            }
+          ]
+        })
       })
       expect(response.status).toBe(502)
       await response.text()
@@ -910,7 +924,18 @@ describe('native Responses compatibility', () => {
       const completed = logSpies.info.mock.calls.find(
         ([message]) => message === 'native Responses compatibility request completed'
       )
-      expect(received?.[1]).toMatchObject({ requestId: expect.any(String) })
+      expect(received?.[1]).toMatchObject({
+        requestId: expect.any(String),
+        requestBytes: expect.any(Number),
+        inputBytes: expect.any(Number),
+        inputItemCount: 1,
+        instructionTextBytes: expect.any(Number),
+        toolDefinitionCount: 1,
+        promptCacheKeyPresent: true
+      })
+      expect(received?.[1]?.requestBytes).toBeGreaterThan(0)
+      expect(received?.[1]?.inputBytes).toBeGreaterThan(0)
+      expect(received?.[1]?.instructionTextBytes).toBeGreaterThan(0)
       expect(upstream?.[1]).toMatchObject({
         requestId: received?.[1]?.requestId,
         status: 502,
@@ -924,6 +949,9 @@ describe('native Responses compatibility', () => {
       })
       const serialized = JSON.stringify(Object.values(logSpies).flatMap((spy) => spy.mock.calls))
       expect(serialized).not.toContain(privatePrompt)
+      expect(serialized).not.toContain(privateInstructions)
+      expect(serialized).not.toContain(privateToolName)
+      expect(serialized).not.toContain('private-cache-key')
       expect(serialized).not.toContain(privateUpstreamDetail)
       expect(serialized).not.toContain('private-api-key')
       expect(serialized).not.toContain(connection.token)

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -589,8 +589,38 @@ export class NativeResponsesCompatibilityProxy {
         ? { ...scopedBody, model: this.target.model }
         : scopedBody
       const { request: upstreamRequest, aliases } = flattenNativeResponsesRequest(routedBody)
+      const upstreamRequestBody = JSON.stringify(upstreamRequest)
+      const requestBytes = Buffer.byteLength(upstreamRequestBody, 'utf8')
+      // Derive the input size from the already-serialized body so a large multimodal input is not
+      // serialized a second time just for diagnostics. The subtracted 8/9 bytes are the JSON key and
+      // optional comma around the removed `input` field.
+      const { input: upstreamInput, ...upstreamRequestWithoutInput } = upstreamRequest
+      const inputBytes =
+        upstreamInput === undefined
+          ? 0
+          : Math.max(
+              0,
+              requestBytes -
+                Buffer.byteLength(JSON.stringify(upstreamRequestWithoutInput), 'utf8') -
+                (Object.keys(upstreamRequestWithoutInput).length > 0 ? 9 : 8)
+            )
       log.info('native Responses compatibility request', {
         requestId,
+        requestBytes,
+        inputBytes,
+        inputItemCount: Array.isArray(upstreamInput)
+          ? upstreamInput.length
+          : upstreamInput === undefined
+            ? 0
+            : 1,
+        instructionTextBytes:
+          typeof upstreamRequest.instructions === 'string'
+            ? Buffer.byteLength(upstreamRequest.instructions, 'utf8')
+            : 0,
+        toolDefinitionCount: Array.isArray(upstreamRequest.tools)
+          ? upstreamRequest.tools.length
+          : 0,
+        promptCacheKeyPresent: promptCacheKey !== undefined,
         namespaceToolCount: aliases.size,
         stream: body.stream === true,
         reviewerScoped,
@@ -604,7 +634,7 @@ export class NativeResponsesCompatibilityProxy {
       const upstream = await this.fetchImpl(responsesUrl(this.target.baseUrl), {
         method: 'POST',
         headers: upstreamHeaders(request, this.target.key),
-        body: JSON.stringify(upstreamRequest),
+        body: upstreamRequestBody,
         signal: AbortSignal.any([request.signal, upstreamAbort.signal])
       })
       clearUpstreamTimeout()


### PR DESCRIPTION
## Problem

A Windows 0.17.0 research run through a GPT-5.5 Responses relay made 30 model requests in about 14 minutes, including 20 separate `repl_execute` connector calls. Upstream time to first response had a 5.9 s median, 7.5 s mean, and 22.3 s maximum. The run was stopped at roughly 30% context usage.

Generated connector guidance explained result reuse and bulk tools, but did not tell agents to group already-known independent calls into one REPL invocation or keep large connector results out of model-visible output. Existing compatibility logs also could not distinguish actual request growth from provider usage reporting.

## Proposed change

- Tell shared, bundled, and custom connector Skills to group known independent calls in one `repl_execute` and keep large results on `globalThis`, returning only a compact summary needed for reasoning.
- Add privacy-safe native Responses diagnostics for total request bytes, input bytes/items, instruction text bytes, tool count, and prompt-cache-key presence.
- Reuse the serialized upstream request body and derive input size without serializing potentially large multimodal input twice.

## Scope and non-goals

- Does not change provider request or response protocol fields, context usage semantics, model selection, permissions, or automatic Skill selection.
- Does not attempt to hide or compensate for the relay's measured upstream latency.
- Does not change persisted data, migrations, historical compatibility, or state enums.

Compatibility impact:

- Connector guidance is shared by Claude Code, OpenCode, and Codex projections.
- Request diagnostics affect only the Codex native Responses compatibility path (`codex-response`).
- The Chat bridge (`codex-bridge`), Claude Code provider protocol, OpenCode provider protocol, subscription routing, reviewer scopes, lifecycle ordering, and Windows path behavior are unchanged.

## Acceptance criteria and validation

Checks below ran after the last material edit:

- Connector batching and bounded model-visible output -> `npm test -- src/main/connectors/skill-doc.test.ts src/main/connectors/provision.test.ts src/main/connectors/custom-skill-doc.test.ts` -> 38 passed.
- Native Responses forwarding, privacy-safe diagnostics, and framework/provider consumers -> `npm run test:module -- settings_backend_resolution` -> 481 passed, 3 skipped.
- Node process types -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed.

The affected-test planner selects the full suite because `src/main/connectors/skill-doc.test.ts` has no declared module owner. Per maintainer direction, the full local `npm test` was not run; exact-head PR Gate remains authoritative for the complete portable and platform suites.

## Review focus

- Whether the generated wording is strong enough to reduce model round trips without encouraging unsafe parallel pressure on rate-limited services.
- Whether the diagnostic fields are sufficient to attribute future context growth while remaining content-free.

Uncovered risk: instruction changes are deterministic at the generated-document seam, but live batching behavior remains model-dependent and was not validated against the reported third-party GPT-5.5 relay.
