### PR TITLE
fix(acp): hide reports for persisted Claude API connection failures

### DIFF
--- a/src/main/acp/prompt-error.ts
+++ b/src/main/acp/prompt-error.ts
@@ -1,4 +1,7 @@
-import { PROVIDER_RESOURCE_NOT_FOUND_PREFIX } from '../../shared/run-error-classification'
+import {
+  isClaudeApiConnectionFailure,
+  PROVIDER_RESOURCE_NOT_FOUND_PREFIX
+} from '../../shared/run-error-classification'
 
 // Turns an agent prompt failure into user-visible text. Agents (opencode) relay an upstream provider
 // HTTP error wrapped as a JSON-RPC failure like
@@ -24,12 +27,10 @@ type UpstreamDetail = { text: string; type?: string }
 // bare "not found" substring, so a benign message like "rate limit config not found" isn't reworded.
 const NOT_FOUND_PATTERN =
   /resource[\s_-]?not[\s_-]?found|no such (?:model|resource)|not[\s_-]?found\s*:/i
-// Claude Code wraps upstream provider HTTP 4xx as `Internal error: API Error: 4xx …`. It also uses the
-// same wrapper for a failed TCP/TLS handshake (`Unable to connect to API (<code>)`) when the model
-// endpoint is unreachable. Both are provider-owned, not ACP-layer defects. 5xx stays excluded: an
-// untagged internal 5xx may still be an adapter defect.
-const CLAUDE_PROVIDER_API_ERROR_PATTERN =
-  /^\s*internal error:\s*api error:\s*(?:4\d{2}\b|unable to connect to api\b)/i
+// Claude Code wraps upstream provider HTTP 4xx as `Internal error: API Error: 4xx …`. Unreachable-API
+// connection failures use the shared `API Error: Unable to connect to API` matcher. 5xx stays excluded:
+// an untagged internal 5xx may still be an adapter defect.
+const CLAUDE_PROVIDER_CLIENT_ERROR_PATTERN = /^\s*internal error:\s*api error:\s*4\d{2}\b/i
 
 // Converts an unknown thrown value into its base message string.
 const rawErrorMessage = (error: unknown): string =>
@@ -184,7 +185,8 @@ const isClaudeProviderApiError = (error: unknown): boolean =>
   error instanceof Error &&
   error.name === 'RequestError' &&
   errorCode(error) === -32603 &&
-  CLAUDE_PROVIDER_API_ERROR_PATTERN.test(error.message)
+  (CLAUDE_PROVIDER_CLIENT_ERROR_PATTERN.test(error.message) ||
+    isClaudeApiConnectionFailure(error.message))
 
 // Whether a failed prompt originates from the model provider (an upstream LLM/HTTP failure the agent
 // relayed) rather than from the app's own ACP layer. Provider failures are the user's/provider's to

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -4903,4 +4903,18 @@ describe('ConversationPanel error box + report affordance', () => {
     })
     expect(reportButton()).not.toBeNull()
   })
+
+  it('hides the Report button for a persisted Claude API connection failure without the reportable flag', () => {
+    renderPanel({
+      view: {
+        activeSession: {
+          ...errorSession,
+          error: 'Internal error: API Error: Unable to connect to API (ConnectionRefused)',
+          errorReportable: undefined
+        }
+      }
+    })
+    expect(errorBoxText()).toContain('Unable to connect to API (ConnectionRefused)')
+    expect(reportButton()).toBeNull()
+  })
 })

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -2989,6 +2989,16 @@ describe('session store', () => {
       .getState()
       .failRun('transport-session-1', 'Session workspace is missing; start a new conversation.')
     expect(useSessionStore.getState().sessions[0].errorReportable).toBe(false)
+
+    // Claude Code's unreachable-API wrapper is recognized without an explicit flag (createSession /
+    // persisted pre-flag sessions).
+    useSessionStore
+      .getState()
+      .failRun(
+        'transport-session-1',
+        'Internal error: API Error: Unable to connect to API (ConnectionRefused)'
+      )
+    expect(useSessionStore.getState().sessions[0].errorReportable).toBe(false)
   })
 
   it('honors an explicit reportable flag (the runtime tags a model-provider failure)', () => {

--- a/src/shared/run-error-classification.test.ts
+++ b/src/shared/run-error-classification.test.ts
@@ -15,6 +15,7 @@ import {
   RESUME_WORKSPACE_MISSING_MESSAGE,
   VISION_EVIDENCE_INVALID_MESSAGE,
   VISION_MODEL_NOT_CONFIGURED_MESSAGE,
+  isClaudeApiConnectionFailure,
   isReportableRunFailure,
   visionRunFailureMessage
 } from './run-error-classification'
@@ -53,7 +54,7 @@ describe('isReportableRunFailure (text tier)', () => {
     }
   })
 
-  it('does NOT recognize provider error TEXT at this tier — the structural flag suppresses those', () => {
+  it('does NOT recognize ordinary provider error TEXT at this tier — the structural flag suppresses those', () => {
     // These come from the model/provider and are hidden by `providerError`/`errorReportable=false`, set
     // structurally at the ACP layer. The text tier must NOT try to recognize them (that heuristic was
     // fragile and swallowed genuine app errors), so here — text only — they read as reportable.
@@ -68,6 +69,25 @@ describe('isReportableRunFailure (text tier)', () => {
     ]) {
       expect(isReportableRunFailure(providerText)).toBe(true)
     }
+  })
+
+  it('recognizes the Claude Code unreachable-API wrapper without the structural flag', () => {
+    // createSession failRun and persisted pre-flag sessions have no providerError tag. The distinctive
+    // Claude wrapper is recognized so Report stays hidden; nearby "connect" wording is not.
+    const live = 'Internal error: API Error: Unable to connect to API (ConnectionRefused)'
+    const wrapped = `Error invoking remote method 'acp:send-prompt': Error: ${live}`
+
+    expect(isClaudeApiConnectionFailure(live)).toBe(true)
+    expect(isClaudeApiConnectionFailure(wrapped)).toBe(true)
+    expect(isReportableRunFailure(live)).toBe(false)
+    expect(isReportableRunFailure(wrapped)).toBe(false)
+    expect(
+      isReportableRunFailure('Internal error: unable to connect to API (ConnectionRefused)')
+    ).toBe(true)
+    expect(
+      isReportableRunFailure('Internal error: Unable to connect to workspace (ConnectionRefused)')
+    ).toBe(true)
+    expect(isReportableRunFailure('Run failed: connection reset')).toBe(true)
   })
 
   it('does not swallow an ordinary app error that merely mentions a provider word', () => {

--- a/src/shared/run-error-classification.ts
+++ b/src/shared/run-error-classification.ts
@@ -3,16 +3,16 @@ import { isMediaOverflowError } from './media-overflow'
 // Classifies a failed run into "expected" (keep the message, no report button) vs "unknown/reportable"
 // (an opaque or internal failure worth a GitHub issue). The primary signal is STRUCTURAL, not textual:
 // a model/provider failure is tagged `providerError` on the error event at the ACP layer (runtime.ts,
-// via isProviderPromptError) and persisted as `session.errorReportable = false`. Text is NEVER used to
-// guess whether a failure came from the provider — that was fragile and repeatedly swallowed genuine
-// app errors that merely mentioned a provider word.
+// via isProviderPromptError) and persisted as `session.errorReportable = false`. Arbitrary provider
+// wording is not guessed from text — that was fragile and repeatedly swallowed genuine app errors.
 //
 // This module owns only the SECONDARY, text-based tier: recognizing the app's OWN crafted reminder
 // strings (which we author, so an exact-match set is reliable) so their report button is hidden even
 // on the paths that don't carry the structural flag (a persisted pre-flag session, or a renderer-side
-// failRun call). It is a pure, dependency-light leaf module (like media-overflow.ts) usable from both
-// processes. Anything it does not recognize stays reportable — including opaque provider text — so the
-// structural flag, not this text tier, is what suppresses ordinary provider errors.
+// failRun call). One additional fixed Claude Code wrapper is recognized here (`API Error: Unable to
+// connect to API`) so historical sessions and createSession failRun hide Report without rewriting
+// stored records. Arbitrary provider text is still not guessed. It is a pure, dependency-light leaf
+// module (like media-overflow.ts) usable from both processes.
 
 // App-crafted resume-failure messages (useWorkspaceAgentRuntime.getResumeFailureMessage). Each is the
 // actionable text the app writes when it recognizes a specific resume cause. The generic
@@ -100,6 +100,17 @@ export const buildActiveModelIncompatibleMessage = (frameworkDisplayName: string
 export const PROVIDER_RESOURCE_NOT_FOUND_PREFIX =
   'The model provider could not find the requested resource'
 
+// Claude Code's fixed unreachable-API wrapper. Recognized here so createSession failRun and persisted
+// pre-flag sessions hide Report without a stored-schema migration. Match the distinctive
+// `API Error: Unable to connect to API` phrase only — not a generic "connection" or "connect" word.
+const CLAUDE_API_CONNECTION_FAILURE_PATTERN = /(?:^|:\s*)api error:\s*unable to connect to api\b/i
+
+export const isClaudeApiConnectionFailure = (error: string | null | undefined): boolean => {
+  const message = error?.trim()
+  if (!message) return false
+  return CLAUDE_API_CONNECTION_FAILURE_PATTERN.test(message)
+}
+
 // The exact app-crafted messages an equality check recognizes as expected.
 const EXPECTED_RUN_FAILURE_MESSAGES = new Set<string>([
   RESUME_WORKSPACE_MISSING_MESSAGE,
@@ -114,11 +125,12 @@ const EXPECTED_RUN_FAILURE_MESSAGES = new Set<string>([
 ])
 
 // Whether a run failure is one the app itself already surfaced with a purpose — an app-crafted
-// actionable reminder, the reworded provider not-found, or a request-size overflow the app auto-
-// recovers — so the report button is hidden even without the structural `providerError` flag (an old
-// persisted session, or a renderer-side failRun). Recognition is by EXACT crafted string / known
-// prefix only; it deliberately does NOT try to recognize arbitrary provider error text (that is the
-// structural flag's job), so an unknown/opaque failure it doesn't author stays reportable.
+// actionable reminder, the reworded provider not-found, Claude Code's fixed unreachable-API wrapper,
+// or a request-size overflow the app auto-recovers — so the report button is hidden even without the
+// structural `providerError` flag (an old persisted session, or a renderer-side failRun). Recognition
+// is by EXACT crafted string / known prefix only; it deliberately does NOT try to recognize arbitrary
+// provider error text (that is the structural flag's job), so an unknown/opaque failure it doesn't
+// author stays reportable.
 export const isExpectedRunFailure = (error: string | null | undefined): boolean => {
   const message = error?.trim()
 
@@ -134,6 +146,8 @@ export const isExpectedRunFailure = (error: string | null | undefined): boolean 
   // share this leading phrase, so one prefix covers the createSession path (which is not reworded) and
   // any framework name. It is app-authored setup guidance ("Open Settings → Model"), not a bug.
   if (message.startsWith(ACTIVE_MODEL_INCOMPATIBLE_PREFIX)) return true
+  // Claude Code's fixed unreachable-API wrapper (createSession / persisted pre-flag sessions).
+  if (isClaudeApiConnectionFailure(message)) return true
   // A request-size overflow the app auto-recovers from — never a reportable bug.
   return isMediaOverflowError(message)
 }


### PR DESCRIPTION
## Problem

#1583 hid **Report error** for live Claude Code prompt failures with `API Error: Unable to connect to API`. That path is structural (`providerError` / `errorReportable: false`). Two remaining surfaces still offered Report for the same provider connection failure:

- `createSession` failRun, which does not pass a structural flag
- sessions persisted before `errorReportable`, which fall back to the text-tier classifier

Both produced the same GitHub noise as #1582 when users reopened an existing failed conversation.

## Proposed change

- Recognize Claude Code's fixed `API Error: Unable to connect to API` wrapper at the text tier (`isExpectedRunFailure`).
- Share that matcher with the ACP structural classifier so the live prompt path and the fallback path cannot drift.
- Keep nearby generic connect text, missing `API Error:` wrappers, and untagged 5xx reportable.
- Cover failRun derivation and the composer Report button for a pre-flag persisted session.

Follow-up to #1583. Historical compatibility was confirmed after that merge.

## ACP compatibility

| ACP path | Classification contract |
| --- | --- |
| Claude Code | Text-tier fallback covers createSession and pre-flag persisted sessions. Live prompt tagging remains the #1583 structural `RequestError(-32603)` path. |
| OpenCode | Unchanged. Structural `errorName: APIError` still owns provider failures. |
| Codex bridge | Unchanged. Structural `errorKind: provider-error` still owns provider failures. |
| Codex Responses | Unchanged. Raw provider JSON does not enter this Report path. |

Excluded: model-specific coverage; platform lanes; rewriting stored session documents.

## Scope and non-goals

- Does not reword the user-visible error text.
- Does not classify untagged 5xx as provider-owned.
- Does not rewrite already-persisted session documents.

## Compatibility notes

- **Historical data:** render-time only. Pre-flag persisted sessions with this error keep their stored document; the text-tier fallback now hides Report. No stored-schema migration and no rewrite of old records.
- **New states / enum values:** none.
- **Persistence:** no schema change. Existing `errorReportable` is reused. A new `failRun` of this message without an explicit flag now stores `errorReportable: false` via the existing optional field.

## Acceptance criteria and validation

All checks below ran after the last material edit.

| Behavior | Command | Result |
| --- | --- | --- |
| Text-tier Claude connection wrapper, negative nearby connect wording, classifier + finalizer coverage | `npx vitest run src/shared/run-error-classification.test.ts src/main/acp/prompt-error.test.ts src/main/acp/prompt-outcome-finalizer.test.ts` | 47 passed |
| ACP compatibility shapes for OpenCode, Claude 4xx, Claude connection refused, and provider bridge | `npx vitest run src/main/acp/runtime.test.ts -t 'tags a provider-relayed'` | 4 passed |
| failRun derives non-reportable from the connection wrapper without an explicit flag | `npx vitest run src/renderer/src/stores/session-store.test.ts -t 'derives errorReportable from the message'` | 1 passed |
| Composer hides Report for a persisted connection failure with `errorReportable: undefined` | `npx vitest run src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx -t 'Report button'` | 8 passed |
| Changed files lint | `npx eslint` on the edited TS/TSX files | no issues after Prettier |

Per task scope, the complete portable/platform suite is left to PR CI.

Uncovered risks: untagged 5xx remains reportable, matching the #1467 / #1583 boundary.

## Review focus

- Whether the text-tier exception is narrow enough (`API Error: Unable to connect to API` only).
- Whether render-time historical classification is sufficient without rewriting stored sessions.

Related: #1582, #1583