### PR TITLE
feat(workspace): add generated artifact preview affordance

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -8,6 +8,7 @@ import { useSettingsStore } from '@/stores/settings-store'
 import type { ChatMessage, ChatSession } from '@/stores/session-store'
 import { Collapsible } from 'radix-ui'
 import {
+  ArrowUpRight,
   Bot,
   Brain,
   Check,
@@ -448,7 +449,7 @@ const TurnTokenUsage = ({
 }
 
 const artifactCardClassName =
-  'h-[82px] w-[128px] shrink-0 overflow-hidden rounded-lg border border-border-200 bg-bg-000 text-left text-text-000 shadow-none transition-colors hover:bg-bg-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-200/60'
+  'h-[82px] w-[128px] shrink-0 cursor-pointer overflow-hidden rounded-lg border border-border-200 bg-bg-000 text-left text-text-000 shadow-none transition-colors hover:bg-bg-200 active:bg-bg-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-200/60 disabled:cursor-not-allowed disabled:opacity-50'
 const artifactPreviewClassName = 'h-[56px] w-full overflow-hidden bg-bg-200'
 const artifactGalleryClassName = 'grid max-w-full grid-cols-[repeat(auto-fill,128px)] gap-2 pb-1'
 
@@ -881,6 +882,13 @@ const ArtifactCard = ({
             {t(FILE_MISSING_TAG_KEY)}
           </span>
         ) : null}
+        <span
+          data-slot="generated-artifact-open-icon"
+          className="absolute right-1 top-1 flex size-7 items-center justify-center rounded-md bg-bg-000/90 text-text-100 opacity-0 shadow-sm transition-[opacity,background-color,color] duration-150 hover:bg-bg-300 hover:text-text-000 group-hover:opacity-100 group-focus-visible:opacity-100 motion-reduce:transition-none"
+          aria-hidden="true"
+        >
+          <ArrowUpRight className="size-4" strokeWidth={1.75} />
+        </span>
       </div>
       <div className="flex min-w-0 flex-1 items-center px-1.5">
         <ExtensionPreservingFileName

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -1915,7 +1915,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(lifecycle?.textContent).toContain('Continued with Data analyst')
   })
 
-  it('upserts and activates the clicked artifact in the preview store, scoped to the active session', async () => {
+  it('opens a generated artifact from both its card and hover icon', async () => {
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
     const session = createSession({
       id: 'session-42',
@@ -1973,6 +1973,19 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
       size: 2048,
       mtimeMs: 1710000000100
     })
+
+    upsertAndActivateItem.mockClear()
+    const openIcon = card?.querySelector<HTMLElement>('[data-slot="generated-artifact-open-icon"]')
+    expect(openIcon).not.toBeNull()
+
+    await act(async () => {
+      openIcon?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(upsertAndActivateItem).toHaveBeenCalledTimes(1)
+    expect(upsertAndActivateItem).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'artifact-1', sessionId: 'session-42' })
+    )
   })
 
   it('routes Markdown artifact links to the panel and Markdown artifact images to the dialog', async () => {


### PR DESCRIPTION
## Problem

Generated artifact cards did not communicate that they were clickable and lacked the floating open affordance shown in the product reference.

## Proposed change

- Show a top-right `ArrowUpRight` affordance when a generated artifact card is hovered or keyboard-focused.
- Use the existing artifact preview handler for both card and icon clicks so the artifact opens in the right PreviewPanel.
- Add pointer, pressed, disabled, focus, reduced-motion, and token-aligned hover styling without introducing a nested interactive control.
- Extend the workspace interaction test to cover both click targets.

## Scope and non-goals

- Renderer-only presentation and interaction change in the generated artifact card.
- No persistence, schema, migration, historical-data compatibility, enum, or application-state changes.
- No changes to artifact resolution or PreviewPanel state management; the existing `upsertAndActivateItem` path remains authoritative.

## Acceptance criteria and validation

Checks ran after the last material edit.

- Generated artifact card and hover icon open PreviewPanel -> `npx vitest run src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx` -> 42/42 passed.
- Renderer API and component types remain valid -> `npm run typecheck:web` -> passed.
- Source lint contract -> `npm run lint` -> passed.
- Changed-file formatting -> `npx prettier --check src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx` -> passed.
- Real UI behavior -> isolated Web UI verification -> pointer cursor confirmed; icon opacity changes from 0 to 1 on card hover; icon hover resolves to the gray surface token; both card and icon clicks open the artifact in the right PreviewPanel.

The repository impact selector reports full fallback because `WorkspaceMessageItem.tsx` has no registered module owner. Per maintainer direction, the complete local `npm test` suite was not run; PR Gate/CI is authoritative for the remaining portable and platform lanes.

## Review focus

- Hover/focus affordance alignment with the supplied reference.
- Reuse of the existing PreviewPanel activation path.
- Accessibility of the single-button structure and keyboard focus state.
