### PR TITLE
fix(session-persistence): merge disjoint concurrent graph changes

### DIFF
--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -910,6 +910,149 @@ describe('renderer session persistence bridge', () => {
     ])
   })
 
+  it('retries a pending tool activity save over disjoint concurrent Main graph changes', async () => {
+    const base = materializeSessionConversationGraph(
+      createPersistedSession({
+        projectId: 'project-a',
+        revision: 8,
+        messages: [
+          {
+            id: 'prompt-1',
+            role: 'user',
+            content: 'Run the notebook',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ]
+      })
+    )
+    const authoritative = materializeSessionConversationGraph({
+      ...base,
+      revision: 9,
+      status: 'waiting-permission' as const,
+      messages: [
+        ...base.messages,
+        {
+          id: 'main-relay-1',
+          role: 'agent' as const,
+          content: 'Main-owned relay update',
+          status: 'complete' as const,
+          eventIds: [],
+          createdAt: 2,
+          updatedAt: 2
+        }
+      ],
+      runtimeContext: {
+        version: 1 as const,
+        revision: 1,
+        permission: {
+          state: 'pending' as const,
+          request: {
+            requestId: 'permission-1',
+            sessionId: base.id,
+            toolCallId: 'tool-1',
+            title: 'notebook_execute',
+            options: [{ optionId: 'allow', name: 'Allow', kind: 'allow_once' as const }]
+          },
+          originatingPromptMessageId: 'prompt-1',
+          fingerprint: 'a'.repeat(64),
+          createdAt: 2
+        }
+      },
+      updatedAt: base.updatedAt + 1
+    })
+    const saveSession = vi
+      .fn<SessionPersistenceApi['saveSession']>()
+      .mockRejectedValueOnce(new SessionRevisionConflictError(8, 9))
+      .mockImplementationOnce(async (submitted) => ({ ...submitted, revision: 10 }))
+    const api = createApi({
+      loadOne: vi.fn().mockResolvedValue(authoritative),
+      saveSession
+    })
+
+    useSessionStore.getState().hydrateSessions([base])
+    const save = createStoreSaver(api, useSessionStore.getState())
+    useSessionStore.getState().upsertToolActivity({
+      sessionId: base.id,
+      toolCallId: 'tool-1',
+      eventId: 'tool-event-1',
+      promptMessageId: 'prompt-1',
+      title: 'notebook_execute',
+      status: 'pending'
+    })
+
+    await expect(save(useSessionStore.getState())).resolves.toBeUndefined()
+
+    expect(saveSession).toHaveBeenCalledTimes(2)
+    expect(saveSession.mock.calls[0][0]).toMatchObject({ revision: 8 })
+    expect(saveSession.mock.calls[1][0]).toMatchObject({
+      revision: 9,
+      status: 'waiting-permission',
+      runtimeContext: authoritative.runtimeContext,
+      activities: [expect.objectContaining({ id: 'tool-1', status: 'pending' })]
+    })
+    expect(saveSession.mock.calls[1][0].messages).toEqual(authoritative.messages)
+    expect(saveSession.mock.calls[1][0].conversationGraph?.messages.map(({ id }) => id)).toEqual([
+      'prompt-1',
+      'main-relay-1'
+    ])
+    expect(saveSession.mock.calls[1][0].conversationGraph?.activities.map(({ id }) => id)).toEqual([
+      'tool-1'
+    ])
+  })
+
+  it('does not retry when the same graph identity changed concurrently', async () => {
+    const base = materializeSessionConversationGraph(
+      createPersistedSession({
+        projectId: 'project-a',
+        revision: 8,
+        agentModel: 'base-model'
+      })
+    )
+    const authoritative = {
+      ...base,
+      revision: 9,
+      conversationGraph: {
+        ...base.conversationGraph,
+        runtimeSegments: base.conversationGraph.runtimeSegments.map((segment) => ({
+          ...segment,
+          model: 'remote-model'
+        }))
+      },
+      updatedAt: base.updatedAt + 1
+    }
+    const conflict = new SessionRevisionConflictError(8, 9)
+    const saveSession = vi.fn<SessionPersistenceApi['saveSession']>().mockRejectedValue(conflict)
+    const api = createApi({
+      loadOne: vi.fn().mockResolvedValue(authoritative),
+      saveSession
+    })
+
+    useSessionStore.getState().hydrateSessions([base])
+    const save = createStoreSaver(api, useSessionStore.getState())
+    const local = useSessionStore.getState().sessions[0]
+    useSessionStore.setState({
+      sessions: [
+        {
+          ...local,
+          conversationGraph: {
+            ...local.conversationGraph!,
+            runtimeSegments: local.conversationGraph!.runtimeSegments.map((segment) => ({
+              ...segment,
+              model: 'local-model'
+            }))
+          },
+          updatedAt: local.updatedAt + 1
+        }
+      ]
+    })
+
+    await expect(save(useSessionStore.getState())).rejects.toBe(conflict)
+    expect(saveSession).toHaveBeenCalledOnce()
+  })
+
   it('does not retry when both the local and authoritative conversation graphs changed', async () => {
     const base = materializeSessionConversationGraph(
       createPersistedSession({ projectId: 'project-a', revision: 1 })

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -115,6 +115,153 @@ const conversationGraphsEqualIgnoringBranchTimestamps = (
   return jsonValuesEqual(withoutBranchTimestamps(left), withoutBranchTimestamps(right))
 }
 
+type SessionConversationGraph = NonNullable<PersistedChatSession['conversationGraph']>
+
+const graphItemsEqual = <Item extends { id: string }>(
+  left: Item | undefined,
+  right: Item | undefined,
+  ignoreUpdatedAt: boolean
+): boolean => {
+  if (!left || !right) return left === right
+  return ignoreUpdatedAt
+    ? jsonValuesEqual({ ...left, updatedAt: 0 }, { ...right, updatedAt: 0 })
+    : jsonValuesEqual(left, right)
+}
+
+// Replays identity-disjoint graph edits onto the latest durable graph. An edit or deletion of the
+// same identity on both sides remains a real conflict; Branch updatedAt alone is derived metadata and
+// does not turn otherwise-disjoint Message/Activity additions into a conflict.
+const rebaseConversationGraphCollection = <Item extends { id: string }>(
+  baseItems: readonly Item[],
+  submittedItems: readonly Item[],
+  latestItems: readonly Item[],
+  ignoreUpdatedAt = false
+): Item[] | undefined => {
+  const baseById = new Map(baseItems.map((item) => [item.id, item]))
+  const submittedById = new Map(submittedItems.map((item) => [item.id, item]))
+  const latestById = new Map(latestItems.map((item) => [item.id, item]))
+  const orderedIds = [
+    ...new Set([
+      ...latestItems.map(({ id }) => id),
+      ...submittedItems.map(({ id }) => id),
+      ...baseItems.map(({ id }) => id)
+    ])
+  ]
+  const rebased: Item[] = []
+
+  for (const id of orderedIds) {
+    const baseItem = baseById.get(id)
+    const submittedItem = submittedById.get(id)
+    const latestItem = latestById.get(id)
+    let selected: Item | undefined
+    if (graphItemsEqual(submittedItem, baseItem, ignoreUpdatedAt)) {
+      selected = latestItem
+    } else if (graphItemsEqual(latestItem, baseItem, ignoreUpdatedAt)) {
+      selected = submittedItem
+    } else if (graphItemsEqual(submittedItem, latestItem, ignoreUpdatedAt)) {
+      selected = submittedItem
+    } else {
+      return undefined
+    }
+    if (selected) rebased.push(structuredClone(selected))
+  }
+
+  return rebased
+}
+
+const rebaseConversationGraph = (
+  base: PersistedChatSession['conversationGraph'],
+  submitted: PersistedChatSession['conversationGraph'],
+  latest: PersistedChatSession['conversationGraph']
+): PersistedChatSession['conversationGraph'] | undefined => {
+  if (conversationGraphsEqualIgnoringBranchTimestamps(submitted, base)) {
+    return latest ? structuredClone(latest) : undefined
+  }
+  if (conversationGraphsEqualIgnoringBranchTimestamps(latest, base)) {
+    return submitted ? structuredClone(submitted) : undefined
+  }
+  if (conversationGraphsEqualIgnoringBranchTimestamps(submitted, latest)) {
+    return submitted ? structuredClone(submitted) : undefined
+  }
+  if (!base || !submitted || !latest) return undefined
+
+  const resolveScalar = <Value>(
+    baseValue: Value,
+    submittedValue: Value,
+    latestValue: Value
+  ): Value | undefined => {
+    if (jsonValuesEqual(submittedValue, baseValue)) return structuredClone(latestValue)
+    if (jsonValuesEqual(latestValue, baseValue) || jsonValuesEqual(submittedValue, latestValue)) {
+      return structuredClone(submittedValue)
+    }
+    return undefined
+  }
+  const schemaVersion = resolveScalar(
+    base.schemaVersion,
+    submitted.schemaVersion,
+    latest.schemaVersion
+  )
+  const rootFrameId = resolveScalar(base.rootFrameId, submitted.rootFrameId, latest.rootFrameId)
+  const activeFrameId = resolveScalar(
+    base.activeFrameId,
+    submitted.activeFrameId,
+    latest.activeFrameId
+  )
+  const frames = rebaseConversationGraphCollection(base.frames, submitted.frames, latest.frames)
+  const branches = rebaseConversationGraphCollection(
+    base.branches,
+    submitted.branches,
+    latest.branches,
+    true
+  )
+  const messages = rebaseConversationGraphCollection(
+    base.messages,
+    submitted.messages,
+    latest.messages
+  )
+  const activities = rebaseConversationGraphCollection(
+    base.activities,
+    submitted.activities,
+    latest.activities
+  )
+  const activityGroups = rebaseConversationGraphCollection(
+    base.activityGroups,
+    submitted.activityGroups,
+    latest.activityGroups
+  )
+  const runtimeSegments = rebaseConversationGraphCollection(
+    base.runtimeSegments,
+    submitted.runtimeSegments,
+    latest.runtimeSegments
+  )
+
+  if (
+    schemaVersion === undefined ||
+    rootFrameId === undefined ||
+    activeFrameId === undefined ||
+    !frames ||
+    !branches ||
+    !messages ||
+    !activities ||
+    !activityGroups ||
+    !runtimeSegments
+  ) {
+    return undefined
+  }
+
+  return {
+    schemaVersion,
+    rootFrameId,
+    activeFrameId,
+    frames,
+    branches,
+    messages,
+    activities,
+    activityGroups,
+    runtimeSegments
+  } satisfies SessionConversationGraph
+}
+
 const sessionFieldValuesEqual = (
   key: keyof PersistedChatSession,
   left: unknown,
@@ -156,8 +303,17 @@ const rebaseSessionAfterRevisionConflict = (
     const localChanged = !sessionFieldValuesEqual(key, submittedValue, baseValue)
     if (!localChanged) continue
     const remoteChanged = !sessionFieldValuesEqual(key, latestValue, baseValue)
-    if (remoteChanged && !sessionFieldValuesEqual(key, submittedValue, latestValue))
-      return undefined
+    if (remoteChanged && !sessionFieldValuesEqual(key, submittedValue, latestValue)) {
+      if (key !== 'conversationGraph') return undefined
+      const graph = rebaseConversationGraph(
+        baseValue as PersistedChatSession['conversationGraph'],
+        submittedValue as PersistedChatSession['conversationGraph'],
+        latestValue as PersistedChatSession['conversationGraph']
+      )
+      if (!graph) return undefined
+      rebased.conversationGraph = graph
+      continue
+    }
 
     if (Object.hasOwn(submitted, key)) {
       Object.assign(rebased, { [key]: structuredClone(submittedValue) })


### PR DESCRIPTION
## Problem

A renderer Session save can race a Main-owned permission or relay persistence update. Revision recovery compared the complete conversation graph atomically, so identity-disjoint changes such as a Main-owned Message and a renderer-owned tool Activity were misclassified as a real cross-window conflict. The user then saw Conversation storage needs attention with expected revision 8 and actual revision 9.

## Proposed change

Rebase conversation graph collections by stable identity after an optimistic revision conflict. Preserve additions and deletions made on only one side, ignore derived Branch updatedAt differences, and retry against the latest durable revision. Continue to fail closed when the same Message, Activity, Frame, Branch, Activity Group, or Runtime Segment identity changed differently on both sides, or when graph scalar authority diverges.

This follows the application-level retry guidance in the Apache CouchDB conflict model and the object/property conflict boundary used by Automerge:

- https://docs.couchdb.org/en/stable/replication/conflicts.html#conflict-avoidance
- https://automerge.org/docs/reference/documents/conflicts/

## Scope and non-goals

- No Session JSON schema or database migration changes.
- No historical data migration or compatibility branch is required.
- No new status or enum values.
- No last-write-wins overwrite and no weakening of whole-Session revision checks.
- No ACP wire protocol, permission correlation, launcher, transport, model routing, or platform-specific path changes.

## Acceptance criteria and validation

Checks listed below ran after the last material implementation edit.

- Disjoint Main Message plus renderer tool Activity conflict recovery -> npm test -- src/renderer/src/lib/session-persistence/session-persistence.test.ts -> 33 passed.
- Same graph identity concurrent edits remain conflicts -> same command -> passed.
- Session renderer owner, persistence contract, and representative runtime consumer -> npm run test:module -- session_renderer -> 444 passed.
- Persistence recovery UI and quit flush behavior -> npm test -- src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx src/renderer/src/hooks/useQuitPersistenceFlush.test.ts -> 25 passed.
- Renderer type safety -> npm run typecheck:web -> passed.
- Source lint -> npm run lint -> passed with no warnings.

The affected-test classifier selects the full suite because src/renderer/src/lib/session-persistence/session-persistence.test.ts has no declared module owner. Per maintainer direction, the complete npm test suite was not run locally; PR Gate CI is the final authority.

## Compatibility matrix

- claude-code -> shared renderer Session persistence path -> covered by session_renderer module tests; no adapter change.
- opencode -> shared renderer Session persistence path -> covered by session_renderer module tests; no adapter change.
- codex-response -> observed native Responses compatibility path reaches the shared renderer saver -> covered by the deterministic revision 8 to 9 regression; no provider protocol change.
- codex-bridge -> shared renderer Session persistence path -> covered by session_renderer module tests; no bridge change.
- Models -> excluded as the persisted graph merge is model-independent.
- Platforms -> macOS local checks passed; Windows and Linux remain for PR CI because no platform-specific code changed.

## Review focus

Please verify that collection identity is the correct automatic merge boundary and that same-identity edits and deletions continue to fail closed.