### PR TITLE
fix(tags): prevent stale mutation snapshots from replacing newer state

### DIFF
--- a/src/renderer/src/stores/tag-store.test.ts
+++ b/src/renderer/src/stores/tag-store.test.ts
@@ -111,6 +111,74 @@ describe('tag store', () => {
     })
   })
 
+  it('does not let an older mutation response overwrite a newer revision', async () => {
+    let resolveOlder: ((snapshot: TagSnapshot) => void) | undefined
+    const olderResponse = new Promise<TagSnapshot>((resolve) => {
+      resolveOlder = resolve
+    })
+    const initialTags: TagSnapshot['tags'] = [
+      ...favoriteSnapshot().tags,
+      {
+        id: 'tag-a',
+        name: 'A',
+        iconKey: 'tag',
+        colorKey: 'blue',
+        createdAt: 2,
+        updatedAt: 2
+      },
+      {
+        id: 'tag-b',
+        name: 'B',
+        iconKey: 'tag',
+        colorKey: 'blue',
+        createdAt: 3,
+        updatedAt: 3
+      }
+    ]
+    const olderSnapshot: TagSnapshot = {
+      revision: 2,
+      tags: initialTags.map((tag) =>
+        tag.id === 'tag-a' ? { ...tag, name: 'Updated A', updatedAt: 4 } : tag
+      ),
+      assignments: []
+    }
+    const newerSnapshot: TagSnapshot = {
+      revision: 3,
+      tags: olderSnapshot.tags.map((tag) =>
+        tag.id === 'tag-b' ? { ...tag, name: 'Updated B', updatedAt: 5 } : tag
+      ),
+      assignments: []
+    }
+    setTagsApi({
+      update: vi.fn().mockReturnValueOnce(olderResponse).mockResolvedValueOnce(newerSnapshot)
+    })
+    useTagStore.setState({ ...favoriteSnapshot(1), tags: initialTags, status: 'ready' })
+
+    const older = useTagStore.getState().update({
+      id: 'tag-a',
+      name: 'Updated A',
+      iconKey: 'tag',
+      colorKey: 'blue',
+      expectedUpdatedAt: 2
+    })
+    await useTagStore.getState().update({
+      id: 'tag-b',
+      name: 'Updated B',
+      iconKey: 'tag',
+      colorKey: 'blue',
+      expectedUpdatedAt: 3
+    })
+    resolveOlder?.(olderSnapshot)
+    await older
+
+    const state = useTagStore.getState()
+    const tagB = state.tags.find((tag) => tag.id === 'tag-b')
+    expect({
+      revision: state.revision,
+      tagBName: tagB && 'name' in tagB ? tagB.name : undefined
+    }).toEqual({ revision: 3, tagBName: 'Updated B' })
+  })
+
   it('ignores a load snapshot older than the current store revision', async () => {
     setTagsApi({ snapshot: vi.fn().mockResolvedValue(favoriteSnapshot(1)) })
     useTagStore.setState({ ...favoriteSnapshot(2), status: 'ready' })

--- a/src/renderer/src/stores/tag-store.ts
+++ b/src/renderer/src/stores/tag-store.ts
@@ -55,6 +55,12 @@ const stateFromSnapshot = (
   status: 'ready'
 })
 
+const stateFromMutationSnapshot = (
+  snapshot: TagSnapshot,
+  currentRevision: number
+): Partial<Pick<TagStore, keyof TagSnapshot | 'status'>> =>
+  snapshot.revision < currentRevision ? { status: 'ready' } : stateFromSnapshot(snapshot)
+
 export const useTagStore = create<TagStore>((set, get) => ({
   ...createInitialTagState(),
   setBrowserSelectedId: (browserSelectedId) =>
@@ -89,7 +95,7 @@ export const useTagStore = create<TagStore>((set, get) => ({
   create: async (request) => {
     const snapshot = await window.api.tags.create(request)
     loadSequence += 1
-    set({ ...stateFromSnapshot(snapshot), error: undefined })
+    set((state) => ({ ...stateFromMutationSnapshot(snapshot, state.revision), error: undefined }))
     const requestedNameKey = request.name
       .normalize('NFKC')
       .trim()
@@ -106,12 +112,12 @@ export const useTagStore = create<TagStore>((set, get) => ({
   update: async (request) => {
     const snapshot = await window.api.tags.update(request)
     loadSequence += 1
-    set({ ...stateFromSnapshot(snapshot), error: undefined })
+    set((state) => ({ ...stateFromMutationSnapshot(snapshot, state.revision), error: undefined }))
   },
   delete: async (id) => {
     const snapshot = await window.api.tags.delete({ id })
     loadSequence += 1
-    set({ ...stateFromSnapshot(snapshot), error: undefined })
+    set((state) => ({ ...stateFromMutationSnapshot(snapshot, state.revision), error: undefined }))
   },
   reorder: async (request) => {
     const before = get().tags
@@ -128,7 +134,7 @@ export const useTagStore = create<TagStore>((set, get) => ({
     try {
       const snapshot = await window.api.tags.reorder(request)
       loadSequence += 1
-      set({ ...stateFromSnapshot(snapshot), error: undefined })
+      set((state) => ({ ...stateFromMutationSnapshot(snapshot, state.revision), error: undefined }))
     } catch (error) {
       set({ tags: before })
       await get().load()
@@ -159,7 +165,7 @@ export const useTagStore = create<TagStore>((set, get) => ({
     try {
       const snapshot = await window.api.tags.setAssignment(request)
       loadSequence += 1
-      set({ ...stateFromSnapshot(snapshot), error: undefined })
+      set((state) => ({ ...stateFromMutationSnapshot(snapshot, state.revision), error: undefined }))
     } catch (error) {
       set({ assignments: before })
       await get().load()


### PR DESCRIPTION
## Problem

Tag mutations return complete snapshots with monotonically increasing revisions. Successful requests can complete in a different order at the renderer boundary, where an older mutation response currently replaces a newer applied snapshot and makes the UI revision and Tag values move backward even though server data is correct.

## Proposed change

Apply mutation snapshots through one revision-aware state projection. A snapshot older than the current renderer revision may finish loading/error presentation state, but it cannot replace Tags or assignments. Create, update, delete, reorder, and assignment mutations all use this rule.

Add a public-store regression test that holds revision 2, applies revision 3 first, then releases revision 2 and verifies that revision 3 and the newer Tag B value remain visible.

## Scope and non-goals

- Renderer Tag store only; no backend, IPC, or renderer contract changes.
- No new data fields, persisted state, migrations, enum values, or historical compatibility behavior.
- No interaction or visual changes.
- No dependency changes or new test seams.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Out-of-order mutation response remains newest-wins -> npm test -- src/renderer/src/stores/tag-store.test.ts -> passed, 10 tests.
- Renderer TypeScript surface remains valid -> npm run typecheck:web -> passed.
- Source lint remains valid -> npm run lint -> passed.
- Patch whitespace -> git diff --check -> passed.

The regression test was run three times before the fix and consistently failed with revision 2 and Tag B value B instead of revision 3 and Updated B, matching the report. The same focused test passes after the fix.

Consumer render tests and platform lanes are excluded locally because the public store API, renderer contract, interaction, persistence, and platform behavior are unchanged. Full-suite and platform validation remain CI authority; a complete local npm test run was intentionally not run.

## Review focus

- The revision comparison must apply consistently to create, update, delete, reorder, and assignment mutation responses.
- Older snapshots must not replace the current Tags or assignments while existing load invalidation behavior remains intact.