### PR TITLE
feat(cli): add application update command

### DIFF
--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -61,6 +61,43 @@ command fails without signalling the PID recorded in `web-service.json`; a stale
 reused by an unrelated process. The state file is retained for diagnosis and can be replaced by a
 later `open-science start`.
 
+## Application updates
+
+Check, download, and apply an Open Science application update without opening the browser or desktop
+window:
+
+```bash
+open-science update
+open-science update --json
+```
+
+The command updates the installed Open Science application, not the npm package. It reuses the
+application's release feed, artifact selection, checksum verification, and platform installer. If
+Open Science is not running, it starts the local headless service and leaves it available for later
+CLI commands. Use `open-science stop` when it is no longer needed.
+
+In-place installation never interrupts active root-agent, subagent, Notebook, or Reviewer work. Stop
+the reported work and run the command again. Platforms that require a visible installer download it
+without a save dialog to the application's writable data directory, then print the full path and
+required next step; the CLI does not open the installer.
+
+With `--json`, `outcome` is `up-to-date`, `install-started`, `manual-action-required`, or `blocked`.
+`install-started` means the platform updater accepted the handoff; because the running application
+exits during installation, the CLI cannot verify the final installed version in that invocation.
+Common fields are `current` and, when known, `latest`. Manual outcomes may add `installerPath` and
+`nextAction`; blocked outcomes add `blockedBy`.
+
+The CLI requires the running application to advertise the `update-cli-v1` RPC capability. If an older
+installation only advertises the legacy update commands, or does not advertise structured headless
+update behavior, it returns `manual-action-required` instead of guessing. Install the latest release from
+[the Open Science download page](https://www.aipoch.com/open-science), then run the command again.
+Because the CLI is bundled with the installed application, installations predating this command need
+that one-time manual update before `open-science update` is available.
+
+On a rootless Linux host where Chromium sandboxing is unavailable, use
+`open-science update --no-sandbox`. This reuses the same explicit, security-reducing startup fallback
+as `open-science start --no-sandbox`; prefer the Debian package or a sandbox-capable host.
+
 ## Codex subscription sign-in
 
 Sign the Open Science Codex profile in from a server terminal without starting the daemon or opening
@@ -92,15 +129,16 @@ daemon logs.
 
 ### Linux AppImage sandbox fallback
 
-`open-science start` keeps Chromium sandboxing enabled by default. On some Linux hosts, an AppImage
-mounted with `nosuid` cannot use Chromium's SUID sandbox helper; Ubuntu may also restrict
-unprivileged user namespaces. In that case the command fails promptly with guidance instead of
-waiting for the service timeout.
+`open-science start` and `open-science update` keep Chromium sandboxing enabled by default. On some
+Linux hosts, an AppImage mounted with `nosuid` cannot use Chromium's SUID sandbox helper; Ubuntu may
+also restrict unprivileged user namespaces. In that case the command fails promptly with guidance
+instead of waiting for the service timeout.
 
 If the host cannot support sandboxed startup, an explicit rootless fallback is available:
 
 ```bash
 open-science start --no-sandbox --no-open
+open-science update --no-sandbox
 ```
 
 `--no-sandbox` disables Chromium's process sandbox and reduces security. Use it only when necessary;
@@ -294,6 +332,8 @@ Exit codes form part of the automation contract:
 | `2`       | CLI usage was invalid.                                                    |
 | `3`       | The local daemon was unavailable.                                         |
 | `4`       | A requested project, run, session, artifact, or Specialist was not found. |
+| `5`       | Active research safely blocked an application update.                     |
+| `6`       | The application update requires a manual installation step.               |
 
 Timeouts and `session_busy` conflicts use exit code `1` and retain their distinct `timeout` and
 `session_busy` error codes in structured output.

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -19,6 +19,10 @@ import { locateApp } from './locate-app.mjs'
 const DEFAULT_PORT = 44100
 const START_TIMEOUT_MS = 30_000
 const STOP_TIMEOUT_MS = 15_000
+const UPDATE_REQUEST_TIMEOUT_MS = 60 * 60 * 1_000
+const UPDATE_CLI_RPC_CAPABILITY = 'update-cli-v1'
+const UPDATE_BLOCKED_EXIT_CODE = 5
+const UPDATE_MANUAL_ACTION_EXIT_CODE = 6
 const MAX_DOWNLOAD_SYMLINK_HOPS = 40
 
 const usage = `Usage: open-science <command> [options]
@@ -28,6 +32,7 @@ Commands:
   stop        Gracefully stop the backend
   status      Show backend status
   url         Print the authenticated web URL
+  update      Check, download, and apply an application update
   codex login [--force]
   project list
   project create <name> [--description <text>] [--agent-context <text> | --agent-context-file <path>]
@@ -72,7 +77,7 @@ Options:
   --output <path>        Artifact download destination
   --yes                  Confirm the offline rollback conversion
   --no-open              Do not open the browser after start
-  --no-sandbox           Disable Chromium's process sandbox (security risk; start only)
+  --no-sandbox           Disable Chromium's process sandbox (security risk; start/update only)
   --force                Sign in again even when Codex credentials already exist
   --json                 Emit one machine-readable result
   -h, --help             Show this help`
@@ -216,8 +221,8 @@ export const parseCliArgs = (argv) => {
   if (options.cancelOnTimeout && options.timeoutMs === undefined) {
     throw new CliUsageError('--cancel-on-timeout requires --timeout-ms.')
   }
-  if (options.noSandbox && command !== 'start') {
-    throw new CliUsageError('--no-sandbox requires start.')
+  if (options.noSandbox && command !== 'start' && command !== 'update') {
+    throw new CliUsageError('--no-sandbox requires start or update.')
   }
   if (options.yes && command !== 'rollback-to-0.7.3') {
     throw new CliUsageError('--yes requires rollback-to-0.7.3.')
@@ -227,6 +232,9 @@ export const parseCliArgs = (argv) => {
   }
   if (options.force && (command !== 'codex' || subcommand !== 'login')) {
     throw new CliUsageError('--force requires codex login.')
+  }
+  if (command === 'update' && positionals.length > 0) {
+    throw new CliUsageError('update accepts no arguments.')
   }
   const isProjectCreate = command === 'project' && subcommand === 'create'
   const isProjectUpdate = command === 'project' && subcommand === 'update'
@@ -464,7 +472,7 @@ export const formatStartupFailure = (outcome, logTail, options) => {
       'Open Science could not start because Chromium sandboxing is unavailable on this host.',
       logTail,
       'This can occur when an AppImage mount cannot provide the SUID permissions required by Chromium; some Linux hosts also restrict unprivileged user namespaces.',
-      'For an explicit rootless fallback, run "open-science start --no-sandbox".',
+      'For an explicit rootless fallback, run "open-science start --no-sandbox" or retry an update with "open-science update --no-sandbox".',
       "Warning: --no-sandbox disables Chromium's process sandbox and reduces security. Prefer the Debian package or a host configuration that supports sandboxed startup."
     ]
       .filter(Boolean)
@@ -485,7 +493,7 @@ const startCommand = async (options, deps = DEFAULT_DEPS) => {
     deps.log(`Open Science is already running (PID ${existing.pid}).`)
     if (options.open) openBrowser(url)
     else deps.log('Run "open-science url" to print a browser login URL.')
-    return
+    return { state: existing, started: false }
   }
 
   const app = await locateApp({ appPath: options.appPath })
@@ -539,6 +547,7 @@ const startCommand = async (options, deps = DEFAULT_DEPS) => {
   deps.log(`Open Science started (PID ${state.pid}).`)
   if (options.open) openBrowser(url)
   else deps.log('Run "open-science url" to print a browser login URL.')
+  return { state, started: true }
 }
 
 const findCurrentState = async (options, deps = DEFAULT_DEPS) => {
@@ -731,6 +740,223 @@ export const rollbackCommand = async (options, dependencies = {}) => {
   deps.log(`Preserved newer Data Root: ${manifest.preservedDataRoot}`)
   deps.log(`Converted Sessions: ${manifest.sessionsConverted}`)
   deps.log(`You can now install and start Open Science ${manifest.targetVersion}.`)
+}
+
+const UPDATE_DOWNLOAD_PAGE = 'https://www.aipoch.com/open-science'
+const UPDATE_BOOTSTRAPS = new WeakMap()
+
+const updateResult = (status, outcome, extras = {}) => ({
+  outcome,
+  current: status.current,
+  ...(status.latest ? { latest: status.latest } : {}),
+  ...extras
+})
+
+const updateBootstrap = async (client) => {
+  let bootstrap = UPDATE_BOOTSTRAPS.get(client)
+  if (!bootstrap) {
+    bootstrap = await client.health()
+    UPDATE_BOOTSTRAPS.set(client, bootstrap)
+  }
+  return bootstrap
+}
+
+const supportsApplicationCommand = async (client, channel) => {
+  const bootstrap = await updateBootstrap(client)
+  return Array.isArray(bootstrap.rpcChannels) && bootstrap.rpcChannels.includes(channel)
+}
+
+const invokeApplicationCommand = async (client, channel, args = []) => {
+  const bootstrap = await updateBootstrap(client)
+  if (!Array.isArray(bootstrap.rpcChannels) || !bootstrap.rpcChannels.includes(channel)) {
+    throw new OpenScienceApiError(`Open Science does not support ${channel}.`, {
+      code: 'command_unavailable'
+    })
+  }
+  if (!Number.isInteger(bootstrap.rpcProtocolVersion)) {
+    throw new OpenScienceApiError('Open Science does not expose a compatible RPC protocol.', {
+      code: 'command_unavailable'
+    })
+  }
+
+  const response = await client.fetch(`${client.baseUrl}/rpc/${encodeURIComponent(channel)}`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${client.token}`,
+      accept: 'application/json',
+      'content-type': 'application/json',
+      'x-open-science-client': 'open-science-cli'
+    },
+    body: JSON.stringify({ protocolVersion: bootstrap.rpcProtocolVersion, args }),
+    signal: AbortSignal.timeout(UPDATE_REQUEST_TIMEOUT_MS)
+  })
+  let payload
+  try {
+    payload = await response.json()
+  } catch {
+    throw new OpenScienceApiError('Open Science RPC returned an invalid response.', {
+      code: 'invalid_response',
+      status: response.status
+    })
+  }
+  if (
+    !response.ok ||
+    payload?.protocolVersion !== bootstrap.rpcProtocolVersion ||
+    typeof payload?.ok !== 'boolean'
+  ) {
+    throw new OpenScienceApiError(
+      payload?.error?.message ?? 'Open Science RPC returned an invalid response.',
+      { code: payload?.error?.code ?? 'invalid_response', status: response.status }
+    )
+  }
+  if (!payload.ok) {
+    throw new OpenScienceApiError(payload.error?.message ?? 'Open Science command failed.', {
+      code: payload.error?.code ?? 'command_failed',
+      status: response.status
+    })
+  }
+  return payload.result
+}
+
+const downloadWithProgress = async (client, options, deps) => {
+  let settled = false
+  const download = deps
+    .invokeCommand(client, 'update:download', [{ nonInteractive: true }])
+    .finally(() => {
+      settled = true
+    })
+  // Observe rejection immediately while the polling loop is active; the final await below still
+  // preserves it for the caller.
+  void download.catch(() => undefined)
+
+  let lastPercent
+  while (!settled) {
+    await deps.sleep(500)
+    if (settled || options.json) continue
+    const status = await deps.invokeCommand(client, 'update:get-status')
+    if (status.state !== 'downloading' || !Number.isFinite(status.progress)) continue
+    const percent = Math.max(0, Math.min(100, Math.round(status.progress)))
+    if (percent === lastPercent) continue
+    lastPercent = percent
+    deps.log(`Downloading update: ${percent}%`)
+  }
+  return await download
+}
+
+export const updateCommand = async (options, dependencies = {}) => {
+  const quietLog = options.json ? () => {} : (...args) => console.log(...args)
+  const deps = {
+    ensureService: (startOptions) => startCommand(startOptions, { ...DEFAULT_DEPS, log: quietLog }),
+    connect: (connectOptions) => connectToOpenScience(connectOptions),
+    sleep,
+    getBootstrap: updateBootstrap,
+    supportsCommand: supportsApplicationCommand,
+    invokeCommand: invokeApplicationCommand,
+    log: (...args) => console.log(...args),
+    setExitCode: (code) => {
+      process.exitCode = code
+    },
+    ...dependencies
+  }
+  await deps.ensureService({ ...options, open: false })
+  const client = await deps.connect({ configRoot: options.configRoot })
+  let result
+
+  const supports = (channel) => deps.supportsCommand(client, channel)
+  const bootstrap = await deps.getBootstrap(client)
+  if (!bootstrap.rpcCapabilities?.includes(UPDATE_CLI_RPC_CAPABILITY)) {
+    const status = { current: bootstrap.appVersion ?? 'unknown' }
+    result = updateResult(status, 'manual-action-required', {
+      nextAction: `Install the latest Open Science release from ${UPDATE_DOWNLOAD_PAGE}, then run this command again.`
+    })
+  } else if (!(await supports('update:check'))) {
+    throw new Error(
+      'The running Open Science version advertises update CLI support without update:check.'
+    )
+  } else {
+    if (!options.json) deps.log('Checking for Open Science updates...')
+    let status = await deps.invokeCommand(client, 'update:check')
+    if (status.state === 'error') throw new Error(status.error ?? 'Update check failed.')
+
+    if (status.state === 'up-to-date') {
+      result = updateResult(status, 'up-to-date')
+    } else if (status.state !== 'available' && status.state !== 'ready') {
+      throw new Error(`Update check ended in an unexpected state: ${status.state}`)
+    } else {
+      if (status.state === 'available') {
+        if (!(await supports('update:download'))) {
+          result = updateResult(status, 'manual-action-required', {
+            nextAction: `Install Open Science ${status.latest ?? 'from the latest release'} manually from ${UPDATE_DOWNLOAD_PAGE}.`
+          })
+        } else {
+          if (!options.json) {
+            deps.log(`Open Science ${status.latest ?? 'update'} is available. Downloading...`)
+          }
+          status = await downloadWithProgress(client, options, deps)
+          if (status.state === 'error') throw new Error(status.error ?? 'Update download failed.')
+          if (status.state !== 'ready') {
+            result = updateResult(status, 'manual-action-required', {
+              nextAction: `No compatible update artifact is available. Install it manually from ${UPDATE_DOWNLOAD_PAGE}.`
+            })
+          }
+        }
+      }
+
+      if (!result && status.state === 'ready') {
+        if (status.applyKind !== 'restart') {
+          const installerPath = status.localPath
+          result = updateResult(status, 'manual-action-required', {
+            ...(installerPath ? { installerPath } : {}),
+            nextAction: installerPath
+              ? `Run the installer at ${installerPath}, then start Open Science again.`
+              : `Install Open Science ${status.latest ?? 'from the latest release'} manually from ${UPDATE_DOWNLOAD_PAGE}.`
+          })
+        } else if (!(await supports('update:apply'))) {
+          result = updateResult(status, 'manual-action-required', {
+            nextAction: `Install Open Science ${status.latest ?? 'from the latest release'} manually from ${UPDATE_DOWNLOAD_PAGE}.`
+          })
+        } else {
+          if (!options.json) deps.log('Applying the update without opening the desktop app...')
+          status = await deps.invokeCommand(client, 'update:apply', [{ relaunch: false }])
+          if (status.blockedBy?.length) {
+            result = updateResult(status, 'blocked', { blockedBy: status.blockedBy })
+          } else if (status.state === 'error') {
+            throw new Error(status.error ?? 'Update apply failed.')
+          } else if (status.state === 'applying') {
+            result = updateResult(status, 'install-started')
+          } else {
+            throw new Error(`Update apply ended in an unexpected state: ${status.state}`)
+          }
+        }
+      }
+    }
+  }
+
+  deps.log(options.json ? JSON.stringify(result) : formatUpdateResult(result))
+  if (result.outcome === 'blocked') deps.setExitCode(UPDATE_BLOCKED_EXIT_CODE)
+  if (result.outcome === 'manual-action-required') {
+    deps.setExitCode(UPDATE_MANUAL_ACTION_EXIT_CODE)
+  }
+  return result
+}
+
+const formatUpdateResult = (result) => {
+  if (result.outcome === 'up-to-date') {
+    return `Open Science ${result.current} is up to date.`
+  }
+  if (result.outcome === 'install-started') {
+    return `Installation of Open Science ${result.latest ?? 'update'} was handed off to the platform updater. The desktop app will not be opened; verify the installed version after the updater exits.`
+  }
+  if (result.outcome === 'blocked') {
+    return `Update blocked by active research: ${result.blockedBy.join(', ')}.`
+  }
+  return [
+    `Open Science ${result.latest ?? result.current} requires a manual install.`,
+    result.installerPath ? `Installer: ${result.installerPath}` : undefined,
+    result.nextAction
+  ]
+    .filter(Boolean)
+    .join('\n')
 }
 
 const readPrompt = async (options, deps) => {
@@ -1069,7 +1295,7 @@ export const reportCliError = (error, argv = process.argv.slice(2), dependencies
   return exitCode
 }
 
-export const runCli = async (argv = process.argv.slice(2)) => {
+export const runCli = async (argv = process.argv.slice(2), dependencies = {}) => {
   const parsed = parseCliArgs(argv)
   const { command, options } = parsed
   if (options.help || !command || command === '-h' || command === '--help') {
@@ -1080,6 +1306,7 @@ export const runCli = async (argv = process.argv.slice(2)) => {
   else if (command === 'stop') await stopCommand(options)
   else if (command === 'status') await statusCommand(options)
   else if (command === 'url') await urlCommand(options)
+  else if (command === 'update') await updateCommand(options, dependencies.update)
   else if (command === 'codex' && parsed.subcommand === 'login') await codexLoginCommand(options)
   else if (command === 'rollback-to-0.7.3') await rollbackCommand(options)
   else if (TASK_COMMANDS.has(command)) await runTaskCommand(parsed)

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -20,7 +20,8 @@ import {
   reportCliError,
   rollbackCommand,
   runCli,
-  runTaskCommand
+  runTaskCommand,
+  updateCommand
 } from './cli.mjs'
 
 const listProjects = async (): Promise<Array<{ id: string; name: string }>> => [
@@ -213,6 +214,17 @@ describe('task CLI', () => {
       'codex login accepts no arguments.'
     )
     expect(() => parseCliArgs(['status', '--force'])).toThrow('--force requires codex login.')
+  })
+
+  it('parses application update output and rejects positional arguments', () => {
+    expect(parseCliArgs(['update', '--json', '--no-sandbox'])).toEqual({
+      command: 'update',
+      options: { open: true, json: true, noSandbox: true }
+    })
+    expect(() => parseCliArgs(['update', 'latest'])).toThrow('update accepts no arguments.')
+    expect(() => parseCliArgs(['status', '--no-sandbox'])).toThrow(
+      '--no-sandbox requires start or update.'
+    )
   })
 
   it('reads a prompt file, waits for completion, and emits one JSON result', async () => {
@@ -1249,6 +1261,370 @@ describe('task CLI', () => {
     ]) {
       await expect(runCli([command])).rejects.toThrow(`Unknown command: ${command}`)
     }
+  })
+
+  it('applies an in-place update without relaunching the desktop app', async () => {
+    const invokeCommand = vi.fn(async (_client, channel: string, args?: unknown[]) => {
+      if (channel === 'update:check') {
+        return {
+          state: 'ready',
+          current: '1.0.0',
+          latest: '1.1.0',
+          applyKind: 'restart'
+        }
+      }
+      if (channel === 'update:apply') {
+        expect(args).toEqual([{ relaunch: false }])
+        return {
+          state: 'applying',
+          current: '1.0.0',
+          latest: '1.1.0',
+          applyKind: 'restart'
+        }
+      }
+      throw new Error(`Unexpected command: ${channel}`)
+    })
+    const log = vi.fn()
+
+    await expect(
+      updateCommand(
+        { open: true, json: true },
+        {
+          ensureService: vi.fn().mockResolvedValue({ started: true }),
+          connect: vi.fn().mockResolvedValue({}),
+          getBootstrap: vi.fn().mockResolvedValue({
+            appVersion: '1.0.0',
+            rpcCapabilities: ['update-cli-v1']
+          }),
+          supportsCommand: vi.fn().mockResolvedValue(true),
+          invokeCommand,
+          log,
+          setExitCode: vi.fn()
+        }
+      )
+    ).resolves.toEqual({ outcome: 'install-started', current: '1.0.0', latest: '1.1.0' })
+
+    expect(JSON.parse(log.mock.calls[0][0])).toEqual({
+      outcome: 'install-started',
+      current: '1.0.0',
+      latest: '1.1.0'
+    })
+  })
+
+  it('uses the authenticated local Web RPC envelope for update commands', async () => {
+    const fetch = vi.fn(async (url: string) => {
+      const channel = decodeURIComponent(url.split('/rpc/')[1] ?? '')
+      const result =
+        channel === 'update:check'
+          ? {
+              state: 'ready',
+              current: '1.0.0',
+              latest: '1.1.0',
+              applyKind: 'restart'
+            }
+          : {
+              state: 'applying',
+              current: '1.0.0',
+              latest: '1.1.0',
+              applyKind: 'restart'
+            }
+      return new Response(JSON.stringify({ protocolVersion: 1, ok: true, result }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    })
+    const client = {
+      health: vi.fn().mockResolvedValue({
+        appVersion: '1.0.0',
+        rpcProtocolVersion: 1,
+        rpcCapabilities: ['update-cli-v1'],
+        rpcChannels: ['update:check', 'update:apply']
+      }),
+      baseUrl: 'http://127.0.0.1:44100',
+      token: 'local-token',
+      fetch
+    }
+
+    await updateCommand(
+      { open: true, json: true },
+      {
+        ensureService: vi.fn().mockResolvedValue({ started: false }),
+        connect: vi.fn().mockResolvedValue(client),
+        log: vi.fn(),
+        setExitCode: vi.fn()
+      }
+    )
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(fetch.mock.calls[0][0]).toBe('http://127.0.0.1:44100/rpc/update%3Acheck')
+    expect(fetch.mock.calls[1][1]).toMatchObject({
+      method: 'POST',
+      headers: expect.objectContaining({
+        authorization: 'Bearer local-token',
+        'x-open-science-client': 'open-science-cli'
+      }),
+      body: JSON.stringify({ protocolVersion: 1, args: [{ relaunch: false }] })
+    })
+  })
+
+  it('downloads a manual installer non-interactively and returns exit code 6', async () => {
+    const invokeCommand = vi.fn(async (_client, channel: string, args?: unknown[]) => {
+      if (channel === 'update:check') {
+        return {
+          state: 'available',
+          current: '1.0.0',
+          latest: '1.1.0',
+          applyKind: 'installer'
+        }
+      }
+      if (channel === 'update:download') {
+        expect(args).toEqual([{ nonInteractive: true }])
+        return {
+          state: 'ready',
+          current: '1.0.0',
+          latest: '1.1.0',
+          applyKind: 'installer',
+          localPath: 'C:\\Users\\test\\Downloads\\Open-Science.exe'
+        }
+      }
+      if (channel === 'storage:detect-active') return []
+      throw new Error(`Unexpected command: ${channel}`)
+    })
+    const setExitCode = vi.fn()
+
+    const result = await updateCommand(
+      { open: true, json: true },
+      {
+        ensureService: vi.fn().mockResolvedValue({ started: true }),
+        connect: vi.fn().mockResolvedValue({}),
+        getBootstrap: vi.fn().mockResolvedValue({
+          appVersion: '1.0.0',
+          rpcCapabilities: ['update-cli-v1']
+        }),
+        supportsCommand: vi.fn().mockResolvedValue(true),
+        invokeCommand,
+        sleep: vi.fn().mockResolvedValue(undefined),
+        log: vi.fn(),
+        setExitCode
+      }
+    )
+
+    expect(result).toMatchObject({
+      outcome: 'manual-action-required',
+      installerPath: 'C:\\Users\\test\\Downloads\\Open-Science.exe'
+    })
+    expect(setExitCode).toHaveBeenCalledWith(6)
+  })
+
+  it('reports an already-current installation without downloading or applying', async () => {
+    const invokeCommand = vi.fn(async (_client, channel: string) => {
+      if (channel === 'update:check') {
+        return { state: 'up-to-date', current: '1.1.0', latest: '1.1.0' }
+      }
+      throw new Error(`Unexpected command: ${channel}`)
+    })
+
+    const ensureService = vi.fn().mockResolvedValue({ started: false })
+    const result = await updateCommand(
+      { open: true, json: true, noSandbox: true },
+      {
+        ensureService,
+        connect: vi.fn().mockResolvedValue({}),
+        getBootstrap: vi.fn().mockResolvedValue({
+          appVersion: '1.1.0',
+          rpcCapabilities: ['update-cli-v1']
+        }),
+        supportsCommand: vi.fn().mockResolvedValue(true),
+        invokeCommand,
+        log: vi.fn(),
+        setExitCode: vi.fn()
+      }
+    )
+
+    expect(result).toEqual({ outcome: 'up-to-date', current: '1.1.0', latest: '1.1.0' })
+    expect(ensureService).toHaveBeenCalledWith(
+      expect.objectContaining({ open: false, noSandbox: true })
+    )
+    expect(invokeCommand).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    ['a failed transfer', 'Network connection lost'],
+    ['a checksum failure', 'Downloaded update checksum mismatch']
+  ])('surfaces %s as a command failure', async (_case, message) => {
+    const invokeCommand = vi.fn(async (_client, channel: string) => {
+      if (channel === 'update:check') {
+        return {
+          state: 'available',
+          current: '1.0.0',
+          latest: '1.1.0',
+          applyKind: 'installer'
+        }
+      }
+      if (channel === 'update:download') {
+        return {
+          state: 'error',
+          current: '1.0.0',
+          latest: '1.1.0',
+          applyKind: 'installer',
+          error: message
+        }
+      }
+      throw new Error(`Unexpected command: ${channel}`)
+    })
+
+    await expect(
+      updateCommand(
+        { open: true, json: true },
+        {
+          ensureService: vi.fn().mockResolvedValue({ started: true }),
+          connect: vi.fn().mockResolvedValue({}),
+          getBootstrap: vi.fn().mockResolvedValue({
+            appVersion: '1.0.0',
+            rpcCapabilities: ['update-cli-v1']
+          }),
+          supportsCommand: vi.fn().mockResolvedValue(true),
+          invokeCommand,
+          sleep: vi.fn().mockResolvedValue(undefined),
+          log: vi.fn(),
+          setExitCode: vi.fn()
+        }
+      )
+    ).rejects.toThrow(message)
+  })
+
+  it('prints observable download progress in human-readable mode', async () => {
+    const ready = {
+      state: 'ready',
+      current: '1.0.0',
+      latest: '1.1.0',
+      applyKind: 'installer',
+      localPath: '/data/update/Open-Science.dmg'
+    }
+    let finishDownload: ((status: typeof ready) => void) | undefined
+    const download = new Promise<typeof ready>((resolve) => {
+      finishDownload = resolve
+    })
+    const invokeCommand = vi.fn(async (_client, channel: string) => {
+      if (channel === 'update:check') {
+        return {
+          state: 'available',
+          current: '1.0.0',
+          latest: '1.1.0',
+          applyKind: 'installer'
+        }
+      }
+      if (channel === 'update:download') return download
+      if (channel === 'update:get-status') {
+        finishDownload?.(ready)
+        return {
+          state: 'downloading',
+          current: '1.0.0',
+          latest: '1.1.0',
+          applyKind: 'installer',
+          progress: 37
+        }
+      }
+      throw new Error(`Unexpected command: ${channel}`)
+    })
+    const log = vi.fn()
+
+    await updateCommand(
+      { open: true, json: false },
+      {
+        ensureService: vi.fn().mockResolvedValue({ started: true }),
+        connect: vi.fn().mockResolvedValue({}),
+        getBootstrap: vi.fn().mockResolvedValue({
+          appVersion: '1.0.0',
+          rpcCapabilities: ['update-cli-v1']
+        }),
+        supportsCommand: vi.fn().mockResolvedValue(true),
+        invokeCommand,
+        sleep: vi.fn().mockResolvedValue(undefined),
+        log,
+        setExitCode: vi.fn()
+      }
+    )
+
+    expect(log).toHaveBeenCalledWith('Downloading update: 37%')
+  })
+
+  it('reports active research blockers with exit code 5 and keeps the service running', async () => {
+    const invokeCommand = vi.fn(async (_client, channel: string) => {
+      if (channel === 'update:check') {
+        return {
+          state: 'ready',
+          current: '1.0.0',
+          latest: '1.1.0',
+          applyKind: 'restart'
+        }
+      }
+      if (channel === 'update:apply') {
+        return {
+          state: 'error',
+          current: '1.0.0',
+          latest: '1.1.0',
+          applyKind: 'restart',
+          blockedBy: ['agent', 'notebook'],
+          error: 'Research work is still running.'
+        }
+      }
+      if (channel === 'storage:detect-active') return [{ kind: 'agent' }]
+      throw new Error(`Unexpected command: ${channel}`)
+    })
+    const setExitCode = vi.fn()
+
+    const result = await updateCommand(
+      { open: true, json: true },
+      {
+        ensureService: vi.fn().mockResolvedValue({ started: true }),
+        connect: vi.fn().mockResolvedValue({}),
+        getBootstrap: vi.fn().mockResolvedValue({
+          appVersion: '1.0.0',
+          rpcCapabilities: ['update-cli-v1']
+        }),
+        supportsCommand: vi.fn().mockResolvedValue(true),
+        invokeCommand,
+        log: vi.fn(),
+        setExitCode
+      }
+    )
+
+    expect(result).toEqual({
+      outcome: 'blocked',
+      current: '1.0.0',
+      latest: '1.1.0',
+      blockedBy: ['agent', 'notebook']
+    })
+    expect(setExitCode).toHaveBeenCalledWith(5)
+    expect(invokeCommand).not.toHaveBeenCalledWith({}, 'storage:detect-active')
+  })
+
+  it('falls back when a legacy app advertises update channels without the CLI capability', async () => {
+    const setExitCode = vi.fn()
+    const supportsCommand = vi.fn().mockResolvedValue(true)
+    const invokeCommand = vi.fn()
+
+    const result = await updateCommand(
+      { open: true, json: true },
+      {
+        ensureService: vi.fn().mockResolvedValue({ started: true }),
+        connect: vi.fn().mockResolvedValue({ bootstrap: { appVersion: '0.9.0' } }),
+        getBootstrap: vi.fn().mockResolvedValue({
+          appVersion: '0.9.0',
+          rpcChannels: ['update:check', 'update:download', 'update:apply']
+        }),
+        supportsCommand,
+        invokeCommand,
+        log: vi.fn(),
+        setExitCode
+      }
+    )
+
+    expect(result).toMatchObject({ outcome: 'manual-action-required', current: '0.9.0' })
+    expect(setExitCode).toHaveBeenCalledWith(6)
+    expect(supportsCommand).not.toHaveBeenCalled()
+    expect(invokeCommand).not.toHaveBeenCalled()
   })
 
   it('emits structured machine errors with stable exit codes', () => {

--- a/src/main/host-application-commands.test.ts
+++ b/src/main/host-application-commands.test.ts
@@ -342,10 +342,16 @@ describe('Host application commands', () => {
       hostApplicationCommands.storage.validateDataRoot,
       invocation([parent])
     )
-    await router.dispatcher.invoke(hostApplicationCommands.update.apply, invocation([]))
+    await router.dispatcher.invoke(
+      hostApplicationCommands.update.apply,
+      invocation([{ relaunch: false }])
+    )
     await router.dispatcher.invoke(hostApplicationCommands.update.cancel, invocation([]))
     await router.dispatcher.invoke(hostApplicationCommands.update.check, invocation([]))
-    await router.dispatcher.invoke(hostApplicationCommands.update.download, invocation([]))
+    await router.dispatcher.invoke(
+      hostApplicationCommands.update.download,
+      invocation([{ nonInteractive: true }])
+    )
     await router.dispatcher.invoke(hostApplicationCommands.update.getAppInfo, invocation([]))
     await router.dispatcher.invoke(hostApplicationCommands.update.getStatus, invocation([]))
 
@@ -370,6 +376,8 @@ describe('Host application commands', () => {
     expect(dependencies.reviewer.abort).toHaveBeenCalledWith(reviewSession)
     expect(dependencies.storage.commitAndRelaunch).toHaveBeenCalledWith(parent)
     expect(dependencies.storage.setDataRootAndRelaunch).toHaveBeenCalledWith(root)
+    expect(dependencies.update.apply).toHaveBeenCalledWith({ relaunch: false })
+    expect(dependencies.update.download).toHaveBeenCalledWith({ nonInteractive: true })
 
     const ownerMethods = Object.values(dependencies).flatMap((owner) => Object.values(owner))
     expect(

--- a/src/main/host-application-commands.ts
+++ b/src/main/host-application-commands.ts
@@ -39,7 +39,12 @@ import type {
   RevealAppStorageResult,
   StorageInfo
 } from '../shared/storage'
-import type { AppInfo, UpdateStatus } from '../shared/update'
+import type {
+  AppInfo,
+  UpdateApplyOptions,
+  UpdateDownloadOptions,
+  UpdateStatus
+} from '../shared/update'
 import {
   defineApplicationCommand,
   defineApplicationCommandGroup,
@@ -284,12 +289,18 @@ const storageCommands = Object.freeze({
 })
 
 const updateCommands = Object.freeze({
-  apply: defineApplicationCommand<'update:apply', readonly [], UpdateStatus>('update:apply'),
+  apply: defineApplicationCommand<
+    'update:apply',
+    readonly [options?: UpdateApplyOptions],
+    UpdateStatus
+  >('update:apply'),
   cancel: defineApplicationCommand<'update:cancel', readonly [], UpdateStatus>('update:cancel'),
   check: defineApplicationCommand<'update:check', readonly [], UpdateStatus>('update:check'),
-  download: defineApplicationCommand<'update:download', readonly [], UpdateStatus>(
-    'update:download'
-  ),
+  download: defineApplicationCommand<
+    'update:download',
+    readonly [options?: UpdateDownloadOptions],
+    UpdateStatus
+  >('update:download'),
   getAppInfo: defineApplicationCommand<'update:get-app-info', readonly [], AppInfo>(
     'update:get-app-info'
   ),
@@ -553,13 +564,13 @@ const registerHostApplicationCommands = (
         )
     })
     scope.registerGroup(hostApplicationCommandGroups[8], {
-      'update:apply': ({ callerContext }) =>
-        localCommand(callerContext, 'update:apply', () => dependencies.update.apply()),
+      'update:apply': ({ args, callerContext }) =>
+        localCommand(callerContext, 'update:apply', () => dependencies.update.apply(args[0])),
       'update:cancel': ({ callerContext }) =>
         localCommand(callerContext, 'update:cancel', () => dependencies.update.cancel()),
       'update:check': () => dependencies.update.check(),
-      'update:download': ({ callerContext }) =>
-        localCommand(callerContext, 'update:download', () => dependencies.update.download()),
+      'update:download': ({ args, callerContext }) =>
+        localCommand(callerContext, 'update:download', () => dependencies.update.download(args[0])),
       'update:get-app-info': () => dependencies.update.getAppInfo(),
       'update:get-status': () => dependencies.update.getStatus()
     })

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -291,7 +291,8 @@ import {
 } from './storage-root'
 import { createUpdateCommandOwner, registerUpdateIpcHandlers } from './update/ipc'
 import { createUpdateStrategy } from './update/create-strategy'
-import { createDelegatedSafeInstallGate } from './update/strategy'
+import { createActiveResearchSafeInstallGate } from './update/strategy'
+import type { UpdateBlocker } from '../shared/update'
 import { startUpdateScheduler } from './update/scheduler'
 import { createDefaultUploadRepository, registerUploadIpcHandlers } from './uploads/ipc'
 import { createUploadCommandOwner } from './uploads/command-owner'
@@ -2325,7 +2326,8 @@ const createApplicationModules = async (
   // Single shared teardown owner for both the before-quit handler (index.ts) and the pre-update-install
   // gate. Update handling is deliberately constructed below, after this dependency is complete.
   let reviewerModelRuntimeShutdown:
-    Pick<ReviewerModelRuntimeOwner, 'shutdown' | 'shutdownForUpdateGate'> | undefined
+    | Pick<ReviewerModelRuntimeOwner, 'hasActiveWork' | 'shutdown' | 'shutdownForUpdateGate'>
+    | undefined
   const shutdownCoordinator = new BackendShutdownCoordinator({
     runtime: {
       shutdownForQuit: async () => {
@@ -2351,8 +2353,16 @@ const createApplicationModules = async (
   // quit the running app to install.
   const updateStrategy = createUpdateStrategy(process.platform, {
     translate,
-    installGate: createDelegatedSafeInstallGate(
-      () => getActiveDelegatedSessions().length > 0,
+    installGate: createActiveResearchSafeInstallGate(
+      () => {
+        const blockers: UpdateBlocker[] = detectActiveSessions({
+          runtime: { getActivePromptSessions: () => runtime.getQuitBlockingPromptSessions() },
+          delegated: { getActiveDelegatedSessions },
+          notebook: notebookService
+        }).map((session) => session.kind)
+        if (reviewerModelRuntimeShutdown?.hasActiveWork()) blockers.push('reviewer')
+        return blockers
+      },
       () => shutdownCoordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS)
     )
   })

--- a/src/main/reviewer/model-runtime-owner.test.ts
+++ b/src/main/reviewer/model-runtime-owner.test.ts
@@ -66,7 +66,9 @@ describe('ReviewerModelRuntimeOwner', () => {
         }
       })
 
+      expect(owner.hasActiveWork()).toBe(false)
       const admission = await owner.admit()
+      expect(owner.hasActiveWork()).toBe(true)
 
       expect(admission.model).toBe(target.model.id)
       expect(admission.reviewerAcpRuntime).toBe(fixedRuntime)
@@ -85,6 +87,7 @@ describe('ReviewerModelRuntimeOwner', () => {
       ).toThrow('no longer available')
 
       await admission.release()
+      expect(owner.hasActiveWork()).toBe(false)
       expect(shutdownForQuit).toHaveBeenCalledOnce()
     }
   )
@@ -154,6 +157,7 @@ describe('ReviewerModelRuntimeOwner', () => {
 
     const admission = owner.admit()
     await vi.waitFor(() => expect(resolveTarget).toHaveBeenCalledOnce())
+    expect(owner.hasActiveWork()).toBe(true)
     let shutdownFinished = false
     const shutdown = owner.shutdown().then(() => {
       shutdownFinished = true
@@ -169,6 +173,7 @@ describe('ReviewerModelRuntimeOwner', () => {
 
     await expect(admission).rejects.toThrow('shutting down')
     await shutdown
+    expect(owner.hasActiveWork()).toBe(false)
     expect(releaseBridge).toHaveBeenCalledOnce()
     expect(createRuntime).not.toHaveBeenCalled()
   })

--- a/src/main/reviewer/model-runtime-owner.test.ts
+++ b/src/main/reviewer/model-runtime-owner.test.ts
@@ -5,6 +5,23 @@ import type { ResolvedAgentBackend } from '../agent-framework'
 import { ReviewerModelRuntimeOwner } from './model-runtime-owner'
 
 describe('ReviewerModelRuntimeOwner', () => {
+  it('tracks inherited Reviewer work until its shared-runtime admission is released', async () => {
+    const owner = new ReviewerModelRuntimeOwner({
+      appVersion: 'test',
+      captureModel: async () => ({ model: 'inherited-model' }),
+      resolveTarget: vi.fn()
+    })
+
+    expect(owner.hasActiveWork()).toBe(false)
+    const admission = await owner.admit()
+
+    expect(admission.reviewerAcpRuntime).toBeUndefined()
+    expect(owner.hasActiveWork()).toBe(true)
+
+    await admission.release()
+    expect(owner.hasActiveWork()).toBe(false)
+  })
+
   it.each([
     {
       path: 'claude-code',

--- a/src/main/reviewer/model-runtime-owner.ts
+++ b/src/main/reviewer/model-runtime-owner.ts
@@ -88,6 +88,10 @@ class ReviewerModelRuntimeOwner {
     return admission
   }
 
+  hasActiveWork(): boolean {
+    return this.activeRuntimes.size > 0 || this.pendingAdmissions.size > 0
+  }
+
   private async admitOwned(): Promise<ReviewerModelRuntimeAdmission> {
     if (this.shuttingDown) throw new Error('Reviewer model runtime is shutting down.')
     const captured = await this.options.captureModel()

--- a/src/main/reviewer/model-runtime-owner.ts
+++ b/src/main/reviewer/model-runtime-owner.ts
@@ -62,6 +62,7 @@ const unavailableRuntime = (error: unknown): ReviewerAcpRuntime => {
 class ReviewerModelRuntimeOwner {
   private readonly runtimeFactory: NonNullable<ReviewerModelRuntimeOwnerOptions['createRuntime']>
   private readonly activeRuntimes = new Set<ActiveReviewerRuntime>()
+  private readonly activeSharedRuntimeAdmissions = new Set<object>()
   private readonly pendingAdmissions = new Set<Promise<void>>()
   private updateGatePromise: Promise<{ reaped: boolean }> | undefined
   private shuttingDown = false
@@ -89,7 +90,11 @@ class ReviewerModelRuntimeOwner {
   }
 
   hasActiveWork(): boolean {
-    return this.activeRuntimes.size > 0 || this.pendingAdmissions.size > 0
+    return (
+      this.activeRuntimes.size > 0 ||
+      this.activeSharedRuntimeAdmissions.size > 0 ||
+      this.pendingAdmissions.size > 0
+    )
   }
 
   private async admitOwned(): Promise<ReviewerModelRuntimeAdmission> {
@@ -97,7 +102,14 @@ class ReviewerModelRuntimeOwner {
     const captured = await this.options.captureModel()
     if (this.shuttingDown) throw new Error('Reviewer model runtime is shutting down.')
     if (!captured.fixedTarget) {
-      return Object.freeze({ model: captured.model, release: async () => undefined })
+      const admission = Object.freeze({})
+      this.activeSharedRuntimeAdmissions.add(admission)
+      return Object.freeze({
+        model: captured.model,
+        release: async () => {
+          this.activeSharedRuntimeAdmissions.delete(admission)
+        }
+      })
     }
 
     const target = captured.fixedTarget

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { Logger } from '../logger'
 import { ElectronUpdaterStrategy } from './electron-updater-strategy'
-import { createDelegatedSafeInstallGate } from './strategy'
+import { createActiveResearchSafeInstallGate } from './strategy'
 import {
   clearApplicationShutdownTrigger,
   currentApplicationShutdownTrigger
@@ -554,6 +554,20 @@ describe('ElectronUpdaterStrategy', () => {
     )
   })
 
+  it('can install silently without relaunching for a headless caller', async () => {
+    const updater = new FakeUpdater()
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn()
+    })
+    markUpdateReady(updater)
+
+    await strategy.apply({ relaunch: false })
+
+    expect(updater.quitAndInstall).toHaveBeenCalledWith(true, false)
+  })
+
   it('rolls back the update shutdown trigger when quitAndInstall throws', async () => {
     const updater = new FakeUpdater()
     updater.quitAndInstall.mockImplementation(() => {
@@ -597,7 +611,7 @@ describe('ElectronUpdaterStrategy', () => {
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
-      installGate: createDelegatedSafeInstallGate(() => true, backendTeardownGate)
+      installGate: createActiveResearchSafeInstallGate(() => ['delegated'], backendTeardownGate)
     })
     markUpdateReady(updater)
 
@@ -605,7 +619,33 @@ describe('ElectronUpdaterStrategy', () => {
 
     expect(status).toMatchObject({
       state: 'error',
-      error: expect.stringMatching(/subagents are still running/i)
+      error: expect.stringMatching(/subagents are still running/i),
+      blockedBy: ['delegated']
+    })
+    expect(backendTeardownGate).not.toHaveBeenCalled()
+    expect(updater.quitAndInstall).not.toHaveBeenCalled()
+  })
+
+  it('blocks restart for root-agent, notebook, and reviewer work without tearing them down', async () => {
+    const updater = new FakeUpdater()
+    const backendTeardownGate = vi.fn(async () => ({ completed: true, reaped: true }))
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      installGate: createActiveResearchSafeInstallGate(
+        () => ['agent', 'notebook', 'reviewer'],
+        backendTeardownGate
+      )
+    })
+    markUpdateReady(updater)
+
+    const status = await strategy.apply()
+
+    expect(status).toMatchObject({
+      state: 'error',
+      error: expect.stringMatching(/research work is still running/i),
+      blockedBy: ['agent', 'notebook', 'reviewer']
     })
     expect(backendTeardownGate).not.toHaveBeenCalled()
     expect(updater.quitAndInstall).not.toHaveBeenCalled()

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -3,7 +3,7 @@ import { spawnSync } from 'node:child_process'
 import { autoUpdater, CancellationToken } from 'electron-updater'
 
 import { APP } from '../../shared/app-config'
-import { isNewer, type UpdateStatus } from '../../shared/update'
+import { isNewer, type UpdateApplyOptions, type UpdateStatus } from '../../shared/update'
 import { startDiagnosticOperation, type DiagnosticOperation } from '../diagnostics/operation'
 import type { Logger } from '../logger'
 import { fetchManifest } from './manifest'
@@ -484,7 +484,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   // Triggered by the user's "Restart to update" click once the download is ready. On Windows,
   // isSilent=true bypasses the assisted NSIS wizard and isForceRunAfter=true relaunches into the new
   // version. Other updaters ignore isSilent.
-  async apply(): Promise<UpdateStatus> {
+  async apply(options: UpdateApplyOptions = {}): Promise<UpdateStatus> {
     // Ignore stale/out-of-order renderer calls until electron-updater reports a completed download,
     // then claim the update synchronously so repeat clicks or concurrent renderers cannot start a
     // second teardown/install. The broadcast also gives the renderer immediate feedback during the
@@ -499,11 +499,11 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
       fields: { strategy: 'in-place' }
     })
 
-    // Stop the agent + notebook process trees BEFORE handing off to the installer. Its uninstall step
-    // deletes the running app's files, and on Windows an executable/DLL still mapped by a background
-    // child (agent CLI, python kernel, conda) is locked — the classic "Failed to uninstall old
-    // application files" error. If the teardown is degraded (budget elapsed, or taskkill fell back and
-    // may have left grandchildren), refuse the install rather than fail mid-uninstall: the gate is
+    // Stop the agent, Reviewer, and notebook process trees BEFORE handing off to the installer. Its
+    // uninstall step deletes the running app's files, and on Windows an executable/DLL still mapped by
+    // a background child (agent CLI, python kernel, conda) is locked — the classic "Failed to uninstall
+    // old application files" error. If the teardown is degraded (budget elapsed, or taskkill fell back
+    // and may have left grandchildren), refuse the install rather than fail mid-uninstall: the gate is
     // non-latching, so the app stays usable and the user can retry (fewer live processes next time).
     if (this.installGate) {
       operation.phase('install-gate')
@@ -532,15 +532,18 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
           ...this.status,
           state: 'error',
           error:
-            readiness.blockedBy === 'delegated-work'
+            readiness.blockedBy?.length === 1 && readiness.blockedBy[0] === 'delegated'
               ? 'Subagents are still running. Return to their tasks and stop them before restarting to update.'
-              : 'Could not fully stop background processes before updating. Please try again.'
+              : readiness.blockedBy?.length
+                ? 'Research work is still running. Stop it before restarting to update.'
+                : 'Could not fully stop background processes before updating. Please try again.',
+          ...(readiness.blockedBy ? { blockedBy: readiness.blockedBy } : {})
         })
         operation.fail(new Error('Install gate refused'), {
           reason: 'install-gate-refused',
           gateCompleted: readiness.completed,
           processTreesReaped: readiness.reaped,
-          ...(readiness.blockedBy ? { blockedBy: readiness.blockedBy } : {})
+          ...(readiness.blockedBy ? { blockedBy: readiness.blockedBy.join(',') } : {})
         })
         return this.status
       }
@@ -552,7 +555,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     this.pendingInstallRollback = rollbackTrigger
     this.installerStarted = true
     try {
-      this.updater.quitAndInstall(true, true)
+      this.updater.quitAndInstall(true, options.relaunch ?? true)
     } catch (error) {
       rollbackTrigger()
       this.pendingInstallRollback = undefined

--- a/src/main/update/ipc.test.ts
+++ b/src/main/update/ipc.test.ts
@@ -3,11 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { APP } from '../../shared/app-config'
 import type { UpdateStrategy } from './strategy'
 
-const handlers = new Map<string, () => unknown>()
+const handlers = new Map<string, (...args: unknown[]) => unknown>()
 
 vi.mock('electron', () => ({
   ipcMain: {
-    handle: (channel: string, handler: () => unknown) => handlers.set(channel, handler)
+    handle: (channel: string, handler: (...args: unknown[]) => unknown) =>
+      handlers.set(channel, handler)
   }
 }))
 
@@ -43,6 +44,12 @@ describe('registerUpdateIpcHandlers', () => {
     expect(registerUpdateIpcHandlers(strategy, owner)).toBe(strategy)
     expect(handlers.get('update:get-app-info')?.()).toMatchObject({ name: 'Injected' })
     await expect(handlers.get('update:check')?.()).resolves.toBe(status)
+    await expect(handlers.get('update:download')?.({}, { nonInteractive: true })).resolves.toBe(
+      status
+    )
+    await expect(handlers.get('update:apply')?.({}, { relaunch: false })).resolves.toBe(status)
+    expect(owner.download).toHaveBeenCalledWith({ nonInteractive: true })
+    expect(owner.apply).toHaveBeenCalledWith({ relaunch: false })
     expect(strategy.check).not.toHaveBeenCalled()
   })
 

--- a/src/main/update/ipc.ts
+++ b/src/main/update/ipc.ts
@@ -1,7 +1,12 @@
 import { ipcMainHandle } from '../ipc-handler-registry'
 
 import { APP } from '../../shared/app-config'
-import type { AppInfo, UpdateStatus } from '../../shared/update'
+import type {
+  AppInfo,
+  UpdateApplyOptions,
+  UpdateDownloadOptions,
+  UpdateStatus
+} from '../../shared/update'
 import { createUpdateStrategy } from './create-strategy'
 import type { UpdateStrategy } from './strategy'
 
@@ -9,9 +14,9 @@ type UpdateCommandOwner = Readonly<{
   getAppInfo: () => AppInfo
   getStatus: () => UpdateStatus
   check: () => Promise<UpdateStatus>
-  download: () => Promise<UpdateStatus>
+  download: (options?: UpdateDownloadOptions) => Promise<UpdateStatus>
   cancel: () => Promise<UpdateStatus>
-  apply: () => Promise<UpdateStatus>
+  apply: (options?: UpdateApplyOptions) => Promise<UpdateStatus>
 }>
 
 const createUpdateCommandOwner = (strategy: UpdateStrategy): UpdateCommandOwner => ({
@@ -22,9 +27,9 @@ const createUpdateCommandOwner = (strategy: UpdateStrategy): UpdateCommandOwner 
   }),
   getStatus: () => strategy.getStatus(),
   check: () => strategy.check(),
-  download: () => strategy.download(),
+  download: (options) => strategy.download(options),
   cancel: () => strategy.cancel(),
-  apply: () => strategy.apply()
+  apply: (options) => strategy.apply(options)
 })
 
 // Registers the renderer-callable update commands. Returns the strategy so the scheduler can drive it.
@@ -35,9 +40,11 @@ export const registerUpdateIpcHandlers = (
   ipcMainHandle('update:get-app-info', () => owner.getAppInfo())
   ipcMainHandle('update:get-status', () => owner.getStatus())
   ipcMainHandle('update:check', () => owner.check())
-  ipcMainHandle('update:download', () => owner.download())
+  ipcMainHandle('update:download', (_event, options?: UpdateDownloadOptions) =>
+    owner.download(options)
+  )
   ipcMainHandle('update:cancel', () => owner.cancel())
-  ipcMainHandle('update:apply', () => owner.apply())
+  ipcMainHandle('update:apply', (_event, options?: UpdateApplyOptions) => owner.apply(options))
   return strategy
 }
 

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -208,6 +208,53 @@ describe('UpdateService.download', () => {
     expect(existsSync(target)).toBe(true)
   })
 
+  it('uses the deterministic download path without opening a save dialog when non-interactive', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'svc-headless-'))
+    const target = join(dir, 'installer.dmg')
+    const body = Buffer.from('installer-bytes')
+    const manifestForCheck = downloadManifest(
+      body.byteLength,
+      createHash('sha256').update(body).digest('hex')
+    )
+    const fetchImpl = ((input: unknown) =>
+      String(input).endsWith('version.json')
+        ? Promise.resolve(jsonResponse(manifestForCheck))
+        : Promise.resolve(new Response(body, { status: 200 }))) as unknown as typeof fetch
+    const promptSavePath = vi.fn().mockResolvedValue(join(dir, 'wrong-path.dmg'))
+    const defaultDownloadPath = vi.fn(() => target)
+    const removeFile = vi.fn((path: string) => rm(path, { force: true }))
+    const broadcast = vi.fn()
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast,
+      promptSavePath,
+      defaultDownloadPath,
+      removeFile
+    })
+
+    await service.check()
+    const status = await service.download({ nonInteractive: true })
+
+    expect(status).toMatchObject({ state: 'ready', localPath: target })
+    expect(defaultDownloadPath).toHaveBeenCalledWith('installer.dmg')
+    expect(promptSavePath).not.toHaveBeenCalled()
+    expect(removeFile).toHaveBeenNthCalledWith(1, target)
+    expect(removeFile).toHaveBeenNthCalledWith(2, `${target}.part`)
+    expect(broadcast).toHaveBeenCalledWith(
+      'update:status',
+      expect.objectContaining({
+        state: 'downloading',
+        progress: 100,
+        downloadedBytes: body.byteLength,
+        totalBytes: body.byteLength
+      })
+    )
+  })
+
   it('preserves a completed download when a check is requested during the transfer', async () => {
     dir = await mkdtemp(join(tmpdir(), 'svc-'))
     const target = join(dir, 'installer.dmg')

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -5,7 +5,12 @@ import { basename, join } from 'node:path'
 import { app, BrowserWindow, dialog, shell } from 'electron'
 
 import { APP } from '../../shared/app-config'
-import { isNewer, selectDownload, type UpdateStatus } from '../../shared/update'
+import {
+  isNewer,
+  selectDownload,
+  type UpdateDownloadOptions,
+  type UpdateStatus
+} from '../../shared/update'
 import { startDiagnosticOperation, type DiagnosticOperation } from '../diagnostics/operation'
 import type { Logger } from '../logger'
 import { downloadInstaller } from './downloader'
@@ -30,6 +35,8 @@ export type UpdateServiceDeps = {
   // Resolves where to save the installer, or null if the user cancels. Injected in tests; the
   // default is platform-aware (see resolveSavePath).
   promptSavePath?: (defaultFileName: string) => Promise<string | null>
+  // Resolves a deterministic target without opening a native dialog (CLI/headless downloads).
+  defaultDownloadPath?: (defaultFileName: string) => string
   // Filesystem + shell hooks, injected in tests so apply never touches Electron/disk.
   fileExists?: (path: string) => boolean
   openPath?: (path: string) => Promise<string>
@@ -85,6 +92,7 @@ export class UpdateService implements UpdateStrategy {
   private readonly manifestUrl: string
   private readonly broadcast: UpdateBroadcast
   private readonly promptSavePath: (defaultFileName: string) => Promise<string | null>
+  private readonly defaultDownloadPath: (defaultFileName: string) => string
   private readonly fileExists: (path: string) => boolean
   private readonly openPath: (path: string) => Promise<string>
   private readonly openExternal: (url: string) => Promise<void>
@@ -105,6 +113,8 @@ export class UpdateService implements UpdateStrategy {
     this.manifestUrl = deps.manifestUrl ?? APP.update.manifestUrl
     this.broadcast = deps.broadcast ?? defaultBroadcast
     this.promptSavePath = deps.promptSavePath ?? ((name) => this.resolveSavePath(name))
+    this.defaultDownloadPath =
+      deps.defaultDownloadPath ?? ((name) => join(app.getPath('userData'), `update-${name}`))
     this.fileExists = deps.fileExists ?? existsSync
     this.openPath = deps.openPath ?? ((path) => shell.openPath(path))
     this.openExternal = deps.openExternal ?? ((url) => shell.openExternal(url))
@@ -209,7 +219,7 @@ export class UpdateService implements UpdateStrategy {
     }
   }
 
-  async download(): Promise<UpdateStatus> {
+  async download(options: UpdateDownloadOptions = {}): Promise<UpdateStatus> {
     // An active download is in flight; ignore repeat clicks / concurrent renderers. The abort claim
     // below is synchronous (before any await) so this guard and a cancel() during the drain both target
     // a consistent slot — a cancel while a retry is still draining must abort it, not be a no-op.
@@ -269,11 +279,19 @@ export class UpdateService implements UpdateStrategy {
         // Ask where to save (platform-aware). A dialog cancel — or a cancel() during the prompt —
         // leaves the status untouched (stays 'available').
         operation.phase('select-target')
-        const targetPath = await this.promptSavePath(installerFileName(download.url))
+        const defaultFileName = installerFileName(download.url)
+        const targetPath = options.nonInteractive
+          ? this.defaultDownloadPath(defaultFileName)
+          : await this.promptSavePath(defaultFileName)
         if (!targetPath) {
           operation.cancel({ reason: 'target-selection' })
           return
         }
+        if (abort.signal.aborted) return
+
+        // The CLI target is deterministic. Drop an older completed artifact before final rename so a
+        // repeated command cannot fail merely because the same release filename is already staged.
+        if (options.nonInteractive) await this.removeFile(targetPath)
         if (abort.signal.aborted) return
 
         // First time this session that we download to this exact path: drop any <target>.part left by
@@ -301,7 +319,18 @@ export class UpdateService implements UpdateStrategy {
         operation.phase('transfer')
         const localPath = await downloadInstaller(download, targetPath, {
           fetchImpl: this.fetchImpl,
-          onProgress: (progress) => this.broadcast('update:progress', progress),
+          onProgress: (progress) => {
+            if (abort.signal.aborted) return
+            this.setStatus({
+              ...this.status,
+              state: 'downloading',
+              progress: progress.percent ?? this.status.progress,
+              downloadedBytes: progress.transferred,
+              totalBytes: progress.total ?? this.status.totalBytes,
+              downloadProgress: progress
+            })
+            this.broadcast('update:progress', progress)
+          },
           signal: abort.signal
         })
         this.setStatus({

--- a/src/main/update/strategy.ts
+++ b/src/main/update/strategy.ts
@@ -1,4 +1,9 @@
-import type { UpdateStatus } from '../../shared/update'
+import type {
+  UpdateApplyOptions,
+  UpdateBlocker,
+  UpdateDownloadOptions,
+  UpdateStatus
+} from '../../shared/update'
 
 // Readiness reported by the pre-install gate: whether the backend teardown completed within its budget
 // and whether every process tree was cleanly reaped. Structurally matches lifecycle-shutdown's
@@ -6,7 +11,7 @@ import type { UpdateStatus } from '../../shared/update'
 export type InstallReadiness = {
   completed: boolean
   reaped: boolean
-  blockedBy?: 'delegated-work'
+  blockedBy?: UpdateBlocker[]
 }
 
 // Runs backend teardown before an in-place install and reports whether it is safe to proceed. The
@@ -14,14 +19,14 @@ export type InstallReadiness = {
 // never starts while a background process still holds app files open.
 export type InstallGate = () => Promise<InstallReadiness>
 
-// Performs the delegated-work check before invoking the destructive backend teardown gate. Kept
-// independent of Electron/runtime types so composition tests can prove the backend remains untouched.
-export const createDelegatedSafeInstallGate =
-  (hasRunningDelegatedWork: () => boolean, runTeardownGate: InstallGate): InstallGate =>
-  async () =>
-    hasRunningDelegatedWork()
-      ? { completed: false, reaped: false, blockedBy: 'delegated-work' }
-      : runTeardownGate()
+// Performs the active-research check before invoking the destructive backend teardown gate. Kept
+// independent of Electron/runtime types so composition tests can prove blocked work remains untouched.
+export const createActiveResearchSafeInstallGate =
+  (detectBlockers: () => UpdateBlocker[], runTeardownGate: InstallGate): InstallGate =>
+  async () => {
+    const blockedBy = [...new Set(detectBlockers())]
+    return blockedBy.length > 0 ? { completed: false, reaped: false, blockedBy } : runTeardownGate()
+  }
 
 // The platform-agnostic update contract the IPC layer and scheduler drive. Two implementations exist:
 // ElectronUpdaterStrategy (win/linux, and signed stable macOS — in-place download/restart) and
@@ -30,10 +35,10 @@ export const createDelegatedSafeInstallGate =
 export interface UpdateStrategy {
   getStatus(): UpdateStatus
   check(): Promise<UpdateStatus>
-  download(): Promise<UpdateStatus>
+  download(options?: UpdateDownloadOptions): Promise<UpdateStatus>
   // Aborts an in-flight download, stops network activity, and returns the reset status (back to
   // 'available' when a download was running). A no-op when nothing is downloading.
   cancel(): Promise<UpdateStatus>
   // Applies a ready update: open the installer (mac) or quitAndInstall (win/linux).
-  apply(): Promise<UpdateStatus>
+  apply(options?: UpdateApplyOptions): Promise<UpdateStatus>
 }

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -17,6 +17,7 @@ import { ApplicationCommandError } from '../../shared/application-command-contra
 import {
   isWebRpcChannel,
   WEB_EVENT_STREAM_PROTOCOL_VERSION,
+  WEB_RPC_CAPABILITIES,
   WEB_RPC_PROTOCOL_VERSION
 } from '../../shared/web-rpc-contract'
 import { ApplicationEventHub } from '../application-events'
@@ -367,6 +368,7 @@ describe('startWebHttpServer', () => {
       appName: 'Open Science',
       configRoot: '/fake/root',
       rpcProtocolVersion: WEB_RPC_PROTOCOL_VERSION,
+      rpcCapabilities: WEB_RPC_CAPABILITIES,
       rpcChannels: ['projects:list']
     })
 

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -26,6 +26,7 @@ import { createApplicationCommandClient } from '../application-command-client'
 import type { ApplicationCommandComposition } from '../application-command-composition'
 import type { ApplicationEventSource } from '../application-events'
 import {
+  WEB_RPC_CAPABILITIES,
   WEB_EVENT_STREAM_PROTOCOL_VERSION,
   isWebRpcChannel,
   WEB_RPC_PROTOCOL_VERSION,
@@ -606,6 +607,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
         json(response, 200, {
           ...(auth.ok ? options.bootstrap : remoteWebBootstrap(options.bootstrap)),
           rpcProtocolVersion: WEB_RPC_PROTOCOL_VERSION,
+          rpcCapabilities: auth.ok ? WEB_RPC_CAPABILITIES : [],
           rpcChannels,
           eventStream: internalEventStream.cursor(),
           restrictedRpcChannels

--- a/src/shared/update.ts
+++ b/src/shared/update.ts
@@ -12,6 +12,13 @@ export type UpdateManifest = {
 export type UpdateState =
   'idle' | 'checking' | 'up-to-date' | 'available' | 'downloading' | 'ready' | 'applying' | 'error'
 
+export type UpdateBlocker = 'agent' | 'delegated' | 'notebook' | 'reviewer'
+
+// Call intent stays transient and transport-neutral. Desktop callers omit these options; headless
+// callers use them to avoid native dialogs and desktop relaunches.
+export type UpdateDownloadOptions = { nonInteractive?: boolean }
+export type UpdateApplyOptions = { relaunch?: boolean }
+
 // The single status the main process broadcasts and the renderer store mirrors.
 export type UpdateStatus = {
   state: UpdateState
@@ -27,6 +34,9 @@ export type UpdateStatus = {
   downloadProgress?: import('./download-progress').DownloadProgress
   localPath?: string // set when state === 'ready'
   error?: string
+  // Active research that prevented an in-place install. This is deliberately not a new UpdateState:
+  // the operation still failed, while callers that need automation can distinguish a safe block.
+  blockedBy?: UpdateBlocker[]
   // How the renderer applies a ready update: open the downloaded installer (mac manual reinstall) or
   // restart into an in-place electron-updater install (win/linux). Set by the active strategy.
   applyKind?: 'installer' | 'restart'

--- a/src/shared/web-rpc-contract.test.ts
+++ b/src/shared/web-rpc-contract.test.ts
@@ -4,9 +4,12 @@ import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from './web-api-map.generated
 import {
   isWebRpcChannel,
   isWebRpcEventChannel,
+  WEB_EVENT_STREAM_PROTOCOL_VERSION,
   WEB_RPC_ALLOWED_CHANNELS,
+  WEB_RPC_CAPABILITY_UPDATE_CLI_V1,
   WEB_RPC_PROTOCOL_VERSION,
   WEB_RPC_UNAVAILABLE_CHANNELS,
+  webRpcBootstrapSchema,
   webRpcRequestSchema,
   webRpcResponseSchema
 } from './web-rpc-contract'
@@ -176,6 +179,23 @@ describe('Web RPC contract', () => {
         error: {
           code: 'invalid-command-arguments',
           message: 'Invalid project request.'
+        }
+      }).success
+    ).toBe(true)
+  })
+
+  it('accepts the versioned CLI update capability in bootstrap data', () => {
+    expect(
+      webRpcBootstrapSchema.safeParse({
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' },
+        rpcProtocolVersion: WEB_RPC_PROTOCOL_VERSION,
+        rpcCapabilities: [WEB_RPC_CAPABILITY_UPDATE_CLI_V1],
+        rpcChannels: [],
+        eventStream: {
+          protocolVersion: WEB_EVENT_STREAM_PROTOCOL_VERSION,
+          streamId: 'stream-1',
+          latestSequence: 0
         }
       }).success
     ).toBe(true)

--- a/src/shared/web-rpc-contract.ts
+++ b/src/shared/web-rpc-contract.ts
@@ -4,6 +4,8 @@ import { APPLICATION_COMMAND_ERROR_CODES } from './application-command-contract'
 import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from './web-api-map.generated'
 
 export const WEB_RPC_PROTOCOL_VERSION = 1 as const
+export const WEB_RPC_CAPABILITY_UPDATE_CLI_V1 = 'update-cli-v1' as const
+export const WEB_RPC_CAPABILITIES = [WEB_RPC_CAPABILITY_UPDATE_CLI_V1] as const
 // v3 requires ACP consumers to apply acp:event incrementally. Reject cached v2 pages after a Main
 // upgrade so they request a reload instead of silently waiting for removed per-chunk state frames.
 export const WEB_EVENT_STREAM_PROTOCOL_VERSION = 3 as const
@@ -108,6 +110,7 @@ export const webRpcBootstrapSchema = z
       })
       .strict(),
     restrictedRpcChannels: z.array(z.string()).optional(),
+    rpcCapabilities: z.array(z.string()).optional(),
     rpcChannels: z.array(z.string()).superRefine((channels, context) => {
       for (const channel of channels) {
         if (isWebRpcChannel(channel)) continue


### PR DESCRIPTION
## Problem

Closes #1484.

The installed Open Science application already owns update checks, downloads, integrity checks, and
platform-specific apply behavior, but terminal-only and automated users cannot drive that workflow
without opening the desktop update UI or selecting an installer manually.

## Proposed change

- add `open-science update` and `open-science update --json` as one workflow over the existing
  authenticated local Web RPC update owner;
- start the existing headless service when needed, including the documented Linux
  `update --no-sandbox` fallback, without opening the desktop UI or browser;
- advertise an explicit transient `update-cli-v1` RPC capability so a new CLI never assumes legacy
  handlers honor non-interactive download or no-relaunch apply options;
- stage manual installers in the application's writable data directory without a save dialog and
  return their path plus the required next action;
- block in-place installation atomically for active root-agent, subagent, Notebook, or Reviewer work;
- report current, progress, download/integrity failure, blocked, manual-action, and truthful
  `install-started` handoff outcomes with documented exit codes.

## Scope and non-goals

- No renderer interaction or translated copy changes.
- No database, schema, settings, session, or domain-model persistence changes.
- No new `UpdateState` value. `blockedBy` and CLI outcomes are transient structured values.
- `rpcCapabilities` is a transient bootstrap field, not persisted application data.
- Existing installer/cache and `.part` files remain the only update artifacts written to disk.
- A process that exits into the platform updater cannot verify the final installed version in the
  same invocation, so the result is `install-started`, not a false `applied` success claim.
- No second updater, privileged helper, durable update-job state, or new release-signing trust root.
- Historical user data needs no migration. Older applications that do not advertise
  `update-cli-v1` conservatively return `manual-action-required`; installations predating the command
  need one manual upgrade.

## Acceptance criteria and validation

- CLI current/download/progress/checksum/blocked/manual/JSON/capability behavior:
  `npm run test:cli` — 78 passed, 4 skipped.
- Update service, Electron strategy, IPC/application-command adapters, Web bootstrap contract:
  focused Vitest run — 143 passed, 4 skipped across 7 files.
- Node and Web type safety: `npm run typecheck` — passed.
- Repository lint: `npm run lint` — passed.
- Published CLI contents and executable mode: `npm run check:cli-package` — passed.
- Whitespace validation: `git diff --check origin/main...HEAD` — passed.

Per the issue workflow, the full `npm test` suite was not run locally; PR CI is the complete-suite
authority. Real packaged installer handoff/elevation remains covered by platform packaging and updater
certification rather than unit tests.

## Review focus

- The active-research check and backend teardown remain in one main-process install gate.
- The CLI update RPC adapter intentionally stays private because the public Task SDK inventory excludes
  application-management capabilities.
- `update-cli-v1` is required in addition to channel presence for historical compatibility.
- `install-started` describes platform-updater handoff rather than claiming post-exit installation
  completion.
- Manual installer paths use existing verified download behavior in app user data and do not open a
  native dialog or installer.
