### PR TITLE
fix(cli): publish artifact downloads atomically

### DIFF
--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -4,8 +4,8 @@
 
 import { randomUUID } from 'node:crypto'
 import { closeSync, createWriteStream, openSync } from 'node:fs'
-import { chmod, mkdir, readFile, rename, rm, stat } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { chmod, lstat, mkdir, readFile, readlink, rename, rm, stat } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
 import { Readable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import { spawn } from 'node:child_process'
@@ -586,16 +586,33 @@ export const urlCommand = async (options, deps = DEFAULT_DEPS) => {
   deps.log(await authenticatedUrl(state, deps))
 }
 
+const resolveDownloadOutput = async (output) => {
+  let candidate = output
+  for (let hop = 0; hop < 40; hop += 1) {
+    const linkTarget = await lstat(candidate).then(
+      (metadata) => (metadata.isSymbolicLink() ? readlink(candidate) : undefined),
+      (error) => {
+        if (error?.code === 'ENOENT') return undefined
+        throw error
+      }
+    )
+    if (linkTarget === undefined) return candidate
+    candidate = resolve(dirname(candidate), linkTarget)
+  }
+  throw new Error(`Too many symbolic links in artifact output: ${output}`)
+}
+
 const writeDownload = async (response, output) => {
   if (!response.body) throw new Error('Artifact download returned no data.')
-  const existingMode = await stat(output).then(
+  const destination = await resolveDownloadOutput(output)
+  const existingMode = await stat(destination).then(
     ({ mode }) => mode & 0o777,
     (error) => {
       if (error?.code === 'ENOENT') return undefined
       throw error
     }
   )
-  const temporaryOutput = `${output}.${process.pid}-${randomUUID()}.tmp`
+  const temporaryOutput = `${destination}.${process.pid}-${randomUUID()}.tmp`
   try {
     await pipeline(
       Readable.fromWeb(response.body),
@@ -605,7 +622,7 @@ const writeDownload = async (response, output) => {
       })
     )
     if (existingMode !== undefined) await chmod(temporaryOutput, existingMode)
-    await rename(temporaryOutput, output)
+    await rename(temporaryOutput, destination)
   } finally {
     await rm(temporaryOutput, { force: true }).catch(() => undefined)
   }

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -2,9 +2,9 @@
 
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
-import { closeSync, openSync } from 'node:fs'
-import { createWriteStream } from 'node:fs'
-import { mkdir, readFile, rm } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import { closeSync, createWriteStream, openSync } from 'node:fs'
+import { mkdir, readFile, rename, rm } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { Readable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
@@ -588,7 +588,16 @@ export const urlCommand = async (options, deps = DEFAULT_DEPS) => {
 
 const writeDownload = async (response, output) => {
   if (!response.body) throw new Error('Artifact download returned no data.')
-  await pipeline(Readable.fromWeb(response.body), createWriteStream(output))
+  const temporaryOutput = `${output}.${process.pid}-${randomUUID()}.tmp`
+  try {
+    await pipeline(
+      Readable.fromWeb(response.body),
+      createWriteStream(temporaryOutput, { flags: 'wx' })
+    )
+    await rename(temporaryOutput, output)
+  } finally {
+    await rm(temporaryOutput, { force: true }).catch(() => undefined)
+  }
 }
 
 const TASK_DEPS = {

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -19,6 +19,7 @@ import { locateApp } from './locate-app.mjs'
 const DEFAULT_PORT = 44100
 const START_TIMEOUT_MS = 30_000
 const STOP_TIMEOUT_MS = 15_000
+const MAX_DOWNLOAD_SYMLINK_HOPS = 40
 
 const usage = `Usage: open-science <command> [options]
 
@@ -588,7 +589,7 @@ export const urlCommand = async (options, deps = DEFAULT_DEPS) => {
 
 const resolveDownloadOutput = async (output) => {
   let candidate = output
-  for (let hop = 0; hop < 40; hop += 1) {
+  for (let hop = 0; ; hop += 1) {
     const linkTarget = await lstat(candidate).then(
       (metadata) => (metadata.isSymbolicLink() ? readlink(candidate) : undefined),
       (error) => {
@@ -597,6 +598,7 @@ const resolveDownloadOutput = async (output) => {
       }
     )
     if (linkTarget === undefined) return candidate
+    if (hop === MAX_DOWNLOAD_SYMLINK_HOPS) break
     candidate = resolve(dirname(candidate), linkTarget)
   }
   throw new Error(`Too many symbolic links in artifact output: ${output}`)

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -4,7 +4,7 @@
 
 import { randomUUID } from 'node:crypto'
 import { closeSync, createWriteStream, openSync } from 'node:fs'
-import { mkdir, readFile, rename, rm } from 'node:fs/promises'
+import { chmod, mkdir, readFile, rename, rm, stat } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { Readable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
@@ -588,12 +588,23 @@ export const urlCommand = async (options, deps = DEFAULT_DEPS) => {
 
 const writeDownload = async (response, output) => {
   if (!response.body) throw new Error('Artifact download returned no data.')
+  const existingMode = await stat(output).then(
+    ({ mode }) => mode & 0o777,
+    (error) => {
+      if (error?.code === 'ENOENT') return undefined
+      throw error
+    }
+  )
   const temporaryOutput = `${output}.${process.pid}-${randomUUID()}.tmp`
   try {
     await pipeline(
       Readable.fromWeb(response.body),
-      createWriteStream(temporaryOutput, { flags: 'wx' })
+      createWriteStream(temporaryOutput, {
+        flags: 'wx',
+        ...(existingMode === undefined ? {} : { mode: existingMode })
+      })
     )
+    if (existingMode !== undefined) await chmod(temporaryOutput, existingMode)
     await rename(temporaryOutput, output)
   } finally {
     await rm(temporaryOutput, { force: true }).catch(() => undefined)

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -1,4 +1,6 @@
-import { resolve } from 'node:path'
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 import { PUBLIC_TERMINAL_FIXTURE } from '../../test/fixtures/renderer-contract-certification'
@@ -462,6 +464,72 @@ describe('task CLI', () => {
     expect(client.listArtifacts).toHaveBeenCalledWith('session-1')
     expect(client.downloadArtifact).toHaveBeenCalledWith('artifact-1')
     expect(writeDownload).toHaveBeenCalledWith(expect.any(Response), 'report.md')
+  })
+
+  it('preserves an existing artifact output when the download stream fails', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'open-science-cli-download-'))
+    const output = join(directory, 'report.md')
+    await writeFile(output, 'existing report')
+    const failure = new Error('download interrupted')
+    let pullCount = 0
+    const response = new Response(
+      new ReadableStream({
+        async pull(controller) {
+          if (pullCount++ === 0) {
+            controller.enqueue(new TextEncoder().encode('partial replacement'))
+          } else {
+            await new Promise((resolveDelay) => setTimeout(resolveDelay, 20))
+            controller.error(failure)
+          }
+        }
+      })
+    )
+    const client = { downloadArtifact: vi.fn().mockResolvedValue(response) }
+
+    try {
+      await expect(
+        runTaskCommand(
+          {
+            command: 'artifacts',
+            subcommand: 'download',
+            positionals: ['artifact-1'],
+            options: { output, json: true, jsonl: false }
+          },
+          { connect: vi.fn().mockResolvedValue(client), log: vi.fn() }
+        )
+      ).rejects.toBe(failure)
+
+      expect(await readFile(output, 'utf8')).toBe('existing report')
+      expect(await readdir(directory)).toEqual(['report.md'])
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('replaces an existing artifact output after the complete download succeeds', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'open-science-cli-download-'))
+    const output = join(directory, 'report.md')
+    await writeFile(output, 'existing report')
+    const client = {
+      downloadArtifact: vi.fn().mockResolvedValue(new Response('replacement report'))
+    }
+
+    try {
+      await runTaskCommand(
+        {
+          command: 'artifacts',
+          subcommand: 'download',
+          positionals: ['artifact-1'],
+          options: { output, json: true, jsonl: false }
+        },
+        { connect: vi.fn().mockResolvedValue(client), log: vi.fn() }
+      )
+
+      expect(await readFile(output, 'utf8')).toBe('replacement report')
+      expect(await readdir(directory)).toEqual(['report.md'])
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
   })
 
   it('dispatches Plan show, decision, and revision feedback through the SDK', async () => {

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
@@ -531,6 +531,35 @@ describe('task CLI', () => {
       await rm(directory, { recursive: true, force: true })
     }
   })
+
+  it.runIf(process.platform !== 'win32')(
+    'preserves existing artifact output permissions after replacement',
+    async () => {
+      const directory = await mkdtemp(join(tmpdir(), 'open-science-cli-download-'))
+      const output = join(directory, 'report.md')
+      await writeFile(output, 'existing report')
+      await chmod(output, 0o600)
+      const client = {
+        downloadArtifact: vi.fn().mockResolvedValue(new Response('replacement report'))
+      }
+
+      try {
+        await runTaskCommand(
+          {
+            command: 'artifacts',
+            subcommand: 'download',
+            positionals: ['artifact-1'],
+            options: { output, json: true, jsonl: false }
+          },
+          { connect: vi.fn().mockResolvedValue(client), log: vi.fn() }
+        )
+
+        expect((await stat(output)).mode & 0o777).toBe(0o600)
+      } finally {
+        await rm(directory, { recursive: true, force: true })
+      }
+    }
+  )
 
   it('dispatches Plan show, decision, and revision feedback through the SDK', async () => {
     const client = {

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -629,6 +629,42 @@ describe('task CLI', () => {
     }
   })
 
+  it.runIf(process.platform !== 'win32')(
+    'follows a 40-link artifact output symlink chain',
+    async () => {
+      const directory = await mkdtemp(join(tmpdir(), 'open-science-cli-download-'))
+      const target = join(directory, 'target.md')
+      const output = join(directory, 'link-0.md')
+      await writeFile(target, 'existing report')
+      for (let index = 39; index >= 0; index -= 1) {
+        await symlink(
+          index === 39 ? 'target.md' : `link-${index + 1}.md`,
+          join(directory, `link-${index}.md`)
+        )
+      }
+      const client = {
+        downloadArtifact: vi.fn().mockResolvedValue(new Response('replacement report'))
+      }
+
+      try {
+        await runTaskCommand(
+          {
+            command: 'artifacts',
+            subcommand: 'download',
+            positionals: ['artifact-1'],
+            options: { output, json: true, jsonl: false }
+          },
+          { connect: vi.fn().mockResolvedValue(client), log: vi.fn() }
+        )
+
+        expect(await readlink(output)).toBe('link-1.md')
+        expect(await readFile(target, 'utf8')).toBe('replacement report')
+      } finally {
+        await rm(directory, { recursive: true, force: true })
+      }
+    }
+  )
+
   it('dispatches Plan show, decision, and revision feedback through the SDK', async () => {
     const client = {
       getSessionPlan: vi.fn().mockResolvedValue({

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -1,4 +1,14 @@
-import { chmod, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import {
+  chmod,
+  mkdtemp,
+  readFile,
+  readdir,
+  readlink,
+  rm,
+  stat,
+  symlink,
+  writeFile
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
@@ -560,6 +570,64 @@ describe('task CLI', () => {
       }
     }
   )
+
+  it.runIf(process.platform !== 'win32')(
+    'follows an existing artifact output symlink',
+    async () => {
+      const directory = await mkdtemp(join(tmpdir(), 'open-science-cli-download-'))
+      const target = join(directory, 'target.md')
+      const output = join(directory, 'report.md')
+      await writeFile(target, 'existing report')
+      await symlink('target.md', output)
+      const client = {
+        downloadArtifact: vi.fn().mockResolvedValue(new Response('replacement report'))
+      }
+
+      try {
+        await runTaskCommand(
+          {
+            command: 'artifacts',
+            subcommand: 'download',
+            positionals: ['artifact-1'],
+            options: { output, json: true, jsonl: false }
+          },
+          { connect: vi.fn().mockResolvedValue(client), log: vi.fn() }
+        )
+
+        expect(await readlink(output)).toBe('target.md')
+        expect(await readFile(target, 'utf8')).toBe('replacement report')
+      } finally {
+        await rm(directory, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.runIf(process.platform !== 'win32')('follows a dangling artifact output symlink', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'open-science-cli-download-'))
+    const target = join(directory, 'target.md')
+    const output = join(directory, 'report.md')
+    await symlink('target.md', output)
+    const client = {
+      downloadArtifact: vi.fn().mockResolvedValue(new Response('downloaded report'))
+    }
+
+    try {
+      await runTaskCommand(
+        {
+          command: 'artifacts',
+          subcommand: 'download',
+          positionals: ['artifact-1'],
+          options: { output, json: true, jsonl: false }
+        },
+        { connect: vi.fn().mockResolvedValue(client), log: vi.fn() }
+      )
+
+      expect(await readlink(output)).toBe('target.md')
+      expect(await readFile(target, 'utf8')).toBe('downloaded report')
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
 
   it('dispatches Plan show, decision, and revision feedback through the SDK', async () => {
     const client = {


### PR DESCRIPTION
## Problem

`artifacts download --output` opened the destination with `createWriteStream` before the response body completed. A stream or local write failure therefore truncated an existing file and could leave the successfully received prefix at the final path.

The regression test reproduced this through the real CLI write path three consecutive times: an existing `existing report` became `partial replacement` after the response stream failed.

## Proposed change

- Resolve existing and dangling output symlinks, including valid chains up to the platform-compatible 40-link limit.
- Stream each artifact into a UUID-named sibling temporary file created with `wx`.
- Rename the temporary file to the resolved destination only after the stream completes.
- Remove the temporary file on caught failures.
- Preserve an existing destination's POSIX permission bits on the staged replacement.
- Cover interrupted-download preservation, successful replacement, restrictive-mode preservation, valid and dangling symlink targets, and the 40-link boundary with real filesystem tests.

## Compatibility and scope

- No CLI arguments, prompts, stdout, JSON, or exit codes change. Successful and failed commands retain their existing interaction contract.
- No API, schema, data-model, or enum changes.
- No application database, configuration, or other persisted state changes. The only persisted data involved is the requested local output file and a transient sibling staging file.
- No historical migration is needed. Files damaged by an older interrupted download cannot be identified or restored because no historical completion marker or checksum exists.
- Existing valid and dangling output symlinks continue to be followed rather than replaced. Chains requiring more than 40 symlink hops are rejected with an explicit error.

## Filesystem tradeoffs

- Abrupt process termination can leave a sibling temporary file, although the final target remains unmodified.
- Atomic replacement requires temporary-file creation and rename permission in the destination directory and temporary free space roughly equal to the artifact size.
- Replacement changes the destination inode; hard-link relationships, custom ACLs, and special metadata beyond POSIX permission bits are not retained. Existing POSIX permission bits are retained.
- Rename atomicity ultimately follows the destination filesystem's guarantees.

## Acceptance criteria and validation

Checks below ran after the last material edit:

- interrupted response preserves the existing output and removes staging bytes -> targeted red/green Vitest -> passed; before the fix it failed 3/3 and replaced `existing report` with `partial replacement`
- complete response replaces the output and leaves no staging file -> `npm run test:cli` -> 4 files, 54 tests passed, 4 platform-gated tests skipped on Windows
- restrictive existing output is not widened on replacement -> real-filesystem POSIX test -> passed in the PR non-Windows CLI lane
- valid and dangling output symlinks remain intact and their targets receive the download -> real-filesystem POSIX tests -> passed in the PR non-Windows CLI lane
- exactly 40 symlink hops remain accepted -> real-filesystem POSIX test -> passed in the PR non-Windows CLI lane
- Node CLI types remain valid -> `npm run typecheck:node` -> passed
- changed files meet lint rules -> `npx eslint packages/open-science/cli.mjs packages/open-science/cli.test.ts` -> passed
- changed files meet formatting rules -> `npx prettier --check packages/open-science/cli.mjs packages/open-science/cli.test.ts` -> passed
- patch whitespace -> `git diff --check` -> passed

The full repository test suite was intentionally not run locally. PR Gate selected and passed the policy, static, formatting, lint, and CLI/SDK coverage required by this change; CodeQL also passed.

## Review focus

- Same-directory staging and publish ordering.
- Cleanup behavior when the response stream or final rename fails.
- Permission preservation and output symlink compatibility.
- The documented filesystem metadata tradeoffs.
