### PR TITLE
fix(acp): defer native follow-up during permission requests

### DIFF
--- a/src/main/acp/native-follow-up-workflow.test.ts
+++ b/src/main/acp/native-follow-up-workflow.test.ts
@@ -15,6 +15,7 @@ const createWorkflow = (
   overrides: {
     advertised?: boolean
     livePrompt?: boolean | (() => boolean)
+    pendingPermission?: boolean | (() => boolean)
     livePromptTurn?: () => { turnToken: string; signal: AbortSignal } | undefined
     frameworkId?: 'claude-code' | 'opencode' | 'codex'
     openCodeHttp?: boolean
@@ -67,6 +68,10 @@ const createWorkflow = (
         typeof overrides.livePrompt === 'function'
           ? overrides.livePrompt()
           : (overrides.livePrompt ?? true),
+      hasPendingPermission: () =>
+        typeof overrides.pendingPermission === 'function'
+          ? overrides.pendingPermission()
+          : (overrides.pendingPermission ?? false),
       livePrompt: () => {
         if (overrides.livePromptTurn) return overrides.livePromptTurn()
         const isLive =
@@ -246,6 +251,44 @@ describe('AcpNativeFollowUpWorkflow', () => {
       messageId: 'message-steer-1',
       text: 'see file'
     })
+  })
+
+  it.each(['claude-code', 'codex'] as const)(
+    'refuses %s ACP steering when permission becomes pending during preparation',
+    async (frameworkId) => {
+      let pendingPermission = false
+      const { request, workflow } = createWorkflow({
+        frameworkId,
+        pendingPermission: () => pendingPermission,
+        prepareFollowUp: async () => {
+          pendingPermission = true
+          return { prompt: [{ type: 'text' as const, text: 'late follow-up' }] }
+        }
+      })
+
+      await expect(
+        workflow.steerFollowUp({ sessionId: 'app-1', text: 'late follow-up' })
+      ).resolves.toEqual({ injected: false, reason: 'prompt-required' })
+      expect(request).not.toHaveBeenCalled()
+      expect(published).toEqual([])
+    }
+  )
+
+  it('refuses OpenCode HTTP follow-up while permission is pending', async () => {
+    const fetchImpl = vi.fn<FetchImpl>()
+    const { workflow } = createWorkflow({
+      advertised: false,
+      frameworkId: 'opencode',
+      openCodeHttp: true,
+      pendingPermission: true,
+      fetchImpl
+    })
+
+    await expect(
+      workflow.steerFollowUp({ sessionId: 'app-1', text: 'http-steer' })
+    ).resolves.toEqual({ injected: false, reason: 'prompt-required' })
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(published).toEqual([])
   })
 
   it('posts OpenCode HTTP follow-up into the v1 session when ACP steering is not advertised', async () => {

--- a/src/main/acp/native-follow-up-workflow.ts
+++ b/src/main/acp/native-follow-up-workflow.ts
@@ -80,6 +80,7 @@ type NativeFollowUpWorkflowOptions = Readonly<{
   openCodeUsageApi: () => AcpOpenCodeUsageApi | undefined
   activeProviderSessionId: (appSessionId: string) => string | undefined
   hasLivePrompt: (appSessionId: string) => boolean
+  hasPendingPermission: (appSessionId: string) => boolean
   livePrompt?: (appSessionId: string) => NativeFollowUpLivePrompt | undefined
   sessionCwd: (appSessionId: string) => string | undefined
   publishUserMessage: (input: NativeFollowUpUserMessage) => void
@@ -234,6 +235,15 @@ class AcpNativeFollowUpWorkflow {
         transport: route.transport
       })
       return refused('no-live-turn')
+    }
+    if (this.options.hasPendingPermission(request.sessionId)) {
+      log.info('native follow-up refused', {
+        sessionId: request.sessionId,
+        reason: 'prompt-required',
+        pendingPermission: true,
+        transport: route.transport
+      })
+      return refused('prompt-required')
     }
 
     const transportSignal = this.transportTimeout(route.transport)

--- a/src/main/acp/permission-context.ts
+++ b/src/main/acp/permission-context.ts
@@ -581,6 +581,10 @@ class AcpPermissionContext {
     return this.broker.getPendingRequests()
   }
 
+  hasPendingForSession(sessionId: string): boolean {
+    return this.broker.hasPendingForSession(sessionId)
+  }
+
   hasDurablePendingForSession(sessionId: string): boolean {
     return this.broker.hasDurablePendingForSession(sessionId)
   }

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -24,6 +24,7 @@ import { composeAcpRuntimeBaseOwners } from './runtime-base-composition'
 import type { RuntimeEventInput } from './runtime-snapshot-owner'
 import { AcpPermissionContext } from './permission-context'
 import { permissionRequestFingerprint } from './permission-broker'
+import { ACP_STEERING_METHOD } from './native-follow-up'
 import { ContextUsageTracker, type TokenCounter } from './context-usage-tracker'
 import {
   ACP_PROMPT_FAILED_EVENT_TITLE,
@@ -750,6 +751,8 @@ const startPermissionProbeAgent = (
       kind: 'allow_once' | 'allow_always' | 'reject_once' | 'reject_always'
     }>
     onPermissionResponse?: (response: unknown) => void
+    onSteer?: (params: unknown) => void
+    advertiseSteering?: boolean
     resume?: 'ok' | 'notFound'
   }
 ): void => {
@@ -761,6 +764,7 @@ const startPermissionProbeAgent = (
         loadSession: false,
         sessionCapabilities: { close: {}, ...(options.resume ? { resume: {} } : {}) }
       },
+      ...(options.advertiseSteering ? { _meta: { steering: { supported: true } } } : {}),
       authMethods: []
     }))
     .onRequest(acp.methods.agent.session.new, () => ({
@@ -877,6 +881,14 @@ const startPermissionProbeAgent = (
 
       return { stopReason: 'end_turn' }
     })
+    .onRequest(
+      ACP_STEERING_METHOD,
+      (params) => params,
+      (ctx) => {
+        options.onSteer?.(ctx.params)
+        return { outcome: 'injected' }
+      }
+    )
     .onNotification(acp.methods.agent.session.cancel, () => undefined)
     .onRequest(acp.methods.agent.session.close, () => ({}))
     .connect(
@@ -16805,6 +16817,43 @@ describe('ACP runtime session management', () => {
     expect(isolatedAgent.resumedSessions).toEqual([])
     expect(isolatedAgent.newSessions).toHaveLength(1)
     expect(sharedAgent.resumedSessions).toEqual([])
+  })
+
+  it('refuses native follow-up while a permission request is pending', async () => {
+    const process = new FakeAgentProcess()
+    const steeringRequests: unknown[] = []
+    startPermissionProbeAgent(process, {
+      newSessionId: 's1',
+      toolCallId: 'pending-command',
+      toolTitle: 'Run command',
+      advertiseSteering: true,
+      onSteer: (params) => steeringRequests.push(params),
+      permissionOptions: [
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject', name: 'Reject', kind: 'reject_once' }
+      ]
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process)
+    })
+
+    const session = await runtime.createSession({ cwd: '/workspace' })
+    const prompt = runtime.sendPrompt({ sessionId: session.sessionId, text: 'request permission' })
+    await vi.waitFor(() => expect(runtime.getSnapshot().pendingPermissions).toHaveLength(1))
+
+    const result = await runtime.steerFollowUp({
+      sessionId: session.sessionId,
+      text: 'follow up at the permission boundary'
+    })
+
+    const [pendingPermission] = runtime.getSnapshot().pendingPermissions
+    runtime.respondToPermission({ requestId: pendingPermission.requestId, optionId: 'reject' })
+    await prompt
+
+    expect(result.injected).toBe(false)
+    expect(steeringRequests).toEqual([])
   })
 
   it('returns detached snapshot collections without collapsing hidden event sequence slots', async () => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -520,6 +520,7 @@ class AcpRuntime {
       openCodeUsageApi: () => this.backendGeneration.openCodeUsageApi(),
       activeProviderSessionId: (sessionId) => this.activeSessionFor(sessionId)?.sessionId,
       hasLivePrompt: (sessionId) => this.sessionInteractions.current(sessionId)?.kind === 'prompt',
+      hasPendingPermission: (sessionId) => this.permissionContext.hasPendingForSession(sessionId),
       livePrompt: (sessionId) => {
         const current = this.sessionInteractions.current(sessionId)
         return current?.kind === 'prompt'


### PR DESCRIPTION
## Problem

When a permission request reaches Main just before its state is projected to the renderer, the stale queued-message UI can still accept a simultaneous **Send now** click. The renderer-side guard added on `main` only sees already-projected permission state, so the click can dispatch native follow-up steering while the provider is waiting for the permission response. In Claude Code this can strand the provider interaction and leave the workspace at `Waiting for your approval`; the reported save-session/EPIPE/degraded teardown logs occur later while quitting the stuck app.

The regression was reproduced at the public ACP runtime boundary before production changes. On unmodified code the focused test failed twice consistently because `steerFollowUp()` returned `injected: true` and the fake ACP provider received `_session/steering` while its permission request was unresolved.

## Proposed change

Fail closed at the shared Main-owned native-follow-up transport boundary. Immediately before ACP steering or OpenCode HTTP dispatch, consult the existing permission owner. If that Session has an unresolved permission request, return the existing `prompt-required` refusal. The renderer's existing refusal behavior keeps the message queued and sends it after the current interaction finishes.

## Scope and non-goals

- Covers Claude Code and Codex ACP steering, including Codex response/bridge paths that share the Codex ACP workflow.
- Covers OpenCode HTTP native follow-up.
- Does not add renderer timing delays, new UI state, or interaction changes.
- Does not change elicitation handling.
- Adds no data fields, schema changes, persistence, migration, historical-data compatibility path, data-model change, or new enum/status value.

## Acceptance criteria and validation

The final checks below ran after the last material edit.

- Pending permission rejects native follow-up without contacting the ACP provider -> `src/main/acp/runtime.test.ts` -> `rtk npm test -- --run src/main/acp/runtime.test.ts` -> **562 passed**.
- Claude Code/Codex ACP steering and OpenCode HTTP fail closed at the transport boundary -> `src/main/acp/native-follow-up-workflow.test.ts` -> focused three-file Vitest command below -> **passed**.
- Permission authority exposes the live per-Session pending decision -> `src/main/acp/permission-context.test.ts` -> focused three-file Vitest command below -> **passed**.
- Renderer keeps a refused Send now message queued/deferred -> `src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts` -> `rtk npm test -- --run src/main/acp/native-follow-up-workflow.test.ts src/main/acp/permission-context.test.ts src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts -t "permission|keeps Send now queued"` -> **32 passed, 49 skipped**.
- Affected Main process types -> `npm run typecheck:node` -> **passed**.
- Linted source -> `npm run lint` -> **passed**.
- Changed-file formatting and whitespace -> Prettier check and `git diff --check` -> **passed**.

The full portable test suite was intentionally not run locally per task scope; PR CI is authoritative. Web typecheck, persistence/migration checks, database checks, and platform/E2E lanes were excluded because no renderer/shared wire interface, persistence, schema, database, or platform-specific code changed. The exact human click scheduling remains nondeterministic in UI automation; the regression test controls and observes the same race at the public runtime/provider boundary without a production-only test seam.

## Review focus

- The permission check occurs after asynchronous follow-up preparation and immediately before transport dispatch, closing the relevant TOCTOU window.
- Refusal reuses `prompt-required`, so no shared result union or consumer contract expands.
- The pending message is not dropped or marked sent when dispatch is refused.
