### PR TITLE
fix(storage): persist onboarding data root atomically

### DIFF
--- a/src/main/settings/capabilities.ts
+++ b/src/main/settings/capabilities.ts
@@ -26,11 +26,15 @@ export type SettingsPreferencesSnapshot = {
   defaultPermissionProfile: PermissionProfileId
 }
 
+export type SetDataRootOptions = Readonly<{
+  completeOnboarding?: boolean
+}>
+
 export interface SettingsPreferences {
   getSnapshot(): Promise<SettingsPreferencesSnapshot>
   markOnboardingComplete(): Promise<SettingsPreferencesSnapshot>
   markPathsNormalized(): Promise<SettingsPreferencesSnapshot>
-  setDataRoot(path: string): Promise<SettingsPreferencesSnapshot>
+  setDataRoot(path: string, options?: SetDataRootOptions): Promise<SettingsPreferencesSnapshot>
   dismissLegacyDataMovePrompt(): Promise<SettingsPreferencesSnapshot>
   setReasoningEffort(effort: ReasoningEffort): Promise<SettingsPreferencesSnapshot>
   setNotificationsEnabled(enabled: boolean): Promise<SettingsPreferencesSnapshot>

--- a/src/main/settings/preferences.test.ts
+++ b/src/main/settings/preferences.test.ts
@@ -45,8 +45,7 @@ describe('SettingsPreferencesModule', () => {
     await preferences.setClosePreference('quit')
     await preferences.setAppIconVariant('dark')
     await preferences.setDefaultPermissionProfile('auto')
-    await preferences.setDataRoot(dataRoot)
-    await preferences.markOnboardingComplete()
+    await preferences.setDataRoot(dataRoot, { completeOnboarding: true })
     await preferences.markPathsNormalized()
     await preferences.dismissLegacyDataMovePrompt()
 

--- a/src/main/settings/preferences.ts
+++ b/src/main/settings/preferences.ts
@@ -12,7 +12,11 @@ import {
   getDefaultPermissionProfile,
   type PermissionProfileId
 } from '../../shared/permission-profiles'
-import type { SettingsPreferences, SettingsPreferencesSnapshot } from './capabilities'
+import type {
+  SetDataRootOptions,
+  SettingsPreferences,
+  SettingsPreferencesSnapshot
+} from './capabilities'
 import type { SettingsRepository } from './repository'
 import type { StoredSettings } from './types'
 
@@ -60,8 +64,16 @@ class SettingsPreferencesModule implements SettingsPreferences {
     return toSettingsPreferencesSnapshot(await this.repository.markPathsNormalized(this.now()))
   }
 
-  async setDataRoot(path: string): Promise<SettingsPreferencesSnapshot> {
-    return toSettingsPreferencesSnapshot(await this.repository.setDataRoot(path))
+  async setDataRoot(
+    path: string,
+    options: SetDataRootOptions = {}
+  ): Promise<SettingsPreferencesSnapshot> {
+    return toSettingsPreferencesSnapshot(
+      await this.repository.setDataRoot({
+        dataRoot: path,
+        ...(options.completeOnboarding ? { onboardingCompletedAt: this.now() } : {})
+      })
+    )
   }
 
   async dismissLegacyDataMovePrompt(): Promise<SettingsPreferencesSnapshot> {
@@ -108,3 +120,4 @@ class SettingsPreferencesModule implements SettingsPreferences {
 }
 
 export { SettingsPreferencesModule, toSettingsPreferencesSnapshot }
+export type { SetDataRootOptions } from './capabilities'

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -903,16 +903,24 @@ describe('settings repository', () => {
     expect(reloaded.pathsNormalizedAt).toBe(1000)
   })
 
-  it('sets dataRoot, overwrites on a later call, and survives a reload', async () => {
+  it('sets dataRoot with an idempotent onboarding marker and survives a reload', async () => {
     const root = await createStorageRoot()
     const repository = new SettingsRepository(root)
 
-    const first = await repository.setDataRoot('/mnt/data-a')
+    const first = await repository.setDataRoot({
+      dataRoot: '/mnt/data-a',
+      onboardingCompletedAt: 1000
+    })
     expect(first.dataRoot).toBe('/mnt/data-a')
+    expect(first.onboardingCompletedAt).toBe(1000)
 
-    // Unlike the marker fields above, dataRoot is not idempotent-once: a later call must move it.
-    const second = await repository.setDataRoot('/mnt/data-b')
+    // dataRoot moves, but the one-time onboarding marker keeps its original timestamp.
+    const second = await repository.setDataRoot({
+      dataRoot: '/mnt/data-b',
+      onboardingCompletedAt: 2000
+    })
     expect(second.dataRoot).toBe('/mnt/data-b')
+    expect(second.onboardingCompletedAt).toBe(1000)
 
     // getSettings reads through sanitizeSettings, which normalizes the stored path (backslashes on
     // Windows), so compare against the platform-normalized form rather than the literal.

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -49,6 +49,7 @@ import {
 } from './subagent-model-settings'
 
 type SkillMutationGuard = <T>(operation: () => Promise<T>) => Promise<T>
+type DataRootUpdate = Readonly<{ dataRoot: string; onboardingCompletedAt?: number }>
 
 // Stable semantic mutation facade. The injected document store owns arbitration and atomic IO; all
 // secret handling remains above this layer in crypto.ts and service.ts.
@@ -414,10 +415,9 @@ class SettingsRepository {
     )
   }
 
-  // Persists the new data-root path after a successful migration (see storage/migration-service.ts).
-  // Unlike the marker fields above this is not idempotent-once: each call overwrites the prior value.
-  async setDataRoot(path: string): Promise<StoredSettings> {
-    return this.mutate((settings) => ({ ...settings, dataRoot: path }))
+  // Persists the relocatable data root, optionally with the idempotent onboarding marker.
+  async setDataRoot(update: DataRootUpdate): Promise<StoredSettings> {
+    return this.mutate((settings) => ({ ...update, ...settings, dataRoot: update.dataRoot }))
   }
 
   // Sets (or clears, when `selection` is null) the persisted runtime choice for one language. The

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3648,17 +3648,18 @@ describe('SettingsService: onboarding', () => {
     expect(settings.pathsNormalizedAt).toBeTypeOf('number')
   })
 
-  it('persists a new dataRoot across a fresh read', async () => {
+  it('persists a new dataRoot with onboarding completion across a fresh read', async () => {
     const service = createService()
 
     // The repository canonicalizes dataRoot to the host separator on read (for samePath comparisons),
     // so build the fixture the same way — a bare POSIX literal comes back with backslashes on Windows
     // and would fail the round-trip.
     const dataRoot = normalize('/mnt/new-data')
-    await service.setDataRoot(dataRoot)
+    await service.setDataRoot(dataRoot, { completeOnboarding: true })
 
     const settings = await service.getStoredSettings()
     expect(settings.dataRoot).toBe(dataRoot)
+    expect(settings.onboardingCompletedAt).toBeTypeOf('number')
   })
 })
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -87,7 +87,7 @@ import type { InstallManagedClaudeOptions, ManagedInstallOutcome } from './manag
 import { isEncryptionAvailable } from './crypto'
 import { getUserClaudeConfigDir } from './provider-env'
 import { SettingsRepository } from './repository'
-import { SettingsPreferencesModule } from './preferences'
+import { SettingsPreferencesModule, type SetDataRootOptions } from './preferences'
 import { buildSettingsSnapshot } from './settings-view'
 import { NotebookRuntimeSettingsModule } from './notebook-runtime-settings'
 import { SkillCatalogModule } from './skill-catalog'
@@ -776,8 +776,8 @@ class SettingsService {
 
   // Persists the new data-root path after a successful migration (see storage/migration-service.ts).
   // The caller is responsible for only invoking this once the move itself has succeeded.
-  async setDataRoot(path: string): Promise<void> {
-    await this.preferences.setDataRoot(path)
+  async setDataRoot(path: string, options?: SetDataRootOptions): Promise<void> {
+    await this.preferences.setDataRoot(path, options)
   }
 
   // Records that the user has answered the one-time legacy-data-move prompt (moved, relocated, or

--- a/src/main/storage/command-owner.atomicity.test.ts
+++ b/src/main/storage/command-owner.atomicity.test.ts
@@ -1,0 +1,129 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electronHome = { path: '' }
+const fsFaults = vi.hoisted(() => ({
+  failSecondSettingsRename: false,
+  settingsRenameCount: 0
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+
+  return {
+    ...actual,
+    rename: vi.fn(async (source, destination) => {
+      if (String(destination).endsWith('settings.json')) {
+        fsFaults.settingsRenameCount += 1
+        if (fsFaults.failSecondSettingsRename && fsFaults.settingsRenameCount === 2) {
+          throw Object.assign(new Error('injected second settings rename failure'), {
+            code: 'EIO'
+          })
+        }
+      }
+      await actual.rename(source, destination)
+    })
+  }
+})
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => electronHome.path,
+    isPackaged: true,
+    relaunch: vi.fn(),
+    exit: vi.fn(),
+    quit: vi.fn()
+  },
+  BrowserWindow: { getAllWindows: () => [] },
+  dialog: { showOpenDialog: vi.fn() },
+  shell: { openPath: vi.fn() }
+}))
+
+vi.mock('./remote-data-root', () => ({
+  inspectWindowsStoragePath: () => ({ isRemote: false, supportsHardLinks: true })
+}))
+
+const { initDataRoot } = await import('../storage-root')
+const { SettingsDocumentStore } = await import('../settings/document-store')
+const { SettingsRepository } = await import('../settings/repository')
+const { SettingsPreferencesModule } = await import('../settings/preferences')
+const { createStorageCommandOwner } = await import('./command-owner')
+
+describe('storage command owner onboarding persistence', () => {
+  let currentParent: string
+  let currentDataRoot: string
+  let targetParent: string
+  let targetDataRoot: string
+
+  beforeEach(async () => {
+    currentParent = await mkdtemp(join(tmpdir(), 'storage-owner-current-'))
+    currentDataRoot = join(currentParent, 'OpenScience')
+    await mkdir(currentDataRoot)
+    targetParent = await mkdtemp(join(tmpdir(), 'storage-owner-target-'))
+    targetDataRoot = join(targetParent, 'OpenScience')
+    electronHome.path = currentParent
+    initDataRoot(currentDataRoot)
+    fsFaults.failSecondSettingsRename = false
+    fsFaults.settingsRenameCount = 0
+  })
+
+  afterEach(async () => {
+    initDataRoot(undefined)
+    await rm(currentParent, { recursive: true, force: true })
+    await rm(targetParent, { recursive: true, force: true })
+  })
+
+  it('commits the initial data root and onboarding completion together', async () => {
+    const store = new SettingsDocumentStore(join(currentParent, 'settings'))
+    const repository = new SettingsRepository(store)
+    const preferences = new SettingsPreferencesModule(repository, () => 1_234)
+    // A split implementation reaches this second publish after dataRoot is already durable. The
+    // combined mutation never performs it, so both fields survive together in the first document.
+    fsFaults.failSecondSettingsRename = true
+
+    const owner = createStorageCommandOwner({
+      runtime: {
+        disconnect: vi.fn().mockResolvedValue(undefined),
+        shutdownForQuit: vi.fn().mockResolvedValue({ reaped: true })
+      },
+      notebook: {
+        shutdownAll: vi.fn().mockResolvedValue({ reaped: true }),
+        dispose: vi.fn().mockResolvedValue({ reaped: true }),
+        getActiveNotebookSessions: vi.fn().mockReturnValue([])
+      },
+      getActivePromptSessions: vi.fn().mockReturnValue([]),
+      getActiveDelegatedSessions: vi.fn().mockReturnValue([]),
+      settingsService: {
+        setDataRoot: async (path, options) => {
+          await preferences.setDataRoot(path, options)
+        },
+        dismissLegacyDataMovePrompt: () => preferences.dismissLegacyDataMovePrompt(),
+        getStoredSettings: () => repository.getSettings()
+      },
+      relaunch: vi.fn()
+    })
+
+    const result = await owner.setDataRootAndRelaunch({
+      parent: targetParent,
+      markOnboarding: true
+    })
+    const persisted = await repository.getSettings()
+
+    expect({
+      result,
+      persisted: {
+        dataRoot: persisted.dataRoot,
+        onboardingCompletedAt: persisted.onboardingCompletedAt
+      }
+    }).toEqual({
+      result: { ok: true },
+      persisted: {
+        dataRoot: targetDataRoot,
+        onboardingCompletedAt: 1_234
+      }
+    })
+  })
+})

--- a/src/main/storage/command-owner.ts
+++ b/src/main/storage/command-owner.ts
@@ -46,6 +46,7 @@ import { RELOCATABLE_DATA_DIRS } from './data-directories'
 import { createLogger, diagnosticErrorFields, type Logger } from '../logger'
 import { startDiagnosticOperation } from '../diagnostics/operation'
 import { markApplicationShutdownTrigger } from '../application-shutdown-trigger'
+import type { SetDataRootOptions } from '../settings/capabilities'
 
 type LegacySessionSource = { projectId: string; sessionId: string }
 type NotebookSessionSource = { projectId: string; sessionId: string }
@@ -65,11 +66,7 @@ type StorageCommandOwnerDeps = {
   getActivePromptSessions: () => LegacySessionSource[]
   getActiveDelegatedSessions: () => LegacySessionSource[]
   settingsService: {
-    setDataRoot: (path: string) => Promise<void>
-    // Stamps onboardingCompletedAt. Injected (rather than importing the renderer store action)
-    // so the marker can be persisted in the same main-process step as setDataRoot, before the
-    // renderer's startup gate ever has a chance to flip.
-    markOnboardingComplete: () => Promise<unknown>
+    setDataRoot: (path: string, options?: SetDataRootOptions) => Promise<void>
     // Marks the one-time legacy-data-move prompt as answered so it is never shown again.
     dismissLegacyDataMovePrompt: () => Promise<unknown>
     // Read to detect an explicitly-configured-but-now-gone data root (see dataRootMissing below)
@@ -576,11 +573,11 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
   // validateNewDataRoot is stricter (move-only) and is never called here.
   //
   // `markOnboarding` is stamped here (not by a separate renderer completeOnboarding() call) so it
-  // lands atomically with setDataRoot, in the same step as the relaunch: App.tsx's startup gate
-  // reads onboardingCompletedAt, and flipping it from the renderer before this IPC resolves would
-  // swap the wizard for Home (showing the OLD data root, and burying any failure below). Settings-
-  // adopt omits it (onboarding has already completed). Order is load-bearing: classify -> mkdir ->
-  // setDataRoot -> [markOnboardingComplete] -> relaunch. On an invalid parent, none of these run.
+  // lands atomically with setDataRoot, in the same settings mutation before relaunch: App.tsx's
+  // startup gate reads onboardingCompletedAt, and flipping it from the renderer before this IPC
+  // resolves would swap the wizard for Home (showing the OLD data root, and burying any failure
+  // below). Settings-adopt omits it (onboarding has already completed). Order is load-bearing:
+  // classify -> mkdir -> persist settings -> relaunch. On an invalid parent, none of these run.
   const setDataRootAndRelaunch = async (request: StorageRootRequest): Promise<ValidateResult> => {
     const operation = startDiagnosticOperation(logger, {
       operation: 'data-root-selection',
@@ -606,10 +603,9 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
       operation.phase('prepare-target', { mode: classification.kind })
       await mkdir(target, { recursive: true })
       operation.phase('persist-pointer', { mode: classification.kind })
-      await deps.settingsService.setDataRoot(target)
-      if (request.markOnboarding) {
-        await deps.settingsService.markOnboardingComplete()
-      }
+      await deps.settingsService.setDataRoot(target, {
+        completeOnboarding: request.markOnboarding === true
+      })
       operation.phase('request-relaunch', { mode: classification.kind })
       await cleanRelaunch()
       operation.complete({ mode: classification.kind })

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -90,7 +90,6 @@ const fakeDeps = (overrides: Partial<FakeDeps> = {}): FakeDeps => ({
   getActiveDelegatedSessions: vi.fn().mockReturnValue([]),
   settingsService: {
     setDataRoot: vi.fn().mockResolvedValue(undefined),
-    markOnboardingComplete: vi.fn().mockResolvedValue(undefined),
     dismissLegacyDataMovePrompt: vi.fn().mockResolvedValue(undefined),
     getStoredSettings: vi.fn().mockResolvedValue({})
   },
@@ -441,7 +440,6 @@ describe('storage IPC handlers', () => {
     const deps = fakeDeps({
       settingsService: {
         setDataRoot: vi.fn().mockResolvedValue(undefined),
-        markOnboardingComplete: vi.fn().mockResolvedValue(undefined),
         dismissLegacyDataMovePrompt: vi.fn().mockResolvedValue(undefined),
         getStoredSettings: vi.fn().mockResolvedValue({ dataRoot })
       }
@@ -458,7 +456,6 @@ describe('storage IPC handlers', () => {
     const deps = fakeDeps({
       settingsService: {
         setDataRoot: vi.fn().mockResolvedValue(undefined),
-        markOnboardingComplete: vi.fn().mockResolvedValue(undefined),
         dismissLegacyDataMovePrompt: vi.fn().mockResolvedValue(undefined),
         getStoredSettings: vi.fn().mockResolvedValue({ dataRoot: target })
       }
@@ -732,7 +729,6 @@ describe('storage IPC handlers', () => {
     const deps = fakeDeps({
       settingsService: {
         setDataRoot: vi.fn().mockRejectedValue(new Error('disk full')),
-        markOnboardingComplete: vi.fn().mockResolvedValue(undefined),
         dismissLegacyDataMovePrompt: vi.fn().mockResolvedValue(undefined),
         getStoredSettings: vi.fn().mockResolvedValue({})
       },
@@ -764,7 +760,6 @@ describe('storage IPC handlers', () => {
         this.repository.save(path)
         return Promise.resolve()
       }
-      markOnboardingComplete = vi.fn().mockResolvedValue(undefined)
       dismissLegacyDataMovePrompt = vi.fn().mockResolvedValue(undefined)
       getStoredSettings = vi.fn().mockResolvedValue({})
     }
@@ -824,7 +819,6 @@ describe('storage IPC handlers', () => {
               signalSetDataRootStarted()
             })
         ),
-        markOnboardingComplete: vi.fn().mockResolvedValue(undefined),
         dismissLegacyDataMovePrompt: vi.fn().mockResolvedValue(undefined),
         getStoredSettings: vi.fn().mockResolvedValue({})
       }
@@ -961,7 +955,6 @@ describe('storage IPC handlers', () => {
     const deps = fakeDeps({
       settingsService: {
         setDataRoot: vi.fn().mockRejectedValue(new Error('disk full')),
-        markOnboardingComplete: vi.fn().mockResolvedValue(undefined),
         dismissLegacyDataMovePrompt: vi.fn().mockResolvedValue(undefined),
         getStoredSettings: vi.fn().mockResolvedValue({})
       }
@@ -1159,8 +1152,9 @@ describe('storage IPC handlers', () => {
     await expect(
       invoke('storage:set-data-root-and-relaunch', { parent: targetParent })
     ).resolves.toEqual({ ok: true })
-    expect(deps.settingsService.setDataRoot).toHaveBeenCalledWith(target)
-    expect(deps.settingsService.markOnboardingComplete).not.toHaveBeenCalled()
+    expect(deps.settingsService.setDataRoot).toHaveBeenCalledWith(target, {
+      completeOnboarding: false
+    })
     expect(deps.relaunch).toHaveBeenCalledTimes(1)
   })
 
@@ -1179,7 +1173,9 @@ describe('storage IPC handlers', () => {
     ).resolves.toEqual({ ok: true })
 
     expect(existsSync(target)).toBe(true)
-    expect(deps.settingsService.setDataRoot).toHaveBeenCalledWith(target)
+    expect(deps.settingsService.setDataRoot).toHaveBeenCalledWith(target, {
+      completeOnboarding: true
+    })
   })
 
   it('set-data-root-and-relaunch creates the target before persisting the pointer', async () => {
@@ -1193,7 +1189,6 @@ describe('storage IPC handlers', () => {
     const deps = fakeDeps({
       settingsService: {
         setDataRoot,
-        markOnboardingComplete: vi.fn().mockResolvedValue(undefined),
         dismissLegacyDataMovePrompt: vi.fn().mockResolvedValue(undefined),
         getStoredSettings: vi.fn().mockResolvedValue({})
       }
@@ -1214,7 +1209,9 @@ describe('storage IPC handlers', () => {
     await expect(
       invoke('storage:set-data-root-and-relaunch', { parent: targetParent })
     ).resolves.toEqual({ ok: true })
-    expect(deps.settingsService.setDataRoot).toHaveBeenCalledWith(target)
+    expect(deps.settingsService.setDataRoot).toHaveBeenCalledWith(target, {
+      completeOnboarding: false
+    })
     expect(deps.relaunch).toHaveBeenCalledTimes(1)
   })
 
@@ -1238,7 +1235,7 @@ describe('storage IPC handlers', () => {
     expect(JSON.stringify(diagnosticRecords(logger))).not.toContain(target)
   })
 
-  it('set-data-root-and-relaunch marks onboarding complete only when markOnboarding is true', async () => {
+  it('set-data-root-and-relaunch commits onboarding with the data root when requested', async () => {
     initDataRoot(dataRoot)
     const deps = fakeDeps()
     registerStorageIpcHandlers(deps)
@@ -1248,10 +1245,12 @@ describe('storage IPC handlers', () => {
       markOnboarding: true
     })
 
-    expect(deps.settingsService.markOnboardingComplete).toHaveBeenCalledTimes(1)
+    expect(deps.settingsService.setDataRoot).toHaveBeenCalledWith(target, {
+      completeOnboarding: true
+    })
   })
 
-  it('set-data-root-and-relaunch does not mark onboarding when markOnboarding is false or omitted', async () => {
+  it('set-data-root-and-relaunch omits onboarding completion when markOnboarding is false', async () => {
     initDataRoot(dataRoot)
     const deps = fakeDeps()
     registerStorageIpcHandlers(deps)
@@ -1261,19 +1260,18 @@ describe('storage IPC handlers', () => {
       markOnboarding: false
     })
 
-    expect(deps.settingsService.markOnboardingComplete).not.toHaveBeenCalled()
+    expect(deps.settingsService.setDataRoot).toHaveBeenCalledWith(target, {
+      completeOnboarding: false
+    })
   })
 
-  it('set-data-root-and-relaunch calls setDataRoot, then markOnboardingComplete, then relaunch, in order', async () => {
+  it('set-data-root-and-relaunch persists both settings before relaunching', async () => {
     initDataRoot(dataRoot)
     const callOrder: string[] = []
     const deps = fakeDeps({
       settingsService: {
-        setDataRoot: vi.fn().mockImplementation(async () => {
-          callOrder.push('setDataRoot')
-        }),
-        markOnboardingComplete: vi.fn().mockImplementation(async () => {
-          callOrder.push('markOnboardingComplete')
+        setDataRoot: vi.fn().mockImplementation(async (_path, options) => {
+          callOrder.push(options?.completeOnboarding ? 'persistBoth' : 'persistDataRoot')
         }),
         dismissLegacyDataMovePrompt: vi.fn().mockResolvedValue(undefined),
         getStoredSettings: vi.fn().mockResolvedValue({})
@@ -1289,7 +1287,7 @@ describe('storage IPC handlers', () => {
       markOnboarding: true
     })
 
-    expect(callOrder).toEqual(['setDataRoot', 'markOnboardingComplete', 'relaunch'])
+    expect(callOrder).toEqual(['persistBoth', 'relaunch'])
   })
 
   it('set-data-root-and-relaunch rejects an invalid parent without setting, marking, or relaunching', async () => {
@@ -1304,7 +1302,6 @@ describe('storage IPC handlers', () => {
       error: 'The new location is the same as the current one.'
     })
     expect(deps.settingsService.setDataRoot).not.toHaveBeenCalled()
-    expect(deps.settingsService.markOnboardingComplete).not.toHaveBeenCalled()
     expect(deps.relaunch).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
## Problem

First-run custom data-root selection persisted `dataRoot` and `onboardingCompletedAt` in two separate settings document mutations. A crash or failure during the second publish could leave the new pointer durable while onboarding remained incomplete.

## Proposed change

- Extend the settings preference interface so data-root persistence can request onboarding completion in the same mutation.
- Persist the data-root update and the idempotent onboarding marker as one `SettingsDocumentStore` publish.
- Add a filesystem-boundary regression test that fails the second `settings.json` rename. The test reproduced the partial state before the fix and now proves there is no second publish between the two fields.
- Preserve the original onboarding timestamp when a later data-root update is committed.

## Scope and non-goals

- No new persisted fields, schema migrations, status values, or enum values.
- No renderer interaction changes and no data copy or relocation changes.
- No automatic repair for historical `dataRoot`-without-onboarding-marker documents; the existing onboarding Finish path remains compatible with that state.

## Acceptance criteria and validation

All passing checks below ran after the last material edit:

- Initial data root and onboarding marker commit together -> `npm test -- src/main/storage/command-owner.atomicity.test.ts` -> passed.
- Settings mutation, idempotent marker, and architecture ceilings -> targeted settings/architecture suite -> 108 passed.
- SettingsService forwarding and fresh-read persistence -> targeted `service.test.ts` case -> passed.
- Node interface consumers -> `npm run typecheck:node` -> passed.
- Source and test lint -> `npm run lint` -> passed.
- `npm run test:module -- settings_repository` -> 581 passed, 1 skipped, 7 failed locally because Windows denied test-only symlink creation with `EPERM`; all seven failures are in unrelated Agent Home Skill symlink cases.

The final affected-test classifier selects the complete Vitest suite because `src/main/settings/capabilities.ts` has no declared module owner. Per maintainer guidance, the complete suite is left to PR CI.

## Review focus

- Confirm that the settings merge order keeps an existing `onboardingCompletedAt` timestamp while always applying the requested `dataRoot`.
- Confirm that non-onboarding relocation/adoption callers retain their previous behavior.
- Confirm that the regression test exercises the real command-to-filesystem persistence path and not only call ordering.
