### PR TITLE
perf(ci): accelerate Windows E2E checks

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -830,7 +830,7 @@ jobs:
           node-version: 22
           cache: npm
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --prefer-offline --no-audit --fund=false
       - name: Build Electron application
         id: build_electron
         continue-on-error: true
@@ -839,7 +839,7 @@ jobs:
         id: e2e_functional_windows
         if: ${{ steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_functional_windows') }}
         continue-on-error: true
-        run: npm run test:e2e:journey
+        run: npm run test:e2e:journey -- --workers=2
       - name: Upload functional failure artifacts
         if: ${{ steps.e2e_functional_windows.outcome == 'failure' }}
         continue-on-error: true
@@ -855,7 +855,7 @@ jobs:
         id: e2e_workspace_windows
         if: ${{ steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_workspace_windows') }}
         continue-on-error: true
-        run: npm run test:e2e:workspace
+        run: npm run test:e2e:workspace -- --workers=2
       - name: Upload workspace failure artifacts
         if: ${{ steps.e2e_workspace_windows.outcome == 'failure' }}
         continue-on-error: true

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -229,14 +229,18 @@ const openMainWindow = async (
   if (windowMode === 'hidden') await page.emulateMedia({ reducedMotion: 'reduce' })
   await rendererFailures.observe(page)
   await page.waitForLoadState('domcontentloaded')
+  // A fresh Windows profile can spend longer than the general assertion budget applying the real
+  // schema manifest under runner I/O contention. Keep the startup gate aligned with settings load.
   await expect
-    .poll(() =>
-      page.evaluate(async () => {
-        const bridge = globalThis as unknown as {
-          api: { databaseStartup: { getState: () => Promise<{ phase: string }> } }
-        }
-        return (await bridge.api.databaseStartup.getState()).phase
-      })
+    .poll(
+      () =>
+        page.evaluate(async () => {
+          const bridge = globalThis as unknown as {
+            api: { databaseStartup: { getState: () => Promise<{ phase: string }> } }
+          }
+          return (await bridge.api.databaseStartup.getState()).phase
+        }),
+      { timeout: 60_000 }
     )
     .toBe('ready')
   await page.getByText('Loading settings...').waitFor({ state: 'hidden', timeout: 60_000 })

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -415,19 +415,15 @@ describe('PR Gate workflow', () => {
   })
 
   it('shares dependency installation and Electron builds inside platform bundles', () => {
-    for (const bundle of [
-      'static',
-      'unit',
-      'unit_shard',
-      'windows_core',
-      'macos_e2e',
-      'windows_e2e'
-    ]) {
+    for (const bundle of ['static', 'unit', 'unit_shard', 'windows_core', 'macos_e2e']) {
       expect(
         workflow.jobs[bundle].steps?.filter(({ run }) => run === 'npm ci'),
         `${bundle} must install dependencies exactly once`
       ).toHaveLength(1)
     }
+    expect(
+      workflow.jobs.windows_e2e.steps?.filter(({ name }) => name === 'Install dependencies')
+    ).toEqual([expect.objectContaining({ run: 'npm ci --prefer-offline --no-audit --fund=false' })])
 
     const macosRuns = workflow.jobs.macos_e2e.steps?.map(({ run }) => run).filter(Boolean)
     expect(macosRuns?.filter((run) => run === 'npm run build:e2e')).toHaveLength(1)
@@ -444,8 +440,8 @@ describe('PR Gate workflow', () => {
     expect(windowsRuns?.filter((run) => run === 'npm run build:e2e')).toHaveLength(1)
     expect(windowsRuns).toEqual(
       expect.arrayContaining([
-        'npm run test:e2e:journey',
-        'npm run test:e2e:workspace',
+        'npm run test:e2e:journey -- --workers=2',
+        'npm run test:e2e:workspace -- --workers=2',
         'npm run test:e2e:accessibility'
       ])
     )


### PR DESCRIPTION
## Problem

The Windows E2E bundle is close to its 15-minute timeout. In the observed PR #1455 run, dependency installation took 5m08s, functional journeys took 4m32s, and the job was cancelled while workspace journeys were still running.

The reported settings persistence failure was not a lost theme value. The shared Electron fixture timed out after 20 seconds while a fresh database was still in the real `migrating` phase on the Windows runner.

Observed run: https://github.com/aipoch/open-science/actions/runs/32264061903/job/96104290739

## Proposed change

- Prefer the setup-node npm cache and skip npm audit/funding work in the Windows E2E install.
- Run the isolated functional and workspace Playwright suites with two workers.
- Give fresh database startup migration a dedicated 60-second readiness budget.
- Keep the PR Gate workflow contract test aligned with the Windows commands.

## Scope and non-goals

- No production database schema, persisted data, state enum, or user interaction changes.
- No `node_modules` cache. Native rebuild, Prisma generation, patches, and local package sources require a broader cache-key design and should be evaluated separately if installation remains the bottleneck.
- No change to macOS E2E parallelism.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Windows workflow command contract -> `npx vitest run scripts/ci/pr-gate-workflow.test.ts scripts/electron-app-fixture.test.ts` -> 25/25 passed.
- Electron fixture and E2E TypeScript -> `npm run typecheck:node` -> passed.
- Settings startup and persistence under parallel pressure -> `npx playwright test e2e/settings-persistence.spec.ts --repeat-each=2 --workers=2 --retries=0` -> 6/6 passed in 73s.
- Changed TypeScript lint -> targeted ESLint -> passed.
- Changed-file formatting and patch health -> targeted Prettier plus `git diff --check` -> passed.

The complete local `npm test` suite was intentionally not run. PR Gate is authoritative for the complete portable and platform lanes.

Uncovered local risk: the existing functional E2E specs use English locators and fail on a Chinese Windows host with either one or two workers. The GitHub Windows runner and this PR's exact-head E2E lane provide the relevant full-module validation.

## Exact-head PR results

PR Gate run: https://github.com/aipoch/open-science/actions/runs/32268266614

- Windows E2E completed in 8m36s instead of timing out around 15m09s.
- Install completed in 3m16s (baseline 5m08s).
- Functional journeys completed in 1m37s (baseline 4m32s), with 8/8 tests passing on two workers.
- Workspace journeys completed in 2m15s (baseline approximately 3m20s), with 11/11 tests passing on two workers.
- `settings-persistence.spec.ts` passed on the first attempt; the job log contains no retry.
- The complete PR Gate, all CodeQL checks, and AI review passed. AI review reported no actionable findings.
- `CI Integrity` fails by design because `.github/workflows/pr-gate.yml` is a protected gate control-plane file; merging this CI change requires an explicit maintainer ruleset bypass.

## Review focus

- Whether two Windows Playwright workers remain stable across the complete functional/workspace lane.
- Windows installation and E2E duration compared with the linked baseline.
- Whether settings persistence completes without a retry or database-startup timeout.