### PR TITLE
fix(tags): reject stale tag updates

### DIFF
--- a/src/main/tags/repository.test.ts
+++ b/src/main/tags/repository.test.ts
@@ -141,6 +141,23 @@ describe('TagRepository', () => {
     )
   })
 
+  it('rejects an out-of-range update timestamp with a domain error', async () => {
+    await repository.create({ name: 'Research', iconKey: 'tag', colorKey: 'blue' })
+    const tag = (await repository.snapshot(0)).tags.find(
+      (candidate) => 'name' in candidate && candidate.name === 'Research'
+    )!
+
+    await expect(
+      repository.update({
+        id: tag.id,
+        name: 'Updated research',
+        iconKey: 'book-open',
+        colorKey: 'green',
+        expectedUpdatedAt: 8_640_000_000_000_001
+      })
+    ).rejects.toThrow('Tag update timestamp is invalid.')
+  })
+
   it('stores many-to-many assignments and cascades custom Tag deletion', async () => {
     await repository.create({ name: 'Methods', iconKey: 'flask-conical', colorKey: 'green' })
     const tag = (await repository.snapshot(0)).tags.find(

--- a/src/main/tags/repository.test.ts
+++ b/src/main/tags/repository.test.ts
@@ -94,9 +94,46 @@ describe('TagRepository', () => {
         id: tag.id,
         name: expandingName,
         iconKey: 'tag',
-        colorKey: 'blue'
+        colorKey: 'blue',
+        expectedUpdatedAt: tag.updatedAt
       })
     ).rejects.toThrow('Tag name is too long.')
+  })
+
+  it('rejects an update from a stale Tag snapshot without overwriting the winner', async () => {
+    await repository.create({ name: 'Research', iconKey: 'tag', colorKey: 'blue' })
+    const staleTag = (await repository.snapshot(0)).tags.find(
+      (candidate) => 'name' in candidate && candidate.name === 'Research'
+    )!
+
+    while (Date.now() <= staleTag.updatedAt) {
+      await new Promise((resolve) => setTimeout(resolve, 1))
+    }
+    await repository.update({
+      id: staleTag.id,
+      name: 'Current research',
+      iconKey: 'book-open',
+      colorKey: 'green',
+      expectedUpdatedAt: staleTag.updatedAt
+    })
+
+    await expect(
+      repository.update({
+        id: staleTag.id,
+        name: 'Research',
+        iconKey: 'star',
+        colorKey: 'amber',
+        expectedUpdatedAt: staleTag.updatedAt
+      })
+    ).rejects.toThrow('Tag changed since it was loaded.')
+    expect((await repository.snapshot(1)).tags).toContainEqual(
+      expect.objectContaining({
+        id: staleTag.id,
+        name: 'Current research',
+        iconKey: 'book-open',
+        colorKey: 'green'
+      })
+    )
   })
 
   it('stores many-to-many assignments and cascades custom Tag deletion', async () => {

--- a/src/main/tags/repository.test.ts
+++ b/src/main/tags/repository.test.ts
@@ -106,9 +106,10 @@ describe('TagRepository', () => {
       (candidate) => 'name' in candidate && candidate.name === 'Research'
     )!
 
-    while (Date.now() <= staleTag.updatedAt) {
-      await new Promise((resolve) => setTimeout(resolve, 1))
-    }
+    repository = new TagRepository(
+      async () => client,
+      () => staleTag.updatedAt
+    )
     await repository.update({
       id: staleTag.id,
       name: 'Current research',
@@ -126,12 +127,16 @@ describe('TagRepository', () => {
         expectedUpdatedAt: staleTag.updatedAt
       })
     ).rejects.toThrow('Tag changed since it was loaded.')
-    expect((await repository.snapshot(1)).tags).toContainEqual(
+    const currentTag = (await repository.snapshot(1)).tags.find(
+      (candidate) => candidate.id === staleTag.id
+    )!
+    expect(currentTag).toEqual(
       expect.objectContaining({
         id: staleTag.id,
         name: 'Current research',
         iconKey: 'book-open',
-        colorKey: 'green'
+        colorKey: 'green',
+        updatedAt: staleTag.updatedAt + 1
       })
     )
   })

--- a/src/main/tags/repository.ts
+++ b/src/main/tags/repository.ts
@@ -5,6 +5,7 @@ import {
   FAVORITE_TAG_SYSTEM_KEY,
   type ReorderTagsRequest,
   TAG_NAME_MAX_LENGTH,
+  TAG_TIMESTAMP_MAX,
   type CreateTagRequest,
   type SetTagAssignmentRequest,
   type TagColorKey,
@@ -122,6 +123,17 @@ class TagRepository {
     const current = await client.tag.findUnique({ where: { id: request.id } })
     if (!current) throw new Error('Tag not found.')
     if (current.systemKey) throw new Error('System Tags cannot be edited.')
+    if (
+      !Number.isSafeInteger(request.expectedUpdatedAt) ||
+      request.expectedUpdatedAt <= 0 ||
+      request.expectedUpdatedAt >= TAG_TIMESTAMP_MAX
+    ) {
+      throw new Error('Tag update timestamp is invalid.')
+    }
+    const updatedAt = Math.max(this.now(), request.expectedUpdatedAt + 1)
+    if (!Number.isSafeInteger(updatedAt) || updatedAt <= 0 || updatedAt > TAG_TIMESTAMP_MAX) {
+      throw new Error('Tag update timestamp is invalid.')
+    }
     try {
       const result = await client.tag.updateMany({
         where: { id: request.id, updatedAt: new Date(request.expectedUpdatedAt) },
@@ -130,7 +142,7 @@ class TagRepository {
           nameKey,
           iconKey: request.iconKey,
           colorKey: request.colorKey,
-          updatedAt: new Date(Math.max(this.now(), request.expectedUpdatedAt + 1))
+          updatedAt: new Date(updatedAt)
         }
       })
       if (result.count === 0) throw new Error('Tag changed since it was loaded.')

--- a/src/main/tags/repository.ts
+++ b/src/main/tags/repository.ts
@@ -120,8 +120,8 @@ class TagRepository {
     if (!current) throw new Error('Tag not found.')
     if (current.systemKey) throw new Error('System Tags cannot be edited.')
     try {
-      await client.tag.update({
-        where: { id: request.id },
+      const result = await client.tag.updateMany({
+        where: { id: request.id, updatedAt: new Date(request.expectedUpdatedAt) },
         data: {
           name,
           nameKey,
@@ -129,6 +129,7 @@ class TagRepository {
           colorKey: request.colorKey
         }
       })
+      if (result.count === 0) throw new Error('Tag changed since it was loaded.')
     } catch (error) {
       duplicateNameError(error)
     }

--- a/src/main/tags/repository.ts
+++ b/src/main/tags/repository.ts
@@ -49,7 +49,10 @@ const duplicateNameError = (error: unknown): never => {
 }
 
 class TagRepository {
-  constructor(private readonly getClient: TagClientProvider) {}
+  constructor(
+    private readonly getClient: TagClientProvider,
+    private readonly now: () => number = Date.now
+  ) {}
 
   private async ensureFavorite(client: TagClient): Promise<void> {
     await client.tag.upsert({
@@ -126,7 +129,8 @@ class TagRepository {
           name,
           nameKey,
           iconKey: request.iconKey,
-          colorKey: request.colorKey
+          colorKey: request.colorKey,
+          updatedAt: new Date(Math.max(this.now(), request.expectedUpdatedAt + 1))
         }
       })
       if (result.count === 0) throw new Error('Tag changed since it was loaded.')

--- a/src/renderer/src/pages/settings/TagsPanel.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.tsx
@@ -268,7 +268,7 @@ const TagsPanel = ({
     setFormError(undefined)
     try {
       if (editing === 'new') await createTag(draft)
-      else await updateTag({ id: editing.id, ...draft })
+      else await updateTag({ id: editing.id, expectedUpdatedAt: editing.updatedAt, ...draft })
       setEditing(undefined)
     } catch {
       setFormError(t('Could not save Tag.'))

--- a/src/shared/tags.test.ts
+++ b/src/shared/tags.test.ts
@@ -54,6 +54,23 @@ describe('tag application command contracts', () => {
     ).toThrow()
   })
 
+  it('requires the Tag version expected by an update', () => {
+    const request = {
+      id: 'custom',
+      name: 'Analysis',
+      iconKey: 'tag',
+      colorKey: 'blue',
+      expectedUpdatedAt: 42
+    } as const
+
+    expect(tagApplicationCommandContracts.update.args.parse([request])).toEqual([request])
+    expect(() =>
+      tagApplicationCommandContracts.update.args.parse([
+        { id: 'custom', name: 'Analysis', iconKey: 'tag', colorKey: 'blue' }
+      ])
+    ).toThrow()
+  })
+
   it('accepts only a strict ordered Tag id list', () => {
     expect(tagApplicationCommandContracts.reorder.args.parse([{ tagIds: ['a', 'b'] }])).toEqual([
       { tagIds: ['a', 'b'] }

--- a/src/shared/tags.test.ts
+++ b/src/shared/tags.test.ts
@@ -69,6 +69,11 @@ describe('tag application command contracts', () => {
         { id: 'custom', name: 'Analysis', iconKey: 'tag', colorKey: 'blue' }
       ])
     ).toThrow()
+    expect(() =>
+      tagApplicationCommandContracts.update.args.parse([
+        { ...request, expectedUpdatedAt: 8_640_000_000_000_001 }
+      ])
+    ).toThrow()
   })
 
   it('accepts only a strict ordered Tag id list', () => {

--- a/src/shared/tags.ts
+++ b/src/shared/tags.ts
@@ -4,6 +4,7 @@ import { defineApplicationCommandContract, validationCodec } from './application
 
 export const TAG_NAME_MAX_LENGTH = 64
 export const TAG_RESOURCE_ID_MAX_LENGTH = 256
+export const TAG_TIMESTAMP_MAX = 8_640_000_000_000_000
 export const FAVORITE_TAG_SYSTEM_KEY = 'favorite' as const
 export const FAVORITE_TAG_ID = 'tag-favorite' as const
 
@@ -86,7 +87,14 @@ export const createTagRequestSchema = z
   })
   .strict()
 export const updateTagRequestSchema = createTagRequestSchema
-  .extend({ id: z.string().min(1), expectedUpdatedAt: z.number().int().positive() })
+  .extend({
+    id: z.string().min(1),
+    expectedUpdatedAt: z
+      .number()
+      .int()
+      .positive()
+      .max(TAG_TIMESTAMP_MAX - 1)
+  })
   .strict()
 export const deleteTagRequestSchema = z.object({ id: z.string().min(1) }).strict()
 export const setTagAssignmentRequestSchema = tagResourceRefSchema

--- a/src/shared/tags.ts
+++ b/src/shared/tags.ts
@@ -86,7 +86,7 @@ export const createTagRequestSchema = z
   })
   .strict()
 export const updateTagRequestSchema = createTagRequestSchema
-  .extend({ id: z.string().min(1) })
+  .extend({ id: z.string().min(1), expectedUpdatedAt: z.number().int().positive() })
   .strict()
 export const deleteTagRequestSchema = z.object({ id: z.string().min(1) }).strict()
 export const setTagAssignmentRequestSchema = tagResourceRefSchema


### PR DESCRIPTION
## Problem

Two windows can edit the same Tag from the same snapshot. The update request previously carried all editable fields but no expected version, so the repository's read was followed by an unconditional update by id. A later save from a stale editor could silently overwrite another window's completed edit.

## Proposed change

- require the Tag snapshot's `expectedUpdatedAt` in the update command contract
- send the edited Tag's `updatedAt` from the renderer
- update with an atomic `id + updatedAt` predicate and reject a stale snapshot
- cover the lost-update scenario with a real migrated SQLite repository test

## Scope and non-goals

- no database columns, migrations, or persisted enum/state changes
- no automatic field merge or new conflict UI
- existing persisted Tags require no compatibility migration
- older independent callers of `tags:update` must add the now-required `expectedUpdatedAt`; the bundled main and renderer ship together

## Acceptance criteria and validation

The checks below ran after the last material edit:

- stale Tag update is rejected and the winning update remains persisted -> `npm test -- src/main/tags/repository.test.ts src/main/tags/service.test.ts src/shared/tags.test.ts src/renderer/src/stores/tag-store.test.ts src/renderer/src/pages/settings/TagsPanel.render.test.tsx` -> 5 files passed, 42 tests passed
- main-process and shared contract types -> `npm run typecheck:node` -> passed
- renderer consumer types -> `npm run typecheck:web` -> passed
- linted source and tests -> `npm run lint` -> passed

The regression test was run before the fix and failed twice because the stale update resolved instead of rejecting. The complete portable and platform suites were intentionally left to PR CI.

## Review focus

- whether `updatedAt` is correctly treated as the Tag compare-and-set version
- whether requiring the field at the application-command boundary is appropriate for all supported callers
- whether the existing generic save failure is sufficient for this minimal data-integrity fix