### PR TITLE
fix(specialists): reject oversized directory packages before reading files

### DIFF
--- a/src/main/specialist/package/adapters.test.ts
+++ b/src/main/specialist/package/adapters.test.ts
@@ -1,4 +1,4 @@
-import { link, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { link, mkdir, mkdtemp, open, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -399,6 +399,91 @@ describe('Specialist package source adapters', () => {
         expect.objectContaining({ code: 'package.hard-link-forbidden' })
       ])
       expect(JSON.stringify(result.preview)).not.toContain('secret')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('accepts the directory file-count boundary and blocks the first file above it', async () => {
+    const extraAtLimit = SPECIALIST_PACKAGE_ARCHIVE_LIMITS.fileCount - 3
+    const writePackage = async (root: string, extraFiles: number): Promise<void> => {
+      await writeFile(
+        join(root, 'manifest.json'),
+        await readFile(join(fixtureRoot, 'manifest.json'))
+      )
+      await writeFile(
+        join(root, 'specialist.json'),
+        await readFile(join(fixtureRoot, 'specialist.json'))
+      )
+      await writeFile(join(root, 'README.txt'), await readFile(join(fixtureRoot, 'README.txt')))
+      await mkdir(join(root, 'skills', 'example', 'references'), { recursive: true })
+      await Promise.all(
+        Array.from({ length: extraFiles }, (_, index) =>
+          writeFile(join(root, 'skills', 'example', 'references', `${index}.md`), '')
+        )
+      )
+    }
+    const atLimitRoot = await mkdtemp(join(tmpdir(), 'specialist-dir-count-limit-'))
+    const aboveLimitRoot = await mkdtemp(join(tmpdir(), 'specialist-dir-count-overflow-'))
+    try {
+      await writePackage(atLimitRoot, extraAtLimit)
+      await writePackage(aboveLimitRoot, extraAtLimit + 1)
+
+      const atLimit = await validateSpecialistDirectory(atLimitRoot, catalog)
+      const aboveLimit = await validateSpecialistDirectory(aboveLimitRoot, catalog)
+
+      expect(atLimit.preview.diagnostics).not.toContainEqual(
+        expect.objectContaining({ code: 'package.archive-file-count-exceeded' })
+      )
+      expect(aboveLimit.preview.installable).toBe(false)
+      expect(aboveLimit.preview.diagnostics).toContainEqual(
+        expect.objectContaining({
+          code: 'package.archive-file-count-exceeded',
+          actual: SPECIALIST_PACKAGE_ARCHIVE_LIMITS.fileCount + 1,
+          limit: SPECIALIST_PACKAGE_ARCHIVE_LIMITS.fileCount,
+          unit: 'files'
+        })
+      )
+      expect(aboveLimit.preview.diagnostics).not.toContainEqual(
+        expect.objectContaining({ code: 'skill.document-missing' })
+      )
+    } finally {
+      await rm(atLimitRoot, { recursive: true, force: true })
+      await rm(aboveLimitRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects an oversized directory file from metadata before reading it', async () => {
+    const actual = SPECIALIST_PACKAGE_ARCHIVE_LIMITS.fileBytes + 1
+    const root = await mkdtemp(join(tmpdir(), 'specialist-dir-file-size-'))
+    try {
+      await writeFile(
+        join(root, 'manifest.json'),
+        await readFile(join(fixtureRoot, 'manifest.json'))
+      )
+      await writeFile(
+        join(root, 'specialist.json'),
+        await readFile(join(fixtureRoot, 'specialist.json'))
+      )
+      const handle = await open(join(root, 'payload.bin'), 'w')
+      await handle.truncate(actual)
+      await handle.close()
+
+      const result = await validateSpecialistDirectory(root, catalog)
+
+      expect(result.preview.installable).toBe(false)
+      expect(result.preview.diagnostics).toContainEqual(
+        expect.objectContaining({
+          code: 'package.archive-file-size-exceeded',
+          path: 'payload.bin',
+          actual,
+          limit: SPECIALIST_PACKAGE_ARCHIVE_LIMITS.fileBytes,
+          unit: 'bytes'
+        })
+      )
+      expect(result.preview.diagnostics).not.toContainEqual(
+        expect.objectContaining({ code: 'package.top-level-content-forbidden' })
+      )
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/src/main/specialist/package/directory-adapter.ts
+++ b/src/main/specialist/package/directory-adapter.ts
@@ -1,32 +1,130 @@
 import { lstat, readFile, readdir } from 'node:fs/promises'
 import { join } from 'node:path'
 
-import type {
-  SpecialistPackageCatalogSnapshot,
-  SpecialistPackageSource,
-  SpecialistPackageValidationResult
+import {
+  SPECIALIST_PACKAGE_ARCHIVE_LIMITS,
+  type PackageDiagnostic,
+  type SpecialistPackageArchiveMetrics,
+  type SpecialistPackageCatalogSnapshot,
+  type SpecialistPackageSource,
+  type SpecialistPackageValidationResult
 } from '../../../shared/specialist-package'
 import { validateSpecialistPackage, type SpecialistPackageFile } from './validator'
 
-const readDirectoryFiles = async (
+const LIMITS = SPECIALIST_PACKAGE_ARCHIVE_LIMITS
+
+const issue = (
+  diagnostics: PackageDiagnostic[],
+  code: string,
+  message: string,
+  path?: string,
+  measurement?: Pick<PackageDiagnostic, 'actual' | 'limit' | 'unit'>
+): void => {
+  diagnostics.push({
+    severity: 'error',
+    code,
+    message,
+    ...(path ? { path } : {}),
+    ...measurement
+  })
+}
+
+const scanDirectory = async (
   root: string,
-  relativeDirectory = ''
-): Promise<SpecialistPackageFile[]> => {
+  limits = LIMITS
+): Promise<{
+  files?: SpecialistPackageFile[]
+  diagnostics: PackageDiagnostic[]
+  archive: SpecialistPackageArchiveMetrics
+}> => {
+  const diagnostics: PackageDiagnostic[] = []
   const files: SpecialistPackageFile[] = []
-  const directory = relativeDirectory ? join(root, relativeDirectory) : root
-  for (const entry of await readdir(directory, { withFileTypes: true })) {
-    const relativePath = relativeDirectory ? `${relativeDirectory}/${entry.name}` : entry.name
-    const absolutePath = join(root, ...relativePath.split('/'))
-    const metadata = await lstat(absolutePath)
-    if (metadata.isSymbolicLink()) throw new Error('symbolic-link')
-    if (metadata.isFile() && metadata.nlink > 1) throw new Error('hard-link')
-    if (entry.isDirectory()) {
-      files.push(...(await readDirectoryFiles(root, relativePath)))
-    } else if (entry.isFile()) {
+  let fileCount = 0
+  let uncompressedBytes = 0
+  let overflow = false
+
+  const visit = async (relativeDirectory = ''): Promise<void> => {
+    if (overflow) return
+    const directory = relativeDirectory ? join(root, relativeDirectory) : root
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      if (overflow) return
+      const relativePath = relativeDirectory ? `${relativeDirectory}/${entry.name}` : entry.name
+      const absolutePath = join(root, ...relativePath.split('/'))
+      const depth = relativePath.split('/').filter(Boolean).length
+      if (depth > limits.pathDepth) {
+        issue(
+          diagnostics,
+          'package.archive-path-depth-exceeded',
+          'The archive entry is nested too deeply.',
+          relativePath,
+          { actual: depth, limit: limits.pathDepth, unit: 'levels' }
+        )
+        if (entry.isDirectory()) continue
+      }
+      const metadata = await lstat(absolutePath)
+      if (metadata.isSymbolicLink()) throw new Error('symbolic-link')
+      if (metadata.isFile() && metadata.nlink > 1) throw new Error('hard-link')
+      if (entry.isDirectory()) {
+        await visit(relativePath)
+        continue
+      }
+      if (!entry.isFile()) continue
+
+      fileCount += 1
+      uncompressedBytes += metadata.size
+      if (fileCount > limits.fileCount || uncompressedBytes > limits.uncompressedBytes) {
+        overflow = true
+      }
+      if (metadata.size > limits.fileBytes) {
+        issue(
+          diagnostics,
+          'package.archive-file-size-exceeded',
+          'An archive entry exceeds the safe preview limit.',
+          relativePath,
+          { actual: metadata.size, limit: limits.fileBytes, unit: 'bytes' }
+        )
+      }
+      const extractable =
+        depth <= limits.pathDepth &&
+        metadata.size <= limits.fileBytes &&
+        fileCount <= limits.fileCount &&
+        uncompressedBytes <= limits.uncompressedBytes
+      if (!extractable) continue
       files.push({ path: relativePath, bytes: new Uint8Array(await readFile(absolutePath)) })
     }
   }
-  return files
+
+  await visit()
+  const archive: SpecialistPackageArchiveMetrics = {
+    compressedBytes: 0,
+    uncompressedBytes,
+    fileCount,
+    limits
+  }
+  if (fileCount > limits.fileCount) {
+    issue(
+      diagnostics,
+      'package.archive-file-count-exceeded',
+      'The archive contains too many files.',
+      undefined,
+      { actual: fileCount, limit: limits.fileCount, unit: 'files' }
+    )
+  }
+  if (uncompressedBytes > limits.uncompressedBytes) {
+    issue(
+      diagnostics,
+      'package.archive-uncompressed-size-exceeded',
+      'The expanded archive exceeds the safe preview limit.',
+      undefined,
+      {
+        actual: uncompressedBytes,
+        limit: limits.uncompressedBytes,
+        unit: 'bytes'
+      }
+    )
+  }
+  if (diagnostics.some((entry) => entry.severity === 'error')) return { diagnostics, archive }
+  return { files, diagnostics, archive }
 }
 
 export const validateSpecialistDirectory = async (
@@ -35,8 +133,24 @@ export const validateSpecialistDirectory = async (
   source: Extract<SpecialistPackageSource, 'directory' | 'builtin'> = 'directory'
 ): Promise<SpecialistPackageValidationResult> => {
   try {
-    const files = await readDirectoryFiles(root)
-    return validateSpecialistPackage(files, catalog, source)
+    const scanned = await scanDirectory(root)
+    if (!scanned.files) {
+      return {
+        preview: {
+          diagnostics: scanned.diagnostics,
+          installable: false,
+          archive: scanned.archive
+        }
+      }
+    }
+    const result = validateSpecialistPackage(scanned.files, catalog, source)
+    return {
+      ...result,
+      preview: {
+        ...result.preview,
+        archive: scanned.archive
+      }
+    }
   } catch (error) {
     const symbolicLink = error instanceof Error && error.message === 'symbolic-link'
     const hardLink = error instanceof Error && error.message === 'hard-link'


### PR DESCRIPTION
## Problem

ZIP Specialist packages count files and uncompressed bytes from archive metadata while unzipping, then refuse to extract past `SPECIALIST_PACKAGE_ARCHIVE_LIMITS` (50 MiB compressed / 200 MiB uncompressed / 2,000 files / 25 MiB per file / depth 32).

Directory packages did the opposite: `validateSpecialistDirectory` recursively `readFile`d the whole tree into `Uint8Array[]` and only then called content validation. A large or malicious directory could fill main-process memory before any fuse ran.

This is the builtin Specialist load path at startup (`BuiltinSpecialistRegistry`) and the shared directory validation boundary that tests already treat as ZIP-equivalent. User import remains ZIP-only.

## Proposed change

Walk the directory with `lstat` first. Count files, accumulate `stat.size`, and check path depth before `readFile`. Stop reading a file that would exceed the per-file, total-bytes, file-count, or depth limit, and stop walking once cumulative file count or uncompressed bytes overflow. Return the existing archive-layer diagnostic codes (`package.archive-file-count-exceeded`, `package.archive-file-size-exceeded`, `package.archive-uncompressed-size-exceeded`, `package.archive-path-depth-exceeded`) and skip content validation when those errors are present — the same contract ZIP already uses.

No new diagnostic codes, persisted fields, schema, or import UI.

## Scope and non-goals

- **In scope:** `validateSpecialistDirectory` / `src/main/specialist/package/directory-adapter.ts`.
- **Out of scope:** Electron ZIP picker (`selectSpecialistArchive`) already rejects compressed files over 50 MiB before reading.
- **Out of scope:** Builtin Skill export snapshot hashing (`builtin-specialist-package-adapter.ts`) is a trusted packaging path, not untrusted package validation.

## Acceptance criteria and validation

- A directory with 2,000 files is accepted at the archive layer; 2,001 files is rejected with `package.archive-file-count-exceeded` and is not content-validated.
- A file larger than 25 MiB is rejected from `lstat` size with `package.archive-file-size-exceeded` and does not produce content-layer diagnostics for that file.
- Existing ZIP fuses, directory/ZIP diagnostic parity, hard-link rejection, and builtin registry loading are unchanged.

Regression tests failed on unfixed code for the reported reason (oversized directory stayed installable; oversized file was content-validated as forbidden top-level content) and pass after the fix.

### Test impact (ran after the last material edit)

| Behavior | Command | Result |
| --- | --- | --- |
| Directory archive fuses and ZIP/directory adapter parity | `npx vitest run src/main/specialist/package/adapters.test.ts` | pass (17) |
| Builtin registry consumer of directory validation | `npx vitest run src/main/specialist/builtin-registry.test.ts` | pass (5) |
| Package content validator | `npx vitest run src/main/specialist/package/validator.test.ts` | pass (30) |
| Package service | `npx vitest run src/main/specialist/package/service.test.ts` | pass (44) |
| Electron ZIP picker (unchanged, size check already present) | `npx vitest run src/main/specialist/package/electron-adapter.test.ts` | pass (6) |
| Contribution template, marketplace ZIP, transaction, release certification | `npx vitest run src/main/specialist/package/contribution-template.test.ts src/main/specialist/package/marketplace-zip.test.ts src/main/specialist/package/transaction.test.ts src/main/specialist/package/release-certification.test.ts` | pass (22) |
| Node types | `npx tsc --noEmit -p tsconfig.node.json --composite false` | pass |
| Lint of changed files | `npx eslint src/main/specialist/package/directory-adapter.ts src/main/specialist/package/adapters.test.ts` | pass |

`adapters.test.ts` is not owned by a `test:module` id. Directory proximity tests in `src/main/specialist/package/` plus the builtin-registry consumer were used instead of a full `npm test`. PR Gate remains authoritative.

### Uncovered risks

- Builtin Skill export still reads whole skill directories for hashing. That path is trusted app content, not the import validator.
- Directory file-count `actual` is the count seen when the walk stops (`limit + 1`), not a full-tree census. Continuing the walk would reintroduce the directory-walk DoS.
- Renderer archive-limit copy still says “ZIP”. Directory/builtin failures use the same codes; user import is ZIP-only today.

## Review focus

- Confirm the directory walk uses `lstat` size/count/depth before `readFile`, and that content validation does not run after an archive-layer error.
- Confirm diagnostic codes stay on the existing ZIP archive-layer vocabulary (no new enum or persisted shape).