### PR TITLE
test(storage): expect recoverable staged migration

### DIFF
--- a/e2e/certification/storage-migration.spec.ts
+++ b/e2e/certification/storage-migration.spec.ts
@@ -14,7 +14,9 @@ test('stages a verified data-root move and recovers on discard', async ({ app })
       api: {
         storage: {
           discardMigratedCopy: (path: string) => Promise<void>
-          inspectDataRoot: (path: string) => Promise<{ kind: string }>
+          inspectDataRoot: (
+            path: string
+          ) => Promise<{ kind: string; recoveryStatus?: 'copying' | 'verified' }>
           migrate: (path: string) => Promise<{ ok: boolean; error?: string }>
         }
       }
@@ -27,7 +29,7 @@ test('stages a verified data-root move and recovers on discard', async ({ app })
   }, parent)
 
   expect(result.migration).toEqual({ ok: true })
-  expect(result.staged.kind).toBe('invalid')
+  expect(result.staged).toMatchObject({ kind: 'recover', recoveryStatus: 'verified' })
   expect(result.discarded.kind).toBe('move')
 
   page = await app.restart()


### PR DESCRIPTION
## Problem

The packaged P0 regression still expected a trusted staged migration to inspect as `invalid`. Since #1356, the production contract intentionally classifies a matching verified migration marker as `recover` with `recoveryStatus: 'verified'`, so the macOS ARM64 certification failed consistently.

## Proposed change

- Align the storage migration certification with the existing `recover` contract.
- Assert the verified recovery status while retaining the discard, restart, and persisted-session checks.

## Scope and non-goals

- Test-only change; no production behavior or CI workflow changes.
- No historical-data compatibility change.
- No new enum or status value; `recover`, `copying`, and `verified` already exist in the production contract.
- No persistence format, schema, migration, or write-path change.

## Acceptance criteria and validation

Checks ran after the last material edit:

- Verified staging classification -> `npm test -- src/main/storage/migration-service.test.ts -t 'classifies a verified marker-bearing staging dir as recoverable'` -> passed (1 test).
- Migration/discard/restart flow -> `npm run test:e2e -- e2e/certification/storage-migration.spec.ts --workers=1` -> passed (1 test).
- Changed-file lint -> `npx eslint e2e/certification/storage-migration.spec.ts` -> passed.
- Diff hygiene -> `git diff --check origin/main...HEAD` -> passed.

The changed file is the owning packaged-certification test. CodeGraph reports only that test as affected, and the production classification contract remains covered by its focused unit test. No consumer or additional platform lane is needed locally because production interfaces and behavior are unchanged; exact-head PR CI remains authoritative. The local E2E used the built Electron app rather than the downloaded packaged artifact, so packaged execution remains the uncovered local risk covered by CI.

## Review focus

Confirm that a freshly verified marker should be surfaced as recoverable before discard, and that the existing post-discard `move` assertion continues to prove cleanup.
