### PR TITLE
fix(artifacts): wire default repository into finalization recovery

### DIFF
--- a/src/main/artifacts/provenance-repository.test.ts
+++ b/src/main/artifacts/provenance-repository.test.ts
@@ -3350,7 +3350,7 @@ describe('artifact provenance repository', () => {
     ).resolves.toHaveLength(2)
   })
 
-  it('replays the compatibility-marker crash window only with durable Branch ownership', async () => {
+  it('replays the default compatibility repository crash window only with durable Branch ownership', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-artifact-marker-recovery-'))
     const client = createProjectDbClient(storageRoot)
     disconnect = () => client.$disconnect()
@@ -3358,8 +3358,7 @@ describe('artifact provenance repository', () => {
     const compatibilityRepository = new ArtifactRepository(storageRoot)
     const repository = new ArtifactProvenanceRepository({
       storageRoot,
-      getClient: () => Promise.resolve(client),
-      compatibilityRepository
+      getClient: () => Promise.resolve(client)
     })
     const prompt = {
       id: 'prompt-1',
@@ -3432,6 +3431,12 @@ describe('artifact provenance repository', () => {
       messageId: 'message-1',
       provenanceContext: context
     })
+    await expect(
+      new ArtifactRepository(storageRoot).findRunFinalizationMarker(
+        request.projectId,
+        request.artifactRunId
+      )
+    ).resolves.toMatchObject({ messageId: 'message-1' })
 
     const session: PersistedChatSession = {
       id: 'session-1',

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -183,7 +183,7 @@ class ArtifactProvenanceRepository {
     })
     this.finalizationRecovery = new ArtifactProvenanceFinalizationRecovery({
       getClient: options.getClient,
-      compatibilityRepository: options.compatibilityRepository,
+      compatibilityRepository: this.compatibilityRepository,
       messageFinalizer: this.messageFinalizer
     })
     this.stagingRecovery = new ArtifactProvenanceStagingRecovery({


### PR DESCRIPTION
## Problem

`ArtifactProvenanceRepository` creates a default compatibility repository when none is injected, but finalization recovery received the original optional constructor argument. Default consumers therefore skipped durable finalization-marker recovery and returned an empty recovery result.

The main application startup path explicitly injects the repository and is currently protected. The Reviewer default constructor omits it, although its current call sites only resolve Version content and do not invoke reconciliation.

## Proposed change

Pass the constructor-resolved compatibility repository to `ArtifactProvenanceFinalizationRecovery`.

Update the existing public `reconcileSession` crash-window test to omit explicit injection and prove that a fresh repository instance can observe the persisted marker before asserting recovery.

## Scope and non-goals

- No database schema, migration, field, enum, or persistence-format changes.
- No data-model, architecture, API, or UI interaction changes.
- No change to finalization proof or durable Branch ownership rules.
- Existing pending Versions and compatibility markers remain the recovery inputs; no historical-data migration is required.

## Acceptance criteria and validation

- Default construction scans and replays a durable compatibility marker.
- A wrong durable Branch remains unrecoverable.
- Recovery advances the existing pending Version to finalized and records the existing message ownership fields.

Final local evidence after the production change:

- `npm test -- src/main/artifacts/provenance-repository.test.ts -t "replays the default compatibility repository crash window only with durable Branch ownership"` — passed.
- `npm run test:module -- artifact_provenance` — 1324 tests passed; one unrelated Windows environment failure because the current account cannot create a symlink (`EPERM`) in `file-reference-resolver.test.ts`. All Artifact, Reviewer, and session-recovery tests in the module plan passed.
- `npm run typecheck:node` — passed.
- `npm run lint` — passed.

The regression was run three times before the production fix and failed deterministically with `recoveredVersionIds: []` instead of the pending Version id. Full portable and platform coverage is delegated to PR CI.

## Review focus

Please verify that every recovery helper receives the same constructor-resolved compatibility repository and that the regression remains at the public repository behavior boundary.