### PR TITLE
fix(runtime): recover caches with invalid package metadata

### DIFF
--- a/src/main/notebook/micromamba-cache-recovery.test.ts
+++ b/src/main/notebook/micromamba-cache-recovery.test.ts
@@ -13,6 +13,7 @@ import {
 const makeRoot = (): string => mkdtempSync(join(tmpdir(), 'os-cache-recovery-'))
 const markComplete = (packageDir: string): void => {
   mkdirSync(join(packageDir, 'info'), { recursive: true })
+  writeFileSync(join(packageDir, 'info', 'index.json'), '{}')
   writeFileSync(
     join(packageDir, 'info', 'repodata_record.json'),
     JSON.stringify({ url: `https://host/channel/noarch/${basename(packageDir)}.conda` })
@@ -53,8 +54,10 @@ describe('removeIncompleteExtractedPackages', () => {
     }
     rmSync(join(urlEmpty, 'info'), { recursive: true })
     writeFileSync(join(flatComplete, 'info', 'repodata_record.json'), '{}')
+    writeFileSync(join(flatComplete, 'info', 'index.json'), '{}')
     writeFileSync(join(flatIncomplete, 'info', 'index.json'), '{}')
     writeFileSync(join(urlComplete, 'info', 'repodata_record.json'), '{}')
+    writeFileSync(join(urlComplete, 'info', 'index.json'), '{}')
     writeFileSync(join(urlIncomplete, 'partial'), 'x')
     mkdirSync(join(cache, 'cache', 'repodata'), { recursive: true })
     writeFileSync(join(cache, 'cache', 'repodata', 'state.json'), '{}')

--- a/src/main/notebook/micromamba-cache-recovery.ts
+++ b/src/main/notebook/micromamba-cache-recovery.ts
@@ -1,10 +1,11 @@
-import { type Dirent, existsSync, readFileSync, readdirSync, realpathSync, rmSync } from 'node:fs'
+import { type Dirent, readFileSync, readdirSync, realpathSync, rmSync } from 'node:fs'
 import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 import { WINDOWS_MAX_USABLE_PATH } from './micromamba-cache'
 import { micromambaDiagnosticText } from './provisioner-runtime'
 
 const COMPLETE_MARKER = join('info', 'repodata_record.json')
+const PACKAGE_INDEX = join('info', 'index.json')
 const CONDA_SUBDIR = /^(?:noarch|win-64|osx-(?:64|arm64)|linux-(?:64|aarch64|ppc64le|s390x))$/i
 const isPackageDistLeaf = (value: string): boolean =>
   /^[A-Za-z0-9_.+-]+-[A-Za-z0-9_.+!]+-[A-Za-z0-9_.+]+$/.test(value)
@@ -21,8 +22,19 @@ const directories = (path: string): Dirent[] => {
   return entries(path).filter((entry) => entry.isDirectory())
 }
 
+const hasJsonObject = (path: string): boolean => {
+  try {
+    const value: unknown = JSON.parse(readFileSync(path, 'utf8'))
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+  } catch {
+    return false
+  }
+}
+
 const removeIfIncomplete = (dir: string): boolean => {
-  if (existsSync(join(dir, COMPLETE_MARKER))) return false
+  if (hasJsonObject(join(dir, COMPLETE_MARKER)) && hasJsonObject(join(dir, PACKAGE_INDEX))) {
+    return false
+  }
   rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 })
   return true
 }

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -438,6 +438,43 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     expect(readReadyMarker(root)?.defaultEnvVersion).toBe(DEFAULT_ENV_VERSION)
   })
 
+  it('repairs an extracted package with an empty index after micromamba reports invalid JSON', async () => {
+    const root = makeRoot()
+    const cache = pkgsCache(root)
+    const corruptPackage = join(cache, 'python-3.12.0-h123_0')
+    const prefix = envPrefix(root, DEFAULT_PY_ENV)
+    const bin = pythonBin(prefix)
+    mkdirSync(join(corruptPackage, 'info'), { recursive: true })
+    writeFileSync(join(corruptPackage, 'info', 'repodata_record.json'), '{}')
+    writeFileSync(join(corruptPackage, 'info', 'index.json'), '')
+
+    let creates = 0
+    const fetchBundle = vi.fn(async (): Promise<FetchedBundle> => ({
+      lockPath: join(root, 'python-3.12.lock')
+    }))
+    const runArgv = vi.fn(async () => {
+      creates += 1
+      if (creates === 1) {
+        throw new Error(
+          'libmamba Error when extracting package: [json.exception.parse_error.101] ' +
+            'parse error at line 1, column 1: attempting to parse an empty input; ' +
+            'critical libmamba Found incorrect downloads. Aborting'
+        )
+      }
+      expect(existsSync(corruptPackage)).toBe(false)
+      mkdirSync(join(bin, '..'), { recursive: true })
+      writeFileSync(bin, 'ok')
+    })
+
+    await new DefaultRuntimeProvisioner(makeDeps(root, { fetchBundle, runArgv })).provisionPython(
+      () => {}
+    )
+
+    expect(creates).toBe(2)
+    expect(fetchBundle).toHaveBeenCalledTimes(2)
+    expect(existsSync(bin)).toBe(true)
+  })
+
   it('repairs and retries after a Windows native access violation leaves an incomplete cache', async () => {
     const root = makeRoot()
     const cache = pkgsCache(root)
@@ -578,6 +615,7 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     // A COMPLETE extracted package has micromamba's repodata marker — another env depends on it; must survive.
     mkdirSync(join(cache, 'good-pkg', 'info'), { recursive: true })
     writeFileSync(join(cache, 'good-pkg', 'info', 'repodata_record.json'), '{}')
+    writeFileSync(join(cache, 'good-pkg', 'info', 'index.json'), '{}')
     // A downloaded TARBALL — offline-rebuild material for other envs; must survive.
     writeFileSync(join(cache, 'numpy-1.26.conda'), 'tarball')
     // An INCOMPLETE extraction (no repodata_record.json) — the corrupt one; must be removed.
@@ -700,6 +738,7 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
       join(legacyLeaf, 'info', 'repodata_record.json'),
       JSON.stringify({ url: 'https://host/channel/win-64/legacy-deep-package-1.0-0.conda' })
     )
+    writeFileSync(join(legacyLeaf, 'info', 'index.json'), '{}')
     const runArgv = vi.fn(async () => {
       expect(existsSync(legacyLeaf)).toBe(false)
       const bin = pythonBin(envPrefix(root, DEFAULT_PY_ENV))


### PR DESCRIPTION
## Problem

Managed runtime setup can fail when micromamba leaves an extracted package with a valid `info/repodata_record.json` marker but a missing, empty, or malformed `info/index.json`. Micromamba reports a JSON parse error followed by `Found incorrect downloads`, but the current cache repair treats the package directory as complete because the marker file exists, so Settings surfaces the failure instead of self-healing.

This matches the extraction failure shape documented upstream in mamba-org/mamba#3351.

## Proposed change

- Treat an extracted package as complete only when both `info/repodata_record.json` and `info/index.json` contain JSON objects.
- Reuse the existing exclusive-cache repair, surgical package-directory removal, bundle re-seed, and single retry path.
- Add a regression test at `DefaultRuntimeProvisioner.provisionPython()` that reproduces the Settings installation failure with an empty package index.

## Scope and non-goals

- No renderer or Settings interaction changes.
- No new state, enum values, database fields, migrations, or persisted formats.
- No whole-cache deletion or additional retry loop.
- Existing invalid cache directories are rebuildable and self-heal on the next recognized extraction failure; package archives and complete sibling packages remain preserved.

## Acceptance criteria and validation

The regression test failed before the fix with the reported empty-input parse error and passes after the fix.

Final checks ran after the last material edit:

- invalid extracted-package recovery -> `npm test -- src/main/notebook/micromamba-cache-recovery.test.ts src/main/notebook/provisioner.test.ts` -> 101 tests passed
- main-process types -> `npm run typecheck:node` -> passed
- linted source -> `npm run lint -- --no-cache` -> passed

Per maintainer direction, the complete local `npm test` suite was not run; PR Gate is authoritative for the full portable and platform coverage.

## Review focus

- Whether `repodata_record.json` plus `index.json` is the correct minimal completeness contract for an extracted package cache.
- Whether recovery remains surgical: only invalid extracted directories are removed while offline archives and valid cache entries are preserved.