### PR TITLE
fix(specialists): align list actions with skills

### DIFF
--- a/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
@@ -1061,6 +1061,36 @@ describe('SpecialistsPanel', () => {
     expect(labels).toEqual(['All(4)', 'Custom(2)', 'Built-in(2)'])
   })
 
+  it('aligns the add action right and matches the Skill row action order', async () => {
+    await act(async () => {
+      root.render(<SpecialistsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+    })
+
+    const toolbar = document.body.querySelector('[data-slot="specialists-toolbar"]')
+    const addButton = Array.from(toolbar?.querySelectorAll<HTMLButtonElement>('button') ?? []).find(
+      (button) => button.textContent?.includes('Add specialist')
+    )
+    expect(addButton?.className).toContain('ml-auto')
+    expect(toolbar?.lastElementChild).toBe(addButton)
+
+    const toggle = document.body.querySelector<HTMLButtonElement>(
+      '[aria-label="Toggle RNA Reviewer"]'
+    )
+    const row = toggle?.closest('[data-slot="settings-list-row"]')
+    const trailingControlLabels = Array.from(
+      row?.querySelectorAll<HTMLButtonElement>('button') ?? []
+    )
+      .map((button) => button.getAttribute('aria-label'))
+      .filter((label) =>
+        ['Manage Tags', 'Actions for RNA Reviewer', 'Toggle RNA Reviewer'].includes(label ?? '')
+      )
+    expect(trailingControlLabels).toEqual([
+      'Manage Tags',
+      'Actions for RNA Reviewer',
+      'Toggle RNA Reviewer'
+    ])
+  })
+
   it('shows a runnable builtin as a read-only row and opens its approved detail view', async () => {
     const onNavigate = vi.fn()
     await act(async () => {

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -1234,7 +1234,7 @@ const InstalledSpecialistsPanel = ({
         />
       </div>
       {/* Toolbar */}
-      <div className="mb-4 flex flex-wrap items-center gap-2">
+      <div data-slot="specialists-toolbar" className="mb-4 flex flex-wrap items-center gap-2">
         <SettingsSegmentedControl
           value={filter}
           options={(['all', 'custom', 'builtin'] as const).map((key) => {
@@ -1268,7 +1268,7 @@ const InstalledSpecialistsPanel = ({
         />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="outline" className="shrink-0">
+            <Button variant="outline" className="ml-auto shrink-0">
               <Plus data-icon="inline-start" aria-hidden="true" />
               {t('Add specialist')}
               <ChevronDown data-icon="inline-end" className="opacity-70" aria-hidden="true" />
@@ -1540,30 +1540,6 @@ const InstalledSpecialistsPanel = ({
                           </span>
                         </div>
 
-                        {item.setupPending ? (
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            className="shrink-0"
-                            disabled={catalogReadOnly}
-                            aria-label={t('Continue setup for {{name}}', {
-                              name: item.displayName ?? item.name
-                            })}
-                            onClick={() => onNavigate({ kind: 'edit', id: item.id })}
-                          >
-                            {t('Continue setup')}
-                          </Button>
-                        ) : (
-                          <SettingsToggle
-                            enabled={item.enabled}
-                            disabled={catalogReadOnly}
-                            aria-label={t('Toggle {{name}}', {
-                              name: item.displayName ?? item.name
-                            })}
-                            onToggle={() => void setEnabled(item.id, !item.enabled)}
-                          />
-                        )}
                         <ResourceTagMenu
                           reference={{ resourceType: 'catalog.specialist', resourceId: item.id }}
                         />
@@ -1642,6 +1618,30 @@ const InstalledSpecialistsPanel = ({
                             </DropdownMenuItem>
                           </DropdownMenuContent>
                         </DropdownMenu>
+                        {item.setupPending ? (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="shrink-0"
+                            disabled={catalogReadOnly}
+                            aria-label={t('Continue setup for {{name}}', {
+                              name: item.displayName ?? item.name
+                            })}
+                            onClick={() => onNavigate({ kind: 'edit', id: item.id })}
+                          >
+                            {t('Continue setup')}
+                          </Button>
+                        ) : (
+                          <SettingsToggle
+                            enabled={item.enabled}
+                            disabled={catalogReadOnly}
+                            aria-label={t('Toggle {{name}}', {
+                              name: item.displayName ?? item.name
+                            })}
+                            onToggle={() => void setEnabled(item.id, !item.enabled)}
+                          />
+                        )}
                       </li>
                     )
                   })}


### PR DESCRIPTION
## Problem

The Specialist list uses a different trailing-action order from the Skill list, and the Add specialist action sits immediately after search instead of at the right edge of the toolbar.

## Proposed change

- Order custom Specialist row actions as Tags, actions menu, then enable switch.
- Keep Continue setup in the same final-action position for incomplete Specialists.
- Push Add specialist to the far right of the wrapping toolbar.
- Add a renderer regression test for toolbar alignment and row action DOM order.

## Scope and non-goals

Renderer layout only. This does not change stored data, compatibility behavior, state enums, translations, shared control implementations, or Specialist actions.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Specialist action order -> npm test -- src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx -> passed, 48 tests.
- Renderer type safety -> npm run typecheck:web -> passed.
- Source lint -> npm run lint -> passed.
- Impact plan -> npm run test:affected:explain -- --base origin/main --head HEAD -> full fallback because the changed render test has no module owner. The complete local suite was intentionally not run per maintainer request; PR Gate remains authoritative.

Consumers and platform lanes are excluded locally because the change only reorders existing rendered controls and adds one Tailwind alignment class; it does not change component interfaces, actions, persistence, IPC, or platform-specific code.

## Review focus

Please verify the custom Specialist row order matches Skills and that Add specialist remains right-aligned when the toolbar wraps.