### PR TITLE
feat(notebook): follow latest output in the current session preview

### DIFF
--- a/src/renderer/src/pages/workspace/NotebookPreview.follow-scroll.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.follow-scroll.test.tsx
@@ -1,0 +1,245 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { NotebookRunRecord } from '../../../../shared/notebook'
+import type { ProvisionStatus } from '../../../../shared/notebook-env'
+import { createInitialNotebookEnvState, useNotebookEnvStore } from '../../stores/notebook-env-store'
+import {
+  createInitialPreviewWorkbenchState,
+  usePreviewWorkbenchStore
+} from '../../stores/preview-workbench-store'
+import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
+import { NotebookPreview, type NotebookPreviewItem } from './NotebookPreview'
+import { deriveProvisionUi } from './provisioning-view'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = (): boolean => false
+  Element.prototype.setPointerCapture = (): void => undefined
+  Element.prototype.releasePointerCapture = (): void => undefined
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = (): void => undefined
+}
+
+vi.mock('./notebook-code', () => ({
+  NotebookCodeBlock: (props: { code: string }) => (
+    <pre data-testid="notebook-code-block">{props.code}</pre>
+  )
+}))
+
+const item: NotebookPreviewItem = {
+  id: 'tool:session-1:notebook',
+  sessionId: 'session-1',
+  title: 'Notebook',
+  type: 'tool',
+  toolKind: 'notebook',
+  notebook: {
+    sessionId: 'session-1',
+    projectId: 'proj',
+    workspaceCwd: '/tmp/proj',
+    notebookSessionRoot: '/tmp/proj/.notebook',
+    dataRoot: '/tmp/proj/.notebook/data',
+    runtimeRoot: '/tmp/proj/.notebook/runtime',
+    runJsonPath: '/tmp/proj/.notebook/run.json'
+  }
+}
+
+const makeRun = (overrides: Partial<NotebookRunRecord> = {}): NotebookRunRecord => ({
+  runId: 'r1',
+  cellId: 'c1',
+  source: 'agent',
+  kernelKind: 'python',
+  script: 'print(1)',
+  status: 'completed',
+  startedAt: 0,
+  text: { stdout: '', stderr: '', traceback: '', plain: [] },
+  outputs: [],
+  artifacts: [],
+  workingFiles: [],
+  rootFrameId: 'root-frame-session-1',
+  agentFrameId: 'root-frame-session-1',
+  ...overrides
+})
+
+const readyStatus: ProvisionStatus = {
+  pythonReady: true,
+  rReady: false,
+  version: 1,
+  provisioning: false
+}
+
+const notebookState = (runs: NotebookRunRecord[]): Record<string, unknown> => ({
+  id: 'session-1',
+  sessionId: 'session-1',
+  cwd: '/tmp/proj',
+  notebookSessionRoot: '/tmp/proj/.notebook',
+  dataRoot: '/tmp/proj/.notebook/data',
+  runtimeRoot: '/tmp/proj/.notebook/runtime',
+  kernelStatus: 'idle',
+  runJsonPath: '/tmp/proj/.notebook/run.json',
+  cells: [],
+  runs,
+  recentRuns: runs,
+  environments: []
+})
+
+const setScrollGeometry = (
+  element: HTMLElement,
+  geometry: { clientHeight: number; scrollHeight: number; scrollTop: number }
+): void => {
+  Object.defineProperties(element, {
+    clientHeight: { configurable: true, value: geometry.clientHeight },
+    scrollHeight: { configurable: true, value: geometry.scrollHeight },
+    scrollTop: { configurable: true, writable: true, value: geometry.scrollTop }
+  })
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  useNotebookEnvStore.setState({
+    ...createInitialNotebookEnvState(),
+    status: readyStatus,
+    ui: deriveProvisionUi(readyStatus, undefined, undefined, undefined)
+  })
+  usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+  useSessionStore.setState({
+    ...createInitialSessionState(),
+    selectedSessionId: 'session-1',
+    sessions: [
+      { id: 'session-1', conversationGraph: { rootFrameId: 'root-frame-session-1', frames: [] } }
+    ]
+  } as never)
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+const flushLoad = async (): Promise<void> => {
+  for (let i = 0; i < 5; i += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+  }
+}
+
+describe('NotebookPreview follow-bottom', () => {
+  it('keeps the current Session cells pinned to new output and pauses after the user scrolls up', async () => {
+    let runs = [makeRun({ runId: 'p1', script: 'print(1)' })]
+    let notifyChanged: (sessionId: string) => void = () => undefined
+
+    window.api = {
+      notebook: {
+        state: vi.fn(() => Promise.resolve(notebookState(runs))),
+        onChanged: vi.fn((listener: (event: { sessionId: string }) => void) => {
+          notifyChanged = (sessionId) => listener({ sessionId })
+          return (): void => undefined
+        })
+      },
+      notebookEnv: {
+        getStatus: vi.fn(() => Promise.resolve(readyStatus)),
+        provision: vi.fn(() => Promise.resolve()),
+        onProgress: vi.fn(() => vi.fn())
+      }
+    } as never
+
+    await act(async () => {
+      root.render(<NotebookPreview item={item} />)
+    })
+    await flushLoad()
+
+    const cells = container.querySelector<HTMLElement>('[data-testid="notebook-cells"]')
+    expect(cells).not.toBeNull()
+    setScrollGeometry(cells as HTMLElement, { clientHeight: 400, scrollHeight: 1000, scrollTop: 0 })
+    await act(async () => {
+      root.render(<NotebookPreview item={item} />)
+    })
+    expect(cells?.scrollTop).toBe(600)
+
+    runs = [
+      makeRun({ runId: 'p1', script: 'print(1)' }),
+      makeRun({ runId: 'p2', script: 'print(2)' })
+    ]
+    setScrollGeometry(cells as HTMLElement, {
+      clientHeight: 400,
+      scrollHeight: 1600,
+      scrollTop: 600
+    })
+    await act(async () => {
+      notifyChanged('session-1')
+      await Promise.resolve()
+    })
+    await flushLoad()
+    expect(cells?.scrollTop).toBe(1200)
+
+    cells!.scrollTop = 80
+    await act(async () => {
+      cells?.dispatchEvent(new Event('scroll'))
+    })
+    runs = [...runs, makeRun({ runId: 'p3', script: 'print(3)' })]
+    setScrollGeometry(cells as HTMLElement, {
+      clientHeight: 400,
+      scrollHeight: 2200,
+      scrollTop: 80
+    })
+    await act(async () => {
+      notifyChanged('session-1')
+      await Promise.resolve()
+    })
+    await flushLoad()
+    expect(cells?.scrollTop).toBe(80)
+  })
+
+  it('does not follow while another Session is selected', async () => {
+    useSessionStore.setState({ selectedSessionId: 'session-2' } as never)
+    let runs = [makeRun({ runId: 'p1' })]
+    window.api = {
+      notebook: {
+        state: vi.fn(() => Promise.resolve(notebookState(runs))),
+        onChanged: vi.fn(() => vi.fn())
+      },
+      notebookEnv: {
+        getStatus: vi.fn(() => Promise.resolve(readyStatus)),
+        provision: vi.fn(() => Promise.resolve()),
+        onProgress: vi.fn(() => vi.fn())
+      }
+    } as never
+
+    await act(async () => {
+      root.render(<NotebookPreview item={item} />)
+    })
+    await flushLoad()
+
+    const cells = container.querySelector<HTMLElement>('[data-testid="notebook-cells"]')
+    setScrollGeometry(cells as HTMLElement, {
+      clientHeight: 400,
+      scrollHeight: 1000,
+      scrollTop: 40
+    })
+    await act(async () => {
+      root.render(<NotebookPreview item={item} />)
+    })
+    expect(cells?.scrollTop).toBe(40)
+
+    runs = [makeRun({ runId: 'p1' }), makeRun({ runId: 'p2' })]
+    setScrollGeometry(cells as HTMLElement, {
+      clientHeight: 400,
+      scrollHeight: 1600,
+      scrollTop: 40
+    })
+    await act(async () => {
+      root.render(<NotebookPreview item={item} />)
+    })
+    expect(cells?.scrollTop).toBe(40)
+  })
+})

--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -354,6 +354,8 @@ describe('NotebookPreview per-kernel tabs', () => {
     expect(
       container.querySelector('[data-testid="notebook-terminal-header"]')?.textContent
     ).toContain('Python kernel')
+    expect(container.querySelector('[data-slot="message-scroller-button"]')).toBeNull()
+    expect(container.querySelector('[aria-label="Scroll to end"]')).toBeNull()
   })
 
   // The header's three strings were unwrapped while their translations already sat in the catalog —

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import type { PreviewToolItem } from '@/stores/preview-workbench-store'
+import { usePreviewWorkbenchStore, type PreviewToolItem } from '@/stores/preview-workbench-store'
 import { useNotebookEnvStore } from '@/stores/notebook-env-store'
 import { useSessionStore } from '@/stores/session-store'
 import { cn } from '@/lib/utils'
@@ -29,6 +29,8 @@ import { notebookGated } from './provisioning-view'
 import { NotebookCodeBlock } from './notebook-code'
 import { NotebookRunOutputs } from './NotebookRunOutputs'
 import { NotebookInputDataStrip } from './NotebookInputDataStrip'
+import { isCurrentSessionNotebookView } from './follow-notebook-scroll'
+import { useFollowScrollBottom } from './use-follow-scroll-bottom'
 import { useHorizontalScrollFade } from './use-horizontal-scroll-fade'
 import {
   resolveRunErrorLine,
@@ -165,26 +167,35 @@ const NotebookRunCell = ({
 }
 
 // Mirrors terminal-originated runs in the bottom terminal scrollback.
-const TerminalScrollback = ({ runs }: { runs: NotebookRunRecord[] }): React.JSX.Element => (
+const TerminalScrollback = ({
+  runs,
+  viewportRef
+}: {
+  runs: NotebookRunRecord[]
+  viewportRef: RefObject<HTMLDivElement | null>
+}): React.JSX.Element => (
   <div
+    ref={viewportRef}
     className="min-h-0 flex-1 overflow-y-auto px-3 py-2 font-mono text-xs leading-5"
     data-testid="kernel-terminal-scrollback"
   >
-    {runs
-      .filter((run) => run.inputKind === 'terminal')
-      .map((run) => (
-        <div key={run.runId} className="whitespace-pre-wrap">
-          <div>
-            <span className="text-text-300">&gt;&gt;&gt; </span>
-            <span className="text-text-100">{run.script}</span>
-          </div>
-          {getRunOutputText(run) ? (
-            <div className={isProblemRunStatus(run.status) ? 'text-danger-000' : 'text-text-200'}>
-              {getRunOutputText(run)}
+    <div>
+      {runs
+        .filter((run) => run.inputKind === 'terminal')
+        .map((run) => (
+          <div key={run.runId} className="whitespace-pre-wrap">
+            <div>
+              <span className="text-text-300">&gt;&gt;&gt; </span>
+              <span className="text-text-100">{run.script}</span>
             </div>
-          ) : null}
-        </div>
-      ))}
+            {getRunOutputText(run) ? (
+              <div className={isProblemRunStatus(run.status) ? 'text-danger-000' : 'text-text-200'}>
+                {getRunOutputText(run)}
+              </div>
+            ) : null}
+          </div>
+        ))}
+    </div>
   </div>
 )
 
@@ -245,6 +256,22 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
   const session = useSessionStore((state) =>
     state.sessions.find((candidate) => candidate.id === item.notebook.sessionId)
   )
+  const selectedSessionId = useSessionStore((state) => state.selectedSessionId)
+  const previewPanelState = usePreviewWorkbenchStore((state) => state.panelState)
+  const previewActiveItemId = usePreviewWorkbenchStore((state) => state.activeItemId)
+  const notebookItemInWorkbench = usePreviewWorkbenchStore((state) =>
+    state.items.some((entry) => entry.id === item.id)
+  )
+  const followEnabled = isCurrentSessionNotebookView({
+    notebookSessionId: item.notebook.sessionId,
+    selectedSessionId,
+    notebookItemId: item.id,
+    previewPanelState,
+    previewActiveItemId,
+    notebookItemInWorkbench
+  })
+  const cellsViewportRef = useFollowScrollBottom(followEnabled)
+  const terminalViewportRef = useFollowScrollBottom(followEnabled)
   // Selected environment within the active python/r pane; undefined lets the effective-env
   // computation below default to the first (canonical-default-first) environment.
   const [activeEnv, setActiveEnv] = useState<string | undefined>(undefined)
@@ -601,6 +628,7 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
           className="min-h-0 overflow-hidden"
         >
           <div
+            ref={cellsViewportRef}
             className="h-full min-h-0 overflow-y-auto overscroll-contain"
             data-testid="notebook-cells"
           >
@@ -636,7 +664,7 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
                 {actionError}
               </div>
             ) : null}
-            <TerminalScrollback runs={projectedRuns} />
+            <TerminalScrollback runs={projectedRuns} viewportRef={terminalViewportRef} />
             <TerminalInput
               code={terminalCode}
               disabled={isTerminalLocked}

--- a/src/renderer/src/pages/workspace/follow-notebook-scroll.test.ts
+++ b/src/renderer/src/pages/workspace/follow-notebook-scroll.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  FOLLOW_SCROLL_EDGE_PX,
+  followScrollBottomTop,
+  isAtFollowScrollBottom,
+  isCurrentSessionNotebookView
+} from './follow-notebook-scroll'
+
+describe('isAtFollowScrollBottom', () => {
+  it('treats the viewport as following when remaining overflow is within the edge', () => {
+    expect(isAtFollowScrollBottom({ scrollTop: 592, clientHeight: 400, scrollHeight: 1000 })).toBe(
+      true
+    )
+    expect(
+      isAtFollowScrollBottom({
+        scrollTop: 1000 - 400 - FOLLOW_SCROLL_EDGE_PX - 1,
+        clientHeight: 400,
+        scrollHeight: 1000
+      })
+    ).toBe(false)
+  })
+})
+
+describe('followScrollBottomTop', () => {
+  it('pins to the last visible line without going negative', () => {
+    expect(followScrollBottomTop({ scrollTop: 0, clientHeight: 400, scrollHeight: 1000 })).toBe(600)
+    expect(followScrollBottomTop({ scrollTop: 0, clientHeight: 400, scrollHeight: 200 })).toBe(0)
+  })
+})
+
+describe('isCurrentSessionNotebookView', () => {
+  const currentView = {
+    notebookSessionId: 'session-1',
+    selectedSessionId: 'session-1',
+    notebookItemId: 'tool:session-1:notebook',
+    previewPanelState: 'open' as const,
+    previewActiveItemId: 'tool:session-1:notebook',
+    notebookItemInWorkbench: true
+  }
+
+  it('follows only the selected Session Notebook while that preview is visible', () => {
+    expect(isCurrentSessionNotebookView(currentView)).toBe(true)
+  })
+
+  it('does not follow another Session even when its Notebook tab is open', () => {
+    expect(
+      isCurrentSessionNotebookView({
+        ...currentView,
+        selectedSessionId: 'session-2'
+      })
+    ).toBe(false)
+  })
+
+  it('does not follow when the preview panel is collapsed or another tab is active', () => {
+    expect(
+      isCurrentSessionNotebookView({
+        ...currentView,
+        previewPanelState: 'collapsed'
+      })
+    ).toBe(false)
+    expect(
+      isCurrentSessionNotebookView({
+        ...currentView,
+        previewActiveItemId: 'tool:project:files'
+      })
+    ).toBe(false)
+  })
+
+  it('follows an isolated mount whose Notebook is not yet in the workbench', () => {
+    expect(
+      isCurrentSessionNotebookView({
+        ...currentView,
+        notebookItemInWorkbench: false,
+        previewPanelState: 'collapsed',
+        previewActiveItemId: undefined
+      })
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/pages/workspace/follow-notebook-scroll.ts
+++ b/src/renderer/src/pages/workspace/follow-notebook-scroll.ts
@@ -1,0 +1,35 @@
+import type { PreviewPanelState } from '@/stores/preview-workbench-store'
+
+export const FOLLOW_SCROLL_EDGE_PX = 8
+
+type FollowScrollViewport = Pick<HTMLElement, 'clientHeight' | 'scrollHeight' | 'scrollTop'>
+
+export const isAtFollowScrollBottom = (
+  viewport: FollowScrollViewport,
+  edgePx: number = FOLLOW_SCROLL_EDGE_PX
+): boolean => viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <= edgePx
+
+export const followScrollBottomTop = (viewport: FollowScrollViewport): number =>
+  Math.max(0, viewport.scrollHeight - viewport.clientHeight)
+
+// Follow only while the visible preview is this Session's Notebook. Isolated mounts that are not
+// yet in the workbench still follow when the selected Session matches.
+export const isCurrentSessionNotebookView = ({
+  notebookSessionId,
+  selectedSessionId,
+  notebookItemId,
+  previewPanelState,
+  previewActiveItemId,
+  notebookItemInWorkbench
+}: {
+  notebookSessionId: string
+  selectedSessionId: string | undefined
+  notebookItemId: string
+  previewPanelState: PreviewPanelState
+  previewActiveItemId: string | undefined
+  notebookItemInWorkbench: boolean
+}): boolean => {
+  if (selectedSessionId !== notebookSessionId) return false
+  if (!notebookItemInWorkbench) return true
+  return previewPanelState === 'open' && previewActiveItemId === notebookItemId
+}

--- a/src/renderer/src/pages/workspace/use-follow-scroll-bottom.test.tsx
+++ b/src/renderer/src/pages/workspace/use-follow-scroll-bottom.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useFollowScrollBottom } from './use-follow-scroll-bottom'
+
+const Harness = ({
+  enabled,
+  contentHeight
+}: {
+  enabled: boolean
+  contentHeight: number
+}): React.JSX.Element => {
+  const viewportRef = useFollowScrollBottom(enabled)
+  return (
+    <div data-testid="viewport" ref={viewportRef}>
+      <div data-testid="content" style={{ height: contentHeight }} />
+    </div>
+  )
+}
+
+const setScrollGeometry = (
+  element: HTMLElement,
+  geometry: { clientHeight: number; scrollHeight: number; scrollTop: number }
+): void => {
+  Object.defineProperties(element, {
+    clientHeight: { configurable: true, value: geometry.clientHeight },
+    scrollHeight: { configurable: true, value: geometry.scrollHeight },
+    scrollTop: { configurable: true, writable: true, value: geometry.scrollTop }
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('useFollowScrollBottom', () => {
+  it('pins new content to the bottom while following', () => {
+    const view = render(<Harness enabled contentHeight={1000} />)
+    const viewport = screen.getByTestId('viewport')
+    setScrollGeometry(viewport, { clientHeight: 400, scrollHeight: 1000, scrollTop: 0 })
+
+    view.rerender(<Harness enabled contentHeight={1000} />)
+    expect(viewport.scrollTop).toBe(600)
+
+    setScrollGeometry(viewport, { clientHeight: 400, scrollHeight: 1400, scrollTop: 600 })
+    view.rerender(<Harness enabled contentHeight={1400} />)
+    expect(viewport.scrollTop).toBe(1000)
+  })
+
+  it('pauses after the user leaves the bottom and resumes when they return', () => {
+    const view = render(<Harness enabled contentHeight={1000} />)
+    const viewport = screen.getByTestId('viewport')
+    setScrollGeometry(viewport, { clientHeight: 400, scrollHeight: 1000, scrollTop: 0 })
+    view.rerender(<Harness enabled contentHeight={1000} />)
+    expect(viewport.scrollTop).toBe(600)
+
+    viewport.scrollTop = 120
+    fireEvent.scroll(viewport)
+
+    setScrollGeometry(viewport, { clientHeight: 400, scrollHeight: 1600, scrollTop: 120 })
+    view.rerender(<Harness enabled contentHeight={1600} />)
+    expect(viewport.scrollTop).toBe(120)
+
+    viewport.scrollTop = 1200
+    fireEvent.scroll(viewport)
+
+    setScrollGeometry(viewport, { clientHeight: 400, scrollHeight: 2000, scrollTop: 1200 })
+    view.rerender(<Harness enabled contentHeight={2000} />)
+    expect(viewport.scrollTop).toBe(1600)
+  })
+
+  it('does not chase content while follow is disabled', () => {
+    const view = render(<Harness enabled={false} contentHeight={1000} />)
+    const viewport = screen.getByTestId('viewport')
+    setScrollGeometry(viewport, { clientHeight: 400, scrollHeight: 1000, scrollTop: 40 })
+
+    view.rerender(<Harness enabled={false} contentHeight={1600} />)
+    setScrollGeometry(viewport, { clientHeight: 400, scrollHeight: 1600, scrollTop: 40 })
+    view.rerender(<Harness enabled={false} contentHeight={1600} />)
+    expect(viewport.scrollTop).toBe(40)
+  })
+
+  it('catches up when follow is re-enabled after staying at the bottom', async () => {
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback): number =>
+        window.setTimeout(() => callback(performance.now()), 0) as unknown as number
+    )
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number): void => {
+      window.clearTimeout(frameId)
+    })
+
+    const view = render(<Harness enabled contentHeight={1000} />)
+    const viewport = screen.getByTestId('viewport')
+    setScrollGeometry(viewport, { clientHeight: 400, scrollHeight: 1000, scrollTop: 0 })
+    view.rerender(<Harness enabled contentHeight={1000} />)
+    expect(viewport.scrollTop).toBe(600)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    view.rerender(<Harness enabled={false} contentHeight={1000} />)
+    setScrollGeometry(viewport, { clientHeight: 400, scrollHeight: 1800, scrollTop: 600 })
+    view.rerender(<Harness enabled={false} contentHeight={1800} />)
+    expect(viewport.scrollTop).toBe(600)
+
+    view.rerender(<Harness enabled contentHeight={1800} />)
+    expect(viewport.scrollTop).toBe(1400)
+  })
+})

--- a/src/renderer/src/pages/workspace/use-follow-scroll-bottom.ts
+++ b/src/renderer/src/pages/workspace/use-follow-scroll-bottom.ts
@@ -1,0 +1,67 @@
+import { useLayoutEffect, useRef, type RefObject } from 'react'
+
+import { followScrollBottomTop, isAtFollowScrollBottom } from './follow-notebook-scroll'
+
+// Keeps a scroller pinned to the latest content while the caller allows follow. User movement
+// away from the bottom pauses; returning to the bottom resumes. There is no jump control.
+export const useFollowScrollBottom = (enabled: boolean): RefObject<HTMLDivElement | null> => {
+  const viewportRef = useRef<HTMLDivElement | null>(null)
+  const followingRef = useRef(true)
+  const autoscrollingRef = useRef(false)
+  const enabledRef = useRef(enabled)
+  const autoscrollFrameRef = useRef<number | undefined>(undefined)
+
+  useLayoutEffect(() => {
+    enabledRef.current = enabled
+    const viewport = viewportRef.current
+    if (!viewport) return
+
+    const clearAutoscroll = (): void => {
+      if (autoscrollFrameRef.current === undefined) return
+      window.cancelAnimationFrame(autoscrollFrameRef.current)
+      autoscrollFrameRef.current = undefined
+    }
+
+    const scrollToEnd = (): void => {
+      const nextTop = followScrollBottomTop(viewport)
+      if (Math.abs(viewport.scrollTop - nextTop) <= 0.5) return
+      autoscrollingRef.current = true
+      viewport.scrollTop = nextTop
+      clearAutoscroll()
+      autoscrollFrameRef.current = window.requestAnimationFrame(() => {
+        autoscrollFrameRef.current = undefined
+        autoscrollingRef.current = false
+      })
+    }
+
+    const handleScroll = (): void => {
+      if (!enabledRef.current) return
+      const atBottom = isAtFollowScrollBottom(viewport)
+      // Programmatic follow lands on the bottom; a user move away from it always pauses.
+      if (autoscrollingRef.current && atBottom) return
+      followingRef.current = atBottom
+    }
+
+    const handleContentResize = (): void => {
+      if (enabledRef.current && followingRef.current) scrollToEnd()
+    }
+
+    if (enabled && followingRef.current) scrollToEnd()
+
+    viewport.addEventListener('scroll', handleScroll, { passive: true })
+    const observer =
+      typeof ResizeObserver === 'undefined' ? undefined : new ResizeObserver(handleContentResize)
+    observer?.observe(viewport)
+    const content = viewport.firstElementChild
+    if (content) observer?.observe(content)
+
+    return () => {
+      viewport.removeEventListener('scroll', handleScroll)
+      observer?.disconnect()
+      clearAutoscroll()
+      autoscrollingRef.current = false
+    }
+  })
+
+  return viewportRef
+}


### PR DESCRIPTION
## Problem

The live Session Notebook preview kept its previous scroll position when new cells or growing output arrived. Watching the current Session required constantly dragging the pane to the latest run.

## Proposed change

Pin the cell list and kernel terminal to the latest content while the visible preview is this Session's Notebook. Follow pauses when the user leaves the bottom and resumes when they return. There is no jump-to-end chip.

Follow is gated so a hidden tab, collapsed preview, or another Session's Notebook does not chase output in the background.

```mermaid
stateDiagram-v2
  [*] --> FollowingBottom: viewing current Session Notebook
  FollowingBottom --> FollowingBottom: new or growing content
  FollowingBottom --> FreeScrolling: user leaves the bottom
  FreeScrolling --> FollowingBottom: user returns to the bottom
  FollowingBottom --> Paused: other tab, collapsed panel, or other Session
  FreeScrolling --> Paused: other tab, collapsed panel, or other Session
```

## Scope and non-goals

- Live `NotebookPreview` cells and kernel terminal only
- No Session notebook dialog follow (`onChanged` is not subscribed there)
- No jump-to-end or first-cell control
- No persisted scroll position, schema, or enum changes

## Compatibility, state, persistence

- **Historical data:** none
- **New enums / lifecycle values:** none. Follow mode is ephemeral scroller state
- **Persistence:** none. Scroll position is not saved

## Acceptance criteria and validation

- New cells and growing output stay in view while following
- Scrolling up pauses; returning to the bottom resumes
- Another Session or a non-visible preview does not follow
- No jump-to-end button

Checks after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Follow policy | `npx vitest run src/renderer/src/pages/workspace/follow-notebook-scroll.test.ts` | pass |
| Follow hook | `npx vitest run src/renderer/src/pages/workspace/use-follow-scroll-bottom.test.tsx` | pass |
| Preview wiring | `npx vitest run src/renderer/src/pages/workspace/NotebookPreview.follow-scroll.test.tsx src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx` | pass |
| Source shape | `npx vitest run src/renderer/src/pages/workspace/workspace-components.test.tsx` | pass |
| Renderer types | `npm run typecheck:web` | pass |
| Changed-file lint | `npx eslint` on the touched Notebook files | pass |

`NotebookPreview` is not an owner path in `module-impact.json`; PR Gate remains authoritative for the complete suite. Full local `npm test` was not run.

Uncovered risks: live streaming output and image-load growth were covered via ResizeObserver and layout follow, not a running kernel in the browser.

## Review focus

- Follow gate (`isCurrentSessionNotebookView`) vs hidden preview tabs
- Pause/resume without a jump control
- Shared hook on cells and terminal, still one overflow owner per pane