### PR TITLE
fix(nightly): delete rolling release via API without a checkout

### DIFF
--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -97,10 +97,30 @@ jobs:
           test -s artifacts/SHA256SUMS.txt
           test -s artifacts/RELEASE-CERTIFICATION.json
 
+      # API-only: this job has no checkout, so `gh release delete --cleanup-tag` fails
+      # before deleting anything. GitHub also will not move an existing `nightly` tag.
       - name: Reset nightly release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release delete nightly --cleanup-tag --yes || true
+        run: |
+          error_file="$RUNNER_TEMP/nightly-reset-error.log"
+          if release_id=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/nightly" --jq .id 2>"$error_file"); then
+            gh api --method DELETE "repos/$GITHUB_REPOSITORY/releases/$release_id"
+          elif grep -Eq 'HTTP 404' "$error_file"; then
+            echo "No existing nightly release to delete."
+          else
+            cat "$error_file" >&2
+            exit 1
+          fi
+
+          if gh api --method DELETE "repos/$GITHUB_REPOSITORY/git/refs/tags/nightly" 2>"$error_file"; then
+            echo "Deleted the nightly tag."
+          elif grep -Eq 'HTTP 404' "$error_file"; then
+            echo "No existing nightly tag to delete."
+          else
+            cat "$error_file" >&2
+            exit 1
+          fi
 
       - name: Publish nightly pre-release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -187,6 +187,12 @@ describe('release and scheduled workflow topology', () => {
       publish.steps?.some(({ run }) => run?.includes('release-certification-evidence.mjs'))
     ).toBe(false)
     expect(reset.if).toBeUndefined()
+    expect(reset.run).toContain('repos/$GITHUB_REPOSITORY/releases/tags/nightly')
+    expect(reset.run).toContain('repos/$GITHUB_REPOSITORY/releases/$release_id')
+    expect(reset.run).toContain('repos/$GITHUB_REPOSITORY/git/refs/tags/nightly')
+    expect(reset.run).toContain("grep -Eq 'HTTP 404'")
+    expect(reset.run).not.toContain('--cleanup-tag')
+    expect(reset.run).not.toMatch(/\|\|\s*true/)
     expect(release.if).toBeUndefined()
   })
 


### PR DESCRIPTION
## Summary

Nightly Publish has been failing on `file_count limited to 1000 assets per release` because the rolling `nightly` release was never actually reset.

The privileged publisher never checks out the repo (by design). `gh release delete nightly --cleanup-tag --yes || true` therefore failed immediately with `fatal: not a git repository`, the error was swallowed, and `softprops/action-gh-release` kept appending uniquely named SHA-suffixed installers to the same release. GitHub also will not move an existing `nightly` tag, so the plan job kept seeing the original tag SHA and republishing every hour.

This switches reset to the Releases / Git Data APIs (404 = nothing to delete; any other error fails the job) so both the release and the `nightly` tag are removed before the new pre-release is created.

## Immediate cleanup

The stuck release (`id=367048742`) had 1001 assets across 126 nightly versions. Those assets, the empty release, and the stale `nightly` tag have already been deleted so the next scheduled publish can recreate a clean rolling pre-release. This workflow change is still required; without it the 1000-file cap will be hit again in a few days.

## Test plan

- [x] `npx vitest run scripts/ci/release-workflows.test.ts`
- [ ] After merge, confirm the next scheduled Nightly Publish recreates `nightly` with ~10 assets and moves the tag to that `main` SHA