### PR TITLE
feat(compute)!: streamline agent host enumeration

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -3203,14 +3203,17 @@ function computeError(raw) {
 // host.compute namespace. Public methods and input keys are camelCase; the adapter immediately maps
 // them to the existing snake_case computeCall RPC contract.
 const hostCompute = {
-  // Enumerate registered compute hosts for discovery. No approval, no session context.
-  async list() {
+  // Enumerate ALL registered compute hosts as summaries (provider_id/display_name/shape/status).
+  // No approval, no session context. Heavy fields live behind details(); listRegistered() itself
+  // stays small so the repl_execute tool result is never truncated.
+  async listRegistered() {
     return computeRpc({ op: 'list' })
   },
 
-  // Returns session-enabled compute hosts (≠ list() which returns all registered hosts).
-  // Uses COMPUTE_SESSION_ID from spawn env so the registry lookup is always session-scoped.
-  async listCompute() {
+  // Returns the session-enabled compute hosts (≠ listRegistered() which returns all registered
+  // hosts) as the same summary objects. Uses COMPUTE_SESSION_ID from spawn env so the registry
+  // lookup is always session-scoped.
+  async listEnabled() {
     return computeRpc({ op: 'list_compute', session_id: COMPUTE_SESSION_ID })
   },
   // Bind a thin handle to one provider (no network call). callCommand runs one short remote command;

--- a/resources/skills/remote-compute-ssh/SKILL.md
+++ b/resources/skills/remote-compute-ssh/SKILL.md
@@ -17,15 +17,12 @@ the sandbox workspace); calling it from a python/r cell will fail with `host.com
 
 <!-- open-science:compute-hosts:start -->
 
-Run `await host.compute.list()` to see all registered hosts.
+Run `await host.compute.listRegistered()` to see all registered hosts.
 <!-- open-science:compute-hosts:end -->
 
-Each host entry shows:
-
-- Display name
-- Provider ID (e.g., `ssh:biowulf`, `ssh:192.168.1.100`)
-- Shape (e.g., `direct_ssh`, `slurm`, `pbs`)
-- Connection status
+Each host entry is a small summary — `provider_id`, `display_name`, `shape`, and `status`
+(`connected`, `probe_failed`, or `not_probed`). Heavy details (knowledge doc, probe snapshot)
+are NOT included; read them on demand with `details()`.
 
 ## Session-active host
 
@@ -33,20 +30,20 @@ The user may enable one host for this conversation via the `≡` panel in the co
 Always check which host is active before creating a handle:
 
 ```javascript
-// Returns the session-enabled host provider_ids (a string[] subset of all registered hosts).
+// Returns the session-enabled hosts as summaries (a subset of all registered hosts).
 // Empty array means the user hasn't chosen a host for this conversation yet.
-const activeHosts = await host.compute.listCompute()
-const c = activeHosts[0] ? host.compute.create(activeHosts[0]) : null
+const activeHosts = await host.compute.listEnabled()
+const c = activeHosts[0] ? host.compute.create(activeHosts[0].provider_id) : null
 ```
 
 ## API reference
 
 ```javascript
-// List ALL registered hosts
-const hosts = await host.compute.list()
+// List ALL registered hosts (summaries: provider_id, display_name, shape, status)
+const hosts = await host.compute.listRegistered()
 
 // List session-enabled hosts (user's active selection for this conversation)
-const activeHosts = await host.compute.listCompute()
+const activeHosts = await host.compute.listEnabled()
 
 // Create a handle to a specific host (no network call)
 const c = host.compute.create('ssh:<alias>')
@@ -58,7 +55,9 @@ const result = await c.callCommand('<shell command>', '<one-line intent for the 
 })
 // result → { exit_code, stdout, stderr, truncated }
 
-// Read the host knowledge doc (returns { doc, isSkeleton })
+// Read the host knowledge doc and probe snapshot.
+// Returns { doc, isSkeleton, probe }; probe is null when the host has not been probed.
+// probe → { ok, probed_at, exit_code, error_tail, os?, cpus?, mem_mib?, gpus?, detected_scheduler? }
 const info = await host.compute.details('ssh:<alias>', { mode: 'read' })
 
 // Append a note to the host knowledge doc (agent writes; 32 KB cap enforced)
@@ -89,8 +88,8 @@ automatically harvests the outputs and initiates a new analysis turn — **you n
 
 ```javascript
 // List the session's active compute hosts (set via the ≡ host selector)
-const activeHosts = await host.compute.listCompute()
-// returns ['ssh:<alias>', ...] — the provider_ids currently enabled for this session
+const activeHosts = await host.compute.listEnabled()
+// returns [{ provider_id, display_name, shape, status }, ...] — the hosts enabled for this session
 
 // Submit a non-blocking job — returns immediately after the user approves
 const c = host.compute.create('ssh:<alias>')

--- a/resources/skills/self-awareness/SKILL.md
+++ b/resources/skills/self-awareness/SKILL.md
@@ -56,7 +56,7 @@ Interpret every key narrowly:
 ```javascript
 const caps = await host.capabilities()
 if (caps.compute === true) {
-  const availableHosts = await host.compute.list()
+  const availableHosts = await host.compute.listRegistered()
 }
 
 if (caps.llm === true) {

--- a/src/main/compute/compute-host-profile-owner.test.ts
+++ b/src/main/compute/compute-host-profile-owner.test.ts
@@ -563,6 +563,7 @@ describe('ComputeHostProfileOwner.getDetails', () => {
     const result = await service.getDetails('ssh:biowulf')
     expect(result.doc).toBe('## Resources\ncpus: 8')
     expect(result.isSkeleton).toBe(false)
+    expect(result.probeResult).toBeUndefined()
   })
 
   it('returns a skeleton from probeResult when detailsDoc is empty', async () => {
@@ -585,6 +586,7 @@ describe('ComputeHostProfileOwner.getDetails', () => {
     expect(result.doc).toContain('mem:')
     expect(result.doc).toContain('gpus:')
     expect(result.doc).toContain('scheduler:')
+    expect(result.probeResult).toEqual(probeResult)
   })
 
   it('returns a skeleton with only available fields when some are missing', async () => {

--- a/src/main/compute/compute-host-profile-owner.ts
+++ b/src/main/compute/compute-host-profile-owner.ts
@@ -233,12 +233,24 @@ export class ComputeHostProfileOwner {
     return result
   }
 
-  async getDetails(providerId: string): Promise<{ doc: string; isSkeleton: boolean }> {
+  async getDetails(providerId: string): Promise<{
+    doc: string
+    isSkeleton: boolean
+    probeResult: ProbeResult | undefined
+  }> {
     const host = await this.repository.get(providerId)
     if (!host) throw hostNotFound(providerId)
-    if (host.detailsDoc) return { doc: host.detailsDoc, isSkeleton: false }
-    if (!host.probeResult?.ok) return { doc: '', isSkeleton: false }
-    return { doc: buildDetailsSkeleton(host.probeResult), isSkeleton: true }
+    if (host.detailsDoc) {
+      return { doc: host.detailsDoc, isSkeleton: false, probeResult: host.probeResult }
+    }
+    if (!host.probeResult?.ok) {
+      return { doc: '', isSkeleton: false, probeResult: host.probeResult }
+    }
+    return {
+      doc: buildDetailsSkeleton(host.probeResult),
+      isSkeleton: true,
+      probeResult: host.probeResult
+    }
   }
 
   async replaceDetails(

--- a/src/main/compute/compute-service.test.ts
+++ b/src/main/compute/compute-service.test.ts
@@ -104,7 +104,8 @@ describe('ComputeService host profile facade', () => {
     })
     await expect(service.getDetails('ssh:biowulf')).resolves.toEqual({
       doc: 'current details',
-      isSkeleton: false
+      isSkeleton: false,
+      probeResult: undefined
     })
     await service.replaceDetails('ssh:biowulf', {
       text: 'replacement',

--- a/src/main/compute/compute-service.ts
+++ b/src/main/compute/compute-service.ts
@@ -107,7 +107,11 @@ export class ComputeService {
     return Promise.all(hosts.map((host) => projectComputeCredentialStatus(host, credentialVault)))
   }
 
-  async getDetails(providerId: string): Promise<{ doc: string; isSkeleton: boolean }> {
+  async getDetails(providerId: string): Promise<{
+    doc: string
+    isSkeleton: boolean
+    probeResult: ProbeResult | undefined
+  }> {
     return this.hostProfiles.getDetails(providerId)
   }
 

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -442,7 +442,10 @@ const createComputeHandlers = (
       }
       return result
     },
-    detailsGet: (providerId) => service.getDetails(providerId),
+    detailsGet: async (providerId) => {
+      const { doc, isSkeleton } = await service.getDetails(providerId)
+      return { doc, isSkeleton }
+    },
     detailsSave: (providerId, text, oldText, author) =>
       service.replaceDetails(providerId, { text, oldText, author }),
     scratchSet: (providerId, path) => service.setScratchRoot(providerId, path),

--- a/src/main/compute/skill-doc.test.ts
+++ b/src/main/compute/skill-doc.test.ts
@@ -53,7 +53,7 @@ const writeCanonicalDocument = async (
       '## Registered hosts',
       '',
       '<!-- open-science:compute-hosts:start -->',
-      'Run `await host.compute.list()` to see all registered hosts.',
+      'Run `await host.compute.listRegistered()` to see all registered hosts.',
       '<!-- open-science:compute-hosts:end -->',
       '',
       '## API reference',
@@ -72,7 +72,8 @@ describe('syncComputeSkillDoc', () => {
     )
 
     for (const name of [
-      'listCompute',
+      'listRegistered',
+      'listEnabled',
       'callCommand',
       'submitJob',
       'attachJob',
@@ -92,6 +93,8 @@ describe('syncComputeSkillDoc', () => {
     expect(doc).not.toMatch(
       /\b(?:list_compute|call_command|submit_job|attach_job|set_concurrency_limit|login_shell|timeout_seconds|old_text|dst_filename|remote_path|max_file_mb|max_total_mb)\b/
     )
+    // The retired enumeration names must not resurface in shipped guidance.
+    expect(doc).not.toMatch(/\bhost\.compute\.(?:list|listCompute)\(/)
   })
 
   it('keeps bundled model-compute examples on the camelCase contract', async () => {

--- a/src/main/compute/skill-provisioning.test.ts
+++ b/src/main/compute/skill-provisioning.test.ts
@@ -65,7 +65,7 @@ describe('SSH Compute Skill provisioning lifecycle', () => {
         '',
         '<!-- open-science:compute-hosts:start -->',
         '',
-        'Run `await host.compute.list()` to see all registered hosts.',
+        'Run `await host.compute.listRegistered()` to see all registered hosts.',
         '<!-- open-science:compute-hosts:end -->',
         '',
         '## API reference',

--- a/src/main/notebook/host-compute.integration.test.ts
+++ b/src/main/notebook/host-compute.integration.test.ts
@@ -114,14 +114,14 @@ gate('repl kernel host.compute', () => {
     expect(stub.received()[0]?.params?.project_id).toBe('proj-x')
   })
 
-  it('maps listCompute, details, submitJob, attachJob, and setConcurrencyLimit to unchanged wire params', async () => {
+  it('maps listEnabled, details, submitJob, attachJob, and setConcurrencyLimit to unchanged wire params', async () => {
     const stub = await startStub()
     const exec = makeExecutor()
     const result = await exec.execute(
       baseRequest({
         code:
           "const c = host.compute.create('ssh:x'); " +
-          'await host.compute.listCompute(); ' +
+          'await host.compute.listEnabled(); ' +
           "await host.compute.details('ssh:x', { mode: 'replace', text: 'new', oldText: 'old' }); " +
           "const job = await c.submitJob('analyze', 'run', { timeoutSeconds: 60, " +
           "inputs: [{ src: 'in.dat', dstFilename: 'input.dat' }, { remotePath: '/remote/ref.dat', dstFilename: 'ref.dat' }], " +

--- a/src/main/notebook/local-rpc-server.mcpcall.test.ts
+++ b/src/main/notebook/local-rpc-server.mcpcall.test.ts
@@ -473,7 +473,12 @@ describe('computeCall RPC', () => {
 
   it('routes computeCall op=list to the compute service', async () => {
     const fakeHosts = [
-      { providerId: 'ssh:biowulf', displayName: 'biowulf', shape: 'direct_ssh', probeResult: null }
+      {
+        providerId: 'ssh:biowulf',
+        displayName: 'biowulf',
+        shape: 'direct_ssh',
+        probeResult: undefined
+      }
     ]
     const fakeCompute = {
       callCommand: async () => ({}),
@@ -493,8 +498,16 @@ describe('computeCall RPC', () => {
       body: JSON.stringify({ method: 'computeCall', params: { op: 'list' } })
     })
     expect(res.status).toBe(200)
-    const body = (await res.json()) as { result: typeof fakeHosts }
-    expect(body.result).toEqual(fakeHosts)
+    // The agent channel answers with the summary projection, never the full host objects.
+    const body = (await res.json()) as { result: unknown[] }
+    expect(body.result).toEqual([
+      {
+        provider_id: 'ssh:biowulf',
+        display_name: 'biowulf',
+        shape: 'direct_ssh',
+        status: 'not_probed'
+      }
+    ])
   })
 
   it('routes computeCall op=details mode=read to getDetails', async () => {

--- a/src/main/notebook/local-rpc-server.test.ts
+++ b/src/main/notebook/local-rpc-server.test.ts
@@ -7,6 +7,7 @@ import { dirname, join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { NotebookRunInputFile } from '../../shared/notebook'
+import type { ComputeHost } from '../../shared/compute'
 import { PlanCommandError } from '../../shared/session-plan/contract'
 import { fetchLocalRpc } from '../local-rpc-transport'
 import { NotebookLocalRpcServer } from './local-rpc-server'
@@ -37,6 +38,31 @@ const createDeferred = <Value = void>(): {
     resolve = promiseResolve
   })
   return { promise, resolve }
+}
+
+function computeHostFixture(
+  overrides: Pick<ComputeHost, 'providerId'> & Partial<ComputeHost>
+): ComputeHost {
+  const { providerId, ...rest } = overrides
+  const sshAlias = providerId.replace(/^ssh:/, '')
+  return {
+    id: `host-${sshAlias}`,
+    providerId,
+    displayName: sshAlias,
+    shape: 'direct_ssh',
+    sshAlias,
+    sshOverrides: undefined,
+    scratchRoot: undefined,
+    scratchPinned: false,
+    concurrencyLimit: undefined,
+    probeResult: undefined,
+    detailsDoc: '',
+    detailsUpdatedAt: undefined,
+    detailsUpdatedBy: undefined,
+    createdAt: 1,
+    updatedAt: 2,
+    ...rest
+  }
 }
 
 const registeredInput = {
@@ -2832,18 +2858,25 @@ describe('notebook local RPC server', () => {
     }
   })
 
-  it('list_compute op returns the enabled hosts for the given session', async () => {
-    const root = await createStorageRoot()
-    const service = new NotebookRuntimeService({
-      configRoot: root,
-      dataRoot: root,
-      projectId: 'default-project',
-      repository: new NotebookRunRepository(root)
-    })
-    // Inject a fake compute service with the minimal surface the dispatch needs.
+  it('list_compute op returns enabled-host summaries, skipping ids with no registered host', async () => {
+    // Inject a fake compute service with the minimal surface the dispatch needs. The enabled set
+    // names a ghost id with no registered host — it must be skipped, not surfaced.
     const fakeComputeService = {
       callCommand: async () => ({}),
-      list: async () => [],
+      list: async (): Promise<ComputeHost[]> => [
+        computeHostFixture({
+          providerId: 'ssh:cluster-1',
+          displayName: 'Cluster One',
+          shape: 'scheduler_cluster',
+          probeResult: {
+            ok: false,
+            probedAt: '2026-01-01T00:00:00.000Z',
+            exitCode: 255,
+            errorTail: 'boom'
+          }
+        }),
+        computeHostFixture({ providerId: 'ssh:alpha' })
+      ],
       getDetails: async () => ({ doc: '', isSkeleton: true }),
       appendDetails: async () => {},
       replaceDetails: async () => {},
@@ -2851,9 +2884,12 @@ describe('notebook local RPC server', () => {
       submitJob: async () => ({}),
       getJobStatus: async () => ({}),
       getJobResult: async () => ({}),
-      // Returns pre-configured enabled hosts for the session under test.
+      // Enabled order intentionally differs from list() order; the join must preserve this registry
+      // order while silently dropping the ghost id.
       getEnabledComputeHosts: (sessionId: string): string[] => {
-        if (sessionId === 'my-session') return ['ssh:cluster-1']
+        if (sessionId === 'my-session') {
+          return ['ssh:alpha', 'ssh:ghost', 'ssh:cluster-1']
+        }
         return []
       },
       setSessionConcurrencyLimit: async () => {},
@@ -2864,7 +2900,7 @@ describe('notebook local RPC server', () => {
         provider_ceilings: {}
       })
     }
-    const server = new NotebookLocalRpcServer(service, {
+    const server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
       transport: 'tcp',
       token: 'secret-token',
       computeService: fakeComputeService
@@ -2888,10 +2924,24 @@ describe('notebook local RPC server', () => {
           params: { op: 'list_compute', session_id: 'forged-session' }
         })
       })
-      const withHostsPayload = (await withHosts.json()) as { result: string[] }
+      const withHostsPayload = (await withHosts.json()) as { result: unknown[] }
 
       expect(withHosts.status).toBe(200)
-      expect(withHostsPayload.result).toEqual(['ssh:cluster-1'])
+      // Both registered hosts are summaries in enabled-registry order; the ghost id is absent.
+      expect(withHostsPayload.result).toEqual([
+        {
+          provider_id: 'ssh:alpha',
+          display_name: 'alpha',
+          shape: 'direct_ssh',
+          status: 'not_probed'
+        },
+        {
+          provider_id: 'ssh:cluster-1',
+          display_name: 'Cluster One',
+          shape: 'scheduler_cluster',
+          status: 'probe_failed'
+        }
+      ])
 
       // Unknown session → empty array.
       const otherConnection = await server.issueSessionConnection(
@@ -2910,10 +2960,130 @@ describe('notebook local RPC server', () => {
           params: { op: 'list_compute', session_id: 'other-session' }
         })
       })
-      const noHostsPayload = (await noHosts.json()) as { result: string[] }
+      const noHostsPayload = (await noHosts.json()) as { result: unknown[] }
 
       expect(noHosts.status).toBe(200)
       expect(noHostsPayload.result).toEqual([])
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('keeps enumeration compact and serves probe snapshots through details', async () => {
+    const probeResult: ComputeHost['probeResult'] = {
+      ok: true,
+      probedAt: '2026-01-01T00:00:00.000Z',
+      exitCode: 0,
+      errorTail: null,
+      os: 'Linux',
+      cpus: 64,
+      memMib: 257_000,
+      gpus: [{ type: 'A100', count: 8 }],
+      detectedScheduler: 'slurm'
+    }
+    // Full ComputeHost fixtures — detailsDoc and probe internals are exactly the heavy fields the
+    // agent channel must not carry (the dedicated details op serves them on demand).
+    const fakeComputeService = {
+      callCommand: async () => ({}),
+      list: async (): Promise<ComputeHost[]> => [
+        computeHostFixture({
+          providerId: 'ssh:alpha',
+          displayName: 'Alpha Cluster',
+          shape: 'scheduler_cluster',
+          probeResult,
+          detailsDoc: '# Alpha knowledge\n'.repeat(500),
+          detailsUpdatedAt: 1,
+          detailsUpdatedBy: 'agent'
+        }),
+        computeHostFixture({ providerId: 'ssh:beta' })
+      ],
+      getDetails: async () => ({
+        doc: '# Alpha knowledge',
+        isSkeleton: false,
+        probeResult
+      }),
+      appendDetails: async () => {},
+      replaceDetails: async () => {},
+      download: async () => ({}),
+      submitJob: async () => ({}),
+      getJobStatus: async () => ({}),
+      getJobResult: async () => ({}),
+      getEnabledComputeHosts: () => [],
+      setSessionConcurrencyLimit: async () => {},
+      getSessionConcurrencyStatus: async () => ({
+        session_limit: null,
+        active_count: 0,
+        queued_count: 0,
+        provider_ceilings: {}
+      })
+    }
+    const server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      token: 'secret-token',
+      computeService: fakeComputeService
+    })
+    const connection = await server.issueSessionConnection(
+      'my-session',
+      'default-project',
+      'root-frame-my-session'
+    )
+
+    try {
+      const response = await fetch(connection.endpoint, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ method: 'computeCall', params: { op: 'list' } })
+      })
+      const payload = (await response.json()) as { result: unknown[] }
+
+      expect(response.status).toBe(200)
+      expect(payload.result).toEqual([
+        {
+          provider_id: 'ssh:alpha',
+          display_name: 'Alpha Cluster',
+          shape: 'scheduler_cluster',
+          status: 'connected'
+        },
+        {
+          provider_id: 'ssh:beta',
+          display_name: 'beta',
+          shape: 'direct_ssh',
+          status: 'not_probed'
+        }
+      ])
+
+      const detailsResponse = await fetch(connection.endpoint, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          method: 'computeCall',
+          params: { op: 'details', provider_id: 'ssh:alpha', mode: 'read' }
+        })
+      })
+      const detailsPayload = (await detailsResponse.json()) as { result: unknown }
+
+      expect(detailsResponse.status).toBe(200)
+      expect(detailsPayload.result).toEqual({
+        doc: '# Alpha knowledge',
+        isSkeleton: false,
+        probe: {
+          ok: true,
+          probed_at: '2026-01-01T00:00:00.000Z',
+          exit_code: 0,
+          error_tail: null,
+          os: 'Linux',
+          cpus: 64,
+          mem_mib: 257_000,
+          gpus: [{ type: 'A100', count: 8 }],
+          detected_scheduler: 'slurm'
+        }
+      })
     } finally {
       await server.close()
     }

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from 'node:crypto'
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 
 import type { NotebookRunProvenanceContext } from '../../shared/notebook'
+import { computeHostSummary, computeProbeSnapshot, type ComputeHost } from '../../shared/compute'
 import type { HostLineageGraph, HostLineageVersion } from '../../shared/host-lineage'
 import type { NotebookRpcConnection } from './mcp-server'
 import { NotebookControlCompletionCapturedError } from './execution-owner'
@@ -109,8 +110,12 @@ type NotebookLocalRpcServerOptions = {
       timeoutSeconds?: number,
       context?: { sessionId: string; projectId: string }
     ): Promise<unknown>
-    list(): Promise<unknown>
-    getDetails(providerId: string): Promise<unknown>
+    list(): Promise<ComputeHost[]>
+    getDetails(providerId: string): Promise<{
+      doc: string
+      isSkeleton: boolean
+      probeResult?: ComputeHost['probeResult']
+    }>
     appendDetails(providerId: string, args: { text: string; author: string }): Promise<void>
     replaceDetails(
       providerId: string,
@@ -2049,9 +2054,12 @@ class NotebookLocalRpcServer {
         }
       }
 
-      // op='list' — returns all registered compute hosts for agent discovery (design.md §5).
+      // op='list' — all registered compute hosts as agent-facing summaries for discovery
+      // (design.md §5). Projected, never full ComputeHost objects: detailsDoc/probe internals
+      // belong to the details op and would overflow the agent-visible tool-result cap.
       if (op === 'list') {
-        return this.computeService.list()
+        const hosts = await this.computeService.list()
+        return hosts.map(computeHostSummary)
       }
 
       // op='details' — agent-facing read/append/replace for host knowledge docs (design.md §5).
@@ -2060,7 +2068,8 @@ class NotebookLocalRpcServer {
         const providerId = typeof params.provider_id === 'string' ? params.provider_id : ''
         const mode = typeof params.mode === 'string' ? params.mode : 'read'
         if (mode === 'read') {
-          return this.computeService.getDetails(providerId)
+          const { probeResult, ...details } = await this.computeService.getDetails(providerId)
+          return { ...details, probe: computeProbeSnapshot(probeResult) }
         }
         if (mode === 'append') {
           const text = typeof params.text === 'string' ? params.text : ''
@@ -2139,12 +2148,21 @@ class NotebookLocalRpcServer {
         return this.computeService.getJobResult(jobId)
       }
 
-      // op='list_compute' — returns session-enabled hosts (design.md §15.1, issue 06).
-      // Differs from op='list' (all registered hosts): this returns only hosts the user enabled for
-      // this conversation via the ComputeHostSelector. Session id comes from COMPUTE_SESSION_ID in
-      // the repl spawn env (same passthrough used by submit_job / call_command).
+      // op='list_compute' — returns session-enabled hosts as agent-facing summaries (design.md
+      // §15.1, issue 06). Differs from op='list' (all registered hosts): this returns only hosts the
+      // user enabled for this conversation via the ComputeHostSelector, in registry order. Session id
+      // comes from COMPUTE_SESSION_ID in the repl spawn env (same passthrough used by submit_job /
+      // call_command). Enabled ids without a registered host row (deleted mid-session) are skipped.
       if (op === 'list_compute') {
-        return this.computeService.getEnabledComputeHosts(sessionId)
+        const enabledIds = this.computeService.getEnabledComputeHosts(sessionId)
+        if (enabledIds.length === 0) return []
+        const byProviderId = new Map(
+          (await this.computeService.list()).map((host) => [host.providerId, host])
+        )
+        return enabledIds.flatMap((providerId) => {
+          const host = byProviderId.get(providerId)
+          return host ? [computeHostSummary(host)] : []
+        })
       }
 
       // op='set_concurrency_limit' — set session-level concurrency limit (Phase 3c, issue 05).

--- a/src/main/notebook/repl-loop.integration.test.ts
+++ b/src/main/notebook/repl-loop.integration.test.ts
@@ -76,7 +76,8 @@ describe('repl_loop local RPC transport', () => {
           "messageReceipt: 'messageReceipt' in host, message_receipt: 'message_receipt' in host, " +
           "resolveMessage: 'resolveMessage' in host, resolve_message: 'resolve_message' in host, " +
           "submitOutput: 'submitOutput' in host, submit_output: 'submit_output' in host, " +
-          "listCompute: 'listCompute' in host.compute, list_compute: 'list_compute' in host.compute, " +
+          "listRegistered: 'listRegistered' in host.compute, list: 'list' in host.compute, " +
+          "listEnabled: 'listEnabled' in host.compute, listCompute: 'listCompute' in host.compute, " +
           "callCommand: 'callCommand' in c, call_command: 'call_command' in c, " +
           "submitJob: 'submitJob' in c, submit_job: 'submit_job' in c, " +
           "attachJob: 'attachJob' in c, attach_job: 'attach_job' in c, " +
@@ -111,8 +112,10 @@ describe('repl_loop local RPC transport', () => {
         resolve_message: false,
         submitOutput: true,
         submit_output: false,
-        listCompute: true,
-        list_compute: false,
+        listRegistered: true,
+        list: false,
+        listEnabled: true,
+        listCompute: false,
         callCommand: true,
         call_command: false,
         submitJob: true,
@@ -2857,7 +2860,7 @@ gate('repl_loop.js host.compute', () => {
     server.close()
   })
 
-  it('host.compute.list() posts op=list and returns the parsed result', async () => {
+  it('host.compute.listRegistered() posts op=list and returns the parsed result', async () => {
     next = {
       status: 200,
       body: { result: [{ provider_id: 'ssh:biowulf', display_name: 'biowulf' }] }
@@ -2867,11 +2870,41 @@ gate('repl_loop.js host.compute', () => {
       OPEN_SCIENCE_MCP_RPC_TOKEN: 'tok'
     })
     try {
-      const r = await send('return (await host.compute.list())[0].provider_id')
+      const r = await send('return (await host.compute.listRegistered())[0].provider_id')
       expect(r.error).toBeNull()
       expect(r.result).toContain('ssh:biowulf')
       expect(received.method).toBe('computeCall')
       expect(received.params?.op).toBe('list')
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
+  it('host.compute.listEnabled() posts op=list_compute with the spawn-env session id', async () => {
+    next = {
+      status: 200,
+      body: {
+        result: [
+          {
+            provider_id: 'ssh:biowulf',
+            display_name: 'biowulf',
+            shape: 'direct_ssh',
+            status: 'connected'
+          }
+        ]
+      }
+    }
+    const { child, send } = startLoop({
+      OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
+      OPEN_SCIENCE_MCP_RPC_TOKEN: 'tok',
+      OPEN_SCIENCE_NOTEBOOK_SESSION_ID: 'session-7'
+    })
+    try {
+      const r = await send('return (await host.compute.listEnabled())[0].status')
+      expect(r.error).toBeNull()
+      expect(r.result).toContain('connected')
+      expect(received.method).toBe('computeCall')
+      expect(received.params).toEqual({ op: 'list_compute', session_id: 'session-7' })
     } finally {
       child.kill()
     }

--- a/src/main/skills/materializer.test.ts
+++ b/src/main/skills/materializer.test.ts
@@ -289,7 +289,7 @@ describe('ClaudeCodeSkillMaterializer', () => {
         '## Registered hosts',
         '',
         '<!-- open-science:compute-hosts:start -->',
-        'Run `await host.compute.list()` to see all registered hosts.',
+        'Run `await host.compute.listRegistered()` to see all registered hosts.',
         '<!-- open-science:compute-hosts:end -->',
         '',
         '## API reference',

--- a/src/shared/compute.ts
+++ b/src/shared/compute.ts
@@ -92,6 +92,62 @@ export type ComputeHost = {
   updatedAt: number
 }
 
+// Agent-facing enumeration summary (computeCall op='list' / op='list_compute'). Intentionally
+// excludes detailsDoc (up to 32 KiB) and the probe snapshot — the dedicated details op serves those
+// on demand, and full objects at enumeration time overflow the agent-visible tool-result cap.
+export type ComputeHostSummary = {
+  provider_id: string
+  display_name: string
+  shape: ComputeHostShape
+  status: 'connected' | 'probe_failed' | 'not_probed'
+}
+
+// Agent-facing probe snapshot returned on demand by host.compute.details(). Keep the wire projection
+// here with the enumeration summary so the control REPL never has to understand renderer models.
+export type ComputeProbeSnapshot = {
+  ok: boolean
+  probed_at: string
+  exit_code: number | null
+  error_tail: string | null
+  os?: string
+  cpus?: number
+  mem_mib?: number
+  gpus?: ProbeGpu[]
+  detected_scheduler?: ProbeResult['detectedScheduler']
+}
+
+// Projects a full host to the agent enumeration summary. Pure and preload-safe.
+export const computeHostSummary = (host: ComputeHost): ComputeHostSummary => ({
+  provider_id: host.providerId,
+  display_name: host.displayName,
+  shape: host.shape,
+  status:
+    host.probeResult === undefined
+      ? 'not_probed'
+      : host.probeResult.ok
+        ? 'connected'
+        : 'probe_failed'
+})
+
+export const computeProbeSnapshot = (
+  probeResult: ProbeResult | undefined
+): ComputeProbeSnapshot | null =>
+  probeResult
+    ? {
+        ok: probeResult.ok,
+        probed_at: probeResult.probedAt,
+        exit_code: probeResult.exitCode,
+        error_tail: probeResult.errorTail,
+        ...(probeResult.os !== undefined ? { os: probeResult.os } : {}),
+        ...(probeResult.cpus !== undefined ? { cpus: probeResult.cpus } : {}),
+        ...(probeResult.memMib !== undefined ? { mem_mib: probeResult.memMib } : {}),
+        ...(probeResult.gpus !== undefined ? { gpus: probeResult.gpus } : {}),
+        ...(probeResult.detectedScheduler !== undefined
+          ? { detected_scheduler: probeResult.detectedScheduler }
+          : {})
+      }
+    : null
+
 // Add-form payload. displayName defaults to the alias; detailsDoc seeds the notes (author = user).
 export type CreateComputeHostRequest = {
   sshAlias: string


### PR DESCRIPTION
## Problem

Agent-side compute host enumeration returned full `ComputeHost` records, including details documents and probe snapshots. Large results could be truncated in the REPL kernel, forcing the Agent to retry with field projections and waste model tokens. Session-enabled enumeration also returned only provider ID strings, requiring another lookup before choosing among multiple hosts.

## Proposed change

- Replace `host.compute.list()` with `listRegistered()` and `listCompute()` with `listEnabled()` without compatibility aliases.
- Return the same compact `{ provider_id, display_name, shape, status }` summary from both enumeration methods.
- Preserve enabled-registry order while joining registered hosts and silently skip deleted host IDs.
- Keep details documents and probe snapshots out of enumeration; expose the full projected probe snapshot through `details()` on demand.
- Update bundled compute guidance and runtime surface coverage for the new names and return shape.

## Scope and non-goals

- No renderer enumeration behavior or `ComputeHost` IPC shape changes.
- No database schema or persistence changes.
- No compatibility layer for the retired Agent-facing methods.

## Acceptance criteria and validation

All checks below ran after the final material code edit. The later commit amendment changed only commit metadata.

- Compact registered/enabled enumeration, registry-order join, deleted-ID filtering, on-demand probe details, REPL mapping, and Skill consumers -> `npm test` -> 1112 files passed, 15 skipped; 16690 tests passed, 217 skipped.
- Node and renderer TypeScript consumers -> `npm run typecheck` -> passed.
- Source and tests -> `npm run lint` -> passed.
- Patch integrity -> `git diff --check origin/main...HEAD` -> passed.

`test:affected -- --base origin/main --head HEAD` selected full mode because `resources/notebook/repl_loop.js` is not mapped to a known Module. The initial run exposed a stale local Prisma Client after rebasing onto the new Tag schema; `npx prisma generate` refreshed the untracked dependency output, the nine affected database/Tag tests then passed, and the complete suite passed on the final run.

Consumer coverage includes both Node and Web typechecks because shared compute types are touched. No platform-specific, persistence, migration, build, or UI E2E behavior changed; the complete portable suite covers the affected runtime and contract paths, while exact-head PR Gate remains authoritative for platform lanes.

## Review focus

- Whether the four summary fields are sufficient for one-call Agent host selection.
- Separation between compact enumeration and on-demand probe/details reads.
- Preservation of enabled-registry ordering and omission of deleted hosts.
- Intentional breaking removal of `list` and `listCompute`.