### PR TITLE
fix(session-persistence): abort quit on recoverable flush failures

### DIFF
--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -1272,6 +1272,27 @@ describe('AcpRuntimeCoordinator', () => {
     expect(created.compactSession).not.toHaveBeenCalled()
   })
 
+  it('reopens prompt admission when quit preparation is aborted', async () => {
+    let created!: ReturnType<typeof createFakeRuntime>
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      created = createFakeRuntime({
+        frameworkId: 'claude-code',
+        sessionIds: ['session-1'],
+        callbacks
+      })
+      return created.runtime
+    })
+    const session = await coordinator.createSession({ cwd: '/workspace' })
+
+    await expect(coordinator.prepareForQuit()).resolves.toBe('completed')
+    coordinator.abortQuitPreparation()
+
+    await expect(
+      coordinator.sendPrompt({ sessionId: session.sessionId, text: 'retry after failed quit' })
+    ).resolves.toBeDefined()
+    expect(created.sendPrompt).toHaveBeenCalledOnce()
+  })
+
   it('linearizes real user prompts and upward continuations through one root admission lock', async () => {
     const prompts = [
       createDeferred<unknown>(),

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -461,6 +461,14 @@ class AcpRuntimeCoordinator {
     })
   }
 
+  // Quit may be cancelled when renderer persistence cannot prove its final snapshot durable. Reopen
+  // only the admission state owned by prepareForQuit; completed prompt cancellation remains completed.
+  abortQuitPreparation(): void {
+    if (this.providerShutdownStartedForQuit) return
+    this.promptAdmissionClosedForQuit = false
+    this.durableQuitDetachedSessionIds.clear()
+  }
+
   async shutdownForUpdateGate(): Promise<{ reaped: boolean }> {
     this.invalidateAllSessionTurns()
     this.supersedeInitializationRequests()

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -123,6 +123,7 @@ type Harness = {
   trayHandlers: TrayHandlers | undefined
   shutdownBackends: () => Promise<ShutdownStepOutcome | void>
   prepareForQuit: () => Promise<ShutdownStepOutcome | void>
+  abortQuitPreparation: () => Promise<void> | void
   flushSessionPersistence: (
     timeoutMs?: number
   ) => Promise<RendererSessionPersistenceFlushOutcome | void>
@@ -140,6 +141,7 @@ const setup = (
       AppLifecycleDeps,
       | 'shutdownBackends'
       | 'prepareForQuit'
+      | 'abortQuitPreparation'
       | 'flushSessionPersistence'
       | 'log'
       | 'flushLogs'
@@ -169,6 +171,7 @@ const setup = (
   let trayHandlers: TrayHandlers | undefined
   const shutdownBackends = overrides.shutdownBackends ?? vi.fn(async () => undefined)
   const prepareForQuit = overrides.prepareForQuit ?? vi.fn(async () => undefined)
+  const abortQuitPreparation = overrides.abortQuitPreparation ?? vi.fn()
   const flushSessionPersistence =
     overrides.flushSessionPersistence ?? vi.fn(async () => 'completed' as const)
   const quit = vi.fn()
@@ -194,6 +197,7 @@ const setup = (
     },
     shutdownBackends,
     prepareForQuit,
+    abortQuitPreparation,
     flushSessionPersistence,
     log: overrides.log,
     flushLogs: overrides.flushLogs,
@@ -216,6 +220,7 @@ const setup = (
     trayHandlers,
     shutdownBackends,
     prepareForQuit,
+    abortQuitPreparation,
     flushSessionPersistence,
     quit,
     showMainWindow,
@@ -359,6 +364,7 @@ describe('installAppLifecycle', () => {
       createTray: () => ({ destroy: vi.fn() }) as unknown as import('electron').Tray,
       shutdownBackends,
       prepareForQuit: async () => undefined,
+      abortQuitPreparation: vi.fn(),
       flushSessionPersistence: async () => undefined,
       isMigrationInProgress: (): boolean => false,
       quit: vi.fn(),
@@ -441,10 +447,10 @@ describe('installAppLifecycle', () => {
     expect(app.exit).toHaveBeenCalledWith(0)
   })
 
-  it('bounds both renderer persistence attempts and drains terminal logs before exit', async () => {
+  it('continues degraded quit when the renderer disappears and drains terminal logs before exit', async () => {
     const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
     const flushLogs = vi.fn(async () => undefined)
-    const flushSessionPersistence = vi.fn(async () => 'timeout' as const)
+    const flushSessionPersistence = vi.fn(async () => 'renderer-gone' as const)
     const { app, closeOpts } = setup({
       log,
       flushLogs,
@@ -462,7 +468,7 @@ describe('installAppLifecycle', () => {
         outcome: 'completed',
         degraded: true,
         usageDrainResult: 'completed',
-        rendererFlushResult: 'timeout',
+        rendererFlushResult: 'degraded',
         backendTeardownResult: 'completed'
       })
     )
@@ -503,7 +509,10 @@ describe('installAppLifecycle', () => {
     const { app, closeOpts } = setup({
       log,
       prepareForQuit: vi.fn(async () => 'timeout' as const),
-      flushSessionPersistence: vi.fn(async () => 'send-failed' as const),
+      flushSessionPersistence: vi
+        .fn()
+        .mockResolvedValueOnce('completed' as const)
+        .mockResolvedValueOnce('renderer-gone' as const),
       shutdownBackends: vi.fn(async () => 'degraded' as const)
     })
     closeOpts[0].requestQuit()
@@ -517,7 +526,7 @@ describe('installAppLifecycle', () => {
     )
     expect(log.info).toHaveBeenCalledWith(
       'operation phase',
-      expect.objectContaining({ phase: 'renderer-session-flush', result: 'failed' })
+      expect.objectContaining({ phase: 'renderer-session-flush', result: 'degraded' })
     )
     expect(log.info).toHaveBeenCalledWith(
       'operation phase',
@@ -529,7 +538,7 @@ describe('installAppLifecycle', () => {
         operation: 'application-shutdown',
         degraded: true,
         usageDrainResult: 'timeout',
-        rendererFlushResult: 'failed',
+        rendererFlushResult: 'degraded',
         backendTeardownResult: 'degraded'
       })
     )
@@ -537,7 +546,15 @@ describe('installAppLifecycle', () => {
 
   it('keeps the app open when the renderer reports an unresolved Session revision conflict', async () => {
     const flushSessionPersistence = vi.fn(async () => 'conflict' as const)
-    const { app, closeOpts, prepareForQuit, shutdownBackends, tray, windows } = setup({
+    const {
+      app,
+      closeOpts,
+      prepareForQuit,
+      abortQuitPreparation,
+      shutdownBackends,
+      tray,
+      windows
+    } = setup({
       flushSessionPersistence
     })
     closeOpts[0].requestQuit()
@@ -547,6 +564,7 @@ describe('installAppLifecycle', () => {
 
     expect(flushSessionPersistence).toHaveBeenCalledOnce()
     expect(prepareForQuit).not.toHaveBeenCalled()
+    expect(abortQuitPreparation).toHaveBeenCalledOnce()
     expect(shutdownBackends).not.toHaveBeenCalled()
     expect(tray?.destroy).not.toHaveBeenCalled()
     expect(app.exit).not.toHaveBeenCalled()
@@ -554,14 +572,49 @@ describe('installAppLifecycle', () => {
     expect(windows[0].focused).toBe(true)
   })
 
-  it('finishes quit from the durable preflight snapshot when the terminal flush conflicts', async () => {
+  it.each(['renderer-failed', 'send-failed', 'timeout'] as const)(
+    'keeps the app open when the renderer persistence preflight returns %s',
+    async (outcome) => {
+      const flushSessionPersistence = vi.fn(async () => outcome)
+      const {
+        app,
+        closeOpts,
+        prepareForQuit,
+        abortQuitPreparation,
+        shutdownBackends,
+        tray,
+        windows
+      } = setup({ flushSessionPersistence })
+      closeOpts[0].requestQuit()
+
+      app.emit('before-quit')
+      await flush()
+
+      expect(flushSessionPersistence).toHaveBeenCalledOnce()
+      expect(prepareForQuit).not.toHaveBeenCalled()
+      expect(abortQuitPreparation).toHaveBeenCalledOnce()
+      expect(shutdownBackends).not.toHaveBeenCalled()
+      expect(tray?.destroy).not.toHaveBeenCalled()
+      expect(app.exit).not.toHaveBeenCalled()
+      expect(windows[0].visible).toBe(true)
+      expect(windows[0].focused).toBe(true)
+    }
+  )
+
+  it('keeps the app open when the terminal renderer flush conflicts', async () => {
     const flushSessionPersistence = vi
       .fn()
       .mockResolvedValueOnce('completed' as const)
       .mockResolvedValueOnce('conflict' as const)
-    const { app, closeOpts, prepareForQuit, shutdownBackends } = setup({
-      flushSessionPersistence
-    })
+    const {
+      app,
+      closeOpts,
+      prepareForQuit,
+      abortQuitPreparation,
+      shutdownBackends,
+      tray,
+      windows
+    } = setup({ flushSessionPersistence })
     closeOpts[0].requestQuit()
 
     app.emit('before-quit')
@@ -569,9 +622,45 @@ describe('installAppLifecycle', () => {
 
     expect(flushSessionPersistence).toHaveBeenCalledTimes(2)
     expect(prepareForQuit).toHaveBeenCalledOnce()
-    expect(shutdownBackends).toHaveBeenCalledOnce()
-    expect(app.exit).toHaveBeenCalledWith(0)
+    expect(abortQuitPreparation).toHaveBeenCalledOnce()
+    expect(shutdownBackends).not.toHaveBeenCalled()
+    expect(tray?.destroy).not.toHaveBeenCalled()
+    expect(app.exit).not.toHaveBeenCalled()
+    expect(windows[0].visible).toBe(true)
+    expect(windows[0].focused).toBe(true)
   })
+
+  it.each(['renderer-failed', 'send-failed', 'timeout'] as const)(
+    'keeps the app open when the terminal renderer flush returns %s',
+    async (outcome) => {
+      const flushSessionPersistence = vi
+        .fn()
+        .mockResolvedValueOnce('completed' as const)
+        .mockResolvedValueOnce(outcome)
+      const {
+        app,
+        closeOpts,
+        prepareForQuit,
+        abortQuitPreparation,
+        shutdownBackends,
+        tray,
+        windows
+      } = setup({ flushSessionPersistence })
+      closeOpts[0].requestQuit()
+
+      app.emit('before-quit')
+      await flush()
+
+      expect(flushSessionPersistence).toHaveBeenCalledTimes(2)
+      expect(prepareForQuit).toHaveBeenCalledOnce()
+      expect(abortQuitPreparation).toHaveBeenCalledOnce()
+      expect(shutdownBackends).not.toHaveBeenCalled()
+      expect(tray?.destroy).not.toHaveBeenCalled()
+      expect(app.exit).not.toHaveBeenCalled()
+      expect(windows[0].visible).toBe(true)
+      expect(windows[0].focused).toBe(true)
+    }
+  )
 
   it('quits on window-all-closed only when non-darwin and no tray host', () => {
     const noTray = setup({ trayHost: false, platform: 'linux' })

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -55,6 +55,8 @@ export type AppLifecycleDeps = {
   shutdownBackends: () => Promise<ShutdownStepOutcome | void>
   // Requests active ACP turns to cancel, then waits a bounded interval for terminal usage events.
   prepareForQuit: () => Promise<ShutdownStepOutcome | void>
+  // Reopens Main/renderer admission when persistence prevents an orderly quit from committing.
+  abortQuitPreparation: () => Promise<void> | void
   // Drains renderer runtime events and its ordered Session write queue before the window disappears.
   flushSessionPersistence: (
     timeoutMs?: number
@@ -132,6 +134,11 @@ export const installAppLifecycle = (
     if (outcome === 'renderer-gone') return 'degraded'
     return 'completed'
   }
+  const rendererOutcomeBlocksQuit = (outcome: RendererSessionPersistenceFlushOutcome): boolean =>
+    outcome === 'conflict' ||
+    outcome === 'renderer-failed' ||
+    outcome === 'send-failed' ||
+    outcome === 'timeout'
   const shutdownTrigger = (): ApplicationShutdownTrigger => {
     try {
       return deps.shutdownTrigger?.() ?? currentApplicationShutdownTrigger()
@@ -315,7 +322,7 @@ export const installAppLifecycle = (
       let rendererFlushOutcome: RendererSessionPersistenceFlushOutcome
       let rendererFlushResult: ShutdownStepOutcome
       let backendTeardownResult: ShutdownStepOutcome
-      let shutdownAbortedForSessionConflict = false
+      let shutdownAbortedForRendererPersistence = false
       const flushRendererSessionPersistence = async (
         phase: 'renderer-session-preflight' | 'renderer-session-flush',
         timeoutMs: number
@@ -341,8 +348,8 @@ export const installAppLifecycle = (
         )
         rendererPreflightOutcome = preflight.outcome
         rendererPreflightResult = preflight.result
-        if (rendererPreflightOutcome === 'conflict') {
-          shutdownAbortedForSessionConflict = true
+        if (rendererOutcomeBlocksQuit(rendererPreflightOutcome)) {
+          shutdownAbortedForRendererPersistence = true
           diagnostics?.complete({
             degraded: true,
             rendererPreflightOutcome,
@@ -375,6 +382,22 @@ export const installAppLifecycle = (
         )
         rendererFlushOutcome = finalFlush.outcome
         rendererFlushResult = finalFlush.result
+        if (rendererOutcomeBlocksQuit(rendererFlushOutcome)) {
+          shutdownAbortedForRendererPersistence = true
+          diagnostics?.complete({
+            degraded: true,
+            rendererPreflightResult,
+            rendererPreflightOutcome,
+            usageDrainResult,
+            rendererFlushResult,
+            rendererFlushOutcome,
+            backendTeardownResult: 'degraded'
+          })
+          if (deps.flushLogs) {
+            await flushDiagnosticsWithTimeout(deps.flushLogs, logFlushTimeoutMs)
+          }
+          return
+        }
 
         diagnostics?.phase('backend-teardown')
         try {
@@ -406,7 +429,16 @@ export const installAppLifecycle = (
           if (result === 'timeout') console.warn('[shutdown] final log flush timed out')
         }
       } finally {
-        if (shutdownAbortedForSessionConflict) {
+        if (shutdownAbortedForRendererPersistence) {
+          try {
+            await deps.abortQuitPreparation()
+          } catch (error) {
+            try {
+              deps.log?.error('quit preparation rollback failed', diagnosticErrorFields(error))
+            } catch {
+              // Restoring the visible app remains authoritative; rollback diagnostics are best-effort.
+            }
+          }
           shutdownStarted = false
           quitConfirmed = false
           clearApplicationShutdownTrigger()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -241,7 +241,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         { parseWebModeOptions, createWebServiceController, buildAuthenticatedWebUrl },
         { routeSecondInstance },
         { createElectronCloseConfirm },
-        { createElectronSessionPersistenceFlush },
+        { createElectronSessionPersistenceFlush, notifyRendererSessionPersistenceFlushAborted },
         { installWindowShortcuts },
         { createAppIconController, buildAppIconPreviews },
         { RemoteAccessService, registerRemoteAccessIpcHandlers },
@@ -409,6 +409,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           taskControls,
           detectActiveSessions,
           prepareForQuit,
+          abortQuitPreparation,
           dispose: disposeApplicationRuntime
         } = await registerIpcHandlers({
           mainEntryPath,
@@ -514,9 +515,13 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           disposeApplicationRuntime,
           detectActiveSessions,
           prepareForQuit,
+          abortQuitPreparation,
           createSessionPersistenceFlush: (
             getWindow: () => InstanceType<typeof BrowserWindow> | undefined
           ) => createElectronSessionPersistenceFlush(getWindow),
+          notifySessionPersistenceFlushAborted: (
+            getWindow: () => InstanceType<typeof BrowserWindow> | undefined
+          ) => notifyRendererSessionPersistenceFlushAborted(getWindow),
           createConfirmClose: (getWindow: () => InstanceType<typeof BrowserWindow> | undefined) =>
             createElectronCloseConfirm(
               getWindow,
@@ -606,6 +611,10 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             createInitialWindow: !ctx.webMode.headless,
             detectActiveSessions: ctx.detectActiveSessions,
             prepareForQuit: ctx.prepareForQuit,
+            abortQuitPreparation: () => {
+              ctx.abortQuitPreparation()
+              ctx.notifySessionPersistenceFlushAborted(() => ctx.mainWindowGetterBox.current?.())
+            },
             flushSessionPersistence: ctx.createSessionPersistenceFlush(() =>
               ctx.mainWindowGetterBox.current?.()
             ),

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -351,6 +351,7 @@ export type ApplicationRuntimeInterfaces = {
   archiveCapability: Pick<ArchiveCoordinator, 'isSessionAvailableById' | 'setMarkReadSessions'>
   detectActiveSessions: () => ReturnType<typeof detectActiveSessions>
   prepareForQuit: () => Promise<Extract<ShutdownStepOutcome, 'completed' | 'timeout' | 'failed'>>
+  abortQuitPreparation: () => void
 }
 
 type ApplicationModuleInterfaces = ApplicationRuntimeInterfaces & {
@@ -3092,6 +3093,7 @@ const createApplicationModules = async (
         notebook: notebookService
       }),
     prepareForQuit: () => runtime.prepareForQuit(),
+    abortQuitPreparation: () => runtime.abortQuitPreparation(),
     electronAdapters: {
       beforeCompute: beforeComputeAdapters,
       compute: {

--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -859,12 +859,15 @@ describe('Session persistence coordinator architecture', () => {
         'removeSession',
         'replaceMetadata',
         'saveSession',
+        'saveSessionSpecialistBinding',
         'sessionProjectId',
         'setDelegationPolicy',
         'setEnabledComputeHosts'
       ].sort()
     )
-    expect(methods(stateOwner, 'private')).toEqual(['loadRuntimeContextSession'])
+    expect(methods(stateOwner, 'private')).toEqual(
+      ['loadRuntimeContextSession', 'saveSessionWithAuthority'].sort()
+    )
     expect(methods(deletionOwner, 'public')).toEqual(
       [
         'assertProjectArchivable',
@@ -935,7 +938,7 @@ describe('Session persistence coordinator architecture', () => {
       pruneSessionEnabledComputeHosts: ['stateOwner.pruneEnabledComputeHosts'],
       readSessionRuntimeContext: ['stateOwner.readRuntimeContext'],
       saveSession: ['stateOwner.saveSession'],
-      saveSessionSpecialistBinding: ['stateOwner.saveSession'],
+      saveSessionSpecialistBinding: ['stateOwner.saveSessionSpecialistBinding'],
       saveSideChatProjection: ['sideChatOwner.saveProjection'],
       sessionMetadataSnapshot: ['stateOwner.metadataSnapshot'],
       sessionProjectId: ['stateOwner.sessionProjectId'],

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -2235,6 +2235,41 @@ describe('SessionPersistenceCoordinator', () => {
     expect(provenance.captureFinalizedMessages).toHaveBeenCalledWith(result)
   })
 
+  it('preserves Main-owned specialist binding fields when renderer save options are forged', async () => {
+    const authoritativeSession = createSession({
+      specialistId: 'specialist-old',
+      updatedAt: 7
+    })
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi
+        .fn()
+        .mockResolvedValue({ status: 'found', session: authoritativeSession })
+    })
+    const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
+    const forgedRendererOptions = {
+      conflictRebaseFields: ['specialistId', 'specialistBindingPending']
+    } as unknown as Parameters<SessionPersistenceCoordinator['saveSession']>[1]
+
+    const result = await coordinator.saveSession(
+      {
+        ...authoritativeSession,
+        specialistId: 'specialist-forged',
+        specialistBindingPending: true
+      },
+      forgedRendererOptions
+    )
+
+    expect(result.specialistId).toBe('specialist-old')
+    expect(result.specialistBindingPending).toBeUndefined()
+    expect(repository.saveSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        specialistId: 'specialist-old',
+        specialistBindingPending: undefined
+      }),
+      0
+    )
+  })
+
   it('advances the session revision when a specialist binding first becomes pending', async () => {
     const authoritativeSession = createSession({
       specialistId: 'specialist-old',

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -76,6 +76,7 @@ import {
   createSafeSessionUpdatePublisher as safeSessionUpdates,
   type SessionUpdatePublisher
 } from './session-update-publication'
+import { sanitizeRendererSaveSessionOptions } from './renderer-save-options'
 
 type SessionMutationRepository = {
   loadAllWithDiagnostics(options?: { mode?: 'repair' | 'read-only' }): Promise<{
@@ -733,7 +734,7 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
   ): Promise<PersistedChatSession> {
     return this.operationScheduler.runSession(session.projectId, session.id, async () => {
       await assertSessionIdentityOwnership(this.repository, this.stateOwner, session)
-      return this.stateOwner.saveSession(session, options)
+      return this.stateOwner.saveSession(session, sanitizeRendererSaveSessionOptions(options))
     })
   }
 
@@ -746,13 +747,10 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
   ): Promise<PersistedChatSession> {
     return this.operationScheduler.runSession(session.projectId, session.id, async () => {
       await assertSessionIdentityOwnership(this.repository, this.stateOwner, session)
-      return this.stateOwner.saveSession(
-        {
-          ...session,
-          specialistId,
-          specialistBindingPending: specialistBindingPending ? true : undefined
-        },
-        { conflictRebaseFields: ['specialistId', 'specialistBindingPending'] }
+      return this.stateOwner.saveSessionSpecialistBinding(
+        session,
+        specialistId,
+        specialistBindingPending
       )
     })
   }

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -272,6 +272,36 @@ describe('session persistence IPC handlers', () => {
     })
   })
 
+  it('does not forward Main-owned specialist save authority from renderer IPC', async () => {
+    const session = createSession()
+    const repository: SessionPersistenceBackend = {
+      loadAll: vi.fn(),
+      loadOne: vi.fn(),
+      saveSession: vi.fn(),
+      deleteSession: vi.fn(),
+      saveManifest: vi.fn()
+    }
+    const saveSession = vi.fn(async () => ({ created: false, session }))
+    const handlers: SessionPersistenceHandlers = {
+      loadAll: vi.fn(),
+      loadOne: vi.fn(),
+      saveSession,
+      setDelegationPolicy: vi.fn(),
+      updateArchive: vi.fn(),
+      deleteSession: vi.fn(),
+      saveManifest: vi.fn()
+    }
+    registerSessionPersistenceIpcHandlers(repository, createMockReviewRepository(), handlers)
+    const invoke = ipcHandlers.get('sessions:save-session')
+    const forgedOptions = {
+      conflictRebaseFields: ['specialistId', 'specialistBindingPending']
+    }
+
+    await expect(invoke?.({ sender: { id: 7 } }, session, forgedOptions)).resolves.toBe(session)
+
+    expect(saveSession).toHaveBeenCalledWith(session)
+  })
+
   it('accepts Reviewer Correction attribution only from main-owned runtime evidence', async () => {
     const correctionAttribution = {
       kind: 'application' as const,

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -21,6 +21,7 @@ import { withDataRootWrite } from '../storage/migration-state'
 import type { SessionMetadataSnapshot } from './coordinator'
 import { MainMessageAttributionAuthority } from './message-attribution-authority'
 import { isSessionCatalogAuthoritative } from './catalog-authority'
+import { sanitizeRendererSaveSessionOptions } from './renderer-save-options'
 
 type SessionPersistenceBackend = {
   loadAll: () => Promise<LoadAllSessionsResult>
@@ -202,7 +203,10 @@ const registerSessionPersistenceIpcHandlers = (
     async (event, session: PersistedChatSession, options?: SaveSessionOptions) => {
       const originClientId = getLifecycleClientId(event)
       const durable = await withDataRootWrite(async () => {
-        const result = await handlers.saveSession(session, options)
+        const rendererOptions = sanitizeRendererSaveSessionOptions(options)
+        const result = rendererOptions
+          ? await handlers.saveSession(session, rendererOptions)
+          : await handlers.saveSession(session)
         broadcastLifecycleEvent(
           result.created ? LIFECYCLE_CHANNELS.sessionCreated : LIFECYCLE_CHANNELS.sessionUpdated,
           {

--- a/src/main/session-persistence/renderer-flush.test.ts
+++ b/src/main/session-persistence/renderer-flush.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import {
+  SESSION_PERSISTENCE_FLUSH_ABORTED_CHANNEL,
   SESSION_PERSISTENCE_FLUSH_REQUEST_CHANNEL,
   SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL
 } from '../../shared/session-persistence-flush'
 import type { SessionPersistenceFlushResponse } from '../../shared/session-persistence-flush'
 import {
   createElectronSessionPersistenceFlush,
+  notifyRendererSessionPersistenceFlushAborted,
   requestRendererSessionPersistenceFlush
 } from './renderer-flush'
 import type { RendererSessionPersistenceFlushOutcome } from './renderer-flush'
@@ -137,6 +139,21 @@ describe('requestRendererSessionPersistenceFlush', () => {
 })
 
 describe('createElectronSessionPersistenceFlush', () => {
+  it('notifies a surviving renderer when quit is aborted', () => {
+    const webContents = {
+      isDestroyed: vi.fn(() => false),
+      send: vi.fn()
+    }
+    const window = {
+      isDestroyed: vi.fn(() => false),
+      webContents
+    }
+
+    notifyRendererSessionPersistenceFlushAborted(() => window as never)
+
+    expect(webContents.send).toHaveBeenCalledWith(SESSION_PERSISTENCE_FLUSH_ABORTED_CHANNEL)
+  })
+
   it('uses a five-second default timeout for a live renderer that never acknowledges', async () => {
     vi.useFakeTimers()
     electronMocks.on.mockClear()

--- a/src/main/session-persistence/renderer-flush.ts
+++ b/src/main/session-persistence/renderer-flush.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { ipcMain, type BrowserWindow } from 'electron'
 
 import {
+  SESSION_PERSISTENCE_FLUSH_ABORTED_CHANNEL,
   SESSION_PERSISTENCE_FLUSH_REQUEST_CHANNEL,
   SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL,
   type SessionPersistenceFlushRequest,
@@ -98,4 +99,13 @@ export const createElectronSessionPersistenceFlush = (
       timeoutMs: timeoutOverrideMs ?? timeoutMs
     })
   }
+}
+
+export const notifyRendererSessionPersistenceFlushAborted = (
+  getWindow: () => BrowserWindow | undefined
+): void => {
+  const window = getWindow()
+  const webContents = window?.webContents
+  if (!window || window.isDestroyed() || !webContents || webContents.isDestroyed()) return
+  webContents.send(SESSION_PERSISTENCE_FLUSH_ABORTED_CHANNEL)
 }

--- a/src/main/session-persistence/renderer-save-options.ts
+++ b/src/main/session-persistence/renderer-save-options.ts
@@ -1,0 +1,32 @@
+import type {
+  SaveSessionOptions,
+  SessionConflictRebaseField
+} from '../../shared/session-persistence'
+
+const RENDERER_SESSION_CONFLICT_REBASE_FIELDS = new Set<SessionConflictRebaseField>([
+  'title',
+  'permissionProfile',
+  'autoReviewEnabled',
+  'enabledComputeHosts',
+  'pinned'
+])
+
+// Electron IPC arguments are runtime values even when the preload contract is typed. Project only
+// renderer-owned rebase authority before the request reaches Main's Session persistence owner.
+export const sanitizeRendererSaveSessionOptions = (
+  options: unknown
+): SaveSessionOptions | undefined => {
+  if (typeof options !== 'object' || options === null) return undefined
+  const candidate = Reflect.get(options, 'conflictRebaseFields')
+  if (!Array.isArray(candidate)) return undefined
+  const conflictRebaseFields = [
+    ...new Set(
+      candidate.filter(
+        (field): field is SessionConflictRebaseField =>
+          typeof field === 'string' &&
+          RENDERER_SESSION_CONFLICT_REBASE_FIELDS.has(field as SessionConflictRebaseField)
+      )
+    )
+  ]
+  return conflictRebaseFields.length > 0 ? { conflictRebaseFields } : undefined
+}

--- a/src/main/session-persistence/revision-conflict.ts
+++ b/src/main/session-persistence/revision-conflict.ts
@@ -5,10 +5,17 @@ import {
   SessionRevisionConflictError,
   sessionRevision,
   type PersistedChatSession,
-  type SaveSessionOptions
+  type SessionConflictRebaseField
 } from '../../shared/session-persistence'
 
-type RebaseFields = NonNullable<SaveSessionOptions['conflictRebaseFields']>
+export type MainSessionConflictRebaseField =
+  SessionConflictRebaseField | 'specialistId' | 'specialistBindingPending'
+
+export type MainSaveSessionOptions = {
+  conflictRebaseFields?: MainSessionConflictRebaseField[]
+}
+
+type RebaseFields = NonNullable<MainSaveSessionOptions['conflictRebaseFields']>
 
 export const rebaseSafeSessionFields = (
   authoritative: PersistedChatSession,

--- a/src/main/session-persistence/state-owner.ts
+++ b/src/main/session-persistence/state-owner.ts
@@ -17,7 +17,11 @@ import {
 } from '../../shared/session-persistence'
 import { FinalizedArtifactBindingConflictError } from '../artifacts/provenance-message-snapshot'
 import { diagnosticErrorFields, type Logger } from '../logger'
-import { rebaseSafeSessionFields, resolveRevisionedSessionSave } from './revision-conflict'
+import {
+  rebaseSafeSessionFields,
+  resolveRevisionedSessionSave,
+  type MainSaveSessionOptions
+} from './revision-conflict'
 import { saveSessionWithRevision } from './save-session'
 
 type SessionMetadata = Readonly<Pick<PersistedChatSession, 'id' | 'projectId' | 'title'>>
@@ -526,6 +530,28 @@ class SessionPersistenceStateOwner {
   async saveSession(
     session: PersistedChatSession,
     options: SaveSessionOptions = {}
+  ): Promise<PersistedChatSession> {
+    return this.saveSessionWithAuthority(session, options)
+  }
+
+  async saveSessionSpecialistBinding(
+    session: PersistedChatSession,
+    specialistId: string | undefined,
+    specialistBindingPending = false
+  ): Promise<PersistedChatSession> {
+    return this.saveSessionWithAuthority(
+      {
+        ...session,
+        specialistId,
+        specialistBindingPending: specialistBindingPending ? true : undefined
+      },
+      { conflictRebaseFields: ['specialistId', 'specialistBindingPending'] }
+    )
+  }
+
+  private async saveSessionWithAuthority(
+    session: PersistedChatSession,
+    options: MainSaveSessionOptions = {}
   ): Promise<PersistedChatSession> {
     this.options.assertMutable(session.projectId, session.id, 'save')
     const authoritative = await this.options.repository.loadSessionWithDiagnostics(

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -61,6 +61,7 @@ type PreloadApi = {
     deleteSession: (request: unknown) => unknown
     saveManifest: (request: unknown) => unknown
     exportConversation: (request: unknown) => unknown
+    onFlushAborted: (listener: () => void) => unknown
     onFlushRequest: (listener: (request: { requestId: string }) => void) => unknown
     sendFlushResponse: (response: { requestId: string }) => void
   }
@@ -430,6 +431,7 @@ describe('preload bridge — public surface inventory', () => {
       'sessions.loadOne',
       'sessions.onCreated',
       'sessions.onDeleted',
+      'sessions.onFlushAborted',
       'sessions.onFlushRequest',
       'sessions.onUpdated',
       'sessions.saveManifest',
@@ -1349,7 +1351,15 @@ describe('preload bridge — sessions + agent-framework IPC channels', () => {
 
   it('bridges the bounded Session flush request and acknowledgement channels', () => {
     const listener = vi.fn()
+    const abortedListener = vi.fn()
     const response = { requestId: 'flush-1' }
+
+    api.sessions.onFlushAborted(abortedListener)
+    expect(onMock).toHaveBeenCalledWith('sessions:flush-aborted', expect.any(Function))
+    const wrappedAbortedListener = onMock.mock.calls.at(-1)?.[1] as
+      ((_event: unknown) => void) | undefined
+    wrappedAbortedListener?.({})
+    expect(abortedListener).toHaveBeenCalledOnce()
 
     api.sessions.onFlushRequest(listener)
     expect(onMock).toHaveBeenCalledWith('sessions:flush-request', expect.any(Function))

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -205,6 +205,8 @@ const api: OpenScienceAPI = {
     // Exports the authoritative persisted active branch through a main-owned Save As flow.
     exportConversation: (request) =>
       electronRendererContracts.invoke('sessions.exportConversation', request),
+    onFlushAborted: (listener) =>
+      electronRendererContracts.subscribe('sessions.onFlushAborted', listener),
     onFlushRequest: (listener) =>
       electronRendererContracts.subscribe('sessions.onFlushRequest', listener),
     sendFlushResponse: (response) =>

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -471,6 +471,7 @@ export interface OpenScienceAPI {
     deleteSession(request: DeleteSessionRequest): Promise<SessionDeletionResult>
     saveManifest(request: SaveSessionManifestRequest): Promise<void>
     exportConversation(request: ExportConversationRequest): Promise<ExportConversationResult>
+    onFlushAborted?(listener: () => void): RemoveListener
     onFlushRequest?(listener: AcpListener<SessionPersistenceFlushRequest>): RemoveListener
     sendFlushResponse?(response: SessionPersistenceFlushResponse): void
     onCreated(listener: AcpListener<SessionUpsertEvent>): RemoveListener

--- a/src/renderer/src/hooks/useQuitPersistenceFlush.test.ts
+++ b/src/renderer/src/hooks/useQuitPersistenceFlush.test.ts
@@ -1,8 +1,57 @@
-import { describe, expect, it, vi } from 'vitest'
+// @vitest-environment jsdom
 
-import { completeQuitPersistenceFlush } from './useQuitPersistenceFlush'
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { resumeAutoReviewsAfterQuitAbort } = vi.hoisted(() => ({
+  resumeAutoReviewsAfterQuitAbort: vi.fn()
+}))
+
+vi.mock('../lib/acp/workspace-events', () => ({
+  resumeAutoReviewsAfterQuitAbort,
+  suppressAutoReviewsForQuit: vi.fn()
+}))
+vi.mock('../lib/acp/useWorkspaceAgentRuntime', () => ({
+  drainWorkspaceRuntimeEventsForPersistence: vi.fn(async () => undefined)
+}))
+vi.mock('../lib/session-persistence/session-persistence', () => ({
+  flushSessionPersistence: vi.fn(async () => undefined)
+}))
+
+import { completeQuitPersistenceFlush, useQuitPersistenceFlush } from './useQuitPersistenceFlush'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  resumeAutoReviewsAfterQuitAbort.mockClear()
+})
 
 describe('completeQuitPersistenceFlush', () => {
+  it('resumes renderer quit preparation when Main aborts shutdown', () => {
+    let notifyAborted = (): void => undefined
+    const removeAborted = vi.fn()
+    const removeRequest = vi.fn()
+    vi.stubGlobal('window', {
+      api: {
+        sessions: {
+          onFlushAborted: (listener: () => void) => {
+            notifyAborted = listener
+            return removeAborted
+          },
+          onFlushRequest: () => removeRequest,
+          sendFlushResponse: vi.fn()
+        }
+      }
+    })
+
+    const { unmount } = renderHook(() => useQuitPersistenceFlush())
+    notifyAborted()
+
+    expect(resumeAutoReviewsAfterQuitAbort).toHaveBeenCalledOnce()
+    unmount()
+    expect(removeAborted).toHaveBeenCalledOnce()
+    expect(removeRequest).toHaveBeenCalledOnce()
+  })
+
   it('drains terminal runtime events before flushing and acknowledging', async () => {
     const calls: string[] = []
 

--- a/src/renderer/src/hooks/useQuitPersistenceFlush.ts
+++ b/src/renderer/src/hooks/useQuitPersistenceFlush.ts
@@ -5,7 +5,10 @@ import type {
   SessionPersistenceFlushResponse
 } from '../../../shared/session-persistence-flush'
 import { isSessionRevisionConflictError } from '../../../shared/session-persistence'
-import { suppressAutoReviewsForQuit } from '../lib/acp/workspace-events'
+import {
+  resumeAutoReviewsAfterQuitAbort,
+  suppressAutoReviewsForQuit
+} from '../lib/acp/workspace-events'
 import { drainWorkspaceRuntimeEventsForPersistence } from '../lib/acp/useWorkspaceAgentRuntime'
 import { flushSessionPersistence } from '../lib/session-persistence/session-persistence'
 
@@ -37,12 +40,14 @@ export const completeQuitPersistenceFlush = async (
 
 export const useQuitPersistenceFlush = (): void => {
   useEffect(() => {
+    const onFlushAborted = window.api.sessions?.onFlushAborted
     const onFlushRequest = window.api.sessions?.onFlushRequest
     const sendFlushResponse = window.api.sessions?.sendFlushResponse
     // Web/headless renderers do not participate in Electron's before-quit handshake.
     if (!onFlushRequest || !sendFlushResponse) return
 
-    return onFlushRequest((request) => {
+    const removeFlushAborted = onFlushAborted?.(resumeAutoReviewsAfterQuitAbort)
+    const removeFlushRequest = onFlushRequest((request) => {
       void completeQuitPersistenceFlush(request, {
         suppressAutoReviews: suppressAutoReviewsForQuit,
         drainRuntimeEvents: drainWorkspaceRuntimeEventsForPersistence,
@@ -50,5 +55,9 @@ export const useQuitPersistenceFlush = (): void => {
         acknowledge: sendFlushResponse
       }).catch(() => undefined)
     })
+    return () => {
+      removeFlushAborted?.()
+      removeFlushRequest()
+    }
   }, [])
 }

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -25,6 +25,7 @@ import { saveSessionInOrder } from '../session-persistence/session-persistence'
 import {
   applyWorkspaceRuntimeEvent,
   assembleReviewRunRequest,
+  resumeAutoReviewsAfterQuitAbort,
   suppressAutoReviewsForQuit,
   suppressNextAutoReview,
   clearSuppressNextAutoReview,
@@ -2716,6 +2717,27 @@ describe('workspace runtime events', () => {
       await vi.runAllTimersAsync()
 
       expect(reviewerRun).not.toHaveBeenCalled()
+      vi.unstubAllGlobals()
+    })
+
+    it('allows future auto-reviews after quit preparation is aborted', async () => {
+      const reviewerRun = vi.fn().mockResolvedValue(undefined)
+
+      vi.stubGlobal('window', { api: { reviewer: { run: reviewerRun } } })
+      useSessionStore.getState().setAutoReviewEnabled('transport-session-1', true)
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'transport-session-1',
+        streamId: 'stream-1',
+        eventId: 'event-agent-1',
+        content: 'Analysis complete'
+      })
+      suppressAutoReviewsForQuit()
+
+      resumeAutoReviewsAfterQuitAbort()
+      await applyWorkspaceRuntimeEvent(createEvent({ id: 'stop-after-abort', kind: 'stop' }))
+      await vi.runAllTimersAsync()
+
+      expect(reviewerRun).toHaveBeenCalledOnce()
       vi.unstubAllGlobals()
     })
 

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -506,6 +506,10 @@ const suppressAutoReviewsForQuit = (): void => {
   scheduledAutoReviewsBySession.clear()
 }
 
+const resumeAutoReviewsAfterQuitAbort = (): void => {
+  autoReviewsSuppressedForQuit = false
+}
+
 // Stop and artifact events normally arrive together, but some providers publish the Artifact just
 // after stop. A short debounced barrier lets that claim finalize before Reviewer freezes its scope.
 // A post-stop Artifact cancels this timer immediately and schedules a fresh review after finalization.
@@ -952,6 +956,7 @@ export {
   applyWorkspaceRuntimeEvent,
   applyWorkspaceRuntimeEventBatch,
   assembleReviewRunRequest,
+  resumeAutoReviewsAfterQuitAbort,
   suppressAutoReviewsForQuit,
   suppressNextAutoReview,
   clearSuppressNextAutoReview,

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -307,7 +307,7 @@ export const RENDERER_CONTRACT_GROUPS = Object.freeze([
   ]),
   group('sessions', 'sessions', [
     ['exportConversation', 'sessions:export-conversation', MAPPED_ELECTRON], ['onCreated', 'session:created', EVENT], ['onDeleted', 'session:deleted', EVENT],
-    ['onFlushRequest', 'sessions:flush-request', ELECTRON_EVENT], ['onUpdated', 'session:updated', EVENT], ['deleteSession', 'sessions:delete-session', WEB, undefined, undefined, RUNTIME_VALIDATED],
+    ['onFlushAborted', 'sessions:flush-aborted', ELECTRON_EVENT], ['onFlushRequest', 'sessions:flush-request', ELECTRON_EVENT], ['onUpdated', 'session:updated', EVENT], ['deleteSession', 'sessions:delete-session', WEB, undefined, undefined, RUNTIME_VALIDATED],
     ['loadAll', 'sessions:load-all'], ['loadOne', 'sessions:load-one'], ['saveManifest', 'sessions:save-manifest'],
     ['saveSession', 'sessions:save-session', WEB, SESSION_SAVE, SESSION_SAVE_JSON], ['updateArchive', 'sessions:update-archive'], ['sendFlushResponse', 'sessions:flush-response', SEND],
   ]),

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -73,6 +73,7 @@ const GENERATED_SOURCE_OMISSIONS = [
   'officePreview.onState',
   'officePreview.open',
   'officePreview.reportState',
+  'sessions.onFlushAborted',
   'sessions.onFlushRequest',
   'sessions.sendFlushResponse',
   'settings.exportCustomServerTemplate',

--- a/src/shared/session-persistence-flush.ts
+++ b/src/shared/session-persistence-flush.ts
@@ -1,5 +1,6 @@
 export const SESSION_PERSISTENCE_FLUSH_REQUEST_CHANNEL = 'sessions:flush-request'
 export const SESSION_PERSISTENCE_FLUSH_RESPONSE_CHANNEL = 'sessions:flush-response'
+export const SESSION_PERSISTENCE_FLUSH_ABORTED_CHANNEL = 'sessions:flush-aborted'
 
 export type SessionPersistenceFlushRequest = { requestId: string }
 export type SessionPersistenceFlushStatus = 'completed' | 'conflict' | 'failed'

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -570,13 +570,7 @@ export type MaterializedPersistedChatSession = PersistedChatSession & {
 // Renderer-owned preferences that can be replayed onto a newer durable graph after a stale-graph
 // conflict. The field list records intent explicitly, including changes that clear optional values.
 export type SessionConflictRebaseField =
-  | 'title'
-  | 'permissionProfile'
-  | 'autoReviewEnabled'
-  | 'enabledComputeHosts'
-  | 'pinned'
-  | 'specialistId'
-  | 'specialistBindingPending'
+  'title' | 'permissionProfile' | 'autoReviewEnabled' | 'enabledComputeHosts' | 'pinned'
 
 export type SaveSessionOptions = {
   conflictRebaseFields?: SessionConflictRebaseField[]


### PR DESCRIPTION
## Problem

Renderer-facing `SaveSessionOptions` exposed Main-owned specialist binding fields, so a forged `sessions:save-session` request could opt those fields into conflict rebasing. During shutdown, a new conflict or another recoverable live-renderer flush failure after preflight still allowed degraded exit, even though the final snapshot was not proven durable.

## Proposed change

- Restrict the shared Renderer save contract to Renderer-owned rebase fields and sanitize IPC values at runtime.
- Keep specialist binding rebase authority behind a dedicated Main-owned persistence method.
- Abort quit for live-renderer `conflict`, `renderer-failed`, `send-failed`, and `timeout` outcomes in both preflight and terminal flush phases.
- Roll back Main prompt admission and Renderer auto-review suppression when quit is aborted, then restore and focus the application window.
- Continue degraded shutdown only when persistence is unavailable because the Renderer is already gone or unavailable.

## Scope and non-goals

- No database schema, migration, persisted field, or historical-data compatibility change.
- No new persisted state or domain enum value. The new `sessions:flush-aborted` channel is a transient Electron lifecycle notification.
- No new dialog or copy. The interaction change is that a recoverable persistence failure keeps the app open and focused so the existing retry path remains available.
- No attempt to recover a Renderer that is already unavailable or destroyed; those outcomes retain degraded shutdown behavior.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Renderer cannot grant itself specialist binding rebase authority -> `npm run test:module -- session_persistence` -> 7 files / 313 tests passed.
- Preflight and terminal conflict/failed/send-failed/timeout outcomes keep the app open and skip backend teardown -> focused Vitest command for lifecycle, runtime rollback, flush notification, preload bridge, hook wiring, and workspace rollback -> 6 files / 316 tests passed.
- Main quit-preparation and Renderer auto-review suppression are reversible after an aborted quit -> same focused Vitest command -> passed.
- Electron/Preload/Web surface inventory includes the new transient rollback subscription -> `npm run check:web-api-map` plus the PR Gate interface-contract Vitest set -> 7 files / 126 tests passed.
- Main/preload/shared contracts typecheck -> `npm run typecheck:node` -> passed.
- Renderer hook and API consumer typecheck -> `npm run typecheck:web` -> passed.
- Changed source follows repository lint rules -> `npm run lint` -> passed.
- Exact base/head impact analysis -> `npm run test:affected:explain -- --base main --head HEAD` -> selected `Mode: full` because `src/main/acp/runtime-coordinator.test.ts` has no module-owner mapping. The full local fallback was intentionally not run per maintainer direction; PR Gate is authoritative for the complete portable and platform plan.

Uncovered locally: packaged Electron shutdown timing and cross-platform lanes. These remain covered by PR Gate/Nightly rather than a local full suite.

## Review focus

- Confirm the Renderer allowlist is the complete supported public rebase surface.
- Confirm only live-renderer recoverable failures block exit, while `unavailable` and `renderer-gone` remain degraded exits.
- Confirm rollback reopens only state closed by quit preparation and does not undo completed prompt cancellation.
