### PR TITLE
fix(settings): keep load actions on the facade contract

### DIFF
--- a/src/renderer/src/stores/settings-connectors-slice.test.ts
+++ b/src/renderer/src/stores/settings-connectors-slice.test.ts
@@ -136,6 +136,19 @@ describe('settings Connectors slice', () => {
     expect(commands.listConnectors).toHaveBeenCalledOnce()
   })
 
+  it('rejects a missing Settings command surface as a promise', async () => {
+    const { store } = createHarness({
+      ...createCommands(),
+      onConnectorRuntimeChanged: () => {
+        throw new Error('settings unavailable')
+      }
+    })
+
+    const result = store.getState().loadConnectors()
+    expect(result).toBeInstanceOf(Promise)
+    await expect(result).rejects.toThrow('settings unavailable')
+  })
+
   it('reloads the authoritative snapshot when runtime availability changes', async () => {
     let runtimeChanged: (() => void) | undefined
     const onConnectorRuntimeChanged = vi.fn((listener: () => void) => {

--- a/src/renderer/src/stores/settings-connectors-slice.ts
+++ b/src/renderer/src/stores/settings-connectors-slice.ts
@@ -165,16 +165,21 @@ export const createSettingsConnectorsSlice = ({
   }
 
   return {
-    loadConnectors: () => {
+    loadConnectors: async () => {
+      // Keep subscription and command lookup inside this async action so a missing Settings
+      // surface rejects the returned promise instead of throwing synchronously into callers.
       subscribeToRuntimeChanges()
-      if (getState().connectorsLoaded) return Promise.resolve()
-      if (catalogLoadRequest) return catalogLoadRequest
+      if (getState().connectorsLoaded) return
+      if (catalogLoadRequest) {
+        await catalogLoadRequest
+        return
+      }
       const request = reconcile(() => getCommands().listConnectors()).then(() => undefined)
       const trackedRequest = request.finally(() => {
         if (catalogLoadRequest === trackedRequest) catalogLoadRequest = undefined
       })
       catalogLoadRequest = trackedRequest
-      return trackedRequest
+      await trackedRequest
     },
     setConnectorEnabled: async (id, enabled) => {
       const key = connectorEnabledKey(id)

--- a/src/renderer/src/stores/settings-skills-slice.test.ts
+++ b/src/renderer/src/stores/settings-skills-slice.test.ts
@@ -147,6 +147,19 @@ describe('settings Skills slice', () => {
     expect(commands.listSkills).toHaveBeenCalledTimes(2)
   })
 
+  it('rejects a missing Settings command surface as a promise', async () => {
+    const { store } = createHarness({
+      ...createCommands(),
+      onSkillCatalogChanged: () => {
+        throw new Error('settings unavailable')
+      }
+    })
+
+    const result = store.getState().loadSkills()
+    expect(result).toBeInstanceOf(Promise)
+    await expect(result).rejects.toThrow('settings unavailable')
+  })
+
   it('optimistically toggles a Skill before reconciling the authoritative catalog', async () => {
     let settle!: (skills: SkillView[]) => void
     vi.mocked(commands.setSkillEnabled).mockReturnValue(

--- a/src/renderer/src/stores/settings-skills-slice.ts
+++ b/src/renderer/src/stores/settings-skills-slice.ts
@@ -127,16 +127,22 @@ export const createSettingsSkillsSlice = ({
   }
 
   return {
-    loadSkills: () => {
+    loadSkills: async () => {
+      // Keep subscription and command lookup inside this async action so a missing Settings
+      // surface rejects the returned promise. Marketplace install settles that rejection and
+      // must not treat it as a synchronous install failure.
       subscribeToCatalogChanges()
-      if (getState().skillsLoaded) return Promise.resolve()
-      if (catalogLoadRequest) return catalogLoadRequest
+      if (getState().skillsLoaded) return
+      if (catalogLoadRequest) {
+        await catalogLoadRequest
+        return
+      }
       const request = reconcileCatalog(() => getCommands().listSkills()).then(() => undefined)
       const trackedRequest = request.finally(() => {
         if (catalogLoadRequest === trackedRequest) catalogLoadRequest = undefined
       })
       catalogLoadRequest = trackedRequest
-      return trackedRequest
+      await trackedRequest
     },
     setSkillEnabled: async (id, enabled) => {
       const current = getState().skills.find((skill) => skill.id === id)

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -291,14 +291,6 @@ export const selectProviderModelOptions = (
 let settingsLoadPromise: Promise<boolean> | undefined
 const SAFE_SETTINGS_LOAD_ERROR = 'Open Science could not load settings. Retry to continue.'
 
-const trackSettingsLoad = (loadPromise: Promise<boolean>): Promise<boolean> => {
-  settingsLoadPromise = loadPromise
-  void loadPromise.then(() => {
-    if (settingsLoadPromise === loadPromise) settingsLoadPromise = undefined
-  })
-  return loadPromise
-}
-
 // Keep raw IPC diagnostics in the developer channel while renderer state remains path-safe.
 const reportSettingsLoadError = (error: unknown): void => {
   console.warn('Settings loading failed', error)
@@ -362,44 +354,42 @@ const createSettingsStoreState = (
     getCommands: () => window.api.settings
   }),
 
-  // Loads settings, preflight, and encryption availability in one startup pass.
+  // Loads settings, preflight, and encryption availability in one startup pass. Reopening Settings
+  // reuses this same action and the same Settings reads, skipping the subprocess probes after the
+  // first successful load so feature actions stay in their slices.
   load: (options) => {
     // StrictMode replays the startup effect. Reuse that identical in-flight pass so a duplicate
     // request cannot supersede its successful result; an explicit user retry still starts a new
     // generation and remains authoritative over any older request.
     if (!options?.force && settingsLoadPromise) return settingsLoadPromise
-    // Reopening Settings refreshes the lightweight snapshot so mutations from another renderer or
-    // backend path are visible. Keep subprocess-based preflight and availability probes startup-only.
-    if (!options?.force && get().isLoaded) {
-      const generation = get().settingsLoadGeneration + 1
-      set({ settingsLoadGeneration: generation })
-      const refreshPromise = window.api.settings
-        .getSettings()
-        .then((snapshot) => {
-          if (get().settingsLoadGeneration !== generation) return false
-          set({ ...applySnapshot(snapshot), loadError: undefined })
-          return true
-        })
-        .catch((error: unknown) => {
-          if (get().settingsLoadGeneration === generation) reportSettingsLoadError(error)
-          return false
-        })
-      return trackSettingsLoad(refreshPromise)
-    }
-
     const generation = get().settingsLoadGeneration + 1
-    set({ settingsLoadGeneration: generation, isLoading: true, loadError: undefined })
+    set(
+      options?.force || !get().isLoaded
+        ? { settingsLoadGeneration: generation, isLoading: true, loadError: undefined }
+        : { settingsLoadGeneration: generation }
+    )
 
     const loadPromise = (async (): Promise<boolean> => {
       try {
         const [snapshot, preflight, encryptionAvailable, npmAvailable] = await Promise.all([
           window.api.settings.getSettings(),
-          window.api.settings.getPreflight(),
-          window.api.settings.isEncryptionAvailable(),
-          window.api.settings.isNpmAvailable()
+          get().isLoading ? window.api.settings.getPreflight() : Promise.resolve(undefined),
+          get().isLoading
+            ? window.api.settings.isEncryptionAvailable()
+            : Promise.resolve(undefined),
+          get().isLoading ? window.api.settings.isNpmAvailable() : Promise.resolve(undefined)
         ])
 
         if (get().settingsLoadGeneration !== generation) return false
+
+        if (
+          preflight === undefined ||
+          encryptionAvailable === undefined ||
+          npmAvailable === undefined
+        ) {
+          set({ ...applySnapshot(snapshot), loadError: undefined })
+          return true
+        }
 
         set({
           ...applySnapshot(snapshot),
@@ -414,15 +404,21 @@ const createSettingsStoreState = (
         if (get().settingsLoadGeneration !== generation) return false
 
         reportSettingsLoadError(error)
-        set({
-          isLoading: false,
-          loadError: SAFE_SETTINGS_LOAD_ERROR
-        })
+        if (get().isLoading) {
+          set({
+            isLoading: false,
+            loadError: SAFE_SETTINGS_LOAD_ERROR
+          })
+        }
         return false
       }
     })()
 
-    return trackSettingsLoad(loadPromise)
+    settingsLoadPromise = loadPromise
+    void loadPromise.then(() => {
+      if (settingsLoadPromise === loadPromise) settingsLoadPromise = undefined
+    })
+    return loadPromise
   },
 
   clearSettingsWriteError: () => writeCoordinator.clearFailures(),


### PR DESCRIPTION
## Problem

PR Gate on #1492 failed macOS shard 1 with three renderer tests:

- `settings store architecture > keeps feature actions and Settings writes out of the facade`
- `Specialist Marketplace settings > pauses an update only when replacing local changes needs confirmation`
- `Specialist Marketplace settings > does not present a provenance-pending installation as fully complete`

The architecture guard failed because reopen-refresh added extra facade helpers (`trackSettingsLoad`, `refreshPromise`) and a second `getSettings()` call site. Marketplace install then treated a missing Settings command surface as a failed install: Skill/Connector catalog loads became synchronous after #1492, so `subscribeToCatalogChanges()` threw before `Promise.allSettled` could swallow the rejection.

These action issues were surfaced by #1492 but are fixed here on latest `main`.

## Proposed change

- Keep Settings `load` as the facade action, but use one generation, one in-flight promise, and one `getSettings` / `getPreflight` / `isEncryptionAvailable` / `isNpmAvailable` call site. After the first successful load, reopen still refreshes only the lightweight snapshot.
- Restore `loadSkills` and `loadConnectors` as async actions so a missing Settings surface rejects the returned promise instead of throwing synchronously into Marketplace install and other `allSettled` / `Promise.all` callers.

## Scope and non-goals

- No change to the process-lifetime catalog cache, reopen-refresh product behavior, or Marketplace install confirmation/provenance UI.
- Does not add a `force` refresh on post-install catalog reload. After a successful Marketplace install, Specialist/Skill projections still reconcile through existing catalog events when those listeners are already attached.
- Does not extract a new Settings load owner slice. The existing facade contract (`load`, `acceptCommittedSnapshot`, `clearSettingsWriteError`) is preserved.

## Compatibility, state, and persistence

- Historical compatibility: none. No stored documents, IPC payloads, or mixed-version command shapes changed.
- Enum/state additions: none. No persisted or shared enum values were added. `settingsLoadGeneration` and in-flight load promises remain process-memory only.
- Persistence: none. No new data is written to disk or SQLite.

## Acceptance criteria and validation

All commands below ran after the last material edit:

- Settings facade architecture, load/reopen, Skill/Connector catalog loads, and Marketplace install -> `npx vitest run src/renderer/src/stores/settings-store.architecture.test.ts src/renderer/src/stores/settings-store.test.ts src/renderer/src/stores/settings-skills-slice.test.ts src/renderer/src/stores/settings-connectors-slice.test.ts src/renderer/src/pages/settings/SpecialistMarketplace.render.test.tsx` -> 5 files, 180 tests passed.
- Related Settings/Specialist consumers -> `npx vitest run src/renderer/src/stores/specialist-store.test.ts src/renderer/src/pages/settings/SettingsPage.render.test.tsx src/renderer/src/pages/settings/SettingsPage.architecture.test.ts` -> 4 files, 119 tests passed.
- Renderer/Web types -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint -- --no-cache` -> passed.
- Changed-file formatting -> `npx prettier --check` on the five touched files -> passed.

Uncovered locally: full portable Vitest suite and platform lanes. PR Gate remains authoritative.

## Review focus

- Facade `load` still owns only snapshot/preflight/availability reads, with reopen refresh using the same call sites.
- Catalog load actions reject as promises so Marketplace install can settle a missing Settings surface without showing "Could not install this Specialist."