### PR TITLE
fix(acp): hide reports for Claude API connection failures

### DIFF
--- a/src/main/acp/prompt-error.test.ts
+++ b/src/main/acp/prompt-error.test.ts
@@ -137,6 +137,17 @@ describe('isProviderPromptError', () => {
     }
   )
 
+  it.each(['ConnectionRefused', 'ECONNREFUSED', 'ENOTFOUND'])(
+    'flags a Claude Code RequestError when the provider API is unreachable (%s)',
+    (code) => {
+      const error = agentError(`Internal error: API Error: Unable to connect to API (${code})`, {
+        errorKind: 'unknown'
+      })
+
+      expect(isProviderPromptError(error)).toBe(true)
+    }
+  )
+
   it('does not infer a provider error from nearby but non-equivalent text', () => {
     expect(
       isProviderPromptError(
@@ -154,6 +165,20 @@ describe('isProviderPromptError', () => {
     ).toBe(false)
     expect(
       isProviderPromptError(
+        agentError('Internal error: unable to connect to API (ConnectionRefused)', {
+          errorKind: 'unknown'
+        })
+      )
+    ).toBe(false)
+    expect(
+      isProviderPromptError(
+        agentError('Internal error: Unable to connect to workspace (ConnectionRefused)', {
+          errorKind: 'unknown'
+        })
+      )
+    ).toBe(false)
+    expect(
+      isProviderPromptError(
         Object.assign(new Error('Internal error: API Error: 400 Invalid request'), {
           code: -32002,
           data: { errorKind: 'unknown' },
@@ -164,6 +189,11 @@ describe('isProviderPromptError', () => {
     expect(isProviderPromptError(new Error('Internal error: API Error: 400 Invalid request'))).toBe(
       false
     )
+    expect(
+      isProviderPromptError(
+        new Error('Internal error: API Error: Unable to connect to API (ConnectionRefused)')
+      )
+    ).toBe(false)
   })
 
   it('flags a provider resource-not-found (wrong model id / endpoint)', () => {

--- a/src/main/acp/prompt-error.ts
+++ b/src/main/acp/prompt-error.ts
@@ -24,7 +24,12 @@ type UpstreamDetail = { text: string; type?: string }
 // bare "not found" substring, so a benign message like "rate limit config not found" isn't reworded.
 const NOT_FOUND_PATTERN =
   /resource[\s_-]?not[\s_-]?found|no such (?:model|resource)|not[\s_-]?found\s*:/i
-const CLAUDE_PROVIDER_CLIENT_ERROR_PATTERN = /^\s*internal error:\s*api error:\s*4\d{2}\b/i
+// Claude Code wraps upstream provider HTTP 4xx as `Internal error: API Error: 4xx …`. It also uses the
+// same wrapper for a failed TCP/TLS handshake (`Unable to connect to API (<code>)`) when the model
+// endpoint is unreachable. Both are provider-owned, not ACP-layer defects. 5xx stays excluded: an
+// untagged internal 5xx may still be an adapter defect.
+const CLAUDE_PROVIDER_API_ERROR_PATTERN =
+  /^\s*internal error:\s*api error:\s*(?:4\d{2}\b|unable to connect to api\b)/i
 
 // Converts an unknown thrown value into its base message string.
 const rawErrorMessage = (error: unknown): string =>
@@ -169,16 +174,17 @@ const isProviderErrorKind = (error: unknown): boolean => {
   }
 }
 
-// claude-agent-acp currently forwards some explicit provider 4xx failures as a generic ACP internal
-// RequestError with `data.errorKind: 'unknown'`. The fixed wrapper and JSON-RPC code are the remaining
-// machine-stable boundary; require both so ordinary app errors containing a status number stay
-// reportable. Do not infer 5xx ownership here: provider-tagged 5xx errors still use the structural
-// APIError/provider-error paths above, while an untagged internal 5xx may be an adapter defect.
-const isClaudeProviderClientError = (error: unknown): boolean =>
+// claude-agent-acp currently forwards some explicit provider 4xx and connect-time failures as a
+// generic ACP internal RequestError with `data.errorKind: 'unknown'`. The fixed wrapper and JSON-RPC
+// code are the remaining machine-stable boundary; require both so ordinary app errors containing a
+// status number or the word "connect" stay reportable. Do not infer 5xx ownership here:
+// provider-tagged 5xx errors still use the structural APIError/provider-error paths above, while an
+// untagged internal 5xx may be an adapter defect.
+const isClaudeProviderApiError = (error: unknown): boolean =>
   error instanceof Error &&
   error.name === 'RequestError' &&
   errorCode(error) === -32603 &&
-  CLAUDE_PROVIDER_CLIENT_ERROR_PATTERN.test(error.message)
+  CLAUDE_PROVIDER_API_ERROR_PATTERN.test(error.message)
 
 // Whether a failed prompt originates from the model provider (an upstream LLM/HTTP failure the agent
 // relayed) rather than from the app's own ACP layer. Provider failures are the user's/provider's to
@@ -188,13 +194,14 @@ const isClaudeProviderClientError = (error: unknown): boolean =>
 // broad human-message pattern matching:
 //   - the agent tagged the failure as an upstream `APIError` (covers auth/rate/quota/5xx/etc.), or
 //   - the agent tagged `data.errorKind: 'provider-error'` (the bridges' machine-readable marker), or
-//   - Claude Code emitted its fixed ACP internal wrapper with an explicit provider 4xx status, or
+//   - Claude Code emitted its fixed ACP internal wrapper with an explicit provider 4xx status or
+//     an unreachable-API connection failure, or
 //   - it is a provider "resource not found" (wrong model id / endpoint), which requires the same
 //     upstream signal (see isProviderNotFound) and is never a bare ACP protocol not-found.
 export const isProviderPromptError = (error: unknown): boolean => {
   if (isApiError(error)) return true
   if (isProviderErrorKind(error)) return true
-  if (isClaudeProviderClientError(error)) return true
+  if (isClaudeProviderApiError(error)) return true
 
   const raw = rawErrorMessage(error)
 

--- a/src/main/acp/prompt-outcome-finalizer.test.ts
+++ b/src/main/acp/prompt-outcome-finalizer.test.ts
@@ -341,6 +341,19 @@ describe('AcpPromptOutcomeFinalizer', () => {
       providerError: true
     },
     {
+      name: 'Claude Code API connection refused with an unknown error kind',
+      error: Object.assign(
+        new Error('Internal error: API Error: Unable to connect to API (ConnectionRefused)'),
+        {
+          code: -32603,
+          data: { errorKind: 'unknown' },
+          name: 'RequestError'
+        }
+      ),
+      recoverable: undefined,
+      providerError: true
+    },
+    {
       name: 'ACP error',
       error: new Error('protocol failed'),
       recoverable: undefined,

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -20909,6 +20909,11 @@ describe('ACP runtime session management', () => {
       'API Error: 400 Authentication Fails, Your api key: ****e52d is invalid'
     ],
     [
+      'Claude Code API connection refused',
+      { errorKind: 'unknown' },
+      'API Error: Unable to connect to API (ConnectionRefused)'
+    ],
+    [
       'provider bridge error kind',
       { errorKind: 'provider-error' },
       '{"error":{"message":"Authentication failed","type":"authentication_error"}}'


### PR DESCRIPTION
## Problem

Claude Code relays an unreachable model endpoint as ACP `RequestError(-32603)` with `data.errorKind: unknown` and the fixed wrapper `Internal error: API Error: Unable to connect to API (<code>)`. The existing classifier only treated the `API Error: 4xx` form as provider-owned, so a connection-refused failure was treated as an internal app error and the composer offered **Report error**. That produced GitHub noise such as #1582, which is a DeepSeek endpoint connectivity failure rather than an Open Science defect.

## Proposed change

- Classify Claude Code `RequestError(-32603)` plus the fixed `API Error: Unable to connect to API` wrapper as provider-owned, in addition to the existing `API Error: 4xx` path.
- Keep nearby generic connect text, other JSON-RPC codes, plain errors, and untagged 5xx failures reportable.
- Add classifier, finalizer, and runtime coverage for the connection-refused shape.

## ACP compatibility

| ACP path | Classification contract |
| --- | --- |
| Claude Code | Extends the existing `RequestError(-32603)` plus `API Error:` fallback to also cover unreachable-API connection failures. |
| OpenCode | Preserves the existing structural `errorName: APIError` path. |
| Codex bridge | Preserves the existing structural `errorKind: provider-error` path. |
| Codex Responses | Raw provider JSON remains a model message and does not enter the composer app-error report path. |

## Scope and non-goals

- Architecture, data model, data relationships, and interaction design: unchanged. This corrects the existing Report affordance classification.
- Does not reword the user-visible error text.
- Does not classify untagged 5xx as provider-owned.

Follow-up for persisted / createSession sessions: #1584

Related: #1582