### PR TITLE
fix(workspace): expose Specialist switch recovery

### DIFF
--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -442,6 +442,7 @@ const createPanelDefaults = (): PanelProps => ({
     },
     actions: {
       selectSpecialist: vi.fn(),
+      retrySpecialistSelection: vi.fn(() => false),
       chooseOtherSpecialist: vi.fn(),
       useMainAgent: vi.fn()
     }
@@ -632,6 +633,80 @@ afterEach(() => {
   vi.useRealTimers()
   vi.unstubAllGlobals()
   container.remove()
+})
+
+describe('ConversationPanel Specialist reconfigure recovery', () => {
+  const activeSession: ChatSession = {
+    id: 'session-specialist-retry',
+    projectId: 'project-a',
+    title: 'Specialist retry',
+    cwd: '/workspace',
+    status: 'idle',
+    messages: [],
+    createdAt: 1,
+    updatedAt: 1
+  }
+
+  const clickRetry = (): void => {
+    const banner = container.querySelector('[data-testid="reconfigure-error-banner"]')
+    const retryButton = Array.from(banner?.querySelectorAll('button') ?? []).find(
+      (button) => button.textContent === 'Retry'
+    )
+    act(() => retryButton?.click())
+  }
+
+  const errorView = {
+    sessionId: activeSession.id,
+    specialistName: 'Specialist B',
+    message: 'switch rejected',
+    committed: false
+  }
+
+  it('retries an idle Specialist selection without submitting the draft', () => {
+    const retrySpecialistSelection = vi.fn(() => true)
+    const retryDraftReconfigure = vi.fn()
+    renderPanel({
+      view: { activeSession },
+      specialist: {
+        view: { specialist: { reconfigureError: errorView } },
+        actions: { retrySpecialistSelection }
+      },
+      conversation: {
+        actions: {
+          submit: { draft: routeDraftSubmit({ reconfigure: retryDraftReconfigure }) }
+        }
+      }
+    })
+
+    const banner = container.querySelector('[data-testid="reconfigure-error-banner"]')
+    expect(banner?.textContent).toContain('Could not switch to Specialist B')
+    clickRetry()
+
+    expect(retrySpecialistSelection).toHaveBeenCalledOnce()
+    expect(retryDraftReconfigure).not.toHaveBeenCalled()
+  })
+
+  it('keeps send-barrier Retry routed through draft submission', () => {
+    const retrySpecialistSelection = vi.fn(() => false)
+    const retryDraftReconfigure = vi.fn()
+    renderPanel({
+      view: { activeSession },
+      specialist: {
+        view: { specialist: { reconfigureError: errorView } },
+        actions: { retrySpecialistSelection }
+      },
+      conversation: {
+        actions: {
+          submit: { draft: routeDraftSubmit({ reconfigure: retryDraftReconfigure }) }
+        }
+      }
+    })
+
+    clickRetry()
+
+    expect(retrySpecialistSelection).toHaveBeenCalledOnce()
+    expect(retryDraftReconfigure).toHaveBeenCalledOnce()
+  })
 })
 
 describe('ConversationPanel composer intake', () => {

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -241,7 +241,7 @@ type ConversationPanelSpecialist = {
   }
   actions: Pick<
     WorkspaceSessionController['actions'],
-    'selectSpecialist' | 'chooseOtherSpecialist' | 'useMainAgent'
+    'selectSpecialist' | 'retrySpecialistSelection' | 'chooseOtherSpecialist' | 'useMainAgent'
   >
 }
 
@@ -459,8 +459,10 @@ const ConversationPanel = ({
   const onBranchInNewSession = activeSession
     ? (forcedSkillIds: string[]): void => submitDraft({ forcedSkillIds, mode: 'branch' })
     : undefined
-  const onReconfigureRetry = (): void =>
+  const onReconfigureRetry = (): void => {
+    if (specialist.actions.retrySpecialistSelection()) return
     submitDraft({ forcedSkillIds: docToSkillIds(draftDoc), mode: 'retry-reconfigure' })
+  }
 
   const specialistItems = useSpecialistStore((state) => state.items)
   const catalogSkills = useSettingsStore((state) => state.skills)

--- a/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
@@ -468,6 +468,41 @@ describe('workspace session controller', () => {
     expect(hook.result.current.view.specialist.reconfigureError).toBeNull()
   })
 
+  it('ignores an idle Specialist rejection that arrives after archival', async () => {
+    const active = session({ specialistId: 'specialist-a' })
+    const updateSessionArchive = vi.fn().mockResolvedValue({ ...active, archivedAt: 2 })
+    let rejectSwitch!: (error: Error) => void
+    const switchPromise = new Promise<never>((_resolve, reject) => {
+      rejectSwitch = reject
+    })
+    useSessionStore.setState({
+      sessions: [active],
+      selectedSessionId: active.id,
+      updateSessionArchive
+    })
+    const setSessionSpecialist = vi.fn(() => switchPromise)
+    window.api = { specialist: { setSessionSpecialist } } as unknown as Window['api']
+    const hook = renderController({
+      activeSession: active,
+      specialistItems: [specialist('specialist-b', 'Specialist B')]
+    })
+    mounted.push(hook)
+
+    act(() => hook.result.current.actions.selectSpecialist('specialist-b'))
+    await act(async () => {
+      hook.result.current.actions.archive(active)
+      await Promise.resolve()
+    })
+    await act(async () => {
+      rejectSwitch(new Error('late switch rejection'))
+      await switchPromise.catch(() => undefined)
+    })
+    hook.rerender(session({ id: active.id }))
+
+    expect(hook.result.current.view.specialist.reconfigureError).toBeNull()
+    expect(hook.result.current.actions.retrySpecialistSelection()).toBe(false)
+  })
+
   it('discards an idle Specialist failure after an authoritative handoff', async () => {
     const active = session({ specialistId: 'specialist-a' })
     const authoritative = specialist('specialist-c', 'Specialist C')

--- a/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
@@ -310,6 +310,93 @@ describe('workspace session controller', () => {
     expect(hook.result.current.view.specialist.barrierInFlight).toBe(false)
   })
 
+  it('exposes feedback when an idle Session Specialist switch rejects', async () => {
+    const active = session({ specialistId: 'specialist-a' })
+    useSessionStore.setState({ sessions: [active], selectedSessionId: active.id })
+    const setSessionSpecialist = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('switch rejected'))
+      .mockResolvedValueOnce({ status: 'applied' as const, contextReset: false })
+    window.api = { specialist: { setSessionSpecialist } } as unknown as Window['api']
+    const hook = renderController({
+      activeSession: active,
+      specialistItems: [
+        specialist('specialist-a', 'Specialist A'),
+        specialist('specialist-b', 'Specialist B')
+      ]
+    })
+    mounted.push(hook)
+
+    await act(async () => {
+      hook.result.current.actions.selectSpecialist('specialist-b')
+      await Promise.resolve()
+    })
+
+    expect(hook.result.current.view.specialist.reconfigureError).toMatchObject({
+      specialistName: 'Specialist B',
+      message: 'switch rejected',
+      committed: false
+    })
+    expect(hook.result.current.view.specialist.barrierInFlight).toBe(false)
+
+    await act(async () => {
+      expect(hook.result.current.actions.retrySpecialistSelection()).toBe(true)
+      await Promise.resolve()
+    })
+
+    expect(setSessionSpecialist).toHaveBeenCalledTimes(2)
+    expect(setSessionSpecialist).toHaveBeenLastCalledWith({
+      sessionId: active.id,
+      specialistId: 'specialist-b'
+    })
+    expect(useSessionStore.getState().sessions[0].specialistId).toBe('specialist-b')
+    expect(hook.result.current.view.specialist.reconfigureError).toBeNull()
+  })
+
+  it('keeps recovery available when switching back to Main Agent rejects', async () => {
+    const active = session({ specialistId: 'specialist-a' })
+    useSessionStore.setState({ sessions: [active], selectedSessionId: active.id })
+    const setSessionSpecialist = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('specialist switch rejected'))
+      .mockRejectedValueOnce(new Error('main switch rejected'))
+      .mockResolvedValueOnce({ status: 'applied' as const, contextReset: false })
+    window.api = { specialist: { setSessionSpecialist } } as unknown as Window['api']
+    const hook = renderController({
+      activeSession: active,
+      specialistItems: [
+        specialist('specialist-a', 'Specialist A'),
+        specialist('specialist-b', 'Specialist B')
+      ]
+    })
+    mounted.push(hook)
+
+    await act(async () => {
+      hook.result.current.actions.selectSpecialist('specialist-b')
+      await Promise.resolve()
+    })
+    await act(async () => {
+      hook.result.current.actions.useMainAgent()
+      await Promise.resolve()
+    })
+
+    expect(setSessionSpecialist).toHaveBeenLastCalledWith({
+      sessionId: active.id,
+      specialistId: undefined
+    })
+    expect(hook.result.current.view.specialist.reconfigureError).toMatchObject({
+      specialistName: 'Main Agent',
+      message: 'main switch rejected',
+      committed: false
+    })
+    await act(async () => {
+      expect(hook.result.current.actions.retrySpecialistSelection()).toBe(true)
+      await Promise.resolve()
+    })
+    expect(setSessionSpecialist).toHaveBeenCalledTimes(3)
+    expect(hook.result.current.view.specialist.reconfigureError).toBeNull()
+  })
+
   it('coordinates duplicate deletion through the composer transaction boundary', async () => {
     const active = session()
     const deletion = deferred<SessionDeletionResult>()

--- a/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
@@ -353,6 +353,49 @@ describe('workspace session controller', () => {
     expect(hook.result.current.view.specialist.reconfigureError).toBeNull()
   })
 
+  it('keeps an idle Specialist retry available after changing another Session', async () => {
+    const first = session({ specialistId: 'specialist-a' })
+    const second = session({ id: 'session-b', specialistId: 'specialist-a' })
+    useSessionStore.setState({ sessions: [first, second], selectedSessionId: first.id })
+    const setSessionSpecialist = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('switch rejected'))
+      .mockResolvedValue({ status: 'applied' as const, contextReset: false })
+    window.api = { specialist: { setSessionSpecialist } } as unknown as Window['api']
+    const hook = renderController({
+      activeSession: first,
+      specialistItems: [
+        specialist('specialist-a', 'Specialist A'),
+        specialist('specialist-b', 'Specialist B')
+      ]
+    })
+    mounted.push(hook)
+
+    await act(async () => {
+      hook.result.current.actions.selectSpecialist('specialist-b')
+      await Promise.resolve()
+    })
+    hook.rerender(second)
+    await act(async () => {
+      hook.result.current.actions.selectSpecialist('specialist-b')
+      await Promise.resolve()
+    })
+    hook.rerender(first)
+
+    expect(hook.result.current.view.specialist.reconfigureError).toMatchObject({
+      sessionId: first.id,
+      message: 'switch rejected'
+    })
+    await act(async () => {
+      expect(hook.result.current.actions.retrySpecialistSelection()).toBe(true)
+      await Promise.resolve()
+    })
+    expect(setSessionSpecialist).toHaveBeenLastCalledWith({
+      sessionId: first.id,
+      specialistId: 'specialist-b'
+    })
+  })
+
   it('keeps recovery available when switching back to Main Agent rejects', async () => {
     const active = session({ specialistId: 'specialist-a' })
     useSessionStore.setState({ sessions: [active], selectedSessionId: active.id })

--- a/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
@@ -353,13 +353,14 @@ describe('workspace session controller', () => {
     expect(hook.result.current.view.specialist.reconfigureError).toBeNull()
   })
 
-  it('keeps an idle Specialist retry available after changing another Session', async () => {
+  it('keeps idle Specialist failures scoped to each Session', async () => {
     const first = session({ specialistId: 'specialist-a' })
     const second = session({ id: 'session-b', specialistId: 'specialist-a' })
     useSessionStore.setState({ sessions: [first, second], selectedSessionId: first.id })
     const setSessionSpecialist = vi
       .fn()
       .mockRejectedValueOnce(new Error('switch rejected'))
+      .mockRejectedValueOnce(new Error('other switch rejected'))
       .mockResolvedValue({ status: 'applied' as const, contextReset: false })
     window.api = { specialist: { setSessionSpecialist } } as unknown as Window['api']
     const hook = renderController({
@@ -392,6 +393,20 @@ describe('workspace session controller', () => {
     })
     expect(setSessionSpecialist).toHaveBeenLastCalledWith({
       sessionId: first.id,
+      specialistId: 'specialist-b'
+    })
+
+    hook.rerender(second)
+    expect(hook.result.current.view.specialist.reconfigureError).toMatchObject({
+      sessionId: second.id,
+      message: 'other switch rejected'
+    })
+    await act(async () => {
+      expect(hook.result.current.actions.retrySpecialistSelection()).toBe(true)
+      await Promise.resolve()
+    })
+    expect(setSessionSpecialist).toHaveBeenLastCalledWith({
+      sessionId: second.id,
       specialistId: 'specialist-b'
     })
   })

--- a/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
@@ -516,6 +516,45 @@ describe('workspace session controller', () => {
     expect(setSessionSpecialist).toHaveBeenCalledOnce()
   })
 
+  it('discards an idle Specialist failure after a newer pending-switch update', async () => {
+    const active = session({ specialistId: 'specialist-a' })
+    let pendingSwitchListener:
+      ((pending: { sessionId: string; targetName: string | null }) => void) | undefined
+    useSessionStore.setState({ sessions: [active], selectedSessionId: active.id })
+    const setSessionSpecialist = vi.fn().mockRejectedValue(new Error('switch rejected'))
+    window.api = {
+      specialist: {
+        setSessionSpecialist,
+        onPendingSwitch: vi.fn((listener) => {
+          pendingSwitchListener = listener
+          return () => undefined
+        })
+      }
+    } as unknown as Window['api']
+    const hook = renderController({
+      activeSession: active,
+      specialistItems: [
+        specialist('specialist-b', 'Specialist B'),
+        specialist('specialist-c', 'Specialist C')
+      ]
+    })
+    mounted.push(hook)
+
+    await act(async () => {
+      hook.result.current.actions.selectSpecialist('specialist-b')
+      await Promise.resolve()
+    })
+    act(() => pendingSwitchListener?.({ sessionId: active.id, targetName: 'Specialist C' }))
+
+    expect(hook.result.current.lifecycle.captureSendIntent(false)).toMatchObject({
+      hasPendingSwitch: true,
+      pendingSpecialistId: 'specialist-c'
+    })
+    expect(hook.result.current.view.specialist.reconfigureError).toBeNull()
+    expect(hook.result.current.actions.retrySpecialistSelection()).toBe(false)
+    expect(setSessionSpecialist).toHaveBeenCalledOnce()
+  })
+
   it('keeps recovery available when switching back to Main Agent rejects', async () => {
     const active = session({ specialistId: 'specialist-a' })
     useSessionStore.setState({ sessions: [active], selectedSessionId: active.id })

--- a/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
@@ -3,7 +3,10 @@ import { act, createElement } from 'react'
 import { createRoot } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { SpecialistListItem } from '../../../../shared/specialist'
+import type {
+  CompletionHandoffLifecycleEvent,
+  SpecialistListItem
+} from '../../../../shared/specialist'
 import type { SessionDeletionResult } from '../../../../shared/session-persistence'
 import { createLinearConversationGraph } from '../../../../shared/conversation-graph'
 import { useArchiveUndoStore } from '@/stores/archive-undo-store'
@@ -463,6 +466,54 @@ describe('workspace session controller', () => {
     hook.rerender(session({ id: active.id }))
 
     expect(hook.result.current.view.specialist.reconfigureError).toBeNull()
+  })
+
+  it('discards an idle Specialist failure after an authoritative handoff', async () => {
+    const active = session({ specialistId: 'specialist-a' })
+    const authoritative = specialist('specialist-c', 'Specialist C')
+    let handoffListener: ((event: CompletionHandoffLifecycleEvent) => void) | undefined
+    useSessionStore.setState({ sessions: [active], selectedSessionId: active.id })
+    const setSessionSpecialist = vi.fn().mockRejectedValue(new Error('switch rejected'))
+    window.api = {
+      specialist: {
+        setSessionSpecialist,
+        resolveSessionSpecialist: vi.fn().mockResolvedValue({
+          kind: 'bound',
+          profile: authoritative
+        }),
+        onHandoffLifecycleEvent: vi.fn((listener) => {
+          handoffListener = listener
+          return () => undefined
+        })
+      }
+    } as unknown as Window['api']
+    const hook = renderController({
+      activeSession: active,
+      specialistItems: [specialist('specialist-b', 'Specialist B'), authoritative]
+    })
+    mounted.push(hook)
+
+    await act(async () => {
+      hook.result.current.actions.selectSpecialist('specialist-b')
+      await Promise.resolve()
+    })
+    await act(async () => {
+      handoffListener?.({
+        id: 'handoff-1',
+        sessionId: active.id,
+        sequence: 1,
+        observedAt: 1,
+        phase: 'continuation-start',
+        target: 'Specialist C',
+        provenance: { originatingTurnId: 'turn-1', attachmentIds: [], artifactIds: [] }
+      })
+      await Promise.resolve()
+    })
+
+    expect(useSessionStore.getState().sessions[0].specialistId).toBe('specialist-c')
+    expect(hook.result.current.view.specialist.reconfigureError).toBeNull()
+    expect(hook.result.current.actions.retrySpecialistSelection()).toBe(false)
+    expect(setSessionSpecialist).toHaveBeenCalledOnce()
   })
 
   it('keeps recovery available when switching back to Main Agent rejects', async () => {

--- a/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
@@ -411,6 +411,60 @@ describe('workspace session controller', () => {
     })
   })
 
+  it('discards an idle Specialist failure after its Session is deleted', async () => {
+    const active = session({ specialistId: 'specialist-a' })
+    useSessionStore.setState({ sessions: [active], selectedSessionId: active.id })
+    const setSessionSpecialist = vi.fn().mockRejectedValue(new Error('switch rejected'))
+    window.api = { specialist: { setSessionSpecialist } } as unknown as Window['api']
+    const hook = renderController({
+      activeSession: active,
+      specialistItems: [specialist('specialist-b', 'Specialist B')]
+    })
+    mounted.push(hook)
+
+    await act(async () => {
+      hook.result.current.actions.selectSpecialist('specialist-b')
+      await Promise.resolve()
+    })
+    act(() => hook.result.current.actions.openDelete(active))
+    await act(async () => {
+      hook.result.current.actions.confirmDelete()
+      await Promise.resolve()
+    })
+    hook.rerender(session({ id: active.id }))
+
+    expect(hook.result.current.view.specialist.reconfigureError).toBeNull()
+  })
+
+  it('discards an idle Specialist failure after its Session is archived', async () => {
+    const active = session({ specialistId: 'specialist-a' })
+    const updateSessionArchive = vi.fn().mockResolvedValue({ ...active, archivedAt: 2 })
+    useSessionStore.setState({
+      sessions: [active],
+      selectedSessionId: active.id,
+      updateSessionArchive
+    })
+    const setSessionSpecialist = vi.fn().mockRejectedValue(new Error('switch rejected'))
+    window.api = { specialist: { setSessionSpecialist } } as unknown as Window['api']
+    const hook = renderController({
+      activeSession: active,
+      specialistItems: [specialist('specialist-b', 'Specialist B')]
+    })
+    mounted.push(hook)
+
+    await act(async () => {
+      hook.result.current.actions.selectSpecialist('specialist-b')
+      await Promise.resolve()
+    })
+    await act(async () => {
+      hook.result.current.actions.archive(active)
+      await Promise.resolve()
+    })
+    hook.rerender(session({ id: active.id }))
+
+    expect(hook.result.current.view.specialist.reconfigureError).toBeNull()
+  })
+
   it('keeps recovery available when switching back to Main Agent rejects', async () => {
     const active = session({ specialistId: 'specialist-a' })
     useSessionStore.setState({ sessions: [active], selectedSessionId: active.id })

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -270,6 +270,7 @@ const useWorkspaceSessionController = ({
       expectedArchivedAt: null
     })
       .then((archived) => {
+        reconfiguration.clearIdleRetry(session.id)
         enqueueSessionArchive(archived)
         if (selectedSessionId === session.id) clearSelection()
       })
@@ -282,7 +283,6 @@ const useWorkspaceSessionController = ({
         })
       })
   }
-
   const openDelete = (session: ChatSession): void => {
     if (isPersistenceHydrated && canDeleteConversations && deletingIdsRef.current.size === 0) {
       setDeleteDialog({
@@ -292,7 +292,6 @@ const useWorkspaceSessionController = ({
       })
     }
   }
-
   const confirmDelete = (): void => {
     if (!isPersistenceHydrated || !canDeleteConversations || !deleteDialog) return
     useNavigationStore.getState().recordUserNavigation()
@@ -309,6 +308,7 @@ const useWorkspaceSessionController = ({
         const deleted = result.status === 'deleted'
         settleSessionDeletion(sessionId, deleted)
         if (deleted) {
+          reconfiguration.clearIdleRetry(sessionId)
           setDeleteDialog((current) => (current?.session.id === sessionId ? null : current))
           return
         }

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -162,6 +162,9 @@ const useWorkspaceSessionController = ({
   )
   const reconfiguration = useWorkspaceSpecialistReconfiguration(specialistItems)
   const { error: reconfigureError, setError: setReconfigureError } = reconfiguration
+  const activeReconfigureError =
+    reconfiguration.idleErrorFor(activeSession?.id) ??
+    (reconfigureError?.sessionId === activeSession?.id ? reconfigureError : null)
   const barrierInFlightIds = useSyncExternalStore(
     subscribeWorkspaceSpecialistBarriers,
     getWorkspaceSpecialistBarrierSnapshot,
@@ -481,16 +484,14 @@ const useWorkspaceSessionController = ({
     setReconfigureError(null)
     return true
   }
-
   const chooseOtherSpecialist = (): void => {
-    if (!activeSession || !reconfigureError) return
+    if (!activeSession || !activeReconfigureError) return
     clearPending(activeSession.id)
     reconfiguration.clearIdleRetry(activeSession.id)
     setReconfigureError(null)
   }
-
   const useMainAgent = (): void => {
-    if (!activeSession || !reconfigureError) return
+    if (!activeSession || !activeReconfigureError) return
     const sessionId = activeSession.id
     const setter = window.api?.specialist?.setSessionSpecialist
     if (!setter || isWorkspaceSpecialistBarrierInFlight(sessionId)) return
@@ -643,8 +644,7 @@ const useWorkspaceSessionController = ({
         hasPendingSwitch: activeHasPendingSwitch,
         barrierInFlight: barrierInFlightIds.has(activeSession?.id ?? ''),
         sendAvailable: specialistSendAvailable && !barrierInFlightIds.has(activeSession?.id ?? ''),
-        reconfigureError:
-          reconfigureError?.sessionId === activeSession?.id ? reconfigureError : null
+        reconfigureError: activeReconfigureError
       }
     },
     actions: {

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -555,6 +555,7 @@ const useWorkspaceSessionController = ({
     const specialistApi = window.api?.specialist
     if (!specialistApi?.onPendingSwitch) return
     return specialistApi.onPendingSwitch((pending) => {
+      clearIdleRetry(pending.sessionId)
       if (pending.targetName === null) {
         setPendingSpecialists((current) => ({
           ...current,
@@ -586,7 +587,7 @@ const useWorkspaceSessionController = ({
         })
         .catch(() => undefined)
     })
-  }, [])
+  }, [clearIdleRetry])
   const applyHandoffLifecycleEvent = useCallback(
     (event: CompletionHandoffLifecycleEvent): void => {
       if (event.phase !== 'continuation-start' && event.phase !== 'continued') return

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -341,7 +341,6 @@ const useWorkspaceSessionController = ({
         })
       })
   }
-
   const selectSpecialist = (specialistId: string | undefined): void => {
     if (!activeSession) {
       setNewConversationSpecialistId(specialistId)
@@ -356,10 +355,12 @@ const useWorkspaceSessionController = ({
     } else {
       const setter = window.api?.specialist?.setSessionSpecialist
       if (!setter) return
+      const attempt = reconfiguration.beginIdleAttempt(sessionId, specialistId)
       clearPending(sessionId)
       setBarrier(sessionId, true)
       void setter({ sessionId, specialistId })
         .then((result) => {
+          if (!attempt.complete()) return
           if (result?.status === 'pending') {
             setSessionSpecialistId(sessionId, specialistId, true)
             setPendingSpecialists((current) => ({ ...current, [sessionId]: specialistId }))
@@ -373,13 +374,12 @@ const useWorkspaceSessionController = ({
         })
         .catch((error: unknown) => {
           console.warn('setSessionSpecialist failed', error)
-          reconfiguration.recordIdleFailure(sessionId, specialistId, errorMessage(error))
+          attempt.recordFailure(errorMessage(error))
         })
         .finally(() => setBarrier(sessionId, false))
     }
     if (reconfigureError?.sessionId === sessionId) setReconfigureError(null)
   }
-
   const canStartSend = (sessionId?: string): boolean => {
     if (sessionId && sessionId !== activeSession?.id) {
       const session = useSessionStore
@@ -496,10 +496,11 @@ const useWorkspaceSessionController = ({
     const sessionId = activeSession.id
     const setter = window.api?.specialist?.setSessionSpecialist
     if (!setter || isWorkspaceSpecialistBarrierInFlight(sessionId)) return
-    clearIdleRetry(sessionId)
+    const attempt = reconfiguration.beginIdleAttempt(sessionId, undefined)
     setBarrier(sessionId, true)
     void setter({ sessionId, specialistId: undefined })
       .then((result) => {
+        if (!attempt.complete()) return
         if (result?.status === 'pending') {
           setSessionSpecialistId(sessionId, undefined, true)
           setPendingSpecialists((current) => ({ ...current, [sessionId]: undefined }))
@@ -515,11 +516,10 @@ const useWorkspaceSessionController = ({
       })
       .catch((error: unknown) => {
         console.warn('setSessionSpecialist (none) failed', error)
-        reconfiguration.recordIdleFailure(sessionId, undefined, errorMessage(error))
+        attempt.recordFailure(errorMessage(error))
       })
       .finally(() => setBarrier(sessionId, false))
   }
-
   useEffect(() => {
     if (!activeSession || activeSession.specialistBindingPending !== true) return
     // The durable Session store is an external source. Mirror its restored recovery state so the

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -162,6 +162,7 @@ const useWorkspaceSessionController = ({
   )
   const reconfiguration = useWorkspaceSpecialistReconfiguration(specialistItems)
   const { error: reconfigureError, setError: setReconfigureError } = reconfiguration
+  const { clearIdleRetry } = reconfiguration
   const activeReconfigureError =
     reconfiguration.idleErrorFor(activeSession?.id) ??
     (reconfigureError?.sessionId === activeSession?.id ? reconfigureError : null)
@@ -270,7 +271,7 @@ const useWorkspaceSessionController = ({
       expectedArchivedAt: null
     })
       .then((archived) => {
-        reconfiguration.clearIdleRetry(session.id)
+        clearIdleRetry(session.id)
         enqueueSessionArchive(archived)
         if (selectedSessionId === session.id) clearSelection()
       })
@@ -308,7 +309,7 @@ const useWorkspaceSessionController = ({
         const deleted = result.status === 'deleted'
         settleSessionDeletion(sessionId, deleted)
         if (deleted) {
-          reconfiguration.clearIdleRetry(sessionId)
+          clearIdleRetry(sessionId)
           setDeleteDialog((current) => (current?.session.id === sessionId ? null : current))
           return
         }
@@ -348,7 +349,7 @@ const useWorkspaceSessionController = ({
     }
     const sessionId = activeSession.id
     if (isWorkspaceSpecialistBarrierInFlight(sessionId)) return
-    reconfiguration.clearIdleRetry(sessionId)
+    clearIdleRetry(sessionId)
     const running = projectSessionActionability(activeSession).activity !== 'inactive'
     if (running) {
       setPendingSpecialists((current) => ({ ...current, [sessionId]: specialistId }))
@@ -487,7 +488,7 @@ const useWorkspaceSessionController = ({
   const chooseOtherSpecialist = (): void => {
     if (!activeSession || !activeReconfigureError) return
     clearPending(activeSession.id)
-    reconfiguration.clearIdleRetry(activeSession.id)
+    clearIdleRetry(activeSession.id)
     setReconfigureError(null)
   }
   const useMainAgent = (): void => {
@@ -495,7 +496,7 @@ const useWorkspaceSessionController = ({
     const sessionId = activeSession.id
     const setter = window.api?.specialist?.setSessionSpecialist
     if (!setter || isWorkspaceSpecialistBarrierInFlight(sessionId)) return
-    reconfiguration.clearIdleRetry(sessionId)
+    clearIdleRetry(sessionId)
     setBarrier(sessionId, true)
     void setter({ sessionId, specialistId: undefined })
       .then((result) => {
@@ -586,7 +587,6 @@ const useWorkspaceSessionController = ({
         .catch(() => undefined)
     })
   }, [])
-
   const applyHandoffLifecycleEvent = useCallback(
     (event: CompletionHandoffLifecycleEvent): void => {
       if (event.phase !== 'continuation-start' && event.phase !== 'continued') return
@@ -600,19 +600,18 @@ const useWorkspaceSessionController = ({
             setSessionSpecialistId(event.sessionId, resolution.profile.id)
           } else if (resolution.kind === 'main') {
             setSessionSpecialistId(event.sessionId, undefined)
-          }
+          } else return
+          clearIdleRetry(event.sessionId)
         })
         .catch(() => undefined)
     },
-    [setSessionSpecialistId]
+    [clearIdleRetry, setSessionSpecialistId]
   )
-
   useEffect(() => {
     const specialistApi = window.api?.specialist
     if (!specialistApi?.onHandoffLifecycleEvent) return
     return specialistApi.onHandoffLifecycleEvent(applyHandoffLifecycleEvent)
   }, [applyHandoffLifecycleEvent])
-
   useEffect(() => {
     const specialistApi = window.api?.specialist
     if (!activeSession?.id || !specialistApi?.getHandoffEvents) return

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -31,6 +31,7 @@ import {
   compareHandoffEventOrder,
   pendingSpecialistReconfigureError,
   specialistNameFor,
+  useWorkspaceSpecialistReconfiguration,
   type WorkspaceSpecialistReconfigureError as ReconfigureError
 } from './workspace-specialist-reconfiguration'
 
@@ -108,6 +109,7 @@ type WorkspaceSessionController = {
     openJobList: (sessionId: string) => void
     closeJobList: () => void
     selectSpecialist: (specialistId: string | undefined) => void
+    retrySpecialistSelection: () => boolean
     resetNewConversationSpecialist: () => void
     beginReconfigureRetry: () => boolean
     chooseOtherSpecialist: () => void
@@ -152,21 +154,20 @@ const useWorkspaceSessionController = ({
     (state) => state.markSpecialistSwitchResetRequired
   )
   const enqueueSessionArchive = useArchiveUndoStore((state) => state.enqueueSession)
-
   const [newConversationSpecialistId, setNewConversationSpecialistId] = useState<
     string | undefined
   >(undefined)
   const [pendingSpecialists, setPendingSpecialists] = useState<Record<string, string | undefined>>(
     {}
   )
-  const [reconfigureError, setReconfigureError] = useState<ReconfigureError | null>(null)
+  const reconfiguration = useWorkspaceSpecialistReconfiguration(specialistItems)
+  const { error: reconfigureError, setError: setReconfigureError } = reconfiguration
   const barrierInFlightIds = useSyncExternalStore(
     subscribeWorkspaceSpecialistBarriers,
     getWorkspaceSpecialistBarrierSnapshot,
     getWorkspaceSpecialistBarrierSnapshot
   )
   const specialistItemsRef = useRef(specialistItems)
-
   const [exportError, setExportError] = useState<string | null>(null)
   const [renameDialog, setRenameDialog] = useState<{
     session: ChatSession
@@ -344,6 +345,7 @@ const useWorkspaceSessionController = ({
     }
     const sessionId = activeSession.id
     if (isWorkspaceSpecialistBarrierInFlight(sessionId)) return
+    reconfiguration.clearIdleRetry()
     const running = projectSessionActionability(activeSession).activity !== 'inactive'
     if (running) {
       setPendingSpecialists((current) => ({ ...current, [sessionId]: specialistId }))
@@ -367,6 +369,7 @@ const useWorkspaceSessionController = ({
         })
         .catch((error: unknown) => {
           console.warn('setSessionSpecialist failed', error)
+          reconfiguration.recordIdleFailure(sessionId, specialistId, errorMessage(error))
         })
         .finally(() => setBarrier(sessionId, false))
     }
@@ -482,6 +485,7 @@ const useWorkspaceSessionController = ({
   const chooseOtherSpecialist = (): void => {
     if (!activeSession || !reconfigureError) return
     clearPending(activeSession.id)
+    reconfiguration.clearIdleRetry()
     setReconfigureError(null)
   }
 
@@ -490,6 +494,7 @@ const useWorkspaceSessionController = ({
     const sessionId = activeSession.id
     const setter = window.api?.specialist?.setSessionSpecialist
     if (!setter || isWorkspaceSpecialistBarrierInFlight(sessionId)) return
+    reconfiguration.clearIdleRetry()
     setBarrier(sessionId, true)
     void setter({ sessionId, specialistId: undefined })
       .then((result) => {
@@ -508,6 +513,7 @@ const useWorkspaceSessionController = ({
       })
       .catch((error: unknown) => {
         console.warn('setSessionSpecialist (none) failed', error)
+        reconfiguration.recordIdleFailure(sessionId, undefined, errorMessage(error))
       })
       .finally(() => setBarrier(sessionId, false))
   }
@@ -531,7 +537,7 @@ const useWorkspaceSessionController = ({
             activeSession.specialistId
           )
     )
-  }, [activeSession, specialistItems])
+  }, [activeSession, setReconfigureError, specialistItems])
 
   useEffect(() => {
     if (typeof window.api?.specialist?.list !== 'function') return
@@ -667,6 +673,8 @@ const useWorkspaceSessionController = ({
       openJobList: (sessionId: string) => setJobListDialog({ open: true, sessionId }),
       closeJobList: () => setJobListDialog((current) => ({ ...current, open: false })),
       selectSpecialist,
+      retrySpecialistSelection: () =>
+        reconfiguration.retryIdle(activeSession?.id, selectSpecialist),
       resetNewConversationSpecialist: () => setNewConversationSpecialistId(undefined),
       beginReconfigureRetry,
       chooseOtherSpecialist,

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -345,7 +345,7 @@ const useWorkspaceSessionController = ({
     }
     const sessionId = activeSession.id
     if (isWorkspaceSpecialistBarrierInFlight(sessionId)) return
-    reconfiguration.clearIdleRetry()
+    reconfiguration.clearIdleRetry(sessionId)
     const running = projectSessionActionability(activeSession).activity !== 'inactive'
     if (running) {
       setPendingSpecialists((current) => ({ ...current, [sessionId]: specialistId }))
@@ -485,7 +485,7 @@ const useWorkspaceSessionController = ({
   const chooseOtherSpecialist = (): void => {
     if (!activeSession || !reconfigureError) return
     clearPending(activeSession.id)
-    reconfiguration.clearIdleRetry()
+    reconfiguration.clearIdleRetry(activeSession.id)
     setReconfigureError(null)
   }
 
@@ -494,7 +494,7 @@ const useWorkspaceSessionController = ({
     const sessionId = activeSession.id
     const setter = window.api?.specialist?.setSessionSpecialist
     if (!setter || isWorkspaceSpecialistBarrierInFlight(sessionId)) return
-    reconfiguration.clearIdleRetry()
+    reconfiguration.clearIdleRetry(sessionId)
     setBarrier(sessionId, true)
     void setter({ sessionId, specialistId: undefined })
       .then((result) => {

--- a/src/renderer/src/pages/workspace/workspace-specialist-reconfiguration.ts
+++ b/src/renderer/src/pages/workspace/workspace-specialist-reconfiguration.ts
@@ -44,7 +44,7 @@ const useWorkspaceSpecialistReconfiguration = (
 ): {
   error: WorkspaceSpecialistReconfigureError | null
   setError: Dispatch<SetStateAction<WorkspaceSpecialistReconfigureError | null>>
-  clearIdleRetry: () => void
+  clearIdleRetry: (sessionId: string) => void
   recordIdleFailure: (sessionId: string, specialistId: string | undefined, message: string) => void
   retryIdle: (
     activeSessionId: string | undefined,
@@ -54,8 +54,8 @@ const useWorkspaceSpecialistReconfiguration = (
   const [error, setError] = useState<WorkspaceSpecialistReconfigureError | null>(null)
   const idleRetryTarget = useRef<IdleSpecialistRetryTarget | null>(null)
 
-  const clearIdleRetry = (): void => {
-    idleRetryTarget.current = null
+  const clearIdleRetry = (sessionId: string): void => {
+    if (idleRetryTarget.current?.sessionId === sessionId) idleRetryTarget.current = null
   }
   const recordIdleFailure = (
     sessionId: string,

--- a/src/renderer/src/pages/workspace/workspace-specialist-reconfiguration.ts
+++ b/src/renderer/src/pages/workspace/workspace-specialist-reconfiguration.ts
@@ -1,4 +1,4 @@
-import { useState, type Dispatch, type SetStateAction } from 'react'
+import { useCallback, useState, type Dispatch, type SetStateAction } from 'react'
 
 import type {
   CompletionHandoffLifecycleEvent,
@@ -59,14 +59,14 @@ const useWorkspaceSpecialistReconfiguration = (
     sessionId: string | undefined
   ): WorkspaceSpecialistReconfigureError | null =>
     sessionId ? (idleFailures[sessionId]?.error ?? null) : null
-  const clearIdleRetry = (sessionId: string): void => {
+  const clearIdleRetry = useCallback((sessionId: string): void => {
     setIdleFailures((current) => {
       if (!Object.hasOwn(current, sessionId)) return current
       const next = { ...current }
       delete next[sessionId]
       return next
     })
-  }
+  }, [])
   const recordIdleFailure = (
     sessionId: string,
     specialistId: string | undefined,

--- a/src/renderer/src/pages/workspace/workspace-specialist-reconfiguration.ts
+++ b/src/renderer/src/pages/workspace/workspace-specialist-reconfiguration.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState, type Dispatch, type SetStateAction } from 'react'
+import { useCallback, useRef, useState, type Dispatch, type SetStateAction } from 'react'
 
 import type {
   CompletionHandoffLifecycleEvent,
@@ -15,6 +15,11 @@ type WorkspaceSpecialistReconfigureError = {
 type IdleSpecialistFailure = {
   specialistId: string | undefined
   error: WorkspaceSpecialistReconfigureError
+}
+
+type IdleSpecialistAttempt = {
+  complete: () => boolean
+  recordFailure: (message: string) => void
 }
 
 const specialistNameFor = (
@@ -46,7 +51,7 @@ const useWorkspaceSpecialistReconfiguration = (
   setError: Dispatch<SetStateAction<WorkspaceSpecialistReconfigureError | null>>
   idleErrorFor: (sessionId: string | undefined) => WorkspaceSpecialistReconfigureError | null
   clearIdleRetry: (sessionId: string) => void
-  recordIdleFailure: (sessionId: string, specialistId: string | undefined, message: string) => void
+  beginIdleAttempt: (sessionId: string, specialistId: string | undefined) => IdleSpecialistAttempt
   retryIdle: (
     activeSessionId: string | undefined,
     retry: (specialistId: string | undefined) => void
@@ -54,12 +59,14 @@ const useWorkspaceSpecialistReconfiguration = (
 } => {
   const [error, setError] = useState<WorkspaceSpecialistReconfigureError | null>(null)
   const [idleFailures, setIdleFailures] = useState<Record<string, IdleSpecialistFailure>>({})
+  const nextIdleAttemptGeneration = useRef(0)
+  const idleAttemptGenerations = useRef(new Map<string, number>())
 
   const idleErrorFor = (
     sessionId: string | undefined
   ): WorkspaceSpecialistReconfigureError | null =>
     sessionId ? (idleFailures[sessionId]?.error ?? null) : null
-  const clearIdleRetry = useCallback((sessionId: string): void => {
+  const removeIdleFailure = useCallback((sessionId: string): void => {
     setIdleFailures((current) => {
       if (!Object.hasOwn(current, sessionId)) return current
       const next = { ...current }
@@ -67,25 +74,45 @@ const useWorkspaceSpecialistReconfiguration = (
       return next
     })
   }, [])
-  const recordIdleFailure = (
-    sessionId: string,
-    specialistId: string | undefined,
-    message: string
-  ): void => {
-    const failure = {
-      specialistId,
-      error: {
-        sessionId,
-        specialistName: specialistNameFor(items, specialistId),
-        message,
-        committed: false
+  const clearIdleRetry = useCallback(
+    (sessionId: string): void => {
+      idleAttemptGenerations.current.delete(sessionId)
+      removeIdleFailure(sessionId)
+    },
+    [removeIdleFailure]
+  )
+  const beginIdleAttempt = useCallback(
+    (sessionId: string, specialistId: string | undefined): IdleSpecialistAttempt => {
+      const generation = ++nextIdleAttemptGeneration.current
+      idleAttemptGenerations.current.set(sessionId, generation)
+      removeIdleFailure(sessionId)
+      return {
+        complete: (): boolean => {
+          if (idleAttemptGenerations.current.get(sessionId) !== generation) return false
+          idleAttemptGenerations.current.delete(sessionId)
+          return true
+        },
+        recordFailure: (message: string): void => {
+          setIdleFailures((current) => {
+            if (idleAttemptGenerations.current.get(sessionId) !== generation) return current
+            return {
+              ...current,
+              [sessionId]: {
+                specialistId,
+                error: {
+                  sessionId,
+                  specialistName: specialistNameFor(items, specialistId),
+                  message,
+                  committed: false
+                }
+              }
+            }
+          })
+        }
       }
-    }
-    setIdleFailures((current) => ({
-      ...current,
-      [sessionId]: failure
-    }))
-  }
+    },
+    [items, removeIdleFailure]
+  )
   const retryIdle = (
     activeSessionId: string | undefined,
     retry: (specialistId: string | undefined) => void
@@ -97,7 +124,7 @@ const useWorkspaceSpecialistReconfiguration = (
     return true
   }
 
-  return { error, setError, idleErrorFor, clearIdleRetry, recordIdleFailure, retryIdle }
+  return { error, setError, idleErrorFor, clearIdleRetry, beginIdleAttempt, retryIdle }
 }
 
 const compareHandoffEventOrder = (

--- a/src/renderer/src/pages/workspace/workspace-specialist-reconfiguration.ts
+++ b/src/renderer/src/pages/workspace/workspace-specialist-reconfiguration.ts
@@ -1,4 +1,4 @@
-import { useRef, useState, type Dispatch, type SetStateAction } from 'react'
+import { useState, type Dispatch, type SetStateAction } from 'react'
 
 import type {
   CompletionHandoffLifecycleEvent,
@@ -12,9 +12,9 @@ type WorkspaceSpecialistReconfigureError = {
   committed: boolean
 }
 
-type IdleSpecialistRetryTarget = {
-  sessionId: string
+type IdleSpecialistFailure = {
   specialistId: string | undefined
+  error: WorkspaceSpecialistReconfigureError
 }
 
 const specialistNameFor = (
@@ -44,6 +44,7 @@ const useWorkspaceSpecialistReconfiguration = (
 ): {
   error: WorkspaceSpecialistReconfigureError | null
   setError: Dispatch<SetStateAction<WorkspaceSpecialistReconfigureError | null>>
+  idleErrorFor: (sessionId: string | undefined) => WorkspaceSpecialistReconfigureError | null
   clearIdleRetry: (sessionId: string) => void
   recordIdleFailure: (sessionId: string, specialistId: string | undefined, message: string) => void
   retryIdle: (
@@ -52,35 +53,51 @@ const useWorkspaceSpecialistReconfiguration = (
   ) => boolean
 } => {
   const [error, setError] = useState<WorkspaceSpecialistReconfigureError | null>(null)
-  const idleRetryTarget = useRef<IdleSpecialistRetryTarget | null>(null)
+  const [idleFailures, setIdleFailures] = useState<Record<string, IdleSpecialistFailure>>({})
 
+  const idleErrorFor = (
+    sessionId: string | undefined
+  ): WorkspaceSpecialistReconfigureError | null =>
+    sessionId ? (idleFailures[sessionId]?.error ?? null) : null
   const clearIdleRetry = (sessionId: string): void => {
-    if (idleRetryTarget.current?.sessionId === sessionId) idleRetryTarget.current = null
+    setIdleFailures((current) => {
+      if (!Object.hasOwn(current, sessionId)) return current
+      const next = { ...current }
+      delete next[sessionId]
+      return next
+    })
   }
   const recordIdleFailure = (
     sessionId: string,
     specialistId: string | undefined,
     message: string
   ): void => {
-    idleRetryTarget.current = { sessionId, specialistId }
-    setError({
-      sessionId,
-      specialistName: specialistNameFor(items, specialistId),
-      message,
-      committed: false
-    })
+    const failure = {
+      specialistId,
+      error: {
+        sessionId,
+        specialistName: specialistNameFor(items, specialistId),
+        message,
+        committed: false
+      }
+    }
+    setIdleFailures((current) => ({
+      ...current,
+      [sessionId]: failure
+    }))
   }
   const retryIdle = (
     activeSessionId: string | undefined,
     retry: (specialistId: string | undefined) => void
   ): boolean => {
-    const target = idleRetryTarget.current
-    if (!activeSessionId || target?.sessionId !== activeSessionId) return false
-    retry(target.specialistId)
+    if (!activeSessionId) return false
+    const failure = idleFailures[activeSessionId]
+    if (!failure) return false
+    retry(failure.specialistId)
     return true
   }
 
-  return { error, setError, clearIdleRetry, recordIdleFailure, retryIdle }
+  return { error, setError, idleErrorFor, clearIdleRetry, recordIdleFailure, retryIdle }
 }
 
 const compareHandoffEventOrder = (

--- a/src/renderer/src/pages/workspace/workspace-specialist-reconfiguration.ts
+++ b/src/renderer/src/pages/workspace/workspace-specialist-reconfiguration.ts
@@ -1,3 +1,5 @@
+import { useRef, useState, type Dispatch, type SetStateAction } from 'react'
+
 import type {
   CompletionHandoffLifecycleEvent,
   SpecialistListItem
@@ -8,6 +10,11 @@ type WorkspaceSpecialistReconfigureError = {
   specialistName: string
   message: string
   committed: boolean
+}
+
+type IdleSpecialistRetryTarget = {
+  sessionId: string
+  specialistId: string | undefined
 }
 
 const specialistNameFor = (
@@ -32,6 +39,50 @@ const pendingSpecialistReconfigureError = (
   committed: true
 })
 
+const useWorkspaceSpecialistReconfiguration = (
+  items: readonly SpecialistListItem[]
+): {
+  error: WorkspaceSpecialistReconfigureError | null
+  setError: Dispatch<SetStateAction<WorkspaceSpecialistReconfigureError | null>>
+  clearIdleRetry: () => void
+  recordIdleFailure: (sessionId: string, specialistId: string | undefined, message: string) => void
+  retryIdle: (
+    activeSessionId: string | undefined,
+    retry: (specialistId: string | undefined) => void
+  ) => boolean
+} => {
+  const [error, setError] = useState<WorkspaceSpecialistReconfigureError | null>(null)
+  const idleRetryTarget = useRef<IdleSpecialistRetryTarget | null>(null)
+
+  const clearIdleRetry = (): void => {
+    idleRetryTarget.current = null
+  }
+  const recordIdleFailure = (
+    sessionId: string,
+    specialistId: string | undefined,
+    message: string
+  ): void => {
+    idleRetryTarget.current = { sessionId, specialistId }
+    setError({
+      sessionId,
+      specialistName: specialistNameFor(items, specialistId),
+      message,
+      committed: false
+    })
+  }
+  const retryIdle = (
+    activeSessionId: string | undefined,
+    retry: (specialistId: string | undefined) => void
+  ): boolean => {
+    const target = idleRetryTarget.current
+    if (!activeSessionId || target?.sessionId !== activeSessionId) return false
+    retry(target.specialistId)
+    return true
+  }
+
+  return { error, setError, clearIdleRetry, recordIdleFailure, retryIdle }
+}
+
 const compareHandoffEventOrder = (
   left: Pick<CompletionHandoffLifecycleEvent, 'commitOrder' | 'observedAt' | 'sequence' | 'id'>,
   right: Pick<CompletionHandoffLifecycleEvent, 'commitOrder' | 'observedAt' | 'sequence' | 'id'>
@@ -46,5 +97,10 @@ const compareHandoffEventOrder = (
   left.sequence - right.sequence ||
   left.id.localeCompare(right.id)
 
-export { compareHandoffEventOrder, pendingSpecialistReconfigureError, specialistNameFor }
+export {
+  compareHandoffEventOrder,
+  pendingSpecialistReconfigureError,
+  specialistNameFor,
+  useWorkspaceSpecialistReconfiguration
+}
 export type { WorkspaceSpecialistReconfigureError }


### PR DESCRIPTION
## Problem

When an idle Session changes Specialist, the renderer invokes specialist.setSessionSpecialist immediately. If that IPC rejects, the controller only logs a warning: the existing recovery banner remains hidden and the user has no explicit retry action.

## Proposed change

- Project idle-selection rejections into the existing Specialist reconfiguration error surface.
- Retain the failed target as renderer-only transient state.
- Route Retry back through the selection IPC without submitting the composer draft.
- Preserve the existing send-barrier Retry behavior and keep Main Agent recovery failures retryable.

## Scope and non-goals

- No database schema, persistent field, migration, historical-data compatibility, IPC contract, preload, ACP, or runtime-model changes.
- No new enum values or user-visible strings.
- No changes to the successful or explicit pending switch paths.

## Acceptance criteria and validation

Checks listed below ran after the last material edit:

- Idle rejection feedback and selection-only retry -> npm test -- src/renderer/src/pages/workspace/workspace-session-controller.test.ts -> 12 passed.
- Recovery banner routing and preservation of send-barrier retry -> npm test -- src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx -> 114 passed.
- Workspace owner, contract, representative consumer, renderer-state, and architecture gates -> npm run test:module -- workspace_page -> 25 files, 462 tests passed.
- Renderer types -> npm run typecheck:web -> passed.
- Lint -> npm run lint -> passed with no warnings.
- Formatting and patch integrity -> Prettier check and git diff --check -> passed.

Uncovered local risk: no manual Electron IPC failure injection was run; the regression uses the existing renderer API boundary. Exact-head PR CI remains authoritative for the complete portable and platform-selected checks.

## Review focus

- Confirm Retry never submits the composer draft for an idle-selection rejection.
- Confirm the transient retry target cannot leak across Session switches or replacement selections.
- Confirm the existing pre-send reconfiguration recovery behavior remains unchanged.