### PR TITLE
fix(updates): prevent duplicate renderer subscriptions

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -308,9 +308,7 @@ const AppContent = (): React.JSX.Element | null => {
   }, [appShellPresentation])
 
   // Load app info and subscribe to update-status broadcasts once at startup.
-  useEffect(() => {
-    initUpdates()
-  }, [initUpdates])
+  useEffect(() => initUpdates(), [initUpdates])
 
   useEffect(() => listenForPermissionChanges(), [listenForPermissionChanges])
   useEffect(() => listenForNotificationChanges(), [listenForNotificationChanges])

--- a/src/renderer/src/stores/update-store.test.ts
+++ b/src/renderer/src/stores/update-store.test.ts
@@ -44,6 +44,38 @@ describe('useUpdateStore', () => {
     expect(onProgress).toHaveBeenCalled()
   })
 
+  it('keeps only one active status/progress subscription when init runs twice', () => {
+    const statusListeners = new Set<(status: unknown) => void>()
+    const progressListeners = new Set<(progress: unknown) => void>()
+    ;(window as unknown as { api: unknown }).api = {
+      update: {
+        getAppInfo: () => new Promise(() => undefined),
+        getStatus: () => new Promise(() => undefined),
+        onStatus: (listener: (status: unknown) => void) => {
+          statusListeners.add(listener)
+          return () => statusListeners.delete(listener)
+        },
+        onProgress: (listener: (progress: unknown) => void) => {
+          progressListeners.add(listener)
+          return () => progressListeners.delete(listener)
+        },
+        check: vi.fn(),
+        download: vi.fn(),
+        apply: vi.fn()
+      }
+    }
+
+    useUpdateStore.getState().init()
+    const cleanup = useUpdateStore.getState().init() as unknown as (() => void) | undefined
+
+    expect(statusListeners).toHaveLength(1)
+    expect(progressListeners).toHaveLength(1)
+
+    cleanup?.()
+    expect(statusListeners).toHaveLength(0)
+    expect(progressListeners).toHaveLength(0)
+  })
+
   it('init hydrates from getStatus when the store is still idle', async () => {
     ;(window as unknown as { api: unknown }).api = {
       update: {

--- a/src/renderer/src/stores/update-store.test.ts
+++ b/src/renderer/src/stores/update-store.test.ts
@@ -68,12 +68,12 @@ describe('useUpdateStore', () => {
     useUpdateStore.getState().init()
     const cleanup = useUpdateStore.getState().init() as unknown as (() => void) | undefined
 
-    expect(statusListeners).toHaveLength(1)
-    expect(progressListeners).toHaveLength(1)
+    expect(statusListeners.size).toBe(1)
+    expect(progressListeners.size).toBe(1)
 
     cleanup?.()
-    expect(statusListeners).toHaveLength(0)
-    expect(progressListeners).toHaveLength(0)
+    expect(statusListeners.size).toBe(0)
+    expect(progressListeners.size).toBe(0)
   })
 
   it('init hydrates from getStatus when the store is still idle', async () => {

--- a/src/renderer/src/stores/update-store.ts
+++ b/src/renderer/src/stores/update-store.ts
@@ -7,7 +7,7 @@ type UpdateStore = {
   status: UpdateStatus
   // Whether the update confirmation dialog is open (opened from the capsule or the settings button).
   isDialogOpen: boolean
-  init: () => void
+  init: () => () => void
   check: () => Promise<void>
   openDialog: () => void
   closeDialog: () => void
@@ -15,6 +15,8 @@ type UpdateStore = {
   cancel: () => Promise<void>
   apply: () => Promise<void>
 }
+
+let cleanupUpdateSubscriptions: (() => void) | undefined
 
 // Single source of truth for update state in the renderer. The main process broadcasts every
 // transition; this store mirrors it so the settings section and the external capsule agree.
@@ -28,8 +30,9 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
   // existed, so its broadcast was dropped). Degrades to a no-op when the preload bridge is absent
   // (e.g. a stray dev/preview mount).
   init: () => {
+    cleanupUpdateSubscriptions?.()
     const api = window.api?.update
-    if (!api) return
+    if (!api) return () => undefined
     void api
       .getAppInfo()
       .then((info) =>
@@ -39,7 +42,7 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
     // immediately a status (electron-updater does on every tick) would otherwise wipe the speed the
     // progress event just set. Preserve downloadProgress across a status update while downloading so
     // DownloadProgressLine keeps rendering speed/ETA on Win/Linux.
-    api.onStatus((status) =>
+    const removeStatusListener = api.onStatus((status) =>
       set((s) => ({
         status: {
           ...status,
@@ -47,7 +50,7 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
         }
       }))
     )
-    api.onProgress((progress) =>
+    const removeProgressListener = api.onProgress((progress) =>
       set((s) => ({
         status: {
           ...s.status,
@@ -65,6 +68,17 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
       // Only apply the startup snapshot if no live broadcast has updated us yet.
       if (get().status.state === 'idle') set({ status })
     })
+
+    let active = true
+    const cleanup = (): void => {
+      if (!active) return
+      active = false
+      removeStatusListener?.()
+      removeProgressListener?.()
+      if (cleanupUpdateSubscriptions === cleanup) cleanupUpdateSubscriptions = undefined
+    }
+    cleanupUpdateSubscriptions = cleanup
+    return cleanup
   },
 
   check: async () => {


### PR DESCRIPTION
## Problem

React StrictMode replays the App startup effect in development. `useUpdateStore.init()` registered fresh status and progress listeners on every call but discarded both unsubscribe callbacks, leaving duplicate active listeners after the replay.

The regression test reproduced the report at the existing store/API boundary: three consecutive pre-fix runs failed with two active status listeners where one was expected.

## Proposed change

- replace any existing update subscription pair before `init()` subscribes again
- return an idempotent cleanup function from `init()` and wire it into the App effect lifecycle
- cover repeated initialization and final cleanup with a focused regression test

## Scope and non-goals

- No database, schema, persisted data, or historical-data compatibility change.
- No new state field or enum value.
- No data-model, architecture, or user-interaction change.
- The only internal contract adjustment is that the renderer store `init()` action now returns its subscription cleanup.
- Existing app-info and update-status hydration behavior is unchanged.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- duplicate subscription replacement and cleanup -> `npm test -- src/renderer/src/stores/update-store.test.ts src/renderer/src/App.test.tsx` -> 2 files passed, 61 tests passed
- renderer store/effect type contract -> `npm run typecheck:web` -> passed
- linted source/test conventions -> `npm run lint` -> passed

The complete `npm test` suite was intentionally not run; PR Gate CI is authoritative for the full portable and platform test plan.

## Review focus

- replacement and identity-safe cleanup of the active listener pair
- preservation of the existing live-broadcast-versus-startup-snapshot race guard