### PR TITLE
fix(task-api): honor idempotency keys for creates and runs

### DIFF
--- a/packages/open-science/README.md
+++ b/packages/open-science/README.md
@@ -28,6 +28,10 @@ final options argument to an individual request method. `downloadArtifact` keeps
 while its returned `Response` body is streaming. `waitForRun` applies its overall `timeoutMs` and
 caller signal to every in-flight polling request as well as the delay between polls.
 
+For retry-safe project creation and Run starts, pass the same `idempotencyKey` in the final options
+argument on every attempt. The daemon replays the first response for up to 24 hours while it remains
+running; reusing a key with a different request body fails with `idempotency_conflict`.
+
 The `project` request field and the `listSessions(projectId)` argument both require a Project ID.
 Project display names are not accepted as routing identifiers.
 

--- a/packages/open-science/README.md
+++ b/packages/open-science/README.md
@@ -30,7 +30,9 @@ caller signal to every in-flight polling request as well as the delay between po
 
 For retry-safe project creation and Run starts, pass the same `idempotencyKey` in the final options
 argument on every attempt. The daemon replays the first response for up to 24 hours while it remains
-running; reusing a key with a different request body fails with `idempotency_conflict`.
+running; reusing a key with a different request body fails with `idempotency_conflict`. If the
+bounded replay registry is full, a new unique key fails with `idempotency_unavailable` rather than
+evicting an existing guarantee.
 
 The `project` request field and the `listSessions(projectId)` argument both require a Project ID.
 Project display names are not accepted as routing identifiers.

--- a/packages/open-science/client.test.ts
+++ b/packages/open-science/client.test.ts
@@ -122,14 +122,17 @@ describe('OpenScienceClient', () => {
       sleep: vi.fn().mockResolvedValue(undefined)
     })
 
-    const started = await client.startRun({
-      project: 'project-1',
-      prompt: 'Research this.',
-      cwd: '/workspace/research',
-      permissionProfile: 'auto',
-      skillIds: ['literature-review'],
-      computeHostIds: ['ssh:alpha', 'ssh:beta']
-    })
+    const started = await client.startRun(
+      {
+        project: 'project-1',
+        prompt: 'Research this.',
+        cwd: '/workspace/research',
+        permissionProfile: 'auto',
+        skillIds: ['literature-review'],
+        computeHostIds: ['ssh:alpha', 'ssh:beta']
+      },
+      { idempotencyKey: 'start-run-1' }
+    )
     const completed = await client.waitForRun(started.id)
 
     expect(completed).toMatchObject({
@@ -142,7 +145,10 @@ describe('OpenScienceClient', () => {
       'http://127.0.0.1:44100/api/v1/runs',
       expect.objectContaining({
         method: 'POST',
-        headers: expect.objectContaining({ authorization: 'Bearer secret-token' }),
+        headers: expect.objectContaining({
+          authorization: 'Bearer secret-token',
+          'idempotency-key': 'start-run-1'
+        }),
         body: JSON.stringify({
           project: 'project-1',
           prompt: 'Research this.',

--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -1,7 +1,11 @@
 export type PermissionProfile = 'ask' | 'auto' | 'full'
 export type DelegationPolicy = 'allow' | 'deny'
 export type TurnIntent = 'plan-first'
-export type RequestOptions = { signal?: AbortSignal; timeoutMs?: number }
+export type RequestOptions = {
+  idempotencyKey?: string
+  signal?: AbortSignal
+  timeoutMs?: number
+}
 export type RunStatus = 'running' | 'completed' | 'failed' | 'cancelled'
 export type RunProgressPhase =
   | 'accepted'

--- a/packages/open-science/index.mjs
+++ b/packages/open-science/index.mjs
@@ -458,12 +458,13 @@ export class OpenScienceClient {
     }
   }
 
-  async request(path, { method = 'GET', body, signal, timeoutMs } = {}) {
+  async request(path, { method = 'GET', body, idempotencyKey, signal, timeoutMs } = {}) {
     const headers = {
       authorization: `Bearer ${this.token}`,
       accept: 'application/json'
     }
     if (body !== undefined) headers['content-type'] = 'application/json'
+    if (idempotencyKey !== undefined) headers['idempotency-key'] = idempotencyKey
     return withRequestTimeout(
       { defaultTimeoutMs: this.requestTimeoutMs, signal, timeoutMs },
       async (requestSignal) => {

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -25,6 +25,7 @@ import type { CallerContext } from '../caller-context'
 import {
   REMOTE_LOCAL_ONLY_RPC_CHANNELS,
   startWebHttpServer,
+  TaskIdempotencyRegistry,
   type ExternalWebAccessAuthorization,
   type RunningWebServer
 } from './http-server'
@@ -89,6 +90,23 @@ afterEach(async () => {
 })
 
 describe('startWebHttpServer', () => {
+  it('preserves valid idempotency entries when replay capacity is full', async () => {
+    const registry = new TaskIdempotencyRegistry(2, 8_192)
+    const first = vi.fn().mockResolvedValue('first result')
+
+    await expect(registry.run('first', 'first fingerprint', 4_096, first)).resolves.toBe(
+      'first result'
+    )
+    await registry.run('second', 'second fingerprint', 4_096, async () => 'second result')
+    await expect(
+      registry.run('third', 'third fingerprint', 4_096, async () => 'third result')
+    ).rejects.toThrow('Idempotency replay capacity is temporarily unavailable.')
+    await expect(registry.run('first', 'first fingerprint', 4_096, first)).resolves.toBe(
+      'first result'
+    )
+    expect(first).toHaveBeenCalledOnce()
+  })
+
   it('serves static resources with browser security policies', async () => {
     const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
     roots.push(staticRoot)

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -1639,6 +1639,110 @@ describe('startWebHttpServer', () => {
     expect(onShutdownRequest).not.toHaveBeenCalled()
   })
 
+  it('replays project and run POST responses for repeated idempotency keys', async () => {
+    const createProject = vi.fn().mockResolvedValue({ id: 'project-1', name: 'Created' })
+    let releaseStartRun: (() => void) | undefined
+    const startRunGate = new Promise<void>((resolve) => {
+      releaseStartRun = resolve
+    })
+    const startRun = vi.fn(async () => {
+      await startRunGate
+      return {
+        id: 'run-1',
+        sessionId: 'session-1',
+        projectId: 'project-1',
+        cwd: '/workspace/research',
+        status: 'running' as const,
+        startedAt: 1,
+        artifacts: [],
+        preferredComputeHostIds: []
+      }
+    })
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      rpc: { channels: () => [], invoke: vi.fn() },
+      tasks: {
+        runWithCallerContext,
+        subscribeProgress: vi.fn(() => vi.fn()),
+        listProjects: vi.fn(),
+        createProject,
+        updateProject: vi.fn(),
+        listSessions: vi.fn(),
+        getSession: vi.fn(),
+        startRun,
+        getRun: vi.fn(),
+        cancelRun: vi.fn(),
+        listArtifacts: vi.fn(),
+        acquireArtifact: vi.fn(),
+        releaseArtifact: vi.fn()
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const base = `http://127.0.0.1:${server.port}`
+    const post = async (path: string, key: string, body: unknown): Promise<unknown> => {
+      const response = await fetch(`${base}${path}`, {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer test-token',
+          'content-type': 'application/json',
+          'idempotency-key': key
+        },
+        body: JSON.stringify(body)
+      })
+      return response.json()
+    }
+    const postTwice = async (path: string, key: string, body: unknown): Promise<unknown[]> => {
+      const responses: unknown[] = []
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        responses.push(await post(path, key, body))
+      }
+      return responses
+    }
+
+    const projectResponses = await postTwice('/api/v1/projects', 'create-project-1', {
+      name: 'Created'
+    })
+    const conflictingProject = await fetch(`${base}/api/v1/projects`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json',
+        'idempotency-key': 'create-project-1'
+      },
+      body: JSON.stringify({ name: 'Different project' })
+    })
+    const runBody = {
+      project: 'project-1',
+      prompt: 'Research this.'
+    }
+    const firstRunResponse = post('/api/v1/runs', 'start-run-1', runBody)
+    await vi.waitFor(() => expect(startRun).toHaveBeenCalledOnce())
+    const secondRunResponse = post('/api/v1/runs', 'start-run-1', runBody)
+    releaseStartRun?.()
+    const runResponses = await Promise.all([firstRunResponse, secondRunResponse])
+
+    expect(projectResponses[1]).toEqual(projectResponses[0])
+    expect(conflictingProject.status).toBe(409)
+    expect(await conflictingProject.json()).toEqual({
+      error: {
+        code: 'idempotency_conflict',
+        message: 'Idempotency-Key was already used with a different request body.'
+      }
+    })
+    expect(runResponses[1]).toEqual(runResponses[0])
+    expect([createProject.mock.calls.length, startRun.mock.calls.length]).toEqual([1, 1])
+  })
+
   it('serves the versioned task API without exposing internal RPC channels', async () => {
     const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
     roots.push(staticRoot)

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
 import { readFile, stat } from 'node:fs/promises'
 import { extname, resolve, sep } from 'node:path'
@@ -54,7 +55,10 @@ const INTERNAL_SERVER_ERROR_MESSAGE = 'Internal server error'
 const DEFAULT_EVENT_HEARTBEAT_INTERVAL_MS = 10_000
 const TASK_IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1_000
 const MAX_TASK_IDEMPOTENCY_ENTRIES = 1_024
+const MAX_TASK_IDEMPOTENCY_BYTES = 64 * 1024 * 1024
+const MIN_TASK_IDEMPOTENCY_ENTRY_BYTES = 16 * 1024
 const MAX_IDEMPOTENCY_KEY_LENGTH = 255
+const MAX_CACHED_TASK_ERROR_MESSAGE_LENGTH = 4_096
 const gzipAsync = promisify(gzip)
 const STATIC_RESPONSE_SECURITY_HEADERS = {
   'content-security-policy':
@@ -294,50 +298,83 @@ class IdempotencyConflictError extends Error {
   }
 }
 
+class IdempotencyUnavailableError extends Error {
+  constructor() {
+    super('Idempotency replay capacity is temporarily unavailable.')
+    this.name = 'IdempotencyUnavailableError'
+  }
+}
+
 type TaskIdempotencyEntry = {
   fingerprint: string
   expiresAt: number
+  reservedBytes: number
   result: Promise<unknown>
 }
 
-class TaskIdempotencyRegistry {
+export class TaskIdempotencyRegistry {
   private readonly entries = new Map<string, TaskIdempotencyEntry>()
+  private reservedBytes = 0
 
-  run<Result>(
+  constructor(
+    private readonly maxEntries = MAX_TASK_IDEMPOTENCY_ENTRIES,
+    private readonly maxBytes = MAX_TASK_IDEMPOTENCY_BYTES,
+    private readonly now: () => number = Date.now
+  ) {}
+
+  async run<Result>(
     scope: string,
     fingerprint: string,
+    reservedBytes: number,
     operation: () => Promise<Result>
   ): Promise<Result> {
-    const now = Date.now()
+    const now = this.now()
     for (const [key, entry] of this.entries) {
-      if (entry.expiresAt <= now) this.entries.delete(key)
+      if (entry.expiresAt <= now) this.delete(key, entry)
     }
 
     const existing = this.entries.get(scope)
     if (existing) {
       if (existing.fingerprint !== fingerprint) throw new IdempotencyConflictError()
-      // Refresh insertion order so bounded eviction retains recently retried operations.
-      this.entries.delete(scope)
-      this.entries.set(scope, existing)
       return existing.result as Promise<Result>
     }
 
-    const result = Promise.resolve().then(operation)
+    if (
+      this.entries.size >= this.maxEntries ||
+      reservedBytes > this.maxBytes - this.reservedBytes
+    ) {
+      throw new IdempotencyUnavailableError()
+    }
+
+    const result = Promise.resolve()
+      .then(operation)
+      .catch((error: unknown) => {
+        if (error instanceof TaskApiError) {
+          throw new TaskApiError(
+            error.code,
+            error.message.slice(0, MAX_CACHED_TASK_ERROR_MESSAGE_LENGTH)
+          )
+        }
+        throw new Error(INTERNAL_SERVER_ERROR_MESSAGE)
+      })
     this.entries.set(scope, {
       fingerprint,
       expiresAt: now + TASK_IDEMPOTENCY_TTL_MS,
+      reservedBytes,
       result
     })
-    while (this.entries.size > MAX_TASK_IDEMPOTENCY_ENTRIES) {
-      const oldest = this.entries.keys().next().value
-      if (oldest === undefined) break
-      this.entries.delete(oldest)
-    }
+    this.reservedBytes += reservedBytes
     return result
   }
 
   clear(): void {
     this.entries.clear()
+    this.reservedBytes = 0
+  }
+
+  private delete(key: string, entry: TaskIdempotencyEntry): void {
+    if (!this.entries.delete(key)) return
+    this.reservedBytes -= entry.reservedBytes
   }
 }
 
@@ -364,7 +401,15 @@ const runIdempotentTask = <Result>(
   const key = idempotencyKey(request)
   if (key === undefined) return operation()
   const scope = JSON.stringify([callerContext.location, request.method, url.pathname, key])
-  return registry.run(scope, JSON.stringify(body), operation)
+  const serializedBody = JSON.stringify(body)
+  const fingerprint = createHash('sha256').update(serializedBody).digest('hex')
+  // Project responses may retain request-derived strings; reserve twice the UTF-8 body plus fixed
+  // Promise/result/error overhead so the registry has both an entry limit and a memory budget.
+  const reservedBytes = Math.max(
+    MIN_TASK_IDEMPOTENCY_ENTRY_BYTES,
+    Buffer.byteLength(serializedBody) * 2 + MIN_TASK_IDEMPOTENCY_ENTRY_BYTES
+  )
+  return registry.run(scope, fingerprint, reservedBytes, operation)
 }
 
 const assertExternalAuthorizationCurrent = (
@@ -391,6 +436,12 @@ const taskError = (response: ServerResponse, error: unknown): void => {
   if (error instanceof IdempotencyConflictError) {
     json(response, 409, {
       error: { code: 'idempotency_conflict', message: error.message }
+    })
+    return
+  }
+  if (error instanceof IdempotencyUnavailableError) {
+    json(response, 503, {
+      error: { code: 'idempotency_unavailable', message: error.message }
     })
     return
   }

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -52,6 +52,9 @@ const MAX_RPC_BODY_BYTES = 64 * 1024 * 1024
 const MIN_GZIP_BYTES = 1_024
 const INTERNAL_SERVER_ERROR_MESSAGE = 'Internal server error'
 const DEFAULT_EVENT_HEARTBEAT_INTERVAL_MS = 10_000
+const TASK_IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1_000
+const MAX_TASK_IDEMPOTENCY_ENTRIES = 1_024
+const MAX_IDEMPOTENCY_KEY_LENGTH = 255
 const gzipAsync = promisify(gzip)
 const STATIC_RESPONSE_SECURITY_HEADERS = {
   'content-security-policy':
@@ -284,6 +287,86 @@ class ExternalAuthorizationExpiredError extends Error {
   }
 }
 
+class IdempotencyConflictError extends Error {
+  constructor() {
+    super('Idempotency-Key was already used with a different request body.')
+    this.name = 'IdempotencyConflictError'
+  }
+}
+
+type TaskIdempotencyEntry = {
+  fingerprint: string
+  expiresAt: number
+  result: Promise<unknown>
+}
+
+class TaskIdempotencyRegistry {
+  private readonly entries = new Map<string, TaskIdempotencyEntry>()
+
+  run<Result>(
+    scope: string,
+    fingerprint: string,
+    operation: () => Promise<Result>
+  ): Promise<Result> {
+    const now = Date.now()
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt <= now) this.entries.delete(key)
+    }
+
+    const existing = this.entries.get(scope)
+    if (existing) {
+      if (existing.fingerprint !== fingerprint) throw new IdempotencyConflictError()
+      // Refresh insertion order so bounded eviction retains recently retried operations.
+      this.entries.delete(scope)
+      this.entries.set(scope, existing)
+      return existing.result as Promise<Result>
+    }
+
+    const result = Promise.resolve().then(operation)
+    this.entries.set(scope, {
+      fingerprint,
+      expiresAt: now + TASK_IDEMPOTENCY_TTL_MS,
+      result
+    })
+    while (this.entries.size > MAX_TASK_IDEMPOTENCY_ENTRIES) {
+      const oldest = this.entries.keys().next().value
+      if (oldest === undefined) break
+      this.entries.delete(oldest)
+    }
+    return result
+  }
+
+  clear(): void {
+    this.entries.clear()
+  }
+}
+
+const idempotencyKey = (request: IncomingMessage): string | undefined => {
+  const value = request.headers['idempotency-key']
+  if (value === undefined) return undefined
+  if (Array.isArray(value) || value.length === 0 || value.length > MAX_IDEMPOTENCY_KEY_LENGTH) {
+    throw new TaskApiError(
+      'invalid_request',
+      `Idempotency-Key must contain between 1 and ${MAX_IDEMPOTENCY_KEY_LENGTH} characters.`
+    )
+  }
+  return value
+}
+
+const runIdempotentTask = <Result>(
+  registry: TaskIdempotencyRegistry,
+  request: IncomingMessage,
+  url: URL,
+  callerContext: CallerContext,
+  body: unknown,
+  operation: () => Promise<Result>
+): Promise<Result> => {
+  const key = idempotencyKey(request)
+  if (key === undefined) return operation()
+  const scope = JSON.stringify([callerContext.location, request.method, url.pathname, key])
+  return registry.run(scope, JSON.stringify(body), operation)
+}
+
 const assertExternalAuthorizationCurrent = (
   authorization: ExternalWebAccessAuthorization | undefined
 ): void => {
@@ -302,6 +385,12 @@ const taskError = (response: ServerResponse, error: unknown): void => {
   if (error instanceof ExternalAuthorizationExpiredError) {
     json(response, 401, {
       error: { code: 'unauthorized', message: error.message }
+    })
+    return
+  }
+  if (error instanceof IdempotencyConflictError) {
+    json(response, 409, {
+      error: { code: 'idempotency_conflict', message: error.message }
     })
     return
   }
@@ -396,6 +485,7 @@ const handleTaskApiRequest = async (
   url: URL,
   tasks: NonNullable<WebServerOptions['tasks']>,
   callerContext: CallerContext,
+  idempotencyRegistry: TaskIdempotencyRegistry,
   externalAuthorization?: ExternalWebAccessAuthorization
 ): Promise<boolean> =>
   tasks.runWithCallerContext(callerContext, async () => {
@@ -409,7 +499,14 @@ const handleTaskApiRequest = async (
         const body = (await readJsonBody(request)) as CreateTaskProjectRequest
         assertExternalAuthorizationCurrent(externalAuthorization)
         json(response, 201, {
-          data: await tasks.createProject(body)
+          data: await runIdempotentTask(
+            idempotencyRegistry,
+            request,
+            url,
+            callerContext,
+            body,
+            () => tasks.createProject(body)
+          )
         })
         return true
       }
@@ -432,7 +529,16 @@ const handleTaskApiRequest = async (
       if (url.pathname === '/api/v1/runs' && request.method === 'POST') {
         const body = (await readJsonBody(request)) as StartTaskRunRequest
         assertExternalAuthorizationCurrent(externalAuthorization)
-        json(response, 202, { data: await tasks.startRun(body) })
+        json(response, 202, {
+          data: await runIdempotentTask(
+            idempotencyRegistry,
+            request,
+            url,
+            callerContext,
+            body,
+            () => tasks.startRun(body)
+          )
+        })
         return true
       }
 
@@ -564,6 +670,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
   const awaitingPong = new WeakSet<WebSocket>()
   const internalEventStream = new InternalWebEventStream()
   const commandClient = createApplicationCommandClient()
+  const taskIdempotencyRegistry = new TaskIdempotencyRegistry()
   const clientLeases = new ClientLeaseRegistry((clientId) => {
     commandClient.releaseClient('web', clientId)
   })
@@ -653,6 +760,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
                 }
               : {})
           }),
+          taskIdempotencyRegistry,
           externalAuthorization
         ))
       ) {
@@ -882,6 +990,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       })
     })
   } catch (error) {
+    taskIdempotencyRegistry.clear()
     removeBroadcastSink()
     removeTaskProgressSink?.()
     try {
@@ -923,6 +1032,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
       }
     },
     close: async () => {
+      taskIdempotencyRegistry.clear()
       clearInterval(eventHeartbeatInterval)
       removeBroadcastSink()
       removeTaskProgressSink?.()


### PR DESCRIPTION
## Problem

`POST /api/v1/projects` and `POST /api/v1/runs` ignored `Idempotency-Key`. Retrying an accepted request therefore invoked `createProject` or `startRun` again. A duplicate Run start can allocate another Run, prompt message, and Session and can trigger duplicate model cost.

The regression test was run twice before the fix and deterministically reported business call counts of `[2, 2]` instead of `[1, 1]`.

## Proposed change

- retain Task API idempotency outcomes in the HTTP server for up to 24 hours
- scope keys by caller location, HTTP method, and endpoint
- coalesce in-flight retries and replay the first settled outcome for matching request bodies
- reject reuse of a key with a different body as `409 idempotency_conflict`
- hash request fingerprints with SHA-256 instead of retaining request bodies
- bound replay state to 1,024 entries and an estimated 64 MiB budget; preserve valid entries and reject new unique keys as `503 idempotency_unavailable` when full
- bound cached failure messages while replaying the same public failure
- expose optional `idempotencyKey` request options through the Node SDK

## Scope and non-goals

- no request-body fields or UI changes
- no database/schema, migration, or durable persistence changes
- no historical-data compatibility path is required
- no business state enum is added; `idempotency_conflict` and `idempotency_unavailable` are additive public error codes
- records are process-local, so a daemon restart ends the replay window

## Acceptance criteria and validation

Checks below ran after the last material edit:

- sequential Project retry, concurrent Run retry, conflicting-body behavior, and capacity preservation -> `npm test -- src/main/web-service/http-server.test.ts packages/open-science/client.test.ts packages/open-science/cli.test.ts` -> 78 passed, 4 skipped
- SDK header propagation and CLI consumer compatibility -> same targeted command -> passed
- Node process type safety -> `npm run typecheck:node` -> passed
- linted source and tests -> `npm run lint` -> passed

Full portable and platform suites are left to the PR Gate as requested.

## Review focus

- process-local retention, expiry, entry-count, and memory-budget semantics
- request fingerprint and key scoping
- caching the first bounded failure as well as the first success to preserve at-most-once behavior
