### PR TITLE
fix(conversation): preserve scroll anchor under blocking panels

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -602,6 +602,10 @@ colors communicate a successful or failed probe/migration result.
 - Blocking interactions own the composer lane in this order: an already-open Side Chat, Permission
   approval, Ask-User elicitation, Plan approval, then the ordinary composer. Closing Side Chat reveals
   any still-pending Permission approval instead of interrupting the Side Chat in progress.
+- Side Chat, Permission, Ask User, and Plan surfaces overlay the ordinary composer lane and the
+  transcript above it. Keep the ordinary composer and its status chrome in layout but visually and
+  interactively hidden while the overlay is open, so opening, resizing, resolving, or closing a
+  blocking surface never changes the message viewport height or the reader's scroll position.
 - Hide both the Notebook-chrome queue disclosure and its expanded composer rows while Side Chat,
   Permission, Ask User, or Plan owns the lane; keep the transient queue in memory so it reappears when
   the ordinary composer returns.

--- a/e2e/message-scroll-anchor.spec.ts
+++ b/e2e/message-scroll-anchor.spec.ts
@@ -4,6 +4,7 @@ import { test } from './fixtures/electron-app'
 
 const PROJECT_NAME = 'Scroll anchor project'
 const USER_MESSAGE = 'Summarize the deterministic fixture.'
+const PERMISSION_PROMPT = 'Request fixture permission.'
 // The fake agent replies with this fixed text regardless of the prompt.
 const AGENT_REPLY = 'Deterministic reply: Summarize the deterministic fixture.'
 
@@ -45,4 +46,54 @@ test('anchors a newly sent user message near the top of the viewport', async ({ 
   const offsetFromViewportTop = userRowBox!.y - viewportBox!.y
   // Anchored near the top: allow the 64px previous-item peek plus paddings.
   expect(offsetFromViewportTop).toBeLessThan(160)
+})
+
+test('keeps the prompt fixed while a blocking panel covers and leaves the transcript', async ({
+  app
+}) => {
+  let page = await app.completeOnboarding()
+  page = await app.configureFakeAgent()
+
+  await page.getByRole('button', { name: 'New project' }).click()
+  const dialog = page.getByRole('dialog', { name: 'New project' })
+  await dialog.getByLabel('Name').fill(`${PROJECT_NAME} permission`)
+  await dialog.getByRole('button', { name: 'Create project' }).click()
+  await expect(page.getByRole('heading', { name: 'New conversation' })).toBeVisible()
+
+  const conversation = page.getByRole('region', { name: 'Conversation' })
+  const textbox = page.getByRole('textbox', { name: 'Ask anything' })
+  const sendButton = page.getByRole('button', { name: 'Send message' })
+
+  for (let turn = 0; turn < 5; turn += 1) {
+    await textbox.fill(`Turn ${turn}: ${USER_MESSAGE}`)
+    await sendButton.click()
+    await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toHaveCount(turn + 1)
+  }
+
+  const viewportHeightBefore = await conversation.evaluate((element) => element.clientHeight)
+  await textbox.fill(`${PERMISSION_PROMPT} preserve the prompt anchor`)
+  await sendButton.click()
+  await expect(page.getByTestId('permission-composer')).toBeVisible()
+
+  const promptRow = conversation
+    .locator('[data-slot="message-scroller-item"][data-scroll-anchor="true"]')
+    .last()
+  await expect(promptRow).toBeVisible()
+  const readPromptOffset = async (): Promise<number> => {
+    const viewportBox = await conversation.boundingBox()
+    const promptBox = await promptRow.boundingBox()
+    expect(viewportBox).not.toBeNull()
+    expect(promptBox).not.toBeNull()
+    return promptBox!.y - viewportBox!.y
+  }
+
+  const offsetWhileBlocked = await readPromptOffset()
+  expect(await conversation.evaluate((element) => element.clientHeight)).toBe(viewportHeightBefore)
+
+  await page.getByRole('button', { name: /^Allow/ }).click()
+  await expect(page.getByText('Fixture permission allowed.', { exact: true })).toBeVisible()
+  await expect(page.getByTestId('permission-composer')).toBeHidden()
+
+  const offsetAfterApproval = await readPromptOffset()
+  expect(Math.abs(offsetAfterApproval - offsetWhileBlocked)).toBeLessThanOrEqual(2)
 })

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -531,9 +531,32 @@ const renderPanel = (props: DeepPartial<PanelProps> = {}): void => {
 }
 
 const getComposerForm = (): HTMLElement => {
-  const form = container.querySelector('form')
+  const form = container.querySelector('[data-testid="ordinary-composer-form"]')
   if (!form) throw new Error('composer form not found')
   return form as HTMLElement
+}
+
+const expectComposerCoveredByBlockingOverlay = (): void => {
+  const form = getComposerForm()
+  expect(form.hidden).toBe(false)
+  expect(form.getAttribute('aria-hidden')).toBe('true')
+  expect(form.hasAttribute('inert')).toBe(true)
+  expect(form.classList.contains('invisible')).toBe(true)
+  expect(form.classList.contains('pointer-events-none')).toBe(true)
+
+  const overlay = container.querySelector('[data-testid="blocking-composer-overlay"]')
+  expect(overlay).not.toBeNull()
+  expect(overlay?.classList.contains('absolute')).toBe(true)
+  expect(overlay?.classList.contains('bottom-0')).toBe(true)
+}
+
+const expectComposerChromeCovered = (selector: string): void => {
+  const element = container.querySelector(selector)
+  expect(element).not.toBeNull()
+  const chrome = element?.closest('[aria-hidden="true"]')
+  expect(chrome?.hasAttribute('inert')).toBe(true)
+  expect(chrome?.classList.contains('invisible')).toBe(true)
+  expect(chrome?.classList.contains('pointer-events-none')).toBe(true)
 }
 
 const getConversationHeader = (): HTMLElement => {
@@ -654,7 +677,7 @@ describe('ConversationPanel composer intake', () => {
       }
     })
 
-    expect(getComposerForm().hidden).toBe(true)
+    expectComposerCoveredByBlockingOverlay()
     expect(document.activeElement).toBe(navigationButton)
   })
 
@@ -989,8 +1012,8 @@ describe('ConversationPanel composer intake', () => {
     expect(scrollSurface.classList.contains('border-border-200')).toBe(true)
     expect(scrollSurface.classList.contains('shadow-sm')).toBe(true)
     expect(scrollSurface.classList.contains('shadow-card-opaque')).toBe(false)
-    expect(container.querySelector('[aria-label="Open notebook"]')).toBeNull()
-    expect(container.querySelector('[data-testid="remote-job-badge"]')).toBeNull()
+    expectComposerChromeCovered('[aria-label="Open notebook"]')
+    expectComposerChromeCovered('[data-testid="remote-job-badge"]')
 
     const optionRows = container.querySelectorAll<HTMLElement>(
       '[data-elicitation-option-row="true"]'
@@ -1093,10 +1116,13 @@ describe('ConversationPanel composer intake', () => {
         .querySelector('[data-testid="composer-card-backdrop"]')
         ?.classList.contains('hidden')
     ).toBe(true)
-    const hiddenComposer = container.querySelector('[role="textbox"]')?.closest('form')
-    expect(hiddenComposer?.hidden).toBe(true)
-    expect(hiddenComposer?.classList.contains('hidden')).toBe(true)
-    expect(container.querySelector('[aria-label="Cancel run"]')?.closest('form')?.hidden).toBe(true)
+    expectComposerCoveredByBlockingOverlay()
+    expect(
+      container
+        .querySelector('[aria-label="Cancel run"]')
+        ?.closest('form')
+        ?.classList.contains('invisible')
+    ).toBe(true)
 
     renderPanel({
       view: {
@@ -1191,9 +1217,9 @@ describe('ConversationPanel composer intake', () => {
     expect(resizeHandle.classList.contains('active:bg-bg-200')).toBe(false)
     expect(container.querySelector('[data-testid="permission-approval-controls"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="elicitation-composer"]')).toBeNull()
-    expect(container.querySelector('[aria-label="Open notebook"]')).toBeNull()
-    expect(container.querySelector('[data-testid="remote-job-badge"]')).toBeNull()
-    expect(getComposerForm().hidden).toBe(true)
+    expectComposerChromeCovered('[aria-label="Open notebook"]')
+    expectComposerChromeCovered('[data-testid="remote-job-badge"]')
+    expectComposerCoveredByBlockingOverlay()
     expect(
       container
         .querySelector('[data-testid="composer-surface-fade"]')
@@ -1300,7 +1326,7 @@ describe('ConversationPanel composer intake', () => {
       'Scope'
     )
     expect(container.textContent).not.toContain('Plan ready for review')
-    expect(container.querySelector('[role="textbox"]')?.closest('form')?.hidden).toBe(true)
+    expectComposerCoveredByBlockingOverlay()
 
     renderPanel({
       view: {
@@ -1324,7 +1350,7 @@ describe('ConversationPanel composer intake', () => {
 
     expect(container.querySelector('[data-testid="elicitation-composer"]')).toBeNull()
     expect(container.textContent).toContain('Plan ready for review')
-    expect(container.querySelector('[role="textbox"]')?.closest('form')?.hidden).toBe(true)
+    expectComposerCoveredByBlockingOverlay()
   })
 
   it('restores a durable pending choice from the persisted activity', async () => {
@@ -2124,7 +2150,7 @@ describe('ConversationPanel composer intake', () => {
     ).toBe(true)
   })
 
-  it('replaces the ordinary composer with an in-flow Side chat panel', () => {
+  it('covers the ordinary composer with an overlay Side chat panel', () => {
     const onCloseSideChat = vi.fn()
     renderPanel({
       sessionTools: {
@@ -2168,8 +2194,8 @@ describe('ConversationPanel composer intake', () => {
     expect(surface?.classList.contains('overflow-hidden')).toBe(true)
     expect(surface?.classList.contains('shadow-none')).toBe(true)
     expect(surface?.classList.contains('shadow-sm')).toBe(false)
-    expect(container.querySelector('[aria-label="Open notebook"]')).toBeNull()
-    expect(getComposerForm().hidden).toBe(true)
+    expectComposerChromeCovered('[aria-label="Open notebook"]')
+    expectComposerCoveredByBlockingOverlay()
     const sideChatPanel = panel as HTMLElement
     const plus = sideChatPanel.querySelector('[data-testid="side-chat-plus-button"]')
     const agentControls = sideChatPanel.querySelector('[data-testid="mock-agent-controls"]')
@@ -2209,7 +2235,7 @@ describe('ConversationPanel composer intake', () => {
       }
     })
 
-    expect(getComposerForm().hidden).toBe(true)
+    expectComposerCoveredByBlockingOverlay()
     expect(document.activeElement).toBe(navigationButton)
   })
 
@@ -2548,7 +2574,7 @@ describe('ConversationPanel composer intake', () => {
     expect(
       container.querySelector('[data-testid="scroller-pending-elicitations"]')?.textContent
     ).toBe('0')
-    expect(getComposerForm().hidden).toBe(true)
+    expectComposerCoveredByBlockingOverlay()
 
     renderPanel({
       view: {
@@ -2965,7 +2991,7 @@ describe('ConversationPanel + menu', () => {
     ).toBe(true)
   })
 
-  it('replaces the composer with a pending Plan card and restores it immediately after approval', async () => {
+  it('covers the composer with a pending Plan card and restores it immediately after approval', async () => {
     renderPanel()
     expect(container.querySelector('[data-testid="menu-view-plan"]')).toBeNull()
 
@@ -3005,7 +3031,8 @@ describe('ConversationPanel + menu', () => {
     })
 
     const pendingEditor = container.querySelector('[role="textbox"]')
-    expect(pendingEditor?.closest('form')?.classList.contains('hidden')).toBe(true)
+    expect(pendingEditor?.closest('form')?.classList.contains('invisible')).toBe(true)
+    expectComposerCoveredByBlockingOverlay()
     expect(container.textContent).toContain('Plan ready for review')
     const planComposer = container.querySelector('[data-testid="plan-composer"]') as HTMLDivElement
     const planScrollSurface = container.querySelector(
@@ -3022,8 +3049,8 @@ describe('ConversationPanel + menu', () => {
         (button) => button.textContent === 'Dismiss'
       )
     ).toBe(false)
-    expect(container.querySelector('[aria-label="Open notebook"]')).toBeNull()
-    expect(container.querySelector('[data-testid="remote-job-badge"]')).toBeNull()
+    expectComposerChromeCovered('[aria-label="Open notebook"]')
+    expectComposerChromeCovered('[data-testid="remote-job-badge"]')
     const pendingPlanCard = [...container.querySelectorAll('article')].find((article) =>
       article.textContent?.includes('Plan ready for review')
     )
@@ -3033,7 +3060,7 @@ describe('ConversationPanel + menu', () => {
       container
         .querySelector('[data-testid="composer-plus-trigger"]')
         ?.closest('form')
-        ?.classList.contains('hidden')
+        ?.classList.contains('invisible')
     ).toBe(true)
 
     planComposer.getBoundingClientRect = () => ({ height: 260 }) as DOMRect
@@ -3207,9 +3234,7 @@ describe('ConversationPanel + menu', () => {
     })
 
     expect(container.textContent).toContain('Plan ready for review')
-    expect(container.querySelector('[role="textbox"]')?.closest('form')?.classList).toContain(
-      'hidden'
-    )
+    expectComposerCoveredByBlockingOverlay()
 
     const textarea = container.querySelector('textarea') as HTMLTextAreaElement
     await act(async () => {

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -971,16 +971,14 @@ const ConversationPanel = ({
 
                 {/* Switching between a compact job bar and Notebook chrome remounts this layer so a
                     Notebook that becomes available after jobs still receives its entrance animation. */}
-                {!sideChat &&
-                !hasPendingPermission &&
-                !pendingElicitation &&
-                !pendingPlan &&
-                (notebookReference ||
-                  messageQueue.items.length > 0 ||
-                  hasAnyJobs ||
-                  hasSubagents ||
-                  (activeBranchPlan ? isPlanProgressVisible(activeBranchPlan) : false)) ? (
+                {notebookReference ||
+                messageQueue.items.length > 0 ||
+                hasAnyJobs ||
+                hasSubagents ||
+                (activeBranchPlan ? isPlanProgressVisible(activeBranchPlan) : false) ? (
                   <div
+                    aria-hidden={ordinaryComposerBlocked || undefined}
+                    inert={ordinaryComposerBlocked || undefined}
                     key={
                       notebookReference
                         ? `notebook-${notebookReference.sessionId}`
@@ -992,7 +990,8 @@ const ConversationPanel = ({
                       'flex px-2',
                       notebookReference || messageQueue.items.length > 0
                         ? 'relative -mb-8 min-h-[68px] items-start rounded-2xl bg-bg-200 pt-1 motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-1 motion-safe:duration-200 motion-safe:ease-out'
-                        : 'mb-2 min-h-9 items-center rounded-lg border border-border-200 bg-bg-000 shadow-card'
+                        : 'mb-2 min-h-9 items-center rounded-lg border border-border-200 bg-bg-000 shadow-card',
+                      ordinaryComposerBlocked && 'invisible pointer-events-none'
                     )}
                   >
                     {activeSession &&
@@ -1149,95 +1148,106 @@ const ConversationPanel = ({
                     </div>
                   ) : null}
 
-                  {sideChat ? (
-                    <SideChatPanel
-                      view={sideChat}
-                      onSend={onSendSideChat}
-                      onDraftChange={onSideChatDraftChange}
-                      onCancel={onCancelSideChat}
-                      onClose={handleCloseSideChat}
-                      controls={
-                        <ComposerAgentControlsMenu
-                          profile={permissionProfile}
-                          profileState={permissionProfileState}
-                          grants={permissionGrants}
-                          autoReviewEnabled={autoReviewEnabled}
-                          readOnly
-                          permissionProfileReadOnly
-                          grantActionsReadOnly
-                          autoReviewDisabled
-                          enabledComputeHosts={enabledComputeHosts}
-                          selectedComputeHosts={selectedComputeHosts}
-                          onComputeHostEnabledChange={onComputeHostEnabledChange}
-                          onComputeHostSelectedChange={onComputeHostSelectedChange}
-                          onProfileChange={onPermissionProfileChange}
-                          onAutoReviewChange={onAutoReviewToggle}
-                          onRevokeGrant={onRevokePermissionGrant}
-                          onClearGrants={onClearPermissionGrants}
-                          showSpecialist={activeSession !== undefined}
-                          specialistId={specialistId}
-                          specialistUnavailable={specialistUnavailable}
-                          specialistReadOnly
-                          onSpecialistChange={onSpecialistChange}
-                        />
-                      }
-                    />
-                  ) : hasPendingPermission ? (
-                    <ResizablePermissionComposer key={rootPermissionRequests[0]?.requestId}>
-                      <PermissionApprovalControls
-                        requests={rootPermissionRequests}
-                        onRespond={onRespondToPermission}
-                        embedded
-                        notebookLookup={
-                          activeSession
-                            ? {
-                                sessionId: activeSession.id,
-                                workspaceCwd: activeSession.cwd ?? '',
-                                projectId: activeSession.projectId
-                              }
-                            : undefined
-                        }
-                      />
-                    </ResizablePermissionComposer>
-                  ) : pendingElicitation ? (
-                    <ResizableElicitationComposer
-                      key={pendingElicitationRequest?.requestId ?? pendingElicitationActivity?.id}
+                  {ordinaryComposerBlocked ? (
+                    <div
+                      data-testid="blocking-composer-overlay"
+                      className="absolute inset-x-0 bottom-0 z-30"
                     >
-                      <WorkspaceElicitationCard
-                        elicitation={pendingElicitation}
-                        request={pendingElicitationRequest}
-                        embedded
-                        onRespond={onRespondToElicitation}
-                        onDraftChange={(answers: ElicitationAnswer[]) => {
-                          if (!activeSession || !pendingElicitationActivity) return
-                          setElicitationDraftAnswers(
-                            activeSession.id,
-                            pendingElicitationActivity.id,
-                            answers
-                          )
-                        }}
-                      />
-                    </ResizableElicitationComposer>
-                  ) : pendingPlan ? (
-                    <ResizablePlanComposer key={activePendingPlanKey}>
-                      <WorkspacePlanCard
-                        embedded
-                        projection={pendingPlan}
-                        onOpen={openPendingPlan}
-                        onRespond={(decision) => respondToPendingPlan({ decision })}
-                        onSubmitResponse={(text) => respondToPendingPlan({ feedback: text })}
-                        onResolved={() => setResolvedPlanKey(activePendingPlanKey)}
-                      />
-                    </ResizablePlanComposer>
+                      {sideChat ? (
+                        <SideChatPanel
+                          view={sideChat}
+                          onSend={onSendSideChat}
+                          onDraftChange={onSideChatDraftChange}
+                          onCancel={onCancelSideChat}
+                          onClose={handleCloseSideChat}
+                          controls={
+                            <ComposerAgentControlsMenu
+                              profile={permissionProfile}
+                              profileState={permissionProfileState}
+                              grants={permissionGrants}
+                              autoReviewEnabled={autoReviewEnabled}
+                              readOnly
+                              permissionProfileReadOnly
+                              grantActionsReadOnly
+                              autoReviewDisabled
+                              enabledComputeHosts={enabledComputeHosts}
+                              selectedComputeHosts={selectedComputeHosts}
+                              onComputeHostEnabledChange={onComputeHostEnabledChange}
+                              onComputeHostSelectedChange={onComputeHostSelectedChange}
+                              onProfileChange={onPermissionProfileChange}
+                              onAutoReviewChange={onAutoReviewToggle}
+                              onRevokeGrant={onRevokePermissionGrant}
+                              onClearGrants={onClearPermissionGrants}
+                              showSpecialist={activeSession !== undefined}
+                              specialistId={specialistId}
+                              specialistUnavailable={specialistUnavailable}
+                              specialistReadOnly
+                              onSpecialistChange={onSpecialistChange}
+                            />
+                          }
+                        />
+                      ) : hasPendingPermission ? (
+                        <ResizablePermissionComposer key={rootPermissionRequests[0]?.requestId}>
+                          <PermissionApprovalControls
+                            requests={rootPermissionRequests}
+                            onRespond={onRespondToPermission}
+                            embedded
+                            notebookLookup={
+                              activeSession
+                                ? {
+                                    sessionId: activeSession.id,
+                                    workspaceCwd: activeSession.cwd ?? '',
+                                    projectId: activeSession.projectId
+                                  }
+                                : undefined
+                            }
+                          />
+                        </ResizablePermissionComposer>
+                      ) : pendingElicitation ? (
+                        <ResizableElicitationComposer
+                          key={
+                            pendingElicitationRequest?.requestId ?? pendingElicitationActivity?.id
+                          }
+                        >
+                          <WorkspaceElicitationCard
+                            elicitation={pendingElicitation}
+                            request={pendingElicitationRequest}
+                            embedded
+                            onRespond={onRespondToElicitation}
+                            onDraftChange={(answers: ElicitationAnswer[]) => {
+                              if (!activeSession || !pendingElicitationActivity) return
+                              setElicitationDraftAnswers(
+                                activeSession.id,
+                                pendingElicitationActivity.id,
+                                answers
+                              )
+                            }}
+                          />
+                        </ResizableElicitationComposer>
+                      ) : pendingPlan ? (
+                        <ResizablePlanComposer key={activePendingPlanKey}>
+                          <WorkspacePlanCard
+                            embedded
+                            projection={pendingPlan}
+                            onOpen={openPendingPlan}
+                            onRespond={(decision) => respondToPendingPlan({ decision })}
+                            onSubmitResponse={(text) => respondToPendingPlan({ feedback: text })}
+                            onResolved={() => setResolvedPlanKey(activePendingPlanKey)}
+                          />
+                        </ResizablePlanComposer>
+                      ) : null}
+                    </div>
                   ) : null}
 
-                  {/* Composer stays mounted to preserve its draft, but a pending blocking interaction
-                      owns the lane and makes the ordinary controls unreachable. */}
+                  {/* The ordinary composer keeps this lane's geometry while a blocking interaction
+                      overlays it, so panel entry/resize/exit never resizes the transcript viewport. */}
                   <form
-                    hidden={ordinaryComposerBlocked}
+                    aria-hidden={ordinaryComposerBlocked || undefined}
+                    data-testid="ordinary-composer-form"
+                    inert={ordinaryComposerBlocked || undefined}
                     className={cn(
                       'relative z-10 flex flex-col gap-2 rounded-2xl border border-border-200 bg-bg-000 px-3 py-2',
-                      ordinaryComposerBlocked && 'hidden'
+                      ordinaryComposerBlocked && 'invisible pointer-events-none'
                     )}
                     data-specialist-color={specialistComposerColor}
                     onSubmit={(event) => event.preventDefault()}
@@ -1404,8 +1414,10 @@ const ConversationPanel = ({
                               ? { sessionId: activeSession.id, projectId: activeSession.projectId }
                               : undefined
                           }
-                          focusRequest={composerFocusKey}
-                          restoreFocusRequest={sideChat ? undefined : composerRestoreFocusRequest}
+                          focusRequest={ordinaryComposerBlocked ? undefined : composerFocusKey}
+                          restoreFocusRequest={
+                            ordinaryComposerBlocked ? undefined : composerRestoreFocusRequest
+                          }
                         />
                       </div>
 


### PR DESCRIPTION
## Problem

Permission, Ask User, Side Chat, and Plan surfaces replaced the ordinary composer in normal flow. Their different heights resized the transcript viewport, so the message scroller lost the established prompt anchor and visibly jumped toward the bottom.

## Proposed change

Render blocking composer surfaces as a bottom overlay. Keep the ordinary composer and status chrome mounted at their original geometry, but make them invisible, inert, and inaccessible while covered. This lets the blocking panel cover transcript content without changing transcript height; resolving the interaction resumes from the same reading position.

The existing blocking priority remains Side Chat, Permission, Ask User, Plan, then ordinary composer.

## Scope and non-goals

- Covers all four blocking composer surfaces through the shared lane.
- Adds no persisted data, schema migration, protocol change, enum value, or user-visible copy.
- Requires no historical-data compatibility handling.
- Does not change message-scroller library behavior.

## Acceptance criteria and validation

All listed checks ran after the last material source edit.

- Blocking-panel ownership and focus isolation → `npm test -- src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx` → 112 passed.
- Renderer typing → `npm run typecheck:web` → passed.
- Source lint → `npm run lint` → passed.
- Packaged renderer used by Electron E2E → `npm run build:e2e` → passed.
- Existing prompt-top anchoring plus Permission overlay entry/approval exit → `npx playwright test e2e/message-scroll-anchor.spec.ts` → 2 passed.
- Exact-head impact classification → `npm run test:affected -- --base origin/main --head HEAD --explain` → full PR plan because the E2E path is unowned by the module manifest.

The new E2E was established red before the fix: the Permission surface reduced the conversation viewport from 760px to 668px. It passes after the fix with unchanged viewport height and prompt offset.

Per the requested local-test scope, the complete `npm test` fallback is left to PR Gate CI. No ACP, persistence, migration, native-platform, or API interface changed. Permission has direct E2E coverage; Side Chat, Ask User, and Plan share the same overlay branch and have structural interaction-test coverage but no separate end-to-end scroll measurement.

## Review focus

- Overlay stacking and clipping while a blocking surface is resized.
- Retained ordinary-composer geometry and `inert` focus isolation.
- Scroll stability when a blocking interaction appears and resolves.