### PR TITLE
feat(notebook): open preview when notebook becomes available

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -112,6 +112,7 @@
     "workspace_page": {
       "ownerPaths": [
         "src/renderer/src/pages/workspace/WorkspacePage.tsx",
+        "src/renderer/src/pages/workspace/notebook-preview-availability.ts",
         "src/renderer/src/pages/workspace/workspace-panel-layout.tsx",
         "src/renderer/src/pages/workspace/workspace-composer-controller.ts",
         "src/renderer/src/pages/workspace/workspace-conversation-controller.ts",

--- a/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as React from 'react'
 import type { PanelImperativeHandle, PanelSize } from 'react-resizable-panels'
+import type { NotebookSessionReference } from '../../../../shared/notebook'
 
 import {
   createInitialPreviewWorkbenchState,
@@ -263,6 +264,7 @@ const { WorkspacePage } = await import('./WorkspacePage')
 describe('WorkspacePage preview panel resize sync', () => {
   let container: HTMLDivElement
   let root: Root
+  let notebookAvailableListener: ((notebook: NotebookSessionReference) => void) | undefined
 
   beforeEach(() => {
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
@@ -280,6 +282,7 @@ describe('WorkspacePage preview panel resize sync', () => {
     workspacePageHarness.previewOnResize = undefined
     workspacePageHarness.previewPanelRef = undefined
     filePreviewDialogHarness.item = undefined
+    notebookAvailableListener = undefined
     vi.clearAllMocks()
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
       callback(0)
@@ -299,7 +302,10 @@ describe('WorkspacePage preview panel resize sync', () => {
     window.api = {
       platform: 'linux',
       notebook: {
-        onAvailable: vi.fn(() => vi.fn()),
+        onAvailable: vi.fn((listener: (notebook: NotebookSessionReference) => void) => {
+          notebookAvailableListener = listener
+          return vi.fn()
+        }),
         getReference: vi.fn(() => Promise.resolve(null))
       },
       reviewer: {
@@ -612,6 +618,36 @@ describe('WorkspacePage preview panel resize sync', () => {
     expect(container.querySelector('[data-testid="workspace-preview-toggle"]')).toBeNull()
     expect(workspacePageHarness.previewPanelDefaultSize).toBe('0%')
     expect(usePreviewWorkbenchStore.getState().panelState).toBe('collapsed')
+  })
+
+  it('opens and activates the notebook preview when its entry first becomes available', async () => {
+    await renderPage(false)
+
+    const notebook: NotebookSessionReference = {
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace/project-1',
+      notebookSessionRoot: '/notebooks/project-1/session-1',
+      dataRoot: '/notebooks/project-1/session-1/data',
+      runtimeRoot: '/notebooks/project-1/session-1/runtime',
+      runJsonPath: '/notebooks/project-1/session-1/run.json'
+    }
+
+    await act(async () => {
+      notebookAvailableListener?.(notebook)
+    })
+
+    expect(usePreviewWorkbenchStore.getState()).toMatchObject({
+      activeItemId: 'tool:session-1:notebook',
+      panelState: 'open',
+      items: [
+        expect.objectContaining({
+          id: 'tool:session-1:notebook',
+          toolKind: 'notebook',
+          notebook
+        })
+      ]
+    })
   })
 
   it('hosts a cross-Project file dialog without creating or activating a Files tab', async () => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
@@ -373,6 +373,7 @@ describe('WorkspacePage preview panel resize sync', () => {
     }
     useNavigationStore.setState({ view: 'workspace', activeProjectId: projectId })
     useSessionStore.setState({ sessions: [session], selectedSessionId: sessionId })
+    usePreviewWorkbenchStore.getState().activateProject(projectId)
   }
 
   const getPreviewToggle = (): HTMLButtonElement => {
@@ -694,6 +695,39 @@ describe('WorkspacePage preview panel resize sync', () => {
       activeItemId: undefined,
       panelState: 'collapsed',
       items: []
+    })
+  })
+
+  it('waits for the target project preview slice before opening the notebook', async () => {
+    selectSession('session-1', 'project-1')
+    await renderPage(false)
+    act(() => usePreviewWorkbenchStore.getState().activateProject('previous-project'))
+
+    const notebook: NotebookSessionReference = {
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace/project-1',
+      notebookSessionRoot: '/notebooks/project-1/session-1',
+      dataRoot: '/notebooks/project-1/session-1/data',
+      runtimeRoot: '/notebooks/project-1/session-1/runtime',
+      runJsonPath: '/notebooks/project-1/session-1/run.json'
+    }
+    await act(async () => notebookAvailableListener?.(notebook))
+
+    expect(usePreviewWorkbenchStore.getState()).toMatchObject({
+      activeProjectId: 'previous-project',
+      activeItemId: undefined,
+      panelState: 'collapsed',
+      items: []
+    })
+
+    act(() => usePreviewWorkbenchStore.getState().activateProject('project-1'))
+
+    expect(usePreviewWorkbenchStore.getState()).toMatchObject({
+      activeProjectId: 'project-1',
+      activeItemId: 'tool:session-1:notebook',
+      panelState: 'open',
+      items: [expect.objectContaining({ id: 'tool:session-1:notebook', notebook })]
     })
   })
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
@@ -12,7 +12,11 @@ import {
   usePreviewWorkbenchStore
 } from '@/stores/preview-workbench-store'
 import { useNavigationStore } from '@/stores/navigation-store'
-import { createInitialSessionState, useSessionStore } from '@/stores/session-store'
+import {
+  createInitialSessionState,
+  type ChatSession,
+  useSessionStore
+} from '@/stores/session-store'
 
 const workspacePageHarness = vi.hoisted(() => ({
   isMobile: false,
@@ -355,6 +359,22 @@ describe('WorkspacePage preview panel resize sync', () => {
     })
   }
 
+  const selectSession = (sessionId: string, projectId: string): void => {
+    const now = Date.now()
+    const session: ChatSession = {
+      id: sessionId,
+      projectId,
+      title: 'Session',
+      cwd: `/workspace/${projectId}`,
+      status: 'idle',
+      messages: [],
+      createdAt: now,
+      updatedAt: now
+    }
+    useNavigationStore.setState({ view: 'workspace', activeProjectId: projectId })
+    useSessionStore.setState({ sessions: [session], selectedSessionId: sessionId })
+  }
+
   const getPreviewToggle = (): HTMLButtonElement => {
     const toggleButton = container.querySelector<HTMLButtonElement>(
       '[data-testid="workspace-preview-toggle"]'
@@ -621,6 +641,7 @@ describe('WorkspacePage preview panel resize sync', () => {
   })
 
   it('opens and activates the notebook preview when its entry first becomes available', async () => {
+    selectSession('session-1', 'project-1')
     await renderPage(false)
 
     const notebook: NotebookSessionReference = {
@@ -647,6 +668,32 @@ describe('WorkspacePage preview panel resize sync', () => {
           notebook
         })
       ]
+    })
+  })
+
+  it.each([
+    ['another session', 'project-1', 'session-2'],
+    ['another project', 'project-2', 'session-1']
+  ])('does not open the notebook preview for %s', async (_label, projectId, sessionId) => {
+    selectSession('session-1', 'project-1')
+    await renderPage(false)
+
+    await act(async () => {
+      notebookAvailableListener?.({
+        projectId,
+        sessionId,
+        workspaceCwd: `/workspace/${projectId}`,
+        notebookSessionRoot: `/notebooks/${projectId}/${sessionId}`,
+        dataRoot: `/notebooks/${projectId}/${sessionId}/data`,
+        runtimeRoot: `/notebooks/${projectId}/${sessionId}/runtime`,
+        runJsonPath: `/notebooks/${projectId}/${sessionId}/run.json`
+      })
+    })
+
+    expect(usePreviewWorkbenchStore.getState()).toMatchObject({
+      activeItemId: undefined,
+      panelState: 'collapsed',
+      items: []
     })
   })
 

--- a/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
@@ -697,6 +697,57 @@ describe('WorkspacePage preview panel resize sync', () => {
     })
   })
 
+  it('refreshes an existing notebook entry without reopening or activating it', async () => {
+    selectSession('session-1', 'project-1')
+    await renderPage(false)
+
+    const notebook: NotebookSessionReference = {
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      workspaceCwd: '/workspace/project-1',
+      notebookSessionRoot: '/notebooks/project-1/session-1/root',
+      dataRoot: '/notebooks/project-1/session-1/root/data',
+      runtimeRoot: '/notebooks/project-1/session-1/root/runtime',
+      runJsonPath: '/notebooks/project-1/session-1/root/run.json'
+    }
+    await act(async () => notebookAvailableListener?.(notebook))
+
+    const fileItem: PreviewFileItem = {
+      id: 'file:session-1:/workspace/project-1/report.md',
+      sessionId: 'session-1',
+      type: 'file',
+      title: 'report.md',
+      path: '/workspace/project-1/report.md',
+      format: 'markdown',
+      name: 'report.md'
+    }
+    act(() => {
+      usePreviewWorkbenchStore.getState().upsertAndActivateItem(fileItem)
+      usePreviewWorkbenchStore.getState().collapsePanel()
+    })
+
+    const delegatedNotebook = {
+      ...notebook,
+      notebookSessionRoot: '/notebooks/project-1/session-1/delegated',
+      dataRoot: '/notebooks/project-1/session-1/delegated/data',
+      runtimeRoot: '/notebooks/project-1/session-1/delegated/runtime',
+      runJsonPath: '/notebooks/project-1/session-1/delegated/run.json'
+    }
+    await act(async () => notebookAvailableListener?.(delegatedNotebook))
+
+    expect(usePreviewWorkbenchStore.getState()).toMatchObject({
+      activeItemId: fileItem.id,
+      panelState: 'collapsed',
+      items: [
+        expect.objectContaining({
+          id: 'tool:session-1:notebook',
+          notebook: delegatedNotebook
+        }),
+        expect.objectContaining({ id: fileItem.id })
+      ]
+    })
+  })
+
   it('hosts a cross-Project file dialog without creating or activating a Files tab', async () => {
     const fileDialogItem = {
       id: 'artifact-b',

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -33,6 +33,7 @@ import {
   clearSuppressNextAutoReview
 } from '@/lib/acp/workspace-events'
 import { resolveEffectiveSpecialistSkills } from '../../../../shared/specialist'
+import { revealNotebookWhenProjectActive } from './notebook-preview-availability'
 import { isCodexSubscriptionProvider } from '../../../../shared/settings'
 import { hasCurrentRunningDelegatedAttempt } from '../../../../shared/delegated-work-projection'
 import {
@@ -663,21 +664,20 @@ const WorkspacePage = ({
 
   // The first agent-side notebook call reveals the new notebook entry and its preview together.
   useEffect(() => {
+    let cancelPendingOpen = (): void => undefined
     const removeNotebookAvailableListener = window.api.notebook.onAvailable((notebook) => {
       setNotebookReferences((references) => ({
         ...references,
         [notebook.sessionId]: notebook
       }))
       if (notebook.projectId !== scopedProjectId || notebook.sessionId !== activeSessionId) return
-      const preview = usePreviewWorkbenchStore.getState()
-      const previewItem = createNotebookPreviewItem(notebook)
-      preview.items.some(({ id }) => id === previewItem.id)
-        ? preview.upsertItem(previewItem)
-        : preview.upsertAndActivateItem(previewItem)
+      cancelPendingOpen()
+      cancelPendingOpen = revealNotebookWhenProjectActive(notebook)
     })
 
     return () => {
       removeNotebookAvailableListener()
+      cancelPendingOpen()
     }
   }, [activeSessionId, scopedProjectId])
 
@@ -904,7 +904,7 @@ const WorkspacePage = ({
     })()
   }
 
-  // Opens the right preview on demand instead of stealing focus when the agent first uses notebook.
+  // Opens the right preview when the user explicitly selects the notebook entry.
   const openNotebookPreview = (notebook: NotebookSessionReference): void => {
     usePreviewWorkbenchStore.getState().upsertAndActivateItem(createNotebookPreviewItem(notebook))
   }

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -671,13 +671,14 @@ const WorkspacePage = ({
         ...references,
         [notebook.sessionId]: notebook
       }))
+      if (notebook.projectId !== scopedProjectId || notebook.sessionId !== activeSessionId) return
       upsertAndActivatePreviewItem(createNotebookPreviewItem(notebook))
     })
 
     return () => {
       removeNotebookAvailableListener()
     }
-  }, [upsertAndActivatePreviewItem])
+  }, [activeSessionId, scopedProjectId, upsertAndActivatePreviewItem])
 
   // Subscribe to reviewer lifecycle updates so the card and Reviewing indicator stay live.
   useEffect(() => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -135,7 +135,6 @@ const WorkspacePage = ({
   const activePreviewItemId = usePreviewWorkbenchStore((state) => state.activeItemId)
   const fileDialogItem = usePreviewWorkbenchStore((state) => state.fileDialogItem)
   const closeFileDialog = usePreviewWorkbenchStore((state) => state.closeFileDialog)
-  const upsertPreviewItem = usePreviewWorkbenchStore((state) => state.upsertItem)
   const upsertAndActivatePreviewItem = usePreviewWorkbenchStore(
     (state) => state.upsertAndActivateItem
   )
@@ -665,20 +664,20 @@ const WorkspacePage = ({
     if (pendingCustomizePrefill !== undefined) consumeCustomizePrefill()
   }, [pendingCustomizePrefill, consumeCustomizePrefill])
 
-  // The first agent-side notebook call promotes a notebook entry into the composer status bar.
+  // The first agent-side notebook call reveals the new notebook entry and its preview together.
   useEffect(() => {
     const removeNotebookAvailableListener = window.api.notebook.onAvailable((notebook) => {
       setNotebookReferences((references) => ({
         ...references,
         [notebook.sessionId]: notebook
       }))
-      upsertPreviewItem(createNotebookPreviewItem(notebook))
+      upsertAndActivatePreviewItem(createNotebookPreviewItem(notebook))
     })
 
     return () => {
       removeNotebookAvailableListener()
     }
-  }, [upsertPreviewItem])
+  }, [upsertAndActivatePreviewItem])
 
   // Subscribe to reviewer lifecycle updates so the card and Reviewing indicator stay live.
   useEffect(() => {

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -135,9 +135,6 @@ const WorkspacePage = ({
   const activePreviewItemId = usePreviewWorkbenchStore((state) => state.activeItemId)
   const fileDialogItem = usePreviewWorkbenchStore((state) => state.fileDialogItem)
   const closeFileDialog = usePreviewWorkbenchStore((state) => state.closeFileDialog)
-  const upsertAndActivatePreviewItem = usePreviewWorkbenchStore(
-    (state) => state.upsertAndActivateItem
-  )
   const togglePreviewPanel = usePreviewWorkbenchStore((state) => state.togglePanel)
   const projectFormDialog = useProjectFormDialog()
   // Drives the sidebar project menu's Download artifacts… disabled state. An incomplete index
@@ -672,13 +669,17 @@ const WorkspacePage = ({
         [notebook.sessionId]: notebook
       }))
       if (notebook.projectId !== scopedProjectId || notebook.sessionId !== activeSessionId) return
-      upsertAndActivatePreviewItem(createNotebookPreviewItem(notebook))
+      const preview = usePreviewWorkbenchStore.getState()
+      const previewItem = createNotebookPreviewItem(notebook)
+      preview.items.some(({ id }) => id === previewItem.id)
+        ? preview.upsertItem(previewItem)
+        : preview.upsertAndActivateItem(previewItem)
     })
 
     return () => {
       removeNotebookAvailableListener()
     }
-  }, [activeSessionId, scopedProjectId, upsertAndActivatePreviewItem])
+  }, [activeSessionId, scopedProjectId])
 
   // Subscribe to reviewer lifecycle updates so the card and Reviewing indicator stay live.
   useEffect(() => {
@@ -905,14 +906,14 @@ const WorkspacePage = ({
 
   // Opens the right preview on demand instead of stealing focus when the agent first uses notebook.
   const openNotebookPreview = (notebook: NotebookSessionReference): void => {
-    upsertAndActivatePreviewItem(createNotebookPreviewItem(notebook))
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createNotebookPreviewItem(notebook))
   }
 
   // Opens the project file library as a stable preview workbench tool tab.
   const openFilesPreview = (): void => {
     if (!isSessionPersistenceReady) return
 
-    upsertAndActivatePreviewItem(createProjectFilesPreviewItem())
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createProjectFilesPreviewItem())
   }
 
   return (

--- a/src/renderer/src/pages/workspace/notebook-preview-availability.ts
+++ b/src/renderer/src/pages/workspace/notebook-preview-availability.ts
@@ -1,0 +1,32 @@
+import type { NotebookSessionReference } from '../../../../shared/notebook'
+import {
+  createNotebookPreviewItem,
+  usePreviewWorkbenchStore
+} from '@/stores/preview-workbench-store'
+
+// Waits for preview persistence to activate the notebook's project before touching its slice.
+export const revealNotebookWhenProjectActive = (
+  notebook: NotebookSessionReference
+): (() => void) => {
+  let cancelled = false
+  let unsubscribe = (): void => undefined
+  const reveal = (): void => {
+    if (cancelled) return
+    const preview = usePreviewWorkbenchStore.getState()
+    if (preview.activeProjectId !== notebook.projectId) return
+
+    cancelled = true
+    unsubscribe()
+    const previewItem = createNotebookPreviewItem(notebook)
+    preview.items.some(({ id }) => id === previewItem.id)
+      ? preview.upsertItem(previewItem)
+      : preview.upsertAndActivateItem(previewItem)
+  }
+
+  unsubscribe = usePreviewWorkbenchStore.subscribe(reveal)
+  reveal()
+  return () => {
+    cancelled = true
+    unsubscribe()
+  }
+}


### PR DESCRIPTION
## Problem

When an Agent first makes the Notebook available, the Notebook entry appears in the composer but the PreviewPanel stays collapsed. On first use this can hide the Notebook runtime installation progress from users.

## Proposed change

Use the existing preview workbench open-and-activate action when `notebook.onAvailable` creates the first Notebook tab for the currently visible Project and Session. The new tab is selected and the PreviewPanel opens with it.

Background Session or Project availability events still update the in-memory Notebook reference but do not open or insert a tab into the active preview workbench. Later lane-level availability events for the same Session passively refresh the existing Notebook tab without reopening the panel or changing the active tab.

If Project navigation has committed but preview persistence is still restoring the target Project slice, defer the open until that slice becomes active. This prevents the Notebook tab from being written into the previous Project slice or being replaced by restoration.

## Scope and non-goals

- Only creation of the first Notebook tab for the visible Session opens the panel.
- Later Agent Notebook executions or Notebook lane availability events do not reopen a panel the user collapsed.
- No renderer/main-process contract changes, new store state values, translations, or dependencies.
- No historical-data compatibility work is required.
- No enum values are added.
- No persistence behavior or persisted format changes.

## Acceptance criteria and validation

All listed checks ran after the last material code edit.

- First visible Notebook tab opens and activates its preview; background Project/Session, repeated lane, and preview-restoration race cases stay non-disruptive -> `npm test -- --run src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx` -> passed, 34 tests
- WorkspacePage completion gate -> `npm test -- --run src/renderer/src/pages/workspace/workspace-page.architecture.test.ts` -> passed, 8 tests
- WorkspacePage owner, contract, and representative consumer coverage -> `npm run test:affected -- --base origin/main --head HEAD` -> passed, 25 files / 465 tests
- Renderer TypeScript surface -> `npm run typecheck:web` -> passed
- Source lint -> `npm run lint` -> passed

The final affected-test plan selected `workspace_page` with the `renderer_state` overlay. Platform lanes were excluded locally because this is a platform-neutral renderer event/store transition with no process, path, or packaging changes. Per maintainer direction, module-scoped checks are the local validation target and PR CI is the final authority.

One intermediate affected-test invocation fell back to the full suite because the new owner file was not yet mapped. It failed in the sandbox on tests that bind `127.0.0.1` (`EPERM`), with no change-related failure identified. The owner is now mapped in `module-impact.json`, and the final affected run stayed module-scoped and passed.

Uncovered local risk: the complete first-use runtime installation journey was not exercised against a live Notebook runtime; the renderer reaction to the production availability event is covered by the interaction test.

## Review focus

Please verify that expansion is scoped to creation of the first Notebook tab for the visible Project and Session, waits for the target preview slice, repeated lane events remain passive, and later Notebook changes remain non-disruptive.
