### PR TITLE
fix(model-provider): format xAI OAuth sources

### DIFF
--- a/src/main/settings/xai-oauth-provider-bridge.ts
+++ b/src/main/settings/xai-oauth-provider-bridge.ts
@@ -49,7 +49,9 @@ const CLAUDE_CODE_COMPAT_MODEL_IDS = Object.freeze([
   'claude-haiku-4-5-20251001'
 ])
 
-const anthropicModel = (id: string): Readonly<{ id: string; type: 'model'; display_name: string }> =>
+const anthropicModel = (
+  id: string
+): Readonly<{ id: string; type: 'model'; display_name: string }> =>
   Object.freeze({ id, type: 'model', display_name: id })
 
 export class XaiOAuthProviderBridge {
@@ -128,7 +130,8 @@ export class XaiOAuthProviderBridge {
     }
     if (pathname !== expected) return json(response, 404, { error: { message: 'Not found' } })
     const body = await request.readJsonObject()
-    const requestModel = typeof body.model === 'string' && body.model ? body.model : this.target.model
+    const requestModel =
+      typeof body.model === 'string' && body.model ? body.model : this.target.model
     this.advertise(requestModel)
     log.info('loopback request', {
       wire: this.wire,

--- a/src/main/settings/xai-oauth.test.ts
+++ b/src/main/settings/xai-oauth.test.ts
@@ -189,9 +189,7 @@ describe('XaiOAuthController', () => {
     const pending = controller.getAccessToken()
     await vi.waitFor(() => expect(finishRefresh).toBeDefined())
     await controller.logout()
-    finishRefresh!(
-      new Response(JSON.stringify({ access_token: 'stale-access', expires_in: 3600 }))
-    )
+    finishRefresh!(new Response(JSON.stringify({ access_token: 'stale-access', expires_in: 3600 })))
 
     await expect(pending).rejects.toThrow('Sign in to xAI (Grok) OAuth to continue.')
     await expect(controller.getAccessToken()).rejects.toThrow(


### PR DESCRIPTION
## Problem

PR #1554 merged with a failing `Static checks` job. Prettier rejected two xAI OAuth files that landed on `main`:

- `src/main/settings/xai-oauth-provider-bridge.ts`
- `src/main/settings/xai-oauth.test.ts`

`PR policy` also failed on that pull request because the branch contained a merge commit (`Merge remote-tracking branch 'origin/main' into feat/grok-subscription-provider`). That history is already squash-merged and is not changed here.

## Proposed change

Run Prettier on the two files so `check-changed-format` passes for any later PR that touches them, and so `main` matches the repo format contract.

## Scope and non-goals

- Formatting only. No behavior, protocol, or settings changes.
- Does not change PR policy to allow merge commits. CONTRIBUTING still requires squash merge and conventional commit subjects.

## Historical compatibility

None. No stored settings, credentials, or on-disk formats are read or rewritten.

## State and enum additions

None. No `ProviderType` values, command names, or other enums are added.

## Persistence

None. No provider records, tokens, or other durable state are written.

## Acceptance criteria and validation

- `npx prettier --check src/main/settings/xai-oauth-provider-bridge.ts src/main/settings/xai-oauth.test.ts` — passed after the last material edit.
- `npx eslint src/main/settings/xai-oauth-provider-bridge.ts src/main/settings/xai-oauth.test.ts` — passed after the last material edit.
- `npx vitest run src/main/settings/xai-oauth.test.ts src/main/settings/xai-oauth-provider-bridge.test.ts` — 10 passed after the last material edit.
- `git diff --check` — passed after the last material edit.
- The complete local `npm test` suite was intentionally not run; CI is the authority for the full matrix.

## Review focus

- Diff should be Prettier wrapping only.