### PR TITLE
fix(renderer-errors): localize unexpected action failures

### DIFF
--- a/src/renderer/src/components/diagnostic-details.tsx
+++ b/src/renderer/src/components/diagnostic-details.tsx
@@ -1,0 +1,19 @@
+import { useTranslation } from 'react-i18next'
+
+const DiagnosticDetails = ({ detail }: { detail?: string }): React.JSX.Element | null => {
+  const { t } = useTranslation()
+  if (!detail?.trim()) return null
+
+  return (
+    <details className="mt-1 text-xs text-muted-foreground">
+      <summary className="w-fit cursor-pointer select-none hover:text-foreground">
+        {t('Details')}
+      </summary>
+      <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted/60 px-2 py-1.5 font-mono text-[11px] leading-4 text-muted-foreground">
+        {detail}
+      </pre>
+    </details>
+  )
+}
+
+export { DiagnosticDetails }

--- a/src/renderer/src/lib/error-detail.ts
+++ b/src/renderer/src/lib/error-detail.ts
@@ -1,0 +1,4 @@
+const errorDetail = (error: unknown): string | undefined =>
+  error instanceof Error ? error.message : typeof error === 'string' ? error : undefined
+
+export { errorDetail }

--- a/src/renderer/src/locales/fr.json
+++ b/src/renderer/src/locales/fr.json
@@ -576,7 +576,7 @@
   "Could not update project pin.": "Impossible de mettre à jour le code PIN du projet.",
   "Could not update the command-line tool.": "Impossible de mettre à jour l'outil de ligne de commande.",
   "Couldn't fetch models: {{reason}}. Using the bundled list.": "Impossible de récupérer les modèles : {{reason}}. Utilisation de la liste groupée.",
-  "Couldn't load hosts: {{message}}": "Impossible de charger les hôtes : {{message}}",
+  "Couldn't load hosts.": "Impossible de charger les hôtes.",
   "Create a project to search sessions and artifacts.": "Créez un projet pour rechercher des sessions et des artefacts.",
   "Create a skill to teach Claude a workflow you use.": "Créez une compétence pour enseigner à Claude un flux de travail que vous utilisez.",
   "Create agent": "Créer un agent",

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -541,7 +541,7 @@
   "Could not update project pin.": "プロジェクト ピンを更新できませんでした。",
   "Could not update the command-line tool.": "コマンドライン ツールを更新できませんでした。",
   "Couldn't fetch models: {{reason}}. Using the bundled list.": "モデルを取得できませんでした：{{reason}}。バンドルリストを使用します。",
-  "Couldn't load hosts: {{message}}": "ホストを読み込めませんでした：{{message}}",
+  "Couldn't load hosts.": "ホストを読み込めませんでした。",
   "Create a project to search sessions and artifacts.": "セッションとアーティファクトを検索するプロジェクトを作成します。",
   "Create a skill to teach Claude a workflow you use.": "スキルを作成して、使用するワークフローを Claude に教えます。",
   "Create agent": "エージェントを作成",

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -560,7 +560,7 @@
   "Could not update project pin.": "프로젝트 고정을 업데이트할 수 없습니다.",
   "Could not update the command-line tool.": "명령줄 도구를 업데이트할 수 없습니다.",
   "Couldn't fetch models: {{reason}}. Using the bundled list.": "모델을 가져올 수 없습니다: {{reason}}. 번들 목록을 사용합니다.",
-  "Couldn't load hosts: {{message}}": "호스트를 로드할 수 없습니다: {{message}}",
+  "Couldn't load hosts.": "호스트를 로드할 수 없습니다.",
   "Create a project to search sessions and artifacts.": "프로젝트를 만들어 세션 및 아티팩트를 검색하세요.",
   "Create a skill to teach Claude a workflow you use.": "스킬을 만들어 사용하는 작업 흐름을 Claude에 가르치세요.",
   "Create agent": "에이전트 만들기",

--- a/src/renderer/src/locales/ru.json
+++ b/src/renderer/src/locales/ru.json
@@ -564,7 +564,7 @@
   "Could not update project pin.": "Не удалось изменить закрепление проекта.",
   "Could not update the command-line tool.": "Не удалось обновить инструмент командной строки.",
   "Couldn't fetch models: {{reason}}. Using the bundled list.": "Не удалось загрузить модели: {{reason}}. Используется встроенный список.",
-  "Couldn't load hosts: {{message}}": "Не удалось загрузить хосты: {{message}}",
+  "Couldn't load hosts.": "Не удалось загрузить хосты.",
   "Create a project to search sessions and artifacts.": "Создайте проект, чтобы искать сессии и артефакты.",
   "Create a skill to teach Claude a workflow you use.": "Создайте навык, чтобы научить Claude работе с рабочим процессом, который вы используете.",
   "Create agent": "Создать агента",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -612,7 +612,7 @@
   "Could not update project pin.": "无法更新项目置顶状态。",
   "Could not update the command-line tool.": "无法更新命令行工具。",
   "Couldn't fetch models: {{reason}}. Using the bundled list.": "无法获取模型：{{reason}}。将使用内置列表。",
-  "Couldn't load hosts: {{message}}": "无法加载主机：{{message}}",
+  "Couldn't load hosts.": "无法加载主机。",
   "Create a project to search sessions and artifacts.": "新建一个项目，即可搜索会话和产物。",
   "Create a skill to teach Claude a workflow you use.": "创建一个技能，把你常用的流程教给 Claude。",
   "Create agent": "创建智能体",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -611,7 +611,7 @@
   "Could not update project pin.": "無法更新專案置頂狀態。",
   "Could not update the command-line tool.": "無法更新命令列工具。",
   "Couldn't fetch models: {{reason}}. Using the bundled list.": "無法取得模型：{{reason}}。將使用內建清單。",
-  "Couldn't load hosts: {{message}}": "無法載入主機：{{message}}",
+  "Couldn't load hosts.": "無法載入主機。",
   "Create a project to search sessions and artifacts.": "新增一個專案，即可搜尋會話和產物。",
   "Create a skill to teach Claude a workflow you use.": "建立一個技能，把你常用的流程教給 Claude。",
   "Create agent": "建立智能體",

--- a/src/renderer/src/pages/settings/ComputePanel.tsx
+++ b/src/renderer/src/pages/settings/ComputePanel.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import type { ComputeHost } from '../../../../shared/compute'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { DiagnosticDetails } from '@/components/diagnostic-details'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { consumeComputeHostsPreload, useComputeStore } from '@/stores/compute-store'
@@ -205,9 +206,12 @@ export function ComputePanel({ onNavigate }: ComputePanelProps): React.JSX.Eleme
 
       <div className="mt-4 flex flex-col gap-2.5">
         {loadError ? (
-          <p className="rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive">
-            {t("Couldn't load hosts: {{message}}", { message: loadError })}
-          </p>
+          <div className="rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2">
+            <p className="text-sm text-destructive" role="alert">
+              {t("Couldn't load hosts.")}
+            </p>
+            <DiagnosticDetails detail={loadError} />
+          </div>
         ) : !isLoaded ? (
           <p className="py-6 text-center text-sm text-muted-foreground">{t('Loading hosts…')}</p>
         ) : hosts.length === 0 ? (

--- a/src/renderer/src/pages/settings/GeneralPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/GeneralPanel.render.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useUpdateStore } from '@/stores/update-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import { useThemeStore } from '@/stores/theme-store'
+import { i18next } from '@/i18n'
 import { GeneralPanel } from './GeneralPanel'
 
 vi.mock('@/assets/logo.png', () => ({ default: 'logo.png' }))
@@ -46,7 +47,14 @@ const flush = async (): Promise<void> => {
   })
 }
 
+const switchTo = (language: string): void => {
+  act(() => {
+    void i18next.changeLanguage(language)
+  })
+}
+
 beforeEach(() => {
+  switchTo('en')
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -120,6 +128,7 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root.unmount())
   container.remove()
+  switchTo('en')
   vi.restoreAllMocks()
 })
 
@@ -168,6 +177,25 @@ describe('GeneralPanel command line tool', () => {
 
     expect(cliApi.uninstall).toHaveBeenCalledTimes(1)
     expect(findButton(/install command/i)).toBeDefined()
+  })
+
+  it('localizes a CLI failure and keeps the backend message in collapsed details', async () => {
+    cliApi.install.mockRejectedValue(
+      new Error('spawn /private/bin/open-science failed with EACCES')
+    )
+
+    await act(async () => root.render(<GeneralPanel />))
+    await flush()
+    await act(async () => findButton(/install command/i)?.click())
+    await flush()
+    switchTo('zh-Hans')
+
+    const alert = container.querySelector('[role="alert"]')
+    expect(alert?.textContent).toBe('无法更新命令行工具。')
+    expect(alert?.textContent).not.toContain('/private/bin/open-science')
+    const details = container.querySelector('details')
+    expect(details?.open).toBe(false)
+    expect(details?.textContent).toContain('/private/bin/open-science')
   })
 })
 

--- a/src/renderer/src/pages/settings/GeneralPanel.tsx
+++ b/src/renderer/src/pages/settings/GeneralPanel.tsx
@@ -1,13 +1,16 @@
 import { ExternalLink, FolderOpen, Globe, Terminal } from 'lucide-react'
+import type { TFunction } from 'i18next'
 import { useEffect, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
 import { ExternalTextLink } from '@/components/ExternalTextLink'
+import { DiagnosticDetails } from '@/components/diagnostic-details'
 import { LanguageSelect } from '@/components/LanguageControls'
 import { ThemeSegmentedControl } from '@/components/ThemeControls'
 import { GitHubStarBadge } from '@/components/GitHubStarBadge'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
+import { errorDetail } from '@/lib/error-detail'
 import { useSettingsStore } from '@/stores/settings-store'
 import type { CloseActionPreference } from '../../../../shared/window-controls'
 import type { CliLauncherStatus } from '../../../../shared/cli'
@@ -20,6 +23,22 @@ import { SettingsRow, SettingsSection, SettingsToggle } from './SettingsLayout'
 // set of "connect with the project" actions.
 const socialLinkClassName =
   'inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-card px-2 text-xs font-medium text-muted-foreground transition-colors duration-150 motion-reduce:transition-none hover:bg-muted hover:text-foreground'
+
+type GeneralActionError = {
+  action: 'cli' | 'open-log' | 'reveal-log'
+  detail?: string
+}
+
+const generalActionErrorCopy = (error: GeneralActionError, t: TFunction): string => {
+  switch (error.action) {
+    case 'cli':
+      return t('Could not update the command-line tool.')
+    case 'open-log':
+      return t('Could not open the log file.')
+    case 'reveal-log':
+      return t('Could not reveal the log file.')
+  }
+}
 
 // Discord and X are brand marks that lucide-react dropped in v1, so we inline the official SVGs.
 // currentColor lets them inherit the link's text color like the other icons.
@@ -41,11 +60,11 @@ const GeneralPanel = (): React.JSX.Element => {
   const { t } = useTranslation()
   const isMac = window.api.platform === 'darwin'
   const [logPath, setLogPath] = useState<string | null>(null)
-  const [message, setMessage] = useState<string | undefined>(undefined)
+  const [message, setMessage] = useState<GeneralActionError | undefined>(undefined)
   const [isOpening, setIsOpening] = useState(false)
   const [cli, setCli] = useState<CliLauncherStatus | null>(null)
   const [isUpdatingCli, setIsUpdatingCli] = useState(false)
-  const [cliError, setCliError] = useState<string | undefined>(undefined)
+  const [cliError, setCliError] = useState<GeneralActionError | undefined>(undefined)
   const notificationsEnabled = useSettingsStore((state) => state.notificationsEnabled)
   const setNotificationsEnabled = useSettingsStore((state) => state.setNotificationsEnabled)
   const closePreference = useSettingsStore((state) => state.closePreference)
@@ -65,9 +84,7 @@ const GeneralPanel = (): React.JSX.Element => {
         action === 'install' ? await window.api.cli.install() : await window.api.cli.uninstall()
       )
     } catch (error) {
-      setCliError(
-        error instanceof Error ? error.message : 'Could not update the command-line tool.'
-      )
+      setCliError({ action: 'cli', detail: errorDetail(error) })
     } finally {
       setIsUpdatingCli(false)
     }
@@ -81,10 +98,10 @@ const GeneralPanel = (): React.JSX.Element => {
       const result = await window.api.logs.openFile()
 
       if (!result.opened) {
-        setMessage(result.error ?? 'Could not open the log file.')
+        setMessage({ action: 'open-log', detail: result.error })
       }
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : 'Could not open the log file.')
+      setMessage({ action: 'open-log', detail: errorDetail(error) })
     } finally {
       setIsOpening(false)
     }
@@ -97,10 +114,10 @@ const GeneralPanel = (): React.JSX.Element => {
       const result = await window.api.logs.revealInFolder()
 
       if (!result.revealed) {
-        setMessage(result.error ?? 'Could not reveal the log file.')
+        setMessage({ action: 'reveal-log', detail: result.error })
       }
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : 'Could not reveal the log file.')
+      setMessage({ action: 'reveal-log', detail: errorDetail(error) })
     }
   }
 
@@ -267,9 +284,12 @@ const GeneralPanel = (): React.JSX.Element => {
         </pre>
 
         {message ? (
-          <p className="mt-2 text-xs text-destructive" role="alert">
-            {t(message)}
-          </p>
+          <div className="mt-2">
+            <p className="text-xs text-destructive" role="alert">
+              {generalActionErrorCopy(message, t)}
+            </p>
+            <DiagnosticDetails detail={message.detail} />
+          </div>
         ) : null}
 
         <p className="mt-3 text-xs text-muted-foreground">
@@ -331,9 +351,12 @@ const GeneralPanel = (): React.JSX.Element => {
         ) : null}
 
         {cliError ? (
-          <p className="mt-2 text-xs text-destructive" role="alert">
-            {t(cliError)}
-          </p>
+          <div className="mt-2">
+            <p className="text-xs text-destructive" role="alert">
+              {generalActionErrorCopy(cliError, t)}
+            </p>
+            <DiagnosticDetails detail={cliError.detail} />
+          </div>
         ) : null}
 
         <p className="mt-3 text-xs text-muted-foreground">

--- a/src/renderer/src/pages/settings/GitHubTokenControl.test.tsx
+++ b/src/renderer/src/pages/settings/GitHubTokenControl.test.tsx
@@ -120,6 +120,30 @@ describe('GitHubTokenControl', () => {
     expect(document.body.querySelector('[role="alert"]')).not.toBeNull()
   })
 
+  it('localizes a token verification failure instead of displaying backend error details', async () => {
+    settingsApi.getGitHubTokenStatus.mockResolvedValue({ configured: true, mask: 'old…oken' })
+    settingsApi.saveGitHubToken.mockRejectedValue(
+      new Error('GitHub rejected this token. Check that it is valid and try again.')
+    )
+    await act(async () => root.render(<GitHubTokenControl />))
+    await flush()
+
+    await click('GitHub token')
+    enterToken('bad-token')
+    await click('Verify and save')
+    await flush()
+
+    await act(async () => i18next.changeLanguage('zh-Hans'))
+    const alert = document.body.querySelector('[role="alert"]')?.textContent
+    const details = document.body.querySelector('details')
+    await act(async () => i18next.changeLanguage('en'))
+
+    expect(alert).toContain('令牌验证失败。')
+    expect(alert).not.toContain('GitHub rejected this token.')
+    expect(details?.open).toBe(false)
+    expect(details?.textContent).toContain('GitHub rejected this token.')
+  })
+
   it('removes a configured token and exposes the success state', async () => {
     settingsApi.getGitHubTokenStatus.mockResolvedValue({ configured: true, mask: 'old…oken' })
     settingsApi.removeGitHubToken.mockResolvedValue({ configured: false })

--- a/src/renderer/src/pages/settings/GitHubTokenControl.tsx
+++ b/src/renderer/src/pages/settings/GitHubTokenControl.tsx
@@ -1,16 +1,36 @@
 /* Hallmark · component: credential disclosure · genre: modern-minimal · theme: existing Settings system */
 /* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4 */
+import type { TFunction } from 'i18next'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AlertTriangle, CheckCircle2, KeyRound, LoaderCircle } from 'lucide-react'
 
 import type { GitHubTokenStatus } from '../../../../shared/settings'
+import { DiagnosticDetails } from '@/components/diagnostic-details'
 import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { errorDetail } from '@/lib/error-detail'
 
-type Feedback = { kind: 'error' | 'success'; text: string; suffix?: string }
+type Feedback =
+  | { kind: 'success'; action: 'saved' | 'removed' }
+  | { kind: 'error'; action: 'status' | 'verify' | 'remove'; detail?: string }
 type Availability = 'checking' | 'available' | 'unavailable'
+
+const feedbackCopy = (feedback: Feedback, t: TFunction): string => {
+  switch (feedback.action) {
+    case 'saved':
+      return t('Token verified and saved.')
+    case 'removed':
+      return t('Saved token removed.')
+    case 'status':
+      return t('Could not read GitHub token status.')
+    case 'verify':
+      return `${t('Token verification failed.')} ${t('Your saved token was not changed.')}`
+    case 'remove':
+      return t('Could not remove the saved token.')
+  }
+}
 
 const isLocalOnlyActionError = (error: unknown): boolean =>
   error instanceof Error && error.message.includes('only available in the local desktop app')
@@ -43,7 +63,8 @@ const GitHubTokenControl = (): React.JSX.Element | null => {
         setAvailability('available')
         setFeedback({
           kind: 'error',
-          text: error instanceof Error ? error.message : 'Could not read GitHub token status.'
+          action: 'status',
+          detail: errorDetail(error)
         })
       })
       .finally(() => {
@@ -63,13 +84,12 @@ const GitHubTokenControl = (): React.JSX.Element | null => {
       const next = await window.api.settings.saveGitHubToken({ token: candidate })
       setStatus(next)
       setToken('')
-      setFeedback({ kind: 'success', text: 'Token verified and saved.' })
+      setFeedback({ kind: 'success', action: 'saved' })
     } catch (error) {
-      const detail = error instanceof Error ? error.message : 'Token verification failed.'
       setFeedback({
         kind: 'error',
-        text: detail,
-        suffix: 'Your saved token was not changed.'
+        action: 'verify',
+        detail: errorDetail(error)
       })
     } finally {
       setBusy(null)
@@ -83,11 +103,12 @@ const GitHubTokenControl = (): React.JSX.Element | null => {
     try {
       setStatus(await window.api.settings.removeGitHubToken())
       setToken('')
-      setFeedback({ kind: 'success', text: 'Saved token removed.' })
+      setFeedback({ kind: 'success', action: 'removed' })
     } catch (error) {
       setFeedback({
         kind: 'error',
-        text: error instanceof Error ? error.message : 'Could not remove the saved token.'
+        action: 'remove',
+        detail: errorDetail(error)
       })
     } finally {
       setBusy(null)
@@ -194,26 +215,27 @@ const GitHubTokenControl = (): React.JSX.Element | null => {
             </div>
           </div>
 
-          <div id="github-token-feedback" className="mt-2 min-h-5">
+          <div className="mt-2 min-h-5">
             {feedback ? (
-              <div
-                role={feedback.kind === 'error' ? 'alert' : 'status'}
-                className={`flex items-start gap-2 text-xs ${
-                  feedback.kind === 'error' ? 'text-danger-000' : 'text-primary'
-                }`}
-              >
-                {feedback.kind === 'error' ? (
-                  <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
-                ) : (
-                  <CheckCircle2 className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
-                )}
-                <p>
-                  {t(feedback.text)}
-                  {feedback.suffix ? ` ${t(feedback.suffix)}` : null}
-                </p>
-              </div>
+              <>
+                <div
+                  id="github-token-feedback"
+                  role={feedback.kind === 'error' ? 'alert' : 'status'}
+                  className={`flex items-start gap-2 text-xs ${
+                    feedback.kind === 'error' ? 'text-danger-000' : 'text-primary'
+                  }`}
+                >
+                  {feedback.kind === 'error' ? (
+                    <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+                  ) : (
+                    <CheckCircle2 className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+                  )}
+                  <p>{feedbackCopy(feedback, t)}</p>
+                </div>
+                {feedback.kind === 'error' ? <DiagnosticDetails detail={feedback.detail} /> : null}
+              </>
             ) : status?.configured ? (
-              <p className="text-xs text-muted-foreground">
+              <p id="github-token-feedback" className="text-xs text-muted-foreground">
                 {t('Saved token:')} {status.mask}
               </p>
             ) : null}

--- a/src/renderer/src/pages/settings/ProvidersPanel.race.test.tsx
+++ b/src/renderer/src/pages/settings/ProvidersPanel.race.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { i18next } from '@/i18n'
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
 import { ProvidersPanel } from './ProvidersPanel'
 
@@ -11,7 +12,14 @@ import { ProvidersPanel } from './ProvidersPanel'
 let container: HTMLDivElement
 let root: Root
 
+const switchTo = (language: string): void => {
+  act(() => {
+    void i18next.changeLanguage(language)
+  })
+}
+
 beforeEach(() => {
+  switchTo('en')
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
@@ -38,6 +46,7 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root.unmount())
   container.remove()
+  switchTo('en')
   vi.restoreAllMocks()
 })
 
@@ -52,6 +61,33 @@ const render = (): void => {
     )
   })
 }
+
+describe('ProvidersPanel: unexpected command failures', () => {
+  it('localizes a connection-test failure and keeps transport details out of the alert', async () => {
+    useSettingsStore.setState({
+      ...useSettingsStore.getState(),
+      validateProvider: vi
+        .fn()
+        .mockRejectedValue(
+          new Error('provider transport failed at /private/provider.sock')
+        ) as never
+    })
+    render()
+
+    const testConnection = document.body.querySelector<HTMLButtonElement>(
+      '[aria-label="Test connection"]'
+    )
+    await act(async () => testConnection?.click())
+    switchTo('zh-Hans')
+
+    const alert = container.querySelector('[role="alert"]')
+    expect(alert?.textContent).toBe('无法测试模型服务商连接。')
+    expect(alert?.textContent).not.toContain('/private/provider.sock')
+    const details = container.querySelector('details')
+    expect(details?.open).toBe(false)
+    expect(details?.textContent).toContain('/private/provider.sock')
+  })
+})
 
 describe('ProvidersPanel: claude-isolated browser + paste race', () => {
   it('suppresses the cancel error when the user explicitly cancels the browser sign-in', async () => {

--- a/src/renderer/src/pages/settings/ProvidersPanel.tsx
+++ b/src/renderer/src/pages/settings/ProvidersPanel.tsx
@@ -1,3 +1,4 @@
+import type { TFunction } from 'i18next'
 import { useEffect, useRef, useState } from 'react'
 import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -9,6 +10,8 @@ import type {
   XaiOAuthDeviceAuthorization
 } from '../../../../shared/settings'
 import { isCodexSubscriptionProvider } from '../../../../shared/settings'
+import { DiagnosticDetails } from '@/components/diagnostic-details'
+import { errorDetail } from '@/lib/error-detail'
 import { ActiveModelSelect } from './ActiveModelSelect'
 import { ProviderList } from './ProviderList'
 import { ReasoningEffortSelect } from './ReasoningEffortSelect'
@@ -26,6 +29,50 @@ type ProvidersPanelProps = {
   // the owner lives in SettingsPage and is passed down.
   busyProviderId?: string
   onBusyProviderChange: (providerId: string | undefined) => void
+}
+
+type ProviderActionError = {
+  action:
+    | 'test'
+    | 'codex-sign-in'
+    | 'codex-sign-out'
+    | 'codex-reimport'
+    | 'claude-token-save'
+    | 'claude-sign-in'
+    | 'claude-sign-out'
+    | 'claude-disconnect'
+    | 'xai-sign-in'
+    | 'xai-sign-out'
+  detail?: string
+}
+
+type ProviderPanelError = string | ProviderActionError
+
+const providerErrorCopy = (error: ProviderPanelError, t: TFunction): string => {
+  if (typeof error === 'string') return error
+
+  switch (error.action) {
+    case 'test':
+      return t('Could not test the provider connection.')
+    case 'codex-sign-in':
+      return t('Could not sign in to Codex.')
+    case 'codex-sign-out':
+      return t('Could not sign out of Codex.')
+    case 'codex-reimport':
+      return t('Could not re-import the Codex login.')
+    case 'claude-token-save':
+      return t('Could not save the Claude token.')
+    case 'claude-sign-in':
+      return t('Could not sign in to Claude.')
+    case 'claude-sign-out':
+      return t('Could not sign out of Claude.')
+    case 'claude-disconnect':
+      return t('Could not disconnect Claude from Open Science.')
+    case 'xai-sign-in':
+      return t('Could not sign in to xAI.')
+    case 'xai-sign-out':
+      return t('Could not sign out of xAI.')
+  }
 }
 
 // The Model settings panel: active-model selection, reasoning effort, and the provider list with
@@ -63,7 +110,9 @@ const ProvidersPanel = ({
   const logoutXaiOAuth = useSettingsStore((state) => state.logoutXaiOAuth)
 
   // The last connection-test/sign-in failure, shown as an error line under the list.
-  const [providerTestError, setProviderTestError] = useState<string | undefined>(undefined)
+  const [providerTestError, setProviderTestError] = useState<ProviderPanelError | undefined>(
+    undefined
+  )
   // True while the explicit isolated Codex sign-in is open in the browser; drives the cancel action.
   const [isCodexLoginPending, setIsCodexLoginPending] = useState(false)
   // True while the explicit shared Claude sign-in is open in the browser.
@@ -146,9 +195,7 @@ const ProvidersPanel = ({
       // separate status line.
       await validateProvider({ providerId: provider.id })
     } catch (error) {
-      setProviderTestError(
-        error instanceof Error ? error.message : t('Could not test the provider connection.')
-      )
+      setProviderTestError({ action: 'test', detail: errorDetail(error) })
     } finally {
       onBusyProviderChange(undefined)
     }
@@ -164,9 +211,7 @@ const ProvidersPanel = ({
     try {
       await loginIsolatedCodex()
     } catch (error) {
-      setProviderTestError(
-        error instanceof Error ? error.message : t('Could not sign in to Codex.')
-      )
+      setProviderTestError({ action: 'codex-sign-in', detail: errorDetail(error) })
     } finally {
       setIsCodexLoginPending(false)
     }
@@ -183,9 +228,7 @@ const ProvidersPanel = ({
         setProviderTestError(result.message ?? t('Codex sign-out did not complete. Try again.'))
       }
     } catch (error) {
-      setProviderTestError(
-        error instanceof Error ? error.message : t('Could not sign out of Codex.')
-      )
+      setProviderTestError({ action: 'codex-sign-out', detail: errorDetail(error) })
     }
   }
 
@@ -203,9 +246,7 @@ const ProvidersPanel = ({
         reimportCodexAuthentication: true
       })
     } catch (error) {
-      setProviderTestError(
-        error instanceof Error ? error.message : t('Could not re-import the Codex login.')
-      )
+      setProviderTestError({ action: 'codex-reimport', detail: errorDetail(error) })
     } finally {
       onBusyProviderChange(undefined)
     }
@@ -232,9 +273,7 @@ const ProvidersPanel = ({
 
       return result
     } catch (error) {
-      setProviderTestError(
-        error instanceof Error ? error.message : t('Could not save the Claude token.')
-      )
+      setProviderTestError({ action: 'claude-token-save', detail: errorDetail(error) })
 
       return undefined
     }
@@ -268,9 +307,7 @@ const ProvidersPanel = ({
       }
     } catch (error) {
       if (manualClaudePasteWonRef.current) return
-      setProviderTestError(
-        error instanceof Error ? error.message : t('Could not sign in to Claude.')
-      )
+      setProviderTestError({ action: 'claude-sign-in', detail: errorDetail(error) })
     } finally {
       setIsClaudeIsolatedLoginPending(false)
     }
@@ -285,9 +322,7 @@ const ProvidersPanel = ({
         setProviderTestError(result.message ?? t('Claude sign-out did not complete. Try again.'))
       }
     } catch (error) {
-      setProviderTestError(
-        error instanceof Error ? error.message : t('Could not sign out of Claude.')
-      )
+      setProviderTestError({ action: 'claude-sign-out', detail: errorDetail(error) })
     }
   }
 
@@ -302,9 +337,7 @@ const ProvidersPanel = ({
         setProviderTestError(result.message ?? t('Could not sign in to Claude. Try again.'))
       }
     } catch (error) {
-      setProviderTestError(
-        error instanceof Error ? error.message : t('Could not sign in to Claude.')
-      )
+      setProviderTestError({ action: 'claude-sign-in', detail: errorDetail(error) })
     } finally {
       setIsClaudeSharedLoginPending(false)
     }
@@ -319,9 +352,7 @@ const ProvidersPanel = ({
         setProviderTestError(result.message ?? t('Could not disconnect Claude from Open Science.'))
       }
     } catch (error) {
-      setProviderTestError(
-        error instanceof Error ? error.message : t('Could not disconnect Claude from Open Science.')
-      )
+      setProviderTestError({ action: 'claude-disconnect', detail: errorDetail(error) })
     }
   }
 
@@ -339,7 +370,7 @@ const ProvidersPanel = ({
       setXaiSession(undefined)
     } catch (error) {
       if (xaiLoginCancelledRef.current) return
-      setProviderTestError(error instanceof Error ? error.message : t('Could not sign in to xAI.'))
+      setProviderTestError({ action: 'xai-sign-in', detail: errorDetail(error) })
     } finally {
       isXaiLoginPendingRef.current = false
       setIsXaiLoginPending(false)
@@ -359,7 +390,7 @@ const ProvidersPanel = ({
     try {
       await logoutXaiOAuth()
     } catch (error) {
-      setProviderTestError(error instanceof Error ? error.message : t('Could not sign out of xAI.'))
+      setProviderTestError({ action: 'xai-sign-out', detail: errorDetail(error) })
     }
   }
 
@@ -466,9 +497,14 @@ const ProvidersPanel = ({
           onLogoutXai={() => void handleXaiLogout()}
         />
         {providerTestError ? (
-          <p className="mt-2 text-sm text-destructive" role="alert">
-            {providerTestError}
-          </p>
+          <div className="mt-2">
+            <p className="text-sm text-destructive" role="alert">
+              {providerErrorCopy(providerTestError, t)}
+            </p>
+            <DiagnosticDetails
+              detail={typeof providerTestError === 'string' ? undefined : providerTestError.detail}
+            />
+          </div>
         ) : null}
         {/* The add action lives with the list: a dashed ghost row appended after the last provider,
             matching the Available-group placeholder treatment. */}
@@ -492,7 +528,7 @@ const ProvidersPanel = ({
       <XaiOAuthSignInDialog
         open={Boolean(xaiSession)}
         session={xaiSession}
-        error={providerTestError}
+        error={providerTestError ? providerErrorCopy(providerTestError, t) : undefined}
         onCancel={handleCancelXaiLogin}
       />
     </div>

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -4096,7 +4096,7 @@ describe('SettingsPage Codex framework', () => {
     expect(errorAlert?.textContent).toBe('Codex sign-out timed out.')
   })
 
-  it('shows Codex login-check IPC failures instead of leaving an unhandled rejection', async () => {
+  it('summarizes Codex login-check IPC failures and keeps their diagnostics available', async () => {
     const api = (window as unknown as { api: { settings: Record<string, unknown> } }).api
     const provider = {
       id: 'builtin-codex-subscription',
@@ -4138,7 +4138,12 @@ describe('SettingsPage Codex framework', () => {
     )
     await act(async () => testLogin?.click())
 
-    expect(document.body.querySelector('[role="alert"]')?.textContent).toContain(
+    expect(document.body.querySelector('[role="alert"]')?.textContent).toBe(
+      'Could not test the provider connection.'
+    )
+    const details = document.body.querySelector('details')
+    expect(details?.open).toBe(false)
+    expect(details?.textContent).toContain(
       'The Codex adapter does not support authentication status.'
     )
   })
@@ -4184,7 +4189,7 @@ describe('SettingsPage Codex framework', () => {
     expect(api.settings.cancelCodexLogin).toHaveBeenCalledOnce()
   })
 
-  it('surfaces isolated sign-in failures instead of leaving an unhandled rejection', async () => {
+  it('summarizes isolated sign-in failures and keeps their diagnostics available', async () => {
     const api = (window as unknown as { api: { settings: Record<string, unknown> } }).api
     const provider = {
       id: 'builtin-codex-subscription',
@@ -4217,8 +4222,11 @@ describe('SettingsPage Codex framework', () => {
     const signIn = document.body.querySelector<HTMLButtonElement>('[aria-label="Sign in"]')
     await act(async () => signIn?.click())
 
-    expect(document.body.querySelector('[role="alert"]')?.textContent).toContain(
-      'The Codex adapter failed to spawn.'
+    expect(document.body.querySelector('[role="alert"]')?.textContent).toBe(
+      'Could not sign in to Codex.'
     )
+    const details = document.body.querySelector('details')
+    expect(details?.open).toBe(false)
+    expect(details?.textContent).toContain('The Codex adapter failed to spawn.')
   })
 })

--- a/src/renderer/src/pages/settings/compute-i18n.render.test.tsx
+++ b/src/renderer/src/pages/settings/compute-i18n.render.test.tsx
@@ -142,6 +142,23 @@ describe('ComputePanel i18n', () => {
     expect(container.textContent).not.toContain('{{')
   })
 
+  it('localizes a host-list failure and keeps backend details out of the primary error', () => {
+    useComputeStore.setState({
+      loadError: 'SQLITE_BUSY while reading /private/data/compute.db',
+      isLoaded: true
+    })
+    act(() => root.render(<ComputePanel onNavigate={vi.fn()} />))
+
+    switchTo('zh-Hans')
+
+    const primary = container.querySelector('.text-destructive')
+    expect(primary?.textContent).toBe('无法加载主机。')
+    expect(primary?.textContent).not.toContain('/private/data/compute.db')
+    const details = container.querySelector('details')
+    expect(details?.open).toBe(false)
+    expect(details?.textContent).toContain('/private/data/compute.db')
+  })
+
   it('re-renders the removal toast in the language active at render time', async () => {
     const deleteHost = vi.fn(() => Promise.resolve())
     useComputeStore.setState({ hosts: [host()], isLoaded: true, deleteHost })


### PR DESCRIPTION
## Problem

Several renderer error surfaces used arbitrary main-process `Error.message` values as display copy or dynamic i18n keys. Those strings are outside the six locale catalogs, can remain English after a language change, and can place local paths or backend diagnostics directly in `role="alert"` regions.

The new public-boundary regression tests were run before the fix and failed consistently because the primary error UI contained the injected CLI path, GitHub backend response, Provider socket path, and Compute database path.

## Proposed change

- render static, catalog-owned summaries for unexpected Compute, General, GitHub token, and Provider action failures
- keep raw backend diagnostics available in a shared, collapsed native `details` disclosure outside the alert/live region
- preserve intentional Provider result messages as primary copy; only thrown infrastructure/IPC failures use the generic localized summary
- replace the interpolated Compute host-load catalog key in all six translated locales

## Scope and non-goals

- This is a bounded renderer presentation fix, not a global error-envelope migration.
- No IPC fields or shared data model changed.
- No persisted data, database schema, settings format, or migration changed; historical compatibility is unaffected.
- No shared enum was added. The only new action variants are component-local, ephemeral renderer state used to select static copy.
- Startup, Storage, Notebook, and file-operation surfaces are intentionally left for follow-up work after this pattern is reviewed.

## Acceptance criteria and validation

All listed checks ran against the final material state:

- localized summary + collapsed diagnostics across Settings consumers -> `npx vitest run src/renderer/src/pages/settings` -> 78 files passed, 863 tests passed
- six-locale catalog and static-call integrity -> `npx vitest run src/renderer/src/i18n/resources.test.ts` -> 1 file passed, 590 tests passed
- renderer TypeScript contracts -> `npm run typecheck:web` -> passed
- lint and Fast Refresh constraints -> `npm run lint` -> passed

The repository impact classifier conservatively selected the full fallback because the new shared renderer component has no module owner entry. Per request, the complete local `npm test` suite was not run; exact-head PR Gate/CI remains authoritative. UI E2E and visual regression were also not run locally; the interaction change is limited to a native, default-collapsed `details` element and is covered at the renderer boundary.

## Review focus

- confirm raw diagnostics never enter the primary alert text
- confirm language changes re-render summaries from static `t()` calls
- confirm retaining explicit Provider result messages while summarizing thrown failures is the right boundary
- confirm the local action discriminants are preferable to introducing a cross-process error taxonomy in this PR
