### PR TITLE
ci(signpath): integrate production Windows signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,12 @@ on:
           Used by the Nightly macos-x64 packaging dry-run; release/nightly leave it empty.
         type: string
         default: ''
+      windows_publisher_name:
+        description: >-
+          Exact Authenticode certificate subject baked into the Windows updater configuration.
+          Stable releases pass the SignPath production certificate subject; other builds omit it.
+        type: string
+        default: ''
 jobs:
   # Run the quality suite once on Apple Silicon beside the native package matrix. The reusable
   # workflow still fails when this job fails, so every caller's publish boundary remains fail closed
@@ -281,9 +287,10 @@ jobs:
         id: package
         shell: bash
         env:
-          # Windows remains unsigned until a code-signing certificate is provisioned. Stable macOS
-          # jobs consume the explicitly prepared keychain without exposing CSC_LINK to electron-builder.
+          # SignPath signs the final Windows installer after this build. The publisher subject is
+          # still baked into app-update.yml here so electron-updater verifies downloaded updates.
           CSC_KEYCHAIN: ${{ steps.mac_signing.outputs.keychain }}
+          WINDOWS_PUBLISHER_NAME: ${{ inputs.windows_publisher_name }}
           # macos-26-intel Node 22 x64 defaults to a ~2 GB old-space. The renderer production graph
           # (~6400 modules) OOMs during emit at that limit. This is a ceiling, not a reservation.
           NODE_OPTIONS: --max-old-space-size=8192
@@ -298,6 +305,10 @@ jobs:
             base=$(node -p "require('./package.json').version")
             eb_ver=(-c.extraMetadata.version="${base}-nightly.${GITHUB_SHA::7}")
           fi
+          windows_signing=()
+          if [ "${{ matrix.platform }}" = "win" ] && [ -n "$WINDOWS_PUBLISHER_NAME" ]; then
+            windows_signing=(-c.win.signtoolOptions.publisherName="$WINDOWS_PUBLISHER_NAME")
+          fi
           if [ "${{ steps.mac_signing.outputs.enabled }}" = "true" ]; then
             # Stable build with a Developer ID cert -> SIGN ONLY (notarize:false). Notarization +
             # stapling happens later in notarize-mac.yml, so this job never waits on Apple.
@@ -309,7 +320,7 @@ jobs:
             # (electron-updater's MacUpdater picks the right one by arch at download time). This avoids
             # the per-arch `${arch}-mac.yml` scheme, which shipped an app-update.yml the mac updater
             # never matched against the published feed names.
-            npx electron-builder ${{ matrix.eb_args }} "${eb_ver[@]}" --publish never \
+            npx electron-builder ${{ matrix.eb_args }} "${eb_ver[@]}" "${windows_signing[@]}" --publish never \
               -c.mac.notarize=false
           else
             # No prepared cert, or a nightly build (ad-hoc on purpose): skip electron-builder's own
@@ -323,7 +334,7 @@ jobs:
               # primary-signature assessment. Certificate-free and nightly builds must stay ad-hoc.
               unsigned_args=(-c.dmg.sign=false)
             fi
-            npx electron-builder ${{ matrix.eb_args }} "${eb_ver[@]}" "${unsigned_args[@]}" --publish never
+            npx electron-builder ${{ matrix.eb_args }} "${eb_ver[@]}" "${windows_signing[@]}" "${unsigned_args[@]}" --publish never
           fi
 
       - name: Clean up macOS signing keychain

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -4,6 +4,12 @@ name: Package Smoke
 # build.yml, so a failed smoke can be retried without rebuilding or re-signing any package.
 on:
   workflow_call:
+    inputs:
+      require_windows_authenticode:
+        description: Require a trusted signature from the configured SignPath production subject.
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -48,6 +54,32 @@ jobs:
           name: ${{ matrix.name }}
           path: dist
 
+      - name: Verify Windows Authenticode signature
+        if: matrix.platform == 'win' && inputs.require_windows_authenticode
+        shell: pwsh
+        env:
+          EXPECTED_PUBLISHER: ${{ vars.SIGNPATH_WINDOWS_PUBLISHER_NAME }}
+        run: |
+          $installers = @(Get-ChildItem -Path dist -Filter '*-win-x64-setup.exe' -File -Recurse)
+          if ($installers.Count -ne 1) {
+            Write-Error "Expected exactly one Windows setup EXE, found $($installers.Count)."
+            exit 1
+          }
+          if ([string]::IsNullOrWhiteSpace($env:EXPECTED_PUBLISHER)) {
+            Write-Error 'SIGNPATH_WINDOWS_PUBLISHER_NAME is required for production verification.'
+            exit 1
+          }
+          $signature = Get-AuthenticodeSignature -FilePath $installers[0].FullName
+          if ($signature.Status -ne 'Valid') {
+            Write-Error "Windows installer signature is not trusted: $($signature.Status) — $($signature.StatusMessage)"
+            exit 1
+          }
+          if ($signature.SignerCertificate.Subject -ne $env:EXPECTED_PUBLISHER) {
+            Write-Error "Unexpected Windows publisher: $($signature.SignerCertificate.Subject)"
+            exit 1
+          }
+          Write-Host "Verified Windows publisher: $($signature.SignerCertificate.Subject)"
+
       - name: Smoke test macOS packages
         if: matrix.platform == 'mac'
         timeout-minutes: 10
@@ -76,7 +108,11 @@ jobs:
           mv dist/database-migration-certification.json "$database_certification"
           authenticode=not-applicable
           if [ "${{ matrix.platform }}" = "win" ]; then
-            authenticode=not-required
+            if [ "${{ inputs.require_windows_authenticode }}" = "true" ]; then
+              authenticode=passed
+            else
+              authenticode=not-required
+            fi
           fi
           node scripts/ci/release-certification-evidence.mjs write \
             --platform "${{ matrix.name }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,19 +43,51 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         run: git merge-base --is-ancestor "$GITHUB_SHA" origin/main
 
+      - name: Require Windows signing configuration
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        env:
+          WINDOWS_PUBLISHER_NAME: ${{ vars.SIGNPATH_WINDOWS_PUBLISHER_NAME }}
+        run: |
+          if [ -z "$WINDOWS_PUBLISHER_NAME" ]; then
+            echo "SIGNPATH_WINDOWS_PUBLISHER_NAME must equal the production certificate subject." >&2
+            exit 1
+          fi
+
   # Build the platform matrix (macOS arm64/x64 + Linux + Windows x64) via the reusable workflow.
   # secrets: inherit forwards the optional signing/notarization secrets. macOS is signed but NOT
   # notarized here — notarization is decoupled into the notarize-mac job below.
   build:
     needs: release-preflight
     uses: ./.github/workflows/build.yml
+    with:
+      windows_publisher_name: ${{ vars.SIGNPATH_WINDOWS_PUBLISHER_NAME }}
+    secrets: inherit
+
+  # Sign the final NSIS setup EXE, then regenerate latest.yml and its blockmap from the signed bytes.
+  # Re-emitting windows-x64 makes every downstream consumer use the finalized artifact.
+  sign-windows:
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    permissions:
+      actions: write
+      contents: read
+    uses: ./.github/workflows/signpath-windows.yml
+    with:
+      signing_policy_slug: release-signing
+      test_certificate: false
+      output_artifact_name: windows-x64
     secrets: inherit
 
   # Exercise the exact uploaded packages in separate native jobs. A failed matrix leg can be retried
   # against the immutable build artifact without repeating installation, packaging, or signing.
   package-smoke:
-    needs: build
+    needs: [build, sign-windows]
+    if: >-
+      always() && needs.build.result == 'success' &&
+      (needs.sign-windows.result == 'success' || needs.sign-windows.result == 'skipped')
     uses: ./.github/workflows/package-smoke.yml
+    with:
+      require_windows_authenticode: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
 
   # Exercise advisory regression in this low-privilege build run and retain its diagnostics without
   # allowing known flakes to override the blocking build + package-smoke result.
@@ -109,6 +141,7 @@ jobs:
           --directory artifacts
           --output artifacts/RELEASE-CERTIFICATION.json
           --expected-sha "$GITHUB_SHA"
+          --require-signed-windows
 
       # Merge the two per-arch mac feeds (from notarize-mac) into the single latest-mac.yml the
       # installed app polls (default `latest` channel). No-ops if the mac feeds are absent.

--- a/.github/workflows/signpath-test.yml
+++ b/.github/workflows/signpath-test.yml
@@ -2,10 +2,9 @@ name: SignPath Windows (dry-run)
 
 # Manual, no-publish Windows Authenticode integration check.
 #
-# Reuses the release build workflow for Windows x64 only, extracts exactly one NSIS setup EXE from
-# its immutable build artifact, and submits that raw PE file to SignPath's test-signing policy. The
-# signed installer is retained as a run artifact for inspection. This workflow never creates or
-# modifies a GitHub Release and does not change the release/nightly publishing path.
+# Reuses the release build workflow for Windows x64 only, then calls the same finalization boundary
+# as a stable release with SignPath's self-signed test certificate. This workflow never creates or
+# modifies a GitHub Release.
 on:
   workflow_dispatch:
 
@@ -23,98 +22,17 @@ jobs:
     with:
       platform_name: windows-x64
       skip_verify: true
+      windows_publisher_name: "CN=Test certificate for 'Open Science [OSS]'"
 
   sign-installer:
     name: Sign Windows installer with SignPath test certificate
     needs: build
-    runs-on: windows-latest
-    timeout-minutes: 20
-    steps:
-      - name: Download Windows build artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: windows-x64
-          path: unsigned
-
-      - name: Select unsigned NSIS installer
-        id: installer
-        shell: pwsh
-        run: |
-          $installers = @(Get-ChildItem -Path unsigned -Filter '*-win-x64-setup.exe' -File -Recurse)
-          if ($installers.Count -ne 1) {
-            Write-Error "Expected exactly one Windows setup EXE, found $($installers.Count)."
-            exit 1
-          }
-          "path=$($installers[0].FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-
-      # SignPath's artifact configuration is a raw <pe-file>. upload-artifact@v7's archive:false
-      # keeps the GitHub artifact as the EXE instead of wrapping it in the default ZIP container.
-      - name: Upload raw installer for SignPath
-        id: upload-unsigned-installer
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          path: ${{ steps.installer.outputs.path }}
-          archive: false
-          retention-days: 1
-          if-no-files-found: error
-
-      - name: Submit SignPath test signing request
-        uses: signpath/github-action-submit-signing-request@c92b958760219087e01f8d67a1669ed57afe2627 # v2
-        with:
-          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
-          project-slug: open-science
-          signing-policy-slug: test-signing
-          artifact-configuration-slug: windows-installer
-          github-artifact-id: ${{ steps.upload-unsigned-installer.outputs.artifact-id }}
-          skip-decompress: true
-          wait-for-completion: true
-          wait-for-completion-timeout-in-seconds: 900
-          output-artifact-directory: ${{ runner.temp }}/signpath-signed
-
-      - name: Verify Authenticode signature was added
-        id: signed-installer
-        shell: pwsh
-        run: |
-          $installers = @(Get-ChildItem -Path '${{ runner.temp }}/signpath-signed' -Filter '*.exe' -File -Recurse)
-          if ($installers.Count -ne 1) {
-            Write-Error "Expected exactly one signed EXE, found $($installers.Count)."
-            exit 1
-          }
-          $signature = Get-AuthenticodeSignature -FilePath $installers[0].FullName
-          if ($null -eq $signature.SignerCertificate) {
-            Write-Error "SignPath returned an artifact without a signer certificate. Status: $($signature.Status)."
-            exit 1
-          }
-
-          Write-Host "Initial signature status: $($signature.Status)"
-          Write-Host "Initial status message: $($signature.StatusMessage)"
-          Write-Host "Signer: $($signature.SignerCertificate.Subject)"
-
-          $expectedTestCertificateSubject = "CN=Test certificate for 'Open Science [OSS]'"
-          $expectedUntrustedRootMessage = 'A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.'
-          $isExpectedSelfSignedTestCertificate = (
-            $signature.SignerCertificate.Subject -eq $signature.SignerCertificate.Issuer -and
-            $signature.SignerCertificate.Subject -eq $expectedTestCertificateSubject
-          )
-          $isExpectedUntrustedStatus = (
-            $signature.Status -eq 'NotTrusted' -or
-            ($signature.Status -eq 'UnknownError' -and $signature.StatusMessage -eq $expectedUntrustedRootMessage)
-          )
-
-          if ($signature.Status -ne 'Valid' -and -not (
-            $isExpectedSelfSignedTestCertificate -and $isExpectedUntrustedStatus
-          )) {
-            Write-Error "SignPath returned an unacceptable Authenticode signature: $($signature.Status) — $($signature.StatusMessage)"
-            exit 1
-          }
-
-          "path=$($installers[0].FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-
-      - name: Upload signed installer
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: signpath-test-windows-x64
-          path: ${{ steps.signed-installer.outputs.path }}
-          retention-days: 7
-          if-no-files-found: error
+    permissions:
+      actions: write
+      contents: read
+    uses: ./.github/workflows/signpath-windows.yml
+    with:
+      signing_policy_slug: test-signing
+      test_certificate: true
+      output_artifact_name: signpath-test-windows-x64
+    secrets: inherit

--- a/.github/workflows/signpath-windows.yml
+++ b/.github/workflows/signpath-windows.yml
@@ -1,0 +1,175 @@
+name: Finalize Windows installer with SignPath
+
+# Reusable post-build boundary for Windows releases. SignPath changes the final NSIS installer
+# bytes, so this workflow also rebuilds the blockmap and updates latest.yml before re-emitting the
+# complete artifact consumed by package smoke and publication.
+on:
+  workflow_call:
+    inputs:
+      signing_policy_slug:
+        description: SignPath signing policy to use (`test-signing` or `release-signing`).
+        required: true
+        type: string
+      test_certificate:
+        description: Accept the Foundation self-signed test certificate instead of requiring trust.
+        required: false
+        type: boolean
+        default: false
+      output_artifact_name:
+        description: Artifact name containing the signed installer and refreshed update metadata.
+        required: true
+        type: string
+    secrets:
+      SIGNPATH_API_TOKEN:
+        required: true
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  sign:
+    name: Sign and finalize Windows installer
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout finalization tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install metadata dependencies
+        run: npm ci --ignore-scripts --omit=optional --no-audit --no-fund
+
+      - name: Download Windows build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: windows-x64
+          path: windows
+
+      - name: Select unsigned NSIS installer
+        id: installer
+        shell: pwsh
+        run: |
+          $installers = @(Get-ChildItem -Path windows -Filter '*-win-x64-setup.exe' -File -Recurse)
+          if ($installers.Count -ne 1) {
+            Write-Error "Expected exactly one Windows setup EXE, found $($installers.Count)."
+            exit 1
+          }
+          "path=$($installers[0].FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      # The SignPath artifact configuration is a raw <pe-file>; do not wrap this upload in ZIP.
+      - name: Upload raw installer for SignPath
+        id: upload-unsigned-installer
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: signpath-unsigned-windows-installer
+          path: ${{ steps.installer.outputs.path }}
+          archive: false
+          overwrite: true
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Submit SignPath signing request
+        uses: signpath/github-action-submit-signing-request@c92b958760219087e01f8d67a1669ed57afe2627 # v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: open-science
+          signing-policy-slug: ${{ inputs.signing_policy_slug }}
+          artifact-configuration-slug: windows-installer
+          github-artifact-id: ${{ steps.upload-unsigned-installer.outputs.artifact-id }}
+          skip-decompress: true
+          wait-for-completion: true
+          wait-for-completion-timeout-in-seconds: 900
+          output-artifact-directory: ${{ runner.temp }}/signpath-signed
+
+      - name: Verify and install signed artifact
+        shell: pwsh
+        env:
+          EXPECTED_PUBLISHER: ${{ vars.SIGNPATH_WINDOWS_PUBLISHER_NAME }}
+        run: |
+          $signedInstallers = @(
+            Get-ChildItem -Path '${{ runner.temp }}/signpath-signed' -Filter '*.exe' -File -Recurse
+          )
+          if ($signedInstallers.Count -ne 1) {
+            Write-Error "Expected exactly one signed EXE, found $($signedInstallers.Count)."
+            exit 1
+          }
+
+          $signedInstaller = $signedInstallers[0]
+          $signature = Get-AuthenticodeSignature -FilePath $signedInstaller.FullName
+          if ($null -eq $signature.SignerCertificate) {
+            Write-Error "SignPath returned an artifact without a signer certificate. Status: $($signature.Status)."
+            exit 1
+          }
+
+          Write-Host "Signature status: $($signature.Status)"
+          Write-Host "Status message: $($signature.StatusMessage)"
+          Write-Host "Signer: $($signature.SignerCertificate.Subject)"
+
+          $testCertificate = '${{ inputs.test_certificate }}' -eq 'true'
+          if ($testCertificate) {
+            $expectedSubject = "CN=Test certificate for 'Open Science [OSS]'"
+            $expectedUntrustedRootMessage = 'A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.'
+            $isExpectedCertificate = (
+              $signature.SignerCertificate.Subject -eq $signature.SignerCertificate.Issuer -and
+              $signature.SignerCertificate.Subject -eq $expectedSubject
+            )
+            $isExpectedStatus = (
+              $signature.Status -eq 'NotTrusted' -or
+              ($signature.Status -eq 'UnknownError' -and
+                $signature.StatusMessage -eq $expectedUntrustedRootMessage)
+            )
+            if (-not $isExpectedCertificate) {
+              Write-Error "SignPath returned the wrong test signer: $($signature.SignerCertificate.Subject)"
+              exit 1
+            }
+            if ($signature.Status -ne 'Valid' -and -not $isExpectedStatus) {
+              Write-Error "SignPath returned an unacceptable test signature: $($signature.Status) — $($signature.StatusMessage)"
+              exit 1
+            }
+          } else {
+            if ($signature.Status -ne 'Valid') {
+              Write-Error "Production Authenticode signature is not trusted: $($signature.Status) — $($signature.StatusMessage)"
+              exit 1
+            }
+            if ([string]::IsNullOrWhiteSpace($env:EXPECTED_PUBLISHER)) {
+              Write-Error 'SIGNPATH_WINDOWS_PUBLISHER_NAME is required for production verification.'
+              exit 1
+            }
+            if ($signature.SignerCertificate.Subject -ne $env:EXPECTED_PUBLISHER) {
+              Write-Error "Unexpected production publisher: $($signature.SignerCertificate.Subject)"
+              exit 1
+            }
+          }
+
+          Copy-Item -LiteralPath $signedInstaller.FullName -Destination '${{ steps.installer.outputs.path }}' -Force
+
+      - name: Refresh Windows release metadata
+        run: node scripts/refresh-windows-release-metadata.mjs --artifact-dir windows
+
+      - name: Upload finalized Windows artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ inputs.output_artifact_name }}
+          overwrite: true
+          retention-days: 7
+          path: windows/*
+          if-no-files-found: error
+
+      # publish downloads every artifact in the run. Remove the raw unsigned input even when a
+      # preceding signing/finalization step fails so it can never collide with release assets.
+      - name: Delete temporary unsigned artifact
+        if: always() && steps.upload-unsigned-installer.outputs.artifact-id != ''
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ID: ${{ steps.upload-unsigned-installer.outputs.artifact-id }}
+        run: >-
+          gh api --method DELETE
+          "repos/$env:GITHUB_REPOSITORY/actions/artifacts/$env:ARTIFACT_ID"

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "@vitejs/plugin-react": "^5.1.1",
         "@vitest/coverage-v8": "^4.1.10",
         "3dmol": "^2.5.5",
+        "app-builder-lib": "26.15.3",
         "axe-core": "^4.12.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "@vitejs/plugin-react": "^5.1.1",
     "@vitest/coverage-v8": "^4.1.10",
     "3dmol": "^2.5.5",
+    "app-builder-lib": "26.15.3",
     "axe-core": "^4.12.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/scripts/ci/release-certification-evidence.mjs
+++ b/scripts/ci/release-certification-evidence.mjs
@@ -214,10 +214,11 @@ const aggregateEvidence = async ({ argv }) => {
   const outputArgument = argumentValue(argv, '--output')
   const expectedSha = argumentValue(argv, '--expected-sha')
   const requireWindowsUpdate = argv.includes('--require-windows-update')
+  const requireSignedWindows = argv.includes('--require-signed-windows')
   if (!directoryArgument || !outputArgument || !expectedSha) {
     throw new Error(
       'Usage: --directory <path> --output <path> --expected-sha <sha> ' +
-        '[--require-windows-update]'
+        '[--require-windows-update] [--require-signed-windows]'
     )
   }
   const directory = resolve(directoryArgument)
@@ -264,6 +265,13 @@ const aggregateEvidence = async ({ argv }) => {
     }
     if (record.checks.packageSmoke !== 'passed') {
       throw new Error(`Package smoke did not pass for ${platform}.`)
+    }
+    if (
+      requireSignedWindows &&
+      platform === 'windows-x64' &&
+      record.checks.authenticode !== 'passed'
+    ) {
+      throw new Error('Windows Authenticode did not pass for the release artifact.')
     }
   }
   let windowsUpdate

--- a/scripts/ci/release-certification-evidence.test.ts
+++ b/scripts/ci/release-certification-evidence.test.ts
@@ -291,6 +291,27 @@ describe('release certification evidence', () => {
       platforms: expect.arrayContaining([expect.objectContaining({ platform: 'windows-x64' })])
     })
 
+    await expect(
+      aggregateEvidence({ argv: [...args, '--require-signed-windows'] })
+    ).rejects.toThrow(/Windows Authenticode did not pass/)
+    await writeFile(
+      join(root, 'certification-windows-x64.json'),
+      JSON.stringify({
+        ...recordFor('windows-x64'),
+        checks: { ...recordFor('windows-x64').checks, authenticode: 'passed' }
+      })
+    )
+    await expect(
+      aggregateEvidence({ argv: [...args, '--require-signed-windows'] })
+    ).resolves.toMatchObject({
+      platforms: expect.arrayContaining([
+        expect.objectContaining({
+          platform: 'windows-x64',
+          checks: expect.objectContaining({ authenticode: 'passed' })
+        })
+      ])
+    })
+
     await writeFile(
       join(root, 'certification-macos-arm64.json'),
       JSON.stringify({

--- a/scripts/refresh-windows-release-metadata.mjs
+++ b/scripts/refresh-windows-release-metadata.mjs
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+import { readFile, readdir, writeFile } from 'node:fs/promises'
+import { basename, join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import blockmap from 'app-builder-lib/out/targets/blockmap/blockmap.js'
+import { dump, load } from 'js-yaml'
+
+const { buildBlockMap } = blockmap
+const WINDOWS_INSTALLER = /-win-x64-setup\.exe$/
+
+const argumentValue = (argv, name) => {
+  const index = argv.indexOf(name)
+  return index === -1 ? undefined : argv[index + 1]
+}
+
+const refreshWindowsReleaseMetadata = async ({ artifactDirectory }) => {
+  const directory = resolve(artifactDirectory)
+  const names = await readdir(directory)
+  const installers = names.filter((name) => WINDOWS_INSTALLER.test(name))
+  if (installers.length !== 1) {
+    throw new Error(
+      `Expected exactly one Windows setup EXE in ${directory}; found ${installers.length}.`
+    )
+  }
+
+  const installerName = installers[0]
+  const installerPath = join(directory, installerName)
+  const blockmapPath = `${installerPath}.blockmap`
+  const feedPath = join(directory, 'latest.yml')
+  const feed = load(await readFile(feedPath, 'utf8'))
+  if (!feed || typeof feed !== 'object' || !Array.isArray(feed.files)) {
+    throw new Error('latest.yml does not contain a files list.')
+  }
+
+  const matchingFiles = feed.files.filter(
+    (file) => file && typeof file === 'object' && basename(file.url ?? '') === installerName
+  )
+  if (matchingFiles.length !== 1 || basename(feed.path ?? '') !== installerName) {
+    throw new Error(`latest.yml does not identify exactly one ${installerName} release file.`)
+  }
+
+  const updateInfo = await buildBlockMap(installerPath, 'gzip', blockmapPath)
+  matchingFiles[0].sha512 = updateInfo.sha512
+  matchingFiles[0].size = updateInfo.size
+  feed.sha512 = updateInfo.sha512
+  await writeFile(feedPath, dump(feed, { lineWidth: -1, noRefs: true }), 'utf8')
+
+  return {
+    installerName,
+    size: updateInfo.size,
+    sha512: updateInfo.sha512
+  }
+}
+
+const main = async () => {
+  const artifactDirectory = argumentValue(process.argv.slice(2), '--artifact-dir')
+  if (!artifactDirectory) throw new Error('Usage: --artifact-dir <path>')
+  const result = await refreshWindowsReleaseMetadata({ artifactDirectory })
+  console.log(`Refreshed ${result.installerName}: size=${result.size}, sha512=${result.sha512}`)
+}
+
+const invokedAsScript =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+if (invokedAsScript) {
+  main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}
+
+export { refreshWindowsReleaseMetadata }

--- a/scripts/refresh-windows-release-metadata.test.ts
+++ b/scripts/refresh-windows-release-metadata.test.ts
@@ -1,0 +1,55 @@
+import { gunzipSync } from 'node:zlib'
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { load } from 'js-yaml'
+import { describe, expect, it } from 'vitest'
+
+import { refreshWindowsReleaseMetadata } from './refresh-windows-release-metadata.mjs'
+
+describe('refresh Windows release metadata', () => {
+  it('rebuilds the blockmap and feed from the signed installer bytes', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'windows-release-metadata-'))
+    const installerName = 'aipoch-open-science-0.17.0-win-x64-setup.exe'
+    const installerPath = join(root, installerName)
+    const blockmapPath = `${installerPath}.blockmap`
+    await writeFile(installerPath, Buffer.from('signed installer bytes'))
+    await writeFile(blockmapPath, Buffer.from('stale blockmap'))
+    await writeFile(
+      join(root, 'latest.yml'),
+      [
+        'version: 0.17.0',
+        'files:',
+        `  - url: ${installerName}`,
+        '    sha512: stale',
+        '    size: 1',
+        `path: ${installerName}`,
+        'sha512: stale',
+        'releaseDate: 2026-08-19T00:00:00.000Z',
+        ''
+      ].join('\n')
+    )
+
+    const result = await refreshWindowsReleaseMetadata({ artifactDirectory: root })
+    const feed = load(await readFile(join(root, 'latest.yml'), 'utf8')) as {
+      files: Array<{ url: string; sha512: string; size: number }>
+      path: string
+      sha512: string
+    }
+    const blockmap = JSON.parse(gunzipSync(await readFile(blockmapPath)).toString('utf8')) as {
+      version: string
+      files: Array<{ sizes: number[] }>
+    }
+
+    expect(result).toMatchObject({ installerName, size: 22 })
+    expect(result.sha512).toMatch(/^[A-Za-z0-9+/]{86}==$/)
+    expect(feed).toMatchObject({
+      path: installerName,
+      sha512: result.sha512,
+      files: [{ url: installerName, sha512: result.sha512, size: result.size }]
+    })
+    expect(blockmap.version).toBe('2')
+    expect(blockmap.files[0].sizes.reduce((sum, size) => sum + size, 0)).toBe(result.size)
+  })
+})

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -98,7 +98,7 @@ describe('post-merge Windows validation', () => {
     expect(smoke['timeout-minutes']).toBe(10)
   })
 
-  it('keeps Windows packaging unsigned until signing credentials are available', () => {
+  it('keeps electron-builder unsigned while baking in the expected updater publisher', () => {
     const build = readWorkflow('build.yml')
     const job = build.jobs.build
     const names = job.steps?.map(({ name }) => name) ?? []
@@ -122,7 +122,8 @@ describe('post-merge Windows validation', () => {
     expect(prepareMacSigning.run).toContain("grep -q 'Developer ID Application:'")
     expect(packageStep.env).toEqual({
       CSC_KEYCHAIN: '${{ steps.mac_signing.outputs.keychain }}',
-      NODE_OPTIONS: '--max-old-space-size=8192'
+      NODE_OPTIONS: '--max-old-space-size=8192',
+      WINDOWS_PUBLISHER_NAME: '${{ inputs.windows_publisher_name }}'
     })
     expect(packageStep.run).toContain(
       'if [ "${{ steps.mac_signing.outputs.enabled }}" = "true" ]; then'
@@ -143,27 +144,44 @@ describe('post-merge Windows validation', () => {
       'rm -f "$MAC_SIGNING_CERTIFICATE" "$MAC_SIGNING_KEYCHAIN_LIST"'
     )
     expect(packageStep.run).toContain('unsigned_args=(-c.dmg.sign=false)')
-    expect(packageStep.run).not.toContain('publisherName')
+    expect(packageStep.run).toContain(
+      '-c.win.signtoolOptions.publisherName="$WINDOWS_PUBLISHER_NAME"'
+    )
   })
 
   it('provides an isolated Windows-only SignPath dry-run', () => {
     const build = readWorkflow('build.yml')
     const inputs = build.on?.workflow_call?.inputs
     const workflow = readWorkflow('signpath-test.yml')
-    const sign = workflow.jobs['sign-installer']
+    const finalizer = readWorkflow('signpath-windows.yml')
+    const sign = finalizer.jobs.sign
     const uploadUnsigned = findStep(sign, 'Upload raw installer for SignPath')
-    const submit = findStep(sign, 'Submit SignPath test signing request')
-    const verify = findStep(sign, 'Verify Authenticode signature was added')
-    const uploadSigned = findStep(sign, 'Upload signed installer')
+    const submit = findStep(sign, 'Submit SignPath signing request')
+    const verify = findStep(sign, 'Verify and install signed artifact')
+    const uploadSigned = findStep(sign, 'Upload finalized Windows artifact')
 
     expect(inputs?.platform_name).toMatchObject({ type: 'string', default: '' })
+    expect(inputs?.windows_publisher_name).toMatchObject({ type: 'string', default: '' })
     expect(workflow.on).toEqual({ workflow_dispatch: null })
     expect(workflow).toMatchObject({ permissions: { actions: 'read', contents: 'read' } })
     expect(workflow.jobs.build).toMatchObject({
       uses: './.github/workflows/build.yml',
-      with: { platform_name: 'windows-x64', skip_verify: true }
+      with: {
+        platform_name: 'windows-x64',
+        skip_verify: true,
+        windows_publisher_name: "CN=Test certificate for 'Open Science [OSS]'"
+      }
     })
-    expect(sign).toMatchObject({ needs: 'build', 'runs-on': 'windows-latest' })
+    expect(workflow.jobs['sign-installer']).toMatchObject({
+      needs: 'build',
+      uses: './.github/workflows/signpath-windows.yml',
+      with: {
+        signing_policy_slug: 'test-signing',
+        test_certificate: true,
+        output_artifact_name: 'signpath-test-windows-x64'
+      },
+      secrets: 'inherit'
+    })
     expect(findStep(sign, 'Select unsigned NSIS installer').run).toContain('*-win-x64-setup.exe')
     expect(uploadUnsigned).toMatchObject({
       id: 'upload-unsigned-installer',
@@ -176,7 +194,7 @@ describe('post-merge Windows validation', () => {
         'api-token': '${{ secrets.SIGNPATH_API_TOKEN }}',
         'organization-id': '${{ vars.SIGNPATH_ORGANIZATION_ID }}',
         'project-slug': 'open-science',
-        'signing-policy-slug': 'test-signing',
+        'signing-policy-slug': '${{ inputs.signing_policy_slug }}',
         'artifact-configuration-slug': 'windows-installer',
         'github-artifact-id': '${{ steps.upload-unsigned-installer.outputs.artifact-id }}',
         'skip-decompress': true,
@@ -185,7 +203,7 @@ describe('post-merge Windows validation', () => {
     })
     expect(verify.run).toContain('Get-AuthenticodeSignature')
     expect(verify.run).toContain(
-      '$expectedTestCertificateSubject = "CN=Test certificate for \'Open Science [OSS]\'"'
+      '$expectedSubject = "CN=Test certificate for \'Open Science [OSS]\'"'
     )
     expect(verify.run).toContain('$expectedUntrustedRootMessage =')
     expect(verify.run).toContain("$signature.Status -eq 'UnknownError'")
@@ -193,13 +211,85 @@ describe('post-merge Windows validation', () => {
       '$signature.SignerCertificate.Subject -eq $signature.SignerCertificate.Issuer'
     )
     expect(verify.run).toContain('$signature.StatusMessage -eq $expectedUntrustedRootMessage')
+    expect(verify.run).toContain('if (-not $isExpectedCertificate)')
     expect(verify.run).not.toContain('X509Store')
     expect(uploadSigned.with).toMatchObject({
-      name: 'signpath-test-windows-x64',
+      name: '${{ inputs.output_artifact_name }}',
       'retention-days': 7,
       'if-no-files-found': 'error'
     })
     expect(workflow.jobs).not.toHaveProperty('publish')
+  })
+
+  it('finalizes the Windows release artifact through one reusable SignPath workflow', () => {
+    const release = readWorkflow('release.yml')
+    const dryRun = readWorkflow('signpath-test.yml')
+    const finalizer = readWorkflow('signpath-windows.yml')
+    const sign = finalizer.jobs.sign
+
+    expect(finalizer.on?.workflow_call?.inputs).toMatchObject({
+      signing_policy_slug: { type: 'string' },
+      test_certificate: { type: 'boolean', default: false },
+      output_artifact_name: { type: 'string' }
+    })
+    expect(release.jobs['sign-windows']).toMatchObject({
+      needs: 'build',
+      uses: './.github/workflows/signpath-windows.yml',
+      with: {
+        signing_policy_slug: 'release-signing',
+        test_certificate: false,
+        output_artifact_name: 'windows-x64'
+      }
+    })
+    expect(release.jobs['package-smoke'].needs).toEqual(['build', 'sign-windows'])
+    expect(dryRun.jobs['sign-installer']).toMatchObject({
+      needs: 'build',
+      uses: './.github/workflows/signpath-windows.yml',
+      with: {
+        signing_policy_slug: 'test-signing',
+        test_certificate: true,
+        output_artifact_name: 'signpath-test-windows-x64'
+      }
+    })
+    expect(findStep(sign, 'Submit SignPath signing request').with).toMatchObject({
+      'signing-policy-slug': '${{ inputs.signing_policy_slug }}'
+    })
+    expect(findStep(sign, 'Refresh Windows release metadata').run).toContain(
+      'scripts/refresh-windows-release-metadata.mjs'
+    )
+    expect(findStep(sign, 'Upload finalized Windows artifact').with).toMatchObject({
+      name: '${{ inputs.output_artifact_name }}',
+      overwrite: true
+    })
+    const cleanup = findStep(sign, 'Delete temporary unsigned artifact')
+    expect(cleanup.if).toContain('always()')
+    expect(cleanup.run).toContain('actions/artifacts/$env:ARTIFACT_ID')
+    expect(finalizer.permissions).toMatchObject({ actions: 'write', contents: 'read' })
+    expect(release.jobs['sign-windows'].permissions).toMatchObject({
+      actions: 'write',
+      contents: 'read'
+    })
+  })
+
+  it('requires production Authenticode during stable Windows package smoke', () => {
+    const release = readWorkflow('release.yml')
+    const smokeWorkflow = readWorkflow('package-smoke.yml')
+    const smoke = smokeWorkflow.jobs.smoke
+    const verify = findStep(smoke, 'Verify Windows Authenticode signature')
+    const evidence = findStep(smoke, 'Record platform certification evidence')
+
+    expect(smokeWorkflow.on?.workflow_call?.inputs?.require_windows_authenticode).toMatchObject({
+      type: 'boolean',
+      default: false
+    })
+    expect(release.jobs['package-smoke'].with?.require_windows_authenticode).toBe(
+      "${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}"
+    )
+    expect(verify.if).toBe("matrix.platform == 'win' && inputs.require_windows_authenticode")
+    expect(verify.run).toContain('Get-AuthenticodeSignature')
+    expect(verify.run).toContain("$signature.Status -ne 'Valid'")
+    expect(verify.env?.EXPECTED_PUBLISHER).toBe('${{ vars.SIGNPATH_WINDOWS_PUBLISHER_NAME }}')
+    expect(evidence.run).toContain('authenticode=passed')
   })
 
   it('separates immutable builds from blocking package smoke and advisory regressions', () => {
@@ -317,7 +407,7 @@ describe('post-merge Windows validation', () => {
     expect(release.jobs.build.uses).toBe('./.github/workflows/build.yml')
     expect(release).toMatchObject({ permissions: { actions: 'read', contents: 'write' } })
     expect(release.jobs['package-smoke']).toMatchObject({
-      needs: 'build',
+      needs: ['build', 'sign-windows'],
       uses: './.github/workflows/package-smoke.yml'
     })
     expect(release.jobs['notarize-mac'].needs).toEqual(['build', 'package-smoke'])
@@ -363,7 +453,7 @@ describe('post-merge Windows validation', () => {
     expect(commands.some((command) => command.startsWith('npm run typecheck'))).toBe(false)
   })
 
-  it('records unsigned Windows update diagnostics without blocking publishing', () => {
+  it('requires signed Windows evidence without making the historical upgrade drill blocking', () => {
     const release = readWorkflow('release.yml')
     const upgrade = readWorkflow('windows-upgrade-smoke.yml').jobs['windows-upgrade-smoke']
 
@@ -467,7 +557,7 @@ if ($artifactReservationBase -eq $artifactReservationCommit) {
     expect(release.jobs.publish.needs).toEqual(['build', 'package-smoke', 'notarize-mac'])
     expect(
       findStep(release.jobs.publish, 'Aggregate release certification evidence').run
-    ).not.toContain('--require-signed-windows')
+    ).toContain('--require-signed-windows')
     expect(
       findStep(release.jobs.publish, 'Aggregate release certification evidence').run
     ).not.toContain('--require-windows-update')
@@ -526,7 +616,14 @@ if ($artifactReservationBase -eq $artifactReservationCommit) {
       run: 'git merge-base --is-ancestor "$GITHUB_SHA" origin/main'
     })
     expect(release.jobs.build.needs).toBe('release-preflight')
-    expect(release.jobs.build.with?.require_windows_signing).toBeUndefined()
+    expect(release.jobs.build.with?.windows_publisher_name).toBe(
+      '${{ vars.SIGNPATH_WINDOWS_PUBLISHER_NAME }}'
+    )
+    const requireWindowsSigning = findStep(preflight, 'Require Windows signing configuration')
+    expect(requireWindowsSigning.if).toBe(stableTagCondition)
+    expect(requireWindowsSigning.env?.WINDOWS_PUBLISHER_NAME).toBe(
+      '${{ vars.SIGNPATH_WINDOWS_PUBLISHER_NAME }}'
+    )
     expect(release.jobs['notarize-mac'].if).toBe(stableTagCondition)
     expect(release.jobs['windows-upgrade-smoke']).toBeUndefined()
     expect(release.jobs.publish.if).toBe(stableTagCondition)
@@ -588,7 +685,7 @@ if ($artifactReservationBase -eq $artifactReservationCommit) {
       'notarize-mac.yml',
       'package-smoke.yml',
       'release.yml',
-      'signpath-test.yml',
+      'signpath-windows.yml',
       'mirror-to-website.yml',
       'windows-upgrade-smoke.yml'
     ]) {


### PR DESCRIPTION
## Problem

The Windows release build currently emits an unsigned NSIS setup executable. The manual SignPath
test workflow proves that SignPath can sign the outer installer, but stable Release jobs do not yet
finalize the installer through the production policy. Signing also changes installer bytes, which
invalidates electron-builder's original `latest.yml` hash/size and blockmap.

## Proposed change

- Add one reusable SignPath finalizer for both test and production policies.
- Submit only the final NSIS setup EXE, verify the returned Authenticode signer, and replace the
  complete Windows build artifact before package smoke.
- Regenerate the Windows blockmap and `latest.yml` SHA-512/size from the signed installer.
- Require the configured production publisher Subject during stable package smoke and require
  signed-Windows certification evidence before publication.
- Bake `SIGNPATH_WINDOWS_PUBLISHER_NAME` into the packaged updater configuration through
  electron-builder's `win.signtoolOptions.publisherName` option.
- Delete the temporary unsigned SignPath input artifact so the Release's merged artifact download
  cannot collide with or publish unsigned bytes.
- Reuse the same path from `signpath-test.yml` with the Foundation self-signed test certificate.

## Scope and non-goals

- Phase 1 signs only `*-win-x64-setup.exe`.
- Pinned third-party `micromamba.exe` and `micromamba-compat.exe` remain unchanged and retain their
  existing archive/binary digest verification.
- The first-party unpacked application executable is not deep-signed in this phase.
- This PR does not create a Release or exercise the production certificate.

## Acceptance criteria and validation

Final evidence after the last material edit:

- Reusable SignPath/release/smoke workflow contracts ->
  `vitest run scripts/windows-release-workflows.test.ts` -> passed.
- Signed-installer blockmap and feed regeneration ->
  `vitest run scripts/refresh-windows-release-metadata.test.ts` -> passed.
- Signed Windows release-evidence gate ->
  `vitest run scripts/ci/release-certification-evidence.test.ts` -> passed.
- Existing electron-builder Windows configuration contract ->
  `vitest run scripts/electron-builder-config.test.ts` -> passed.
- Combined focused suite -> 25 tests passed.
- Dependency/lockfile installation contract ->
  `npm ci --dry-run --ignore-scripts --omit=optional --no-audit --no-fund` -> passed (existing peer
  warnings only).
- Changed-file formatting -> Prettier check passed.
- GitHub Actions syntax -> actionlint passed with only two pre-existing shellcheck warnings in
  unchanged `build.yml` script lines.
- Patch hygiene -> `git diff --check origin/main...HEAD` passed.
- Independent Standards review -> passed after declaring exact `app-builder-lib@26.15.3`.
- Independent Spec review -> passed after adding always-run cleanup for the unsigned input artifact.

Per maintainer direction, the full local `npm test` suite was not run; exact-head PR CI is the
authority for the complete portable and platform lanes.

## Review focus

- Stable tag dependency order: build -> SignPath finalizer -> package smoke -> publish.
- Exact production certificate Subject configured in `SIGNPATH_WINDOWS_PUBLISHER_NAME`.
- Fail-closed behavior when the production policy, signature trust, signer Subject, metadata refresh,
  or temporary-artifact cleanup fails.
- Electron-updater compatibility of the regenerated `latest.yml` and gzip blockmap.

## Uncovered risks

- The `release-signing` policy and production certificate are not exercised by this PR. They must be
  active in SignPath before the next tag.
- `SIGNPATH_WINDOWS_PUBLISHER_NAME` must exactly match the production certificate Subject.
- A no-publish branch dry-run with `test-signing` will be attached after the PR is opened.
