### PR TITLE
fix(web-service): harden local HTTP boundaries

### DIFF
--- a/scripts/ci/change-impact.json
+++ b/scripts/ci/change-impact.json
@@ -169,7 +169,6 @@
         "src/main/tray.ts",
         "src/main/update/create-strategy.ts",
         "src/main/update/electron-updater-strategy.ts",
-        "src/main/web-service/auth.ts",
         "src/main/session-persistence/**",
         "src/main/file-save.ts",
         "src/main/specialist/repository.ts",

--- a/scripts/ci/change-impact.json
+++ b/scripts/ci/change-impact.json
@@ -169,6 +169,7 @@
         "src/main/tray.ts",
         "src/main/update/create-strategy.ts",
         "src/main/update/electron-updater-strategy.ts",
+        "src/main/web-service/auth.ts",
         "src/main/session-persistence/**",
         "src/main/file-save.ts",
         "src/main/specialist/repository.ts",

--- a/src/main/web-service/auth.test.ts
+++ b/src/main/web-service/auth.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { chmod, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { IncomingMessage } from 'node:http'
@@ -26,6 +26,21 @@ describe('web authentication', () => {
     expect(second).toBe(first)
     expect((await readFile(join(dir, 'web-token'), 'utf8')).trim()).toBe(first)
   })
+
+  it.runIf(process.platform !== 'win32')(
+    'repairs reused token permissions without rotating the credential',
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'open-science-web-auth-'))
+      dirs.push(dir)
+      const tokenPath = join(dir, 'web-token')
+      const existing = 'a'.repeat(43)
+      await writeFile(tokenPath, `${existing}\n`, { mode: 0o644 })
+      await chmod(tokenPath, 0o644)
+
+      expect(await loadOrCreateWebToken(dir)).toBe(existing)
+      expect((await stat(tokenPath)).mode & 0o777).toBe(0o600)
+    }
+  )
 
   it('accepts only token-authenticated loopback requests with a same-origin Origin', () => {
     const token = 'a'.repeat(43)

--- a/src/main/web-service/auth.test.ts
+++ b/src/main/web-service/auth.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { chmod, mkdtemp, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { IncomingMessage } from 'node:http'
@@ -39,6 +39,24 @@ describe('web authentication', () => {
 
       expect(await loadOrCreateWebToken(dir)).toBe(existing)
       expect((await stat(tokenPath)).mode & 0o777).toBe(0o600)
+    }
+  )
+
+  it.runIf(process.platform !== 'win32')(
+    'rejects a symlinked token without modifying its target',
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'open-science-web-auth-'))
+      dirs.push(dir)
+      const targetPath = join(dir, 'unrelated-file')
+      const tokenPath = join(dir, 'web-token')
+      const target = 'b'.repeat(43)
+      await writeFile(targetPath, `${target}\n`, { mode: 0o644 })
+      await chmod(targetPath, 0o644)
+      await symlink(targetPath, tokenPath)
+
+      await expect(loadOrCreateWebToken(dir)).rejects.toThrow()
+      expect((await readFile(targetPath, 'utf8')).trim()).toBe(target)
+      expect((await stat(targetPath)).mode & 0o777).toBe(0o644)
     }
   )
 

--- a/src/main/web-service/auth.test.ts
+++ b/src/main/web-service/auth.test.ts
@@ -42,6 +42,18 @@ describe('web authentication', () => {
     }
   )
 
+  it.runIf(process.platform !== 'win32')('repairs and reuses a read-only token file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'open-science-web-auth-'))
+    dirs.push(dir)
+    const tokenPath = join(dir, 'web-token')
+    const existing = 'c'.repeat(43)
+    await writeFile(tokenPath, `${existing}\n`, { mode: 0o400 })
+    await chmod(tokenPath, 0o400)
+
+    expect(await loadOrCreateWebToken(dir)).toBe(existing)
+    expect((await stat(tokenPath)).mode & 0o777).toBe(0o600)
+  })
+
   it.runIf(process.platform !== 'win32')(
     'rejects a symlinked token without modifying its target',
     async () => {

--- a/src/main/web-service/auth.ts
+++ b/src/main/web-service/auth.ts
@@ -1,33 +1,32 @@
 import { randomBytes, timingSafeEqual } from 'node:crypto'
-import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { mkdir, open } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 
 const TOKEN_FILE = 'web-token'
 const COOKIE_NAME = 'open_science_web_token'
 
-const restrictTokenPermissions = async (tokenPath: string): Promise<void> => {
-  await chmod(tokenPath, 0o600)
-}
-
 const loadOrCreateWebToken = async (configRoot: string): Promise<string> => {
   const tokenPath = join(configRoot, TOKEN_FILE)
-  let existing: string | undefined
-  try {
-    existing = (await readFile(tokenPath, 'utf8')).trim()
-  } catch {
-    // Create the token below.
-  }
-  if (existing && existing.length >= 32) {
-    await restrictTokenPermissions(tokenPath)
-    return existing
-  }
-
-  const token = randomBytes(32).toString('base64url')
   await mkdir(dirname(tokenPath), { recursive: true })
-  await writeFile(tokenPath, `${token}\n`, { encoding: 'utf8', mode: 0o600 })
-  await restrictTokenPermissions(tokenPath)
-  return token
+  const tokenFile = await open(
+    tokenPath,
+    constants.O_CREAT | constants.O_RDWR | constants.O_NOFOLLOW,
+    0o600
+  )
+  try {
+    await tokenFile.chmod(0o600)
+    const existing = (await tokenFile.readFile('utf8')).trim()
+    if (existing.length >= 32) return existing
+
+    const token = randomBytes(32).toString('base64url')
+    await tokenFile.truncate(0)
+    await tokenFile.write(`${token}\n`, 0, 'utf8')
+    return token
+  } finally {
+    await tokenFile.close()
+  }
 }
 
 const safeEqual = (left: string | undefined, right: string): boolean => {

--- a/src/main/web-service/auth.ts
+++ b/src/main/web-service/auth.ts
@@ -1,31 +1,71 @@
 import { randomBytes, timingSafeEqual } from 'node:crypto'
 import { constants } from 'node:fs'
-import { mkdir, open } from 'node:fs/promises'
+import { mkdir, open, type FileHandle } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 
 const TOKEN_FILE = 'web-token'
 const COOKIE_NAME = 'open_science_web_token'
 
+const hasErrorCode = (error: unknown, code: string): boolean =>
+  error instanceof Error && 'code' in error && error.code === code
+
+const newWebToken = (): string => randomBytes(32).toString('base64url')
+
 const loadOrCreateWebToken = async (configRoot: string): Promise<string> => {
   const tokenPath = join(configRoot, TOKEN_FILE)
   await mkdir(dirname(tokenPath), { recursive: true })
-  const tokenFile = await open(
-    tokenPath,
-    constants.O_CREAT | constants.O_RDWR | constants.O_NOFOLLOW,
-    0o600
-  )
-  try {
-    await tokenFile.chmod(0o600)
-    const existing = (await tokenFile.readFile('utf8')).trim()
-    if (existing.length >= 32) return existing
 
-    const token = randomBytes(32).toString('base64url')
-    await tokenFile.truncate(0)
-    await tokenFile.write(`${token}\n`, 0, 'utf8')
-    return token
-  } finally {
-    await tokenFile.close()
+  for (;;) {
+    let tokenFile: FileHandle
+    try {
+      tokenFile = await open(tokenPath, constants.O_RDONLY | constants.O_NOFOLLOW)
+    } catch (error) {
+      if (!hasErrorCode(error, 'ENOENT')) throw error
+
+      const token = newWebToken()
+      try {
+        tokenFile = await open(
+          tokenPath,
+          constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
+          0o600
+        )
+      } catch (createError) {
+        if (hasErrorCode(createError, 'EEXIST')) continue
+        throw createError
+      }
+      try {
+        await tokenFile.chmod(0o600)
+        await tokenFile.write(`${token}\n`, 0, 'utf8')
+        return token
+      } finally {
+        await tokenFile.close()
+      }
+    }
+
+    try {
+      await tokenFile.chmod(0o600)
+      const identity = await tokenFile.stat()
+      const existing = (await tokenFile.readFile('utf8')).trim()
+      if (existing.length >= 32) return existing
+
+      const writableTokenFile = await open(tokenPath, constants.O_WRONLY | constants.O_NOFOLLOW)
+      try {
+        const writableIdentity = await writableTokenFile.stat()
+        if (writableIdentity.dev !== identity.dev || writableIdentity.ino !== identity.ino) {
+          throw new Error('Web token file changed while it was being opened.')
+        }
+        const token = newWebToken()
+        await writableTokenFile.chmod(0o600)
+        await writableTokenFile.truncate(0)
+        await writableTokenFile.write(`${token}\n`, 0, 'utf8')
+        return token
+      } finally {
+        await writableTokenFile.close()
+      }
+    } finally {
+      await tokenFile.close()
+    }
   }
 }
 

--- a/src/main/web-service/auth.ts
+++ b/src/main/web-service/auth.ts
@@ -1,23 +1,32 @@
 import { randomBytes, timingSafeEqual } from 'node:crypto'
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 
 const TOKEN_FILE = 'web-token'
 const COOKIE_NAME = 'open_science_web_token'
 
+const restrictTokenPermissions = async (tokenPath: string): Promise<void> => {
+  if (process.platform !== 'win32') await chmod(tokenPath, 0o600)
+}
+
 const loadOrCreateWebToken = async (configRoot: string): Promise<string> => {
   const tokenPath = join(configRoot, TOKEN_FILE)
+  let existing: string | undefined
   try {
-    const existing = (await readFile(tokenPath, 'utf8')).trim()
-    if (existing.length >= 32) return existing
+    existing = (await readFile(tokenPath, 'utf8')).trim()
   } catch {
     // Create the token below.
+  }
+  if (existing && existing.length >= 32) {
+    await restrictTokenPermissions(tokenPath)
+    return existing
   }
 
   const token = randomBytes(32).toString('base64url')
   await mkdir(dirname(tokenPath), { recursive: true })
   await writeFile(tokenPath, `${token}\n`, { encoding: 'utf8', mode: 0o600 })
+  await restrictTokenPermissions(tokenPath)
   return token
 }
 

--- a/src/main/web-service/auth.ts
+++ b/src/main/web-service/auth.ts
@@ -7,7 +7,7 @@ const TOKEN_FILE = 'web-token'
 const COOKIE_NAME = 'open_science_web_token'
 
 const restrictTokenPermissions = async (tokenPath: string): Promise<void> => {
-  if (process.platform !== 'win32') await chmod(tokenPath, 0o600)
+  await chmod(tokenPath, 0o600)
 }
 
 const loadOrCreateWebToken = async (configRoot: string): Promise<string> => {

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -88,6 +88,46 @@ afterEach(async () => {
 })
 
 describe('startWebHttpServer', () => {
+  it('serves static resources with browser security policies', async () => {
+    const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
+    roots.push(staticRoot)
+    await writeFile(join(staticRoot, 'index.html'), '<!doctype html><title>Web test</title>')
+    await writeFile(join(staticRoot, 'app.js'), 'window.__staticTest = true')
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot,
+      rpc: {
+        channels: () => [],
+        invoke: vi.fn(),
+        releaseClient: vi.fn(),
+        dispose: vi.fn()
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+
+    for (const path of ['/', '/app.js']) {
+      const response = await fetch(`http://127.0.0.1:${server.port}${path}`, {
+        headers: { authorization: 'Bearer test-token' }
+      })
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-security-policy')).toContain("default-src 'self'")
+      expect(response.headers.get('content-security-policy')).toContain(
+        "frame-ancestors 'none'"
+      )
+      expect(response.headers.get('x-frame-options')).toBe('DENY')
+      expect(response.headers.get('referrer-policy')).toBe('no-referrer')
+    }
+  })
+
   it('dispatches local Web RPC through the narrow application command view', async () => {
     const unusedFallbackInvoke = vi.fn()
     const directInvoke = vi.fn(

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -120,9 +120,7 @@ describe('startWebHttpServer', () => {
       })
       expect(response.status).toBe(200)
       expect(response.headers.get('content-security-policy')).toContain("default-src 'self'")
-      expect(response.headers.get('content-security-policy')).toContain(
-        "frame-ancestors 'none'"
-      )
+      expect(response.headers.get('content-security-policy')).toContain("frame-ancestors 'none'")
       expect(response.headers.get('x-frame-options')).toBe('DENY')
       expect(response.headers.get('referrer-policy')).toBe('no-referrer')
     }

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -46,6 +46,12 @@ const MAX_RPC_BODY_BYTES = 64 * 1024 * 1024
 const MIN_GZIP_BYTES = 1_024
 const INTERNAL_SERVER_ERROR_MESSAGE = 'Internal server error'
 const gzipAsync = promisify(gzip)
+const STATIC_RESPONSE_SECURITY_HEADERS = {
+  'content-security-policy':
+    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; media-src 'self' https: blob:; frame-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none'",
+  'x-frame-options': 'DENY',
+  'referrer-policy': 'no-referrer'
+} as const
 
 // Remote Browser access is an application session, not authority over native host lifecycle and
 // shell integration. The catalog keeps that authority decision aligned with renderer installation.
@@ -511,6 +517,7 @@ const serveStatic = async (
     const acceptsGzip = /\bgzip\b/i.test(String(request.headers['accept-encoding'] ?? ''))
     const body = canCompress && acceptsGzip ? await gzipAsync(content) : content
     response.writeHead(200, {
+      ...STATIC_RESPONSE_SECURITY_HEADERS,
       'content-type': MIME_TYPES[extension] ?? 'application/octet-stream',
       'content-length': String(body.byteLength),
       'cache-control': filePath.endsWith('index.html') ? 'no-store' : 'public, max-age=31536000',
@@ -522,6 +529,7 @@ const serveStatic = async (
   } catch {
     const message = 'Web UI is not built. Run npm run build:web first.'
     response.writeHead(503, {
+      ...STATIC_RESPONSE_SECURITY_HEADERS,
       'content-type': 'text/plain; charset=utf-8',
       'content-length': String(Buffer.byteLength(message))
     })


### PR DESCRIPTION
## Problem

The local Web service reuses an existing bearer-token file without restoring POSIX `0600` permissions. Static Web UI responses also omit an enforceable CSP response header, anti-framing policy, and an explicit referrer policy.

## Proposed change

- restore an existing valid token file to POSIX mode `0600` without rotating the credential;
- fail closed if the token permission repair cannot be applied;
- reject symlinked token files and apply permission repair to the opened file descriptor;
- add CSP, `X-Frame-Options: DENY`, and `Referrer-Policy: no-referrer` to static responses;
- cover both boundaries through real filesystem and HTTP regression tests.

## Scope and non-goals

The JSON request-body residency finding is intentionally deferred. This PR does not change body limits, parsing, HTTP 413 behavior, request fields, upload transport, data models, or database persistence.

## Acceptance criteria and validation

- existing POSIX token files end with mode `0600` and retain their token value;
- HTML and asset responses carry the required browser security policies;
- existing authentication and static content behavior remains intact;
- static-build fallback responses carry the same browser security policies;
- focused Web service tests, Node typecheck, lint, and changed-file formatting pass after the final material edit.

Red-before-fix evidence from PR Gate run 32311819849 on macOS:

- token regression: existing mode remained decimal `420` (`0644`) instead of `384` (`0600`);
- static-response regression: `Content-Security-Policy` was absent (`null`).

Green local verification after the final material edit:

- `npm test -- src/main/web-service/auth.test.ts src/main/web-service/http-server.test.ts`: 23 passed, 3 Windows-only POSIX skips;
- `npx vitest run scripts/ci/classify-pr-changes.test.ts`: 50 passed;
- `npm run typecheck:node`: passed;
- `npm run lint`: passed;
- Prettier check for the four changed Web service files: passed;
- `git diff --check main...HEAD`: passed.

Final PR verification at head `94afd6745`:

- PR Gate run `32317312175`: passed, including both full macOS Module-test shards, Module coverage, macOS build/E2E, Windows core, Windows E2E, and static checks;
- CI Integrity and CodeQL: passed;
- Codex Review: mergeable, no actionable findings.

## Compatibility and data impact

- Historical token compatibility: valid token bytes are retained, including read-only `0400`/`0444` files; only file mode metadata is repaired in place. Symlinked token paths and files that cannot be safely opened or repaired now fail startup closed instead of serving with a readable bearer credential.
- Interaction: framing is intentionally denied, including same-origin framing. Ordinary top-level Web UI use is unchanged.
- Data fields, schemas, data model, database persistence, and enum/state values: no changes.
- Persistence: no new persisted data; only existing/new token file mode metadata is enforced on POSIX.

## Review focus

- fail-closed behavior on POSIX permission repair failures;
- CSP compatibility with the existing Web HTML policy;
- confirmation that preview proxy responses and JSON body handling remain untouched.
