### PR TITLE
refactor(settings): collapse navigation route state

### DIFF
--- a/src/renderer/src/components/NetworkStatusIndicator.render.test.tsx
+++ b/src/renderer/src/components/NetworkStatusIndicator.render.test.tsx
@@ -24,7 +24,7 @@ afterEach(() => {
   act(() => root.unmount())
   container.remove()
   useNetworkStore.setState({ isOnline: true, connectivity: 'unknown' })
-  useSettingsStore.setState({ isSettingsOpen: false, pendingSettingsPanel: undefined })
+  useSettingsStore.setState({ isSettingsOpen: false, pendingSettingsIntent: undefined })
 })
 
 describe('NetworkStatusIndicator', () => {
@@ -75,7 +75,10 @@ describe('NetworkStatusIndicator', () => {
     })
 
     expect(useSettingsStore.getState().isSettingsOpen).toBe(true)
-    expect(useSettingsStore.getState().pendingSettingsPanel).toBe('network')
+    expect(useSettingsStore.getState().pendingSettingsIntent?.route).toEqual({
+      panel: 'network',
+      view: { kind: 'list' }
+    })
   })
 
   it('disappears when connectivity recovers', async () => {

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -2829,6 +2829,23 @@ describe('SettingsPage layout', () => {
     )
   })
 
+  it('keeps an external intent pending until Settings is visible', async () => {
+    useSettingsStore.getState().openSettingsToSkill('alpha')
+
+    await act(async () => {
+      root.render(<SettingsPage open={false} onClose={vi.fn()} />)
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+      await Promise.resolve()
+    })
+    await waitFor(() =>
+      expect(document.body.querySelector('[aria-label="Back to skills"]')).not.toBeNull()
+    )
+  })
+
   it('opens directly on a requested settings panel and consumes the target', async () => {
     useSettingsStore.getState().openSettingsToPanel('storage')
 

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -1164,7 +1164,7 @@ describe('SettingsPage layout', () => {
     })
 
     await act(async () => {
-      useSettingsStore.setState({ pendingSkillId: 'alpha' })
+      useSettingsStore.getState().openSettingsToSkill('alpha')
     })
 
     expect(navButton('Agent')?.parentElement?.tagName).toBe('LI')
@@ -2778,8 +2778,8 @@ describe('SettingsPage layout', () => {
   })
 
   it('opens directly on a skill detail when the store has a pending skill', async () => {
-    // A skill mention sets the pending id before the dialog opens.
-    useSettingsStore.setState({ pendingSkillId: 'alpha' })
+    // A skill mention publishes a landing intent before the dialog opens.
+    useSettingsStore.getState().openSettingsToSkill('alpha')
 
     const settingsRef = createRef<SettingsPageHandle>()
     await act(async () => {
@@ -2797,8 +2797,8 @@ describe('SettingsPage layout', () => {
     expect(document.body.querySelector('[aria-label="Back to skills"]')).not.toBeNull()
     expect(document.body.textContent).toContain('Alpha')
     expect(document.body.querySelector('section[aria-label="Providers"]')).toBeNull()
-    // The pending id is consumed so a later normal open won't jump back to it.
-    expect(useSettingsStore.getState().pendingSkillId).toBeUndefined()
+    // The intent is consumed so a later normal open won't jump back to it.
+    expect(useSettingsStore.getState().pendingSettingsIntent).toBeUndefined()
 
     act(() => {
       expect(settingsRef.current?.closeActivePane()).toBe(true)
@@ -2809,8 +2809,28 @@ describe('SettingsPage layout', () => {
     )
   })
 
+  it('honors a repeated external intent for the same skill while Settings stays open', async () => {
+    useSettingsStore.getState().openSettingsToSkill('alpha')
+
+    await act(async () => {
+      root.render(<SettingsPage open onClose={vi.fn()} />)
+      await Promise.resolve()
+    })
+    await waitFor(() =>
+      expect(document.body.querySelector('[aria-label="Back to skills"]')).not.toBeNull()
+    )
+
+    await act(async () => navButton('Model')?.click())
+    expect(document.body.querySelector('section[aria-label="Providers"]')).not.toBeNull()
+
+    act(() => useSettingsStore.getState().openSettingsToSkill('alpha'))
+    await waitFor(() =>
+      expect(document.body.querySelector('[aria-label="Back to skills"]')).not.toBeNull()
+    )
+  })
+
   it('opens directly on a requested settings panel and consumes the target', async () => {
-    useSettingsStore.setState({ pendingSettingsPanel: 'storage' })
+    useSettingsStore.getState().openSettingsToPanel('storage')
 
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)
@@ -2820,11 +2840,11 @@ describe('SettingsPage layout', () => {
     })
 
     expect(navButton('Storage')?.getAttribute('aria-current')).toBe('page')
-    expect(useSettingsStore.getState().pendingSettingsPanel).toBeUndefined()
+    expect(useSettingsStore.getState().pendingSettingsIntent).toBeUndefined()
   })
 
   it('opens directly on a specialist editor when the store has a pending specialist', async () => {
-    // The switch approval card deep-links to one specialist's editor: the pending id is set
+    // The switch approval card deep-links to one specialist's editor: the intent is published
     // before the dialog opens, and the catalog resolves that profile.
     const researcher: SpecialistProfileView = {
       id: 'spc-1',
@@ -2845,7 +2865,7 @@ describe('SettingsPage layout', () => {
       integrity: { status: 'ok' }
     })
     useSpecialistStore.setState({ items: [{ kind: 'custom', ...researcher }], isLoaded: true })
-    useSettingsStore.setState({ pendingSpecialistId: researcher.id })
+    useSettingsStore.getState().openSettingsToSpecialist(researcher.id)
 
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)
@@ -2863,8 +2883,8 @@ describe('SettingsPage layout', () => {
     const name = document.body.querySelector<HTMLInputElement>('#sp-name')
     expect(name?.value).toBe('Researcher')
     expect(document.body.querySelector('section[aria-label="Providers"]')).toBeNull()
-    // The pending id is consumed so a later normal open won't jump back to it.
-    expect(useSettingsStore.getState().pendingSpecialistId).toBeUndefined()
+    // The intent is consumed so a later normal open won't jump back to it.
+    expect(useSettingsStore.getState().pendingSettingsIntent).toBeUndefined()
   })
 
   it('navigates from a specialist capability row to the skill detail and back', async () => {
@@ -2887,7 +2907,7 @@ describe('SettingsPage layout', () => {
       integrity: { status: 'ok' }
     })
     useSpecialistStore.setState({ items: [{ kind: 'custom', ...researcher }], isLoaded: true })
-    useSettingsStore.setState({ pendingSpecialistId: researcher.id })
+    useSettingsStore.getState().openSettingsToSpecialist(researcher.id)
 
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)
@@ -2940,7 +2960,7 @@ describe('SettingsPage layout', () => {
       integrity: { status: 'ok' }
     })
     useSpecialistStore.setState({ items: [{ kind: 'custom', ...researcher }], isLoaded: true })
-    useSettingsStore.setState({ pendingSkillId: 'alpha' })
+    useSettingsStore.getState().openSettingsToSkill('alpha')
 
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)
@@ -2993,7 +3013,7 @@ describe('SettingsPage layout', () => {
       integrity: { status: 'ok' }
     })
     useSpecialistStore.setState({ items: [{ kind: 'custom', ...researcher }], isLoaded: true })
-    useSettingsStore.setState({ pendingSettingsPanel: 'connectors' })
+    useSettingsStore.getState().openSettingsToPanel('connectors')
 
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)
@@ -3084,7 +3104,7 @@ describe('SettingsPage layout', () => {
       tools: []
     })
     useSpecialistStore.setState({ items: [{ kind: 'custom', ...researcher }], isLoaded: true })
-    useSettingsStore.setState({ pendingSpecialistId: researcher.id })
+    useSettingsStore.getState().openSettingsToSpecialist(researcher.id)
 
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)
@@ -3165,7 +3185,7 @@ describe('SettingsPage layout', () => {
       integrity: { status: 'ok' }
     })
     useSpecialistStore.setState({ items: [{ kind: 'custom', ...researcher }], isLoaded: true })
-    useSettingsStore.setState({ pendingSpecialistId: researcher.id })
+    useSettingsStore.getState().openSettingsToSpecialist(researcher.id)
 
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)
@@ -3202,7 +3222,7 @@ describe('SettingsPage layout', () => {
   })
 
   it('opens the specialist creation form from Write from scratch', async () => {
-    useSettingsStore.setState({ pendingSettingsPanel: 'specialists' })
+    useSettingsStore.getState().openSettingsToPanel('specialists')
 
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)
@@ -3229,7 +3249,7 @@ describe('SettingsPage layout', () => {
   })
 
   it('uses a multi-level header breadcrumb for Marketplace Specialist details', async () => {
-    useSettingsStore.setState({ pendingSettingsPanel: 'specialists' })
+    useSettingsStore.getState().openSettingsToPanel('specialists')
     Object.assign(window.api.specialist, {
       listMarketplace: vi.fn().mockResolvedValue({
         sources: [
@@ -3350,8 +3370,8 @@ describe('SettingsPage layout', () => {
       useSettingsStore.setState({ environmentCheck: repairedStorage })
       return repairedStorage
     })
+    useSettingsStore.getState().openSettingsToPanel('storage')
     useSettingsStore.setState({
-      pendingSettingsPanel: 'storage',
       environmentCheck: failedStorage,
       checkEnvironment
     })

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -49,7 +49,14 @@ import { preloadComputeHosts, useComputeStore } from '@/stores/compute-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useSessionStore } from '@/stores/session-store'
 import { selectFrameworkApiEndpoints, useSettingsStore } from '@/stores/settings-store'
-import type { SettingsPanelId } from './settings-navigation'
+import {
+  INITIAL_SETTINGS_ROUTE,
+  settingsPanelRoute,
+  type ModelView,
+  type NetworkView,
+  type SettingsPanelId,
+  type SettingsRoute
+} from './settings-navigation'
 import { useSpecialistStore } from '@/stores/specialist-store'
 import { useTagStore } from '@/stores/tag-store'
 import { ProvidersPanel } from './ProvidersPanel'
@@ -194,9 +201,6 @@ type SettingsPageHandle = {
   closeActivePane: () => boolean
 }
 
-// The model panel sub-view, driven by the settings navigation history so add/edit is a breadcrumb page.
-type ModelView = { kind: 'list' } | { kind: 'create' } | { kind: 'edit'; providerId: string }
-
 // Builds a form value from an existing provider (never carrying the plaintext key).
 const toFormValue = (provider: ProviderView): ProviderFormValue =>
   createEmptyProviderFormValue({
@@ -321,35 +325,6 @@ const SETTINGS_PANELS: ReadonlyArray<SettingsPanel> = SETTINGS_GROUPS.flatMap(
 const EMPTY_USAGE_SESSIONS = [] as const
 const EMPTY_USAGE_PROJECTS = [] as const
 
-// One entry in the settings back/forward history: the active panel plus each panel's current sub-view
-// (skills: list / manage / detail / create / edit / import; model: list / create / edit; connectors: list /
-// detail / add / edit). `connectors` is optional so panel switches that don't touch it stay terse.
-// Network panel sub-view: the package-mirror list vs. the configure form (a breadcrumb drill-in).
-type NetworkView = { kind: 'list' | 'mirror' | 'proxy' }
-
-type NavLocation = {
-  panel: SettingsPanelId
-  skills: SkillsView
-  model: ModelView
-  connectors?: ConnectorsView
-  network?: NetworkView
-  compute?: ComputeView
-  specialists?: SpecialistsView
-  archived?: ArchivedView
-  tagId?: string
-}
-
-const INITIAL_LOCATION: NavLocation = {
-  panel: 'model',
-  skills: { kind: 'list' },
-  model: { kind: 'list' },
-  connectors: { kind: 'list' },
-  network: { kind: 'list' },
-  compute: { kind: 'list' },
-  specialists: { kind: 'list' },
-  archived: { kind: 'list' }
-}
-
 // App-level model settings surface. Reuses the onboarding cards/form; manages providers (CRUD +
 // activate + test). Opened from the Home/Workspace gear entry.
 const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function SettingsPage(
@@ -380,19 +355,9 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
   const persistProvider = useSettingsStore((state) => state.persistProvider)
   const validateProvider = useSettingsStore((state) => state.validateProvider)
   const refreshProviderModels = useSettingsStore((state) => state.refreshProviderModels)
-  const pendingSkillId = useSettingsStore((state) => state.pendingSkillId)
-  const consumePendingSkill = useSettingsStore((state) => state.consumePendingSkill)
-  const pendingSpecialistId = useSettingsStore((state) => state.pendingSpecialistId)
-  const consumePendingSpecialist = useSettingsStore((state) => state.consumePendingSpecialist)
-  const pendingSettingsPanel = useSettingsStore((state) => state.pendingSettingsPanel)
-  const consumePendingSettingsPanel = useSettingsStore((state) => state.consumePendingSettingsPanel)
-  const pendingComputeHostId = useSettingsStore((state) => state.pendingComputeHostId)
-  const consumePendingComputeHost = useSettingsStore((state) => state.consumePendingComputeHost)
-  const pendingComputeAuthentication = useSettingsStore(
-    (state) => state.pendingComputeAuthentication
-  )
-  const consumePendingComputeAuthentication = useSettingsStore(
-    (state) => state.consumePendingComputeAuthentication
+  const pendingSettingsIntent = useSettingsStore((state) => state.pendingSettingsIntent)
+  const consumePendingSettingsIntent = useSettingsStore(
+    (state) => state.consumePendingSettingsIntent
   )
   const settingsWriteError = useSettingsStore((state) => state.settingsWriteError)
   const clearSettingsWriteError = useSettingsStore((state) => state.clearSettingsWriteError)
@@ -400,9 +365,9 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
     typeof window.api.settings.listAgentHomeSkills === 'function' &&
     typeof window.api.settings.importAgentHomeSkills === 'function'
 
-  // Settings navigation history (browser-like back/forward). Panel switches and drill-downs push a
-  // new location; the active panel and open sub-views are derived from the current entry.
-  const [history, setHistory] = useState<NavLocation[]>([INITIAL_LOCATION])
+  // Settings navigation history (browser-like back/forward). Each entry contains only its active
+  // panel route, so unrelated panel views cannot form impossible combinations.
+  const [history, setHistory] = useState<SettingsRoute[]>([INITIAL_SETTINGS_ROUTE])
   const [historyIndex, setHistoryIndex] = useState(0)
   const returnFocusRef = useRef<HTMLElement | null>(null)
   // Whether the dialog is enlarged to near-fullscreen via the maximize control.
@@ -456,124 +421,32 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
     mobileNavTriggerRef.current?.focus()
   }, [isMobile, isMobileNavOpen])
 
-  // When opened from a skill mention, seed the history straight to that skill's detail page. This is
-  // the derive-state-during-render pattern (guarded so it runs once per request); the guard resets on
-  // close so reopening the same skill re-seeds. The Skills panel loads its list on mount, so the
-  // breadcrumb name resolves once that arrives.
-  const [seededSkillId, setSeededSkillId] = useState<string | undefined>(undefined)
-  if (open && pendingSkillId !== undefined && pendingSkillId !== seededSkillId) {
-    setSeededSkillId(pendingSkillId)
-    setHistory([
-      {
-        panel: 'skills',
-        skills: { kind: 'detail', id: pendingSkillId },
-        model: { kind: 'list' },
-        connectors: { kind: 'list' }
-      }
-    ])
-    setHistoryIndex(0)
-  }
-  if (!open && seededSkillId !== undefined) {
-    setSeededSkillId(undefined)
-  }
-
-  // External entry points seed one shared panel target. The consumed target cannot override a later
-  // manual navigation when the dialog is reopened normally.
-  const [seededSettingsPanel, setSeededSettingsPanel] = useState<SettingsPanelId | undefined>()
-  if (open && pendingSettingsPanel !== undefined && pendingSettingsPanel !== seededSettingsPanel) {
-    setSeededSettingsPanel(pendingSettingsPanel)
-    setHistory([{ ...INITIAL_LOCATION, panel: pendingSettingsPanel }])
-    setHistoryIndex(0)
-  }
-  if (!open && seededSettingsPanel !== undefined) {
-    setSeededSettingsPanel(undefined)
-  }
-
-  const [seededComputeHostId, setSeededComputeHostId] = useState<string | undefined>()
-  if (open && pendingComputeHostId !== undefined && pendingComputeHostId !== seededComputeHostId) {
-    setSeededComputeHostId(pendingComputeHostId)
-    setHistory([
-      {
-        ...INITIAL_LOCATION,
-        panel: 'compute',
-        compute: { kind: 'detail', providerId: pendingComputeHostId }
-      }
-    ])
-    setHistoryIndex(0)
-  }
-  if (!open && seededComputeHostId !== undefined) {
-    setSeededComputeHostId(undefined)
-  }
-
-  const [seededComputeAuthentication, setSeededComputeAuthentication] = useState<
-    string | undefined
-  >()
-  const pendingComputeAuthenticationKey = pendingComputeAuthentication
-    ? String(pendingComputeAuthentication.requestId)
-    : undefined
+  // External entry points publish one route intent with an event identity. Guard by request rather
+  // than target value so two separate requests for the same route are both honored.
+  const [seededIntentId, setSeededIntentId] = useState<number | undefined>()
   if (
     open &&
-    pendingComputeAuthentication &&
-    pendingComputeAuthenticationKey !== seededComputeAuthentication
+    pendingSettingsIntent !== undefined &&
+    pendingSettingsIntent.requestId !== seededIntentId
   ) {
-    setSeededComputeAuthentication(pendingComputeAuthenticationKey)
-    setHistory([
-      {
-        ...INITIAL_LOCATION,
-        panel: 'compute',
-        compute: {
-          kind: 'detail',
-          providerId: pendingComputeAuthentication.providerId,
-          authenticationFocus: pendingComputeAuthentication.errorCode,
-          authenticationRequestId: pendingComputeAuthentication.requestId
-        }
-      }
-    ])
+    setSeededIntentId(pendingSettingsIntent.requestId)
+    setHistory([pendingSettingsIntent.route])
     setHistoryIndex(0)
   }
-  if (!open && seededComputeAuthentication !== undefined) {
-    setSeededComputeAuthentication(undefined)
+  if (!open && seededIntentId !== undefined) {
+    setSeededIntentId(undefined)
   }
 
-  // When opened from the specialist switch approval card, seed the history straight onto that
-  // specialist's editor. Same derive-during-render pattern as the skill seed above; the
-  // Specialists panel resolves the profile from the catalog once it mounts.
-  const [seededSpecialistId, setSeededSpecialistId] = useState<string | undefined>(undefined)
-  if (open && pendingSpecialistId !== undefined && pendingSpecialistId !== seededSpecialistId) {
-    setSeededSpecialistId(pendingSpecialistId)
-    setHistory([
-      {
-        panel: 'specialists',
-        specialists: { kind: 'edit', id: pendingSpecialistId },
-        skills: { kind: 'list' },
-        model: { kind: 'list' }
-      }
-    ])
-    setHistoryIndex(0)
-  }
-  if (!open && seededSpecialistId !== undefined) {
-    setSeededSpecialistId(undefined)
-  }
+  // Consume only the request applied above. A newer intent that arrives before this effect runs must
+  // remain pending for the next render.
+  useEffect(() => {
+    if (pendingSettingsIntent !== undefined) {
+      consumePendingSettingsIntent(pendingSettingsIntent.requestId)
+    }
+  }, [consumePendingSettingsIntent, pendingSettingsIntent])
 
-  useEffect(() => {
-    if (pendingSettingsPanel !== undefined) consumePendingSettingsPanel()
-  }, [pendingSettingsPanel, consumePendingSettingsPanel])
-  // Clear the store's pending flag after it has been applied, so a later normal open starts fresh.
-  useEffect(() => {
-    if (pendingSkillId !== undefined) consumePendingSkill()
-  }, [pendingSkillId, consumePendingSkill])
-  useEffect(() => {
-    if (pendingSpecialistId !== undefined) consumePendingSpecialist()
-  }, [pendingSpecialistId, consumePendingSpecialist])
-  useEffect(() => {
-    if (pendingComputeHostId !== undefined) consumePendingComputeHost()
-  }, [pendingComputeHostId, consumePendingComputeHost])
-  useEffect(() => {
-    if (pendingComputeAuthentication !== undefined) consumePendingComputeAuthentication()
-  }, [pendingComputeAuthentication, consumePendingComputeAuthentication])
-
-  const currentLocation = history[historyIndex]
-  const activePanel = currentLocation.panel
+  const currentRoute = history[historyIndex]
+  const activePanel = currentRoute.panel
 
   // Auto-detect opencode the first time its detection card is shown without a known path, so the card
   // reflects reality without a manual re-detect. Guarded on path + in-flight to run at most once.
@@ -617,68 +490,48 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
   const projects = useProjectStore((state) =>
     isUsageVisible ? state.projects : EMPTY_USAGE_PROJECTS
   )
-  const skillsView = currentLocation.skills
-  const modelView = currentLocation.model
-  const connectorsView: ConnectorsView = currentLocation.connectors ?? { kind: 'list' }
-  const networkView: NetworkView = currentLocation.network ?? { kind: 'list' }
-  const computeView: ComputeView = currentLocation.compute ?? { kind: 'list' }
-  const specialistsView: SpecialistsView = currentLocation.specialists ?? { kind: 'list' }
-  const archivedView: ArchivedView = currentLocation.archived ?? { kind: 'list' }
+  const skillsView: SkillsView =
+    currentRoute.panel === 'skills' ? currentRoute.view : { kind: 'list' }
+  const modelView: ModelView = currentRoute.panel === 'model' ? currentRoute.view : { kind: 'list' }
+  const connectorsView: ConnectorsView =
+    currentRoute.panel === 'connectors' ? currentRoute.view : { kind: 'list' }
+  const networkView: NetworkView =
+    currentRoute.panel === 'network' ? currentRoute.view : { kind: 'list' }
+  const computeView: ComputeView =
+    currentRoute.panel === 'compute' ? currentRoute.view : { kind: 'list' }
+  const specialistsView: SpecialistsView =
+    currentRoute.panel === 'specialists' ? currentRoute.view : { kind: 'list' }
+  const archivedView: ArchivedView =
+    currentRoute.panel === 'archived' ? currentRoute.view : { kind: 'list' }
+  const activeTagId = currentRoute.panel === 'tags' ? currentRoute.tagId : undefined
   const canGoBack = historyIndex > 0
   const canGoForward = historyIndex < history.length - 1
 
   useEffect(() => {
-    if (currentLocation.panel === 'tags' && currentLocation.tagId) {
-      setSelectedTagId(currentLocation.tagId)
-    }
-  }, [currentLocation.panel, currentLocation.tagId, setSelectedTagId])
+    if (activeTagId) setSelectedTagId(activeTagId)
+  }, [activeTagId, setSelectedTagId])
 
-  // Pushes a new location, dropping any forward entries.
-  const navigate = (location: NavLocation): void => {
-    const nextConnectors = location.connectors ?? { kind: 'list' }
-    const nextNetwork = location.network ?? { kind: 'list' }
-    const nextCompute = location.compute ?? { kind: 'list' }
-    const nextSpecialists = location.specialists ?? { kind: 'list' }
-    const nextArchived = location.archived ?? { kind: 'list' }
-    if (
-      location.panel === activePanel &&
-      location.skills.kind === skillsView.kind &&
-      ('id' in location.skills ? location.skills.id : undefined) ===
-        ('id' in skillsView ? skillsView.id : undefined) &&
-      location.model.kind === modelView.kind &&
-      ('providerId' in location.model ? location.model.providerId : undefined) ===
-        ('providerId' in modelView ? modelView.providerId : undefined) &&
-      nextConnectors.kind === connectorsView.kind &&
-      ('id' in nextConnectors ? nextConnectors.id : undefined) ===
-        ('id' in connectorsView ? connectorsView.id : undefined) &&
-      nextNetwork.kind === networkView.kind &&
-      nextCompute.kind === computeView.kind &&
-      ('providerId' in nextCompute ? nextCompute.providerId : undefined) ===
-        ('providerId' in computeView ? computeView.providerId : undefined) &&
-      JSON.stringify(nextSpecialists) === JSON.stringify(specialistsView) &&
-      nextArchived.kind === archivedView.kind &&
-      ('projectId' in nextArchived ? nextArchived.projectId : undefined) ===
-        ('projectId' in archivedView ? archivedView.projectId : undefined) &&
-      location.tagId === currentLocation.tagId
-    ) {
-      return
-    }
-    setHistory((entries) => [...entries.slice(0, historyIndex + 1), location])
+  // Pushes a complete active route, dropping any forward entries. Routes contain only serializable
+  // navigation values, so comparing the whole route automatically covers fields added later.
+  const navigate = (route: SettingsRoute): void => {
+    if (JSON.stringify(route) === JSON.stringify(currentRoute)) return
+    setHistory((entries) => [...entries.slice(0, historyIndex + 1), route])
     setHistoryIndex((index) => index + 1)
   }
 
   // Internal panel transitions must use this dialog's history instead of reseeding an external
   // entry point, so Back returns to the recovery panel the user just completed.
-  const navigatePanel = (panel: SettingsPanelId): void =>
-    navigate({
-      ...INITIAL_LOCATION,
-      panel,
-      tagId: panel === 'tags' ? browserSelectedTagId : undefined
-    })
+  const navigatePanel = (panel: SettingsPanelId): void => {
+    if (panel === 'tags') {
+      navigate({ panel, tagId: browserSelectedTagId })
+      return
+    }
+    navigate(settingsPanelRoute(panel))
+  }
 
   const navigateTag = (tagId: string): void => {
     setSelectedTagId(tagId)
-    navigate({ ...currentLocation, panel: 'tags', tagId })
+    navigate({ panel: 'tags', tagId })
   }
 
   const recordSelectedTag = useCallback(
@@ -695,53 +548,34 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
   )
 
   // Navigates within the skills panel (list/detail/create/edit/import) as a history entry.
-  const navigateSkills = (skills: SkillsView): void =>
-    navigate({ panel: 'skills', skills, model: modelView, connectors: connectorsView })
+  const navigateSkills = (skills: SkillsView): void => navigate({ panel: 'skills', view: skills })
 
   // Navigates within the connectors panel (list/detail/add/edit) as a history entry.
   const navigateConnectors = (connectors: ConnectorsView): void =>
-    navigate({ panel: 'connectors', skills: skillsView, model: modelView, connectors })
+    navigate({ panel: 'connectors', view: connectors })
 
   // Navigates within the specialists panel (list/create) as a history entry.
   const navigateSpecialists = (specialists: SpecialistsView): void =>
-    navigate({ panel: 'specialists', skills: skillsView, model: modelView, specialists })
+    navigate({ panel: 'specialists', view: specialists })
 
   // Navigates within the network panel (package-mirror list vs. configure) as a history entry, so the
   // configure form gets a proper "Network / Package mirror" breadcrumb + back/forward.
   const navigateNetwork = (network: NetworkView): void =>
-    navigate({
-      panel: 'network',
-      skills: skillsView,
-      model: modelView,
-      connectors: connectorsView,
-      network
-    })
+    navigate({ panel: 'network', view: network })
 
   // Navigates within the compute panel (list/add/detail) as a history entry.
   const navigateCompute = (compute: ComputeView): void =>
-    navigate({
-      panel: 'compute',
-      skills: skillsView,
-      model: modelView,
-      connectors: connectorsView,
-      compute
-    })
+    navigate({ panel: 'compute', view: compute })
 
   const navigateArchived = (archived: ArchivedView): void =>
-    navigate({
-      panel: 'archived',
-      skills: skillsView,
-      model: modelView,
-      connectors: connectorsView,
-      archived
-    })
+    navigate({ panel: 'archived', view: archived })
 
   // Shared header breadcrumb for a drilled-in sub-view (null when on a panel's list, so the plain
   // panel title shows). Covers both the skills and model panels.
   const breadcrumb = ((): {
     rootLabelKey: DrillablePanelName
-    rootTo: NavLocation
-    parents?: ReadonlyArray<{ label: string; to: NavLocation; ariaLabel: string }>
+    rootTo: SettingsRoute
+    parents?: ReadonlyArray<{ label: string; to: SettingsRoute; ariaLabel: string }>
     leaf: string
   } | null => {
     if (activePanel === 'skills' && skillsView.kind !== 'list') {
@@ -762,7 +596,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                     })()
       return {
         rootLabelKey: 'Skills',
-        rootTo: { panel: 'skills', skills: { kind: 'list' }, model: currentLocation.model },
+        rootTo: { panel: 'skills', view: { kind: 'list' } },
         leaf
       }
     }
@@ -773,19 +607,14 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
           : ''
       return {
         rootLabelKey: 'Model',
-        rootTo: { panel: 'model', skills: currentLocation.skills, model: { kind: 'list' } },
+        rootTo: { panel: 'model', view: { kind: 'list' } },
         leaf: modelView.kind === 'create' ? t('Add provider') : t('Edit {{name}}', { name }).trim()
       }
     }
     if (activePanel === 'network' && networkView.kind !== 'list') {
       return {
         rootLabelKey: 'Network',
-        rootTo: {
-          panel: 'network',
-          skills: currentLocation.skills,
-          model: currentLocation.model,
-          network: { kind: 'list' }
-        },
+        rootTo: { panel: 'network', view: { kind: 'list' } },
         leaf: networkView.kind === 'proxy' ? t('Proxy') : t('Package mirror')
       }
     }
@@ -808,12 +637,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                 : (connectors.find((c) => c.id === connectorsView.id)?.displayName ?? '')
       return {
         rootLabelKey: 'Connectors',
-        rootTo: {
-          panel: 'connectors',
-          skills: currentLocation.skills,
-          model: currentLocation.model,
-          connectors: { kind: 'list' }
-        },
+        rootTo: { panel: 'connectors', view: { kind: 'list' } },
         leaf
       }
     }
@@ -825,22 +649,14 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
             computeView.providerId)
       return {
         rootLabelKey: 'Compute',
-        rootTo: {
-          panel: 'compute',
-          skills: currentLocation.skills,
-          model: currentLocation.model,
-          connectors: currentLocation.connectors,
-          compute: { kind: 'list' }
-        },
+        rootTo: { panel: 'compute', view: { kind: 'list' } },
         leaf
       }
     }
     if (activePanel === 'specialists' && specialistsView.kind !== 'list') {
-      const rootTo: NavLocation = {
+      const rootTo: SettingsRoute = {
         panel: 'specialists',
-        skills: currentLocation.skills,
-        model: currentLocation.model,
-        specialists: { kind: 'list' }
+        view: { kind: 'list' }
       }
       if (
         specialistsView.kind === 'marketplace-sources' ||
@@ -852,7 +668,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
           parents: [
             {
               label: t('Marketplace'),
-              to: { ...rootTo, specialists: { kind: 'marketplace' } },
+              to: { panel: 'specialists', view: { kind: 'marketplace' } },
               ariaLabel: t('Back to Marketplace')
             }
           ],
@@ -884,12 +700,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
     if (activePanel === 'archived' && archivedView.kind === 'project') {
       return {
         rootLabelKey: 'Archived',
-        rootTo: {
-          panel: 'archived',
-          skills: currentLocation.skills,
-          model: currentLocation.model,
-          archived: { kind: 'list' }
-        },
+        rootTo: { panel: 'archived', view: { kind: 'list' } },
         leaf:
           projects.find((project) => project.id === archivedView.projectId)?.name ??
           t('Archived project')
@@ -976,18 +787,15 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
     setStatusMessage(undefined)
   }
 
-  const openCreate = (): void =>
-    navigate({ panel: 'model', skills: currentLocation.skills, model: { kind: 'create' } })
+  const openCreate = (): void => navigate({ panel: 'model', view: { kind: 'create' } })
 
   const openEdit = (provider: ProviderView): void =>
     navigate({
       panel: 'model',
-      skills: currentLocation.skills,
-      model: { kind: 'edit', providerId: provider.id }
+      view: { kind: 'edit', providerId: provider.id }
     })
 
-  const closeForm = (): void =>
-    navigate({ panel: 'model', skills: currentLocation.skills, model: { kind: 'list' } })
+  const closeForm = (): void => navigate({ panel: 'model', view: { kind: 'list' } })
 
   const handleSave = async (): Promise<void> => {
     if (providerEditTargetMissing) return
@@ -1003,7 +811,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
         ...(modelView.kind === 'edit' ? { requireExisting: true } : {})
       })
 
-      navigate({ panel: 'model', skills: currentLocation.skills, model: { kind: 'list' } })
+      navigate({ panel: 'model', view: { kind: 'list' } })
 
       if (providerId) {
         setBusyProviderId(providerId)
@@ -1358,9 +1166,8 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                       onOpenTag={navigateTag}
                       onOpenSpecialist={(usage) =>
                         navigate({
-                          ...currentLocation,
                           panel: 'specialists',
-                          specialists:
+                          view:
                             usage.kind === 'builtin'
                               ? { kind: 'builtin', id: usage.id }
                               : { kind: 'edit', id: usage.id }
@@ -1375,16 +1182,14 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                       onOpenTag={navigateTag}
                       onOpenSkillDetail={(skillId) =>
                         navigate({
-                          ...currentLocation,
                           panel: 'skills',
-                          skills: { kind: 'detail', id: skillId }
+                          view: { kind: 'detail', id: skillId }
                         })
                       }
                       onOpenConnectorDetail={(connectorId) =>
                         navigate({
-                          ...currentLocation,
                           panel: 'connectors',
-                          connectors: customServers.some((server) => server.id === connectorId)
+                          view: customServers.some((server) => server.id === connectorId)
                             ? { kind: 'edit', id: connectorId }
                             : { kind: 'detail', id: connectorId }
                         })
@@ -1396,19 +1201,15 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                       onOpenResource={(reference) => {
                         if (reference.resourceType === 'catalog.skill') {
                           navigate({
-                            ...currentLocation,
                             panel: 'skills',
-                            skills: { kind: 'detail', id: reference.resourceId }
+                            view: { kind: 'detail', id: reference.resourceId }
                           })
                           return
                         }
                         if (reference.resourceType === 'catalog.connector') {
                           navigate({
-                            ...currentLocation,
                             panel: 'connectors',
-                            connectors: customServers.some(
-                              (server) => server.id === reference.resourceId
-                            )
+                            view: customServers.some((server) => server.id === reference.resourceId)
                               ? { kind: 'edit', id: reference.resourceId }
                               : { kind: 'detail', id: reference.resourceId }
                           })
@@ -1418,9 +1219,8 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                           (item) => item.id === reference.resourceId
                         )
                         navigate({
-                          ...currentLocation,
                           panel: 'specialists',
-                          specialists:
+                          view:
                             specialist?.kind === 'builtin'
                               ? { kind: 'builtin', id: reference.resourceId }
                               : { kind: 'edit', id: reference.resourceId }
@@ -1491,9 +1291,8 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                         onOpenTag={navigateTag}
                         onOpenSpecialist={(usage) =>
                           navigate({
-                            ...currentLocation,
                             panel: 'specialists',
-                            specialists:
+                            view:
                               usage.kind === 'builtin'
                                 ? { kind: 'builtin', id: usage.id }
                                 : { kind: 'edit', id: usage.id }

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -440,10 +440,10 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
   // Consume only the request applied above. A newer intent that arrives before this effect runs must
   // remain pending for the next render.
   useEffect(() => {
-    if (pendingSettingsIntent !== undefined) {
+    if (open && pendingSettingsIntent !== undefined) {
       consumePendingSettingsIntent(pendingSettingsIntent.requestId)
     }
-  }, [consumePendingSettingsIntent, pendingSettingsIntent])
+  }, [consumePendingSettingsIntent, open, pendingSettingsIntent])
 
   const currentRoute = history[historyIndex]
   const activePanel = currentRoute.panel

--- a/src/renderer/src/pages/settings/settings-navigation.ts
+++ b/src/renderer/src/pages/settings/settings-navigation.ts
@@ -1,4 +1,9 @@
 import type { EnvironmentCheckId, EnvironmentCheckItem } from '../../../../shared/settings'
+import type { ArchivedView } from './ArchivedPanel'
+import type { ComputeView } from './ComputePanel'
+import type { ConnectorsView } from './ConnectorsPanel'
+import type { SkillsView } from './SkillsPanel'
+import type { SpecialistsView } from './SpecialistsPanel'
 
 export type SettingsPanelId =
   | 'model'
@@ -16,6 +21,52 @@ export type SettingsPanelId =
   | 'network'
   | 'runtimes'
   | 'remote-control'
+
+export type ModelView = { kind: 'list' } | { kind: 'create' } | { kind: 'edit'; providerId: string }
+
+export type NetworkView = { kind: 'list' | 'mirror' | 'proxy' }
+
+// A Settings history entry contains only the active panel's state. This sum type prevents unrelated
+// panel views from forming impossible combinations or leaking into every navigation transition.
+export type SettingsRoute = {
+  [Panel in SettingsPanelId]: Panel extends 'skills'
+    ? { panel: Panel; view: SkillsView }
+    : Panel extends 'model'
+      ? { panel: Panel; view: ModelView }
+      : Panel extends 'connectors'
+        ? { panel: Panel; view: ConnectorsView }
+        : Panel extends 'network'
+          ? { panel: Panel; view: NetworkView }
+          : Panel extends 'compute'
+            ? { panel: Panel; view: ComputeView }
+            : Panel extends 'specialists'
+              ? { panel: Panel; view: SpecialistsView }
+              : Panel extends 'archived'
+                ? { panel: Panel; view: ArchivedView }
+                : Panel extends 'tags'
+                  ? { panel: Panel; tagId?: string }
+                  : { panel: Panel }
+}[SettingsPanelId]
+
+export const INITIAL_SETTINGS_ROUTE: SettingsRoute = {
+  panel: 'model',
+  view: { kind: 'list' }
+}
+
+export const settingsPanelRoute = (panel: SettingsPanelId): SettingsRoute => {
+  switch (panel) {
+    case 'skills':
+    case 'model':
+    case 'connectors':
+    case 'network':
+    case 'compute':
+    case 'specialists':
+    case 'archived':
+      return { panel, view: { kind: 'list' } }
+    default:
+      return { panel }
+  }
+}
 
 const AGENT_REPAIR_CHECK_IDS: readonly EnvironmentCheckId[] = ['agent', 'install-network', 'system']
 

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.specialist-switch.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.specialist-switch.render.test.tsx
@@ -109,7 +109,10 @@ describe('PermissionApprovalControls specialist switch card', () => {
 
     // The stable profile id (never the renameable public name) reaches the settings dialog.
     expect(useSettingsStore.getState().isSettingsOpen).toBe(true)
-    expect(useSettingsStore.getState().pendingSpecialistId).toBe('spc-1')
+    expect(useSettingsStore.getState().pendingSettingsIntent?.route).toEqual({
+      panel: 'specialists',
+      view: { kind: 'edit', id: 'spc-1' }
+    })
   })
 
   it('carries a Configure affordance on the clickable detail block', () => {

--- a/src/renderer/src/stores/settings-navigation-slice.test.ts
+++ b/src/renderer/src/stores/settings-navigation-slice.test.ts
@@ -11,9 +11,12 @@ import {
 type TestStore = SettingsNavigationState & SettingsNavigationActions
 
 const createHarness = (): StoreApi<TestStore> =>
-  createStore<TestStore>((set) => ({
+  createStore<TestStore>((set, get) => ({
     ...createInitialSettingsNavigationState(),
-    ...createSettingsNavigationSlice({ setState: (patch) => set(patch) })
+    ...createSettingsNavigationSlice({
+      getState: get,
+      setState: (patch) => set(patch)
+    })
   }))
 
 describe('settings navigation slice', () => {
@@ -23,81 +26,69 @@ describe('settings navigation slice', () => {
     store = createHarness()
   })
 
-  it('opens normally without replacing a pending landing target', () => {
-    store.setState({ pendingSettingsPanel: 'storage' })
+  it('opens normally without replacing a pending landing intent', () => {
+    store.getState().openSettingsToPanel('storage')
+    const intent = store.getState().pendingSettingsIntent
+    store.setState({ isSettingsOpen: false })
 
     store.getState().openSettings()
 
     expect(store.getState()).toMatchObject({
       isSettingsOpen: true,
-      pendingSettingsPanel: 'storage'
+      pendingSettingsIntent: intent
     })
   })
 
   it.each([
-    [
-      'panel',
-      () => store.getState().openSettingsToPanel('storage'),
-      'storage',
-      undefined,
-      undefined
-    ],
+    ['panel', () => store.getState().openSettingsToPanel('storage'), { panel: 'storage' }],
     [
       'Skill',
       () => store.getState().openSettingsToSkill('skill-1'),
-      undefined,
-      'skill-1',
-      undefined
+      { panel: 'skills', view: { kind: 'detail', id: 'skill-1' } }
     ],
     [
       'Specialist',
       () => store.getState().openSettingsToSpecialist('specialist-1'),
-      undefined,
-      undefined,
-      'specialist-1'
+      { panel: 'specialists', view: { kind: 'edit', id: 'specialist-1' } }
     ],
-    ['Compute', () => store.getState().openSettingsToCompute(), 'compute', undefined, undefined]
-  ] as const)(
-    'opens the %s target and clears every competing target',
-    (_label, open, panel, skillId, specialistId) => {
-      store.setState({
-        pendingSettingsPanel: 'agent',
-        pendingSkillId: 'stale-skill',
-        pendingSpecialistId: 'stale-specialist'
-      })
+    [
+      'Compute',
+      () => store.getState().openSettingsToCompute(),
+      { panel: 'compute', view: { kind: 'list' } }
+    ]
+  ] as const)('opens the exact %s route as one intent', (_label, open, route) => {
+    store.getState().openSettingsToSkill('stale-skill')
 
-      open()
+    open()
 
-      expect(store.getState()).toMatchObject({
-        isSettingsOpen: true,
-        pendingSettingsPanel: panel,
-        pendingSkillId: skillId,
-        pendingSpecialistId: specialistId
-      })
-    }
-  )
+    expect(store.getState().isSettingsOpen).toBe(true)
+    expect(store.getState().pendingSettingsIntent?.route).toEqual(route)
+  })
 
-  it('consumes each landing target exactly once without closing the dialog', () => {
-    store.setState({
-      isSettingsOpen: true,
-      pendingSettingsPanel: 'storage',
-      pendingSkillId: 'skill-1',
-      pendingSpecialistId: 'specialist-1'
-    })
+  it('consumes one landing intent without closing the dialog', () => {
+    store.getState().openSettingsToSkill('skill-1')
+    const requestId = store.getState().pendingSettingsIntent!.requestId
 
-    store.getState().consumePendingSettingsPanel()
-    store.getState().consumePendingSkill()
-    store.getState().consumePendingSpecialist()
+    store.getState().consumePendingSettingsIntent(requestId)
 
     expect(store.getState()).toMatchObject({
       isSettingsOpen: true,
-      pendingSettingsPanel: undefined,
-      pendingSkillId: undefined,
-      pendingSpecialistId: undefined
+      pendingSettingsIntent: undefined
     })
   })
 
-  it('clears stale targets on close so a normal reopen starts fresh', () => {
+  it('does not consume a newer intent when an older effect completes', () => {
+    store.getState().openSettingsToSkill('skill-1')
+    const staleRequestId = store.getState().pendingSettingsIntent!.requestId
+    store.getState().openSettingsToSpecialist('specialist-1')
+    const latestIntent = store.getState().pendingSettingsIntent
+
+    store.getState().consumePendingSettingsIntent(staleRequestId)
+
+    expect(store.getState().pendingSettingsIntent).toEqual(latestIntent)
+  })
+
+  it('clears a stale intent on close so a normal reopen starts fresh', () => {
     store.getState().openSettingsToSpecialist('specialist-1')
 
     store.getState().closeSettings()
@@ -105,45 +96,42 @@ describe('settings navigation slice', () => {
 
     expect(store.getState()).toMatchObject({
       isSettingsOpen: true,
-      pendingSettingsPanel: undefined,
-      pendingSkillId: undefined,
-      pendingSpecialistId: undefined
+      pendingSettingsIntent: undefined
     })
   })
 
-  it('opens the exact Compute Host authentication recovery target', () => {
+  it('opens the exact Compute Host authentication recovery route', () => {
     store.getState().openSettingsToComputeAuthentication('ssh:biowulf', 'authentication_failed')
 
-    expect(store.getState()).toMatchObject({
-      isSettingsOpen: true,
-      pendingSettingsPanel: undefined,
-      pendingComputeAuthentication: {
+    const intent = store.getState().pendingSettingsIntent!
+    expect(store.getState().isSettingsOpen).toBe(true)
+    expect(intent.route).toEqual({
+      panel: 'compute',
+      view: {
+        kind: 'detail',
         providerId: 'ssh:biowulf',
-        errorCode: 'authentication_failed'
+        authenticationFocus: 'authentication_failed',
+        authenticationRequestId: intent.requestId
       }
     })
-    const targetRequestId = store.getState().pendingComputeAuthentication!.requestId
 
-    store.getState().consumePendingComputeAuthentication()
-    expect(store.getState().pendingComputeAuthentication).toBeUndefined()
+    store.getState().consumePendingSettingsIntent(intent.requestId)
+    expect(store.getState().pendingSettingsIntent).toBeUndefined()
 
     store.getState().openSettingsToComputeAuthentication('ssh:biowulf', 'authentication_failed')
-    expect(store.getState().pendingComputeAuthentication?.requestId).toBeGreaterThan(
-      targetRequestId
-    )
+    expect(store.getState().pendingSettingsIntent?.requestId).toBeGreaterThan(intent.requestId)
   })
 
-  it('opens the exact Compute Host detail target', () => {
+  it('opens the exact Compute Host detail route', () => {
     store.getState().openSettingsToComputeHost('ssh:biowulf')
 
-    expect(store.getState()).toMatchObject({
-      isSettingsOpen: true,
-      pendingSettingsPanel: undefined,
-      pendingComputeHostId: 'ssh:biowulf',
-      pendingComputeAuthentication: undefined
+    const intent = store.getState().pendingSettingsIntent!
+    expect(intent.route).toEqual({
+      panel: 'compute',
+      view: { kind: 'detail', providerId: 'ssh:biowulf' }
     })
 
-    store.getState().consumePendingComputeHost()
-    expect(store.getState().pendingComputeHostId).toBeUndefined()
+    store.getState().consumePendingSettingsIntent(intent.requestId)
+    expect(store.getState().pendingSettingsIntent).toBeUndefined()
   })
 })

--- a/src/renderer/src/stores/settings-navigation-slice.ts
+++ b/src/renderer/src/stores/settings-navigation-slice.ts
@@ -1,21 +1,20 @@
-import type { SettingsPanelId } from '../pages/settings/settings-navigation'
 import type { ComputeAuthenticationErrorCode } from '../../../shared/compute'
+import {
+  settingsPanelRoute,
+  type SettingsPanelId,
+  type SettingsRoute
+} from '../pages/settings/settings-navigation'
 
-export type ComputeAuthenticationTarget = Readonly<{
-  providerId: string
-  errorCode: ComputeAuthenticationErrorCode
+export type SettingsNavigationIntent = Readonly<{
   requestId: number
+  route: SettingsRoute
 }>
 
-let computeAuthenticationRequestId = 0
+let settingsNavigationRequestId = 0
 
 export type SettingsNavigationState = {
   isSettingsOpen: boolean
-  pendingSettingsPanel?: SettingsPanelId
-  pendingSkillId?: string
-  pendingSpecialistId?: string
-  pendingComputeHostId?: string
-  pendingComputeAuthentication?: ComputeAuthenticationTarget
+  pendingSettingsIntent?: SettingsNavigationIntent
 }
 
 export type SettingsNavigationActions = {
@@ -30,110 +29,75 @@ export type SettingsNavigationActions = {
     providerId: string,
     errorCode: ComputeAuthenticationErrorCode
   ) => void
-  consumePendingSettingsPanel: () => void
-  consumePendingSkill: () => void
-  consumePendingSpecialist: () => void
-  consumePendingComputeHost: () => void
-  consumePendingComputeAuthentication: () => void
+  consumePendingSettingsIntent: (requestId: number) => void
 }
 
 type SettingsNavigationSliceOptions = {
+  getState: () => SettingsNavigationState
   setState: (patch: Partial<SettingsNavigationState>) => void
 }
 
 export const createInitialSettingsNavigationState = (): SettingsNavigationState => ({
   isSettingsOpen: false,
-  pendingSettingsPanel: undefined,
-  pendingSkillId: undefined,
-  pendingSpecialistId: undefined,
-  pendingComputeHostId: undefined,
-  pendingComputeAuthentication: undefined
+  pendingSettingsIntent: undefined
 })
 
-// Owns only the global dialog visibility and one-shot external landing targets. SettingsPage keeps
-// its local breadcrumb/history stack and consumes these targets through the compatibility store.
+// Owns global dialog visibility and a one-shot landing intent. Caller-facing actions remain stable;
+// route construction, mutual exclusion, and repeated-intent identity stay behind this module's seam.
 export const createSettingsNavigationSlice = ({
+  getState,
   setState
-}: SettingsNavigationSliceOptions): SettingsNavigationActions => ({
-  openSettings: () => setState({ isSettingsOpen: true }),
-
-  openSettingsToPanel: (panel) =>
+}: SettingsNavigationSliceOptions): SettingsNavigationActions => {
+  const openTo = (route: SettingsRoute): void =>
     setState({
       isSettingsOpen: true,
-      pendingSettingsPanel: panel,
-      pendingSkillId: undefined,
-      pendingSpecialistId: undefined,
-      pendingComputeHostId: undefined,
-      pendingComputeAuthentication: undefined
-    }),
+      pendingSettingsIntent: { requestId: ++settingsNavigationRequestId, route }
+    })
 
-  closeSettings: () =>
-    setState({
-      isSettingsOpen: false,
-      pendingSettingsPanel: undefined,
-      pendingSkillId: undefined,
-      pendingSpecialistId: undefined,
-      pendingComputeHostId: undefined,
-      pendingComputeAuthentication: undefined
-    }),
+  return {
+    openSettings: () => setState({ isSettingsOpen: true }),
 
-  openSettingsToSkill: (skillId) =>
-    setState({
-      isSettingsOpen: true,
-      pendingSettingsPanel: undefined,
-      pendingSkillId: skillId,
-      pendingSpecialistId: undefined,
-      pendingComputeHostId: undefined,
-      pendingComputeAuthentication: undefined
-    }),
+    openSettingsToPanel: (panel) => openTo(settingsPanelRoute(panel)),
 
-  openSettingsToSpecialist: (specialistId) =>
-    setState({
-      isSettingsOpen: true,
-      pendingSettingsPanel: undefined,
-      pendingSkillId: undefined,
-      pendingSpecialistId: specialistId,
-      pendingComputeHostId: undefined,
-      pendingComputeAuthentication: undefined
-    }),
+    closeSettings: () =>
+      setState({
+        isSettingsOpen: false,
+        pendingSettingsIntent: undefined
+      }),
 
-  openSettingsToCompute: () =>
-    setState({
-      isSettingsOpen: true,
-      pendingSettingsPanel: 'compute',
-      pendingSkillId: undefined,
-      pendingSpecialistId: undefined,
-      pendingComputeHostId: undefined,
-      pendingComputeAuthentication: undefined
-    }),
+    openSettingsToSkill: (skillId) =>
+      openTo({ panel: 'skills', view: { kind: 'detail', id: skillId } }),
 
-  openSettingsToComputeHost: (providerId) =>
-    setState({
-      isSettingsOpen: true,
-      pendingSettingsPanel: undefined,
-      pendingSkillId: undefined,
-      pendingSpecialistId: undefined,
-      pendingComputeHostId: providerId,
-      pendingComputeAuthentication: undefined
-    }),
+    openSettingsToSpecialist: (specialistId) =>
+      openTo({ panel: 'specialists', view: { kind: 'edit', id: specialistId } }),
 
-  openSettingsToComputeAuthentication: (providerId, errorCode) =>
-    setState({
-      isSettingsOpen: true,
-      pendingSettingsPanel: undefined,
-      pendingSkillId: undefined,
-      pendingSpecialistId: undefined,
-      pendingComputeHostId: undefined,
-      pendingComputeAuthentication: {
-        providerId,
-        errorCode,
-        requestId: ++computeAuthenticationRequestId
-      }
-    }),
+    openSettingsToCompute: () => openTo({ panel: 'compute', view: { kind: 'list' } }),
 
-  consumePendingSettingsPanel: () => setState({ pendingSettingsPanel: undefined }),
-  consumePendingSkill: () => setState({ pendingSkillId: undefined }),
-  consumePendingSpecialist: () => setState({ pendingSpecialistId: undefined }),
-  consumePendingComputeHost: () => setState({ pendingComputeHostId: undefined }),
-  consumePendingComputeAuthentication: () => setState({ pendingComputeAuthentication: undefined })
-})
+    openSettingsToComputeHost: (providerId) =>
+      openTo({ panel: 'compute', view: { kind: 'detail', providerId } }),
+
+    openSettingsToComputeAuthentication: (providerId, errorCode) => {
+      const requestId = ++settingsNavigationRequestId
+      setState({
+        isSettingsOpen: true,
+        pendingSettingsIntent: {
+          requestId,
+          route: {
+            panel: 'compute',
+            view: {
+              kind: 'detail',
+              providerId,
+              authenticationFocus: errorCode,
+              authenticationRequestId: requestId
+            }
+          }
+        }
+      })
+    },
+
+    consumePendingSettingsIntent: (requestId) => {
+      if (getState().pendingSettingsIntent?.requestId !== requestId) return
+      setState({ pendingSettingsIntent: undefined })
+    }
+  }
+}

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -1153,36 +1153,44 @@ describe('settings store: refreshProviderModels', () => {
 })
 
 describe('settings store: openSettingsToSkill', () => {
-  it('opens the dialog on a skill; consume and close both clear the pending id', () => {
+  it('opens the dialog on a skill; consume and close both clear the pending intent', () => {
     useSettingsStore.getState().openSettingsToSkill('x')
     expect(useSettingsStore.getState().isSettingsOpen).toBe(true)
-    expect(useSettingsStore.getState().pendingSkillId).toBe('x')
+    expect(useSettingsStore.getState().pendingSettingsIntent?.route).toEqual({
+      panel: 'skills',
+      view: { kind: 'detail', id: 'x' }
+    })
 
-    useSettingsStore.getState().consumePendingSkill()
-    expect(useSettingsStore.getState().pendingSkillId).toBeUndefined()
+    const requestId = useSettingsStore.getState().pendingSettingsIntent!.requestId
+    useSettingsStore.getState().consumePendingSettingsIntent(requestId)
+    expect(useSettingsStore.getState().pendingSettingsIntent).toBeUndefined()
 
-    // Closing after a fresh open-to-skill clears the pending id so a later open starts fresh.
+    // Closing after a fresh open-to-skill clears the intent so a later open starts fresh.
     useSettingsStore.getState().openSettingsToSkill('y')
     useSettingsStore.getState().closeSettings()
     expect(useSettingsStore.getState().isSettingsOpen).toBe(false)
-    expect(useSettingsStore.getState().pendingSkillId).toBeUndefined()
+    expect(useSettingsStore.getState().pendingSettingsIntent).toBeUndefined()
   })
 })
 
 describe('settings store: openSettingsToSpecialist', () => {
-  it('opens the dialog on a specialist; consume and close both clear the pending id', () => {
+  it('opens the dialog on a specialist; consume and close both clear the pending intent', () => {
     useSettingsStore.getState().openSettingsToSpecialist('spc-1')
     expect(useSettingsStore.getState().isSettingsOpen).toBe(true)
-    expect(useSettingsStore.getState().pendingSpecialistId).toBe('spc-1')
+    expect(useSettingsStore.getState().pendingSettingsIntent?.route).toEqual({
+      panel: 'specialists',
+      view: { kind: 'edit', id: 'spc-1' }
+    })
 
-    useSettingsStore.getState().consumePendingSpecialist()
-    expect(useSettingsStore.getState().pendingSpecialistId).toBeUndefined()
+    const requestId = useSettingsStore.getState().pendingSettingsIntent!.requestId
+    useSettingsStore.getState().consumePendingSettingsIntent(requestId)
+    expect(useSettingsStore.getState().pendingSettingsIntent).toBeUndefined()
 
-    // Closing after a fresh open-to-specialist clears the pending id so a later open starts fresh.
+    // Closing after a fresh open-to-specialist clears the intent so a later open starts fresh.
     useSettingsStore.getState().openSettingsToSpecialist('spc-2')
     useSettingsStore.getState().closeSettings()
     expect(useSettingsStore.getState().isSettingsOpen).toBe(false)
-    expect(useSettingsStore.getState().pendingSpecialistId).toBeUndefined()
+    expect(useSettingsStore.getState().pendingSettingsIntent).toBeUndefined()
   })
 })
 
@@ -1190,23 +1198,26 @@ describe('settings store: openSettingsToPanel', () => {
   it('opens the requested panel and clears an unconsumed target on close', () => {
     useSettingsStore.getState().openSettingsToPanel('storage')
     expect(useSettingsStore.getState().isSettingsOpen).toBe(true)
-    expect(useSettingsStore.getState().pendingSettingsPanel).toBe('storage')
+    expect(useSettingsStore.getState().pendingSettingsIntent?.route).toEqual({ panel: 'storage' })
 
     useSettingsStore.getState().closeSettings()
     expect(useSettingsStore.getState().isSettingsOpen).toBe(false)
-    expect(useSettingsStore.getState().pendingSettingsPanel).toBeUndefined()
+    expect(useSettingsStore.getState().pendingSettingsIntent).toBeUndefined()
   })
 
   it('routes Compute through the panel target and consumes it exactly once', () => {
     useSettingsStore.getState().openSettingsToSkill('stale-skill')
     useSettingsStore.getState().openSettingsToCompute()
 
-    expect(useSettingsStore.getState().pendingSettingsPanel).toBe('compute')
-    expect(useSettingsStore.getState().pendingSkillId).toBeUndefined()
+    expect(useSettingsStore.getState().pendingSettingsIntent?.route).toEqual({
+      panel: 'compute',
+      view: { kind: 'list' }
+    })
 
-    useSettingsStore.getState().consumePendingSettingsPanel()
+    const requestId = useSettingsStore.getState().pendingSettingsIntent!.requestId
+    useSettingsStore.getState().consumePendingSettingsIntent(requestId)
     useSettingsStore.getState().openSettings()
-    expect(useSettingsStore.getState().pendingSettingsPanel).toBeUndefined()
+    expect(useSettingsStore.getState().pendingSettingsIntent).toBeUndefined()
   })
 })
 

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -342,7 +342,10 @@ const createSettingsStoreState = (
     reconcileSnapshot: (snapshot) => set(applySnapshot(snapshot)),
     writeCoordinator
   }),
-  ...createSettingsNavigationSlice({ setState: (patch) => set(patch) }),
+  ...createSettingsNavigationSlice({
+    getState: get,
+    setState: (patch) => set(patch)
+  }),
   ...createSettingsSkillsSlice({
     getState: get,
     setState: (patch) => set(patch),


### PR DESCRIPTION
## Summary

- replace the wide Settings history location product with a discriminated `SettingsRoute` that contains only the active panel state
- replace five competing external landing fields with one request-identified `pendingSettingsIntent`
- honor repeated external navigation requests to the same target while Settings remains open

## Reproduction and regression

On the unfixed code:

1. Open Settings directly on Skill `alpha`.
2. Navigate to Model without closing Settings.
3. Request the same external Skill `alpha` target again.

The second target was consumed, but Settings remained on Model because the target value was also used as the processed-request guard. A second regression test covers a landing intent received while Settings is temporarily hidden and ensures it remains pending until the route can be applied. Both public-boundary tests failed for their reported reasons before their fixes and pass after them.

## Scope and design

This is a renderer-local navigation refactor. Existing caller actions such as `openSettingsToSkill` and `openSettingsToComputeHost` remain unchanged. Breadcrumb rendering and panel interaction remain owned by `SettingsPage`; this does not introduce a router, URL state, or a generic navigation framework.

- Architecture: local history is `SettingsRoute[]`; external landing state is one intent with `{ requestId, route }`.
- Interaction: unchanged except that every external request, including an identical repeated target, is honored.
- Data fields: five optional in-memory landing fields collapse into one optional in-memory intent.
- New state/enum values: none; existing panel and view kinds are reused. `requestId` is ephemeral event identity, not user state.
- Data model/schema: unchanged.
- Persistence: none.
- Historical data compatibility: not applicable; no persisted data is read or written.

The limited refactor is justified by the confirmed repeated-intent defect and the current modification footprint for new drill-down entry points. Expanding this into URL routing or persisted navigation would be over-design and is intentionally out of scope.

## Validation

- `npm test -- src/renderer/src/pages/settings/SettingsPage.render.test.tsx src/renderer/src/pages/settings/SettingsPage.architecture.test.ts` (87 passed)
- `npm test -- src/renderer/src/stores/settings-navigation-slice.test.ts src/renderer/src/stores/settings-store.test.ts` (105 passed)
- `npm test -- src/renderer/src/stores/settings-store.architecture.test.ts` (27 passed)
- `npm test -- src/renderer/src/components/NetworkStatusIndicator.render.test.tsx src/renderer/src/pages/workspace/PermissionApprovalControls.specialist-switch.render.test.tsx` (15 passed)
- `npm run typecheck:web`
- targeted ESLint and Prettier checks for all changed files

The affected-test explainer conservatively selected the full suite because one changed renderer test has no module owner. Per project guidance, the complete suite is left to PR CI.

## Review focus

- route coverage for each drillable panel
- request-id consumption race safety (an older effect must not clear a newer intent)
- preservation of back/forward and breadcrumb behavior
