### PR TITLE
fix(workspace-runtime): bound incremental event admission work

### DIFF
--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -244,6 +244,41 @@ describe('workspace agent runtime event processing', () => {
     expect(appliedEventIds).toEqual(events.map((event) => event.id))
   })
 
+  it('keeps synchronous incremental event admission within a linear main-thread work budget', async () => {
+    let eventIdReads = 0
+    const appliedEventIds: string[] = []
+    const processor = createWorkspaceRuntimeEventProcessor(async (event) => {
+      appliedEventIds.push(event.id)
+      return true
+    })
+    const events = Array.from({ length: 1_200 }, (_, index) => {
+      const event = createEvent({
+        id: `thought-event-${index + 1}`,
+        kind: 'thought',
+        role: 'assistant',
+        text: 'x'
+      })
+      const eventId = event.id
+      Object.defineProperty(event, 'id', {
+        enumerable: true,
+        get: () => {
+          eventIdReads += 1
+          return eventId
+        }
+      })
+      return event
+    })
+
+    // IPC listeners admit live events synchronously and intentionally do not await presentation.
+    const drains = events.map((event) => processor.processIncremental([event]))
+    const admissionEventIdReads = eventIdReads
+    await Promise.all(drains)
+    await processor.drain()
+
+    expect(admissionEventIdReads).toBeLessThan(events.length * 20)
+    expect(appliedEventIds).toEqual(events.map((event) => event.id))
+  })
+
   it('releases fast assistant text in grapheme-budgeted 30 fps batches', async () => {
     vi.useFakeTimers()
     try {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -244,6 +244,28 @@ describe('workspace agent runtime event processing', () => {
     expect(appliedEventIds).toEqual(events.map((event) => event.id))
   })
 
+  it('does not replay a processed event from an oversized incremental batch', async () => {
+    const appliedEventIds: string[] = []
+    const processor = createWorkspaceRuntimeEventProcessor(async (event) => {
+      appliedEventIds.push(event.id)
+      return true
+    })
+    const firstEvent = createEvent({ id: 'tool-event-1', kind: 'tool', status: 'completed' })
+    const laterEvents = Array.from({ length: 600 }, (_, index) =>
+      createEvent({
+        id: `tool-event-${index + 2}`,
+        kind: 'tool',
+        status: 'completed'
+      })
+    )
+
+    await processor.processIncremental([firstEvent])
+    await processor.processIncremental([firstEvent, ...laterEvents])
+    await processor.drain()
+
+    expect(appliedEventIds).toEqual([firstEvent, ...laterEvents].map((event) => event.id))
+  })
+
   it('keeps synchronous incremental event admission within a linear main-thread work budget', async () => {
     let eventIdReads = 0
     const appliedEventIds: string[] = []

--- a/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
@@ -243,6 +243,7 @@ const createWorkspaceRuntimeEventProcessor = (
     events: readonly AcpRuntimeEvent[],
     replaceLatestEvents: boolean
   ): Promise<void> => {
+    const evictedEvents: AcpRuntimeEvent[] = []
     if (replaceLatestEvents) {
       latestEventsById = new Map(events.map((event) => [event.id, event]))
     } else {
@@ -256,7 +257,7 @@ const createWorkspaceRuntimeEventProcessor = (
           [string, AcpRuntimeEvent] | undefined
         if (!oldest) break
         latestEventsById.delete(oldest[0])
-        releaseEvictedEvent(oldest[1])
+        evictedEvents.push(oldest[1])
       }
     }
     const visibleLaneKeys = new Set<string | symbol>()
@@ -277,6 +278,11 @@ const createWorkspaceRuntimeEventProcessor = (
         presentationBuffer.forceOnAccepted(lane.presentation, event)
       }
     }
+
+    // Keep processed markers through admission so an oversized batch cannot re-admit an event that
+    // this same retention update evicted. Once every batch item has been classified, targeted cleanup
+    // can safely release the evicted lane state.
+    for (const event of evictedEvents) releaseEvictedEvent(event)
 
     if (replaceLatestEvents) {
       for (const [laneKey, lane] of eventLanes) cleanEventLane(laneKey, lane)

--- a/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-event-owner.ts
@@ -130,7 +130,7 @@ const createWorkspaceRuntimeEventProcessor = (
   const unscopedEventLane = Symbol('unscoped-workspace-runtime-events')
   const eventLanes = new Map<string | symbol, EventLane>()
   const presentationBuffer = createWorkspaceRuntimePresentationBuffer(options.presentation)
-  let latestEvents: AcpRuntimeEvent[] = []
+  let latestEventsById = new Map<string, AcpRuntimeEvent>()
   let acceptedEventVersion = 0
 
   const getEventLaneKey = (event: AcpRuntimeEvent): string | symbol =>
@@ -153,20 +153,24 @@ const createWorkspaceRuntimeEventProcessor = (
     return lane
   }
 
+  const releaseProcessedEvent = (lane: EventLane, eventId: string): void => {
+    if (latestEventsById.has(eventId) || !lane.processedEventIds.has(eventId)) return
+    lane.acceptedEvents.delete(eventId)
+    lane.failedEventIds.delete(eventId)
+    lane.processedEventIds.delete(eventId)
+    lane.processingEventIds.delete(eventId)
+  }
+
   const cleanEventLane = (laneKey: string | symbol, lane: EventLane): void => {
-    const visibleEventIds = new Set(
-      latestEvents.filter((event) => getEventLaneKey(event) === laneKey).map((event) => event.id)
-    )
+    for (const eventId of lane.acceptedEvents.keys()) releaseProcessedEvent(lane, eventId)
+    if (lane.acceptedEvents.size === 0 && !lane.drainInFlight) eventLanes.delete(laneKey)
+  }
 
-    for (const eventId of lane.acceptedEvents.keys()) {
-      if (!visibleEventIds.has(eventId) && lane.processedEventIds.has(eventId)) {
-        lane.acceptedEvents.delete(eventId)
-        lane.failedEventIds.delete(eventId)
-        lane.processedEventIds.delete(eventId)
-        lane.processingEventIds.delete(eventId)
-      }
-    }
-
+  const releaseEvictedEvent = (event: AcpRuntimeEvent): void => {
+    const laneKey = getEventLaneKey(event)
+    const lane = eventLanes.get(laneKey)
+    if (!lane) return
+    releaseProcessedEvent(lane, event.id)
     if (lane.acceptedEvents.size === 0 && !lane.drainInFlight) eventLanes.delete(laneKey)
   }
 
@@ -191,7 +195,6 @@ const createWorkspaceRuntimeEventProcessor = (
         const selectedEvents = presentationBuffer.select(lane.presentation, pendingLaneEvents(lane))
         if (selectedEvents.length === 0) continue
 
-        const processedCount = lane.processedEventIds.size
         await processVisibleWorkspaceRuntimeEvents(
           selectedEvents,
           lane.processedEventIds,
@@ -202,9 +205,7 @@ const createWorkspaceRuntimeEventProcessor = (
               lane.failedEventIds.delete(event.id)
               return applied
             } catch (error) {
-              const isVisible = latestEvents.some(
-                (candidate) => candidate.id === event.id && getEventLaneKey(candidate) === laneKey
-              )
+              const isVisible = latestEventsById.has(event.id)
               if (hadFailed && !isVisible) {
                 lane.acceptedEvents.delete(event.id)
                 lane.failedEventIds.delete(event.id)
@@ -220,7 +221,8 @@ const createWorkspaceRuntimeEventProcessor = (
             retainedEvents: [...lane.acceptedEvents.values()]
           }
         )
-        const madeProgress = lane.processedEventIds.size > processedCount
+        const madeProgress = selectedEvents.some((event) => lane.processedEventIds.has(event.id))
+        for (const event of selectedEvents) releaseProcessedEvent(lane, event.id)
         const hasPending = pendingLaneEvents(lane).length > 0
         if (madeProgress) {
           presentationBuffer.recordProgress(lane.presentation, selectedEvents, hasPending)
@@ -233,7 +235,7 @@ const createWorkspaceRuntimeEventProcessor = (
       await lane.drainInFlight
     } finally {
       lane.drainInFlight = undefined
-      cleanEventLane(laneKey, lane)
+      if (lane.acceptedEvents.size === 0) eventLanes.delete(laneKey)
     }
   }
 
@@ -242,17 +244,19 @@ const createWorkspaceRuntimeEventProcessor = (
     replaceLatestEvents: boolean
   ): Promise<void> => {
     if (replaceLatestEvents) {
-      latestEvents = [...events]
+      latestEventsById = new Map(events.map((event) => [event.id, event]))
     } else {
-      const latestEventIds = new Set(latestEvents.map((event) => event.id))
       for (const event of events) {
-        if (!latestEventIds.has(event.id)) {
-          latestEvents.push(event)
-          latestEventIds.add(event.id)
+        if (!latestEventsById.has(event.id)) {
+          latestEventsById.set(event.id, event)
         }
       }
-      if (latestEvents.length > MAX_ACP_RUNTIME_EVENTS) {
-        latestEvents = latestEvents.slice(-MAX_ACP_RUNTIME_EVENTS)
+      while (latestEventsById.size > MAX_ACP_RUNTIME_EVENTS) {
+        const oldest = latestEventsById.entries().next().value as
+          [string, AcpRuntimeEvent] | undefined
+        if (!oldest) break
+        latestEventsById.delete(oldest[0])
+        releaseEvictedEvent(oldest[1])
       }
     }
     const visibleLaneKeys = new Set<string | symbol>()
@@ -274,7 +278,9 @@ const createWorkspaceRuntimeEventProcessor = (
       }
     }
 
-    for (const [laneKey, lane] of eventLanes) cleanEventLane(laneKey, lane)
+    if (replaceLatestEvents) {
+      for (const [laneKey, lane] of eventLanes) cleanEventLane(laneKey, lane)
+    }
 
     const drains = [...visibleLaneKeys].map((laneKey) => drainLane(laneKey))
     for (const [laneKey, lane] of eventLanes) {


### PR DESCRIPTION
## Problem

Long, high-volume Agent streams can make the Open Science renderer unresponsive while the rest of the operating system remains usable. The supplied production log records 17 renderer-unresponsive periods, including several lasting 39–175 seconds and one ending with the renderer process being killed. During the affected runs, ACP published tens of thousands of fine-grained thought, tool, and message events.

Incremental IPC delivery admits events synchronously so the bounded runtime window cannot discard an unaccepted prefix. The workspace event processor rebuilt the retained-event ID set and rescanned every accepted lane for each arrival. A synchronous burst therefore accumulated approximately quadratic renderer-main-thread work before presentation could drain it.

## Proposed change

- Maintain the retained runtime-event window as an insertion-ordered ID index.
- Clean processed entries when their specific retained event is evicted.
- Reserve full lane reconciliation for full runtime snapshots.
- Preserve event ordering, retry behavior, per-session lanes, presentation pacing, and persistence barriers.
- Add a deterministic regression test for the real IPC behavior: 1,200 incremental events admitted synchronously without awaiting presentation.

On the unfixed implementation, the regression test failed identically across three runs with 957,202 event-ID reads against a linear budget below 24,000. It passes after the change.

## Scope and non-goals

- No renderer interaction changes.
- No architecture or public interface changes.
- No database, persisted-session format, data-model, field, migration, or enum changes.
- No historical-data compatibility path is needed.
- This does not change provider streaming granularity or presentation animation policy.

## Acceptance criteria and validation

Checks listed below ran after the last material edit:

- synchronous incremental admission stays within a linear work budget -> `npm test -- src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts -t "keeps synchronous incremental event admission within a linear main-thread work budget"` -> passed after reproducing the unfixed failure three times
- workspace runtime owner, contracts, and representative consumer -> `npm run test:module -- workspace_runtime` -> 8 files / 320 tests passed
- renderer TypeScript boundary -> `npm run typecheck:web` -> passed
- linted source -> `npm run lint` -> passed

The changed file is an internal `workspace_runtime` owner rather than its public facade. The module plan already includes its declared owner, contract, and representative workspace consumer tests. No persistence, migration, path, native-process, or platform-specific behavior changed, so additional platform lanes were not selected locally. Exact-head PR CI remains authoritative; a full local `npm test` was intentionally not run.

Uncovered local risk: the supplied multi-hour production stream was represented by the deterministic burst regression rather than replayed through a packaged Electron build.

## Review focus

- Verify that targeted eviction cleanup preserves retries for events evicted while still processing.
- Verify that full snapshots still reconcile processed entries no longer retained by Main.
- Verify that presentation progress remains based on the selected batch even when processed evicted entries are released immediately.