### PR TITLE
fix(notebook): skip macOS developer-tools Python stub

### DIFF
--- a/src/main/notebook/environment-discovery.test.ts
+++ b/src/main/notebook/environment-discovery.test.ts
@@ -88,10 +88,29 @@ const makeDeps = (
   probeVersion: async (p) => opts.versions?.[p],
   rRunnable: async (p) => opts.rRunnable?.[p] ?? false,
   realpath: (p) => opts.realpath?.[p] ?? p,
-  runtimeRoot: '/rt'
+  runtimeRoot: '/rt',
+  platform: 'linux'
 })
 
 describe('discoverInterpreters', () => {
+  it('does not probe the macOS developer-tools Python stub and keeps other interpreters', async () => {
+    const probeVersion = vi.fn(async (path: string) =>
+      path === '/opt/homebrew/bin/python3' ? '3.12.4' : '3.9.6'
+    )
+    const deps = {
+      ...makeDeps(['/usr/bin/python3', '/opt/homebrew/bin/python3']),
+      platform: 'darwin' as const,
+      probeVersion
+    }
+
+    const found = await discoverInterpreters('python', deps)
+
+    expect(probeVersion).not.toHaveBeenCalledWith('/usr/bin/python3', 'python')
+    expect(found.map((interpreter) => interpreter.interpreterPath)).toEqual([
+      '/opt/homebrew/bin/python3'
+    ])
+  })
+
   it('classifies provenance and dedupes python interpreters by real path', async () => {
     const deps = makeDeps(
       ['/usr/bin/python3', '/rt/envs/default-python/bin/python', '/a/python', '/b/python'],

--- a/src/main/notebook/environment-discovery.ts
+++ b/src/main/notebook/environment-discovery.ts
@@ -7,7 +7,7 @@ import { promisify } from 'node:util'
 
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { DiscoveredInterpreter, EnvProvenance } from '../../shared/notebook-runtime'
-import { probeInterpreterVersion } from './python-command'
+import { isMacOSDeveloperToolsPythonStub, probeInterpreterVersion } from './python-command'
 import { parseRVersion, rHasJsonlite } from './r-command'
 import {
   condaActivatedPath,
@@ -50,6 +50,8 @@ export type DiscoveryDeps = {
   // App runtime root (<storageRoot>/runtime); used to classify provenance of an interpreter by whether
   // it lives under runtime/envs and whether it is a default (app-managed) vs a named (agent-created) env.
   runtimeRoot: string
+  // Platform policy used before probing OS-owned interpreter stubs.
+  platform?: NodeJS.Platform
 }
 
 const safeRealpath = (p: string): string => {
@@ -379,6 +381,7 @@ export const discoverInterpreters = async (
   const unique: { path: string; envId: string }[] = []
   for (const path of await deps.candidatePaths(language)) {
     const envId = deps.realpath(path)
+    if (language === 'python' && isMacOSDeveloperToolsPythonStub(envId, deps.platform)) continue
     if (seen.has(envId)) continue
     seen.add(envId)
     unique.push({ path, envId })
@@ -504,6 +507,7 @@ export const defaultDiscoveryDeps = (
         }
       }),
     realpath: safeRealpath,
-    runtimeRoot
+    runtimeRoot,
+    platform
   }
 }

--- a/src/main/notebook/python-command.test.ts
+++ b/src/main/notebook/python-command.test.ts
@@ -1,3 +1,6 @@
+import { access, chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 import { findPythonCommand, isPython3Version, resolvePythonCommand } from './python-command'
@@ -29,6 +32,74 @@ describe('resolvePythonCommand', () => {
 
     expect(tried).toEqual(['python3', 'python'])
     expect(result).toEqual({ command: 'python', baseArgs: [] })
+  })
+
+  it('does not execute /usr/bin/python3 during automatic macOS detection', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-python-stub-'))
+    const bin = join(root, 'bin')
+    const marker = join(root, 'python3-invoked')
+    const originalPath = process.env.PATH
+
+    try {
+      await mkdir(bin)
+      await writeFile(
+        join(bin, 'python3'),
+        `#!/bin/sh\nprintf invoked > "${marker}"\nprintf 'Python 3.9.6\\n'\n`
+      )
+      await chmod(join(bin, 'python3'), 0o755)
+      process.env.PATH = bin
+
+      const result = await findPythonCommand({
+        platform: 'darwin',
+        resolveExecutables: async (command) => (command === 'python3' ? ['/usr/bin/python3'] : [])
+      })
+
+      expect(result).toBeUndefined()
+      await expect(access(marker)).rejects.toMatchObject({ code: 'ENOENT' })
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH
+      else process.env.PATH = originalPath
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('still probes a non-Apple python3 on macOS', async () => {
+    const probe = vi.fn().mockResolvedValue(true)
+
+    const result = await findPythonCommand({
+      platform: 'darwin',
+      probe,
+      resolveExecutables: async () => ['/opt/homebrew/bin/python3']
+    })
+
+    expect(result).toEqual({ command: '/opt/homebrew/bin/python3', baseArgs: [] })
+    expect(probe).toHaveBeenCalledOnce()
+  })
+
+  it('finds a later non-Apple python3 when /usr/bin appears first on PATH', async () => {
+    const probe = vi.fn(({ command }) => Promise.resolve(command === '/opt/homebrew/bin/python3'))
+
+    const result = await findPythonCommand({
+      platform: 'darwin',
+      probe,
+      resolveExecutables: async () => ['/usr/bin/python3', '/opt/homebrew/bin/python3']
+    })
+
+    expect(result).toEqual({ command: '/opt/homebrew/bin/python3', baseArgs: [] })
+    expect(probe).not.toHaveBeenCalledWith({ command: '/usr/bin/python3', baseArgs: [] })
+  })
+
+  it('ignores /usr/bin/python3 even when Apple developer tools are available', async () => {
+    const probe = vi.fn(({ command }) => Promise.resolve(command === 'python3'))
+
+    const result = await findPythonCommand({
+      platform: 'darwin',
+      probe,
+      resolveExecutables: async () => ['/usr/bin/python3']
+    })
+
+    expect(result).toBeUndefined()
+    expect(probe).not.toHaveBeenCalledWith({ command: 'python3', baseArgs: [] })
   })
 
   it('prefers the `py -3` launcher on windows', async () => {

--- a/src/main/notebook/python-command.ts
+++ b/src/main/notebook/python-command.ts
@@ -1,4 +1,7 @@
 import { execFile } from 'node:child_process'
+import { constants } from 'node:fs'
+import { access, realpath } from 'node:fs/promises'
+import { delimiter, join } from 'node:path'
 import { promisify } from 'node:util'
 
 const execFileAsync = promisify(execFile)
@@ -11,6 +14,11 @@ export type PythonCommand = {
   command: string
   baseArgs: string[]
 }
+
+export const isMacOSDeveloperToolsPythonStub = (
+  interpreterPath: string,
+  platform: NodeJS.Platform = process.platform
+): boolean => platform === 'darwin' && interpreterPath === '/usr/bin/python3'
 
 // Ordered interpreter candidates by platform. Windows prefers the `py -3` launcher (the reliable way
 // to reach a real CPython, and it sidesteps the Microsoft Store `python3` execution-alias stub), then
@@ -31,6 +39,26 @@ export type ResolvePythonDeps = {
   platform: NodeJS.Platform
   // Returns true when `<command> <baseArgs...> --version` runs successfully.
   probe: (candidate: PythonCommand) => Promise<boolean>
+  resolveExecutables: (command: string) => Promise<string[]>
+}
+
+const defaultResolveExecutables = async (command: string): Promise<string[]> => {
+  const matches: string[] = []
+  const seen = new Set<string>()
+  for (const directory of (process.env.PATH ?? '').split(delimiter).filter(Boolean)) {
+    const candidate = join(directory, command)
+    try {
+      await access(candidate, constants.X_OK)
+      const resolved = await realpath(candidate)
+      if (!seen.has(resolved)) {
+        seen.add(resolved)
+        matches.push(resolved)
+      }
+    } catch {
+      // Keep searching PATH when this entry is missing, inaccessible, or a broken symlink.
+    }
+  }
+  return matches
 }
 
 // Real `<command> --version` probe. On Windows the check runs through a shell so a shimmed launcher
@@ -58,9 +86,19 @@ export const findPythonCommand = async (
 ): Promise<PythonCommand | undefined> => {
   const platform = deps.platform ?? process.platform
   const probe = deps.probe ?? defaultProbe(platform)
+  const resolveExecutables = deps.resolveExecutables ?? defaultResolveExecutables
   const candidates = pythonCandidates(platform)
 
   for (const candidate of candidates) {
+    if (platform === 'darwin' && candidate.command === 'python3') {
+      const executables = await resolveExecutables(candidate.command).catch(() => [])
+      for (const executable of executables) {
+        if (isMacOSDeveloperToolsPythonStub(executable, platform)) continue
+        const resolvedCandidate = { ...candidate, command: executable }
+        if (await probe(resolvedCandidate)) return resolvedCandidate
+      }
+      continue
+    }
     if (await probe(candidate)) return candidate
   }
 


### PR DESCRIPTION
## Problem

The first-run Environment check probes `python3 --version` to discover an optional external Notebook runtime. On a fresh macOS installation, PATH can resolve that command to `/usr/bin/python3`, an Apple developer-tool shim that opens the Command Line Tools installer instead of behaving like an installed Python runtime.

Environment detection should remain read-only and must not prompt users to install developer tooling that Open Science does not require.

## Proposed change

- Enumerate automatic macOS `python3` PATH matches and resolve each to its canonical executable path.
- Ignore `/usr/bin/python3` while continuing through later PATH entries.
- Version-probe Homebrew, pyenv, Conda, and other non-Apple Python candidates by absolute path.
- Add a regression fixture that proves the Apple shim is never executed.

## Scope and non-goals

- No changes to the app-managed Python environment or its provisioning flow.
- No changes to explicit user-selected interpreter validation.
- No renderer copy, interaction, i18n, Windows, or Linux behavior changes.

## Acceptance criteria and validation

All commands below ran after the last material edit.

- Apple shim suppression and third-party Python discovery, including `/usr/bin` preceding Homebrew -> `npx vitest run src/main/notebook/python-command.test.ts src/main/settings/environment-check.test.ts src/main/notebook/runtime-adapters.test.ts` -> passed, 35 tests.
- Main-process TypeScript contract -> `npm run typecheck` -> passed.
- Source and test linting -> `npm run lint` -> passed.
- Complete portable regression suite, used because this helper is not owned by the module-impact manifest -> `npm test` -> passed.

Platform impact: the behavior change is guarded to macOS and the regression test simulates canonical resolution to `/usr/bin/python3`. Windows and Linux retain their existing candidate order and probing. A pristine macOS machine without Command Line Tools and a packaged DMG were not available for manual validation; macOS PR CI remains the final platform authority.

## Review focus

- Confirm automatic discovery should exclude the Apple developer-tool Python shim even when Command Line Tools are installed.
- Confirm canonical PATH resolution remains narrow and preserves third-party Python discovery.
