### PR TITLE
fix(message-edit): preserve uploaded attachments

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -34,6 +34,7 @@
         "src/renderer/src/lib/acp/workspace-runtime-event-owner.ts",
         "src/renderer/src/lib/acp/workspace-runtime-prompt-preparation-owner.ts",
         "src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.ts",
+        "src/renderer/src/lib/acp/workspace-runtime-attachment-owner.ts",
         "src/renderer/src/lib/acp/workspace-runtime-command-owner.ts",
         "src/renderer/src/lib/acp/workspace-runtime-session-lifecycle-owner.ts",
         "src/renderer/src/lib/acp/workspace-runtime-save-as-skill-owner.ts",

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
@@ -73,12 +73,15 @@ const ownerNames = [
   'workspace-runtime-event-owner',
   'workspace-runtime-prompt-preparation-owner',
   'workspace-runtime-session-branch-owner',
+  'workspace-runtime-attachment-owner',
   'workspace-runtime-command-owner',
   'workspace-runtime-session-lifecycle-owner',
   'workspace-runtime-save-as-skill-owner'
 ] as const
 const facadeOwnerNames = ownerNames.filter(
-  (name) => name !== 'workspace-runtime-session-branch-owner'
+  (name) =>
+    name !== 'workspace-runtime-session-branch-owner' &&
+    name !== 'workspace-runtime-attachment-owner'
 )
 const ownerTargets = new Map(ownerNames.map((name) => [name, modulePath(resolve(__dirname, name))]))
 const ownerFilePath = (name: (typeof ownerNames)[number]): string => `${ownerTargets.get(name)}.ts`
@@ -610,9 +613,11 @@ describe('workspace runtime architecture', () => {
       'workspace-runtime-event-owner': [],
       'workspace-runtime-prompt-preparation-owner': [],
       'workspace-runtime-session-branch-owner': [],
+      'workspace-runtime-attachment-owner': [],
       'workspace-runtime-command-owner': [
         'workspace-runtime-prompt-preparation-owner',
-        'workspace-runtime-session-branch-owner'
+        'workspace-runtime-session-branch-owner',
+        'workspace-runtime-attachment-owner'
       ],
       'workspace-runtime-session-lifecycle-owner': [
         'workspace-runtime-prompt-preparation-owner',

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -6,7 +6,11 @@ import type {
 import type { HistoryReplayTarget } from '../../../../shared/history-preamble'
 import type { PersistedChatSession } from '../../../../shared/session-persistence'
 import type { AgentFrameworkId } from '../../../../shared/settings'
-import type { UploadedAttachment } from '../../../../shared/uploads'
+import {
+  MAX_COMPOSER_ATTACHMENTS,
+  type FinalizeUploadSessionRequest,
+  type UploadedAttachment
+} from '../../../../shared/uploads'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -3291,7 +3295,9 @@ describe('workspace agent message sending', () => {
     expect(retryPromptCall[5]).toContain('The original analysis is complete.')
     expect(retryPromptCall[5]).not.toContain('Try a different interpretation')
     expect(retryPromptCall[7]).toBeUndefined()
-    expect(finalizeSession).toHaveBeenCalledTimes(2)
+    // The retry reuses the immutable Version returned by the first attempt instead of finalizing it
+    // again under the already-bound Session.
+    expect(finalizeSession).toHaveBeenCalledOnce()
     expect(child.messages.at(-1)?.uploads).toEqual([
       expect.objectContaining({ versionId: 'upload-version-1' })
     ])
@@ -6327,7 +6333,8 @@ describe('resendEditedWorkspaceMessage', () => {
     id: string,
     role: 'user' | 'agent',
     content: string,
-    createdAt: number
+    createdAt: number,
+    overrides: Partial<ChatMessage> = {}
   ): ChatMessage => ({
     id,
     role,
@@ -6335,7 +6342,8 @@ describe('resendEditedWorkspaceMessage', () => {
     status: 'complete' as const,
     eventIds: [],
     createdAt,
-    updatedAt: createdAt
+    updatedAt: createdAt,
+    ...overrides
   })
 
   const seedConversation = (): void => {
@@ -6577,6 +6585,372 @@ describe('resendEditedWorkspaceMessage', () => {
     expect(preamble).not.toContain('second prompt')
     expect(preamble).not.toContain('third prompt')
     expect(runtime.sendPrompt.mock.calls[0]?.[3]).toEqual(['skill-forecast'])
+  })
+
+  it('routes a cross-session source Upload Version through history after branching', async () => {
+    const sourceUpload = {
+      id: 'upload-source',
+      versionId: 'upload-version-source',
+      versionNumber: 1,
+      sessionId: 'source-session',
+      name: 'measurements.csv',
+      originalName: 'measurements.csv',
+      mimeType: 'text/csv',
+      size: 24,
+      sha256: 'source-checksum'
+    }
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'default-project',
+          title: 'Conversation',
+          cwd: '/workspace/project',
+          status: 'idle' as const,
+          messages: [
+            createMessage('user-1', 'user', 'first prompt', baseTime),
+            createMessage('agent-1', 'agent', 'first answer', baseTime + 100),
+            createMessage('user-2', 'user', 'second prompt', baseTime + 200, {
+              uploads: [sourceUpload]
+            }),
+            createMessage('agent-2', 'agent', 'second answer', baseTime + 300)
+          ],
+          createdAt: baseTime,
+          updatedAt: baseTime + 300
+        }
+      ],
+      selectedSessionId: 'session-1'
+    })
+    const finalizeSession = vi.fn(
+      async ({ attachments }: FinalizeUploadSessionRequest) => attachments
+    )
+    vi.stubGlobal('window', { api: { uploads: { finalizeSession } } })
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn().mockResolvedValue({ contextReset: true }),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    const resent = await resendEditedWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      messageId: 'user-2',
+      text: 'second prompt, edited'
+    })
+    await flushRuntimeTasks()
+
+    expect(resent).toBe(true)
+    expect(finalizeSession).not.toHaveBeenCalled()
+    expect(runtime.sendPrompt.mock.calls[0]?.[2]).toEqual([])
+    expect(runtime.sendPrompt.mock.calls[0]?.[6]).toEqual([
+      expect.objectContaining({
+        id: 'upload-source',
+        versionId: 'upload-version-source',
+        path: 'upload-version:default-project/source-session/upload-version-source'
+      })
+    ])
+
+    const editedSession = useSessionStore.getState().sessions[0]
+    expect(editedSession.messages.at(-1)).toMatchObject({
+      content: 'second prompt, edited',
+      uploads: [expect.objectContaining({ versionId: 'upload-version-source' })]
+    })
+    expect(
+      editedSession.conversationGraph?.messages.find((message) => message.id === 'user-2')?.uploads
+    ).toEqual([expect.objectContaining({ versionId: 'upload-version-source' })])
+    expect(editedSession.conversationGraph?.branches).toHaveLength(2)
+  })
+
+  it('keeps edited attachments newest within the Composer replay limit', async () => {
+    const versionedUpload = (id: string): NonNullable<ChatMessage['uploads']>[number] => ({
+      id,
+      versionId: `${id}-version`,
+      versionNumber: 1,
+      sessionId: 'source-session',
+      name: `${id}.txt`,
+      originalName: `${id}.txt`,
+      mimeType: 'text/plain',
+      size: 24
+    })
+    const historyUploads = Array.from({ length: MAX_COMPOSER_ATTACHMENTS }, (_, index) =>
+      versionedUpload(`history-${index}`)
+    )
+    const editedUploads = [versionedUpload('edited-0'), versionedUpload('edited-1')]
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'default-project',
+          title: 'Conversation',
+          cwd: '/workspace/project',
+          status: 'idle' as const,
+          messages: [
+            createMessage('user-1', 'user', 'first prompt', baseTime, {
+              uploads: historyUploads
+            }),
+            createMessage('agent-1', 'agent', 'first answer', baseTime + 100),
+            createMessage('user-2', 'user', 'second prompt', baseTime + 200, {
+              uploads: editedUploads
+            }),
+            createMessage('agent-2', 'agent', 'second answer', baseTime + 300)
+          ],
+          createdAt: baseTime,
+          updatedAt: baseTime + 300
+        }
+      ],
+      selectedSessionId: 'session-1'
+    })
+    vi.stubGlobal('window', { api: { uploads: { finalizeSession: vi.fn() } } })
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn().mockResolvedValue({ contextReset: true }),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    await expect(
+      resendEditedWorkspaceMessage(runtime, {
+        sessionId: 'session-1',
+        messageId: 'user-2',
+        text: 'second prompt, edited'
+      })
+    ).resolves.toBe(true)
+    await flushRuntimeTasks()
+
+    expect(runtime.sendPrompt.mock.calls[0]?.[6]?.map((attachment) => attachment.id)).toEqual([
+      'history-2',
+      'history-3',
+      'history-4',
+      'history-5',
+      'history-6',
+      'history-7',
+      'history-8',
+      'history-9',
+      'edited-0',
+      'edited-1'
+    ])
+    const editedSession = useSessionStore.getState().sessions[0]
+    expect(editedSession.messages.at(-1)?.uploads).toHaveLength(editedUploads.length)
+    const activeFrame = editedSession.conversationGraph?.frames.find(
+      (frame) => frame.id === editedSession.conversationGraph?.activeFrameId
+    )
+    const activeBranch = editedSession.conversationGraph?.branches.find(
+      (branch) => branch.id === activeFrame?.activeBranchId
+    )
+    const activeHead = editedSession.conversationGraph?.messages.find(
+      (message) => message.id === activeBranch?.headMessageId
+    )
+    expect(activeHead).toMatchObject({
+      content: 'second prompt, edited',
+      uploads: editedUploads
+    })
+  })
+
+  it('filters edited image uploads for a text-only runtime without a Vision relay', async () => {
+    const versionedUpload = (
+      id: string,
+      name: string,
+      mimeType: string
+    ): NonNullable<ChatMessage['uploads']> => [
+      {
+        id,
+        versionId: `${id}-version`,
+        versionNumber: 1,
+        sessionId: 'source-session',
+        name,
+        originalName: name,
+        mimeType,
+        size: 24
+      }
+    ]
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'default-project',
+          title: 'Conversation',
+          cwd: '/workspace/project',
+          status: 'idle' as const,
+          messages: [
+            createMessage('user-1', 'user', 'first prompt', baseTime),
+            createMessage('agent-1', 'agent', 'first answer', baseTime + 100),
+            createMessage('user-2', 'user', 'second prompt', baseTime + 200, {
+              uploads: [
+                ...versionedUpload('photo', 'photo.png', 'application/octet-stream'),
+                ...versionedUpload('notes', 'notes.txt', 'text/plain')
+              ]
+            })
+          ],
+          createdAt: baseTime,
+          updatedAt: baseTime + 200
+        }
+      ],
+      selectedSessionId: 'session-1'
+    })
+    vi.stubGlobal('window', { api: { uploads: { finalizeSession: vi.fn() } } })
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn().mockResolvedValue({ contextReset: true }),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    await expect(
+      resendEditedWorkspaceMessage(
+        runtime,
+        { sessionId: 'session-1', messageId: 'user-2', text: 'second prompt, edited' },
+        { supportsImageInput: false }
+      )
+    ).resolves.toBe(true)
+    await flushRuntimeTasks()
+
+    expect(runtime.sendPrompt.mock.calls[0]?.[2]).toEqual([])
+    expect(runtime.sendPrompt.mock.calls[0]?.[6]).toEqual([
+      expect.objectContaining({ id: 'notes', name: 'notes.txt' })
+    ])
+    expect(useSessionStore.getState().sessions[0].messages.at(-1)?.uploads).toHaveLength(2)
+  })
+
+  it('upgrades a legacy source upload before cutting the edited Branch', async () => {
+    const legacyUpload = {
+      id: 'legacy-upload',
+      sessionId: 'source-session',
+      name: 'legacy.csv',
+      originalName: 'legacy.csv',
+      path: '/legacy/session-1/legacy.csv',
+      mimeType: 'text/csv',
+      size: 18,
+      checksum: 'legacy-checksum'
+    }
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'default-project',
+          title: 'Conversation',
+          cwd: '/workspace/project',
+          status: 'idle' as const,
+          messages: [
+            createMessage('user-1', 'user', 'first prompt', baseTime),
+            createMessage('agent-1', 'agent', 'first answer', baseTime + 100),
+            createMessage('user-2', 'user', 'second prompt', baseTime + 200, {
+              uploads: [legacyUpload]
+            }),
+            createMessage('agent-2', 'agent', 'second answer', baseTime + 300)
+          ],
+          createdAt: baseTime,
+          updatedAt: baseTime + 300
+        }
+      ],
+      selectedSessionId: 'session-1'
+    })
+    const finalizeSession = vi.fn(async ({ attachments }: FinalizeUploadSessionRequest) => [
+      {
+        ...attachments[0],
+        versionId: 'legacy-upload-version-1',
+        versionNumber: 1,
+        path: '/durable/legacy-upload-version-1/content',
+        checksum: 'legacy-checksum'
+      }
+    ])
+    vi.stubGlobal('window', { api: { uploads: { finalizeSession } } })
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn().mockResolvedValue({ contextReset: true }),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    await expect(
+      resendEditedWorkspaceMessage(runtime, {
+        sessionId: 'session-1',
+        messageId: 'user-2',
+        text: 'second prompt, edited'
+      })
+    ).resolves.toBe(true)
+    await flushRuntimeTasks()
+
+    expect(finalizeSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'source-session' })
+    )
+
+    const editedSession = useSessionStore.getState().sessions[0]
+    const originalRevision = editedSession.conversationGraph?.messages.find(
+      (message) => message.id === 'user-2'
+    )
+    expect(originalRevision?.uploads).toEqual([
+      expect.objectContaining({ versionId: 'legacy-upload-version-1' })
+    ])
+    expect(originalRevision?.uploads?.[0]).not.toHaveProperty('path')
+    expect(editedSession.messages.at(-1)?.uploads).toEqual([
+      expect.objectContaining({ versionId: 'legacy-upload-version-1' })
+    ])
+  })
+
+  it('keeps the original Branch intact when source attachment finalization is incomplete', async () => {
+    seedConversation()
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        messages: session.messages.map((message) =>
+          message.id === 'user-2'
+            ? {
+                ...message,
+                uploads: [
+                  {
+                    id: 'upload-source',
+                    sessionId: 'session-1',
+                    name: 'measurements.csv',
+                    originalName: 'measurements.csv',
+                    path: '/legacy/session-1/measurements.csv',
+                    mimeType: 'text/csv',
+                    size: 24,
+                    checksum: 'source-checksum'
+                  }
+                ]
+              }
+            : message
+        )
+      }))
+    }))
+    vi.stubGlobal('window', {
+      api: {
+        uploads: { finalizeSession: vi.fn().mockResolvedValue([]) }
+      }
+    })
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn().mockResolvedValue({ contextReset: true }),
+      sendPrompt: vi.fn()
+    }
+    const originalMessageIds = useSessionStore.getState().sessions[0].messages.map(({ id }) => id)
+
+    await expect(
+      resendEditedWorkspaceMessage(runtime, {
+        sessionId: 'session-1',
+        messageId: 'user-2',
+        text: 'second prompt, edited'
+      })
+    ).resolves.toBe(false)
+
+    expect(useSessionStore.getState().sessions[0].messages.map(({ id }) => id)).toEqual(
+      originalMessageIds
+    )
+    expect(useSessionStore.getState().sessions[0].conversationGraph?.branches).toHaveLength(1)
+    expect(useSessionStore.getState().sessions[0].error).toContain(
+      'Upload finalization did not return the attachment: upload-source'
+    )
+    expect(runtime.sendPrompt).not.toHaveBeenCalled()
   })
 
   it('keeps the transcript intact when the context reset fails', async () => {

--- a/src/renderer/src/lib/acp/workspace-runtime-attachment-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-attachment-owner.ts
@@ -1,0 +1,89 @@
+import {
+  MAX_COMPOSER_ATTACHMENTS,
+  PENDING_UPLOAD_SESSION_ID,
+  imageAttachmentMimeType,
+  type UploadedAttachment
+} from '../../../../shared/uploads'
+import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
+
+type FinalizeWorkspaceAttachmentsInput = {
+  sessionId: string
+  attachments: UploadedAttachment[]
+  projectId?: string
+  preserveSourceOwnership?: boolean
+}
+
+export const finalizeWorkspaceAttachments = async ({
+  sessionId,
+  attachments,
+  projectId,
+  preserveSourceOwnership = false
+}: FinalizeWorkspaceAttachmentsInput): Promise<UploadedAttachment[]> => {
+  const staged = attachments.filter((attachment) => !attachment.versionId)
+  if (staged.length === 0) return attachments
+
+  const stagedBySession = new Map<string, UploadedAttachment[]>()
+  for (const attachment of staged) {
+    const ownerSessionId =
+      preserveSourceOwnership && attachment.sessionId !== PENDING_UPLOAD_SESSION_ID
+        ? attachment.sessionId
+        : sessionId
+    const ownedAttachments = stagedBySession.get(ownerSessionId) ?? []
+    ownedAttachments.push(attachment)
+    stagedBySession.set(ownerSessionId, ownedAttachments)
+  }
+
+  const finalized = (
+    await Promise.all(
+      [...stagedBySession].map(([ownerSessionId, ownedAttachments]) =>
+        window.api.uploads.finalizeSession({
+          projectId,
+          sessionId: ownerSessionId,
+          attachments: ownedAttachments
+        })
+      )
+    )
+  ).flat()
+  const finalizedById = new Map(finalized.map((attachment) => [attachment.id, attachment]))
+  usePreviewWorkbenchStore.getState().reconcileFinalizedUploads(finalized)
+  return attachments.map((attachment) => {
+    if (attachment.versionId) return attachment
+    const replacement = finalizedById.get(attachment.id)
+    if (!replacement) {
+      throw new Error(`Upload finalization did not return the attachment: ${attachment.id}`)
+    }
+    return replacement
+  })
+}
+
+export const filterWorkspaceHistoryAttachments = (
+  attachments: UploadedAttachment[],
+  supportsImageInput?: boolean,
+  supportsImageRelay?: boolean
+): UploadedAttachment[] =>
+  supportsImageInput === false && supportsImageRelay !== true
+    ? attachments.filter(
+        (attachment) => !imageAttachmentMimeType(attachment.name, attachment.mimeType)
+      )
+    : attachments
+
+export const mergeWorkspaceHistoryAttachments = ({
+  historyAttachments = [],
+  latestAttachments,
+  supportsImageInput,
+  supportsImageRelay
+}: {
+  historyAttachments?: UploadedAttachment[]
+  latestAttachments: UploadedAttachment[]
+  supportsImageInput?: boolean
+  supportsImageRelay?: boolean
+}): UploadedAttachment[] => {
+  const filteredLatest = filterWorkspaceHistoryAttachments(
+    latestAttachments,
+    supportsImageInput,
+    supportsImageRelay
+  )
+  const historyLimit = Math.max(0, MAX_COMPOSER_ATTACHMENTS - filteredLatest.length)
+  const latestHistory = historyLimit > 0 ? historyAttachments.slice(-historyLimit) : []
+  return [...latestHistory, ...filteredLatest]
+}

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -14,7 +14,6 @@ import {
 } from '../../../../shared/uploads'
 import { getActiveConversationContext } from '../../../../shared/conversation-graph'
 import { saveSessionInOrder } from '../session-persistence/session-persistence'
-import { usePreviewWorkbenchStore } from '../../stores/preview-workbench-store'
 import { toPersistedSession, useSessionStore, type ChatMessage } from '../../stores/session-store'
 import {
   buildWorkspaceHistoryReplay,
@@ -29,6 +28,10 @@ import {
   branchWorkspaceSessionFromMessage,
   reconcileBranchedAttachments
 } from './workspace-runtime-session-branch-owner'
+import {
+  finalizeWorkspaceAttachments,
+  mergeWorkspaceHistoryAttachments
+} from './workspace-runtime-attachment-owner'
 import type { useAcpRuntime } from './useAcpRuntime'
 
 type SendWorkspaceMessageIntent = {
@@ -51,7 +54,6 @@ type SendWorkspaceMessageIntent = {
   enabledComputeHosts?: string[]
   selectedComputeHosts?: string[]
 }
-
 type SendWorkspaceMessageCommand = SendWorkspaceMessageIntent & {
   agentFrameworkId?: AgentFrameworkId
   agentBackendId?: string
@@ -64,7 +66,6 @@ type SendWorkspaceMessageCommand = SendWorkspaceMessageIntent & {
   allowCompactionRecovery?: boolean
   requireExistingSession?: boolean
 }
-
 type SendWorkspaceMessageResult = { sessionId: string; messageId: string }
 type SendPreparationStateChange = (sessionId: string, inFlight: boolean) => void
 type RuntimeEventDrain = (sessionId?: string) => Promise<void>
@@ -137,17 +138,6 @@ const failPrompt = async (
     // The persisted run error remains useful when the live runtime snapshot is unavailable.
   }
   useSessionStore.getState().failRun(sessionId, message, { reportable })
-}
-
-const finalizeAttachments = async (
-  sessionId: string,
-  attachments: UploadedAttachment[],
-  projectId?: string
-): Promise<UploadedAttachment[]> => {
-  if (attachments.length === 0) return attachments
-  const finalized = await window.api.uploads.finalizeSession({ projectId, sessionId, attachments })
-  usePreviewWorkbenchStore.getState().reconcileFinalizedUploads(finalized)
-  return finalized
 }
 
 const replayHistory = (
@@ -283,7 +273,11 @@ const startPendingPrompt = (
 
     let attachments = request.attachments
     try {
-      attachments = await finalizeAttachments(created.sessionId, attachments, request.projectId)
+      attachments = await finalizeWorkspaceAttachments({
+        sessionId: created.sessionId,
+        attachments,
+        projectId: request.projectId
+      })
       useSessionStore.getState().replaceMessageUploads({
         sessionId: created.sessionId,
         messageId: boundMessageId,
@@ -509,12 +503,24 @@ const sendWorkspaceMessage = async (
     if (!prepared) return undefined
     let promptAttachments = effectiveAttachments
     try {
-      promptAttachments = await finalizeAttachments(sessionId, effectiveAttachments, projectId)
+      promptAttachments = await finalizeWorkspaceAttachments({
+        sessionId,
+        attachments: effectiveAttachments,
+        projectId,
+        preserveSourceOwnership: Boolean(input.truncateFromMessageId)
+      })
     } catch (error) {
       useSessionStore.getState().failRun(sessionId, errorMessage(error))
       return undefined
     }
     if (input.truncateFromMessageId) {
+      if (promptAttachments.length > 0) {
+        useSessionStore.getState().replaceMessageUploads({
+          sessionId,
+          messageId: input.truncateFromMessageId,
+          uploads: promptAttachments.map(toPersistedUploadedAttachment)
+        })
+      }
       useSessionStore.getState().truncateSessionFromMessage(sessionId, input.truncateFromMessageId)
     }
     const appended = useSessionStore.getState().appendUserMessage({
@@ -545,10 +551,22 @@ const sendWorkspaceMessage = async (
       sessionId,
       messageId: appended.messageId,
       content,
-      attachments: promptAttachments,
+      attachments: input.truncateFromMessageId ? [] : promptAttachments,
       forcedSkillIds: input.forcedSkillIds,
       referencedArtifacts: input.referencedArtifacts,
-      replay,
+      // Edits reuse Message-owned Versions, which resolve through the project-scoped history path.
+      replay:
+        input.truncateFromMessageId && promptAttachments.length > 0
+          ? {
+              ...replay,
+              historyAttachments: mergeWorkspaceHistoryAttachments({
+                historyAttachments: replay?.historyAttachments,
+                latestAttachments: promptAttachments,
+                supportsImageInput: input.supportsImageInput,
+                supportsImageRelay: input.supportsImageRelay
+              })
+            }
+          : replay,
       continuation,
       turnIntent: input.turnIntent,
       accepted: () => prepared.acceptPrompt(appended.messageId)
@@ -593,13 +611,23 @@ const resendEditedWorkspaceMessage = async (
 ): Promise<boolean> => {
   const session = useSessionStore.getState().sessions.find((item) => item.id === input.sessionId)
   if (!session) return false
+  const sourceMessage = session.messages.find((message) => message.id === input.messageId)
   const cwd = session.cwd || runtime.state.cwd
   if (
     !cwd ||
     !input.text.trim() ||
-    !session.messages.some((message) => message.id === input.messageId) ||
+    !sourceMessage ||
     runtime.state.promptInFlightSessionIds.includes(input.sessionId)
   ) {
+    return false
+  }
+  let attachments: UploadedAttachment[]
+  try {
+    attachments = (sourceMessage.uploads ?? []).map((upload) =>
+      toRuntimeUploadedAttachment(upload, session.projectId)
+    )
+  } catch (error) {
+    useSessionStore.getState().failRun(input.sessionId, errorMessage(error))
     return false
   }
   return Boolean(
@@ -608,7 +636,7 @@ const resendEditedWorkspaceMessage = async (
       {
         sessionId: input.sessionId,
         text: input.text.trim(),
-        attachments: [],
+        attachments,
         parts: input.parts,
         cwd,
         projectId: session.projectId,

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
@@ -628,6 +628,36 @@ describe('WorkspaceMessageItem user message actions', () => {
     expect(editor?.querySelector('[data-mention-type="skill"]')).not.toBeNull()
   })
 
+  it('separates read-only uploaded files from the message editor', async () => {
+    await renderItem(
+      createMessage({
+        uploads: [
+          {
+            id: 'upload-1',
+            versionId: 'upload-version-1',
+            versionNumber: 1,
+            sessionId: 'session-1',
+            name: 'GSE23649_group-1.csv',
+            originalName: 'GSE23649_group-1.csv',
+            mimeType: 'text/csv',
+            size: 1024,
+            sha256: 'checksum-1'
+          }
+        ]
+      }),
+      { canEditMessage: true }
+    )
+
+    await click(getButton('Edit message'))
+
+    const editorCard = getEditorCardButton('Send').parentElement?.parentElement
+    expect(editorCard?.textContent).toContain('GSE23649_group-1.csv')
+    expect(editorCard?.querySelector('[role="separator"]')).not.toBeNull()
+    expect(
+      editorCard?.querySelector('[aria-label="Remove attachment GSE23649_group-1.csv"]')
+    ).toBeNull()
+  })
+
   it('keeps the artifact mention popup outside transcript row containment while editing', async () => {
     await renderItem(createMessage(), { canEditMessage: true })
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -1204,6 +1204,16 @@ const WorkspaceMessageItemImpl = ({
             <div className="flex justify-end">
               {/* Inline editing swaps the bubble for a multi-line editor; confirm resends the prompt. */}
               <div className={editCardClassName}>
+                <MessageUploadAttachmentList
+                  attachments={uploads}
+                  onPreviewUploadAttachment={onPreviewUploadAttachment}
+                />
+                {uploads.length > 0 ? (
+                  <hr
+                    role="separator"
+                    className="-mt-1.5 w-full border-0 border-t border-border-200"
+                  />
+                ) : null}
                 <ComposerEditor
                   doc={editDoc}
                   onDocChange={setEditDoc}


### PR DESCRIPTION
## Problem

Inline Message editing rebuilt only the message text and structured parts. Uploaded attachments were
hidden when the edit card opened, and the edited resend path explicitly supplied an empty attachment
list, so the new Message Revision silently lost the source uploads.

## Proposed change

- Show the source Message's existing upload pills inside the inline edit card.
- Reuse immutable Upload Version references on the edited Message Branch without uploading or
  finalizing those versions again.
- Finalize only staged or legacy path-only attachments, then reconcile the immutable Version identity
  back into the source Message before truncating the active Branch.
- Fail before Branch truncation if attachment finalization is incomplete.
- Cover same-Session and cross-Session Version ownership, legacy upgrade, failure-before-cut, retry,
  and UI visibility behavior.

## Scope and non-goals

- The attachment set is read-only while editing; this PR does not add attachment add/remove controls.
- No renderer API or ACP wire method changes.
- No new dependency or user-visible copy.

## Compatibility, state, and persistence

- Current path-free attachments reuse their existing `versionId`, including versions owned by a source
  Session inherited through Branch into new Session.
- Legacy path-only attachments are finalized and reconciled before the Message Branch is cut.
- No new enum or lifecycle state.
- No Prisma/schema migration. The edited Message Node persists the existing path-free upload reference
  through the current Session JSON/Conversation Graph format.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- Edit card exposes existing uploads -> `npm test -- src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx` -> 27 passed.
- Edited Branch preserves Upload Versions, upgrades legacy uploads, and fails before cut on incomplete finalization -> `npm run test:module -- workspace_runtime` -> 321 passed across 8 files.
- Workspace controllers, Message Graph consumers, and Session projection remain compatible -> `npm run test:module -- workspace_page` -> 459 passed across 25 files.
- Renderer types -> `npm run typecheck:web` -> passed.
- Lint and formatting -> `npm run lint` -> passed with no findings.

Per maintainer request, the local full `npm test` suite was not run; exact-head PR Gate CI remains the
authority for the complete portable and platform-selected plan. Web and Electron share the changed
renderer/runtime path. The attachment payload continues through the existing shared `sendPrompt`
contract before framework adapters, so no framework-specific ACP behavior changes.

## Review focus

- Reusing finalized Upload Versions without re-finalization.
- Reconciliation ordering before `truncateSessionFromMessage`.
- Retaining the original and edited Message Branch attachment relationships independently.
- The edit card intentionally shows previewable, non-removable attachment pills.

## Uncovered risk

- No manual authenticated Web UI visual pass was performed; the edit-card DOM and interaction are
  covered by the focused jsdom regression test. PR Gate CI is expected to exercise the repository's
  selected renderer lanes.
