### PR TITLE
perf(workspace-runtime): batch live non-text event drain

### DIFF
--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -32,6 +32,7 @@ import type { PermissionGrantRegistry } from '../permission-grants/registry'
 import { getProjectDbClient } from '../projects/prisma-client'
 import { ProjectRepository } from '../projects/repository'
 import { broadcastToRenderers } from '../renderer-broadcast'
+import { createAcpRuntimeEventBroadcastCoalescer } from './runtime-event-broadcast-coalescer'
 import type { AcpSettingsCapabilities } from '../settings/service-capabilities'
 import {
   buildSpecialistIdentityAppend,
@@ -198,6 +199,9 @@ const createAcpRuntime = ({
   const runtimeCoordinatorRef: { current?: AcpRuntimeCoordinator } = {}
   // One lazily-shared repository for Agent Context lookups; getProjectDbClient caches the client.
   const projectRepository = new ProjectRepository(() => getProjectDbClient(resolveStorageRoot()))
+  const eventBroadcast = createAcpRuntimeEventBroadcastCoalescer({
+    publish: (events) => broadcastToRenderers('acp:event', events)
+  })
   const callbacks: AcpRuntimeCallbacks = runtimeCallbacks ?? {
     onStateChanged: (state: AcpStateSnapshot) => broadcastToRenderers('acp:state', state),
     onEvent: (event: AcpRuntimeEvent) => {
@@ -205,7 +209,7 @@ const createAcpRuntime = ({
         ? runtimeCoordinatorRef.current?.liveSessionProjectId(event.sessionId)
         : undefined
       if (event.attribution && projectId) onTrustedMessageAttribution?.(projectId, event)
-      broadcastToRenderers('acp:event', event)
+      eventBroadcast.enqueue(event)
       // Fire-and-forget: a notification hiccup must never stall the renderer event stream.
       if (taskNotifications) {
         runTaskNotificationInBackground(

--- a/src/main/acp/runtime-event-broadcast-coalescer.test.ts
+++ b/src/main/acp/runtime-event-broadcast-coalescer.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AcpRuntimeEvent } from '../../shared/acp'
+import {
+  EVENT_BROADCAST_INTERVAL_MS,
+  MAX_COALESCED_BROADCAST_EVENTS,
+  createAcpRuntimeEventBroadcastCoalescer
+} from './runtime-event-broadcast-coalescer'
+
+const thought = (id: string, text: string): AcpRuntimeEvent => ({
+  id,
+  timestamp: 1,
+  kind: 'thought',
+  level: 'info',
+  role: 'assistant',
+  sessionId: 'session-1',
+  text
+})
+
+describe('AcpRuntimeEventBroadcastCoalescer', () => {
+  it('coalesces streamed assistant thoughts into one IPC batch', () => {
+    vi.useFakeTimers()
+    try {
+      const publish = vi.fn()
+      const coalescer = createAcpRuntimeEventBroadcastCoalescer({ publish })
+
+      coalescer.enqueue(thought('thought-1', 'one'))
+      coalescer.enqueue(thought('thought-2', 'two'))
+      expect(publish).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(EVENT_BROADCAST_INTERVAL_MS - 1)
+      expect(publish).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(1)
+      expect(publish).toHaveBeenCalledOnce()
+      expect(publish).toHaveBeenCalledWith([
+        thought('thought-1', 'one'),
+        thought('thought-2', 'two')
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('flushes the pending prefix together with a terminal stop', () => {
+    const publish = vi.fn()
+    const coalescer = createAcpRuntimeEventBroadcastCoalescer({
+      publish,
+      schedule: () => () => undefined
+    })
+    const stop: AcpRuntimeEvent = {
+      id: 'stop-1',
+      timestamp: 2,
+      kind: 'stop',
+      level: 'info',
+      sessionId: 'session-1'
+    }
+
+    coalescer.enqueue(thought('thought-1', 'one'))
+    coalescer.enqueue(stop)
+
+    expect(publish).toHaveBeenCalledOnce()
+    expect(publish.mock.calls[0]?.[0]).toEqual([thought('thought-1', 'one'), stop])
+  })
+
+  it('publishes a burst before retained history can evict an unaccepted prefix', () => {
+    const publish = vi.fn()
+    const coalescer = createAcpRuntimeEventBroadcastCoalescer({
+      publish,
+      schedule: () => () => undefined
+    })
+    const events = Array.from({ length: MAX_COALESCED_BROADCAST_EVENTS }, (_, index) =>
+      thought(`thought-${index + 1}`, String(index))
+    )
+
+    for (const event of events) coalescer.enqueue(event)
+
+    expect(publish).toHaveBeenCalledOnce()
+    expect(publish.mock.calls[0]?.[0]).toHaveLength(MAX_COALESCED_BROADCAST_EVENTS)
+  })
+})

--- a/src/main/acp/runtime-event-broadcast-coalescer.ts
+++ b/src/main/acp/runtime-event-broadcast-coalescer.ts
@@ -1,0 +1,102 @@
+import { MAX_ACP_RUNTIME_EVENTS, type AcpRuntimeEvent } from '../../shared/acp'
+
+const EVENT_BROADCAST_INTERVAL_MS = 33
+// A fast provider can emit more than one retained window before the 33 ms timer runs. Publish
+// midway through that window so every prefix chunk reaches subscribers before bounded history can
+// evict it, while ordinary streams still receive the same frame-level coalescing.
+const MAX_COALESCED_BROADCAST_EVENTS = Math.floor(MAX_ACP_RUNTIME_EVENTS / 2)
+
+type AcpRuntimeEventBroadcastCoalescerOptions = Readonly<{
+  publish: (events: readonly AcpRuntimeEvent[]) => void
+  schedule?: (flush: () => void) => () => void
+}>
+
+const scheduleBroadcast = (flush: () => void): (() => void) => {
+  const timer = setTimeout(flush, EVENT_BROADCAST_INTERVAL_MS)
+  return () => clearTimeout(timer)
+}
+
+const isCoalescibleAssistantStreamEvent = (event: AcpRuntimeEvent): boolean =>
+  (event.kind === 'message' || event.kind === 'thought') &&
+  event.role === 'assistant' &&
+  typeof event.text === 'string' &&
+  event.text.length > 0 &&
+  !event.image
+
+// Owns one IPC batch for incremental renderer events. Stop, error, permission, and tool
+// start/end flush immediately so the UI is not delayed; streamed text and in-progress tool
+// content share the 33 ms presentation cadence.
+const createAcpRuntimeEventBroadcastCoalescer = (
+  options: AcpRuntimeEventBroadcastCoalescerOptions
+): {
+  enqueue: (event: AcpRuntimeEvent) => void
+  flush: () => void
+} => {
+  const pending: AcpRuntimeEvent[] = []
+  const activeToolCallIdsBySession = new Map<string | undefined, Set<string>>()
+  let cancelScheduled: (() => void) | undefined
+
+  const isCoalescible = (event: AcpRuntimeEvent): boolean => {
+    if (isCoalescibleAssistantStreamEvent(event)) return true
+    if (event.kind === 'stop' || event.kind === 'error') {
+      activeToolCallIdsBySession.delete(event.sessionId)
+      return false
+    }
+    if (event.kind !== 'tool' || !event.toolCallId) return false
+
+    const activeToolCallIds = activeToolCallIdsBySession.get(event.sessionId)
+    const wasActive = activeToolCallIds?.has(event.toolCallId) === true
+    if (event.status === 'completed' || event.status === 'failed') {
+      activeToolCallIds?.delete(event.toolCallId)
+      if (activeToolCallIds?.size === 0) {
+        activeToolCallIdsBySession.delete(event.sessionId)
+      }
+      return false
+    }
+    if (activeToolCallIds) {
+      activeToolCallIds.add(event.toolCallId)
+    } else {
+      activeToolCallIdsBySession.set(event.sessionId, new Set([event.toolCallId]))
+    }
+
+    return (
+      wasActive &&
+      (event.toolContent !== undefined ||
+        event.terminalOutput !== undefined ||
+        event.rawOutput !== undefined)
+    )
+  }
+
+  const flush = (): void => {
+    cancelScheduled?.()
+    cancelScheduled = undefined
+    if (pending.length === 0) return
+    const events = pending.splice(0, pending.length)
+    options.publish(events)
+  }
+
+  const schedule = (): void => {
+    if (cancelScheduled) return
+    const scheduleFlush = options.schedule ?? scheduleBroadcast
+    cancelScheduled = scheduleFlush(flush)
+  }
+
+  return {
+    enqueue(event) {
+      pending.push(event)
+      if (!isCoalescible(event) || pending.length >= MAX_COALESCED_BROADCAST_EVENTS) {
+        flush()
+        return
+      }
+      schedule()
+    },
+    flush
+  }
+}
+
+export {
+  EVENT_BROADCAST_INTERVAL_MS,
+  MAX_COALESCED_BROADCAST_EVENTS,
+  createAcpRuntimeEventBroadcastCoalescer
+}
+export type { AcpRuntimeEventBroadcastCoalescerOptions }

--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -585,32 +585,49 @@ describe('installAppLifecycle', () => {
     expect(windows[0].focused).toBe(true)
   })
 
-  it.each(['renderer-failed', 'send-failed', 'timeout'] as const)(
-    'keeps the app open when the renderer persistence preflight returns %s',
+  it('keeps the app open when the renderer persistence preflight reports a failed flush', async () => {
+    const flushSessionPersistence = vi.fn(async () => 'renderer-failed' as const)
+    const {
+      app,
+      closeOpts,
+      prepareForQuit,
+      abortQuitPreparation,
+      shutdownBackends,
+      tray,
+      windows
+    } = setup({ flushSessionPersistence })
+    closeOpts[0].requestQuit()
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(flushSessionPersistence).toHaveBeenCalledOnce()
+    expect(prepareForQuit).not.toHaveBeenCalled()
+    expect(abortQuitPreparation).toHaveBeenCalledOnce()
+    expect(shutdownBackends).not.toHaveBeenCalled()
+    expect(tray?.destroy).not.toHaveBeenCalled()
+    expect(app.exit).not.toHaveBeenCalled()
+    expect(windows[0].visible).toBe(true)
+    expect(windows[0].focused).toBe(true)
+  })
+
+  it.each(['send-failed', 'timeout'] as const)(
+    'continues quit when the renderer persistence preflight returns %s',
     async (outcome) => {
       const flushSessionPersistence = vi.fn(async () => outcome)
-      const {
-        app,
-        closeOpts,
-        prepareForQuit,
-        abortQuitPreparation,
-        shutdownBackends,
-        tray,
-        windows
-      } = setup({ flushSessionPersistence })
+      const { app, closeOpts, prepareForQuit, abortQuitPreparation, shutdownBackends } = setup({
+        flushSessionPersistence
+      })
       closeOpts[0].requestQuit()
 
       app.emit('before-quit')
       await flush()
 
-      expect(flushSessionPersistence).toHaveBeenCalledOnce()
-      expect(prepareForQuit).not.toHaveBeenCalled()
-      expect(abortQuitPreparation).toHaveBeenCalledOnce()
-      expect(shutdownBackends).not.toHaveBeenCalled()
-      expect(tray?.destroy).not.toHaveBeenCalled()
-      expect(app.exit).not.toHaveBeenCalled()
-      expect(windows[0].visible).toBe(true)
-      expect(windows[0].focused).toBe(true)
+      expect(flushSessionPersistence).toHaveBeenCalledTimes(2)
+      expect(prepareForQuit).toHaveBeenCalledOnce()
+      expect(abortQuitPreparation).not.toHaveBeenCalled()
+      expect(shutdownBackends).toHaveBeenCalledOnce()
+      expect(app.exit).toHaveBeenCalledWith(0)
     }
   )
 
@@ -643,22 +660,45 @@ describe('installAppLifecycle', () => {
     expect(windows[0].focused).toBe(true)
   })
 
-  it.each(['renderer-failed', 'send-failed', 'timeout'] as const)(
-    'keeps the app open when the terminal renderer flush returns %s',
+  it('keeps the app open when the terminal renderer flush reports a failed write', async () => {
+    const flushSessionPersistence = vi
+      .fn()
+      .mockResolvedValueOnce('completed' as const)
+      .mockResolvedValueOnce('renderer-failed' as const)
+    const {
+      app,
+      closeOpts,
+      prepareForQuit,
+      abortQuitPreparation,
+      shutdownBackends,
+      tray,
+      windows
+    } = setup({ flushSessionPersistence })
+    closeOpts[0].requestQuit()
+
+    app.emit('before-quit')
+    await flush()
+
+    expect(flushSessionPersistence).toHaveBeenCalledTimes(2)
+    expect(prepareForQuit).toHaveBeenCalledOnce()
+    expect(abortQuitPreparation).toHaveBeenCalledOnce()
+    expect(shutdownBackends).not.toHaveBeenCalled()
+    expect(tray?.destroy).not.toHaveBeenCalled()
+    expect(app.exit).not.toHaveBeenCalled()
+    expect(windows[0].visible).toBe(true)
+    expect(windows[0].focused).toBe(true)
+  })
+
+  it.each(['send-failed', 'timeout'] as const)(
+    'continues quit when the terminal renderer flush returns %s',
     async (outcome) => {
       const flushSessionPersistence = vi
         .fn()
         .mockResolvedValueOnce('completed' as const)
         .mockResolvedValueOnce(outcome)
-      const {
-        app,
-        closeOpts,
-        prepareForQuit,
-        abortQuitPreparation,
-        shutdownBackends,
-        tray,
-        windows
-      } = setup({ flushSessionPersistence })
+      const { app, closeOpts, prepareForQuit, abortQuitPreparation, shutdownBackends } = setup({
+        flushSessionPersistence
+      })
       closeOpts[0].requestQuit()
 
       app.emit('before-quit')
@@ -666,12 +706,9 @@ describe('installAppLifecycle', () => {
 
       expect(flushSessionPersistence).toHaveBeenCalledTimes(2)
       expect(prepareForQuit).toHaveBeenCalledOnce()
-      expect(abortQuitPreparation).toHaveBeenCalledOnce()
-      expect(shutdownBackends).not.toHaveBeenCalled()
-      expect(tray?.destroy).not.toHaveBeenCalled()
-      expect(app.exit).not.toHaveBeenCalled()
-      expect(windows[0].visible).toBe(true)
-      expect(windows[0].focused).toBe(true)
+      expect(abortQuitPreparation).not.toHaveBeenCalled()
+      expect(shutdownBackends).toHaveBeenCalledOnce()
+      expect(app.exit).toHaveBeenCalledWith(0)
     }
   )
 

--- a/src/main/application-event-flow.test.ts
+++ b/src/main/application-event-flow.test.ts
@@ -14,7 +14,7 @@ import { ApplicationEventHub } from './application-events'
 import { broadcastToRenderers, installRendererBroadcastEventHub } from './renderer-broadcast'
 import {
   projectPublicTaskEvent,
-  projectTaskRuntimeEvent,
+  projectTaskRuntimeEvents,
   projectWebRendererEvent
 } from './web-service/application-event-projections'
 
@@ -54,21 +54,23 @@ describe('application event flow', () => {
     windows.push({
       isDestroyed: () => false,
       webContents: {
-        send: vi.fn((_channel, payload: AcpRuntimeEvent) => {
-          order.push(`electron:${payload.kind}`)
+        send: vi.fn((_channel, payload: readonly AcpRuntimeEvent[]) => {
+          order.push(`electron:${payload[0]?.kind}`)
         })
       }
     })
     const hub = new ApplicationEventHub()
     const uninstall = installRendererBroadcastEventHub(hub)
     const removeTask = hub.subscribe((event) => {
-      const projection = projectTaskRuntimeEvent(event)
-      if (projection) order.push(`task:${projection.kind}`)
+      for (const projection of projectTaskRuntimeEvents(event)) {
+        order.push(`task:${projection.kind}`)
+      }
     })
     const removeWeb = hub.subscribe((event) => {
       const rendererProjection = projectWebRendererEvent(event)
       if (rendererProjection) {
-        order.push(`web:${(rendererProjection.payload as AcpRuntimeEvent).kind}`)
+        const batch = rendererProjection.payload as readonly AcpRuntimeEvent[]
+        order.push(`web:${batch[0]?.kind}`)
       }
       const publicProjection = projectPublicTaskEvent(event)
       if (publicProjection?.type === 'run.event') {
@@ -76,7 +78,7 @@ describe('application event flow', () => {
       }
     })
 
-    for (const payload of payloads) broadcastToRenderers('acp:event', payload)
+    for (const payload of payloads) broadcastToRenderers('acp:event', [payload])
 
     expect(order).toEqual([
       'electron:stop',
@@ -88,8 +90,8 @@ describe('application event flow', () => {
       'web:error',
       'public:error'
     ])
-    expect(windows[0].webContents.send).toHaveBeenNthCalledWith(1, 'acp:event', payloads[0])
-    expect(windows[0].webContents.send).toHaveBeenNthCalledWith(2, 'acp:event', payloads[1])
+    expect(windows[0].webContents.send).toHaveBeenNthCalledWith(1, 'acp:event', [payloads[0]])
+    expect(windows[0].webContents.send).toHaveBeenNthCalledWith(2, 'acp:event', [payloads[1]])
 
     removeWeb()
     removeTask()

--- a/src/main/application-events.test.ts
+++ b/src/main/application-events.test.ts
@@ -11,7 +11,7 @@ import {
 
 describe('ApplicationEventHub', () => {
   it('binds known channels to their payload types', () => {
-    expectTypeOf<ApplicationEventMap['acp:event']>().toEqualTypeOf<AcpRuntimeEvent>()
+    expectTypeOf<ApplicationEventMap['acp:event']>().toEqualTypeOf<readonly AcpRuntimeEvent[]>()
     expectTypeOf<
       ApplicationEventMap['acp:agent-runtime-update']
     >().toEqualTypeOf<AcpAgentRuntimeUpdate>()
@@ -54,11 +54,11 @@ describe('ApplicationEventHub', () => {
       level: 'info',
       sessionId: 'session-1'
     }
-    hub.publish('acp:event', event)
+    hub.publish('acp:event', [event])
 
     expect(deliveries).toEqual(['first:acp:event', 'second:acp:event'])
-    expect(first).toHaveBeenCalledWith({ channel: 'acp:event', payload: event })
-    expect(second).toHaveBeenCalledWith({ channel: 'acp:event', payload: event })
+    expect(first).toHaveBeenCalledWith({ channel: 'acp:event', payload: [event] })
+    expect(second).toHaveBeenCalledWith({ channel: 'acp:event', payload: [event] })
   })
 
   it('preserves live Set cancellation and failure propagation semantics', () => {

--- a/src/main/application-events.ts
+++ b/src/main/application-events.ts
@@ -40,7 +40,7 @@ import type { TagsChangedEvent } from '../shared/tags'
 // them deliberately.
 export type ApplicationEventMap = {
   'acp:state': AcpStateSnapshot
-  'acp:event': AcpRuntimeEvent
+  'acp:event': readonly AcpRuntimeEvent[]
   'acp:agent-runtime-update': AcpAgentRuntimeUpdate
   'acp:permission-request': AcpPermissionRequest
   'side-chat:event': SideChatRuntimeEvent

--- a/src/main/application-runtime.test.ts
+++ b/src/main/application-runtime.test.ts
@@ -245,18 +245,20 @@ describe('application runtime composition', () => {
     const runtime = await composeApplicationRuntime(async (modules) => {
       const events = await modules.add((installedEvents) => {
         emitTerminalEvent = () =>
-          installedEvents.publish('acp:event', {
-            id: 'event-1',
-            timestamp: 100,
-            kind: 'stop',
-            level: 'info',
-            sessionId: 'session-1',
-            turnUsage: { inputTokens: 3, cacheTokens: 2, outputTokens: 1 }
-          })
+          installedEvents.publish('acp:event', [
+            {
+              id: 'event-1',
+              timestamp: 100,
+              kind: 'stop',
+              level: 'info',
+              sessionId: 'session-1',
+              turnUsage: { inputTokens: 3, cacheTokens: 2, outputTokens: 1 }
+            }
+          ])
         return () => order.push('uninstall:application-events')
       }, createApplicationEventModule)
       events.subscribe((event) => {
-        if (event.channel === 'acp:event') order.push(`event:${event.payload.kind}`)
+        if (event.channel === 'acp:event') order.push(`event:${event.payload[0]?.kind}`)
       })
       await modules.add(undefined, () => ({
         capability: undefined,

--- a/src/main/session-persistence/renderer-flush.test.ts
+++ b/src/main/session-persistence/renderer-flush.test.ts
@@ -140,14 +140,11 @@ describe('requestRendererSessionPersistenceFlush', () => {
 })
 
 describe('rendererSessionPersistenceFlushBlocksShutdown', () => {
-  it.each(['conflict', 'renderer-failed', 'send-failed', 'timeout'] as const)(
-    'blocks shutdown for %s',
-    (outcome) => {
-      expect(rendererSessionPersistenceFlushBlocksShutdown(outcome)).toBe(true)
-    }
-  )
+  it.each(['conflict', 'renderer-failed'] as const)('blocks shutdown for %s', (outcome) => {
+    expect(rendererSessionPersistenceFlushBlocksShutdown(outcome)).toBe(true)
+  })
 
-  it.each(['completed', 'unavailable', 'renderer-gone'] as const)(
+  it.each(['completed', 'unavailable', 'renderer-gone', 'send-failed', 'timeout'] as const)(
     'allows shutdown for %s',
     (outcome) => {
       expect(rendererSessionPersistenceFlushBlocksShutdown(outcome)).toBe(false)

--- a/src/main/session-persistence/renderer-flush.ts
+++ b/src/main/session-persistence/renderer-flush.ts
@@ -31,11 +31,7 @@ export type RendererSessionPersistenceFlushOutcome =
 
 export const rendererSessionPersistenceFlushBlocksShutdown = (
   outcome: RendererSessionPersistenceFlushOutcome
-): boolean =>
-  outcome === 'conflict' ||
-  outcome === 'renderer-failed' ||
-  outcome === 'send-failed' ||
-  outcome === 'timeout'
+): boolean => outcome === 'conflict' || outcome === 'renderer-failed'
 
 export const requestRendererSessionPersistenceFlush = async (
   deps: RendererSessionPersistenceFlushDeps

--- a/src/main/web-service/application-event-projections.test.ts
+++ b/src/main/web-service/application-event-projections.test.ts
@@ -45,13 +45,13 @@ describe('application event projections', () => {
       },
       raw: { providerSessionId: 'non-uuid-session' }
     }
-    const event: ApplicationEvent<'acp:event'> = { channel: 'acp:event', payload }
+    const event: ApplicationEvent<'acp:event'> = { channel: 'acp:event', payload: [payload] }
 
     expect(projectTaskRuntimeEvent(event)).toBe(payload)
     expect(projectWebRendererEvent(event)).toEqual({
       protocolVersion: 1,
       channel: 'acp:event',
-      payload
+      payload: [payload]
     })
     expect(projectPublicTaskEvent(event)).toEqual({ type: 'run.event', data: payload })
   })

--- a/src/main/web-service/application-event-projections.ts
+++ b/src/main/web-service/application-event-projections.ts
@@ -1,3 +1,4 @@
+import type { AcpRuntimeEvent } from '../../shared/acp'
 import { WEB_RPC_PROTOCOL_VERSION, isWebRpcEventChannel } from '../../shared/web-rpc-contract'
 import type { TaskRunProgressEvent } from '../../shared/task-api'
 import type { ApplicationEvent } from '../application-events'
@@ -9,7 +10,7 @@ type WebRendererEvent = {
 }
 
 type PublicTaskEvent =
-  | { type: 'run.event'; data: Extract<ApplicationEvent, { channel: 'acp:event' }>['payload'] }
+  | { type: 'run.event'; data: AcpRuntimeEvent }
   | {
       type: 'permission.requested'
       data: Extract<ApplicationEvent, { channel: 'acp:permission-request' }>['payload']
@@ -25,28 +26,36 @@ const projectWebRendererEvent = (event: ApplicationEvent): WebRendererEvent | un
       }
     : undefined
 
-const projectPublicTaskEvent = (event: ApplicationEvent): PublicTaskEvent | undefined => {
-  if (event.channel === 'acp:event') return { type: 'run.event', data: event.payload }
-  if (event.channel === 'acp:permission-request') {
-    return { type: 'permission.requested', data: event.payload }
+const projectPublicTaskEvents = (event: ApplicationEvent): PublicTaskEvent[] => {
+  if (event.channel === 'acp:event') {
+    return event.payload.map((item) => ({ type: 'run.event' as const, data: item }))
   }
-  return undefined
+  if (event.channel === 'acp:permission-request') {
+    return [{ type: 'permission.requested', data: event.payload }]
+  }
+  return []
 }
+
+const projectPublicTaskEvent = (event: ApplicationEvent): PublicTaskEvent | undefined =>
+  projectPublicTaskEvents(event)[0]
 
 const projectPublicTaskProgressEvent = (event: TaskRunProgressEvent): PublicTaskEvent => ({
   type: 'run.progress',
   data: event
 })
 
-const projectTaskRuntimeEvent = (
-  event: ApplicationEvent
-): Extract<ApplicationEvent, { channel: 'acp:event' }>['payload'] | undefined =>
-  event.channel === 'acp:event' ? event.payload : undefined
+const projectTaskRuntimeEvents = (event: ApplicationEvent): readonly AcpRuntimeEvent[] =>
+  event.channel === 'acp:event' ? event.payload : []
+
+const projectTaskRuntimeEvent = (event: ApplicationEvent): AcpRuntimeEvent | undefined =>
+  projectTaskRuntimeEvents(event)[0]
 
 export {
   projectPublicTaskEvent,
+  projectPublicTaskEvents,
   projectPublicTaskProgressEvent,
   projectTaskRuntimeEvent,
+  projectTaskRuntimeEvents,
   projectWebRendererEvent
 }
 export type { PublicTaskEvent, WebRendererEvent }

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -517,14 +517,16 @@ describe('startWebHttpServer', () => {
     await new Promise<void>((resolve) => publicSocket.once('open', resolve))
     const publicMessages: unknown[] = []
     publicSocket.on('message', (data) => publicMessages.push(JSON.parse(data.toString())))
-    applicationEvents.publish('acp:event', {
-      id: 'event-1',
-      timestamp: 1,
-      level: 'info',
-      sessionId: 'session-1',
-      kind: 'message',
-      text: 'Hi'
-    })
+    applicationEvents.publish('acp:event', [
+      {
+        id: 'event-1',
+        timestamp: 1,
+        level: 'info',
+        sessionId: 'session-1',
+        kind: 'message',
+        text: 'Hi'
+      }
+    ])
     applicationEvents.publish('acp:permission-request', {
       sessionId: 'session-1',
       requestId: 'permission-1',

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -35,7 +35,7 @@ import {
 } from '../../shared/web-rpc-contract'
 import { RENDERER_CONTRACT_CATALOG } from '../../shared/renderer-contract-catalog'
 import {
-  projectPublicTaskEvent,
+  projectPublicTaskEvents,
   projectPublicTaskProgressEvent,
   projectWebRendererEvent
 } from './application-event-projections'
@@ -1006,18 +1006,19 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
 
   const removeBroadcastSink = options.applicationEvents.subscribe((event) => {
     const internalProjection = projectWebRendererEvent(event)
-    const publicProjection = projectPublicTaskEvent(event)
+    const publicMessages = projectPublicTaskEvents(event).map((projection) =>
+      JSON.stringify(projection)
+    )
     const legacyInternalMessage = internalProjection
       ? JSON.stringify(internalProjection)
       : undefined
     const replayInternalMessage = internalProjection
       ? internalEventStream.publish(internalProjection)
       : undefined
-    const publicMessage = publicProjection ? JSON.stringify(publicProjection) : undefined
     for (const socket of sockets) {
       if (socket.readyState !== WebSocket.OPEN) continue
       if (publicEventSockets.has(socket)) {
-        if (publicMessage) socket.send(publicMessage)
+        for (const publicMessage of publicMessages) socket.send(publicMessage)
       } else if (internalEventSockets.get(socket) === 'replay') {
         if (replayInternalMessage) socket.send(replayInternalMessage)
       } else if (legacyInternalMessage) {

--- a/src/main/web-service/index.ts
+++ b/src/main/web-service/index.ts
@@ -10,7 +10,7 @@ import type { TaskAgentPort, TaskComputePreferencePort } from '../tasks/task-run
 import { resolveConfigRoot } from '../storage-root'
 import { loadOrCreateWebToken } from './auth'
 import { startWebHttpServer, type ExternalWebAccess, type RunningWebServer } from './http-server'
-import { projectTaskRuntimeEvent } from './application-event-projections'
+import { projectTaskRuntimeEvents } from './application-event-projections'
 import { HeadlessTaskApi } from './task-api'
 import { removeWebServiceState, writeWebServiceState, type WebServiceState } from './state-file'
 
@@ -111,8 +111,7 @@ const createWebServiceController = (
     {
       subscribeEvents: (listener) =>
         applicationEvents.subscribe((event) => {
-          const runtimeEvent = projectTaskRuntimeEvent(event)
-          if (runtimeEvent) listener(runtimeEvent)
+          for (const runtimeEvent of projectTaskRuntimeEvents(event)) listener(runtimeEvent)
         })
     }
   )

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -450,7 +450,7 @@ export interface OpenScienceAPI {
     revokePermissionGrant(request: AcpRevokePermissionGrantRequest): Promise<AcpStateSnapshot>
     onState(listener: AcpListener<AcpStateSnapshot>): RemoveListener
     onAgentRuntimeUpdate(listener: AcpListener<AcpAgentRuntimeUpdate>): RemoveListener
-    onEvent(listener: AcpListener<AcpRuntimeEvent>): RemoveListener
+    onEvent(listener: AcpListener<readonly AcpRuntimeEvent[]>): RemoveListener
     onPermissionRequest(listener: AcpListener<AcpPermissionRequest>): RemoveListener
   }
   sideChat: {

--- a/src/renderer/src/lib/acp/runtime-event-subscription-owner.test.ts
+++ b/src/renderer/src/lib/acp/runtime-event-subscription-owner.test.ts
@@ -91,6 +91,20 @@ describe('runtime event subscription owner', () => {
     expect(replayed.at(-1)?.id).toBe('runtime-1:acp-event-601')
   })
 
+  it('publishes an incremental batch as one listener delivery', () => {
+    const owner = createRuntimeEventSubscriptionOwner()
+    owner.observeInitialSnapshot([])
+    const listener = vi.fn<(events: readonly AcpRuntimeEvent[]) => void>()
+    owner.subscribe(listener)
+    const first = runtimeEvent(1)
+    const second = runtimeEvent(2)
+
+    owner.observeEvents([first, second])
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener.mock.calls[0]?.[0]).toEqual([first, second])
+  })
+
   it('bounds rolling snapshot history without an incremental subscriber', () => {
     const owner = createRuntimeEventSubscriptionOwner()
     const events = Array.from({ length: 600 }, (_, index) => runtimeEvent(index + 1))

--- a/src/renderer/src/lib/acp/runtime-event-subscription-owner.ts
+++ b/src/renderer/src/lib/acp/runtime-event-subscription-owner.ts
@@ -11,6 +11,7 @@ type RuntimeEventListener = (
 ) => void
 type RuntimeEventSubscriptionOwner = {
   observeEvent: (event: AcpRuntimeEvent) => void
+  observeEvents: (events: readonly AcpRuntimeEvent[]) => void
   observeInitialSnapshot: (
     events: readonly AcpRuntimeEvent[],
     snapshot?: RuntimeEventSnapshotContext
@@ -127,24 +128,34 @@ const createRuntimeEventSubscriptionOwner = (): RuntimeEventSubscriptionOwner =>
     publish(unseen, snapshot)
   }
 
-  return {
-    observeEvent(event: AcpRuntimeEvent): void {
+  const observeEvents = (events: readonly AcpRuntimeEvent[]): void => {
+    const unseen: AcpRuntimeEvent[] = []
+    for (const event of events) {
       if (
         retainedEventIds.has(event.id) ||
         pendingInitialEvents.has(event.id) ||
         directEventsSinceSnapshot.has(event.id)
       ) {
-        return
+        continue
       }
       arrivalSequence += 1
       directEventsSinceSnapshot.set(event.id, arrivalSequence)
       if (!initialized) {
         pendingInitialEvents.set(event.id, event)
-        return
+        continue
       }
-      retain([event])
-      publish([event])
+      unseen.push(event)
+    }
+    if (unseen.length === 0) return
+    retain(unseen)
+    publish(unseen)
+  }
+
+  return {
+    observeEvent(event: AcpRuntimeEvent): void {
+      observeEvents([event])
     },
+    observeEvents,
     observeInitialSnapshot(
       events: readonly AcpRuntimeEvent[],
       snapshot?: RuntimeEventSnapshotContext

--- a/src/renderer/src/lib/acp/useAcpRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.test.ts
@@ -19,7 +19,7 @@ import {
 
 type AcpRuntimeApi = ReturnType<typeof useAcpRuntime>
 type OnStateListener = (snapshot: AcpStateSnapshot) => void
-type OnEventListener = (event: AcpRuntimeEvent) => void
+type OnEventListener = (events: readonly AcpRuntimeEvent[]) => void
 
 // Minimal renderHook so we can exercise the real hook without pulling in @testing-library/react,
 // which the repo does not depend on. A null-rendering harness captures each render's return value.
@@ -472,7 +472,7 @@ describe('useAcpRuntime state subscription', () => {
     expect(acpApi.onEvent.mock.invocationCallOrder[0]).toBeLessThan(
       acpApi.getState.mock.invocationCallOrder[0]
     )
-    act(() => capturedEventListener?.(event))
+    act(() => capturedEventListener?.([event]))
 
     expect(delivered).toHaveBeenCalledWith([event], undefined)
     expect(result.current.currentRuntimeEvents()).toEqual([event])
@@ -499,7 +499,7 @@ describe('useAcpRuntime state subscription', () => {
       text: 'newer live output'
     }
 
-    act(() => capturedEventListener?.(event))
+    act(() => capturedEventListener?.([event]))
     await act(async () => {
       initial.resolve(createSnapshot({ revision: 1, events: [] }))
       await initial.promise

--- a/src/renderer/src/lib/acp/useAcpRuntime.ts
+++ b/src/renderer/src/lib/acp/useAcpRuntime.ts
@@ -173,9 +173,9 @@ const useAcpRuntime = (): {
       hasPushedSnapshot = true
       applyMountedSnapshot(snapshot)
     })
-    const removeEventListener = onRuntimeEvent?.((event: AcpRuntimeEvent) => {
+    const removeEventListener = onRuntimeEvent?.((events: readonly AcpRuntimeEvent[]) => {
       if (!isMounted) return
-      runtimeEventOwner.observeEvent(event)
+      runtimeEventOwner.observeEvents(events)
     })
 
     void loadInitialState()

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -305,6 +305,44 @@ describe('workspace agent runtime event processing', () => {
     expect(appliedEventIds).toEqual(events.map((event) => event.id))
   })
 
+  it('keeps live presentation drain of a thought burst within a linear main-thread work budget', async () => {
+    let eventIdReads = 0
+    const appliedEventIds: string[] = []
+    const processor = createWorkspaceRuntimeEventProcessor(
+      async (event) => {
+        appliedEventIds.push(event.id)
+        return true
+      },
+      { presentation: createTimerPresentation() }
+    )
+    const events = Array.from({ length: 1_200 }, (_, index) => {
+      const event = createEvent({
+        id: `thought-event-${index + 1}`,
+        kind: 'thought',
+        role: 'assistant',
+        text: 'x'
+      })
+      const eventId = event.id
+      Object.defineProperty(event, 'id', {
+        enumerable: true,
+        get: () => {
+          eventIdReads += 1
+          return eventId
+        }
+      })
+      return event
+    })
+
+    const drains = events.map((event) => processor.processIncremental([event]))
+    await Promise.all(drains)
+    await processor.drain()
+
+    // Admission-only budget is 20 reads/event. Live drain also walks the pending lane and the
+    // selected batch, so allow a still-linear 32. The unfixed presentation path was ~4,600.
+    expect(eventIdReads).toBeLessThan(events.length * 32)
+    expect(appliedEventIds).toEqual(events.map((event) => event.id))
+  })
+
   it('releases fast assistant text in grapheme-budgeted 30 fps batches', async () => {
     vi.useFakeTimers()
     try {

--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -1044,6 +1044,22 @@ describe('workspace runtime events', () => {
     expect(useSessionStore.getState().sessions[0].messages).toHaveLength(1)
   })
 
+  it('does not project thought events into the transcript', async () => {
+    const sessionBefore = useSessionStore.getState().sessions[0]
+
+    const applied = await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'event-thought-1',
+        kind: 'thought',
+        role: 'assistant',
+        text: 'I will inspect the notebook next.'
+      })
+    )
+
+    expect(applied).toBe(false)
+    expect(useSessionStore.getState().sessions[0]).toBe(sessionBefore)
+  })
+
   it('ignores an info-level system event (only warnings become status)', async () => {
     const applied = await applyWorkspaceRuntimeEvent(
       createEvent({ id: 'event-1', kind: 'system', level: 'info', text: 'Session created' })

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -530,6 +530,10 @@ const applyWorkspaceRuntimeEvent = async (
 ): Promise<boolean> => {
   const store = useSessionStore.getState()
 
+  // Thought chunks never enter the transcript. Exit before the permission / message / tool
+  // probes so a thinking-model burst cannot walk Session state once per provider token.
+  if (event.kind === 'thought') return false
+
   if (event.kind === 'permission' && event.sessionId) {
     const permission = store.sessions.find((session) => session.id === event.sessionId)
       ?.runtimeContext?.permission

--- a/src/renderer/src/lib/acp/workspace-runtime-presentation-buffer.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-presentation-buffer.ts
@@ -152,13 +152,22 @@ const createWorkspaceRuntimePresentationBuffer = (
     })
   }
 
+  const consecutiveNonTextPrefix = (pending: AcpRuntimeEvent[]): AcpRuntimeEvent[] => {
+    const end = pending.findIndex((event) => isBufferableAssistantTextEvent(event))
+    return pending.slice(0, end === -1 ? pending.length : end)
+  }
+
   const select = (
     lane: WorkspacePresentationLane,
     pending: AcpRuntimeEvent[]
   ): AcpRuntimeEvent[] => {
     if (!presentation) return pending
     const first = pending[0]
-    if (!first || !isBufferableAssistantTextEvent(first)) return first ? [first] : []
+    if (!first) return []
+    // Thought, tool, stop, and other non-text events are not grapheme-paced. Selecting only the
+    // first one made a live burst drain one event per iteration and recopy the remaining lane
+    // each time. Consecutive non-text events stay ordered and still apply sequentially.
+    if (!isBufferableAssistantTextEvent(first)) return consecutiveNonTextPrefix(pending)
 
     const textRun = pending.slice(
       0,

--- a/src/shared/renderer-surface-matrix.test.ts
+++ b/src/shared/renderer-surface-matrix.test.ts
@@ -320,14 +320,14 @@ describe('renderer surface compatibility matrix', () => {
   it('passes complete terminal metadata through Electron, Web, and Task without recomputation', () => {
     const event: ApplicationEvent<'acp:event'> = {
       channel: 'acp:event',
-      payload: TERMINAL_EVENT_FIXTURE
+      payload: [TERMINAL_EVENT_FIXTURE]
     }
     const webEvent = projectWebRendererEvent(event)
     expect(webEvent).toMatchObject({ protocolVersion: 1, channel: 'acp:event' })
     const projected = projectThroughRendererAdapters('acp.onEvent', 'acp:event', webEvent?.payload)
 
-    expect(projected.electronPayload).toEqual(TERMINAL_EVENT_FIXTURE)
-    expect(projected.webPayload).toEqual(TERMINAL_EVENT_FIXTURE)
+    expect(projected.electronPayload).toEqual([TERMINAL_EVENT_FIXTURE])
+    expect(projected.webPayload).toEqual([TERMINAL_EVENT_FIXTURE])
     expect(projectTaskRuntimeEvent(event)).toEqual(TERMINAL_EVENT_FIXTURE)
     expect(projectPublicTaskEvent(event)).toEqual({
       type: 'run.event',

--- a/src/shared/web-rpc-contract.ts
+++ b/src/shared/web-rpc-contract.ts
@@ -6,8 +6,8 @@ import { WEB_EVENT_CHANNELS, WEB_INVOKE_CHANNELS } from './web-api-map.generated
 export const WEB_RPC_PROTOCOL_VERSION = 1 as const
 export const WEB_RPC_CAPABILITY_UPDATE_CLI_V1 = 'update-cli-v1' as const
 export const WEB_RPC_CAPABILITIES = [WEB_RPC_CAPABILITY_UPDATE_CLI_V1] as const
-// v3 requires ACP consumers to apply acp:event incrementally. Reject cached v2 pages after a Main
-// upgrade so they request a reload instead of silently waiting for removed per-chunk state frames.
+// v3 requires ACP consumers to apply acp:event incrementally. The payload is an ordered event
+// batch on the same protocol version; Electron and Web clients that ship with this Main consume it.
 export const WEB_EVENT_STREAM_PROTOCOL_VERSION = 3 as const
 export const WEB_RPC_TRANSPORT_ERROR_CODES = [
   'invalid_request',


### PR DESCRIPTION
## Problem

After v0.18.0, sending a message, stopping a run, and switching windows can hitch or freeze. In severe cases the app only closes from the command line. Skills and plugins are not the cause; a custom model router can add time-to-first-token, but it does not occupy the renderer or main event loop.

v0.18.0 started publishing one incremental `acp:event` per provider notification (#1444). v0.18.2 bounded *admission* work (#1515), but live presentation still drained thought and tool events one at a time, and main still structured-cloned one IPC per event. A hung renderer also made Cmd+Q abort: session-persistence flush timed out and shutdown stayed blocked.

A 1,200-event thought burst on the unfixed presentation path did 5,559,802 event-id reads against a linear budget of 24,000.

## Proposed change

- Select a consecutive non-text prefix (thought, tool, stop, …) in one drain iteration. Order is unchanged; each event still applies sequentially.
- Return immediately from `applyWorkspaceRuntimeEvent` for `thought` events, which never enter the transcript.
- Coalesce streamed assistant text and in-progress tool content onto the 33 ms presentation cadence, and publish each flush as an ordered `acp:event` array. Stop, error, and tool start/end still flush immediately.
- Keep the Web event-stream protocol at v3 and send the batch payload on that existing stream. Public Task `run.event` frames still fan out one event at a time.
- Allow quit to continue when renderer persistence flush returns `timeout` or `send-failed`. Keep aborting quit for revision conflicts and explicit renderer write failures.

```mermaid
flowchart LR
  burst["Thought/tool burst"] --> coalesce["33 ms IPC batch"]
  coalesce --> select["select consecutive non-text prefix"]
  select --> apply["apply in order"]
  apply --> ui["Send/cancel/window stay on the event loop"]
  hung["Hung renderer + Cmd+Q"] --> timeout["flush timeout"]
  timeout --> quit["process exits"]
```

## Scope and non-goals

- No database schema, persisted Session format, data field, domain model, migration, or enum changes.
- No historical-data compatibility path.
- No ACP provider protocol change. All four frameworks share the same projector → coalescer → renderer processor.
- Dropping thought events from publication remains out of scope (reviewer logs still use thought entries on reviewer sessions).

## Compatibility

- Historical data: not required.
- New status / enum values: none in persisted data.
- Data persistence: none. Drain, IPC payload shape, and quit policy only.
- Web event-stream protocol stays at v3. The `acp:event` payload is now an ordered batch on that same version. Electron Main and renderer ship together.

## Acceptance criteria and validation

Checks below ran after the last material edit:

- live presentation drain of 1,200 thoughts stays linear -> `npx vitest run src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts -t "workspace agent runtime event processing"` -> passed
- IPC coalescer batches thoughts and flushes on stop -> `npx vitest run src/main/acp/runtime-event-broadcast-coalescer.test.ts` -> passed
- Electron / Task / Web projections keep terminal metadata and fan out public Task events -> `npx vitest run src/main/application-event-flow.test.ts src/main/web-service/application-event-projections.test.ts src/shared/renderer-surface-matrix.test.ts src/main/web-service/http-server.test.ts` -> passed
- Web event-stream protocol remains v3 -> `npx vitest run src/shared/web-rpc-contract.test.ts src/main/web-service/internal-web-event-stream.test.ts src/main/web-service/http-server.test.ts src/renderer/web/bootstrap.test.ts` -> 54 passed after the last material edit
- quit continues on flush timeout/send-failed and still aborts on conflict/renderer-failed -> `npx vitest run src/main/session-persistence/renderer-flush.test.ts src/main/app-lifecycle.test.ts` -> passed
- workspace runtime owner, contracts, and representative consumer -> `npm run test:module -- workspace_runtime` -> 8 files / 327 tests passed
- Main and renderer TypeScript -> `npm run typecheck:node` and `npm run typecheck:web` -> passed
- linted source and generated Web API map -> `npm run lint` and `npm run check:web-api-map` -> passed

Exact-head PR CI remains authoritative; a full local `npm test` was intentionally not run.

Uncovered local risk: the supplied production stream was represented by deterministic thought-burst and coalescer tests rather than replayed through a packaged Electron build. A stale Web tab that still expects a single-event `acp:event` payload will not be rejected by a protocol bump.

## Review focus

- Consecutive non-text selection must not change grapheme-paced assistant text or the text-then-tool catch-up frames.
- Batched `acp:event` must preserve order, flush immediately on stop/error, and leave public Task `run.event` as one event per frame.
- Quit must still stop on a Session revision conflict.