### PR TITLE
fix(delegation): prevent replayed activity collisions

### DIFF
--- a/src/main/delegation/attempt-runtime-transcript.ts
+++ b/src/main/delegation/attempt-runtime-transcript.ts
@@ -46,6 +46,11 @@ type AttemptRuntimeTranscriptStager = (
   input: StageAttemptRuntimeTranscriptInput
 ) => Promise<AttemptRuntimeTranscript | undefined>
 
+type AttemptRuntimeTranscriptScope = Readonly<{
+  runtimeSegmentId: string
+  promptMessageId: string
+}>
+
 type AttemptCancellationReason = 'main_agent_stop' | 'session_stop' | 'runtime_interrupted'
 
 const TOOL_STATUSES = new Set<PersistedToolActivityStatus>([
@@ -71,6 +76,16 @@ const toolTitle = (title: string | undefined, kind: string | undefined): string 
 
 const appOwnedToolCallId = (runtimeSegmentId: string, providerToolCallId: string): string =>
   `agent-runtime:${encodeURIComponent(runtimeSegmentId)}:${encodeURIComponent(providerToolCallId)}`
+
+const selectRuntimeScopeUpdates = (
+  updates: readonly AcpAgentRuntimeUpdate[],
+  scope: AttemptRuntimeTranscriptScope
+): AcpAgentRuntimeUpdate[] =>
+  updates.filter(
+    (update) =>
+      update.scope.runtimeSegmentId === scope.runtimeSegmentId &&
+      update.scope.promptMessageId === scope.promptMessageId
+  )
 
 const projectAttemptRuntimeTranscript = (
   input: ProjectAttemptRuntimeTranscriptInput
@@ -264,18 +279,19 @@ const createAttemptRuntimeTranscriptStager = (options: {
   frameId: string
   attemptId: string
   updates: readonly AcpAgentRuntimeUpdate[]
-  promptMessageId(): string | undefined
+  runtimeScope(): AttemptRuntimeTranscriptScope | undefined
   createMessageId(): string
 }): AttemptRuntimeTranscriptStager => {
   let stagingStarted = false
   return async (input) => {
-    const promptMessageId = options.promptMessageId()
-    if (!promptMessageId || stagingStarted) return undefined
+    const runtimeScope = options.runtimeScope()
+    if (!runtimeScope || stagingStarted) return undefined
     stagingStarted = true
     return stageAttemptRuntimeTranscript(options.records, options.frameId, options.attemptId, {
-      updates: options.updates,
+      updates: selectRuntimeScopeUpdates(options.updates, runtimeScope),
       frameId: options.frameId,
-      promptMessageId,
+      promptMessageId: runtimeScope.promptMessageId,
+      runtimeSegmentId: runtimeScope.runtimeSegmentId,
       fallbackResponse: input.fallbackResponse ?? '',
       endedAt: input.endedAt,
       terminalStatus: input.terminalStatus,
@@ -334,6 +350,7 @@ const terminalizeUnsuccessfulAttempt = async (
 export {
   createAttemptRuntimeTranscriptStager,
   projectAttemptRuntimeTranscript,
+  selectRuntimeScopeUpdates,
   stageAttemptRuntimeTranscript,
   terminalizeUnsuccessfulAttempt
 }

--- a/src/main/delegation/delegated-turn-lifecycle.ts
+++ b/src/main/delegation/delegated-turn-lifecycle.ts
@@ -1,6 +1,9 @@
 import type { AcpAgentRuntimeUpdate } from '../../shared/acp'
 import type { ArtifactFile } from '../../shared/artifacts'
-import { stageAttemptRuntimeTranscript } from './attempt-runtime-transcript'
+import {
+  selectRuntimeScopeUpdates,
+  stageAttemptRuntimeTranscript
+} from './attempt-runtime-transcript'
 import type { DurableMessage, DelegatedWorkDurableRecords } from './delegated-work-record-types'
 import type { DelegateExecutionInput } from './execution-port'
 
@@ -58,6 +61,7 @@ const createDelegatedTurnLifecycle = (options: {
   openInitial(context: TurnContext): Promise<void>
   currentArtifact(): DelegatedArtifactHandle | undefined
   lastTurnMessage(): DurableMessage | undefined
+  unstagedRuntimeScope(context: TurnContext | undefined): TurnContext | undefined
   create(context: TurnContext, initial: boolean): NonNullable<DelegateExecutionInput['turn']>
   finalizeFallback(terminalMessageId: string): Promise<void>
   dispose(): Promise<void>
@@ -67,6 +71,9 @@ const createDelegatedTurnLifecycle = (options: {
   let artifactHandoffFile: string | undefined
   let stagedRuntimeUpdateCount = 0
   let completedTurnMessage: DurableMessage | undefined
+  const stagedRuntimeScopes = new Set<string>()
+  const runtimeScopeKey = (context: TurnContext): string =>
+    `${context.runtimeSegmentId}\u0000${context.promptMessageId}`
 
   const openArtifact = async (context: TurnContext, executionId: string): Promise<void> => {
     const artifact = await options.artifactEvidence?.open({
@@ -91,6 +98,8 @@ const createDelegatedTurnLifecycle = (options: {
     openInitial: (context) => openArtifact(context, options.attemptId),
     currentArtifact: () => currentArtifact,
     lastTurnMessage: () => completedTurnMessage,
+    unstagedRuntimeScope: (context) =>
+      context && !stagedRuntimeScopes.has(runtimeScopeKey(context)) ? context : undefined,
     create: (context, initial) => ({
       promptMessageId: context.promptMessageId,
       messageBranchId: context.messageBranchId,
@@ -102,7 +111,10 @@ const createDelegatedTurnLifecycle = (options: {
         : {}),
       async complete(response, turnUsage, turnUsageUnavailable) {
         const completedAt = options.now()
-        const turnUpdates = options.runtimeUpdates.slice(stagedRuntimeUpdateCount)
+        const turnUpdates = selectRuntimeScopeUpdates(
+          options.runtimeUpdates.slice(stagedRuntimeUpdateCount),
+          context
+        )
         stagedRuntimeUpdateCount = options.runtimeUpdates.length
         const transcript = await stageAttemptRuntimeTranscript(
           options.records,
@@ -124,6 +136,7 @@ const createDelegatedTurnLifecycle = (options: {
             createMessageId: options.createMessageId
           }
         )
+        stagedRuntimeScopes.add(runtimeScopeKey(context))
         const message = transcript.terminalMessage
         if (!message) throw new Error('Completed child Turn has no final agent Message.')
         await currentArtifact?.finalize(message.id)

--- a/src/main/delegation/durable-delegated-work.ts
+++ b/src/main/delegation/durable-delegated-work.ts
@@ -179,7 +179,15 @@ const createDurableDelegatedWork = (
       frameId: child.frameId,
       attemptId: attempt.id,
       updates: runtimeUpdates,
-      promptMessageId: () => context?.promptMessageId,
+      runtimeScope: () => {
+        const unstagedScope = turnLifecycle.unstagedRuntimeScope(context)
+        return unstagedScope
+          ? {
+              runtimeSegmentId: unstagedScope.runtimeSegmentId,
+              promptMessageId: unstagedScope.promptMessageId
+            }
+          : undefined
+      },
       createMessageId: () => createId('message')
     })
     const completion = (async () => {

--- a/src/main/delegation/session-record-adapter.test.ts
+++ b/src/main/delegation/session-record-adapter.test.ts
@@ -19,8 +19,14 @@ import {
 } from '../session-persistence/coordinator'
 import { SpecialistRepository } from '../specialist/repository'
 import { ProfileService } from '../specialist/service'
-import { createDeterministicDelegateExecution } from './deterministic-execution'
-import { type AuthenticatedDelegateCaller } from './durable-delegated-work'
+import {
+  createDeterministicDelegateExecution,
+  type ExecutionControl
+} from './deterministic-execution'
+import {
+  type AuthenticatedDelegateCaller,
+  type DurableDelegatedWork
+} from './durable-delegated-work'
 import { createTestDurableDelegatedWork as createDurableDelegatedWork } from './durable-delegated-work-test-fixture'
 import { createSessionDelegatedWorkRecords } from './session-record-adapter'
 
@@ -101,6 +107,111 @@ const createHarness = (): Readonly<{
   }
   const coordinator = new SessionPersistenceCoordinator(repository, fileIndex)
   return { coordinator, repository, readSession: async () => structuredClone(durable) }
+}
+
+type LateReplayScenario = Readonly<{
+  caller: AuthenticatedDelegateCaller
+  control: ExecutionControl
+  readSession: ReturnType<typeof createHarness>['readSession']
+  records: ReturnType<typeof createSessionDelegatedWorkRecords>
+  repository: SessionMutationRepository
+  work: DurableDelegatedWork
+}>
+
+async function createLateReplayScenario(): Promise<LateReplayScenario> {
+  const { coordinator, repository, readSession } = createHarness()
+  const execution = createDeterministicDelegateExecution()
+  const rootFrameId = createSession().conversationGraph!.rootFrameId
+  const records = createSessionDelegatedWorkRecords(
+    { commands: coordinator, readSession, frameworkId: 'codex', createId: () => 'child-branch' },
+    key
+  )
+  const ids = {
+    frame: ['child-frame'],
+    attempt: ['attempt-1'],
+    message: ['prompt-1', 'pending-1', 'prompt-2', 'answer-1', 'answer-2'],
+    runtime: ['runtime-1', 'runtime-2']
+  }
+  const work = createDurableDelegatedWork({
+    execution,
+    records,
+    now: () => 50,
+    createId: (kind) => ids[kind].shift()!
+  })
+  const caller: AuthenticatedDelegateCaller = {
+    session: key,
+    frameId: rootFrameId,
+    role: 'main',
+    originMessageId: rootPrompt.id,
+    toolInvocationId: 'dispatch'
+  }
+
+  await work.delegate(caller, { task: 'Initial task', name: 'Initial task' }, { wait: false })
+  await expect.poll(() => execution.controls()).toHaveLength(1)
+  const control = execution.control('attempt-1')
+  control.accept()
+  await work.sendMessage(
+    { ...caller, toolInvocationId: 'message-call' },
+    'child-frame',
+    'Additional evidence',
+    { kind: 'info' }
+  )
+
+  return { caller, control, readSession, records, repository, work }
+}
+
+function createScopedToolUpdate(
+  runtimeSegmentId: string,
+  promptMessageId: string,
+  event: AcpAgentRuntimeUpdate['event']
+): AcpAgentRuntimeUpdate {
+  return {
+    scope: {
+      projectId: key.projectId,
+      sessionId: key.sessionId,
+      agentFrameId: 'child-frame',
+      attemptId: 'attempt-1',
+      runtimeSegmentId,
+      promptMessageId
+    },
+    event
+  }
+}
+
+function createInitialToolUpdate(): AcpAgentRuntimeUpdate {
+  return createScopedToolUpdate('runtime-1', 'prompt-1', {
+    id: 'tool-one',
+    timestamp: 40,
+    kind: 'tool',
+    level: 'info',
+    toolCallId: 'call-1',
+    title: 'Inspect evidence',
+    status: 'completed'
+  })
+}
+
+function createLateToolReplay(): AcpAgentRuntimeUpdate {
+  return createScopedToolUpdate('runtime-1', 'prompt-1', {
+    id: 'tool-one-late',
+    timestamp: 41,
+    kind: 'tool',
+    level: 'info',
+    toolCallId: 'call-1',
+    status: 'completed',
+    rawOutput: { replayed: true }
+  })
+}
+
+function createActiveToolUpdate(): AcpAgentRuntimeUpdate {
+  return createScopedToolUpdate('runtime-2', 'prompt-2', {
+    id: 'tool-two',
+    timestamp: 42,
+    kind: 'tool',
+    level: 'info',
+    toolCallId: 'call-2',
+    title: 'Check counterexample',
+    status: 'in_progress'
+  })
 }
 
 describe('Session delegated-work adapter', () => {
@@ -694,6 +805,234 @@ describe('Session delegated-work adapter', () => {
         runtimeSegmentId: 'runtime-2'
       })
   })
+
+  it('completes a queued child turn when a late tool replay arrives from the previous Runtime Segment', async () => {
+    const { control, readSession, records } = await createLateReplayScenario()
+    const replayedToolUpdate = createScopedToolUpdate('runtime-1', 'prompt-1', {
+      id: 'tool-event',
+      timestamp: 40,
+      kind: 'tool',
+      level: 'info',
+      toolCallId: 'call-1',
+      title: 'Inspect evidence',
+      status: 'completed'
+    })
+
+    control.emit({ kind: 'runtime', update: replayedToolUpdate })
+    await control.completeTurn('Initial answer')
+    control.emit({ kind: 'runtime', update: replayedToolUpdate })
+    control.complete('Final answer')
+
+    await expect
+      .poll(async () => (await records.snapshot()).records[0].attempts[0])
+      .toMatchObject({ status: 'completed' })
+    expect((await records.snapshot()).records[0].attempts[0]).not.toHaveProperty('error')
+    expect((await readSession()).conversationGraph?.activities).toEqual([
+      expect.objectContaining({
+        id: 'agent-runtime:runtime-1:call-1',
+        runtimeSegmentId: 'runtime-1',
+        status: 'completed',
+        eventIds: ['tool-event']
+      })
+    ])
+  })
+
+  it('preserves a provider error when the active child turn follows a late tool replay', async () => {
+    const { control, readSession, records } = await createLateReplayScenario()
+
+    control.emit({ kind: 'runtime', update: createInitialToolUpdate() })
+    await control.completeTurn('Initial answer')
+    control.emit({ kind: 'runtime', update: createLateToolReplay() })
+    control.emit({ kind: 'runtime', update: createActiveToolUpdate() })
+    control.fail(new Error('provider failed'))
+
+    await expect
+      .poll(async () => (await records.snapshot()).records[0].attempts[0])
+      .toMatchObject({
+        status: 'error',
+        error: { code: 'execution_failure', message: 'provider failed' }
+      })
+    expect((await readSession()).conversationGraph?.activities).toEqual([
+      expect.objectContaining({
+        id: 'agent-runtime:runtime-1:call-1',
+        runtimeSegmentId: 'runtime-1',
+        status: 'completed',
+        eventIds: ['tool-one']
+      }),
+      expect.objectContaining({
+        id: 'agent-runtime:runtime-2:call-2',
+        runtimeSegmentId: 'runtime-2',
+        status: 'failed',
+        eventIds: ['tool-two']
+      })
+    ])
+  })
+
+  it('cancels the active child turn when it follows a late tool replay', async () => {
+    const { caller, control, readSession, records, work } = await createLateReplayScenario()
+
+    control.emit({ kind: 'runtime', update: createInitialToolUpdate() })
+    await control.completeTurn('Initial answer')
+    control.emit({ kind: 'runtime', update: createLateToolReplay() })
+    control.emit({ kind: 'runtime', update: createActiveToolUpdate() })
+
+    await expect(work.stopChildren(caller, ['child-frame'])).resolves.toEqual([
+      { frameId: 'child-frame', status: 'cancelled' }
+    ])
+    await expect
+      .poll(async () => (await records.snapshot()).records[0].attempts[0])
+      .toMatchObject({ status: 'cancelled', cancellationReason: 'main_agent_stop' })
+    expect((await records.snapshot()).records[0].attempts[0]).not.toHaveProperty('error')
+    expect((await readSession()).conversationGraph?.activities).toEqual([
+      expect.objectContaining({
+        id: 'agent-runtime:runtime-1:call-1',
+        runtimeSegmentId: 'runtime-1',
+        status: 'completed',
+        eventIds: ['tool-one']
+      }),
+      expect.objectContaining({
+        id: 'agent-runtime:runtime-2:call-2',
+        runtimeSegmentId: 'runtime-2',
+        status: 'failed',
+        eventIds: ['tool-two']
+      })
+    ])
+  })
+
+  it('preserves a queued child turn begin error after the previous Runtime Segment closes', async () => {
+    const { control, readSession, records, repository } = await createLateReplayScenario()
+    const beginError = new Error('pending turn storage unavailable')
+    let markBeginSaveStarted!: () => void
+    const beginSaveStarted = new Promise<void>((resolve) => {
+      markBeginSaveStarted = resolve
+    })
+    let rejectBeginSave!: () => void
+    const beginSaveRejection = new Promise<void>((resolve) => {
+      rejectBeginSave = resolve
+    })
+    const persistSession = vi.mocked(repository.saveSession).getMockImplementation()!
+    vi.mocked(repository.saveSession).mockImplementation(async (session) => {
+      if (session.conversationGraph?.messages.some(({ id }) => id === 'prompt-2')) {
+        markBeginSaveStarted()
+        await beginSaveRejection
+        throw beginError
+      }
+      return persistSession(session)
+    })
+
+    control.emit({ kind: 'runtime', update: createInitialToolUpdate() })
+
+    const completingFirstTurn = control.completeTurn('Initial answer')
+    await beginSaveStarted
+    control.emit({ kind: 'runtime', update: createLateToolReplay() })
+    rejectBeginSave()
+    await expect(completingFirstTurn).rejects.toThrow(beginError)
+    control.fail(beginError)
+
+    await expect
+      .poll(async () => (await records.snapshot()).records[0].attempts[0])
+      .toMatchObject({
+        status: 'error',
+        error: { code: 'execution_failure', message: beginError.message }
+      })
+    expect((await readSession()).conversationGraph?.activities).toEqual([
+      expect.objectContaining({
+        id: 'agent-runtime:runtime-1:call-1',
+        runtimeSegmentId: 'runtime-1',
+        status: 'completed',
+        eventIds: ['tool-one']
+      })
+    ])
+  })
+
+  it('preserves a child turn completion storage error after its transcript is durable', async () => {
+    const { coordinator, repository, readSession } = createHarness()
+    const execution = createDeterministicDelegateExecution()
+    const rootFrameId = createSession().conversationGraph!.rootFrameId
+    const records = createSessionDelegatedWorkRecords(
+      { commands: coordinator, readSession, frameworkId: 'codex', createId: () => 'child-branch' },
+      key
+    )
+    const ids = {
+      frame: ['child-frame'],
+      attempt: ['attempt-1'],
+      message: ['prompt-1', 'answer-1', 'fallback-answer'],
+      runtime: ['runtime-1']
+    }
+    const work = createDurableDelegatedWork({
+      execution,
+      records,
+      now: () => 50,
+      createId: (kind) => ids[kind].shift()!
+    })
+    const caller: AuthenticatedDelegateCaller = {
+      session: key,
+      frameId: rootFrameId,
+      role: 'main',
+      originMessageId: rootPrompt.id,
+      toolInvocationId: 'dispatch'
+    }
+    const completionError = new Error('child turn completion storage unavailable')
+    let markCompletionSaveStarted!: () => void
+    const completionSaveStarted = new Promise<void>((resolve) => {
+      markCompletionSaveStarted = resolve
+    })
+    let rejectCompletionSave!: () => void
+    const completionSaveRejection = new Promise<void>((resolve) => {
+      rejectCompletionSave = resolve
+    })
+    let completionSaveRejected = false
+    const persistSession = vi.mocked(repository.saveSession).getMockImplementation()!
+    vi.mocked(repository.saveSession).mockImplementation(async (session) => {
+      const attempt = session.runtimeContext?.delegatedWork?.records[0]?.attempts[0]
+      const completingDurableTranscript =
+        !completionSaveRejected &&
+        attempt?.status === 'running' &&
+        session.conversationGraph?.runtimeSegments.some(
+          ({ id, endedAt }) => id === 'runtime-1' && endedAt !== undefined
+        ) &&
+        session.conversationGraph.activities.some(
+          ({ id }) => id === 'agent-runtime:runtime-1:call-1'
+        )
+      if (completingDurableTranscript) {
+        completionSaveRejected = true
+        markCompletionSaveStarted()
+        await completionSaveRejection
+        throw completionError
+      }
+      return persistSession(session)
+    })
+
+    const delegated = work.delegate(caller, { task: 'Initial task', name: 'Initial task' })
+    await expect.poll(() => execution.controls()).toHaveLength(1)
+    const control = execution.control('attempt-1')
+    control.accept()
+    control.emit({ kind: 'runtime', update: createInitialToolUpdate() })
+
+    control.complete('Initial answer')
+    await completionSaveStarted
+    control.emit({ kind: 'runtime', update: createLateToolReplay() })
+    rejectCompletionSave()
+
+    await expect(delegated).resolves.toMatchObject({
+      kind: 'results',
+      children: [
+        {
+          status: 'error',
+          error: { code: 'execution_failure', message: completionError.message }
+        }
+      ]
+    })
+    expect((await readSession()).conversationGraph?.activities).toEqual([
+      expect.objectContaining({
+        id: 'agent-runtime:runtime-1:call-1',
+        runtimeSegmentId: 'runtime-1',
+        status: 'completed',
+        eventIds: ['tool-one']
+      })
+    ])
+  })
+
   it('starts an admitted array against revisioned Session records without sibling conflicts', async () => {
     const { coordinator, readSession } = createHarness()
     const execution = createDeterministicDelegateExecution()


### PR DESCRIPTION
## Problem

A late or replayed ACP runtime update from an already completed Runtime Segment could be staged again during a later child Turn or an error/cancellation fallback. Because persisted Activity identity is segment-scoped and inserts remain strict, the replay could surface as `Activity already exists` and replace the real provider or storage failure.

## Proposed change

- Select runtime updates by the compound `(runtimeSegmentId, promptMessageId)` scope before projecting a Turn transcript.
- Track scopes whose transcript has already been staged so failures in artifact finalization or child-Turn completion cannot stage the same Activity twice.
- Keep fallback staging available for the current open, unstaged scope without weakening strict Activity ownership or merging cross-Segment records.
- Add integration coverage through durable delegated work and Session-backed records.

## Scope and non-goals

This change is limited to delegated runtime transcript selection and fallback staging. It does not change provider execution, ACP notification delivery, Activity identity, Session upsert semantics, renderer copy, or persistence ownership rules.

## Acceptance criteria and validation

TDD red evidence:

- A queued Turn with a late replay reproduced `Activity already exists` before compound-scope selection.
- Provider error and cancellation paths demonstrated that old-Segment replay could replace or pollute the intended terminal outcome.
- A queued-Turn begin/storage failure covered the boundary where the prior scope was already closed.
- A child-Turn completion save failure, after its transcript was durable, failed with `Activity already exists: agent-runtime:runtime-1:call-1` instead of `child turn completion storage unavailable` before the explicit staged-scope state was added.

Final Test Impact Set, run after the last material edit:

- Delegation owner, Session adapter contract, and ACP execution consumer: `npx vitest run src/main/delegation/session-record-adapter.test.ts src/main/delegation/attempt-runtime-transcript.test.ts src/main/delegation/durable-delegated-work.test.ts src/main/delegation/acp-execution.test.ts` — 4 files passed, 150 tests passed.
- Main-process types: `npm run typecheck:node` — passed.
- Changed-file lint: `npx eslint --no-cache src/main/delegation/attempt-runtime-transcript.ts src/main/delegation/delegated-turn-lifecycle.ts src/main/delegation/durable-delegated-work.ts src/main/delegation/session-record-adapter.test.ts` — passed.
- Repository lint required by CONTRIBUTING.md: `npm run lint` — passed.
- Patch integrity: `git diff --check` — passed before commit.

No renderer, schema, migration, package, or platform integration surface changed, so web typecheck, E2E, migration, and packaging lanes were excluded from the local impact set. Exact-head CI remains authoritative for additional platform lanes.

Uncovered risk: transcript persistence is not transactional across every Message and Activity write. If staging itself fails after a partial write, fallback retry behavior remains a separate partial-write problem. This PR only prevents replay after transcript staging has completed successfully; it does not introduce merge/upsert behavior or hide genuine provenance conflicts.

## Review focus

- The staged-scope state is set only after transcript staging succeeds, but before artifact finalization and child-Turn completion.
- A new Turn receives a new compound scope and remains eligible for fallback staging.
- Old Runtime Segment updates never enter a later Turn transcript, and strict Frame/Segment persistence ownership remains intact.

Related issue: none.