### PR TITLE
fix(specialists): finish appearance saves before catalog refresh

### DIFF
--- a/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
@@ -1169,6 +1169,35 @@ describe('SpecialistsPanel', () => {
     expect(document.body.querySelector('[aria-label="Purple"]')).not.toBeNull()
   })
 
+  it('finishes an appearance save without waiting for the catalog reload', async () => {
+    const current = specialistItems[0] as Extract<SpecialistListItem, { kind: 'custom' }>
+    const updated = { ...current, colorKey: 'purple', revision: 2 }
+    window.api.specialist.update = vi.fn().mockResolvedValue(updated)
+    window.api.specialist.list = vi
+      .fn()
+      .mockResolvedValueOnce({ items: specialistItems, integrity: { status: 'ok' } })
+      .mockReturnValue(new Promise(() => undefined))
+
+    await act(async () => {
+      root.render(<SpecialistsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+    })
+
+    const trigger = document.body.querySelector<HTMLButtonElement>(
+      '[aria-label="Change appearance for RNA Reviewer"]'
+    )
+    expect(trigger).not.toBeNull()
+    openRadixMenu(trigger)
+
+    await act(async () =>
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Purple"]')?.click()
+    )
+    await vi.waitFor(() => expect(window.api.specialist.update).toHaveBeenCalledOnce())
+    await act(async () => Promise.resolve())
+
+    expect(trigger?.getAttribute('data-appearance-state')).toBe('success')
+    expect(document.body.textContent).toContain('Saved')
+  })
+
   it('routes wheel input from the popover to the hidden icon scroller', async () => {
     await act(async () => {
       root.render(<SpecialistsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)

--- a/src/renderer/src/stores/specialist-store.ts
+++ b/src/renderer/src/stores/specialist-store.ts
@@ -118,8 +118,17 @@ const useSpecialistStore = create<SpecialistStore>((set) => ({
       throw new Error(SPECIALIST_DOCUMENT_READ_ONLY_ERROR)
     }
     const view = await window.api.specialist.update(input)
-    // Reload the full list so Reviewer and ordering stay consistent.
-    await refreshCatalog(set)
+    // The mutation result is authoritative for this custom Specialist. Apply it immediately so a
+    // slow catalog enrichment cannot leave an already-saved appearance stuck in its loading state.
+    set((state) => ({
+      items: state.items.map((item) =>
+        item.kind === 'custom' && item.id === view.id ? { ...item, ...view, kind: 'custom' } : item
+      )
+    }))
+    // Keep derived catalog fields and ordering synchronized without making mutation completion depend
+    // on the broader catalog read. Catalog-change events may race this refresh; request IDs ensure
+    // only the newest response is applied.
+    void refreshCatalog(set).catch(() => undefined)
     return view
   },
 


### PR DESCRIPTION
## Problem

After a Specialist appearance mutation succeeded, the renderer store still awaited a full catalog reload. A slow or stalled `specialist.list` therefore left the appearance picker in its loading state even though `specialist.update` had completed.

## Proposed change

- Apply the authoritative update response to the matching custom Specialist row immediately.
- Refresh derived catalog fields and ordering in the background.
- Add a regression test where the update succeeds while the catalog reload never resolves.

## Scope and non-goals

- Renderer state handling only; no main-process, IPC, or API contract changes.
- No historical-data compatibility work is required.
- No state enum values are added.
- No persistence schema or persisted data format changes are involved.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Appearance save terminalization -> `npm test -- src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx` -> 47 passed.
- Specialist store behavior -> `npm test -- src/renderer/src/stores/specialist-store.test.ts` -> 9 passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Linted source -> `npm run lint` -> passed.
- Impact explanation -> `npm run test:affected:explain -- --base origin/main --head HEAD` -> selected the full plan because the Specialist panel test has no registered module owner. Per maintainer direction, the full local `npm test` was not run; PR Gate remains the final authority.

The focused regression models the observed stalled reload deterministically. A live Electron E2E reproduction of catalog enrichment latency is not included.

## Review focus

Confirm that successful mutations resolve from the returned Specialist view without waiting for catalog enrichment, while update failures still reject and retain the existing rollback/retry behavior.