### PR TITLE
feat(tags): add persistent drag ordering

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -770,7 +770,9 @@ colors communicate a successful or failed probe/migration result.
   resource's detail or editor.
 - The Tag list is a single-action selector: every row keeps its resource count in one right-aligned
   trailing column. Persistent edit and delete icon actions belong to the selected custom Tag's detail
-  header instead of individual list rows; the protected Favorites Tag exposes neither action.
+  header instead of individual list rows; the protected Favorites Tag exposes neither action. A
+  leading handle reorders custom Tags by pointer or keyboard. Favorites instead shows a fixed lock
+  affordance and always remains first.
 - A Tag may belong to any number of resources and a resource may have any number of Tags. The same
   Tag filter is available in the three catalog panels and in the Specialist capability picker, but
   Specialist persistence continues to store concrete Skill and Connector IDs rather than a dynamic
@@ -783,7 +785,10 @@ colors communicate a successful or failed probe/migration result.
   from the cleaned display name with NFKC normalization and deterministic lowercase; it never crosses
   the renderer contract. Names compare case-insensitively without changing the cleaned display value
   shown to the user.
-- SQLite owns `Tag` definitions and `TagAssignment` edges. An assignment's composite identity is
+- SQLite owns `Tag` definitions, their unique contiguous `sortOrder`, and `TagAssignment` edges.
+  Favorites owns position `0`; custom Tags own positions `1..N`, and newly created Tags append. The
+  ordered Tag snapshot is the single global presentation order, so every resource with multiple Tags
+  renders its badges in that same order. An assignment's composite identity is
   `(tagId, resourceType, resourceId)`; deleting a custom Tag cascades its edges. `resourceType` stays a
   registry-validated string so later resource adapters do not require a table rebuild. Catalog
   reconciliation prunes references to deleted resources, while each V1 resource-deletion workflow

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -561,6 +561,7 @@ model Tag {
   nameKey     String?         @unique
   iconKey     String?
   colorKey    String?
+  sortOrder   Int             @unique @default(0)
   createdAt   DateTime        @default(now())
   updatedAt   DateTime        @updatedAt
   assignments TagAssignment[]

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -48,6 +48,10 @@ const EXPECTED_MIGRATION_LEDGER = [
   {
     id: '0011_cross_resource_tags',
     checksum: 'fd269c67c41caf4b0863d04564165a0373737817c5ec742a3160739324e1d3c1'
+  },
+  {
+    id: '0012_tag_ordering',
+    checksum: '2cbc89454c8642d65806366add598ef4547fb7f513e04c267d1ad0274a472e2f'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/scripts/database-migration-ledger-smoke.test.ts
+++ b/scripts/database-migration-ledger-smoke.test.ts
@@ -20,7 +20,7 @@ import { PrismaClient } from '@prisma/client'
 describe('packaged database migration ledger smoke', () => {
   it('pins every packaged application migration identity and checksum', () => {
     expect(MIGRATION_MANIFEST.at(-1)?.checksum).toBe(
-      'fd269c67c41caf4b0863d04564165a0373737817c5ec742a3160739324e1d3c1'
+      '2cbc89454c8642d65806366add598ef4547fb7f513e04c267d1ad0274a472e2f'
     )
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST)).not.toThrow()
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST.slice(0, -1))).toThrow(

--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -200,6 +200,7 @@ describe('application command composition', () => {
       'sessions:delete-session',
       'tags:create',
       'tags:delete',
+      'tags:reorder',
       'tags:set-assignment',
       'tags:snapshot',
       'tags:update'

--- a/src/main/application-command-electron-adapter.test.ts
+++ b/src/main/application-command-electron-adapter.test.ts
@@ -28,6 +28,7 @@ const validatedChannels = [
   'sessions:delete-session',
   'tags:create',
   'tags:delete',
+  'tags:reorder',
   'tags:set-assignment',
   'tags:snapshot',
   'tags:update'

--- a/src/main/database/application-database.integration.test.ts
+++ b/src/main/database/application-database.integration.test.ts
@@ -112,7 +112,8 @@ describe('application database (integration)', () => {
         '0008_database_json_constraints',
         '0009_vision_evidence',
         '0010_compute_password_auth',
-        '0011_cross_resource_tags'
+        '0011_cross_resource_tags',
+        '0012_tag_ordering'
       ]
     })
 
@@ -722,7 +723,7 @@ describe('application database (integration)', () => {
   it('backs up legacy data through the shared client on a portable storage path', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open science 数据 legacy backup-'))
     const databasePath = join(storageRoot, 'open-science.db')
-    const backupPath = `${databasePath}.before-0010_compute_password_auth.backup`
+    const backupPath = `${databasePath}.before-0012_tag_ordering.backup`
     const seedClient = createProjectDbClient(storageRoot)
     try {
       await seedClient.$executeRawUnsafe(`CREATE TABLE "Project" (
@@ -762,7 +763,7 @@ describe('application database (integration)', () => {
         backupClient.$queryRaw<Array<{ id: string }>>`
           SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1
         `
-      ).resolves.toEqual([{ id: '0009_vision_evidence' }])
+      ).resolves.toEqual([{ id: '0011_cross_resource_tags' }])
     } finally {
       await backupClient.$disconnect()
     }
@@ -1033,7 +1034,8 @@ describe('application database (integration)', () => {
         '0008_database_json_constraints',
         '0009_vision_evidence',
         '0010_compute_password_auth',
-        '0011_cross_resource_tags'
+        '0011_cross_resource_tags',
+        '0012_tag_ordering'
       ]
     })
 

--- a/src/main/database/database-json-constraints-migration.test.ts
+++ b/src/main/database/database-json-constraints-migration.test.ts
@@ -144,10 +144,11 @@ describe('database JSON constraints migration', () => {
         MIGRATION_ID,
         '0009_vision_evidence',
         '0010_compute_password_auth',
-        '0011_cross_resource_tags'
+        '0011_cross_resource_tags',
+        '0012_tag_ordering'
       ],
       from: '0007_notification_attention_metadata',
-      to: '0011_cross_resource_tags'
+      to: '0012_tag_ordering'
     })
     await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).rejects.toMatchObject({
       code: 'ENOENT'
@@ -155,9 +156,7 @@ describe('database JSON constraints migration', () => {
     await expect(
       access(`${databasePath}.before-0011_cross_resource_tags.backup`)
     ).resolves.toBeUndefined()
-    await expect(
-      access(`${databasePath}.before-0010_compute_password_auth.backup`)
-    ).resolves.toBeUndefined()
+    await expect(access(`${databasePath}.before-0012_tag_ordering.backup`)).resolves.toBeUndefined()
 
     await expect(
       client.$queryRaw<Array<{ scope: string; reviewerLog: string }>>`

--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -108,7 +108,8 @@ describe('database startup logging', () => {
               '0008_database_json_constraints',
               '0009_vision_evidence',
               '0010_compute_password_auth',
-              '0011_cross_resource_tags'
+              '0011_cross_resource_tags',
+              '0012_tag_ordering'
             ],
             adoptedLegacy: true
           })

--- a/src/main/database/generated/runtime-schema.ts
+++ b/src/main/database/generated/runtime-schema.ts
@@ -463,6 +463,7 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "nameKey" TEXT,
     "iconKey" TEXT,
     "colorKey" TEXT,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" DATETIME NOT NULL,
     CONSTRAINT "Tag_shape_check" CHECK ((("systemKey" IS NOT NULL AND "name" IS NULL AND "nameKey" IS NULL AND "iconKey" IS NULL AND "colorKey" IS NULL) OR ("systemKey" IS NULL AND "name" IS NOT NULL AND "nameKey" IS NOT NULL AND "iconKey" IS NOT NULL AND "colorKey" IS NOT NULL))),
@@ -538,6 +539,7 @@ const RUNTIME_SCHEMA_INDEX_DDLS = [
   `CREATE UNIQUE INDEX IF NOT EXISTS "GrantedLocalRoot_path_key" ON "GrantedLocalRoot"("path");`,
   `CREATE UNIQUE INDEX IF NOT EXISTS "Tag_systemKey_key" ON "Tag"("systemKey");`,
   `CREATE UNIQUE INDEX IF NOT EXISTS "Tag_nameKey_key" ON "Tag"("nameKey");`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "Tag_sortOrder_key" ON "Tag"("sortOrder");`,
   `CREATE INDEX IF NOT EXISTS "TagAssignment_resourceType_resourceId_idx" ON "TagAssignment"("resourceType", "resourceId");`
 ] as const
 

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -20,7 +20,7 @@ import {
 } from './migration-service'
 
 const futureTestMigration = (): MigrationManifestEntry => {
-  const id = '0012_test_suffix'
+  const id = '0013_test_suffix'
   const statements = [`UPDATE "Project" SET "name" = "name" WHERE 0`] as const
   const verifiers = [{ kind: 'table-exists', version: 1, table: 'Project' }] as const
   return {
@@ -248,10 +248,11 @@ describe('application database migrations', () => {
         '0008_database_json_constraints',
         '0009_vision_evidence',
         '0010_compute_password_auth',
-        '0011_cross_resource_tags'
+        '0011_cross_resource_tags',
+        '0012_tag_ordering'
       ],
       from: null,
-      to: '0011_cross_resource_tags'
+      to: '0012_tag_ordering'
     })
     expect(compatibility).toEqual([{ sqliteVersion: expect.stringMatching(/^\d+\.\d+\.\d+$/) }])
     await expect(
@@ -264,8 +265,8 @@ describe('application database migrations', () => {
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
       applied: [],
-      from: '0011_cross_resource_tags',
-      to: '0011_cross_resource_tags'
+      from: '0012_tag_ordering',
+      to: '0012_tag_ordering'
     })
   })
 
@@ -328,7 +329,8 @@ describe('application database migrations', () => {
         '0008_database_json_constraints',
         '0009_vision_evidence',
         '0010_compute_password_auth',
-        '0011_cross_resource_tags'
+        '0011_cross_resource_tags',
+        '0012_tag_ordering'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -373,7 +375,7 @@ describe('application database migrations', () => {
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: expect.arrayContaining(['0010_compute_password_auth']),
-      to: '0011_cross_resource_tags'
+      to: '0012_tag_ordering'
     })
     await expect(
       client.$executeRawUnsafe(
@@ -395,7 +397,7 @@ describe('application database migrations', () => {
     await client.$executeRawUnsafe('DROP INDEX "ComputeJob_status_idx"')
     await removeComputePasswordAuthSchema(client)
     await client.$executeRawUnsafe(`DELETE FROM "_open_science_migrations"
-      WHERE "id" IN ('0006_database_domain_constraints', '0007_notification_attention_metadata', '0008_database_json_constraints', '0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags')`)
+      WHERE "id" IN ('0006_database_domain_constraints', '0007_notification_attention_metadata', '0008_database_json_constraints', '0009_vision_evidence', '0010_compute_password_auth', '0011_cross_resource_tags', '0012_tag_ordering')`)
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: [
@@ -404,10 +406,11 @@ describe('application database migrations', () => {
         '0008_database_json_constraints',
         '0009_vision_evidence',
         '0010_compute_password_auth',
-        '0011_cross_resource_tags'
+        '0011_cross_resource_tags',
+        '0012_tag_ordering'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0011_cross_resource_tags'
+      to: '0012_tag_ordering'
     })
     await expect(verifyCurrentRuntimeSchema(client)).resolves.toBeUndefined()
   })
@@ -469,10 +472,11 @@ describe('application database migrations', () => {
         '0008_database_json_constraints',
         '0009_vision_evidence',
         '0010_compute_password_auth',
-        '0011_cross_resource_tags'
+        '0011_cross_resource_tags',
+        '0012_tag_ordering'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0011_cross_resource_tags'
+      to: '0012_tag_ordering'
     })
     await expect(
       client.$queryRaw<
@@ -591,7 +595,7 @@ describe('application database migrations', () => {
       })
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0011_cross_resource_tags'
+      migrationId: '0012_tag_ordering'
     })
     expect(retired).toEqual([])
     await expect(access(backupPath)).resolves.toBeUndefined()
@@ -607,9 +611,9 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).resolves.toEqual({
       adoptedLegacy: false,
-      applied: ['0012_test_suffix'],
-      from: '0011_cross_resource_tags',
-      to: '0012_test_suffix'
+      applied: ['0013_test_suffix'],
+      from: '0012_tag_ordering',
+      to: '0013_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ id: string }>>`
@@ -627,7 +631,8 @@ describe('application database migrations', () => {
       { id: '0009_vision_evidence' },
       { id: '0010_compute_password_auth' },
       { id: '0011_cross_resource_tags' },
-      { id: '0012_test_suffix' }
+      { id: '0012_tag_ordering' },
+      { id: '0013_test_suffix' }
     ])
   })
 
@@ -690,10 +695,11 @@ describe('application database migrations', () => {
         '0008_database_json_constraints',
         '0009_vision_evidence',
         '0010_compute_password_auth',
-        '0011_cross_resource_tags'
+        '0011_cross_resource_tags',
+        '0012_tag_ordering'
       ],
       from: '0001_runtime_schema_baseline',
-      to: '0011_cross_resource_tags'
+      to: '0012_tag_ordering'
     })
     expect(backupEvents).toEqual([
       {
@@ -745,12 +751,15 @@ describe('application database migrations', () => {
         migrationId: '0011_cross_resource_tags',
         path: `${databasePath}.before-0011_cross_resource_tags.backup`,
         reused: false
+      },
+      {
+        migrationId: '0012_tag_ordering',
+        path: `${databasePath}.before-0012_tag_ordering.backup`,
+        reused: false
       }
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
-    await expect(
-      access(`${databasePath}.before-0010_compute_password_auth.backup`)
-    ).resolves.toBeUndefined()
+    await expect(access(`${databasePath}.before-0012_tag_ordering.backup`)).resolves.toBeUndefined()
     await expect(
       access(`${databasePath}.before-0011_cross_resource_tags.backup`)
     ).resolves.toBeUndefined()
@@ -783,7 +792,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0012_test_suffix'
+      migrationId: '0013_test_suffix'
     })
     await expect(
       client.$queryRaw<Array<{ name: string }>>`
@@ -806,7 +815,8 @@ describe('application database migrations', () => {
       { id: '0008_database_json_constraints' },
       { id: '0009_vision_evidence' },
       { id: '0010_compute_password_auth' },
-      { id: '0011_cross_resource_tags' }
+      { id: '0011_cross_resource_tags' },
+      { id: '0012_tag_ordering' }
     ])
   })
 
@@ -850,10 +860,7 @@ describe('application database migrations', () => {
       readdir(storageRoot).then((entries) =>
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
-    ).resolves.toEqual([
-      'open-science.db.before-0011_cross_resource_tags.backup',
-      `open-science.db.before-${future.id}.backup`
-    ])
+    ).resolves.toEqual([`open-science.db.before-${future.id}.backup`])
   })
 
   it('rejects a migration when its required column is missing', async () => {
@@ -874,7 +881,7 @@ describe('application database migrations', () => {
       migrateApplicationDatabaseWithManifest(client, [...MIGRATION_MANIFEST, future])
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0012_test_suffix'
+      migrationId: '0013_test_suffix'
     })
   })
 
@@ -911,9 +918,10 @@ describe('application database migrations', () => {
         '0009_vision_evidence',
         '0010_compute_password_auth',
         '0011_cross_resource_tags',
-        '0012_test_suffix'
+        '0012_tag_ordering',
+        '0013_test_suffix'
       ],
-      to: '0012_test_suffix'
+      to: '0013_test_suffix'
     })
     await expect(
       client.project.findUniqueOrThrow({ where: { id: 'legacy-project' } })
@@ -1139,7 +1147,8 @@ describe('application database migrations', () => {
         '0008_database_json_constraints',
         '0009_vision_evidence',
         '0010_compute_password_auth',
-        '0011_cross_resource_tags'
+        '0011_cross_resource_tags',
+        '0012_tag_ordering'
       ]
     })
     await expect(
@@ -1245,7 +1254,8 @@ describe('application database migrations', () => {
         '0008_database_json_constraints',
         '0009_vision_evidence',
         '0010_compute_password_auth',
-        '0011_cross_resource_tags'
+        '0011_cross_resource_tags',
+        '0012_tag_ordering'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -1305,7 +1315,8 @@ describe('application database migrations', () => {
         '0008_database_json_constraints',
         '0009_vision_evidence',
         '0010_compute_password_auth',
-        '0011_cross_resource_tags'
+        '0011_cross_resource_tags',
+        '0012_tag_ordering'
       ]
     })
     await expect(
@@ -1368,7 +1379,8 @@ describe('application database migrations', () => {
         '0008_database_json_constraints',
         '0009_vision_evidence',
         '0010_compute_password_auth',
-        '0011_cross_resource_tags'
+        '0011_cross_resource_tags',
+        '0012_tag_ordering'
       ]
     })
     await expect(verifyCurrentRuntimeSchema(client)).resolves.toBeUndefined()
@@ -1465,7 +1477,8 @@ describe('application database migrations', () => {
         '0008_database_json_constraints',
         '0009_vision_evidence',
         '0010_compute_password_auth',
-        '0011_cross_resource_tags'
+        '0011_cross_resource_tags',
+        '0012_tag_ordering'
       ]
     })
     await expect(
@@ -1482,6 +1495,7 @@ describe('application database migrations', () => {
     const visionEvidenceBackupPath = `${databasePath}.before-0009_vision_evidence.backup`
     const computePasswordAuthBackupPath = `${databasePath}.before-0010_compute_password_auth.backup`
     const crossResourceTagsBackupPath = `${databasePath}.before-0011_cross_resource_tags.backup`
+    const tagOrderingBackupPath = `${databasePath}.before-0012_tag_ordering.backup`
     const backupEvents: unknown[] = []
     client = createProjectDbClient(storageRoot)
     await client.$executeRawUnsafe(`CREATE TABLE "Project" (
@@ -1518,7 +1532,8 @@ describe('application database migrations', () => {
         '0008_database_json_constraints',
         '0009_vision_evidence',
         '0010_compute_password_auth',
-        '0011_cross_resource_tags'
+        '0011_cross_resource_tags',
+        '0012_tag_ordering'
       ]
     })
     expect(backupEvents).toEqual([
@@ -1576,6 +1591,11 @@ describe('application database migrations', () => {
         migrationId: '0011_cross_resource_tags',
         path: `${databasePath}.before-0011_cross_resource_tags.backup`,
         reused: false
+      },
+      {
+        migrationId: '0012_tag_ordering',
+        path: `${databasePath}.before-0012_tag_ordering.backup`,
+        reused: false
       }
     ])
     await expect(
@@ -1583,18 +1603,19 @@ describe('application database migrations', () => {
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
     ).resolves.toEqual([
-      'open-science.db.before-0010_compute_password_auth.backup',
-      'open-science.db.before-0011_cross_resource_tags.backup'
+      'open-science.db.before-0011_cross_resource_tags.backup',
+      'open-science.db.before-0012_tag_ordering.backup'
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(agentContextBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(visionEvidenceBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
-    await expect(access(computePasswordAuthBackupPath)).resolves.toBeUndefined()
+    await expect(access(computePasswordAuthBackupPath)).rejects.toMatchObject({ code: 'ENOENT' })
     await expect(access(crossResourceTagsBackupPath)).resolves.toBeUndefined()
+    await expect(access(tagOrderingBackupPath)).resolves.toBeUndefined()
     await expect(client.project.count()).resolves.toBe(1)
 
     const backupClient = new PrismaClient({
-      datasources: { db: { url: `file:${computePasswordAuthBackupPath.replaceAll('\\', '/')}` } }
+      datasources: { db: { url: `file:${crossResourceTagsBackupPath.replaceAll('\\', '/')}` } }
     })
     try {
       await expect(
@@ -1606,7 +1627,7 @@ describe('application database migrations', () => {
         backupClient.$queryRaw<Array<{ id: string }>>`
           SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1
         `
-      ).resolves.toEqual([{ id: '0009_vision_evidence' }])
+      ).resolves.toEqual([{ id: '0010_compute_password_auth' }])
     } finally {
       await backupClient.$disconnect()
     }
@@ -2009,6 +2030,11 @@ describe('application database migrations', () => {
         migrationId: '0011_cross_resource_tags',
         path: `${databasePath}.before-0011_cross_resource_tags.backup`,
         reused: false
+      }),
+      expect.objectContaining({
+        migrationId: '0012_tag_ordering',
+        path: `${databasePath}.before-0012_tag_ordering.backup`,
+        reused: false
       })
     ])
     expect(retired).toEqual([
@@ -2049,6 +2075,10 @@ describe('application database migrations', () => {
       {
         migrationId: '0011_cross_resource_tags',
         path: `${databasePath}.before-0011_cross_resource_tags.backup`
+      },
+      {
+        migrationId: '0012_tag_ordering',
+        path: `${databasePath}.before-0012_tag_ordering.backup`
       }
     ])
     await expect(access(backupPath)).rejects.toMatchObject({ code: 'ENOENT' })
@@ -2082,11 +2112,11 @@ describe('application database migrations', () => {
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
     ).resolves.toEqual([
-      'open-science.db.before-0010_compute_password_auth.backup',
       'open-science.db.before-0011_cross_resource_tags.backup',
+      'open-science.db.before-0012_tag_ordering.backup',
       unknownBackupName
     ])
-    expect(retired).toHaveLength(9)
+    expect(retired).toHaveLength(10)
     expect(retired).toEqual(
       expect.arrayContaining(
         MIGRATION_MANIFEST.slice(0, -2).map((migration) =>

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -25,6 +25,7 @@ import { databaseJsonConstraintsMigration } from './migrations/0008-database-jso
 import { visionEvidenceMigration } from './migrations/0009-vision-evidence'
 import { computePasswordAuthMigration } from './migrations/0010-compute-password-auth'
 import { crossResourceTagsMigration } from './migrations/0011-cross-resource-tags'
+import { tagOrderingMigration } from './migrations/0012-tag-ordering'
 import {
   applySqliteMigrationOperations,
   type SqliteMigrationOperation
@@ -209,6 +210,12 @@ const CROSS_RESOURCE_TAGS_CHECKSUM = checksumMigrationPayload(
   crossResourceTagsMigration.verifiers,
   crossResourceTagsMigration.operations
 )
+const TAG_ORDERING_CHECKSUM = checksumMigrationPayload(
+  tagOrderingMigration.id,
+  tagOrderingMigration.statements,
+  tagOrderingMigration.verifiers,
+  tagOrderingMigration.operations
+)
 const DATABASE_DOMAIN_ALLOWED_SUFFIX_CHECKS: AllowedSuffixCheckConstraints = Object.fromEntries(
   databaseDomainConstraintsMigration.verifiers[0].tables.map(({ table, constraints }) => [
     table,
@@ -337,6 +344,12 @@ const MIGRATION_MANIFEST = [
   {
     ...crossResourceTagsMigration,
     checksum: CROSS_RESOURCE_TAGS_CHECKSUM,
+    backupOnApply: 'required',
+    backupRetention: 'retain'
+  },
+  {
+    ...tagOrderingMigration,
+    checksum: TAG_ORDERING_CHECKSUM,
     backupOnApply: 'required',
     backupRetention: 'retain'
   }
@@ -1242,6 +1255,7 @@ export {
   DATABASE_JSON_CONSTRAINTS_CHECKSUM,
   VISION_EVIDENCE_CHECKSUM,
   COMPUTE_PASSWORD_AUTH_CHECKSUM,
+  TAG_ORDERING_CHECKSUM,
   DatabaseMigrationError,
   checksumMigrationPayload,
   classifyDatabaseFailure,

--- a/src/main/database/migrations/0012-tag-ordering.ts
+++ b/src/main/database/migrations/0012-tag-ordering.ts
@@ -1,0 +1,36 @@
+const tagOrderingMigration = {
+  id: '0012_tag_ordering',
+  statements: [
+    `ALTER TABLE "Tag" ADD COLUMN "sortOrder" INTEGER NOT NULL DEFAULT 0`,
+    `UPDATE "Tag" AS current
+      SET "sortOrder" = CASE
+        WHEN current."systemKey" = 'favorite' THEN 0
+        ELSE 1 + (
+          SELECT COUNT(*)
+          FROM "Tag" AS earlier
+          WHERE earlier."systemKey" IS NULL
+            AND (
+              earlier."nameKey" < current."nameKey"
+              OR (earlier."nameKey" = current."nameKey" AND earlier."id" < current."id")
+            )
+        )
+      END`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS "Tag_sortOrder_key" ON "Tag"("sortOrder")`
+  ] as const,
+  operations: [] as const,
+  verifiers: [
+    { kind: 'column-exists', version: 1, table: 'Tag', column: 'sortOrder' },
+    {
+      kind: 'indexes-exist',
+      version: 1,
+      indexes: [
+        {
+          name: 'Tag_sortOrder_key',
+          sql: `CREATE UNIQUE INDEX IF NOT EXISTS "Tag_sortOrder_key" ON "Tag"("sortOrder")`
+        }
+      ]
+    }
+  ] as const
+}
+
+export { tagOrderingMigration }

--- a/src/main/database/notification-attention-metadata-migration.test.ts
+++ b/src/main/database/notification-attention-metadata-migration.test.ts
@@ -70,10 +70,11 @@ describe('notification attention metadata migration', () => {
         '0008_database_json_constraints',
         '0009_vision_evidence',
         '0010_compute_password_auth',
-        '0011_cross_resource_tags'
+        '0011_cross_resource_tags',
+        '0012_tag_ordering'
       ],
       from: '0006_database_domain_constraints',
-      to: '0011_cross_resource_tags'
+      to: '0012_tag_ordering'
     })
     await expect(
       access(`${databasePath}.before-0007_notification_attention_metadata.backup`)
@@ -81,9 +82,7 @@ describe('notification attention metadata migration', () => {
     await expect(
       access(`${databasePath}.before-0011_cross_resource_tags.backup`)
     ).resolves.toBeUndefined()
-    await expect(
-      access(`${databasePath}.before-0010_compute_password_auth.backup`)
-    ).resolves.toBeUndefined()
+    await expect(access(`${databasePath}.before-0012_tag_ordering.backup`)).resolves.toBeUndefined()
 
     await expect(
       client.$queryRaw<

--- a/src/main/database/tag-ordering-migration.test.ts
+++ b/src/main/database/tag-ordering-migration.test.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import type { PrismaClient } from '@prisma/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { createProjectDbClient } from '../projects/prisma-client'
+import { tagOrderingMigration } from './migrations/0012-tag-ordering'
+
+describe('Tag ordering migration', () => {
+  let root: string
+  let client: PrismaClient
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'open-science-tag-ordering-'))
+    client = createProjectDbClient(root)
+  })
+
+  afterEach(async () => {
+    await client.$disconnect()
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('backfills the previous visible order and keeps Favorites first', async () => {
+    await client.$executeRawUnsafe(`CREATE TABLE "Tag" (
+      "id" TEXT NOT NULL PRIMARY KEY,
+      "systemKey" TEXT,
+      "name" TEXT,
+      "nameKey" TEXT,
+      "iconKey" TEXT,
+      "colorKey" TEXT,
+      "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updatedAt" DATETIME NOT NULL
+    )`)
+    await client.$executeRawUnsafe(`INSERT INTO "Tag"
+      ("id", "systemKey", "updatedAt") VALUES
+      ('tag-favorite', 'favorite', CURRENT_TIMESTAMP)`)
+    await client.$executeRawUnsafe(`INSERT INTO "Tag"
+      ("id", "name", "nameKey", "iconKey", "colorKey", "updatedAt") VALUES
+      ('tag-zeta', 'Zeta', 'zeta', 'tag', 'blue', CURRENT_TIMESTAMP),
+      ('tag-alpha-b', 'Alpha B', 'alpha-b', 'tag', 'blue', CURRENT_TIMESTAMP),
+      ('tag-alpha-a', 'Alpha A', 'alpha-a', 'tag', 'green', CURRENT_TIMESTAMP)`)
+
+    for (const statement of tagOrderingMigration.statements) {
+      await client.$executeRawUnsafe(statement)
+    }
+    const rows = await client.$queryRawUnsafe<Array<{ id: string; sortOrder: number }>>(
+      `SELECT "id", "sortOrder" FROM "Tag" ORDER BY "sortOrder" ASC`
+    )
+    expect(rows).toEqual([
+      { id: 'tag-favorite', sortOrder: 0 },
+      { id: 'tag-alpha-a', sortOrder: 1 },
+      { id: 'tag-alpha-b', sortOrder: 2 },
+      { id: 'tag-zeta', sortOrder: 3 }
+    ])
+  })
+})

--- a/src/main/tags/application-commands.ts
+++ b/src/main/tags/application-commands.ts
@@ -2,6 +2,7 @@ import {
   tagApplicationCommandContracts,
   type CreateTagRequest,
   type DeleteTagRequest,
+  type ReorderTagsRequest,
   type SetTagAssignmentRequest,
   type TagSnapshot,
   type UpdateTagRequest
@@ -18,6 +19,7 @@ type TagCommandOwner = Readonly<{
   create(request: CreateTagRequest): Promise<TagSnapshot>
   update(request: UpdateTagRequest): Promise<TagSnapshot>
   delete(request: DeleteTagRequest): Promise<TagSnapshot>
+  reorder(request: ReorderTagsRequest): Promise<TagSnapshot>
   setAssignment(request: SetTagAssignmentRequest): Promise<TagSnapshot>
 }>
 
@@ -38,6 +40,10 @@ const tagApplicationCommands = Object.freeze({
     'tags:delete',
     tagApplicationCommandContracts.delete
   ),
+  reorder: defineApplicationCommand<'tags:reorder', readonly [ReorderTagsRequest], TagSnapshot>(
+    'tags:reorder',
+    tagApplicationCommandContracts.reorder
+  ),
   setAssignment: defineApplicationCommand<
     'tags:set-assignment',
     readonly [SetTagAssignmentRequest],
@@ -48,6 +54,7 @@ const tagApplicationCommands = Object.freeze({
 const tagApplicationCommandGroup = defineApplicationCommandGroup('tags', [
   tagApplicationCommands.create,
   tagApplicationCommands.delete,
+  tagApplicationCommands.reorder,
   tagApplicationCommands.setAssignment,
   tagApplicationCommands.snapshot,
   tagApplicationCommands.update
@@ -64,6 +71,7 @@ const registerTagApplicationCommands = (
       'tags:create': ({ args }) => owner.create(args[0]),
       'tags:update': ({ args }) => owner.update(args[0]),
       'tags:delete': ({ args }) => owner.delete(args[0]),
+      'tags:reorder': ({ args }) => owner.reorder(args[0]),
       'tags:set-assignment': ({ args }) => owner.setAssignment(args[0])
     })
     return scope.complete()

--- a/src/main/tags/repository.test.ts
+++ b/src/main/tags/repository.test.ts
@@ -49,6 +49,35 @@ describe('TagRepository', () => {
     ).rejects.toThrow('A Tag with this name already exists.')
   })
 
+  it('appends new Tags and persists a validated global custom order', async () => {
+    await repository.create({ name: 'Alpha', iconKey: 'tag', colorKey: 'blue' })
+    await repository.create({ name: 'Beta', iconKey: 'bookmark', colorKey: 'green' })
+    const before = await repository.snapshot(1)
+    const custom = before.tags.filter((tag) => !('systemKey' in tag))
+
+    expect(before.tags[0]).toMatchObject({ systemKey: 'favorite' })
+    expect(custom.map((tag) => ('name' in tag ? tag.name : 'system'))).toEqual(['Alpha', 'Beta'])
+
+    await repository.reorder({ tagIds: [custom[1]!.id, custom[0]!.id] })
+    const after = await repository.snapshot(2)
+    expect(after.tags[0]).toMatchObject({ systemKey: 'favorite' })
+    expect(after.tags.slice(1).map((tag) => ('name' in tag ? tag.name : 'system'))).toEqual([
+      'Beta',
+      'Alpha'
+    ])
+    await expect(repository.reorder({ tagIds: [custom[0]!.id] })).rejects.toThrow(
+      'Tag order must include every custom Tag exactly once.'
+    )
+    await expect(repository.reorder({ tagIds: [custom[0]!.id, 'tag-favorite'] })).rejects.toThrow(
+      'Tag order must include every custom Tag exactly once.'
+    )
+
+    await repository.delete(custom[1]!.id)
+    await expect(
+      client.tag.findUniqueOrThrow({ where: { id: custom[0]!.id } })
+    ).resolves.toMatchObject({ sortOrder: 1 })
+  })
+
   it('rejects names whose normalized comparison key exceeds the storage limit', async () => {
     const expandingName = 'İ'.repeat(64)
 

--- a/src/main/tags/repository.ts
+++ b/src/main/tags/repository.ts
@@ -3,6 +3,7 @@ import { Prisma, type PrismaClient, type Tag as PrismaTag } from '@prisma/client
 import {
   FAVORITE_TAG_ID,
   FAVORITE_TAG_SYSTEM_KEY,
+  type ReorderTagsRequest,
   TAG_NAME_MAX_LENGTH,
   type CreateTagRequest,
   type SetTagAssignmentRequest,
@@ -16,7 +17,7 @@ import {
 } from '../../shared/tags'
 import type { TagResourceCatalogSnapshot } from './resource-catalog'
 
-type TagClient = Pick<PrismaClient, 'tag' | 'tagAssignment'>
+type TagClient = Pick<PrismaClient, 'tag' | 'tagAssignment' | '$transaction'>
 type TagClientProvider = () => Promise<TagClient>
 
 const cleanTagName = (input: string): string => input.normalize('NFKC').trim().replace(/\s+/gu, ' ')
@@ -56,6 +57,7 @@ class TagRepository {
       create: {
         id: FAVORITE_TAG_ID,
         systemKey: FAVORITE_TAG_SYSTEM_KEY,
+        sortOrder: 0,
         updatedAt: new Date()
       },
       update: {}
@@ -66,7 +68,7 @@ class TagRepository {
     const client = await this.getClient()
     await this.ensureFavorite(client)
     const [tags, assignments] = await Promise.all([
-      client.tag.findMany({ orderBy: [{ systemKey: 'desc' }, { nameKey: 'asc' }, { id: 'asc' }] }),
+      client.tag.findMany({ orderBy: [{ sortOrder: 'asc' }, { id: 'asc' }] }),
       client.tagAssignment.findMany({
         orderBy: [{ createdAt: 'asc' }, { tagId: 'asc' }, { resourceType: 'asc' }]
       })
@@ -91,12 +93,15 @@ class TagRepository {
     if (nameKey.length > TAG_NAME_MAX_LENGTH) throw new Error('Tag name is too long.')
     try {
       const client = await this.getClient()
+      await this.ensureFavorite(client)
+      const lastTag = await client.tag.findFirst({ orderBy: { sortOrder: 'desc' } })
       await client.tag.create({
         data: {
           name,
           nameKey,
           iconKey: request.iconKey,
-          colorKey: request.colorKey
+          colorKey: request.colorKey,
+          sortOrder: (lastTag?.sortOrder ?? 0) + 1
         }
       })
     } catch (error) {
@@ -134,7 +139,51 @@ class TagRepository {
     const current = await client.tag.findUnique({ where: { id } })
     if (!current) throw new Error('Tag not found.')
     if (current.systemKey) throw new Error('System Tags cannot be deleted.')
-    await client.tag.delete({ where: { id } })
+    const trailingTags = await client.tag.findMany({
+      where: { sortOrder: { gt: current.sortOrder } },
+      select: { id: true },
+      orderBy: { sortOrder: 'asc' }
+    })
+    await client.$transaction([
+      client.tag.delete({ where: { id } }),
+      ...trailingTags.map((tag, index) =>
+        client.tag.update({ where: { id: tag.id }, data: { sortOrder: -(index + 1) } })
+      ),
+      ...trailingTags.map((tag, index) =>
+        client.tag.update({
+          where: { id: tag.id },
+          data: { sortOrder: current.sortOrder + index }
+        })
+      )
+    ])
+  }
+
+  async reorder(request: ReorderTagsRequest): Promise<void> {
+    const client = await this.getClient()
+    const customTags = await client.tag.findMany({
+      where: { systemKey: null },
+      select: { id: true },
+      orderBy: [{ sortOrder: 'asc' }, { id: 'asc' }]
+    })
+    const persistedIds = customTags.map(({ id }) => id)
+    const requestedIds = request.tagIds
+    if (
+      new Set(requestedIds).size !== requestedIds.length ||
+      requestedIds.length !== persistedIds.length ||
+      requestedIds.some((id) => !persistedIds.includes(id))
+    ) {
+      throw new Error('Tag order must include every custom Tag exactly once.')
+    }
+    if (requestedIds.every((id, index) => id === persistedIds[index])) return
+
+    await client.$transaction([
+      ...requestedIds.map((id, index) =>
+        client.tag.update({ where: { id }, data: { sortOrder: -(index + 1) } })
+      ),
+      ...requestedIds.map((id, index) =>
+        client.tag.update({ where: { id }, data: { sortOrder: index + 1 } })
+      )
+    ])
   }
 
   async setAssignment(request: SetTagAssignmentRequest): Promise<void> {

--- a/src/main/tags/service.test.ts
+++ b/src/main/tags/service.test.ts
@@ -8,6 +8,23 @@ import { TagService } from './service'
 const snapshot = (revision: number): TagSnapshot => ({ revision, tags: [], assignments: [] })
 
 describe('TagService', () => {
+  it('serializes Tag reordering and publishes the authoritative result', async () => {
+    const repository = {
+      reorder: vi.fn().mockResolvedValue(undefined),
+      snapshot: vi.fn((revision) => Promise.resolve(snapshot(revision)))
+    }
+    const events = { publish: vi.fn() }
+    const service = new TagService(
+      repository as unknown as TagRepository,
+      {} as TagResourceCatalog,
+      events
+    )
+
+    await expect(service.reorder({ tagIds: ['tag-b', 'tag-a'] })).resolves.toEqual(snapshot(1))
+    expect(repository.reorder).toHaveBeenCalledWith({ tagIds: ['tag-b', 'tag-a'] })
+    expect(events.publish).toHaveBeenCalledWith('tags:changed', { revision: 1 })
+  })
+
   it('validates resources, advances revision, and publishes a convergence event', async () => {
     const repository = {
       setAssignment: vi.fn().mockResolvedValue(undefined),

--- a/src/main/tags/service.ts
+++ b/src/main/tags/service.ts
@@ -1,6 +1,7 @@
 import type {
   CreateTagRequest,
   DeleteTagRequest,
+  ReorderTagsRequest,
   SetTagAssignmentRequest,
   TagSnapshot,
   TagResourceRef,
@@ -70,6 +71,10 @@ class TagService {
 
   delete(request: DeleteTagRequest): Promise<TagSnapshot> {
     return this.mutate(() => this.repository.delete(request.id))
+  }
+
+  reorder(request: ReorderTagsRequest): Promise<TagSnapshot> {
+    return this.mutate(() => this.repository.reorder(request))
   }
 
   setAssignment(request: SetTagAssignmentRequest): Promise<TagSnapshot> {

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -586,6 +586,7 @@ describe('preload bridge — public surface inventory', () => {
       'tags.create',
       'tags.delete',
       'tags.onChanged',
+      'tags.reorder',
       'tags.setAssignment',
       'tags.snapshot',
       'tags.update',

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -532,6 +532,7 @@ const api: OpenScienceAPI = {
     create: (request) => electronRendererContracts.invoke('tags.create', request),
     update: (request) => electronRendererContracts.invoke('tags.update', request),
     delete: (request) => electronRendererContracts.invoke('tags.delete', request),
+    reorder: (request) => electronRendererContracts.invoke('tags.reorder', request),
     setAssignment: (request) => electronRendererContracts.invoke('tags.setAssignment', request),
     onChanged: (listener) => electronRendererContracts.subscribe('tags.onChanged', listener)
   },

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -188,6 +188,7 @@ import type {
 import type {
   CreateTagRequest,
   DeleteTagRequest,
+  ReorderTagsRequest,
   SetTagAssignmentRequest,
   TagSnapshot,
   TagsChangedEvent,
@@ -724,6 +725,7 @@ export interface OpenScienceAPI {
     create(request: CreateTagRequest): Promise<TagSnapshot>
     update(request: UpdateTagRequest): Promise<TagSnapshot>
     delete(request: DeleteTagRequest): Promise<TagSnapshot>
+    reorder(request: ReorderTagsRequest): Promise<TagSnapshot>
     setAssignment(request: SetTagAssignmentRequest): Promise<TagSnapshot>
     onChanged(listener: AcpListener<TagsChangedEvent>): RemoveListener
   }

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -3047,5 +3047,9 @@
   "Slate": "スレート",
   "Change appearance for {{name}}": "{{name}} の外観を変更",
   "Appearance wasn’t saved. Try again.": "外観を保存できませんでした。もう一度お試しください。",
-  "Specialist appearance picker — 8 states": "スペシャリスト外観ピッカー — 8つの状態"
+  "Specialist appearance picker — 8 states": "スペシャリスト外観ピッカー — 8つの状態",
+  "System Tags stay first": "システムタグは常に先頭に表示されます",
+  "Reorder {{tag}}": "{{tag}} の順序を変更",
+  "Moved {{tag}} to position {{position}}.": "{{tag}} を {{position}} 番目に移動しました。",
+  "Could not reorder Tags. Try again.": "タグの順序を変更できませんでした。もう一度お試しください。"
 }

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -3045,5 +3045,9 @@
   "Pink": "핑크",
   "Change appearance for {{name}}": "{{name}}의 외관 변경",
   "Appearance wasn’t saved. Try again.": "외관을 저장하지 못했습니다. 다시 시도하세요.",
-  "Specialist appearance picker — 8 states": "스페셜리스트 외관 선택기 — 8가지 상태"
+  "Specialist appearance picker — 8 states": "스페셜리스트 외관 선택기 — 8가지 상태",
+  "System Tags stay first": "시스템 태그는 항상 맨 앞에 표시됩니다",
+  "Reorder {{tag}}": "{{tag}} 순서 변경",
+  "Moved {{tag}} to position {{position}}.": "{{tag}}을(를) {{position}}번째로 이동했습니다.",
+  "Could not reorder Tags. Try again.": "태그 순서를 변경하지 못했습니다. 다시 시도하세요."
 }

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -3047,5 +3047,9 @@
   "Slate": "石板灰",
   "Change appearance for {{name}}": "更改 {{name}} 的外观",
   "Appearance wasn’t saved. Try again.": "未能保存外观。请重试。",
-  "Specialist appearance picker — 8 states": "专家外观选择器 — 8 种状态"
+  "Specialist appearance picker — 8 states": "专家外观选择器 — 8 种状态",
+  "System Tags stay first": "系统标签固定在首位",
+  "Reorder {{tag}}": "调整 {{tag}} 的顺序",
+  "Moved {{tag}} to position {{position}}.": "已将 {{tag}} 移至第 {{position}} 位。",
+  "Could not reorder Tags. Try again.": "无法调整标签顺序。请重试。"
 }

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -3047,5 +3047,9 @@
   "Slate": "石板灰",
   "Change appearance for {{name}}": "更改 {{name}} 的外觀",
   "Appearance wasn’t saved. Try again.": "無法儲存外觀。請重試。",
-  "Specialist appearance picker — 8 states": "專家外觀選擇器 — 8 種狀態"
+  "Specialist appearance picker — 8 states": "專家外觀選擇器 — 8 種狀態",
+  "System Tags stay first": "系統標籤固定在首位",
+  "Reorder {{tag}}": "調整 {{tag}} 的順序",
+  "Moved {{tag}} to position {{position}}.": "已將 {{tag}} 移至第 {{position}} 位。",
+  "Could not reorder Tags. Try again.": "無法調整標籤順序。請再試一次。"
 }

--- a/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
@@ -12,6 +12,20 @@ import { TagsPanel } from './TagsPanel'
 let container: HTMLDivElement
 let root: Root
 
+const dispatchPointer = (
+  element: Element,
+  type: 'pointerdown' | 'pointermove' | 'pointerup',
+  clientY: number
+): void => {
+  const event = new MouseEvent(type, { bubbles: true, button: 0, clientX: 10, clientY })
+  Object.defineProperties(event, {
+    isPrimary: { value: true },
+    pointerId: { value: 1 },
+    pointerType: { value: 'mouse' }
+  })
+  act(() => element.dispatchEvent(event))
+}
+
 beforeEach(() => {
   container = document.createElement('div')
   document.body.append(container)
@@ -52,6 +66,7 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root.unmount())
   container.remove()
+  Reflect.deleteProperty(document, 'elementFromPoint')
 })
 
 describe('TagsPanel', () => {
@@ -193,6 +208,51 @@ describe('TagsPanel', () => {
     expect(container.textContent).toContain('+2')
     expect(container.textContent).not.toContain('Production')
     expect(container.firstElementChild?.className).toContain('overflow-hidden')
+  })
+
+  it("renders a resource's Tags in the persisted global order", () => {
+    useTagStore.setState({
+      tags: [
+        { id: 'tag-favorite', systemKey: 'favorite', createdAt: 1, updatedAt: 1 },
+        {
+          id: 'tag-beta',
+          name: 'Beta',
+          iconKey: 'bookmark',
+          colorKey: 'green',
+          createdAt: 3,
+          updatedAt: 3
+        },
+        {
+          id: 'tag-alpha',
+          name: 'Alpha',
+          iconKey: 'tag',
+          colorKey: 'blue',
+          createdAt: 2,
+          updatedAt: 2
+        }
+      ],
+      assignments: ['tag-alpha', 'tag-favorite', 'tag-beta'].map((tagId, index) => ({
+        tagId,
+        resourceType: 'catalog.skill' as const,
+        resourceId: 'analysis',
+        createdAt: index + 1
+      }))
+    })
+
+    act(() => {
+      root.render(
+        <ResourceTagBadges
+          reference={{ resourceType: 'catalog.skill', resourceId: 'analysis' }}
+          limit={Number.POSITIVE_INFINITY}
+        />
+      )
+    })
+
+    expect(
+      Array.from(container.querySelectorAll<HTMLElement>('[title]')).map(
+        (element) => element.textContent
+      )
+    ).toEqual(['Favorites', 'Beta', 'Alpha'])
   })
 
   it('opens a Tag from its resource badge and removes the assignment without navigating', async () => {
@@ -421,7 +481,7 @@ describe('TagsPanel', () => {
     expect(tagList?.classList.contains('border-b')).toBe(true)
     expect(tagList?.classList.contains('md:border-b-0')).toBe(true)
     expect(tagList?.classList.contains('md:border-r')).toBe(true)
-    expect(tagRows.every((row) => row.classList.contains('w-full'))).toBe(true)
+    expect(tagRows.every((row) => row.classList.contains('flex-1'))).toBe(true)
     expect(counts.map((count) => count?.textContent)).toEqual(['1', '0'])
     expect(counts.every((count) => count?.classList.contains('ml-auto'))).toBe(true)
     expect(counts.every((count) => count?.classList.contains('min-w-5'))).toBe(true)
@@ -436,5 +496,129 @@ describe('TagsPanel', () => {
     expect(detailHeader?.classList.contains('flex-wrap')).toBe(true)
     expect(detailActions?.querySelector('[aria-label="Edit Tag"]')).not.toBeNull()
     expect(detailActions?.querySelector('[aria-label="Delete Tag"]')).not.toBeNull()
+  })
+
+  it('keeps the system Tag fixed and reorders custom Tags with the keyboard', async () => {
+    const reorder = vi.fn().mockResolvedValue(undefined)
+    useTagStore.setState({
+      reorder,
+      tags: [
+        { id: 'tag-favorite', systemKey: 'favorite', createdAt: 1, updatedAt: 1 },
+        {
+          id: 'tag-a',
+          name: 'Alpha',
+          iconKey: 'tag',
+          colorKey: 'blue',
+          createdAt: 2,
+          updatedAt: 2
+        },
+        {
+          id: 'tag-b',
+          name: 'Beta',
+          iconKey: 'bookmark',
+          colorKey: 'green',
+          createdAt: 3,
+          updatedAt: 3
+        }
+      ]
+    })
+
+    await act(async () => {
+      root.render(<TagsPanel onOpenResource={vi.fn()} />)
+    })
+
+    expect(container.querySelector('[aria-label="System Tags stay first"]')).not.toBeNull()
+    expect(container.querySelector('[aria-label="Reorder Favorites"]')).toBeNull()
+    const handle = container.querySelector<HTMLButtonElement>('[aria-label="Reorder Alpha"]')!
+    handle.focus()
+    await act(async () => {
+      handle.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    })
+    expect(reorder).toHaveBeenCalledWith({ tagIds: ['tag-b', 'tag-a'] })
+    expect(document.activeElement).toBe(handle)
+    expect(container.textContent).toContain('Moved Alpha to position 3.')
+  })
+
+  it('keeps the first-position drop target stable while dragging upward', async () => {
+    const reorder = vi.fn().mockResolvedValue(undefined)
+    useTagStore.setState({
+      reorder,
+      tags: [
+        { id: 'tag-favorite', systemKey: 'favorite', createdAt: 1, updatedAt: 1 },
+        {
+          id: 'tag-a',
+          name: 'Alpha',
+          iconKey: 'tag',
+          colorKey: 'blue',
+          createdAt: 2,
+          updatedAt: 2
+        },
+        {
+          id: 'tag-b',
+          name: 'Beta',
+          iconKey: 'bookmark',
+          colorKey: 'green',
+          createdAt: 3,
+          updatedAt: 3
+        }
+      ]
+    })
+    await act(async () => {
+      root.render(<TagsPanel onOpenResource={vi.fn()} />)
+    })
+
+    const rows = Array.from(container.querySelectorAll<HTMLElement>('[data-reorderable-tag-id]'))
+    const firstBounds = vi.spyOn(rows[0]!, 'getBoundingClientRect').mockReturnValue({
+      top: 0,
+      bottom: 40,
+      left: 0,
+      right: 240,
+      width: 240,
+      height: 40,
+      x: 0,
+      y: 0,
+      toJSON: () => undefined
+    })
+    vi.spyOn(rows[1]!, 'getBoundingClientRect').mockReturnValue({
+      top: 40,
+      bottom: 80,
+      left: 0,
+      right: 240,
+      width: 240,
+      height: 40,
+      x: 0,
+      y: 40,
+      toJSON: () => undefined
+    })
+    const handle = container.querySelector<HTMLButtonElement>('[aria-label="Reorder Beta"]')!
+    handle.setPointerCapture = vi.fn()
+    handle.hasPointerCapture = vi.fn(() => true)
+    handle.releasePointerCapture = vi.fn()
+
+    dispatchPointer(handle, 'pointerdown', 70)
+    dispatchPointer(handle, 'pointermove', 66)
+    expect(rows[1]!.className).not.toContain('ring-primary/30')
+    dispatchPointer(handle, 'pointermove', 0)
+    expect(rows[1]!.className).toContain('ring-primary/30')
+    expect(rows[0]!.querySelector('.-top-px')).not.toBeNull()
+    expect(rows.every((row) => row.style.transform === '')).toBe(true)
+
+    firstBounds.mockReturnValue({
+      top: 40,
+      bottom: 80,
+      left: 0,
+      right: 240,
+      width: 240,
+      height: 40,
+      x: 0,
+      y: 40,
+      toJSON: () => undefined
+    })
+    dispatchPointer(handle, 'pointermove', 0)
+    expect(rows[0]!.querySelector('.-top-px')).not.toBeNull()
+
+    await act(async () => dispatchPointer(handle, 'pointerup', 0))
+    expect(reorder).toHaveBeenCalledWith({ tagIds: ['tag-b', 'tag-a'] })
+    expect(handle.releasePointerCapture).toHaveBeenCalledWith(1)
   })
 })

--- a/src/renderer/src/pages/settings/TagsPanel.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.tsx
@@ -1,8 +1,29 @@
 /* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5 */
-/* Hallmark · component: Tag master-detail · genre: modern-minimal · tone: technical/utilitarian · theme: project tokens · contrast: pass · slop: pass */
+/* Hallmark · component: Tag master-detail + reorder · genre: modern-minimal · tone: technical/utilitarian
+ * states: default · hover · focus · active · disabled · loading · error · success
+ * theme: project tokens · contrast: pass · slop: pass
+ */
 import { AlertDialog, Dialog } from 'radix-ui'
-import { ChevronDown, Pencil, Plus, ScrollText, Search, Trash2, Users, X } from 'lucide-react'
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import {
+  ChevronDown,
+  GripVertical,
+  LockKeyhole,
+  Pencil,
+  Plus,
+  ScrollText,
+  Search,
+  Trash2,
+  Users,
+  X
+} from 'lucide-react'
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent
+} from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -46,6 +67,17 @@ type TagResourceRow = TagResourceRef & {
 }
 
 type TagDraft = { name: string; iconKey: TagIconKey; colorKey: TagColorKey }
+type CustomTagView = Extract<TagView, { name: string }>
+type TagDropTarget = { tagId: string; edge: 'before' | 'after' }
+type TagDropZone = { tagId: string; top: number; bottom: number }
+type TagPointerDrag = {
+  pointerId: number
+  tagId: string
+  startY: number
+  active: boolean
+  dropZones: TagDropZone[]
+  target?: TagDropTarget
+}
 const EMPTY_DRAFT: TagDraft = { name: '', iconKey: 'tag', colorKey: 'blue' }
 
 const resourceTypeLabel = (
@@ -95,6 +127,7 @@ const TagsPanel = ({
   const createTag = useTagStore((state) => state.create)
   const updateTag = useTagStore((state) => state.update)
   const deleteTag = useTagStore((state) => state.delete)
+  const reorderTags = useTagStore((state) => state.reorder)
   const setAssignment = useTagStore((state) => state.setAssignment)
   const loadTags = useTagStore((state) => state.load)
   const skills = useSettingsStore((state) => state.skills)
@@ -123,6 +156,12 @@ const TagsPanel = ({
   const [assignmentError, setAssignmentError] = useState<string>()
   const [removingResourceKey, setRemovingResourceKey] = useState<string>()
   const [collapsed, setCollapsed] = useState<Partial<Record<TagResourceType, boolean>>>({})
+  const [reorderBusy, setReorderBusy] = useState(false)
+  const [reorderError, setReorderError] = useState<string>()
+  const [reorderAnnouncement, setReorderAnnouncement] = useState('')
+  const [draggedTagId, setDraggedTagId] = useState<string>()
+  const [tagDropTarget, setTagDropTarget] = useState<TagDropTarget>()
+  const tagPointerDragRef = useRef<TagPointerDrag | undefined>(undefined)
 
   useEffect(() => {
     if (status === 'idle') void loadTags()
@@ -269,6 +308,93 @@ const TagsPanel = ({
     }
   }
 
+  const customTags = tags.filter((tag): tag is CustomTagView => !('systemKey' in tag))
+  const finishTagDrag = (): void => {
+    tagPointerDragRef.current = undefined
+    setDraggedTagId(undefined)
+    setTagDropTarget(undefined)
+  }
+  const showTagDropTarget = (next?: TagDropTarget): void => {
+    const drag = tagPointerDragRef.current
+    if (!drag) return
+    if (drag.target?.tagId === next?.tagId && drag.target?.edge === next?.edge) return
+    drag.target = next
+    setTagDropTarget(next)
+  }
+  const moveTag = async (
+    tagId: string,
+    targetTagId: string,
+    edge: TagDropTarget['edge']
+  ): Promise<void> => {
+    if (reorderBusy) return
+    const fromIndex = customTags.findIndex((tag) => tag.id === tagId)
+    const targetIndex = customTags.findIndex((tag) => tag.id === targetTagId)
+    if (fromIndex < 0 || targetIndex < 0) return
+    let insertionIndex = targetIndex + (edge === 'after' ? 1 : 0)
+    if (fromIndex < insertionIndex) insertionIndex -= 1
+    if (insertionIndex === fromIndex) return
+    const ordered = [...customTags]
+    const [moved] = ordered.splice(fromIndex, 1)
+    if (!moved) return
+    ordered.splice(insertionIndex, 0, moved)
+    setReorderBusy(true)
+    setReorderError(undefined)
+    try {
+      await reorderTags({ tagIds: ordered.map((tag) => tag.id) })
+      setReorderAnnouncement(
+        t('Moved {{tag}} to position {{position}}.', {
+          tag: moved.name,
+          position: insertionIndex + 2
+        })
+      )
+    } catch {
+      setReorderError(t('Could not reorder Tags. Try again.'))
+    } finally {
+      setReorderBusy(false)
+    }
+  }
+  const moveTagPointer = (event: ReactPointerEvent<HTMLButtonElement>): void => {
+    const drag = tagPointerDragRef.current
+    if (!drag || drag.pointerId !== event.pointerId) return
+    if (!drag.active) {
+      if (Math.abs(event.clientY - drag.startY) < 6) return
+      drag.active = true
+      setDraggedTagId(drag.tagId)
+    }
+    event.preventDefault()
+    const target = drag.dropZones.reduce<{ zone: TagDropZone; distance: number } | undefined>(
+      (closest, zone) => {
+        const distance =
+          event.clientY < zone.top
+            ? zone.top - event.clientY
+            : event.clientY > zone.bottom
+              ? event.clientY - zone.bottom
+              : 0
+        return !closest || distance < closest.distance ? { zone, distance } : closest
+      },
+      undefined
+    )?.zone
+    if (!target) {
+      showTagDropTarget()
+      return
+    }
+    showTagDropTarget({
+      tagId: target.tagId,
+      edge: event.clientY >= target.top + (target.bottom - target.top) / 2 ? 'after' : 'before'
+    })
+  }
+  const endTagPointer = (event: ReactPointerEvent<HTMLButtonElement>): void => {
+    const drag = tagPointerDragRef.current
+    if (!drag || drag.pointerId !== event.pointerId) return
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+    if (drag.active && drag.target) {
+      void moveTag(drag.tagId, drag.target.tagId, drag.target.edge)
+    }
+    finishTagDrag()
+  }
+
   return (
     <div className="flex min-h-full flex-col p-5">
       <div className="mb-4 flex items-start justify-between gap-4">
@@ -293,33 +419,126 @@ const TagsPanel = ({
         data-slot="tag-master-detail"
         className="grid min-h-[420px] flex-1 grid-cols-1 overflow-hidden rounded-lg border border-border md:grid-cols-[15rem_minmax(0,1fr)]"
       >
-        <aside className="border-b border-border bg-background p-2 md:border-r md:border-b-0">
-          {tags.map((tag) => (
-            <Button
-              key={tag.id}
-              type="button"
-              variant="ghost"
-              size="lg"
-              data-slot="tag-list-row"
-              aria-current={tag.id === currentSelectedId ? 'page' : undefined}
-              onClick={() => {
-                setSelectedId(tag.id)
-                onSelectedTagChange?.(tag.id)
-              }}
-              className={cn(
-                'w-full min-w-0 cursor-pointer justify-start gap-2 px-2 text-left font-normal hover:bg-muted',
-                tag.id === currentSelectedId && 'bg-muted font-medium'
-              )}
-            >
-              <TagBadge tag={tag} className="min-w-0" />
-              <span
-                data-slot="tag-list-count"
-                className="ml-auto min-w-5 shrink-0 text-right text-xs tabular-nums text-muted-foreground"
-              >
-                {counts.get(tag.id) ?? 0}
-              </span>
-            </Button>
-          ))}
+        <aside
+          className="border-b border-border bg-background p-2 md:border-r md:border-b-0"
+          aria-busy={reorderBusy || undefined}
+        >
+          {reorderError ? (
+            <p role="alert" className="mb-2 px-2 text-xs text-destructive">
+              {reorderError}
+            </p>
+          ) : null}
+          <p className="sr-only" aria-live="polite" aria-atomic="true">
+            {reorderAnnouncement}
+          </p>
+          <ol>
+            {tags.map((tag) => {
+              const customIndex = customTags.findIndex((candidate) => candidate.id === tag.id)
+              const dropBefore = tagDropTarget?.tagId === tag.id && tagDropTarget.edge === 'before'
+              const dropAfter = tagDropTarget?.tagId === tag.id && tagDropTarget.edge === 'after'
+              return (
+                <li
+                  key={tag.id}
+                  data-reorderable-tag-id={'systemKey' in tag ? undefined : tag.id}
+                  className={cn(
+                    'relative flex min-w-0 items-center',
+                    draggedTagId === tag.id &&
+                      'rounded-md bg-muted/60 ring-1 ring-primary/30 ring-inset'
+                  )}
+                >
+                  {dropBefore || dropAfter ? (
+                    <span
+                      aria-hidden="true"
+                      className={cn(
+                        'pointer-events-none absolute right-1 left-1 z-10 h-0.5 rounded-full bg-primary',
+                        dropBefore ? '-top-px' : '-bottom-px'
+                      )}
+                    />
+                  ) : null}
+                  {'systemKey' in tag ? (
+                    <span
+                      className="flex size-9 shrink-0 items-center justify-center text-muted-foreground/60 [@media(pointer:coarse)]:size-11"
+                      role="img"
+                      aria-label={t('System Tags stay first')}
+                      title={t('System Tags stay first')}
+                    >
+                      <LockKeyhole className="size-3.5" aria-hidden="true" />
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      disabled={reorderBusy}
+                      className="flex size-9 shrink-0 touch-none cursor-grab items-center justify-center rounded-md text-muted-foreground select-none hover:bg-muted hover:text-foreground active:cursor-grabbing focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 [@media(pointer:coarse)]:size-11"
+                      aria-label={t('Reorder {{tag}}', { tag: tag.name })}
+                      title={t('Drag or use arrow keys to reorder')}
+                      onPointerCancel={finishTagDrag}
+                      onPointerDown={(event) => {
+                        if (event.isPrimary === false || event.button !== 0 || reorderBusy) return
+                        event.currentTarget.setPointerCapture?.(event.pointerId)
+                        tagPointerDragRef.current = {
+                          pointerId: event.pointerId,
+                          tagId: tag.id,
+                          startY: event.clientY,
+                          active: false,
+                          dropZones: Array.from(
+                            event.currentTarget
+                              .closest('ol')
+                              ?.querySelectorAll<HTMLElement>('[data-reorderable-tag-id]') ?? []
+                          )
+                            .filter((row) => row.dataset.reorderableTagId !== tag.id)
+                            .flatMap((row) => {
+                              const tagId = row.dataset.reorderableTagId
+                              if (!tagId) return []
+                              const bounds = row.getBoundingClientRect()
+                              return [{ tagId, top: bounds.top, bottom: bounds.bottom }]
+                            })
+                        }
+                      }}
+                      onPointerMove={moveTagPointer}
+                      onPointerUp={endTagPointer}
+                      onKeyDown={(event) => {
+                        if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return
+                        event.preventDefault()
+                        const target = customTags[customIndex + (event.key === 'ArrowUp' ? -1 : 1)]
+                        if (target) {
+                          void moveTag(
+                            tag.id,
+                            target.id,
+                            event.key === 'ArrowUp' ? 'before' : 'after'
+                          )
+                        }
+                      }}
+                    >
+                      <GripVertical className="size-4" aria-hidden="true" />
+                    </button>
+                  )}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="lg"
+                    data-slot="tag-list-row"
+                    aria-current={tag.id === currentSelectedId ? 'page' : undefined}
+                    onClick={() => {
+                      setSelectedId(tag.id)
+                      onSelectedTagChange?.(tag.id)
+                    }}
+                    className={cn(
+                      'min-w-0 flex-1 cursor-pointer justify-start gap-2 px-2 text-left font-normal hover:bg-muted',
+                      tag.id === currentSelectedId && 'bg-muted font-medium'
+                    )}
+                  >
+                    <TagBadge tag={tag} className="min-w-0" />
+                    <span
+                      data-slot="tag-list-count"
+                      className="ml-auto min-w-5 shrink-0 text-right text-xs tabular-nums text-muted-foreground"
+                    >
+                      {counts.get(tag.id) ?? 0}
+                    </span>
+                  </Button>
+                </li>
+              )
+            })}
+          </ol>
         </aside>
 
         <section

--- a/src/renderer/src/stores/tag-store.test.ts
+++ b/src/renderer/src/stores/tag-store.test.ts
@@ -160,4 +160,72 @@ describe('tag store', () => {
     expect(snapshot).toHaveBeenCalledOnce()
     expect(useTagStore.getState()).toMatchObject({ revision: 2, assignments: [] })
   })
+
+  it('optimistically reorders custom Tags while keeping the system Tag first', async () => {
+    const tags: TagSnapshot['tags'] = [
+      ...favoriteSnapshot().tags,
+      {
+        id: 'tag-a',
+        name: 'A',
+        iconKey: 'tag',
+        colorKey: 'blue',
+        createdAt: 2,
+        updatedAt: 2
+      },
+      {
+        id: 'tag-b',
+        name: 'B',
+        iconKey: 'tag',
+        colorKey: 'green',
+        createdAt: 3,
+        updatedAt: 3
+      }
+    ]
+    let resolveReorder: ((snapshot: TagSnapshot) => void) | undefined
+    const pending = new Promise<TagSnapshot>((resolve) => {
+      resolveReorder = resolve
+    })
+    const reorder = vi.fn(() => pending)
+    setTagsApi({ reorder })
+    useTagStore.setState({ ...favoriteSnapshot(1), tags, status: 'ready' })
+
+    const mutation = useTagStore.getState().reorder({ tagIds: ['tag-b', 'tag-a'] })
+    expect(useTagStore.getState().tags.map((tag) => tag.id)).toEqual([
+      'tag-favorite',
+      'tag-b',
+      'tag-a'
+    ])
+    resolveReorder?.({ ...favoriteSnapshot(2), tags: [tags[0]!, tags[2]!, tags[1]!] })
+    await mutation
+    expect(reorder).toHaveBeenCalledWith({ tagIds: ['tag-b', 'tag-a'] })
+    expect(useTagStore.getState().revision).toBe(2)
+  })
+
+  it('reloads the authoritative Tag order after a failed optimistic reorder', async () => {
+    const authoritative = favoriteSnapshot(2)
+    const snapshot = vi.fn().mockResolvedValue(authoritative)
+    setTagsApi({
+      reorder: vi.fn().mockRejectedValue(new Error('failed')),
+      snapshot
+    })
+    useTagStore.setState({
+      ...favoriteSnapshot(1),
+      status: 'ready',
+      tags: [
+        ...favoriteSnapshot().tags,
+        {
+          id: 'tag-a',
+          name: 'A',
+          iconKey: 'tag',
+          colorKey: 'blue',
+          createdAt: 2,
+          updatedAt: 2
+        }
+      ]
+    })
+
+    await expect(useTagStore.getState().reorder({ tagIds: ['tag-a'] })).rejects.toThrow('failed')
+    expect(snapshot).toHaveBeenCalledOnce()
+    expect(useTagStore.getState()).toMatchObject(authoritative)
+  })
 })

--- a/src/renderer/src/stores/tag-store.ts
+++ b/src/renderer/src/stores/tag-store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 
 import type {
   CreateTagRequest,
+  ReorderTagsRequest,
   SetTagAssignmentRequest,
   TagSnapshot,
   TagResourceType,
@@ -23,6 +24,7 @@ type TagStore = TagSnapshot & {
   create(request: CreateTagRequest): Promise<string>
   update(request: UpdateTagRequest): Promise<void>
   delete(id: string): Promise<void>
+  reorder(request: ReorderTagsRequest): Promise<void>
   setAssignment(request: SetTagAssignmentRequest): Promise<void>
   listen(): () => void
 }
@@ -110,6 +112,28 @@ export const useTagStore = create<TagStore>((set, get) => ({
     const snapshot = await window.api.tags.delete({ id })
     loadSequence += 1
     set({ ...stateFromSnapshot(snapshot), error: undefined })
+  },
+  reorder: async (request) => {
+    const before = get().tags
+    const byId = new Map(before.map((tag) => [tag.id, tag]))
+    set({
+      tags: [
+        ...before.filter((tag) => 'systemKey' in tag),
+        ...request.tagIds.flatMap((id) => {
+          const tag = byId.get(id)
+          return tag && !('systemKey' in tag) ? [tag] : []
+        })
+      ]
+    })
+    try {
+      const snapshot = await window.api.tags.reorder(request)
+      loadSequence += 1
+      set({ ...stateFromSnapshot(snapshot), error: undefined })
+    } catch (error) {
+      set({ tags: before })
+      await get().load()
+      throw error
+    }
   },
   setAssignment: async (request) => {
     const before = get().assignments

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -208,6 +208,7 @@ describe('renderer contract catalog', () => {
       'sessions.deleteSession',
       'tags.create',
       'tags.delete',
+      'tags.reorder',
       'tags.setAssignment',
       'tags.snapshot',
       'tags.update'
@@ -222,6 +223,7 @@ describe('renderer contract catalog', () => {
       'sessions:delete-session',
       'tags:create',
       'tags:delete',
+      'tags:reorder',
       'tags:set-assignment',
       'tags:snapshot',
       'tags:update'

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -271,7 +271,7 @@ export const RENDERER_CONTRACT_GROUPS = Object.freeze([
   ]),
   group('tags', 'tags', [
     ['onChanged', 'tags:changed', EVENT], ['create', 'tags:create', WEB, undefined, undefined, RUNTIME_VALIDATED],
-    ['delete', 'tags:delete', WEB, undefined, undefined, RUNTIME_VALIDATED], ['setAssignment', 'tags:set-assignment', WEB, undefined, undefined, RUNTIME_VALIDATED],
+    ['delete', 'tags:delete', WEB, undefined, undefined, RUNTIME_VALIDATED], ['reorder', 'tags:reorder', WEB, undefined, undefined, RUNTIME_VALIDATED], ['setAssignment', 'tags:set-assignment', WEB, undefined, undefined, RUNTIME_VALIDATED],
     ['snapshot', 'tags:snapshot', WEB, undefined, undefined, RUNTIME_VALIDATED], ['update', 'tags:update', WEB, undefined, undefined, RUNTIME_VALIDATED],
   ]),
   group('remote-access', 'remoteAccess', [

--- a/src/shared/tags.test.ts
+++ b/src/shared/tags.test.ts
@@ -53,4 +53,13 @@ describe('tag application command contracts', () => {
       ])
     ).toThrow()
   })
+
+  it('accepts only a strict ordered Tag id list', () => {
+    expect(tagApplicationCommandContracts.reorder.args.parse([{ tagIds: ['a', 'b'] }])).toEqual([
+      { tagIds: ['a', 'b'] }
+    ])
+    expect(() =>
+      tagApplicationCommandContracts.reorder.args.parse([{ tagIds: ['a'], extra: true }])
+    ).toThrow()
+  })
 })

--- a/src/shared/tags.ts
+++ b/src/shared/tags.ts
@@ -92,6 +92,7 @@ export const deleteTagRequestSchema = z.object({ id: z.string().min(1) }).strict
 export const setTagAssignmentRequestSchema = tagResourceRefSchema
   .extend({ tagId: z.string().min(1), assigned: z.boolean() })
   .strict()
+export const reorderTagsRequestSchema = z.object({ tagIds: z.array(z.string().min(1)) }).strict()
 
 export type TagResourceType = z.infer<typeof tagResourceTypeSchema>
 export type TagIconKey = z.infer<typeof tagIconKeySchema>
@@ -104,6 +105,7 @@ export type CreateTagRequest = z.infer<typeof createTagRequestSchema>
 export type UpdateTagRequest = z.infer<typeof updateTagRequestSchema>
 export type DeleteTagRequest = z.infer<typeof deleteTagRequestSchema>
 export type SetTagAssignmentRequest = z.infer<typeof setTagAssignmentRequestSchema>
+export type ReorderTagsRequest = z.infer<typeof reorderTagsRequestSchema>
 export type TagsChangedEvent = Readonly<{ revision: number }>
 
 export const tagApplicationCommandContracts = Object.freeze({
@@ -121,6 +123,10 @@ export const tagApplicationCommandContracts = Object.freeze({
   ),
   delete: defineApplicationCommandContract(
     validationCodec(z.tuple([deleteTagRequestSchema])),
+    validationCodec(tagSnapshotSchema)
+  ),
+  reorder: defineApplicationCommandContract(
+    validationCodec(z.tuple([reorderTagsRequestSchema])),
     validationCodec(tagSnapshotSchema)
   ),
   setAssignment: defineApplicationCommandContract(

--- a/src/shared/web-api-map.generated.ts
+++ b/src/shared/web-api-map.generated.ts
@@ -249,6 +249,7 @@ export const WEB_INVOKE_CHANNELS = {
   'storage.validateDataRoot': 'storage:validate-data-root',
   'tags.create': 'tags:create',
   'tags.delete': 'tags:delete',
+  'tags.reorder': 'tags:reorder',
   'tags.setAssignment': 'tags:set-assignment',
   'tags.snapshot': 'tags:snapshot',
   'tags.update': 'tags:update',


### PR DESCRIPTION
## Problem

Tags had a deterministic name-based display order but users could not control it. Resources with multiple Tags therefore could not present those Tags in a user-defined priority order.

## Proposed change

- Persist one global Tag order with a unique integer sortOrder.
- Keep Favorites fixed at position 0 and reject any reorder payload containing system Tags or an incomplete custom Tag set.
- Append new Tags, compact positions after deletion, and persist reorders transactionally.
- Add pointer/touch drag handles with a movement threshold, insertion feedback, and pointer capture.
- Add Arrow Up and Arrow Down keyboard reordering, retained focus, live announcements, busy state, and visible failure recovery.
- Make resource Tag badges inherit the authoritative global snapshot order.

The interaction follows the WAI-ARIA rearrangeable listbox guidance for keyboard movement and announcements, and MDN pointer-capture guidance for robust pointer drags.

## Scope and non-goals

- Global ordering only; no per-resource Tag order.
- No Tag assignment or resource file-format changes.
- No new dependency and no new persistent enum or business-state value.

## Data persistence

Adds Tag.sortOrder and migration 0012_tag_ordering. Favorites owns 0; custom Tags use contiguous positions starting at 1. Reorder writes use temporary negative positions followed by final positive positions in one transaction to preserve the unique constraint.

## Historical compatibility

Existing databases are backfilled in their current visible order: Favorites first, then custom Tags by nameKey and id. Existing TagAssignment rows and resource files are unchanged. Downgrading a migrated database remains outside the supported migration policy.

## Acceptance and validation

- Targeted Tag contracts, repository, service, store, migration, and Settings panel tests pass.
- Database migration and backup suites pass.
- Renderer/preload/application-command contract suites pass.
- Four-locale i18n resource guard passes.
- Node and renderer type checks pass.
- ESLint, generated database schema check, generated Web API map check, and git diff check pass.
- Full npm test intentionally not run; PR CI owns the complete suite.

## Review focus

- Migration backfill and unique-order transaction behavior.
- System Tag immovability and exact-set validation.
- Pointer, keyboard, focus, and rollback behavior in TagsPanel.