### PR TITLE
fix(settings): keep in-flight optimistic preferences across onChanged

### DIFF
--- a/src/renderer/src/stores/settings-preferences-slice.ts
+++ b/src/renderer/src/stores/settings-preferences-slice.ts
@@ -89,6 +89,27 @@ type SettingsPreferencesSliceOptions = {
   writeCoordinator: SettingsWriteCoordinator
 }
 
+const OPTIMISTIC_PREFERENCE_WRITES = [
+  ['reasoningEffort', 'reasoningEffort'],
+  ['notificationsEnabled', 'notifications'],
+  ['conversationSkillImportEnabled', 'conversationSkillImport'],
+  ['closePreference', 'closePreference'],
+  ['appIconVariant', 'appIcon'],
+  ['projectFilesFilter', 'projectFilesFilter'],
+  ['defaultPermissionProfile', 'defaultPermissionProfile']
+] as const satisfies ReadonlyArray<readonly [OptimisticPreferenceField, OptimisticSettingsWriteKey]>
+
+export const omitInFlightOptimisticPreferences = <Patch extends Partial<SettingsPreferencesState>>(
+  patch: Patch,
+  hasPending: (key: OptimisticSettingsWriteKey) => boolean
+): Patch => {
+  const next = { ...patch }
+  for (const [field, key] of OPTIMISTIC_PREFERENCE_WRITES) {
+    if (hasPending(key)) delete next[field]
+  }
+  return next
+}
+
 const SETTINGS_WRITE_ERRORS: Record<OptimisticSettingsWriteKey, string> = {
   reasoningEffort: 'Could not save reasoning effort. Try again.',
   notifications: 'Could not save notification preference. Try again.',

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -1966,6 +1966,116 @@ describe('settings store: setNotificationsEnabled', () => {
   })
 })
 
+describe('settings store: acceptCommittedSnapshot vs in-flight optimistic preference', () => {
+  it('does not let a foreign committed snapshot clobber an in-flight optimistic preference', async () => {
+    let resolveNotifications: (value: SettingsSnapshot) => void = () => undefined
+    api.setNotificationsEnabled.mockImplementation(
+      () =>
+        new Promise<SettingsSnapshot>((resolve) => {
+          resolveNotifications = resolve
+        })
+    )
+
+    const pending = useSettingsStore.getState().setNotificationsEnabled(false)
+    expect(useSettingsStore.getState().notificationsEnabled).toBe(false)
+
+    try {
+      useSettingsStore.getState().acceptCommittedSnapshot({
+        ...snapshot([]),
+        notificationsEnabled: true,
+        appIconVariant: 'dark'
+      })
+
+      expect(useSettingsStore.getState().notificationsEnabled).toBe(false)
+      expect(useSettingsStore.getState().appIconVariant).toBe('dark')
+    } finally {
+      resolveNotifications({
+        ...snapshot([]),
+        notificationsEnabled: false,
+        appIconVariant: 'dark'
+      })
+      await pending
+    }
+
+    expect(useSettingsStore.getState().notificationsEnabled).toBe(false)
+  })
+
+  it('rolls back a failed optimistic preference to the last confirmed value after a foreign snapshot', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    let rejectNotifications: (reason?: unknown) => void = () => undefined
+    api.setNotificationsEnabled.mockImplementation(
+      () =>
+        new Promise<SettingsSnapshot>((_resolve, reject) => {
+          rejectNotifications = reject
+        })
+    )
+
+    const pending = useSettingsStore.getState().setNotificationsEnabled(false)
+    expect(useSettingsStore.getState().notificationsEnabled).toBe(false)
+
+    useSettingsStore.getState().acceptCommittedSnapshot({
+      ...snapshot([]),
+      notificationsEnabled: false,
+      appIconVariant: 'dark'
+    })
+
+    rejectNotifications(new Error('ipc down'))
+    await pending
+
+    expect(useSettingsStore.getState().notificationsEnabled).toBe(true)
+    expect(useSettingsStore.getState().appIconVariant).toBe('dark')
+    expect(useSettingsStore.getState().settingsWriteError).toBe(
+      'Could not save notification preference. Try again.'
+    )
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to set notifications enabled',
+      expect.any(Error)
+    )
+  })
+
+  it('applies a committed snapshot when no preference write is in flight', () => {
+    useSettingsStore.getState().acceptCommittedSnapshot({
+      ...snapshot([]),
+      notificationsEnabled: false,
+      appIconVariant: 'dark',
+      reasoningEffort: 'high'
+    })
+
+    expect(useSettingsStore.getState().notificationsEnabled).toBe(false)
+    expect(useSettingsStore.getState().appIconVariant).toBe('dark')
+    expect(useSettingsStore.getState().reasoningEffort).toBe('high')
+  })
+
+  it('does not let a foreign committed snapshot clobber an in-flight non-boolean optimistic preference', async () => {
+    let resolveEffort: (value: SettingsSnapshot) => void = () => undefined
+    api.setReasoningEffort.mockImplementation(
+      () =>
+        new Promise<SettingsSnapshot>((resolve) => {
+          resolveEffort = resolve
+        })
+    )
+
+    const pending = useSettingsStore.getState().setReasoningEffort('max')
+    expect(useSettingsStore.getState().reasoningEffort).toBe('max')
+
+    try {
+      useSettingsStore.getState().acceptCommittedSnapshot({
+        ...snapshot([]),
+        reasoningEffort: 'high',
+        notificationsEnabled: false
+      })
+
+      expect(useSettingsStore.getState().reasoningEffort).toBe('max')
+      expect(useSettingsStore.getState().notificationsEnabled).toBe(false)
+    } finally {
+      resolveEffort({ ...snapshot([]), reasoningEffort: 'max', notificationsEnabled: false })
+      await pending
+    }
+
+    expect(useSettingsStore.getState().reasoningEffort).toBe('max')
+  })
+})
+
 describe('settings store: setConversationSkillImportEnabled', () => {
   it('forwards the flag to main and caches the returned snapshot', async () => {
     await useSettingsStore.getState().setConversationSkillImportEnabled(false)

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -43,6 +43,7 @@ import {
 } from './settings-connectors-slice'
 import {
   createSettingsPreferencesSlice,
+  omitInFlightOptimisticPreferences,
   type SettingsPreferencesActions
 } from './settings-preferences-slice'
 import {
@@ -425,7 +426,10 @@ const createSettingsStoreState = (
   },
 
   clearSettingsWriteError: () => writeCoordinator.clearFailures(),
-  acceptCommittedSnapshot: (snapshot) => set(applySnapshot(snapshot))
+  acceptCommittedSnapshot: (snapshot) =>
+    set(() =>
+      omitInFlightOptimisticPreferences(applySnapshot(snapshot), writeCoordinator.hasPending)
+    )
 })
 
 export const useSettingsStore = create<SettingsStore>((set, get) =>

--- a/src/renderer/src/stores/settings-write-coordinator.ts
+++ b/src/renderer/src/stores/settings-write-coordinator.ts
@@ -54,6 +54,7 @@ export type SettingsWriteCoordinator = {
     key: OptimisticSettingsWriteKey,
     confirmedValue: T
   ) => OptimisticSettingsWrite<T>
+  hasPending: (key: OptimisticSettingsWriteKey) => boolean
   clearFailures: () => void
 }
 
@@ -166,6 +167,7 @@ export const createSettingsWriteCoordinator = (
         complete: (value) => completeOptimistic(key, state, value)
       }
     },
+    hasPending: (key) => (optimisticStates.get(key)?.pendingCount ?? 0) > 0,
     clearFailures: () => {
       failures.clear()
       onVisibleError(undefined)


### PR DESCRIPTION
## Problem

The renderer paints Settings preferences (notifications, reasoning effort, app icon, and the other `beginOptimistic` fields) before Main confirms the write. `App` still applies every `settings:changed` payload as a full snapshot.

A foreign or own-echo snapshot that lands while that write is in flight replaces the optimistic value with the last committed one. The toggle flickers, then the command result puts the intended value back.

```mermaid
sequenceDiagram
  participant TabA as Renderer tab A
  participant Main as SettingsDocumentStore
  participant TabB as Renderer tab B
  TabA->>TabA: optimistic notificationsEnabled=false
  TabA->>Main: setNotificationsEnabled(false)
  TabB->>Main: unrelated mutate
  Main-->>TabA: settings:changed (still true)
  Note over TabA: acceptCommittedSnapshot used to apply true
  Main-->>TabA: command returns false
  TabA->>TabA: reconcileSnapshot if current
```

Today only reviewer, subagent, and vision model setters broadcast `settings:changed`. That is enough: an unrelated model write fans out a full snapshot while another tab's preference write is still in flight.

## Proposed change

Keep the in-flight optimistic preference on screen until its own write settles.

- `SettingsWriteCoordinator.hasPending` reports whether an optimistic key still has a queued write.
- `acceptCommittedSnapshot` omits those fields from the applied snapshot so Zustand keeps the already-shown value.
- Unrelated snapshot fields still apply immediately.
- A failed write still rolls back through the coordinator's last confirmed value, not the foreign snapshot.
- `begin()`-only writes (`activeProvider`, `agentFramework`, reviewer / subagent / vision) stay unfenced: they do not paint an optimistic value.

Durable Settings remain on the existing `SettingsDocumentStore` mutation queue. This is renderer projection only.

## Scope and non-goals

**In this PR:** fence `acceptCommittedSnapshot` for the seven optimistic preference keys, and pin the public `useSettingsStore` seam.

**Not in this PR:**

- Main RMW / broadcast fan-out
- Dual `SettingsDocumentStore` instances
- Connector / Skill toggles (they already `project()` on their own catalog events)
- `load()` and command `reconcileSnapshot`, which still apply the full snapshot
- Fencing two concurrent different-key optimistic writes against each other
- Schema, migrations, or i18n

## Acceptance criteria and validation

- While `setNotificationsEnabled(false)` is in flight, `acceptCommittedSnapshot({ notificationsEnabled: true, appIconVariant: 'dark' })` keeps notifications off and still applies the dark icon.
- The same fence holds for `setReasoningEffort`.
- After a failed write, the field returns to the coordinator's last confirmed value even if a foreign snapshot carried the optimistic value.
- A snapshot that arrives with no write in flight still applies in full.
- Existing Settings write-generation tests still pass.

These checks ran after the last material edit:

| Behavior | Command | Result |
|---|---|---|
| Optimistic preference vs `acceptCommittedSnapshot` | `npm test -- src/renderer/src/stores/settings-preferences-slice.test.ts src/renderer/src/stores/settings-store.test.ts src/renderer/src/stores/settings-write-coordinator.test.ts` | pass |
| Store architecture (single write coordinator) | `npm test -- src/renderer/src/stores/settings-store.architecture.test.ts` | pass (27) |
| Web typecheck | `npm run typecheck:web` | pass |
| Lint | `npm run lint` | pass |

**Excluded:** ACP frameworks, live model, E2E, migrations, Web API map, Electron-only packaging. No renderer contract catalog change. No UI component change, so no localhost Web walkthrough.

**Uncovered risk:** a command `reconcileSnapshot` that returns while a *different* optimistic key is still in flight can still overwrite that sibling field. That path is not `settings:changed` and is left for a later seam.

## Review focus

- Whether omitting in-flight fields in `acceptCommittedSnapshot` is the right owner, versus teaching `applySnapshot` itself.
- The field ↔ coordinator-key map in the preferences slice staying in lockstep with `runOptimisticWrite`.
- That `hasPending` is a read on the existing coordinator, not a second pending map or a second `createSettingsWriteCoordinator` call.