### PR TITLE
fix(message-queue): make send now interrupt fallback

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -593,12 +593,13 @@ colors communicate a successful or failed probe/migration result.
   hairline separators rather than nested cards. Dragging over another row moves neighboring rows
   aside to preview whether the item will land before or after it. Each row also supports Arrow
   Up/Arrow Down keyboard reordering, Edit, Remove, and Send now. Edit moves an item back into an
-  unchanged empty composer. Send now promotes the item and tries to inject it into the current run
-  through the agent framework's native follow-up, without cancelling that run. While inject is in
-  flight, the row shows a sending state. If inject is unavailable or refused, the item stays queued,
-  the row explains that it will send after the current run finishes, and the queue drains it when
-  the Session becomes sendable. Stop remains the explicit control for cancelling a live turn. Branch,
-  admission, or edit failures keep the row and show a recoverable inline error.
+  unchanged empty composer. Send now promotes the item and first tries to inject it into the current
+  run through the agent framework's native follow-up, without cancelling that run. While inject is in
+  flight, the row shows a sending state. If inject is unavailable or refused, Send now stops the live
+  turn and dispatches the promoted item as soon as the Session becomes sendable; the row shows a
+  stopping state while cancellation is in flight. Stop remains the explicit control for cancelling a
+  live turn without sending a queued message. Branch, admission, cancellation, or edit failures keep
+  the row and show a recoverable inline error.
 - Queued messages are transient and Session-scoped. They are not persisted across renderer restart.
   Bind each item to its admission Message Branch and block branch switching or inline message edits
   while that Session has queued work so a later dispatch cannot silently retarget it. Pause queue

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
@@ -724,7 +724,7 @@ describe('workspace message queue controller', () => {
         error: { kind: 'send', detail: resumeError }
       })
     )
-    expect(input.runtime.cancelRun).not.toHaveBeenCalled()
+    expect(input.runtime.cancelRun).toHaveBeenCalledWith('session-a')
   })
 
   it('keeps a generic admission miss when Send now fails without a new session error', async () => {
@@ -946,7 +946,7 @@ describe('workspace message queue controller', () => {
     expect(input.composer.discardSnapshot).toHaveBeenCalledTimes(2)
   })
 
-  it('keeps Send now queued until the current run finishes when native follow-up is unavailable', async () => {
+  it('stops the current run and sends immediately when native follow-up is unavailable', async () => {
     const order: string[] = []
     let currentSession = session()
     const input = options(currentSession, {
@@ -967,15 +967,12 @@ describe('workspace message queue controller', () => {
     act(() => hook.result.current.lifecycle.enqueue(admission('wait')))
 
     await act(async () => hook.result.current.actions.sendNow(hook.result.current.items[0].id))
-    expect(order).toEqual([])
-    expect(input.runtime.cancelRun).not.toHaveBeenCalled()
-    expect(hook.result.current.items[0]).toMatchObject({
-      text: 'wait',
-      phase: 'queued',
-      deferredUntilIdle: true
-    })
+    expect(order).toEqual(['cancel'])
+    expect(hook.result.current.items[0]).toMatchObject({ text: 'wait', phase: 'interrupting' })
+    expect(hook.result.current.announcement).toBe(
+      'Stopping the current run before sending the queued message.'
+    )
 
-    currentSession = session('idle')
     hook.rerender(
       options(currentSession, {
         ...input,
@@ -984,8 +981,8 @@ describe('workspace message queue controller', () => {
         getSession: () => currentSession
       })
     )
-    await vi.waitFor(() => expect(order).toEqual(['send']))
-    expect(input.runtime.cancelRun).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(order).toEqual(['cancel', 'send']))
+    await vi.waitFor(() => expect(hook.result.current.items).toEqual([]))
   })
 
   it('serializes Send now behind an in-flight admission', async () => {
@@ -1029,26 +1026,16 @@ describe('workspace message queue controller', () => {
       completions[0]()
       await sendNow
     })
-    expect(input.runtime.cancelRun).not.toHaveBeenCalled()
-    expect(sendMessage).toHaveBeenCalledOnce()
+    expect(input.runtime.cancelRun).toHaveBeenCalledWith('session-a')
+    expect(sendMessage).toHaveBeenCalledTimes(2)
     expect(hook.result.current.items.map((item) => item.text)).toEqual(['second'])
-    expect(hook.result.current.items[0]?.phase).toBe('queued')
+    expect(hook.result.current.items[0]?.phase).toBe('sending')
 
-    currentSession = session('idle')
-    hook.rerender(
-      options(currentSession, {
-        ...input,
-        activeSession: currentSession,
-        promptInFlightSessionIds: [],
-        getSession: () => currentSession
-      })
-    )
-    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(2))
     await act(async () => completions[1]())
     await vi.waitFor(() => expect(hook.result.current.items).toEqual([]))
   })
 
-  it('does not cancel the current run when native follow-up is unavailable', async () => {
+  it('surfaces a cancellation failure when native follow-up is unavailable', async () => {
     const input = options(session(), {
       runtime: {
         cancelRun: vi.fn(async () => {
@@ -1066,10 +1053,10 @@ describe('workspace message queue controller', () => {
     expect(hook.result.current.items).toHaveLength(1)
     expect(hook.result.current.items[0]).toMatchObject({
       text: 'keep me',
-      phase: 'queued',
-      deferredUntilIdle: true
+      phase: 'error',
+      error: { kind: 'cancel', detail: 'runtime refused cancellation' }
     })
-    expect(input.runtime.cancelRun).not.toHaveBeenCalled()
+    expect(input.runtime.cancelRun).toHaveBeenCalledWith('session-a')
     expect(input.runtime.sendMessage).not.toHaveBeenCalled()
   })
 
@@ -1202,7 +1189,7 @@ describe('workspace message queue controller', () => {
     expect(hook.result.current.items).toEqual([])
   })
 
-  it('requeues when native follow-up is refused instead of interrupting', async () => {
+  it('interrupts and sends when native follow-up is refused', async () => {
     let currentSession = session()
     const input = options(currentSession, {
       getSession: () => currentSession,
@@ -1222,12 +1209,11 @@ describe('workspace message queue controller', () => {
     act(() => hook.result.current.lifecycle.enqueue(admission('fallback')))
 
     await act(async () => hook.result.current.actions.sendNow(hook.result.current.items[0].id))
-    expect(input.runtime.cancelRun).not.toHaveBeenCalled()
+    expect(input.runtime.cancelRun).toHaveBeenCalledWith('session-a')
     expect(input.runtime.sendMessage).not.toHaveBeenCalled()
     expect(hook.result.current.items[0]).toMatchObject({
       text: 'fallback',
-      phase: 'queued',
-      deferredUntilIdle: true
+      phase: 'interrupting'
     })
 
     currentSession = session('idle')

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.ts
@@ -588,24 +588,48 @@ const useWorkspaceMessageQueueController = (
               return
             }
           } catch {
-            // Native follow-up is fail-closed. Keep the current run and send after it finishes.
+            // Fall back to interrupting the live turn below.
           }
-          replaceItem(queue.sessionId, itemId, { phase: 'queued', error: undefined })
-          if (owner.dispatches.get(queue.sessionId) === displacedDispatch) {
-            owner.dispatches.delete(queue.sessionId)
-          }
+        }
+        if (liveTurn && hasPayload) {
           const latest = owner.resolveOptions(optionsRef.current)
           const latestSession = latest.getSession(queue.sessionId)
-          if (!latestSession || queueSessionIsSendable(latest, latestSession)) {
+          const latestLiveTurn =
+            latestSession?.status === 'running' ||
+            latestSession?.status === 'waiting-for-user' ||
+            latestSession?.status === 'waiting-permission'
+          if (!latestSession || !latestLiveTurn || queueSessionIsSendable(latest, latestSession)) {
+            replaceItem(queue.sessionId, itemId, {
+              phase: 'queued',
+              error: undefined,
+              deferredUntilIdle: false
+            })
+            if (owner.dispatches.get(queue.sessionId) === displacedDispatch) {
+              owner.dispatches.delete(queue.sessionId)
+            }
             drainQueues()
             return
           }
+          const contextError = queueItemContextError(latestSession, item)
+          if (contextError) {
+            replaceItem(queue.sessionId, itemId, {
+              phase: 'error',
+              error: contextError,
+              deferredUntilIdle: false
+            })
+            return
+          }
           replaceItem(queue.sessionId, itemId, {
-            phase: 'queued',
+            phase: 'interrupting',
             error: undefined,
-            deferredUntilIdle: true
+            deferredUntilIdle: false
           })
-          emit('Queued message will send after the current run finishes.')
+          emit('Stopping the current run before sending the queued message.')
+          await latest.runtime.cancelRun(queue.sessionId)
+          if (owner.dispatches.get(queue.sessionId) === displacedDispatch) {
+            owner.dispatches.delete(queue.sessionId)
+          }
+          drainQueues()
           return
         }
         if (liveTurn) {


### PR DESCRIPTION
## Problem

When a queued message used **Send now** during a live turn, the renderer tried native follow-up once. If that capability was missing, refused, or threw, the item was put back into the queue with “will send after the current run finishes.” No cancellation or immediate send occurred, which contradicted the action label.

The public queue-controller regression was run three times against the unfixed code. Each run failed with the same symptom: expected `cancel -> send`, received no runtime calls.

## Proposed change

- Preserve the native follow-up fast path: successful injection still does not interrupt the live turn.
- If injection is unavailable, refused, or throws while the turn is still live, move the item to the existing `interrupting` phase, cancel the live turn, then drain the queue as soon as the session is sendable.
- Re-read session state after the native attempt so a turn that naturally ended during injection is sent without an unnecessary cancellation.
- Surface cancellation failure on the queued row instead of silently deferring it.
- Update the renderer design specification to match the interaction.

## Scope and non-goals

- The change is renderer-side and applies uniformly to every agent framework through the shared `cancelRun`/`sendMessage` boundary. Framework-specific native follow-up success behavior is unchanged.
- No new queue phase or enum value is introduced; the existing `interrupting` phase is reused.
- No persistence or migration changes. Queued messages remain transient renderer memory.
- No historical-data compatibility handling is required.
- Specialist readiness and other admission barriers remain authoritative; **Send now** cannot bypass an unavailable captured Specialist or invalid queue context.

## Acceptance criteria and validation

All listed checks ran after the last material edit on commit `4f8f8906`.

- Native follow-up unavailable/refused/throws -> `npm run test:module -- workspace_page` -> 25 files, 496 tests passed.
- Successful native injection and ACP refusal contracts remain intact -> `npm test -- src/main/acp/native-follow-up.test.ts src/main/acp/native-follow-up-workflow.test.ts` -> 2 files, 24 tests passed.
- Renderer process type safety -> `npm run typecheck:web` -> passed.
- Source/style validation -> `npm run lint` -> passed.
- Diff hygiene -> `git diff --check` -> passed before commit.

The exact-head impact planner selects the full fallback because `docs/design.md` has no module owner. Per project guidance, the complete portable/platform suite is left to PR Gate. Uncovered locally: packaged Electron UI and cross-platform behavior.

## Review focus

- The state re-check between failed native injection and cancellation, especially the race where the live turn finishes naturally.
- Queue ordering after an in-flight admission completes.
- Whether cancellation errors remain recoverable without losing the queued payload.
