### PR TITLE
perf(startup): shorten the application critical path

### DIFF
--- a/src/main/app-startup.test.ts
+++ b/src/main/app-startup.test.ts
@@ -280,19 +280,22 @@ describe('prepareVisibleStartupRuntime', () => {
 
 describe('waitForStartupShell', () => {
   const makeWindow = (): {
+    destroy: ReturnType<typeof vi.fn>
     emitWindow: (event: string) => void
     emitWebContents: (event: string, ...args: unknown[]) => void
-    window: Pick<BrowserWindow, 'once' | 'removeListener' | 'webContents'>
+    window: Pick<BrowserWindow, 'destroy' | 'once' | 'removeListener' | 'webContents'>
   } => {
     const windowEvents = new EventEmitter()
     const webContentsEvents = new EventEmitter()
+    const destroy = vi.fn()
     return {
+      destroy,
       emitWindow: (event) => windowEvents.emit(event),
       emitWebContents: (event, ...args) => webContentsEvents.emit(event, ...args),
-      window: Object.assign(windowEvents, { webContents: webContentsEvents }) as unknown as Pick<
-        BrowserWindow,
-        'once' | 'removeListener' | 'webContents'
-      >
+      window: Object.assign(windowEvents, {
+        destroy,
+        webContents: webContentsEvents
+      }) as unknown as Pick<BrowserWindow, 'destroy' | 'once' | 'removeListener' | 'webContents'>
     }
   }
 
@@ -307,14 +310,21 @@ describe('waitForStartupShell', () => {
 
     source.emitWindow('ready-to-show')
     await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce())
+    expect(source.destroy).not.toHaveBeenCalled()
+  })
+
+  it('discards an unusable startup window after a main-frame load failure', async () => {
+    const source = makeWindow()
+    const settled = vi.fn()
+    void waitForStartupShell(source.window).then(settled)
+
+    source.emitWebContents('did-fail-load', {}, -105, 'NAME_NOT_RESOLVED', 'file://index', true)
+
+    await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce())
+    expect(source.destroy).toHaveBeenCalledOnce()
   })
 
   it.each([
-    [
-      'a main-frame load failure',
-      (source: ReturnType<typeof makeWindow>) =>
-        source.emitWebContents('did-fail-load', {}, -105, 'NAME_NOT_RESOLVED', 'file://index', true)
-    ],
     [
       'a renderer exit',
       (source: ReturnType<typeof makeWindow>) =>
@@ -332,5 +342,6 @@ describe('waitForStartupShell', () => {
     signal(source)
 
     await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce())
+    expect(source.destroy).not.toHaveBeenCalled()
   })
 })

--- a/src/main/app-startup.test.ts
+++ b/src/main/app-startup.test.ts
@@ -4,8 +4,22 @@ import {
   createSecondInstanceRelay,
   createStartupWindowCloseOptions,
   createStartupWindowSecondInstanceHandler,
-  orchestrateAppStartup
+  orchestrateAppStartup,
+  prepareVisibleStartupRuntime
 } from './app-startup'
+
+const deferred = <T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} => {
+  let resolve!: (value: T) => void
+  return {
+    promise: new Promise<T>((next) => {
+      resolve = next
+    }),
+    resolve
+  }
+}
 
 describe('createSecondInstanceRelay', () => {
   it('records a signal that arrives before bind and drains it on bind, with its argv', () => {
@@ -182,5 +196,80 @@ describe('orchestrateAppStartup', () => {
     expect(diagnostics.phase).toHaveBeenCalledWith('prepare-runtime')
     expect(diagnostics.fail).toHaveBeenCalledWith(failure)
     expect(diagnostics.complete).not.toHaveBeenCalled()
+  })
+})
+
+describe('prepareVisibleStartupRuntime', () => {
+  it('loads the backend while database verification runs, then composes only after both finish', async () => {
+    const shellReady = deferred<{ tag: 'shell' }>()
+    const databaseReady = deferred<void>()
+    const modulesReady = deferred<{ tag: 'modules' }>()
+    const events: string[] = []
+
+    const preparation = prepareVisibleStartupRuntime({
+      prepareShell: vi.fn(async () => {
+        events.push('shell:start')
+        const shell = await shellReady.promise
+        events.push('shell:ready')
+        return shell
+      }),
+      verifyDatabase: vi.fn(async () => {
+        events.push('database:start')
+        await databaseReady.promise
+        events.push('database:ready')
+      }),
+      loadApplicationModules: vi.fn(async () => {
+        events.push('modules:start')
+        const modules = await modulesReady.promise
+        events.push('modules:ready')
+        return modules
+      }),
+      composeRuntime: vi.fn(async (_shell, modules) => {
+        events.push('runtime:ready')
+        return modules.tag
+      })
+    })
+
+    expect(events).toEqual(['shell:start'])
+    shellReady.resolve({ tag: 'shell' })
+    await vi.waitFor(() => {
+      expect(events).toEqual(['shell:start', 'shell:ready', 'database:start', 'modules:start'])
+    })
+
+    modulesReady.resolve({ tag: 'modules' })
+    await vi.waitFor(() => expect(events).toContain('modules:ready'))
+    expect(events).not.toContain('runtime:ready')
+
+    databaseReady.resolve()
+    await expect(preparation).resolves.toBe('modules')
+    expect(events).toEqual([
+      'shell:start',
+      'shell:ready',
+      'database:start',
+      'modules:start',
+      'modules:ready',
+      'database:ready',
+      'runtime:ready'
+    ])
+  })
+
+  it('rolls back the visible shell when a concurrent prerequisite fails', async () => {
+    const failure = new Error('backend import failed')
+    const rollbackShell = vi.fn()
+
+    await expect(
+      prepareVisibleStartupRuntime({
+        prepareShell: async () => ({ tag: 'shell' }),
+        verifyDatabase: async () => undefined,
+        loadApplicationModules: async () => {
+          throw failure
+        },
+        composeRuntime: vi.fn(),
+        rollbackShell
+      })
+    ).rejects.toBe(failure)
+
+    expect(rollbackShell).toHaveBeenCalledOnce()
+    expect(rollbackShell).toHaveBeenCalledWith({ tag: 'shell' }, failure)
   })
 })

--- a/src/main/app-startup.test.ts
+++ b/src/main/app-startup.test.ts
@@ -1,3 +1,6 @@
+import { EventEmitter } from 'node:events'
+
+import type { BrowserWindow } from 'electron'
 import { describe, expect, it, vi } from 'vitest'
 
 import {
@@ -5,7 +8,8 @@ import {
   createStartupWindowCloseOptions,
   createStartupWindowSecondInstanceHandler,
   orchestrateAppStartup,
-  prepareVisibleStartupRuntime
+  prepareVisibleStartupRuntime,
+  waitForStartupShell
 } from './app-startup'
 
 const deferred = <T>(): {
@@ -271,5 +275,62 @@ describe('prepareVisibleStartupRuntime', () => {
 
     expect(rollbackShell).toHaveBeenCalledOnce()
     expect(rollbackShell).toHaveBeenCalledWith({ tag: 'shell' }, failure)
+  })
+})
+
+describe('waitForStartupShell', () => {
+  const makeWindow = (): {
+    emitWindow: (event: string) => void
+    emitWebContents: (event: string, ...args: unknown[]) => void
+    window: Pick<BrowserWindow, 'once' | 'removeListener' | 'webContents'>
+  } => {
+    const windowEvents = new EventEmitter()
+    const webContentsEvents = new EventEmitter()
+    return {
+      emitWindow: (event) => windowEvents.emit(event),
+      emitWebContents: (event, ...args) => webContentsEvents.emit(event, ...args),
+      window: Object.assign(windowEvents, { webContents: webContentsEvents }) as unknown as Pick<
+        BrowserWindow,
+        'once' | 'removeListener' | 'webContents'
+      >
+    }
+  }
+
+  it('waits through subframe failures and resolves after the first paint', async () => {
+    const source = makeWindow()
+    const settled = vi.fn()
+    void waitForStartupShell(source.window).then(settled)
+
+    source.emitWebContents('did-fail-load', {}, -3, 'ABORTED', 'preview://frame', false)
+    await Promise.resolve()
+    expect(settled).not.toHaveBeenCalled()
+
+    source.emitWindow('ready-to-show')
+    await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce())
+  })
+
+  it.each([
+    [
+      'a main-frame load failure',
+      (source: ReturnType<typeof makeWindow>) =>
+        source.emitWebContents('did-fail-load', {}, -105, 'NAME_NOT_RESOLVED', 'file://index', true)
+    ],
+    [
+      'a renderer exit',
+      (source: ReturnType<typeof makeWindow>) =>
+        source.emitWebContents('render-process-gone', {}, { reason: 'crashed', exitCode: 1 })
+    ],
+    [
+      'the startup window closing',
+      (source: ReturnType<typeof makeWindow>) => source.emitWindow('closed')
+    ]
+  ])('continues startup after %s', async (_label, signal) => {
+    const source = makeWindow()
+    const settled = vi.fn()
+    void waitForStartupShell(source.window).then(settled)
+
+    signal(source)
+
+    await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce())
   })
 })

--- a/src/main/app-startup.ts
+++ b/src/main/app-startup.ts
@@ -1,6 +1,9 @@
+import type { BrowserWindow, Event as ElectronEvent } from 'electron'
+
 import type { DiagnosticOperation } from './diagnostics/operation'
 
-// Startup orchestration for the UI process, kept as a dependency-injected unit (no Electron imports) so
+// Startup orchestration for the UI process, kept as a dependency-injected unit (no runtime Electron
+// imports) so
 // the single-instance gate, the second-instance-during-startup handoff, and the ordering of the
 // migration quit-guard relative to the lifecycle can be exercised together in a unit test — the real
 // combination, not just each helper in isolation.
@@ -118,6 +121,43 @@ export const prepareVisibleStartupRuntime = async <Shell, Modules, Runtime>(
     throw error
   }
 }
+
+// Resolve the first-paint barrier on terminal renderer/window events as well as success. The backend
+// and lifecycle must keep initializing even when Chromium cannot produce the first frame; windows.ts
+// owns renderer recovery and can then reload or close the failed startup window.
+export const waitForStartupShell = (
+  window: Pick<BrowserWindow, 'once' | 'removeListener' | 'webContents'>
+): Promise<void> =>
+  new Promise((resolve) => {
+    let settled = false
+
+    const cleanup = (): void => {
+      window.removeListener('ready-to-show', settle)
+      window.removeListener('closed', settle)
+      window.webContents.removeListener('did-fail-load', onDidFailLoad)
+      window.webContents.removeListener('render-process-gone', settle)
+    }
+    const settle = (): void => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve()
+    }
+    const onDidFailLoad = (
+      _event: ElectronEvent,
+      _errorCode: number,
+      _errorDescription: string,
+      _validatedURL: string,
+      isMainFrame: boolean
+    ): void => {
+      if (isMainFrame) settle()
+    }
+
+    window.once('ready-to-show', settle)
+    window.once('closed', settle)
+    window.webContents.on('did-fail-load', onDidFailLoad)
+    window.webContents.once('render-process-gone', settle)
+  })
 
 // Runs the ordered startup sequence: gate on the single-instance lock (quitting a secondary launch
 // before any backend work), prepare the backend, install the migration guard, then the lifecycle, and

--- a/src/main/app-startup.ts
+++ b/src/main/app-startup.ts
@@ -123,10 +123,10 @@ export const prepareVisibleStartupRuntime = async <Shell, Modules, Runtime>(
 }
 
 // Resolve the first-paint barrier on terminal renderer/window events as well as success. The backend
-// and lifecycle must keep initializing even when Chromium cannot produce the first frame; windows.ts
-// owns renderer recovery and can then reload or close the failed startup window.
+// and lifecycle must keep initializing even when Chromium cannot produce the first frame. Main-frame
+// load failure discards the unusable window; windows.ts owns renderer-process crash recovery.
 export const waitForStartupShell = (
-  window: Pick<BrowserWindow, 'once' | 'removeListener' | 'webContents'>
+  window: Pick<BrowserWindow, 'destroy' | 'once' | 'removeListener' | 'webContents'>
 ): Promise<void> =>
   new Promise((resolve) => {
     let settled = false
@@ -150,7 +150,11 @@ export const waitForStartupShell = (
       _validatedURL: string,
       isMainFrame: boolean
     ): void => {
-      if (isMainFrame) settle()
+      if (!isMainFrame) return
+      // windows.ts logs document load failures but deliberately does not retry them. Discard this
+      // unusable hidden window so the lifecycle creates a fresh main window after composition.
+      window.destroy()
+      settle()
     }
 
     window.once('ready-to-show', settle)

--- a/src/main/app-startup.ts
+++ b/src/main/app-startup.ts
@@ -91,6 +91,34 @@ export type AppStartupDeps<Context> = {
   diagnostics?: DiagnosticOperation
 }
 
+export type VisibleStartupRuntimeDeps<Shell, Modules, Runtime> = {
+  // Builds only what is required to show the renderer's database-startup shell. Keeping this seam
+  // deliberately small lets the user see useful UI before the full backend module graph is loaded.
+  prepareShell: () => Promise<Shell>
+  // Database verification and backend loading are independent after the shell exists, so both start
+  // immediately. Runtime composition remains ordered behind both prerequisites.
+  verifyDatabase: (shell: Shell) => Promise<void>
+  loadApplicationModules: (shell: Shell) => Promise<Modules>
+  composeRuntime: (shell: Shell, modules: Modules) => Promise<Runtime>
+  rollbackShell?: (shell: Shell, error: unknown) => Promise<void> | void
+}
+
+export const prepareVisibleStartupRuntime = async <Shell, Modules, Runtime>(
+  deps: VisibleStartupRuntimeDeps<Shell, Modules, Runtime>
+): Promise<Runtime> => {
+  const shell = await deps.prepareShell()
+
+  try {
+    const databaseVerification = deps.verifyDatabase(shell)
+    const applicationModules = deps.loadApplicationModules(shell)
+    const [modules] = await Promise.all([applicationModules, databaseVerification])
+    return await deps.composeRuntime(shell, modules)
+  } catch (error) {
+    await deps.rollbackShell?.(shell, error)
+    throw error
+  }
+}
+
 // Runs the ordered startup sequence: gate on the single-instance lock (quitting a secondary launch
 // before any backend work), prepare the backend, install the migration guard, then the lifecycle, and
 // finally bind the second-instance relay to the window — draining any handoff that arrived mid-startup.

--- a/src/main/index-fatal-errors.test.ts
+++ b/src/main/index-fatal-errors.test.ts
@@ -55,7 +55,8 @@ vi.mock('./app-startup', () => ({
   createStartupWindowCloseOptions: vi.fn(),
   createStartupWindowSecondInstanceHandler: vi.fn(),
   orchestrateAppStartup: vi.fn(),
-  prepareVisibleStartupRuntime: vi.fn()
+  prepareVisibleStartupRuntime: vi.fn(),
+  waitForStartupShell: vi.fn()
 }))
 
 vi.mock('./crash-diagnostics', () => ({

--- a/src/main/index-fatal-errors.test.ts
+++ b/src/main/index-fatal-errors.test.ts
@@ -54,7 +54,8 @@ vi.mock('./app-startup', () => ({
   })),
   createStartupWindowCloseOptions: vi.fn(),
   createStartupWindowSecondInstanceHandler: vi.fn(),
-  orchestrateAppStartup: vi.fn()
+  orchestrateAppStartup: vi.fn(),
+  prepareVisibleStartupRuntime: vi.fn()
 }))
 
 vi.mock('./crash-diagnostics', () => ({

--- a/src/main/index-startup-order.test.ts
+++ b/src/main/index-startup-order.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const mainSource = readFileSync(resolve(__dirname, 'index.ts'), 'utf8')
+
+describe('main startup ordering', () => {
+  it('registers the managed-preview protocol bridge before creating the first window', () => {
+    const registerBridge = mainSource.indexOf(
+      'const managedPreviewProtocolBridge = createManagedPreviewProtocolBridge(protocol)'
+    )
+    const createFirstWindow = mainSource.indexOf(
+      'createMainWindow(startupWindowCloseOptions, translate)'
+    )
+
+    expect(registerBridge).toBeGreaterThan(-1)
+    expect(createFirstWindow).toBeGreaterThan(registerBridge)
+  })
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -116,7 +116,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       createStartupWindowCloseOptions,
       createStartupWindowSecondInstanceHandler,
       orchestrateAppStartup,
-      prepareVisibleStartupRuntime
+      prepareVisibleStartupRuntime,
+      waitForStartupShell
     }
   ] = await Promise.all([import('./single-instance'), import('./app-startup')])
   const preStartupSecondInstanceRelay = createSecondInstanceRelay()
@@ -326,7 +327,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       // 5 MB backend chunk immediately after BrowserWindow construction can otherwise delay
       // ready-to-show even though the window no longer depends on that chunk.
       const startupShellRendered = startupWindow
-        ? new Promise<void>((resolve) => startupWindow.once('ready-to-show', () => resolve()))
+        ? waitForStartupShell(startupWindow)
         : Promise.resolve()
       if (startupWindow) {
         if (!forwardSecondInstanceDuringStartup) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -115,7 +115,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       createSecondInstanceRelay,
       createStartupWindowCloseOptions,
       createStartupWindowSecondInstanceHandler,
-      orchestrateAppStartup
+      orchestrateAppStartup,
+      prepareVisibleStartupRuntime
     }
   ] = await Promise.all([import('./single-instance'), import('./app-startup')])
   const preStartupSecondInstanceRelay = createSecondInstanceRelay()
@@ -228,28 +229,12 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       })
       startupDiagnostics?.phase('crash-reporting', { enabled: crashReporting.enabled })
 
-      startupDiagnostics?.phase('load-application-modules')
+      startupDiagnostics?.phase('load-startup-shell-modules')
       const [
-        { registerIpcHandlers },
-        { createManagedPreviewProtocolBridge },
         { configureMainWindow, createMainWindow },
-        { installMigrationQuitGuard, isMigrationInProgress },
-        { createAppTray, refreshAppTrayLocale, setTrayIconVariant },
         { LocalePreferenceOwner },
         { registerLocalePreferenceIpc },
-        { installAppLifecycle },
-        { disposeIpcHandlerRegistry },
-        { parseWebModeOptions, createWebServiceController, buildAuthenticatedWebUrl },
-        { routeSecondInstance },
-        { createElectronCloseConfirm },
-        { createElectronSessionPersistenceFlush, notifyRendererSessionPersistenceFlushAborted },
         { installWindowShortcuts },
-        { createAppIconController, buildAppIconPreviews },
-        { RemoteAccessService, registerRemoteAccessIpcHandlers },
-        { createDesktopAttentionController, wireDesktopAttention },
-        { createDesktopBadgeAdapter, createWindowsBadgeBitmap },
-        { wireNotificationInboxController },
-        { registerUnreadTaskIpc },
         { registerNetworkIpcHandlers },
         { createDatabaseStartupLogging },
         { createDatabaseStartupOwner },
@@ -257,28 +242,13 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         { getProjectDbClient },
         { resolveStorageRoot },
         { SettingsDocumentStore },
-        { SettingsRepository }
+        { SettingsRepository },
+        { parseWebModeOptions }
       ] = await Promise.all([
-        import('./ipc'),
-        import('./managed-preview-protocol'),
         import('./windows'),
-        import('./storage/migration-state'),
-        import('./tray'),
         import('./locale/owner'),
         import('./locale/ipc'),
-        import('./app-lifecycle'),
-        import('./ipc-handler-registry'),
-        import('./web-service'),
-        import('./second-instance-router'),
-        import('./window-close-confirm'),
-        import('./session-persistence/renderer-flush'),
         import('./window-shortcuts'),
-        import('./app-icon'),
-        import('./remote-access'),
-        import('./notifications/desktop-attention'),
-        import('./notifications/desktop-badge'),
-        import('./notifications/notification-inbox-controller'),
-        import('./notifications/unread-task-ipc'),
         import('./network-ipc'),
         import('./database/database-startup-logging'),
         import('./database/database-startup-owner'),
@@ -286,13 +256,13 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         import('./projects/prisma-client'),
         import('./storage-root'),
         import('./settings/document-store'),
-        import('./settings/repository')
+        import('./settings/repository'),
+        import('./web-service/options')
       ])
 
       startupDiagnostics?.phase('electron-ready')
       await app.whenReady()
       startupDiagnostics?.phase('prepare-shell')
-      const managedPreviewProtocolBridge = createManagedPreviewProtocolBridge(protocol)
       // Create the settings document owner before any native surface. The startup locale repository
       // and the later application Settings repository share this store, so every settings.json
       // mutation uses one serialization queue and one atomic-write implementation.
@@ -346,6 +316,12 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       const startupWindow = webMode.headless
         ? undefined
         : createMainWindow(startupWindowCloseOptions, translate)
+      // Yield the main-process event loop until Chromium has painted the startup shell. Evaluating the
+      // 5 MB backend chunk immediately after BrowserWindow construction can otherwise delay
+      // ready-to-show even though the window no longer depends on that chunk.
+      const startupShellRendered = startupWindow
+        ? new Promise<void>((resolve) => startupWindow.once('ready-to-show', () => resolve()))
+        : Promise.resolve()
       if (startupWindow) {
         if (!forwardSecondInstanceDuringStartup) {
           throw new Error('Second-instance startup relay is not initialized.')
@@ -358,209 +334,265 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         )
       }
 
-      try {
-        startupDiagnostics?.phase('database-startup')
-        const initialDatabaseAttempt = databaseStartupOwner.start()
-        if (webMode.headless) {
-          const state = await initialDatabaseAttempt
-          if (state.phase === 'blocked') {
-            databaseStartupQuitGuard.dispose()
-            disposeDatabaseStartupIpc()
-            throw Object.assign(new Error(state.error.message), state.error)
+      startupDiagnostics?.phase('database-and-application-modules')
+      const initialDatabaseAttempt = databaseStartupOwner.start()
+      return prepareVisibleStartupRuntime({
+        // The shell and its first BrowserWindow already exist before this orchestration begins. The
+        // async seam keeps the ordering explicit and lets database verification and backend loading
+        // start together on the next step.
+        prepareShell: async () => undefined,
+        verifyDatabase: async () => {
+          if (webMode.headless) {
+            const state = await initialDatabaseAttempt
+            if (state.phase === 'blocked') {
+              throw Object.assign(new Error(state.error.message), state.error)
+            }
+            return
           }
-        } else {
           await Promise.race([
             databaseStartupOwner.whenVerified(),
             initialDatabaseAttempt.then((state) =>
               state.phase === 'blocked' ? new Promise<void>(() => undefined) : undefined
             )
           ])
-        }
-        startupDiagnostics?.phase('compose-runtime')
+        },
+        loadApplicationModules: async () => {
+          await startupShellRendered
+          return Promise.all([
+            import('./ipc'),
+            import('./managed-preview-protocol'),
+            import('./storage/migration-state'),
+            import('./tray'),
+            import('./app-lifecycle'),
+            import('./ipc-handler-registry'),
+            import('./web-service'),
+            import('./second-instance-router'),
+            import('./window-close-confirm'),
+            import('./session-persistence/renderer-flush'),
+            import('./app-icon'),
+            import('./remote-access'),
+            import('./notifications/desktop-attention'),
+            import('./notifications/desktop-badge'),
+            import('./notifications/notification-inbox-controller'),
+            import('./notifications/unread-task-ipc')
+          ])
+        },
+        composeRuntime: async (
+          _,
+          [
+            { registerIpcHandlers },
+            { createManagedPreviewProtocolBridge },
+            { installMigrationQuitGuard, isMigrationInProgress },
+            { createAppTray, refreshAppTrayLocale, setTrayIconVariant },
+            { installAppLifecycle },
+            { disposeIpcHandlerRegistry },
+            { createWebServiceController, buildAuthenticatedWebUrl },
+            { routeSecondInstance },
+            { createElectronCloseConfirm },
+            { createElectronSessionPersistenceFlush, notifyRendererSessionPersistenceFlushAborted },
+            { createAppIconController, buildAppIconPreviews },
+            { RemoteAccessService, registerRemoteAccessIpcHandlers },
+            { createDesktopAttentionController, wireDesktopAttention },
+            { createDesktopBadgeAdapter, createWindowsBadgeBitmap },
+            { wireNotificationInboxController },
+            { registerUnreadTaskIpc }
+          ]
+        ) => {
+          startupDiagnostics?.phase('compose-runtime')
+          const managedPreviewProtocolBridge = createManagedPreviewProtocolBridge(protocol)
 
-        // Held in a box (not a bare let) so the settings IPC callback registered below can reach the icon
-        // controller, which itself needs the persisted variant that only exists once settingsService is
-        // constructed. The change callback only fires on a user action (well after startup), so the
-        // controller is always set by then. Mirrors the trayBox late-binding pattern in app-lifecycle.ts.
-        const appIconControllerBox: {
-          current: ReturnType<typeof createAppIconController> | undefined
-        } = { current: undefined }
-        // Late-bound tray handle so the settings IPC below can restyle the tray when the user switches
-        // the app icon variant — the tray only exists once the lifecycle is installed (assigned in the
-        // createTray callback). Mirrors the trayBox late-binding pattern in app-lifecycle.ts.
-        const appTrayBox: { current: ReturnType<typeof createAppTray> } = { current: undefined }
-        const disposeTrayLocaleSubscription = localeOwner.subscribe(() =>
-          refreshAppTrayLocale(appTrayBox.current)
-        )
-        // Unread state restores before the main-window lifecycle is installed. Late-bind its getter so
-        // restoration remains window-independent while later badge/probe calls always target the live window.
-        const mainWindowGetterBox: {
-          current: (() => InstanceType<typeof BrowserWindow> | undefined) | undefined
-        } = { current: undefined }
+          try {
+            // Held in a box (not a bare let) so the settings IPC callback registered below can reach the icon
+            // controller, which itself needs the persisted variant that only exists once settingsService is
+            // constructed. The change callback only fires on a user action (well after startup), so the
+            // controller is always set by then. Mirrors the trayBox late-binding pattern in app-lifecycle.ts.
+            const appIconControllerBox: {
+              current: ReturnType<typeof createAppIconController> | undefined
+            } = { current: undefined }
+            // Late-bound tray handle so the settings IPC below can restyle the tray when the user switches
+            // the app icon variant — the tray only exists once the lifecycle is installed (assigned in the
+            // createTray callback). Mirrors the trayBox late-binding pattern in app-lifecycle.ts.
+            const appTrayBox: { current: ReturnType<typeof createAppTray> } = { current: undefined }
+            const disposeTrayLocaleSubscription = localeOwner.subscribe(() =>
+              refreshAppTrayLocale(appTrayBox.current)
+            )
+            // Unread state restores before the main-window lifecycle is installed. Late-bind its getter so
+            // restoration remains window-independent while later badge/probe calls always target the live window.
+            const mainWindowGetterBox: {
+              current: (() => InstanceType<typeof BrowserWindow> | undefined) | undefined
+            } = { current: undefined }
 
-        // Pass the concrete main entry path so ACP can launch the artifact MCP server from the same bundle.
-        const {
-          applicationCommands,
-          applicationEvents,
-          bindRemoteAccess,
-          taskNotifications,
-          notificationInbox,
-          settingsService,
-          taskAgent,
-          taskControls,
-          detectActiveSessions,
-          prepareForQuit,
-          abortQuitPreparation,
-          dispose: disposeApplicationRuntime
-        } = await registerIpcHandlers({
-          mainEntryPath,
-          settingsStore,
-          translate,
-          managedPreviewProtocol: managedPreviewProtocolBridge.registrar,
-          handoffRuntime: 'production',
-          headless: webMode.headless,
-          onAppIconVariantChanged: (variant) => {
-            appIconControllerBox.current?.setVariant(variant)
-            // Keep the tray glyph on the same variant as the window icon. No-op before the lifecycle
-            // installs the tray, or off Windows (single static tray asset there).
-            if (appTrayBox.current && trayVariantIconPaths) {
-              setTrayIconVariant(appTrayBox.current, trayVariantIconPaths, variant)
-            }
-          },
-          listAppIconPreviews: () => buildAppIconPreviews(nativeImage, iconVariantPaths)
-        })
-
-        // The controller must exist before its IPC responder, while the responder calls back into the
-        // controller. This box breaks that startup cycle without exposing unread ownership to renderer.
-        const visibilityProbeBox: {
-          current: ReturnType<typeof registerUnreadTaskIpc> | undefined
-        } = { current: undefined }
-        notificationInbox.configureDesktop({
-          // Only the main conversation window can acknowledge a visible session. A focused preview
-          // window must not clear unread state for the conversation underneath it.
-          isAppFocused: () => mainWindowGetterBox.current?.()?.isFocused() ?? false,
-          confirmSessionVisible: (sessionId) =>
-            visibilityProbeBox.current?.confirmSessionVisible(sessionId) ?? Promise.resolve(false),
-          badge: createDesktopBadgeAdapter({
-            platform: process.platform,
-            setBadgeCount: (count) => app.setBadgeCount(count),
-            isUnityRunning: () => app.isUnityRunning(),
-            getMainWindow: () => mainWindowGetterBox.current?.(),
-            createWindowsOverlay: (label) =>
-              nativeImage.createFromBitmap(createWindowsBadgeBitmap(label), {
-                width: 16,
-                height: 16,
-                scaleFactor: 1
-              }),
-            onError: (error) => log.warn('desktop unread badge failed', error)
-          })
-        })
-        visibilityProbeBox.current = registerUnreadTaskIpc({
-          getMainWindow: () => mainWindowGetterBox.current?.(),
-          controller: notificationInbox,
-          onError: (error) => log.warn('message center visibility IPC failed', error)
-        })
-        // Restore the independent icon variant off macOS and create the macOS Theme/Dock controller.
-        // macOS deliberately leaves the packaged Icon Composer icon untouched until a renderer announces
-        // its Theme; after that, nativeTheme keeps System mode live even with no BrowserWindow open.
-        const initialVariant = await settingsService.getAppIconVariant()
-        appIconControllerBox.current = createAppIconController({
-          electron: {
-            app,
-            getAllWindows: () => BrowserWindow.getAllWindows(),
-            nativeImage,
-            nativeTheme
-          },
-          variantPaths: iconVariantPaths,
-          initialVariant
-        })
-        const remoteAccess = await RemoteAccessService.create()
-        bindRemoteAccess(remoteAccess)
-        const webController = createWebServiceController({
-          applicationCommands,
-          requestQuit: () => app.quit(),
-          externalAccess: remoteAccess.webAccess,
-          applicationEvents,
-          taskAgent,
-          taskControls
-        })
-        remoteAccess.attachWebController(webController)
-        registerRemoteAccessIpcHandlers(remoteAccess)
-        // A launch that itself requested serving (a dedicated headless daemon, or an explicit --serve) is
-        // not attached: stopping it quits the process. On-demand starts for a running instance are attached.
-        if (webMode.enabled) await webController.ensureStarted(webMode.port, { attached: false })
-        // Restore a persisted remote-access preference only after the normal IPC/web surfaces exist.
-        // A missing or signed-out third-party remote-access installation must never delay the desktop window.
-        void remoteAccess.restore()
-
-        return {
-          installMigrationQuitGuard,
-          isMigrationInProgress,
-          createMainWindow: (options: Parameters<typeof createMainWindow>[0]) =>
-            createMainWindow(options, translate),
-          configureMainWindow,
-          startupWindow,
-          createAppTray,
-          translate,
-          buildAuthenticatedWebUrl,
-          routeSecondInstance,
-          taskNotifications,
-          notificationInbox,
-          mainWindowGetterBox,
-          settingsService,
-          appIconControllerBox,
-          appTrayBox,
-          // Read through the controller (not a snapshot) so a tray created after a settings change —
-          // e.g. a headless web client flipping the variant mid-startup — starts on the live value.
-          getAppIconVariant: () => appIconControllerBox.current?.getVariant() ?? initialVariant,
-          disposeApplicationRuntime,
-          detectActiveSessions,
-          prepareForQuit,
-          abortQuitPreparation,
-          createSessionPersistenceFlush: (
-            getWindow: () => InstanceType<typeof BrowserWindow> | undefined
-          ) => createElectronSessionPersistenceFlush(getWindow),
-          notifySessionPersistenceFlushAborted: (
-            getWindow: () => InstanceType<typeof BrowserWindow> | undefined
-          ) => notifyRendererSessionPersistenceFlushAborted(getWindow),
-          createConfirmClose: (getWindow: () => InstanceType<typeof BrowserWindow> | undefined) =>
-            createElectronCloseConfirm(
-              getWindow,
-              {
-                get: () => settingsService.getClosePreference(),
-                set: async (preference) => {
-                  await settingsService.setClosePreference(preference)
+            // Pass the concrete main entry path so ACP can launch the artifact MCP server from the same bundle.
+            const {
+              applicationCommands,
+              applicationEvents,
+              bindRemoteAccess,
+              taskNotifications,
+              notificationInbox,
+              settingsService,
+              taskAgent,
+              taskControls,
+              detectActiveSessions,
+              prepareForQuit,
+              abortQuitPreparation,
+              dispose: disposeApplicationRuntime
+            } = await registerIpcHandlers({
+              mainEntryPath,
+              settingsStore,
+              translate,
+              managedPreviewProtocol: managedPreviewProtocolBridge.registrar,
+              handoffRuntime: 'production',
+              headless: webMode.headless,
+              onAppIconVariantChanged: (variant) => {
+                appIconControllerBox.current?.setVariant(variant)
+                // Keep the tray glyph on the same variant as the window icon. No-op before the lifecycle
+                // installs the tray, or off Windows (single static tray asset there).
+                if (appTrayBox.current && trayVariantIconPaths) {
+                  setTrayIconVariant(appTrayBox.current, trayVariantIconPaths, variant)
                 }
               },
-              translate
-            ),
-          installAppLifecycle,
-          createDesktopAttentionController,
-          wireDesktopAttention,
-          wireNotificationInboxController,
-          log,
-          webMode,
-          webController,
-          remoteAccess,
-          databaseStartupOwner,
-          databaseStartupQuitGuard,
-          disposeIpcHandlerRegistry: () => {
-            disposeTrayLocaleSubscription()
-            disposeLocalePreferenceIpc()
+              listAppIconPreviews: () => buildAppIconPreviews(nativeImage, iconVariantPaths)
+            })
+
+            // The controller must exist before its IPC responder, while the responder calls back into the
+            // controller. This box breaks that startup cycle without exposing unread ownership to renderer.
+            const visibilityProbeBox: {
+              current: ReturnType<typeof registerUnreadTaskIpc> | undefined
+            } = { current: undefined }
+            notificationInbox.configureDesktop({
+              // Only the main conversation window can acknowledge a visible session. A focused preview
+              // window must not clear unread state for the conversation underneath it.
+              isAppFocused: () => mainWindowGetterBox.current?.()?.isFocused() ?? false,
+              confirmSessionVisible: (sessionId) =>
+                visibilityProbeBox.current?.confirmSessionVisible(sessionId) ??
+                Promise.resolve(false),
+              badge: createDesktopBadgeAdapter({
+                platform: process.platform,
+                setBadgeCount: (count) => app.setBadgeCount(count),
+                isUnityRunning: () => app.isUnityRunning(),
+                getMainWindow: () => mainWindowGetterBox.current?.(),
+                createWindowsOverlay: (label) =>
+                  nativeImage.createFromBitmap(createWindowsBadgeBitmap(label), {
+                    width: 16,
+                    height: 16,
+                    scaleFactor: 1
+                  }),
+                onError: (error) => log.warn('desktop unread badge failed', error)
+              })
+            })
+            visibilityProbeBox.current = registerUnreadTaskIpc({
+              getMainWindow: () => mainWindowGetterBox.current?.(),
+              controller: notificationInbox,
+              onError: (error) => log.warn('message center visibility IPC failed', error)
+            })
+            // Restore the independent icon variant off macOS and create the macOS Theme/Dock controller.
+            // macOS deliberately leaves the packaged Icon Composer icon untouched until a renderer announces
+            // its Theme; after that, nativeTheme keeps System mode live even with no BrowserWindow open.
+            const initialVariant = await settingsService.getAppIconVariant()
+            appIconControllerBox.current = createAppIconController({
+              electron: {
+                app,
+                getAllWindows: () => BrowserWindow.getAllWindows(),
+                nativeImage,
+                nativeTheme
+              },
+              variantPaths: iconVariantPaths,
+              initialVariant
+            })
+            const remoteAccess = await RemoteAccessService.create()
+            bindRemoteAccess(remoteAccess)
+            const webController = createWebServiceController({
+              applicationCommands,
+              requestQuit: () => app.quit(),
+              externalAccess: remoteAccess.webAccess,
+              applicationEvents,
+              taskAgent,
+              taskControls
+            })
+            remoteAccess.attachWebController(webController)
+            registerRemoteAccessIpcHandlers(remoteAccess)
+            // A launch that itself requested serving (a dedicated headless daemon, or an explicit --serve) is
+            // not attached: stopping it quits the process. On-demand starts for a running instance are attached.
+            if (webMode.enabled)
+              await webController.ensureStarted(webMode.port, { attached: false })
+            // Restore a persisted remote-access preference only after the normal IPC/web surfaces exist.
+            // A missing or signed-out third-party remote-access installation must never delay the desktop window.
+            void remoteAccess.restore()
+
+            return {
+              installMigrationQuitGuard,
+              isMigrationInProgress,
+              createMainWindow: (options: Parameters<typeof createMainWindow>[0]) =>
+                createMainWindow(options, translate),
+              configureMainWindow,
+              startupWindow,
+              createAppTray,
+              translate,
+              buildAuthenticatedWebUrl,
+              routeSecondInstance,
+              taskNotifications,
+              notificationInbox,
+              mainWindowGetterBox,
+              settingsService,
+              appIconControllerBox,
+              appTrayBox,
+              // Read through the controller (not a snapshot) so a tray created after a settings change —
+              // e.g. a headless web client flipping the variant mid-startup — starts on the live value.
+              getAppIconVariant: () => appIconControllerBox.current?.getVariant() ?? initialVariant,
+              disposeApplicationRuntime,
+              detectActiveSessions,
+              prepareForQuit,
+              abortQuitPreparation,
+              createSessionPersistenceFlush: (
+                getWindow: () => InstanceType<typeof BrowserWindow> | undefined
+              ) => createElectronSessionPersistenceFlush(getWindow),
+              notifySessionPersistenceFlushAborted: (
+                getWindow: () => InstanceType<typeof BrowserWindow> | undefined
+              ) => notifyRendererSessionPersistenceFlushAborted(getWindow),
+              createConfirmClose: (
+                getWindow: () => InstanceType<typeof BrowserWindow> | undefined
+              ) =>
+                createElectronCloseConfirm(
+                  getWindow,
+                  {
+                    get: () => settingsService.getClosePreference(),
+                    set: async (preference) => {
+                      await settingsService.setClosePreference(preference)
+                    }
+                  },
+                  translate
+                ),
+              installAppLifecycle,
+              createDesktopAttentionController,
+              wireDesktopAttention,
+              wireNotificationInboxController,
+              log,
+              webMode,
+              webController,
+              remoteAccess,
+              databaseStartupOwner,
+              databaseStartupQuitGuard,
+              disposeIpcHandlerRegistry: () => {
+                disposeTrayLocaleSubscription()
+                disposeLocalePreferenceIpc()
+                managedPreviewProtocolBridge.dispose()
+                disposeDatabaseStartupIpc()
+                disposeIpcHandlerRegistry()
+              }
+            }
+          } catch (error) {
             managedPreviewProtocolBridge.dispose()
-            disposeDatabaseStartupIpc()
-            disposeIpcHandlerRegistry()
+            throw error
           }
+        },
+        rollbackShell: () => {
+          disposeLocalePreferenceIpc()
+          databaseStartupQuitGuard.dispose()
+          disposeDatabaseStartupIpc()
+          if (startupWindow && !startupWindow.isDestroyed()) startupWindow.destroy()
+          app.quit()
         }
-      } catch (error) {
-        disposeLocalePreferenceIpc()
-        databaseStartupQuitGuard.dispose()
-        managedPreviewProtocolBridge.dispose()
-        disposeDatabaseStartupIpc()
-        if (startupWindow && !startupWindow.isDestroyed()) startupWindow.destroy()
-        app.quit()
-        throw error
-      }
+      })
     },
     // Warn (rather than silently tear down) if the user tries to quit mid data-root migration. Installed
     // BEFORE the lifecycle so its before-quit runs first: a migration it cancels leaves

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -593,7 +593,10 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             throw error
           }
         },
-        rollbackShell: () => {
+        rollbackShell: async () => {
+          // Module loading can fail while verification is actively migrating. Keep the quit guard
+          // installed until that attempt settles so app.quit cannot interrupt database writes.
+          await databaseStartupOwner.whenAttemptSettled()
           disposeLocalePreferenceIpc()
           databaseStartupQuitGuard.dispose()
           managedPreviewProtocolBridge.dispose()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -231,6 +231,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
 
       startupDiagnostics?.phase('load-startup-shell-modules')
       const [
+        { createManagedPreviewProtocolBridge },
         { configureMainWindow, createMainWindow },
         { LocalePreferenceOwner },
         { registerLocalePreferenceIpc },
@@ -245,6 +246,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         { SettingsRepository },
         { parseWebModeOptions }
       ] = await Promise.all([
+        import('./managed-preview-protocol'),
         import('./windows'),
         import('./locale/owner'),
         import('./locale/ipc'),
@@ -263,6 +265,10 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
       startupDiagnostics?.phase('electron-ready')
       await app.whenReady()
       startupDiagnostics?.phase('prepare-shell')
+      // The bridge is lightweight, but its protocol handler must exist before the first BrowserWindow
+      // creates the default session. macOS otherwise treats later managed-preview requests as an
+      // unknown scheme even though the privileged scheme itself was registered before app ready.
+      const managedPreviewProtocolBridge = createManagedPreviewProtocolBridge(protocol)
       // Create the settings document owner before any native surface. The startup locale repository
       // and the later application Settings repository share this store, so every settings.json
       // mutation uses one serialization queue and one atomic-write implementation.
@@ -360,7 +366,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           await startupShellRendered
           return Promise.all([
             import('./ipc'),
-            import('./managed-preview-protocol'),
             import('./storage/migration-state'),
             import('./tray'),
             import('./app-lifecycle'),
@@ -381,7 +386,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           _,
           [
             { registerIpcHandlers },
-            { createManagedPreviewProtocolBridge },
             { installMigrationQuitGuard, isMigrationInProgress },
             { createAppTray, refreshAppTrayLocale, setTrayIconVariant },
             { installAppLifecycle },
@@ -399,7 +403,6 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           ]
         ) => {
           startupDiagnostics?.phase('compose-runtime')
-          const managedPreviewProtocolBridge = createManagedPreviewProtocolBridge(protocol)
 
           try {
             // Held in a box (not a bare let) so the settings IPC callback registered below can reach the icon
@@ -588,6 +591,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         rollbackShell: () => {
           disposeLocalePreferenceIpc()
           databaseStartupQuitGuard.dispose()
+          managedPreviewProtocolBridge.dispose()
           disposeDatabaseStartupIpc()
           if (startupWindow && !startupWindow.isDestroyed()) startupWindow.destroy()
           app.quit()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -585,6 +585,10 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
               }
             }
           } catch (error) {
+            // Invalidate caller leases immediately if composition fails after registering IPC. The
+            // outer shell rollback destroys the window and quits, but renderer calls can still arrive
+            // while that shutdown is in flight.
+            disposeIpcHandlerRegistry()
             managedPreviewProtocolBridge.dispose()
             throw error
           }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -141,7 +141,6 @@ import { HostFramesService } from './notebook/host-frames-service'
 import { HostSessionsService } from './notebook/host-sessions-service'
 import { HostModelService } from './notebook/host-model-service'
 import { HostViewImageService } from './notebook/host-view-image-service'
-import type { NotebookEnvironmentManager } from './notebook/runtime-service'
 import { parseArtifactVersionLocator } from '../shared/artifact-provenance'
 import { parseUploadVersionReference } from '../shared/uploads'
 import { DEFAULT_ARTIFACT_PROJECT_ID } from '../shared/artifacts'
@@ -2635,9 +2634,9 @@ const createApplicationModules = async (
   )
 
   // Resolve the shared conda base under the app data root (relocatable, where the runtime install
-  // lives) and start the env readiness gate. The conda channel comes from the effective package mirror
-  // (configured override, else the region default from locale). Runtime packs use the official CDN base
-  // with OPEN_SCIENCE_ENV_CDN_BASE available for private/self-hosted deployments.
+  // lives) and start the env readiness gate. Named environments resolve the effective conda channel
+  // lazily because they are the only path that solves online; default runtime packs use the official
+  // CDN and must not wait for mirror probing during application startup.
   // Build the provisioner separately from registering the IPC surface: if construction fails (e.g.
   // micromamba missing in dev), `provisioner` stays undefined but the notebook-env handlers are STILL
   // registered below (as unavailable stubs), so the renderer gets an actionable "runtime unavailable"
@@ -2646,12 +2645,18 @@ const createApplicationModules = async (
   let serialized: RuntimeProvisioner | undefined
   try {
     const configuredMirror = await settingsService.getPackageMirror()
-    const mirror = await effectiveMirrorAsync(configuredMirror, app.getLocale())
+    const effectiveMirror = (): ReturnType<typeof effectiveMirrorAsync> =>
+      effectiveMirrorAsync(configuredMirror, app.getLocale())
     provisioner = createProductionProvisioner(
       {
         root: provisioningRoot,
-        channel: mirror.condaChannel ?? process.env.OPEN_SCIENCE_CONDA_CHANNEL ?? 'conda-forge',
-        caBundle: mirror.caBundle,
+        channel: async () =>
+          (await effectiveMirror()).condaChannel ??
+          process.env.OPEN_SCIENCE_CONDA_CHANNEL ??
+          'conda-forge',
+        // Mirror probing never changes the configured enterprise CA bundle, so it is safe to pass
+        // through synchronously while channel selection warms in the background.
+        caBundle: configuredMirror?.caBundle,
         micromamba: { resourcesPath: process.resourcesPath },
         // Self-guard the provisioner's prefix writes (startup restore/upgrade/repair, named create, lazy
         // materialize) against a prefix crash-recovery could not confirm free of a live orphan — closes
@@ -2678,6 +2683,11 @@ const createApplicationModules = async (
         withPrefixLock: (envName, fn) => notebookService.withEnvLock(envName, fn)
       },
       { runner: micromambaRunner }
+    )
+    // Warm the process-local mirror cache after provisioner construction succeeds. This stays outside
+    // the startup critical path; a later named-env create awaits the same memoized probe if necessary.
+    void effectiveMirror().catch((error) =>
+      console.error('Notebook package mirror warmup failed:', error)
     )
     // One serialized wrapper shared by the startup gate and the notebook service's on-demand default
     // provisioning, so a concurrent build of the same default env (UI R-tab + an agent R run) can't
@@ -2728,7 +2738,7 @@ const createApplicationModules = async (
     // Back the notebook service's manage_environments tool with the same provisioner that owns the env
     // gate (it is a DefaultRuntimeProvisioner, which implements createNamedEnvironment/listEnvironments/
     // removeEnvironment). Wired after construction like the mcp/mirror resolvers above.
-    notebookService.setEnvironmentManager(provisioner as unknown as NotebookEnvironmentManager)
+    notebookService.setEnvironmentManager(provisioner)
     // On first agent use of a not-yet-built default env, build it from the offline bundle (via the
     // shared serialized provisioner) instead of erroring — keeps R lazy but avoids the agent creating
     // a redundant named env.

--- a/src/main/notebook/provisioner.startup.test.ts
+++ b/src/main/notebook/provisioner.startup.test.ts
@@ -234,4 +234,31 @@ describe('createProductionProvisioner', () => {
     expect(runArgv).toHaveBeenCalledOnce()
     expect(runArgv.mock.calls[0]?.[0]?.[0]).toBe(compatibility)
   })
+
+  it('resolves the package channel only when a named environment needs online solving', async () => {
+    const root = makeRoot()
+    const mmPath = join(root, 'bin', micromambaBinName)
+    touchBin(mmPath)
+    const resolveChannel = vi.fn(async () => 'https://fast-mirror.invalid/conda-forge')
+    const runArgv = vi.fn<NonNullable<ProductionProvisionerDeps['runArgv']>>(async () => undefined)
+    const provisioner = createProductionProvisioner(
+      {
+        root,
+        channel: resolveChannel,
+        micromamba: { env: { OPEN_SCIENCE_MICROMAMBA_BIN: mmPath } }
+      },
+      {
+        runner: { initialPath: mmPath, resolve: async () => mmPath },
+        runArgv,
+        verify: async () => undefined
+      }
+    )
+
+    expect(resolveChannel).not.toHaveBeenCalled()
+
+    await provisioner.createNamedEnvironment('analysis', 'python')
+
+    expect(resolveChannel).toHaveBeenCalledOnce()
+    expect(runArgv.mock.calls[0]?.[0]).toContain('https://fast-mirror.invalid/conda-forge')
+  })
 })

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -144,7 +144,7 @@ export const BASE_R_PACKAGES: string[] = ['r-base', 'r-jsonlite']
 export type ProvisionerDeps = {
   root: string
   mm: string
-  channel: string
+  channel: string | (() => Promise<string>)
   // Downloads the (spec, version) bundle into the pkgs cache and returns its local lock path, or
   // undefined when no bundle is published (the caller must fail closed rather than silently solving
   // online for the default envs).
@@ -311,6 +311,10 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
   private readonly liveUnconfirmedPrefixes = new Set<string>()
 
   constructor(private readonly deps: ProvisionerDeps) {}
+
+  private async resolveChannel(): Promise<string> {
+    return typeof this.deps.channel === 'string' ? this.deps.channel : this.deps.channel()
+  }
 
   private get cache(): MicromambaCache {
     return this.deps.cache ?? selectMicromambaCache(this.deps.root)
@@ -1102,6 +1106,9 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     // Refuse if recovery flagged this named prefix possibly-live (an orphan create/install may still
     // be writing it) — the service also gates this, but self-guarding covers every caller.
     this.assertPrefixWritable(prefix)
+    // Named environments are the only online-solving path. Resolve/probe the channel here so normal
+    // application startup and offline default-runtime provisioning never wait for mirror selection.
+    const channel = await this.resolveChannel()
     // Journal the create (child PID + prefix) so a crash mid-create is recovered like any other prefix
     // write: a survivor is killed and, if unconfirmed, the prefix is blocked so a later create/remove
     // can't race it. Take the shared pkgs cache lock (+ MAX_PATH recovery) for the whole prefix cleanup
@@ -1125,13 +1132,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
             // (ipc.ts wires them separately). Passing this.abort here would let a cancel of the default env
             // abort this unrelated named-env child. Named create has no per-language cancel path of its own.
             await this.deps.runArgv(
-              createFromPackagesArgv(
-                this.deps.mm,
-                this.deps.root,
-                prefix,
-                [this.deps.channel],
-                pkgs
-              ),
+              createFromPackagesArgv(this.deps.mm, this.deps.root, prefix, [channel], pkgs),
               undefined,
               onChild,
               onBeforeSpawn,
@@ -1536,7 +1537,7 @@ export const planStartupAction = (root: string, expectedVersion: number): Startu
 // is resolved centrally when no override is supplied.
 export type ProductionProvisionerOptions = {
   root: string
-  channel: string
+  channel: string | (() => Promise<string>)
   micromamba?: MicromambaRunnerDeps
   // PEM CA bundle path (enterprise TLS proxy) exported into micromamba's env so an ONLINE provision /
   // named-env create verifies HTTPS against it. Offline bundle creates need no network, so this only
@@ -1578,7 +1579,7 @@ export type ProductionProvisionerDeps = {
 export const createProductionProvisioner = (
   opts: ProductionProvisionerOptions,
   deps: ProductionProvisionerDeps = {}
-): RuntimeProvisioner => {
+): DefaultRuntimeProvisioner => {
   // `root` is `<storageRoot>/runtime`; derive the real home dir from it (storageRoot's parent) as a
   // robust fallback for resolveMicromamba's storage-root branch, instead of leaving it to fall back to
   // resolveMicromamba's own process.env.HOME lookup — which can be unset for a packaged Electron app

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -767,7 +767,9 @@ describe('Settings backend ownership architecture', () => {
     expect(mainIndex).toContain(
       'const startupSettingsRepository = new SettingsRepository(settingsStore)'
     )
-    expect(mainIndex).toContain('settingsStore,\n          translate,')
+    expect(mainIndex).toMatch(
+      /registerIpcHandlers\(\{\s+mainEntryPath,\s+settingsStore,\s+translate,/u
+    )
     expect(mainIpc).toContain('settingsStore ?? resolveStorageRoot()')
     expect(mainIpc).toContain(
       'capability: new SettingsService({\n      repository: settingsRepository,\n      skillRuntimeMcpEntryPath: mainEntryPath,\n      applyNetworkProxy:'


### PR DESCRIPTION
## Problem

Application startup waited for the complete main-process backend graph before creating the first window. Notebook setup also awaited an eight-request conda mirror probe even though normal startup and default runtime provisioning do not solve packages online. Together these delayed useful renderer feedback and runtime readiness.

## Proposed change

- Load only the settings, locale, window, network, database-startup, and lightweight managed-preview protocol bridge before creating the first `BrowserWindow`.
- Start database verification immediately, allow Chromium to paint the startup shell, then load the full backend while verification is in flight. Runtime composition and lifecycle installation still wait for both prerequisites.
- Resolve the conda channel only when a named environment uses the online solver. Warm the existing process-local mirror promise in the background without awaiting it.
- Preserve ordered startup rollback, database compatibility gating, migration quit guards, IPC registration, protocol availability, and lifecycle installation.

```mermaid
flowchart LR
  A["Single-instance lock"] --> B["Lightweight startup shell"]
  B --> C["Register preview protocol bridge"]
  C --> D["Create first window"]
  D --> E["Database verification"]
  D --> F["Renderer first paint"]
  F --> G["Load full backend"]
  E --> H["Compose runtime"]
  G --> H
  H --> I["Install lifecycle and publish ready"]
```

## Scope and non-goals

- The existing update check remains asynchronous and is unchanged.
- Renderer bundle splitting is intentionally out of scope for this PR.
- No historical data compatibility or migration behavior changes.
- No state-machine or enum values are added.
- No persistence format, durable state, or new cache is added; mirror warmup reuses the existing in-process memoized promise.

## Acceptance criteria and validation

Latest five-run local production-build medians on Windows, using isolated temporary profiles:

| Metric | Baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| First BrowserWindow observed | ~802 ms | 421 ms | ~47% faster |
| Renderer DOM content loaded | ~1276 ms | 896 ms | ~30% faster |
| Settings-interactive | ~1940 ms | 1396 ms | ~28% faster |
| Main startup diagnostic | ~2068 ms | 1231 ms | ~40% faster |

Evidence mapping:

- Startup dependency ordering and rollback -> targeted `src/main/app-startup.test.ts` -> passed.
- Main entry startup contracts -> targeted `src/main/index-fatal-errors.test.ts` and `src/main/app-branding.test.ts` -> passed.
- Database verification/IPC/logging gate -> three targeted `database-startup-*.test.ts` files -> 12 tests passed.
- Lazy mirror selection and provisioner consumers -> `mirror-probe.test.ts`, `provisioner.startup.test.ts`, `provisioner.test.ts`, `provisioner.upgrade.test.ts`, and `provisioner-runtime.test.ts` -> passed.
- Window-before-protocol regression and managed preview adapters -> `index-startup-order.test.ts`, `managed-preview-protocol.test.ts`, and `managed-preview-ipc.test.ts` -> passed after the CI-driven fix (53 tests with the startup orchestration test).
- Main-process types -> `tsc --noEmit -p tsconfig.node.json --composite false` -> passed after the final material edit. Renderer types were excluded locally because no renderer interface or source changed; CI runs both.
- Changed source lint/format -> targeted ESLint and Prettier checks -> passed after the final material edit.
- Production bundling -> `electron-vite build` -> passed after the final material edit.
- Managed image preview journey -> the exact failing Playwright case from `e2e/workspace-files.spec.ts` -> passed after the final material edit.
- Startup performance -> five hidden Electron launches against the final production build -> medians shown above; temporary profiles were removed by the harness.

The first macOS CI run exposed that registering the custom-protocol bridge after the first window is too late on macOS (`ERR_UNKNOWN_URL_SCHEME`). Commit `c44338b44` keeps that ~7 KB bridge in the pre-window shell while leaving all resource ownership and full IPC composition deferred; the exact failing journey now passes locally. Exact-head PR CI is rerunning this cross-platform lane.

Per the requested workflow, the complete local `npm test` suite was not run. The exact-head PR Gate is authoritative for the full portable and Windows-sensitive fallback lanes. Locally uncovered risks are macOS/Linux scheduling differences and packaged-install cold-start variance.

## Review focus

- Confirm the lightweight shell contains every renderer dependency needed before database readiness.
- Confirm full backend imports cannot begin before the startup shell has painted, while headless mode remains unblocked.
- Confirm the managed-preview bridge is registered before the first window while its real resource handler remains owned by normal runtime composition.
- Confirm named-environment channel resolution remains equivalent for configured mirrors, locale fallback, environment override, and enterprise CA bundle handling.

Related issue: none.
