### PR TITLE
fix(workspace): surface resume failures on queued Send now

### DIFF
--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
@@ -541,6 +541,179 @@ describe('workspace message queue controller', () => {
     )
   })
 
+  it('surfaces a resume failure after Send now of a queued attachment when the live turn ends during inject', async () => {
+    const resumeError = 'Agent session resume failed: reply was never sent'
+    const attachment = {
+      id: 'upload-1',
+      sessionId: 'session-a',
+      name: 'data.csv',
+      originalName: 'data.csv',
+      path: '/tmp/data.csv',
+      mimeType: 'text/csv',
+      size: 12
+    }
+    let currentSession = session()
+    let notifySessionChanged: (() => void) | undefined
+    let finishSteer!: (result: { injected: false; reason: 'not-advertised' }) => void
+    const sendMessage = vi.fn(async () => {
+      currentSession = { ...session('error'), error: resumeError, errorReportable: true }
+      return undefined
+    })
+    const steerFollowUp = vi.fn(
+      () =>
+        new Promise<{ injected: false; reason: 'not-advertised' }>((resolve) => {
+          finishSteer = resolve
+        })
+    )
+    const input = options(currentSession, {
+      getSession: () => currentSession,
+      subscribeSessionChanges: (listener) => {
+        notifySessionChanged = listener
+        return () => {
+          notifySessionChanged = undefined
+        }
+      },
+      runtime: {
+        cancelRun: vi.fn(async () => undefined),
+        sendMessage,
+        steerFollowUp
+      }
+    })
+    const hook = renderController(input)
+    mounted.push(hook)
+    act(() =>
+      hook.result.current.lifecycle.enqueue({
+        ...admission('Draw a pie chart'),
+        snapshot: {
+          draftKey: 'session-a',
+          version: 1,
+          doc: textDoc('Draw a pie chart'),
+          attachments: [attachment]
+        }
+      })
+    )
+    expect(sendMessage).not.toHaveBeenCalled()
+
+    let sendNow!: Promise<void>
+    act(() => {
+      sendNow = hook.result.current.actions.sendNow(hook.result.current.items[0].id)
+    })
+    await vi.waitFor(() => expect(steerFollowUp).toHaveBeenCalledOnce())
+    expect(steerFollowUp).toHaveBeenCalledWith({
+      sessionId: 'session-a',
+      text: 'Draw a pie chart',
+      attachments: [attachment],
+      parts: textDoc('Draw a pie chart').nodes
+    })
+
+    currentSession = session('idle')
+    hook.rerender(
+      options(currentSession, {
+        ...input,
+        activeSession: currentSession,
+        promptInFlightSessionIds: [],
+        getSession: () => currentSession,
+        subscribeSessionChanges: input.subscribeSessionChanges,
+        runtime: input.runtime
+      })
+    )
+    act(() => notifySessionChanged?.())
+
+    await act(async () => {
+      finishSteer({ injected: false, reason: 'not-advertised' })
+      await sendNow
+    })
+
+    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledOnce())
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Draw a pie chart',
+        attachments: [attachment]
+      })
+    )
+    await vi.waitFor(() =>
+      expect(hook.result.current.items[0]).toMatchObject({
+        text: 'Draw a pie chart',
+        attachmentCount: 1,
+        phase: 'error',
+        error: { kind: 'send', detail: resumeError }
+      })
+    )
+    expect(input.runtime.cancelRun).not.toHaveBeenCalled()
+
+    await act(async () => hook.result.current.actions.sendNow(hook.result.current.items[0].id))
+    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(2))
+    expect(hook.result.current.items[0]).toMatchObject({
+      text: 'Draw a pie chart',
+      attachmentCount: 1,
+      phase: 'error',
+      error: { kind: 'send', detail: resumeError }
+    })
+  })
+
+  it('surfaces a resume failure after Send now of a queued attachment when native follow-up never replies', async () => {
+    const resumeError = 'Agent session resume failed: reply was never sent'
+    const attachment = {
+      id: 'upload-1',
+      sessionId: 'session-a',
+      name: 'data.csv',
+      originalName: 'data.csv',
+      path: '/tmp/data.csv',
+      mimeType: 'text/csv',
+      size: 12
+    }
+    let currentSession = session()
+    const sendMessage = vi.fn(async () => undefined)
+    const input = options(currentSession, {
+      getSession: () => currentSession,
+      runtime: {
+        cancelRun: vi.fn(async () => undefined),
+        sendMessage,
+        steerFollowUp: vi.fn(async () => {
+          currentSession = { ...session('error'), error: resumeError, errorReportable: true }
+          throw new Error("Error invoking remote method 'acp:steerFollowUp': reply was never sent")
+        })
+      }
+    })
+    const hook = renderController(input)
+    mounted.push(hook)
+    act(() =>
+      hook.result.current.lifecycle.enqueue({
+        ...admission('Draw a pie chart'),
+        snapshot: {
+          draftKey: 'session-a',
+          version: 1,
+          doc: textDoc('Draw a pie chart'),
+          attachments: [attachment]
+        }
+      })
+    )
+
+    await act(async () => hook.result.current.actions.sendNow(hook.result.current.items[0].id))
+    act(() => {
+      hook.rerender(
+        options(currentSession, {
+          ...input,
+          activeSession: currentSession,
+          promptInFlightSessionIds: [],
+          getSession: () => currentSession,
+          runtime: input.runtime
+        })
+      )
+    })
+
+    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledOnce())
+    await vi.waitFor(() =>
+      expect(hook.result.current.items[0]).toMatchObject({
+        text: 'Draw a pie chart',
+        attachmentCount: 1,
+        phase: 'error',
+        error: { kind: 'send', detail: resumeError }
+      })
+    )
+    expect(input.runtime.cancelRun).not.toHaveBeenCalled()
+  })
+
   it('pauses dispatch while a permission request is pending', async () => {
     const idle = session('idle')
     let permissionPending = true

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
@@ -556,7 +556,12 @@ describe('workspace message queue controller', () => {
     let notifySessionChanged: (() => void) | undefined
     let finishSteer!: (result: { injected: false; reason: 'not-advertised' }) => void
     const sendMessage = vi.fn(async () => {
-      currentSession = { ...session('error'), error: resumeError, errorReportable: true }
+      currentSession = {
+        ...session('error'),
+        error: resumeError,
+        errorReportable: true,
+        updatedAt: currentSession.updatedAt + 1
+      }
       return undefined
     })
     const steerFollowUp = vi.fn(
@@ -663,14 +668,21 @@ describe('workspace message queue controller', () => {
       size: 12
     }
     let currentSession = session()
-    const sendMessage = vi.fn(async () => undefined)
+    const sendMessage = vi.fn(async () => {
+      currentSession = {
+        ...session('error'),
+        error: resumeError,
+        errorReportable: true,
+        updatedAt: currentSession.updatedAt + 1
+      }
+      return undefined
+    })
     const input = options(currentSession, {
       getSession: () => currentSession,
       runtime: {
         cancelRun: vi.fn(async () => undefined),
         sendMessage,
         steerFollowUp: vi.fn(async () => {
-          currentSession = { ...session('error'), error: resumeError, errorReportable: true }
           throw new Error("Error invoking remote method 'acp:steerFollowUp': reply was never sent")
         })
       }
@@ -690,6 +702,7 @@ describe('workspace message queue controller', () => {
     )
 
     await act(async () => hook.result.current.actions.sendNow(hook.result.current.items[0].id))
+    currentSession = session('idle')
     act(() => {
       hook.rerender(
         options(currentSession, {
@@ -709,6 +722,91 @@ describe('workspace message queue controller', () => {
         attachmentCount: 1,
         phase: 'error',
         error: { kind: 'send', detail: resumeError }
+      })
+    )
+    expect(input.runtime.cancelRun).not.toHaveBeenCalled()
+  })
+
+  it('keeps a generic admission miss when Send now fails without a new session error', async () => {
+    const staleError = 'Agent session resume failed: reply was never sent'
+    const attachment = {
+      id: 'upload-1',
+      sessionId: 'session-a',
+      name: 'data.csv',
+      originalName: 'data.csv',
+      path: '/tmp/data.csv',
+      mimeType: 'text/csv',
+      size: 12
+    }
+    let currentSession = session()
+    let notifySessionChanged: (() => void) | undefined
+    let finishSteer!: (result: { injected: false; reason: 'not-advertised' }) => void
+    const sendMessage = vi.fn(async () => undefined)
+    const steerFollowUp = vi.fn(
+      () =>
+        new Promise<{ injected: false; reason: 'not-advertised' }>((resolve) => {
+          finishSteer = resolve
+        })
+    )
+    const input = options(currentSession, {
+      getSession: () => currentSession,
+      subscribeSessionChanges: (listener) => {
+        notifySessionChanged = listener
+        return () => {
+          notifySessionChanged = undefined
+        }
+      },
+      runtime: {
+        cancelRun: vi.fn(async () => undefined),
+        sendMessage,
+        steerFollowUp
+      }
+    })
+    const hook = renderController(input)
+    mounted.push(hook)
+    act(() =>
+      hook.result.current.lifecycle.enqueue({
+        ...admission('Draw a pie chart'),
+        snapshot: {
+          draftKey: 'session-a',
+          version: 1,
+          doc: textDoc('Draw a pie chart'),
+          attachments: [attachment]
+        }
+      })
+    )
+
+    let sendNow!: Promise<void>
+    act(() => {
+      sendNow = hook.result.current.actions.sendNow(hook.result.current.items[0].id)
+    })
+    await vi.waitFor(() => expect(steerFollowUp).toHaveBeenCalledOnce())
+
+    currentSession = { ...session('error'), error: staleError, errorReportable: true, updatedAt: 1 }
+    hook.rerender(
+      options(currentSession, {
+        ...input,
+        activeSession: currentSession,
+        promptInFlightSessionIds: [],
+        getSession: () => currentSession,
+        subscribeSessionChanges: input.subscribeSessionChanges,
+        runtime: input.runtime
+      })
+    )
+    act(() => notifySessionChanged?.())
+
+    await act(async () => {
+      finishSteer({ injected: false, reason: 'not-advertised' })
+      await sendNow
+    })
+
+    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledOnce())
+    await vi.waitFor(() =>
+      expect(hook.result.current.items[0]).toMatchObject({
+        text: 'Draw a pie chart',
+        attachmentCount: 1,
+        phase: 'error',
+        error: { kind: 'send', detail: 'The queued message was not admitted.' }
       })
     )
     expect(input.runtime.cancelRun).not.toHaveBeenCalled()

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
@@ -180,6 +180,21 @@ const queueItemContextError = (
   return undefined
 }
 
+const queuedAdmissionFailure = (
+  sessionBefore: Pick<ChatSession, 'status' | 'error' | 'updatedAt'> | undefined,
+  sessionAfter: Pick<ChatSession, 'status' | 'error' | 'updatedAt'> | undefined
+): string => {
+  const causedError =
+    sessionAfter?.status === 'error' &&
+    Boolean(sessionAfter.error) &&
+    (sessionBefore?.status !== 'error' ||
+      sessionBefore.error !== sessionAfter.error ||
+      sessionBefore.updatedAt !== sessionAfter.updatedAt)
+  return causedError && sessionAfter.error
+    ? sessionAfter.error
+    : 'The queued message was not admitted.'
+}
+
 const queueSessionIsSendable = (
   options: WorkspaceMessageQueueControllerOptions,
   session: ChatSession
@@ -301,6 +316,14 @@ const useWorkspaceMessageQueueController = (
       owner.dispatches.set(sessionId, activeDispatch)
       void (async (): Promise<void> => {
         try {
+          const sessionBeforeSend = current.getSession(sessionId)
+          const sessionBeforeAdmission = sessionBeforeSend
+            ? {
+                status: sessionBeforeSend.status,
+                error: sessionBeforeSend.error,
+                updatedAt: sessionBeforeSend.updatedAt
+              }
+            : undefined
           const result = await current.runtime.sendMessage({
             sessionId,
             text: item.text,
@@ -329,11 +352,7 @@ const useWorkspaceMessageQueueController = (
               emit('Queued message will send after the current run finishes.')
               return
             }
-            throw new Error(
-              latestSession?.status === 'error' && latestSession.error
-                ? latestSession.error
-                : 'The queued message was not admitted.'
-            )
+            throw new Error(queuedAdmissionFailure(sessionBeforeAdmission, latestSession))
           }
           const latest = itemsFor(sessionId)
           const remaining = latest.filter((candidate) => candidate.id !== item.id)

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
@@ -329,7 +329,11 @@ const useWorkspaceMessageQueueController = (
               emit('Queued message will send after the current run finishes.')
               return
             }
-            throw new Error('The queued message was not admitted.')
+            throw new Error(
+              latestSession?.status === 'error' && latestSession.error
+                ? latestSession.error
+                : 'The queued message was not admitted.'
+            )
           }
           const latest = itemsFor(sessionId)
           const remaining = latest.filter((candidate) => candidate.id !== item.id)


### PR DESCRIPTION
## Problem

Send now on a queued message with an attachment could leave the queue row in a send error whose detail was `The queued message was not admitted.` even when the Session had already failed with `Agent session resume failed: reply was never sent`. A second Send now retried the same drain and looked like it stopped immediately.

This happens after Send now: native follow-up is refused or never replies, the live turn ends, drain calls `sendMessage`, resume `failRun`s the Session, and `sendMessage` still returns `undefined`. Error Sessions are sendable, so the queue mapped that `undefined` to a generic admission miss.

## Proposed change

When queued admission returns `undefined` against a Session that is already in `error` with an `error` string, use that Session error as the queue send-error detail. Idle admission misses without a Session error still use `The queued message was not admitted.`

No new fields, enums, or persistence. Queue remains in-memory. The only interaction change is the queue error copy matching the resume banner.

## Scope and non-goals

- Does not fix the underlying `acp:resume-session` invoke that never replies.
- Does not add Codex native follow-up / steering for attachments.

## Acceptance criteria and validation

- After Send now of a queued attachment, when the live turn ends during inject and resume failRuns the Session, the queue row shows the resume error instead of a generic admission miss.
- A second Send now keeps that resume error and does not cancel the run.
- The same mapping holds when native follow-up never replies and the Session is already errored.
- Generic idle admission misses are unchanged.

### Validation (after the last material edit)

- queued Send now + resume failure copy -> `npm test -- src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts` -> pass (32)
- queue UI + conversation consumers -> `npm test -- src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts src/renderer/src/pages/workspace/ComposerMessageQueue.interaction.test.tsx src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts` -> pass (69)
- renderer types -> `npm run typecheck:web` -> pass
- changed files -> `npx eslint src/renderer/src/pages/workspace/workspace-message-queue-controller.ts src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts` -> pass

Excluded `test:module -- workspace_page` and the full portable suite locally; PR Gate remains authoritative. No Electron-only or persistence/migration risk in this diff.

## Review focus

- The `undefined` + errored-Session branch in `workspace-message-queue-controller.ts`.
- The two Send now attachment regressions; they failed on unfixed code with `The queued message was not admitted.`