### PR TITLE
fix(preview): serialize persistence writes

### DIFF
--- a/src/renderer/src/hooks/useQuitPersistenceFlush.test.ts
+++ b/src/renderer/src/hooks/useQuitPersistenceFlush.test.ts
@@ -3,8 +3,15 @@
 import { renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const { resumeAutoReviewsAfterQuitAbort } = vi.hoisted(() => ({
-  resumeAutoReviewsAfterQuitAbort: vi.fn()
+const { flushPreviewPersistence, flushSessionPersistence, resumeAutoReviewsAfterQuitAbort } =
+  vi.hoisted(() => ({
+    flushPreviewPersistence: vi.fn(async () => undefined),
+    flushSessionPersistence: vi.fn(async () => undefined),
+    resumeAutoReviewsAfterQuitAbort: vi.fn()
+  }))
+
+vi.mock('../lib/preview-persistence/preview-persistence', () => ({
+  flushPreviewPersistence
 }))
 
 vi.mock('../lib/acp/workspace-events', () => ({
@@ -15,13 +22,15 @@ vi.mock('../lib/acp/useWorkspaceAgentRuntime', () => ({
   drainWorkspaceRuntimeEventsForPersistence: vi.fn(async () => undefined)
 }))
 vi.mock('../lib/session-persistence/session-persistence', () => ({
-  flushSessionPersistence: vi.fn(async () => undefined)
+  flushSessionPersistence
 }))
 
 import { completeQuitPersistenceFlush, useQuitPersistenceFlush } from './useQuitPersistenceFlush'
 
 afterEach(() => {
   vi.unstubAllGlobals()
+  flushPreviewPersistence.mockClear()
+  flushSessionPersistence.mockClear()
   resumeAutoReviewsAfterQuitAbort.mockClear()
 })
 
@@ -52,6 +61,44 @@ describe('completeQuitPersistenceFlush', () => {
     expect(removeRequest).toHaveBeenCalledOnce()
   })
 
+  it('flushes Preview persistence before acknowledging quit', async () => {
+    let notifyFlush: (request: { requestId: string }) => void = () => undefined
+    const removeRequest = vi.fn()
+    const sendFlushResponse = vi.fn()
+    vi.stubGlobal('window', {
+      api: {
+        sessions: {
+          onFlushRequest: (listener: (request: { requestId: string }) => void) => {
+            notifyFlush = listener
+            return removeRequest
+          },
+          sendFlushResponse
+        }
+      }
+    })
+
+    const { unmount } = renderHook(() => useQuitPersistenceFlush())
+    notifyFlush({ requestId: 'flush-preview-1' })
+
+    await vi.waitFor(() => {
+      expect(sendFlushResponse).toHaveBeenCalledWith({
+        requestId: 'flush-preview-1',
+        status: 'completed'
+      })
+    })
+    expect(flushSessionPersistence).toHaveBeenCalledOnce()
+    expect(flushPreviewPersistence).toHaveBeenCalledOnce()
+    expect(flushSessionPersistence.mock.invocationCallOrder[0]).toBeLessThan(
+      flushPreviewPersistence.mock.invocationCallOrder[0]
+    )
+    expect(flushPreviewPersistence.mock.invocationCallOrder[0]).toBeLessThan(
+      sendFlushResponse.mock.invocationCallOrder[0]
+    )
+
+    unmount()
+    expect(removeRequest).toHaveBeenCalledOnce()
+  })
+
   it('drains terminal runtime events before flushing and acknowledging', async () => {
     const calls: string[] = []
 
@@ -67,13 +114,22 @@ describe('completeQuitPersistenceFlush', () => {
         flushPersistence: async () => {
           calls.push('flush')
         },
+        flushPreviewPersistence: async () => {
+          calls.push('flush-preview')
+        },
         acknowledge: () => {
           calls.push('acknowledge')
         }
       }
     )
 
-    expect(calls).toEqual(['suppress-auto-reviews', 'drain', 'flush', 'acknowledge'])
+    expect(calls).toEqual([
+      'suppress-auto-reviews',
+      'drain',
+      'flush',
+      'flush-preview',
+      'acknowledge'
+    ])
   })
 
   it('always acknowledges so a failed renderer flush cannot strand app quit', async () => {
@@ -88,11 +144,34 @@ describe('completeQuitPersistenceFlush', () => {
             throw new Error('renderer unavailable')
           },
           flushPersistence: async () => undefined,
+          flushPreviewPersistence: async () => undefined,
           acknowledge
         }
       )
     ).rejects.toThrow('renderer unavailable')
     expect(acknowledge).toHaveBeenCalledWith({ requestId: 'flush-1', status: 'failed' })
+  })
+
+  it('reports a failed Preview flush so Main can abort quit', async () => {
+    const acknowledge = vi.fn()
+    const previewFailure = new Error('preview persistence failed')
+
+    await expect(
+      completeQuitPersistenceFlush(
+        { requestId: 'flush-preview-failed' },
+        {
+          suppressAutoReviews: () => undefined,
+          drainRuntimeEvents: async () => undefined,
+          flushPersistence: async () => undefined,
+          flushPreviewPersistence: async () => Promise.reject(previewFailure),
+          acknowledge
+        }
+      )
+    ).rejects.toBe(previewFailure)
+    expect(acknowledge).toHaveBeenCalledWith({
+      requestId: 'flush-preview-failed',
+      status: 'failed'
+    })
   })
 
   it('acknowledges an unresolved revision conflict without classifying the flush as completed', async () => {
@@ -108,6 +187,7 @@ describe('completeQuitPersistenceFlush', () => {
           suppressAutoReviews: () => undefined,
           drainRuntimeEvents: async () => undefined,
           flushPersistence: async () => Promise.reject(conflict),
+          flushPreviewPersistence: async () => undefined,
           acknowledge
         }
       )

--- a/src/renderer/src/hooks/useQuitPersistenceFlush.ts
+++ b/src/renderer/src/hooks/useQuitPersistenceFlush.ts
@@ -10,12 +10,14 @@ import {
   suppressAutoReviewsForQuit
 } from '../lib/acp/workspace-events'
 import { drainWorkspaceRuntimeEventsForPersistence } from '../lib/acp/useWorkspaceAgentRuntime'
+import { flushPreviewPersistence } from '../lib/preview-persistence/preview-persistence'
 import { flushSessionPersistence } from '../lib/session-persistence/session-persistence'
 
 type QuitPersistenceFlushDeps = {
   suppressAutoReviews: () => void
   drainRuntimeEvents: () => Promise<void>
   flushPersistence: () => Promise<void>
+  flushPreviewPersistence: () => Promise<void>
   acknowledge: (response: SessionPersistenceFlushResponse) => void
 }
 
@@ -29,6 +31,7 @@ export const completeQuitPersistenceFlush = async (
     deps.suppressAutoReviews()
     await deps.drainRuntimeEvents()
     await deps.flushPersistence()
+    await deps.flushPreviewPersistence()
   } catch (error) {
     failure = error
     status = isSessionRevisionConflictError(error) ? 'conflict' : 'failed'
@@ -52,6 +55,7 @@ export const useQuitPersistenceFlush = (): void => {
         suppressAutoReviews: suppressAutoReviewsForQuit,
         drainRuntimeEvents: drainWorkspaceRuntimeEventsForPersistence,
         flushPersistence: flushSessionPersistence,
+        flushPreviewPersistence,
         acknowledge: sendFlushResponse
       }).catch(() => undefined)
     })

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
@@ -530,6 +530,59 @@ describe('usePreviewPersistence per-project save/restore', () => {
     })
   })
 
+  it('keeps the latest state durable when an earlier save completes last', async () => {
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+    })
+
+    const firstItem = createStoredFileItem()
+    const secondItem = createStoredFileItem({
+      id: 'file:session-1:/workspace/project/results.csv',
+      title: 'results.csv',
+      path: '/workspace/project/results.csv',
+      format: 'csv',
+      name: 'results.csv'
+    })
+    act(() => {
+      usePreviewWorkbenchStore.setState({
+        panelState: 'open',
+        activeItemId: undefined,
+        items: [firstItem, secondItem]
+      })
+    })
+    await act(async () => Promise.resolve())
+
+    const delayedFirstSave = createDeferred<void>()
+    let durableState: PersistedPreviewState | undefined
+    save.mockClear()
+    save
+      .mockImplementationOnce(
+        ({ state }: { state: PersistedPreviewState }) =>
+          delayedFirstSave.promise.then(() => {
+            durableState = state
+          })
+      )
+      .mockImplementationOnce(({ state }: { state: PersistedPreviewState }) => {
+        durableState = state
+        return Promise.resolve()
+      })
+
+    act(() => {
+      usePreviewWorkbenchStore.setState({ activeItemId: firstItem.id })
+      usePreviewWorkbenchStore.setState({ activeItemId: secondItem.id })
+    })
+
+    await act(async () => {
+      delayedFirstSave.resolve()
+      await delayedFirstSave.promise
+    })
+
+    await vi.waitFor(() => {
+      expect(save).toHaveBeenCalledTimes(2)
+      expect(durableState?.activeItemId).toBe(secondItem.id)
+    })
+  })
+
   it('flushes the active project on unmount', async () => {
     await act(async () => {
       root.render(<PersistenceHarness projectId="project-a" />)

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
@@ -26,15 +26,18 @@ type StoreState = ReturnType<typeof usePreviewWorkbenchStore.getState>
 type Deferred<Value> = {
   promise: Promise<Value>
   resolve: (value: Value) => void
+  reject: (reason?: unknown) => void
 }
 
 const createDeferred = <Value,>(): Deferred<Value> => {
   let resolve!: (value: Value) => void
-  const promise = new Promise<Value>((innerResolve) => {
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<Value>((innerResolve, innerReject) => {
     resolve = innerResolve
+    reject = innerReject
   })
 
-  return { promise, resolve }
+  return { promise, resolve, reject }
 }
 
 // A stored file item as it lives in the workbench store (timestamps + type included).
@@ -641,6 +644,45 @@ describe('usePreviewPersistence per-project save/restore', () => {
     })
 
     expect(durableState?.activeItemId).toBe(secondItem.id)
+  })
+
+  it('retries the latest failed state on a later flush', async () => {
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+    })
+
+    const item = createStoredFileItem()
+    act(() => {
+      usePreviewWorkbenchStore.setState({
+        panelState: 'open',
+        activeItemId: undefined,
+        items: [item]
+      })
+    })
+    await act(async () => Promise.resolve())
+
+    const failedSave = createDeferred<void>()
+    let durableState: PersistedPreviewState | undefined
+    save.mockClear()
+    save
+      .mockImplementationOnce(() => failedSave.promise)
+      .mockImplementationOnce(({ state }: { state: PersistedPreviewState }) => {
+        durableState = state
+        return Promise.resolve()
+      })
+
+    act(() => {
+      usePreviewWorkbenchStore.setState({ activeItemId: item.id })
+    })
+
+    const firstFlush = flushPreviewPersistence()
+    failedSave.reject(new Error('transient save failure'))
+    await expect(firstFlush).rejects.toThrow('transient save failure')
+
+    await flushPreviewPersistence()
+
+    expect(save).toHaveBeenCalledTimes(2)
+    expect(durableState?.activeItemId).toBe(item.id)
   })
 
   it('flushes the active project on unmount', async () => {

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
@@ -556,11 +556,10 @@ describe('usePreviewPersistence per-project save/restore', () => {
     let durableState: PersistedPreviewState | undefined
     save.mockClear()
     save
-      .mockImplementationOnce(
-        ({ state }: { state: PersistedPreviewState }) =>
-          delayedFirstSave.promise.then(() => {
-            durableState = state
-          })
+      .mockImplementationOnce(({ state }: { state: PersistedPreviewState }) =>
+        delayedFirstSave.promise.then(() => {
+          durableState = state
+        })
       )
       .mockImplementationOnce(({ state }: { state: PersistedPreviewState }) => {
         durableState = state
@@ -579,6 +578,68 @@ describe('usePreviewPersistence per-project save/restore', () => {
 
     await vi.waitFor(() => {
       expect(save).toHaveBeenCalledTimes(2)
+      expect(durableState?.activeItemId).toBe(secondItem.id)
+    })
+  })
+
+  it('keeps the latest state durable across a remount while an earlier save is in flight', async () => {
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+    })
+
+    const firstItem = createStoredFileItem()
+    const secondItem = createStoredFileItem({
+      id: 'file:session-1:/workspace/project/results.csv',
+      title: 'results.csv',
+      path: '/workspace/project/results.csv',
+      format: 'csv',
+      name: 'results.csv'
+    })
+    act(() => {
+      usePreviewWorkbenchStore.setState({
+        panelState: 'open',
+        activeItemId: undefined,
+        items: [firstItem, secondItem]
+      })
+    })
+    await act(async () => Promise.resolve())
+
+    const delayedFirstSave = createDeferred<void>()
+    const pendingRemountLoad = createDeferred<PersistedPreviewState | undefined>()
+    let durableState: PersistedPreviewState | undefined
+    load.mockReturnValueOnce(pendingRemountLoad.promise)
+    save.mockClear()
+    save
+      .mockImplementationOnce(({ state }: { state: PersistedPreviewState }) =>
+        delayedFirstSave.promise.then(() => {
+          durableState = state
+        })
+      )
+      .mockImplementationOnce(({ state }: { state: PersistedPreviewState }) => {
+        durableState = state
+        return Promise.resolve()
+      })
+
+    act(() => {
+      usePreviewWorkbenchStore.setState({ activeItemId: firstItem.id })
+    })
+    await act(async () => {
+      root.unmount()
+    })
+    root = createRoot(container)
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+    })
+    act(() => {
+      usePreviewWorkbenchStore.setState({ activeItemId: secondItem.id })
+    })
+
+    await act(async () => {
+      delayedFirstSave.resolve()
+      await delayedFirstSave.promise
+    })
+
+    await vi.waitFor(() => {
       expect(durableState?.activeItemId).toBe(secondItem.id)
     })
   })

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../stores/session-store'
 import type { UploadedAttachment } from '../../../../shared/uploads'
 import {
+  flushPreviewPersistence,
   toPersistedPreviewState,
   toRestoredSlice,
   usePreviewPersistence
@@ -571,15 +572,14 @@ describe('usePreviewPersistence per-project save/restore', () => {
       usePreviewWorkbenchStore.setState({ activeItemId: secondItem.id })
     })
 
+    const flushing = flushPreviewPersistence()
     await act(async () => {
       delayedFirstSave.resolve()
-      await delayedFirstSave.promise
+      await flushing
     })
 
-    await vi.waitFor(() => {
-      expect(save).toHaveBeenCalledTimes(2)
-      expect(durableState?.activeItemId).toBe(secondItem.id)
-    })
+    expect(save).toHaveBeenCalledTimes(2)
+    expect(durableState?.activeItemId).toBe(secondItem.id)
   })
 
   it('keeps the latest state durable across a remount while an earlier save is in flight', async () => {
@@ -634,14 +634,13 @@ describe('usePreviewPersistence per-project save/restore', () => {
       usePreviewWorkbenchStore.setState({ activeItemId: secondItem.id })
     })
 
+    const flushing = flushPreviewPersistence()
     await act(async () => {
       delayedFirstSave.resolve()
-      await delayedFirstSave.promise
+      await flushing
     })
 
-    await vi.waitFor(() => {
-      expect(durableState?.activeItemId).toBe(secondItem.id)
-    })
+    expect(durableState?.activeItemId).toBe(secondItem.id)
   })
 
   it('flushes the active project on unmount', async () => {

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.ts
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.ts
@@ -39,7 +39,13 @@ const createPreviewSaveScheduler = (
       drain: Promise<void> | undefined
     }
   >()
-  const failures = new Map<string, unknown>()
+  const failures = new Map<
+    string,
+    {
+      state: PersistedPreviewState
+      error: unknown
+    }
+  >()
 
   const schedule = ({ projectId, state }: SavePreviewStateRequest): void => {
     const queue = queues.get(projectId) ?? { pendingState: undefined, drain: undefined }
@@ -58,7 +64,7 @@ const createPreviewSaveScheduler = (
             await save({ projectId, state: nextState })
             failures.delete(projectId)
           } catch (error) {
-            failures.set(projectId, error)
+            failures.set(projectId, { state: nextState, error })
             reportError(error)
           }
         }
@@ -71,6 +77,10 @@ const createPreviewSaveScheduler = (
   }
 
   const flush = async (): Promise<void> => {
+    for (const [projectId, failure] of failures) {
+      if (!queues.has(projectId)) schedule({ projectId, state: failure.state })
+    }
+
     while (queues.size > 0) {
       await Promise.all(
         [...queues.values()]
@@ -80,7 +90,7 @@ const createPreviewSaveScheduler = (
     }
 
     if (failures.size > 0) {
-      throw failures.values().next().value ?? new Error('Preview persistence flush failed')
+      throw failures.values().next().value?.error ?? new Error('Preview persistence flush failed')
     }
   }
 

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.ts
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.ts
@@ -17,6 +17,10 @@ import { getPreviewFormatForFile } from '../../pages/workspace/preview-support'
 
 type PreviewStoreState = ReturnType<typeof usePreviewWorkbenchStore.getState>
 type PreviewSave = (request: SavePreviewStateRequest) => Promise<void>
+type PreviewSaveScheduler = {
+  schedule: (request: SavePreviewStateRequest) => void
+  flush: () => Promise<void>
+}
 
 const reportPersistenceError = (error: unknown): void => {
   console.warn('Preview persistence failed', error)
@@ -27,46 +31,70 @@ const reportPersistenceError = (error: unknown): void => {
 const createPreviewSaveScheduler = (
   save: PreviewSave,
   reportError: (error: unknown) => void
-): ((request: SavePreviewStateRequest) => void) => {
+): PreviewSaveScheduler => {
   const queues = new Map<
     string,
     {
       pendingState: PersistedPreviewState | undefined
-      isDraining: boolean
+      drain: Promise<void> | undefined
     }
   >()
+  const failures = new Map<string, unknown>()
 
-  return ({ projectId, state }) => {
-    const queue = queues.get(projectId) ?? { pendingState: undefined, isDraining: false }
+  const schedule = ({ projectId, state }: SavePreviewStateRequest): void => {
+    const queue = queues.get(projectId) ?? { pendingState: undefined, drain: undefined }
     queue.pendingState = state
     queues.set(projectId, queue)
 
-    if (queue.isDraining) return
-    queue.isDraining = true
+    if (queue.drain) return
 
-    void (async () => {
-      while (queue.pendingState) {
-        const nextState = queue.pendingState
-        queue.pendingState = undefined
+    const drain = (async () => {
+      try {
+        while (queue.pendingState) {
+          const nextState = queue.pendingState
+          queue.pendingState = undefined
 
-        try {
-          await save({ projectId, state: nextState })
-        } catch (error) {
-          reportError(error)
+          try {
+            await save({ projectId, state: nextState })
+            failures.delete(projectId)
+          } catch (error) {
+            failures.set(projectId, error)
+            reportError(error)
+          }
         }
+      } finally {
+        if (queues.get(projectId) === queue) queues.delete(projectId)
       }
-
-      queues.delete(projectId)
     })()
+    queue.drain = drain
+    void drain.catch(() => undefined)
   }
+
+  const flush = async (): Promise<void> => {
+    while (queues.size > 0) {
+      await Promise.all(
+        [...queues.values()]
+          .map((queue) => queue.drain)
+          .filter((drain): drain is Promise<void> => !!drain)
+      )
+    }
+
+    if (failures.size > 0) {
+      throw failures.values().next().value ?? new Error('Preview persistence flush failed')
+    }
+  }
+
+  return { schedule, flush }
 }
 
 // WorkspacePage can unmount while an IPC save is still in flight. Keep one renderer-lifetime scheduler
 // so a later Workspace mount cannot start a competing queue for the same Project.
-const schedulePreviewSave = createPreviewSaveScheduler(
+const previewSaveScheduler = createPreviewSaveScheduler(
   (request) => window.api.preview.save(request),
   reportPersistenceError
 )
+const schedulePreviewSave = previewSaveScheduler.schedule
+const flushPreviewPersistence = previewSaveScheduler.flush
 
 // Projects the live store slice down to its durable subset: file previews plus the one Session-scoped
 // Subagents selection. Other tool tabs remain runtime-only and re-appear from their existing owners.
@@ -259,4 +287,4 @@ export const usePreviewPersistence = (
   }, [])
 }
 
-export { toPersistedPreviewState, toRestoredSlice }
+export { flushPreviewPersistence, toPersistedPreviewState, toRestoredSlice }

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.ts
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.ts
@@ -61,6 +61,13 @@ const createPreviewSaveScheduler = (
   }
 }
 
+// WorkspacePage can unmount while an IPC save is still in flight. Keep one renderer-lifetime scheduler
+// so a later Workspace mount cannot start a competing queue for the same Project.
+const schedulePreviewSave = createPreviewSaveScheduler(
+  (request) => window.api.preview.save(request),
+  reportPersistenceError
+)
+
 // Projects the live store slice down to its durable subset: file previews plus the one Session-scoped
 // Subagents selection. Other tool tabs remain runtime-only and re-appear from their existing owners.
 const toPersistedPreviewState = (state: PreviewStoreState): PersistedPreviewState => ({
@@ -176,15 +183,6 @@ export const usePreviewPersistence = (
   isSessionPersistenceReady: boolean
 ): void => {
   const previousProjectIdRef = useRef<string | undefined>(undefined)
-  const scheduleSaveRef = useRef<((request: SavePreviewStateRequest) => void) | undefined>(undefined)
-
-  if (!scheduleSaveRef.current) {
-    scheduleSaveRef.current = createPreviewSaveScheduler(
-      (request) => window.api.preview.save(request),
-      reportPersistenceError
-    )
-  }
-  const scheduleSave = scheduleSaveRef.current
 
   useEffect(() => {
     // Upload preview paths can only be reconciled after persisted sessions have hydrated.
@@ -204,7 +202,7 @@ export const usePreviewPersistence = (
       previousProjectId !== activeProjectId &&
       store.activeProjectId === previousProjectId
     ) {
-      scheduleSave({ projectId: previousProjectId, state: toPersistedPreviewState(store) })
+      schedulePreviewSave({ projectId: previousProjectId, state: toPersistedPreviewState(store) })
     }
 
     previousProjectIdRef.current = activeProjectId
@@ -234,14 +232,14 @@ export const usePreviewPersistence = (
     return () => {
       cancelled = true
     }
-  }, [activeProjectId, isSessionPersistenceReady, scheduleSave])
+  }, [activeProjectId, isSessionPersistenceReady])
 
   // Write through workbench changes so a process-level restart cannot lose the selected Subagent
   // Frame (or another durable preview change) before React gets an unmount opportunity.
   useEffect(() => {
     const unsubscribe = usePreviewWorkbenchStore.subscribe((state) => {
       if (!state.activeProjectId) return
-      scheduleSave({
+      schedulePreviewSave({
         projectId: state.activeProjectId,
         state: toPersistedPreviewState(state)
       })
@@ -251,11 +249,14 @@ export const usePreviewPersistence = (
       unsubscribe()
       const state = usePreviewWorkbenchStore.getState()
       if (state.activeProjectId) {
-        scheduleSave({ projectId: state.activeProjectId, state: toPersistedPreviewState(state) })
+        schedulePreviewSave({
+          projectId: state.activeProjectId,
+          state: toPersistedPreviewState(state)
+        })
       }
       state.closeFileDialog()
     }
-  }, [scheduleSave])
+  }, [])
 }
 
 export { toPersistedPreviewState, toRestoredSlice }

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.ts
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.ts
@@ -1,6 +1,10 @@
 import { useEffect, useRef } from 'react'
 
-import { PREVIEW_STATE_VERSION, type PersistedPreviewState } from '../../../../shared/preview-state'
+import {
+  PREVIEW_STATE_VERSION,
+  type PersistedPreviewState,
+  type SavePreviewStateRequest
+} from '../../../../shared/preview-state'
 import { getUploadedAttachmentPath } from '../../../../shared/uploads'
 import {
   usePreviewWorkbenchStore,
@@ -12,9 +16,49 @@ import { useSessionStore, type ChatSession } from '../../stores/session-store'
 import { getPreviewFormatForFile } from '../../pages/workspace/preview-support'
 
 type PreviewStoreState = ReturnType<typeof usePreviewWorkbenchStore.getState>
+type PreviewSave = (request: SavePreviewStateRequest) => Promise<void>
 
 const reportPersistenceError = (error: unknown): void => {
   console.warn('Preview persistence failed', error)
+}
+
+// Serializes saves per Project while coalescing queued snapshots to the newest state. Different
+// Projects drain independently, and a failed write does not prevent a newer snapshot from being saved.
+const createPreviewSaveScheduler = (
+  save: PreviewSave,
+  reportError: (error: unknown) => void
+): ((request: SavePreviewStateRequest) => void) => {
+  const queues = new Map<
+    string,
+    {
+      pendingState: PersistedPreviewState | undefined
+      isDraining: boolean
+    }
+  >()
+
+  return ({ projectId, state }) => {
+    const queue = queues.get(projectId) ?? { pendingState: undefined, isDraining: false }
+    queue.pendingState = state
+    queues.set(projectId, queue)
+
+    if (queue.isDraining) return
+    queue.isDraining = true
+
+    void (async () => {
+      while (queue.pendingState) {
+        const nextState = queue.pendingState
+        queue.pendingState = undefined
+
+        try {
+          await save({ projectId, state: nextState })
+        } catch (error) {
+          reportError(error)
+        }
+      }
+
+      queues.delete(projectId)
+    })()
+  }
 }
 
 // Projects the live store slice down to its durable subset: file previews plus the one Session-scoped
@@ -132,6 +176,15 @@ export const usePreviewPersistence = (
   isSessionPersistenceReady: boolean
 ): void => {
   const previousProjectIdRef = useRef<string | undefined>(undefined)
+  const scheduleSaveRef = useRef<((request: SavePreviewStateRequest) => void) | undefined>(undefined)
+
+  if (!scheduleSaveRef.current) {
+    scheduleSaveRef.current = createPreviewSaveScheduler(
+      (request) => window.api.preview.save(request),
+      reportPersistenceError
+    )
+  }
+  const scheduleSave = scheduleSaveRef.current
 
   useEffect(() => {
     // Upload preview paths can only be reconciled after persisted sessions have hydrated.
@@ -151,9 +204,7 @@ export const usePreviewPersistence = (
       previousProjectId !== activeProjectId &&
       store.activeProjectId === previousProjectId
     ) {
-      void window.api.preview
-        .save({ projectId: previousProjectId, state: toPersistedPreviewState(store) })
-        .catch(reportPersistenceError)
+      scheduleSave({ projectId: previousProjectId, state: toPersistedPreviewState(store) })
     }
 
     previousProjectIdRef.current = activeProjectId
@@ -183,32 +234,28 @@ export const usePreviewPersistence = (
     return () => {
       cancelled = true
     }
-  }, [activeProjectId, isSessionPersistenceReady])
+  }, [activeProjectId, isSessionPersistenceReady, scheduleSave])
 
   // Write through workbench changes so a process-level restart cannot lose the selected Subagent
   // Frame (or another durable preview change) before React gets an unmount opportunity.
   useEffect(() => {
     const unsubscribe = usePreviewWorkbenchStore.subscribe((state) => {
       if (!state.activeProjectId) return
-      void window.api.preview
-        .save({
-          projectId: state.activeProjectId,
-          state: toPersistedPreviewState(state)
-        })
-        .catch(reportPersistenceError)
+      scheduleSave({
+        projectId: state.activeProjectId,
+        state: toPersistedPreviewState(state)
+      })
     })
 
     return () => {
       unsubscribe()
       const state = usePreviewWorkbenchStore.getState()
       if (state.activeProjectId) {
-        void window.api.preview
-          .save({ projectId: state.activeProjectId, state: toPersistedPreviewState(state) })
-          .catch(reportPersistenceError)
+        scheduleSave({ projectId: state.activeProjectId, state: toPersistedPreviewState(state) })
       }
       state.closeFileDialog()
     }
-  }, [])
+  }, [scheduleSave])
 }
 
 export { toPersistedPreviewState, toRestoredSlice }


### PR DESCRIPTION
## Problem

Preview workbench mutations launched `preview.save` calls concurrently. If an older request completed after a newer one, its valid but stale snapshot could become the final durable state and restore an old active tab, panel state, or Subagent Frame after navigation or restart.

The production SQLite client uses one connection, which reduces the likelihood of reordering, but the renderer-to-persistence contract did not enforce FIFO or last-write-wins behavior.

## Proposed change

- keep one renderer-lifetime scheduler across Workspace remounts and serialize preview saves independently per Project;
- retain only the newest queued snapshot while a save is in flight;
- continue draining a newer snapshot after an earlier save fails;
- retain the latest failed snapshot so a later orderly-quit flush can retry a transient failure;
- route subscription, Project-switch, and unmount saves through the same scheduler;
- await queued Preview snapshots through the existing renderer quit-persistence handshake;
- add deterministic regression tests for out-of-order completion, remount ordering, quit flushing, and retry recovery.

## Scope and non-goals

- No database schema, migration, persisted field, state version, enum, shared request, or user interaction changes.
- Existing `PersistedPreviewState` version 1 data remains compatible without conversion.
- Orderly quit can wait for outstanding Preview persistence; a failed flush uses the existing quit-abort behavior and can retry on the next quit attempt.
- Intermediate queued snapshots may be coalesced because persistence owns the latest Project snapshot, not an event log.
- Abrupt process termination outside the orderly quit handshake remains outside this fix.

## Acceptance criteria and validation

Checks below ran after the last material edit:

- latest Preview state remains durable across out-of-order completion and Workspace remount, and a later flush retries a transient failure -> `npm test -- src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx` -> 15/15 passed;
- orderly quit waits for queued Preview state and reports write failures -> `npm test -- src/renderer/src/hooks/useQuitPersistenceFlush.test.ts src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx` -> 21/21 passed;
- renderer types remain valid -> `npm run typecheck:web` -> passed;
- changed source and tests satisfy lint rules -> `npm run lint` -> passed.

The changed path is not currently assigned to a standalone Module in `scripts/ci/module-impact.json`, so the project-owned preview-persistence test file is the focused local module check. PR Gate remains authoritative for complete affected and platform lanes.

## Review focus

- per-Project isolation and latest-snapshot coalescing;
- ordering across subscription, Project switch, unmount, and orderly quit paths;
- transient failure recovery without blocking newer queued snapshots.
