### PR TITLE
feat(cli): manage project agent context

### DIFF
--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -111,12 +111,36 @@ the Debian package or a host configuration that supports Chromium sandboxing is 
 Create a project and list the projects available to task runs:
 
 ```bash
-open-science project create "Systematic review" --description "Evidence review workspace" --json
+open-science project create "Systematic review" \
+  --description "Evidence review workspace" \
+  --agent-context-file ./agent-context.md \
+  --json
 open-science project list --json
 ```
 
 Commands that accept `--project` allow either a project ID or an exact project name. The CLI resolves
 a unique display name to its ID before calling the Task API; use the ID when names are duplicated.
+
+Project Agent Context contains persistent instructions that are added when Open Science sets up an
+agent Session. Supply it directly with `--agent-context <text>` or read multiline instructions from a
+strict UTF-8 file with `--agent-context-file <path>`; the two options are mutually exclusive. The
+existing 16,000-character limit applies to both forms.
+
+Update Project metadata or replace its Agent Context later using an ID or exact name:
+
+```bash
+open-science project update "Systematic review" \
+  --description "Updated evidence review workspace" \
+  --agent-context-file ./revised-agent-context.md \
+  --json
+
+open-science project update <project-id> --clear-agent-context --json
+```
+
+`--clear-agent-context` is explicit so an omitted option keeps the existing value. An update affects
+newly created Sessions and provider Sessions that are set up again after the update. It does not
+rebuild an already attached Session. Project list, create, and update output reports only the boolean
+`hasAgentContext`; Agent Context contents are not returned through the public Task API or CLI output.
 
 ## Run a task
 

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -30,7 +30,8 @@ Commands:
   url         Print the authenticated web URL
   codex login [--force]
   project list
-  project create <name> [--description <text>]
+  project create <name> [--description <text>] [--agent-context <text> | --agent-context-file <path>]
+  project update <id-or-name> [--name <name>] [--description <text>] [--agent-context <text> | --agent-context-file <path> | --clear-agent-context]
   run --project <id-or-name> (--prompt <text> | --prompt-file <path>) [--wait]
   run status <run-id>
   run cancel <run-id>
@@ -53,6 +54,9 @@ Options:
   --cwd <path>           Working directory for a new or matching existing session
   --prompt <text>        Prompt text (or read stdin when omitted)
   --prompt-file <path>   Read the prompt from a UTF-8 file
+  --agent-context <text> Persistent Project Agent Context
+  --agent-context-file <path>  Read Project Agent Context from a UTF-8 file
+  --clear-agent-context  Clear a Project's persistent Agent Context
   --approval-profile <profile>  ask, auto, or full (default: ask)
   --skill <id>           Force-load a skill for this run (repeatable)
   --plan-first           Require an approved Plan before execution
@@ -92,7 +96,10 @@ const VALUE_OPTIONS = {
   '--revision': 'revision',
   '--feedback': 'feedback',
   '--timeout-ms': 'timeoutMs',
+  '--name': 'name',
   '--description': 'description',
+  '--agent-context': 'agentContext',
+  '--agent-context-file': 'agentContextFile',
   '--output': 'output'
 }
 
@@ -145,6 +152,7 @@ export const parseCliArgs = (argv) => {
       }
       options.autoReviewEnabled = false
     } else if (arg === '--cancel-on-timeout') options.cancelOnTimeout = true
+    else if (arg === '--clear-agent-context') options.clearAgentContext = true
     else if (arg === '--skill') {
       const value = args.shift()
       if (!value) throw new CliUsageError('--skill requires a value.')
@@ -219,6 +227,39 @@ export const parseCliArgs = (argv) => {
   }
   if (options.force && (command !== 'codex' || subcommand !== 'login')) {
     throw new CliUsageError('--force requires codex login.')
+  }
+  const isProjectCreate = command === 'project' && subcommand === 'create'
+  const isProjectUpdate = command === 'project' && subcommand === 'update'
+  const agentContextSources = [
+    options.agentContext !== undefined,
+    options.agentContextFile !== undefined,
+    options.clearAgentContext === true
+  ].filter(Boolean)
+  if (agentContextSources.length > 1) {
+    throw new CliUsageError('Use only one Agent Context source.')
+  }
+  if (agentContextSources.length > 0 && !isProjectCreate && !isProjectUpdate) {
+    throw new CliUsageError('Agent Context options require project create or project update.')
+  }
+  if (options.clearAgentContext && !isProjectUpdate) {
+    throw new CliUsageError('--clear-agent-context requires project update.')
+  }
+  if (options.name !== undefined && !isProjectUpdate) {
+    throw new CliUsageError('--name requires project update.')
+  }
+  if (options.name !== undefined && !options.name.trim()) {
+    throw new CliUsageError('--name requires a non-empty value.')
+  }
+  if (options.description !== undefined && !isProjectCreate && !isProjectUpdate) {
+    throw new CliUsageError('--description requires project create or project update.')
+  }
+  if (options.agentContext !== undefined) {
+    const context = options.agentContext.trim()
+    if (!context) throw new CliUsageError('Agent Context must not be empty.')
+    if (context.length > 16_000) {
+      throw new CliUsageError('Agent Context must not exceed 16000 characters.')
+    }
+    options.agentContext = context
   }
   if (command === 'codex' && subcommand === 'login') {
     if (options.json || options.jsonl) {
@@ -633,6 +674,7 @@ const writeDownload = async (response, output) => {
 const TASK_DEPS = {
   connect: (options) => connectToOpenScience(options),
   readFile: (path) => readFile(path, 'utf8'),
+  readBinaryFile: (path) => readFile(path),
   readStdin: () => readFile(0, 'utf8'),
   writeDownload,
   log: (...args) => console.log(...args),
@@ -702,17 +744,49 @@ const readPrompt = async (options, deps) => {
   return (await deps.readStdin()).trim()
 }
 
-const resolveCliProjectId = async (client, selector) => {
+const validateAgentContext = (value) => {
+  const context = value.trim()
+  if (!context) throw new CliUsageError('Agent Context must not be empty.')
+  if (context.length > 16_000) {
+    throw new CliUsageError('Agent Context must not exceed 16000 characters.')
+  }
+  return context
+}
+
+const readAgentContext = async (options, deps) => {
+  if (options.clearAgentContext) return ''
+  if (options.agentContext !== undefined) return validateAgentContext(options.agentContext)
+  if (options.agentContextFile === undefined) return undefined
+  let decoded
+  try {
+    const bytes = await deps.readBinaryFile(options.agentContextFile)
+    decoded = new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      throw new CliUsageError(`Agent Context file not found: ${options.agentContextFile}`)
+    }
+    if (error instanceof TypeError) {
+      throw new CliUsageError('Agent Context file must contain valid UTF-8 text.')
+    }
+    throw error
+  }
+  return validateAgentContext(decoded)
+}
+
+const resolveCliProject = async (client, selector) => {
   const projects = await client.listProjects()
   const byId = projects.find((project) => project.id === selector)
-  if (byId) return byId.id
+  if (byId) return byId
   const byName = projects.filter((project) => project.name === selector)
-  if (byName.length === 1) return byName[0].id
+  if (byName.length === 1) return byName[0]
   if (byName.length > 1) {
     throw new CliUsageError(`Project name is ambiguous: ${selector}. Use a project ID.`)
   }
   throw new OpenScienceApiError(`Project not found: ${selector}`, { code: 'project_not_found' })
 }
+
+const resolveCliProjectId = async (client, selector) =>
+  (await resolveCliProject(client, selector)).id
 
 const emitRunEvent = (event, options, deps) => {
   if (options.jsonl) {
@@ -779,8 +853,37 @@ export const runTaskCommand = async (parsed, dependencies = {}) => {
   if (command === 'project' && subcommand === 'create') {
     const name = positionals.join(' ').trim()
     if (!name) throw new CliUsageError('Project name is required.')
+    const agentContext = await readAgentContext(options, deps)
     outputValue(
-      await client.createProject({ name, description: options.description }),
+      await client.createProject({
+        name,
+        description: options.description,
+        ...(agentContext === undefined ? {} : { agentContext })
+      }),
+      options,
+      deps
+    )
+    return
+  }
+  if (command === 'project' && subcommand === 'update') {
+    const selector = positionals.join(' ').trim()
+    if (!selector) throw new CliUsageError('Project id or name is required.')
+    const agentContext = await readAgentContext(options, deps)
+    if (
+      options.name === undefined &&
+      options.description === undefined &&
+      agentContext === undefined
+    ) {
+      throw new CliUsageError('Project update requires at least one field.')
+    }
+    const project = await resolveCliProject(client, selector)
+    outputValue(
+      await client.updateProject(project.id, {
+        expectedUpdatedAt: project.updatedAt,
+        ...(options.name === undefined ? {} : { name: options.name }),
+        ...(options.description === undefined ? {} : { description: options.description }),
+        ...(agentContext === undefined ? {} : { agentContext })
+      }),
       options,
       deps
     )

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -30,6 +30,41 @@ const listProjects = async (): Promise<Array<{ id: string; name: string }>> => [
 describe('task CLI', () => {
   it('parses the first milestone run interface', () => {
     expect(
+      parseCliArgs(['project', 'create', 'Research', '--agent-context', 'Always cite sources.'])
+    ).toMatchObject({
+      command: 'project',
+      subcommand: 'create',
+      options: { agentContext: 'Always cite sources.' }
+    })
+    expect(
+      parseCliArgs([
+        'project',
+        'update',
+        'Research',
+        '--name',
+        'Evidence review',
+        '--clear-agent-context'
+      ])
+    ).toMatchObject({
+      command: 'project',
+      subcommand: 'update',
+      options: { name: 'Evidence review', clearAgentContext: true }
+    })
+    expect(() =>
+      parseCliArgs([
+        'project',
+        'create',
+        'Research',
+        '--agent-context',
+        'Inline',
+        '--agent-context-file',
+        'context.md'
+      ])
+    ).toThrow('Use only one Agent Context source.')
+    expect(() =>
+      parseCliArgs(['project', 'create', 'Research', '--agent-context', 'x'.repeat(16_001)])
+    ).toThrow('Agent Context must not exceed 16000 characters.')
+    expect(
       parseCliArgs([
         'run',
         '--project',
@@ -664,6 +699,130 @@ describe('task CLI', () => {
       }
     }
   )
+
+  it('creates, updates, and clears persistent Project Agent Context without printing it', async () => {
+    const projects = [
+      {
+        id: 'project-1',
+        name: 'Research',
+        description: '',
+        updatedAt: 7,
+        hasAgentContext: false
+      }
+    ]
+    const client = {
+      listProjects: vi.fn().mockResolvedValue(projects),
+      createProject: vi.fn().mockResolvedValue({
+        ...projects[0],
+        id: 'project-2',
+        hasAgentContext: true
+      }),
+      updateProject: vi.fn().mockResolvedValue({ ...projects[0], hasAgentContext: true })
+    }
+    const log = vi.fn()
+    const dependencies = {
+      connect: vi.fn().mockResolvedValue(client),
+      readBinaryFile: vi.fn().mockResolvedValue(new TextEncoder().encode('Prefer Python.\n')),
+      log,
+      stdinIsTTY: true
+    }
+
+    await runTaskCommand(
+      {
+        command: 'project',
+        subcommand: 'create',
+        positionals: ['Created'],
+        options: {
+          agentContext: 'Always cite sources.',
+          json: true,
+          jsonl: false
+        }
+      },
+      dependencies
+    )
+    await runTaskCommand(
+      {
+        command: 'project',
+        subcommand: 'update',
+        positionals: ['Research'],
+        options: {
+          agentContextFile: 'context.md',
+          json: true,
+          jsonl: false
+        }
+      },
+      dependencies
+    )
+    await runTaskCommand(
+      {
+        command: 'project',
+        subcommand: 'update',
+        positionals: ['project-1'],
+        options: {
+          clearAgentContext: true,
+          json: true,
+          jsonl: false
+        }
+      },
+      dependencies
+    )
+
+    expect(client.createProject).toHaveBeenCalledWith({
+      name: 'Created',
+      description: undefined,
+      agentContext: 'Always cite sources.'
+    })
+    expect(client.updateProject).toHaveBeenNthCalledWith(1, 'project-1', {
+      expectedUpdatedAt: 7,
+      agentContext: 'Prefer Python.'
+    })
+    expect(client.updateProject).toHaveBeenNthCalledWith(2, 'project-1', {
+      expectedUpdatedAt: 7,
+      agentContext: ''
+    })
+    expect(JSON.stringify(log.mock.calls)).not.toContain('Always cite sources.')
+    expect(JSON.stringify(log.mock.calls)).not.toContain('Prefer Python.')
+  })
+
+  it('rejects invalid Agent Context files before mutating a Project', async () => {
+    const client = {
+      listProjects: vi
+        .fn()
+        .mockResolvedValue([
+          { id: 'project-1', name: 'Research', updatedAt: 7, hasAgentContext: false }
+        ]),
+      updateProject: vi.fn()
+    }
+    const readBinaryFile = vi
+      .fn()
+      .mockResolvedValueOnce(Uint8Array.from([0xc3, 0x28]))
+      .mockResolvedValueOnce(new TextEncoder().encode('  \n'))
+      .mockResolvedValueOnce(new TextEncoder().encode('x'.repeat(16_001)))
+    const dependencies = {
+      connect: vi.fn().mockResolvedValue(client),
+      readBinaryFile,
+      stdinIsTTY: true
+    }
+    const updateFrom = (agentContextFile: string): Promise<void> =>
+      runTaskCommand(
+        {
+          command: 'project',
+          subcommand: 'update',
+          positionals: ['Research'],
+          options: { agentContextFile, json: true, jsonl: false }
+        },
+        dependencies
+      )
+
+    await expect(updateFrom('invalid.md')).rejects.toThrow(
+      'Agent Context file must contain valid UTF-8 text.'
+    )
+    await expect(updateFrom('empty.md')).rejects.toThrow('Agent Context must not be empty.')
+    await expect(updateFrom('oversized.md')).rejects.toThrow(
+      'Agent Context must not exceed 16000 characters.'
+    )
+    expect(client.updateProject).not.toHaveBeenCalled()
+  })
 
   it('dispatches Plan show, decision, and revision feedback through the SDK', async () => {
     const client = {

--- a/packages/open-science/client.test.ts
+++ b/packages/open-science/client.test.ts
@@ -27,6 +27,7 @@ describe('OpenScienceClient', () => {
         'health',
         'listProjects',
         'createProject',
+        'updateProject',
         'listSessions',
         'getSession',
         'getSessionPlan',
@@ -284,6 +285,11 @@ describe('OpenScienceClient', () => {
       if (path === '/api/v1/projects' && init?.method === 'POST') {
         return response(201, { data: { id: 'project-1', name: 'Created' } })
       }
+      if (path === '/api/v1/projects/project%2F1' && init?.method === 'PATCH') {
+        return response(200, {
+          data: { id: 'project-1', name: 'Created', hasAgentContext: true }
+        })
+      }
       if (path === '/api/v1/projects') return response(200, { data: [] })
       if (path === '/api/v1/sessions') return response(200, { data: [] })
       if (path === '/api/v1/sessions/session%2F1') {
@@ -310,7 +316,11 @@ describe('OpenScienceClient', () => {
     })
 
     await client.listProjects()
-    await client.createProject({ name: 'Created' })
+    await client.createProject({ name: 'Created', agentContext: 'Always cite sources.' })
+    await client.updateProject('project/1', {
+      expectedUpdatedAt: 7,
+      agentContext: 'Prefer Python.'
+    })
     await client.listSessions('project-1')
     await client.getSession('session/1')
     await client.getSessionPlan('session/1')
@@ -325,11 +335,18 @@ describe('OpenScienceClient', () => {
     for (const call of fetch.mock.calls) {
       expect(call[1]?.headers).toMatchObject({ authorization: 'Bearer token-1' })
     }
+    expect(fetch.mock.calls[1]?.[1]?.body).toBe(
+      JSON.stringify({ name: 'Created', agentContext: 'Always cite sources.' })
+    )
+    expect(fetch.mock.calls[2]?.[1]?.body).toBe(
+      JSON.stringify({ expectedUpdatedAt: 7, agentContext: 'Prefer Python.' })
+    )
     expect(
       fetch.mock.calls.map(([input]) => new URL(input).pathname + new URL(input).search)
     ).toEqual([
       '/api/v1/projects',
       '/api/v1/projects',
+      '/api/v1/projects/project%2F1',
       '/api/v1/sessions?project=project-1',
       '/api/v1/sessions/session%2F1',
       '/api/v1/sessions/session%2F1/plan',

--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -26,6 +26,7 @@ export type Project = {
   id: string
   name: string
   description: string
+  hasAgentContext: boolean
   isExample: boolean
   createdAt: number
   updatedAt: number
@@ -160,7 +161,20 @@ export class OpenScienceClient {
   })
   health(): Promise<unknown>
   listProjects(): Promise<Project[]>
-  createProject(request: { name: string; description?: string }): Promise<Project>
+  createProject(request: {
+    name: string
+    description?: string
+    agentContext?: string
+  }): Promise<Project>
+  updateProject(
+    projectId: string,
+    request: {
+      expectedUpdatedAt: number
+      name?: string
+      description?: string
+      agentContext?: string
+    }
+  ): Promise<Project>
   listSessions(projectId?: string): Promise<Session[]>
   getSession(sessionId: string): Promise<Session>
   getSessionPlan(sessionId: string): Promise<SessionPlan | null>

--- a/packages/open-science/index.mjs
+++ b/packages/open-science/index.mjs
@@ -42,10 +42,21 @@ export class OpenScienceClient {
     return this.request('/api/v1/projects')
   }
 
-  createProject({ name, description }) {
+  createProject({ name, description, agentContext }) {
     return this.request('/api/v1/projects', {
       method: 'POST',
-      body: { name, ...(description === undefined ? {} : { description }) }
+      body: {
+        name,
+        ...(description === undefined ? {} : { description }),
+        ...(agentContext === undefined ? {} : { agentContext })
+      }
+    })
+  }
+
+  updateProject(projectId, request) {
+    return this.request(`/api/v1/projects/${encodeURIComponent(projectId)}`, {
+      method: 'PATCH',
+      body: request
     })
   }
 

--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -252,12 +252,13 @@ describe('application command composition', () => {
     expect(composition.task.commandNames()).not.toContain('reviewer:abort-fix-loop')
   })
 
-  it('exposes only the thirteen Task commands and no transport-wide capability', async () => {
+  it('exposes only the fourteen Task commands and no transport-wide capability', async () => {
     const composition = createApplicationCommandComposition(dependencies())
 
     expect(composition.task.commandNames()).toEqual([
       'projects:list',
       'projects:create',
+      'projects:update',
       'sessions:load-all',
       'sessions:save-session',
       'sessions:set-delegation-policy',

--- a/src/main/application-command-composition.ts
+++ b/src/main/application-command-composition.ts
@@ -134,6 +134,7 @@ const TASK_NATIVE_COMMAND_NAMES = Object.freeze([
 const TASK_COMMAND_NAMES = Object.freeze([
   'projects:list',
   'projects:create',
+  'projects:update',
   'sessions:load-all',
   'sessions:save-session',
   'sessions:set-delegation-policy',

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -111,8 +111,10 @@ describe('TaskRunner', () => {
     await expect(
       runner.updateProject(project.id, {
         expectedUpdatedAt: project.updatedAt,
-        agentContext: 'Prefer Python.'
-      })
+        agentContext: 'Prefer Python.',
+        id: 'project-redirect',
+        pinned: true
+      } as never)
     ).resolves.toEqual({ ...project, updatedAt: 2, hasAgentContext: true })
     expect(update).toHaveBeenCalledWith({
       id: project.id,

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -93,7 +93,43 @@ describe('TaskRunner', () => {
     }
     const runner = createRunner({ projects })
 
-    await expect(runner.listProjects()).resolves.toEqual([project])
+    await expect(runner.listProjects()).resolves.toEqual([{ ...project, hasAgentContext: false }])
+  })
+
+  it('projects and updates Agent Context without exposing its contents', async () => {
+    const contextualProject = { ...project, agentContext: 'Always cite sources.' }
+    const update = vi.fn(async (request) => ({ ...contextualProject, ...request, updatedAt: 2 }))
+    const runner = createRunner({
+      projects: {
+        list: async () => [contextualProject],
+        create: async (request) => ({ ...contextualProject, ...request }),
+        update
+      }
+    })
+
+    await expect(runner.listProjects()).resolves.toEqual([{ ...project, hasAgentContext: true }])
+    await expect(
+      runner.updateProject(project.id, {
+        expectedUpdatedAt: project.updatedAt,
+        agentContext: 'Prefer Python.'
+      })
+    ).resolves.toEqual({ ...project, updatedAt: 2, hasAgentContext: true })
+    expect(update).toHaveBeenCalledWith({
+      id: project.id,
+      expectedUpdatedAt: project.updatedAt,
+      agentContext: 'Prefer Python.'
+    })
+
+    update.mockRejectedValueOnce(new Error('Project changed elsewhere.'))
+    await expect(
+      runner.updateProject(project.id, {
+        expectedUpdatedAt: project.updatedAt,
+        agentContext: ''
+      })
+    ).rejects.toMatchObject({
+      code: 'project_conflict',
+      message: 'Project changed elsewhere. Refresh it and try again.'
+    })
   })
 
   it('rejects an empty project name before creating a project', async () => {

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -16,7 +16,12 @@ import type {
 import { ARTIFACT_OWNERSHIP_PERSISTENCE_RACE, artifactCreatedAtMs } from '../../shared/artifacts'
 import { DEFAULT_PERMISSION_PROFILE } from '../../shared/permission-profiles'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
-import type { Project } from '../../shared/projects'
+import {
+  PROJECT_DESCRIPTION_MAX_LENGTH,
+  PROJECT_NAME_MAX_LENGTH,
+  type Project,
+  type UpdateProjectRequest
+} from '../../shared/projects'
 import type { AgentFrameworkId } from '../../shared/settings'
 import type {
   DelegationPolicy,
@@ -28,23 +33,22 @@ import type {
 } from '../../shared/session-persistence'
 import type {
   AcquiredTaskArtifact,
+  CreateTaskProjectRequest,
   StartTaskRunRequest,
   TaskApiErrorCode,
+  TaskProject,
   TaskRun,
   TaskRunProgressEvent,
   TaskRunProgressPhase,
   TaskRunReview,
-  TaskSessionSummary
+  TaskSessionSummary,
+  UpdateTaskProjectRequest
 } from '../../shared/task-api'
-
-type CreateTaskProjectRequest = {
-  name: string
-  description?: string
-}
 
 type TaskProjectPort = {
   list(): Promise<Project[]>
   create(request: CreateTaskProjectRequest): Promise<Project>
+  update?(request: UpdateProjectRequest): Promise<Project>
 }
 
 type TaskSessionPort = {
@@ -312,6 +316,18 @@ const summarizeSession = (session: PersistedChatSession): TaskSessionSummary => 
   artifactCount: session.artifacts?.length ?? 0
 })
 
+const projectTaskProjection = (project: Project): TaskProject => ({
+  id: project.id,
+  name: project.name,
+  description: project.description,
+  isExample: project.isExample,
+  ...(project.pinned ? { pinned: true } : {}),
+  ...(project.archivedAt ? { archivedAt: project.archivedAt } : {}),
+  createdAt: project.createdAt,
+  updatedAt: project.updatedAt,
+  hasAgentContext: Boolean(project.agentContext?.trim())
+})
+
 class TaskRunnerError extends Error {
   constructor(
     readonly code: TaskApiErrorCode,
@@ -411,18 +427,104 @@ class TaskRunner {
     return () => this.progressListeners.delete(listener)
   }
 
-  listProjects(): Promise<Project[]> {
-    return this.dependencies.projects.list()
+  async listProjects(): Promise<TaskProject[]> {
+    return (await this.dependencies.projects.list()).map(projectTaskProjection)
   }
 
-  async createProject(request: CreateTaskProjectRequest): Promise<Project> {
+  async createProject(request: CreateTaskProjectRequest): Promise<TaskProject> {
     if (!request || typeof request.name !== 'string' || !request.name.trim()) {
       throw new TaskRunnerError('invalid_request', 'Project name is required.')
+    }
+    if (request.name.length > PROJECT_NAME_MAX_LENGTH) {
+      throw new TaskRunnerError(
+        'invalid_request',
+        `Project name must not exceed ${PROJECT_NAME_MAX_LENGTH} characters.`
+      )
     }
     if (request.description !== undefined && typeof request.description !== 'string') {
       throw new TaskRunnerError('invalid_request', 'Project description must be a string.')
     }
-    return this.dependencies.projects.create(request)
+    if ((request.description?.length ?? 0) > PROJECT_DESCRIPTION_MAX_LENGTH) {
+      throw new TaskRunnerError(
+        'invalid_request',
+        `Project description must not exceed ${PROJECT_DESCRIPTION_MAX_LENGTH} characters.`
+      )
+    }
+    if (request.agentContext !== undefined && typeof request.agentContext !== 'string') {
+      throw new TaskRunnerError('invalid_request', 'Project Agent Context must be a string.')
+    }
+    if ((request.agentContext?.length ?? 0) > 16_000) {
+      throw new TaskRunnerError(
+        'invalid_request',
+        'Project Agent Context must not exceed 16000 characters.'
+      )
+    }
+    return projectTaskProjection(await this.dependencies.projects.create(request))
+  }
+
+  async updateProject(projectId: string, request: UpdateTaskProjectRequest): Promise<TaskProject> {
+    const project = await this.resolveProject(projectId)
+    if (!request || typeof request !== 'object') {
+      throw new TaskRunnerError('invalid_request', 'Project update must be an object.')
+    }
+    if (
+      request.name === undefined &&
+      request.description === undefined &&
+      request.agentContext === undefined
+    ) {
+      throw new TaskRunnerError('invalid_request', 'Project update requires at least one field.')
+    }
+    if (request.name !== undefined) {
+      if (typeof request.name !== 'string' || !request.name.trim()) {
+        throw new TaskRunnerError('invalid_request', 'Project name is required.')
+      }
+      if (request.name.length > PROJECT_NAME_MAX_LENGTH) {
+        throw new TaskRunnerError(
+          'invalid_request',
+          `Project name must not exceed ${PROJECT_NAME_MAX_LENGTH} characters.`
+        )
+      }
+    }
+    if (request.description !== undefined && typeof request.description !== 'string') {
+      throw new TaskRunnerError('invalid_request', 'Project description must be a string.')
+    }
+    if ((request.description?.length ?? 0) > PROJECT_DESCRIPTION_MAX_LENGTH) {
+      throw new TaskRunnerError(
+        'invalid_request',
+        `Project description must not exceed ${PROJECT_DESCRIPTION_MAX_LENGTH} characters.`
+      )
+    }
+    if (request.agentContext !== undefined && typeof request.agentContext !== 'string') {
+      throw new TaskRunnerError('invalid_request', 'Project Agent Context must be a string.')
+    }
+    if ((request.agentContext?.length ?? 0) > 16_000) {
+      throw new TaskRunnerError(
+        'invalid_request',
+        'Project Agent Context must not exceed 16000 characters.'
+      )
+    }
+    if (!Number.isSafeInteger(request.expectedUpdatedAt) || request.expectedUpdatedAt <= 0) {
+      throw new TaskRunnerError('invalid_request', 'Project update timestamp is invalid.')
+    }
+    if (!this.dependencies.projects.update) {
+      throw new Error('Task Project update is unavailable.')
+    }
+    try {
+      return projectTaskProjection(
+        await this.dependencies.projects.update({ id: project.id, ...request })
+      )
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.message === 'Project changed elsewhere.' || error.message === 'Project not found.')
+      ) {
+        throw new TaskRunnerError(
+          'project_conflict',
+          'Project changed elsewhere. Refresh it and try again.'
+        )
+      }
+      throw error
+    }
   }
 
   async listSessions(projectId?: string): Promise<TaskSessionSummary[]> {
@@ -1177,7 +1279,7 @@ class TaskRunner {
   private async resolveProject(projectId: string): Promise<Project> {
     const normalized = typeof projectId === 'string' ? projectId.trim() : ''
     if (!normalized) throw new TaskRunnerError('invalid_request', 'Project id is required.')
-    const projects = await this.listProjects()
+    const projects = await this.dependencies.projects.list()
     const project = projects.find((candidate) => candidate.id === normalized)
     if (project) return project
     throw new TaskRunnerError('project_not_found', `Project not found: ${normalized}`)
@@ -1194,7 +1296,6 @@ class TaskRunner {
 
 export { TaskRunner, TaskRunnerError, summarizeSession }
 export type {
-  CreateTaskProjectRequest,
   TaskAgentCreateSessionRequest,
   TaskAgentPort,
   TaskAgentPromptObserver,

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -510,9 +510,14 @@ class TaskRunner {
       throw new Error('Task Project update is unavailable.')
     }
     try {
-      return projectTaskProjection(
-        await this.dependencies.projects.update({ id: project.id, ...request })
-      )
+      const updateRequest: UpdateProjectRequest = {
+        id: project.id,
+        expectedUpdatedAt: request.expectedUpdatedAt,
+        ...(request.name !== undefined ? { name: request.name } : {}),
+        ...(request.description !== undefined ? { description: request.description } : {}),
+        ...(request.agentContext !== undefined ? { agentContext: request.agentContext } : {})
+      }
+      return projectTaskProjection(await this.dependencies.projects.update(updateRequest))
     } catch (error) {
       if (
         error instanceof Error &&

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -231,6 +231,7 @@ describe('startWebHttpServer', () => {
         subscribeProgress,
         listProjects: vi.fn(),
         createProject: vi.fn(),
+        updateProject: vi.fn(),
         listSessions: vi.fn(),
         getSession: vi.fn(),
         startRun: vi.fn(),
@@ -920,6 +921,7 @@ describe('startWebHttpServer', () => {
       subscribeProgress: () => () => undefined,
       listProjects: vi.fn(),
       createProject: vi.fn(),
+      updateProject: vi.fn(),
       listSessions: vi.fn(),
       getSession: vi.fn(),
       startRun: vi.fn(async () => ({
@@ -1548,8 +1550,15 @@ describe('startWebHttpServer', () => {
           publishProgress = undefined
         }
       }),
-      listProjects: vi.fn().mockResolvedValue([{ id: 'project-1', name: 'Research' }]),
-      createProject: vi.fn().mockResolvedValue({ id: 'project-2', name: 'Created' }),
+      listProjects: vi
+        .fn()
+        .mockResolvedValue([{ id: 'project-1', name: 'Research', hasAgentContext: false }]),
+      createProject: vi
+        .fn()
+        .mockResolvedValue({ id: 'project-2', name: 'Created', hasAgentContext: true }),
+      updateProject: vi
+        .fn()
+        .mockResolvedValue({ id: 'project-1', name: 'Research', hasAgentContext: true }),
       listSessions: vi.fn().mockResolvedValue([{ id: 'session/1', title: 'Review' }]),
       getSession: vi.fn().mockResolvedValue({ id: 'session/1', title: 'Review' }),
       getSessionPlan: vi.fn().mockResolvedValue({
@@ -1653,7 +1662,9 @@ describe('startWebHttpServer', () => {
     expect(projects.status).toBe(200)
     expect(projects.headers.get('content-type')).toBe('application/json; charset=utf-8')
     expect(projects.headers.get('cache-control')).toBe('no-store')
-    expect(await projects.json()).toEqual({ data: [{ id: 'project-1', name: 'Research' }] })
+    expect(await projects.json()).toEqual({
+      data: [{ id: 'project-1', name: 'Research', hasAgentContext: false }]
+    })
     expect(taskContexts[0]).toMatchObject({
       surface: 'task',
       location: 'local',
@@ -1664,13 +1675,34 @@ describe('startWebHttpServer', () => {
     const created = await fetch(`${base}/api/v1/projects`, {
       method: 'POST',
       headers: { ...headers, 'content-type': 'application/json' },
-      body: JSON.stringify({ name: 'Created', description: 'A new project' })
+      body: JSON.stringify({
+        name: 'Created',
+        description: 'A new project',
+        agentContext: 'Always cite sources.'
+      })
     })
     expect(created.status).toBe(201)
-    expect(await created.json()).toEqual({ data: { id: 'project-2', name: 'Created' } })
+    expect(await created.json()).toEqual({
+      data: { id: 'project-2', name: 'Created', hasAgentContext: true }
+    })
     expect(tasks.createProject).toHaveBeenCalledWith({
       name: 'Created',
-      description: 'A new project'
+      description: 'A new project',
+      agentContext: 'Always cite sources.'
+    })
+
+    const updated = await fetch(`${base}/api/v1/projects/project%2F1`, {
+      method: 'PATCH',
+      headers: { ...headers, 'content-type': 'application/json' },
+      body: JSON.stringify({ expectedUpdatedAt: 7, agentContext: 'Prefer Python.' })
+    })
+    expect(updated.status).toBe(200)
+    expect(await updated.json()).toEqual({
+      data: { id: 'project-1', name: 'Research', hasAgentContext: true }
+    })
+    expect(tasks.updateProject).toHaveBeenCalledWith('project/1', {
+      expectedUpdatedAt: 7,
+      agentContext: 'Prefer Python.'
     })
 
     const sessions = await fetch(`${base}/api/v1/sessions?project=project-1`, {
@@ -1876,6 +1908,7 @@ describe('startWebHttpServer', () => {
       subscribeProgress: () => () => undefined,
       listProjects: vi.fn(),
       createProject: vi.fn(),
+      updateProject: vi.fn(),
       listSessions: vi.fn(),
       getSession: vi.fn(),
       startRun: vi.fn(),
@@ -1944,6 +1977,7 @@ describe('startWebHttpServer', () => {
       subscribeProgress: () => () => undefined,
       listProjects: vi.fn(),
       createProject: vi.fn(),
+      updateProject: vi.fn(),
       listSessions: vi.fn(),
       getSession: vi.fn(),
       startRun: vi.fn(),

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -39,7 +39,12 @@ import {
 } from './application-event-projections'
 import { InternalWebEventStream } from './internal-web-event-stream'
 import { authenticateRequest, persistAuthCookie } from './auth'
-import type { StartTaskRunRequest, TaskPlanResponseRequest } from '../../shared/task-api'
+import type {
+  CreateTaskProjectRequest,
+  StartTaskRunRequest,
+  TaskPlanResponseRequest,
+  UpdateTaskProjectRequest
+} from '../../shared/task-api'
 import { TaskApiError, type HeadlessTaskApi } from './task-api'
 
 const MAX_RPC_BODY_BYTES = 64 * 1024 * 1024
@@ -85,6 +90,7 @@ type WebServerOptions = {
     HeadlessTaskApi,
     | 'listProjects'
     | 'createProject'
+    | 'updateProject'
     | 'listSessions'
     | 'getSession'
     | 'startRun'
@@ -219,7 +225,7 @@ const readJsonBody = async (request: IncomingMessage): Promise<unknown> => {
 
 const taskErrorStatus = (error: TaskApiError): number => {
   if (error.code === 'invalid_request') return 400
-  if (error.code === 'session_busy') return 409
+  if (error.code === 'session_busy' || error.code === 'project_conflict') return 409
   return 404
 }
 
@@ -391,10 +397,19 @@ const handleTaskApiRequest = async (
         return true
       }
       if (url.pathname === '/api/v1/projects' && request.method === 'POST') {
-        const body = (await readJsonBody(request)) as { name?: string; description?: string }
+        const body = (await readJsonBody(request)) as CreateTaskProjectRequest
         assertExternalAuthorizationCurrent(externalAuthorization)
         json(response, 201, {
-          data: await tasks.createProject({ name: body.name ?? '', description: body.description })
+          data: await tasks.createProject(body)
+        })
+        return true
+      }
+      const projectMatch = url.pathname.match(/^\/api\/v1\/projects\/([^/]+)$/)
+      if (projectMatch && request.method === 'PATCH') {
+        const body = (await readJsonBody(request)) as UpdateTaskProjectRequest
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, {
+          data: await tasks.updateProject(decodeURIComponent(projectMatch[1]), body)
         })
         return true
       }

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -55,7 +55,9 @@ const commandsFrom = (
 
 describe('HeadlessTaskApi adapter', () => {
   it('dispatches façade operations through the narrow Task command view', async () => {
-    const commandInvoke = vi.fn(async () => [project])
+    const commandInvoke = vi.fn(async () => [
+      { ...project, agentContext: 'Do not expose this instruction.' }
+    ])
     const api = new HeadlessTaskApi({
       commands: {
         commandNames: () => ['projects:list'],
@@ -64,7 +66,9 @@ describe('HeadlessTaskApi adapter', () => {
       agent: createAgent()
     })
 
-    await expect(api.listProjects()).resolves.toEqual([project])
+    const projects = await api.listProjects()
+    expect(projects).toEqual([{ ...project, hasAgentContext: true }])
+    expect(JSON.stringify(projects)).not.toContain('Do not expose this instruction.')
     expect(commandInvoke).toHaveBeenCalledWith(
       'projects:list',
       expect.objectContaining({
@@ -191,6 +195,9 @@ describe('HeadlessTaskApi adapter', () => {
       if (channel === 'projects:create') {
         return { ...project, ...(args[0] as object), id: 'project-created' }
       }
+      if (channel === 'projects:update') {
+        return { ...project, ...(args[0] as object), updatedAt: 3 }
+      }
       if (channel === 'sessions:load-all') {
         return { sessions: [session], manifest: { version: 1 } }
       }
@@ -207,10 +214,19 @@ describe('HeadlessTaskApi adapter', () => {
     })
     const api = new HeadlessTaskApi({ commands: commandsFrom(invoke), agent: createAgent() })
 
-    await expect(api.createProject({ name: 'Created' })).resolves.toMatchObject({
+    await expect(
+      api.createProject({ name: 'Created', agentContext: 'Always cite sources.' })
+    ).resolves.toMatchObject({
       id: 'project-created',
-      name: 'Created'
+      name: 'Created',
+      hasAgentContext: true
     })
+    await expect(
+      api.updateProject(project.id, {
+        expectedUpdatedAt: project.updatedAt,
+        agentContext: 'Prefer Python.'
+      })
+    ).resolves.toMatchObject({ id: project.id, updatedAt: 3, hasAgentContext: true })
     await expect(api.listSessions(project.id)).resolves.toEqual([
       expect.objectContaining({ id: session.id, artifactCount: 1 })
     ])
@@ -231,6 +247,13 @@ describe('HeadlessTaskApi adapter', () => {
     ])
     expect(invoke).toHaveBeenCalledWith('preview-resources:release', taskCallerContext(), [
       { resourceId: 'resource-query' }
+    ])
+    expect(invoke).toHaveBeenCalledWith('projects:update', taskCallerContext(), [
+      {
+        id: project.id,
+        expectedUpdatedAt: project.updatedAt,
+        agentContext: 'Prefer Python.'
+      }
     ])
   })
 

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -12,12 +12,15 @@ import type { ActivePlanProjection, PlanResponseCommand } from '../../shared/ses
 import type { PersistedArtifact, PersistedChatSession } from '../../shared/session-persistence'
 import type {
   AcquiredTaskArtifact,
+  CreateTaskProjectRequest,
   StartTaskRunRequest,
+  TaskProject,
   TaskPlanResponseRequest,
   TaskRun,
   TaskRunProgressEvent,
   TaskRunReview,
-  TaskSessionSummary
+  TaskSessionSummary,
+  UpdateTaskProjectRequest
 } from '../../shared/task-api'
 import { createApplicationCommandClient } from '../application-command-client'
 import type { ApplicationCommandByNameDispatcher } from '../application-command-composition'
@@ -28,7 +31,6 @@ import {
   TaskRunner,
   TaskRunnerError,
   summarizeSession,
-  type CreateTaskProjectRequest,
   type TaskAgentPort,
   type TaskRunnerDependencies
 } from '../tasks/task-runner'
@@ -62,7 +64,8 @@ class HeadlessTaskApi {
     this.runner = new TaskRunner({
       projects: {
         list: () => this.invoke('projects:list') as Promise<Project[]>,
-        create: (request) => this.invoke('projects:create', request) as Promise<Project>
+        create: (request) => this.invoke('projects:create', request) as Promise<Project>,
+        update: (request) => this.invoke('projects:update', request) as Promise<Project>
       },
       sessions: {
         list: async () => {
@@ -143,12 +146,16 @@ class HeadlessTaskApi {
     return this.callerContexts.run(context, operation)
   }
 
-  listProjects(): Promise<Project[]> {
+  listProjects(): Promise<TaskProject[]> {
     return this.runner.listProjects()
   }
 
-  createProject(request: CreateTaskProjectRequest): Promise<Project> {
+  createProject(request: CreateTaskProjectRequest): Promise<TaskProject> {
     return this.runner.createProject(request)
+  }
+
+  updateProject(projectId: string, request: UpdateTaskProjectRequest): Promise<TaskProject> {
+    return this.runner.updateProject(projectId, request)
   }
 
   listSessions(projectId?: string): Promise<TaskSessionSummary[]> {

--- a/src/shared/task-api.ts
+++ b/src/shared/task-api.ts
@@ -1,6 +1,6 @@
 import type { ArtifactFile } from './artifacts'
 import type { PermissionProfileId } from './permission-profiles'
-import type { Project } from './projects'
+import type { CreateProjectRequest, Project, UpdateProjectRequest } from './projects'
 import type { ReviewLifecycle, ReviewOutcome, ReviewRunNotStartedReason } from './reviewer'
 import type { DelegationPolicy, PersistedSessionStatus } from './session-persistence'
 import type { ActivePlanProjection } from './session-plan/contract'
@@ -95,7 +95,19 @@ export type TaskSessionSummary = {
   artifactCount: number
 }
 
-export type TaskProject = Project
+export type TaskProject = Omit<Project, 'agentContext'> & {
+  hasAgentContext: boolean
+}
+
+export type CreateTaskProjectRequest = Pick<
+  CreateProjectRequest,
+  'name' | 'description' | 'agentContext'
+>
+
+export type UpdateTaskProjectRequest = Pick<
+  UpdateProjectRequest,
+  'name' | 'description' | 'agentContext' | 'expectedUpdatedAt'
+>
 
 export type AcquiredTaskArtifact = {
   resourceId: string
@@ -108,6 +120,7 @@ export type AcquiredTaskArtifact = {
 export type TaskApiErrorCode =
   | 'invalid_request'
   | 'project_not_found'
+  | 'project_conflict'
   | 'session_not_found'
   | 'session_busy'
   | 'run_not_found'


### PR DESCRIPTION
## Problem

Project Agent Context is already supported by the Project model, persistence layer, and desktop UI, but headless users cannot set it through the CLI. The CLI also has no Project update command, so persistent context cannot be replaced or cleared after Project creation.

## Proposed change

- Add `--agent-context` and strict UTF-8 `--agent-context-file` inputs to `project create`.
- Add `project update <id-or-name>` for Project name, description, Agent Context replacement, and explicit `--clear-agent-context`.
- Carry create/update requests through the public SDK and HTTP Task API into the existing Project repository, preserving optimistic concurrency through `expectedUpdatedAt`.
- Project public responses now expose `hasAgentContext` while explicitly omitting Agent Context contents.
- Document validation, privacy, and attached-Session behavior.

## Scope and non-goals

This PR implements persistent Project Agent Context only. It does not add per-run temporary context or append/precedence behavior. Updating a Project does not rebuild an already attached provider Session; the new value applies when a new Session is created or a provider Session is set up again.

This is the persistent Project portion of #1442. The run-specific portion remains separate.

## Compatibility, state, and persistence

- Historical data: no migration is required. Existing databases already have the nullable-on-wire / `NOT NULL DEFAULT ''` Agent Context compatibility path, so old Projects continue to mean “no Agent Context”.
- State: no persisted lifecycle/status enum is added. The Task API adds only a `project_conflict` error code, mapped to HTTP 409 for stale optimistic-concurrency updates.
- Persistence: values continue to use the existing SQLite `Project.agentContext` column and repository update path; this PR adds no new store or serialized state.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- CLI parsing, file validation, create/update/clear dispatch, and output privacy -> `npm test -- packages/open-science/cli.test.ts packages/open-science/client.test.ts src/main/tasks/task-runner.test.ts src/main/web-service/task-api.test.ts` -> 4 files, 88 tests passed.
- HTTP create/update routing and public projection -> `npm test -- src/main/web-service/http-server.test.ts` -> 1 file, 20 tests passed.
- Main-process and shared TypeScript contracts -> `npm run typecheck:node` -> passed.
- Source lint and formatting -> `npm run lint` and `git diff --check` -> passed.
- Final affected-test explanation -> `npm run test:affected:explain -- --base origin/main --head HEAD` -> selected full fallback because `packages/open-science/CLI.md` has ambiguous ownership (`cli_sdk`, `documentation`). Per maintainer direction, the complete local `npm test` suite was not run; exact-head PR Gate CI is authoritative.

Uncovered local risk is limited to platform lanes and the classifier-selected full suite, both delegated to PR CI. The changed behavior is otherwise covered at CLI, SDK, Task runner, adapter, HTTP, type, and lint boundaries.

## Review focus

- Confirm the public Project projection cannot return `agentContext` contents.
- Confirm explicit clear versus omitted-value semantics and optimistic concurrency.
- Confirm the attached-Session non-rebuild behavior matches the existing desktop flow.
