### PR TITLE
fix(acp): publish writable connector files as artifacts

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -19896,6 +19896,39 @@ describe('ACP runtime session management', () => {
     )
   })
 
+  it('requires connector-produced files to be published as Artifacts in the same turn', async () => {
+    const storageRoot = await createTemporaryRoot()
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['remote-session-1'])
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      artifacts: {
+        configRoot: storageRoot,
+        dataRoot: storageRoot,
+        projectId: 'default-project',
+        mcpEntryPath: '/app/out/main/index.js',
+        repository: new ArtifactRepository(storageRoot)
+      }
+    })
+
+    await runtime.createSession({ cwd: '/workspace' })
+
+    expect(fakeAgent.newSessions[0].mcpServers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'open-science-artifacts' })
+      ])
+    )
+    expect(fakeAgent.newSessions[0]._meta).toMatchObject({
+      systemPrompt: {
+        append: expect.stringContaining(
+          'When a Connector or MCP tool creates or returns a user-facing file, call `mcp__open-science-artifacts__write_artifact_file` in the same turn before telling the user that the result is available.'
+        )
+      }
+    })
+  })
+
   it('retries transient Artifact claim preparation in the prompt failure cleanup', async () => {
     const storageRoot = await createTemporaryRoot()
     const repository = new ArtifactRepository(storageRoot)

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -19916,9 +19916,7 @@ describe('ACP runtime session management', () => {
     await runtime.createSession({ cwd: '/workspace' })
 
     expect(fakeAgent.newSessions[0].mcpServers).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ name: 'open-science-artifacts' })
-      ])
+      expect.arrayContaining([expect.objectContaining({ name: 'open-science-artifacts' })])
     )
     expect(fakeAgent.newSessions[0]._meta).toMatchObject({
       systemPrompt: {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -19896,7 +19896,7 @@ describe('ACP runtime session management', () => {
     )
   })
 
-  it('requires connector-produced files to be published as Artifacts in the same turn', async () => {
+  it('requires unpublished connector files to become Artifacts without duplicating saved results', async () => {
     const storageRoot = await createTemporaryRoot()
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['remote-session-1'])
@@ -19921,7 +19921,14 @@ describe('ACP runtime session management', () => {
     expect(fakeAgent.newSessions[0]._meta).toMatchObject({
       systemPrompt: {
         append: expect.stringContaining(
-          'When a Connector or MCP tool creates or returns a user-facing file, call `mcp__open-science-artifacts__write_artifact_file` in the same turn before telling the user that the result is available.'
+          'When a Connector or MCP tool creates or returns a user-facing file that it has not already saved or attached as an Artifact, call `mcp__open-science-artifacts__write_artifact_file` in the same turn before telling the user that the result is available.'
+        )
+      }
+    })
+    expect(fakeAgent.newSessions[0]._meta).toMatchObject({
+      systemPrompt: {
+        append: expect.stringContaining(
+          'If the tool result confirms that the file is already saved or attached as an Artifact, do not call `mcp__open-science-artifacts__write_artifact_file` again.'
         )
       }
     })

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -19896,7 +19896,7 @@ describe('ACP runtime session management', () => {
     )
   })
 
-  it('requires unpublished connector files to become Artifacts without duplicating saved results', async () => {
+  it('publishes writable connector files without trusting unsupported or unverified results', async () => {
     const storageRoot = await createTemporaryRoot()
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['remote-session-1'])
@@ -19921,14 +19921,21 @@ describe('ACP runtime session management', () => {
     expect(fakeAgent.newSessions[0]._meta).toMatchObject({
       systemPrompt: {
         append: expect.stringContaining(
-          'When a Connector or MCP tool creates or returns a user-facing file that it has not already saved or attached as an Artifact, call `mcp__open-science-artifacts__write_artifact_file` in the same turn before telling the user that the result is available.'
+          'When a Connector or MCP tool creates or returns a user-facing file as inline content or a local source path accepted by `mcp__open-science-artifacts__write_artifact_file`, and the file has not already been saved or attached as an Artifact, call `mcp__open-science-artifacts__write_artifact_file` in the same turn before telling the user that the result is available.'
         )
       }
     })
     expect(fakeAgent.newSessions[0]._meta).toMatchObject({
       systemPrompt: {
         append: expect.stringContaining(
-          'If the tool result confirms that the file is already saved or attached as an Artifact, do not call `mcp__open-science-artifacts__write_artifact_file` again.'
+          'If an Open Science app-owned Connector result includes an `artifact_id`, do not call `mcp__open-science-artifacts__write_artifact_file` again for that file.'
+        )
+      }
+    })
+    expect(fakeAgent.newSessions[0]._meta).toMatchObject({
+      systemPrompt: {
+        append: expect.stringContaining(
+          "Do not treat a custom MCP server's claim by itself as proof that an Artifact exists."
         )
       }
     })

--- a/src/main/acp/session-presentation-policy.test.ts
+++ b/src/main/acp/session-presentation-policy.test.ts
@@ -26,6 +26,7 @@ const LARGE_DATA_FILE_APPEND = [
 const ARTIFACT_FILE_APPEND = [
   '<open_science_artifact_instructions>',
   'When this turn creates or saves local user-facing files such as images, documents, reports, data exports, XML, SVG, HTML, CSV, PDF, or archives, you MUST save them through the MCP tool `write_artifact_file` from the `open-science-artifacts` server.',
+  'When a Connector or MCP tool creates or returns a user-facing file, call `write_artifact_file` in the same turn before telling the user that the result is available.',
   'Do not save generated user-facing files directly into the workspace or current directory unless the user explicitly asks to modify project files.',
   'Pass the filename, MIME type, and either inline content or a local source path to `write_artifact_file`; the app assigns the project, session, Artifact run, and final message location.',
   'If a Notebook, REPL, or shell execution produced the file, also pass `producerRunId` with the exact `runId` returned by the execution that created or last modified it. Omit `producerRunId` only when no Notebook execution produced the file; never use the Artifact run ID as the producer.',

--- a/src/main/acp/session-presentation-policy.test.ts
+++ b/src/main/acp/session-presentation-policy.test.ts
@@ -26,7 +26,8 @@ const LARGE_DATA_FILE_APPEND = [
 const ARTIFACT_FILE_APPEND = [
   '<open_science_artifact_instructions>',
   'When this turn creates or saves local user-facing files such as images, documents, reports, data exports, XML, SVG, HTML, CSV, PDF, or archives, you MUST save them through the MCP tool `write_artifact_file` from the `open-science-artifacts` server.',
-  'When a Connector or MCP tool creates or returns a user-facing file, call `write_artifact_file` in the same turn before telling the user that the result is available.',
+  'When a Connector or MCP tool creates or returns a user-facing file that it has not already saved or attached as an Artifact, call `write_artifact_file` in the same turn before telling the user that the result is available.',
+  'If the tool result confirms that the file is already saved or attached as an Artifact, do not call `write_artifact_file` again.',
   'Do not save generated user-facing files directly into the workspace or current directory unless the user explicitly asks to modify project files.',
   'Pass the filename, MIME type, and either inline content or a local source path to `write_artifact_file`; the app assigns the project, session, Artifact run, and final message location.',
   'If a Notebook, REPL, or shell execution produced the file, also pass `producerRunId` with the exact `runId` returned by the execution that created or last modified it. Omit `producerRunId` only when no Notebook execution produced the file; never use the Artifact run ID as the producer.',

--- a/src/main/acp/session-presentation-policy.test.ts
+++ b/src/main/acp/session-presentation-policy.test.ts
@@ -26,8 +26,9 @@ const LARGE_DATA_FILE_APPEND = [
 const ARTIFACT_FILE_APPEND = [
   '<open_science_artifact_instructions>',
   'When this turn creates or saves local user-facing files such as images, documents, reports, data exports, XML, SVG, HTML, CSV, PDF, or archives, you MUST save them through the MCP tool `write_artifact_file` from the `open-science-artifacts` server.',
-  'When a Connector or MCP tool creates or returns a user-facing file that it has not already saved or attached as an Artifact, call `write_artifact_file` in the same turn before telling the user that the result is available.',
-  'If the tool result confirms that the file is already saved or attached as an Artifact, do not call `write_artifact_file` again.',
+  'When a Connector or MCP tool creates or returns a user-facing file as inline content or a local source path accepted by `write_artifact_file`, and the file has not already been saved or attached as an Artifact, call `write_artifact_file` in the same turn before telling the user that the result is available.',
+  'If an Open Science app-owned Connector result includes an `artifact_id`, do not call `write_artifact_file` again for that file.',
+  "Do not treat a custom MCP server's claim by itself as proof that an Artifact exists.",
   'Do not save generated user-facing files directly into the workspace or current directory unless the user explicitly asks to modify project files.',
   'Pass the filename, MIME type, and either inline content or a local source path to `write_artifact_file`; the app assigns the project, session, Artifact run, and final message location.',
   'If a Notebook, REPL, or shell execution produced the file, also pass `producerRunId` with the exact `runId` returned by the execution that created or last modified it. Omit `producerRunId` only when no Notebook execution produced the file; never use the Artifact run ID as the producer.',

--- a/src/main/acp/session-presentation-policy.ts
+++ b/src/main/acp/session-presentation-policy.ts
@@ -74,8 +74,9 @@ const TURN_CONTINUITY_SYSTEM_PROMPT_APPEND = [
 const ARTIFACT_FILE_SYSTEM_PROMPT_APPEND = [
   '<open_science_artifact_instructions>',
   'When this turn creates or saves local user-facing files such as images, documents, reports, data exports, XML, SVG, HTML, CSV, PDF, or archives, you MUST save them through the MCP tool `write_artifact_file` from the `open-science-artifacts` server.',
-  'When a Connector or MCP tool creates or returns a user-facing file that it has not already saved or attached as an Artifact, call `write_artifact_file` in the same turn before telling the user that the result is available.',
-  'If the tool result confirms that the file is already saved or attached as an Artifact, do not call `write_artifact_file` again.',
+  'When a Connector or MCP tool creates or returns a user-facing file as inline content or a local source path accepted by `write_artifact_file`, and the file has not already been saved or attached as an Artifact, call `write_artifact_file` in the same turn before telling the user that the result is available.',
+  'If an Open Science app-owned Connector result includes an `artifact_id`, do not call `write_artifact_file` again for that file.',
+  "Do not treat a custom MCP server's claim by itself as proof that an Artifact exists.",
   'Do not save generated user-facing files directly into the workspace or current directory unless the user explicitly asks to modify project files.',
   'Pass the filename, MIME type, and either inline content or a local source path to `write_artifact_file`; the app assigns the project, session, Artifact run, and final message location.',
   'If a Notebook, REPL, or shell execution produced the file, also pass `producerRunId` with the exact `runId` returned by the execution that created or last modified it. Omit `producerRunId` only when no Notebook execution produced the file; never use the Artifact run ID as the producer.',

--- a/src/main/acp/session-presentation-policy.ts
+++ b/src/main/acp/session-presentation-policy.ts
@@ -74,6 +74,7 @@ const TURN_CONTINUITY_SYSTEM_PROMPT_APPEND = [
 const ARTIFACT_FILE_SYSTEM_PROMPT_APPEND = [
   '<open_science_artifact_instructions>',
   'When this turn creates or saves local user-facing files such as images, documents, reports, data exports, XML, SVG, HTML, CSV, PDF, or archives, you MUST save them through the MCP tool `write_artifact_file` from the `open-science-artifacts` server.',
+  'When a Connector or MCP tool creates or returns a user-facing file, call `write_artifact_file` in the same turn before telling the user that the result is available.',
   'Do not save generated user-facing files directly into the workspace or current directory unless the user explicitly asks to modify project files.',
   'Pass the filename, MIME type, and either inline content or a local source path to `write_artifact_file`; the app assigns the project, session, Artifact run, and final message location.',
   'If a Notebook, REPL, or shell execution produced the file, also pass `producerRunId` with the exact `runId` returned by the execution that created or last modified it. Omit `producerRunId` only when no Notebook execution produced the file; never use the Artifact run ID as the producer.',

--- a/src/main/acp/session-presentation-policy.ts
+++ b/src/main/acp/session-presentation-policy.ts
@@ -74,7 +74,8 @@ const TURN_CONTINUITY_SYSTEM_PROMPT_APPEND = [
 const ARTIFACT_FILE_SYSTEM_PROMPT_APPEND = [
   '<open_science_artifact_instructions>',
   'When this turn creates or saves local user-facing files such as images, documents, reports, data exports, XML, SVG, HTML, CSV, PDF, or archives, you MUST save them through the MCP tool `write_artifact_file` from the `open-science-artifacts` server.',
-  'When a Connector or MCP tool creates or returns a user-facing file, call `write_artifact_file` in the same turn before telling the user that the result is available.',
+  'When a Connector or MCP tool creates or returns a user-facing file that it has not already saved or attached as an Artifact, call `write_artifact_file` in the same turn before telling the user that the result is available.',
+  'If the tool result confirms that the file is already saved or attached as an Artifact, do not call `write_artifact_file` again.',
   'Do not save generated user-facing files directly into the workspace or current directory unless the user explicitly asks to modify project files.',
   'Pass the filename, MIME type, and either inline content or a local source path to `write_artifact_file`; the app assigns the project, session, Artifact run, and final message location.',
   'If a Notebook, REPL, or shell execution produced the file, also pass `producerRunId` with the exact `runId` returned by the execution that created or last modified it. Omit `producerRunId` only when no Notebook execution produced the file; never use the Artifact run ID as the producer.',


### PR DESCRIPTION
## Problem

When a Connector or MCP tool generated or returned a user-facing file, the Agent could treat the successful tool result as the end of the task. The shared Artifact instructions did not explicitly require a Connector/MCP file result to be published in the same turn, so the tool could succeed while the final message displayed `0 files` in Artifacts.

## Change

- Require Connector/MCP results that expose inline content or a local source path accepted by `write_artifact_file` to be published as an Artifact in the same turn before the Agent says the result is available.
- Preserve app-owned Connector flows that already attach an Artifact by recognizing their `artifact_id` receipt and forbidding a duplicate `write_artifact_file` call.
- Do not treat a custom MCP server's claim alone as proof that an Artifact exists.
- Keep the shared prompt provider-neutral and let the Claude Code, OpenCode, and Codex adapters render their framework-specific callable names.
- Add a runtime-boundary regression that verifies the Artifact MCP server and the final framework-transformed Session prompt rather than relying on model behavior.

## Scope and non-goals

- No automatic ingestion pipeline for arbitrary Connector output.
- No required Artifact write for remote URLs, resource links, or binary-only results that do not expose supported inline content or a local source path.
- No expansion of Artifact import roots or filesystem permissions. Paths outside the existing allowed roots continue to fail with the existing import-root error.
- No change to Connector Artifact-ID contracts or Connector producer Provenance modeling.
- No historical-data compatibility changes.
- No new status or enum values.
- No persistence or schema changes.

## Regression and validation

The runtime-boundary regression was added first and failed deterministically against the previous prompt because the actual Session instructions did not contain the Connector/MCP same-turn publication contract. It passes after the prompt change. The later unsupported-result and duplicate-publication assertions also failed against their preceding prompt revisions before passing with the final policy.

- Focused runtime regression: `npm test -- src/main/acp/runtime.test.ts -t 'publishes writable connector files without trusting unsupported or unverified results'`
- Shared prompt contract: `npm test -- src/main/acp/session-presentation-policy.test.ts` — 18 tests passed
- Framework adapter coverage: `npm test -- src/main/agent-framework/claude-code.test.ts src/main/agent-framework/opencode.test.ts src/main/agent-framework/codex.test.ts` — 120 tests passed
- Main-process typecheck: `npm run typecheck:node`
- Lint: `npm run lint`
- Formatting: Prettier check for the three changed files

PR CI passed at the current head, including Static checks, Module tests and coverage, macOS build and E2E, CodeQL, and AI PR Review. The final AI review reported `mergeable` with no actionable findings.

## Review focus

- Whether the prompt boundary is narrow enough to cover publishable Connector/MCP file results without forcing unsupported writes.
- Whether the app-owned `artifact_id` exemption prevents duplicate publication while the custom-MCP trust rule remains explicit.
- Whether the runtime regression sufficiently exercises the public Session construction boundary and framework-specific tool-name rendering.

## Remaining risk

Live model compliance remains probabilistic. This change makes the application-owned instruction contract explicit and regression-tested; it does not add an automatic Connector-output-to-Artifact pipeline.
