### PR TITLE
fix(i18n): add Korean copy for capability row details

### DIFF
--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -2058,6 +2058,7 @@
   "View source": "소스 보기",
   "View this device's runtime log — it records what the app is doing so problems can be diagnosed.": "이 기기의 런타임 로그를 확인하세요. 문제를 진단할 수 있도록 앱이 수행하는 작업을 기록합니다.",
   "View {{name}}": "{{name}} 보기",
+  "View {{name}} details": "{{name}} 세부정보 보기",
   "Viewer failed": "뷰어 실패",
   "Waiting for a response…": "응답을 기다리는 중…",
   "Waiting for permission": "허가를 기다리는 중",


### PR DESCRIPTION
## Problem

#1430 made specialist capability rows open their Settings detail pages and added `View {{name}} details` to Japanese and Chinese catalogs. Korean was not updated, so the catalog guard fails and Korean UI falls back to English.

## Proposed change

Add the Korean catalog entry, matching existing `View {{name}}` / `View details` phrasing: `{{name}} 세부정보 보기`.

## Scope and non-goals

- Korean catalog only
- no source-copy, routing, or editor behavior changes

## Acceptance criteria and validation

Checks ran after the last material edit.

| Behavior | Command | Result |
| --- | --- | --- |
| Korean catalog completeness, orphans, particles, placeholders | `npm run test:module -- i18n_catalog` | 278 passed |

Consumers, typechecks, and E2E were excluded: this is one catalog string. PR Gate remains authoritative for the complete suite. Uncovered risk: none beyond CI reconfirming the i18n lane.

## Review focus

- Korean product voice for the new aria-label

Refs: #1430