### PR TITLE
fix(workspace): hold message queue until transcript reveal settles

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -343,6 +343,9 @@ class ElectronAppHarness implements ElectronApp {
       process.platform === 'win32' ? 'opencode.cmd' : 'opencode'
     )
     settings.opencodeVersion = '1.0.0'
+    // Specs assert English copy. Pin the locale so the host language can't leak in — Main
+    // resolves a 'system' preference from the OS language list, ignoring Chromium's --lang.
+    settings.localePreference = 'en'
     await writeFile(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf8')
     await this.launch()
     return this.page

--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -29,6 +29,7 @@ const RELIABLE_FAILURE_PROMPT = 'Start the reliable messaging post-fence failure
 const RELIABLE_FAILURE_OBSERVE_PROMPT = 'Observe the reliable messaging post-fence failure.'
 const RELIABLE_FAIRNESS_PROMPT = 'Start the reliable messaging fairness journey.'
 const LONG_STREAM_PROMPT = 'Stream the long scroll journey.'
+const QUEUE_GATE_PROMPT = 'Hold the queue until the reveal finishes.'
 const TOOL_ORDER_PROMPT = 'Run the ordered slow tool journey.'
 const RELIABLE_FAIRNESS_USER_PROMPT = 'Run the concurrent real user prompt.'
 const DELEGATION_INHERITED_SPECIALIST_PROMPT =
@@ -573,6 +574,36 @@ if (process.argv.includes('--version')) {
             }
           })
           await streamSegment(3, 8)
+          reply = ''
+        } else if (prompt.includes(QUEUE_GATE_PROMPT)) {
+          // Regression journey for queue dispatch gating: a slow lead-in, then one large final
+          // chunk so the renderer's paced reveal trails the store-complete state by seconds.
+          // An ungated queue would dispatch the next message mid-reveal.
+          const gateMessageId = `e2e-message-${nextMessageId++}`
+          for (let chunk = 0; chunk < 4; chunk += 1) {
+            await context.client.notify(acp.methods.client.session.update, {
+              sessionId: context.params.sessionId,
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                messageId: gateMessageId,
+                content: { type: 'text', text: `Queue gate lead-in chunk ${chunk}.\n\n` }
+              }
+            })
+            await delay(50)
+          }
+          await context.client.notify(acp.methods.client.session.update, {
+            sessionId: context.params.sessionId,
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              messageId: gateMessageId,
+              content: {
+                type: 'text',
+                text: 'Queue gate backlog paragraph: the reveal keeps pacing after the store completes. '.repeat(
+                  200
+                )
+              }
+            }
+          })
           reply = ''
         } else if (
           await submitReviewerPass(sessionRoutes.get(context.params.sessionId)?.mcpServers ?? [])

--- a/e2e/message-queue-presentation-gate.spec.ts
+++ b/e2e/message-queue-presentation-gate.spec.ts
@@ -1,0 +1,60 @@
+import { expect } from '@playwright/test'
+
+import { test } from './fixtures/electron-app'
+
+// Pacing must actually run: hidden windows emulate reduced motion (instant commits), so this
+// journey needs a normal window with live animation frames.
+test.use({ windowMode: 'normal' })
+
+const PROJECT_NAME = 'Queue presentation gate project'
+const WARMUP_PROMPT = 'Summarize the deterministic fixture.'
+const GATE_PROMPT = 'Hold the queue until the reveal finishes.'
+const FOLLOW_UP = 'Follow-up after the reveal.'
+// The fake agent replies with this fixed text for any prompt without a journey route.
+const AGENT_REPLY = 'Deterministic reply: Summarize the deterministic fixture.'
+
+test('holds the queued message until the previous reply finishes revealing', async ({ app }) => {
+  let page = await app.completeOnboarding()
+  page = await app.configureFakeAgent()
+
+  await page.getByRole('button', { name: 'New project' }).click()
+  const dialog = page.getByRole('dialog', { name: 'New project' })
+  await dialog.getByLabel('Name').fill(PROJECT_NAME)
+  await dialog.getByRole('button', { name: 'Create project' }).click()
+  await expect(page.getByRole('heading', { name: 'New conversation' })).toBeVisible()
+
+  const conversation = page.getByRole('region', { name: 'Conversation' })
+  const textbox = page.getByRole('textbox', { name: 'Ask anything' })
+  const sendButton = page.getByRole('button', { name: 'Send message' })
+
+  // Warm-up turn: queueing during a brand-new conversation's first turn is a separate flow;
+  // the presentation race this spec covers happens on an established session.
+  await textbox.fill(WARMUP_PROMPT)
+  await expect(sendButton).toBeEnabled()
+  await sendButton.click()
+  await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toHaveCount(1)
+
+  await textbox.fill(GATE_PROMPT)
+  await expect(sendButton).toBeEnabled()
+  await sendButton.click()
+
+  // Queue a follow-up while the gated turn is still streaming.
+  const queueSubmit = page.getByTestId('composer-queue-submit')
+  await expect(queueSubmit).toBeVisible()
+  await textbox.fill(FOLLOW_UP)
+  await queueSubmit.click()
+  const queueTrigger = page.getByTestId('composer-queue-trigger')
+  await expect(queueTrigger).toBeVisible()
+
+  // The fake agent's stream ends almost immediately (the session goes idle), but the giant
+  // final chunk keeps the paced reveal busy for seconds afterwards. Well past store-complete
+  // the follow-up must still be queued — an ungated queue dispatches the moment the session
+  // turns idle, mid-reveal.
+  await page.waitForTimeout(2000)
+  await expect(queueTrigger).toBeVisible()
+  await expect(conversation.getByText(FOLLOW_UP)).toHaveCount(0)
+
+  // Once the reveal settles, the queue drains and the follow-up turn completes.
+  await expect(conversation.getByText(FOLLOW_UP)).toBeVisible({ timeout: 30000 })
+  await expect(conversation.getByText(AGENT_REPLY, { exact: true }).last()).toBeVisible()
+})

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -830,6 +830,7 @@ const ConversationPanel = ({
             pendingElicitations={sideChat ? [] : sessionPendingElicitations}
             handoffLifecycleSource={workspaceHandoffLifecycleClient}
             onRetryHandoff={(request) => workspaceHandoffLifecycleClient.retry(request)}
+            reportPresentationRevealing
           />
         </WorkspaceMessageEditStateProvider>
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -86,6 +86,7 @@ import { useNotebookRunsById } from './use-notebook-runs-by-id'
 import { WorkspaceElicitationCard } from './WorkspaceElicitationCard'
 import { WorkspaceSubagentMessageRow } from './WorkspaceSubagentMessageRow'
 import { getNotebookRunIdFromActivity } from './workspace-tool-activity-details'
+import { setWorkspacePresentationRevealing } from './workspace-presentation-revealing'
 
 type WorkspaceMessageScrollerProps = {
   activeSession: ChatSession | undefined
@@ -99,6 +100,9 @@ type WorkspaceMessageScrollerProps = {
   // Events are read-only projections; retry sends an intent that main validates against its state.
   handoffLifecycleSource?: HandoffLifecycleEventSource
   onRetryHandoff?: (request: HandoffRetryRequest) => Promise<void>
+  // Opt-in (main panel only): report smooth-streaming reveal activity so the workspace
+  // message queue can hold queued sends until the transcript finishes presenting.
+  reportPresentationRevealing?: boolean
 }
 
 type TerminalAnnouncement = {
@@ -122,6 +126,10 @@ type SessionScopedActivityExpansionState = {
 }
 
 const EMPTY_ACTIVITY_EXPANSION_OVERRIDES: ActivityExpansionOverrides = {}
+
+// Extra hold after the paced reveal drains, so a queued message dispatches into a settled
+// transcript instead of the same moment as the final reveal frame.
+const PRESENTATION_SETTLE_MS = 500
 
 type SessionScopedMessagePresentationState = {
   scopeId: string | undefined
@@ -344,7 +352,8 @@ const WorkspaceMessageScrollerImpl = ({
   trailingContent,
   pendingElicitations = [],
   handoffLifecycleSource,
-  onRetryHandoff
+  onRetryHandoff,
+  reportPresentationRevealing = false
 }: WorkspaceMessageScrollerProps): React.JSX.Element => {
   const { t } = useTranslation()
   const currentSessionId = activeSession?.id
@@ -506,6 +515,26 @@ const WorkspaceMessageScrollerImpl = ({
     messagePresentationState.scopeId === currentPresentationScopeId
       ? messagePresentationState.messageIds
       : new Set<string>()
+  const presentationRevealing = presentingMessageIds.size > 0
+  // Let the workspace message queue hold queued sends until this transcript's reveal finishes,
+  // plus a short settle delay so the dispatched message's scroll anchor lands after the final
+  // frame. Session switch/unmount clears immediately so a stale flag can't deadlock a queue.
+  useEffect(() => {
+    if (!reportPresentationRevealing || !currentSessionId) return
+    if (presentationRevealing) {
+      setWorkspacePresentationRevealing(currentSessionId, true)
+      return
+    }
+    const settleTimer = setTimeout(
+      () => setWorkspacePresentationRevealing(currentSessionId, false),
+      PRESENTATION_SETTLE_MS
+    )
+    return () => clearTimeout(settleTimer)
+  }, [reportPresentationRevealing, currentSessionId, presentationRevealing])
+  useEffect(() => {
+    if (!reportPresentationRevealing || !currentSessionId) return
+    return () => setWorkspacePresentationRevealing(currentSessionId, false)
+  }, [reportPresentationRevealing, currentSessionId])
   const presentationBarrierIndex = conversationItems.findIndex(
     (item) => item.type === 'message' && presentingMessageIds.has(item.message.id)
   )
@@ -1438,6 +1467,7 @@ const areWorkspaceMessageScrollerPropsEqual = (
 ): boolean =>
   previous.onSendEditedMessage === next.onSendEditedMessage &&
   (previous.canBranchInNewSession ?? false) === (next.canBranchInNewSession ?? false) &&
+  (previous.reportPresentationRevealing ?? false) === (next.reportPresentationRevealing ?? false) &&
   previous.onBranchInNewSession === next.onBranchInNewSession &&
   previous.trailingContent === next.trailingContent &&
   previous.isResumingSession === next.isResumingSession &&

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
@@ -19,6 +19,7 @@ import {
   useWorkspaceMessageQueueController,
   type WorkspaceMessageQueueController
 } from './workspace-message-queue-controller'
+import { isWorkspacePresentationRevealing } from './workspace-presentation-revealing'
 import type { WorkspaceSessionController } from './workspace-session-controller'
 import { hasMainConversation } from './use-side-chat-controller'
 
@@ -229,6 +230,7 @@ const useWorkspaceConversationController = (
     },
     runtime: options.runtime,
     isBarrierInFlight: options.session.lifecycle.isBarrierInFlight,
+    isPresentationRevealing: isWorkspacePresentationRevealing,
     isSpecialistReady: (sessionId) => {
       const current = optionsRef.current
       return current.session.lifecycle.canStartSend(sessionId)

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
@@ -17,6 +17,10 @@ import {
   isWorkspaceSpecialistBarrierInFlight,
   setWorkspaceSpecialistBarrier
 } from './workspace-specialist-barrier'
+import {
+  isWorkspacePresentationRevealing,
+  setWorkspacePresentationRevealing
+} from './workspace-presentation-revealing'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -90,6 +94,7 @@ const options = (
     cancelRun: vi.fn(async () => undefined)
   },
   isBarrierInFlight: vi.fn(() => false),
+  isPresentationRevealing: vi.fn(() => false),
   isSpecialistReady: vi.fn(() => true),
   hasPendingPermissionRequest: vi.fn(() => false),
   abortFixLoop: vi.fn(async () => undefined),
@@ -149,6 +154,7 @@ const mounted: Hook[] = []
 afterEach(() => {
   for (const hook of mounted.splice(0)) hook.unmount()
   setWorkspaceSpecialistBarrier('session-a', false)
+  setWorkspacePresentationRevealing('session-a', false)
   vi.restoreAllMocks()
 })
 
@@ -221,6 +227,59 @@ describe('workspace message queue controller', () => {
     expect(input.runtime.sendMessage).not.toHaveBeenCalled()
 
     act(() => setWorkspaceSpecialistBarrier(currentSession.id, false))
+
+    await vi.waitFor(() => expect(input.runtime.sendMessage).toHaveBeenCalledOnce())
+  })
+
+  it('holds queued messages until the transcript presentation settles', async () => {
+    let currentSession = session()
+    let notifySessionChanged: (() => void) | undefined
+    setWorkspacePresentationRevealing(currentSession.id, true)
+    const input = options(currentSession, {
+      promptInFlightSessionIds: [],
+      isPresentationRevealing: isWorkspacePresentationRevealing,
+      getSession: () => currentSession,
+      subscribeSessionChanges: (listener) => {
+        notifySessionChanged = listener
+        return () => {
+          notifySessionChanged = undefined
+        }
+      }
+    })
+    const workspace = renderController(input)
+    mounted.push(workspace)
+
+    act(() => workspace.result.current.lifecycle.enqueue(admission('send after reveal')))
+    currentSession = session('idle')
+    act(() => notifySessionChanged?.())
+    expect(input.runtime.sendMessage).not.toHaveBeenCalled()
+
+    act(() => setWorkspacePresentationRevealing(currentSession.id, false))
+
+    await vi.waitFor(() => expect(input.runtime.sendMessage).toHaveBeenCalledOnce())
+  })
+
+  it('dispatches queued messages immediately when the session errored mid-reveal', async () => {
+    let currentSession = session()
+    let notifySessionChanged: (() => void) | undefined
+    setWorkspacePresentationRevealing(currentSession.id, true)
+    const input = options(currentSession, {
+      promptInFlightSessionIds: [],
+      isPresentationRevealing: isWorkspacePresentationRevealing,
+      getSession: () => currentSession,
+      subscribeSessionChanges: (listener) => {
+        notifySessionChanged = listener
+        return () => {
+          notifySessionChanged = undefined
+        }
+      }
+    })
+    const workspace = renderController(input)
+    mounted.push(workspace)
+
+    act(() => workspace.result.current.lifecycle.enqueue(admission('send despite error')))
+    currentSession = session('error')
+    act(() => notifySessionChanged?.())
 
     await vi.waitFor(() => expect(input.runtime.sendMessage).toHaveBeenCalledOnce())
   })

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
@@ -28,6 +28,7 @@ import {
   isWorkspaceSpecialistBarrierInFlight,
   subscribeWorkspaceSpecialistBarriers
 } from './workspace-specialist-barrier'
+import { subscribeWorkspacePresentationRevealing } from './workspace-presentation-revealing'
 import { useOpenSideChatParentSessionIds } from './use-side-chat-controller'
 import type { ComposerSendSnapshot } from './workspace-composer-controller'
 
@@ -87,6 +88,7 @@ type WorkspaceMessageQueueControllerOptions = {
   }
   runtime: Pick<WorkspaceAgentRuntime, 'sendMessage' | 'cancelRun'>
   isBarrierInFlight: (sessionId: string) => boolean
+  isPresentationRevealing: (sessionId: string) => boolean
   isSpecialistReady: (sessionId: string) => boolean
   hasPendingPermissionRequest: (sessionId: string) => boolean
   abortFixLoop: (request: { projectId: string; appSessionId: string }) => Promise<unknown>
@@ -243,8 +245,10 @@ const WorkspaceMessageQueueProvider = ({ children }: PropsWithChildren): ReactEl
   const [owner] = useState(() => new WorkspaceMessageQueueOwner())
   useEffect(() => {
     const unsubscribeBarriers = subscribeWorkspaceSpecialistBarriers(owner.requestDrain)
+    const unsubscribePresentation = subscribeWorkspacePresentationRevealing(owner.requestDrain)
     return () => {
       unsubscribeBarriers()
+      unsubscribePresentation()
       owner.dispose()
     }
   }, [owner])
@@ -324,6 +328,8 @@ const queueSessionIsSendable = (
 ): boolean =>
   session.archivedAt === undefined &&
   (session.status === 'idle' || session.status === 'error') &&
+  // Errored turns have no live reveal to wait for; let the queue proceed immediately.
+  (session.status === 'error' || !options.isPresentationRevealing(session.id)) &&
   !options.promptInFlightSessionIds.includes(session.id) &&
   !options.sendPreparationInFlightSessionIds.includes(session.id) &&
   !options.saveAsSkillInFlightSessionIds.includes(session.id) &&

--- a/src/renderer/src/pages/workspace/workspace-presentation-revealing.ts
+++ b/src/renderer/src/pages/workspace/workspace-presentation-revealing.ts
@@ -1,0 +1,28 @@
+let revealingSessionIds: ReadonlySet<string> = new Set()
+const listeners = new Set<() => void>()
+
+const getWorkspacePresentationRevealingSnapshot = (): ReadonlySet<string> => revealingSessionIds
+
+const subscribeWorkspacePresentationRevealing = (listener: () => void): (() => void) => {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+const setWorkspacePresentationRevealing = (sessionId: string, revealing: boolean): void => {
+  if (revealingSessionIds.has(sessionId) === revealing) return
+  const next = new Set(revealingSessionIds)
+  if (revealing) next.add(sessionId)
+  else next.delete(sessionId)
+  revealingSessionIds = next
+  for (const listener of listeners) listener()
+}
+
+const isWorkspacePresentationRevealing = (sessionId: string): boolean =>
+  revealingSessionIds.has(sessionId)
+
+export {
+  getWorkspacePresentationRevealingSnapshot,
+  isWorkspacePresentationRevealing,
+  setWorkspacePresentationRevealing,
+  subscribeWorkspacePresentationRevealing
+}


### PR DESCRIPTION
## Problem

`session.status` flips to `idle` the moment the provider stream closes, but the paced smooth-streaming reveal (`useSmoothStreamingContent` grapheme pacing + the scroller's presentation barrier) can keep presenting the previous reply for seconds afterwards. `queueSessionIsSendable()` only checked session-level gates, so the composer message queue dispatched the next queued message into that window: the new user message went out mid-reveal and its scroll anchor interrupted the previous reply's presentation.

## Proposed change

- Add a module-level per-session presentation-revealing signal (`workspace-presentation-revealing.ts`), mirroring the specialist-barrier precedent. The main `WorkspaceMessageScroller` reports while any transcript row is still revealing, and holds the flag for a 500 ms settle after the final frame so the queued message dispatches into a settled transcript.
- `queueSessionIsSendable()` holds dispatch until the flag clears. Errored sessions bypass the wait (no live reveal to wait for).
- The flag clears immediately on session switch/unmount so a stale flag can never deadlock a background queue; the subagent preview scroller does not report.
- New fake-agent journey: a slow lead-in followed by one giant final chunk, so the store completes seconds before the reveal drains. The regression spec asserts the queued message is still queued well past store-complete and dispatches only after the reveal settles.
- E2E fixture: pin `localePreference = 'en'` in the seeded `settings.json`. Since #1376, Main resolves a `system` locale preference from the OS language list (ignoring Chromium's `--lang`), which broke English locators on non-English hosts.

## Scope and non-goals

- The signal is renderer-memory only; nothing is written to Session JSON, SQLite, localStorage, or another durable format.
- The 500 ms settle is a fixed constant, not user-configurable.
- No changes to the smooth-streaming pacing itself, the presentation barrier, or scroll anchoring.
- Not addressed here (pre-existing, observed while testing): queueing during a brand-new conversation's first turn can silently drop the queued item when the session identity swaps.

## Acceptance criteria and validation

All listed checks ran after the last material edit, on top of current `main`.

- Queue controller unit tests, including the new presentation gate and error-bypass cases -> `npx vitest run src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts` -> 21 tests passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Regression journey -> `npx playwright test e2e/message-queue-presentation-gate.spec.ts` -> passed; the queue holds for ~8 s while the session is idle but still revealing, then dispatches after the settle.
- `e2e/message-scroll-release.spec.ts` -> passed. `message-scroll-anchor` / `message-scroll-reanchor` fail identically on a clean baseline checkout in this environment (pre-existing, unrelated to this change).

## Review focus

- Signal lifecycle: scroller -> module store -> queue drain, including session-switch/unmount clearing and the two-effect split for the settle delay.
- Placing the settle delay in the scroller's flag clearing rather than in the queue controller.

## Uncovered risks

- Non-visible (background) sessions never report revealing; their queues dispatch on session status alone, unchanged by this PR.
- Only the macOS e2e lane ran locally; Windows/Linux lanes are left to CI.

## Authors

- Roxi (@roxi3906)
