### PR TITLE
fix(acp): prevent interrupted-turn admission deadlock

### DIFF
--- a/src/main/acp/handler-workflows.test.ts
+++ b/src/main/acp/handler-workflows.test.ts
@@ -159,6 +159,55 @@ const createHarness = (
   }
 }
 
+describe('ACP interrupted turn workflow', () => {
+  it('does not re-enter archive admission while continuing an interrupted turn', async () => {
+    let archiveQueue: Promise<void> = Promise.resolve()
+    const enqueueArchive = <Result>(operation: () => Promise<Result>): Promise<Result> => {
+      const result = archiveQueue.then(operation, operation)
+      archiveQueue = result.then(
+        () => undefined,
+        () => undefined
+      )
+      return result
+    }
+    const harness = createHarness(undefined, {
+      withSessionAvailable: (_projectId, _sessionId, operation) => enqueueArchive(operation),
+      withSessionAvailableById: (_sessionId, operation) => enqueueArchive(operation)
+    })
+    harness.session.status = 'error'
+    harness.session.activeRun = undefined
+    harness.session.resumeRecovery = {
+      kind: 'resume-required',
+      cause: 'app-restart',
+      promptMessageId: 'prompt-1'
+    }
+    // The ordinary continuation path enters the dispatch admission guard, which is backed by the
+    // same archive queue in production. Calling it while withSessionAvailable is active waits on
+    // itself; the dispatch-admitted path intentionally bypasses only that nested guard.
+    harness.startContinuation.mockImplementationOnce(() => enqueueArchive(async () => undefined))
+    harness.startContinuationWhenDispatchAdmitted.mockImplementationOnce(
+      async (_request: unknown, validate: () => Promise<void>) => {
+        await validate()
+        return 'provider_prompt_accepted'
+      }
+    )
+
+    const outcome = await Promise.race([
+      harness.workflows
+        .continueInterruptedTurn({
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          promptMessageId: 'prompt-1'
+        })
+        .then(() => 'completed' as const),
+      new Promise<'timed-out'>((resolve) => setTimeout(() => resolve('timed-out'), 50))
+    ])
+
+    expect(outcome).toBe('completed')
+    expect(harness.startContinuationWhenDispatchAdmitted).toHaveBeenCalledOnce()
+  })
+})
+
 describe('ACP send prompt workflow', () => {
   it('returns the current snapshot after provider admission', async () => {
     const harness = createHarness()

--- a/src/main/acp/handler-workflows.ts
+++ b/src/main/acp/handler-workflows.ts
@@ -330,6 +330,14 @@ const createAcpHandlerWorkflows = (
           runtime,
           loadSession: (projectId, sessionId) =>
             interruptedTurnSessions.loadSession(projectId, sessionId),
+          ...(archiveAvailability
+            ? {
+                startDispatchAdmittedContinuation: (
+                  continuation: AcpPromptRequest,
+                  validate: () => Promise<void>
+                ) => runtime.startContinuationWhenDispatchAdmitted(continuation, validate)
+              }
+            : {}),
           notifications: taskNotifications
         },
         request

--- a/src/main/acp/interrupted-turn-continuation.test.ts
+++ b/src/main/acp/interrupted-turn-continuation.test.ts
@@ -406,6 +406,39 @@ describe('continueInterruptedTurn', () => {
     expect(startContinuation).not.toHaveBeenCalled()
   })
 
+  it('revalidates the durable turn inside dispatch-admitted root admission', async () => {
+    const durable = session([message('prompt-1', 'user', 'Keep going')])
+    const startContinuation = vi.fn()
+    const startDispatchAdmittedContinuation = vi.fn(
+      async (_request: AcpPromptRequest, validate: () => Promise<void>) => {
+        durable.resumeRecovery = {
+          kind: 'resume-required',
+          cause: 'app-restart',
+          promptMessageId: 'newer-prompt'
+        }
+        await validate()
+      }
+    )
+
+    await expect(
+      continueInterruptedTurn(
+        {
+          runtime: {
+            getSnapshot: () => snapshot(),
+            getLatestUserPrompt: () => undefined,
+            startContinuation
+          },
+          loadSession: vi.fn(async () => durable),
+          startDispatchAdmittedContinuation
+        },
+        { sessionId: 'session-1', projectId: 'project-1', promptMessageId: 'prompt-1' }
+      )
+    ).rejects.toThrow(/no longer matches the interrupted turn/i)
+
+    expect(startDispatchAdmittedContinuation).toHaveBeenCalledOnce()
+    expect(startContinuation).not.toHaveBeenCalled()
+  })
+
   it('rejects a stale or cross-branch recovery prompt', async () => {
     const durable = session([message('prompt-1', 'user', 'Keep going')])
 

--- a/src/main/acp/interrupted-turn-continuation.test.ts
+++ b/src/main/acp/interrupted-turn-continuation.test.ts
@@ -354,6 +354,8 @@ describe('continueInterruptedTurn', () => {
       startedAt: 2
     })
     const startContinuation = vi.fn()
+    const trackPrompt = vi.fn(() => ({ token: 11 }))
+    const untrackPrompt = vi.fn()
 
     await expect(
       continueInterruptedTurn(
@@ -363,7 +365,8 @@ describe('continueInterruptedTurn', () => {
             getLatestUserPrompt: () => undefined,
             startContinuation
           },
-          loadSession: vi.fn(async () => durable)
+          loadSession: vi.fn(async () => durable),
+          notifications: { trackPrompt, untrackPrompt }
         },
         {
           sessionId: 'session-1',
@@ -379,6 +382,7 @@ describe('continueInterruptedTurn', () => {
       )
     ).rejects.toThrow('history could not be replayed after context reset')
     expect(startContinuation).not.toHaveBeenCalled()
+    expect(untrackPrompt).toHaveBeenCalledWith('session-1', { token: 11 })
   })
 
   it('does not dispatch a second continuation while the recovered prompt is already running', async () => {

--- a/src/main/acp/interrupted-turn-continuation.ts
+++ b/src/main/acp/interrupted-turn-continuation.ts
@@ -1,3 +1,5 @@
+import { isDeepStrictEqual } from 'node:util'
+
 import type {
   AcpContinueInterruptedTurnRequest,
   AcpPromptRequest,
@@ -39,6 +41,10 @@ type InterruptedTurnContinuationRuntime = {
 type InterruptedTurnContinuationDependencies = {
   runtime: InterruptedTurnContinuationRuntime
   loadSession(projectId: string, sessionId: string): Promise<PersistedChatSession | undefined>
+  startDispatchAdmittedContinuation?: (
+    request: AcpPromptRequest,
+    validate: () => Promise<void>
+  ) => Promise<unknown>
   notifications?: Pick<TaskNotificationService, 'trackPrompt' | 'untrackPrompt'>
 }
 
@@ -228,10 +234,30 @@ export const continueInterruptedTurn = async (
     sessionId: request.sessionId,
     text: prompt.content
   })
+  const continuation = buildContinuationRequest(session, prompt, request, livePrompt)
   try {
-    await dependencies.runtime.startContinuation(
-      buildContinuationRequest(session, prompt, request, livePrompt)
-    )
+    if (dependencies.startDispatchAdmittedContinuation) {
+      await dependencies.startDispatchAdmittedContinuation(continuation, async () => {
+        const admittedSession = await dependencies.loadSession(request.projectId, request.sessionId)
+        if (!admittedSession) throw new Error('Interrupted Session could not be loaded.')
+        const admittedPrompt = requireInterruptedTurn(admittedSession, request)
+        const admittedLivePrompt = dependencies.runtime.getLatestUserPrompt(
+          request.sessionId,
+          request.promptMessageId
+        )
+        const admittedContinuation = buildContinuationRequest(
+          admittedSession,
+          admittedPrompt,
+          request,
+          admittedLivePrompt
+        )
+        if (!isDeepStrictEqual(admittedContinuation, continuation)) {
+          throw new Error('Interrupted Session changed before provider admission.')
+        }
+      })
+    } else {
+      await dependencies.runtime.startContinuation(continuation)
+    }
   } catch (error) {
     if (tracked) dependencies.notifications?.untrackPrompt(request.sessionId, tracked)
     throw error

--- a/src/main/acp/interrupted-turn-continuation.ts
+++ b/src/main/acp/interrupted-turn-continuation.ts
@@ -234,8 +234,8 @@ export const continueInterruptedTurn = async (
     sessionId: request.sessionId,
     text: prompt.content
   })
-  const continuation = buildContinuationRequest(session, prompt, request, livePrompt)
   try {
+    const continuation = buildContinuationRequest(session, prompt, request, livePrompt)
     if (dependencies.startDispatchAdmittedContinuation) {
       await dependencies.startDispatchAdmittedContinuation(continuation, async () => {
         const admittedSession = await dependencies.loadSession(request.projectId, request.sessionId)


### PR DESCRIPTION
## Problem

Continuing an interrupted turn holds `ArchiveCoordinator.withSessionAvailable` until provider admission completes. The ordinary continuation dispatch path then enters `promptDispatchAdmissionGuard`, which calls `withSessionDeletionAdmissionById` on the same non-reentrant archive queue. The outer operation waits for dispatch while dispatch waits behind the outer operation, so the UI can wait indefinitely.

## Proposed change

- Reuse the existing dispatch-admitted continuation path when the workflow already owns archive admission.
- Keep per-Session root admission intact; only bypass the nested archive-backed dispatch guard.
- Reload and compare the durable interrupted turn inside root admission so a changed or stale turn still fails closed before provider dispatch.
- Keep continuation construction inside the notification rollback boundary, including replay-validation failures.
- Add regression tests for the shared-queue self-wait, durable-turn revalidation, and tracked-prompt cleanup.

## Scope and non-goals

- No ACP wire or application-command changes.
- No Renderer behavior or copy changes.
- No database, persisted Session, journal, or Skill format changes.
- No new lifecycle states or enum values.
- The separately discovered Specialist Skill-lock self-wait is not changed here: latest `main` fixed it in `d860b846` and its focused context/overwrite tests pass on this branch.

## Validation

The final Test Impact Set below ran after the last material source edit.

- Interrupted-turn archive admission, durable revalidation, and notification rollback:
  - `npm test -- src/main/acp/handler-workflows.test.ts src/main/acp/interrupted-turn-continuation.test.ts`
  - Result: 2 files, 48 tests passed.
- Main-process types: `npm run typecheck:node` — passed.
- Changed ACP files: ESLint and Prettier checks — passed.
- Patch integrity: `git diff --check` — passed.

An earlier broader audit sweep also passed 13 files / 279 tests covering ACP application and IPC consumers, Archive coordinator, the upstream Specialist lock regression, Session scheduling, storage migration admission, Notebook locks, and Compute admission/polling. The notification rollback regression was independently demonstrated red before the final fix, then green afterward.

Per maintainer direction, the complete local `npm test` was intentionally not run. Exact-head PR Gate is authoritative. The previous exact-head run passed ACP Module tests and macOS build/E2E; its only failure was the Korean i18n catalog guard introduced by base commit `0645b193`, outside this PR's four-file ACP diff. The next exact-head run will recheck the final review fix.

## Review focus

- Confirm the workflow uses the dispatch-admitted entry only while outer archive admission is active.
- Confirm the validation callback preserves stale-turn rejection before provider acceptance.
- Confirm notification tracking is rolled back for construction, validation, and dispatch failures.
- Confirm no ordinary prompt path bypasses deletion admission.
