### PR TITLE
feat(archive): add keyboard undo shortcut

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -392,6 +392,12 @@ colors communicate a successful or failed probe/migration result.
   recovery, legacy data move, update, compute approval, Connector approval, Skill import approval,
   global search, Settings, preview, then base content. A covered presentation stays requested and
   resumes when higher-priority work clears.
+- A successful Project or Session archive adds an eight-second app-root Undo receipt. The latest
+  unexpired archive owns the visible shortcut hint and responds to `Cmd+Z` on macOS or `Ctrl+Z` on
+  Windows/Linux; older receipts remain clickable. Text inputs, textareas, selects, ARIA textboxes,
+  contenteditable editors, IME composition, modified chords, and key repeat retain native behavior.
+  Expired receipts never consume the shortcut, and Settings -> Archived remains the durable restore
+  path after the transient receipt disappears.
 - Session visibility, App Shell shortcut eligibility, and `Cmd/Ctrl+W` routing must consume that
   projection. Do not rebuild parallel Boolean gate lists in `AppContent` or feature components.
 - When a presentation above preview/base owns the shell, base content is `inert` and

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -261,6 +261,10 @@ const AppContent = (): React.JSX.Element | null => {
     return 'handled'
   }, [appShellPresentation])
   useCloseActivePaneShortcut(resolveCloseRequest)
+  const allowsArchiveUndoShortcut = useCallback(
+    () => appShellPresentation.allowsShortcut('archiveUndo'),
+    [appShellPresentation]
+  )
 
   const retrySettingsInitialization = useCallback(async (): Promise<void> => {
     if (await loadSettings({ force: true })) await checkEnvironment()
@@ -664,7 +668,7 @@ const AppContent = (): React.JSX.Element | null => {
         />
         <ConnectorAuthToast />
         <NotificationLiveToast />
-        <PermissionUndoSnackbar />
+        <PermissionUndoSnackbar allowsArchiveShortcut={allowsArchiveUndoShortcut} />
       </div>
       <WebEventRecoveryDialog
         active={activePresentation === 'webEventRecovery'}

--- a/src/renderer/src/app-shell-presentation-owner.architecture.test.ts
+++ b/src/renderer/src/app-shell-presentation-owner.architecture.test.ts
@@ -128,6 +128,7 @@ describe('App Shell presentation owner architecture', () => {
     )
     expect(appSource).toContain("!appShellPresentation.allowsShortcut('settings')")
     expect(appSource).toContain("!appShellPresentation.allowsShortcut('globalSearch')")
+    expect(appSource).toContain("appShellPresentation.allowsShortcut('archiveUndo')")
     expect(appSource).toContain('const action = appShellPresentation.resolveCloseAction()')
     expect(appSource).not.toContain('STREAMDOWN_FULLSCREEN_SELECTOR')
     expect(appSource).not.toContain('document.querySelector')

--- a/src/renderer/src/app-shell-presentation-owner.test.ts
+++ b/src/renderer/src/app-shell-presentation-owner.test.ts
@@ -84,17 +84,20 @@ describe('App Shell presentation owner', () => {
     const base = resolveAppShellPresentation(input())
     expect(base.allowsShortcut('settings')).toBe(true)
     expect(base.allowsShortcut('globalSearch')).toBe(true)
+    expect(base.allowsShortcut('archiveUndo')).toBe(true)
 
     const nestedDialog = document.createElement('div')
     nestedDialog.setAttribute('role', 'dialog')
     document.body.appendChild(nestedDialog)
     expect(base.allowsShortcut('settings')).toBe(false)
     expect(base.allowsShortcut('globalSearch')).toBe(false)
+    expect(base.allowsShortcut('archiveUndo')).toBe(false)
     nestedDialog.remove()
 
     const search = resolveAppShellPresentation(input({ globalSearch: true }))
     expect(search.allowsShortcut('globalSearch')).toBe(true)
     expect(search.allowsShortcut('settings')).toBe(false)
+    expect(search.allowsShortcut('archiveUndo')).toBe(false)
     expect(
       resolveAppShellPresentation(input({ settings: true })).allowsShortcut('globalSearch')
     ).toBe(false)

--- a/src/renderer/src/app-shell-presentation-owner.ts
+++ b/src/renderer/src/app-shell-presentation-owner.ts
@@ -24,7 +24,7 @@ export type AppShellPresentationInput = Readonly<{
 }>
 
 export type AppShellPresentation = keyof AppShellPresentationState | 'startup' | 'base'
-export type AppShellShortcut = 'settings' | 'globalSearch'
+export type AppShellShortcut = 'settings' | 'globalSearch' | 'archiveUndo'
 
 export type AppShellCloseAction =
   | Readonly<{ kind: 'consume' }>

--- a/src/renderer/src/components/PermissionUndoSnackbar.test.tsx
+++ b/src/renderer/src/components/PermissionUndoSnackbar.test.tsx
@@ -6,7 +6,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { i18next } from '@/i18n'
 import { usePermissionGrantsStore } from '@/stores/permission-grants-store'
 import { useArchiveUndoStore } from '@/stores/archive-undo-store'
-import { PermissionUndoSnackbar } from './PermissionUndoSnackbar'
+import { PermissionUndoSnackbar as PermissionUndoSnackbarComponent } from './PermissionUndoSnackbar'
+
+const PermissionUndoSnackbar = (): React.JSX.Element => (
+  <PermissionUndoSnackbarComponent allowsArchiveShortcut={() => true} />
+)
 
 const archivedProjectNotice = (
   id = 'project-1',
@@ -211,6 +215,50 @@ describe('PermissionUndoSnackbar', () => {
       expectedArchivedAt: 20
     })
     expect(restore).not.toHaveBeenCalled()
+  })
+
+  it('leaves Cmd+Z untouched when the App Shell presentation owner blocks archive Undo', async () => {
+    useArchiveUndoStore.setState({
+      notices: [archivedProjectNotice()],
+      restoringKey: undefined
+    })
+    await act(async () =>
+      root.render(<PermissionUndoSnackbarComponent allowsArchiveShortcut={() => false} />)
+    )
+    const shortcut = new KeyboardEvent('keydown', {
+      key: 'z',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+
+    await act(async () => window.dispatchEvent(shortcut))
+
+    expect(shortcut.defaultPrevented).toBe(false)
+    expect(updateProjectArchive).not.toHaveBeenCalled()
+  })
+
+  it('moves the shortcut hint to the latest remaining unexpired archive receipt', async () => {
+    const expiring = archivedProjectNotice('project-2', 20, 'Expiring')
+    expiring.expiresAt = Date.now() + 1_000
+    const remaining = archivedProjectNotice('project-1', 10, 'Remaining')
+    useArchiveUndoStore.setState({ notices: [expiring, remaining], restoringKey: undefined })
+    await act(async () => root.render(<PermissionUndoSnackbar />))
+    const firstSnackbar = container.querySelector<HTMLElement>(
+      '[data-testid="archive-undo-snackbar"]'
+    )
+    await act(async () =>
+      firstSnackbar?.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+    )
+
+    await act(async () => vi.advanceTimersByTimeAsync(1_000))
+
+    const actions = container.querySelectorAll<HTMLButtonElement>(
+      '[data-testid="archive-undo-snackbar"] button:not([aria-label])'
+    )
+    expect(actions[0]?.hasAttribute('aria-keyshortcuts')).toBe(false)
+    expect(actions[1]?.getAttribute('aria-keyshortcuts')).toBe('Meta+Z')
+    expect(actions[1]?.textContent).toContain('⌘Z')
   })
 
   it('uses Ctrl+Z outside macOS', async () => {

--- a/src/renderer/src/components/PermissionUndoSnackbar.test.tsx
+++ b/src/renderer/src/components/PermissionUndoSnackbar.test.tsx
@@ -8,6 +8,20 @@ import { usePermissionGrantsStore } from '@/stores/permission-grants-store'
 import { useArchiveUndoStore } from '@/stores/archive-undo-store'
 import { PermissionUndoSnackbar } from './PermissionUndoSnackbar'
 
+const archivedProjectNotice = (
+  id = 'project-1',
+  archivedAt = 10,
+  name = 'Project'
+): ReturnType<typeof useArchiveUndoStore.getState>['notices'][number] => ({
+  key: `project:${id}:${archivedAt}`,
+  kind: 'project',
+  projectId: id,
+  archivedAt,
+  expiresAt: Date.now() + 8_000,
+  messageKey: 'Archived project “{{name}}”.',
+  messageParams: { name }
+})
+
 describe('PermissionUndoSnackbar', () => {
   let container: HTMLDivElement
   let root: Root
@@ -42,6 +56,7 @@ describe('PermissionUndoSnackbar', () => {
       updatedAt: 1
     })
     window.api = {
+      platform: 'darwin',
       permissions: { extendUndo, restore },
       projects: { updateArchive: updateProjectArchive }
     } as unknown as Window['api']
@@ -129,17 +144,7 @@ describe('PermissionUndoSnackbar', () => {
 
   it('shares the top stack with Archive Undo actions', async () => {
     useArchiveUndoStore.setState({
-      notices: [
-        {
-          key: 'project:project-1:10',
-          kind: 'project',
-          projectId: 'project-1',
-          archivedAt: 10,
-          expiresAt: Date.now() + 8_000,
-          messageKey: 'Archived project “{{name}}”.',
-          messageParams: { name: 'Project' }
-        }
-      ],
+      notices: [archivedProjectNotice()],
       restoringKey: undefined
     })
     await act(async () => root.render(<PermissionUndoSnackbar />))
@@ -160,6 +165,119 @@ describe('PermissionUndoSnackbar', () => {
       expectedArchivedAt: 10
     })
     expect(container.querySelector('[data-testid="archive-undo-snackbar"]')).toBeNull()
+  })
+
+  it('shows the platform shortcut only on the latest Archive Undo action', async () => {
+    useArchiveUndoStore.setState({
+      notices: [
+        archivedProjectNotice('project-2', 20, 'Latest'),
+        archivedProjectNotice('project-1', 10, 'Earlier')
+      ],
+      restoringKey: undefined
+    })
+    await act(async () => root.render(<PermissionUndoSnackbar />))
+
+    const actions = container.querySelectorAll<HTMLButtonElement>(
+      '[data-testid="archive-undo-snackbar"] button:not([aria-label])'
+    )
+    expect(actions[0]?.getAttribute('aria-keyshortcuts')).toBe('Meta+Z')
+    expect(actions[0]?.textContent).toContain('⌘Z')
+    expect(actions[1]?.hasAttribute('aria-keyshortcuts')).toBe(false)
+    expect(actions[1]?.textContent).not.toContain('⌘Z')
+  })
+
+  it('undoes the latest archive with Cmd+Z without restoring a permission receipt', async () => {
+    useArchiveUndoStore.setState({
+      notices: [
+        archivedProjectNotice('project-2', 20, 'Latest'),
+        archivedProjectNotice('project-1', 10, 'Earlier')
+      ],
+      restoringKey: undefined
+    })
+    await act(async () => root.render(<PermissionUndoSnackbar />))
+    const shortcut = new KeyboardEvent('keydown', {
+      key: 'z',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+
+    await act(async () => window.dispatchEvent(shortcut))
+
+    expect(shortcut.defaultPrevented).toBe(true)
+    expect(updateProjectArchive).toHaveBeenCalledWith({
+      id: 'project-2',
+      archived: false,
+      expectedArchivedAt: 20
+    })
+    expect(restore).not.toHaveBeenCalled()
+  })
+
+  it('uses Ctrl+Z outside macOS', async () => {
+    window.api.platform = 'win32'
+    useArchiveUndoStore.setState({
+      notices: [archivedProjectNotice()],
+      restoringKey: undefined
+    })
+    await act(async () => root.render(<PermissionUndoSnackbar />))
+    const action = container.querySelector<HTMLButtonElement>(
+      '[data-testid="archive-undo-snackbar"] button:not([aria-label])'
+    )
+    const shortcut = new KeyboardEvent('keydown', {
+      key: 'z',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+
+    expect(action?.getAttribute('aria-keyshortcuts')).toBe('Control+Z')
+    expect(action?.textContent).toContain('Ctrl+Z')
+
+    await act(async () => window.dispatchEvent(shortcut))
+
+    expect(shortcut.defaultPrevented).toBe(true)
+    expect(updateProjectArchive).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    ['input', () => document.createElement('input')],
+    ['textarea', () => document.createElement('textarea')],
+    [
+      'contenteditable',
+      () => {
+        const editor = document.createElement('div')
+        editor.setAttribute('contenteditable', 'true')
+        return editor
+      }
+    ],
+    [
+      'ARIA textbox',
+      () => {
+        const editor = document.createElement('div')
+        editor.setAttribute('role', 'textbox')
+        return editor
+      }
+    ]
+  ])('preserves native Cmd+Z in an %s', async (_, createEditor) => {
+    useArchiveUndoStore.setState({
+      notices: [archivedProjectNotice()],
+      restoringKey: undefined
+    })
+    await act(async () => root.render(<PermissionUndoSnackbar />))
+    const editor = createEditor()
+    document.body.appendChild(editor)
+    const shortcut = new KeyboardEvent('keydown', {
+      key: 'z',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+
+    await act(async () => editor.dispatchEvent(shortcut))
+
+    expect(shortcut.defaultPrevented).toBe(false)
+    expect(updateProjectArchive).not.toHaveBeenCalled()
+    editor.remove()
   })
 
   it('renews the authoritative receipt while automatic dismissal is paused by hover', async () => {

--- a/src/renderer/src/components/PermissionUndoSnackbar.tsx
+++ b/src/renderer/src/components/PermissionUndoSnackbar.tsx
@@ -244,7 +244,11 @@ const ArchiveUndoItem = ({
 
 // App-root ownership keeps Undo available when Settings closes. The Registry receipt remains the
 // authority; this component only owns its short-lived renderer presentation.
-const PermissionUndoSnackbar = (): React.JSX.Element | null => {
+const PermissionUndoSnackbar = ({
+  allowsArchiveShortcut
+}: {
+  allowsArchiveShortcut: () => boolean
+}): React.JSX.Element | null => {
   const undo = usePermissionGrantsStore((state) => state.undo)
   const undoQueue = usePermissionGrantsStore((state) => state.undoQueue)
   const restore = usePermissionGrantsStore((state) => state.restore)
@@ -255,6 +259,26 @@ const PermissionUndoSnackbar = (): React.JSX.Element | null => {
   const restoreArchive = useArchiveUndoStore((state) => state.undo)
   const dismissArchive = useArchiveUndoStore((state) => state.dismiss)
   const archiveRestoringKey = useArchiveUndoStore((state) => state.restoringKey)
+  const [archiveProjectionTime, setArchiveProjectionTime] = useState(() => Date.now())
+  const archiveShortcutTargetKey = archiveNotices.find(
+    (notice) => notice.expiresAt > archiveProjectionTime
+  )?.key
+
+  useEffect(() => {
+    const nextExpiry = archiveNotices
+      .filter((notice) => notice.expiresAt > archiveProjectionTime)
+      .reduce<number | undefined>(
+        (earliest, notice) =>
+          earliest === undefined ? notice.expiresAt : Math.min(earliest, notice.expiresAt),
+        undefined
+      )
+    if (nextExpiry === undefined) return
+    const timer = window.setTimeout(
+      () => setArchiveProjectionTime(Date.now()),
+      Math.max(0, nextExpiry - Date.now())
+    )
+    return () => window.clearTimeout(timer)
+  }, [archiveNotices, archiveProjectionTime])
 
   useEffect(() => {
     const undoLatestArchive = (event: KeyboardEvent): void => {
@@ -270,22 +294,25 @@ const PermissionUndoSnackbar = (): React.JSX.Element | null => {
         !primaryModifier ||
         event.altKey ||
         event.shiftKey ||
-        isEditableShortcutTarget(event.target)
+        isEditableShortcutTarget(event.target) ||
+        !allowsArchiveShortcut()
       ) {
         return
       }
 
       const archiveUndo = useArchiveUndoStore.getState()
-      const latest = archiveUndo.notices.find((notice) => notice.expiresAt > Date.now())
-      if (!latest || archiveUndo.restoringKey !== undefined) return
+      const target = archiveUndo.notices.find(
+        (notice) => notice.key === archiveShortcutTargetKey && notice.expiresAt > Date.now()
+      )
+      if (!target || archiveUndo.restoringKey !== undefined) return
 
       event.preventDefault()
-      void archiveUndo.undo(latest.key)
+      void archiveUndo.undo(target.key)
     }
 
     window.addEventListener('keydown', undoLatestArchive)
     return () => window.removeEventListener('keydown', undoLatestArchive)
-  }, [])
+  }, [allowsArchiveShortcut, archiveShortcutTargetKey])
 
   const items = useMemo(
     () => [undo, ...undoQueue].filter((item): item is PermissionUndo => Boolean(item)),
@@ -312,14 +339,14 @@ const PermissionUndoSnackbar = (): React.JSX.Element | null => {
             isRestoring={isRestoring}
           />
         ))}
-        {archiveNotices.map((item, index) => (
+        {archiveNotices.map((item) => (
           <ArchiveUndoItem
             key={item.key}
             undo={item}
             dismiss={dismissArchive}
             restore={restoreArchive}
             isRestoring={archiveRestoringKey === item.key}
-            isShortcutTarget={index === 0}
+            isShortcutTarget={item.key === archiveShortcutTargetKey}
           />
         ))}
       </div>

--- a/src/renderer/src/components/PermissionUndoSnackbar.tsx
+++ b/src/renderer/src/components/PermissionUndoSnackbar.tsx
@@ -8,6 +8,17 @@ import { usePermissionGrantsStore } from '@/stores/permission-grants-store'
 import type { PermissionUndo } from '@/stores/permission-grants-store'
 import { useArchiveUndoStore, type ArchiveUndo } from '@/stores/archive-undo-store'
 
+const EDITABLE_SHORTCUT_TARGET =
+  'input, textarea, select, [role="textbox"], [contenteditable]:not([contenteditable="false"])'
+
+const archiveUndoShortcut = (): { aria: string; label: string } =>
+  window.api.platform === 'darwin'
+    ? { aria: 'Meta+Z', label: '⌘Z' }
+    : { aria: 'Control+Z', label: 'Ctrl+Z' }
+
+const isEditableShortcutTarget = (target: EventTarget | null): boolean =>
+  target instanceof Element && target.closest(EDITABLE_SHORTCUT_TARGET) !== null
+
 const PermissionUndoItem = ({
   undo,
   extend,
@@ -133,14 +144,17 @@ const ArchiveUndoItem = ({
   undo,
   dismiss,
   restore,
-  isRestoring
+  isRestoring,
+  isShortcutTarget
 }: {
   undo: ArchiveUndo
   dismiss: (key: string) => void
   restore: (key: string) => Promise<void>
   isRestoring: boolean
+  isShortcutTarget: boolean
 }): React.JSX.Element => {
   const { t } = useTranslation()
+  const shortcut = archiveUndoShortcut()
 
   const [pointerPaused, setPointerPaused] = useState(false)
   const [focusPaused, setFocusPaused] = useState(false)
@@ -178,6 +192,7 @@ const ArchiveUndoItem = ({
         variant="ghost"
         size="sm"
         className="relative ml-1 h-8 gap-1.5 whitespace-nowrap px-2 font-medium before:absolute before:-inset-y-1.5 before:inset-x-0 before:content-['']"
+        aria-keyshortcuts={isShortcutTarget ? shortcut.aria : undefined}
         disabled={isRestoring}
         onClick={() => void restore(undo.key)}
       >
@@ -196,6 +211,14 @@ const ArchiveUndoItem = ({
           : undo.retry
             ? t('Retry')
             : t('Undo')}
+        {isShortcutTarget && !isRestoring ? (
+          <kbd
+            aria-hidden="true"
+            className="rounded border border-border/80 bg-muted px-1 py-0.5 font-mono text-[10px] leading-none text-muted-foreground"
+          >
+            {shortcut.label}
+          </kbd>
+        ) : null}
       </Button>
       <TooltipProvider delayDuration={200}>
         <Tooltip>
@@ -233,6 +256,37 @@ const PermissionUndoSnackbar = (): React.JSX.Element | null => {
   const dismissArchive = useArchiveUndoStore((state) => state.dismiss)
   const archiveRestoringKey = useArchiveUndoStore((state) => state.restoringKey)
 
+  useEffect(() => {
+    const undoLatestArchive = (event: KeyboardEvent): void => {
+      const primaryModifier =
+        window.api.platform === 'darwin'
+          ? event.metaKey && !event.ctrlKey
+          : event.ctrlKey && !event.metaKey
+      if (
+        event.defaultPrevented ||
+        event.isComposing ||
+        event.repeat ||
+        event.key.toLowerCase() !== 'z' ||
+        !primaryModifier ||
+        event.altKey ||
+        event.shiftKey ||
+        isEditableShortcutTarget(event.target)
+      ) {
+        return
+      }
+
+      const archiveUndo = useArchiveUndoStore.getState()
+      const latest = archiveUndo.notices.find((notice) => notice.expiresAt > Date.now())
+      if (!latest || archiveUndo.restoringKey !== undefined) return
+
+      event.preventDefault()
+      void archiveUndo.undo(latest.key)
+    }
+
+    window.addEventListener('keydown', undoLatestArchive)
+    return () => window.removeEventListener('keydown', undoLatestArchive)
+  }, [])
+
   const items = useMemo(
     () => [undo, ...undoQueue].filter((item): item is PermissionUndo => Boolean(item)),
     [undo, undoQueue]
@@ -258,13 +312,14 @@ const PermissionUndoSnackbar = (): React.JSX.Element | null => {
             isRestoring={isRestoring}
           />
         ))}
-        {archiveNotices.map((item) => (
+        {archiveNotices.map((item, index) => (
           <ArchiveUndoItem
             key={item.key}
             undo={item}
             dismiss={dismissArchive}
             restore={restoreArchive}
             isRestoring={archiveRestoringKey === item.key}
+            isShortcutTarget={index === 0}
           />
         ))}
       </div>


### PR DESCRIPTION
## Problem

Archiving a Project or Session already exposes a short-lived Undo action, but keyboard users must move focus to the snackbar and activate the button. The standard desktop Undo shortcut does not restore the latest archive.

## Proposed change

- Let the latest unexpired archive receipt respond to `Cmd+Z` on macOS and `Ctrl+Z` on Windows/Linux.
- Preserve native undo in inputs, textareas, selects, ARIA textboxes, and contenteditable editors.
- Ignore composition, repeat, alternate modifiers, and chords reserved for redo.
- Show the platform shortcut only on the archive receipt that the shortcut will target, with `aria-keyshortcuts` for assistive technology.
- Document the interaction and the durable Settings -> Archived fallback.

## Scope and non-goals

- Covers Project and Session archive receipts only.
- Does not change permission-revocation Undo receipts, the eight-second archive receipt duration, or restore persistence.
- Adds no schema, migration, enum value, renderer API, dependency, or translated copy.
- Historical compatibility: not applicable; no stored format changes.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Latest Project/Session archive shortcut, platform keycap, receipt ordering, permission-receipt isolation, and native editor precedence -> `npm test -- src/renderer/src/components/PermissionUndoSnackbar.test.tsx` -> 17 tests passed.
- Renderer TypeScript surface -> `npm run typecheck:web` -> passed.
- Source and documentation lint -> `npm run lint` -> passed.
- Final diff whitespace -> `git diff origin/main...HEAD --check` -> passed.
- Dependency-aware plan -> `npm run test:affected -- --base origin/main --head HEAD --explain` -> full fallback because `docs/design.md` is not mapped to a Module. Per task direction, the complete local Vitest suite was not run; PR Gate CI is the final authority.

Included locally: the owning snackbar behavior, macOS and non-macOS modifier paths, native editing surfaces, Web renderer types, and lint.

Excluded locally: full portable Vitest, packaged Electron, and OS-specific UI lanes. The implementation is renderer-only and does not change IPC or native menu registration; PR CI covers the repository-selected complete and platform checks.

## Review focus

- Whether the editable-target guard preserves every native text-editing surface used by the app.
- Whether limiting the shortcut to archive receipts (and leaving permission Undo click-only) keeps the outcome predictable.
- Whether the shortcut hint remains clear at compact widths and in translated UI.
