### PR TITLE
fix(e2e): match session menu accessible name

### DIFF
--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -167,7 +167,11 @@ test('archives a completed session from its mobile sidebar actions', async ({ ap
   await page.setViewportSize({ width: 375, height: 900 })
   await page.getByRole('button', { name: 'Open navigation' }).click()
   await page.getByRole('button', { name: `Open actions for ${USER_MESSAGE}` }).click()
-  const sessionActions = page.getByRole('menu', { name: 'Session actions' })
+  // Chromium names a popup menu from its trigger, so the computed accessible name is the
+  // session-specific trigger label rather than the content aria-label "Session actions".
+  const sessionActions = page.getByRole('menu', {
+    name: `Open actions for ${USER_MESSAGE}`
+  })
   await expect(sessionActions).toBeVisible()
   expect(await sessionActions.evaluate((element) => Number(getComputedStyle(element).zIndex))).toBe(
     80

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -583,6 +583,52 @@ describe('WorkspaceSidebar accessible render', () => {
     expect(html).toContain('aria-label="Open actions for Dataset cleanup"')
   })
 
+  it('labels session action content and raises its stacking only in mobile mode', async () => {
+    const { WorkspaceSidebarView } = await import('./WorkspaceSidebar')
+    const session = createSession({ id: 'session-a', title: 'Notebook review' })
+    const sharedProps = {
+      now: Date.now(),
+      projectName: 'Example project',
+      sessions: [session],
+      activeSessionId: session.id,
+      canCreateConversation: true,
+      canMutateConversations: true,
+      canDeleteConversations: true,
+      onGoHome: vi.fn(),
+      onNewConversation: vi.fn(),
+      isFilesOpen: false,
+      onOpenFiles: vi.fn(),
+      onOpenSession: vi.fn(),
+      onRenameSession: vi.fn(),
+      canDownloadArtifacts: true,
+      onDownloadArtifacts: vi.fn(),
+      onViewNotebook: vi.fn(),
+      onExportSession: vi.fn(),
+      onTogglePin: vi.fn(),
+      onDeleteSession: vi.fn(),
+      onOpenSettings: vi.fn(),
+      onOpenProjectSettings: vi.fn(),
+      onNewProject: vi.fn()
+    }
+
+    const desktopMenu = collectElements(WorkspaceSidebarView(sharedProps)).find(
+      (element) => element.props['aria-label'] === 'Session actions'
+    )
+    const mobileMenu = collectElements(
+      WorkspaceSidebarView({
+        ...sharedProps,
+        mobileMode: true,
+        isMobileOpen: true,
+        onMobileClose: vi.fn()
+      })
+    ).find((element) => element.props['aria-label'] === 'Session actions')
+
+    expect(desktopMenu).toBeDefined()
+    expect(String(desktopMenu?.props.className ?? '')).not.toContain('z-[80]')
+    expect(mobileMenu).toBeDefined()
+    expect(String(mobileMenu?.props.className ?? '')).toContain('z-[80]')
+  })
+
   it('reveals session actions on interaction without keeping the selected row action visible', async () => {
     const session = createSession({ id: 'session-a', title: 'Notebook review' })
     const desktop = document.createElement('div')


### PR DESCRIPTION
## Problem

#1530 retargeted the mobile sidebar export journey at the new export dialog and located the session-actions menu with `getByRole('menu', { name: 'Session actions' })`. Chromium names that Radix popup from its trigger, so the computed accessible name is `Open actions for …` rather than the content `aria-label`.

The menu was already open (CI screenshots and the Playwright accessibility tree both show Pin / Rename / Export conversation… / Archive). The assertion still timed out, failing workspace E2E on #1531, #1530, #1528, #1526, #1525, and #1532.

## Proposed change

- locate the open menu by the trigger-derived accessible name `Open actions for ${title}`
- keep the existing mobile `z-index: 80` stacking check and the export-dialog / Archive journey
- pin the content `aria-label="Session actions"` and mobile-only `z-[80]` class in the sidebar render contract

## Scope and non-goals

- No export request, prompt-boundary projection, or selection behavior changes.
- No historical-data compatibility work is required; persisted conversation and session formats are unchanged.
- No status or enum values are added.
- No data persistence, database schema, migration, or preference changes are included.
- No change to the session-actions menu items or the export dialog itself.

## Acceptance criteria and validation

All commands below ran after the last material edit.

- session-actions trigger naming, mobile stacking class, and content label → `npm test -- src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx` → **1 file, 30 passed**
- workspace page owner and representative consumer tests → `npm run test:module -- workspace_page` → **25 files, 460 passed**
- node type contracts including e2e specs → `npm run typecheck:node` → **passed**
- renderer type contracts → `npm run typecheck:web` → **passed**
- changed-file lint → `npx eslint e2e/workspace-conversation.spec.ts src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx` → **passed**

Per maintainer direction, the complete `npm test` suite was not run locally; PR Gate remains authoritative for full portable and platform coverage, including `test:e2e:workspace`.

Uncovered locally: the Electron workspace journey was not rebuilt here. The failing CI run already showed the menu open under the trigger-derived name; PR CI remains authoritative for the built renderer.

## Review focus

- whether targeting the trigger-derived accessible name matches Chromium's popup naming rather than papering over a missing menu
- whether the mobile stacking assertion still attaches to the same `DropdownMenuContent` node