### PR TITLE
fix(notebook): reject unknown environment languages at the IPC boundary

### DIFF
--- a/src/main/notebook/application-commands.test.ts
+++ b/src/main/notebook/application-commands.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { ApplicationCommandError } from '../../shared/application-command-contract'
 import {
   createApplicationCommandRouter,
   type ApplicationInvocation
@@ -331,6 +332,35 @@ describe('Notebook application commands', () => {
       )
     ).rejects.toThrow('Channel only available from the local app: notebook-env:cancel')
     expect(status).toHaveBeenCalledOnce()
+    expect(provision).not.toHaveBeenCalled()
+    expect(repair).not.toHaveBeenCalled()
+    expect(cancel).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unknown Environment language before the lifecycle runs', async () => {
+    const provision = vi.fn()
+    const repair = vi.fn()
+    const cancel = vi.fn()
+    const router = createApplicationCommandRouter()
+    installNotebookEnvironmentApplicationCommands(router.registrar, {
+      status: vi.fn(),
+      provision,
+      repair,
+      cancel,
+      startup: vi.fn()
+    })
+
+    const error = await router.dispatcher
+      .invoke(notebookEnvironmentProvisionCommand, invocation(['julia'] as never))
+      .catch((caught: unknown) => caught)
+    expect(error).toBeInstanceOf(ApplicationCommandError)
+    expect(error).toMatchObject({ code: 'invalid-command-arguments' })
+    await expect(
+      router.dispatcher.invoke(notebookEnvironmentRepairCommand, invocation(['julia'] as never))
+    ).rejects.toMatchObject({ code: 'invalid-command-arguments' })
+    await expect(
+      router.dispatcher.invoke(notebookEnvironmentCancelCommand, invocation(['julia'] as never))
+    ).rejects.toMatchObject({ code: 'invalid-command-arguments' })
     expect(provision).not.toHaveBeenCalled()
     expect(repair).not.toHaveBeenCalled()
     expect(cancel).not.toHaveBeenCalled()

--- a/src/main/notebook/application-commands.test.ts
+++ b/src/main/notebook/application-commands.test.ts
@@ -365,4 +365,32 @@ describe('Notebook application commands', () => {
     expect(repair).not.toHaveBeenCalled()
     expect(cancel).not.toHaveBeenCalled()
   })
+
+  it('treats JSON-null optional Environment arguments as omitted', async () => {
+    const provision = vi.fn(async () => undefined)
+    const repair = vi.fn(async () => undefined)
+    const cancel = vi.fn()
+    const router = createApplicationCommandRouter()
+    installNotebookEnvironmentApplicationCommands(router.registrar, {
+      status: vi.fn(),
+      provision,
+      repair,
+      cancel,
+      startup: vi.fn()
+    })
+
+    await router.dispatcher.invoke(notebookEnvironmentCancelCommand, invocation([null] as never))
+    await router.dispatcher.invoke(
+      notebookEnvironmentProvisionCommand,
+      invocation(['python', null] as never)
+    )
+    await router.dispatcher.invoke(
+      notebookEnvironmentRepairCommand,
+      invocation(['r', null] as never)
+    )
+
+    expect(cancel).toHaveBeenCalledWith(undefined)
+    expect(provision).toHaveBeenCalledWith('python', undefined)
+    expect(repair).toHaveBeenCalledWith('r', undefined)
+  })
 })

--- a/src/main/notebook/env-ipc.test.ts
+++ b/src/main/notebook/env-ipc.test.ts
@@ -78,6 +78,27 @@ describe('registerNotebookEnvIpcHandlers', () => {
     )
   })
 
+  it('rejects an unknown provision language instead of installing Python', async () => {
+    const provisioner = fakeProvisioner()
+    registerNotebookEnvIpcHandlers(createLifecycle(provisioner))
+
+    await expect(registered.get('notebook-env:provision')?.({}, 'julia')).rejects.toThrow(
+      /python or r/i
+    )
+    expect(provisioner.provisionPython).not.toHaveBeenCalled()
+    expect(provisioner.provisionR).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unknown repair language instead of rebuilding Python', async () => {
+    const provisioner = fakeProvisioner()
+    registerNotebookEnvIpcHandlers(createLifecycle(provisioner))
+
+    await expect(registered.get('notebook-env:repair')?.({}, 'julia')).rejects.toThrow(
+      /python or r/i
+    )
+    expect(provisioner.repair).not.toHaveBeenCalled()
+  })
+
   it('projects scoped progress only through live Electron BrowserWindows', async () => {
     const provisioner = fakeProvisioner({
       provisionR: vi.fn().mockImplementation(async (report) => {

--- a/src/main/notebook/environment-application-commands.ts
+++ b/src/main/notebook/environment-application-commands.ts
@@ -1,3 +1,4 @@
+import { notebookEnvironmentApplicationCommandContracts } from '../../shared/notebook'
 import {
   defineApplicationCommand,
   defineApplicationCommandGroup,
@@ -32,17 +33,17 @@ const notebookEnvironmentProvisionCommand = defineApplicationCommand<
   'notebook-env:provision',
   LifecycleArgs<'provision'>,
   LifecycleResult<'provision'>
->('notebook-env:provision')
+>('notebook-env:provision', notebookEnvironmentApplicationCommandContracts.provision)
 const notebookEnvironmentRepairCommand = defineApplicationCommand<
   'notebook-env:repair',
   LifecycleArgs<'repair'>,
   LifecycleResult<'repair'>
->('notebook-env:repair')
+>('notebook-env:repair', notebookEnvironmentApplicationCommandContracts.repair)
 const notebookEnvironmentCancelCommand = defineApplicationCommand<
   'notebook-env:cancel',
   LifecycleArgs<'cancel'>,
   LifecycleResult<'cancel'>
->('notebook-env:cancel')
+>('notebook-env:cancel', notebookEnvironmentApplicationCommandContracts.cancel)
 
 const notebookEnvironmentApplicationCommands = defineApplicationCommandGroup(
   'notebook-environment',

--- a/src/main/notebook/environment-lifecycle-workflows.test.ts
+++ b/src/main/notebook/environment-lifecycle-workflows.test.ts
@@ -99,6 +99,19 @@ describe('createNotebookEnvironmentLifecycle', () => {
     expect(provisioner.provisionR).toHaveBeenCalledOnce()
   })
 
+  it('rejects an unknown language instead of falling through to Python', async () => {
+    const provisioner = fakeProvisioner()
+    const lifecycle = createLifecycle(provisioner)
+
+    await expect(lifecycle.provision('julia' as 'python')).rejects.toThrow(/python or r/i)
+    await expect(lifecycle.repair('julia' as 'python')).rejects.toThrow(/python or r/i)
+    expect(() => lifecycle.cancel('julia' as 'python')).toThrow(/python or r/i)
+    expect(provisioner.provisionPython).not.toHaveBeenCalled()
+    expect(provisioner.provisionR).not.toHaveBeenCalled()
+    expect(provisioner.repair).not.toHaveBeenCalled()
+    expect(provisioner.cancel).not.toHaveBeenCalled()
+  })
+
   it('tags a failure that occurs before provision progress is emitted', async () => {
     const failure = new Error('provision rejected before startup')
     const provisioner = fakeProvisioner({ provisionPython: vi.fn().mockRejectedValue(failure) })

--- a/src/main/notebook/environment-lifecycle-workflows.test.ts
+++ b/src/main/notebook/environment-lifecycle-workflows.test.ts
@@ -112,6 +112,13 @@ describe('createNotebookEnvironmentLifecycle', () => {
     expect(provisioner.cancel).not.toHaveBeenCalled()
   })
 
+  it('treats a JSON-null optional language as omit-all cancel', () => {
+    const provisioner = fakeProvisioner()
+    const lifecycle = createLifecycle(provisioner)
+    lifecycle.cancel(null as unknown as undefined)
+    expect(provisioner.cancel).toHaveBeenCalledWith(undefined)
+  })
+
   it('tags a failure that occurs before provision progress is emitted', async () => {
     const failure = new Error('provision rejected before startup')
     const provisioner = fakeProvisioner({ provisionPython: vi.fn().mockRejectedValue(failure) })

--- a/src/main/notebook/environment-lifecycle-workflows.ts
+++ b/src/main/notebook/environment-lifecycle-workflows.ts
@@ -1,6 +1,10 @@
 import { existsSync } from 'node:fs'
 
-import type { NotebookLanguage } from '../../shared/notebook'
+import {
+  parseNotebookLanguage,
+  parseOptionalNotebookLanguage,
+  type NotebookLanguage
+} from '../../shared/notebook'
 import { withDataRootWrite } from '../storage/migration-state'
 import {
   logStartupGateFailure,
@@ -64,10 +68,13 @@ const createUnavailableLifecycle = (
       version: DEFAULT_ENV_VERSION,
       provisioning: false
     }),
-  provision: (language, operationId) =>
-    runUnavailableOperation(deps, 'provision', language, operationId),
-  repair: (language, operationId) => runUnavailableOperation(deps, 'repair', language, operationId),
-  cancel: () => undefined,
+  provision: async (language, operationId) =>
+    runUnavailableOperation(deps, 'provision', parseNotebookLanguage(language), operationId),
+  repair: async (language, operationId) =>
+    runUnavailableOperation(deps, 'repair', parseNotebookLanguage(language), operationId),
+  cancel: (language) => {
+    parseOptionalNotebookLanguage(language)
+  },
   startup: () => Promise.resolve()
 })
 
@@ -84,45 +91,54 @@ const createNotebookEnvironmentLifecycle = (
       return provisioner.status()
     })
 
-  const provision = (language: NotebookLanguage, operationId?: string): Promise<void> =>
-    runLoggedRuntimeOperation(
+  const provision = async (language: NotebookLanguage, operationId?: string): Promise<void> => {
+    const parsedLanguage = parseNotebookLanguage(language)
+    return runLoggedRuntimeOperation(
       'provision',
-      language,
+      parsedLanguage,
       deps.root,
       (report) =>
         withDataRootWrite(async () => {
           if (deps.waitForRecovery) await deps.waitForRecovery()
-          deps.assertProvisionAllowed?.(language)
-          await (language === 'r'
-            ? provisioner.provisionR(report)
-            : provisioner.provisionPython(report))
+          deps.assertProvisionAllowed?.(parsedLanguage)
+          switch (parsedLanguage) {
+            case 'r':
+              await provisioner.provisionR(report)
+              return
+            case 'python':
+              await provisioner.provisionPython(report)
+              return
+          }
         }),
       (progress) =>
         deps.projectProgress({
           ...progress,
-          scope: language,
+          scope: parsedLanguage,
           ...(operationId === undefined ? {} : { operationId })
         })
     )
+  }
 
-  const repair = (language: NotebookLanguage, operationId?: string): Promise<void> =>
-    runLoggedRuntimeOperation(
+  const repair = async (language: NotebookLanguage, operationId?: string): Promise<void> => {
+    const parsedLanguage = parseNotebookLanguage(language)
+    return runLoggedRuntimeOperation(
       'repair',
-      language,
+      parsedLanguage,
       deps.root,
       (report) =>
         withDataRootWrite(async () => {
           if (deps.waitForRecovery) await deps.waitForRecovery()
-          await provisioner.repair(language, report, { force: true })
-          await deps.onRepairCompleted?.(language)
+          await provisioner.repair(parsedLanguage, report, { force: true })
+          await deps.onRepairCompleted?.(parsedLanguage)
         }),
       (progress) =>
         deps.projectProgress({
           ...progress,
-          scope: language,
+          scope: parsedLanguage,
           ...(operationId === undefined ? {} : { operationId })
         })
     )
+  }
 
   const startup = async (): Promise<void> => {
     try {
@@ -159,7 +175,7 @@ const createNotebookEnvironmentLifecycle = (
     status,
     provision,
     repair,
-    cancel: (language) => provisioner.cancel(language),
+    cancel: (language) => provisioner.cancel(parseOptionalNotebookLanguage(language)),
     startup
   }
 }

--- a/src/shared/notebook.test.ts
+++ b/src/shared/notebook.test.ts
@@ -1,10 +1,42 @@
 import { describe, it, expect } from 'vitest'
-import type { NotebookLanguage, NotebookOutput, NotebookCell } from './notebook'
+import {
+  notebookEnvironmentApplicationCommandContracts,
+  parseNotebookLanguage,
+  parseOptionalNotebookLanguage,
+  type NotebookOutput,
+  type NotebookCell
+} from './notebook'
 
 describe('shared notebook types', () => {
-  it('NotebookLanguage admits python and r', () => {
-    const langs: NotebookLanguage[] = ['python', 'r']
-    expect(langs).toEqual(['python', 'r'])
+  it('parses only python and r as NotebookLanguage', () => {
+    expect(parseNotebookLanguage('python')).toBe('python')
+    expect(parseNotebookLanguage('r')).toBe('r')
+    expect(parseOptionalNotebookLanguage(undefined)).toBeUndefined()
+    expect(() => parseNotebookLanguage('julia')).toThrow(/python or r/i)
+    expect(() => parseNotebookLanguage('R')).toThrow(/python or r/i)
+    expect(() => parseOptionalNotebookLanguage('julia')).toThrow(/python or r/i)
+  })
+
+  it('rejects an unknown Environment command language before the owner runs', () => {
+    expect(notebookEnvironmentApplicationCommandContracts.provision.args.parse(['python'])).toEqual(
+      ['python']
+    )
+    expect(
+      notebookEnvironmentApplicationCommandContracts.provision.args.parse(['r', 'op-1'])
+    ).toEqual(['r', 'op-1'])
+    expect(notebookEnvironmentApplicationCommandContracts.cancel.args.parse([])).toEqual([])
+    expect(notebookEnvironmentApplicationCommandContracts.cancel.args.parse(['python'])).toEqual([
+      'python'
+    ])
+    expect(() =>
+      notebookEnvironmentApplicationCommandContracts.provision.args.parse(['julia'])
+    ).toThrow()
+    expect(() =>
+      notebookEnvironmentApplicationCommandContracts.repair.args.parse(['julia'])
+    ).toThrow()
+    expect(() =>
+      notebookEnvironmentApplicationCommandContracts.cancel.args.parse(['julia'])
+    ).toThrow()
   })
 
   it('NotebookOutput supports a display (mime bundle) variant', () => {

--- a/src/shared/notebook.test.ts
+++ b/src/shared/notebook.test.ts
@@ -12,8 +12,10 @@ describe('shared notebook types', () => {
     expect(parseNotebookLanguage('python')).toBe('python')
     expect(parseNotebookLanguage('r')).toBe('r')
     expect(parseOptionalNotebookLanguage(undefined)).toBeUndefined()
+    expect(parseOptionalNotebookLanguage(null)).toBeUndefined()
     expect(() => parseNotebookLanguage('julia')).toThrow(/python or r/i)
     expect(() => parseNotebookLanguage('R')).toThrow(/python or r/i)
+    expect(() => parseNotebookLanguage(null)).toThrow(/python or r/i)
     expect(() => parseOptionalNotebookLanguage('julia')).toThrow(/python or r/i)
   })
 
@@ -28,6 +30,16 @@ describe('shared notebook types', () => {
     expect(notebookEnvironmentApplicationCommandContracts.cancel.args.parse(['python'])).toEqual([
       'python'
     ])
+    expect(notebookEnvironmentApplicationCommandContracts.cancel.args.parse([null])).toEqual([])
+    expect(
+      notebookEnvironmentApplicationCommandContracts.provision.args.parse(['python', null])
+    ).toEqual(['python'])
+    expect(notebookEnvironmentApplicationCommandContracts.repair.args.parse(['r', null])).toEqual([
+      'r'
+    ])
+    expect(() =>
+      notebookEnvironmentApplicationCommandContracts.provision.args.parse([null])
+    ).toThrow()
     expect(() =>
       notebookEnvironmentApplicationCommandContracts.provision.args.parse(['julia'])
     ).toThrow()

--- a/src/shared/notebook.ts
+++ b/src/shared/notebook.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod'
 
-import { defineApplicationCommandContract, validationCodec } from './application-command-contract'
+import {
+  defineApplicationCommandContract,
+  validationCodec,
+  type RuntimeCodec
+} from './application-command-contract'
 import type { ArtifactFile } from './artifacts'
 import type { NotebookRuntimeBindings } from './notebook-runtime'
 import type { OptionalProjectIdScope, ProjectIdScope } from './project-scope'
@@ -52,11 +56,25 @@ export const parseNotebookLanguage = (value: unknown): NotebookLanguage => {
 }
 
 export const parseOptionalNotebookLanguage = (value: unknown): NotebookLanguage | undefined => {
-  if (value === undefined) return undefined
+  if (value == null) return undefined
   return parseNotebookLanguage(value)
 }
 
-const languageAndOptionalOperationId = validationCodec(
+// JSON RPC encodes omitted optional slots as null. Drop trailing nulls so cancel() and
+// provision/repair without an operation id stay valid, while a null required language still fails.
+const omitTrailingNull = (value: unknown): unknown => {
+  if (!Array.isArray(value)) return value
+  const args = [...value]
+  while (args.length > 0 && args[args.length - 1] === null) args.pop()
+  return args
+}
+
+const parsedArgs = <Args extends readonly unknown[]>(schema: z.ZodType<Args>): RuntimeCodec<Args> =>
+  Object.freeze({
+    parse: (value: unknown): Args => schema.parse(omitTrailingNull(value))
+  })
+
+const languageAndOptionalOperationId = parsedArgs(
   z.union([z.tuple([notebookLanguageSchema]), z.tuple([notebookLanguageSchema, z.string()])])
 )
 
@@ -70,7 +88,7 @@ export const notebookEnvironmentApplicationCommandContracts = Object.freeze({
     validationCodec(z.undefined())
   ),
   cancel: defineApplicationCommandContract(
-    validationCodec(z.union([z.tuple([]), z.tuple([notebookLanguageSchema])])),
+    parsedArgs(z.union([z.tuple([]), z.tuple([notebookLanguageSchema])])),
     validationCodec(z.undefined())
   )
 })

--- a/src/shared/notebook.ts
+++ b/src/shared/notebook.ts
@@ -1,3 +1,6 @@
+import { z } from 'zod'
+
+import { defineApplicationCommandContract, validationCodec } from './application-command-contract'
 import type { ArtifactFile } from './artifacts'
 import type { NotebookRuntimeBindings } from './notebook-runtime'
 import type { OptionalProjectIdScope, ProjectIdScope } from './project-scope'
@@ -34,8 +37,43 @@ export type NotebookRunProvenanceContext = {
 }
 
 // Languages a notebook kernel can run in this phase; each runs as a persistent exec-loop process
-// (no ipykernel/IRkernel involved).
-export type NotebookLanguage = 'python' | 'r'
+// (no ipykernel/IRkernel involved). Renderer IPC must parse this at runtime — TypeScript unions
+// do not reject a compromised or stale client.
+export const NOTEBOOK_LANGUAGES = ['python', 'r'] as const
+export type NotebookLanguage = (typeof NOTEBOOK_LANGUAGES)[number]
+export const notebookLanguageSchema = z.enum(NOTEBOOK_LANGUAGES)
+
+export const parseNotebookLanguage = (value: unknown): NotebookLanguage => {
+  const parsed = notebookLanguageSchema.safeParse(value)
+  if (!parsed.success) {
+    throw new Error('Notebook language must be python or r.')
+  }
+  return parsed.data
+}
+
+export const parseOptionalNotebookLanguage = (value: unknown): NotebookLanguage | undefined => {
+  if (value === undefined) return undefined
+  return parseNotebookLanguage(value)
+}
+
+const languageAndOptionalOperationId = validationCodec(
+  z.union([z.tuple([notebookLanguageSchema]), z.tuple([notebookLanguageSchema, z.string()])])
+)
+
+export const notebookEnvironmentApplicationCommandContracts = Object.freeze({
+  provision: defineApplicationCommandContract(
+    languageAndOptionalOperationId,
+    validationCodec(z.undefined())
+  ),
+  repair: defineApplicationCommandContract(
+    languageAndOptionalOperationId,
+    validationCodec(z.undefined())
+  ),
+  cancel: defineApplicationCommandContract(
+    validationCodec(z.union([z.tuple([]), z.tuple([notebookLanguageSchema])])),
+    validationCodec(z.undefined())
+  )
+})
 
 // Identifies which kernel produced a run: python/r are analysis cells, repl/bash are
 // control-plane/shell.


### PR DESCRIPTION
## Problem

Notebook environment IPC accepts `NotebookLanguage` as a TypeScript type only. The owner then dispatches:

```ts
language === 'r' ? provisionR() : provisionPython()
```

A compromised, stale, or buggy renderer can send any non-`r` value (for example `julia`). That value currently **installs or rebuilds the default Python environment**. The same fail-open exists on repair and on cancel (cancel of an unknown language does not abort a running Python/R install).

Reproduced on unfixed `main`: `notebook-env:provision` with `'julia'` resolved successfully and completed a `provision` operation whose language was `'julia'`. After this change the same call is rejected and neither `provisionPython` nor `provisionR` runs.

## Proposed change

Use the existing Zod / application-command contract helper. No new validation framework.

- Add `notebookLanguageSchema` and `parseNotebookLanguage()` in `src/shared/notebook.ts`.
- Fail-closed parse at `createNotebookEnvironmentLifecycle` **before** the Python/R dispatch (covers Electron `env-ipc`, local Web application commands, and any other caller).
- Attach application-command contracts on `notebook-env:provision`, `repair`, and `cancel` so Web rejects with `invalid-command-arguments` before the owner runs.
- Keep Electron on `env-ipc.ts`. Invalid language still fails, via the lifecycle.

### What this does **not** change

- **Data fields:** none
- **Data model:** none
- **Persistence / migrations:** none
- **New enum values:** none (still `'python' | 'r'`)
- **Historical compatibility:** none required. Valid renderer traffic is unchanged. Invalid language that previously installed Python now fails; that is the bugfix.
- **User interaction (valid path):** none
- **Architecture / Electron envelope:** not migrated onto catalog `RUNTIME_VALIDATED`. That flag would double-register the same `ipcMainHandle` channels `env-ipc.ts` already owns, or require retiring those handlers and switching Electron to `{ ok, result }` envelopes. Called out as follow-up.

## Scope and non-goals

**In this PR:** the reproduced Notebook install/repair/cancel language fail-open.

**Not in this PR (over-engineering as one change):**

- Marking `notebookEnv.*` as `RUNTIME_VALIDATED` and retiring overlapping `env-ipc` invoke handlers (Electron envelope cutover).
- Present-but-invalid `notebook:execute` language (omitted language still means Python by design; garbage should fail closed in a follow-up).
- File, credential, Provider, Connector, Skill, Compute, and remote-access IPC. Those do not share this ternary. Several already confine paths or require a desktop caller. Each needs its own reproduction.

## Acceptance criteria and validation

- `'julia'` (and any non-`python`/`r` value) must not call `provisionPython` or `provisionR`.
- `'python'` and `'r'` still provision/repair as before.
- Local Web application commands reject unknown language with `invalid-command-arguments`.
- Remote Web mutations remain rejected before the lifecycle (unchanged).

### Test Impact Set (ran after the last material edit)

| Behavior | Command | Result |
| --- | --- | --- |
| Unknown language no longer installs Python (IPC + owner) | `npm test -- src/main/notebook/env-ipc.test.ts src/main/notebook/environment-lifecycle-workflows.test.ts src/main/notebook/application-commands.test.ts src/shared/notebook.test.ts` | pass (52 tests). On unfixed `main` the three new owner/IPC cases failed because `'julia'` resolved and completed a provision/repair. |
| Application-command inventory still certifies | `npm test -- src/main/application-command-composition.test.ts src/main/application-command-router.test.ts` | pass (25 tests) |
| Node typecheck | `npm run typecheck:node` | pass |
| Lint of touched files | `npx eslint --max-warnings 0` on the 7 changed files | pass |

Not run: full `npm test` (PR Gate / CI is authoritative). No renderer UI change, so no Web typecheck or browser pass. No persistence/migration. No ACP protocol change.

**Consumers / platform lanes:** Electron and local Web share the lifecycle parse. Remote Web cannot call these mutations today. Windows path behavior is not involved.

**Uncovered risks:** `kernel-executor` still maps a present-but-invalid execute language to Python (`language === 'r' ? 'r' : 'python'`). Agent/MCP install already uses `z.enum(['python', 'r'])`. Internal `=== 'r' ? r : python` helpers remain behind typed callers.

## Review focus

- Fail-closed at the owner vs. a full catalog `RUNTIME_VALIDATED` Electron cutover.
- Whether execute-language validation should be a stacked follow-up PR rather than this one.