### PR TITLE
fix(workspace): defer queued sends during permission response

### DIFF
--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
@@ -66,6 +66,29 @@ const session = (status: ChatSession['status'] = 'running'): ChatSession => ({
   }
 })
 
+const sessionWithPendingPermission = (
+  status: ChatSession['status'] = 'waiting-permission'
+): ChatSession => ({
+  ...session(status),
+  runtimeContext: {
+    version: 1,
+    revision: 1,
+    permission: {
+      state: 'pending',
+      request: {
+        requestId: 'permission-1',
+        sessionId: 'session-a',
+        toolCallId: 'tool-1',
+        title: 'Run command',
+        options: [{ optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' }]
+      },
+      originatingPromptMessageId: 'message-a',
+      fingerprint: 'a'.repeat(64),
+      createdAt: 1
+    }
+  }
+})
+
 const admission = (text: string): MessageQueueAdmission => ({
   session: session(),
   snapshot: { draftKey: 'session-a', version: 1, doc: textDoc(text), attachments: [] },
@@ -559,6 +582,29 @@ describe('workspace message queue controller', () => {
     await vi.waitFor(() => expect(input.runtime.sendMessage).toHaveBeenCalledOnce())
   })
 
+  it('keeps a queued prompt blocked while a durable permission response is in flight', async () => {
+    const pendingPermissionSession = sessionWithPendingPermission('error')
+    const input = options(pendingPermissionSession, {
+      // The approval card is hidden optimistically as soon as the user responds. The durable
+      // Session authority remains pending until Main settles that response.
+      hasPendingPermissionRequest: () => false
+    })
+    const hook = renderController(input)
+    mounted.push(hook)
+
+    act(() =>
+      hook.result.current.lifecycle.enqueue({
+        ...admission('wait for approval'),
+        session: pendingPermissionSession
+      })
+    )
+
+    expect(input.runtime.sendMessage).not.toHaveBeenCalled()
+    expect(hook.result.current.items).toEqual([
+      expect.objectContaining({ text: 'wait for approval', phase: 'queued' })
+    ])
+  })
+
   it('pauses dispatch until the captured Specialist is ready', async () => {
     const idle = session('idle')
     let specialistReady = false
@@ -715,6 +761,42 @@ describe('workspace message queue controller', () => {
     )
     await vi.waitFor(() => expect(order).toEqual(['send']))
     expect(input.runtime.cancelRun).not.toHaveBeenCalled()
+  })
+
+  it('keeps Send now queued while a durable permission response is in flight', async () => {
+    const pendingPermissionSession = sessionWithPendingPermission()
+    const steerFollowUp = vi.fn(async () => ({
+      injected: true as const,
+      transport: 'acp-steering' as const,
+      messageId: 'message-steer'
+    }))
+    const input = options(pendingPermissionSession, {
+      getSession: () => pendingPermissionSession,
+      hasPendingPermissionRequest: () => false,
+      runtime: {
+        cancelRun: vi.fn(async () => undefined),
+        sendMessage: vi.fn(),
+        steerFollowUp
+      }
+    })
+    const hook = renderController(input)
+    mounted.push(hook)
+    act(() =>
+      hook.result.current.lifecycle.enqueue({
+        ...admission('wait for approval'),
+        session: pendingPermissionSession
+      })
+    )
+
+    await act(async () => hook.result.current.actions.sendNow(hook.result.current.items[0].id))
+
+    expect(steerFollowUp).not.toHaveBeenCalled()
+    expect(input.runtime.sendMessage).not.toHaveBeenCalled()
+    expect(hook.result.current.items[0]).toMatchObject({
+      text: 'wait for approval',
+      phase: 'queued',
+      deferredUntilIdle: true
+    })
   })
 
   it('serializes Send now behind an in-flight admission', async () => {

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
@@ -180,6 +180,13 @@ const queueItemContextError = (
   return undefined
 }
 
+const queuePermissionIsPending = (
+  options: WorkspaceMessageQueueControllerOptions,
+  session: ChatSession
+): boolean =>
+  session.runtimeContext?.permission?.state === 'pending' ||
+  options.hasPendingPermissionRequest(session.id)
+
 const queueSessionIsSendable = (
   options: WorkspaceMessageQueueControllerOptions,
   session: ChatSession
@@ -191,7 +198,7 @@ const queueSessionIsSendable = (
   !options.promptInFlightSessionIds.includes(session.id) &&
   !options.sendPreparationInFlightSessionIds.includes(session.id) &&
   !options.saveAsSkillInFlightSessionIds.includes(session.id) &&
-  !options.hasPendingPermissionRequest(session.id) &&
+  !queuePermissionIsPending(options, session) &&
   !session.fixLoopActive &&
   !session.conversationGraphSyncBlocked &&
   !session.compacting &&
@@ -521,6 +528,15 @@ const useWorkspaceMessageQueueController = (
             return
           }
           if (!current.isSpecialistReady(queue.sessionId)) {
+            replaceItem(queue.sessionId, itemId, {
+              phase: 'queued',
+              error: undefined,
+              deferredUntilIdle: true
+            })
+            emit('Queued message will send after the current run finishes.')
+            return
+          }
+          if (queuePermissionIsPending(current, liveSession)) {
             replaceItem(queue.sessionId, itemId, {
               phase: 'queued',
               error: undefined,


### PR DESCRIPTION
## Problem

Responding to a durable permission request optimistically hides its approval card before Main has settled the response. The Workspace message queue used that visible projection as its only permission gate, so an error-state Session could auto-dispatch a queued prompt, or Send now could steer it, while the durable permission authority was still pending. That overlap can invalidate the in-flight Electron permission response and surface `reply was never sent`.

## Proposed change

- Treat the existing durable Session permission authority and the visible runtime request list as one queue permission gate.
- Keep both automatic dispatch and Send now queued until the pending permission authority settles.
- Add regression coverage for the optimistic-hidden auto-dispatch and native follow-up paths.

## Scope and non-goals

- Interaction change: Send now remains queued while permission approval is unresolved.
- No new data fields, enum values, dependencies, renderer APIs, ACP wire shapes, or provider translations.
- No persistence schema or migration change; the fix only reads the existing `runtimeContext.permission.state` projection.
- No historical-data compatibility work is required. Sessions without that existing projection continue to use the live pending-request gate.
- Queued messages remain transient and are not persisted.

## Acceptance criteria and validation

The regression tests were written and run before the production fix:

- Automatic dispatch repro: failed 3/3 times because `sendMessage` was called while durable permission authority remained pending.
- Send now repro: failed 2/2 times because `steerFollowUp` was called during the same pending window.

Final checks, all run after the last material edit:

- queued permission response gate -> `npm test -- src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts -t 'durable permission response is in flight'` -> 2 passed
- queue owner behavior -> `npm test -- src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts` -> 32 passed
- Workspace owner, contracts, and representative consumers -> `npm run test:module -- workspace_page` -> 25 files / 495 tests passed
- restored durable permission compatibility -> `npm test -- src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts -t 'reattaches a restored session before submitting its durable answer'` -> Claude Code, OpenCode, Codex Responses, and Codex Bridge: 4 passed
- renderer types -> `npm run typecheck:web` -> passed
- lint -> `npm run lint` -> passed
- patch hygiene -> `git diff --check` -> passed

The final affected-test plan selects only `workspace_page` with the `renderer_state` overlay. Framework launchers share the changed renderer gate; provider-specific ACP methods and transports are excluded because this diff does not alter protocol routing, correlation, or translation. Platform-specific lanes are excluded locally because the state predicate is platform-neutral. PR Gate remains authoritative for selected CI.

Uncovered risk: the exact Electron-generated `reply was never sent` string is not synthesized in a live desktop E2E. The deterministic regression tests instead pin the causal overlapping `sendMessage` / `steerFollowUp` behavior at the existing queue boundary.

## Review focus

- Confirm that durable pending authority must outlive optimistic approval-card hiding.
- Confirm that deferring Send now is preferable to injecting into a turn whose permission response is unresolved.
