### PR TITLE
style(workspace): refine message scroll controls

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -159,11 +159,14 @@ vi.mock('@/components/ui/message-scroller', () => {
   const Button = forwardRef<
     HTMLButtonElement,
     PropsWithChildren<
-      React.ButtonHTMLAttributes<HTMLButtonElement> & { direction?: 'start' | 'end' }
+      React.ButtonHTMLAttributes<HTMLButtonElement> & {
+        direction?: 'start' | 'end'
+        size?: string
+      }
     >
-  >(function MockMessageScrollerButton({ children, direction = 'end', ...props }, ref) {
+  >(function MockMessageScrollerButton({ children, direction = 'end', size, ...props }, ref) {
     return (
-      <button ref={ref} type="button" data-direction={direction} {...props}>
+      <button ref={ref} type="button" data-direction={direction} data-size={size} {...props}>
         {children ?? `Scroll to ${direction}`}
       </button>
     )
@@ -2985,7 +2988,11 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(firstMessageButton?.getAttribute('aria-hidden')).toBe('true')
     expect(firstMessageButton?.getAttribute('tabindex')).toBe('-1')
     expect(firstMessageButton?.classList.contains('gap-1')).toBe(true)
+    expect(firstMessageButton?.classList.contains('px-3')).toBe(true)
+    expect(firstMessageButton?.classList.contains('min-h-11')).toBe(false)
     expect(lastMessageButton).not.toBeNull()
+    expect(lastMessageButton?.getAttribute('data-size')).toBe('icon-lg')
+    expect(lastMessageButton?.classList.contains('rounded-full')).toBe(true)
     for (const button of [firstMessageButton, lastMessageButton]) {
       expect(button?.classList.contains('border-transparent')).toBe(true)
       expect(button?.classList.contains('shadow-card')).toBe(true)

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -1441,14 +1441,17 @@ const WorkspaceMessageScrollerImpl = ({
               data-revealed="false"
               tabIndex={-1}
               size="default"
-              className="z-20 min-h-11 gap-1 rounded-full border-transparent bg-bg-000 px-4 text-sm shadow-card transition-[translate,scale,opacity] hover:bg-bg-200 data-[direction=start]:top-3 data-[revealed=false]:pointer-events-none data-[revealed=false]:-translate-y-2 data-[revealed=false]:opacity-0 motion-reduce:transition-none"
+              className="z-20 gap-1 rounded-full border-transparent bg-bg-000 px-3 text-sm shadow-card transition-[translate,scale,opacity] hover:bg-bg-200 data-[direction=start]:top-3 data-[revealed=false]:pointer-events-none data-[revealed=false]:-translate-y-2 data-[revealed=false]:opacity-0 motion-reduce:transition-none [&_svg]:size-3.5"
             >
               <ArrowDownIcon aria-hidden="true" />
               <span>{t('First message')}</span>
             </MessageScrollerButton>
           ) : null}
 
-          <MessageScrollerButton className="z-10 border-transparent bg-bg-000 shadow-card hover:bg-bg-200 data-[direction=end]:bottom-3" />
+          <MessageScrollerButton
+            size="icon-lg"
+            className="z-10 rounded-full border-transparent bg-bg-000 shadow-card hover:bg-bg-200 data-[direction=end]:bottom-3"
+          />
           <div
             data-testid="message-completion-live-region"
             aria-live="polite"


### PR DESCRIPTION
## Problem

The first-message navigation control is visually oversized relative to the conversation content, while the scroll-to-bottom control reads as a rounded rectangle instead of the circular icon control shown in the reference.

## Proposed change

- Return the first-message control to the shared 32px button height, tighten its horizontal padding, and reduce the arrow size.
- Render the scroll-to-bottom action as a 36px circular icon button.
- Preserve the existing reveal threshold, inactivity timeout, scrolling behavior, labels, and focus treatment.

## Scope and non-goals

- No changes to the shared MessageScrollerButton defaults or its Artifact Provenance consumer.
- No new strings, state values, persistence, or historical-data compatibility behavior.
- No full-suite local test run; exact-head PR CI remains authoritative as requested.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Message-scroll control sizing and reveal behavior -> npm test -- src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx -> 42 passed.
- Renderer type safety -> npm run typecheck:web -> passed.
- Changed-file lint -> eslint --no-cache src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx -> passed.
- Web build and production CSS -> npm run build:web -> passed; existing chunk-size and dynamic-import warnings only.
- Visual geometry -> isolated Web build QA -> first-message control 136.13 x 32px; scroll-to-bottom control 36 x 36px with full circular radius.

Uncovered local risk: the full portable and platform suites were intentionally deferred to PR CI.

## Review focus

Please verify that the compact top pill and circular bottom button match the supplied reference without changing the current scroll/reveal interaction.