### PR TITLE
fix(specialist-marketplace): bound persisted release caches

### DIFF
--- a/src/main/specialist/marketplace/repository.test.ts
+++ b/src/main/specialist/marketplace/repository.test.ts
@@ -4,7 +4,11 @@ import { join } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import { MarketplaceRepository } from './repository'
+import {
+  MarketplaceRepository,
+  MAX_MARKETPLACE_RELEASE_CACHE_BYTES,
+  MAX_MARKETPLACE_RELEASE_CACHE_ENTRIES
+} from './repository'
 
 describe('MarketplaceRepository', () => {
   it('recovers a valid historical temp when the primary is missing', async () => {
@@ -121,6 +125,162 @@ describe('MarketplaceRepository', () => {
     await expect(
       reloaded.getCachedRelease('github-example', 'releases/example/1.0.0.json', 'a'.repeat(64))
     ).resolves.toBeUndefined()
+  })
+
+  it('replaces the same release path without accumulating extra cache entries', async () => {
+    const repository = new MarketplaceRepository(
+      await mkdtemp(join(tmpdir(), 'marketplace-release-replace-'))
+    )
+    for (let index = 0; index < 20; index += 1) {
+      await repository.cacheRelease(
+        'github-example',
+        'releases/example/1.0.0.json',
+        index.toString(16).padStart(64, '0'),
+        new TextEncoder().encode(`release-${index}`),
+        `2026-08-18T00:00:${String(index).padStart(2, '0')}.000Z`
+      )
+    }
+
+    const document = await repository.getAll()
+    expect(document.releaseCaches).toHaveLength(1)
+    await expect(
+      repository.getCachedRelease(
+        'github-example',
+        'releases/example/1.0.0.json',
+        (19).toString(16).padStart(64, '0')
+      )
+    ).resolves.toMatchObject({
+      bytes: new TextEncoder().encode('release-19'),
+      cachedAt: '2026-08-18T00:00:19.000Z'
+    })
+  })
+
+  it('does not keep an unbounded working set of distinct release paths', async () => {
+    const repository = new MarketplaceRepository(
+      await mkdtemp(join(tmpdir(), 'marketplace-release-count-'))
+    )
+    const cachedCount = 20
+    for (let index = 0; index < cachedCount; index += 1) {
+      await repository.cacheRelease(
+        'github-example',
+        `releases/example/${index}.json`,
+        index.toString(16).padStart(64, '0'),
+        new TextEncoder().encode(`release-${index}`),
+        `2026-08-18T00:00:${String(index).padStart(2, '0')}.000Z`
+      )
+    }
+
+    const document = await repository.getAll()
+    expect(document.releaseCaches.length).toBeLessThan(cachedCount)
+    expect(document.releaseCaches.length).toBeLessThanOrEqual(MAX_MARKETPLACE_RELEASE_CACHE_ENTRIES)
+    expect(document.releaseCaches.map((item) => item.path)).toEqual(
+      Array.from(
+        { length: MAX_MARKETPLACE_RELEASE_CACHE_ENTRIES },
+        (_, index) =>
+          `releases/example/${index + cachedCount - MAX_MARKETPLACE_RELEASE_CACHE_ENTRIES}.json`
+      )
+    )
+    await expect(
+      repository.getCachedRelease(
+        'github-example',
+        'releases/example/0.json',
+        (0).toString(16).padStart(64, '0')
+      )
+    ).resolves.toBeUndefined()
+    await expect(
+      repository.getCachedRelease(
+        'github-example',
+        'releases/example/19.json',
+        (19).toString(16).padStart(64, '0')
+      )
+    ).resolves.toMatchObject({
+      bytes: new TextEncoder().encode('release-19'),
+      cachedAt: '2026-08-18T00:00:19.000Z'
+    })
+  })
+
+  it('evicts older distinct release caches once decoded payloads exceed the byte budget', async () => {
+    const repository = new MarketplaceRepository(
+      await mkdtemp(join(tmpdir(), 'marketplace-release-bytes-'))
+    )
+    const payload = Buffer.alloc(Math.floor(MAX_MARKETPLACE_RELEASE_CACHE_BYTES * 0.5), 0x61)
+    for (let index = 0; index < 3; index += 1) {
+      await repository.cacheRelease(
+        'github-example',
+        `releases/example/${index}.json`,
+        index.toString(16).padStart(64, '0'),
+        payload,
+        `2026-08-18T00:00:0${index}.000Z`
+      )
+    }
+
+    const document = await repository.getAll()
+    expect(document.releaseCaches.length).toBeLessThan(3)
+    expect(document.releaseCaches.map((item) => item.path)).toEqual([
+      'releases/example/1.json',
+      'releases/example/2.json'
+    ])
+    await expect(
+      repository.getCachedRelease(
+        'github-example',
+        'releases/example/0.json',
+        (0).toString(16).padStart(64, '0')
+      )
+    ).resolves.toBeUndefined()
+    await expect(
+      repository.getCachedRelease(
+        'github-example',
+        'releases/example/2.json',
+        (2).toString(16).padStart(64, '0')
+      )
+    ).resolves.toMatchObject({
+      cachedAt: '2026-08-18T00:00:02.000Z'
+    })
+  })
+
+  it('trims a historical document that already stored too many release caches', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'marketplace-release-historical-'))
+    await writeFile(
+      join(root, 'specialist-marketplace.json'),
+      JSON.stringify({
+        version: 1,
+        sources: [
+          {
+            id: 'github-example',
+            kind: 'github',
+            repositoryUrl: 'https://github.com/example/marketplace',
+            owner: 'example',
+            repository: 'marketplace',
+            ref: 'main',
+            marketplaceId: 'example',
+            name: 'Example Marketplace',
+            keyId: 'example-2026-01',
+            publicKey: Buffer.from('public-key').toString('base64'),
+            keyFingerprint: 'f'.repeat(64),
+            createdAt: '2026-08-18T00:00:00.000Z'
+          }
+        ],
+        releaseCaches: Array.from({ length: 20 }, (_, index) => ({
+          sourceId: 'github-example',
+          path: `releases/example/${index}.json`,
+          digest: index.toString(16).padStart(64, '0'),
+          bytesBase64: Buffer.from(`release-${index}`).toString('base64'),
+          cachedAt: `2026-08-18T00:00:${String(index).padStart(2, '0')}.000Z`
+        }))
+      }),
+      'utf8'
+    )
+
+    const document = await new MarketplaceRepository(root).getAll()
+    expect(document.sources).toEqual([expect.objectContaining({ id: 'github-example' })])
+    expect(document.releaseCaches.length).toBeLessThan(20)
+    expect(document.releaseCaches.length).toBeLessThanOrEqual(MAX_MARKETPLACE_RELEASE_CACHE_ENTRIES)
+    expect(document.releaseCaches.map((item) => item.path)).toEqual(
+      Array.from(
+        { length: MAX_MARKETPLACE_RELEASE_CACHE_ENTRIES },
+        (_, index) => `releases/example/${index + 20 - MAX_MARKETPLACE_RELEASE_CACHE_ENTRIES}.json`
+      )
+    )
   })
 
   it('reconstructs persisted records from known, validated fields', async () => {

--- a/src/main/specialist/marketplace/repository.test.ts
+++ b/src/main/specialist/marketplace/repository.test.ts
@@ -238,6 +238,47 @@ describe('MarketplaceRepository', () => {
     })
   })
 
+  it('keeps the newest release cache even when that payload alone exceeds the byte budget', async () => {
+    const repository = new MarketplaceRepository(
+      await mkdtemp(join(tmpdir(), 'marketplace-release-oversize-'))
+    )
+    const oversized = Buffer.alloc(MAX_MARKETPLACE_RELEASE_CACHE_BYTES + 1024, 0x61)
+    await repository.cacheRelease(
+      'github-example',
+      'releases/example/0.json',
+      (0).toString(16).padStart(64, '0'),
+      new TextEncoder().encode('older-release'),
+      '2026-08-18T00:00:00.000Z'
+    )
+    await repository.cacheRelease(
+      'github-example',
+      'releases/example/1.json',
+      (1).toString(16).padStart(64, '0'),
+      oversized,
+      '2026-08-18T00:00:01.000Z'
+    )
+
+    const document = await repository.getAll()
+    expect(document.releaseCaches).toHaveLength(1)
+    expect(document.releaseCaches[0]?.path).toBe('releases/example/1.json')
+    await expect(
+      repository.getCachedRelease(
+        'github-example',
+        'releases/example/0.json',
+        (0).toString(16).padStart(64, '0')
+      )
+    ).resolves.toBeUndefined()
+    await expect(
+      repository.getCachedRelease(
+        'github-example',
+        'releases/example/1.json',
+        (1).toString(16).padStart(64, '0')
+      )
+    ).resolves.toMatchObject({
+      cachedAt: '2026-08-18T00:00:01.000Z'
+    })
+  })
+
   it('trims a historical document that already stored too many release caches', async () => {
     const root = await mkdtemp(join(tmpdir(), 'marketplace-release-historical-'))
     await writeFile(

--- a/src/main/specialist/marketplace/repository.ts
+++ b/src/main/specialist/marketplace/repository.ts
@@ -99,7 +99,9 @@ const isCanonicalBase64 = (value: unknown, maxLength: number): value is string =
     value.length === 0 ||
     value.length > maxLength ||
     value.length % 4 !== 0 ||
-    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)
+    // A grouped `{4}*` pattern overflows the regex stack on multi-mebibyte
+    // release payloads. Alphabet + canonical round-trip is linear.
+    /[^A-Za-z0-9+/=]/.test(value)
   ) {
     return false
   }
@@ -258,6 +260,9 @@ const boundReleaseCaches = (caches: MarketplaceReleaseCache[]): MarketplaceRelea
   for (const entry of ranked) {
     const size = releaseCachePayloadBytes(entry.item)
     if (kept.length >= MAX_MARKETPLACE_RELEASE_CACHE_ENTRIES) continue
+    // Fetch allows an 8 MiB release JSON, which can exceed the 4 MiB working-set
+    // budget by itself. Keep that newest row so offline fallback still works;
+    // drop older rows rather than evicting the payload just viewed.
     if (kept.length > 0 && keptBytes + size > MAX_MARKETPLACE_RELEASE_CACHE_BYTES) continue
     kept.push(entry)
     keptBytes += size

--- a/src/main/specialist/marketplace/repository.ts
+++ b/src/main/specialist/marketplace/repository.ts
@@ -73,6 +73,11 @@ const emptyDocument = (): MarketplaceDocument => ({
   releaseCaches: []
 })
 
+// Distinct release paths are stored as base64 in the same JSON document every
+// marketplace read parses. Cap the working set; root caches stay 1:1 with sources.
+export const MAX_MARKETPLACE_RELEASE_CACHE_ENTRIES = 16
+export const MAX_MARKETPLACE_RELEASE_CACHE_BYTES = 4 * 1024 * 1024
+
 const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((item) => typeof item === 'string')
 
@@ -225,6 +230,41 @@ const sanitizeReleaseCache = (value: unknown): MarketplaceReleaseCache | undefin
   }
 }
 
+const releaseCachePayloadBytes = (item: MarketplaceReleaseCache): number =>
+  Buffer.byteLength(item.bytesBase64, 'base64')
+
+const boundReleaseCaches = (caches: MarketplaceReleaseCache[]): MarketplaceReleaseCache[] => {
+  if (caches.length <= MAX_MARKETPLACE_RELEASE_CACHE_ENTRIES) {
+    let totalBytes = 0
+    let withinBudget = true
+    for (const item of caches) {
+      totalBytes += releaseCachePayloadBytes(item)
+      if (totalBytes > MAX_MARKETPLACE_RELEASE_CACHE_BYTES) {
+        withinBudget = false
+        break
+      }
+    }
+    if (withinBudget) return caches
+  }
+
+  const ranked = caches
+    .map((item, index) => ({ item, index }))
+    .sort((left, right) => {
+      const time = Date.parse(right.item.cachedAt) - Date.parse(left.item.cachedAt)
+      return time !== 0 ? time : right.index - left.index
+    })
+  const kept: { item: MarketplaceReleaseCache; index: number }[] = []
+  let keptBytes = 0
+  for (const entry of ranked) {
+    const size = releaseCachePayloadBytes(entry.item)
+    if (kept.length >= MAX_MARKETPLACE_RELEASE_CACHE_ENTRIES) continue
+    if (kept.length > 0 && keptBytes + size > MAX_MARKETPLACE_RELEASE_CACHE_BYTES) continue
+    kept.push(entry)
+    keptBytes += size
+  }
+  return kept.sort((left, right) => left.index - right.index).map((entry) => entry.item)
+}
+
 const sanitizeDocument = (value: unknown): MarketplaceDocument => {
   if (!value || typeof value !== 'object') return emptyDocument()
   const document = value as {
@@ -250,9 +290,11 @@ const sanitizeDocument = (value: unknown): MarketplaceDocument => {
     rootCaches: Array.isArray(document.rootCaches)
       ? document.rootCaches.flatMap((item) => sanitizeRootCache(item) ?? [])
       : [],
-    releaseCaches: Array.isArray(document.releaseCaches)
-      ? document.releaseCaches.flatMap((item) => sanitizeReleaseCache(item) ?? [])
-      : []
+    releaseCaches: boundReleaseCaches(
+      Array.isArray(document.releaseCaches)
+        ? document.releaseCaches.flatMap((item) => sanitizeReleaseCache(item) ?? [])
+        : []
+    )
   }
 }
 
@@ -398,12 +440,12 @@ export class MarketplaceRepository {
     }
     await this.mutate((document) => ({
       ...document,
-      releaseCaches: [
+      releaseCaches: boundReleaseCaches([
         ...document.releaseCaches.filter(
           (item) => item.sourceId !== sourceId || item.path !== path
         ),
         cache
-      ]
+      ])
     }))
   }
 


### PR DESCRIPTION
## Problem

Marketplace release metadata is cached inside `specialist-marketplace.json` as `bytesBase64`. Replacement is keyed only by `(sourceId, path)`, so **distinct paths accumulate with no count, TTL, or total-byte cap**. `getAll()` JSON-parses that whole document (sources, provenance, **and every cached blob**) on list, refresh, install, and every other mutate.

**Correction of the external description:** the cached payload is verified **release JSON** (`RELEASE_MAX_BYTES = 8 MiB`), not the specialist ZIP (`ARTIFACT_MAX_BYTES = 50 MiB`, never persisted here). The failure mode is the same: binary-as-base64 rows in one durable JSON file.

### When it happens

- Opening Specialist details (`getRelease` / install preview) downloads the release JSON and calls `cacheRelease`.
- The same specialist version is replaced in place. A **new version or a different specialist** uses a different `releases/…/x.y.z.json` path and **appends**.
- User-added GitHub sources do the same under their own `sourceId`.
- `rootCaches` are 1:1 with sources (replaced, dropped on `removeSource`) and are **not** this bug.

### If left unbounded

- `specialist-marketplace.json` grows without a working-set cap (theoretical worst case: thousands of up-to-8 MiB blobs).
- Every marketplace `getAll()` / `mutate()` parses and pretty-prints the entire cache, so listing and install get slower and more memory-heavy over time.
- Offline fallback still works for old paths, but the document is no longer a cache; it is an unbounded archive.

## Proposed change

Keep the existing document (`version: 1`, same fields) and evict `releaseCaches` by recency (`cachedAt`, then write order):

- at most **16** entries
- at most **4 MiB** decoded payload
- the newest entry is always kept, even if that one payload is over budget (an 8 MiB release JSON can still be the sole cache row)
- applied on `cacheRelease` (persist) and on `sanitizeDocument` (in-memory `getAll()` of a historical bloated file)

No architecture change, no UI, no new persisted fields, no document version bump, no wall-clock TTL. Root serving already has a 60s TTL; release cache is network-first and only a digest-matched fallback, so a serving TTL would weaken offline use without bounding growth better than count + bytes.

## Scope and non-goals

- Does **not** split blobs into sidecar files or stop `getAll()` from being a whole-document read (bounding the array is enough for the reported growth).
- Does **not** bound `rootCaches` (already 1:1 with sources).
- Does **not** cache the specialist ZIP.

## Historical data compatibility

- No migration. Same `version: 1` shape.
- Extra historical `releaseCaches` rows are dropped from the **in-memory** working set on `getAll()`; the next mutate persists the trimmed array.
- Sources, installations, and pending installs are untouched.
- Evicted rows become a cache miss: online refetch, or offline failure for that old path (same as never cached).

## Enums / interaction / data model

- **No new enum values.**
- **No user-visible interaction change.**
- **No schema/field additions.** Persistence policy only: fewer `releaseCaches` rows may remain on disk.

## Persistence

- File: `specialist-marketplace.json`
- Still pretty-printed durable JSON
- Bounded `releaseCaches`; other arrays unchanged

## Acceptance criteria and validation

Regression tests were added first and **failed on unfixed code** for the reported phenomenon (`expected 20 to be less than 20` distinct paths; three 2 MiB payloads kept; historical `getAll()` returned 20). Same tests pass after the bound.

| behavior | command | result |
| --- | --- | --- |
| Same `(sourceId, path)` still replaces in place | `npm test -- src/main/specialist/marketplace/repository.test.ts` | pass |
| Distinct paths no longer accumulate without bound | same | pass (failed on unfixed: 20 kept) |
| Decoded payload over 4 MiB evicts oldest | same | pass (failed on unfixed: 3 kept) |
| Historical bloated document is a bounded `getAll()` working set | same | pass (failed on unfixed: 20 kept) |
| Existing marketplace service cache/fallback behavior | `npm test -- src/main/specialist/marketplace/service.test.ts` | pass |
| Main-process types | `npm run typecheck:node` | pass |
| Lint of changed files | `npx eslint src/main/specialist/marketplace/repository.ts src/main/specialist/marketplace/repository.test.ts` | pass |

These checks ran after the last material edit. Marketplace is not a named `test:module` owner; PR Gate / CI remains authoritative for the full portable suite.

Uncovered risks: a single 8 MiB release still occupies the byte budget alone (intentional); evicting an old path while offline loses fallback for that path (intentional cache miss).

## Review focus

- Eviction order (newest `cachedAt` wins; original order of survivors).
- Read-path trim in `sanitizeDocument` vs write-path trim in `cacheRelease`.
- Whether 16 / 4 MiB is the right working set; a wall-clock TTL was deliberately omitted.