### PR TITLE
fix(acp): hide reports for Claude provider 4xx

### DIFF
--- a/src/main/acp/prompt-error.test.ts
+++ b/src/main/acp/prompt-error.test.ts
@@ -126,6 +126,46 @@ describe('isProviderPromptError', () => {
     expect(isProviderPromptError(error)).toBe(true)
   })
 
+  it.each([400, 401, 422, 499])(
+    'flags a Claude Code RequestError with an explicit provider %i status',
+    (status) => {
+      const error = agentError(`Internal error: API Error: ${status} Authentication Fails`, {
+        errorKind: 'unknown'
+      })
+
+      expect(isProviderPromptError(error)).toBe(true)
+    }
+  )
+
+  it('does not infer a provider error from nearby but non-equivalent text', () => {
+    expect(
+      isProviderPromptError(
+        agentError('Internal error: API Error: 500 Provider unavailable', {
+          errorKind: 'unknown'
+        })
+      )
+    ).toBe(false)
+    expect(
+      isProviderPromptError(
+        agentError('Internal error: validation failed with status 400', {
+          errorKind: 'unknown'
+        })
+      )
+    ).toBe(false)
+    expect(
+      isProviderPromptError(
+        Object.assign(new Error('Internal error: API Error: 400 Invalid request'), {
+          code: -32002,
+          data: { errorKind: 'unknown' },
+          name: 'RequestError'
+        })
+      )
+    ).toBe(false)
+    expect(isProviderPromptError(new Error('Internal error: API Error: 400 Invalid request'))).toBe(
+      false
+    )
+  })
+
   it('flags a provider resource-not-found (wrong model id / endpoint)', () => {
     const error = agentError(
       'Internal error: Not Found: {"error":{"message":"unknown model","type":"resource_not_found_error"}}'

--- a/src/main/acp/prompt-error.ts
+++ b/src/main/acp/prompt-error.ts
@@ -24,6 +24,7 @@ type UpstreamDetail = { text: string; type?: string }
 // bare "not found" substring, so a benign message like "rate limit config not found" isn't reworded.
 const NOT_FOUND_PATTERN =
   /resource[\s_-]?not[\s_-]?found|no such (?:model|resource)|not[\s_-]?found\s*:/i
+const CLAUDE_PROVIDER_CLIENT_ERROR_PATTERN = /^\s*internal error:\s*api error:\s*4\d{2}\b/i
 
 // Converts an unknown thrown value into its base message string.
 const rawErrorMessage = (error: unknown): string =>
@@ -168,19 +169,32 @@ const isProviderErrorKind = (error: unknown): boolean => {
   }
 }
 
+// claude-agent-acp currently forwards some explicit provider 4xx failures as a generic ACP internal
+// RequestError with `data.errorKind: 'unknown'`. The fixed wrapper and JSON-RPC code are the remaining
+// machine-stable boundary; require both so ordinary app errors containing a status number stay
+// reportable. Do not infer 5xx ownership here: provider-tagged 5xx errors still use the structural
+// APIError/provider-error paths above, while an untagged internal 5xx may be an adapter defect.
+const isClaudeProviderClientError = (error: unknown): boolean =>
+  error instanceof Error &&
+  error.name === 'RequestError' &&
+  errorCode(error) === -32603 &&
+  CLAUDE_PROVIDER_CLIENT_ERROR_PATTERN.test(error.message)
+
 // Whether a failed prompt originates from the model provider (an upstream LLM/HTTP failure the agent
 // relayed) rather than from the app's own ACP layer. Provider failures are the user's/provider's to
 // resolve (wrong key, rate limit, quota, model id, a provider 5xx), so the renderer does NOT offer a
 // "Report error → GitHub issue" affordance for them — only genuinely unexpected ACP-layer exceptions
 // are worth a bug report. Determined structurally, from the signals the agent attaches, so it needs no
-// message-text pattern matching:
+// broad human-message pattern matching:
 //   - the agent tagged the failure as an upstream `APIError` (covers auth/rate/quota/5xx/etc.), or
 //   - the agent tagged `data.errorKind: 'provider-error'` (the bridges' machine-readable marker), or
+//   - Claude Code emitted its fixed ACP internal wrapper with an explicit provider 4xx status, or
 //   - it is a provider "resource not found" (wrong model id / endpoint), which requires the same
 //     upstream signal (see isProviderNotFound) and is never a bare ACP protocol not-found.
 export const isProviderPromptError = (error: unknown): boolean => {
   if (isApiError(error)) return true
   if (isProviderErrorKind(error)) return true
+  if (isClaudeProviderClientError(error)) return true
 
   const raw = rawErrorMessage(error)
 

--- a/src/main/acp/prompt-outcome-finalizer.test.ts
+++ b/src/main/acp/prompt-outcome-finalizer.test.ts
@@ -326,6 +326,21 @@ describe('AcpPromptOutcomeFinalizer', () => {
       providerError: true
     },
     {
+      name: 'Claude Code provider 4xx with an unknown error kind',
+      error: Object.assign(
+        new Error(
+          'Internal error: API Error: 400 Authentication Fails, Your api key: ****e52d is invalid'
+        ),
+        {
+          code: -32603,
+          data: { errorKind: 'unknown' },
+          name: 'RequestError'
+        }
+      ),
+      recoverable: undefined,
+      providerError: true
+    },
+    {
       name: 'ACP error',
       error: new Error('protocol failed'),
       recoverable: undefined,

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -20808,31 +20808,45 @@ describe('ACP runtime session management', () => {
     expect(errorEvent?.recoverable).toBeUndefined()
   })
 
-  it('tags a provider-relayed prompt failure with providerError so the renderer hides Report', async () => {
-    const process = new FakeAgentProcess()
-    const events: Array<{ kind: string; providerError?: boolean }> = []
-    startFakeAgent(process, ['remote-session-1'], {
-      onPrompt: () => {
-        // An upstream provider rejection the agent relays as an APIError — the user's to fix, not a bug.
-        throw acp.RequestError.internalError({ errorName: 'APIError' }, 'Invalid API key')
-      }
-    })
-    const runtime = new AcpRuntime({
-      appVersion: '0.1.0',
-      defaultCwd: '/workspace',
-      spawnAgent: () => asAgentProcess(process),
-      callbacks: {
-        onEvent: (event) => events.push({ kind: event.kind, providerError: event.providerError })
-      }
-    })
+  it.each([
+    ['OpenCode APIError', { errorName: 'APIError' }, 'Invalid API key'],
+    [
+      'Claude Code explicit 4xx',
+      { errorKind: 'unknown' },
+      'API Error: 400 Authentication Fails, Your api key: ****e52d is invalid'
+    ],
+    [
+      'provider bridge error kind',
+      { errorKind: 'provider-error' },
+      '{"error":{"message":"Authentication failed","type":"authentication_error"}}'
+    ]
+  ] as const)(
+    'tags a provider-relayed %s prompt failure so the renderer hides Report',
+    async (_name, data, message) => {
+      const process = new FakeAgentProcess()
+      const events: Array<{ kind: string; providerError?: boolean }> = []
+      startFakeAgent(process, ['remote-session-1'], {
+        onPrompt: () => {
+          throw acp.RequestError.internalError(data, message)
+        }
+      })
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        spawnAgent: () => asAgentProcess(process),
+        callbacks: {
+          onEvent: (event) => events.push({ kind: event.kind, providerError: event.providerError })
+        }
+      })
 
-    await runtime.createSession({ cwd: '/workspace' })
-    await expect(
-      runtime.sendPrompt({ sessionId: 'remote-session-1', text: 'hi' })
-    ).rejects.toThrow()
+      await runtime.createSession({ cwd: '/workspace' })
+      await expect(
+        runtime.sendPrompt({ sessionId: 'remote-session-1', text: 'hi' })
+      ).rejects.toThrow()
 
-    expect(events).toContainEqual({ kind: 'error', providerError: true })
-  })
+      expect(events).toContainEqual({ kind: 'error', providerError: true })
+    }
+  )
 
   it('does not tag an ACP-layer prompt failure as providerError (stays reportable)', async () => {
     const process = new FakeAgentProcess()


### PR DESCRIPTION
## Problem

Claude Code relays some explicit upstream provider 4xx failures as ACP `RequestError(-32603)` with `data.errorKind: unknown`. The existing classifier therefore treated an invalid API key response as an internal app failure and showed the composer `Report error` action.

## Change

- Classify only the fixed Claude Code `Internal error: API Error: 4xx` wrapper as provider-owned when it is also a `RequestError` with code `-32603`.
- Keep nearby generic status text, other JSON-RPC codes, plain errors, and untagged 5xx failures reportable.
- Add classifier, finalizer, runtime, and renderer-contract coverage for the behavior.

## ACP compatibility

| ACP path | Classification contract |
| --- | --- |
| Claude Code | Adds the narrow `RequestError(-32603)` plus explicit `API Error: 4xx` fallback. |
| OpenCode | Preserves the existing structural `errorName: APIError` path. |
| Codex bridge | Preserves the existing structural `errorKind: provider-error` path. |
| Codex Responses | Raw provider JSON remains a model message and does not enter the composer app-error report path. |

## Scope and compatibility

- Architecture, data model, data relationships, and interaction design: unchanged. This corrects the existing Report affordance classification.
- Historical data compatibility: not required; no stored schema or historical record is changed.
- New states or enum values: none.
- Persistence: none. Existing runtime `providerError` and renderer `errorReportable` fields are reused without schema changes.
- Platform behavior: pure error classification; no platform-specific path changed.

## Validation

All checks below ran after the final material edit.

- Claude 4xx ownership and negative boundaries -> focused classifier/finalizer tests -> 6 passed.
- ACP compatibility shapes for OpenCode, Claude Code, and provider bridge -> focused runtime test -> 3 passed.
- `providerError: true` reaches renderer non-reportable state and hides Report -> focused renderer contract tests -> 2 passed.
- Node and renderer types -> `npm run typecheck:node`, `npm run typecheck:web` -> passed.
- Repository lint -> `npm run lint` -> passed.

The broader `src/main/acp/runtime.test.ts` run completed 587 tests successfully; 3 unrelated HTTP/Artifact tests could not bind `127.0.0.1` in the local sandbox (`listen EPERM`). The focused runtime contract above passed. Per task scope, the complete portable/platform suite is left to PR CI.

## Review focus

- Whether the Claude wrapper boundary is sufficiently narrow to avoid hiding genuine adapter defects.
- Whether the ACP compatibility coverage preserves existing OpenCode and bridge behavior.
