### PR TITLE
fix(acp-runtime): restore workspace facade architecture gates

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -46,6 +46,7 @@
           "src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts",
           "src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts",
           "src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx",
+          "src/renderer/src/lib/acp/workspace-runtime-event-owner.test.ts",
           "src/renderer/src/lib/acp/workspace-runtime-save-as-skill-owner.test.tsx",
           "src/renderer/src/lib/acp/workspace-events.test.ts"
         ],

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.ts
@@ -37,17 +37,16 @@ import {
   createWorkspaceRuntimeEventProcessor,
   drainWorkspaceRuntimeEventsForPersistence,
   markRunningSessionsDisconnectedOnDrop,
-  processIncrementalWorkspaceRuntimeEvents,
   processVisibleWorkspaceRuntimeEvents,
   processWorkspaceRuntimeEvents,
   refreshDelegatedWorkSessions,
   subscribeWorkspacePermissionLifecycle,
-  syncWorkspaceAgentFirstOutputState,
   syncWorkspaceContextUsage,
   syncWorkspaceElicitationState,
   syncWorkspaceInteractionState,
   syncWorkspacePermissionState,
-  useWorkspaceRuntimeEventDrain
+  useWorkspaceRuntimeEventDrain,
+  useWorkspaceRuntimeEventIngest
 } from './workspace-runtime-event-owner'
 import { getResumeFailureMessage } from './workspace-runtime-prompt-preparation-owner'
 import {
@@ -70,7 +69,6 @@ type WorkspacePermissionProfileRuntime = Pick<
   'state' | 'setPermissionProfile'
 >
 type SubagentRuntimeListener = (update: AcpAgentRuntimeUpdate) => void
-const EMPTY_AGENT_PROMPT_IN_FLIGHT_SESSION_IDS: string[] = []
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
 const setWorkspacePermissionProfile = async (
@@ -125,12 +123,6 @@ const WorkspaceAgentRuntimeContext = createContext<WorkspaceAgentRuntime | null>
 const RuntimeProvider = WorkspaceAgentRuntimeContext.Provider
 const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   const runtime = useAcpRuntime()
-  // Characterization fixtures can still present the legacy snapshot-only seam. Production
-  // useAcpRuntime always supplies this subscription, including when an older Main lacks onEvent.
-  const subscribeRuntimeEvents = (
-    runtime as Partial<Pick<ReturnType<typeof useAcpRuntime>, 'subscribeRuntimeEvents'>>
-  ).subscribeRuntimeEvents
-  const runtimeRef = useRef(runtime)
   const subagentRuntimeUpdateListeners = useRef(new Set<SubagentRuntimeListener>())
   const subscribeToSubagentRuntimeUpdates = useCallback(
     (listener: SubagentRuntimeListener): (() => void) => {
@@ -194,18 +186,13 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
     },
     [agentFrameworks, providers]
   )
-  const runtimeEventLifecycleOptionsRef = useRef({
-    supportsImageInput: supportsHistoryImageInput,
-    getHistoryReplayDescriptor: getSessionHistoryReplayDescriptor
-  })
-  useEffect(() => {
-    runtimeRef.current = runtime
-    runtimeEventLifecycleOptionsRef.current = {
-      supportsImageInput: supportsHistoryImageInput,
-      getHistoryReplayDescriptor: getSessionHistoryReplayDescriptor
-    }
-  }, [getSessionHistoryReplayDescriptor, runtime, supportsHistoryImageInput])
   const [lifecycleOwner] = useState(createWorkspaceRuntimeSessionLifecycleOwner)
+  const liveRuntimeEvents = useWorkspaceRuntimeEventIngest(
+    runtime,
+    lifecycleOwner.processRuntimeEvents,
+    supportsHistoryImageInput,
+    getSessionHistoryReplayDescriptor
+  )
   const pendingPermissions = useMemo(
     () => pendingWorkspacePermissions(restoredPermissionSessions, runtime.state.pendingPermissions),
     [restoredPermissionSessions, runtime.state.pendingPermissions]
@@ -260,7 +247,6 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
     () => new Set(JSON.parse(durablePermissionSessionIdsKey) as string[]),
     [durablePermissionSessionIdsKey]
   )
-
   useEffect(() => {
     const subscribe = window.api?.acp?.onAgentRuntimeUpdate
     if (!subscribe) return
@@ -268,24 +254,6 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
       for (const listener of subagentRuntimeUpdateListeners.current) listener(update)
     })
   }, [])
-
-  useEffect(() => {
-    if (!subscribeRuntimeEvents) return
-    return subscribeRuntimeEvents((events, snapshot) => {
-      const currentRuntime = runtimeRef.current
-      const eventRuntime = snapshot ? { ...currentRuntime, state: snapshot } : currentRuntime
-      const acceptedEvents = [...events]
-      syncWorkspaceAgentFirstOutputState(eventRuntime.state.agentPromptInFlightSessionIds ?? [])
-      lifecycleOwner.processRuntimeEvents(
-        eventRuntime,
-        acceptedEvents,
-        runtimeEventLifecycleOptionsRef.current
-      )
-      void processIncrementalWorkspaceRuntimeEvents(acceptedEvents)
-    })
-  }, [lifecycleOwner, subscribeRuntimeEvents])
-  const agentPromptInFlightSessionIds =
-    runtime.state.agentPromptInFlightSessionIds ?? EMPTY_AGENT_PROMPT_IN_FLIGHT_SESSION_IDS
 
   useEffect(
     () =>
@@ -295,7 +263,6 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
       }),
     [permissionResponseAttemptOwner]
   )
-
   useEffect(() => {
     permissionResponseAttemptOwner.cleanSessions(restoredPermissionSessions)
   }, [permissionResponseAttemptOwner, restoredPermissionSessions])
@@ -305,21 +272,18 @@ const useOwnedWorkspaceAgentRuntime = (): WorkspaceAgentRuntime => {
   }, [permissionResponseAttemptOwner, runtime.state.pendingPermissions])
 
   useEffect(() => {
-    if (subscribeRuntimeEvents) {
-      syncWorkspaceAgentFirstOutputState(agentPromptInFlightSessionIds)
-      return
-    }
+    if (liveRuntimeEvents) return
     lifecycleOwner.processRuntimeEvents(runtime, runtime.state.events, {
       supportsImageInput: supportsHistoryImageInput,
       getHistoryReplayDescriptor: getSessionHistoryReplayDescriptor
     })
     void processWorkspaceRuntimeEvents(runtime.state)
   }, [
-    agentPromptInFlightSessionIds,
     getSessionHistoryReplayDescriptor,
     lifecycleOwner,
+    liveRuntimeEvents,
     runtime,
-    subscribeRuntimeEvents,
+    runtime.state,
     supportsHistoryImageInput
   ])
 

--- a/src/renderer/src/lib/acp/workspace-runtime-event-owner.test.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-event-owner.test.ts
@@ -1,8 +1,54 @@
+// @vitest-environment jsdom
+import { act, createElement } from 'react'
+import { createRoot } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { AcpRuntimeEvent, AcpStateSnapshot } from '../../../../shared/acp'
 import type { PersistedChatSession } from '../../../../shared/session-persistence'
 import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
-import { refreshDelegatedWorkSessions } from './workspace-runtime-event-owner'
+import {
+  refreshDelegatedWorkSessions,
+  resetWorkspaceRuntimeEventOwnerForTests,
+  useWorkspaceRuntimeEventIngest
+} from './workspace-runtime-event-owner'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const renderHook = <Value>(
+  hook: () => Value
+): { result: { current: Value }; unmount: () => void } => {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+  const result = { current: undefined as unknown as Value }
+  const HookHarness = (): null => {
+    result.current = hook()
+    return null
+  }
+  act(() => {
+    root.render(createElement(HookHarness))
+  })
+  return {
+    result,
+    unmount: () =>
+      act(() => {
+        root.unmount()
+      })
+  }
+}
+
+const createSnapshot = (overrides: Partial<AcpStateSnapshot> = {}): AcpStateSnapshot => ({
+  status: 'connected',
+  cwd: '/workspace',
+  sessionIds: [],
+  events: [],
+  pendingPermissions: [],
+  permissionProfiles: {},
+  permissionGrants: {},
+  contextUsageBySession: {},
+  promptInFlight: false,
+  promptInFlightSessionIds: [],
+  ...overrides
+})
 
 const createSession = (id: string, projectId: string, revision: number): PersistedChatSession => ({
   id,
@@ -53,5 +99,78 @@ describe('delegated-work Session refresh', () => {
     expect(sessions).toHaveLength(2)
     expect(sessions[0]).toMatchObject({ id: 'session-1', runtimeContext: { revision: 2 } })
     expect(sessions[1]).toMatchObject({ id: 'session-2', runtimeContext: { revision: 1 } })
+  })
+})
+
+describe('live runtime event ingest', () => {
+  beforeEach(() => {
+    useSessionStore.setState(createInitialSessionState())
+    resetWorkspaceRuntimeEventOwnerForTests()
+  })
+
+  afterEach(() => {
+    resetWorkspaceRuntimeEventOwnerForTests()
+  })
+
+  it('leaves snapshot-only runtimes on the legacy seam', () => {
+    const processLifecycleEvents = vi.fn()
+    const { result, unmount } = renderHook(() =>
+      useWorkspaceRuntimeEventIngest(
+        { state: createSnapshot() },
+        processLifecycleEvents,
+        true,
+        () => ({ target: 'codex-bridge' })
+      )
+    )
+
+    expect(result.current).toBe(false)
+    expect(processLifecycleEvents).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('forwards subscribed events through the lifecycle sink with snapshot overlay', () => {
+    let publish:
+      ((events: readonly AcpRuntimeEvent[], snapshot?: AcpStateSnapshot) => void) | undefined
+    const unsubscribe = vi.fn()
+    const processLifecycleEvents = vi.fn()
+    const snapshot = createSnapshot({
+      sessionIds: ['session-1'],
+      agentPromptInFlightSessionIds: ['session-1']
+    })
+    const event: AcpRuntimeEvent = {
+      id: 'runtime-1:message-1',
+      timestamp: 1,
+      kind: 'message',
+      level: 'info',
+      role: 'assistant',
+      sessionId: 'session-1',
+      text: 'hello'
+    }
+    const { result, unmount } = renderHook(() =>
+      useWorkspaceRuntimeEventIngest(
+        {
+          state: createSnapshot(),
+          subscribeRuntimeEvents: (listener) => {
+            publish = listener
+            return unsubscribe
+          }
+        },
+        processLifecycleEvents,
+        true,
+        () => ({ target: 'codex-bridge' })
+      )
+    )
+
+    expect(result.current).toBe(true)
+    act(() => {
+      publish?.([event], snapshot)
+    })
+    expect(processLifecycleEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ state: snapshot }),
+      [event],
+      expect.objectContaining({ supportsImageInput: true })
+    )
+    unmount()
+    expect(unsubscribe).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
@@ -12,7 +12,8 @@ import {
   type AcpStateSnapshot,
   type PendingElicitationRequest
 } from '../../../../shared/acp'
-import { useCallback } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
+import type { HistoryReplayDescriptor } from '../../../../shared/history-preamble'
 import { useSessionStore } from '../../stores/session-store'
 import {
   acceptAcpRuntimeSnapshotRevision,
@@ -482,6 +483,61 @@ const processIncrementalWorkspaceRuntimeEvents = (
   events: readonly AcpRuntimeEvent[]
 ): Promise<void> => liveWorkspaceRuntimeEventProcessor.processIncremental(events)
 
+type WorkspaceRuntimeEventIngestRuntime = {
+  state: AcpStateSnapshot
+  subscribeRuntimeEvents?: (
+    listener: (events: readonly AcpRuntimeEvent[], snapshot?: AcpStateSnapshot) => void
+  ) => () => void
+}
+type WorkspaceRuntimeEventLifecycleOptions = {
+  supportsImageInput?: boolean
+  getHistoryReplayDescriptor: (sessionId: string) => HistoryReplayDescriptor
+}
+const EMPTY_AGENT_PROMPT_IN_FLIGHT_SESSION_IDS: string[] = []
+
+// Characterization fixtures can still present the legacy snapshot-only seam. Production
+// useAcpRuntime always supplies this subscription, including when an older Main lacks onEvent.
+const useWorkspaceRuntimeEventIngest = <Runtime extends WorkspaceRuntimeEventIngestRuntime>(
+  runtime: Runtime,
+  processLifecycleEvents: (
+    runtime: Runtime,
+    events: AcpRuntimeEvent[],
+    options: WorkspaceRuntimeEventLifecycleOptions
+  ) => void,
+  supportsImageInput: boolean | undefined,
+  getHistoryReplayDescriptor: (sessionId: string) => HistoryReplayDescriptor
+): boolean => {
+  const subscribeRuntimeEvents = runtime.subscribeRuntimeEvents
+  const runtimeRef = useRef(runtime)
+  const optionsRef = useRef({ supportsImageInput, getHistoryReplayDescriptor })
+  const agentPromptInFlightSessionIds =
+    runtime.state.agentPromptInFlightSessionIds ?? EMPTY_AGENT_PROMPT_IN_FLIGHT_SESSION_IDS
+
+  useEffect(() => {
+    runtimeRef.current = runtime
+    optionsRef.current = { supportsImageInput, getHistoryReplayDescriptor }
+  }, [getHistoryReplayDescriptor, runtime, supportsImageInput])
+
+  useEffect(() => {
+    if (!subscribeRuntimeEvents) return
+    return subscribeRuntimeEvents((events, snapshot) => {
+      const currentRuntime = runtimeRef.current
+      const eventRuntime = snapshot ? { ...currentRuntime, state: snapshot } : currentRuntime
+      const acceptedEvents = [...events]
+      syncWorkspaceAgentFirstOutputState(eventRuntime.state.agentPromptInFlightSessionIds ?? [])
+      processLifecycleEvents(eventRuntime, acceptedEvents, optionsRef.current)
+      void processIncrementalWorkspaceRuntimeEvents(acceptedEvents)
+    })
+  }, [processLifecycleEvents, subscribeRuntimeEvents])
+
+  useEffect(() => {
+    if (!subscribeRuntimeEvents) return
+    syncWorkspaceAgentFirstOutputState(agentPromptInFlightSessionIds)
+  }, [agentPromptInFlightSessionIds, subscribeRuntimeEvents])
+
+  return Boolean(subscribeRuntimeEvents)
+}
+
 // Flags sessions with a live Agent operation as disconnected on a transition into a dropped
 // connection state. Durable permission waits are intentionally quiescent: their provider RPC can
 // disappear while the persisted card remains actionable after a later resume.
@@ -587,5 +643,6 @@ export {
   syncWorkspaceElicitationState,
   syncWorkspaceInteractionState,
   syncWorkspacePermissionState,
-  useWorkspaceRuntimeEventDrain
+  useWorkspaceRuntimeEventDrain,
+  useWorkspaceRuntimeEventIngest
 }


### PR DESCRIPTION
## Problem

`#1444` streamed ACP runtime events incrementally, but the extra live subscription stayed in `useWorkspaceAgentRuntime`. The facade grew to 636 lines (gate is 600) and called `lifecycleOwner.processRuntimeEvents` twice. Full Module tests on later PRs failed on that architecture contract, including `#1453`.

Locale catalogs on current `main` are already complete. Earlier Korean orphan/missing-key Nightly failures were fixed by `#1436` / `#1437`.

## Proposed change

Move live runtime-event ingest into the event owner (`useWorkspaceRuntimeEventIngest`) so the facade only wires the owner and keeps the snapshot-only fallback as its one `processRuntimeEvents` call.

Live events still: sync first-output state, run overflow recovery through the injected lifecycle sink, and accept events incrementally. Characterization fixtures without `subscribeRuntimeEvents` still use the snapshot seam.

## Scope and non-goals

- No ACP protocol, launcher, or framework-adapter changes. The renderer ingest path is shared by `claude-code`, `opencode`, `codex-response`, and `codex-bridge`.
- No UI copy, so no locale catalog updates.
- Does not raise the 600-line facade gate or the six-operation lifecycle interface.

## Compatibility notes

- **Historical data:** none. Event application, session records, and snapshot watermarks are unchanged.
- **New states / enum values:** none.
- **Persistence:** none. This is renderer composition only; it does not change SQLite, settings documents, or packaged migration ledgers.

## Acceptance criteria and validation

These checks ran after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Facade ≤600 lines, one `processRuntimeEvents` call, owner DAG unchanged | `npx vitest run src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts` | pass |
| Live ingest + snapshot fallback + permission rearm | `npx vitest run src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx` | pass |
| Live subscribe overlay and snapshot-only seam | `npx vitest run src/renderer/src/lib/acp/workspace-runtime-event-owner.test.ts` | pass |
| Owner module closure | `npm run test:module -- workspace_runtime` | pass (318 tests) |
| Renderer/web types | `npm run typecheck:web` | pass |
| Locale catalogs on current main | `npx vitest run src/renderer/src/i18n/resources.test.ts` | pass (no catalog edits) |

`workspace_runtime` overlays: `renderer_state`. Consumer: `workspace_page` send-gate test included in the module plan.

Excluded locally: full `npm test` (PR Gate is authoritative), Windows lanes (this is source-architecture, not path/OS behavior), E2E (no user-visible interaction change).

## Review focus

- Live ingest belongs in the event owner, not a second facade effect.
- Snapshot-only fixtures still process `runtime.state` when `subscribeRuntimeEvents` is absent.
- Event owner stays under 660 lines and does not import other workspace-runtime owners.