### PR TITLE
feat(specialist-marketplace): add capability icons

### DIFF
--- a/src/renderer/src/pages/settings/SpecialistMarketplace.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistMarketplace.render.test.tsx
@@ -370,6 +370,11 @@ describe('Specialist Marketplace settings', () => {
     const skills = Array.from(container.querySelectorAll('button')).find((button) =>
       button.textContent?.includes('Skills')
     )
+    const connectors = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Connectors')
+    )
+    expect(skills?.querySelector('.lucide-scroll-text')).not.toBeNull()
+    expect(connectors?.querySelector('svg > rect[x="14.5"]')).not.toBeNull()
     expect(skills?.getAttribute('aria-expanded')).toBe('false')
     fireEvent.click(skills!)
     expect(skills?.getAttribute('aria-expanded')).toBe('true')

--- a/src/renderer/src/pages/settings/SpecialistMarketplace.tsx
+++ b/src/renderer/src/pages/settings/SpecialistMarketplace.tsx
@@ -8,6 +8,7 @@ import {
   GitBranch,
   Loader2,
   RefreshCw,
+  ScrollText,
   Settings2,
   ShieldCheck,
   Trash2
@@ -28,6 +29,7 @@ import type {
 import { SettingsSearchInput } from './SettingsSearchInput'
 import { SettingsIconAction } from './SettingsLayout'
 import { SettingsSegmentedControl } from './SettingsSegmentedControl'
+import { ConnectorsNavIcon } from './connector-icons'
 import { SpecialistSkillConflictChoices } from './SpecialistSkillConflictChoices'
 import {
   skillConflictResolutionList,
@@ -767,6 +769,10 @@ const SpecialistMarketplace = ({ view, onNavigate }: Props): React.JSX.Element =
                   onClick={() => setSkillsExpanded((expanded) => !expanded)}
                   className="flex w-full items-center gap-3 p-4 text-left hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
                 >
+                  <ScrollText
+                    className="size-5 shrink-0 text-muted-foreground"
+                    aria-hidden="true"
+                  />
                   <div className="min-w-0 flex-1">
                     <h3 className="text-sm font-semibold text-foreground">{t('Skills')}</h3>
                     <p className="mt-0.5 text-xs text-muted-foreground">
@@ -820,6 +826,7 @@ const SpecialistMarketplace = ({ view, onNavigate }: Props): React.JSX.Element =
                   onClick={() => setConnectorsExpanded((expanded) => !expanded)}
                   className="flex w-full items-center gap-3 p-4 text-left hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
                 >
+                  <ConnectorsNavIcon className="size-5 shrink-0 text-muted-foreground" />
                   <div className="min-w-0 flex-1">
                     <h3 className="text-sm font-semibold text-foreground">{t('Connectors')}</h3>
                     <p className="mt-0.5 text-xs text-muted-foreground">


### PR DESCRIPTION
## Problem

The Specialist Marketplace release view lists included Skills and Connectors without the visual identifiers already used for those capabilities in Settings.

## Proposed change

- Reuse the Settings `ScrollText` icon for the Skills capability section.
- Reuse the Settings `ConnectorsNavIcon` for the Connectors capability section.
- Render both as muted 20 px decorative icons alongside the existing heading and count.
- Cover both icon render paths in the Marketplace release render test.

## Scope and non-goals

- No copy, translation, behavior, API, data-model, persistence, or dependency changes.
- No new status or enum values.
- Existing accordion selection, focus, hover, and reduced-motion behavior is unchanged.

## Acceptance criteria and validation

Checks were run after the final material edit.

- Capability icon reuse -> `npm test -- src/renderer/src/pages/settings/SpecialistMarketplace.render.test.tsx` -> passed (16/16)
- Renderer type safety -> `npm run typecheck:web` -> passed
- Source lint -> `npm run lint` -> passed
- Changed-file formatting -> `npx prettier --check src/renderer/src/pages/settings/SpecialistMarketplace.tsx src/renderer/src/pages/settings/SpecialistMarketplace.render.test.tsx` -> passed
- Dependency-aware plan -> `npm run test:affected -- --base origin/main --head HEAD --explain` -> selected the full fallback because the changed render test has no registered module owner

The full local `npm test` suite was intentionally not run per maintainer request; exact-head PR CI is the final authority for complete portable and platform coverage.

## Review focus

- Confirm the 20 px muted icon treatment is proportionate to the two-line capability labels.
- Confirm the reused icons remain decorative and do not duplicate accessible button names.

Uncovered local risk: no screenshot-based visual regression test exists for this Marketplace release view. The change is confined to existing flex layout and icon components; PR CI covers the broader suite.
