### PR TITLE
fix(e2e): restore layout typecheck and export journey

### DIFF
--- a/e2e/message-tool-layout-stability.spec.ts
+++ b/e2e/message-tool-layout-stability.spec.ts
@@ -134,7 +134,10 @@ test('keeps a running tool stationary while one line of buffered Markdown finish
       surfaceHeight: surface.getBoundingClientRect().height
     }
   })
-  expect(bufferedGeometry.surfaceHeight - bufferedGeometry.markdownHeight, bufferedGeometry).toBe(0)
+  expect(
+    bufferedGeometry.surfaceHeight - bufferedGeometry.markdownHeight,
+    JSON.stringify(bufferedGeometry)
+  ).toBe(0)
 
   await expect(toolGroup).toBeVisible()
 

--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -167,17 +167,21 @@ test('archives a completed session from its mobile sidebar actions', async ({ ap
   await page.setViewportSize({ width: 375, height: 900 })
   await page.getByRole('button', { name: 'Open navigation' }).click()
   await page.getByRole('button', { name: `Open actions for ${USER_MESSAGE}` }).click()
-  await page.getByRole('menuitem', { name: 'Export conversation' }).click()
-  const exportFormats = page.locator(
-    '[data-slot="dropdown-menu-sub-content"][aria-label="Export conversation formats"]'
-  )
-  const markdownExport = exportFormats.getByRole('menuitem', { name: 'Markdown' })
-  await expect(exportFormats).toBeVisible()
-  expect(await exportFormats.evaluate((element) => Number(getComputedStyle(element).zIndex))).toBe(
+  const sessionActions = page.getByRole('menu', { name: 'Session actions' })
+  await expect(sessionActions).toBeVisible()
+  expect(await sessionActions.evaluate((element) => Number(getComputedStyle(element).zIndex))).toBe(
     80
   )
-  await expect(markdownExport).toBeVisible()
-  await markdownExport.hover()
+
+  await page.getByRole('menuitem', { name: 'Export conversation…' }).click()
+  const exportDialog = page.getByRole('dialog', { name: 'Export conversation' })
+  await expect(exportDialog).toBeVisible()
+  await expect(exportDialog.getByRole('radio', { name: 'Markdown' })).toBeVisible()
+  await exportDialog.getByRole('button', { name: 'Close' }).click()
+  await expect(exportDialog).toBeHidden()
+
+  await page.getByRole('button', { name: 'Open navigation' }).click()
+  await page.getByRole('button', { name: `Open actions for ${USER_MESSAGE}` }).click()
   const archive = page.getByRole('menuitem', { name: 'Archive' })
   await expect(archive).toBeEnabled()
   await archive.click()


### PR DESCRIPTION
## Problem

Two recently merged PRs left `main` with independent CI failures:

- #1527 (`fix(message-stream): avoid reserving space before tool calls`) failed **Static checks / typecheck:node**. `e2e/message-tool-layout-stability.spec.ts` passed a geometry object as Playwright's `expect` message, which must be `string | { message?: string }`.
- #1526 (`feat(conversation-export): add turn selection`) failed **macOS build and E2E** and **Windows E2E**. Conversation export moved from a nested format submenu to a dialog, but `archives a completed session from its mobile sidebar actions` still looked for `[data-slot="dropdown-menu-sub-content"][aria-label="Export conversation formats"]`.

Latest `main` (`f396d6ca`) contains both commits, so the same failures reproduce there.

## Proposed change

- Stringify the layout-stability diagnostic so it matches the other Playwright `expect` messages in that spec.
- Retarget the mobile sidebar journey at the session-actions menu (`z-index: 80`) and the new Export conversation dialog, then re-open the menu to Archive. Markdown remains a visible format choice inside the dialog.

## Scope and non-goals

- E2E specs only. No renderer, main-process, IPC, or catalog changes.
- Does not change export availability, turn-selection behavior, or the layout-reservation product code from #1527.

## Compatibility, enums, and persistence

- **Historical data compatibility:** none. No stored session, export, or UI documents are read or migrated.
- **New state / enum values:** none.
- **Data persistence:** none. No schema, migration, IPC payload, or preference writes.

## Acceptance criteria and validation

All commands below ran after the last material edit, from `.worktree/workspace-export-e2e-and-layout-typecheck`.

- Layout spec typechecks under the Node project (`e2e/**` is in `tsconfig.node.json`) → `npm run typecheck:node` → **passed** (previously `TS2345` at `e2e/message-tool-layout-stability.spec.ts:137`)
- Changed E2E files satisfy lint and Prettier → `npx eslint e2e/message-tool-layout-stability.spec.ts e2e/workspace-conversation.spec.ts` and `npx prettier --check` on those files → **passed**

Per maintainer direction, the complete portable suite and Electron E2E were left to PR Gate rather than running `npm test` or `npm run test:e2e` locally.

Uncovered locally: the rebuilt mobile export/archive journey and the layout-stability Electron cases run only in CI (`e2e_workspace_*`, `e2e_functional_*` / macOS build and E2E). Windows rendering remains CI-only.

## Review focus

- Whether the dialog journey still covers the stacking and Archive path that the old submenu click was protecting.
- Whether stringify-ing the layout diagnostic preserves failure detail without changing the height assertion.

Refs: #1526, #1527