### PR TITLE
fix(storage): handle legacy move prompt failures

### DIFF
--- a/src/main/storage/command-owner.ts
+++ b/src/main/storage/command-owner.ts
@@ -195,6 +195,7 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
       await deps.settingsService.dismissLegacyDataMovePrompt()
     } catch (err) {
       logger.warn('legacy move prompt dismissal failed', diagnosticErrorFields(err))
+      throw err
     }
   }
 

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -403,6 +403,18 @@ describe('storage IPC handlers', () => {
     expect(deps.settingsService.dismissLegacyDataMovePrompt).toHaveBeenCalledTimes(1)
   })
 
+  it('reports a legacy-move prompt dismissal persistence failure to the renderer', async () => {
+    const deps = fakeDeps()
+    vi.mocked(deps.settingsService.dismissLegacyDataMovePrompt).mockRejectedValue(
+      new Error('settings write failed')
+    )
+    registerStorageIpcHandlers(deps)
+
+    await expect(invoke('storage:dismiss-legacy-move-prompt')).rejects.toThrow(
+      'settings write failed'
+    )
+  })
+
   it('get-info reports isDefault false and real usage/availableBytes for a relocated data root', async () => {
     initDataRoot(dataRoot)
     registerStorageIpcHandlers(fakeDeps())

--- a/src/renderer/src/components/LegacyDataMoveDialog.render.test.tsx
+++ b/src/renderer/src/components/LegacyDataMoveDialog.render.test.tsx
@@ -247,6 +247,60 @@ describe('LegacyDataMoveDialog', () => {
     expect(moveButton?.disabled).toBe(false)
   })
 
+  it('does not remain stuck resolving when the default destination inspection fails', async () => {
+    const api = installApi({
+      inspectDataRoot: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('inspection unavailable'))
+        .mockResolvedValueOnce({ kind: 'move', dataRoot: '/home/u/OpenScience' })
+    })
+    await renderDialog()
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).not.toContain('Resolving…')
+    expect(document.body.textContent).toContain('Unavailable')
+    expect(document.body.textContent).toContain('Could not check the data folder. Try again.')
+
+    await act(async () => {
+      clickButton(/^Try again$/)
+      await Promise.resolve()
+    })
+
+    expect(api.inspectDataRoot).toHaveBeenCalledTimes(2)
+    expect(document.body.textContent).toContain('/home/u/OpenScience')
+  })
+
+  it('does not dismiss the prompt when persisting the keep-here choice fails', async () => {
+    const api = installApi({
+      dismissLegacyMovePrompt: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('settings write failed'))
+        .mockResolvedValueOnce(undefined)
+    })
+    const onDismiss = vi.fn()
+    await renderDialog(onDismiss)
+
+    await act(async () => {
+      clickButton(/Keep it in the current/)
+      await Promise.resolve()
+    })
+
+    expect(api.dismissLegacyMovePrompt).toHaveBeenCalledTimes(1)
+    expect(onDismiss).not.toHaveBeenCalled()
+    expect(document.body.textContent).toContain('Could not save changes.')
+
+    await act(async () => {
+      clickButton(/Keep it in the current/)
+      await Promise.resolve()
+    })
+
+    expect(api.dismissLegacyMovePrompt).toHaveBeenCalledTimes(2)
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
   it('offers discard-only recovery for an interrupted chosen-folder copy', async () => {
     const api = installApi({
       pickDirectory: vi.fn().mockResolvedValue('/mnt/interrupted'),
@@ -292,5 +346,27 @@ describe('LegacyDataMoveDialog', () => {
     expect(document.body.textContent).toContain('Nope.')
     // An invalid pick must not start a migration.
     expect(api.detectActive).not.toHaveBeenCalled()
+  })
+
+  it('reports a chosen-folder inspection failure and re-enables every action', async () => {
+    installApi({
+      pickDirectory: vi.fn().mockResolvedValue('/mnt/unavailable'),
+      inspectDataRoot: vi
+        .fn()
+        .mockResolvedValueOnce({ kind: 'move', dataRoot: '/home/u/OpenScience' })
+        .mockRejectedValueOnce(new Error('inspection unavailable'))
+    })
+    await renderDialog()
+
+    await act(async () => {
+      clickButton(/Choose another folder/)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).toContain('Could not check the data folder. Try again.')
+    const buttons = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+    expect(buttons).toHaveLength(3)
+    expect(buttons.every((button) => !button.disabled)).toBe(true)
   })
 })

--- a/src/renderer/src/components/LegacyDataMoveDialog.tsx
+++ b/src/renderer/src/components/LegacyDataMoveDialog.tsx
@@ -1,6 +1,6 @@
 import { AlertDialog } from 'radix-ui'
-import { FolderInput, FolderOpen } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { FolderInput, FolderOpen, RefreshCw } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
@@ -56,32 +56,54 @@ const LegacyDataMoveDialog = ({
   >(undefined)
   const defaultInspection =
     defaultInspectionState?.parent === defaultParent ? defaultInspectionState.result : undefined
-  const [pickError, setPickError] = useState<string | undefined>(undefined)
+  const defaultInspectionRequestId = useRef(0)
+  const [defaultInspectionError, setDefaultInspectionError] = useState<string | undefined>(
+    undefined
+  )
+  const defaultInspectionFailed = defaultInspectionError !== undefined
+  const [operationError, setOperationError] = useState<string | undefined>(undefined)
   const [isPicking, setIsPicking] = useState(false)
+  const [isDismissing, setIsDismissing] = useState(false)
+
+  const requestDefaultInspection = useCallback((): void => {
+    const requestId = ++defaultInspectionRequestId.current
+    void window.api.storage.inspectDataRoot(defaultParent).then(
+      (result) => {
+        if (defaultInspectionRequestId.current !== requestId) return
+        setDefaultInspectionState({ parent: defaultParent, result })
+        setDefaultInspectionError(undefined)
+      },
+      () => {
+        if (defaultInspectionRequestId.current !== requestId) return
+        setDefaultInspectionError(t('Could not check the data folder. Try again.'))
+      }
+    )
+  }, [defaultParent, t])
 
   useEffect(() => {
-    void window.api.storage.inspectDataRoot(defaultParent).then((result) => {
-      setDefaultInspectionState({ parent: defaultParent, result })
-    })
-  }, [defaultParent])
+    requestDefaultInspection()
+    return () => {
+      defaultInspectionRequestId.current += 1
+    }
+  }, [requestDefaultInspection])
 
-  const refreshDefaultDestination = (): void => {
+  const refreshDefaultInspection = (): void => {
     setDefaultInspectionState(undefined)
-    void window.api.storage.inspectDataRoot(defaultParent).then((result) => {
-      setDefaultInspectionState({ parent: defaultParent, result })
-    })
+    setDefaultInspectionError(undefined)
+    setOperationError(undefined)
+    requestDefaultInspection()
   }
 
   const handleMigrationClose = (): void => {
     const resolvedTarget = migrationTarget
     setMigrationTarget(null)
     if (resolvedTarget?.path === defaultParent) {
-      refreshDefaultDestination()
+      refreshDefaultInspection()
     }
   }
 
   const handleMoveToDefault = (): void => {
-    setPickError(undefined)
+    setOperationError(undefined)
     if (!defaultInspection) return
     if (defaultInspection.kind === 'move' || defaultInspection.kind === 'recover') {
       setMigrationTarget({
@@ -91,7 +113,7 @@ const LegacyDataMoveDialog = ({
       })
       return
     }
-    setPickError(
+    setOperationError(
       defaultInspection.kind === 'adopt'
         ? t(
             'That folder already contains Open Science data. Pick an empty folder, or use the default location.'
@@ -101,12 +123,12 @@ const LegacyDataMoveDialog = ({
   }
 
   const handleChooseFolder = async (): Promise<void> => {
-    setPickError(undefined)
-    const picked = await window.api.storage.pickDirectory()
-    if (!picked) return
-
+    setOperationError(undefined)
     setIsPicking(true)
     try {
+      const picked = await window.api.storage.pickDirectory()
+      if (!picked) return
+
       const inspection = await window.api.storage.inspectDataRoot(picked)
       if (inspection.kind === 'move' || inspection.kind === 'recover') {
         setMigrationTarget({
@@ -118,20 +140,32 @@ const LegacyDataMoveDialog = ({
       // This prompt moves data into a fresh location or resumes the same interrupted move. An
       // 'adopt' target (already holds unrelated data) would mean abandoning the legacy data, which
       // isn't what "move it out" should do here.
-      setPickError(
+      setOperationError(
         inspection.kind === 'adopt'
           ? t(
               'That folder already contains Open Science data. Pick an empty folder, or use the default location.'
             )
           : (inspection.error ?? t('That folder can’t be used. Pick another one.'))
       )
+    } catch {
+      setOperationError(t('Could not check the data folder. Try again.'))
     } finally {
       setIsPicking(false)
     }
   }
 
-  const handleKeepHere = (): void => {
-    void window.api.storage.dismissLegacyMovePrompt().finally(() => onDismiss())
+  const handleKeepHere = async (): Promise<void> => {
+    setOperationError(undefined)
+    setIsDismissing(true)
+    try {
+      await window.api.storage.dismissLegacyMovePrompt()
+    } catch {
+      setOperationError(t('Could not save changes.'))
+      setIsDismissing(false)
+      return
+    }
+    setIsDismissing(false)
+    onDismiss()
   }
 
   // Accepted a move: the shared modal drives detect → copy → Restart/Keep. Cancelling it returns here.
@@ -180,13 +214,14 @@ const LegacyDataMoveDialog = ({
                 className="mt-1 overflow-x-auto whitespace-pre-wrap break-all rounded-lg border border-border-200 bg-bg-10 px-2.5 py-1.5 font-mono text-xs text-text-000"
                 aria-label={t('New data location')}
               >
-                {defaultInspection?.dataRoot ?? t('Resolving…')}
+                {defaultInspection?.dataRoot ??
+                  (defaultInspectionFailed ? t('Unavailable') : t('Resolving…'))}
               </pre>
             </div>
 
-            {pickError ? (
+            {(operationError ?? defaultInspectionError) ? (
               <p className="text-xs text-destructive" role="alert">
-                {pickError}
+                {operationError ?? defaultInspectionError}
               </p>
             ) : null}
           </div>
@@ -194,26 +229,37 @@ const LegacyDataMoveDialog = ({
           <div className={cn(dialogFooterClassName, 'flex-col items-stretch')}>
             <Button
               type="button"
-              disabled={isPicking || defaultInspection === undefined}
-              onClick={handleMoveToDefault}
+              disabled={
+                isPicking ||
+                isDismissing ||
+                (!defaultInspectionFailed && defaultInspection === undefined)
+              }
+              onClick={defaultInspectionFailed ? refreshDefaultInspection : handleMoveToDefault}
             >
-              <FolderInput aria-hidden="true" />
-              {t('Move to OpenScience')}
+              {defaultInspectionFailed ? (
+                <RefreshCw aria-hidden="true" />
+              ) : (
+                <FolderInput aria-hidden="true" />
+              )}
+              {defaultInspectionFailed ? t('Try again') : t('Move to OpenScience')}
             </Button>
             <Button
               type="button"
               variant="outline"
-              disabled={isPicking}
+              disabled={isPicking || isDismissing}
               onClick={() => void handleChooseFolder()}
             >
               <FolderOpen aria-hidden="true" />
               {isPicking ? t('Checking…') : t('Choose another folder…')}
             </Button>
-            <AlertDialog.Cancel asChild>
-              <Button type="button" variant="ghost" disabled={isPicking} onClick={handleKeepHere}>
-                {t('Keep it in the current folder')}
-              </Button>
-            </AlertDialog.Cancel>
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={isPicking || isDismissing}
+              onClick={() => void handleKeepHere()}
+            >
+              {isDismissing ? t('Saving…') : t('Keep it in the current folder')}
+            </Button>
             <p className="text-xs text-muted-foreground">
               {t(
                 "You can always change this later in Settings → Data location. We won't ask again."


### PR DESCRIPTION
## Problem

The legacy data move prompt had two incomplete failure paths:

- a rejected destination inspection left the dialog on `Resolving…` and produced an unhandled rejection;
- a failed dismissal write was swallowed by the storage command, while the renderer called `onDismiss` from `finally`, so the UI claimed success without persisting `legacyDataMovePromptDismissedAt`.

## Proposed change

- Propagate legacy prompt dismissal persistence failures through the existing `Promise<void>` command contract.
- Await dismissal in the renderer and close only after the settings write succeeds.
- Keep the dialog open, re-enable its actions, and show an inline error when dismissal fails.
- Catch rejected default and chosen-folder inspections, replace the indefinite resolving state with an unavailable/retry state, and ignore stale inspection completions.
- Reuse existing translated copy in all four renderer locales.

## Scope and non-goals

- No database or settings schema changes.
- No new persisted fields, enums, or data-model changes.
- No migration or legacy-data rewrite. Existing successful dismissal timestamps remain unchanged; a previously failed write has no timestamp and can be retried when the prompt appears again.
- No changes to the successful data-move flow.

## Acceptance criteria and validation

All listed checks ran after the final material edit:

- inspection rejection exits `Resolving…`, exposes retry, and chosen-folder rejection restores actions -> `npm test -- src/renderer/src/components/LegacyDataMoveDialog.render.test.tsx` -> 12 passed
- dismissal persistence failure reaches the renderer -> `npm test -- src/main/storage/ipc.test.ts -t "dismiss-legacy-move-prompt|reports a legacy-move prompt dismissal persistence failure"` -> 2 passed
- all renderer-visible copy remains covered in every locale -> `npm test -- src/renderer/src/i18n/resources.test.ts` -> 278 passed
- main-process contract -> `npm run typecheck:node` -> passed
- renderer state and API usage -> `npm run typecheck:web` -> passed
- linted source and tests -> `npm run lint` -> passed

The full portable suite and platform/package lanes were not run locally; PR Gate remains authoritative for those checks.

## Review focus

- The storage owner now logs and rethrows the settings write failure instead of reporting false success.
- The dialog closes only after durable dismissal succeeds and remains retryable on every rejected inspection path.
