### PR TITLE
fix(notebook): analyze historical runs without a live interpreter

### DIFF
--- a/src/main/notebook/dependency-analysis.scientific.test.ts
+++ b/src/main/notebook/dependency-analysis.scientific.test.ts
@@ -5,9 +5,12 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { NotebookRunRecord } from '../../shared/notebook'
-import { NotebookDependencyAnalyzer } from './dependency-analysis'
+import {
+  NotebookDependencyAnalyzer,
+  type NotebookDependencyInterpreter
+} from './dependency-analysis'
 
-const unusedInterpreter = (kernelKind: 'python' | 'r') => ({
+const unusedInterpreter = (kernelKind: 'python' | 'r'): NotebookDependencyInterpreter => ({
   command: kernelKind === 'python' ? 'unused-python' : 'unused-rscript'
 })
 

--- a/src/main/notebook/dependency-analysis.test.ts
+++ b/src/main/notebook/dependency-analysis.test.ts
@@ -1256,6 +1256,34 @@ describe('projectNotebookDependencies', { timeout: 60_000 }, () => {
     expect(analyze).not.toHaveBeenCalled()
   })
 
+  it('analyzes historical in-process facts when an external runtime is gone', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'open-science-missing-runtime-in-process-'))
+    temporaryRoots.push(storageRoot)
+    const runs = [
+      { ...run('run-1', 'prepare-data', 'x = 1', 1), runtimeId: '/missing/python' },
+      { ...run('run-2', 'make-result', 'y = x', 2), runtimeId: '/missing/python' },
+      { ...run('run-3', 'new-call', 'x = 2', 3), runtimeId: '/missing/python' }
+    ]
+    const analyzer = new NotebookDependencyAnalyzer({
+      storageRoot,
+      repository: { readSessionRuns: vi.fn(async () => runs) },
+      resolveInterpreter: vi.fn(async () => undefined)
+    })
+
+    const projection = await analyzer.project({
+      projectId: 'default-project',
+      sessionId: 'session-1'
+    })
+    expect(projection.stalenessByRunId['run-1']).toEqual({ state: 'clear' })
+    expect(projection.stalenessByRunId['run-2']).toEqual({
+      state: 'stale',
+      causedByRunId: 'run-3',
+      names: ['x'],
+      path: ['run-1', 'run-2']
+    })
+    expect(projection.stalenessByRunId['run-3']).toEqual({ state: 'clear' })
+  })
+
   it('resolves each external runtime once while rebuilding a history', async () => {
     const storageRoot = await mkdtemp(join(tmpdir(), 'open-science-external-runtime-cache-'))
     temporaryRoots.push(storageRoot)

--- a/src/main/notebook/dependency-analysis.ts
+++ b/src/main/notebook/dependency-analysis.ts
@@ -776,7 +776,7 @@ class NotebookDependencyAnalyzer {
 
     const missingByInterpreter = new Map<
       string,
-      { interpreter: NotebookDependencyInterpreter; runs: NotebookRunRecord[] }
+      { interpreter?: NotebookDependencyInterpreter; runs: NotebookRunRecord[] }
     >()
     const resolvedExternalInterpreters = new Map<
       string,
@@ -789,6 +789,13 @@ class NotebookDependencyAnalyzer {
         attemptedRunIds.has(run.runId) ||
         cachedAnalysisIsReusable(sidecar.runs[run.runId], checksum)
       ) {
+        continue
+      }
+      if (!this.options.analyze) {
+        const key = `in-process:${run.kernelKind}`
+        const group = missingByInterpreter.get(key) ?? { runs: [] }
+        group.runs.push(run)
+        missingByInterpreter.set(key, group)
         continue
       }
       const interpreter = run.runtimeId
@@ -827,7 +834,7 @@ class NotebookDependencyAnalyzer {
   private async analyzeGroup(
     sidecar: NotebookDependencyAnalysisSidecar,
     runs: readonly NotebookRunRecord[],
-    interpreter: NotebookDependencyInterpreter
+    interpreter?: NotebookDependencyInterpreter
   ): Promise<boolean> {
     const pending = runs.filter(
       (run) => !cachedAnalysisIsReusable(sidecar.runs[run.runId], checksumFor(run))
@@ -836,9 +843,10 @@ class NotebookDependencyAnalyzer {
     const language = pending[0]?.kernelKind
     if (language !== 'python' && language !== 'r') return false
     const sources = pending.map((run) => run.script)
-    const facts = this.options.analyze
-      ? await this.options.analyze(interpreter, language, sources)
-      : await analyzeNotebookSources(language, sources)
+    const facts =
+      this.options.analyze && interpreter
+        ? await this.options.analyze(interpreter, language, sources)
+        : await analyzeNotebookSources(language, sources)
     pending.forEach((run, index) => {
       sidecar.runs[run.runId] = {
         checksum: checksumFor(run),


### PR DESCRIPTION
## Problem

Notebook dependency analysis parses Python and R in-process with tree-sitter and does not execute the recorded interpreter. Historical rebuilds still required a resolvable interpreter. When an external runtime had been deleted or could not be resolved, the sidecar stored `unknown` facts with `parser-unavailable`.

That made otherwise analyzable history look unknown, and because `parser-unavailable` is retryable, later session `state()` calls kept rewriting the sidecar.

A second lint failure in the scientific corpus helper (`unusedInterpreter`) omitted an explicit return type.

## Proposed change

- Default analyzer (no injected `analyze`) rebuilds missing historical Python/R facts in-process, grouped by language, without resolving an interpreter.
- Injected `analyze` still requires an interpreter and still records `parser-unavailable` when none exists.
- Annotate `unusedInterpreter` with `NotebookDependencyInterpreter`.

```mermaid
flowchart TD
  load["session state(): project() without interpreter"]
  cache{"sidecar reusable?"}
  custom{"injected analyze?"}
  resolve["resolve interpreter"]
  missing{"interpreter missing?"}
  parse["in-process tree-sitter"]
  unknown["unknown / parser-unavailable"]
  project["staleness projection"]

  load --> cache
  cache -->|yes| project
  cache -->|no| custom
  custom -->|no| parse
  custom -->|yes| resolve
  resolve --> missing
  missing -->|yes| unknown
  missing -->|no| parse
  parse --> project
  unknown --> project
```

## Scope and non-goals

- No sidecar schema, version, or field changes.
- No new staleness reasons or enum values.
- No UI or interaction changes.
- Did not add 1k/10k CI benchmarks or sidecar trimming. In-memory projection of 10k runs is tens of milliseconds on this machine; trimming sidecar facts without trimming run history would only force reanalysis. Unbounded `run.json` history remains a separate product decision.

## Acceptance criteria and validation

- Historical Python runs whose external runtime is gone still project definite staleness (`run-2` stale when `x` is later redefined), instead of `parser-unavailable`.
- Existing custom-`analyze` tests continue to treat a missing interpreter as `parser-unavailable`.
- Scientific corpus helper satisfies `@typescript-eslint/explicit-function-return-type`.

Checks ran after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Historical in-process analysis and existing interpreter-gated tests | `npx vitest run src/main/notebook/dependency-analysis.test.ts src/main/notebook/dependency-analysis.scientific.test.ts` | PASS 403 |
| session-read-model consumer | `npx vitest run src/main/notebook/session-read-model.test.ts` | PASS 8 |
| Changed-file lint | `npx eslint src/main/notebook/dependency-analysis.ts src/main/notebook/dependency-analysis.test.ts src/main/notebook/dependency-analysis.scientific.test.ts` | pass |
| Node typecheck | `npm run typecheck:node` | pass |

Uncovered risks: full portable `npm test` was not run locally; PR Gate CI remains authoritative. Notebook main-process files are not in `test:module`. Existing `parser-unavailable` sidecar entries remain retryable and will be rebuilt in-process on the next projection.

## Review focus

- Default vs injected `analyze` split in `projectExclusive`.
- Regression at `NotebookDependencyAnalyzer.project()` for deleted external runtimes.
- Confirm no persistence or enum expansion.

## Historical compatibility

Sidecar format stays `dependency-analysis.json` v1. Cached `parser-unavailable` entries are already retryable and repair themselves on the next projection. No migration and no `ANALYZER_VERSION` bump.