### PR TITLE
fix(window-find): isolate overlay preload capabilities

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -10,7 +10,8 @@ export default defineConfig({
     build: {
       rollupOptions: {
         input: {
-          index: resolve('src/preload/index.ts')
+          index: resolve('src/preload/index.ts'),
+          'find-overlay': resolve('src/preload/find-overlay.ts')
         }
       }
     }

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -33,7 +33,8 @@ vi.mock('./logger', () => ({
 
 // The overlay manager is a collaborator with its own deep test suite; here we only need to observe
 // that the chord/Escape wiring drives it, so the real module is replaced with a spy object.
-const { findOverlayMock } = vi.hoisted(() => ({
+const { createFindOverlayManagerMock, findOverlayMock } = vi.hoisted(() => ({
+  createFindOverlayManagerMock: vi.fn(),
   findOverlayMock: {
     open: vi.fn(),
     close: vi.fn(),
@@ -43,7 +44,10 @@ const { findOverlayMock } = vi.hoisted(() => ({
   }
 }))
 vi.mock('./find-overlay', () => ({
-  createFindOverlayManager: () => findOverlayMock
+  createFindOverlayManager: (...args: unknown[]) => {
+    createFindOverlayManagerMock(...args)
+    return findOverlayMock
+  }
 }))
 
 // Captured window-open handler so tests can drive it directly, mirroring how Electron invokes it on a
@@ -215,6 +219,16 @@ describe('window presentation', () => {
     for (const handler of window.handlers.get('ready-to-show') ?? []) handler({} as CloseEvent)
 
     expect(window.showMock).toHaveBeenCalledOnce()
+  })
+
+  it('gives the find overlay a dedicated least-privilege preload', () => {
+    createMainWindow()
+
+    expect(createFindOverlayManagerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preloadPath: expect.stringMatching(/[\\/]preload[\\/]find-overlay\.js$/u)
+      })
+    )
   })
 })
 

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -34,6 +34,7 @@ import {
 
 const rendererEntry = join(__dirname, '../renderer/index.html')
 const preloadEntry = join(__dirname, '../preload/index.js')
+const findOverlayPreloadEntry = join(__dirname, '../preload/find-overlay.js')
 const icon = process.platform === 'win32' ? iconWindows : iconPng
 // The find overlay is a static page (no bundler entry) shipped under resources/, so it resolves the
 // same way in dev (project root) and packaged (asar root) via app.getAppPath().
@@ -310,7 +311,7 @@ const createMainWindow = (
     // contentView.addChildView is typed against the base View (no webContents), so bridge the gap here.
     mainWindow: window as unknown as FindOverlayDeps['mainWindow'],
     createView: (opts) => new WebContentsView(opts),
-    preloadPath: preloadEntry,
+    preloadPath: findOverlayPreloadEntry,
     overlayHtmlPath: findOverlayEntry,
     registerOwner: registerFindOverlayOwner
   })

--- a/src/preload/find-overlay.test.ts
+++ b/src/preload/find-overlay.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+const { exposeMock, onMock, removeListenerMock, sendMock } = vi.hoisted(() => ({
+  exposeMock: vi.fn(),
+  onMock: vi.fn(),
+  removeListenerMock: vi.fn(),
+  sendMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: exposeMock },
+  ipcRenderer: {
+    on: onMock,
+    removeListener: removeListenerMock,
+    send: sendMock
+  }
+}))
+
+type FindOverlayApi = {
+  window: {
+    findInPage: (request: unknown) => void
+    clearFind: () => void
+    onFindInPageResult: (listener: (payload: unknown) => void) => () => void
+    onShowWindowFind: (listener: (payload: unknown) => void) => () => void
+    onWindowFindAppearance: (listener: (payload: unknown) => void) => () => void
+    closeFind: () => void
+  }
+}
+
+const collectFunctionPaths = (value: unknown, prefix = ''): string[] => {
+  if (typeof value === 'function') return [prefix]
+  if (!value || typeof value !== 'object') return []
+  return Object.entries(value)
+    .flatMap(([key, child]) => collectFunctionPaths(child, prefix ? `${prefix}.${key}` : key))
+    .sort()
+}
+
+let api: FindOverlayApi
+
+beforeAll(async () => {
+  Object.defineProperty(process, 'contextIsolated', { value: true, configurable: true })
+  await import('./find-overlay')
+  const exposed = exposeMock.mock.calls.find(([key]) => key === 'api')?.[1] as
+    FindOverlayApi | undefined
+  if (!exposed) throw new Error('find overlay preload did not expose an "api" bridge')
+  api = exposed
+})
+
+afterEach(() => {
+  onMock.mockClear()
+  removeListenerMock.mockClear()
+  sendMock.mockClear()
+})
+
+describe('find overlay preload capability boundary', () => {
+  it('exposes only the window-find operations required by the overlay', () => {
+    expect(collectFunctionPaths(api)).toEqual([
+      'window.clearFind',
+      'window.closeFind',
+      'window.findInPage',
+      'window.onFindInPageResult',
+      'window.onShowWindowFind',
+      'window.onWindowFindAppearance'
+    ])
+  })
+
+  it('sends only the overlay request, clear, and close channels', () => {
+    const request = { requestId: 7, text: 'result', findNext: true, forward: false }
+
+    api.window.findInPage(request)
+    api.window.clearFind()
+    api.window.closeFind()
+
+    expect(sendMock.mock.calls).toEqual([
+      ['window:find-in-page', request],
+      ['window:clear-find-in-page'],
+      ['window:find-close']
+    ])
+  })
+
+  it.each([
+    ['onFindInPageResult', 'window:find-in-page-result'],
+    ['onShowWindowFind', 'window:find-show'],
+    ['onWindowFindAppearance', 'window:find-appearance']
+  ] as const)('subscribes %s to %s and returns a working unsubscribe', (method, channel) => {
+    const listener = vi.fn()
+    const remove = api.window[method](listener)
+    const wrappedListener = onMock.mock.calls.find(
+      ([registered]) => registered === channel
+    )?.[1] as ((event: unknown, payload: unknown) => void) | undefined
+    expect(wrappedListener).toBeDefined()
+
+    const payload = { value: channel }
+    wrappedListener!({}, payload)
+    remove()
+
+    expect(listener).toHaveBeenCalledWith(payload)
+    expect(removeListenerMock).toHaveBeenCalledWith(channel, wrappedListener)
+  })
+})

--- a/src/preload/find-overlay.ts
+++ b/src/preload/find-overlay.ts
@@ -1,16 +1,20 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
 
-import {
-  WINDOW_FIND_APPEARANCE_CHANNEL,
-  WINDOW_FIND_CLEAR_CHANNEL,
-  WINDOW_FIND_CLOSE_CHANNEL,
-  WINDOW_FIND_REQUEST_CHANNEL,
-  WINDOW_FIND_RESULT_CHANNEL,
-  WINDOW_FIND_SHOW_CHANNEL,
-  type WindowFindAppearance,
-  type WindowFindRequest,
-  type WindowFindResult
+import type {
+  WindowFindAppearance,
+  WindowFindRequest,
+  WindowFindResult
 } from '../shared/window-controls'
+
+// Sandboxed preloads cannot require local chunks emitted by Rollup. Keep this second preload entry's
+// runtime constants local so it stays self-contained instead of sharing a chunk with the main preload.
+// The dedicated preload tests pin every channel string against the main-process contract.
+const WINDOW_FIND_REQUEST_CHANNEL = 'window:find-in-page'
+const WINDOW_FIND_CLEAR_CHANNEL = 'window:clear-find-in-page'
+const WINDOW_FIND_RESULT_CHANNEL = 'window:find-in-page-result'
+const WINDOW_FIND_SHOW_CHANNEL = 'window:find-show'
+const WINDOW_FIND_APPEARANCE_CHANNEL = 'window:find-appearance'
+const WINDOW_FIND_CLOSE_CHANNEL = 'window:find-close'
 
 type RemoveListener = () => void
 type Listener<Payload> = (payload: Payload) => void

--- a/src/preload/find-overlay.ts
+++ b/src/preload/find-overlay.ts
@@ -1,0 +1,39 @@
+import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
+
+import {
+  WINDOW_FIND_APPEARANCE_CHANNEL,
+  WINDOW_FIND_CLEAR_CHANNEL,
+  WINDOW_FIND_CLOSE_CHANNEL,
+  WINDOW_FIND_REQUEST_CHANNEL,
+  WINDOW_FIND_RESULT_CHANNEL,
+  WINDOW_FIND_SHOW_CHANNEL,
+  type WindowFindAppearance,
+  type WindowFindRequest,
+  type WindowFindResult
+} from '../shared/window-controls'
+
+type RemoveListener = () => void
+type Listener<Payload> = (payload: Payload) => void
+
+const onIpcMessage = <Payload>(channel: string, listener: Listener<Payload>): RemoveListener => {
+  const wrappedListener = (_event: IpcRendererEvent, payload: Payload): void => listener(payload)
+  ipcRenderer.on(channel, wrappedListener)
+  return () => ipcRenderer.removeListener(channel, wrappedListener)
+}
+
+const api = {
+  window: {
+    findInPage: (request: WindowFindRequest): void =>
+      ipcRenderer.send(WINDOW_FIND_REQUEST_CHANNEL, request),
+    clearFind: (): void => ipcRenderer.send(WINDOW_FIND_CLEAR_CHANNEL),
+    onFindInPageResult: (listener: Listener<WindowFindResult>): RemoveListener =>
+      onIpcMessage(WINDOW_FIND_RESULT_CHANNEL, listener),
+    onShowWindowFind: (listener: Listener<WindowFindAppearance>): RemoveListener =>
+      onIpcMessage(WINDOW_FIND_SHOW_CHANNEL, listener),
+    onWindowFindAppearance: (listener: Listener<WindowFindAppearance>): RemoveListener =>
+      onIpcMessage(WINDOW_FIND_APPEARANCE_CHANNEL, listener),
+    closeFind: (): void => ipcRenderer.send(WINDOW_FIND_CLOSE_CHANNEL)
+  }
+}
+
+contextBridge.exposeInMainWorld('api', api)


### PR DESCRIPTION
## Problem

Find Overlay used the desktop renderer's full preload, so its `WebContentsView` received the complete `window.api` surface even though it only needs native page-find IPC. The IPC handler registry manages sender lifecycle but does not enforce per-WebContents capabilities.

No current overlay injection path was found, but a compromised overlay renderer would inherit session, settings, ACP, Notebook, storage, and other desktop capabilities beyond its purpose.

## Proposed change

- add a dedicated Electron preload entry for Find Overlay
- expose only find request, clear, close, result, show, and appearance operations
- load that dedicated preload for the overlay while leaving the main renderer preload unchanged
- add regression coverage for the selected preload path, exact contextBridge inventory, IPC channel forwarding, and unsubscribe behavior

## Scope and non-goals

- no global IPC registry authorization redesign
- no user interaction changes
- no data fields, schema, persistence, enum/state, or historical-data compatibility changes

## Acceptance criteria and validation

The window configuration test was first run against the original implementation and failed with the observed overlay path `src/preload/index.js`. After the change:

- `npm test -- src/preload/find-overlay.test.ts src/main/windows.test.ts src/main/find-overlay.test.ts resources/find-overlay/findOverlay.test.js src/main/window-find-ipc.test.ts` — 99 passed
- `npm run typecheck:node` — passed
- `npm run lint` — passed
- `npx electron-vite build` — passed and emitted `out/preload/find-overlay.js`
- PR impact classifier selects the complete Vitest suite because `electron.vite.config.ts` is a global gate input

The complete local `npm test` suite was intentionally not run; PR CI is authoritative for full coverage.

## Review focus

- confirm the overlay bridge exposes only the six required Window Find operations
- confirm the new Vite preload entry matches the runtime path used by `windows.ts`
- confirm normal find behavior and listener cleanup remain unchanged