### PR TITLE
fix(conversation): scope stop state to Session

### DIFF
--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -4088,6 +4088,93 @@ describe('ConversationPanel fix loop lock', () => {
     expect(container.textContent).toContain('cascade unavailable')
   })
 
+  it('does not carry a pending Stop state or its failure into another Session', async () => {
+    let rejectFirstStop!: (error: Error) => void
+    const cancelFirstSession = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectFirstStop = reject
+        })
+    )
+    const cancelSecondSession = vi.fn()
+    const firstSession: ChatSession = {
+      ...idleSession,
+      id: 'session-a',
+      title: 'Session A',
+      status: 'running',
+      activeRun: { promptMessageId: 'msg-a', startedAt: Date.now() }
+    }
+    const secondSession: ChatSession = {
+      ...idleSession,
+      id: 'session-b',
+      title: 'Session B',
+      status: 'running',
+      activeRun: { promptMessageId: 'msg-b', startedAt: Date.now() }
+    }
+
+    renderPanel({
+      view: { activeSession: firstSession },
+      conversation: {
+        availability: { submit: true, submitMode: 'queue' },
+        actions: { cancel: cancelFirstSession }
+      }
+    })
+    act(() => {
+      const cancel = container.querySelector('[aria-label="Cancel run"]') as HTMLButtonElement
+      cancel.click()
+    })
+
+    renderPanel({
+      view: { activeSession: secondSession },
+      conversation: {
+        availability: { submit: true, submitMode: 'queue' },
+        actions: { cancel: cancelSecondSession }
+      }
+    })
+
+    const secondSessionCancel = container.querySelector(
+      'section[data-session-id="session-b"] [aria-label="Cancel run"], ' +
+        'section[data-session-id="session-b"] [aria-label="Stopping run and subagents"]'
+    )
+    const secondSessionQueue = container.querySelector(
+      '[data-testid="composer-queue-submit"]'
+    ) as HTMLButtonElement
+    const secondSessionState = {
+      cancelLabel: secondSessionCancel?.getAttribute('aria-label'),
+      cancelDisabled: (secondSessionCancel as HTMLButtonElement | null)?.disabled,
+      queueDisabled: secondSessionQueue.disabled,
+      firstSessionErrorVisible: false
+    }
+
+    act(() => {
+      secondSessionCancel?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(cancelSecondSession).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      rejectFirstStop(new Error('Session A stop failed'))
+      await Promise.resolve()
+    })
+
+    secondSessionState.firstSessionErrorVisible =
+      container.textContent?.includes('Session A stop failed') ?? false
+    expect(secondSessionState).toEqual({
+      cancelLabel: 'Cancel run',
+      cancelDisabled: false,
+      queueDisabled: false,
+      firstSessionErrorVisible: false
+    })
+
+    renderPanel({
+      view: { activeSession: firstSession },
+      conversation: {
+        availability: { submit: true, submitMode: 'queue' },
+        actions: { cancel: cancelFirstSession }
+      }
+    })
+    expect(container.textContent).toContain('Session A stop failed')
+  })
+
   it('keeps the split-send width while running so adjacent hover controls do not shift', () => {
     const runningSession: ChatSession = {
       ...idleSession,

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -311,6 +311,11 @@ type ConversationPanelSubagents = {
   stop: () => void | Promise<void>
 }
 
+type StopSubmissionState = Readonly<{
+  pending: boolean
+  error?: string
+}>
+
 type ConversationPanelProps = {
   view: ConversationPanelView
   composer: Pick<WorkspaceComposerController, 'view' | 'actions'>
@@ -459,10 +464,11 @@ const ConversationPanel = ({
   const settingsLoaded = useSettingsStore((state) => state.isLoaded)
   const openSettings = useSettingsStore((state) => state.openSettings)
   const openSettingsToPanel = useSettingsStore((state) => state.openSettingsToPanel)
-  const stopSubmissionPendingRef = useRef(false)
-  const [isStopping, setIsStopping] = useState(false)
+  const stopSubmissionPendingSessionIdsRef = useRef(new Set<string>())
+  const [stopSubmissionsBySessionId, setStopSubmissionsBySessionId] = useState(
+    () => new Map<string, StopSubmissionState>()
+  )
   const [messageQueueExpanded, setMessageQueueExpanded] = useState(false)
-  const [stopError, setStopError] = useState<string>()
   const setElicitationDraftAnswers = useSessionStore((state) => state.setElicitationDraftAnswers)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const globalSearchShortcut = window.api?.platform === 'darwin' ? '⌘K' : 'Ctrl+K'
@@ -484,38 +490,51 @@ const ConversationPanel = ({
     setIsReportOpen(true)
   }
 
-  const submitStop = (action: () => void | Promise<void>): void => {
-    if (stopSubmissionPendingRef.current) return
-    stopSubmissionPendingRef.current = true
-    setIsStopping(true)
-    setStopError(undefined)
+  const activeStopSubmission = activeSession
+    ? stopSubmissionsBySessionId.get(activeSession.id)
+    : undefined
+  const isStopping = activeStopSubmission?.pending === true
+  const stopError = activeStopSubmission?.error
+
+  const settleStopSubmission = (sessionId: string, error?: string): void => {
+    stopSubmissionPendingSessionIdsRef.current.delete(sessionId)
+    setStopSubmissionsBySessionId((current) => {
+      const next = new Map(current)
+      if (error !== undefined) next.set(sessionId, { pending: false, error })
+      else next.delete(sessionId)
+      return next
+    })
+  }
+
+  const submitStop = (sessionId: string | undefined, action: () => void | Promise<void>): void => {
+    if (!sessionId || stopSubmissionPendingSessionIdsRef.current.has(sessionId)) return
+    stopSubmissionPendingSessionIdsRef.current.add(sessionId)
+    setStopSubmissionsBySessionId((current) => {
+      const next = new Map(current)
+      next.set(sessionId, { pending: true })
+      return next
+    })
     let outcome: void | Promise<void>
     try {
       outcome = action()
     } catch (error) {
-      stopSubmissionPendingRef.current = false
-      setIsStopping(false)
-      setStopError(error instanceof Error ? error.message : String(error))
+      settleStopSubmission(sessionId, error instanceof Error ? error.message : String(error))
       return
     }
     if (!outcome || typeof (outcome as Promise<void>).then !== 'function') {
-      stopSubmissionPendingRef.current = false
-      setIsStopping(false)
+      settleStopSubmission(sessionId)
       return
     }
-    void outcome
-      .catch((error: unknown) => {
-        setStopError(error instanceof Error ? error.message : String(error))
-      })
-      .finally(() => {
-        stopSubmissionPendingRef.current = false
-        setIsStopping(false)
-      })
+    void outcome.then(
+      () => settleStopSubmission(sessionId),
+      (error: unknown) =>
+        settleStopSubmission(sessionId, error instanceof Error ? error.message : String(error))
+    )
   }
 
-  const handleStop = (): void => submitStop(onCancelRun)
+  const handleStop = (): void => submitStop(activeSession?.id, onCancelRun)
 
-  const handleStopSubagents = (): void => submitStop(onStopSubagents)
+  const handleStopSubagents = (): void => submitStop(activeSession?.id, onStopSubagents)
 
   // Unconditional hook: check if the active session has any jobs (running or finished).
   const allJobsForSession = useSessionJobStore((s) => s.allJobsForSession)


### PR DESCRIPTION
## Problem

Stop progress, duplicate-submit protection, and failure text were owned by the mounted `ConversationPanel` instance. Switching from Session A while its asynchronous Stop was pending caused Session B to inherit A's spinner, disabled send/Stop controls, and later error.

## Proposed change

Track transient Stop attempts by Session id inside `ConversationPanel`. Pending deduplication and completion now update only the initiating Session, allowing another Session to send or Stop independently while preserving A's progress/error when returning to it.

## Scope and non-goals

- Renderer-only transient state; no `ChatSession` or `PersistedChatSession` field changes.
- No new `PersistedSessionStatus` value, migration, historical compatibility path, IPC contract, ACP runtime, subscription, or Agent-framework behavior change.
- No new user-visible copy or locale updates.

## Acceptance criteria and validation

- Cross-Session Stop isolation -> `npm test -- src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx -t "does not carry a pending Stop state or its failure into another Session"` -> passed (1/1).
- Existing ConversationPanel interactions and Stop recovery -> `npm test -- src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx` -> passed (112/112).
- Workspace owner/contract consumers -> `npm run test:module -- workspace_page` -> passed (25 files, 459 tests).
- Renderer types -> `npm run typecheck:web` -> passed.
- Lint -> `npm run lint` -> passed.

The behavior, module, and type checks ran after the last material edit. The targeted regression and lint were rerun after the final formatting-only edit. Per maintainer direction, the complete local `npm test` suite was not run; PR CI is authoritative. No manual E2E was run because the deterministic component interaction test exercises the actual mounted A-to-B rerender and async completion path.

## Review focus

- Session-id ownership of pending/error completion callbacks.
- Independent duplicate prevention when A and B have concurrent Stop attempts.
- Successful attempts remove their transient entry; failed attempts remain visible only when their originating Session is active.