### PR TITLE
perf(acp-runtime): coalesce tool bursts into renderer IPC batches

### DIFF
--- a/src/main/acp/runtime-event-broadcast-coalescer.test.ts
+++ b/src/main/acp/runtime-event-broadcast-coalescer.test.ts
@@ -17,6 +17,17 @@ const thought = (id: string, text: string): AcpRuntimeEvent => ({
   text
 })
 
+const inProgressTool = (id: string, toolCallId: string): AcpRuntimeEvent => ({
+  id,
+  timestamp: 1,
+  kind: 'tool',
+  level: 'info',
+  sessionId: 'session-1',
+  toolCallId,
+  status: 'in_progress',
+  title: 'Read'
+})
+
 describe('AcpRuntimeEventBroadcastCoalescer', () => {
   it('coalesces streamed assistant thoughts into one IPC batch', () => {
     vi.useFakeTimers()
@@ -77,5 +88,95 @@ describe('AcpRuntimeEventBroadcastCoalescer', () => {
 
     expect(publish).toHaveBeenCalledOnce()
     expect(publish.mock.calls[0]?.[0]).toHaveLength(MAX_COALESCED_BROADCAST_EVENTS)
+  })
+
+  it('does not publish one renderer IPC per in-progress tool start during a burst', () => {
+    const publish = vi.fn()
+    const coalescer = createAcpRuntimeEventBroadcastCoalescer({
+      publish,
+      schedule: () => () => undefined
+    })
+    const events = Array.from({ length: 1_200 }, (_, index) =>
+      inProgressTool(`tool-${index + 1}`, `call-${index + 1}`)
+    )
+
+    for (const event of events) coalescer.enqueue(event)
+
+    const publishedBatches = publish.mock.calls.map(([batch]) => batch)
+    const publishedCount = publishedBatches.reduce((count, batch) => count + batch.length, 0)
+
+    expect(publish).toHaveBeenCalledTimes(
+      Math.floor(events.length / MAX_COALESCED_BROADCAST_EVENTS)
+    )
+    expect(publishedCount).toBe(
+      MAX_COALESCED_BROADCAST_EVENTS * Math.floor(events.length / MAX_COALESCED_BROADCAST_EVENTS)
+    )
+    expect(publishedBatches.flat().map((event) => event.id)).toEqual(
+      events.slice(0, publishedCount).map((event) => event.id)
+    )
+  })
+
+  it('keeps a mixed thought and new-tool burst on the presentation cadence until the batch cap', () => {
+    const publish = vi.fn()
+    const coalescer = createAcpRuntimeEventBroadcastCoalescer({
+      publish,
+      schedule: () => () => undefined
+    })
+    const events = Array.from({ length: 1_200 }, (_, index) =>
+      index % 2 === 0
+        ? thought(`thought-${index + 1}`, 'x')
+        : inProgressTool(`tool-${index + 1}`, `call-${index + 1}`)
+    )
+
+    for (const event of events) coalescer.enqueue(event)
+
+    expect(publish).toHaveBeenCalledTimes(
+      Math.floor(events.length / MAX_COALESCED_BROADCAST_EVENTS)
+    )
+    expect(
+      publish.mock.calls.every(([batch]) => batch.length === MAX_COALESCED_BROADCAST_EVENTS)
+    ).toBe(true)
+  })
+
+  it('holds an in-progress tool start until the 33 ms presentation cadence', () => {
+    vi.useFakeTimers()
+    try {
+      const publish = vi.fn()
+      const coalescer = createAcpRuntimeEventBroadcastCoalescer({ publish })
+      const tool = inProgressTool('tool-1', 'call-1')
+
+      coalescer.enqueue(tool)
+      vi.advanceTimersByTime(EVENT_BROADCAST_INTERVAL_MS - 1)
+      expect(publish).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(1)
+      expect(publish).toHaveBeenCalledOnce()
+      expect(publish).toHaveBeenCalledWith([tool])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('flushes the pending prefix together with a permission request', () => {
+    const publish = vi.fn()
+    const coalescer = createAcpRuntimeEventBroadcastCoalescer({
+      publish,
+      schedule: () => () => undefined
+    })
+    const permission: AcpRuntimeEvent = {
+      id: 'permission-1',
+      timestamp: 2,
+      kind: 'permission',
+      level: 'warning',
+      sessionId: 'session-1',
+      title: 'Permission requested'
+    }
+    const tool = inProgressTool('tool-1', 'call-1')
+
+    coalescer.enqueue(tool)
+    coalescer.enqueue(permission)
+
+    expect(publish).toHaveBeenCalledOnce()
+    expect(publish.mock.calls[0]?.[0]).toEqual([tool, permission])
   })
 })

--- a/src/main/acp/runtime-event-broadcast-coalescer.ts
+++ b/src/main/acp/runtime-event-broadcast-coalescer.ts
@@ -16,16 +16,17 @@ const scheduleBroadcast = (flush: () => void): (() => void) => {
   return () => clearTimeout(timer)
 }
 
-const isCoalescibleAssistantStreamEvent = (event: AcpRuntimeEvent): boolean =>
-  (event.kind === 'message' || event.kind === 'thought') &&
-  event.role === 'assistant' &&
-  typeof event.text === 'string' &&
-  event.text.length > 0 &&
-  !event.image
+// Stop, error, and permission must not wait for the presentation cadence. Image-bearing
+// messages flush with the pending prefix so a 250-event batch cannot accumulate binary
+// payloads. Everything else, including tool starts, shares the 33 ms IPC batch.
+const isImmediateBroadcastEvent = (event: AcpRuntimeEvent): boolean =>
+  event.kind === 'stop' ||
+  event.kind === 'error' ||
+  event.kind === 'permission' ||
+  Boolean(event.image)
 
-// Owns one IPC batch for incremental renderer events. Stop, error, permission, and tool
-// start/end flush immediately so the UI is not delayed; streamed text and in-progress tool
-// content share the 33 ms presentation cadence.
+// Owns one IPC batch for incremental renderer events. A thinking-model or tool-call storm
+// must not structured-clone one payload per provider notification.
 const createAcpRuntimeEventBroadcastCoalescer = (
   options: AcpRuntimeEventBroadcastCoalescerOptions
 ): {
@@ -33,39 +34,7 @@ const createAcpRuntimeEventBroadcastCoalescer = (
   flush: () => void
 } => {
   const pending: AcpRuntimeEvent[] = []
-  const activeToolCallIdsBySession = new Map<string | undefined, Set<string>>()
   let cancelScheduled: (() => void) | undefined
-
-  const isCoalescible = (event: AcpRuntimeEvent): boolean => {
-    if (isCoalescibleAssistantStreamEvent(event)) return true
-    if (event.kind === 'stop' || event.kind === 'error') {
-      activeToolCallIdsBySession.delete(event.sessionId)
-      return false
-    }
-    if (event.kind !== 'tool' || !event.toolCallId) return false
-
-    const activeToolCallIds = activeToolCallIdsBySession.get(event.sessionId)
-    const wasActive = activeToolCallIds?.has(event.toolCallId) === true
-    if (event.status === 'completed' || event.status === 'failed') {
-      activeToolCallIds?.delete(event.toolCallId)
-      if (activeToolCallIds?.size === 0) {
-        activeToolCallIdsBySession.delete(event.sessionId)
-      }
-      return false
-    }
-    if (activeToolCallIds) {
-      activeToolCallIds.add(event.toolCallId)
-    } else {
-      activeToolCallIdsBySession.set(event.sessionId, new Set([event.toolCallId]))
-    }
-
-    return (
-      wasActive &&
-      (event.toolContent !== undefined ||
-        event.terminalOutput !== undefined ||
-        event.rawOutput !== undefined)
-    )
-  }
 
   const flush = (): void => {
     cancelScheduled?.()
@@ -84,7 +53,7 @@ const createAcpRuntimeEventBroadcastCoalescer = (
   return {
     enqueue(event) {
       pending.push(event)
-      if (!isCoalescible(event) || pending.length >= MAX_COALESCED_BROADCAST_EVENTS) {
+      if (isImmediateBroadcastEvent(event) || pending.length >= MAX_COALESCED_BROADCAST_EVENTS) {
         flush()
         return
       }


### PR DESCRIPTION
## Problem

After v0.18.0, live ACP updates are incremental `acp:event` deliveries. Production always supplies `onEvent`, so the 33 ms snapshot coalescer never runs. #1555 already batched assistant thought/text IPC and renderer drain, but a **new tool start, status-only tool update, or tool completion still flushed immediately**.

A 1,200 unique in-progress tool-call burst on the unfixed coalescer published **1,200** `acp:event` clones (one structured clone per provider notification). A mixed thought/tool burst published **600** times — one IPC per tool start, with pending thoughts riding along. Main and the renderer stay busy; send, cancel, and window switching queue behind that work.

## Proposed change

Keep the existing ordered `acp:event` array payload (Web event-stream protocol stays at v3). Change only the coalescer flush predicate:

- Coalesce tool starts and other non-terminal events onto the 33 ms presentation cadence, the same way streamed text already works.
- Still flush immediately on `stop`, `error`, `permission`, and image-bearing messages, including any pending prefix, so ordering and approval/terminal UI are unchanged.
- Keep the 250-event mid-window flush so a burst larger than the retained snapshot still publishes prefixes before snapshot eviction.

```mermaid
flowchart LR
  burst["Thought/tool burst"] --> enqueue["coalescer.enqueue"]
  enqueue --> cadence["33 ms batch or 250-event cap"]
  cadence --> ipc["one acp:event array per flush"]
  ipc --> ui["Send/cancel/window stay on the event loop"]
  stop["stop / error / permission / image"] --> flushNow["flush pending prefix now"]
  flushNow --> ipc
```

## Scope and non-goals

- No database schema, persisted Session format, data field, domain model, migration, or enum changes.
- No historical-data compatibility path.
- No renderer-contract catalog change and no Web protocol bump.
- No ACP provider protocol change. All four frameworks share the same projector → `pushEvent` → composition coalescer.
- Not dropping thought events from publication.
- Not changing quit policy (already handled in #1555).

## Compatibility

- Historical data: not required.
- New status / enum values: none.
- Data persistence: none. Coalescer flush policy only.

## Acceptance criteria and validation

Checks below ran after the last material edit:

- 1,200 unique in-progress tool starts no longer publish one IPC each -> `npx vitest run src/main/acp/runtime-event-broadcast-coalescer.test.ts` -> failed on unfixed code with `expected "vi.fn()" to be called 4 times, but got 1200 times`; passed after the policy change (7 tests)
- mixed thought + new-tool burst stays on the batch cap -> same command -> failed on unfixed code with `got 600 times`; passed after the change
- thought batch, stop-flush, and mid-window burst still hold; permission still flushes the pending prefix; a lone tool start waits 33 ms -> same command -> passed
- snapshot-only publication path unchanged -> `npx vitest run src/main/acp/runtime-publication-owner.test.ts` -> 15 passed
- Electron / Task / Web terminal projections still fan out in order -> `npx vitest run src/main/application-event-flow.test.ts` -> passed
- Main TypeScript -> `npm run typecheck:node` -> passed
- linted changed files -> `npx eslint src/main/acp/runtime-event-broadcast-coalescer.ts src/main/acp/runtime-event-broadcast-coalescer.test.ts` -> passed

This file is not owned by a `test:module` Module ID. Targeted ACP coalescer tests plus the publication-owner and application-event-flow contracts are the local impact set. No persistence, migration, path, native-process, renderer-contract, or platform-specific behavior changed, so additional platform lanes were not selected locally. Exact-head PR CI remains authoritative; a full local `npm test` was intentionally not run.

Uncovered local risk: the production stream was represented by deterministic tool-start and mixed thought/tool burst tests rather than replayed through a packaged Electron build. A 250-event synchronous clone can still hitch; yielding between cap flushes is left for a follow-up if this is insufficient.

## Review focus

- Tool rows may appear up to one 33 ms presentation frame later. Stop, error, permission, and images must still flush immediately with the pending prefix.
- Public Task `run.event` frames still fan out one event at a time; only the renderer `acp:event` array is batched.
- Event order inside each batch must match enqueue order.