### PR TITLE
fix(web-sdk): separate transport and operation lifecycles

### DIFF
--- a/packages/open-science/README.md
+++ b/packages/open-science/README.md
@@ -22,6 +22,12 @@ const result = await client.waitForRun(run.id)
 console.log(result.output)
 ```
 
+SDK requests have a 30-second default deadline that remains active while the response body is being
+consumed. Override the client default with `requestTimeoutMs`, or pass `{ signal, timeoutMs }` as the
+final options argument to an individual request method. `downloadArtifact` keeps the deadline active
+while its returned `Response` body is streaming. `waitForRun` applies its overall `timeoutMs` and
+caller signal to every in-flight polling request as well as the delay between polls.
+
 The `project` request field and the `listSessions(projectId)` argument both require a Project ID.
 Project display names are not accepted as routing identifiers.
 
@@ -59,6 +65,10 @@ abortController.abort()
 await progress
 console.log(observedResult.output)
 ```
+
+`events.ready` rejects if the socket fails or closes before opening. Malformed frames and a consumer
+backlog above 1024 events terminate the iterator with `event_stream_invalid_message` or
+`event_stream_overflow` instead of throwing outside the iterator or growing memory without a bound.
 
 Plan First runs can opt into actionable waiting with returnOnAttention. When the returned Run has
 attention.kind equal to plan-approval, use getSessionPlan and respondSessionPlan. Calling waitForRun

--- a/packages/open-science/README.md
+++ b/packages/open-science/README.md
@@ -38,9 +38,11 @@ use a managed workspace. External working directories remain caller-owned and ar
 Open Science.
 
 For live automation feedback, subscribe before starting the Run. `run.progress` reports ordered
-provider-neutral phases and emits a heartbeat every ten seconds until the first visible provider
-output. The timer starts after Task has prepared the Session and registered its Run; Session
-creation or resume time before registration is outside this event stream:
+provider-neutral phases and emits a progress heartbeat every ten seconds until the first visible
+provider output. This progress heartbeat describes Run activity; it is separate from the filtered
+connection heartbeat that keeps an otherwise-idle WebSocket alive. The timer starts after Task has
+prepared the Session and registered its Run; Session creation or resume time before registration is
+outside this event stream:
 
 ```js
 const abortController = new AbortController()
@@ -66,9 +68,13 @@ await progress
 console.log(observedResult.output)
 ```
 
-`events.ready` rejects if the socket fails or closes before opening. Malformed frames and a consumer
-backlog above 1024 events terminate the iterator with `event_stream_invalid_message` or
-`event_stream_overflow` instead of throwing outside the iterator or growing memory without a bound.
+`events.ready` rejects if the socket fails, closes, or receives no liveness frame before opening.
+After opening, the iterator fails with `timeout` when no event or connection heartbeat arrives for
+30 seconds. Pass `idleTimeoutMs` to change that connection-liveness window; it does not limit model,
+Notebook, permission-approval, or other Run duration. Connection heartbeats are control frames and
+are not yielded to consumers. Malformed frames and a consumer backlog above 1024 events terminate
+the iterator with `event_stream_invalid_message` or `event_stream_overflow` instead of throwing
+outside the iterator or growing memory without a bound.
 
 Plan First runs can opt into actionable waiting with returnOnAttention. When the returned Run has
 attention.kind equal to plan-approval, use getSessionPlan and respondSessionPlan. Calling waitForRun

--- a/packages/open-science/client.test.ts
+++ b/packages/open-science/client.test.ts
@@ -627,6 +627,12 @@ describe('OpenScienceClient', () => {
     })
     const events = client.events({ WebSocket: FakeWebSocket as never })[Symbol.asyncIterator]()
     FakeWebSocket.instance.emit('open')
+    FakeWebSocket.instance.emit('message', {
+      data: JSON.stringify({
+        type: 'connection.heartbeat',
+        data: { timestamp: 100 }
+      })
+    })
     const first = events.next()
     FakeWebSocket.instance.emit('message', {
       data: JSON.stringify(PUBLIC_TERMINAL_FIXTURE)
@@ -683,6 +689,7 @@ describe('OpenScienceClient', () => {
     expect(FakeWebSocket.instance.url.pathname).toBe('/api/v1/events')
     expect(FakeWebSocket.instance.url.searchParams.get('token')).toBe('token-1')
     expect(FakeWebSocket.instance.url.searchParams.get('client')).toMatch(/^sdk-/)
+    expect(FakeWebSocket.instance.url.searchParams.get('liveness')).toBe('1')
     await events.return?.()
     expect(FakeWebSocket.instance.closed).toBe(true)
   })
@@ -701,6 +708,43 @@ describe('OpenScienceClient', () => {
       code: 'event_stream_failed',
       message: 'Open Science event stream failed.'
     })
+  })
+
+  it('fails a ready event iterator when the connection stops receiving liveness frames', async () => {
+    vi.useFakeTimers()
+    try {
+      const client = new OpenScienceClient({
+        baseUrl: 'http://127.0.0.1:44100',
+        token: 'token-1',
+        fetch: vi.fn()
+      })
+      const events = client.events({
+        idleTimeoutMs: 25,
+        WebSocket: ControllableWebSocket as never
+      })
+      const iterator = events[Symbol.asyncIterator]()
+      ControllableWebSocket.instance.emit('open')
+      await events.ready
+      let outcome: unknown = 'still-pending'
+      void iterator.next().then(
+        () => {
+          outcome = 'resolved'
+        },
+        (error: unknown) => {
+          outcome = error
+        }
+      )
+
+      await vi.advanceTimersByTimeAsync(25)
+
+      expect(outcome).toMatchObject({
+        code: 'timeout',
+        message: 'Open Science event stream timed out after 25 milliseconds.'
+      })
+      expect(ControllableWebSocket.instance.closed).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('rejects event readiness when the socket closes before opening', async () => {

--- a/packages/open-science/client.test.ts
+++ b/packages/open-science/client.test.ts
@@ -13,6 +13,31 @@ const response = (status: number, payload: unknown): Response =>
     headers: { 'content-type': 'application/json' }
   })
 
+class ControllableWebSocket {
+  static instance: ControllableWebSocket
+
+  readonly listeners = new Map<string, Array<(event: { data?: string }) => void>>()
+  closed = false
+
+  constructor(readonly url: URL) {
+    ControllableWebSocket.instance = this
+  }
+
+  addEventListener(name: string, listener: (event: { data?: string }) => void): void {
+    this.listeners.set(name, [...(this.listeners.get(name) ?? []), listener])
+  }
+
+  emit(name: string, event: { data?: string } = {}): void {
+    for (const listener of this.listeners.get(name) ?? []) listener(event)
+  }
+
+  close(): void {
+    if (this.closed) return
+    this.closed = true
+    this.emit('close')
+  }
+}
+
 const roots: string[] = []
 
 afterEach(async () => {
@@ -200,6 +225,44 @@ describe('OpenScienceClient', () => {
     }
   })
 
+  it('stops waiting when the timeout expires during an in-flight polling request', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    try {
+      const fetch = vi.fn((_input: string, init?: RequestInit) => {
+        const signal = init?.signal
+        return new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+        })
+      })
+      const client = new OpenScienceClient({
+        baseUrl: 'http://127.0.0.1:44100',
+        token: 'secret-token',
+        fetch
+      })
+      let outcome: unknown = 'still-pending'
+
+      void client.waitForRun('run-1', { timeoutMs: 500 }).then(
+        () => {
+          outcome = 'resolved'
+        },
+        (error: unknown) => {
+          outcome = error
+        }
+      )
+      expect(fetch).toHaveBeenCalledOnce()
+
+      await vi.advanceTimersByTimeAsync(500)
+
+      expect(outcome).toMatchObject({
+        code: 'timeout',
+        message: 'Timed out waiting for run run-1.'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('cancels one run through the explicit server operation', async () => {
     const fetch = vi.fn().mockResolvedValue(
       response(200, {
@@ -259,6 +322,36 @@ describe('OpenScienceClient', () => {
     expect(client).not.toHaveProperty('runtime')
   })
 
+  it('honors caller cancellation while a polling request is in flight', async () => {
+    const fetch = vi.fn((_input: string, init?: RequestInit) => {
+      const signal = init?.signal
+      return new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+      })
+    })
+    const client = new OpenScienceClient({
+      baseUrl: 'http://127.0.0.1:44100',
+      token: 'secret-token',
+      fetch
+    })
+    const abortController = new AbortController()
+    const cancellation = new Error('caller cancelled the in-flight poll')
+    let outcome: unknown = 'still-pending'
+
+    void client.waitForRun('run-1', { signal: abortController.signal }).then(
+      () => {
+        outcome = 'resolved'
+      },
+      (error: unknown) => {
+        outcome = error
+      }
+    )
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce())
+    abortController.abort(cancellation)
+
+    await vi.waitFor(() => expect(outcome).toBe(cancellation))
+  })
+
   it('surfaces stable API errors without including the authentication token', async () => {
     const fetch = vi.fn().mockResolvedValue(
       response(404, {
@@ -277,6 +370,154 @@ describe('OpenScienceClient', () => {
       message: 'Project not found: missing'
     })
     await expect(client.listSessions('missing')).rejects.not.toThrow('do-not-leak')
+  })
+
+  it('applies the client request timeout while an SDK request is in flight', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    try {
+      const fetch = vi.fn((_input: string, init?: RequestInit) => {
+        const signal = init?.signal
+        return new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+        })
+      })
+      const client = new OpenScienceClient({
+        baseUrl: 'http://127.0.0.1:44100',
+        token: 'secret-token',
+        fetch,
+        requestTimeoutMs: 30_000
+      })
+      let outcome: unknown = 'still-pending'
+
+      void client.getRun('run-1').then(
+        () => {
+          outcome = 'resolved'
+        },
+        (error: unknown) => {
+          outcome = error
+        }
+      )
+
+      await vi.advanceTimersByTimeAsync(30_000)
+
+      expect(outcome).toMatchObject({ code: 'timeout' })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps the request timeout active while a JSON response body is being consumed', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    try {
+      const fetch = vi.fn((_input: string, init?: RequestInit) => {
+        const signal = init?.signal
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            new Promise((_resolve, reject) => {
+              signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+            })
+        } as Response)
+      })
+      const client = new OpenScienceClient({
+        baseUrl: 'http://127.0.0.1:44100',
+        token: 'secret-token',
+        fetch,
+        requestTimeoutMs: 30_000
+      })
+      let outcome: unknown = 'still-pending'
+
+      void client.getRun('run-1').then(
+        () => {
+          outcome = 'resolved'
+        },
+        (error: unknown) => {
+          outcome = error
+        }
+      )
+
+      await vi.advanceTimersByTimeAsync(30_000)
+
+      expect(outcome).toMatchObject({ code: 'timeout' })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps the request timeout active while an artifact response body is streaming', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    try {
+      const fetch = vi.fn((_input: string, init?: RequestInit) => {
+        const signal = init?.signal
+        return Promise.resolve(
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                signal?.addEventListener('abort', () => controller.error(signal.reason), {
+                  once: true
+                })
+              }
+            }),
+            { status: 200 }
+          )
+        )
+      })
+      const client = new OpenScienceClient({
+        baseUrl: 'http://127.0.0.1:44100',
+        token: 'secret-token',
+        fetch,
+        requestTimeoutMs: 30_000
+      })
+      const response = await client.downloadArtifact('artifact-1')
+      let outcome: unknown = 'still-pending'
+      void response.text().then(
+        () => {
+          outcome = 'resolved'
+        },
+        (error: unknown) => {
+          outcome = error
+        }
+      )
+
+      await vi.advanceTimersByTimeAsync(30_000)
+
+      expect(outcome).toMatchObject({ code: 'timeout' })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('honors per-request cancellation while an SDK request is in flight', async () => {
+    const fetch = vi.fn((_input: string, init?: RequestInit) => {
+      const signal = init?.signal
+      return new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+      })
+    })
+    const client = new OpenScienceClient({
+      baseUrl: 'http://127.0.0.1:44100',
+      token: 'secret-token',
+      fetch
+    })
+    const abortController = new AbortController()
+    const cancellation = new Error('caller cancelled the SDK request')
+    let outcome: unknown = 'still-pending'
+
+    void client.getRun('run-1', { signal: abortController.signal }).then(
+      () => {
+        outcome = 'resolved'
+      },
+      (error: unknown) => {
+        outcome = error
+      }
+    )
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce())
+    abortController.abort(cancellation)
+
+    await vi.waitFor(() => expect(outcome).toBe(cancellation))
   })
 
   it('covers project, session, artifact, and authenticated download operations', async () => {
@@ -444,6 +685,123 @@ describe('OpenScienceClient', () => {
     expect(FakeWebSocket.instance.url.searchParams.get('client')).toMatch(/^sdk-/)
     await events.return?.()
     expect(FakeWebSocket.instance.closed).toBe(true)
+  })
+
+  it('rejects event readiness when the socket reports a connection error', async () => {
+    const client = new OpenScienceClient({
+      baseUrl: 'http://127.0.0.1:44100',
+      token: 'token-1',
+      fetch: vi.fn()
+    })
+    const events = client.events({ WebSocket: ControllableWebSocket as never })
+
+    ControllableWebSocket.instance.emit('error')
+
+    await expect(events.ready).rejects.toMatchObject({
+      code: 'event_stream_failed',
+      message: 'Open Science event stream failed.'
+    })
+  })
+
+  it('rejects event readiness when the socket closes before opening', async () => {
+    const client = new OpenScienceClient({
+      baseUrl: 'http://127.0.0.1:44100',
+      token: 'token-1',
+      fetch: vi.fn()
+    })
+    const events = client.events({ WebSocket: ControllableWebSocket as never })
+    let outcome: unknown = 'still-pending'
+    void events.ready.then(
+      () => {
+        outcome = 'resolved'
+      },
+      (error: unknown) => {
+        outcome = error
+      }
+    )
+
+    ControllableWebSocket.instance.emit('close')
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(outcome).toMatchObject({ code: 'event_stream_failed' })
+  })
+
+  it('rejects event readiness with the caller reason when cancelled before opening', async () => {
+    const client = new OpenScienceClient({
+      baseUrl: 'http://127.0.0.1:44100',
+      token: 'token-1',
+      fetch: vi.fn()
+    })
+    const abortController = new AbortController()
+    const cancellation = new Error('caller cancelled event setup')
+    const events = client.events({
+      signal: abortController.signal,
+      WebSocket: ControllableWebSocket as never
+    })
+
+    abortController.abort(cancellation)
+
+    await expect(events.ready).rejects.toBe(cancellation)
+    expect(ControllableWebSocket.instance.closed).toBe(true)
+  })
+
+  it('reports malformed event JSON through the async iterator failure channel', async () => {
+    const client = new OpenScienceClient({
+      baseUrl: 'http://127.0.0.1:44100',
+      token: 'token-1',
+      fetch: vi.fn()
+    })
+    const events = client.events({ WebSocket: ControllableWebSocket as never })
+    const iterator = events[Symbol.asyncIterator]()
+    ControllableWebSocket.instance.emit('open')
+    await events.ready
+    let iteratorOutcome: unknown = 'still-pending'
+    void iterator.next().then(
+      () => {
+        iteratorOutcome = 'resolved'
+      },
+      (error: unknown) => {
+        iteratorOutcome = error
+      }
+    )
+    let callbackError: unknown
+
+    try {
+      ControllableWebSocket.instance.emit('message', { data: '{not-json' })
+    } catch (error) {
+      callbackError = error
+    }
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(callbackError).toBeUndefined()
+    expect(iteratorOutcome).toMatchObject({ code: 'event_stream_invalid_message' })
+    expect(ControllableWebSocket.instance.closed).toBe(true)
+  })
+
+  it('fails closed when more than 1024 events are buffered without a consumer', async () => {
+    const client = new OpenScienceClient({
+      baseUrl: 'http://127.0.0.1:44100',
+      token: 'token-1',
+      fetch: vi.fn()
+    })
+    const events = client.events({ WebSocket: ControllableWebSocket as never })
+    const iterator = events[Symbol.asyncIterator]()
+    ControllableWebSocket.instance.emit('open')
+    await events.ready
+
+    for (let sequence = 1; sequence <= 1_025; sequence += 1) {
+      ControllableWebSocket.instance.emit('message', {
+        data: JSON.stringify({
+          type: 'run.event',
+          data: { sequence }
+        })
+      })
+    }
+
+    await expect(iterator.next()).rejects.toMatchObject({ code: 'event_stream_overflow' })
+    expect(ControllableWebSocket.instance.closed).toBe(true)
   })
 
   it('discovers a daemon from its state and token files before returning a client', async () => {

--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -1,6 +1,7 @@
 export type PermissionProfile = 'ask' | 'auto' | 'full'
 export type DelegationPolicy = 'allow' | 'deny'
 export type TurnIntent = 'plan-first'
+export type RequestOptions = { signal?: AbortSignal; timeoutMs?: number }
 export type RunStatus = 'running' | 'completed' | 'failed' | 'cancelled'
 export type RunProgressPhase =
   | 'accepted'
@@ -158,14 +159,15 @@ export class OpenScienceClient {
     token: string
     fetch?: typeof globalThis.fetch
     sleep?: (milliseconds: number) => Promise<void>
+    requestTimeoutMs?: number
   })
-  health(): Promise<unknown>
-  listProjects(): Promise<Project[]>
+  health(options?: RequestOptions): Promise<unknown>
+  listProjects(options?: RequestOptions): Promise<Project[]>
   createProject(request: {
     name: string
     description?: string
     agentContext?: string
-  }): Promise<Project>
+  }, options?: RequestOptions): Promise<Project>
   updateProject(
     projectId: string,
     request: {
@@ -173,11 +175,12 @@ export class OpenScienceClient {
       name?: string
       description?: string
       agentContext?: string
-    }
+    },
+    options?: RequestOptions
   ): Promise<Project>
-  listSessions(projectId?: string): Promise<Session[]>
-  getSession(sessionId: string): Promise<Session>
-  getSessionPlan(sessionId: string): Promise<SessionPlan | null>
+  listSessions(projectId?: string, options?: RequestOptions): Promise<Session[]>
+  getSession(sessionId: string, options?: RequestOptions): Promise<Session>
+  getSessionPlan(sessionId: string, options?: RequestOptions): Promise<SessionPlan | null>
   respondSessionPlan(
     sessionId: string,
     response:
@@ -186,22 +189,26 @@ export class OpenScienceClient {
           artifactVersionId: string
           expectedRevision: number
         }
-      | { feedback: string }
+      | { feedback: string },
+    options?: RequestOptions
   ): Promise<PlanResponse>
-  startRun(request: {
-    project: string
-    prompt: string
-    cwd?: string
-    sessionId?: string
-    permissionProfile?: PermissionProfile
-    skillIds?: string[]
-    turnIntent?: TurnIntent
-    autoReviewEnabled?: boolean
-    specialist?: string
-    delegationPolicy?: DelegationPolicy
-  }): Promise<Run>
-  getRun(runId: string): Promise<Run>
-  cancelRun(runId: string): Promise<Run>
+  startRun(
+    request: {
+      project: string
+      prompt: string
+      cwd?: string
+      sessionId?: string
+      permissionProfile?: PermissionProfile
+      skillIds?: string[]
+      turnIntent?: TurnIntent
+      autoReviewEnabled?: boolean
+      specialist?: string
+      delegationPolicy?: DelegationPolicy
+    },
+    options?: RequestOptions
+  ): Promise<Run>
+  getRun(runId: string, options?: RequestOptions): Promise<Run>
+  cancelRun(runId: string, options?: RequestOptions): Promise<Run>
   waitForRun(
     runId: string,
     options?: {
@@ -211,8 +218,8 @@ export class OpenScienceClient {
       timeoutMs?: number
     }
   ): Promise<Run>
-  listArtifacts(sessionId: string): Promise<Artifact[]>
-  downloadArtifact(artifactId: string, options?: { signal?: AbortSignal }): Promise<Response>
+  listArtifacts(sessionId: string, options?: RequestOptions): Promise<Artifact[]>
+  downloadArtifact(artifactId: string, options?: RequestOptions): Promise<Response>
   events(options?: {
     signal?: AbortSignal
     WebSocket?: typeof globalThis.WebSocket
@@ -226,4 +233,6 @@ export function connectToOpenScience(options?: {
   configRoot?: string
   env?: Record<string, string | undefined>
   fetch?: typeof globalThis.fetch
+  requestTimeoutMs?: number
+  signal?: AbortSignal
 }): Promise<OpenScienceClient>

--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -163,11 +163,14 @@ export class OpenScienceClient {
   })
   health(options?: RequestOptions): Promise<unknown>
   listProjects(options?: RequestOptions): Promise<Project[]>
-  createProject(request: {
-    name: string
-    description?: string
-    agentContext?: string
-  }, options?: RequestOptions): Promise<Project>
+  createProject(
+    request: {
+      name: string
+      description?: string
+      agentContext?: string
+    },
+    options?: RequestOptions
+  ): Promise<Project>
   updateProject(
     projectId: string,
     request: {
@@ -221,6 +224,7 @@ export class OpenScienceClient {
   listArtifacts(sessionId: string, options?: RequestOptions): Promise<Artifact[]>
   downloadArtifact(artifactId: string, options?: RequestOptions): Promise<Response>
   events(options?: {
+    idleTimeoutMs?: number
     signal?: AbortSignal
     WebSocket?: typeof globalThis.WebSocket
   }): AsyncIterable<

--- a/packages/open-science/index.mjs
+++ b/packages/open-science/index.mjs
@@ -6,6 +6,7 @@ const defaultSleep = (milliseconds) =>
   new Promise((resolveSleep) => setTimeout(resolveSleep, milliseconds))
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
+const DEFAULT_EVENT_IDLE_TIMEOUT_MS = 30_000
 const MAX_BUFFERED_EVENTS = 1_024
 
 export class OpenScienceApiError extends Error {
@@ -300,13 +301,19 @@ export class OpenScienceClient {
     }
   }
 
-  events({ signal, WebSocket: WebSocketImpl = globalThis.WebSocket } = {}) {
+  events({
+    idleTimeoutMs = DEFAULT_EVENT_IDLE_TIMEOUT_MS,
+    signal,
+    WebSocket: WebSocketImpl = globalThis.WebSocket
+  } = {}) {
     if (!WebSocketImpl) throw new Error('A WebSocket implementation is required.')
     signal?.throwIfAborted()
+    resolveRequestTimeout(DEFAULT_EVENT_IDLE_TIMEOUT_MS, idleTimeoutMs)
     const endpoint = new URL('/api/v1/events', this.baseUrl)
     endpoint.protocol = endpoint.protocol === 'https:' ? 'wss:' : 'ws:'
     endpoint.searchParams.set('token', this.token)
     endpoint.searchParams.set('client', `sdk-${globalThis.crypto.randomUUID()}`)
+    endpoint.searchParams.set('liveness', '1')
     const socket = new WebSocketImpl(endpoint)
     const queue = []
     const waiters = []
@@ -316,6 +323,7 @@ export class OpenScienceClient {
     let rejectReady
     let readySettled = false
     let opened = false
+    let idleTimer
     const ready = new Promise((resolve, reject) => {
       resolveReady = resolve
       rejectReady = reject
@@ -342,6 +350,7 @@ export class OpenScienceClient {
       if (finished) return
       finished = true
       failure = error
+      clearTimeout(idleTimer)
       if (discardQueue) queue.splice(0)
       if (!opened) {
         settleReady(
@@ -362,8 +371,21 @@ export class OpenScienceClient {
         discardQueue: true
       })
     }
+    const armIdleTimeout = () => {
+      clearTimeout(idleTimer)
+      idleTimer = setTimeout(
+        () =>
+          fail(
+            `Open Science event stream timed out after ${idleTimeoutMs} milliseconds.`,
+            'timeout'
+          ),
+        idleTimeoutMs
+      )
+    }
+    armIdleTimeout()
     socket.addEventListener('message', (event) => {
       if (finished) return
+      armIdleTimeout()
       let parsed
       try {
         parsed = JSON.parse(String(event.data))
@@ -374,6 +396,7 @@ export class OpenScienceClient {
         )
         return
       }
+      if (parsed?.type === 'connection.heartbeat') return
       if (queue.length >= MAX_BUFFERED_EVENTS) {
         fail(
           'Open Science event stream exceeded its buffered event limit.',
@@ -387,6 +410,7 @@ export class OpenScienceClient {
     socket.addEventListener('open', () => {
       if (finished) return
       opened = true
+      armIdleTimeout()
       settleReady()
     })
     socket.addEventListener('error', () => {

--- a/packages/open-science/index.mjs
+++ b/packages/open-science/index.mjs
@@ -5,6 +5,9 @@ import { findServiceState, readWebToken } from './config-root.mjs'
 const defaultSleep = (milliseconds) =>
   new Promise((resolveSleep) => setTimeout(resolveSleep, milliseconds))
 
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
+const MAX_BUFFERED_EVENTS = 1_024
+
 export class OpenScienceApiError extends Error {
   constructor(message, { code = 'request_failed', status } = {}) {
     super(message)
@@ -14,36 +17,170 @@ export class OpenScienceApiError extends Error {
   }
 }
 
+const resolveRequestTimeout = (defaultTimeoutMs, timeoutMs) => {
+  const resolved = timeoutMs ?? defaultTimeoutMs
+  if (!Number.isFinite(resolved) || resolved <= 0) {
+    throw new TypeError('timeoutMs must be a positive number.')
+  }
+  return resolved
+}
+
+const createRequestLifecycle = ({ defaultTimeoutMs, signal, timeoutMs }) => {
+  signal?.throwIfAborted()
+  const resolvedTimeoutMs = resolveRequestTimeout(defaultTimeoutMs, timeoutMs)
+  const timeoutController = new AbortController()
+  const timeoutError = new OpenScienceApiError(
+    `Open Science request timed out after ${resolvedTimeoutMs} milliseconds.`,
+    { code: 'timeout' }
+  )
+  const timeout = setTimeout(() => timeoutController.abort(timeoutError), resolvedTimeoutMs)
+  const requestSignal = signal
+    ? AbortSignal.any([signal, timeoutController.signal])
+    : timeoutController.signal
+  let finalized = false
+
+  return {
+    signal: requestSignal,
+    finalize() {
+      if (finalized) return
+      finalized = true
+      clearTimeout(timeout)
+    },
+    normalizeError(error) {
+      if (signal?.aborted) return signal.reason
+      if (timeoutController.signal.aborted) return timeoutError
+      return error
+    }
+  }
+}
+
+const withRequestTimeout = async (options, operation) => {
+  const lifecycle = createRequestLifecycle(options)
+  try {
+    return await operation(lifecycle.signal)
+  } catch (error) {
+    throw lifecycle.normalizeError(error)
+  } finally {
+    lifecycle.finalize()
+  }
+}
+
+const wrapResponseBodyLifecycle = (response, lifecycle) => {
+  if (!response.body) {
+    lifecycle.finalize()
+    return response
+  }
+  const reader = response.body.getReader()
+  const body = new ReadableStream({
+    async pull(controller) {
+      try {
+        const chunk = await reader.read()
+        if (chunk.done) {
+          lifecycle.finalize()
+          controller.close()
+        } else {
+          controller.enqueue(chunk.value)
+        }
+      } catch (error) {
+        lifecycle.finalize()
+        controller.error(lifecycle.normalizeError(error))
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason)
+      } finally {
+        lifecycle.finalize()
+      }
+    }
+  })
+  const wrapped = new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers
+  })
+  Object.defineProperties(wrapped, {
+    redirected: { value: response.redirected },
+    type: { value: response.type },
+    url: { value: response.url }
+  })
+  return wrapped
+}
+
+const sleepWithSignal = async (sleep, milliseconds, signal) => {
+  signal?.throwIfAborted()
+  if (!signal) {
+    await sleep(milliseconds)
+    return
+  }
+  await new Promise((resolve, reject) => {
+    let settled = false
+    const finish = (callback, value) => {
+      if (settled) return
+      settled = true
+      signal.removeEventListener('abort', abort)
+      callback(value)
+    }
+    const abort = () => finish(reject, signal.reason)
+    signal.addEventListener('abort', abort, { once: true })
+    Promise.resolve()
+      .then(() => sleep(milliseconds))
+      .then(
+        () => finish(resolve),
+        (error) => finish(reject, error)
+      )
+  })
+}
+
 export class OpenScienceClient {
-  constructor({ baseUrl, token, fetch: fetchImpl = globalThis.fetch, sleep = defaultSleep }) {
+  constructor({
+    baseUrl,
+    token,
+    fetch: fetchImpl = globalThis.fetch,
+    sleep = defaultSleep,
+    requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS
+  }) {
     if (!baseUrl) throw new Error('Open Science baseUrl is required.')
     if (!token) throw new Error('Open Science token is required.')
     if (!fetchImpl) throw new Error('A Fetch implementation is required.')
+    resolveRequestTimeout(requestTimeoutMs)
     this.baseUrl = baseUrl.replace(/\/$/, '')
     this.token = token
     this.fetch = fetchImpl
     this.sleep = sleep
+    this.requestTimeoutMs = requestTimeoutMs
   }
 
-  async health() {
-    const response = await this.fetch(`${this.baseUrl}/api/bootstrap`, {
-      headers: { authorization: `Bearer ${this.token}`, accept: 'application/json' }
-    })
-    if (!response.ok) {
-      throw new OpenScienceApiError('Open Science is not running.', {
-        code: 'daemon_unavailable',
-        status: response.status
-      })
-    }
-    return response.json()
+  async health(options = {}) {
+    return withRequestTimeout(
+      {
+        defaultTimeoutMs: this.requestTimeoutMs,
+        signal: options.signal,
+        timeoutMs: options.timeoutMs
+      },
+      async (signal) => {
+        const response = await this.fetch(`${this.baseUrl}/api/bootstrap`, {
+          headers: { authorization: `Bearer ${this.token}`, accept: 'application/json' },
+          signal
+        })
+        if (!response.ok) {
+          throw new OpenScienceApiError('Open Science is not running.', {
+            code: 'daemon_unavailable',
+            status: response.status
+          })
+        }
+        return await response.json()
+      }
+    )
   }
 
-  listProjects() {
-    return this.request('/api/v1/projects')
+  listProjects(options) {
+    return this.request('/api/v1/projects', options)
   }
 
-  createProject({ name, description, agentContext }) {
+  createProject({ name, description, agentContext }, options) {
     return this.request('/api/v1/projects', {
+      ...options,
       method: 'POST',
       body: {
         name,
@@ -53,43 +190,48 @@ export class OpenScienceClient {
     })
   }
 
-  updateProject(projectId, request) {
+  updateProject(projectId, request, options) {
     return this.request(`/api/v1/projects/${encodeURIComponent(projectId)}`, {
+      ...options,
       method: 'PATCH',
       body: request
     })
   }
 
-  listSessions(projectId) {
+  listSessions(projectId, options) {
     const query = projectId ? `?project=${encodeURIComponent(projectId)}` : ''
-    return this.request(`/api/v1/sessions${query}`)
+    return this.request(`/api/v1/sessions${query}`, options)
   }
 
-  getSession(sessionId) {
-    return this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}`)
+  getSession(sessionId, options) {
+    return this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}`, options)
   }
 
-  getSessionPlan(sessionId) {
-    return this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/plan`)
+  getSessionPlan(sessionId, options) {
+    return this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/plan`, options)
   }
 
-  respondSessionPlan(sessionId, response) {
+  respondSessionPlan(sessionId, response, options) {
     return this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/plan/respond`, {
+      ...options,
       method: 'POST',
       body: response
     })
   }
 
-  startRun(request) {
-    return this.request('/api/v1/runs', { method: 'POST', body: request })
+  startRun(request, options) {
+    return this.request('/api/v1/runs', { ...options, method: 'POST', body: request })
   }
 
-  getRun(runId) {
-    return this.request(`/api/v1/runs/${encodeURIComponent(runId)}`)
+  getRun(runId, options) {
+    return this.request(`/api/v1/runs/${encodeURIComponent(runId)}`, options)
   }
 
-  cancelRun(runId) {
-    return this.request(`/api/v1/runs/${encodeURIComponent(runId)}/cancel`, { method: 'POST' })
+  cancelRun(runId, options) {
+    return this.request(`/api/v1/runs/${encodeURIComponent(runId)}/cancel`, {
+      ...options,
+      method: 'POST'
+    })
   }
 
   async waitForRun(
@@ -105,27 +247,57 @@ export class OpenScienceClient {
       if (deadline !== undefined && Date.now() >= deadline) {
         throw new OpenScienceApiError(`Timed out waiting for run ${runId}.`, { code: 'timeout' })
       }
-      const run = await this.getRun(runId)
+      const remainingMs = deadline === undefined ? undefined : Math.max(1, deadline - Date.now())
+      let run
+      try {
+        run = await this.getRun(runId, { signal, timeoutMs: remainingMs })
+      } catch (error) {
+        signal?.throwIfAborted()
+        if (
+          deadline !== undefined &&
+          (Date.now() >= deadline ||
+            (error instanceof OpenScienceApiError && error.code === 'timeout'))
+        ) {
+          throw new OpenScienceApiError(`Timed out waiting for run ${runId}.`, { code: 'timeout' })
+        }
+        throw error
+      }
       if (run.status !== 'running') return run
       if (returnOnAttention && run.attention) return run
-      await this.sleep(pollIntervalMs)
+      const sleepMs =
+        deadline === undefined
+          ? pollIntervalMs
+          : Math.min(pollIntervalMs, Math.max(0, deadline - Date.now()))
+      await sleepWithSignal(this.sleep, sleepMs, signal)
     }
   }
 
-  listArtifacts(sessionId) {
-    return this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/artifacts`)
+  listArtifacts(sessionId, options) {
+    return this.request(`/api/v1/sessions/${encodeURIComponent(sessionId)}/artifacts`, options)
   }
 
-  async downloadArtifact(artifactId, { signal } = {}) {
-    const response = await this.fetch(
-      `${this.baseUrl}/api/v1/artifacts/${encodeURIComponent(artifactId)}/content`,
-      {
-        headers: { authorization: `Bearer ${this.token}` },
-        signal
+  async downloadArtifact(artifactId, { signal, timeoutMs } = {}) {
+    const lifecycle = createRequestLifecycle({
+      defaultTimeoutMs: this.requestTimeoutMs,
+      signal,
+      timeoutMs
+    })
+    try {
+      const response = await this.fetch(
+        `${this.baseUrl}/api/v1/artifacts/${encodeURIComponent(artifactId)}/content`,
+        {
+          headers: { authorization: `Bearer ${this.token}` },
+          signal: lifecycle.signal
+        }
+      )
+      if (!response.ok) {
+        await this.throwResponseError(response)
       }
-    )
-    if (!response.ok) await this.throwResponseError(response)
-    return response
+      return wrapResponseBodyLifecycle(response, lifecycle)
+    } catch (error) {
+      lifecycle.finalize()
+      throw lifecycle.normalizeError(error)
+    }
   }
 
   events({ signal, WebSocket: WebSocketImpl = globalThis.WebSocket } = {}) {
@@ -141,9 +313,16 @@ export class OpenScienceClient {
     let finished = false
     let failure
     let resolveReady
-    const ready = new Promise((resolve) => {
+    let rejectReady
+    let readySettled = false
+    let opened = false
+    const ready = new Promise((resolve, reject) => {
       resolveReady = resolve
+      rejectReady = reject
     })
+    // Iteration without awaiting `ready` still receives the same terminal error through `next()`;
+    // keep the parallel readiness promise from becoming an unhandled rejection in that usage.
+    void ready.catch(() => undefined)
 
     const flush = () => {
       while (waiters.length && queue.length) waiters.shift().resolve(queue.shift())
@@ -153,24 +332,85 @@ export class OpenScienceClient {
         else waiter.resolve(undefined)
       }
     }
+    const settleReady = (error) => {
+      if (readySettled) return
+      readySettled = true
+      if (error) rejectReady(error)
+      else resolveReady()
+    }
+    const finish = ({ error, closeSocket = false, discardQueue = false } = {}) => {
+      if (finished) return
+      finished = true
+      failure = error
+      if (discardQueue) queue.splice(0)
+      if (!opened) {
+        settleReady(
+          error ??
+            new OpenScienceApiError('Open Science event stream closed before it was ready.', {
+              code: 'event_stream_failed'
+            })
+        )
+      }
+      signal?.removeEventListener('abort', abort)
+      if (closeSocket) socket.close()
+      flush()
+    }
+    const fail = (message, code) => {
+      finish({
+        error: new OpenScienceApiError(message, { code }),
+        closeSocket: true,
+        discardQueue: true
+      })
+    }
     socket.addEventListener('message', (event) => {
-      queue.push(JSON.parse(String(event.data)))
+      if (finished) return
+      let parsed
+      try {
+        parsed = JSON.parse(String(event.data))
+      } catch {
+        fail(
+          'Open Science event stream returned an invalid message.',
+          'event_stream_invalid_message'
+        )
+        return
+      }
+      if (queue.length >= MAX_BUFFERED_EVENTS) {
+        fail(
+          'Open Science event stream exceeded its buffered event limit.',
+          'event_stream_overflow'
+        )
+        return
+      }
+      queue.push(parsed)
       flush()
     })
-    socket.addEventListener('open', () => resolveReady())
+    socket.addEventListener('open', () => {
+      if (finished) return
+      opened = true
+      settleReady()
+    })
     socket.addEventListener('error', () => {
-      failure = new OpenScienceApiError('Open Science event stream failed.', {
-        code: 'event_stream_failed'
-      })
-      resolveReady()
-      finished = true
-      flush()
+      fail('Open Science event stream failed.', 'event_stream_failed')
     })
     socket.addEventListener('close', () => {
-      finished = true
-      flush()
+      if (!opened) {
+        finish({
+          error: new OpenScienceApiError('Open Science event stream closed before it was ready.', {
+            code: 'event_stream_failed'
+          }),
+          discardQueue: true
+        })
+        return
+      }
+      finish()
     })
-    const abort = () => socket.close()
+    const abort = () => {
+      if (!opened) {
+        finish({ error: signal.reason, closeSocket: true, discardQueue: true })
+      } else {
+        finish({ closeSocket: true })
+      }
+    }
     signal?.addEventListener('abort', abort, { once: true })
 
     return {
@@ -188,28 +428,32 @@ export class OpenScienceClient {
         return value === undefined ? { value: undefined, done: true } : { value, done: false }
       },
       async return() {
-        signal?.removeEventListener('abort', abort)
-        socket.close()
+        finish({ closeSocket: true })
         return { value: undefined, done: true }
       }
     }
   }
 
-  async request(path, { method = 'GET', body, signal } = {}) {
+  async request(path, { method = 'GET', body, signal, timeoutMs } = {}) {
     const headers = {
       authorization: `Bearer ${this.token}`,
       accept: 'application/json'
     }
     if (body !== undefined) headers['content-type'] = 'application/json'
-    const response = await this.fetch(`${this.baseUrl}${path}`, {
-      method,
-      headers,
-      body: body === undefined ? undefined : JSON.stringify(body),
-      signal
-    })
-    if (!response.ok) await this.throwResponseError(response)
-    const payload = await response.json()
-    return payload.data
+    return withRequestTimeout(
+      { defaultTimeoutMs: this.requestTimeoutMs, signal, timeoutMs },
+      async (requestSignal) => {
+        const response = await this.fetch(`${this.baseUrl}${path}`, {
+          method,
+          headers,
+          body: body === undefined ? undefined : JSON.stringify(body),
+          signal: requestSignal
+        })
+        if (!response.ok) await this.throwResponseError(response)
+        const payload = await response.json()
+        return payload.data
+      }
+    )
   }
 
   async throwResponseError(response) {
@@ -229,7 +473,13 @@ export class OpenScienceClient {
   }
 }
 
-export const connectToOpenScience = async ({ configRoot, env, fetch } = {}) => {
+export const connectToOpenScience = async ({
+  configRoot,
+  env,
+  fetch,
+  requestTimeoutMs,
+  signal
+} = {}) => {
   const state = await findServiceState({ override: configRoot, env })
   if (!state) {
     throw new OpenScienceApiError(
@@ -243,8 +493,9 @@ export const connectToOpenScience = async ({ configRoot, env, fetch } = {}) => {
   const client = new OpenScienceClient({
     baseUrl: `http://127.0.0.1:${state.port}`,
     token,
-    fetch
+    fetch,
+    requestTimeoutMs
   })
-  await client.health()
+  await client.health({ signal })
   return client
 }

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -725,7 +725,44 @@ describe('AcpRuntimeCoordinator', () => {
     }
   )
 
-  it('rejects prompt admission when the turn ends without provider acceptance', async () => {
+  it('acknowledges a blocking provider prompt after local dispatch without waiting for output', async () => {
+    const completion = createDeferred<unknown>()
+    let created!: ReturnType<typeof createFakeRuntime>
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      created = createFakeRuntime({
+        frameworkId: 'codex',
+        sessionIds: ['session-1'],
+        callbacks,
+        skipProviderPromptAccepted: true,
+        prompt: () => completion.promise
+      })
+      return created.runtime
+    })
+    const session = await coordinator.createSession()
+    const admission = coordinator.startPrompt({
+      sessionId: session.sessionId,
+      text: 'Wait for the blocking model response.'
+    })
+    const outcome = Promise.race([
+      admission.then(
+        () => 'acknowledged' as const,
+        () => 'rejected' as const
+      ),
+      new Promise<'still-pending'>((resolve) => setImmediate(() => resolve('still-pending')))
+    ])
+
+    await vi.waitFor(() => expect(created.sendPrompt).toHaveBeenCalledOnce())
+
+    await expect(outcome).resolves.toBe('acknowledged')
+    expect(coordinator.getSnapshot().promptInFlightSessionIds).toContain(session.sessionId)
+
+    completion.resolve({ stopReason: 'end_turn' })
+    await vi.waitFor(() =>
+      expect(coordinator.getSnapshot().promptInFlightSessionIds).not.toContain(session.sessionId)
+    )
+  })
+
+  it('keeps application admission independent from a missing provider acceptance update', async () => {
     const coordinator = new AcpRuntimeCoordinator(
       (callbacks) =>
         createFakeRuntime({
@@ -739,7 +776,7 @@ describe('AcpRuntimeCoordinator', () => {
 
     await expect(
       coordinator.startPrompt({ sessionId: session.sessionId, text: 'Research this.' })
-    ).rejects.toThrow('ACP prompt ended before provider acceptance.')
+    ).resolves.toBeUndefined()
   })
 
   it('does not report provider acceptance when dispatch fails before acceptance', async () => {

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -762,6 +762,25 @@ describe('AcpRuntimeCoordinator', () => {
     )
   })
 
+  it('rejects an immediately failed runtime dispatch before acknowledging application admission', async () => {
+    const failure = new Error('Active session disposed')
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) =>
+        createFakeRuntime({
+          frameworkId: 'codex',
+          sessionIds: ['session-1'],
+          callbacks,
+          skipProviderPromptAccepted: true,
+          prompt: () => Promise.reject(failure)
+        }).runtime
+    )
+    const session = await coordinator.createSession()
+
+    await expect(
+      coordinator.startPrompt({ sessionId: session.sessionId, text: 'Research this.' })
+    ).rejects.toBe(failure)
+  })
+
   it('keeps application admission independent from a missing provider acceptance update', async () => {
     const coordinator = new AcpRuntimeCoordinator(
       (callbacks) =>

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -713,9 +713,9 @@ class AcpRuntimeCoordinator {
   }
 
   // Interactive prompt dispatch is an admission RPC, while the authoritative turn lifecycle is
-  // streamed through runtime state/events. Settle the RPC as soon as the provider accepts the
-  // prompt so a long-running turn (or its terminal maintenance) does not retain an Electron reply
-  // channel until completion.
+  // streamed through runtime state/events. Settle once the application runtime owns the prompt;
+  // blocking providers and human approval waits may produce no provider update before their own
+  // domain lifecycle completes and must not retain a Web request until then.
   startPrompt(request: AcpPromptRequest): Promise<void> {
     let settled = false
     let resolve!: () => void
@@ -724,7 +724,7 @@ class AcpRuntimeCoordinator {
       resolve = promiseResolve
       reject = promiseReject
     })
-    const settleAccepted = (): void => {
+    const settleAdmitted = (): void => {
       if (settled) return
       settled = true
       resolve()
@@ -735,8 +735,8 @@ class AcpRuntimeCoordinator {
       reject(error)
     }
 
-    void this.sendPromptObserved(request, settleAccepted).then(
-      () => settleRejected(new Error('ACP prompt ended before provider acceptance.')),
+    void this.sendObservedPrompt(request, undefined, settleAdmitted).then(
+      settleAdmitted,
       settleRejected
     )
     return accepted
@@ -767,14 +767,21 @@ class AcpRuntimeCoordinator {
 
   private sendObservedPrompt(
     request: AcpPromptRequest,
-    acceptance?: PromptAcceptance
+    acceptance?: PromptAcceptance,
+    onApplicationPromptAdmitted?: () => void
   ): ReturnType<AcpRuntime['sendPrompt']> {
     if (this.promptAdmissionClosedForQuit) return this.rejectPromptForQuit()
     const dispatch = (): ReturnType<AcpRuntime['sendPrompt']> =>
       this.linearizeRootAdmission(request.sessionId, () =>
-        this.dispatchPrompt(request, acceptance, 'sendPrompt').finally(() =>
-          this.delegatedWork?.wakeMessages?.(request.sessionId)
-        )
+        this.dispatchPrompt(
+          request,
+          acceptance,
+          'sendPrompt',
+          undefined,
+          true,
+          undefined,
+          onApplicationPromptAdmitted
+        ).finally(() => this.delegatedWork?.wakeMessages?.(request.sessionId))
       )
     const admission = this.promptAdmissionGuard?.(request.sessionId)
     return admission ? admission.then(dispatch) : dispatch()
@@ -909,7 +916,8 @@ class AcpRuntimeCoordinator {
     operation: 'sendPrompt' | 'sendAppContinuation' | 'sendApplicationPrompt',
     pinnedRuntime?: AcpRuntime,
     retainAsLatestUserPrompt = operation === 'sendPrompt',
-    attribution?: MessageAttribution
+    attribution?: MessageAttribution,
+    onApplicationPromptAdmitted?: () => void
   ): ReturnType<AcpRuntime['sendPrompt']> {
     const dispatch = (): ReturnType<AcpRuntime['sendPrompt']> =>
       this.dispatchAdmittedPrompt(
@@ -918,7 +926,8 @@ class AcpRuntimeCoordinator {
         operation,
         pinnedRuntime,
         retainAsLatestUserPrompt,
-        attribution
+        attribution,
+        onApplicationPromptAdmitted
       )
     return this.promptDispatchAdmissionGuard
       ? this.promptDispatchAdmissionGuard(request.sessionId, dispatch)
@@ -931,7 +940,8 @@ class AcpRuntimeCoordinator {
     operation: 'sendPrompt' | 'sendAppContinuation' | 'sendApplicationPrompt',
     pinnedRuntime?: AcpRuntime,
     retainAsLatestUserPrompt = operation === 'sendPrompt',
-    attribution?: MessageAttribution
+    attribution?: MessageAttribution,
+    onApplicationPromptAdmitted?: () => void
   ): ReturnType<AcpRuntime['sendPrompt']> {
     if (this.promptAdmissionClosedForQuit) return this.rejectPromptForQuit()
     const owner = pinnedRuntime ?? this.findRuntimeForSession(request.sessionId)
@@ -971,6 +981,7 @@ class AcpRuntimeCoordinator {
       operation === 'sendApplicationPrompt'
         ? runtime.sendApplicationPrompt(taskRequest, attribution!, attempt.id)
         : runtime[operation](taskRequest, attempt.id)
+    onApplicationPromptAdmitted?.()
     return prompt
       .catch((error: unknown) => {
         if (

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -734,8 +734,16 @@ class AcpRuntimeCoordinator {
       settled = true
       reject(error)
     }
+    const settleAfterRuntimeDispatch = (prompt: ReturnType<AcpRuntime['sendPrompt']>): void => {
+      // A runtime can return an immediately rejected Promise through several async wrappers when
+      // it cannot accept the prompt. Let that microtask chain drain before acknowledging local
+      // ownership. Once accepted, later model, tool, or human-input waits remain authoritative
+      // through state/events.
+      void prompt.then(settleAdmitted, settleRejected)
+      setImmediate(settleAdmitted)
+    }
 
-    void this.sendObservedPrompt(request, undefined, settleAdmitted).then(
+    void this.sendObservedPrompt(request, undefined, settleAfterRuntimeDispatch).then(
       settleAdmitted,
       settleRejected
     )
@@ -768,7 +776,7 @@ class AcpRuntimeCoordinator {
   private sendObservedPrompt(
     request: AcpPromptRequest,
     acceptance?: PromptAcceptance,
-    onApplicationPromptAdmitted?: () => void
+    onApplicationPromptAdmitted?: (prompt: ReturnType<AcpRuntime['sendPrompt']>) => void
   ): ReturnType<AcpRuntime['sendPrompt']> {
     if (this.promptAdmissionClosedForQuit) return this.rejectPromptForQuit()
     const dispatch = (): ReturnType<AcpRuntime['sendPrompt']> =>
@@ -917,7 +925,7 @@ class AcpRuntimeCoordinator {
     pinnedRuntime?: AcpRuntime,
     retainAsLatestUserPrompt = operation === 'sendPrompt',
     attribution?: MessageAttribution,
-    onApplicationPromptAdmitted?: () => void
+    onApplicationPromptAdmitted?: (prompt: ReturnType<AcpRuntime['sendPrompt']>) => void
   ): ReturnType<AcpRuntime['sendPrompt']> {
     const dispatch = (): ReturnType<AcpRuntime['sendPrompt']> =>
       this.dispatchAdmittedPrompt(
@@ -941,7 +949,7 @@ class AcpRuntimeCoordinator {
     pinnedRuntime?: AcpRuntime,
     retainAsLatestUserPrompt = operation === 'sendPrompt',
     attribution?: MessageAttribution,
-    onApplicationPromptAdmitted?: () => void
+    onApplicationPromptAdmitted?: (prompt: ReturnType<AcpRuntime['sendPrompt']>) => void
   ): ReturnType<AcpRuntime['sendPrompt']> {
     if (this.promptAdmissionClosedForQuit) return this.rejectPromptForQuit()
     const owner = pinnedRuntime ?? this.findRuntimeForSession(request.sessionId)
@@ -981,7 +989,7 @@ class AcpRuntimeCoordinator {
       operation === 'sendApplicationPrompt'
         ? runtime.sendApplicationPrompt(taskRequest, attribution!, attempt.id)
         : runtime[operation](taskRequest, attempt.id)
-    onApplicationPromptAdmitted?.()
+    onApplicationPromptAdmitted?.(prompt)
     return prompt
       .catch((error: unknown) => {
         if (

--- a/src/main/settings/native-responses-compatibility.test.ts
+++ b/src/main/settings/native-responses-compatibility.test.ts
@@ -498,6 +498,65 @@ describe('native Responses compatibility', () => {
     }
   })
 
+  it('aborts a blocking native Responses body after the configured idle period', async () => {
+    let upstreamSignal: AbortSignal | undefined
+    let failUpstream: ((reason?: unknown) => void) | undefined
+    const fetchImpl = vi.fn(
+      async (_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        upstreamSignal = init?.signal ?? undefined
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              failUpstream = (reason) => controller.error(reason)
+              upstreamSignal?.addEventListener(
+                'abort',
+                () => failUpstream?.(upstreamSignal?.reason),
+                { once: true }
+              )
+            }
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      }
+    )
+    const proxy = new NativeResponsesCompatibilityProxy(
+      { baseUrl: 'https://api.deepseek.com/v1', model: 'deepseek-v4-pro' },
+      fetchImpl,
+      { streamIdleTimeoutMs: 25 }
+    )
+    const connection = await proxy.start()
+
+    try {
+      const outcome = await Promise.race([
+        fetch(`${connection.baseUrl}/responses`, {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${connection.token}`,
+            'content-type': 'application/json'
+          },
+          body: JSON.stringify({ model: 'deepseek-v4-pro', input: 'analyze', stream: false })
+        }),
+        new Promise<'still-pending'>((resolve) => setTimeout(() => resolve('still-pending'), 500))
+      ])
+
+      expect(outcome).toBeInstanceOf(Response)
+      const response = outcome as Response
+      expect(response.status).toBe(400)
+      expect(upstreamSignal?.aborted).toBe(true)
+      expect(logSpies.warn.mock.calls).toContainEqual([
+        'native Responses compatibility request failed',
+        expect.objectContaining({
+          phase: 'forward-response',
+          outcome: 'error',
+          errorCategory: 'timeout'
+        })
+      ])
+    } finally {
+      failUpstream?.()
+      await proxy.close()
+    }
+  })
+
   it('aborts a native Responses request when upstream headers do not arrive in time', async () => {
     let upstreamSignal: AbortSignal | undefined
     const fetchImpl = vi.fn(

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -318,6 +318,17 @@ const streamResponse = async (
   response.end()
 }
 
+const readResponseText = async (upstream: Response, onActivity: () => void): Promise<string> => {
+  if (!upstream.body) throw new Error('native Responses upstream returned no body')
+  const decoder = new TextDecoder()
+  let body = ''
+  for await (const chunk of upstream.body) {
+    onActivity()
+    body += decoder.decode(chunk, { stream: true })
+  }
+  return body + decoder.decode()
+}
+
 const namespaceToolDeclarations = (tools: ResponsesBridgeNamespacedTool[]): JsonObject[] => {
   const byNamespace = new Map<string, JsonObject[]>()
   for (const tool of tools) {
@@ -741,7 +752,11 @@ export class NativeResponsesCompatibilityProxy {
         armStreamIdleTimeout()
         await streamResponse(upstream, response, aliases, armStreamIdleTimeout)
       } else if (responseType === 'json') {
-        const payload = restoreNativeResponsesPayload(await upstream.json(), aliases)
+        armStreamIdleTimeout()
+        const payload = restoreNativeResponsesPayload(
+          JSON.parse(await readResponseText(upstream, armStreamIdleTimeout)),
+          aliases
+        )
         response.writeHead(upstream.status, copyResponseHeaders(upstream))
         response.end(JSON.stringify(payload))
       } else {

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -621,6 +621,76 @@ describe('startWebHttpServer', () => {
     publicSocket.close()
   })
 
+  it('sends opt-in liveness frames on internal and public event sockets', async () => {
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      eventHeartbeatIntervalMs: 10,
+      rpc: {
+        channels: () => [],
+        invoke: vi.fn(),
+        releaseClient: vi.fn(),
+        dispose: vi.fn()
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const base = `http://127.0.0.1:${server.port}`
+    const bootstrap = (await (
+      await fetch(`${base}/api/bootstrap`, {
+        headers: { authorization: 'Bearer test-token' }
+      })
+    ).json()) as {
+      eventStream: { streamId: string; latestSequence: number }
+    }
+    const internalUrl = new URL(`${base.replace('http:', 'ws:')}/events`)
+    internalUrl.searchParams.set('token', 'test-token')
+    internalUrl.searchParams.set('client', 'heartbeat-web')
+    internalUrl.searchParams.set('eventProtocol', String(WEB_EVENT_STREAM_PROTOCOL_VERSION))
+    internalUrl.searchParams.set('stream', bootstrap.eventStream.streamId)
+    internalUrl.searchParams.set('after', String(bootstrap.eventStream.latestSequence))
+    internalUrl.searchParams.set('liveness', '1')
+    const publicUrl = new URL(`${base.replace('http:', 'ws:')}/api/v1/events`)
+    publicUrl.searchParams.set('token', 'test-token')
+    publicUrl.searchParams.set('client', 'heartbeat-sdk')
+    publicUrl.searchParams.set('liveness', '1')
+    const internalSocket = new WebSocket(internalUrl)
+    const publicSocket = new WebSocket(publicUrl)
+    const messages = (socket: WebSocket): Promise<unknown> =>
+      new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('Timed out waiting for heartbeat.')), 250)
+        socket.on('message', (data) => {
+          const parsed = JSON.parse(data.toString())
+          if (parsed.kind === 'ready') return
+          clearTimeout(timeout)
+          resolve(parsed)
+        })
+      })
+
+    await expect(Promise.all([messages(internalSocket), messages(publicSocket)])).resolves.toEqual([
+      expect.objectContaining({
+        kind: 'heartbeat',
+        protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+        streamId: bootstrap.eventStream.streamId,
+        latestSequence: bootstrap.eventStream.latestSequence
+      }),
+      expect.objectContaining({
+        type: 'connection.heartbeat',
+        data: { timestamp: expect.any(Number) }
+      })
+    ])
+    internalSocket.close()
+    publicSocket.close()
+  })
+
   it('exposes only versioned, schema-valid RPC contract channels', async () => {
     const rpc = {
       channels: () => ['projects:list', 'test:unsafe'],

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -50,6 +50,7 @@ import { TaskApiError, type HeadlessTaskApi } from './task-api'
 const MAX_RPC_BODY_BYTES = 64 * 1024 * 1024
 const MIN_GZIP_BYTES = 1_024
 const INTERNAL_SERVER_ERROR_MESSAGE = 'Internal server error'
+const DEFAULT_EVENT_HEARTBEAT_INTERVAL_MS = 10_000
 const gzipAsync = promisify(gzip)
 
 // Remote Browser access is an application session, not authority over native host lifecycle and
@@ -85,6 +86,7 @@ type WebServerOptions = {
   staticRoot: string
   applicationCommands: Pick<ApplicationCommandComposition, 'localWeb' | 'remoteWeb'>
   applicationEvents: ApplicationEventSource
+  eventHeartbeatIntervalMs?: number
   externalAccess?: ExternalWebAccess
   tasks?: Pick<
     HeadlessTaskApi,
@@ -549,6 +551,8 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
   const externalSockets = new Map<WebSocket, string | undefined>()
   const publicEventSockets = new Set<WebSocket>()
   const internalEventSockets = new Map<WebSocket, 'legacy' | 'replay'>()
+  const livenessSockets = new Set<WebSocket>()
+  const awaitingPong = new WeakSet<WebSocket>()
   const internalEventStream = new InternalWebEventStream()
   const commandClient = createApplicationCommandClient()
   const clientLeases = new ClientLeaseRegistry((clientId) => {
@@ -802,8 +806,11 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       externalSockets.delete(socket)
       publicEventSockets.delete(socket)
       internalEventSockets.delete(socket)
+      livenessSockets.delete(socket)
       lease.release()
     })
+    socket.on('pong', () => awaitingPong.delete(socket))
+    if (url.searchParams.get('liveness') === '1') livenessSockets.add(socket)
     if (url.pathname === '/api/v1/events') {
       publicEventSockets.add(socket)
     } else {
@@ -877,6 +884,24 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
 
   const address = server.address()
   const port = typeof address === 'object' && address ? address.port : options.port
+  const eventHeartbeatInterval = setInterval(() => {
+    const publicHeartbeat = JSON.stringify({
+      type: 'connection.heartbeat',
+      data: { timestamp: Date.now() }
+    })
+    const internalHeartbeat = internalEventStream.heartbeat()
+    for (const socket of livenessSockets) {
+      if (socket.readyState !== WebSocket.OPEN) continue
+      if (awaitingPong.has(socket)) {
+        socket.terminate()
+        continue
+      }
+      awaitingPong.add(socket)
+      socket.ping()
+      if (publicEventSockets.has(socket)) socket.send(publicHeartbeat)
+      else if (internalEventSockets.has(socket)) socket.send(internalHeartbeat)
+    }
+  }, options.eventHeartbeatIntervalMs ?? DEFAULT_EVENT_HEARTBEAT_INTERVAL_MS)
 
   return {
     port,
@@ -888,6 +913,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       }
     },
     close: async () => {
+      clearInterval(eventHeartbeatInterval)
       removeBroadcastSink()
       removeTaskProgressSink?.()
       for (const socket of sockets) socket.close()

--- a/src/main/web-service/internal-web-event-stream.ts
+++ b/src/main/web-service/internal-web-event-stream.ts
@@ -82,6 +82,13 @@ class InternalWebEventStream {
     return serialized
   }
 
+  heartbeat(): string {
+    return JSON.stringify({
+      kind: 'heartbeat',
+      ...this.cursor()
+    })
+  }
+
   resume(cursor: ResumeCursor): readonly string[] {
     if (cursor.streamId !== this.#streamId) return [this.#resyncRequired('stream-changed')]
 

--- a/src/renderer/web/bootstrap.test.ts
+++ b/src/renderer/web/bootstrap.test.ts
@@ -31,6 +31,7 @@ class FakeWebSocket {
   static instances: FakeWebSocket[] = []
 
   readonly listeners = new Map<SocketEventName, Set<SocketListener>>()
+  closed = false
 
   constructor(readonly url: string) {
     FakeWebSocket.instances.push(this)
@@ -43,6 +44,8 @@ class FakeWebSocket {
   }
 
   close(): void {
+    if (this.closed) return
+    this.closed = true
     this.emit('close')
   }
   emit(name: SocketEventName, event: SocketEvent = {}): void {
@@ -51,6 +54,9 @@ class FakeWebSocket {
 }
 
 type WebApi = {
+  notebook: {
+    execute: (request: unknown) => Promise<unknown>
+  }
   projects: {
     create: (request: unknown) => Promise<unknown>
     onCreated: (listener: (payload: unknown) => void) => () => void
@@ -87,6 +93,14 @@ const eventFrame = (sequence: number, channel: string, payload: unknown): string
 const readyFrame = (latestSequence: number): string =>
   JSON.stringify({
     kind: 'ready',
+    protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+    streamId: 'stream-1',
+    latestSequence
+  })
+
+const heartbeatFrame = (latestSequence: number): string =>
+  JSON.stringify({
+    kind: 'heartbeat',
     protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
     streamId: 'stream-1',
     latestSequence
@@ -277,6 +291,134 @@ describe('Web bootstrap event connection', () => {
     expect(rpcSignal?.aborted).toBe(true)
   })
 
+  it('lets a long Notebook execution finish under its own deadline', async () => {
+    let rpcSignal: AbortSignal | undefined
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input) === '/api/bootstrap') {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ ...bootstrapPayload, rpcChannels: ['notebook:execute'] }),
+              { status: 200, headers: { 'content-type': 'application/json' } }
+            )
+          )
+        }
+        if (String(input) === '/rpc/notebook%3Aexecute') {
+          rpcSignal = init?.signal ?? undefined
+          return new Promise<Response>((resolve, reject) => {
+            const timeout = window.setTimeout(
+              () =>
+                resolve(
+                  new Response(
+                    JSON.stringify({
+                      protocolVersion: WEB_RPC_PROTOCOL_VERSION,
+                      ok: true,
+                      result: { runId: 'run-1', status: 'completed' }
+                    }),
+                    { status: 200, headers: { 'content-type': 'application/json' } }
+                  )
+                ),
+              60_000
+            )
+            rpcSignal?.addEventListener(
+              'abort',
+              () => {
+                window.clearTimeout(timeout)
+                reject(rpcSignal?.reason ?? new DOMException('Request aborted', 'AbortError'))
+              },
+              { once: true }
+            )
+          })
+        }
+        throw new Error(`Unexpected fetch: ${String(input)}`)
+      })
+    )
+
+    const api = await loadBootstrap()
+    const socket = FakeWebSocket.instances[0]
+    socket.emit('open')
+    socket.emit('message', { data: readyFrame(0) })
+    const request = api.notebook.execute({
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      code: 'long_running_analysis()'
+    })
+    let settled = false
+    void request.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      }
+    )
+
+    await vi.advanceTimersByTimeAsync(20_000)
+    socket.emit('message', { data: heartbeatFrame(0) })
+    await vi.advanceTimersByTimeAsync(10_001)
+
+    expect(settled).toBe(false)
+    expect(rpcSignal?.aborted ?? false).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(9_999)
+    socket.emit('message', { data: heartbeatFrame(0) })
+    await vi.advanceTimersByTimeAsync(20_000)
+
+    await expect(request).resolves.toEqual({ runId: 'run-1', status: 'completed' })
+  })
+
+  it('aborts a long Notebook request when its event connection disconnects', async () => {
+    let rpcSignal: AbortSignal | undefined
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input) === '/api/bootstrap') {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ ...bootstrapPayload, rpcChannels: ['notebook:execute'] }),
+              { status: 200, headers: { 'content-type': 'application/json' } }
+            )
+          )
+        }
+        if (String(input) === '/rpc/notebook%3Aexecute') {
+          rpcSignal = init?.signal ?? undefined
+          return new Promise<Response>((_resolve, reject) => {
+            rpcSignal?.addEventListener(
+              'abort',
+              () => reject(rpcSignal?.reason ?? new DOMException('Request aborted', 'AbortError')),
+              { once: true }
+            )
+          })
+        }
+        throw new Error(`Unexpected fetch: ${String(input)}`)
+      })
+    )
+
+    const api = await loadBootstrap()
+    const socket = FakeWebSocket.instances[0]
+    socket.emit('open')
+    socket.emit('message', { data: readyFrame(0) })
+    const request = api.notebook.execute({
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace',
+      code: 'long_running_analysis()'
+    })
+    let outcome: unknown = 'still-pending'
+    void request.then(
+      () => {
+        outcome = 'resolved'
+      },
+      (error: unknown) => {
+        outcome = error
+      }
+    )
+
+    socket.emit('close')
+    expect(rpcSignal?.aborted).toBe(true)
+    await vi.waitFor(() => expect(outcome).toBeInstanceOf(DOMException))
+  })
+
   it('settles a stalled managed download and releases its acquired resource', async () => {
     let downloadSignal: AbortSignal | undefined
     let released = false
@@ -380,7 +522,8 @@ describe('Web bootstrap event connection', () => {
       client: 'web-client-1',
       eventProtocol: String(WEB_EVENT_STREAM_PROTOCOL_VERSION),
       stream: 'stream-1',
-      after: '0'
+      after: '0',
+      liveness: '1'
     })
   })
 
@@ -398,6 +541,33 @@ describe('Web bootstrap event connection', () => {
     expect(FakeWebSocket.instances).toHaveLength(2)
     await vi.advanceTimersByTimeAsync(1)
     expect(FakeWebSocket.instances).toHaveLength(3)
+  })
+
+  it('closes a ready event socket that stops receiving liveness frames', async () => {
+    await loadBootstrap()
+
+    const socket = FakeWebSocket.instances[0]
+    socket.emit('open')
+    socket.emit('message', { data: readyFrame(0) })
+
+    await vi.advanceTimersByTimeAsync(30_001)
+
+    expect(socket.closed).toBe(true)
+  })
+
+  it('keeps a ready event socket alive while heartbeat frames continue', async () => {
+    await loadBootstrap()
+
+    const socket = FakeWebSocket.instances[0]
+    socket.emit('open')
+    socket.emit('message', { data: readyFrame(0) })
+    await vi.advanceTimersByTimeAsync(20_000)
+    socket.emit('message', { data: heartbeatFrame(0) })
+    await vi.advanceTimersByTimeAsync(20_000)
+
+    expect(socket.closed).toBe(false)
+    await vi.advanceTimersByTimeAsync(10_001)
+    expect(socket.closed).toBe(true)
   })
 
   it('resets reconnect backoff after a socket becomes ready', async () => {

--- a/src/renderer/web/bootstrap.test.ts
+++ b/src/renderer/web/bootstrap.test.ts
@@ -55,6 +55,11 @@ type WebApi = {
     create: (request: unknown) => Promise<unknown>
     onCreated: (listener: (payload: unknown) => void) => () => void
   }
+  saveManagedFile: (request: {
+    source: 'artifact' | 'upload'
+    path: string
+    suggestedName: string
+  }) => Promise<{ saved: boolean }>
 }
 
 const bootstrapPayload = {
@@ -225,6 +230,135 @@ describe('Web bootstrap event connection', () => {
       code: 'invalid-command-arguments',
       message: 'Invalid project request.'
     })
+  })
+
+  it('settles a Web RPC when the remote response stops making progress', async () => {
+    let rpcSignal: AbortSignal | undefined
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input) === '/api/bootstrap') {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ ...bootstrapPayload, rpcChannels: ['projects:create'] }),
+              { status: 200, headers: { 'content-type': 'application/json' } }
+            )
+          )
+        }
+        if (String(input) === '/rpc/projects%3Acreate') {
+          rpcSignal = init?.signal ?? undefined
+          return new Promise<Response>((_resolve, reject) => {
+            rpcSignal?.addEventListener(
+              'abort',
+              () => reject(rpcSignal?.reason ?? new DOMException('Request aborted', 'AbortError')),
+              { once: true }
+            )
+          })
+        }
+        throw new Error(`Unexpected fetch: ${String(input)}`)
+      })
+    )
+
+    const api = await loadBootstrap()
+    const request = api.projects.create({ name: 'Never finishes' })
+    const outcome = Promise.race([
+      request.then(
+        () => 'resolved' as const,
+        () => 'rejected' as const
+      ),
+      new Promise<'still-pending'>((resolve) =>
+        window.setTimeout(() => resolve('still-pending'), 30_001)
+      )
+    ])
+
+    await vi.advanceTimersByTimeAsync(30_001)
+
+    await expect(outcome).resolves.toBe('rejected')
+    expect(rpcSignal?.aborted).toBe(true)
+  })
+
+  it('settles a stalled managed download and releases its acquired resource', async () => {
+    let downloadSignal: AbortSignal | undefined
+    let released = false
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        if (url === '/api/bootstrap') {
+          return Promise.resolve(
+            new Response(JSON.stringify(bootstrapPayload), {
+              status: 200,
+              headers: { 'content-type': 'application/json' }
+            })
+          )
+        }
+        if (url === '/rpc/preview-resources%3Aacquire') {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                protocolVersion: WEB_RPC_PROTOCOL_VERSION,
+                ok: true,
+                result: { id: 'resource-1', url: '/preview/resource-1' }
+              }),
+              { status: 200, headers: { 'content-type': 'application/json' } }
+            )
+          )
+        }
+        if (url === '/preview/resource-1') {
+          downloadSignal = init?.signal ?? undefined
+          return Promise.resolve({
+            ok: true,
+            blob: () =>
+              new Promise<Blob>((_resolve, reject) => {
+                downloadSignal?.addEventListener(
+                  'abort',
+                  () =>
+                    reject(
+                      downloadSignal?.reason ?? new DOMException('Download aborted', 'AbortError')
+                    ),
+                  { once: true }
+                )
+              })
+          } as Response)
+        }
+        if (url === '/rpc/preview-resources%3Arelease') {
+          released = true
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                protocolVersion: WEB_RPC_PROTOCOL_VERSION,
+                ok: true,
+                result: null
+              }),
+              { status: 200, headers: { 'content-type': 'application/json' } }
+            )
+          )
+        }
+        throw new Error(`Unexpected fetch: ${url}`)
+      })
+    )
+
+    const api = await loadBootstrap()
+    const request = api.saveManagedFile({
+      source: 'artifact',
+      path: 'artifact-1/report.pdf',
+      suggestedName: 'report.pdf'
+    })
+    const outcome = Promise.race([
+      request.then(
+        () => 'resolved' as const,
+        () => 'rejected' as const
+      ),
+      new Promise<'still-pending'>((resolve) =>
+        window.setTimeout(() => resolve('still-pending'), 300_001)
+      )
+    ])
+
+    await vi.advanceTimersByTimeAsync(300_001)
+
+    await expect(outcome).resolves.toBe('rejected')
+    expect(downloadSignal?.aborted).toBe(true)
+    expect(released).toBe(true)
   })
 
   it('waits for renderer consumers before opening the event stream', async () => {

--- a/src/renderer/web/bootstrap.test.ts
+++ b/src/renderer/web/bootstrap.test.ts
@@ -419,6 +419,57 @@ describe('Web bootstrap event connection', () => {
     await vi.waitFor(() => expect(outcome).toBeInstanceOf(DOMException))
   })
 
+  it('does not abort an ordinary mutation when its event connection disconnects', async () => {
+    let rpcSignal: AbortSignal | undefined
+    let resolveRpc!: (response: Response) => void
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input) === '/api/bootstrap') {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ ...bootstrapPayload, rpcChannels: ['projects:create'] }),
+              { status: 200, headers: { 'content-type': 'application/json' } }
+            )
+          )
+        }
+        if (String(input) === '/rpc/projects%3Acreate') {
+          rpcSignal = init?.signal ?? undefined
+          return new Promise<Response>((resolve, reject) => {
+            resolveRpc = resolve
+            rpcSignal?.addEventListener(
+              'abort',
+              () => reject(rpcSignal?.reason ?? new DOMException('Request aborted', 'AbortError')),
+              { once: true }
+            )
+          })
+        }
+        throw new Error(`Unexpected fetch: ${String(input)}`)
+      })
+    )
+
+    const api = await loadBootstrap()
+    const socket = FakeWebSocket.instances[0]
+    socket.emit('open')
+    socket.emit('message', { data: readyFrame(0) })
+    const request = api.projects.create({ name: 'Committed once' })
+
+    socket.emit('close')
+
+    expect(rpcSignal?.aborted).toBe(false)
+    resolveRpc(
+      new Response(
+        JSON.stringify({
+          protocolVersion: WEB_RPC_PROTOCOL_VERSION,
+          ok: true,
+          result: { id: 'project-1', name: 'Committed once' }
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    )
+    await expect(request).resolves.toMatchObject({ id: 'project-1' })
+  })
+
   it('settles a stalled managed download and releases its acquired resource', async () => {
     let downloadSignal: AbortSignal | undefined
     let released = false

--- a/src/renderer/web/bootstrap.ts
+++ b/src/renderer/web/bootstrap.ts
@@ -45,6 +45,8 @@ type Listener = (payload: unknown) => void
 
 const BOOTSTRAP_ATTEMPTS = 8
 const BOOTSTRAP_TIMEOUT_MS = 8_000
+const WEB_RPC_TIMEOUT_MS = 30_000
+const WEB_DOWNLOAD_TIMEOUT_MS = 5 * 60_000
 const EVENT_CONNECTION_ATTEMPTS = 8
 
 const clientId = sessionStorage.getItem('open-science-web-client') ?? crypto.randomUUID()
@@ -72,6 +74,25 @@ if (connectionLogo) {
 
 const wait = (delayMs: number): Promise<void> =>
   new Promise((resolve) => window.setTimeout(resolve, delayMs))
+
+const withRequestTimeout = async <T>(
+  timeoutMs: number,
+  operation: (signal: AbortSignal) => Promise<T>
+): Promise<T> => {
+  const controller = new AbortController()
+  const timeout = window.setTimeout(
+    () =>
+      controller.abort(
+        new DOMException(`Request timed out after ${timeoutMs} milliseconds.`, 'TimeoutError')
+      ),
+    timeoutMs
+  )
+  try {
+    return await operation(controller.signal)
+  } finally {
+    window.clearTimeout(timeout)
+  }
+}
 
 const responseError = (response: Response, body: string, fallback: string): Error => {
   if (response.status === 401) return new RemoteAccessOffError(REMOTE_ACCESS_OFF_MESSAGE)
@@ -103,26 +124,24 @@ const fetchBootstrap = async (): Promise<unknown> => {
       )
       await wait(Math.min(500 * 2 ** (attempt - 2), 5_000))
     }
-    const controller = new AbortController()
-    const timeout = window.setTimeout(() => controller.abort(), BOOTSTRAP_TIMEOUT_MS)
     try {
-      const response = await fetch('/api/bootstrap', {
-        cache: 'no-store',
-        signal: controller.signal
+      return await withRequestTimeout(BOOTSTRAP_TIMEOUT_MS, async (signal) => {
+        const response = await fetch('/api/bootstrap', {
+          cache: 'no-store',
+          signal
+        })
+        if (!response.ok) {
+          throw responseError(
+            response,
+            await response.text(),
+            `Open Science returned HTTP ${response.status}.`
+          )
+        }
+        return await response.json()
       })
-      if (!response.ok) {
-        throw responseError(
-          response,
-          await response.text(),
-          `Open Science returned HTTP ${response.status}.`
-        )
-      }
-      return response.json()
     } catch (error) {
       if (error instanceof RemoteAccessOffError) throw error
       lastError = error
-    } finally {
-      window.clearTimeout(timeout)
     }
   }
   throw lastError instanceof Error
@@ -179,15 +198,18 @@ const encodeBinary = (_key: string, value: unknown): unknown => {
 }
 
 const invoke = async (channel: string, args: unknown[]): Promise<unknown> => {
-  const response = await fetch(`/rpc/${encodeURIComponent(channel)}`, {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      'x-open-science-client': clientId
-    },
-    body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args }, encodeBinary)
+  const { response, body } = await withRequestTimeout(WEB_RPC_TIMEOUT_MS, async (signal) => {
+    const response = await fetch(`/rpc/${encodeURIComponent(channel)}`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-open-science-client': clientId
+      },
+      body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args }, encodeBinary),
+      signal
+    })
+    return { response, body: await response.text() }
   })
-  const body = await response.text()
   let payload
   try {
     payload = webRpcResponseSchema.parse(JSON.parse(body, reviveBinary))
@@ -367,9 +389,12 @@ const installWebApi = async (): Promise<EventCursor> => {
           { source: request.source, path: request.path }
         ])) as { id: string; url: string }
         try {
-          const response = await fetch(resource.url)
-          if (!response.ok) throw new Error(`Download failed: HTTP ${response.status}`)
-          downloadBlob(await response.blob(), request.suggestedName)
+          const blob = await withRequestTimeout(WEB_DOWNLOAD_TIMEOUT_MS, async (signal) => {
+            const response = await fetch(resource.url, { signal })
+            if (!response.ok) throw new Error(`Download failed: HTTP ${response.status}`)
+            return await response.blob()
+          })
+          downloadBlob(blob, request.suggestedName)
           return { saved: true }
         } finally {
           await invoke('preview-resources:release', [{ resourceId: resource.id }])

--- a/src/renderer/web/bootstrap.ts
+++ b/src/renderer/web/bootstrap.ts
@@ -48,11 +48,14 @@ const BOOTSTRAP_TIMEOUT_MS = 8_000
 const WEB_RPC_TIMEOUT_MS = 30_000
 const WEB_DOWNLOAD_TIMEOUT_MS = 5 * 60_000
 const EVENT_CONNECTION_ATTEMPTS = 8
+const EVENT_CONNECTION_IDLE_TIMEOUT_MS = 30_000
+const MODEL_OWNED_WEB_RPC_CHANNELS = new Set(['notebook:execute', 'notebook:run-cell'])
 
 const clientId = sessionStorage.getItem('open-science-web-client') ?? crypto.randomUUID()
 sessionStorage.setItem('open-science-web-client', clientId)
 
 const listeners = new Map<string, Set<Listener>>()
+let eventConnectionController = new AbortController()
 
 const connectionMessage = (): HTMLElement | null =>
   document.getElementById('open-science-connection-message')
@@ -77,7 +80,8 @@ const wait = (delayMs: number): Promise<void> =>
 
 const withRequestTimeout = async <T>(
   timeoutMs: number,
-  operation: (signal: AbortSignal) => Promise<T>
+  operation: (signal: AbortSignal) => Promise<T>,
+  externalSignal?: AbortSignal
 ): Promise<T> => {
   const controller = new AbortController()
   const timeout = window.setTimeout(
@@ -88,7 +92,9 @@ const withRequestTimeout = async <T>(
     timeoutMs
   )
   try {
-    return await operation(controller.signal)
+    return await operation(
+      externalSignal ? AbortSignal.any([externalSignal, controller.signal]) : controller.signal
+    )
   } finally {
     window.clearTimeout(timeout)
   }
@@ -198,7 +204,7 @@ const encodeBinary = (_key: string, value: unknown): unknown => {
 }
 
 const invoke = async (channel: string, args: unknown[]): Promise<unknown> => {
-  const { response, body } = await withRequestTimeout(WEB_RPC_TIMEOUT_MS, async (signal) => {
+  const request = async (signal?: AbortSignal): Promise<{ response: Response; body: string }> => {
     const response = await fetch(`/rpc/${encodeURIComponent(channel)}`, {
       method: 'POST',
       headers: {
@@ -209,7 +215,13 @@ const invoke = async (channel: string, args: unknown[]): Promise<unknown> => {
       signal
     })
     return { response, body: await response.text() }
-  })
+  }
+  // Notebook execution has its own optional domain deadline. A transport wall clock must not report
+  // failure while the kernel is still legitimately running; connection liveness owns disconnects.
+  const connectionSignal = eventConnectionController.signal
+  const { response, body } = MODEL_OWNED_WEB_RPC_CHANNELS.has(channel)
+    ? await request(connectionSignal)
+    : await withRequestTimeout(WEB_RPC_TIMEOUT_MS, request, connectionSignal)
   let payload
   try {
     payload = webRpcResponseSchema.parse(JSON.parse(body, reviveBinary))
@@ -269,18 +281,36 @@ const requireEventReload = (socket: WebSocket): void => {
 
 const connectEvents = (): void => {
   if (eventRecoveryRequired) return
+  if (eventConnectionController.signal.aborted) {
+    eventConnectionController = new AbortController()
+  }
+  const connectionLease = eventConnectionController
   const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
   const url = new URL(`${protocol}//${location.host}/events`)
   url.searchParams.set('client', clientId)
   url.searchParams.set('eventProtocol', String(WEB_EVENT_STREAM_PROTOCOL_VERSION))
   url.searchParams.set('stream', eventCursor.streamId)
   url.searchParams.set('after', String(eventCursor.latestSequence))
+  url.searchParams.set('liveness', '1')
   const socket = new WebSocket(url.toString())
+  const expireConnection = (): void => {
+    if (eventConnectionController === connectionLease && !connectionLease.signal.aborted) {
+      connectionLease.abort(new DOMException('Event stream liveness timed out.', 'TimeoutError'))
+    }
+    socket.close(4000, 'Event stream liveness timeout')
+  }
+  let idleTimeout = window.setTimeout(expireConnection, EVENT_CONNECTION_IDLE_TIMEOUT_MS)
+  const armIdleTimeout = (): void => {
+    window.clearTimeout(idleTimeout)
+    idleTimeout = window.setTimeout(expireConnection, EVENT_CONNECTION_IDLE_TIMEOUT_MS)
+  }
 
   socket.addEventListener('open', () => {
+    armIdleTimeout()
     publishEventConnectionPhase('replaying')
   })
   socket.addEventListener('message', (event) => {
+    armIdleTimeout()
     let decoded: unknown
     try {
       decoded = JSON.parse(String(event.data), reviveBinary)
@@ -317,6 +347,10 @@ const connectEvents = (): void => {
       eventCursor.latestSequence = message.sequence
       return
     }
+    if (message.kind === 'heartbeat') {
+      if (message.latestSequence !== eventCursor.latestSequence) requireEventReload(socket)
+      return
+    }
     if (message.latestSequence !== eventCursor.latestSequence) {
       requireEventReload(socket)
       return
@@ -326,6 +360,10 @@ const connectEvents = (): void => {
     window.dispatchEvent(new Event(WEB_EVENTS_OPEN_EVENT))
   })
   socket.addEventListener('close', () => {
+    window.clearTimeout(idleTimeout)
+    if (eventConnectionController === connectionLease && !connectionLease.signal.aborted) {
+      connectionLease.abort(new DOMException('Event stream disconnected.', 'NetworkError'))
+    }
     if (eventRecoveryRequired) return
     eventReconnectAttempt += 1
     if (eventReconnectAttempt >= EVENT_CONNECTION_ATTEMPTS) {

--- a/src/renderer/web/bootstrap.ts
+++ b/src/renderer/web/bootstrap.ts
@@ -221,7 +221,7 @@ const invoke = async (channel: string, args: unknown[]): Promise<unknown> => {
   const connectionSignal = eventConnectionController.signal
   const { response, body } = MODEL_OWNED_WEB_RPC_CHANNELS.has(channel)
     ? await request(connectionSignal)
-    : await withRequestTimeout(WEB_RPC_TIMEOUT_MS, request, connectionSignal)
+    : await withRequestTimeout(WEB_RPC_TIMEOUT_MS, request)
   let payload
   try {
     payload = webRpcResponseSchema.parse(JSON.parse(body, reviveBinary))

--- a/src/shared/web-rpc-contract.ts
+++ b/src/shared/web-rpc-contract.ts
@@ -140,6 +140,15 @@ export const webRpcEventReadySchema = z
   })
   .strict()
 
+export const webRpcEventHeartbeatSchema = z
+  .object({
+    kind: z.literal('heartbeat'),
+    protocolVersion: z.literal(WEB_EVENT_STREAM_PROTOCOL_VERSION),
+    streamId: z.string().min(1),
+    latestSequence: z.number().int().nonnegative()
+  })
+  .strict()
+
 export const webRpcEventResyncRequiredSchema = z
   .object({
     kind: z.literal('resync-required'),
@@ -153,6 +162,7 @@ export const webRpcEventResyncRequiredSchema = z
 export const webRpcEventMessageSchema = z.discriminatedUnion('kind', [
   webRpcEventSchema,
   webRpcEventReadySchema,
+  webRpcEventHeartbeatSchema,
   webRpcEventResyncRequiredSchema
 ])
 


### PR DESCRIPTION
## Problem

The original fix bounded Web and SDK waits, but one 30-second Web RPC wall clock was too broad:
legitimate long Notebook execution could be aborted even while the kernel was healthy. The same
lifecycle distinction matters for blocking model responses and prompts paused for permission or
elicitation: human/model duration is not transport failure.

There were also transport gaps beneath those operations:

- Web and SDK requests, polling, and download bodies could remain pending on a stalled connection.
- SDK event readiness could resolve on failure; malformed JSON escaped the iterator error channel;
  and its queue was unbounded.
- A WebSocket could stay half-open forever because neither endpoint had observable liveness.
- The native Responses compatibility path bounded response headers and streaming idle time, but a
  blocking JSON response body could stall indefinitely after headers.
- Interactive prompt admission waited for a provider update. A blocking provider that emitted no
  early update retained the Web request even after the application runtime had accepted the prompt.

Focused tests reproduced all reported paths before implementation. The expanded red cases cover
long Notebook execution, disconnect cancellation, blocking provider admission, immediate dispatch
rejection, blocking model JSON bodies, client idle watchdogs, heartbeat filtering, real server
heartbeats, and protection of ordinary mutations during an event-stream reconnect.

## Proposed change

Separate transport liveness from domain-operation duration:

```mermaid
flowchart LR
  UI[Web or SDK caller] -->|short request deadline| HTTP[HTTP request/body]
  UI -->|long Notebook or Run| Operation[Domain operation lifecycle]
  UI <-->|10 s heartbeat / 30 s idle watchdog| Events[Event WebSocket]
  Events -->|disconnect abort lease| Operation
  HTTP -->|prompt admitted| Runtime[Application runtime]
  Runtime -->|events and Run/Session state| Events
  Runtime -->|2 min headers / 5 min body idle| Model[Model provider]
  Runtime -->|no transport deadline| Human[Permission or elicitation]
```

- Keep finite deadlines for Web bootstrap, ordinary Web RPC, managed downloads, SDK HTTP requests,
  polling requests, and SDK download-body consumption. Caller `AbortSignal`s remain authoritative.
- Keep ordinary Web RPCs independent from event-stream reconnects. A socket close must not turn a
  server-side committed mutation into a client-visible failure that is unsafe to retry.
- Exempt `notebook:execute` and `notebook:run-cell` from the generic 30-second Web RPC wall clock.
  They use their own optional domain deadline, but remain bound to the event-connection lease so a
  disconnect or liveness timeout rejects deterministically.
- Settle interactive `startPrompt` when the application runtime owns the prompt, while preserving
  immediate runtime dispatch rejection. Blocking model work, permission approval, and elicitation
  continue through existing events and Session/Run state.
- Apply the existing 5-minute upstream idle deadline to blocking native Responses JSON bodies as
  well as event streams; the response-header deadline remains 2 minutes.
- Add opt-in WebSocket liveness (`liveness=1`). The server sends native ping frames and application
  heartbeat control frames every 10 seconds. Web and SDK clients fail after 30 seconds without any
  frame; SDK callers may override this with `idleTimeoutMs`. Control heartbeats are filtered and are
  never delivered as business events.
- Preserve SDK event settle-once behavior, contain JSON parse failures in the iterator, and fail
  closed above 1024 buffered business events.

## Scope and non-goals

- **Historical compatibility:** no stored-data compatibility or migration is required. Liveness is
  opt-in, so old Web/SDK clients do not receive the new control frames. Existing SDK call sites stay
  source-compatible because `requestTimeoutMs`, per-request `{ signal, timeoutMs }`, and event
  `idleTimeoutMs` are optional. Callers that relied on unbounded broken connections now receive an
  error instead.
- **State / enum additions:** no persisted or business lifecycle status is added. Existing Session
  statuses and `RunAttention` remain unchanged; `plan-approval` is still the only structured SDK Run
  attention. Permission and elicitation do not gain new attention values. `heartbeat` and
  `connection.heartbeat` are opt-in transport control discriminants, not domain states.
- **Persistence:** no database field, Session JSON field, migration, or other durable representation
  changes.
- **Data model / API payloads:** no business request/response field or domain relationship changes.
  The public SDK adds only optional lifecycle configuration, and WebSocket URLs add the transport
  query parameter `liveness=1`.
- **Interaction:** no new renderer control or copy. Prompt submission acknowledges application
  admission earlier after immediate dispatch rejection has been ruled out; ongoing model, Notebook,
  permission, and elicitation work remains represented by existing events and state. Existing error
  paths handle transport timeout/disconnect failures.
- Existing timeout defaults remain: ordinary Web/SDK requests 30 seconds, managed Web downloads 5
  minutes, native model response headers 2 minutes, native model body idle 5 minutes.

New stable runtime error codes from the original scope are `event_stream_invalid_message` and
`event_stream_overflow`; event idle expiry reuses the existing `timeout` code.

## Acceptance criteria and validation

Checks below ran after the last material edit:

- Web, SDK, event-server, replay stream, ACP admission, native model body, and Task API behavior ->
  `npx vitest run src/renderer/web/bootstrap.test.ts packages/open-science/client.test.ts src/main/web-service/http-server.test.ts src/main/web-service/internal-web-event-stream.test.ts src/main/acp/runtime-coordinator.test.ts src/main/acp/ipc.test.ts src/main/settings/native-responses-compatibility.test.ts src/main/web-service/task-api.test.ts` -> 8 files, 238 tests passed.
- Published SDK/CLI consumers, including existing Plan attention -> `npm run test:cli` -> 4 files,
  68 tests passed and 4 platform-gated tests skipped.
- Node declarations and main-process consumers -> `npm run typecheck:node` -> passed.
- Web protocol and renderer consumers -> `npm run typecheck:web` -> passed.
- Source/style validation -> `npm run lint` -> passed.
- Published package contents -> `npm run check:cli-package` -> passed; implementation, declarations,
  and README are included.
- Formatting/patch hygiene -> targeted Prettier and `git diff --check` -> passed.

The complete local `npm test` was intentionally not run per maintainer direction. Exact-head impact
classification selects the full plan because `packages/open-science/README.md` has ambiguous
`cli_sdk`/documentation ownership; PR CI is authoritative for the complete portable and platform
lanes.

## Review focus

- The boundary between short transport deadlines and long Notebook/model/human-owned lifecycles.
- Ordinary mutation safety across event-stream reconnects versus explicit Notebook lease cancellation.
- Whether application-runtime ownership is the correct prompt admission point while provider
  acceptance remains available to Task progress observers and immediate dispatch errors still reject.
- Backward compatibility of opt-in heartbeat frames and the 10-second/30-second liveness windows.
- Cancellation propagation when an event connection becomes half-open or disconnects.
- Blocking native Responses JSON-body idle handling and stream behavior preservation.
- Public SDK compatibility of optional lifecycle controls and stable iterator error ordering.

Independent review and exact-head PR CI are authoritative after the expanded commit is pushed.
