### PR TITLE
fix(acp): negotiate legacy Codex provider slot

### DIFF
--- a/src/main/acp/agent-connection-adapter.test.ts
+++ b/src/main/acp/agent-connection-adapter.test.ts
@@ -244,6 +244,7 @@ describe('AcpAgentConnectionAdapter', () => {
         'authenticate',
         'backendAttempt',
         'initialize',
+        'listProviders',
         'setProvider'
       ])
       expect(candidate).not.toHaveProperty('process')

--- a/src/main/acp/agent-connection-adapter.ts
+++ b/src/main/acp/agent-connection-adapter.ts
@@ -6,6 +6,7 @@ import type {
   CreateElicitationResponse,
   InitializeRequest,
   InitializeResponse,
+  ListProvidersResponse,
   RequestPermissionRequest,
   RequestPermissionResponse,
   SetProviderRequest,
@@ -90,6 +91,7 @@ type AcpTransferredAgentConnection = Readonly<{
   backendAttempt: AcpBackendGenerationAttempt
   initialize: (request: InitializeRequest) => Promise<InitializeResponse>
   authenticate: (request: AuthenticateRequest) => Promise<void>
+  listProviders: () => Promise<ListProvidersResponse>
   setProvider: (request: SetProviderRequest) => Promise<void>
 }>
 
@@ -251,6 +253,7 @@ class AcpAgentConnectionAdapter {
           authenticate: async (request) => {
             await openedConnection.agent.request(acp.methods.agent.authenticate, request)
           },
+          listProviders: () => openedConnection.agent.request(acp.methods.agent.providers.list, {}),
           setProvider: async (request) => {
             await openedConnection.agent.request(acp.methods.agent.providers.set, request)
           }

--- a/src/main/acp/connection-lifecycle-workflow.test.ts
+++ b/src/main/acp/connection-lifecycle-workflow.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import type { ClientConnection } from '@agentclientprotocol/sdk'
+import {
+  RequestError,
+  type ClientConnection,
+  type SetProviderRequest
+} from '@agentclientprotocol/sdk'
 import type { AcpConnectRequest, AcpStateSnapshot } from '../../shared/acp'
 import { AcpConnectionLifecycleWorkflow } from './connection-lifecycle-workflow'
 
 const connection = {} as ClientConnection
 
 describe('AcpConnectionLifecycleWorkflow', () => {
-  it('initializes, authenticates, configures the provider, then publishes connected', async () => {
+  it('initializes, authenticates, configures the advertised provider, then publishes connected', async () => {
     const actions: string[] = []
     const ready = {
       epoch: 1,
@@ -29,7 +33,7 @@ describe('AcpConnectionLifecycleWorkflow', () => {
           consumeInitializeMaterial: () => ({
             authentication: { methodId: 'api-key' },
             providerConfiguration: {
-              providerId: 'gateway',
+              providerId: 'openai',
               apiType: 'openai',
               baseUrl: 'http://127.0.0.1:1234/v1',
               headers: {}
@@ -47,9 +51,29 @@ describe('AcpConnectionLifecycleWorkflow', () => {
         authenticate: async () => {
           actions.push('authenticate')
         },
-        setProvider: async () => {
+        listProviders: async () => {
+          actions.push('provider-list')
+          // Real Codex ACP 1.1.4 wire response captured from the reported failing setup.
+          return {
+            providers: [
+              {
+                providerId: 'custom-gateway',
+                supported: ['openai' as const],
+                required: false,
+                current: null
+              }
+            ]
+          }
+        },
+        setProvider: vi.fn(async (request: SetProviderRequest) => {
           actions.push('provider-set')
-        }
+          if (request.providerId !== 'custom-gateway') {
+            throw RequestError.invalidParams(
+              { providerId: request.providerId },
+              `Unknown providerId "${request.providerId}"; only "custom-gateway" is configurable`
+            )
+          }
+        })
       })),
       dispose: vi.fn(async () => undefined)
     }
@@ -87,6 +111,8 @@ describe('AcpConnectionLifecycleWorkflow', () => {
       'initialize',
       'authenticate',
       'provider-set',
+      'provider-list',
+      'provider-set',
       'Agent initialized',
       'connected'
     ])
@@ -96,6 +122,12 @@ describe('AcpConnectionLifecycleWorkflow', () => {
         clientCapabilities: expect.objectContaining({ elicitation: { form: {} } })
       })
     )
+    expect(candidate.transferTo.mock.results[0]?.value.setProvider).toHaveBeenCalledWith({
+      providerId: 'custom-gateway',
+      apiType: 'openai',
+      baseUrl: 'http://127.0.0.1:1234/v1',
+      headers: {}
+    })
     expect(attempt.publish).toHaveBeenCalledWith({
       close: true,
       delete: false,

--- a/src/main/acp/connection-lifecycle-workflow.ts
+++ b/src/main/acp/connection-lifecycle-workflow.ts
@@ -1,9 +1,9 @@
 import * as acp from '@agentclientprotocol/sdk'
-import type { ClientConnection } from '@agentclientprotocol/sdk'
+import type { ClientConnection, SetProviderRequest } from '@agentclientprotocol/sdk'
 import { resolve } from 'node:path'
 
 import type { AcpConnectRequest, AcpRuntimeEvent, AcpStateSnapshot } from '../../shared/acp'
-import type { AgentFramework } from '../agent-framework'
+import type { AgentFramework, AgentProviderConfiguration } from '../agent-framework'
 import { createLogger, diagnosticErrorFields } from '../logger'
 import type { AcpAgentConnectionCandidate } from './agent-connection-adapter'
 import type {
@@ -15,6 +15,23 @@ import { retainInitializeCapabilities } from './native-follow-up'
 
 type LifecycleEvent = Omit<AcpRuntimeEvent, 'id' | 'timestamp'> & Partial<AcpRuntimeEvent>
 type TransferredConnection = ReturnType<AcpAgentConnectionCandidate['transferTo']>
+
+const resolveFallbackProviderConfiguration = async (
+  connection: TransferredConnection,
+  requested: AgentProviderConfiguration
+): Promise<SetProviderRequest | undefined> => {
+  const { providers } = await connection.listProviders()
+  const exact = providers.find(
+    (provider) =>
+      provider.providerId === requested.providerId && provider.supported.includes(requested.apiType)
+  )
+  if (exact) return undefined
+
+  const compatible = providers.filter((provider) => provider.supported.includes(requested.apiType))
+  return compatible.length === 1
+    ? { ...requested, providerId: compatible[0].providerId }
+    : undefined
+}
 
 type AcpConnectionLifecycleWorkflowOptions = Readonly<{
   appVersion: string
@@ -162,8 +179,23 @@ class AcpConnectionLifecycleWorkflow {
         attempt.assertCurrent()
       }
       if (initializeMaterial?.providerConfiguration) {
-        await transferred.setProvider(initializeMaterial.providerConfiguration)
-        attempt.assertCurrent()
+        try {
+          await transferred.setProvider(initializeMaterial.providerConfiguration)
+          attempt.assertCurrent()
+        } catch (cause) {
+          if (!(cause instanceof acp.RequestError) || cause.code !== -32602) throw cause
+          attempt.assertCurrent()
+          // Codex ACP 1.1.4 advertises `custom-gateway`; 1.6.2 advertises `openai`.
+          // Retry only when the adapter itself exposes one unambiguous compatible slot.
+          const fallback = await resolveFallbackProviderConfiguration(
+            transferred,
+            initializeMaterial.providerConfiguration
+          )
+          if (!fallback) throw cause
+          attempt.assertCurrent()
+          await transferred.setProvider(fallback)
+          attempt.assertCurrent()
+        }
       }
 
       const handle = attempt.publish(retainInitializeCapabilities(initResult))


### PR DESCRIPTION
## Problem

PR #1566 upgraded the managed Codex ACP pin from 1.1.4 to 1.6.2 and changed the host provider slot from custom-gateway to openai. Existing managed runtimes live in the Open Science config root and are not replaced by npm install or by an app source update, so an existing 1.1.4 adapter can still be selected by current main.

The real 1.1.4 wire exchange advertises custom-gateway from providers/list and rejects providers/set with providerId openai using JSON-RPC -32602. Session creation then fails before session/new. Fresh 1.6.2 adapters advertise openai, so reverting the constant would break new installs.

## Proposed change

Keep openai as the normal 1.6.2 request. Only when providers/set returns invalid_params, ask the adapter for providers/list and retry against the single advertised provider that supports the requested API type. If the requested provider is already advertised or the compatible choice is ambiguous, preserve the original failure.

This keeps the common path unchanged and makes the fallback adapter-described rather than version-table-driven.

## Scope and non-goals

- Historical compatibility: supports the persisted Codex ACP 1.1.4 provider slot while retaining 1.6.2 behavior.
- Data fields and data model: none added or changed.
- State and enums: none added or changed.
- Persistence and migrations: none; negotiation is connection-local and ephemeral.
- Architecture: one existing ACP transport method, providers/list, is exposed to the connection lifecycle. No renderer, IPC, database, or session schema changes.
- Interaction: none. The existing create-session action succeeds instead of surfacing the providerId RequestError.
- Non-goal: automatically reinstall or upgrade managed runtimes. Users can still reinstall to receive newer adapter features such as native steering.

## Compatibility matrix

- claude-code: excluded; it never supplies providerConfiguration.
- opencode: excluded; it never supplies providerConfiguration.
- codex-responses: excluded; direct Responses backends do not configure the bridge provider slot.
- codex-bridge with ACP 1.6.2: existing providers/set(openai) succeeds; no new wire request.
- codex-bridge with ACP 1.1.4: providers/set(openai) returns -32602, then providers/list returns custom-gateway and the retry succeeds.
- Codex subscription: excluded; it does not use bridge provider configuration.
- Subscription timing, updates, and cleanup are unchanged.

## Acceptance criteria and validation

All passing checks below ran after the last material edit.

- Reported real adapter failure -> direct ACP 1.1.4 repro -> reproduced the exact -32602 message and providerId data before the fix.
- Legacy slot negotiation -> real ACP 1.1.4 plus Codex 0.144.6 protocol replay -> negotiated custom-gateway and providers/set returned success after the fix.
- Connection ordering and regression -> npm test -- src/main/acp/connection-lifecycle-workflow.test.ts src/main/acp/agent-connection-adapter.test.ts -> 22 passed.
- Shared runtime handshake -> npm test -- src/main/acp/runtime.test.ts with the initialize/auth/provider patterns -> 3 passed, 557 intentionally skipped by the test filter.
- ACP runtime module -> npm test -- src/main/acp/runtime.test.ts -> 557 passed; 3 localhost-listener tests were blocked by sandbox EPERM, then all 3 passed in an unsandboxed targeted rerun.
- Codex direct and bridge configuration -> npm test -- src/main/agent-framework/codex.test.ts -> 54 passed.
- Source lint -> npm run lint -- --no-cache -> passed.
- Formatting -> Prettier check on all four changed files -> passed.
- Node typecheck -> not green on current main baseline: the same three pre-existing errors reproduce in the primary main worktree in native-follow-up-workflow.test.ts and runtime.ts. No typecheck diagnostic points to this diff.

Per task scope, the full npm test suite was not run locally; PR Gate and selected CI lanes are authoritative. Platform-specific process behavior is unchanged, so no local Windows lane was added. The provider wire fixtures are platform-independent.

## Review focus

Please review the fail-closed fallback condition: it runs only for JSON-RPC invalid_params and only when providers/list yields one unambiguous compatible alternate slot. The original error is retained for every other case.
