### PR TITLE
feat(providers): add deepseek-v4-flash-vision-exp

### DIFF
--- a/src/main/settings/provider-runtime-projection.test.ts
+++ b/src/main/settings/provider-runtime-projection.test.ts
@@ -97,6 +97,36 @@ describe('ProviderRuntimeProjectionOwner', () => {
     })
   })
 
+  it('enables image input only for DeepSeek vision-exp while keeping native Responses', () => {
+    const owner = new ProviderRuntimeProjectionOwner()
+    const provider: StoredProvider = {
+      id: 'deepseek',
+      type: 'official',
+      vendorId: 'deepseek',
+      name: 'DeepSeek'
+    }
+
+    expect(
+      owner.resolveRuntimeTarget(
+        provider,
+        { kind: 'required', model: 'deepseek-v4-flash-vision-exp' },
+        getAgentFramework('codex')
+      )
+    ).toMatchObject({
+      apiEndpoints: ['anthropic', 'openai', 'responses'],
+      needsNativeResponsesCompatibility: true,
+      provider: { supportsImageInput: true, model: 'deepseek-v4-flash-vision-exp' }
+    })
+    expect(
+      owner.resolveRuntimeTarget(
+        provider,
+        { kind: 'required', model: 'deepseek-v4-flash' },
+        getAgentFramework('codex')
+      ).provider.supportsImageInput
+    ).toBe(false)
+    expect(owner.toProviderView(provider).supportsImageInput).toBe(false)
+  })
+
   it('keeps an exact required model when a subscription catalog is unknown', () => {
     const owner = new ProviderRuntimeProjectionOwner()
     const provider: StoredProvider = {

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3297,11 +3297,17 @@ describe('SettingsService: official vendors', () => {
       settings: {
         skipWebFetchPreflight: true,
         permissions: { ask: ['WebFetch'] },
-        availableModels: ['deepseek-v4-flash', 'deepseek-v4-pro', 'deepseek-v4-pro[1m]'],
+        availableModels: [
+          'deepseek-v4-flash',
+          'deepseek-v4-pro',
+          'deepseek-v4-pro[1m]',
+          'deepseek-v4-flash-vision-exp'
+        ],
         modelOverrides: {
           'deepseek-v4-flash': 'deepseek-v4-flash',
           'deepseek-v4-pro': 'deepseek-v4-pro',
-          'deepseek-v4-pro[1m]': 'deepseek-v4-pro[1m]'
+          'deepseek-v4-pro[1m]': 'deepseek-v4-pro[1m]',
+          'deepseek-v4-flash-vision-exp': 'deepseek-v4-flash-vision-exp'
         }
       }
     })
@@ -3309,11 +3315,17 @@ describe('SettingsService: official vendors', () => {
     await expect(
       readFile(join(getAppClaudeConfigDir(storageRoot), 'settings.json'), 'utf8').then(JSON.parse)
     ).resolves.toMatchObject({
-      availableModels: ['deepseek-v4-flash', 'deepseek-v4-pro', 'deepseek-v4-pro[1m]'],
+      availableModels: [
+        'deepseek-v4-flash',
+        'deepseek-v4-pro',
+        'deepseek-v4-pro[1m]',
+        'deepseek-v4-flash-vision-exp'
+      ],
       modelOverrides: {
         'deepseek-v4-flash': 'deepseek-v4-flash',
         'deepseek-v4-pro': 'deepseek-v4-pro',
-        'deepseek-v4-pro[1m]': 'deepseek-v4-pro[1m]'
+        'deepseek-v4-pro[1m]': 'deepseek-v4-pro[1m]',
+        'deepseek-v4-flash-vision-exp': 'deepseek-v4-flash-vision-exp'
       }
     })
     expect(config.contextWindow).toBe(1_000_000)
@@ -3561,6 +3573,28 @@ describe('SettingsService: image-input capability', () => {
     })
     const deepseek = deepseekSnapshot.providers.find((p) => p.vendorId === 'deepseek')
     expect(deepseek?.supportsImageInput).toBe(false)
+  })
+
+  it('tracks the active model for a vendor with mixed vision support (DeepSeek)', async () => {
+    const service = createService()
+    const created = (
+      await service.upsertProvider({
+        type: 'official',
+        name: 'DeepSeek',
+        vendorId: 'deepseek',
+        key: 'k'
+      })
+    ).providers[0]
+
+    let view = (
+      await service.setActiveProvider(created.id, 'deepseek-v4-flash-vision-exp')
+    ).providers.find((provider) => provider.id === created.id)
+    expect(view?.supportsImageInput).toBe(true)
+
+    view = (await service.setActiveProvider(created.id, 'deepseek-v4-flash')).providers.find(
+      (provider) => provider.id === created.id
+    )
+    expect(view?.supportsImageInput).toBe(false)
   })
 
   it('tracks the active model for a vendor with mixed vision support (GLM)', async () => {

--- a/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ProviderForm.render.test.tsx
@@ -279,6 +279,7 @@ describe('ProviderForm field switching', () => {
     // The supported models are shown read-only as reference tags.
     expect(container.textContent).toContain('Supported models')
     expect(container.textContent).toContain('deepseek-v4-pro')
+    expect(container.textContent).toContain('deepseek-v4-flash-vision-exp')
   })
 
   it('shows a region-specific "get a key" link for an official vendor', () => {

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -53,6 +53,20 @@ describe('provider registry', () => {
     expect(getOfficialVendor('deepseek')?.label).toBe('DeepSeek')
   })
 
+  it('ships DeepSeek V4 with a vision-capable flash experimental model', () => {
+    expect(
+      getOfficialVendor('deepseek')?.models.map(({ id, contextWindow }) => ({ id, contextWindow }))
+    ).toEqual([
+      { id: 'deepseek-v4-pro', contextWindow: 1_000_000 },
+      { id: 'deepseek-v4-pro[1m]', contextWindow: 1_000_000 },
+      { id: 'deepseek-v4-flash', contextWindow: 1_000_000 },
+      { id: 'deepseek-v4-flash-vision-exp', contextWindow: 1_000_000 }
+    ])
+    expect(defaultVendorModel('deepseek')).toBe('deepseek-v4-pro')
+    expect(resolveVendorOpenAiBaseUrl('deepseek')).toBe('https://api.deepseek.com/v1')
+    expect(resolveVendorApiEndpoints('deepseek')).toEqual(['anthropic', 'openai'])
+  })
+
   it('resolves a multi-region vendor by region, defaulting to the first', () => {
     expect(vendorHasRegions('minimax')).toBe(true)
     expect(resolveVendorBaseUrl('minimax', 'china')).toBe('https://api.minimaxi.com/anthropic')
@@ -499,7 +513,8 @@ describe('provider registry', () => {
       expect(isVendorModelMultimodal('openai', 'gpt-6-turbo')).toBe(true)
     })
 
-    it('returns false for DeepSeek models (no vision support)', () => {
+    it('returns true only for the DeepSeek vision-exp model', () => {
+      expect(isVendorModelMultimodal('deepseek', 'deepseek-v4-flash-vision-exp')).toBe(true)
       expect(isVendorModelMultimodal('deepseek', 'deepseek-v4-pro')).toBe(false)
       expect(isVendorModelMultimodal('deepseek', 'deepseek-v4-flash')).toBe(false)
     })
@@ -626,6 +641,7 @@ describe('provider registry', () => {
       expect(isVendorModelResponsesSupported('deepseek', 'deepseek-v4-pro')).toBe(true)
       expect(isVendorModelResponsesSupported('deepseek', 'deepseek-v4-pro[1m]')).toBe(true)
       expect(isVendorModelResponsesSupported('deepseek', 'deepseek-v4-flash')).toBe(true)
+      expect(isVendorModelResponsesSupported('deepseek', 'deepseek-v4-flash-vision-exp')).toBe(true)
     })
 
     it('returns false for unknown DeepSeek models', () => {
@@ -670,6 +686,7 @@ describe('provider registry', () => {
       expect(resolveModelContextWindow('xai', 'grok-4.3')).toBe(1_000_000)
       expect(resolveModelContextWindow('xai', 'grok-build-0.1')).toBe(256_000)
       expect(resolveModelContextWindow('deepseek', 'deepseek-v4-flash')).toBe(1_000_000)
+      expect(resolveModelContextWindow('deepseek', 'deepseek-v4-flash-vision-exp')).toBe(1_000_000)
       expect(resolveModelContextWindow('glmcodingplan', 'glm-5.3')).toBe(1_000_000)
       expect(resolveModelContextWindow('zhipu', 'glm-5.2')).toBe(1_000_000)
       expect(resolveModelContextWindow('zhipu', 'glm-5.1')).toBe(200_000)

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -213,12 +213,20 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     models: [
       { id: 'deepseek-v4-pro', contextWindow: 1_000_000 },
       { id: 'deepseek-v4-pro[1m]', contextWindow: 1_000_000 },
-      { id: 'deepseek-v4-flash', contextWindow: 1_000_000 }
+      { id: 'deepseek-v4-flash', contextWindow: 1_000_000 },
+      { id: 'deepseek-v4-flash-vision-exp', contextWindow: 1_000_000 }
     ],
-    // Both DeepSeek V4 models serve the native Responses API. Keep the explicit list because the
+    // Bundled DeepSeek V4 models serve the native Responses API. Keep the explicit list because the
     // vendor also exposes non-Responses models through its live model catalog.
-    responsesModels: ['deepseek-v4-pro', 'deepseek-v4-pro[1m]', 'deepseek-v4-flash']
-    // DeepSeek's chat models are text-only, so no `multimodal` rule (image input stays disabled).
+    responsesModels: [
+      'deepseek-v4-pro',
+      'deepseek-v4-pro[1m]',
+      'deepseek-v4-flash',
+      'deepseek-v4-flash-vision-exp'
+    ],
+    // Only the vision-exp id accepts image input. Pro and flash stay text-only; sending images to
+    // them returns 400. The explicit list also covers the same id when it arrives via live refresh.
+    multimodal: { multimodalModels: ['deepseek-v4-flash-vision-exp'] }
   },
   {
     id: 'bailian',


### PR DESCRIPTION
## Problem

DeepSeek's official API now ships `deepseek-v4-flash-vision-exp`, a 1M-context V4 Flash variant that accepts image input (OpenAI Chat Completions, Anthropic Messages, and Responses). The bundled official DeepSeek catalog still listed only `deepseek-v4-pro`, `deepseek-v4-pro[1m]`, and `deepseek-v4-flash`, all marked text-only, so the composer could not select the vision model or attach images through that provider.

Official model and pricing: https://api-docs.deepseek.com/zh-cn/quick_start/pricing
Vision guide: https://api-docs.deepseek.com/zh-cn/guides/vision

## Proposed change

- Add `deepseek-v4-flash-vision-exp` to the official DeepSeek catalog with a 1M context window.
- Keep the existing vendor default (`deepseek-v4-pro`).
- Include the new id in `responsesModels` (documented native Responses support).
- Declare an explicit `multimodalModels` rule for this id only so pro/flash stay text-only.
- Cover catalog, vision, Responses, provider-view image capability, Claude available-models projection, and the Settings form tag list.

## Scope and non-goals

- Official `deepseek` vendor only.
- Bailian, Bailian for Plan, SenseNova, and OpenRouter catalogs are unchanged.
- No new provider type, endpoint, reasoning-effort profile, or framework adapter.
- Image send/replay still uses the existing `supportsImageInput` pipeline; this change only flips that flag for the new model id.

## Historical compatibility

No stored-record migration is required. Existing DeepSeek sessions and saved selections stay on their current model.

- Providers **without** `fetchedModels` pick up the new bundled id automatically.
- Providers **with** a previously refreshed `fetchedModels` list keep that list until the user refreshes again. If the live catalog already includes this id, a refresh surfaces it; vision capability is resolved from the registry rule by id, not from persisted flags.
- Sessions on `deepseek-v4-pro` / `deepseek-v4-flash` remain text-only. Image attachments enable only after the user selects `deepseek-v4-flash-vision-exp`.
- DeepSeek documents that non-vision models return 400 if they receive images. That matches the existing mixed-vision reconnect/relay behavior (same pattern as GLM).

## Enum / state additions

None. `OfficialVendorId` is unchanged. The new model is a catalog string id. No new reasoning-effort preset, API endpoint, or runtime lifecycle state.

## Persistence

None. No new settings fields, no Prisma schema change, no migration.

- Bundled catalog is code, not stored data.
- `fetchedModels` remains the existing optional live-refresh snapshot; this change does not merge the new id into already-persisted snapshots.
- Claude Code `availableModels` / `modelOverrides` in the app profile are rewritten at spawn time from the current catalog.

## Acceptance criteria and validation

The checks below ran after the last material edit:

- DeepSeek catalog, vision, Responses, and context contracts -> `npx vitest run src/shared/provider-registry.test.ts` -> 58 passed
- Runtime projection of image input and Responses for the new id -> `npx vitest run src/main/settings/provider-runtime-projection.test.ts` -> 6 passed
- Settings form lists the new id among supported models -> `npx vitest run src/renderer/src/pages/settings/ProviderForm.render.test.tsx` -> 21 passed
- Claude spawn catalog and mixed-vision provider view -> `npx vitest run src/main/settings/service.test.ts -t 'builds spawn env from the registry|image-input capability|mixed vision support (DeepSeek)'` -> 7 passed
- Owner module contracts and representative consumers -> `npm run test:module -- settings_provider_accounts` -> 20 files passed, 352 tests passed
- Shared registry types consumed by the main process -> `npm run typecheck:node` -> passed
- Shared registry types consumed by the renderer -> `npm run typecheck:web` -> passed
- Changed files -> `npx eslint --cache <changed files>` -> passed
- Patch integrity -> `git diff --check` -> passed

The full portable test suite and `settings_service_facade` module suite were not run locally per the requested module-scoped validation workflow. PR CI remains authoritative for the complete portable and platform lanes.

ACP framework paths (`claude-code`, `opencode`, `codex-response`, `codex-bridge`) were not re-run as a matrix: this change is catalog metadata, and image routing already keys off `supportsImageInput` per model.

## Review focus

- Confirm vision should be an explicit-id rule, not `allMultimodal` (pro/flash remain text-only and reject images).
- Confirm Responses should be advertised for this id, matching DeepSeek's published catalog.
- Confirm we should not auto-merge the new id into persisted `fetchedModels` lists (same behavior as prior catalog additions).

## Uncovered risks

- Live image-input behavior against DeepSeek's API was not exercised (no live key in this change).
- Browser/Web UI picker was not clicked end-to-end; coverage is registry, provider-view, and Settings form render tests.