### PR TITLE
fix(notebook): keep the R namespace after cancellation

### DIFF
--- a/resources/notebook/r_loop.R
+++ b/resources/notebook/r_loop.R
@@ -629,15 +629,54 @@ capture_environment <- function() {
   )
 }
 
+# SIGINT during a blocked stdin read looks like an empty read and, if left uncaught at top level,
+# prints "Execution halted" and exits the persistent kernel. Remember it so the request we were
+# about to read can be acknowledged without dropping the namespace.
+interrupt_during_read <- FALSE
+
 # Reads one request off the length-prefixed protocol; returns list(req_id, code) or NULL at EOF.
 read_request <- function() {
-  header <- readLines(con, n = 1L, warn = FALSE)
-  if (length(header) == 0L) return(NULL)
-  parts <- strsplit(header, " ", fixed = TRUE)[[1]]
-  req_id <- parts[1]
-  n <- as.integer(parts[2])
-  code <- if (n > 0L) readChar(con, n, useBytes = TRUE) else ""
-  list(req_id = req_id, code = code)
+  empty_streak <- 0L
+  repeat {
+    header <- tryCatch(
+      readLines(con, n = 1L, warn = FALSE),
+      interrupt = function(cnd) {
+        interrupt_during_read <<- TRUE
+        character()
+      }
+    )
+    if (length(header) == 0L) {
+      empty_streak <- empty_streak + 1L
+      if (!isOpen(con, rw = "read") || empty_streak >= 2L) return(NULL)
+      interrupt_during_read <<- TRUE
+      next
+    }
+    parts <- strsplit(header, " ", fixed = TRUE)[[1]]
+    req_id <- parts[1]
+    n <- as.integer(parts[2])
+    if (is.na(n) || n < 0L) n <- 0L
+    acc <- raw()
+    body_empty <- 0L
+    while (length(acc) < n) {
+      chunk <- tryCatch(
+        readBin(con, what = "raw", n = n - length(acc)),
+        interrupt = function(cnd) {
+          interrupt_during_read <<- TRUE
+          raw()
+        }
+      )
+      if (length(chunk) == 0L) {
+        body_empty <- body_empty + 1L
+        if (!isOpen(con, rw = "read") || body_empty >= 2L) return(NULL)
+        interrupt_during_read <<- TRUE
+        next
+      }
+      body_empty <- 0L
+      acc <- c(acc, chunk)
+    }
+    code <- if (n > 0L) rawToChar(acc, multiple = FALSE) else ""
+    return(list(req_id = req_id, code = code))
+  }
 }
 
 # User code may manage its own output sinks, but it must never pop the kernel-owned capture sink and
@@ -1294,10 +1333,59 @@ run <- base::local({
 ))
 lockEnvironment(environment(run), bindings = TRUE)
 
+interrupted_response <- function(req_id) {
+  environment <- tryCatch(
+    capture_environment(),
+    interrupt = function(cnd) {
+      list(
+        runtime_version = paste(R.version$major, R.version$minor, sep = "."),
+        packages = list()
+      )
+    },
+    error = function(cnd) {
+      list(
+        runtime_version = paste(R.version$major, R.version$minor, sep = "."),
+        packages = list()
+      )
+    }
+  )
+  list(
+    stdout = "",
+    stderr = "",
+    error = "interrupted",
+    interrupt_ack = TRUE,
+    error_line = NULL,
+    result = NA,
+    cwd = getwd(),
+    figures = list(),
+    output_truncated = FALSE,
+    environment = environment,
+    req_id = req_id
+  )
+}
+
 repeat {
-  req <- read_request()
+  req <- tryCatch(
+    read_request(),
+    interrupt = function(cnd) {
+      interrupt_during_read <<- TRUE
+      "retry"
+    }
+  )
   if (is.null(req)) break
-  resp <- run(req)
-  resp$req_id <- req$req_id
+  if (identical(req, "retry")) next
+  resp <- tryCatch(
+    {
+      if (isTRUE(interrupt_during_read)) {
+        interrupt_during_read <<- FALSE
+        interrupted_response(req$req_id)
+      } else {
+        result <- run(req)
+        result$req_id <- req$req_id
+        result
+      }
+    },
+    interrupt = function(cnd) interrupted_response(req$req_id)
+  )
   emit(resp)
 }

--- a/resources/notebook/r_loop.R
+++ b/resources/notebook/r_loop.R
@@ -629,56 +629,6 @@ capture_environment <- function() {
   )
 }
 
-# SIGINT during a blocked stdin read looks like an empty read and, if left uncaught at top level,
-# prints "Execution halted" and exits the persistent kernel. Remember it so the request we were
-# about to read can be acknowledged without dropping the namespace.
-interrupt_during_read <- FALSE
-
-# Reads one request off the length-prefixed protocol; returns list(req_id, code) or NULL at EOF.
-read_request <- function() {
-  empty_streak <- 0L
-  repeat {
-    header <- tryCatch(
-      readLines(con, n = 1L, warn = FALSE),
-      interrupt = function(cnd) {
-        interrupt_during_read <<- TRUE
-        character()
-      }
-    )
-    if (length(header) == 0L) {
-      empty_streak <- empty_streak + 1L
-      if (!isOpen(con, rw = "read") || empty_streak >= 2L) return(NULL)
-      interrupt_during_read <<- TRUE
-      next
-    }
-    parts <- strsplit(header, " ", fixed = TRUE)[[1]]
-    req_id <- parts[1]
-    n <- as.integer(parts[2])
-    if (is.na(n) || n < 0L) n <- 0L
-    acc <- raw()
-    body_empty <- 0L
-    while (length(acc) < n) {
-      chunk <- tryCatch(
-        readBin(con, what = "raw", n = n - length(acc)),
-        interrupt = function(cnd) {
-          interrupt_during_read <<- TRUE
-          raw()
-        }
-      )
-      if (length(chunk) == 0L) {
-        body_empty <- body_empty + 1L
-        if (!isOpen(con, rw = "read") || body_empty >= 2L) return(NULL)
-        interrupt_during_read <<- TRUE
-        next
-      }
-      body_empty <- 0L
-      acc <- c(acc, chunk)
-    }
-    code <- if (n > 0L) rawToChar(acc, multiple = FALSE) else ""
-    return(list(req_id = req_id, code = code))
-  }
-}
-
 # User code may manage its own output sinks, but it must never pop the kernel-owned capture sink and
 # expose arbitrary output to the JSON-lines protocol. Keep the original primitive in a locked policy
 # closure for trusted setup/cleanup, and let user sink(NULL) calls remove only sinks above the active
@@ -1333,59 +1283,113 @@ run <- base::local({
 ))
 lockEnvironment(environment(run), bindings = TRUE)
 
-interrupted_response <- function(req_id) {
-  environment <- tryCatch(
-    capture_environment(),
-    interrupt = function(cnd) {
-      list(
-        runtime_version = paste(R.version$major, R.version$minor, sep = "."),
-        packages = list()
-      )
-    },
-    error = function(cnd) {
-      list(
-        runtime_version = paste(R.version$major, R.version$minor, sep = "."),
-        packages = list()
-      )
-    }
-  )
-  list(
-    stdout = "",
-    stderr = "",
-    error = "interrupted",
-    interrupt_ack = TRUE,
-    error_line = NULL,
-    result = NA,
-    cwd = getwd(),
-    figures = list(),
-    output_truncated = FALSE,
-    environment = environment,
-    req_id = req_id
-  )
-}
+# Request I/O and the read-path interrupt flag live in this local environment, not .GlobalEnv.
+# User cells eval in globalenv() and may assign names such as interrupt_during_read; those
+# assignments must not skip the next request or crash the persistent kernel. SIGINT during a
+# blocked stdin read looks like an empty read and, if left uncaught at top level, prints
+# "Execution halted" and exits.
+local({
+  state <- new.env(parent = emptyenv())
+  state$during_read <- FALSE
 
-repeat {
-  req <- tryCatch(
-    read_request(),
-    interrupt = function(cnd) {
-      interrupt_during_read <<- TRUE
-      "retry"
-    }
-  )
-  if (is.null(req)) break
-  if (identical(req, "retry")) next
-  resp <- tryCatch(
-    {
-      if (isTRUE(interrupt_during_read)) {
-        interrupt_during_read <<- FALSE
-        interrupted_response(req$req_id)
-      } else {
-        result <- run(req)
-        result$req_id <- req$req_id
-        result
+  read_request <- function() {
+    empty_streak <- 0L
+    repeat {
+      header <- tryCatch(
+        readLines(con, n = 1L, warn = FALSE),
+        interrupt = function(cnd) {
+          state$during_read <- TRUE
+          character()
+        }
+      )
+      if (length(header) == 0L) {
+        empty_streak <- empty_streak + 1L
+        if (!isOpen(con, rw = "read") || empty_streak >= 2L) return(NULL)
+        state$during_read <- TRUE
+        next
       }
-    },
-    interrupt = function(cnd) interrupted_response(req$req_id)
-  )
-  emit(resp)
-}
+      parts <- strsplit(header, " ", fixed = TRUE)[[1]]
+      req_id <- parts[1]
+      n <- as.integer(parts[2])
+      if (is.na(n) || n < 0L) n <- 0L
+      acc <- raw()
+      body_empty <- 0L
+      while (length(acc) < n) {
+        chunk <- tryCatch(
+          readBin(con, what = "raw", n = n - length(acc)),
+          interrupt = function(cnd) {
+            state$during_read <- TRUE
+            raw()
+          }
+        )
+        if (length(chunk) == 0L) {
+          body_empty <- body_empty + 1L
+          if (!isOpen(con, rw = "read") || body_empty >= 2L) return(NULL)
+          state$during_read <- TRUE
+          next
+        }
+        body_empty <- 0L
+        acc <- c(acc, chunk)
+      }
+      code <- if (n > 0L) rawToChar(acc, multiple = FALSE) else ""
+      return(list(req_id = req_id, code = code))
+    }
+  }
+
+  interrupted_response <- function(req_id) {
+    environment <- tryCatch(
+      capture_environment(),
+      interrupt = function(cnd) {
+        list(
+          runtime_version = paste(R.version$major, R.version$minor, sep = "."),
+          packages = list()
+        )
+      },
+      error = function(cnd) {
+        list(
+          runtime_version = paste(R.version$major, R.version$minor, sep = "."),
+          packages = list()
+        )
+      }
+    )
+    list(
+      stdout = "",
+      stderr = "",
+      error = "interrupted",
+      interrupt_ack = TRUE,
+      error_line = NULL,
+      result = NA,
+      cwd = getwd(),
+      figures = list(),
+      output_truncated = FALSE,
+      environment = environment,
+      req_id = req_id
+    )
+  }
+
+  repeat {
+    req <- tryCatch(
+      read_request(),
+      interrupt = function(cnd) {
+        state$during_read <- TRUE
+        "retry"
+      }
+    )
+    if (is.null(req)) break
+    if (identical(req, "retry")) next
+    resp <- tryCatch(
+      {
+        if (isTRUE(state$during_read)) {
+          state$during_read <- FALSE
+          interrupted_response(req$req_id)
+        } else {
+          result <- run(req)
+          result$req_id <- req$req_id
+          result
+        }
+      },
+      interrupt = function(cnd) interrupted_response(req$req_id)
+    )
+    emit(resp)
+  }
+})

--- a/resources/notebook/r_loop.R
+++ b/resources/notebook/r_loop.R
@@ -1283,12 +1283,12 @@ run <- base::local({
 ))
 lockEnvironment(environment(run), bindings = TRUE)
 
-# Request I/O and the read-path interrupt flag live in this local environment, not .GlobalEnv.
-# User cells eval in globalenv() and may assign names such as interrupt_during_read; those
-# assignments must not skip the next request or crash the persistent kernel. SIGINT during a
-# blocked stdin read looks like an empty read and, if left uncaught at top level, prints
-# "Execution halted" and exits.
-local({
+# Request I/O and the read-path interrupt flag live outside .GlobalEnv. User cells eval in
+# globalenv() and may assign names such as interrupt_during_read or getwd; those assignments
+# must not skip the next request or crash cancellation. Parent is baseenv() so cancellation
+# helpers resolve trusted bindings. SIGINT during a blocked stdin read looks like an empty
+# read and, if left uncaught at top level, prints "Execution halted" and exits.
+base::local({
   state <- new.env(parent = emptyenv())
   state$during_read <- FALSE
 
@@ -1299,15 +1299,13 @@ local({
         readLines(con, n = 1L, warn = FALSE),
         interrupt = function(cnd) {
           state$during_read <- TRUE
-          character()
+          NA_character_
         }
       )
+      if (length(header) == 1L && is.na(header)) next
       if (length(header) == 0L) {
-        if (!isOpen(con, rw = "read")) return(NULL)
-        if (isTRUE(state$during_read)) next
         empty_streak <- empty_streak + 1L
-        if (empty_streak >= 2L) return(NULL)
-        state$during_read <- TRUE
+        if (!isOpen(con, rw = "read") || empty_streak >= 2L) return(NULL)
         next
       }
       empty_streak <- 0L
@@ -1322,17 +1320,13 @@ local({
           readBin(con, what = "raw", n = n - length(acc)),
           interrupt = function(cnd) {
             state$during_read <- TRUE
-            raw()
+            structure(raw(), interrupt = TRUE)
           }
         )
-        # Keep draining the declared frame. An interrupt is not EOF: counting it
-        # as an empty read would close the loop and desynchronize the next request.
+        if (isTRUE(attr(chunk, "interrupt"))) next
         if (length(chunk) == 0L) {
-          if (!isOpen(con, rw = "read")) return(NULL)
-          if (isTRUE(state$during_read)) next
           body_empty <- body_empty + 1L
-          if (body_empty >= 2L) return(NULL)
-          state$during_read <- TRUE
+          if (!isOpen(con, rw = "read") || body_empty >= 2L) return(NULL)
           next
         }
         body_empty <- 0L
@@ -1399,4 +1393,12 @@ local({
     )
     emit(resp)
   }
-})
+}, envir = base::list2env(
+  base::list(
+    con = con,
+    emit = emit,
+    run = run,
+    capture_environment = capture_environment
+  ),
+  parent = base::baseenv()
+))

--- a/resources/notebook/r_loop.R
+++ b/resources/notebook/r_loop.R
@@ -1305,7 +1305,9 @@ base::local({
       if (length(header) == 1L && is.na(header)) next
       if (length(header) == 0L) {
         empty_streak <- empty_streak + 1L
-        if (!isOpen(con, rw = "read") || empty_streak >= 2L) return(NULL)
+        if (!isOpen(con) || empty_streak >= 2L) return(NULL)
+        # SIGINT on a blocked read often returns empty without raising interrupt.
+        state$during_read <- TRUE
         next
       }
       empty_streak <- 0L
@@ -1326,7 +1328,8 @@ base::local({
         if (isTRUE(attr(chunk, "interrupt"))) next
         if (length(chunk) == 0L) {
           body_empty <- body_empty + 1L
-          if (!isOpen(con, rw = "read") || body_empty >= 2L) return(NULL)
+          if (!isOpen(con) || body_empty >= 2L) return(NULL)
+          state$during_read <- TRUE
           next
         }
         body_empty <- 0L

--- a/resources/notebook/r_loop.R
+++ b/resources/notebook/r_loop.R
@@ -1303,11 +1303,14 @@ local({
         }
       )
       if (length(header) == 0L) {
+        if (!isOpen(con, rw = "read")) return(NULL)
+        if (isTRUE(state$during_read)) next
         empty_streak <- empty_streak + 1L
-        if (!isOpen(con, rw = "read") || empty_streak >= 2L) return(NULL)
+        if (empty_streak >= 2L) return(NULL)
         state$during_read <- TRUE
         next
       }
+      empty_streak <- 0L
       parts <- strsplit(header, " ", fixed = TRUE)[[1]]
       req_id <- parts[1]
       n <- as.integer(parts[2])
@@ -1322,9 +1325,13 @@ local({
             raw()
           }
         )
+        # Keep draining the declared frame. An interrupt is not EOF: counting it
+        # as an empty read would close the loop and desynchronize the next request.
         if (length(chunk) == 0L) {
+          if (!isOpen(con, rw = "read")) return(NULL)
+          if (isTRUE(state$during_read)) next
           body_empty <- body_empty + 1L
-          if (!isOpen(con, rw = "read") || body_empty >= 2L) return(NULL)
+          if (body_empty >= 2L) return(NULL)
           state$during_read <- TRUE
           next
         }

--- a/src/main/notebook/kernel-executor.test.ts
+++ b/src/main/notebook/kernel-executor.test.ts
@@ -192,6 +192,30 @@ const procFor = (
 ): ProcStateLike | undefined =>
   (executor as unknown as ExecutorInternals).procs.get(procKeyFor(kind, env))
 
+const abortOnNextStdinWrite = (
+  child: ChildProcessWithoutNullStreams,
+  cancellation: AbortController
+): void => {
+  const originalWrite = child.stdin.write.bind(child.stdin)
+  let abortOnWrite = true
+  child.stdin.write = ((
+    chunk: string | Uint8Array,
+    encoding?: BufferEncoding | ((error?: Error | null) => void),
+    cb?: (error?: Error | null) => void
+  ) => {
+    const result =
+      typeof encoding === 'function'
+        ? originalWrite(chunk, encoding)
+        : originalWrite(chunk, encoding, cb)
+    if (abortOnWrite) {
+      abortOnWrite = false
+      child.stdin.write = originalWrite
+      cancellation.abort()
+    }
+    return result
+  }) as typeof child.stdin.write
+}
+
 let cwdDir: string | undefined
 
 const makeExecutor = (): NotebookKernelExecutor =>
@@ -1238,42 +1262,104 @@ describe.skipIf(!rExecutable || !rScriptExecutable)('NotebookKernelExecutor (rea
     }
   })
 
-  it('cancels a run without clearing the persistent R namespace', async () => {
-    cwdDir = await mkdtemp(join(tmpdir(), 'os-r-loop-cancel-'))
-    const request = baseRequest(cwdDir)
-    await stubEnvR(request.runtimeRoot, DEFAULT_R_ENV)
-    const executor = new NotebookKernelExecutor({
-      rLoopPath: join(__dirname, '../../../resources/notebook/r_loop.R'),
-      platform: 'linux'
-    })
-
-    try {
-      await expect(
-        executor.execute({ ...request, code: 'preserved_after_cancel <- 41', language: 'r' })
-      ).resolves.toMatchObject({ status: 'completed' })
-      const child = procFor(executor, 'r')?.child
-      const cancellation = new AbortController()
-      const run = executor.execute({
-        ...request,
-        code: 'Sys.sleep(30)',
-        language: 'r',
-        signal: cancellation.signal
+  // Windows maps SIGINT to process termination, so cancellation cannot keep this namespace.
+  it.skipIf(process.platform === 'win32')(
+    'cancels a run without clearing the persistent R namespace',
+    async () => {
+      cwdDir = await mkdtemp(join(tmpdir(), 'os-r-loop-cancel-'))
+      const request = baseRequest(cwdDir)
+      await stubEnvR(request.runtimeRoot, DEFAULT_R_ENV)
+      const executor = new NotebookKernelExecutor({
+        rLoopPath: join(__dirname, '../../../resources/notebook/r_loop.R'),
+        platform: 'linux'
       })
-      await vi.waitFor(() => expect(procFor(executor, 'r')?.pending).toBeDefined())
-      cancellation.abort()
 
-      await expect(run).resolves.toMatchObject({ status: 'cancelled', traceback: '' })
-      const next = await executor.execute({
-        ...request,
-        code: 'cat(preserved_after_cancel + 1)',
-        language: 'r'
+      try {
+        await expect(
+          executor.execute({ ...request, code: 'preserved_after_cancel <- 41', language: 'r' })
+        ).resolves.toMatchObject({ status: 'completed' })
+        const child = procFor(executor, 'r')?.child as ChildProcessWithoutNullStreams
+        const cancellation = new AbortController()
+        // Abort in the same turn as the request write so SIGINT can land while the loop is still
+        // reading the framed request. Waiting until Sys.sleep starts hides the read-path crash.
+        abortOnNextStdinWrite(child, cancellation)
+        const run = executor.execute({
+          ...request,
+          code: 'Sys.sleep(30)',
+          language: 'r',
+          signal: cancellation.signal
+        })
+
+        await expect(run).resolves.toMatchObject({ status: 'cancelled', traceback: '' })
+        const next = await executor.execute({
+          ...request,
+          code: 'cat(preserved_after_cancel + 1)',
+          language: 'r'
+        })
+        expect(next).toMatchObject({ status: 'completed', stdout: '42', traceback: '' })
+        expect(procFor(executor, 'r')?.child).toBe(child)
+      } finally {
+        await executor.shutdown()
+      }
+    },
+    15_000
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'preserves the R namespace across an in-eval cancel and 50 dispatch cancels',
+    async () => {
+      cwdDir = await mkdtemp(join(tmpdir(), 'os-r-loop-cancel-stress-'))
+      const request = baseRequest(cwdDir)
+      await stubEnvR(request.runtimeRoot, DEFAULT_R_ENV)
+      const executor = new NotebookKernelExecutor({
+        rLoopPath: join(__dirname, '../../../resources/notebook/r_loop.R'),
+        platform: 'linux'
       })
-      expect(next).toMatchObject({ status: 'completed', stdout: '42' })
-      expect(procFor(executor, 'r')?.child).toBe(child)
-    } finally {
-      await executor.shutdown()
-    }
-  }, 15_000)
+
+      try {
+        await expect(
+          executor.execute({ ...request, code: 'preserved_after_cancel <- 41', language: 'r' })
+        ).resolves.toMatchObject({ status: 'completed' })
+        const child = procFor(executor, 'r')?.child as ChildProcessWithoutNullStreams
+
+        const inEval = new AbortController()
+        const sleeping = executor.execute({
+          ...request,
+          code: 'Sys.sleep(30)',
+          language: 'r',
+          signal: inEval.signal
+        })
+        await vi.waitFor(() => expect(procFor(executor, 'r')?.pending).toBeDefined())
+        await new Promise((resolve) => setTimeout(resolve, 150))
+        inEval.abort()
+        await expect(sleeping).resolves.toMatchObject({ status: 'cancelled', traceback: '' })
+
+        for (let i = 0; i < 50; i++) {
+          const cancellation = new AbortController()
+          abortOnNextStdinWrite(child, cancellation)
+          await expect(
+            executor.execute({
+              ...request,
+              code: 'Sys.sleep(30)',
+              language: 'r',
+              signal: cancellation.signal
+            })
+          ).resolves.toMatchObject({ status: 'cancelled', traceback: '' })
+        }
+
+        const next = await executor.execute({
+          ...request,
+          code: 'cat(preserved_after_cancel + 1)',
+          language: 'r'
+        })
+        expect(next).toMatchObject({ status: 'completed', stdout: '42', traceback: '' })
+        expect(procFor(executor, 'r')?.child).toBe(child)
+      } finally {
+        await executor.shutdown()
+      }
+    },
+    60_000
+  )
 
   it.each([
     {

--- a/src/main/notebook/kernel-executor.test.ts
+++ b/src/main/notebook/kernel-executor.test.ts
@@ -206,7 +206,9 @@ const abortOnNextStdinWrite = (
     const result =
       typeof encoding === 'function'
         ? originalWrite(chunk, encoding)
-        : originalWrite(chunk, encoding, cb)
+        : encoding === undefined
+          ? originalWrite(chunk, cb)
+          : originalWrite(chunk, encoding, cb)
     if (abortOnWrite) {
       abortOnWrite = false
       child.stdin.write = originalWrite

--- a/src/main/notebook/kernel-executor.test.ts
+++ b/src/main/notebook/kernel-executor.test.ts
@@ -1307,33 +1307,51 @@ describe.skipIf(!rExecutable || !rScriptExecutable)('NotebookKernelExecutor (rea
     15_000
   )
 
-  it('does not let user R code poison cancellation interrupt state', async () => {
-    cwdDir = await mkdtemp(join(tmpdir(), 'os-r-loop-interrupt-poison-'))
-    const request = baseRequest(cwdDir)
-    await stubEnvR(request.runtimeRoot, DEFAULT_R_ENV)
-    const executor = new NotebookKernelExecutor({
-      rLoopPath: join(__dirname, '../../../resources/notebook/r_loop.R'),
-      platform: 'linux'
-    })
+  it.skipIf(process.platform === 'win32')(
+    'does not let user R code poison cancellation interrupt state',
+    async () => {
+      cwdDir = await mkdtemp(join(tmpdir(), 'os-r-loop-interrupt-poison-'))
+      const request = baseRequest(cwdDir)
+      await stubEnvR(request.runtimeRoot, DEFAULT_R_ENV)
+      const executor = new NotebookKernelExecutor({
+        rLoopPath: join(__dirname, '../../../resources/notebook/r_loop.R'),
+        platform: 'linux'
+      })
 
-    try {
-      await expect(
-        executor.execute({
+      try {
+        await expect(
+          executor.execute({
+            ...request,
+            code:
+              'interrupt_during_read <- TRUE; during_read <- TRUE; ' +
+              'getwd <- function(...) 1; preserved_after_cancel <- 41',
+            language: 'r'
+          })
+        ).resolves.toMatchObject({ status: 'completed' })
+        const child = procFor(executor, 'r')?.child as ChildProcessWithoutNullStreams
+        const cancellation = new AbortController()
+        abortOnNextStdinWrite(child, cancellation)
+        await expect(
+          executor.execute({
+            ...request,
+            code: 'Sys.sleep(30)',
+            language: 'r',
+            signal: cancellation.signal
+          })
+        ).resolves.toMatchObject({ status: 'cancelled', traceback: '' })
+        const next = await executor.execute({
           ...request,
-          code: 'interrupt_during_read <- TRUE; during_read <- TRUE',
+          code: 'cat(preserved_after_cancel + 1)',
           language: 'r'
         })
-      ).resolves.toMatchObject({ status: 'completed' })
-      const next = await executor.execute({
-        ...request,
-        code: 'cat(40 + 2)',
-        language: 'r'
-      })
-      expect(next).toMatchObject({ status: 'completed', stdout: '42', traceback: '' })
-    } finally {
-      await executor.shutdown()
-    }
-  }, 15_000)
+        expect(next).toMatchObject({ status: 'completed', stdout: '42', traceback: '' })
+        expect(procFor(executor, 'r')?.child).toBe(child)
+      } finally {
+        await executor.shutdown()
+      }
+    },
+    15_000
+  )
 
   it.skipIf(process.platform === 'win32')(
     'preserves the R namespace across an in-eval cancel and 50 dispatch cancels',

--- a/src/main/notebook/kernel-executor.test.ts
+++ b/src/main/notebook/kernel-executor.test.ts
@@ -1305,6 +1305,34 @@ describe.skipIf(!rExecutable || !rScriptExecutable)('NotebookKernelExecutor (rea
     15_000
   )
 
+  it('does not let user R code poison cancellation interrupt state', async () => {
+    cwdDir = await mkdtemp(join(tmpdir(), 'os-r-loop-interrupt-poison-'))
+    const request = baseRequest(cwdDir)
+    await stubEnvR(request.runtimeRoot, DEFAULT_R_ENV)
+    const executor = new NotebookKernelExecutor({
+      rLoopPath: join(__dirname, '../../../resources/notebook/r_loop.R'),
+      platform: 'linux'
+    })
+
+    try {
+      await expect(
+        executor.execute({
+          ...request,
+          code: 'interrupt_during_read <- TRUE; during_read <- TRUE',
+          language: 'r'
+        })
+      ).resolves.toMatchObject({ status: 'completed' })
+      const next = await executor.execute({
+        ...request,
+        code: 'cat(40 + 2)',
+        language: 'r'
+      })
+      expect(next).toMatchObject({ status: 'completed', stdout: '42', traceback: '' })
+    } finally {
+      await executor.shutdown()
+    }
+  }, 15_000)
+
   it.skipIf(process.platform === 'win32')(
     'preserves the R namespace across an in-eval cancel and 50 dispatch cancels',
     async () => {

--- a/src/main/notebook/r-loop.integration.test.ts
+++ b/src/main/notebook/r-loop.integration.test.ts
@@ -168,6 +168,19 @@ gate('r_loop.R', () => {
     60_000
   )
 
+  it('does not skip the next request when user code assigns interrupt_during_read', async () => {
+    const { child, send } = startLoop(rscriptBin(), {})
+    try {
+      expect((await send('interrupt_during_read <- TRUE; during_read <- TRUE')).error).toBeNull()
+      const next = await send('cat(40 + 2)')
+      expect(next.error).toBeNull()
+      expect(next.stdout).toContain('42')
+      expect(next.interruptAck).not.toBe(true)
+    } finally {
+      child.kill()
+    }
+  }, 60_000)
+
   it.skipIf(process.platform === 'win32')(
     'acknowledges SIGINT that arrives while the next request is still being read',
     async () => {

--- a/src/main/notebook/r-loop.integration.test.ts
+++ b/src/main/notebook/r-loop.integration.test.ts
@@ -34,6 +34,7 @@ const startLoop = (
 ): {
   child: ChildProcessWithoutNullStreams
   send: (code: string) => Promise<KernelLoopResponse>
+  waitFor: (reqId: string) => Promise<KernelLoopResponse>
 } => {
   const child = spawn(rscript, [LOOP], { env: { ...process.env, ...env } })
   const rl = createInterface({ input: child.stdout })
@@ -66,13 +67,17 @@ const startLoop = (
       w.resolve(msg)
     }
   })
-  const send = (code: string): Promise<KernelLoopResponse> =>
+  const waitFor = (reqId: string): Promise<KernelLoopResponse> =>
     new Promise((resolve, reject) => {
-      const reqId = randomUUID()
       waiters.set(reqId, { resolve, reject })
-      child.stdin.write(frameRRequest(reqId, code))
     })
-  return { child, send }
+  const send = (code: string): Promise<KernelLoopResponse> => {
+    const reqId = randomUUID()
+    const pending = waitFor(reqId)
+    child.stdin.write(frameRRequest(reqId, code))
+    return pending
+  }
+  return { child, send, waitFor }
 }
 
 // Resolved lazily inside each `it` (not at describe-body scope) so a skipped describe.skip run
@@ -180,6 +185,33 @@ gate('r_loop.R', () => {
       child.kill()
     }
   }, 60_000)
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps the protocol aligned when SIGINT arrives in the middle of a framed body',
+    async () => {
+      const { child, send, waitFor } = startLoop(rscriptBin(), {})
+      try {
+        expect((await send('aligned <- 41'))?.error).toBeNull()
+        const reqId = randomUUID()
+        const frame = frameRRequest(reqId, 'cat("split-ok")')
+        const mid = Math.max(1, Math.floor(frame.length / 2))
+        const pending = waitFor(reqId)
+        child.stdin.write(frame.subarray(0, mid))
+        child.kill('SIGINT')
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        child.stdin.write(frame.subarray(mid))
+
+        const split = await pending
+        expect(split.error === 'interrupted' || split.stdout.includes('split-ok')).toBe(true)
+        const next = await send('cat(aligned + 1)')
+        expect(next.error).toBeNull()
+        expect(next.stdout).toContain('42')
+      } finally {
+        child.kill()
+      }
+    },
+    60_000
+  )
 
   it.skipIf(process.platform === 'win32')(
     'acknowledges SIGINT that arrives while the next request is still being read',

--- a/src/main/notebook/r-loop.integration.test.ts
+++ b/src/main/notebook/r-loop.integration.test.ts
@@ -168,6 +168,28 @@ gate('r_loop.R', () => {
     60_000
   )
 
+  it.skipIf(process.platform === 'win32')(
+    'acknowledges SIGINT that arrives while the next request is still being read',
+    async () => {
+      const { child, send } = startLoop(rscriptBin(), {})
+      try {
+        expect((await send('cancel_state <- 41'))?.error).toBeNull()
+        const sleeping = send('Sys.sleep(30)')
+        child.kill('SIGINT')
+
+        const interrupted = await sleeping
+        expect(interrupted.error).toBe('interrupted')
+        expect(interrupted.interruptAck).toBe(true)
+        const next = await send('cat(cancel_state + 1)')
+        expect(next.error).toBeNull()
+        expect(next.stdout).toContain('42')
+      } finally {
+        child.kill()
+      }
+    },
+    60_000
+  )
+
   it.each(['file.link', 'file.symlink'] as const)(
     'blocks %s aliases sourced from the managed runtime',
     async (operation) => {


### PR DESCRIPTION
## Problem

Cancelling a running R cell returns `cancelled`, then the next cell fails. The existing real-R test `cancels a run without clearing the persistent R namespace` reproduces this.

The external report guessed a late SIGINT into the next request. Instrumentation on unfixed `main` showed a different, stable failure:

1. Save `preserved_after_cancel <- 41`.
2. Dispatch `Sys.sleep(30)` and cancel as soon as the framed request is written.
3. Cancel returns `cancelled`.
4. The R process exits with code 1 and stderr `Execution halted`.
5. The next `execute()` respawns a new process.
6. `cat(preserved_after_cancel + 1)` fails with `object 'preserved_after_cancel' not found`.

SIGINT is sent as soon as the request is written. The loop is often still blocked in `read_request()` / `readLines("stdin")`, **outside** the eval `tryCatch(..., interrupt=)`. A top-level interrupt in non-interactive Rscript is fatal. The #1275 probe never runs because the process is already gone.

When SIGINT instead lands inside `Sys.sleep`, the existing eval handler and probe usually work. Waiting ~50ms for `pending` therefore made the original test flake; aborting in the same turn as the stdin write makes the read-path crash stable.

```mermaid
sequenceDiagram
  participant Driver
  participant Loop as R loop
  Driver->>Loop: framed Sys.sleep request
  Driver->>Loop: SIGINT (same turn)
  Note over Loop: still in read_request()
  Loop-->>Driver: exit 1, Execution halted
  Driver->>Loop: respawn on next execute
  Loop-->>Driver: object not found
```

## Proposed change

Keep the persistent R process alive across cancellation SIGINT. Internal loop change only.

- Retry empty / interrupted stdin reads instead of treating them as EOF.
- Catch interrupts around the whole request cycle, including `run()` setup.
- If SIGINT arrived while reading the next framed request, acknowledge that request as `interrupted` with the existing `interrupt_ack` field and do not drop the process.
- Keep the existing executor probe for the late-SIGINT-after-response race.

No executor public API change. No new protocol field.

### What this does **not** change

- **Data fields:** none
- **Data model:** none
- **Persistence / migrations:** none
- **New enum values:** none (`cancelled` stays `cancelled`)
- **Historical compatibility:** none required. Valid cells and successful cancellations keep the same results. The previously fatal read-path interrupt now preserves the kernel instead of respawning empty.
- **User interaction:** none. Cancel still returns `cancelled`.
- **Architecture:** no larger executor state machine. #1275 already holds the queue until interrupt ack or probe; that path is unreachable when R dies first.

## Scope and non-goals

**In this PR:** the reproduced R cancel-then-next-cell namespace loss, plus a dispatch-time regression and a 50-iteration cancel stress test on the public `execute()` seam.

**Not in this PR (over-engineering as one change):**

- A new executor state machine for “original response / SIGINT consumed / probe complete”. #1275 already owns that late-SIGINT path.
- New wire fields or execution statuses.
- Windows recoverable cancel. Node maps SIGINT to `TerminateProcess`; the existing POSIX skip and Windows drop path stay as-is.

## Acceptance criteria and validation

- Fast cancel of `Sys.sleep(30)` returns `cancelled` and leaves the same R process alive.
- The next cell `cat(preserved_after_cancel + 1)` returns `42`.
- An in-eval cancel and 50 subsequent dispatch cancels still preserve the namespace.
- Existing fake-loop interrupt / probe tests still pass.

On unfixed `main`, the tightened real-R test failed 5/5 with `object 'preserved_after_cancel' not found`. After this change it passed 5/5.

### Test Impact Set (ran after the last material edit)

| Behavior | Command | Result |
| --- | --- | --- |
| Cancel then next R cell keeps the namespace | `npx vitest run src/main/notebook/kernel-executor.test.ts -t 'cancels a run without clearing the persistent R namespace'` | pass 5/5. On unfixed code the same command failed 5/5 with `object 'preserved_after_cancel' not found`. |
| In-eval cancel + 50 dispatch cancels | `npx vitest run src/main/notebook/kernel-executor.test.ts -t 'preserves the R namespace across an in-eval cancel'` | pass |
| Owner kernel-executor file | `npx vitest run src/main/notebook/kernel-executor.test.ts` | 73 passed / 1 skipped |
| Real `r_loop.R` protocol, including immediate SIGINT | `RUN_KERNEL=1 OPEN_SCIENCE_TEST_R_ENV=... npx vitest run src/main/notebook/r-loop.integration.test.ts` | 43 passed |
| Lint of touched TypeScript tests | `npx eslint --no-error-on-unmatched-pattern src/main/notebook/kernel-executor.test.ts src/main/notebook/r-loop.integration.test.ts` | pass |

Not run: full `npm test` (PR Gate / CI is authoritative). No renderer UI change, so no Web typecheck or browser pass. No persistence/migration. No ACP protocol change.

**Consumers / platform lanes:** the R loop script is shared by Electron and headless Web notebook execution. macOS `sandbox-exec` spawn was checked with a direct SIGINT against the wrapped Rscript; the process survived and the follow-up cell printed `42`. Linux uses the same `r_loop.R` without sandbox-exec. Windows cancellation still cannot preserve this namespace.

**Uncovered risks:** Linux CI skips the real-R tests when R is not installed. User code that catches interrupts still depends on the existing #1275 probe. The fake loop cannot exercise `Execution halted`; that path is covered by the real-R tests and `r_loop.R` integration.

## Review focus

- Treating interrupted / empty stdin reads as retryable rather than EOF, without hanging shutdown when stdin is actually closed.
- Skipping eval for a request that was interrupted during read, versus waiting for `Sys.sleep` to see a leftover interrupt flag.
- Whether a larger executor state machine is still warranted after this loop-level fix.
