### PR TITLE
fix(main-process): terminate after fatal errors

### DIFF
--- a/src/main/index-fatal-errors.test.ts
+++ b/src/main/index-fatal-errors.test.ts
@@ -1,0 +1,188 @@
+import { spawn } from 'node:child_process'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const log = {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn()
+  }
+  const app = {
+    isPackaged: false,
+    setName: vi.fn(),
+    getPath: vi.fn(() => 'test-logs'),
+    getVersion: vi.fn(() => '0.0.0-test'),
+    on: vi.fn(),
+    quit: vi.fn(),
+    exit: vi.fn()
+  }
+
+  return {
+    app,
+    log,
+    writeFatalLogSync: vi.fn(),
+    registerRendererDiagnosticsIpc: vi.fn(() => {
+      throw new Error('stop after process failure handlers are installed')
+    }),
+    reportApplicationStartupFailure: vi.fn(async () => undefined)
+  }
+})
+
+vi.mock('node:module', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:module')>()),
+  createRequire: () => () => ({
+    app: mocks.app,
+    BrowserWindow: {},
+    crashReporter: {},
+    ipcMain: {},
+    nativeImage: {},
+    nativeTheme: {},
+    protocol: { registerSchemesAsPrivileged: vi.fn() }
+  })
+}))
+
+vi.mock('./single-instance', () => ({
+  acquireSingleInstanceLock: vi.fn(() => true)
+}))
+
+vi.mock('./app-startup', () => ({
+  createSecondInstanceRelay: vi.fn(() => ({
+    bind: vi.fn(),
+    signal: vi.fn()
+  })),
+  createStartupWindowCloseOptions: vi.fn(),
+  createStartupWindowSecondInstanceHandler: vi.fn(),
+  orchestrateAppStartup: vi.fn()
+}))
+
+vi.mock('./crash-diagnostics', () => ({
+  installChildProcessGoneLogging: vi.fn(),
+  startLocalCrashReporting: vi.fn()
+}))
+
+vi.mock('./diagnostics/startup', () => ({
+  initializeApplicationDiagnostics: vi.fn(() => ({
+    log: mocks.log,
+    operation: { phase: vi.fn() },
+    flush: vi.fn(async () => undefined)
+  })),
+  reportApplicationStartupFailure: mocks.reportApplicationStartupFailure
+}))
+
+vi.mock('./logger', () => ({
+  createLogger: vi.fn(() => mocks.log),
+  diagnosticErrorFields: vi.fn((error: unknown) => ({ error })),
+  flushLogs: vi.fn(async () => undefined),
+  writeFatalLogSync: mocks.writeFatalLogSync
+}))
+
+vi.mock('./renderer-diagnostics', () => ({
+  createRendererFailureReporter: vi.fn(() => vi.fn()),
+  registerRendererDiagnosticsIpc: mocks.registerRendererDiagnosticsIpc
+}))
+
+type ProcessFailureListener = (reason: unknown, origin?: string) => void
+
+type ChildResult = {
+  exitCode: number | null
+  signal: NodeJS.Signals | null
+  stderr: string
+  stdout: string
+}
+
+const runFatalChild = (
+  eventName: 'uncaughtException' | 'unhandledRejection'
+): Promise<ChildResult> =>
+  new Promise((resolve, reject) => {
+    const script = `
+      process.on('uncaughtExceptionMonitor', (error, origin) => {
+        process.stderr.write('MONITORED:' + origin + ':' + error.message + '\\n')
+      })
+      setTimeout(() => process.stdout.write('POST_FATAL_SENTINEL\\n'), 100)
+      if (${JSON.stringify(eventName)} === 'uncaughtException') {
+        setImmediate(() => { throw new Error('fatal uncaughtException') })
+      } else {
+        void Promise.reject(new Error('fatal unhandledRejection'))
+      }
+    `
+    const child = spawn(process.execPath, ['-e', script], {
+      env: { ...process.env, NODE_OPTIONS: '' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true
+    })
+    let stderr = ''
+    let stdout = ''
+    child.stderr.setEncoding('utf8')
+    child.stdout.setEncoding('utf8')
+    child.stderr.on('data', (chunk: string) => (stderr += chunk))
+    child.stdout.on('data', (chunk: string) => (stdout += chunk))
+    child.once('error', reject)
+    child.once('close', (exitCode, signal) => resolve({ exitCode, signal, stderr, stdout }))
+  })
+
+const bootUntilFailureHandlersAreInstalled = async (): Promise<
+  Map<NodeJS.Signals | string, ProcessFailureListener>
+> => {
+  vi.resetModules()
+  mocks.app.quit.mockClear()
+  mocks.app.exit.mockClear()
+  mocks.log.error.mockClear()
+  mocks.writeFatalLogSync.mockClear()
+  mocks.registerRendererDiagnosticsIpc.mockClear()
+  mocks.reportApplicationStartupFailure.mockClear()
+  vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+  const listeners = new Map<NodeJS.Signals | string, ProcessFailureListener>()
+  vi.spyOn(process, 'on').mockImplementation(((event: string, listener: ProcessFailureListener) => {
+    listeners.set(event, listener)
+    return process
+  }) as typeof process.on)
+
+  await import('./index')
+  await vi.waitFor(() => expect(mocks.registerRendererDiagnosticsIpc).toHaveBeenCalledOnce())
+
+  return listeners
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('main-process fatal errors', () => {
+  it('observes both fatal origins without installing a consuming listener', async () => {
+    const listeners = await bootUntilFailureHandlersAreInstalled()
+    const monitor = listeners.get('uncaughtExceptionMonitor')
+
+    expect(monitor).toBeTypeOf('function')
+    expect(listeners.has('uncaughtException')).toBe(false)
+    expect(listeners.has('unhandledRejection')).toBe(false)
+
+    for (const eventName of ['uncaughtException', 'unhandledRejection'] as const) {
+      const error = new Error(`fatal ${eventName}`)
+      monitor?.(error, eventName)
+      expect(mocks.writeFatalLogSync).toHaveBeenCalledWith(
+        'main',
+        eventName,
+        expect.objectContaining({ error })
+      )
+    }
+
+    expect(mocks.log.error).not.toHaveBeenCalled()
+    expect(mocks.app.quit).not.toHaveBeenCalled()
+    expect(mocks.app.exit).not.toHaveBeenCalled()
+  })
+
+  it.each(['uncaughtException', 'unhandledRejection'] as const)(
+    'preserves Node fail-fast termination for %s',
+    async (eventName) => {
+      const result = await runFatalChild(eventName)
+
+      expect(result.signal).toBeNull()
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain(`MONITORED:${eventName}:fatal ${eventName}`)
+      expect(result.stdout).not.toContain('POST_FATAL_SENTINEL')
+    }
+  )
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,7 +18,7 @@ import {
   initializeApplicationDiagnostics,
   reportApplicationStartupFailure
 } from './diagnostics/startup'
-import { createLogger, diagnosticErrorFields, flushLogs } from './logger'
+import { createLogger, diagnosticErrorFields, flushLogs, writeFatalLogSync } from './logger'
 import { MANAGED_PREVIEW_SCHEME } from './managed-preview-resources'
 import { OFFICE_PREVIEW_RUNTIME_SCHEME_CONFIG } from './office-preview/office-preview-runtime-protocol'
 import {
@@ -146,11 +146,12 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
   // Register process-level failure capture before loading the application modules. Keep renderer
   // diagnostics on a separate, one-way channel while the central IPC registry is being refactored.
   installChildProcessGoneLogging((listener) => app.on('child-process-gone', listener), log)
-  process.on('uncaughtException', (error) =>
-    log.error('uncaughtException', diagnosticErrorFields(error))
-  )
-  process.on('unhandledRejection', (reason) =>
-    log.error('unhandledRejection', diagnosticErrorFields(reason))
+  // Observe fatal JavaScript failures without consuming Node's default non-zero termination. A
+  // consuming uncaughtException/unhandledRejection listener would leave Electron serving IPC and
+  // mutating durable state after application invariants became unknown. The monitor also receives
+  // unhandled rejections promoted by Node's default `throw` mode, preserving their distinct origin.
+  process.on('uncaughtExceptionMonitor', (error, origin) =>
+    writeFatalLogSync('main', origin, diagnosticErrorFields(error))
   )
   registerRendererDiagnosticsIpc(
     ipcMain,

--- a/src/main/logger.test.ts
+++ b/src/main/logger.test.ts
@@ -10,7 +10,8 @@ import {
   errorLogFields,
   flushLogs,
   formatLine,
-  initLogger
+  initLogger,
+  writeFatalLogSync
 } from './logger'
 import {
   ApplicationModuleDisposalTimeoutError,
@@ -1269,6 +1270,35 @@ describe('logger: application shutdown diagnostics', () => {
     expect(json).not.toContain('1000ms')
     expect(json).not.toContain('compute poller stop failed')
     expect(json).not.toContain('/private/project')
+  })
+})
+
+describe('logger: fatal process diagnostics', () => {
+  it('persists the fatal record before returning without awaiting the write queue', async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'os-logger-fatal-'))
+    initLogger({
+      logDir,
+      fileName: 'main.log',
+      mirrorToConsole: false,
+      runId: 'fatal-test-run'
+    })
+
+    writeFatalLogSync('main', 'unhandledRejection', { errorCategory: 'type' })
+
+    const record = JSON.parse(await readFile(join(logDir, 'main.log'), 'utf8')) as {
+      level: string
+      scope: string
+      msg: string
+      runId: string
+      data: { errorCategory: string }
+    }
+    expect(record).toMatchObject({
+      level: 'error',
+      scope: 'main',
+      msg: 'unhandledRejection',
+      runId: 'fatal-test-run',
+      data: { errorCategory: 'type' }
+    })
   })
 })
 

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -1,4 +1,5 @@
 import { appendFile, mkdir, rename, rm, stat } from 'node:fs/promises'
+import { appendFileSync, mkdirSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { extname, join } from 'node:path'
 
@@ -813,6 +814,26 @@ const getLogFilePath = (): string | undefined =>
 // Resolves once all queued writes have flushed. Useful for tests and orderly shutdown.
 const flushLogs = (): Promise<void> => writeChain
 
+// Fatal process failures cannot await the ordinary Promise-backed write queue: Node terminates as soon
+// as the uncaughtExceptionMonitor listeners return. Append the final bounded, redacted record
+// synchronously so the diagnostic survives that exit. Rotation and currentBytes bookkeeping are
+// intentionally skipped because the process must not resume after this call; at worst one small fatal
+// record temporarily exceeds the configured cap before the next startup rotates normally.
+const writeFatalLogSync = (scope: string, message: string, data?: unknown): void => {
+  if (!config || LEVEL_ORDER.error < LEVEL_ORDER[config.minLevel]) return
+
+  try {
+    mkdirSync(config.logDir, { recursive: true })
+    appendFileSync(
+      join(config.logDir, config.fileName),
+      `${formatLine('error', scope, message, data, config.runId)}\n`,
+      'utf8'
+    )
+  } catch {
+    // Fatal logging is best-effort and must never mask the original uncaught failure.
+  }
+}
+
 const emit = (level: LogLevel, scope: string, message: string, data?: unknown): void => {
   const mirror = config?.mirrorToConsole ?? true
   const line = formatLine(level, scope, message, data, config?.runId)
@@ -853,5 +874,6 @@ export {
   flushLogs,
   formatLine,
   getLogFilePath,
-  initLogger
+  initLogger,
+  writeFatalLogSync
 }


### PR DESCRIPTION
## Problem

The Electron main process registered consuming `uncaughtException` and `unhandledRejection` listeners that only logged. Those listeners suppressed Node's default fatal termination and allowed IPC, persistence, SQLite access, and child-process supervision to continue after application invariants became unknown.

A regression test first reproduced the issue through the real `src/main/index.ts` registration path: both handlers logged, but neither requested termination.

## Proposed change

- observe JavaScript fatal failures through `uncaughtExceptionMonitor`;
- synchronously append the bounded, redacted fatal diagnostic before the monitor returns, because Node cannot await the normal Promise-backed log queue at this boundary;
- remove the consuming `unhandledRejection` listener so Node's default `throw` mode promotes it to a fatal uncaught exception;
- retain distinct `uncaughtException` / `unhandledRejection` diagnostic origins;
- cover the production registration, synchronous fatal-log persistence, and real Node child processes proving both origins exit with code 1 before post-failure work can execute.

## Scope and non-goals

- No database fields, migrations, JSON shapes, domain relationships, or historical-data compatibility changes.
- No new persisted application state or enum value. The only persistence addition is one fatal diagnostic line in the existing `main.log` format.
- No dialog or other UI interaction change; the observable change is fail-fast termination instead of continued operation.
- The ordinary Electron quit lifecycle is unchanged. It remains cancellable for active delegated work, migrations, and renderer Session persistence failures.
- Automatic restart and a new cross-platform child-process supervisor/job-object design are out of scope.

On fatal termination, committed SQLite and Session data retain their existing formats. An in-flight SQLite transaction relies on journal/WAL recovery; queued but uncommitted writes may be lost, and an interrupted Session temp-file write may leave an ignored `.tmp` file. This intentionally prefers the last committed state over accepting new writes from an undefined process.

## Acceptance criteria and validation

All listed local checks ran after the last material edit:

- fatal registration, synchronous diagnostic persistence, and real-process exit behavior -> `npm test -- src/main/index-fatal-errors.test.ts src/main/logger.test.ts` -> 2 files passed, 70 tests passed;
- Node main-process type contracts -> `npm run typecheck:node` -> passed;
- linted source and tests -> `npm run lint` -> passed with no warnings;
- changed-file formatting -> `npx prettier --check src/main/index.ts src/main/index-fatal-errors.test.ts src/main/logger.ts src/main/logger.test.ts` -> passed.

The fatal registration test was red before the fail-fast production change. A second review-driven red assertion then failed with 1 failed / 2 passed until the production handler used the synchronous fatal sink. Per maintainer direction, the full local `npm test` suite was not run; exact-head PR Gate is authoritative for broader and cross-platform coverage.

Residual risk: previously queued asynchronous log records are not guaranteed to flush, and external descendants not bound to main-process death may survive a genuine crash. The fatal record itself is synchronously persisted; supervising external descendants requires a separate cross-platform design.

## Review focus

- Confirm `uncaughtExceptionMonitor` preserves Node's default non-zero exit rather than consuming the failure.
- Confirm the fatal-only synchronous append cannot mask the original exception and reuses the existing bounded/redacted log format.
- Confirm removing the `unhandledRejection` listener is correct for the shipped Node default `throw` behavior.
- Confirm the subprocess regression would fail if either consuming listener were restored.
