### PR TITLE
feat(settings): add feedback entry

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,47 +1,34 @@
-name: Feature request
-description: Suggest an idea or improvement for Open Science
-title: '[Feature]: '
+name: Feedback
+description: Share an idea, improvement, or general feedback about Open Science
+title: '[Feedback]: '
 labels: ['enhancement']
 body:
   - type: markdown
     attributes:
       value: |
-        Have an idea? We'd love to hear it. For open-ended ideas or questions,
-        consider starting a [Discussion](https://github.com/aipoch/open-science/discussions)
-        instead — it's a better fit for conversation.
-  - type: checkboxes
-    id: preflight
+        Thanks for helping improve Open Science. Share as much or as little
+        context as you have — a complete solution is not required.
+  - type: dropdown
+    id: type
     attributes:
-      label: Preflight checklist
+      label: Feedback type
       options:
-        - label: I searched existing issues and discussions and this hasn't been proposed yet.
-          required: true
-  - type: textarea
-    id: problem
-    attributes:
-      label: What problem does this solve?
-      description: Describe the problem or limitation you're running into. Focus on the "why".
-      placeholder: I'm always frustrated when ...
+        - Idea
+        - Improvement
+        - General feedback
     validations:
       required: true
   - type: textarea
-    id: proposal
+    id: feedback
     attributes:
-      label: Proposed solution
-      description: Describe what you'd like to happen.
+      label: What would you like to share?
+      description: Tell us about your idea, suggestion, or experience.
     validations:
       required: true
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives considered
-      description: Any alternative solutions or workarounds you've thought about.
-    validations:
-      required: false
   - type: textarea
     id: context
     attributes:
       label: Additional context
-      description: Anything else that would help — mockups, links, use cases.
+      description: Add any relevant examples, links, screenshots, or use cases.
     validations:
       required: false

--- a/src/renderer/src/locales/fr.json
+++ b/src/renderer/src/locales/fr.json
@@ -802,6 +802,7 @@
   "Failed to save details.": "Échec de l'enregistrement des détails.",
   "Failed to set concurrency limit.": "Échec de la définition de la limite de simultanéité.",
   "Failed to set scratch root.": "Échec de la définition de la racine de travail.",
+  "Feedback": "Avis",
   "Featured": "En vedette",
   "Fetching packages from {{hosts}}": "Récupération des paquets depuis {{hosts}}",
   "File": "Fichier",

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -763,6 +763,7 @@
   "Failed to save details.": "詳細の保存に失敗しました。",
   "Failed to set concurrency limit.": "同時実行制限の設定に失敗しました。",
   "Failed to set scratch root.": "スクラッチルートの設定に失敗しました。",
+  "Feedback": "フィードバック",
   "Featured": "注目の",
   "Fetching packages from {{hosts}}": "{{hosts}} からパッケージを取得しています",
   "File": "ファイル",

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -782,6 +782,7 @@
   "Failed to save details.": "세부정보를 저장하지 못했습니다.",
   "Failed to set concurrency limit.": "동시성 한도를 설정하지 못했습니다.",
   "Failed to set scratch root.": "스크래치 루트를 설정하지 못했습니다.",
+  "Feedback": "피드백",
   "Featured": "추천",
   "Fetching packages from {{hosts}}": "{{hosts}}에서 패키지를 가져오는 중",
   "File": "파일",

--- a/src/renderer/src/locales/ru.json
+++ b/src/renderer/src/locales/ru.json
@@ -792,6 +792,7 @@
   "Failed to save details.": "Не удалось сохранить детали.",
   "Failed to set concurrency limit.": "Не удалось установить лимит одновременных выполнений.",
   "Failed to set scratch root.": "Не удалось установить корень временной папки.",
+  "Feedback": "Отзыв",
   "Featured": "Рекомендуемый",
   "Fetching packages from {{hosts}}": "Скачивание пакетов с {{hosts}}",
   "File": "Файл",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -834,6 +834,7 @@
   "Failed to save details.": "保存详细信息失败。",
   "Failed to set concurrency limit.": "设置并发上限失败。",
   "Failed to set scratch root.": "设置临时目录失败。",
+  "Feedback": "反馈",
   "Featured": "精选",
   "Fetching packages from {{hosts}}": "正在从 {{hosts}} 获取软件包",
   "File": "文件",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -833,6 +833,7 @@
   "Failed to save details.": "儲存詳細資訊失敗。",
   "Failed to set concurrency limit.": "設定並行上限失敗。",
   "Failed to set scratch root.": "設定暫存目錄失敗。",
+  "Feedback": "回饋",
   "Featured": "精選",
   "Fetching packages from {{hosts}}": "正在從 {{hosts}} 取得套件",
   "File": "檔案",

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -6,6 +6,7 @@ import { Dialog } from 'radix-ui'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LinkSafetyModal } from '@/components/streamdown/LinkSafetyModal'
+import { APP } from '../../../../shared/app-config'
 import type { ProviderView } from '../../../../shared/settings'
 import type { SpecialistProfileView } from '../../../../shared/specialist'
 import { i18next } from '@/i18n'
@@ -638,21 +639,24 @@ describe('SettingsPage layout', () => {
     expect(document.body.querySelector('[aria-label="Back to archived"]')).toBeNull()
   })
 
-  it('anchors Archived at the bottom of Settings navigation', async () => {
+  it('anchors Feedback above Archived at the bottom of Settings navigation', async () => {
     await act(async () => root.render(<SettingsPage open onClose={vi.fn()} />))
 
     const archived = navButton('Archived')
+    const feedback = document.body.querySelector<HTMLAnchorElement>(
+      `nav[aria-label="Settings"] a[href="${APP.links.githubFeedback}"]`
+    )
     const remoteControl = navButton('Remote control')
+    const navItems = Array.from(document.body.querySelectorAll('nav[aria-label="Settings"] li'))
 
     expect(archived?.parentElement?.parentElement?.parentElement?.className).toContain('mt-auto')
-    expect(
-      Array.from(document.body.querySelectorAll('nav[aria-label="Settings"] button')).indexOf(
-        archived as HTMLButtonElement
-      )
-    ).toBeGreaterThan(
-      Array.from(document.body.querySelectorAll('nav[aria-label="Settings"] button')).indexOf(
-        remoteControl as HTMLButtonElement
-      )
+    expect(feedback?.textContent?.trim()).toBe('Feedback')
+    expect(feedback?.target).toBe('_blank')
+    expect(navItems.indexOf(feedback?.parentElement as HTMLLIElement)).toBeGreaterThan(
+      navItems.indexOf(remoteControl?.parentElement as HTMLLIElement)
+    )
+    expect(navItems.indexOf(feedback?.parentElement as HTMLLIElement)).toBeLessThan(
+      navItems.indexOf(archived?.parentElement as HTMLLIElement)
     )
   })
 
@@ -719,7 +723,7 @@ describe('SettingsPage layout', () => {
 
     // Left navigation grouped as Capabilities (Skills, Connectors, Specialists, Compute, Network)
     // and Workspace (Model, Agent, Tags, Permissions, Runtimes, Storage, Usage, General).
-    // Remote access stays isolated and Archived is anchored at the navigation bottom.
+    // Remote access stays isolated; Feedback and Archived are anchored at the navigation bottom.
     const nav = document.body.querySelector('nav[aria-label="Settings"]')
     expect(nav).not.toBeNull()
     expect(nav?.className).toContain('bg-background')
@@ -730,7 +734,7 @@ describe('SettingsPage layout', () => {
     expect(nav?.textContent).toContain('Workspace')
     expect(nav?.textContent).toContain('Remote access')
     const navItems = nav?.querySelectorAll('li') ?? []
-    expect(navItems).toHaveLength(15)
+    expect(navItems).toHaveLength(16)
     expect(navItems[0]?.textContent).toContain('Skills')
     expect(navItems[1]?.textContent).toContain('Connectors')
     expect(navItems[2]?.textContent).toContain('Specialists')
@@ -745,7 +749,8 @@ describe('SettingsPage layout', () => {
     expect(navItems[11]?.textContent).toContain('Usage')
     expect(navItems[12]?.textContent).toContain('General')
     expect(navItems[13]?.textContent).toContain('Remote control')
-    expect(navItems[14]?.textContent).toContain('Archived')
+    expect(navItems[14]?.textContent).toContain('Feedback')
+    expect(navItems[15]?.textContent).toContain('Archived')
     const modelNavButton = navButton('Model')
     const agentNavButton = navButton('Agent')
     expect(modelNavButton?.querySelector('.lucide-brain')).not.toBeNull()

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -729,6 +729,8 @@ describe('SettingsPage layout', () => {
     expect(nav?.className).toContain('bg-background')
     expect(nav?.className).toContain('md:w-48')
     expect(nav?.className).toContain('w-[min(86vw,320px)]')
+    expect(nav?.className).toContain('overflow-y-auto')
+    expect(nav?.className).toContain('md:overflow-y-visible')
     expect(nav?.parentElement?.nextElementSibling?.className).toContain('bg-card')
     expect(nav?.textContent).toContain('Capabilities')
     expect(nav?.textContent).toContain('Workspace')

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -933,7 +933,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                 aria-hidden={isMobile && !isMobileNavOpen ? true : undefined}
                 inert={isMobile && !isMobileNavOpen ? true : undefined}
                 className={cn(
-                  'fixed inset-y-0 left-0 z-[70] flex w-[min(86vw,320px)] shrink-0 flex-col gap-4 border-r border-border bg-background p-3 transition-transform duration-200 ease-out md:static md:z-auto md:w-48 md:translate-x-0',
+                  'fixed inset-y-0 left-0 z-[70] flex w-[min(86vw,320px)] shrink-0 flex-col gap-4 overflow-y-auto overscroll-contain border-r border-border bg-background p-3 transition-transform duration-200 ease-out md:static md:z-auto md:w-48 md:translate-x-0 md:overflow-y-visible',
                   isMobileNavOpen ? 'translate-x-0' : '-translate-x-full'
                 )}
               >

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -11,6 +11,7 @@ import {
   LockKeyhole,
   Maximize2,
   Menu,
+  MessageSquare,
   Minimize2,
   MonitorSmartphone,
   ScrollText,
@@ -39,6 +40,7 @@ import {
   type ProviderView,
   type UpsertProviderRequest
 } from '../../../../shared/settings'
+import { APP } from '../../../../shared/app-config'
 import type { SpecialistListItem } from '../../../../shared/specialist'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
@@ -946,6 +948,22 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                       </div>
                     ) : null}
                     <ul className="flex flex-col gap-0.5">
+                      {group.bottom ? (
+                        <li>
+                          <a
+                            href={APP.links.githubFeedback}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="flex h-8 w-full items-center gap-2 rounded-lg px-2 text-left text-sm text-muted-foreground transition-colors duration-150 motion-reduce:transition-none hover:bg-muted hover:text-foreground"
+                          >
+                            <MessageSquare
+                              className="size-4 shrink-0 text-muted-foreground"
+                              aria-hidden="true"
+                            />
+                            <span className="min-w-0 flex-1 truncate">{t('Feedback')}</span>
+                          </a>
+                        </li>
+                      ) : null}
                       {group.panels.map(({ id, labelKey, Icon }) => {
                         const isActive = activePanel === id
                         return (

--- a/src/shared/app-config.ts
+++ b/src/shared/app-config.ts
@@ -17,6 +17,7 @@ export const APP = {
     githubReleases: `${GITHUB_REPO_URL}/releases`,
     githubApi: `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}`,
     githubIssues: `${GITHUB_REPO_URL}/issues`,
+    githubFeedback: `${GITHUB_REPO_URL}/issues/new?template=feature_request.yml`,
     discord: 'https://discord.gg/85dKfuGM9',
     x: 'https://x.com/aipoch_ai'
   },


### PR DESCRIPTION
## Summary

- add a single-word `Feedback` entry above `Archived` in the Settings navigation
- open the GitHub feedback issue form directly, keeping the app free of an additional form or dialog
- broaden the existing feature-request form to cover ideas, improvements, and general feedback
- localize the new entry in all supported renderer locales and test its placement and destination

## Testing

- `npx vitest run src/renderer/src/pages/settings/SettingsPage.render.test.tsx src/renderer/src/i18n/resources.test.ts` (675 tests passed)
