### PR TITLE
fix(acp): keep notebook static context within budget

### DIFF
--- a/src/main/acp/context-usage-static-context.test.ts
+++ b/src/main/acp/context-usage-static-context.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest'
 import { Tiktoken } from 'js-tiktoken/lite'
 import cl100kBase from 'js-tiktoken/ranks/cl100k_base'
 
-import { NOTEBOOK_SYSTEM_PROMPT_APPEND } from '../notebook/mcp-server'
+import {
+  BASH_EXECUTE_DOC,
+  buildShellExecuteDoc,
+  NOTEBOOK_SYSTEM_PROMPT_APPEND
+} from '../notebook/mcp-server'
+import type { AgentFrameworkId } from '../agent-framework/types'
 import { contextUsageMcpSections } from './context-usage-static-context'
 
 describe('contextUsageMcpSections', () => {
@@ -38,17 +43,40 @@ describe('contextUsageMcpSections', () => {
   })
 
   it('keeps the notebook schema plus scoped guidance within the static context budget', () => {
-    const [{ text: schema }] = contextUsageMcpSections('codex', {
-      artifacts: false,
-      notebook: true,
-      skillImport: false
-    })
     const tokenizer = new Tiktoken(cl100kBase)
+    const tokenCount = (text: string): number => tokenizer.encode(text).length
+    // bash_execute embeds a platform-specific shell contract. Windows PowerShell docs are the
+    // largest variant, so a POSIX host must still count that extra or Windows full-suite CI
+    // is the first place the budget regresses.
+    const bashHeadroom = Math.max(
+      0,
+      ...(['win32', 'linux', 'darwin'] as const).map(
+        (platform) => tokenCount(buildShellExecuteDoc(platform)) - tokenCount(BASH_EXECUTE_DOC)
+      )
+    )
+    const frameworks: Array<{
+      frameworkId: AgentFrameworkId
+      codexBridgeAliases?: boolean
+    }> = [
+      { frameworkId: 'codex' },
+      { frameworkId: 'codex', codexBridgeAliases: true },
+      { frameworkId: 'claude-code' },
+      { frameworkId: 'opencode' }
+    ]
 
     // Baseline before deduplication was about 5.2k cl100k tokens (3.6k schema + 1.6k prompt).
-    expect(
-      tokenizer.encode(`${NOTEBOOK_SYSTEM_PROMPT_APPEND}\n${schema}`).length
-    ).toBeLessThanOrEqual(3_500)
+    for (const { frameworkId, codexBridgeAliases } of frameworks) {
+      const [{ text: schema }] = contextUsageMcpSections(frameworkId, {
+        artifacts: false,
+        notebook: true,
+        skillImport: false,
+        ...(codexBridgeAliases ? { codexBridgeAliases } : {})
+      })
+      expect(
+        tokenCount(`${NOTEBOOK_SYSTEM_PROMPT_APPEND}\n${schema}`) + bashHeadroom,
+        `${frameworkId}${codexBridgeAliases ? ' (bridge aliases)' : ''}`
+      ).toBeLessThanOrEqual(3_500)
+    }
   })
 
   it('uses bridge aliases for Codex MCP tools delivered through a compatibility proxy', () => {

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -26,7 +26,7 @@ const NOTEBOOK_MCP_PROGRESS_HEARTBEAT_MS = 30_000
 const MAX_RUNTIME_RESULTS = 40
 const MAX_ENVIRONMENT_RESULTS = 30
 const HOST_SDK_DISCOVERY_GUIDANCE =
-  "Host SDK discovery (use from `repl_execute`): `await host.help()` is the role-aware catalog. Query only the operation you plan to call; each topic returns concise parameter and result field descriptions. Main/root agents can use `await host.help('delegate')` when delegation guidance is needed; do not prefetch all Help topics. Delegate agents should use the same catalog for messaging and structured-output operations; unavailable root-only topics remain visible with a reason."
+  "Host SDK discovery (use from `repl_execute`): `await host.help()` is the role-aware catalog. Query only the planned operation; each topic returns concise field descriptions. Main/root agents can use `await host.help('delegate')` when needed; do not prefetch all Help topics. Delegate agents should use the same catalog; unavailable root-only topics remain visible."
 
 // Scoped prompt addendum that only applies when the agent is given notebook tools.
 const NOTEBOOK_SYSTEM_PROMPT_APPEND = [
@@ -37,10 +37,10 @@ const NOTEBOOK_SYSTEM_PROMPT_APPEND = [
   'Use `notebook_execute` for one persistent Python/R cell per call; reuse `cellId` to rerun it. Python/R data kernels cannot call connectors; use `repl_execute` for `host.capabilities`/`host.llm`/`host.mcp`/`host.compute`/`host.agents`/`host.skills`. For large cross-kernel data, write under `process.env.OPEN_SCIENCE_HANDOFF_DIR` in the REPL and read that path from Python/R.',
   HOST_SDK_DISCOVERY_GUIDANCE,
   'Each runtime is a separate persistent namespace. Create named runtimes with `manage_environments`, select them with the bind/switch tools, and use files to move data across runtimes. Memory is lost on restart or app reopen; run history and files survive.',
-  'The notebook already runs inside a writable session workspace. The cwd is already the session data dir; use plain relative paths for normal inputs and outputs. The connector handoff directory is outside that cwd and must be resolved from `OPEN_SCIENCE_HANDOFF_DIR`. Never copy a saved file onto the same path. Do not modify original user files.',
+  'The notebook already runs inside a writable session workspace. cwd is the session data dir; use plain relative paths. Connector handoff is outside cwd and must be resolved from `OPEN_SCIENCE_HANDOFF_DIR`. Never copy a saved file onto the same path. Do not modify original user files.',
   'Use `inspect_packages` for version checks and `manage_packages` for installs. Never install inside a cell or shell. App-managed runtime contents belong under `$OPEN_SCIENCE_RUNTIME_DIR`, never the project, workspace, system Python, or a user global environment.',
   'MCP execution replies include bounded output for the next step; use it directly when sufficient. Full output remains in the notebook preview. Inspect stdout, stderr, traceback, outputs, and workingFiles, then revise and rerun if needed. The notebook runtime does not classify files for you.',
-  'Dependency metadata in notebook tool results describes execution order, not an execution verdict: `clear` means no later tracked dependency change was found, `stale` means a tracked dependency changed after that run, and `unknown` means variable changes could not be fully tracked. `stale` does not mean the run failed or its captured output is incorrect; rerun only when the task requires output from the current variable state.',
+  'Dependency metadata describes execution order, not an execution verdict: `clear` means no later tracked change, `stale` means a tracked dependency changed after that run, and `unknown` means tracking was incomplete. `stale` does not mean the run failed or its captured output is incorrect; rerun only when the task requires the current variable state.',
   'For a final user-facing file, call `write_artifact_file` from the `open-science-artifacts` server before announcing it. Use `source: { "kind": "localPath", "path": "plot.png" }` with the SAME relative filename you saved with and `producerRunId` set to the exact `runId` returned by the execution that last wrote it. Use inline content only for small text.',
   '</open_science_notebook_instructions>'
 ].join('\n')


### PR DESCRIPTION
## Problem

Scheduled **Windows Full Test** (`32601034141`) failed on `src/main/acp/context-usage-static-context.test.ts`: combined notebook prompt + MCP schema was 3532 cl100k tokens against a 3500 cap.

The budget test serialized `bash_execute` from the host platform. Windows PowerShell docs are about 87 tokens larger than the POSIX `sh -c` contract, so macOS PR Gate and Nightly verify could pass while Windows full-suite CI failed. Nightly (`32600060605`) lint on `e1b58fe` is already fixed on `main` by #1569.

## Proposed change

- Trim shared notebook guidance (`HOST_SDK_DISCOVERY_GUIDANCE`, workspace cwd/handoff, dependency-status glossary) enough that the **Windows** schema plus prompt stays under 3500 tokens.
- Count the largest platform `bash_execute` contract (and every ACP framework naming variant, including Codex bridge aliases) in the budget test so a POSIX host cannot miss a Windows overflow.

Agent-facing meaning is unchanged: Host SDK discovery, relative-path workspace writes, and `clear`/`stale`/`unknown` as execution-order metadata rather than run success.

## Scope and non-goals

- No protocol, permission, persistence, or schema-enum changes.
- Does not rebase or merge other open PRs.
- Does not change Windows PowerShell operational guidance.

## Acceptance criteria and validation

- Combined notebook prompt + schema stays `<= 3500` cl100k tokens for `codex`, `codex` bridge aliases, `claude-code`, and `opencode`, using the largest platform shell contract.
- Existing notebook MCP prompt/tool contract tests still pass.

## Review focus

- Whether the compacted Host SDK / workspace / dependency sentences still steer agents correctly.
- Whether the budget test’s platform headroom matches how `buildShellExecuteDoc` is embedded in `NOTEBOOK_RPC_TOOLS`.

## Validation evidence

Checks ran after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Static context budget, including Windows shell docs and all framework names | `npm test -- src/main/acp/context-usage-static-context.test.ts` | pass |
| Notebook MCP prompt/tool contracts | `npm test -- src/main/notebook/mcp-server.test.ts` | pass |
| Session presentation appends | `npm test -- src/main/acp/session-presentation-policy.test.ts` | pass (before final Host SDK trim; contract strings unchanged) |
| Claude Code MCP name rewriting | `npm test -- src/main/agent-framework/claude-code.test.ts` | pass (before final Host SDK trim; contract strings unchanged) |
| Lint on changed files | `npx eslint --no-cache src/main/notebook/mcp-server.ts src/main/acp/context-usage-static-context.test.ts` | pass |
| Node typecheck | `npm run typecheck:node` | pass |

`mcp-server.ts` is not an owned Module in `scripts/ci/module-impact.json`, so `test:affected` selected no modules. PR Gate remains the complete portable/platform authority.

Uncovered risks: live ACP session prompt rendering was not re-exercised in a running app; this change is text-only.

## Compatibility notes

- **Historical data compatibility:** none
- **New state / enum values:** none
- **Data persistence:** none