### PR TITLE
fix(notebook): preserve approved run status during state reads

### DIFF
--- a/src/main/artifacts/provenance-write-contract.test.ts
+++ b/src/main/artifacts/provenance-write-contract.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import type { NotebookRunInputFile } from '../../shared/notebook'
 import { ImmutableInputAuthority } from '../immutable-input-authority'
 import { createFrameNotebookLane } from '../notebook/lane-identity'
+import { NotebookRuntimeService, type NotebookExecutionResult } from '../notebook/runtime-service'
 import { createPngBytes } from './artifact-test-fixtures'
 import * as provenanceModule from './provenance-repository'
 import { ArtifactProvenanceRepository } from './provenance-repository'
@@ -308,6 +309,76 @@ const createReadyUploadInput = async (
 }
 
 describe('artifact provenance producer and source validation', () => {
+  it('accepts a root Notebook producer after renderer state creates the Session owner first', async () => {
+    const value = await fixture()
+    const rootFrameId = 'root-frame-pending-session-1'
+    const service = new NotebookRuntimeService({
+      configRoot: value.storageRoot,
+      dataRoot: value.storageRoot,
+      projectId: 'project-1',
+      repository: value.notebookRepository,
+      executorFactory: () => ({
+        execute: async (request): Promise<NotebookExecutionResult> => ({
+          status: 'completed',
+          stdout: '',
+          stderr: '',
+          traceback: '',
+          cwdAfter: request.cwd,
+          outputs: []
+        }),
+        shutdown: async () => ({ reaped: true })
+      })
+    })
+
+    try {
+      await service.state({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        workspaceCwd: join(value.storageRoot, 'workspace')
+      })
+      await service.executeControl({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        workspaceCwd: join(value.storageRoot, 'workspace'),
+        code: 'save_plot("plot.png")',
+        provenanceContext: {
+          rootFrameId,
+          agentFrameId: rootFrameId,
+          messageBranchId: 'branch-1',
+          runtimeSegmentId: 'runtime-segment-1',
+          promptMessageId: 'prompt-1'
+        }
+      })
+      const notebookState = await service.state({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        workspaceCwd: join(value.storageRoot, 'workspace')
+      })
+      const producerRunId = notebookState.runs.at(-1)?.runId
+      expect(producerRunId).toBeDefined()
+
+      await value.stagePng('producer bytes')
+      const version = await value.repository.createVersion(
+        createArtifactVersionRequest({
+          notebookSessionId: 'session-1',
+          producerRunId,
+          sourceKind: 'inline',
+          rootFrameId,
+          agentFrameId: rootFrameId,
+          messageBranchId: 'branch-1',
+          runtimeSegmentId: 'runtime-segment-1',
+          promptMessageId: 'prompt-1'
+        })
+      )
+
+      await expect(
+        value.client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
+      ).resolves.toMatchObject({ producerRunId })
+    } finally {
+      await service.shutdownAll()
+    }
+  })
+
   it('binds a declared producer only to the exact observed source owner and retries identically', async () => {
     const value = await fixture()
     const observation = await appendNotebookRun(value, {

--- a/src/main/notebook/execution-owner.ts
+++ b/src/main/notebook/execution-owner.ts
@@ -8,6 +8,7 @@ import type {
   NotebookLanguage,
   NotebookOutput,
   NotebookRunRecord,
+  NotebookRunProvenanceContext,
   NotebookRunSource,
   NotebookRunStatus,
   NotebookWorkingFile,
@@ -123,6 +124,14 @@ const cancelledExecutionResult = (cwd: string): NotebookSessionExecutionResult =
   ...errorToExecutionResult(new Error(CANCELLED_MESSAGE), cwd),
   status: 'cancelled'
 })
+
+// Root runtime ownership is Session-scoped, but every durable Run still belongs to the authenticated
+// conversation Frame that produced it. A renderer state read may have created the shared owner first.
+const runAgentFrameId = (
+  session: NotebookSessionAggregate,
+  provenanceContext: NotebookRunProvenanceContext | undefined
+): string => provenanceContext?.agentFrameId ?? notebookLaneScope(session.lane).agentFrameId
+
 class NotebookExecutionOwner {
   private readonly shellProcess: NotebookShellProcess
   private controlCompletionInterceptor: NotebookControlCompletionInterceptor | undefined
@@ -183,7 +192,7 @@ class NotebookExecutionOwner {
       executionCount,
       environment,
       ...request.provenanceContext,
-      agentFrameId: notebookLaneScope(session.lane).agentFrameId,
+      agentFrameId: runAgentFrameId(session, request.provenanceContext),
       text: { stdout: '', stderr: '', traceback: '', plain: [] },
       outputs: [],
       artifacts: [],
@@ -385,7 +394,7 @@ class NotebookExecutionOwner {
       startedAt: Date.now(),
       cwdBefore: session.cwd,
       ...request.provenanceContext,
-      agentFrameId: notebookLaneScope(session.lane).agentFrameId,
+      agentFrameId: runAgentFrameId(session, request.provenanceContext),
       text: { stdout: '', stderr: '', traceback: '', plain: [] },
       outputs: [],
       artifacts: [],
@@ -511,7 +520,7 @@ class NotebookExecutionOwner {
       startedAt: Date.now(),
       cwdBefore: session.cwd,
       ...request.provenanceContext,
-      agentFrameId: notebookLaneScope(session.lane).agentFrameId,
+      agentFrameId: runAgentFrameId(session, request.provenanceContext),
       text: { stdout: '', stderr: '', traceback: '', plain: [] },
       outputs: [],
       artifacts: [],

--- a/src/main/notebook/lane-identity.ts
+++ b/src/main/notebook/lane-identity.ts
@@ -63,6 +63,15 @@ export const notebookLaneScope = (lane: NotebookLaneIdentity): NotebookLaneScope
 }
 
 export const notebookLaneKey = (lane: NotebookLaneIdentity): string => {
-  const { projectId, sessionId, agentFrameId, attemptId } = notebookLaneScope(lane)
-  return JSON.stringify([projectId, sessionId, agentFrameId, attemptId ?? null])
+  const { projectId, sessionId, agentFrameId, kind, attemptId } = notebookLaneScope(lane)
+  // A root Notebook is durable per Session even when the Agent runtime adopted a provisional root
+  // Frame id before the final Session id existed. Keep that provenance on Run records, but do not
+  // let its alternate presentation create a second in-memory owner for the same root run.json.
+  return JSON.stringify([
+    projectId,
+    sessionId,
+    kind,
+    kind === 'root' ? null : agentFrameId,
+    kind === 'root' ? null : (attemptId ?? null)
+  ])
 }

--- a/src/main/notebook/repository.ts
+++ b/src/main/notebook/repository.ts
@@ -359,8 +359,13 @@ const withoutTerminatedKernelInstances = (
 }
 
 const ownRun = (lane: NotebookLaneIdentity, run: NotebookRunRecord): NotebookRunRecord => {
-  const { agentFrameId } = notebookLaneScope(lane)
-  if (run.agentFrameId && run.agentFrameId !== agentFrameId) {
+  const scope = notebookLaneScope(lane)
+  const agentFrameId = run.agentFrameId ?? scope.agentFrameId
+  // Root lanes share one durable document across their provisional and conversation Frame ids. Keep
+  // the Run's self-consistent root provenance; child lanes must still match their exact Frame owner.
+  const matchesRootRunProvenance =
+    scope.kind === 'root' && run.rootFrameId !== undefined && agentFrameId === run.rootFrameId
+  if (agentFrameId !== scope.agentFrameId && !matchesRootRunProvenance) {
     throw new Error('Notebook Run Frame owner does not match its lane.')
   }
   return { ...run, agentFrameId }

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -3153,6 +3153,73 @@ describe('notebook runtime service', () => {
     }
   })
 
+  it('keeps root-Frame provenance when renderer state creates the Session owner first', async () => {
+    const root = await createStorageRoot()
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectId: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory: () => ({
+        execute: async (request): Promise<NotebookExecutionResult> => ({
+          status: 'completed',
+          stdout: 'done\n',
+          stderr: '',
+          traceback: '',
+          cwdAfter: request.cwd,
+          outputs: []
+        }),
+        shutdown: async () => ({ reaped: true })
+      })
+    })
+    const sessionId = 'codex-session'
+    const rootFrameId = 'root-frame-pending-session-1'
+
+    await service.state({
+      projectId: 'default-project',
+      sessionId,
+      workspaceCwd: '/workspace'
+    })
+    await service.executeControl({
+      projectId: 'default-project',
+      sessionId,
+      workspaceCwd: '/workspace',
+      code: 'await host.mcp("pubmed", "search_articles", {})',
+      executionInvocationId: 'invocation-1',
+      provenanceContext: {
+        rootFrameId,
+        agentFrameId: rootFrameId,
+        messageBranchId: 'branch-1',
+        runtimeSegmentId: 'runtime-1',
+        promptMessageId: 'prompt-1'
+      }
+    })
+
+    const state = await service.state({
+      projectId: 'default-project',
+      sessionId,
+      workspaceCwd: '/workspace'
+    })
+    expect(state.runs).toContainEqual(
+      expect.objectContaining({
+        executionInvocationId: 'invocation-1',
+        agentFrameId: rootFrameId,
+        rootFrameId
+      })
+    )
+
+    const frameSummary = await service.state({
+      projectId: 'default-project',
+      sessionId,
+      workspaceCwd: '/workspace',
+      historySummaryFrameId: rootFrameId
+    })
+    expect(frameSummary.historySummary).toMatchObject({
+      agentFrameId: rootFrameId,
+      runCount: 1
+    })
+  })
+
   it('serializes overlapping runs on the shared interpreter instead of failing the second', async () => {
     const root = await createStorageRoot()
     let active = 0

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -3091,6 +3091,68 @@ describe('notebook runtime service', () => {
     })
   })
 
+  it('keeps a live root-Frame control run running when the renderer reads Session state', async () => {
+    const root = await createStorageRoot()
+    const executionStarted = createDeferred<void>()
+    const releaseExecution = createDeferred<void>()
+    const service = new NotebookRuntimeService({
+      configRoot: root,
+      dataRoot: root,
+      projectId: 'default-project',
+      repository: new NotebookRunRepository(root),
+      executorFactory: () => ({
+        execute: async (request): Promise<NotebookExecutionResult> => {
+          executionStarted.resolve()
+          await releaseExecution.promise
+          return {
+            status: 'completed',
+            stdout: 'done\n',
+            stderr: '',
+            traceback: '',
+            cwdAfter: request.cwd,
+            outputs: []
+          }
+        },
+        shutdown: async () => ({ reaped: true })
+      })
+    })
+    const sessionId = 'codex-session'
+    const rootFrameId = 'root-frame-pending-session-1'
+    const executing = service.executeControl({
+      projectId: 'default-project',
+      sessionId,
+      workspaceCwd: '/workspace',
+      code: 'await host.mcp("pubmed", "search_articles", {})',
+      executionInvocationId: 'invocation-1',
+      provenanceContext: {
+        rootFrameId,
+        agentFrameId: rootFrameId,
+        messageBranchId: 'branch-1',
+        runtimeSegmentId: 'runtime-1',
+        promptMessageId: 'prompt-1'
+      }
+    })
+
+    await executionStarted.promise
+    try {
+      const state = await service.state({
+        projectId: 'default-project',
+        sessionId,
+        workspaceCwd: '/workspace'
+      })
+
+      expect(state.runs).toContainEqual(
+        expect.objectContaining({
+          executionInvocationId: 'invocation-1',
+          status: 'running'
+        })
+      )
+    } finally {
+      releaseExecution.resolve()
+      await executing
+    }
+  })
+
   it('serializes overlapping runs on the shared interpreter instead of failing the second', async () => {
     const root = await createStorageRoot()
     let active = 0

--- a/src/renderer/src/pages/workspace/tool-execution-phase.test.ts
+++ b/src/renderer/src/pages/workspace/tool-execution-phase.test.ts
@@ -58,6 +58,38 @@ describe('getToolExecutionPhase', () => {
     expect(getToolExecutionPhase(activity(), permission())).toBe('awaiting-approval')
   })
 
+  it('moves one approved Notebook activity from approval preview into Run execution', () => {
+    const authorizedActivity = activity({ executionInvocationId: 'invocation-1' })
+
+    expect([
+      getToolExecutionPhase(activity(), permission()),
+      getToolExecutionPhase(authorizedActivity, undefined),
+      getToolExecutionPhase(
+        authorizedActivity,
+        undefined,
+        new Map([['run-1', run({ status: 'running' })]])
+      ),
+      getToolExecutionPhase(
+        authorizedActivity,
+        undefined,
+        new Map([['run-1', run({ status: 'completed', endedAt: 2 })]])
+      )
+    ]).toEqual(['awaiting-approval', 'prepared', 'executing', 'completed'])
+  })
+
+  it('skips approval preview when Notebook execution is already authorized', () => {
+    const authorizedActivity = activity({ executionInvocationId: 'invocation-1' })
+
+    expect([
+      getToolExecutionPhase(authorizedActivity, undefined),
+      getToolExecutionPhase(
+        authorizedActivity,
+        undefined,
+        new Map([['run-1', run({ status: 'running' })]])
+      )
+    ]).toEqual(['prepared', 'executing'])
+  })
+
   it('fails closed when permission identity does not match the active activity', () => {
     expect(
       getToolExecutionPhase(


### PR DESCRIPTION
## Problem

After a user approved an ACP Notebook execution, the activity could briefly show `Interrupted Notebook run` before completing. The renderer state read opened the same durable root `run.json` through a second in-memory owner because the live runtime root Frame id differed from the Session-derived root Frame id. Crash recovery then wrote `interrupted / app-terminated` over the live Run.

Root owner deduplication also has to preserve per-Run provenance. If renderer `state()` creates the shared Session owner before execution, replacing the authenticated root Frame id with the Session-derived owner id makes the Notebook preview filter omit the Run and makes `write_artifact_file` reject its `producerRunId` as belonging to another Agent Frame.

## Proposed change

- Canonicalize root Notebook runtime owner keys by Project and Session.
- Preserve each Run's authenticated root Frame provenance independently from that shared runtime owner.
- Keep child Frame and Attempt ownership strictly isolated.
- Preserve one ACP tool presentation across approval and execution, following `awaiting-approval -> prepared -> executing -> completed`.
- Skip approval presentation when execution is already authorized.

## Scope and non-goals

- No new tool entity, shared status, enum value, field, or persistence format.
- No authorization interaction changes.
- No migration or historical Run rewrite.
- Existing historical interrupted records remain unchanged because genuine and formerly false interruptions cannot be distinguished safely.

## Regression evidence

The tests were added and run against the affected code before each fix:

- A live root Run changed from `running` to `interrupted / app-terminated` when renderer state hydrated the same Session.
- With renderer state first, a Run expected on `root-frame-pending-session-1` was persisted on `root-frame-codex-session`, matching the empty preview symptom.
- Artifact Version creation with that Run as `producerRunId` failed with `Notebook producer run belongs to a different agent frame`, matching the partial `write_artifact_file` anomaly.

All three pass after the final change.

## Validation

All listed checks ran after the final material edit.

- Notebook owner, repository, preview-first provenance, and Artifact producer contract: `npm test -- src/main/notebook/lane-identity.test.ts src/main/notebook/session-registry.test.ts src/main/notebook/repository.test.ts src/main/notebook/runtime-service.test.ts src/main/artifacts/provenance-write-contract.test.ts src/main/artifacts/mcp-server.test.ts` -> 308 passed.
- Permission and renderer presentation paths: `npm test -- src/main/acp/permission-context.test.ts src/main/acp/permission-broker.test.ts src/renderer/src/pages/workspace/tool-execution-phase.test.ts src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx` -> 216 passed.
- Renderer types: `npm run typecheck:web` -> passed.
- Lint: `npm run lint` -> passed.
- Formatting: `npx prettier --check` on all six changed files -> passed.
- Whitespace: `git diff --check` -> passed.

`npm run typecheck:node` reaches an unrelated E2E matcher error on this older branch base at `e2e/message-tool-layout-stability.spec.ts:137`. Current main passes the same check because that issue was fixed by `f35c81be` / #1530. Per contribution guidance, this branch was not updated solely because main advanced. Full portable and platform suites are left to PR Gate as requested.

## Review focus

- Root runtime owner equivalence matches the existing root `run.json` storage identity.
- A root Run retains the authenticated conversation Frame id even when a renderer state read created the shared owner first.
- Child Frame and Attempt identities remain isolated.
- Artifact producer validation succeeds without weakening its exact Frame checks for child runs.
- Regression tests exercise public Runtime Service and Artifact Repository behavior without a new test seam.
