### PR TITLE
feat(workspace): collapse long user messages

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
@@ -29,6 +29,9 @@ vi.mock('./artifact-preview', () => ({
 
 let container: HTMLDivElement
 let root: Root
+let notifyResize: (() => void) | undefined
+
+const originalResizeObserver = globalThis.ResizeObserver
 
 const writeText = vi.fn().mockResolvedValue(undefined)
 
@@ -132,6 +135,18 @@ const typeIntoEditor = async (editor: HTMLElement, text: string): Promise<void> 
 }
 
 beforeEach(() => {
+  globalThis.ResizeObserver = class {
+    constructor(private readonly callback: ResizeObserverCallback) {}
+    observe(): void {
+      notifyResize = () => this.callback([], this as unknown as ResizeObserver)
+    }
+    disconnect(): void {
+      notifyResize = undefined
+    }
+    unobserve(): void {
+      notifyResize = undefined
+    }
+  }
   writeText.mockClear()
   Object.defineProperty(window.navigator, 'clipboard', {
     value: { writeText },
@@ -146,6 +161,9 @@ afterEach(() => {
   act(() => root.unmount())
   container.remove()
   document.body.innerHTML = ''
+  notifyResize = undefined
+  if (originalResizeObserver) globalThis.ResizeObserver = originalResizeObserver
+  else delete (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver
 })
 
 describe('WorkspaceMessageItem user message actions', () => {
@@ -273,6 +291,127 @@ describe('WorkspaceMessageItem user message actions', () => {
 
     const bubbleRow = container.querySelector<HTMLElement>('[data-slot="user-bubble-row"]')
     expect(bubbleRow?.classList.contains('w-full')).toBe(true)
+  })
+
+  it('collapses user message content beyond twelve lines and expands it downward on demand', async () => {
+    await renderItem(createMessage({ content: 'Long prompt line\n'.repeat(13) }))
+
+    const content = container.querySelector<HTMLElement>('[data-slot="user-message-content"]')
+    const measurement = container.querySelector<HTMLElement>(
+      '[data-slot="user-message-measurement"]'
+    )
+    if (!content || !measurement) throw new Error('user message content not found')
+    expect(measurement.textContent).toBe('')
+    expect(measurement.dataset.content).toBe('Long prompt line\n'.repeat(13))
+    measurement.style.lineHeight = '20px'
+    Object.defineProperty(measurement, 'scrollHeight', { configurable: true, value: 260 })
+    act(() => notifyResize?.())
+
+    const showMore = getButton('Show more')
+    expect(content.classList.contains('max-h-[12lh]')).toBe(true)
+    expect(content.classList.contains('overflow-hidden')).toBe(true)
+    expect(showMore.getAttribute('aria-expanded')).toBe('false')
+    expect(showMore.getAttribute('aria-controls')).toBe(content.id)
+
+    await click(showMore)
+
+    expect(content.classList.contains('max-h-[12lh]')).toBe(false)
+    expect(content.classList.contains('overflow-hidden')).toBe(false)
+    const showLess = getButton('Show less')
+    expect(showLess.getAttribute('aria-expanded')).toBe('true')
+
+    await click(showLess)
+
+    expect(content.classList.contains('max-h-[12lh]')).toBe(true)
+    expect(getButton('Show more').getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('keeps short user message content fully visible without an expand control', async () => {
+    await renderItem(createMessage({ content: 'Short prompt' }))
+
+    const content = container.querySelector<HTMLElement>('[data-slot="user-message-content"]')
+    const measurement = container.querySelector<HTMLElement>(
+      '[data-slot="user-message-measurement"]'
+    )
+    if (!content || !measurement) throw new Error('user message content not found')
+    measurement.style.lineHeight = '20px'
+    Object.defineProperty(measurement, 'scrollHeight', { configurable: true, value: 240 })
+    act(() => notifyResize?.())
+
+    expect(container.querySelector('[aria-label="Show more"]')).toBeNull()
+    expect(content.classList.contains('max-h-[12lh]')).toBe(false)
+  })
+
+  it('remeasures structured content and uses a non-interactive summary while collapsed', async () => {
+    const text = 'Structured prompt line\n'.repeat(13)
+    const contentText = `${text}/forecast @evidence.csv`
+    await renderItem(
+      createMessage({
+        content: contentText,
+        parts: [
+          { type: 'text', text },
+          { type: 'skill', id: 'skill-forecast', name: 'forecast' },
+          { type: 'text', text: ' ' },
+          {
+            type: 'artifact',
+            id: 'artifact-1',
+            name: 'evidence.csv',
+            path: '/project/evidence.csv',
+            source: 'artifact'
+          }
+        ],
+        uploads: [
+          {
+            id: 'upload-1',
+            sessionId: 'session-1',
+            name: 'evidence.pdf',
+            originalName: 'evidence.pdf',
+            mimeType: 'application/pdf',
+            size: 1024
+          }
+        ]
+      })
+    )
+
+    const content = container.querySelector<HTMLElement>('[data-slot="user-message-content"]')
+    const measurement = container.querySelector<HTMLElement>(
+      '[data-slot="user-message-measurement"]'
+    )
+    const attachment = getButton('Preview uploaded attachment evidence.pdf')
+    if (!content || !measurement) throw new Error('user message content not found')
+    const measuredSkill = measurement.querySelector<HTMLElement>('[data-part-type="skill"]')
+    const measuredArtifact = measurement.querySelector<HTMLElement>('[data-part-type="artifact"]')
+    expect(measurement.textContent).toBe('')
+    expect(measurement.dataset.content).toBeUndefined()
+    expect(measuredSkill?.dataset.content).toBe('/forecast')
+    expect(measuredSkill?.classList.contains('px-1.5')).toBe(true)
+    expect(measuredArtifact?.dataset.content).toBe('@evidence.csv')
+    expect(measuredArtifact?.classList.contains('inline-flex')).toBe(true)
+    measurement.style.lineHeight = '20px'
+    let scrollHeight = 240
+    Object.defineProperty(measurement, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight
+    })
+
+    act(() => notifyResize?.())
+    expect(container.querySelector('[aria-label="Show more"]')).toBeNull()
+    expect(getButton('Open skill forecast')).not.toBeNull()
+
+    scrollHeight = 260
+    act(() => notifyResize?.())
+
+    expect(getButton('Show more')).not.toBeNull()
+    expect(container.querySelector('[aria-label="Open skill forecast"]')).toBeNull()
+    expect(container.querySelector('[aria-label="Preview evidence.csv"]')).toBeNull()
+    expect(content.textContent).toBe(contentText)
+    expect(content.contains(attachment)).toBe(false)
+
+    await click(getButton('Show more'))
+
+    expect(content.contains(getButton('Open skill forecast'))).toBe(true)
+    expect(content.contains(getButton('Preview evidence.csv'))).toBe(true)
+    expect(getButton('Show less').getAttribute('aria-expanded')).toBe('true')
   })
 
   it('labels an interrupted user turn without creating another message item', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -12,8 +12,10 @@ import {
   Bot,
   Brain,
   Check,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
+  ChevronUp,
   CircleGauge,
   Copy,
   FileText,
@@ -22,7 +24,16 @@ import {
   MessageCircleMore,
   Pencil
 } from 'lucide-react'
-import { memo, useEffect, useId, useLayoutEffect, useRef, useState, type FocusEvent } from 'react'
+import {
+  memo,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type FocusEvent,
+  type ReactNode
+} from 'react'
 import { useTranslation } from 'react-i18next'
 import { formatDisplayNumber } from '@/lib/locale-format'
 import type { ArtifactPreviewResult } from '../../../../shared/artifacts'
@@ -432,6 +443,9 @@ const artifactGalleryClassName = 'grid max-w-full grid-cols-[repeat(auto-fill,12
 
 const userMessageBubbleClassName =
   'max-w-[90%] break-words rounded-2xl bg-bg-300 px-3.5 py-2 text-sm text-message-user-text md:max-w-[min(85%,56rem)] md:px-4 md:py-2.5 md:text-[15px]'
+const userMessageCollapseButtonClassName =
+  'mt-2 inline-flex items-center gap-1 rounded-md text-[13px] font-medium text-text-200 transition-colors duration-200 ease-out hover:text-text-000 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 motion-reduce:transition-none'
+const USER_MESSAGE_PREVIEW_LINE_COUNT = 12
 // Hover actions sit left of the user bubble, revealed on row hover or keyboard focus.
 const userMessageActionsClassName =
   'flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100 focus-within:opacity-100'
@@ -476,6 +490,168 @@ const mentionButtonClassName =
 
 const assistantMessageSurfaceClassName =
   'relative w-full max-w-[56rem] text-sm leading-relaxed text-text-000 md:text-[15px]'
+
+const measurementContentClassName = 'before:content-[attr(data-content)]'
+
+const MessagePartsMeasurement = ({
+  parts,
+  isStatic
+}: {
+  parts: Array<MessagePart | ProvenanceMessagePart>
+  isStatic: boolean
+}): React.JSX.Element => (
+  <p className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+    {parts.map((part, index) => {
+      if (part.type === 'skill') {
+        return (
+          <span
+            key={index}
+            data-slot="user-message-measurement-part"
+            data-part-type="skill"
+            data-content={`/${part.name}`}
+            className={cn(mentionPillClassName, measurementContentClassName)}
+          />
+        )
+      }
+
+      if (part.type === 'artifact') {
+        const isLinkedFolder = !isStatic && 'source' in part && part.source === 'linked-folder'
+        return (
+          <span
+            key={index}
+            data-slot="user-message-measurement-part"
+            data-part-type="artifact"
+            data-content={`@${isLinkedFolder ? part.relativePath : part.name}`}
+            className={cn(
+              isStatic ? mentionPillClassName : artifactMentionPillClassName,
+              measurementContentClassName
+            )}
+          />
+        )
+      }
+
+      return (
+        <span
+          key={index}
+          data-slot="user-message-measurement-part"
+          data-part-type="text"
+          data-content={part.text}
+          className={cn('whitespace-pre-wrap', measurementContentClassName)}
+        />
+      )
+    })}
+  </p>
+)
+
+type CollapsibleUserMessageContentProps = {
+  children: ReactNode
+  hasInteractiveContent: boolean
+  message: ChatMessage
+  staticParts?: ProvenanceMessagePart[]
+}
+
+const CollapsibleUserMessageContent = ({
+  children,
+  hasInteractiveContent,
+  message,
+  staticParts
+}: CollapsibleUserMessageContentProps): React.JSX.Element => {
+  const { t } = useTranslation()
+  const contentId = useId()
+  const measurementRef = useRef<HTMLDivElement>(null)
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [canExpand, setCanExpand] = useState(false)
+  const isCollapsed = canExpand && !isExpanded
+  const measurementParts =
+    staticParts && staticParts.length > 0
+      ? staticParts
+      : message.parts && message.parts.length > 0
+        ? message.parts
+        : undefined
+
+  useLayoutEffect(() => {
+    const measurement = measurementRef.current
+    if (!measurement) return
+
+    setIsExpanded(false)
+    const measureOverflow = (): void => {
+      const style = window.getComputedStyle(measurement)
+      const parsedLineHeight = Number.parseFloat(style.lineHeight)
+      const parsedFontSize = Number.parseFloat(style.fontSize)
+      const lineHeight =
+        Number.isFinite(parsedLineHeight) && parsedLineHeight > 0
+          ? parsedLineHeight < 4 && Number.isFinite(parsedFontSize)
+            ? parsedLineHeight * parsedFontSize
+            : parsedLineHeight
+          : Number.isFinite(parsedFontSize) && parsedFontSize > 0
+            ? parsedFontSize * 1.5
+            : undefined
+      const previewHeight = lineHeight ? lineHeight * USER_MESSAGE_PREVIEW_LINE_COUNT : undefined
+      const overflows = previewHeight !== undefined && measurement.scrollHeight > previewHeight + 1
+      setCanExpand(overflows)
+      if (!overflows) setIsExpanded(false)
+    }
+
+    measureOverflow()
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(measureOverflow)
+    observer.observe(measurement)
+    return () => observer.disconnect()
+  }, [message.content, message.id, message.parts, staticParts])
+
+  return (
+    <div className="relative">
+      <div
+        ref={measurementRef}
+        data-slot="user-message-measurement"
+        data-content={measurementParts ? undefined : message.content}
+        aria-hidden="true"
+        className={cn(
+          'pointer-events-none invisible absolute inset-x-0 top-0 whitespace-pre-wrap break-words [overflow-wrap:anywhere]',
+          !measurementParts && measurementContentClassName
+        )}
+      >
+        {measurementParts ? (
+          <MessagePartsMeasurement
+            parts={measurementParts}
+            isStatic={Boolean(staticParts && staticParts.length > 0)}
+          />
+        ) : null}
+      </div>
+      <div
+        id={contentId}
+        data-slot="user-message-content"
+        className={cn(isCollapsed && 'max-h-[12lh] overflow-hidden')}
+      >
+        {isCollapsed && hasInteractiveContent ? (
+          <p className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+            {message.content}
+          </p>
+        ) : (
+          children
+        )}
+      </div>
+      {canExpand ? (
+        <button
+          type="button"
+          data-slot="user-message-collapse-toggle"
+          className={userMessageCollapseButtonClassName}
+          aria-label={isExpanded ? t('Show less') : t('Show more')}
+          aria-expanded={isExpanded}
+          aria-controls={contentId}
+          onClick={() => setIsExpanded((expanded) => !expanded)}
+        >
+          <span>{isExpanded ? t('Show less') : t('Show more')}</span>
+          {isExpanded ? (
+            <ChevronUp className="size-3.5" aria-hidden="true" />
+          ) : (
+            <ChevronDown className="size-3.5" aria-hidden="true" />
+          )}
+        </button>
+      ) : null}
+    </div>
+  )
+}
 
 // ACP message images are already MIME- and size-checked at runtime and persistence boundaries.
 const MessageImageList = ({ images }: { images: MessageImage[] }): React.JSX.Element | null => {
@@ -932,6 +1108,27 @@ const WorkspaceMessageItemImpl = ({
     confirmEditedResend()
   }
 
+  const userMessageContent =
+    staticParts && staticParts.length > 0 ? (
+      <MessagePartsContent
+        parts={staticParts}
+        isStatic
+        onOpenSkillMention={onOpenSkillMention}
+        onPreviewMentionArtifact={onPreviewMentionArtifact}
+      />
+    ) : message.parts && message.parts.length > 0 ? (
+      <MessagePartsContent
+        parts={message.parts}
+        onOpenSkillMention={onOpenSkillMention}
+        onPreviewMentionArtifact={onPreviewMentionArtifact}
+      />
+    ) : message.content ? (
+      <p className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{message.content}</p>
+    ) : null
+  const hasInteractiveUserMessageContent = Boolean(
+    !staticParts && message.parts?.some((part) => part.type === 'skill' || part.type === 'artifact')
+  )
+
   return (
     <MessageScrollerItem
       key={message.id}
@@ -1064,24 +1261,17 @@ const WorkspaceMessageItemImpl = ({
                     onPreviewUploadAttachment={onPreviewUploadAttachment}
                   />
                   {/* Structured parts drive styled pills; plain content is the backward-compatible fallback. */}
-                  {staticParts && staticParts.length > 0 ? (
-                    <MessagePartsContent
-                      parts={staticParts}
-                      isStatic
-                      onOpenSkillMention={onOpenSkillMention}
-                      onPreviewMentionArtifact={onPreviewMentionArtifact}
-                    />
-                  ) : message.parts && message.parts.length > 0 ? (
-                    <MessagePartsContent
-                      parts={message.parts}
-                      onOpenSkillMention={onOpenSkillMention}
-                      onPreviewMentionArtifact={onPreviewMentionArtifact}
-                    />
-                  ) : message.content ? (
-                    <p className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
-                      {message.content}
-                    </p>
-                  ) : null}
+                  {isHumanUser && userMessageContent ? (
+                    <CollapsibleUserMessageContent
+                      hasInteractiveContent={hasInteractiveUserMessageContent}
+                      message={message}
+                      staticParts={staticParts}
+                    >
+                      {userMessageContent}
+                    </CollapsibleUserMessageContent>
+                  ) : (
+                    userMessageContent
+                  )}
                 </div>
               </div>
               {sentDate || message.interrupted || showRevisionNavigation ? (


### PR DESCRIPTION
## Problem

Long user-authored messages can dominate the workspace transcript and make nearby turns difficult to scan.

## Proposed change

- Collapse user message text after 12 rendered lines.
- Show an accessible Show more / Show less control inside the bubble.
- Recompute overflow when the bubble width changes and expand content downward in the transcript.
- Keep uploaded attachments outside the collapsed region.
- Render collapsed structured prompts as a non-interactive plain-text summary, then restore Skill and Artifact actions when expanded.

## Scope and non-goals

- Renderer-only presentation change in WorkspaceMessageItem.
- No Session schema, persisted data, history compatibility, data model, or enum changes.
- Expanded state is local to the mounted message component and is not persisted.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Long-message collapse, responsive remeasurement, accessibility, structured-summary behavior, attachments, and expansion -> npm test -- src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx -> passed, 25 tests.
- Message renderer, structured mentions, Scroller consumers, Provenance reuse, and locale catalog contract -> npm test -- src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx src/renderer/src/i18n/resources.test.ts -> passed, 494 tests.
- Exact PR Gate affected coverage path -> npx vitest run --coverage --changed origin/main -> passed, 27 files and 581 tests; 95.32% statements, 88.8% branches, 95.58% functions, 98% lines.
- Renderer TypeScript surface -> npm run typecheck:web -> passed.
- Source lint -> npm run lint -> passed.
- Final standards and specification review -> passed with no remaining findings.

The dependency-aware module explain command falls back to the complete Vitest plan because the changed test file has no module owner. Per maintainer direction, the complete local npm test suite was not run; PR Gate is the final authority for the remaining portable and platform checks.

## Review focus

- Twelve-line overflow measurement and ResizeObserver cleanup.
- Collapsed structured prompts use clear non-interactive summaries without hiding attachment actions.
- Keyboard and assistive-technology behavior of the toggle.