### PR TITLE
fix(workspace): keep run indicator after tool rounds

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -859,7 +859,61 @@ describe('WorkspaceMessageScroller loading render', () => {
     expect(html).toContain('>Thinking</span>')
   })
 
-  it('does not render loading after current-run agent text arrives', async () => {
+  it('keeps the loading row after multiple tool rounds while the run is still active', async () => {
+    const html = await renderScroller(
+      createSession({
+        activeRun: {
+          promptMessageId: 'prompt-1',
+          startedAt: 1710000000100
+        },
+        messages: [
+          createMessage({ id: 'prompt-1', sortIndex: 1 }),
+          createMessage({
+            id: 'reply-after-first-tool',
+            role: 'agent',
+            content: 'The chart is ready. I will adjust it next.',
+            status: 'streaming',
+            streamId: 'assistant-message-1',
+            responseToMessageId: 'prompt-1',
+            sortIndex: 4,
+            updatedAt: 1710000000400
+          }),
+          createMessage({
+            id: 'reply-after-second-tool',
+            role: 'agent',
+            content: 'The chart looks good. Next I will generate the report.',
+            status: 'streaming',
+            streamId: 'assistant-message-2',
+            responseToMessageId: 'prompt-1',
+            sortIndex: 6,
+            updatedAt: 1710000000600
+          })
+        ],
+        activities: [
+          createActivity({
+            id: 'tool-read-1',
+            title: 'Used tool: ToolRead',
+            promptMessageId: 'prompt-1',
+            sortIndex: 3,
+            updatedAt: 1710000000300
+          }),
+          createActivity({
+            id: 'tool-read-2',
+            title: 'Used tool: ToolRead',
+            promptMessageId: 'prompt-1',
+            sortIndex: 5,
+            updatedAt: 1710000000500
+          })
+        ]
+      })
+    )
+
+    expect(html).toContain('The chart looks good. Next I will generate the report.')
+    expect(html).toContain('data-testid="open-science-thinking-indicator"')
+    expect(html).toContain('>Thinking</span>')
+  })
+
+  it('continues rendering loading after current-run agent text while the run remains active', async () => {
     const html = await renderScroller(
       createSession({
         activeRun: {
@@ -880,7 +934,8 @@ describe('WorkspaceMessageScroller loading render', () => {
       })
     )
 
-    expect(html).not.toContain('role="status"')
+    expect(html).toContain('data-testid="open-science-thinking-indicator"')
+    expect(html).toContain('>Thinking</span>')
     expect(html).toContain('Answer text')
   })
 

--- a/src/renderer/src/pages/workspace/agent-loading-message.test.ts
+++ b/src/renderer/src/pages/workspace/agent-loading-message.test.ts
@@ -173,7 +173,7 @@ describe('agent loading message state', () => {
     expect(getAgentLoadingPhase(session)).toBe('hidden')
   })
 
-  it('hides loading once the active prompt has an agent response', async () => {
+  it('keeps loading while an active run has a partial agent response', async () => {
     const { getAgentLoadingPhase } = await loadAgentLoadingMessageModule()
     const session = createSession({
       activeRun: {
@@ -197,10 +197,10 @@ describe('agent loading message state', () => {
       ]
     })
 
-    expect(getAgentLoadingPhase(session)).toBe('hidden')
+    expect(getAgentLoadingPhase(session)).toBe('thinking')
   })
 
-  it('tracks the latest tool or token update when one stream spans a tool call', async () => {
+  it('keeps loading across a completed tool and later token while the run remains active', async () => {
     const { getAgentLoadingPhase } = await loadAgentLoadingMessageModule()
     const session = createSession({
       activeRun: {
@@ -232,10 +232,10 @@ describe('agent loading message state', () => {
           message.id === 'reply-1' ? { ...message, updatedAt: 1710000000400 } : message
         )
       })
-    ).toBe('hidden')
+    ).toBe('thinking')
   })
 
-  it('hides loading once an image-only agent response arrives', async () => {
+  it('keeps loading while an active run has an image-only agent response', async () => {
     const { getAgentLoadingPhase } = await loadAgentLoadingMessageModule()
     const session = createSession({
       activeRun: {
@@ -255,7 +255,7 @@ describe('agent loading message state', () => {
       ]
     })
 
-    expect(getAgentLoadingPhase(session)).toBe('hidden')
+    expect(getAgentLoadingPhase(session)).toBe('thinking')
   })
 
   it('ignores previous replies when a follow-up prompt starts a new run', async () => {

--- a/src/renderer/src/pages/workspace/agent-loading-message.ts
+++ b/src/renderer/src/pages/workspace/agent-loading-message.ts
@@ -61,9 +61,9 @@ const getAgentThinkingStartedAt = (session: ChatSession | undefined): number | u
   return Math.max(runStartedAt, latestTool?.updatedAt ?? runStartedAt)
 }
 
-// The transient row belongs to the active request, not persisted history. User waits stay visible
-// until answered; otherwise text output owns the transcript while tools and silent gaps use their
-// own indicator phases.
+// The transient row belongs to the active request, not persisted history. User waits and live tools
+// own their distinct phases. Visible Agent output is still partial until the run terminates, so it
+// must not hide the only liveness signal during a silent gap before the next tool or text update.
 const getAgentLoadingPhase = (session: ChatSession | undefined): AgentLoadingPhase => {
   if (!session) return 'hidden'
   const actionability = projectSessionActionability(session)
@@ -92,22 +92,7 @@ const getAgentLoadingPhase = (session: ChatSession | undefined): AgentLoadingPha
 
   if (promptIndex === -1) return 'hidden'
 
-  const latestVisibleOutput = findLatest(
-    session.messages
-      .slice(promptIndex + 1)
-      .filter(
-        (message) =>
-          message.role === 'agent' &&
-          message.responseToMessageId === promptMessageId &&
-          (message.content.trim().length > 0 || Boolean(message.images?.length))
-      )
-  )
-
-  if (!latestVisibleOutput) return 'thinking'
-
-  const latestTool = findLatest(currentRunTools)
-
-  return latestTool && isLaterThan(latestTool, latestVisibleOutput) ? 'thinking' : 'hidden'
+  return 'thinking'
 }
 
 export { getAgentLoadingPhase, getAgentThinkingStartedAt }


### PR DESCRIPTION
## Problem

The transcript loading indicator disappeared while an Agent run was still active after repeated tool and text rounds. The renderer treated the newest visible Agent output as owning the transcript and returned a hidden loading phase whenever that output was newer than the latest completed tool activity. This left a silent gap before the next tool or text event, matching the reported screenshot.

## Proposed change

Tie the fallback `Thinking` phase to active run authority instead of the relative timestamp of visible Agent output. Live tools and user waits keep their existing distinct phases, and terminal runs still hide the transient row.

Add a transcript-level regression that renders two completed tool rounds followed by Agent text while the run remains active. The test was run against the unfixed implementation four times and failed consistently because the thinking indicator was absent; it passes after this change.

## Scope and non-goals

- Renderer-only liveness projection and tests.
- No ACP method, wire event, adapter, launcher, model, or provider behavior changes.
- No new fields, state enum values, architecture boundaries, data-model changes, or persisted data.
- No historical-data compatibility or migration requirement.
- No timeout/debounce heuristic and no new protocol activity state.

Framework/path impact: `claude-code`, `opencode`, `codex-response`, and `codex-bridge` all reach the same renderer `ChatSession` projection. The behavior is covered at that shared boundary plus the runtime first-output consumer boundary; no framework-specific wire shape differs for this change.

Platform impact: renderer-only DOM projection with no filesystem, process, packaging, or OS-specific behavior. macOS, Linux, and Windows use the same path.

## Acceptance criteria and validation

All listed checks ran after the last material edit:

- repeated tool/text run keeps liveness visible -> shared renderer transcript -> `npm test -- src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx -t 'keeps the loading row after multiple tool rounds while the run is still active'` -> passed
- loading phase and affected renderer consumers -> all framework paths through shared `ChatSession` projection -> `npm test -- src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx src/renderer/src/pages/workspace/agent-loading-message.test.ts src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.render.test.tsx src/renderer/src/lib/acp/useWorkspaceAgentRuntime.first-output.render.test.tsx` -> 4 files, 106 tests passed
- renderer types -> `npm run typecheck:web` -> passed
- lint -> `npm run lint` -> passed
- changed-file formatting -> `npx prettier --check src/renderer/src/pages/workspace/agent-loading-message.ts src/renderer/src/pages/workspace/agent-loading-message.test.ts src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx` -> passed

`npm run test:affected:explain -- --base origin/main --head HEAD` conservatively selected the complete suite because the existing `WorkspaceMessageScroller.render.test.tsx` has no module owner in the impact manifest. Per maintainer direction, the complete local `npm test` was not run; exact-head PR Gate CI is the final authority for the portable and platform suites.

## Review focus

- Confirm that active run authority is the right terminal boundary for the loading row.
- Confirm that tool and user-wait phases still take precedence.
- Confirm that the regression represents the reported order: tool, Agent text, tool, Agent text, continued active run.
