### PR TITLE
fix(signpath): verify self-signed test certificate

### DIFF
--- a/.github/workflows/signpath-test.yml
+++ b/.github/workflows/signpath-test.yml
@@ -82,13 +82,33 @@ jobs:
             exit 1
           }
           $signature = Get-AuthenticodeSignature -FilePath $installers[0].FullName
-          $acceptableStatuses = @('Valid', 'NotTrusted')
-          if ($null -eq $signature.SignerCertificate -or $signature.Status.ToString() -notin $acceptableStatuses) {
-            Write-Error "SignPath returned an unacceptable Authenticode status: $($signature.Status)."
+          if ($null -eq $signature.SignerCertificate) {
+            Write-Error "SignPath returned an artifact without a signer certificate. Status: $($signature.Status)."
             exit 1
           }
-          Write-Host "Signature status: $($signature.Status)"
+
+          Write-Host "Initial signature status: $($signature.Status)"
+          Write-Host "Initial status message: $($signature.StatusMessage)"
           Write-Host "Signer: $($signature.SignerCertificate.Subject)"
+
+          $expectedTestCertificateSubject = "CN=Test certificate for 'Open Science [OSS]'"
+          $expectedUntrustedRootMessage = 'A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.'
+          $isExpectedSelfSignedTestCertificate = (
+            $signature.SignerCertificate.Subject -eq $signature.SignerCertificate.Issuer -and
+            $signature.SignerCertificate.Subject -eq $expectedTestCertificateSubject
+          )
+          $isExpectedUntrustedStatus = (
+            $signature.Status -eq 'NotTrusted' -or
+            ($signature.Status -eq 'UnknownError' -and $signature.StatusMessage -eq $expectedUntrustedRootMessage)
+          )
+
+          if ($signature.Status -ne 'Valid' -and -not (
+            $isExpectedSelfSignedTestCertificate -and $isExpectedUntrustedStatus
+          )) {
+            Write-Error "SignPath returned an unacceptable Authenticode signature: $($signature.Status) — $($signature.StatusMessage)"
+            exit 1
+          }
+
           "path=$($installers[0].FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Upload signed installer

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -184,8 +184,16 @@ describe('post-merge Windows validation', () => {
       })
     })
     expect(verify.run).toContain('Get-AuthenticodeSignature')
-    expect(verify.run).toContain("$acceptableStatuses = @('Valid', 'NotTrusted')")
-    expect(verify.run).toContain('$signature.Status.ToString() -notin $acceptableStatuses')
+    expect(verify.run).toContain(
+      '$expectedTestCertificateSubject = "CN=Test certificate for \'Open Science [OSS]\'"'
+    )
+    expect(verify.run).toContain('$expectedUntrustedRootMessage =')
+    expect(verify.run).toContain("$signature.Status -eq 'UnknownError'")
+    expect(verify.run).toContain(
+      '$signature.SignerCertificate.Subject -eq $signature.SignerCertificate.Issuer'
+    )
+    expect(verify.run).toContain('$signature.StatusMessage -eq $expectedUntrustedRootMessage')
+    expect(verify.run).not.toContain('X509Store')
     expect(uploadSigned.with).toMatchObject({
       name: 'signpath-test-windows-x64',
       'retention-days': 7,


### PR DESCRIPTION
## Problem

The first post-merge SignPath dry-run completed signing request `7c91b398-22b5-437f-8036-c599abe8f763`, but Windows Server 2025 reported the intentionally self-signed test certificate as `UnknownError`. A diagnostic rerun confirmed the exact status message is the Windows untrusted-root result; attempting a temporary trust-store recheck then hung in WinVerifyTrust until the 20-minute job timeout.

## Proposed change

Accept a non-`Valid` result only when all of these are true: the signer certificate is self-signed, its subject exactly identifies the Open Science SignPath test certificate, and the status is either `NotTrusted` or `UnknownError` with the exact Windows untrusted-root message.

## Scope and non-goals

This only changes the manual `test-signing` dry-run. It does not modify release publishing, production certificate trust, artifact selection, the runner certificate store, or SignPath submission settings. Missing signers, hash mismatches, and arbitrary `UnknownError` statuses still fail.

## Acceptance criteria and validation

- The expected self-signed Open Science test certificate can complete the dry-run on Windows Server 2025.
- A missing signer, unexpected certificate identity, hash mismatch, or any unrelated invalid status fails closed.
- Final evidence mapping after the last material edit:
  - `scripts/windows-release-workflows.test.ts` -> 12/12 passed
  - `.github/workflows/signpath-test.yml` -> `actionlint` passed
  - changed workflow/test files -> Prettier check passed
  - patch -> `git diff --check` passed
- Full local `npm test` was not run; focused checks and exact-head PR CI are authoritative.
- Uncovered risk: final behavior requires the GitHub-hosted Windows runner and SignPath, so the dry-run will be dispatched from this exact branch head.

## Review focus

Please focus on whether the exact certificate identity and status-message checks remain fail-closed without mutating the runner trust store.