### PR TITLE
fix(acp-runtime): stream runtime events incrementally

### DIFF
--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -337,6 +337,61 @@ describe('AcpRuntimeCoordinator', () => {
     expect(incrementalPublicationConfigured).toBe(false)
   })
 
+  it('retains snapshot-only events after a new runtime generation adopts the session', async () => {
+    const retirement = createDeferred<void>()
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const snapshots: AcpStateSnapshot[] = []
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId: created.length === 0 ? 'codex' : 'claude-code',
+          sessionIds: [`agent-session-${created.length + 1}`],
+          callbacks
+        })
+        created.push(fake)
+        return fake.runtime
+      },
+      { onStateChanged: (snapshot) => snapshots.push(snapshot) }
+    )
+
+    const session = await coordinator.createSession()
+    created[0].emitEvent({
+      id: 'old-owner-message',
+      timestamp: 1,
+      kind: 'message',
+      level: 'info',
+      sessionId: session.sessionId,
+      role: 'assistant',
+      text: 'published before adoption'
+    })
+    expect(snapshots.at(-1)?.events.map((event) => event.id)).toEqual([
+      expect.stringMatching(runtimeEventId(1, 'old-owner-message'))
+    ])
+
+    created[0].emitState({
+      promptInFlight: true,
+      promptInFlightSessionIds: [session.sessionId]
+    })
+    created[0].requestRetirement.mockReturnValue(retirement.promise)
+    const switchRequest = coordinator.requestAgentFrameworkSwitch()
+    await coordinator.connect()
+    const resumeRequest = coordinator.resumeSession({
+      sessionId: session.sessionId,
+      cwd: '/workspace',
+      previousFrameworkId: 'codex'
+    })
+    await vi.waitFor(() => expect(created[1].resumeSession).toHaveBeenCalledOnce())
+    created[0].emitState({ promptInFlight: false, promptInFlightSessionIds: [] })
+    await resumeRequest
+
+    expect(coordinator.getSnapshot().events.map((event) => event.id)).toContainEqual(
+      expect.stringMatching(runtimeEventId(1, 'old-owner-message'))
+    )
+
+    retirement.resolve()
+    await switchRequest
+  })
+
   it('does not capture the process Active backend for a Session without an owning runtime', async () => {
     const created: ReturnType<typeof createFakeRuntime>[] = []
     const coordinator = new AcpRuntimeCoordinator((callbacks) => {

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -320,6 +320,23 @@ describe('AcpRuntimeCoordinator', () => {
     expect(coordinator.getSnapshot().revision).toBe(2)
   })
 
+  it('keeps snapshot publication available when no incremental event adapter is configured', () => {
+    let incrementalPublicationConfigured = true
+    new AcpRuntimeCoordinator(
+      (callbacks) => {
+        incrementalPublicationConfigured = callbacks.onEvent !== undefined
+        return createFakeRuntime({
+          frameworkId: 'claude-code',
+          sessionIds: ['session-1'],
+          callbacks
+        }).runtime
+      },
+      { onStateChanged: vi.fn() }
+    )
+
+    expect(incrementalPublicationConfigured).toBe(false)
+  })
+
   it('does not capture the process Active backend for a Session without an owning runtime', async () => {
     const created: ReturnType<typeof createFakeRuntime>[] = []
     const coordinator = new AcpRuntimeCoordinator((callbacks) => {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -1,6 +1,7 @@
 import type { ActiveSession } from '@agentclientprotocol/sdk'
 import { randomUUID } from 'node:crypto'
 
+import { MAX_ACP_RUNTIME_EVENTS } from '../../shared/acp'
 import type {
   AcpCancelPromptRequest,
   AcpCompactSessionRequest,
@@ -35,7 +36,6 @@ import {
 } from '../delegation/execution-port'
 import type { ShutdownStepOutcome } from '../lifecycle-shutdown'
 
-const MAX_EVENTS = 500
 const QUIT_PREPARATION_TIMEOUT_MS = 4_000
 
 const isOwnershipScopedControlEvent = (event: AcpRuntimeEvent): boolean =>
@@ -213,7 +213,7 @@ class AcpRuntimeCoordinator {
       ...this.applicationEvents
     ]
       .sort((left, right) => left.timestamp - right.timestamp)
-      .slice(-MAX_EVENTS)
+      .slice(-MAX_ACP_RUNTIME_EVENTS)
     const sessionIds = Array.from(
       new Set(
         snapshots.flatMap(({ runtime, snapshot }) => this.visibleSessionIds(runtime, snapshot))
@@ -676,8 +676,8 @@ class AcpRuntimeCoordinator {
       }
     }
     this.applicationEvents.push(event)
-    if (this.applicationEvents.length > MAX_EVENTS) {
-      this.applicationEvents.splice(0, this.applicationEvents.length - MAX_EVENTS)
+    if (this.applicationEvents.length > MAX_ACP_RUNTIME_EVENTS) {
+      this.applicationEvents.splice(0, this.applicationEvents.length - MAX_ACP_RUNTIME_EVENTS)
     }
     this.callbacks.onEvent?.(event)
     this.callbacks.onStateChanged?.(this.getSnapshot())
@@ -1433,10 +1433,14 @@ class AcpRuntimeCoordinator {
     const runtime = this.createRuntime(
       {
         onStateChanged: (snapshot) => this.handleRuntimeState(runtime, snapshot),
-        onEvent: (event) => {
-          if (!this.shouldPublishEvent(runtime, event)) return
-          this.callbacks.onEvent?.({ ...event, id: this.eventId(runtime, event.id) })
-        },
+        ...(this.callbacks.onEvent
+          ? {
+              onEvent: (event: AcpRuntimeEvent) => {
+                if (!this.shouldPublishEvent(runtime, event)) return
+                this.callbacks.onEvent?.({ ...event, id: this.eventId(runtime, event.id) })
+              }
+            }
+          : {}),
         onPermissionRequest: (request) => {
           this.permissionRuntimes.set(request.requestId, runtime)
           this.callbacks.onPermissionRequest?.(request)

--- a/src/main/acp/runtime-publication-owner.test.ts
+++ b/src/main/acp/runtime-publication-owner.test.ts
@@ -59,7 +59,7 @@ describe('AcpRuntimePublicationOwner', () => {
     }
   })
 
-  it('coalesces assistant text state while publishing every event immediately', () => {
+  it('publishes assistant text incrementally without scheduling snapshot delivery', () => {
     const order: string[] = []
     let releaseScheduledState: (() => void) | undefined
     const owner = new AcpRuntimePublicationOwner({
@@ -81,7 +81,38 @@ describe('AcpRuntimePublicationOwner', () => {
 
     expect(order).toEqual(['event:one', 'event:two'])
     releaseScheduledState?.()
-    expect(order).toEqual(['event:one', 'event:two', 'state:2'])
+    expect(order).toEqual(['event:one', 'event:two'])
+  })
+
+  it('publishes all runtime events incrementally until lifecycle state is explicitly requested', () => {
+    let releaseScheduledState: (() => void) | undefined
+    const onEvent = vi.fn()
+    const onStateChanged = vi.fn()
+    const owner = new AcpRuntimePublicationOwner({
+      snapshotOwner: new AcpRuntimeSnapshotOwner('/workspace'),
+      interactions: new AcpSessionInteractionOwner(),
+      snapshotProjection: createProjection,
+      callbacks: { onEvent, onStateChanged },
+      scheduleStatePublication: (publish) => {
+        releaseScheduledState = publish
+        return () => (releaseScheduledState = undefined)
+      }
+    })
+
+    owner.pushEvent({ kind: 'thought', level: 'info', role: 'assistant', text: 'one' })
+    owner.pushEvent({ kind: 'message', level: 'info', role: 'assistant', text: 'two' })
+    owner.pushEvent({ kind: 'tool', level: 'info', toolCallId: 'tool-1', status: 'in_progress' })
+    owner.pushEvent({ kind: 'tool', level: 'info', toolCallId: 'tool-1', status: 'completed' })
+    owner.pushEvent({ kind: 'stop', level: 'info', text: 'end_turn' })
+    owner.pushEvent({ kind: 'error', level: 'error', text: 'provider failed' })
+    releaseScheduledState?.()
+
+    expect(onEvent).toHaveBeenCalledTimes(6)
+    expect(onStateChanged).not.toHaveBeenCalled()
+
+    owner.emitState()
+    expect(onStateChanged).toHaveBeenCalledOnce()
+    expect(onStateChanged.mock.calls[0]?.[0].events).toHaveLength(6)
   })
 
   it('coalesces streamed assistant thought state', () => {
@@ -139,7 +170,7 @@ describe('AcpRuntimePublicationOwner', () => {
     expect([...visibleChunks.values()].join('')).toBe(chunks.join(''))
   })
 
-  it('flushes pending assistant text at a tool boundary without losing event order', () => {
+  it('keeps incremental event order across a tool boundary', () => {
     const order: string[] = []
     const owner = new AcpRuntimePublicationOwner({
       snapshotOwner: new AcpRuntimeSnapshotOwner('/workspace'),
@@ -155,7 +186,7 @@ describe('AcpRuntimePublicationOwner', () => {
     owner.pushEvent({ kind: 'message', level: 'info', role: 'assistant', text: 'before' })
     owner.pushEvent({ kind: 'tool', level: 'info', toolCallId: 'tool-1', status: 'in_progress' })
 
-    expect(order).toEqual(['event:message', 'event:tool', 'state:2'])
+    expect(order).toEqual(['event:message', 'event:tool'])
   })
 
   it('coalesces progressive tool output but publishes completion immediately', () => {
@@ -289,7 +320,7 @@ describe('AcpRuntimePublicationOwner', () => {
     expect(statePublications).toBeLessThanOrEqual(3)
   })
 
-  it('publishes an event only after append hooks and before the resulting state', () => {
+  it('publishes an event after append hooks and before explicitly requested state', () => {
     const order: string[] = []
     const snapshotOwner = new AcpRuntimeSnapshotOwner('/workspace')
     const owner = new AcpRuntimePublicationOwner({
@@ -304,13 +335,15 @@ describe('AcpRuntimePublicationOwner', () => {
 
     owner.pushEvent({ kind: 'message', level: 'info', text: 'hello' }, () => order.push('appended'))
 
+    expect(order).toEqual(['appended', 'event'])
+    owner.emitState()
     expect(order).toEqual(['appended', 'event', 'state'])
     expect(owner.getSnapshot().events).toEqual([
       expect.objectContaining({ id: 'acp-event-1', kind: 'message', text: 'hello' })
     ])
   })
 
-  it('keeps the established permission event-state-callback-state order', () => {
+  it('publishes permission event and callback before one lifecycle state', () => {
     const order: string[] = []
     const request: AcpPermissionRequest = {
       requestId: 'request-1',
@@ -332,7 +365,7 @@ describe('AcpRuntimePublicationOwner', () => {
 
     owner.publishPermissionRequest(request)
 
-    expect(order).toEqual(['event', 'state', 'permission', 'state'])
+    expect(order).toEqual(['event', 'permission', 'state'])
     expect(owner.getSnapshot().events[0]).toMatchObject({
       kind: 'permission',
       sessionId: 'session-1',

--- a/src/main/acp/runtime-publication-owner.ts
+++ b/src/main/acp/runtime-publication-owner.ts
@@ -101,7 +101,14 @@ class AcpRuntimePublicationOwner {
       (acpRuntimeEventsPublished.get(runtimeEvent.kind) ?? 0) + 1
     )
     this.options.callbacks.onEvent?.(runtimeEvent)
-    if (this.isCoalescibleRuntimeEvent(runtimeEvent)) {
+    // Incremental adapters receive every event in order. State is published only by the explicit
+    // lifecycle mutations that follow this call; rebuilding the retained window for this event
+    // would duplicate the same payload across IPC. Snapshot-only adapters retain the established
+    // coalesced-state fallback below.
+    if (this.options.callbacks.onEvent) return
+
+    const coalescible = this.isCoalescibleRuntimeEvent(runtimeEvent)
+    if (coalescible) {
       this.coalescedEvents += 1
       if (this.coalescedEvents >= MAX_COALESCED_EVENTS) {
         this.emitState()

--- a/src/main/acp/runtime-snapshot-owner.ts
+++ b/src/main/acp/runtime-snapshot-owner.ts
@@ -1,8 +1,12 @@
 import type { AcpRuntimeEvent, AcpStateSnapshot } from '../../shared/acp'
-import { getAcpRuntimeEventImage, MAX_ACP_SESSION_IMAGE_BYTES } from '../../shared/acp'
+import {
+  getAcpRuntimeEventImage,
+  MAX_ACP_RUNTIME_EVENTS,
+  MAX_ACP_SESSION_IMAGE_BYTES
+} from '../../shared/acp'
 import { capToolDetailText, sanitizeToolContent } from '../../shared/tool-detail-sanitizer'
 
-const ACP_RUNTIME_EVENT_RETENTION_LIMIT = 500
+const ACP_RUNTIME_EVENT_RETENTION_LIMIT = MAX_ACP_RUNTIME_EVENTS
 // Amortized eviction: trim only after a full cap of slack accumulates, so steady-state appends are
 // a plain push instead of an O(n) array rebuild per event. Reads always go through the last
 // ACP_RUNTIME_EVENT_RETENTION_LIMIT window, keeping the observable retention bound exact.

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1728,6 +1728,59 @@ describe('ACP runtime provider prompt acceptance', () => {
   )
 })
 
+describe('ACP runtime incremental publication routes', () => {
+  it.each([
+    ['Claude Code', claudeCodeFramework, 'claude-anthropic', 'claude-code:provider-a'],
+    ['OpenCode', opencodeFramework, 'opencode-openai', 'opencode:provider-a'],
+    ['Codex Responses', codexFramework, 'codex-responses', 'codex:provider-a'],
+    ['Codex Bridge', codexFramework, 'codex-bridge', 'codex:provider-a']
+  ] as const)(
+    'keeps %s tool and message updates on the incremental channel',
+    async (_name, framework, modelRoute, backendId) => {
+      const process = new FakeAgentProcess()
+      startFakeAgent(process, ['incremental-session'], {
+        toolForPrompt: () => ({
+          toolCallId: 'notebook-tool-1',
+          title: 'Notebook run'
+        }),
+        ...(framework.id === 'codex'
+          ? { modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent') }
+          : {})
+      })
+      const publicationOrder: string[] = []
+      const bridgeLease =
+        modelRoute === 'codex-bridge' ? createBackendLeaseHarness().lease : undefined
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        callbacks: {
+          onEvent: (event) => publicationOrder.push(`event:${event.kind}`),
+          onStateChanged: () => publicationOrder.push('state')
+        },
+        resolveBackend: () => ({
+          framework: { ...framework, spawn: () => asAgentProcess(process) },
+          backendId,
+          modelRoute,
+          executablePath: '/bin/agent',
+          env: {},
+          ...(bridgeLease ? { responsesBridgeLease: bridgeLease } : {})
+        })
+      })
+
+      const session = await runtime.createSession({ cwd: '/workspace' })
+      publicationOrder.length = 0
+      await runtime.sendPrompt({ sessionId: session.sessionId, text: 'Run the notebook.' })
+
+      const toolEventIndex = publicationOrder.indexOf('event:tool')
+      expect(toolEventIndex).toBeGreaterThanOrEqual(0)
+      expect(publicationOrder.slice(toolEventIndex, toolEventIndex + 2)).toEqual([
+        'event:tool',
+        'event:message'
+      ])
+    }
+  )
+})
+
 const PERMISSION_PROJECTION_FRAMEWORKS = [
   ['Claude Code', claudeCodeFramework, 'claude-anthropic', 'claude-code:provider-a'],
   ['OpenCode', opencodeFramework, 'opencode-openai', 'opencode:provider-a'],

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -549,6 +549,13 @@ describe('startWebHttpServer', () => {
       return url.toString()
     }
 
+    const staleSocketUrl = new URL(eventSocketUrl(0))
+    staleSocketUrl.searchParams.set('eventProtocol', String(WEB_EVENT_STREAM_PROTOCOL_VERSION - 1))
+    const staleSocket = new WebSocket(staleSocketUrl)
+    await expect(
+      new Promise<number>((resolve) => staleSocket.once('close', (code) => resolve(code)))
+    ).resolves.toBe(1002)
+
     const firstSocket = new WebSocket(eventSocketUrl(0))
     const firstMessage = new Promise<unknown>((resolve) =>
       firstSocket.once('message', (data) => resolve(JSON.parse(data.toString())))

--- a/src/renderer/src/lib/acp/runtime-event-subscription-owner.test.ts
+++ b/src/renderer/src/lib/acp/runtime-event-subscription-owner.test.ts
@@ -1,0 +1,79 @@
+import type { AcpRuntimeEvent } from '../../../../shared/acp'
+import { describe, expect, it, vi } from 'vitest'
+import { createRuntimeEventSubscriptionOwner } from './runtime-event-subscription-owner'
+
+const runtimeEvent = (index: number): AcpRuntimeEvent => ({
+  id: `runtime-1:acp-event-${index}`,
+  timestamp: index,
+  kind: 'message',
+  level: 'info',
+  role: 'assistant',
+  sessionId: 'session-1',
+  text: String(index)
+})
+
+describe('runtime event subscription owner', () => {
+  it('delivers a synchronous pre-subscription burst before bounding retained history', () => {
+    const owner = createRuntimeEventSubscriptionOwner()
+    const events = Array.from({ length: 600 }, (_, index) => runtimeEvent(index + 1))
+    for (const event of events) owner.observeEvent(event)
+
+    const delivered: AcpRuntimeEvent[] = []
+    owner.subscribe((batch) => delivered.push(...batch))
+    owner.observeInitialSnapshot(events.slice(100))
+
+    expect(delivered.map((event) => event.id)).toEqual(events.map((event) => event.id))
+    expect(owner.currentEvents()).toHaveLength(500)
+    expect(owner.currentEvents()[0]?.id).toBe('runtime-1:acp-event-101')
+  })
+
+  it('reconciles an initial snapshot with events that arrived while the pull was pending', () => {
+    const owner = createRuntimeEventSubscriptionOwner()
+    const listener = vi.fn<(events: readonly AcpRuntimeEvent[]) => void>()
+    const first = runtimeEvent(1)
+    const second = runtimeEvent(2)
+    owner.subscribe(listener)
+
+    owner.observeEvent(second)
+    owner.observeInitialSnapshot([first, second])
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener.mock.calls[0]?.[0]).toEqual([first, second])
+  })
+
+  it('deduplicates delayed snapshots without suppressing newer incremental events', () => {
+    const owner = createRuntimeEventSubscriptionOwner()
+    const delivered: AcpRuntimeEvent[] = []
+    owner.subscribe((batch) => delivered.push(...batch))
+    owner.observeInitialSnapshot([])
+
+    const events = Array.from({ length: 600 }, (_, index) => runtimeEvent(index + 1))
+    for (const event of events) owner.observeEvent(event)
+    owner.observeSnapshot(events.slice(0, 500))
+    owner.observeEvent(runtimeEvent(601))
+    owner.observeSnapshot(events.slice(100))
+
+    expect(delivered.map((event) => event.id)).toEqual([
+      ...events.map((event) => event.id),
+      'runtime-1:acp-event-601'
+    ])
+  })
+
+  it('unsubscribes listeners and replays only the retained window on remount', () => {
+    const owner = createRuntimeEventSubscriptionOwner()
+    owner.observeInitialSnapshot([])
+    const firstListener = vi.fn()
+    const remove = owner.subscribe(firstListener)
+    for (let index = 1; index <= 600; index += 1) owner.observeEvent(runtimeEvent(index))
+
+    remove()
+    owner.observeEvent(runtimeEvent(601))
+    const replayed: AcpRuntimeEvent[] = []
+    owner.subscribe((batch) => replayed.push(...batch))
+
+    expect(firstListener).toHaveBeenCalledTimes(600)
+    expect(replayed).toHaveLength(500)
+    expect(replayed[0]?.id).toBe('runtime-1:acp-event-102')
+    expect(replayed.at(-1)?.id).toBe('runtime-1:acp-event-601')
+  })
+})

--- a/src/renderer/src/lib/acp/runtime-event-subscription-owner.test.ts
+++ b/src/renderer/src/lib/acp/runtime-event-subscription-owner.test.ts
@@ -90,4 +90,16 @@ describe('runtime event subscription owner', () => {
     expect(replayed[0]?.id).toBe('runtime-1:acp-event-102')
     expect(replayed.at(-1)?.id).toBe('runtime-1:acp-event-601')
   })
+
+  it('bounds rolling snapshot history without an incremental subscriber', () => {
+    const owner = createRuntimeEventSubscriptionOwner()
+    const events = Array.from({ length: 600 }, (_, index) => runtimeEvent(index + 1))
+
+    owner.observeInitialSnapshot(events.slice(0, 500))
+    owner.observeSnapshot(events.slice(100))
+
+    expect(owner.currentEvents()).toHaveLength(500)
+    expect(owner.currentEvents()[0]?.id).toBe('runtime-1:acp-event-101')
+    expect(owner.currentEvents().at(-1)?.id).toBe('runtime-1:acp-event-600')
+  })
 })

--- a/src/renderer/src/lib/acp/runtime-event-subscription-owner.test.ts
+++ b/src/renderer/src/lib/acp/runtime-event-subscription-owner.test.ts
@@ -41,6 +41,20 @@ describe('runtime event subscription owner', () => {
     expect(listener.mock.calls[0]?.[0]).toEqual([first, second])
   })
 
+  it('keeps snapshot-only events that follow the first pending overlap', () => {
+    const owner = createRuntimeEventSubscriptionOwner()
+    const delivered: AcpRuntimeEvent[] = []
+    const first = runtimeEvent(1)
+    const second = runtimeEvent(2)
+    const third = runtimeEvent(3)
+    owner.subscribe((events) => delivered.push(...events))
+
+    owner.observeEvent(second)
+    owner.observeInitialSnapshot([first, second, third])
+
+    expect(delivered).toEqual([first, second, third])
+  })
+
   it('deduplicates delayed snapshots without suppressing newer incremental events', () => {
     const owner = createRuntimeEventSubscriptionOwner()
     const delivered: AcpRuntimeEvent[] = []

--- a/src/renderer/src/lib/acp/runtime-event-subscription-owner.ts
+++ b/src/renderer/src/lib/acp/runtime-event-subscription-owner.ts
@@ -35,10 +35,11 @@ const createRuntimeEventSubscriptionOwner = (): RuntimeEventSubscriptionOwner =>
   let previousSnapshotEventIds = new Set<string>()
   let initialized = false
   let hasSubscribed = false
+  let preserveInitialReplay = false
   let arrivalSequence = 0
 
   const capRetainedEvents = (): void => {
-    if (!hasSubscribed || retainedEvents.length <= MAX_ACP_RUNTIME_EVENTS) return
+    if (preserveInitialReplay || retainedEvents.length <= MAX_ACP_RUNTIME_EVENTS) return
     const removed = retainedEvents.splice(0, retainedEvents.length - MAX_ACP_RUNTIME_EVENTS)
     for (const event of removed) retainedEventIds.delete(event.id)
   }
@@ -110,6 +111,7 @@ const createRuntimeEventSubscriptionOwner = (): RuntimeEventSubscriptionOwner =>
       const snapshotEventIds = new Set(events.map((event) => event.id))
       const pendingEvents = [...pendingInitialEvents.values()]
       const initialEvents = mergeInitialEvents(events, pendingEvents)
+      preserveInitialReplay = !hasSubscribed && pendingEvents.length > 0
       reconcileDirectEvents(events)
       previousSnapshotEventIds = snapshotEventIds
       pendingInitialEvents.clear()
@@ -155,6 +157,7 @@ const createRuntimeEventSubscriptionOwner = (): RuntimeEventSubscriptionOwner =>
       if (!hasSubscribed) {
         hasSubscribed = true
         if (initialized) publish(retainedEvents)
+        preserveInitialReplay = false
         capRetainedEvents()
       } else if (initialized && retainedEvents.length > 0) {
         listener(retainedEvents)

--- a/src/renderer/src/lib/acp/runtime-event-subscription-owner.ts
+++ b/src/renderer/src/lib/acp/runtime-event-subscription-owner.ts
@@ -1,0 +1,154 @@
+import {
+  MAX_ACP_RUNTIME_EVENTS,
+  type AcpRuntimeEvent,
+  type AcpStateSnapshot
+} from '../../../../shared/acp'
+
+type RuntimeEventSnapshotContext = AcpStateSnapshot
+type RuntimeEventListener = (
+  events: readonly AcpRuntimeEvent[],
+  snapshot?: RuntimeEventSnapshotContext
+) => void
+type RuntimeEventSubscriptionOwner = {
+  observeEvent: (event: AcpRuntimeEvent) => void
+  observeInitialSnapshot: (
+    events: readonly AcpRuntimeEvent[],
+    snapshot?: RuntimeEventSnapshotContext
+  ) => void
+  observeSnapshot: (
+    events: readonly AcpRuntimeEvent[],
+    snapshot?: RuntimeEventSnapshotContext
+  ) => void
+  subscribe: (listener: RuntimeEventListener) => () => void
+  currentEvents: () => readonly AcpRuntimeEvent[]
+}
+
+// Keeps incremental delivery outside React state. The initial pull is a barrier: events arriving
+// while it is in flight are queued after the snapshot, then every mounted subscriber receives new
+// events synchronously so a bounded presentation window can never discard an unaccepted prefix.
+const createRuntimeEventSubscriptionOwner = (): RuntimeEventSubscriptionOwner => {
+  const listeners = new Set<RuntimeEventListener>()
+  const retainedEvents: AcpRuntimeEvent[] = []
+  const retainedEventIds = new Set<string>()
+  const pendingInitialEvents = new Map<string, AcpRuntimeEvent>()
+  const directEventsSinceSnapshot = new Map<string, number>()
+  let previousSnapshotEventIds = new Set<string>()
+  let initialized = false
+  let hasSubscribed = false
+  let arrivalSequence = 0
+
+  const capRetainedEvents = (): void => {
+    if (!hasSubscribed || retainedEvents.length <= MAX_ACP_RUNTIME_EVENTS) return
+    const removed = retainedEvents.splice(0, retainedEvents.length - MAX_ACP_RUNTIME_EVENTS)
+    for (const event of removed) retainedEventIds.delete(event.id)
+  }
+
+  const retain = (events: readonly AcpRuntimeEvent[]): void => {
+    for (const event of events) {
+      if (retainedEventIds.has(event.id)) continue
+      retainedEvents.push(event)
+      retainedEventIds.add(event.id)
+    }
+    capRetainedEvents()
+  }
+
+  const publish = (
+    events: readonly AcpRuntimeEvent[],
+    snapshot?: RuntimeEventSnapshotContext
+  ): void => {
+    if (events.length === 0) return
+    for (const listener of listeners) listener(events, snapshot)
+  }
+
+  const reconcileDirectEvents = (events: readonly AcpRuntimeEvent[]): void => {
+    let confirmedArrival = 0
+    for (const event of events) {
+      confirmedArrival = Math.max(confirmedArrival, directEventsSinceSnapshot.get(event.id) ?? 0)
+    }
+    if (confirmedArrival === 0) return
+    for (const [eventId, sequence] of directEventsSinceSnapshot) {
+      if (sequence <= confirmedArrival) directEventsSinceSnapshot.delete(eventId)
+    }
+  }
+
+  const unseenSnapshotEvents = (events: readonly AcpRuntimeEvent[]): AcpRuntimeEvent[] =>
+    events.filter(
+      (event) =>
+        !retainedEventIds.has(event.id) &&
+        !previousSnapshotEventIds.has(event.id) &&
+        !pendingInitialEvents.has(event.id) &&
+        !directEventsSinceSnapshot.has(event.id)
+    )
+
+  const observeSnapshot = (
+    events: readonly AcpRuntimeEvent[],
+    snapshot?: RuntimeEventSnapshotContext
+  ): void => {
+    if (!initialized) {
+      initialized = true
+      const snapshotEventIds = new Set(events.map((event) => event.id))
+      const pendingEvents = [...pendingInitialEvents.values()]
+      const firstOverlapIndex = events.findIndex((event) => pendingInitialEvents.has(event.id))
+      const initialEvents =
+        firstOverlapIndex < 0
+          ? [...events, ...pendingEvents]
+          : [...events.slice(0, firstOverlapIndex), ...pendingEvents]
+      reconcileDirectEvents(events)
+      previousSnapshotEventIds = snapshotEventIds
+      pendingInitialEvents.clear()
+      retain(initialEvents)
+      publish(initialEvents, snapshot)
+      return
+    }
+
+    const unseen = unseenSnapshotEvents(events)
+    reconcileDirectEvents(events)
+    previousSnapshotEventIds = new Set(events.map((event) => event.id))
+    retain(unseen)
+    publish(unseen, snapshot)
+  }
+
+  return {
+    observeEvent(event: AcpRuntimeEvent): void {
+      if (
+        retainedEventIds.has(event.id) ||
+        pendingInitialEvents.has(event.id) ||
+        directEventsSinceSnapshot.has(event.id)
+      ) {
+        return
+      }
+      arrivalSequence += 1
+      directEventsSinceSnapshot.set(event.id, arrivalSequence)
+      if (!initialized) {
+        pendingInitialEvents.set(event.id, event)
+        return
+      }
+      retain([event])
+      publish([event])
+    },
+    observeInitialSnapshot(
+      events: readonly AcpRuntimeEvent[],
+      snapshot?: RuntimeEventSnapshotContext
+    ): void {
+      observeSnapshot(events, snapshot)
+    },
+    observeSnapshot,
+    subscribe(listener: RuntimeEventListener): () => void {
+      listeners.add(listener)
+      if (!hasSubscribed) {
+        hasSubscribed = true
+        if (initialized) publish(retainedEvents)
+        capRetainedEvents()
+      } else if (initialized && retainedEvents.length > 0) {
+        listener(retainedEvents)
+      }
+      return () => listeners.delete(listener)
+    },
+    currentEvents(): readonly AcpRuntimeEvent[] {
+      return retainedEvents
+    }
+  }
+}
+
+export { createRuntimeEventSubscriptionOwner }
+export type { RuntimeEventListener, RuntimeEventSnapshotContext }

--- a/src/renderer/src/lib/acp/runtime-event-subscription-owner.ts
+++ b/src/renderer/src/lib/acp/runtime-event-subscription-owner.ts
@@ -80,6 +80,27 @@ const createRuntimeEventSubscriptionOwner = (): RuntimeEventSubscriptionOwner =>
         !directEventsSinceSnapshot.has(event.id)
     )
 
+  const mergeInitialEvents = (
+    snapshotEvents: readonly AcpRuntimeEvent[],
+    pendingEvents: readonly AcpRuntimeEvent[]
+  ): AcpRuntimeEvent[] => {
+    const pendingIndexes = new Map(pendingEvents.map((event, index) => [event.id, index]))
+    const merged: AcpRuntimeEvent[] = []
+    let pendingIndex = 0
+
+    for (const snapshotEvent of snapshotEvents) {
+      const overlapIndex = pendingIndexes.get(snapshotEvent.id)
+      if (overlapIndex === undefined) {
+        merged.push(snapshotEvent)
+      } else if (overlapIndex >= pendingIndex) {
+        merged.push(...pendingEvents.slice(pendingIndex, overlapIndex + 1))
+        pendingIndex = overlapIndex + 1
+      }
+    }
+    merged.push(...pendingEvents.slice(pendingIndex))
+    return merged
+  }
+
   const observeSnapshot = (
     events: readonly AcpRuntimeEvent[],
     snapshot?: RuntimeEventSnapshotContext
@@ -88,11 +109,7 @@ const createRuntimeEventSubscriptionOwner = (): RuntimeEventSubscriptionOwner =>
       initialized = true
       const snapshotEventIds = new Set(events.map((event) => event.id))
       const pendingEvents = [...pendingInitialEvents.values()]
-      const firstOverlapIndex = events.findIndex((event) => pendingInitialEvents.has(event.id))
-      const initialEvents =
-        firstOverlapIndex < 0
-          ? [...events, ...pendingEvents]
-          : [...events.slice(0, firstOverlapIndex), ...pendingEvents]
+      const initialEvents = mergeInitialEvents(events, pendingEvents)
       reconcileDirectEvents(events)
       previousSnapshotEventIds = snapshotEventIds
       pendingInitialEvents.clear()

--- a/src/renderer/src/lib/acp/useAcpRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.test.ts
@@ -1,5 +1,9 @@
 // @vitest-environment jsdom
-import type { AcpPermissionResponse, AcpStateSnapshot } from '../../../../shared/acp'
+import type {
+  AcpPermissionResponse,
+  AcpRuntimeEvent,
+  AcpStateSnapshot
+} from '../../../../shared/acp'
 import { act, createElement } from 'react'
 import { createRoot } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -15,6 +19,7 @@ import {
 
 type AcpRuntimeApi = ReturnType<typeof useAcpRuntime>
 type OnStateListener = (snapshot: AcpStateSnapshot) => void
+type OnEventListener = (event: AcpRuntimeEvent) => void
 
 // Minimal renderHook so we can exercise the real hook without pulling in @testing-library/react,
 // which the repo does not depend on. A null-rendering harness captures each render's return value.
@@ -74,10 +79,13 @@ const createDeferred = <Value>(): {
 
 // Captures the applySnapshot listener the hook registers so tests can push broadcasts through it.
 let capturedStateListener: OnStateListener | undefined
+let capturedEventListener: OnEventListener | undefined
 let removeStateListener: ReturnType<typeof vi.fn>
+let removeEventListener: ReturnType<typeof vi.fn>
 let acpApi: {
   getState: ReturnType<typeof vi.fn>
   onState: ReturnType<typeof vi.fn>
+  onEvent: ReturnType<typeof vi.fn>
   connect: ReturnType<typeof vi.fn>
   disconnect: ReturnType<typeof vi.fn>
   createSession: ReturnType<typeof vi.fn>
@@ -106,12 +114,18 @@ const mountRuntime = async (): Promise<{
 beforeEach(() => {
   resetAcpRuntimeSnapshotRevisionForTests()
   capturedStateListener = undefined
+  capturedEventListener = undefined
   removeStateListener = vi.fn()
+  removeEventListener = vi.fn()
   acpApi = {
     getState: vi.fn().mockResolvedValue(createSnapshot({ status: 'idle' })),
     onState: vi.fn((listener: OnStateListener) => {
       capturedStateListener = listener
       return removeStateListener
+    }),
+    onEvent: vi.fn((listener: OnEventListener) => {
+      capturedEventListener = listener
+      return removeEventListener
     }),
     connect: vi.fn().mockResolvedValue(createSnapshot()),
     disconnect: vi.fn().mockResolvedValue(createSnapshot({ status: 'idle' })),
@@ -418,6 +432,65 @@ describe('useAcpRuntime payload construction', () => {
 })
 
 describe('useAcpRuntime state subscription', () => {
+  it('streams runtime events outside React state and unsubscribes both IPC listeners', async () => {
+    const { result, unmount } = await mountRuntime()
+    const delivered = vi.fn()
+    result.current.subscribeRuntimeEvents(delivered)
+    const event: AcpRuntimeEvent = {
+      id: 'runtime-1:event-1',
+      timestamp: 1,
+      kind: 'message',
+      level: 'info',
+      role: 'assistant',
+      sessionId: 'session-1',
+      text: 'incremental output'
+    }
+
+    expect(acpApi.onEvent).toHaveBeenCalledTimes(1)
+    expect(acpApi.onState.mock.invocationCallOrder[0]).toBeLessThan(
+      acpApi.getState.mock.invocationCallOrder[0]
+    )
+    expect(acpApi.onEvent.mock.invocationCallOrder[0]).toBeLessThan(
+      acpApi.getState.mock.invocationCallOrder[0]
+    )
+    act(() => capturedEventListener?.(event))
+
+    expect(delivered).toHaveBeenCalledWith([event], undefined)
+    expect(result.current.currentRuntimeEvents()).toEqual([event])
+    expect(result.current.state.events).toEqual([])
+
+    unmount()
+    expect(removeEventListener).toHaveBeenCalledTimes(1)
+    expect(removeStateListener).toHaveBeenCalledTimes(1)
+  })
+
+  it('delivers an incremental event that arrives before the initial snapshot resolves', async () => {
+    const initial = createDeferred<AcpStateSnapshot>()
+    acpApi.getState.mockReturnValueOnce(initial.promise)
+    const { result } = await mountRuntime()
+    const delivered: AcpRuntimeEvent[] = []
+    result.current.subscribeRuntimeEvents((events) => delivered.push(...events))
+    const event: AcpRuntimeEvent = {
+      id: 'runtime-1:event-1',
+      timestamp: 2,
+      kind: 'thought',
+      level: 'info',
+      role: 'assistant',
+      sessionId: 'session-1',
+      text: 'newer live output'
+    }
+
+    act(() => capturedEventListener?.(event))
+    await act(async () => {
+      initial.resolve(createSnapshot({ revision: 1, events: [] }))
+      await initial.promise
+    })
+
+    expect(delivered).toEqual([event])
+    expect(result.current.currentRuntimeEvents()).toEqual([event])
+    expect(result.current.state.events).toEqual([])
+  })
+
   it('subscribes on mount, applies pushed snapshots, and unsubscribes on unmount', async () => {
     const { result, unmount } = await mountRuntime()
 

--- a/src/renderer/src/lib/acp/useAcpRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.test.ts
@@ -432,10 +432,29 @@ describe('useAcpRuntime payload construction', () => {
 })
 
 describe('useAcpRuntime state subscription', () => {
+  it('keeps snapshot delivery enabled when the Main event channel is unavailable', async () => {
+    const event: AcpRuntimeEvent = {
+      id: 'runtime-1:event-1',
+      timestamp: 1,
+      kind: 'message',
+      level: 'info',
+      role: 'assistant',
+      sessionId: 'session-1',
+      text: 'snapshot output'
+    }
+    Reflect.deleteProperty(acpApi, 'onEvent')
+    acpApi.getState.mockResolvedValueOnce(createSnapshot({ events: [event] }))
+
+    const { result } = await mountRuntime()
+
+    expect(result.current.subscribeRuntimeEvents).toBeUndefined()
+    expect(result.current.state.events).toEqual([event])
+  })
+
   it('streams runtime events outside React state and unsubscribes both IPC listeners', async () => {
     const { result, unmount } = await mountRuntime()
     const delivered = vi.fn()
-    result.current.subscribeRuntimeEvents(delivered)
+    result.current.subscribeRuntimeEvents?.(delivered)
     const event: AcpRuntimeEvent = {
       id: 'runtime-1:event-1',
       timestamp: 1,
@@ -469,7 +488,7 @@ describe('useAcpRuntime state subscription', () => {
     acpApi.getState.mockReturnValueOnce(initial.promise)
     const { result } = await mountRuntime()
     const delivered: AcpRuntimeEvent[] = []
-    result.current.subscribeRuntimeEvents((events) => delivered.push(...events))
+    result.current.subscribeRuntimeEvents?.((events) => delivered.push(...events))
     const event: AcpRuntimeEvent = {
       id: 'runtime-1:event-1',
       timestamp: 2,

--- a/src/renderer/src/lib/acp/useAcpRuntime.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.ts
@@ -48,7 +48,7 @@ const getErrorMessage = (error: unknown): string => {
 const useAcpRuntime = (): {
   state: AcpStateSnapshot
   reconcileSnapshot: (snapshot: AcpStateSnapshot) => void
-  subscribeRuntimeEvents: (listener: RuntimeEventListener) => () => void
+  subscribeRuntimeEvents?: (listener: RuntimeEventListener) => () => void
   currentRuntimeEvents: () => readonly AcpRuntimeEvent[]
   actionError: string | null
   isConnecting: boolean
@@ -121,6 +121,8 @@ const useAcpRuntime = (): {
   const [isConnecting, setIsConnecting] = useState(false)
   const [isDisconnecting, setIsDisconnecting] = useState(false)
   const [runtimeEventOwner] = useState(createRuntimeEventSubscriptionOwner)
+  const onRuntimeEvent = (window.api.acp as Partial<Pick<typeof window.api.acp, 'onEvent'>>).onEvent
+  const subscribeRuntimeEvents = onRuntimeEvent ? runtimeEventOwner.subscribe : undefined
 
   const applySnapshot = useCallback(
     (snapshot: AcpStateSnapshot): void => {
@@ -171,7 +173,7 @@ const useAcpRuntime = (): {
       hasPushedSnapshot = true
       applyMountedSnapshot(snapshot)
     })
-    const removeEventListener = window.api.acp.onEvent?.((event: AcpRuntimeEvent) => {
+    const removeEventListener = onRuntimeEvent?.((event: AcpRuntimeEvent) => {
       if (!isMounted) return
       runtimeEventOwner.observeEvent(event)
     })
@@ -183,7 +185,7 @@ const useAcpRuntime = (): {
       removeStateListener()
       removeEventListener?.()
     }
-  }, [applyInitialSnapshot, applySnapshot, runtimeEventOwner])
+  }, [applyInitialSnapshot, applySnapshot, onRuntimeEvent, runtimeEventOwner])
 
   // Runs an IPC action that returns a full runtime snapshot.
   const runSnapshotAction = useCallback(
@@ -454,7 +456,7 @@ const useAcpRuntime = (): {
   return {
     state,
     reconcileSnapshot: applySnapshot,
-    subscribeRuntimeEvents: runtimeEventOwner.subscribe,
+    subscribeRuntimeEvents,
     currentRuntimeEvents: runtimeEventOwner.currentEvents,
     actionError,
     isConnecting,

--- a/src/renderer/src/lib/acp/useAcpRuntime.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.ts
@@ -6,12 +6,17 @@ import type {
   AcpPromptRequest,
   AcpResumeSessionRequest,
   AcpRevokePermissionGrantRequest,
+  AcpRuntimeEvent,
   AcpSetPermissionProfileRequest,
   AcpStateSnapshot
 } from '../../../../shared/acp'
 import type { PermissionProfileId } from '../../../../shared/permission-profiles'
 import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react'
 import { acceptAcpRuntimeSnapshotRevision } from './runtime-snapshot-revision-owner'
+import {
+  createRuntimeEventSubscriptionOwner,
+  type RuntimeEventListener
+} from './runtime-event-subscription-owner'
 
 // Provides a stable renderer fallback before the first main-process snapshot arrives.
 const emptyAcpState: AcpStateSnapshot = {
@@ -43,6 +48,8 @@ const getErrorMessage = (error: unknown): string => {
 const useAcpRuntime = (): {
   state: AcpStateSnapshot
   reconcileSnapshot: (snapshot: AcpStateSnapshot) => void
+  subscribeRuntimeEvents: (listener: RuntimeEventListener) => () => void
+  currentRuntimeEvents: () => readonly AcpRuntimeEvent[]
   actionError: string | null
   isConnecting: boolean
   isDisconnecting: boolean
@@ -113,11 +120,25 @@ const useAcpRuntime = (): {
   const [actionError, setActionError] = useState<string | null>(null)
   const [isConnecting, setIsConnecting] = useState(false)
   const [isDisconnecting, setIsDisconnecting] = useState(false)
+  const [runtimeEventOwner] = useState(createRuntimeEventSubscriptionOwner)
 
-  const applySnapshot = useCallback((snapshot: AcpStateSnapshot): void => {
-    if (!acceptAcpRuntimeSnapshotRevision(snapshot)) return
-    setState(snapshot)
-  }, [])
+  const applySnapshot = useCallback(
+    (snapshot: AcpStateSnapshot): void => {
+      if (!acceptAcpRuntimeSnapshotRevision(snapshot)) return
+      runtimeEventOwner.observeSnapshot(snapshot.events, snapshot)
+      setState(snapshot)
+    },
+    [runtimeEventOwner]
+  )
+
+  const applyInitialSnapshot = useCallback(
+    (snapshot: AcpStateSnapshot): void => {
+      if (!acceptAcpRuntimeSnapshotRevision(snapshot)) return
+      runtimeEventOwner.observeInitialSnapshot(snapshot.events, snapshot)
+      setState(snapshot)
+    },
+    [runtimeEventOwner]
+  )
 
   // Loads the initial snapshot and keeps state fresh through runtime broadcasts.
   useEffect(() => {
@@ -135,9 +156,12 @@ const useAcpRuntime = (): {
         const snapshot = await window.api.acp.getState()
         // Older Main versions do not publish revisions. In that compatibility case, a pushed
         // snapshot received after subscription is the only safe authority over the initial pull.
-        if (!hasPushedSnapshot || snapshot.revision !== undefined) applyMountedSnapshot(snapshot)
+        if (!hasPushedSnapshot || snapshot.revision !== undefined) {
+          if (isMounted) applyInitialSnapshot(snapshot)
+        }
       } catch (error) {
         if (isMounted) {
+          runtimeEventOwner.observeInitialSnapshot([])
           setActionError(getErrorMessage(error))
         }
       }
@@ -147,14 +171,19 @@ const useAcpRuntime = (): {
       hasPushedSnapshot = true
       applyMountedSnapshot(snapshot)
     })
+    const removeEventListener = window.api.acp.onEvent?.((event: AcpRuntimeEvent) => {
+      if (!isMounted) return
+      runtimeEventOwner.observeEvent(event)
+    })
 
     void loadInitialState()
 
     return () => {
       isMounted = false
       removeStateListener()
+      removeEventListener?.()
     }
-  }, [applySnapshot])
+  }, [applyInitialSnapshot, applySnapshot, runtimeEventOwner])
 
   // Runs an IPC action that returns a full runtime snapshot.
   const runSnapshotAction = useCallback(
@@ -425,6 +454,8 @@ const useAcpRuntime = (): {
   return {
     state,
     reconcileSnapshot: applySnapshot,
+    subscribeRuntimeEvents: runtimeEventOwner.subscribe,
+    currentRuntimeEvents: runtimeEventOwner.currentEvents,
     actionError,
     isConnecting,
     isDisconnecting,

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -13,6 +13,7 @@ import {
   type AcpAgentRuntimeUpdate,
   type AcpCreateSessionResponse,
   type AcpPermissionRequest,
+  type AcpRuntimeEvent,
   type AcpStateSnapshot
 } from '../../../../shared/acp'
 import {
@@ -73,6 +74,8 @@ type RuntimeMock = {
   respondToElicitation: Mock
   setPermissionProfile: Mock
   revokePermissionGrant: Mock
+  subscribeRuntimeEvents?: Mock
+  currentRuntimeEvents?: () => readonly AcpRuntimeEvent[]
 }
 
 const createRuntime = (state: AcpStateSnapshot): RuntimeMock => ({
@@ -281,6 +284,103 @@ describe('workspace Agent Runtime hook contract', () => {
       saveAsSkillInFlightSessionIds: [],
       nativeContextCompactionSessionIds: ['session-1']
     })
+  })
+
+  it('routes live events into Workspace before snapshot reconciliation', async () => {
+    const pending = useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Stream the answer',
+      cwd: workspacePath,
+      projectId: 'project-1',
+      agentFrameworkId: 'claude-code'
+    })
+    let liveListener: ((events: readonly AcpRuntimeEvent[]) => void) | undefined
+    const runtime = createRuntime(
+      createSnapshot({
+        sessionIds: ['session-1'],
+        promptInFlight: true,
+        promptInFlightSessionIds: ['session-1'],
+        agentPromptInFlightSessionIds: ['session-1']
+      })
+    )
+    runtime.subscribeRuntimeEvents = vi.fn((listener) => {
+      liveListener = listener
+      return vi.fn()
+    })
+    runtime.currentRuntimeEvents = () => []
+    runtimeMock.current = runtime
+    await render()
+
+    const events: AcpRuntimeEvent[] = Array.from({ length: 8 }, (_, index) => ({
+      id: `runtime-1:acp-event-${index + 1}`,
+      timestamp: index + 1,
+      kind: 'message',
+      level: 'info',
+      role: 'assistant',
+      sessionId: 'session-1',
+      promptMessageId: pending?.messageId,
+      text: 'x'
+    }))
+    vi.mocked(window.api.acp.getState).mockResolvedValue(
+      createSnapshot({
+        revision: 1,
+        sessionIds: ['session-1'],
+        events
+      })
+    )
+    await act(async () => {
+      for (const event of events) liveListener?.([event])
+      await drainWorkspaceRuntimeEventsForPersistence('session-1')
+    })
+
+    const agentText = useSessionStore
+      .getState()
+      .sessions.find((session) => session.id === 'session-1')
+      ?.messages.filter((message) => message.role === 'agent')
+      .map((message) => message.content)
+      .join('')
+    expect(agentText).toBe('x'.repeat(8))
+    expect(
+      useSessionStore.getState().sessions.find((session) => session.id === 'session-1')
+        ?.awaitingFirstAgentOutput
+    ).not.toBe(true)
+  })
+
+  it('uses initial snapshot state when handling a recoverable lifecycle event', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Continue after compacting',
+      cwd: workspacePath,
+      projectId: 'project-1',
+      agentFrameworkId: 'claude-code'
+    })
+    let liveListener:
+      ((events: readonly AcpRuntimeEvent[], snapshot?: AcpStateSnapshot) => void) | undefined
+    const runtime = createRuntime(createSnapshot())
+    runtime.subscribeRuntimeEvents = vi.fn((listener) => {
+      liveListener = listener
+      return vi.fn()
+    })
+    runtime.currentRuntimeEvents = () => []
+    runtimeMock.current = runtime
+    await render()
+
+    liveListener?.(
+      [
+        {
+          id: 'runtime-1:overflow-1',
+          timestamp: 1,
+          kind: 'error',
+          level: 'error',
+          sessionId: 'session-1',
+          recoverable: 'context-overflow',
+          text: 'context overflow'
+        }
+      ],
+      createSnapshot({ sessionIds: ['session-1'] })
+    )
+
+    await vi.waitFor(() => expect(runtime.resetSessionContext).toHaveBeenCalledOnce())
   })
 
   it('owns one child runtime transport subscription and exposes its selector', async () => {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -223,6 +223,27 @@ describe('workspace agent runtime event processing', () => {
     shouldAnimate: () => true
   })
 
+  it('does not replay a retained snapshot after incremental events were already applied', async () => {
+    const appliedEventIds: string[] = []
+    const processor = createWorkspaceRuntimeEventProcessor(async (event) => {
+      appliedEventIds.push(event.id)
+      return true
+    })
+    const events = Array.from({ length: 600 }, (_, index) =>
+      createEvent({
+        id: `tool-event-${index + 1}`,
+        kind: 'tool',
+        toolCallId: `tool-${index + 1}`,
+        status: 'completed'
+      })
+    )
+
+    for (const event of events) await processor.processIncremental([event])
+    await processor.process(events.slice(-500))
+
+    expect(appliedEventIds).toEqual(events.map((event) => event.id))
+  })
+
   it('releases fast assistant text in grapheme-budgeted 30 fps batches', async () => {
     vi.useFakeTimers()
     try {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -37,10 +37,12 @@ import {
   createWorkspaceRuntimeEventProcessor,
   drainWorkspaceRuntimeEventsForPersistence,
   markRunningSessionsDisconnectedOnDrop,
+  processIncrementalWorkspaceRuntimeEvents,
   processVisibleWorkspaceRuntimeEvents,
   processWorkspaceRuntimeEvents,
   refreshDelegatedWorkSessions,
   subscribeWorkspacePermissionLifecycle,
+  syncWorkspaceAgentFirstOutputState,
   syncWorkspaceContextUsage,
   syncWorkspaceElicitationState,
   syncWorkspaceInteractionState,
@@ -123,6 +125,12 @@ const WorkspaceAgentRuntimeContext = createContext<WorkspaceAgentRuntime | null>
 const RuntimeProvider = WorkspaceAgentRuntimeContext.Provider
 const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   const runtime = useAcpRuntime()
+  // Characterization fixtures can still present the legacy snapshot-only seam. Production
+  // useAcpRuntime always supplies this subscription, including when an older Main lacks onEvent.
+  const subscribeRuntimeEvents = (
+    runtime as Partial<Pick<ReturnType<typeof useAcpRuntime>, 'subscribeRuntimeEvents'>>
+  ).subscribeRuntimeEvents
+  const runtimeRef = useRef(runtime)
   const subagentRuntimeUpdateListeners = useRef(new Set<SubagentRuntimeListener>())
   const subscribeToSubagentRuntimeUpdates = useCallback(
     (listener: SubagentRuntimeListener): (() => void) => {
@@ -186,6 +194,17 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
     },
     [agentFrameworks, providers]
   )
+  const runtimeEventLifecycleOptionsRef = useRef({
+    supportsImageInput: supportsHistoryImageInput,
+    getHistoryReplayDescriptor: getSessionHistoryReplayDescriptor
+  })
+  useEffect(() => {
+    runtimeRef.current = runtime
+    runtimeEventLifecycleOptionsRef.current = {
+      supportsImageInput: supportsHistoryImageInput,
+      getHistoryReplayDescriptor: getSessionHistoryReplayDescriptor
+    }
+  }, [getSessionHistoryReplayDescriptor, runtime, supportsHistoryImageInput])
   const [lifecycleOwner] = useState(createWorkspaceRuntimeSessionLifecycleOwner)
   const pendingPermissions = useMemo(
     () => pendingWorkspacePermissions(restoredPermissionSessions, runtime.state.pendingPermissions),
@@ -251,12 +270,20 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   }, [])
 
   useEffect(() => {
-    lifecycleOwner.processRuntimeEvents(runtime, runtime.state.events, {
-      supportsImageInput: supportsHistoryImageInput,
-      getHistoryReplayDescriptor: getSessionHistoryReplayDescriptor
+    if (!subscribeRuntimeEvents) return
+    return subscribeRuntimeEvents((events, snapshot) => {
+      const currentRuntime = runtimeRef.current
+      const eventRuntime = snapshot ? { ...currentRuntime, state: snapshot } : currentRuntime
+      const acceptedEvents = [...events]
+      syncWorkspaceAgentFirstOutputState(eventRuntime.state.agentPromptInFlightSessionIds ?? [])
+      lifecycleOwner.processRuntimeEvents(
+        eventRuntime,
+        acceptedEvents,
+        runtimeEventLifecycleOptionsRef.current
+      )
+      void processIncrementalWorkspaceRuntimeEvents(acceptedEvents)
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- runtime is read fresh; fire on new events.
-  }, [runtime.state.events, getSessionHistoryReplayDescriptor, supportsHistoryImageInput])
+  }, [lifecycleOwner, subscribeRuntimeEvents])
   const agentPromptInFlightSessionIds =
     runtime.state.agentPromptInFlightSessionIds ?? EMPTY_AGENT_PROMPT_IN_FLIGHT_SESSION_IDS
 
@@ -278,8 +305,23 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   }, [permissionResponseAttemptOwner, runtime.state.pendingPermissions])
 
   useEffect(() => {
+    if (subscribeRuntimeEvents) {
+      syncWorkspaceAgentFirstOutputState(agentPromptInFlightSessionIds)
+      return
+    }
+    lifecycleOwner.processRuntimeEvents(runtime, runtime.state.events, {
+      supportsImageInput: supportsHistoryImageInput,
+      getHistoryReplayDescriptor: getSessionHistoryReplayDescriptor
+    })
     void processWorkspaceRuntimeEvents(runtime.state)
-  }, [agentPromptInFlightSessionIds, runtime.state])
+  }, [
+    agentPromptInFlightSessionIds,
+    getSessionHistoryReplayDescriptor,
+    lifecycleOwner,
+    runtime,
+    subscribeRuntimeEvents,
+    supportsHistoryImageInput
+  ])
 
   useEffect(() => {
     syncWorkspaceElicitationState(runtime.state.pendingElicitations ?? [])

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -89,7 +89,7 @@ type WorkspaceCommandRuntime = Pick<
   ReturnType<typeof useAcpRuntime>,
   'state' | 'createSession' | 'resumeSession' | 'resetSessionContext' | 'sendPrompt'
 > &
-  Partial<Pick<ReturnType<typeof useAcpRuntime>, 'deleteSession'>>
+  Partial<Pick<ReturnType<typeof useAcpRuntime>, 'currentRuntimeEvents' | 'deleteSession'>>
 type HistoryReplayContext = {
   historyPreamble?: string
   historyAttachments?: UploadedAttachment[]
@@ -195,7 +195,10 @@ type PromptDispatch = {
 }
 
 const dispatchPrompt = (runtime: WorkspaceCommandRuntime, request: PromptDispatch): void => {
-  const priorErrorEventId = latestFailureId(runtime.state.events, request.sessionId)
+  const priorErrorEventId = latestFailureId(
+    [...(runtime.currentRuntimeEvents?.() ?? runtime.state.events)],
+    request.sessionId
+  )
   const args = [
     request.sessionId,
     request.content,

--- a/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
@@ -3,6 +3,7 @@ import {
   ACP_RESTORED_PERMISSION_REARMED_EVENT_TITLE,
   ACP_RESTORED_PERMISSION_REARM_FAILED_EVENT_TITLE,
   ACP_RESTORED_PERMISSION_SETTLED_EVENT_TITLE,
+  MAX_ACP_RUNTIME_EVENTS,
   isDurableAgentUserChoiceRequest,
   type AcpConnectionStatus,
   type AcpContextUsage,
@@ -45,6 +46,7 @@ type WorkspacePermissionLifecycleObserver = {
 
 type WorkspaceRuntimeEventProcessor = {
   process: (events: AcpRuntimeEvent[]) => Promise<void>
+  processIncremental: (events: readonly AcpRuntimeEvent[]) => Promise<void>
   drain: (sessionId?: string) => Promise<void>
 }
 type WorkspaceRuntimeEventSnapshot = Pick<
@@ -234,37 +236,56 @@ const createWorkspaceRuntimeEventProcessor = (
     }
   }
 
-  return {
-    process: (events) => {
-      latestEvents = events
-      const visibleLaneKeys = new Set<string | symbol>()
-
+  const acceptEvents = (
+    events: readonly AcpRuntimeEvent[],
+    replaceLatestEvents: boolean
+  ): Promise<void> => {
+    if (replaceLatestEvents) {
+      latestEvents = [...events]
+    } else {
+      const latestEventIds = new Set(latestEvents.map((event) => event.id))
       for (const event of events) {
-        const laneKey = getEventLaneKey(event)
-        const lane = getEventLane(laneKey)
-        visibleLaneKeys.add(laneKey)
-
-        if (
-          !lane.processedEventIds.has(event.id) &&
-          !lane.processingEventIds.has(event.id) &&
-          !lane.acceptedEvents.has(event.id)
-        ) {
-          // A bounded source snapshot may evict this event before a slow predecessor finishes.
-          lane.acceptedEvents.set(event.id, event)
-          acceptedEventVersion += 1
-          presentationBuffer.forceOnAccepted(lane.presentation, event)
+        if (!latestEventIds.has(event.id)) {
+          latestEvents.push(event)
+          latestEventIds.add(event.id)
         }
       }
-
-      for (const [laneKey, lane] of eventLanes) cleanEventLane(laneKey, lane)
-
-      const drains = [...visibleLaneKeys].map((laneKey) => drainLane(laneKey))
-      for (const [laneKey, lane] of eventLanes) {
-        if (!visibleLaneKeys.has(laneKey) && lane.acceptedEvents.size > 0) void drainLane(laneKey)
+      if (latestEvents.length > MAX_ACP_RUNTIME_EVENTS) {
+        latestEvents = latestEvents.slice(-MAX_ACP_RUNTIME_EVENTS)
       }
+    }
+    const visibleLaneKeys = new Set<string | symbol>()
 
-      return Promise.all(drains).then(() => undefined)
-    },
+    for (const event of events) {
+      const laneKey = getEventLaneKey(event)
+      const lane = getEventLane(laneKey)
+      visibleLaneKeys.add(laneKey)
+
+      if (
+        !lane.processedEventIds.has(event.id) &&
+        !lane.processingEventIds.has(event.id) &&
+        !lane.acceptedEvents.has(event.id)
+      ) {
+        // A bounded source snapshot may evict this event before a slow predecessor finishes.
+        lane.acceptedEvents.set(event.id, event)
+        acceptedEventVersion += 1
+        presentationBuffer.forceOnAccepted(lane.presentation, event)
+      }
+    }
+
+    for (const [laneKey, lane] of eventLanes) cleanEventLane(laneKey, lane)
+
+    const drains = [...visibleLaneKeys].map((laneKey) => drainLane(laneKey))
+    for (const [laneKey, lane] of eventLanes) {
+      if (!visibleLaneKeys.has(laneKey) && lane.acceptedEvents.size > 0) void drainLane(laneKey)
+    }
+
+    return Promise.all(drains).then(() => undefined)
+  }
+
+  return {
+    process: (events) => acceptEvents(events, true),
+    processIncremental: (events) => acceptEvents(events, false),
     drain: async (sessionId) => {
       if (sessionId !== undefined) {
         const lane = eventLanes.get(sessionId)
@@ -454,6 +475,13 @@ const ingestWorkspaceRuntimeSnapshot = async (
 const processWorkspaceRuntimeEvents = (snapshot: WorkspaceRuntimeEventSnapshot): Promise<boolean> =>
   ingestWorkspaceRuntimeSnapshot(snapshot, true)
 
+// Accepts live IPC events immediately, outside React state. The processor copies each event into
+// its per-session lane before returning, so later snapshot-window eviction cannot drop a prefix
+// while asynchronous presentation or persistence is still draining.
+const processIncrementalWorkspaceRuntimeEvents = (
+  events: readonly AcpRuntimeEvent[]
+): Promise<void> => liveWorkspaceRuntimeEventProcessor.processIncremental(events)
+
 // Flags sessions with a live Agent operation as disconnected on a transition into a dropped
 // connection state. Durable permission waits are intentionally quiescent: their provider RPC can
 // disappear while the persisted card remains actionable after a later resume.
@@ -548,6 +576,7 @@ export {
   createWorkspaceRuntimeEventProcessor,
   drainWorkspaceRuntimeEventsForPersistence,
   markRunningSessionsDisconnectedOnDrop,
+  processIncrementalWorkspaceRuntimeEvents,
   processVisibleWorkspaceRuntimeEvents,
   processWorkspaceRuntimeEvents,
   refreshDelegatedWorkSessions,

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -79,6 +79,7 @@ export const MAX_ACP_MESSAGE_IMAGE_BYTES = 4 * 1024 * 1024
 export const MAX_ACP_MESSAGE_IMAGES_PER_MESSAGE = 4
 export const MAX_ACP_MESSAGE_IMAGE_BYTES_PER_MESSAGE = 8 * 1024 * 1024
 export const MAX_ACP_SESSION_IMAGE_BYTES = 24 * 1024 * 1024
+export const MAX_ACP_RUNTIME_EVENTS = 500
 // Existing runtime projection keeps only text-bearing message events. This sentinel carries a valid
 // image through that projection and is removed before transcript storage or rendering.
 export const ACP_MESSAGE_IMAGE_EVENT_TEXT = '[open-science:acp-message-image]'

--- a/src/shared/web-rpc-contract.ts
+++ b/src/shared/web-rpc-contract.ts
@@ -4,7 +4,9 @@ import { APPLICATION_COMMAND_ERROR_CODES } from './application-command-contract'
 import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from './web-api-map.generated'
 
 export const WEB_RPC_PROTOCOL_VERSION = 1 as const
-export const WEB_EVENT_STREAM_PROTOCOL_VERSION = 2 as const
+// v3 requires ACP consumers to apply acp:event incrementally. Reject cached v2 pages after a Main
+// upgrade so they request a reload instead of silently waiting for removed per-chunk state frames.
+export const WEB_EVENT_STREAM_PROTOCOL_VERSION = 3 as const
 export const WEB_RPC_TRANSPORT_ERROR_CODES = [
   'invalid_request',
   'method_not_found',


### PR DESCRIPTION
## Problem

High-frequency ACP updates were published twice: once as an incremental acp:event and again through AcpStateSnapshot containing the retained window of up to 500 events. Notebook and tool-heavy turns could therefore repeatedly clone, serialize, and broadcast the same history across Desktop IPC, Web event streams, and Side Chat state callbacks.

The supplied application logs do not contain a native crash stack and the latest run reaches stopReason=end_turn, so they cannot prove the final operating-system exit cause. They do demonstrate the high-volume execution path that exercised this amplification.

## Proposed change

- Publish live ACP updates through the incremental event channel and reserve full state snapshots for lifecycle mutations, command responses, initialization, and reconciliation.
- Feed live renderer events directly into the Workspace processor outside React state, with ordered initial reconciliation, ID deduplication, and a shared 500-event retention window.
- Preserve snapshot-only adapters when no incremental callback is available.
- Cover Claude Code, OpenCode, Codex Responses, and Codex Bridge through their real runtime routes.
- Bump the Web event-stream protocol to v3 so cached v2 pages are rejected and shown the existing reload-required flow instead of silently losing streamed output.

## Scope and non-goals

- No database schema, persisted session format, data field, domain model, or migration changes.
- No new status or enum values.
- Historical conversations require no compatibility migration.
- Desktop Main and renderer ship together. Cached Web v2 clients must reload after a Main upgrade.
- Estimated context usage can refresh at provider usage or lifecycle snapshot boundaries instead of every text chunk.
- Separate follow-ups are intentionally excluded for Notebook full-state pulls after appendCodeCell, delegated-runtime update retention, and Side Chat persistence projection frequency.

## Acceptance criteria and validation

All checks below ran after the final material edit.

- Main publication semantics, lifecycle state, four framework routes, Side Chat, Web projections, renderer contracts, event races, persistence drain, and 500-event retention
  - npx vitest run with the 18-file final Test Impact Set
  - Result: 18 files passed, 1068 tests passed
- Main and shared process types
  - npm run typecheck:node
  - Result: passed
- Renderer and Web types
  - npm run typecheck:web
  - Result: passed
- Source quality
  - npm run lint
  - Result: passed
- Patch hygiene
  - git diff --check
  - Result: passed

The complete npm test suite was not run locally by request. PR Gate remains authoritative for the complete portable and platform-selected test plan.

Independent review confirmed the final impact mapping and found no remaining P0 or P1 issue.

## Review focus

- Ordering between initial getState reconciliation and live acp:event delivery.
- Lifecycle processing against the snapshot that introduced an event.
- Event-window deduplication and bounded retention during synchronous bursts.
- Web protocol v3 behavior for cached v2 clients.
- Explicit lifecycle snapshots after removing per-event snapshot publication.

## Uncovered risks

- The application log does not prove the exact native process termination cause; Windows Event or Crashpad evidence is still needed to attribute the reported force close conclusively.
- The renderer tracks incremental event IDs until a confirming snapshot; an exceptionally long turn with no snapshot can grow this lightweight ID map.
- Notebook full-state refresh amplification is a separate path and remains for follow-up.