### PR TITLE
fix(session-persistence): transport revision conflicts as outcomes

### DIFF
--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'v
 import {
   createEmptySessionManifest,
   materializeSessionConversationGraph,
+  SessionRevisionConflictError,
   type PersistedChatSession
 } from '../../shared/session-persistence'
 import type { Logger } from '../logger'
@@ -297,7 +298,10 @@ describe('session persistence IPC handlers', () => {
       conflictRebaseFields: ['specialistId', 'specialistBindingPending']
     }
 
-    await expect(invoke?.({ sender: { id: 7 } }, session, forgedOptions)).resolves.toBe(session)
+    await expect(invoke?.({ sender: { id: 7 } }, session, forgedOptions)).resolves.toEqual({
+      ok: true,
+      result: session
+    })
 
     expect(saveSession).toHaveBeenCalledWith(session)
   })
@@ -491,9 +495,10 @@ describe('session persistence IPC handlers', () => {
     await expect(ipcHandlers.get('sessions:load-one')?.(event, deleteRequest)).resolves.toBe(
       durableSession
     )
-    await expect(ipcHandlers.get('sessions:save-session')?.(event, session)).resolves.toBe(
-      durableSession
-    )
+    await expect(ipcHandlers.get('sessions:save-session')?.(event, session)).resolves.toEqual({
+      ok: true,
+      result: durableSession
+    })
     const updatedSession = { ...session, title: 'Updated session', updatedAt: 1710000000001 }
     await ipcHandlers.get('sessions:save-session')?.(event, updatedSession)
     await ipcHandlers.get('sessions:update-archive')?.(event, archiveRequest)
@@ -644,6 +649,38 @@ describe('session persistence IPC handlers', () => {
     expect(broadcastLifecycleEvent).not.toHaveBeenCalled()
   })
 
+  it('returns a revision-conflict outcome without rejecting the Electron IPC handler', async () => {
+    const conflict = new SessionRevisionConflictError(3, 4)
+    const repository: SessionPersistenceBackend = {
+      loadAll: vi.fn(),
+      loadOne: vi.fn(),
+      saveSession: vi.fn(),
+      deleteSession: vi.fn(),
+      saveManifest: vi.fn()
+    }
+    const handlers: SessionPersistenceHandlers = {
+      loadAll: vi.fn(),
+      loadOne: vi.fn(),
+      saveSession: vi.fn().mockRejectedValue(conflict),
+      setDelegationPolicy: vi.fn(),
+      updateArchive: vi.fn(),
+      deleteSession: vi.fn(),
+      saveManifest: vi.fn()
+    }
+    registerSessionPersistenceIpcHandlers(repository, createMockReviewRepository(), handlers)
+
+    await expect(
+      ipcHandlers.get('sessions:save-session')?.({ sender: { id: 1 } }, createSession())
+    ).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'session-revision-conflict',
+        message: conflict.message
+      }
+    })
+    expect(broadcastLifecycleEvent).not.toHaveBeenCalled()
+  })
+
   it('captures the lifecycle origin before awaiting a durable save', async () => {
     const session = createSession()
     let completeSave!: () => void
@@ -667,7 +704,7 @@ describe('session persistence IPC handlers', () => {
     expect(getLifecycleClientId).toHaveBeenCalledOnce()
     expect(getLifecycleClientId).toHaveReturnedWith('electron:1')
     completeSave()
-    await expect(save).resolves.toBe(session)
+    await expect(save).resolves.toEqual({ ok: true, result: session })
   })
 
   it('publishes a lifecycle event only after the durable Session transition is readable', async () => {

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -1,5 +1,11 @@
 import { ipcMainHandle } from '../ipc-handler-registry'
 
+import type { ApplicationCommandOutcome } from '../../shared/application-command-contract'
+import { LIFECYCLE_CHANNELS } from '../../shared/lifecycle-events'
+import {
+  isSessionRevisionConflictError,
+  SESSION_REVISION_CONFLICT_ERROR_CODE
+} from '../../shared/session-persistence'
 import type {
   DeleteSessionRequest,
   LoadAllSessionsResult,
@@ -10,7 +16,6 @@ import type {
   SaveSessionManifestRequest,
   UpdateSessionArchiveRequest
 } from '../../shared/session-persistence'
-import { LIFECYCLE_CHANNELS } from '../../shared/lifecycle-events'
 import { broadcastLifecycleEvent, getLifecycleClientId } from '../lifecycle-broadcast'
 import { createLogger, diagnosticErrorFields, type Logger } from '../logger'
 import { resolveStorageRoot } from '../storage-root'
@@ -200,24 +205,43 @@ const registerSessionPersistenceIpcHandlers = (
   )
   ipcMainHandle(
     'sessions:save-session',
-    async (event, session: PersistedChatSession, options?: SaveSessionOptions) => {
+    async (
+      event,
+      session: PersistedChatSession,
+      options?: SaveSessionOptions
+    ): Promise<ApplicationCommandOutcome<PersistedChatSession>> => {
       const originClientId = getLifecycleClientId(event)
-      const durable = await withDataRootWrite(async () => {
-        const rendererOptions = sanitizeRendererSaveSessionOptions(options)
-        const result = rendererOptions
-          ? await handlers.saveSession(session, rendererOptions)
-          : await handlers.saveSession(session)
-        broadcastLifecycleEvent(
-          result.created ? LIFECYCLE_CHANNELS.sessionCreated : LIFECYCLE_CHANNELS.sessionUpdated,
-          {
-            session: result.session,
-            originClientId
-          }
-        )
-        return result.session
-      })
+      let durable: PersistedChatSession
+      try {
+        durable = await withDataRootWrite(async () => {
+          const rendererOptions = sanitizeRendererSaveSessionOptions(options)
+          const result = rendererOptions
+            ? await handlers.saveSession(session, rendererOptions)
+            : await handlers.saveSession(session)
+          broadcastLifecycleEvent(
+            result.created ? LIFECYCLE_CHANNELS.sessionCreated : LIFECYCLE_CHANNELS.sessionUpdated,
+            {
+              session: result.session,
+              originClientId
+            }
+          )
+          return result.session
+        })
+      } catch (error) {
+        if (!isSessionRevisionConflictError(error)) throw error
+        return Object.freeze({
+          ok: false,
+          error: Object.freeze({
+            code: SESSION_REVISION_CONFLICT_ERROR_CODE,
+            message:
+              error instanceof Error
+                ? error.message
+                : 'Session revision conflict. Reload and retry.'
+          })
+        })
+      }
       void Promise.resolve(onSessionSaved?.(durable)).catch(() => undefined)
-      return durable
+      return Object.freeze({ ok: true, result: durable })
     }
   )
   ipcMainHandle('sessions:update-archive', async (event, request: UpdateSessionArchiveRequest) => {

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -182,7 +182,9 @@ beforeAll(async () => {
   // Take the contextBridge branch of the preload's expose logic (production path with context isolation).
   Object.defineProperty(process, 'contextIsolated', { value: true, configurable: true })
   invokeMock.mockImplementation(async (channel: string) =>
-    validatedApplicationCommandChannels.has(channel) ? { ok: true, result: undefined } : undefined
+    validatedApplicationCommandChannels.has(channel) || channel === 'sessions:save-session'
+      ? { ok: true, result: undefined }
+      : undefined
   )
 
   await import('./index')
@@ -850,6 +852,22 @@ describe('preload bridge — core renderer contract catalog', () => {
       ...request,
       sourcePath: '/data/large.csv'
     })
+  })
+
+  it('restores a revision-conflict rejection from the Session save IPC outcome', async () => {
+    invokeMock.mockResolvedValueOnce({
+      ok: false,
+      error: {
+        code: 'session-revision-conflict',
+        message:
+          'Session revision conflict: expected 3, actual 4. Reload the latest conversation before retrying.'
+      }
+    })
+
+    await expect(api.sessions.saveSession({ id: 'session-1' })).rejects.toMatchObject({
+      code: 'session-revision-conflict'
+    })
+    expect(invokeMock).toHaveBeenCalledWith('sessions:save-session', { id: 'session-1' })
   })
 
   it('returns null without IPC when native upload path extraction fails', async () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer, webUtils, type IpcRendererEvent } from 'electron'
 
+import { unwrapApplicationCommandOutcome } from '../shared/application-command-contract'
 import { createElectronRendererContractAdapter } from './electron-renderer-contract-adapter'
 import type { OpenScienceAPI } from './renderer-api'
 
@@ -196,8 +197,10 @@ const api: OpenScienceAPI = {
     // Loads one durable Session without scanning unrelated Project/Session files.
     loadOne: (request) => electronRendererContracts.invoke('sessions.loadOne', request),
     // Persists a single sanitized session file.
-    saveSession: (session, options) =>
-      electronRendererContracts.invoke('sessions.saveSession', session, options),
+    saveSession: async (session, options) =>
+      unwrapApplicationCommandOutcome(
+        await electronRendererContracts.invoke('sessions.saveSession', session, options)
+      ),
     updateArchive: (request) => electronRendererContracts.invoke('sessions.updateArchive', request),
     // Removes one session file.
     deleteSession: (request) => electronRendererContracts.invoke('sessions.deleteSession', request),

--- a/src/renderer/web/renderer-argument-shape-characterization.test.ts
+++ b/src/renderer/web/renderer-argument-shape-characterization.test.ts
@@ -110,6 +110,9 @@ const invokeElectron = async (
   args: unknown[]
 ): Promise<CapturedInvocation> => {
   electronMocks.invoke.mockClear()
+  if (path === 'sessions.saveSession') {
+    electronMocks.invoke.mockResolvedValueOnce({ ok: true, result: null })
+  }
   await methodAt(api, path)(...args)
   const [channel, ...forwardedArgs] = electronMocks.invoke.mock.calls.at(-1) ?? []
   return { channel: String(channel), args: forwardedArgs }


### PR DESCRIPTION
## Problem

An expected Session revision conflict still rejects the Electron `sessions:save-session` handler before renderer conflict recovery can run. The universal IPC diagnostic boundary and Electron therefore log a recoverable stale-save race as an IPC handler failure, as seen after permission and artifact calls (`expected 3, actual 4`, then `expected 24, actual 25`).

The existing renderer reload/rebase/retry logic preserves data, but the first rejected IPC request produces misleading error diagnostics during otherwise successful turns.

## Proposed change

- Encode Electron Session-save success and revision conflicts as `ApplicationCommandOutcome` values at the Main IPC boundary.
- Unwrap that outcome in preload so the public renderer API retains its existing behavior: success resolves to the durable Session and a revision conflict rejects with `code: session-revision-conflict` for the existing recovery path.
- Continue to reject migration, storage, validation, and unknown failures normally.
- Add regression coverage at both sides of the Electron boundary, including a red-capable test that proves a revision conflict no longer rejects the Main IPC handler.

## Scope and non-goals

- No weakening of whole-Session revision checks, no last-write-wins behavior, and no change to three-way rebase rules.
- No ACP protocol, permission, elicitation, model, launcher, or framework-adapter changes. Claude Code, OpenCode, `codex-response`, and `codex-bridge` reach the same shared renderer persistence boundary; provider-specific paths are excluded from additional local coverage because the changed behavior occurs after ACP event projection.
- No renderer-facing method or event was added, removed, or renamed; the public `window.api.sessions.saveSession` contract is unchanged.
- No Web or Task transport changes.

## Compatibility and persistence impact

- Historical compatibility: none required. Existing Session JSON remains unchanged.
- New state or enum values: none.
- Persistence: the same durable Session save and revision comparison run unchanged. Only the Electron Main-to-preload transport representation of success/conflict changes; no schema, migration, file, field, version, or database change is introduced.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Recoverable revision conflict does not reject/log as an Electron IPC handler failure -> `npx vitest run src/main/session-persistence/ipc.test.ts src/preload/index.test.ts` -> 99 passed.
- Preload restores the existing renderer conflict rejection semantics -> same command -> passed.
- Existing renderer reload/rebase/retry behavior remains intact -> `npx vitest run src/main/session-persistence/ipc.test.ts src/preload/index.test.ts src/renderer/src/lib/session-persistence/session-persistence.test.ts` -> 139 passed.
- Electron/Web Session-save argument characterization models the new success outcome while preserving request parity -> `npx vitest run src/renderer/web/renderer-argument-shape-characterization.test.ts` -> 7 passed.
- Session persistence owner, contract, and representative consumer behavior -> `npm run test:module -- session_persistence` -> 315 passed.
- Main/preload types -> `npm run typecheck:node` -> passed.
- Renderer-facing preload types -> `npm run typecheck:web` -> passed.
- Source lint and formatting -> `npm run lint` -> passed.
- Patch whitespace -> `git diff --check` -> passed.

Local full `npm test` was intentionally not run per maintainer direction. PR CI is the authority for complete portable and platform coverage.

PR CI -> all required checks passed after the final commit, including Module tests and coverage, Static checks, Windows core/E2E, macOS build/E2E, PR Gate, CodeQL, and Codex review.

Uncovered local risk: the exact Electron console formatting is owned by Electron and is not asserted end-to-end; the regression test instead proves the handler promise resolves for the recoverable conflict, removing the condition that causes Electron's rejection log.

## Review focus

Please verify the Main/preload authority boundary: only `session-revision-conflict` becomes a resolved transport outcome, preload restores the existing renderer rejection, and all other persistence errors still reject at the IPC boundary.
