### PR TITLE
fix(notebook): avoid non-ASCII micromamba package caches

### DIFF
--- a/src/main/notebook/micromamba-cache.ts
+++ b/src/main/notebook/micromamba-cache.ts
@@ -333,6 +333,9 @@ const defaultPrepare = (
 const fitsBudget = (cacheRoot: string, maxCacheRelativePath: number): boolean =>
   cacheRoot.length + maxCacheRelativePath <= WINDOWS_MAX_USABLE_PATH
 
+const isAsciiPath = (path: string): boolean =>
+  Array.from(path).every((character) => character.charCodeAt(0) <= 0x7f)
+
 const BASE32_ALPHABET = '0123456789abcdefghjkmnpqrstvwxyz'
 
 const compactCacheHash = (digest: Buffer): string => {
@@ -421,6 +424,12 @@ export const selectMicromambaCache = (
   const rejections: string[] = []
 
   for (const candidate of candidates) {
+    if (!isAsciiPath(candidate.path)) {
+      rejections.push(
+        `${candidate.path}: contains non-ASCII characters unsupported by micromamba package extraction on Windows`
+      )
+      continue
+    }
     if (!fitsBudget(candidate.path, maxCacheRelativePath)) {
       const excess = candidate.path.length + maxCacheRelativePath - WINDOWS_MAX_USABLE_PATH
       rejections.push(`${candidate.path}: exceeds the Windows path budget by ${excess} characters`)
@@ -437,6 +446,12 @@ export const selectMicromambaCache = (
     if (!physical) {
       rejections.push(
         `${candidate.path}: ${preparation?.rejection ?? 'cache preparation returned no usable path'}`
+      )
+      continue
+    }
+    if (!isAsciiPath(physical)) {
+      rejections.push(
+        `${physical}: physical path contains non-ASCII characters unsupported by micromamba package extraction on Windows`
       )
       continue
     }

--- a/src/main/notebook/micromamba.test.ts
+++ b/src/main/notebook/micromamba.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, win32 } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
@@ -277,6 +277,22 @@ describe('caBundleEnv', () => {
 })
 
 describe('micromambaSpawnEnv', () => {
+  it('keeps the Windows package cache ASCII-only for a non-ASCII user profile', () => {
+    const env = micromambaSpawnEnv('C:\\Users\\甲乙\\OpenScience\\runtime', undefined, {
+      platform: 'win32',
+      env: {
+        USERNAME: '甲乙',
+        USERPROFILE: 'C:\\Users\\甲乙',
+        PUBLIC: 'C:\\Users\\Public'
+      },
+      canonicalize: (path) => win32.normalize(path),
+      prepare: (path) => (path.startsWith('C:\\osp') ? undefined : win32.normalize(path)),
+      verifyOwnership: () => true
+    })
+
+    expect(env.CONDA_PKGS_DIRS).toMatch(/^C:\\Users\\Public\\osp[0-9a-f]{10}$/)
+  })
+
   it('cleans inherited conda/mamba values before injecting the Windows app cache and CA vars', () => {
     const env = micromambaSpawnEnv('D:\\OpenScience\\runtime', '/ca.pem', {
       platform: 'win32',


### PR DESCRIPTION
## Problem

On Windows, micromamba 2.8.1 cannot extract a valid package archive when
`CONDA_PKGS_DIRS` contains non-ASCII characters. A one-package offline differential
reproduction succeeded with an ASCII cache and failed with a non-ASCII cache, producing
the same missing `info/index.json`, empty JSON parse, and incorrect-download errors from
the user report. A non-ASCII runtime root and environment prefix still succeeded when the
package cache was ASCII.

The app currently accepts a writable cache beneath a non-ASCII user profile before trying
the existing trusted Public fallback, so retries repeatedly corrupt freshly seeded cache
entries.

## Proposed change

- Reject non-ASCII Windows package-cache candidates before preparing them.
- Reject a candidate whose canonical physical path becomes non-ASCII.
- Fall through to the existing trusted, ACL-hardened ASCII candidate (for example,
  `C:\Users\Public\osp...`) while continuing to allow non-ASCII runtime and environment
  paths.
- Cover the subprocess-environment contract through `micromambaSpawnEnv` with a neutral
  non-ASCII profile fixture.

## Scope and non-goals

- No schema, data-model, state-enum, architecture, or user-interaction changes.
- No database or business-data persistence changes.
- Existing non-ASCII package caches are disposable derived data. This change ignores
  them rather than deleting them during upgrade; existing reset and root-migration cleanup
  paths remain responsible for eligible app-owned caches.
- This does not patch micromamba or change its pinned version.

## Acceptance criteria and validation

The regression test was first observed red: `micromambaSpawnEnv` returned a package cache
under the non-ASCII profile instead of the trusted Public fallback.

Checks below ran after the final material edit:

- Windows cache selection and subprocess environment -> targeted six-file notebook test
  set -> 234 tests passed.
- Node main-process types -> `npm run typecheck:node` -> passed.
- Lint for changed source and tests -> `npm run lint` -> passed.

The complete `npm test` suite was intentionally not run locally; exact-head PR CI is the
authority for complete portable and Windows lanes.

## Review focus

- Whether rejecting both lexical and canonical physical non-ASCII cache paths fully guards
  the value exported as `CONDA_PKGS_DIRS`.
- Whether retaining old derived caches for existing cleanup flows is preferable to adding
  upgrade-time destructive cleanup.
- CI coverage remains the independent verification step; a real non-ASCII Windows account
  is not available in the standard hosted runner.
