### PR TITLE
fix(message-edit): inline edited attachments on resend

### DIFF
--- a/src/main/acp/prompt-content-owner.test.ts
+++ b/src/main/acp/prompt-content-owner.test.ts
@@ -377,6 +377,59 @@ describe('AcpPromptContentOwner', () => {
     expect(finalizeUploads).not.toHaveBeenCalled()
   })
 
+  it('inlines a current Version owned by another Session in the same Project', async () => {
+    const root = await createRoot()
+    const uploads = new UploadRepository(root)
+    const [staged] = await stageUploadFixtures(uploads, {
+      files: [
+        {
+          name: 'measurements.csv',
+          mimeType: 'text/csv',
+          content: Buffer.from('id,value\n1,2\n').toString('base64')
+        }
+      ]
+    })
+    const [sourceOwned] = await uploads.finalizePendingSessionUploads(
+      'source-session',
+      [staged],
+      'default-project'
+    )
+    const currentUpload = {
+      ...sourceOwned,
+      versionId: 'upload-version-source',
+      versionNumber: 1
+    }
+    const finalizeUploads = vi.spyOn(uploads, 'finalizePendingSessionUploads')
+    const owner = new AcpPromptContentOwner({
+      uploadRepository: uploads,
+      fileReferenceResolver: createManagedFileReferenceResolver({ uploads })
+    })
+
+    const result = await owner.prepare({
+      appSessionId: 'target-session',
+      projectId: 'default-project',
+      text: 'analyze the uploaded table',
+      historyImages: [],
+      historyUploads: [],
+      currentUploads: [currentUpload],
+      references: [],
+      codexSkillInputs: [],
+      skillImportEnabled: false
+    })
+
+    expect(finalizeUploads).not.toHaveBeenCalled()
+    expect(contentBlocks(result.content)).toEqual([
+      { type: 'text', text: 'analyze the uploaded table' },
+      expect.objectContaining({
+        type: 'resource',
+        resource: expect.objectContaining({ text: 'id,value\n1,2\n' })
+      })
+    ])
+    expect(result.turnInputs?.uploads.map((upload) => upload.versionId)).toEqual([
+      'upload-version-source'
+    ])
+  })
+
   it('owns cumulative image budget per Session and releases it on resetSession and clear', async () => {
     const root = await createRoot()
     const uploads = new UploadRepository(root)

--- a/src/main/acp/prompt-content-owner.ts
+++ b/src/main/acp/prompt-content-owner.ts
@@ -198,7 +198,8 @@ class AcpPromptContentOwner {
         const stagedHistoryUploads = input.historyUploads.filter(
           (upload) => !upload.versionId && upload.sessionId === PENDING_UPLOAD_SESSION_ID
         )
-        const uploadsToFinalize = [...stagedHistoryUploads, ...input.currentUploads]
+        const stagedCurrentUploads = input.currentUploads.filter((upload) => !upload.versionId)
+        const uploadsToFinalize = [...stagedHistoryUploads, ...stagedCurrentUploads]
         const finalizedUploads =
           uploadsToFinalize.length > 0
             ? await this.options.uploadRepository.finalizePendingSessionUploads(
@@ -348,7 +349,11 @@ class AcpPromptContentOwner {
       { path: attachment.path },
       {
         projectId: input.projectId,
-        ...(isHistoryUpload ? {} : { sessionId: input.appSessionId })
+        ...(isHistoryUpload
+          ? {}
+          : {
+              sessionId: attachment.versionId ? attachment.sessionId : input.appSessionId
+            })
       }
     )
     const { size } = await stat(filePath)

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -6644,7 +6644,7 @@ describe('resendEditedWorkspaceMessage', () => {
     expect(runtime.sendPrompt.mock.calls[0]?.[3]).toEqual(['skill-forecast'])
   })
 
-  it('routes a cross-session source Upload Version through history after branching', async () => {
+  it('routes a cross-session source Upload Version as a current attachment after branching', async () => {
     const sourceUpload = {
       id: 'upload-source',
       versionId: 'upload-version-source',
@@ -6700,14 +6700,14 @@ describe('resendEditedWorkspaceMessage', () => {
 
     expect(resent).toBe(true)
     expect(finalizeSession).not.toHaveBeenCalled()
-    expect(runtime.sendPrompt.mock.calls[0]?.[2]).toEqual([])
-    expect(runtime.sendPrompt.mock.calls[0]?.[6]).toEqual([
+    expect(runtime.sendPrompt.mock.calls[0]?.[2]).toEqual([
       expect.objectContaining({
         id: 'upload-source',
         versionId: 'upload-version-source',
         path: 'upload-version:default-project/source-session/upload-version-source'
       })
     ])
+    expect(runtime.sendPrompt.mock.calls[0]?.[6]).toBeUndefined()
 
     const editedSession = useSessionStore.getState().sessions[0]
     expect(editedSession.messages.at(-1)).toMatchObject({
@@ -6778,6 +6778,10 @@ describe('resendEditedWorkspaceMessage', () => {
     ).resolves.toBe(true)
     await flushRuntimeTasks()
 
+    expect(runtime.sendPrompt.mock.calls[0]?.[2]?.map((attachment) => attachment.id)).toEqual([
+      'edited-0',
+      'edited-1'
+    ])
     expect(runtime.sendPrompt.mock.calls[0]?.[6]?.map((attachment) => attachment.id)).toEqual([
       'history-2',
       'history-3',
@@ -6786,9 +6790,7 @@ describe('resendEditedWorkspaceMessage', () => {
       'history-6',
       'history-7',
       'history-8',
-      'history-9',
-      'edited-0',
-      'edited-1'
+      'history-9'
     ])
     const editedSession = useSessionStore.getState().sessions[0]
     expect(editedSession.messages.at(-1)?.uploads).toHaveLength(editedUploads.length)
@@ -6867,10 +6869,10 @@ describe('resendEditedWorkspaceMessage', () => {
     ).resolves.toBe(true)
     await flushRuntimeTasks()
 
-    expect(runtime.sendPrompt.mock.calls[0]?.[2]).toEqual([])
-    expect(runtime.sendPrompt.mock.calls[0]?.[6]).toEqual([
+    expect(runtime.sendPrompt.mock.calls[0]?.[2]).toEqual([
       expect.objectContaining({ id: 'notes', name: 'notes.txt' })
     ])
+    expect(runtime.sendPrompt.mock.calls[0]?.[6]).toBeUndefined()
     expect(useSessionStore.getState().sessions[0].messages.at(-1)?.uploads).toHaveLength(2)
   })
 
@@ -6938,6 +6940,10 @@ describe('resendEditedWorkspaceMessage', () => {
     expect(finalizeSession).toHaveBeenCalledWith(
       expect.objectContaining({ sessionId: 'source-session' })
     )
+    expect(runtime.sendPrompt.mock.calls[0]?.[2]).toEqual([
+      expect.objectContaining({ versionId: 'legacy-upload-version-1' })
+    ])
+    expect(runtime.sendPrompt.mock.calls[0]?.[6]).toBeUndefined()
 
     const editedSession = useSessionStore.getState().sessions[0]
     const originalRevision = editedSession.conversationGraph?.messages.find(

--- a/src/renderer/src/lib/acp/workspace-runtime-attachment-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-attachment-owner.ts
@@ -67,7 +67,7 @@ export const filterWorkspaceHistoryAttachments = (
       )
     : attachments
 
-export const mergeWorkspaceHistoryAttachments = ({
+export const partitionWorkspacePromptAttachments = ({
   historyAttachments = [],
   latestAttachments,
   supportsImageInput,
@@ -77,13 +77,19 @@ export const mergeWorkspaceHistoryAttachments = ({
   latestAttachments: UploadedAttachment[]
   supportsImageInput?: boolean
   supportsImageRelay?: boolean
-}): UploadedAttachment[] => {
-  const filteredLatest = filterWorkspaceHistoryAttachments(
+}): {
+  historyAttachments?: UploadedAttachment[]
+  currentAttachments: UploadedAttachment[]
+} => {
+  const currentAttachments = filterWorkspaceHistoryAttachments(
     latestAttachments,
     supportsImageInput,
     supportsImageRelay
   )
-  const historyLimit = Math.max(0, MAX_COMPOSER_ATTACHMENTS - filteredLatest.length)
-  const latestHistory = historyLimit > 0 ? historyAttachments.slice(-historyLimit) : []
-  return [...latestHistory, ...filteredLatest]
+  const historyLimit = Math.max(0, MAX_COMPOSER_ATTACHMENTS - currentAttachments.length)
+  const retainedHistory = historyLimit > 0 ? historyAttachments.slice(-historyLimit) : []
+  return {
+    ...(retainedHistory.length > 0 ? { historyAttachments: retainedHistory } : {}),
+    currentAttachments
+  }
 }

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -30,7 +30,7 @@ import {
 } from './workspace-runtime-session-branch-owner'
 import {
   finalizeWorkspaceAttachments,
-  mergeWorkspaceHistoryAttachments
+  partitionWorkspacePromptAttachments
 } from './workspace-runtime-attachment-owner'
 import type { useAcpRuntime } from './useAcpRuntime'
 
@@ -547,26 +547,25 @@ const sendWorkspaceMessage = async (
             : {})
         }
       : undefined
+    const promptMedia =
+      input.truncateFromMessageId && promptAttachments.length > 0
+        ? partitionWorkspacePromptAttachments({
+            historyAttachments: replay?.historyAttachments,
+            latestAttachments: promptAttachments,
+            supportsImageInput: input.supportsImageInput,
+            supportsImageRelay: input.supportsImageRelay
+          })
+        : undefined
     dispatchPrompt(runtime, {
       sessionId,
       messageId: appended.messageId,
       content,
-      attachments: input.truncateFromMessageId ? [] : promptAttachments,
+      attachments: promptMedia?.currentAttachments ?? promptAttachments,
       forcedSkillIds: input.forcedSkillIds,
       referencedArtifacts: input.referencedArtifacts,
-      // Edits reuse Message-owned Versions, which resolve through the project-scoped history path.
-      replay:
-        input.truncateFromMessageId && promptAttachments.length > 0
-          ? {
-              ...replay,
-              historyAttachments: mergeWorkspaceHistoryAttachments({
-                historyAttachments: replay?.historyAttachments,
-                latestAttachments: promptAttachments,
-                supportsImageInput: input.supportsImageInput,
-                supportsImageRelay: input.supportsImageRelay
-              })
-            }
-          : replay,
+      replay: promptMedia
+        ? { ...replay, historyAttachments: promptMedia.historyAttachments }
+        : replay,
       continuation,
       turnIntent: input.turnIntent,
       accepted: () => prepared.acceptPrompt(appended.messageId)


### PR DESCRIPTION
## Problem

PR #1511 preserved Upload Version identity and edit-card pills, but routed the
edited Message's files through `historyAttachments`. Main-process prompt content
treats historical non-image files as descriptors (`resource_link` / local-file
notice). Editing and resending a Message that originally inlined CSV, text, or
PDF therefore sent a weaker prompt than the first turn.

## Proposed change

- Keep older replay files on the history path (descriptor-only, Composer-capped).
- Dispatch the edited Message's Composer-valid attachments as current uploads so
  they keep current-turn inlining and Skill-package eligibility.
- Resolve Versioned current uploads by their immutable owning Session instead of
  the active Session, so Branch-in-new-Session edits still resolve.
- Skip re-finalization of current uploads that already have a Version identity.

## Scope and non-goals

- No UI change. Attachment pills remain read-only during edit.
- No new persisted fields, enums, Session JSON shape, or Prisma migration.
- Does not add attachment add/remove controls on the edit card.
- Does not add empty-text edit with attachments-only (composer already allows
  that on new sends; listed separately as a product decision).

## Compatibility, state, and persistence

- No historical data migration.
- No new lifecycle or enum values.
- Session JSON already stores the Version on the edited Message from #1511.
  This change only affects prompt bytes sent to the provider.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- Edited resend places current vs history attachments correctly, keeps the
  Composer cap, filters text-only images, and upgrades legacy source uploads
  -> `npm run test:module -- workspace_runtime` -> 325 passed.
- Versioned current upload owned by another Session in the same Project is
  inlined without re-finalization; image-input contract coverage remains green
  -> `npm run test:module -- image_input_compatibility` -> 242 passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Main types -> `npm run typecheck:node` -> passed.
- Lint -> `npm run lint` -> passed with no findings.

Per maintainer request, the local full `npm test` suite was not run; exact-head
PR Gate CI remains the authority. Web and Electron share the changed
renderer/runtime path. Prompt content is prepared on the shared ACP
`sendPrompt` contract before framework adapters, so no framework-specific ACP
behavior changes.

## Review focus

- Current vs history split after edit: inlining for the edited turn, descriptors
  for older replay.
- Versioned current upload resolution using `attachment.sessionId`.
- Empty partitioned history must not fall back to the uncapped original replay.

## Uncovered risk

- No authenticated Web UI visual pass. This change does not alter the edit-card
  DOM; coverage is prompt dispatch and prompt-content unit tests.