### PR TITLE
fix(notebook): defer parser runtime loading

### DIFF
--- a/src/main/notebook/dependency-analysis-parser-unavailable.test.ts
+++ b/src/main/notebook/dependency-analysis-parser-unavailable.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('web-tree-sitter', () => {
+  throw Object.assign(new Error("Cannot find module 'web-tree-sitter'"), {
+    code: 'MODULE_NOT_FOUND'
+  })
+})
+
+describe('Notebook dependency analysis parser availability', () => {
+  it('degrades to unknown when the parser runtime cannot load', async () => {
+    const { analyzePythonSources } = await import('./dependency-analysis-python')
+
+    await expect(analyzePythonSources(['result = source + 1'])).resolves.toEqual([
+      { state: 'unknown', reasons: ['parser-unavailable'] }
+    ])
+  })
+})

--- a/src/main/notebook/dependency-analysis-parser.ts
+++ b/src/main/notebook/dependency-analysis-parser.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { Language, Parser, type Node, type Tree } from 'web-tree-sitter'
+import type { Language, Node, Tree } from 'web-tree-sitter'
 
 const here = typeof __dirname === 'string' ? __dirname : dirname(fileURLToPath(import.meta.url))
 
@@ -34,15 +34,19 @@ const resolveTreeSitterDir = (): string | undefined => {
 }
 
 let initPromise: Promise<string | undefined> | undefined
+let parserRuntime: typeof import('web-tree-sitter') | undefined
 const languages = new Map<NotebookParserLanguage, Language>()
 
 const ensureParserRuntime = (): Promise<string | undefined> => {
   initPromise ??= (async () => {
     const dir = resolveTreeSitterDir()
     if (!dir) return undefined
-    await Parser.init({
+    const runtime = await import('web-tree-sitter').catch(() => undefined)
+    if (!runtime) return undefined
+    await runtime.Parser.init({
       locateFile: (scriptName: string) => join(dir, scriptName)
     })
+    parserRuntime = runtime
     return dir
   })()
   return initPromise
@@ -52,8 +56,8 @@ const loadLanguage = async (language: NotebookParserLanguage): Promise<Language 
   const cached = languages.get(language)
   if (cached) return cached
   const dir = await ensureParserRuntime()
-  if (!dir) return undefined
-  const loaded = await Language.load(join(dir, wasmFile(language)))
+  if (!dir || !parserRuntime) return undefined
+  const loaded = await parserRuntime.Language.load(join(dir, wasmFile(language)))
   languages.set(language, loaded)
   return loaded
 }
@@ -67,8 +71,9 @@ const withParsedNotebookSource = async <T>(
   analyze: (root: Node) => T
 ): Promise<ParsedNotebookSource<T>> => {
   const grammar = await loadLanguage(language)
-  if (!grammar) return { state: 'error', reason: 'parser-unavailable' }
-  const parser = new Parser()
+  const runtime = parserRuntime
+  if (!grammar || !runtime) return { state: 'error', reason: 'parser-unavailable' }
+  const parser = new runtime.Parser()
   let tree: Tree | null = null
   try {
     parser.setLanguage(grammar)

--- a/src/main/notebook/dependency-analysis.scientific.test.ts
+++ b/src/main/notebook/dependency-analysis.scientific.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { NotebookRunRecord } from '../../shared/notebook'
 import { NotebookDependencyAnalyzer } from './dependency-analysis'
 
-const unusedInterpreter = (kernelKind: 'python' | 'r') => ({
+const unusedInterpreter = (kernelKind: 'python' | 'r'): { command: string } => ({
   command: kernelKind === 'python' ? 'unused-python' : 'unused-rscript'
 })
 


### PR DESCRIPTION
## Problem

Application startup loaded the Notebook dependency parser with the main IPC graph. When web-tree-sitter was unavailable, npm run dev failed during database-and-application-modules with MODULE_NOT_FOUND. Startup rollback then removed database-startup:get-state while the renderer was still probing it, producing the reported No handler registered errors.

## Proposed change

- Keep web-tree-sitter as a type-only static dependency and load its runtime only when Notebook dependency analysis runs.
- Reuse the existing parser-unavailable result when the runtime cannot load.
- Add a regression test at the public analyzePythonSources boundary that simulates the same MODULE_NOT_FOUND failure.
- Add the explicit return type missing from the newly added scientific fixture helper so the current main baseline satisfies the repository lint policy.

## Scope and non-goals

- No dependency manifest or lockfile changes.
- No database schema, migration, startup IPC, or renderer changes.
- No new state or enum value; this uses the existing parser-unavailable reason.
- The fixture annotation is type-only and does not change test behavior.

## Compatibility and persistence

- Historical compatibility: no stored format changes are required. Existing dependency-analysis sidecars remain readable.
- State additions: none.
- Persistence: no schema or serialization changes. If the parser runtime is unavailable during analysis, the existing parser-unavailable unknown facts may be persisted and remain retryable under the existing retry policy.

## Acceptance criteria and validation

All passing checks below ran after the last material edit:

- Missing parser runtime degrades instead of aborting startup -> npm test -- src/main/notebook/dependency-analysis-parser-unavailable.test.ts src/main/notebook/dependency-analysis.test.ts src/main/notebook/dependency-analysis.scientific.test.ts -> 403 passed.
- Main-process types remain valid -> npm run typecheck:node -> passed.
- Repository lint policy -> npm run lint -> passed.
- Changed files satisfy formatting -> npx prettier --check on the three changed files -> passed.
- Original darwin-arm64 reproduction without web-tree-sitter installed -> npm run dev -> application-startup completed through install-lifecycle; no database-startup handler errors.

Before the fix, the regression test was run twice and failed both times with Cannot find module web-tree-sitter and code MODULE_NOT_FOUND, matching the reproduced startup root cause.

The affected-test explain plan intentionally selects the full PR CI suite because the new Notebook files are not yet owned in module-impact.json. Per maintainer request, the full local npm test suite was not run; PR CI is the final authority.

Platform scope: the original failure and fixed startup were verified on darwin arm64. No platform-specific code changed; Windows and Linux startup remain covered by PR CI.

## Review focus

Please verify that the lazy external runtime boundary preserves normal parser behavior when installed and that parser-unavailable remains the correct existing fallback when loading fails.