### PR TITLE
fix(agents)!: narrow agent list summaries

### DIFF
--- a/resources/skills/customize/SKILL.md
+++ b/resources/skills/customize/SKILL.md
@@ -45,9 +45,9 @@ The Skill never uses the following, and you must not invent them:
 The SDK is name-first and lives in the trusted calling session. JavaScript methods, inputs, and
 returned records all use camelCase. Methods:
 
-- `host.agents.list()` — custom Specialists only.
-- `host.agents.get(name)` — one Specialist by immutable name (returns stable `id` and `revision`, but you
-  do not show those to the user).
+- `host.agents.list()` — custom Specialist summaries for discovery and selection only.
+- `host.agents.get(name)` — one existing Specialist's complete current state by immutable name
+  (returns stable `id` and `revision`, but you do not show those to the user).
 - `host.agents.create(input)` — object form (see below).
 - `host.agents.update(name, patch)` — `name` selects the Specialist and is immutable; use
   `patch.displayName` to change its presentation label.
@@ -99,12 +99,13 @@ the application approves the privileged operation.
 
 ## Workflow — every operation
 
-Follow this order for every mutation. Do not skip the live read, and do not snapshot catalog contents
+Follow this order for every mutation. Do not snapshot catalog contents
 into a profile or session (resolution is always live):
 
 1. **Understand scope.** What does the user want to create/change/delete/switch?
-2. **Live read.** Call `get`/`list` plus `listSkills`/`listConnectors` to read the current state and
-   the catalogs before proposing anything.
+2. **Live read.** Use `list` for discovery and selection. For an existing Specialist, call `get(name)`
+   to read its complete current state. Also call `listSkills`/`listConnectors` to read the catalogs
+   before proposing anything.
    Resolve persisted Custom Connector UUIDs through the live Connector catalog and use each
    Connector's immutable `name` in drafts, reviews, and mutation inputs. Never show a Connector UUID
    in ordinary prose. Bundled Connector IDs already equal their names; do not invent suffixes.
@@ -112,8 +113,8 @@ into a profile or session (resolution is always live):
 4. **Review.** Show the complete target state to the user.
 5. **Applicable confirmation.** Get the confirmation that matches the operation kind (see below).
 6. **Mutate.** Call the SDK with the reviewed revision.
-7. **Read-back.** Re-read actual state via `get`/`list` (or binding read-back for switch) before
-   reporting completion.
+7. **Read-back.** After a mutation, re-read actual state with `get(name)`. After delete, verify absence
+   with `list` or an expected not-found result from `get(name)`. For switch, use binding read-back.
 
 ## Scope clarification (Full vs Selected)
 
@@ -189,14 +190,14 @@ Report it as a **user decision** and stop. Do not retry it.
 
 ## Read-back and reporting
 
-- After a successful create/update, re-read with `get`/`list` and report the actual state. Never assume
+- After a successful create/update, re-read with `get(name)` and report the actual state. Never assume
   success from the call alone.
 - After `switch`, report that approval lets the **current control tool finish**, then automatically
   continues the same task under the approved target. A decline leaves the current Agent unchanged.
   The binding survives app restart.
 - After `delete`, report that existing conversations bound to the deleted Specialist become
   **unavailable** — they are not switched to Main Agent; the user must explicitly choose another
-  Specialist or Main Agent.
+  Specialist or Main Agent. Verify deletion with `list` or an expected not-found `get(name)` result.
 
 ## Do not expose UUIDs/revisions in ordinary prose
 

--- a/src/main/agents/agents-dispatch.test.ts
+++ b/src/main/agents/agents-dispatch.test.ts
@@ -54,7 +54,9 @@ describe('AgentsService.dispatch — extensible operation dispatcher', () => {
     const viaDispatch = await service.dispatch({ op: 'list' })
     const viaRead = await service.read({ op: 'list' })
     expect(viaDispatch).toEqual(viaRead)
-    expect((viaDispatch as Array<{ id: string }>)[0].id).toBe('sp-1')
+    expect(Object.keys((viaDispatch as Array<{ id: string }>)[0]).sort()).toEqual(
+      ['id', 'name', 'displayName', 'description', 'enabled'].sort()
+    )
   })
 
   it('rejects an unknown op with a sanitized host.agents.<op>: error', async () => {
@@ -131,7 +133,7 @@ describe('AgentsService.dispatch — extensible operation dispatcher', () => {
       name: 'Bio',
       displayName: 'Bio',
       description: '',
-      systemPrompt: '',
+      systemPrompt: 'CREATE READ-BACK PROMPT SENTINEL',
       enabled: true,
       capabilityMode: 'full' as const,
       fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
@@ -145,10 +147,28 @@ describe('AgentsService.dispatch — extensible operation dispatcher', () => {
     const result = (await service.dispatch({ op: 'create', params: { name: 'Bio' } })) as {
       id: string
       capabilityMode: string
+      systemPrompt: string
     }
     expect(created).toHaveBeenCalledTimes(1)
     expect(result.id).toBe('sp-1')
     expect(result.capabilityMode).toBe('full')
+    expect(result.systemPrompt).toBe('CREATE READ-BACK PROMPT SENTINEL')
+    expect(Object.keys(result).sort()).toEqual(
+      [
+        'id',
+        'name',
+        'displayName',
+        'description',
+        'enabled',
+        'systemPrompt',
+        'iconKey',
+        'colorKey',
+        'capabilityMode',
+        'fullAccess',
+        'selectedCapabilities',
+        'revision'
+      ].sort()
+    )
   })
 
   it('switch fails closed when its approval/binding/persistence seams are not configured', async () => {
@@ -366,7 +386,12 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
   it('routes a displayName edit through the ordinary mutation path', async () => {
     // The ProfileService returns the real post-write record; the dispatcher
     // must surface it verbatim, not echo the request patch.
-    const updated = specialist({ displayName: 'Biology', description: 'new', revision: 4 })
+    const updated = specialist({
+      displayName: 'Biology',
+      description: 'new',
+      systemPrompt: 'UPDATE READ-BACK PROMPT SENTINEL',
+      revision: 4
+    })
     const { service, profileService, gateway } = buildService({
       profiles: [specialist()]
     })
@@ -377,10 +402,11 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
       params: { name: 'Bio', patch: { display_name: 'Biology', description: 'new', revision: 3 } }
     })) as SpecialistProfileView
 
-    // Ordinary path returns a projected AgentReadModel (no {status:'updated'} envelope).
+    // Ordinary path returns a projected AgentDetailReadModel (no {status:'updated'} envelope).
     expect(result.name).toBe('Bio')
     expect(result.displayName).toBe('Biology')
     expect(result.revision).toBe(4)
+    expect(result.systemPrompt).toBe('UPDATE READ-BACK PROMPT SENTINEL')
     // The ordinary path pinned the re-resolved name -> id and revision before update.
     const updateArgs = (profileService.update as ReturnType<typeof vi.fn>).mock.calls[0][0]
     expect(updateArgs.id).toBe('sp-1')
@@ -411,11 +437,54 @@ describe('AgentsService.dispatch — mutation routing (privileged delete + ordin
       params: { name: 'Bio', patch: { description: 'edited', revision: 3 } }
     })) as { id: string; description: string }
 
-    // Ordinary path returns a projected AgentReadModel (no {status:'updated'} envelope).
+    // Ordinary path returns a projected AgentDetailReadModel (no {status:'updated'} envelope).
     expect(result.id).toBe('sp-1')
     expect(result.description).toBe('edited')
     // The privileged gateway was NOT consulted for a non-name update.
     expect(gateway.decide).not.toHaveBeenCalled()
+  })
+
+  it('an attach mutation returns detail including the post-write system prompt', async () => {
+    const attached = specialist({
+      systemPrompt: 'ATTACH READ-BACK PROMPT SENTINEL',
+      selectedCapabilities: {
+        skillIds: ['skill-1'],
+        connectorIds: [],
+        connectorTools: []
+      },
+      revision: 4
+    })
+    const attachSkill = vi.fn(async () => attached)
+    const profileService = withExplicitResolvers({
+      ...noopProfileService(),
+      getByName: vi.fn(async () => specialist()),
+      attachSkill
+    } as unknown as ProfileService)
+    const service = new AgentsService({
+      profileService,
+      catalog: {
+        ...noopCatalog(),
+        listSkillCatalog: vi.fn(async () => [
+          {
+            id: 'skill-1',
+            frameworkName: 'skill-one',
+            displayName: 'Skill One',
+            source: 'personal',
+            mainEnabled: true,
+            available: true
+          }
+        ])
+      }
+    })
+
+    const result = (await service.dispatch({
+      op: 'attach_skill',
+      params: { name: 'Bio', skill_ref: 'skill-1', revision: 3 }
+    })) as SpecialistProfileView
+
+    expect(result.systemPrompt).toBe('ATTACH READ-BACK PROMPT SENTINEL')
+    expect(result.selectedCapabilities.skillIds).toEqual(['skill-1'])
+    expect(attachSkill).toHaveBeenCalledWith('sp-1', 'skill-1', 3, 'selected')
   })
 
   it('routes delete through applyDelete and returns { status: deleted, name }', async () => {

--- a/src/main/agents/agents-repl.integration.test.ts
+++ b/src/main/agents/agents-repl.integration.test.ts
@@ -162,7 +162,13 @@ gate('host.agents repl integration', () => {
     releaseControl = connection.release
 
     // Seed a specialist profile directly through the authoritative ProfileService.
-    await profileService.create({ name: 'Bio Expert', description: 'secret: apikey=XYZ' })
+    await profileService.create({
+      name: 'Bio Expert',
+      description: 'secret: apikey=XYZ',
+      systemPrompt: 'RPC SYSTEM PROMPT SENTINEL',
+      iconKey: 'beaker',
+      colorKey: 'green'
+    })
   })
 
   afterAll(async () => {
@@ -183,8 +189,11 @@ gate('host.agents repl integration', () => {
       expect(r.error).toBeNull()
       const list = JSON.parse(r.result ?? '[]')
       expect(list).toHaveLength(1)
+      expect(Object.keys(list[0]).sort()).toEqual(
+        ['id', 'name', 'displayName', 'description', 'enabled'].sort()
+      )
       expect(list[0].name).toBe('Bio Expert')
-      expect(list[0].revision).toBe(1)
+      expect(r.result).not.toContain('RPC SYSTEM PROMPT SENTINEL')
       // No synthesized Settings-only Reviewer row.
       expect(list.some((item: { id: string }) => item.id === 'reviewer')).toBe(false)
     } finally {
@@ -192,7 +201,7 @@ gate('host.agents repl integration', () => {
     }
   }, 60_000)
 
-  it('host.agents.get(name) returns id + revision', async () => {
+  it('host.agents.get(name) returns complete detail including the system prompt', async () => {
     const { child, send } = startLoop({
       OPEN_SCIENCE_MCP_RPC_ENDPOINT: endpoint,
       OPEN_SCIENCE_MCP_RPC_TOKEN: token,
@@ -205,6 +214,23 @@ gate('host.agents repl integration', () => {
       expect(got.name).toBe('Bio Expert')
       expect(got.revision).toBe(1)
       expect(typeof got.id).toBe('string')
+      expect(got.systemPrompt).toBe('RPC SYSTEM PROMPT SENTINEL')
+      expect(Object.keys(got).sort()).toEqual(
+        [
+          'id',
+          'name',
+          'displayName',
+          'description',
+          'enabled',
+          'systemPrompt',
+          'iconKey',
+          'colorKey',
+          'capabilityMode',
+          'fullAccess',
+          'selectedCapabilities',
+          'revision'
+        ].sort()
+      )
     } finally {
       child.kill()
     }

--- a/src/main/agents/agents-service.test.ts
+++ b/src/main/agents/agents-service.test.ts
@@ -55,19 +55,22 @@ const catalog = (overrides: Partial<AgentsCatalogSource> = {}): AgentsCatalogSou
 })
 
 describe('AgentsService read surface', () => {
-  it('list() returns custom profiles and never synthesizes the Reviewer row', async () => {
+  it('list() returns summary records without system prompts or a synthetic Reviewer row', async () => {
     const service = new AgentsService({
       profileService: profileService([profile()]),
       catalog: catalog()
     })
     const result = (await service.list()) as Awaited<ReturnType<typeof service.list>>
     expect(result).toHaveLength(1)
+    expect(Object.keys(result[0]).sort()).toEqual(
+      ['id', 'name', 'displayName', 'description', 'enabled'].sort()
+    )
     expect(result[0].id).toBe('sp-1')
-    expect(result[0].revision).toBe(3)
+    expect(JSON.stringify(result)).not.toContain('SECRET INSTRUCTIONS')
     expect(result.some((item) => item.id === 'reviewer')).toBe(false)
   })
 
-  it('get(name) resolves the public name and returns id + revision', async () => {
+  it('get(name) returns detail including the system prompt', async () => {
     const service = new AgentsService({
       profileService: profileService([profile()]),
       catalog: catalog()
@@ -75,6 +78,23 @@ describe('AgentsService read surface', () => {
     const got = await service.get({ name: 'Bio Expert' })
     expect(got.id).toBe('sp-1')
     expect(got.revision).toBe(3)
+    expect(got.systemPrompt).toBe('SECRET INSTRUCTIONS')
+    expect(Object.keys(got).sort()).toEqual(
+      [
+        'id',
+        'name',
+        'displayName',
+        'description',
+        'enabled',
+        'systemPrompt',
+        'iconKey',
+        'colorKey',
+        'capabilityMode',
+        'fullAccess',
+        'selectedCapabilities',
+        'revision'
+      ].sort()
+    )
   })
 
   it('get() rejects a missing name with a host.agents.get-prefixed error', async () => {

--- a/src/main/agents/agents-service.ts
+++ b/src/main/agents/agents-service.ts
@@ -96,15 +96,23 @@ export type AgentsServiceDeps = {
 // Public read models (camelCase records returned to the SDK)
 // ---------------------------------------------------------------------------
 
-export type AgentReadModel = {
+// Listing Specialists is a discovery operation, so its collection shape is limited to the five
+// fields needed to identify and present a Specialist. Callers that need editable configuration must
+// explicitly request one profile via get().
+export type AgentSummaryReadModel = {
   id: string
   name: string
   displayName: string
   description: string
+  enabled: boolean
+}
+
+// Single-Agent details and mutation read-backs retain the prompt so callers can inspect, edit, and
+// verify a complete Specialist configuration.
+export type AgentDetailReadModel = AgentSummaryReadModel & {
   systemPrompt: string
   iconKey?: string
   colorKey?: string
-  enabled: boolean
   capabilityMode: 'full' | 'selected'
   fullAccess: SpecialistProfileView['fullAccess']
   selectedCapabilities: SpecialistProfileView['selectedCapabilities']
@@ -158,15 +166,19 @@ class AgentsCallError extends AgentsSafeError {
 const asString = (value: unknown): string | undefined =>
   typeof value === 'string' ? value : undefined
 
-const projectAgent = (profile: SpecialistProfileView): AgentReadModel => ({
+const projectAgentSummary = (profile: SpecialistProfileView): AgentSummaryReadModel => ({
   id: profile.id,
   name: profile.name,
   displayName: profile.displayName ?? profile.name,
   description: profile.description,
+  enabled: profile.enabled
+})
+
+const projectAgentDetail = (profile: SpecialistProfileView): AgentDetailReadModel => ({
+  ...projectAgentSummary(profile),
   systemPrompt: profile.systemPrompt,
   iconKey: profile.iconKey,
   colorKey: profile.colorKey,
-  enabled: profile.enabled,
   capabilityMode: profile.capabilityMode,
   fullAccess: profile.fullAccess,
   selectedCapabilities: profile.selectedCapabilities,
@@ -224,7 +236,7 @@ export class AgentsService {
         opName === 'attach_connector' ||
         opName === 'detach_connector'
       ) {
-        return projectAgent(
+        return projectAgentDetail(
           await executeAgentsMutation(
             { op: opName, params } as Parameters<typeof executeAgentsMutation>[0],
             {
@@ -344,18 +356,18 @@ export class AgentsService {
   }
 
   // Returns custom Specialist Profiles only — never synthesizes the Settings-only Reviewer row.
-  async list(): Promise<AgentReadModel[]> {
+  async list(): Promise<AgentSummaryReadModel[]> {
     const profiles = await this.deps.profileService.list()
-    return profiles.map(projectAgent)
+    return profiles.map(projectAgentSummary)
   }
 
   // Resolves the exact public Specialist name to the current Profile and returns a renderer-safe
   // read model including stable id and revision.
-  async get(params: { name?: unknown }): Promise<AgentReadModel> {
+  async get(params: { name?: unknown }): Promise<AgentDetailReadModel> {
     const name = asString(params.name)
     if (!name) throw agentsPublicError('name is required')
     const profile = await this.deps.profileService.getByName(name)
-    return projectAgent(profile)
+    return projectAgentDetail(profile)
   }
 
   // Returns the complete Specialist-visible skill catalog, including Main-disabled installed

--- a/src/main/agents/customize/fake-host-agents.ts
+++ b/src/main/agents/customize/fake-host-agents.ts
@@ -11,7 +11,12 @@
 // own minimal profile records and catalogs. Behavior mirrors the rules in design.md §5 (capability
 // semantics), §8 (revision + read-back), §10 (delete leaves bindings unavailable).
 
-import type { AgentReadModel, ConnectorReadModel, SkillCatalogReadModel } from '../agents-service'
+import type {
+  AgentDetailReadModel,
+  AgentSummaryReadModel,
+  ConnectorReadModel,
+  SkillCatalogReadModel
+} from '../agents-service'
 
 // ---------------------------------------------------------------------------
 // Internal fake state
@@ -114,7 +119,17 @@ export class FakeHostAgents {
     }
   }
 
-  private project(profile: FakeProfileRecord): AgentReadModel {
+  private projectSummary(profile: FakeProfileRecord): AgentSummaryReadModel {
+    return {
+      id: profile.id,
+      name: profile.name,
+      displayName: profile.displayName,
+      description: profile.description,
+      enabled: profile.enabled
+    }
+  }
+
+  private project(profile: FakeProfileRecord): AgentDetailReadModel {
     return {
       id: profile.id,
       name: profile.name,
@@ -141,13 +156,13 @@ export class FakeHostAgents {
 
   // ----- public read surface -----------------------------------------------------
 
-  async list(): Promise<AgentReadModel[]> {
+  async list(): Promise<AgentSummaryReadModel[]> {
     return Array.from(this.profiles.values())
       .sort((a, b) => a.name.localeCompare(b.name))
-      .map((profile) => this.project(profile))
+      .map((profile) => this.projectSummary(profile))
   }
 
-  async get(name: string): Promise<AgentReadModel> {
+  async get(name: string): Promise<AgentDetailReadModel> {
     const profile = this.profiles.get(name)
     if (!profile) throw agentsError('get', `Specialist "${name}" not found.`)
     return this.project(profile)
@@ -176,7 +191,7 @@ export class FakeHostAgents {
     unrestricted?: boolean
     skillNames?: string[]
     connectorNames?: string[]
-  }): Promise<AgentReadModel> {
+  }): Promise<AgentDetailReadModel> {
     const method = 'create'
     const name = input.name
     if (!name || typeof name !== 'string') throw agentsError(method, 'name is required')
@@ -226,7 +241,7 @@ export class FakeHostAgents {
       connectorNames?: string[]
       revision?: number
     }
-  ): Promise<AgentReadModel> {
+  ): Promise<AgentDetailReadModel> {
     const method = 'update'
     const existing = this.profiles.get(name)
     if (!existing) throw agentsError(method, `Specialist "${name}" not found.`)
@@ -266,7 +281,7 @@ export class FakeHostAgents {
     name: string,
     skillRef: string,
     options: { revision?: number } = {}
-  ): Promise<AgentReadModel> {
+  ): Promise<AgentDetailReadModel> {
     return this.mutateCollection(name, 'skill', skillRef, 'attach', options.revision)
   }
 
@@ -274,7 +289,7 @@ export class FakeHostAgents {
     name: string,
     skillRef: string,
     options: { revision?: number } = {}
-  ): Promise<AgentReadModel> {
+  ): Promise<AgentDetailReadModel> {
     return this.mutateCollection(name, 'skill', skillRef, 'detach', options.revision)
   }
 
@@ -282,7 +297,7 @@ export class FakeHostAgents {
     name: string,
     connectorRef: string,
     options: { revision?: number } = {}
-  ): Promise<AgentReadModel> {
+  ): Promise<AgentDetailReadModel> {
     return this.mutateCollection(name, 'connector', connectorRef, 'attach', options.revision)
   }
 
@@ -290,7 +305,7 @@ export class FakeHostAgents {
     name: string,
     connectorRef: string,
     options: { revision?: number } = {}
-  ): Promise<AgentReadModel> {
+  ): Promise<AgentDetailReadModel> {
     return this.mutateCollection(name, 'connector', connectorRef, 'detach', options.revision)
   }
 
@@ -300,7 +315,7 @@ export class FakeHostAgents {
     ref: string,
     action: 'attach' | 'detach',
     revision: number | undefined
-  ): AgentReadModel {
+  ): AgentDetailReadModel {
     const method = `${action}${kind[0].toUpperCase()}${kind.slice(1)}`
     const existing = this.profiles.get(name)
     if (!existing) throw agentsError(method, `Specialist "${name}" not found.`)

--- a/src/main/agents/customize/workflow.test.ts
+++ b/src/main/agents/customize/workflow.test.ts
@@ -304,10 +304,15 @@ describe('customize Skill: scope clarification', () => {
 describe('customize Skill: live read + complete draft', () => {
   it('reads live Profiles plus Skill/Connector catalogs before proposing a target state', async () => {
     const sdk = makeSdk()
-    const [profile] = await sdk.list()
+    const [summary] = await sdk.list()
+    const profile = await sdk.get(summary.name)
     const skillCatalog = await sdk.listSkills()
     const connectorCatalog = await sdk.listConnectors()
     expect(profile.name).toBe('Bio Expert')
+    expect(Object.keys(summary).sort()).toEqual(
+      ['id', 'name', 'displayName', 'description', 'enabled'].sort()
+    )
+    expect(profile.systemPrompt).toBe('You are a bio expert.')
     expect(skillCatalog.map((entry) => entry.id)).toContain('skill-a')
     expect(connectorCatalog.map((entry) => entry.id)).toContain('conn-a')
     const target = buildReviewedTarget(profile, connectorCatalog)

--- a/src/main/agents/customize/workflow.ts
+++ b/src/main/agents/customize/workflow.ts
@@ -12,7 +12,7 @@
 //  - privileged mutations (delete and switch): explain the impending action, then
 //    invoke the SDK — the standard permission card is the single authorization point.
 
-import type { AgentReadModel, ConnectorReadModel } from '../agents-service'
+import type { AgentDetailReadModel, ConnectorReadModel } from '../agents-service'
 
 // ---------------------------------------------------------------------------
 // Scope clarification (design.md §5: never silently grant Full)
@@ -61,7 +61,7 @@ export type ReviewedTargetState = {
 }
 
 export const buildReviewedTarget = (
-  profile: AgentReadModel,
+  profile: AgentDetailReadModel,
   connectorCatalog: ConnectorReadModel[] = []
 ): ReviewedTargetState => {
   const connectorNameById = new Map(connectorCatalog.map(({ id, name }) => [id, name]))


### PR DESCRIPTION
## Problem

`host.agents.list()` returned complete editable Specialist records, including system prompts, appearance, capability configuration, and revisions. Discovery callers received more configuration than they needed and could unintentionally place every Specialist prompt into Notebook or model context.

Related issue: N/A.

## Proposed change

Return only `id`, `name`, `displayName`, `description`, and `enabled` from `host.agents.list()`. Keep `host.agents.get(name)` and mutation read-backs as complete detail records. Use separate explicit summary and detail projections in `AgentsService`, and update Customize guidance and its fake SDK to follow the same contract.

Breaking migration: consumers that need full configuration must select a summary and call `host.agents.get(summary.name)` for full details.

## Scope and non-goals

This changes only the public list projection and its direct Customize consumer, contract guidance, and tests. It does not change persisted Specialist data, `ProfileService`, `SpecialistProfileView`, authorization, general host SDK help, or Notebook transport behavior.

## Acceptance criteria and validation

- Discovery list exposes exactly the five summary fields; full details remain available from `get(name)` and create/update/attach mutation read-backs.
- Customize uses list for discovery and get for complete review and verification.
- Interface and adapter behavior is covered by service, dispatcher, fake SDK, REPL, and RPC tests.
- `npm run test:affected -- --base 49cd746b2fdae77fbba19b9c5af5787ea60e2bef --head 11a0413dafdcb54eadb78d282a7d1d0c0d868d89` — passed via full fallback: 1,143 test files and 17,755 tests passed; 15 files and 219 tests skipped; zero failures.
- `npx prettier --check` on all 8 changed files, including `resources/skills/customize/SKILL.md` — passed.
- `git diff --check` — passed.

These checks ran after the last material edit. No platform-specific runtime behavior or persistence schema changed; exact-head CI remains authoritative for platform lanes. The intentional uncovered compatibility risk is external list consumers that read detail-only fields, which must use the migration above.

## Review focus

Please focus on the five-field summary boundary, the explicit detail projection, mutation read-back preservation, and whether Customize consistently directs detail consumers to `get(name)`.