### PR TITLE
fix(storage): unify durable JSON publication

### DIFF
--- a/src/main/notebook/repository.test.ts
+++ b/src/main/notebook/repository.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -22,6 +22,33 @@ afterEach(async () => {
 })
 
 describe('notebook run repository', () => {
+  it('recovers a valid historical run.json temp when the primary is missing', async () => {
+    const root = await createStorageRoot()
+    const lane = createRootNotebookLane('default-project', 'session-1', 'root-frame-session-1')
+    const original = await new NotebookRunRepository(root).loadOrCreate({
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      lane,
+      workspaceCwd: '/workspace/before-crash'
+    })
+    const filePath = join(original.notebookSessionRoot, 'run.json')
+    await rename(filePath, `${filePath}.1700000000000-1.tmp`)
+
+    const recovered = await new NotebookRunRepository(root).loadOrCreate({
+      projectId: 'default-project',
+      sessionId: 'session-1',
+      lane,
+      workspaceCwd: '/workspace/after-crash'
+    })
+
+    expect(recovered.workspaceCwd).toBe('/workspace/after-crash')
+    expect(recovered.updatedAt).toBe(original.updatedAt)
+    await expect(readdir(original.notebookSessionRoot)).resolves.not.toEqual(
+      expect.arrayContaining([expect.stringContaining('.tmp')])
+    )
+    await expect(readFile(filePath, 'utf8')).resolves.toContain('before-crash')
+  })
+
   it('bounds the process-lifetime full-document cache', async () => {
     const root = await createStorageRoot()
     const repository = new NotebookRunRepository(root)

--- a/src/main/notebook/repository.ts
+++ b/src/main/notebook/repository.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, readdir, rename, stat, writeFile } from 'node:fs/promises'
+import { mkdir, readdir, stat } from 'node:fs/promises'
 import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 import type {
@@ -11,6 +11,7 @@ import type {
 } from '../../shared/notebook'
 import { NOTEBOOK_RUN_FILE, NOTEBOOKS_DIR } from '../../shared/notebook'
 import type { NotebookRuntimeBindings } from '../../shared/notebook-runtime'
+import { readDurableJsonFile, writeDurableJsonFile } from '../storage/durable-json-file'
 import { decodeRunDocumentDataPaths, encodeRunDocumentDataPaths } from './run-document-data-paths'
 import {
   createFrameNotebookLane,
@@ -315,7 +316,6 @@ const normalizeDocument = (
 // Owns durable run.json persistence for one app storage root.
 class NotebookRunRepository {
   private saveQueue: Promise<void> = Promise.resolve()
-  private saveSequence = 0
   private readonly documentCache = new Map<
     string,
     { mtimeMs: number; size: number; ino: number; document: NotebookRunDocument }
@@ -331,41 +331,39 @@ class NotebookRunRepository {
     const sessionId = assertSafeNotebookPathSegment(request.sessionId)
     const filePath = getNotebookRunJsonPath(this.storageRoot, projectId, sessionId, request.lane)
 
-    try {
-      const rawDocument = await readFile(filePath, 'utf8')
-      const document: unknown = JSON.parse(rawDocument)
+    const read = await readDurableJsonFile(filePath, (contents) => {
+      const document: unknown = JSON.parse(contents)
       assertNotebookDocumentOwnership(document, projectId, sessionId)
+      return document
+    })
+    if (read.status === 'found') {
       // Decode $DATA sentinels against the current data root before recomputing session roots,
       // so a relocated data root and the decoded working-file paths agree.
-      const decoded = decodeRunDocumentDataPaths(document, this.storageRoot)
+      const decoded = decodeRunDocumentDataPaths(read.value, this.storageRoot)
 
       return normalizeDocument(this.storageRoot, request, decoded)
-    } catch (error) {
-      if (!isMissingFileError(error)) {
-        throw error
-      }
-
-      const document = normalizeDocument(this.storageRoot, request, {
-        version: 1,
-        projectId,
-        sessionId,
-        workspaceCwd: request.workspaceCwd,
-        notebookSessionRoot: '',
-        dataRoot: '',
-        kernel: {
-          pythonPath: request.pythonPath,
-          kernelName: request.kernelName ?? 'python3',
-          runtimeRoot: '',
-          lastKnownStatus: 'idle'
-        },
-        runs: [],
-        updatedAt: Date.now()
-      })
-
-      await this.writeDocument(document)
-
-      return document
     }
+
+    const document = normalizeDocument(this.storageRoot, request, {
+      version: 1,
+      projectId,
+      sessionId,
+      workspaceCwd: request.workspaceCwd,
+      notebookSessionRoot: '',
+      dataRoot: '',
+      kernel: {
+        pythonPath: request.pythonPath,
+        kernelName: request.kernelName ?? 'python3',
+        runtimeRoot: '',
+        lastKnownStatus: 'idle'
+      },
+      runs: [],
+      updatedAt: Date.now()
+    })
+
+    await this.writeDocument(document)
+
+    return document
   }
 
   // Appends a new execution record, including "running" records created before execution starts.
@@ -678,7 +676,19 @@ class NotebookRunRepository {
     const safeSessionId = assertSafeNotebookPathSegment(sessionId)
     const filePath = getNotebookRunJsonPath(this.storageRoot, safeProjectId, safeSessionId, lane)
     for (let attempt = 0; attempt < MAX_DOCUMENT_READ_ATTEMPTS; attempt += 1) {
-      const fileInfo = await stat(filePath)
+      let fileInfo
+      try {
+        fileInfo = await stat(filePath)
+      } catch (error) {
+        if (!isMissingFileError(error)) throw error
+        const recovered = await readDurableJsonFile(filePath, (contents) => {
+          const document: unknown = JSON.parse(contents)
+          assertNotebookDocumentOwnership(document, safeProjectId, safeSessionId)
+          return document
+        })
+        if (recovered.status === 'missing') throw error
+        fileInfo = await stat(filePath)
+      }
       const cached = this.documentCache.get(filePath)
       if (cached && sameDocumentFileIdentity(cached, fileInfo)) {
         assertNotebookDocumentOwnership(cached.document, safeProjectId, safeSessionId)
@@ -687,11 +697,14 @@ class NotebookRunRepository {
         this.documentCache.set(filePath, cached)
         return cached.document
       }
-      const rawDocument = await readFile(filePath, 'utf8')
-      const document: unknown = JSON.parse(rawDocument)
-      assertNotebookDocumentOwnership(document, safeProjectId, safeSessionId)
+      const read = await readDurableJsonFile(filePath, (contents) => {
+        const document: unknown = JSON.parse(contents)
+        assertNotebookDocumentOwnership(document, safeProjectId, safeSessionId)
+        return document
+      })
+      if (read.status === 'missing') throw new Error(`Notebook document disappeared: ${filePath}`)
       // Decode before normalization for the same reason as loadOrCreate above.
-      const decoded = decodeRunDocumentDataPaths(document, this.storageRoot)
+      const decoded = decodeRunDocumentDataPaths(read.value, this.storageRoot)
 
       const normalized = normalizeDocument(
         this.storageRoot,
@@ -798,7 +811,6 @@ class NotebookRunRepository {
     const directory = document.notebookSessionRoot
     const filePath = join(directory, NOTEBOOK_RUN_FILE)
 
-    this.saveSequence += 1
     // Ensure the full notebook workspace exists before exposing run.json to readers.
     await mkdir(join(directory, 'data', 'raw'), { recursive: true })
     await mkdir(join(directory, 'data', 'processed'), { recursive: true })
@@ -810,14 +822,11 @@ class NotebookRunRepository {
     await mkdir(join(directory, 'handoff'), { recursive: true })
     await mkdir(join(directory, 'outputs'), { recursive: true })
 
-    const temporaryPath = `${filePath}.${Date.now()}-${this.saveSequence}.tmp`
-
     // Encode only the serialized copy: `directory` above must stay derived from the absolute in-memory
     // `document.notebookSessionRoot`, never from the $DATA-sentinel-encoded copy, so run.json stores
     // portable "$DATA/..." paths that survive a data-root relocation.
     const encoded = encodeRunDocumentDataPaths(document, this.storageRoot)
-    await writeFile(temporaryPath, `${JSON.stringify(encoded, null, 2)}\n`, 'utf8')
-    await rename(temporaryPath, filePath)
+    await writeDurableJsonFile(filePath, `${JSON.stringify(encoded, null, 2)}\n`)
     const fileInfo = await stat(filePath)
     this.rememberDocument(filePath, {
       mtimeMs: fileInfo.mtimeMs,

--- a/src/main/remote-access/repository.test.ts
+++ b/src/main/remote-access/repository.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -13,6 +13,22 @@ afterEach(async () => {
 })
 
 describe('RemoteAccessRepository', () => {
+  it('recovers a valid historical temp when the primary is missing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-remote-repository-temp-'))
+    roots.push(root)
+    await writeFile(
+      join(root, 'remote-access.json.123.tmp'),
+      JSON.stringify({ version: 4, mode: 'remoteit', trustedBrowsers: [] }),
+      'utf8'
+    )
+
+    await expect(new RemoteAccessRepository(root).load()).resolves.toMatchObject({
+      version: 4,
+      mode: 'remoteit'
+    })
+    await expect(readdir(root)).resolves.toEqual(['remote-access.json'])
+  })
+
   it('starts disabled and persists only hashed trusted-browser records', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-remote-repository-'))
     roots.push(root)

--- a/src/main/remote-access/repository.ts
+++ b/src/main/remote-access/repository.ts
@@ -1,7 +1,7 @@
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
 
 import type { RemoteAccessMode } from '../../shared/remote-access'
+import { readDurableJsonFile, writeDurableJsonFile } from '../storage/durable-json-file'
 
 const REMOTE_ACCESS_FILE = 'remote-access.json'
 const REMOTE_ACCESS_VERSION = 4 as const
@@ -93,23 +93,16 @@ export class RemoteAccessRepository {
   }
 
   async load(): Promise<StoredRemoteAccess> {
-    let contents: string
-    try {
-      contents = await readFile(this.path, 'utf8')
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return defaults()
-      throw error
-    }
-    return parseStored(JSON.parse(contents))
+    const result = await readDurableJsonFile(this.path, (contents) =>
+      parseStored(JSON.parse(contents))
+    )
+    return result.status === 'found' ? result.value : defaults()
   }
 
   save(value: StoredRemoteAccess): Promise<void> {
     const snapshot = JSON.stringify(value, null, 2)
     const operation = this.writeQueue.then(async () => {
-      await mkdir(dirname(this.path), { recursive: true })
-      const temporaryPath = `${this.path}.${process.pid}.tmp`
-      await writeFile(temporaryPath, `${snapshot}\n`, { encoding: 'utf8', mode: 0o600 })
-      await rename(temporaryPath, this.path)
+      await writeDurableJsonFile(this.path, `${snapshot}\n`)
     })
     this.writeQueue = operation.then(
       () => undefined,

--- a/src/main/session-persistence/repository-queue.test.ts
+++ b/src/main/session-persistence/repository-queue.test.ts
@@ -4,6 +4,7 @@ import type { PersistedChatSession } from '../../shared/session-persistence'
 
 const fsMock = vi.hoisted(() => ({
   mkdir: vi.fn(),
+  open: vi.fn(),
   readFile: vi.fn(),
   readdir: vi.fn(),
   rename: vi.fn(),
@@ -55,6 +56,11 @@ const createSession = (id: string, projectId = 'project-a'): PersistedChatSessio
 describe('session persistence repository save ordering', () => {
   beforeEach(() => {
     vi.resetAllMocks()
+    fsMock.open.mockResolvedValue({
+      close: vi.fn().mockResolvedValue(undefined),
+      sync: vi.fn().mockResolvedValue(undefined)
+    })
+    fsMock.rm.mockResolvedValue(undefined)
   })
 
   it('does not start a later session write while an earlier one is still writing', async () => {
@@ -71,7 +77,7 @@ describe('session persistence repository save ordering', () => {
     })
 
     const firstSave = repository.saveSession(createSession('first-session'))
-    await flushMicrotasks()
+    await vi.waitFor(() => expect(fsMock.writeFile).toHaveBeenCalledTimes(1))
 
     const secondSave = repository.saveSession(createSession('second-session'))
     await flushMicrotasks()

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rename, rm, utimes, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { pathToFileURL } from 'node:url'
@@ -794,6 +794,46 @@ describe('session persistence repository (per-session files)', () => {
     })
     await expect(readFile(futurePath, 'utf8')).resolves.toBe(futureJson)
     await expect(readdir(projectDir)).resolves.toEqual(['future.json'])
+    expect(renameFile).not.toHaveBeenCalled()
+  })
+
+  it('does not replace a newer unsupported Session temp with an older compatible temp', async () => {
+    const root = await createStorageRoot()
+    const projectDir = join(root, 'sessions', 'project-a')
+    const primaryPath = join(projectDir, 'session-1.json')
+    const compatibleTempPath = `${primaryPath}.1700000000000-1.tmp`
+    const unsupportedTempPath = `${primaryPath}.1700000001000-2.tmp`
+    const renameFile = vi.fn(rename)
+    const repository = new SessionRepository(root, { renameFile })
+    await repository.saveSession(createSession({ title: 'Older compatible authority' }))
+    await rename(primaryPath, compatibleTempPath)
+    const unsupportedJson = JSON.stringify({
+      version: 3,
+      payload: { id: 'session-1', futureAuthority: { revision: 2 } }
+    })
+    await writeFile(unsupportedTempPath, unsupportedJson, 'utf8')
+    const now = new Date()
+    await utimes(
+      compatibleTempPath,
+      new Date(now.getTime() - 2_000),
+      new Date(now.getTime() - 2_000)
+    )
+    await utimes(
+      unsupportedTempPath,
+      new Date(now.getTime() - 1_000),
+      new Date(now.getTime() - 1_000)
+    )
+    renameFile.mockClear()
+
+    const scan = await repository.loadAllWithDiagnostics()
+
+    expect(scan.result.sessions).toEqual([])
+    expect(scan.isComplete).toBe(false)
+    await expect(readFile(unsupportedTempPath, 'utf8')).resolves.toBe(unsupportedJson)
+    await expect(readdir(projectDir)).resolves.toEqual([
+      'session-1.json.1700000000000-1.tmp',
+      'session-1.json.1700000001000-2.tmp'
+    ])
     expect(renameFile).not.toHaveBeenCalled()
   })
 

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -393,6 +393,36 @@ describe('session persistence repository (per-session files)', () => {
     )
   })
 
+  it('recovers a valid historical Session temp when the primary is missing', async () => {
+    const root = await createStorageRoot()
+    const filePath = join(root, 'sessions', 'project-a', 'session-1.json')
+    await new SessionRepository(root).saveSession(createSession({ title: 'Before crash' }))
+    await rename(filePath, `${filePath}.1700000000000-1.tmp`)
+
+    await expect(new SessionRepository(root).loadAll()).resolves.toMatchObject({
+      sessions: [{ id: 'session-1', title: 'Before crash' }]
+    })
+    await expect(readdir(join(root, 'sessions', 'project-a'))).resolves.toEqual(['session-1.json'])
+  })
+
+  it('recovers a valid historical manifest temp when the primary is missing', async () => {
+    const root = await createStorageRoot()
+    const manifestPath = join(root, 'sessions', 'manifest.json')
+    await new SessionRepository(root).saveManifest({
+      lastProjectId: 'project-a',
+      lastSessionId: 'session-1'
+    })
+    await rename(manifestPath, `${manifestPath}.1700000000000-1.tmp`)
+
+    await expect(new SessionRepository(root).loadAll()).resolves.toMatchObject({
+      manifest: {
+        lastProjectId: 'project-a',
+        lastSessionId: 'session-1'
+      }
+    })
+    await expect(readdir(join(root, 'sessions'))).resolves.toEqual(['manifest.json'])
+  })
+
   it('loads one session directly so callers can refresh durable state between turns', async () => {
     const repository = new SessionRepository(await createStorageRoot())
     await repository.saveSession(createSession({ title: 'Before correction' }))

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -19,12 +19,16 @@ import {
 } from '../../shared/session-persistence'
 import { decodeSessionDataPaths, encodeSessionDataPaths } from './session-data-paths'
 import { SessionPersistenceOperationScheduler } from './operation-scheduler'
+import {
+  readDurableJsonFile,
+  recoverDurableJsonDirectory,
+  writeDurableJsonFile
+} from '../storage/durable-json-file'
 
 const SESSIONS_DIR = 'sessions'
 const DELETED_SESSIONS_DIR = 'deleted-sessions'
 const PROJECT_DELETION_COMMIT_MARKER = '.project-deletion-committed'
 const MANIFEST_FILE = 'manifest.json'
-const FILE_REPLACEMENT_RETRY_DELAYS_MS = [25, 50, 100, 200, 400] as const
 const PRE_S2_BACKUP_SUFFIX = '.pre-s2-backup'
 const PRE_SUBAGENT_MODEL_BACKUP_SUFFIX = '.pre-subagent-model-backup'
 
@@ -124,6 +128,8 @@ type ProjectSessionLoadDiagnostics = {
 
 type ProjectSessionDeletionState = 'live' | 'legacy-committed' | 'prepared' | 'absent'
 
+class UnsupportedSessionFileError extends Error {}
+
 type SessionDirectoryEntry = {
   name: string
   isDirectory(): boolean
@@ -149,12 +155,6 @@ const DEFAULT_DEPENDENCIES: SessionRepositoryDependencies = {
   renameFile: (source, destination) => rename(source, destination),
   wait: (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs))
 }
-
-const isRetryableFileReplacementError = (error: unknown): boolean =>
-  typeof error === 'object' &&
-  error !== null &&
-  'code' in error &&
-  ['EPERM', 'EACCES', 'EBUSY'].includes(String((error as { code?: unknown }).code))
 
 // Production storage lives under ~/.open-science; dev builds use an isolated sibling directory.
 export const PROD_SESSION_DIR_NAME = '.open-science'
@@ -190,7 +190,6 @@ const assertSafeSegment = (segment: string): string => {
 class SessionRepository {
   private readonly operationScheduler = new SessionPersistenceOperationScheduler()
   private readonly sessionRevisions = new Map<string, number>()
-  private writeSequence = 0
   private backupSequence = 0
   private readonly dependencies: SessionRepositoryDependencies
 
@@ -753,38 +752,45 @@ class SessionRepository {
 
   // Shared temp-file + rename write used by session files and the manifest.
   private async atomicWrite(filePath: string, payload: unknown): Promise<void> {
-    this.writeSequence += 1
-    const temporaryPath = `${filePath}.${Date.now()}-${this.writeSequence}.tmp`
-
-    await writeFile(temporaryPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8')
-    try {
-      for (let attempt = 0; ; attempt += 1) {
-        try {
-          await this.dependencies.renameFile(temporaryPath, filePath)
-          return
-        } catch (error) {
-          const delayMs = FILE_REPLACEMENT_RETRY_DELAYS_MS[attempt]
-          if (delayMs === undefined || !isRetryableFileReplacementError(error)) throw error
-          await this.dependencies.wait(delayMs)
-        }
-      }
-    } catch (error) {
-      await this.dependencies
-        .remove(temporaryPath, { recursive: false, force: true })
-        .catch(() => undefined)
-      throw error
-    }
+    await writeDurableJsonFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, {
+      remove: this.dependencies.remove,
+      rename: this.dependencies.renameFile,
+      wait: this.dependencies.wait
+    })
   }
 
   private async readManifest(options: { quarantineInvalidFiles: boolean }): Promise<{
     manifest: PersistedSessionManifest
     warning?: SessionLoadWarning
   }> {
-    let raw: string
     try {
-      raw = await this.dependencies.readManifestFile(this.manifestPath)
+      const read = await readDurableJsonFile(
+        this.manifestPath,
+        (contents) => {
+          const parsed = JSON.parse(contents) as unknown
+          if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+            throw new Error('Invalid Session manifest')
+          }
+          return normalizeSessionManifest(parsed)
+        },
+        {
+          readDirectoryEntries: this.dependencies.readDirectoryEntries,
+          readFile: this.dependencies.readManifestFile,
+          remove: this.dependencies.remove,
+          rename: this.dependencies.renameFile,
+          wait: this.dependencies.wait
+        }
+      )
+      return {
+        manifest: read.status === 'found' ? read.value : createEmptySessionManifest()
+      }
     } catch (error) {
-      if (!isMissingFileError(error)) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        !isMissingFileError(error)
+      ) {
         return {
           manifest: createEmptySessionManifest(),
           warning: {
@@ -794,20 +800,6 @@ class SessionRepository {
           }
         }
       }
-      return {
-        manifest: createEmptySessionManifest()
-      }
-    }
-
-    try {
-      const parsed = JSON.parse(raw) as unknown
-      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-        throw new Error('Invalid Session manifest')
-      }
-      return {
-        manifest: normalizeSessionManifest(parsed)
-      }
-    } catch {
       const wasQuarantined =
         options.quarantineInvalidFiles && (await this.tryBackupInvalidFile(this.manifestPath))
       return {
@@ -881,6 +873,22 @@ class SessionRepository {
       scanMetrics?: SessionScanMetrics
     } = {}
   ): Promise<ProjectSessionLoadDiagnostics> {
+    let recoveryComplete = true
+    try {
+      await recoverDurableJsonDirectory(
+        projectDir,
+        (filePath, contents) => this.decodeSessionContents(filePath, projectId, contents),
+        {
+          readDirectoryEntries: this.dependencies.readDirectoryEntries,
+          readFile: this.dependencies.readSessionFile,
+          remove: this.dependencies.remove,
+          rename: this.dependencies.renameFile,
+          wait: this.dependencies.wait
+        }
+      )
+    } catch {
+      recoveryComplete = false
+    }
     const sessionFiles = await this.listSessionFileNames(projectDir, {
       missingIsIncomplete: options.missingDirectoryIsIncomplete
     })
@@ -888,7 +896,7 @@ class SessionRepository {
     const activeQuarantines = new Set(sessionFiles.quarantinedPrimaryFileNames)
     if (options.scanMetrics) options.scanMetrics.sessionFileCount += sessionFiles.names.length
     const warnedFiles = new Set<string>()
-    let isComplete = sessionFiles.isComplete
+    let isComplete = sessionFiles.isComplete && recoveryComplete
 
     for (const fileName of sessionFiles.names) {
       // The directory is the authoritative owning project, regardless of the file's stored projectId.
@@ -939,10 +947,56 @@ class SessionRepository {
     wasQuarantined?: boolean
     warning?: SessionLoadWarning
   }> {
-    let raw: string
+    let read:
+      | { status: 'found'; value: { session: PersistedChatSession; bytes: number } }
+      | { status: 'missing' }
     try {
-      raw = await this.dependencies.readSessionFile(filePath)
+      read = await readDurableJsonFile(
+        filePath,
+        (contents) => this.decodeSessionContents(filePath, projectId, contents),
+        {
+          readDirectoryEntries: this.dependencies.readDirectoryEntries,
+          readFile: this.dependencies.readSessionFile,
+          remove: this.dependencies.remove,
+          rename: this.dependencies.renameFile,
+          wait: this.dependencies.wait
+        }
+      )
     } catch (error) {
+      if (error instanceof UnsupportedSessionFileError) {
+        return {
+          isComplete: false,
+          warning: {
+            kind: 'unsupported-version',
+            projectId,
+            fileName: basename(filePath),
+            recovered: false
+          }
+        }
+      }
+      if (
+        typeof error !== 'object' ||
+        error === null ||
+        !('code' in error) ||
+        isMissingFileError(error)
+      ) {
+        const wasQuarantined =
+          !isMissingFileError(error) &&
+          options.quarantineInvalidFiles !== false &&
+          (await this.tryBackupInvalidFile(filePath))
+        if (!isMissingFileError(error)) {
+          return {
+            isComplete: wasQuarantined,
+            wasQuarantined,
+            warning: {
+              kind: 'corrupt',
+              projectId,
+              fileName: basename(filePath),
+              recovered: wasQuarantined
+            }
+          }
+        }
+      }
       if (isMissingFileError(error) && !options.missingIsIncomplete) return { isComplete: true }
       return {
         isComplete: false,
@@ -954,67 +1008,48 @@ class SessionRepository {
         }
       }
     }
-    if (options.scanMetrics) options.scanMetrics.sessionBytes += Buffer.byteLength(raw, 'utf8')
-
-    try {
-      const decoded = decodeSessionFile(JSON.parse(raw) as unknown, {
-        preserveLegacyUploadPaths: true,
-        preserveRuntimeState: (sessionId) =>
-          this.dependencies.hasActiveRuntimePrompt(projectId, sessionId)
-      })
-      if (decoded.status === 'unsupported-version') {
-        // A newer app still owns this authority. Leaving the primary file untouched and reporting an
-        // incomplete scan blocks reconciliation and all ordinary saving until a compatible app loads it.
-        return {
-          isComplete: false,
-          warning: {
-            kind: 'unsupported-version',
-            projectId,
-            fileName: basename(filePath),
-            recovered: false
-          }
-        }
-      }
-      if (decoded.status === 'invalid') {
-        const wasQuarantined =
-          options.quarantineInvalidFiles !== false && (await this.tryBackupInvalidFile(filePath))
-        return {
-          isComplete: wasQuarantined,
-          wasQuarantined,
-          warning: {
-            kind: 'corrupt',
-            projectId,
-            fileName: basename(filePath),
-            recovered: wasQuarantined
-          }
-        }
-      }
-      const session = decoded.session
-
-      // The file name is authoritative for global Session identity. Unlike the owning Project,
-      // an id mismatch is corruption rather than a legacy field that may be repaired from the path.
-      const fileName = basename(filePath)
-      const fileSessionId = fileName.endsWith('.json')
-        ? fileName.slice(0, -'.json'.length)
-        : undefined
-      if (session.id !== fileSessionId) {
-        throw new Error('Session id does not match its file name')
-      }
-
-      return { session: decodeSessionDataPaths({ ...session, projectId }), isComplete: true }
-    } catch {
-      const wasQuarantined =
-        options.quarantineInvalidFiles !== false && (await this.tryBackupInvalidFile(filePath))
+    if (read.status === 'missing') {
+      if (!options.missingIsIncomplete) return { isComplete: true }
       return {
-        isComplete: wasQuarantined,
-        wasQuarantined,
+        isComplete: false,
         warning: {
-          kind: 'corrupt',
+          kind: 'unreadable',
           projectId,
           fileName: basename(filePath),
-          recovered: wasQuarantined
+          recovered: false
         }
       }
+    }
+    if (options.scanMetrics) options.scanMetrics.sessionBytes += read.value.bytes
+    return { session: read.value.session, isComplete: true }
+  }
+
+  private decodeSessionContents(
+    filePath: string,
+    projectId: string,
+    contents: string
+  ): { session: PersistedChatSession; bytes: number } {
+    const decoded = decodeSessionFile(JSON.parse(contents) as unknown, {
+      preserveLegacyUploadPaths: true,
+      preserveRuntimeState: (sessionId) =>
+        this.dependencies.hasActiveRuntimePrompt(projectId, sessionId)
+    })
+    if (decoded.status === 'unsupported-version') throw new UnsupportedSessionFileError()
+    if (decoded.status === 'invalid') throw new Error('Invalid Session file')
+
+    // The file name is authoritative for global Session identity. Unlike the owning Project,
+    // an id mismatch is corruption rather than a legacy field that may be repaired from the path.
+    const fileName = basename(filePath)
+    const fileSessionId = fileName.endsWith('.json')
+      ? fileName.slice(0, -'.json'.length)
+      : undefined
+    if (decoded.session.id !== fileSessionId) {
+      throw new Error('Session id does not match its file name')
+    }
+
+    return {
+      session: decodeSessionDataPaths({ ...decoded.session, projectId }),
+      bytes: Buffer.byteLength(contents, 'utf8')
     }
   }
 

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -20,6 +20,7 @@ import {
 import { decodeSessionDataPaths, encodeSessionDataPaths } from './session-data-paths'
 import { SessionPersistenceOperationScheduler } from './operation-scheduler'
 import {
+  DurableJsonRecoveryBarrierError,
   readDurableJsonFile,
   recoverDurableJsonDirectory,
   writeDurableJsonFile
@@ -128,7 +129,7 @@ type ProjectSessionLoadDiagnostics = {
 
 type ProjectSessionDeletionState = 'live' | 'legacy-committed' | 'prepared' | 'absent'
 
-class UnsupportedSessionFileError extends Error {}
+class UnsupportedSessionFileError extends DurableJsonRecoveryBarrierError {}
 
 type SessionDirectoryEntry = {
   name: string

--- a/src/main/settings/document-store.test.ts
+++ b/src/main/settings/document-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, readdir, rename as renameFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const faults = vi.hoisted(() => ({
   failReadOnceWith: undefined as Error | undefined,
-  failRenameOnce: false
+  renameFailuresRemaining: 0
 }))
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>()
@@ -21,8 +21,8 @@ vi.mock('node:fs/promises', async (importOriginal) => {
       return actual.readFile(...args)
     }),
     rename: vi.fn(async (source: string, destination: string) => {
-      if (faults.failRenameOnce) {
-        faults.failRenameOnce = false
+      if (faults.renameFailuresRemaining > 0) {
+        faults.renameFailuresRemaining -= 1
         throw Object.assign(new Error('EPERM: settings file is temporarily locked'), {
           code: 'EPERM'
         })
@@ -38,7 +38,8 @@ let storageRoot: string | undefined
 
 afterEach(async () => {
   faults.failReadOnceWith = undefined
-  faults.failRenameOnce = false
+  faults.renameFailuresRemaining = 0
+  vi.clearAllMocks()
   if (storageRoot) await rm(storageRoot, { recursive: true, force: true })
   storageRoot = undefined
 })
@@ -56,6 +57,24 @@ describe('settings document store', () => {
     await expect(
       store.mutate((settings) => ({ ...settings, notificationsEnabled: false }))
     ).resolves.toMatchObject({ providers: [], notificationsEnabled: false })
+  })
+
+  it('recovers a valid historical Settings temp when the primary is missing', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-store-temp-'))
+    await writeFile(
+      join(storageRoot, 'settings.json.1700000000000-1.tmp'),
+      JSON.stringify({
+        version: 2,
+        providers: [],
+        notificationsEnabled: false
+      }),
+      'utf8'
+    )
+
+    await expect(new SettingsDocumentStore(storageRoot).read()).resolves.toMatchObject({
+      notificationsEnabled: false
+    })
+    await expect(readdir(storageRoot)).resolves.toEqual(['settings.json'])
   })
 
   it('rejects corrupt JSON and prevents a mutation from publishing over it', async () => {
@@ -101,17 +120,55 @@ describe('settings document store', () => {
     })
   })
 
-  it('recovers its mutation queue after an atomic rename failure', async () => {
+  it('retries a transient Windows file-replacement denial without losing the Settings save', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-store-'))
     const store = new SettingsDocumentStore(storageRoot)
-    faults.failRenameOnce = true
+    faults.renameFailuresRemaining = 1
+
+    await expect(
+      store.mutate((settings) => ({ ...settings, notificationsEnabled: true }))
+    ).resolves.toMatchObject({ notificationsEnabled: true })
+
+    expect(vi.mocked(renameFile)).toHaveBeenCalledTimes(2)
+    await expect(store.read()).resolves.toMatchObject({ notificationsEnabled: true })
+  })
+
+  it('fails closed and removes its temporary file after persistent replacement denial', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-store-'))
+    const store = new SettingsDocumentStore(storageRoot)
+    faults.renameFailuresRemaining = Number.POSITIVE_INFINITY
 
     await expect(
       store.mutate((settings) => ({ ...settings, notificationsEnabled: true }))
     ).rejects.toThrow('temporarily locked')
-    await expect(
-      store.mutate((settings) => ({ ...settings, conversationSkillImportEnabled: true }))
-    ).resolves.toMatchObject({ conversationSkillImportEnabled: true })
-    await expect(store.read()).resolves.toMatchObject({ conversationSkillImportEnabled: true })
+
+    await expect(readdir(storageRoot)).resolves.not.toEqual(
+      expect.arrayContaining([expect.stringContaining('.tmp')])
+    )
+    expect(vi.mocked(renameFile)).toHaveBeenCalledTimes(6)
+  })
+
+  it('keeps independent store instances from colliding on a temporary path', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-settings-store-collision-'))
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+    try {
+      const first = new SettingsDocumentStore(storageRoot)
+      const second = new SettingsDocumentStore(storageRoot)
+
+      await expect(
+        Promise.all([
+          first.mutate((settings) => ({ ...settings, notificationsEnabled: true })),
+          second.mutate((settings) => ({ ...settings, telemetryEnabled: false }))
+        ])
+      ).resolves.toHaveLength(2)
+
+      await expect(new SettingsDocumentStore(storageRoot).read()).resolves.toMatchObject({
+        version: 2,
+        providers: []
+      })
+      await expect(readdir(storageRoot)).resolves.toEqual(['settings.json'])
+    } finally {
+      now.mockRestore()
+    }
   })
 })

--- a/src/main/settings/document-store.ts
+++ b/src/main/settings/document-store.ts
@@ -1,6 +1,6 @@
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
+import { readDurableJsonFile, writeDurableJsonFile } from '../storage/durable-json-file'
 import { sanitizeSettings } from './document-codec'
 import { createEmptySettings, type StoredSettings } from './types'
 
@@ -10,7 +10,6 @@ const SETTINGS_FILE = 'settings.json'
 // queue recovery. Callers sharing this instance cannot overwrite one another with stale snapshots.
 class SettingsDocumentStore {
   private mutationTail: Promise<void> = Promise.resolve()
-  private writeSequence = 0
 
   constructor(private readonly storageDir: string) {}
 
@@ -19,23 +18,10 @@ class SettingsDocumentStore {
   }
 
   async read(): Promise<StoredSettings> {
-    let contents: string
-
-    try {
-      contents = await readFile(this.path, 'utf8')
-    } catch (error) {
-      if (
-        typeof error === 'object' &&
-        error !== null &&
-        'code' in error &&
-        error.code === 'ENOENT'
-      ) {
-        return createEmptySettings()
-      }
-      throw error
-    }
-
-    return sanitizeSettings(JSON.parse(contents) as unknown)
+    const result = await readDurableJsonFile(this.path, (contents) =>
+      sanitizeSettings(JSON.parse(contents) as unknown)
+    )
+    return result.status === 'found' ? result.value : createEmptySettings()
   }
 
   mutate(update: (settings: StoredSettings) => StoredSettings): Promise<StoredSettings> {
@@ -52,10 +38,7 @@ class SettingsDocumentStore {
   }
 
   private async write(settings: StoredSettings): Promise<void> {
-    await mkdir(this.storageDir, { recursive: true })
-    const temporaryPath = `${this.path}.${Date.now()}-${++this.writeSequence}.tmp`
-    await writeFile(temporaryPath, `${JSON.stringify(settings, null, 2)}\n`, 'utf8')
-    await rename(temporaryPath, this.path)
+    await writeDurableJsonFile(this.path, `${JSON.stringify(settings, null, 2)}\n`)
   }
 }
 

--- a/src/main/specialist/marketplace/repository.test.ts
+++ b/src/main/specialist/marketplace/repository.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -7,6 +7,38 @@ import { describe, expect, it } from 'vitest'
 import { MarketplaceRepository } from './repository'
 
 describe('MarketplaceRepository', () => {
+  it('recovers a valid historical temp when the primary is missing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'marketplace-repository-temp-'))
+    await writeFile(
+      join(root, 'specialist-marketplace.json.1700000000000-1.tmp'),
+      JSON.stringify({
+        version: 1,
+        sources: [
+          {
+            id: 'recovered-source',
+            kind: 'github',
+            repositoryUrl: 'https://github.com/example/marketplace',
+            owner: 'example',
+            repository: 'marketplace',
+            ref: 'main',
+            marketplaceId: 'example',
+            name: 'Recovered Marketplace',
+            keyId: 'example-2026-01',
+            publicKey: Buffer.from('public-key').toString('base64'),
+            keyFingerprint: 'f'.repeat(64),
+            createdAt: '2026-08-17T00:00:00.000Z'
+          }
+        ]
+      }),
+      'utf8'
+    )
+
+    await expect(new MarketplaceRepository(root).getAll()).resolves.toMatchObject({
+      sources: [{ id: 'recovered-source' }]
+    })
+    await expect(readdir(root)).resolves.toEqual(['specialist-marketplace.json'])
+  })
+
   it('persists user trust separately from Specialist installation provenance', async () => {
     const root = await mkdtemp(join(tmpdir(), 'marketplace-repository-'))
     const repository = new MarketplaceRepository(root)

--- a/src/main/specialist/marketplace/repository.ts
+++ b/src/main/specialist/marketplace/repository.ts
@@ -1,5 +1,6 @@
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+
+import { readDurableJsonFile, writeDurableJsonFile } from '../../storage/durable-json-file'
 
 export type StoredMarketplaceSource = {
   id: string
@@ -258,19 +259,16 @@ const sanitizeDocument = (value: unknown): MarketplaceDocument => {
 export class MarketplaceRepository {
   private readonly filePath: string
   private queue: Promise<void> = Promise.resolve()
-  private writeSequence = 0
 
-  constructor(private readonly storageDir: string) {
+  constructor(storageDir: string) {
     this.filePath = join(storageDir, 'specialist-marketplace.json')
   }
 
   async getAll(): Promise<MarketplaceDocument> {
-    try {
-      return sanitizeDocument(JSON.parse(await readFile(this.filePath, 'utf8')))
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return emptyDocument()
-      throw error
-    }
+    const result = await readDurableJsonFile(this.filePath, (contents) =>
+      sanitizeDocument(JSON.parse(contents))
+    )
+    return result.status === 'found' ? result.value : emptyDocument()
   }
 
   async addSource(source: StoredMarketplaceSource): Promise<void> {
@@ -437,10 +435,6 @@ export class MarketplaceRepository {
   }
 
   private async write(document: MarketplaceDocument): Promise<void> {
-    await mkdir(this.storageDir, { recursive: true })
-    this.writeSequence += 1
-    const temporary = `${this.filePath}.${Date.now()}-${this.writeSequence}.tmp`
-    await writeFile(temporary, `${JSON.stringify(document, null, 2)}\n`, 'utf8')
-    await rename(temporary, this.filePath)
+    await writeDurableJsonFile(this.filePath, `${JSON.stringify(document, null, 2)}\n`)
   }
 }

--- a/src/main/specialist/repository.test.ts
+++ b/src/main/specialist/repository.test.ts
@@ -1,6 +1,6 @@
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 
@@ -110,6 +110,20 @@ afterEach(async () => {
 })
 
 describe('SpecialistRepository.getAll', () => {
+  it('recovers a valid historical temp when the primary is missing', async () => {
+    const specialist = makeSpecialist({ id: 'recovered-specialist' })
+    await writeFile(
+      join(tmpDir, 'specialists.json.1700000000000-1.tmp'),
+      JSON.stringify({ version: 2, specialists: [specialist] }),
+      'utf8'
+    )
+
+    await expect(new SpecialistRepository(tmpDir).getAll()).resolves.toMatchObject({
+      specialists: [{ id: 'recovered-specialist' }]
+    })
+    await expect(readdir(tmpDir)).resolves.toEqual(['specialists.json'])
+  })
+
   it('returns empty document on a fresh directory', async () => {
     const repo = new SpecialistRepository(tmpDir)
     const doc = await repo.getAll()

--- a/src/main/specialist/repository.ts
+++ b/src/main/specialist/repository.ts
@@ -1,7 +1,7 @@
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { createLogger } from '../logger'
+import { readDurableJsonFile, writeDurableJsonFile } from '../storage/durable-json-file'
 import {
   createEmptySpecialists,
   SPECIALISTS_FILE_VERSION,
@@ -349,7 +349,6 @@ const sanitizeSpecialists = (v: unknown): StoredSpecialists =>
 // and serializes concurrent mutations through a queue — identical to SettingsRepository.
 export class SpecialistRepository {
   private saveQueue: Promise<void> = Promise.resolve()
-  private writeSequence = 0
 
   constructor(private readonly storageDir: string) {}
 
@@ -365,38 +364,26 @@ export class SpecialistRepository {
     document: StoredSpecialists
     integrity: SpecialistDocumentIntegrity
   }> {
-    let raw: string
     try {
-      raw = await readFile(this.filePath, 'utf8')
+      const result = await readDurableJsonFile(this.filePath, (contents) =>
+        sanitizeSpecialistsWithIntegrity(JSON.parse(contents) as unknown)
+      )
+      return result.status === 'found'
+        ? result.value
+        : { document: createEmptySpecialists(), integrity: { status: 'ok' } }
     } catch (err) {
-      // ENOENT is the normal first-run state — return an empty document.
-      // Any other OS error (EMFILE, EACCES, truncated read, etc.) must propagate so
-      // that mutate() aborts rather than silently overwriting a store we could not read.
-      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-        return { document: createEmptySpecialists(), integrity: { status: 'ok' } }
-      }
-      log.error('failed to read specialists file — aborting to prevent data loss', {
-        code: (err as NodeJS.ErrnoException).code
-        // intentionally omitting file contents — systemPrompt must not reach the log
-      })
+      const parseFailure = err instanceof SyntaxError
+      log.error(
+        parseFailure
+          ? 'failed to parse specialists file — aborting to prevent data loss'
+          : 'failed to read specialists file — aborting to prevent data loss',
+        {
+          code: parseFailure ? 'specialists-json-invalid' : (err as NodeJS.ErrnoException).code
+          // intentionally omitting file contents — systemPrompt must not reach the log
+        }
+      )
       throw err
     }
-
-    // JSON.parse failure (truncated write, disk corruption) must also propagate.
-    // We do not return empty here because the file exists but is unreadable — a
-    // subsequent write would permanently destroy every specialist the file contained.
-    let parsed: unknown
-    try {
-      parsed = JSON.parse(raw) as unknown
-    } catch (err) {
-      log.error('failed to parse specialists file — aborting to prevent data loss', {
-        code: 'specialists-json-invalid'
-        // intentionally omitting raw content — systemPrompt must not reach the log
-      })
-      throw err
-    }
-
-    return sanitizeSpecialistsWithIntegrity(parsed)
   }
 
   // Insert a new specialist (caller supplies a fully-formed record).
@@ -535,11 +522,7 @@ export class SpecialistRepository {
   }
 
   private async write(doc: StoredSpecialists): Promise<void> {
-    await mkdir(this.storageDir, { recursive: true })
-    this.writeSequence += 1
-    const tmp = `${this.filePath}.${Date.now()}-${this.writeSequence}.tmp`
-    await writeFile(tmp, `${JSON.stringify(doc, null, 2)}\n`, 'utf8')
-    await rename(tmp, this.filePath)
+    await writeDurableJsonFile(this.filePath, `${JSON.stringify(doc, null, 2)}\n`)
   }
 }
 

--- a/src/main/storage/durable-json-file.test.ts
+++ b/src/main/storage/durable-json-file.test.ts
@@ -1,0 +1,269 @@
+import {
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat as statFile,
+  utimes,
+  writeFile
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  readDurableJsonFile,
+  writeDurableJsonFile,
+  type DurableJsonFileDependencies
+} from './durable-json-file'
+
+const replacementDenied = (): NodeJS.ErrnoException =>
+  Object.assign(new Error('replacement denied'), { code: 'EPERM' })
+
+const createDependencies = (
+  overrides: Partial<DurableJsonFileDependencies> = {}
+): DurableJsonFileDependencies => ({
+  createTemporarySuffix: () => '1234-test',
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  readDirectoryEntries: vi.fn().mockResolvedValue([]),
+  readFile: vi.fn(),
+  remove: vi.fn().mockResolvedValue(undefined),
+  rename: vi.fn().mockResolvedValue(undefined),
+  stat: vi.fn(),
+  syncDirectory: vi.fn().mockResolvedValue(undefined),
+  syncFile: vi.fn().mockResolvedValue(undefined),
+  wait: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  ...overrides
+})
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { force: true, recursive: true })))
+})
+
+describe('durable JSON file publication', () => {
+  it.skipIf(process.platform === 'win32')('publishes an owner-only file mode', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'durable-json-mode-'))
+    roots.push(root)
+    const filePath = join(root, 'settings.json')
+
+    await writeDurableJsonFile(filePath, '{}\n')
+
+    expect((await statFile(filePath)).mode & 0o777).toBe(0o600)
+  })
+
+  it('syncs a private unique temp and retries a transient Windows replacement denial', async () => {
+    const filePath = join('config', 'settings.json')
+    const events: string[] = []
+    let renameAttempts = 0
+    const dependencies = createDependencies({
+      writeFile: vi.fn(async (_path, _contents, options) => {
+        expect(options).toEqual({ encoding: 'utf8', flag: 'wx', mode: 0o600 })
+        events.push('write')
+      }),
+      syncFile: vi.fn(async () => {
+        events.push('sync-file')
+      }),
+      rename: vi.fn(async () => {
+        renameAttempts += 1
+        if (renameAttempts === 1) {
+          events.push('rename-denied')
+          throw replacementDenied()
+        }
+        events.push('rename')
+      }),
+      syncDirectory: vi.fn(async () => {
+        events.push('sync-directory')
+      })
+    })
+
+    await writeDurableJsonFile(filePath, '{"version":2}\n', dependencies)
+
+    expect(events).toEqual(['write', 'sync-file', 'rename-denied', 'rename', 'sync-directory'])
+    expect(dependencies.writeFile).toHaveBeenCalledWith(
+      `${filePath}.1234-test.tmp`,
+      '{"version":2}\n',
+      { encoding: 'utf8', flag: 'wx', mode: 0o600 }
+    )
+    expect(dependencies.wait).toHaveBeenCalledWith(25)
+    expect(dependencies.remove).not.toHaveBeenCalled()
+  })
+
+  it('removes its temp after persistent replacement denial', async () => {
+    const filePath = join('config', 'settings.json')
+    const failure = replacementDenied()
+    const dependencies = createDependencies({
+      rename: vi.fn().mockRejectedValue(failure)
+    })
+
+    await expect(writeDurableJsonFile(filePath, '{}\n', dependencies)).rejects.toBe(failure)
+
+    expect(dependencies.rename).toHaveBeenCalledTimes(6)
+    expect(dependencies.wait).toHaveBeenCalledTimes(5)
+    expect(dependencies.remove).toHaveBeenCalledWith(`${filePath}.1234-test.tmp`, {
+      force: true,
+      recursive: false
+    })
+  })
+
+  it('does not remove a pre-existing temp when exclusive creation rejects a suffix collision', async () => {
+    const collision = Object.assign(new Error('temp already exists'), { code: 'EEXIST' })
+    const dependencies = createDependencies({
+      writeFile: vi.fn().mockRejectedValue(collision)
+    })
+
+    await expect(
+      writeDurableJsonFile(join('config', 'settings.json'), '{}\n', dependencies)
+    ).rejects.toBe(collision)
+
+    expect(dependencies.remove).not.toHaveBeenCalled()
+  })
+
+  it('serializes independent writers that select the same temporary path', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'durable-json-writer-collision-'))
+    roots.push(root)
+    const filePath = join(root, 'settings.json')
+    const temporaryPath = `${filePath}.4321-12345678-1234-1234-1234-123456789abc.tmp`
+    const writtenPaths: string[] = []
+    const write = async (
+      path: string,
+      contents: string,
+      options: { encoding: 'utf8'; flag: 'wx'; mode: number }
+    ): Promise<void> => {
+      writtenPaths.push(path)
+      await writeFile(path, contents, options)
+    }
+    const dependencies = {
+      createTemporarySuffix: () => '4321-12345678-1234-1234-1234-123456789abc',
+      writeFile: write
+    }
+
+    await expect(
+      Promise.all([
+        writeDurableJsonFile(filePath, '{"writer":1}\n', dependencies),
+        writeDurableJsonFile(filePath, '{"writer":2}\n', dependencies)
+      ])
+    ).resolves.toEqual([undefined, undefined])
+
+    expect(writtenPaths).toEqual([temporaryPath, temporaryPath])
+    await expect(readFile(filePath, 'utf8')).resolves.toBe('{"writer":2}\n')
+    await expect(readdir(root)).resolves.toEqual(['settings.json'])
+  })
+})
+
+describe('durable JSON file recovery', () => {
+  it('keeps a valid primary authoritative and removes recognized temps', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'durable-json-primary-'))
+    roots.push(root)
+    const filePath = join(root, 'settings.json')
+    const temporaryPath = `${filePath}.1700000000000-1.tmp`
+    await writeFile(filePath, '{"source":"primary"}\n', 'utf8')
+    await writeFile(temporaryPath, '{"source":"temp"}\n', 'utf8')
+
+    await expect(readDurableJsonFile(filePath, JSON.parse)).resolves.toEqual({
+      status: 'found',
+      value: { source: 'primary' }
+    })
+    await expect(readdir(root)).resolves.toEqual(['settings.json'])
+  })
+
+  it('does not treat an unrelated tmp file as publication residue', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'durable-json-unrelated-temp-'))
+    roots.push(root)
+    const filePath = join(root, 'settings.json')
+    const unrelatedPath = `${filePath}.manual-backup.tmp`
+    await writeFile(filePath, '{"source":"primary"}\n', 'utf8')
+    await writeFile(unrelatedPath, '{"source":"manual"}\n', 'utf8')
+
+    await expect(readDurableJsonFile(filePath, JSON.parse)).resolves.toEqual({
+      status: 'found',
+      value: { source: 'primary' }
+    })
+    await expect(readdir(root)).resolves.toEqual([
+      'settings.json',
+      'settings.json.manual-backup.tmp'
+    ])
+  })
+
+  it('promotes the newest valid temp only when the primary is missing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'durable-json-recovery-'))
+    roots.push(root)
+    const filePath = join(root, 'settings.json')
+    const validTemporaryPath = `${filePath}.1700000000000-1.tmp`
+    const invalidTemporaryPath = `${filePath}.1700000001000-2.tmp`
+    await writeFile(validTemporaryPath, '{"source":"recovered"}\n', 'utf8')
+    await writeFile(invalidTemporaryPath, '{', 'utf8')
+    const now = new Date()
+    await utimes(
+      validTemporaryPath,
+      new Date(now.getTime() - 2_000),
+      new Date(now.getTime() - 2_000)
+    )
+    await utimes(
+      invalidTemporaryPath,
+      new Date(now.getTime() - 1_000),
+      new Date(now.getTime() - 1_000)
+    )
+
+    await expect(readDurableJsonFile(filePath, JSON.parse)).resolves.toEqual({
+      status: 'found',
+      value: { source: 'recovered' }
+    })
+    await expect(readFile(filePath, 'utf8')).resolves.toBe('{"source":"recovered"}\n')
+    await expect(readdir(root)).resolves.toEqual(['settings.json'])
+  })
+
+  it('does not mask a corrupt committed primary with a valid temp', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'durable-json-corrupt-primary-'))
+    roots.push(root)
+    const filePath = join(root, 'settings.json')
+    const temporaryPath = `${filePath}.1700000000000-1.tmp`
+    await writeFile(filePath, '{', 'utf8')
+    await writeFile(temporaryPath, '{"source":"temp"}\n', 'utf8')
+
+    await expect(readDurableJsonFile(filePath, JSON.parse)).rejects.toBeInstanceOf(SyntaxError)
+    await expect(readdir(root)).resolves.toEqual([
+      'settings.json',
+      'settings.json.1700000000000-1.tmp'
+    ])
+  })
+
+  it('preserves invalid temps when no primary or valid recovery candidate exists', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'durable-json-invalid-temp-'))
+    roots.push(root)
+    const filePath = join(root, 'settings.json')
+    const temporaryPath = `${filePath}.1700000000000-1.tmp`
+    await writeFile(temporaryPath, '{', 'utf8')
+
+    await expect(readDurableJsonFile(filePath, JSON.parse)).resolves.toEqual({ status: 'missing' })
+    await expect(readdir(root)).resolves.toEqual(['settings.json.1700000000000-1.tmp'])
+  })
+
+  it('does not promote or remove a temp owned by a live process', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'durable-json-live-writer-'))
+    roots.push(root)
+    const filePath = join(root, 'settings.json')
+    const temporaryPath = `${filePath}.${process.pid}-12345678-1234-1234-1234-123456789abc.tmp`
+    await writeFile(temporaryPath, '{"source":"in-flight"}\n', 'utf8')
+
+    await expect(readDurableJsonFile(filePath, JSON.parse)).resolves.toEqual({ status: 'missing' })
+    await expect(readdir(root)).resolves.toEqual([
+      `settings.json.${process.pid}-12345678-1234-1234-1234-123456789abc.tmp`
+    ])
+  })
+
+  it('recovers a legacy PID-only temp even when that PID has been reused', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'durable-json-legacy-pid-'))
+    roots.push(root)
+    const filePath = join(root, 'settings.json')
+    await writeFile(`${filePath}.${process.pid}.tmp`, '{"source":"legacy"}\n', 'utf8')
+
+    await expect(readDurableJsonFile(filePath, JSON.parse)).resolves.toEqual({
+      status: 'found',
+      value: { source: 'legacy' }
+    })
+    await expect(readdir(root)).resolves.toEqual(['settings.json'])
+  })
+})

--- a/src/main/storage/durable-json-file.ts
+++ b/src/main/storage/durable-json-file.ts
@@ -36,6 +36,10 @@ export type DurableJsonFileDependencies = {
   writeFile(path: string, contents: string, options: DurableJsonWriteOptions): Promise<void>
 }
 
+// Signals that a recognized temp may contain authoritative data this release cannot interpret.
+// Recovery must preserve it and stop instead of falling back to an older decodable candidate.
+export class DurableJsonRecoveryBarrierError extends Error {}
+
 const DEFAULT_DEPENDENCIES: DurableJsonFileDependencies = {
   createTemporarySuffix: () => `${process.pid}-${randomUUID()}`,
   mkdir: (path, options) => mkdir(path, options),
@@ -249,7 +253,8 @@ export const readDurableJsonFile = async <Value>(
         let value: Value
         try {
           value = decode(candidateContents)
-        } catch {
+        } catch (error) {
+          if (error instanceof DurableJsonRecoveryBarrierError) throw error
           continue
         }
 

--- a/src/main/storage/durable-json-file.ts
+++ b/src/main/storage/durable-json-file.ts
@@ -1,0 +1,308 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises'
+import { basename, dirname, join } from 'node:path'
+
+import { defaultFileDurability } from './file-durability'
+
+const FILE_REPLACEMENT_RETRY_DELAYS_MS = [25, 50, 100, 200, 400] as const
+const fileOperations = new Map<string, Promise<void>>()
+
+type DurableJsonDirectoryEntry = {
+  name: string
+  isFile(): boolean
+}
+
+type DurableJsonFileStat = {
+  mtimeMs: number
+}
+
+type DurableJsonWriteOptions = {
+  encoding: 'utf8'
+  flag: 'wx'
+  mode: number
+}
+
+export type DurableJsonFileDependencies = {
+  createTemporarySuffix(): string
+  mkdir(path: string, options: { recursive: true }): Promise<unknown>
+  readDirectoryEntries(path: string): Promise<DurableJsonDirectoryEntry[]>
+  readFile(path: string): Promise<string>
+  remove(path: string, options: { force: true; recursive: false }): Promise<void>
+  rename(source: string, destination: string): Promise<void>
+  stat(path: string): Promise<DurableJsonFileStat>
+  syncDirectory(path: string): Promise<void>
+  syncFile(path: string): Promise<void>
+  wait(delayMs: number): Promise<void>
+  writeFile(path: string, contents: string, options: DurableJsonWriteOptions): Promise<void>
+}
+
+const DEFAULT_DEPENDENCIES: DurableJsonFileDependencies = {
+  createTemporarySuffix: () => `${process.pid}-${randomUUID()}`,
+  mkdir: (path, options) => mkdir(path, options),
+  readDirectoryEntries: (path) => readdir(path, { withFileTypes: true }),
+  readFile: (path) => readFile(path, 'utf8'),
+  remove: (path, options) => rm(path, options),
+  rename: (source, destination) => rename(source, destination),
+  stat: (path) => stat(path),
+  syncDirectory: (path) => defaultFileDurability.syncDirectory(path),
+  syncFile: (path) => defaultFileDurability.syncFile(path),
+  wait: (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)),
+  writeFile: (path, contents, options) => writeFile(path, contents, options)
+}
+
+const isRetryableFileReplacementError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  ['EPERM', 'EACCES', 'EBUSY'].includes(String(error.code))
+
+const isMissingFileError = (error: unknown): boolean =>
+  typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT'
+
+const isExistingFileError = (error: unknown): boolean =>
+  typeof error === 'object' && error !== null && 'code' in error && error.code === 'EEXIST'
+
+const runFileOperation = async <Result>(
+  filePath: string,
+  operation: () => Promise<Result>
+): Promise<Result> => {
+  const previous = fileOperations.get(filePath) ?? Promise.resolve()
+  let release = (): void => undefined
+  const current = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const tail = previous.then(() => current)
+  fileOperations.set(filePath, tail)
+  await previous
+  try {
+    return await operation()
+  } finally {
+    release()
+    if (fileOperations.get(filePath) === tail) fileOperations.delete(filePath)
+  }
+}
+
+const renameWithRetry = async (
+  source: string,
+  destination: string,
+  dependencies: DurableJsonFileDependencies
+): Promise<void> => {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await dependencies.rename(source, destination)
+      return
+    } catch (error) {
+      const delayMs = FILE_REPLACEMENT_RETRY_DELAYS_MS[attempt]
+      if (delayMs === undefined || !isRetryableFileReplacementError(error)) throw error
+      await dependencies.wait(delayMs)
+    }
+  }
+}
+
+export const writeDurableJsonFile = async (
+  filePath: string,
+  contents: string,
+  dependencyOverrides: Partial<DurableJsonFileDependencies> = {}
+): Promise<void> => {
+  const dependencies = { ...DEFAULT_DEPENDENCIES, ...dependencyOverrides }
+  return runFileOperation(filePath, async () => {
+    const directory = dirname(filePath)
+    await dependencies.mkdir(directory, { recursive: true })
+    const temporaryPath = `${filePath}.${dependencies.createTemporarySuffix()}.tmp`
+    let ownsTemporaryPath = true
+
+    try {
+      try {
+        await dependencies.writeFile(temporaryPath, contents, {
+          encoding: 'utf8',
+          flag: 'wx',
+          mode: 0o600
+        })
+      } catch (error) {
+        if (isExistingFileError(error)) ownsTemporaryPath = false
+        throw error
+      }
+      await dependencies.syncFile(temporaryPath)
+      await renameWithRetry(temporaryPath, filePath, dependencies)
+      await dependencies.syncDirectory(directory)
+    } catch (error) {
+      if (ownsTemporaryPath) {
+        await dependencies
+          .remove(temporaryPath, { force: true, recursive: false })
+          .catch(() => undefined)
+      }
+      throw error
+    }
+  })
+}
+
+type DurableJsonReadResult<Value> = { status: 'found'; value: Value } | { status: 'missing' }
+
+type TemporaryCandidate = {
+  name: string
+  path: string
+  mtimeMs: number
+}
+
+type RecognizedTemporarySuffix = {
+  activeCreatorPid?: number
+}
+
+const recognizeTemporarySuffix = (
+  filePath: string,
+  name: string
+): RecognizedTemporarySuffix | undefined => {
+  const prefix = `${basename(filePath)}.`
+  const suffix = name.slice(prefix.length, -'.tmp'.length)
+  const currentMatch =
+    /^(\d+)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu.exec(suffix)
+  if (currentMatch) {
+    const activeCreatorPid = Number(currentMatch[1])
+    return Number.isSafeInteger(activeCreatorPid) && activeCreatorPid > 0
+      ? { activeCreatorPid }
+      : undefined
+  }
+
+  // Older Settings/Session/Notebook/Specialist writers used Date.now() plus a sequence. Older
+  // Remote Access and Web state writers used a PID alone. Those formats never had a reliable live
+  // ownership marker, so treat them as crash residue even if a later process happens to reuse the PID.
+  if (/^\d{13}-\d+$/u.test(suffix) || /^\d+$/u.test(suffix)) return {}
+  return undefined
+}
+
+const isProcessAlive = (pid: number): boolean => {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return typeof error === 'object' && error !== null && 'code' in error && error.code === 'EPERM'
+  }
+}
+
+const listTemporaryCandidates = async (
+  filePath: string,
+  dependencies: DurableJsonFileDependencies
+): Promise<TemporaryCandidate[]> => {
+  const directory = dirname(filePath)
+  const prefix = `${basename(filePath)}.`
+  let entries: DurableJsonDirectoryEntry[]
+  try {
+    entries = await dependencies.readDirectoryEntries(directory)
+  } catch (error) {
+    if (isMissingFileError(error)) return []
+    throw error
+  }
+
+  const candidates = await Promise.all(
+    entries
+      .filter((entry) => {
+        if (!entry.isFile() || !entry.name.startsWith(prefix) || !entry.name.endsWith('.tmp')) {
+          return false
+        }
+        const recognized = recognizeTemporarySuffix(filePath, entry.name)
+        return recognized && !isProcessAlive(recognized.activeCreatorPid ?? 0)
+      })
+      .map(async (entry) => {
+        const path = join(directory, entry.name)
+        return { name: entry.name, path, mtimeMs: (await dependencies.stat(path)).mtimeMs }
+      })
+  )
+  return candidates.sort(
+    (left, right) => right.mtimeMs - left.mtimeMs || right.name.localeCompare(left.name)
+  )
+}
+
+const cleanupTemporaryCandidates = async (
+  candidates: readonly TemporaryCandidate[],
+  dependencies: DurableJsonFileDependencies
+): Promise<void> => {
+  await Promise.all(
+    candidates.map((candidate) =>
+      dependencies.remove(candidate.path, { force: true, recursive: false }).catch(() => undefined)
+    )
+  )
+}
+
+export const readDurableJsonFile = async <Value>(
+  filePath: string,
+  decode: (contents: string) => Value,
+  dependencyOverrides: Partial<DurableJsonFileDependencies> = {}
+): Promise<DurableJsonReadResult<Value>> => {
+  const dependencies = { ...DEFAULT_DEPENDENCIES, ...dependencyOverrides }
+  return runFileOperation(filePath, async () => {
+    let primaryContents: string
+    try {
+      primaryContents = await dependencies.readFile(filePath)
+    } catch (error) {
+      if (!isMissingFileError(error)) throw error
+      const candidates = await listTemporaryCandidates(filePath, dependencies)
+      for (const candidate of candidates) {
+        let candidateContents: string
+        try {
+          candidateContents = await dependencies.readFile(candidate.path)
+        } catch (candidateReadError) {
+          if (isMissingFileError(candidateReadError)) continue
+          throw candidateReadError
+        }
+
+        let value: Value
+        try {
+          value = decode(candidateContents)
+        } catch {
+          continue
+        }
+
+        await dependencies.syncFile(candidate.path)
+        await renameWithRetry(candidate.path, filePath, dependencies)
+        await dependencies.syncDirectory(dirname(filePath))
+        await cleanupTemporaryCandidates(candidates, dependencies)
+        return { status: 'found', value }
+      }
+      return { status: 'missing' }
+    }
+
+    const value = decode(primaryContents)
+    await cleanupTemporaryCandidates(
+      await listTemporaryCandidates(filePath, dependencies),
+      dependencies
+    )
+    return { status: 'found', value }
+  })
+}
+
+export const recoverDurableJsonDirectory = async (
+  directory: string,
+  decode: (targetPath: string, contents: string) => unknown,
+  dependencyOverrides: Partial<DurableJsonFileDependencies> = {}
+): Promise<void> => {
+  const dependencies = { ...DEFAULT_DEPENDENCIES, ...dependencyOverrides }
+  let entries: DurableJsonDirectoryEntry[]
+  try {
+    entries = await dependencies.readDirectoryEntries(directory)
+  } catch (error) {
+    if (isMissingFileError(error)) return
+    throw error
+  }
+
+  const targetNames = new Set(
+    entries.flatMap((entry) => {
+      if (!entry.isFile()) return []
+      const match =
+        /^(.+\.json)\.(?:\d{13}-\d+|\d+|\d+-[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})\.tmp$/iu.exec(
+          entry.name
+        )
+      return match?.[1] ? [match[1]] : []
+    })
+  )
+  for (const targetName of [...targetNames].sort()) {
+    const targetPath = join(directory, targetName)
+    try {
+      await dependencies.stat(targetPath)
+      continue
+    } catch (error) {
+      if (!isMissingFileError(error)) throw error
+    }
+    await readDurableJsonFile(targetPath, (contents) => decode(targetPath, contents), dependencies)
+  }
+}

--- a/src/main/storage/file-durability.ts
+++ b/src/main/storage/file-durability.ts
@@ -1,0 +1,60 @@
+import { open, type FileHandle } from 'node:fs/promises'
+
+type SyncHandle = Pick<FileHandle, 'sync' | 'close'>
+type OpenSyncHandle = (path: string, flags: 'r' | 'r+') => Promise<SyncHandle>
+
+export type FileDurability = {
+  syncFile: (path: string) => Promise<void>
+  syncDirectory: (path: string) => Promise<void>
+}
+
+type FileDurabilityOptions = {
+  openHandle?: OpenSyncHandle
+  platform?: NodeJS.Platform
+}
+
+const defaultOpenHandle: OpenSyncHandle = (path, flags) => open(path, flags)
+
+const syncOpenPath = async (
+  openHandle: OpenSyncHandle,
+  path: string,
+  flags: 'r' | 'r+'
+): Promise<void> => {
+  const handle = await openHandle(path, flags)
+  try {
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+}
+
+export const createFileDurability = (options: FileDurabilityOptions = {}): FileDurability => {
+  const openHandle = options.openHandle ?? defaultOpenHandle
+  const platform = options.platform ?? process.platform
+
+  return {
+    // Windows requires a write-capable handle for FlushFileBuffers. Opening an ordinary file with
+    // `r` makes FileHandle.sync() fail with EPERM even when the file itself is writable.
+    syncFile: (path) => syncOpenPath(openHandle, path, 'r+'),
+    syncDirectory: async (path) => {
+      try {
+        await syncOpenPath(openHandle, path, 'r')
+      } catch (error) {
+        // Node cannot open or flush directory handles on Windows. File barriers still protect the
+        // payload there; POSIX platforms additionally make directory publication durable.
+        if (
+          platform === 'win32' &&
+          typeof error === 'object' &&
+          error !== null &&
+          'code' in error &&
+          ['EISDIR', 'EPERM', 'EINVAL', 'ENOTSUP'].includes(String(error.code))
+        ) {
+          return
+        }
+        throw error
+      }
+    }
+  }
+}
+
+export const defaultFileDurability = createFileDurability()

--- a/src/main/web-service/state-file.test.ts
+++ b/src/main/web-service/state-file.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -18,6 +18,29 @@ afterEach(async () => {
 })
 
 describe('web service state file', () => {
+  it('recovers a valid historical temp when the primary is missing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-state-temp-'))
+    roots.push(root)
+    await writeFile(
+      `${statePathFor(root)}.123.tmp`,
+      JSON.stringify({
+        pid: process.pid,
+        port: 44100,
+        startedAt: '2026-07-19T00:00:00.000Z',
+        appVersion: '0.4.0',
+        configRoot: root,
+        attached: false
+      }),
+      'utf8'
+    )
+
+    await expect(readWebServiceState(root)).resolves.toMatchObject({
+      pid: process.pid,
+      port: 44100
+    })
+    await expect(readdir(root)).resolves.toEqual(['web-service.json'])
+  })
+
   it('writes, reads, and removes a live state atomically', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-state-'))
     roots.push(root)

--- a/src/main/web-service/state-file.ts
+++ b/src/main/web-service/state-file.ts
@@ -1,5 +1,7 @@
-import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { rm } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { readDurableJsonFile, writeDurableJsonFile } from '../storage/durable-json-file'
 
 const WEB_SERVICE_STATE_FILE = 'web-service.json'
 
@@ -28,27 +30,32 @@ const isProcessAlive = (pid: number): boolean => {
   }
 }
 
+const decodeWebServiceState = (contents: string): WebServiceState => {
+  const state = JSON.parse(contents) as WebServiceState
+  if (
+    !Number.isInteger(state.pid) ||
+    !Number.isInteger(state.port) ||
+    typeof state.startedAt !== 'string' ||
+    typeof state.appVersion !== 'string' ||
+    typeof state.configRoot !== 'string'
+  ) {
+    throw new Error('Invalid web service state.')
+  }
+  return { ...state, attached: state.attached === true }
+}
+
 const readWebServiceState = async (configRoot: string): Promise<WebServiceState | undefined> => {
   const statePath = statePathFor(configRoot)
   try {
-    const state = JSON.parse(await readFile(statePath, 'utf8')) as WebServiceState
-    if (
-      !Number.isInteger(state.pid) ||
-      !Number.isInteger(state.port) ||
-      typeof state.startedAt !== 'string' ||
-      typeof state.appVersion !== 'string' ||
-      typeof state.configRoot !== 'string'
-    ) {
-      throw new Error('Invalid web service state.')
-    }
+    const result = await readDurableJsonFile(statePath, decodeWebServiceState)
+    if (result.status === 'missing') return undefined
+    const state = result.value
     if (!isProcessAlive(state.pid)) {
       await rm(statePath, { force: true })
       return undefined
     }
-    // Coerce attached so a state file written before this field existed reads as a dedicated daemon.
-    return { ...state, attached: state.attached === true }
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    return state
+  } catch {
     await rm(statePath, { force: true })
     return undefined
   }
@@ -60,13 +67,7 @@ const writeWebServiceState = async (
 ): Promise<WebServiceState> => {
   const completeState = { ...state, configRoot }
   const statePath = statePathFor(configRoot)
-  const temporaryPath = `${statePath}.${process.pid}.tmp`
-  await mkdir(dirname(statePath), { recursive: true })
-  await writeFile(temporaryPath, `${JSON.stringify(completeState, null, 2)}\n`, {
-    encoding: 'utf8',
-    mode: 0o600
-  })
-  await rename(temporaryPath, statePath)
+  await writeDurableJsonFile(statePath, `${JSON.stringify(completeState, null, 2)}\n`)
   return completeState
 }
 


### PR DESCRIPTION
## Problem

Settings, Session persistence, Notebook run history, Remote Access, Specialist profiles,
Specialist Marketplace metadata, and Web service state each published JSON through a same-directory
temp plus rename, but disagreed on file/directory sync, creation permissions, Windows replacement
retry, failure cleanup, collision behavior, and crash-temp recovery. A transient Windows `EPERM`
could reject Settings saves, persistent failures could leave residue, and a complete pre-rename temp
was ignored after restart.

## Proposed change

- Add one Main-process durable JSON primitive that creates an exclusive unique temp with POSIX
  `0600`, syncs the file, retries transient `EPERM`/`EACCES`/`EBUSY`, renames, and syncs the parent
  directory where supported.
- Serialize in-process writes by target path and fail closed without deleting a temp owned by another
  writer after an `EEXIST` collision.
- Keep an existing primary authoritative. Only if it is missing, recover the newest valid recognized
  temp through the owner's existing decoder.
- Recognize only the historical `timestamp-sequence` and PID-only patterns plus the new PID-UUID
  pattern. Ignore unrelated `*.tmp` files and do not promote a current-format temp owned by a live
  process.
- Migrate all seven JSON owners without changing their public repository/state APIs or validation
  rules.

## Scope and non-goals

- Persistence behavior changes for the seven listed JSON authorities only.
- No persisted fields, schema versions, data-model changes, migrations, IPC changes, UI interaction
  changes, or new enum/status values.
- Existing primary JSON remains byte/schema compatible. Existing broader POSIX permissions are not
  changed eagerly; the next successful replacement is created as `0600`.
- Windows ACLs are not rewritten; inherited directory ACL remains authoritative.
- Artifact/Upload publication, SQLite/Prisma, Notebook journals, and package-directory publication
  remain unchanged.

## Acceptance criteria and validation

Red evidence captured before implementation:

- Settings fault test: 2 failed / 4 passed. A transient `EPERM` rejected save, and persistent denial
  left `settings.json.<timestamp>-<sequence>.tmp`.
- Recovery-boundary test: 2 failed / 8 passed / 1 skipped. An unrelated manual temp was deleted, and
  PID reuse suppressed recovery of a legacy PID-only temp.

Final evidence, run after the last relevant edit:

- Durable helper plus all seven owner tests: 169 passed / 1 POSIX-only test skipped on Windows.
- Final helper plus Settings collision tests: 19 passed / 1 POSIX-only test skipped on Windows.
- Session repository plus durability queue tests: 72 passed. The queue mocks include the new
  `open().sync()/close()` barrier and Promise-returning cleanup while retaining strict same-Project
  serialization and independent-Project concurrency assertions.
- `npm run test:module -- session_persistence`: 313 passed.
- `npm run typecheck:node`: passed.
- `npm run lint`: passed.
- `git diff --check`: passed.
- Independent Standards review: no hard violations. Independent Spec review: passed after fixes.

Per maintainer direction, the complete local `npm test` was not run. The latest exact-head PR CI on
`60b1d47dc` selected affected Module tests and coverage and passed, along with static checks,
Windows core, Windows E2E, macOS build/E2E, CI integrity, CodeQL, and the deterministic PR Gate. The
Settings module run reached 583 passed / 1 skipped and 7 Windows symlink tests failed at symlink
creation with `EPERM`; the same failure was reproduced on unchanged `main`.

## Review focus

- Recovery policy: primary always wins; a temp is promoted only when primary is missing and owner
  decoding succeeds.
- Temp recognition boundaries and the distinction between historical PID-only residue and live
  PID-UUID writers.
- Session corrupt/unreadable/unsupported-version classification after routing reads through the
  common primitive.
- Platform durability behavior: writable file handle for Windows flush, parent-directory sync on
  supported platforms, and no Windows ACL claims from POSIX `mode`.
