### PR TITLE
fix(startup): keep loading animation continuous

### DIFF
--- a/src/renderer/src/components/OpenScienceLogoLoader.test.tsx
+++ b/src/renderer/src/components/OpenScienceLogoLoader.test.tsx
@@ -54,8 +54,79 @@ describe('OpenScienceLogoLoader', () => {
     }
   })
 
+  it('continues the animation timeline after the loader remounts', () => {
+    const context = {
+      arc: vi.fn(),
+      beginPath: vi.fn(),
+      clearRect: vi.fn(),
+      fill: vi.fn(),
+      fillStyle: '',
+      globalAlpha: 1,
+      globalCompositeOperation: 'source-over',
+      restore: vi.fn(),
+      save: vi.fn()
+    } as unknown as CanvasRenderingContext2D
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(context)
+    vi.spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect').mockImplementation(() => ({
+      bottom: 224,
+      height: 224,
+      left: 0,
+      right: 224,
+      top: 0,
+      width: 224,
+      x: 0,
+      y: 0,
+      toJSON: () => undefined
+    }))
+
+    let now = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => now)
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => createTestMediaQuery(false) as unknown as MediaQueryList)
+    )
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe = vi.fn()
+        disconnect = vi.fn()
+      }
+    )
+    vi.stubGlobal(
+      'MutationObserver',
+      class {
+        observe = vi.fn()
+        disconnect = vi.fn()
+      }
+    )
+
+    const animationFrames: FrameRequestCallback[] = []
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      animationFrames.push(callback)
+      return animationFrames.length
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+
+    act(() => root.render(<OpenScienceLogoLoader />))
+    context.arc = vi.fn()
+    now = 1_000
+    act(() => animationFrames.shift()?.(now))
+    const firstFrameArc = vi.mocked(context.arc).mock.calls[0]
+
+    vi.mocked(context.arc).mockClear()
+    act(() => root.render(null))
+    now = 2_000
+    act(() => root.render(<OpenScienceLogoLoader />))
+    const remountedFrameArc = vi.mocked(context.arc).mock.calls.at(-1)
+
+    expect(firstFrameArc).toBeDefined()
+    expect(remountedFrameArc).toBeDefined()
+    expect(remountedFrameArc).not.toEqual(firstFrameArc)
+  })
+
   it('draws, reacts to motion and DPR changes, and releases browser observers', () => {
     Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 1 })
+    vi.spyOn(performance, 'now').mockReturnValue(0)
 
     const context = {
       arc: vi.fn(),

--- a/src/renderer/src/components/OpenScienceLogoLoader.tsx
+++ b/src/renderer/src/components/OpenScienceLogoLoader.tsx
@@ -14,6 +14,12 @@ const MIN_FRAME_INTERVAL_MS = 1000 / MAX_ANIMATION_FPS
 // The startup surface is short-lived; 2x keeps the logo crisp without allocating a 3x/4x canvas.
 const MAX_DEVICE_PIXEL_RATIO = 2
 const FALLBACK_CANVAS_SIZE = 448
+let animationStartedAt: number | undefined
+
+const resolveAnimationTime = (now: number): number => {
+  animationStartedAt ??= now
+  return now - animationStartedAt
+}
 
 const OpenScienceLogoLoader = (): React.JSX.Element => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -31,7 +37,6 @@ const OpenScienceLogoLoader = (): React.JSX.Element => {
     let metrics: LogoCanvasMetrics = { width: 1, height: 1, dpr: 1 }
     let particles: LogoParticle[] = []
     let color = getComputedStyle(canvas).color
-    let animationStartedAt = performance.now()
     let lastDrawnAt: number | undefined
 
     const draw = (time: number): void => {
@@ -47,21 +52,24 @@ const OpenScienceLogoLoader = (): React.JSX.Element => {
 
     const animate = (now: number): void => {
       if (lastDrawnAt === undefined || now - lastDrawnAt >= MIN_FRAME_INTERVAL_MS) {
-        draw(now - animationStartedAt)
+        draw(resolveAnimationTime(now))
         lastDrawnAt = now
       }
       animationFrame = requestAnimationFrame(animate)
     }
 
-    const restartAnimation = (): void => {
+    const restartLoop = (): void => {
       if (animationFrame !== undefined) cancelAnimationFrame(animationFrame)
 
       animationFrame = undefined
-      animationStartedAt = performance.now()
-      lastDrawnAt = undefined
+      const now = performance.now()
+      lastDrawnAt = now
 
       if (prefersReducedMotion) draw(0)
-      else animationFrame = requestAnimationFrame(animate)
+      else {
+        draw(resolveAnimationTime(now))
+        animationFrame = requestAnimationFrame(animate)
+      }
     }
 
     const resize = (): void => {
@@ -79,12 +87,12 @@ const OpenScienceLogoLoader = (): React.JSX.Element => {
       metrics = { width, height, dpr }
       particles = createLogoParticles(metrics)
       color = getComputedStyle(canvas).color
-      restartAnimation()
+      restartLoop()
     }
 
     const handleMotionPreferenceChange = (event: MediaQueryListEvent): void => {
       prefersReducedMotion = event.matches
-      restartAnimation()
+      restartLoop()
     }
 
     const handleDevicePixelRatioChange = (): void => {

--- a/src/renderer/src/components/database-startup-gate.test.tsx
+++ b/src/renderer/src/components/database-startup-gate.test.tsx
@@ -45,11 +45,19 @@ describe('DatabaseStartupGate', () => {
     )
 
     const startupLoader = screen.getByTestId('open-science-logo-loader')
-    expect(screen.getByText('Checking database…')).toBeTruthy()
+    const startupStatus = screen.getByRole('status')
+    const checkingLabel = screen.getByText('Checking database…')
+    expect(startupStatus.className).toContain('min-h-svh')
+    expect(startupStatus.className).toContain('text-foreground')
+    expect(checkingLabel.tagName).toBe('SPAN')
+    expect(checkingLabel.className).toContain('text-sm')
+    expect(checkingLabel.className).toContain('text-muted-foreground')
 
     act(() => publish({ phase: 'migrating', migrationId: '0002_example' }))
 
-    expect(screen.getByText('Updating database…')).toBeTruthy()
+    const updatingLabel = screen.getByText('Updating database…')
+    expect(updatingLabel.tagName).toBe('SPAN')
+    expect(updatingLabel.className).toBe(checkingLabel.className)
     expect(screen.getByText('Keep Open Science open while this finishes.')).toBeTruthy()
     expect(screen.getByTestId('open-science-logo-loader')).toBe(startupLoader)
   })

--- a/src/renderer/src/components/database-startup-gate.tsx
+++ b/src/renderer/src/components/database-startup-gate.tsx
@@ -144,16 +144,16 @@ const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.
   if (state.phase !== 'blocked') {
     return (
       <main
-        className="flex min-h-screen items-center justify-center bg-background px-6"
-        aria-live="polite"
+        role="status"
+        className="flex min-h-svh items-center justify-center bg-background px-6 text-foreground"
       >
         <section className="flex w-full max-w-md flex-col items-center text-center">
           <div className="flex flex-col items-center gap-14">
             <OpenScienceLogoLoader />
             <div className="flex flex-col items-center gap-4">
-              <h1 className="text-base font-medium text-foreground">
+              <span className="text-sm text-muted-foreground">
                 {state.phase === 'migrating' ? t('Updating database…') : t('Checking database…')}
-              </h1>
+              </span>
               {state.phase === 'migrating' ? (
                 <p className="text-sm text-muted-foreground">
                   {t('Keep Open Science open while this finishes.')}


### PR DESCRIPTION
## Problem

The database startup screen used larger, darker status text than the settings and saved-conversation loading screens that follow it. Its branded particle loader also restarted when DatabaseStartupGate handed off to App because each mounted loader owned a fresh animation origin.

## Proposed change

- Match the database startup shell and status label to the existing App loading treatment: status semantics, min-h-svh, text-sm, and text-muted-foreground.
- Keep one renderer-lifetime animation origin for the branded loader and draw the current frame immediately after a mount or canvas refresh, so startup phase handoffs do not flash or restart.
- Preserve the existing 30 FPS cap, deterministic particles, DPR handling, theme updates, and reduced-motion behavior.
- Add regression coverage for typography parity and loader remount continuity.

## Scope and non-goals

- No database verification, migration, or IPC behavior changes.
- No new dependencies or user-visible strings.
- No persisted data, schema, historical-data compatibility, or enum changes.

## Acceptance criteria and validation

Final checks ran after the last material edit:

- Database and subsequent loading typography -> npm test -- src/renderer/src/App.test.tsx src/renderer/src/components/OpenScienceLogoLoader.test.tsx src/renderer/src/components/database-startup-gate.test.tsx -> 3 files / 63 tests passed.
- Loader remount continuity and reduced-motion/DPR cleanup -> same targeted Vitest command -> passed.
- Renderer types -> npm run typecheck:web -> passed.
- Source lint -> npm run lint -> passed.
- Changed-file formatting and whitespace -> Prettier check plus git diff --check -> passed.

The exact-head module-impact classifier selected the full plan because these startup component tests do not yet have a registered module owner. Per maintainer direction, the complete local npm test suite was not run; PR Gate and selected CI lanes are the final validation authority.

Consumer and platform scope: App is included as the direct renderer consumer. Database behavior and Web API contracts are excluded because their interfaces are unchanged. The visual handoff is Electron-specific; cross-platform rendering remains covered by the existing semantic Tailwind classes and CI.

## Review focus

- Whether the renderer-lifetime animation origin is the appropriate continuity boundary for startup-only loader instances.
- Whether the immediate first draw preserves a seamless handoff without changing frame throttling or reduced-motion behavior.