### PR TITLE
fix(workspace): prevent edit mention popup clipping

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
@@ -14,7 +14,12 @@ import { WorkspaceMessageItem } from './WorkspaceMessageItem'
 
 // Keep the transcript row and markdown surface as thin wrappers so the test never loads Shiki.
 vi.mock('@/components/ui/message-scroller', () => ({
-  MessageScrollerItem: ({ children }: PropsWithChildren): JSX.Element => <div>{children}</div>
+  MessageScrollerItem: ({
+    children,
+    disableContainment
+  }: PropsWithChildren<{ disableContainment?: boolean }>): JSX.Element => (
+    <div data-disable-containment={disableContainment || undefined}>{children}</div>
+  )
 }))
 
 vi.mock('@/components/streamdown/AgentMarkdown', () => ({
@@ -134,6 +139,19 @@ const typeIntoEditor = async (editor: HTMLElement, text: string): Promise<void> 
   })
 }
 
+const typeMentionIntoEditor = async (editor: HTMLElement): Promise<void> => {
+  await act(async () => {
+    const mention = document.createTextNode('@')
+    editor.replaceChildren(mention)
+    const range = document.createRange()
+    range.setStart(mention, 1)
+    range.collapse(true)
+    window.getSelection()?.removeAllRanges()
+    window.getSelection()?.addRange(range)
+    editor.dispatchEvent(new InputEvent('input', { bubbles: true }))
+  })
+}
+
 beforeEach(() => {
   globalThis.ResizeObserver = class {
     constructor(private readonly callback: ResizeObserverCallback) {}
@@ -152,6 +170,12 @@ beforeEach(() => {
     value: { writeText },
     configurable: true
   })
+  Range.prototype.getBoundingClientRect = () => new DOMRect()
+  ;(window as unknown as { api: unknown }).api = {
+    projectFiles: {
+      listFiles: vi.fn().mockResolvedValue({ items: [], totalCount: 0 })
+    }
+  }
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -161,6 +185,7 @@ afterEach(() => {
   act(() => root.unmount())
   container.remove()
   document.body.innerHTML = ''
+  delete (window as unknown as { api?: unknown }).api
   notifyResize = undefined
   if (originalResizeObserver) globalThis.ResizeObserver = originalResizeObserver
   else delete (globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver
@@ -601,6 +626,18 @@ describe('WorkspaceMessageItem user message actions', () => {
     expect(editor?.textContent).toBe('Run /forecast now')
     // The structured skill segment comes back as a chip, not flattened text.
     expect(editor?.querySelector('[data-mention-type="skill"]')).not.toBeNull()
+  })
+
+  it('keeps the artifact mention popup outside transcript row containment while editing', async () => {
+    await renderItem(createMessage(), { canEditMessage: true })
+
+    await click(getButton('Edit message'))
+    const editor = getEditor()
+    if (!editor) throw new Error('editor not found')
+    await typeMentionIntoEditor(editor)
+
+    expect(container.querySelector('[role="listbox"]')).not.toBeNull()
+    expect(container.firstElementChild?.getAttribute('data-disable-containment')).toBe('true')
   })
 
   it('cancels editing and restores the bubble without resending', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -1147,7 +1147,7 @@ const WorkspaceMessageItemImpl = ({
     <MessageScrollerItem
       key={message.id}
       messageId={message.id}
-      disableContainment={message.status === 'streaming' || isAssistantPresenting}
+      disableContainment={message.status === 'streaming' || isAssistantPresenting || isEditing}
       scrollAnchor={message.role === 'user'}
       className="min-w-0"
     >


### PR DESCRIPTION
## Problem

Editing a completed user message and typing `@` opens the artifact suggestions above the inline editor. The transcript row retained `content-visibility` containment, so Chromium clipped the portion that painted outside that row.

## Proposed change

- Disable transcript-row containment while a user message is being edited, then restore it when editing closes.
- Add a regression test that opens the inline editor, triggers the artifact list, and verifies that the containing message row opts out of containment.

## Scope and non-goals

- No change to the shared mention popup, its z-index, or the normal composer.
- No historical-data compatibility requirement.
- No enum or persisted-state additions.
- No data-persistence changes.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Inline edit artifact popup paints outside the transcript row -> `npm test -- src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx` -> 26 tests passed.
- Workspace-page behavior and representative consumers -> `npm run test:module -- workspace_page` -> 25 files, 459 tests passed.
- Renderer type safety -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint` -> passed.
- Renderer development build -> `npm run dev:headless` -> renderer and preload builds passed; interactive Web verification was unavailable because an existing Electron development instance held the single-instance lock.

The exact-head impact classifier fails closed to the full PR Gate plan because `WorkspaceMessageItem.actions.test.tsx` currently has no declared module owner. Per maintainer direction, the complete portable suite is left to PR CI.

## Review focus

Confirm that limiting `disableContainment` to `isEditing` preserves containment for stable transcript rows while allowing both `/` and `@` upward-opening suggestion popups to paint outside the edited row.