### PR TITLE
fix(tags): align Tag counts and actions

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -768,6 +768,9 @@ colors communicate a successful or failed probe/migration result.
   The left column manages Tags and the right column aggregates assigned resources with resource-type
   and text filters. Selecting a result navigates through the existing Settings history to that
   resource's detail or editor.
+- The Tag list is a single-action selector: every row keeps its resource count in one right-aligned
+  trailing column. Persistent edit and delete icon actions belong to the selected custom Tag's detail
+  header instead of individual list rows; the protected Favorites Tag exposes neither action.
 - A Tag may belong to any number of resources and a resource may have any number of Tags. The same
   Tag filter is available in the three catalog panels and in the Specialist capability picker, but
   Specialist persistence continues to store concrete Skill and Connector IDs rather than a dynamic

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -3012,7 +3012,6 @@
   "Tags": "タグ",
   "Organize Skills, Connectors, and Specialists across one shared catalog.": "スキル、コネクタ、スペシャリストを1つの共有カタログで整理します。",
   "New Tag": "新しいタグ",
-  "Tag actions": "タグの操作",
   "Edit Tag": "タグを編集",
   "Delete Tag": "タグを削除",
   "Could not delete Tag.": "タグを削除できませんでした。",

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -3012,7 +3012,6 @@
   "Tags": "태그",
   "Organize Skills, Connectors, and Specialists across one shared catalog.": "하나의 공유 카탈로그에서 스킬, 커넥터 및 스페셜리스트를 구성합니다.",
   "New Tag": "새 태그",
-  "Tag actions": "태그 작업",
   "Edit Tag": "태그 편집",
   "Delete Tag": "태그 삭제",
   "Could not delete Tag.": "태그를 삭제할 수 없습니다.",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -3012,7 +3012,6 @@
   "Tags": "标签",
   "Organize Skills, Connectors, and Specialists across one shared catalog.": "在一个共享目录中整理技能、连接器和专家。",
   "New Tag": "新建标签",
-  "Tag actions": "标签操作",
   "Edit Tag": "编辑标签",
   "Delete Tag": "删除标签",
   "Could not delete Tag.": "无法删除标签。",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -3012,7 +3012,6 @@
   "Tags": "標籤",
   "Organize Skills, Connectors, and Specialists across one shared catalog.": "在一個共用目錄中整理技能、連接器和專家。",
   "New Tag": "新增標籤",
-  "Tag actions": "標籤操作",
   "Edit Tag": "編輯標籤",
   "Delete Tag": "刪除標籤",
   "Could not delete Tag.": "無法刪除標籤。",

--- a/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
@@ -389,7 +389,7 @@ describe('TagsPanel', () => {
     expect(container.textContent).toContain('Auto Research')
   })
 
-  it('reveals custom Tag actions on row hover or keyboard focus', async () => {
+  it('aligns Tag counts and scopes management actions to the selected custom Tag', async () => {
     useTagStore.setState({
       tags: [
         { id: 'tag-favorite', systemKey: 'favorite', createdAt: 1, updatedAt: 1 },
@@ -408,12 +408,24 @@ describe('TagsPanel', () => {
       root.render(<TagsPanel onOpenResource={vi.fn()} />)
     })
 
-    const actions = container.querySelector<HTMLButtonElement>('[aria-label="Tag actions"]')
-    const selectedTag = container.querySelector<HTMLButtonElement>('aside [aria-current="page"]')
-    expect(selectedTag?.className).toContain('cursor-pointer')
-    expect(actions?.className).toContain('sm:opacity-0')
-    expect(actions?.className).toContain('sm:group-hover:opacity-100')
-    expect(actions?.className).toContain('focus-visible:opacity-100')
-    expect(actions?.className).toContain('data-[state=open]:opacity-100')
+    const tagRows = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[data-slot="tag-list-row"]')
+    )
+    const counts = tagRows.map((row) => row.querySelector('[data-slot="tag-list-count"]'))
+
+    expect(tagRows).toHaveLength(2)
+    expect(tagRows.every((row) => row.classList.contains('w-full'))).toBe(true)
+    expect(counts.map((count) => count?.textContent)).toEqual(['1', '0'])
+    expect(counts.every((count) => count?.classList.contains('ml-auto'))).toBe(true)
+    expect(counts.every((count) => count?.classList.contains('min-w-5'))).toBe(true)
+    expect(counts.every((count) => count?.classList.contains('text-right'))).toBe(true)
+    expect(container.querySelector('[data-slot="tag-detail-actions"]')).toBeNull()
+    expect(container.querySelector('[aria-label="Tag actions"]')).toBeNull()
+
+    await act(async () => tagRows[1]?.click())
+
+    const detailActions = container.querySelector('[data-slot="tag-detail-actions"]')
+    expect(detailActions?.querySelector('[aria-label="Edit Tag"]')).not.toBeNull()
+    expect(detailActions?.querySelector('[aria-label="Delete Tag"]')).not.toBeNull()
   })
 })

--- a/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
@@ -389,7 +389,7 @@ describe('TagsPanel', () => {
     expect(container.textContent).toContain('Auto Research')
   })
 
-  it('aligns Tag counts and scopes management actions to the selected custom Tag', async () => {
+  it('aligns Tag counts and scopes management actions to the responsive detail view', async () => {
     useTagStore.setState({
       tags: [
         { id: 'tag-favorite', systemKey: 'favorite', createdAt: 1, updatedAt: 1 },
@@ -412,8 +412,15 @@ describe('TagsPanel', () => {
       container.querySelectorAll<HTMLButtonElement>('[data-slot="tag-list-row"]')
     )
     const counts = tagRows.map((row) => row.querySelector('[data-slot="tag-list-count"]'))
+    const masterDetail = container.querySelector('[data-slot="tag-master-detail"]')
+    const tagList = masterDetail?.querySelector('aside')
 
     expect(tagRows).toHaveLength(2)
+    expect(masterDetail?.classList.contains('grid-cols-1')).toBe(true)
+    expect(masterDetail?.classList.contains('md:grid-cols-[15rem_minmax(0,1fr)]')).toBe(true)
+    expect(tagList?.classList.contains('border-b')).toBe(true)
+    expect(tagList?.classList.contains('md:border-b-0')).toBe(true)
+    expect(tagList?.classList.contains('md:border-r')).toBe(true)
     expect(tagRows.every((row) => row.classList.contains('w-full'))).toBe(true)
     expect(counts.map((count) => count?.textContent)).toEqual(['1', '0'])
     expect(counts.every((count) => count?.classList.contains('ml-auto'))).toBe(true)
@@ -424,7 +431,9 @@ describe('TagsPanel', () => {
 
     await act(async () => tagRows[1]?.click())
 
+    const detailHeader = container.querySelector('[data-slot="tag-detail-header"]')
     const detailActions = container.querySelector('[data-slot="tag-detail-actions"]')
+    expect(detailHeader?.classList.contains('flex-wrap')).toBe(true)
     expect(detailActions?.querySelector('[aria-label="Edit Tag"]')).not.toBeNull()
     expect(detailActions?.querySelector('[aria-label="Delete Tag"]')).not.toBeNull()
   })

--- a/src/renderer/src/pages/settings/TagsPanel.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.tsx
@@ -1,17 +1,7 @@
-/* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4 */
-/* Hallmark · component: grouped resource index · genre: modern-minimal · tone: technical/utilitarian · theme: project tokens · slop: pass */
+/* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5 */
+/* Hallmark · component: Tag master-detail · genre: modern-minimal · tone: technical/utilitarian · theme: project tokens · contrast: pass · slop: pass */
 import { AlertDialog, Dialog } from 'radix-ui'
-import {
-  ChevronDown,
-  MoreHorizontal,
-  Pencil,
-  Plus,
-  ScrollText,
-  Search,
-  Trash2,
-  Users,
-  X
-} from 'lucide-react'
+import { ChevronDown, Pencil, Plus, ScrollText, Search, Trash2, Users, X } from 'lucide-react'
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -38,12 +28,6 @@ import {
   dialogPanelClassName,
   dialogTitleClassName
 } from '@/components/ui/dialog-chrome'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger
-} from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
 import { cn } from '@/lib/utils'
@@ -308,56 +292,30 @@ const TagsPanel = ({
       <div className="grid min-h-[420px] flex-1 grid-cols-[15rem_minmax(0,1fr)] overflow-hidden rounded-lg border border-border">
         <aside className="border-r border-border bg-background p-2">
           {tags.map((tag) => (
-            <div key={tag.id} className="group flex items-center gap-1">
-              <button
-                type="button"
-                aria-current={tag.id === currentSelectedId ? 'page' : undefined}
-                onClick={() => {
-                  setSelectedId(tag.id)
-                  onSelectedTagChange?.(tag.id)
-                }}
-                className={cn(
-                  'flex h-9 min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-lg px-2 text-left text-sm hover:bg-muted',
-                  tag.id === currentSelectedId && 'bg-muted font-medium'
-                )}
-              >
-                <TagBadge tag={tag} className="min-w-0" />
-                <span className="ml-auto text-xs tabular-nums text-muted-foreground">
-                  {counts.get(tag.id) ?? 0}
-                </span>
-              </button>
-              {'systemKey' in tag ? null : (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      aria-label={t('Tag actions')}
-                      className="shrink-0 opacity-100 transition-[opacity,color,background-color] duration-200 ease-out hover:!opacity-100 focus-visible:opacity-100 sm:opacity-0 sm:group-hover:opacity-100 data-[state=open]:opacity-100"
-                    >
-                      <MoreHorizontal className="size-4" aria-hidden="true" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem className="gap-2" onSelect={() => openEditor(tag)}>
-                      <Pencil className="size-4" aria-hidden="true" />
-                      {t('Edit Tag')}
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      className="gap-2 text-destructive"
-                      onSelect={() => {
-                        setDeleteError(undefined)
-                        setDeleting(tag)
-                      }}
-                    >
-                      <Trash2 className="size-4" aria-hidden="true" />
-                      {t('Delete Tag')}
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+            <Button
+              key={tag.id}
+              type="button"
+              variant="ghost"
+              size="lg"
+              data-slot="tag-list-row"
+              aria-current={tag.id === currentSelectedId ? 'page' : undefined}
+              onClick={() => {
+                setSelectedId(tag.id)
+                onSelectedTagChange?.(tag.id)
+              }}
+              className={cn(
+                'w-full min-w-0 cursor-pointer justify-start gap-2 px-2 text-left font-normal hover:bg-muted',
+                tag.id === currentSelectedId && 'bg-muted font-medium'
               )}
-            </div>
+            >
+              <TagBadge tag={tag} className="min-w-0" />
+              <span
+                data-slot="tag-list-count"
+                className="ml-auto min-w-5 shrink-0 text-right text-xs tabular-nums text-muted-foreground"
+              >
+                {counts.get(tag.id) ?? 0}
+              </span>
+            </Button>
           ))}
         </aside>
 
@@ -368,14 +326,34 @@ const TagsPanel = ({
         >
           {selectedTag ? (
             <>
-              <div className="mb-4 flex items-center gap-2">
-                <TagBadge tag={selectedTag} />
-                <span className="text-xs text-muted-foreground">
-                  {t('{{count}} resources', {
-                    count: filteredResources.length,
-                    defaultValue_one: '{{count}} resource'
-                  })}
-                </span>
+              <div className="mb-4 flex min-h-7 items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-2">
+                  <TagBadge tag={selectedTag} />
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {t('{{count}} resources', {
+                      count: filteredResources.length,
+                      defaultValue_one: '{{count}} resource'
+                    })}
+                  </span>
+                </div>
+                {'systemKey' in selectedTag ? null : (
+                  <div data-slot="tag-detail-actions" className="flex shrink-0 items-center gap-1">
+                    <SettingsIconAction
+                      label={t('Edit Tag')}
+                      icon={Pencil}
+                      onClick={() => openEditor(selectedTag)}
+                    />
+                    <SettingsIconAction
+                      label={t('Delete Tag')}
+                      icon={Trash2}
+                      danger
+                      onClick={() => {
+                        setDeleteError(undefined)
+                        setDeleting(selectedTag)
+                      }}
+                    />
+                  </div>
+                )}
               </div>
               <div className="mb-3 flex items-center gap-2">
                 <Select

--- a/src/renderer/src/pages/settings/TagsPanel.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.tsx
@@ -289,8 +289,11 @@ const TagsPanel = ({
           {t('Tags could not be loaded.')}
         </p>
       ) : null}
-      <div className="grid min-h-[420px] flex-1 grid-cols-[15rem_minmax(0,1fr)] overflow-hidden rounded-lg border border-border">
-        <aside className="border-r border-border bg-background p-2">
+      <div
+        data-slot="tag-master-detail"
+        className="grid min-h-[420px] flex-1 grid-cols-1 overflow-hidden rounded-lg border border-border md:grid-cols-[15rem_minmax(0,1fr)]"
+      >
+        <aside className="border-b border-border bg-background p-2 md:border-r md:border-b-0">
           {tags.map((tag) => (
             <Button
               key={tag.id}
@@ -326,7 +329,10 @@ const TagsPanel = ({
         >
           {selectedTag ? (
             <>
-              <div className="mb-4 flex min-h-7 items-center justify-between gap-3">
+              <div
+                data-slot="tag-detail-header"
+                className="mb-4 flex min-h-7 flex-wrap items-center justify-between gap-3"
+              >
                 <div className="flex min-w-0 items-center gap-2">
                   <TagBadge tag={selectedTag} />
                   <span className="shrink-0 text-xs text-muted-foreground">


### PR DESCRIPTION
## Problem

Favorites and custom Tag resource counts do not share a trailing alignment because custom rows reserve space for a hover-only overflow menu. The result looks uneven and makes management actions less discoverable on touch and keyboard workflows.

## Proposed change

- Make every Tag row a single-action selector with a stable, right-aligned count column.
- Move Edit and Delete to persistent icon actions in the selected custom Tag detail header.
- Stack the Tag list and detail view on narrow layouts, then restore the fixed sidebar at `md` widths.
- Keep the protected Favorites Tag free of management actions.
- Remove the now-orphaned `Tag actions` locale key.

## Scope and non-goals

- Renderer presentation, focused render tests, and design documentation only.
- No Tag model, API, persistence, migration, or historical-data changes.
- No new state or enum values.

## Acceptance criteria and validation

| Behavior / risk | Validation | Result |
| --- | --- | --- |
| Counts align, actions follow the selected custom Tag, and the narrow layout stacks safely | `npm test -- src/renderer/src/pages/settings/TagsPanel.render.test.tsx` | 9 tests passed |
| Locale catalogs remain complete and free of orphan keys | `npx vitest run src/renderer/src/i18n/resources.test.ts` | 278 tests passed |
| Renderer types remain valid | `npm run typecheck:web` | Passed |
| Source formatting and lint rules remain valid | `npm run lint` | Passed |
| Patch formatting | `git diff --check` | Passed |

All checks above were run after the final material edit. Per task scope, the full `npm test` suite was not run; PR CI is the authoritative full gate.

## Review focus

- Stable count alignment across Favorites and custom Tags.
- Discoverability and keyboard/touch access of persistent detail-header actions.
- Favorites remains protected from edit and delete actions.
