### PR TITLE
perf(file-save): stream Project Artifact ZIP exports

### DIFF
--- a/src/main/file-save.test.ts
+++ b/src/main/file-save.test.ts
@@ -664,7 +664,9 @@ describe('file save IPC handlers', () => {
     const bytes = Buffer.from('artifact bytes')
     const readFileMock = vi.fn().mockResolvedValue(bytes)
     const openProjectArtifactFile = vi.fn().mockImplementation(async () => ({
-      stat: vi.fn().mockResolvedValue({ isFile: () => true, size: bytes.byteLength }),
+      stat: vi
+        .fn()
+        .mockResolvedValue({ isFile: () => true, size: bytes.byteLength, dev: 1, ino: 1 }),
       readFile: readFileMock,
       createReadStream: vi.fn(() => Readable.from([bytes])),
       close: vi.fn().mockResolvedValue(undefined)
@@ -697,6 +699,68 @@ describe('file save IPC handlers', () => {
       expect(result).toEqual({ saved: true, filePath: destinationPath })
       const entries = unzipSync(new Uint8Array(await readFile(destinationPath)))
       expect(Buffer.from(entries['generated/report.csv']!).toString('utf8')).toBe('artifact bytes')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a Project Artifact whose inode changes after validation', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-save-project-identity-'))
+    const destinationPath = join(root, 'Research-artifacts.zip')
+    await writeFile(destinationPath, 'existing destination')
+    const createReadStream = vi.fn(() => Readable.from([Buffer.from('replacement bytes')]))
+    const closeValidated = vi.fn().mockResolvedValue(undefined)
+    const closeReplacement = vi.fn().mockResolvedValue(undefined)
+    const openProjectArtifactFile = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stat: vi.fn().mockResolvedValue({ isFile: () => true, size: 14, dev: 7, ino: 11 }),
+        createReadStream,
+        close: closeValidated
+      })
+      .mockResolvedValueOnce({
+        stat: vi.fn().mockResolvedValue({ isFile: () => true, size: 17, dev: 7, ino: 12 }),
+        createReadStream,
+        close: closeReplacement
+      })
+    const resolveSessionArtifactFilePath = vi.fn().mockResolvedValue('/managed/report.csv')
+    showSaveDialog.mockResolvedValue({ canceled: false, filePath: destinationPath })
+    registerFileSaveHandlers({ resolveSessionArtifactFilePath, openProjectArtifactFile } as never)
+
+    try {
+      const result = await handlers.get('file:save-project-artifacts')!(
+        { sender: {} },
+        {
+          projectId: 'project-1',
+          suggestedArchiveName: 'Research',
+          files: [
+            {
+              source: 'artifact',
+              sessionId: 'session-1',
+              path: 'artifact://report',
+              suggestedName: 'report.csv'
+            }
+          ]
+        }
+      )
+
+      expect(result).toEqual({
+        saved: true,
+        failures: [
+          {
+            source: 'artifact',
+            sessionId: 'session-1',
+            path: 'artifact://report',
+            suggestedName: 'report.csv',
+            message: 'Project export source changed after validation.'
+          }
+        ]
+      })
+      expect(resolveSessionArtifactFilePath).toHaveBeenCalledTimes(1)
+      expect(createReadStream).not.toHaveBeenCalled()
+      expect(closeValidated).toHaveBeenCalledTimes(1)
+      expect(closeReplacement).toHaveBeenCalledTimes(1)
+      await expect(readFile(destinationPath, 'utf8')).resolves.toBe('existing destination')
     } finally {
       await rm(root, { recursive: true, force: true })
     }
@@ -1171,7 +1235,7 @@ describe('file save IPC handlers', () => {
     await writeFile(destinationPath, 'existing destination')
     const close = vi.fn().mockResolvedValue(undefined)
     const openProjectArtifactFile = vi.fn().mockResolvedValue({
-      stat: vi.fn().mockResolvedValue({ isFile: () => true, size: 5 }),
+      stat: vi.fn().mockResolvedValue({ isFile: () => true, size: 5, dev: 1, ino: 1 }),
       createReadStream: vi.fn(() => Readable.from([Buffer.from('this grew past the limit')])),
       close
     })

--- a/src/main/file-save.test.ts
+++ b/src/main/file-save.test.ts
@@ -3,6 +3,7 @@ import { unzipSync } from 'fflate'
 import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { Readable } from 'node:stream'
 
 const downloadsPath = join('/Users/example', 'Downloads')
 
@@ -10,6 +11,18 @@ const handlers = new Map<string, (event: unknown, payload?: unknown) => unknown>
 const getAppPath = vi.hoisted(() => vi.fn())
 const showSaveDialog = vi.hoisted(() => vi.fn())
 const showOpenDialog = vi.hoisted(() => vi.fn())
+const zipSyncMock = vi.hoisted(() => vi.fn())
+
+vi.mock('fflate', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fflate')>()
+  return {
+    ...actual,
+    zipSync: (...args: Parameters<typeof actual.zipSync>) => {
+      zipSyncMock()
+      return actual.zipSync(...args)
+    }
+  }
+})
 
 vi.mock('electron', () => ({
   app: { getPath: getAppPath },
@@ -31,6 +44,7 @@ describe('file save IPC handlers', () => {
     getAppPath.mockReturnValue(downloadsPath)
     showOpenDialog.mockReset()
     showSaveDialog.mockReset()
+    zipSyncMock.mockClear()
   })
 
   it('exports one selected Session Artifact through Save As', async () => {
@@ -644,6 +658,50 @@ describe('file save IPC handlers', () => {
     }
   })
 
+  it('exports Project Artifacts without reading an entire source into memory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-save-project-stream-'))
+    const destinationPath = join(root, 'Research-artifacts.zip')
+    const bytes = Buffer.from('artifact bytes')
+    const readFileMock = vi.fn().mockResolvedValue(bytes)
+    const openProjectArtifactFile = vi.fn().mockImplementation(async () => ({
+      stat: vi.fn().mockResolvedValue({ isFile: () => true, size: bytes.byteLength }),
+      readFile: readFileMock,
+      createReadStream: vi.fn(() => Readable.from([bytes])),
+      close: vi.fn().mockResolvedValue(undefined)
+    }))
+    showSaveDialog.mockResolvedValue({ canceled: false, filePath: destinationPath })
+    registerFileSaveHandlers({
+      resolveSessionArtifactFilePath: vi.fn().mockResolvedValue('/managed/report.csv'),
+      openProjectArtifactFile
+    } as never)
+
+    try {
+      const result = await handlers.get('file:save-project-artifacts')!(
+        { sender: {} },
+        {
+          projectId: 'project-1',
+          suggestedArchiveName: 'Research',
+          files: [
+            {
+              source: 'artifact',
+              sessionId: 'session-1',
+              path: 'artifact://report',
+              suggestedName: 'report.csv'
+            }
+          ]
+        }
+      )
+
+      expect.soft(readFileMock).not.toHaveBeenCalled()
+      expect(zipSyncMock).not.toHaveBeenCalled()
+      expect(result).toEqual({ saved: true, filePath: destinationPath })
+      const entries = unzipSync(new Uint8Array(await readFile(destinationPath)))
+      expect(Buffer.from(entries['generated/report.csv']!).toString('utf8')).toBe('artifact bytes')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it('applies collision suffixes within each source category only', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-save-project-categories-'))
     const artifactPathA = join(root, 'managed-a.csv')
@@ -1107,50 +1165,48 @@ describe('file save IPC handlers', () => {
     }
   })
 
-  it('drops files that outgrow the per-file limit between stat and read', async () => {
+  it('aborts the export when a source outgrows the per-file limit while streaming', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-save-project-growth-'))
+    const destinationPath = join(root, 'Research-artifacts.zip')
+    await writeFile(destinationPath, 'existing destination')
     const close = vi.fn().mockResolvedValue(undefined)
-    const readFileMock = vi.fn().mockResolvedValue(Buffer.from('this grew past the limit'))
     const openProjectArtifactFile = vi.fn().mockResolvedValue({
       stat: vi.fn().mockResolvedValue({ isFile: () => true, size: 5 }),
-      readFile: readFileMock,
+      createReadStream: vi.fn(() => Readable.from([Buffer.from('this grew past the limit')])),
       close
     })
+    showSaveDialog.mockResolvedValue({ canceled: false, filePath: destinationPath })
     registerFileSaveHandlers({
       resolveSessionArtifactFilePath: vi.fn().mockResolvedValue('/managed/report.csv'),
       openProjectArtifactFile,
       projectArtifactExportLimits: { maxFiles: 5000, maxFileBytes: 10, maxTotalBytes: 1024 }
     } as never)
 
-    const result = await handlers.get('file:save-project-artifacts')!(
-      { sender: {} },
-      {
-        projectId: 'project-1',
-        suggestedArchiveName: 'Research',
-        files: [
+    try {
+      await expect(
+        handlers.get('file:save-project-artifacts')!(
+          { sender: {} },
           {
-            source: 'artifact',
-            sessionId: 'session-1',
-            path: 'artifact://report',
-            suggestedName: 'report.csv'
+            projectId: 'project-1',
+            suggestedArchiveName: 'Research',
+            files: [
+              {
+                source: 'artifact',
+                sessionId: 'session-1',
+                path: 'artifact://report',
+                suggestedName: 'report.csv'
+              }
+            ]
           }
-        ]
-      }
-    )
+        )
+      ).rejects.toThrow('Project export file exceeds the per-file size limit.')
 
-    expect(result).toEqual({
-      saved: true,
-      failures: [
-        {
-          source: 'artifact',
-          sessionId: 'session-1',
-          path: 'artifact://report',
-          suggestedName: 'report.csv',
-          message: 'Project export file exceeds the per-file size limit.'
-        }
-      ]
-    })
-    expect(showSaveDialog).not.toHaveBeenCalled()
-    expect(close).toHaveBeenCalledTimes(1)
+      await expect(readFile(destinationPath, 'utf8')).resolves.toBe('existing destination')
+      expect(showSaveDialog).toHaveBeenCalledTimes(1)
+      expect(close).toHaveBeenCalledTimes(2)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
   })
 
   it('reports non-file export sources without reading them', async () => {

--- a/src/main/file-save.ts
+++ b/src/main/file-save.ts
@@ -1,11 +1,13 @@
 import { BrowserWindow, app, dialog, type OpenDialogOptions } from 'electron'
-import { zipSync } from 'fflate'
+import { Zip, ZipDeflate } from 'fflate'
 
 import { ipcMainHandle } from './ipc-handler-registry'
 import { constants } from 'node:fs'
-import { open, rm, writeFile } from 'node:fs/promises'
+import { copyFile, mkdtemp, open, rm, writeFile, type FileHandle } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { basename, extname, join } from 'node:path'
 import { pipeline } from 'node:stream/promises'
+import { setImmediate as yieldToEventLoop } from 'node:timers/promises'
 
 import type {
   SaveBlobFileRequest,
@@ -42,19 +44,28 @@ type ProjectArtifactExportLimits = {
   maxTotalBytes: number
 }
 
-// Structural subset of fs FileHandle: the size check and the read must observe one open file.
+// Structural subset of fs FileHandle: the size check and stream must observe one open file.
 type ProjectArtifactFileHandle = {
   stat: () => Promise<{ isFile: () => boolean; size: number }>
-  readFile: () => Promise<Uint8Array>
+  createReadStream: (options: {
+    autoClose: false
+    highWaterMark: number
+  }) => AsyncIterable<Uint8Array>
   close: () => Promise<void>
 }
 
-// Project exports buffer every file plus one zipSync output in main-process memory; cap the
-// per-file and cumulative bytes so a batch of multi-GB uploads cannot exhaust the process.
 const PROJECT_ARTIFACT_EXPORT_LIMITS: ProjectArtifactExportLimits = {
   maxFiles: 5000,
   maxFileBytes: 1024 ** 3,
   maxTotalBytes: 2 * 1024 ** 3
+}
+
+const PROJECT_ARTIFACT_STREAM_CHUNK_BYTES = 64 * 1024
+
+type ProjectArtifactExportCandidate = {
+  file: SaveProjectArtifactsRequest['files'][number]
+  sourcePath: string
+  entryName: string
 }
 
 type ManagedFileHandle = {
@@ -165,6 +176,131 @@ const openManagedFile = async (sourcePath: string): Promise<ManagedFileHandle> =
 // file, mirroring the inode-pinning approach of openManagedFile.
 const openProjectArtifactFile = (sourcePath: string): Promise<ProjectArtifactFileHandle> =>
   open(sourcePath, 'r')
+
+const appendArchiveChunk = async (handle: FileHandle, chunk: Uint8Array): Promise<void> => {
+  let offset = 0
+  while (offset < chunk.byteLength) {
+    const { bytesWritten } = await handle.write(chunk, offset, chunk.byteLength - offset, null)
+    if (bytesWritten === 0) throw new Error('Failed to make progress writing Project Artifact ZIP.')
+    offset += bytesWritten
+  }
+}
+
+const writeProjectArtifactArchive = async (options: {
+  destinationPath: string
+  candidates: ProjectArtifactExportCandidate[]
+  failures: SaveProjectArtifactFailure[]
+  limits: ProjectArtifactExportLimits
+  openSource: (sourcePath: string) => Promise<ProjectArtifactFileHandle>
+}): Promise<boolean> => {
+  const temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-project-export-'))
+  const temporaryArchivePath = join(temporaryRoot, 'project-artifacts.zip')
+  let archiveHandle: FileHandle | undefined
+  let archiveHandleClosed = false
+  let zip: Zip | undefined
+
+  try {
+    archiveHandle = await open(temporaryArchivePath, 'wx', 0o600)
+    let archiveFailure: Error | undefined
+    let pendingArchiveWrite = Promise.resolve()
+    let streamedEntries = 0
+    let streamedBytes = 0
+
+    zip = new Zip((error, chunk) => {
+      if (error) {
+        archiveFailure ??= error
+        return
+      }
+      if (!chunk) return
+      pendingArchiveWrite = pendingArchiveWrite
+        .then(() => (archiveFailure ? undefined : appendArchiveChunk(archiveHandle!, chunk)))
+        .catch((writeError) => {
+          archiveFailure = writeError instanceof Error ? writeError : new Error(String(writeError))
+        })
+    })
+
+    const throwIfArchiveFailed = (): void => {
+      if (archiveFailure) throw archiveFailure
+    }
+
+    for (const candidate of options.candidates) {
+      let source: ProjectArtifactFileHandle | undefined
+      let entryStarted = false
+      try {
+        source = await options.openSource(candidate.sourcePath)
+        const metadata = await source.stat()
+        if (!metadata.isFile()) {
+          throw new Error('Project export source is not a regular file.')
+        }
+        if (metadata.size > options.limits.maxFileBytes) {
+          throw new Error('Project export file exceeds the per-file size limit.')
+        }
+        if (streamedBytes + metadata.size > options.limits.maxTotalBytes) {
+          throw new Error('Project export exceeds the total size limit.')
+        }
+
+        const zipEntry = new ZipDeflate(candidate.entryName, { level: 6 })
+        zip.add(zipEntry)
+        entryStarted = true
+        let entryBytes = 0
+        const sourceStream = source.createReadStream({
+          autoClose: false,
+          highWaterMark: PROJECT_ARTIFACT_STREAM_CHUNK_BYTES
+        })
+        for await (const chunk of sourceStream) {
+          entryBytes += chunk.byteLength
+          if (entryBytes > options.limits.maxFileBytes) {
+            throw new Error('Project export file exceeds the per-file size limit.')
+          }
+          if (streamedBytes + entryBytes > options.limits.maxTotalBytes) {
+            throw new Error('Project export exceeds the total size limit.')
+          }
+
+          zipEntry.push(chunk, false)
+          await pendingArchiveWrite
+          throwIfArchiveFailed()
+          // Bound each synchronous compression slice and explicitly let Electron service IPC,
+          // window, and lifecycle events between source chunks.
+          await yieldToEventLoop()
+        }
+        zipEntry.push(new Uint8Array(0), true)
+        await pendingArchiveWrite
+        throwIfArchiveFailed()
+        streamedBytes += entryBytes
+        streamedEntries += 1
+      } catch (error) {
+        if (entryStarted) throw error
+        options.failures.push({
+          ...candidate.file,
+          message: error instanceof Error ? error.message : String(error)
+        })
+      } finally {
+        await source?.close()
+      }
+    }
+
+    if (streamedEntries === 0) {
+      zip.terminate()
+      return false
+    }
+
+    zip.end()
+    await pendingArchiveWrite
+    throwIfArchiveFailed()
+    await archiveHandle.close()
+    archiveHandleClosed = true
+    await copyFile(temporaryArchivePath, options.destinationPath)
+    return true
+  } catch (error) {
+    zip?.terminate()
+    throw error
+  } finally {
+    if (archiveHandle && !archiveHandleClosed) {
+      await archiveHandle.close().catch(() => undefined)
+    }
+    await rm(temporaryRoot, { recursive: true, force: true }).catch(() => undefined)
+  }
+}
 
 const isAlreadyExistsError = (error: unknown): boolean =>
   error instanceof Error && 'code' in error && error.code === 'EEXIST'
@@ -442,9 +578,7 @@ const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {})
       assertSaveProjectArtifactsRequest(request)
 
       const limits = options.projectArtifactExportLimits ?? PROJECT_ARTIFACT_EXPORT_LIMITS
-      // Null-prototype map: entry names are renderer-controlled, so a suggestedName like
-      // '__proto__' must become a real own key instead of polluting the prototype chain.
-      const zipEntries: Record<string, Uint8Array> = Object.create(null)
+      const candidates: ProjectArtifactExportCandidate[] = []
       const takenNames = new Set<string>()
       const failures: SaveProjectArtifactFailure[] = []
       let totalBytes = 0
@@ -478,18 +612,10 @@ const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {})
             takenNames,
             `${categoryDirectory}/${getSafeZipEntryName(file.suggestedName, sourcePath)}`
           )
-          const bytes = new Uint8Array(await exportFile.readFile())
-          // Re-check the bytes actually read: the source may have grown between stat and read.
-          if (bytes.byteLength > limits.maxFileBytes) {
-            throw new Error('Project export file exceeds the per-file size limit.')
-          }
-          if (totalBytes + bytes.byteLength > limits.maxTotalBytes) {
-            throw new Error('Project export exceeds the total size limit.')
-          }
-          zipEntries[entryName] = bytes
+          candidates.push({ file, sourcePath, entryName })
           // Claim checks are case-insensitive; the entry itself keeps its original casing.
           takenNames.add(entryName.toLowerCase())
-          totalBytes += bytes.byteLength
+          totalBytes += metadata.size
         } catch (error) {
           failures.push({
             ...file,
@@ -499,7 +625,7 @@ const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {})
           await exportFile?.close()
         }
       }
-      if (takenNames.size === 0) {
+      if (candidates.length === 0) {
         return { saved: true, ...(failures.length > 0 ? { failures } : {}) }
       }
 
@@ -522,9 +648,18 @@ const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {})
         : await dialog.showSaveDialog(dialogOptions)
       if (canceled || !filePath) return { saved: false }
 
-      // Compress only after the user confirms the destination so a canceled dialog costs nothing.
-      await writeFile(filePath, zipSync(zipEntries, { level: 6 }))
-      return { saved: true, filePath, ...(failures.length > 0 ? { failures } : {}) }
+      const wroteArchive = await writeProjectArtifactArchive({
+        destinationPath: filePath,
+        candidates,
+        failures,
+        limits,
+        openSource: options.openProjectArtifactFile ?? openProjectArtifactFile
+      })
+      return {
+        saved: true,
+        ...(wroteArchive ? { filePath } : {}),
+        ...(failures.length > 0 ? { failures } : {})
+      }
     }
   )
 }

--- a/src/main/file-save.ts
+++ b/src/main/file-save.ts
@@ -46,7 +46,7 @@ type ProjectArtifactExportLimits = {
 
 // Structural subset of fs FileHandle: the size check and stream must observe one open file.
 type ProjectArtifactFileHandle = {
-  stat: () => Promise<{ isFile: () => boolean; size: number }>
+  stat: () => Promise<{ isFile: () => boolean; size: number; dev: number; ino: number }>
   createReadStream: (options: {
     autoClose: false
     highWaterMark: number
@@ -66,6 +66,8 @@ type ProjectArtifactExportCandidate = {
   file: SaveProjectArtifactsRequest['files'][number]
   sourcePath: string
   entryName: string
+  device: number
+  inode: number
 }
 
 type ManagedFileHandle = {
@@ -231,6 +233,9 @@ const writeProjectArtifactArchive = async (options: {
         const metadata = await source.stat()
         if (!metadata.isFile()) {
           throw new Error('Project export source is not a regular file.')
+        }
+        if (metadata.dev !== candidate.device || metadata.ino !== candidate.inode) {
+          throw new Error('Project export source changed after validation.')
         }
         if (metadata.size > options.limits.maxFileBytes) {
           throw new Error('Project export file exceeds the per-file size limit.')
@@ -612,7 +617,13 @@ const registerFileSaveHandlers = (options: RegisterFileSaveHandlersOptions = {})
             takenNames,
             `${categoryDirectory}/${getSafeZipEntryName(file.suggestedName, sourcePath)}`
           )
-          candidates.push({ file, sourcePath, entryName })
+          candidates.push({
+            file,
+            sourcePath,
+            entryName,
+            device: metadata.dev,
+            inode: metadata.ino
+          })
           // Claim checks are case-insensitive; the entry itself keeps its original casing.
           takenNames.add(entryName.toLowerCase())
           totalBytes += metadata.size


### PR DESCRIPTION
## Problem

Project Artifact export accepted up to 2 GiB but read every source into `zipEntries`, then called `zipSync` in the Electron main process. A 128 MiB incompressible benchmark retained about 581 MiB RSS and blocked for about 2.74 seconds; larger exports could make the app unresponsive or OOM.

The regression test was run three times before the fix and failed deterministically because the handler called the injected whole-file `readFile` path.

## Proposed change

- preflight source paths and sizes without retaining file contents
- retain each resolver-canonical path plus its device/inode identity, and reject replacements before streaming
- stream each accepted source through `fflate` in 64 KiB chunks
- await every temporary-archive write and yield between compression slices
- build the ZIP in a mode-0600 temporary file, then copy it to the selected destination only after success
- abort the whole export and clean up the temporary archive when a source fails after streaming starts

## Scope and non-goals

- no IPC fields, database schema, data model, enum, or durable state changes
- no historical-data migration or compatibility handling
- ZIP entry names, category layout, limits, and normal Save As interaction remain unchanged
- the temporary ZIP is ephemeral filesystem data; a hard process/OS crash may leave an OS-temp directory for normal system cleanup
- preflight failures remain per-file failures; mid-stream read/limit failures intentionally abort the export and preserve any existing destination file

## Acceptance criteria and validation

Checks below ran after the last material edit:

- Project Artifact streaming, identity pinning, and existing file-save behavior -> `npm test -- src/main/file-save.test.ts` -> 66 passed
- main-process types -> `npm run typecheck:node` -> passed
- changed source/test lint -> `npm run lint -- --no-warn-ignored src/main/file-save.ts src/main/file-save.test.ts` -> passed
- changed file formatting -> `npx prettier --check src/main/file-save.ts src/main/file-save.test.ts` -> passed
- patch whitespace -> `git diff --check` -> passed

A same-input 128 MiB isolated mechanism comparison measured about 67 MiB peak RSS and a 9.9 ms longest compression slice after streaming, versus about 581 MiB RSS and a 2.74-second synchronous block before it.

`npm run test:affected:explain -- --base main --head HEAD` selects the full suite because `src/main/file-save*.ts` has no module owner in the impact manifest. Per maintainer direction, the full local `npm test` was not run; exact-head PR Gate CI is authoritative for that coverage.

## Review focus

- canonical path plus device/inode pinning across the Save As dialog
- temporary archive cleanup and preservation of an existing destination on failure
- streaming limit enforcement when a source changes after preflight
- 64 KiB compression slices and explicit event-loop yielding