### PR TITLE
fix(message-stream): avoid reserving space before tool calls

### DIFF
--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -34,6 +34,8 @@ const QUEUE_GATE_PROMPT = 'Hold the queue until the reveal finishes.'
 const TOOL_ORDER_PROMPT = 'Run the ordered slow tool journey.'
 const TOOL_LAYOUT_SHIFT_PROMPT = 'Run the tool layout stability journey.'
 const TOOL_STATUS_LAYOUT_SHIFT_PROMPT = 'Run the status-bearing layout stability journey.'
+const BUFFERED_TEXT_TOOL_LAYOUT_SHIFT_PROMPT =
+  'Run the buffered text tool layout stability journey.'
 const RELIABLE_FAIRNESS_USER_PROMPT = 'Run the concurrent real user prompt.'
 const DELEGATION_INHERITED_SPECIALIST_PROMPT =
   'Run the production inherited Specialist delegation journey.'
@@ -487,7 +489,42 @@ if (process.argv.includes('--version')) {
 
       let reply = 'Deterministic reply: Summarize the deterministic fixture.'
       try {
-        if (
+        if (prompt.includes(BUFFERED_TEXT_TOOL_LAYOUT_SHIFT_PROMPT)) {
+          const intentMessageId = `e2e-message-${nextMessageId++}`
+          await context.client.notify(acp.methods.client.session.update, {
+            sessionId: context.params.sessionId,
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              messageId: intentMessageId,
+              content: { type: 'text', text: 'Next step.' }
+            }
+          })
+          // Leave the text fragment as the trailing item long enough for its presentation buffer
+          // to drain while the Thinking row remains visible, matching a real model that pauses
+          // before issuing its tool call.
+          await delay(2_000)
+          await context.client.notify(acp.methods.client.session.update, {
+            sessionId: context.params.sessionId,
+            update: {
+              sessionUpdate: 'tool_call',
+              toolCallId: 'e2e-buffered-layout-tool',
+              title: 'Buffered layout probe',
+              kind: 'other',
+              status: 'in_progress'
+            }
+          })
+          await delay(2_000)
+          await context.client.notify(acp.methods.client.session.update, {
+            sessionId: context.params.sessionId,
+            update: {
+              sessionUpdate: 'tool_call_update',
+              toolCallId: 'e2e-buffered-layout-tool',
+              title: 'Buffered layout probe',
+              status: 'completed'
+            }
+          })
+          reply = ''
+        } else if (
           prompt.includes(TOOL_LAYOUT_SHIFT_PROMPT) ||
           prompt.includes(TOOL_STATUS_LAYOUT_SHIFT_PROMPT)
         ) {

--- a/e2e/message-tool-layout-stability.spec.ts
+++ b/e2e/message-tool-layout-stability.spec.ts
@@ -7,6 +7,8 @@ const USER_MESSAGE = 'Summarize the deterministic fixture.'
 const AGENT_REPLY = 'Deterministic reply: Summarize the deterministic fixture.'
 const TOOL_LAYOUT_SHIFT_PROMPT = 'Run the tool layout stability journey.'
 const TOOL_STATUS_LAYOUT_SHIFT_PROMPT = 'Run the status-bearing layout stability journey.'
+const BUFFERED_TEXT_TOOL_LAYOUT_SHIFT_PROMPT =
+  'Run the buffered text tool layout stability journey.'
 
 test.use({ windowMode: 'normal' })
 
@@ -91,3 +93,78 @@ for (const scenario of cases) {
     await runLayoutStabilityJourney(app, scenario.prompt, scenario.agentStatus)
   })
 }
+
+test('keeps a running tool stationary while one line of buffered Markdown finishes rendering', async ({
+  app
+}) => {
+  let page = await app.completeOnboarding()
+  page = await app.configureFakeAgent()
+
+  await page.getByRole('button', { name: 'New project' }).click()
+  const dialog = page.getByRole('dialog', { name: 'New project' })
+  await dialog.getByLabel('Name').fill(PROJECT_NAME)
+  await dialog.getByRole('button', { name: 'Create project' }).click()
+  await expect(page.getByRole('heading', { name: 'New conversation' })).toBeVisible()
+
+  const conversation = page.getByRole('region', { name: 'Conversation' })
+  const textbox = page.getByRole('textbox', { name: 'Ask anything' })
+
+  await textbox.fill(USER_MESSAGE)
+  await page.getByRole('button', { name: 'Send message' }).click()
+  await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
+
+  await textbox.fill(BUFFERED_TEXT_TOOL_LAYOUT_SHIFT_PROMPT)
+  await page.getByRole('button', { name: 'Send message' }).click()
+
+  const bufferedMessage = conversation.getByText('Next step.', { exact: true })
+  const toolGroup = conversation.locator(
+    '[data-message-id="activity-group-e2e-buffered-layout-tool"]'
+  )
+
+  await expect(bufferedMessage).toBeVisible()
+  await expect(toolGroup).not.toBeVisible()
+  await expect(conversation.getByText('Thinking', { exact: true })).toBeVisible()
+
+  const bufferedGeometry = await bufferedMessage.evaluate((element) => {
+    const markdown = element.closest<HTMLElement>('.agent-markdown-root')
+    const surface = markdown?.parentElement
+    if (!markdown || !surface) throw new Error('Could not resolve the Agent message surface.')
+    return {
+      markdownHeight: markdown.getBoundingClientRect().height,
+      surfaceHeight: surface.getBoundingClientRect().height
+    }
+  })
+  expect(bufferedGeometry.surfaceHeight - bufferedGeometry.markdownHeight, bufferedGeometry).toBe(0)
+
+  await expect(toolGroup).toBeVisible()
+
+  const tops = await toolGroup.evaluate(
+    (element) =>
+      new Promise<number[]>((resolve) => {
+        const observations: number[] = []
+        const startedAt = performance.now()
+        const sample = (): void => {
+          observations.push(element.getBoundingClientRect().top)
+          if (performance.now() - startedAt >= 1_500) {
+            resolve(observations)
+            return
+          }
+          requestAnimationFrame(sample)
+        }
+        requestAnimationFrame(sample)
+      })
+  )
+
+  await expect(bufferedMessage).toBeVisible()
+
+  const excursion = Math.max(...tops) - Math.min(...tops)
+  expect(
+    excursion,
+    JSON.stringify({
+      firstTop: tops[0],
+      minimumTop: Math.min(...tops),
+      maximumTop: Math.max(...tops),
+      finalTop: tops.at(-1)
+    })
+  ).toBeLessThanOrEqual(2)
+})

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -122,6 +122,9 @@ type WorkspaceMessageItemProps = {
   onPresentationChange?: (messageId: string, presenting: boolean) => void
   presentationSourceOpen?: boolean
   presentationAnimateOnMount?: boolean
+  // A trailing buffered reply can reserve the loading-row geometry it replaces. When another
+  // live row remains below it, the message keeps only its natural text-line height.
+  reserveLoadingRowHeight?: boolean
   // True only while this application-authored correction is the current live Agent prompt and no
   // Agent response has appeared. Historical/reloaded rows stay settled and motionless.
   reviewerCorrectionActive?: boolean
@@ -1121,6 +1124,7 @@ const WorkspaceMessageItemImpl = ({
   onPresentationChange,
   presentationSourceOpen,
   presentationAnimateOnMount = true,
+  reserveLoadingRowHeight = true,
   reviewerCorrectionActive = false
 }: WorkspaceMessageItemProps): React.JSX.Element => {
   const { t } = useTranslation()
@@ -1450,9 +1454,9 @@ const WorkspaceMessageItemImpl = ({
             className={cn(
               assistantMessageSurfaceClassName,
               'select-text overflow-visible',
-              // Match the tallest loading row while initial content is buffered so replacing it
-              // cannot collapse the workspace scroll extent. Side chat keeps its natural geometry.
-              isAssistantPresenting && 'min-h-14'
+              // Reserve the tallest loading-row geometry only when this reply replaces that row.
+              // If Thinking or a live tool remains below, the buffered message stays at line height.
+              isAssistantPresenting && (reserveLoadingRowHeight ? 'min-h-14' : 'min-h-5')
             )}
           >
             {message.content ? (
@@ -1555,7 +1559,8 @@ const areWorkspaceMessageItemPropsEqual = (
   areRevisionNavigationsEqual(previous.revisionNavigation, next.revisionNavigation) &&
   previous.onPresentationChange === next.onPresentationChange &&
   (previous.presentationSourceOpen ?? true) === (next.presentationSourceOpen ?? true) &&
-  (previous.presentationAnimateOnMount ?? true) === (next.presentationAnimateOnMount ?? true)
+  (previous.presentationAnimateOnMount ?? true) === (next.presentationAnimateOnMount ?? true) &&
+  (previous.reserveLoadingRowHeight ?? true) === (next.reserveLoadingRowHeight ?? true)
 
 const WorkspaceMessageItem = memo(WorkspaceMessageItemImpl, areWorkspaceMessageItemPropsEqual)
 WorkspaceMessageItem.displayName = 'WorkspaceMessageItem'

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -1148,12 +1148,20 @@ const WorkspaceMessageScrollerImpl = ({
                       !respondedPromptMessageIds.has(item.message.id)
                   }
                   if (item.message.role === 'agent') {
+                    const nextConversationItem = conversationItems[itemIndex + 1]
+                    const hasFollowingLiveActivity =
+                      nextConversationItem?.type === 'activity' ||
+                      nextConversationItem?.type === 'activity-group'
                     messageItemProps.onPresentationChange = handleMessagePresentationChange
                     messageItemProps.presentationSourceOpen =
                       itemIndex === conversationItems.length - 1
                     messageItemProps.presentationAnimateOnMount =
                       presentationScopeRemainedVisible &&
                       !visibleMessageSnapshot.messageIds.has(item.message.id)
+                    messageItemProps.reserveLoadingRowHeight =
+                      !hasFollowingLiveActivity &&
+                      !isResumingSession &&
+                      agentLoadingPhase === 'hidden'
                   }
 
                   return (

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -1149,7 +1149,9 @@ const WorkspaceMessageScrollerImpl = ({
                   }
                   if (item.message.role === 'agent') {
                     const nextConversationItem = conversationItems[itemIndex + 1]
-                    const hasFollowingLiveActivity =
+                    // Completed activity rows remain visible too. Any following activity row means
+                    // this message is not replacing the trailing loading row and needs no reserve.
+                    const hasFollowingActivityRow =
                       nextConversationItem?.type === 'activity' ||
                       nextConversationItem?.type === 'activity-group'
                     messageItemProps.onPresentationChange = handleMessagePresentationChange
@@ -1159,7 +1161,7 @@ const WorkspaceMessageScrollerImpl = ({
                       presentationScopeRemainedVisible &&
                       !visibleMessageSnapshot.messageIds.has(item.message.id)
                     messageItemProps.reserveLoadingRowHeight =
-                      !hasFollowingLiveActivity &&
+                      !hasFollowingActivityRow &&
                       !isResumingSession &&
                       agentLoadingPhase === 'hidden'
                   }


### PR DESCRIPTION
## Problem

When a short Agent text fragment streamed before a tool call, the message surface kept the 56px loading-row minimum height even while the Thinking row was still visible. This left a 36px blank area below the text and made the subsequent tool row jump upward when presentation finished.

## Proposed change

- Reserve loading-row height only when a buffered reply actually replaces the loading row.
- Keep the message at natural line height while Thinking or a live tool remains below it.
- Add an Electron regression that pauses between a one-line text fragment and a tool call, asserts there is no reserved gap, and measures the tool row for movement.

## Scope and non-goals

- Renderer layout and its deterministic OpenCode E2E fixture only.
- No changes to streaming cadence, provider event timing, persisted data, state enums, or historical-session compatibility.
- Follow-up to #1476; the completed-tool-to-final-reply reservation remains covered and unchanged.

## Acceptance criteria and validation

All commands below ran after the last material edit.

- Visible streamed text with Thinking below has no reserved gap -> focused Electron regression -> failed 3/3 before the fix with a 36px gap; passed 3/3 after the fix.
- Running tool remains stationary while the one-line buffer settles -> npm run build:e2e; npm run test:e2e -- e2e/message-tool-layout-stability.spec.ts -> 3 tests passed, including both existing final-reply cases.
- Workspace owner behavior -> npm run test:module -- workspace_page -> 25 files, 459 tests passed.
- Direct message/scroller consumers -> npx vitest run WorkspaceMessageScroller.render.test.tsx WorkspaceMessageScroller.interaction.test.tsx WorkspaceMessageItem.actions.test.tsx WorkspaceMessageItem.mentions.test.tsx -> 4 files, 159 tests passed.
- Renderer types -> npm run typecheck:web -> passed.
- Lint and formatting -> npm run lint and focused Prettier check -> passed.

The full npm test suite was intentionally not run locally; PR Gate is authoritative for complete portable and platform coverage. Windows-specific rendering remains covered only by CI.

## Review focus

- Whether reserveLoadingRowHeight matches the actual loading-row visibility boundary.
- Whether the E2E timing fixture represents the text-pause-tool sequence without overfitting provider behavior.
