### PR TITLE
fix(message-stream): prevent tool layout shift

### DIFF
--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -33,6 +33,7 @@ const LONG_STREAM_PROMPT = 'Stream the long scroll journey.'
 const QUEUE_GATE_PROMPT = 'Hold the queue until the reveal finishes.'
 const TOOL_ORDER_PROMPT = 'Run the ordered slow tool journey.'
 const TOOL_LAYOUT_SHIFT_PROMPT = 'Run the tool layout stability journey.'
+const TOOL_STATUS_LAYOUT_SHIFT_PROMPT = 'Run the status-bearing layout stability journey.'
 const RELIABLE_FAIRNESS_USER_PROMPT = 'Run the concurrent real user prompt.'
 const DELEGATION_INHERITED_SPECIALIST_PROMPT =
   'Run the production inherited Specialist delegation journey.'
@@ -486,7 +487,10 @@ if (process.argv.includes('--version')) {
 
       let reply = 'Deterministic reply: Summarize the deterministic fixture.'
       try {
-        if (prompt.includes(TOOL_LAYOUT_SHIFT_PROMPT)) {
+        if (
+          prompt.includes(TOOL_LAYOUT_SHIFT_PROMPT) ||
+          prompt.includes(TOOL_STATUS_LAYOUT_SHIFT_PROMPT)
+        ) {
           // Keep the completed tool group on screen before streaming the final Markdown so the
           // renderer test can observe whether the existing row moves while the next row mounts.
           await context.client.notify(acp.methods.client.session.update, {
@@ -508,6 +512,9 @@ if (process.argv.includes('--version')) {
               status: 'completed'
             }
           })
+          if (prompt.includes(TOOL_STATUS_LAYOUT_SHIFT_PROMPT)) {
+            process.stderr.write('Layout fixture status.\n')
+          }
           await delay(750)
 
           const finalMessageId = `e2e-message-${nextMessageId++}`

--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -32,6 +32,7 @@ const RELIABLE_FAIRNESS_PROMPT = 'Start the reliable messaging fairness journey.
 const LONG_STREAM_PROMPT = 'Stream the long scroll journey.'
 const QUEUE_GATE_PROMPT = 'Hold the queue until the reveal finishes.'
 const TOOL_ORDER_PROMPT = 'Run the ordered slow tool journey.'
+const TOOL_LAYOUT_SHIFT_PROMPT = 'Run the tool layout stability journey.'
 const RELIABLE_FAIRNESS_USER_PROMPT = 'Run the concurrent real user prompt.'
 const DELEGATION_INHERITED_SPECIALIST_PROMPT =
   'Run the production inherited Specialist delegation journey.'
@@ -485,7 +486,41 @@ if (process.argv.includes('--version')) {
 
       let reply = 'Deterministic reply: Summarize the deterministic fixture.'
       try {
-        if (prompt.includes(TOOL_ORDER_PROMPT)) {
+        if (prompt.includes(TOOL_LAYOUT_SHIFT_PROMPT)) {
+          // Keep the completed tool group on screen before streaming the final Markdown so the
+          // renderer test can observe whether the existing row moves while the next row mounts.
+          await context.client.notify(acp.methods.client.session.update, {
+            sessionId: context.params.sessionId,
+            update: {
+              sessionUpdate: 'tool_call',
+              toolCallId: 'e2e-layout-tool-1',
+              title: 'Prepare layout fixture',
+              kind: 'other',
+              status: 'in_progress'
+            }
+          })
+          await context.client.notify(acp.methods.client.session.update, {
+            sessionId: context.params.sessionId,
+            update: {
+              sessionUpdate: 'tool_call_update',
+              toolCallId: 'e2e-layout-tool-1',
+              title: 'Layout probe completed',
+              status: 'completed'
+            }
+          })
+          await delay(750)
+
+          const finalMessageId = `e2e-message-${nextMessageId++}`
+          await context.client.notify(acp.methods.client.session.update, {
+            sessionId: context.params.sessionId,
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              messageId: finalMessageId,
+              content: { type: 'text', text: 'Layout fixture complete.' }
+            }
+          })
+          reply = ''
+        } else if (prompt.includes(TOOL_ORDER_PROMPT)) {
           // Mirrors a real agent turn: intent text, a slow tool call, then follow-up text.
           const intentMessageId = `e2e-message-${nextMessageId++}`
           // A long intent text, chunked quickly so live pacing trails far behind arrival.

--- a/e2e/message-tool-layout-stability.spec.ts
+++ b/e2e/message-tool-layout-stability.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from '@playwright/test'
+import { expect, type Page } from '@playwright/test'
 
 import { test } from './fixtures/electron-app'
 
@@ -6,12 +6,27 @@ const PROJECT_NAME = 'Tool layout stability project'
 const USER_MESSAGE = 'Summarize the deterministic fixture.'
 const AGENT_REPLY = 'Deterministic reply: Summarize the deterministic fixture.'
 const TOOL_LAYOUT_SHIFT_PROMPT = 'Run the tool layout stability journey.'
+const TOOL_STATUS_LAYOUT_SHIFT_PROMPT = 'Run the status-bearing layout stability journey.'
 
 test.use({ windowMode: 'normal' })
 
-test('keeps a completed tool group stationary when final Markdown starts rendering', async ({
-  app
-}) => {
+const cases = [
+  { name: 'without agent status', prompt: TOOL_LAYOUT_SHIFT_PROMPT, agentStatus: undefined },
+  {
+    name: 'with agent status',
+    prompt: TOOL_STATUS_LAYOUT_SHIFT_PROMPT,
+    agentStatus: 'Layout fixture status.'
+  }
+] as const
+
+const runLayoutStabilityJourney = async (
+  app: {
+    completeOnboarding: () => Promise<Page>
+    configureFakeAgent: () => Promise<Page>
+  },
+  prompt: string,
+  agentStatus?: string
+): Promise<void> => {
   let page = await app.completeOnboarding()
   page = await app.configureFakeAgent()
 
@@ -29,11 +44,14 @@ test('keeps a completed tool group stationary when final Markdown starts renderi
   await sendButton.click()
   await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
 
-  await textbox.fill(TOOL_LAYOUT_SHIFT_PROMPT)
+  await textbox.fill(prompt)
   await sendButton.click()
 
   const toolGroup = conversation.locator('[data-message-id="activity-group-e2e-layout-tool-1"]')
   await expect(toolGroup).toBeVisible()
+  if (agentStatus) {
+    await expect(conversation.getByText(agentStatus, { exact: true })).toBeVisible()
+  }
 
   const tops = await toolGroup.evaluate(
     (element) =>
@@ -64,4 +82,12 @@ test('keeps a completed tool group stationary when final Markdown starts renderi
       finalTop: tops.at(-1)
     })
   ).toBeLessThanOrEqual(2)
-})
+}
+
+for (const scenario of cases) {
+  test(`keeps a completed tool group stationary when final Markdown starts rendering ${scenario.name}`, async ({
+    app
+  }) => {
+    await runLayoutStabilityJourney(app, scenario.prompt, scenario.agentStatus)
+  })
+}

--- a/e2e/message-tool-layout-stability.spec.ts
+++ b/e2e/message-tool-layout-stability.spec.ts
@@ -1,0 +1,67 @@
+import { expect } from '@playwright/test'
+
+import { test } from './fixtures/electron-app'
+
+const PROJECT_NAME = 'Tool layout stability project'
+const USER_MESSAGE = 'Summarize the deterministic fixture.'
+const AGENT_REPLY = 'Deterministic reply: Summarize the deterministic fixture.'
+const TOOL_LAYOUT_SHIFT_PROMPT = 'Run the tool layout stability journey.'
+
+test.use({ windowMode: 'normal' })
+
+test('keeps a completed tool group stationary when final Markdown starts rendering', async ({
+  app
+}) => {
+  let page = await app.completeOnboarding()
+  page = await app.configureFakeAgent()
+
+  await page.getByRole('button', { name: 'New project' }).click()
+  const dialog = page.getByRole('dialog', { name: 'New project' })
+  await dialog.getByLabel('Name').fill(PROJECT_NAME)
+  await dialog.getByRole('button', { name: 'Create project' }).click()
+  await expect(page.getByRole('heading', { name: 'New conversation' })).toBeVisible()
+
+  const conversation = page.getByRole('region', { name: 'Conversation' })
+  const textbox = page.getByRole('textbox', { name: 'Ask anything' })
+  const sendButton = page.getByRole('button', { name: 'Send message' })
+
+  await textbox.fill(USER_MESSAGE)
+  await sendButton.click()
+  await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
+
+  await textbox.fill(TOOL_LAYOUT_SHIFT_PROMPT)
+  await sendButton.click()
+
+  const toolGroup = conversation.locator('[data-message-id="activity-group-e2e-layout-tool-1"]')
+  await expect(toolGroup).toBeVisible()
+
+  const tops = await toolGroup.evaluate(
+    (element) =>
+      new Promise<number[]>((resolve) => {
+        const observations: number[] = []
+        const startedAt = performance.now()
+        const sample = (): void => {
+          observations.push(element.getBoundingClientRect().top)
+          if (performance.now() - startedAt >= 2_000) {
+            resolve(observations)
+            return
+          }
+          requestAnimationFrame(sample)
+        }
+        requestAnimationFrame(sample)
+      })
+  )
+
+  await expect(conversation.getByText('Layout fixture complete.', { exact: true })).toBeVisible()
+
+  const excursion = Math.max(...tops) - Math.min(...tops)
+  expect(
+    excursion,
+    JSON.stringify({
+      firstTop: tops[0],
+      minimumTop: Math.min(...tops),
+      maximumTop: Math.max(...tops),
+      finalTop: tops.at(-1)
+    })
+  ).toBeLessThanOrEqual(2)
+})

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:e2e": "node --max-old-space-size=4096 node_modules/electron-vite/bin/electron-vite.js build",
     "test:e2e": "playwright test",
     "test:e2e:journey": "playwright test e2e/electron-foundation.spec.ts e2e/settings-persistence.spec.ts e2e/windows-window-system.spec.ts",
-    "test:e2e:workspace": "playwright test e2e/launch-environment.spec.ts e2e/workspace-conversation.spec.ts e2e/workspace-files.spec.ts",
+    "test:e2e:workspace": "playwright test e2e/launch-environment.spec.ts e2e/message-tool-layout-stability.spec.ts e2e/workspace-conversation.spec.ts e2e/workspace-files.spec.ts",
     "test:e2e:accessibility": "playwright test e2e/accessibility.spec.ts",
     "test:e2e:accessibility:signal": "node scripts/ci/run-accessibility-e2e.mjs",
     "test:e2e:visual": "playwright test e2e/visual-regression.spec.ts",

--- a/src/renderer/src/components/streamdown/AgentMarkdown.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.tsx
@@ -259,9 +259,9 @@ const RichAgentMarkdown = memo(
       <div
         className={cn(
           'agent-markdown-root max-w-full min-w-0',
-          // Match the loading row while the first streamed content is still buffered so replacing
-          // it cannot collapse the scroll extent and visibly move completed tool activity.
-          isAnimating && 'agent-markdown-streaming min-h-9'
+          // Match the tallest loading row (including its optional status line) while the first
+          // streamed content is buffered so replacing it cannot collapse the scroll extent.
+          isAnimating && 'agent-markdown-streaming min-h-14'
         )}
       >
         <Streamdown

--- a/src/renderer/src/components/streamdown/AgentMarkdown.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.tsx
@@ -259,7 +259,9 @@ const RichAgentMarkdown = memo(
       <div
         className={cn(
           'agent-markdown-root max-w-full min-w-0',
-          isAnimating && 'agent-markdown-streaming'
+          // Match the loading row while the first streamed content is still buffered so replacing
+          // it cannot collapse the scroll extent and visibly move completed tool activity.
+          isAnimating && 'agent-markdown-streaming min-h-9'
         )}
       >
         <Streamdown

--- a/src/renderer/src/components/streamdown/AgentMarkdown.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.tsx
@@ -259,9 +259,7 @@ const RichAgentMarkdown = memo(
       <div
         className={cn(
           'agent-markdown-root max-w-full min-w-0',
-          // Match the tallest loading row (including its optional status line) while the first
-          // streamed content is buffered so replacing it cannot collapse the scroll extent.
-          isAnimating && 'agent-markdown-streaming min-h-14'
+          isAnimating && 'agent-markdown-streaming'
         )}
       >
         <Streamdown

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -1142,7 +1142,15 @@ const WorkspaceMessageItemImpl = ({
             </div>
           )
         ) : (
-          <div className={cn(assistantMessageSurfaceClassName, 'select-text overflow-visible')}>
+          <div
+            className={cn(
+              assistantMessageSurfaceClassName,
+              'select-text overflow-visible',
+              // Match the tallest loading row while initial content is buffered so replacing it
+              // cannot collapse the workspace scroll extent. Side chat keeps its natural geometry.
+              isAssistantPresenting && 'min-h-14'
+            )}
+          >
             {message.content ? (
               <PresentedAgentMarkdown
                 content={assistantPresentation.content}


### PR DESCRIPTION
## Problem

After a completed tool call, replacing the terminal loading row with the final assistant message can briefly move the already-rendered tool group upward and then back. The canonical message arrives before the smooth-streaming prebuffer exposes any text, so the row loses about 36 px, the conversation scroll extent collapses, and the browser clamps `scrollTop` until content catches up.

The new Electron reproduction measured a 35.5 px viewport excursion before the fix with one prior completed turn, one completed tool, and one plain final message. This also rules out Markdown structure and CSS containment as the cause. A status-bearing loading row exposed a second red case: the initial 36 px reservation still moved by 19.5 px because the optional status line makes that row taller.

## Proposed change

- Reserve the tallest loading row's 56 px height only on the main workspace assistant surface while its Markdown is actively being presented.
- Add a deterministic fake-agent journey for the completed-tool-to-final-message transition.
- Add Electron E2E regressions for both normal and status-bearing loading rows. Each samples the completed tool group's viewport position while final content starts rendering and allows at most 2 px of movement.

## Scope and non-goals

- Presentation-only change in the main workspace; side-chat Markdown keeps its natural streaming geometry. No message timing, tool lifecycle, scrolling interaction, or persisted behavior changes.
- No architecture or data-model changes.
- No new data fields, enum values, or persistent state.
- No historical-data compatibility path is required.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Completed tool activity remains stationary with and without an agent status line, and PR CI invokes both through the workspace journey -> `npm run test:e2e:workspace -- --grep "keeps a completed tool group stationary" --reporter=line --repeat-each=2` -> 4/4 passed.
- Shared Agent Markdown, workspace message, and scroller behavior remain intact -> `npx vitest run src/renderer/src/components/streamdown/AgentMarkdown.streaming.render.test.tsx src/renderer/src/components/streamdown/AgentMarkdown.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx` -> 98/98 passed.
- Electron production bundle includes the presentation class -> `npm run build:e2e` -> passed.
- Node and renderer types -> `npm run typecheck` -> passed.
- Changed lint surfaces -> `npx eslint src/renderer/src/components/streamdown/AgentMarkdown.tsx e2e/fixtures/fake-opencode.mjs e2e/message-tool-layout-stability.spec.ts` -> passed.
- Formatting/whitespace -> `git diff --check` and targeted Prettier check -> passed.

The module manifest does not declare `AgentMarkdown.tsx` as an owned module path, and the final diff updates package script metadata to register the regression, so exact-head PR Gate will fail closed to its authoritative full plan. Per task scope, the complete local `npm test` and full-repository lint were not run; PR CI is the remaining coverage for unrelated renderer consumers and platform lanes.

## Review focus

- Whether limiting `min-h-14` to the main workspace's `isAssistantPresenting` surface preserves terminal layout without affecting completed/static or side-chat messages.
- Whether the E2E timing represents the production transition without introducing an unnecessarily broad fixture.
