### PR TITLE
fix(cli): prevent stale PID process-tree kills

### DIFF
--- a/cli/lifecycle.test.ts
+++ b/cli/lifecycle.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
 import {
   buildAppLaunchArgs,
   formatStartupFailure,
+  isProcessAlive,
   openLaunchLog,
   statusCommand,
   stopCommand,
@@ -16,6 +17,7 @@ import {
   urlCommand,
   waitForStartup
 } from './index.mjs'
+import { findServiceState, STATE_FILE } from './config-root.mjs'
 
 // A running daemon's on-disk state, as findServiceState would return it.
 const RUNNING_STATE = { pid: 4242, port: 44100, configRoot: '/tmp/os-config' }
@@ -41,6 +43,8 @@ const makeDeps = (overrides: Partial<CommandDeps> = {}): CommandDeps => {
     findServiceState: vi.fn().mockResolvedValue(RUNNING_STATE),
     readWebToken: vi.fn().mockResolvedValue('token-abc'),
     isAlive: vi.fn().mockReturnValue(true),
+    // Legacy destructive seam: retained in the harness so regression tests prove stopCommand never
+    // delegates a persisted PID to the old external process-tree kill path.
     forceKill: vi.fn(),
     removeState: vi.fn().mockResolvedValue(undefined),
     fetch: vi.fn().mockResolvedValue({ ok: true, arrayBuffer: async () => new ArrayBuffer(0) }),
@@ -66,45 +70,23 @@ describe('terminateDaemon', () => {
       let t = 0
       return () => (t += 1000)
     })(),
-    gracefulTimeoutMs: 5_000,
-    killTimeoutMs: 2_000
+    gracefulTimeoutMs: 5_000
   }
 
-  it('returns true without force-killing when the process exits gracefully', async () => {
-    const forceKill = vi.fn()
+  it('returns true when the process exits gracefully', async () => {
     const stopped = await terminateDaemon(1, {
       ...base,
-      isAlive: () => false,
-      forceKill
+      isAlive: () => false
     })
     expect(stopped).toBe(true)
-    expect(forceKill).not.toHaveBeenCalled()
   })
 
-  it('force-kills the tree and returns true when the process dies after the kill', async () => {
-    // Stays alive through the graceful window (so the wait times out), then is reaped by force-kill.
-    let killed = false
-    const forceKill = vi.fn(() => {
-      killed = true
-    })
-    const onForceKill = vi.fn()
+  it('returns false when the process remains alive through the graceful timeout', async () => {
     const stopped = await terminateDaemon(99, {
       ...base,
-      isAlive: () => !killed,
-      forceKill,
-      onForceKill
+      isAlive: () => true
     })
-    expect(stopped).toBe(true)
-    expect(forceKill).toHaveBeenCalledWith(99)
-    expect(onForceKill).toHaveBeenCalledTimes(1)
-  })
-
-  it('returns false when the process is still alive after the force-kill window', async () => {
-    // force-kill runs but the process refuses to die (isAlive stays true throughout).
-    const forceKill = vi.fn()
-    const stopped = await terminateDaemon(7, { ...base, isAlive: () => true, forceKill })
     expect(stopped).toBe(false)
-    expect(forceKill).toHaveBeenCalledWith(7)
   })
 })
 
@@ -205,24 +187,63 @@ describe('stopCommand', () => {
     expect(deps.log).toHaveBeenCalledWith('Open Science stopped.')
   })
 
-  it('does NOT remove state or print stopped when the process survives the force-kill', async () => {
-    // Always alive: findCurrentState passes, graceful times out, force-kill fails to reap it.
+  it('does not signal or remove state when the process survives the graceful timeout', async () => {
+    // Always alive: findCurrentState passes and the authenticated graceful shutdown times out.
     const deps = makeDeps({ isAlive: vi.fn().mockReturnValue(true) })
     await expect(stopCommand({}, deps)).rejects.toThrow(/still running/)
 
-    expect(deps.forceKill).toHaveBeenCalledWith(RUNNING_STATE.pid)
+    expect(deps.forceKill).not.toHaveBeenCalled()
     expect(deps.removeState).not.toHaveBeenCalled()
     expect(deps.log).not.toHaveBeenCalledWith('Open Science stopped.')
   })
 
-  it('still force-kills when the graceful shutdown request fails', async () => {
+  it('fails closed without signalling when the authenticated shutdown request fails', async () => {
     const deps = makeDeps({
       isAlive: vi.fn().mockReturnValue(true),
       fetch: vi.fn().mockRejectedValue(new Error('connection refused'))
     })
-    await expect(stopCommand({}, deps)).rejects.toThrow(/still running/)
+    await expect(stopCommand({}, deps)).rejects.toThrow(
+      /authenticated shutdown request was not accepted/
+    )
     expect(deps.warn).toHaveBeenCalledWith(expect.stringContaining('Graceful shutdown failed'))
-    expect(deps.forceKill).toHaveBeenCalledWith(RUNNING_STATE.pid)
+    expect(deps.forceKill).not.toHaveBeenCalled()
+    expect(deps.removeState).not.toHaveBeenCalled()
+  })
+
+  it('does not force-kill an unrelated live process when stale state contains its reused PID', async () => {
+    const configRoot = await mkdtemp(join(tmpdir(), 'open-science-cli-stale-pid-'))
+    const forceKill = vi.fn()
+    try {
+      // Reproduce PID reuse deterministically: this state belongs to a long-gone daemon, while its PID
+      // now names the unrelated Vitest process. The real liveness probe therefore reports the PID alive.
+      await writeFile(
+        join(configRoot, STATE_FILE),
+        JSON.stringify({
+          pid: process.pid,
+          port: 44100,
+          startedAt: '2000-01-01T00:00:00.000Z',
+          appVersion: '0.0.0',
+          configRoot,
+          attached: false
+        })
+      )
+      const deps = makeDeps({
+        findServiceState: vi.fn((options) => findServiceState(options)),
+        isAlive: vi.fn(isProcessAlive),
+        forceKill,
+        fetch: vi.fn().mockRejectedValue(new Error('connection refused'))
+      })
+
+      await expect(stopCommand({ configRoot }, deps)).rejects.toThrow(
+        /authenticated shutdown request was not accepted/
+      )
+
+      expect(isProcessAlive(process.pid)).toBe(true)
+      expect(forceKill).not.toHaveBeenCalled()
+      expect(deps.removeState).not.toHaveBeenCalled()
+    } finally {
+      await rm(configRoot, { recursive: true })
+    }
   })
 
   it('stops only the web service and never kills the pid when the state is attached', async () => {
@@ -250,6 +271,19 @@ describe('stopCommand', () => {
     expect(deps.log).toHaveBeenCalledWith(
       'Open Science web service stopped; the app is still running.'
     )
+  })
+
+  it('retains attached state when the authenticated shutdown request is not accepted', async () => {
+    const deps = makeDeps({
+      findServiceState: vi.fn().mockResolvedValue({ ...RUNNING_STATE, attached: true }),
+      fetch: vi.fn().mockRejectedValue(new Error('connection refused'))
+    })
+
+    await expect(stopCommand({}, deps)).rejects.toThrow(
+      /authenticated shutdown request was not accepted/
+    )
+    expect(deps.forceKill).not.toHaveBeenCalled()
+    expect(deps.removeState).not.toHaveBeenCalled()
   })
 
   it('fails loudly without killing the pid when an attached web service refuses to stop', async () => {

--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -55,6 +55,12 @@ human-readable, JSON, and JSONL output never includes the local token.
 Use `--port <port>` to override the default port of `44100`. `--app-path <path>` selects a specific
 Open Science executable. Development builds also support `--config-root <path>`.
 
+`open-science stop` requests an authenticated graceful shutdown and waits for the service to exit. If
+the request cannot be accepted or a dedicated daemon remains alive after the shutdown deadline, the
+command fails without signalling the PID recorded in `web-service.json`; a stale PID may have been
+reused by an unrelated process. The state file is retained for diagnosis and can be replaced by a
+later `open-science start`.
+
 ## Codex subscription sign-in
 
 Sign the Open Science Codex profile in from a server terminal without starting the daemon or opening

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -8,7 +8,7 @@ import { mkdir, readFile, rm } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { Readable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
-import { spawn, spawnSync } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
 import { findServiceState, readWebToken, resolveConfigRoot, STATE_FILE } from './config-root.mjs'
@@ -356,26 +356,6 @@ const removeStateFiles = async (configRoot) => {
   await rm(join(configRoot, STATE_FILE), { force: true })
 }
 
-// Force-kills the daemon's entire process tree after graceful shutdown failed. The daemon is spawned
-// detached, so on POSIX it leads its own process group: negating the PID signals the whole group
-// (agent/Notebook children included), and SIGKILL is required because the graceful SIGTERM was ignored.
-const forceKillTree = (pid) => {
-  if (process.platform === 'win32') {
-    spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' })
-    return
-  }
-  try {
-    process.kill(-pid, 'SIGKILL')
-  } catch {
-    // Group already gone or never formed: fall back to the lone leader.
-    try {
-      process.kill(pid, 'SIGKILL')
-    } catch {
-      // Already dead.
-    }
-  }
-}
-
 // The real I/O the commands use, bundled so tests can substitute fakes. Declared after the helpers it
 // references so its initializer sees them; commands take `deps = DEFAULT_DEPS`, so production callers
 // pass nothing and get these.
@@ -383,7 +363,6 @@ const DEFAULT_DEPS = {
   findServiceState: (options) => findServiceState(options),
   readWebToken: (configRoot) => readWebToken(configRoot),
   isAlive: isProcessAlive,
-  forceKill: forceKillTree,
   removeState: (configRoot) => removeStateFiles(configRoot),
   fetch: (input, init) => fetch(input, init),
   sleep,
@@ -392,27 +371,13 @@ const DEFAULT_DEPS = {
   warn: (...args) => console.warn(...args)
 }
 
-// Waits for the daemon to exit gracefully, then force-kills its process tree and verifies the process
-// is actually gone. Returns true iff it stopped. The caller sends the graceful shutdown request first;
-// all timing/kill primitives are injected so the escalation path is testable without real processes.
+// Waits for the daemon to exit after an authenticated graceful shutdown request. A PID proves only
+// that some process is alive, not that it is still the daemon recorded in a potentially stale state
+// file, so this function deliberately never signals it. Returns true iff the PID is no longer alive.
 export const terminateDaemon = async (pid, opts) => {
-  const {
-    isAlive,
-    forceKill,
-    sleep: sleepFn,
-    now,
-    gracefulTimeoutMs,
-    killTimeoutMs,
-    onForceKill
-  } = opts
+  const { isAlive, sleep: sleepFn, now, gracefulTimeoutMs } = opts
   const deadline = now() + gracefulTimeoutMs
   while (now() < deadline && isAlive(pid)) await sleepFn(250)
-  if (!isAlive(pid)) return true
-
-  onForceKill?.()
-  forceKill(pid)
-  const killDeadline = now() + killTimeoutMs
-  while (now() < killDeadline && isAlive(pid)) await sleepFn(250)
   return !isAlive(pid)
 }
 
@@ -551,6 +516,7 @@ export const stopCommand = async (options, deps = DEFAULT_DEPS) => {
     return
   }
   const token = await deps.readWebToken(state.configRoot)
+  let shutdownAccepted = false
   try {
     const response = await deps.fetch(`http://127.0.0.1:${state.port}/api/shutdown`, {
       method: 'POST',
@@ -558,13 +524,20 @@ export const stopCommand = async (options, deps = DEFAULT_DEPS) => {
       signal: AbortSignal.timeout(3_000)
     })
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    shutdownAccepted = true
     await response.arrayBuffer()
   } catch (error) {
     deps.warn(`Graceful shutdown failed: ${error.message}`)
   }
 
+  if (!shutdownAccepted) {
+    throw new Error(
+      `Could not safely stop Open Science (PID ${state.pid}); the authenticated shutdown request was not accepted, so no process signal was sent.`
+    )
+  }
+
   // Attached: the web service rides on the running desktop app. A graceful request stops only the web
-  // service; the app stays up. Never fall through to force-killing — that pid is the user's app.
+  // service; the app stays up, so observe service health instead of waiting for its pid to exit.
   if (state.attached) {
     const stopped = await waitForWebServiceStopped(state, deps, STOP_TIMEOUT_MS)
     if (!stopped) {
@@ -579,17 +552,16 @@ export const stopCommand = async (options, deps = DEFAULT_DEPS) => {
 
   const stopped = await terminateDaemon(state.pid, {
     isAlive: deps.isAlive,
-    forceKill: deps.forceKill,
     sleep: deps.sleep,
     now: deps.now,
-    gracefulTimeoutMs: STOP_TIMEOUT_MS,
-    killTimeoutMs: 2_000,
-    onForceKill: () => deps.warn('Graceful shutdown timed out; force-killing the process tree.')
+    gracefulTimeoutMs: STOP_TIMEOUT_MS
   })
   // Only claim success (and drop the state file) once the process is confirmed gone; otherwise leave
   // the state in place and fail loudly so the user isn't told it stopped when it didn't.
   if (!stopped) {
-    throw new Error(`Could not stop Open Science (PID ${state.pid}); it is still running.`)
+    throw new Error(
+      `Could not stop Open Science (PID ${state.pid}); it is still running, so no process signal was sent.`
+    )
   }
   await deps.removeState(state.configRoot)
   deps.log('Open Science stopped.')


### PR DESCRIPTION
## Problem

`open-science stop` treated `process.kill(pid, 0)` as proof that the PID in
`web-service.json` still belonged to the recorded daemon. If abnormal exit left a stale state file
and the OS reused that PID, a failed graceful shutdown was followed by `taskkill /T /F` on Windows
or a POSIX process-group `SIGKILL`, potentially terminating an unrelated process tree.

The regression test reproduces this with a real persisted state file and the live Vitest PID. Before
the fix it deterministically observed the legacy `forceKill` seam receiving that unrelated PID.

## Proposed change

- Remove the CLI-owned external process-tree hard-kill path.
- Require the authenticated shutdown request to be accepted before waiting for shutdown.
- Fail closed without signalling the persisted PID when the request is rejected/unreachable or a
  dedicated daemon remains alive after the existing deadline.
- Retain the state file on unsafe failure for diagnosis and replacement by a later `start`.
- Document the fail-closed lifecycle behavior and cover dedicated and attached service paths.

## Scope and non-goals

- No new persisted fields or `WebServiceState` changes.
- No database schema or migration changes.
- No new status/enum values.
- No new supervisor, watchdog, or process-identity architecture.
- Successful graceful shutdown behavior is unchanged.
- This PR deliberately does not preserve automatic hard-kill recovery for an unreachable daemon;
  externally killing a PID without instance identity is the unsafe operation being removed.

## Historical compatibility and persistence

Historical `web-service.json` files remain readable, including files that predate `attached`. They
are now safe because no historical or current state can authorize an external PID signal. No state
migration or rewrite is required. This affects only the local lifecycle state file, not application
database persistence.

## Acceptance criteria and validation

All listed checks ran after the last material edit:

- stale PID is never delegated to external tree kill ->
  `npm test -- cli/lifecycle.test.ts -t "does not force-kill an unrelated live process when stale state contains its reused PID"` -> passed
- CLI lifecycle, entry, config contract, and publishable package behavior ->
  `npm test -- cli/lifecycle.test.ts cli/index.test.ts cli/config-root.test.ts packages/open-science` -> 7 files / 79 tests passed
- affected Node/CLI types -> `npm run typecheck:node` -> passed
- linted source and tests -> `npm run lint` -> passed
- publishable CLI contents -> `npm run check:cli-package` -> passed (11 expected entries)

Per maintainer direction, the complete local `npm test` suite was not run; exact-head PR CI is
authoritative for the full portable and platform lanes. No renderer, database, migration, ACP, or
path-handling behavior changed, so their local suites were excluded from the impact set.

## Review focus

- Confirm the safety boundary: authenticated graceful shutdown plus observation only; never an
  external signal based on persisted PID liveness.
- Confirm state is removed only after a verified stop and retained on request failure or timeout.
- Confirm the failure-path interaction change is acceptable for unreachable/wedged daemons.
