### PR TITLE
fix(compute): deduplicate retried job submissions

### DIFF
--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -12,6 +12,7 @@ const vm = require('node:vm')
 const readline = require('node:readline')
 const fs = require('node:fs')
 const path = require('node:path')
+const { randomUUID } = require('node:crypto')
 const { fileURLToPath } = require('node:url')
 
 // Protocol output line. console is captured into strings during a run (see run()), so writing the
@@ -2703,11 +2704,19 @@ const hostSessions = Object.freeze({ list: hostSessionsList, inspect: hostSessio
 // token-isolation reasons documented on host.mcp above.
 async function computeRpc(params) {
   if (!RPC_ENDPOINT) throw new Error('host.compute is unavailable: connector RPC endpoint not set')
-  const res = await capturedRpcFetch(RPC_ENDPOINT, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', authorization: 'Bearer ' + (RPC_TOKEN || '') },
-    body: JSON.stringify({ method: 'computeCall', params })
-  })
+  const request = () =>
+    capturedRpcFetch(RPC_ENDPOINT, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: 'Bearer ' + (RPC_TOKEN || '') },
+      body: JSON.stringify({ method: 'computeCall', params })
+    })
+  let res
+  try {
+    res = await request()
+  } catch (error) {
+    if (params?.op !== 'submit_job' || typeof params.invocation_id !== 'string') throw error
+    res = await request()
+  }
   const body = await res.json().catch(() => ({}))
   if (!res.ok || body.error) {
     throw computeError(body.error || 'host.compute HTTP ' + res.status)
@@ -3309,6 +3318,7 @@ const hostCompute = {
         }
         return computeRpc({
           op: 'submit_job',
+          invocation_id: randomUUID(),
           provider_id: providerId,
           intent,
           command,

--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -2704,20 +2704,28 @@ const hostSessions = Object.freeze({ list: hostSessionsList, inspect: hostSessio
 // token-isolation reasons documented on host.mcp above.
 async function computeRpc(params) {
   if (!RPC_ENDPOINT) throw new Error('host.compute is unavailable: connector RPC endpoint not set')
-  const request = () =>
-    capturedRpcFetch(RPC_ENDPOINT, {
+  const isRetryableSubmit =
+    params?.op === 'submit_job' && typeof params.invocation_id === 'string'
+  const request = async () => {
+    const res = await capturedRpcFetch(RPC_ENDPOINT, {
       method: 'POST',
       headers: { 'content-type': 'application/json', authorization: 'Bearer ' + (RPC_TOKEN || '') },
       body: JSON.stringify({ method: 'computeCall', params })
     })
-  let res
-  try {
-    res = await request()
-  } catch (error) {
-    if (params?.op !== 'submit_job' || typeof params.invocation_id !== 'string') throw error
-    res = await request()
+    const body = await res.json().catch((error) => {
+      if (isRetryableSubmit && res.ok) throw error
+      return {}
+    })
+    return { res, body }
   }
-  const body = await res.json().catch(() => ({}))
+  let response
+  try {
+    response = await request()
+  } catch (error) {
+    if (!isRetryableSubmit) throw error
+    response = await request()
+  }
+  const { res, body } = response
   if (!res.ok || body.error) {
     throw computeError(body.error || 'host.compute HTTP ' + res.status)
   }

--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -2704,8 +2704,7 @@ const hostSessions = Object.freeze({ list: hostSessionsList, inspect: hostSessio
 // token-isolation reasons documented on host.mcp above.
 async function computeRpc(params) {
   if (!RPC_ENDPOINT) throw new Error('host.compute is unavailable: connector RPC endpoint not set')
-  const isRetryableSubmit =
-    params?.op === 'submit_job' && typeof params.invocation_id === 'string'
+  const isRetryableSubmit = params?.op === 'submit_job' && typeof params.invocation_id === 'string'
   const request = async () => {
     const res = await capturedRpcFetch(RPC_ENDPOINT, {
       method: 'POST',

--- a/src/main/notebook/host-compute.integration.test.ts
+++ b/src/main/notebook/host-compute.integration.test.ts
@@ -17,13 +17,16 @@ const makeExecutor = (): NotebookKernelExecutor =>
 
 // Minimal stub computeCall RPC endpoint that captures params and returns representative unchanged
 // snake_case result projections.
-const startStub = async (): Promise<{
+const startStub = async (
+  options: { dropFirstSubmitResponse?: boolean } = {}
+): Promise<{
   endpoint: string
   close: () => void
   received: () => Array<{ params?: Record<string, unknown> }>
 }> => {
   const { createServer } = await import('node:http')
   const requests: Array<{ params?: Record<string, unknown> }> = []
+  let droppedFirstSubmitResponse = false
   const server = createServer((req, res) => {
     let body = ''
     req.on('data', (c) => (body += c))
@@ -31,6 +34,11 @@ const startStub = async (): Promise<{
       const request = body ? JSON.parse(body) : {}
       requests.push(request)
       const op = request.params?.op
+      if (op === 'submit_job' && options.dropFirstSubmitResponse && !droppedFirstSubmitResponse) {
+        droppedFirstSubmitResponse = true
+        res.destroy()
+        return
+      }
       const result =
         op === 'submit_job'
           ? { job_id: 'job-1', provider_id: 'ssh:x', status: 'submitted' }
@@ -150,6 +158,7 @@ gate('repl kernel host.compute', () => {
       },
       {
         op: 'submit_job',
+        invocation_id: expect.any(String),
         provider_id: 'ssh:x',
         intent: 'analyze',
         command: 'run',
@@ -168,6 +177,34 @@ gate('repl kernel host.compute', () => {
       { op: 'job_result', provider_id: 'ssh:x', job_id: 'job-1' },
       { op: 'set_concurrency_limit', session_id: 'session-7', limit: 2 }
     ])
+  })
+
+  it('retries a lost submitJob response with the same invocation id', async () => {
+    const stub = await startStub({ dropFirstSubmitResponse: true })
+    const exec = makeExecutor()
+    const result = await exec.execute(
+      baseRequest({
+        code:
+          "const job = await host.compute.create('ssh:x').submitJob('analyze', 'run'); " +
+          'console.log(JSON.stringify(job))',
+        mcpRpcEndpoint: stub.endpoint,
+        mcpRpcToken: 'tok',
+        sessionId: 'session-7',
+        projectId: 'proj-x'
+      })
+    )
+    await exec.shutdown()
+    stub.close()
+
+    expect(result.status).toBe('completed')
+    expect(result.stdout).toContain('"job_id":"job-1"')
+    const submissions = stub
+      .received()
+      .map((request) => request.params)
+      .filter((params) => params?.op === 'submit_job')
+    expect(submissions).toHaveLength(2)
+    expect(submissions[0]?.invocation_id).toEqual(expect.any(String))
+    expect(submissions[1]?.invocation_id).toBe(submissions[0]?.invocation_id)
   })
 
   it('rejects every old compute input key before RPC', async () => {

--- a/src/main/notebook/host-compute.integration.test.ts
+++ b/src/main/notebook/host-compute.integration.test.ts
@@ -18,7 +18,11 @@ const makeExecutor = (): NotebookKernelExecutor =>
 // Minimal stub computeCall RPC endpoint that captures params and returns representative unchanged
 // snake_case result projections.
 const startStub = async (
-  options: { dropFirstSubmitResponse?: boolean } = {}
+  options: {
+    dropFirstSubmitResponse?: boolean
+    dropFirstSubmitBody?: boolean
+    rejectSubmit?: boolean
+  } = {}
 ): Promise<{
   endpoint: string
   close: () => void
@@ -37,6 +41,26 @@ const startStub = async (
       if (op === 'submit_job' && options.dropFirstSubmitResponse && !droppedFirstSubmitResponse) {
         droppedFirstSubmitResponse = true
         res.destroy()
+        return
+      }
+      if (op === 'submit_job' && options.dropFirstSubmitBody && !droppedFirstSubmitResponse) {
+        droppedFirstSubmitResponse = true
+        const responseBody = JSON.stringify({
+          result: { job_id: 'job-1', provider_id: 'ssh:x', status: 'submitted' }
+        })
+        res.writeHead(200, {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(responseBody)
+        })
+        res.flushHeaders()
+        res.write(responseBody.slice(0, -1))
+        setImmediate(() => res.destroy())
+        return
+      }
+      if (op === 'submit_job' && options.rejectSubmit) {
+        res
+          .writeHead(409, { 'content-type': 'application/json' })
+          .end(JSON.stringify({ error: 'submission rejected' }))
         return
       }
       const result =
@@ -205,6 +229,53 @@ gate('repl kernel host.compute', () => {
     expect(submissions).toHaveLength(2)
     expect(submissions[0]?.invocation_id).toEqual(expect.any(String))
     expect(submissions[1]?.invocation_id).toBe(submissions[0]?.invocation_id)
+  })
+
+  it('retries a lost submitJob response body with the same invocation id', async () => {
+    const stub = await startStub({ dropFirstSubmitBody: true })
+    const exec = makeExecutor()
+    const result = await exec.execute(
+      baseRequest({
+        code:
+          "const job = await host.compute.create('ssh:x').submitJob('analyze', 'run'); " +
+          'console.log(JSON.stringify(job))',
+        mcpRpcEndpoint: stub.endpoint,
+        mcpRpcToken: 'tok',
+        sessionId: 'session-7',
+        projectId: 'proj-x'
+      })
+    )
+    await exec.shutdown()
+    stub.close()
+
+    expect(result.status).toBe('completed')
+    expect(result.stdout).toContain('"job_id":"job-1"')
+    const submissions = stub
+      .received()
+      .map((request) => request.params)
+      .filter((params) => params?.op === 'submit_job')
+    expect(submissions).toHaveLength(2)
+    expect(submissions[0]?.invocation_id).toEqual(expect.any(String))
+    expect(submissions[1]?.invocation_id).toBe(submissions[0]?.invocation_id)
+  })
+
+  it('does not retry submitJob HTTP errors', async () => {
+    const stub = await startStub({ rejectSubmit: true })
+    const exec = makeExecutor()
+    const result = await exec.execute(
+      baseRequest({
+        code: "await host.compute.create('ssh:x').submitJob('analyze', 'run')",
+        mcpRpcEndpoint: stub.endpoint,
+        mcpRpcToken: 'tok',
+        sessionId: 'session-7',
+        projectId: 'proj-x'
+      })
+    )
+    await exec.shutdown()
+    stub.close()
+
+    expect(result.status).toBe('failed')
+    expect(stub.received().filter((request) => request.params?.op === 'submit_job')).toHaveLength(1)
   })
 
   it('rejects every old compute input key before RPC', async () => {

--- a/src/main/notebook/local-rpc-server.mcpcall.test.ts
+++ b/src/main/notebook/local-rpc-server.mcpcall.test.ts
@@ -1081,6 +1081,57 @@ describe('computeCall RPC', () => {
     expect(submitJob).toHaveBeenCalledTimes(102)
   })
 
+  it('keeps a successor session cache when an old submit_job later fails', async () => {
+    let rejectOldSubmission!: (error: Error) => void
+    const oldSubmission = new Promise<never>((_resolve, reject) => {
+      rejectOldSubmission = reject
+    })
+    const submitJob = vi.fn().mockImplementation(async () => {
+      if (submitJob.mock.calls.length === 1) return oldSubmission
+      return { job_id: `job-${submitJob.mock.calls.length}`, status: 'queued' }
+    })
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      computeService: { submitJob } as never
+    })
+    const submit = (endpoint: string, token: string, invocationId: string): Promise<Response> =>
+      fetch(endpoint, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          method: 'computeCall',
+          params: {
+            op: 'submit_job',
+            invocation_id: invocationId,
+            provider_id: 'ssh:biowulf',
+            intent: 'analyze data',
+            command: 'python analyze.py'
+          }
+        })
+      })
+
+    const oldConnection = await sessionConnection(server)
+    const oldResponse = submit(oldConnection.endpoint, oldConnection.token, 'old-invocation')
+    await vi.waitFor(() => expect(submitJob).toHaveBeenCalledTimes(1))
+    server.releaseSessionCapabilities('s-42')
+
+    const successorConnection = await sessionConnection(server)
+    await expect(
+      (
+        await submit(successorConnection.endpoint, successorConnection.token, 'new-invocation')
+      ).json()
+    ).resolves.toEqual({ result: { job_id: 'job-2', status: 'queued' } })
+
+    rejectOldSubmission(new Error('old submission failed'))
+    expect((await oldResponse).status).toBe(500)
+    await expect(
+      (
+        await submit(successorConnection.endpoint, successorConnection.token, 'new-invocation')
+      ).json()
+    ).resolves.toEqual({ result: { job_id: 'job-2', status: 'queued' } })
+    expect(submitJob).toHaveBeenCalledTimes(2)
+  })
+
   it('serializes submit_job compute call errors', async () => {
     const submitErr = new Error('approval denied') as Error & { computeCallError: unknown }
     submitErr.computeCallError = {

--- a/src/main/notebook/local-rpc-server.mcpcall.test.ts
+++ b/src/main/notebook/local-rpc-server.mcpcall.test.ts
@@ -923,6 +923,41 @@ describe('computeCall RPC', () => {
     ])
   })
 
+  it('reuses the first submit_job result when the same invocation is retried', async () => {
+    const submitJob = vi
+      .fn()
+      .mockResolvedValueOnce({ job_id: 'job-1', status: 'queued' })
+      .mockResolvedValueOnce({ job_id: 'job-2', status: 'queued' })
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      computeService: { submitJob } as never
+    })
+    const { endpoint, token } = await sessionConnection(server)
+    const submit = (): Promise<Response> =>
+      fetch(endpoint, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          method: 'computeCall',
+          params: {
+            op: 'submit_job',
+            invocation_id: 'invocation-1',
+            provider_id: 'ssh:biowulf',
+            intent: 'analyze data',
+            command: 'python analyze.py'
+          }
+        })
+      })
+
+    await expect((await submit()).json()).resolves.toEqual({
+      result: { job_id: 'job-1', status: 'queued' }
+    })
+    await expect((await submit()).json()).resolves.toEqual({
+      result: { job_id: 'job-1', status: 'queued' }
+    })
+    expect(submitJob).toHaveBeenCalledTimes(1)
+  })
+
   it('serializes submit_job compute call errors', async () => {
     const submitErr = new Error('approval denied') as Error & { computeCallError: unknown }
     submitErr.computeCallError = {

--- a/src/main/notebook/local-rpc-server.mcpcall.test.ts
+++ b/src/main/notebook/local-rpc-server.mcpcall.test.ts
@@ -991,6 +991,96 @@ describe('computeCall RPC', () => {
     expect(submitJob).toHaveBeenCalledTimes(1)
   })
 
+  it('bounds completed submit_job invocations for a long-lived session', async () => {
+    const submitJob = vi.fn().mockImplementation(async () => ({
+      job_id: `job-${submitJob.mock.calls.length}`,
+      status: 'queued'
+    }))
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      computeService: { submitJob } as never
+    })
+    const { endpoint, token } = await sessionConnection(server)
+    const submit = async (invocationId: string): Promise<{ job_id: string; status: string }> => {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          method: 'computeCall',
+          params: {
+            op: 'submit_job',
+            invocation_id: invocationId,
+            provider_id: 'ssh:biowulf',
+            intent: 'analyze data',
+            command: 'python analyze.py'
+          }
+        })
+      })
+      const body = (await response.json()) as { result: { job_id: string; status: string } }
+      return body.result
+    }
+
+    for (let index = 0; index <= 100; index += 1) {
+      await submit(`invocation-${index}`)
+    }
+
+    await expect(submit('invocation-0')).resolves.toEqual({
+      job_id: 'job-102',
+      status: 'queued'
+    })
+    await expect(submit('invocation-100')).resolves.toEqual({
+      job_id: 'job-101',
+      status: 'queued'
+    })
+    expect(submitJob).toHaveBeenCalledTimes(102)
+  })
+
+  it('retains in-flight submit_job invocations while bounding completed entries', async () => {
+    let resolvePending!: (value: { job_id: string; status: string }) => void
+    const pending = new Promise<{ job_id: string; status: string }>((resolve) => {
+      resolvePending = resolve
+    })
+    const submitJob = vi.fn().mockImplementation(async () => {
+      if (submitJob.mock.calls.length === 1) return pending
+      return { job_id: `job-${submitJob.mock.calls.length}`, status: 'queued' }
+    })
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      computeService: { submitJob } as never
+    })
+    const { endpoint, token } = await sessionConnection(server)
+    const submit = async (invocationId: string): Promise<{ job_id: string; status: string }> => {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          method: 'computeCall',
+          params: {
+            op: 'submit_job',
+            invocation_id: invocationId,
+            provider_id: 'ssh:biowulf',
+            intent: 'analyze data',
+            command: 'python analyze.py'
+          }
+        })
+      })
+      const body = (await response.json()) as { result: { job_id: string; status: string } }
+      return body.result
+    }
+
+    const firstPending = submit('pending-invocation')
+    await vi.waitFor(() => expect(submitJob).toHaveBeenCalledTimes(1))
+    const retriedPending = submit('pending-invocation')
+    for (let index = 0; index <= 100; index += 1) {
+      await submit(`completed-invocation-${index}`)
+    }
+
+    resolvePending({ job_id: 'job-pending', status: 'queued' })
+    await expect(firstPending).resolves.toEqual({ job_id: 'job-pending', status: 'queued' })
+    await expect(retriedPending).resolves.toEqual({ job_id: 'job-pending', status: 'queued' })
+    expect(submitJob).toHaveBeenCalledTimes(102)
+  })
+
   it('serializes submit_job compute call errors', async () => {
     const submitErr = new Error('approval denied') as Error & { computeCallError: unknown }
     submitErr.computeCallError = {

--- a/src/main/notebook/local-rpc-server.mcpcall.test.ts
+++ b/src/main/notebook/local-rpc-server.mcpcall.test.ts
@@ -958,6 +958,39 @@ describe('computeCall RPC', () => {
     expect(submitJob).toHaveBeenCalledTimes(1)
   })
 
+  it('rejects a reused submit_job invocation with a different request', async () => {
+    const submitJob = vi.fn().mockResolvedValue({ job_id: 'job-1', status: 'queued' })
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      computeService: { submitJob } as never
+    })
+    const { endpoint, token } = await sessionConnection(server)
+    const submit = (command: string): Promise<Response> =>
+      fetch(endpoint, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          method: 'computeCall',
+          params: {
+            op: 'submit_job',
+            invocation_id: 'invocation-1',
+            provider_id: 'ssh:biowulf',
+            intent: 'analyze data',
+            command
+          }
+        })
+      })
+
+    expect((await submit('python analyze.py')).status).toBe(200)
+    const conflict = await submit('python different.py')
+
+    expect(conflict.status).toBe(409)
+    await expect(conflict.json()).resolves.toEqual({
+      error: 'invocation_id was already used with a different submit_job request.'
+    })
+    expect(submitJob).toHaveBeenCalledTimes(1)
+  })
+
   it('serializes submit_job compute call errors', async () => {
     const submitErr = new Error('approval denied') as Error & { computeCallError: unknown }
     submitErr.computeCallError = {

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -2214,7 +2214,10 @@ class NotebookLocalRpcServer {
           } catch (error) {
             if (sessionInvocations.get(invocationId)?.submission === submission) {
               sessionInvocations.delete(invocationId)
-              if (sessionInvocations.size === 0) {
+              if (
+                sessionInvocations.size === 0 &&
+                this.computeSubmissionInvocations.get(sessionId) === sessionInvocations
+              ) {
                 this.computeSubmissionInvocations.delete(sessionId)
               }
             }

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -84,6 +84,7 @@ import type {
 } from './host-view-image-service'
 
 const log = createLogger('notebook:local-rpc')
+const MAX_COMPLETED_COMPUTE_SUBMISSIONS_PER_SESSION = 100
 
 type NotebookLocalRpcServerOptions = {
   token?: string
@@ -511,7 +512,7 @@ class NotebookLocalRpcServer {
   private readonly consumedExecutionToolCalls = new Map<string, Set<string>>()
   private readonly computeSubmissionInvocations = new Map<
     string,
-    Map<string, { fingerprint: string; submission: Promise<unknown> }>
+    Map<string, { fingerprint: string; submission: Promise<unknown>; completed: boolean }>
   >()
 
   constructor(
@@ -2172,7 +2173,9 @@ class NotebookLocalRpcServer {
           }
 
           const sessionInvocations = this.computeSubmissionInvocations.get(sessionId) ?? new Map()
-          const fingerprint = JSON.stringify([providerId, intent, command, options])
+          const fingerprint = createHash('sha256')
+            .update(JSON.stringify([providerId, intent, command, options]))
+            .digest('hex')
           const existing = sessionInvocations.get(invocationId)
           if (existing) {
             if (existing.fingerprint !== fingerprint) {
@@ -2191,10 +2194,23 @@ class NotebookLocalRpcServer {
             command,
             options
           )
-          sessionInvocations.set(invocationId, { fingerprint, submission })
+          const invocation = { fingerprint, submission, completed: false }
+          sessionInvocations.set(invocationId, invocation)
           this.computeSubmissionInvocations.set(sessionId, sessionInvocations)
           try {
-            return await submission
+            const result = await submission
+            invocation.completed = true
+            let completedCount = 0
+            for (const cached of sessionInvocations.values()) {
+              if (cached.completed) completedCount += 1
+            }
+            for (const [cachedInvocationId, cached] of sessionInvocations) {
+              if (completedCount <= MAX_COMPLETED_COMPUTE_SUBMISSIONS_PER_SESSION) break
+              if (!cached.completed) continue
+              sessionInvocations.delete(cachedInvocationId)
+              completedCount -= 1
+            }
+            return result
           } catch (error) {
             if (sessionInvocations.get(invocationId)?.submission === submission) {
               sessionInvocations.delete(invocationId)

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -509,7 +509,10 @@ class NotebookLocalRpcServer {
     Map<NotebookExecutionRpcMethod, NotebookExecutionAuthorization | 'ambiguous'>
   >()
   private readonly consumedExecutionToolCalls = new Map<string, Set<string>>()
-  private readonly computeSubmissionInvocations = new Map<string, Map<string, Promise<unknown>>>()
+  private readonly computeSubmissionInvocations = new Map<
+    string,
+    Map<string, { fingerprint: string; submission: Promise<unknown> }>
+  >()
 
   constructor(
     private readonly service: NotebookLocalRpcCapability,
@@ -2169,8 +2172,17 @@ class NotebookLocalRpcServer {
           }
 
           const sessionInvocations = this.computeSubmissionInvocations.get(sessionId) ?? new Map()
+          const fingerprint = JSON.stringify([providerId, intent, command, options])
           const existing = sessionInvocations.get(invocationId)
-          if (existing) return await existing
+          if (existing) {
+            if (existing.fingerprint !== fingerprint) {
+              throw new RpcHttpError(
+                409,
+                'invocation_id was already used with a different submit_job request.'
+              )
+            }
+            return await existing.submission
+          }
 
           const submission = this.computeService.submitJob(
             context,
@@ -2179,12 +2191,12 @@ class NotebookLocalRpcServer {
             command,
             options
           )
-          sessionInvocations.set(invocationId, submission)
+          sessionInvocations.set(invocationId, { fingerprint, submission })
           this.computeSubmissionInvocations.set(sessionId, sessionInvocations)
           try {
             return await submission
           } catch (error) {
-            if (sessionInvocations.get(invocationId) === submission) {
+            if (sessionInvocations.get(invocationId)?.submission === submission) {
               sessionInvocations.delete(invocationId)
               if (sessionInvocations.size === 0) {
                 this.computeSubmissionInvocations.delete(sessionId)

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -509,6 +509,7 @@ class NotebookLocalRpcServer {
     Map<NotebookExecutionRpcMethod, NotebookExecutionAuthorization | 'ambiguous'>
   >()
   private readonly consumedExecutionToolCalls = new Map<string, Set<string>>()
+  private readonly computeSubmissionInvocations = new Map<string, Map<string, Promise<unknown>>>()
 
   constructor(
     private readonly service: NotebookLocalRpcCapability,
@@ -665,6 +666,7 @@ class NotebookLocalRpcServer {
     this.skillImportRpcTokens.clear()
     this.executionAuthorizations.clear()
     this.consumedExecutionToolCalls.clear()
+    this.computeSubmissionInvocations.clear()
 
     if (!server || !lifecycle) {
       return this.artifactProvenance?.releaseAllWriteReservations?.() ?? Promise.resolve()
@@ -816,6 +818,7 @@ class NotebookLocalRpcServer {
       this.sessionSpecialists.delete(ownedSessionId)
       this.executionAuthorizations.delete(ownedSessionId)
       this.consumedExecutionToolCalls.delete(ownedSessionId)
+      this.computeSubmissionInvocations.delete(ownedSessionId)
     }
     for (const [aliasSessionId, targetSessionId] of this.sessionAliases) {
       if (ownedSessionIds.has(aliasSessionId) || ownedSessionIds.has(targetSessionId)) {
@@ -2139,6 +2142,7 @@ class NotebookLocalRpcServer {
         const providerId = typeof params.provider_id === 'string' ? params.provider_id : ''
         const intent = typeof params.intent === 'string' ? params.intent : ''
         const command = typeof params.command === 'string' ? params.command : ''
+        const invocationId = typeof params.invocation_id === 'string' ? params.invocation_id : ''
         const options = {
           environment: typeof params.environment === 'string' ? params.environment : undefined,
           resourceRequest: isRecord(params.resources)
@@ -2154,7 +2158,40 @@ class NotebookLocalRpcServer {
           workspaceCwd: typeof params.workspace_cwd === 'string' ? params.workspace_cwd : undefined
         }
         try {
-          return await this.computeService.submitJob(context, providerId, intent, command, options)
+          if (!invocationId) {
+            return await this.computeService.submitJob(
+              context,
+              providerId,
+              intent,
+              command,
+              options
+            )
+          }
+
+          const sessionInvocations = this.computeSubmissionInvocations.get(sessionId) ?? new Map()
+          const existing = sessionInvocations.get(invocationId)
+          if (existing) return await existing
+
+          const submission = this.computeService.submitJob(
+            context,
+            providerId,
+            intent,
+            command,
+            options
+          )
+          sessionInvocations.set(invocationId, submission)
+          this.computeSubmissionInvocations.set(sessionId, sessionInvocations)
+          try {
+            return await submission
+          } catch (error) {
+            if (sessionInvocations.get(invocationId) === submission) {
+              sessionInvocations.delete(invocationId)
+              if (sessionInvocations.size === 0) {
+                this.computeSubmissionInvocations.delete(sessionId)
+              }
+            }
+            throw error
+          }
         } catch (err) {
           // Re-throw compute call errors as structured error objects so the JS shim can parse them.
           if (err instanceof Error && 'computeCallError' in err) {


### PR DESCRIPTION
## Problem

`computeCall` handled every `submit_job` request as a new submission, even when a retry carried the same `invocation_id`. A lost response or caller retry could therefore create a second Job record, dispatch the remote workload again, and incur duplicate compute charges.

A public RPC regression test reproduced the issue before the fix: two identical requests with `invocation_id: invocation-1` returned `job-1` and `job-2`, and invoked `submitJob` twice.

## Proposed change

Keep a session-scoped in-memory map from `invocation_id` to the first submission Promise. Sequential and concurrent retries reuse the first result when the normalized request fingerprint matches. Reusing an invocation ID with a different provider, command, intent, or options is rejected with HTTP 409. Failed submissions are removed so a real retry remains possible, and entries are cleared when the Session is released or the RPC server closes.

Completed entries are limited to 100 per session and request fingerprints are stored as SHA-256 digests, so long-lived sessions do not retain unbounded command/options payloads. In-flight entries are never evicted by the capacity limit. Cleanup verifies map identity so a delayed failure from an old session cannot delete a same-ID successor session cache.

The standard JS caller generates a private ID per logical submission and retries one transport failure with the same request. Its retry boundary includes both request delivery and successful-response body parsing; HTTP and business errors remain non-retryable.

## Scope and non-goals

- No database schema, migration, persistent state, external data model, or UI changes.
- No persisted status or enum is added. The cache entry only gains a transient in-memory `completed` boolean for safe eviction.
- Calls without `invocation_id` retain their existing behavior.
- Cross-process/restart idempotency is not added.
- No historical data compatibility work is required.

## Acceptance criteria and validation

All checks below ran after the final rebase onto `origin/main` (`e02b94add`).

- Retried `submit_job` reuses the first result, rejects conflicting payloads, bounds completed entries, retains in-flight entries, and protects successor caches from stale cleanup -> `npm test -- src/main/notebook/local-rpc-server.mcpcall.test.ts` -> 33 passed.
- Production `host.compute.submitJob` recovers request and response-body transport loss with the same invocation ID while leaving HTTP errors non-retryable -> `RUN_KERNEL=1 npm test -- src/main/notebook/host-compute.integration.test.ts` -> 7 passed.
- Packaged REPL script syntax -> `node --check resources/notebook/repl_loop.js` -> passed.
- Compute owner and contract behavior -> `npm run test:module -- compute_service` -> 724 passed, 25 skipped (27 files passed, 1 skipped).
- Main-process types -> `npm run typecheck:node` -> passed.
- Source style -> `npm run lint` -> passed with no warnings.

The complete portable suite was intentionally left to PR CI per the requested validation strategy.

## Review focus

- Session and server lifecycle cleanup of cached submissions, including stale completion from a released predecessor.
- Failure eviction semantics: only successful/in-flight submissions are replayed.
- Completed-cache capacity and in-flight retention under pressure.
- The one-retry transport boundary and generated per-call invocation identity; durable database-backed idempotency remains out of scope.