### PR TITLE
fix(session): let users dismiss catalog recovery overlays

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -1248,7 +1248,20 @@ describe('App startup routing', () => {
     expect(alert?.textContent).toContain('A damaged saved conversation was moved aside')
     expect(alert?.textContent).toContain('You can still permanently delete the project')
     expect(container.querySelector('[data-testid="session-persistence-retry"]')).toBeNull()
-    expect(container.querySelector('[data-testid="session-persistence-dismiss"]')).toBeNull()
+    const dismiss = container.querySelector<HTMLButtonElement>(
+      '[data-testid="session-persistence-dismiss"]'
+    )
+    expect(dismiss?.getAttribute('aria-label')).toBe('Dismiss storage warning')
+    expect(container.querySelector('[data-testid="home-page"]')).not.toBeNull()
+    expect(
+      container.querySelector<HTMLElement>('[data-testid="home-page"]')?.dataset
+        .hasCompleteSessionCatalog
+    ).toBe('false')
+
+    await act(async () => dismiss?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+
+    expect(container.querySelector('[data-testid="session-persistence-alert"]')).toBeNull()
+    expect(container.textContent).not.toContain('saved conversation file was damaged')
     expect(container.querySelector('[data-testid="home-page"]')).not.toBeNull()
     expect(
       container.querySelector<HTMLElement>('[data-testid="home-page"]')?.dataset

--- a/src/renderer/src/components/SessionCatalogRecoveryAlert.render.test.tsx
+++ b/src/renderer/src/components/SessionCatalogRecoveryAlert.render.test.tsx
@@ -39,6 +39,7 @@ describe('SessionCatalogRecoveryAlert', () => {
       '[data-testid="session-persistence-retry"]'
     )
     expect(repair?.textContent).toBe('Repair index')
+    expect(container.querySelector('[data-testid="session-persistence-dismiss"]')).not.toBeNull()
     act(() => repair?.click())
     expect(onRetry).toHaveBeenCalledOnce()
   })
@@ -60,6 +61,29 @@ describe('SessionCatalogRecoveryAlert', () => {
     expect(container.textContent).toContain('A damaged saved conversation was moved aside')
     expect(container.textContent).toContain('You can still permanently delete the project')
     expect(container.querySelector('[data-testid="session-persistence-retry"]')).toBeNull()
+    const dismiss = container.querySelector<HTMLButtonElement>(
+      '[data-testid="session-persistence-dismiss"]'
+    )
+    expect(dismiss?.getAttribute('aria-label')).toBe('Dismiss storage warning')
+    act(() => dismiss?.click())
+    expect(container.querySelector('[data-testid="session-persistence-alert"]')).toBeNull()
+  })
+
+  it('does not offer overlay dismissal on the Settings archive reminder', () => {
+    act(() =>
+      root.render(
+        <SessionCatalogRecoveryAlert
+          inline
+          recovery={{
+            kind: 'damaged-authority',
+            affectedFileCount: 1
+          }}
+        />
+      )
+    )
+
+    expect(container.textContent).toContain('Project archive needs attention')
+    expect(container.querySelector('[data-testid="session-persistence-dismiss"]')).toBeNull()
   })
 
   it('requires an app update without offering a destructive repair for future Session files', () => {

--- a/src/renderer/src/components/SessionCatalogRecoveryAlert.tsx
+++ b/src/renderer/src/components/SessionCatalogRecoveryAlert.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { SessionCatalogRecovery } from '@/lib/session-persistence/session-persistence'
@@ -17,8 +18,15 @@ const SessionCatalogRecoveryAlert = ({
   onRetry
 }: SessionCatalogRecoveryAlertProps): React.JSX.Element | null => {
   const { t } = useTranslation()
+  const [isOverlayDismissed, setIsOverlayDismissed] = useState(false)
 
   if (recovery.kind === 'ready') return null
+  if (!inline && isOverlayDismissed) return null
+
+  // Overlay dismissal is session-local: archive remains blocked and Settings still shows the
+  // inline reminder. Restarting the app re-derives catalog recovery and shows the overlay again.
+  const onDismiss = inline ? undefined : () => setIsOverlayDismissed(true)
+
   if (recovery.kind === 'project-deletion-recovery') {
     return (
       <SessionPersistenceAlert
@@ -29,6 +37,7 @@ const SessionCatalogRecoveryAlert = ({
         inline={inline}
         onRetry={onRetry}
         retryLabel={t('Retry recovery')}
+        onDismiss={onDismiss}
       />
     )
   }
@@ -46,6 +55,7 @@ const SessionCatalogRecoveryAlert = ({
         )}
         variant="warning"
         inline={inline}
+        onDismiss={onDismiss}
       />
     )
   }
@@ -63,6 +73,7 @@ const SessionCatalogRecoveryAlert = ({
         )}
         variant="warning"
         inline={inline}
+        onDismiss={onDismiss}
       />
     )
   }
@@ -82,6 +93,7 @@ const SessionCatalogRecoveryAlert = ({
       inline={inline}
       onRetry={onRetry}
       retryLabel={t('Repair index')}
+      onDismiss={onDismiss}
     />
   )
 }


### PR DESCRIPTION
## Problem

When saved conversation files are quarantined, the catalog recovery warning (`Project archive needs attention`) stays pinned to the bottom-right of the app shell. `SessionPersistenceAlert` already supports a dismiss control, but catalog recovery never passed `onDismiss`, so users could not clear the overlay.

## Proposed change

Reuse the existing overlay dismiss control on catalog recovery alerts:

- Overlay (app shell, bottom-right) can be dismissed for the current session.
- Settings → Archived still shows the inline reminder.
- Catalog recovery state is unchanged: archive stays unavailable, healthy sessions stay usable, and the overlay can return after a restart.

## Scope and non-goals

- Overlay dismissal only. The Settings archive reminder is not dismissable.
- No change to catalog diagnostics, archive gates, or session load/write errors.
- No new user-visible copy.

## Compatibility notes

- **Historical data:** none. Existing quarantined session files are unchanged.
- **New enum/state values:** none. `SessionCatalogRecovery` kinds are unchanged.
- **Data persistence:** none. Dismissal is in-memory for the current renderer session. Restarting the app re-derives catalog recovery and can show the overlay again.

## Acceptance criteria and validation

- Damaged-authority overlay shows the existing dismiss button and hides after click.
- Dismissing the overlay does not fall through to the generic load-warning card.
- Home stays usable and `hasCompleteSessionCatalog` remains false.
- Inline Settings archive reminder has no dismiss control.

## Review focus

- Overlay-only dismissal vs. the durable Settings reminder.
- Session-local dismissal (restart can show the overlay again). This matches `dismissLoadWarning`; durable dismissal would need a persisted fingerprint of the recovery case.

## Test impact

These checks ran after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Overlay dismiss hides catalog recovery without surfacing load warning | `npx vitest run src/renderer/src/App.test.tsx src/renderer/src/components/SessionCatalogRecoveryAlert.render.test.tsx src/renderer/src/components/SessionPersistenceAlert.render.test.tsx` | pass (59 tests) |
| Renderer types | `npm run typecheck:web` | pass |
| Changed-file lint | `npx eslint` on the three edited files | pass |

Not run locally (PR CI is authoritative): full `npm test`, `typecheck:node`, and E2E.

**Uncovered risk:** `e2e/visual-regression.spec.ts` screenshots `session-recovery-warning.png`. Adding the dismiss control will change that snapshot; visual CI may need an updated baseline.