### PR TITLE
fix(cache-lifecycle): release stale session caches

### DIFF
--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -1490,6 +1490,15 @@ describe('session persistence repository (per-session files)', () => {
     ])
   })
 
+  it('drops the saved revision when deleting a Session', async () => {
+    const repository = new SessionRepository(await createStorageRoot())
+    await expect(repository.saveSession(createSession())).resolves.toMatchObject({ revision: 1 })
+
+    await repository.deleteSession('project-a', 'session-1')
+
+    await expect(repository.saveSession(createSession())).resolves.toMatchObject({ revision: 1 })
+  })
+
   it('keeps valid primary JSON when removing a superseded quarantine fails', async () => {
     const root = await createStorageRoot()
     const session = createSession()

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -468,7 +468,11 @@ class SessionRepository {
       if (diagnostic.status === 'unreadable') {
         throw new Error('Cannot delete a Session whose durable JSON is unreadable.')
       }
-      if (diagnostic.status === 'missing') return
+      const revisionKey = `${safeProjectId}:${safeSessionId}`
+      if (diagnostic.status === 'missing') {
+        this.sessionRevisions.delete(revisionKey)
+        return
+      }
 
       // The valid primary proves matching quarantines are superseded authority covered by this
       // explicit Session deletion. Remove every backup first so any failure leaves that proof in
@@ -494,6 +498,7 @@ class SessionRepository {
         force: true,
         recursive: false
       })
+      this.sessionRevisions.delete(revisionKey)
     })
   }
 

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx
@@ -1041,6 +1041,72 @@ describe('PermissionApprovalControls interactions', () => {
     }
   })
 
+  it('refreshes the environment badge for a later permission in the same session', async () => {
+    const firstRequest: AcpPermissionRequest = {
+      requestId: 'req-refresh-env-1',
+      sessionId: 'session-refresh-env',
+      toolCallId: 'tool-refresh-env-1',
+      title: 'mcp__open-science-notebook__notebook_execute',
+      providerToolName: 'mcp__open-science-notebook__notebook_execute',
+      isMcp: true,
+      mcpIdentity: 'open-science-notebook/notebook_execute',
+      rawInput: { kernelKind: 'python', code: 'print(1)' },
+      options: [{ optionId: 'opt-once', name: 'Allow once', kind: 'allow_once' }]
+    }
+    let environment = 'first-python'
+    ;(window as { api?: unknown }).api = {
+      notebook: {
+        state: async () => ({
+          environments: [{ kind: 'python', environment, processKey: `python:${environment}` }],
+          runs: []
+        })
+      }
+    }
+    try {
+      act(() => {
+        root.render(
+          <PermissionApprovalControls
+            requests={[firstRequest]}
+            onRespond={vi.fn()}
+            notebookLookup={{ sessionId: 'session-refresh-env', workspaceCwd: '' }}
+          />
+        )
+      })
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      expect(container.querySelector('[data-testid="permission-env-badge"]')?.textContent).toBe(
+        'first-python'
+      )
+
+      environment = 'second-python'
+      act(() => {
+        root.render(
+          <PermissionApprovalControls
+            requests={[
+              {
+                ...firstRequest,
+                requestId: 'req-refresh-env-2',
+                toolCallId: 'tool-refresh-env-2'
+              }
+            ]}
+            onRespond={vi.fn()}
+            notebookLookup={{ sessionId: 'session-refresh-env', workspaceCwd: '' }}
+          />
+        )
+      })
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+
+      expect(container.querySelector('[data-testid="permission-env-badge"]')?.textContent).toBe(
+        'second-python'
+      )
+    } finally {
+      delete (window as { api?: unknown }).api
+    }
+  })
+
   it('does not use a live Python environment for an R permission request', async () => {
     const rNotebookRequest: AcpPermissionRequest = {
       requestId: 'req-r-env',

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -312,10 +312,6 @@ const PermissionCodeSection = ({
   )
 }
 
-// Per-session env-name lookups, cached so every prompt in the same chat reuses a single read.
-// Keyed by sessionId + kernel kind so a python badge and an R badge never share a stale answer.
-const notebookEnvCache = new Map<string, Promise<string | undefined>>()
-
 // Resolves the environment a session's notebook kernel of the requested kind runs in, best-known
 // first: the matching live kernel, then the latest matching run, and finally the enabled runtime
 // from Settings → Runtimes (what a kernel of that kind started now would bind).
@@ -372,12 +368,7 @@ const useNotebookEnvironment = (
   useEffect(() => {
     if (!lookup || !key || !kernelKind) return
     let cancelled = false
-    let cached = notebookEnvCache.get(key)
-    if (!cached) {
-      cached = lookupNotebookEnvironment(lookup, kernelKind)
-      notebookEnvCache.set(key, cached)
-    }
-    void cached.then((name) => {
+    void lookupNotebookEnvironment(lookup, kernelKind).then((name) => {
       if (!cancelled) setEnvironment({ key, name })
     })
     return () => {


### PR DESCRIPTION
## Problem

- `SessionRepository` retained revision entries after Session deletion, so the process-local map grew with deleted Sessions and a direct repository recreation inherited the deleted revision.
- Notebook permission cards cached one environment lookup forever per project, Session, and kernel kind, so a later permission could show a stale environment after a runtime change.

## Proposed change

- Evict the matching Session revision only after deletion succeeds or the Session is confirmed missing.
- Resolve the Notebook environment for each newly mounted permission card instead of retaining a module-level Promise cache.
- Add public-boundary regressions that were red before the fix and green afterward.

## Scope and non-goals

- No database schema, persisted file format, data field, data model, enum state, or interaction-flow changes.
- No historical-data compatibility work is required.
- Project-wide Session deletion cache cleanup remains out of scope.
- A new Notebook permission card performs a fresh IPC read; ordinary rerenders do not.

## Acceptance criteria and validation

Checks below ran after the last material edit:

- Deleted Session revision lifecycle -> `npm test -- src/main/session-persistence/repository.test.ts src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx` -> 108 passed.
- Session persistence consumers -> `npm run test:module -- session_persistence` -> 315 passed.
- Workspace consumers -> `npm run test:module -- workspace_page` -> 459 passed.
- Main-process types -> `npm run typecheck:node` -> passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Lint -> `npm run lint` -> passed with no warnings.

The complete local `npm test` suite was intentionally not run; exact-head PR CI is authoritative for complete portable and platform coverage.

## Review focus

- Revision eviction remains after durable authority removal, so failed deletions retain retry-safe state.
- Later permission requests refresh their environment badge without introducing TTL or LRU policy.