### PR TITLE
fix(updater): preserve macOS update handoff

### DIFF
--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -504,6 +504,19 @@ describe('installAppLifecycle', () => {
     }
   )
 
+  it('completes an update handoff after quitAndInstall has already closed the renderer', async () => {
+    markApplicationShutdownTrigger('update')
+    const flushSessionPersistence = vi.fn(async () => 'send-failed' as const)
+    const { app, abortQuitPreparation } = setup({ flushSessionPersistence })
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(flushSessionPersistence).toHaveBeenCalledTimes(2)
+    expect(abortQuitPreparation).not.toHaveBeenCalled()
+    expect(app.exit).toHaveBeenCalledWith(0)
+  })
+
   it('records fixed outcomes for every shutdown step and never reports a degraded shutdown as clean', async () => {
     const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
     const { app, closeOpts } = setup({

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -1,7 +1,10 @@
 import type { App, BrowserWindow, Tray } from 'electron'
 
 import type { ActiveSessionInfo } from '../shared/storage'
-import type { RendererSessionPersistenceFlushOutcome } from './session-persistence/renderer-flush'
+import {
+  rendererSessionPersistenceFlushBlocksShutdown,
+  type RendererSessionPersistenceFlushOutcome
+} from './session-persistence/renderer-flush'
 import type { ShutdownStepOutcome } from './lifecycle-shutdown'
 import { flushDiagnosticsWithTimeout } from './diagnostics/flush'
 import { diagnosticErrorFields, type Logger } from './logger'
@@ -134,11 +137,6 @@ export const installAppLifecycle = (
     if (outcome === 'renderer-gone') return 'degraded'
     return 'completed'
   }
-  const rendererOutcomeBlocksQuit = (outcome: RendererSessionPersistenceFlushOutcome): boolean =>
-    outcome === 'conflict' ||
-    outcome === 'renderer-failed' ||
-    outcome === 'send-failed' ||
-    outcome === 'timeout'
   const shutdownTrigger = (): ApplicationShutdownTrigger => {
     try {
       return deps.shutdownTrigger?.() ?? currentApplicationShutdownTrigger()
@@ -348,7 +346,10 @@ export const installAppLifecycle = (
         )
         rendererPreflightOutcome = preflight.outcome
         rendererPreflightResult = preflight.result
-        if (rendererOutcomeBlocksQuit(rendererPreflightOutcome)) {
+        if (
+          trigger !== 'update' &&
+          rendererSessionPersistenceFlushBlocksShutdown(rendererPreflightOutcome)
+        ) {
           shutdownAbortedForRendererPersistence = true
           diagnostics?.complete({
             degraded: true,
@@ -382,7 +383,10 @@ export const installAppLifecycle = (
         )
         rendererFlushOutcome = finalFlush.outcome
         rendererFlushResult = finalFlush.result
-        if (rendererOutcomeBlocksQuit(rendererFlushOutcome)) {
+        if (
+          trigger !== 'update' &&
+          rendererSessionPersistenceFlushBlocksShutdown(rendererFlushOutcome)
+        ) {
           shutdownAbortedForRendererPersistence = true
           diagnostics?.complete({
             degraded: true,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -404,7 +404,11 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             { createWebServiceController, buildAuthenticatedWebUrl },
             { routeSecondInstance },
             { createElectronCloseConfirm },
-            { createElectronSessionPersistenceFlush, notifyRendererSessionPersistenceFlushAborted },
+            {
+              createElectronSessionPersistenceFlush,
+              notifyRendererSessionPersistenceFlushAborted,
+              rendererSessionPersistenceFlushBlocksShutdown
+            },
             { createAppIconController, buildAppIconPreviews },
             { RemoteAccessService, registerRemoteAccessIpcHandlers },
             { createDesktopAttentionController, wireDesktopAttention },
@@ -458,6 +462,14 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
               managedPreviewProtocol: managedPreviewProtocolBridge.registrar,
               handoffRuntime: 'production',
               headless: webMode.headless,
+              confirmUpdateRendererDurability: async () => {
+                const getWindow = (): InstanceType<typeof BrowserWindow> | undefined =>
+                  mainWindowGetterBox.current?.()
+                const outcome = await createElectronSessionPersistenceFlush(getWindow)()
+                if (!rendererSessionPersistenceFlushBlocksShutdown(outcome)) return true
+                notifyRendererSessionPersistenceFlushAborted(getWindow)
+                return false
+              },
               onAppIconVariantChanged: (variant) => {
                 appIconControllerBox.current?.setVariant(variant)
                 // Keep the tray glyph on the same variant as the window icon. No-op before the lifecycle

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -291,7 +291,7 @@ import {
 } from './storage-root'
 import { createUpdateCommandOwner, registerUpdateIpcHandlers } from './update/ipc'
 import { createUpdateStrategy } from './update/create-strategy'
-import { createActiveResearchSafeInstallGate } from './update/strategy'
+import { createActiveResearchSafeInstallGate, createDurableInstallGate } from './update/strategy'
 import type { UpdateBlocker } from '../shared/update'
 import { startUpdateScheduler } from './update/scheduler'
 import { createDefaultUploadRepository, registerUploadIpcHandlers } from './uploads/ipc'
@@ -326,6 +326,9 @@ type IpcRegistrationOptions = {
   onAppIconVariantChanged?: (variant: AppIconVariant) => void
   // Renders the built-in icon variants to preview data URLs for the Appearance picker.
   listAppIconPreviews?: () => AppIconPreview[]
+  // Flushes renderer-owned Session/Preview state after backend teardown and before an in-place
+  // updater can close the renderer. Desktop startup supplies the late-bound window implementation.
+  confirmUpdateRendererDurability?: () => Promise<boolean>
   // Retained as an explicit startup marker while the app owns the only handoff composition.
   handoffRuntime?: 'production'
 }
@@ -371,7 +374,8 @@ const createApplicationModules = async (
     headless = false,
     translate = englishNativeTranslator,
     onAppIconVariantChanged,
-    listAppIconPreviews
+    listAppIconPreviews,
+    confirmUpdateRendererDurability = () => Promise.resolve(true)
   }: IpcRegistrationOptions,
   modules: ApplicationModuleBuilder
 ): Promise<ApplicationModuleInterfaces> => {
@@ -2363,7 +2367,10 @@ const createApplicationModules = async (
         if (reviewerModelRuntimeShutdown?.hasActiveWork()) blockers.push('reviewer')
         return blockers
       },
-      () => shutdownCoordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS)
+      createDurableInstallGate(
+        () => shutdownCoordinator.runForUpdateGate(UPDATE_SHUTDOWN_BUDGET_MS),
+        confirmUpdateRendererDurability
+      )
     )
   })
   const updateCommandOwner = createUpdateCommandOwner(updateStrategy)

--- a/src/main/session-persistence/renderer-flush.test.ts
+++ b/src/main/session-persistence/renderer-flush.test.ts
@@ -9,6 +9,7 @@ import type { SessionPersistenceFlushResponse } from '../../shared/session-persi
 import {
   createElectronSessionPersistenceFlush,
   notifyRendererSessionPersistenceFlushAborted,
+  rendererSessionPersistenceFlushBlocksShutdown,
   requestRendererSessionPersistenceFlush
 } from './renderer-flush'
 import type { RendererSessionPersistenceFlushOutcome } from './renderer-flush'
@@ -136,6 +137,22 @@ describe('requestRendererSessionPersistenceFlush', () => {
 
     await expect(harness.request()).resolves.toBe('send-failed')
   })
+})
+
+describe('rendererSessionPersistenceFlushBlocksShutdown', () => {
+  it.each(['conflict', 'renderer-failed', 'send-failed', 'timeout'] as const)(
+    'blocks shutdown for %s',
+    (outcome) => {
+      expect(rendererSessionPersistenceFlushBlocksShutdown(outcome)).toBe(true)
+    }
+  )
+
+  it.each(['completed', 'unavailable', 'renderer-gone'] as const)(
+    'allows shutdown for %s',
+    (outcome) => {
+      expect(rendererSessionPersistenceFlushBlocksShutdown(outcome)).toBe(false)
+    }
+  )
 })
 
 describe('createElectronSessionPersistenceFlush', () => {

--- a/src/main/session-persistence/renderer-flush.ts
+++ b/src/main/session-persistence/renderer-flush.ts
@@ -29,6 +29,14 @@ export type RendererSessionPersistenceFlushOutcome =
   | 'send-failed'
   | 'timeout'
 
+export const rendererSessionPersistenceFlushBlocksShutdown = (
+  outcome: RendererSessionPersistenceFlushOutcome
+): boolean =>
+  outcome === 'conflict' ||
+  outcome === 'renderer-failed' ||
+  outcome === 'send-failed' ||
+  outcome === 'timeout'
+
 export const requestRendererSessionPersistenceFlush = async (
   deps: RendererSessionPersistenceFlushDeps
 ): Promise<RendererSessionPersistenceFlushOutcome> => {

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { Logger } from '../logger'
 import { ElectronUpdaterStrategy } from './electron-updater-strategy'
-import { createActiveResearchSafeInstallGate } from './strategy'
+import { createActiveResearchSafeInstallGate, createDurableInstallGate } from './strategy'
 import {
   clearApplicationShutdownTrigger,
   currentApplicationShutdownTrigger
@@ -589,19 +589,50 @@ describe('ElectronUpdaterStrategy', () => {
 
   it('apply runs the install gate before quitAndInstall when the teardown is clean', async () => {
     const updater = new FakeUpdater()
-    const gate = vi.fn(async () => ({ completed: true, reaped: true }))
+    const backendTeardownGate = vi.fn(async () => ({ completed: true, reaped: true }))
+    const confirmRendererDurability = vi.fn(async () => true)
     const strategy = new ElectronUpdaterStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
-      installGate: gate
+      installGate: createDurableInstallGate(backendTeardownGate, confirmRendererDurability)
     })
     markUpdateReady(updater)
 
     await strategy.apply()
 
-    expect(gate).toHaveBeenCalledTimes(1)
+    expect(backendTeardownGate).toHaveBeenCalledOnce()
+    expect(confirmRendererDurability).toHaveBeenCalledOnce()
+    expect(backendTeardownGate.mock.invocationCallOrder[0]).toBeLessThan(
+      confirmRendererDurability.mock.invocationCallOrder[0]
+    )
     expect(updater.quitAndInstall).toHaveBeenCalledTimes(1)
+  })
+
+  it('blocks restart when renderer durability cannot be confirmed after teardown', async () => {
+    const updater = new FakeUpdater()
+    const backendTeardownGate = vi.fn(async () => ({ completed: true, reaped: true }))
+    const confirmRendererDurability = vi.fn(async () => false)
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      installGate: createDurableInstallGate(backendTeardownGate, confirmRendererDurability)
+    })
+    markUpdateReady(updater)
+
+    const status = await strategy.apply()
+
+    expect(backendTeardownGate).toHaveBeenCalledOnce()
+    expect(confirmRendererDurability).toHaveBeenCalledOnce()
+    expect(backendTeardownGate.mock.invocationCallOrder[0]).toBeLessThan(
+      confirmRendererDurability.mock.invocationCallOrder[0]
+    )
+    expect(updater.quitAndInstall).not.toHaveBeenCalled()
+    expect(status).toMatchObject({
+      state: 'error',
+      error: 'Could not fully stop background processes before updating. Please try again.'
+    })
   })
 
   it('blocks restart before backend teardown when delegated work is running', async () => {

--- a/src/main/update/strategy.ts
+++ b/src/main/update/strategy.ts
@@ -28,6 +28,17 @@ export const createActiveResearchSafeInstallGate =
     return blockedBy.length > 0 ? { completed: false, reaped: false, blockedBy } : runTeardownGate()
   }
 
+// Confirms renderer-owned state is durable only after backend teardown has stopped producing runtime
+// events. A refused durability check leaves the installer untouched, while the non-latching teardown
+// allows the still-open app to reconnect on the next action.
+export const createDurableInstallGate =
+  (runTeardownGate: InstallGate, confirmRendererDurability: () => Promise<boolean>): InstallGate =>
+  async () => {
+    const readiness = await runTeardownGate()
+    if (!readiness.completed || !readiness.reaped) return readiness
+    return (await confirmRendererDurability()) ? readiness : { completed: false, reaped: false }
+  }
+
 // The platform-agnostic update contract the IPC layer and scheduler drive. Two implementations exist:
 // ElectronUpdaterStrategy (win/linux, and signed stable macOS — in-place download/restart) and
 // UpdateService (dev/nightly macOS + any other fallback — manifest download + manual reinstall). Both


### PR DESCRIPTION
## Problem

On signed macOS builds, restarting to apply an update can reopen the old version instead of installing the downloaded release. Electron's native `quitAndInstall()` closes renderer windows before `before-quit`; the persistence safeguards added in #1434 then classify the renderer send failure as recoverable, roll back shutdown, and leave Squirrel.Mac unable to replace the still-running app.

The public 0.18.1 -> 0.18.2 arm64 feed and ZIP were verified independently, and the real ShipIt log recorded `SQRLInstallerErrorDomain Code=-9` (`App Still Running Error`).

## Proposed change

- Extend the existing in-place install gate to confirm renderer-owned Session/Preview state is durable after backend teardown and before the installer can close the renderer.
- Refuse installation and reuse the existing retryable update error when renderer durability cannot be confirmed.
- Let a committed `update` shutdown complete when `before-quit` observes the renderer already closed by Electron; ordinary quit and migration-relaunch safeguards remain unchanged.
- Centralize the existing blocking outcome classification so the gate and lifecycle use the same contract.

## Scope and non-goals

- No database migration, persisted field, update-state enum, or data-model change.
- No new user-visible copy or renderer interaction on the success path.
- This does not revert #1434's ordinary-quit durability protection.
- This does not add a post-launch persisted expected-version repair mechanism.

## Acceptance criteria and validation

The lifecycle regression test was added before the fix and failed consistently three times because `abortQuitPreparation()` ran instead of exiting. After the final material edit:

- macOS update handoff after Electron closes the renderer -> `rtk npx vitest run src/main/app-lifecycle.test.ts src/main/update/electron-updater-strategy.test.ts src/main/update/create-strategy.test.ts src/main/session-persistence/renderer-flush.test.ts src/main/settings/settings-backend.architecture.test.ts --config <worktree config>` -> **143 passed**
- updater refuses to call `quitAndInstall()` when renderer durability fails, and enforces backend teardown before durability confirmation -> same focused Vitest command -> **passed**
- blocking renderer flush outcomes remain consistent across the lifecycle and updater gate -> same focused Vitest command -> **passed**
- affected Main-process interfaces and composition -> `rtk npm run typecheck:node` -> **passed**
- linted source and tests -> `rtk npm run lint` -> **passed**
- changed-file formatting -> `prettier --check <changed files>` -> **passed**

The changed behavior is Main-process-only, so Web typecheck and renderer suites were excluded. Per the requested workflow, the complete portable suite was left to PR CI.

Uncovered local risk: a forward install of a packaged build containing this fix requires a newly signed release artifact and feed version, so the final Squirrel.Mac replacement step cannot be re-certified locally before PR CI/release packaging.

## Review focus

- Whether renderer durability is confirmed at the correct point: after runtime/notebook teardown, before installer handoff.
- Whether trusting the `update` shutdown trigger is sufficiently constrained by the successful install gate.
- Whether ordinary quit and migration relaunch still fail closed on recoverable renderer persistence errors.
