### PR TITLE
perf(session-history): bound transcript rendering

### DIFF
--- a/src/main/window-find-ipc.test.ts
+++ b/src/main/window-find-ipc.test.ts
@@ -4,6 +4,8 @@ import { registerFindOverlayOwner } from './find-overlay-registry'
 import {
   WINDOW_FIND_CLEAR_CHANNEL,
   WINDOW_FIND_CLOSE_CHANNEL,
+  WINDOW_FIND_PREPARED_CHANNEL,
+  WINDOW_FIND_PREPARE_CHANNEL,
   WINDOW_FIND_REQUEST_CHANNEL,
   WINDOW_FIND_RESULT_CHANNEL,
   type WindowFindResult
@@ -29,6 +31,7 @@ type FindInPageOptions = { findNext: boolean; forward: boolean; matchCase: boole
 type TargetWindow = {
   webContents: {
     findInPage: Mock<(text: string, options: FindInPageOptions) => number>
+    send: Mock<(channel: string, payload: { requestId: number }) => void>
     stopFindInPage: Mock<(action: 'clearSelection') => void>
     on: Mock<
       (
@@ -50,6 +53,7 @@ const createTargetWindow = (): TargetWindow => {
   const foundListeners: Array<(event: unknown, result: FoundInPageResult) => void> = []
   const webContents = {
     findInPage: vi.fn<(text: string, options: FindInPageOptions) => number>(() => 17),
+    send: vi.fn<(channel: string, payload: { requestId: number }) => void>(),
     stopFindInPage: vi.fn<(action: 'clearSelection') => void>(),
     on: vi.fn<
       (
@@ -85,6 +89,13 @@ describe('window find IPC', () => {
       { sender: overlay },
       { requestId: 1, text: 'protein', findNext: true, forward: true }
     )
+
+    expect(target.webContents.findInPage).not.toHaveBeenCalled()
+    expect(target.webContents.send).toHaveBeenCalledWith(WINDOW_FIND_PREPARE_CHANNEL, {
+      requestId: 1
+    })
+
+    handlers.get(WINDOW_FIND_PREPARED_CHANNEL)!({ sender: target.webContents }, { requestId: 1 })
     target.emitFoundInPage({ requestId: 17, activeMatchOrdinal: 1, matches: 4, finalUpdate: true })
 
     // The search runs against the MAIN window's webContents, never the overlay's.
@@ -112,10 +123,12 @@ describe('window find IPC', () => {
       { sender: overlay },
       { requestId: 1, text: 'protein', findNext: true, forward: true }
     )
+    handlers.get(WINDOW_FIND_PREPARED_CHANNEL)!({ sender: target.webContents }, { requestId: 1 })
     handlers.get(WINDOW_FIND_REQUEST_CHANNEL)!(
       { sender: overlay },
       { requestId: 2, text: 'variant', findNext: true, forward: true }
     )
+    handlers.get(WINDOW_FIND_PREPARED_CHANNEL)!({ sender: target.webContents }, { requestId: 2 })
     target.emitFoundInPage({ requestId: 17, activeMatchOrdinal: 1, matches: 4, finalUpdate: true })
     target.emitFoundInPage({ requestId: 18, activeMatchOrdinal: 1, matches: 2, finalUpdate: true })
 
@@ -126,6 +139,31 @@ describe('window find IPC', () => {
       matches: 2,
       finalUpdate: true
     })
+  })
+
+  it('ignores preparation acknowledgements for a superseded query', () => {
+    const target = createTargetWindow()
+    const overlay = createOverlay()
+    registerWindowFindIpcHandlers({ resolveMainWindow: () => target })
+
+    handlers.get(WINDOW_FIND_REQUEST_CHANNEL)!(
+      { sender: overlay },
+      { requestId: 1, text: 'protein', findNext: true, forward: true }
+    )
+    handlers.get(WINDOW_FIND_REQUEST_CHANNEL)!(
+      { sender: overlay },
+      { requestId: 2, text: 'variant', findNext: true, forward: true }
+    )
+
+    handlers.get(WINDOW_FIND_PREPARED_CHANNEL)!({ sender: target.webContents }, { requestId: 1 })
+    expect(target.webContents.findInPage).not.toHaveBeenCalled()
+
+    handlers.get(WINDOW_FIND_PREPARED_CHANNEL)!({ sender: target.webContents }, { requestId: 2 })
+    expect(target.webContents.findInPage).toHaveBeenCalledTimes(1)
+    expect(target.webContents.findInPage).toHaveBeenCalledWith(
+      'variant',
+      expect.objectContaining({ findNext: true, forward: true })
+    )
   })
 
   it('clears the search selection on the MAIN window when the overlay closes', () => {

--- a/src/main/window-find-ipc.ts
+++ b/src/main/window-find-ipc.ts
@@ -4,20 +4,24 @@ import { resolveFindOverlayOwner } from './find-overlay-registry'
 import {
   WINDOW_FIND_CLEAR_CHANNEL,
   WINDOW_FIND_CLOSE_CHANNEL,
+  WINDOW_FIND_PREPARED_CHANNEL,
+  WINDOW_FIND_PREPARE_CHANNEL,
   WINDOW_FIND_REQUEST_CHANNEL,
   WINDOW_FIND_RESULT_CHANNEL,
+  type WindowFindPrepareRequest,
   type WindowFindRequest,
   type WindowFindResult
 } from '../shared/window-controls'
 
-// The MAIN window's webContents is what actually gets searched and emits found-in-page. It needs no
-// send(): results are delivered to the OVERLAY that issued the request, not echoed to the main window.
+// The MAIN window's webContents is what actually gets searched and emits found-in-page. Main first
+// sends it a prepare request so React can expose any transcript rows outside the initial render window.
 type FindTargetWebContents = {
   findInPage: (
     text: string,
     options: { findNext: boolean; forward: boolean; matchCase: boolean }
   ) => number
   stopFindInPage: (action: 'clearSelection') => void
+  send: (channel: string, payload: WindowFindPrepareRequest) => void
   on: (
     event: 'found-in-page',
     listener: (event: unknown, result: WindowFindResult & { requestId: number }) => void
@@ -40,10 +44,16 @@ const isWindowFindRequest = (value: unknown): value is WindowFindRequest => {
   if (!value || typeof value !== 'object') return false
   const request = value as Partial<WindowFindRequest>
   return (
+    Number.isSafeInteger(request.requestId) &&
     typeof request.text === 'string' &&
     typeof request.findNext === 'boolean' &&
     typeof request.forward === 'boolean'
   )
+}
+
+const isWindowFindPrepareRequest = (value: unknown): value is WindowFindPrepareRequest => {
+  if (!value || typeof value !== 'object') return false
+  return Number.isSafeInteger((value as Partial<WindowFindPrepareRequest>).requestId)
 }
 
 // Registers native page-find for the overlay->main-window flow. The overlay owns the query UI; main
@@ -61,6 +71,10 @@ const registerWindowFindIpcHandlers = (deps: WindowFindIpcDeps = {}): void => {
   const activeRequests = new WeakMap<
     FindTargetWebContents,
     { nativeRequestId: number; rendererRequestId: number; replyTo: OverlayWebContents }
+  >()
+  const pendingRequests = new WeakMap<
+    FindTargetWebContents,
+    { request: WindowFindRequest; replyTo: OverlayWebContents }
   >()
   const listening = new WeakSet<FindTargetWebContents>()
 
@@ -80,11 +94,11 @@ const registerWindowFindIpcHandlers = (deps: WindowFindIpcDeps = {}): void => {
     })
   }
 
-  ipcMain.on(WINDOW_FIND_REQUEST_CHANNEL, (event: IpcMainEvent, request: unknown): void => {
-    if (!isWindowFindRequest(request) || request.text.length === 0) return
-    const webContents = resolveMainWindow(event.sender)?.webContents
-    if (!webContents) return
-
+  const startFind = (
+    webContents: FindTargetWebContents,
+    request: WindowFindRequest,
+    replyTo: OverlayWebContents
+  ): void => {
     installResultListener(webContents)
     activeRequests.set(webContents, {
       nativeRequestId: webContents.findInPage(request.text, {
@@ -93,13 +107,33 @@ const registerWindowFindIpcHandlers = (deps: WindowFindIpcDeps = {}): void => {
         matchCase: false
       }),
       rendererRequestId: request.requestId,
-      replyTo: event.sender
+      replyTo
     })
+  }
+
+  ipcMain.on(WINDOW_FIND_REQUEST_CHANNEL, (event: IpcMainEvent, request: unknown): void => {
+    if (!isWindowFindRequest(request) || request.text.length === 0) return
+    const webContents = resolveMainWindow(event.sender)?.webContents
+    if (!webContents) return
+
+    pendingRequests.set(webContents, { request, replyTo: event.sender })
+    webContents.send(WINDOW_FIND_PREPARE_CHANNEL, { requestId: request.requestId })
+  })
+
+  ipcMain.on(WINDOW_FIND_PREPARED_CHANNEL, (event: IpcMainEvent, payload: unknown): void => {
+    if (!isWindowFindPrepareRequest(payload)) return
+    const webContents = event.sender as unknown as FindTargetWebContents
+    const pendingRequest = pendingRequests.get(webContents)
+    if (!pendingRequest || pendingRequest.request.requestId !== payload.requestId) return
+
+    pendingRequests.delete(webContents)
+    startFind(webContents, pendingRequest.request, pendingRequest.replyTo)
   })
 
   ipcMain.on(WINDOW_FIND_CLEAR_CHANNEL, (event: IpcMainEvent): void => {
     const webContents = resolveMainWindow(event.sender)?.webContents
     if (!webContents) return
+    pendingRequests.delete(webContents)
     activeRequests.delete(webContents)
     webContents.stopFindInPage('clearSelection')
   })

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -986,6 +986,38 @@ describe('preload bridge — window find IPC channels', () => {
     expect(removeListenerMock).toHaveBeenCalledWith('window:find-prepare', expect.any(Function))
   })
 
+  it('waits for every mounted find target before acknowledging one preparation', () => {
+    const firstListener = vi.fn()
+    const secondListener = vi.fn()
+    const disposeFirst = api.window.announceWindowFindReady?.(firstListener) as
+      (() => void) | undefined
+    const disposeSecond = api.window.announceWindowFindReady?.(secondListener) as
+      (() => void) | undefined
+    const wrappedListener = onMock.mock.calls.find(
+      ([channel]) => channel === 'window:find-prepare'
+    )?.[1] as ((event: unknown, payload: unknown) => void) | undefined
+
+    expect(onMock.mock.calls.filter(([channel]) => channel === 'window:find-prepare')).toHaveLength(
+      1
+    )
+    expect(
+      sendMock.mock.calls.filter(([channel]) => channel === 'shortcut:window-find-ready')
+    ).toHaveLength(1)
+
+    wrappedListener?.({}, { requestId: 42 })
+    firstListener.mock.calls[0]?.[0].complete()
+    expect(sendMock).not.toHaveBeenCalledWith('window:find-prepared', { requestId: 42 })
+
+    secondListener.mock.calls[0]?.[0].complete()
+    expect(sendMock).toHaveBeenCalledTimes(2)
+    expect(sendMock).toHaveBeenLastCalledWith('window:find-prepared', { requestId: 42 })
+
+    disposeFirst?.()
+    expect(sendMock).not.toHaveBeenCalledWith('shortcut:window-find-unready')
+    disposeSecond?.()
+    expect(sendMock).toHaveBeenLastCalledWith('shortcut:window-find-unready')
+  })
+
   it('forwards renderer theme changes to main as a typed appearance payload', () => {
     const appearance = { theme: 'dark' as const, followsSystem: false }
 

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -162,7 +162,9 @@ type PreloadApi = {
       theme: 'light' | 'dark'
       followsSystem: boolean
     }) => void
-    announceWindowFindReady?: () => unknown
+    announceWindowFindReady?: (
+      listener?: (preparation: { requestId: number; complete: () => void }) => void
+    ) => unknown
     onCloseActivePane: (listener: () => void) => () => void
   }
 }
@@ -963,6 +965,25 @@ describe('preload bridge — window find IPC channels', () => {
     dispose?.()
 
     expect(sendMock).toHaveBeenNthCalledWith(2, 'shortcut:window-find-unready')
+  })
+
+  it('delivers find preparation requests and acknowledges completion to main', () => {
+    const listener = vi.fn()
+    const dispose = api.window.announceWindowFindReady?.(listener) as (() => void) | undefined
+    const wrappedListener = onMock.mock.calls.find(
+      ([channel]) => channel === 'window:find-prepare'
+    )?.[1] as ((event: unknown, payload: unknown) => void) | undefined
+
+    wrappedListener?.({}, { requestId: 42 })
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    const preparation = listener.mock.calls[0]?.[0]
+    preparation.complete()
+    preparation.complete()
+    expect(sendMock).toHaveBeenCalledWith('window:find-prepared', { requestId: 42 })
+
+    dispose?.()
+    expect(removeListenerMock).toHaveBeenCalledWith('window:find-prepare', expect.any(Function))
   })
 
   it('forwards renderer theme changes to main as a typed appearance payload', () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -851,9 +851,17 @@ const api: OpenScienceAPI = {
     findInPage: (request) => electronRendererContracts.send('window.findInPage', request),
     clearFind: () => electronRendererContracts.send('window.clearFind'),
     // The Workspace announces it is mounted and searchable so main knows whether to intercept
-    // Cmd/Ctrl+F. Returns a teardown that announces UNREADY on unmount.
-    announceWindowFindReady: () =>
-      announceWindowFindReady({ send: (channel) => ipcRenderer.send(channel) }),
+    // Cmd/Ctrl+F. Before native find runs, the optional listener can expose deferred transcript rows
+    // and acknowledge completion without handling raw IPC request ids itself.
+    announceWindowFindReady: (listener) =>
+      announceWindowFindReady(
+        {
+          on: (channel, prepareListener) => onIpcMessage(channel, prepareListener),
+          send: (channel, payload) =>
+            payload === undefined ? ipcRenderer.send(channel) : ipcRenderer.send(channel, payload)
+        },
+        listener
+      ),
     onFindInPageResult: (listener) =>
       electronRendererContracts.subscribe('window.onFindInPageResult', listener),
     // Overlay-only surface: main signals the bar was shown (focus + restore remembered query), and the

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -78,7 +78,11 @@ import type {
   SideChatSessionRequest,
   SideChatStartRequest
 } from '../shared/side-chat'
-import { announceWindowFindReady, subscribeCloseActivePane } from '../shared/window-controls'
+import {
+  announceWindowFindReady,
+  subscribeCloseActivePane,
+  type WindowFindPreparation
+} from '../shared/window-controls'
 
 type RemoveListener = () => void
 type AcpListener<Payload> = (payload: Payload) => void
@@ -91,6 +95,71 @@ const onIpcMessage = <Payload>(channel: string, listener: AcpListener<Payload>):
 
   return () => {
     ipcRenderer.removeListener(channel, wrappedListener)
+  }
+}
+
+type WindowFindTargetRegistration = {
+  listener: (preparation: WindowFindPreparation) => void
+  pendingCompletions: Set<() => void>
+}
+
+const windowFindTargets = new Set<WindowFindTargetRegistration>()
+let stopWindowFindHandshake: RemoveListener | undefined
+
+const prepareAllWindowFindTargets = (preparation: WindowFindPreparation): void => {
+  const targets = [...windowFindTargets]
+  if (targets.length === 0) {
+    preparation.complete()
+    return
+  }
+
+  let remaining = targets.length
+  for (const target of targets) {
+    // Main keeps only the latest overlay request. Resolve any older preparation owned by this target
+    // before replacing it so rapid query changes cannot retain stale completion callbacks until unmount.
+    for (const complete of [...target.pendingCompletions]) complete()
+    let completed = false
+    const completeTarget = (): void => {
+      if (completed) return
+      completed = true
+      target.pendingCompletions.delete(completeTarget)
+      remaining -= 1
+      if (remaining === 0) preparation.complete()
+    }
+    target.pendingCompletions.add(completeTarget)
+    target.listener({ requestId: preparation.requestId, complete: completeTarget })
+  }
+}
+
+const registerWindowFindTarget = (
+  listener: ((preparation: WindowFindPreparation) => void) | undefined
+): RemoveListener => {
+  const target: WindowFindTargetRegistration = {
+    listener: listener ?? ((preparation) => preparation.complete()),
+    pendingCompletions: new Set()
+  }
+  windowFindTargets.add(target)
+  if (windowFindTargets.size === 1) {
+    stopWindowFindHandshake = announceWindowFindReady(
+      {
+        on: (channel, prepareListener) => onIpcMessage(channel, prepareListener),
+        send: (channel, payload) =>
+          payload === undefined ? ipcRenderer.send(channel) : ipcRenderer.send(channel, payload)
+      },
+      prepareAllWindowFindTargets
+    )
+  }
+
+  let removed = false
+  return () => {
+    if (removed) return
+    removed = true
+    windowFindTargets.delete(target)
+    for (const complete of [...target.pendingCompletions]) complete()
+    if (windowFindTargets.size > 0) return
+
+    stopWindowFindHandshake?.()
+    stopWindowFindHandshake = undefined
   }
 }
 
@@ -853,15 +922,7 @@ const api: OpenScienceAPI = {
     // The Workspace announces it is mounted and searchable so main knows whether to intercept
     // Cmd/Ctrl+F. Before native find runs, the optional listener can expose deferred transcript rows
     // and acknowledge completion without handling raw IPC request ids itself.
-    announceWindowFindReady: (listener) =>
-      announceWindowFindReady(
-        {
-          on: (channel, prepareListener) => onIpcMessage(channel, prepareListener),
-          send: (channel, payload) =>
-            payload === undefined ? ipcRenderer.send(channel) : ipcRenderer.send(channel, payload)
-        },
-        listener
-      ),
+    announceWindowFindReady: registerWindowFindTarget,
     onFindInPageResult: (listener) =>
       electronRendererContracts.subscribe('window.onFindInPageResult', listener),
     // Overlay-only surface: main signals the bar was shown (focus + restore remembered query), and the

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -386,6 +386,7 @@ import type {
   CloseConfirmRequest,
   CloseConfirmResponse,
   WindowFindAppearance,
+  WindowFindPreparation,
   WindowFindRequest,
   WindowFindResult
 } from '../shared/window-controls'
@@ -1012,8 +1013,11 @@ export interface OpenScienceAPI {
     onCloseActivePane(listener: () => void): RemoveListener
     findInPage?(request: WindowFindRequest): void
     clearFind?(): void
-    // Announces the Workspace is mounted (READY) and returns a teardown that announces UNREADY.
-    announceWindowFindReady?(): RemoveListener
+    // Announces the Workspace is mounted (READY). The optional listener exposes deferred transcript
+    // rows and calls complete() after React commits them; teardown announces UNREADY.
+    announceWindowFindReady?(
+      listener?: (preparation: WindowFindPreparation) => void
+    ): RemoveListener
     onFindInPageResult?(listener: AcpListener<WindowFindResult>): RemoveListener
     // Overlay-only: main signals the bar was shown; the overlay asks main to hide it.
     onShowWindowFind?(listener: AcpListener<WindowFindAppearance>): RemoveListener

--- a/src/renderer/src/locales/fr.json
+++ b/src/renderer/src/locales/fr.json
@@ -963,6 +963,7 @@
   "List view": "Vue en liste",
   "Listing packages…": "Liste des paquets…",
   "Live": "En direct",
+  "Load earlier messages": "Charger les messages précédents",
   "Load more": "Charger plus",
   "Load more files from {{title}}": "Charger plus de fichiers à partir de {{title}}",
   "Load more sessions": "Charger plus de sessions",

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -911,6 +911,7 @@
   "List view": "リストビュー",
   "Listing packages…": "パッケージをリストしています…",
   "Live": "ライブ",
+  "Load earlier messages": "以前のメッセージをさらに読み込む",
   "Load more": "さらに読み込む",
   "Load more files from {{title}}": "{{title}} からさらにファイルをロードします",
   "Load more sessions": "セッションをさらに読み込む",

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -927,6 +927,7 @@
   "List view": "목록 보기",
   "Listing packages…": "패키지 나열 중…",
   "Live": "라이브",
+  "Load earlier messages": "이전 메시지 더 불러오기",
   "Load more": "더 불러오기",
   "Load more files from {{title}}": "{{title}}에서 파일 더 불러오기",
   "Load more sessions": "세션 더 불러오기",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -982,6 +982,7 @@
   "List view": "列表视图",
   "Listing packages…": "正在列出软件包…",
   "Live": "实时",
+  "Load earlier messages": "加载更早的消息",
   "Load more": "加载更多",
   "Load more files from {{title}}": "加载 {{title}} 的更多文件",
   "Load more sessions": "加载更多会话",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -980,6 +980,7 @@
   "List view": "清單檢視",
   "Listing packages…": "正在列出套件…",
   "Live": "即時",
+  "Load earlier messages": "載入較早的訊息",
   "Load more": "載入更多",
   "Load more files from {{title}}": "載入 {{title}} 的更多檔案",
   "Load more sessions": "載入更多工作階段",

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -168,7 +168,10 @@ const createSessionSubagentsPreviewItem = vi.fn(
     selectedAgentFrameId
   })
 )
-const announceWindowFindReady = vi.fn(() => () => undefined)
+type FindPreparation = { requestId: number; complete: () => void }
+const announceWindowFindReady = vi.fn<
+  (listener?: (preparation: FindPreparation) => void) => () => void
+>(() => () => undefined)
 
 vi.mock('@/stores/preview-workbench-store', () => ({
   usePreviewWorkbenchStore: {
@@ -375,6 +378,168 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(userRow?.getAttribute('data-scroll-anchor')).toBe('true')
     const agentRow = content?.querySelector('[data-message-id="reply-structure"]')
     expect(agentRow?.getAttribute('data-scroll-anchor')).toBeNull()
+  })
+
+  it('loads earlier transcript messages in bounded chunks without moving the viewport', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const messages = Array.from({ length: 240 }, (_, index) =>
+      createMessage({
+        id: `window-message-${index + 1}`,
+        content: `Message ${index + 1}`,
+        createdAt: 1710000000000 + index,
+        updatedAt: 1710000000000 + index
+      })
+    )
+
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={createSession({ status: 'idle', messages })}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    })
+
+    const messageRows = (): NodeListOf<HTMLElement> =>
+      container.querySelectorAll('[data-message-id^="window-message-"]')
+    const viewport = container.querySelector<HTMLElement>(
+      '[data-testid="message-scroller-viewport"]'
+    )
+    Object.defineProperties(viewport, {
+      scrollHeight: {
+        configurable: true,
+        get: () => messageRows().length * 10
+      },
+      scrollTop: { configurable: true, writable: true, value: 320 }
+    })
+
+    expect(messageRows()).toHaveLength(100)
+    expect(container.querySelector('[data-message-id="window-message-140"]')).toBeNull()
+    expect(container.querySelector('[data-message-id="window-message-141"]')).not.toBeNull()
+
+    const firstLoad = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Load earlier messages'
+    )
+    expect(firstLoad).not.toBeUndefined()
+    await act(async () => firstLoad?.click())
+
+    expect(messageRows()).toHaveLength(200)
+    expect(container.querySelector('[data-message-id="window-message-40"]')).toBeNull()
+    expect(container.querySelector('[data-message-id="window-message-41"]')).not.toBeNull()
+    expect(viewport?.scrollTop).toBe(1320)
+
+    const secondLoad = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Load earlier messages'
+    )
+    await act(async () => secondLoad?.click())
+
+    expect(messageRows()).toHaveLength(240)
+    expect(container.querySelector('[data-message-id="window-message-1"]')).not.toBeNull()
+    expect(viewport?.scrollTop).toBe(1720)
+    expect(
+      Array.from(container.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Load earlier messages'
+      )
+    ).toBeUndefined()
+  })
+
+  it('commits the complete transcript before acknowledging native find preparation', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const messages = Array.from({ length: 240 }, (_, index) =>
+      createMessage({
+        id: `find-message-${index + 1}`,
+        content: `Find target ${index + 1}`,
+        createdAt: 1710000000000 + index,
+        updatedAt: 1710000000000 + index
+      })
+    )
+
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={createSession({ messages })}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    })
+
+    const messageRows = (): Element[] =>
+      Array.from(container.querySelectorAll('[data-message-id^="find-message-"]'))
+    expect(messageRows()).toHaveLength(100)
+
+    const viewport = container.querySelector<HTMLElement>(
+      '[data-testid="message-scroller-viewport"]'
+    )
+    Object.defineProperties(viewport, {
+      scrollHeight: {
+        configurable: true,
+        get: () => messageRows().length * 10
+      },
+      scrollTop: { configurable: true, writable: true, value: 320 }
+    })
+
+    const prepare = announceWindowFindReady.mock.calls.at(-1)?.[0]
+    expect(prepare).toBeTypeOf('function')
+    const complete = vi.fn(() => expect(messageRows()).toHaveLength(240))
+
+    await act(async () => {
+      prepare?.({ requestId: 42, complete })
+    })
+
+    expect(messageRows()).toHaveLength(240)
+    expect(viewport?.scrollTop).toBe(1720)
+    expect(complete).toHaveBeenCalledTimes(1)
+  })
+
+  it('reveals the real first message before scrolling to the transcript start', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const messages = Array.from({ length: 240 }, (_, index) =>
+      createMessage({
+        id: `first-message-${index + 1}`,
+        content: `Message ${index + 1}`,
+        createdAt: 1710000000000 + index,
+        updatedAt: 1710000000000 + index
+      })
+    )
+
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={createSession({ status: 'idle', messages })}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    })
+
+    const messageRows = (): NodeListOf<HTMLElement> =>
+      container.querySelectorAll('[data-message-id^="first-message-"]')
+    const viewport = container.querySelector<HTMLElement>(
+      '[data-testid="message-scroller-viewport"]'
+    )
+    Object.defineProperties(viewport, {
+      clientHeight: { configurable: true, value: 400 },
+      scrollHeight: { configurable: true, get: () => messageRows().length * 10 },
+      scrollTop: { configurable: true, writable: true, value: 600 }
+    })
+
+    await act(async () => viewport?.dispatchEvent(new Event('scroll', { bubbles: true })))
+    if (viewport) viewport.scrollTop = 599
+    await act(async () => viewport?.dispatchEvent(new Event('scroll', { bubbles: true })))
+
+    const firstMessageButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Scroll to first message"]'
+    )
+    expect(firstMessageButton).not.toBeNull()
+    expect(messageRows()).toHaveLength(100)
+
+    await act(async () => firstMessageButton?.click())
+
+    expect(messageRows()).toHaveLength(240)
+    expect(container.querySelector('[data-message-id="first-message-1"]')).not.toBeNull()
+    expect(viewport?.scrollTop).toBe(0)
   })
 
   it('renders later tools in real time while the assistant reply is still pacing', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -207,6 +207,30 @@ const renderScroller = async (
   )
 }
 
+describe('WorkspaceMessageScroller transcript render budget', () => {
+  it('keeps the initial message row count bounded for a long conversation', async () => {
+    const messageCount = 240
+    const markup = await renderScroller(
+      createSession({
+        status: 'idle',
+        messages: Array.from({ length: messageCount }, (_, index) =>
+          createMessage({
+            id: `message-${index + 1}`,
+            content: `Message ${index + 1}`,
+            createdAt: 1710000000000 + index,
+            updatedAt: 1710000000000 + index
+          })
+        )
+      })
+    )
+
+    const renderedMessageRows = markup.match(/data-message-id="message-\d+"/g) ?? []
+
+    expect(renderedMessageRows.length).toBeLessThanOrEqual(100)
+    expect(markup).toContain(`data-message-id="message-${messageCount}"`)
+  })
+})
+
 describe('WorkspaceMessageScroller Run Marks render', () => {
   it('passes the presented conversation to Run Marks', async () => {
     const oneRun = await renderScroller(

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -29,6 +29,7 @@ import {
   useRef,
   useState,
   type ComponentProps,
+  type MouseEvent as ReactMouseEvent,
   type ReactNode
 } from 'react'
 import { ArrowDownIcon } from 'lucide-react'
@@ -87,6 +88,7 @@ import { WorkspaceElicitationCard } from './WorkspaceElicitationCard'
 import { WorkspaceSubagentMessageRow } from './WorkspaceSubagentMessageRow'
 import { getNotebookRunIdFromActivity } from './workspace-tool-activity-details'
 import { setWorkspacePresentationRevealing } from './workspace-presentation-revealing'
+import type { WindowFindPreparation } from '../../../../shared/window-controls'
 
 type WorkspaceMessageScrollerProps = {
   activeSession: ChatSession | undefined
@@ -141,6 +143,19 @@ type VisibleMessageSnapshot = {
   messageIds: Set<string>
 }
 
+type TranscriptWindowState = {
+  scopeId: string | undefined
+  startIndex: number
+}
+
+type PendingTranscriptPrepend = {
+  scopeId: string | undefined
+  scrollHeight: number
+  scrollTop: number
+  complete?: () => void
+  scrollToStart?: boolean
+}
+
 const VisibleMessageSnapshotCommit = ({
   scopeId,
   messageIdsKey,
@@ -162,6 +177,7 @@ const SCROLL_TO_FIRST_MESSAGE_MIN_HEIGHT_VIEWPORTS = 2
 const SCROLL_TO_FIRST_MESSAGE_MIN_PROGRESS = 0.1
 const SCROLL_TO_FIRST_MESSAGE_MIN_DISTANCE_VIEWPORTS = 1
 const SCROLL_TO_FIRST_MESSAGE_IDLE_TIMEOUT_MS = 3000
+const INITIAL_TRANSCRIPT_ITEM_COUNT = 100
 // How long a "no longer available" mention notice stays visible before auto-dismissing.
 const MENTION_NOTICE_TIMEOUT_MS = 3000
 
@@ -372,6 +388,8 @@ const WorkspaceMessageScrollerImpl = ({
   const scrollToFirstMessageButtonRef = useRef<HTMLButtonElement | null>(null)
   const previousMessageScrollerScrollTopRef = useRef(0)
   const scrollToFirstMessageHideTimeoutRef = useRef<number | undefined>(undefined)
+  const pendingTranscriptPrependRef = useRef<PendingTranscriptPrepend | undefined>(undefined)
+  const [transcriptWindowState, setTranscriptWindowState] = useState<TranscriptWindowState>()
   const [scrollThresholdAllowsFirstMessage, setScrollThresholdAllowsFirstMessage] = useState(false)
   const handleMessageScrollerViewportRef = useCallback((node: HTMLDivElement | null): void => {
     messageScrollerViewportRef.current = node
@@ -383,14 +401,12 @@ const WorkspaceMessageScrollerImpl = ({
   const currentPresentationScopeId = currentSessionId
     ? JSON.stringify([currentSessionId, activeConversationFrame?.activeBranchId ?? 'legacy'])
     : undefined
+  const currentPresentationScopeIdRef = useRef(currentPresentationScopeId)
+  useLayoutEffect(() => {
+    currentPresentationScopeIdRef.current = currentPresentationScopeId
+  }, [currentPresentationScopeId])
   const artifactVisibility = useWorkspaceArtifactVisibility(activeSession)
   const handoffEvents = useHandoffLifecycleEvents(handoffLifecycleSource, currentSessionId)
-  // The whole-window find bar is an Electron overlay owned by main; the Workspace only needs to tell
-  // main it is mounted and searchable so Cmd/Ctrl+F is intercepted (and re-arm UNREADY on unmount).
-  useEffect(() => {
-    const stop = window.api?.window?.announceWindowFindReady?.()
-    return () => stop?.()
-  }, [])
   const loadReviewsForSession = useReviewStore((state) => state.loadReviewsForSession)
   const reviewLoadError = useReviewStore((state) =>
     selectProjectSessionReviewLoadError(
@@ -542,10 +558,106 @@ const WorkspaceMessageScrollerImpl = ({
     presentationBarrierIndex >= 0
       ? conversationItems.slice(0, presentationBarrierIndex + 1)
       : conversationItems
+  const defaultTranscriptWindowStart = Math.max(
+    0,
+    presentedConversationItems.length - INITIAL_TRANSCRIPT_ITEM_COUNT
+  )
+  const transcriptWindowStart =
+    transcriptWindowState && transcriptWindowState.scopeId === currentPresentationScopeId
+      ? Math.min(transcriptWindowState.startIndex, defaultTranscriptWindowStart)
+      : defaultTranscriptWindowStart
+  const transcriptWindowStartRef = useRef(transcriptWindowStart)
+  useLayoutEffect(() => {
+    transcriptWindowStartRef.current = transcriptWindowStart
+  }, [transcriptWindowStart])
+  const renderedConversationItems = conversationItems.slice(transcriptWindowStart)
+  const renderedPresentedConversationItems = presentedConversationItems.slice(transcriptWindowStart)
+  const loadEarlierTranscriptItems = useCallback((): void => {
+    if (transcriptWindowStart <= 0) return
+    const viewport = messageScrollerViewportRef.current
+    pendingTranscriptPrependRef.current = {
+      scopeId: currentPresentationScopeId,
+      scrollHeight: viewport?.scrollHeight ?? 0,
+      scrollTop: viewport?.scrollTop ?? 0
+    }
+    setTranscriptWindowState({
+      scopeId: currentPresentationScopeId,
+      startIndex: Math.max(0, transcriptWindowStart - INITIAL_TRANSCRIPT_ITEM_COUNT)
+    })
+  }, [currentPresentationScopeId, transcriptWindowStart])
+  const revealTranscriptMessage = useCallback(
+    (messageId: string): void => {
+      const targetIndex = presentedConversationItems.findIndex(
+        (item) => item.type === 'message' && item.message.id === messageId
+      )
+      if (targetIndex < 0 || targetIndex >= transcriptWindowStart) return
+      setTranscriptWindowState({
+        scopeId: currentPresentationScopeId,
+        startIndex: targetIndex
+      })
+    },
+    [currentPresentationScopeId, presentedConversationItems, transcriptWindowStart]
+  )
+  const handleScrollToFirstMessage = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>): void => {
+      if (transcriptWindowStart <= 0) return
+      event.preventDefault()
+      const viewport = messageScrollerViewportRef.current
+      pendingTranscriptPrependRef.current = {
+        scopeId: currentPresentationScopeId,
+        scrollHeight: viewport?.scrollHeight ?? 0,
+        scrollTop: viewport?.scrollTop ?? 0,
+        scrollToStart: true
+      }
+      setTranscriptWindowState({ scopeId: currentPresentationScopeId, startIndex: 0 })
+    },
+    [currentPresentationScopeId, transcriptWindowStart]
+  )
+  const prepareTranscriptForFind = useCallback((preparation: WindowFindPreparation): void => {
+    const startIndex = transcriptWindowStartRef.current
+    if (startIndex <= 0) {
+      preparation.complete()
+      return
+    }
+
+    const viewport = messageScrollerViewportRef.current
+    const scopeId = currentPresentationScopeIdRef.current
+    pendingTranscriptPrependRef.current = {
+      scopeId,
+      scrollHeight: viewport?.scrollHeight ?? 0,
+      scrollTop: viewport?.scrollTop ?? 0,
+      complete: preparation.complete
+    }
+    setTranscriptWindowState({ scopeId, startIndex: 0 })
+  }, [])
+  // Main delays Electron's native find until this callback has exposed the complete active transcript
+  // and the layout effect below acknowledges the committed DOM. The preload helper owns request ids.
+  useEffect(() => {
+    const stop = window.api?.window?.announceWindowFindReady?.(prepareTranscriptForFind)
+    return () => stop?.()
+  }, [prepareTranscriptForFind])
+  useLayoutEffect(() => {
+    const pending = pendingTranscriptPrependRef.current
+    if (!pending) return
+    if (pending.scopeId !== currentPresentationScopeId) {
+      pendingTranscriptPrependRef.current = undefined
+      pending.complete?.()
+      return
+    }
+
+    const viewport = messageScrollerViewportRef.current
+    if (viewport) {
+      viewport.scrollTop = pending.scrollToStart
+        ? 0
+        : pending.scrollTop + Math.max(0, viewport.scrollHeight - pending.scrollHeight)
+    }
+    pendingTranscriptPrependRef.current = undefined
+    pending.complete?.()
+  }, [currentPresentationScopeId, transcriptWindowStart])
   // Brand-new conversation (nothing presented, no resume in flight): invite the first prompt with
   // a centered placeholder banner over the empty transcript area.
   const showEmptyConversationBanner = presentedConversationItems.length === 0 && !isResumingSession
-  const visibleMessageIds = presentedConversationItems.flatMap((item) =>
+  const visibleMessageIds = renderedPresentedConversationItems.flatMap((item) =>
     item.type === 'message' ? [item.message.id] : []
   )
   const visibleMessageIdsKey = JSON.stringify(visibleMessageIds)
@@ -1026,6 +1138,8 @@ const WorkspaceMessageScrollerImpl = ({
           <WorkspaceRunMarks
             items={presentedConversationItems}
             viewport={messageScrollerViewport}
+            transcriptWindowStart={transcriptWindowStart}
+            onRevealMessage={revealTranscriptMessage}
           />
           <div
             aria-hidden="true"
@@ -1042,6 +1156,23 @@ const WorkspaceMessageScrollerImpl = ({
               ref={messageScrollerContentRef}
               className="mx-auto w-full max-w-4xl gap-0 px-4 pb-[56px]"
             >
+              {transcriptWindowStart > 0 ? (
+                <MessageScrollerItem
+                  messageId={`transcript-history-${currentSessionId ?? 'unknown'}`}
+                  className="min-w-0"
+                >
+                  <div className="flex justify-center px-4 pb-2 pt-3 md:px-6">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={loadEarlierTranscriptItems}
+                    >
+                      {t('Load earlier messages')}
+                    </Button>
+                  </div>
+                </MessageScrollerItem>
+              ) : null}
               {reviewLoadError ? (
                 <MessageScrollerItem
                   messageId={`review-load-error-${currentSessionId ?? 'unknown'}`}
@@ -1073,7 +1204,8 @@ const WorkspaceMessageScrollerImpl = ({
                 onCommit={handleVisibleMessageSnapshotCommit}
               />
               {/* Messages and tool activities share one sorted transcript timeline. */}
-              {conversationItems.map((item, itemIndex) => {
+              {renderedConversationItems.map((item, windowItemIndex) => {
+                const itemIndex = transcriptWindowStart + windowItemIndex
                 // Only later text messages stay behind the presentation barrier; tool,
                 // activity, and other non-message rows render in real time so their
                 // running state stays visible while the reply paces above them.
@@ -1378,6 +1510,7 @@ const WorkspaceMessageScrollerImpl = ({
               tabIndex={-1}
               size="default"
               className="z-20 min-h-11 gap-1 rounded-full border-transparent bg-bg-000 px-4 text-sm shadow-card transition-[translate,scale,opacity] hover:bg-bg-200 data-[direction=start]:top-3 data-[revealed=false]:pointer-events-none data-[revealed=false]:-translate-y-2 data-[revealed=false]:opacity-0 motion-reduce:transition-none"
+              onClick={handleScrollToFirstMessage}
             >
               <ArrowDownIcon aria-hidden="true" />
               <span>{t('First message')}</span>

--- a/src/renderer/src/pages/workspace/WorkspaceRunMarks.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceRunMarks.interaction.test.tsx
@@ -372,6 +372,43 @@ describe('WorkspaceRunMarks interaction', () => {
     expect(scrollTo).toHaveBeenCalledWith({ top: 800, behavior: 'smooth' })
   })
 
+  it('reveals a run outside the transcript window before scrolling to it', () => {
+    appendMessageTarget(viewport, 'prompt-2', 600)
+    const scrollTo = vi.fn()
+    viewport.scrollTo = scrollTo
+    const items = [
+      createMessageItem({ id: 'prompt-1', content: 'Hidden prompt' }, 0),
+      createMessageItem({ id: 'prompt-2', content: 'Visible prompt' }, 1)
+    ]
+    const onRevealMessage = vi.fn((messageId: string) => {
+      expect(messageId).toBe('prompt-1')
+      appendMessageTarget(viewport, 'prompt-1', 120)
+    })
+
+    const { rerender } = render(
+      <WorkspaceRunMarks
+        viewport={viewport}
+        items={items}
+        transcriptWindowStart={1}
+        onRevealMessage={onRevealMessage}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Go to run 1/u }))
+    expect(onRevealMessage).toHaveBeenCalledTimes(1)
+    expect(scrollTo).not.toHaveBeenCalled()
+
+    rerender(
+      <WorkspaceRunMarks
+        viewport={viewport}
+        items={items}
+        transcriptWindowStart={0}
+        onRevealMessage={onRevealMessage}
+      />
+    )
+    expect(scrollTo).toHaveBeenCalledWith({ top: 12, behavior: 'smooth' })
+  })
+
   it('tracks the last mark above the viewport reading boundary', () => {
     appendMessageTarget(viewport, 'prompt-1', 80)
     appendMessageTarget(viewport, 'prompt-2', 125)

--- a/src/renderer/src/pages/workspace/WorkspaceRunMarks.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceRunMarks.tsx
@@ -21,6 +21,8 @@ import {
 type WorkspaceRunMarksProps = {
   items: readonly GroupedConversationItem[]
   viewport: HTMLDivElement | null
+  transcriptWindowStart?: number
+  onRevealMessage?: (messageId: string) => void
 }
 
 const RUN_MARK_HOVER_DELAY_MS = 200
@@ -37,7 +39,9 @@ type RunMarkRailPosition = {
 
 const WorkspaceRunMarks = ({
   items,
-  viewport
+  viewport,
+  transcriptWindowStart = 0,
+  onRevealMessage
 }: WorkspaceRunMarksProps): React.JSX.Element | null => {
   const { t } = useTranslation()
   const marks = useMemo(() => createRunMarks(items), [items])
@@ -49,6 +53,7 @@ const WorkspaceRunMarks = ({
   const [railPosition, setRailPosition] = useState<RunMarkRailPosition | null>(null)
   const animationFrameRef = useRef<number | undefined>(undefined)
   const layoutAnimationFrameRef = useRef<number | undefined>(undefined)
+  const pendingNavigationRef = useRef<{ mark: RunMark; index: number } | undefined>(undefined)
 
   const updateCurrentIndex = useCallback((): void => {
     if (!viewport || marks.length === 0) return
@@ -87,10 +92,15 @@ const WorkspaceRunMarks = ({
         element.dataset.messageId ? [element.dataset.messageId] : []
       )
     )
-    // The rendered transcript is the source of truth for whether a projected mark is navigable.
+    // A parent with a bounded transcript window can reveal hidden targets on demand; otherwise the
+    // rendered transcript remains the source of truth for whether a projected mark is navigable.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setAvailableMessageIds(
-      new Set(marks.flatMap((mark) => (renderedMessageIds.has(mark.id) ? [mark.id] : [])))
+      new Set(
+        marks.flatMap((mark) =>
+          onRevealMessage || renderedMessageIds.has(mark.id) ? [mark.id] : []
+        )
+      )
     )
     updateCurrentIndex()
     updateRailPosition()
@@ -132,24 +142,42 @@ const WorkspaceRunMarks = ({
         layoutAnimationFrameRef.current = undefined
       }
     }
-  }, [marks, updateCurrentIndex, updateRailPosition, viewport])
+  }, [marks, onRevealMessage, updateCurrentIndex, updateRailPosition, viewport])
 
-  const scrollToRun = (mark: RunMark, index: number): void => {
-    if (!viewport) return
-    const target = findMessageTarget(viewport, mark.id)
-    if (!target) return
+  const scrollToRun = useCallback(
+    (mark: RunMark, index: number): void => {
+      if (!viewport) return
+      const target = findMessageTarget(viewport, mark.id)
+      if (!target) {
+        if (onRevealMessage) {
+          pendingNavigationRef.current = { mark, index }
+          onRevealMessage(mark.id)
+        }
+        return
+      }
 
-    const viewportTop = viewport.getBoundingClientRect().top
-    const targetTop = target.getBoundingClientRect().top
-    const maximumScrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight)
-    const nextScrollTop = Math.min(
-      Math.max(0, viewport.scrollTop + targetTop - viewportTop - RUN_MARK_TOP_OFFSET_PX),
-      maximumScrollTop
-    )
-    const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
-    viewport.scrollTo({ top: nextScrollTop, behavior: reduceMotion ? 'auto' : 'smooth' })
-    setCurrentIndex(index)
-  }
+      const viewportTop = viewport.getBoundingClientRect().top
+      const targetTop = target.getBoundingClientRect().top
+      const maximumScrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight)
+      const nextScrollTop = Math.min(
+        Math.max(0, viewport.scrollTop + targetTop - viewportTop - RUN_MARK_TOP_OFFSET_PX),
+        maximumScrollTop
+      )
+      const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+      viewport.scrollTo({ top: nextScrollTop, behavior: reduceMotion ? 'auto' : 'smooth' })
+      setCurrentIndex(index)
+    },
+    [onRevealMessage, viewport]
+  )
+
+  useLayoutEffect(() => {
+    const pendingNavigation = pendingNavigationRef.current
+    if (!pendingNavigation || !viewport) return
+    if (!findMessageTarget(viewport, pendingNavigation.mark.id)) return
+
+    pendingNavigationRef.current = undefined
+    scrollToRun(pendingNavigation.mark, pendingNavigation.index)
+  }, [scrollToRun, transcriptWindowStart, viewport])
 
   if (marks.length < 2 || !railPosition || typeof document === 'undefined') return null
 

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -496,7 +496,12 @@ describe('conversation message scroller integration', () => {
     expect(workspaceMessageScrollerSource).not.toContain('createActivityToggleLabel(')
     expect(workspaceMessageScrollerSource).not.toContain('renderWebSearchDetails(')
     expect(workspaceMessageScrollerSource).not.toContain('formatActivityDetails(activity)')
-    expect(workspaceMessageScrollerSource).toContain('conversationItems.map((item, itemIndex)')
+    expect(workspaceMessageScrollerSource).toContain(
+      'renderedConversationItems.map((item, windowItemIndex)'
+    )
+    expect(workspaceMessageScrollerSource).toContain(
+      'const itemIndex = transcriptWindowStart + windowItemIndex'
+    )
     expect(workspaceMessageScrollerSource).toMatch(/import \{[^}]*\buseState\b[^}]*\} from 'react'/)
     expect(workspaceMessageScrollerSource).toContain('const currentSessionId = activeSession?.id')
     expect(workspaceMessageScrollerSource).toContain(

--- a/src/shared/window-controls.test.ts
+++ b/src/shared/window-controls.test.ts
@@ -5,6 +5,8 @@ import {
   CLOSE_ACTIVE_PANE_READY_CHANNEL,
   CLOSE_ACTIVE_PANE_UNREADY_CHANNEL,
   WINDOW_FIND_READY_CHANNEL,
+  WINDOW_FIND_PREPARE_CHANNEL,
+  WINDOW_FIND_PREPARED_CHANNEL,
   WINDOW_FIND_UNREADY_CHANNEL,
   announceWindowFindReady,
   isWindowFindAppearance,
@@ -169,5 +171,34 @@ describe('announceWindowFindReady', () => {
     unsubscribe()
 
     expect(send).toHaveBeenCalledWith(WINDOW_FIND_UNREADY_CHANNEL)
+  })
+
+  it('exposes one completion callback for each validated find preparation request', () => {
+    const send = vi.fn()
+    const removeListener = vi.fn()
+    let prepareListener: ((payload: unknown) => void) | undefined
+    const on = vi.fn((channel: string, listener: (payload: unknown) => void) => {
+      expect(channel).toBe(WINDOW_FIND_PREPARE_CHANNEL)
+      prepareListener = listener
+      return removeListener
+    })
+    const onPrepare = vi.fn()
+
+    const unsubscribe = announceWindowFindReady({ on, send }, onPrepare)
+    prepareListener?.({ requestId: 42 })
+
+    expect(onPrepare).toHaveBeenCalledTimes(1)
+    const preparation = onPrepare.mock.calls[0]?.[0]
+    preparation.complete()
+    preparation.complete()
+    expect(send).toHaveBeenCalledWith(WINDOW_FIND_PREPARED_CHANNEL, { requestId: 42 })
+    expect(send).toHaveBeenCalledTimes(2)
+
+    prepareListener?.({ requestId: 'invalid' })
+    expect(onPrepare).toHaveBeenCalledTimes(1)
+
+    unsubscribe()
+    expect(removeListener).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenLastCalledWith(WINDOW_FIND_UNREADY_CHANNEL)
   })
 })

--- a/src/shared/window-controls.ts
+++ b/src/shared/window-controls.ts
@@ -31,6 +31,13 @@ export const WINDOW_FIND_REQUEST_CHANNEL = 'window:find-in-page'
 export const WINDOW_FIND_CLEAR_CHANNEL = 'window:clear-find-in-page'
 export const WINDOW_FIND_RESULT_CHANNEL = 'window:find-in-page-result'
 
+// Before native page-find runs, main asks the Workspace to expose any transcript rows that are
+// intentionally outside the initial render window. The renderer acknowledges only after React has
+// committed those rows, so Electron searches the complete active transcript rather than the current
+// DOM window.
+export const WINDOW_FIND_PREPARE_CHANNEL = 'window:find-prepare'
+export const WINDOW_FIND_PREPARED_CHANNEL = 'window:find-prepared'
+
 // Main -> overlay: the find bar was just shown — apply the main renderer's resolved appearance,
 // focus the field, and re-run the remembered query. `followsSystem` lets the separate file:// overlay
 // live-follow OS changes without trying to read the renderer's origin-scoped localStorage.
@@ -60,6 +67,14 @@ export type WindowFindResult = {
   activeMatchOrdinal: number
   matches: number
   finalUpdate: boolean
+}
+
+export type WindowFindPrepareRequest = {
+  requestId: number
+}
+
+export type WindowFindPreparation = WindowFindPrepareRequest & {
+  complete: () => void
 }
 
 export type WindowFindAppearance = {
@@ -99,15 +114,44 @@ export const subscribeCloseActivePane = (
   }
 }
 
+type WindowFindReadyBridge = {
+  on?: (channel: string, listener: (payload: unknown) => void) => () => void
+  send: (channel: string, payload?: WindowFindPrepareRequest) => void
+}
+
+const isWindowFindPrepareRequest = (value: unknown): value is WindowFindPrepareRequest => {
+  if (!value || typeof value !== 'object') return false
+  return Number.isSafeInteger((value as Partial<WindowFindPrepareRequest>).requestId)
+}
+
 // In the overlay-window architecture main opens the find bar itself (no OPEN message reaches the
-// renderer), so the Workspace only needs to tell main that it is mounted and searchable. This announces
-// READY on mount and UNREADY on teardown, so main can keep intercepting Cmd/Ctrl+F only while a
-// searchable Workspace is actually present.
+// renderer). The Workspace announces that it is searchable and, when requested, exposes hidden
+// transcript rows before acknowledging that native find may start. Keeping the acknowledgement behind
+// the completion callback prevents renderer callers from inventing or mismatching request ids.
 export const announceWindowFindReady = (
-  bridge: Pick<CloseActivePaneBridge, 'send'>
+  bridge: WindowFindReadyBridge,
+  onPrepare?: (preparation: WindowFindPreparation) => void
 ): (() => void) => {
+  const removePrepareListener =
+    onPrepare && bridge.on
+      ? bridge.on(WINDOW_FIND_PREPARE_CHANNEL, (payload) => {
+          if (!isWindowFindPrepareRequest(payload)) return
+          let completed = false
+          onPrepare({
+            requestId: payload.requestId,
+            complete: () => {
+              if (completed) return
+              completed = true
+              bridge.send(WINDOW_FIND_PREPARED_CHANNEL, payload)
+            }
+          })
+        })
+      : undefined
   bridge.send(WINDOW_FIND_READY_CHANNEL)
-  return () => bridge.send(WINDOW_FIND_UNREADY_CHANNEL)
+  return () => {
+    removePrepareListener?.()
+    bridge.send(WINDOW_FIND_UNREADY_CHANNEL)
+  }
 }
 
 // The subset of Electron's before-input-event Input that the chord test needs. Kept structural so the


### PR DESCRIPTION
## Problem

Session startup currently reads and hydrates every persisted Session payload. The active Workspace then mounted every transcript row, so React node count grew linearly with the active Session even though `content-visibility` deferred only layout and paint.

A public-render regression fixture with 240 ordinary messages reproduced the reported DOM behavior: the unmodified scroller mounted all 240 message rows. The same fixture now mounts the latest 100 rows initially.

## Proposed change

- Render the latest 100 active-transcript items initially and load earlier items in 100-item chunks while preserving the reader's viewport.
- Preserve complete Cmd/Ctrl+F behavior with a main/preload/renderer prepare-and-ack handshake. Electron `findInPage` starts only after every mounted Scroller commits its complete active transcript.
- Keep Run Marks and “First message” navigation complete by revealing hidden targets before scrolling.
- Scope the transient render window by Session and active branch.

## Scope and non-goals

- No persisted Session fields, schema, enum values, migration, or historical-data compatibility path are added.
- No Session data-model or Zustand hydration architecture is changed; the complete Session remains available for branch/recovery behavior.
- This PR bounds React transcript nodes. It intentionally does not yet replace the startup repository scan with a metadata-first catalog or lazy Session hydration; that larger persistence boundary should be justified by startup parse/memory measurements separately.
- The only visible interaction change is a localized “Load earlier messages” control when older transcript rows are deferred. Native find may briefly wait for the hidden rows to commit.

## Acceptance criteria and validation

- Initial long-transcript DOM is bounded and the newest message remains visible.
- Earlier history loads in bounded chunks without moving the viewport.
- Native find waits for the complete committed transcript and ignores stale acknowledgements.
- Run Marks and first-message navigation reveal hidden targets.
- Active branch behavior remains scoped independently.

Final Test Impact Set, run after the last material edit:

- Transcript/render/navigation and find protocol → targeted Vitest command covering 8 files → 609 passed.
- Node main/preload/shared contracts → `npm run typecheck:node` → passed.
- Renderer and preload API consumers → `npm run typecheck:web` → passed.
- Source lint → `npm run lint` → passed.
- Impact planner → `npm run test:affected:explain -- --base main --head HEAD` → selected full fallback because `src/main/window-find-ipc.test.ts` has no declared module owner. Per maintainer instruction, the complete local `npm test` was not run; PR CI is authoritative for the full suite.

## Review focus

- The Session/active-branch scoping and viewport restoration around prepends.
- The one-shot find preparation completion callback and stale-request rejection in main.
- The explicit non-goal: persisted Session scan/hydration cost remains linear and is not hidden by this React-focused mitigation.
