### PR TITLE
fix(connectors): recover transient custom MCP connections

### DIFF
--- a/src/main/connectors/mcp-client-manager.ts
+++ b/src/main/connectors/mcp-client-manager.ts
@@ -181,11 +181,16 @@ export class McpClientManager {
   ): Promise<McpClientManagerTool[]> {
     signal?.throwIfAborted()
     const client = await this.connect(config, signal)
-    signal?.throwIfAborted()
-    const { tools } = signal
-      ? await client.listTools(undefined, { signal })
-      : await client.listTools()
-    return tools
+    try {
+      signal?.throwIfAborted()
+      const { tools } = signal
+        ? await client.listTools(undefined, { signal })
+        : await client.listTools()
+      return tools
+    } catch (error) {
+      if (!signal?.aborted) await this.discardClient(config.id, client)
+      throw error
+    }
   }
 
   async call(
@@ -196,12 +201,19 @@ export class McpClientManager {
   ): Promise<unknown> {
     signal?.throwIfAborted()
     const client = await this.connect(config, signal)
-    signal?.throwIfAborted()
-    const input = { name: method, arguments: args }
-    const result = signal
-      ? await client.callTool(input, undefined, { signal })
-      : await client.callTool(input)
-    return unwrapToolResult(result)
+    try {
+      signal?.throwIfAborted()
+      const input = { name: method, arguments: args }
+      const result = signal
+        ? await client.callTool(input, undefined, { signal })
+        : await client.callTool(input)
+      return unwrapToolResult(result)
+    } catch (error) {
+      if (!signal?.aborted && !(error instanceof McpToolCallError)) {
+        await this.discardClient(config.id, client)
+      }
+      throw error
+    }
   }
 
   async close(id: string): Promise<void> {
@@ -396,6 +408,12 @@ export class McpClientManager {
 
   private generation(id: string): number {
     return this.generations.get(id) ?? 0
+  }
+
+  private async discardClient(id: string, expected: Client): Promise<void> {
+    if (this.clients.get(id) !== expected) return
+    this.clients.delete(id)
+    await expected.close().catch(() => undefined)
   }
 }
 

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { ConnectorService } from './service'
 import { ParserEngine } from './engine'
-import { McpToolCallError } from './mcp-client-manager'
+import { McpClientManager, McpToolCallError } from './mcp-client-manager'
 import type { SpecialistProfileView } from '../../shared/specialist'
 import type { CustomMcpServerConfig } from './mcp-client-manager'
 
@@ -1149,6 +1150,65 @@ describe('ConnectorService', () => {
           expect(error.message).not.toContain('SECRET')
           expect(error.message).not.toContain('private.example')
         })
+    })
+
+    it('backs off before probing a custom MCP server after a transient connection failure', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-08-22T00:00:00.000Z'))
+      const failedClient = {
+        listTools: vi.fn().mockRejectedValue(new Error('Connection closed')),
+        close: vi.fn().mockResolvedValue(undefined)
+      } as unknown as Client
+      const recoveredClient = {
+        listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'lookup' }] }),
+        callTool: vi.fn().mockResolvedValue({
+          content: [{ type: 'text', text: JSON.stringify({ ok: true }) }]
+        }),
+        close: vi.fn().mockResolvedValue(undefined)
+      } as unknown as Client
+      const createClient = vi
+        .fn()
+        .mockResolvedValueOnce(failedClient)
+        .mockResolvedValueOnce(recoveredClient)
+      const mcpClientManager = new McpClientManager({ createClient })
+      try {
+        const svc = new ConnectorService({
+          mcpClientManager,
+          getConnectors: () => ({
+            enabledIds: [],
+            autoAllowIds: [],
+            customMcpServers: [
+              {
+                id: 'srv-transient',
+                name: 'transient-server',
+                displayName: 'Transient server',
+                transport: 'streamable_http',
+                url: 'https://mcp.example.test',
+                enabled: true
+              }
+            ]
+          }),
+          resolveApiKey: () => undefined
+        })
+
+        await expect(svc.call('transient-server', 'lookup', {}, internal)).rejects.toThrow(
+          'connector_unavailable'
+        )
+        await expect(svc.call('transient-server', 'lookup', {}, internal)).rejects.toThrow(
+          'connector_unavailable'
+        )
+        expect(createClient).toHaveBeenCalledOnce()
+
+        await vi.advanceTimersByTimeAsync(1_000)
+
+        await expect(svc.call('transient-server', 'lookup', {}, internal)).resolves.toEqual({
+          ok: true
+        })
+        expect(createClient).toHaveBeenCalledTimes(2)
+      } finally {
+        await mcpClientManager.closeAll()
+        vi.useRealTimers()
+      }
     })
 
     it('does not contact an OAuth connector before it has tokens', async () => {

--- a/src/main/connectors/service.ts
+++ b/src/main/connectors/service.ts
@@ -103,6 +103,16 @@ const customMcpFailureCategory = (
   availability: CustomMcpFailureAvailability
 ): 'connector_unavailable' | 'connector_unauthenticated' => `connector_${availability}`
 
+const CUSTOM_MCP_RETRY_BASE_MS = 1_000
+const CUSTOM_MCP_RETRY_MAX_MS = 30_000
+
+type CustomMcpFailureState = {
+  category: 'connector_unavailable' | 'connector_unauthenticated'
+  failureCount: number
+  retryAt?: number
+  probing: boolean
+}
+
 const stableRecordEntries = (record: Record<string, string> | undefined): [string, string][] =>
   Object.entries(record ?? {}).sort(([left], [right]) => left.localeCompare(right))
 
@@ -148,11 +158,9 @@ class ConnectorGateError extends Error {
 export class ConnectorService {
   private readonly engine: ParserEngine
   // A connector that cannot authenticate or start is physically unavailable to every scope. Main
-  // enablement is only a logical preference and may be overridden by a Specialist; this state may not.
-  private readonly unavailableCustomConnectors = new Map<
-    string,
-    'connector_unavailable' | 'connector_unauthenticated'
-  >()
+  // enablement is only a logical preference and may be overridden by a Specialist; this state may
+  // not. Transient transport failures become eligible for one demand-driven probe after backoff.
+  private readonly unavailableCustomConnectors = new Map<string, CustomMcpFailureState>()
   private readonly customServerFailureEpochs = new Map<string, number>()
   private readonly permissionBroker: ConnectorPermissionBroker
   private readonly customServerGenerations = new Map<string, number>()
@@ -328,7 +336,9 @@ export class ConnectorService {
     const generation = this.assertCustomServerCurrent(custom)
     const failureEpoch = this.customServerFailureEpochs.get(custom.id) ?? 0
     const physicalFailure = this.unavailableCustomConnectors.get(custom.id)
-    if (physicalFailure) throw new ConnectorGateError(physicalFailure)
+    if (physicalFailure && !this.isCustomServerProbeDue(physicalFailure)) {
+      throw new ConnectorGateError(physicalFailure.category)
+    }
     if (!access.bypassMainEnablement && !custom.enabled) {
       throw new ConnectorGateError(
         'connector_disabled',
@@ -356,6 +366,7 @@ export class ConnectorService {
       signal
     )
     const config = toCustomMcpConfig(authorization.custom)
+    if (physicalFailure) this.claimCustomServerProbe(custom.id, physicalFailure)
 
     let tools: Array<{ name: string }>
     try {
@@ -363,7 +374,10 @@ export class ConnectorService {
         ? await this.deps.mcpClientManager.listTools(config, signal)
         : await this.deps.mcpClientManager.listTools(config)
     } catch (error) {
-      if (signal?.aborted) throw error
+      if (signal?.aborted) {
+        if (physicalFailure) this.releaseCustomServerProbe(custom.id, physicalFailure)
+        throw error
+      }
       // Never relay a transport error: custom server URLs, headers, or server-provided diagnostics
       // can contain credentials. Record only the availability category for subsequent fail-closed
       // dispatches; a successful connection clears the transient state.
@@ -371,6 +385,8 @@ export class ConnectorService {
       this.recordCustomServerFailure(custom.id, failureEpoch, availability)
       throw new ConnectorGateError(customMcpFailureCategory(availability))
     }
+
+    this.publishCustomServerRecovery(custom.id, failureEpoch)
 
     if (!tools.some((tool) => tool.name === method)) {
       throw new ConnectorGateError(
@@ -409,11 +425,7 @@ export class ConnectorService {
       const result = signal
         ? await this.deps.mcpClientManager.call(config, method, args, signal)
         : await this.deps.mcpClientManager.call(config, method, args)
-      if ((this.customServerFailureEpochs.get(custom.id) ?? 0) === failureEpoch) {
-        if (this.unavailableCustomConnectors.delete(custom.id)) {
-          this.deps.onCustomServerAvailabilityChanged?.(custom.id, undefined)
-        }
-      }
+      this.publishCustomServerRecovery(custom.id, failureEpoch)
       return result
     } catch (error) {
       if (signal?.aborted) throw error
@@ -436,8 +448,54 @@ export class ConnectorService {
     availability: CustomMcpFailureAvailability
   ): void {
     if ((this.customServerFailureEpochs.get(serverId) ?? 0) === expectedEpoch) {
-      this.unavailableCustomConnectors.set(serverId, customMcpFailureCategory(availability))
+      const category = customMcpFailureCategory(availability)
+      const previous = this.unavailableCustomConnectors.get(serverId)
+      const failureCount =
+        category === 'connector_unavailable' && previous?.category === category
+          ? previous.failureCount + 1
+          : 1
+      const retryDelay = Math.min(
+        CUSTOM_MCP_RETRY_BASE_MS * 2 ** (failureCount - 1),
+        CUSTOM_MCP_RETRY_MAX_MS
+      )
+      this.unavailableCustomConnectors.set(serverId, {
+        category,
+        failureCount,
+        ...(category === 'connector_unavailable' ? { retryAt: Date.now() + retryDelay } : {}),
+        probing: false
+      })
       this.deps.onCustomServerAvailabilityChanged?.(serverId, availability)
+    }
+  }
+
+  private isCustomServerProbeDue(failure: CustomMcpFailureState): boolean {
+    return (
+      failure.category === 'connector_unavailable' &&
+      !failure.probing &&
+      failure.retryAt !== undefined &&
+      Date.now() >= failure.retryAt
+    )
+  }
+
+  private claimCustomServerProbe(serverId: string, expected: CustomMcpFailureState): void {
+    const current = this.unavailableCustomConnectors.get(serverId)
+    if (!current) return
+    if (current !== expected || !this.isCustomServerProbeDue(current)) {
+      throw new ConnectorGateError(current.category)
+    }
+    current.probing = true
+  }
+
+  private releaseCustomServerProbe(serverId: string, expected: CustomMcpFailureState): void {
+    if (this.unavailableCustomConnectors.get(serverId) === expected) expected.probing = false
+  }
+
+  private publishCustomServerRecovery(serverId: string, expectedEpoch: number): void {
+    if (
+      (this.customServerFailureEpochs.get(serverId) ?? 0) === expectedEpoch &&
+      this.unavailableCustomConnectors.delete(serverId)
+    ) {
+      this.deps.onCustomServerAvailabilityChanged?.(serverId, undefined)
     }
   }
 


### PR DESCRIPTION
## Problem

A transient custom MCP transport failure was recorded as connector_unavailable and then treated as a permanent process-lifetime gate. Every later ConnectorService.call short-circuited before MCP discovery, so recovery depended on the user clicking Retry (or restarting the app). The MCP client manager also retained a Client whose transport had closed, so merely clearing the gate would reuse a disconnected client.

The regression test reproduced this with a first Client that raises Connection closed and a second healthy Client. Before the fix, the post-cooldown call failed at service.ts:331 without creating the second client.

## Proposed change

- Keep authentication failures explicitly recoverable through sign-in.
- For transport unavailability, allow one demand-driven probe after exponential backoff (1 second initial delay, capped at 30 seconds).
- Reject concurrent calls while that recovery probe is active.
- Discard disconnected cached MCP clients after discovery or transport-call failures so the probe establishes a fresh connection.
- Publish recovery as soon as tool discovery proves the server is reachable.

## Scope and non-goals

- No database, migration, persisted setting, or historical-data compatibility change.
- No public status/enum addition and no shared data-contract change.
- No renderer copy or interaction change; the existing Retry action remains an immediate manual recovery path.
- No background periodic polling. Idle Connectors and the separate startup Skill-discovery projection are not probed by this change.
- Structured MCP tool errors remain reachable and do not evict a healthy client.

## Acceptance criteria and validation

The checks below ran after the last material edit:

- transient failure recovery and Connector service behavior -> npm test -- src/main/connectors/service.test.ts src/main/connectors/mcp-client-manager.test.ts src/main/connectors/runtime-settings-projection.test.ts -> 89 passed
- main-process TypeScript contracts -> npm run typecheck:node -> passed
- linted source and tests -> npm run lint -> passed
- whitespace/error-marker validation -> git diff --check -> passed

The Connector area has no module ID in scripts/ci/module-impact.json, so no test:module result is claimed. Per maintainer request, the complete portable suite is left to PR CI. No renderer, persistence, migration, build, or platform-specific lane is implicated by the final diff.

## Review focus

- Whether demand-driven probing preserves fail-closed behavior during the cooldown and concurrent probe window.
- Whether client eviction is correctly limited to transport/discovery failures and excludes caller cancellation and structured tool errors.
- Whether the 1-to-30-second backoff is an appropriate operational bound.