### PR TITLE
fix(notebook): reclaim unused conda package cache

### DIFF
--- a/src/main/notebook/micromamba-cache-maintenance.ts
+++ b/src/main/notebook/micromamba-cache-maintenance.ts
@@ -1,5 +1,6 @@
 import { createLogger, diagnosticErrorFields } from '../logger'
 import { withExclusiveCacheLocks } from './pkgs-cache-lock'
+import { isChildUnconfirmedError } from './provisioner-runtime'
 
 const logger = createLogger('notebook:package-cache')
 
@@ -10,13 +11,13 @@ export const packageCacheCleanArgv = (micromamba: string): string[] => [
   '--no-rc',
   'clean',
   '--packages',
-  '--tarballs',
   '--yes'
 ]
 
-// Cache maintenance is opportunistic: a cleanup bug must not turn a package/environment mutation that
-// could otherwise succeed into a new hard failure. The existing exclusive cache locks still make the
-// deletion safe with respect to concurrent create/install operations.
+// Cache maintenance is opportunistic for ordinary failures: a cleanup bug must not turn a package or
+// environment mutation that could otherwise succeed into a new hard failure. CHILD_UNCONFIRMED is the
+// exception: the cleanup worker may still be deleting cache entries, so the journaled caller must retain
+// its recovery evidence and refuse to start another cache writer.
 export const maintainPackageCacheBestEffort = async (
   cacheLockKeys: string[],
   run: () => Promise<void>
@@ -24,6 +25,7 @@ export const maintainPackageCacheBestEffort = async (
   try {
     await withExclusiveCacheLocks(cacheLockKeys, run)
   } catch (error) {
+    if (isChildUnconfirmedError(error)) throw error
     logger.warn('package cache maintenance failed', diagnosticErrorFields(error))
   }
 }

--- a/src/main/notebook/micromamba-cache-maintenance.ts
+++ b/src/main/notebook/micromamba-cache-maintenance.ts
@@ -20,7 +20,8 @@ export const packageCacheCleanArgv = (micromamba: string): string[] => [
 // its recovery evidence and refuse to start another cache writer.
 export const maintainPackageCacheBestEffort = async (
   cacheLockKeys: string[],
-  run: () => Promise<void>
+  run: () => Promise<void>,
+  onSettled?: () => Promise<void> | void
 ): Promise<void> => {
   try {
     await withExclusiveCacheLocks(cacheLockKeys, run)
@@ -28,4 +29,5 @@ export const maintainPackageCacheBestEffort = async (
     if (isChildUnconfirmedError(error)) throw error
     logger.warn('package cache maintenance failed', diagnosticErrorFields(error))
   }
+  await onSettled?.()
 }

--- a/src/main/notebook/micromamba-cache-maintenance.ts
+++ b/src/main/notebook/micromamba-cache-maintenance.ts
@@ -1,0 +1,29 @@
+import { createLogger, diagnosticErrorFields } from '../logger'
+import { withExclusiveCacheLocks } from './pkgs-cache-lock'
+
+const logger = createLogger('notebook:package-cache')
+
+// `clean` does not accept --root-prefix. Callers bind MAMBA_ROOT_PREFIX and CONDA_PKGS_DIRS in the
+// subprocess environment so cleanup cannot follow inherited host Conda settings outside app storage.
+export const packageCacheCleanArgv = (micromamba: string): string[] => [
+  micromamba,
+  '--no-rc',
+  'clean',
+  '--packages',
+  '--tarballs',
+  '--yes'
+]
+
+// Cache maintenance is opportunistic: a cleanup bug must not turn a package/environment mutation that
+// could otherwise succeed into a new hard failure. The existing exclusive cache locks still make the
+// deletion safe with respect to concurrent create/install operations.
+export const maintainPackageCacheBestEffort = async (
+  cacheLockKeys: string[],
+  run: () => Promise<void>
+): Promise<void> => {
+  try {
+    await withExclusiveCacheLocks(cacheLockKeys, run)
+  } catch (error) {
+    logger.warn('package cache maintenance failed', diagnosticErrorFields(error))
+  }
+}

--- a/src/main/notebook/package-manager.test.ts
+++ b/src/main/notebook/package-manager.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
@@ -39,6 +39,10 @@ const scriptedSpawn = (
   const calls: [string, string[], NodeJS.ProcessEnv?][] = []
   let i = 0
   const spawn: InstallSpawn = async (command, args, env) => {
+    // Cache maintenance is orthogonal to the transaction result scripts below. The dedicated cache-
+    // growth test observes it directly; existing command-contract tests keep recording only the
+    // install/remove/pip/R subprocesses they own.
+    if (args.includes('clean')) return ok
     calls.push([command, args, env])
     return results[i++] ?? { code: 0, stdout: '', stderr: '' }
   }
@@ -535,7 +539,8 @@ describe('installPackages', () => {
   it('journals the approved R transaction but not the read-only dry-run', async () => {
     const order: string[] = []
     let call = 0
-    const spawn: InstallSpawn = async (_command, _args, _env, onChild, onBeforeSpawn) => {
+    const spawn: InstallSpawn = async (_command, args, _env, onChild, onBeforeSpawn) => {
+      if (args.includes('clean')) return ok
       onBeforeSpawn?.()
       order.push(`spawn#${call}`)
       onChild?.(4100 + call)
@@ -864,7 +869,8 @@ describe('installPackages', () => {
       { code: 1, stdout: 'retry install stdout', stderr: 'retry install failed' }
     ]
     let calls = 0
-    const spawn: InstallSpawn = async () => {
+    const spawn: InstallSpawn = async (_command, args) => {
+      if (args.includes('clean')) return ok
       calls += 1
       return results[calls - 1]
     }
@@ -919,7 +925,8 @@ describe('installPackages', () => {
     let i = 0
     // deps.onBeforeSpawn is threaded to baseSpawn as its 5th arg; a faithful stub invokes it (as the real
     // defaultSpawn does) BEFORE reporting the child, so we can assert both that it ran and that it ran first.
-    const spawn: InstallSpawn = async (_command, _args, _env, onChild, onBeforeSpawn) => {
+    const spawn: InstallSpawn = async (_command, args, _env, onChild, onBeforeSpawn) => {
+      if (args.includes('clean')) return ok
       onBeforeSpawn?.()
       order.push(`child#${i}`)
       onChild?.(1000 + i)
@@ -1524,6 +1531,72 @@ describe('installPackages default-env additive-only policy', () => {
 })
 
 describe('installPackages shared pkgs cache lock', () => {
+  it('removes a superseded cached package before the next conda mutation', async () => {
+    const storageRoot = mkdtempSync(join(tmpdir(), 'os-package-cache-growth-'))
+    const root = runtimeRoot(storageRoot)
+    const cachePath = join(root, 'pkgs')
+    const stalePackage = join(cachePath, 'zlib-1.2.13-h2466b09_6')
+    mkdirSync(stalePackage, { recursive: true })
+    const order: string[] = []
+    let cleanEnv: NodeJS.ProcessEnv | undefined
+    let cleanArgs: string[] | undefined
+    const spawn: InstallSpawn = async (_command, args, env) => {
+      if (args.includes('clean')) {
+        order.push('clean')
+        cleanArgs = args
+        cleanEnv = env
+        rmSync(stalePackage, { recursive: true, force: true })
+      } else {
+        order.push('install')
+      }
+      return ok
+    }
+
+    const result = await installPackages(
+      { language: 'python', packages: ['zlib==1.3.1'] },
+      {
+        ...base,
+        storageRoot,
+        spawn,
+        micromambaEnv: {
+          selectCache: () => ({
+            path: cachePath,
+            lockKey: micromambaCacheLockKey(cachePath)
+          })
+        }
+      }
+    )
+
+    expect(result.ok).toBe(true)
+    expect(existsSync(stalePackage)).toBe(false)
+    expect(order).toEqual(['clean', 'install'])
+    expect(cleanArgs).toEqual(['--no-rc', 'clean', '--packages', '--tarballs', '--yes'])
+    expect(cleanEnv).toMatchObject({
+      MAMBA_ROOT_PREFIX: root,
+      CONDA_PKGS_DIRS: cachePath
+    })
+  })
+
+  it('continues the requested install when cache maintenance fails', async () => {
+    const order: string[] = []
+    const spawn: InstallSpawn = async (_command, args) => {
+      if (args.includes('clean')) {
+        order.push('clean-failed')
+        return { code: 1, stdout: '', stderr: 'cleanup failed' }
+      }
+      order.push('install')
+      return ok
+    }
+
+    const result = await installPackages(
+      { language: 'python', packages: ['numpy'] },
+      { ...base, spawn }
+    )
+
+    expect(result.ok).toBe(true)
+    expect(order).toEqual(['clean-failed', 'install'])
+  })
+
   it.each(['legacy', 'selected'] as const)(
     'holds the %s physical cache identity while micromamba runs',
     async (heldCache) => {
@@ -1567,7 +1640,7 @@ describe('installPackages shared pkgs cache lock', () => {
       expect(spawn).not.toHaveBeenCalled()
       releaseCache()
       await Promise.all([reader, install])
-      expect(spawn).toHaveBeenCalledOnce()
+      expect(spawn.mock.calls.filter(([, args]) => !args.includes('clean'))).toHaveLength(1)
     }
   )
 
@@ -1578,8 +1651,12 @@ describe('installPackages shared pkgs cache lock', () => {
   // across a delay, and an exclusive holder requested meanwhile must wait until the spawn releases it.
   it('holds the shared lock across a conda install, so a concurrent exclusive repair cannot run mid-install', async () => {
     const order: string[] = []
-    const spawn: InstallSpawn = async () => {
+    let markInstallStarted!: () => void
+    const installStarted = new Promise<void>((resolve) => (markInstallStarted = resolve))
+    const spawn: InstallSpawn = async (_command, args) => {
+      if (args.includes('clean')) return ok
       order.push('install-start')
+      markInstallStarted()
       await new Promise((r) => setTimeout(r, 10))
       order.push('install-end')
       return ok
@@ -1588,6 +1665,7 @@ describe('installPackages shared pkgs cache lock', () => {
     // Kick off the conda install (holds the shared lock synchronously), then request the cache EXCLUSIVE
     // on the same key the source uses.
     const install = installPackages({ language: 'python', packages: ['numpy'] }, { spawn, ...base })
+    await installStarted
     const exclusive = withExclusiveCacheLock(
       selectMicromambaCache(runtimeRoot('/root')).lockKey,
       async () => {
@@ -1601,8 +1679,12 @@ describe('installPackages shared pkgs cache lock', () => {
 
   it('holds the shared lock across a conda remove, so a concurrent exclusive repair cannot run mid-remove', async () => {
     const order: string[] = []
-    const spawn: InstallSpawn = async () => {
+    let markRemoveStarted!: () => void
+    const removeStarted = new Promise<void>((resolve) => (markRemoveStarted = resolve))
+    const spawn: InstallSpawn = async (_command, args) => {
+      if (args.includes('clean')) return ok
       order.push('remove-start')
+      markRemoveStarted()
       await new Promise((r) => setTimeout(r, 10))
       order.push('remove-end')
       return ok
@@ -1619,6 +1701,7 @@ describe('installPackages shared pkgs cache lock', () => {
       },
       { spawn, ...base, pathExists: () => true }
     )
+    await removeStarted
     const exclusive = withExclusiveCacheLock(
       selectMicromambaCache(runtimeRoot('/root')).lockKey,
       async () => {

--- a/src/main/notebook/package-manager.test.ts
+++ b/src/main/notebook/package-manager.test.ts
@@ -1570,13 +1570,14 @@ describe('installPackages shared pkgs cache lock', () => {
             path: cachePath,
             lockKey: micromambaCacheLockKey(cachePath)
           })
-        }
+        },
+        onCacheMaintenanceSettled: () => void order.push('settled')
       }
     )
 
     expect(result.ok).toBe(true)
     expect(existsSync(stalePackage)).toBe(false)
-    expect(order).toEqual(['clean', 'install'])
+    expect(order).toEqual(['clean', 'settled', 'install'])
     expect(cleanArgs).toEqual(['--no-rc', 'clean', '--packages', '--yes'])
     expect(cleanEnv).toMatchObject({
       MAMBA_ROOT_PREFIX: root,
@@ -1597,15 +1598,16 @@ describe('installPackages shared pkgs cache lock', () => {
 
     const result = await installPackages(
       { language: 'python', packages: ['numpy'] },
-      { ...base, spawn }
+      { ...base, spawn, onCacheMaintenanceSettled: () => void order.push('settled') }
     )
 
     expect(result.ok).toBe(true)
-    expect(order).toEqual(['clean-failed', 'install'])
+    expect(order).toEqual(['clean-failed', 'settled', 'install'])
   })
 
   it('does not continue when the cleanup worker cannot be confirmed stopped', async () => {
     let installStarted = false
+    const onCacheMaintenanceSettled = vi.fn()
     const spawn: InstallSpawn = async (_command, args) => {
       if (isCacheClean(args)) {
         throw new Error(`${CHILD_UNCONFIRMED}: cleanup worker may still be running`)
@@ -1615,9 +1617,13 @@ describe('installPackages shared pkgs cache lock', () => {
     }
 
     await expect(
-      installPackages({ language: 'python', packages: ['numpy'] }, { ...base, spawn })
+      installPackages(
+        { language: 'python', packages: ['numpy'] },
+        { ...base, spawn, onCacheMaintenanceSettled }
+      )
     ).rejects.toThrow(CHILD_UNCONFIRMED)
     expect(installStarted).toBe(false)
+    expect(onCacheMaintenanceSettled).not.toHaveBeenCalled()
   })
 
   it.each(['legacy', 'selected'] as const)(

--- a/src/main/notebook/package-manager.test.ts
+++ b/src/main/notebook/package-manager.test.ts
@@ -22,6 +22,7 @@ import {
 } from './package-manager'
 import { micromambaCacheLockKey, selectMicromambaCache } from './micromamba-cache'
 import { withExclusiveCacheLock } from './pkgs-cache-lock'
+import { CHILD_UNCONFIRMED } from './provisioner-runtime'
 import {
   envPrefix,
   pipBin,
@@ -927,7 +928,12 @@ describe('installPackages', () => {
     // deps.onBeforeSpawn is threaded to baseSpawn as its 5th arg; a faithful stub invokes it (as the real
     // defaultSpawn does) BEFORE reporting the child, so we can assert both that it ran and that it ran first.
     const spawn: InstallSpawn = async (_command, args, _env, onChild, onBeforeSpawn) => {
-      if (isCacheClean(args)) return ok
+      if (isCacheClean(args)) {
+        onBeforeSpawn?.()
+        order.push('cleanup-child')
+        onChild?.(999)
+        return ok
+      }
       onBeforeSpawn?.()
       order.push(`child#${i}`)
       onChild?.(1000 + i)
@@ -954,7 +960,7 @@ describe('installPackages', () => {
     expect(result.ok).toBe(true)
     // The intent fired before the child on the FIRST spawn AND again on the RETRY (old bug: zero intents,
     // since runConda dropped deps.onBeforeSpawn entirely).
-    expect(order).toEqual(['intent', 'child#0', 'intent', 'child#1'])
+    expect(order).toEqual(['intent', 'cleanup-child', 'intent', 'child#0', 'intent', 'child#1'])
     expect(i).toBe(2)
   })
 
@@ -1571,7 +1577,7 @@ describe('installPackages shared pkgs cache lock', () => {
     expect(result.ok).toBe(true)
     expect(existsSync(stalePackage)).toBe(false)
     expect(order).toEqual(['clean', 'install'])
-    expect(cleanArgs).toEqual(['--no-rc', 'clean', '--packages', '--tarballs', '--yes'])
+    expect(cleanArgs).toEqual(['--no-rc', 'clean', '--packages', '--yes'])
     expect(cleanEnv).toMatchObject({
       MAMBA_ROOT_PREFIX: root,
       CONDA_PKGS_DIRS: cachePath
@@ -1596,6 +1602,22 @@ describe('installPackages shared pkgs cache lock', () => {
 
     expect(result.ok).toBe(true)
     expect(order).toEqual(['clean-failed', 'install'])
+  })
+
+  it('does not continue when the cleanup worker cannot be confirmed stopped', async () => {
+    let installStarted = false
+    const spawn: InstallSpawn = async (_command, args) => {
+      if (isCacheClean(args)) {
+        throw new Error(`${CHILD_UNCONFIRMED}: cleanup worker may still be running`)
+      }
+      installStarted = true
+      return ok
+    }
+
+    await expect(
+      installPackages({ language: 'python', packages: ['numpy'] }, { ...base, spawn })
+    ).rejects.toThrow(CHILD_UNCONFIRMED)
+    expect(installStarted).toBe(false)
   })
 
   it.each(['legacy', 'selected'] as const)(

--- a/src/main/notebook/package-manager.test.ts
+++ b/src/main/notebook/package-manager.test.ts
@@ -42,7 +42,7 @@ const scriptedSpawn = (
     // Cache maintenance is orthogonal to the transaction result scripts below. The dedicated cache-
     // growth test observes it directly; existing command-contract tests keep recording only the
     // install/remove/pip/R subprocesses they own.
-    if (args.includes('clean')) return ok
+    if (isCacheClean(args)) return ok
     calls.push([command, args, env])
     return results[i++] ?? { code: 0, stdout: '', stderr: '' }
   }
@@ -50,6 +50,7 @@ const scriptedSpawn = (
 }
 
 const ok: SpawnResult = { code: 0, stdout: 'done', stderr: '' }
+const isCacheClean = (args: string[]): boolean => args[0] === '--no-rc' && args[1] === 'clean'
 const safeRPlan: SpawnResult = {
   code: 0,
   stdout: JSON.stringify({
@@ -540,7 +541,7 @@ describe('installPackages', () => {
     const order: string[] = []
     let call = 0
     const spawn: InstallSpawn = async (_command, args, _env, onChild, onBeforeSpawn) => {
-      if (args.includes('clean')) return ok
+      if (isCacheClean(args)) return ok
       onBeforeSpawn?.()
       order.push(`spawn#${call}`)
       onChild?.(4100 + call)
@@ -870,7 +871,7 @@ describe('installPackages', () => {
     ]
     let calls = 0
     const spawn: InstallSpawn = async (_command, args) => {
-      if (args.includes('clean')) return ok
+      if (isCacheClean(args)) return ok
       calls += 1
       return results[calls - 1]
     }
@@ -926,7 +927,7 @@ describe('installPackages', () => {
     // deps.onBeforeSpawn is threaded to baseSpawn as its 5th arg; a faithful stub invokes it (as the real
     // defaultSpawn does) BEFORE reporting the child, so we can assert both that it ran and that it ran first.
     const spawn: InstallSpawn = async (_command, args, _env, onChild, onBeforeSpawn) => {
-      if (args.includes('clean')) return ok
+      if (isCacheClean(args)) return ok
       onBeforeSpawn?.()
       order.push(`child#${i}`)
       onChild?.(1000 + i)
@@ -1541,7 +1542,7 @@ describe('installPackages shared pkgs cache lock', () => {
     let cleanEnv: NodeJS.ProcessEnv | undefined
     let cleanArgs: string[] | undefined
     const spawn: InstallSpawn = async (_command, args, env) => {
-      if (args.includes('clean')) {
+      if (isCacheClean(args)) {
         order.push('clean')
         cleanArgs = args
         cleanEnv = env
@@ -1580,7 +1581,7 @@ describe('installPackages shared pkgs cache lock', () => {
   it('continues the requested install when cache maintenance fails', async () => {
     const order: string[] = []
     const spawn: InstallSpawn = async (_command, args) => {
-      if (args.includes('clean')) {
+      if (isCacheClean(args)) {
         order.push('clean-failed')
         return { code: 1, stdout: '', stderr: 'cleanup failed' }
       }
@@ -1640,7 +1641,7 @@ describe('installPackages shared pkgs cache lock', () => {
       expect(spawn).not.toHaveBeenCalled()
       releaseCache()
       await Promise.all([reader, install])
-      expect(spawn.mock.calls.filter(([, args]) => !args.includes('clean'))).toHaveLength(1)
+      expect(spawn.mock.calls.filter(([, args]) => !isCacheClean(args))).toHaveLength(1)
     }
   )
 
@@ -1654,7 +1655,7 @@ describe('installPackages shared pkgs cache lock', () => {
     let markInstallStarted!: () => void
     const installStarted = new Promise<void>((resolve) => (markInstallStarted = resolve))
     const spawn: InstallSpawn = async (_command, args) => {
-      if (args.includes('clean')) return ok
+      if (isCacheClean(args)) return ok
       order.push('install-start')
       markInstallStarted()
       await new Promise((r) => setTimeout(r, 10))
@@ -1682,7 +1683,7 @@ describe('installPackages shared pkgs cache lock', () => {
     let markRemoveStarted!: () => void
     const removeStarted = new Promise<void>((resolve) => (markRemoveStarted = resolve))
     const spawn: InstallSpawn = async (_command, args) => {
-      if (args.includes('clean')) return ok
+      if (isCacheClean(args)) return ok
       order.push('remove-start')
       markRemoveStarted()
       await new Promise((r) => setTimeout(r, 10))

--- a/src/main/notebook/package-manager.ts
+++ b/src/main/notebook/package-manager.ts
@@ -166,6 +166,9 @@ export type InstallDeps = {
   onChild?: (pid: number) => void
   // Invoked synchronously right before EACH spawn so the caller can (re)record the per-spawn intent.
   onBeforeSpawn?: () => void
+  // Invoked after cache maintenance has either completed or failed with its child confirmed stopped.
+  // The journal owner uses it to clear the maintenance child's evidence before any solver/install spawn.
+  onCacheMaintenanceSettled?: () => Promise<void> | void
 }
 
 const DEFAULT_CONDA_CHANNEL = 'conda-forge'
@@ -1172,7 +1175,8 @@ export async function installPackages(
             code: 'MICROMAMBA_CACHE_CLEAN_EXIT'
           })
         }
-      }
+      },
+      deps.onCacheMaintenanceSettled
     )
     return condaCacheMaintenance
   }

--- a/src/main/notebook/package-manager.ts
+++ b/src/main/notebook/package-manager.ts
@@ -34,6 +34,10 @@ import {
   selectMicromambaCache,
   type MicromambaCache
 } from './micromamba-cache'
+import {
+  maintainPackageCacheBestEffort,
+  packageCacheCleanArgv
+} from './micromamba-cache-maintenance'
 import { recoverWindowsMaxPathPackage } from './micromamba-cache-recovery'
 import { withExclusiveCacheLocks, withSharedCacheLocks } from './pkgs-cache-lock'
 import { CHILD_UNCONFIRMED, killAndConfirmExit } from './provisioner-runtime'
@@ -1139,12 +1143,40 @@ export async function installPackages(
       canonicalize: deps.micromambaEnv?.canonicalize
     })
   ]
+  // A single install request may run a dry-run and a real transaction. Maintain the persistent cache
+  // once, before whichever conda subprocess comes first, so old versions are reclaimed without adding
+  // duplicate scans. Cleanup is deliberately outside the prefix-write journal: it never writes the
+  // target environment, and maintainPackageCacheBestEffort owns the cache-exclusive lock and failure
+  // isolation.
+  let condaCacheMaintenance: Promise<void> | undefined
+  const maintainCondaCache = (command: string): Promise<void> => {
+    if (condaCacheMaintenance) return condaCacheMaintenance
+    const context = resolveCondaContext()
+    const argv = packageCacheCleanArgv(command)
+    condaCacheMaintenance = maintainPackageCacheBestEffort(
+      condaCacheKeys(context.cache),
+      async () => {
+        const result = await baseSpawn(argv[0], argv.slice(1), {
+          ...context.env,
+          MAMBA_ROOT_PREFIX: root,
+          CONDA_PKGS_DIRS: context.cache.path
+        })
+        if (result.code !== 0) {
+          throw Object.assign(new Error('micromamba package cache maintenance failed'), {
+            code: 'MICROMAMBA_CACHE_CLEAN_EXIT'
+          })
+        }
+      }
+    )
+    return condaCacheMaintenance
+  }
   // A dry-run may refresh repodata in the shared package cache, so it takes the same in-process cache
   // locks as a real transaction. It deliberately does NOT reuse the install journal hooks: the solver
   // cannot write the target prefix, and recording it as an `install` would make a crash after a harmless
   // probe quarantine an untouched runtime at the next startup.
   const runCondaPreflight: InstallSpawn = async (command, args) => {
     const context = resolveCondaContext()
+    await maintainCondaCache(command)
     return withSharedCacheLocks(condaCacheKeys(context.cache), () =>
       baseSpawn(command, args, context.env)
     )
@@ -1156,6 +1188,7 @@ export async function installPackages(
   ): Promise<SpawnResult> => {
     const context = resolveCondaContext()
     const cacheKeys = condaCacheKeys(context.cache)
+    await maintainCondaCache(command)
     const result = await withSharedCacheLocks(cacheKeys, () =>
       // Thread onBeforeSpawn so the {spawning} intent sidecar is written BEFORE conda spawns, exactly as
       // the pip path does. Without it, a crash in the spawn→onChild window leaves no sidecar, and recovery

--- a/src/main/notebook/package-manager.ts
+++ b/src/main/notebook/package-manager.ts
@@ -1145,9 +1145,9 @@ export async function installPackages(
   ]
   // A single install request may run a dry-run and a real transaction. Maintain the persistent cache
   // once, before whichever conda subprocess comes first, so old versions are reclaimed without adding
-  // duplicate scans. Cleanup is deliberately outside the prefix-write journal: it never writes the
-  // target environment, and maintainPackageCacheBestEffort owns the cache-exclusive lock and failure
-  // isolation.
+  // duplicate scans. Cleanup reuses the package operation's spawn hooks. It does not write the target
+  // prefix, but a crash may leave its cache-deleting child alive; recording that child lets the existing
+  // recovery barrier prevent a later cache mutation from racing it without another journal kind.
   let condaCacheMaintenance: Promise<void> | undefined
   const maintainCondaCache = (command: string): Promise<void> => {
     if (condaCacheMaintenance) return condaCacheMaintenance
@@ -1156,11 +1156,17 @@ export async function installPackages(
     condaCacheMaintenance = maintainPackageCacheBestEffort(
       condaCacheKeys(context.cache),
       async () => {
-        const result = await baseSpawn(argv[0], argv.slice(1), {
-          ...context.env,
-          MAMBA_ROOT_PREFIX: root,
-          CONDA_PKGS_DIRS: context.cache.path
-        })
+        const result = await baseSpawn(
+          argv[0],
+          argv.slice(1),
+          {
+            ...context.env,
+            MAMBA_ROOT_PREFIX: root,
+            CONDA_PKGS_DIRS: context.cache.path
+          },
+          deps.onChild,
+          deps.onBeforeSpawn
+        )
         if (result.code !== 0) {
           throw Object.assign(new Error('micromamba package cache maintenance failed'), {
             code: 'MICROMAMBA_CACHE_CLEAN_EXIT'
@@ -1171,9 +1177,9 @@ export async function installPackages(
     return condaCacheMaintenance
   }
   // A dry-run may refresh repodata in the shared package cache, so it takes the same in-process cache
-  // locks as a real transaction. It deliberately does NOT reuse the install journal hooks: the solver
-  // cannot write the target prefix, and recording it as an `install` would make a crash after a harmless
-  // probe quarantine an untouched runtime at the next startup.
+  // locks as a real transaction. The solver itself deliberately does NOT reuse the install journal hooks:
+  // it cannot write the target prefix. Cache maintenance above does reuse them because its deleting child
+  // must remain supervised until it exits.
   const runCondaPreflight: InstallSpawn = async (command, args) => {
     const context = resolveCondaContext()
     await maintainCondaCache(command)

--- a/src/main/notebook/package-mutation.test.ts
+++ b/src/main/notebook/package-mutation.test.ts
@@ -231,6 +231,38 @@ describe('NotebookPackageMutationOwner', () => {
     expect(options.runtimeRepair.quarantineProtectedIdentity).not.toHaveBeenCalled()
   })
 
+  it('clears settled cache-maintenance child evidence before the installer transaction', async () => {
+    let operationId = ''
+    const { owner, target, runtimeRoot } = ownerHarness({
+      environmentStateTracker: {
+        markPackageMutationDirty: vi.fn(async (_target, mutation) => {
+          operationId = mutation.operationId
+        }),
+        refreshAfterPackageMutation: vi.fn().mockResolvedValue({ result: 'success' })
+      },
+      installPackages: vi.fn(async (_request, deps) => {
+        deps?.onBeforeSpawn?.()
+        deps?.onChild?.(process.pid)
+        await vi.waitFor(async () => {
+          expect((await pending(runtimeRoot))[0]).toMatchObject({ childPid: process.pid })
+        })
+
+        await (
+          deps as (typeof deps & { onCacheMaintenanceSettled?: () => Promise<void> }) | undefined
+        )?.onCacheMaintenanceSettled?.()
+
+        expect(readOperationChild(runtimeRoot, operationId)).toBeUndefined()
+        const [record] = await pending(runtimeRoot)
+        expect(record).not.toHaveProperty('childPid')
+        expect(record).not.toHaveProperty('childStartedAt')
+        expect(record).not.toHaveProperty('childStartToken')
+        return { ok: true, needsRestart: false, log: 'installed', method: 'conda' as const }
+      })
+    })
+
+    await expect(owner.mutate({ target, mirror: {} })).resolves.toMatchObject({ ok: true })
+  })
+
   it('fails closed without dirtying or spawning when the journal cannot begin', async () => {
     const { owner, options, target, runtimeRoot } = ownerHarness()
     writeFileSync(operationJournalPath(runtimeRoot), '{not-json', 'utf8')

--- a/src/main/notebook/package-mutation.ts
+++ b/src/main/notebook/package-mutation.ts
@@ -131,6 +131,18 @@ class NotebookPackageMutationOwner {
                 void journal
                   .update(operationId, { childPid, childStartedAt, childStartToken })
                   .catch(() => undefined)
+              },
+              onCacheMaintenanceSettled: async () => {
+                // Cache cleanup reuses this operation's recovery barrier while its child is alive, but
+                // it is not the installer transaction. Clear its settled identity before a dry-run or
+                // real install can begin so a crash in that gap cannot be recovered as an interrupted
+                // package mutation. Awaiting update also serializes behind the fire-and-forget PID write.
+                await journal.update(operationId, {
+                  childPid: undefined,
+                  childStartedAt: undefined,
+                  childStartToken: undefined
+                })
+                removeOperationChildSync(runtimeRoot, operationId)
               }
             })
             installerDurationMs = Date.now() - installerStartedAt

--- a/src/main/notebook/provisioner.startup.test.ts
+++ b/src/main/notebook/provisioner.startup.test.ts
@@ -284,27 +284,34 @@ describe('createProductionProvisioner', () => {
       },
       {
         runner: { initialPath: primary, resolve: async () => compatibility },
+        fetchBundle: async () => ({ lockPath: join(root, 'python.lock') }),
         runCacheMaintenance,
         runArgv,
         verify: async () => undefined
       }
     )
 
-    await provisioner.createNamedEnvironment('analysis', 'python')
+    await provisioner.provisionPython(() => undefined)
 
-    expect(runCacheMaintenance).toHaveBeenCalledOnce()
-    expect(runCacheMaintenance.mock.calls[0]?.[0]).toEqual([
+    expect(runCacheMaintenance).toHaveBeenCalled()
+    const selectedCacheCall = runCacheMaintenance.mock.calls.find(
+      ([, env]) => env?.CONDA_PKGS_DIRS === selectMicromambaCache(root).path
+    )
+    expect(selectedCacheCall?.[0]).toEqual([
       compatibility,
       '--no-rc',
       'clean',
       '--packages',
       '--yes'
     ])
-    expect(runCacheMaintenance.mock.calls[0]?.[1]).toMatchObject({
+    expect(selectedCacheCall?.[1]).toMatchObject({
       MAMBA_ROOT_PREFIX: root,
       CONDA_PKGS_DIRS: selectMicromambaCache(root).path
     })
-    expect(runCacheMaintenance.mock.calls[0]?.[3]).toEqual(expect.any(Function))
-    expect(runCacheMaintenance.mock.calls[0]?.[4]).toEqual(expect.any(Function))
+    for (const call of runCacheMaintenance.mock.calls) {
+      expect(call[2]).toBeInstanceOf(AbortSignal)
+      expect(call[3]).toEqual(expect.any(Function))
+      expect(call[4]).toEqual(expect.any(Function))
+    }
   })
 })

--- a/src/main/notebook/provisioner.startup.test.ts
+++ b/src/main/notebook/provisioner.startup.test.ts
@@ -298,12 +298,13 @@ describe('createProductionProvisioner', () => {
       '--no-rc',
       'clean',
       '--packages',
-      '--tarballs',
       '--yes'
     ])
     expect(runCacheMaintenance.mock.calls[0]?.[1]).toMatchObject({
       MAMBA_ROOT_PREFIX: root,
       CONDA_PKGS_DIRS: selectMicromambaCache(root).path
     })
+    expect(runCacheMaintenance.mock.calls[0]?.[3]).toEqual(expect.any(Function))
+    expect(runCacheMaintenance.mock.calls[0]?.[4]).toEqual(expect.any(Function))
   })
 })

--- a/src/main/notebook/provisioner.startup.test.ts
+++ b/src/main/notebook/provisioner.startup.test.ts
@@ -224,6 +224,7 @@ describe('createProductionProvisioner', () => {
       {
         runner: { initialPath: primary, resolve: async () => compatibility },
         fetchBundle: async () => ({ lockPath }),
+        maintainCache: async () => undefined,
         runArgv,
         verify: async () => undefined
       }
@@ -249,6 +250,7 @@ describe('createProductionProvisioner', () => {
       },
       {
         runner: { initialPath: mmPath, resolve: async () => mmPath },
+        maintainCache: async () => undefined,
         runArgv,
         verify: async () => undefined
       }

--- a/src/main/notebook/provisioner.startup.test.ts
+++ b/src/main/notebook/provisioner.startup.test.ts
@@ -18,6 +18,7 @@ import {
   planStartupAction,
   type ProductionProvisionerDeps
 } from './provisioner'
+import { selectMicromambaCache } from './micromamba-cache'
 
 const makeRoot = (): string => mkdtempSync(join(tmpdir(), 'os-start-'))
 const touchBin = (path: string): void => {
@@ -162,6 +163,7 @@ describe('createProductionProvisioner', () => {
         }
       },
       {
+        maintainCache: async () => undefined,
         fetchBundle: async () => {
           events.push('fetch')
           throw new Error('stop after observing fetch')
@@ -262,5 +264,46 @@ describe('createProductionProvisioner', () => {
 
     expect(resolveChannel).toHaveBeenCalledOnce()
     expect(runArgv.mock.calls[0]?.[0]).toContain('https://fast-mirror.invalid/conda-forge')
+  })
+
+  it('binds the default cache-maintenance adapter to the selected app cache', async () => {
+    const root = makeRoot()
+    const primary = join(root, 'bin', micromambaBinName)
+    const compatibility = join(root, 'bin', `compat-${micromambaBinName}`)
+    touchBin(primary)
+    touchBin(compatibility)
+    const runCacheMaintenance = vi.fn<
+      NonNullable<ProductionProvisionerDeps['runCacheMaintenance']>
+    >(async () => undefined)
+    const runArgv = vi.fn<NonNullable<ProductionProvisionerDeps['runArgv']>>(async () => undefined)
+    const provisioner = createProductionProvisioner(
+      {
+        root,
+        channel: 'conda-forge',
+        micromamba: { env: { OPEN_SCIENCE_MICROMAMBA_BIN: primary } }
+      },
+      {
+        runner: { initialPath: primary, resolve: async () => compatibility },
+        runCacheMaintenance,
+        runArgv,
+        verify: async () => undefined
+      }
+    )
+
+    await provisioner.createNamedEnvironment('analysis', 'python')
+
+    expect(runCacheMaintenance).toHaveBeenCalledOnce()
+    expect(runCacheMaintenance.mock.calls[0]?.[0]).toEqual([
+      compatibility,
+      '--no-rc',
+      'clean',
+      '--packages',
+      '--tarballs',
+      '--yes'
+    ])
+    expect(runCacheMaintenance.mock.calls[0]?.[1]).toMatchObject({
+      MAMBA_ROOT_PREFIX: root,
+      CONDA_PKGS_DIRS: selectMicromambaCache(root).path
+    })
   })
 })

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -85,7 +85,7 @@ const makeDeps = (root: string, overrides: Partial<ProvisionerDeps> = {}): Provi
 }
 
 describe('DefaultRuntimeProvisioner.provisionPython', () => {
-  it('maintains the package cache before fetching and materializing the runtime', async () => {
+  it('maintains the package cache under the materialize journal after fetching the runtime', async () => {
     const root = makeRoot()
     const cachePath = join(root, 'pkgs')
     const order: string[] = []
@@ -98,8 +98,10 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
           order.push('fetch')
           return { lockPath: join(root, 'python.lock') }
         },
-        maintainCache: async (cache) => {
+        maintainCache: async (cache, onBeforeSpawn, onChild) => {
           expect(cache.path).toBe(cachePath)
+          expect(onBeforeSpawn).toEqual(expect.any(Function))
+          expect(onChild).toEqual(expect.any(Function))
           order.push('clean')
         },
         runArgv: async (argv) => {
@@ -114,7 +116,7 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
 
     await provisioner.provisionPython(() => undefined)
 
-    expect(order).toEqual(['clean', 'fetch', 'create'])
+    expect(order).toEqual(['fetch', 'clean', 'create'])
   })
 
   it('materializes python, stamps the marker, and emits monotonic progress ending at 1', async () => {
@@ -1311,6 +1313,22 @@ describe('DefaultRuntimeProvisioner.createNamedEnvironment', () => {
     await new DefaultRuntimeProvisioner(deps).createNamedEnvironment('analysis', 'python')
 
     expect(order).toEqual(['clean', 'create'])
+  })
+
+  it('does not start a named create when the cleanup worker cannot be confirmed stopped', async () => {
+    const root = makeRoot()
+    const runArgv = vi.fn(async () => undefined)
+    const { deps } = makeNamedEnvDeps(root, {
+      maintainCache: async () => {
+        throw new Error(`${CHILD_UNCONFIRMED}: cleanup worker may still be running`)
+      },
+      runArgv
+    })
+
+    await expect(
+      new DefaultRuntimeProvisioner(deps).createNamedEnvironment('analysis', 'python')
+    ).rejects.toThrow(CHILD_UNCONFIRMED)
+    expect(runArgv).not.toHaveBeenCalled()
   })
 
   it('builds the create argv from the base floor + user packages (deduped), targeting envs/<name>', async () => {

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -77,6 +77,7 @@ const makeDeps = (root: string, overrides: Partial<ProvisionerDeps> = {}): Provi
       writeFileSync(bin, 'x')
       created.push(argv[1])
     },
+    maintainCache: async () => undefined,
     verify: async (): Promise<void> => undefined,
     now: () => 't-now',
     ...overrides
@@ -84,6 +85,30 @@ const makeDeps = (root: string, overrides: Partial<ProvisionerDeps> = {}): Provi
 }
 
 describe('DefaultRuntimeProvisioner.provisionPython', () => {
+  it('maintains the selected cache before materializing the runtime', async () => {
+    const root = makeRoot()
+    const order: string[] = []
+    const provisioner = new DefaultRuntimeProvisioner(
+      makeDeps(root, {
+        maintainCache: async (cache) => {
+          expect(cache.path).toBe(selectMicromambaCache(root).path)
+          order.push('clean')
+        },
+        runArgv: async (argv) => {
+          order.push('create')
+          const prefix = argv[argv.findIndex((a) => a === '--prefix' || a === '-p') + 1]
+          const bin = pythonBin(prefix)
+          mkdirSync(join(bin, '..'), { recursive: true })
+          writeFileSync(bin, 'x')
+        }
+      })
+    )
+
+    await provisioner.provisionPython(() => undefined)
+
+    expect(order).toEqual(['clean', 'create'])
+  })
+
   it('materializes python, stamps the marker, and emits monotonic progress ending at 1', async () => {
     const root = makeRoot()
     const provisioner = new DefaultRuntimeProvisioner(makeDeps(root))
@@ -1253,6 +1278,7 @@ const makeNamedEnvDeps = (
       mkdirSync(join(bin, '..'), { recursive: true })
       writeFileSync(bin, 'x')
     },
+    maintainCache: async () => undefined,
     verify: async () => undefined,
     ...overrides
   }
@@ -1260,6 +1286,25 @@ const makeNamedEnvDeps = (
 }
 
 describe('DefaultRuntimeProvisioner.createNamedEnvironment', () => {
+  it('maintains the cache before the online create', async () => {
+    const root = makeRoot()
+    const order: string[] = []
+    const { deps } = makeNamedEnvDeps(root, {
+      maintainCache: async () => void order.push('clean'),
+      runArgv: async (argv) => {
+        order.push('create')
+        const prefix = argv[argv.indexOf('--prefix') + 1]
+        const bin = pythonBin(prefix)
+        mkdirSync(join(bin, '..'), { recursive: true })
+        writeFileSync(bin, 'x')
+      }
+    })
+
+    await new DefaultRuntimeProvisioner(deps).createNamedEnvironment('analysis', 'python')
+
+    expect(order).toEqual(['clean', 'create'])
+  })
+
   it('builds the create argv from the base floor + user packages (deduped), targeting envs/<name>', async () => {
     const root = makeRoot()
     const { deps, argvs } = makeNamedEnvDeps(root)
@@ -1646,7 +1691,9 @@ describe('DefaultRuntimeProvisioner.restoreRelocatedEnvs', () => {
     const prefix = envPrefix(root, DEFAULT_PY_ENV)
     mkdirSync(join(prefix, 'conda-meta'), { recursive: true }) // conda-meta but no python bin
     let condaMetaAtCreate: boolean | undefined
+    const maintainCache = vi.fn(async () => undefined)
     const deps = makeDeps(root, {
+      maintainCache,
       runArgv: async (argv) => {
         const p = argv[argv.findIndex((a) => a === '-p' || a === '--prefix') + 1]
         condaMetaAtCreate = existsSync(join(p, 'conda-meta'))
@@ -1658,6 +1705,7 @@ describe('DefaultRuntimeProvisioner.restoreRelocatedEnvs', () => {
     await new DefaultRuntimeProvisioner(deps).restoreRelocatedEnvs(() => {})
     expect(condaMetaAtCreate).toBe(false) // the wedged prefix was cleared before create
     expect(existsSync(pythonBin(prefix))).toBe(true) // rebuilt
+    expect(maintainCache).not.toHaveBeenCalled() // the copied cache is the offline restore source
   })
 
   it('keeps a valid prefix AND its lock when the ready-marker write fails (no destructive rebuild)', async () => {

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -85,13 +85,20 @@ const makeDeps = (root: string, overrides: Partial<ProvisionerDeps> = {}): Provi
 }
 
 describe('DefaultRuntimeProvisioner.provisionPython', () => {
-  it('maintains the selected cache before materializing the runtime', async () => {
+  it('maintains the package cache before fetching and materializing the runtime', async () => {
     const root = makeRoot()
+    const cachePath = join(root, 'pkgs')
     const order: string[] = []
     const provisioner = new DefaultRuntimeProvisioner(
       makeDeps(root, {
+        platform: 'linux',
+        cache: { path: cachePath, lockKey: cachePath },
+        fetchBundle: async () => {
+          order.push('fetch')
+          return { lockPath: join(root, 'python.lock') }
+        },
         maintainCache: async (cache) => {
-          expect(cache.path).toBe(selectMicromambaCache(root).path)
+          expect(cache.path).toBe(cachePath)
           order.push('clean')
         },
         runArgv: async (argv) => {
@@ -106,7 +113,7 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
 
     await provisioner.provisionPython(() => undefined)
 
-    expect(order).toEqual(['clean', 'create'])
+    expect(order).toEqual(['clean', 'fetch', 'create'])
   })
 
   it('materializes python, stamps the marker, and emits monotonic progress ending at 1', async () => {

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -89,6 +89,8 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     const root = makeRoot()
     const cachePath = join(root, 'pkgs')
     const order: string[] = []
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(root))
+    let operationId = ''
     const provisioner = new DefaultRuntimeProvisioner(
       makeDeps(root, {
         platform: 'linux',
@@ -100,11 +102,21 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
         },
         maintainCache: async (cache, onBeforeSpawn, onChild) => {
           expect(cache.path).toBe(cachePath)
-          expect(onBeforeSpawn).toEqual(expect.any(Function))
-          expect(onChild).toEqual(expect.any(Function))
+          onBeforeSpawn()
+          onChild(process.pid)
+          await vi.waitFor(async () => {
+            const [record] = await journal.pending()
+            operationId = record.operationId
+            expect(record).toMatchObject({ childPid: process.pid })
+          })
           order.push('clean')
         },
         runArgv: async (argv) => {
+          expect(readOperationChild(root, operationId)).toBeUndefined()
+          const [record] = await journal.pending()
+          expect(record).not.toHaveProperty('childPid')
+          expect(record).not.toHaveProperty('childStartedAt')
+          expect(record).not.toHaveProperty('childStartToken')
           order.push('create')
           const prefix = argv[argv.findIndex((a) => a === '--prefix' || a === '-p') + 1]
           const bin = pythonBin(prefix)

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -92,7 +92,8 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     const provisioner = new DefaultRuntimeProvisioner(
       makeDeps(root, {
         platform: 'linux',
-        cache: { path: cachePath, lockKey: cachePath },
+        // macOS may canonicalize the legacy lock key (/var -> /private/var) while preserving this path.
+        cache: { path: cachePath, lockKey: 'selected-cache-key' },
         fetchBundle: async () => {
           order.push('fetch')
           return { lockPath: join(root, 'python.lock') }

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -336,6 +336,37 @@ describe('DefaultRuntimeProvisioner.provisionPython', () => {
     await expect(run).rejects.toThrow(/cancelled/i)
   })
 
+  it('cancel() aborts in-flight cache maintenance before create', async () => {
+    const root = makeRoot()
+    const cachePath = join(root, 'pkgs')
+    let seenSignal: AbortSignal | undefined
+    let releaseMaintenance: (() => void) | undefined
+    const deps = makeDeps(root, {
+      platform: 'linux',
+      cache: { path: cachePath, lockKey: 'selected-cache-key' },
+      maintainCache: (_cache, _onBeforeSpawn, _onChild, signal?: AbortSignal) => {
+        seenSignal = signal
+        return new Promise<void>((resolve, reject) => {
+          releaseMaintenance = resolve
+          signal?.addEventListener('abort', () => reject(signal.reason))
+        })
+      },
+      runArgv: async (_argv, signal) => {
+        if (signal?.aborted) throw signal.reason
+      }
+    })
+    const provisioner = new DefaultRuntimeProvisioner(deps)
+    const run = provisioner.provisionPython(() => {})
+    await vi.waitFor(() => expect(releaseMaintenance).toBeDefined())
+
+    provisioner.cancel()
+    if (!seenSignal) releaseMaintenance?.()
+
+    await expect(run).rejects.toThrow(/cancelled/i)
+    expect(seenSignal).toBeDefined()
+    expect(seenSignal?.aborted).toBe(true)
+  })
+
   it('cancel(runningLang) aborts that run', async () => {
     const root = makeRoot()
     let seenSignal: AbortSignal | undefined

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -41,6 +41,10 @@ import {
   type MicromambaCache
 } from './micromamba-cache'
 import {
+  maintainPackageCacheBestEffort,
+  packageCacheCleanArgv
+} from './micromamba-cache-maintenance'
+import {
   caBundleEnv,
   createFromLockArgv,
   createFromPackagesArgv,
@@ -165,6 +169,10 @@ export type ProvisionerDeps = {
     cache?: MicromambaCache,
     maxCacheRelativePath?: number
   ) => Promise<void>
+  // Runs micromamba's supported unused-package/tarball cleanup with MAMBA_ROOT_PREFIX bound to this
+  // provisioner's root. Optional only for directly-constructed test provisioners; production always
+  // wires it in createProductionProvisioner.
+  maintainCache?: (cache: MicromambaCache) => Promise<void>
   // Verifies `<bin> --version`; rejects otherwise.
   verify: (bin: string, prefix: string) => Promise<void>
   // Clock injection for the ready-marker timestamp.
@@ -329,6 +337,12 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       cache.lockKey,
       micromambaCacheLockKey(pkgsCache(this.deps.root), { platform: this.deps.platform })
     ]
+  }
+
+  private maintainCacheBeforeMutation(cache: MicromambaCache = this.cache): Promise<void> {
+    const maintainCache = this.deps.maintainCache
+    if (!maintainCache) return Promise.resolve()
+    return maintainPackageCacheBestEffort(this.cacheLockKeys(cache), () => maintainCache(cache))
   }
 
   private async seedBundleCache(bundle: FetchedBundle, cache: MicromambaCache): Promise<void> {
@@ -1109,6 +1123,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     // Named environments are the only online-solving path. Resolve/probe the channel here so normal
     // application startup and offline default-runtime provisioning never wait for mirror selection.
     const channel = await this.resolveChannel()
+    await this.maintainCacheBeforeMutation(this.cache)
     // Journal the create (child PID + prefix) so a crash mid-create is recovered like any other prefix
     // write: a survivor is killed and, if unconfirmed, the prefix is blocked so a later create/remove
     // can't race it. Take the shared pkgs cache lock (+ MAX_PATH recovery) for the whole prefix cleanup
@@ -1235,6 +1250,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     // must not delete an incomplete extraction mid-upgrade, and a Windows path-limit failure is retried
     // once after a short cache recovery.
     const selected = this.cacheForBundle(spec, bundle)
+    await this.maintainCacheBeforeMutation(selected.cache)
     await this.seedBundleCache(bundle, selected.cache)
     await this.cleanLegacyWindowsUrlCache(selected.cache, onProgress)
     await this.withJournaledPrefixWrite(
@@ -1331,6 +1347,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     // Select the cache scoped to this bundle (Windows budget) and clear any legacy over-budget URL
     // packages before the create, so a Windows path-limit blocker doesn't fail the first attempt.
     const selected = this.cacheForBundle(spec, bundle)
+    await this.maintainCacheBeforeMutation(selected.cache)
     await this.seedBundleCache(bundle, selected.cache)
     await this.cleanLegacyWindowsUrlCache(selected.cache, onProgress)
     // Journal the create (child PID + prefix) so a process death mid-materialize is reconciled at next
@@ -1570,6 +1587,7 @@ export type ProductionProvisionerDeps = {
   runner?: MicromambaRunner
   fetchBundle?: ProvisionerDeps['fetchBundle']
   runArgv?: ProvisionerDeps['runArgv']
+  maintainCache?: ProvisionerDeps['maintainCache']
   verify?: ProvisionerDeps['verify']
 }
 
@@ -1655,6 +1673,18 @@ export const createProductionProvisioner = (
         onBeforeSpawn
       )
     },
+    maintainCache:
+      deps.maintainCache ??
+      (async (runCache) => {
+        const selected = await runner.resolve()
+        await runMicromamba(packageCacheCleanArgv(selected), {
+          ...micromambaSpawnEnv(opts.root, opts.caBundle, {
+            selectCache: () => runCache
+          }),
+          MAMBA_ROOT_PREFIX: opts.root,
+          CONDA_PKGS_DIRS: runCache.path
+        })
+      }),
     verify: deps.verify ?? ((bin, prefix) => verifyExecutable(bin, { prefix, env: caEnv })),
     isPrefixBlocked: opts.isPrefixBlocked,
     clearPrefixBlock: opts.clearPrefixBlock,

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -355,12 +355,15 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
   private maintainCacheBeforeMutation(
     cache: MicromambaCache,
     onBeforeSpawn: () => void,
-    onChild: (pid: number) => void
+    onChild: (pid: number) => void,
+    onSettled: () => Promise<void>
   ): Promise<void> {
     const maintainCache = this.deps.maintainCache
     if (!maintainCache) return Promise.resolve()
-    return maintainPackageCacheBestEffort(this.cacheLockKeys(cache), () =>
-      maintainCache(cache, onBeforeSpawn, onChild)
+    return maintainPackageCacheBestEffort(
+      this.cacheLockKeys(cache),
+      () => maintainCache(cache, onBeforeSpawn, onChild),
+      onSettled
     )
   }
 
@@ -542,7 +545,11 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     // `run` performs the actual spawn(s). It MUST pass `onBeforeSpawn` and `onChild` to runArgv so the
     // per-spawn intent is re-armed and the PID recorded around EACH spawn (an op may spawn more than
     // once: create + cache-repair retry).
-    run: (onBeforeSpawn: () => void, onChild: (pid: number) => void) => Promise<void>
+    run: (
+      onBeforeSpawn: () => void,
+      onChild: (pid: number) => void,
+      onCacheMaintenanceSettled: () => Promise<void>
+    ) => Promise<void>
   ): Promise<void> {
     const journal = RuntimeOperationJournal.forPath(operationJournalPath(this.deps.root))
     const operationId = randomUUID()
@@ -581,9 +588,21 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
         .update(operationId, { childPid, childStartedAt, childStartToken })
         .catch(() => undefined)
     }
+    const onCacheMaintenanceSettled = async (): Promise<void> => {
+      // A cleanup child borrows this prefix operation's recovery barrier only while it is alive. Clear
+      // that settled identity before continuing so a crash between cleanup and the prefix write cannot
+      // be recovered as though cleanup had interrupted the environment mutation. Awaiting update also
+      // serializes behind the fire-and-forget PID write above.
+      await journal.update(operationId, {
+        childPid: undefined,
+        childStartedAt: undefined,
+        childStartToken: undefined
+      })
+      removeOperationChildSync(this.deps.root, operationId)
+    }
     let retainForRecovery = false
     try {
-      await run(onBeforeSpawn, onChild)
+      await run(onBeforeSpawn, onChild, onCacheMaintenanceSettled)
     } catch (error) {
       // A teardown whose child tree could NOT be confirmed stopped: a worker may still be writing the
       // prefix, so KEEP the sidecar + journal record (recovery blocks) instead of clearing them.
@@ -1154,8 +1173,13 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       name,
       prefix,
       `create-${language}`,
-      async (onBeforeSpawn, onChild) => {
-        await this.maintainCacheBeforeMutation(this.cache, onBeforeSpawn, onChild)
+      async (onBeforeSpawn, onChild, onCacheMaintenanceSettled) => {
+        await this.maintainCacheBeforeMutation(
+          this.cache,
+          onBeforeSpawn,
+          onChild,
+          onCacheMaintenanceSettled
+        )
         return this.runWithMaxPathRecovery(() =>
           withSharedCacheLocks(this.cacheLockKeys(this.cache), async () => {
             // Clear a half-built prefix from an interrupted prior create (incl. conda-meta-but-no-
@@ -1276,13 +1300,23 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       spec.name,
       prefix,
       `upgrade-${spec.language}`,
-      async (onBeforeSpawn, onChild) => {
+      async (onBeforeSpawn, onChild, onCacheMaintenanceSettled) => {
         // Fetch adapters seed relocation-critical archives into root/pkgs before this journaled section.
         // Clean only unused extracted directories, then seed any selected short cache. Running the child
         // here lets the existing upgrade journal supervise it without a new durable operation kind.
-        await this.maintainCacheBeforeMutation(fetchCache, onBeforeSpawn, onChild)
+        await this.maintainCacheBeforeMutation(
+          fetchCache,
+          onBeforeSpawn,
+          onChild,
+          onCacheMaintenanceSettled
+        )
         if (selected.cache.path !== fetchCache.path) {
-          await this.maintainCacheBeforeMutation(selected.cache, onBeforeSpawn, onChild)
+          await this.maintainCacheBeforeMutation(
+            selected.cache,
+            onBeforeSpawn,
+            onChild,
+            onCacheMaintenanceSettled
+          )
         }
         await this.seedBundleCache(bundle, selected.cache)
         await this.cleanLegacyWindowsUrlCache(selected.cache, onProgress)
@@ -1384,12 +1418,22 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       spec.name,
       prefix,
       `create-${spec.language}`,
-      async (onBeforeSpawn, onChild) => {
+      async (onBeforeSpawn, onChild, onCacheMaintenanceSettled) => {
         // Fetch completes before cleanup so its child can reuse this materialize journal. Tarballs stay
         // intact for future offline relocation; only unused extracted package directories are reclaimed.
-        await this.maintainCacheBeforeMutation(fetchCache, onBeforeSpawn, onChild)
+        await this.maintainCacheBeforeMutation(
+          fetchCache,
+          onBeforeSpawn,
+          onChild,
+          onCacheMaintenanceSettled
+        )
         if (selected.cache.path !== fetchCache.path) {
-          await this.maintainCacheBeforeMutation(selected.cache, onBeforeSpawn, onChild)
+          await this.maintainCacheBeforeMutation(
+            selected.cache,
+            onBeforeSpawn,
+            onChild,
+            onCacheMaintenanceSettled
+          )
         }
         await this.seedBundleCache(bundle, selected.cache)
         await this.cleanLegacyWindowsUrlCache(selected.cache, onProgress)

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -1262,7 +1262,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     // must not delete an incomplete extraction mid-upgrade, and a Windows path-limit failure is retried
     // once after a short cache recovery.
     const selected = this.cacheForBundle(spec, bundle)
-    if (selected.cache.lockKey !== fetchCache.lockKey) {
+    if (selected.cache.path !== fetchCache.path) {
       await this.maintainCacheBeforeMutation(selected.cache)
     }
     await this.seedBundleCache(bundle, selected.cache)
@@ -1365,7 +1365,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     // Select the cache scoped to this bundle (Windows budget) and clear any legacy over-budget URL
     // packages before the create, so a Windows path-limit blocker doesn't fail the first attempt.
     const selected = this.cacheForBundle(spec, bundle)
-    if (selected.cache.lockKey !== fetchCache.lockKey) {
+    if (selected.cache.path !== fetchCache.path) {
       await this.maintainCacheBeforeMutation(selected.cache)
     }
     await this.seedBundleCache(bundle, selected.cache)

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -169,10 +169,15 @@ export type ProvisionerDeps = {
     cache?: MicromambaCache,
     maxCacheRelativePath?: number
   ) => Promise<void>
-  // Runs micromamba's supported unused-package/tarball cleanup with MAMBA_ROOT_PREFIX bound to this
-  // provisioner's root. Optional only for directly-constructed test provisioners; production always
-  // wires it in createProductionProvisioner.
-  maintainCache?: (cache: MicromambaCache) => Promise<void>
+  // Runs micromamba's supported unused-package cleanup with MAMBA_ROOT_PREFIX bound to this provisioner's
+  // root. Tarballs remain available for offline data-root relocation. The existing prefix-operation
+  // journal hooks supervise the cleanup child; no separate persisted operation kind is needed. Optional
+  // only for directly-constructed test provisioners; production always wires it in.
+  maintainCache?: (
+    cache: MicromambaCache,
+    onBeforeSpawn: () => void,
+    onChild: (pid: number) => void
+  ) => Promise<void>
   // Verifies `<bin> --version`; rejects otherwise.
   verify: (bin: string, prefix: string) => Promise<void>
   // Clock injection for the ready-marker timestamp.
@@ -347,10 +352,16 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     ]
   }
 
-  private maintainCacheBeforeMutation(cache: MicromambaCache = this.cache): Promise<void> {
+  private maintainCacheBeforeMutation(
+    cache: MicromambaCache,
+    onBeforeSpawn: () => void,
+    onChild: (pid: number) => void
+  ): Promise<void> {
     const maintainCache = this.deps.maintainCache
     if (!maintainCache) return Promise.resolve()
-    return maintainPackageCacheBestEffort(this.cacheLockKeys(cache), () => maintainCache(cache))
+    return maintainPackageCacheBestEffort(this.cacheLockKeys(cache), () =>
+      maintainCache(cache, onBeforeSpawn, onChild)
+    )
   }
 
   private async seedBundleCache(bundle: FetchedBundle, cache: MicromambaCache): Promise<void> {
@@ -1131,7 +1142,6 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     // Named environments are the only online-solving path. Resolve/probe the channel here so normal
     // application startup and offline default-runtime provisioning never wait for mirror selection.
     const channel = await this.resolveChannel()
-    await this.maintainCacheBeforeMutation(this.cache)
     // Journal the create (child PID + prefix) so a crash mid-create is recovered like any other prefix
     // write: a survivor is killed and, if unconfirmed, the prefix is blocked so a later create/remove
     // can't race it. Take the shared pkgs cache lock (+ MAX_PATH recovery) for the whole prefix cleanup
@@ -1144,8 +1154,9 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       name,
       prefix,
       `create-${language}`,
-      (onBeforeSpawn, onChild) =>
-        this.runWithMaxPathRecovery(() =>
+      async (onBeforeSpawn, onChild) => {
+        await this.maintainCacheBeforeMutation(this.cache, onBeforeSpawn, onChild)
+        return this.runWithMaxPathRecovery(() =>
           withSharedCacheLocks(this.cacheLockKeys(this.cache), async () => {
             // Clear a half-built prefix from an interrupted prior create (incl. conda-meta-but-no-
             // interpreter) so micromamba doesn't abort on it.
@@ -1164,6 +1175,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
             )
           })
         )
+      }
     )
     await this.deps.verify(bin, prefix)
     return {
@@ -1236,10 +1248,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     spec: EnvSpec,
     onProgress: (p: ProvisionProgress) => void
   ): Promise<void> {
-    // Bundle adapters validate and seed archives into the legacy root/pkgs cache while fetching. Reclaim
-    // that cache first so a nearly-full data disk does not fail before post-fetch cache selection runs.
     const fetchCache = this.legacyCache
-    await this.maintainCacheBeforeMutation(fetchCache)
     const bundle = await this.deps.fetchBundle(
       spec,
       DEFAULT_ENV_VERSION,
@@ -1262,18 +1271,22 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     // must not delete an incomplete extraction mid-upgrade, and a Windows path-limit failure is retried
     // once after a short cache recovery.
     const selected = this.cacheForBundle(spec, bundle)
-    if (selected.cache.path !== fetchCache.path) {
-      await this.maintainCacheBeforeMutation(selected.cache)
-    }
-    await this.seedBundleCache(bundle, selected.cache)
-    await this.cleanLegacyWindowsUrlCache(selected.cache, onProgress)
     await this.withJournaledPrefixWrite(
       'upgrade',
       spec.name,
       prefix,
       `upgrade-${spec.language}`,
-      (onBeforeSpawn, onChild) =>
-        this.runWithMaxPathRecovery(
+      async (onBeforeSpawn, onChild) => {
+        // Fetch adapters seed relocation-critical archives into root/pkgs before this journaled section.
+        // Clean only unused extracted directories, then seed any selected short cache. Running the child
+        // here lets the existing upgrade journal supervise it without a new durable operation kind.
+        await this.maintainCacheBeforeMutation(fetchCache, onBeforeSpawn, onChild)
+        if (selected.cache.path !== fetchCache.path) {
+          await this.maintainCacheBeforeMutation(selected.cache, onBeforeSpawn, onChild)
+        }
+        await this.seedBundleCache(bundle, selected.cache)
+        await this.cleanLegacyWindowsUrlCache(selected.cache, onProgress)
+        return this.runWithMaxPathRecovery(
           () =>
             withSharedCacheLocks(this.cacheLockKeys(selected.cache), () =>
               this.deps.runArgv(
@@ -1288,6 +1301,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
           undefined,
           selected.cache
         )
+      }
     )
     await this.deps.verify(bin, prefix)
   }
@@ -1341,10 +1355,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       message: `Preparing ${spec.name} packages…`,
       progress: 0.1
     })
-    // Fetch adapters write verified package archives into root/pkgs. Cleanup must precede that write or
-    // an already-full data disk can prevent the bundle from being staged at all.
     const fetchCache = this.legacyCache
-    await this.maintainCacheBeforeMutation(fetchCache)
     const bundle = await this.deps.fetchBundle(
       spec,
       DEFAULT_ENV_VERSION,
@@ -1365,11 +1376,6 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     // Select the cache scoped to this bundle (Windows budget) and clear any legacy over-budget URL
     // packages before the create, so a Windows path-limit blocker doesn't fail the first attempt.
     const selected = this.cacheForBundle(spec, bundle)
-    if (selected.cache.path !== fetchCache.path) {
-      await this.maintainCacheBeforeMutation(selected.cache)
-    }
-    await this.seedBundleCache(bundle, selected.cache)
-    await this.cleanLegacyWindowsUrlCache(selected.cache, onProgress)
     // Journal the create (child PID + prefix) so a process death mid-materialize is reconciled at next
     // startup: the recorded child is killed if it survived and, if liveness is unconfirmed, the prefix
     // is blocked. verify() is read-only and stays outside the journaled window.
@@ -1379,6 +1385,14 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       prefix,
       `create-${spec.language}`,
       async (onBeforeSpawn, onChild) => {
+        // Fetch completes before cleanup so its child can reuse this materialize journal. Tarballs stay
+        // intact for future offline relocation; only unused extracted package directories are reclaimed.
+        await this.maintainCacheBeforeMutation(fetchCache, onBeforeSpawn, onChild)
+        if (selected.cache.path !== fetchCache.path) {
+          await this.maintainCacheBeforeMutation(selected.cache, onBeforeSpawn, onChild)
+        }
+        await this.seedBundleCache(bundle, selected.cache)
+        await this.cleanLegacyWindowsUrlCache(selected.cache, onProgress)
         const runCreate = (
           lockPath: string,
           cache: MicromambaCache = selected.cache,
@@ -1697,15 +1711,21 @@ export const createProductionProvisioner = (
     },
     maintainCache:
       deps.maintainCache ??
-      (async (runCache) => {
+      (async (runCache, onBeforeSpawn, onChild) => {
         const selected = await runner.resolve()
-        await (deps.runCacheMaintenance ?? runMicromamba)(packageCacheCleanArgv(selected), {
-          ...micromambaSpawnEnv(opts.root, opts.caBundle, {
-            selectCache: () => runCache
-          }),
-          MAMBA_ROOT_PREFIX: opts.root,
-          CONDA_PKGS_DIRS: runCache.path
-        })
+        await (deps.runCacheMaintenance ?? runMicromamba)(
+          packageCacheCleanArgv(selected),
+          {
+            ...micromambaSpawnEnv(opts.root, opts.caBundle, {
+              selectCache: () => runCache
+            }),
+            MAMBA_ROOT_PREFIX: opts.root,
+            CONDA_PKGS_DIRS: runCache.path
+          },
+          undefined,
+          onChild,
+          onBeforeSpawn
+        )
       }),
     verify: deps.verify ?? ((bin, prefix) => verifyExecutable(bin, { prefix, env: caEnv })),
     isPrefixBlocked: opts.isPrefixBlocked,

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -176,7 +176,8 @@ export type ProvisionerDeps = {
   maintainCache?: (
     cache: MicromambaCache,
     onBeforeSpawn: () => void,
-    onChild: (pid: number) => void
+    onChild: (pid: number) => void,
+    signal?: AbortSignal
   ) => Promise<void>
   // Verifies `<bin> --version`; rejects otherwise.
   verify: (bin: string, prefix: string) => Promise<void>
@@ -352,19 +353,24 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     ]
   }
 
-  private maintainCacheBeforeMutation(
+  private async maintainCacheBeforeMutation(
     cache: MicromambaCache,
     onBeforeSpawn: () => void,
     onChild: (pid: number) => void,
-    onSettled: () => Promise<void>
+    onSettled: () => Promise<void>,
+    signal?: AbortSignal
   ): Promise<void> {
     const maintainCache = this.deps.maintainCache
-    if (!maintainCache) return Promise.resolve()
-    return maintainPackageCacheBestEffort(
+    if (!maintainCache) return
+    await maintainPackageCacheBestEffort(
       this.cacheLockKeys(cache),
-      () => maintainCache(cache, onBeforeSpawn, onChild),
+      () => maintainCache(cache, onBeforeSpawn, onChild, signal),
       onSettled
     )
+    // Cancellation is not an ordinary best-effort maintenance failure. The subprocess adapter rejects
+    // when the signal aborts; after confirmed settlement, stop this provision immediately instead of
+    // attempting another cache or waiting for the following create to observe the already-aborted signal.
+    if (signal?.aborted) throw signal.reason
   }
 
   private async seedBundleCache(bundle: FetchedBundle, cache: MicromambaCache): Promise<void> {
@@ -1308,14 +1314,16 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
           fetchCache,
           onBeforeSpawn,
           onChild,
-          onCacheMaintenanceSettled
+          onCacheMaintenanceSettled,
+          this.abort?.signal
         )
         if (selected.cache.path !== fetchCache.path) {
           await this.maintainCacheBeforeMutation(
             selected.cache,
             onBeforeSpawn,
             onChild,
-            onCacheMaintenanceSettled
+            onCacheMaintenanceSettled,
+            this.abort?.signal
           )
         }
         await this.seedBundleCache(bundle, selected.cache)
@@ -1425,14 +1433,16 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
           fetchCache,
           onBeforeSpawn,
           onChild,
-          onCacheMaintenanceSettled
+          onCacheMaintenanceSettled,
+          this.abort?.signal
         )
         if (selected.cache.path !== fetchCache.path) {
           await this.maintainCacheBeforeMutation(
             selected.cache,
             onBeforeSpawn,
             onChild,
-            onCacheMaintenanceSettled
+            onCacheMaintenanceSettled,
+            this.abort?.signal
           )
         }
         await this.seedBundleCache(bundle, selected.cache)
@@ -1755,7 +1765,7 @@ export const createProductionProvisioner = (
     },
     maintainCache:
       deps.maintainCache ??
-      (async (runCache, onBeforeSpawn, onChild) => {
+      (async (runCache, onBeforeSpawn, onChild, signal) => {
         const selected = await runner.resolve()
         await (deps.runCacheMaintenance ?? runMicromamba)(
           packageCacheCleanArgv(selected),
@@ -1766,7 +1776,7 @@ export const createProductionProvisioner = (
             MAMBA_ROOT_PREFIX: opts.root,
             CONDA_PKGS_DIRS: runCache.path
           },
-          undefined,
+          signal,
           onChild,
           onBeforeSpawn
         )

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -328,6 +328,14 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     return this.deps.cache ?? selectMicromambaCache(this.deps.root)
   }
 
+  private get legacyCache(): MicromambaCache {
+    const path = pkgsCache(this.deps.root)
+    return {
+      path,
+      lockKey: micromambaCacheLockKey(path, { platform: this.deps.platform })
+    }
+  }
+
   private cacheRoots(cache: MicromambaCache): string[] {
     return [...new Set([pkgsCache(this.deps.root), cache.path])]
   }
@@ -1228,6 +1236,10 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     spec: EnvSpec,
     onProgress: (p: ProvisionProgress) => void
   ): Promise<void> {
+    // Bundle adapters validate and seed archives into the legacy root/pkgs cache while fetching. Reclaim
+    // that cache first so a nearly-full data disk does not fail before post-fetch cache selection runs.
+    const fetchCache = this.legacyCache
+    await this.maintainCacheBeforeMutation(fetchCache)
     const bundle = await this.deps.fetchBundle(
       spec,
       DEFAULT_ENV_VERSION,
@@ -1250,7 +1262,9 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     // must not delete an incomplete extraction mid-upgrade, and a Windows path-limit failure is retried
     // once after a short cache recovery.
     const selected = this.cacheForBundle(spec, bundle)
-    await this.maintainCacheBeforeMutation(selected.cache)
+    if (selected.cache.lockKey !== fetchCache.lockKey) {
+      await this.maintainCacheBeforeMutation(selected.cache)
+    }
     await this.seedBundleCache(bundle, selected.cache)
     await this.cleanLegacyWindowsUrlCache(selected.cache, onProgress)
     await this.withJournaledPrefixWrite(
@@ -1327,6 +1341,10 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       message: `Preparing ${spec.name} packages…`,
       progress: 0.1
     })
+    // Fetch adapters write verified package archives into root/pkgs. Cleanup must precede that write or
+    // an already-full data disk can prevent the bundle from being staged at all.
+    const fetchCache = this.legacyCache
+    await this.maintainCacheBeforeMutation(fetchCache)
     const bundle = await this.deps.fetchBundle(
       spec,
       DEFAULT_ENV_VERSION,
@@ -1347,7 +1365,9 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     // Select the cache scoped to this bundle (Windows budget) and clear any legacy over-budget URL
     // packages before the create, so a Windows path-limit blocker doesn't fail the first attempt.
     const selected = this.cacheForBundle(spec, bundle)
-    await this.maintainCacheBeforeMutation(selected.cache)
+    if (selected.cache.lockKey !== fetchCache.lockKey) {
+      await this.maintainCacheBeforeMutation(selected.cache)
+    }
     await this.seedBundleCache(bundle, selected.cache)
     await this.cleanLegacyWindowsUrlCache(selected.cache, onProgress)
     // Journal the create (child PID + prefix) so a process death mid-materialize is reconciled at next
@@ -1588,6 +1608,8 @@ export type ProductionProvisionerDeps = {
   fetchBundle?: ProvisionerDeps['fetchBundle']
   runArgv?: ProvisionerDeps['runArgv']
   maintainCache?: ProvisionerDeps['maintainCache']
+  // Narrow subprocess seam for the default maintenance adapter's argv/environment contract test.
+  runCacheMaintenance?: typeof runMicromamba
   verify?: ProvisionerDeps['verify']
 }
 
@@ -1677,7 +1699,7 @@ export const createProductionProvisioner = (
       deps.maintainCache ??
       (async (runCache) => {
         const selected = await runner.resolve()
-        await runMicromamba(packageCacheCleanArgv(selected), {
+        await (deps.runCacheMaintenance ?? runMicromamba)(packageCacheCleanArgv(selected), {
           ...micromambaSpawnEnv(opts.root, opts.caBundle, {
             selectCache: () => runCache
           }),

--- a/src/main/notebook/provisioner.upgrade.test.ts
+++ b/src/main/notebook/provisioner.upgrade.test.ts
@@ -44,12 +44,29 @@ const baseDeps = (root: string, over: Partial<ProvisionerDeps> = {}): Provisione
     const prefix = argv[pIdx + 1]
     touchBin(logicalNameForPrefix(prefix) === DEFAULT_PY_ENV ? pythonBin(prefix) : rBin(prefix))
   },
+  maintainCache: async () => undefined,
   verify: async () => undefined,
   now: () => 't2',
   ...over
 })
 
 describe('upgradeIfNeeded', () => {
+  it('maintains the selected cache before an offline upgrade mutation', async () => {
+    const root = makeRoot()
+    touchBin(pythonBin(envPrefix(root, DEFAULT_PY_ENV)))
+    writeReadyMarker(root, DEFAULT_ENV_VERSION - 1, 't1')
+    const order: string[] = []
+
+    await new DefaultRuntimeProvisioner(
+      baseDeps(root, {
+        maintainCache: async () => void order.push('clean'),
+        runArgv: async () => void order.push('install')
+      })
+    ).upgradeIfNeeded(() => undefined)
+
+    expect(order).toEqual(['clean', 'install'])
+  })
+
   it('is a no-op when already at the expected version', async () => {
     const root = makeRoot()
     touchBin(pythonBin(envPrefix(root, DEFAULT_PY_ENV)))

--- a/src/main/notebook/provisioner.upgrade.test.ts
+++ b/src/main/notebook/provisioner.upgrade.test.ts
@@ -51,20 +51,27 @@ const baseDeps = (root: string, over: Partial<ProvisionerDeps> = {}): Provisione
 })
 
 describe('upgradeIfNeeded', () => {
-  it('maintains the selected cache before an offline upgrade mutation', async () => {
+  it('maintains the package cache before fetching and applying an offline upgrade', async () => {
     const root = makeRoot()
+    const cachePath = join(root, 'pkgs')
     touchBin(pythonBin(envPrefix(root, DEFAULT_PY_ENV)))
     writeReadyMarker(root, DEFAULT_ENV_VERSION - 1, 't1')
     const order: string[] = []
 
     await new DefaultRuntimeProvisioner(
       baseDeps(root, {
+        platform: 'linux',
+        cache: { path: cachePath, lockKey: cachePath },
+        fetchBundle: async () => {
+          order.push('fetch')
+          return { lockPath: join(root, 'python.lock') }
+        },
         maintainCache: async () => void order.push('clean'),
         runArgv: async () => void order.push('install')
       })
     ).upgradeIfNeeded(() => undefined)
 
-    expect(order).toEqual(['clean', 'install'])
+    expect(order).toEqual(['clean', 'fetch', 'install'])
   })
 
   it('is a no-op when already at the expected version', async () => {

--- a/src/main/notebook/provisioner.upgrade.test.ts
+++ b/src/main/notebook/provisioner.upgrade.test.ts
@@ -61,7 +61,8 @@ describe('upgradeIfNeeded', () => {
     await new DefaultRuntimeProvisioner(
       baseDeps(root, {
         platform: 'linux',
-        cache: { path: cachePath, lockKey: cachePath },
+        // macOS may canonicalize the legacy lock key (/var -> /private/var) while preserving this path.
+        cache: { path: cachePath, lockKey: 'selected-cache-key' },
         fetchBundle: async () => {
           order.push('fetch')
           return { lockPath: join(root, 'python.lock') }

--- a/src/main/notebook/provisioner.upgrade.test.ts
+++ b/src/main/notebook/provisioner.upgrade.test.ts
@@ -51,7 +51,7 @@ const baseDeps = (root: string, over: Partial<ProvisionerDeps> = {}): Provisione
 })
 
 describe('upgradeIfNeeded', () => {
-  it('maintains the package cache before fetching and applying an offline upgrade', async () => {
+  it('maintains the package cache under the upgrade journal after fetching the offline bundle', async () => {
     const root = makeRoot()
     const cachePath = join(root, 'pkgs')
     touchBin(pythonBin(envPrefix(root, DEFAULT_PY_ENV)))
@@ -67,12 +67,16 @@ describe('upgradeIfNeeded', () => {
           order.push('fetch')
           return { lockPath: join(root, 'python.lock') }
         },
-        maintainCache: async () => void order.push('clean'),
+        maintainCache: async (_cache, onBeforeSpawn, onChild) => {
+          expect(onBeforeSpawn).toEqual(expect.any(Function))
+          expect(onChild).toEqual(expect.any(Function))
+          order.push('clean')
+        },
         runArgv: async () => void order.push('install')
       })
     ).upgradeIfNeeded(() => undefined)
 
-    expect(order).toEqual(['clean', 'fetch', 'install'])
+    expect(order).toEqual(['fetch', 'clean', 'install'])
   })
 
   it('is a no-op when already at the expected version', async () => {


### PR DESCRIPTION
## Problem

Notebook uses a persistent shared micromamba `pkgs` cache. Repeatedly installing or upgrading different package versions retained superseded extracted packages and archives indefinitely because normal mutations never ran package GC.

A real micromamba 2.8.1 reproduction upgraded zlib 1.2.13 to 1.3.1 in the same cache: the old archive and extracted directory remained and the cache grew by 494,006 bytes. Native cache cleanup confirmed that the retained extracted package was reclaimable.

## Proposed change

- Run micromamba's supported `clean --packages` before app-managed Conda mutations to reclaim unused extracted package directories.
- Preserve cached `.conda` / `.tar.bz2` archives because data-root relocation copies them for offline reconstruction.
- Reuse the existing install/materialize/upgrade operation journal hooks for the cleanup child; no new operation kind or persisted schema is introduced.
- Clear the cleanup child's sidecar and journal identity after it is confirmed settled, before any solver or environment mutation can start.
- Treat ordinary cleanup failures as best-effort, but propagate `CHILD_UNCONFIRMED` so recovery evidence is retained and subsequent cache writers are blocked. Thread the active provisioning `AbortSignal` into cleanup so user cancellation stops it promptly.
- Take the existing cache-exclusive locks while cleaning, then release them before the normal shared-lock mutation.
- Bind both `MAMBA_ROOT_PREFIX` and `CONDA_PKGS_DIRS` to app-owned paths so inherited host Conda settings cannot expand the cleanup scope.
- For bundled runtimes, fetch first and perform cleanup inside the existing materialize/upgrade journal before cache seeding and environment mutation.
- Skip cleanup before relocation restore because the copied cache is its offline reconstruction source.

## Scope and non-goals

- No quota, custom LRU, scheduler, UI, new status/enum, schema, operation kind, or data-model change.
- No migration is required. Existing extracted-package caches are reclaimed lazily on the next app-managed Conda mutation.
- Persistence effect: unused extracted package directories in the app-owned cache can be deleted. Package archives are retained for offline relocation, so this reduces growth but does not impose a hard cache-size bound.
- Reference-aware archive GC would require tracking every active environment and pending relocation lock; that is intentionally outside this conservative fix.
- No renderer, IPC, database, or user interaction changes.

## Acceptance criteria and validation

The public `installPackages` regression test failed twice on the original code because the superseded cache entry still existed, then passed after package cleanup was added. Review regressions also failed on the corresponding pre-fix implementations for the reported reasons: `--tarballs` was present, cleanup spawn hooks were absent, `CHILD_UNCONFIRMED` was swallowed, provisioner cleanup ran outside the prefix-operation journal, and settled cleanup child evidence remained visible before the real mutation.

Current focused validation:

- cache cleanup ordering, ordinary best-effort failure, fail-closed unconfirmed-child handling, cleanup evidence settlement, cache locking, and package install/remove -> `npm test -- --run src/main/notebook/package-manager.test.ts src/main/notebook/package-mutation.test.ts src/main/notebook/provisioner.test.ts src/main/notebook/provisioner.upgrade.test.ts src/main/notebook/provisioner.startup.test.ts` -> 5 files, 209 tests passed
- default runtime materialize, named create, upgrade, production spawn-hook forwarding, and relocation-restore exclusion -> same focused command -> passed
- affected main-process TypeScript contracts -> `npm run typecheck:node` -> passed
- changed-file lint -> `npx eslint <changed Notebook files>` -> passed
- changed-file formatting -> `npx prettier --check <changed Notebook files>` -> passed

The complete local suite was intentionally not run per task scope; exact-head PR Gate and platform lanes remain authoritative.

## Review focus

- micromamba liveness semantics for `clean --packages`
- reuse and settlement of existing operation journal hooks around cleanup spawns
- ordinary best-effort cleanup versus fail-closed `CHILD_UNCONFIRMED`
- exclusive-to-shared cache lock sequencing
- preservation of tarballs and relocation restore's offline cache dependency

Uncovered local risk: tarball archives remain intentionally unbounded to preserve offline relocation. A hard size limit requires a separate reference-aware archive-GC design.
