### PR TITLE
feat(reviewer): allow empty initial review checks

### DIFF
--- a/src/main/reviewer/bridge-tools.ts
+++ b/src/main/reviewer/bridge-tools.ts
@@ -40,7 +40,8 @@ export const REVIEWER_BRIDGE_NAMESPACED_TOOLS: ResponsesBridgeNamespacedTool[] =
     namespace: REVIEWER_BRIDGE_TOOL_NAMESPACE,
     name: REVIEWER_MCP_TOOLS.submitFindings,
     description:
-      'Submit at least one structured pass, warn, or fail check exactly once, then stop. An empty checks array is invalid.',
+      'Submit structured review checks exactly once, then stop. In an initial review with no ' +
+      'checkable claims, submit empty checks; tracked re-reviews follow their strict run prompt.',
     parameters: z.toJSONSchema(submitFindingsBridgeInputSchema, {
       target: 'draft-7'
     }) as ResponsesBridgeNamespacedTool['parameters']

--- a/src/main/reviewer/mcp-server.test.ts
+++ b/src/main/reviewer/mcp-server.test.ts
@@ -238,8 +238,19 @@ describe('submitFindingsInputSchema — v3 unified checks[] (no reasoning)', () 
       }
     ).properties?.checks
 
-    expect(checksSchema?.minItems).toBe(1)
+    expect(checksSchema?.minItems).toBeUndefined()
     expect(checksSchema?.maxItems).toBeUndefined()
+  })
+
+  it('does not tell initial bridge reviewers to manufacture a pass check', () => {
+    const submitFindingsTool = REVIEWER_BRIDGE_NAMESPACED_TOOLS.find(
+      (tool) => tool.name === 'submit_findings'
+    )
+
+    expect(submitFindingsTool?.description).not.toMatch(
+      /at least one|empty checks array is invalid/i
+    )
+    expect(submitFindingsTool?.description).toMatch(/initial.*no checkable claims.*empty checks/i)
   })
 
   it('accepts checks[] with status pass|warn|fail (no reasoning field)', () => {
@@ -284,9 +295,9 @@ describe('submitFindingsInputSchema — v3 unified checks[] (no reasoning)', () 
     expect(parsed.success).toBe(false)
   })
 
-  it('rejects an empty checks array instead of manufacturing a pass', () => {
+  it('accepts an empty checks array for an initial Review', () => {
     const parsed = submitFindingsInputSchema.safeParse({ checks: [] })
-    expect(parsed.success).toBe(false)
+    expect(parsed.success).toBe(true)
   })
 
   it('rejects unknown status values (inconclusive no longer valid)', () => {
@@ -550,7 +561,7 @@ describe('ReviewerMcpServer HTTP transport', () => {
         clientInfo: { name: 'budget-test', version: '1.0' }
       }
     })
-    const server = new ReviewerMcpServer(scope, onSubmit, evidence, [], {
+    const server = new ReviewerMcpServer(scope, onSubmit, evidence, 'initial', [], {
       requestBytes: Buffer.byteLength(initializeBody)
     })
     const { endpoint, token } = await server.start()
@@ -597,7 +608,12 @@ describe('ReviewerMcpServer HTTP transport', () => {
   })
 
   it('reuses the session transport for the GET SSE stream and still serves tool calls', async () => {
-    const server = new ReviewerMcpServer(scope, async () => undefined, createReviewerEvidence())
+    const server = new ReviewerMcpServer(
+      scope,
+      async () => undefined,
+      createReviewerEvidence(),
+      'initial'
+    )
     const { endpoint, token } = await server.start()
 
     const authHeaders = { authorization: `Bearer ${token}`, accept: MCP_ACCEPT }
@@ -672,6 +688,7 @@ describe('ReviewerMcpServer HTTP transport', () => {
       scope,
       async () => undefined,
       createReviewerEvidence(),
+      'initial',
       [],
       { command: 'unused', entryPath: 'unused', transport: 'pipe' }
     )
@@ -744,7 +761,7 @@ describe('ReviewerMcpServer HTTP transport', () => {
   })
 
   it('rejects a request with an unknown mcp-session-id', async () => {
-    const server = new ReviewerMcpServer(scope, async () => undefined)
+    const server = new ReviewerMcpServer(scope, async () => undefined, undefined, 'initial')
     const { endpoint, token } = await server.start()
 
     try {
@@ -768,7 +785,7 @@ describe('ReviewerMcpServer HTTP transport', () => {
   it('exposes evidence only through the scope-bounded reviewer MCP tools', async () => {
     const evidence = createReviewerEvidence()
     const onSubmit = vi.fn().mockResolvedValue(undefined)
-    const server = new ReviewerMcpServer(scope, onSubmit, evidence)
+    const server = new ReviewerMcpServer(scope, onSubmit, evidence, 'initial')
     const { endpoint, token } = await server.start()
 
     try {
@@ -831,9 +848,54 @@ describe('ReviewerMcpServer HTTP transport', () => {
     }
   })
 
+  it('accepts an explicit empty initial submission only after the frozen turn was read', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const server = new ReviewerMcpServer(scope, onSubmit, createReviewerEvidence(), 'initial')
+    const { endpoint, token } = await server.start()
+
+    try {
+      const { sessionId, headers } = await initialize(endpoint, token)
+      const beforeRead = await callTool(endpoint, sessionId, headers, 'submit_findings', {
+        checks: []
+      })
+      expect(beforeRead.result?.isError).toBe(true)
+      expect(beforeRead.result?.content?.[0]?.text).toContain('must read the frozen turn')
+
+      await callTool(endpoint, sessionId, headers, 'read_turn', {})
+      const accepted = await callTool(endpoint, sessionId, headers, 'submit_findings', {
+        checks: []
+      })
+      expect(accepted.result?.isError).not.toBe(true)
+      expect(onSubmit).toHaveBeenCalledOnce()
+      expect(onSubmit).toHaveBeenCalledWith([], scope, {})
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('rejects an empty tracked re-review submission even without tracked ids', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const server = new ReviewerMcpServer(scope, onSubmit, createReviewerEvidence(), 'tracked')
+    const { endpoint, token } = await server.start()
+
+    try {
+      const { sessionId, headers } = await initialize(endpoint, token)
+      await callTool(endpoint, sessionId, headers, 'read_turn', {})
+      const rejected = await callTool(endpoint, sessionId, headers, 'submit_findings', {
+        checks: []
+      })
+      expect(rejected.result?.isError).toBe(true)
+      expect(onSubmit).not.toHaveBeenCalled()
+    } finally {
+      await server.stop()
+    }
+  })
+
   it('requires exactly one stable disposition per tracked finding and rejects duplicate submission', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined)
-    const server = new ReviewerMcpServer(scope, onSubmit, createReviewerEvidence(), ['finding-1'])
+    const server = new ReviewerMcpServer(scope, onSubmit, createReviewerEvidence(), 'tracked', [
+      'finding-1'
+    ])
     const { endpoint, token } = await server.start()
 
     try {
@@ -961,6 +1023,7 @@ describe('ReviewerMcpServer HTTP transport', () => {
         scope,
         onSubmit,
         createReviewerEvidence(),
+        'tracked',
         trackedFindingIds
       )
       const { endpoint, token } = await server.start()
@@ -992,7 +1055,7 @@ describe('ReviewerMcpServer HTTP transport', () => {
 
   it('drops a model-invented sourceFindingId during an initial review', async () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined)
-    const server = new ReviewerMcpServer(scope, onSubmit, createReviewerEvidence())
+    const server = new ReviewerMcpServer(scope, onSubmit, createReviewerEvidence(), 'initial')
     const { endpoint, token } = await server.start()
 
     try {
@@ -1034,7 +1097,7 @@ describe('ReviewerMcpServer HTTP transport', () => {
       if (submissionsStarted === 2) releaseSubmission?.()
       await submissionGate
     })
-    const server = new ReviewerMcpServer(scope, onSubmit, createReviewerEvidence())
+    const server = new ReviewerMcpServer(scope, onSubmit, createReviewerEvidence(), 'initial')
     const { endpoint, token } = await server.start()
 
     try {
@@ -1062,7 +1125,7 @@ describe('ReviewerMcpServer HTTP transport', () => {
       .fn()
       .mockRejectedValueOnce(new Error('persistence failed'))
       .mockResolvedValueOnce(undefined)
-    const server = new ReviewerMcpServer(scope, onSubmit, createReviewerEvidence())
+    const server = new ReviewerMcpServer(scope, onSubmit, createReviewerEvidence(), 'initial')
     const { endpoint, token } = await server.start()
 
     try {
@@ -1112,7 +1175,7 @@ describe('ReviewerMcpServer named-pipe proxy', () => {
   it('lists and calls the existing scoped tools through stdio without loopback TCP', async () => {
     const evidence = createReviewerEvidence()
     const onSubmit = vi.fn().mockResolvedValue(undefined)
-    const server = new ReviewerMcpServer(scope, onSubmit, evidence, [], {
+    const server = new ReviewerMcpServer(scope, onSubmit, evidence, 'initial', [], {
       command: 'C:\\Open Science.exe',
       entryPath: 'C:\\app\\main.js',
       transport: 'pipe'

--- a/src/main/reviewer/mcp-server.ts
+++ b/src/main/reviewer/mcp-server.ts
@@ -78,7 +78,7 @@ const checkFields = {
     .min(1)
     .optional()
     .describe(
-      'Stable id of an original finding being re-evaluated. Required for every tracked finding ' +
+      'Stable id of an original Review Check being re-evaluated. Required for every tracked check ' +
         'during a fix-loop re-review; never invent or rewrite this id.'
     ),
   artifactVersionId: z
@@ -117,11 +117,13 @@ type SubmitFindingsObjectSchema = z.ZodObject<{
 export type SubmitFindingsInput = z.infer<SubmitFindingsObjectSchema>
 
 const createSubmitFindingsObjectSchema = (
+  mode: 'initial' | 'tracked',
   trackedCheckAllowance: number | null = 0
 ): SubmitFindingsObjectSchema => {
-  const checksSchema = z
-    .array(checkSchema)
-    .min(1, 'Submit at least one explicit pass, warn, or fail check.')
+  const checksSchema =
+    mode === 'tracked'
+      ? z.array(checkSchema).min(1, 'A tracked re-review must disposition every tracked check.')
+      : z.array(checkSchema)
   const boundedChecksSchema =
     trackedCheckAllowance === null
       ? checksSchema
@@ -135,16 +137,18 @@ const createSubmitFindingsObjectSchema = (
       checks: boundedChecksSchema.describe(
         'All checks you ran, each with status pass|warn|fail, claim, and evidence. ' +
           'A locator is required for warn/fail and optional for pass. ' +
-          'A completed review requires at least one explicit check; an empty array is never a pass.'
+          'An initial review may submit an empty array only when the frozen turn contains no ' +
+          'checkable claims; tracked re-reviews must disposition every tracked check.'
       )
     })
     .strict() // Reject unknown fields including the old `summary`, old `findings`, and old `reasoning`
 }
 
 const createSubmitFindingsInputSchema = (
+  mode: 'initial' | 'tracked',
   trackedCheckAllowance = 0
 ): z.ZodType<SubmitFindingsInput> =>
-  createSubmitFindingsObjectSchema(trackedCheckAllowance).superRefine((input, context) => {
+  createSubmitFindingsObjectSchema(mode, trackedCheckAllowance).superRefine((input, context) => {
     const bytes = reviewSubmissionByteLength(input.checks)
     if (bytes > MAX_REVIEW_SUBMISSION_BYTES) {
       context.addIssue({
@@ -157,8 +161,8 @@ const createSubmitFindingsInputSchema = (
     }
   })
 
-export const submitFindingsInputSchema = createSubmitFindingsInputSchema()
-export const submitFindingsBridgeInputSchema = createSubmitFindingsObjectSchema(null)
+export const submitFindingsInputSchema = createSubmitFindingsInputSchema('initial')
+export const submitFindingsBridgeInputSchema = createSubmitFindingsObjectSchema('initial', null)
 
 export type ReviewerEvidenceAccessLedger = {
   turnRead: boolean
@@ -293,7 +297,8 @@ export class ReviewerMcpServer {
   constructor(
     private readonly scope: TurnScope,
     private readonly onSubmitFindings: SubmitFindingsHandler,
-    private readonly evidence?: ReviewerEvidenceAccess,
+    private readonly evidence: ReviewerEvidenceAccess | undefined,
+    private readonly mode: 'initial' | 'tracked',
     trackedFindingIds: readonly string[] = [],
     private readonly options: ReviewerMcpServerOptions = {}
   ) {
@@ -380,8 +385,14 @@ export class ReviewerMcpServer {
     })
 
     const trackedCheckAllowance = this.trackedFindingIds.size
-    const submitFindingsObjectSchema = createSubmitFindingsObjectSchema(trackedCheckAllowance)
-    const submitFindingsInputSchema = createSubmitFindingsInputSchema(trackedCheckAllowance)
+    const submitFindingsObjectSchema = createSubmitFindingsObjectSchema(
+      this.mode,
+      trackedCheckAllowance
+    )
+    const submitFindingsInputSchema = createSubmitFindingsInputSchema(
+      this.mode,
+      trackedCheckAllowance
+    )
 
     const evidence = this.evidence
     if (evidence) {
@@ -472,7 +483,10 @@ export class ReviewerMcpServer {
         title: 'Submit review checks',
         description:
           'Submit your structured review checks. Call this exactly once, then stop. ' +
-          'Submit at least one explicit check; an empty checks array is invalid. ' +
+          (this.mode === 'initial'
+            ? 'For an initial review, submit an empty checks array only when the frozen turn ' +
+              'contains no checkable claims. '
+            : 'Disposition every tracked check; an empty checks array is invalid. ') +
           'Each check has status (pass/warn/fail), claim, and evidence; locator is required for ' +
           'warn/fail and optional for pass. ' +
           'Do NOT include a reasoning or summary field — they are no longer accepted.',
@@ -510,7 +524,7 @@ export class ReviewerMcpServer {
         // an initial review; discard it there so a valid assessment is not lost to a non-semantic
         // tracking mistake. Re-reviews remain strict because their tracked ids are authoritative.
         const trackedChecks =
-          this.trackedFindingIds.size === 0
+          this.mode === 'initial'
             ? parsed.checks.map((check) => {
                 const sanitized = { ...check }
                 delete sanitized.sourceFindingId
@@ -591,7 +605,7 @@ export class ReviewerMcpServer {
 
     const missing = [...this.trackedFindingIds].filter((id) => !supplied.has(id))
     if (missing.length > 0) {
-      return `Missing disposition for tracked finding id(s): ${missing.join(', ')}.`
+      return `Missing disposition for tracked Review Check id(s): ${missing.join(', ')}.`
     }
 
     return undefined

--- a/src/main/reviewer/orchestrator-prompt.test.ts
+++ b/src/main/reviewer/orchestrator-prompt.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { buildReviewerPrompt } from './orchestrator'
+import { INITIAL_REVIEW_CHECKABILITY_GUIDANCE } from './rubric'
 import type { ReviewCheck, TurnScope } from '../../shared/reviewer'
 
 const scope: TurnScope = {
@@ -16,7 +17,7 @@ const scope: TurnScope = {
 
 describe('buildReviewerPrompt — isolated evidence access', () => {
   it('advertises only MCP evidence tools and carries no Bash/Python bootstrap or bearer secret', () => {
-    const prompt = buildReviewerPrompt(scope)
+    const prompt = buildReviewerPrompt(scope, 'initial')
 
     expect(prompt).toContain('read_turn')
     expect(prompt).toContain('query_execution_log')
@@ -40,17 +41,26 @@ describe('buildReviewerPrompt — isolated evidence access', () => {
         reflagCount: 0
       }
     ]
-    const prompt = buildReviewerPrompt(scope, tracked)
+    const prompt = buildReviewerPrompt(scope, 'tracked', tracked)
 
     expect(prompt).toContain('sourceFindingId')
     expect(prompt).toContain('finding-stable-1')
     expect(prompt).toContain('exactly once')
+    expect(prompt).not.toMatch(/tracked\s+tracked/u)
   })
 
-  it('requires an explicit pass instead of accepting an empty submission', () => {
-    const prompt = buildReviewerPrompt(scope)
+  it('distinguishes pure greetings from mixed messages with checkable claims', () => {
+    const prompt = buildReviewerPrompt(scope, 'initial')
 
-    expect(prompt).toContain('at least one explicit pass check')
-    expect(prompt).toContain('an empty array is invalid')
+    expect(prompt).toContain(INITIAL_REVIEW_CHECKABILITY_GUIDANCE)
+    expect(prompt).toMatch(/do not create a pass check merely because you read the turn/i)
+  })
+
+  it('keeps tracked mode strict even when the tracked check set is empty', () => {
+    const prompt = buildReviewerPrompt(scope, 'tracked', [])
+
+    expect(prompt).toContain('tracked re-review')
+    expect(prompt).toContain('non-empty checks array')
+    expect(prompt).not.toContain(INITIAL_REVIEW_CHECKABILITY_GUIDANCE)
   })
 })

--- a/src/main/reviewer/orchestrator.test.ts
+++ b/src/main/reviewer/orchestrator.test.ts
@@ -443,6 +443,63 @@ describe('reviewer orchestrator', () => {
     await client.$disconnect()
   })
 
+  it('reads a greeting-only turn and explicitly completes with no Review Checks', async () => {
+    const process = new FakeAgentProcess()
+    startFakeReviewerAgent(process, 'reviewer-session-1', {
+      simulateFindingsViaHttp: true,
+      checksToSubmit: []
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+    const client = createProjectDbClient(temporaryRoot!)
+    await migrateApplicationDatabase(client)
+    const repository = new ReviewRepository(() => Promise.resolve(client))
+
+    const review = await runReview({
+      sessionId: 'session-1',
+      turnMessageId: 'msg-2',
+      projectId: 'project-1',
+      getSession: () =>
+        makeSession({
+          messages: [
+            {
+              id: 'msg-1',
+              role: 'user',
+              content: 'hi',
+              status: 'complete',
+              eventIds: [],
+              createdAt: 1000,
+              updatedAt: 1000
+            },
+            {
+              id: 'msg-2',
+              role: 'agent',
+              content: 'Hi! How can I help?',
+              status: 'complete',
+              eventIds: [],
+              createdAt: 2000,
+              updatedAt: 2000
+            }
+          ]
+        }),
+      reviewRepository: repository,
+      acpRuntime: runtime,
+      artifactStorageRoot: temporaryRoot!
+    })
+
+    expect(review).toMatchObject({ lifecycle: 'complete', outcome: 'pass', checks: [] })
+    expect(review.scope.blocks.map((block) => block.sourceId)).toEqual(['msg-1', 'msg-2'])
+    expect(review.reviewerLog).not.toEqual([])
+    const [reloaded] = await repository.getReviewsForSession('session-1')
+    expect(reloaded).toMatchObject({ lifecycle: 'complete', outcome: 'pass', checks: [] })
+    expect(reloaded?.reviewerLog).toEqual(review.reviewerLog)
+
+    await client.$disconnect()
+  })
+
   it('persists checks and reviewer log (v3: reasoning removed, log captured from stream)', async () => {
     const process = new FakeAgentProcess()
 

--- a/src/main/reviewer/repository.test.ts
+++ b/src/main/reviewer/repository.test.ts
@@ -344,7 +344,7 @@ describe('review repository (integration)', () => {
     await expect(repository.getFindingDispositions(validFinding.id)).resolves.toEqual([])
   })
 
-  it('commits tracked dispositions and newly discovered Findings as one scoped submission', async () => {
+  it('commits tracked dispositions and newly discovered Review Checks as one scoped submission', async () => {
     const repository = await createRepository()
     const sourceReview = await repository.createReview({
       projectId: 'project-1',
@@ -363,6 +363,7 @@ describe('review repository (integration)', () => {
     })
 
     const committed = await repository.commitScopedSubmission({
+      mode: 'tracked',
       reviewId: assessmentReview.id,
       checks: [
         {
@@ -381,7 +382,6 @@ describe('review repository (integration)', () => {
         }
       ],
       expectedSourceFindingIds: [sourceFinding.id],
-      outcome: 'flagged',
       reviewerLog: [{ kind: 'message', text: 'reviewed' }]
     })
 
@@ -445,6 +445,7 @@ describe('review repository (integration)', () => {
     })
     await expect(
       repository.commitScopedSubmission({
+        mode: 'tracked',
         reviewId: staleAssessment.id,
         checks: [
           {
@@ -454,10 +455,82 @@ describe('review repository (integration)', () => {
             sourceFindingId: sourceFinding.id
           }
         ],
-        expectedSourceFindingIds: [sourceFinding.id],
-        outcome: 'flagged'
+        expectedSourceFindingIds: [sourceFinding.id]
       })
     ).rejects.toThrow(/Tracked Finding is unavailable/i)
+  })
+
+  it('commits and reloads an explicit empty initial submission as complete/pass', async () => {
+    const repository = await createRepository()
+    const review = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-empty-initial',
+      turnMessageId: 'a1',
+      scope: scope('a1')
+    })
+    const reviewerLog = [
+      { kind: 'thought' as const, text: 'The frozen turn has no checkable claims.' },
+      { kind: 'tool' as const, toolName: 'read_turn', title: 'read_turn', status: 'ok' as const }
+    ]
+
+    const committed = await repository.commitScopedSubmission({
+      mode: 'initial',
+      reviewId: review.id,
+      checks: [],
+      expectedSourceFindingIds: [],
+      reviewerLog
+    })
+
+    expect(committed).toMatchObject({
+      lifecycle: 'complete',
+      outcome: 'pass',
+      checks: [],
+      reviewerLog,
+      scope: scope('a1')
+    })
+    expect(await repository.countFindings()).toBe(0)
+
+    await client?.$disconnect()
+    client = createProjectDbClient(storageRoot!)
+    const reopened = new ReviewRepository(() => Promise.resolve(client!), {
+      snapshotStorageRoot: storageRoot
+    })
+    const [reloaded] = await reopened.getReviewsForProjectSession(
+      'project-1',
+      'session-empty-initial'
+    )
+    expect(reloaded).toMatchObject({
+      lifecycle: 'complete',
+      outcome: 'pass',
+      checks: [],
+      reviewerLog,
+      scope: scope('a1')
+    })
+  })
+
+  it('rejects an empty tracked submission even when no tracked checks are supplied', async () => {
+    const repository = await createRepository()
+    const review = await repository.createReview({
+      projectId: 'project-1',
+      sessionId: 'session-empty-tracked',
+      turnMessageId: 'a1',
+      scope: scope('a1')
+    })
+
+    await expect(
+      repository.commitScopedSubmission({
+        mode: 'tracked',
+        reviewId: review.id,
+        checks: [],
+        expectedSourceFindingIds: []
+      })
+    ).rejects.toThrow(/tracked/i)
+
+    const [stored] = await repository.getReviewsForProjectSession(
+      'project-1',
+      'session-empty-tracked'
+    )
+    expect(stored).toMatchObject({ lifecycle: 'running', outcome: null, checks: [] })
   })
 
   it('commits more than five historical tracked dispositions in one re-review', async () => {
@@ -490,6 +563,7 @@ describe('review repository (integration)', () => {
     })
 
     const committed = await repository.commitScopedSubmission({
+      mode: 'tracked',
       reviewId: assessmentReview.id,
       checks: source.checks.map((finding, index) => ({
         status: 'pass' as const,
@@ -497,8 +571,7 @@ describe('review repository (integration)', () => {
         evidence: `Verified historical finding ${index + 1}`,
         sourceFindingId: finding.id
       })),
-      expectedSourceFindingIds: source.checks.map((finding) => finding.id),
-      outcome: 'pass'
+      expectedSourceFindingIds: source.checks.map((finding) => finding.id)
     })
 
     expect(committed).toMatchObject({ lifecycle: 'complete', outcome: 'pass' })
@@ -521,6 +594,7 @@ describe('review repository (integration)', () => {
 
     await expect(
       repository.commitScopedSubmission({
+        mode: 'tracked',
         reviewId: assessmentReview.id,
         checks: [
           {
@@ -537,8 +611,7 @@ describe('review repository (integration)', () => {
             sortIndex: 1
           }
         ],
-        expectedSourceFindingIds: ['missing-finding'],
-        outcome: 'flagged'
+        expectedSourceFindingIds: ['missing-finding']
       })
     ).rejects.toThrow(/missing-finding/)
 
@@ -566,6 +639,7 @@ describe('review repository (integration)', () => {
       scope: scope('a1')
     })
     await repository.commitScopedSubmission({
+      mode: 'tracked',
       reviewId: roundTwo.id,
       checks: [
         {
@@ -576,8 +650,7 @@ describe('review repository (integration)', () => {
           sourceFindingId: sourceFinding.id
         }
       ],
-      expectedSourceFindingIds: [sourceFinding.id],
-      outcome: 'flagged'
+      expectedSourceFindingIds: [sourceFinding.id]
     })
 
     const roundThree = await repository.createReview({
@@ -587,6 +660,7 @@ describe('review repository (integration)', () => {
       scope: scope('a1')
     })
     await repository.commitScopedSubmission({
+      mode: 'tracked',
       reviewId: roundThree.id,
       checks: [
         {
@@ -596,8 +670,7 @@ describe('review repository (integration)', () => {
           sourceFindingId: sourceFinding.id
         }
       ],
-      expectedSourceFindingIds: [sourceFinding.id],
-      outcome: 'pass'
+      expectedSourceFindingIds: [sourceFinding.id]
     })
 
     const history = await repository.getReviewsForProjectSession('project-1', 'session-history')
@@ -687,6 +760,7 @@ describe('review repository (integration)', () => {
       scope: scope('a1')
     })
     const submission = {
+      mode: 'tracked' as const,
       reviewId: assessmentReview.id,
       checks: [
         {
@@ -696,8 +770,7 @@ describe('review repository (integration)', () => {
           sourceFindingId: sourceFinding.id
         }
       ],
-      expectedSourceFindingIds: [sourceFinding.id],
-      outcome: 'flagged' as const
+      expectedSourceFindingIds: [sourceFinding.id]
     }
     await repository.commitScopedSubmission(submission)
 
@@ -758,6 +831,7 @@ describe('review repository (integration)', () => {
 
     await expect(
       repository.commitScopedSubmission({
+        mode: 'tracked',
         reviewId: assessmentReview.id,
         checks: [
           {
@@ -767,10 +841,9 @@ describe('review repository (integration)', () => {
             sourceFindingId: source.checks[0]!.id
           }
         ],
-        expectedSourceFindingIds: source.checks.map((check) => check.id),
-        outcome: 'pass'
+        expectedSourceFindingIds: source.checks.map((check) => check.id)
       })
-    ).rejects.toThrow(/exact expected tracked Finding set/i)
+    ).rejects.toThrow(/exact expected tracked Review Check set/i)
 
     const otherTurnReview = await repository.createReview({
       projectId: 'project-1',
@@ -791,6 +864,7 @@ describe('review repository (integration)', () => {
 
     await expect(
       repository.commitScopedSubmission({
+        mode: 'tracked',
         reviewId: crossTurnAssessment.id,
         checks: [
           {
@@ -800,8 +874,7 @@ describe('review repository (integration)', () => {
             sourceFindingId: otherTurn.checks[0]!.id
           }
         ],
-        expectedSourceFindingIds: [otherTurn.checks[0]!.id],
-        outcome: 'pass'
+        expectedSourceFindingIds: [otherTurn.checks[0]!.id]
       })
     ).rejects.toThrow(/another Review turn chain/i)
 
@@ -814,6 +887,7 @@ describe('review repository (integration)', () => {
     })
     await expect(
       repository.commitScopedSubmission({
+        mode: 'tracked',
         reviewId: terminalAssessment.id,
         checks: [
           {
@@ -823,8 +897,7 @@ describe('review repository (integration)', () => {
             sourceFindingId: otherTurn.checks[0]!.id
           }
         ],
-        expectedSourceFindingIds: [otherTurn.checks[0]!.id],
-        outcome: 'pass'
+        expectedSourceFindingIds: [otherTurn.checks[0]!.id]
       })
     ).rejects.toThrow(/Tracked Finding is unavailable/i)
   })

--- a/src/main/reviewer/repository.ts
+++ b/src/main/reviewer/repository.ts
@@ -356,19 +356,24 @@ class ReviewRepository {
     })
   }
 
-  // Commits one scoped re-review submission behind a single interface. Tracked sourceFindingId
-  // entries are immutable assessments of existing Findings, never new Finding rows; untracked checks
-  // are newly discovered Findings. Review completion and every materialized disposition commit in the
+  // Commits one scoped Reviewer submission behind a single interface. Explicit initial mode may
+  // submit no checks; tracked mode requires a non-empty submission and exact disposition of its
+  // expected ids. Tracked sourceFindingId entries are immutable
+  // assessments of existing Review Checks, never new Finding rows; untracked checks are newly
+  // discovered Review Checks. Review completion and every materialized disposition commit in the
   // same SQLite transaction, so a malformed item cannot leave a partially applied audit result.
   async commitScopedSubmission(input: {
+    mode: 'initial' | 'tracked'
     reviewId: string
     checks: NewCheck[]
     expectedSourceFindingIds: string[]
-    outcome: ReviewOutcome
     reviewerLog?: ReviewerLogEntry[]
   }): Promise<ReviewWithChecks> {
-    if (input.checks.length === 0) {
-      throw new Error('A completed Review submission requires at least one explicit check.')
+    if (input.mode !== 'initial' && input.mode !== 'tracked') {
+      throw new Error('Review submission mode must be initial or tracked.')
+    }
+    if (input.mode === 'tracked' && input.checks.length === 0) {
+      throw new Error('A tracked Review submission requires at least one Review Check.')
     }
     assertReviewSubmissionWithinLimits(input.checks, input.expectedSourceFindingIds.length)
     const trackedFindingIds = input.checks.flatMap((check) =>
@@ -376,10 +381,10 @@ class ReviewRepository {
     )
     const expectedFindingIds = input.expectedSourceFindingIds
     if (new Set(expectedFindingIds).size !== expectedFindingIds.length) {
-      throw new Error('Expected tracked Finding ids must be unique.')
+      throw new Error('Expected tracked Review Check ids must be unique.')
     }
     if (new Set(trackedFindingIds).size !== trackedFindingIds.length) {
-      throw new Error('A tracked Finding may only be assessed once in a Review submission.')
+      throw new Error('A tracked Review Check may only be assessed once in a Review submission.')
     }
     const expectedSet = new Set(expectedFindingIds)
     const submittedSet = new Set(trackedFindingIds)
@@ -387,8 +392,13 @@ class ReviewRepository {
       expectedSet.size !== submittedSet.size ||
       [...expectedSet].some((findingId) => !submittedSet.has(findingId))
     ) {
-      throw new Error('Review submission must assess the exact expected tracked Finding set.')
+      throw new Error('Review submission must assess the exact expected tracked Review Check set.')
     }
+    const outcome: ReviewOutcome = input.checks.some(
+      (check) => check.status === 'warn' || check.status === 'fail'
+    )
+      ? 'flagged'
+      : 'pass'
 
     const client = await this.getClient()
     const ownership = await client.$transaction(async (tx) => {
@@ -511,7 +521,7 @@ class ReviewRepository {
         where: { id: assessmentReview.id },
         data: {
           lifecycle: 'complete',
-          outcome: input.outcome,
+          outcome,
           errorMessage: null,
           reviewerLog: JSON.stringify(input.reviewerLog ?? [])
         }

--- a/src/main/reviewer/review-assessment-owner.test.ts
+++ b/src/main/reviewer/review-assessment-owner.test.ts
@@ -26,6 +26,16 @@ const harness = vi.hoisted(() => ({
   stopError: undefined as Error | undefined,
   bridgeScoped: undefined as boolean | undefined
 }))
+const logSpies = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn()
+}))
+
+vi.mock('../logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../logger')>()
+  return { ...actual, createLogger: () => logSpies }
+})
 
 const outsideMutation = (event: string): void => {
   if (harness.inMutation) throw new Error(`${event} ran inside the Session mutation`)
@@ -67,6 +77,7 @@ vi.mock('./mcp-server', () => ({
       _scope: TurnScope,
       submit: (checks: NewCheck[]) => Promise<void>,
       _host: unknown,
+      _mode: 'initial' | 'tracked',
       trackedIds: string[]
     ) {
       outsideMutation(`mcp:create:${trackedIds.join(',')}`)
@@ -257,6 +268,7 @@ describe('review assessment owner', () => {
     harness.disposeError = undefined
     harness.stopError = undefined
     harness.bridgeScoped = undefined
+    vi.clearAllMocks()
   })
 
   it('publishes initial running before onStarted and keeps remote work outside mutations', async () => {
@@ -291,8 +303,64 @@ describe('review assessment owner', () => {
     ])
   })
 
+  it('completes an explicit empty initial assessment and classifies its completion log', async () => {
+    harness.submission = []
+    const reviewRepository = makeRepository()
+
+    const result = await runReviewAssessment({
+      ...commonOptions(reviewRepository),
+      mode: 'initial'
+    })
+
+    expect(result.submittedChecks).toEqual([])
+    expect(reviewRepository.commitScopedSubmission).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'initial', checks: [], expectedSourceFindingIds: [] })
+    )
+    expect(logSpies.info).toHaveBeenCalledWith('review complete', {
+      reviewId: 'assessment-review',
+      outcome: 'pass',
+      checkCount: 0,
+      model: 'reviewer-model',
+      assessmentKind: 'no_checkable_claims'
+    })
+  })
+
+  it('classifies non-empty initial and tracked assessment completion as assessed', async () => {
+    await runReviewAssessment({
+      ...commonOptions(makeRepository()),
+      mode: 'initial'
+    })
+    expect(logSpies.info).toHaveBeenCalledWith(
+      'review complete',
+      expect.objectContaining({ assessmentKind: 'assessed', checkCount: 1 })
+    )
+
+    vi.clearAllMocks()
+    harness.submission = [
+      {
+        status: 'pass',
+        claim: 'Fixed',
+        evidence: 'Verified',
+        sourceFindingId: trackedCheck.id
+      }
+    ]
+    await runReviewAssessment({
+      ...commonOptions(makeRepository()),
+      mode: 'tracked',
+      trackedChecks: [trackedCheck]
+    })
+    expect(logSpies.info).toHaveBeenCalledWith(
+      'scoped re-review complete',
+      expect.objectContaining({ assessmentKind: 'assessed', checkCount: 1 })
+    )
+  })
+
   it('reconciles the Review model with the backend pinned by the runtime', async () => {
     const reviewRepository = makeRepository()
+    vi.mocked(reviewRepository.commitScopedSubmission).mockImplementation(async () => ({
+      ...committedAssessmentReview(),
+      model: 'actual-runtime-model'
+    }))
     const updates: ReviewWithChecks[] = []
 
     await runReviewAssessment({
@@ -307,6 +375,10 @@ describe('review assessment owner', () => {
     })
     expect(updates).toContainEqual(
       expect.objectContaining({ lifecycle: 'running', model: 'actual-runtime-model' })
+    )
+    expect(logSpies.info).toHaveBeenCalledWith(
+      'review complete',
+      expect.objectContaining({ model: 'actual-runtime-model' })
     )
   })
 
@@ -424,7 +496,7 @@ describe('review assessment owner', () => {
     )
   })
 
-  it('commits tracked findings atomically before publishing source then assessment', async () => {
+  it('commits tracked Review Checks atomically before publishing source then assessment', async () => {
     harness.submission = [
       {
         status: 'pass',
@@ -447,7 +519,7 @@ describe('review assessment owner', () => {
 
     expect(result.submittedChecks).toEqual(harness.submission)
     expect(reviewRepository.commitScopedSubmission).toHaveBeenCalledWith(
-      expect.objectContaining({ expectedSourceFindingIds: [trackedCheck.id] })
+      expect.objectContaining({ mode: 'tracked', expectedSourceFindingIds: [trackedCheck.id] })
     )
     expect(harness.events).toEqual(
       expect.arrayContaining([

--- a/src/main/reviewer/review-assessment-owner.ts
+++ b/src/main/reviewer/review-assessment-owner.ts
@@ -9,7 +9,6 @@ import type {
   NewCheck,
   ReviewCheck,
   ReviewerLogEntry,
-  ReviewOutcome,
   ReviewWithChecks,
   TurnScope
 } from '../../shared/reviewer'
@@ -21,7 +20,10 @@ import { ReviewerHostServer, type ArtifactVersionContentResolver } from './host-
 import { ReviewerMcpServer } from './mcp-server'
 import type { ReviewRepository } from './repository'
 import { driveReviewerToStop } from './reviewer-session-driver'
-import { REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND } from './rubric'
+import {
+  INITIAL_REVIEW_CHECKABILITY_GUIDANCE,
+  REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND
+} from './rubric'
 import { buildReviewScopeSnapshot } from './scope-snapshot'
 import { assertDelegatedReviewEvidenceScope } from './scope'
 
@@ -214,12 +216,13 @@ export const runReviewAssessment = async (
         }
       },
       evidence,
+      options.mode,
       trackedChecks.map((check) => check.id),
       { command: process.execPath, entryPath: reviewerMcpEntryPath }
     )
     await mcpServer.start()
 
-    const reviewerPrompt = buildReviewerPrompt(scope, trackedChecks)
+    const reviewerPrompt = buildReviewerPrompt(scope, options.mode, trackedChecks)
     const built = await acpRuntime.buildReviewerSession({
       cwd: session.cwd || homedir(),
       mcpServers: [mcpServer.toAcpMcpServerConfig()],
@@ -345,27 +348,26 @@ export const runReviewAssessment = async (
 
   let finalReview: ReviewWithChecks
   try {
-    const hasWarnOrFailCheck = checksReceived.some(
-      (check) => check.status === 'warn' || check.status === 'fail'
-    )
-    const outcome: ReviewOutcome = hasWarnOrFailCheck ? 'flagged' : 'pass'
     finalReview = await runReviewMutation(runSessionMutation, () =>
       reviewRepository.commitScopedSubmission({
+        mode: options.mode,
         reviewId: review.id,
         checks: checksReceived,
         expectedSourceFindingIds: trackedChecks.map((check) => check.id),
-        outcome,
         reviewerLog: capturedLog
       })
     )
     review = finalReview
-    if (options.mode === 'initial') {
-      log.info('review complete', {
-        reviewId: review.id,
-        outcome,
-        checkCount: checksReceived.length
-      })
-    }
+    log.info(options.mode === 'tracked' ? 'scoped re-review complete' : 'review complete', {
+      reviewId: review.id,
+      outcome: finalReview.outcome,
+      checkCount: checksReceived.length,
+      model: finalReview.model,
+      assessmentKind:
+        options.mode === 'initial' && checksReceived.length === 0
+          ? 'no_checkable_claims'
+          : 'assessed'
+    })
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)
     log.error(
@@ -399,6 +401,7 @@ export const runReviewAssessment = async (
 
 export const buildReviewerPrompt = (
   scope: TurnScope,
+  mode: ReviewAssessmentOptions['mode'],
   trackedChecks: readonly ReviewCheck[] = []
 ): string => {
   const blockSummary =
@@ -417,11 +420,11 @@ export const buildReviewerPrompt = (
       : `Artifact version ids: ${scope.artifactVersionIds.join(', ')}`
 
   const trackedSummary =
-    trackedChecks.length === 0
+    mode === 'initial'
       ? []
       : [
           '',
-          'This is a fix-loop re-review. Disposition every tracked finding exactly once by copying',
+          'This is a fix-loop re-review. Disposition every tracked check exactly once by copying',
           '`sourceFindingId` unchanged into its check. Use pass if fixed, warn/fail if it remains:',
           JSON.stringify(
             trackedChecks.map((check) => ({
@@ -431,9 +434,15 @@ export const buildReviewerPrompt = (
               evidence: check.evidence
             }))
           ),
-          'You may report a newly discovered issue without sourceFindingId, but omission of any tracked',
-          'finding or reuse of an unknown/duplicate id is rejected.'
+          'You may report a newly discovered issue without sourceFindingId, but omission of any',
+          'tracked check or reuse of an unknown/duplicate id is rejected.'
         ]
+
+  const submissionInstruction =
+    mode === 'tracked'
+      ? 'This tracked re-review must submit a non-empty checks array that dispositions every tracked check.'
+      : `${INITIAL_REVIEW_CHECKABILITY_GUIDANCE} Do not create a pass check merely because you ` +
+        'read the turn or the agent replied.'
 
   return [
     `You are reviewing turn: ${scope.turnMessageId}`,
@@ -446,6 +455,6 @@ export const buildReviewerPrompt = (
     'They expose only this audited scope. Do not use Bash, filesystem, network, or other tools.',
     '',
     'After reading the turn data, apply the rubric, then call submit_findings once with your findings.',
-    'Call submit_findings with at least one explicit pass check if you find no issues; an empty array is invalid.'
+    submissionInstruction
   ].join('\n')
 }

--- a/src/main/reviewer/rubric.test.ts
+++ b/src/main/reviewer/rubric.test.ts
@@ -3,7 +3,10 @@
 // if the rubric drifts back toward the paraphrase or loses load-bearing disciplines.
 
 import { describe, it, expect } from 'vitest'
-import { REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND } from './rubric'
+import {
+  INITIAL_REVIEW_CHECKABILITY_GUIDANCE,
+  REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND
+} from './rubric'
 
 const rubric = REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND
 
@@ -135,6 +138,14 @@ describe('REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND — yaml-grounded disciplines', (
     it('keeps pass checks visible but consolidated (no one-card-per-value)', () => {
       expect(rubric).toMatch(/consolidated pass checks|one per area you verified/i)
       expect(rubric).toMatch(/never one per value|not one card per metric/i)
+    })
+
+    it('allows an empty initial submission only when the turn has no checkable claims', () => {
+      expect(rubric).toMatch(/no checkable claims/i)
+      expect(rubric).toMatch(/empty checks array/i)
+      expect(rubric).toMatch(/if uncertain[\s\S]*continue the review/i)
+      expect(rubric).toContain(INITIAL_REVIEW_CHECKABILITY_GUIDANCE)
+      expect(rubric).toMatch(/do not create a pass\s+check merely to prove you read the turn/i)
     })
 
     it('explicitly excludes summary field', () => {

--- a/src/main/reviewer/rubric.ts
+++ b/src/main/reviewer/rubric.ts
@@ -15,6 +15,16 @@
 //   - yaml: repl + read_file → here: dedicated reviewer MCP tools whose handlers validate every id
 //     against the immutable turn scope.
 
+export const INITIAL_REVIEW_CHECKABILITY_GUIDANCE = [
+  'An initial review may submit an empty checks array only when there are no checkable claims.',
+  'Pure greetings, thanks, simple acknowledgements, clarification questions, unexecuted next steps,',
+  'and purely subjective expressions have no checkable claims only when the same turn contains no',
+  'objective claim, completed action claim, or deliverable. A polite reply to those messages is not',
+  'itself a checkable claim. If any objective claim, completed action claim, or deliverable is also',
+  'present, continue substantive review (for example: "Hi, I ran the tests and they pass", "I saved',
+  'the file, thanks", or "The upload failed; can you resend it?").'
+].join(' ')
+
 export const REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND = [
   '<reviewer_instructions>',
 
@@ -238,10 +248,19 @@ export const REVIEWER_RUBRIC_SYSTEM_PROMPT_APPEND = [
   '      - artifactVersionId: Optional — include when the check relates to a specific artifact.',
   'Before submitting, call read_turn. For an activity locator, also query that exact execution log.',
   'For artifactVersionId, first read that exact Artifact Version with read_artifact.',
+  'After read_turn, decide whether the turn contains checkable claims. Checkable claims include',
+  'claimed actions (executed, tested, verified, saved, created, or modified work); factual values,',
+  'entities, directions, source contents, or conclusions traceable in scope; Artifact Versions or',
+  'objective deliverables; and specific external identifiers such as DOI, PMID, or accession.',
+  INITIAL_REVIEW_CHECKABILITY_GUIDANCE,
+  'Reading the turn is a protocol prerequisite, not substantive verification. Do not create a pass',
+  'check merely to prove you read the turn or that the agent replied. If uncertain whether an',
+  'objective claim exists, continue the review and submit checks.',
+  'A tracked re-review can never use an empty checks array: disposition every tracked check.',
   'Record pass checks CONSOLIDATED: one per area you verified, never one per value traced. A',
   'system-info report whose fields all match its tool output is ONE pass check ("traced all reported',
   'metrics to the host output; all match"), not one card per metric.',
-  'If you find no issues, still submit a few consolidated pass checks describing what you verified.',
-  'An empty checks array is invalid and never means pass.',
+  'Whenever you perform substantive verification, record it in consolidated pass checks; do not',
+  'omit completed verification merely to reduce the number of checks.',
   '</reviewer_instructions>'
 ].join('\n')

--- a/src/main/settings/responses-bridge.integration.test.ts
+++ b/src/main/settings/responses-bridge.integration.test.ts
@@ -619,7 +619,8 @@ it.runIf(runLiveContract)(
     const reviewerMcp = new ReviewerMcpServer(
       scope,
       submitFindings as SubmitFindingsHandler,
-      evidence
+      evidence,
+      'initial'
     )
     await reviewerMcp.start()
 

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
@@ -933,6 +933,41 @@ describe('ArtifactProvenancePanel', () => {
     expect(reviewerCardSpy).toHaveBeenCalledWith(expect.objectContaining({ defaultExpanded: true }))
   })
 
+  it('projects a pass Review with zero checks without inventing Review Check evidence', async () => {
+    const baseProjection = provenance().review
+    if (baseProjection.state !== 'available') throw new Error('Expected available review fixture.')
+    const emptyPassAssessment = { ...review, checks: [], submittedChecks: [] }
+    getVersionReview.mockResolvedValue({
+      review: {
+        state: 'available',
+        value: {
+          ...baseProjection.value,
+          selectedVersionAssessment: emptyPassAssessment,
+          currentDirectAssessment: emptyPassAssessment,
+          latestChainReview: emptyPassAssessment,
+          selectedVersionChecks: [],
+          turnLevelChecks: []
+        }
+      }
+    })
+
+    await clickTab('Review')
+    await flush()
+
+    expect(reviewerCardSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        review: expect.objectContaining({
+          outcome: 'pass',
+          checks: [],
+          submittedChecks: []
+        })
+      })
+    )
+    expect(container.querySelector('[data-testid="reviewer-card"]')?.textContent).not.toContain(
+      'The curve matches the executed code'
+    )
+  })
+
   it('renders the Reviewer-owned selected Version projection without mutating frozen history', async () => {
     const selectedTrackedSource = {
       ...check,


### PR DESCRIPTION
## Problem

Initial Reviewer assessments currently force at least one Review Check even when a turn contains no checkable claim. This can manufacture a passing check for greeting-only, thanks-only, acknowledgment-only, or clarification-only turns. Empty submissions also need to remain distinguishable from tracked rechecks, where the exact tracked set is still required.

## Proposed change

- Allow an initial Reviewer run to explicitly finish with `checks: []` after reading the turn.
- Keep tracked assessment mode explicit across prompt, MCP, and repository boundaries so tracked runs reject empty or incomplete submissions, including when the tracked ID set is empty.
- Derive the assessment outcome from accepted checks while preserving reviewer logs, frozen scope, transaction semantics, and the final runtime model in completion logs.
- Share one initial-review checkability rule between the system rubric and per-run prompt: pure greetings, thanks, simple acknowledgments, and clarification questions may be empty only when they contain no objective claim, completed-action claim, or deliverable.
- Keep the Responses bridge description aligned and prevent zero-check provenance projections from inventing Review Check content.

## Scope and non-goals

This change is limited to Reviewer assessment, prompt/rubric guidance, MCP validation, repository persistence, structured logging, and regression coverage. It does not skip the Reviewer ACP run: an empty initial assessment still reads the turn and explicitly invokes the terminal submission tool.

There are no database schema or migration changes, no renderer or IPC schema changes, no output-format changes, and no new user-visible strings or locale changes. Substantive mixed messages and claims of completed work remain reviewable.

## Acceptance criteria and validation

All checks below were run after the final material edit.

| Behavior / risk | Command or evidence | Result |
| --- | --- | --- |
| Greeting-only initial turns can explicitly submit zero checks while mixed/substantive messages remain reviewable; tracked exact-set behavior and Responses bridge routing remain intact | Focused greeting, Reviewer, and Responses bridge Vitest set | 28 files passed, 1 skipped; 377 tests passed, 4 skipped |
| Full application regression coverage | `npm test` | 1127 files passed, 15 skipped; 17302 tests passed, 217 skipped |
| Main and renderer TypeScript contracts | `npm run typecheck` | Passed |
| Source lint requirements | `npm run lint` | Passed |
| Translation catalog and renderer i18n invariants | `npx vitest run src/renderer/src/i18n/resources.test.ts` | 351 passed |
| Generated database schema remains unchanged/current | `npm run db:schema:check` | Passed: generated database schema is current |
| Spec and repository standards | Independent Standards and Spec reviews | Final review: 0 findings |

Uncovered risk: the live Responses Reviewer contract is gated by `CODEX_ACP_PATH` and `CODEX_NATIVE_PATH`; those paths were unavailable locally, so that contract was skipped. Equivalent non-live bridge integration and the real Reviewer MCP HTTP seam cover `read_turn` through explicit submission, but CI remains authoritative for the live adapter/native binary contract.

## Review focus

- The explicit initial-versus-tracked mode propagation and tracked empty-set rejection.
- The boundary between pure social/clarification turns and mixed messages containing objective claims, completed actions, or deliverables.
- Repository outcome derivation and preservation of reviewer logs, scope, transaction behavior, and the actual final model.
- Prompt/rubric consistency and the absence of invented Review Check content for zero-check passes.