### PR TITLE
fix(notifications): keep item actions independent of read writes

### DIFF
--- a/src/renderer/src/components/NotificationBell.test.tsx
+++ b/src/renderer/src/components/NotificationBell.test.tsx
@@ -262,6 +262,77 @@ describe('NotificationBell', () => {
     expect(markAllRead).toHaveBeenCalledTimes(1)
   })
 
+  it('continues the notification action when marking the message as read fails', async () => {
+    const connectorRequest = {
+      id: 'request-1',
+      connector: 'pubchem',
+      method: 'search',
+      argsPreview: '{}',
+      availableScopes: ['once']
+    } satisfies ConnectorApprovalRequest
+    const replayConnectorApproval = vi.fn(async () => connectorRequest)
+    const enqueueApproval = vi.fn()
+    const openSessionById = vi.fn()
+    const markRead = vi.fn(async () => {
+      throw new Error('notification write failed')
+    })
+    window.api.settings.replayConnectorApproval = replayConnectorApproval
+    useSettingsStore.setState({ enqueueApproval })
+    useNavigationStore.setState({ openSessionById })
+    const item = useNotificationInboxStore.getState().items[0]
+    useNotificationInboxStore.setState({
+      markRead,
+      items: item ? [{ ...item, sessionId: 'session-1' }] : []
+    })
+    await act(async () => root.render(<NotificationBell />))
+
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[aria-label^="Messages,"]')?.click()
+    )
+    const message = [...document.body.querySelectorAll('button')].find((button) =>
+      button.textContent?.includes('Approval needed')
+    )
+    await act(async () => message?.click())
+
+    expect(markRead).toHaveBeenCalledWith(['message-1'])
+    expect(replayConnectorApproval).toHaveBeenCalledWith('request-1')
+    expect(enqueueApproval).toHaveBeenCalledWith(connectorRequest)
+    expect(openSessionById).toHaveBeenCalledWith('session-1', 'notification')
+    expect(container.querySelector('[aria-label="Message center"]')).toBeNull()
+  })
+
+  it('does not wait for the read write before navigating to the notification target', async () => {
+    let completeMarkRead: (() => void) | undefined
+    const markRead = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          completeMarkRead = resolve
+        })
+    )
+    const openSessionById = vi.fn()
+    useNavigationStore.setState({ openSessionById })
+    const item = useNotificationInboxStore.getState().items[0]
+    useNotificationInboxStore.setState({
+      markRead,
+      items: item ? [{ ...item, actionState: 'resolved', sessionId: 'session-1' }] : []
+    })
+    await act(async () => root.render(<NotificationBell />))
+
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[aria-label^="Messages,"]')?.click()
+    )
+    const message = [...document.body.querySelectorAll('button')].find((button) =>
+      button.textContent?.includes('Approval needed')
+    )
+    await act(async () => message?.click())
+
+    expect(markRead).toHaveBeenCalledWith(['message-1'])
+    expect(openSessionById).toHaveBeenCalledWith('session-1', 'notification')
+    expect(container.querySelector('[aria-label="Message center"]')).toBeNull()
+
+    completeMarkRead?.()
+  })
+
   it.each([
     ['connector', undefined],
     ['compute', undefined],

--- a/src/renderer/src/components/NotificationBell.tsx
+++ b/src/renderer/src/components/NotificationBell.tsx
@@ -233,7 +233,7 @@ const NotificationBell = ({
 
   const openItem = async (item: NotificationInboxItem): Promise<void> => {
     if (item.targetInvalidatedAt !== undefined) return
-    if (item.readAt === undefined) await markRead([item.id])
+    if (item.readAt === undefined) void markRead([item.id]).catch(() => undefined)
     const replayedApproval = await replayPendingApproval(item)
     if (item.sessionId) {
       useNavigationStore.getState().openSessionById(item.sessionId, 'notification')


### PR DESCRIPTION
## Problem

Clicking an unread message-center item awaited the persisted read-state update before replaying a pending approval or navigating to its Project or Session target. A rejected notification write therefore blocked an otherwise valid primary action and surfaced an unhandled Promise rejection.

The regression test was run before the production change and failed deterministically twice: markRead was called, replayConnectorApproval had zero calls, navigation did not run, and Vitest reported the injected write rejection as unhandled.

## Proposed change

Treat the per-item read update as a best-effort asynchronous side effect. Start it when the user clicks, handle its rejection locally, and continue approval replay and target navigation without waiting. Backend notification write failures remain logged by the notification inbox controller.

Add component-level regression coverage for both a rejected read write and a read write that remains pending.

## Scope and non-goals

- No database columns, data fields, migrations, relationships, or persistence formats change.
- No enum or state values are added.
- Existing readAt persistence remains authoritative; a failed write leaves the item unread and can be retried later.
- No historical-data compatibility handling is required.
- Approval replay failures remain outside this focused change.
- No user-visible copy or locale catalogs change.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Rejected read write does not block approval replay, Session navigation, or panel close -> npm test -- src/renderer/src/components/NotificationBell.test.tsx -> 17 passed.
- Pending read write does not delay Session navigation -> npm test -- src/renderer/src/components/NotificationBell.test.tsx -> 17 passed.
- Renderer type safety -> npm run typecheck:web -> passed.
- Linted source and tests -> npm run lint -> passed.
- Patch formatting -> git diff --check -> passed.

NotificationBell is not assigned a dedicated module ID in scripts/ci/module-impact.json, so no nonexistent module suite is claimed. The targeted component suite covers the changed public interaction seam; PR Gate remains authoritative for conservative owner/consumer and platform selection. No platform-specific logic changed. The locally uncovered risk is a real database/IPC failure E2E; the regression injects the rejection at the renderer store boundary that NotificationBell consumes.

## Review focus

Please verify that marking a notification read is correctly treated as auxiliary to replay/navigation and that retaining an unread item after a failed write is the desired retry behavior.