### PR TITLE
refactor(connectors): extract application composition from ipc.ts

### DIFF
--- a/src/main/application-command-wiring.test.ts
+++ b/src/main/application-command-wiring.test.ts
@@ -37,7 +37,7 @@ const notificationAdapterBlock = compact(
   between(
     ipcSource,
     "declareElectronAdapter('task-notifications'",
-    '// One MCP client manager backs both dispatch'
+    'const connectorApplication = await modules.add('
   )
 )
 const dependencyBlock = compact(

--- a/src/main/connectors/application.test.ts
+++ b/src/main/connectors/application.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { composeApplicationRuntime } from '../application-runtime'
+import { createConnectorApplicationModule, type ConnectorApplicationDeps } from './application'
+
+describe('Connector application composition', () => {
+  it('reuses fakes and closes the MCP manager through runtime disposal', async () => {
+    const settings = {
+      getConnectors: vi.fn().mockResolvedValue({ customMcpServers: [] }),
+      saveCustomServerOAuthState: vi.fn().mockResolvedValue(undefined),
+      setCustomServerRuntimeProjectionProvider: vi.fn(),
+      setCustomServerAuthenticator: vi.fn(),
+      previewSkillArchive: vi.fn(),
+      importSkillArchiveBatch: vi.fn(),
+      scanRepoSkills: vi.fn().mockResolvedValue({ skills: [] }),
+      importSkill: vi.fn()
+    } as unknown as ConnectorApplicationDeps['settings']
+    const mcpClientManager = {
+      listTools: vi.fn().mockResolvedValue([]),
+      call: vi.fn(),
+      authenticate: vi.fn().mockResolvedValue(undefined),
+      cancelAuthentication: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+      closeAll: vi.fn().mockResolvedValue(undefined)
+    } as unknown as NonNullable<ConnectorApplicationDeps['mcpClientManager']>
+    const connectorApprovals = {
+      request: vi.fn().mockResolvedValue('once'),
+      respond: vi.fn(),
+      getPending: vi.fn().mockReturnValue(null),
+      pauseSession: vi.fn(),
+      resumeSession: vi.fn()
+    } as unknown as NonNullable<ConnectorApplicationDeps['connectorApprovals']>
+    const skillImportApprovals = {
+      createCancellationGuard: vi.fn().mockReturnValue({ isCancelled: () => false }),
+      createSessionCancellationGuard: vi.fn().mockReturnValue({ isCancelled: () => false }),
+      request: vi.fn(),
+      respond: vi.fn(),
+      replayPending: vi.fn(),
+      beginSessionTurn: vi.fn(),
+      endSessionTurn: vi.fn(),
+      allowSessionTurnAttachment: vi.fn(),
+      cancelSession: vi.fn(),
+      cancelAll: vi.fn()
+    } as unknown as NonNullable<ConnectorApplicationDeps['skillImportApprovals']>
+    const deps: ConnectorApplicationDeps = {
+      settings,
+      skillsDir: '/tmp/skills',
+      openExternal: vi.fn(),
+      notifyStatusChanged: vi.fn(),
+      broadcastConnectorApproval: vi.fn(),
+      replayConnectorApproval: vi.fn(),
+      onConnectorApprovalSettled: vi.fn(),
+      broadcastSkillImportApproval: vi.fn(),
+      onSkillImportSettled: vi.fn(),
+      onSkillImportLifecycleSettled: vi.fn(),
+      uploads: {} as ConnectorApplicationDeps['uploads'],
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+      resolveApiKey: vi.fn(),
+      resolveSpecialistProfile: vi.fn().mockResolvedValue(undefined),
+      mcpClientManager,
+      connectorApprovals,
+      skillImportApprovals
+    }
+    const runtime = await composeApplicationRuntime(async (modules) => ({
+      application: await modules.add(deps, createConnectorApplicationModule)
+    }))
+    const application = runtime.interfaces.application
+
+    expect(application.mcpClientManager).toBe(mcpClientManager)
+    expect(application.connectorApprovals).toBe(connectorApprovals)
+    expect(application.skillImportApprovals).toBe(skillImportApprovals)
+    expect(application.connectorService).toBeDefined()
+    expect(application.runtimeSettings).toBeDefined()
+    expect(application.skillImporter).toBeDefined()
+    expect(settings.setCustomServerRuntimeProjectionProvider).toHaveBeenCalledOnce()
+    expect(settings.setCustomServerAuthenticator).toHaveBeenCalledOnce()
+
+    await runtime.dispose()
+    expect(mcpClientManager.closeAll).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/connectors/application.test.ts
+++ b/src/main/connectors/application.test.ts
@@ -3,7 +3,17 @@ import { describe, expect, it, vi } from 'vitest'
 import { composeApplicationRuntime } from '../application-runtime'
 import { createConnectorApplicationModule, type ConnectorApplicationDeps } from './application'
 
-const createHarness = () => {
+type TestDoubles = Record<string, ReturnType<typeof vi.fn>>
+
+interface ConnectorApplicationHarness {
+  settings: TestDoubles
+  mcpClientManager: TestDoubles
+  connectorApprovals: TestDoubles
+  skillImportApprovals: TestDoubles
+  deps: ConnectorApplicationDeps
+}
+
+const createHarness = (): ConnectorApplicationHarness => {
   const settings = {
     getConnectors: vi.fn().mockResolvedValue({ customMcpServers: [] }),
     saveCustomServerOAuthState: vi.fn().mockResolvedValue(undefined),

--- a/src/main/connectors/application.test.ts
+++ b/src/main/connectors/application.test.ts
@@ -3,64 +3,76 @@ import { describe, expect, it, vi } from 'vitest'
 import { composeApplicationRuntime } from '../application-runtime'
 import { createConnectorApplicationModule, type ConnectorApplicationDeps } from './application'
 
+const createHarness = () => {
+  const settings = {
+    getConnectors: vi.fn().mockResolvedValue({ customMcpServers: [] }),
+    saveCustomServerOAuthState: vi.fn().mockResolvedValue(undefined),
+    setCustomServerRuntimeProjectionProvider: vi.fn(),
+    setCustomServerAuthenticator: vi.fn(),
+    previewSkillArchive: vi.fn(),
+    importSkillArchiveBatch: vi.fn(),
+    scanRepoSkills: vi.fn().mockResolvedValue({ skills: [] }),
+    importSkill: vi.fn()
+  }
+  const mcpClientManager = {
+    listTools: vi.fn().mockResolvedValue([]),
+    call: vi.fn(),
+    authenticate: vi.fn().mockResolvedValue(undefined),
+    cancelAuthentication: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    closeAll: vi.fn().mockResolvedValue(undefined)
+  }
+  const connectorApprovals = {
+    request: vi.fn().mockResolvedValue('once'),
+    respond: vi.fn(),
+    getPending: vi.fn().mockReturnValue(null),
+    pauseSession: vi.fn(),
+    resumeSession: vi.fn()
+  }
+  const skillImportApprovals = {
+    createCancellationGuard: vi.fn().mockReturnValue({ isCancelled: () => false }),
+    createSessionCancellationGuard: vi.fn().mockReturnValue({ isCancelled: () => false }),
+    request: vi.fn(),
+    respond: vi.fn(),
+    replayPending: vi.fn(),
+    beginSessionTurn: vi.fn(),
+    endSessionTurn: vi.fn(),
+    allowSessionTurnAttachment: vi.fn(),
+    cancelSession: vi.fn(),
+    cancelAll: vi.fn()
+  }
+  const deps: ConnectorApplicationDeps = {
+    settings: settings as unknown as ConnectorApplicationDeps['settings'],
+    skillsDir: '/tmp/skills',
+    openExternal: vi.fn(),
+    notifyStatusChanged: vi.fn(),
+    broadcastConnectorApproval: vi.fn(),
+    replayConnectorApproval: vi.fn(),
+    onConnectorApprovalSettled: vi.fn(),
+    broadcastSkillImportApproval: vi.fn(),
+    onSkillImportSettled: vi.fn(),
+    onSkillImportLifecycleSettled: vi.fn(),
+    uploads: {} as ConnectorApplicationDeps['uploads'],
+    fetchImpl: vi.fn() as unknown as typeof fetch,
+    resolveApiKey: vi.fn(),
+    resolveSpecialistProfile: vi.fn().mockResolvedValue(undefined),
+    mcpClientManager: mcpClientManager as unknown as NonNullable<
+      ConnectorApplicationDeps['mcpClientManager']
+    >,
+    connectorApprovals: connectorApprovals as unknown as NonNullable<
+      ConnectorApplicationDeps['connectorApprovals']
+    >,
+    skillImportApprovals: skillImportApprovals as unknown as NonNullable<
+      ConnectorApplicationDeps['skillImportApprovals']
+    >
+  }
+  return { settings, mcpClientManager, connectorApprovals, skillImportApprovals, deps }
+}
+
 describe('Connector application composition', () => {
   it('reuses fakes and closes the MCP manager through runtime disposal', async () => {
-    const settings = {
-      getConnectors: vi.fn().mockResolvedValue({ customMcpServers: [] }),
-      saveCustomServerOAuthState: vi.fn().mockResolvedValue(undefined),
-      setCustomServerRuntimeProjectionProvider: vi.fn(),
-      setCustomServerAuthenticator: vi.fn(),
-      previewSkillArchive: vi.fn(),
-      importSkillArchiveBatch: vi.fn(),
-      scanRepoSkills: vi.fn().mockResolvedValue({ skills: [] }),
-      importSkill: vi.fn()
-    } as unknown as ConnectorApplicationDeps['settings']
-    const mcpClientManager = {
-      listTools: vi.fn().mockResolvedValue([]),
-      call: vi.fn(),
-      authenticate: vi.fn().mockResolvedValue(undefined),
-      cancelAuthentication: vi.fn().mockResolvedValue(undefined),
-      close: vi.fn().mockResolvedValue(undefined),
-      closeAll: vi.fn().mockResolvedValue(undefined)
-    } as unknown as NonNullable<ConnectorApplicationDeps['mcpClientManager']>
-    const connectorApprovals = {
-      request: vi.fn().mockResolvedValue('once'),
-      respond: vi.fn(),
-      getPending: vi.fn().mockReturnValue(null),
-      pauseSession: vi.fn(),
-      resumeSession: vi.fn()
-    } as unknown as NonNullable<ConnectorApplicationDeps['connectorApprovals']>
-    const skillImportApprovals = {
-      createCancellationGuard: vi.fn().mockReturnValue({ isCancelled: () => false }),
-      createSessionCancellationGuard: vi.fn().mockReturnValue({ isCancelled: () => false }),
-      request: vi.fn(),
-      respond: vi.fn(),
-      replayPending: vi.fn(),
-      beginSessionTurn: vi.fn(),
-      endSessionTurn: vi.fn(),
-      allowSessionTurnAttachment: vi.fn(),
-      cancelSession: vi.fn(),
-      cancelAll: vi.fn()
-    } as unknown as NonNullable<ConnectorApplicationDeps['skillImportApprovals']>
-    const deps: ConnectorApplicationDeps = {
-      settings,
-      skillsDir: '/tmp/skills',
-      openExternal: vi.fn(),
-      notifyStatusChanged: vi.fn(),
-      broadcastConnectorApproval: vi.fn(),
-      replayConnectorApproval: vi.fn(),
-      onConnectorApprovalSettled: vi.fn(),
-      broadcastSkillImportApproval: vi.fn(),
-      onSkillImportSettled: vi.fn(),
-      onSkillImportLifecycleSettled: vi.fn(),
-      uploads: {} as ConnectorApplicationDeps['uploads'],
-      fetchImpl: vi.fn() as unknown as typeof fetch,
-      resolveApiKey: vi.fn(),
-      resolveSpecialistProfile: vi.fn().mockResolvedValue(undefined),
-      mcpClientManager,
-      connectorApprovals,
-      skillImportApprovals
-    }
+    const { settings, mcpClientManager, connectorApprovals, skillImportApprovals, deps } =
+      createHarness()
     const runtime = await composeApplicationRuntime(async (modules) => ({
       application: await modules.add(deps, createConnectorApplicationModule)
     }))
@@ -76,6 +88,18 @@ describe('Connector application composition', () => {
     expect(settings.setCustomServerAuthenticator).toHaveBeenCalledOnce()
 
     await runtime.dispose()
+    expect(mcpClientManager.closeAll).toHaveBeenCalledOnce()
+  })
+
+  it('closes the MCP manager when construction fails before runtime ownership', async () => {
+    const { settings, mcpClientManager, deps } = createHarness()
+    const failure = new Error('settings projection registration failed')
+    settings.setCustomServerRuntimeProjectionProvider.mockImplementationOnce(() => {
+      throw failure
+    })
+
+    await expect(createConnectorApplicationModule(deps)).rejects.toBe(failure)
+
     expect(mcpClientManager.closeAll).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/connectors/application.ts
+++ b/src/main/connectors/application.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto'
 
 import type { ApplicationModule } from '../application-runtime'
 import type { PermissionGrantRegistry } from '../permission-grants/registry'
-import type { SettingsService } from '../settings/service'
+import type { ConnectorApplicationSettingsCapabilities } from '../settings/service-capabilities'
 import type { UploadRepository } from '../uploads/repository'
 import type { SpecialistProfileView } from '../../shared/specialist'
 import type {
@@ -17,20 +17,8 @@ import { toCustomMcpConfig } from './custom-mcp-bootstrap'
 import { ConnectorRuntimeSettingsProjection } from './runtime-settings-projection'
 import { ConnectorService, type ConnectorCallContext } from './service'
 
-type ConnectorApplicationSettings = Pick<
-  SettingsService,
-  | 'getConnectors'
-  | 'saveCustomServerOAuthState'
-  | 'setCustomServerRuntimeProjectionProvider'
-  | 'setCustomServerAuthenticator'
-  | 'previewSkillArchive'
-  | 'importSkillArchiveBatch'
-  | 'scanRepoSkills'
-  | 'importSkill'
->
-
 export type ConnectorApplicationDeps = {
-  settings: ConnectorApplicationSettings
+  settings: ConnectorApplicationSettingsCapabilities
   skillsDir: string
   openExternal: (url: string) => Promise<void> | void
   notifyStatusChanged: () => void
@@ -81,16 +69,10 @@ const previewArgs = (args: Record<string, unknown>): string => {
   return json.length > 300 ? `${json.slice(0, 300)}…` : json
 }
 
-export const createConnectorApplicationModule = (
-  deps: ConnectorApplicationDeps
-): ApplicationModule<ConnectorApplication> => {
-  const mcpClientManager =
-    deps.mcpClientManager ??
-    new McpClientManager({
-      openExternal: deps.openExternal,
-      saveOAuthState: (serverId, state) => deps.settings.saveCustomServerOAuthState(serverId, state)
-    })
-
+const createConnectorApplication = (
+  deps: ConnectorApplicationDeps,
+  mcpClientManager: McpClientManager
+): ConnectorApplication => {
   const runtimeSettings = new ConnectorRuntimeSettingsProjection({
     readConnectors: () => deps.settings.getConnectors(),
     skillsDir: deps.skillsDir,
@@ -170,15 +152,40 @@ export const createConnectorApplicationModule = (
   })
 
   return {
-    name: 'connector-application',
-    capability: {
-      connectorService,
-      runtimeSettings,
-      mcpClientManager,
-      skillImporter,
-      connectorApprovals,
-      skillImportApprovals
-    },
-    dispose: () => mcpClientManager.closeAll()
+    connectorService,
+    runtimeSettings,
+    mcpClientManager,
+    skillImporter,
+    connectorApprovals,
+    skillImportApprovals
+  }
+}
+
+export const createConnectorApplicationModule = async (
+  deps: ConnectorApplicationDeps
+): Promise<ApplicationModule<ConnectorApplication>> => {
+  const mcpClientManager =
+    deps.mcpClientManager ??
+    new McpClientManager({
+      openExternal: deps.openExternal,
+      saveOAuthState: (serverId, state) => deps.settings.saveCustomServerOAuthState(serverId, state)
+    })
+
+  try {
+    return {
+      name: 'connector-application',
+      capability: createConnectorApplication(deps, mcpClientManager),
+      dispose: () => mcpClientManager.closeAll()
+    }
+  } catch (error) {
+    try {
+      await mcpClientManager.closeAll()
+    } catch (disposeError) {
+      throw new AggregateError(
+        [error, disposeError],
+        'Connector application construction and disposal failed.'
+      )
+    }
+    throw error
   }
 }

--- a/src/main/connectors/application.ts
+++ b/src/main/connectors/application.ts
@@ -1,0 +1,184 @@
+import { randomUUID } from 'node:crypto'
+
+import type { ApplicationModule } from '../application-runtime'
+import type { PermissionGrantRegistry } from '../permission-grants/registry'
+import type { SettingsService } from '../settings/service'
+import type { UploadRepository } from '../uploads/repository'
+import type { SpecialistProfileView } from '../../shared/specialist'
+import type {
+  ConnectorApprovalRequest,
+  ConversationSkillImportApprovalRequest
+} from '../../shared/settings'
+import { ConversationSkillImporter, SkillImportApprovalBroker } from '../skills/conversation-import'
+import { ApprovalBroker } from './approval-broker'
+import { ParserEngine } from './engine'
+import { McpClientManager } from './mcp-client-manager'
+import { toCustomMcpConfig } from './custom-mcp-bootstrap'
+import { ConnectorRuntimeSettingsProjection } from './runtime-settings-projection'
+import { ConnectorService, type ConnectorCallContext } from './service'
+
+type ConnectorApplicationSettings = Pick<
+  SettingsService,
+  | 'getConnectors'
+  | 'saveCustomServerOAuthState'
+  | 'setCustomServerRuntimeProjectionProvider'
+  | 'setCustomServerAuthenticator'
+  | 'previewSkillArchive'
+  | 'importSkillArchiveBatch'
+  | 'scanRepoSkills'
+  | 'importSkill'
+>
+
+export type ConnectorApplicationDeps = {
+  settings: ConnectorApplicationSettings
+  skillsDir: string
+  openExternal: (url: string) => Promise<void> | void
+  notifyStatusChanged: () => void
+  broadcastConnectorApproval: (request: ConnectorApprovalRequest) => void
+  replayConnectorApproval: (request: ConnectorApprovalRequest) => void
+  onConnectorApprovalSettled: (
+    id: string,
+    state: 'resolved' | 'rejected' | 'expired' | 'cancelled'
+  ) => void
+  broadcastSkillImportApproval: (request: ConversationSkillImportApprovalRequest) => void
+  onSkillImportSettled: (id: string) => void
+  onSkillImportLifecycleSettled: (id: string, state: 'resolved' | 'expired' | 'cancelled') => void
+  uploads: Pick<UploadRepository, 'resolveManagedUpload' | 'resolveSessionUpload'>
+  fetchImpl: typeof fetch
+  resolveApiKey: (ref?: string) => string | undefined
+  permissionGrantRegistry?: PermissionGrantRegistry
+  resolveSpecialistProfile: (specialistId: string) => Promise<SpecialistProfileView | undefined>
+  localToolHandlers?: Record<
+    string,
+    (
+      args: Record<string, unknown>,
+      context: ConnectorCallContext,
+      signal?: AbortSignal
+    ) => Promise<unknown>
+  >
+  onSkillsChanged?: () => void
+  mcpClientManager?: McpClientManager
+  connectorApprovals?: ApprovalBroker
+  skillImportApprovals?: SkillImportApprovalBroker
+}
+
+type ConnectorApplication = {
+  connectorService: ConnectorService
+  runtimeSettings: ConnectorRuntimeSettingsProjection
+  mcpClientManager: McpClientManager
+  skillImporter: ConversationSkillImporter
+  connectorApprovals: ApprovalBroker
+  skillImportApprovals: SkillImportApprovalBroker
+}
+
+const previewArgs = (args: Record<string, unknown>): string => {
+  let json: string
+  try {
+    json = JSON.stringify(args)
+  } catch {
+    json = '{…}'
+  }
+  return json.length > 300 ? `${json.slice(0, 300)}…` : json
+}
+
+export const createConnectorApplicationModule = (
+  deps: ConnectorApplicationDeps
+): ApplicationModule<ConnectorApplication> => {
+  const mcpClientManager =
+    deps.mcpClientManager ??
+    new McpClientManager({
+      openExternal: deps.openExternal,
+      saveOAuthState: (serverId, state) => deps.settings.saveCustomServerOAuthState(serverId, state)
+    })
+
+  const runtimeSettings = new ConnectorRuntimeSettingsProjection({
+    readConnectors: () => deps.settings.getConnectors(),
+    skillsDir: deps.skillsDir,
+    mcpClientManager,
+    notifyStatusChanged: deps.notifyStatusChanged
+  })
+
+  deps.settings.setCustomServerRuntimeProjectionProvider({
+    materializedSkillNames: () => runtimeSettings.materializedCustomSkillNames(),
+    availability: (id) => runtimeSettings.customServerAvailability(id),
+    isRefreshing: (id) => runtimeSettings.isRefreshing(id)
+  })
+  deps.settings.setCustomServerAuthenticator(
+    async (serverId) => {
+      const server = (await deps.settings.getConnectors())?.customMcpServers?.find(
+        (candidate) => candidate.id === serverId
+      )
+      if (!server) throw new Error(`Unknown custom connector: ${serverId}`)
+      await mcpClientManager.authenticate(toCustomMcpConfig(server))
+    },
+    (serverId) => mcpClientManager.cancelAuthentication(serverId)
+  )
+
+  const connectorApprovals =
+    deps.connectorApprovals ??
+    new ApprovalBroker({
+      generateId: () => randomUUID(),
+      onSettled: deps.onConnectorApprovalSettled,
+      broadcast: deps.broadcastConnectorApproval,
+      replay: deps.replayConnectorApproval
+    })
+  const skillImportApprovals =
+    deps.skillImportApprovals ??
+    new SkillImportApprovalBroker({
+      generateId: () => randomUUID(),
+      broadcast: deps.broadcastSkillImportApproval,
+      onSettled: deps.onSkillImportSettled,
+      onLifecycleSettled: deps.onSkillImportLifecycleSettled
+    })
+
+  const skillImporter = new ConversationSkillImporter({
+    uploads: deps.uploads,
+    createCancellationGuard: (sessionId, turnToken, attachmentUri) =>
+      skillImportApprovals.createCancellationGuard(sessionId, turnToken, attachmentUri),
+    createSessionCancellationGuard: (sessionId) =>
+      skillImportApprovals.createSessionCancellationGuard(sessionId),
+    previewBundle: (bundle) => deps.settings.previewSkillArchive(bundle),
+    importBundle: (bundle, items) => deps.settings.importSkillArchiveBatch(bundle, items),
+    scanGitHub: async (url) => (await deps.settings.scanRepoSkills({ repo: url })).skills,
+    importGitHub: (url) => deps.settings.importSkill({ url }),
+    requestApproval: (request, cancellation) => skillImportApprovals.request(request, cancellation),
+    onSkillsChanged: deps.onSkillsChanged
+  })
+
+  const connectorService = new ConnectorService({
+    engine: new ParserEngine({ fetchImpl: deps.fetchImpl }),
+    getConnectors: () => runtimeSettings.current(),
+    getConnectorsFresh: () => deps.settings.getConnectors(),
+    resolveApiKey: deps.resolveApiKey,
+    mcpClientManager,
+    permissionGrantRegistry: deps.permissionGrantRegistry,
+    requestApproval: ({ connector, method, args, sessionId, availableScopes }, signal) =>
+      connectorApprovals.request(
+        {
+          connector,
+          method,
+          argsPreview: previewArgs(args),
+          ...(sessionId ? { sessionId } : {}),
+          availableScopes
+        },
+        signal
+      ),
+    resolveSpecialistProfile: deps.resolveSpecialistProfile,
+    onCustomServerAvailabilityChanged: (serverId, availability) =>
+      runtimeSettings.setCustomServerDispatchAvailability(serverId, availability),
+    localToolHandlers: deps.localToolHandlers
+  })
+
+  return {
+    name: 'connector-application',
+    capability: {
+      connectorService,
+      runtimeSettings,
+      mcpClientManager,
+      skillImporter,
+      connectorApprovals,
+      skillImportApprovals
+    },
+    dispose: () => mcpClientManager.closeAll()
+  }
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -65,15 +65,11 @@ import { attachEnabledComputeHosts } from './compute/enabled-hosts-registry'
 import { SessionEnabledComputeHostsOwner } from './compute/session-enabled-hosts-owner'
 import { createComputeJobRuntime } from './compute/job-runtime'
 import { waitForInitialConnectorRefresh } from './connector-reload'
-import { ApprovalBroker } from './connectors/approval-broker'
-import { ParserEngine } from './connectors/engine'
-import { McpClientManager } from './connectors/mcp-client-manager'
-import { isCustomMcpServerRouteSafe, toCustomMcpConfig } from './connectors/custom-mcp-bootstrap'
+import { createConnectorApplicationModule } from './connectors/application'
+import { isCustomMcpServerRouteSafe } from './connectors/custom-mcp-bootstrap'
 import { createMoleculePreviewHandler } from './connectors/molecule-preview'
 import { ALL_CONNECTOR_IDS } from './connectors/registry'
-import { ConnectorRuntimeSettingsProjection } from './connectors/runtime-settings-projection'
 import { connectorSkillSourceDir } from './connectors/provision'
-import { ConnectorService } from './connectors/service'
 import { registerFileSaveHandlers } from './file-save'
 import { ImmutableInputAuthority } from './immutable-input-authority'
 import { createSessionArtifactFileResolver } from './session-artifact-file-resolver'
@@ -306,7 +302,6 @@ import {
   type ElectronRuntimeAdapterInterfaces,
   type NamedElectronSurfaceAdapter
 } from './runtime-electron-wiring'
-import { ConversationSkillImporter, SkillImportApprovalBroker } from './skills/conversation-import'
 import { HostSkillsService, type HostSkillsCatalog } from './skills/host-skills-service'
 import { UserSkillCatalogObserver } from './skills/user-skill-catalog-observer'
 import type { ConversationSkillImportApprovalResponse } from '../shared/settings'
@@ -362,17 +357,6 @@ type ApplicationModuleInterfaces = ApplicationRuntimeInterfaces & {
 
 type IpcRegistration = ApplicationRuntimeInterfaces & {
   dispose: () => Promise<void>
-}
-
-// Builds a short, human-readable preview of a connector call's arguments for the approval card.
-const previewArgs = (args: Record<string, unknown>): string => {
-  let json: string
-  try {
-    json = JSON.stringify(args)
-  } catch {
-    json = '{…}'
-  }
-  return json.length > 300 ? `${json.slice(0, 300)}…` : json
 }
 
 // Constructs application-owned modules and their narrow Electron adapter interfaces. The factory does
@@ -1263,126 +1247,69 @@ const createApplicationModules = async (
         : null
     )
   })
-  // One MCP client manager backs both dispatch (ConnectorService.call → custom server) and skill-doc
-  // generation (listTools) for user-added custom MCP servers (stdio + remote). It lazily connects per
-  // server, so constructing it here does not spawn anything until a custom server is actually used.
-  const mcpClientManager = await modules.add(undefined, () => {
-    const manager = new McpClientManager({
-      openExternal: (url) => shell.openExternal(url),
-      saveOAuthState: (serverId, state) =>
-        settingsService.saveCustomServerOAuthState(serverId, state)
-    })
-    return {
-      name: 'mcp-client-manager',
-      capability: manager,
-      dispose: () => manager.closeAll()
-    }
-  })
-  const connectorRuntimeSettings = new ConnectorRuntimeSettingsProjection({
-    readConnectors: () => settingsService.getConnectors(),
-    skillsDir: connectorSkillSourceDir(resolveStorageRoot()),
-    mcpClientManager,
-    notifyStatusChanged: () => broadcastToRenderers('settings:connector-runtime-changed', undefined)
-  })
-  settingsService.setCustomServerRuntimeProjectionProvider({
-    materializedSkillNames: () => connectorRuntimeSettings.materializedCustomSkillNames(),
-    availability: (id) => connectorRuntimeSettings.customServerAvailability(id),
-    isRefreshing: (id) => connectorRuntimeSettings.isRefreshing(id)
-  })
-  settingsService.setCustomServerAuthenticator(
-    async (serverId) => {
-      const server = (await settingsService.getConnectors())?.customMcpServers?.find(
-        (candidate) => candidate.id === serverId
-      )
-      if (!server) throw new Error(`Unknown custom connector: ${serverId}`)
-      await mcpClientManager.authenticate(toCustomMcpConfig(server))
-    },
-    (serverId) => mcpClientManager.cancelAuthentication(serverId)
-  )
-  // Bridges un-trusted connector calls to the renderer approval card. A tool call that isn't
-  // pre-allowed or skip-approved is held here until the user decides (or it auto-denies on timeout).
-  const approvalBroker = new ApprovalBroker({
-    generateId: () => randomUUID(),
-    onSettled: (id, state) => {
-      try {
-        broadcastToRenderers('connectors:approval-settled', id)
-      } finally {
-        void taskNotifications.settleAuthorization('connector', id, state)
-      }
-    },
-    broadcast: buildConnectorApprovalBroadcast({
-      broadcastToRenderers,
-      taskNotifications,
-      onNotificationError: (error) =>
-        notificationsLog.warn('connector approval notification failed', errorLogFields(error))
-    }),
-    replay: (request) => broadcastToRenderers('connectors:approval-request', request)
-  })
-  // The late-bound app runtime also serves connector tools that attach a generated file to the current
-  // turn. It is created below because it depends on the connector service.
-  const skillImportApprovalBroker = new SkillImportApprovalBroker({
-    generateId: () => randomUUID(),
-    broadcast: buildSkillImportApprovalBroadcast({
-      broadcastToRenderers,
-      taskNotifications,
-      onNotificationError: (error) =>
-        notificationsLog.warn('skill import approval notification failed', errorLogFields(error))
-    }),
-    onSettled: (id) => broadcastToRenderers('skills:conversation-import-settled', id),
-    onLifecycleSettled: (id, state) =>
-      void taskNotifications.settleAuthorization('skill-import', id, state)
-  })
-  const conversationSkillImporter = new ConversationSkillImporter({
-    uploads: uploadRepository,
-    createCancellationGuard: (sessionId, turnToken, attachmentUri) =>
-      skillImportApprovalBroker.createCancellationGuard(sessionId, turnToken, attachmentUri),
-    createSessionCancellationGuard: (sessionId) =>
-      skillImportApprovalBroker.createSessionCancellationGuard(sessionId),
-    previewBundle: (bundle) => settingsService.previewSkillArchive(bundle),
-    importBundle: (bundle, items) => settingsService.importSkillArchiveBatch(bundle, items),
-    scanGitHub: async (url) => (await settingsService.scanRepoSkills({ repo: url })).skills,
-    importGitHub: (url) => settingsService.importSkill({ url }),
-    requestApproval: (request, cancellation) =>
-      skillImportApprovalBroker.request(request, cancellation),
-    // If a prompt is active the coordinator defers the reconnect until its terminal event, making the
-    // new Skill available on the next user turn without interrupting the importing tool call.
-    onSkillsChanged: requestSkillCatalogRefresh
-  })
+  // The connector application owns MCP, connector/skill approval, runtime projection, and service
+  // construction. Late-bound local tools remain composition-root dependencies and are passed in.
   const moleculePreviewHandler = createMoleculePreviewHandler({
     writeArtifactForCurrentRun: (sessionId, input) => {
       if (!runtimeRef.current) throw new Error('Artifact runtime is not initialized.')
       return runtimeRef.current.writeArtifactForCurrentRun(sessionId, input)
     }
   })
-  const connectorService = new ConnectorService({
-    engine: new ParserEngine({ fetchImpl: netFetchStandard }),
-    getConnectors: () => connectorRuntimeSettings.current(),
-    getConnectorsFresh: () => settingsService.getConnectors(),
-    resolveApiKey: (ref) => tryDecryptKey(ref),
-    mcpClientManager,
-    permissionGrantRegistry,
-    requestApproval: ({ connector, method, args, sessionId, availableScopes }, signal) =>
-      approvalBroker.request(
-        {
-          connector,
-          method,
-          argsPreview: previewArgs(args),
-          ...(sessionId ? { sessionId } : {}),
-          availableScopes
-        },
-        signal
-      ),
-    resolveSpecialistProfile: async (specialistId) => {
-      try {
-        return await profileService.resolveRunnableById(specialistId)
-      } catch {
-        return undefined
-      }
+  const connectorApplication = await modules.add(
+    {
+      settings: settingsService,
+      skillsDir: connectorSkillSourceDir(resolveStorageRoot()),
+      openExternal: (url) => shell.openExternal(url),
+      notifyStatusChanged: () =>
+        broadcastToRenderers('settings:connector-runtime-changed', undefined),
+      broadcastConnectorApproval: buildConnectorApprovalBroadcast({
+        broadcastToRenderers,
+        taskNotifications,
+        onNotificationError: (error) =>
+          notificationsLog.warn('connector approval notification failed', errorLogFields(error))
+      }),
+      onConnectorApprovalSettled: (id, state) => {
+        try {
+          broadcastToRenderers('connectors:approval-settled', id)
+        } finally {
+          void taskNotifications.settleAuthorization('connector', id, state)
+        }
+      },
+      replayConnectorApproval: (request) =>
+        broadcastToRenderers('connectors:approval-request', request),
+      broadcastSkillImportApproval: buildSkillImportApprovalBroadcast({
+        broadcastToRenderers,
+        taskNotifications,
+        onNotificationError: (error) =>
+          notificationsLog.warn('skill import approval notification failed', errorLogFields(error))
+      }),
+      onSkillImportSettled: (id) => broadcastToRenderers('skills:conversation-import-settled', id),
+      onSkillImportLifecycleSettled: (id, state) =>
+        void taskNotifications.settleAuthorization('skill-import', id, state),
+      uploads: uploadRepository,
+      fetchImpl: netFetchStandard,
+      resolveApiKey: (ref) => tryDecryptKey(ref),
+      permissionGrantRegistry,
+      resolveSpecialistProfile: async (specialistId) => {
+        try {
+          return await profileService.resolveRunnableById(specialistId)
+        } catch {
+          return undefined
+        }
+      },
+      localToolHandlers: { 'molecule/preview_molecule': moleculePreviewHandler },
+      onSkillsChanged: requestSkillCatalogRefresh
     },
-    onCustomServerAvailabilityChanged: (serverId, availability) =>
-      connectorRuntimeSettings.setCustomServerDispatchAvailability(serverId, availability),
-    localToolHandlers: { 'molecule/preview_molecule': moleculePreviewHandler }
-  })
+    createConnectorApplicationModule
+  )
+  const {
+    connectorService,
+    runtimeSettings: connectorRuntimeSettings,
+    mcpClientManager,
+    skillImporter: conversationSkillImporter,
+    connectorApprovals: approvalBroker,
+    skillImportApprovals: skillImportApprovalBroker
+  } = connectorApplication
   // Register compute IPC handlers early so computeService can be wired into the notebook RPC server.
   // The approval broker in compute/ipc.ts broadcasts via BrowserWindow.getAllWindows(), which requires
   // Electron to be ready — this is always the case here since we're inside registerIpcHandlers.

--- a/src/main/settings/service-capabilities.ts
+++ b/src/main/settings/service-capabilities.ts
@@ -23,3 +23,15 @@ export type WindowSettingsCapabilities = Pick<
   SettingsService,
   'getAppIconVariant' | 'getClosePreference' | 'setClosePreference'
 >
+
+export type ConnectorApplicationSettingsCapabilities = Pick<
+  SettingsService,
+  | 'getConnectors'
+  | 'saveCustomServerOAuthState'
+  | 'setCustomServerRuntimeProjectionProvider'
+  | 'setCustomServerAuthenticator'
+  | 'previewSkillArchive'
+  | 'importSkillArchiveBatch'
+  | 'scanRepoSkills'
+  | 'importSkill'
+>


### PR DESCRIPTION
## Problem

The connector wiring in `src/main/ipc.ts`'s composition root inlined ~120 lines constructing the MCP client manager, connector/skill approval brokers, runtime settings projection, and connector service. That block is not unit-testable in isolation and grows an already-large file that also owns unrelated IPC handlers.

## Proposed change

Extract the block into `createConnectorApplicationModule` in a new `src/main/connectors/application.ts`. The factory takes a narrow `ConnectorApplicationDeps` (settings, broadcasts, uploads, fetch, key resolution, profile resolution, late-bound local tool handlers) and returns an `ApplicationModule` exposing the same instances `ipc.ts` used to build inline. `ipc.ts` now constructs the deps object and destructures the returned capability. Added `application.test.ts` — a composition test asserting that injected fakes are reused as-is and that `dispose()` closes the MCP manager through the runtime.

## Scope and non-goals

- Pure extraction; no behavior, interface, or instance-identity change. The same `McpClientManager`, `ApprovalBroker`, `SkillImportApprovalBroker`, `ConnectorRuntimeSettingsProjection`, `ConnectorService`, and `ConversationSkillImporter` flow to the same consumers under the same names.
- Late-bound local tool handlers (`molecule/preview_molecule`) stay a composition-root dependency, passed into the factory rather than owned by it.
- No new dependency, no settings/schema/migration change, no renderer touch.

## Acceptance criteria and validation

Checks ran after the last material edit.

| Behavior | Command | Result |
| --- | --- | --- |
| Connector application composition (fake reuse + dispose) | `npm test -- src/main/connectors/application.test.ts` | ✅ pass (1 test, exit 0) |
| Main-process compile, incl. `ipc.ts` consumer of the factory | `npm run typecheck:node` | ✅ pass (exit 0) |
| Lint across changed source | `npm run lint` | ✅ pass (exit 0, 0 errors) |

Consumer/exclusion rationale: `ipc.ts` is the sole consumer of the new factory and is covered by `typecheck:node`. No Interface or Adapter contract changed, so connector/IPC feature-slice and E2E suites were not re-run. The 10 lint warnings are all pre-existing in files outside this diff (`scripts/fix-electron-path.cjs`, `src/main/compute/job-notifier.test.ts`, `src/renderer/...`, `src/shared/remote-fs.ts`).

Uncovered risks: only Windows verified locally; exact-head CI remains authoritative for the other platform lanes.

## Review focus

Confirm the destructure in `ipc.ts` (`connectorService`, `runtimeSettings`, `mcpClientManager`, `skillImporter`, `connectorApprovals`, `skillImportApprovals`) maps 1:1 to the previously inlined instances and that `dispose` still calls `mcpClientManager.closeAll()`.
