### PR TITLE
fix(session): keep an unsaved local title across a newer remote upsert

### DIFF
--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -1564,6 +1564,53 @@ describe('renderer session persistence bridge', () => {
     expect(saveSession.mock.calls[1][0].messages).toEqual(latest.messages)
   })
 
+  it('still saves an unsaved local title after a newer remote Session projection', async () => {
+    const persisted = materializeSessionConversationGraph(
+      createPersistedSession({
+        projectId: 'project-a',
+        revision: 1,
+        title: 'Original'
+      })
+    )
+    const remote = materializeSessionConversationGraph({
+      ...persisted,
+      revision: 2,
+      title: 'Remote title',
+      messages: [
+        {
+          id: 'remote-message',
+          role: 'agent',
+          content: 'Saved in another window',
+          status: 'complete',
+          eventIds: [],
+          createdAt: persisted.updatedAt + 1,
+          updatedAt: persisted.updatedAt + 1
+        }
+      ],
+      updatedAt: persisted.updatedAt + 10
+    })
+    const saveSession = vi
+      .fn<SessionPersistenceApi['saveSession']>()
+      .mockImplementation(async (submitted) => ({
+        ...submitted,
+        revision: (submitted.revision ?? 0) + 1
+      }))
+    const api = createApi({ saveSession })
+    useSessionStore.getState().hydrateSessions([persisted])
+    const save = createStoreSaver(api, useSessionStore.getState())
+
+    useSessionStore.getState().renameSession('session-1', 'Local draft')
+    useSessionStore.getState().upsertPersistedSession(remote)
+    await save(useSessionStore.getState())
+
+    expect(useSessionStore.getState().sessions[0].title).toBe('Local draft')
+    expect(useSessionStore.getState().sessions[0].unsavedTitle).toBeUndefined()
+    expect(saveSession).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Local draft', revision: 2 }),
+      { conflictRebaseFields: ['title'] }
+    )
+  })
+
   it('reports an earlier failed write even when a later queued write succeeds', async () => {
     const api = createApi({
       saveSession: vi.fn().mockRejectedValue(new Error('disk full')),

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -982,26 +982,28 @@ const createStoreSaver = (
 
       const target = `session:${session.id}`
       const isForced = options?.forceTargets?.has(target) === true
-      if (isExternallyHydratedSession(session)) {
-        const authority = getExternallyHydratedSessionAuthority(session)
-        if (authority) {
-          const previousAuthority = acknowledgedSessions.get(session.id)
-          const authorityIsNewer =
-            !previousAuthority ||
-            sessionRevision(authority) > sessionRevision(previousAuthority) ||
-            (sessionRevision(authority) === sessionRevision(previousAuthority) &&
-              authority.updatedAt >= previousAuthority.updatedAt)
-          acknowledgedRevisions.set(
-            session.id,
-            Math.max(acknowledgedRevisions.get(session.id) ?? 0, sessionRevision(authority))
-          )
-          if (authorityIsNewer) acknowledgedSessions.set(session.id, authority)
-        }
+      const authority = isExternallyHydratedSession(session)
+        ? getExternallyHydratedSessionAuthority(session)
+        : undefined
+      if (authority) {
+        const previousAuthority = acknowledgedSessions.get(session.id)
+        const authorityIsNewer =
+          !previousAuthority ||
+          sessionRevision(authority) > sessionRevision(previousAuthority) ||
+          (sessionRevision(authority) === sessionRevision(previousAuthority) &&
+            authority.updatedAt >= previousAuthority.updatedAt)
+        acknowledgedRevisions.set(
+          session.id,
+          Math.max(acknowledgedRevisions.get(session.id) ?? 0, sessionRevision(authority))
+        )
+        if (authorityIsNewer) acknowledgedSessions.set(session.id, authority)
       }
 
+      const hasUnsavedLocalTitle =
+        session.unsavedTitle === true && Boolean(authority && session.title !== authority.title)
       if (
         (previousById.get(session.id) !== session || isForced) &&
-        (isForced || !isExternallyHydratedSession(session)) &&
+        (isForced || !isExternallyHydratedSession(session) || hasUnsavedLocalTitle) &&
         !hasStagedUploads(session) &&
         // A terminal graph-integrity failure keeps the renderer responsive, but the flat projection
         // is no longer proven to match the immutable Branch graph. Preserve the last durable copy.
@@ -1016,6 +1018,7 @@ const createStoreSaver = (
         const conflictRebaseFields = [
           ...new Set([
             ...changedConflictRebaseFields,
+            ...(hasUnsavedLocalTitle ? (['title'] as const) : []),
             ...(options?.conflictRebaseFieldsByTarget?.get(target) ?? [])
           ])
         ]

--- a/src/renderer/src/stores/session-store-persistence-merge.ts
+++ b/src/renderer/src/stores/session-store-persistence-merge.ts
@@ -1,5 +1,7 @@
 import type {
+  PersistedChatMessage,
   PersistedChatSession,
+  PersistedUploadedAttachment,
   SessionDelegatedWorkRuntimeContext,
   SessionRuntimeContext
 } from '../../../shared/session-persistence'
@@ -265,6 +267,55 @@ type PersistedIdentityState = Pick<
   PersistedChatSession,
   'artifacts' | 'conversationGraph' | 'filesRevision' | 'messages' | 'runtimeContext'
 >
+
+const isSameSubmittedUpload = (
+  current: PersistedUploadedAttachment,
+  submitted: PersistedUploadedAttachment
+): boolean =>
+  current.id === submitted.id &&
+  current.versionId === submitted.versionId &&
+  current.sessionId === submitted.sessionId &&
+  current.name === submitted.name &&
+  current.originalName === submitted.originalName &&
+  current.path === submitted.path &&
+  current.mimeType === submitted.mimeType &&
+  current.size === submitted.size
+
+export const mergeDurableUploadProjection = <Message extends PersistedChatMessage>(
+  currentMessages: Message[],
+  submittedMessages: PersistedChatMessage[],
+  durableMessages: PersistedChatMessage[]
+): { messages: Message[]; changed: boolean } => {
+  const submittedById = new Map(submittedMessages.map((message) => [message.id, message]))
+  const durableById = new Map(durableMessages.map((message) => [message.id, message]))
+  let changed = false
+  const messages = currentMessages.map((message) => {
+    const submitted = submittedById.get(message.id)
+    const durable = durableById.get(message.id)
+    if (!message.uploads || !submitted?.uploads || !durable?.uploads) return message
+    const submittedUploads = new Map(submitted.uploads.map((upload) => [upload.id, upload]))
+    const durableUploads = new Map(durable.uploads.map((upload) => [upload.id, upload]))
+    let uploadsChanged = false
+    const uploads = message.uploads.map((upload) => {
+      const submittedUpload = submittedUploads.get(upload.id)
+      const durableUpload = durableUploads.get(upload.id)
+      if (
+        !submittedUpload ||
+        !durableUpload?.versionId ||
+        submittedUpload.versionId ||
+        !isSameSubmittedUpload(upload, submittedUpload)
+      ) {
+        return upload
+      }
+      uploadsChanged = true
+      return durableUpload
+    })
+    if (!uploadsChanged) return message
+    changed = true
+    return { ...message, uploads } as Message
+  })
+  return { messages, changed }
+}
 
 export const mergeRuntimeConversationAuthority = (
   current: Pick<PersistedChatSession, 'conversationGraph' | 'messages'>,

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -27,8 +27,7 @@ import {
   type PersistedMessageStatus,
   type PersistedSessionManifest,
   type PersistedSessionStatus,
-  type PersistedToolActivity,
-  type PersistedUploadedAttachment
+  type PersistedToolActivity
 } from '../../../shared/session-persistence'
 import {
   inferSessionInteractionState,
@@ -37,6 +36,7 @@ import {
 } from './session-store-interaction-state'
 import {
   mergeDelegatedWorkAuthorityProjection,
+  mergeDurableUploadProjection,
   mergeNewerPersistedSessionByIdentity,
   mergePersistedRuntimeIdentityProjection,
   mergeRuntimeConversationAuthority,
@@ -82,6 +82,8 @@ export type ChatSession = Omit<
   activePlanProjection?: ActivePlanProjection
   planHistoryProjections?: ActivePlanProjection[]
   isPending?: boolean
+  // Transient: renameSession wrote a title that disk has not acknowledged.
+  unsavedTitle?: true
   interrupted?: boolean
   fixLoopActive?: boolean
   compacting?: boolean
@@ -169,6 +171,7 @@ export const toPersistedSession = (session: ChatSession): PersistedChatSession =
     activities,
     activityGroups,
     isPending,
+    unsavedTitle,
     interrupted,
     fixLoopActive,
     compacting,
@@ -191,6 +194,7 @@ export const toPersistedSession = (session: ChatSession): PersistedChatSession =
   } = session
 
   void isPending
+  void unsavedTitle
   void interrupted
   void fixLoopActive
   void compacting
@@ -297,55 +301,6 @@ const withTransientSessionState = (
     pendingContextReplayMessageId: source.pendingContextReplayMessageId,
     interactionState: source.interactionState
   }
-}
-
-const isSameSubmittedUpload = (
-  current: PersistedUploadedAttachment,
-  submitted: PersistedUploadedAttachment
-): boolean =>
-  current.id === submitted.id &&
-  current.versionId === submitted.versionId &&
-  current.sessionId === submitted.sessionId &&
-  current.name === submitted.name &&
-  current.originalName === submitted.originalName &&
-  current.path === submitted.path &&
-  current.mimeType === submitted.mimeType &&
-  current.size === submitted.size
-
-const mergeDurableUploadProjection = <Message extends PersistedChatMessage>(
-  currentMessages: Message[],
-  submittedMessages: PersistedChatMessage[],
-  durableMessages: PersistedChatMessage[]
-): { messages: Message[]; changed: boolean } => {
-  const submittedById = new Map(submittedMessages.map((message) => [message.id, message]))
-  const durableById = new Map(durableMessages.map((message) => [message.id, message]))
-  let changed = false
-  const messages = currentMessages.map((message) => {
-    const submitted = submittedById.get(message.id)
-    const durable = durableById.get(message.id)
-    if (!message.uploads || !submitted?.uploads || !durable?.uploads) return message
-    const submittedUploads = new Map(submitted.uploads.map((upload) => [upload.id, upload]))
-    const durableUploads = new Map(durable.uploads.map((upload) => [upload.id, upload]))
-    let uploadsChanged = false
-    const uploads = message.uploads.map((upload) => {
-      const submittedUpload = submittedUploads.get(upload.id)
-      const durableUpload = durableUploads.get(upload.id)
-      if (
-        !submittedUpload ||
-        !durableUpload?.versionId ||
-        submittedUpload.versionId ||
-        !isSameSubmittedUpload(upload, submittedUpload)
-      ) {
-        return upload
-      }
-      uploadsChanged = true
-      return durableUpload
-    })
-    if (!uploadsChanged) return message
-    changed = true
-    return { ...message, uploads } as Message
-  })
-  return { messages, changed }
 }
 
 const projectDurablePlanAuthority = (
@@ -492,10 +447,15 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
         !hydratedSession.planHistoryProjections && existing?.planHistoryProjections
           ? { planHistoryProjections: existing.planHistoryProjections }
           : {}
+      const unsavedLocalTitle =
+        existing?.unsavedTitle === true
+          ? { title: existing.title, unsavedTitle: true as const }
+          : {}
       const hydratedWithTransientState = {
         ...hydratedSession,
         ...retainedPlanHistory,
-        ...currentPlanProjection
+        ...currentPlanProjection,
+        ...unsavedLocalTitle
       }
       markExternallyHydratedSession(hydratedWithTransientState, session)
       const nextSessions = [

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -458,7 +458,7 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
           ? { planHistoryProjections: existing.planHistoryProjections }
           : {}
       const unsavedLocalTitle =
-        existing?.unsavedTitle === true
+        existing?.unsavedTitle === true && existing.title !== session.title
           ? { title: existing.title, unsavedTitle: true as const }
           : {}
       const hydratedWithTransientState = {

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -303,6 +303,16 @@ const withTransientSessionState = (
   }
 }
 
+const withAcknowledgedUnsavedTitle = (
+  projected: ChatSession,
+  durable: PersistedChatSession
+): ChatSession => {
+  if (projected.unsavedTitle !== true || projected.title !== durable.title) return projected
+  const next = { ...projected }
+  delete next.unsavedTitle
+  return next
+}
+
 const projectDurablePlanAuthority = (
   current: ChatSession,
   durable: PersistedChatSession
@@ -643,14 +653,25 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
           !graph?.changed &&
           projected === merged &&
           sessionRevision(session) <= sessionRevision(current)
-        )
-          return state
+        ) {
+          const acknowledged = withAcknowledgedUnsavedTitle(current, session)
+          if (acknowledged === current) return state
+          markExternallyHydratedSession(acknowledged, session)
+          return {
+            sessions: state.sessions.map((candidate) =>
+              candidate.id === session.id ? acknowledged : candidate
+            )
+          } as Partial<State>
+        }
       }
 
-      projected = {
-        ...projected,
-        revision: Math.max(sessionRevision(projected), sessionRevision(session))
-      }
+      projected = withAcknowledgedUnsavedTitle(
+        {
+          ...projected,
+          revision: Math.max(sessionRevision(projected), sessionRevision(session))
+        },
+        session
+      )
       markExternallyHydratedSession(projected, session)
       return {
         sessions: state.sessions.map((candidate) =>

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -1167,6 +1167,94 @@ describe('session store', () => {
     expect(useSessionStore.getState().sessions[0].title).toBe('Remote title')
   })
 
+  it('clears an unsaved title after a durable save acknowledgement even if the live Session advanced', () => {
+    useSessionStore.getState().hydrateSessions([
+      {
+        id: 'session-1',
+        projectId: 'project-1',
+        title: 'Original',
+        cwd: '/workspace',
+        status: 'idle',
+        revision: 1,
+        messages: [],
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ])
+    useSessionStore.getState().renameSession('session-1', 'Local draft')
+    const source = useSessionStore.getState().sessions[0]
+    useSessionStore.getState().togglePinned('session-1')
+    const live = useSessionStore.getState().sessions[0]
+    expect(live).not.toBe(source)
+    expect(live.unsavedTitle).toBe(true)
+
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: {
+        ...toPersistedSession(live),
+        title: 'Local draft',
+        revision: 2,
+        updatedAt: live.updatedAt + 1
+      },
+      mode: 'replace-persisted-if-current'
+    })
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      title: 'Local draft',
+      pinned: true
+    })
+    expect(useSessionStore.getState().sessions[0].unsavedTitle).toBeUndefined()
+
+    useSessionStore.getState().upsertPersistedSession({
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Remote later',
+      cwd: '/workspace',
+      status: 'idle',
+      revision: 3,
+      messages: [],
+      createdAt: 1,
+      updatedAt: Date.now() + 2
+    })
+    expect(useSessionStore.getState().sessions[0].title).toBe('Remote later')
+  })
+
+  it('keeps a newer unsaved title when a durable save acknowledgement is for the previous title', () => {
+    useSessionStore.getState().hydrateSessions([
+      {
+        id: 'session-1',
+        projectId: 'project-1',
+        title: 'Original',
+        cwd: '/workspace',
+        status: 'idle',
+        revision: 1,
+        messages: [],
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ])
+    useSessionStore.getState().renameSession('session-1', 'Local draft')
+    const source = useSessionStore.getState().sessions[0]
+    useSessionStore.getState().renameSession('session-1', 'Even newer')
+    expect(useSessionStore.getState().sessions[0]).not.toBe(source)
+
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: {
+        ...toPersistedSession(source),
+        title: 'Local draft',
+        revision: 2,
+        updatedAt: source.updatedAt + 1
+      },
+      mode: 'replace-persisted-if-current'
+    })
+
+    expect(useSessionStore.getState().sessions[0]).toMatchObject({
+      title: 'Even newer',
+      unsavedTitle: true
+    })
+  })
+
   it('merges a stale-timestamp child completion by durable identities without clearing root transient state', () => {
     const rootMessage = {
       id: 'root-message',

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -1167,6 +1167,83 @@ describe('session store', () => {
     expect(useSessionStore.getState().sessions[0].title).toBe('Remote title')
   })
 
+  it('does not mark a no-op rename as an unsaved title', () => {
+    useSessionStore.getState().hydrateSessions([
+      {
+        id: 'session-1',
+        projectId: 'project-1',
+        title: 'Original',
+        cwd: '/workspace',
+        status: 'idle',
+        revision: 1,
+        messages: [],
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ])
+    const before = useSessionStore.getState().sessions[0]
+    useSessionStore.getState().renameSession('session-1', '  Original  ')
+    expect(useSessionStore.getState().sessions[0]).toBe(before)
+    expect(useSessionStore.getState().sessions[0].unsavedTitle).toBeUndefined()
+
+    useSessionStore.getState().upsertPersistedSession({
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Remote title',
+      cwd: '/workspace',
+      status: 'idle',
+      revision: 2,
+      messages: [],
+      createdAt: 1,
+      updatedAt: Date.now() + 1
+    })
+    expect(useSessionStore.getState().sessions[0].title).toBe('Remote title')
+  })
+
+  it('clears an unsaved title when a newer remote projection already has the local title', () => {
+    useSessionStore.getState().hydrateSessions([
+      {
+        id: 'session-1',
+        projectId: 'project-1',
+        title: 'Original',
+        cwd: '/workspace',
+        status: 'idle',
+        revision: 1,
+        messages: [],
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ])
+    useSessionStore.getState().renameSession('session-1', 'Local draft')
+
+    useSessionStore.getState().upsertPersistedSession({
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Local draft',
+      cwd: '/workspace',
+      status: 'idle',
+      revision: 2,
+      messages: [],
+      createdAt: 1,
+      updatedAt: Date.now() + 1
+    })
+    expect(useSessionStore.getState().sessions[0].title).toBe('Local draft')
+    expect(useSessionStore.getState().sessions[0].unsavedTitle).toBeUndefined()
+
+    useSessionStore.getState().upsertPersistedSession({
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Remote later',
+      cwd: '/workspace',
+      status: 'idle',
+      revision: 3,
+      messages: [],
+      createdAt: 1,
+      updatedAt: Date.now() + 2
+    })
+    expect(useSessionStore.getState().sessions[0].title).toBe('Remote later')
+  })
+
   it('clears an unsaved title after a durable save acknowledgement even if the live Session advanced', () => {
     useSessionStore.getState().hydrateSessions([
       {

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -1066,6 +1066,107 @@ describe('session store', () => {
     })
   })
 
+  it('keeps an unsaved local title when a newer remote Session projection arrives', () => {
+    useSessionStore.getState().hydrateSessions([
+      {
+        id: 'session-1',
+        projectId: 'project-1',
+        title: 'Original',
+        cwd: '/workspace',
+        status: 'idle',
+        revision: 1,
+        messages: [
+          {
+            id: 'local-message',
+            role: 'user',
+            content: 'Keep this local message.',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ],
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ])
+    useSessionStore.getState().renameSession('session-1', 'Local draft')
+
+    useSessionStore.getState().upsertPersistedSession({
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Remote title',
+      cwd: '/workspace',
+      status: 'idle',
+      revision: 2,
+      pinned: true,
+      permissionProfile: 'full',
+      messages: [
+        {
+          id: 'local-message',
+          role: 'user',
+          content: 'Keep this local message.',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 1
+        },
+        {
+          id: 'remote-message',
+          role: 'agent',
+          content: 'Saved in another window',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 2,
+          updatedAt: 2
+        }
+      ],
+      createdAt: 1,
+      updatedAt: Date.now() + 1
+    })
+
+    const session = useSessionStore.getState().sessions[0]
+    expect(session).toMatchObject({
+      title: 'Local draft',
+      unsavedTitle: true,
+      pinned: true,
+      permissionProfile: 'full',
+      revision: 2,
+      messages: [{ id: 'local-message' }, { id: 'remote-message' }]
+    })
+    expect(toPersistedSession(session)).not.toHaveProperty('unsavedTitle')
+  })
+
+  it('applies a newer remote title when the local Session title was not renamed', () => {
+    useSessionStore.getState().hydrateSessions([
+      {
+        id: 'session-1',
+        projectId: 'project-1',
+        title: 'Original',
+        cwd: '/workspace',
+        status: 'idle',
+        revision: 1,
+        messages: [],
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ])
+
+    useSessionStore.getState().upsertPersistedSession({
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Remote title',
+      cwd: '/workspace',
+      status: 'idle',
+      revision: 2,
+      messages: [],
+      createdAt: 1,
+      updatedAt: Date.now() + 1
+    })
+
+    expect(useSessionStore.getState().sessions[0].title).toBe('Remote title')
+  })
+
   it('merges a stale-timestamp child completion by durable identities without clearing root transient state', () => {
     const rootMessage = {
       id: 'root-message',
@@ -4866,6 +4967,7 @@ describe('session store public contract', () => {
       sessions: state.sessions.map((session) => ({
         ...session,
         isPending: true,
+        unsavedTitle: true,
         interrupted: true,
         fixLoopActive: true,
         compacting: true,
@@ -4909,6 +5011,7 @@ describe('session store public contract', () => {
     expect(durable.messages[0]).not.toHaveProperty('sortIndex')
     for (const transientKey of [
       'isPending',
+      'unsavedTitle',
       'interrupted',
       'fixLoopActive',
       'compacting',

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -299,6 +299,7 @@ const createSessionStoreInitializer = (): StateCreator<SessionStore> => (set, ge
           ? {
               ...session,
               title: trimmedTitle,
+              unsavedTitle: true,
               updatedAt: Date.now()
             }
           : session

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -293,18 +293,20 @@ const createSessionStoreInitializer = (): StateCreator<SessionStore> => (set, ge
 
     if (!trimmedTitle) return
 
-    set((state) => ({
-      sessions: state.sessions.map((session) =>
-        session.id === sessionId
-          ? {
-              ...session,
-              title: trimmedTitle,
-              unsavedTitle: true,
-              updatedAt: Date.now()
-            }
-          : session
-      )
-    }))
+    set((state) => {
+      let changed = false
+      const sessions = state.sessions.map((session) => {
+        if (session.id !== sessionId || session.title === trimmedTitle) return session
+        changed = true
+        return {
+          ...session,
+          title: trimmedTitle,
+          unsavedTitle: true,
+          updatedAt: Date.now()
+        }
+      })
+      return changed ? { sessions } : state
+    })
   },
 
   // Removes a session and falls selection back to the next session within the same project.


### PR DESCRIPTION
## Problem

Client A can rename a Session in the renderer store before the ordered saver reaches disk. Client B's higher-revision `session:updated` still arrived through `upsertPersistedSession`, and `mergeNewerPersistedSessionByIdentity` started from `structuredClone(incoming)` for scalars.

A's unsaved title was replaced in the UI even though durable Session JSON already uses `expectedRevision` CAS. After the upsert, the session was marked externally hydrated, so the saver also skipped writing A's title.

```mermaid
sequenceDiagram
  participant A as Client A store
  participant S as Ordered saver
  participant M as Main JSON CAS
  participant B as Client B
  A->>A: renameSession Local draft
  B->>A: session:updated revision N+1 title Remote
  Note over A: upsert used to take Remote title
  A->>S: skipped as externally hydrated
  Note over M: disk still at B's revision, A's title never saved
```

This is renderer projection, not disk last-write-wins. Same product shape as `fix(settings): keep in-flight optimistic preferences across onChanged`: keep the local in-flight field, apply the rest of the snapshot.

## Proposed change

Keep the unsaved local title until the local save is acknowledged.

- `renameSession` sets a transient `unsavedTitle` flag that `toPersistedSession` strips.
- `upsertPersistedSession` still identity-merges the incoming snapshot (messages, graph, `pinned`, `permissionProfile`, …), then overlays only `title` when that flag is set.
- The ordered saver still acknowledges the remote revision, but if store title differs from the externally hydrated authority it enqueues a write with `conflictRebaseFields: ['title']`.
- A successful durable save acknowledgement clears the flag. A remote title still replaces local state when A did not rename.

Main `expectedRevision` CAS is unchanged.

## Scope and non-goals

**In this PR:** fence `upsertPersistedSession` for an unsaved local title only, and still persist that title after a newer remote projection.

**Not in this PR:**

- `pinned`, `permissionProfile`, `autoReviewEnabled`, and `agentConfiguration` remain incoming-wins
- Rename-dialog draft before confirm
- Overlapping `sendWorkspaceMessage`
- Settings `onChanged` (already shipped)
- R kernel cancel
- Main CAS / rebase policy
- Schema, migrations, or i18n

## Acceptance criteria and validation

- After `renameSession` to `Local draft`, a higher-revision upsert with title `Remote title` keeps `Local draft`, still merges remote messages, and still applies remote `pinned` / `permissionProfile`.
- `unsavedTitle` is not present on `toPersistedSession`.
- Without a local rename, a higher-revision remote title still replaces the store title.
- After rename then remote upsert, the ordered saver writes `{ title: 'Local draft', revision: 2 }` with `conflictRebaseFields: ['title']`, then clears `unsavedTitle`.
- Existing revision-conflict / CAS tests still pass.

These checks ran after the last material edit:

| Behavior | Command | Result |
|---|---|---|
| Unsaved title vs newer upsert | `npx vitest run src/renderer/src/stores/session-store.test.ts -t 'unsaved local title\|newer remote title'` | pass |
| Saver still writes title | `npx vitest run src/renderer/src/lib/session-persistence/session-persistence.test.ts -t 'unsaved local title'` | pass |
| Session store + architecture | `npx vitest run src/renderer/src/stores/session-store.test.ts src/renderer/src/stores/session-store.architecture.test.ts src/renderer/src/lib/session-persistence/session-persistence.test.ts` | pass (215) |
| Module | `npm run test:module -- session_renderer` | pass (466) |
| Durable CAS / lifecycle | `npx vitest run src/main/session-persistence/coordinator.test.ts src/main/session-persistence/coordinator-contract.test.ts src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx src/renderer/src/hooks/useLifecycleSync.test.tsx` | pass |
| Web typecheck | `npm run typecheck:web` | pass |
| Lint | `npm run lint` | pass |

**ACP:** renderer projection and saver only. `claude-code` / `opencode` / `codex-response` / `codex-bridge` excluded as Main mutex and Session JSON CAS already shared; no adapter change.

**Excluded:** live model output, E2E, packaging, database migrations, Web API map. No renderer contract catalog change. No visual UI component change, so no localhost Web walkthrough.

**Uncovered risk:** Main-owned `applyDurableSessionProjection` paths that replace persisted fields (for example continuation echo) still apply their snapshot title. That is not the other-client `upsertPersistedSession` seam.

## Review focus

- Whether overlaying title after identity merge in `upsertPersistedSession` is the right owner, versus teaching the merge helper itself.
- That `unsavedTitle` stays transient and never reaches Session JSON.
- That the saver still acknowledges the remote revision and only extra-writes when the store title differs from that authority.