### PR TITLE
fix(artifact-provenance): record connector artifact identities

### DIFF
--- a/src/main/acp/artifact-turn-owner.test.ts
+++ b/src/main/acp/artifact-turn-owner.test.ts
@@ -204,7 +204,18 @@ describe('ArtifactTurnOwner', () => {
 
     await Promise.all([
       owner.write(root, { filename: 'root.txt', content: 'root' }),
-      owner.write(parallel, { filename: 'parallel.txt', content: 'parallel' })
+      owner.write(parallel, {
+        filename: 'parallel.txt',
+        content: 'parallel',
+        producer: {
+          kind: 'connector',
+          connectorId: 'molecule',
+          toolId: 'preview_molecule',
+          invocationId: 'connector-call-1',
+          implementationVersion: '1',
+          normalizedArguments: { filename: 'parallel.txt' }
+        }
+      })
     ])
     await owner.finalize(root)
     await owner.dispose(root)
@@ -235,7 +246,13 @@ describe('ArtifactTurnOwner', () => {
         artifactRunId: 'artifact-run-100-2',
         agentFrameId: 'parallel-frame',
         runtimeSegmentId: 'parallel-segment',
-        promptMessageId: 'parallel-prompt'
+        promptMessageId: 'parallel-prompt',
+        producer: expect.objectContaining({
+          kind: 'connector',
+          connectorId: 'molecule',
+          toolId: 'preview_molecule',
+          invocationId: 'connector-call-1'
+        })
       })
     ])
     expect(issuedBindings).toEqual([

--- a/src/main/acp/artifact-turn-owner.ts
+++ b/src/main/acp/artifact-turn-owner.ts
@@ -3,7 +3,10 @@ import { mkdir, rm, rmdir, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
 import type { ArtifactFile } from '../../shared/artifacts'
-import type { ArtifactRpcCapabilityBinding } from '../../shared/artifact-provenance'
+import type {
+  AppGeneratedArtifactProducer,
+  ArtifactRpcCapabilityBinding
+} from '../../shared/artifact-provenance'
 import type { ArtifactRunContext } from '../artifacts/mcp-server'
 import { ArtifactRepository, getArtifactCurrentRunFilePath } from '../artifacts/repository'
 import { ArtifactRunRegistry } from '../artifacts/run-registry'
@@ -39,6 +42,7 @@ type ArtifactTurnWriteInput = {
   content: string
   mimeType?: string
   kind?: 'plan'
+  producer?: AppGeneratedArtifactProducer
 }
 
 type ArtifactTurnPublication = {
@@ -101,6 +105,7 @@ type ArtifactTurnProvenance = {
     content: string
     contentType?: string
     kind?: 'plan'
+    producer?: AppGeneratedArtifactProducer
   }) => Promise<ArtifactFile>
 }
 
@@ -341,7 +346,8 @@ class ArtifactTurnOwner {
           filename: input.filename,
           content: input.content,
           contentType: input.mimeType,
-          kind: input.kind
+          kind: input.kind,
+          producer: input.producer
         })
       : this.options.repository.writePendingFile({
           projectId: turn.projectId,

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -8715,11 +8715,27 @@ describe('ACP runtime session management', () => {
     const artifact = await runtime.writeArtifactForCurrentRun(session.sessionId, {
       filename: 'aspirin.mol',
       content: 'mol',
-      mimeType: 'chemical/x-mdl-molfile'
+      mimeType: 'chemical/x-mdl-molfile',
+      producer: {
+        kind: 'connector',
+        connectorId: 'molecule',
+        toolId: 'preview_molecule',
+        invocationId: 'connector-call-1',
+        implementationVersion: '1',
+        normalizedArguments: { filename: 'aspirin.mol' }
+      }
     })
 
     expect(artifact).toMatchObject({ id: 'version-1', versionId: 'version-1' })
-    expect(provenance.writeAppGeneratedVersion).toHaveBeenCalledOnce()
+    expect(provenance.writeAppGeneratedVersion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        producer: expect.objectContaining({
+          kind: 'connector',
+          connectorId: 'molecule',
+          invocationId: 'connector-call-1'
+        })
+      })
+    )
     promptGate.resolve()
     await prompt
     expect(runtime.getSnapshot().events).toContainEqual(
@@ -20196,7 +20212,15 @@ describe('ACP runtime session management', () => {
         appWrite = runtime.writeArtifactForCurrentRun(sessionId, {
           filename: 'late.txt',
           content: 'accepted before stop',
-          mimeType: 'text/plain'
+          mimeType: 'text/plain',
+          producer: {
+            kind: 'connector',
+            connectorId: 'molecule',
+            toolId: 'preview_molecule',
+            invocationId: 'connector-call-late',
+            implementationVersion: '1',
+            normalizedArguments: { filename: 'late.txt' }
+          }
         })
         await writeStarted.promise
       }
@@ -20261,6 +20285,14 @@ describe('ACP runtime session management', () => {
     const claim = resolveArtifactRunClaim(runtime, artifactClaimId!)
     const version = await client.artifactVersion.findFirstOrThrow({
       where: { artifactRunId: claim.runId }
+    })
+    expect(JSON.parse(version.evidenceJson)).toMatchObject({
+      producer: {
+        state: 'available',
+        kind: 'connector',
+        connector_id: 'molecule',
+        invocation_id: 'connector-call-late'
+      }
     })
     expect(claim.artifactVersionIds).toEqual([version.id])
     await expect(
@@ -20479,7 +20511,15 @@ describe('ACP runtime session management', () => {
           await runtime.writeArtifactForCurrentRun(sessionId, {
             filename: 'sin.txt',
             content: 'restored-session-image',
-            mimeType: 'text/plain'
+            mimeType: 'text/plain',
+            producer: {
+              kind: 'connector',
+              connectorId: 'molecule',
+              toolId: 'preview_molecule',
+              invocationId: 'connector-call-restored',
+              implementationVersion: '1',
+              normalizedArguments: { filename: 'sin.txt' }
+            }
           })
         } catch (error) {
           writeError = error
@@ -20660,9 +20700,17 @@ describe('ACP runtime session management', () => {
     })
 
     expect(finalized).toEqual([expect.objectContaining({ name: 'sin.txt' })])
-    await expect(
-      client.artifactVersion.findFirstOrThrow({ where: { artifactRunId: claim.runId } })
-    ).resolves.toMatchObject({ state: 'finalized', messageId: 'assistant-current' })
+    const finalizedVersion = await client.artifactVersion.findFirstOrThrow({
+      where: { artifactRunId: claim.runId }
+    })
+    expect(finalizedVersion).toMatchObject({ state: 'finalized', messageId: 'assistant-current' })
+    expect(JSON.parse(finalizedVersion.evidenceJson)).toMatchObject({
+      producer: {
+        state: 'available',
+        kind: 'connector',
+        invocation_id: 'connector-call-restored'
+      }
+    })
   })
 
   it('emits an artifact event for pending files even when the prompt fails', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -71,7 +71,10 @@ import { opencodeStorageDir } from '../agent-framework/opencode'
 import type { UploadRepository } from '../uploads/repository'
 import type { UploadedAttachment } from '../../shared/uploads'
 import type { ArtifactFile, FileReference } from '../../shared/artifacts'
-import type { ArtifactRpcCapabilityBinding } from '../../shared/artifact-provenance'
+import type {
+  AppGeneratedArtifactProducer,
+  ArtifactRpcCapabilityBinding
+} from '../../shared/artifact-provenance'
 import type { HistoryReplayDescriptor } from '../../shared/history-preamble'
 import type { AcpRuntimeActivity, AcpRuntimeActivityOptions } from './runtime-activity'
 import type { AcpAppContinuationOwner } from './app-continuation-owner'
@@ -2150,6 +2153,7 @@ class AcpRuntime {
       filename: string
       content: string
       mimeType?: string
+      producer?: AppGeneratedArtifactProducer
     }
   ): Promise<ArtifactFile> {
     if (!this.artifactTurns) {

--- a/src/main/artifacts/code-reconstruction.ts
+++ b/src/main/artifacts/code-reconstruction.ts
@@ -11,6 +11,7 @@ import type {
   ProvenanceNotebookOutput,
   ProvenanceNotebookRun
 } from '../../shared/artifact-provenance'
+import { isArtifactNotebookProducer } from '../../shared/artifact-provenance'
 import type { NotebookKernelKind } from '../../shared/notebook'
 import type { AgentFrameworkId } from '../../shared/settings'
 import type { ExplicitAgentBackendTarget } from '../settings/backend-resolver'
@@ -181,7 +182,7 @@ const sourceState = (
     return { state: 'unavailable', reason: 'execution-unavailable' }
   }
   const producer = provenance.evidence.producer
-  if (producer.state !== 'available') {
+  if (!isArtifactNotebookProducer(producer)) {
     return { state: 'unavailable', reason: 'producer-unavailable' }
   }
   const producerRun = provenance.execution.runs.find(

--- a/src/main/artifacts/provenance-canonical.ts
+++ b/src/main/artifacts/provenance-canonical.ts
@@ -3,6 +3,25 @@ import { createHash } from 'node:crypto'
 type CanonicalJson =
   null | boolean | number | string | CanonicalJson[] | { [key: string]: CanonicalJson }
 
+const isCanonicalJsonValue = (value: unknown, seen: Set<object> = new Set()): boolean => {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'boolean' ||
+    (typeof value === 'number' && Number.isFinite(value))
+  ) {
+    return true
+  }
+  if (typeof value !== 'object' || seen.has(value)) return false
+  seen.add(value)
+  const valid = Array.isArray(value)
+    ? value.every((entry) => isCanonicalJsonValue(entry, seen))
+    : Object.getPrototypeOf(value) === Object.prototype &&
+      Object.values(value).every((entry) => isCanonicalJsonValue(entry, seen))
+  seen.delete(value)
+  return valid
+}
+
 const canonicalize = (value: CanonicalJson): CanonicalJson => {
   if (Array.isArray(value)) return value.map(canonicalize)
   if (value === null || typeof value !== 'object') return value
@@ -17,5 +36,5 @@ const canonicalize = (value: CanonicalJson): CanonicalJson => {
 const canonicalJson = (value: CanonicalJson): string => JSON.stringify(canonicalize(value))
 const sha256 = (value: Buffer | string): string => createHash('sha256').update(value).digest('hex')
 
-export { canonicalJson, sha256 }
+export { canonicalJson, isCanonicalJsonValue, sha256 }
 export type { CanonicalJson }

--- a/src/main/artifacts/provenance-core-evidence.ts
+++ b/src/main/artifacts/provenance-core-evidence.ts
@@ -1,6 +1,10 @@
 import type { Prisma } from '@prisma/client'
 
 import type { ArtifactVersionEvidence } from '../../shared/artifact-provenance'
+import {
+  connectorEvidenceIsValid,
+  isConnectorProducerEvidence
+} from './provenance-producer-capture'
 
 type CoreEvidenceVersion = Prisma.ArtifactVersionGetPayload<{
   include: { artifact: true; inputs: true }
@@ -40,18 +44,29 @@ const validateArtifactCoreEvidence = (
   version: CoreEvidenceVersion
 ): void => {
   const producer = evidence.producer
+  const connectorProducer = isConnectorProducerEvidence(producer)
   const producerValid =
     version.producerRunId === null
-      ? version.notebookSessionId === null &&
-        version.producerRunIndex === null &&
-        version.executionSnapshotChecksum === null &&
-        evidence.execution_snapshot_checksum === undefined &&
-        evidence.reproduction_code === undefined &&
-        producer.state === 'unavailable' &&
-        evidence.execution_status.state === 'unavailable' &&
-        evidence.execution_status.reason === producer.reason &&
-        evidence.inputs.length === 0
+      ? connectorProducer
+        ? version.notebookSessionId === null &&
+          version.producerRunIndex === null &&
+          version.executionSnapshotChecksum === null &&
+          evidence.execution_snapshot_checksum === undefined &&
+          evidence.reproduction_code === undefined &&
+          evidence.execution_status.state === 'partial' &&
+          connectorEvidenceIsValid(evidence)
+        : version.notebookSessionId === null &&
+          version.producerRunIndex === null &&
+          version.executionSnapshotChecksum === null &&
+          evidence.execution_snapshot_checksum === undefined &&
+          evidence.connector_execution === undefined &&
+          evidence.reproduction_code === undefined &&
+          producer.state === 'unavailable' &&
+          evidence.execution_status.state === 'unavailable' &&
+          evidence.execution_status.reason === producer.reason &&
+          evidence.inputs.length === 0
       : producer.state === 'available' &&
+        !connectorProducer &&
         producer.notebook_session_id === version.notebookSessionId &&
         producer.producer_run_id === version.producerRunId &&
         producer.run_index === version.producerRunIndex &&
@@ -60,15 +75,18 @@ const validateArtifactCoreEvidence = (
         typeof evidence.reproduction_code === 'string'
   const environmentValid = evidence.environment
     ? producer.state === 'available' &&
+      !connectorProducer &&
       producer.environment_manifest_checksum === evidence.environment.source_manifest_checksum &&
       evidence.environment_status.state ===
         (evidence.environment.capture_status === 'complete' ? 'available' : 'partial') &&
       evidence.environment.complete === (evidence.environment.capture_status === 'complete')
     : evidence.environment_status.state === 'unavailable' &&
-      (producer.state === 'unavailable'
-        ? evidence.environment_status.reason === producer.reason
-        : producer.environment_manifest_checksum === undefined &&
-          ENVIRONMENT_UNAVAILABLE_REASONS.has(evidence.environment_status.reason))
+      (connectorProducer
+        ? evidence.environment_status.reason === 'environment-not-supported'
+        : producer.state === 'unavailable'
+          ? evidence.environment_status.reason === producer.reason
+          : producer.environment_manifest_checksum === undefined &&
+            ENVIRONMENT_UNAVAILABLE_REASONS.has(evidence.environment_status.reason))
   const inputsValid =
     evidence.inputs.length === version.inputs.length &&
     evidence.inputs.every((input, ordinal) => {

--- a/src/main/artifacts/provenance-execution-evidence.ts
+++ b/src/main/artifacts/provenance-execution-evidence.ts
@@ -6,6 +6,7 @@ import type {
   ProvenanceNotebookOutput,
   ProvenanceNotebookRun
 } from '../../shared/artifact-provenance'
+import { isArtifactNotebookProducer } from '../../shared/artifact-provenance'
 import type {
   NotebookEnvironmentManifest,
   NotebookEnvironmentPackage,
@@ -467,7 +468,7 @@ const validateArtifactExecutionSnapshot = (
     snapshot.producerRunId !== expected.producerRunId ||
     snapshot.producerRunIndex !== expected.producerRunIndex ||
     expected.evidence.execution_snapshot_checksum !== expected.executionSnapshotChecksum ||
-    producer.state !== 'available' ||
+    !isArtifactNotebookProducer(producer) ||
     producer.producer_run_id !== expected.producerRunId ||
     producer.run_index !== expected.producerRunIndex ||
     snapshot.runs.length === 0 ||

--- a/src/main/artifacts/provenance-message-finalization.ts
+++ b/src/main/artifacts/provenance-message-finalization.ts
@@ -13,6 +13,7 @@ import {
   parseArtifactExecutionSnapshot,
   validateArtifactExecutionSnapshot
 } from './provenance-execution-evidence'
+import { connectorEvidenceIsValid } from './provenance-producer-capture'
 import type { PersistedVersionFileRecord } from './provenance-version-writer'
 
 const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
@@ -225,7 +226,16 @@ const validateArtifactFinalizationProof = (
           evidence.inputs.length === 0 &&
           evidence.execution_snapshot_checksum === undefined &&
           evidence.reproduction_code === undefined
-        if (hasProducerOrExecutionFields || !isProvenUnavailableWithoutExecution) {
+        const isProvenConnectorWithoutNotebookExecution =
+          evidence.execution_status?.state === 'partial' &&
+          Array.isArray(evidence.inputs) &&
+          evidence.execution_snapshot_checksum === undefined &&
+          evidence.reproduction_code === undefined &&
+          connectorEvidenceIsValid(evidence)
+        if (
+          hasProducerOrExecutionFields ||
+          (!isProvenUnavailableWithoutExecution && !isProvenConnectorWithoutNotebookExecution)
+        ) {
           throw new ArtifactFinalizationProofError(
             'execution-snapshot-missing',
             `Artifact Version execution snapshot is missing: ${version.id}`

--- a/src/main/artifacts/provenance-producer-capture.ts
+++ b/src/main/artifacts/provenance-producer-capture.ts
@@ -4,6 +4,8 @@ import { isAbsolute, relative, resolve, sep } from 'node:path'
 import type { Prisma } from '@prisma/client'
 
 import type {
+  AppGeneratedArtifactProducer,
+  ArtifactConnectorArgumentValue,
   ArtifactProducerUnavailableReason,
   ArtifactVersionEvidence,
   CreateArtifactVersionRequest
@@ -16,13 +18,84 @@ import type {
 } from '../../shared/notebook'
 import type { ImmutableInputAuthority } from '../immutable-input-authority'
 import { NotebookRunRepository } from '../notebook/repository'
-import { canonicalJson, sha256, type CanonicalJson } from './provenance-canonical'
+import {
+  canonicalJson,
+  isCanonicalJsonValue,
+  sha256,
+  type CanonicalJson
+} from './provenance-canonical'
 import {
   buildBoundedExecutionSnapshot,
   environmentEvidence,
   inputEvidence,
   resolveRunEnvironmentCapture
 } from './provenance-execution-evidence'
+
+const CONNECTOR_ARGUMENTS_MAX_BYTES = 64 * 1024
+const CONNECTOR_IDENTITY_MAX_LENGTH = 256
+
+const isConnectorProducerEvidence = (
+  producer: ArtifactVersionEvidence['producer']
+): producer is Extract<ArtifactVersionEvidence['producer'], { kind: 'connector' }> =>
+  producer.state === 'available' && 'kind' in producer && producer.kind === 'connector'
+
+const prepareConnectorExecution = (
+  producer: AppGeneratedArtifactProducer
+): {
+  normalizedArguments: { [key: string]: ArtifactConnectorArgumentValue }
+  argumentsChecksum: string
+} => {
+  const identities = [
+    ['id', producer.connectorId],
+    ['tool id', producer.toolId],
+    ['invocation id', producer.invocationId],
+    ['implementation version', producer.implementationVersion]
+  ] as const
+  for (const [label, value] of identities) {
+    if (
+      value.length === 0 ||
+      value.length > CONNECTOR_IDENTITY_MAX_LENGTH ||
+      Array.from(value).some((character) => {
+        const codePoint = character.codePointAt(0) ?? 0
+        return codePoint <= 0x1f || codePoint === 0x7f
+      })
+    ) {
+      throw new Error(`Invalid Connector ${label}.`)
+    }
+  }
+  if (!isCanonicalJsonValue(producer.normalizedArguments)) {
+    throw new Error('Connector normalized arguments must be finite canonical JSON values.')
+  }
+  const serialized = canonicalJson(producer.normalizedArguments as CanonicalJson)
+  if (Buffer.byteLength(serialized, 'utf8') > CONNECTOR_ARGUMENTS_MAX_BYTES) {
+    throw new Error('Connector normalized arguments exceed the provenance evidence limit.')
+  }
+  return {
+    normalizedArguments: JSON.parse(serialized) as {
+      [key: string]: ArtifactConnectorArgumentValue
+    },
+    argumentsChecksum: sha256(serialized)
+  }
+}
+
+const connectorEvidenceIsValid = (evidence: ArtifactVersionEvidence): boolean => {
+  const producer = evidence.producer
+  const execution = evidence.connector_execution
+  if (
+    !isConnectorProducerEvidence(producer) ||
+    !execution ||
+    execution.schema_version !== 1 ||
+    !isCanonicalJsonValue(execution.normalized_arguments)
+  ) {
+    return false
+  }
+  const serialized = canonicalJson(execution.normalized_arguments as CanonicalJson)
+  return (
+    Buffer.byteLength(serialized, 'utf8') <= CONNECTOR_ARGUMENTS_MAX_BYTES &&
+    sha256(serialized) === execution.arguments_checksum &&
+    execution.arguments_checksum === producer.arguments_checksum
+  )
+}
 
 type ArtifactVersionProducerCapture =
   | {
@@ -31,6 +104,7 @@ type ArtifactVersionProducerCapture =
     }
   | {
       state: 'available'
+      kind: 'notebook'
       notebookSessionId: string
       producerRunId: string
       producerRunIndex: number
@@ -44,6 +118,17 @@ type ArtifactVersionProducerCapture =
       environmentCapture: NotebookRunEnvironmentCapture
       environmentManifest?: NotebookEnvironmentManifest
       environmentManifestChecksum?: string
+    }
+  | {
+      state: 'available'
+      kind: 'connector'
+      connectorId: string
+      toolId: string
+      invocationId: string
+      implementationVersion: string
+      normalizedArguments: AppGeneratedArtifactProducer['normalizedArguments']
+      argumentsChecksum: string
+      inputFiles: NotebookRunInputFile[]
     }
 
 type PreparedArtifactVersionPersistence = {
@@ -88,8 +173,25 @@ class ArtifactProvenanceProducerCapture {
   async captureProducer(
     request: CreateArtifactVersionRequest,
     createdAt: Date,
-    artifactChecksum: string
+    artifactChecksum: string,
+    appGeneratedProducer?: AppGeneratedArtifactProducer
   ): Promise<ArtifactVersionProducerCapture> {
+    if (appGeneratedProducer) {
+      const execution = prepareConnectorExecution(appGeneratedProducer)
+      const inputFiles = appGeneratedProducer.inputFiles ?? []
+      await this.validateInputReferences(request.projectId, inputFiles, 'Connector')
+      return {
+        state: 'available',
+        kind: 'connector',
+        connectorId: appGeneratedProducer.connectorId,
+        toolId: appGeneratedProducer.toolId,
+        invocationId: appGeneratedProducer.invocationId,
+        implementationVersion: appGeneratedProducer.implementationVersion,
+        normalizedArguments: execution.normalizedArguments,
+        argumentsChecksum: execution.argumentsChecksum,
+        inputFiles
+      }
+    }
     // Local files require an app-side observation before an Agent-declared run may become evidence.
     // Inline bytes have no file observation, so they retain the declared run only after the durable
     // Notebook Session and graph-scope checks below succeed.
@@ -235,6 +337,7 @@ class ArtifactProvenanceProducerCapture {
 
     return {
       state: 'available',
+      kind: 'notebook',
       notebookSessionId: request.notebookSessionId,
       producerRunId,
       producerRunIndex,
@@ -267,6 +370,9 @@ class ArtifactProvenanceProducerCapture {
     sizeBytes,
     createdAt
   }: PrepareVersionPersistenceInput): PreparedArtifactVersionPersistence {
+    const notebookProducer = producer.state === 'available' && producer.kind === 'notebook'
+    const connectorProducer = producer.state === 'available' && producer.kind === 'connector'
+    const producerInputs = producer.state === 'available' ? producer.inputFiles : []
     const evidence: ArtifactVersionEvidence = {
       app_session_id: request.appSessionId,
       artifact_id: artifactId,
@@ -283,12 +389,12 @@ class ArtifactProvenanceProducerCapture {
       environment_status:
         producer.state !== 'available'
           ? { reason: producer.reason, state: 'unavailable' }
-          : producer.environmentCapture.state === 'unavailable'
-            ? { reason: producer.environmentCapture.reason, state: 'unavailable' }
-            : { state: producer.environmentCapture.state },
-      ...(producer.state === 'available' &&
-      producer.environmentManifest &&
-      producer.environmentManifestChecksum
+          : connectorProducer
+            ? { reason: 'environment-not-supported', state: 'unavailable' }
+            : producer.environmentCapture.state === 'unavailable'
+              ? { reason: producer.environmentCapture.reason, state: 'unavailable' }
+              : { state: producer.environmentCapture.state },
+      ...(notebookProducer && producer.environmentManifest && producer.environmentManifestChecksum
         ? {
             environment: environmentEvidence(
               producer.environmentManifest,
@@ -297,38 +403,56 @@ class ArtifactProvenanceProducerCapture {
           }
         : {}),
       execution_status:
-        producer.state === 'available'
-          ? { state: 'available' }
-          : { reason: producer.reason, state: 'unavailable' },
+        producer.state !== 'available'
+          ? { reason: producer.reason, state: 'unavailable' }
+          : connectorProducer
+            ? { state: 'partial' }
+            : { state: 'available' },
       ...(producer.state === 'available'
-        ? {
-            execution_snapshot_checksum: producer.executionChecksum,
-            reproduction_code: producer.reproductionCode
-          }
+        ? notebookProducer
+          ? {
+              execution_snapshot_checksum: producer.executionChecksum,
+              reproduction_code: producer.reproductionCode
+            }
+          : {
+              connector_execution: {
+                schema_version: 1,
+                normalized_arguments: producer.normalizedArguments,
+                arguments_checksum: producer.argumentsChecksum
+              }
+            }
         : {}),
       filename: request.filename,
-      inputs:
-        producer.state === 'available'
-          ? producer.inputFiles.map((input, ordinal) => inputEvidence(input, ordinal))
-          : [],
+      inputs: producerInputs.map((input, ordinal) => inputEvidence(input, ordinal)),
       is_user_upload: false,
       ...(request.agentName ? { agent_name: request.agentName } : {}),
       producer:
-        producer.state === 'available'
-          ? {
-              association_method: producer.associationMethod,
-              kernel_kind: producer.kernelKind,
-              notebook_session_id: producer.notebookSessionId,
-              producer_run_id: producer.producerRunId,
-              run_index: producer.producerRunIndex,
-              ...(producer.environmentCapture.state !== 'unavailable'
-                ? {
-                    environment_manifest_checksum: producer.environmentCapture.manifestChecksum
-                  }
-                : {}),
-              state: 'available'
-            }
-          : { reason: producer.reason, state: 'unavailable' },
+        producer.state === 'unavailable'
+          ? { reason: producer.reason, state: 'unavailable' }
+          : producer.kind === 'notebook'
+            ? {
+                association_method: producer.associationMethod,
+                kernel_kind: producer.kernelKind,
+                notebook_session_id: producer.notebookSessionId,
+                producer_run_id: producer.producerRunId,
+                run_index: producer.producerRunIndex,
+                ...(producer.environmentCapture.state !== 'unavailable'
+                  ? {
+                      environment_manifest_checksum: producer.environmentCapture.manifestChecksum
+                    }
+                  : {}),
+                state: 'available'
+              }
+            : {
+                state: 'available',
+                kind: 'connector',
+                connector_id: producer.connectorId,
+                tool_id: producer.toolId,
+                invocation_id: producer.invocationId,
+                implementation_version: producer.implementationVersion,
+                arguments_checksum: producer.argumentsChecksum,
+                association_method: 'app-owned-handler'
+              },
       project_id: request.projectId,
       schema_version: 1,
       size_bytes: sizeBytes,
@@ -337,18 +461,17 @@ class ArtifactProvenanceProducerCapture {
     }
     const evidenceJson = canonicalJson(evidence as unknown as CanonicalJson)
     return {
-      notebookSessionId: producer.state === 'available' ? producer.notebookSessionId : undefined,
-      producerRunId: producer.state === 'available' ? producer.producerRunId : undefined,
-      producerRunIndex: producer.state === 'available' ? producer.producerRunIndex : undefined,
+      notebookSessionId: notebookProducer ? producer.notebookSessionId : undefined,
+      producerRunId: notebookProducer ? producer.producerRunId : undefined,
+      producerRunIndex: notebookProducer ? producer.producerRunIndex : undefined,
       evidenceJson,
       evidenceChecksum: sha256(evidenceJson),
-      executionSnapshotJson: producer.state === 'available' ? producer.executionJson : undefined,
-      executionSnapshotChecksum:
-        producer.state === 'available' ? producer.executionChecksum : undefined,
-      ...(producer.state === 'available' && producer.inputFiles.length > 0
+      executionSnapshotJson: notebookProducer ? producer.executionJson : undefined,
+      executionSnapshotChecksum: notebookProducer ? producer.executionChecksum : undefined,
+      ...(producerInputs.length > 0
         ? {
             inputs: {
-              create: producer.inputFiles.map((input, ordinal) => ({
+              create: producerInputs.map((input, ordinal) => ({
                 id: this.options.createId(),
                 ordinal,
                 inputFileVersionId: input.inputFileVersionId,
@@ -509,20 +632,25 @@ class ArtifactProvenanceProducerCapture {
 
   private async validateInputReferences(
     projectId: string,
-    inputs: NotebookRunInputFile[]
+    inputs: NotebookRunInputFile[],
+    producerLabel = 'Notebook'
   ): Promise<void> {
     for (const input of inputs) {
       const validation = await this.options.inputAuthority.validateVersion(projectId, input)
       if (validation.state === 'project-mismatch') {
-        throw new Error(`Notebook input belongs to another Project: ${input.inputFileVersionId}`)
+        throw new Error(
+          `${producerLabel} input belongs to another Project: ${input.inputFileVersionId}`
+        )
       }
       if (validation.state !== 'available') {
         const label = input.sourceKind === 'upload-version' ? 'Upload' : 'Artifact'
-        throw new Error(`Notebook ${label} input identity is corrupt: ${input.inputFileVersionId}`)
+        throw new Error(
+          `${producerLabel} ${label} input identity is corrupt: ${input.inputFileVersionId}`
+        )
       }
     }
   }
 }
 
-export { ArtifactProvenanceProducerCapture }
+export { ArtifactProvenanceProducerCapture, connectorEvidenceIsValid, isConnectorProducerEvidence }
 export type { ArtifactVersionProducerCapture, PreparedArtifactVersionPersistence }

--- a/src/main/artifacts/provenance-repository.test.ts
+++ b/src/main/artifacts/provenance-repository.test.ts
@@ -665,6 +665,320 @@ describe('artifact provenance repository', () => {
     })
   })
 
+  it('persists a trusted app-owned Connector execution receipt with its generated Version', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-connector-provenance-'))
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+    await migrateApplicationDatabase(client)
+    const repository = new ArtifactProvenanceRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client),
+      compatibilityRepository: new ArtifactRepository(storageRoot)
+    })
+    const normalizedArguments = {
+      filename: 'caffeine',
+      smiles: 'CN1C=NC2=C1C(=O)N(C(=O)N2C)C'
+    }
+    const argumentsChecksum = createHash('sha256')
+      .update(JSON.stringify(normalizedArguments))
+      .digest('hex')
+
+    const version = await repository.writeAppGeneratedVersion({
+      projectId: 'project-1',
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-1',
+      artifactRunId: 'artifact-run-1',
+      rootFrameId: 'root-frame-1',
+      agentFrameId: 'agent-frame-1',
+      messageBranchId: 'branch-1',
+      runtimeSegmentId: 'runtime-segment-1',
+      promptMessageId: 'prompt-1',
+      agentName: 'OpenCode',
+      filename: 'caffeine.mol',
+      content: 'generated molecule bytes',
+      contentType: 'chemical/x-mdl-molfile',
+      producer: {
+        kind: 'connector',
+        connectorId: 'molecule',
+        toolId: 'preview_molecule',
+        invocationId: 'connector-call-1',
+        implementationVersion: '1',
+        normalizedArguments
+      }
+    })
+
+    await expect(
+      repository.getVersionProvenance({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactId: version.artifactId,
+        versionId: version.versionId
+      })
+    ).resolves.toMatchObject({
+      evidence: {
+        producer: {
+          state: 'available',
+          kind: 'connector',
+          connector_id: 'molecule',
+          tool_id: 'preview_molecule',
+          invocation_id: 'connector-call-1',
+          implementation_version: '1',
+          arguments_checksum: argumentsChecksum,
+          association_method: 'app-owned-handler'
+        },
+        connector_execution: {
+          schema_version: 1,
+          normalized_arguments: normalizedArguments,
+          arguments_checksum: argumentsChecksum
+        },
+        execution_status: { state: 'partial' },
+        environment_status: { state: 'unavailable', reason: 'environment-not-supported' },
+        inputs: []
+      }
+    })
+  })
+
+  it('ignores Connector producer claims attached to the ordinary Artifact create request', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-untrusted-connector-provenance-'))
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+    await migrateApplicationDatabase(client)
+    const compatibilityRepository = new ArtifactRepository(storageRoot)
+    const repository = new ArtifactProvenanceRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client),
+      compatibilityRepository
+    })
+    await compatibilityRepository.writePendingFile({
+      projectId: 'project-1',
+      sessionId: 'artifact-session-1',
+      runId: 'artifact-run-1',
+      filename: 'untrusted.mol',
+      source: { kind: 'inline', content: 'untrusted bytes', encoding: 'utf8' }
+    })
+
+    const untrustedRequest = {
+      projectId: 'project-1',
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-1',
+      artifactRunId: 'artifact-run-1',
+      writeOperationId: 'write-1',
+      writeRequestChecksum: 'a'.repeat(64),
+      rootFrameId: 'root-frame-1',
+      agentFrameId: 'agent-frame-1',
+      messageBranchId: 'branch-1',
+      runtimeSegmentId: 'runtime-segment-1',
+      promptMessageId: 'prompt-1',
+      filename: 'untrusted.mol',
+      sourceKind: 'inline' as const,
+      producer: {
+        kind: 'connector',
+        connectorId: 'custom-mcp',
+        toolId: 'spoof_producer',
+        invocationId: 'untrusted-call-1',
+        implementationVersion: '1',
+        normalizedArguments: {}
+      }
+    }
+
+    const version = await repository.createVersion(untrustedRequest)
+
+    await expect(
+      repository.getVersionProvenance({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactId: version.artifactId,
+        versionId: version.versionId
+      })
+    ).resolves.toMatchObject({
+      evidence: {
+        producer: { state: 'unavailable', reason: 'producer-not-supplied' },
+        execution_status: { state: 'unavailable', reason: 'producer-not-supplied' }
+      }
+    })
+  })
+
+  it('links a verified Upload Version as an input to a Connector-generated Artifact Version', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-connector-upload-provenance-'))
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+    await migrateApplicationDatabase(client)
+    const repository = new ArtifactProvenanceRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client),
+      compatibilityRepository: new ArtifactRepository(storageRoot)
+    })
+    const inputContent = 'CC(=O)Oc1ccccc1C(=O)O\n'
+    const inputChecksum = createHash('sha256').update(inputContent).digest('hex')
+    const inputStorageKey =
+      'uploads/project-1/source-session/upload-1/versions/upload-version-1/content'
+    const inputPath = join(storageRoot, ...inputStorageKey.split('/'))
+    await mkdir(dirname(inputPath), { recursive: true })
+    await writeFile(inputPath, inputContent)
+    await client.fileOriginSession.create({
+      data: { projectId: 'project-1', sessionId: 'source-session' }
+    })
+    await client.uploadFile.create({
+      data: {
+        id: 'upload-1',
+        projectId: 'project-1',
+        sessionId: 'source-session',
+        filename: 'aspirin.smi',
+        originalFilename: 'aspirin.smi',
+        versions: {
+          create: {
+            id: 'upload-version-1',
+            versionNumber: 1,
+            state: 'ready',
+            contentStorageKey: inputStorageKey,
+            filename: 'aspirin.smi',
+            originalFilename: 'aspirin.smi',
+            contentType: 'chemical/x-daylight-smiles',
+            sizeBytes: BigInt(Buffer.byteLength(inputContent)),
+            checksum: inputChecksum,
+            createdAt: new Date('2026-08-20T06:00:00.000Z')
+          }
+        }
+      }
+    })
+
+    const version = await repository.writeAppGeneratedVersion({
+      projectId: 'project-1',
+      appSessionId: 'session-1',
+      artifactStorageSessionId: 'artifact-session-1',
+      artifactRunId: 'artifact-run-1',
+      rootFrameId: 'root-frame-1',
+      agentFrameId: 'agent-frame-1',
+      messageBranchId: 'branch-1',
+      runtimeSegmentId: 'runtime-segment-1',
+      promptMessageId: 'prompt-1',
+      filename: 'aspirin.mol',
+      content: 'generated molecule bytes',
+      contentType: 'chemical/x-mdl-molfile',
+      producer: {
+        kind: 'connector',
+        connectorId: 'molecule',
+        toolId: 'preview_molecule',
+        invocationId: 'connector-call-1',
+        implementationVersion: '1',
+        normalizedArguments: { filename: 'aspirin.mol' },
+        inputFiles: [
+          {
+            inputFileVersionId: 'upload-version-1',
+            sourceKind: 'upload-version',
+            sourceFileId: 'upload-1',
+            sourceVersionNumber: 1,
+            sourceCreatedAt: '2026-08-20T06:00:00.000Z',
+            sourceProjectId: 'project-1',
+            sourceSessionId: 'source-session',
+            filename: 'aspirin.smi',
+            contentType: 'chemical/x-daylight-smiles',
+            sizeBytes: Buffer.byteLength(inputContent),
+            checksum: inputChecksum,
+            storageKey: inputStorageKey,
+            association: 'resolver-accessed'
+          }
+        ]
+      }
+    })
+
+    await expect(
+      repository.readDependencyRelations({
+        projectId: 'project-1',
+        versionId: version.versionId,
+        direction: 'up'
+      })
+    ).resolves.toEqual([
+      {
+        versionId: version.versionId,
+        dependsOnVersionId: 'upload-version-1',
+        ordinal: 0,
+        sourceKind: 'upload-version',
+        inputFilename: 'aspirin.smi',
+        association: 'resolver-accessed'
+      }
+    ])
+    await expect(
+      repository.getVersionProvenance({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactId: version.artifactId,
+        versionId: version.versionId
+      })
+    ).resolves.toMatchObject({
+      evidence: {
+        inputs: [
+          {
+            input_file_version_id: 'upload-version-1',
+            source_kind: 'upload-version',
+            source_file_id: 'upload-1',
+            strongest_association: 'resolver-accessed'
+          }
+        ]
+      }
+    })
+  })
+
+  it('fails closed when a Connector claims an unverifiable Upload Version input', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-connector-upload-rejection-'))
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+    await migrateApplicationDatabase(client)
+    const repository = new ArtifactProvenanceRepository({
+      storageRoot,
+      getClient: () => Promise.resolve(client),
+      compatibilityRepository: new ArtifactRepository(storageRoot),
+      inputAuthority: {
+        validateVersion: async () => ({ state: 'unavailable' })
+      }
+    })
+
+    await expect(
+      repository.writeAppGeneratedVersion({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactStorageSessionId: 'artifact-session-1',
+        artifactRunId: 'artifact-run-1',
+        rootFrameId: 'root-frame-1',
+        agentFrameId: 'agent-frame-1',
+        messageBranchId: 'branch-1',
+        runtimeSegmentId: 'runtime-segment-1',
+        promptMessageId: 'prompt-1',
+        filename: 'aspirin.mol',
+        content: 'generated molecule bytes',
+        producer: {
+          kind: 'connector',
+          connectorId: 'molecule',
+          toolId: 'preview_molecule',
+          invocationId: 'connector-call-1',
+          implementationVersion: '1',
+          normalizedArguments: { filename: 'aspirin.mol' },
+          inputFiles: [
+            {
+              inputFileVersionId: 'missing-upload-version',
+              sourceKind: 'upload-version',
+              sourceFileId: 'upload-1',
+              sourceProjectId: 'project-1',
+              sourceSessionId: 'source-session',
+              filename: 'aspirin.smi',
+              sizeBytes: 1,
+              checksum: 'a'.repeat(64),
+              storageKey: 'uploads/untrusted/content',
+              association: 'resolver-accessed'
+            }
+          ]
+        }
+      })
+    ).rejects.toThrow('Connector Upload input identity is corrupt: missing-upload-version')
+    await expect(
+      repository.listRunVersions({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactRunId: 'artifact-run-1'
+      })
+    ).resolves.toEqual([])
+  })
+
   it('resolves finalized native Versions in first-occurrence request order without paths', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-artifact-version-descriptors-'))
     const client = createProjectDbClient(storageRoot)

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from 'node:url'
 import type { PrismaClient } from '@prisma/client'
 
 import type {
+  AppGeneratedArtifactProducer,
   ArtifactLineageProvenance,
   ArtifactVersionDescriptor,
   ArtifactVersionFile,
@@ -88,6 +89,7 @@ export type WriteAppGeneratedArtifactVersionRequest = Omit<
   content: string
   contentType?: string
   kind?: 'plan'
+  producer?: AppGeneratedArtifactProducer
 }
 
 type ArtifactStorageReconciliationResult = {
@@ -209,8 +211,8 @@ class ArtifactProvenanceRepository {
       durability: this.durability,
       resourceBudgets: options.resourceBudgets,
       writeBudgetOwner: this.writeBudgetOwner,
-      captureProducer: (request, createdAt, checksum) =>
-        this.producerCapture.captureProducer(request, createdAt, checksum),
+      captureProducer: (request, createdAt, checksum, appGeneratedProducer) =>
+        this.producerCapture.captureProducer(request, createdAt, checksum, appGeneratedProducer),
       prepareVersionPersistence: (input) => this.producerCapture.prepareVersionPersistence(input),
       recoverStagingVersion: (version, projectId, appSessionId, filename, publish) =>
         this.stagingRecovery.recoverVersion(version, projectId, appSessionId, filename, publish),
@@ -225,7 +227,7 @@ class ArtifactProvenanceRepository {
   async writeAppGeneratedVersion(
     request: WriteAppGeneratedArtifactVersionRequest
   ): Promise<ArtifactVersionFile> {
-    const { content, kind, ...versionRequest } = request
+    const { content, kind, producer, ...versionRequest } = request
     const writeOperationId = `artifact-app-write-${this.createId()}`
     const reservationScope = {
       projectId: request.projectId,
@@ -290,7 +292,9 @@ class ArtifactProvenanceRepository {
                 mimeType: version.contentType ?? undefined
               },
               resolveStorageKey(this.options.storageRoot, version.contentStorageKey)
-            )
+            ),
+          undefined,
+          producer
         )
       }
     )

--- a/src/main/artifacts/provenance-version-writer.ts
+++ b/src/main/artifacts/provenance-version-writer.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path'
 import type { PrismaClient } from '@prisma/client'
 
 import type {
+  AppGeneratedArtifactProducer,
   ArtifactVersionFile,
   CreateArtifactVersionRequest
 } from '../../shared/artifact-provenance'
@@ -125,7 +126,8 @@ type ArtifactProvenanceVersionWriterOptions = {
   captureProducer: (
     request: CreateArtifactVersionRequest,
     createdAt: Date,
-    artifactChecksum: string
+    artifactChecksum: string,
+    appGeneratedProducer?: AppGeneratedArtifactProducer
   ) => Promise<ArtifactVersionProducerCapture>
   prepareVersionPersistence: (input: {
     request: CreateArtifactVersionRequest
@@ -161,7 +163,8 @@ class ArtifactProvenanceVersionWriter {
   async writeVersion(
     request: CreateArtifactVersionRequest,
     publishCompatibilityRouting: PublishCompatibilityRouting,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    appGeneratedProducer?: AppGeneratedArtifactProducer
   ): Promise<ArtifactVersionFile> {
     if (request.resourceReservationId) {
       if (
@@ -188,7 +191,12 @@ class ArtifactProvenanceVersionWriter {
 
     let version: ArtifactVersionFile
     try {
-      version = await this.writeVersionWithinSession(request, publishCompatibilityRouting, signal)
+      version = await this.writeVersionWithinSession(
+        request,
+        publishCompatibilityRouting,
+        signal,
+        appGeneratedProducer
+      )
     } catch (error) {
       if (request.resourceReservationId) {
         try {
@@ -221,7 +229,8 @@ class ArtifactProvenanceVersionWriter {
   private async writeVersionWithinSession(
     request: CreateArtifactVersionRequest,
     publishCompatibilityRouting: PublishCompatibilityRouting,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    appGeneratedProducer?: AppGeneratedArtifactProducer
   ): Promise<ArtifactVersionFile> {
     const sessionKey = `${this.options.storageRoot}\0${request.projectId}\0${request.appSessionId}`
     const previous =
@@ -235,7 +244,12 @@ class ArtifactProvenanceVersionWriter {
     await previous
 
     try {
-      return await this.writeVersionSerialized(request, publishCompatibilityRouting, signal)
+      return await this.writeVersionSerialized(
+        request,
+        publishCompatibilityRouting,
+        signal,
+        appGeneratedProducer
+      )
     } finally {
       release()
       if (ArtifactProvenanceVersionWriter.sessionWrites.get(sessionKey) === tail) {
@@ -247,7 +261,8 @@ class ArtifactProvenanceVersionWriter {
   private async writeVersionSerialized(
     request: CreateArtifactVersionRequest,
     publishCompatibilityRouting: PublishCompatibilityRouting,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    appGeneratedProducer?: AppGeneratedArtifactProducer
   ): Promise<ArtifactVersionFile> {
     const projectId = assertSafeSegment(request.projectId, 'project id')
     const appSessionId = assertSafeSegment(request.appSessionId, 'session id')
@@ -354,7 +369,12 @@ class ArtifactProvenanceVersionWriter {
         throw new Error('Artifact write reservation checksum does not match staged content.')
       }
       const createdAt = this.options.now()
-      const producer = await this.options.captureProducer(request, createdAt, checksum)
+      const producer = await this.options.captureProducer(
+        request,
+        createdAt,
+        checksum,
+        appGeneratedProducer
+      )
       const persisted = await withVersionAllocationRetry(() =>
         client.$transaction(async (transaction) => {
           const origin = await transaction.fileOriginSession.upsert({

--- a/src/main/connectors/descriptors/molecule.ts
+++ b/src/main/connectors/descriptors/molecule.ts
@@ -118,7 +118,7 @@ export const MOLECULE_TOOLS: ToolDescriptor[] = [
       'Validate a 2D chemical structure and open it in the preview panel in one call. Pass a `smiles` or a `molfile`; the structure is saved as a canonical .mol artifact this turn and rendered read-only with OpenChemLib. Returns the saved artifact id. Call it during an assistant turn (the file is attached to the current turn).',
     input: STRUCTURE_INPUT_SCHEMA,
     returns:
-      '`{ "valid": bool, "artifact_id": str, "filename": str, "smiles": str, "formula": str, "molecular_weight": float, "heavy_atom_count": int }` on success. On an unparseable structure: `{ "valid": false, "error": str }`. The saved .mol artifact opens automatically in the preview panel.',
+      '`{ "valid": bool, "artifact_id": str, "version_id": str, "version_number": int, "filename": str, "smiles": str, "formula": str, "molecular_weight": float, "heavy_atom_count": int }` on success. `artifact_id` identifies the stable Artifact lineage; `version_id` identifies the immutable saved Version. On an unparseable structure: `{ "valid": false, "error": str }`. The saved .mol artifact opens automatically in the preview panel.',
     example:
       'const result = await host.mcp("molecule", "preview_molecule", {"smiles": "CC(=O)Oc1ccccc1C(=O)O", "filename": "aspirin"})',
     // The real write + preview is performed by the app runtime via ConnectorService.localToolHandlers;

--- a/src/main/connectors/molecule-preview.test.ts
+++ b/src/main/connectors/molecule-preview.test.ts
@@ -5,24 +5,47 @@ import { createMoleculePreviewHandler } from './molecule-preview'
 const ASPIRIN_SMILES = 'CC(=O)Oc1ccccc1C(=O)O'
 
 describe('molecule preview handler', () => {
-  it('validates a SMILES, writes a canonical .mol artifact, and returns its id', async () => {
+  it('returns the Artifact lineage id separately from the immutable Version identity', async () => {
     const writeArtifactForCurrentRun = vi.fn().mockResolvedValue({
-      id: 'session:run:aspirin.mol',
+      id: 'version-1',
+      artifactId: 'artifact-1',
+      versionId: 'version-1',
+      versionNumber: 1,
       name: 'aspirin.mol',
       path: '/artifacts/aspirin.mol'
     })
-    const handler = createMoleculePreviewHandler({ writeArtifactForCurrentRun })
+    const handler = createMoleculePreviewHandler(
+      { writeArtifactForCurrentRun },
+      { createInvocationId: () => 'connector-call-1' }
+    )
 
     const out = await handler({ smiles: ASPIRIN_SMILES, filename: 'aspirin' }, { sessionId: 's-1' })
 
     expect(writeArtifactForCurrentRun).toHaveBeenCalledTimes(1)
     const [sessionId, written] = writeArtifactForCurrentRun.mock.calls[0]
     expect(sessionId).toBe('s-1')
-    expect(written).toMatchObject({ filename: 'aspirin.mol', mimeType: 'chemical/x-mdl-molfile' })
+    expect(written).toMatchObject({
+      filename: 'aspirin.mol',
+      mimeType: 'chemical/x-mdl-molfile',
+      producer: {
+        kind: 'connector',
+        connectorId: 'molecule',
+        toolId: 'preview_molecule',
+        invocationId: 'connector-call-1',
+        implementationVersion: '1',
+        normalizedArguments: {
+          inputKind: 'smiles',
+          filename: 'aspirin.mol',
+          smiles: 'CC(OC1=CC=CC=C1C(O)=O)=O'
+        }
+      }
+    })
     expect(written.content).toContain('V2000')
     expect(out).toMatchObject({
       valid: true,
-      artifact_id: 'session:run:aspirin.mol',
+      artifact_id: 'artifact-1',
+      version_id: 'version-1',
+      version_number: 1,
       filename: 'aspirin.mol',
       formula: 'C9H8O4'
     })

--- a/src/main/connectors/molecule-preview.ts
+++ b/src/main/connectors/molecule-preview.ts
@@ -1,4 +1,8 @@
+import { randomUUID } from 'node:crypto'
+
 import { renderMoleculeStructure } from './descriptors/molecule'
+import type { ArtifactFile } from '../../shared/artifacts'
+import type { AppGeneratedArtifactProducer } from '../../shared/artifact-provenance'
 
 // Minimal view of the app runtime's artifact writer, so the handler stays testable with a fake. The
 // session id routes the write to the run of the session that invoked the tool.
@@ -9,8 +13,9 @@ export type MoleculeArtifactWriter = {
       filename: string
       content: string
       mimeType?: string
+      producer?: AppGeneratedArtifactProducer
     }
-  ): Promise<{ id: string; name: string; path: string }>
+  ): Promise<ArtifactFile>
 }
 
 const MOLFILE_MIME = 'chemical/x-mdl-molfile'
@@ -19,7 +24,7 @@ const MOLFILE_MIME = 'chemical/x-mdl-molfile'
 // then save it as a canonical .mol artifact on the current turn. The saved molecule-format artifact is
 // auto-opened in the preview panel by the renderer (workspace-events), so no extra IPC is needed.
 export const createMoleculePreviewHandler =
-  (writer: MoleculeArtifactWriter) =>
+  (writer: MoleculeArtifactWriter, options: { createInvocationId?: () => string } = {}) =>
   async (
     args: Record<string, unknown>,
     context: { sessionId?: string } = {},
@@ -40,12 +45,26 @@ export const createMoleculePreviewHandler =
     const artifact = await writer.writeArtifactForCurrentRun(context.sessionId, {
       filename: result.filename_suggestion,
       content: result.molfile,
-      mimeType: MOLFILE_MIME
+      mimeType: MOLFILE_MIME,
+      producer: {
+        kind: 'connector',
+        connectorId: 'molecule',
+        toolId: 'preview_molecule',
+        invocationId: (options.createInvocationId ?? randomUUID)(),
+        implementationVersion: '1',
+        normalizedArguments: {
+          inputKind: typeof args.smiles === 'string' ? 'smiles' : 'molfile',
+          filename: result.filename_suggestion,
+          smiles: result.smiles
+        }
+      }
     })
 
     return {
       valid: true,
-      artifact_id: artifact.id,
+      artifact_id: artifact.artifactId ?? artifact.id,
+      ...(artifact.versionId ? { version_id: artifact.versionId } : {}),
+      ...(artifact.versionNumber ? { version_number: artifact.versionNumber } : {}),
       filename: artifact.name,
       smiles: result.smiles,
       formula: result.formula,

--- a/src/main/notebook/host-lineage-service.ts
+++ b/src/main/notebook/host-lineage-service.ts
@@ -3,6 +3,7 @@ import type {
   ArtifactVersionEnvironmentEvidence,
   GetArtifactVersionProvenanceRequest
 } from '../../shared/artifact-provenance'
+import { isArtifactNotebookProducer } from '../../shared/artifact-provenance'
 import type {
   HostLineageDependencyRelation,
   HostLineageDirection,
@@ -124,17 +125,28 @@ const projectProducer = (
 ): HostLineageVersion['producer'] =>
   value.state === 'unavailable'
     ? { state: value.state, reason: value.reason }
-    : {
-        state: value.state,
-        notebook_session_id: value.notebook_session_id,
-        producer_run_id: value.producer_run_id,
-        run_index: value.run_index,
-        kernel_kind: value.kernel_kind,
-        association_method: value.association_method,
-        ...(value.environment_manifest_checksum
-          ? { environment_manifest_checksum: value.environment_manifest_checksum }
-          : {})
-      }
+    : isArtifactNotebookProducer(value)
+      ? {
+          state: value.state,
+          notebook_session_id: value.notebook_session_id,
+          producer_run_id: value.producer_run_id,
+          run_index: value.run_index,
+          kernel_kind: value.kernel_kind,
+          association_method: value.association_method,
+          ...(value.environment_manifest_checksum
+            ? { environment_manifest_checksum: value.environment_manifest_checksum }
+            : {})
+        }
+      : {
+          state: value.state,
+          kind: value.kind,
+          connector_id: value.connector_id,
+          tool_id: value.tool_id,
+          invocation_id: value.invocation_id,
+          implementation_version: value.implementation_version,
+          arguments_checksum: value.arguments_checksum,
+          association_method: value.association_method
+        }
 
 const projectEnvironment = (
   value: ArtifactVersionEnvironmentEvidence

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
@@ -31,6 +31,7 @@ import type {
   ProvenanceNotebookRun,
   ProvenanceMessage
 } from '../../../../shared/artifact-provenance'
+import { isArtifactNotebookProducer } from '../../../../shared/artifact-provenance'
 import type {
   ArtifactCodeReconstruction,
   ArtifactCodeReconstructionState
@@ -899,7 +900,10 @@ const ArtifactProvenancePanel = ({
   const downloadProducerCode = async (): Promise<void> => {
     if (!reproductionCode) return
     const evidenceProducer = provenance?.evidence.producer
-    const language = evidenceProducer?.state === 'available' ? evidenceProducer.kernel_kind : 'repl'
+    const language =
+      evidenceProducer && isArtifactNotebookProducer(evidenceProducer)
+        ? evidenceProducer.kernel_kind
+        : 'repl'
     await downloadScript(reproductionCode, language)
   }
 
@@ -1217,7 +1221,7 @@ const ArtifactProvenancePanel = ({
                   <NotebookCodeBlock
                     code={reproductionCode}
                     language={
-                      provenance.evidence.producer.state === 'available'
+                      isArtifactNotebookProducer(provenance.evidence.producer)
                         ? provenance.evidence.producer.kernel_kind
                         : undefined
                     }

--- a/src/shared/artifact-provenance.ts
+++ b/src/shared/artifact-provenance.ts
@@ -224,6 +224,59 @@ export type ArtifactVersionInputEvidence = {
   strongest_association: NotebookInputAssociation
 }
 
+export type ArtifactConnectorArgumentValue =
+  | null
+  | boolean
+  | number
+  | string
+  | ArtifactConnectorArgumentValue[]
+  | { [key: string]: ArtifactConnectorArgumentValue }
+
+// Only app-owned Connector handlers may supply this receipt. It is deliberately not part of the
+// Artifact MCP/RPC request so a model or custom MCP server cannot promote its own claims to trusted
+// producer evidence.
+export type AppGeneratedArtifactProducer = {
+  kind: 'connector'
+  connectorId: string
+  toolId: string
+  invocationId: string
+  implementationVersion: string
+  normalizedArguments: { [key: string]: ArtifactConnectorArgumentValue }
+  inputFiles?: NotebookRunInputFile[]
+}
+
+export type ArtifactConnectorExecutionEvidence = {
+  schema_version: 1
+  normalized_arguments: { [key: string]: ArtifactConnectorArgumentValue }
+  arguments_checksum: string
+}
+
+export type ArtifactNotebookProducerEvidence = {
+  state: 'available'
+  notebook_session_id: string
+  producer_run_id: string
+  run_index: number
+  kernel_kind: NotebookKernelKind
+  association_method: 'agent-declared-and-session-validated' | 'server-inferred-file-observation'
+  environment_manifest_checksum?: string
+}
+
+export type ArtifactConnectorProducerEvidence = {
+  state: 'available'
+  kind: 'connector'
+  connector_id: string
+  tool_id: string
+  invocation_id: string
+  implementation_version: string
+  arguments_checksum: string
+  association_method: 'app-owned-handler'
+}
+
+export const isArtifactNotebookProducer = (
+  producer: ArtifactVersionEvidence['producer']
+): producer is ArtifactNotebookProducerEvidence =>
+  producer.state === 'available' && !('kind' in producer)
+
 export type ArtifactVersionEnvironmentEvidence = {
   capture_kind: 'completed-run'
   environment_name: string
@@ -346,19 +399,12 @@ export type ArtifactVersionEvidence = {
   is_user_upload: false
   reproduction_code?: string
   execution_snapshot_checksum?: string
+  connector_execution?: ArtifactConnectorExecutionEvidence
   execution_status: ArtifactVersionAvailability
   inputs: ArtifactVersionInputEvidence[]
   producer:
-    | {
-        state: 'available'
-        notebook_session_id: string
-        producer_run_id: string
-        run_index: number
-        kernel_kind: NotebookKernelKind
-        association_method:
-          'agent-declared-and-session-validated' | 'server-inferred-file-observation'
-        environment_manifest_checksum?: string
-      }
+    | ArtifactNotebookProducerEvidence
+    | ArtifactConnectorProducerEvidence
     | { state: 'unavailable'; reason: ArtifactProducerUnavailableReason }
   environment?: ArtifactVersionEnvironmentEvidence
   environment_status: ArtifactVersionAvailability

--- a/src/shared/host-lineage.ts
+++ b/src/shared/host-lineage.ts
@@ -74,6 +74,16 @@ export type HostLineageVersion = {
         environment_manifest_checksum?: string
       }
     | {
+        state: 'available'
+        kind: 'connector'
+        connector_id: string
+        tool_id: string
+        invocation_id: string
+        implementation_version: string
+        arguments_checksum: string
+        association_method: 'app-owned-handler'
+      }
+    | {
         state: 'unavailable'
         reason: 'producer-not-supplied' | 'producer-source-unverifiable'
       }


### PR DESCRIPTION
## Problem

The app-owned `preview_molecule` Connector wrote a durable Artifact Version but returned the Version ID as `artifact_id`, conflating the stable Artifact lineage with one immutable Version. The same trusted write path persisted `producer-not-supplied`, so Connector execution identity and verified Artifact/Upload inputs could not be represented in Provenance.

## Proposed change

- Return `artifact_id` as the stable Artifact lineage ID, with separate `version_id` and `version_number` fields.
- Carry a trusted Connector producer receipt only through the app-owned handler path; ordinary Artifact MCP/RPC requests cannot assert it.
- Persist canonical Connector arguments, their checksum, Connector/tool/invocation/implementation identities, and the `app-owned-handler` association.
- Validate any declared ArtifactVersion or UploadVersion input through `ImmutableInputAuthority` before persisting the existing `ArtifactVersionInput` relation.
- Treat Connector execution as `partial` and its Notebook environment as unsupported, and keep Notebook-only reconstruction/download behavior guarded.

```mermaid
flowchart LR
  H["App-owned Connector handler"] --> R["writeAppGeneratedVersion"]
  R --> V["Validate trusted producer receipt"]
  V --> I["Validate ArtifactVersion / UploadVersion inputs"]
  I --> P["Persist Artifact Version evidence and input relations"]
```

## Scope and non-goals

- No producer inference from paths, filenames, or arbitrary MCP result JSON.
- No ability for a model or custom MCP server to promote an untrusted producer claim.
- No change to Upload creation or UI interaction. Molecule inputs remain inline and do not fabricate an Upload dependency.
- No ACP wire method, permission, correlation, cancellation, subscription, session-routing, or provider adapter change.

## Compatibility, state, and persistence

- Historical schema-v1 Notebook and unavailable evidence remains readable; no data migration is required.
- New persisted evidence values are producer `kind: connector` and association `app-owned-handler`.
- Existing execution state `partial` and environment state `unavailable` are reused; no new Artifact, Upload, or database enum/state is added.
- New Connector-generated versions persist evidence JSON and may persist the existing `sourceUploadVersionId` input relationship after authority validation.
- No database table, column, index, constraint, or migration changes.

## Acceptance criteria and validation

The following checks ran after the last material edit:

- Artifact lineage/Version receipt contract -> `npm test -- src/main/connectors/molecule-preview.test.ts` -> 4 passed. The regression first failed on the old code because `artifact_id` was `version-1` and `version_id`/`version_number` were absent.
- Trusted Connector capture, UploadVersion dependency, fail-closed input validation, and spoofed public-request producer rejection -> `npm test -- src/main/artifacts/provenance-repository.test.ts` plus architecture test -> 48 passed in the final combined run; the added public repository regression first failed with `producer-not-supplied` on the old code.
- Shared runtime/owner forwarding and representative restored-branch finalization -> included in `npm run test:module -- artifact_provenance` -> 26 files, 1309 tests passed.
- Node types -> `npm run typecheck:node` -> passed.
- Renderer/shared types -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint` -> passed.
- Changed-file formatting and `git diff --check` -> passed.

`claude-code`, `opencode`, `codex-response`, and `codex-bridge` share the tested runtime/ArtifactTurnOwner path. Provider launcher/transport tests are excluded because no protocol translation or framework-specific behavior changed. No model-specific behavior is involved. Local Windows and the complete portable suite were not run; exact-head PR CI is the authority for those risks. `test:affected --explain` conservatively selected the full suite because an existing ACP test file has no module owner declaration, so this PR keeps the requested module-scoped local validation rather than expanding the test-impact manifest.

## Review focus

- Trust boundary between app-owned Connector handlers and ordinary Artifact MCP/RPC writes.
- Artifact lineage ID versus immutable Version ID semantics.
- Backward compatibility of schema-v1 evidence and fail-closed UploadVersion input authority.

Follow-up to #1486; this PR intentionally remains separate from the prompt-only Artifact publication fix.
