### PR TITLE
fix(granted-folders): ignore stale refresh after mutation

### DIFF
--- a/src/renderer/src/stores/granted-folders-store.test.ts
+++ b/src/renderer/src/stores/granted-folders-store.test.ts
@@ -79,4 +79,26 @@ describe('granted-folders-store', () => {
     expect(removeGrantedRoot).toHaveBeenCalledWith({ id: 'root-1' })
     expect(useGrantedFoldersStore.getState().roots).toEqual([])
   })
+
+  it('does not let a stale refresh overwrite a newer grant result', async () => {
+    let resolveRefresh: ((roots: GrantedLocalRoot[]) => void) | undefined
+    const staleRefresh = new Promise<GrantedLocalRoot[]>((resolve) => {
+      resolveRefresh = resolve
+    })
+    const granted = [
+      createRoot(),
+      createRoot({ id: 'root-2', path: '/data/shared', name: 'shared' })
+    ]
+    setLocalFsApi({
+      listGrantedRoots: vi.fn(() => staleRefresh),
+      grantRoot: vi.fn().mockResolvedValue(granted)
+    })
+
+    const refresh = useGrantedFoldersStore.getState().refresh()
+    await useGrantedFoldersStore.getState().grant('/data/shared', 'rw')
+    resolveRefresh?.([createRoot()])
+    await refresh
+
+    expect(useGrantedFoldersStore.getState().roots).toEqual(granted)
+  })
 })

--- a/src/renderer/src/stores/granted-folders-store.ts
+++ b/src/renderer/src/stores/granted-folders-store.ts
@@ -1,7 +1,8 @@
 // Renderer-side cache of the folders the user granted the app access to ("Grant folder access").
 // The main-process SQLite table is authoritative; every mutation channel returns the full updated
-// list, so each action just stores what comes back. `loaded` distinguishes "never fetched" from
-// "fetched, user granted nothing" so surfaces don't flash an empty state on first paint.
+// list. A refresh that started before a successful mutation cannot replace that newer list. `loaded`
+// distinguishes "never fetched" from "fetched, user granted nothing" so surfaces don't flash an
+// empty state on first paint.
 import { create } from 'zustand'
 
 import type { GrantedLocalRoot, GrantedLocalRootAccess } from '../../../shared/local-fs'
@@ -24,24 +25,36 @@ export const createInitialGrantedFoldersState = (): GrantedFoldersStoreData => (
   loaded: false
 })
 
-export const useGrantedFoldersStore = create<GrantedFoldersStore>((set) => {
+export const useGrantedFoldersStore = create<GrantedFoldersStore>((set, get) => {
+  let mutationRevision = 0
+
   const apply = (roots: GrantedLocalRoot[]): GrantedLocalRoot[] => {
     set({ roots, loaded: true })
     return roots
   }
 
+  const applyMutation = (roots: GrantedLocalRoot[]): GrantedLocalRoot[] => {
+    mutationRevision += 1
+    return apply(roots)
+  }
+
   return {
     ...createInitialGrantedFoldersState(),
 
-    refresh: async () => apply(await window.api.localFs.listGrantedRoots()),
+    refresh: async () => {
+      const startedAtRevision = mutationRevision
+      const roots = await window.api.localFs.listGrantedRoots()
+      return startedAtRevision === mutationRevision ? apply(roots) : get().roots
+    },
 
     // Rejections carry a user-presentable message from main; callers surface them and the store
     // keeps the previous list.
-    grant: async (path, access) => apply(await window.api.localFs.grantRoot({ path, access })),
+    grant: async (path, access) =>
+      applyMutation(await window.api.localFs.grantRoot({ path, access })),
 
     setAccess: async (id, access) =>
-      apply(await window.api.localFs.setGrantedRootAccess({ id, access })),
+      applyMutation(await window.api.localFs.setGrantedRootAccess({ id, access })),
 
-    remove: async (id) => apply(await window.api.localFs.removeGrantedRoot({ id }))
+    remove: async (id) => applyMutation(await window.api.localFs.removeGrantedRoot({ id }))
   }
 })


### PR DESCRIPTION
## Problem

An in-flight `listGrantedRoots()` request could resolve after a newer grant, access change, or removal and unconditionally replace the Renderer cache with its older full-list snapshot. Main and SQLite retained the mutation, but the current UI no longer reflected the authoritative state.

## Proposed change

- Track successful granted-folder mutations with a Renderer-local revision.
- Apply a refresh response only when no mutation completed after that refresh started.
- Return the current store roots when discarding a stale refresh response.
- Add a deterministic regression test that starts refresh first, completes grant second, and resolves the stale refresh last.

## Scope and non-goals

- Renderer store only; no IPC or Main changes.
- No new persisted fields, schema changes, enum values, architecture changes, data-model changes, or interaction changes.
- No historical-data compatibility or migration work is required.
- Concurrent mutation-versus-mutation ordering is unchanged; this fix covers the reproduced stale refresh crossing a newer successful mutation.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Stale refresh reproduction -> `npm test -- src/renderer/src/stores/granted-folders-store.test.ts` on unfixed code -> failed 3/3 runs with one received root instead of the two-root grant result.
- Store regression and key UI consumers -> `npm test -- src/renderer/src/stores/granted-folders-store.test.ts src/renderer/src/pages/workspace/GrantFolderAccessDialog.interaction.test.tsx src/renderer/src/pages/workspace/ComposerYourFilesMenu.interaction.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx` -> 81 passed.
- Project files consumer module -> `npm run test:module -- project_files_view` -> 164 passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Lint -> `npm run lint` -> passed.
- Affected-test explain -> `npm run test:affected -- --base main --head HEAD --explain` -> selected full fallback because the store test has no registered module owner. Per maintainer direction, the complete local suite was not run; PR CI is the authority for the full suite and platform lanes.

Platform, persistence, migration, build, and E2E lanes are excluded locally because the change is a platform-neutral, non-persisted Renderer ordering guard at an existing public store boundary. The remaining uncovered risk is unrelated mutation-versus-mutation response reordering, which was not demonstrated by this report and is intentionally out of scope.

## Review focus

- Confirm the mutation revision advances only after successful mutation responses.
- Confirm stale refresh callers receive the current roots without the stale response touching observable store state.
