### PR TITLE
fix(session-persistence): log deletion failure phases

### DIFF
--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -570,6 +570,7 @@ describe('Session persistence coordinator architecture', () => {
         'assertArchiveMutable',
         'computeJobs',
         'fileIndex',
+        'log',
         'notifyFilesChanged',
         'notifySessionsDeleted',
         'provenance',

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -5567,6 +5567,13 @@ describe('SessionPersistenceCoordinator', () => {
       },
       fileIndex: {
         restoreSession: vi.fn().mockRejectedValue(new Error('file index unavailable'))
+      },
+      computeJobs: {
+        prepareSessionJobDeletion: vi.fn(async () => undefined),
+        commitSessionJobDeletion: vi.fn(async () => undefined),
+        prepareProjectJobDeletion: vi.fn(async () => undefined),
+        commitProjectJobDeletion: vi.fn(async () => undefined),
+        abortSessionJobDeletion: vi.fn(async () => undefined)
       }
     })
 

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -5438,6 +5438,153 @@ describe('SessionPersistenceCoordinator', () => {
     expect(computeJobs.abortSessionJobDeletion).toHaveBeenCalledWith('project-1', 'session-1')
   })
 
+  it('logs the privacy-safe phase when Session authority deletion fails', async () => {
+    const log = createTestLogger()
+    const coordinator = createDeletionDiagnosticCoordinator(log, {
+      repository: {
+        deleteSession: vi
+          .fn()
+          .mockRejectedValue(
+            new Error('database locked at C:\\Users\\example\\private-study\\open-science.db')
+          )
+      }
+    })
+
+    await expect(coordinator.deleteSession('project-1', 'session-1')).rejects.toThrow(
+      'database locked'
+    )
+    expect(log.error).toHaveBeenCalledWith(
+      'operation failed',
+      expect.objectContaining({
+        operation: 'session-persistence-deletion',
+        operationId: expect.any(String),
+        phase: 'delete-authority',
+        failurePhase: 'delete-authority',
+        outcome: 'failed',
+        errorCategory: 'error',
+        durationMs: expect.any(Number)
+      })
+    )
+    const diagnosticPayload = JSON.stringify(log.error.mock.calls)
+    expect(diagnosticPayload).not.toContain('database locked')
+    expect(diagnosticPayload).not.toContain('private-study')
+    expect(diagnosticPayload).not.toContain('open-science.db')
+  })
+
+  it('distinguishes Session deletion participant failure phases', async () => {
+    const failure = (): Promise<never> => Promise.reject(new Error('participant unavailable'))
+    const session = createSession()
+    const computeJobs = (overrides: {
+      prepareSessionJobDeletion?: () => Promise<void>
+      commitSessionJobDeletion?: () => Promise<void>
+    }): NonNullable<ConstructorParameters<typeof SessionPersistenceCoordinator>[8]> => ({
+      prepareSessionJobDeletion: vi.fn(
+        overrides.prepareSessionJobDeletion ?? (async () => undefined)
+      ),
+      commitSessionJobDeletion: vi.fn(
+        overrides.commitSessionJobDeletion ?? (async () => undefined)
+      ),
+      prepareProjectJobDeletion: vi.fn(async () => undefined),
+      commitProjectJobDeletion: vi.fn(async () => undefined)
+    })
+    const cases: Array<{ phase: string; overrides: DeletionDiagnosticOverrides }> = [
+      {
+        phase: 'prepare-compute-cleanup',
+        overrides: { computeJobs: computeJobs({ prepareSessionJobDeletion: failure }) }
+      },
+      {
+        phase: 'load-authority',
+        overrides: { repository: { loadSessionWithDiagnostics: vi.fn(failure) } }
+      },
+      {
+        phase: 'prepare-upload-cleanup',
+        overrides: {
+          repository: {
+            loadSessionWithDiagnostics: vi.fn(async () => ({ status: 'found' as const, session }))
+          },
+          uploads: { upgradeLegacySessionUploads: vi.fn(failure) }
+        }
+      },
+      {
+        phase: 'prepare-provenance',
+        overrides: {
+          repository: {
+            loadSessionWithDiagnostics: vi.fn(async () => ({ status: 'found' as const, session }))
+          },
+          provenance: { prepareSessionDeletion: vi.fn(failure) }
+        }
+      },
+      {
+        phase: 'soft-delete-file-index',
+        overrides: {
+          repository: {
+            loadSessionWithDiagnostics: vi.fn(async () => ({ status: 'found' as const, session }))
+          },
+          fileIndex: { softDeleteSession: vi.fn(failure) }
+        }
+      },
+      {
+        phase: 'commit-compute-cleanup',
+        overrides: { computeJobs: computeJobs({ commitSessionJobDeletion: failure }) }
+      },
+      {
+        phase: 'complete-provenance',
+        overrides: {
+          repository: {
+            loadSessionWithDiagnostics: vi.fn(async () => ({ status: 'found' as const, session }))
+          },
+          provenance: { completeSessionDeletion: vi.fn(failure) }
+        }
+      }
+    ]
+
+    for (const testCase of cases) {
+      const log = createTestLogger()
+      await expect(
+        createDeletionDiagnosticCoordinator(log, testCase.overrides).deleteSession(
+          'project-1',
+          'session-1'
+        )
+      ).rejects.toThrow('participant unavailable')
+      expect(log.error).toHaveBeenCalledWith(
+        'operation failed',
+        expect.objectContaining({
+          operation: 'session-persistence-deletion',
+          failurePhase: testCase.phase,
+          outcome: 'failed'
+        })
+      )
+    }
+  })
+
+  it('logs the failed recovery phase without losing the original deletion phase', async () => {
+    const session = createSession()
+    const log = createTestLogger()
+    const coordinator = createDeletionDiagnosticCoordinator(log, {
+      repository: {
+        loadSessionWithDiagnostics: vi.fn(async () => ({ status: 'found' as const, session })),
+        deleteSession: vi.fn().mockRejectedValue(new Error('authority unavailable'))
+      },
+      fileIndex: {
+        restoreSession: vi.fn().mockRejectedValue(new Error('file index unavailable'))
+      }
+    })
+
+    await expect(coordinator.deleteSession('project-1', 'session-1')).rejects.toThrow(
+      'file index unavailable'
+    )
+    expect(log.error).toHaveBeenCalledWith(
+      'operation failed',
+      expect.objectContaining({
+        operation: 'session-persistence-deletion',
+        phase: 'delete-authority',
+        failurePhase: 'delete-authority',
+        recoveryPhase: 'restore-file-index',
+        outcome: 'failed'
+      })
+    )
+  })
+
   it('keeps Session authority deleted when post-authority Compute cleanup fails', async () => {
     const session = createSession()
     const repository = createSessionRepository({
@@ -5627,6 +5774,30 @@ const createProvenancePersistence = (
   abortSessionDeletion: vi.fn().mockResolvedValue(undefined),
   ...overrides
 })
+
+type DeletionDiagnosticOverrides = {
+  repository?: Partial<SessionMutationRepository>
+  fileIndex?: Partial<SessionFileIndex>
+  provenance?: Partial<SessionProvenancePersistence>
+  uploads?: ConstructorParameters<typeof SessionPersistenceCoordinator>[4]
+  computeJobs?: ConstructorParameters<typeof SessionPersistenceCoordinator>[8]
+}
+
+const createDeletionDiagnosticCoordinator = (
+  log: Logger,
+  overrides: DeletionDiagnosticOverrides = {}
+): SessionPersistenceCoordinator =>
+  new SessionPersistenceCoordinator(
+    createSessionRepository(overrides.repository),
+    createFileIndex(overrides.fileIndex),
+    undefined,
+    overrides.provenance ? createProvenancePersistence(overrides.provenance) : undefined,
+    overrides.uploads,
+    undefined,
+    undefined,
+    log,
+    overrides.computeJobs
+  )
 
 const createDeferred = <T>(): { promise: Promise<T>; resolve: (value: T) => void } => {
   let resolve!: (value: T) => void

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -243,6 +243,7 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
       provenance,
       uploads,
       computeJobs,
+      log,
       assertArchiveMutable: (projectId, sessionId) => {
         if (this.deletedProjects.has(projectId)) {
           throw new Error('Cannot archive a Session whose project has been deleted.')
@@ -983,7 +984,6 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
     }
   }
 }
-
 const sessionKey = (projectId: string, sessionId: string): string => `${projectId}:${sessionId}`
 
 export { SessionPersistenceCoordinator, SessionRuntimeContextRevisionConflictError }

--- a/src/main/session-persistence/deletion-owner.ts
+++ b/src/main/session-persistence/deletion-owner.ts
@@ -425,6 +425,8 @@ class SessionPersistenceDeletionOwner {
       let recoveryPhase: string | undefined
       try {
         if (!jsonDeleted) {
+          let recoveryError: unknown
+          let recoveryFailed = false
           try {
             if (receipt.kind === 'retained') {
               recoveryPhase = 'abort-provenance'
@@ -434,12 +436,20 @@ class SessionPersistenceDeletionOwner {
               recoveryPhase = 'restore-file-index'
               await this.fileIndex.restoreSession(projectId, sessionId, token)
             }
-          } finally {
-            if (computeJobsPrepared) {
-              recoveryPhase = 'abort-compute-cleanup'
+          } catch (restoreError) {
+            recoveryError = restoreError
+            recoveryFailed = true
+          }
+          if (computeJobsPrepared) {
+            try {
               await this.computeJobs?.abortSessionJobDeletion?.(projectId, sessionId)
+            } catch (computeRestoreError) {
+              recoveryPhase = 'abort-compute-cleanup'
+              recoveryError = computeRestoreError
+              recoveryFailed = true
             }
           }
+          if (recoveryFailed) throw recoveryError
         } else {
           this.fileIndex.markReconciliationIncomplete()
         }

--- a/src/main/session-persistence/deletion-owner.ts
+++ b/src/main/session-persistence/deletion-owner.ts
@@ -10,6 +10,8 @@ import type {
 } from '../../shared/session-persistence'
 import type { SessionDeletionReceipt } from '../artifacts/provenance-message-snapshot'
 import type { ManagedFileSoftDeleteToken } from '../project-files/repository'
+import type { Logger } from '../logger'
+import { startDiagnosticOperation } from '../diagnostics/operation'
 import {
   OrphanLegacyUploadAuthorityMissingError,
   UnsafeLegacyUploadResidualError
@@ -98,6 +100,7 @@ type SessionPersistenceDeletionOwnerOptions = {
   provenance?: SessionDeletionProvenance
   uploads?: SessionDeletionUploads
   computeJobs?: ComputeJobDeletionParticipant
+  log: Logger
   assertArchiveMutable(projectId: string, sessionId: string): void
   notifyFilesChanged(event: ProjectFilesChangedEvent): void
   notifySessionsDeleted(sessionIds: string[]): Promise<void>
@@ -129,6 +132,7 @@ class SessionPersistenceDeletionOwner {
   private readonly provenance: SessionDeletionProvenance | undefined
   private readonly uploads: SessionDeletionUploads | undefined
   private readonly computeJobs: ComputeJobDeletionParticipant | undefined
+  private readonly log: Logger
   private readonly assertArchiveMutable: (projectId: string, sessionId: string) => void
   private readonly notifyFilesChanged: (event: ProjectFilesChangedEvent) => void
   private readonly notifySessionsDeleted: (sessionIds: string[]) => Promise<void>
@@ -140,6 +144,7 @@ class SessionPersistenceDeletionOwner {
     this.provenance = options.provenance
     this.uploads = options.uploads
     this.computeJobs = options.computeJobs
+    this.log = options.log
     this.assertArchiveMutable = options.assertArchiveMutable
     this.notifyFilesChanged = options.notifyFilesChanged
     this.notifySessionsDeleted = options.notifySessionsDeleted
@@ -365,6 +370,10 @@ class SessionPersistenceDeletionOwner {
     projectId: string,
     sessionId: string
   ): Promise<SessionDeletionReceipt['kind']> {
+    const operation = startDiagnosticOperation(this.log, {
+      operation: 'session-persistence-deletion'
+    })
+    let failurePhase = 'load-authority'
     let token: ManagedFileSoftDeleteToken | undefined
     let receipt: SessionDeletionReceipt = { kind: 'ordinary', projectId, sessionId }
     let jsonDeleted = false
@@ -373,36 +382,61 @@ class SessionPersistenceDeletionOwner {
 
     try {
       if (this.computeJobs) {
+        failurePhase = 'prepare-compute-cleanup'
+        operation.phase(failurePhase)
         await this.computeJobs.prepareSessionJobDeletion(projectId, sessionId)
         computeJobsPrepared = true
       }
+      failurePhase = 'load-authority'
+      operation.phase(failurePhase)
       const loadedSession = await this.repository.loadSessionWithDiagnostics(projectId, sessionId)
       if (loadedSession.status === 'unreadable') {
         throw new Error('Cannot delete a Session whose durable JSON is unreadable.')
       }
       session = loadedSession.status === 'found' ? loadedSession.session : undefined
-      if (session && this.uploads)
+      if (session && this.uploads) {
+        failurePhase = 'prepare-upload-cleanup'
+        operation.phase(failurePhase)
         session = await this.prepareSessionUploadsForTerminalDelete(session)
+      }
       if (session && this.provenance) {
+        failurePhase = 'prepare-provenance'
+        operation.phase(failurePhase)
         receipt = await this.provenance.prepareSessionDeletion(session)
       }
       if (receipt.kind === 'ordinary') {
+        failurePhase = 'soft-delete-file-index'
+        operation.phase(failurePhase)
         token = await this.fileIndex.softDeleteSession(projectId, sessionId)
       }
+      failurePhase = 'delete-authority'
+      operation.phase(failurePhase)
       await this.repository.deleteSession(projectId, sessionId)
       jsonDeleted = true
       if (this.computeJobs) {
+        failurePhase = 'commit-compute-cleanup'
+        operation.phase(failurePhase)
         await this.computeJobs.commitSessionJobDeletion(projectId, sessionId)
       }
+      failurePhase = 'complete-provenance'
+      operation.phase(failurePhase)
       await this.provenance?.completeSessionDeletion(receipt)
     } catch (error) {
+      let recoveryPhase: string | undefined
       try {
         if (!jsonDeleted) {
           try {
-            if (receipt.kind === 'retained') await this.provenance?.abortSessionDeletion(receipt)
-            if (token) await this.fileIndex.restoreSession(projectId, sessionId, token)
+            if (receipt.kind === 'retained') {
+              recoveryPhase = 'abort-provenance'
+              await this.provenance?.abortSessionDeletion(receipt)
+            }
+            if (token) {
+              recoveryPhase = 'restore-file-index'
+              await this.fileIndex.restoreSession(projectId, sessionId, token)
+            }
           } finally {
             if (computeJobsPrepared) {
+              recoveryPhase = 'abort-compute-cleanup'
               await this.computeJobs?.abortSessionJobDeletion?.(projectId, sessionId)
             }
           }
@@ -411,11 +445,14 @@ class SessionPersistenceDeletionOwner {
         }
       } catch (restoreError) {
         this.fileIndex.markReconciliationIncomplete()
+        operation.fail(restoreError, { failurePhase, recoveryPhase })
         throw restoreError
       }
+      operation.fail(error, { failurePhase })
       throw error
     }
 
+    operation.complete({ receiptKind: receipt.kind })
     return receipt.kind
   }
 


### PR DESCRIPTION
## Problem

A user can confirm Session deletion in the renderer, but durable deletion can fail after the runtime detaches. The current main.log collapses every persistence participant into phase=delete-persistence with only errorCategory=error, so an external log cannot distinguish Session authority, Upload, provenance, file-index, or Compute cleanup failures.

## Proposed change

Instrument the existing SessionPersistenceDeletionOwner transaction with the shared privacy-safe diagnostic operation helper.

- Record stable primary failurePhase values for Compute preparation/commit, authority loading/deletion, Upload cleanup, provenance preparation/completion, and file-index soft deletion.
- Preserve the original failurePhase and add recoveryPhase only when provenance, file-index, or Compute compensation itself fails.
- Keep project/session identifiers, raw error messages, and filesystem paths out of diagnostic records.
- Keep deletion ordering, return values, rollback behavior, and renderer behavior unchanged.

## Scope and non-goals

This PR closes the observability gap only; it does not claim to fix the reported deletion failure before a new affected-user log identifies the failing participant.

- No database fields or migrations.
- No persisted enum/status additions.
- No persistence-format or data-model changes.
- No historical-data compatibility behavior.
- No renderer or interaction changes.

## Acceptance criteria and validation

The tests use the existing public SessionPersistenceCoordinator.deleteSession boundary. Before implementation, focused tests failed because no terminal deletion diagnostic existed, participant failures remained at the generic preparation phase, and recovery failures lacked recoveryPhase.

Final checks were run after the last material edit:

- Session deletion diagnostic phases and privacy -> npm run test:module -- session_persistence -> 7 files passed, 320 tests passed.
- Main-process TypeScript contracts -> npm run typecheck:node -> passed.
- Repository lint rules -> npm run lint -> passed.

The module plan includes coordinator owner/architecture tests, shared and coordinator contracts, and artifact/deletion integration consumers. It also selects the windows_sensitive capability overlay. No renderer code or public IPC interface changed, so web typecheck and UI lanes were excluded locally; PR CI remains authoritative for the complete selected plan.

## Review focus

- Are the phase names sufficient to distinguish the next affected-user report without encoding user data?
- Does recoveryPhase preserve the original failurePhase in every compensation failure path?
- Does instrumentation remain observational and leave deletion/rollback authority unchanged?