### PR TITLE
fix(reviewer): isolate MCP protocol per transport

### DIFF
--- a/src/main/reviewer/mcp-server.test.ts
+++ b/src/main/reviewer/mcp-server.test.ts
@@ -20,6 +20,7 @@ import { REVIEWER_BRIDGE_NAMESPACED_TOOLS } from './bridge-tools'
 import { createReviewerMcpStdioProxy } from './mcp-stdio-proxy'
 import type { TurnScope } from '../../shared/reviewer'
 import type { ArtifactContent, ExecRecord, OrderedBlock, ReviewerHostServer } from './host-sdk'
+import { fetchOverSocket } from '../local-rpc-transport'
 
 const scope: TurnScope = {
   turnMessageId: 'msg-2',
@@ -662,6 +663,82 @@ describe('ReviewerMcpServer HTTP transport', () => {
       const toolJson = parseSse(await toolResponse.text())
       expect(toolJson.error).toBeUndefined()
     } finally {
+      await server.stop()
+    }
+  })
+
+  it('does not emit an unhandled rejection when two initialize requests race', async () => {
+    const server = new ReviewerMcpServer(
+      scope,
+      async () => undefined,
+      createReviewerEvidence(),
+      [],
+      { command: 'unused', entryPath: 'unused', transport: 'pipe' }
+    )
+    const { endpoint, token } = await server.start()
+    const proxyConfig = server.toAcpMcpServerConfig()
+    if (!('env' in proxyConfig)) throw new Error('Expected Reviewer MCP stdio proxy config')
+    const socketPath = proxyConfig.env?.find(
+      (entry) => entry.name === 'OPEN_SCIENCE_REVIEWER_MCP_SOCKET_PATH'
+    )?.value
+    if (!socketPath) throw new Error('Expected Reviewer MCP named-pipe path')
+    const socketFetch = fetchOverSocket(socketPath)
+    const unhandledRejections: unknown[] = []
+    const onUnhandledRejection = (reason: unknown): void => {
+      unhandledRejections.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandledRejection)
+
+    const headers = {
+      authorization: `Bearer ${token}`,
+      accept: MCP_ACCEPT,
+      'content-type': 'application/json'
+    }
+    const initializeBody = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'racing-client', version: '1.0' }
+      }
+    })
+
+    try {
+      const responses = await Promise.allSettled([
+        socketFetch(endpoint, {
+          method: 'POST',
+          headers,
+          body: initializeBody,
+          signal: AbortSignal.timeout(2_000)
+        }),
+        socketFetch(endpoint, {
+          method: 'POST',
+          headers,
+          body: initializeBody,
+          signal: AbortSignal.timeout(2_000)
+        })
+      ])
+      await new Promise((resolve) => setImmediate(resolve))
+
+      expect(responses.every((result) => result.status === 'fulfilled')).toBe(true)
+      const fulfilledResponses = responses
+        .filter(
+          (result): result is PromiseFulfilledResult<Response> => result.status === 'fulfilled'
+        )
+        .map((result) => result.value)
+      expect(fulfilledResponses.map((response) => response.status)).toEqual([200, 200])
+      expect(
+        new Set(fulfilledResponses.map((response) => response.headers.get('mcp-session-id'))).size
+      ).toBe(2)
+      expect(unhandledRejections).toEqual([])
+
+      await Promise.all(
+        fulfilledResponses.map((response) => response.body?.cancel().catch(() => undefined))
+      )
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection)
       await server.stop()
     }
   })

--- a/src/main/reviewer/mcp-server.ts
+++ b/src/main/reviewer/mcp-server.ts
@@ -275,7 +275,6 @@ export type SubmitFindingsHandler = (
 
 // The per-run reviewer MCP server: exposes submit_findings and starts/stops with the review.
 export class ReviewerMcpServer {
-  private readonly mcpServer: ModelContextProtocolServer
   private readonly httpServer: ReturnType<typeof createServer>
   private readonly token: string
   private _endpoint: string | undefined
@@ -300,9 +299,16 @@ export class ReviewerMcpServer {
   ) {
     this.trackedFindingIds = new Set(trackedFindingIds)
     this.token = randomUUID()
-    this.mcpServer = this.buildMcpServer()
     this.httpServer = createServer((req, res) => {
-      void this.handleHttpRequest(req, res)
+      void this.handleHttpRequest(req, res).catch((error) => {
+        log.error('reviewer MCP request failed', { error })
+        if (!res.headersSent) {
+          res.writeHead(500, { 'content-type': 'application/json' })
+          res.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }))
+        } else {
+          res.destroy(error instanceof Error ? error : undefined)
+        }
+      })
     })
   }
 
@@ -653,7 +659,7 @@ export class ReviewerMcpServer {
       transport.onclose = () => {
         if (transport.sessionId) this.transports.delete(transport.sessionId)
       }
-      await this.mcpServer.connect(transport)
+      await this.buildMcpServer().connect(transport)
     } else {
       res.writeHead(400, { 'content-type': 'application/json' })
       res.end(JSON.stringify({ error: 'Bad Request: missing or unknown mcp-session-id' }))


### PR DESCRIPTION
## Problem

On Windows, overlapping Reviewer MCP `initialize` requests can reach the named-pipe server before the first request registers its session id. The server currently connects both transports to one MCP protocol instance, so the second connection rejects with `Already connected to a transport`, leaks as a main-process `unhandledRejection`, and can leave Claude Code waiting until its 10-second MCP readiness timeout.

Closes #1421.

## Proposed change

- Create one Reviewer MCP protocol instance per newly initialized transport while continuing to reuse the registered transport for session-id requests.
- Catch request-boundary failures, log the original error in the `reviewer:mcp` scope, and return or terminate the HTTP response instead of leaking a process-level rejection.
- Add a named-pipe regression test that races two initialization requests and requires two successful, independently identified sessions with no unhandled rejection.

## Scope and non-goals

- No database fields, schema migrations, persisted enum values, or data-model changes.
- No renderer or user-interaction changes.
- No provider, model, or ACP framework configuration changes; the fix is at the framework-neutral Reviewer MCP boundary.
- Existing failed Review rows are not rewritten or retried automatically. Users must request a new review.

## Acceptance criteria and validation

The listed checks ran against the final material diff:

- Concurrent Windows pipe initialization and existing Reviewer MCP HTTP/SSE/tool behavior -> `npm test -- src/main/reviewer/mcp-server.test.ts` -> 33/33 passed.
- Reviewer owners, contracts, and representative consumers -> `npm run test:module -- reviewer_orchestrator` -> 27 files, 456/456 passed.
- Node and web type safety plus production bundles -> `npm run build` -> passed.
- Repository lint policy -> `npm run lint` -> passed.

The complete `npm test` suite was intentionally not run locally; PR Gate remains authoritative for the complete portable and platform-selected suites.

## Review focus

- Confirm that protocol ownership correctly follows transport ownership while review-scoped evidence/submission state remains shared.
- Confirm the HTTP error boundary cannot leave a request unresolved or leak another `unhandledRejection`.
- The exact external condition that caused the affected Claude Code installation to retry initialization was not reproduced on the local Claude Code 2.1.215 normal path. The deterministic named-pipe race covers the server-side failure contract observed in the issue.
