### PR TITLE
fix(workspace): reject overlapping idle Session sends without failing the live turn

### DIFF
--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -4319,6 +4319,59 @@ describe('workspace agent message sending', () => {
     expect(runtime.sendPrompt).toHaveBeenCalledTimes(1)
   })
 
+  it('admits only one local user Message when two sends race an attached idle Session', async () => {
+    vi.stubGlobal('window', {
+      api: { acp: { getState: vi.fn().mockResolvedValue(createSnapshot(['session-1'])) } }
+    })
+
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'Previous prompt',
+      cwd: '/workspace/project',
+      projectId: 'project-1'
+    })
+    useSessionStore.getState().finishRun('session-1')
+
+    const firstGate = createDeferred<AcpStateSnapshot>()
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi
+        .fn()
+        .mockImplementationOnce(() => firstGate.promise)
+        .mockRejectedValueOnce(new Error('An ACP prompt is already running for this session'))
+    }
+
+    const [first, second] = await Promise.all([
+      sendWorkspaceMessage(runtime, {
+        sessionId: 'session-1',
+        text: 'first',
+        cwd: '/workspace/project',
+        projectId: 'project-1'
+      }),
+      sendWorkspaceMessage(runtime, {
+        sessionId: 'session-1',
+        text: 'second',
+        cwd: '/workspace/project',
+        projectId: 'project-1'
+      })
+    ])
+    await flushRuntimeTasks()
+    await flushRuntimeTasks()
+
+    expect([first, second].filter(Boolean)).toHaveLength(1)
+    const session = useSessionStore.getState().sessions[0]
+    expect(
+      session.messages
+        .filter((message) => message.role === 'user')
+        .map((message) => message.content)
+    ).toEqual(['Previous prompt', first ? 'first' : 'second'])
+    expect(session.status).not.toBe('error')
+    firstGate.resolve(createSnapshot(['session-1']))
+  })
+
   it('does not append a prompt while the runtime owns the session for compaction', async () => {
     const runtime = {
       state: {

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -21,7 +21,7 @@ import {
   type HistoryReplayDescriptor
 } from './history-preamble'
 import {
-  canPrepareExistingWorkspacePrompt,
+  canAdmitExistingWorkspacePrompt,
   prepareExistingWorkspacePrompt
 } from './workspace-runtime-prompt-preparation-owner'
 import {
@@ -172,6 +172,9 @@ const ownsPrompt = (sessionId: string, messageId: string): boolean => {
   return session?.status === 'running' && session.activeRun?.promptMessageId === messageId
 }
 
+const isOverlappingPromptRejection = (error: unknown): boolean =>
+  /An ACP (?:prompt|interaction) is already running/i.test(errorMessage(error))
+
 type PromptDispatch = {
   sessionId: string
   messageId: string
@@ -214,6 +217,8 @@ const dispatchPrompt = (runtime: WorkspaceCommandRuntime, request: PromptDispatc
   void result
     .then(() => request.accepted?.())
     .catch((error) => {
+      if (isOverlappingPromptRejection(error) && !ownsPrompt(request.sessionId, request.messageId))
+        return
       const message = errorMessage(error).trim() || 'Agent run failed'
       void failPrompt(request.sessionId, message, priorErrorEventId)
     })
@@ -447,15 +452,7 @@ const sendWorkspaceMessage = async (
     const sessionId = input.sessionId
     const session = useSessionStore.getState().sessions.find((item) => item.id === sessionId)
     if (input.requireExistingSession && !session) return undefined
-    if (
-      !canPrepareExistingWorkspacePrompt({
-        sessionId,
-        session,
-        runtimeState: runtime.state,
-        allowCompactionRecovery: input.allowCompactionRecovery === true
-      })
-    )
-      return undefined
+    if (!canAdmitExistingWorkspacePrompt(runtime.state, input)) return undefined
     const projectId = input.projectId ?? session?.projectId
     if (input.planContinuation && !projectId) return undefined
 
@@ -543,6 +540,7 @@ const sendWorkspaceMessage = async (
       useSessionStore.getState().failRun(sessionId, errorMessage(error))
       return undefined
     }
+    if (!canAdmitExistingWorkspacePrompt(runtime.state, input)) return undefined
     if (input.truncateFromMessageId) {
       if (promptAttachments.length > 0) {
         useSessionStore.getState().replaceMessageUploads({

--- a/src/renderer/src/lib/acp/workspace-runtime-prompt-preparation-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-prompt-preparation-owner.ts
@@ -104,6 +104,22 @@ const canPrepareExistingWorkspacePrompt = ({
       )
     }).actions.startTurn.allowed)
 
+const canAdmitExistingWorkspacePrompt = (
+  runtimeState: ExistingWorkspacePromptAdmission['runtimeState'],
+  command: { sessionId?: string; allowCompactionRecovery?: boolean }
+): boolean => {
+  const sessionId = command.sessionId
+  return Boolean(
+    sessionId &&
+    canPrepareExistingWorkspacePrompt({
+      sessionId,
+      session: useSessionStore.getState().sessions.find((session) => session.id === sessionId),
+      runtimeState,
+      allowCompactionRecovery: command.allowCompactionRecovery === true
+    })
+  )
+}
+
 const isReplayImage = (attachment: Pick<UploadedAttachment, 'name' | 'mimeType'>): boolean =>
   imageAttachmentMimeType(attachment.name, attachment.mimeType) !== undefined
 
@@ -440,6 +456,7 @@ const prepareExistingWorkspacePrompt = async (
 
 export {
   acquireWorkspacePromptPreparation,
+  canAdmitExistingWorkspacePrompt,
   canPrepareExistingWorkspacePrompt,
   getResumeFailureMessage,
   isWorkspacePromptPreparationInFlight,


### PR DESCRIPTION
## Problem

Two parallel `sendWorkspaceMessage` calls on one attached idle Session both pass the idle admission check, then both `appendUserMessage`. Main still admits only one provider turn. The rejected send's `failRun` marks the whole Session `error`, including the first live turn.

Same-tab composer double-submit is already guarded by `inFlightDraftKeysRef`. This gap is the renderer send seam when two calls race before `status` becomes `running`.

```mermaid
sequenceDiagram
  participant A as sendWorkspaceMessage A
  participant B as sendWorkspaceMessage B
  participant Store as Session store
  participant Main as ACP Main mutex
  A->>Store: canPrepare (idle)
  B->>Store: canPrepare (idle)
  A->>Store: appendUserMessage (running)
  B->>Store: appendUserMessage (second user Message)
  A->>Main: sendPrompt
  B->>Main: sendPrompt
  Main-->>A: admitted
  Main-->>B: already running
  B->>Store: failRun (Session error)
```

## Proposed change

Drop the second send (option A). Do not queue it at `sendWorkspaceMessage`.

- Re-check `canAdmitExistingWorkspacePrompt` after attachment finalization and before `appendUserMessage`, so the later same-heap send returns `undefined`.
- Skip `failPrompt` / `failRun` when Main rejects with `An ACP prompt|interaction is already running` and this send does not own `activeRun.promptMessageId`.
- Keep the first live turn `running`, not `error`.

Composer draft queue while `status === 'running'` is unchanged. Main `linearizeRootAdmission` is unchanged.

## Scope and non-goals

**In this PR:** renderer admission and overlapping-reject handling at `sendWorkspaceMessage` / `dispatchPrompt`.

**Not in this PR:**

- Queuing the second draft as a later turn
- Same-tab composer `inFlightDraftKeysRef`
- Main prompt mutex / adapter changes
- Cross-tab extra local Message after Main reject (separate heaps)
- Settings `onChanged`, R kernel cancel, i18n, schema, migrations

## Acceptance criteria and validation

- Two parallel `sendWorkspaceMessage` calls on an attached idle Session admit exactly one local user Message from the race.
- The rejected send returns `undefined`.
- Session `status` is not `error`; the first turn is not `failRun`'d.
- Same-tab draft double-submit and send-gate tests still pass.
- Main overlapping-prompt tests still pass.

These checks ran after the last material edit:

| Behavior | Command | Result |
|---|---|---|
| Overlapping send | `npm test -- src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts -t 'admits only one local user Message'` | pass |
| `workspace_runtime` module | `npm run test:module -- workspace_runtime` | pass (340) |
| Same-tab send | `npm test -- src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx` | pass |
| Main mutex | `npm test -- src/main/acp/prompt-turn-workflow.test.ts src/main/acp/session-interaction-owner.test.ts` | pass |
| Web typecheck | `npm run typecheck:web` | pass |
| Lint | eslint on the three changed files | pass |

**ACP:** renderer-only admission. `claude-code` / `opencode` / `codex-response` / `codex-bridge` already share Main mutex; no adapter change.

**Excluded:** live model output, E2E, migrations, Web API map, Electron-only packaging, i18n (no new copy).

**Uncovered risk:** two Web tabs still each have their own JS heap. This PR covers same-heap `sendWorkspaceMessage` races. A cross-tab extra local Message after Main reject remains out of scope.

## Review focus

- The post-finalization re-check is enough for same-heap interleaving because JS is single-threaded after the last `await`.
- Skipping `failRun` only when the overlapping rejection does not own `activeRun.promptMessageId`, so real provider failures still error the Session.
- `canAdmitExistingWorkspacePrompt` staying a thin store re-read of `canPrepareExistingWorkspacePrompt`, not a second admission policy.