### PR TITLE
fix(settings): stop retrying deterministic provider errors

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -422,6 +422,7 @@
         "src/main/settings/native-responses-compatibility.ts",
         "src/main/settings/anthropic-provider-bridge.ts",
         "src/main/settings/openai-provider-bridge.ts",
+        "src/main/settings/provider-error-replay.ts",
         "src/main/settings/provider-loopback-http-host.ts",
         "src/main/settings/provider-transport-owner.ts",
         "src/main/settings/responses-bridge.ts",
@@ -459,6 +460,7 @@
           "src/main/settings/native-responses-compatibility.test.ts",
           "src/main/settings/anthropic-provider-bridge.test.ts",
           "src/main/settings/openai-provider-bridge.test.ts",
+          "src/main/settings/provider-error-replay.test.ts",
           "src/main/settings/system-proxy.test.ts",
           "src/main/settings/network-proxy-runtime.test.ts",
           "src/main/settings/environment-check-proxy.test.ts"

--- a/src/main/acp/model-change-workflow.test.ts
+++ b/src/main/acp/model-change-workflow.test.ts
@@ -56,6 +56,8 @@ type WorkflowHarness = {
   updateModel: ReturnType<typeof vi.fn>
   updateReasoningEffort: ReturnType<typeof vi.fn>
   updateAggregateModel: ReturnType<typeof vi.fn>
+  setProviderTransportTarget: ReturnType<typeof vi.fn>
+  setAnthropicBridgeTarget: ReturnType<typeof vi.fn>
   setBridgeReasoningEffort: ReturnType<typeof vi.fn>
   applyLiveEffort: ReturnType<typeof vi.fn>
   clearContext: ReturnType<typeof vi.fn>
@@ -147,6 +149,8 @@ const createHarness = (): WorkflowHarness => {
     updateReasoningEffort
   } as Pick<AcpBackendGenerationOwner, 'current' | 'updateModel' | 'updateReasoningEffort'>
 
+  const setProviderTransportTarget = vi.fn(() => true)
+  const setAnthropicBridgeTarget = vi.fn(() => true)
   const setBridgeReasoningEffort = vi.fn()
   const connectionResources = {
     epoch: 1,
@@ -163,8 +167,8 @@ const createHarness = (): WorkflowHarness => {
       return false
     },
     assertCurrentConnection: vi.fn(),
-    setProviderTransportTarget: vi.fn(() => true),
-    setAnthropicBridgeTarget: vi.fn(() => true),
+    setProviderTransportTarget,
+    setAnthropicBridgeTarget,
     setBridgeModelTarget: vi.fn(() => true),
     setBridgeReasoningEffort
   } as Pick<
@@ -218,6 +222,8 @@ const createHarness = (): WorkflowHarness => {
     updateModel,
     updateReasoningEffort,
     updateAggregateModel,
+    setProviderTransportTarget,
+    setAnthropicBridgeTarget,
     setBridgeReasoningEffort,
     applyLiveEffort,
     clearContext,
@@ -300,6 +306,32 @@ describe('ACP model-change workflow', () => {
       expect.objectContaining({ model: 'model-b' })
     )
     expect(harness.emitState).toHaveBeenCalledOnce()
+  })
+
+  it('reconnects when the current generation lacks a projected provider target', async () => {
+    const harness = createHarness()
+    harness.setProviderTransportTarget.mockReturnValue(false)
+
+    await expect(
+      harness.workflow.apply(target('model-b', { providerTransportTargetId: 'provider/model-b' }))
+    ).resolves.toBe(true)
+
+    expect(harness.setProviderTransportTarget).toHaveBeenCalledWith('provider/model-b')
+    expect(harness.requestReconnect).toHaveBeenCalledOnce()
+    expect(harness.updateModel).not.toHaveBeenCalled()
+  })
+
+  it('reconnects when the current generation lacks a projected Anthropic target', async () => {
+    const harness = createHarness()
+    harness.setAnthropicBridgeTarget.mockReturnValue(false)
+
+    await expect(
+      harness.workflow.apply(target('model-b', { anthropicBridgeTargetId: 'provider/model-b' }))
+    ).resolves.toBe(true)
+
+    expect(harness.setAnthropicBridgeTarget).toHaveBeenCalledWith('provider/model-b')
+    expect(harness.requestReconnect).toHaveBeenCalledOnce()
+    expect(harness.updateModel).not.toHaveBeenCalled()
   })
 
   it('reconnects instead of committing an image downgrade with opaque provider history', async () => {

--- a/src/main/settings/anthropic-provider-bridge.test.ts
+++ b/src/main/settings/anthropic-provider-bridge.test.ts
@@ -222,6 +222,38 @@ describe('AnthropicProviderBridge', () => {
     expect(fetchImpl).toHaveBeenCalledOnce()
   })
 
+  it('does not replay an error after an upstream-visible request header changes', async () => {
+    const fetchImpl = vi.fn(async (_url: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const headers = new Headers(init?.headers)
+      return headers.get('anthropic-beta') === 'invalid-beta'
+        ? Response.json({ error: { message: 'Invalid beta' } }, { status: 400 })
+        : Response.json({ content: [], model: 'model-a' })
+    })
+    const target = {
+      id: 'provider/model-a',
+      baseUrl: 'https://provider.example.test',
+      key: 'key-a',
+      model: 'model-a'
+    }
+    const bridge = new AnthropicProviderBridge([target], target.id, fetchImpl)
+    bridges.push(bridge)
+    const connection = await bridge.start()
+    const send = (beta?: string): Promise<Response> =>
+      fetch(`${connection.baseUrl}/v1/messages`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json',
+          ...(beta ? { 'anthropic-beta': beta } : {})
+        },
+        body: JSON.stringify({ model: 'ignored', messages: [] })
+      })
+
+    expect((await send('invalid-beta')).status).toBe(400)
+    expect((await send()).status).toBe(200)
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
   it.each([
     ['Claude Code', CLAUDE_CODE_TOOL_IMAGE_REQUEST_FIXTURE],
     ['OpenCode', OPENCODE_ANTHROPIC_TOOL_IMAGE_REQUEST_FIXTURE]

--- a/src/main/settings/anthropic-provider-bridge.test.ts
+++ b/src/main/settings/anthropic-provider-bridge.test.ts
@@ -222,6 +222,47 @@ describe('AnthropicProviderBridge', () => {
     expect(fetchImpl).toHaveBeenCalledOnce()
   })
 
+  it('labels a bounded fallback error as JSON on the first response and replay', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('oversized', {
+          status: 401,
+          headers: {
+            'content-encoding': 'gzip',
+            'content-length': String(256 * 1024 + 1),
+            'content-type': 'text/event-stream'
+          }
+        })
+    )
+    const target = {
+      id: 'provider/model-a',
+      baseUrl: 'https://provider.example.test',
+      key: 'wrong-key',
+      model: 'model-a'
+    }
+    const bridge = new AnthropicProviderBridge([target], target.id, fetchImpl)
+    bridges.push(bridge)
+    const connection = await bridge.start()
+    const send = (): Promise<Response> =>
+      fetch(`${connection.baseUrl}/v1/messages`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'ignored', messages: [] })
+      })
+
+    for (const response of [await send(), await send()]) {
+      expect(response.headers.get('content-type')).toBe('application/json')
+      expect(response.headers.get('content-encoding')).toBeNull()
+      await expect(response.json()).resolves.toMatchObject({
+        error: { message: 'Provider request failed with status 401' }
+      })
+    }
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
   it('does not replay an error after an upstream-visible request header changes', async () => {
     const fetchImpl = vi.fn(async (_url: Parameters<typeof fetch>[0], init?: RequestInit) => {
       const headers = new Headers(init?.headers)

--- a/src/main/settings/anthropic-provider-bridge.test.ts
+++ b/src/main/settings/anthropic-provider-bridge.test.ts
@@ -1,7 +1,7 @@
 import { createServer, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   AnthropicProviderBridge,
@@ -182,6 +182,44 @@ describe('AnthropicProviderBridge', () => {
     expect(response.status).toBe(200)
     expect(upstreamHeaders?.get('sec-fetch-site')).toBeNull()
     expect(upstreamHeaders?.get('x-request-id')).toBe('request-1')
+  })
+
+  it('replays an identical deterministic provider error without a second upstream request', async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json(
+        { error: { type: 'authentication_error', message: 'Incorrect API key provided' } },
+        { status: 401 }
+      )
+    )
+    const target = {
+      id: 'provider/model-a',
+      baseUrl: 'https://provider.example.test',
+      key: 'wrong-key',
+      model: 'model-a'
+    }
+    const bridge = new AnthropicProviderBridge([target], target.id, fetchImpl)
+    bridges.push(bridge)
+    const connection = await bridge.start()
+    const send = (): Promise<Response> =>
+      fetch(`${connection.baseUrl}/v1/messages`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'ignored', messages: [{ role: 'user', content: 'hello' }] })
+      })
+
+    const first = await send()
+    const second = await send()
+
+    expect(first.status).toBe(400)
+    expect(second.status).toBe(400)
+    expect(second.headers.get('x-open-science-upstream-status')).toBe('401')
+    await expect(second.json()).resolves.toMatchObject({
+      error: { type: 'authentication_error', message: 'Incorrect API key provided' }
+    })
+    expect(fetchImpl).toHaveBeenCalledOnce()
   })
 
   it.each([

--- a/src/main/settings/anthropic-provider-bridge.ts
+++ b/src/main/settings/anthropic-provider-bridge.ts
@@ -194,6 +194,7 @@ export class AnthropicProviderBridge {
         signal: request.signal
       })
       delete headers['content-encoding']
+      if (!upstreamBody.complete) headers['content-type'] = 'application/json'
       const bodyToReplay = upstreamBody.complete
         ? upstreamBody.body
         : Buffer.from(

--- a/src/main/settings/anthropic-provider-bridge.ts
+++ b/src/main/settings/anthropic-provider-bridge.ts
@@ -13,7 +13,8 @@ import {
   DeterministicProviderErrorReplay,
   isDeterministicProviderErrorStatus,
   providerErrorClientStatus,
-  providerRequestFingerprint
+  providerRequestFingerprint,
+  readBoundedProviderErrorBody
 } from './provider-error-replay'
 
 const ALLOWED_PATHS = new Set(['/v1/messages', '/v1/messages/count_tokens'])
@@ -30,8 +31,6 @@ const HOP_BY_HOP_HEADERS = new Set([
   'transfer-encoding',
   'upgrade'
 ])
-const MAX_REPLAY_ERROR_BODY_BYTES = 256 * 1024
-
 type ProviderErrorSnapshot = Readonly<{
   body: Buffer
   headers: Record<string, string>
@@ -184,19 +183,20 @@ export class AnthropicProviderBridge {
     })
     const headers = responseHeaders(upstream.headers)
     if (isDeterministicProviderErrorStatus(upstream.status)) {
-      const upstreamBody = Buffer.from(await upstream.arrayBuffer())
+      const upstreamBody = await readBoundedProviderErrorBody(upstream, {
+        signal: request.signal
+      })
       delete headers['content-encoding']
-      const bodyToReplay =
-        upstreamBody.byteLength <= MAX_REPLAY_ERROR_BODY_BYTES
-          ? upstreamBody
-          : Buffer.from(
-              JSON.stringify({
-                error: {
-                  type: 'invalid_request_error',
-                  message: `Provider request failed with status ${upstream.status}`
-                }
-              })
-            )
+      const bodyToReplay = upstreamBody.complete
+        ? upstreamBody.body
+        : Buffer.from(
+            JSON.stringify({
+              error: {
+                type: 'invalid_request_error',
+                message: `Provider request failed with status ${upstream.status}`
+              }
+            })
+          )
       const snapshot = {
         body: bodyToReplay,
         headers: {

--- a/src/main/settings/anthropic-provider-bridge.ts
+++ b/src/main/settings/anthropic-provider-bridge.ts
@@ -9,6 +9,12 @@ import {
   writeProviderLoopbackJson as json,
   type ProviderLoopbackHttpRequest
 } from './provider-loopback-http-host'
+import {
+  DeterministicProviderErrorReplay,
+  isDeterministicProviderErrorStatus,
+  providerErrorClientStatus,
+  providerRequestFingerprint
+} from './provider-error-replay'
 
 const ALLOWED_PATHS = new Set(['/v1/messages', '/v1/messages/count_tokens'])
 const HOP_BY_HOP_HEADERS = new Set([
@@ -24,6 +30,13 @@ const HOP_BY_HOP_HEADERS = new Set([
   'transfer-encoding',
   'upgrade'
 ])
+const MAX_REPLAY_ERROR_BODY_BYTES = 256 * 1024
+
+type ProviderErrorSnapshot = Readonly<{
+  body: Buffer
+  headers: Record<string, string>
+  status: number
+}>
 
 export type AnthropicProviderBridgeTarget = Readonly<{
   id: string
@@ -61,10 +74,12 @@ const requestHeaders = (request: ProviderLoopbackHttpRequest, key?: string): Hea
   return headers
 }
 
-const copyResponseHeaders = (source: Headers, response: ServerResponse): void => {
+const responseHeaders = (source: Headers): Record<string, string> => {
+  const headers: Record<string, string> = {}
   for (const [name, value] of source) {
-    if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) response.setHeader(name, value)
+    if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) headers[name] = value
   }
+  return headers
 }
 
 export class AnthropicProviderBridge {
@@ -72,6 +87,8 @@ export class AnthropicProviderBridge {
   private readonly host: ProviderLoopbackHttpHost<AnthropicProviderBridgeConnection>
   private target: AnthropicProviderBridgeTarget
   private readonly fetchImpl: typeof fetch
+  private readonly deterministicErrors =
+    new DeterministicProviderErrorReplay<ProviderErrorSnapshot>()
 
   constructor(
     targets: readonly AnthropicProviderBridgeTarget[],
@@ -110,6 +127,7 @@ export class AnthropicProviderBridge {
   setTarget(targetId: string): boolean {
     const target = this.targets.get(targetId)
     if (!target) return false
+    if (this.target.id !== target.id) this.deterministicErrors.clear()
     this.target = target
     return true
   }
@@ -119,6 +137,7 @@ export class AnthropicProviderBridge {
   }
 
   async close(): Promise<void> {
+    this.deterministicErrors.clear()
     await this.host.close()
   }
 
@@ -143,6 +162,17 @@ export class AnthropicProviderBridge {
 
     const target = this.target
     const body = JSON.stringify({ ...parsed, model: target.model })
+    const replayKey = providerRequestFingerprint(
+      target.id,
+      `${requestUrl.pathname}${requestUrl.search}`,
+      body
+    )
+    const replay = this.deterministicErrors.get(replayKey)
+    if (replay) {
+      response.writeHead(replay.status, replay.headers)
+      response.end(replay.body)
+      return
+    }
     const baseUrl = normalizeAnthropicBaseUrl(target.baseUrl)
     if (!baseUrl) throw new Error('The Anthropic provider target has no valid base URL.')
     const upstream = await this.fetchImpl(`${baseUrl}${requestUrl.pathname}${requestUrl.search}`, {
@@ -152,9 +182,38 @@ export class AnthropicProviderBridge {
       redirect: 'manual',
       signal: request.signal
     })
+    const headers = responseHeaders(upstream.headers)
+    if (isDeterministicProviderErrorStatus(upstream.status)) {
+      const upstreamBody = Buffer.from(await upstream.arrayBuffer())
+      delete headers['content-encoding']
+      const bodyToReplay =
+        upstreamBody.byteLength <= MAX_REPLAY_ERROR_BODY_BYTES
+          ? upstreamBody
+          : Buffer.from(
+              JSON.stringify({
+                error: {
+                  type: 'invalid_request_error',
+                  message: `Provider request failed with status ${upstream.status}`
+                }
+              })
+            )
+      const snapshot = {
+        body: bodyToReplay,
+        headers: {
+          ...headers,
+          'content-length': String(bodyToReplay.byteLength),
+          'x-open-science-upstream-status': String(upstream.status)
+        },
+        status: providerErrorClientStatus(upstream.status)
+      }
+      this.deterministicErrors.remember(replayKey, upstream.status, snapshot)
+      response.writeHead(snapshot.status, snapshot.headers)
+      response.end(snapshot.body)
+      return
+    }
     response.statusCode = upstream.status
     response.statusMessage = upstream.statusText
-    copyResponseHeaders(upstream.headers, response)
+    for (const [name, value] of Object.entries(headers)) response.setHeader(name, value)
     if (!upstream.body) {
       response.end()
       return

--- a/src/main/settings/anthropic-provider-bridge.ts
+++ b/src/main/settings/anthropic-provider-bridge.ts
@@ -13,6 +13,7 @@ import {
   DeterministicProviderErrorReplay,
   isDeterministicProviderErrorStatus,
   providerErrorClientStatus,
+  providerRequestHeadersFingerprint,
   providerRequestFingerprint,
   readBoundedProviderErrorBody
 } from './provider-error-replay'
@@ -131,6 +132,10 @@ export class AnthropicProviderBridge {
     return true
   }
 
+  clearErrorReplay(): void {
+    this.deterministicErrors.clear()
+  }
+
   async start(): Promise<AnthropicProviderBridgeConnection> {
     return this.host.start()
   }
@@ -161,9 +166,11 @@ export class AnthropicProviderBridge {
 
     const target = this.target
     const body = JSON.stringify({ ...parsed, model: target.model })
+    const headersToForward = requestHeaders(request, target.key)
     const replayKey = providerRequestFingerprint(
       target.id,
       `${requestUrl.pathname}${requestUrl.search}`,
+      providerRequestHeadersFingerprint(headersToForward),
       body
     )
     const replay = this.deterministicErrors.get(replayKey)
@@ -176,7 +183,7 @@ export class AnthropicProviderBridge {
     if (!baseUrl) throw new Error('The Anthropic provider target has no valid base URL.')
     const upstream = await this.fetchImpl(`${baseUrl}${requestUrl.pathname}${requestUrl.search}`, {
       method: 'POST',
-      headers: requestHeaders(request, target.key),
+      headers: headersToForward,
       body,
       redirect: 'manual',
       signal: request.signal

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -631,7 +631,7 @@ describe('AgentBackendResolver configured and explicit targets', () => {
     await backend.anthropicBridgeLease?.release()
   })
 
-  it('keeps a single Claude target behind loopback without exposing a retarget id', async () => {
+  it('keeps a single Claude target behind loopback and projects its model target', async () => {
     const harness = makeHarness()
     const backend = await harness.resolver.resolveActiveBackend()
 
@@ -647,9 +647,9 @@ describe('AgentBackendResolver configured and explicit targets', () => {
       ],
       JSON.stringify(['provider-a', 'model-a'])
     )
-    await expect(harness.resolver.resolveActiveModelChangeTarget()).resolves.not.toHaveProperty(
-      'anthropicBridgeTargetId'
-    )
+    await expect(harness.resolver.resolveActiveModelChangeTarget()).resolves.toMatchObject({
+      anthropicBridgeTargetId: JSON.stringify(['provider-a', 'model-a'])
+    })
     await backend.anthropicBridgeLease?.release()
   })
 

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -631,15 +631,26 @@ describe('AgentBackendResolver configured and explicit targets', () => {
     await backend.anthropicBridgeLease?.release()
   })
 
-  it('omits an Anthropic bridge target when the active generation has no bridge', async () => {
+  it('keeps a single Claude target behind loopback without exposing a retarget id', async () => {
     const harness = makeHarness()
     const backend = await harness.resolver.resolveActiveBackend()
 
-    expect(backend.anthropicBridgeLease).toBeUndefined()
-    expect(harness.createAnthropicProviderBridge).not.toHaveBeenCalled()
+    expect(backend.anthropicBridgeLease).toBeDefined()
+    expect(harness.createAnthropicProviderBridge).toHaveBeenCalledWith(
+      [
+        {
+          id: JSON.stringify(['provider-a', 'model-a']),
+          baseUrl: 'https://gateway.example',
+          key: 'plain:provider-a-key-ref',
+          model: 'model-a'
+        }
+      ],
+      JSON.stringify(['provider-a', 'model-a'])
+    )
     await expect(harness.resolver.resolveActiveModelChangeTarget()).resolves.not.toHaveProperty(
       'anthropicBridgeTargetId'
     )
+    await backend.anthropicBridgeLease?.release()
   })
 
   it('routes configured Claude API providers through one retargetable loopback generation', async () => {
@@ -1048,7 +1059,11 @@ describe('AgentBackendResolver configured and explicit targets', () => {
       reasoningEffort: 'high'
     })
 
-    expect(explicit).toEqual(configured)
+    const { anthropicBridgeLease: configuredLease, ...configuredStable } = configured
+    const { anthropicBridgeLease: explicitLease, ...explicitStable } = explicit
+    expect(explicitStable).toEqual(configuredStable)
+    expect(configuredLease).toBeDefined()
+    expect(explicitLease).toBeDefined()
     expect(harness.resolveRuntimeTarget).toHaveBeenNthCalledWith(
       1,
       settings.providers[0],
@@ -1061,6 +1076,8 @@ describe('AgentBackendResolver configured and explicit targets', () => {
       { kind: 'provider-default' },
       expect.objectContaining({ id: 'claude-code' })
     )
+    await configuredLease?.release()
+    await explicitLease?.release()
   })
 
   it('late-binds a configured selection but keeps an explicit target fixed', async () => {

--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -134,7 +134,8 @@ const makeAnthropicProviderBridgeDouble = (): AnthropicProviderBridgeDouble => (
     token: 'anthropic-bridge-token'
   })),
   close: vi.fn(async () => undefined),
-  setTarget: vi.fn(() => true)
+  setTarget: vi.fn(() => true),
+  clearErrorReplay: vi.fn()
 })
 
 const makeOpenAiProviderBridgeDouble = (index: number): OpenAiProviderBridgeDouble => ({
@@ -143,7 +144,8 @@ const makeOpenAiProviderBridgeDouble = (index: number): OpenAiProviderBridgeDoub
     token: `openai-bridge-token-${index}`
   })),
   close: vi.fn(async () => undefined),
-  setTarget: vi.fn(() => true)
+  setTarget: vi.fn(() => true),
+  clearErrorReplay: vi.fn()
 })
 
 type HarnessOptions = {

--- a/src/main/settings/backend-route-planner.test.ts
+++ b/src/main/settings/backend-route-planner.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { SETTINGS_FILE_VERSION } from '../../shared/settings'
 import type { AgentFrameworkId } from '../agent-framework'
+import { opencodeTransportProviderId } from '../agent-framework/opencode'
 import type { ProviderRuntimeTarget } from './provider-accounts'
 import type { ResolvedProvider } from './provider-env'
 import type { StoredProvider, StoredSettings } from './types'
@@ -164,6 +165,25 @@ describe('BackendRoutePlanner route matrix', () => {
     })
 
     expect(plan.transport.kind).toBe(kind)
+  })
+
+  it('keeps Codex subscription authentication on its direct transport', () => {
+    const provider = makeStoredProvider({
+      id: 'builtin-codex-subscription',
+      type: 'codex-isolated',
+      codexAuthMode: 'isolated',
+      keyRef: undefined
+    })
+
+    const plan = makePlanner().planBackend({
+      settings: makeSettings(provider),
+      frameworkId: 'codex',
+      target: makeTarget(provider),
+      effortIntent: 'high',
+      conversationSkillImportEnabled: true
+    })
+
+    expect(plan.transport).toEqual({ kind: 'direct' })
   })
 })
 
@@ -556,6 +576,69 @@ describe('BackendRoutePlanner provider candidates', () => {
 })
 
 describe('BackendRoutePlanner model-change projection', () => {
+  it('projects a target for a single-provider Claude bridge model change', () => {
+    const provider = makeStoredProvider({ model: 'model-a' })
+    const target = makeTarget(provider, {
+      effectiveModel: 'model-b',
+      provider: { model: 'model-b' }
+    })
+
+    const change = makePlanner().projectModelChange({
+      settings: makeSettings(provider),
+      frameworkId: 'claude-code',
+      target,
+      effortIntent: 'high'
+    })
+
+    expect(change).toMatchObject({
+      sessionModel: 'model-b',
+      anthropicBridgeTargetId: JSON.stringify(['provider-a', 'model-b'])
+    })
+  })
+
+  it('projects the generated provider and target for a single-provider OpenCode model change', () => {
+    const provider = makeStoredProvider({ model: 'model-a', apiEndpoints: ['openai'] })
+    const target = makeTarget(provider, {
+      effectiveModel: 'model-b',
+      apiEndpoints: ['openai'],
+      provider: { model: 'model-b', apiEndpoints: ['openai'] }
+    })
+    const agentProviderId = opencodeTransportProviderId(provider.id, 'model-b')
+
+    const change = makePlanner().projectModelChange({
+      settings: makeSettings(provider),
+      frameworkId: 'opencode',
+      target,
+      effortIntent: 'high'
+    })
+
+    expect(change).toMatchObject({
+      sessionModel: `${agentProviderId}/model-b`,
+      providerTransportTargetId: JSON.stringify(['opencode', 'provider-a', 'model-b'])
+    })
+  })
+
+  it('projects a target for a single-provider native Responses model change', () => {
+    const provider = makeStoredProvider({ model: 'model-a', apiEndpoints: ['responses'] })
+    const target = makeTarget(provider, {
+      effectiveModel: 'model-b',
+      apiEndpoints: ['responses'],
+      provider: { model: 'model-b', apiEndpoints: ['responses'] }
+    })
+
+    const change = makePlanner().projectModelChange({
+      settings: makeSettings(provider),
+      frameworkId: 'codex',
+      target,
+      effortIntent: 'high'
+    })
+
+    expect(change).toMatchObject({
+      sessionModel: 'model-b',
+      providerTransportTargetId: JSON.stringify(['codex', 'provider-a', 'model-b'])
+    })
+  })
+
   it('projects a secret-free retargetable Codex model identity', () => {
     const providerA = makeStoredProvider({ id: 'provider-a', model: 'model-a' })
     const providerB = makeStoredProvider({ id: 'provider-b', model: 'model-b' })

--- a/src/main/settings/backend-route-planner.test.ts
+++ b/src/main/settings/backend-route-planner.test.ts
@@ -146,6 +146,25 @@ describe('BackendRoutePlanner route matrix', () => {
       })
     ).toThrow('unavailable with Codex subscription authentication')
   })
+
+  it.each([
+    ['claude-code', 'claude-anthropic'],
+    ['opencode', 'opencode-openai'],
+    ['codex', 'codex-native-responses']
+  ] as const)('keeps a single custom %s provider behind the %s loopback', (frameworkId, kind) => {
+    const provider = makeStoredProvider()
+    const target = makeTarget(provider)
+
+    const plan = makePlanner().planBackend({
+      settings: makeSettings(provider),
+      frameworkId,
+      target,
+      effortIntent: 'high',
+      conversationSkillImportEnabled: true
+    })
+
+    expect(plan.transport.kind).toBe(kind)
+  })
 })
 
 describe('BackendRoutePlanner provider candidates', () => {

--- a/src/main/settings/backend-route-planner.ts
+++ b/src/main/settings/backend-route-planner.ts
@@ -300,8 +300,7 @@ class BackendRoutePlanner {
     effortIntent: ReasoningEffort
   ): BackendTransportPlan {
     if (frameworkId === 'claude-code') {
-      if (!retargetable || active.provider.type !== 'custom')
-        return Object.freeze({ kind: 'direct' })
+      if (active.provider.type !== 'custom') return Object.freeze({ kind: 'direct' })
       const targets = candidates.flatMap((candidate): AnthropicProviderBridgeTarget[] => {
         const model = candidate.effectiveModel ?? candidate.provider.model
         const baseUrl = normalizeAnthropicBaseUrl(candidate.provider.baseUrl ?? '')
@@ -328,12 +327,10 @@ class BackendRoutePlanner {
         : Object.freeze({ kind: 'direct' })
     }
     if (frameworkId === 'opencode') {
-      return retargetable
-        ? Object.freeze({
-            kind: route as 'opencode-anthropic' | 'opencode-openai',
-            targets: this.plannedTargets(candidates, frameworkId, effortIntent)
-          })
-        : Object.freeze({ kind: 'direct' })
+      return Object.freeze({
+        kind: route as 'opencode-anthropic' | 'opencode-openai',
+        targets: this.plannedTargets(candidates, frameworkId, effortIntent)
+      })
     }
     if (route === 'codex-bridge' || route === 'codex-responses-compatibility') {
       return Object.freeze({
@@ -344,7 +341,7 @@ class BackendRoutePlanner {
       })
     }
     const model = active.effectiveModel ?? active.provider.model
-    return retargetable && model
+    return model
       ? Object.freeze({
           kind: 'codex-native-responses',
           targets: this.plannedTargets(candidates, frameworkId, effortIntent),

--- a/src/main/settings/backend-route-planner.ts
+++ b/src/main/settings/backend-route-planner.ts
@@ -240,8 +240,16 @@ class BackendRoutePlanner {
     const route = modelRouteFor(input.frameworkId, input.target)
     const candidates = this.routeCandidates(input.settings, input.target, input.frameworkId, route)
     const retargetable = new Set(candidates.map(({ providerId }) => providerId)).size >= 2
+    const customTarget = input.target.provider.type === 'custom'
     const hasClaudeTransport =
-      input.frameworkId === 'claude-code' && retargetable && candidates.includes(input.target)
+      input.frameworkId === 'claude-code' && customTarget && candidates.includes(input.target)
+    const hasProviderTransport =
+      input.frameworkId === 'opencode' ||
+      (input.frameworkId === 'codex' &&
+        (retargetable || (route === 'codex-responses' && customTarget)))
+    const providerTransportTargetId = hasProviderTransport
+      ? transportTargetId(input.frameworkId, input.target.providerId, model)
+      : undefined
     const backendProviderId =
       input.frameworkId === 'codex' && isCodexSubscriptionProvider(input.target.provider.type)
         ? CODEX_ISOLATED_PROVIDER_ID
@@ -254,7 +262,7 @@ class BackendRoutePlanner {
       sessionModel:
         route === 'codex-bridge'
           ? CODEX_BRIDGE_MODEL
-          : input.frameworkId === 'opencode' && retargetable
+          : input.frameworkId === 'opencode'
             ? `${opencodeTransportProviderId(input.target.providerId, model)}/${model}`
             : model,
       sessionModelRequired:
@@ -264,15 +272,7 @@ class BackendRoutePlanner {
       ...(hasClaudeTransport
         ? { anthropicBridgeTargetId: claudeTargetId(input.target.providerId, model) }
         : {}),
-      ...((input.frameworkId === 'opencode' || input.frameworkId === 'codex') && retargetable
-        ? {
-            providerTransportTargetId: transportTargetId(
-              input.frameworkId,
-              input.target.providerId,
-              model
-            )
-          }
-        : {}),
+      ...(providerTransportTargetId ? { providerTransportTargetId } : {}),
       ...(input.target.provider.contextWindow
         ? { contextWindow: input.target.provider.contextWindow }
         : {}),
@@ -341,7 +341,7 @@ class BackendRoutePlanner {
       })
     }
     const model = active.effectiveModel ?? active.provider.model
-    return model
+    return active.provider.type === 'custom' && model
       ? Object.freeze({
           kind: 'codex-native-responses',
           targets: this.plannedTargets(candidates, frameworkId, effortIntent),

--- a/src/main/settings/native-responses-compatibility.test.ts
+++ b/src/main/settings/native-responses-compatibility.test.ts
@@ -125,6 +125,81 @@ describe('native Responses compatibility', () => {
     }
   })
 
+  it.each([
+    ['empty', ''],
+    ['malformed', '{not-json']
+  ])(
+    'replays an identical deterministic provider error with a %s JSON body',
+    async (_name, body) => {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(body, { status: 401, headers: { 'content-type': 'application/json' } })
+      )
+      const proxy = new NativeResponsesCompatibilityProxy(
+        { baseUrl: 'https://provider.example.test/v1', key: 'wrong-key', model: 'model-a' },
+        fetchImpl
+      )
+      const connection = await proxy.start()
+      const send = (): Promise<Response> =>
+        fetch(`${connection.baseUrl}/responses`, {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${connection.token}`,
+            'content-type': 'application/json'
+          },
+          body: JSON.stringify({ model: 'ignored', input: 'hello', stream: true })
+        })
+
+      try {
+        const first = await send()
+        const second = await send()
+        expect(first.status).toBe(400)
+        expect(second.status).toBe(400)
+        expect(first.headers.get('x-open-science-upstream-status')).toBe('401')
+        expect(second.headers.get('x-open-science-upstream-status')).toBe('401')
+        expect(fetchImpl).toHaveBeenCalledOnce()
+      } finally {
+        await proxy.close()
+      }
+    }
+  )
+
+  it('does not replay an error after an upstream-visible request header changes', async () => {
+    const fetchImpl = vi.fn(async (_url: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const headers = new Headers(init?.headers)
+      return headers.get('x-provider-feature') === 'invalid'
+        ? Response.json({ error: { message: 'Invalid feature' } }, { status: 400 })
+        : Response.json({
+            id: 'response',
+            output: [],
+            usage: { input_tokens: 1, output_tokens: 1 }
+          })
+    })
+    const proxy = new NativeResponsesCompatibilityProxy(
+      { baseUrl: 'https://provider.example.test/v1', key: 'key-a', model: 'model-a' },
+      fetchImpl
+    )
+    const connection = await proxy.start()
+    const send = (feature?: string): Promise<Response> =>
+      fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json',
+          ...(feature ? { 'x-provider-feature': feature } : {})
+        },
+        body: JSON.stringify({ model: 'ignored', input: 'hello', stream: false })
+      })
+
+    try {
+      expect((await send('invalid')).status).toBe(400)
+      expect((await send()).status).toBe(200)
+      expect(fetchImpl).toHaveBeenCalledTimes(2)
+    } finally {
+      await proxy.close()
+    }
+  })
+
   it('flattens namespace tools and matching history without changing plain functions', () => {
     const { request, aliases } = flattenNativeResponsesRequest({
       model: 'MiniMax-M3',

--- a/src/main/settings/native-responses-compatibility.test.ts
+++ b/src/main/settings/native-responses-compatibility.test.ts
@@ -87,6 +87,44 @@ describe('native Responses compatibility', () => {
     })
   })
 
+  it('replays an identical deterministic provider error without a second upstream request', async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json(
+        { error: { type: 'authentication_error', message: 'Incorrect API key provided' } },
+        { status: 401 }
+      )
+    )
+    const proxy = new NativeResponsesCompatibilityProxy(
+      { baseUrl: 'https://provider.example.test/v1', key: 'wrong-key', model: 'model-a' },
+      fetchImpl
+    )
+    const connection = await proxy.start()
+    const send = (): Promise<Response> =>
+      fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'ignored', input: 'hello', stream: true })
+      })
+
+    try {
+      const first = await send()
+      const second = await send()
+
+      expect(first.status).toBe(400)
+      expect(second.status).toBe(400)
+      expect(second.headers.get('x-open-science-upstream-status')).toBe('401')
+      await expect(second.json()).resolves.toMatchObject({
+        error: { type: 'authentication_error', message: 'Incorrect API key provided' }
+      })
+      expect(fetchImpl).toHaveBeenCalledOnce()
+    } finally {
+      await proxy.close()
+    }
+  })
+
   it('flattens namespace tools and matching history without changing plain functions', () => {
     const { request, aliases } = flattenNativeResponsesRequest({
       model: 'MiniMax-M3',

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -24,7 +24,8 @@ import {
   DeterministicProviderErrorReplay,
   isDeterministicProviderErrorStatus,
   providerErrorClientStatus,
-  providerRequestFingerprint
+  providerRequestFingerprint,
+  readBoundedProviderErrorBody
 } from './provider-error-replay'
 
 // Responses payloads are intentionally open-ended across providers. Keep the compatibility boundary
@@ -684,29 +685,36 @@ export class NativeResponsesCompatibilityProxy {
       })
       phase = 'forward-response'
       if (isDeterministicProviderErrorStatus(upstream.status)) {
+        const boundedBody = await readBoundedProviderErrorBody(upstream, {
+          signal: request.signal
+        })
         const rawBody =
-          responseType === 'json'
+          boundedBody.complete && responseType === 'json'
             ? Buffer.from(
-                JSON.stringify(restoreNativeResponsesPayload(await upstream.json(), aliases))
+                JSON.stringify(
+                  restoreNativeResponsesPayload(
+                    JSON.parse(boundedBody.body.toString('utf8')),
+                    aliases
+                  )
+                )
               )
-            : Buffer.from(await upstream.arrayBuffer())
-        const bodyToReplay =
-          rawBody.byteLength <= MAX_REPLAY_ERROR_BODY_BYTES
-            ? rawBody
-            : Buffer.from(
-                JSON.stringify({
-                  error: {
-                    type: 'invalid_request_error',
-                    message: `Provider request failed with status ${upstream.status}`,
-                    status: upstream.status
-                  }
-                })
-              )
+            : boundedBody.body
+        const bodyIsReplayable =
+          boundedBody.complete && rawBody.byteLength <= MAX_REPLAY_ERROR_BODY_BYTES
+        const bodyToReplay = bodyIsReplayable
+          ? rawBody
+          : Buffer.from(
+              JSON.stringify({
+                error: {
+                  type: 'invalid_request_error',
+                  message: `Provider request failed with status ${upstream.status}`,
+                  status: upstream.status
+                }
+              })
+            )
         const headers = {
           ...copyResponseHeaders(upstream),
-          ...(rawBody.byteLength <= MAX_REPLAY_ERROR_BODY_BYTES
-            ? {}
-            : { 'content-type': 'application/json' }),
+          ...(bodyIsReplayable ? {} : { 'content-type': 'application/json' }),
           'content-length': String(bodyToReplay.byteLength),
           'x-open-science-upstream-status': String(upstream.status)
         }

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -24,6 +24,7 @@ import {
   DeterministicProviderErrorReplay,
   isDeterministicProviderErrorStatus,
   providerErrorClientStatus,
+  providerRequestHeadersFingerprint,
   providerRequestFingerprint,
   readBoundedProviderErrorBody
 } from './provider-error-replay'
@@ -613,7 +614,12 @@ export class NativeResponsesCompatibilityProxy {
         : scopedBody
       const { request: upstreamRequest, aliases } = flattenNativeResponsesRequest(routedBody)
       const upstreamRequestBody = JSON.stringify(upstreamRequest)
-      const replayKey = providerRequestFingerprint(this.target.baseUrl, upstreamRequestBody)
+      const headersToForward = upstreamHeaders(request, this.target.key)
+      const replayKey = providerRequestFingerprint(
+        this.target.baseUrl,
+        providerRequestHeadersFingerprint(headersToForward),
+        upstreamRequestBody
+      )
       const requestBytes = Buffer.byteLength(upstreamRequestBody, 'utf8')
       // Derive the input size from the already-serialized body so a large multimodal input is not
       // serialized a second time just for diagnostics. The subtracted 8/9 bytes are the JSON key and
@@ -670,7 +676,7 @@ export class NativeResponsesCompatibilityProxy {
       )
       const upstream = await this.fetchImpl(responsesUrl(this.target.baseUrl), {
         method: 'POST',
-        headers: upstreamHeaders(request, this.target.key),
+        headers: headersToForward,
         body: upstreamRequestBody,
         signal: AbortSignal.any([request.signal, upstreamAbort.signal])
       })
@@ -688,19 +694,23 @@ export class NativeResponsesCompatibilityProxy {
         const boundedBody = await readBoundedProviderErrorBody(upstream, {
           signal: request.signal
         })
-        const rawBody =
-          boundedBody.complete && responseType === 'json'
-            ? Buffer.from(
-                JSON.stringify(
-                  restoreNativeResponsesPayload(
-                    JSON.parse(boundedBody.body.toString('utf8')),
-                    aliases
-                  )
+        let rawBody = boundedBody.body
+        let bodyIsReplayable = boundedBody.complete
+        if (boundedBody.complete && responseType === 'json') {
+          try {
+            rawBody = Buffer.from(
+              JSON.stringify(
+                restoreNativeResponsesPayload(
+                  JSON.parse(boundedBody.body.toString('utf8')),
+                  aliases
                 )
               )
-            : boundedBody.body
-        const bodyIsReplayable =
-          boundedBody.complete && rawBody.byteLength <= MAX_REPLAY_ERROR_BODY_BYTES
+            )
+          } catch {
+            bodyIsReplayable = false
+          }
+        }
+        bodyIsReplayable &&= rawBody.byteLength <= MAX_REPLAY_ERROR_BODY_BYTES
         const bodyToReplay = bodyIsReplayable
           ? rawBody
           : Buffer.from(

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -20,6 +20,12 @@ import {
   writeProviderLoopbackJson as json,
   type ProviderLoopbackHttpRequest
 } from './provider-loopback-http-host'
+import {
+  DeterministicProviderErrorReplay,
+  isDeterministicProviderErrorStatus,
+  providerErrorClientStatus,
+  providerRequestFingerprint
+} from './provider-error-replay'
 
 // Responses payloads are intentionally open-ended across providers. Keep the compatibility boundary
 // permissive, then validate the fields this module rewrites before touching them.
@@ -53,6 +59,7 @@ type NativeFetch = typeof fetch
 const log = createLogger('native-responses-compatibility')
 const DEFAULT_RESPONSE_HEADER_TIMEOUT_MS = 2 * 60_000
 const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 5 * 60_000
+const MAX_REPLAY_ERROR_BODY_BYTES = 256 * 1024
 const SAFE_NETWORK_ERROR_CODES = new Set([
   'EAI_AGAIN',
   'ECONNREFUSED',
@@ -62,6 +69,13 @@ const SAFE_NETWORK_ERROR_CODES = new Set([
   'ESOCKETTIMEDOUT',
   'ETIMEDOUT'
 ])
+
+type ProviderErrorSnapshot = Readonly<{
+  body: Buffer
+  headers: Record<string, string>
+  status: number
+  upstreamStatus: number
+}>
 
 class NativeResponsesTimeoutError extends Error {
   readonly code = 'ETIMEDOUT'
@@ -331,6 +345,8 @@ export class NativeResponsesCompatibilityProxy {
   private readonly hostMessageSessionScopes = new Map<string, ResponsesBridgeNamespacedTool[]>()
   private readonly scopedHostMessageSessionKeys = new Set<string>()
   private readonly strictHostMessageSessionKeys = new Set<string>()
+  private readonly deterministicErrors =
+    new DeterministicProviderErrorReplay<ProviderErrorSnapshot>()
 
   constructor(
     private target: NativeResponsesCompatibilityTarget,
@@ -365,7 +381,12 @@ export class NativeResponsesCompatibilityProxy {
   }
 
   setTarget(target: NativeResponsesCompatibilityTarget): void {
+    const changed =
+      this.target.baseUrl !== target.baseUrl ||
+      this.target.model !== target.model ||
+      this.target.key !== target.key
     this.target = target
+    if (changed) this.deterministicErrors.clear()
   }
 
   setModelTarget(target: ResponsesBridgeModelTarget): void {
@@ -510,6 +531,7 @@ export class NativeResponsesCompatibilityProxy {
   }
 
   async close(): Promise<void> {
+    this.deterministicErrors.clear()
     this.reviewerSessionKeys.clear()
     this.scopedReviewerSessionKeys.clear()
     this.toolLessSessionKeys.clear()
@@ -590,6 +612,7 @@ export class NativeResponsesCompatibilityProxy {
         : scopedBody
       const { request: upstreamRequest, aliases } = flattenNativeResponsesRequest(routedBody)
       const upstreamRequestBody = JSON.stringify(upstreamRequest)
+      const replayKey = providerRequestFingerprint(this.target.baseUrl, upstreamRequestBody)
       const requestBytes = Buffer.byteLength(upstreamRequestBody, 'utf8')
       // Derive the input size from the already-serialized body so a large multimodal input is not
       // serialized a second time just for diagnostics. The subtracted 8/9 bytes are the JSON key and
@@ -627,6 +650,19 @@ export class NativeResponsesCompatibilityProxy {
         toolLessScoped
       })
       phase = 'upstream-fetch'
+      const replay = this.deterministicErrors.get(replayKey)
+      if (replay) {
+        phase = 'forward-response'
+        response.writeHead(replay.status, replay.headers)
+        response.end(replay.body)
+        log.info('native Responses compatibility request completed', {
+          requestId,
+          status: replay.upstreamStatus,
+          replayed: true,
+          durationMs: Math.max(0, Date.now() - startedAt)
+        })
+        return
+      }
       armUpstreamTimeout(
         this.options.responseHeaderTimeoutMs ?? DEFAULT_RESPONSE_HEADER_TIMEOUT_MS,
         'Native Responses upstream did not return response headers in time.'
@@ -647,7 +683,43 @@ export class NativeResponsesCompatibilityProxy {
         durationMs: Math.max(0, Date.now() - startedAt)
       })
       phase = 'forward-response'
-      if (responseType === 'event-stream') {
+      if (isDeterministicProviderErrorStatus(upstream.status)) {
+        const rawBody =
+          responseType === 'json'
+            ? Buffer.from(
+                JSON.stringify(restoreNativeResponsesPayload(await upstream.json(), aliases))
+              )
+            : Buffer.from(await upstream.arrayBuffer())
+        const bodyToReplay =
+          rawBody.byteLength <= MAX_REPLAY_ERROR_BODY_BYTES
+            ? rawBody
+            : Buffer.from(
+                JSON.stringify({
+                  error: {
+                    type: 'invalid_request_error',
+                    message: `Provider request failed with status ${upstream.status}`,
+                    status: upstream.status
+                  }
+                })
+              )
+        const headers = {
+          ...copyResponseHeaders(upstream),
+          ...(rawBody.byteLength <= MAX_REPLAY_ERROR_BODY_BYTES
+            ? {}
+            : { 'content-type': 'application/json' }),
+          'content-length': String(bodyToReplay.byteLength),
+          'x-open-science-upstream-status': String(upstream.status)
+        }
+        const snapshot = {
+          body: bodyToReplay,
+          headers,
+          status: providerErrorClientStatus(upstream.status),
+          upstreamStatus: upstream.status
+        }
+        this.deterministicErrors.remember(replayKey, upstream.status, snapshot)
+        response.writeHead(snapshot.status, snapshot.headers)
+        response.end(snapshot.body)
+      } else if (responseType === 'event-stream') {
         armStreamIdleTimeout()
         await streamResponse(upstream, response, aliases, armStreamIdleTimeout)
       } else if (responseType === 'json') {

--- a/src/main/settings/openai-provider-bridge.test.ts
+++ b/src/main/settings/openai-provider-bridge.test.ts
@@ -227,6 +227,48 @@ describe('OpenAiProviderBridge', () => {
     expect(fetchImpl).toHaveBeenCalledOnce()
   })
 
+  it('labels a bounded fallback error as JSON on the first response and replay', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('oversized', {
+          status: 401,
+          headers: {
+            'content-encoding': 'gzip',
+            'content-length': String(256 * 1024 + 1),
+            'content-type': 'text/event-stream'
+          }
+        })
+    )
+    const target: OpenAiProviderBridgeTarget = {
+      id: 'provider/model-a',
+      wire: 'responses',
+      endpoint: 'https://provider.example.test/v1/responses',
+      key: 'wrong-key',
+      model: 'model-a'
+    }
+    const bridge = new OpenAiProviderBridge([target], target.id, fetchImpl)
+    bridges.push(bridge)
+    const connection = await bridge.start()
+    const send = (): Promise<Response> =>
+      fetch(`${connection.baseUrl}/v1/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'ignored', input: 'hello' })
+      })
+
+    for (const response of [await send(), await send()]) {
+      expect(response.headers.get('content-type')).toBe('application/json')
+      expect(response.headers.get('content-encoding')).toBeNull()
+      await expect(response.json()).resolves.toMatchObject({
+        error: { message: 'Provider request failed with status 401' }
+      })
+    }
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
   it('does not replay an error after an upstream-visible request header changes', async () => {
     const fetchImpl = vi.fn(async (_url: Parameters<typeof fetch>[0], init?: RequestInit) => {
       const headers = new Headers(init?.headers)

--- a/src/main/settings/openai-provider-bridge.test.ts
+++ b/src/main/settings/openai-provider-bridge.test.ts
@@ -227,6 +227,39 @@ describe('OpenAiProviderBridge', () => {
     expect(fetchImpl).toHaveBeenCalledOnce()
   })
 
+  it('does not replay an error after an upstream-visible request header changes', async () => {
+    const fetchImpl = vi.fn(async (_url: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const headers = new Headers(init?.headers)
+      return headers.get('x-provider-feature') === 'invalid'
+        ? Response.json({ error: { message: 'Invalid feature' } }, { status: 400 })
+        : Response.json({ output: [], model: 'model-a' })
+    })
+    const target: OpenAiProviderBridgeTarget = {
+      id: 'provider/model-a',
+      wire: 'responses',
+      endpoint: 'https://provider.example.test/v1/responses',
+      key: 'key-a',
+      model: 'model-a'
+    }
+    const bridge = new OpenAiProviderBridge([target], target.id, fetchImpl)
+    bridges.push(bridge)
+    const connection = await bridge.start()
+    const send = (feature?: string): Promise<Response> =>
+      fetch(`${connection.baseUrl}/v1/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json',
+          ...(feature ? { 'x-provider-feature': feature } : {})
+        },
+        body: JSON.stringify({ model: 'ignored', input: 'hello' })
+      })
+
+    expect((await send('invalid')).status).toBe(400)
+    expect((await send()).status).toBe(200)
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
   it('keeps retryable 429 responses out of the deterministic replay cache', async () => {
     const fetchImpl = vi.fn(async () =>
       Response.json({ error: { message: 'Rate limited' } }, { status: 429 })

--- a/src/main/settings/openai-provider-bridge.test.ts
+++ b/src/main/settings/openai-provider-bridge.test.ts
@@ -1,7 +1,7 @@
 import { createServer, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { OpenAiProviderBridge, type OpenAiProviderBridgeTarget } from './openai-provider-bridge'
 import { OPENCODE_TOOL_IMAGE_REQUEST_FIXTURE } from './provider-tool-image-wire.test-fixtures'
@@ -186,6 +186,74 @@ describe('OpenAiProviderBridge', () => {
     expect(response.status).toBe(200)
     expect(upstreamHeaders?.get('sec-fetch-site')).toBeNull()
     expect(upstreamHeaders?.get('x-request-id')).toBe('request-1')
+  })
+
+  it('replays an identical deterministic provider error without a second upstream request', async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json(
+        { error: { type: 'authentication_error', message: 'Incorrect API key provided' } },
+        { status: 401 }
+      )
+    )
+    const target: OpenAiProviderBridgeTarget = {
+      id: 'provider/model-a',
+      wire: 'responses',
+      endpoint: 'https://provider.example.test/v1/responses',
+      key: 'wrong-key',
+      model: 'model-a'
+    }
+    const bridge = new OpenAiProviderBridge([target], target.id, fetchImpl)
+    bridges.push(bridge)
+    const connection = await bridge.start()
+    const send = (): Promise<Response> =>
+      fetch(`${connection.baseUrl}/v1/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'ignored', input: 'hello' })
+      })
+
+    const first = await send()
+    const second = await send()
+
+    expect(first.status).toBe(400)
+    expect(second.status).toBe(400)
+    expect(second.headers.get('x-open-science-upstream-status')).toBe('401')
+    await expect(second.json()).resolves.toMatchObject({
+      error: { type: 'authentication_error', message: 'Incorrect API key provided' }
+    })
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
+  it('keeps retryable 429 responses out of the deterministic replay cache', async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json({ error: { message: 'Rate limited' } }, { status: 429 })
+    )
+    const target: OpenAiProviderBridgeTarget = {
+      id: 'provider/model-a',
+      wire: 'responses',
+      endpoint: 'https://provider.example.test/v1/responses',
+      key: 'key-a',
+      model: 'model-a'
+    }
+    const bridge = new OpenAiProviderBridge([target], target.id, fetchImpl)
+    bridges.push(bridge)
+    const connection = await bridge.start()
+    const send = (): Promise<Response> =>
+      fetch(`${connection.baseUrl}/v1/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'ignored', input: 'hello' })
+      })
+
+    expect((await send()).status).toBe(429)
+    expect((await send()).status).toBe(429)
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
   })
 
   it('preserves the captured OpenCode MCP image fixture at the final Chat boundary', async () => {

--- a/src/main/settings/openai-provider-bridge.ts
+++ b/src/main/settings/openai-provider-bridge.ts
@@ -8,6 +8,12 @@ import {
   writeProviderLoopbackJson as json,
   type ProviderLoopbackHttpRequest
 } from './provider-loopback-http-host'
+import {
+  DeterministicProviderErrorReplay,
+  isDeterministicProviderErrorStatus,
+  providerErrorClientStatus,
+  providerRequestFingerprint
+} from './provider-error-replay'
 
 const WIRE_PATH = {
   'chat-completions': '/v1/chat/completions',
@@ -26,6 +32,13 @@ const HOP_BY_HOP_HEADERS = new Set([
   'transfer-encoding',
   'upgrade'
 ])
+const MAX_REPLAY_ERROR_BODY_BYTES = 256 * 1024
+
+type ProviderErrorSnapshot = Readonly<{
+  body: Buffer
+  headers: Record<string, string>
+  status: number
+}>
 
 export type OpenAiProviderBridgeTarget = Readonly<{
   id: string
@@ -64,10 +77,12 @@ const requestHeaders = (request: ProviderLoopbackHttpRequest, key?: string): Hea
   return headers
 }
 
-const copyResponseHeaders = (source: Headers, response: ServerResponse): void => {
+const responseHeaders = (source: Headers): Record<string, string> => {
+  const headers: Record<string, string> = {}
   for (const [name, value] of source) {
-    if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) response.setHeader(name, value)
+    if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) headers[name] = value
   }
+  return headers
 }
 
 export class OpenAiProviderBridge {
@@ -76,6 +91,8 @@ export class OpenAiProviderBridge {
   private readonly host: ProviderLoopbackHttpHost<OpenAiProviderBridgeConnection>
   private target: OpenAiProviderBridgeTarget
   private readonly fetchImpl: typeof fetch
+  private readonly deterministicErrors =
+    new DeterministicProviderErrorReplay<ProviderErrorSnapshot>()
 
   constructor(
     targets: readonly OpenAiProviderBridgeTarget[],
@@ -115,6 +132,7 @@ export class OpenAiProviderBridge {
   setTarget(targetId: string): boolean {
     const target = this.targets.get(targetId)
     if (!target || target.wire !== this.wire) return false
+    if (this.target.id !== target.id) this.deterministicErrors.clear()
     this.target = target
     return true
   }
@@ -124,6 +142,7 @@ export class OpenAiProviderBridge {
   }
 
   async close(): Promise<void> {
+    this.deterministicErrors.clear()
     await this.host.close()
   }
 
@@ -152,6 +171,13 @@ export class OpenAiProviderBridge {
       throw new Error('The OpenAI provider target has no valid endpoint URL.')
     }
     const body = JSON.stringify({ ...parsed, model: target.model })
+    const replayKey = providerRequestFingerprint(target.id, requestUrl.pathname, body)
+    const replay = this.deterministicErrors.get(replayKey)
+    if (replay) {
+      response.writeHead(replay.status, replay.headers)
+      response.end(replay.body)
+      return
+    }
 
     const upstream = await this.fetchImpl(endpoint, {
       method: 'POST',
@@ -160,9 +186,38 @@ export class OpenAiProviderBridge {
       redirect: 'manual',
       signal: request.signal
     })
+    const headers = responseHeaders(upstream.headers)
+    if (isDeterministicProviderErrorStatus(upstream.status)) {
+      const upstreamBody = Buffer.from(await upstream.arrayBuffer())
+      delete headers['content-encoding']
+      const bodyToReplay =
+        upstreamBody.byteLength <= MAX_REPLAY_ERROR_BODY_BYTES
+          ? upstreamBody
+          : Buffer.from(
+              JSON.stringify({
+                error: {
+                  type: 'invalid_request_error',
+                  message: `Provider request failed with status ${upstream.status}`
+                }
+              })
+            )
+      const snapshot = {
+        body: bodyToReplay,
+        headers: {
+          ...headers,
+          'content-length': String(bodyToReplay.byteLength),
+          'x-open-science-upstream-status': String(upstream.status)
+        },
+        status: providerErrorClientStatus(upstream.status)
+      }
+      this.deterministicErrors.remember(replayKey, upstream.status, snapshot)
+      response.writeHead(snapshot.status, snapshot.headers)
+      response.end(snapshot.body)
+      return
+    }
     response.statusCode = upstream.status
     response.statusMessage = upstream.statusText
-    copyResponseHeaders(upstream.headers, response)
+    for (const [name, value] of Object.entries(headers)) response.setHeader(name, value)
     if (!upstream.body) {
       response.end()
       return

--- a/src/main/settings/openai-provider-bridge.ts
+++ b/src/main/settings/openai-provider-bridge.ts
@@ -12,6 +12,7 @@ import {
   DeterministicProviderErrorReplay,
   isDeterministicProviderErrorStatus,
   providerErrorClientStatus,
+  providerRequestHeadersFingerprint,
   providerRequestFingerprint,
   readBoundedProviderErrorBody
 } from './provider-error-replay'
@@ -136,6 +137,10 @@ export class OpenAiProviderBridge {
     return true
   }
 
+  clearErrorReplay(): void {
+    this.deterministicErrors.clear()
+  }
+
   async start(): Promise<OpenAiProviderBridgeConnection> {
     return this.host.start()
   }
@@ -170,7 +175,13 @@ export class OpenAiProviderBridge {
       throw new Error('The OpenAI provider target has no valid endpoint URL.')
     }
     const body = JSON.stringify({ ...parsed, model: target.model })
-    const replayKey = providerRequestFingerprint(target.id, requestUrl.pathname, body)
+    const headersToForward = requestHeaders(request, target.key)
+    const replayKey = providerRequestFingerprint(
+      target.id,
+      requestUrl.pathname,
+      providerRequestHeadersFingerprint(headersToForward),
+      body
+    )
     const replay = this.deterministicErrors.get(replayKey)
     if (replay) {
       response.writeHead(replay.status, replay.headers)
@@ -180,7 +191,7 @@ export class OpenAiProviderBridge {
 
     const upstream = await this.fetchImpl(endpoint, {
       method: 'POST',
-      headers: requestHeaders(request, target.key),
+      headers: headersToForward,
       body,
       redirect: 'manual',
       signal: request.signal

--- a/src/main/settings/openai-provider-bridge.ts
+++ b/src/main/settings/openai-provider-bridge.ts
@@ -202,6 +202,7 @@ export class OpenAiProviderBridge {
         signal: request.signal
       })
       delete headers['content-encoding']
+      if (!upstreamBody.complete) headers['content-type'] = 'application/json'
       const bodyToReplay = upstreamBody.complete
         ? upstreamBody.body
         : Buffer.from(

--- a/src/main/settings/openai-provider-bridge.ts
+++ b/src/main/settings/openai-provider-bridge.ts
@@ -12,7 +12,8 @@ import {
   DeterministicProviderErrorReplay,
   isDeterministicProviderErrorStatus,
   providerErrorClientStatus,
-  providerRequestFingerprint
+  providerRequestFingerprint,
+  readBoundedProviderErrorBody
 } from './provider-error-replay'
 
 const WIRE_PATH = {
@@ -32,8 +33,6 @@ const HOP_BY_HOP_HEADERS = new Set([
   'transfer-encoding',
   'upgrade'
 ])
-const MAX_REPLAY_ERROR_BODY_BYTES = 256 * 1024
-
 type ProviderErrorSnapshot = Readonly<{
   body: Buffer
   headers: Record<string, string>
@@ -188,19 +187,20 @@ export class OpenAiProviderBridge {
     })
     const headers = responseHeaders(upstream.headers)
     if (isDeterministicProviderErrorStatus(upstream.status)) {
-      const upstreamBody = Buffer.from(await upstream.arrayBuffer())
+      const upstreamBody = await readBoundedProviderErrorBody(upstream, {
+        signal: request.signal
+      })
       delete headers['content-encoding']
-      const bodyToReplay =
-        upstreamBody.byteLength <= MAX_REPLAY_ERROR_BODY_BYTES
-          ? upstreamBody
-          : Buffer.from(
-              JSON.stringify({
-                error: {
-                  type: 'invalid_request_error',
-                  message: `Provider request failed with status ${upstream.status}`
-                }
-              })
-            )
+      const bodyToReplay = upstreamBody.complete
+        ? upstreamBody.body
+        : Buffer.from(
+            JSON.stringify({
+              error: {
+                type: 'invalid_request_error',
+                message: `Provider request failed with status ${upstream.status}`
+              }
+            })
+          )
       const snapshot = {
         body: bodyToReplay,
         headers: {

--- a/src/main/settings/provider-error-replay.test.ts
+++ b/src/main/settings/provider-error-replay.test.ts
@@ -5,6 +5,7 @@ import {
   isDeterministicProviderErrorStatus,
   providerErrorClientStatus,
   providerRequestFingerprint,
+  providerRequestHeadersFingerprint,
   readBoundedProviderErrorBody
 } from './provider-error-replay'
 
@@ -54,6 +55,24 @@ describe('provider error replay policy', () => {
     expect(cache.get('third')).toBe('third')
     cache.clear()
     expect(cache.get('first')).toBe(undefined)
+  })
+
+  it('fingerprints forwarded headers independently of name casing and insertion order', () => {
+    const first = new Headers([
+      ['Anthropic-Version', '2023-06-01'],
+      ['Anthropic-Beta', 'feature-a']
+    ])
+    const reordered = {
+      'anthropic-beta': 'feature-a',
+      'anthropic-version': '2023-06-01'
+    }
+
+    expect(providerRequestHeadersFingerprint(first)).toBe(
+      providerRequestHeadersFingerprint(reordered)
+    )
+    expect(
+      providerRequestHeadersFingerprint({ ...reordered, 'anthropic-beta': 'feature-b' })
+    ).not.toBe(providerRequestHeadersFingerprint(first))
   })
 
   it('cancels a deterministic error body as soon as it exceeds the byte limit', async () => {

--- a/src/main/settings/provider-error-replay.test.ts
+++ b/src/main/settings/provider-error-replay.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DeterministicProviderErrorReplay,
+  isDeterministicProviderErrorStatus,
+  providerErrorClientStatus,
+  providerRequestFingerprint
+} from './provider-error-replay'
+
+describe('provider error replay policy', () => {
+  it.each([
+    400, 401, 402, 403, 404, 405, 406, 407, 410, 411, 413, 414, 415, 416, 417, 421, 422, 426, 428,
+    431, 451
+  ])('classifies explicit status %i as deterministic', (status) => {
+    expect(isDeterministicProviderErrorStatus(status)).toBe(true)
+    expect(providerErrorClientStatus(status)).toBe(400)
+  })
+
+  it.each([200, 301, 408, 409, 418, 423, 424, 425, 429, 500, 503])(
+    'preserves retry semantics for status %i',
+    (status) => {
+      expect(isDeterministicProviderErrorStatus(status)).toBe(false)
+      expect(providerErrorClientStatus(status)).toBe(status)
+    }
+  )
+
+  it('replays only a matching, unexpired deterministic error', () => {
+    let now = 100
+    const cache = new DeterministicProviderErrorReplay<string>(50, 2, () => now)
+    const key = providerRequestFingerprint('provider-a', '{"input":"same"}')
+
+    expect(cache.remember(key, 401, 'cached')).toBe(true)
+    expect(cache.get(key)).toBe('cached')
+    expect(cache.get(providerRequestFingerprint('provider-a', '{"input":"different"}'))).toBe(
+      undefined
+    )
+    expect(cache.remember('transient', 429, 'not-cached')).toBe(false)
+    expect(cache.get('transient')).toBe(undefined)
+
+    now = 150
+    expect(cache.get(key)).toBe(undefined)
+  })
+
+  it('keeps the replay cache bounded and clearable', () => {
+    const cache = new DeterministicProviderErrorReplay<string>(1_000, 2)
+    cache.remember('first', 401, 'first')
+    cache.remember('second', 403, 'second')
+    cache.get('first')
+    cache.remember('third', 404, 'third')
+
+    expect(cache.get('second')).toBe(undefined)
+    expect(cache.get('first')).toBe('first')
+    expect(cache.get('third')).toBe('third')
+    cache.clear()
+    expect(cache.get('first')).toBe(undefined)
+  })
+})

--- a/src/main/settings/provider-error-replay.test.ts
+++ b/src/main/settings/provider-error-replay.test.ts
@@ -4,7 +4,8 @@ import {
   DeterministicProviderErrorReplay,
   isDeterministicProviderErrorStatus,
   providerErrorClientStatus,
-  providerRequestFingerprint
+  providerRequestFingerprint,
+  readBoundedProviderErrorBody
 } from './provider-error-replay'
 
 describe('provider error replay policy', () => {
@@ -53,5 +54,42 @@ describe('provider error replay policy', () => {
     expect(cache.get('third')).toBe('third')
     cache.clear()
     expect(cache.get('first')).toBe(undefined)
+  })
+
+  it('cancels a deterministic error body as soon as it exceeds the byte limit', async () => {
+    let cancelled = false
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          controller.enqueue(new Uint8Array(8))
+        },
+        cancel() {
+          cancelled = true
+        }
+      }),
+      { status: 401 }
+    )
+
+    await expect(
+      readBoundedProviderErrorBody(response, { maxBytes: 10, timeoutMs: 1_000 })
+    ).resolves.toEqual({ body: Buffer.alloc(0), complete: false })
+    expect(cancelled).toBe(true)
+  })
+
+  it('cancels a deterministic error body that does not finish', async () => {
+    let cancelled = false
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        cancel() {
+          cancelled = true
+        }
+      }),
+      { status: 401 }
+    )
+
+    await expect(
+      readBoundedProviderErrorBody(response, { maxBytes: 10, timeoutMs: 5 })
+    ).resolves.toEqual({ body: Buffer.alloc(0), complete: false })
+    expect(cancelled).toBe(true)
   })
 })

--- a/src/main/settings/provider-error-replay.ts
+++ b/src/main/settings/provider-error-replay.ts
@@ -1,0 +1,75 @@
+import { createHash } from 'node:crypto'
+
+// ACP runtimes currently disagree on which client errors are retryable. Keep the provider-facing
+// contract as an explicit allowlist: only status codes that describe an unchanged request as
+// invalid or unauthorized are suppressed. Unknown and potentially transient 4xx statuses retain
+// the upstream retry behavior.
+const DETERMINISTIC_PROVIDER_ERROR_STATUS_CODES = new Set([
+  400, 401, 402, 403, 404, 405, 406, 407, 410, 411, 413, 414, 415, 416, 417, 421, 422, 426, 428,
+  431, 451
+])
+const DEFAULT_TTL_MS = 30_000
+const DEFAULT_MAX_ENTRIES = 32
+
+const isDeterministicProviderErrorStatus = (status: number): boolean =>
+  DETERMINISTIC_PROVIDER_ERROR_STATUS_CODES.has(status)
+
+// Codex, Claude Code, and OpenCode all retry at least some deterministic 4xx statuses. A local 400
+// makes the failure terminal sooner; bridge-specific diagnostics retain the real upstream status.
+const providerErrorClientStatus = (upstreamStatus: number): number =>
+  isDeterministicProviderErrorStatus(upstreamStatus) ? 400 : upstreamStatus
+
+const providerRequestFingerprint = (...parts: readonly string[]): string => {
+  const hash = createHash('sha256')
+  for (const part of parts) {
+    hash.update(String(Buffer.byteLength(part, 'utf8')))
+    hash.update(':')
+    hash.update(part)
+  }
+  return hash.digest('hex')
+}
+
+class DeterministicProviderErrorReplay<T> {
+  private readonly entries = new Map<string, { expiresAt: number; value: T }>()
+
+  constructor(
+    private readonly ttlMs = DEFAULT_TTL_MS,
+    private readonly maxEntries = DEFAULT_MAX_ENTRIES,
+    private readonly now: () => number = Date.now
+  ) {}
+
+  get(key: string): T | undefined {
+    const entry = this.entries.get(key)
+    if (!entry) return undefined
+    if (entry.expiresAt <= this.now()) {
+      this.entries.delete(key)
+      return undefined
+    }
+    this.entries.delete(key)
+    this.entries.set(key, entry)
+    return entry.value
+  }
+
+  remember(key: string, upstreamStatus: number, value: T): boolean {
+    if (!isDeterministicProviderErrorStatus(upstreamStatus)) return false
+    this.entries.delete(key)
+    this.entries.set(key, { expiresAt: this.now() + this.ttlMs, value })
+    while (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next().value
+      if (typeof oldest !== 'string') break
+      this.entries.delete(oldest)
+    }
+    return true
+  }
+
+  clear(): void {
+    this.entries.clear()
+  }
+}
+
+export {
+  DeterministicProviderErrorReplay,
+  isDeterministicProviderErrorStatus,
+  providerErrorClientStatus,
+  providerRequestFingerprint
+}

--- a/src/main/settings/provider-error-replay.ts
+++ b/src/main/settings/provider-error-replay.ts
@@ -10,6 +10,19 @@ const DETERMINISTIC_PROVIDER_ERROR_STATUS_CODES = new Set([
 ])
 const DEFAULT_TTL_MS = 30_000
 const DEFAULT_MAX_ENTRIES = 32
+const DEFAULT_ERROR_BODY_MAX_BYTES = 256 * 1024
+const DEFAULT_ERROR_BODY_TIMEOUT_MS = 10_000
+
+type BoundedProviderErrorBody = Readonly<{
+  body: Buffer
+  complete: boolean
+}>
+
+type BoundedProviderErrorBodyOptions = Readonly<{
+  maxBytes?: number
+  signal?: AbortSignal
+  timeoutMs?: number
+}>
 
 const isDeterministicProviderErrorStatus = (status: number): boolean =>
   DETERMINISTIC_PROVIDER_ERROR_STATUS_CODES.has(status)
@@ -27,6 +40,66 @@ const providerRequestFingerprint = (...parts: readonly string[]): string => {
     hash.update(part)
   }
   return hash.digest('hex')
+}
+
+const readBoundedProviderErrorBody = async (
+  response: Response,
+  options: BoundedProviderErrorBodyOptions = {}
+): Promise<BoundedProviderErrorBody> => {
+  const maxBytes = options.maxBytes ?? DEFAULT_ERROR_BODY_MAX_BYTES
+  const timeoutMs = options.timeoutMs ?? DEFAULT_ERROR_BODY_TIMEOUT_MS
+  const contentLength = response.headers.get('content-length')
+  if (contentLength && /^\d+$/.test(contentLength) && Number(contentLength) > maxBytes) {
+    await response.body?.cancel().catch(() => undefined)
+    return { body: Buffer.alloc(0), complete: false }
+  }
+  if (!response.body) return { body: Buffer.alloc(0), complete: true }
+  if (options.signal?.aborted) {
+    await response.body.cancel().catch(() => undefined)
+    throw options.signal.reason ?? new DOMException('The request was aborted.', 'AbortError')
+  }
+
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let byteLength = 0
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  let removeAbortListener: (() => void) | undefined
+  const stopped = new Promise<'aborted' | 'timeout'>((resolve) => {
+    timeout = setTimeout(() => resolve('timeout'), timeoutMs)
+    if (options.signal) {
+      const onAbort = (): void => resolve('aborted')
+      options.signal.addEventListener('abort', onAbort, { once: true })
+      removeAbortListener = () => options.signal?.removeEventListener('abort', onAbort)
+    }
+  })
+
+  try {
+    while (true) {
+      const result = await Promise.race([
+        reader.read().then((value) => ({ kind: 'read' as const, value })),
+        stopped.then((kind) => ({ kind }))
+      ])
+      if (result.kind !== 'read') {
+        await reader.cancel().catch(() => undefined)
+        if (result.kind === 'aborted') {
+          throw options.signal?.reason ?? new DOMException('The request was aborted.', 'AbortError')
+        }
+        return { body: Buffer.alloc(0), complete: false }
+      }
+      if (result.value.done) return { body: Buffer.concat(chunks, byteLength), complete: true }
+      if (!result.value.value) continue
+      byteLength += result.value.value.byteLength
+      if (byteLength > maxBytes) {
+        await reader.cancel().catch(() => undefined)
+        return { body: Buffer.alloc(0), complete: false }
+      }
+      chunks.push(result.value.value)
+    }
+  } finally {
+    if (timeout) clearTimeout(timeout)
+    removeAbortListener?.()
+    reader.releaseLock()
+  }
 }
 
 class DeterministicProviderErrorReplay<T> {
@@ -71,5 +144,6 @@ export {
   DeterministicProviderErrorReplay,
   isDeterministicProviderErrorStatus,
   providerErrorClientStatus,
-  providerRequestFingerprint
+  providerRequestFingerprint,
+  readBoundedProviderErrorBody
 }

--- a/src/main/settings/provider-error-replay.ts
+++ b/src/main/settings/provider-error-replay.ts
@@ -42,6 +42,16 @@ const providerRequestFingerprint = (...parts: readonly string[]): string => {
   return hash.digest('hex')
 }
 
+const providerRequestHeadersFingerprint = (
+  source: Headers | Readonly<Record<string, string>>
+): string => {
+  const entries = source instanceof Headers ? [...source.entries()] : Object.entries(source)
+  entries.sort(([left], [right]) => left.toLowerCase().localeCompare(right.toLowerCase()))
+  return providerRequestFingerprint(
+    ...entries.flatMap(([name, value]) => [name.toLowerCase(), value])
+  )
+}
+
 const readBoundedProviderErrorBody = async (
   response: Response,
   options: BoundedProviderErrorBodyOptions = {}
@@ -145,5 +155,6 @@ export {
   isDeterministicProviderErrorStatus,
   providerErrorClientStatus,
   providerRequestFingerprint,
+  providerRequestHeadersFingerprint,
   readBoundedProviderErrorBody
 }

--- a/src/main/settings/provider-transport-owner.test.ts
+++ b/src/main/settings/provider-transport-owner.test.ts
@@ -6,6 +6,7 @@ import {
   ProviderTransportOwner,
   type ProviderTransportOwnerOptions
 } from './provider-transport-owner'
+import { OpenAiProviderBridge } from './openai-provider-bridge'
 
 type ResponsesBridgeStub = ReturnType<
   NonNullable<ProviderTransportOwnerOptions['createResponsesBridge']>
@@ -91,7 +92,8 @@ const makeAnthropicBridge = (): AnthropicBridgeStub => ({
     token: 'anthropic-bridge-token'
   })),
   close: vi.fn(async () => undefined),
-  setTarget: vi.fn(() => true)
+  setTarget: vi.fn(() => true),
+  clearErrorReplay: vi.fn()
 })
 
 const makeOpenAiBridge = (index: number, startError?: Error): OpenAiBridgeStub => ({
@@ -100,7 +102,8 @@ const makeOpenAiBridge = (index: number, startError?: Error): OpenAiBridgeStub =
     return { baseUrl: `http://127.0.0.1:${44000 + index}`, token: `openai-token-${index}` }
   }),
   close: vi.fn(async () => undefined),
-  setTarget: vi.fn(() => true)
+  setTarget: vi.fn(() => true),
+  clearErrorReplay: vi.fn()
 })
 
 const makePlan = (transport: BackendTransportPlan): BackendRoutePlan => ({
@@ -285,6 +288,62 @@ describe('ProviderTransportOwner generations', () => {
 
     expect(bridges[0]?.close).toHaveBeenCalledTimes(1)
     expect(bridges[1]?.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('invalidates OpenCode replay caches across A to B to A target changes', async () => {
+    const upstreamFetch = vi.fn(async (_url: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { model: string }
+      return body.model === 'model-a'
+        ? Response.json({ error: { message: 'Invalid model-a request' } }, { status: 400 })
+        : Response.json({ choices: [{ message: { role: 'assistant', content: 'ok' } }] })
+    })
+    const owner = new ProviderTransportOwner({
+      createOpenAiProviderBridge: (targets, initialTargetId) =>
+        new OpenAiProviderBridge(targets, initialTargetId, upstreamFetch)
+    })
+    const targetA = makeTarget()
+    const targetB: ProviderRuntimeTarget = {
+      ...makeTarget(),
+      providerId: 'provider-b',
+      effectiveModel: 'model-b',
+      provider: { ...makeTarget().provider, model: 'model-b' }
+    }
+    const targetAId = 'opencode/provider-a/model-a'
+    const targetBId = 'opencode/provider-b/model-b'
+    const generation = await owner.acquire({
+      activeTarget: targetA,
+      plan: {
+        ...makePlan({ kind: 'direct' }),
+        modelRoute: 'opencode-openai',
+        transport: {
+          kind: 'opencode-openai',
+          targets: [
+            { id: targetAId, target: targetA },
+            { id: targetBId, target: targetB }
+          ]
+        }
+      }
+    })
+    const providerA = generation.providerModelCatalog?.find(
+      ({ provider }) => provider.model === 'model-a'
+    )?.provider
+    if (!providerA?.openaiBaseUrl || !providerA.key) throw new Error('Missing provider A loopback')
+    const sendA = (): Promise<Response> =>
+      fetch(`${providerA.openaiBaseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${providerA.key}`, 'content-type': 'application/json' },
+        body: JSON.stringify({ model: 'ignored', messages: [] })
+      })
+
+    try {
+      expect((await sendA()).status).toBe(400)
+      expect(generation.providerTransportLease?.setTarget(targetBId)).toBe(true)
+      expect(generation.providerTransportLease?.setTarget(targetAId)).toBe(true)
+      expect((await sendA()).status).toBe(400)
+      expect(upstreamFetch).toHaveBeenCalledTimes(2)
+    } finally {
+      await generation.release()
+    }
   })
 
   it('owns the native Codex provider projection, retargeting, and release', async () => {

--- a/src/main/settings/provider-transport-owner.ts
+++ b/src/main/settings/provider-transport-owner.ts
@@ -44,8 +44,14 @@ type ResponsesBridgePort = Pick<
   | 'setModelTarget'
   | 'setTarget'
 >
-type AnthropicProviderBridgePort = Pick<AnthropicProviderBridge, 'start' | 'close' | 'setTarget'>
-type OpenAiProviderBridgePort = Pick<OpenAiProviderBridge, 'start' | 'close' | 'setTarget'>
+type AnthropicProviderBridgePort = Pick<
+  AnthropicProviderBridge,
+  'start' | 'close' | 'setTarget' | 'clearErrorReplay'
+>
+type OpenAiProviderBridgePort = Pick<
+  OpenAiProviderBridge,
+  'start' | 'close' | 'setTarget' | 'clearErrorReplay'
+>
 
 type ResponsesBridgeEntry = {
   bridge: ResponsesBridgePort
@@ -252,6 +258,7 @@ class ProviderTransportOwner {
     const targetIds = new Set<string>()
     const catalog: AgentModelCatalogEntry[] = []
     let activeProvider: ProviderRuntimeTarget['provider'] | undefined
+    let activeTargetId: string | undefined
     try {
       for (const planned of transport.targets) {
         const candidate = planned.target
@@ -312,6 +319,7 @@ class ProviderTransportOwner {
           model === (input.activeTarget.effectiveModel ?? input.activeTarget.provider.model)
         ) {
           activeProvider = localProvider
+          activeTargetId = targetId
         }
       }
       if (!activeProvider)
@@ -327,7 +335,14 @@ class ProviderTransportOwner {
         providerModelCatalog: Object.freeze(catalog),
         environment: loopbackProxyBypassEnvironment(process.env),
         providerTransportLease: {
-          setTarget: (targetId: string) => targetIds.has(targetId),
+          setTarget: (targetId: string) => {
+            if (!targetIds.has(targetId)) return false
+            if (activeTargetId !== targetId) {
+              activeTargetId = targetId
+              for (const bridge of bridges) bridge.clearErrorReplay()
+            }
+            return true
+          },
           release
         },
         release

--- a/src/main/settings/responses-bridge.integration.test.ts
+++ b/src/main/settings/responses-bridge.integration.test.ts
@@ -217,6 +217,100 @@ it.runIf(runLiveContract)(
 )
 
 it.runIf(runLiveContract)(
+  'does not retry a deterministic native Responses authentication failure',
+  async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'open-science-codex-native-auth-'))
+    const workspace = join(tempRoot, 'workspace')
+    await mkdir(workspace)
+
+    const upstreamFetch = vi.fn(async () =>
+      Response.json(
+        { error: { message: 'Incorrect API key provided', type: 'authentication_error' } },
+        { status: 401 }
+      )
+    )
+    const proxy = new NativeResponsesCompatibilityProxy(
+      { baseUrl: 'https://vendor.invalid/v1', model: 'probe-native-model' },
+      upstreamFetch
+    )
+    const connection = await proxy.start()
+    const framework = createCodexFramework()
+    const modelConfig = framework.prepareModelConfig(
+      {
+        type: 'custom',
+        apiEndpoints: ['responses'],
+        baseUrl: 'https://vendor.invalid/v1',
+        model: 'probe-native-model',
+        contextWindow: 128_000
+      },
+      {
+        storageRoot: tempRoot,
+        executablePath: adapterPath!,
+        responsesBridge: connection
+      }
+    )
+    for (const file of modelConfig.configFiles ?? []) {
+      await mkdir(dirname(file.path), { recursive: true })
+      await writeFile(file.path, file.content, 'utf8')
+    }
+
+    const child = spawnAdapter(workspace, {
+      ...process.env,
+      ...modelConfig.env,
+      CODEX_PATH: nativeCodexPath!
+    })
+    const stderr: string[] = []
+    child.stderr.on('data', (chunk) => stderr.push(chunk.toString('utf8')))
+
+    try {
+      const stream = acp.ndJsonStream(
+        Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
+        Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>
+      )
+      await acp
+        .client({ name: 'open-science-native-auth-contract' })
+        .onRequest(acp.methods.client.session.requestPermission, (ctx) => ({
+          outcome: {
+            outcome: 'selected',
+            optionId:
+              ctx.params.options.find((option) => option.kind === 'allow_once')?.optionId ??
+              ctx.params.options[0].optionId
+          }
+        }))
+        .onRequest(acp.methods.client.fs.readTextFile, () => ({ content: '' }))
+        .onRequest(acp.methods.client.fs.writeTextFile, () => ({}))
+        .connectWith(stream, async (ctx) => {
+          await ctx.request(acp.methods.agent.initialize, {
+            protocolVersion: acp.PROTOCOL_VERSION,
+            clientInfo: { name: 'open-science-native-auth-contract', version: '1.0.0' },
+            clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } }
+          })
+          await ctx.request(acp.methods.agent.providers.set, modelConfig.providerConfiguration!)
+
+          await ctx
+            .buildSession({ cwd: workspace, mcpServers: [] })
+            .withSession(async (session) => {
+              session.prompt('Confirm authentication.')
+              for (;;) {
+                const update = await session.nextUpdate()
+                if (update.kind === 'stop') return
+              }
+            })
+        })
+
+      expect(upstreamFetch).toHaveBeenCalledOnce()
+    } catch (error) {
+      throw new Error(`${String(error)}\n${stderr.join('')}`)
+    } finally {
+      await terminate(child)
+      await proxy.close()
+      await rm(tempRoot, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+    }
+  },
+  30_000
+)
+
+it.runIf(runLiveContract)(
   'dispatches a bridged function and reports native compaction through the real Codex MCP router',
   async () => {
     const tempRoot = await mkdtemp(join(tmpdir(), 'open-science-codex-mcp-bridge-'))

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -575,6 +575,47 @@ describe('Responses-compatible bridge conversion', () => {
     }
   })
 
+  it('replays an identical deterministic provider error without a second upstream request', async () => {
+    const upstreamFetch = vi.fn(async () =>
+      Response.json(
+        { error: { type: 'authentication_error', message: 'Incorrect API key provided' } },
+        { status: 401 }
+      )
+    )
+    const bridge = new ResponsesBridge(
+      { baseUrl: 'https://vendor.example/v1', key: 'wrong-key', model: 'model-a' },
+      upstreamFetch
+    )
+    const connection = await bridge.start()
+    const send = (): Promise<Response> =>
+      fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ model: 'ignored', input: 'hello', stream: true })
+      })
+
+    try {
+      const first = await send()
+      const second = await send()
+
+      expect(first.status).toBe(400)
+      expect(second.status).toBe(400)
+      await expect(second.json()).resolves.toMatchObject({
+        error: {
+          type: 'upstream_error',
+          message: 'Incorrect API key provided',
+          status: 401
+        }
+      })
+      expect(upstreamFetch).toHaveBeenCalledOnce()
+    } finally {
+      await bridge.close()
+    }
+  })
+
   it('overrides Codex\u2019s effort with the model-resolved value at the upstream gateway', async () => {
     let upstreamRequest: Record<string, unknown> | undefined
     const upstreamFetch = vi.fn(

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -27,6 +27,11 @@ import {
   writeProviderLoopbackJson as json,
   type ProviderLoopbackHttpRequest
 } from './provider-loopback-http-host'
+import {
+  DeterministicProviderErrorReplay,
+  providerErrorClientStatus,
+  providerRequestFingerprint
+} from './provider-error-replay'
 
 // The bridge deliberately keeps protocol payloads open-ended; validation rejects unsupported shapes
 // at the boundary before values reach the upstream request.
@@ -113,6 +118,10 @@ export class ResponsesBridge {
   private readonly hostMessageSessionScopes = new Map<string, ResponsesBridgeNamespacedTool[]>()
   private readonly scopedHostMessageSessionKeys = new Set<string>()
   private readonly strictHostMessageSessionKeys = new Set<string>()
+  private readonly deterministicErrors = new DeterministicProviderErrorReplay<{
+    message: string
+    upstreamStatus: number
+  }>()
 
   constructor(
     target: ResponsesBridgeTarget,
@@ -267,7 +276,10 @@ export class ResponsesBridge {
       this.target.reasoningEffortTransport !== target.reasoningEffortTransport ||
       this.target.key !== target.key
     this.target = target
-    if (changed) this.clearReasoningCache()
+    if (changed) {
+      this.clearReasoningCache()
+      this.deterministicErrors.clear()
+    }
   }
 
   setModelTarget(target: ResponsesBridgeModelTarget): void {
@@ -323,6 +335,7 @@ export class ResponsesBridge {
 
   async close(): Promise<void> {
     this.clearReasoningCache()
+    this.deterministicErrors.clear()
     this.reviewerSessionKeys.clear()
     this.scopedReviewerSessionKeys.clear()
     this.toolLessSessionKeys.clear()
@@ -482,6 +495,8 @@ export class ResponsesBridge {
         reasoningEffortTransport: this.target.reasoningEffortTransport
       }
     )
+    const chatRequestBody = JSON.stringify(chatRequest)
+    const replayKey = providerRequestFingerprint(this.target.baseUrl, chatRequestBody)
     this.reconcileReasoningForRequest(promptCacheKey, body.input)
 
     // Reveals which real model actually serves the turn (Codex only ever sees the internal catalog
@@ -512,22 +527,38 @@ export class ResponsesBridge {
       'content-type': 'application/json',
       ...(this.target.key ? { authorization: `Bearer ${this.target.key}` } : {})
     }
+    const replay = this.deterministicErrors.get(replayKey)
+    if (replay) {
+      json(response, providerErrorClientStatus(replay.upstreamStatus), {
+        error: {
+          type: 'upstream_error',
+          message: replay.message,
+          status: replay.upstreamStatus
+        }
+      })
+      return
+    }
     const upstream = await this.fetchImpl(chatUrl(this.target.baseUrl), {
       method: 'POST',
       headers,
-      body: JSON.stringify(chatRequest),
+      body: chatRequestBody,
       signal: request.signal
     })
     if (!upstream.ok) {
       const errorBody = await upstream.text()
+      const message = upstreamErrorMessage(errorBody, upstream.status)
+      this.deterministicErrors.remember(replayKey, upstream.status, {
+        message,
+        upstreamStatus: upstream.status
+      })
       log.warn('bridge upstream error', {
         upstreamModel: chatRequest.model,
         status: upstream.status
       })
-      json(response, upstream.status, {
+      json(response, providerErrorClientStatus(upstream.status), {
         error: {
           type: 'upstream_error',
-          message: upstreamErrorMessage(errorBody, upstream.status),
+          message,
           status: upstream.status
         }
       })

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -30,7 +30,8 @@ import {
 import {
   DeterministicProviderErrorReplay,
   providerErrorClientStatus,
-  providerRequestFingerprint
+  providerRequestFingerprint,
+  readBoundedProviderErrorBody
 } from './provider-error-replay'
 
 // The bridge deliberately keeps protocol payloads open-ended; validation rejects unsupported shapes
@@ -38,10 +39,7 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type JsonObject = Record<string, any>
 
-// Diagnostics for the Codex Responses bridge. Logs the resolved upstream model, the tool translation
-// (Responses tool types in → Chat function names out), and what each turn actually produced (text vs
-// tool calls) so a "tools not called / task not continued" report can be traced. Never logs keys,
-// prompt text, or tool arguments — only shapes, counts, names, and the model id.
+// Diagnostics log only model IDs and tool shapes/counts, never keys, prompts, or arguments.
 const log = createLogger('acp-bridge')
 
 export type ResponsesBridgeTarget = {
@@ -545,8 +543,10 @@ export class ResponsesBridge {
       signal: request.signal
     })
     if (!upstream.ok) {
-      const errorBody = await upstream.text()
-      const message = upstreamErrorMessage(errorBody, upstream.status)
+      const errorBody = await readBoundedProviderErrorBody(upstream, { signal: request.signal })
+      const message = errorBody.complete
+        ? upstreamErrorMessage(errorBody.body.toString('utf8'), upstream.status)
+        : `Provider request failed with status ${upstream.status}`
       this.deterministicErrors.remember(replayKey, upstream.status, {
         message,
         upstreamStatus: upstream.status

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -61,6 +61,7 @@ const { managedClaudeDir } = await import('./managed-claude')
 const { managedOpencodeDir } = await import('./managed-opencode')
 const { netFetch } = await import('../skills/net-fetch')
 const { UserSkillSpecialistPackageAdapter } = await import('../skills/specialist-package-adapter')
+const { opencodeTransportProviderId } = await import('../agent-framework/opencode')
 const { net: mockedNet } = (await import('electron')) as unknown as {
   net: { fetch: ReturnType<typeof vi.fn> }
 }
@@ -1204,7 +1205,8 @@ describe('SettingsService: providers', () => {
     await service.setActiveProvider(view.id)
     const backend = await resolveActiveBackend(service)
     const content = JSON.parse(backend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
-    expect(content.provider.anthropic.models.m.limit.context).toBe(64_000)
+    const agentProviderId = opencodeTransportProviderId(view.id, 'm')
+    expect(content.provider[agentProviderId].models.m.limit.context).toBe(64_000)
   })
 
   it('uses a 200k runtime default when a custom context window is omitted', async () => {
@@ -1231,7 +1233,8 @@ describe('SettingsService: providers', () => {
     await service.setActiveProvider(view.id)
     const backend = await resolveActiveBackend(service)
     const content = JSON.parse(backend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
-    expect(content.provider.anthropic.models.m.limit.context).toBe(200_000)
+    const agentProviderId = opencodeTransportProviderId(view.id, 'm')
+    expect(content.provider[agentProviderId].models.m.limit.context).toBe(200_000)
   })
 
   it('keeps OpenCode connector details in on-demand skills instead of baseline context', async () => {
@@ -2251,7 +2254,7 @@ describe('SettingsService: preflight & spawn config', () => {
 
     expect(backend.framework.id).toBe('codex')
     expect(backend.executablePath).toBe(adapterPath)
-    // Responses provider ⇒ no bridge ⇒ Codex runs the provider's own model, not the bridge catalog model.
+    // Native Responses keeps the provider model while the compatibility loopback owns retry policy.
     expect(backend.sessionModel).toBe('gpt-5-codex')
     expect(backend.env).toMatchObject({
       CODEX_HOME: join(storageRoot, 'codex'),
@@ -2269,8 +2272,9 @@ describe('SettingsService: preflight & spawn config', () => {
     expect(backend.persistentSystemPrompt).toBe(developerInstructions)
     expect(backend.authentication).toEqual({
       methodId: 'api-key',
-      _meta: { 'api-key': { apiKey: 'test-key' } }
+      _meta: { 'api-key': { apiKey: expect.stringMatching(/^[a-f0-9]+$/) } }
     })
+    expect(JSON.stringify(backend)).not.toContain('test-key')
     // Stable guidance only tells Codex to load the matching Skill; exact connector methods remain
     // progressive content and must not be copied into the baseline.
     expect(backend.systemPromptAppends).toBeUndefined()
@@ -2286,8 +2290,9 @@ describe('SettingsService: preflight & spawn config', () => {
     expect(pinnedBackend.backendId).toBe(`codex:${provider.id}`)
     expect(pinnedBackend.authentication).toEqual({
       methodId: 'api-key',
-      _meta: { 'api-key': { apiKey: 'test-key' } }
+      _meta: { 'api-key': { apiKey: expect.stringMatching(/^[a-f0-9]+$/) } }
     })
+    expect(JSON.stringify(pinnedBackend)).not.toContain('test-key')
   })
 
   it('trusts bundled model metadata only after a live native version probe', async () => {
@@ -2686,7 +2691,8 @@ describe('SettingsService: preflight & spawn config', () => {
     // the model as image-capable instead of a bare entry whose image parts it would strip. Deleting the
     // wiring in resolveProvider or buildModelCapabilities makes this fail.
     const content = JSON.parse(backend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
-    expect(content.provider['openai-compatible'].models['kimi-k3']).toEqual({
+    const agentProviderId = opencodeTransportProviderId(provider.id, 'kimi-k3')
+    expect(content.provider[agentProviderId].models['kimi-k3']).toEqual({
       attachment: true,
       modalities: { input: ['text', 'image'] },
       limit: { context: 1_000_000, output: 32_000 }
@@ -2712,13 +2718,15 @@ describe('SettingsService: preflight & spawn config', () => {
     const smallBackend = await resolveActiveBackend(service)
     const smallConfig = JSON.parse(smallBackend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
     expect(smallBackend.contextWindow).toBe(200_000)
-    expect(smallConfig.provider['openai-compatible'].models['glm-5.1'].limit.context).toBe(200_000)
+    const smallAgentProviderId = opencodeTransportProviderId(provider.id, 'glm-5.1')
+    expect(smallConfig.provider[smallAgentProviderId].models['glm-5.1'].limit.context).toBe(200_000)
 
     await service.setActiveProvider(provider.id, 'glm-5.2')
     const largeBackend = await resolveActiveBackend(service)
     const largeConfig = JSON.parse(largeBackend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
     expect(largeBackend.contextWindow).toBe(1_000_000)
-    expect(largeConfig.provider['openai-compatible'].models['glm-5.2'].limit.context).toBe(
+    const largeAgentProviderId = opencodeTransportProviderId(provider.id, 'glm-5.2')
+    expect(largeConfig.provider[largeAgentProviderId].models['glm-5.2'].limit.context).toBe(
       1_000_000
     )
   })
@@ -3152,12 +3160,12 @@ describe('SettingsService: preflight & spawn config', () => {
 
     expect(config.executablePath).toBe(execPath)
     expect(config.env).toMatchObject({
-      // A user-supplied trailing /v1 is normalized away; the client appends /v1/messages itself.
-      ANTHROPIC_BASE_URL: 'https://api.anthropic.com',
-      ANTHROPIC_AUTH_TOKEN: 'test-key',
+      ANTHROPIC_BASE_URL: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/),
+      ANTHROPIC_AUTH_TOKEN: expect.stringMatching(/^[a-f0-9]+$/),
       ANTHROPIC_MODEL: 'm',
       CLAUDE_CONFIG_DIR: getAppClaudeConfigDir(storageRoot)
     })
+    expect(JSON.stringify(config)).not.toContain('test-key')
     expect(config.sessionOptions).toMatchObject({
       settings: {
         skipWebFetchPreflight: true,
@@ -3165,8 +3173,8 @@ describe('SettingsService: preflight & spawn config', () => {
       }
     })
     expect(claudeSkillProjectionRoot(config)).toContain(getClaudeSkillRuntimeRoot(storageRoot))
-    // Custom providers always use the bearer token variable, never x-api-key.
-    expect(config.env.ANTHROPIC_API_KEY).toBeUndefined()
+    // Both Claude credential variables carry only the app-owned loopback token.
+    expect(config.env.ANTHROPIC_API_KEY).toBe(config.env.ANTHROPIC_AUTH_TOKEN)
   })
 
   it('does not inject WebFetch preflight settings into isolated Claude sessions', async () => {
@@ -3280,10 +3288,11 @@ describe('SettingsService: official vendors', () => {
     const config = await resolveActiveBackend(service)
 
     expect(config.env).toMatchObject({
-      ANTHROPIC_BASE_URL: 'https://api.deepseek.com/anthropic',
-      ANTHROPIC_AUTH_TOKEN: 'sk-ds',
+      ANTHROPIC_BASE_URL: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/),
+      ANTHROPIC_AUTH_TOKEN: expect.stringMatching(/^[a-f0-9]+$/),
       ANTHROPIC_MODEL: 'deepseek-v4-flash'
     })
+    expect(JSON.stringify(config)).not.toContain('sk-ds')
     expect(config.sessionOptions).toMatchObject({
       settings: {
         skipWebFetchPreflight: true,
@@ -5004,7 +5013,8 @@ describe('SettingsService: reasoning effort', () => {
     // The official vendor identity survives provider resolution, so OpenCode receives DeepSeek's
     // native thinking switch instead of an invalid reasoningEffort: none literal.
     const content = JSON.parse(backend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
-    expect(content.provider['openai-compatible'].models['deepseek-v4-pro']).toEqual(
+    const agentProviderId = opencodeTransportProviderId(provider.id, 'deepseek-v4-pro')
+    expect(content.provider[agentProviderId].models['deepseek-v4-pro']).toEqual(
       expect.objectContaining({ options: { thinking: { type: 'disabled' } } })
     )
   })
@@ -5031,10 +5041,11 @@ describe('SettingsService: reasoning effort', () => {
 
     const backend = await resolveActiveBackend(service)
     const content = JSON.parse(backend.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+    const agentProviderId = opencodeTransportProviderId(provider.id, 'claude-opus-5')
 
-    expect(backend.sessionModel).toBe('claude-opus-5')
+    expect(backend.sessionModel).toBe(`${agentProviderId}/claude-opus-5`)
     expect(backend.sessionEffort).toBe('max')
-    expect(content.model).toBe('anthropic/claude-opus-5')
+    expect(content.model).toBe(`${agentProviderId}/claude-opus-5`)
   })
 
   it('surfaces sessionEffort on the Claude backend too (the early-return path)', async () => {
@@ -5264,8 +5275,12 @@ describe('SettingsService: Subagent model', () => {
     })
     expect(claim.backend).toMatchObject({
       framework: { id: 'claude-code' },
-      env: { ANTHROPIC_AUTH_TOKEN: 'secret' }
+      env: {
+        ANTHROPIC_BASE_URL: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/),
+        ANTHROPIC_AUTH_TOKEN: expect.stringMatching(/^[a-f0-9]+$/)
+      }
     })
+    expect(JSON.stringify(claim.backend)).not.toContain('secret')
     await expect(service.resolveAdmittedSubagentBackend(admission.snapshot)).rejects.toThrow()
     await admission.backendLease!.release()
     await claim.release()

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -808,6 +808,7 @@ describe('Settings backend ownership architecture', () => {
       'src/main/settings/native-responses-compatibility.ts',
       'src/main/settings/anthropic-provider-bridge.ts',
       'src/main/settings/openai-provider-bridge.ts',
+      'src/main/settings/provider-error-replay.ts',
       'src/main/settings/provider-loopback-http-host.ts',
       'src/main/settings/provider-transport-owner.ts',
       'src/main/settings/responses-bridge.ts',


### PR DESCRIPTION
## Problem

A deterministic provider failure could be sent upstream many times because ACP runtimes disagree about retryable HTTP errors. The reported native Responses request returned `401` six times with the same body. Local spikes also observed repeated `401` requests from Claude Code (8+ POSTs in 10 seconds) and OpenCode (2 POSTs).

## Proposed change

- Classify deterministic failures with an explicit HTTP status allowlist: `400`, `401`, `402`, `403`, `404`, `405`, `406`, `407`, `410`, `411`, `413`, `414`, `415`, `416`, `417`, `421`, `422`, `426`, `428`, `431`, and `451`.
- Return a terminal local `400` for those statuses while retaining the real upstream status in bridge diagnostics (structured JSON or `x-open-science-upstream-status`).
- Replay an identical deterministic failure from a bounded in-memory cache (SHA-256 request fingerprint, 30-second TTL, 32 entries) instead of sending the ACP retry upstream again.
- Include the final upstream-visible request headers in replay fingerprints, so a request with different provider feature/version headers cannot reuse an earlier deterministic error.
- Clear every per-target OpenCode bridge replay cache when the generation changes target, including A→B→A transitions within the replay TTL.
- Read error bodies through a bounded stream collector (256 KiB, 10-second completion timeout). Oversized or non-terminating bodies are cancelled and replaced with a small structured JSON error whose response headers match the fallback before replay.
- Normalize empty or malformed JSON error responses to the same bounded structured fallback before caching, while preserving the real upstream status.
- Keep retryable and unknown statuses out of the cache. `408`, `409`, `425`, `429`, 5xx, and unlisted statuses preserve upstream retry semantics.
- Route single custom Claude Code, OpenCode, and native Codex Responses providers through the existing loopback transports so the policy applies consistently, not only when multiple providers are configured.
- Project explicit bridge targets for single-provider model changes. If the active generation does not contain the new model target, the existing workflow reconnects instead of leaving the bridge pinned to the old model. Codex subscription authentication remains direct.

## ACP compatibility matrix

| ACP / wire path | Spike / regression evidence | Expected result |
| --- | --- | --- |
| Codex native Responses compatibility | Real Codex reproduced 6 identical upstream `401`s before the change; contracts cover replay, malformed/empty JSON, and changed forwarded headers | Deterministic retry is terminal locally and only equivalent requests replay |
| Codex native Responses direct | Single-provider routing uses the OpenAI loopback; contracts cover replay and changed forwarded headers | Same policy as compatibility mode |
| Codex Chat bridge | The bridge generates only content/auth headers and already clears replay state when its target, credential, or model changes; its unit contract preserves upstream `status: 401` in JSON | Same policy for Chat-to-Responses conversion without client-header aliasing |
| Claude Code / Anthropic | Spike reproduced 8+ `401` POSTs; contracts cover identical replay and changed Anthropic feature/version headers | No duplicate identical upstream request; changed upstream-visible headers bypass replay |
| OpenCode / OpenAI | Spike reproduced 2 identical `401` calls; contracts cover identical replay, changed forwarded headers, and A→B→A target transitions | No stale error after a header or target change |
| OpenCode / Anthropic | Uses the same OpenCode generation owner; Anthropic bridge contract covers identical replay and changed headers, while the owner clears every per-target cache on transitions | No stale error after a header or target change |

`429` is covered separately to ensure retryable rate-limit responses still reach upstream on each attempt.

## Scope and non-goals

- This does not modify retry algorithms inside third-party ACP runtimes.
- No renderer copy or i18n catalog changes.
- Oversized deterministic error bodies are normalized to a bounded JSON error; normal streaming responses are unchanged.

## Compatibility and persistence

- **Historical data compatibility:** none required; no stored schema or existing data changes.
- **New enum values:** none. The explicit status allowlist is internal policy, not a persisted or public enum.
- **Runtime-only state:** one generation-local `activeTargetId` tracks real OpenCode target transitions so A→B→A clears every per-target replay cache. It is not public, serialized, or retained across generations.
- **Persistence:** none. Replay entries are process-local memory only and are cleared on target changes and bridge shutdown.

## Validation

- `npm run typecheck:node`
- ESLint for all changed TypeScript files
- Focused bridge/planner/resolver suite: 7 files, 205 tests passed
- `settings_backend_resolution` module files with PR Gate settings (`--maxWorkers=1 --testTimeout=30000`): 35 files passed, 1 conditional skip; 524 tests passed, 4 skipped
- Four architecture scans: 19 tests passed
- Model-change and architecture regression suite after review feedback: 7 files, 112 tests passed
- Bounded error body + affected bridge/service suite after review feedback: 6 files, 386 tests passed
- Settings architecture + module-impact contracts after the bounded-reader change: 11 files, 57 tests passed
- Final affected bridge/owner/resolver/service suite after replay-boundary and fallback-header fixes: 8 files, 457 tests passed
- Header fingerprint normalization contract covers case/order stability and value changes
- Live native Codex regression: one upstream `401` request
- Module-impact manifest contract: 28 tests passed

The full local `npm test` suite was intentionally not run. Updating the module-impact manifest is a global gate input, so PR CI will run the complete required test plan.

## Review focus

- Whether the explicit deterministic status allowlist is appropriately conservative.
- Whether every app-owned custom-provider transport is covered without changing subscription-backed direct routes.
- Whether the 30-second / 32-entry replay bounds are suitable for retry bursts.
