### PR TITLE
fix(delegation): wake main agent after child settlement

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -2989,7 +2989,8 @@ async function hostCollect(selectors, options = undefined) {
     options === undefined
       ? undefined
       : remappedHostObject(options, 'host.collect options', {
-          timeoutSeconds: 'timeout_seconds'
+          timeoutSeconds: 'timeout_seconds',
+          returnWhen: 'return_when'
         })
   return delegatedObservationRpc('collect', normalizedSelectors, normalizedOptions)
 }

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -12,6 +12,7 @@ import type { AcpRuntime, AcpRuntimeCallbacks } from './runtime'
 import type { ConversationPermissionGrantStore } from './permission-broker'
 import type { AgentModelChangeTarget } from '../agent-framework'
 import { DelegateMessageParkedError } from '../delegation/execution-port'
+import type { RootDelegatedWorkControl } from '../delegation/production-composition'
 
 const createDeferred = <Value = void>(): {
   promise: Promise<Value>
@@ -1369,6 +1370,86 @@ describe('AcpRuntimeCoordinator', () => {
     expect(created[0].sendPrompt).not.toHaveBeenCalled()
   })
 
+  it('reports completed user and application-owned root turns to delegated settlement watching', async () => {
+    const rootTurnEnded = vi.fn(async () => undefined)
+    let settlementLease = 0
+    const rootTurnStarted = vi.fn(async () => `settlement-lease-${++settlementLease}`)
+    const delegatedWork: RootDelegatedWorkControl = {
+      pendingPermissions: () => [],
+      subscribe: () => () => undefined,
+      respondToPermission: async () => false,
+      setPermissionProfile: async () => undefined,
+      stopSession: async () => undefined,
+      stopAll: async () => undefined,
+      deleteSession: async () => undefined,
+      deleteProject: async () => undefined,
+      rootTurnStarted,
+      rootTurnEnded
+    }
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) =>
+        createFakeRuntime({
+          frameworkId: 'codex',
+          sessionIds: ['session-1'],
+          callbacks
+        }).runtime,
+      {},
+      '',
+      undefined,
+      undefined,
+      undefined,
+      {},
+      undefined,
+      delegatedWork
+    )
+    const session = await coordinator.createSession()
+
+    await coordinator.sendPrompt({
+      sessionId: session.sessionId,
+      text: 'delegate in the background',
+      provenanceContext: { promptMessageId: 'root-prompt' }
+    })
+    await coordinator.sendAppContinuation({
+      sessionId: session.sessionId,
+      text: 'application follow-up',
+      provenanceContext: { promptMessageId: 'root-prompt' }
+    })
+    await coordinator.sendApplicationPrompt(
+      {
+        sessionId: session.sessionId,
+        text: 'review correction',
+        provenanceContext: { promptMessageId: 'review-prompt' }
+      },
+      {
+        kind: 'application',
+        feature: 'reviewer',
+        purpose: 'correction',
+        causeReviewId: 'review-1'
+      }
+    )
+
+    expect(rootTurnEnded).toHaveBeenCalledTimes(3)
+    expect(rootTurnEnded).toHaveBeenNthCalledWith(1, {
+      sessionId: session.sessionId,
+      originatingPromptId: 'root-prompt',
+      clean: true,
+      leaseId: 'settlement-lease-1'
+    })
+    expect(rootTurnEnded).toHaveBeenNthCalledWith(2, {
+      sessionId: session.sessionId,
+      originatingPromptId: 'root-prompt',
+      clean: true,
+      leaseId: 'settlement-lease-2'
+    })
+    expect(rootTurnEnded).toHaveBeenNthCalledWith(3, {
+      sessionId: session.sessionId,
+      originatingPromptId: 'review-prompt',
+      clean: true,
+      leaseId: 'settlement-lease-3'
+    })
+    expect(rootTurnStarted).toHaveBeenCalledTimes(3)
+  })
+
   it('acknowledges prompt ownership release only after the owning runtime publishes drain', async () => {
     const promptResult = createDeferred<{ stopReason: 'end_turn' }>()
     const coordinator = new AcpRuntimeCoordinator(
@@ -1414,7 +1495,9 @@ describe('AcpRuntimeCoordinator', () => {
     const session = await coordinator.createSession()
     const original = { sessionId: session.sessionId, text: 'analyse these samples' }
     const pending = coordinator.sendPrompt(original)
-    await Promise.resolve()
+    await vi.waitFor(() =>
+      expect(coordinator.capturePromptForHandoff(session.sessionId)).toBeDefined()
+    )
 
     expect(coordinator.capturePromptForHandoff(session.sessionId)).toMatchObject({
       prompt: expect.objectContaining(original),
@@ -2142,10 +2225,20 @@ describe('AcpRuntimeCoordinator', () => {
       return dispatch()
     })
 
-    const continuation = coordinator.sendAppContinuation({
+    const request = {
       sessionId: session.sessionId,
-      text: 'approved recovery continuation'
-    })
+      text: 'approved recovery continuation',
+      suppressUserMessage: true,
+      provenanceContext: {
+        promptMessageId: 'originating-user-message',
+        originMessageId: 'originating-user-message',
+        rootFrameId: 'root-frame',
+        agentFrameId: 'root-frame',
+        messageAncestry: ['originating-user-message'],
+        runtimeSegmentId: 'settlement-wake-prompt'
+      }
+    }
+    const continuation = coordinator.sendAppContinuation(request)
     await Promise.resolve()
     expect(createdRuntime.sendAppContinuation).not.toHaveBeenCalled()
 
@@ -2153,7 +2246,7 @@ describe('AcpRuntimeCoordinator', () => {
     await continuation
 
     expect(admittedSessionIds).toEqual([session.sessionId])
-    expect(createdRuntime.sendAppContinuation).toHaveBeenCalledOnce()
+    expect(createdRuntime.sendAppContinuation).toHaveBeenCalledWith(request, 'prompt-attempt-1')
   })
 
   it('applies prompt admission and deletion fences to native follow-up', async () => {

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -1370,6 +1370,35 @@ describe('AcpRuntimeCoordinator', () => {
     expect(created[0].sendPrompt).not.toHaveBeenCalled()
   })
 
+  it('classifies a continuation dispatch-guard rejection as proven pre-acceptance', async () => {
+    let created!: ReturnType<typeof createFakeRuntime>
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      created = createFakeRuntime({
+        frameworkId: 'codex',
+        sessionIds: ['session-1'],
+        callbacks
+      })
+      return created.runtime
+    })
+    const session = await coordinator.createSession()
+    coordinator.setPromptDispatchAdmissionGuard(async () => {
+      throw new Error('dispatch admission unavailable')
+    })
+    const onProviderPromptAccepted = vi.fn()
+
+    await expect(
+      coordinator.sendAppContinuationObserved(
+        { sessionId: session.sessionId, text: 'retry safely' },
+        onProviderPromptAccepted
+      )
+    ).rejects.toMatchObject({
+      name: 'DelegateMessagePreAcceptanceError',
+      message: 'dispatch admission unavailable'
+    })
+    expect(created.sendAppContinuation).not.toHaveBeenCalled()
+    expect(onProviderPromptAccepted).not.toHaveBeenCalled()
+  })
+
   it('reports completed user and application-owned root turns to delegated settlement watching', async () => {
     const rootTurnEnded = vi.fn(async () => undefined)
     let settlementLease = 0
@@ -1449,6 +1478,71 @@ describe('AcpRuntimeCoordinator', () => {
     })
     expect(rootTurnStarted).toHaveBeenCalledTimes(3)
   })
+
+  it.each(['cancel', 'handoff'] as const)(
+    'does not dispatch a root turn superseded by %s while its settlement baseline loads',
+    async (supersede) => {
+      const settlementStart = createDeferred<string | undefined>()
+      const rootTurnStarted = vi.fn(async () => settlementStart.promise)
+      const rootTurnEnded = vi.fn(async () => undefined)
+      const delegatedWork: RootDelegatedWorkControl = {
+        pendingPermissions: () => [],
+        subscribe: () => () => undefined,
+        respondToPermission: async () => false,
+        setPermissionProfile: async () => undefined,
+        stopSession: async () => undefined,
+        stopAll: async () => undefined,
+        deleteSession: async () => undefined,
+        deleteProject: async () => undefined,
+        rootTurnStarted,
+        rootTurnEnded
+      }
+      let created!: ReturnType<typeof createFakeRuntime>
+      const coordinator = new AcpRuntimeCoordinator(
+        (callbacks) => {
+          created = createFakeRuntime({
+            frameworkId: 'codex',
+            sessionIds: ['session-1'],
+            callbacks
+          })
+          return created.runtime
+        },
+        {},
+        '',
+        undefined,
+        undefined,
+        undefined,
+        {},
+        undefined,
+        delegatedWork
+      )
+      const session = await coordinator.createSession()
+      const prompt = coordinator.sendPrompt({
+        sessionId: session.sessionId,
+        text: 'do not revive this prompt',
+        provenanceContext: { promptMessageId: 'superseded-root-prompt' }
+      })
+      await vi.waitFor(() => expect(rootTurnStarted).toHaveBeenCalledOnce())
+
+      if (supersede === 'cancel') {
+        await coordinator.cancelPrompt({ sessionId: session.sessionId })
+      } else {
+        await coordinator.stopPromptForHandoff(session.sessionId)
+      }
+      await coordinator.waitForSessionInteractionRelease(session.sessionId)
+      settlementStart.resolve('settlement-lease-1')
+
+      await expect(prompt).rejects.toThrow('superseded before provider dispatch')
+      expect(created.sendPrompt).not.toHaveBeenCalled()
+      expect(rootTurnEnded).toHaveBeenCalledOnce()
+      expect(rootTurnEnded).toHaveBeenCalledWith({
+        sessionId: session.sessionId,
+        originatingPromptId: 'superseded-root-prompt',
+        clean: false,
+        leaseId: 'settlement-lease-1'
+      })
+    }
+  )
 
   it('acknowledges prompt ownership release only after the owning runtime publishes drain', async () => {
     const promptResult = createDeferred<{ stopReason: 'end_turn' }>()
@@ -1723,6 +1817,7 @@ describe('AcpRuntimeCoordinator', () => {
       sessionId: session.sessionId,
       text: 'first turn'
     })
+    await vi.waitFor(() => expect(promptAttempt).toBe(1))
     await coordinator.cancelPrompt({ sessionId: session.sessionId })
     firstPromptStart.resolve()
     await cancelledBeforeStart
@@ -2135,8 +2230,7 @@ describe('AcpRuntimeCoordinator', () => {
     const activity = coordinator.withActivity({}, (runtime) =>
       runtime.sendPrompt({ sessionId: session.sessionId, text: '[Auditor] correction' })
     )
-    await Promise.resolve()
-    await Promise.resolve()
+    await vi.waitFor(() => expect(beforePromptStart).toHaveBeenCalledOnce())
 
     let prepared = false
     const preparing = coordinator.prepareForQuit().then(() => {
@@ -2393,6 +2487,7 @@ describe('AcpRuntimeCoordinator', () => {
       sessionId: session.sessionId,
       text: 'cancelled before start'
     })
+    await vi.waitFor(() => expect(promptAttempt).toBe(1))
     await coordinator.cancelPrompt({ sessionId: session.sessionId })
 
     await coordinator.sendPrompt({ sessionId: session.sessionId, text: 'new turn starts first' })
@@ -2423,6 +2518,7 @@ describe('AcpRuntimeCoordinator', () => {
       sessionId: session.sessionId,
       text: 'active predecessor'
     })
+    await vi.waitFor(() => expect(promptAttempt).toBe(1))
     const upward = coordinator.startContinuationWhen(
       { sessionId: session.sessionId, text: 'queued child message' },
       async () => undefined
@@ -2461,6 +2557,7 @@ describe('AcpRuntimeCoordinator', () => {
     })
     const session = await coordinator.createSession({ cwd: '/workspace' })
     const active = coordinator.sendPrompt({ sessionId: session.sessionId, text: 'active prompt' })
+    await vi.waitFor(() => expect(created.sendPrompt).toHaveBeenCalledOnce())
     const upward = coordinator.startContinuationWhen(
       { sessionId: session.sessionId, text: 'queued child message' },
       async () => undefined

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -1017,13 +1017,41 @@ class AcpRuntimeCoordinator {
     }
     this.activePromptRequests.set(request.sessionId, activePrompt)
     if (retainAsLatestUserPrompt) this.latestPromptRequests.set(request.sessionId, taskRequest)
-    const prompt =
-      operation === 'sendApplicationPrompt'
+    const originatingPromptId = taskRequest.provenanceContext?.promptMessageId
+    let settlementLeaseId: string | undefined
+    const endRootTurn = async (clean: boolean): Promise<void> => {
+      if (!originatingPromptId) return
+      await this.delegatedWork
+        ?.rootTurnEnded?.({
+          sessionId: request.sessionId,
+          originatingPromptId,
+          clean,
+          ...(settlementLeaseId ? { leaseId: settlementLeaseId } : {})
+        })
+        .catch(() => undefined)
+    }
+    const settlementStart = originatingPromptId
+      ? this.delegatedWork
+          ?.rootTurnStarted?.({
+            sessionId: request.sessionId,
+            originatingPromptId
+          })
+          .catch(() => undefined)
+      : undefined
+    const prompt = Promise.resolve(settlementStart).then((leaseId) => {
+      settlementLeaseId = leaseId
+      return operation === 'sendApplicationPrompt'
         ? runtime.sendApplicationPrompt(taskRequest, attribution!, attempt.id)
         : runtime[operation](taskRequest, attempt.id)
+    })
     onApplicationPromptAdmitted?.(prompt)
     return prompt
-      .catch((error: unknown) => {
+      .then(async (response) => {
+        await endRootTurn(response?.stopReason !== 'cancelled')
+        return response
+      })
+      .catch(async (error: unknown) => {
+        await endRootTurn(false)
         if (
           operation === 'sendPrompt' &&
           this.promptAdmissionClosedForQuit &&

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -833,6 +833,19 @@ class AcpRuntimeCoordinator {
     )
   }
 
+  sendAppContinuationObserved(
+    request: AcpPromptRequest,
+    onProviderPromptAccepted: () => void
+  ): ReturnType<AcpRuntime['sendAppContinuation']> {
+    return this.linearizeRootAdmission(request.sessionId, () =>
+      this.dispatchPrompt(
+        request,
+        observePromptAcceptance(onProviderPromptAccepted),
+        'sendAppContinuation'
+      )
+    )
+  }
+
   private linearizeRootAdmission<Result>(
     sessionId: string,
     operation: () => Promise<Result>
@@ -959,8 +972,10 @@ class AcpRuntimeCoordinator {
     attribution?: MessageAttribution,
     onApplicationPromptAdmitted?: (prompt: ReturnType<AcpRuntime['sendPrompt']>) => void
   ): ReturnType<AcpRuntime['sendPrompt']> {
-    const dispatch = (): ReturnType<AcpRuntime['sendPrompt']> =>
-      this.dispatchAdmittedPrompt(
+    let dispatchStarted = false
+    const dispatch = (): ReturnType<AcpRuntime['sendPrompt']> => {
+      dispatchStarted = true
+      return this.dispatchAdmittedPrompt(
         request,
         acceptance,
         operation,
@@ -969,9 +984,15 @@ class AcpRuntimeCoordinator {
         attribution,
         onApplicationPromptAdmitted
       )
-    return this.promptDispatchAdmissionGuard
-      ? this.promptDispatchAdmissionGuard(request.sessionId, dispatch)
-      : dispatch()
+    }
+    if (!this.promptDispatchAdmissionGuard) return dispatch()
+    return this.promptDispatchAdmissionGuard(request.sessionId, dispatch).catch((error) => {
+      if (dispatchStarted || error instanceof DelegateMessagePreAcceptanceError) throw error
+      throw new DelegateMessagePreAcceptanceError(
+        error instanceof Error ? error.message : String(error),
+        error
+      )
+    })
   }
 
   private dispatchAdmittedPrompt(
@@ -1040,6 +1061,16 @@ class AcpRuntimeCoordinator {
       : undefined
     const prompt = Promise.resolve(settlementStart).then((leaseId) => {
       settlementLeaseId = leaseId
+      if (
+        attempt.globalCancellationGeneration !== this.globalCancellationGeneration ||
+        attempt.sessionCancellationGeneration !==
+          (this.sessionCancellationGenerations.get(request.sessionId) ?? 0) ||
+        this.activePromptRequests.get(request.sessionId) !== activePrompt
+      ) {
+        throw new DelegateMessagePreAcceptanceError(
+          'ACP prompt start was superseded before provider dispatch'
+        )
+      }
       return operation === 'sendApplicationPrompt'
         ? runtime.sendApplicationPrompt(taskRequest, attribution!, attempt.id)
         : runtime[operation](taskRequest, attempt.id)

--- a/src/main/delegation/delegated-work-read-model.ts
+++ b/src/main/delegation/delegated-work-read-model.ts
@@ -1,5 +1,9 @@
 import { DurableDelegatedWorkError } from './durable-delegated-work-error'
-import { currentAttempt, sameSession } from './delegated-work-record-invariants'
+import {
+  currentAttempt,
+  isDelegatedAttemptSettled,
+  sameSession
+} from './delegated-work-record-invariants'
 import { DelegatedWorkProjectionOwner } from './delegated-work-projection'
 import type {
   AuthenticatedDelegateCaller,
@@ -58,6 +62,13 @@ class DelegatedWorkReadModel {
       )
     }
     const timeoutSeconds = options.timeoutSeconds ?? 30
+    const returnWhen = options.returnWhen ?? 'all'
+    if (returnWhen !== 'all' && returnWhen !== 'any') {
+      throw new DurableDelegatedWorkError(
+        'admission_rejection',
+        'collect returnWhen must be all or any'
+      )
+    }
     if (
       typeof timeoutSeconds !== 'number' ||
       !Number.isFinite(timeoutSeconds) ||
@@ -80,7 +91,12 @@ class DelegatedWorkReadModel {
           this.projections.projectSnapshotObservation(snapshot, child, attempt)
         )
       )
-      if (observations.every((observation) => observation.status !== 'running')) {
+      const settled = observations.map((observation) =>
+        observation.status === 'awaiting_user'
+          ? false
+          : isDelegatedAttemptSettled(observation.status)
+      )
+      if (returnWhen === 'all' ? settled.every(Boolean) : settled.some(Boolean)) {
         return observations
       }
       if (timeoutSeconds === 0) return observations

--- a/src/main/delegation/delegated-work-record-invariants.ts
+++ b/src/main/delegation/delegated-work-record-invariants.ts
@@ -8,4 +8,12 @@ const sameSession = (left: SessionIdentity, right: SessionIdentity): boolean =>
 const currentAttempt = (child: DurableChild): DurableAttempt =>
   child.attempts[child.attempts.length - 1]
 
-export { currentAttempt, sameSession }
+type DurableSettledAttemptStatus = Exclude<DurableAttempt['status'], 'running'>
+
+const isDelegatedAttemptSettled = (
+  status: DurableAttempt['status']
+): status is DurableSettledAttemptStatus =>
+  status === 'completed' || status === 'cancelled' || status === 'error'
+
+export { currentAttempt, isDelegatedAttemptSettled, sameSession }
+export type { DurableSettledAttemptStatus }

--- a/src/main/delegation/delegated-work-record-types.ts
+++ b/src/main/delegation/delegated-work-record-types.ts
@@ -105,7 +105,10 @@ type DurableDelegateObservation =
 
 type DurableCollectSelector = string | Readonly<{ frameId: string; attemptId: string }>
 
-type DurableCollectOptions = Readonly<{ timeoutSeconds?: number }>
+type DurableCollectOptions = Readonly<{
+  timeoutSeconds?: number
+  returnWhen?: 'all' | 'any'
+}>
 
 type DurableDelegateOutcome =
   | Readonly<{

--- a/src/main/delegation/delegation-settlement-wake-owner.test.ts
+++ b/src/main/delegation/delegation-settlement-wake-owner.test.ts
@@ -1,0 +1,663 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  DelegationSettlementWakeOwner,
+  type DelegationSettlementDispatch,
+  type DelegationSettlementSnapshot
+} from './delegation-settlement-wake-owner'
+
+const snapshot = (
+  attempts: DelegationSettlementSnapshot['attempts'],
+  overrides: Partial<DelegationSettlementSnapshot> = {}
+): DelegationSettlementSnapshot => ({
+  projectId: 'project-1',
+  sessionId: 'session-1',
+  rootFrameId: 'root-frame',
+  activeRootPromptIds: ['root-prompt'],
+  attempts,
+  ...overrides
+})
+
+const child = (
+  frameId: string,
+  status: 'running' | 'completed' | 'error' | 'cancelled',
+  overrides: Partial<DelegationSettlementSnapshot['attempts'][number]> = {}
+): DelegationSettlementSnapshot['attempts'][number] => ({
+  frameId,
+  attemptId: `attempt-${frameId}`,
+  parentFrameId: 'root-frame',
+  originatingPromptId: 'root-prompt',
+  name: frameId,
+  status,
+  ...overrides
+})
+
+const acceptDispatch = async (request: DelegationSettlementDispatch): Promise<void> => {
+  void request
+}
+
+const endRootTurn = async (
+  owner: DelegationSettlementWakeOwner,
+  input: Readonly<{ sessionId: string; originatingPromptId: string; clean: boolean }>,
+  duringTurn: () => void | Promise<void> = () => undefined
+): Promise<void> => {
+  const leaseId = await owner.onRootTurnStarted({
+    sessionId: input.sessionId,
+    originatingPromptId: input.originatingPromptId
+  })
+  await duringTurn()
+  await owner.onRootTurnEnded({ ...input, leaseId })
+}
+
+describe('DelegationSettlementWakeOwner', () => {
+  it('watches running direct Attempts at clean root end and wakes after one settles', async () => {
+    vi.useFakeTimers()
+    let current = snapshot([])
+    const dispatched: DelegationSettlementDispatch[] = []
+    const owner = new DelegationSettlementWakeOwner({
+      readSnapshot: async () => current,
+      dispatch: async (request) => {
+        dispatched.push(request)
+      },
+      createPromptId: () => 'wake-1'
+    })
+
+    await endRootTurn(
+      owner,
+      { sessionId: 'session-1', originatingPromptId: 'root-prompt', clean: true },
+      () => {
+        current = snapshot([child('alpha', 'running')])
+      }
+    )
+    current = snapshot([child('alpha', 'completed')])
+    await owner.onRecordsChanged('session-1')
+    await vi.advanceTimersByTimeAsync(99)
+    expect(dispatched).toEqual([])
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(dispatched).toHaveLength(1)
+    expect(dispatched[0]).toMatchObject({
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      originatingPromptId: 'root-prompt',
+      promptId: 'wake-1'
+    })
+    expect(dispatched[0].text).toContain('alpha')
+    expect(dispatched[0].text).toContain('frame=alpha')
+    expect(dispatched[0].text).toContain('attempt=attempt-alpha')
+    expect(dispatched[0].text).toContain('status=completed')
+    expect(dispatched[0].text).toContain('All watched Subagent Attempts have settled')
+    vi.useRealTimers()
+  })
+
+  it('reconciles the root-end race and ignores terminal, nested, and unrelated Attempts', async () => {
+    vi.useFakeTimers()
+    const current = snapshot([
+      child('raced', 'completed'),
+      child('already-terminal', 'completed'),
+      child('nested', 'running', { parentFrameId: 'raced' }),
+      child('other-turn', 'running', { originatingPromptId: 'other-prompt' })
+    ])
+    const dispatch = vi.fn(acceptDispatch)
+    const owner = new DelegationSettlementWakeOwner({
+      readSnapshot: vi
+        .fn()
+        .mockResolvedValueOnce(snapshot([]))
+        .mockResolvedValueOnce(snapshot([child('raced', 'running')]))
+        .mockResolvedValue(current),
+      dispatch,
+      createPromptId: () => 'wake-race'
+    })
+
+    await endRootTurn(owner, {
+      sessionId: 'session-1',
+      originatingPromptId: 'root-prompt',
+      clean: true
+    })
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(dispatch).toHaveBeenCalledOnce()
+    const request = dispatch.mock.calls[0]?.[0]
+    expect(request?.text).toContain('raced')
+    expect(request?.text).not.toContain('already-terminal')
+    expect(request?.text).not.toContain('nested')
+    expect(request?.text).not.toContain('other-turn')
+    vi.useRealTimers()
+  })
+
+  it('uses a fixed leading debounce and freezes stable batches from the final snapshot', async () => {
+    vi.useFakeTimers()
+    let current = snapshot([])
+    const dispatch = vi.fn(acceptDispatch)
+    const owner = new DelegationSettlementWakeOwner({
+      readSnapshot: async () => current,
+      dispatch,
+      createPromptId: () => 'wake-batch'
+    })
+    await endRootTurn(
+      owner,
+      { sessionId: 'session-1', originatingPromptId: 'root-prompt', clean: true },
+      () => {
+        current = snapshot([
+          child('alpha', 'running'),
+          child('beta', 'running'),
+          child('gamma', 'running')
+        ])
+      }
+    )
+
+    current = snapshot([
+      child('alpha', 'completed'),
+      child('beta', 'running'),
+      child('gamma', 'running')
+    ])
+    await owner.onRecordsChanged('session-1')
+    await vi.advanceTimersByTimeAsync(70)
+    current = snapshot([
+      child('alpha', 'completed'),
+      child('beta', 'error'),
+      child('gamma', 'running')
+    ])
+    await owner.onRecordsChanged('session-1')
+    await vi.advanceTimersByTimeAsync(30)
+
+    expect(dispatch).toHaveBeenCalledOnce()
+    const text = dispatch.mock.calls[0]?.[0]?.text ?? ''
+    expect(text.indexOf('alpha')).toBeLessThan(text.indexOf('beta'))
+    expect(text).toContain('status=completed')
+    expect(text).toContain('status=error')
+    expect(text).toContain('1 watched Subagent Attempt remains running')
+    vi.useRealTimers()
+  })
+
+  it('keeps one Session flight until the exact wake prompt ends and then dispatches later settlements', async () => {
+    vi.useFakeTimers()
+    let prompt = 0
+    let current = snapshot([])
+    const dispatch = vi.fn(acceptDispatch)
+    const owner = new DelegationSettlementWakeOwner({
+      readSnapshot: async () => current,
+      dispatch,
+      createPromptId: () => `wake-${++prompt}`
+    })
+    await endRootTurn(
+      owner,
+      { sessionId: 'session-1', originatingPromptId: 'root-prompt', clean: true },
+      () => {
+        current = snapshot([child('alpha', 'running'), child('beta', 'running')])
+      }
+    )
+    current = snapshot([child('alpha', 'completed'), child('beta', 'running')])
+    await owner.onRecordsChanged('session-1')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(dispatch).toHaveBeenCalledOnce()
+
+    current = snapshot([child('alpha', 'completed'), child('beta', 'cancelled')])
+    await owner.onRecordsChanged('session-1')
+    await vi.advanceTimersByTimeAsync(500)
+    expect(dispatch).toHaveBeenCalledOnce()
+    await owner.onWakePromptEnded('session-1', 'unrelated')
+    expect(dispatch).toHaveBeenCalledOnce()
+    await owner.onWakePromptEnded('session-1', 'wake-1')
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    expect(dispatch.mock.calls[1]?.[0]).toMatchObject({ promptId: 'wake-2' })
+    expect(dispatch.mock.calls[1]?.[0]?.text).toContain('status=cancelled')
+    vi.useRealTimers()
+  })
+
+  it('retains an invalidated branch flight until its exact terminal callback releases the Session', async () => {
+    vi.useFakeTimers()
+    let prompt = 0
+    let current = snapshot([], { activeRootPromptIds: ['prompt-a', 'prompt-b'] })
+    const dispatch = vi.fn(acceptDispatch)
+    const owner = new DelegationSettlementWakeOwner({
+      readSnapshot: async () => current,
+      dispatch,
+      createPromptId: () => `wake-${++prompt}`
+    })
+    await endRootTurn(
+      owner,
+      { sessionId: 'session-1', originatingPromptId: 'prompt-a', clean: true },
+      () => {
+        current = snapshot([child('alpha', 'running', { originatingPromptId: 'prompt-a' })], {
+          activeRootPromptIds: ['prompt-a', 'prompt-b']
+        })
+      }
+    )
+    await endRootTurn(
+      owner,
+      { sessionId: 'session-1', originatingPromptId: 'prompt-b', clean: true },
+      () => {
+        current = snapshot(
+          [
+            child('alpha', 'running', { originatingPromptId: 'prompt-a' }),
+            child('beta', 'running', { originatingPromptId: 'prompt-b' })
+          ],
+          { activeRootPromptIds: ['prompt-a', 'prompt-b'] }
+        )
+      }
+    )
+
+    current = snapshot(
+      [
+        child('alpha', 'completed', { originatingPromptId: 'prompt-a' }),
+        child('beta', 'running', { originatingPromptId: 'prompt-b' })
+      ],
+      { activeRootPromptIds: ['prompt-a', 'prompt-b'] }
+    )
+    await owner.onRecordsChanged('session-1')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(dispatch).toHaveBeenCalledOnce()
+
+    current = snapshot(
+      [
+        child('alpha', 'completed', { originatingPromptId: 'prompt-a' }),
+        child('beta', 'error', { originatingPromptId: 'prompt-b' })
+      ],
+      { activeRootPromptIds: ['prompt-a', 'prompt-b'] }
+    )
+    await owner.onRecordsChanged('session-1')
+    await owner.invalidateBranch('session-1', 'prompt-a')
+    await vi.advanceTimersByTimeAsync(500)
+    expect(dispatch).toHaveBeenCalledOnce()
+
+    await owner.onWakePromptEnded('session-1', 'wake-1')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    expect(dispatch.mock.calls[1]?.[0]).toMatchObject({ originatingPromptId: 'prompt-b' })
+    expect(dispatch.mock.calls[1]?.[0]?.text).toContain('beta')
+    vi.useRealTimers()
+  })
+
+  it('watches only direct Attempts created during the leased root turn', async () => {
+    vi.useFakeTimers()
+    let current = snapshot([child('older', 'running')])
+    const dispatch = vi.fn(acceptDispatch)
+    const owner = new DelegationSettlementWakeOwner({
+      readSnapshot: async () => current,
+      dispatch,
+      createPromptId: () => 'wake-cohort'
+    })
+    await endRootTurn(
+      owner,
+      { sessionId: 'session-1', originatingPromptId: 'root-prompt', clean: true },
+      () => {
+        current = snapshot([child('older', 'running'), child('newer', 'running')])
+      }
+    )
+
+    current = snapshot([child('older', 'completed'), child('newer', 'running')])
+    await owner.onRecordsChanged('session-1')
+    await vi.advanceTimersByTimeAsync(200)
+    expect(dispatch).not.toHaveBeenCalled()
+
+    current = snapshot([child('older', 'completed'), child('newer', 'completed')])
+    await owner.onRecordsChanged('session-1')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(dispatch).toHaveBeenCalledOnce()
+    expect(dispatch.mock.calls[0]?.[0]?.text).toContain('newer')
+    expect(dispatch.mock.calls[0]?.[0]?.text).not.toContain('older')
+    vi.useRealTimers()
+  })
+
+  it('allows different Sessions to debounce and dispatch independently', async () => {
+    vi.useFakeTimers()
+    const currents = new Map<string, DelegationSettlementSnapshot>([
+      ['session-1', snapshot([])],
+      ['session-2', snapshot([], { projectId: 'project-2', sessionId: 'session-2' })]
+    ])
+    const dispatch = vi.fn(acceptDispatch)
+    const owner = new DelegationSettlementWakeOwner({
+      readSnapshot: async (sessionId) => currents.get(sessionId),
+      dispatch
+    })
+    await Promise.all(
+      ['session-1', 'session-2'].map((sessionId) =>
+        endRootTurn(owner, { sessionId, originatingPromptId: 'root-prompt', clean: true }, () => {
+          currents.set(
+            sessionId,
+            sessionId === 'session-1'
+              ? snapshot([child('alpha', 'running')])
+              : snapshot([child('beta', 'running')], {
+                  projectId: 'project-2',
+                  sessionId: 'session-2'
+                })
+          )
+        })
+      )
+    )
+
+    currents.set('session-1', snapshot([child('alpha', 'completed')]))
+    await owner.onRecordsChanged('session-1')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(dispatch).toHaveBeenCalledOnce()
+    expect(dispatch.mock.calls[0]?.[0].sessionId).toBe('session-1')
+
+    currents.set(
+      'session-2',
+      snapshot([child('beta', 'error')], { projectId: 'project-2', sessionId: 'session-2' })
+    )
+    await owner.onRecordsChanged('session-2')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    expect(dispatch.mock.calls[1]?.[0]).toMatchObject({
+      projectId: 'project-2',
+      sessionId: 'session-2'
+    })
+    vi.useRealTimers()
+  })
+
+  it('merges children started by an app continuation without dropping pending settlements', async () => {
+    vi.useFakeTimers()
+    let prompt = 0
+    let current = snapshot([])
+    const dispatch = vi.fn(acceptDispatch)
+    const owner = new DelegationSettlementWakeOwner({
+      readSnapshot: async () => current,
+      dispatch,
+      createPromptId: () => `wake-${++prompt}`
+    })
+    await endRootTurn(
+      owner,
+      { sessionId: 'session-1', originatingPromptId: 'root-prompt', clean: true },
+      () => {
+        current = snapshot([child('alpha', 'running'), child('beta', 'running')])
+      }
+    )
+    current = snapshot([child('alpha', 'completed'), child('beta', 'running')])
+    await owner.onRecordsChanged('session-1')
+    await vi.advanceTimersByTimeAsync(100)
+
+    current = snapshot([child('alpha', 'completed'), child('beta', 'error')])
+    await owner.onRecordsChanged('session-1')
+    await endRootTurn(
+      owner,
+      { sessionId: 'session-1', originatingPromptId: 'root-prompt', clean: true },
+      () => {
+        current = snapshot([
+          child('alpha', 'completed'),
+          child('beta', 'error'),
+          child('gamma', 'running')
+        ])
+      }
+    )
+    await owner.onWakePromptEnded('session-1', 'wake-1')
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    expect(dispatch.mock.calls[1]?.[0]?.text).toContain('beta')
+    expect(dispatch.mock.calls[1]?.[0]?.text).toContain('status=error')
+    expect(dispatch.mock.calls[1]?.[0]?.text).toContain(
+      '1 watched Subagent Attempt remains running'
+    )
+
+    current = snapshot([
+      child('alpha', 'completed'),
+      child('beta', 'error'),
+      child('gamma', 'completed')
+    ])
+    await owner.onRecordsChanged('session-1')
+    await owner.onWakePromptEnded('session-1', 'wake-2')
+    await vi.advanceTimersByTimeAsync(100)
+    expect(dispatch).toHaveBeenCalledTimes(3)
+    expect(dispatch.mock.calls[2]?.[0]?.text).toContain('gamma')
+    vi.useRealTimers()
+  })
+
+  it('cleans unclean turns and Session invalidation without late continuations', async () => {
+    vi.useFakeTimers()
+    let current = snapshot([])
+    const dispatch = vi.fn(acceptDispatch)
+    const owner = new DelegationSettlementWakeOwner({
+      readSnapshot: async () => current,
+      dispatch
+    })
+    await endRootTurn(
+      owner,
+      { sessionId: 'session-1', originatingPromptId: 'root-prompt', clean: false },
+      () => {
+        current = snapshot([child('alpha', 'running')])
+      }
+    )
+    current = snapshot([child('alpha', 'completed')])
+    await owner.onRecordsChanged('session-1')
+    await vi.advanceTimersByTimeAsync(200)
+    expect(dispatch).not.toHaveBeenCalled()
+
+    await endRootTurn(
+      owner,
+      { sessionId: 'session-1', originatingPromptId: 'root-prompt', clean: true },
+      () => {
+        current = snapshot([child('alpha', 'completed'), child('beta', 'running')])
+      }
+    )
+    current = snapshot([child('alpha', 'completed'), child('beta', 'completed')])
+    await owner.onRecordsChanged('session-1')
+    owner.invalidateSession('session-1')
+    await vi.advanceTimersByTimeAsync(200)
+    expect(dispatch).not.toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
+  it('clears a pending settlement timer on shutdown', async () => {
+    vi.useFakeTimers()
+    let current = snapshot([])
+    const dispatch = vi.fn(acceptDispatch)
+    const owner = new DelegationSettlementWakeOwner({
+      readSnapshot: async () => current,
+      dispatch
+    })
+    await endRootTurn(
+      owner,
+      { sessionId: 'session-1', originatingPromptId: 'root-prompt', clean: true },
+      () => {
+        current = snapshot([child('alpha', 'running')])
+      }
+    )
+    current = snapshot([child('alpha', 'completed')])
+    await owner.onRecordsChanged('session-1')
+
+    owner.shutdown()
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+    vi.useRealTimers()
+  })
+
+  it.each(['session', 'project', 'shutdown', 'branch'] as const)(
+    'rejects a prior root-turn lease whose terminal callback arrives after %s invalidation',
+    async (scope) => {
+      vi.useFakeTimers()
+      let current = snapshot([child('alpha', 'running')])
+      const dispatch = vi.fn(acceptDispatch)
+      const owner = new DelegationSettlementWakeOwner({
+        readSnapshot: async () => current,
+        dispatch
+      })
+      const leaseId = await owner.onRootTurnStarted({
+        sessionId: 'session-1',
+        originatingPromptId: 'root-prompt'
+      })
+
+      if (scope === 'session') owner.invalidateSession('session-1')
+      else if (scope === 'project') await owner.invalidateProject('project-1')
+      else if (scope === 'shutdown') owner.shutdown()
+      else await owner.invalidateBranch('session-1', 'root-prompt')
+
+      if (scope === 'shutdown') {
+        expect(
+          await owner.onRootTurnStarted({
+            sessionId: 'session-1',
+            originatingPromptId: 'later-root-prompt'
+          })
+        ).toBeUndefined()
+      }
+
+      await owner.onRootTurnEnded({
+        sessionId: 'session-1',
+        originatingPromptId: 'root-prompt',
+        clean: true,
+        leaseId
+      })
+      current = snapshot([child('alpha', 'completed')])
+      await owner.onRecordsChanged('session-1')
+      await vi.advanceTimersByTimeAsync(200)
+
+      expect(dispatch).not.toHaveBeenCalled()
+      expect(vi.getTimerCount()).toBe(0)
+      vi.useRealTimers()
+    }
+  )
+
+  it('does not let a rejected stale turn-start snapshot delete a replacement Session state', async () => {
+    vi.useFakeTimers()
+    let rejectOldSnapshot!: (error: Error) => void
+    const oldSnapshot = new Promise<DelegationSettlementSnapshot | undefined>(
+      (_resolve, reject) => {
+        rejectOldSnapshot = reject
+      }
+    )
+    let reads = 0
+    let current = snapshot([], { activeRootPromptIds: ['new-prompt'] })
+    const dispatch = vi.fn(acceptDispatch)
+    const owner = new DelegationSettlementWakeOwner({
+      readSnapshot: async () => {
+        reads += 1
+        return reads === 1 ? oldSnapshot : current
+      },
+      dispatch,
+      createPromptId: () => 'new-wake'
+    })
+
+    const oldStart = owner.onRootTurnStarted({
+      sessionId: 'session-1',
+      originatingPromptId: 'old-prompt'
+    })
+    owner.invalidateSession('session-1')
+    const newLease = await owner.onRootTurnStarted({
+      sessionId: 'session-1',
+      originatingPromptId: 'new-prompt'
+    })
+    current = snapshot([child('new-child', 'running', { originatingPromptId: 'new-prompt' })], {
+      activeRootPromptIds: ['new-prompt']
+    })
+    await owner.onRootTurnEnded({
+      sessionId: 'session-1',
+      originatingPromptId: 'new-prompt',
+      clean: true,
+      leaseId: newLease
+    })
+
+    rejectOldSnapshot(new Error('stale snapshot failed'))
+    await expect(oldStart).rejects.toThrow('stale snapshot failed')
+    current = snapshot([child('new-child', 'completed', { originatingPromptId: 'new-prompt' })], {
+      activeRootPromptIds: ['new-prompt']
+    })
+    await owner.onRecordsChanged('session-1')
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(dispatch).toHaveBeenCalledOnce()
+    expect(dispatch.mock.calls[0]?.[0]).toMatchObject({
+      originatingPromptId: 'new-prompt',
+      promptId: 'new-wake'
+    })
+    vi.useRealTimers()
+  })
+
+  it('serializes branch invalidation behind an in-progress root-end snapshot', async () => {
+    vi.useFakeTimers()
+    let releaseSnapshot!: (value: DelegationSettlementSnapshot) => void
+    const firstSnapshot = new Promise<DelegationSettlementSnapshot>((resolve) => {
+      releaseSnapshot = resolve
+    })
+    let current = snapshot([child('alpha', 'running')])
+    let reads = 0
+    const dispatch = vi.fn(acceptDispatch)
+    const owner = new DelegationSettlementWakeOwner({
+      readSnapshot: async () => {
+        reads += 1
+        if (reads === 1) return snapshot([])
+        return reads === 2 ? firstSnapshot : current
+      },
+      dispatch
+    })
+
+    const rootEnded = endRootTurn(owner, {
+      sessionId: 'session-1',
+      originatingPromptId: 'root-prompt',
+      clean: true
+    })
+    const invalidated = owner.invalidateBranch('session-1', 'root-prompt')
+    releaseSnapshot(current)
+    await Promise.all([rootEnded, invalidated])
+
+    current = snapshot([child('alpha', 'completed')])
+    await owner.onRecordsChanged('session-1')
+    await vi.advanceTimersByTimeAsync(200)
+    expect(dispatch).not.toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
+  it('serializes Project invalidation behind every known Session root-end snapshot', async () => {
+    vi.useFakeTimers()
+    let releaseDeletedSnapshot!: (value: DelegationSettlementSnapshot) => void
+    const deletedSnapshot = new Promise<DelegationSettlementSnapshot>((resolve) => {
+      releaseDeletedSnapshot = resolve
+    })
+    let deletedCurrent = snapshot([])
+    let retainedCurrent = snapshot([], {
+      projectId: 'project-2',
+      sessionId: 'session-2'
+    })
+    const dispatch = vi.fn(acceptDispatch)
+    const owner = new DelegationSettlementWakeOwner({
+      readSnapshot: async (sessionId) => {
+        if (sessionId === 'session-1' && deletedCurrent.attempts[0]?.status === 'running') {
+          return deletedSnapshot
+        }
+        return sessionId === 'session-1' ? deletedCurrent : retainedCurrent
+      },
+      dispatch
+    })
+
+    const deletedRootEnded = endRootTurn(
+      owner,
+      { sessionId: 'session-1', originatingPromptId: 'root-prompt', clean: true },
+      () => {
+        deletedCurrent = snapshot([child('deleted-child', 'running')])
+      }
+    )
+    const retainedRootEnded = endRootTurn(
+      owner,
+      { sessionId: 'session-2', originatingPromptId: 'root-prompt', clean: true },
+      () => {
+        retainedCurrent = snapshot([child('retained-child', 'running')], {
+          projectId: 'project-2',
+          sessionId: 'session-2'
+        })
+      }
+    )
+    await retainedRootEnded
+    const invalidated = owner.invalidateProject('project-1')
+    releaseDeletedSnapshot(deletedCurrent)
+    await Promise.all([deletedRootEnded, invalidated])
+
+    deletedCurrent = snapshot([child('deleted-child', 'completed')])
+    retainedCurrent = snapshot([child('retained-child', 'completed')], {
+      projectId: 'project-2',
+      sessionId: 'session-2'
+    })
+    await Promise.all([owner.onRecordsChanged('session-1'), owner.onRecordsChanged('session-2')])
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(dispatch).toHaveBeenCalledOnce()
+    expect(dispatch.mock.calls[0]?.[0]).toMatchObject({
+      projectId: 'project-2',
+      sessionId: 'session-2'
+    })
+    vi.useRealTimers()
+  })
+})

--- a/src/main/delegation/delegation-settlement-wake-owner.test.ts
+++ b/src/main/delegation/delegation-settlement-wake-owner.test.ts
@@ -90,6 +90,183 @@ describe('DelegationSettlementWakeOwner', () => {
     vi.useRealTimers()
   })
 
+  it('wakes for an unobserved detached Attempt that settles before the root turn ends', async () => {
+    vi.useFakeTimers()
+    let current = snapshot([])
+    const dispatch = vi.fn(acceptDispatch)
+    const owner = new DelegationSettlementWakeOwner({
+      readSnapshot: async () => current,
+      dispatch,
+      createPromptId: () => 'wake-early-terminal'
+    })
+    const leaseId = await owner.onRootTurnStarted({
+      sessionId: 'session-1',
+      originatingPromptId: 'root-prompt'
+    })
+    owner.trackUnobservedAttempts({
+      sessionId: 'session-1',
+      originatingPromptId: 'root-prompt',
+      attempts: [{ frameId: 'fast', attemptId: 'attempt-fast', name: 'fast' }]
+    })
+    current = snapshot([child('fast', 'completed')])
+
+    await owner.onRootTurnEnded({
+      sessionId: 'session-1',
+      originatingPromptId: 'root-prompt',
+      clean: true,
+      leaseId
+    })
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(dispatch).toHaveBeenCalledOnce()
+    expect(dispatch.mock.calls[0]?.[0]?.text).toContain('status=completed')
+    vi.useRealTimers()
+  })
+
+  it('does not wake for a detached Attempt whose terminal result was observed in the root turn', async () => {
+    vi.useFakeTimers()
+    let current = snapshot([])
+    const dispatch = vi.fn(acceptDispatch)
+    const owner = new DelegationSettlementWakeOwner({
+      readSnapshot: async () => current,
+      dispatch
+    })
+    const leaseId = await owner.onRootTurnStarted({
+      sessionId: 'session-1',
+      originatingPromptId: 'root-prompt'
+    })
+    owner.trackUnobservedAttempts({
+      sessionId: 'session-1',
+      originatingPromptId: 'root-prompt',
+      attempts: [{ frameId: 'collected', attemptId: 'attempt-collected', name: 'collected' }]
+    })
+    owner.markAttemptsObserved({
+      sessionId: 'session-1',
+      originatingPromptId: 'root-prompt',
+      attempts: [{ frameId: 'collected', attemptId: 'attempt-collected' }]
+    })
+    current = snapshot([child('collected', 'completed')])
+
+    await owner.onRootTurnEnded({
+      sessionId: 'session-1',
+      originatingPromptId: 'root-prompt',
+      clean: true,
+      leaseId
+    })
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+    vi.useRealTimers()
+  })
+
+  it('wakes only for the unobserved sibling after a partial same-turn collect', async () => {
+    vi.useFakeTimers()
+    let current = snapshot([])
+    const dispatch = vi.fn(acceptDispatch)
+    const owner = new DelegationSettlementWakeOwner({
+      readSnapshot: async () => current,
+      dispatch
+    })
+    const leaseId = await owner.onRootTurnStarted({
+      sessionId: 'session-1',
+      originatingPromptId: 'root-prompt'
+    })
+    owner.trackUnobservedAttempts({
+      sessionId: 'session-1',
+      originatingPromptId: 'root-prompt',
+      attempts: [
+        { frameId: 'collected', attemptId: 'attempt-collected', name: 'collected' },
+        { frameId: 'detached', attemptId: 'attempt-detached', name: 'detached' }
+      ]
+    })
+    owner.markAttemptsObserved({
+      sessionId: 'session-1',
+      originatingPromptId: 'root-prompt',
+      attempts: [{ frameId: 'collected', attemptId: 'attempt-collected' }]
+    })
+    current = snapshot([child('collected', 'completed'), child('detached', 'error')])
+
+    await owner.onRootTurnEnded({
+      sessionId: 'session-1',
+      originatingPromptId: 'root-prompt',
+      clean: true,
+      leaseId
+    })
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(dispatch).toHaveBeenCalledOnce()
+    expect(dispatch.mock.calls[0]?.[0]?.text).toContain('detached')
+    expect(dispatch.mock.calls[0]?.[0]?.text).not.toContain('collected')
+    vi.useRealTimers()
+  })
+
+  it.each(['throw', 'reject'] as const)(
+    'restores a settlement batch when continuation dispatch %s fails before acceptance',
+    async (failure) => {
+      vi.useFakeTimers()
+      let current = snapshot([])
+      let dispatchAttempt = 0
+      const dispatch = vi.fn((request: DelegationSettlementDispatch): Promise<void> | void => {
+        void request
+        dispatchAttempt += 1
+        if (dispatchAttempt !== 1) return Promise.resolve()
+        if (failure === 'throw') throw new Error('runtime unavailable')
+        return Promise.reject(new Error('runtime unavailable'))
+      })
+      const owner = new DelegationSettlementWakeOwner({
+        readSnapshot: async () => current,
+        dispatch,
+        createPromptId: () => `wake-${dispatchAttempt + 1}`
+      })
+      await endRootTurn(
+        owner,
+        { sessionId: 'session-1', originatingPromptId: 'root-prompt', clean: true },
+        () => {
+          current = snapshot([child('retry-me', 'running')])
+        }
+      )
+      current = snapshot([child('retry-me', 'completed')])
+      await owner.onRecordsChanged('session-1')
+
+      await vi.advanceTimersByTimeAsync(100)
+      await Promise.resolve()
+      expect(dispatch).toHaveBeenCalledOnce()
+      await vi.advanceTimersByTimeAsync(100)
+
+      expect(dispatch).toHaveBeenCalledTimes(2)
+      expect(dispatch.mock.calls[0]?.[0]?.text).toContain('retry-me')
+      expect(dispatch.mock.calls[1]?.[0]?.text).toContain('retry-me')
+      vi.useRealTimers()
+    }
+  )
+
+  it('backs off repeated pre-accept failures instead of polling the repository at 10Hz', async () => {
+    vi.useFakeTimers()
+    let current = snapshot([])
+    const dispatch = vi.fn(async () => {
+      throw new Error('runtime remains unavailable')
+    })
+    const owner = new DelegationSettlementWakeOwner({
+      readSnapshot: async () => current,
+      dispatch
+    })
+    await endRootTurn(
+      owner,
+      { sessionId: 'session-1', originatingPromptId: 'root-prompt', clean: true },
+      () => {
+        current = snapshot([child('retry-with-backoff', 'running')])
+      }
+    )
+    current = snapshot([child('retry-with-backoff', 'completed')])
+    await owner.onRecordsChanged('session-1')
+
+    await vi.advanceTimersByTimeAsync(1_600)
+
+    expect(dispatch).toHaveBeenCalledTimes(5)
+    vi.useRealTimers()
+  })
+
   it('reconciles the root-end race and ignores terminal, nested, and unrelated Attempts', async () => {
     vi.useFakeTimers()
     const current = snapshot([

--- a/src/main/delegation/delegation-settlement-wake-owner.ts
+++ b/src/main/delegation/delegation-settlement-wake-owner.ts
@@ -6,6 +6,8 @@ import {
 
 type SettledStatus = DurableSettledAttemptStatus
 
+const MAX_RETRY_DELAY_MS = 5_000
+
 type DelegationSettlementAttempt = Readonly<{
   frameId: string
   attemptId: string
@@ -63,10 +65,19 @@ type SessionWakeState = {
   watches: Map<string, Watch>
   turnLeases: Map<
     string,
-    Readonly<{ originatingPromptId: string; baselineAttemptKeys: ReadonlySet<string> }>
+    {
+      originatingPromptId: string
+      baselineAttemptKeys: ReadonlySet<string>
+      unobserved: Map<string, WatchedAttempt>
+    }
   >
-  flight?: Readonly<{ promptId: string; originatingPromptId: string }>
+  flight?: Readonly<{
+    promptId: string
+    originatingPromptId: string
+    items: readonly SettlementItem[]
+  }>
   timer?: ReturnType<typeof setTimeout>
+  retryDelayMs?: number
 }
 
 const handleKey = (frameId: string, attemptId: string): string => `${frameId}\u0000${attemptId}`
@@ -119,7 +130,8 @@ class DelegationSettlementWakeOwner {
     const leaseId = randomUUID()
     state.turnLeases.set(leaseId, {
       originatingPromptId: input.originatingPromptId,
-      baselineAttemptKeys: new Set()
+      baselineAttemptKeys: new Set(),
+      unobserved: new Map()
     })
     let snapshot: DelegationSettlementSnapshot | undefined
     try {
@@ -140,9 +152,44 @@ class DelegationSettlementWakeOwner {
       originatingPromptId: input.originatingPromptId,
       baselineAttemptKeys: new Set(
         snapshot?.attempts.map((attempt) => handleKey(attempt.frameId, attempt.attemptId)) ?? []
-      )
+      ),
+      unobserved: state.turnLeases.get(leaseId)?.unobserved ?? new Map()
     })
     return leaseId
+  }
+
+  trackUnobservedAttempts(
+    input: Readonly<{
+      sessionId: string
+      originatingPromptId: string
+      attempts: readonly WatchedAttempt[]
+    }>
+  ): void {
+    const state = this.sessions.get(input.sessionId)
+    if (!state) return
+    for (const lease of state.turnLeases.values()) {
+      if (lease.originatingPromptId !== input.originatingPromptId) continue
+      for (const attempt of input.attempts) {
+        lease.unobserved.set(handleKey(attempt.frameId, attempt.attemptId), attempt)
+      }
+    }
+  }
+
+  markAttemptsObserved(
+    input: Readonly<{
+      sessionId: string
+      originatingPromptId: string
+      attempts: readonly Readonly<{ frameId: string; attemptId: string }>[]
+    }>
+  ): void {
+    const state = this.sessions.get(input.sessionId)
+    if (!state) return
+    for (const lease of state.turnLeases.values()) {
+      if (lease.originatingPromptId !== input.originatingPromptId) continue
+      for (const attempt of input.attempts) {
+        lease.unobserved.delete(handleKey(attempt.frameId, attempt.attemptId))
+      }
+    }
   }
 
   onRootTurnEnded(
@@ -169,22 +216,28 @@ class DelegationSettlementWakeOwner {
         return
       }
       const remaining = new Map<string, WatchedAttempt>()
+      const pending = new Map<string, SettlementItem>()
       for (const attempt of snapshot.attempts) {
+        const key = handleKey(attempt.frameId, attempt.attemptId)
         if (
-          attempt.status !== 'running' ||
           attempt.parentFrameId !== snapshot.rootFrameId ||
           attempt.originatingPromptId !== input.originatingPromptId ||
-          lease.baselineAttemptKeys.has(handleKey(attempt.frameId, attempt.attemptId))
+          (lease.baselineAttemptKeys.has(key) && !lease.unobserved.has(key))
         ) {
           continue
         }
-        remaining.set(handleKey(attempt.frameId, attempt.attemptId), {
+        const watched = lease.unobserved.get(key) ?? {
           frameId: attempt.frameId,
           attemptId: attempt.attemptId,
           name: attempt.name
-        })
+        }
+        if (isDelegatedAttemptSettled(attempt.status)) {
+          if (lease.unobserved.has(key)) pending.set(key, { ...watched, status: attempt.status })
+        } else {
+          remaining.set(key, watched)
+        }
       }
-      if (remaining.size === 0) {
+      if (remaining.size === 0 && pending.size === 0) {
         this.deleteIfIdle(input.sessionId, state)
         return
       }
@@ -198,6 +251,10 @@ class DelegationSettlementWakeOwner {
         for (const [key, watched] of remaining) {
           if (!existing.pending.has(key)) existing.remaining.set(key, watched)
         }
+        for (const [key, settled] of pending) {
+          existing.remaining.delete(key)
+          existing.pending.set(key, settled)
+        }
       } else {
         state.watches.set(input.originatingPromptId, {
           projectId: snapshot.projectId,
@@ -205,7 +262,7 @@ class DelegationSettlementWakeOwner {
           rootFrameId: snapshot.rootFrameId,
           ...(snapshot.rootBranchId ? { rootBranchId: snapshot.rootBranchId } : {}),
           remaining,
-          pending: new Map()
+          pending
         })
       }
       await this.reconcile(input.sessionId, state)
@@ -224,6 +281,7 @@ class DelegationSettlementWakeOwner {
     return this.enqueueExisting(sessionId, state, async () => {
       if (state.flight?.promptId !== promptId) return
       state.flight = undefined
+      state.retryDelayMs = undefined
       this.cleanupWatches(state)
       if (this.hasPending(state)) this.schedule(sessionId, state)
       else this.deleteIfIdle(sessionId, state)
@@ -338,6 +396,7 @@ class DelegationSettlementWakeOwner {
 
   private schedule(sessionId: string, state: SessionWakeState): void {
     if (state.timer || state.flight) return
+    const delayMs = state.retryDelayMs ?? this.debounceMs
     state.timer = setTimeout(() => {
       state.timer = undefined
       void this.enqueueExisting(sessionId, state, async () => {
@@ -348,7 +407,11 @@ class DelegationSettlementWakeOwner {
         const items = stableItems(selected.pending.values())
         selected.pending.clear()
         const promptId = this.createPromptId()
-        state.flight = { promptId, originatingPromptId: selected.originatingPromptId }
+        state.flight = {
+          promptId,
+          originatingPromptId: selected.originatingPromptId,
+          items
+        }
         const request: DelegationSettlementDispatch = {
           projectId: selected.projectId,
           sessionId,
@@ -367,7 +430,7 @@ class DelegationSettlementWakeOwner {
           this.clearFailedFlight(sessionId, state, promptId)
         }
       })
-    }, this.debounceMs)
+    }, delayMs)
   }
 
   private onDispatchFailed(sessionId: string, promptId: string): Promise<void> {
@@ -379,8 +442,19 @@ class DelegationSettlementWakeOwner {
   }
 
   private clearFailedFlight(sessionId: string, state: SessionWakeState, promptId: string): void {
-    if (state.flight?.promptId !== promptId) return
+    const flight = state.flight
+    if (flight?.promptId !== promptId) return
+    const watch = state.watches.get(flight.originatingPromptId)
+    if (watch) {
+      for (const item of flight.items) {
+        watch.pending.set(handleKey(item.frameId, item.attemptId), item)
+      }
+    }
     state.flight = undefined
+    state.retryDelayMs = Math.min(
+      state.retryDelayMs === undefined ? Math.max(this.debounceMs, 1) : state.retryDelayMs * 2,
+      MAX_RETRY_DELAY_MS
+    )
     this.cleanupWatches(state)
     if (this.hasPending(state)) this.schedule(sessionId, state)
     else this.deleteIfIdle(sessionId, state)

--- a/src/main/delegation/delegation-settlement-wake-owner.ts
+++ b/src/main/delegation/delegation-settlement-wake-owner.ts
@@ -1,0 +1,425 @@
+import { randomUUID } from 'node:crypto'
+import {
+  isDelegatedAttemptSettled,
+  type DurableSettledAttemptStatus
+} from './delegated-work-record-invariants'
+
+type SettledStatus = DurableSettledAttemptStatus
+
+type DelegationSettlementAttempt = Readonly<{
+  frameId: string
+  attemptId: string
+  parentFrameId: string
+  originatingPromptId: string
+  name: string
+  status: 'running' | SettledStatus
+}>
+
+type DelegationSettlementSnapshot = Readonly<{
+  projectId: string
+  sessionId: string
+  rootFrameId: string
+  rootBranchId?: string
+  activeRootPromptIds: readonly string[]
+  attempts: readonly DelegationSettlementAttempt[]
+}>
+
+type DelegationSettlementDispatch = Readonly<{
+  projectId: string
+  sessionId: string
+  originatingPromptId: string
+  rootFrameId: string
+  rootBranchId?: string
+  promptId: string
+  text: string
+}>
+
+type DelegationSettlementWakeOwnerOptions = Readonly<{
+  readSnapshot(sessionId: string): Promise<DelegationSettlementSnapshot | undefined>
+  dispatch(request: DelegationSettlementDispatch): Promise<void> | void
+  createPromptId?: () => string
+  debounceMs?: number
+}>
+
+type WatchedAttempt = Readonly<{
+  frameId: string
+  attemptId: string
+  name: string
+}>
+
+type SettlementItem = WatchedAttempt & Readonly<{ status: SettledStatus }>
+
+type Watch = {
+  projectId: string
+  originatingPromptId: string
+  rootFrameId: string
+  rootBranchId?: string
+  remaining: Map<string, WatchedAttempt>
+  pending: Map<string, SettlementItem>
+}
+
+type SessionWakeState = {
+  tail: Promise<void>
+  watches: Map<string, Watch>
+  turnLeases: Map<
+    string,
+    Readonly<{ originatingPromptId: string; baselineAttemptKeys: ReadonlySet<string> }>
+  >
+  flight?: Readonly<{ promptId: string; originatingPromptId: string }>
+  timer?: ReturnType<typeof setTimeout>
+}
+
+const handleKey = (frameId: string, attemptId: string): string => `${frameId}\u0000${attemptId}`
+
+const stableItems = (items: Iterable<SettlementItem>): SettlementItem[] =>
+  [...items].sort(
+    (left, right) =>
+      left.frameId.localeCompare(right.frameId) || left.attemptId.localeCompare(right.attemptId)
+  )
+
+const settlementText = (items: readonly SettlementItem[], remaining: number): string => {
+  const lines = items.map(
+    ({ name, frameId, attemptId, status }) =>
+      `- ${name}: frame=${frameId}; attempt=${attemptId}; status=${status}`
+  )
+  const summary =
+    remaining === 0
+      ? 'All watched Subagent Attempts have settled.'
+      : `${remaining} watched Subagent Attempt${remaining === 1 ? ' remains' : 's remain'} running.`
+  return [
+    'Delegated work settlement update (application-owned context, not a user message).',
+    'The following Subagent Attempts newly settled; settled does not imply success:',
+    ...lines,
+    summary,
+    'Use the exact Frame/Attempt identities if you choose to collect results. Decide whether to inspect evidence, handle failures, continue waiting, or update the user.'
+  ].join('\n')
+}
+
+class DelegationSettlementWakeOwner {
+  private readonly sessions = new Map<string, SessionWakeState>()
+  private readonly debounceMs: number
+  private readonly createPromptId: () => string
+  private stopped = false
+
+  constructor(private readonly options: DelegationSettlementWakeOwnerOptions) {
+    this.debounceMs = options.debounceMs ?? 100
+    this.createPromptId = options.createPromptId ?? (() => `delegation-settlement-${randomUUID()}`)
+  }
+
+  async onRootTurnStarted(
+    input: Readonly<{ sessionId: string; originatingPromptId: string }>
+  ): Promise<string | undefined> {
+    if (this.stopped) return undefined
+    const state = this.sessions.get(input.sessionId) ?? {
+      tail: Promise.resolve(),
+      watches: new Map(),
+      turnLeases: new Map()
+    }
+    if (!this.sessions.has(input.sessionId)) this.sessions.set(input.sessionId, state)
+    const leaseId = randomUUID()
+    state.turnLeases.set(leaseId, {
+      originatingPromptId: input.originatingPromptId,
+      baselineAttemptKeys: new Set()
+    })
+    let snapshot: DelegationSettlementSnapshot | undefined
+    try {
+      snapshot = await this.options.readSnapshot(input.sessionId)
+    } catch (error) {
+      state.turnLeases.delete(leaseId)
+      this.deleteIfIdle(input.sessionId, state)
+      throw error
+    }
+    if (
+      this.stopped ||
+      this.sessions.get(input.sessionId) !== state ||
+      !state.turnLeases.has(leaseId)
+    ) {
+      return undefined
+    }
+    state.turnLeases.set(leaseId, {
+      originatingPromptId: input.originatingPromptId,
+      baselineAttemptKeys: new Set(
+        snapshot?.attempts.map((attempt) => handleKey(attempt.frameId, attempt.attemptId)) ?? []
+      )
+    })
+    return leaseId
+  }
+
+  onRootTurnEnded(
+    input: Readonly<{
+      sessionId: string
+      originatingPromptId: string
+      clean: boolean
+      leaseId?: string
+    }>
+  ): Promise<void> {
+    const state = this.sessions.get(input.sessionId)
+    if (!state || !input.leaseId) return Promise.resolve()
+    return this.enqueueExisting(input.sessionId, state, async () => {
+      const lease = state.turnLeases.get(input.leaseId!)
+      if (lease?.originatingPromptId !== input.originatingPromptId) return
+      state.turnLeases.delete(input.leaseId!)
+      if (!input.clean) {
+        this.deleteIfIdle(input.sessionId, state)
+        return
+      }
+      const snapshot = await this.options.readSnapshot(input.sessionId)
+      if (!snapshot || !snapshot.activeRootPromptIds.includes(input.originatingPromptId)) {
+        this.deleteIfIdle(input.sessionId, state)
+        return
+      }
+      const remaining = new Map<string, WatchedAttempt>()
+      for (const attempt of snapshot.attempts) {
+        if (
+          attempt.status !== 'running' ||
+          attempt.parentFrameId !== snapshot.rootFrameId ||
+          attempt.originatingPromptId !== input.originatingPromptId ||
+          lease.baselineAttemptKeys.has(handleKey(attempt.frameId, attempt.attemptId))
+        ) {
+          continue
+        }
+        remaining.set(handleKey(attempt.frameId, attempt.attemptId), {
+          frameId: attempt.frameId,
+          attemptId: attempt.attemptId,
+          name: attempt.name
+        })
+      }
+      if (remaining.size === 0) {
+        this.deleteIfIdle(input.sessionId, state)
+        return
+      }
+      const existing = state.watches.get(input.originatingPromptId)
+      if (
+        existing &&
+        existing.projectId === snapshot.projectId &&
+        existing.rootFrameId === snapshot.rootFrameId
+      ) {
+        existing.rootBranchId = snapshot.rootBranchId
+        for (const [key, watched] of remaining) {
+          if (!existing.pending.has(key)) existing.remaining.set(key, watched)
+        }
+      } else {
+        state.watches.set(input.originatingPromptId, {
+          projectId: snapshot.projectId,
+          originatingPromptId: input.originatingPromptId,
+          rootFrameId: snapshot.rootFrameId,
+          ...(snapshot.rootBranchId ? { rootBranchId: snapshot.rootBranchId } : {}),
+          remaining,
+          pending: new Map()
+        })
+      }
+      await this.reconcile(input.sessionId, state)
+    })
+  }
+
+  onRecordsChanged(sessionId: string): Promise<void> {
+    const state = this.sessions.get(sessionId)
+    if (!state) return Promise.resolve()
+    return this.enqueueExisting(sessionId, state, () => this.reconcile(sessionId, state))
+  }
+
+  onWakePromptEnded(sessionId: string, promptId: string): Promise<void> {
+    const state = this.sessions.get(sessionId)
+    if (!state) return Promise.resolve()
+    return this.enqueueExisting(sessionId, state, async () => {
+      if (state.flight?.promptId !== promptId) return
+      state.flight = undefined
+      this.cleanupWatches(state)
+      if (this.hasPending(state)) this.schedule(sessionId, state)
+      else this.deleteIfIdle(sessionId, state)
+    })
+  }
+
+  invalidateSession(sessionId: string): void {
+    const state = this.sessions.get(sessionId)
+    if (state?.timer) clearTimeout(state.timer)
+    this.sessions.delete(sessionId)
+  }
+
+  async invalidateProject(projectId: string): Promise<void> {
+    const invalidations: Promise<void>[] = []
+    for (const [sessionId, state] of this.sessions) {
+      invalidations.push(
+        this.enqueueExisting(sessionId, state, async () => {
+          const snapshot = await this.options.readSnapshot(sessionId)
+          if (this.sessions.get(sessionId) !== state) return
+          if (snapshot?.projectId === projectId) {
+            if (state.timer) clearTimeout(state.timer)
+            state.watches.clear()
+            state.turnLeases.clear()
+            state.flight = undefined
+            state.timer = undefined
+            this.sessions.delete(sessionId)
+            return
+          }
+          const invalidatedOrigins = new Set<string>()
+          for (const [originatingPromptId, watch] of state.watches) {
+            if (watch.projectId !== projectId) continue
+            invalidatedOrigins.add(originatingPromptId)
+            state.watches.delete(originatingPromptId)
+          }
+          if (state.flight && invalidatedOrigins.has(state.flight.originatingPromptId)) {
+            state.flight = undefined
+          }
+          this.finishInvalidation(sessionId, state)
+        })
+      )
+    }
+    await Promise.all(invalidations)
+  }
+
+  invalidateBranch(sessionId: string, originatingPromptId: string): Promise<void> {
+    const state = this.sessions.get(sessionId)
+    if (!state) return Promise.resolve()
+    return this.enqueueExisting(sessionId, state, async () => {
+      state.watches.delete(originatingPromptId)
+      for (const [leaseId, lease] of state.turnLeases) {
+        if (lease.originatingPromptId === originatingPromptId) state.turnLeases.delete(leaseId)
+      }
+      this.finishInvalidation(sessionId, state)
+    })
+  }
+
+  shutdown(): void {
+    this.stopped = true
+    for (const state of this.sessions.values()) if (state.timer) clearTimeout(state.timer)
+    this.sessions.clear()
+  }
+
+  private enqueueExisting(
+    sessionId: string,
+    state: SessionWakeState,
+    operation: () => Promise<void>
+  ): Promise<void> {
+    const result = state.tail.then(async () => {
+      if (this.sessions.get(sessionId) !== state) return
+      await operation()
+    })
+    state.tail = result.catch(() => undefined)
+    return result
+  }
+
+  private async reconcile(
+    sessionId: string,
+    state: SessionWakeState,
+    schedulePending = true
+  ): Promise<void> {
+    const snapshot = await this.options.readSnapshot(sessionId)
+    if (this.sessions.get(sessionId) !== state) return
+    if (!snapshot) {
+      this.invalidateSession(sessionId)
+      return
+    }
+    const active = new Set(snapshot.activeRootPromptIds)
+    const attempts = new Map(
+      snapshot.attempts.map((attempt) => [handleKey(attempt.frameId, attempt.attemptId), attempt])
+    )
+    for (const [originatingPromptId, watch] of state.watches) {
+      if (!active.has(originatingPromptId) || watch.projectId !== snapshot.projectId) {
+        state.watches.delete(originatingPromptId)
+        continue
+      }
+      for (const [key, watched] of watch.remaining) {
+        const attempt = attempts.get(key)
+        if (!attempt) {
+          watch.remaining.delete(key)
+          continue
+        }
+        if (isDelegatedAttemptSettled(attempt.status)) {
+          watch.remaining.delete(key)
+          watch.pending.set(key, { ...watched, status: attempt.status })
+        }
+      }
+    }
+    this.cleanupWatches(state)
+    if (schedulePending && !state.flight && this.hasPending(state)) this.schedule(sessionId, state)
+    else this.deleteIfIdle(sessionId, state)
+  }
+
+  private schedule(sessionId: string, state: SessionWakeState): void {
+    if (state.timer || state.flight) return
+    state.timer = setTimeout(() => {
+      state.timer = undefined
+      void this.enqueueExisting(sessionId, state, async () => {
+        await this.reconcile(sessionId, state, false)
+        if (this.sessions.get(sessionId) !== state || state.flight) return
+        const selected = [...state.watches.values()].find((watch) => watch.pending.size > 0)
+        if (!selected) return
+        const items = stableItems(selected.pending.values())
+        selected.pending.clear()
+        const promptId = this.createPromptId()
+        state.flight = { promptId, originatingPromptId: selected.originatingPromptId }
+        const request: DelegationSettlementDispatch = {
+          projectId: selected.projectId,
+          sessionId,
+          originatingPromptId: selected.originatingPromptId,
+          rootFrameId: selected.rootFrameId,
+          ...(selected.rootBranchId ? { rootBranchId: selected.rootBranchId } : {}),
+          promptId,
+          text: settlementText(items, selected.remaining.size)
+        }
+        try {
+          const dispatched = this.options.dispatch(request)
+          void Promise.resolve(dispatched).catch(() => {
+            void this.onDispatchFailed(sessionId, promptId)
+          })
+        } catch {
+          this.clearFailedFlight(sessionId, state, promptId)
+        }
+      })
+    }, this.debounceMs)
+  }
+
+  private onDispatchFailed(sessionId: string, promptId: string): Promise<void> {
+    const state = this.sessions.get(sessionId)
+    if (!state) return Promise.resolve()
+    return this.enqueueExisting(sessionId, state, async () => {
+      this.clearFailedFlight(sessionId, state, promptId)
+    })
+  }
+
+  private clearFailedFlight(sessionId: string, state: SessionWakeState, promptId: string): void {
+    if (state.flight?.promptId !== promptId) return
+    state.flight = undefined
+    this.cleanupWatches(state)
+    if (this.hasPending(state)) this.schedule(sessionId, state)
+    else this.deleteIfIdle(sessionId, state)
+  }
+
+  private cleanupWatches(state: SessionWakeState): void {
+    for (const [origin, watch] of state.watches) {
+      const ownsFlight = state.flight?.originatingPromptId === origin
+      if (watch.remaining.size === 0 && watch.pending.size === 0 && !ownsFlight) {
+        state.watches.delete(origin)
+      }
+    }
+  }
+
+  private hasPending(state: SessionWakeState): boolean {
+    return [...state.watches.values()].some((watch) => watch.pending.size > 0)
+  }
+
+  private finishInvalidation(sessionId: string, state: SessionWakeState): void {
+    if (state.timer && !this.hasPending(state)) {
+      clearTimeout(state.timer)
+      state.timer = undefined
+    }
+    if (!state.flight && this.hasPending(state)) this.schedule(sessionId, state)
+    else this.deleteIfIdle(sessionId, state)
+  }
+
+  private deleteIfIdle(sessionId: string, state: SessionWakeState): void {
+    if (this.sessions.get(sessionId) !== state) return
+    if (!state.flight && !state.timer && state.watches.size === 0 && state.turnLeases.size === 0) {
+      this.sessions.delete(sessionId)
+    }
+  }
+}
+
+export { DelegationSettlementWakeOwner }
+export type {
+  DelegationSettlementAttempt,
+  DelegationSettlementDispatch,
+  DelegationSettlementSnapshot,
+  DelegationSettlementWakeOwnerOptions
+}

--- a/src/main/delegation/durable-delegated-work.test.ts
+++ b/src/main/delegation/durable-delegated-work.test.ts
@@ -2979,6 +2979,103 @@ describe('durable delegated work', () => {
     ).resolves.toMatchObject([{ status: 'completed', response: 'later' }])
   })
 
+  it('returns every pinned observation in caller order when any Attempt settles', async () => {
+    const execution = createDeterministicDelegateExecution()
+    const records = createInMemoryDelegatedWorkRecords({
+      session: caller.session,
+      rootFrameId: caller.frameId,
+      originMessageId: caller.originMessageId
+    })
+    const work = createDurableDelegatedWork({ execution, records, collectPollIntervalMs: 1 })
+    const dispatched = await work.delegate(
+      caller,
+      [
+        { task: 'first', name: 'first' },
+        { task: 'second', name: 'second' }
+      ],
+      { wait: false }
+    )
+    await expect.poll(() => execution.controls()).toHaveLength(2)
+    for (const control of execution.controls()) control.accept()
+
+    await expect(
+      work.collect(caller, [dispatched.children[1].frameId, dispatched.children[0].frameId], {
+        returnWhen: 'any',
+        timeoutSeconds: 0
+      })
+    ).resolves.toMatchObject([{ status: 'running' }, { status: 'running' }])
+
+    const collecting = work.collect(
+      caller,
+      [dispatched.children[1].frameId, dispatched.children[0].frameId],
+      { returnWhen: 'any', timeoutSeconds: 1 }
+    )
+    execution.controls()[0].complete('first result')
+
+    await expect(collecting).resolves.toMatchObject([
+      { frameId: dispatched.children[1].frameId, status: 'running' },
+      {
+        frameId: dispatched.children[0].frameId,
+        status: 'completed',
+        response: 'first result'
+      }
+    ])
+    await expect(work.children(caller)).resolves.toMatchObject([
+      { status: 'completed' },
+      { status: 'running' }
+    ])
+    execution.controls()[1].complete('second result')
+  })
+
+  it('validates collect returnWhen before observing and defaults to all', async () => {
+    const execution = createDeterministicDelegateExecution()
+    const records = createInMemoryDelegatedWorkRecords({
+      session: caller.session,
+      rootFrameId: caller.frameId,
+      originMessageId: caller.originMessageId
+    })
+    const work = createDurableDelegatedWork({ execution, records })
+    const dispatched = await work.delegate(
+      caller,
+      [
+        { task: 'terminal', name: 'terminal' },
+        { task: 'running', name: 'running' }
+      ],
+      { wait: false }
+    )
+    await expect.poll(() => execution.controls()).toHaveLength(2)
+    for (const control of execution.controls()) control.accept()
+    execution.controls()[0].complete('done')
+    await expect
+      .poll(() => work.children(caller))
+      .toMatchObject([{ status: 'completed' }, { status: 'running' }])
+
+    await expect(
+      work.collect(
+        caller,
+        dispatched.children.map(({ frameId }) => frameId),
+        {
+          returnWhen: 'any'
+        }
+      )
+    ).resolves.toMatchObject([{ status: 'completed' }, { status: 'running' }])
+    await expect(
+      work.collect(
+        caller,
+        dispatched.children.map(({ frameId }) => frameId),
+        {
+          timeoutSeconds: 0
+        }
+      )
+    ).resolves.toMatchObject([{ status: 'completed' }, { status: 'running' }])
+    await expect(
+      work.collect(caller, [dispatched.children[0].frameId], {
+        returnWhen: 'first' as 'any'
+      })
+    ).rejects.toMatchObject({ code: 'admission_rejection' })
+    execution.controls()[1].complete('later')
+  })
+
   it('pins explicit Attempt handles and rejects mismatched pairs as one batch', async () => {
     const execution = createDeterministicDelegateExecution()
     const records = createInMemoryDelegatedWorkRecords({
@@ -3006,6 +3103,7 @@ describe('durable delegated work', () => {
 
     await expect(
       work.collect(caller, [{ frameId: handle.frameId, attemptId: handle.attemptId }], {
+        returnWhen: 'any',
         timeoutSeconds: 0
       })
     ).resolves.toEqual([
@@ -3924,9 +4022,26 @@ describe('durable delegated work', () => {
       { task: 'Cancellation', name: 'Cancellation' },
       { wait: false }
     )
-    await expect.poll(() => execution.controls()).toHaveLength(2)
+    const running = await work.delegate(
+      { ...caller, toolInvocationId: 'tool-call-3' },
+      { task: 'Running', name: 'Running' },
+      { wait: false }
+    )
+    await expect.poll(() => execution.controls()).toHaveLength(3)
     execution.controls()[1].accept()
     execution.controls()[1].cancel()
+    execution.controls()[2].accept()
+
+    await expect(
+      work.collect(caller, [failed.children[0].frameId, running.children[0].frameId], {
+        returnWhen: 'any'
+      })
+    ).resolves.toMatchObject([{ status: 'error' }, { status: 'running' }])
+    await expect(
+      work.collect(caller, [running.children[0].frameId, cancelled.children[0].frameId], {
+        returnWhen: 'any'
+      })
+    ).resolves.toMatchObject([{ status: 'running' }, { status: 'cancelled' }])
 
     await expect(
       work.collect(caller, [cancelled.children[0].frameId, failed.children[0].frameId])
@@ -3954,8 +4069,11 @@ describe('durable delegated work', () => {
       code: 'admission_rejection'
     })
     await expect(
-      work.collect(caller, [failed.children[0].frameId, 'unknown-frame'])
+      work.collect(caller, [failed.children[0].frameId, 'unknown-frame'], {
+        returnWhen: 'any'
+      })
     ).rejects.toMatchObject({ code: 'authorization' })
+    execution.controls()[2].complete('later')
     await expect(
       work.collect({ ...caller, session: { ...caller.session, sessionId: 'session-2' } }, [
         failed.children[0].frameId

--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -615,6 +615,106 @@ describe('production delegated-work composition', () => {
     vi.useRealTimers()
   })
 
+  it('wakes when a detached child settles before the originating root turn ends', async () => {
+    vi.useFakeTimers()
+    root = await mkdtemp(join(tmpdir(), 'delegated-production-early-settlement-wake-'))
+    const dispatch = vi.fn(async (request: DelegationSettlementDispatch) => {
+      void request
+    })
+    const harness = await createCompositionHarness(
+      root,
+      'codex',
+      createDeterministicDelegateExecution(),
+      undefined,
+      { settlementContinuations: { dispatch } }
+    )
+    const leaseId = await harness.composition.root.rootTurnStarted?.({
+      sessionId: harness.session.id,
+      originatingPromptId: harness.caller.originMessageId
+    })
+    const receipt = await harness.composition.host.delegate(
+      harness.caller,
+      { task: 'finish before root end', name: 'Fast background check' },
+      { wait: false }
+    )
+    const detached = receipt.children[0]
+    await expect.poll(() => harness.execution.controls()).toHaveLength(1)
+    harness.execution.control(detached.attemptId).accept()
+    harness.execution.control(detached.attemptId).complete('fast canonical final')
+    await expect
+      .poll(() => harness.composition.host.children(harness.caller))
+      .toMatchObject([{ status: 'completed' }])
+
+    await harness.composition.root.rootTurnEnded?.({
+      sessionId: harness.session.id,
+      originatingPromptId: harness.caller.originMessageId,
+      clean: true,
+      leaseId
+    })
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(dispatch).toHaveBeenCalledOnce()
+    expect(dispatch.mock.calls[0]?.[0]?.text).toContain(detached.attemptId)
+    expect(dispatch.mock.calls[0]?.[0]?.text).toContain('status=completed')
+    vi.useRealTimers()
+  })
+
+  it('does not wake for terminal child results already returned in the originating root turn', async () => {
+    root = await mkdtemp(join(tmpdir(), 'delegated-production-observed-settlement-'))
+    const dispatch = vi.fn(async (request: DelegationSettlementDispatch) => {
+      void request
+    })
+    const harness = await createCompositionHarness(
+      root,
+      'codex',
+      createDeterministicDelegateExecution(),
+      undefined,
+      { settlementContinuations: { dispatch } }
+    )
+    const leaseId = await harness.composition.root.rootTurnStarted?.({
+      sessionId: harness.session.id,
+      originatingPromptId: harness.caller.originMessageId
+    })
+    const receipt = await harness.composition.host.delegate(
+      harness.caller,
+      { task: 'collect before root end', name: 'Collected child' },
+      { wait: false }
+    )
+    const collectedChild = receipt.children[0]
+    const collecting = harness.composition.host.collect(
+      { ...harness.caller, toolInvocationId: 'observe-terminal-child' },
+      [collectedChild]
+    )
+    await expect.poll(() => harness.execution.controls()).toHaveLength(1)
+    harness.execution.control(collectedChild.attemptId).accept()
+    harness.execution.control(collectedChild.attemptId).complete('observed result')
+    await expect(collecting).resolves.toMatchObject([{ status: 'completed' }])
+
+    const waited = harness.composition.host.delegate(
+      { ...harness.caller, toolInvocationId: 'wait-for-terminal-child' },
+      { task: 'return normally', name: 'Waited child' },
+      {}
+    )
+    await expect.poll(() => harness.execution.controls()).toHaveLength(2)
+    const waitedControl = harness.execution.controls()[1]
+    waitedControl.accept()
+    waitedControl.complete('waited result')
+    await expect(waited).resolves.toMatchObject({ kind: 'results' })
+
+    vi.useFakeTimers()
+    await harness.composition.root.rootTurnEnded?.({
+      sessionId: harness.session.id,
+      originatingPromptId: harness.caller.originMessageId,
+      clean: true,
+      leaseId
+    })
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+    vi.useRealTimers()
+  })
+
   it('batches three staggered children without overlapping Session wake continuations', async () => {
     vi.useFakeTimers()
     root = await mkdtemp(join(tmpdir(), 'delegated-production-staggered-wake-'))
@@ -690,7 +790,9 @@ describe('production delegated-work composition', () => {
   it('runs same-turn collect and staggered settlement wakes through ACP admission and terminal callbacks', async () => {
     vi.useFakeTimers()
     root = await mkdtemp(join(tmpdir(), 'delegated-production-acp-settlement-chain-'))
-    const productionDispatch: { current?: (request: DelegationSettlementDispatch) => void } = {}
+    const productionDispatch: {
+      current?: (request: DelegationSettlementDispatch) => Promise<void>
+    } = {}
     const harness = await createCompositionHarness(
       root,
       'codex',
@@ -788,7 +890,8 @@ describe('production delegated-work composition', () => {
     )
     const promptEnded: Array<Readonly<{ sessionId: string; promptId: string }>> = []
     productionDispatch.current = createDelegationSettlementContinuationDispatch({
-      sendAppContinuation: (request) => coordinator.sendAppContinuation(request),
+      sendAppContinuationObserved: (request, onProviderPromptAccepted) =>
+        coordinator.sendAppContinuationObserved(request, onProviderPromptAccepted),
       onPromptEnded: (sessionId, promptId) => {
         promptEnded.push({ sessionId, promptId })
         return harness.composition.root.settlementPromptEnded?.(sessionId, promptId)

--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -46,9 +46,14 @@ import { finalizeDelegatedArtifactPublication } from './delegated-artifact-publi
 import { createProductionDelegatedFrameworks } from './production-frameworks'
 import type { AcpDelegateExecutionCallbacks, AcpDelegateRuntime } from './acp-execution'
 import type { DelegateExecutionInput } from './execution-port'
+import type { DelegationSettlementDispatch } from './delegation-settlement-wake-owner'
 import { claudeCodeFramework } from '../agent-framework'
 import { CODEX_ACP_VERSION, CODEX_VERSION } from '../settings/managed-codex'
 import { preS6ReaderSave } from '../../shared/pre-s6-session-reader.fixture'
+import type { AcpPromptRequest, AcpStateSnapshot } from '../../shared/acp'
+import { AcpRuntimeCoordinator } from '../acp/runtime-coordinator'
+import type { AcpRuntime, AcpRuntimeCallbacks } from '../acp/runtime'
+import { createDelegationSettlementContinuationDispatch } from './settlement-continuation-dispatch'
 
 let root: string | undefined
 let server: NotebookLocalRpcServer | undefined
@@ -100,7 +105,7 @@ const createCompositionHarness = async (
   admissionError?: Error,
   owners: Pick<
     ProductionDelegatedWorkOptions,
-    'artifactEvidence' | 'reviewEvidence' | 'parentMessages'
+    'artifactEvidence' | 'reviewEvidence' | 'parentMessages' | 'settlementContinuations'
   > = {},
   initialRootInvocations: readonly Readonly<{
     rootMessageId: string
@@ -549,6 +554,7 @@ const createFrameworkCompositionHarness = async (
 }
 
 afterEach(async () => {
+  vi.useRealTimers()
   await server?.close()
   server = undefined
   await disconnect?.()
@@ -558,6 +564,412 @@ afterEach(async () => {
 })
 
 describe('production delegated-work composition', () => {
+  it('wakes the root through application context when a background child settles', async () => {
+    vi.useFakeTimers()
+    root = await mkdtemp(join(tmpdir(), 'delegated-production-settlement-wake-'))
+    const dispatch = vi.fn(async (request: DelegationSettlementDispatch) => {
+      void request
+    })
+    const harness = await createCompositionHarness(
+      root,
+      'codex',
+      createDeterministicDelegateExecution(),
+      undefined,
+      { settlementContinuations: { dispatch } }
+    )
+    const leaseId = await harness.composition.root.rootTurnStarted?.({
+      sessionId: harness.session.id,
+      originatingPromptId: harness.caller.originMessageId
+    })
+    const delegated = await harness.composition.host.delegate(
+      harness.caller,
+      { task: 'finish later', name: 'Background check' },
+      { wait: false }
+    )
+    await expect.poll(() => harness.execution.controls()).toHaveLength(1)
+    harness.execution.controls()[0].accept()
+    await harness.composition.root.rootTurnEnded?.({
+      sessionId: harness.session.id,
+      originatingPromptId: harness.caller.originMessageId,
+      clean: true,
+      leaseId
+    })
+
+    harness.execution.controls()[0].complete('canonical final')
+    await expect
+      .poll(() => harness.composition.host.children(harness.caller))
+      .toMatchObject([{ status: 'completed' }])
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(dispatch).toHaveBeenCalledOnce()
+    const request = dispatch.mock.calls[0]?.[0]
+    expect(request).toMatchObject({
+      projectId: harness.session.projectId,
+      sessionId: harness.session.id,
+      originatingPromptId: harness.caller.originMessageId
+    })
+    expect(request?.text).toContain(delegated.children[0].frameId)
+    expect(request?.text).toContain(delegated.children[0].attemptId)
+    expect(request?.text).not.toContain('canonical final')
+    expect(request?.text).toContain('application-owned context, not a user message')
+    vi.useRealTimers()
+  })
+
+  it('batches three staggered children without overlapping Session wake continuations', async () => {
+    vi.useFakeTimers()
+    root = await mkdtemp(join(tmpdir(), 'delegated-production-staggered-wake-'))
+    const dispatch = vi.fn(async (request: DelegationSettlementDispatch) => {
+      void request
+    })
+    const harness = await createCompositionHarness(
+      root,
+      'codex',
+      createDeterministicDelegateExecution(),
+      undefined,
+      { settlementContinuations: { dispatch } }
+    )
+    const leaseId = await harness.composition.root.rootTurnStarted?.({
+      sessionId: harness.session.id,
+      originatingPromptId: harness.caller.originMessageId
+    })
+    const delegated = await harness.composition.host.delegate(
+      harness.caller,
+      [
+        { task: 'alpha', name: 'Alpha' },
+        { task: 'beta', name: 'Beta' },
+        { task: 'gamma', name: 'Gamma' }
+      ],
+      { wait: false }
+    )
+    await expect.poll(() => harness.execution.controls()).toHaveLength(3)
+    for (const { attemptId } of delegated.children) harness.execution.control(attemptId).accept()
+    await harness.composition.root.rootTurnEnded?.({
+      sessionId: harness.session.id,
+      originatingPromptId: harness.caller.originMessageId,
+      clean: true,
+      leaseId
+    })
+
+    harness.execution.control(delegated.children[0].attemptId).complete('alpha result')
+    harness.execution.control(delegated.children[1].attemptId).complete('beta result')
+    await expect
+      .poll(() => harness.composition.host.children(harness.caller))
+      .toMatchObject([{ status: 'completed' }, { status: 'completed' }, { status: 'running' }])
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(dispatch).toHaveBeenCalledOnce()
+    const first = dispatch.mock.calls[0]?.[0]
+    expect(first?.text).toContain(delegated.children[0].frameId)
+    expect(first?.text).toContain(delegated.children[1].frameId)
+    expect(first?.text).not.toContain(delegated.children[2].frameId)
+
+    harness.execution.control(delegated.children[2].attemptId).complete('gamma result')
+    await expect
+      .poll(() => harness.composition.host.children(harness.caller))
+      .toMatchObject([{ status: 'completed' }, { status: 'completed' }, { status: 'completed' }])
+    await vi.advanceTimersByTimeAsync(200)
+    expect(dispatch).toHaveBeenCalledOnce()
+
+    await harness.composition.root.settlementPromptEnded?.(harness.session.id, first!.promptId)
+    await vi.advanceTimersByTimeAsync(100)
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    expect(dispatch.mock.calls[1]?.[0]?.text).toContain(delegated.children[2].frameId)
+    expect(dispatch.mock.calls[1]?.[0]?.text).toContain(
+      'All watched Subagent Attempts have settled'
+    )
+    const second = dispatch.mock.calls[1]?.[0]
+    await harness.composition.root.settlementPromptEnded?.(harness.session.id, second!.promptId)
+    await vi.advanceTimersByTimeAsync(500)
+    await harness.composition.root.settlementPromptEnded?.(harness.session.id, first!.promptId)
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    expect(vi.getTimerCount()).toBe(0)
+    vi.useRealTimers()
+  })
+
+  it('runs same-turn collect and staggered settlement wakes through ACP admission and terminal callbacks', async () => {
+    vi.useFakeTimers()
+    root = await mkdtemp(join(tmpdir(), 'delegated-production-acp-settlement-chain-'))
+    const productionDispatch: { current?: (request: DelegationSettlementDispatch) => void } = {}
+    const harness = await createCompositionHarness(
+      root,
+      'codex',
+      createDeterministicDelegateExecution(),
+      undefined,
+      { settlementContinuations: { dispatch: (request) => productionDispatch.current!(request) } }
+    )
+    const snapshot: AcpStateSnapshot = {
+      status: 'connected',
+      cwd: '/workspace',
+      sessionId: harness.session.id,
+      sessionIds: [harness.session.id],
+      events: [],
+      pendingPermissions: [],
+      permissionProfiles: {},
+      permissionGrants: {},
+      contextUsageBySession: {},
+      promptInFlight: false,
+      promptInFlightSessionIds: []
+    }
+    let callbacks!: AcpRuntimeCallbacks
+    let turn = 0
+    let modelTurnMode: 'same-turn' | 'background' | undefined
+    let sameTurnHandle: Readonly<{ frameId: string; attemptId: string }> | undefined
+    let sameTurnResult: Awaited<ReturnType<typeof harness.composition.host.collect>> | undefined
+    let staggered: Awaited<ReturnType<typeof harness.composition.host.delegate>> | undefined
+    const pendingContinuations: Array<{
+      request: AcpPromptRequest
+      resolve(response: { stopReason: 'end_turn' }): void
+    }> = []
+    const runTurn = (
+      request: AcpPromptRequest,
+      promptAttemptId: string | undefined,
+      completion: Promise<{ stopReason: 'end_turn' }>
+    ): Promise<{ stopReason: 'end_turn' }> => {
+      const turnToken = `model-turn-${++turn}`
+      callbacks.onPromptStarted?.(request.sessionId, turnToken, promptAttemptId)
+      callbacks.onProviderPromptAccepted?.(request.sessionId, promptAttemptId)
+      return completion.finally(() => callbacks.onPromptEnded?.(request.sessionId, turnToken))
+    }
+    const sendPrompt = vi.fn((request: AcpPromptRequest, promptAttemptId?: string) => {
+      const completion = (async (): Promise<{ stopReason: 'end_turn' }> => {
+        if (modelTurnMode === 'same-turn') {
+          const receipt = await harness.composition.host.delegate(
+            harness.caller,
+            { task: 'Collect inside the model turn', name: 'Same-turn model child' },
+            { wait: false }
+          )
+          sameTurnHandle = receipt.children[0]
+          sameTurnResult = await harness.composition.host.collect(
+            { ...harness.caller, toolInvocationId: 'model-same-turn-collect' },
+            [sameTurnHandle]
+          )
+        } else if (modelTurnMode === 'background') {
+          staggered = await harness.composition.host.delegate(
+            { ...harness.caller, toolInvocationId: 'model-staggered-delegate' },
+            [
+              { task: 'alpha model', name: 'Alpha model' },
+              { task: 'beta model', name: 'Beta model' },
+              { task: 'gamma model', name: 'Gamma model' }
+            ],
+            { wait: false }
+          )
+        }
+        return { stopReason: 'end_turn' }
+      })()
+      return runTurn(request, promptAttemptId, completion)
+    })
+    const sendAppContinuation = vi.fn((request: AcpPromptRequest, promptAttemptId?: string) => {
+      let resolve!: (response: { stopReason: 'end_turn' }) => void
+      const completion = new Promise<{ stopReason: 'end_turn' }>((done) => {
+        resolve = done
+      })
+      pendingContinuations.push({ request, resolve })
+      return runTurn(request, promptAttemptId, completion)
+    })
+    const runtime = {
+      getSnapshot: () => snapshot,
+      sendPrompt,
+      sendAppContinuation
+    } as unknown as AcpRuntime
+    const coordinator = new AcpRuntimeCoordinator(
+      (runtimeCallbacks) => {
+        callbacks = runtimeCallbacks
+        return runtime
+      },
+      {},
+      '',
+      undefined,
+      undefined,
+      undefined,
+      {},
+      undefined,
+      harness.composition.root
+    )
+    const promptEnded: Array<Readonly<{ sessionId: string; promptId: string }>> = []
+    productionDispatch.current = createDelegationSettlementContinuationDispatch({
+      sendAppContinuation: (request) => coordinator.sendAppContinuation(request),
+      onPromptEnded: (sessionId, promptId) => {
+        promptEnded.push({ sessionId, promptId })
+        return harness.composition.root.settlementPromptEnded?.(sessionId, promptId)
+      }
+    })
+
+    modelTurnMode = 'same-turn'
+    const rootPrompt = coordinator.sendPrompt({
+      sessionId: harness.session.id,
+      text: 'Coordinate and collect',
+      provenanceContext: { promptMessageId: harness.caller.originMessageId }
+    })
+    await expect.poll(() => sameTurnHandle).toBeDefined()
+    await expect.poll(() => harness.execution.controls()).toHaveLength(1)
+    harness.execution.control(sameTurnHandle!.attemptId).accept()
+    harness.execution.control(sameTurnHandle!.attemptId).complete('same-turn model result')
+    await vi.advanceTimersByTimeAsync(100)
+    await rootPrompt
+    expect(sameTurnResult).toMatchObject([
+      { status: 'completed', response: 'same-turn model result' }
+    ])
+    sameTurnHandle = undefined
+
+    modelTurnMode = 'background'
+    await coordinator.sendPrompt({
+      sessionId: harness.session.id,
+      text: 'Start background model children',
+      provenanceContext: { promptMessageId: harness.caller.originMessageId }
+    })
+    if (!staggered) throw new Error('Background model turn did not delegate children.')
+    await expect.poll(() => harness.execution.controls()).toHaveLength(4)
+    for (const child of staggered.children) harness.execution.control(child.attemptId).accept()
+    let releaseAdmission!: () => void
+    const admission = new Promise<void>((resolve) => {
+      releaseAdmission = resolve
+    })
+    coordinator.setPromptDispatchAdmissionGuard(async (_sessionId, dispatch) => {
+      await admission
+      return dispatch()
+    })
+
+    harness.execution.control(staggered.children[0].attemptId).complete('alpha')
+    harness.execution.control(staggered.children[1].attemptId).complete('beta')
+    await expect
+      .poll(() => harness.composition.host.children(harness.caller))
+      .toMatchObject([
+        { status: 'completed' },
+        { status: 'completed' },
+        { status: 'completed' },
+        { status: 'running' }
+      ])
+    await vi.advanceTimersByTimeAsync(100)
+    expect(sendAppContinuation).not.toHaveBeenCalled()
+
+    releaseAdmission()
+    await expect.poll(() => pendingContinuations).toHaveLength(1)
+    const first = pendingContinuations[0]
+    expect(first.request).toMatchObject({
+      sessionId: harness.session.id,
+      suppressUserMessage: true,
+      provenanceContext: {
+        promptMessageId: harness.caller.originMessageId,
+        originMessageId: harness.caller.originMessageId,
+        rootFrameId: harness.caller.frameId,
+        agentFrameId: harness.caller.frameId,
+        messageAncestry: [harness.caller.originMessageId],
+        runtimeSegmentId: expect.stringMatching(/^delegation-settlement-/u)
+      }
+    })
+    harness.execution.control(staggered.children[2].attemptId).complete('gamma')
+    await expect
+      .poll(() => harness.composition.host.children(harness.caller))
+      .toMatchObject([
+        { status: 'completed' },
+        { status: 'completed' },
+        { status: 'completed' },
+        { status: 'completed' }
+      ])
+    await vi.advanceTimersByTimeAsync(200)
+    expect(pendingContinuations).toHaveLength(1)
+
+    first.resolve({ stopReason: 'end_turn' })
+    await expect
+      .poll(() => promptEnded)
+      .toContainEqual({
+        sessionId: harness.session.id,
+        promptId: first.request.provenanceContext!.runtimeSegmentId!
+      })
+    await vi.advanceTimersByTimeAsync(100)
+    await expect.poll(() => pendingContinuations).toHaveLength(2)
+    pendingContinuations[1].resolve({ stopReason: 'end_turn' })
+    await expect.poll(() => promptEnded).toHaveLength(2)
+    await vi.advanceTimersByTimeAsync(200)
+    expect(pendingContinuations).toHaveLength(2)
+    expect(vi.getTimerCount()).toBe(0)
+    vi.useRealTimers()
+  })
+
+  it('collects a background child to completion within the originating root turn', async () => {
+    root = await mkdtemp(join(tmpdir(), 'delegated-production-same-turn-collect-'))
+    const harness = await createCompositionHarness(root, 'codex')
+    const receipt = await harness.composition.host.delegate(
+      harness.caller,
+      { task: 'Return during this turn', name: 'Same-turn child' },
+      { wait: false }
+    )
+    const child = receipt.children[0]
+    const collecting = harness.composition.host.collect(
+      { ...harness.caller, toolInvocationId: 'same-turn-collect' },
+      [{ frameId: child.frameId, attemptId: child.attemptId }]
+    )
+    await expect.poll(() => harness.execution.controls()).toHaveLength(1)
+    harness.execution.control(child.attemptId).accept()
+    harness.execution.control(child.attemptId).complete('same-turn result')
+
+    await expect(collecting).resolves.toMatchObject([
+      {
+        frameId: child.frameId,
+        attemptId: child.attemptId,
+        status: 'completed',
+        response: 'same-turn result'
+      }
+    ])
+  })
+
+  it.each(['branch', 'project', 'shutdown'] as const)(
+    'cancels a pending settlement wake on %s invalidation',
+    async (scope) => {
+      vi.useFakeTimers()
+      root = await mkdtemp(join(tmpdir(), `delegated-production-${scope}-wake-invalidation-`))
+      const dispatch = vi.fn(async (request: DelegationSettlementDispatch) => {
+        void request
+      })
+      const harness = await createCompositionHarness(
+        root,
+        'codex',
+        createDeterministicDelegateExecution(),
+        undefined,
+        { settlementContinuations: { dispatch } }
+      )
+      const leaseId = await harness.composition.root.rootTurnStarted?.({
+        sessionId: harness.session.id,
+        originatingPromptId: harness.caller.originMessageId
+      })
+      const receipt = await harness.composition.host.delegate(
+        harness.caller,
+        { task: `Invalidate ${scope} wake`, name: `${scope} invalidation child` },
+        { wait: false }
+      )
+      const child = receipt.children[0]
+      await expect.poll(() => harness.execution.controls()).toHaveLength(1)
+      harness.execution.control(child.attemptId).accept()
+      await harness.composition.root.rootTurnEnded?.({
+        sessionId: harness.session.id,
+        originatingPromptId: harness.caller.originMessageId,
+        clean: true,
+        leaseId
+      })
+      harness.execution.control(child.attemptId).complete('terminal before invalidation')
+      await expect
+        .poll(() => harness.composition.host.children(harness.caller))
+        .toMatchObject([{ status: 'completed' }])
+
+      if (scope === 'branch') {
+        await harness.composition.root.cancelTurn?.(
+          harness.session.id,
+          harness.caller.originMessageId
+        )
+      } else if (scope === 'project') {
+        await harness.composition.root.deleteProject(harness.session.projectId)
+      } else {
+        await harness.composition.root.stopAll()
+      }
+      await vi.advanceTimersByTimeAsync(200)
+
+      expect(dispatch).not.toHaveBeenCalled()
+      expect(vi.getTimerCount()).toBe(0)
+      vi.useRealTimers()
+    }
+  )
+
   it('lets a legacy Session without delegated history establish its durable framework identity', async () => {
     root = await mkdtemp(join(tmpdir(), 'delegated-production-legacy-identity-'))
     const harness = await createCompositionHarness(root, 'claude-code')

--- a/src/main/delegation/production-composition.ts
+++ b/src/main/delegation/production-composition.ts
@@ -6,6 +6,8 @@ import type {
   AcpPermissionResponse
 } from '../../shared/acp'
 import type { PersistedChatSession } from '../../shared/session-persistence'
+import { materializeSessionConversationGraph } from '../../shared/session-persistence'
+import { resolveActiveConversationMessages } from '../../shared/conversation-graph'
 import type { SpecialistProfileView } from '../../shared/specialist'
 import type { AgentFrameworkId } from '../../shared/settings'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
@@ -34,6 +36,11 @@ import {
 } from './durable-delegated-work'
 import { createProductionFrameWorkspace, type ResolvedImmutableInput } from './frame-workspace'
 import { createSessionDelegatedWorkRecords } from './session-record-adapter'
+import {
+  DelegationSettlementWakeOwner,
+  type DelegationSettlementDispatch,
+  type DelegationSettlementSnapshot
+} from './delegation-settlement-wake-owner'
 
 type CertifiedSessionFramework = Readonly<{
   frameworkId: AgentFrameworkId
@@ -65,6 +72,9 @@ type ProductionDelegatedWorkOptions = Readonly<{
   }>
   onAgentRuntimeUpdate?(update: AcpAgentRuntimeUpdate): void
   resolveExecutionModel(session: PersistedChatSession): Promise<DelegatedExecutionModelAdmission>
+  settlementContinuations?: Readonly<{
+    dispatch(request: DelegationSettlementDispatch): Promise<void> | void
+  }>
 }>
 
 type RootDelegatedWorkEvent =
@@ -93,6 +103,21 @@ type RootDelegatedWorkControl = Readonly<{
     }>
   ): Promise<void>
   wakeMessages?(sessionId: string): Promise<void>
+  rootTurnStarted?(
+    input: Readonly<{
+      sessionId: string
+      originatingPromptId: string
+    }>
+  ): Promise<string | undefined>
+  rootTurnEnded?(
+    input: Readonly<{
+      sessionId: string
+      originatingPromptId: string
+      clean: boolean
+      leaseId?: string
+    }>
+  ): Promise<void>
+  settlementPromptEnded?(sessionId: string, promptId: string): Promise<void>
   stopAll(): Promise<void>
   deleteSession(sessionId: string): Promise<void>
   deleteProject(projectId: string): Promise<void>
@@ -122,6 +147,47 @@ const keyOf = (key: SessionKey): string => `${key.projectId}\u0000${key.sessionI
 const permissionPublicId = (session: SessionKey, request: RootDelegatePermissionRequest): string =>
   `delegated:${encodeURIComponent(session.projectId)}:${encodeURIComponent(session.sessionId)}:${encodeURIComponent(request.frameId)}:${encodeURIComponent(request.attemptId)}:${encodeURIComponent(request.requestId)}`
 
+const settlementSnapshot = (
+  session: PersistedChatSession
+): DelegationSettlementSnapshot | undefined => {
+  const graph = materializeSessionConversationGraph(session).conversationGraph
+  if (!graph) return undefined
+  const rootFrame = graph.frames.find(({ id }) => id === graph.rootFrameId)
+  if (!rootFrame) return undefined
+  const rootBranch = graph.branches.find(({ id }) => id === rootFrame.activeBranchId)
+  if (!rootBranch) return undefined
+  const activeRootPromptIds = resolveActiveConversationMessages({
+    ...graph,
+    activeFrameId: graph.rootFrameId
+  }).map(({ id }) => id)
+  const records = session.runtimeContext?.delegatedWork?.records ?? []
+  return {
+    projectId: session.projectId,
+    sessionId: session.id,
+    rootFrameId: graph.rootFrameId,
+    rootBranchId: rootBranch.id,
+    activeRootPromptIds,
+    attempts: records.flatMap((record) => {
+      const frame = graph.frames.find(({ id }) => id === record.agentFrameId)
+      if (!frame) return []
+      return record.attempts.flatMap((attempt) =>
+        attempt.initiatingTurnMessageId
+          ? [
+              {
+                frameId: record.agentFrameId,
+                attemptId: attempt.id,
+                parentFrameId: frame.parentFrameId ?? '',
+                originatingPromptId: attempt.initiatingTurnMessageId,
+                name: frame.delegateName ?? frame.agentName ?? record.agentFrameId,
+                status: attempt.status
+              }
+            ]
+          : []
+      )
+    })
+  }
+}
+
 const createProductionDelegatedWorkComposition = (
   options: ProductionDelegatedWorkOptions
 ): ProductionDelegatedWorkComposition => {
@@ -145,6 +211,16 @@ const createProductionDelegatedWorkComposition = (
     : undefined
   const reviewEvidence = options.reviewEvidence
     ? createDelegatedReviewEvidence(options.reviewEvidence)
+    : undefined
+  const settlementWake = options.settlementContinuations
+    ? new DelegationSettlementWakeOwner({
+        readSnapshot: async (sessionId) => {
+          const sessions = (await options.sessions.findSessions?.(sessionId)) ?? []
+          const matches = sessions.filter(({ id }) => id === sessionId)
+          return matches.length === 1 ? settlementSnapshot(matches[0]) : undefined
+        },
+        dispatch: (request) => options.settlementContinuations!.dispatch(request)
+      })
     : undefined
 
   const publish = (event: RootDelegatedWorkEvent): void => {
@@ -193,7 +269,10 @@ const createProductionDelegatedWorkComposition = (
         commands: options.sessions.commands,
         readSession: options.sessions.readSession,
         frameworkId: framework.frameworkId,
-        onRecordsChanged: () => publish({ kind: 'records-changed', sessionId: key.sessionId })
+        onRecordsChanged: () => {
+          publish({ kind: 'records-changed', sessionId: key.sessionId })
+          void settlementWake?.onRecordsChanged(key.sessionId)
+        }
       },
       key
     )
@@ -362,6 +441,10 @@ const createProductionDelegatedWorkComposition = (
       await Promise.all(scoped.map(({ key, work }) => work.setPermissionProfile(key, profile)))
     },
     async cancelTurn(sessionId, initiatingTurnMessageId) {
+      const settlementInvalidation = settlementWake?.invalidateBranch(
+        sessionId,
+        initiatingTurnMessageId
+      )
       cancelledSessionTurns.add(`${sessionId}\u0000${initiatingTurnMessageId}`)
       const pendingScoped = [...works.entries()].filter(([identity]) =>
         identity.endsWith(`\u0000${sessionId}`)
@@ -372,9 +455,10 @@ const createProductionDelegatedWorkComposition = (
         cancelledTurns.add(`${identity}\u0000${initiatingTurnMessageId}`)
       }
       const scoped = await Promise.all(pendingScoped.map(([, work]) => work))
-      await Promise.all(
-        scoped.map(({ key, work }) => work.cancelTurn(key, initiatingTurnMessageId))
-      )
+      await Promise.all([
+        settlementInvalidation,
+        ...scoped.map(({ key, work }) => work.cancelTurn(key, initiatingTurnMessageId))
+      ])
     },
     async stopActiveBranch(sessionId) {
       const scoped = await worksForSession(sessionId)
@@ -389,6 +473,7 @@ const createProductionDelegatedWorkComposition = (
       }
     },
     async stopSession(sessionId) {
+      settlementWake?.invalidateSession(sessionId)
       const scoped = await worksForSession(sessionId)
       await Promise.all(scoped.map(({ key, work }) => work.stopSession(key)))
     },
@@ -427,11 +512,22 @@ const createProductionDelegatedWorkComposition = (
       const scoped = await worksForSession(sessionId)
       await Promise.all(scoped.map(({ work }) => work.wakeMessages()))
     },
+    async rootTurnEnded(input) {
+      await settlementWake?.onRootTurnEnded(input)
+    },
+    async rootTurnStarted(input) {
+      return settlementWake?.onRootTurnStarted(input)
+    },
+    async settlementPromptEnded(sessionId, promptId) {
+      await settlementWake?.onWakePromptEnded(sessionId, promptId)
+    },
     async stopAll() {
+      settlementWake?.shutdown()
       const scoped = await Promise.all([...works.values()])
       await Promise.all(scoped.map(({ key, work }) => work.stopSession(key)))
     },
     async deleteSession(sessionId) {
+      settlementWake?.invalidateSession(sessionId)
       const scoped = await worksForSession(sessionId)
       const durableSessions = (await options.sessions.findSessions?.(sessionId)) ?? []
       const keys = new Map<string, SessionKey>()
@@ -464,6 +560,7 @@ const createProductionDelegatedWorkComposition = (
       }
     },
     async deleteProject(projectId) {
+      await settlementWake?.invalidateProject(projectId)
       const scoped = await worksForProject(projectId)
       const workDeletion = await Promise.allSettled(
         scoped.map(({ key, work }) => work.deleteSession(key))

--- a/src/main/delegation/production-composition.ts
+++ b/src/main/delegation/production-composition.ts
@@ -354,6 +354,21 @@ const createProductionDelegatedWorkComposition = (
         const result = await (
           await workFor(caller.session)
         ).work.delegate(caller, request, delegateOptions)
+        const unobserved =
+          result.kind === 'receipts'
+            ? result.children
+            : result.kind === 'observations'
+              ? result.children.filter(
+                  ({ status }) => status === 'running' || status === 'awaiting_user'
+                )
+              : []
+        if (unobserved.length > 0) {
+          settlementWake?.trackUnobservedAttempts({
+            sessionId: caller.session.sessionId,
+            originatingPromptId: caller.originMessageId,
+            attempts: unobserved
+          })
+        }
         unavailableReasons.delete(caller.session.sessionId)
         return result
       } catch (error) {
@@ -378,7 +393,20 @@ const createProductionDelegatedWorkComposition = (
       return (await workFor(caller.session)).work.children(caller, frameIds)
     },
     async collect(caller, selectors, collectOptions) {
-      return (await workFor(caller.session)).work.collect(caller, selectors, collectOptions)
+      const observations = await (
+        await workFor(caller.session)
+      ).work.collect(caller, selectors, collectOptions)
+      const observed = observations.filter(
+        ({ status }) => status !== 'running' && status !== 'awaiting_user'
+      )
+      if (observed.length > 0) {
+        settlementWake?.markAttemptsObserved({
+          sessionId: caller.session.sessionId,
+          originatingPromptId: caller.originMessageId,
+          attempts: observed
+        })
+      }
+      return observations
     },
     async submitOutput(caller, value) {
       return (await workFor(caller.session)).work.submitOutput(caller, value)

--- a/src/main/delegation/production-framework-runtime.test.ts
+++ b/src/main/delegation/production-framework-runtime.test.ts
@@ -11,7 +11,11 @@ import {
   opencodeFramework,
   type ResolvedAgentBackend
 } from '../agent-framework'
-import { createProductionDelegatedFrameworkRuntime } from './production-framework-runtime'
+import {
+  createProductionDelegatedFrameworkRuntime,
+  DELEGATED_CHILD_SYSTEM_PROMPT_APPEND,
+  withDelegatedChildContext
+} from './production-framework-runtime'
 
 const safeOpenCodeConfig = JSON.stringify({
   permission: { task: 'deny' },
@@ -140,6 +144,33 @@ const delegatedSession = (frameworkId: AgentFrameworkId): PersistedChatSession =
 })
 
 describe('production delegated framework runtime bridge', () => {
+  it.each(['claude-code', 'opencode', 'codex'] as const)(
+    'adds child-only identity and canonical delivery context for %s without replacing backend rules',
+    (frameworkId) => {
+      const decorated = withDelegatedChildContext({
+        ...backend(frameworkId),
+        systemPromptAppends: ['Keep the existing specialist and safety rules.']
+      })
+      expect(decorated.systemPromptAppends).toEqual([
+        'Keep the existing specialist and safety rules.',
+        DELEGATED_CHILD_SYSTEM_PROMPT_APPEND
+      ])
+      expect(DELEGATED_CHILD_SYSTEM_PROMPT_APPEND).toContain('delegated Attempt for the Main Agent')
+      expect(DELEGATED_CHILD_SYSTEM_PROMPT_APPEND).toContain(
+        'final response is automatically preserved'
+      )
+      expect(DELEGATED_CHILD_SYSTEM_PROMPT_APPEND).toContain(
+        "host.sendFrameMessage('parent', ...) only while the Attempt is still running"
+      )
+      expect(DELEGATED_CHILD_SYSTEM_PROMPT_APPEND).toContain(
+        'submitting it with host.submitOutput(value) remains mandatory'
+      )
+      expect(DELEGATED_CHILD_SYSTEM_PROMPT_APPEND).toContain(
+        'never replaces your ordinary final response'
+      )
+      expect(DELEGATED_CHILD_SYSTEM_PROMPT_APPEND).toContain('Do not duplicate your final response')
+    }
+  )
   it('prepares an admitted Attempt from its transient backend after the provider was deleted', async () => {
     const dataRoot = await mkdtemp(join(tmpdir(), 'delegated-framework-deleted-provider-'))
     const workspaceCwd = await mkdtemp(join(tmpdir(), 'delegated-framework-workspace-'))

--- a/src/main/delegation/production-framework-runtime.ts
+++ b/src/main/delegation/production-framework-runtime.ts
@@ -46,6 +46,22 @@ type ProductionFrameworkRuntimeOptions = Readonly<{
   resolvePermissionProfile?(sessionId: string): PermissionProfileId | undefined
 }>
 
+const DELEGATED_CHILD_SYSTEM_PROMPT_APPEND = [
+  'You are a Subagent executing a delegated Attempt for the Main Agent.',
+  'Your final response is automatically preserved as the canonical terminal result for this Attempt, including ordinary conclusions, change summaries, validation results, Artifacts, and any required structured output.',
+  "Use host.sendFrameMessage('parent', ...) only while the Attempt is still running when the Main Agent needs an early actionable update, must answer a question, or must coordinate around a blocker or material risk.",
+  'When a structured-output schema is configured, submitting it with host.submitOutput(value) remains mandatory; that submission supplements and never replaces your ordinary final response.',
+  'Do not duplicate your final response through parent messaging when completing normally.'
+].join(' ')
+
+const withDelegatedChildContext = (backend: ResolvedAgentBackend): ResolvedAgentBackend => ({
+  ...backend,
+  systemPromptAppends: [
+    ...(backend.systemPromptAppends ?? []),
+    DELEGATED_CHILD_SYSTEM_PROMPT_APPEND
+  ]
+})
+
 const openCodeModelConfig = (backend: ResolvedAgentBackend): AgentModelConfig => ({
   env: { ...backend.env },
   configFiles: [
@@ -216,7 +232,7 @@ const createProductionDelegatedFrameworkRuntime = (
           return createAcpRuntime({
             ...options.runtime,
             notebookRpcServer: options.notebookRpcServer(),
-            fixedBackend: owned.backend,
+            fixedBackend: withDelegatedChildContext(owned.backend),
             runtimeCallbacks: callbacks,
             delegatedNotebookConnection: owned.connection,
             permissionGrantContext: {
@@ -243,5 +259,9 @@ const createProductionDelegatedFrameworkRuntime = (
     }
   })
 
-export { createProductionDelegatedFrameworkRuntime }
+export {
+  createProductionDelegatedFrameworkRuntime,
+  DELEGATED_CHILD_SYSTEM_PROMPT_APPEND,
+  withDelegatedChildContext
+}
 export type { ProductionFrameworkRuntimeOptions }

--- a/src/main/delegation/settlement-continuation-dispatch.test.ts
+++ b/src/main/delegation/settlement-continuation-dispatch.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createDelegationSettlementContinuationDispatch,
+  type SettlementContinuationDispatchOptions
+} from './settlement-continuation-dispatch'
+import type { DelegationSettlementDispatch } from './delegation-settlement-wake-owner'
+import { DelegateMessagePreAcceptanceError } from './execution-port'
+
+const request: DelegationSettlementDispatch = {
+  projectId: 'project-1',
+  sessionId: 'session-1',
+  originatingPromptId: 'root-prompt',
+  rootFrameId: 'root-frame',
+  rootBranchId: 'root-branch',
+  promptId: 'wake-1',
+  text: 'settlement update'
+}
+
+describe('delegation settlement continuation dispatch', () => {
+  it('reports a rejection before provider acceptance so the settlement batch can retry', async () => {
+    const failure = new DelegateMessagePreAcceptanceError('runtime unavailable')
+    const sendAppContinuationObserved = vi.fn(async () => {
+      throw failure
+    })
+    const onPromptEnded = vi.fn(async () => undefined)
+    const dispatch = createDelegationSettlementContinuationDispatch({
+      sendAppContinuationObserved,
+      onPromptEnded
+    })
+
+    await expect(dispatch(request)).rejects.toBe(failure)
+    expect(onPromptEnded).not.toHaveBeenCalled()
+  })
+
+  it('ends the flight without retrying an unconfirmed provider rejection', async () => {
+    const sendAppContinuationObserved = vi.fn(async () => {
+      throw new Error('provider outcome is unknown')
+    })
+    const onPromptEnded = vi.fn(async () => undefined)
+    const dispatch = createDelegationSettlementContinuationDispatch({
+      sendAppContinuationObserved,
+      onPromptEnded
+    })
+
+    await expect(dispatch(request)).resolves.toBeUndefined()
+    expect(onPromptEnded).toHaveBeenCalledOnce()
+  })
+
+  it('ends the single flight without retrying when an accepted provider prompt later rejects', async () => {
+    const failure = new Error('provider turn failed')
+    const sendAppContinuationObserved: SettlementContinuationDispatchOptions['sendAppContinuationObserved'] =
+      vi.fn(async (_request, onProviderPromptAccepted) => {
+        onProviderPromptAccepted()
+        throw failure
+      })
+    const onPromptEnded = vi.fn(async () => undefined)
+    const dispatch = createDelegationSettlementContinuationDispatch({
+      sendAppContinuationObserved,
+      onPromptEnded
+    })
+
+    await expect(dispatch(request)).resolves.toBeUndefined()
+    expect(onPromptEnded).toHaveBeenCalledOnce()
+    expect(onPromptEnded).toHaveBeenCalledWith('session-1', 'wake-1')
+  })
+
+  it('does not turn terminal flight-cleanup failure into a continuation retry', async () => {
+    const sendAppContinuationObserved = vi.fn(
+      async (_request, onProviderPromptAccepted: () => void) => {
+        onProviderPromptAccepted()
+      }
+    )
+    const onPromptEnded = vi.fn(async () => {
+      throw new Error('local cleanup failed')
+    })
+    const dispatch = createDelegationSettlementContinuationDispatch({
+      sendAppContinuationObserved,
+      onPromptEnded
+    })
+
+    await expect(dispatch(request)).resolves.toBeUndefined()
+    expect(onPromptEnded).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/delegation/settlement-continuation-dispatch.ts
+++ b/src/main/delegation/settlement-continuation-dispatch.ts
@@ -1,0 +1,39 @@
+import type { AcpPromptRequest } from '../../shared/acp'
+import type { DelegationSettlementDispatch } from './delegation-settlement-wake-owner'
+
+type SettlementContinuationDispatchOptions = Readonly<{
+  sendAppContinuation(request: AcpPromptRequest): Promise<unknown>
+  onPromptEnded(sessionId: string, promptId: string): Promise<void> | void
+}>
+
+const createDelegationSettlementContinuationDispatch =
+  (
+    options: SettlementContinuationDispatchOptions
+  ): ((request: DelegationSettlementDispatch) => void) =>
+  (request) => {
+    const completion = options.sendAppContinuation({
+      sessionId: request.sessionId,
+      text: request.text,
+      suppressUserMessage: true,
+      provenanceContext: {
+        promptMessageId: request.originatingPromptId,
+        originMessageId: request.originatingPromptId,
+        rootFrameId: request.rootFrameId,
+        agentFrameId: request.rootFrameId,
+        ...(request.rootBranchId
+          ? {
+              messageBranchId: request.rootBranchId,
+              messageBranchAncestry: [request.rootBranchId]
+            }
+          : {}),
+        messageAncestry: [request.originatingPromptId],
+        runtimeSegmentId: request.promptId
+      }
+    })
+    const settle = (): Promise<void> | void =>
+      options.onPromptEnded(request.sessionId, request.promptId)
+    void completion.then(settle, settle)
+  }
+
+export { createDelegationSettlementContinuationDispatch }
+export type { SettlementContinuationDispatchOptions }

--- a/src/main/delegation/settlement-continuation-dispatch.ts
+++ b/src/main/delegation/settlement-continuation-dispatch.ts
@@ -1,38 +1,53 @@
 import type { AcpPromptRequest } from '../../shared/acp'
 import type { DelegationSettlementDispatch } from './delegation-settlement-wake-owner'
+import { DelegateMessagePreAcceptanceError } from './execution-port'
 
 type SettlementContinuationDispatchOptions = Readonly<{
-  sendAppContinuation(request: AcpPromptRequest): Promise<unknown>
+  sendAppContinuationObserved(
+    request: AcpPromptRequest,
+    onProviderPromptAccepted: () => void
+  ): Promise<unknown>
   onPromptEnded(sessionId: string, promptId: string): Promise<void> | void
 }>
 
 const createDelegationSettlementContinuationDispatch =
   (
     options: SettlementContinuationDispatchOptions
-  ): ((request: DelegationSettlementDispatch) => void) =>
-  (request) => {
-    const completion = options.sendAppContinuation({
-      sessionId: request.sessionId,
-      text: request.text,
-      suppressUserMessage: true,
-      provenanceContext: {
-        promptMessageId: request.originatingPromptId,
-        originMessageId: request.originatingPromptId,
-        rootFrameId: request.rootFrameId,
-        agentFrameId: request.rootFrameId,
-        ...(request.rootBranchId
-          ? {
-              messageBranchId: request.rootBranchId,
-              messageBranchAncestry: [request.rootBranchId]
-            }
-          : {}),
-        messageAncestry: [request.originatingPromptId],
-        runtimeSegmentId: request.promptId
+  ): ((request: DelegationSettlementDispatch) => Promise<void>) =>
+  async (request) => {
+    let providerAccepted = false
+    const completion = options.sendAppContinuationObserved(
+      {
+        sessionId: request.sessionId,
+        text: request.text,
+        suppressUserMessage: true,
+        provenanceContext: {
+          promptMessageId: request.originatingPromptId,
+          originMessageId: request.originatingPromptId,
+          rootFrameId: request.rootFrameId,
+          agentFrameId: request.rootFrameId,
+          ...(request.rootBranchId
+            ? {
+                messageBranchId: request.rootBranchId,
+                messageBranchAncestry: [request.rootBranchId]
+              }
+            : {}),
+          messageAncestry: [request.originatingPromptId],
+          runtimeSegmentId: request.promptId
+        }
+      },
+      () => {
+        providerAccepted = true
       }
-    })
-    const settle = (): Promise<void> | void =>
-      options.onPromptEnded(request.sessionId, request.promptId)
-    void completion.then(settle, settle)
+    )
+    try {
+      await completion
+    } catch (error) {
+      if (!providerAccepted && error instanceof DelegateMessagePreAcceptanceError) throw error
+    }
+    await Promise.resolve(options.onPromptEnded(request.sessionId, request.promptId)).catch(
+      () => undefined
+    )
   }
 
 export { createDelegationSettlementContinuationDispatch }

--- a/src/main/host-sdk/delegate-contract.test.ts
+++ b/src/main/host-sdk/delegate-contract.test.ts
@@ -131,6 +131,10 @@ describe('Agent-facing collect contract', () => {
       maximum: 1800,
       default: 30
     })
+    expect(COLLECT_AGENT_CONTRACT.options.properties.returnWhen).toMatchObject({
+      enum: ['all', 'any'],
+      default: 'all'
+    })
     expect(COLLECT_AGENT_CONTRACT.options.properties).not.toHaveProperty('timeout_seconds')
     expect(COLLECT_AGENT_CONTRACT.options.additionalProperties).toBe(false)
     expect(COLLECT_AGENT_CONTRACT.returns.items.oneOf[0].required).toContain('frame_id')
@@ -141,11 +145,11 @@ describe('Agent-facing collect contract', () => {
     expect(
       parseCollectRpcCall({
         selectors: ['frame-1', { frame_id: 'frame-2', attempt_id: 'attempt-2' }],
-        options: { timeout_seconds: 0 }
+        options: { timeout_seconds: 0, return_when: 'any' }
       })
     ).toEqual({
       selectors: ['frame-1', { frameId: 'frame-2', attemptId: 'attempt-2' }],
-      options: { timeoutSeconds: 0 }
+      options: { timeoutSeconds: 0, returnWhen: 'any' }
     })
     for (const invalid of [-1, 1801, Number.NaN, Number.POSITIVE_INFINITY, '30']) {
       expect(() =>
@@ -173,5 +177,8 @@ describe('Agent-facing collect contract', () => {
         options: { timeout_seconds: 0, timeoutSeconds: 0 }
       })
     ).toThrow('private RPC options use timeout_seconds')
+    expect(() =>
+      parseCollectRpcCall({ selectors: ['frame-1'], options: { return_when: 'first' } })
+    ).toThrow('return_when must be all or any')
   })
 })

--- a/src/main/host-sdk/delegate-contract.ts
+++ b/src/main/host-sdk/delegate-contract.ts
@@ -100,7 +100,8 @@ const COLLECT_AGENT_CONTRACT = {
     type: 'object',
     additionalProperties: false,
     properties: {
-      timeoutSeconds: { type: 'number', minimum: 0, maximum: 1800, default: 30 }
+      timeoutSeconds: { type: 'number', minimum: 0, maximum: 1800, default: 30 },
+      returnWhen: { type: 'string', enum: ['all', 'any'], default: 'all' }
     }
   },
   returns: { type: 'array', items: DELEGATE_OBSERVATION_SCHEMA },
@@ -358,7 +359,13 @@ const parseCollectRpcCall = (params: Readonly<Record<string, unknown>>): Collect
       'host.collect private RPC options use timeout_seconds; caller-facing timeoutSeconds must be remapped before transport.'
     )
   }
+  if (hasOwn(requestedOptions, 'returnWhen')) {
+    throw new Error(
+      'host.collect private RPC options use return_when; caller-facing returnWhen must be remapped before transport.'
+    )
+  }
   const timeoutSeconds = requestedOptions.timeout_seconds
+  const returnWhen = requestedOptions.return_when
   if (
     timeoutSeconds !== undefined &&
     (typeof timeoutSeconds !== 'number' ||
@@ -370,9 +377,15 @@ const parseCollectRpcCall = (params: Readonly<Record<string, unknown>>): Collect
       'host.collect options.timeout_seconds must be a finite number from 0 through 1800; choose a value in that range or omit it.'
     )
   }
+  if (returnWhen !== undefined && returnWhen !== 'all' && returnWhen !== 'any') {
+    throw new Error('host.collect options.return_when must be all or any; omit it to use all.')
+  }
   return {
     selectors,
-    options: timeoutSeconds === undefined ? {} : { timeoutSeconds }
+    options: {
+      ...(timeoutSeconds === undefined ? {} : { timeoutSeconds }),
+      ...(returnWhen === undefined ? {} : { returnWhen })
+    }
   }
 }
 

--- a/src/main/host-sdk/help.test.ts
+++ b/src/main/host-sdk/help.test.ts
@@ -308,6 +308,8 @@ describe('Host SDK help', () => {
       default: 30,
       range: '0..1800'
     })
+    expect(named(fields(collect.options), 'returnWhen')).toMatchObject({ default: 'all' })
+    expect(collect.constraints.join(' ')).toContain('currently running')
     expect(collect.call_forms[0]?.signature).toBe('await host.collect(selectors, options?)')
     expect(collect.examples[0]?.code).toContain('{ frameId: frame_id, attemptId: attempt_id }')
 
@@ -344,6 +346,8 @@ describe('Host SDK help', () => {
 
     const submitOutput = operation('submitOutput', 'delegate')
     expect(submitOutput.call_forms[0]?.signature).toBe('await host.submitOutput(value)')
+    expect(submitOutput.constraints.join(' ')).toContain('mandatory')
+    expect(submitOutput.constraints.join(' ')).toContain('ordinary final response')
   })
 
   it('describes reliable receipt routes and states without exhaustive unions', () => {

--- a/src/main/host-sdk/help.ts
+++ b/src/main/host-sdk/help.ts
@@ -305,7 +305,7 @@ const COLLECT_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   id: 'host.collect',
   path: 'host.collect',
   aliases: ['collect'],
-  summary: 'Observe pinned child Attempts until all settle or a deadline expires.',
+  summary: 'Observe pinned Attempts until any/all settle or time expires.',
   call_forms: [
     { signature: 'await host.collect(selectors, options?)', accepts: 'non_empty_selector_array' }
   ],
@@ -328,13 +328,21 @@ const COLLECT_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
         default: 30,
         range: '0..1800',
         description: 'Observation deadline.'
+      },
+      {
+        name: 'returnWhen',
+        type: 'string',
+        required: false,
+        default: 'all',
+        description: 'all waits for every pinned Attempt; any returns after the first settles.'
       }
     ]
   },
   returns: { type: 'array', item_fields: DELEGATION_CHILD_FIELDS },
   constraints: [
     'Main/root only; only direct children on the active branch are collectible.',
-    'Expiry returns running observations and never stops a child.'
+    'Expiry returns every latest observation and never stops a child.',
+    'To wait for the next settlement with any, first use host.children() and select exact handles for currently running Attempts.'
   ],
   examples: [
     {
@@ -419,6 +427,7 @@ const SUBMIT_OUTPUT_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   },
   constraints: [
     'Available only to a running child delegated with outputSchema.',
+    'A configured structured submission is mandatory and supplements rather than replaces the child’s ordinary final response.',
     'The first valid value is durable; equal retry is idempotent and different retry is rejected.'
   ],
   examples: [{ title: 'Submit output', code: 'await host.submitOutput({ answer: 42 })' }],
@@ -536,7 +545,7 @@ const SEND_FRAME_MESSAGE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   id: 'host.sendFrameMessage',
   path: 'host.sendFrameMessage',
   aliases: ['sendFrameMessage'],
-  summary: 'Durably queue a reliable message to a direct child or root parent.',
+  summary: 'Queue a running coordination message to a child or parent.',
   call_forms: [
     {
       signature: 'await host.sendFrameMessage(target, message, options?)',
@@ -577,7 +586,8 @@ const SEND_FRAME_MESSAGE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
     fields: DELIVERY_RECEIPT_FIELDS
   },
   constraints: [
-    'Receipt is delivery evidence, not a reply; same requestId recovers, and uncertain is not auto-retried.'
+    'Receipt is delivery evidence, not a reply; same requestId recovers, and uncertain is not auto-retried.',
+    'A Subagent uses parent messaging only for coordination while its Attempt is running; its final response is already preserved as the canonical terminal result and should not be duplicated here.'
   ],
   examples: [],
   resolveAvailability: messageAvailability('sendFrameMessage')

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -222,7 +222,10 @@ import type { WindowSettingsCapabilities } from './settings/service-capabilities
 import { createProductionDelegatedWorkComposition } from './delegation/production-composition'
 import { createProductionDelegatedFrameworkRuntime } from './delegation/production-framework-runtime'
 import { finalizeDelegatedArtifactPublication } from './delegation/delegated-artifact-publication'
-import { DelegateMessageParkedError } from './delegation/execution-port'
+import {
+  DelegateMessageParkedError,
+  DelegateMessagePreAcceptanceError
+} from './delegation/execution-port'
 import { createDelegationSettlementContinuationDispatch } from './delegation/settlement-continuation-dispatch'
 import { createSettingsWorkflows } from './settings/workflows'
 import { showSettingsSaveDialog } from './settings/save-dialog'
@@ -1640,10 +1643,12 @@ const createApplicationModules = async (
     onAgentRuntimeUpdate: (update) => broadcastToRenderers('acp:agent-runtime-update', update),
     settlementContinuations: {
       dispatch: createDelegationSettlementContinuationDispatch({
-        sendAppContinuation: (request) => {
+        sendAppContinuationObserved: (request, onProviderPromptAccepted) => {
           const activeRuntime = runtimeRef.current
-          if (!activeRuntime) throw new Error('The Main Agent runtime is unavailable.')
-          return activeRuntime.sendAppContinuation(request)
+          if (!activeRuntime) {
+            throw new DelegateMessagePreAcceptanceError('The Main Agent runtime is unavailable.')
+          }
+          return activeRuntime.sendAppContinuationObserved(request, onProviderPromptAccepted)
         },
         onPromptEnded: (sessionId, promptId) =>
           delegatedWorkRef.current?.root.settlementPromptEnded?.(sessionId, promptId)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -223,6 +223,7 @@ import { createProductionDelegatedWorkComposition } from './delegation/productio
 import { createProductionDelegatedFrameworkRuntime } from './delegation/production-framework-runtime'
 import { finalizeDelegatedArtifactPublication } from './delegation/delegated-artifact-publication'
 import { DelegateMessageParkedError } from './delegation/execution-port'
+import { createDelegationSettlementContinuationDispatch } from './delegation/settlement-continuation-dispatch'
 import { createSettingsWorkflows } from './settings/workflows'
 import { showSettingsSaveDialog } from './settings/save-dialog'
 import { ProfileService } from './specialist/service'
@@ -1618,6 +1619,9 @@ const createApplicationModules = async (
     revokeRpcCapability: (token) => requireNotebookRpcServer().revokeArtifactRunCapability(token),
     provenance: artifactProvenanceRepository
   })
+  const delegatedWorkRef: {
+    current?: ReturnType<typeof createProductionDelegatedWorkComposition>
+  } = {}
   const delegatedWork = createProductionDelegatedWorkComposition({
     dataRoot: resolveDataRoot(),
     resolveExecutionModel: async (session) => {
@@ -1634,6 +1638,17 @@ const createApplicationModules = async (
       })
     },
     onAgentRuntimeUpdate: (update) => broadcastToRenderers('acp:agent-runtime-update', update),
+    settlementContinuations: {
+      dispatch: createDelegationSettlementContinuationDispatch({
+        sendAppContinuation: (request) => {
+          const activeRuntime = runtimeRef.current
+          if (!activeRuntime) throw new Error('The Main Agent runtime is unavailable.')
+          return activeRuntime.sendAppContinuation(request)
+        },
+        onPromptEnded: (sessionId, promptId) =>
+          delegatedWorkRef.current?.root.settlementPromptEnded?.(sessionId, promptId)
+      })
+    },
     sessions: {
       commands: sessionPersistenceCoordinator,
       readSession: ({ projectId, sessionId }) =>
@@ -2464,6 +2479,7 @@ const createApplicationModules = async (
       errorLogFields(error)
     )
   })
+  delegatedWorkRef.current = delegatedWork
   permissionGrantRegistry.subscribe(() => runtime.notifyPermissionGrantsChanged())
   // Single shared teardown owner for both the before-quit handler (index.ts) and the pre-update-install
   // gate. Update handling is deliberately constructed below, after this dependency is complete.

--- a/src/main/notebook/repl-loop.integration.test.ts
+++ b/src/main/notebook/repl-loop.integration.test.ts
@@ -555,7 +555,7 @@ describe('repl_loop local RPC transport', () => {
         ]
       })
       const secondCell = await send(
-        'return { results: await host.collect(globalThis.pendingDelegation.children.map(({ frame_id, attempt_id }) => ({ frameId: frame_id, attemptId: attempt_id })), { timeoutSeconds: 0 }) }'
+        "return { results: await host.collect(globalThis.pendingDelegation.children.map(({ frame_id, attempt_id }) => ({ frameId: frame_id, attemptId: attempt_id })), { timeoutSeconds: 0, returnWhen: 'any' }) }"
       )
       expect(secondCell.error).toBeNull()
       expect(JSON.parse(secondCell.result ?? '{}')).toEqual({
@@ -596,7 +596,7 @@ describe('repl_loop local RPC transport', () => {
           params: {
             op: 'collect',
             selectors: [{ frame_id: 'child-1', attempt_id: 'attempt-1' }],
-            options: { timeout_seconds: 0 }
+            options: { timeout_seconds: 0, return_when: 'any' }
           }
         }
       ])

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -19,8 +19,8 @@ import type {
 import { hasCurrentRunningDelegatedAttempt } from '../../../../shared/delegated-work-projection'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useArchiveUndoStore } from '@/stores/archive-undo-store'
-import { projectSessionActionability, type ChatSession } from '@/stores/session-store'
-import { useSessionStore } from '@/stores/session-store'
+import { projectSessionActionability, useSessionStore } from '@/stores/session-store'
+import type { ChatSession } from '@/stores/session-store'
 import {
   hydratePersistedSessionIfPresent,
   loadPersistedSession
@@ -126,7 +126,6 @@ type WorkspaceSessionController = {
 }
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
-// Owns Workspace session transactions and Specialist identity without taking over message dispatch.
 const useWorkspaceSessionController = ({
   activeSession,
   selectedSessionId,

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -8,10 +8,8 @@ import type { StoreApi } from 'zustand'
 
 import type { ElicitationProjection } from '../../../shared/acp'
 import type { ActivePlanProjection } from '../../../shared/session-plan/contract'
-import {
-  DEFAULT_PERMISSION_PROFILE,
-  type PermissionProfileId
-} from '../../../shared/permission-profiles'
+import { DEFAULT_PERMISSION_PROFILE } from '../../../shared/permission-profiles'
+import type { PermissionProfileId } from '../../../shared/permission-profiles'
 import {
   INTERRUPTED_SESSION_ERROR,
   materializeSessionConversationGraph,
@@ -116,9 +114,7 @@ export type SessionStoreData = {
   selectedSessionId: string | undefined
 }
 
-export type SessionHydrationSelection = {
-  sessionId: string | undefined
-}
+export type SessionHydrationSelection = { sessionId: string | undefined }
 
 export type ApplyDurableSessionProjectionInput = {
   source: ChatSession
@@ -157,7 +153,6 @@ const markExternallyHydratedSession = (
   externallyHydratedSessionAuthorities.set(session, structuredClone(authority))
 }
 
-// Builds the empty in-memory state used by the app and isolated tests.
 export const createInitialSessionState = (): SessionStoreData => ({
   sessions: [],
   selectedSessionId: undefined


### PR DESCRIPTION
## Problem

Delegated work could settle without reliably waking the owning main agent, leaving collect waits and same-turn continuation dependent on later unrelated activity.

## Proposed change

Add settlement-aware wake ownership and continuation dispatch across the production delegation composition and ACP runtime coordinator. Preserve settlement provenance, batch wakeups, enforce single-flight delivery, and invalidate stale watches while keeping cross-runtime consumers aligned.

## Scope and non-goals

This change covers delegated collect any/all behavior, same-turn continuation after child settlement, production composition, ACP coordination, host SDK contracts, and the Notebook bridge. Watch and lease state remains process-local and is not restored after an application restart; that is an intentional specification non-goal. No renderer UI or documentation changes are included.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Delegated collect any/all and same-turn continuation -> focused contract, production, and ACP tests -> 713/713 passed.
- Settlement batching, single-flight delivery, invalidation, and provenance -> production composition, wake-owner, and runtime-coordinator focused tests -> passed.
- Cross-runtime consumers (ACP, host SDK, and Notebook bridge) -> Node and Web typechecks plus the i18n guard -> 351/351 i18n tests passed; typechecks passed.
- Full fallback -> npm run typecheck, npm run lint, and npm test -> passed; 1,144 test files passed and 15 skipped, with 17,536 tests passed and 218 skipped.

Independent Standards and Spec reviews each reported 0 findings.

Uncovered risk: process-local watch and lease state does not survive an application restart, as specified. Additional UI/platform E2E was not run because the change has no renderer UI and the full portable suite plus affected runtime typechecks cover the current impact surface.

## Review focus

Please focus on settlement ordering, wake coalescing and single-flight guarantees, stale-watch invalidation, provenance preservation, and continuation behavior across ACP, host SDK, and Notebook consumers.