### PR TITLE
feat(tags): add direct unlinking and navigation

### DIFF
--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -3001,6 +3001,8 @@
   "Search Tags": "タグを検索",
   "Create “{{name}}”": "「{{name}}」を作成",
   "Could not update Tags.": "タグを更新できませんでした。",
+  "Remove {{tag}} from this resource": "このリソースから「{{tag}}」を削除",
+  "Remove {{resource}} from {{tag}}": "「{{tag}}」から「{{resource}}」を削除",
   "Filter by Tag": "タグで絞り込む",
   "All Tags": "すべてのタグ",
   "All resources": "すべてのリソース",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -3001,6 +3001,8 @@
   "Search Tags": "搜索标签",
   "Create “{{name}}”": "创建“{{name}}”",
   "Could not update Tags.": "无法更新标签。",
+  "Remove {{tag}} from this resource": "从此资源中移除“{{tag}}”",
+  "Remove {{resource}} from {{tag}}": "从“{{tag}}”中移除“{{resource}}”",
   "Filter by Tag": "按标签筛选",
   "All Tags": "所有标签",
   "All resources": "所有资源",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -3001,6 +3001,8 @@
   "Search Tags": "搜尋標籤",
   "Create “{{name}}”": "建立「{{name}}」",
   "Could not update Tags.": "無法更新標籤。",
+  "Remove {{tag}} from this resource": "從此資源中移除「{{tag}}」",
+  "Remove {{resource}} from {{tag}}": "從「{{tag}}」中移除「{{resource}}」",
   "Filter by Tag": "依標籤篩選",
   "All Tags": "所有標籤",
   "All resources": "所有資源",

--- a/src/renderer/src/pages/settings/ConnectorsPanel.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.tsx
@@ -128,9 +128,13 @@ const requiresSignInBeforeEnable = (server: CustomServerView): boolean =>
 
 type ConnectorsPanelProps = {
   onNavigate: (view: ConnectorsView) => void
+  onOpenTag?: (tagId: string) => void
 }
 
-export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX.Element {
+export function ConnectorsPanel({
+  onNavigate,
+  onOpenTag
+}: ConnectorsPanelProps): React.JSX.Element {
   const { t } = useTranslation()
   const { t: tCommon } = useTranslation()
   const connectors = useSettingsStore((state) => state.connectors)
@@ -452,33 +456,40 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
                     className="flex min-h-14 items-center gap-3 py-2.5"
                   >
                     <ConnectorGlyph size={24} />
-                    <button
-                      type="button"
-                      onClick={() => onNavigate({ kind: 'detail', id: connector.id })}
-                      className="min-w-0 flex-1 text-left"
-                    >
-                      <span className="block truncate text-sm text-foreground">
-                        {connector.displayName}
-                      </span>
-                      <span className="block truncate text-xs text-muted-foreground">
-                        {connector.description}
-                      </span>
+                    <div className="min-w-0 flex-1">
+                      <button
+                        type="button"
+                        onClick={() => onNavigate({ kind: 'detail', id: connector.id })}
+                        className="block w-full min-w-0 text-left"
+                      >
+                        <span className="block truncate text-sm text-foreground">
+                          {connector.displayName}
+                        </span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {connector.description}
+                        </span>
+                      </button>
                       <div
                         className="mt-0.5 flex min-w-0 items-center gap-2"
                         data-connector-metadata={connector.id}
                       >
-                        <span className="min-w-0 truncate text-xs text-muted-foreground">
+                        <button
+                          type="button"
+                          onClick={() => onNavigate({ kind: 'detail', id: connector.id })}
+                          className="min-w-0 truncate text-left text-xs text-muted-foreground"
+                        >
                           {usageLabel ? `${usageLabel} · ` : ''}
                           {t(SCOPE_LABEL_KEYS[scope])}
-                        </span>
+                        </button>
                         <ResourceTagBadges
                           reference={{
                             resourceType: 'catalog.connector',
                             resourceId: connector.id
                           }}
+                          onOpenTag={onOpenTag}
                         />
                       </div>
-                    </button>
+                    </div>
                     <div className="flex shrink-0 items-center gap-2">
                       <ResourceTagMenu
                         reference={{ resourceType: 'catalog.connector', resourceId: connector.id }}
@@ -801,6 +812,7 @@ export function ConnectorsPanel({ onNavigate }: ConnectorsPanelProps): React.JSX
                                 resourceType: 'catalog.connector',
                                 resourceId: server.id
                               }}
+                              onOpenTag={onOpenTag}
                             />
                           </div>
                         </div>

--- a/src/renderer/src/pages/settings/ResourceTagControls.tsx
+++ b/src/renderer/src/pages/settings/ResourceTagControls.tsx
@@ -1,4 +1,4 @@
-import { Check, Plus, Search, Tags } from 'lucide-react'
+import { Check, Plus, Search, Tags, X } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -184,13 +184,19 @@ const TagFilter = ({
 
 const ResourceTagBadges = ({
   reference,
-  limit = 2
+  limit = 2,
+  onOpenTag
 }: {
   reference: TagResourceRef
   limit?: number
+  onOpenTag?: (tagId: string) => void
 }): React.JSX.Element => {
+  const { t } = useTranslation()
   const tags = useTagStore((state) => state.tags)
   const assignments = useTagStore((state) => state.assignments)
+  const setAssignment = useTagStore((state) => state.setAssignment)
+  const [removingId, setRemovingId] = useState<string>()
+  const [error, setError] = useState<string>()
   const ids = new Set(
     assignments
       .filter(
@@ -203,38 +209,104 @@ const ResourceTagBadges = ({
   const assigned = tags.filter((tag) => ids.has(tag.id))
   if (assigned.length === 0) return <></>
   const compact = Number.isFinite(limit)
+  const removeTag = async (tagId: string): Promise<void> => {
+    if (removingId) return
+    setRemovingId(tagId)
+    setError(undefined)
+    try {
+      await setAssignment({ ...reference, tagId, assigned: false })
+    } catch {
+      setError(t('Could not update Tags.'))
+    } finally {
+      setRemovingId(undefined)
+    }
+  }
   return (
-    <div
-      className={cn(
-        compact
-          ? 'flex min-w-0 max-w-52 flex-nowrap items-center justify-end gap-1 overflow-hidden'
-          : 'flex flex-wrap items-center gap-1'
-      )}
-    >
-      {assigned.slice(0, limit).map((tag) => (
-        <TagBadge key={tag.id} tag={tag} className={compact ? 'min-w-0 max-w-24' : undefined} />
-      ))}
-      {assigned.length > limit ? (
-        <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
-          +{assigned.length - limit}
+    <>
+      <div
+        className={cn(
+          compact
+            ? 'flex min-w-0 max-w-52 flex-nowrap items-center justify-end gap-1 overflow-hidden'
+            : 'flex flex-wrap items-center gap-1'
+        )}
+      >
+        {assigned.slice(0, limit).map((tag) => {
+          const presentation = tagPresentation(tag, t)
+          const removeLabel = t('Remove {{tag}} from this resource', {
+            tag: presentation.name
+          })
+          const badge = <TagBadge tag={tag} className={compact ? 'min-w-0 max-w-24' : undefined} />
+          return (
+            <span
+              key={tag.id}
+              className={cn('group/tag relative inline-flex min-w-0', compact && 'max-w-24')}
+            >
+              {onOpenTag ? (
+                <button
+                  type="button"
+                  className="min-w-0 rounded-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  onClick={() => onOpenTag(tag.id)}
+                >
+                  {badge}
+                </button>
+              ) : (
+                badge
+              )}
+              <TooltipProvider delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label={removeLabel}
+                      disabled={removingId === tag.id}
+                      className="pointer-events-auto absolute top-1/2 right-1.5 inline-flex size-3.5 -translate-y-1/2 items-center justify-center rounded-full bg-background text-foreground opacity-100 transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none sm:pointer-events-none sm:opacity-0 sm:group-hover/tag:pointer-events-auto sm:group-hover/tag:opacity-100 sm:group-focus-within/tag:pointer-events-auto sm:group-focus-within/tag:opacity-100"
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        void removeTag(tag.id)
+                      }}
+                    >
+                      <X className="size-3" aria-hidden="true" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>{removeLabel}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </span>
+          )
+        })}
+        {assigned.length > limit ? (
+          <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+            +{assigned.length - limit}
+          </span>
+        ) : null}
+      </div>
+      {error ? (
+        <span role="alert" className="shrink-0 text-xs text-destructive">
+          {error}
         </span>
       ) : null}
-    </div>
+    </>
   )
 }
 
 const ResourceTagSummary = ({
   reference,
-  className
+  className,
+  onOpenTag
 }: {
   reference: TagResourceRef
   className?: string
+  onOpenTag?: (tagId: string) => void
 }): React.JSX.Element => {
   const { t } = useTranslation()
   return (
     <div className={cn('flex flex-wrap items-center gap-2', className)}>
       <span className="text-xs font-medium text-muted-foreground">{t('Tags')}</span>
-      <ResourceTagBadges reference={reference} limit={Number.POSITIVE_INFINITY} />
+      <ResourceTagBadges
+        reference={reference}
+        limit={Number.POSITIVE_INFINITY}
+        onOpenTag={onOpenTag}
+      />
       <ResourceTagMenu reference={reference} />
     </div>
   )

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -12,6 +12,7 @@ import { createInitialProjectState, useProjectStore } from '@/stores/project-sto
 import { createInitialSessionState, useSessionStore } from '@/stores/session-store'
 import { useSpecialistStore } from '@/stores/specialist-store'
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+import { createInitialTagState, useTagStore } from '@/stores/tag-store'
 import { SettingsPage, type SettingsPageHandle } from './SettingsPage'
 import { clickRadixMenuItem, openRadixMenu } from './test-utils'
 
@@ -183,6 +184,14 @@ const installApi = (): void => {
       create: vi.fn(),
       setEnabled: vi.fn(),
       onCatalogChanged: vi.fn(() => vi.fn())
+    },
+    tags: {
+      snapshot: vi.fn().mockResolvedValue({
+        revision: 1,
+        tags: [{ id: 'tag-favorite', systemKey: 'favorite', createdAt: 1, updatedAt: 1 }],
+        assignments: []
+      }),
+      onChanged: vi.fn(() => vi.fn())
     }
   }
 }
@@ -192,6 +201,7 @@ beforeEach(() => {
   useSettingsStore.setState(createInitialSettingsState())
   useProjectStore.setState(createInitialProjectState())
   useSessionStore.setState(createInitialSessionState())
+  useTagStore.setState(createInitialTagState())
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -226,6 +236,214 @@ const settingsSection = (title: string): HTMLElement | undefined =>
   )
 
 describe('SettingsPage layout', () => {
+  it('opens a resource Tag through Settings history and returns to the catalog with Back', async () => {
+    vi.mocked(window.api.tags.snapshot).mockResolvedValue({
+      revision: 2,
+      tags: [{ id: 'tag-favorite', systemKey: 'favorite', createdAt: 1, updatedAt: 1 }],
+      assignments: [
+        {
+          tagId: 'tag-favorite',
+          resourceType: 'catalog.skill',
+          resourceId: 'alpha',
+          createdAt: 1
+        }
+      ]
+    })
+
+    await act(async () => root.render(<SettingsPage open onClose={vi.fn()} />))
+    await act(async () => navButton('Skills')?.click())
+
+    const tag = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'Favorites'
+    )
+    expect(tag).toBeDefined()
+    expect(document.body.querySelector('button button')).toBeNull()
+    await act(async () => tag?.click())
+
+    expect(document.body.querySelector('nav [aria-current="page"]')?.textContent?.trim()).toBe(
+      'Tags'
+    )
+    expect(document.body.textContent).toContain('Alpha')
+    expect(document.body.querySelector<HTMLButtonElement>('[aria-label="Back"]')?.disabled).toBe(
+      false
+    )
+
+    await act(async () =>
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Back"]')?.click()
+    )
+    expect(document.body.querySelector('nav [aria-current="page"]')?.textContent?.trim()).toBe(
+      'Skills'
+    )
+  })
+
+  it('restores the Tag selected by a Settings history entry', async () => {
+    vi.mocked(window.api.tags.snapshot).mockResolvedValue({
+      revision: 2,
+      tags: [
+        { id: 'tag-favorite', systemKey: 'favorite', createdAt: 1, updatedAt: 1 },
+        {
+          id: 'tag-research',
+          name: 'Research',
+          iconKey: 'book-open',
+          colorKey: 'purple',
+          createdAt: 2,
+          updatedAt: 2
+        }
+      ],
+      assignments: [
+        {
+          tagId: 'tag-favorite',
+          resourceType: 'catalog.skill',
+          resourceId: 'alpha',
+          createdAt: 1
+        },
+        {
+          tagId: 'tag-research',
+          resourceType: 'catalog.skill',
+          resourceId: 'alpha',
+          createdAt: 2
+        }
+      ]
+    })
+
+    await act(async () => root.render(<SettingsPage open onClose={vi.fn()} />))
+    await act(async () => navButton('Skills')?.click())
+
+    const favorite = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'Favorites'
+    )
+    await act(async () => favorite?.click())
+    await act(async () =>
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Back"]')?.click()
+    )
+    act(() => useTagStore.getState().setBrowserSelectedId('tag-research'))
+    await act(async () =>
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Forward"]')?.click()
+    )
+
+    const selectedTag = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('aside button')
+    ).find((button) => button.getAttribute('aria-current') === 'page')
+    expect(selectedTag?.textContent).toContain('Favorites')
+  })
+
+  it('preserves an in-panel Tag selection when returning from a resource', async () => {
+    vi.mocked(window.api.tags.snapshot).mockResolvedValue({
+      revision: 2,
+      tags: [
+        { id: 'tag-favorite', systemKey: 'favorite', createdAt: 1, updatedAt: 1 },
+        {
+          id: 'tag-research',
+          name: 'Research',
+          iconKey: 'book-open',
+          colorKey: 'purple',
+          createdAt: 2,
+          updatedAt: 2
+        }
+      ],
+      assignments: [
+        {
+          tagId: 'tag-favorite',
+          resourceType: 'catalog.skill',
+          resourceId: 'alpha',
+          createdAt: 1
+        },
+        {
+          tagId: 'tag-research',
+          resourceType: 'catalog.skill',
+          resourceId: 'alpha',
+          createdAt: 2
+        }
+      ]
+    })
+
+    await act(async () => root.render(<SettingsPage open onClose={vi.fn()} />))
+    await act(async () => navButton('Skills')?.click())
+
+    const favorite = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'Favorites'
+    )
+    await act(async () => favorite?.click())
+
+    const research = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('aside button')
+    ).find((button) => button.textContent?.includes('Research'))
+    await act(async () => research?.click())
+
+    const resource = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('aside + section button')
+    ).find((button) => button.textContent?.includes('Alpha'))
+    await act(async () => resource?.click())
+    await act(async () =>
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Back"]')?.click()
+    )
+
+    const selectedTag = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('aside button')
+    ).find((button) => button.getAttribute('aria-current') === 'page')
+    expect(selectedTag?.textContent).toContain('Research')
+  })
+
+  it('records the default Tag in history before navigating through a resource', async () => {
+    vi.mocked(window.api.tags.snapshot).mockResolvedValue({
+      revision: 2,
+      tags: [
+        { id: 'tag-favorite', systemKey: 'favorite', createdAt: 1, updatedAt: 1 },
+        {
+          id: 'tag-research',
+          name: 'Research',
+          iconKey: 'book-open',
+          colorKey: 'purple',
+          createdAt: 2,
+          updatedAt: 2
+        }
+      ],
+      assignments: [
+        {
+          tagId: 'tag-favorite',
+          resourceType: 'catalog.skill',
+          resourceId: 'alpha',
+          createdAt: 1
+        },
+        {
+          tagId: 'tag-research',
+          resourceType: 'catalog.skill',
+          resourceId: 'alpha',
+          createdAt: 2
+        }
+      ]
+    })
+
+    await act(async () => root.render(<SettingsPage open onClose={vi.fn()} />))
+    await act(async () => navButton('Tags')?.click())
+
+    const selectedDefault = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('aside button')
+    ).find((button) => button.getAttribute('aria-current') === 'page')
+    expect(selectedDefault?.textContent).toContain('Favorites')
+
+    const resource = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('aside + section button')
+    ).find((button) => button.textContent?.includes('Alpha'))
+    await act(async () => resource?.click())
+
+    const research = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'Research'
+    )
+    await act(async () => research?.click())
+    await act(async () =>
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Back"]')?.click()
+    )
+    await act(async () =>
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Back"]')?.click()
+    )
+
+    const restoredDefault = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('aside button')
+    ).find((button) => button.getAttribute('aria-current') === 'page')
+    expect(restoredDefault?.textContent).toContain('Favorites')
+  })
+
   it('renders the model-dependent reasoning effort explanation naturally in Japanese', async () => {
     await i18next.changeLanguage('ja')
     try {

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -23,7 +23,7 @@ import {
 } from 'lucide-react'
 import { Dialog } from 'radix-ui'
 import { FocusScope } from '@radix-ui/react-focus-scope'
-import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -236,6 +236,7 @@ type NavLocation = {
   compute?: ComputeView
   specialists?: SpecialistsView
   archived?: ArchivedView
+  tagId?: string
 }
 
 const INITIAL_LOCATION: NavLocation = {
@@ -316,6 +317,8 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
   const specialistItems = useSpecialistStore((state) => state.items)
   const loadTags = useTagStore((state) => state.load)
   const listenForTagChanges = useTagStore((state) => state.listen)
+  const browserSelectedTagId = useTagStore((state) => state.browserSelectedId)
+  const setSelectedTagId = useTagStore((state) => state.setBrowserSelectedId)
   const [formValue, setFormValue] = useState<ProviderFormValue>(() =>
     createEmptyProviderFormValue()
   )
@@ -488,6 +491,12 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
   const canGoBack = historyIndex > 0
   const canGoForward = historyIndex < history.length - 1
 
+  useEffect(() => {
+    if (currentLocation.panel === 'tags' && currentLocation.tagId) {
+      setSelectedTagId(currentLocation.tagId)
+    }
+  }, [currentLocation.panel, currentLocation.tagId, setSelectedTagId])
+
   // Pushes a new location, dropping any forward entries.
   const navigate = (location: NavLocation): void => {
     const nextConnectors = location.connectors ?? { kind: 'list' }
@@ -513,7 +522,8 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
       JSON.stringify(nextSpecialists) === JSON.stringify(specialistsView) &&
       nextArchived.kind === archivedView.kind &&
       ('projectId' in nextArchived ? nextArchived.projectId : undefined) ===
-        ('projectId' in archivedView ? archivedView.projectId : undefined)
+        ('projectId' in archivedView ? archivedView.projectId : undefined) &&
+      location.tagId === currentLocation.tagId
     ) {
       return
     }
@@ -523,7 +533,30 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
 
   // Internal panel transitions must use this dialog's history instead of reseeding an external
   // entry point, so Back returns to the recovery panel the user just completed.
-  const navigatePanel = (panel: SettingsPanelId): void => navigate({ ...INITIAL_LOCATION, panel })
+  const navigatePanel = (panel: SettingsPanelId): void =>
+    navigate({
+      ...INITIAL_LOCATION,
+      panel,
+      tagId: panel === 'tags' ? browserSelectedTagId : undefined
+    })
+
+  const navigateTag = (tagId: string): void => {
+    setSelectedTagId(tagId)
+    navigate({ ...currentLocation, panel: 'tags', tagId })
+  }
+
+  const recordSelectedTag = useCallback(
+    (tagId: string): void => {
+      setHistory((entries) => {
+        const entry = entries[historyIndex]
+        if (entry?.panel !== 'tags' || entry.tagId === tagId) return entries
+        return entries.map((candidate, index) =>
+          index === historyIndex ? { ...candidate, tagId } : candidate
+        )
+      })
+    },
+    [historyIndex]
+  )
 
   // Navigates within the skills panel (list/detail/create/edit/import) as a history entry.
   const navigateSkills = (skills: SkillsView): void =>
@@ -1177,12 +1210,18 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                   <SkillsPanel
                     view={skillsView}
                     onNavigate={navigateSkills}
+                    onOpenTag={navigateTag}
                     canImportInstalledSkills={canImportInstalledSkills}
                   />
                 ) : activePanel === 'specialists' ? (
-                  <SpecialistsPanel view={specialistsView} onNavigate={navigateSpecialists} />
+                  <SpecialistsPanel
+                    view={specialistsView}
+                    onNavigate={navigateSpecialists}
+                    onOpenTag={navigateTag}
+                  />
                 ) : activePanel === 'tags' ? (
                   <TagsPanel
+                    onSelectedTagChange={recordSelectedTag}
                     onOpenResource={(reference) => {
                       if (reference.resourceType === 'catalog.skill') {
                         navigate({
@@ -1226,6 +1265,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                           resourceId: connectorsView.id
                         }}
                         className="px-5 pt-5"
+                        onOpenTag={navigateTag}
                       />
                       <ConnectorDetailView
                         key={connectorsView.id}
@@ -1265,6 +1305,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                           resourceId: connectorsView.id
                         }}
                         className="px-5 pt-5"
+                        onOpenTag={navigateTag}
                       />
                       <ConnectorAddForm
                         editServer={customServers.find((s) => s.id === connectorsView.id)}
@@ -1273,7 +1314,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                       />
                     </div>
                   ) : (
-                    <ConnectorsPanel onNavigate={navigateConnectors} />
+                    <ConnectorsPanel onNavigate={navigateConnectors} onOpenTag={navigateTag} />
                   )
                 ) : activePanel === 'compute' ? (
                   computeView.kind === 'add' ? (

--- a/src/renderer/src/pages/settings/SkillsPanel.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.tsx
@@ -118,12 +118,14 @@ const SOURCE_GROUPS = [
 type SkillsPanelProps = {
   view: SkillsView
   onNavigate: (view: SkillsView) => void
+  onOpenTag?: (tagId: string) => void
   canImportInstalledSkills?: boolean
 }
 
 const SkillsPanel = ({
   view,
   onNavigate,
+  onOpenTag,
   canImportInstalledSkills = true
 }: SkillsPanelProps): React.JSX.Element => {
   const { t } = useTranslation()
@@ -281,6 +283,7 @@ const SkillsPanel = ({
         <ResourceTagSummary
           reference={{ resourceType: 'catalog.skill', resourceId: view.id }}
           className="px-5 pt-5"
+          onOpenTag={onOpenTag}
         />
         <SkillDetailView key={view.id} skillId={view.id} />
       </div>
@@ -310,6 +313,7 @@ const SkillsPanel = ({
         <ResourceTagSummary
           reference={{ resourceType: 'catalog.skill', resourceId: view.id }}
           className="px-5 pt-5"
+          onOpenTag={onOpenTag}
         />
         <SkillEditLoader skillId={view.id} onDone={() => onNavigate({ kind: 'list' })} />
       </div>
@@ -607,30 +611,37 @@ const SkillsPanel = ({
                           data-slot="settings-list-row"
                           className="flex min-h-14 flex-wrap items-center gap-2 py-2.5"
                         >
-                          <button
-                            type="button"
-                            onClick={() => onNavigate({ kind: 'detail', id: skill.id })}
-                            className="min-w-0 flex-1 text-left"
-                          >
-                            <span className="block truncate text-sm text-foreground">
-                              {skill.displayName}
-                            </span>
-                            <span className="block truncate text-xs text-muted-foreground">
-                              {skill.description}
-                            </span>
+                          <div className="min-w-0 flex-1">
+                            <button
+                              type="button"
+                              onClick={() => onNavigate({ kind: 'detail', id: skill.id })}
+                              className="block w-full min-w-0 text-left"
+                            >
+                              <span className="block truncate text-sm text-foreground">
+                                {skill.displayName}
+                              </span>
+                              <span className="block truncate text-xs text-muted-foreground">
+                                {skill.description}
+                              </span>
+                            </button>
                             <div className="mt-0.5 flex min-w-0 items-center gap-2">
-                              <span className="min-w-0 truncate text-xs text-muted-foreground">
+                              <button
+                                type="button"
+                                onClick={() => onNavigate({ kind: 'detail', id: skill.id })}
+                                className="min-w-0 truncate text-left text-xs text-muted-foreground"
+                              >
                                 {usageLabel ? `${usageLabel} · ` : ''}
                                 {t(SCOPE_LABEL_KEYS[scope])}
-                              </span>
+                              </button>
                               <ResourceTagBadges
                                 reference={{
                                   resourceType: 'catalog.skill',
                                   resourceId: skill.id
                                 }}
+                                onOpenTag={onOpenTag}
                               />
                             </div>
-                          </button>
+                          </div>
                           {exportStatus?.id === skill.id ? (
                             <span role="status" className="shrink-0 text-xs text-muted-foreground">
                               {exportStatus.message}

--- a/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
@@ -977,6 +977,25 @@ describe('SpecialistsPanel', () => {
     }
   })
 
+  it('keeps non-Tag metadata connected to specialist row navigation', async () => {
+    const onNavigate = vi.fn()
+    await act(async () => {
+      root.render(<SpecialistsPanel view={{ kind: 'list' }} onNavigate={onNavigate} />)
+    })
+
+    const customMetadata = document.body.querySelector<HTMLElement>(
+      '[data-specialist-metadata-group="rna-reviewer"] [data-specialist-metadata="capabilities"]'
+    )
+    await act(async () => customMetadata?.click())
+    expect(onNavigate).toHaveBeenLastCalledWith({ kind: 'edit', id: 'rna-reviewer' })
+
+    const builtinMetadata = document.body.querySelector<HTMLButtonElement>(
+      '[data-specialist-metadata-group="builtin-curator"] button'
+    )
+    await act(async () => builtinMetadata?.click())
+    expect(onNavigate).toHaveBeenLastCalledWith({ kind: 'builtin', id: 'builtin-curator' })
+  })
+
   it('distinguishes a Marketplace install from a manually imported ZIP', async () => {
     const installed: SpecialistListItem = {
       ...(specialistItems[0] as Extract<SpecialistListItem, { kind: 'custom' }>),

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -148,16 +148,19 @@ const SEVERITY_CLASSES = {
 type SpecialistsPanelProps = {
   view: SpecialistsView
   onNavigate: (view: SpecialistsView) => void
+  onOpenTag?: (tagId: string) => void
 }
 
 type InstalledSpecialistsView = Exclude<SpecialistsView, SpecialistMarketplaceView>
 
 const InstalledSpecialistsPanel = ({
   view,
-  onNavigate
+  onNavigate,
+  onOpenTag
 }: {
   view: InstalledSpecialistsView
   onNavigate: (view: SpecialistsView) => void
+  onOpenTag?: (tagId: string) => void
 }): React.JSX.Element => {
   const { t } = useTranslation()
 
@@ -623,6 +626,7 @@ const InstalledSpecialistsPanel = ({
           <ResourceTagSummary
             reference={{ resourceType: 'catalog.specialist', resourceId: specialist.id }}
             className="px-5 pt-5"
+            onOpenTag={onOpenTag}
           />
           <SpecialistEditor
             key={specialist.id}
@@ -1181,6 +1185,7 @@ const InstalledSpecialistsPanel = ({
           <ResourceTagSummary
             reference={{ resourceType: 'catalog.specialist', resourceId: specialist.id }}
             className="mt-4"
+            onOpenTag={onOpenTag}
           />
           <p className="mt-4 text-sm text-foreground">{specialist.description}</p>
           <div className="mt-5 rounded-lg border border-border bg-muted/30 p-3">
@@ -1408,32 +1413,48 @@ const InstalledSpecialistsPanel = ({
                         />
 
                         {/* Click the row body to open the editor (prefilled) */}
-                        <button
-                          type="button"
-                          disabled={catalogReadOnly}
-                          onClick={() => onNavigate({ kind: 'edit', id: item.id })}
-                          aria-label={
-                            item.setupPending
-                              ? t('Continue setup for {{name}}', {
-                                  name: item.displayName ?? item.name
-                                })
-                              : t('Edit {{name}}', { name: item.displayName ?? item.name })
-                          }
-                          className="flex min-w-0 flex-1 cursor-pointer items-center rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default"
-                        >
-                          {/* Body: name + description */}
-                          <div className="min-w-0 flex-1">
-                            <span className="block truncate text-sm text-foreground">
-                              {item.displayName ?? item.name}
-                            </span>
-                            {item.description ? (
-                              <span className="block truncate text-xs text-muted-foreground">
-                                {item.description}
+                        <div className="min-w-0 flex-1">
+                          <button
+                            type="button"
+                            disabled={catalogReadOnly}
+                            onClick={() => onNavigate({ kind: 'edit', id: item.id })}
+                            aria-label={
+                              item.setupPending
+                                ? t('Continue setup for {{name}}', {
+                                    name: item.displayName ?? item.name
+                                  })
+                                : t('Edit {{name}}', { name: item.displayName ?? item.name })
+                            }
+                            className="flex w-full min-w-0 cursor-pointer items-center rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default"
+                          >
+                            {/* Body: name + description */}
+                            <div className="min-w-0 flex-1">
+                              <span className="block truncate text-sm text-foreground">
+                                {item.displayName ?? item.name}
                               </span>
-                            ) : null}
-                            <span
-                              className="mt-1 flex min-w-0 flex-wrap items-center gap-1"
-                              data-specialist-metadata-group={item.id}
+                              {item.description ? (
+                                <span className="block truncate text-xs text-muted-foreground">
+                                  {item.description}
+                                </span>
+                              ) : null}
+                            </div>
+                          </button>
+                          <span
+                            className="mt-1 flex min-w-0 flex-wrap items-center gap-1"
+                            data-specialist-metadata-group={item.id}
+                          >
+                            <button
+                              type="button"
+                              disabled={catalogReadOnly}
+                              onClick={() => onNavigate({ kind: 'edit', id: item.id })}
+                              aria-label={
+                                item.setupPending
+                                  ? t('Continue setup for {{name}}', {
+                                      name: item.displayName ?? item.name
+                                    })
+                                  : t('Edit {{name}}', { name: item.displayName ?? item.name })
+                              }
+                              className="flex min-w-0 cursor-pointer flex-wrap items-center gap-1 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default"
                             >
                               <Badge
                                 variant="outline"
@@ -1497,15 +1518,16 @@ const InstalledSpecialistsPanel = ({
                                   </Badge>
                                 </>
                               ) : null}
-                              <ResourceTagBadges
-                                reference={{
-                                  resourceType: 'catalog.specialist',
-                                  resourceId: item.id
-                                }}
-                              />
-                            </span>
-                          </div>
-                        </button>
+                            </button>
+                            <ResourceTagBadges
+                              reference={{
+                                resourceType: 'catalog.specialist',
+                                resourceId: item.id
+                              }}
+                              onOpenTag={onOpenTag}
+                            />
+                          </span>
+                        </div>
 
                         {item.setupPending ? (
                           <Button
@@ -1637,36 +1659,46 @@ const InstalledSpecialistsPanel = ({
                     data-slot="settings-list-row"
                     className="flex min-h-14 items-center gap-2 py-2.5"
                   >
-                    <button
-                      type="button"
-                      onClick={() => onNavigate({ kind: 'builtin', id: item.id })}
-                      aria-label={t('View {{name}}', { name: item.displayName ?? item.name })}
-                      className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    >
-                      <SpecialistAvatar iconKey={item.iconKey} colorKey={item.colorKey} />
-                      <div className="min-w-0 flex-1">
-                        <span className="block truncate text-sm text-foreground">
-                          {item.displayName ?? item.name}
-                        </span>
-                        <span className="block truncate text-xs text-muted-foreground">
-                          {item.description}
-                        </span>
-                        <div
-                          className="mt-0.5 flex min-w-0 items-center gap-2"
-                          data-specialist-metadata-group={item.id}
-                        >
-                          <span className="min-w-0 truncate text-[11px] text-muted-foreground">
-                            {t('Built-in · Version {{version}}', { version: item.version })}
+                    <div className="min-w-0 flex-1">
+                      <button
+                        type="button"
+                        onClick={() => onNavigate({ kind: 'builtin', id: item.id })}
+                        aria-label={t('View {{name}}', { name: item.displayName ?? item.name })}
+                        className="flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      >
+                        <SpecialistAvatar iconKey={item.iconKey} colorKey={item.colorKey} />
+                        <div className="min-w-0 flex-1">
+                          <span className="block truncate text-sm text-foreground">
+                            {item.displayName ?? item.name}
                           </span>
-                          <ResourceTagBadges
-                            reference={{
-                              resourceType: 'catalog.specialist',
-                              resourceId: item.id
-                            }}
-                          />
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {item.description}
+                          </span>
                         </div>
+                      </button>
+                      <div
+                        className="mt-0.5 ml-9 flex min-w-0 items-center gap-2"
+                        data-specialist-metadata-group={item.id}
+                      >
+                        <button
+                          type="button"
+                          onClick={() => onNavigate({ kind: 'builtin', id: item.id })}
+                          aria-label={t('View {{name}}', {
+                            name: item.displayName ?? item.name
+                          })}
+                          className="min-w-0 cursor-pointer truncate rounded-md text-left text-[11px] text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        >
+                          {t('Built-in · Version {{version}}', { version: item.version })}
+                        </button>
+                        <ResourceTagBadges
+                          reference={{
+                            resourceType: 'catalog.specialist',
+                            resourceId: item.id
+                          }}
+                          onOpenTag={onOpenTag}
+                        />
                       </div>
-                    </button>
+                    </div>
                     <ResourceTagMenu
                       reference={{ resourceType: 'catalog.specialist', resourceId: item.id }}
                     />
@@ -1989,7 +2021,11 @@ const SpecialistsPanel = (props: SpecialistsPanelProps): React.JSX.Element =>
   props.view.kind === 'marketplace-release' ? (
     <SpecialistMarketplace view={props.view} onNavigate={props.onNavigate} />
   ) : (
-    <InstalledSpecialistsPanel view={props.view} onNavigate={props.onNavigate} />
+    <InstalledSpecialistsPanel
+      view={props.view}
+      onNavigate={props.onNavigate}
+      onOpenTag={props.onOpenTag}
+    />
   )
 
 export { SpecialistsPanel }

--- a/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
@@ -131,4 +131,203 @@ describe('TagsPanel', () => {
     expect(container.textContent).not.toContain('Production')
     expect(container.firstElementChild?.className).toContain('overflow-hidden')
   })
+
+  it('opens a Tag from its resource badge and removes the assignment without navigating', async () => {
+    const onOpenTag = vi.fn()
+    const setAssignment = vi.fn().mockResolvedValue(undefined)
+    useTagStore.setState({ setAssignment })
+
+    act(() => {
+      root.render(
+        <ResourceTagBadges
+          reference={{ resourceType: 'catalog.skill', resourceId: 'analysis' }}
+          onOpenTag={onOpenTag}
+        />
+      )
+    })
+
+    const openTag = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'Favorites'
+    )
+    expect(openTag?.firstElementChild?.className).not.toContain('pr-6')
+    act(() => openTag?.click())
+    expect(onOpenTag).toHaveBeenCalledWith('tag-favorite')
+
+    const removeTag = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Remove Favorites from this resource"]'
+    )
+    expect(removeTag?.className).toContain('bg-background')
+    expect(removeTag?.className).toContain('sm:pointer-events-none')
+    expect(removeTag?.className).toContain('sm:group-hover/tag:pointer-events-auto')
+    await act(async () => removeTag?.click())
+
+    expect(setAssignment).toHaveBeenCalledWith({
+      tagId: 'tag-favorite',
+      resourceType: 'catalog.skill',
+      resourceId: 'analysis',
+      assigned: false
+    })
+    expect(onOpenTag).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a visible error when removing a resource Tag fails', async () => {
+    useTagStore.setState({ setAssignment: vi.fn().mockRejectedValue(new Error('write failed')) })
+
+    act(() => {
+      root.render(
+        <ResourceTagBadges
+          reference={{ resourceType: 'catalog.skill', resourceId: 'analysis' }}
+          onOpenTag={vi.fn()}
+        />
+      )
+    })
+
+    const removeTag = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Remove Favorites from this resource"]'
+    )
+    await act(async () => removeTag?.click())
+
+    const alert = container.querySelector<HTMLElement>('[role="alert"]')
+    expect(alert?.textContent).toBe('Could not update Tags.')
+    expect(alert?.className).toContain('text-destructive')
+    expect(alert?.className).not.toContain('sr-only')
+  })
+
+  it('removes a hovered resource from the selected Tag', async () => {
+    const setAssignment = vi.fn().mockResolvedValue(undefined)
+    useTagStore.setState({ setAssignment })
+
+    await act(async () => {
+      root.render(<TagsPanel onOpenResource={vi.fn()} />)
+    })
+
+    const removeResource = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Remove Analysis from Favorites"]'
+    )
+    expect(removeResource?.className).toContain('sm:pointer-events-none')
+    expect(removeResource?.className).toContain('sm:group-hover:pointer-events-auto')
+    await act(async () => removeResource?.click())
+
+    expect(setAssignment).toHaveBeenCalledWith({
+      tagId: 'tag-favorite',
+      resourceType: 'catalog.skill',
+      resourceId: 'analysis',
+      assigned: false
+    })
+  })
+
+  it('renders icon-aligned resource groups that start expanded and can collapse', async () => {
+    useSettingsStore.setState({
+      connectors: [
+        {
+          id: 'pubmed',
+          name: 'pubmed',
+          displayName: 'PubMed',
+          description: 'Biomedical literature',
+          sources: ['NCBI'],
+          requiresNcbi: true,
+          enabled: true,
+          autoAllow: false,
+          group: 'directory'
+        }
+      ]
+    })
+    useSpecialistStore.setState({
+      items: [
+        {
+          kind: 'builtin',
+          readonly: true,
+          id: 'auto-research',
+          name: 'AUTO_RESEARCH',
+          displayName: 'Auto Research',
+          description: 'Research specialist',
+          systemPrompt: 'Research',
+          iconKey: 'bot',
+          colorKey: 'blue',
+          version: '1.0.0',
+          enabled: true,
+          capabilityMode: 'selected',
+          fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+          selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+          revision: 1
+        }
+      ]
+    })
+    useTagStore.setState({
+      assignments: [
+        {
+          tagId: 'tag-favorite',
+          resourceType: 'catalog.skill',
+          resourceId: 'analysis',
+          createdAt: 1
+        },
+        {
+          tagId: 'tag-favorite',
+          resourceType: 'catalog.connector',
+          resourceId: 'pubmed',
+          createdAt: 2
+        },
+        {
+          tagId: 'tag-favorite',
+          resourceType: 'catalog.specialist',
+          resourceId: 'auto-research',
+          createdAt: 3
+        }
+      ]
+    })
+
+    await act(async () => {
+      root.render(<TagsPanel onOpenResource={vi.fn()} />)
+    })
+
+    const groupButtons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[data-slot="tag-resource-group"]')
+    )
+    expect(groupButtons.map((button) => button.textContent?.trim())).toEqual([
+      'Skills (1)',
+      'Connectors (1)',
+      'Specialists (1)'
+    ])
+    expect(groupButtons[0]?.querySelector('.lucide-scroll-text')).not.toBeNull()
+    expect(groupButtons[1]?.querySelectorAll('rect')).toHaveLength(4)
+    expect(groupButtons[2]?.querySelector('.lucide-users')).not.toBeNull()
+    expect(groupButtons.every((button) => button.classList.contains('cursor-pointer'))).toBe(true)
+    expect(groupButtons.every((button) => button.getAttribute('aria-expanded') === 'true')).toBe(
+      true
+    )
+
+    act(() => groupButtons[0]?.click())
+    expect(groupButtons[0]?.getAttribute('aria-expanded')).toBe('false')
+    expect(container.textContent).not.toContain('Analysis')
+    expect(container.textContent).toContain('PubMed')
+    expect(container.textContent).toContain('Auto Research')
+  })
+
+  it('reveals custom Tag actions on row hover or keyboard focus', async () => {
+    useTagStore.setState({
+      tags: [
+        { id: 'tag-favorite', systemKey: 'favorite', createdAt: 1, updatedAt: 1 },
+        {
+          id: 'tag-research',
+          name: 'Research',
+          iconKey: 'book-open',
+          colorKey: 'purple',
+          createdAt: 2,
+          updatedAt: 2
+        }
+      ]
+    })
+
+    await act(async () => {
+      root.render(<TagsPanel onOpenResource={vi.fn()} />)
+    })
+
+    const actions = container.querySelector<HTMLButtonElement>('[aria-label="Tag actions"]')
+    const selectedTag = container.querySelector<HTMLButtonElement>('aside [aria-current="page"]')
+    expect(selectedTag?.className).toContain('cursor-pointer')
+    expect(actions?.className).toContain('sm:opacity-0')
+    expect(actions?.className).toContain('sm:group-hover:opacity-100')
+    expect(actions?.className).toContain('focus-visible:opacity-100')
+    expect(actions?.className).toContain('data-[state=open]:opacity-100')
+  })
 })

--- a/src/renderer/src/pages/settings/TagsPanel.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.tsx
@@ -1,5 +1,15 @@
 import { AlertDialog, Dialog } from 'radix-ui'
-import { MoreHorizontal, Pencil, Plus, Search, Trash2, X } from 'lucide-react'
+import {
+  ChevronDown,
+  MoreHorizontal,
+  Pencil,
+  Plus,
+  ScrollText,
+  Search,
+  Trash2,
+  Users,
+  X
+} from 'lucide-react'
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -38,7 +48,9 @@ import { cn } from '@/lib/utils'
 import { useSettingsStore } from '@/stores/settings-store'
 import { useSpecialistStore } from '@/stores/specialist-store'
 import { useTagStore } from '@/stores/tag-store'
-import { TAG_COLORS, TAG_ICONS } from './tag-presentation'
+import { ConnectorsNavIcon } from './connector-icons'
+import { SettingsIconAction } from './SettingsLayout'
+import { TAG_COLORS, TAG_ICONS, tagPresentation } from './tag-presentation'
 import { TagBadge } from './tag-visuals'
 
 type TagResourceRow = TagResourceRef & {
@@ -82,9 +94,11 @@ const colorLabel = (t: ReturnType<typeof useTranslation>['t'], key: TagColorKey)
 }
 
 const TagsPanel = ({
-  onOpenResource
+  onOpenResource,
+  onSelectedTagChange
 }: {
   onOpenResource(reference: TagResourceRef): void
+  onSelectedTagChange?(tagId: string): void
 }): React.JSX.Element => {
   const { t } = useTranslation()
   const tags = useTagStore((state) => state.tags)
@@ -94,6 +108,7 @@ const TagsPanel = ({
   const createTag = useTagStore((state) => state.create)
   const updateTag = useTagStore((state) => state.update)
   const deleteTag = useTagStore((state) => state.delete)
+  const setAssignment = useTagStore((state) => state.setAssignment)
   const loadTags = useTagStore((state) => state.load)
   const skills = useSettingsStore((state) => state.skills)
   const connectors = useSettingsStore((state) => state.connectors)
@@ -118,6 +133,9 @@ const TagsPanel = ({
   const [deleting, setDeleting] = useState<TagView>()
   const [deleteBusy, setDeleteBusy] = useState(false)
   const [deleteError, setDeleteError] = useState<string>()
+  const [assignmentError, setAssignmentError] = useState<string>()
+  const [removingResourceKey, setRemovingResourceKey] = useState<string>()
+  const [collapsed, setCollapsed] = useState<Partial<Record<TagResourceType, boolean>>>({})
 
   useEffect(() => {
     if (status === 'idle') void loadTags()
@@ -164,6 +182,13 @@ const TagsPanel = ({
   )
   const currentSelectedId = tags.some((tag) => tag.id === selectedId) ? selectedId : tags[0]?.id
   const selectedTag = tags.find((tag) => tag.id === currentSelectedId)
+
+  useEffect(() => {
+    if (!currentSelectedId || selectedId === currentSelectedId) return
+    setSelectedId(currentSelectedId)
+    onSelectedTagChange?.(currentSelectedId)
+  }, [currentSelectedId, onSelectedTagChange, selectedId, setSelectedId])
+
   const selectedAssignments = assignments.filter(
     (assignment) => assignment.tagId === currentSelectedId
   )
@@ -232,6 +257,24 @@ const TagsPanel = ({
       setDeleteBusy(false)
     }
   }
+  const removeResource = async (resource: TagResourceRow): Promise<void> => {
+    if (!selectedTag || removingResourceKey) return
+    const key = `${resource.resourceType}:${resource.resourceId}`
+    setRemovingResourceKey(key)
+    setAssignmentError(undefined)
+    try {
+      await setAssignment({
+        tagId: selectedTag.id,
+        resourceType: resource.resourceType,
+        resourceId: resource.resourceId,
+        assigned: false
+      })
+    } catch {
+      setAssignmentError(t('Could not update Tags.'))
+    } finally {
+      setRemovingResourceKey(undefined)
+    }
+  }
 
   return (
     <div className="flex min-h-full flex-col p-5">
@@ -260,9 +303,12 @@ const TagsPanel = ({
               <button
                 type="button"
                 aria-current={tag.id === currentSelectedId ? 'page' : undefined}
-                onClick={() => setSelectedId(tag.id)}
+                onClick={() => {
+                  setSelectedId(tag.id)
+                  onSelectedTagChange?.(tag.id)
+                }}
                 className={cn(
-                  'flex h-9 min-w-0 flex-1 items-center gap-2 rounded-lg px-2 text-left text-sm hover:bg-muted',
+                  'flex h-9 min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-lg px-2 text-left text-sm hover:bg-muted',
                   tag.id === currentSelectedId && 'bg-muted font-medium'
                 )}
               >
@@ -279,6 +325,7 @@ const TagsPanel = ({
                       variant="ghost"
                       size="icon-sm"
                       aria-label={t('Tag actions')}
+                      className="shrink-0 opacity-100 transition-[opacity,color,background-color] duration-200 ease-out hover:!opacity-100 focus-visible:opacity-100 sm:opacity-0 sm:group-hover:opacity-100 data-[state=open]:opacity-100"
                     >
                       <MoreHorizontal className="size-4" aria-hidden="true" />
                     </Button>
@@ -357,33 +404,85 @@ const TagsPanel = ({
                   />
                 </div>
               </div>
+              {assignmentError ? (
+                <p role="alert" className="mb-3 text-xs text-destructive">
+                  {assignmentError}
+                </p>
+              ) : null}
               {filteredResources.length > 0 ? (
                 <div className="space-y-4">
-                  {resourceGroups.map(({ resourceType, resources: groupedResources }) => (
-                    <section key={resourceType}>
-                      <h4 className="mb-1 text-xs font-medium text-muted-foreground">
-                        {resourceTypeLabel(t, resourceType)} ({groupedResources.length})
-                      </h4>
-                      <ul className="divide-y divide-border">
-                        {groupedResources.map((resource) => (
-                          <li key={`${resource.resourceType}:${resource.resourceId}`}>
-                            <button
-                              type="button"
-                              className="flex w-full items-center gap-3 py-3 text-left hover:text-primary"
-                              onClick={() => onOpenResource(resource)}
-                            >
-                              <span className="min-w-0 flex-1">
-                                <span className="block truncate text-sm">{resource.title}</span>
-                                <span className="block truncate text-xs text-muted-foreground">
-                                  {resource.subtitle}
-                                </span>
-                              </span>
-                            </button>
-                          </li>
-                        ))}
-                      </ul>
-                    </section>
-                  ))}
+                  {resourceGroups.map(({ resourceType, resources: groupedResources }) => {
+                    const expanded = !collapsed[resourceType]
+                    const Icon =
+                      resourceType === 'catalog.skill'
+                        ? ScrollText
+                        : resourceType === 'catalog.connector'
+                          ? ConnectorsNavIcon
+                          : Users
+                    return (
+                      <section key={resourceType}>
+                        <button
+                          type="button"
+                          data-slot="tag-resource-group"
+                          aria-expanded={expanded}
+                          onClick={() =>
+                            setCollapsed((value) => ({
+                              ...value,
+                              [resourceType]: !value[resourceType]
+                            }))
+                          }
+                          className="flex w-full cursor-pointer items-center gap-1 text-left text-sm font-semibold text-foreground"
+                        >
+                          <Icon className="size-4 shrink-0 text-muted-foreground" />
+                          <span>
+                            {resourceTypeLabel(t, resourceType)} ({groupedResources.length})
+                          </span>
+                          <ChevronDown
+                            className={cn(
+                              'size-4 shrink-0 text-muted-foreground transition-transform motion-reduce:transition-none',
+                              !expanded && '-rotate-90'
+                            )}
+                            aria-hidden="true"
+                          />
+                        </button>
+                        {expanded ? (
+                          <ul className="mt-1 divide-y divide-border">
+                            {groupedResources.map((resource) => {
+                              const key = `${resource.resourceType}:${resource.resourceId}`
+                              return (
+                                <li key={key} className="group flex items-center gap-1">
+                                  <button
+                                    type="button"
+                                    className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 py-3 text-left hover:text-primary"
+                                    onClick={() => onOpenResource(resource)}
+                                  >
+                                    <span className="min-w-0 flex-1">
+                                      <span className="block truncate text-sm">
+                                        {resource.title}
+                                      </span>
+                                      <span className="block truncate text-xs text-muted-foreground">
+                                        {resource.subtitle}
+                                      </span>
+                                    </span>
+                                  </button>
+                                  <SettingsIconAction
+                                    label={t('Remove {{resource}} from {{tag}}', {
+                                      resource: resource.title,
+                                      tag: tagPresentation(selectedTag, t).name
+                                    })}
+                                    icon={X}
+                                    disabled={removingResourceKey === key}
+                                    className="pointer-events-auto shrink-0 opacity-100 transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 sm:pointer-events-none sm:opacity-0 sm:group-hover:pointer-events-auto sm:group-hover:opacity-100 sm:group-focus-within:pointer-events-auto sm:group-focus-within:opacity-100"
+                                    onClick={() => void removeResource(resource)}
+                                  />
+                                </li>
+                              )
+                            })}
+                          </ul>
+                        ) : null}
+                      </section>
+                    )
+                  })}
                 </div>
               ) : (
                 <p className="py-12 text-center text-sm text-muted-foreground">

--- a/src/renderer/src/stores/tag-store.test.ts
+++ b/src/renderer/src/stores/tag-store.test.ts
@@ -20,6 +20,16 @@ beforeEach(() => {
 })
 
 describe('tag store', () => {
+  it('preserves browser scroll when restoring the currently selected Tag', () => {
+    useTagStore.setState({ browserSelectedId: 'tag-favorite', browserScrollTop: 240 })
+
+    useTagStore.getState().setBrowserSelectedId('tag-favorite')
+    expect(useTagStore.getState().browserScrollTop).toBe(240)
+
+    useTagStore.getState().setBrowserSelectedId('tag-research')
+    expect(useTagStore.getState().browserScrollTop).toBe(0)
+  })
+
   it('hydrates the authoritative snapshot', async () => {
     setTagsApi({ snapshot: vi.fn().mockResolvedValue(favoriteSnapshot()) })
 

--- a/src/renderer/src/stores/tag-store.ts
+++ b/src/renderer/src/stores/tag-store.ts
@@ -55,7 +55,12 @@ const stateFromSnapshot = (
 
 export const useTagStore = create<TagStore>((set, get) => ({
   ...createInitialTagState(),
-  setBrowserSelectedId: (browserSelectedId) => set({ browserSelectedId, browserScrollTop: 0 }),
+  setBrowserSelectedId: (browserSelectedId) =>
+    set((state) =>
+      state.browserSelectedId === browserSelectedId
+        ? { browserSelectedId }
+        : { browserSelectedId, browserScrollTop: 0 }
+    ),
   setBrowserTypeFilter: (browserTypeFilter) => set({ browserTypeFilter, browserScrollTop: 0 }),
   setBrowserQuery: (browserQuery) => set({ browserQuery, browserScrollTop: 0 }),
   setBrowserScrollTop: (browserScrollTop) => set({ browserScrollTop }),


### PR DESCRIPTION
## Problem

Tag relationships could only be managed through the assignment menu, and the Tags browser did not provide direct unlinking or collapsible resource groups. Tag badges on Skills, Connectors, and Specialists were not navigable.

## Proposed change

- Add hover/focus unlink actions to resource Tag badges and Tags browser resource rows.
- Make resource Tag badges navigate through Settings history to the selected Tag.
- Preserve the selected Tag in each Settings history entry for correct Back/Forward behavior.
- Add icon-aligned, default-expanded collapsible resource groups in the Tags browser.
- Reveal custom Tag action menus on hover/focus, matching Session behavior.
- Overlay the unlink icon without reserving Tag label space or leaving a hidden click target.
- Show visible feedback if direct unlinking fails.
- Add localized accessible labels and tooltips in zh-Hans, zh-Hant, and ja.

## Scope and non-goals

- Reuse the existing optimistic Tag assignment store and rollback behavior.
- No historical-data compatibility handling is needed.
- No persisted enum or state values are added; collapse state and Settings navigation history are in-memory only.
- No database schema, migration, or new persistence model is introduced.

## Acceptance criteria and validation

- Targeted renderer and i18n suite: 6 files, 304 tests passed after rebasing onto current main.
- Final review regression suite: 3 files, 184 tests passed.
- npm run typecheck passed.
- npm run typecheck:web passed after final review fixes.
- npm run lint passed.
- git diff --check passed.
- test:affected --explain conservatively selects the full suite because these Settings files have no module owner; the full local suite was intentionally not run per the requested impact plan, and PR CI is authoritative.

## Review focus

- Hover/focus affordances, touch behavior, and keyboard accessibility for unlink controls.
- Full Tag label layout with the unlink icon overlaid only during interaction.
- Visible rollback feedback when direct unlinking fails.
- Selected Tag restoration across Settings Back/Forward navigation.
- List-row structure changes that avoid nested interactive elements.
