### PR TITLE
fix(preview): reject stale preview snapshots

### DIFF
--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -72,8 +72,8 @@ const invocationCommandFor =
 type PreviewApplicationCommandOwner = Readonly<{
   load(
     request: PreviewState.LoadPreviewStateRequest
-  ): Promise<PreviewState.PersistedPreviewState | null>
-  save(request: PreviewState.SavePreviewStateRequest): Promise<void>
+  ): Promise<PreviewState.PreviewStateSnapshot | null>
+  save(request: PreviewState.SavePreviewStateRequest): Promise<PreviewState.SavePreviewStateResult>
   delete(request: PreviewState.DeletePreviewStateRequest): Promise<void>
 }>
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -3037,7 +3037,8 @@ const createApplicationModules = async (
       managedPreview: managedPreviewOwners,
       preview: {
         load: (request) => previewStateRepository.get(request.projectId),
-        save: (request) => previewStateRepository.save(request.projectId, request.state),
+        save: (request) =>
+          previewStateRepository.save(request.projectId, request.state, request.expectedRevision),
         delete: (request) => previewStateRepository.delete(request.projectId)
       },
       projectFiles: projectFilesHandlers,

--- a/src/main/projects/ipc.test.ts
+++ b/src/main/projects/ipc.test.ts
@@ -167,12 +167,13 @@ describe('createProjectHandlers', () => {
     await ipcHandlers.get('preview:load')?.(undefined, { projectId: 'project-1' })
     await ipcHandlers.get('preview:save')?.(undefined, {
       projectId: 'project-1',
-      state: previewState
+      state: previewState,
+      expectedRevision: 7
     })
     await ipcHandlers.get('preview:delete')?.(undefined, { projectId: 'project-1' })
 
     expect(previewRepository.get).toHaveBeenCalledWith('project-1')
-    expect(previewRepository.save).toHaveBeenCalledWith('project-1', previewState)
+    expect(previewRepository.save).toHaveBeenCalledWith('project-1', previewState, 7)
     expect(previewRepository.delete).toHaveBeenCalledWith('project-1')
   })
 })

--- a/src/main/projects/ipc.ts
+++ b/src/main/projects/ipc.ts
@@ -3,7 +3,7 @@ import { ipcMainHandle } from '../ipc-handler-registry'
 import type {
   DeletePreviewStateRequest,
   LoadPreviewStateRequest,
-  PersistedPreviewState,
+  PreviewStateSnapshot,
   SavePreviewStateRequest
 } from '../../shared/preview-state'
 import type {
@@ -85,11 +85,11 @@ const createProjectHandlers = (
 const registerPreviewStateIpcHandlers = (previewRepository: PreviewStateRepository): void => {
   ipcMainHandle(
     'preview:load',
-    (_event, request: LoadPreviewStateRequest): Promise<PersistedPreviewState | null> =>
+    (_event, request: LoadPreviewStateRequest): Promise<PreviewStateSnapshot | null> =>
       previewRepository.get(request.projectId)
   )
   ipcMainHandle('preview:save', (_event, request: SavePreviewStateRequest) =>
-    previewRepository.save(request.projectId, request.state)
+    previewRepository.save(request.projectId, request.state, request.expectedRevision)
   )
   ipcMainHandle('preview:delete', (_event, request: DeletePreviewStateRequest) =>
     previewRepository.delete(request.projectId)

--- a/src/main/projects/preview-repository.test.ts
+++ b/src/main/projects/preview-repository.test.ts
@@ -65,10 +65,11 @@ describe('preview state repository (integration)', () => {
     })
 
     const repository = new PreviewStateRepository(() => Promise.resolve(client))
-    await repository.save('project-a', createState())
+    await repository.save('project-a', createState(), 0)
     await repository.save(
       'project-b',
-      createState({ panelState: 'collapsed', activeItemId: undefined, items: [] })
+      createState({ panelState: 'collapsed', activeItemId: undefined, items: [] }),
+      0
     )
     const otherProjectBefore = await client.project.findUniqueOrThrow({
       where: { id: 'project-b' }
@@ -90,7 +91,10 @@ describe('preview state repository (integration)', () => {
     }
     expect(directFailure).toMatchObject({ code: 'P2003' })
 
-    await expect(repository.save('project-a', createState())).resolves.toBeUndefined()
+    await expect(repository.save('project-a', createState(), 0)).resolves.toEqual({
+      status: 'saved',
+      revision: 0
+    })
     await expect(repository.get('project-a')).resolves.toBeNull()
     await expect(client.project.findUniqueOrThrow({ where: { id: 'project-b' } })).resolves.toEqual(
       otherProjectBefore
@@ -101,18 +105,21 @@ describe('preview state repository (integration)', () => {
   })
 
   it('swallows a raw SQLite owner FK failure but propagates unrelated write errors', async () => {
-    const upsert = vi.fn()
+    const create = vi.fn()
     const client = {
-      projectPreviewState: { upsert }
+      projectPreviewState: { create }
     } as unknown as PreviewStateClient
     const repository = new PreviewStateRepository(() => Promise.resolve(client))
 
-    upsert.mockRejectedValueOnce(new Error('FOREIGN KEY constraint failed'))
-    await expect(repository.save('deleted-project', createState())).resolves.toBeUndefined()
+    create.mockRejectedValueOnce(new Error('FOREIGN KEY constraint failed'))
+    await expect(repository.save('deleted-project', createState(), 0)).resolves.toEqual({
+      status: 'saved',
+      revision: 0
+    })
 
     const writeFailure = new Error('disk I/O error')
-    upsert.mockRejectedValueOnce(writeFailure)
-    await expect(repository.save('project-a', createState())).rejects.toBe(writeFailure)
+    create.mockRejectedValueOnce(writeFailure)
+    await expect(repository.save('project-a', createState(), 0)).rejects.toBe(writeFailure)
   })
 
   it('does not update the owning Project timestamp when saving preview state', async () => {
@@ -128,7 +135,7 @@ describe('preview state repository (integration)', () => {
     })
 
     const repository = new PreviewStateRepository(() => Promise.resolve(client))
-    await repository.save('project-a', createState())
+    await repository.save('project-a', createState(), 0)
 
     await expect(
       client.project.findUniqueOrThrow({ where: { id: 'project-a' } })
@@ -150,25 +157,87 @@ describe('preview state repository (integration)', () => {
     await expect(repository.get('project-a')).resolves.toBeNull()
 
     // Save then read back the durable projection.
-    await repository.save('project-a', createState())
+    await repository.save('project-a', createState(), 0)
     const loaded = await repository.get('project-a')
     expect(loaded).toMatchObject({
-      panelState: 'open',
-      activeItemId: 'file:session-1:/workspace/report.md',
-      items: [{ id: 'file:session-1:/workspace/report.md', path: '/workspace/report.md' }]
+      revision: expect.any(Number),
+      state: {
+        panelState: 'open',
+        activeItemId: 'file:session-1:/workspace/report.md',
+        items: [{ id: 'file:session-1:/workspace/report.md', path: '/workspace/report.md' }]
+      }
     })
 
-    // Upsert overwrites the existing row.
-    await repository.save('project-a', createState({ panelState: 'collapsed', items: [] }))
+    // A matching revision replaces the existing row and advances its revision.
+    await repository.save(
+      'project-a',
+      createState({ panelState: 'collapsed', items: [] }),
+      loaded!.revision
+    )
     const updated = await repository.get('project-a')
-    expect(updated).toMatchObject({ panelState: 'collapsed', items: [] })
+    expect(updated).toMatchObject({ state: { panelState: 'collapsed', items: [] } })
+    expect(updated!.revision).toBeGreaterThan(loaded!.revision)
     // A dangling active id (its item was removed) is dropped on read.
-    expect(updated?.activeItemId).toBeUndefined()
+    expect(updated?.state.activeItemId).toBeUndefined()
 
     // Delete removes the row; deleting again is a no-op.
     await repository.delete('project-a')
     await expect(repository.get('project-a')).resolves.toBeNull()
     await expect(repository.delete('project-a')).resolves.toBeUndefined()
+  })
+
+  it("does not let a stale client snapshot erase another client's newly opened preview", async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-preview-'))
+
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-a', name: 'Project A' } })
+
+    const repository = new PreviewStateRepository(() => Promise.resolve(client))
+    const initial = createState({ activeItemId: undefined, items: [] })
+    await repository.save('project-a', initial, 0)
+    const staleClientSnapshot = (await repository.get('project-a'))!
+    const otherClientSnapshot = (await repository.get('project-a'))!
+
+    const newItem = createState().items[0]!
+    await repository.save(
+      'project-a',
+      { ...otherClientSnapshot.state, activeItemId: newItem.id, items: [newItem] },
+      otherClientSnapshot.revision
+    )
+    await expect(
+      repository.save('project-a', staleClientSnapshot.state, staleClientSnapshot.revision)
+    ).resolves.toMatchObject({ status: 'conflict' })
+
+    expect(await repository.get('project-a')).toMatchObject({
+      state: {
+        activeItemId: newItem.id,
+        items: [expect.objectContaining({ id: newItem.id })]
+      }
+    })
+  })
+
+  it('does not let a second revision-zero save replace the client that created the row', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-preview-'))
+
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-a', name: 'Project A' } })
+
+    const repository = new PreviewStateRepository(() => Promise.resolve(client))
+    const newItem = createState().items[0]!
+    await repository.save('project-a', createState({ items: [newItem] }), 0)
+
+    await expect(
+      repository.save('project-a', createState({ activeItemId: undefined, items: [] }), 0)
+    ).resolves.toMatchObject({ status: 'conflict' })
+    await expect(repository.get('project-a')).resolves.toMatchObject({
+      state: { items: [expect.objectContaining({ id: newItem.id })] }
+    })
   })
 
   it('persists an item path under the data root as a $DATA sentinel and decodes it back on read', async () => {
@@ -198,7 +267,8 @@ describe('preview state repository (integration)', () => {
             name: 'plot.png'
           }
         ]
-      })
+      }),
+      0
     )
 
     // Stored row: the data-root prefix is replaced with the portable $DATA sentinel.
@@ -208,7 +278,7 @@ describe('preview state repository (integration)', () => {
 
     // Read back: the sentinel resolves to an absolute path under the current data root.
     const loaded = await repository.get('project-a')
-    expect(loaded?.items[0].path).toBe(absolutePath)
+    expect(loaded?.state.items[0].path).toBe(absolutePath)
   })
 
   it('rejects an escaping $DATA path from persisted Preview state', async () => {

--- a/src/main/projects/preview-repository.ts
+++ b/src/main/projects/preview-repository.ts
@@ -1,9 +1,11 @@
-import { Prisma, type PrismaClient } from '@prisma/client'
+import { Prisma, type PrismaClient, type ProjectPreviewState } from '@prisma/client'
 
 import {
   PREVIEW_STATE_VERSION,
   normalizePersistedPreviewState,
-  type PersistedPreviewState
+  type PersistedPreviewState,
+  type PreviewStateSnapshot,
+  type SavePreviewStateResult
 } from '../../shared/preview-state'
 import { decodeDataPath, encodeDataPath } from '../storage/data-path'
 
@@ -27,33 +29,49 @@ const isMissingPreviewOwnerError = (error: unknown): boolean =>
   (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2003') ||
   (error instanceof Error && /FOREIGN KEY constraint failed/i.test(error.message))
 
-// Owns per-project preview panel state reads/writes. The client is resolved lazily per call.
-class PreviewStateRepository {
-  constructor(private readonly getClient: PreviewStateClientProvider) {}
+const isExistingPreviewStateError = (error: unknown): boolean =>
+  (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') ||
+  (error instanceof Error && /UNIQUE constraint failed/i.test(error.message))
 
-  // Returns a project's persisted preview state, or null when none has been saved yet.
-  async get(projectId: string): Promise<PersistedPreviewState | null> {
-    const client = await this.getClient()
-    const row = await client.projectPreviewState.findUnique({ where: { projectId } })
+const toSnapshot = (row: ProjectPreviewState): PreviewStateSnapshot => {
+  const state = normalizePersistedPreviewState({
+    version: PREVIEW_STATE_VERSION,
+    panelState: row.panelState,
+    activeItemId: row.activeItemId ?? undefined,
+    items: parseItems(row.items)
+  })
 
-    if (!row) return null
-
-    const state = normalizePersistedPreviewState({
-      version: PREVIEW_STATE_VERSION,
-      panelState: row.panelState,
-      activeItemId: row.activeItemId ?? undefined,
-      items: parseItems(row.items)
-    })
-
-    // Resolve item paths against the current data root so a relocated root needs no rewrite.
-    return {
+  return {
+    revision: row.updatedAt.getTime(),
+    state: {
       ...state,
       items: state.items.map((item) => ({ ...item, path: decodeDataPath(item.path) ?? item.path }))
     }
   }
+}
 
-  // Upserts a project's preview state, sanitizing before writing so only durable fields are stored.
-  async save(projectId: string, state: PersistedPreviewState): Promise<void> {
+// Owns per-project preview panel state reads/writes. The client is resolved lazily per call.
+class PreviewStateRepository {
+  constructor(private readonly getClient: PreviewStateClientProvider) {}
+
+  // Returns a project's persisted preview state and compare-and-set revision, or null when absent.
+  async get(projectId: string): Promise<PreviewStateSnapshot | null> {
+    const client = await this.getClient()
+    const row = await client.projectPreviewState.findUnique({ where: { projectId } })
+
+    return row ? toSnapshot(row) : null
+  }
+
+  // Saves only when the row still has the revision observed by the caller.
+  async save(
+    projectId: string,
+    state: PersistedPreviewState,
+    expectedRevision: number
+  ): Promise<SavePreviewStateResult> {
+    if (!Number.isSafeInteger(expectedRevision) || expectedRevision < 0) {
+      throw new Error('Preview state revision must be a non-negative integer.')
+    }
+
     const normalized = normalizePersistedPreviewState(state)
     const data = {
       panelState: normalized.panelState,
@@ -68,19 +86,31 @@ class PreviewStateRepository {
       ])
     }
     const client = await this.getClient()
+    const revision = Math.max(Date.now(), expectedRevision + 1)
 
-    // The owner FK is the deletion fence: if this write wins first, a later Project delete cascades
-    // it; if deletion wins first, the rejected autosave is an expected no-op for renderer and Web.
-    try {
-      await client.projectPreviewState.upsert({
-        where: { projectId },
-        create: { projectId, ...data },
-        update: data
+    if (expectedRevision === 0) {
+      // Revision zero means the caller observed no row. A concurrent create becomes a conflict,
+      // never an unconditional upsert that replaces the winning snapshot.
+      try {
+        await client.projectPreviewState.create({
+          data: { projectId, ...data, updatedAt: new Date(revision) }
+        })
+        return { status: 'saved', revision }
+      } catch (error) {
+        // The owner FK remains the Project-deletion fence for late autosaves.
+        if (isMissingPreviewOwnerError(error)) return { status: 'saved', revision: 0 }
+        if (!isExistingPreviewStateError(error)) throw error
+      }
+    } else {
+      const result = await client.projectPreviewState.updateMany({
+        where: { projectId, updatedAt: new Date(expectedRevision) },
+        data: { ...data, updatedAt: new Date(revision) }
       })
-    } catch (error) {
-      if (isMissingPreviewOwnerError(error)) return
-      throw error
+      if (result.count === 1) return { status: 'saved', revision }
     }
+
+    const current = await client.projectPreviewState.findUnique({ where: { projectId } })
+    return { status: 'conflict', snapshot: current ? toSnapshot(current) : null }
   }
 
   // Removes a project's preview state (used when the project is deleted). Missing rows are ignored.

--- a/src/main/storage/normalize-legacy-paths.test.ts
+++ b/src/main/storage/normalize-legacy-paths.test.ts
@@ -195,7 +195,7 @@ describe('normalizeLegacyDataPaths (integration)', () => {
       )
 
       const relocatedPreview = await previewStateRepository.get(projectId)
-      expect(relocatedPreview?.items[0].path).toBe(
+      expect(relocatedPreview?.state.items[0].path).toBe(
         join(newRoot, 'artifacts', projectId, 'session-1', 'm', 'plot.png')
       )
 

--- a/src/main/storage/normalize-legacy-paths.ts
+++ b/src/main/storage/normalize-legacy-paths.ts
@@ -48,9 +48,11 @@ const normalizePreviewStates = async (
   const projects = await projectRepository.list()
 
   for (const project of projects) {
-    const state = await previewStateRepository.get(project.id)
+    const snapshot = await previewStateRepository.get(project.id)
 
-    if (state) await previewStateRepository.save(project.id, state)
+    if (snapshot) {
+      await previewStateRepository.save(project.id, snapshot.state, snapshot.revision)
+    }
   }
 }
 

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -162,7 +162,8 @@ import type {
 import type {
   DeletePreviewStateRequest,
   LoadPreviewStateRequest,
-  PersistedPreviewState,
+  PreviewStateSnapshot,
+  SavePreviewStateResult,
   SavePreviewStateRequest
 } from '../shared/preview-state'
 import type {
@@ -813,8 +814,8 @@ export interface OpenScienceAPI {
     ): Promise<PersistedChatSession>
   }
   preview: {
-    load(request: LoadPreviewStateRequest): Promise<PersistedPreviewState | null>
-    save(request: SavePreviewStateRequest): Promise<void>
+    load(request: LoadPreviewStateRequest): Promise<PreviewStateSnapshot | null>
+    save(request: SavePreviewStateRequest): Promise<SavePreviewStateResult>
     delete(request: DeletePreviewStateRequest): Promise<void>
   }
   previewResources: {

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
@@ -597,6 +597,74 @@ describe('usePreviewPersistence per-project save/restore', () => {
     expect(save).toHaveBeenLastCalledWith(expect.objectContaining({ expectedRevision: 10 }))
   })
 
+  it('rebases a user change queued after the conflicting snapshot', async () => {
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+      await flushPreviewPersistence()
+    })
+    save.mockClear()
+
+    const submittedItem = createStoredFileItem()
+    const queuedItem = createStoredFileItem({
+      id: 'file:session-1:/workspace/project/notes.md',
+      title: 'notes.md',
+      path: '/workspace/project/notes.md',
+      name: 'notes.md'
+    })
+    const serverItem = createStoredFileItem({
+      id: 'file:session-2:/workspace/project/results.csv',
+      sessionId: 'session-2',
+      title: 'results.csv',
+      path: '/workspace/project/results.csv',
+      format: 'csv',
+      name: 'results.csv'
+    })
+    const serverState = toPersistedPreviewState({
+      ...usePreviewWorkbenchStore.getState(),
+      panelState: 'open',
+      activeItemId: serverItem.id,
+      items: [serverItem]
+    })
+    const pendingSave = createDeferred<SavePreviewStateResult>()
+    save
+      .mockReturnValueOnce(pendingSave.promise)
+      .mockResolvedValueOnce({ status: 'saved', revision: 11 })
+
+    act(() => {
+      usePreviewWorkbenchStore.setState({
+        panelState: 'open',
+        activeItemId: submittedItem.id,
+        items: [submittedItem]
+      })
+      usePreviewWorkbenchStore.setState({
+        activeItemId: queuedItem.id,
+        items: [submittedItem, queuedItem]
+      })
+    })
+
+    await act(async () => {
+      pendingSave.resolve({
+        status: 'conflict',
+        snapshot: { state: serverState, revision: 10 }
+      })
+      await pendingSave.promise
+      await flushPreviewPersistence()
+    })
+
+    expect(save).toHaveBeenCalledTimes(2)
+    expect(save).toHaveBeenLastCalledWith({
+      projectId: 'project-a',
+      expectedRevision: 10,
+      state: expect.objectContaining({
+        activeItemId: queuedItem.id,
+        items: [
+          expect.objectContaining({ id: serverItem.id }),
+          expect.objectContaining({ id: queuedItem.id })
+        ]
+      })
+    })
+  })
+
   it('does not reuse an inactive project cache after its save conflicts', async () => {
     await act(async () => {
       root.render(<PersistenceHarness projectId="project-a" />)
@@ -702,10 +770,11 @@ describe('usePreviewPersistence per-project save/restore', () => {
     expect(save).toHaveBeenCalledWith(
       expect.objectContaining({
         projectId: 'project-a',
-        expectedRevision: 10,
+        expectedRevision: expect.any(Number),
         state: expect.objectContaining({ panelState: 'collapsed' })
       })
     )
+    expect(save.mock.calls[0]?.[0].expectedRevision).toBeGreaterThanOrEqual(10)
   })
 
   it('keeps the latest state durable when an earlier save completes last', async () => {
@@ -823,6 +892,61 @@ describe('usePreviewPersistence per-project save/restore', () => {
     })
 
     expect(durableState?.activeItemId).toBe(secondItem.id)
+  })
+
+  it('ignores a stale load that returns after an in-flight save completes', async () => {
+    const item = createStoredFileItem()
+    load.mockResolvedValueOnce({
+      revision: 5,
+      state: toPersistedPreviewState({
+        ...usePreviewWorkbenchStore.getState(),
+        panelState: 'open',
+        items: [item]
+      })
+    })
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+      await flushPreviewPersistence()
+    })
+    save.mockClear()
+
+    const pendingSave = createDeferred<SavePreviewStateResult>()
+    const pendingLoad = createDeferred<PreviewStateSnapshot | null>()
+    save.mockReturnValueOnce(pendingSave.promise)
+    load.mockReturnValueOnce(pendingLoad.promise)
+
+    act(() => usePreviewWorkbenchStore.setState({ activeItemId: item.id }))
+    await act(async () => root.unmount())
+    root = createRoot(container)
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+    })
+
+    await act(async () => {
+      pendingSave.resolve({ status: 'saved', revision: 6 })
+      await pendingSave.promise
+      await flushPreviewPersistence()
+    })
+    save.mockClear()
+
+    await act(async () => {
+      pendingLoad.resolve({
+        revision: 5,
+        state: toPersistedPreviewState({
+          ...usePreviewWorkbenchStore.getState(),
+          panelState: 'collapsed',
+          activeItemId: undefined,
+          items: [item]
+        })
+      })
+      await pendingLoad.promise
+    })
+
+    expect(usePreviewWorkbenchStore.getState()).toMatchObject({
+      activeItemId: item.id,
+      panelState: 'open'
+    })
+    expect(save).not.toHaveBeenCalled()
   })
 
   it('retries the latest failed state on a later flush', async () => {

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
@@ -693,15 +693,16 @@ describe('usePreviewPersistence per-project save/restore', () => {
     act(() => {
       usePreviewWorkbenchStore.setState({
         panelState: 'open',
-        activeItemId: staleItem.id,
-        items: [staleItem]
+        activeItemId: createStoredToolItem().id,
+        items: [staleItem, createStoredToolItem()]
       })
     })
     await act(async () => {
       root.render(<PersistenceHarness projectId="project-b" />)
     })
     expect(usePreviewWorkbenchStore.getState().byProject['project-a']?.items).toEqual([
-      expect.objectContaining({ id: staleItem.id })
+      expect.objectContaining({ id: staleItem.id }),
+      expect.objectContaining({ id: createStoredToolItem().id })
     ])
 
     await act(async () => {
@@ -720,8 +721,11 @@ describe('usePreviewPersistence per-project save/restore', () => {
 
     expect(usePreviewWorkbenchStore.getState()).toMatchObject({
       activeProjectId: 'project-a',
-      activeItemId: serverItem.id,
-      items: [expect.objectContaining({ id: serverItem.id })]
+      activeItemId: createStoredToolItem().id,
+      items: [
+        expect.objectContaining({ id: serverItem.id }),
+        expect.objectContaining({ id: createStoredToolItem().id })
+      ]
     })
   })
 

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
@@ -657,6 +657,57 @@ describe('usePreviewPersistence per-project save/restore', () => {
     })
   })
 
+  it('saves the first user change after an unmounted conflict restore', async () => {
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+      await flushPreviewPersistence()
+    })
+    save.mockClear()
+
+    const pendingSave = createDeferred<SavePreviewStateResult>()
+    save.mockReturnValueOnce(pendingSave.promise)
+    act(() => {
+      usePreviewWorkbenchStore.setState({
+        panelState: 'open',
+        activeItemId: createStoredFileItem().id,
+        items: [createStoredFileItem()]
+      })
+      root.unmount()
+    })
+
+    const serverState = toPersistedPreviewState({
+      ...usePreviewWorkbenchStore.getState(),
+      panelState: 'open',
+      items: [createStoredFileItem()]
+    })
+    await act(async () => {
+      pendingSave.resolve({
+        status: 'conflict',
+        snapshot: { state: serverState, revision: 10 }
+      })
+      await pendingSave.promise
+      await flushPreviewPersistence()
+    })
+    save.mockClear()
+
+    const pendingLoad = createDeferred<PreviewStateSnapshot | null>()
+    load.mockReturnValueOnce(pendingLoad.promise)
+    root = createRoot(container)
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+    })
+
+    act(() => usePreviewWorkbenchStore.getState().collapsePanel())
+
+    expect(save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'project-a',
+        expectedRevision: 10,
+        state: expect.objectContaining({ panelState: 'collapsed' })
+      })
+    )
+  })
+
   it('keeps the latest state durable when an earlier save completes last', async () => {
     await act(async () => {
       root.render(<PersistenceHarness projectId="project-a" />)

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
@@ -3,7 +3,11 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { PREVIEW_STATE_VERSION, type PersistedPreviewState } from '../../../../shared/preview-state'
+import {
+  PREVIEW_STATE_VERSION,
+  type PersistedPreviewState,
+  type PreviewStateSnapshot
+} from '../../../../shared/preview-state'
 import {
   createInitialPreviewWorkbenchState,
   usePreviewWorkbenchStore
@@ -294,8 +298,10 @@ describe('usePreviewPersistence per-project save/restore', () => {
   beforeEach(() => {
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
     useSessionStore.setState(createInitialSessionState())
-    load = vi.fn(() => Promise.resolve(undefined))
-    save = vi.fn(() => Promise.resolve())
+    load = vi.fn(() => Promise.resolve(null))
+    save = vi.fn(({ expectedRevision }: { expectedRevision: number }) =>
+      Promise.resolve({ status: 'saved' as const, revision: expectedRevision + 1 })
+    )
     window.api = { preview: { load, save } } as never
     container = document.createElement('div')
     document.body.appendChild(container)
@@ -327,7 +333,7 @@ describe('usePreviewPersistence per-project save/restore', () => {
         }
       ]
     }
-    load.mockResolvedValueOnce(persisted)
+    load.mockResolvedValueOnce({ state: persisted, revision: 7 })
 
     await act(async () => {
       root.render(<PersistenceHarness projectId="project-a" />)
@@ -354,20 +360,23 @@ describe('usePreviewPersistence per-project save/restore', () => {
       sessions: [createSession(finalizedUpload), createSession(unopenedUpload)]
     })
     load.mockResolvedValueOnce({
-      version: PREVIEW_STATE_VERSION,
-      panelState: 'open',
-      activeItemId: 'upload:upload-1',
-      items: [
-        {
-          id: 'upload:upload-1',
-          sessionId: '.pending',
-          title: 'data.csv',
-          source: 'upload',
-          path: '/workspace/uploads/.pending/data.csv',
-          format: 'csv',
-          name: 'data.csv'
-        }
-      ]
+      revision: 7,
+      state: {
+        version: PREVIEW_STATE_VERSION,
+        panelState: 'open',
+        activeItemId: 'upload:upload-1',
+        items: [
+          {
+            id: 'upload:upload-1',
+            sessionId: '.pending',
+            title: 'data.csv',
+            source: 'upload',
+            path: '/workspace/uploads/.pending/data.csv',
+            format: 'csv',
+            name: 'data.csv'
+          }
+        ]
+      }
     })
 
     await act(async () => {
@@ -387,20 +396,23 @@ describe('usePreviewPersistence per-project save/restore', () => {
   it('waits for session hydration before restoring uploaded preview paths', async () => {
     const finalizedUpload = createUpload()
     load.mockResolvedValueOnce({
-      version: PREVIEW_STATE_VERSION,
-      panelState: 'open',
-      activeItemId: 'upload:upload-1',
-      items: [
-        {
-          id: 'upload:upload-1',
-          sessionId: '.pending',
-          title: 'data.csv',
-          source: 'upload',
-          path: '/workspace/uploads/.pending/data.csv',
-          format: 'csv',
-          name: 'data.csv'
-        }
-      ]
+      revision: 7,
+      state: {
+        version: PREVIEW_STATE_VERSION,
+        panelState: 'open',
+        activeItemId: 'upload:upload-1',
+        items: [
+          {
+            id: 'upload:upload-1',
+            sessionId: '.pending',
+            title: 'data.csv',
+            source: 'upload',
+            path: '/workspace/uploads/.pending/data.csv',
+            format: 'csv',
+            name: 'data.csv'
+          }
+        ]
+      }
     })
 
     await act(async () => {
@@ -447,6 +459,7 @@ describe('usePreviewPersistence per-project save/restore', () => {
 
     expect(save).toHaveBeenCalledWith({
       projectId: 'project-a',
+      expectedRevision: expect.any(Number),
       state: {
         version: PREVIEW_STATE_VERSION,
         panelState: 'open',
@@ -471,7 +484,7 @@ describe('usePreviewPersistence per-project save/restore', () => {
   it('skips the outgoing save when a pending load left the live slice on another project', async () => {
     // project-a's load never resolves, so activateProject never runs: the top-level slice does not
     // belong to project-a when the rapid switch to project-b happens.
-    const pendingLoad = createDeferred<PersistedPreviewState | undefined>()
+    const pendingLoad = createDeferred<PreviewStateSnapshot | null>()
     load.mockReturnValueOnce(pendingLoad.promise)
 
     await act(async () => {
@@ -517,6 +530,7 @@ describe('usePreviewPersistence per-project save/restore', () => {
 
     expect(save).toHaveBeenCalledWith({
       projectId: 'project-a',
+      expectedRevision: expect.any(Number),
       state: {
         version: PREVIEW_STATE_VERSION,
         panelState: 'open',
@@ -532,6 +546,54 @@ describe('usePreviewPersistence per-project save/restore', () => {
         }
       }
     })
+  })
+
+  it('restores the authoritative snapshot and advances after a save conflict', async () => {
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+      await flushPreviewPersistence()
+    })
+    save.mockClear()
+
+    const serverItem = createStoredFileItem({
+      id: 'file:session-2:/workspace/project/results.csv',
+      sessionId: 'session-2',
+      title: 'results.csv',
+      path: '/workspace/project/results.csv',
+      format: 'csv',
+      name: 'results.csv'
+    })
+    const serverState = toPersistedPreviewState({
+      ...usePreviewWorkbenchStore.getState(),
+      panelState: 'open',
+      activeItemId: serverItem.id,
+      items: [serverItem]
+    })
+    save.mockResolvedValueOnce({
+      status: 'conflict',
+      snapshot: { state: serverState, revision: 10 }
+    })
+
+    act(() => {
+      usePreviewWorkbenchStore.setState({
+        panelState: 'open',
+        activeItemId: 'file:session-1:/workspace/project/report.md',
+        items: [createStoredFileItem()]
+      })
+    })
+    await flushPreviewPersistence()
+
+    expect(save).toHaveBeenCalledTimes(1)
+    expect(usePreviewWorkbenchStore.getState()).toMatchObject({
+      activeItemId: serverItem.id,
+      items: [expect.objectContaining({ id: serverItem.id })]
+    })
+
+    save.mockResolvedValueOnce({ status: 'saved', revision: 11 })
+    act(() => usePreviewWorkbenchStore.getState().collapsePanel())
+    await flushPreviewPersistence()
+
+    expect(save).toHaveBeenLastCalledWith(expect.objectContaining({ expectedRevision: 10 }))
   })
 
   it('keeps the latest state durable when an earlier save completes last', async () => {
@@ -560,14 +622,15 @@ describe('usePreviewPersistence per-project save/restore', () => {
     let durableState: PersistedPreviewState | undefined
     save.mockClear()
     save
-      .mockImplementationOnce(({ state }: { state: PersistedPreviewState }) =>
+      .mockImplementationOnce(({ expectedRevision, state }) =>
         delayedFirstSave.promise.then(() => {
           durableState = state
+          return { status: 'saved' as const, revision: expectedRevision + 1 }
         })
       )
-      .mockImplementationOnce(({ state }: { state: PersistedPreviewState }) => {
+      .mockImplementationOnce(({ expectedRevision, state }) => {
         durableState = state
-        return Promise.resolve()
+        return Promise.resolve({ status: 'saved' as const, revision: expectedRevision + 1 })
       })
 
     act(() => {
@@ -582,6 +645,9 @@ describe('usePreviewPersistence per-project save/restore', () => {
     })
 
     expect(save).toHaveBeenCalledTimes(2)
+    expect(save.mock.calls[1]?.[0].expectedRevision).toBe(
+      save.mock.calls[0]?.[0].expectedRevision + 1
+    )
     expect(durableState?.activeItemId).toBe(secondItem.id)
   })
 
@@ -608,19 +674,20 @@ describe('usePreviewPersistence per-project save/restore', () => {
     await act(async () => Promise.resolve())
 
     const delayedFirstSave = createDeferred<void>()
-    const pendingRemountLoad = createDeferred<PersistedPreviewState | undefined>()
+    const pendingRemountLoad = createDeferred<PreviewStateSnapshot | null>()
     let durableState: PersistedPreviewState | undefined
     load.mockReturnValueOnce(pendingRemountLoad.promise)
     save.mockClear()
     save
-      .mockImplementationOnce(({ state }: { state: PersistedPreviewState }) =>
+      .mockImplementationOnce(({ expectedRevision, state }) =>
         delayedFirstSave.promise.then(() => {
           durableState = state
+          return { status: 'saved' as const, revision: expectedRevision + 1 }
         })
       )
-      .mockImplementationOnce(({ state }: { state: PersistedPreviewState }) => {
+      .mockImplementationOnce(({ expectedRevision, state }) => {
         durableState = state
-        return Promise.resolve()
+        return Promise.resolve({ status: 'saved' as const, revision: expectedRevision + 1 })
       })
 
     act(() => {
@@ -666,9 +733,9 @@ describe('usePreviewPersistence per-project save/restore', () => {
     save.mockClear()
     save
       .mockImplementationOnce(() => failedSave.promise)
-      .mockImplementationOnce(({ state }: { state: PersistedPreviewState }) => {
+      .mockImplementationOnce(({ expectedRevision, state }) => {
         durableState = state
-        return Promise.resolve()
+        return Promise.resolve({ status: 'saved' as const, revision: expectedRevision + 1 })
       })
 
     act(() => {
@@ -712,6 +779,7 @@ describe('usePreviewPersistence per-project save/restore', () => {
     expect(save).toHaveBeenCalledTimes(1)
     expect(save).toHaveBeenCalledWith({
       projectId: 'project-a',
+      expectedRevision: expect.any(Number),
       state: {
         version: PREVIEW_STATE_VERSION,
         panelState: 'open',

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
@@ -6,7 +6,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   PREVIEW_STATE_VERSION,
   type PersistedPreviewState,
-  type PreviewStateSnapshot
+  type PreviewStateSnapshot,
+  type SavePreviewStateResult
 } from '../../../../shared/preview-state'
 import {
   createInitialPreviewWorkbenchState,
@@ -594,6 +595,66 @@ describe('usePreviewPersistence per-project save/restore', () => {
     await flushPreviewPersistence()
 
     expect(save).toHaveBeenLastCalledWith(expect.objectContaining({ expectedRevision: 10 }))
+  })
+
+  it('does not reuse an inactive project cache after its save conflicts', async () => {
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+      await flushPreviewPersistence()
+    })
+    save.mockClear()
+
+    const staleItem = createStoredFileItem()
+    const serverItem = createStoredFileItem({
+      id: 'file:session-2:/workspace/project/results.csv',
+      sessionId: 'session-2',
+      title: 'results.csv',
+      path: '/workspace/project/results.csv',
+      format: 'csv',
+      name: 'results.csv'
+    })
+    const serverState = toPersistedPreviewState({
+      ...usePreviewWorkbenchStore.getState(),
+      panelState: 'open',
+      activeItemId: serverItem.id,
+      items: [serverItem]
+    })
+    const pendingSave = createDeferred<SavePreviewStateResult>()
+    save.mockReturnValueOnce(pendingSave.promise)
+
+    act(() => {
+      usePreviewWorkbenchStore.setState({
+        panelState: 'open',
+        activeItemId: staleItem.id,
+        items: [staleItem]
+      })
+    })
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-b" />)
+    })
+    expect(usePreviewWorkbenchStore.getState().byProject['project-a']?.items).toEqual([
+      expect.objectContaining({ id: staleItem.id })
+    ])
+
+    await act(async () => {
+      pendingSave.resolve({
+        status: 'conflict',
+        snapshot: { state: serverState, revision: 10 }
+      })
+      await pendingSave.promise
+      await flushPreviewPersistence()
+    })
+
+    load.mockResolvedValueOnce({ state: serverState, revision: 10 })
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+    })
+
+    expect(usePreviewWorkbenchStore.getState()).toMatchObject({
+      activeProjectId: 'project-a',
+      activeItemId: serverItem.id,
+      items: [expect.objectContaining({ id: serverItem.id })]
+    })
   })
 
   it('keeps the latest state durable when an earlier save completes last', async () => {

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.ts
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.ts
@@ -231,7 +231,16 @@ const suppressedConflictRestoreSaves = new Set<string>()
 
 const restorePreviewConflict = (projectId: string, snapshot: PreviewStateSnapshot | null): void => {
   const store = usePreviewWorkbenchStore.getState()
-  if (store.activeProjectId !== projectId) return
+  if (store.activeProjectId !== projectId) {
+    usePreviewWorkbenchStore.setState((state) => {
+      if (!Object.hasOwn(state.byProject, projectId)) return state
+
+      const byProject = { ...state.byProject }
+      delete byProject[projectId]
+      return { byProject }
+    })
+    return
+  }
 
   const projectSessions = useSessionStore
     .getState()

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.ts
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.ts
@@ -246,10 +246,14 @@ const restorePreviewConflict = (projectId: string, snapshot: PreviewStateSnapsho
     .getState()
     .sessions.filter((session) => session.projectId === projectId)
   suppressedConflictRestoreSaves.add(projectId)
-  store.activateProject(
-    projectId,
-    snapshot ? toRestoredSlice(snapshot.state, projectSessions) : { items: [] }
-  )
+  try {
+    store.activateProject(
+      projectId,
+      snapshot ? toRestoredSlice(snapshot.state, projectSessions) : { items: [] }
+    )
+  } finally {
+    suppressedConflictRestoreSaves.delete(projectId)
+  }
 }
 
 // WorkspacePage can unmount while an IPC save is still in flight. Keep one renderer-lifetime scheduler
@@ -327,7 +331,7 @@ export const usePreviewPersistence = (
   useEffect(() => {
     const unsubscribe = usePreviewWorkbenchStore.subscribe((state) => {
       if (!state.activeProjectId) return
-      if (suppressedConflictRestoreSaves.delete(state.activeProjectId)) return
+      if (suppressedConflictRestoreSaves.has(state.activeProjectId)) return
       schedulePreviewSave({
         projectId: state.activeProjectId,
         state: toPersistedPreviewState(state)

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.ts
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.ts
@@ -361,16 +361,8 @@ const suppressedConflictRestoreSaves = new Set<string>()
 
 const restorePreviewConflict = (projectId: string, snapshot: PreviewStateSnapshot | null): void => {
   const store = usePreviewWorkbenchStore.getState()
-  if (store.activeProjectId !== projectId) {
-    usePreviewWorkbenchStore.setState((state) => {
-      if (!Object.hasOwn(state.byProject, projectId)) return state
-
-      const byProject = { ...state.byProject }
-      delete byProject[projectId]
-      return { byProject }
-    })
-    return
-  }
+  // The next activation will merge a fresh durable snapshot into the cached runtime-owned tabs.
+  if (store.activeProjectId !== projectId) return
 
   const projectSessions = useSessionStore
     .getState()

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.ts
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.ts
@@ -3,6 +3,8 @@ import { useEffect, useRef } from 'react'
 import {
   PREVIEW_STATE_VERSION,
   type PersistedPreviewState,
+  type PreviewStateSnapshot,
+  type SavePreviewStateResult,
   type SavePreviewStateRequest
 } from '../../../../shared/preview-state'
 import { getUploadedAttachmentPath } from '../../../../shared/uploads'
@@ -16,9 +18,11 @@ import { useSessionStore, type ChatSession } from '../../stores/session-store'
 import { getPreviewFormatForFile } from '../../pages/workspace/preview-support'
 
 type PreviewStoreState = ReturnType<typeof usePreviewWorkbenchStore.getState>
-type PreviewSave = (request: SavePreviewStateRequest) => Promise<void>
+type PreviewSave = (request: SavePreviewStateRequest) => Promise<SavePreviewStateResult>
+type PreviewSaveInput = Omit<SavePreviewStateRequest, 'expectedRevision'>
 type PreviewSaveScheduler = {
-  schedule: (request: SavePreviewStateRequest) => void
+  schedule: (request: PreviewSaveInput) => void
+  setRevision: (projectId: string, revision: number) => void
   flush: () => Promise<void>
 }
 
@@ -30,7 +34,8 @@ const reportPersistenceError = (error: unknown): void => {
 // Projects drain independently, and a failed write does not prevent a newer snapshot from being saved.
 const createPreviewSaveScheduler = (
   save: PreviewSave,
-  reportError: (error: unknown) => void
+  reportError: (error: unknown) => void,
+  restoreConflict: (projectId: string, snapshot: PreviewStateSnapshot | null) => void
 ): PreviewSaveScheduler => {
   const queues = new Map<
     string,
@@ -46,8 +51,9 @@ const createPreviewSaveScheduler = (
       error: unknown
     }
   >()
+  const revisions = new Map<string, number>()
 
-  const schedule = ({ projectId, state }: SavePreviewStateRequest): void => {
+  const schedule = ({ projectId, state }: PreviewSaveInput): void => {
     const queue = queues.get(projectId) ?? { pendingState: undefined, drain: undefined }
     queue.pendingState = state
     queues.set(projectId, queue)
@@ -61,7 +67,19 @@ const createPreviewSaveScheduler = (
           queue.pendingState = undefined
 
           try {
-            await save({ projectId, state: nextState })
+            const result = await save({
+              projectId,
+              state: nextState,
+              expectedRevision: revisions.get(projectId) ?? 0
+            })
+            if (result.status === 'conflict') {
+              queue.pendingState = undefined
+              revisions.set(projectId, result.snapshot?.revision ?? 0)
+              failures.delete(projectId)
+              restoreConflict(projectId, result.snapshot)
+              break
+            }
+            revisions.set(projectId, Math.max(revisions.get(projectId) ?? 0, result.revision))
             failures.delete(projectId)
           } catch (error) {
             failures.set(projectId, { state: nextState, error })
@@ -94,17 +112,12 @@ const createPreviewSaveScheduler = (
     }
   }
 
-  return { schedule, flush }
-}
+  const setRevision = (projectId: string, revision: number): void => {
+    revisions.set(projectId, revision)
+  }
 
-// WorkspacePage can unmount while an IPC save is still in flight. Keep one renderer-lifetime scheduler
-// so a later Workspace mount cannot start a competing queue for the same Project.
-const previewSaveScheduler = createPreviewSaveScheduler(
-  (request) => window.api.preview.save(request),
-  reportPersistenceError
-)
-const schedulePreviewSave = previewSaveScheduler.schedule
-const flushPreviewPersistence = previewSaveScheduler.flush
+  return { schedule, setRevision, flush }
+}
 
 // Projects the live store slice down to its durable subset: file previews plus the one Session-scoped
 // Subagents selection. Other tool tabs remain runtime-only and re-appear from their existing owners.
@@ -214,6 +227,32 @@ const toRestoredSlice = (
   }
 }
 
+const suppressedConflictRestoreSaves = new Set<string>()
+
+const restorePreviewConflict = (projectId: string, snapshot: PreviewStateSnapshot | null): void => {
+  const store = usePreviewWorkbenchStore.getState()
+  if (store.activeProjectId !== projectId) return
+
+  const projectSessions = useSessionStore
+    .getState()
+    .sessions.filter((session) => session.projectId === projectId)
+  suppressedConflictRestoreSaves.add(projectId)
+  store.activateProject(
+    projectId,
+    snapshot ? toRestoredSlice(snapshot.state, projectSessions) : { items: [] }
+  )
+}
+
+// WorkspacePage can unmount while an IPC save is still in flight. Keep one renderer-lifetime scheduler
+// so a later Workspace mount cannot start a competing queue for the same Project.
+const previewSaveScheduler = createPreviewSaveScheduler(
+  (request) => window.api.preview.save(request),
+  reportPersistenceError,
+  restorePreviewConflict
+)
+const schedulePreviewSave = previewSaveScheduler.schedule
+const flushPreviewPersistence = previewSaveScheduler.flush
+
 // Persists and restores the preview panel per project: saves the outgoing project before switching,
 // loads the incoming project's saved slice, and flushes the current project on unmount (e.g. Home).
 export const usePreviewPersistence = (
@@ -251,8 +290,10 @@ export const usePreviewPersistence = (
 
     void window.api.preview
       .load({ projectId: activeProjectId })
-      .then((restored) => {
+      .then((snapshot) => {
         if (cancelled) return
+
+        previewSaveScheduler.setRevision(activeProjectId, snapshot?.revision ?? 0)
 
         const projectSessions = useSessionStore
           .getState()
@@ -262,7 +303,7 @@ export const usePreviewPersistence = (
           .getState()
           .activateProject(
             activeProjectId,
-            restored ? toRestoredSlice(restored, projectSessions) : undefined
+            snapshot ? toRestoredSlice(snapshot.state, projectSessions) : undefined
           )
       })
       .catch(reportPersistenceError)
@@ -277,6 +318,7 @@ export const usePreviewPersistence = (
   useEffect(() => {
     const unsubscribe = usePreviewWorkbenchStore.subscribe((state) => {
       if (!state.activeProjectId) return
+      if (suppressedConflictRestoreSaves.delete(state.activeProjectId)) return
       schedulePreviewSave({
         projectId: state.activeProjectId,
         state: toPersistedPreviewState(state)

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.ts
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.ts
@@ -2,6 +2,8 @@ import { useEffect, useRef } from 'react'
 
 import {
   PREVIEW_STATE_VERSION,
+  createEmptyPersistedPreviewState,
+  normalizePersistedPreviewState,
   type PersistedPreviewState,
   type PreviewStateSnapshot,
   type SavePreviewStateResult,
@@ -22,12 +24,76 @@ type PreviewSave = (request: SavePreviewStateRequest) => Promise<SavePreviewStat
 type PreviewSaveInput = Omit<SavePreviewStateRequest, 'expectedRevision'>
 type PreviewSaveScheduler = {
   schedule: (request: PreviewSaveInput) => void
-  setRevision: (projectId: string, revision: number) => void
+  getGeneration: (projectId: string) => number
+  acceptLoadedRevision: (projectId: string, generation: number, revision: number) => boolean
+  hasFailure: (projectId: string) => boolean
+  waitForIdle: (projectId: string) => Promise<void>
   flush: () => Promise<void>
 }
 
 const reportPersistenceError = (error: unknown): void => {
   console.warn('Preview persistence failed', error)
+}
+
+const previewValuesEqual = (left: unknown, right: unknown): boolean => {
+  if (Object.is(left, right)) return true
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => previewValuesEqual(value, right[index]))
+    )
+  }
+  if (!left || !right || typeof left !== 'object' || typeof right !== 'object') return false
+
+  const leftRecord = left as Record<string, unknown>
+  const rightRecord = right as Record<string, unknown>
+  const leftKeys = Object.keys(leftRecord)
+  return (
+    leftKeys.length === Object.keys(rightRecord).length &&
+    leftKeys.every(
+      (key) =>
+        Object.hasOwn(rightRecord, key) && previewValuesEqual(leftRecord[key], rightRecord[key])
+    )
+  )
+}
+
+// Applies only the changes made after `base` to the authoritative state. This preserves remote tabs
+// while retaining user actions that happened after the conflicting save had already started.
+const rebasePreviewState = (
+  base: PersistedPreviewState,
+  local: PersistedPreviewState,
+  authoritative: PersistedPreviewState
+): PersistedPreviewState => {
+  const baseItems = new Map(base.items.map((item) => [item.id, item]))
+  const localItems = new Map(local.items.map((item) => [item.id, item]))
+  const mergedItems = authoritative.items
+    .filter((item) => !(baseItems.has(item.id) && !localItems.has(item.id)))
+    .map((item) => {
+      const localItem = localItems.get(item.id)
+      const baseItem = baseItems.get(item.id)
+      return localItem && (!baseItem || !previewValuesEqual(localItem, baseItem)) ? localItem : item
+    })
+  const mergedIds = new Set(mergedItems.map((item) => item.id))
+
+  for (const localItem of local.items) {
+    const baseItem = baseItems.get(localItem.id)
+    if (!mergedIds.has(localItem.id) && (!baseItem || !previewValuesEqual(localItem, baseItem))) {
+      mergedItems.push(localItem)
+    }
+  }
+
+  return normalizePersistedPreviewState({
+    ...authoritative,
+    panelState: local.panelState !== base.panelState ? local.panelState : authoritative.panelState,
+    activeItemId:
+      local.activeItemId !== base.activeItemId ? local.activeItemId : authoritative.activeItemId,
+    items: mergedItems,
+    subagents: !previewValuesEqual(local.subagents, base.subagents)
+      ? local.subagents
+      : authoritative.subagents
+  })
 }
 
 // Serializes saves per Project while coalescing queued snapshots to the newest state. Different
@@ -41,6 +107,7 @@ const createPreviewSaveScheduler = (
     string,
     {
       pendingState: PersistedPreviewState | undefined
+      pendingBaseState: PersistedPreviewState | undefined
       drain: Promise<void> | undefined
     }
   >()
@@ -52,11 +119,22 @@ const createPreviewSaveScheduler = (
     }
   >()
   const revisions = new Map<string, number>()
+  const generations = new Map<string, number>()
+
+  const bumpGeneration = (projectId: string): void => {
+    generations.set(projectId, (generations.get(projectId) ?? 0) + 1)
+  }
 
   const schedule = ({ projectId, state }: PreviewSaveInput): void => {
-    const queue = queues.get(projectId) ?? { pendingState: undefined, drain: undefined }
+    const queue = queues.get(projectId) ?? {
+      pendingState: undefined,
+      pendingBaseState: undefined,
+      drain: undefined
+    }
     queue.pendingState = state
+    queue.pendingBaseState = undefined
     queues.set(projectId, queue)
+    bumpGeneration(projectId)
 
     if (queue.drain) return
 
@@ -64,7 +142,9 @@ const createPreviewSaveScheduler = (
       try {
         while (queue.pendingState) {
           const nextState = queue.pendingState
+          const nextBaseState = queue.pendingBaseState
           queue.pendingState = undefined
+          queue.pendingBaseState = undefined
 
           try {
             const result = await save({
@@ -73,16 +153,41 @@ const createPreviewSaveScheduler = (
               expectedRevision: revisions.get(projectId) ?? 0
             })
             if (result.status === 'conflict') {
-              queue.pendingState = undefined
-              revisions.set(projectId, result.snapshot?.revision ?? 0)
+              const authoritativeState =
+                result.snapshot?.state ?? createEmptyPersistedPreviewState()
+              const localState = queue.pendingState ?? (nextBaseState ? nextState : undefined)
+              const localBaseState = queue.pendingState ? nextState : nextBaseState
+              const revision = result.snapshot?.revision ?? 0
+              revisions.set(projectId, revision)
+              bumpGeneration(projectId)
               failures.delete(projectId)
-              restoreConflict(projectId, result.snapshot)
+
+              if (localState && localBaseState) {
+                const rebasedState = rebasePreviewState(
+                  localBaseState,
+                  localState,
+                  authoritativeState
+                )
+                restoreConflict(projectId, { state: rebasedState, revision })
+                if (!previewValuesEqual(rebasedState, authoritativeState)) {
+                  queue.pendingState = rebasedState
+                  queue.pendingBaseState = authoritativeState
+                  continue
+                }
+              } else {
+                restoreConflict(projectId, result.snapshot)
+              }
+
+              queue.pendingState = undefined
+              queue.pendingBaseState = undefined
               break
             }
             revisions.set(projectId, Math.max(revisions.get(projectId) ?? 0, result.revision))
+            bumpGeneration(projectId)
             failures.delete(projectId)
           } catch (error) {
             failures.set(projectId, { state: nextState, error })
+            bumpGeneration(projectId)
             reportError(error)
           }
         }
@@ -112,11 +217,36 @@ const createPreviewSaveScheduler = (
     }
   }
 
-  const setRevision = (projectId: string, revision: number): void => {
-    revisions.set(projectId, revision)
+  const getGeneration = (projectId: string): number => generations.get(projectId) ?? 0
+
+  const hasFailure = (projectId: string): boolean => failures.has(projectId)
+
+  const waitForIdle = async (projectId: string): Promise<void> => {
+    let drain = queues.get(projectId)?.drain
+    while (drain) {
+      await drain
+      drain = queues.get(projectId)?.drain
+    }
   }
 
-  return { schedule, setRevision, flush }
+  const acceptLoadedRevision = (
+    projectId: string,
+    generation: number,
+    revision: number
+  ): boolean => {
+    if (
+      generation !== getGeneration(projectId) ||
+      queues.has(projectId) ||
+      failures.has(projectId)
+    ) {
+      return false
+    }
+
+    revisions.set(projectId, Math.max(revisions.get(projectId) ?? 0, revision))
+    return true
+  }
+
+  return { schedule, getGeneration, acceptLoadedRevision, hasFailure, waitForIdle, flush }
 }
 
 // Projects the live store slice down to its durable subset: file previews plus the one Session-scoped
@@ -300,26 +430,43 @@ export const usePreviewPersistence = (
     if (!activeProjectId) return
 
     let cancelled = false
+    const loadLatest = async (): Promise<void> => {
+      const loadGeneration = previewSaveScheduler.getGeneration(activeProjectId)
+      const snapshot = await window.api.preview.load({ projectId: activeProjectId })
+      if (cancelled) return
 
-    void window.api.preview
-      .load({ projectId: activeProjectId })
-      .then((snapshot) => {
-        if (cancelled) return
+      if (
+        !previewSaveScheduler.acceptLoadedRevision(
+          activeProjectId,
+          loadGeneration,
+          snapshot?.revision ?? 0
+        )
+      ) {
+        const currentStore = usePreviewWorkbenchStore.getState()
+        if (currentStore.activeProjectId === activeProjectId) return
+        if (previewSaveScheduler.hasFailure(activeProjectId)) {
+          currentStore.activateProject(activeProjectId)
+          return
+        }
 
-        previewSaveScheduler.setRevision(activeProjectId, snapshot?.revision ?? 0)
+        await previewSaveScheduler.waitForIdle(activeProjectId)
+        if (!cancelled) await loadLatest()
+        return
+      }
 
-        const projectSessions = useSessionStore
-          .getState()
-          .sessions.filter((session) => session.projectId === activeProjectId)
+      const projectSessions = useSessionStore
+        .getState()
+        .sessions.filter((session) => session.projectId === activeProjectId)
 
-        usePreviewWorkbenchStore
-          .getState()
-          .activateProject(
-            activeProjectId,
-            snapshot ? toRestoredSlice(snapshot.state, projectSessions) : undefined
-          )
-      })
-      .catch(reportPersistenceError)
+      usePreviewWorkbenchStore
+        .getState()
+        .activateProject(
+          activeProjectId,
+          snapshot ? toRestoredSlice(snapshot.state, projectSessions) : undefined
+        )
+    }
+
+    void loadLatest().catch(reportPersistenceError)
 
     return () => {
       cancelled = true

--- a/src/renderer/src/stores/preview-workbench-store.test.ts
+++ b/src/renderer/src/stores/preview-workbench-store.test.ts
@@ -576,10 +576,11 @@ describe('preview workbench store', () => {
     })
   })
 
-  it('replaces an active project slice when persistence resolves a conflict', () => {
+  it('replaces durable tabs without dropping active runtime-only tabs', () => {
     const store = usePreviewWorkbenchStore.getState()
     store.activateProject('project-a')
     store.upsertAndActivateItem(createProjectFilesPreviewItem())
+    store.setToolItemExpanded(PROJECT_FILES_PREVIEW_ID)
 
     store.activateProject('project-a', {
       panelState: 'open',
@@ -599,8 +600,9 @@ describe('preview workbench store', () => {
 
     expect(usePreviewWorkbenchStore.getState()).toMatchObject({
       activeProjectId: 'project-a',
-      activeItemId: 'file:session-2:/workspace/results.csv',
-      items: [{ id: 'file:session-2:/workspace/results.csv' }]
+      activeItemId: PROJECT_FILES_PREVIEW_ID,
+      expandedToolItemId: PROJECT_FILES_PREVIEW_ID,
+      items: [{ id: 'file:session-2:/workspace/results.csv' }, { id: PROJECT_FILES_PREVIEW_ID }]
     })
   })
 

--- a/src/renderer/src/stores/preview-workbench-store.test.ts
+++ b/src/renderer/src/stores/preview-workbench-store.test.ts
@@ -576,6 +576,34 @@ describe('preview workbench store', () => {
     })
   })
 
+  it('replaces an active project slice when persistence resolves a conflict', () => {
+    const store = usePreviewWorkbenchStore.getState()
+    store.activateProject('project-a')
+    store.upsertAndActivateItem(createProjectFilesPreviewItem())
+
+    store.activateProject('project-a', {
+      panelState: 'open',
+      activeItemId: 'file:session-2:/workspace/results.csv',
+      items: [
+        {
+          id: 'file:session-2:/workspace/results.csv',
+          sessionId: 'session-2',
+          type: 'file',
+          title: 'results.csv',
+          path: '/workspace/results.csv',
+          format: 'csv',
+          name: 'results.csv'
+        }
+      ]
+    })
+
+    expect(usePreviewWorkbenchStore.getState()).toMatchObject({
+      activeProjectId: 'project-a',
+      activeItemId: 'file:session-2:/workspace/results.csv',
+      items: [{ id: 'file:session-2:/workspace/results.csv' }]
+    })
+  })
+
   it('repairs a dangling restored active item to the first surviving tab', () => {
     usePreviewWorkbenchStore.getState().activateProject('project-a', {
       panelState: 'open',

--- a/src/renderer/src/stores/preview-workbench-store.ts
+++ b/src/renderer/src/stores/preview-workbench-store.ts
@@ -295,11 +295,19 @@ export const usePreviewWorkbenchStore = create<PreviewWorkbenchStore>((set, get)
   ...createInitialPreviewWorkbenchState(),
 
   // Switches the visible preview slice to a project's own tabs, stashing the outgoing project's slice
-  // so returning to it restores its tabs. `restored` seeds a project's slice from persistence on first
-  // activation in this session.
+  // so returning to it restores its tabs. `restored` replaces the target slice with authoritative
+  // persistence, including when conflict recovery refreshes the currently active Project.
   activateProject: (projectId, restored) => {
     set((state) => {
-      if (state.activeProjectId === projectId) return state
+      if (state.activeProjectId === projectId) {
+        return restored
+          ? {
+              ...restoredToSlice(restored, projectId),
+              expandedToolItemId: null,
+              fileDialogItem: state.fileDialogItem
+            }
+          : state
+      }
 
       const byProject = { ...state.byProject }
 

--- a/src/renderer/src/stores/preview-workbench-store.ts
+++ b/src/renderer/src/stores/preview-workbench-store.ts
@@ -176,6 +176,38 @@ const restoredToSlice = (restored: RestoredPreviewSlice, projectId: string): Pre
   }
 }
 
+// Persistence owns file tabs and the Session-scoped Subagents selection. Other tool tabs are
+// reconstructed by their runtime owners and must survive a durable snapshot refresh.
+const isDurablePreviewItem = (item: PreviewItem): boolean =>
+  item.type === 'file' || item.toolKind === 'subagents'
+
+const mergeRestoredPreviewSlice = (
+  current: PreviewSlice,
+  restored: RestoredPreviewSlice,
+  projectId: string
+): PreviewSlice => {
+  const authoritative = restoredToSlice(restored, projectId)
+  const authoritativeIds = new Set(authoritative.items.map((item) => item.id))
+  const runtimeItems = current.items.filter(
+    (item) => !isDurablePreviewItem(item) && !authoritativeIds.has(item.id)
+  )
+  const activeRuntimeItem = runtimeItems.some((item) => item.id === current.activeItemId)
+  const activeItemId = activeRuntimeItem
+    ? current.activeItemId
+    : (authoritative.activeItemId ?? runtimeItems[0]?.id)
+
+  return {
+    ...authoritative,
+    items: [...authoritative.items, ...runtimeItems],
+    activeItemId,
+    panelState:
+      activeRuntimeItem || (!authoritative.activeItemId && runtimeItems.length > 0)
+        ? current.panelState
+        : authoritative.panelState,
+    openRequestVersion: current.openRequestVersion
+  }
+}
+
 // Builds the stable preview tab identity for the notebook attached to one chat session.
 const createNotebookPreviewItem = (notebook: NotebookSessionReference): PreviewToolItem => ({
   id: `tool:${notebook.sessionId}:notebook`,
@@ -295,18 +327,25 @@ export const usePreviewWorkbenchStore = create<PreviewWorkbenchStore>((set, get)
   ...createInitialPreviewWorkbenchState(),
 
   // Switches the visible preview slice to a project's own tabs, stashing the outgoing project's slice
-  // so returning to it restores its tabs. `restored` replaces the target slice with authoritative
-  // persistence, including when conflict recovery refreshes the currently active Project.
+  // so returning to it restores its tabs. `restored` replaces the target's durable subset with
+  // authoritative persistence while retaining runtime-owned tool tabs.
   activateProject: (projectId, restored) => {
     set((state) => {
       if (state.activeProjectId === projectId) {
-        return restored
-          ? {
-              ...restoredToSlice(restored, projectId),
-              expandedToolItemId: null,
-              fileDialogItem: state.fileDialogItem
-            }
-          : state
+        if (!restored) return state
+
+        const targetSlice = mergeRestoredPreviewSlice(state, restored, projectId)
+        const expandedToolItemId = targetSlice.items.some(
+          (item) => item.id === state.expandedToolItemId && !isDurablePreviewItem(item)
+        )
+          ? state.expandedToolItemId
+          : null
+
+        return {
+          ...targetSlice,
+          expandedToolItemId,
+          fileDialogItem: state.fileDialogItem
+        }
       }
 
       const byProject = { ...state.byProject }
@@ -320,9 +359,10 @@ export const usePreviewWorkbenchStore = create<PreviewWorkbenchStore>((set, get)
         }
       }
 
-      const targetSlice =
-        byProject[projectId] ??
-        (restored ? restoredToSlice(restored, projectId) : createEmptyPreviewSlice())
+      const cachedSlice = byProject[projectId]
+      const targetSlice = restored
+        ? mergeRestoredPreviewSlice(cachedSlice ?? createEmptyPreviewSlice(), restored, projectId)
+        : (cachedSlice ?? createEmptyPreviewSlice())
 
       // The active slice lives at top level, never duplicated in the stash.
       delete byProject[projectId]

--- a/src/shared/preview-state.ts
+++ b/src/shared/preview-state.ts
@@ -45,6 +45,11 @@ export type PersistedPreviewState = {
   subagents?: PersistedSubagentsPreviewItem
 }
 
+export type PreviewStateSnapshot = {
+  state: PersistedPreviewState
+  revision: number
+}
+
 export type LoadPreviewStateRequest = {
   projectId: string
 }
@@ -52,7 +57,12 @@ export type LoadPreviewStateRequest = {
 export type SavePreviewStateRequest = {
   projectId: string
   state: PersistedPreviewState
+  expectedRevision: number
 }
+
+export type SavePreviewStateResult =
+  | { status: 'saved'; revision: number }
+  | { status: 'conflict'; snapshot: PreviewStateSnapshot | null }
 
 export type DeletePreviewStateRequest = {
   projectId: string


### PR DESCRIPTION
## Problem

Preview persistence accepted complete snapshots without the database revision observed by the caller. A stale desktop window or browser client could therefore autosave after another client and erase that client's newer Preview tabs, active selection, panel state, or persisted Subagents selection.

## Proposed change

- return each loaded Preview state with an opaque revision derived from the existing `ProjectPreviewState.updatedAt` column
- require saves to compare-and-set that revision, including create races from revision `0`
- return the authoritative snapshot on conflict without modifying the stored row
- restore the authoritative Preview slice on conflict and continue later saves from the returned revision
- retain only user changes made after the conflicting request began by rebasing that narrow delta onto the authoritative state
- reject load results superseded by a save, refresh stale inactive durable caches without dropping runtime-only tools, and scope conflict-save suppression to the synchronous restore

## Scope and non-goals

- no Prisma schema change, database migration, or historical-data backfill
- no change to persisted Preview JSON or `PREVIEW_STATE_VERSION`
- no new user-visible copy or notification
- no general cross-client snapshot merge, operation log, or CRDT; the renderer only rebases changes made while one save request is in flight
- old renderer requests without an expected revision fail closed and require refresh after an app upgrade

## Acceptance criteria and validation

Checks listed below ran after the last material edit.

- stale A / newer B and revision-zero create races preserve the winning Preview item -> focused repository tests -> passed
- renderer serializes revisions, restores authoritative conflicts, preserves post-request local changes and runtime-only tool tabs, refreshes inactive stale durable caches, ignores superseded loads, and does not swallow changes across unmount/remount -> focused Preview persistence/store tests -> passed
- Electron/application-command/preload/local-Web/remote-Web contract paths retain the same method names and carry the new request/results -> focused IPC, application-command, preload, Web installer, and argument-shape tests -> passed
- legacy portable Preview paths still normalize through the revisioned repository boundary -> focused normalization test -> passed
- affected Node and renderer types -> `npm run typecheck:node`; `npm run typecheck:web` -> passed
- linted source -> `npm run lint` -> passed
- combined focused Vitest evidence -> 10 files, 206 tests passed

`npm run test:affected -- --base origin/main --head HEAD --explain` fails closed to the full plan because `src/main/data-content-application-commands.ts` has no declared module owner. Per maintainer request, the complete local `npm test` was not run; exact-head PR Gate CI is the remaining validation authority. No local cross-platform E2E was run because the change is a typed persistence/API contract with no platform-specific path or UI behavior.

## Review focus

- compare-and-set correctness for both absent and existing Preview rows
- renderer ordering when load, save, conflict, Project switching, and unmount overlap
- narrow post-request delta rebase semantics for additions, removals, item updates, active selection, panel state, and Subagents selection
- durable snapshot replacement without removing Notebook, Project Files, Reviewer, or Plan runtime tabs
- use of the existing monotonic `updatedAt` token instead of adding a schema migration
