### PR TITLE
fix(persistence): classify versioned JSON reads

### DIFF
--- a/src/main/artifacts/provenance-execution-evidence.ts
+++ b/src/main/artifacts/provenance-execution-evidence.ts
@@ -15,6 +15,10 @@ import type {
   NotebookRunRecord
 } from '../../shared/notebook'
 import { canonicalJson, sha256, type CanonicalJson } from './provenance-canonical'
+import {
+  decodeArtifactExecutionSnapshot,
+  parseArtifactExecutionSnapshot
+} from './provenance-execution-snapshot-decoder'
 
 const MAX_EXECUTION_SNAPSHOT_BYTES = 4 * 1024 * 1024
 const MAX_EXECUTION_SNAPSHOT_RUNS = 128
@@ -38,12 +42,6 @@ const recordValue = (value: unknown): Record<string, unknown> | undefined =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : undefined
-
-const stringValue = (value: unknown): string | undefined =>
-  typeof value === 'string' ? value : undefined
-
-const numberValue = (value: unknown): number | undefined =>
-  typeof value === 'number' && Number.isFinite(value) ? value : undefined
 
 const tableCell = (value: unknown): CanonicalJson => {
   if (
@@ -440,110 +438,6 @@ const resolveRunEnvironmentCapture = (
   }
 }
 
-const normalizeStoredProvenanceOutput = (value: unknown): ProvenanceNotebookOutput[] => {
-  const output = recordValue(value)
-  if (output?.type === 'text' && typeof output.text === 'string') {
-    return [
-      {
-        type: 'text',
-        text: output.text,
-        ...(output.truncated === true ? { truncated: true } : {})
-      }
-    ]
-  }
-  if (output?.type === 'error') {
-    const name = stringValue(output.name)
-    const message = stringValue(output.message) ?? name ?? 'Notebook execution failed.'
-    const traceback = Array.isArray(output.traceback)
-      ? output.traceback.filter((line): line is string => typeof line === 'string')
-      : typeof output.traceback === 'string' && output.traceback
-        ? output.traceback.split('\n')
-        : undefined
-    return [
-      { type: 'error', ...(name ? { name } : {}), message, ...(traceback ? { traceback } : {}) }
-    ]
-  }
-  if (output?.type === 'table') {
-    const columns = Array.isArray(output.columns)
-      ? output.columns.filter((column): column is string => typeof column === 'string')
-      : []
-    const previewRows = Array.isArray(output.previewRows)
-      ? output.previewRows.filter((row): row is unknown[] => Array.isArray(row))
-      : []
-    const rowCount = numberValue(output.rowCount)
-    return columns.length > 0 && rowCount !== undefined
-      ? [{ type: 'table', columns, rowCount, previewRows }]
-      : []
-  }
-  if (output?.type === 'omitted-media') {
-    const mimeTypes =
-      typeof output.mimeType === 'string'
-        ? [output.mimeType]
-        : Array.isArray(output.mime_types)
-          ? output.mime_types.filter((mimeType): mimeType is string => typeof mimeType === 'string')
-          : []
-    return mimeTypes.map((mimeType) => ({
-      type: 'omitted-media',
-      mimeType,
-      ...(typeof output.byteLength === 'number' ? { byteLength: output.byteLength } : {})
-    }))
-  }
-  return []
-}
-
-const parseArtifactExecutionSnapshot = (value: string): PersistedArtifactExecutionSnapshot => {
-  const parsed = JSON.parse(value) as unknown
-  const snapshot = recordValue(parsed)
-  const truncation = recordValue(snapshot?.truncation)
-  if (
-    snapshot?.schemaVersion !== 2 ||
-    typeof snapshot.rootFrameId !== 'string' ||
-    typeof snapshot.agentFrameId !== 'string' ||
-    typeof snapshot.messageBranchId !== 'string' ||
-    typeof snapshot.terminalPromptMessageId !== 'string' ||
-    typeof snapshot.producerRunId !== 'string' ||
-    typeof snapshot.producerRunIndex !== 'number' ||
-    !Number.isSafeInteger(snapshot.producerRunIndex) ||
-    typeof snapshot.createdAt !== 'string' ||
-    !Array.isArray(snapshot.inputFiles) ||
-    !Array.isArray(snapshot.runs) ||
-    (snapshot.truncation !== undefined &&
-      (!truncation ||
-        truncation.reason !== 'payload-limit' ||
-        !Number.isSafeInteger(truncation.omittedLeadingRunCount) ||
-        Number(truncation.omittedLeadingRunCount) < 0 ||
-        !Number.isSafeInteger(truncation.omittedOutputCount) ||
-        Number(truncation.omittedOutputCount) < 0 ||
-        !Number.isSafeInteger(truncation.omittedInputCount) ||
-        Number(truncation.omittedInputCount) < 0)) ||
-    snapshot.runs.some((run) => {
-      const candidate = recordValue(run)
-      return (
-        !candidate ||
-        typeof candidate.runId !== 'string' ||
-        typeof candidate.runIndex !== 'number' ||
-        !Number.isSafeInteger(candidate.runIndex) ||
-        typeof candidate.kernelKind !== 'string' ||
-        typeof candidate.script !== 'string' ||
-        typeof candidate.status !== 'string' ||
-        typeof candidate.startedAt !== 'string' ||
-        !Array.isArray(candidate.outputs) ||
-        !Array.isArray(candidate.inputFileVersionKeys)
-      )
-    })
-  ) {
-    throw new Error('Artifact Version execution snapshot schema is invalid.')
-  }
-  const normalized = parsed as PersistedArtifactExecutionSnapshot
-  return {
-    ...normalized,
-    runs: normalized.runs.map((run) => ({
-      ...run,
-      outputs: (run.outputs as unknown[]).flatMap(normalizeStoredProvenanceOutput)
-    }))
-  }
-}
-
 const validateArtifactExecutionSnapshot = (
   snapshot: PersistedArtifactExecutionSnapshot,
   expected: {
@@ -588,6 +482,7 @@ const validateArtifactExecutionSnapshot = (
 
 export {
   buildBoundedExecutionSnapshot,
+  decodeArtifactExecutionSnapshot,
   environmentEvidence,
   inputEvidence,
   parseArtifactExecutionSnapshot,

--- a/src/main/artifacts/provenance-execution-snapshot-decoder.ts
+++ b/src/main/artifacts/provenance-execution-snapshot-decoder.ts
@@ -1,0 +1,205 @@
+import type {
+  PersistedArtifactExecutionSnapshot,
+  ProvenanceNotebookOutput
+} from '../../shared/artifact-provenance'
+import {
+  decodeVersionedJson,
+  type VersionedJsonDecodeResult
+} from '../storage/versioned-json-decoder'
+
+const recordValue = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+
+const normalizeStoredProvenanceOutput = (value: unknown): ProvenanceNotebookOutput[] => {
+  const output = recordValue(value)
+  if (output?.type === 'text' && typeof output.text === 'string') {
+    return [
+      {
+        type: 'text',
+        text: output.text,
+        ...(output.truncated === true ? { truncated: true } : {})
+      }
+    ]
+  }
+  if (output?.type === 'error') {
+    const name = typeof output.name === 'string' ? output.name : undefined
+    const message = typeof output.message === 'string' ? output.message : name
+    const traceback = Array.isArray(output.traceback)
+      ? output.traceback.filter((line): line is string => typeof line === 'string')
+      : typeof output.traceback === 'string' && output.traceback
+        ? output.traceback.split('\n')
+        : undefined
+    return [
+      {
+        type: 'error',
+        ...(name ? { name } : {}),
+        message: message ?? 'Notebook execution failed.',
+        ...(traceback ? { traceback } : {})
+      }
+    ]
+  }
+  if (output?.type === 'table') {
+    const columns = Array.isArray(output.columns)
+      ? output.columns.filter((column): column is string => typeof column === 'string')
+      : []
+    const previewRows = Array.isArray(output.previewRows)
+      ? output.previewRows.filter((row): row is unknown[] => Array.isArray(row))
+      : []
+    const rowCount =
+      typeof output.rowCount === 'number' && Number.isFinite(output.rowCount)
+        ? output.rowCount
+        : undefined
+    return columns.length > 0 && rowCount !== undefined
+      ? [{ type: 'table', columns, rowCount, previewRows }]
+      : []
+  }
+  if (output?.type === 'omitted-media') {
+    const mimeTypes =
+      typeof output.mimeType === 'string'
+        ? [output.mimeType]
+        : Array.isArray(output.mime_types)
+          ? output.mime_types.filter((mimeType): mimeType is string => typeof mimeType === 'string')
+          : []
+    return mimeTypes.map((mimeType) => ({
+      type: 'omitted-media',
+      mimeType,
+      ...(typeof output.byteLength === 'number' ? { byteLength: output.byteLength } : {})
+    }))
+  }
+  return []
+}
+
+const executionInputFileValue = (value: unknown): boolean => {
+  const input = recordValue(value)
+  return (
+    input !== undefined &&
+    typeof input.inputFileVersionId === 'string' &&
+    (input.sourceKind === 'upload-version' || input.sourceKind === 'artifact-version') &&
+    typeof input.sourceFileId === 'string' &&
+    (input.sourceVersionNumber === undefined ||
+      (typeof input.sourceVersionNumber === 'number' &&
+        Number.isSafeInteger(input.sourceVersionNumber))) &&
+    (input.sourceCreatedAt === undefined || typeof input.sourceCreatedAt === 'string') &&
+    typeof input.sourceProjectId === 'string' &&
+    typeof input.sourceSessionId === 'string' &&
+    typeof input.filename === 'string' &&
+    (input.contentType === undefined || typeof input.contentType === 'string') &&
+    typeof input.sizeBytes === 'number' &&
+    Number.isFinite(input.sizeBytes) &&
+    typeof input.checksum === 'string' &&
+    typeof input.storageKey === 'string' &&
+    (input.association === 'turn-attached' || input.association === 'resolver-accessed')
+  )
+}
+
+const executionInputKeyValue = (value: unknown): boolean => {
+  const key = recordValue(value)
+  return (
+    key !== undefined &&
+    (key.sourceKind === 'upload-version' || key.sourceKind === 'artifact-version') &&
+    typeof key.inputFileVersionId === 'string'
+  )
+}
+
+const executionRunValue = (value: unknown): boolean => {
+  const run = recordValue(value)
+  return (
+    run !== undefined &&
+    typeof run.runId === 'string' &&
+    typeof run.runIndex === 'number' &&
+    Number.isSafeInteger(run.runIndex) &&
+    typeof run.agentFrameId === 'string' &&
+    typeof run.messageBranchId === 'string' &&
+    typeof run.runtimeSegmentId === 'string' &&
+    typeof run.promptMessageId === 'string' &&
+    (run.kernelKind === 'python' ||
+      run.kernelKind === 'r' ||
+      run.kernelKind === 'repl' ||
+      run.kernelKind === 'bash') &&
+    typeof run.script === 'string' &&
+    (run.status === 'queued' ||
+      run.status === 'running' ||
+      run.status === 'completed' ||
+      run.status === 'failed' ||
+      run.status === 'timeout' ||
+      run.status === 'interrupted' ||
+      run.status === 'cancelled') &&
+    (run.environmentName === undefined || typeof run.environmentName === 'string') &&
+    (run.scriptTruncated === undefined || run.scriptTruncated === true) &&
+    (run.executionCount === undefined ||
+      (typeof run.executionCount === 'number' && Number.isFinite(run.executionCount))) &&
+    typeof run.startedAt === 'string' &&
+    (run.completedAt === undefined || typeof run.completedAt === 'string') &&
+    Array.isArray(run.outputs) &&
+    run.outputs.every((output) => normalizeStoredProvenanceOutput(output).length > 0) &&
+    Array.isArray(run.inputFileVersionKeys) &&
+    run.inputFileVersionKeys.every(executionInputKeyValue) &&
+    (run.hasOmittedFiles === undefined || run.hasOmittedFiles === true) &&
+    (run.hasOmittedInputs === undefined || run.hasOmittedInputs === true) &&
+    (run.omittedOutputCount === undefined ||
+      (Number.isSafeInteger(run.omittedOutputCount) && Number(run.omittedOutputCount) >= 0))
+  )
+}
+
+const executionSnapshotValue = (value: unknown): PersistedArtifactExecutionSnapshot | undefined => {
+  const snapshot = recordValue(value)
+  const truncation = recordValue(snapshot?.truncation)
+  if (
+    snapshot?.schemaVersion !== 2 ||
+    typeof snapshot.rootFrameId !== 'string' ||
+    typeof snapshot.agentFrameId !== 'string' ||
+    typeof snapshot.messageBranchId !== 'string' ||
+    typeof snapshot.terminalPromptMessageId !== 'string' ||
+    typeof snapshot.producerRunId !== 'string' ||
+    typeof snapshot.producerRunIndex !== 'number' ||
+    !Number.isSafeInteger(snapshot.producerRunIndex) ||
+    typeof snapshot.createdAt !== 'string' ||
+    !Array.isArray(snapshot.inputFiles) ||
+    snapshot.inputFiles.some((input) => !executionInputFileValue(input)) ||
+    !Array.isArray(snapshot.runs) ||
+    (snapshot.truncation !== undefined &&
+      (!truncation ||
+        truncation.reason !== 'payload-limit' ||
+        !Number.isSafeInteger(truncation.omittedLeadingRunCount) ||
+        Number(truncation.omittedLeadingRunCount) < 0 ||
+        !Number.isSafeInteger(truncation.omittedOutputCount) ||
+        Number(truncation.omittedOutputCount) < 0 ||
+        !Number.isSafeInteger(truncation.omittedInputCount) ||
+        Number(truncation.omittedInputCount) < 0)) ||
+    snapshot.runs.some((run) => !executionRunValue(run))
+  ) {
+    return undefined
+  }
+  const normalized = value as PersistedArtifactExecutionSnapshot
+  return {
+    ...normalized,
+    runs: normalized.runs.map((run) => ({
+      ...run,
+      outputs: (run.outputs as unknown[]).flatMap(normalizeStoredProvenanceOutput)
+    }))
+  }
+}
+
+export const decodeArtifactExecutionSnapshot = (
+  value: string
+): VersionedJsonDecodeResult<PersistedArtifactExecutionSnapshot> =>
+  decodeVersionedJson(value, {
+    currentVersion: 2,
+    readVersion: (candidate) => recordValue(candidate)?.schemaVersion,
+    decode: executionSnapshotValue
+  })
+
+export const parseArtifactExecutionSnapshot = (
+  value: string
+): PersistedArtifactExecutionSnapshot => {
+  const decoded = decodeArtifactExecutionSnapshot(value)
+  if (decoded.status === 'unsupported') {
+    throw new Error('Artifact Version execution snapshot version is not supported.')
+  }
+  if (decoded.status === 'corrupt') {
+    throw new Error('Artifact Version execution snapshot schema is invalid.')
+  }
+  return decoded.value
+}

--- a/src/main/artifacts/provenance-lifecycle-contract.test.ts
+++ b/src/main/artifacts/provenance-lifecycle-contract.test.ts
@@ -270,6 +270,20 @@ describe('artifact provenance durable lifecycle contract', () => {
       value.storageRoot,
       ...snapshotRow.messageSnapshot!.storageKey.split('/')
     )
+    const currentSnapshot = JSON.parse(await readFile(snapshotPath, 'utf8')) as Record<
+      string,
+      unknown
+    >
+    const futureSnapshot = JSON.stringify({ ...currentSnapshot, schemaVersion: 4 })
+    await writeFile(snapshotPath, futureSnapshot, 'utf8')
+    await value.client.artifactMessageSnapshot.update({
+      where: { id: snapshotRow.messageSnapshot!.id },
+      data: { checksum: sha256(futureSnapshot) }
+    })
+    await expect(repository.getVersionMessages(firstIdentity)).resolves.toEqual({
+      messages: { state: 'unavailable', reason: 'message-snapshot-unsupported' }
+    })
+
     await writeFile(snapshotPath, '{"corrupt":true}\n', 'utf8')
     await expect(repository.getVersionMessages(firstIdentity)).resolves.toEqual({
       messages: { state: 'unavailable', reason: 'message-snapshot-corrupt' }

--- a/src/main/artifacts/provenance-read-model.ts
+++ b/src/main/artifacts/provenance-read-model.ts
@@ -6,7 +6,6 @@ import type { PrismaClient } from '@prisma/client'
 import type {
   ArtifactExecutionSnapshot,
   ArtifactLineageProvenance,
-  ArtifactMessageSnapshotFile,
   ArtifactVersionDescriptor,
   ArtifactVersionEvidence,
   ArtifactVersionProvenance,
@@ -25,7 +24,6 @@ import {
 import type {
   ReviewFindingDispositionOutcome,
   ReviewFindingDispositionTrigger,
-  ReviewScopeSnapshotBlock,
   ReviewWithProvenanceEvidence
 } from '../../shared/reviewer'
 import { flagStaleReviews } from '../reviewer/stale-reviews'
@@ -39,10 +37,16 @@ import {
 } from './provenance-execution-evidence'
 import { sha256 } from './provenance-canonical'
 import { validateArtifactCoreEvidence } from './provenance-core-evidence'
+import {
+  decodeArtifactMessageSnapshot,
+  decodeReviewScopeSnapshot
+} from './provenance-snapshot-decoder'
 import { readOptionalFile, resolveStorageKey } from './provenance-storage'
 import type { PersistedVersionFileRecord } from './provenance-version-writer'
 
 const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+class UnsupportedMessageSnapshotVersionError extends Error {}
 
 const assertSafeSegment = (value: string, label: string): string => {
   if (!SAFE_SEGMENT_PATTERN.test(value)) throw new Error(`Invalid ${label}: ${value}`)
@@ -324,7 +328,14 @@ class ArtifactProvenanceReadModel {
         ) {
           throw new Error('Message snapshot checksum mismatch.')
         }
-        const snapshot = JSON.parse(serializedSnapshot) as ArtifactMessageSnapshotFile
+        const decodedSnapshot = decodeArtifactMessageSnapshot(serializedSnapshot)
+        if (decodedSnapshot.status === 'unsupported') {
+          throw new UnsupportedMessageSnapshotVersionError()
+        }
+        if (decodedSnapshot.status === 'corrupt') {
+          throw new Error('Message snapshot schema is invalid.')
+        }
+        const snapshot = decodedSnapshot.value
         const hasValidPath = snapshot.messages.every(
           (message, index) =>
             index === 0 || message.parentMessageId === snapshot.messages[index - 1]?.id
@@ -382,8 +393,14 @@ class ArtifactProvenanceReadModel {
           return attribution ? { ...rest, attribution } : rest
         })
         messages = { state: 'available', items, activities, activityGroups }
-      } catch {
-        messages = { state: 'unavailable', reason: 'message-snapshot-corrupt' }
+      } catch (error) {
+        messages = {
+          state: 'unavailable',
+          reason:
+            error instanceof UnsupportedMessageSnapshotVersionError
+              ? 'message-snapshot-unsupported'
+              : 'message-snapshot-corrupt'
+        }
       }
     }
 
@@ -408,20 +425,19 @@ class ArtifactProvenanceReadModel {
           }
           if (snapshot?.state === 'ready') {
             try {
-              const payload = JSON.parse(snapshot.snapshotJson) as {
-                schemaVersion?: unknown
-                blocks?: unknown
-              }
-              if (
-                (payload.schemaVersion !== 1 && payload.schemaVersion !== 2) ||
-                !Array.isArray(payload.blocks) ||
-                sha256(snapshot.snapshotJson) !== snapshot.checksum
-              ) {
+              if (sha256(snapshot.snapshotJson) !== snapshot.checksum) {
                 throw new Error('Review scope snapshot checksum mismatch.')
+              }
+              const decodedSnapshot = decodeReviewScopeSnapshot(snapshot.snapshotJson)
+              if (
+                decodedSnapshot.status === 'unsupported' ||
+                decodedSnapshot.status === 'corrupt'
+              ) {
+                throw new Error('Review scope snapshot schema is invalid.')
               }
               scopeSnapshot = {
                 state: 'available',
-                blocks: payload.blocks as ReviewScopeSnapshotBlock[]
+                blocks: decodedSnapshot.value
               }
             } catch {
               scopeSnapshot = { state: 'unavailable', reason: 'corrupt' }

--- a/src/main/artifacts/provenance-snapshot-decoder.test.ts
+++ b/src/main/artifacts/provenance-snapshot-decoder.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest'
+
+import { decodeArtifactExecutionSnapshot } from './provenance-execution-evidence'
+import {
+  decodeArtifactMessageSnapshot,
+  decodeReviewScopeSnapshot
+} from './provenance-snapshot-decoder'
+
+const messageSnapshot = (schemaVersion: number): Record<string, unknown> => ({
+  schemaVersion,
+  snapshotId: 'snapshot-1',
+  rootFrameId: 'root-1',
+  agentFrameId: 'agent-1',
+  messageBranchId: 'branch-1',
+  terminalMessageId: 'message-1',
+  createdAt: '2026-08-20T00:00:00.000Z',
+  messages: [],
+  ...(schemaVersion === 3 ? { activities: [], activityGroups: [] } : {})
+})
+
+const executionSnapshot = (schemaVersion: number): Record<string, unknown> => ({
+  schemaVersion,
+  rootFrameId: 'root-1',
+  agentFrameId: 'agent-1',
+  messageBranchId: 'branch-1',
+  terminalPromptMessageId: 'prompt-1',
+  producerRunId: 'run-1',
+  producerRunIndex: 0,
+  createdAt: '2026-08-20T00:00:00.000Z',
+  inputFiles: [],
+  runs: [
+    {
+      runId: 'run-1',
+      runIndex: 0,
+      agentFrameId: 'agent-1',
+      messageBranchId: 'branch-1',
+      runtimeSegmentId: 'runtime-1',
+      promptMessageId: 'prompt-1',
+      kernelKind: 'python',
+      script: 'print(1)',
+      status: 'completed',
+      startedAt: '2026-08-20T00:00:00.000Z',
+      outputs: [],
+      inputFileVersionKeys: []
+    }
+  ]
+})
+
+describe('Artifact persistence decoders', () => {
+  it('classifies Message v3 as valid, v2 as legacy, and future versions as unsupported', () => {
+    expect(decodeArtifactMessageSnapshot(JSON.stringify(messageSnapshot(3))).status).toBe('valid')
+    expect(decodeArtifactMessageSnapshot(JSON.stringify(messageSnapshot(2))).status).toBe('legacy')
+    expect(decodeArtifactMessageSnapshot(JSON.stringify(messageSnapshot(4)))).toEqual({
+      status: 'unsupported',
+      version: 4
+    })
+  })
+
+  it('classifies Execution v2 as valid and future versions as unsupported', () => {
+    expect(decodeArtifactExecutionSnapshot(JSON.stringify(executionSnapshot(2))).status).toBe(
+      'valid'
+    )
+    expect(decodeArtifactExecutionSnapshot(JSON.stringify(executionSnapshot(3)))).toEqual({
+      status: 'unsupported',
+      version: 3
+    })
+  })
+
+  it('classifies Review scope v2 as valid, v1 as legacy, and future versions as unsupported', () => {
+    expect(decodeReviewScopeSnapshot('{"schemaVersion":2,"blocks":[]}').status).toBe('valid')
+    expect(decodeReviewScopeSnapshot('{"schemaVersion":1,"blocks":[]}').status).toBe('legacy')
+    expect(decodeReviewScopeSnapshot('{"schemaVersion":3,"blocks":[]}')).toEqual({
+      status: 'unsupported',
+      version: 3
+    })
+  })
+
+  it('classifies malformed and structurally invalid Artifact snapshots as corrupt', () => {
+    expect(decodeArtifactMessageSnapshot('{')).toEqual({ status: 'corrupt' })
+    expect(decodeArtifactExecutionSnapshot('{"schemaVersion":2}')).toEqual({
+      status: 'corrupt'
+    })
+    expect(decodeReviewScopeSnapshot('{"schemaVersion":2,"blocks":false}')).toEqual({
+      status: 'corrupt'
+    })
+  })
+
+  it('rejects invalid Message and Review domain records instead of trusting their arrays', () => {
+    expect(
+      decodeArtifactMessageSnapshot(
+        JSON.stringify({
+          ...messageSnapshot(3),
+          messages: [{ id: 'message-1', role: 'robot', content: 42, createdAt: 'now' }]
+        })
+      )
+    ).toEqual({ status: 'corrupt' })
+    expect(
+      decodeReviewScopeSnapshot(
+        JSON.stringify({
+          schemaVersion: 2,
+          blocks: [
+            {
+              blockIndex: 'zero',
+              id: 'block-1',
+              kind: 'message',
+              sourceId: 'message-1',
+              contentHash: 'hash',
+              payload: {}
+            }
+          ]
+        })
+      )
+    ).toEqual({ status: 'corrupt' })
+  })
+
+  it('rejects invalid Message activities and Execution domain records', () => {
+    expect(
+      decodeArtifactMessageSnapshot(JSON.stringify({ ...messageSnapshot(3), activities: [null] }))
+    ).toEqual({ status: 'corrupt' })
+    expect(
+      decodeArtifactExecutionSnapshot(
+        JSON.stringify({
+          ...executionSnapshot(2),
+          inputFiles: [null],
+          runs: [
+            { ...(executionSnapshot(2).runs as Record<string, unknown>[])[0], status: 'invented' }
+          ]
+        })
+      )
+    ).toEqual({ status: 'corrupt' })
+  })
+
+  it('rejects an invalid nested Message elicitation projection', () => {
+    expect(
+      decodeArtifactMessageSnapshot(
+        JSON.stringify({
+          ...messageSnapshot(3),
+          activities: [
+            {
+              id: 'activity-1',
+              kind: 'tool',
+              title: 'Ask a question',
+              status: 'completed',
+              sortIndex: 0,
+              eventIds: [],
+              elicitation: {},
+              createdAt: 1,
+              updatedAt: 2
+            }
+          ]
+        })
+      )
+    ).toEqual({ status: 'corrupt' })
+  })
+})

--- a/src/main/artifacts/provenance-snapshot-decoder.ts
+++ b/src/main/artifacts/provenance-snapshot-decoder.ts
@@ -1,0 +1,315 @@
+import type { ArtifactMessageSnapshotFile } from '../../shared/artifact-provenance'
+import type { ReviewScopeSnapshotBlock } from '../../shared/reviewer'
+import {
+  decodeVersionedJson,
+  type VersionedJsonDecodeResult
+} from '../storage/versioned-json-decoder'
+
+const recordValue = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+
+const readSchemaVersion = (value: unknown): unknown => recordValue(value)?.schemaVersion
+
+const optionalString = (value: unknown): boolean => value === undefined || typeof value === 'string'
+
+const optionalFiniteNumber = (value: unknown): boolean =>
+  value === undefined || (typeof value === 'number' && Number.isFinite(value))
+
+const stringArrayValue = (value: unknown): boolean =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string')
+
+const elicitationAnswerValue = (value: unknown): boolean =>
+  typeof value === 'string' ||
+  typeof value === 'boolean' ||
+  (typeof value === 'number' && Number.isFinite(value)) ||
+  stringArrayValue(value)
+
+const elicitationOptionValue = (value: unknown): boolean => {
+  const option = recordValue(value)
+  return (
+    option !== undefined &&
+    typeof option.value === 'string' &&
+    typeof option.label === 'string' &&
+    optionalString(option.description)
+  )
+}
+
+const elicitationFieldValue = (value: unknown): boolean => {
+  const field = recordValue(value)
+  return (
+    field !== undefined &&
+    typeof field.id === 'string' &&
+    typeof field.label === 'string' &&
+    optionalString(field.description) &&
+    (field.kind === 'text' ||
+      field.kind === 'single-select' ||
+      field.kind === 'multi-select' ||
+      field.kind === 'number' ||
+      field.kind === 'integer' ||
+      field.kind === 'boolean') &&
+    (field.required === undefined || typeof field.required === 'boolean') &&
+    (field.options === undefined ||
+      (Array.isArray(field.options) && field.options.every(elicitationOptionValue))) &&
+    (field.format === undefined ||
+      field.format === 'email' ||
+      field.format === 'uri' ||
+      field.format === 'date' ||
+      field.format === 'date-time') &&
+    optionalFiniteNumber(field.minLength) &&
+    optionalFiniteNumber(field.maxLength) &&
+    optionalFiniteNumber(field.minimum) &&
+    optionalFiniteNumber(field.maximum) &&
+    optionalFiniteNumber(field.minItems) &&
+    optionalFiniteNumber(field.maxItems) &&
+    (field.defaultValue === undefined || elicitationAnswerValue(field.defaultValue))
+  )
+}
+
+const elicitationAnswerRecordValue = (value: unknown): boolean => {
+  const answer = recordValue(value)
+  return (
+    answer !== undefined &&
+    typeof answer.fieldId === 'string' &&
+    elicitationAnswerValue(answer.value)
+  )
+}
+
+const elicitationProvenanceContextValue = (value: unknown): boolean => {
+  const context = recordValue(value)
+  return (
+    context !== undefined &&
+    typeof context.promptMessageId === 'string' &&
+    optionalString(context.originMessageId) &&
+    optionalString(context.rootFrameId) &&
+    optionalString(context.agentFrameId) &&
+    optionalString(context.messageBranchId) &&
+    optionalString(context.runtimeSegmentId) &&
+    (context.messageBranchAncestry === undefined ||
+      stringArrayValue(context.messageBranchAncestry)) &&
+    (context.messageAncestry === undefined || stringArrayValue(context.messageAncestry))
+  )
+}
+
+const elicitationDurableValue = (value: unknown): boolean => {
+  const durable = recordValue(value)
+  return (
+    durable !== undefined &&
+    durable.kind === 'agent-user-choice' &&
+    typeof durable.requestId === 'string' &&
+    optionalString(durable.promptMessageId) &&
+    (durable.provenanceContext === undefined ||
+      elicitationProvenanceContextValue(durable.provenanceContext))
+  )
+}
+
+const elicitationValue = (value: unknown): boolean => {
+  const elicitation = recordValue(value)
+  return (
+    elicitation !== undefined &&
+    typeof elicitation.message === 'string' &&
+    Array.isArray(elicitation.fields) &&
+    elicitation.fields.length > 0 &&
+    elicitation.fields.every(elicitationFieldValue) &&
+    (elicitation.state === 'pending' ||
+      elicitation.state === 'answered' ||
+      elicitation.state === 'declined' ||
+      elicitation.state === 'cancelled') &&
+    (elicitation.durable === undefined || elicitationDurableValue(elicitation.durable)) &&
+    (elicitation.draftAnswers === undefined ||
+      (Array.isArray(elicitation.draftAnswers) &&
+        elicitation.draftAnswers.every(elicitationAnswerRecordValue))) &&
+    (elicitation.answers === undefined ||
+      (Array.isArray(elicitation.answers) &&
+        elicitation.answers.every(elicitationAnswerRecordValue))) &&
+    optionalFiniteNumber(elicitation.respondedAt)
+  )
+}
+
+const messagePartValue = (value: unknown): boolean => {
+  const part = recordValue(value)
+  if (!part) return false
+  if (part.type === 'text') return typeof part.text === 'string'
+  if (part.type === 'skill') return typeof part.name === 'string'
+  return part.type === 'artifact' && typeof part.name === 'string' && optionalString(part.versionId)
+}
+
+const messageValue = (value: unknown): boolean => {
+  const message = recordValue(value)
+  if (
+    !message ||
+    typeof message.id !== 'string' ||
+    (message.role !== 'user' && message.role !== 'agent') ||
+    typeof message.content !== 'string' ||
+    typeof message.createdAt !== 'number' ||
+    !Number.isFinite(message.createdAt) ||
+    !optionalString(message.parentMessageId) ||
+    !optionalString(message.supersedesMessageId) ||
+    (message.hasOmittedMedia !== undefined && typeof message.hasOmittedMedia !== 'boolean') ||
+    (message.parts !== undefined &&
+      (!Array.isArray(message.parts) || message.parts.some((part) => !messagePartValue(part)))) ||
+    (message.artifacts !== undefined &&
+      (!Array.isArray(message.artifacts) ||
+        message.artifacts.some((artifact) => {
+          const candidate = recordValue(artifact)
+          return (
+            !candidate || typeof candidate.name !== 'string' || !optionalString(candidate.versionId)
+          )
+        })))
+  ) {
+    return false
+  }
+  if (message.agentAttribution !== undefined) {
+    const attribution = recordValue(message.agentAttribution)
+    if (
+      !attribution ||
+      (attribution.frameworkId !== 'claude-code' &&
+        attribution.frameworkId !== 'opencode' &&
+        attribution.frameworkId !== 'codex') ||
+      !optionalString(attribution.agentName) ||
+      !optionalString(attribution.model)
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
+const activityValue = (value: unknown): boolean => {
+  const activity = recordValue(value)
+  const locationsAreValid =
+    activity?.toolLocations === undefined ||
+    (Array.isArray(activity.toolLocations) &&
+      activity.toolLocations.every((location) => {
+        const candidate = recordValue(location)
+        return (
+          candidate !== undefined &&
+          typeof candidate.path === 'string' &&
+          (candidate.line === undefined ||
+            candidate.line === null ||
+            (typeof candidate.line === 'number' && Number.isFinite(candidate.line)))
+        )
+      }))
+  return (
+    activity !== undefined &&
+    typeof activity.id === 'string' &&
+    activity.kind === 'tool' &&
+    typeof activity.title === 'string' &&
+    (activity.status === 'pending' ||
+      activity.status === 'in_progress' ||
+      activity.status === 'completed' ||
+      activity.status === 'failed') &&
+    typeof activity.sortIndex === 'number' &&
+    Number.isFinite(activity.sortIndex) &&
+    Array.isArray(activity.eventIds) &&
+    activity.eventIds.every((eventId) => typeof eventId === 'string') &&
+    optionalString(activity.activityGroupId) &&
+    optionalString(activity.promptMessageId) &&
+    optionalString(activity.executionInvocationId) &&
+    optionalString(activity.providerToolName) &&
+    optionalString(activity.toolKind) &&
+    (activity.toolDisposition === undefined ||
+      activity.toolDisposition === 'declined' ||
+      activity.toolDisposition === 'permission-closed') &&
+    (activity.toolContent === undefined || Array.isArray(activity.toolContent)) &&
+    locationsAreValid &&
+    optionalString(activity.terminalOutput) &&
+    (activity.terminalExitCode === undefined ||
+      activity.terminalExitCode === null ||
+      (typeof activity.terminalExitCode === 'number' &&
+        Number.isFinite(activity.terminalExitCode))) &&
+    (activity.elicitation === undefined || elicitationValue(activity.elicitation)) &&
+    typeof activity.createdAt === 'number' &&
+    Number.isFinite(activity.createdAt) &&
+    typeof activity.updatedAt === 'number' &&
+    Number.isFinite(activity.updatedAt)
+  )
+}
+
+const activityGroupValue = (value: unknown): boolean => {
+  const group = recordValue(value)
+  return (
+    group !== undefined &&
+    typeof group.id === 'string' &&
+    typeof group.title === 'string' &&
+    typeof group.sortIndex === 'number' &&
+    Number.isFinite(group.sortIndex) &&
+    Array.isArray(group.activityIds) &&
+    group.activityIds.every((activityId) => typeof activityId === 'string') &&
+    optionalString(group.promptMessageId) &&
+    typeof group.createdAt === 'number' &&
+    Number.isFinite(group.createdAt) &&
+    typeof group.updatedAt === 'number' &&
+    Number.isFinite(group.updatedAt) &&
+    (group.completedAt === undefined ||
+      (typeof group.completedAt === 'number' && Number.isFinite(group.completedAt)))
+  )
+}
+
+const messageSnapshotValue = (value: unknown): ArtifactMessageSnapshotFile | undefined => {
+  const snapshot = recordValue(value)
+  if (
+    !snapshot ||
+    (snapshot.schemaVersion !== 2 && snapshot.schemaVersion !== 3) ||
+    typeof snapshot.snapshotId !== 'string' ||
+    typeof snapshot.rootFrameId !== 'string' ||
+    typeof snapshot.agentFrameId !== 'string' ||
+    typeof snapshot.messageBranchId !== 'string' ||
+    typeof snapshot.terminalMessageId !== 'string' ||
+    typeof snapshot.createdAt !== 'string' ||
+    !Array.isArray(snapshot.messages) ||
+    snapshot.messages.some((message) => !messageValue(message)) ||
+    (snapshot.schemaVersion === 3 &&
+      (!Array.isArray(snapshot.activities) ||
+        snapshot.activities.some((activity) => !activityValue(activity)) ||
+        !Array.isArray(snapshot.activityGroups) ||
+        snapshot.activityGroups.some((group) => !activityGroupValue(group))))
+  ) {
+    return undefined
+  }
+  return value as ArtifactMessageSnapshotFile
+}
+
+const decodeArtifactMessageSnapshot = (
+  value: string
+): VersionedJsonDecodeResult<ArtifactMessageSnapshotFile> =>
+  decodeVersionedJson(value, {
+    currentVersion: 3,
+    legacyVersions: [2],
+    readVersion: readSchemaVersion,
+    decode: messageSnapshotValue
+  })
+
+const reviewScopeSnapshotValue = (value: unknown): ReviewScopeSnapshotBlock[] | undefined => {
+  const snapshot = recordValue(value)
+  return snapshot &&
+    Array.isArray(snapshot.blocks) &&
+    snapshot.blocks.every((block) => {
+      const candidate = recordValue(block)
+      return (
+        candidate !== undefined &&
+        Number.isSafeInteger(candidate.blockIndex) &&
+        Number(candidate.blockIndex) >= 0 &&
+        typeof candidate.id === 'string' &&
+        (candidate.kind === 'message' || candidate.kind === 'activity') &&
+        typeof candidate.sourceId === 'string' &&
+        typeof candidate.contentHash === 'string' &&
+        recordValue(candidate.payload) !== undefined
+      )
+    })
+    ? (snapshot.blocks as ReviewScopeSnapshotBlock[])
+    : undefined
+}
+
+const decodeReviewScopeSnapshot = (
+  value: string
+): VersionedJsonDecodeResult<ReviewScopeSnapshotBlock[]> =>
+  decodeVersionedJson(value, {
+    currentVersion: 2,
+    legacyVersions: [1],
+    readVersion: readSchemaVersion,
+    decode: reviewScopeSnapshotValue
+  })
+
+export { decodeArtifactMessageSnapshot, decodeReviewScopeSnapshot }

--- a/src/main/compute/repository.test.ts
+++ b/src/main/compute/repository.test.ts
@@ -100,6 +100,76 @@ describe('compute host repository', () => {
     expect(host?.detailsUpdatedBy).toBe('user')
   })
 
+  it('decodes current Compute JSON without exposing its persistence version', async () => {
+    const { client } = createMockClient({
+      findUnique: () =>
+        Promise.resolve(
+          createRow({
+            sshOverrides: JSON.stringify({ schemaVersion: 1, user: 'argocd', port: 2222 }),
+            probeResult: JSON.stringify({
+              schemaVersion: 1,
+              ok: true,
+              probedAt: '2026-01-01T00:00:00Z',
+              exitCode: 0,
+              errorTail: null,
+              cpus: 64
+            })
+          })
+        )
+    })
+    const repository = new ComputeHostRepository(() => Promise.resolve(client))
+
+    await expect(repository.get('ssh:biowulf')).resolves.toMatchObject({
+      sshOverrides: { user: 'argocd', port: 2222 },
+      probeResult: { ok: true, cpus: 64 }
+    })
+  })
+
+  it('does not expose unsupported or corrupt Compute JSON payloads', async () => {
+    const { client } = createMockClient({
+      findMany: () =>
+        Promise.resolve([
+          createRow({
+            id: 'future',
+            providerId: 'ssh:future',
+            sshOverrides: JSON.stringify({ schemaVersion: 2, user: 'future-user' }),
+            probeResult: JSON.stringify({ schemaVersion: 2, ok: true })
+          }),
+          createRow({
+            id: 'corrupt',
+            providerId: 'ssh:corrupt',
+            sshOverrides: JSON.stringify({ schemaVersion: 1, port: 'not-a-number' }),
+            probeResult: JSON.stringify({
+              schemaVersion: 1,
+              ok: 'yes',
+              probedAt: '2026-01-01T00:00:00Z',
+              exitCode: 0,
+              errorTail: null
+            })
+          })
+        ])
+    })
+    const repository = new ComputeHostRepository(() => Promise.resolve(client))
+
+    await expect(repository.list()).resolves.toMatchObject([
+      { providerId: 'ssh:future', sshOverrides: undefined, probeResult: undefined },
+      { providerId: 'ssh:corrupt', sshOverrides: undefined, probeResult: undefined }
+    ])
+  })
+
+  it('keeps readable Compute rows available when one row is corrupt', async () => {
+    const { client } = createMockClient({
+      findMany: () =>
+        Promise.resolve([
+          createRow({ authenticationMode: 'future-authentication-mode' }),
+          createRow({ id: 'healthy', providerId: 'ssh:healthy', sshAlias: 'healthy' })
+        ])
+    })
+    const repository = new ComputeHostRepository(() => Promise.resolve(client))
+
+    await expect(repository.list()).resolves.toMatchObject([{ providerId: 'ssh:healthy' }])
+  })
+
   it('returns null when a host is not found', async () => {
     const { client, computeHost } = createMockClient({
       findUnique: () => Promise.resolve(null)
@@ -156,6 +226,7 @@ describe('compute host repository', () => {
 
     const call = computeHost.create.mock.calls[0]![0] as { data: Record<string, unknown> }
     expect(JSON.parse(call.data.sshOverrides as string)).toEqual({
+      schemaVersion: 1,
       user: 'argocd',
       port: 22,
       identityFile: '~/.ssh/id_ed25519'
@@ -426,7 +497,10 @@ describe('compute host repository', () => {
     ).resolves.toBe(false)
     expect(updateMany).toHaveBeenCalledWith({
       where: { providerId: 'ssh:biowulf', authenticationRevision: 1 },
-      data: { probeResult: JSON.stringify(failure), shape: 'direct_ssh' }
+      data: {
+        probeResult: JSON.stringify({ schemaVersion: 1, ...failure }),
+        shape: 'direct_ssh'
+      }
     })
   })
 
@@ -450,7 +524,10 @@ describe('compute host repository', () => {
     ).resolves.toBeUndefined()
     expect(updateMany).toHaveBeenCalledWith({
       where: { providerId: 'ssh:biowulf', authenticationRevision: 1 },
-      data: { probeResult: JSON.stringify(staleProbe), shape: 'direct_ssh' }
+      data: {
+        probeResult: JSON.stringify({ schemaVersion: 1, ...staleProbe }),
+        shape: 'direct_ssh'
+      }
     })
     expect(update).not.toHaveBeenCalled()
   })

--- a/src/main/compute/repository.ts
+++ b/src/main/compute/repository.ts
@@ -19,6 +19,7 @@ import type {
   ResetPasswordHostPersistence
 } from './compute-auth-owner'
 import { computeProviderId, DETAILS_DOC_MAX_LENGTH } from '../../shared/compute'
+import { decodeVersionedJson } from '../storage/versioned-json-decoder'
 import { ComputeConnectionError } from './connection-broker'
 
 // Only the computeHost delegate is needed; typing to this subset keeps the repository unit-testable
@@ -38,16 +39,138 @@ type ComputeHostClient = Pick<
 // projects/repository.ts).
 type ComputeHostClientProvider = () => Promise<ComputeHostClient>
 
-// JSON columns are parsed defensively: a corrupt value degrades to undefined rather than throwing, so
-// one bad row cannot break loading the whole host list.
-const parseJson = <T>(value: string | null): T | undefined => {
-  if (value === null) return undefined
-  try {
-    return JSON.parse(value) as T
-  } catch {
+const COMPUTE_JSON_SCHEMA_VERSION = 1
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const readSchemaVersion = (value: unknown): unknown =>
+  isRecord(value) && 'schemaVersion' in value ? value.schemaVersion : undefined
+
+const decodeSshOverrides = (value: unknown): SshOverrides | undefined => {
+  if (!isRecord(value)) return undefined
+  if (value.user !== undefined && typeof value.user !== 'string') return undefined
+  if (
+    value.port !== undefined &&
+    (typeof value.port !== 'number' || !Number.isFinite(value.port))
+  ) {
     return undefined
   }
+  if (value.identityFile !== undefined && typeof value.identityFile !== 'string') return undefined
+
+  return {
+    ...(typeof value.user === 'string' ? { user: value.user } : {}),
+    ...(typeof value.port === 'number' ? { port: value.port } : {}),
+    ...(typeof value.identityFile === 'string' ? { identityFile: value.identityFile } : {})
+  }
 }
+
+const authenticationErrorCodes = new Set([
+  'credential_required',
+  'credential_unavailable',
+  'secure_storage_unavailable',
+  'authentication_failed',
+  'credential_conflict',
+  'credential_change_blocked_by_jobs',
+  'host_key_unknown',
+  'host_key_changed',
+  'host_unreachable',
+  'timeout',
+  'create_failed',
+  'reset_failed',
+  'unsupported_auth_configuration'
+])
+
+const decodeProbeResult = (value: unknown): ProbeResult | undefined => {
+  if (!isRecord(value)) return undefined
+  if (typeof value.ok !== 'boolean' || typeof value.probedAt !== 'string') return undefined
+  if (value.exitCode !== null && typeof value.exitCode !== 'number') return undefined
+  if (value.errorTail !== null && typeof value.errorTail !== 'string') return undefined
+  if (
+    value.authenticationCode !== undefined &&
+    (typeof value.authenticationCode !== 'string' ||
+      !authenticationErrorCodes.has(value.authenticationCode))
+  ) {
+    return undefined
+  }
+  if (
+    value.authenticationRevision !== undefined &&
+    (typeof value.authenticationRevision !== 'number' ||
+      !Number.isInteger(value.authenticationRevision))
+  ) {
+    return undefined
+  }
+  if (value.os !== undefined && typeof value.os !== 'string') return undefined
+  for (const numericField of ['cpus', 'memMib'] as const) {
+    if (
+      value[numericField] !== undefined &&
+      (typeof value[numericField] !== 'number' || !Number.isFinite(value[numericField]))
+    ) {
+      return undefined
+    }
+  }
+  if (
+    value.gpus !== undefined &&
+    (!Array.isArray(value.gpus) ||
+      value.gpus.some(
+        (gpu) =>
+          !isRecord(gpu) ||
+          typeof gpu.type !== 'string' ||
+          typeof gpu.count !== 'number' ||
+          !Number.isFinite(gpu.count)
+      ))
+  ) {
+    return undefined
+  }
+  if (
+    value.detectedScheduler !== undefined &&
+    value.detectedScheduler !== 'slurm' &&
+    value.detectedScheduler !== 'pbs' &&
+    value.detectedScheduler !== 'lsf' &&
+    value.detectedScheduler !== 'none'
+  ) {
+    return undefined
+  }
+
+  return {
+    ok: value.ok,
+    probedAt: value.probedAt,
+    exitCode: value.exitCode,
+    errorTail: value.errorTail,
+    ...(value.authenticationCode !== undefined
+      ? { authenticationCode: value.authenticationCode as ProbeResult['authenticationCode'] }
+      : {}),
+    ...(typeof value.authenticationRevision === 'number'
+      ? { authenticationRevision: value.authenticationRevision }
+      : {}),
+    ...(typeof value.os === 'string' ? { os: value.os } : {}),
+    ...(typeof value.cpus === 'number' ? { cpus: value.cpus } : {}),
+    ...(typeof value.memMib === 'number' ? { memMib: value.memMib } : {}),
+    ...(Array.isArray(value.gpus) ? { gpus: value.gpus as ProbeResult['gpus'] } : {}),
+    ...(value.detectedScheduler !== undefined
+      ? { detectedScheduler: value.detectedScheduler as ProbeResult['detectedScheduler'] }
+      : {})
+  }
+}
+
+// Existing unversioned values remain readable as legacy data. Unsupported and corrupt payloads are
+// deliberately omitted from the domain object instead of being mistaken for the current schema.
+const parseComputeJson = <T>(
+  value: string | null,
+  decode: (value: unknown) => T | undefined
+): T | undefined => {
+  if (value === null) return undefined
+  const result = decodeVersionedJson(value, {
+    currentVersion: COMPUTE_JSON_SCHEMA_VERSION,
+    readVersion: readSchemaVersion,
+    decode,
+    decodeUnversioned: decode
+  })
+  return result.status === 'valid' || result.status === 'legacy' ? result.value : undefined
+}
+
+const serializeProbeResult = (result: ProbeResult): string =>
+  JSON.stringify({ schemaVersion: COMPUTE_JSON_SCHEMA_VERSION, ...result })
 
 // Narrows the free-text shape column back to the domain union, defaulting unknown values to
 // 'direct_ssh' so a corrupt row still renders as a plain host rather than crashing.
@@ -92,7 +215,7 @@ const toHost = (row: PrismaComputeHost, hasCredential = false): ComputeHost => (
   displayName: row.displayName,
   shape: asShape(row.shape),
   sshAlias: row.sshAlias,
-  sshOverrides: parseJson<SshOverrides>(row.sshOverrides),
+  sshOverrides: parseComputeJson(row.sshOverrides, decodeSshOverrides),
   authentication: {
     mode: asAuthenticationMode(row.authenticationMode ?? 'ssh_config'),
     credentialStatus:
@@ -107,7 +230,7 @@ const toHost = (row: PrismaComputeHost, hasCredential = false): ComputeHost => (
   scratchRoot: row.scratchRoot ?? undefined,
   scratchPinned: row.scratchPinned,
   concurrencyLimit: row.concurrencyLimit ?? undefined,
-  probeResult: parseJson<ProbeResult>(row.probeResult),
+  probeResult: parseComputeJson(row.probeResult, decodeProbeResult),
   detailsDoc: row.detailsDoc,
   detailsUpdatedAt: row.detailsUpdatedAt?.getTime(),
   detailsUpdatedBy: asAuthor(row.detailsUpdatedBy),
@@ -125,7 +248,9 @@ const serializeOverrides = (overrides: SshOverrides | undefined): string | null 
     clean.port = overrides.port
   }
   if (overrides.identityFile?.trim()) clean.identityFile = overrides.identityFile.trim()
-  return Object.keys(clean).length === 0 ? null : JSON.stringify(clean)
+  return Object.keys(clean).length === 0
+    ? null
+    : JSON.stringify({ schemaVersion: COMPUTE_JSON_SCHEMA_VERSION, ...clean })
 }
 
 // Owns ComputeHost reads/writes. The client is resolved lazily per call so schema-ensure failures can
@@ -168,7 +293,13 @@ class ComputeHostRepository {
     const client = await this.getClient()
     const rows = await client.computeHost.findMany({ orderBy: { createdAt: 'desc' } })
 
-    return rows.map((row) => toHost(row))
+    return rows.flatMap((row) => {
+      try {
+        return [toHost(row)]
+      } catch {
+        return []
+      }
+    })
   }
 
   // Returns a single host by its provider id ("ssh:<alias>") or null when it no longer exists.
@@ -314,7 +445,7 @@ class ComputeHostRepository {
     const updated = await client.computeHost.updateMany({
       where: { providerId, authenticationRevision },
       data: {
-        probeResult: JSON.stringify(result),
+        probeResult: serializeProbeResult(result),
         shape
       }
     })
@@ -594,7 +725,7 @@ class ComputeHostRepository {
       await client.computeHost.updateMany({
         where: { providerId, authenticationRevision: result.authenticationRevision },
         data: {
-          probeResult: JSON.stringify(result),
+          probeResult: serializeProbeResult(result),
           shape
         }
       })
@@ -603,7 +734,7 @@ class ComputeHostRepository {
     await client.computeHost.update({
       where: { providerId },
       data: {
-        probeResult: JSON.stringify(result),
+        probeResult: serializeProbeResult(result),
         shape
       }
     })

--- a/src/main/notebook/repository.test.ts
+++ b/src/main/notebook/repository.test.ts
@@ -235,6 +235,121 @@ describe('notebook run repository', () => {
     })
   })
 
+  it('keeps readable Notebook documents available when one Frame document is corrupt', async () => {
+    const root = await createStorageRoot()
+    const repository = new NotebookRunRepository(root)
+    const projectId = 'default-project'
+    const sessionId = 'session-1'
+    await repository.loadOrCreate({
+      projectId,
+      sessionId,
+      workspaceCwd: '/workspace',
+      lane: createRootNotebookLane(projectId, sessionId, 'root-frame-session-1')
+    })
+    const corruptLane = createFrameNotebookLane(projectId, sessionId, 'corrupt-frame')
+    const corruptDocument = await repository.loadOrCreate({
+      projectId,
+      sessionId,
+      workspaceCwd: '/workspace',
+      lane: corruptLane
+    })
+    await writeFile(join(corruptDocument.notebookSessionRoot, 'run.json'), '{ not-json', 'utf8')
+
+    await expect(
+      new NotebookRunRepository(root).readSessionDocuments(projectId, sessionId)
+    ).resolves.toEqual([expect.objectContaining({ projectId, sessionId })])
+  })
+
+  it('keeps readable Notebook documents available when one Frame has a corrupt shape', async () => {
+    const root = await createStorageRoot()
+    const projectId = 'default-project'
+    const sessionId = 'session-1'
+    const repository = new NotebookRunRepository(root)
+    await repository.loadOrCreate({
+      projectId,
+      sessionId,
+      workspaceCwd: '/workspace',
+      lane: createRootNotebookLane(projectId, sessionId, 'root-frame-session-1')
+    })
+    const corruptDocument = await repository.loadOrCreate({
+      projectId,
+      sessionId,
+      workspaceCwd: '/workspace',
+      lane: createFrameNotebookLane(projectId, sessionId, 'corrupt-frame')
+    })
+    const filePath = join(corruptDocument.notebookSessionRoot, 'run.json')
+    const malformed = JSON.parse(await readFile(filePath, 'utf8')) as Record<string, unknown>
+    malformed.runs = [null]
+    await writeFile(filePath, JSON.stringify(malformed), 'utf8')
+
+    await expect(
+      new NotebookRunRepository(root).readSessionDocuments(projectId, sessionId)
+    ).resolves.toEqual([expect.objectContaining({ projectId, sessionId })])
+  })
+
+  it('does not treat an unversioned Notebook document as registered legacy data', async () => {
+    const root = await createStorageRoot()
+    const projectId = 'default-project'
+    const sessionId = 'session-1'
+    const document = await new NotebookRunRepository(root).loadOrCreate({
+      projectId,
+      sessionId,
+      workspaceCwd: '/workspace',
+      lane: createRootNotebookLane(projectId, sessionId, 'root-frame-session-1')
+    })
+    const filePath = join(document.notebookSessionRoot, 'run.json')
+    const unversioned = JSON.parse(await readFile(filePath, 'utf8')) as Record<string, unknown>
+    delete unversioned.version
+    await writeFile(filePath, JSON.stringify(unversioned), 'utf8')
+
+    await expect(
+      new NotebookRunRepository(root).readSessionDocuments(projectId, sessionId)
+    ).resolves.toEqual([])
+  })
+
+  it('does not rewrite a Notebook document created by a newer app version', async () => {
+    const root = await createStorageRoot()
+    const projectId = 'default-project'
+    const sessionId = 'session-1'
+    const lane = createRootNotebookLane(projectId, sessionId, 'root-frame-session-1')
+    const document = await new NotebookRunRepository(root).loadOrCreate({
+      projectId,
+      sessionId,
+      workspaceCwd: '/workspace',
+      lane
+    })
+    const filePath = join(document.notebookSessionRoot, 'run.json')
+    const futureDocument = {
+      ...JSON.parse(await readFile(filePath, 'utf8')),
+      version: 2,
+      futureNotebookState: { mustSurvive: true }
+    }
+    const futureBytes = `${JSON.stringify(futureDocument, null, 2)}\n`
+    await writeFile(filePath, futureBytes, 'utf8')
+
+    await expect(
+      new NotebookRunRepository(root).appendRun({
+        projectId,
+        sessionId,
+        lane,
+        run: {
+          runId: 'new-run',
+          cellId: 'cell-new-run',
+          source: 'agent',
+          kernelKind: 'python',
+          script: '1',
+          status: 'completed',
+          startedAt: 1,
+          text: { stdout: '', stderr: '', traceback: '', plain: [] },
+          outputs: [],
+          artifacts: [],
+          workingFiles: []
+        }
+      })
+    ).rejects.toThrow('Notebook document version is not supported.')
+    await expect(readFile(filePath, 'utf8')).resolves.toBe(futureBytes)
+  })
+
   it('creates run.json under the notebook session workspace with runtime and data roots', async () => {
     const root = await createStorageRoot()
     const repository = new NotebookRunRepository(root)

--- a/src/main/notebook/repository.ts
+++ b/src/main/notebook/repository.ts
@@ -11,7 +11,13 @@ import type {
 } from '../../shared/notebook'
 import { NOTEBOOK_RUN_FILE, NOTEBOOKS_DIR } from '../../shared/notebook'
 import type { NotebookRuntimeBindings } from '../../shared/notebook-runtime'
-import { readDurableJsonFile, writeDurableJsonFile } from '../storage/durable-json-file'
+import { createLogger } from '../logger'
+import {
+  DurableJsonRecoveryBarrierError,
+  readDurableJsonFile,
+  writeDurableJsonFile
+} from '../storage/durable-json-file'
+import { decodeVersionedJson } from '../storage/versioned-json-decoder'
 import { decodeRunDocumentDataPaths, encodeRunDocumentDataPaths } from './run-document-data-paths'
 import {
   createFrameNotebookLane,
@@ -23,6 +29,7 @@ const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
 const MAX_DOCUMENT_CACHE_ENTRIES = 8
 const MAX_DOCUMENT_CACHE_BYTES = 32 * 1024 * 1024
 const MAX_DOCUMENT_READ_ATTEMPTS = 2
+const log = createLogger('notebook:persistence')
 
 type DocumentFileIdentity = { mtimeMs: number; size: number; ino: number }
 
@@ -94,6 +101,96 @@ const isMissingFileError = (error: unknown): boolean =>
 
 const persistedScopeValue = (value: unknown): string =>
   value === undefined || value === null ? '<missing>' : (JSON.stringify(value) ?? String(value))
+
+class UnsupportedNotebookDocumentVersionError extends DurableJsonRecoveryBarrierError {
+  constructor() {
+    super('Notebook document version is not supported.')
+  }
+}
+
+class CorruptNotebookDocumentError extends Error {
+  constructor() {
+    super('Notebook document is corrupt.')
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const notebookRunCandidate = (value: unknown): boolean => {
+  if (!isRecord(value)) return false
+  if (
+    typeof value.runId !== 'string' ||
+    typeof value.cellId !== 'string' ||
+    (value.source !== 'agent' && value.source !== 'user') ||
+    typeof value.script !== 'string' ||
+    !['queued', 'running', 'completed', 'failed', 'timeout', 'interrupted', 'cancelled'].includes(
+      String(value.status)
+    ) ||
+    typeof value.startedAt !== 'number' ||
+    !Number.isFinite(value.startedAt) ||
+    (value.kernelKind !== undefined &&
+      value.kernelKind !== 'python' &&
+      value.kernelKind !== 'r' &&
+      value.kernelKind !== 'repl' &&
+      value.kernelKind !== 'bash')
+  ) {
+    return false
+  }
+  if (
+    value.workingFiles !== undefined &&
+    (!Array.isArray(value.workingFiles) ||
+      value.workingFiles.some((file) => !isRecord(file) || typeof file.path !== 'string'))
+  ) {
+    return false
+  }
+  if (
+    value.artifacts !== undefined &&
+    (!Array.isArray(value.artifacts) ||
+      value.artifacts.some(
+        (artifact) =>
+          !isRecord(artifact) ||
+          typeof artifact.path !== 'string' ||
+          (typeof artifact.projectId !== 'string' && typeof artifact.projectName !== 'string')
+      ))
+  ) {
+    return false
+  }
+  return true
+}
+
+const notebookDocumentCandidate = (value: unknown): NotebookRunDocument | undefined =>
+  isRecord(value) && Array.isArray(value.runs) ? (value as NotebookRunDocument) : undefined
+
+function assertNotebookDocumentShape(value: unknown): asserts value is NotebookRunDocument {
+  if (!isRecord(value)) throw new CorruptNotebookDocumentError()
+  const kernel = isRecord(value.kernel) ? value.kernel : undefined
+  if (
+    (typeof value.projectId !== 'string' && typeof value.projectName !== 'string') ||
+    typeof value.sessionId !== 'string' ||
+    typeof value.workspaceCwd !== 'string' ||
+    typeof value.notebookSessionRoot !== 'string' ||
+    typeof value.dataRoot !== 'string' ||
+    !kernel ||
+    typeof kernel.runtimeRoot !== 'string' ||
+    !Array.isArray(value.runs) ||
+    value.runs.some((run) => !notebookRunCandidate(run))
+  ) {
+    throw new CorruptNotebookDocumentError()
+  }
+}
+
+const decodeNotebookDocument = (contents: string): NotebookRunDocument => {
+  const decoded = decodeVersionedJson(contents, {
+    currentVersion: 1,
+    readVersion: (value) =>
+      typeof value === 'object' && value !== null && 'version' in value ? value.version : undefined,
+    decode: notebookDocumentCandidate
+  })
+  if (decoded.status === 'unsupported') throw new UnsupportedNotebookDocumentVersionError()
+  if (decoded.status === 'corrupt') throw new CorruptNotebookDocumentError()
+  return decoded.value
+}
 
 // The physical notebooks/<projectId>/<sessionId>/run.json path is the ownership boundary. Validate
 // the persisted identity before decoding paths or normalizing request-derived fields so a misplaced
@@ -332,8 +429,9 @@ class NotebookRunRepository {
     const filePath = getNotebookRunJsonPath(this.storageRoot, projectId, sessionId, request.lane)
 
     const read = await readDurableJsonFile(filePath, (contents) => {
-      const document: unknown = JSON.parse(contents)
+      const document = decodeNotebookDocument(contents)
       assertNotebookDocumentOwnership(document, projectId, sessionId)
+      assertNotebookDocumentShape(document)
       return document
     })
     if (read.status === 'found') {
@@ -554,7 +652,22 @@ class NotebookRunRepository {
 
   async readSessionDocuments(projectId: string, sessionId: string): Promise<NotebookRunDocument[]> {
     const documents: NotebookRunDocument[] = []
-    const legacy = await this.findExisting(projectId, sessionId)
+    const legacy = await this.findExisting(projectId, sessionId).catch((error) => {
+      if (
+        error instanceof CorruptNotebookDocumentError ||
+        error instanceof UnsupportedNotebookDocumentVersionError
+      ) {
+        log.warn('skipping unreadable Notebook document', {
+          projectId,
+          sessionId,
+          lane: 'root',
+          status:
+            error instanceof UnsupportedNotebookDocumentVersionError ? 'unsupported' : 'corrupt'
+        })
+        return null
+      }
+      throw error
+    })
     if (legacy) documents.push(legacy)
 
     const framesRoot = join(
@@ -572,7 +685,21 @@ class NotebookRunRepository {
       if (!entry.isDirectory()) continue
       const lane = createFrameNotebookLane(projectId, sessionId, entry.name)
       const document = await this.loadExisting(projectId, sessionId, lane).catch((error) => {
-        if (isMissingFileError(error)) return undefined
+        if (
+          isMissingFileError(error) ||
+          error instanceof CorruptNotebookDocumentError ||
+          error instanceof UnsupportedNotebookDocumentVersionError
+        ) {
+          log.warn('skipping unreadable Notebook document', {
+            projectId,
+            sessionId,
+            lane: 'frame',
+            frameId: entry.name,
+            status:
+              error instanceof UnsupportedNotebookDocumentVersionError ? 'unsupported' : 'corrupt'
+          })
+          return undefined
+        }
         throw error
       })
       if (document) documents.push(document)
@@ -682,8 +809,9 @@ class NotebookRunRepository {
       } catch (error) {
         if (!isMissingFileError(error)) throw error
         const recovered = await readDurableJsonFile(filePath, (contents) => {
-          const document: unknown = JSON.parse(contents)
+          const document = decodeNotebookDocument(contents)
           assertNotebookDocumentOwnership(document, safeProjectId, safeSessionId)
+          assertNotebookDocumentShape(document)
           return document
         })
         if (recovered.status === 'missing') throw error
@@ -698,8 +826,9 @@ class NotebookRunRepository {
         return cached.document
       }
       const read = await readDurableJsonFile(filePath, (contents) => {
-        const document: unknown = JSON.parse(contents)
+        const document = decodeNotebookDocument(contents)
         assertNotebookDocumentOwnership(document, safeProjectId, safeSessionId)
+        assertNotebookDocumentShape(document)
         return document
       })
       if (read.status === 'missing') throw new Error(`Notebook document disappeared: ${filePath}`)

--- a/src/main/notebook/run-document-data-paths.ts
+++ b/src/main/notebook/run-document-data-paths.ts
@@ -67,8 +67,8 @@ const decodeRun = (run: NotebookRunRecord, dataRoot: string | undefined): Notebo
   ...run,
   cwdBefore: decodeDataPath(run.cwdBefore, dataRoot),
   cwdAfter: decodeDataPath(run.cwdAfter, dataRoot),
-  workingFiles: run.workingFiles.map((file) => decodeWorkingFile(file, dataRoot)),
-  artifacts: run.artifacts.map((artifact) => decodeArtifact(artifact, dataRoot))
+  workingFiles: (run.workingFiles ?? []).map((file) => decodeWorkingFile(file, dataRoot)),
+  artifacts: (run.artifacts ?? []).map((artifact) => decodeArtifact(artifact, dataRoot))
 })
 
 // Encodes a notebook run.json document's data-root paths (roots, cwds, working files, artifacts)

--- a/src/main/storage/versioned-json-decoder.test.ts
+++ b/src/main/storage/versioned-json-decoder.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+
+import { decodeVersionedJson } from './versioned-json-decoder'
+
+type ExampleDocument = Readonly<{ schemaVersion: number; name: string }>
+
+const decodeExample = (value: unknown): ExampleDocument | undefined => {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !('schemaVersion' in value) ||
+    !('name' in value) ||
+    typeof value.schemaVersion !== 'number' ||
+    typeof value.name !== 'string'
+  ) {
+    return undefined
+  }
+  return { schemaVersion: value.schemaVersion, name: value.name }
+}
+
+describe('versioned JSON decoder', () => {
+  it('returns valid for a current-version document that passes domain decoding', () => {
+    expect(
+      decodeVersionedJson<ExampleDocument>(JSON.stringify({ schemaVersion: 3, name: 'current' }), {
+        currentVersion: 3,
+        readVersion: (value) =>
+          typeof value === 'object' && value !== null && 'schemaVersion' in value
+            ? value.schemaVersion
+            : undefined,
+        decode: decodeExample
+      })
+    ).toEqual({ status: 'valid', version: 3, value: { schemaVersion: 3, name: 'current' } })
+  })
+
+  it('returns corrupt for malformed JSON', () => {
+    expect(
+      decodeVersionedJson<ExampleDocument>('{ not-json', {
+        currentVersion: 3,
+        readVersion: () => undefined,
+        decode: decodeExample
+      })
+    ).toEqual({ status: 'corrupt' })
+  })
+
+  it('returns unsupported for a well-formed future version without domain decoding', () => {
+    let decoded = false
+    expect(
+      decodeVersionedJson<ExampleDocument>(JSON.stringify({ schemaVersion: 4, name: 'future' }), {
+        currentVersion: 3,
+        readVersion: (value) =>
+          typeof value === 'object' && value !== null && 'schemaVersion' in value
+            ? value.schemaVersion
+            : undefined,
+        decode: (value) => {
+          decoded = true
+          return decodeExample(value)
+        }
+      })
+    ).toEqual({ status: 'unsupported', version: 4 })
+    expect(decoded).toBe(false)
+  })
+
+  it('returns legacy for a registered historical version that passes domain decoding', () => {
+    expect(
+      decodeVersionedJson<ExampleDocument>(
+        JSON.stringify({ schemaVersion: 2, name: 'historical' }),
+        {
+          currentVersion: 3,
+          legacyVersions: [2],
+          readVersion: (value) =>
+            typeof value === 'object' && value !== null && 'schemaVersion' in value
+              ? value.schemaVersion
+              : undefined,
+          decode: decodeExample
+        }
+      )
+    ).toEqual({
+      status: 'legacy',
+      version: 2,
+      value: { schemaVersion: 2, name: 'historical' }
+    })
+  })
+
+  it('returns legacy for an explicitly supported unversioned document', () => {
+    expect(
+      decodeVersionedJson<{ name: string }>(JSON.stringify({ name: 'unversioned' }), {
+        currentVersion: 1,
+        readVersion: (value) =>
+          typeof value === 'object' && value !== null && 'schemaVersion' in value
+            ? value.schemaVersion
+            : undefined,
+        decode: () => undefined,
+        decodeUnversioned: (value) =>
+          typeof value === 'object' && value !== null && 'name' in value
+            ? { name: String(value.name) }
+            : undefined
+      })
+    ).toEqual({ status: 'legacy', value: { name: 'unversioned' } })
+  })
+})

--- a/src/main/storage/versioned-json-decoder.ts
+++ b/src/main/storage/versioned-json-decoder.ts
@@ -1,0 +1,40 @@
+export type VersionedJsonDecodeResult<Value> =
+  | Readonly<{ status: 'valid'; version: number; value: Value }>
+  | Readonly<{ status: 'legacy'; version?: number; value: Value }>
+  | Readonly<{ status: 'unsupported'; version: number }>
+  | Readonly<{ status: 'corrupt' }>
+
+export type VersionedJsonDecoder<Value> = Readonly<{
+  currentVersion: number
+  legacyVersions?: readonly number[]
+  readVersion: (value: unknown) => unknown
+  decode: (value: unknown) => Value | undefined
+  decodeUnversioned?: (value: unknown) => Value | undefined
+}>
+
+export const decodeVersionedJson = <Value>(
+  serialized: string,
+  decoder: VersionedJsonDecoder<Value>
+): VersionedJsonDecodeResult<Value> => {
+  try {
+    const parsed: unknown = JSON.parse(serialized)
+    const version = decoder.readVersion(parsed)
+    if (version === undefined && decoder.decodeUnversioned) {
+      const value = decoder.decodeUnversioned(parsed)
+      return value === undefined ? { status: 'corrupt' } : { status: 'legacy', value }
+    }
+    if (Number.isSafeInteger(version) && Number(version) > decoder.currentVersion) {
+      return { status: 'unsupported', version: Number(version) }
+    }
+    const legacyVersion =
+      Number.isSafeInteger(version) && decoder.legacyVersions?.includes(Number(version)) === true
+    if (version !== decoder.currentVersion && !legacyVersion) return { status: 'corrupt' }
+    const value = decoder.decode(parsed)
+    if (value === undefined) return { status: 'corrupt' }
+    return legacyVersion
+      ? { status: 'legacy', version: Number(version), value }
+      : { status: 'valid', version: decoder.currentVersion, value }
+  } catch {
+    return { status: 'corrupt' }
+  }
+}

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -1835,6 +1835,7 @@
   "The gateway root; a trailing <code>/v1</code> is added automatically. Choose the API format below to match the endpoint.": "ゲートウェイのルート。末尾の <code>/v1</code> が自動的に追加されます。エンドポイントに一致する API 形式を以下から選択します。",
   "The immutable Execution Log was bounded; the reconstruction may include a provenance-gap comment.": "変更できない実行ログの一部が省略されています。再構築された内容には、来歴情報の欠落を示すコメントが含まれる場合があります。",
   "The immutable message snapshot is not available for this version ({{reason}}).": "不変のメッセージ スナップショットは、このバージョン ({{reason}}) では使用できません。",
+  "This message snapshot was created by a newer version of Open Science. Update the app to view it.": "このメッセージスナップショットは、より新しいバージョンの Open Science で作成されました。表示するにはアプリを更新してください。",
   "The installer could not be started.": "インストーラーを起動できませんでした。",
   "The internet is reachable.": "インターネットにアクセスできます。",
   "The latest Agent total remains authoritative while local categories update.": "ローカル カテゴリが更新される間、最新のエージェント合計が引き続き信頼されます。",

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -1835,6 +1835,7 @@
   "The gateway root; a trailing <code>/v1</code> is added automatically. Choose the API format below to match the endpoint.": "게이트웨이 루트. 후행 <code>/v1</code>이 자동으로 추가됩니다. 아래에서 엔드포인트와 일치하는 API 형식을 선택하세요.",
   "The immutable Execution Log was bounded; the reconstruction may include a provenance-gap comment.": "불변 실행 로그가 제한되었습니다. 재구성에는 출처 격차 설명이 포함될 수 있습니다.",
   "The immutable message snapshot is not available for this version ({{reason}}).": "이 버전에서는 변경 불가능한 메시지 스냅샷을 사용할 수 없습니다({{reason}}).",
+  "This message snapshot was created by a newer version of Open Science. Update the app to view it.": "이 메시지 스냅샷은 더 최신 버전의 Open Science에서 생성되었습니다. 보려면 앱을 업데이트하세요.",
   "The installer could not be started.": "설치 프로그램을 시작할 수 없습니다.",
   "The internet is reachable.": "인터넷에 접속할 수 있습니다.",
   "The latest Agent total remains authoritative while local categories update.": "지역 카테고리가 업데이트되는 동안 최신 에이전트 총계는 여전히 신뢰할 수 있습니다.",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -1896,6 +1896,7 @@
   "The gateway root; a trailing <code>/v1</code> is added automatically. Choose the API format below to match the endpoint.": "网关根地址；末尾的 <code>/v1</code> 会自动补上。在下方选择与该端点匹配的 API 格式。",
   "The immutable Execution Log was bounded; the reconstruction may include a provenance-gap comment.": "不可变执行日志已被截断，重建结果中可能包含溯源缺口的注释。",
   "The immutable message snapshot is not available for this version ({{reason}}).": "此版本的不可变消息快照不可用（{{reason}}）。",
+  "This message snapshot was created by a newer version of Open Science. Update the app to view it.": "此消息快照由较新版本的 Open Science 创建。请更新应用以查看。",
   "The installer could not be started.": "安装程序无法启动。",
   "The internet is reachable.": "互联网可以访问。",
   "The latest Agent total remains authoritative while local categories update.": "本地类别更新时，最新智能体总数仍是权威值。",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -1893,6 +1893,7 @@
   "The gateway root; a trailing <code>/v1</code> is added automatically. Choose the API format below to match the endpoint.": "閘道根位址；結尾的 <code>/v1</code> 會自動補上。在下方選擇與該端點相符的 API 格式。",
   "The immutable Execution Log was bounded; the reconstruction may include a provenance-gap comment.": "不可變執行紀錄已被截斷，重建結果中可能包含來源缺口的註解。",
   "The immutable message snapshot is not available for this version ({{reason}}).": "此版本的不可變訊息快照無法使用（{{reason}}）。",
+  "This message snapshot was created by a newer version of Open Science. Update the app to view it.": "此訊息快照由較新版本的 Open Science 建立。請更新應用程式以檢視。",
   "The installer could not be started.": "安裝程式無法啟動。",
   "The internet is reachable.": "網際網路可以連線。",
   "The latest Agent total remains authoritative while local categories update.": "本機類別更新時，最新智能體總數仍是權威值。",

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
@@ -745,6 +745,20 @@ describe('ArtifactProvenancePanel', () => {
     expect(container.textContent).not.toContain('Loading Messages')
   })
 
+  it('asks for an update when a Message snapshot uses a newer persistence version', async () => {
+    getVersionMessages.mockResolvedValueOnce({
+      messages: { state: 'unavailable', reason: 'message-snapshot-unsupported' }
+    })
+
+    await clickTab('Messages')
+    await flush()
+
+    expect(container.textContent).toContain(
+      'This message snapshot was created by a newer version of Open Science. Update the app to view it.'
+    )
+    expect(container.textContent).not.toContain('(message-snapshot-unsupported)')
+  })
+
   it('reuses a loaded lazy section when switching away and back', async () => {
     await clickTab('Messages')
     await flush()

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
@@ -1295,9 +1295,14 @@ const ArtifactProvenancePanel = ({
             />
           ) : (
             <p className="p-5 text-sm text-text-300">
-              {t('The immutable message snapshot is not available for this version ({{reason}}).', {
-                reason: provenance.messages.reason
-              })}
+              {provenance.messages.reason === 'message-snapshot-unsupported'
+                ? t(
+                    'This message snapshot was created by a newer version of Open Science. Update the app to view it.'
+                  )
+                : t(
+                    'The immutable message snapshot is not available for this version ({{reason}}).',
+                    { reason: provenance.messages.reason }
+                  )}
             </p>
           )
         ) : null}

--- a/src/shared/artifact-provenance.ts
+++ b/src/shared/artifact-provenance.ts
@@ -448,7 +448,11 @@ export type ArtifactVersionProvenance = {
       }
     | {
         state: 'unavailable'
-        reason: 'not-loaded' | 'message-snapshot-pending' | 'message-snapshot-corrupt'
+        reason:
+          | 'not-loaded'
+          | 'message-snapshot-pending'
+          | 'message-snapshot-unsupported'
+          | 'message-snapshot-corrupt'
       }
   review:
     | {


### PR DESCRIPTION
## Problem

Notebook documents, Compute JSON columns, and Artifact provenance snapshots previously decoded persisted JSON through separate ad-hoc paths. Malformed JSON, valid JSON with an invalid nested shape, or data written by a newer app version could therefore be conflated, throw through a whole list read, or be normalized back into an older schema.

This occurs after interrupted/manual writes, partial filesystem damage, database JSON corruption, upgrade/downgrade across schema versions, or when a structurally invalid record is present beside otherwise healthy records.

Without this change:

- one corrupt Notebook frame or Compute row can reject an otherwise readable list;
- a future Notebook document can be read and rewritten as v1, losing unknown fields;
- corrupt/future Compute optional JSON is trusted or leaks parsing failures;
- Artifact Message, Execution, and Review snapshots conflate future data with corruption, and malformed nested domain records can be cast as valid;
- users see an internal reason token instead of actionable guidance for a newer Message snapshot.

## Proposed change

- Add one version-aware JSON decoder that classifies reads as `valid`, `legacy`, `unsupported`, or `corrupt` before returning domain values.
- Route Notebook v1, Compute `sshOverrides` / `probeResult`, and Artifact Message / Execution / Review snapshots through that boundary.
- Validate nested persisted domain records rather than checking only the outer arrays.
- Isolate corrupt/unsupported Notebook siblings and unusable Compute rows during list reads; fail closed for direct reads and mutation paths.
- Prevent future Notebook bytes from participating in durable recovery or being rewritten.
- Show an upgrade-oriented message when an Artifact Message snapshot was produced by a newer app version.

## Historical compatibility

- Notebook v1 remains current and retains the existing v1 compatibility fields, including missing `kernelKind`, legacy `projectName`, and optional historical file arrays.
- Unversioned Notebook documents are intentionally **not** registered as legacy.
- Existing unversioned Compute `sshOverrides` and `probeResult` JSON remains readable as `legacy`.
- Artifact Message v2 and Review scope v1 remain readable as `legacy`.
- Immutable Artifact snapshot bytes are never migrated or rewritten.

## New states

- Internal persistence reads now share four states: `valid`, `legacy`, `unsupported`, and `corrupt`.
- The only new renderer-visible reason is `message-snapshot-unsupported`.
- No new external Notebook, Compute, Execution, or Review state is introduced; Review preserves its existing public corrupt/unavailable behavior.

## Persistence and data model impact

- New Compute writes add an internal top-level `schemaVersion: 1` inside the existing JSON columns.
- Notebook's persisted version remains v1.
- Artifact schema bytes, checksums, and lifecycle storage remain unchanged.
- No Prisma migration, table, column, relation, or database backfill is required.
- Domain models remain unchanged except for the shared Artifact Message unavailability reason used by the renderer.
- Interaction changes are limited to the Artifact Message upgrade copy; there is no new user input or migration flow.

## Scope and non-goals

- ComputeJob JSON is out of scope; this covers only `ComputeHost.sshOverrides` and `probeResult`.
- Artifact coverage is Message, Execution, and Review scope snapshots.
- This does not add eager migration, background rewrite, or automatic repair of corrupt records.
- This does not run the complete local test suite; the PR CI remains the full-suite fallback.

## Acceptance criteria and validation

The tests were written to reproduce the observed failure modes before implementation. Red-phase failures included:

- malformed/shape-invalid Notebook siblings throwing `SyntaxError` / `TypeError` and collapsing the list;
- a future Notebook document being accepted and rewritten as v1;
- an unversioned Notebook document being normalized instead of rejected;
- a bad Compute row rejecting the whole list and new writes lacking a version;
- future Artifact snapshots being reported as corrupt, and the renderer exposing the raw reason;
- invalid Message activities, `elicitation: {}`, and invalid Execution inputs/status values being returned as `valid`.

Final Test Impact Set:

| Surface | Validation | Result |
| --- | --- | --- |
| Decoder + Notebook + Compute + Artifact + renderer + i18n | 8 targeted Vitest files | 377 passed |
| Compute module | `npm run test:module -- compute` | 28 files; 734 passed, 6 skipped |
| Artifact provenance module | `npm run test:module -- artifact_provenance` | 26 files; 1301 passed |
| Main/shared types | `npm run typecheck:node` | passed |
| Renderer types | `npm run typecheck:web` | passed |
| Static checks | `npm run lint`, `git diff --check` | passed |
| Independent review | Standards / Spec | 0 / 0 actionable findings |

`test:affected --explain` selects the complete suite because the new decoder files do not yet have a module owner. Per the requested workflow, the complete suite is deferred to PR CI rather than run locally.

## Review focus

- Classification precedence: future safe-integer versions must return `unsupported` before current-schema decoding.
- Notebook recovery and mutation paths must never rewrite unsupported bytes.
- List isolation must skip only the unusable entry and preserve healthy siblings.
- Registered historical compatibility must remain explicit and narrow.
- Compute version metadata must stay inside existing JSON storage; no schema migration should appear.
- Artifact Message is the only new renderer-visible unsupported state.
