### PR TITLE
feat(specialist): open capability rows in their settings detail pages

### DIFF
--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -2037,6 +2037,7 @@
   "Version {{version}}": "バージョン {{version}}",
   "Version unavailable": "バージョンが利用できません",
   "View": "表示",
+  "View {{name}} details": "{{name}} の詳細を表示",
   "The selected model doesn't support images. Configure a Vision model in Settings > Model to enable image support.": "選択したモデルは画像をサポートしていません。 [設定] > [モデル] で Vision モデルを構成し、画像サポートを有効にします。",
   "The attached image is invalid.": "添付された画像は無効です。",
   "The attached image is too large to prepare for the Vision model.": "添付画像が大きすぎるため、Vision model 用に処理できません。",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -2098,6 +2098,7 @@
   "Version {{version}}": "版本 {{version}}",
   "Version unavailable": "版本不可用",
   "View": "查看",
+  "View {{name}} details": "查看 {{name}} 详情",
   "The selected model doesn't support images. Configure a Vision model in Settings > Model to enable image support.": "当前所选模型不支持图片。请在“设置 > 模型”中配置视觉模型以启用图片支持。",
   "The attached image is invalid.": "附加的图片无效。",
   "The attached image is too large to prepare for the Vision model.": "附加的图片过大，无法交给视觉模型处理。",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -2095,6 +2095,7 @@
   "Version {{version}}": "版本 {{version}}",
   "Version unavailable": "版本無法使用",
   "View": "檢視",
+  "View {{name}} details": "檢視 {{name}} 詳情",
   "The selected model doesn't support images. Configure a Vision model in Settings > Model to enable image support.": "目前所選模型不支援圖片。請在「設定 > 模型」中設定視覺模型以啟用圖片支援。",
   "The attached image is invalid.": "附加的圖片無效。",
   "The attached image is too large to prepare for the Vision model.": "附加的圖片過大，無法交給視覺模型處理。",

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -202,6 +202,8 @@ beforeEach(() => {
   useProjectStore.setState(createInitialProjectState())
   useSessionStore.setState(createInitialSessionState())
   useTagStore.setState(createInitialTagState())
+  // Editor drafts persist across mounts by design; keep tests independent of each other.
+  useSpecialistStore.setState({ editorDrafts: {} })
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -2393,6 +2395,230 @@ describe('SettingsPage layout', () => {
     expect(document.body.querySelector('section[aria-label="Providers"]')).toBeNull()
     // The pending id is consumed so a later normal open won't jump back to it.
     expect(useSettingsStore.getState().pendingSpecialistId).toBeUndefined()
+  })
+
+  it('navigates from a specialist capability row to the skill detail and back', async () => {
+    const researcher: SpecialistProfileView = {
+      id: 'spc-1',
+      name: 'RESEARCHER',
+      displayName: 'Researcher',
+      description: 'Conducts systematic literature reviews.',
+      systemPrompt: 'You are a literature review specialist.',
+      iconKey: 'search',
+      colorKey: 'blue',
+      enabled: true,
+      capabilityMode: 'selected',
+      fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+      selectedCapabilities: { skillIds: ['alpha'], connectorIds: [], connectorTools: [] },
+      revision: 1
+    }
+    ;(window.api.specialist.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+      items: [{ kind: 'custom', ...researcher }],
+      integrity: { status: 'ok' }
+    })
+    useSpecialistStore.setState({ items: [{ kind: 'custom', ...researcher }], isLoaded: true })
+    useSettingsStore.setState({ pendingSpecialistId: researcher.id })
+
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // The capabilities whitelist lists Alpha; clicking the row navigates.
+    await act(async () => {
+      fireEvent.click(
+        document.body.querySelector<HTMLElement>('[aria-label="View Alpha details"]')!
+      )
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // Landed on Skills › Alpha: the mocked detail metadata renders.
+    expect(navButton('Skills')?.getAttribute('aria-current')).toBe('page')
+    expect(document.body.textContent).toContain('Test Author')
+
+    // Back returns to the specialist editor.
+    await act(async () => {
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Back"]')?.click()
+    })
+    expect(document.body.querySelector<HTMLInputElement>('#sp-name')?.value).toBe('Researcher')
+  })
+
+  it('routes connector capability rows to detail or edit by server kind', async () => {
+    const researcher: SpecialistProfileView = {
+      id: 'spc-2',
+      name: 'RESEARCHER',
+      displayName: 'Researcher',
+      description: '',
+      systemPrompt: '',
+      iconKey: 'search',
+      colorKey: 'blue',
+      enabled: true,
+      capabilityMode: 'selected',
+      fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+      selectedCapabilities: {
+        skillIds: [],
+        connectorIds: ['chemistry', 'route-uuid'],
+        connectorTools: []
+      },
+      revision: 1
+    }
+    ;(window.api.specialist.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+      items: [{ kind: 'custom', ...researcher }],
+      integrity: { status: 'ok' }
+    })
+    ;(window.api.settings.listConnectors as ReturnType<typeof vi.fn>).mockResolvedValue({
+      connectors: [
+        {
+          id: 'chemistry',
+          displayName: 'Chemistry',
+          description: 'Small-molecule chemistry via PubChem.',
+          sources: ['PubChem'],
+          requiresNcbi: false,
+          enabled: true,
+          autoAllow: false
+        }
+      ],
+      customServers: [
+        {
+          id: 'route-uuid',
+          name: 'route',
+          displayName: 'Public Route',
+          transport: 'stdio',
+          enabled: true
+        }
+      ],
+      ncbi: { hasApiKey: false }
+    })
+    ;(
+      window.api.settings as unknown as Record<string, ReturnType<typeof vi.fn>>
+    ).getConnectorDetail = vi.fn().mockResolvedValue({
+      id: 'chemistry',
+      name: 'chemistry',
+      displayName: 'Chemistry',
+      description: 'Small-molecule chemistry via PubChem.',
+      sources: ['PubChem'],
+      requiresNcbi: false,
+      enabled: true,
+      autoAllow: false,
+      tools: []
+    })
+    useSpecialistStore.setState({ items: [{ kind: 'custom', ...researcher }], isLoaded: true })
+    useSettingsStore.setState({ pendingSpecialistId: researcher.id })
+
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // Open the Connectors capability tab.
+    await act(async () => {
+      fireEvent.click(
+        Array.from(document.body.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find((tab) =>
+          tab.textContent?.includes('Connectors')
+        )!
+      )
+    })
+
+    const crumb = (): string =>
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Back"]')?.closest('div')
+        ?.textContent ?? ''
+
+    // A bundled connector lands on its detail page.
+    await act(async () => {
+      fireEvent.click(
+        document.body.querySelector<HTMLElement>('[aria-label="View Chemistry details"]')!
+      )
+    })
+    expect(navButton('Connectors')?.getAttribute('aria-current')).toBe('page')
+    expect(crumb()).toContain('Connectors›Chemistry')
+
+    // Back to the editor (capability tabs reset to Skills on remount), then a
+    // custom server lands on its edit page.
+    await act(async () => {
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Back"]')?.click()
+    })
+    await act(async () => {
+      fireEvent.click(
+        Array.from(document.body.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find((tab) =>
+          tab.textContent?.includes('Connectors')
+        )!
+      )
+    })
+    await act(async () => {
+      fireEvent.click(
+        document.body.querySelector<HTMLElement>('[aria-label="View Public Route details"]')!
+      )
+    })
+    expect(navButton('Connectors')?.getAttribute('aria-current')).toBe('page')
+    expect(crumb()).toContain('Connectors›Edit route')
+  })
+
+  it('keeps unsaved specialist edits across a capability detail round trip', async () => {
+    const researcher: SpecialistProfileView = {
+      id: 'spc-3',
+      name: 'RESEARCHER',
+      displayName: 'Researcher',
+      description: 'Conducts systematic literature reviews.',
+      systemPrompt: 'You are a literature review specialist.',
+      iconKey: 'search',
+      colorKey: 'blue',
+      enabled: true,
+      capabilityMode: 'selected',
+      fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+      selectedCapabilities: { skillIds: ['alpha'], connectorIds: [], connectorTools: [] },
+      revision: 1
+    }
+    ;(window.api.specialist.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+      items: [{ kind: 'custom', ...researcher }],
+      integrity: { status: 'ok' }
+    })
+    useSpecialistStore.setState({ items: [{ kind: 'custom', ...researcher }], isLoaded: true })
+    useSettingsStore.setState({ pendingSpecialistId: researcher.id })
+
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // An unsaved edit in the specialist editor.
+    await act(async () => {
+      fireEvent.change(document.body.querySelector<HTMLInputElement>('#sp-description')!, {
+        target: { value: 'My unsaved edit' }
+      })
+    })
+
+    // Round trip through the skill detail page.
+    await act(async () => {
+      fireEvent.click(
+        document.body.querySelector<HTMLElement>('[aria-label="View Alpha details"]')!
+      )
+    })
+    expect(document.body.textContent).toContain('Test Author')
+    await act(async () => {
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Back"]')?.click()
+    })
+
+    // Back on the editor, the unsaved edit survived the trip.
+    expect(document.body.querySelector<HTMLInputElement>('#sp-description')?.value).toBe(
+      'My unsaved edit'
+    )
   })
 
   it('opens the specialist creation form from Write from scratch', async () => {

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -1218,6 +1218,22 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                     view={specialistsView}
                     onNavigate={navigateSpecialists}
                     onOpenTag={navigateTag}
+                    onOpenSkillDetail={(skillId) =>
+                      navigate({
+                        ...currentLocation,
+                        panel: 'skills',
+                        skills: { kind: 'detail', id: skillId }
+                      })
+                    }
+                    onOpenConnectorDetail={(connectorId) =>
+                      navigate({
+                        ...currentLocation,
+                        panel: 'connectors',
+                        connectors: customServers.some((server) => server.id === connectorId)
+                          ? { kind: 'edit', id: connectorId }
+                          : { kind: 'detail', id: connectorId }
+                      })
+                    }
                   />
                 ) : activePanel === 'tags' ? (
                   <TagsPanel

--- a/src/renderer/src/pages/settings/SpecialistCapabilitiesSection.tsx
+++ b/src/renderer/src/pages/settings/SpecialistCapabilitiesSection.tsx
@@ -1,0 +1,725 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useSettingsStore } from '@/stores/settings-store'
+import { useTagStore } from '@/stores/tag-store'
+import { SettingsIconAction } from './SettingsLayout'
+import {
+  getSettingsSearchKeyShortcuts,
+  useSettingsSearchShortcut
+} from './settings-search-shortcut'
+import { TagFilter } from './ResourceTagControls'
+
+type ConnectorRow = {
+  id: string
+  name: string
+  description?: string
+  mainEnabled: boolean
+  available: boolean
+  availability?: 'unavailable' | 'unauthenticated'
+}
+
+type SkillRow = {
+  id: string
+  name: string
+  description?: string
+  source?: string
+  mainEnabled: boolean
+  missing: boolean
+}
+
+// Interaction props for a clickable capability row. A div[role="button"] does not synthesize a
+// click from Enter/Space the way a native button does, so both keys are handled explicitly.
+// Keyboard activation of an inner control (e.g. the remove button) is left to that control: the
+// row only reacts when it is itself the event target.
+const clickableRowProps = (
+  open: (() => void) | undefined,
+  label: string
+):
+  | {
+      role: 'button'
+      tabIndex: number
+      'aria-label': string
+      onClick: () => void
+      onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void
+    }
+  | undefined =>
+  open === undefined
+    ? undefined
+    : {
+        role: 'button',
+        tabIndex: 0,
+        'aria-label': label,
+        onClick: open,
+        onKeyDown: (event) => {
+          if (event.target !== event.currentTarget) return
+          if (event.key !== 'Enter' && event.key !== ' ') return
+          event.preventDefault()
+          open()
+        }
+      }
+
+// Shared layout for the capability list rows; `interactive` adds the clickable affordance.
+const capabilityRowClassName = (interactive: boolean): string =>
+  cn(
+    'flex h-[40px] items-center gap-2.5 border-b border-border px-3 last:border-b-0',
+    interactive && 'cursor-pointer hover:bg-muted focus-visible:bg-muted'
+  )
+
+// The remove action sits inside a row that may itself be clickable; stopping propagation keeps
+// removal from also activating the row's navigation.
+const stopThen =
+  (remove: () => void) =>
+  (event: React.MouseEvent<HTMLButtonElement>): void => {
+    event.stopPropagation()
+    remove()
+  }
+
+type SpecialistCapabilitiesSectionProps = {
+  // Mirrors the shared domain field form.capabilityMode; the section stays fully
+  // controlled so the editor's form remains the single source of truth for what
+  // gets saved.
+  capabilityMode: 'full' | 'selected'
+  onCapabilityModeChange: (mode: 'full' | 'selected') => void
+  selectedSkillIds: string[]
+  excludedSkillIds: string[]
+  selectedConnectorIds: string[]
+  excludedConnectorIds: string[]
+  // Updater-style callbacks keep add/remove race-free against rapid interactions, exactly
+  // like the setForm-based updates this section was extracted from.
+  updateSkillIds: (update: (prev: string[]) => string[]) => void
+  updateConnectorIds: (update: (prev: string[]) => string[]) => void
+  activeTab: 'skills' | 'connectors'
+  onActiveTabChange: (tab: 'skills' | 'connectors') => void
+  // Called when a selected Skill row is clicked to view that Skill in Settings.
+  onOpenSkillDetail?: (skillId: string) => void
+  // Called when a selected Connector row is clicked to view that Connector in
+  // Settings. Receives the canonical id: a custom server referenced by its legacy
+  // name is resolved to server.id before the call.
+  onOpenConnectorDetail?: (connectorId: string) => void
+}
+
+const SpecialistCapabilitiesSection = ({
+  capabilityMode,
+  onCapabilityModeChange,
+  selectedSkillIds,
+  excludedSkillIds,
+  selectedConnectorIds,
+  excludedConnectorIds,
+  updateSkillIds,
+  updateConnectorIds,
+  activeTab,
+  onActiveTabChange,
+  onOpenSkillDetail,
+  onOpenConnectorDetail
+}: SpecialistCapabilitiesSectionProps): React.JSX.Element => {
+  const { t } = useTranslation()
+  const connectors = useSettingsStore((state) => state.connectors)
+  const skills = useSettingsStore((state) => state.skills)
+  const customServers = useSettingsStore((state) => state.customServers)
+  const loadConnectors = useSettingsStore((state) => state.loadConnectors)
+  const loadSkills = useSettingsStore((state) => state.loadSkills)
+  const tagAssignments = useTagStore((state) => state.assignments)
+
+  const isFullAccess = capabilityMode === 'full'
+
+  const [skillSearchQuery, setSkillSearchQuery] = useState('')
+  const [connectorSearchQuery, setConnectorSearchQuery] = useState('')
+  const [skillTagFilter, setSkillTagFilter] = useState('all')
+  const [connectorTagFilter, setConnectorTagFilter] = useState('all')
+  const skillSearchRef = useRef<HTMLInputElement>(null)
+  const connectorSearchRef = useRef<HTMLInputElement>(null)
+  const [skillPopoverOpen, setSkillPopoverOpen] = useState(false)
+  const [connectorPopoverOpen, setConnectorPopoverOpen] = useState(false)
+  const skillDropdownRef = useRef<HTMLDivElement>(null)
+  const connectorDropdownRef = useRef<HTMLDivElement>(null)
+  useSettingsSearchShortcut(skillSearchRef, skillPopoverOpen)
+  useSettingsSearchShortcut(connectorSearchRef, connectorPopoverOpen)
+  const skillTriggerRef = useRef<HTMLButtonElement>(null)
+  const connectorTriggerRef = useRef<HTMLButtonElement>(null)
+
+  const closeSkillDropdown = useCallback(() => setSkillPopoverOpen(false), [])
+  const closeConnectorDropdown = useCallback(() => setConnectorPopoverOpen(false), [])
+
+  useEffect(() => {
+    if (!skillPopoverOpen) return
+    const handle = (e: MouseEvent): void => {
+      if (skillDropdownRef.current && !skillDropdownRef.current.contains(e.target as Node)) {
+        closeSkillDropdown()
+      }
+    }
+    document.addEventListener('mousedown', handle)
+    return () => document.removeEventListener('mousedown', handle)
+  }, [skillPopoverOpen, closeSkillDropdown])
+
+  useEffect(() => {
+    if (!connectorPopoverOpen) return
+    const handle = (e: MouseEvent): void => {
+      if (
+        connectorDropdownRef.current &&
+        !connectorDropdownRef.current.contains(e.target as Node)
+      ) {
+        closeConnectorDropdown()
+      }
+    }
+    document.addEventListener('mousedown', handle)
+    return () => document.removeEventListener('mousedown', handle)
+  }, [connectorPopoverOpen, closeConnectorDropdown])
+
+  useEffect(() => {
+    void loadConnectors()
+  }, [loadConnectors])
+
+  useEffect(() => {
+    if (skills.length === 0) void loadSkills()
+  }, [skills.length, loadSkills])
+
+  // Persist references to unavailable entries so a temporarily missing connector is visible and
+  // cannot silently broaden the profile when it returns. Main-disabled installed connectors remain
+  // selectable: Main's toggle is not a Specialist capability limit.
+  const connectorRows = useMemo(() => {
+    const referencedIds = new Set([...excludedConnectorIds, ...selectedConnectorIds])
+    const known: ConnectorRow[] = [
+      ...connectors.map((connector) => ({
+        id: connector.id,
+        name: connector.displayName,
+        description: connector.description,
+        mainEnabled: connector.enabled,
+        available: true
+      })),
+      ...customServers.map((server) => ({
+        id:
+          referencedIds.has(server.name) && !referencedIds.has(server.id) ? server.name : server.id,
+        name: server.displayName,
+        description: server.description ? `${server.name} · ${server.description}` : server.name,
+        mainEnabled: server.enabled,
+        available: server.availability === undefined,
+        availability: server.availability
+      }))
+    ]
+    const ids = new Set(known.map((row) => row.id))
+    for (const id of [...excludedConnectorIds, ...selectedConnectorIds]) {
+      if (ids.has(id)) continue
+      const legacy = customServers.find((server) => server.name === id)
+      if (legacy) {
+        known.push({
+          id,
+          name: legacy.displayName,
+          description: legacy.description ? `${legacy.name} · ${legacy.description}` : legacy.name,
+          mainEnabled: legacy.enabled,
+          available: legacy.availability === undefined,
+          availability: legacy.availability
+        })
+      } else {
+        known.push({ id, name: id, mainEnabled: false, available: false })
+      }
+    }
+    return known.sort((a, b) => a.name.localeCompare(b.name))
+  }, [connectors, customServers, selectedConnectorIds, excludedConnectorIds])
+
+  // Main-disabled installed Skills remain selectable for a Specialist. Persisted IDs absent from
+  // the live catalog are rendered locally so the user can remove them without blocking the session.
+  const skillRows = useMemo(() => {
+    const known: SkillRow[] = skills.map((skill) => ({
+      id: skill.id,
+      name: skill.name,
+      description: skill.description,
+      source: skill.source,
+      mainEnabled: skill.enabled,
+      missing: false
+    }))
+    const ids = new Set(known.map((skill) => skill.id))
+    for (const id of [...excludedSkillIds, ...selectedSkillIds]) {
+      if (!ids.has(id)) known.push({ id, name: id, mainEnabled: false, missing: true })
+    }
+    return known.sort((a, b) => a.name.localeCompare(b.name))
+  }, [skills, excludedSkillIds, selectedSkillIds])
+
+  // Selected-capabilities mode lists. Skills and Connectors are both whitelists: they start empty
+  // and are added explicitly. Persisted IDs missing from the catalog stay visible (and removable)
+  // so a stale reference never locks the session. Main-disabled installed items remain addable:
+  // Main's toggle is not a Specialist capability limit.
+  const selectedSkillRows = useMemo(
+    () =>
+      selectedSkillIds.map((id) => {
+        const found = skillRows.find((row) => row.id === id)
+        return found ?? { id, name: id, mainEnabled: false, missing: true }
+      }),
+    [selectedSkillIds, skillRows]
+  )
+  const addableSkills = useMemo(
+    () =>
+      skills
+        .filter((skill) => !selectedSkillIds.includes(skill.id))
+        .map((skill) => ({
+          id: skill.id,
+          name: skill.name,
+          description: skill.description,
+          source: skill.source
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [skills, selectedSkillIds]
+  )
+
+  const selectedConnectorRows = useMemo(
+    () =>
+      selectedConnectorIds.map((id) => {
+        const found = connectorRows.find((row) => row.id === id)
+        return found ?? { id, name: id, mainEnabled: false, available: false }
+      }),
+    [selectedConnectorIds, connectorRows]
+  )
+  const addableConnectors = useMemo(() => {
+    const all: ConnectorRow[] = [
+      ...connectors.map((connector) => ({
+        id: connector.id,
+        name: connector.displayName,
+        description: connector.description,
+        mainEnabled: connector.enabled,
+        available: true
+      })),
+      ...customServers.map((server) => ({
+        id: server.id,
+        name: server.displayName,
+        description: server.description ? `${server.name} · ${server.description}` : server.name,
+        mainEnabled: server.enabled,
+        available: server.availability === undefined,
+        availability: server.availability
+      }))
+    ]
+    return all
+      .filter((row) => {
+        if (!row.available) return false
+        const custom = customServers.find((server) => server.id === row.id)
+        return !selectedConnectorIds.some(
+          (id) => id === row.id || (custom !== undefined && id === custom.name)
+        )
+      })
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }, [connectors, customServers, selectedConnectorIds])
+
+  const filteredAddableSkills = useMemo(() => {
+    const tagged =
+      skillTagFilter === 'all'
+        ? addableSkills
+        : addableSkills.filter((skill) =>
+            tagAssignments.some(
+              (assignment) =>
+                assignment.tagId === skillTagFilter &&
+                assignment.resourceType === 'catalog.skill' &&
+                assignment.resourceId === skill.id
+            )
+          )
+    if (!skillSearchQuery.trim()) return tagged
+    const q = skillSearchQuery.toLowerCase()
+    return tagged.filter(
+      (skill) =>
+        skill.name.toLowerCase().includes(q) ||
+        (skill.description && skill.description.toLowerCase().includes(q))
+    )
+  }, [addableSkills, skillSearchQuery, skillTagFilter, tagAssignments])
+
+  const filteredAddableConnectors = useMemo(() => {
+    const tagged =
+      connectorTagFilter === 'all'
+        ? addableConnectors
+        : addableConnectors.filter((connector) =>
+            tagAssignments.some(
+              (assignment) =>
+                assignment.tagId === connectorTagFilter &&
+                assignment.resourceType === 'catalog.connector' &&
+                assignment.resourceId === connector.id
+            )
+          )
+    if (!connectorSearchQuery.trim()) return tagged
+    const q = connectorSearchQuery.toLowerCase()
+    return tagged.filter(
+      (connector) =>
+        connector.name.toLowerCase().includes(q) ||
+        (connector.description && connector.description.toLowerCase().includes(q))
+    )
+  }, [addableConnectors, connectorSearchQuery, connectorTagFilter, tagAssignments])
+
+  const addSkill = (id: string): void =>
+    updateSkillIds((prev) => (prev.includes(id) ? prev : [...prev, id]))
+  const removeSkill = (id: string): void =>
+    updateSkillIds((prev) => prev.filter((skillId) => skillId !== id))
+  const addConnector = (id: string): void =>
+    updateConnectorIds((prev) => (prev.includes(id) ? prev : [...prev, id]))
+  const removeConnector = (id: string): void =>
+    updateConnectorIds((prev) => prev.filter((connectorId) => connectorId !== id))
+
+  return (
+    <section className="border-t border-border pt-5">
+      <h3 className="mb-1 text-base font-semibold text-foreground">{t('Capabilities')}</h3>
+      <p className="mb-4 text-[13px] leading-5 text-muted-foreground">
+        {t(
+          'Skills and connectors this specialist can use. Anything not chosen here stays invisible and unreachable in its sessions, even when enabled globally.'
+        )}
+      </p>
+
+      {/* Full access — single option, default selected. Loads every Main Agent skill and
+          connector; selecting it disables the Select capabilities panel below. */}
+      <button
+        type="button"
+        role="switch"
+        aria-checked={isFullAccess}
+        aria-label={t('Full access')}
+        onClick={() => onCapabilityModeChange(capabilityMode === 'full' ? 'selected' : 'full')}
+        className={cn(
+          'mb-2 flex items-start gap-3 rounded-lg border p-3 text-left transition-colors',
+          isFullAccess ? 'border-primary bg-primary/5' : 'border-border bg-card hover:bg-muted'
+        )}
+      >
+        <span
+          className={cn(
+            'mt-0.5 flex size-[18px] shrink-0 items-center justify-center rounded-full border-2',
+            isFullAccess ? 'border-primary' : 'border-text-300'
+          )}
+        >
+          {isFullAccess ? <span className="size-2.5 rounded-full bg-primary" /> : null}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="flex items-center gap-2 text-[13px] font-semibold">
+            {t('Full access')}
+            <span className="rounded bg-primary px-1.5 py-px text-[9.5px] font-semibold uppercase tracking-wide text-primary-foreground">
+              {t('Default')}
+            </span>
+          </span>
+          <span className="mt-0.5 block text-[11.5px] leading-snug text-muted-foreground">
+            {t(
+              "Use all of the Main Agent's skills and connectors, including new ones added later. No need to configure each item."
+            )}
+          </span>
+        </span>
+      </button>
+
+      <div className="my-3 flex items-center gap-3" aria-hidden="true">
+        <span className="h-px flex-1 bg-border" />
+        <span className="text-[11px] text-text-300">{t('or choose specific capabilities')}</span>
+        <span className="h-px flex-1 bg-border" />
+      </div>
+
+      {/* Select capabilities — greyed and non-interactive while Full access is on. Clicking the
+          greyed panel turns Full access off so the lists become editable. */}
+      <div className="relative">
+        <div
+          className={cn('rounded-lg', isFullAccess && 'pointer-events-none opacity-45 select-none')}
+        >
+          <div className="mb-3 flex items-center justify-between">
+            <div
+              className="inline-flex gap-0.5 rounded-lg bg-muted p-1"
+              role="tablist"
+              aria-label={t('Capability type')}
+            >
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeTab === 'skills'}
+                onClick={() => onActiveTabChange('skills')}
+                className={cn(
+                  'rounded-md px-3 py-1 text-[12.5px] font-medium',
+                  activeTab === 'skills'
+                    ? 'bg-card text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                {t('Skills')}{' '}
+                <span className="ml-0.5 text-[11px] opacity-75">{selectedSkillIds.length}</span>
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeTab === 'connectors'}
+                onClick={() => onActiveTabChange('connectors')}
+                className={cn(
+                  'rounded-md px-3 py-1 text-[12.5px] font-medium',
+                  activeTab === 'connectors'
+                    ? 'bg-card text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                {t('Connectors')}{' '}
+                <span className="ml-0.5 text-[11px] opacity-75">{selectedConnectorIds.length}</span>
+              </button>
+            </div>
+
+            {/* Add button + dropdown — right side of the same row */}
+            {activeTab === 'skills' ? (
+              <div className="relative" ref={skillDropdownRef}>
+                <button
+                  ref={skillTriggerRef}
+                  type="button"
+                  onClick={() => {
+                    setSkillPopoverOpen((prev) => !prev)
+                    setSkillSearchQuery('')
+                    setTimeout(() => skillSearchRef.current?.focus(), 0)
+                  }}
+                  className="flex h-[28px] items-center rounded-lg border border-dashed border-border bg-card px-3 text-[12px] text-muted-foreground hover:bg-muted"
+                >
+                  {t('＋ Add a skill')}
+                </button>
+                {skillPopoverOpen ? (
+                  <div className="absolute right-0 top-full z-50 mt-1 flex max-h-[260px] w-[240px] flex-col overflow-y-auto rounded-lg border border-border bg-card shadow-md">
+                    <div className="sticky top-0 z-10 border-b border-border bg-card p-2">
+                      <input
+                        ref={skillSearchRef}
+                        type="search"
+                        aria-label={t('Search skills to add')}
+                        aria-keyshortcuts={getSettingsSearchKeyShortcuts()}
+                        placeholder={t('Search skills…')}
+                        value={skillSearchQuery}
+                        onChange={(e) => setSkillSearchQuery(e.target.value)}
+                        className="w-full rounded-md border border-border bg-card px-2.5 py-1.5 text-[12.5px] text-foreground placeholder:text-muted-foreground outline-none focus:border-primary"
+                      />
+                      <TagFilter
+                        resourceType="catalog.skill"
+                        value={skillTagFilter}
+                        onChange={setSkillTagFilter}
+                        className="mt-2 w-full"
+                      />
+                    </div>
+                    <div className="flex-1">
+                      {filteredAddableSkills.length === 0 ? (
+                        <p className="px-3 py-3 text-[12px] text-muted-foreground">
+                          {skillSearchQuery ? t('No matching skills') : t('No more skills to add')}
+                        </p>
+                      ) : (
+                        filteredAddableSkills.map((skill) => (
+                          <button
+                            key={skill.id}
+                            type="button"
+                            onClick={() => {
+                              addSkill(skill.id)
+                              setSkillPopoverOpen(false)
+                            }}
+                            className="flex h-[32px] w-full items-center gap-2 px-3 text-left hover:bg-muted"
+                          >
+                            <span className="min-w-0 flex-1 truncate text-[12.5px]">
+                              {skill.name}
+                            </span>
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <div className="relative" ref={connectorDropdownRef}>
+                <button
+                  ref={connectorTriggerRef}
+                  type="button"
+                  onClick={() => {
+                    setConnectorPopoverOpen((prev) => !prev)
+                    setConnectorSearchQuery('')
+                    setTimeout(() => connectorSearchRef.current?.focus(), 0)
+                  }}
+                  className="flex h-[28px] items-center rounded-lg border border-dashed border-border bg-card px-3 text-[12px] text-muted-foreground hover:bg-muted"
+                >
+                  {t('＋ Add a connector')}
+                </button>
+                {connectorPopoverOpen ? (
+                  <div className="absolute right-0 top-full z-50 mt-1 flex max-h-[260px] w-[240px] flex-col overflow-y-auto rounded-lg border border-border bg-card shadow-md">
+                    <div className="sticky top-0 z-10 border-b border-border bg-card p-2">
+                      <input
+                        ref={connectorSearchRef}
+                        type="search"
+                        aria-label={t('Search connectors to add')}
+                        aria-keyshortcuts={getSettingsSearchKeyShortcuts()}
+                        placeholder={t('Search connectors…')}
+                        value={connectorSearchQuery}
+                        onChange={(e) => setConnectorSearchQuery(e.target.value)}
+                        className="w-full rounded-md border border-border bg-card px-2.5 py-1.5 text-[12.5px] text-foreground placeholder:text-muted-foreground outline-none focus:border-primary"
+                      />
+                      <TagFilter
+                        resourceType="catalog.connector"
+                        value={connectorTagFilter}
+                        onChange={setConnectorTagFilter}
+                        className="mt-2 w-full"
+                      />
+                    </div>
+                    <div className="flex-1">
+                      {filteredAddableConnectors.length === 0 ? (
+                        <p className="px-3 py-3 text-[12px] text-muted-foreground">
+                          {connectorSearchQuery
+                            ? t('No matching connectors')
+                            : t('No more connectors to add')}
+                        </p>
+                      ) : (
+                        filteredAddableConnectors.map((connector) => (
+                          <button
+                            key={connector.id}
+                            type="button"
+                            onClick={() => {
+                              addConnector(connector.id)
+                              setConnectorPopoverOpen(false)
+                            }}
+                            className="flex h-[32px] w-full items-center gap-2 px-3 text-left hover:bg-muted"
+                          >
+                            <span className="min-w-0 flex-1 truncate text-[12.5px]">
+                              {connector.name}
+                            </span>
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            )}
+          </div>
+
+          {activeTab === 'skills' ? (
+            <div>
+              <div className="overflow-hidden rounded-lg border border-border">
+                {selectedSkillRows.length === 0 ? (
+                  <p className="px-3 py-3.5 text-[12px] text-muted-foreground">
+                    {t('No skills added yet.')}
+                  </p>
+                ) : (
+                  selectedSkillRows.map((skill) => {
+                    const openSkill =
+                      !skill.missing && onOpenSkillDetail !== undefined
+                        ? () => onOpenSkillDetail(skill.id)
+                        : undefined
+                    return (
+                      <div
+                        key={skill.id}
+                        {...clickableRowProps(
+                          openSkill,
+                          t('View {{name}} details', { name: skill.name })
+                        )}
+                        className={capabilityRowClassName(openSkill !== undefined)}
+                      >
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate text-[12.5px]">{skill.name}</div>
+                          {!skill.missing && skill.description ? (
+                            <div className="truncate text-[11px] text-muted-foreground">
+                              {skill.description}
+                            </div>
+                          ) : null}
+                        </div>
+                        {skill.missing ? (
+                          <span className="shrink-0 text-[11px] text-muted-foreground">
+                            {t('Missing · unavailable')}
+                          </span>
+                        ) : (
+                          <>
+                            {skill.source ? (
+                              <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] capitalize text-muted-foreground">
+                                {skill.source}
+                              </span>
+                            ) : null}
+                            {!skill.mainEnabled ? (
+                              <span className="shrink-0 text-[11px] text-muted-foreground">
+                                {t('Main disabled · available here')}
+                              </span>
+                            ) : null}
+                          </>
+                        )}
+                        <SettingsIconAction
+                          label={t('Remove {{name}}', { name: skill.name })}
+                          icon={X}
+                          onClick={stopThen(() => removeSkill(skill.id))}
+                          danger
+                        />
+                      </div>
+                    )
+                  })
+                )}
+              </div>
+              <p className="mt-2.5 flex gap-2 rounded-lg bg-muted p-2.5 text-[11.5px] leading-snug text-muted-foreground">
+                <span aria-hidden="true">ⓘ</span>
+                <span>
+                  {t(
+                    'Skills start empty and must be added. Skills not listed here are hidden from this specialist, and Skill calls to them are rejected.'
+                  )}
+                </span>
+              </p>
+            </div>
+          ) : null}
+
+          {activeTab === 'connectors' ? (
+            <div>
+              <div className="overflow-hidden rounded-lg border border-border">
+                {selectedConnectorRows.length === 0 ? (
+                  <p className="px-3 py-3.5 text-[12px] text-muted-foreground">
+                    {t('No connectors added yet.')}
+                  </p>
+                ) : (
+                  selectedConnectorRows.map((connector) => {
+                    const canonicalConnectorId = (): string =>
+                      customServers.find(
+                        (server) => server.id === connector.id || server.name === connector.id
+                      )?.id ?? connector.id
+                    const openConnector =
+                      connector.available && onOpenConnectorDetail !== undefined
+                        ? () => onOpenConnectorDetail(canonicalConnectorId())
+                        : undefined
+                    return (
+                      <div
+                        key={connector.id}
+                        {...clickableRowProps(
+                          openConnector,
+                          t('View {{name}} details', { name: connector.name })
+                        )}
+                        className={capabilityRowClassName(openConnector !== undefined)}
+                      >
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate text-[12.5px]">{connector.name}</div>
+                          {connector.available && connector.description ? (
+                            <div className="truncate text-[11px] text-muted-foreground">
+                              {connector.description}
+                            </div>
+                          ) : null}
+                        </div>
+                        {!connector.available ? (
+                          <span className="shrink-0 text-[11px] text-muted-foreground">
+                            {t('Unavailable — {{reason}}', {
+                              reason: connector.availability ?? t('not installed')
+                            })}
+                          </span>
+                        ) : !connector.mainEnabled ? (
+                          <span className="shrink-0 text-[11px] text-muted-foreground">
+                            {t('Main disabled · available here')}
+                          </span>
+                        ) : null}
+                        <SettingsIconAction
+                          label={t('Remove {{name}}', { name: connector.name })}
+                          icon={X}
+                          onClick={stopThen(() => removeConnector(connector.id))}
+                          danger
+                        />
+                      </div>
+                    )
+                  })
+                )}
+              </div>
+              <p className="mt-2.5 flex gap-2 rounded-lg bg-muted p-2.5 text-[11.5px] leading-snug text-muted-foreground">
+                <span aria-hidden="true">ⓘ</span>
+                <span>
+                  {t(
+                    "Connectors start empty and must be added. Connectors not listed here are blocked at runtime for this specialist's sessions."
+                  )}
+                </span>
+              </p>
+            </div>
+          ) : null}
+        </div>
+
+        {isFullAccess ? (
+          <button
+            type="button"
+            aria-label={t('Enable select capabilities')}
+            onClick={() => onCapabilityModeChange('selected')}
+            className="absolute inset-0 cursor-pointer rounded-lg"
+          />
+        ) : null}
+      </div>
+    </section>
+  )
+}
+
+export { SpecialistCapabilitiesSection }

--- a/src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx
@@ -7,9 +7,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SpecialistEditor } from './SpecialistEditor'
 import { clickRadixMenuItem, openRadixMenu } from './test-utils'
 import { useSettingsStore } from '@/stores/settings-store'
+import { useSpecialistStore } from '@/stores/specialist-store'
 import {
   SPECIALIST_DESCRIPTION_MAX_LENGTH,
-  SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH
+  SPECIALIST_SYSTEM_PROMPT_MAX_LENGTH,
+  type SpecialistProfileView
 } from '../../../../shared/specialist'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -29,6 +31,7 @@ beforeEach(() => {
     loadSkills: vi.fn().mockResolvedValue(undefined),
     loadConnectors: vi.fn().mockResolvedValue(undefined)
   })
+  useSpecialistStore.setState({ editorDrafts: {} })
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -875,6 +878,734 @@ describe('SpecialistEditor', () => {
     })
 
     expect(onReload).toHaveBeenCalledOnce()
+  })
+
+  it('opens the skill detail when a selected skill row is clicked', async () => {
+    const onOpenSkillDetail = vi.fn()
+    useSettingsStore.setState({
+      skills: [
+        {
+          id: 'literature-review',
+          name: 'Literature Review',
+          displayName: 'Literature Review',
+          description: '',
+          source: 'featured',
+          enabled: true,
+          updatedAt: ''
+        }
+      ],
+      loadSkills: vi.fn().mockResolvedValue(undefined)
+    })
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={{
+            id: 'skills-bot',
+            name: 'Skills Bot',
+            description: '',
+            systemPrompt: '',
+            enabled: true,
+            capabilityMode: 'selected',
+            fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+            selectedCapabilities: {
+              skillIds: ['literature-review'],
+              connectorIds: [],
+              connectorTools: []
+            },
+            revision: 1
+          }}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={vi.fn().mockResolvedValue(undefined)}
+          onOpenSkillDetail={onOpenSkillDetail}
+        />
+      )
+    })
+
+    await act(async () => {
+      fireEvent.click(
+        document.body.querySelector<HTMLElement>('[aria-label="View Literature Review details"]')!
+      )
+    })
+
+    expect(onOpenSkillDetail).toHaveBeenCalledOnce()
+    expect(onOpenSkillDetail).toHaveBeenCalledWith('literature-review')
+  })
+
+  it('opens connector details on row click, mapping a legacy server name to its canonical id', async () => {
+    const onOpenConnectorDetail = vi.fn()
+    useSettingsStore.setState({
+      connectors: [
+        {
+          id: 'chemistry',
+          name: 'chemistry',
+          displayName: 'Chemistry',
+          description: '',
+          sources: [],
+          requiresNcbi: false,
+          enabled: true,
+          autoAllow: false,
+          group: 'featured'
+        }
+      ],
+      customServers: [
+        {
+          id: 'public-route-uuid',
+          name: 'public-route',
+          displayName: 'Public Route',
+          transport: 'stdio',
+          enabled: true
+        }
+      ],
+      loadConnectors: vi.fn().mockResolvedValue(undefined)
+    })
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={{
+            id: 'connector-bot',
+            name: 'Connector Bot',
+            description: '',
+            systemPrompt: '',
+            enabled: true,
+            capabilityMode: 'selected',
+            fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+            selectedCapabilities: {
+              skillIds: [],
+              // 'public-route' is a legacy reference stored by server name.
+              connectorIds: ['chemistry', 'public-route'],
+              connectorTools: []
+            },
+            revision: 1
+          }}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={vi.fn().mockResolvedValue(undefined)}
+          onOpenConnectorDetail={onOpenConnectorDetail}
+        />
+      )
+    })
+
+    await act(async () => {
+      fireEvent.click(
+        Array.from(document.body.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find((tab) =>
+          tab.textContent?.includes('Connectors')
+        )!
+      )
+    })
+    await act(async () => {
+      fireEvent.click(
+        document.body.querySelector<HTMLElement>('[aria-label="View Chemistry details"]')!
+      )
+    })
+    expect(onOpenConnectorDetail).toHaveBeenCalledWith('chemistry')
+
+    await act(async () => {
+      fireEvent.click(
+        document.body.querySelector<HTMLElement>('[aria-label="View Public Route details"]')!
+      )
+    })
+    expect(onOpenConnectorDetail).toHaveBeenLastCalledWith('public-route-uuid')
+  })
+
+  it('keeps missing skills and unavailable connectors non-clickable', async () => {
+    const onOpenSkillDetail = vi.fn()
+    const onOpenConnectorDetail = vi.fn()
+    useSettingsStore.setState({
+      customServers: [
+        {
+          id: 'broken-server-uuid',
+          name: 'broken-server',
+          displayName: 'Broken Server',
+          transport: 'stdio',
+          enabled: true,
+          availability: 'unavailable'
+        }
+      ],
+      loadConnectors: vi.fn().mockResolvedValue(undefined)
+    })
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={{
+            id: 'stale-bot',
+            name: 'Stale Bot',
+            description: '',
+            systemPrompt: '',
+            enabled: true,
+            capabilityMode: 'selected',
+            fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+            selectedCapabilities: {
+              skillIds: ['legacy-pipeline'],
+              connectorIds: ['broken-server'],
+              connectorTools: []
+            },
+            revision: 1
+          }}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={vi.fn().mockResolvedValue(undefined)}
+          onOpenSkillDetail={onOpenSkillDetail}
+          onOpenConnectorDetail={onOpenConnectorDetail}
+        />
+      )
+    })
+
+    // Neither row exposes a click target or navigation semantics.
+    expect(document.body.querySelector('[aria-label="View legacy-pipeline details"]')).toBeNull()
+    expect(document.body.querySelector('[aria-label="View Broken Server details"]')).toBeNull()
+
+    // Clicking the row container (around the remove action) still never navigates.
+    const missingRow = document.body
+      .querySelector('[aria-label="Remove legacy-pipeline"]')!
+      .closest('div.border-b')!
+    await act(async () => {
+      fireEvent.click(missingRow)
+    })
+    expect(onOpenSkillDetail).not.toHaveBeenCalled()
+
+    await act(async () => {
+      fireEvent.click(
+        Array.from(document.body.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find((tab) =>
+          tab.textContent?.includes('Connectors')
+        )!
+      )
+    })
+    const unavailableRow = document.body
+      .querySelector('[aria-label="Remove Broken Server"]')!
+      .closest('div.border-b')!
+    await act(async () => {
+      fireEvent.click(unavailableRow)
+    })
+    expect(onOpenConnectorDetail).not.toHaveBeenCalled()
+  })
+
+  it('removes a skill from the remove action without triggering navigation', async () => {
+    const onOpenSkillDetail = vi.fn()
+    useSettingsStore.setState({
+      skills: [
+        {
+          id: 'literature-review',
+          name: 'Literature Review',
+          displayName: 'Literature Review',
+          description: '',
+          source: 'featured',
+          enabled: true,
+          updatedAt: ''
+        }
+      ],
+      loadSkills: vi.fn().mockResolvedValue(undefined)
+    })
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={{
+            id: 'skills-bot',
+            name: 'Skills Bot',
+            description: '',
+            systemPrompt: '',
+            enabled: true,
+            capabilityMode: 'selected',
+            fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+            selectedCapabilities: {
+              skillIds: ['literature-review'],
+              connectorIds: [],
+              connectorTools: []
+            },
+            revision: 1
+          }}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={vi.fn().mockResolvedValue(undefined)}
+          onOpenSkillDetail={onOpenSkillDetail}
+        />
+      )
+    })
+
+    await act(async () => {
+      fireEvent.click(
+        document.body.querySelector<HTMLButtonElement>('[aria-label="Remove Literature Review"]')!
+      )
+    })
+
+    expect(onOpenSkillDetail).not.toHaveBeenCalled()
+    expect(document.body.textContent).not.toContain('Literature Review')
+  })
+
+  it('renders plain non-clickable rows when no detail callbacks are provided', async () => {
+    useSettingsStore.setState({
+      skills: [
+        {
+          id: 'literature-review',
+          name: 'Literature Review',
+          displayName: 'Literature Review',
+          description: '',
+          source: 'featured',
+          enabled: true,
+          updatedAt: ''
+        }
+      ],
+      loadSkills: vi.fn().mockResolvedValue(undefined)
+    })
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={{
+            id: 'skills-bot',
+            name: 'Skills Bot',
+            description: '',
+            systemPrompt: '',
+            enabled: true,
+            capabilityMode: 'selected',
+            fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+            selectedCapabilities: {
+              skillIds: ['literature-review'],
+              connectorIds: [],
+              connectorTools: []
+            },
+            revision: 1
+          }}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={vi.fn().mockResolvedValue(undefined)}
+        />
+      )
+    })
+
+    expect(document.body.textContent).toContain('Literature Review')
+    expect(document.body.querySelector('[aria-label="View Literature Review details"]')).toBeNull()
+  })
+
+  it('activates a clickable skill row from the keyboard', async () => {
+    const onOpenSkillDetail = vi.fn()
+    useSettingsStore.setState({
+      skills: [
+        {
+          id: 'literature-review',
+          name: 'Literature Review',
+          displayName: 'Literature Review',
+          description: '',
+          source: 'featured',
+          enabled: true,
+          updatedAt: ''
+        }
+      ],
+      loadSkills: vi.fn().mockResolvedValue(undefined)
+    })
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={{
+            id: 'skills-bot',
+            name: 'Skills Bot',
+            description: '',
+            systemPrompt: '',
+            enabled: true,
+            capabilityMode: 'selected',
+            fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+            selectedCapabilities: {
+              skillIds: ['literature-review'],
+              connectorIds: [],
+              connectorTools: []
+            },
+            revision: 1
+          }}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={vi.fn().mockResolvedValue(undefined)}
+          onOpenSkillDetail={onOpenSkillDetail}
+        />
+      )
+    })
+
+    const row = document.body.querySelector<HTMLElement>(
+      '[aria-label="View Literature Review details"]'
+    )!
+    await act(async () => {
+      fireEvent.keyDown(row, { key: 'Enter' })
+    })
+    expect(onOpenSkillDetail).toHaveBeenCalledWith('literature-review')
+
+    await act(async () => {
+      fireEvent.keyDown(row, { key: ' ' })
+    })
+    expect(onOpenSkillDetail).toHaveBeenCalledTimes(2)
+  })
+
+  it('restores an unsaved edit after navigating to a detail page and back', async () => {
+    const profile: SpecialistProfileView = {
+      id: 'skills-bot',
+      name: 'Skills Bot',
+      description: 'Original description',
+      systemPrompt: '',
+      enabled: true,
+      capabilityMode: 'selected',
+      fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+      selectedCapabilities: {
+        skillIds: ['literature-review'],
+        connectorIds: ['chemistry'],
+        connectorTools: []
+      },
+      revision: 1
+    }
+    useSettingsStore.setState({
+      skills: [
+        {
+          id: 'literature-review',
+          name: 'Literature Review',
+          displayName: 'Literature Review',
+          description: '',
+          source: 'featured',
+          enabled: true,
+          updatedAt: ''
+        }
+      ],
+      connectors: [
+        {
+          id: 'chemistry',
+          name: 'chemistry',
+          displayName: 'Chemistry',
+          description: '',
+          sources: [],
+          requiresNcbi: false,
+          enabled: true,
+          autoAllow: false,
+          group: 'featured'
+        }
+      ],
+      loadSkills: vi.fn().mockResolvedValue(undefined),
+      loadConnectors: vi.fn().mockResolvedValue(undefined)
+    })
+    const renderEditor = (onOpenConnectorDetail = vi.fn()): void => {
+      act(() => {
+        root.render(
+          <SpecialistEditor
+            editSpecialist={{ ...profile }}
+            onCancel={vi.fn()}
+            onSave={vi.fn()}
+            onSaveEdit={vi.fn().mockResolvedValue(undefined)}
+            onOpenConnectorDetail={onOpenConnectorDetail}
+          />
+        )
+      })
+    }
+    renderEditor()
+
+    // Make an unsaved edit and switch to the Connectors capability tab.
+    await act(async () => {
+      fireEvent.change(document.body.querySelector<HTMLInputElement>('#sp-description')!, {
+        target: { value: 'My unsaved edit' }
+      })
+    })
+    await act(async () => {
+      fireEvent.click(
+        Array.from(document.body.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find((tab) =>
+          tab.textContent?.includes('Connectors')
+        )!
+      )
+    })
+
+    // Navigate away (row click) — the editor unmounts when Settings switches panels.
+    await act(async () => {
+      fireEvent.click(
+        document.body.querySelector<HTMLElement>('[aria-label="View Chemistry details"]')!
+      )
+    })
+    await act(() => {
+      root.unmount()
+    })
+    container.remove()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    // Back returns to the editor: the unsaved edit and the active tab survive.
+    renderEditor()
+    expect(document.body.querySelector<HTMLInputElement>('#sp-description')?.value).toBe(
+      'My unsaved edit'
+    )
+    expect(
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('[role="tab"]'))
+        .find((tab) => tab.textContent?.includes('Connectors'))
+        ?.getAttribute('aria-selected')
+    ).toBe('true')
+  })
+
+  it('drops the editor draft after a successful save or an explicit cancel', async () => {
+    const profile: SpecialistProfileView = {
+      id: 'draft-bot',
+      name: 'Draft Bot',
+      description: 'Original description',
+      systemPrompt: '',
+      enabled: true,
+      capabilityMode: 'full',
+      fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+      selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+      revision: 1
+    }
+    const remount = (): void => {
+      act(() => {
+        root.unmount()
+      })
+      container.remove()
+      container = document.createElement('div')
+      document.body.appendChild(container)
+      root = createRoot(container)
+      act(() => {
+        root.render(
+          <SpecialistEditor
+            editSpecialist={{ ...profile }}
+            onCancel={vi.fn()}
+            onSave={vi.fn()}
+            onSaveEdit={vi.fn().mockResolvedValue(undefined)}
+          />
+        )
+      })
+    }
+    remount()
+
+    // Save succeeds: the draft must not resurrect the pre-save edit later.
+    await act(async () => {
+      fireEvent.change(document.body.querySelector<HTMLInputElement>('#sp-description')!, {
+        target: { value: 'Saved soon' }
+      })
+    })
+    await act(async () => {
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((button) => button.textContent === 'Save changes')
+        ?.click()
+    })
+    remount()
+    expect(document.body.querySelector<HTMLInputElement>('#sp-description')?.value).toBe(
+      'Original description'
+    )
+
+    // Cancel discards explicitly: the draft is cleared too.
+    await act(async () => {
+      fireEvent.change(document.body.querySelector<HTMLInputElement>('#sp-description')!, {
+        target: { value: 'Cancelled edit' }
+      })
+    })
+    await act(async () => {
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((button) => button.textContent === 'Cancel')
+        ?.click()
+    })
+    remount()
+    expect(document.body.querySelector<HTMLInputElement>('#sp-description')?.value).toBe(
+      'Original description'
+    )
+  })
+
+  it('ignores a stale draft when the specialist revision advanced meanwhile', async () => {
+    const profile: SpecialistProfileView = {
+      id: 'stale-bot',
+      name: 'Stale Bot',
+      description: 'Original description',
+      systemPrompt: '',
+      enabled: true,
+      capabilityMode: 'full',
+      fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+      selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+      revision: 1
+    }
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={{ ...profile }}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={vi.fn().mockResolvedValue(undefined)}
+        />
+      )
+    })
+    await act(async () => {
+      fireEvent.change(document.body.querySelector<HTMLInputElement>('#sp-description')!, {
+        target: { value: 'Edit on revision 1' }
+      })
+    })
+    await act(() => {
+      root.unmount()
+    })
+    container.remove()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    // The profile was saved elsewhere (revision 2): the draft taken at revision 1 is stale.
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={{ ...profile, description: 'Newer saved description', revision: 2 }}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={vi.fn().mockResolvedValue(undefined)}
+        />
+      )
+    })
+    expect(document.body.querySelector<HTMLInputElement>('#sp-description')?.value).toBe(
+      'Newer saved description'
+    )
+  })
+
+  it('restores a create-form draft across mounts', async () => {
+    const renderCreate = (): void => {
+      act(() => {
+        root.render(<SpecialistEditor onCancel={vi.fn()} onSave={vi.fn()} />)
+      })
+    }
+    renderCreate()
+    await act(async () => {
+      fireEvent.change(document.body.querySelector<HTMLInputElement>('#sp-name')!, {
+        target: { value: 'RNA Reviewer' }
+      })
+    })
+    await act(() => {
+      root.unmount()
+    })
+    container.remove()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    renderCreate()
+
+    expect(document.body.querySelector<HTMLInputElement>('#sp-name')?.value).toBe('RNA Reviewer')
+  })
+
+  it('does not navigate when the remove action is activated from the keyboard', async () => {
+    const onOpenSkillDetail = vi.fn()
+    useSettingsStore.setState({
+      skills: [
+        {
+          id: 'literature-review',
+          name: 'Literature Review',
+          displayName: 'Literature Review',
+          description: '',
+          source: 'featured',
+          enabled: true,
+          updatedAt: ''
+        }
+      ],
+      loadSkills: vi.fn().mockResolvedValue(undefined)
+    })
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={{
+            id: 'skills-bot',
+            name: 'Skills Bot',
+            description: '',
+            systemPrompt: '',
+            enabled: true,
+            capabilityMode: 'selected',
+            fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+            selectedCapabilities: {
+              skillIds: ['literature-review'],
+              connectorIds: [],
+              connectorTools: []
+            },
+            revision: 1
+          }}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={vi.fn().mockResolvedValue(undefined)}
+          onOpenSkillDetail={onOpenSkillDetail}
+        />
+      )
+    })
+
+    // Focus lands on the remove button; pressing Enter must remove the row via the button's
+    // own activation, never the row's keyboard navigation.
+    await act(async () => {
+      fireEvent.keyDown(
+        document.body.querySelector<HTMLButtonElement>('[aria-label="Remove Literature Review"]')!,
+        { key: 'Enter' }
+      )
+    })
+    expect(onOpenSkillDetail).not.toHaveBeenCalled()
+  })
+
+  it('clears the editor draft from the store after a successful save', async () => {
+    const profile: SpecialistProfileView = {
+      id: 'save-clears-draft',
+      name: 'Save Clears Draft',
+      description: 'Original',
+      systemPrompt: '',
+      enabled: true,
+      capabilityMode: 'full',
+      fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+      selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+      revision: 1
+    }
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          editSpecialist={profile}
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          onSaveEdit={vi.fn().mockResolvedValue(undefined)}
+        />
+      )
+    })
+    await act(async () => {
+      fireEvent.change(document.body.querySelector<HTMLInputElement>('#sp-description')!, {
+        target: { value: 'Edited then saved' }
+      })
+    })
+    expect(useSpecialistStore.getState().editorDrafts[profile.id]).toBeDefined()
+
+    await act(async () => {
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((button) => button.textContent === 'Save changes')
+        ?.click()
+    })
+
+    // The save advances the form revision; that re-render must not re-create the draft.
+    expect(useSpecialistStore.getState().editorDrafts[profile.id]).toBeUndefined()
+  })
+
+  it('prefers a provided initial input over a stale create draft', async () => {
+    useSpecialistStore.setState({
+      editorDrafts: {
+        __create__: {
+          form: {
+            id: '',
+            name: 'Abandoned Half Done',
+            packageVersion: '0.1.0',
+            description: '',
+            systemPrompt: '',
+            iconKey: 'brain',
+            colorKey: 'purple',
+            capabilityMode: 'full',
+            excludedSkillIds: [],
+            selectedSkillIds: [],
+            excludedConnectorIds: [],
+            connectorIds: [],
+            baseRevision: 0
+          },
+          idTouched: false,
+          activeCapTab: 'skills'
+        }
+      }
+    })
+    await act(async () => {
+      root.render(
+        <SpecialistEditor
+          onCancel={vi.fn()}
+          onSave={vi.fn()}
+          initialInput={{
+            name: 'Marketplace Imported',
+            description: 'Prefilled by an import',
+            capabilityMode: 'selected',
+            selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] }
+          }}
+        />
+      )
+    })
+
+    expect(document.body.querySelector<HTMLInputElement>('#sp-name')?.value).toBe(
+      'Marketplace Imported'
+    )
   })
 
   it('does not show a conflict banner for non-conflict errors', async () => {

--- a/src/renderer/src/pages/settings/SpecialistEditor.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.tsx
@@ -32,6 +32,7 @@ import { SpecialistAvatar } from './specialist-avatar'
 import { AVATAR_COLORS, SPECIALIST_COLOR_OPTIONS } from './specialist-icons'
 import { APP_ICON_GROUPS, APP_ICONS, DEFAULT_APP_ICON } from '@/components/app-icons/registry'
 import { useSettingsStore } from '@/stores/settings-store'
+import { CREATE_SPECIALIST_DRAFT_KEY, useSpecialistStore } from '@/stores/specialist-store'
 import { useTagStore } from '@/stores/tag-store'
 import { SettingsIconAction } from './SettingsLayout'
 import {
@@ -54,6 +55,12 @@ type SpecialistEditorProps = {
   // Called when the user clicks "Reload" after a revision conflict.
   // Should fetch the latest profile from the store and return it.
   onReload?: () => Promise<SpecialistProfileView | undefined>
+  // Called when a selected Skill row is clicked to view that Skill in Settings.
+  onOpenSkillDetail?: (skillId: string) => void
+  // Called when a selected Connector row is clicked to view that Connector in
+  // Settings. Receives the canonical id: a custom server referenced by its legacy
+  // name is resolved to server.id before the call.
+  onOpenConnectorDetail?: (connectorId: string) => void
 }
 
 type FormState = {
@@ -96,11 +103,60 @@ type SkillRow = {
 // Flat view of the grouped registry for selected-value lookups (trigger label, previews).
 const ICON_ENTRIES = APP_ICON_GROUPS.flatMap((group) => group.icons)
 
+// Interaction props for a clickable capability row. A div[role="button"] does not synthesize a
+// click from Enter/Space the way a native button does, so both keys are handled explicitly.
+// Keyboard activation of an inner control (e.g. the remove button) is left to that control: the
+// row only reacts when it is itself the event target.
+const clickableRowProps = (
+  open: (() => void) | undefined,
+  label: string
+):
+  | {
+      role: 'button'
+      tabIndex: number
+      'aria-label': string
+      onClick: () => void
+      onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void
+    }
+  | undefined =>
+  open === undefined
+    ? undefined
+    : {
+        role: 'button',
+        tabIndex: 0,
+        'aria-label': label,
+        onClick: open,
+        onKeyDown: (event) => {
+          if (event.target !== event.currentTarget) return
+          if (event.key !== 'Enter' && event.key !== ' ') return
+          event.preventDefault()
+          open()
+        }
+      }
+
+// Shared layout for the capability list rows; `interactive` adds the clickable affordance.
+const capabilityRowClassName = (interactive: boolean): string =>
+  cn(
+    'flex h-[40px] items-center gap-2.5 border-b border-border px-3 last:border-b-0',
+    interactive && 'cursor-pointer hover:bg-muted focus-visible:bg-muted'
+  )
+
+// The remove action sits inside a row that may itself be clickable; stopping propagation keeps
+// removal from also activating the row's navigation.
+const stopThen =
+  (remove: () => void) =>
+  (event: React.MouseEvent<HTMLButtonElement>): void => {
+    event.stopPropagation()
+    remove()
+  }
+
 const SpecialistEditor = ({
   onCancel,
   onSave,
   onSaveEdit,
   onReload,
+  onOpenSkillDetail,
+  onOpenConnectorDetail,
   existingNames = [],
   existingIds = [],
   editSpecialist,
@@ -123,42 +179,62 @@ const SpecialistEditor = ({
   const customServers = useSettingsStore((state) => state.customServers)
   const loadConnectors = useSettingsStore((state) => state.loadConnectors)
   const loadSkills = useSettingsStore((state) => state.loadSkills)
+  const saveEditorDraft = useSpecialistStore((state) => state.saveEditorDraft)
+  const clearEditorDraft = useSpecialistStore((state) => state.clearEditorDraft)
+  // Editor drafts survive unmounts — opening a capability's detail page navigates Settings away —
+  // so a returning editor re-seeds from the draft instead of the stored profile. A draft restores
+  // only while the profile revision it was taken from still matches; the create form additionally
+  // yields to a provided initialInput (e.g. a marketplace import's prefill) so an abandoned
+  // earlier draft cannot swallow the new prefill.
+  const editorDraftKey = editSpecialist ? editSpecialist.id : CREATE_SPECIALIST_DRAFT_KEY
+  const storedDraft = useSpecialistStore.getState().editorDrafts[editorDraftKey]
+  const restoredDraft =
+    storedDraft !== undefined &&
+    (editSpecialist !== undefined
+      ? storedDraft.form.baseRevision === editSpecialist.revision
+      : initialInput === undefined)
+      ? storedDraft
+      : undefined
   const [form, setForm] = useState<FormState>(() =>
-    editSpecialist
-      ? {
-          id: editSpecialist.id,
-          name: editSpecialist.displayName ?? editSpecialist.name,
-          packageVersion: editSpecialist.packageVersion ?? '0.1.0',
-          description: editSpecialist.description,
-          systemPrompt: editSpecialist.systemPrompt,
-          iconKey: editSpecialist.iconKey ?? 'brain',
-          colorKey: editSpecialist.colorKey ?? 'purple',
-          capabilityMode: editSpecialist.capabilityMode,
-          excludedSkillIds: editSpecialist.fullAccess.excludedSkillIds,
-          selectedSkillIds: editSpecialist.selectedCapabilities.skillIds,
-          excludedConnectorIds: editSpecialist.fullAccess.excludedConnectorIds,
-          connectorIds: editSpecialist.selectedCapabilities.connectorIds,
-          // Pin base revision at mount so concurrent remote writes do not silently
-          // refresh it. Only a successful save or an explicit Reload may update it.
-          baseRevision: editSpecialist.revision
-        }
-      : {
-          id: initialInput?.id ?? '',
-          name: initialInput?.name ?? '',
-          packageVersion: '0.1.0',
-          description: initialInput?.description ?? '',
-          systemPrompt: initialInput?.systemPrompt ?? '',
-          iconKey: initialInput?.iconKey ?? 'brain',
-          colorKey: initialInput?.colorKey ?? 'purple',
-          capabilityMode: initialInput?.capabilityMode ?? 'full',
-          excludedSkillIds: initialInput?.fullAccess?.excludedSkillIds ?? [],
-          selectedSkillIds: initialInput?.selectedCapabilities?.skillIds ?? [],
-          excludedConnectorIds: initialInput?.fullAccess?.excludedConnectorIds ?? [],
-          connectorIds: initialInput?.selectedCapabilities?.connectorIds ?? [],
-          baseRevision: 0
-        }
+    restoredDraft !== undefined
+      ? restoredDraft.form
+      : editSpecialist
+        ? {
+            id: editSpecialist.id,
+            name: editSpecialist.displayName ?? editSpecialist.name,
+            packageVersion: editSpecialist.packageVersion ?? '0.1.0',
+            description: editSpecialist.description,
+            systemPrompt: editSpecialist.systemPrompt,
+            iconKey: editSpecialist.iconKey ?? 'brain',
+            colorKey: editSpecialist.colorKey ?? 'purple',
+            capabilityMode: editSpecialist.capabilityMode,
+            excludedSkillIds: editSpecialist.fullAccess.excludedSkillIds,
+            selectedSkillIds: editSpecialist.selectedCapabilities.skillIds,
+            excludedConnectorIds: editSpecialist.fullAccess.excludedConnectorIds,
+            connectorIds: editSpecialist.selectedCapabilities.connectorIds,
+            // Pin base revision at mount so concurrent remote writes do not silently
+            // refresh it. Only a successful save or an explicit Reload may update it.
+            baseRevision: editSpecialist.revision
+          }
+        : {
+            id: initialInput?.id ?? '',
+            name: initialInput?.name ?? '',
+            packageVersion: '0.1.0',
+            description: initialInput?.description ?? '',
+            systemPrompt: initialInput?.systemPrompt ?? '',
+            iconKey: initialInput?.iconKey ?? 'brain',
+            colorKey: initialInput?.colorKey ?? 'purple',
+            capabilityMode: initialInput?.capabilityMode ?? 'full',
+            excludedSkillIds: initialInput?.fullAccess?.excludedSkillIds ?? [],
+            selectedSkillIds: initialInput?.selectedCapabilities?.skillIds ?? [],
+            excludedConnectorIds: initialInput?.fullAccess?.excludedConnectorIds ?? [],
+            connectorIds: initialInput?.selectedCapabilities?.connectorIds ?? [],
+            baseRevision: 0
+          }
   )
-  const [idTouched, setIdTouched] = useState(initialInput?.id !== undefined)
+  const [idTouched, setIdTouched] = useState(
+    restoredDraft !== undefined ? restoredDraft.idTouched : initialInput?.id !== undefined
+  )
   const [fallbackId] = useState(() => crypto.randomUUID())
   const [fieldErrors, setFieldErrors] = useState<SpecialistFieldError[]>([])
   const [isSaving, setIsSaving] = useState(false)
@@ -167,7 +243,9 @@ const SpecialistEditor = ({
   const [hasConflict, setHasConflict] = useState(false)
   const [isReloading, setIsReloading] = useState(false)
   const [advancedOpen, setAdvancedOpen] = useState(initialInput?.id !== undefined)
-  const [activeCapTab, setActiveCapTab] = useState<'skills' | 'connectors'>('skills')
+  const [activeCapTab, setActiveCapTab] = useState<'skills' | 'connectors'>(
+    restoredDraft !== undefined ? restoredDraft.activeCapTab : 'skills'
+  )
   const [skillSearchQuery, setSkillSearchQuery] = useState('')
   const [connectorSearchQuery, setConnectorSearchQuery] = useState('')
   const [skillTagFilter, setSkillTagFilter] = useState('all')
@@ -219,6 +297,19 @@ const SpecialistEditor = ({
   useEffect(() => {
     if (skills.length === 0) void loadSkills()
   }, [skills.length, loadSkills])
+
+  // Keep the editor draft in the specialist store in sync with the live form so any unmount —
+  // detail navigation, panel switch, closing Settings — can restore the unsaved edits. A
+  // successful save suppresses the next write (the baseRevision advance) so the just-cleared
+  // draft is not immediately re-created.
+  const suppressDraftWriteRef = useRef(false)
+  useEffect(() => {
+    if (suppressDraftWriteRef.current) {
+      suppressDraftWriteRef.current = false
+      return
+    }
+    saveEditorDraft(editorDraftKey, { form, idTouched, activeCapTab })
+  }, [saveEditorDraft, editorDraftKey, form, idTouched, activeCapTab])
 
   // Persist references to unavailable entries so a temporarily missing connector is visible and
   // cannot silently broaden the profile when it returns. Main-disabled installed connectors remain
@@ -506,14 +597,18 @@ const SpecialistEditor = ({
           ...(editSpecialist.setupPending ? { completeSetup: true as const } : {}),
           ...trimmed
         })
-        // Advance the base revision only after a confirmed save.
+        // Advance the base revision only after a confirmed save, and keep that form update
+        // from re-creating the draft the save just cleared.
+        suppressDraftWriteRef.current = true
         setForm((prev) => ({ ...prev, baseRevision: prev.baseRevision + 1 }))
+        clearEditorDraft(editorDraftKey)
       } else {
         await onSave({
           ...(submittedId ? { id: submittedId } : {}),
           name: form.name.trim(),
           ...trimmed
         })
+        clearEditorDraft(editorDraftKey)
       }
     } catch (error) {
       const message =
@@ -1185,45 +1280,55 @@ const SpecialistEditor = ({
                         {t('No skills added yet.')}
                       </p>
                     ) : (
-                      selectedSkillRows.map((skill) => (
-                        <div
-                          key={skill.id}
-                          className="flex h-[40px] items-center gap-2.5 border-b border-border px-3 last:border-b-0"
-                        >
-                          <div className="min-w-0 flex-1">
-                            <div className="truncate text-[12.5px]">{skill.name}</div>
-                            {!skill.missing && skill.description ? (
-                              <div className="truncate text-[11px] text-muted-foreground">
-                                {skill.description}
-                              </div>
-                            ) : null}
+                      selectedSkillRows.map((skill) => {
+                        const openSkill =
+                          !skill.missing && onOpenSkillDetail !== undefined
+                            ? () => onOpenSkillDetail(skill.id)
+                            : undefined
+                        return (
+                          <div
+                            key={skill.id}
+                            {...clickableRowProps(
+                              openSkill,
+                              t('View {{name}} details', { name: skill.name })
+                            )}
+                            className={capabilityRowClassName(openSkill !== undefined)}
+                          >
+                            <div className="min-w-0 flex-1">
+                              <div className="truncate text-[12.5px]">{skill.name}</div>
+                              {!skill.missing && skill.description ? (
+                                <div className="truncate text-[11px] text-muted-foreground">
+                                  {skill.description}
+                                </div>
+                              ) : null}
+                            </div>
+                            {skill.missing ? (
+                              <span className="shrink-0 text-[11px] text-muted-foreground">
+                                {t('Missing · unavailable')}
+                              </span>
+                            ) : (
+                              <>
+                                {skill.source ? (
+                                  <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] capitalize text-muted-foreground">
+                                    {skill.source}
+                                  </span>
+                                ) : null}
+                                {!skill.mainEnabled ? (
+                                  <span className="shrink-0 text-[11px] text-muted-foreground">
+                                    {t('Main disabled · available here')}
+                                  </span>
+                                ) : null}
+                              </>
+                            )}
+                            <SettingsIconAction
+                              label={t('Remove {{name}}', { name: skill.name })}
+                              icon={X}
+                              onClick={stopThen(() => removeSkill(skill.id))}
+                              danger
+                            />
                           </div>
-                          {skill.missing ? (
-                            <span className="shrink-0 text-[11px] text-muted-foreground">
-                              {t('Missing · unavailable')}
-                            </span>
-                          ) : (
-                            <>
-                              {skill.source ? (
-                                <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] capitalize text-muted-foreground">
-                                  {skill.source}
-                                </span>
-                              ) : null}
-                              {!skill.mainEnabled ? (
-                                <span className="shrink-0 text-[11px] text-muted-foreground">
-                                  {t('Main disabled · available here')}
-                                </span>
-                              ) : null}
-                            </>
-                          )}
-                          <SettingsIconAction
-                            label={t('Remove {{name}}', { name: skill.name })}
-                            icon={X}
-                            onClick={() => removeSkill(skill.id)}
-                            danger
-                          />
-                        </div>
-                      ))
+                        )
+                      })
                     )}
                   </div>
                   <p className="mt-2.5 flex gap-2 rounded-lg bg-muted p-2.5 text-[11.5px] leading-snug text-muted-foreground">
@@ -1245,38 +1350,52 @@ const SpecialistEditor = ({
                         {t('No connectors added yet.')}
                       </p>
                     ) : (
-                      selectedConnectorRows.map((connector) => (
-                        <div
-                          key={connector.id}
-                          className="flex h-[40px] items-center gap-2.5 border-b border-border px-3 last:border-b-0"
-                        >
-                          <div className="min-w-0 flex-1">
-                            <div className="truncate text-[12.5px]">{connector.name}</div>
-                            {connector.available && connector.description ? (
-                              <div className="truncate text-[11px] text-muted-foreground">
-                                {connector.description}
-                              </div>
+                      selectedConnectorRows.map((connector) => {
+                        const canonicalConnectorId = (): string =>
+                          customServers.find(
+                            (server) => server.id === connector.id || server.name === connector.id
+                          )?.id ?? connector.id
+                        const openConnector =
+                          connector.available && onOpenConnectorDetail !== undefined
+                            ? () => onOpenConnectorDetail(canonicalConnectorId())
+                            : undefined
+                        return (
+                          <div
+                            key={connector.id}
+                            {...clickableRowProps(
+                              openConnector,
+                              t('View {{name}} details', { name: connector.name })
+                            )}
+                            className={capabilityRowClassName(openConnector !== undefined)}
+                          >
+                            <div className="min-w-0 flex-1">
+                              <div className="truncate text-[12.5px]">{connector.name}</div>
+                              {connector.available && connector.description ? (
+                                <div className="truncate text-[11px] text-muted-foreground">
+                                  {connector.description}
+                                </div>
+                              ) : null}
+                            </div>
+                            {!connector.available ? (
+                              <span className="shrink-0 text-[11px] text-muted-foreground">
+                                {t('Unavailable — {{reason}}', {
+                                  reason: connector.availability ?? t('not installed')
+                                })}
+                              </span>
+                            ) : !connector.mainEnabled ? (
+                              <span className="shrink-0 text-[11px] text-muted-foreground">
+                                {t('Main disabled · available here')}
+                              </span>
                             ) : null}
+                            <SettingsIconAction
+                              label={t('Remove {{name}}', { name: connector.name })}
+                              icon={X}
+                              onClick={stopThen(() => removeConnector(connector.id))}
+                              danger
+                            />
                           </div>
-                          {!connector.available ? (
-                            <span className="shrink-0 text-[11px] text-muted-foreground">
-                              {t('Unavailable — {{reason}}', {
-                                reason: connector.availability ?? t('not installed')
-                              })}
-                            </span>
-                          ) : !connector.mainEnabled ? (
-                            <span className="shrink-0 text-[11px] text-muted-foreground">
-                              {t('Main disabled · available here')}
-                            </span>
-                          ) : null}
-                          <SettingsIconAction
-                            label={t('Remove {{name}}', { name: connector.name })}
-                            icon={X}
-                            onClick={() => removeConnector(connector.id)}
-                            danger
-                          />
-                        </div>
-                      ))
+                        )
+                      })
                     )}
                   </div>
                   <p className="mt-2.5 flex gap-2 rounded-lg bg-muted p-2.5 text-[11.5px] leading-snug text-muted-foreground">
@@ -1337,7 +1456,16 @@ const SpecialistEditor = ({
 
         {/* Footer actions */}
         <div className="mt-6 flex justify-end gap-2">
-          <Button type="button" variant="ghost" onClick={onCancel} disabled={isSaving}>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => {
+              // Cancel discards the form explicitly; the draft must not resurrect it later.
+              clearEditorDraft(editorDraftKey)
+              onCancel()
+            }}
+            disabled={isSaving}
+          >
             {t('Cancel')}
           </Button>
           <Button

--- a/src/renderer/src/pages/settings/SpecialistEditor.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
+import { useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { ChevronDown, X } from 'lucide-react'
+import { ChevronDown } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -31,15 +31,8 @@ import {
 import { SpecialistAvatar } from './specialist-avatar'
 import { AVATAR_COLORS, SPECIALIST_COLOR_OPTIONS } from './specialist-icons'
 import { APP_ICON_GROUPS, APP_ICONS, DEFAULT_APP_ICON } from '@/components/app-icons/registry'
-import { useSettingsStore } from '@/stores/settings-store'
-import { CREATE_SPECIALIST_DRAFT_KEY, useSpecialistStore } from '@/stores/specialist-store'
-import { useTagStore } from '@/stores/tag-store'
-import { SettingsIconAction } from './SettingsLayout'
-import {
-  getSettingsSearchKeyShortcuts,
-  useSettingsSearchShortcut
-} from './settings-search-shortcut'
-import { TagFilter } from './ResourceTagControls'
+import { SpecialistCapabilitiesSection } from './SpecialistCapabilitiesSection'
+import { formFromProfile, useSpecialistEditorForm } from './useSpecialistEditorForm'
 
 type SpecialistEditorProps = {
   onCancel: () => void
@@ -63,92 +56,8 @@ type SpecialistEditorProps = {
   onOpenConnectorDetail?: (connectorId: string) => void
 }
 
-type FormState = {
-  id: string
-  name: string
-  packageVersion: string
-  description: string
-  systemPrompt: string
-  iconKey: string
-  colorKey: string
-  capabilityMode: 'full' | 'selected'
-  excludedSkillIds: string[]
-  selectedSkillIds: string[]
-  excludedConnectorIds: string[]
-  connectorIds: string[]
-  // Pinned at mount from editSpecialist.revision; updated only on a successful save
-  // or explicit Reload. Never updated by prop changes — that would silently defeat
-  // the optimistic concurrency guard.
-  baseRevision: number
-}
-
-type ConnectorRow = {
-  id: string
-  name: string
-  description?: string
-  mainEnabled: boolean
-  available: boolean
-  availability?: 'unavailable' | 'unauthenticated'
-}
-
-type SkillRow = {
-  id: string
-  name: string
-  description?: string
-  source?: string
-  mainEnabled: boolean
-  missing: boolean
-}
-
 // Flat view of the grouped registry for selected-value lookups (trigger label, previews).
 const ICON_ENTRIES = APP_ICON_GROUPS.flatMap((group) => group.icons)
-
-// Interaction props for a clickable capability row. A div[role="button"] does not synthesize a
-// click from Enter/Space the way a native button does, so both keys are handled explicitly.
-// Keyboard activation of an inner control (e.g. the remove button) is left to that control: the
-// row only reacts when it is itself the event target.
-const clickableRowProps = (
-  open: (() => void) | undefined,
-  label: string
-):
-  | {
-      role: 'button'
-      tabIndex: number
-      'aria-label': string
-      onClick: () => void
-      onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void
-    }
-  | undefined =>
-  open === undefined
-    ? undefined
-    : {
-        role: 'button',
-        tabIndex: 0,
-        'aria-label': label,
-        onClick: open,
-        onKeyDown: (event) => {
-          if (event.target !== event.currentTarget) return
-          if (event.key !== 'Enter' && event.key !== ' ') return
-          event.preventDefault()
-          open()
-        }
-      }
-
-// Shared layout for the capability list rows; `interactive` adds the clickable affordance.
-const capabilityRowClassName = (interactive: boolean): string =>
-  cn(
-    'flex h-[40px] items-center gap-2.5 border-b border-border px-3 last:border-b-0',
-    interactive && 'cursor-pointer hover:bg-muted focus-visible:bg-muted'
-  )
-
-// The remove action sits inside a row that may itself be clickable; stopping propagation keeps
-// removal from also activating the row's navigation.
-const stopThen =
-  (remove: () => void) =>
-  (event: React.MouseEvent<HTMLButtonElement>): void => {
-    event.stopPropagation()
-    remove()
-  }
 
 const SpecialistEditor = ({
   onCancel,
@@ -174,67 +83,19 @@ const SpecialistEditor = ({
   }
 
   const isEdit = editSpecialist !== undefined
-  const connectors = useSettingsStore((state) => state.connectors)
-  const skills = useSettingsStore((state) => state.skills)
-  const customServers = useSettingsStore((state) => state.customServers)
-  const loadConnectors = useSettingsStore((state) => state.loadConnectors)
-  const loadSkills = useSettingsStore((state) => state.loadSkills)
-  const saveEditorDraft = useSpecialistStore((state) => state.saveEditorDraft)
-  const clearEditorDraft = useSpecialistStore((state) => state.clearEditorDraft)
-  // Editor drafts survive unmounts — opening a capability's detail page navigates Settings away —
-  // so a returning editor re-seeds from the draft instead of the stored profile. A draft restores
-  // only while the profile revision it was taken from still matches; the create form additionally
-  // yields to a provided initialInput (e.g. a marketplace import's prefill) so an abandoned
-  // earlier draft cannot swallow the new prefill.
-  const editorDraftKey = editSpecialist ? editSpecialist.id : CREATE_SPECIALIST_DRAFT_KEY
-  const storedDraft = useSpecialistStore.getState().editorDrafts[editorDraftKey]
-  const restoredDraft =
-    storedDraft !== undefined &&
-    (editSpecialist !== undefined
-      ? storedDraft.form.baseRevision === editSpecialist.revision
-      : initialInput === undefined)
-      ? storedDraft
-      : undefined
-  const [form, setForm] = useState<FormState>(() =>
-    restoredDraft !== undefined
-      ? restoredDraft.form
-      : editSpecialist
-        ? {
-            id: editSpecialist.id,
-            name: editSpecialist.displayName ?? editSpecialist.name,
-            packageVersion: editSpecialist.packageVersion ?? '0.1.0',
-            description: editSpecialist.description,
-            systemPrompt: editSpecialist.systemPrompt,
-            iconKey: editSpecialist.iconKey ?? 'brain',
-            colorKey: editSpecialist.colorKey ?? 'purple',
-            capabilityMode: editSpecialist.capabilityMode,
-            excludedSkillIds: editSpecialist.fullAccess.excludedSkillIds,
-            selectedSkillIds: editSpecialist.selectedCapabilities.skillIds,
-            excludedConnectorIds: editSpecialist.fullAccess.excludedConnectorIds,
-            connectorIds: editSpecialist.selectedCapabilities.connectorIds,
-            // Pin base revision at mount so concurrent remote writes do not silently
-            // refresh it. Only a successful save or an explicit Reload may update it.
-            baseRevision: editSpecialist.revision
-          }
-        : {
-            id: initialInput?.id ?? '',
-            name: initialInput?.name ?? '',
-            packageVersion: '0.1.0',
-            description: initialInput?.description ?? '',
-            systemPrompt: initialInput?.systemPrompt ?? '',
-            iconKey: initialInput?.iconKey ?? 'brain',
-            colorKey: initialInput?.colorKey ?? 'purple',
-            capabilityMode: initialInput?.capabilityMode ?? 'full',
-            excludedSkillIds: initialInput?.fullAccess?.excludedSkillIds ?? [],
-            selectedSkillIds: initialInput?.selectedCapabilities?.skillIds ?? [],
-            excludedConnectorIds: initialInput?.fullAccess?.excludedConnectorIds ?? [],
-            connectorIds: initialInput?.selectedCapabilities?.connectorIds ?? [],
-            baseRevision: 0
-          }
-  )
-  const [idTouched, setIdTouched] = useState(
-    restoredDraft !== undefined ? restoredDraft.idTouched : initialInput?.id !== undefined
-  )
+  // Form state machine: mount-time seeding (profile, create prefill, or restorable
+  // draft) plus the unsaved-form draft kept in the specialist store. Restore rules
+  // live in the hook.
+  const {
+    form,
+    setForm,
+    idTouched,
+    setIdTouched,
+    activeCapTab,
+    setActiveCapTab,
+    clearDraft,
+    suppressNextDraftWrite
+  } = useSpecialistEditorForm({ editSpecialist, initialInput })
   const [fallbackId] = useState(() => crypto.randomUUID())
   const [fieldErrors, setFieldErrors] = useState<SpecialistFieldError[]>([])
   const [isSaving, setIsSaving] = useState(false)
@@ -243,265 +104,10 @@ const SpecialistEditor = ({
   const [hasConflict, setHasConflict] = useState(false)
   const [isReloading, setIsReloading] = useState(false)
   const [advancedOpen, setAdvancedOpen] = useState(initialInput?.id !== undefined)
-  const [activeCapTab, setActiveCapTab] = useState<'skills' | 'connectors'>(
-    restoredDraft !== undefined ? restoredDraft.activeCapTab : 'skills'
-  )
-  const [skillSearchQuery, setSkillSearchQuery] = useState('')
-  const [connectorSearchQuery, setConnectorSearchQuery] = useState('')
-  const [skillTagFilter, setSkillTagFilter] = useState('all')
-  const [connectorTagFilter, setConnectorTagFilter] = useState('all')
-  const tagAssignments = useTagStore((state) => state.assignments)
-  const skillSearchRef = useRef<HTMLInputElement>(null)
-  const connectorSearchRef = useRef<HTMLInputElement>(null)
-  const [skillPopoverOpen, setSkillPopoverOpen] = useState(false)
-  const [connectorPopoverOpen, setConnectorPopoverOpen] = useState(false)
-  const skillDropdownRef = useRef<HTMLDivElement>(null)
-  const connectorDropdownRef = useRef<HTMLDivElement>(null)
-  useSettingsSearchShortcut(skillSearchRef, skillPopoverOpen)
-  useSettingsSearchShortcut(connectorSearchRef, connectorPopoverOpen)
-  const skillTriggerRef = useRef<HTMLButtonElement>(null)
-  const connectorTriggerRef = useRef<HTMLButtonElement>(null)
-
-  const closeSkillDropdown = useCallback(() => setSkillPopoverOpen(false), [])
-  const closeConnectorDropdown = useCallback(() => setConnectorPopoverOpen(false), [])
-
-  useEffect(() => {
-    if (!skillPopoverOpen) return
-    const handle = (e: MouseEvent): void => {
-      if (skillDropdownRef.current && !skillDropdownRef.current.contains(e.target as Node)) {
-        closeSkillDropdown()
-      }
-    }
-    document.addEventListener('mousedown', handle)
-    return () => document.removeEventListener('mousedown', handle)
-  }, [skillPopoverOpen, closeSkillDropdown])
-
-  useEffect(() => {
-    if (!connectorPopoverOpen) return
-    const handle = (e: MouseEvent): void => {
-      if (
-        connectorDropdownRef.current &&
-        !connectorDropdownRef.current.contains(e.target as Node)
-      ) {
-        closeConnectorDropdown()
-      }
-    }
-    document.addEventListener('mousedown', handle)
-    return () => document.removeEventListener('mousedown', handle)
-  }, [connectorPopoverOpen, closeConnectorDropdown])
-
-  useEffect(() => {
-    void loadConnectors()
-  }, [loadConnectors])
-
-  useEffect(() => {
-    if (skills.length === 0) void loadSkills()
-  }, [skills.length, loadSkills])
-
-  // Keep the editor draft in the specialist store in sync with the live form so any unmount —
-  // detail navigation, panel switch, closing Settings — can restore the unsaved edits. A
-  // successful save suppresses the next write (the baseRevision advance) so the just-cleared
-  // draft is not immediately re-created.
-  const suppressDraftWriteRef = useRef(false)
-  useEffect(() => {
-    if (suppressDraftWriteRef.current) {
-      suppressDraftWriteRef.current = false
-      return
-    }
-    saveEditorDraft(editorDraftKey, { form, idTouched, activeCapTab })
-  }, [saveEditorDraft, editorDraftKey, form, idTouched, activeCapTab])
-
-  // Persist references to unavailable entries so a temporarily missing connector is visible and
-  // cannot silently broaden the profile when it returns. Main-disabled installed connectors remain
-  // selectable: Main's toggle is not a Specialist capability limit.
-  const connectorRows = useMemo(() => {
-    const referencedIds = new Set([...form.excludedConnectorIds, ...form.connectorIds])
-    const known: ConnectorRow[] = [
-      ...connectors.map((connector) => ({
-        id: connector.id,
-        name: connector.displayName,
-        description: connector.description,
-        mainEnabled: connector.enabled,
-        available: true
-      })),
-      ...customServers.map((server) => ({
-        id:
-          referencedIds.has(server.name) && !referencedIds.has(server.id) ? server.name : server.id,
-        name: server.displayName,
-        description: server.description ? `${server.name} · ${server.description}` : server.name,
-        mainEnabled: server.enabled,
-        available: server.availability === undefined,
-        availability: server.availability
-      }))
-    ]
-    const ids = new Set(known.map((row) => row.id))
-    for (const id of [...form.excludedConnectorIds, ...form.connectorIds]) {
-      if (ids.has(id)) continue
-      const legacy = customServers.find((server) => server.name === id)
-      if (legacy) {
-        known.push({
-          id,
-          name: legacy.displayName,
-          description: legacy.description ? `${legacy.name} · ${legacy.description}` : legacy.name,
-          mainEnabled: legacy.enabled,
-          available: legacy.availability === undefined,
-          availability: legacy.availability
-        })
-      } else {
-        known.push({ id, name: id, mainEnabled: false, available: false })
-      }
-    }
-    return known.sort((a, b) => a.name.localeCompare(b.name))
-  }, [connectors, customServers, form.connectorIds, form.excludedConnectorIds])
-
-  // Main-disabled installed Skills remain selectable for a Specialist. Persisted IDs absent from
-  // the live catalog are rendered locally so the user can remove them without blocking the session.
-  const skillRows = useMemo(() => {
-    const known: SkillRow[] = skills.map((skill) => ({
-      id: skill.id,
-      name: skill.name,
-      description: skill.description,
-      source: skill.source,
-      mainEnabled: skill.enabled,
-      missing: false
-    }))
-    const ids = new Set(known.map((skill) => skill.id))
-    for (const id of [...form.excludedSkillIds, ...form.selectedSkillIds]) {
-      if (!ids.has(id)) known.push({ id, name: id, mainEnabled: false, missing: true })
-    }
-    return known.sort((a, b) => a.name.localeCompare(b.name))
-  }, [skills, form.excludedSkillIds, form.selectedSkillIds])
-
-  // Selected-capabilities mode lists. Skills and Connectors are both whitelists: they start empty
-  // and are added explicitly. Persisted IDs missing from the catalog stay visible (and removable)
-  // so a stale reference never locks the session. Main-disabled installed items remain addable:
-  // Main's toggle is not a Specialist capability limit.
-  const selectedSkillRows = useMemo(
-    () =>
-      form.selectedSkillIds.map((id) => {
-        const found = skillRows.find((row) => row.id === id)
-        return found ?? { id, name: id, mainEnabled: false, missing: true }
-      }),
-    [form.selectedSkillIds, skillRows]
-  )
-  const addableSkills = useMemo(
-    () =>
-      skills
-        .filter((skill) => !form.selectedSkillIds.includes(skill.id))
-        .map((skill) => ({
-          id: skill.id,
-          name: skill.name,
-          description: skill.description,
-          source: skill.source
-        }))
-        .sort((a, b) => a.name.localeCompare(b.name)),
-    [skills, form.selectedSkillIds]
-  )
-
-  const selectedConnectorRows = useMemo(
-    () =>
-      form.connectorIds.map((id) => {
-        const found = connectorRows.find((row) => row.id === id)
-        return found ?? { id, name: id, mainEnabled: false, available: false }
-      }),
-    [form.connectorIds, connectorRows]
-  )
-  const addableConnectors = useMemo(() => {
-    const all: ConnectorRow[] = [
-      ...connectors.map((connector) => ({
-        id: connector.id,
-        name: connector.displayName,
-        description: connector.description,
-        mainEnabled: connector.enabled,
-        available: true
-      })),
-      ...customServers.map((server) => ({
-        id: server.id,
-        name: server.displayName,
-        description: server.description ? `${server.name} · ${server.description}` : server.name,
-        mainEnabled: server.enabled,
-        available: server.availability === undefined,
-        availability: server.availability
-      }))
-    ]
-    return all
-      .filter((row) => {
-        if (!row.available) return false
-        const custom = customServers.find((server) => server.id === row.id)
-        return !form.connectorIds.some(
-          (id) => id === row.id || (custom !== undefined && id === custom.name)
-        )
-      })
-      .sort((a, b) => a.name.localeCompare(b.name))
-  }, [connectors, customServers, form.connectorIds])
-
-  const filteredAddableSkills = useMemo(() => {
-    const tagged =
-      skillTagFilter === 'all'
-        ? addableSkills
-        : addableSkills.filter((skill) =>
-            tagAssignments.some(
-              (assignment) =>
-                assignment.tagId === skillTagFilter &&
-                assignment.resourceType === 'catalog.skill' &&
-                assignment.resourceId === skill.id
-            )
-          )
-    if (!skillSearchQuery.trim()) return tagged
-    const q = skillSearchQuery.toLowerCase()
-    return tagged.filter(
-      (skill) =>
-        skill.name.toLowerCase().includes(q) ||
-        (skill.description && skill.description.toLowerCase().includes(q))
-    )
-  }, [addableSkills, skillSearchQuery, skillTagFilter, tagAssignments])
-
-  const filteredAddableConnectors = useMemo(() => {
-    const tagged =
-      connectorTagFilter === 'all'
-        ? addableConnectors
-        : addableConnectors.filter((connector) =>
-            tagAssignments.some(
-              (assignment) =>
-                assignment.tagId === connectorTagFilter &&
-                assignment.resourceType === 'catalog.connector' &&
-                assignment.resourceId === connector.id
-            )
-          )
-    if (!connectorSearchQuery.trim()) return tagged
-    const q = connectorSearchQuery.toLowerCase()
-    return tagged.filter(
-      (connector) =>
-        connector.name.toLowerCase().includes(q) ||
-        (connector.description && connector.description.toLowerCase().includes(q))
-    )
-  }, [addableConnectors, connectorSearchQuery, connectorTagFilter, tagAssignments])
-
-  const addSkill = (id: string): void =>
-    setForm((prev) =>
-      prev.selectedSkillIds.includes(id)
-        ? prev
-        : { ...prev, selectedSkillIds: [...prev.selectedSkillIds, id] }
-    )
-  const removeSkill = (id: string): void =>
-    setForm((prev) => ({
-      ...prev,
-      selectedSkillIds: prev.selectedSkillIds.filter((skillId) => skillId !== id)
-    }))
-  const addConnector = (id: string): void =>
-    setForm((prev) =>
-      prev.connectorIds.includes(id) ? prev : { ...prev, connectorIds: [...prev.connectorIds, id] }
-    )
-  const removeConnector = (id: string): void =>
-    setForm((prev) => ({
-      ...prev,
-      connectorIds: prev.connectorIds.filter((connectorId) => connectorId !== id)
-    }))
 
   const getFieldError = (field: SpecialistFieldError['field']): string | undefined =>
     fieldErrors.find((e) => e.field === field)?.message
 
-  const isFullAccess = form.capabilityMode === 'full'
   const inferredId = inferSpecialistId(form.name)
   const generatedId = inferredId && !existingIds.includes(inferredId) ? inferredId : fallbackId
   const currentId = idTouched ? form.id : generatedId
@@ -599,16 +205,16 @@ const SpecialistEditor = ({
         })
         // Advance the base revision only after a confirmed save, and keep that form update
         // from re-creating the draft the save just cleared.
-        suppressDraftWriteRef.current = true
+        suppressNextDraftWrite()
         setForm((prev) => ({ ...prev, baseRevision: prev.baseRevision + 1 }))
-        clearEditorDraft(editorDraftKey)
+        clearDraft()
       } else {
         await onSave({
           ...(submittedId ? { id: submittedId } : {}),
           name: form.name.trim(),
           ...trimmed
         })
-        clearEditorDraft(editorDraftKey)
+        clearDraft()
       }
     } catch (error) {
       const message =
@@ -639,21 +245,7 @@ const SpecialistEditor = ({
     try {
       const fresh = await onReload()
       if (fresh) {
-        setForm({
-          id: fresh.id,
-          name: fresh.displayName ?? fresh.name,
-          packageVersion: fresh.packageVersion ?? '0.1.0',
-          description: fresh.description,
-          systemPrompt: fresh.systemPrompt,
-          iconKey: fresh.iconKey ?? 'brain',
-          colorKey: fresh.colorKey ?? 'purple',
-          capabilityMode: fresh.capabilityMode,
-          excludedSkillIds: fresh.fullAccess.excludedSkillIds,
-          selectedSkillIds: fresh.selectedCapabilities.skillIds,
-          excludedConnectorIds: fresh.fullAccess.excludedConnectorIds,
-          connectorIds: fresh.selectedCapabilities.connectorIds,
-          baseRevision: fresh.revision
-        })
+        setForm(formFromProfile(fresh))
         setHasConflict(false)
       }
     } finally {
@@ -1036,390 +628,26 @@ const SpecialistEditor = ({
         </section>
 
         {/* Capabilities */}
-        <section className="border-t border-border pt-5">
-          <h3 className="mb-1 text-base font-semibold text-foreground">{t('Capabilities')}</h3>
-          <p className="mb-4 text-[13px] leading-5 text-muted-foreground">
-            {t(
-              'Skills and connectors this specialist can use. Anything not chosen here stays invisible and unreachable in its sessions, even when enabled globally.'
-            )}
-          </p>
-
-          {/* Full access — single option, default selected. Loads every Main Agent skill and
-              connector; selecting it disables the Select capabilities panel below. */}
-          <button
-            type="button"
-            role="switch"
-            aria-checked={isFullAccess}
-            aria-label={t('Full access')}
-            onClick={() =>
-              setForm((prev) => ({
-                ...prev,
-                capabilityMode: prev.capabilityMode === 'full' ? 'selected' : 'full'
-              }))
-            }
-            className={cn(
-              'mb-2 flex items-start gap-3 rounded-lg border p-3 text-left transition-colors',
-              isFullAccess ? 'border-primary bg-primary/5' : 'border-border bg-card hover:bg-muted'
-            )}
-          >
-            <span
-              className={cn(
-                'mt-0.5 flex size-[18px] shrink-0 items-center justify-center rounded-full border-2',
-                isFullAccess ? 'border-primary' : 'border-text-300'
-              )}
-            >
-              {isFullAccess ? <span className="size-2.5 rounded-full bg-primary" /> : null}
-            </span>
-            <span className="min-w-0 flex-1">
-              <span className="flex items-center gap-2 text-[13px] font-semibold">
-                {t('Full access')}
-                <span className="rounded bg-primary px-1.5 py-px text-[9.5px] font-semibold uppercase tracking-wide text-primary-foreground">
-                  {t('Default')}
-                </span>
-              </span>
-              <span className="mt-0.5 block text-[11.5px] leading-snug text-muted-foreground">
-                {t(
-                  "Use all of the Main Agent's skills and connectors, including new ones added later. No need to configure each item."
-                )}
-              </span>
-            </span>
-          </button>
-
-          <div className="my-3 flex items-center gap-3" aria-hidden="true">
-            <span className="h-px flex-1 bg-border" />
-            <span className="text-[11px] text-text-300">
-              {t('or choose specific capabilities')}
-            </span>
-            <span className="h-px flex-1 bg-border" />
-          </div>
-
-          {/* Select capabilities — greyed and non-interactive while Full access is on. Clicking the
-              greyed panel turns Full access off so the lists become editable. */}
-          <div className="relative">
-            <div
-              className={cn(
-                'rounded-lg',
-                isFullAccess && 'pointer-events-none opacity-45 select-none'
-              )}
-            >
-              <div className="mb-3 flex items-center justify-between">
-                <div
-                  className="inline-flex gap-0.5 rounded-lg bg-muted p-1"
-                  role="tablist"
-                  aria-label={t('Capability type')}
-                >
-                  <button
-                    type="button"
-                    role="tab"
-                    aria-selected={activeCapTab === 'skills'}
-                    onClick={() => setActiveCapTab('skills')}
-                    className={cn(
-                      'rounded-md px-3 py-1 text-[12.5px] font-medium',
-                      activeCapTab === 'skills'
-                        ? 'bg-card text-foreground shadow-sm'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    {t('Skills')}{' '}
-                    <span className="ml-0.5 text-[11px] opacity-75">
-                      {form.selectedSkillIds.length}
-                    </span>
-                  </button>
-                  <button
-                    type="button"
-                    role="tab"
-                    aria-selected={activeCapTab === 'connectors'}
-                    onClick={() => setActiveCapTab('connectors')}
-                    className={cn(
-                      'rounded-md px-3 py-1 text-[12.5px] font-medium',
-                      activeCapTab === 'connectors'
-                        ? 'bg-card text-foreground shadow-sm'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    {t('Connectors')}{' '}
-                    <span className="ml-0.5 text-[11px] opacity-75">
-                      {form.connectorIds.length}
-                    </span>
-                  </button>
-                </div>
-
-                {/* Add button + dropdown — right side of the same row */}
-                {activeCapTab === 'skills' ? (
-                  <div className="relative" ref={skillDropdownRef}>
-                    <button
-                      ref={skillTriggerRef}
-                      type="button"
-                      onClick={() => {
-                        setSkillPopoverOpen((prev) => !prev)
-                        setSkillSearchQuery('')
-                        setTimeout(() => skillSearchRef.current?.focus(), 0)
-                      }}
-                      className="flex h-[28px] items-center rounded-lg border border-dashed border-border bg-card px-3 text-[12px] text-muted-foreground hover:bg-muted"
-                    >
-                      {t('＋ Add a skill')}
-                    </button>
-                    {skillPopoverOpen ? (
-                      <div className="absolute right-0 top-full z-50 mt-1 flex max-h-[260px] w-[240px] flex-col overflow-y-auto rounded-lg border border-border bg-card shadow-md">
-                        <div className="sticky top-0 z-10 border-b border-border bg-card p-2">
-                          <input
-                            ref={skillSearchRef}
-                            type="search"
-                            aria-label={t('Search skills to add')}
-                            aria-keyshortcuts={getSettingsSearchKeyShortcuts()}
-                            placeholder={t('Search skills…')}
-                            value={skillSearchQuery}
-                            onChange={(e) => setSkillSearchQuery(e.target.value)}
-                            className="w-full rounded-md border border-border bg-card px-2.5 py-1.5 text-[12.5px] text-foreground placeholder:text-muted-foreground outline-none focus:border-primary"
-                          />
-                          <TagFilter
-                            resourceType="catalog.skill"
-                            value={skillTagFilter}
-                            onChange={setSkillTagFilter}
-                            className="mt-2 w-full"
-                          />
-                        </div>
-                        <div className="flex-1">
-                          {filteredAddableSkills.length === 0 ? (
-                            <p className="px-3 py-3 text-[12px] text-muted-foreground">
-                              {skillSearchQuery
-                                ? t('No matching skills')
-                                : t('No more skills to add')}
-                            </p>
-                          ) : (
-                            filteredAddableSkills.map((skill) => (
-                              <button
-                                key={skill.id}
-                                type="button"
-                                onClick={() => {
-                                  addSkill(skill.id)
-                                  setSkillPopoverOpen(false)
-                                }}
-                                className="flex h-[32px] w-full items-center gap-2 px-3 text-left hover:bg-muted"
-                              >
-                                <span className="min-w-0 flex-1 truncate text-[12.5px]">
-                                  {skill.name}
-                                </span>
-                              </button>
-                            ))
-                          )}
-                        </div>
-                      </div>
-                    ) : null}
-                  </div>
-                ) : (
-                  <div className="relative" ref={connectorDropdownRef}>
-                    <button
-                      ref={connectorTriggerRef}
-                      type="button"
-                      onClick={() => {
-                        setConnectorPopoverOpen((prev) => !prev)
-                        setConnectorSearchQuery('')
-                        setTimeout(() => connectorSearchRef.current?.focus(), 0)
-                      }}
-                      className="flex h-[28px] items-center rounded-lg border border-dashed border-border bg-card px-3 text-[12px] text-muted-foreground hover:bg-muted"
-                    >
-                      {t('＋ Add a connector')}
-                    </button>
-                    {connectorPopoverOpen ? (
-                      <div className="absolute right-0 top-full z-50 mt-1 flex max-h-[260px] w-[240px] flex-col overflow-y-auto rounded-lg border border-border bg-card shadow-md">
-                        <div className="sticky top-0 z-10 border-b border-border bg-card p-2">
-                          <input
-                            ref={connectorSearchRef}
-                            type="search"
-                            aria-label={t('Search connectors to add')}
-                            aria-keyshortcuts={getSettingsSearchKeyShortcuts()}
-                            placeholder={t('Search connectors…')}
-                            value={connectorSearchQuery}
-                            onChange={(e) => setConnectorSearchQuery(e.target.value)}
-                            className="w-full rounded-md border border-border bg-card px-2.5 py-1.5 text-[12.5px] text-foreground placeholder:text-muted-foreground outline-none focus:border-primary"
-                          />
-                          <TagFilter
-                            resourceType="catalog.connector"
-                            value={connectorTagFilter}
-                            onChange={setConnectorTagFilter}
-                            className="mt-2 w-full"
-                          />
-                        </div>
-                        <div className="flex-1">
-                          {filteredAddableConnectors.length === 0 ? (
-                            <p className="px-3 py-3 text-[12px] text-muted-foreground">
-                              {connectorSearchQuery
-                                ? t('No matching connectors')
-                                : t('No more connectors to add')}
-                            </p>
-                          ) : (
-                            filteredAddableConnectors.map((connector) => (
-                              <button
-                                key={connector.id}
-                                type="button"
-                                onClick={() => {
-                                  addConnector(connector.id)
-                                  setConnectorPopoverOpen(false)
-                                }}
-                                className="flex h-[32px] w-full items-center gap-2 px-3 text-left hover:bg-muted"
-                              >
-                                <span className="min-w-0 flex-1 truncate text-[12.5px]">
-                                  {connector.name}
-                                </span>
-                              </button>
-                            ))
-                          )}
-                        </div>
-                      </div>
-                    ) : null}
-                  </div>
-                )}
-              </div>
-
-              {activeCapTab === 'skills' ? (
-                <div>
-                  <div className="overflow-hidden rounded-lg border border-border">
-                    {selectedSkillRows.length === 0 ? (
-                      <p className="px-3 py-3.5 text-[12px] text-muted-foreground">
-                        {t('No skills added yet.')}
-                      </p>
-                    ) : (
-                      selectedSkillRows.map((skill) => {
-                        const openSkill =
-                          !skill.missing && onOpenSkillDetail !== undefined
-                            ? () => onOpenSkillDetail(skill.id)
-                            : undefined
-                        return (
-                          <div
-                            key={skill.id}
-                            {...clickableRowProps(
-                              openSkill,
-                              t('View {{name}} details', { name: skill.name })
-                            )}
-                            className={capabilityRowClassName(openSkill !== undefined)}
-                          >
-                            <div className="min-w-0 flex-1">
-                              <div className="truncate text-[12.5px]">{skill.name}</div>
-                              {!skill.missing && skill.description ? (
-                                <div className="truncate text-[11px] text-muted-foreground">
-                                  {skill.description}
-                                </div>
-                              ) : null}
-                            </div>
-                            {skill.missing ? (
-                              <span className="shrink-0 text-[11px] text-muted-foreground">
-                                {t('Missing · unavailable')}
-                              </span>
-                            ) : (
-                              <>
-                                {skill.source ? (
-                                  <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] capitalize text-muted-foreground">
-                                    {skill.source}
-                                  </span>
-                                ) : null}
-                                {!skill.mainEnabled ? (
-                                  <span className="shrink-0 text-[11px] text-muted-foreground">
-                                    {t('Main disabled · available here')}
-                                  </span>
-                                ) : null}
-                              </>
-                            )}
-                            <SettingsIconAction
-                              label={t('Remove {{name}}', { name: skill.name })}
-                              icon={X}
-                              onClick={stopThen(() => removeSkill(skill.id))}
-                              danger
-                            />
-                          </div>
-                        )
-                      })
-                    )}
-                  </div>
-                  <p className="mt-2.5 flex gap-2 rounded-lg bg-muted p-2.5 text-[11.5px] leading-snug text-muted-foreground">
-                    <span aria-hidden="true">ⓘ</span>
-                    <span>
-                      {t(
-                        'Skills start empty and must be added. Skills not listed here are hidden from this specialist, and Skill calls to them are rejected.'
-                      )}
-                    </span>
-                  </p>
-                </div>
-              ) : null}
-
-              {activeCapTab === 'connectors' ? (
-                <div>
-                  <div className="overflow-hidden rounded-lg border border-border">
-                    {selectedConnectorRows.length === 0 ? (
-                      <p className="px-3 py-3.5 text-[12px] text-muted-foreground">
-                        {t('No connectors added yet.')}
-                      </p>
-                    ) : (
-                      selectedConnectorRows.map((connector) => {
-                        const canonicalConnectorId = (): string =>
-                          customServers.find(
-                            (server) => server.id === connector.id || server.name === connector.id
-                          )?.id ?? connector.id
-                        const openConnector =
-                          connector.available && onOpenConnectorDetail !== undefined
-                            ? () => onOpenConnectorDetail(canonicalConnectorId())
-                            : undefined
-                        return (
-                          <div
-                            key={connector.id}
-                            {...clickableRowProps(
-                              openConnector,
-                              t('View {{name}} details', { name: connector.name })
-                            )}
-                            className={capabilityRowClassName(openConnector !== undefined)}
-                          >
-                            <div className="min-w-0 flex-1">
-                              <div className="truncate text-[12.5px]">{connector.name}</div>
-                              {connector.available && connector.description ? (
-                                <div className="truncate text-[11px] text-muted-foreground">
-                                  {connector.description}
-                                </div>
-                              ) : null}
-                            </div>
-                            {!connector.available ? (
-                              <span className="shrink-0 text-[11px] text-muted-foreground">
-                                {t('Unavailable — {{reason}}', {
-                                  reason: connector.availability ?? t('not installed')
-                                })}
-                              </span>
-                            ) : !connector.mainEnabled ? (
-                              <span className="shrink-0 text-[11px] text-muted-foreground">
-                                {t('Main disabled · available here')}
-                              </span>
-                            ) : null}
-                            <SettingsIconAction
-                              label={t('Remove {{name}}', { name: connector.name })}
-                              icon={X}
-                              onClick={stopThen(() => removeConnector(connector.id))}
-                              danger
-                            />
-                          </div>
-                        )
-                      })
-                    )}
-                  </div>
-                  <p className="mt-2.5 flex gap-2 rounded-lg bg-muted p-2.5 text-[11.5px] leading-snug text-muted-foreground">
-                    <span aria-hidden="true">ⓘ</span>
-                    <span>
-                      {t(
-                        "Connectors start empty and must be added. Connectors not listed here are blocked at runtime for this specialist's sessions."
-                      )}
-                    </span>
-                  </p>
-                </div>
-              ) : null}
-            </div>
-
-            {isFullAccess ? (
-              <button
-                type="button"
-                aria-label={t('Enable select capabilities')}
-                onClick={() => setForm((prev) => ({ ...prev, capabilityMode: 'selected' }))}
-                className="absolute inset-0 cursor-pointer rounded-lg"
-              />
-            ) : null}
-          </div>
-        </section>
+        <SpecialistCapabilitiesSection
+          capabilityMode={form.capabilityMode}
+          onCapabilityModeChange={(capabilityMode) =>
+            setForm((prev) => ({ ...prev, capabilityMode }))
+          }
+          selectedSkillIds={form.selectedSkillIds}
+          excludedSkillIds={form.excludedSkillIds}
+          selectedConnectorIds={form.connectorIds}
+          excludedConnectorIds={form.excludedConnectorIds}
+          updateSkillIds={(update) =>
+            setForm((prev) => ({ ...prev, selectedSkillIds: update(prev.selectedSkillIds) }))
+          }
+          updateConnectorIds={(update) =>
+            setForm((prev) => ({ ...prev, connectorIds: update(prev.connectorIds) }))
+          }
+          activeTab={activeCapTab}
+          onActiveTabChange={setActiveCapTab}
+          onOpenSkillDetail={onOpenSkillDetail}
+          onOpenConnectorDetail={onOpenConnectorDetail}
+        />
 
         {/* Revision conflict banner — shown when another save raced ahead.
             Local edits are preserved so the user can review before reloading. */}
@@ -1461,7 +689,7 @@ const SpecialistEditor = ({
             variant="ghost"
             onClick={() => {
               // Cancel discards the form explicitly; the draft must not resurrect it later.
-              clearEditorDraft(editorDraftKey)
+              clearDraft()
               onCancel()
             }}
             disabled={isSaving}

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -149,6 +149,9 @@ type SpecialistsPanelProps = {
   view: SpecialistsView
   onNavigate: (view: SpecialistsView) => void
   onOpenTag?: (tagId: string) => void
+  // Opens one Skill / Connector from a specialist's capability list in its own settings panel.
+  onOpenSkillDetail?: (skillId: string) => void
+  onOpenConnectorDetail?: (connectorId: string) => void
 }
 
 type InstalledSpecialistsView = Exclude<SpecialistsView, SpecialistMarketplaceView>
@@ -156,11 +159,15 @@ type InstalledSpecialistsView = Exclude<SpecialistsView, SpecialistMarketplaceVi
 const InstalledSpecialistsPanel = ({
   view,
   onNavigate,
-  onOpenTag
+  onOpenTag,
+  onOpenSkillDetail,
+  onOpenConnectorDetail
 }: {
   view: InstalledSpecialistsView
   onNavigate: (view: SpecialistsView) => void
   onOpenTag?: (tagId: string) => void
+  onOpenSkillDetail?: (skillId: string) => void
+  onOpenConnectorDetail?: (connectorId: string) => void
 }): React.JSX.Element => {
   const { t } = useTranslation()
 
@@ -433,6 +440,8 @@ const InstalledSpecialistsPanel = ({
           await createSpecialist(input)
           onNavigate({ kind: 'list' })
         }}
+        onOpenSkillDetail={onOpenSkillDetail}
+        onOpenConnectorDetail={onOpenConnectorDetail}
       />
     )
   }
@@ -650,6 +659,8 @@ const InstalledSpecialistsPanel = ({
               if (refreshed && refreshed.kind === 'custom') return refreshed
               return undefined
             }}
+            onOpenSkillDetail={onOpenSkillDetail}
+            onOpenConnectorDetail={onOpenConnectorDetail}
           />
         </div>
       )
@@ -2025,6 +2036,8 @@ const SpecialistsPanel = (props: SpecialistsPanelProps): React.JSX.Element =>
       view={props.view}
       onNavigate={props.onNavigate}
       onOpenTag={props.onOpenTag}
+      onOpenSkillDetail={props.onOpenSkillDetail}
+      onOpenConnectorDetail={props.onOpenConnectorDetail}
     />
   )
 

--- a/src/renderer/src/pages/settings/useSpecialistEditorForm.ts
+++ b/src/renderer/src/pages/settings/useSpecialistEditorForm.ts
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react'
+import type { CreateSpecialistInput, SpecialistProfileView } from '../../../../shared/specialist'
+import {
+  CREATE_SPECIALIST_DRAFT_KEY,
+  useSpecialistStore,
+  type SpecialistEditorFormDraft
+} from '@/stores/specialist-store'
+
+// Seeds a form from a stored profile. Used both at mount (edit mode) and after an
+// explicit Reload following a revision conflict.
+export const formFromProfile = (profile: SpecialistProfileView): SpecialistEditorFormDraft => ({
+  id: profile.id,
+  name: profile.displayName ?? profile.name,
+  packageVersion: profile.packageVersion ?? '0.1.0',
+  description: profile.description,
+  systemPrompt: profile.systemPrompt,
+  iconKey: profile.iconKey ?? 'brain',
+  colorKey: profile.colorKey ?? 'purple',
+  capabilityMode: profile.capabilityMode,
+  excludedSkillIds: profile.fullAccess.excludedSkillIds,
+  selectedSkillIds: profile.selectedCapabilities.skillIds,
+  excludedConnectorIds: profile.fullAccess.excludedConnectorIds,
+  connectorIds: profile.selectedCapabilities.connectorIds,
+  // Pin base revision so concurrent remote writes do not silently refresh it.
+  // Only a successful save or an explicit Reload may update it.
+  baseRevision: profile.revision
+})
+
+export const formFromCreateInput = (
+  input: CreateSpecialistInput | undefined
+): SpecialistEditorFormDraft => ({
+  id: input?.id ?? '',
+  name: input?.name ?? '',
+  packageVersion: '0.1.0',
+  description: input?.description ?? '',
+  systemPrompt: input?.systemPrompt ?? '',
+  iconKey: input?.iconKey ?? 'brain',
+  colorKey: input?.colorKey ?? 'purple',
+  capabilityMode: input?.capabilityMode ?? 'full',
+  excludedSkillIds: input?.fullAccess?.excludedSkillIds ?? [],
+  selectedSkillIds: input?.selectedCapabilities?.skillIds ?? [],
+  excludedConnectorIds: input?.fullAccess?.excludedConnectorIds ?? [],
+  connectorIds: input?.selectedCapabilities?.connectorIds ?? [],
+  baseRevision: 0
+})
+
+type UseSpecialistEditorFormOptions = {
+  editSpecialist?: SpecialistProfileView
+  initialInput?: CreateSpecialistInput
+}
+
+export type SpecialistEditorFormState = {
+  form: SpecialistEditorFormDraft
+  setForm: Dispatch<SetStateAction<SpecialistEditorFormDraft>>
+  idTouched: boolean
+  setIdTouched: Dispatch<SetStateAction<boolean>>
+  activeCapTab: 'skills' | 'connectors'
+  setActiveCapTab: Dispatch<SetStateAction<'skills' | 'connectors'>>
+  // Removes the stored draft so a later remount starts clean. Call after anything
+  // that settles the form: a successful save or an explicit cancel.
+  clearDraft: () => void
+  // Flags the next form change (the post-save baseRevision advance) to skip the
+  // draft write so a successful save's clearDraft is not immediately undone.
+  suppressNextDraftWrite: () => void
+}
+
+// Owns the specialist editor's form state machine: mount-time seeding (profile,
+// create prefill, or restorable draft), and the unsaved-form draft kept in the
+// specialist store so any unmount loses nothing. The editor only consumes the
+// returned state and setters; persistence details stay here.
+export const useSpecialistEditorForm = ({
+  editSpecialist,
+  initialInput
+}: UseSpecialistEditorFormOptions): SpecialistEditorFormState => {
+  const saveEditorDraft = useSpecialistStore((state) => state.saveEditorDraft)
+  const clearEditorDraft = useSpecialistStore((state) => state.clearEditorDraft)
+  // Editor drafts survive unmounts — opening a capability's detail page navigates Settings away —
+  // so a returning editor re-seeds from the draft instead of the stored profile. A draft restores
+  // only while the profile revision it was taken from still matches; the create form additionally
+  // yields to a provided initialInput (e.g. a marketplace import's prefill) so an abandoned
+  // earlier draft cannot swallow the new prefill.
+  const draftKey = editSpecialist ? editSpecialist.id : CREATE_SPECIALIST_DRAFT_KEY
+  const storedDraft = useSpecialistStore.getState().editorDrafts[draftKey]
+  const restoredDraft =
+    storedDraft !== undefined &&
+    (editSpecialist !== undefined
+      ? storedDraft.form.baseRevision === editSpecialist.revision
+      : initialInput === undefined)
+      ? storedDraft
+      : undefined
+  const [form, setForm] = useState<SpecialistEditorFormDraft>(() =>
+    restoredDraft !== undefined
+      ? restoredDraft.form
+      : editSpecialist
+        ? formFromProfile(editSpecialist)
+        : formFromCreateInput(initialInput)
+  )
+  const [idTouched, setIdTouched] = useState(
+    restoredDraft !== undefined ? restoredDraft.idTouched : initialInput?.id !== undefined
+  )
+  const [activeCapTab, setActiveCapTab] = useState<'skills' | 'connectors'>(
+    restoredDraft !== undefined ? restoredDraft.activeCapTab : 'skills'
+  )
+
+  // Keep the editor draft in the specialist store in sync with the live form so any unmount —
+  // detail navigation, panel switch, closing Settings — can restore the unsaved edits. A
+  // successful save suppresses the next write (the baseRevision advance) so the just-cleared
+  // draft is not immediately re-created.
+  const suppressDraftWriteRef = useRef(false)
+  useEffect(() => {
+    if (suppressDraftWriteRef.current) {
+      suppressDraftWriteRef.current = false
+      return
+    }
+    saveEditorDraft(draftKey, { form, idTouched, activeCapTab })
+  }, [saveEditorDraft, draftKey, form, idTouched, activeCapTab])
+
+  const clearDraft = useCallback(() => clearEditorDraft(draftKey), [clearEditorDraft, draftKey])
+  const suppressNextDraftWrite = useCallback(() => {
+    suppressDraftWriteRef.current = true
+  }, [])
+
+  return {
+    form,
+    setForm,
+    idTouched,
+    setIdTouched,
+    activeCapTab,
+    setActiveCapTab,
+    clearDraft,
+    suppressNextDraftWrite
+  }
+}

--- a/src/renderer/src/stores/specialist-store.ts
+++ b/src/renderer/src/stores/specialist-store.ts
@@ -16,6 +16,33 @@ import type {
   SpecialistPackageInstallRequest
 } from '../../../shared/specialist-package'
 
+// Draft key for the create-specialist form; edit drafts are keyed by specialist id.
+export const CREATE_SPECIALIST_DRAFT_KEY = '__create__'
+
+// One snapshot of the specialist editor's form state, kept while the editor is unmounted so a
+// round trip through Settings (e.g. opening a capability's detail page) loses nothing.
+export type SpecialistEditorFormDraft = {
+  id: string
+  name: string
+  packageVersion: string
+  description: string
+  systemPrompt: string
+  iconKey: string
+  colorKey: string
+  capabilityMode: 'full' | 'selected'
+  excludedSkillIds: string[]
+  selectedSkillIds: string[]
+  excludedConnectorIds: string[]
+  connectorIds: string[]
+  baseRevision: number
+}
+
+export type SpecialistEditorDraft = {
+  form: SpecialistEditorFormDraft
+  idTouched: boolean
+  activeCapTab: 'skills' | 'connectors'
+}
+
 type SpecialistStoreData = {
   items: SpecialistListItem[]
   isLoaded: boolean
@@ -23,6 +50,7 @@ type SpecialistStoreData = {
   integrity: SpecialistDocumentIntegrity
   packagePreview?: SpecialistPackageCandidatePreview
   exportPreview?: SpecialistExportPreview
+  editorDrafts: Record<string, SpecialistEditorDraft>
 }
 
 type SpecialistStoreActions = {
@@ -48,6 +76,8 @@ type SpecialistStoreActions = {
     includedSkillIds: readonly string[]
   ) => Promise<SpecialistExportSaveResult>
   clearExport: () => void
+  saveEditorDraft: (key: string, draft: SpecialistEditorDraft) => void
+  clearEditorDraft: (key: string) => void
 }
 
 type SpecialistStore = SpecialistStoreData & SpecialistStoreActions
@@ -88,6 +118,7 @@ const useSpecialistStore = create<SpecialistStore>((set) => ({
   integrity: { status: 'ok' },
   packagePreview: undefined,
   exportPreview: undefined,
+  editorDrafts: {},
 
   load: () => {
     // Guard: specialist.list is Electron-only and unavailable in the web gateway.
@@ -201,6 +232,19 @@ const useSpecialistStore = create<SpecialistStore>((set) => ({
   clearExport: () => {
     latestExportPreviewRequest += 1
     set({ exportPreview: undefined })
+  },
+
+  saveEditorDraft: (key, draft) => {
+    set((state) => ({ editorDrafts: { ...state.editorDrafts, [key]: draft } }))
+  },
+
+  clearEditorDraft: (key) => {
+    set((state) => {
+      if (!(key in state.editorDrafts)) return state
+      const editorDrafts = { ...state.editorDrafts }
+      delete editorDrafts[key]
+      return { editorDrafts }
+    })
   }
 }))
 


### PR DESCRIPTION
## Problem

In the specialist editor's capabilities lists, selected skills and connectors are display-only: to inspect or adjust one (open its detail page, toggle it, edit its config), the user must leave the editor, navigate Settings by hand, and find the same item again. Worse, leaving the editor at all — that round trip, a panel switch, or closing Settings — discards every unsaved edit, so the form starts over.

## Proposed change

**Inline navigation from capability rows** (262d6df2)

- Selected skill and connector rows are clickable and navigate through Settings history: skills land on the Skills detail page, bundled connectors on the Connectors detail page, custom (MCP) servers on their edit page — the same routing tag references already use
- A custom server referenced by its legacy name is resolved to its canonical server id before navigating
- Missing skills and unavailable connectors stay non-clickable; the remove action never triggers navigation, and rows answer Enter/Space
- Back returns to the specialist editor

**Unsaved-form draft** (262d6df2)

- The editor keeps a draft of the unsaved form in the specialist store, so any unmount — the navigation round trip, a panel switch, closing Settings — restores every unsaved edit, including the active capability tab
- Drafts are cleared on save/cancel; the post-save baseRevision advance is suppressed from re-creating the just-cleared draft
- A draft is ignored once the profile revision advances past the revision it was taken at; the create form yields to a provided prefill (marketplace import) over an abandoned draft

**Structure** (95ffdaf8)

`SpecialistEditor.tsx` had grown to ~1500 lines where navigation, draft persistence, and form fields all landed in one file. The two concerns above now have their own homes:

- `useSpecialistEditorForm` — the form state machine: mount-time seeding (profile / create prefill / restorable draft) and draft persistence; `formFromProfile` also replaces the hand-repeated seed literal in Reload
- `SpecialistCapabilitiesSection` — the capabilities block end to end (full-access switch, tabs, add dropdowns, clickable rows, catalog row memos), fully controlled via `capabilityMode` / id arrays / updater callbacks

Pure extraction: no behavior, UI, or test changes in 95ffdaf8.

## Scope and non-goals

- No change to capability semantics: selected-capabilities whitelists and full-access mode behave exactly as before
- No hover tooltip on rows; the accessible name (`aria-label`) covers screen readers only
- The draft is in-memory (specialist store): it survives navigation and remounts, not an app restart
- No editing UI for full-access exclusions (unchanged)

## Acceptance criteria and validation

Evidence mapping, all run after the last material edit (95ffdaf8) at this exact head:

| Behavior | Command | Result |
| --- | --- | --- |
| Row navigation: click, Enter/Space, legacy-name → canonical id, missing/unavailable rows stay inert, remove does not navigate | `npm test -- src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx` | pass |
| Draft lifecycle: restore after round trip, cleared on save/cancel, stale draft ignored on revision advance, create-form draft across mounts | `npm test -- src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx` | pass |
| Settings history round trip (Back returns to the editor) | `npm test -- src/renderer/src/pages/settings/SettingsPage.render.test.tsx` | pass |
| Whole settings surface (count assertions elsewhere included) | full `vitest run` | 1113 files / 16732 tests pass |
| Renderer types | `npm run typecheck:web` | pass |
| Lint on changed files | `eslint` on the changed renderer files | 0 errors |

Commands were run from the worktree via the shared repository toolchain (same binaries and config as the npm scripts).

Uncovered risks: platform, packaging, and E2E lanes were not run locally; exact-head PR Gate CI is authoritative for those. Draft loss on quit or crash is by design (memory-only).

## Review focus

- Draft restore rules (revision match; create form yields to prefill) and the save sequence `suppressNextDraftWrite → setForm → clearDraft` in `useSpecialistEditorForm.ts`
- `SpecialistCapabilitiesSection` stays fully controlled; id updates go through `(prev) => next` updaters so rapid add/remove stays race-free
- Keyboard activation ignores events originating from inner controls (the remove button) — the `event.target !== event.currentTarget` guard
