### PR TITLE
feat(connectors): complete OAuth authorization lifecycle

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -853,6 +853,8 @@ colors communicate a successful or failed probe/migration result.
 - The single wrapping toolbar row contains source (`w-36`), agent (`w-48`), and Tag controls followed by a flex-1 search field; **Add connector** remains the final, far-right control. Search stays in this first row when space permits and wraps with the toolbar at narrow widths.
 - Bundled and custom rows retain the leading generic Connector glyph. The name and description open detail for bundled Connectors and edit for custom Connectors; the metadata line begins with Connector-specific status when present, then the shared actual-user avatar stack and Tag badges.
 - Trailing controls retain Connector-specific retry, configure, and sign-in actions, followed by Tag assignment, one `ChevronDown` action menu for custom Connectors, and the unlabeled Main switch. The custom menu orders Export, Edit, separator, Remove; removal continues to use the Specialist impact check and confirmation dialog.
+- Creating a custom OAuth Connector saves its configuration first, then immediately starts browser authorization in a cancellable dialog. Cancelling or failing authorization keeps the saved Connector disabled so the user can retry from the same dialog or finish later. Existing Connector rows reuse this dialog for sign-in rather than presenting a separate inline waiting state.
+- When a runtime refresh shows that a previously authenticated OAuth Connector has lost its tokens, the app raises one transient global notice with a shortcut back to Settings. The Connector row remains the persistent source of truth and continues to show that sign-in is required. This notice is session-local UI state: it adds no persisted status field, migration, or shared enum value.
 
 ## Clickable Area Guidelines
 

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -236,6 +236,9 @@ vi.mock('@/components/LegacyDataMoveDialog', () => ({
 vi.mock('@/components/LifecycleToast', () => ({
   LifecycleToast: (): React.JSX.Element => <div data-testid="lifecycle-toast" />
 }))
+vi.mock('@/components/ConnectorAuthToast', () => ({
+  ConnectorAuthToast: (): React.JSX.Element => <div data-testid="connector-auth-toast" />
+}))
 vi.mock('@/components/NotificationLiveToast', () => ({
   NotificationLiveToast: (): React.JSX.Element => <div data-testid="notification-live-toast" />
 }))
@@ -637,6 +640,11 @@ describe('App startup routing', () => {
     ).not.toBeNull()
     expect(
       container.querySelector('[data-testid="lifecycle-toast"]')?.closest('[aria-hidden="true"]')
+    ).not.toBeNull()
+    expect(
+      container
+        .querySelector('[data-testid="connector-auth-toast"]')
+        ?.closest('[aria-hidden="true"]')
     ).not.toBeNull()
     expect(
       container.querySelector('[data-testid="permission-undo"]')?.closest('[aria-hidden="true"]')

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -11,6 +11,7 @@ import { CloseConfirmModal } from '@/components/CloseConfirmModal'
 import { DataRootMissingDialog } from '@/components/DataRootMissingDialog'
 import { LegacyDataMoveDialog } from '@/components/LegacyDataMoveDialog'
 import { LifecycleToast } from '@/components/LifecycleToast'
+import { ConnectorAuthToast } from '@/components/ConnectorAuthToast'
 import { NotificationLiveToast } from '@/components/NotificationLiveToast'
 import { OpenScienceLogoLoader } from '@/components/OpenScienceLogoLoader'
 import { PermissionUndoSnackbar } from '@/components/PermissionUndoSnackbar'
@@ -661,6 +662,7 @@ const AppContent = (): React.JSX.Element | null => {
           onDismiss={lifecycleSync.dismissNotice}
           onView={lifecycleSync.viewNotice}
         />
+        <ConnectorAuthToast />
         <NotificationLiveToast />
         <PermissionUndoSnackbar />
       </div>

--- a/src/renderer/src/components/ActionToast.test.tsx
+++ b/src/renderer/src/components/ActionToast.test.tsx
@@ -53,4 +53,27 @@ describe('ActionToast', () => {
     await act(async () => vi.advanceTimersByTime(6000))
     expect(onDismiss).toHaveBeenCalledOnce()
   })
+
+  it('keeps its dismissal deadline when a parent passes a new callback', async () => {
+    const onDismiss = vi.fn()
+    const renderToast = (): void => {
+      root.render(
+        <ActionToast
+          title="Connector needs sign-in"
+          actionLabel="Open Connectors"
+          dismissLabel="Dismiss"
+          onAction={vi.fn()}
+          onDismiss={() => onDismiss()}
+          autoDismissMs={6000}
+        />
+      )
+    }
+    await act(async () => renderToast())
+
+    await act(async () => vi.advanceTimersByTime(3000))
+    await act(async () => renderToast())
+    await act(async () => vi.advanceTimersByTime(3000))
+
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
 })

--- a/src/renderer/src/components/ActionToast.test.tsx
+++ b/src/renderer/src/components/ActionToast.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ActionToast } from './ActionToast'
+
+describe('ActionToast', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    container.remove()
+    vi.useRealTimers()
+  })
+
+  it('runs its action and pauses automatic dismissal while focused', async () => {
+    const onAction = vi.fn()
+    const onDismiss = vi.fn()
+    await act(async () =>
+      root.render(
+        <ActionToast
+          title="Connector needs sign-in"
+          detail="OAuth MCP"
+          actionLabel="Open Connectors"
+          dismissLabel="Dismiss"
+          onAction={onAction}
+          onDismiss={onDismiss}
+          autoDismissMs={6000}
+        />
+      )
+    )
+
+    const action = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Open Connectors'
+    )
+    act(() => action?.focus())
+    action?.click()
+    expect(onAction).toHaveBeenCalledOnce()
+
+    await act(async () => vi.advanceTimersByTime(6000))
+    expect(onDismiss).not.toHaveBeenCalled()
+
+    act(() => action?.blur())
+    await act(async () => vi.advanceTimersByTime(6000))
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/components/ActionToast.test.tsx
+++ b/src/renderer/src/components/ActionToast.test.tsx
@@ -42,7 +42,14 @@ describe('ActionToast', () => {
     const action = [...container.querySelectorAll('button')].find(
       (button) => button.textContent === 'Open Connectors'
     )
-    act(() => action?.focus())
+    const toast = container.querySelector('[role="status"]')
+    act(() => {
+      action?.focus()
+      toast?.dispatchEvent(new MouseEvent('pointerover', { bubbles: true }))
+      toast?.dispatchEvent(
+        new MouseEvent('pointerout', { bubbles: true, relatedTarget: document.body })
+      )
+    })
     action?.click()
     expect(onAction).toHaveBeenCalledOnce()
 

--- a/src/renderer/src/components/ActionToast.tsx
+++ b/src/renderer/src/components/ActionToast.tsx
@@ -1,6 +1,6 @@
 /* Hallmark · component: action toast · genre: modern-minimal · theme: project app tokens */
 /* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4 · contrast: project tokens · slop: pass */
-import { useEffect, useState } from 'react'
+import { useEffect, useEffectEvent, useState } from 'react'
 import { X } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
@@ -29,12 +29,13 @@ const ActionToast = ({
   testId
 }: ActionToastProps): React.JSX.Element => {
   const [paused, setPaused] = useState(false)
+  const dismissAfterTimeout = useEffectEvent(onDismiss)
 
   useEffect(() => {
     if (!autoDismissMs || paused) return
-    const timeout = window.setTimeout(onDismiss, autoDismissMs)
+    const timeout = window.setTimeout(dismissAfterTimeout, autoDismissMs)
     return () => window.clearTimeout(timeout)
-  }, [autoDismissMs, onDismiss, paused])
+  }, [autoDismissMs, paused])
 
   return (
     <div

--- a/src/renderer/src/components/ActionToast.tsx
+++ b/src/renderer/src/components/ActionToast.tsx
@@ -1,0 +1,82 @@
+/* Hallmark · component: action toast · genre: modern-minimal · theme: project app tokens */
+/* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4 · contrast: project tokens · slop: pass */
+import { useEffect, useState } from 'react'
+import { X } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+type ActionToastProps = {
+  title: string
+  detail?: string
+  actionLabel: string
+  dismissLabel: string
+  onAction: () => void
+  onDismiss: () => void
+  autoDismissMs?: number
+  className?: string
+  testId?: string
+}
+
+const ActionToast = ({
+  title,
+  detail,
+  actionLabel,
+  dismissLabel,
+  onAction,
+  onDismiss,
+  autoDismissMs,
+  className,
+  testId
+}: ActionToastProps): React.JSX.Element => {
+  const [paused, setPaused] = useState(false)
+
+  useEffect(() => {
+    if (!autoDismissMs || paused) return
+    const timeout = window.setTimeout(onDismiss, autoDismissMs)
+    return () => window.clearTimeout(timeout)
+  }, [autoDismissMs, onDismiss, paused])
+
+  return (
+    <div
+      role="status"
+      data-testid={testId}
+      onPointerEnter={() => setPaused(true)}
+      onPointerLeave={() => setPaused(false)}
+      onFocusCapture={() => setPaused(true)}
+      onBlurCapture={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) setPaused(false)
+      }}
+      className={cn(
+        'fixed right-3 top-3 z-toast flex w-[min(24rem,calc(100vw-1.5rem))] items-center gap-3 rounded-lg border border-border-100 bg-bg-200 px-3 py-2 text-sm text-text-100 shadow-lg',
+        className
+      )}
+    >
+      <span className="min-w-0 flex-1">
+        <span className="block">{title}</span>
+        {detail ? (
+          <span className="block truncate text-xs text-text-300" title={detail}>
+            {detail}
+          </span>
+        ) : null}
+      </span>
+      <button
+        type="button"
+        onClick={onAction}
+        className="inline-flex h-7 shrink-0 items-center rounded px-2 text-xs font-medium whitespace-nowrap text-primary hover:bg-bg-300 focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+      >
+        {actionLabel}
+      </button>
+      <button
+        type="button"
+        aria-label={dismissLabel}
+        onClick={onDismiss}
+        className="inline-flex size-7 shrink-0 items-center justify-center rounded text-text-300 hover:bg-bg-300 hover:text-text-100 focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+      >
+        <X className="size-3.5" aria-hidden="true" />
+      </button>
+    </div>
+  )
+}
+
+export { ActionToast }
+export type { ActionToastProps }

--- a/src/renderer/src/components/ActionToast.tsx
+++ b/src/renderer/src/components/ActionToast.tsx
@@ -28,7 +28,9 @@ const ActionToast = ({
   className,
   testId
 }: ActionToastProps): React.JSX.Element => {
-  const [paused, setPaused] = useState(false)
+  const [hovered, setHovered] = useState(false)
+  const [focusedWithin, setFocusedWithin] = useState(false)
+  const paused = hovered || focusedWithin
   const dismissAfterTimeout = useEffectEvent(onDismiss)
 
   useEffect(() => {
@@ -41,11 +43,11 @@ const ActionToast = ({
     <div
       role="status"
       data-testid={testId}
-      onPointerEnter={() => setPaused(true)}
-      onPointerLeave={() => setPaused(false)}
-      onFocusCapture={() => setPaused(true)}
+      onPointerEnter={() => setHovered(true)}
+      onPointerLeave={() => setHovered(false)}
+      onFocusCapture={() => setFocusedWithin(true)}
       onBlurCapture={(event) => {
-        if (!event.currentTarget.contains(event.relatedTarget)) setPaused(false)
+        if (!event.currentTarget.contains(event.relatedTarget)) setFocusedWithin(false)
       }}
       className={cn(
         'fixed right-3 top-3 z-toast flex w-[min(24rem,calc(100vw-1.5rem))] items-center gap-3 rounded-lg border border-border-100 bg-bg-200 px-3 py-2 text-sm text-text-100 shadow-lg',

--- a/src/renderer/src/components/ConnectorAuthToast.test.tsx
+++ b/src/renderer/src/components/ConnectorAuthToast.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+import { ConnectorAuthToast } from './ConnectorAuthToast'
+
+describe('ConnectorAuthToast', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    useSettingsStore.setState({
+      ...createInitialSettingsState(),
+      connectorAuthNotice: { id: 'oauth-mcp', displayName: 'OAuth MCP' },
+      loadConnectors: vi.fn().mockResolvedValue(undefined),
+      dismissConnectorAuthNotice: vi.fn(),
+      openSettingsToPanel: vi.fn()
+    })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('loads the runtime projection and opens Connector settings from the notice', async () => {
+    await act(async () => root.render(<ConnectorAuthToast />))
+
+    expect(useSettingsStore.getState().loadConnectors).toHaveBeenCalledOnce()
+    expect(container.textContent).toContain('OAuth MCP needs sign-in')
+    const open = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Open Connectors'
+    )
+    act(() => open?.click())
+
+    expect(useSettingsStore.getState().dismissConnectorAuthNotice).toHaveBeenCalledOnce()
+    expect(useSettingsStore.getState().openSettingsToPanel).toHaveBeenCalledWith('connectors')
+  })
+})

--- a/src/renderer/src/components/ConnectorAuthToast.tsx
+++ b/src/renderer/src/components/ConnectorAuthToast.tsx
@@ -1,0 +1,45 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useSettingsStore } from '@/stores/settings-store'
+import { ActionToast } from './ActionToast'
+
+const AUTO_DISMISS_MS = 8000
+
+// Starts the existing Connector runtime subscription at app scope and projects only actionable
+// reauthentication transitions. The durable recovery state remains the Connector row in Settings.
+const ConnectorAuthToast = (): React.JSX.Element | null => {
+  const { t } = useTranslation()
+  const notice = useSettingsStore((state) => state.connectorAuthNotice)
+  const loadConnectors = useSettingsStore((state) => state.loadConnectors)
+  const dismissConnectorAuthNotice = useSettingsStore((state) => state.dismissConnectorAuthNotice)
+  const openSettingsToPanel = useSettingsStore((state) => state.openSettingsToPanel)
+
+  useEffect(() => {
+    void loadConnectors().catch(() => undefined)
+  }, [loadConnectors])
+
+  if (!notice) return null
+
+  return (
+    <ActionToast
+      key={notice.id}
+      title={t('{{name}} needs sign-in', { name: notice.displayName })}
+      detail={t(
+        'Authorization expired or was revoked. Sign in again to keep this Connector available.'
+      )}
+      actionLabel={t('Open Connectors')}
+      dismissLabel={t('Dismiss')}
+      onAction={() => {
+        dismissConnectorAuthNotice()
+        openSettingsToPanel('connectors')
+      }}
+      onDismiss={dismissConnectorAuthNotice}
+      autoDismissMs={AUTO_DISMISS_MS}
+      className="top-20"
+      testId="connector-auth-toast"
+    />
+  )
+}
+
+export { ConnectorAuthToast }

--- a/src/renderer/src/components/LifecycleToast.test.tsx
+++ b/src/renderer/src/components/LifecycleToast.test.tsx
@@ -45,4 +45,34 @@ describe('LifecycleToast', () => {
     await act(async () => vi.advanceTimersByTime(6000))
     expect(onDismiss).toHaveBeenCalledOnce()
   })
+
+  it('restarts automatic dismissal for a newer notice', async () => {
+    const onDismiss = vi.fn()
+    const onView = vi.fn()
+    await act(async () =>
+      root.render(
+        <LifecycleToast
+          notice={{ projectId: 'project-1', sessionId: 'session-1', title: 'First session' }}
+          onDismiss={onDismiss}
+          onView={onView}
+        />
+      )
+    )
+
+    await act(async () => vi.advanceTimersByTime(3000))
+    await act(async () =>
+      root.render(
+        <LifecycleToast
+          notice={{ projectId: 'project-1', sessionId: 'session-2', title: 'Second session' }}
+          onDismiss={onDismiss}
+          onView={onView}
+        />
+      )
+    )
+    await act(async () => vi.advanceTimersByTime(3000))
+    expect(onDismiss).not.toHaveBeenCalled()
+
+    await act(async () => vi.advanceTimersByTime(3000))
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
 })

--- a/src/renderer/src/components/LifecycleToast.tsx
+++ b/src/renderer/src/components/LifecycleToast.tsx
@@ -1,8 +1,7 @@
-import { useEffect } from 'react'
-import { X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import type { ExternalSessionNotice } from '@/hooks/useLifecycleSync'
+import { ActionToast } from './ActionToast'
 
 const AUTO_DISMISS_MS = 6000
 
@@ -17,42 +16,20 @@ const LifecycleToast = ({
 }): React.JSX.Element | null => {
   const { t } = useTranslation()
 
-  useEffect(() => {
-    if (!notice) return
-    const timeout = window.setTimeout(onDismiss, AUTO_DISMISS_MS)
-    return () => window.clearTimeout(timeout)
-  }, [notice, onDismiss])
-
   if (!notice) return null
 
   return (
-    <div
-      role="status"
-      data-testid="lifecycle-toast"
-      className="fixed right-3 top-3 z-50 flex max-w-sm items-center gap-3 rounded-lg border border-border-100 bg-bg-200 px-3 py-2 text-sm text-text-100 shadow-lg"
-    >
-      <span className="min-w-0 flex-1">
-        <span className="block">{t('Session created externally')}</span>
-        <span className="block truncate text-xs text-text-300" title={notice.title}>
-          {notice.title}
-        </span>
-      </span>
-      <button
-        type="button"
-        onClick={onView}
-        className="shrink-0 rounded px-2 py-1 text-xs font-medium text-accent-main-100 hover:bg-bg-300"
-      >
-        {t('View')}
-      </button>
-      <button
-        type="button"
-        aria-label={t('Dismiss')}
-        onClick={onDismiss}
-        className="shrink-0 rounded p-1 text-text-300 hover:bg-bg-300 hover:text-text-100"
-      >
-        <X className="size-3.5" />
-      </button>
-    </div>
+    <ActionToast
+      key={`${notice.projectId}:${notice.sessionId}`}
+      title={t('Session created externally')}
+      detail={notice.title}
+      actionLabel={t('View')}
+      dismissLabel={t('Dismiss')}
+      onAction={onView}
+      onDismiss={onDismiss}
+      autoDismissMs={AUTO_DISMISS_MS}
+      testId="lifecycle-toast"
+    />
   )
 }
 

--- a/src/renderer/src/locales/fr.json
+++ b/src/renderer/src/locales/fr.json
@@ -2838,7 +2838,6 @@
   "OAuth configuration only; tokens excluded": "Configuration OAuth uniquement ; jetons exclus",
   "Names only: {{names}}": "Noms uniquement : {{names}}",
   "Save configuration": "Enregistrer la configuration",
-  "Connecting…": "Connexion…",
   "GitHub token · {{mask}}": "Jeton GitHub · {{mask}}",
   "GitHub token": "Jeton GitHub",
   "Setup incomplete": "Configuration incomplète",
@@ -3462,5 +3461,12 @@
   "This imported Connector requires a client secret entered locally.": "Ce connecteur importé nécessite un secret client saisi localement.",
   "Authorization server URL is required for a pre-registered client.": "L’URL du serveur d’autorisation est requise pour un client préenregistré.",
   "Client ID is required when a client secret is configured.": "L’ID client est requis lorsqu’un secret client est configuré.",
-  "Client metadata URL cannot be combined with a pre-registered client.": "L’URL des métadonnées client ne peut pas être combinée avec un client préenregistré."
+  "Client metadata URL cannot be combined with a pre-registered client.": "L’URL des métadonnées client ne peut pas être combinée avec un client préenregistré.",
+  "Add and sign in": "Ajouter et se connecter",
+  "Sign in to {{name}}": "Se connecter à {{name}}",
+  "Complete authorization in your browser. This dialog will update when sign-in finishes.": "Terminez l’autorisation dans votre navigateur. Cette boîte de dialogue sera mise à jour une fois la connexion terminée.",
+  "Finish later": "Terminer plus tard",
+  "{{name}} needs sign-in": "{{name}} nécessite une connexion",
+  "Authorization expired or was revoked. Sign in again to keep this Connector available.": "L’autorisation a expiré ou a été révoquée. Reconnectez-vous pour que ce Connecteur reste disponible.",
+  "Open Connectors": "Ouvrir les Connecteurs"
 }

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -2590,7 +2590,6 @@
   "OAuth configuration only; tokens excluded": "OAuth 構成のみ。除外されたトークン",
   "Names only: {{names}}": "名前のみ：{{names}}",
   "Save configuration": "設定の保存",
-  "Connecting…": "接続中…",
   "GitHub token · {{mask}}": "GitHub トークン · {{mask}}",
   "GitHub token": "GitHub トークン",
   "Setup incomplete": "セットアップが不完全",
@@ -3190,5 +3189,12 @@
   "This imported Connector requires a client secret entered locally.": "このインポートされたコネクタには、ローカルで入力するクライアントシークレットが必要です。",
   "Authorization server URL is required for a pre-registered client.": "事前登録済みクライアントには認可サーバー URL が必要です。",
   "Client ID is required when a client secret is configured.": "クライアントシークレットを設定する場合はクライアント ID が必要です。",
-  "Client metadata URL cannot be combined with a pre-registered client.": "クライアントメタデータ URL を事前登録済みクライアントと併用することはできません。"
+  "Client metadata URL cannot be combined with a pre-registered client.": "クライアントメタデータ URL を事前登録済みクライアントと併用することはできません。",
+  "Add and sign in": "追加してサインイン",
+  "Sign in to {{name}}": "{{name}} にサインイン",
+  "Complete authorization in your browser. This dialog will update when sign-in finishes.": "ブラウザーで認証を完了してください。サインインが完了すると、このダイアログが更新されます。",
+  "Finish later": "後で完了",
+  "{{name}} needs sign-in": "{{name}} へのサインインが必要です",
+  "Authorization expired or was revoked. Sign in again to keep this Connector available.": "認証の有効期限が切れたか、取り消されました。このコネクタを引き続き使用するには、もう一度サインインしてください。",
+  "Open Connectors": "コネクタを開く"
 }

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -2601,7 +2601,6 @@
   "OAuth configuration only; tokens excluded": "OAuth 구성에만 해당; 토큰 제외됨",
   "Names only: {{names}}": "이름만: {{names}}",
   "Save configuration": "구성 저장",
-  "Connecting…": "연결 중…",
   "GitHub token · {{mask}}": "GitHub 토큰 · {{mask}}",
   "GitHub token": "GitHub 토큰",
   "Setup incomplete": "설정이 완료되지 않았습니다.",
@@ -3188,5 +3187,12 @@
   "This imported Connector requires a client secret entered locally.": "가져온 커넥터에는 로컬에서 입력한 클라이언트 시크릿이 필요합니다.",
   "Authorization server URL is required for a pre-registered client.": "사전 등록된 클라이언트에는 인증 서버 URL이 필요합니다.",
   "Client ID is required when a client secret is configured.": "클라이언트 시크릿을 구성할 때 클라이언트 ID가 필요합니다.",
-  "Client metadata URL cannot be combined with a pre-registered client.": "클라이언트 메타데이터 URL은 사전 등록된 클라이언트와 함께 사용할 수 없습니다."
+  "Client metadata URL cannot be combined with a pre-registered client.": "클라이언트 메타데이터 URL은 사전 등록된 클라이언트와 함께 사용할 수 없습니다.",
+  "Add and sign in": "추가하고 로그인",
+  "Sign in to {{name}}": "{{name}}에 로그인",
+  "Complete authorization in your browser. This dialog will update when sign-in finishes.": "브라우저에서 인증을 완료하세요. 로그인이 끝나면 이 대화 상자가 업데이트됩니다.",
+  "Finish later": "나중에 완료",
+  "{{name}} needs sign-in": "{{name}}에 로그인이 필요합니다",
+  "Authorization expired or was revoked. Sign in again to keep this Connector available.": "인증이 만료되었거나 취소되었습니다. 이 커넥터를 계속 사용하려면 다시 로그인하세요.",
+  "Open Connectors": "커넥터 열기"
 }

--- a/src/renderer/src/locales/ru.json
+++ b/src/renderer/src/locales/ru.json
@@ -2930,7 +2930,6 @@
   "OAuth configuration only; tokens excluded": "Только настройки OAuth; токены исключены",
   "Names only: {{names}}": "Только имена: {{names}}",
   "Save configuration": "Сохранить настройки",
-  "Connecting…": "Соединение…",
   "GitHub token · {{mask}}": "Токен GitHub · {{mask}}",
   "GitHub token": "Токен GitHub",
   "Setup incomplete": "Настройка не завершена",
@@ -3573,5 +3572,12 @@
   "This imported Connector requires a client secret entered locally.": "Для импортированного коннектора необходимо локально ввести секрет клиента.",
   "Authorization server URL is required for a pre-registered client.": "Для заранее зарегистрированного клиента требуется URL сервера авторизации.",
   "Client ID is required when a client secret is configured.": "Если настроен секрет клиента, необходимо указать идентификатор клиента.",
-  "Client metadata URL cannot be combined with a pre-registered client.": "URL метаданных клиента нельзя использовать вместе с заранее зарегистрированным клиентом."
+  "Client metadata URL cannot be combined with a pre-registered client.": "URL метаданных клиента нельзя использовать вместе с заранее зарегистрированным клиентом.",
+  "Add and sign in": "Добавить и войти",
+  "Sign in to {{name}}": "Войти в {{name}}",
+  "Complete authorization in your browser. This dialog will update when sign-in finishes.": "Завершите авторизацию в браузере. После входа это диалоговое окно обновится.",
+  "Finish later": "Завершить позже",
+  "{{name}} needs sign-in": "Для {{name}} требуется вход",
+  "Authorization expired or was revoked. Sign in again to keep this Connector available.": "Авторизация истекла или была отозвана. Войдите снова, чтобы этот Коннектор оставался доступным.",
+  "Open Connectors": "Открыть Коннекторы"
 }

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -2661,7 +2661,6 @@
   "OAuth configuration only; tokens excluded": "仅包含 OAuth 配置；不包含令牌",
   "Names only: {{names}}": "仅名称：{{names}}",
   "Save configuration": "保存配置",
-  "Connecting…": "正在连接…",
   "GitHub token · {{mask}}": "GitHub 令牌 · {{mask}}",
   "GitHub token": "GitHub 令牌",
   "Setup incomplete": "设置未完成",
@@ -3190,5 +3189,12 @@
   "This imported Connector requires a client secret entered locally.": "此导入的连接器需要在本地输入客户端密钥。",
   "Authorization server URL is required for a pre-registered client.": "预注册客户端必须提供授权服务器 URL。",
   "Client ID is required when a client secret is configured.": "配置客户端密钥时必须提供客户端 ID。",
-  "Client metadata URL cannot be combined with a pre-registered client.": "客户端元数据 URL 不能与预注册客户端同时使用。"
+  "Client metadata URL cannot be combined with a pre-registered client.": "客户端元数据 URL 不能与预注册客户端同时使用。",
+  "Add and sign in": "添加并登录",
+  "Sign in to {{name}}": "登录 {{name}}",
+  "Complete authorization in your browser. This dialog will update when sign-in finishes.": "请在浏览器中完成授权。登录完成后，此对话框将更新。",
+  "Finish later": "稍后完成",
+  "{{name}} needs sign-in": "{{name}} 需要登录",
+  "Authorization expired or was revoked. Sign in again to keep this Connector available.": "授权已过期或被撤销。请重新登录以保持此连接器可用。",
+  "Open Connectors": "打开连接器"
 }

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -2661,7 +2661,6 @@
   "OAuth configuration only; tokens excluded": "僅包含 OAuth 設定；不包含權杖",
   "Names only: {{names}}": "僅名稱：{{names}}",
   "Save configuration": "儲存設定",
-  "Connecting…": "正在連線…",
   "GitHub token · {{mask}}": "GitHub 權杖 · {{mask}}",
   "GitHub token": "GitHub 權杖",
   "Setup incomplete": "設定未完成",
@@ -3190,5 +3189,12 @@
   "This imported Connector requires a client secret entered locally.": "此匯入的連接器需要在本機輸入用戶端密鑰。",
   "Authorization server URL is required for a pre-registered client.": "預先註冊的用戶端必須提供授權伺服器 URL。",
   "Client ID is required when a client secret is configured.": "設定用戶端密鑰時必須提供用戶端 ID。",
-  "Client metadata URL cannot be combined with a pre-registered client.": "用戶端中繼資料 URL 不能與預先註冊的用戶端同時使用。"
+  "Client metadata URL cannot be combined with a pre-registered client.": "用戶端中繼資料 URL 不能與預先註冊的用戶端同時使用。",
+  "Add and sign in": "新增並登入",
+  "Sign in to {{name}}": "登入 {{name}}",
+  "Complete authorization in your browser. This dialog will update when sign-in finishes.": "請在瀏覽器中完成授權。登入完成後，此對話框將更新。",
+  "Finish later": "稍後完成",
+  "{{name}} needs sign-in": "{{name}} 需要登入",
+  "Authorization expired or was revoked. Sign in again to keep this Connector available.": "授權已過期或遭撤銷。請重新登入以維持此連接器可用。",
+  "Open Connectors": "開啟連接器"
 }

--- a/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.render.test.tsx
@@ -58,8 +58,8 @@ const checkTrust = (): void => {
 }
 
 const addButton = (): HTMLButtonElement | undefined =>
-  Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
-    (button) => button.textContent?.trim() === 'Add connector'
+  Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find((button) =>
+    ['Add connector', 'Add and sign in'].includes(button.textContent?.trim() ?? '')
   )
 
 const advancedButton = (): HTMLButtonElement | null =>
@@ -372,10 +372,23 @@ describe('ConnectorAddForm (remote server)', () => {
   })
 
   it('adds a remote OAuth server with scopes and discovery overrides', async () => {
+    const created = {
+      id: 'oauth-mcp',
+      name: 'oauth-mcp',
+      displayName: 'OAuth MCP',
+      transport: 'streamable_http' as const,
+      enabled: false,
+      url: 'https://mcp.example.test',
+      oauth: { hasTokens: false }
+    }
+    const onDone = vi.fn()
+    useSettingsStore.setState({
+      addCustomServer: vi.fn().mockResolvedValue(created),
+      authenticateCustomServer: vi.fn().mockResolvedValue(undefined),
+      cancelCustomServerAuthentication: vi.fn().mockResolvedValue(undefined)
+    })
     act(() => {
-      root.render(
-        <ConnectorAddForm initialTransport="remote" onDone={vi.fn()} onCancel={vi.fn()} />
-      )
+      root.render(<ConnectorAddForm initialTransport="remote" onDone={onDone} onCancel={vi.fn()} />)
     })
 
     setValue('Display name', 'OAuth MCP')
@@ -399,6 +412,7 @@ describe('ConnectorAddForm (remote server)', () => {
       ).not.toBeNull()
     }
     checkTrust()
+    expect(addButton()?.textContent).toContain('Add and sign in')
 
     await act(async () => {
       addButton()?.click()
@@ -416,6 +430,10 @@ describe('ConnectorAddForm (remote server)', () => {
         clientMetadataUrl: 'https://client.example.test/metadata.json'
       }
     })
+    expect(useSettingsStore.getState().authenticateCustomServer).toHaveBeenCalledWith({
+      id: 'oauth-mcp'
+    })
+    expect(onDone).toHaveBeenCalledOnce()
   })
 
   it('requires an imported OAuth client secret locally and submits pre-registered credentials', async () => {

--- a/src/renderer/src/pages/settings/ConnectorAddForm.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.tsx
@@ -969,17 +969,19 @@ export function ConnectorAddForm({
           </Button>
         </div>
       </div>
-      <ConnectorOAuthSignInDialog
-        server={oauthSignInServer}
-        onAuthenticated={() => {
-          setOAuthSignInServer(undefined)
-          onDone()
-        }}
-        onFinish={() => {
-          setOAuthSignInServer(undefined)
-          onDone()
-        }}
-      />
+      {oauthSignInServer ? (
+        <ConnectorOAuthSignInDialog
+          server={oauthSignInServer}
+          onAuthenticated={() => {
+            setOAuthSignInServer(undefined)
+            onDone()
+          }}
+          onFinish={() => {
+            setOAuthSignInServer(undefined)
+            onDone()
+          }}
+        />
+      ) : null}
     </div>
   )
 }

--- a/src/renderer/src/pages/settings/ConnectorAddForm.tsx
+++ b/src/renderer/src/pages/settings/ConnectorAddForm.tsx
@@ -16,6 +16,7 @@ import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
 import { useSettingsStore } from '@/stores/settings-store'
+import { ConnectorOAuthSignInDialog } from './ConnectorOAuthSignInDialog'
 import { isCustomConnectorName, toCustomConnectorName } from '../../../../shared/custom-connector'
 import {
   RESOURCE_ID_MAX_LENGTH,
@@ -265,6 +266,7 @@ export function ConnectorAddForm({
   const [trusted, setTrusted] = useState(isEdit)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [oauthSignInServer, setOAuthSignInServer] = useState<CustomServerView>()
   // A generated-ID collision must remain visible instead of leaving the disabled submit button as
   // the only sign that something needs attention.
   const advancedVisible =
@@ -376,6 +378,7 @@ export function ConnectorAddForm({
           }
         }
         await updateCustomServer(request)
+        onDone()
       } else {
         const request: AddCustomServerRequest = {
           ...(submittedId ? { id: submittedId } : {}),
@@ -392,9 +395,10 @@ export function ConnectorAddForm({
             ...(clientSecret.trim() ? { clientSecret: clientSecret.trim() } : {})
           }
         }
-        await addCustomServer(request)
+        const created = await addCustomServer(request)
+        if (request.oauth) setOAuthSignInServer(created)
+        else onDone()
       }
-      onDone()
     } catch (err) {
       const message = err instanceof Error ? err.message : undefined
       const localizedMessage =
@@ -959,10 +963,23 @@ export function ConnectorAddForm({
                 : t('Adding…')
               : isEdit
                 ? t('Save changes')
-                : t('Add connector')}
+                : mode === 'remote' && remoteAuth === 'oauth'
+                  ? t('Add and sign in')
+                  : t('Add connector')}
           </Button>
         </div>
       </div>
+      <ConnectorOAuthSignInDialog
+        server={oauthSignInServer}
+        onAuthenticated={() => {
+          setOAuthSignInServer(undefined)
+          onDone()
+        }}
+        onFinish={() => {
+          setOAuthSignInServer(undefined)
+          onDone()
+        }}
+      />
     </div>
   )
 }

--- a/src/renderer/src/pages/settings/ConnectorOAuthSignInDialog.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorOAuthSignInDialog.render.test.tsx
@@ -86,6 +86,30 @@ describe('ConnectorOAuthSignInDialog', () => {
     expect(document.body.textContent).not.toContain('cancelled')
   })
 
+  it('does not restart a pending attempt when the server projection object refreshes', () => {
+    useSettingsStore.setState({
+      authenticateCustomServer: vi.fn(() => new Promise<void>(() => undefined))
+    })
+    act(() => {
+      root.render(
+        <ConnectorOAuthSignInDialog server={server} onAuthenticated={vi.fn()} onFinish={vi.fn()} />
+      )
+    })
+    act(() => {
+      root.render(
+        <ConnectorOAuthSignInDialog
+          server={{ ...server, displayName: 'Renamed OAuth MCP' }}
+          onAuthenticated={vi.fn()}
+          onFinish={vi.fn()}
+        />
+      )
+    })
+
+    expect(useSettingsStore.getState().authenticateCustomServer).toHaveBeenCalledOnce()
+    expect(useSettingsStore.getState().cancelCustomServerAuthentication).not.toHaveBeenCalled()
+    expect(document.body.textContent).toContain('Sign in to Renamed OAuth MCP')
+  })
+
   it('keeps a failed attempt open and retries from the same dialog', async () => {
     const authenticate = vi
       .fn()

--- a/src/renderer/src/pages/settings/ConnectorOAuthSignInDialog.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorOAuthSignInDialog.render.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
+import { ConnectorOAuthSignInDialog } from './ConnectorOAuthSignInDialog'
+
+const server = {
+  id: 'oauth-mcp',
+  name: 'oauth-mcp',
+  displayName: 'OAuth MCP',
+  transport: 'streamable_http' as const,
+  enabled: false,
+  url: 'https://mcp.example.test',
+  oauth: { hasTokens: false }
+}
+
+describe('ConnectorOAuthSignInDialog', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    useSettingsStore.setState({
+      ...createInitialSettingsState(),
+      authenticateCustomServer: vi.fn().mockResolvedValue(undefined),
+      cancelCustomServerAuthentication: vi.fn().mockResolvedValue(undefined)
+    })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    document.body.innerHTML = ''
+  })
+
+  it('starts authentication and reports successful completion', async () => {
+    const onAuthenticated = vi.fn()
+    await act(async () =>
+      root.render(
+        <ConnectorOAuthSignInDialog
+          server={server}
+          onAuthenticated={onAuthenticated}
+          onFinish={vi.fn()}
+        />
+      )
+    )
+
+    expect(useSettingsStore.getState().authenticateCustomServer).toHaveBeenCalledWith({
+      id: 'oauth-mcp'
+    })
+    expect(onAuthenticated).toHaveBeenCalledOnce()
+  })
+
+  it('cancels a pending attempt and ignores its later rejection', async () => {
+    let rejectAuthentication!: (error: Error) => void
+    useSettingsStore.setState({
+      authenticateCustomServer: vi.fn(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectAuthentication = reject
+          })
+      )
+    })
+    const onFinish = vi.fn()
+    act(() => {
+      root.render(
+        <ConnectorOAuthSignInDialog server={server} onAuthenticated={vi.fn()} onFinish={onFinish} />
+      )
+    })
+
+    const cancel = [...document.body.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Cancel'
+    )
+    act(() => cancel?.click())
+
+    expect(useSettingsStore.getState().cancelCustomServerAuthentication).toHaveBeenCalledWith({
+      id: 'oauth-mcp'
+    })
+    expect(onFinish).toHaveBeenCalledOnce()
+
+    await act(async () => rejectAuthentication(new Error('cancelled')))
+    expect(document.body.textContent).not.toContain('cancelled')
+  })
+
+  it('keeps a failed attempt open and retries from the same dialog', async () => {
+    const authenticate = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Authorization denied'))
+      .mockResolvedValueOnce(undefined)
+    useSettingsStore.setState({ authenticateCustomServer: authenticate })
+    const onAuthenticated = vi.fn()
+    await act(async () =>
+      root.render(
+        <ConnectorOAuthSignInDialog
+          server={server}
+          onAuthenticated={onAuthenticated}
+          onFinish={vi.fn()}
+        />
+      )
+    )
+
+    expect(document.body.querySelector('[role="alert"]')?.textContent).toContain(
+      'Authorization denied'
+    )
+    const retry = [...document.body.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Try again'
+    )
+    await act(async () => retry?.click())
+
+    expect(authenticate).toHaveBeenCalledTimes(2)
+    expect(onAuthenticated).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/pages/settings/ConnectorOAuthSignInDialog.tsx
+++ b/src/renderer/src/pages/settings/ConnectorOAuthSignInDialog.tsx
@@ -43,12 +43,13 @@ const ConnectorOAuthSignInDialog = ({
   const pendingRef = useRef(false)
   const generationRef = useRef(0)
   const handleAuthenticated = useEffectEvent(onAuthenticated)
+  const serverId = server.id
 
   useEffect(() => {
     const generation = ++generationRef.current
     pendingRef.current = true
 
-    void authenticateCustomServer({ id: server.id }).then(
+    void authenticateCustomServer({ id: serverId }).then(
       () => {
         if (generationRef.current !== generation) return
         pendingRef.current = false
@@ -65,15 +66,15 @@ const ConnectorOAuthSignInDialog = ({
       if (generationRef.current !== generation || !pendingRef.current) return
       generationRef.current += 1
       pendingRef.current = false
-      void cancelCustomServerAuthentication({ id: server.id })
+      void cancelCustomServerAuthentication({ id: serverId })
     }
-  }, [attempt, authenticateCustomServer, cancelCustomServerAuthentication, server, t])
+  }, [attempt, authenticateCustomServer, cancelCustomServerAuthentication, serverId, t])
 
   const finish = (): void => {
     generationRef.current += 1
     if (pendingRef.current) {
       pendingRef.current = false
-      void cancelCustomServerAuthentication({ id: server.id })
+      void cancelCustomServerAuthentication({ id: serverId })
     }
     onFinish()
   }

--- a/src/renderer/src/pages/settings/ConnectorOAuthSignInDialog.tsx
+++ b/src/renderer/src/pages/settings/ConnectorOAuthSignInDialog.tsx
@@ -21,7 +21,7 @@ import { useSettingsStore } from '@/stores/settings-store'
 import type { CustomServerView } from '../../../../shared/settings'
 
 type ConnectorOAuthSignInDialogProps = {
-  server?: CustomServerView
+  server: CustomServerView
   onAuthenticated: () => void
   onFinish: () => void
 }
@@ -32,7 +32,7 @@ const ConnectorOAuthSignInDialog = ({
   server,
   onAuthenticated,
   onFinish
-}: ConnectorOAuthSignInDialogProps): React.JSX.Element | null => {
+}: ConnectorOAuthSignInDialogProps): React.JSX.Element => {
   const { t } = useTranslation()
   const authenticateCustomServer = useSettingsStore((state) => state.authenticateCustomServer)
   const cancelCustomServerAuthentication = useSettingsStore(
@@ -45,7 +45,6 @@ const ConnectorOAuthSignInDialog = ({
   const handleAuthenticated = useEffectEvent(onAuthenticated)
 
   useEffect(() => {
-    if (!server) return
     const generation = ++generationRef.current
     pendingRef.current = true
 
@@ -69,8 +68,6 @@ const ConnectorOAuthSignInDialog = ({
       void cancelCustomServerAuthentication({ id: server.id })
     }
   }, [attempt, authenticateCustomServer, cancelCustomServerAuthentication, server, t])
-
-  if (!server) return null
 
   const finish = (): void => {
     generationRef.current += 1

--- a/src/renderer/src/pages/settings/ConnectorOAuthSignInDialog.tsx
+++ b/src/renderer/src/pages/settings/ConnectorOAuthSignInDialog.tsx
@@ -1,0 +1,157 @@
+/* Hallmark · component: Connector OAuth sign-in · genre: modern-minimal · theme: project Settings tokens */
+/* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4 · contrast: project tokens · slop: pass */
+import { useEffect, useEffectEvent, useRef, useState } from 'react'
+import { AlertDialog } from 'radix-ui'
+import { LoaderCircle, X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import {
+  dialogBodyClassName,
+  dialogCancelButtonClassName,
+  dialogCloseButtonClassName,
+  dialogDescriptionClassName,
+  dialogFooterClassName,
+  dialogHeaderClassName,
+  dialogOverlayClassName,
+  dialogPanelClassName,
+  dialogTitleClassName
+} from '@/components/ui/dialog-chrome'
+import { useSettingsStore } from '@/stores/settings-store'
+import type { CustomServerView } from '../../../../shared/settings'
+
+type ConnectorOAuthSignInDialogProps = {
+  server?: CustomServerView
+  onAuthenticated: () => void
+  onFinish: () => void
+}
+
+// Owns the complete interactive OAuth attempt so add/list callers only select a Connector and react
+// to its outcome. Main remains authoritative for browser launch, callback validation, and tokens.
+const ConnectorOAuthSignInDialog = ({
+  server,
+  onAuthenticated,
+  onFinish
+}: ConnectorOAuthSignInDialogProps): React.JSX.Element | null => {
+  const { t } = useTranslation()
+  const authenticateCustomServer = useSettingsStore((state) => state.authenticateCustomServer)
+  const cancelCustomServerAuthentication = useSettingsStore(
+    (state) => state.cancelCustomServerAuthentication
+  )
+  const [attempt, setAttempt] = useState(0)
+  const [error, setError] = useState<string>()
+  const pendingRef = useRef(false)
+  const generationRef = useRef(0)
+  const handleAuthenticated = useEffectEvent(onAuthenticated)
+
+  useEffect(() => {
+    if (!server) return
+    const generation = ++generationRef.current
+    pendingRef.current = true
+
+    void authenticateCustomServer({ id: server.id }).then(
+      () => {
+        if (generationRef.current !== generation) return
+        pendingRef.current = false
+        handleAuthenticated()
+      },
+      (cause: unknown) => {
+        if (generationRef.current !== generation) return
+        pendingRef.current = false
+        setError(cause instanceof Error ? cause.message : t('OAuth sign-in failed.'))
+      }
+    )
+
+    return () => {
+      if (generationRef.current !== generation || !pendingRef.current) return
+      generationRef.current += 1
+      pendingRef.current = false
+      void cancelCustomServerAuthentication({ id: server.id })
+    }
+  }, [attempt, authenticateCustomServer, cancelCustomServerAuthentication, server, t])
+
+  if (!server) return null
+
+  const finish = (): void => {
+    generationRef.current += 1
+    if (pendingRef.current) {
+      pendingRef.current = false
+      void cancelCustomServerAuthentication({ id: server.id })
+    }
+    onFinish()
+  }
+
+  return (
+    <AlertDialog.Root open onOpenChange={(open) => !open && finish()}>
+      <AlertDialog.Portal>
+        <AlertDialog.Overlay className={dialogOverlayClassName} />
+        <AlertDialog.Content
+          className={dialogPanelClassName('w-[min(460px,calc(100vw-2rem))] p-0')}
+        >
+          <div className={dialogHeaderClassName}>
+            <AlertDialog.Title className={dialogTitleClassName}>
+              {t('Sign in to {{name}}', { name: server.displayName })}
+            </AlertDialog.Title>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label={t('Close')}
+              className={dialogCloseButtonClassName}
+              onClick={finish}
+            >
+              <X className="size-4" aria-hidden="true" />
+            </Button>
+          </div>
+          <div className={dialogBodyClassName}>
+            <AlertDialog.Description className={dialogDescriptionClassName}>
+              {t(
+                'Complete authorization in your browser. This dialog will update when sign-in finishes.'
+              )}
+            </AlertDialog.Description>
+            {error ? (
+              <p className="mt-4 text-sm text-destructive" role="alert">
+                {t(error)}
+              </p>
+            ) : (
+              <div
+                className="mt-4 flex items-center gap-2 text-sm text-muted-foreground"
+                role="status"
+              >
+                <LoaderCircle
+                  className="size-4 animate-spin motion-reduce:animate-none"
+                  aria-hidden="true"
+                />
+                {t('Waiting for authorization…')}
+              </div>
+            )}
+          </div>
+          <div className={dialogFooterClassName}>
+            <Button
+              type="button"
+              variant="outline"
+              className={dialogCancelButtonClassName}
+              onClick={finish}
+            >
+              {error ? t('Finish later') : t('Cancel')}
+            </Button>
+            {error ? (
+              <Button
+                type="button"
+                onClick={() => {
+                  setError(undefined)
+                  setAttempt((current) => current + 1)
+                }}
+              >
+                {t('Try again')}
+              </Button>
+            ) : null}
+          </div>
+        </AlertDialog.Content>
+      </AlertDialog.Portal>
+    </AlertDialog.Root>
+  )
+}
+
+export { ConnectorOAuthSignInDialog }
+export type { ConnectorOAuthSignInDialogProps }

--- a/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
@@ -808,12 +808,11 @@ describe('ConnectorsPanel (groups)', () => {
     expect(onNavigate).toHaveBeenCalledWith({ kind: 'edit', id: 'anonymous-remote' })
   })
 
-  it('keeps a waiting OAuth sign-in disabled until it settles', async () => {
-    let finishAuthentication!: () => void
+  it('shows a cancellable dialog while OAuth sign-in is waiting', async () => {
     const authenticateCustomServer = vi.fn(
       () =>
-        new Promise<void>((resolve) => {
-          finishAuthentication = resolve
+        new Promise<void>(() => {
+          // Settled by cancellation in the main process.
         })
     )
     useSettingsStore.setState({
@@ -836,74 +835,18 @@ describe('ConnectorsPanel (groups)', () => {
     })
 
     clickButtonByText('Sign in')
-    const connecting = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
-      (button) => button.textContent?.trim() === 'Connecting…'
+    expect(document.body.textContent).toContain('Waiting for authorization…')
+    const cancel = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.trim() === 'Cancel'
     )
-    expect(connecting?.disabled).toBe(true)
-    expect(document.body.textContent).not.toContain('Cancel')
-    act(() => connecting?.click())
     expect(authenticateCustomServer).toHaveBeenCalledOnce()
-    expect(useSettingsStore.getState().cancelCustomServerAuthentication).not.toHaveBeenCalled()
-
-    await act(async () => finishAuthentication())
-  })
-
-  it('keeps concurrent OAuth sign-ins independently disabled', async () => {
-    const finishAuthentications = new Map<string, () => void>()
-    const authenticateCustomServer = vi.fn(
-      ({ id }: { id: string }) =>
-        new Promise<void>((resolve) => {
-          finishAuthentications.set(id, resolve)
-        })
-    )
-    useSettingsStore.setState({
-      authenticateCustomServer,
-      customServers: [
-        {
-          id: 'oauth-a',
-          name: 'oauth-a',
-          displayName: 'OAuth A',
-          transport: 'streamable_http',
-          enabled: false,
-          url: 'https://a.example.test',
-          oauth: { hasTokens: false }
-        },
-        {
-          id: 'oauth-b',
-          name: 'oauth-b',
-          displayName: 'OAuth B',
-          transport: 'streamable_http',
-          enabled: false,
-          url: 'https://b.example.test',
-          oauth: { hasTokens: false }
-        }
-      ]
+    act(() => cancel?.click())
+    expect(useSettingsStore.getState().cancelCustomServerAuthentication).toHaveBeenCalledWith({
+      id: 'oauth-mcp'
     })
-    act(() => root.render(<ConnectorsPanel onNavigate={vi.fn()} />))
-    const row = (name: string): HTMLLIElement | undefined =>
-      Array.from(document.body.querySelectorAll<HTMLLIElement>('li')).find((item) =>
-        item.textContent?.includes(name)
-      )
-    const clickRowAction = (name: string, action: string): void => {
-      const button = Array.from(
-        row(name)?.querySelectorAll<HTMLButtonElement>('button') ?? []
-      ).find((candidate) => candidate.textContent?.trim() === action)
-      button?.click()
-    }
-
-    act(() => clickRowAction('OAuth A', 'Sign in'))
-    act(() => clickRowAction('OAuth B', 'Sign in'))
-    expect(row('OAuth A')?.textContent).toContain('Connecting…')
-    expect(row('OAuth B')?.textContent).toContain('Connecting…')
-
-    await act(async () => finishAuthentications.get('oauth-a')?.())
-    expect(row('OAuth A')?.textContent).toContain('Sign in')
-    expect(row('OAuth B')?.textContent).toContain('Connecting…')
-
-    await act(async () => finishAuthentications.get('oauth-b')?.())
   })
 
-  it('uses the Settings danger banner for OAuth errors', async () => {
+  it('keeps OAuth errors in the retryable sign-in dialog', async () => {
     useSettingsStore.setState({
       authenticateCustomServer: vi.fn().mockRejectedValue(new Error('Authorization denied')),
       customServers: [
@@ -924,7 +867,8 @@ describe('ConnectorsPanel (groups)', () => {
 
     const alert = document.body.querySelector('[role="alert"]')
     expect(alert?.textContent).toContain('Authorization denied')
-    expect(alert?.className).toContain('border-danger-000/30')
+    expect(document.body.textContent).toContain('Try again')
+    expect(document.body.textContent).toContain('Finish later')
   })
 
   it('shows an empty-state line when there are no custom servers', () => {

--- a/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.render.test.tsx
@@ -847,8 +847,12 @@ describe('ConnectorsPanel (groups)', () => {
   })
 
   it('keeps OAuth errors in the retryable sign-in dialog', async () => {
+    const authenticateCustomServer = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Authorization denied'))
+      .mockReturnValueOnce(new Promise<void>(() => undefined))
     useSettingsStore.setState({
-      authenticateCustomServer: vi.fn().mockRejectedValue(new Error('Authorization denied')),
+      authenticateCustomServer,
       customServers: [
         {
           id: 'oauth-mcp',
@@ -869,6 +873,13 @@ describe('ConnectorsPanel (groups)', () => {
     expect(alert?.textContent).toContain('Authorization denied')
     expect(document.body.textContent).toContain('Try again')
     expect(document.body.textContent).toContain('Finish later')
+
+    clickButtonByText('Finish later')
+    clickButtonByText('Sign in')
+
+    expect(authenticateCustomServer).toHaveBeenCalledTimes(2)
+    expect(document.body.querySelector('[role="alert"]')).toBeNull()
+    expect(document.body.textContent).toContain('Waiting for authorization…')
   })
 
   it('shows an empty-state line when there are no custom servers', () => {

--- a/src/renderer/src/pages/settings/ConnectorsPanel.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.tsx
@@ -1009,11 +1009,13 @@ export function ConnectorsPanel({
           </AlertDialog.Content>
         </AlertDialog.Portal>
       </AlertDialog.Root>
-      <ConnectorOAuthSignInDialog
-        server={oauthSignInServer}
-        onAuthenticated={() => setOAuthSignInServer(undefined)}
-        onFinish={() => setOAuthSignInServer(undefined)}
-      />
+      {oauthSignInServer ? (
+        <ConnectorOAuthSignInDialog
+          server={oauthSignInServer}
+          onAuthenticated={() => setOAuthSignInServer(undefined)}
+          onFinish={() => setOAuthSignInServer(undefined)}
+        />
+      ) : null}
     </div>
   )
 }

--- a/src/renderer/src/pages/settings/ConnectorsPanel.tsx
+++ b/src/renderer/src/pages/settings/ConnectorsPanel.tsx
@@ -55,6 +55,7 @@ import { SettingsSearchInput } from './SettingsSearchInput'
 import { specialistsUsingConnector, type SpecialistUsage } from './specialist-resource-scope'
 import { ResourceTagBadges, ResourceTagMenu, TagFilter } from './ResourceTagControls'
 import { SkillUsageAgents } from './SkillUsageAgents'
+import { ConnectorOAuthSignInDialog } from './ConnectorOAuthSignInDialog'
 
 // The connectors panel sub-view, driven by the settings navigation history. The detail and add pages
 // are separate components owned by SettingsPage; this panel only renders the list + contact-email section.
@@ -127,7 +128,6 @@ export function ConnectorsPanel({
   const setCustomServerEnabled = useSettingsStore((state) => state.setCustomServerEnabled)
   const retryCustomServer = useSettingsStore((state) => state.retryCustomServer)
   const removeCustomServer = useSettingsStore((state) => state.removeCustomServer)
-  const authenticateCustomServer = useSettingsStore((state) => state.authenticateCustomServer)
   const setNcbiCredentials = useSettingsStore((state) => state.setNcbiCredentials)
   const specialistItems = useSpecialistStore((state) => state.items)
   const loadSpecialists = useSpecialistStore((state) => state.load)
@@ -143,9 +143,8 @@ export function ConnectorsPanel({
   const [editing, setEditing] = useState(false)
   const [emailField, setEmailField] = useState('')
   const [keyField, setKeyField] = useState('')
-  const [authenticatingIds, setAuthenticatingIds] = useState<Set<string>>(() => new Set())
   const [retryingIds, setRetryingIds] = useState<Set<string>>(() => new Set())
-  const [authError, setAuthError] = useState<string | null>(null)
+  const [oauthSignInServer, setOAuthSignInServer] = useState<CustomServerView>()
   const [removal, setRemoval] = useState<{
     server: CustomServerView
     specialistNames?: string[]
@@ -279,30 +278,15 @@ export function ConnectorsPanel({
     setKeyField('')
   }
 
-  const signIn = async (id: string): Promise<void> => {
-    setAuthenticatingIds((current) => new Set(current).add(id))
-    setAuthError(null)
-    try {
-      await authenticateCustomServer({ id })
-    } catch (error) {
-      await loadCatalog()
-      setAuthError(error instanceof Error ? error.message : 'OAuth sign-in failed.')
-    } finally {
-      setAuthenticatingIds((current) => {
-        const next = new Set(current)
-        next.delete(id)
-        return next
-      })
-    }
-  }
-
   const retry = async (id: string): Promise<void> => {
     setRetryingIds((current) => new Set(current).add(id))
-    setAuthError(null)
+    setOperationError(null)
     try {
       await retryCustomServer(id)
     } catch (error) {
-      setAuthError(error instanceof Error ? error.message : 'Could not reconnect this Connector.')
+      setOperationError(
+        error instanceof Error ? error.message : 'Could not reconnect this Connector.'
+      )
     } finally {
       setRetryingIds((current) => {
         const next = new Set(current)
@@ -676,13 +660,13 @@ export function ConnectorsPanel({
       </div>
 
       <div className="flex flex-col gap-4">
-        {authError || operationError ? (
+        {operationError ? (
           <div
             className="flex items-start gap-2 rounded-lg border border-danger-000/30 bg-danger-000/10 px-3 py-2 text-xs text-danger-000"
             role="alert"
           >
             <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
-            <span>{operationError ?? t(authError ?? '')}</span>
+            <span>{t(operationError)}</span>
           </div>
         ) : null}
         {showFeatured
@@ -824,24 +808,20 @@ export function ConnectorsPanel({
                             type="button"
                             size="sm"
                             variant={
-                              authenticatingIds.has(server.id) ||
-                              (server.oauth.hasTokens && server.availability !== 'unauthenticated')
+                              server.oauth.hasTokens && server.availability !== 'unauthenticated'
                                 ? 'outline'
                                 : 'default'
                             }
                             disabled={
-                              authenticatingIds.has(server.id) ||
-                              (server.oauth.hasTokens && server.availability !== 'unauthenticated')
+                              server.oauth.hasTokens && server.availability !== 'unauthenticated'
                             }
-                            onClick={() => void signIn(server.id)}
+                            onClick={() => setOAuthSignInServer(server)}
                           >
-                            {authenticatingIds.has(server.id)
-                              ? t('Connecting…')
-                              : server.oauth.hasTokens && server.availability !== 'unauthenticated'
-                                ? t('Connected')
-                                : server.availability === 'unauthenticated'
-                                  ? t('Retry')
-                                  : t('Sign in')}
+                            {server.oauth.hasTokens && server.availability !== 'unauthenticated'
+                              ? t('Connected')
+                              : server.availability === 'unauthenticated'
+                                ? t('Retry')
+                                : t('Sign in')}
                           </Button>
                         ) : null}
                         <ResourceTagMenu
@@ -1029,6 +1009,11 @@ export function ConnectorsPanel({
           </AlertDialog.Content>
         </AlertDialog.Portal>
       </AlertDialog.Root>
+      <ConnectorOAuthSignInDialog
+        server={oauthSignInServer}
+        onAuthenticated={() => setOAuthSignInServer(undefined)}
+        onFinish={() => setOAuthSignInServer(undefined)}
+      />
     </div>
   )
 }

--- a/src/renderer/src/stores/settings-connectors-slice.test.ts
+++ b/src/renderer/src/stores/settings-connectors-slice.test.ts
@@ -178,6 +178,66 @@ describe('settings Connectors slice', () => {
     expect(commands.listConnectors).toHaveBeenCalledTimes(2)
   })
 
+  it('notices when runtime invalidates a previously authenticated OAuth Connector', async () => {
+    let runtimeChanged: (() => void) | undefined
+    const authenticated = {
+      ...server('oauth'),
+      displayName: 'OAuth MCP',
+      transport: 'streamable_http' as const,
+      url: 'https://mcp.example.test',
+      oauth: { hasTokens: true }
+    }
+    const unauthenticated = {
+      ...authenticated,
+      enabled: false,
+      availability: 'unauthenticated' as const
+    }
+    const runtimeCommands: ConnectorCommands = {
+      ...createCommands(),
+      listConnectors: vi
+        .fn()
+        .mockResolvedValueOnce(snapshot([], [authenticated]))
+        .mockResolvedValueOnce(snapshot([], [unauthenticated]))
+        .mockResolvedValueOnce(snapshot([], [unauthenticated])),
+      onConnectorRuntimeChanged: vi.fn((listener: () => void) => {
+        runtimeChanged = listener
+        return () => undefined
+      })
+    }
+    ;({ store, commands } = createHarness(runtimeCommands))
+
+    await store.getState().loadConnectors()
+    runtimeChanged?.()
+
+    await vi.waitFor(() =>
+      expect(store.getState().connectorAuthNotice).toEqual({
+        id: 'oauth',
+        displayName: 'OAuth MCP'
+      })
+    )
+    store.getState().dismissConnectorAuthNotice()
+    runtimeChanged?.()
+    await vi.waitFor(() => expect(commands.listConnectors).toHaveBeenCalledTimes(3))
+    expect(store.getState().connectorAuthNotice).toBeUndefined()
+  })
+
+  it('does not treat initial or mutation-owned unauthenticated state as token expiry', async () => {
+    const unauthenticated = {
+      ...server('oauth'),
+      transport: 'streamable_http' as const,
+      url: 'https://mcp.example.test',
+      oauth: { hasTokens: false },
+      availability: 'unauthenticated' as const
+    }
+    vi.mocked(commands.listConnectors).mockResolvedValue(snapshot([], [unauthenticated]))
+    vi.mocked(commands.authenticateCustomServer).mockResolvedValue(snapshot([], [unauthenticated]))
+
+    await store.getState().loadConnectors()
+    await store.getState().authenticateCustomServer({ id: 'oauth' })
+
+    expect(store.getState().connectorAuthNotice).toBeUndefined()
+  })
+
   it('does not let an older runtime snapshot overwrite a newer mutation', async () => {
     let runtimeChanged: (() => void) | undefined
     let settleRuntimeSnapshot!: (result: ConnectorsSnapshot) => void
@@ -399,12 +459,14 @@ describe('settings Connectors slice', () => {
       .setNcbiCredentials({ contactEmail: 'science@example.test', apiKey: 'secret' })
     expect(store.getState().ncbi).toEqual(withCredentials.ncbi)
 
-    await store.getState().addCustomServer({
-      name: 'created',
-      displayName: 'Created',
-      transport: 'stdio',
-      command: 'npx'
-    })
+    await expect(
+      store.getState().addCustomServer({
+        name: 'created',
+        displayName: 'Created',
+        transport: 'stdio',
+        command: 'npx'
+      })
+    ).resolves.toEqual(created)
     expect(store.getState().customServers).toEqual([created])
 
     await store.getState().updateCustomServer({

--- a/src/renderer/src/stores/settings-connectors-slice.test.ts
+++ b/src/renderer/src/stores/settings-connectors-slice.test.ts
@@ -334,6 +334,59 @@ describe('settings Connectors slice', () => {
     )
   })
 
+  it('preserves OAuth expiry observed during an in-flight mutation', async () => {
+    let runtimeChanged: (() => void) | undefined
+    let settleMutation!: (result: ConnectorsSnapshot) => void
+    let settleDeferredRefresh!: (result: ConnectorsSnapshot) => void
+    const mutation = new Promise<ConnectorsSnapshot>((resolve) => {
+      settleMutation = resolve
+    })
+    const deferredRefresh = new Promise<ConnectorsSnapshot>((resolve) => {
+      settleDeferredRefresh = resolve
+    })
+    const authenticated = {
+      ...server('oauth'),
+      transport: 'streamable_http' as const,
+      url: 'https://mcp.example.test',
+      oauth: { hasTokens: true }
+    }
+    const unauthenticated = {
+      ...authenticated,
+      enabled: false,
+      availability: 'unauthenticated' as const
+    }
+    const runtimeCommands: ConnectorCommands = {
+      ...createCommands(),
+      listConnectors: vi
+        .fn()
+        .mockResolvedValueOnce(snapshot([], [authenticated]))
+        .mockReturnValueOnce(deferredRefresh),
+      setCustomServerEnabled: vi.fn(() => mutation),
+      onConnectorRuntimeChanged: vi.fn((listener: () => void) => {
+        runtimeChanged = listener
+        return () => undefined
+      })
+    }
+    ;({ store, commands } = createHarness(runtimeCommands))
+
+    await store.getState().loadConnectors()
+    const pendingMutation = store.getState().setCustomServerEnabled('oauth', false)
+    runtimeChanged?.()
+    settleMutation(snapshot([], [unauthenticated]))
+    await pendingMutation
+
+    expect(store.getState().connectorAuthNotice).toEqual({
+      id: 'oauth',
+      displayName: 'oauth'
+    })
+    settleDeferredRefresh(snapshot([], [unauthenticated]))
+    await vi.waitFor(() => expect(commands.listConnectors).toHaveBeenCalledTimes(2))
+    expect(store.getState().connectorAuthNotice).toEqual({
+      id: 'oauth',
+      displayName: 'oauth'
+    })
+  })
+
   it('optimistically enables a Connector before authoritative reconciliation', async () => {
     let settle!: (result: ConnectorsSnapshot) => void
     vi.mocked(commands.setConnectorEnabled).mockReturnValue(

--- a/src/renderer/src/stores/settings-connectors-slice.test.ts
+++ b/src/renderer/src/stores/settings-connectors-slice.test.ts
@@ -238,6 +238,29 @@ describe('settings Connectors slice', () => {
     expect(store.getState().connectorAuthNotice).toBeUndefined()
   })
 
+  it('clears an auth notice when reauthentication succeeds', async () => {
+    const authenticated = {
+      ...server('oauth'),
+      transport: 'streamable_http' as const,
+      url: 'https://mcp.example.test',
+      oauth: { hasTokens: true }
+    }
+    const unauthenticated = {
+      ...authenticated,
+      enabled: false,
+      availability: 'unauthenticated' as const
+    }
+    store.setState({
+      customServers: [unauthenticated],
+      connectorAuthNotice: { id: 'oauth', displayName: 'oauth' }
+    })
+    vi.mocked(commands.authenticateCustomServer).mockResolvedValue(snapshot([], [authenticated]))
+
+    await store.getState().authenticateCustomServer({ id: 'oauth' })
+
+    expect(store.getState().connectorAuthNotice).toBeUndefined()
+  })
+
   it('does not let an older runtime snapshot overwrite a newer mutation', async () => {
     let runtimeChanged: (() => void) | undefined
     let settleRuntimeSnapshot!: (result: ConnectorsSnapshot) => void

--- a/src/renderer/src/stores/settings-connectors-slice.ts
+++ b/src/renderer/src/stores/settings-connectors-slice.ts
@@ -21,9 +21,15 @@ type SettingsConnectorsProjection = {
   ncbi: NcbiCredentialsView
 }
 
+export type ConnectorAuthNotice = Readonly<{
+  id: string
+  displayName: string
+}>
+
 export type SettingsConnectorsState = SettingsConnectorsProjection & {
   connectorsLoaded: boolean
   pendingApprovals: ConnectorApprovalRequest[]
+  connectorAuthNotice?: ConnectorAuthNotice
 }
 
 export type SettingsConnectorsActions = {
@@ -32,13 +38,14 @@ export type SettingsConnectorsActions = {
   setConnectorAutoAllow: (id: string, autoAllow: boolean) => Promise<void>
   setToolPermission: (toolId: string, permission: ToolPermission) => Promise<ConnectorDetailView>
   setNcbiCredentials: (request: SetNcbiCredentialsRequest) => Promise<void>
-  addCustomServer: (request: AddCustomServerRequest) => Promise<void>
+  addCustomServer: (request: AddCustomServerRequest) => Promise<CustomServerView>
   updateCustomServer: (request: UpdateCustomServerRequest) => Promise<void>
   authenticateCustomServer: (request: AuthenticateCustomServerRequest) => Promise<void>
   cancelCustomServerAuthentication: (request: AuthenticateCustomServerRequest) => Promise<void>
   retryCustomServer: (id: string) => Promise<void>
   setCustomServerEnabled: (id: string, enabled: boolean) => Promise<void>
   removeCustomServer: (id: string) => Promise<void>
+  dismissConnectorAuthNotice: () => void
   enqueueApproval: (request: ConnectorApprovalRequest) => void
   dismissApproval: (id: string) => void
   respondApproval: (id: string, decision: ApprovalDecision) => Promise<void>
@@ -78,6 +85,7 @@ export const createInitialSettingsConnectorsState = (): SettingsConnectorsState 
   reservedCustomServerIds: [],
   connectorsLoaded: false,
   pendingApprovals: [],
+  connectorAuthNotice: undefined,
   ncbi: { hasApiKey: false }
 })
 
@@ -118,16 +126,41 @@ export const createSettingsConnectorsSlice = ({
   })
   let reconcileGeneration = 0
   const reconcile = async (
-    command: () => Promise<SettingsConnectorsProjection>
+    command: () => Promise<SettingsConnectorsProjection>,
+    source: 'load' | 'mutation' | 'runtime' = 'mutation'
   ): Promise<SettingsConnectorsProjection> => {
     const generation = ++reconcileGeneration
     const projectionGeneration = toggleWrites.beginProjection()
     const projection = await command()
-    if (generation === reconcileGeneration)
-      setState({
-        ...projectOptimisticToggles(projection, projectionGeneration),
-        connectorsLoaded: true
+    if (generation === reconcileGeneration) {
+      const projected = projectOptimisticToggles(projection, projectionGeneration)
+      setState((state) => {
+        const connectorAuthNotice =
+          source === 'runtime'
+            ? projected.customServers.find((server) => {
+                const previous = state.customServers.find(({ id }) => id === server.id)
+                return Boolean(
+                  server.oauth &&
+                  previous?.oauth?.hasTokens &&
+                  previous.availability !== 'unauthenticated' &&
+                  (server.availability === 'unauthenticated' || !server.oauth.hasTokens)
+                )
+              })
+            : undefined
+        return {
+          ...projected,
+          connectorsLoaded: true,
+          ...(connectorAuthNotice
+            ? {
+                connectorAuthNotice: {
+                  id: connectorAuthNotice.id,
+                  displayName: connectorAuthNotice.displayName
+                }
+              }
+            : {})
+        }
       })
+    }
     return projection
   }
   let mutationsInFlight = 0
@@ -137,7 +170,7 @@ export const createSettingsConnectorsSlice = ({
       runtimeRefreshPending = true
       return
     }
-    void reconcile(() => getCommands().listConnectors()).catch(() => undefined)
+    void reconcile(() => getCommands().listConnectors(), 'runtime').catch(() => undefined)
   }
   const runMutation = async <Result>(mutation: () => Promise<Result>): Promise<Result> => {
     mutationsInFlight += 1
@@ -174,7 +207,7 @@ export const createSettingsConnectorsSlice = ({
         await catalogLoadRequest
         return
       }
-      const request = reconcile(() => getCommands().listConnectors()).then(() => undefined)
+      const request = reconcile(() => getCommands().listConnectors(), 'load').then(() => undefined)
       const trackedRequest = request.finally(() => {
         if (catalogLoadRequest === trackedRequest) catalogLoadRequest = undefined
       })
@@ -261,7 +294,14 @@ export const createSettingsConnectorsSlice = ({
       getCommands().setToolPermission({ toolId, permission }),
     setNcbiCredentials: (request) =>
       reconcileMutation(() => getCommands().setNcbiCredentials(request)),
-    addCustomServer: (request) => reconcileMutation(() => getCommands().addCustomServer(request)),
+    addCustomServer: async (request) => {
+      const projection = await runMutation(() =>
+        reconcile(() => getCommands().addCustomServer(request))
+      )
+      const created = projection.customServers.find((server) => server.name === request.name.trim())
+      if (!created) throw new Error('Added Connector was missing from the saved settings.')
+      return created
+    },
     updateCustomServer: (request) =>
       reconcileMutation(() => getCommands().updateCustomServer(request)),
     authenticateCustomServer: (request) =>
@@ -317,6 +357,7 @@ export const createSettingsConnectorsSlice = ({
       }
     },
     removeCustomServer: (id) => reconcileMutation(() => getCommands().removeCustomServer({ id })),
+    dismissConnectorAuthNotice: () => setState({ connectorAuthNotice: undefined }),
     enqueueApproval: (request) => {
       setState((state) =>
         state.pendingApprovals.some(({ id }) => id === request.id)

--- a/src/renderer/src/stores/settings-connectors-slice.ts
+++ b/src/renderer/src/stores/settings-connectors-slice.ts
@@ -135,7 +135,7 @@ export const createSettingsConnectorsSlice = ({
     if (generation === reconcileGeneration) {
       const projected = projectOptimisticToggles(projection, projectionGeneration)
       setState((state) => {
-        const connectorAuthNotice =
+        const runtimeAuthNotice =
           source === 'runtime'
             ? projected.customServers.find((server) => {
                 const previous = state.customServers.find(({ id }) => id === server.id)
@@ -147,17 +147,22 @@ export const createSettingsConnectorsSlice = ({
                 )
               })
             : undefined
+        const candidateAuthNotice = runtimeAuthNotice
+          ? { id: runtimeAuthNotice.id, displayName: runtimeAuthNotice.displayName }
+          : state.connectorAuthNotice
+        const candidateServer = candidateAuthNotice
+          ? projected.customServers.find(({ id }) => id === candidateAuthNotice.id)
+          : undefined
+        const connectorAuthNotice =
+          candidateAuthNotice &&
+          candidateServer?.oauth &&
+          (candidateServer.availability === 'unauthenticated' || !candidateServer.oauth.hasTokens)
+            ? candidateAuthNotice
+            : undefined
         return {
           ...projected,
           connectorsLoaded: true,
-          ...(connectorAuthNotice
-            ? {
-                connectorAuthNotice: {
-                  id: connectorAuthNotice.id,
-                  displayName: connectorAuthNotice.displayName
-                }
-              }
-            : {})
+          connectorAuthNotice
         }
       })
     }

--- a/src/renderer/src/stores/settings-connectors-slice.ts
+++ b/src/renderer/src/stores/settings-connectors-slice.ts
@@ -136,7 +136,7 @@ export const createSettingsConnectorsSlice = ({
       const projected = projectOptimisticToggles(projection, projectionGeneration)
       setState((state) => {
         const runtimeAuthNotice =
-          source === 'runtime'
+          source === 'runtime' || runtimeRefreshPending
             ? projected.customServers.find((server) => {
                 const previous = state.customServers.find(({ id }) => id === server.id)
                 return Boolean(


### PR DESCRIPTION
## Problem

OAuth Connector setup saved configuration without guiding the user through the first authorization. Row-level sign-in exposed an uncancellable waiting state, and runtime credential invalidation had no transient recovery prompt outside Settings.

## Proposed change

- Save a new OAuth Connector, then immediately start browser authorization in a cancellable dialog.
- Reuse the same dialog for list sign-in, failure recovery, retry, and finish-later behavior.
- Detect the runtime transition from authenticated to unauthenticated and show a session-local action toast that opens Connector settings.
- Extract the common action-toast presentation and reuse it for the existing lifecycle notice.
- Add all six renderer translations and document the interaction contract.

## Scope and non-goals

- Renderer-only change; main, preload, shared protocols, and OAuth token handling are unchanged.
- No historical-data migration, persisted field, database change, or new shared enum value.
- A cancelled or failed first authorization intentionally retains the saved Connector in its disabled state.
- xAI device authorization remains a separate provider-specific UI. This change reuses its established cancellable-dialog lifecycle and the shared dialog chrome without forcing unlike protocols into one abstraction.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Save-then-authorize, cancellation, retry, and list reuse -> focused Connector dialog, add-form, and panel render tests -> passed.
- Runtime credential invalidation and no-repeat transition semantics -> settings Connector slice tests -> passed.
- Shared toast behavior and lifecycle timer reset -> ActionToast, ConnectorAuthToast, and LifecycleToast tests -> passed.
- Settings and app consumers -> SettingsPage, settings-store, architecture, connector i18n, and App tests -> passed.
- Localization contract -> renderer i18n guard -> 590 passed.
- Combined focused Vitest set -> 14 files, 937 tests passed.
- Type safety -> npm run typecheck -> passed.
- Static analysis -> npm run lint -> passed.

The affected-test selector conservatively requested the complete suite because docs/design.md has no module owner. Per task scope, the complete npm test suite was not run locally; PR CI is authoritative for the full portable and platform plan. No live-provider OAuth or packaged Electron E2E was run locally.

## Review focus

- The runtime-only authenticated-to-unauthenticated transition in settings-connectors-slice.
- Cancellation and stale-promise guards in ConnectorOAuthSignInDialog.
- The intentionally narrow ActionToast extraction and the decision to keep xAI device-code UI separate.