### PR TITLE
test(xai-oauth): characterize sequential force-refresh CAS

### DIFF
--- a/src/main/settings/xai-oauth.test.ts
+++ b/src/main/settings/xai-oauth.test.ts
@@ -94,6 +94,49 @@ describe('XaiOAuthController', () => {
     expect(store.save).toHaveBeenCalledWith('old-ref', 'new-refresh')
   })
 
+  it('does not write a second force-refresh with a stale expected key ref after the first refresh settles', async () => {
+    stored = { keyRef: 'ref-0', refreshToken: 'refresh-1' }
+    store.save = vi.fn(async (expectedKeyRef, refreshToken, accountEmail) => {
+      if (stored.keyRef !== expectedKeyRef) return false
+      stored = { keyRef: `ref-after-${refreshToken}`, refreshToken, accountEmail }
+      return true
+    })
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(discovery)))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'access-1',
+            refresh_token: 'refresh-2',
+            expires_in: 3600
+          })
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'access-2',
+            refresh_token: 'refresh-3',
+            expires_in: 3600
+          })
+        )
+      )
+    const controller = new XaiOAuthController({ store, fetch })
+
+    await expect(controller.getAccessToken(true)).resolves.toBe('access-1')
+    await expect(controller.getAccessToken(true)).resolves.toBe('access-2')
+
+    expect(fetch).toHaveBeenCalledTimes(3)
+    expect(store.save).toHaveBeenNthCalledWith(1, 'ref-0', 'refresh-2')
+    expect(store.save).toHaveBeenNthCalledWith(2, 'ref-after-refresh-2', 'refresh-3')
+    expect(store.save).not.toHaveBeenCalledWith('ref-0', 'refresh-3')
+    expect(stored).toEqual({
+      keyRef: 'ref-after-refresh-3',
+      refreshToken: 'refresh-3'
+    })
+  })
+
   it('accepts xAI account verification URLs on accounts.x.ai', async () => {
     const fetch = vi
       .fn()


### PR DESCRIPTION
## Problem

xAI loopback traffic can 401 twice in sequence: first `getAccessToken(true)` refreshes and settles, then a later 401 starts another force-refresh after `refreshPromise` is cleared. Overlapping callers already share one in-flight refresh. The gap is the sequential case: the second save must not succeed with the `expectedKeyRef` captured before the first rotation replaced it.

## Proposed change

Pin that behavior in `XaiOAuthController` with a CAS-aware store:

1. First `getAccessToken(true)` rotates `ref-0` / `refresh-1` to `ref-after-refresh-2` / `refresh-2` and then settles.
2. Second `getAccessToken(true)` starts a new refresh and must save as `('ref-after-refresh-2', 'refresh-3')`.
3. A write of `('ref-0', 'refresh-3')` must not succeed.

No production code change. The controller already reloads credentials at the start of each `refreshAccessToken` after `refreshPromise` is cleared.

## Scope and non-goals

- In scope: sequential force-refresh after a settled `refreshPromise`.
- Out of scope: overlapping/coalesced refresh (already covered), login CAS, logout discarding an in-flight refresh, and product changes unless this characterization fails.

## Acceptance criteria and validation

- After the first force-refresh settles, the second `getAccessToken(true)` persists against the current key ref.
- The stale pre-rotation key ref cannot win the second save.
- Existing coalesced-refresh coverage remains unchanged.

## Review focus

- Whether the new test is the sequential-401 path rather than another overlapping-refresh case.
- Whether the CAS store fixture matches production `expectedKeyRef` compare-and-swap.

## Test Impact Set

Material change: `src/main/settings/xai-oauth.test.ts` only. Owner module: `settings_provider_accounts`. Test-file-only change inside an owned module; full fallback not required.

| Behavior | Command | Result |
| --- | --- | --- |
| Sequential force-refresh CAS after `refreshPromise` settles | `npx vitest run src/main/settings/xai-oauth.test.ts` | 8 passed |
| Owner/contract/consumer coverage for `settings_provider_accounts` | `npm run test:module -- settings_provider_accounts` | 21 files / 366 passed |
| Lint the changed test | `npx eslint src/main/settings/xai-oauth.test.ts` | no issues |

These checks ran after the last material edit.

Excluded: renderer/web typecheck (no renderer or contract-catalog change), Electron/Web E2E (no UI), ACP framework lanes (no ACP protocol change), and other OS CI lanes (no path or process behavior change). Exact-head PR Gate remains authoritative for the portable suite.

Uncovered risks: this pins `XaiOAuthController` at the credential-store port. It does not exercise `XaiProviderAccountOwner` persistence or live xAI token rotation.