### PR TITLE
fix(session-resume): recover opaque Codex resume failures

### DIFF
--- a/src/main/acp/provider-session-resumer.test.ts
+++ b/src/main/acp/provider-session-resumer.test.ts
@@ -1,3 +1,4 @@
+import * as acp from '@agentclientprotocol/sdk'
 import type { ActiveSession, ClientConnection } from '@agentclientprotocol/sdk'
 import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
@@ -42,6 +43,12 @@ const codexBridgeBackend: AcpBackendGenerationView = {
   ...codexResponsesBackend,
   backendId: 'codex:bridge-provider',
   modelRoute: 'codex-bridge'
+}
+
+const codexResponsesCompatibilityBackend: AcpBackendGenerationView = {
+  ...codexResponsesBackend,
+  backendId: 'codex:responses-compatibility-provider',
+  modelRoute: 'codex-responses-compatibility'
 }
 
 const opencodeBackend: AcpBackendGenerationView = {
@@ -640,6 +647,29 @@ describe('AcpProviderSessionResumer', () => {
         providerSessionId,
         previousFrameworkId: 'codex',
         previousBackendId: codexResponsesBackend.backendId
+      })
+    ).resolves.toMatchObject({ contextReset: true })
+
+    expect(harness.request).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ sessionId: providerSessionId })
+    )
+    expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: true })
+    expect(harness.adopt).toHaveBeenCalledOnce()
+  })
+
+  it('fresh-adopts a persisted Codex Responses Compatibility Session after an opaque internal resume failure', async () => {
+    const providerSessionId = '019fb8c8-6c66-7f22-9653-17b5b287dbbb'
+    const harness = createHarness({
+      initialBackend: codexResponsesCompatibilityBackend,
+      resumeError: acp.RequestError.internalError()
+    })
+
+    await expect(
+      harness.resume({
+        providerSessionId,
+        previousFrameworkId: 'codex',
+        previousBackendId: codexResponsesCompatibilityBackend.backendId
       })
     ).resolves.toMatchObject({ contextReset: true })
 

--- a/src/main/acp/session-resume-policy.ts
+++ b/src/main/acp/session-resume-policy.ts
@@ -150,6 +150,13 @@ const authoritativeFailure = (
   reason: AcpSessionResumeAuthoritativeFailureReason
 ): AcpSessionResumeFailureClassification => Object.freeze({ disposition: 'authoritative', reason })
 
+const isCodexResponsesResumeContext = (
+  context: AcpSessionResumeFailureContext | undefined
+): boolean =>
+  context?.currentFrameworkId === 'codex' &&
+  (context.currentModelRoute === 'codex-responses' ||
+    context.currentModelRoute === 'codex-responses-compatibility')
+
 // ARD-04 intentionally adds this pure policy without a production caller. ARD-20 exclusively owns
 // the Runtime cutover once its transaction seams exist; integrating here would violate the serialized
 // hot-file boundary. Session ownership, protocol calls, and replay stay with those transactions.
@@ -270,11 +277,7 @@ class AcpSessionResumePolicy {
     if (service.value !== undefined) return authoritativeFailure('non-session-service-failure')
 
     if (typeof message.value === 'string' && /^unknown error\.?$/i.test(message.value.trim())) {
-      if (
-        context?.currentFrameworkId === 'codex' &&
-        (context.currentModelRoute === 'codex-responses' ||
-          context.currentModelRoute === 'codex-responses-compatibility')
-      ) {
+      if (isCodexResponsesResumeContext(context)) {
         return adoptableFailure('legacy-codex-session-unavailable')
       }
       if (
@@ -302,6 +305,9 @@ class AcpSessionResumePolicy {
     if (!details.readable) return authoritativeFailure('uninspectable-error')
     if (describesUnresumableSession(details.value)) {
       return adoptableFailure('legacy-unresumable-details')
+    }
+    if (data.value === undefined && isCodexResponsesResumeContext(context)) {
+      return adoptableFailure('legacy-codex-session-unavailable')
     }
     return authoritativeFailure('unrelated-internal-error')
   }


### PR DESCRIPTION
## Problem

A packaged Windows 0.18.0 log shows the same persisted Session failing `acp:resume-session` three times with JSON-RPC code `-32603`. The SDK surfaces the failure as a detail-free `RequestError: Internal error`, which the renderer intentionally presents as `Agent session resume failed: Unknown error`.

Codex Responses already fresh-adopts when an unavailable provider Session is reported as exact `Unknown error`, but the equivalent SDK `Internal error` shape remained authoritative. The Session therefore never reached the existing context-reset and transcript-replay recovery path.

## Proposed change

- Treat exact, detail-free `-32603 Internal error` as an unavailable provider Session only for `codex-responses` and `codex-responses-compatibility` routes.
- Reuse the existing `legacy-codex-session-unavailable` classification and fresh-adoption transaction.
- Cover the packaged-log shape through the public `AcpProviderSessionResumer.resume()` boundary using a real SDK `RequestError`.

On successful fresh adoption, the existing response returns `contextReset: true`; the renderer replays locally persisted history and persists the replacement `providerSessionId` under the stable application Session ID.

## Scope and non-goals

- No database or schema migration.
- No new persisted field, data relationship, enum, or state value.
- No new UI surface; the interaction changes from a blocking Unknown error to the existing automatic fresh-adopt and replay fallback.
- Structured `service`, `errorKind`, and `details` failures remain authoritative.
- Claude Code, OpenCode, and Codex Bridge behavior is unchanged.
- Historical compatibility is intentional: existing Session JSON remains readable and receives the new provider Session ID only after adoption succeeds.

## Acceptance criteria and validation

The regression test was run four times against unmodified production code and failed deterministically because `resume()` rejected `RequestError(-32603, Internal error, data: undefined)` instead of resolving with `contextReset: true`. Changing only the probe message to the already-supported `Unknown error` made the same test pass, isolating the classification gap.

Final checks ran after the last material edit:

- Reported resume behavior -> `npm test -- src/main/acp/provider-session-resumer.test.ts -t "fresh-adopts a persisted Codex Responses Compatibility Session after an opaque internal resume failure"` -> passed (1/1).
- Resume owner and policy behavior -> `npm test -- src/main/acp/session-resume-policy.test.ts src/main/acp/provider-session-resumer.test.ts` -> passed (76/76).
- Other-framework and structured-error safeguards -> targeted `src/main/acp/runtime.test.ts` selection -> passed (7/7).
- Context-reset transcript replay consumer -> targeted `src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts` selection -> passed (1/1).
- Main-process types -> `npm run typecheck:node` -> passed.
- Lint -> `npm run lint` -> passed.
- Diff hygiene -> `git diff --check` -> passed.

The full portable suite was not run locally per maintainer request. The ACP files are not assigned to a declared module in `scripts/ci/module-impact.json`, so exact-head PR Gate and its fail-closed CI plan remain authoritative for wider consumers and platform lanes. No path, schema, migration, or platform-specific behavior changed.

## Review focus

- Whether the fallback is narrow enough: exact RPC code, exact message, missing data, and Codex Responses routes only.
- Whether reusing `legacy-codex-session-unavailable` remains the right internal reason for both legacy and persisted provider identities.