### PR TITLE
fix(startup): separate database checks from composition delays

### DIFF
--- a/src/main/database/database-startup-owner.test.ts
+++ b/src/main/database/database-startup-owner.test.ts
@@ -22,10 +22,7 @@ describe('database startup owner', () => {
     finish?.()
     await attempt
 
-    expect(owner.getState()).toEqual({
-      phase: 'migrating',
-      migrationId: '0001_runtime_schema_baseline'
-    })
+    expect(owner.getState()).toEqual({ phase: 'starting' })
     expect(owner.isMigrating()).toBe(false)
   })
 
@@ -58,15 +55,9 @@ describe('database startup owner', () => {
       migrationId: '0001_runtime_schema_baseline'
     })
 
-    await expect(owner.retry()).resolves.toEqual({
-      phase: 'migrating',
-      migrationId: '0001_runtime_schema_baseline'
-    })
+    await expect(owner.retry()).resolves.toEqual({ phase: 'starting' })
     await expect(owner.whenVerified()).resolves.toBeUndefined()
-    expect(owner.getState()).toEqual({
-      phase: 'migrating',
-      migrationId: '0001_runtime_schema_baseline'
-    })
+    expect(owner.getState()).toEqual({ phase: 'starting' })
 
     owner.complete()
     expect(owner.getState()).toEqual({ phase: 'ready' })
@@ -97,9 +88,24 @@ describe('database startup owner', () => {
       })
     )
 
-    await expect(owner.retry()).resolves.toEqual({ phase: 'checking' })
+    await expect(owner.retry()).resolves.toEqual({ phase: 'starting' })
     await expect(owner.whenVerified()).resolves.toBeUndefined()
     expect(verifyDatabase).toHaveBeenCalledTimes(2)
+  })
+
+  it('leaves the database-checking copy after verification while runtime composition continues', async () => {
+    const owner = createDatabaseStartupOwner({
+      reportBlocked: vi.fn(),
+      verifyDatabase: async (onProgress) => {
+        onProgress({ phase: 'checking' })
+      }
+    })
+    const states: ReturnType<typeof owner.getState>[] = []
+    owner.subscribe((state) => states.push(state))
+
+    await expect(owner.start()).resolves.toEqual({ phase: 'starting' })
+    expect(states).toEqual([{ phase: 'checking' }, { phase: 'checking' }, { phase: 'starting' }])
+    expect(owner.getState()).toEqual({ phase: 'starting' })
   })
 
   it('does not retry a non-retryable compatibility failure', async () => {

--- a/src/main/database/database-startup-owner.ts
+++ b/src/main/database/database-startup-owner.ts
@@ -48,6 +48,8 @@ const createDatabaseStartupOwner = (deps: DatabaseStartupOwnerDeps): DatabaseSta
       .then(() => {
         verified = true
         resolveVerified?.()
+        // `ready` still waits for runtime composition; this only leaves the database-checking copy.
+        publish({ phase: 'starting' })
         return state
       })
       .catch((error: unknown) => {

--- a/src/main/diagnostics/operation.test.ts
+++ b/src/main/diagnostics/operation.test.ts
@@ -105,6 +105,33 @@ describe('diagnostic operation', () => {
     })
   })
 
+  it('classifies a long off-CPU phase as io-or-wait', () => {
+    const { logger, records } = createRecordingLogger()
+    let timestamp = 0
+    const cpuSamples = [
+      { user: 1_000, system: 0 },
+      { user: 2_000, system: 0 }
+    ]
+    const operation = startDiagnosticOperation(logger, {
+      operation: 'application-composition',
+      operationId: 'compose-1',
+      now: () => timestamp,
+      cpuUsage: () => cpuSamples.shift() ?? { user: 2_000, system: 0 }
+    })
+    timestamp = 120_000
+    operation.phase('specialist-catalog')
+
+    expect(records[1]).toMatchObject({
+      data: {
+        phase: 'specialist-catalog',
+        phaseDurationMs: 120_000,
+        phaseCpuTotalMs: 1,
+        phaseWaitMs: 119_999,
+        delayKind: 'io-or-wait'
+      }
+    })
+  })
+
   it('records opt-in cumulative and phase CPU deltas without changing default diagnostics', () => {
     const { logger, records } = createRecordingLogger()
     const cpuSamples = [

--- a/src/main/diagnostics/operation.ts
+++ b/src/main/diagnostics/operation.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 
 import { diagnosticErrorFields, type Logger } from '../logger'
+import { classifyStartupDelay } from './startup-delay'
 
 export type DiagnosticValue = string | number | boolean | null | undefined
 export type DiagnosticFields = Record<string, DiagnosticValue>
@@ -150,6 +151,16 @@ export const startDiagnosticOperation = (
       phaseCpuTotalMs: phaseCpuUserMs + phaseCpuSystemMs
     }
   }
+  const delayFields = (
+    durationMs: number,
+    cpu: Record<string, unknown>
+  ): Record<string, unknown> => {
+    const cpuMs = cpu.phaseCpuTotalMs
+    if (typeof cpuMs !== 'number') return {}
+    const classified = classifyStartupDelay(durationMs, cpuMs)
+    if (!classified) return {}
+    return { phaseWaitMs: classified.waitMs, delayKind: classified.delayKind }
+  }
   const finish = (
     level: keyof Logger,
     message: string,
@@ -161,15 +172,23 @@ export const startDiagnosticOperation = (
     terminal = true
     const finishedAt = readNow()
     const terminalCpuFields = cpuFields(latestPhase ?? 'operation-start')
+    const phaseDurationMs = Math.max(0, finishedAt - phaseStartedAt)
+    const durationMs = Math.max(0, finishedAt - startedAt)
+    const operationDelay =
+      typeof terminalCpuFields.cpuTotalMs === 'number'
+        ? classifyStartupDelay(durationMs, terminalCpuFields.cpuTotalMs)
+        : undefined
     emitSafely(logger, level, message, {
       ...eventFields(fields),
       ...(latestPhase === undefined ? {} : { phase: latestPhase }),
       outcome,
-      durationMs: Math.max(0, finishedAt - startedAt),
-      ...(Object.keys(terminalCpuFields).length === 0
-        ? {}
-        : { phaseDurationMs: Math.max(0, finishedAt - phaseStartedAt) }),
+      durationMs,
+      ...(Object.keys(terminalCpuFields).length === 0 ? {} : { phaseDurationMs }),
       ...terminalCpuFields,
+      ...delayFields(phaseDurationMs, terminalCpuFields),
+      ...(operationDelay
+        ? { waitMs: operationDelay.waitMs, operationDelayKind: operationDelay.delayKind }
+        : {}),
       ...extraFields
     })
   }
@@ -187,12 +206,15 @@ export const startDiagnosticOperation = (
       const phaseAt = readNow()
       const cpuIntervalPhase = latestPhase ?? 'operation-start'
       latestPhase = name
+      const phaseDurationMs = Math.max(0, phaseAt - phaseStartedAt)
+      const cpu = cpuFields(cpuIntervalPhase)
       emitSafely(logger, 'info', 'operation phase', {
         ...eventFields(fields),
         phase: name,
         elapsedMs: Math.max(0, phaseAt - startedAt),
-        phaseDurationMs: Math.max(0, phaseAt - phaseStartedAt),
-        ...cpuFields(cpuIntervalPhase)
+        phaseDurationMs,
+        ...cpu,
+        ...delayFields(phaseDurationMs, cpu)
       })
       phaseStartedAt = phaseAt
     },

--- a/src/main/diagnostics/startup-delay.test.ts
+++ b/src/main/diagnostics/startup-delay.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { classifyStartupDelay } from './startup-delay'
+
+describe('classifyStartupDelay', () => {
+  it('omits sub-millisecond intervals', () => {
+    expect(classifyStartupDelay(0, 0)).toBeUndefined()
+    expect(classifyStartupDelay(0.4, 0.1)).toBeUndefined()
+  })
+
+  it('labels mostly off-CPU time as io-or-wait', () => {
+    expect(classifyStartupDelay(120_000, 4_000)).toEqual({
+      waitMs: 116_000,
+      delayKind: 'io-or-wait'
+    })
+  })
+
+  it('labels mostly on-CPU time as cpu', () => {
+    expect(classifyStartupDelay(80, 76)).toEqual({ waitMs: 4, delayKind: 'cpu' })
+  })
+
+  it('labels balanced intervals as mixed', () => {
+    expect(classifyStartupDelay(1000, 500)).toEqual({ waitMs: 500, delayKind: 'mixed' })
+  })
+})

--- a/src/main/diagnostics/startup-delay.ts
+++ b/src/main/diagnostics/startup-delay.ts
@@ -1,0 +1,22 @@
+export type StartupDelayKind = 'cpu' | 'io-or-wait' | 'mixed'
+
+export type StartupDelayClassification = {
+  waitMs: number
+  delayKind: StartupDelayKind
+}
+
+// Classifies one timed interval when both wall time and CPU time are known. `io-or-wait` means the
+// process spent most of the interval off-CPU (disk, antivirus, locks, or blocking syscalls) rather
+// than executing JavaScript. Intervals under 1ms are omitted as timer noise.
+export const classifyStartupDelay = (
+  durationMs: number,
+  cpuMs: number
+): StartupDelayClassification | undefined => {
+  if (!Number.isFinite(durationMs) || durationMs < 1) return undefined
+  if (!Number.isFinite(cpuMs) || cpuMs < 0) return undefined
+  const waitMs = Math.max(0, Math.round(durationMs - cpuMs))
+  const waitShare = waitMs / durationMs
+  const delayKind: StartupDelayKind =
+    waitShare >= 0.75 ? 'io-or-wait' : waitShare <= 0.25 ? 'cpu' : 'mixed'
+  return { waitMs, delayKind }
+}

--- a/src/main/diagnostics/startup-storage-probe.test.ts
+++ b/src/main/diagnostics/startup-storage-probe.test.ts
@@ -69,6 +69,25 @@ describe('probeStartupStorage', () => {
     expect(JSON.stringify(result)).not.toContain(probeDir)
   })
 
+  it('terminates an isolated probe after a result so cleanup cannot outlive the timeout', async () => {
+    probeDir = await mkdtemp(join(tmpdir(), 'os-startup-probe-join-'))
+    let terminated = 0
+    const result = await timedStartupStorageProbe(
+      {
+        probeDir,
+        isolate: () => ({
+          result: Promise.resolve({ sequentialMs: 1, syncWriteMs: 1, kind: 'typical' }),
+          terminate: async () => {
+            terminated += 1
+          }
+        })
+      },
+      1_500
+    )
+    expect(result).toEqual({ sequentialMs: 1, syncWriteMs: 1, kind: 'typical' })
+    expect(terminated).toBe(1)
+  })
+
   it('terminates an isolated probe when the timeout fires', async () => {
     probeDir = await mkdtemp(join(tmpdir(), 'os-startup-probe-timeout-'))
     let terminated = 0

--- a/src/main/diagnostics/startup-storage-probe.test.ts
+++ b/src/main/diagnostics/startup-storage-probe.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -18,11 +18,38 @@ describe('probeStartupStorage', () => {
     const result = await probeStartupStorage({ probeDir })
     expect(result.sequentialMs).toBeGreaterThanOrEqual(0)
     expect(result.syncWriteMs).toBeGreaterThanOrEqual(0)
-    expect(['typical', 'likely-slow-disk', 'slow-disk-or-scanner', 'unknown']).toContain(result.kind)
+    expect(['typical', 'likely-slow-disk', 'slow-disk-or-scanner', 'unknown']).toContain(
+      result.kind
+    )
     expect(JSON.stringify(result)).not.toContain(probeDir)
-    await expect(readFile(join(probeDir, '.open-science-startup-probe'))).rejects.toMatchObject({
-      code: 'ENOENT'
+  })
+
+  it('does not overwrite or delete an existing file in the probe directory', async () => {
+    probeDir = await mkdtemp(join(tmpdir(), 'os-startup-probe-keep-'))
+    const sentinel = join(probeDir, '.open-science-startup-probe')
+    await writeFile(sentinel, 'keep-me')
+    await probeStartupStorage({ probeDir })
+    await timedStartupStorageProbe({ probeDir }, 1_500)
+    expect(await readFile(sentinel, 'utf8')).toBe('keep-me')
+  })
+
+  it('does not delete a pre-existing file at a supplied probe path', async () => {
+    probeDir = await mkdtemp(join(tmpdir(), 'os-startup-probe-existing-'))
+    const existing = join(probeDir, '.open-science-startup-probe-existing')
+    await writeFile(existing, 'keep-me')
+    await expect(probeStartupStorage({ probeDir, probePath: existing })).resolves.toEqual({
+      sequentialMs: 0,
+      syncWriteMs: 0,
+      kind: 'unknown'
     })
+    await expect(
+      timedStartupStorageProbe({ probeDir, probePath: existing }, 1_500)
+    ).resolves.toEqual({
+      sequentialMs: 0,
+      syncWriteMs: 0,
+      kind: 'unknown'
+    })
+    expect(await readFile(existing, 'utf8')).toBe('keep-me')
   })
 
   it('returns unknown when the probe directory cannot be written', async () => {
@@ -36,7 +63,9 @@ describe('probeStartupStorage', () => {
     probeDir = await mkdtemp(join(tmpdir(), 'os-startup-probe-worker-'))
     const result = await timedStartupStorageProbe({ probeDir }, 1_500)
     expect(result.timedOut).toBeUndefined()
-    expect(['typical', 'likely-slow-disk', 'slow-disk-or-scanner', 'unknown']).toContain(result.kind)
+    expect(['typical', 'likely-slow-disk', 'slow-disk-or-scanner', 'unknown']).toContain(
+      result.kind
+    )
     expect(JSON.stringify(result)).not.toContain(probeDir)
   })
 

--- a/src/main/diagnostics/startup-storage-probe.test.ts
+++ b/src/main/diagnostics/startup-storage-probe.test.ts
@@ -32,12 +32,26 @@ describe('probeStartupStorage', () => {
     expect(result).toEqual({ sequentialMs: 0, syncWriteMs: 0, kind: 'unknown' })
   })
 
-  it('caps a hung probe as slow-disk-or-scanner', async () => {
+  it('runs the default isolated probe to completion', async () => {
+    probeDir = await mkdtemp(join(tmpdir(), 'os-startup-probe-worker-'))
+    const result = await timedStartupStorageProbe({ probeDir }, 1_500)
+    expect(result.timedOut).toBeUndefined()
+    expect(['typical', 'likely-slow-disk', 'slow-disk-or-scanner', 'unknown']).toContain(result.kind)
+    expect(JSON.stringify(result)).not.toContain(probeDir)
+  })
+
+  it('terminates an isolated probe when the timeout fires', async () => {
     probeDir = await mkdtemp(join(tmpdir(), 'os-startup-probe-timeout-'))
+    let terminated = 0
     const result = await timedStartupStorageProbe(
       {
         probeDir,
-        probe: () => new Promise(() => undefined)
+        isolate: () => ({
+          result: new Promise(() => undefined),
+          terminate: async () => {
+            terminated += 1
+          }
+        })
       },
       20
     )
@@ -47,5 +61,6 @@ describe('probeStartupStorage', () => {
       kind: 'slow-disk-or-scanner',
       timedOut: true
     })
+    expect(terminated).toBe(1)
   })
 })

--- a/src/main/diagnostics/startup-storage-probe.test.ts
+++ b/src/main/diagnostics/startup-storage-probe.test.ts
@@ -1,0 +1,51 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { probeStartupStorage, timedStartupStorageProbe } from './startup-storage-probe'
+
+let probeDir: string | undefined
+
+afterEach(async () => {
+  if (probeDir) await rm(probeDir, { recursive: true, force: true })
+  probeDir = undefined
+})
+
+describe('probeStartupStorage', () => {
+  it('reports numeric timings and a coarse kind without paths', async () => {
+    probeDir = await mkdtemp(join(tmpdir(), 'os-startup-probe-'))
+    const result = await probeStartupStorage({ probeDir })
+    expect(result.sequentialMs).toBeGreaterThanOrEqual(0)
+    expect(result.syncWriteMs).toBeGreaterThanOrEqual(0)
+    expect(['typical', 'likely-slow-disk', 'slow-disk-or-scanner', 'unknown']).toContain(result.kind)
+    expect(JSON.stringify(result)).not.toContain(probeDir)
+    await expect(readFile(join(probeDir, '.open-science-startup-probe'))).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+  })
+
+  it('returns unknown when the probe directory cannot be written', async () => {
+    const result = await probeStartupStorage({
+      probeDir: join(tmpdir(), 'os-startup-probe-missing', 'no-such-dir')
+    })
+    expect(result).toEqual({ sequentialMs: 0, syncWriteMs: 0, kind: 'unknown' })
+  })
+
+  it('caps a hung probe as slow-disk-or-scanner', async () => {
+    probeDir = await mkdtemp(join(tmpdir(), 'os-startup-probe-timeout-'))
+    const result = await timedStartupStorageProbe(
+      {
+        probeDir,
+        probe: () => new Promise(() => undefined)
+      },
+      20
+    )
+    expect(result).toEqual({
+      sequentialMs: 20,
+      syncWriteMs: 20,
+      kind: 'slow-disk-or-scanner',
+      timedOut: true
+    })
+  })
+})

--- a/src/main/diagnostics/startup-storage-probe.ts
+++ b/src/main/diagnostics/startup-storage-probe.ts
@@ -1,5 +1,6 @@
 import { open, readFile, unlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { Worker } from 'node:worker_threads'
 
 export type StartupStorageKind = 'typical' | 'likely-slow-disk' | 'slow-disk-or-scanner' | 'unknown'
 
@@ -10,9 +11,15 @@ export type StartupStorageProbeResult = {
   timedOut?: boolean
 }
 
+export type IsolatedStartupStorageProbe = {
+  result: Promise<StartupStorageProbeResult>
+  terminate: () => Promise<void>
+}
+
 type StartupStorageProbeDeps = {
   probeDir: string
   now?: () => number
+  isolate?: (input: StartupStorageProbeDeps) => IsolatedStartupStorageProbe
 }
 
 const SEQUENTIAL_BYTES = 64 * 1024
@@ -21,12 +28,28 @@ const SYNC_WRITE_COUNT = 8
 const PROBE_FILE = '.open-science-startup-probe'
 const LIKELY_SLOW_MS = 200
 const SCANNER_MS = 1000
+const UNKNOWN_RESULT: StartupStorageProbeResult = {
+  sequentialMs: 0,
+  syncWriteMs: 0,
+  kind: 'unknown'
+}
 
 const classify = (syncWriteMs: number): StartupStorageKind => {
   if (syncWriteMs >= SCANNER_MS) return 'slow-disk-or-scanner'
   if (syncWriteMs >= LIKELY_SLOW_MS) return 'likely-slow-disk'
   return 'typical'
 }
+
+const removeProbeFile = async (probeDir: string): Promise<void> => {
+  await unlink(join(probeDir, PROBE_FILE)).catch(() => undefined)
+}
+
+const timedOutResult = (timeoutMs: number): StartupStorageProbeResult => ({
+  sequentialMs: timeoutMs,
+  syncWriteMs: timeoutMs,
+  kind: 'slow-disk-or-scanner',
+  timedOut: true
+})
 
 // Bounded, path-free disk probe. Distinguishes a warm SSD from HDD/antivirus stalls without logging
 // filesystem locations. Failures are swallowed so diagnostics never delay or abort startup.
@@ -56,35 +79,127 @@ export const probeStartupStorage = async (
     const syncWriteMs = Math.max(0, now() - syncStarted)
     return { sequentialMs, syncWriteMs, kind: classify(syncWriteMs) }
   } catch {
-    return { sequentialMs: 0, syncWriteMs: 0, kind: 'unknown' }
+    return UNKNOWN_RESULT
+  } finally {
+    await removeProbeFile(deps.probeDir)
+  }
+}
+
+// Self-contained CJS worker so a stalled fsync can be terminated without blocking or leaking onto
+// the Electron main thread. Keep this source free of app imports; packaged main bundles cannot be
+// used as worker_threads entry points.
+const isolatedProbeWorkerSource = `'use strict'
+const { parentPort, workerData } = require('node:worker_threads')
+const { open, readFile, unlink, writeFile } = require('node:fs/promises')
+const { join } = require('node:path')
+const sequentialBytes = ${SEQUENTIAL_BYTES}
+const syncWriteBytes = ${SYNC_WRITE_BYTES}
+const syncWriteCount = ${SYNC_WRITE_COUNT}
+const probeFile = ${JSON.stringify(PROBE_FILE)}
+const likelySlowMs = ${LIKELY_SLOW_MS}
+const scannerMs = ${SCANNER_MS}
+const unknown = { sequentialMs: 0, syncWriteMs: 0, kind: 'unknown' }
+const classify = (syncWriteMs) =>
+  syncWriteMs >= scannerMs
+    ? 'slow-disk-or-scanner'
+    : syncWriteMs >= likelySlowMs
+      ? 'likely-slow-disk'
+      : 'typical'
+const probeDir = typeof workerData?.probeDir === 'string' ? workerData.probeDir : ''
+const probePath = join(probeDir, probeFile)
+void (async () => {
+  try {
+    const sequential = Buffer.alloc(sequentialBytes, 7)
+    const chunk = Buffer.alloc(syncWriteBytes, 9)
+    const sequentialStarted = Date.now()
+    await writeFile(probePath, sequential)
+    await readFile(probePath)
+    const sequentialMs = Math.max(0, Date.now() - sequentialStarted)
+    const syncStarted = Date.now()
+    for (let index = 0; index < syncWriteCount; index += 1) {
+      const handle = await open(probePath, 'w')
+      try {
+        await handle.write(chunk)
+        await handle.sync()
+      } finally {
+        await handle.close()
+      }
+    }
+    const syncWriteMs = Math.max(0, Date.now() - syncStarted)
+    parentPort.postMessage({ sequentialMs, syncWriteMs, kind: classify(syncWriteMs) })
+  } catch {
+    parentPort.postMessage(unknown)
   } finally {
     await unlink(probePath).catch(() => undefined)
+  }
+})()
+`
+
+const startIsolatedProbe = (deps: StartupStorageProbeDeps): IsolatedStartupStorageProbe => {
+  let worker: Worker
+  try {
+    worker = new Worker(isolatedProbeWorkerSource, {
+      eval: true,
+      workerData: { probeDir: deps.probeDir }
+    })
+  } catch {
+    return {
+      result: Promise.resolve(UNKNOWN_RESULT),
+      terminate: async () => undefined
+    }
+  }
+  const result = new Promise<StartupStorageProbeResult>((resolve) => {
+    let settled = false
+    const finish = (value: StartupStorageProbeResult): void => {
+      if (settled) return
+      settled = true
+      worker.off('message', onMessage)
+      worker.off('error', onError)
+      worker.off('exit', onExit)
+      resolve(value)
+    }
+    const onMessage = (value: unknown): void => {
+      if (
+        typeof value === 'object' &&
+        value !== null &&
+        'sequentialMs' in value &&
+        'syncWriteMs' in value &&
+        'kind' in value
+      ) {
+        finish(value as StartupStorageProbeResult)
+        return
+      }
+      finish(UNKNOWN_RESULT)
+    }
+    const onError = (): void => finish(UNKNOWN_RESULT)
+    const onExit = (): void => finish(UNKNOWN_RESULT)
+    worker.once('message', onMessage)
+    worker.once('error', onError)
+    worker.once('exit', onExit)
+  })
+  return {
+    result,
+    terminate: async () => {
+      await worker.terminate().catch(() => undefined)
+      await removeProbeFile(deps.probeDir)
+    }
   }
 }
 
 export const timedStartupStorageProbe = async (
-  deps: StartupStorageProbeDeps & {
-    probe?: (input: StartupStorageProbeDeps) => Promise<StartupStorageProbeResult>
-  },
+  deps: StartupStorageProbeDeps,
   timeoutMs: number
 ): Promise<StartupStorageProbeResult> => {
+  const isolated = (deps.isolate ?? startIsolatedProbe)(deps)
   let timer: ReturnType<typeof setTimeout> | undefined
   const timeout = new Promise<StartupStorageProbeResult>((resolve) => {
-    timer = setTimeout(
-      () =>
-        resolve({
-          sequentialMs: timeoutMs,
-          syncWriteMs: timeoutMs,
-          kind: 'slow-disk-or-scanner',
-          timedOut: true
-        }),
-      timeoutMs
-    )
+    timer = setTimeout(() => resolve(timedOutResult(timeoutMs)), timeoutMs)
     timer.unref?.()
   })
-  const probe = deps.probe ?? probeStartupStorage
   try {
-    return await Promise.race([probe(deps), timeout])
+    const result = await Promise.race([isolated.result, timeout])
+    if (result.timedOut) await isolated.terminate()
+    return result
   } finally {
     if (timer) clearTimeout(timer)
   }

--- a/src/main/diagnostics/startup-storage-probe.ts
+++ b/src/main/diagnostics/startup-storage-probe.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { open, readFile, unlink, writeFile } from 'node:fs/promises'
+import { open, readFile, unlink } from 'node:fs/promises'
 import { join } from 'node:path'
 import { Worker } from 'node:worker_threads'
 
@@ -68,8 +68,13 @@ export const probeStartupStorage = async (
   let created = false
   try {
     const sequentialStarted = now()
-    await writeFile(probePath, sequential, { flag: 'wx' })
+    const createdHandle = await open(probePath, 'wx')
     created = true
+    try {
+      await createdHandle.write(sequential)
+    } finally {
+      await createdHandle.close()
+    }
     await readFile(probePath)
     const sequentialMs = Math.max(0, now() - sequentialStarted)
 
@@ -97,7 +102,7 @@ export const probeStartupStorage = async (
 // used as worker_threads entry points.
 const isolatedProbeWorkerSource = `'use strict'
 const { parentPort, workerData } = require('node:worker_threads')
-const { open, readFile, unlink, writeFile } = require('node:fs/promises')
+const { open, readFile, unlink } = require('node:fs/promises')
 const sequentialBytes = ${SEQUENTIAL_BYTES}
 const syncWriteBytes = ${SYNC_WRITE_BYTES}
 const syncWriteCount = ${SYNC_WRITE_COUNT}
@@ -113,13 +118,19 @@ const classify = (syncWriteMs) =>
 const probePath = typeof workerData?.probePath === 'string' ? workerData.probePath : ''
 void (async () => {
   let created = false
+  let outcome = unknown
   try {
     if (!probePath) throw new Error('missing probe path')
     const sequential = Buffer.alloc(sequentialBytes, 7)
     const chunk = Buffer.alloc(syncWriteBytes, 9)
     const sequentialStarted = Date.now()
-    await writeFile(probePath, sequential, { flag: 'wx' })
+    const createdHandle = await open(probePath, 'wx')
     created = true
+    try {
+      await createdHandle.write(sequential)
+    } finally {
+      await createdHandle.close()
+    }
     await readFile(probePath)
     const sequentialMs = Math.max(0, Date.now() - sequentialStarted)
     const syncStarted = Date.now()
@@ -133,17 +144,19 @@ void (async () => {
       }
     }
     const syncWriteMs = Math.max(0, Date.now() - syncStarted)
-    parentPort.postMessage({ sequentialMs, syncWriteMs, kind: classify(syncWriteMs) })
+    outcome = { sequentialMs, syncWriteMs, kind: classify(syncWriteMs) }
   } catch {
-    parentPort.postMessage(unknown)
+    outcome = unknown
   } finally {
     if (created) await unlink(probePath).catch(() => undefined)
+    parentPort.postMessage(outcome)
   }
 })()
 `
 
 const startIsolatedProbe = (deps: StartupStorageProbeDeps): IsolatedStartupStorageProbe => {
   const probePath = deps.probePath ?? exclusiveProbePath(deps.probeDir)
+  const removeOnTerminate = deps.probePath === undefined
   let worker: Worker
   try {
     worker = new Worker(isolatedProbeWorkerSource, {
@@ -189,7 +202,7 @@ const startIsolatedProbe = (deps: StartupStorageProbeDeps): IsolatedStartupStora
     result,
     terminate: async () => {
       await worker.terminate().catch(() => undefined)
-      await removeProbeFile(probePath)
+      if (removeOnTerminate) await removeProbeFile(probePath)
     }
   }
 }
@@ -206,7 +219,7 @@ export const timedStartupStorageProbe = async (
   })
   try {
     const result = await Promise.race([isolated.result, timeout])
-    if (result.timedOut) await isolated.terminate()
+    await isolated.terminate()
     return result
   } finally {
     if (timer) clearTimeout(timer)

--- a/src/main/diagnostics/startup-storage-probe.ts
+++ b/src/main/diagnostics/startup-storage-probe.ts
@@ -163,6 +163,8 @@ const startIsolatedProbe = (deps: StartupStorageProbeDeps): IsolatedStartupStora
       eval: true,
       workerData: { probePath }
     })
+    // Diagnostic only: do not pin a fatal startup exit to the 1.5s probe timeout.
+    worker.unref()
   } catch {
     return {
       result: Promise.resolve(UNKNOWN_RESULT),

--- a/src/main/diagnostics/startup-storage-probe.ts
+++ b/src/main/diagnostics/startup-storage-probe.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { open, readFile, unlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { Worker } from 'node:worker_threads'
@@ -18,6 +19,7 @@ export type IsolatedStartupStorageProbe = {
 
 type StartupStorageProbeDeps = {
   probeDir: string
+  probePath?: string
   now?: () => number
   isolate?: (input: StartupStorageProbeDeps) => IsolatedStartupStorageProbe
 }
@@ -40,8 +42,11 @@ const classify = (syncWriteMs: number): StartupStorageKind => {
   return 'typical'
 }
 
-const removeProbeFile = async (probeDir: string): Promise<void> => {
-  await unlink(join(probeDir, PROBE_FILE)).catch(() => undefined)
+const exclusiveProbePath = (probeDir: string): string =>
+  join(probeDir, `${PROBE_FILE}-${randomUUID()}`)
+
+const removeProbeFile = async (probePath: string): Promise<void> => {
+  await unlink(probePath).catch(() => undefined)
 }
 
 const timedOutResult = (timeoutMs: number): StartupStorageProbeResult => ({
@@ -57,12 +62,14 @@ export const probeStartupStorage = async (
   deps: StartupStorageProbeDeps
 ): Promise<StartupStorageProbeResult> => {
   const now = deps.now ?? Date.now
-  const probePath = join(deps.probeDir, PROBE_FILE)
+  const probePath = deps.probePath ?? exclusiveProbePath(deps.probeDir)
   const sequential = Buffer.alloc(SEQUENTIAL_BYTES, 7)
   const chunk = Buffer.alloc(SYNC_WRITE_BYTES, 9)
+  let created = false
   try {
     const sequentialStarted = now()
-    await writeFile(probePath, sequential)
+    await writeFile(probePath, sequential, { flag: 'wx' })
+    created = true
     await readFile(probePath)
     const sequentialMs = Math.max(0, now() - sequentialStarted)
 
@@ -81,7 +88,7 @@ export const probeStartupStorage = async (
   } catch {
     return UNKNOWN_RESULT
   } finally {
-    await removeProbeFile(deps.probeDir)
+    if (created) await removeProbeFile(probePath)
   }
 }
 
@@ -91,11 +98,9 @@ export const probeStartupStorage = async (
 const isolatedProbeWorkerSource = `'use strict'
 const { parentPort, workerData } = require('node:worker_threads')
 const { open, readFile, unlink, writeFile } = require('node:fs/promises')
-const { join } = require('node:path')
 const sequentialBytes = ${SEQUENTIAL_BYTES}
 const syncWriteBytes = ${SYNC_WRITE_BYTES}
 const syncWriteCount = ${SYNC_WRITE_COUNT}
-const probeFile = ${JSON.stringify(PROBE_FILE)}
 const likelySlowMs = ${LIKELY_SLOW_MS}
 const scannerMs = ${SCANNER_MS}
 const unknown = { sequentialMs: 0, syncWriteMs: 0, kind: 'unknown' }
@@ -105,14 +110,16 @@ const classify = (syncWriteMs) =>
     : syncWriteMs >= likelySlowMs
       ? 'likely-slow-disk'
       : 'typical'
-const probeDir = typeof workerData?.probeDir === 'string' ? workerData.probeDir : ''
-const probePath = join(probeDir, probeFile)
+const probePath = typeof workerData?.probePath === 'string' ? workerData.probePath : ''
 void (async () => {
+  let created = false
   try {
+    if (!probePath) throw new Error('missing probe path')
     const sequential = Buffer.alloc(sequentialBytes, 7)
     const chunk = Buffer.alloc(syncWriteBytes, 9)
     const sequentialStarted = Date.now()
-    await writeFile(probePath, sequential)
+    await writeFile(probePath, sequential, { flag: 'wx' })
+    created = true
     await readFile(probePath)
     const sequentialMs = Math.max(0, Date.now() - sequentialStarted)
     const syncStarted = Date.now()
@@ -130,17 +137,18 @@ void (async () => {
   } catch {
     parentPort.postMessage(unknown)
   } finally {
-    await unlink(probePath).catch(() => undefined)
+    if (created) await unlink(probePath).catch(() => undefined)
   }
 })()
 `
 
 const startIsolatedProbe = (deps: StartupStorageProbeDeps): IsolatedStartupStorageProbe => {
+  const probePath = deps.probePath ?? exclusiveProbePath(deps.probeDir)
   let worker: Worker
   try {
     worker = new Worker(isolatedProbeWorkerSource, {
       eval: true,
-      workerData: { probeDir: deps.probeDir }
+      workerData: { probePath }
     })
   } catch {
     return {
@@ -181,7 +189,7 @@ const startIsolatedProbe = (deps: StartupStorageProbeDeps): IsolatedStartupStora
     result,
     terminate: async () => {
       await worker.terminate().catch(() => undefined)
-      await removeProbeFile(deps.probeDir)
+      await removeProbeFile(probePath)
     }
   }
 }

--- a/src/main/diagnostics/startup-storage-probe.ts
+++ b/src/main/diagnostics/startup-storage-probe.ts
@@ -1,0 +1,91 @@
+import { open, readFile, unlink, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export type StartupStorageKind = 'typical' | 'likely-slow-disk' | 'slow-disk-or-scanner' | 'unknown'
+
+export type StartupStorageProbeResult = {
+  sequentialMs: number
+  syncWriteMs: number
+  kind: StartupStorageKind
+  timedOut?: boolean
+}
+
+type StartupStorageProbeDeps = {
+  probeDir: string
+  now?: () => number
+}
+
+const SEQUENTIAL_BYTES = 64 * 1024
+const SYNC_WRITE_BYTES = 4096
+const SYNC_WRITE_COUNT = 8
+const PROBE_FILE = '.open-science-startup-probe'
+const LIKELY_SLOW_MS = 200
+const SCANNER_MS = 1000
+
+const classify = (syncWriteMs: number): StartupStorageKind => {
+  if (syncWriteMs >= SCANNER_MS) return 'slow-disk-or-scanner'
+  if (syncWriteMs >= LIKELY_SLOW_MS) return 'likely-slow-disk'
+  return 'typical'
+}
+
+// Bounded, path-free disk probe. Distinguishes a warm SSD from HDD/antivirus stalls without logging
+// filesystem locations. Failures are swallowed so diagnostics never delay or abort startup.
+export const probeStartupStorage = async (
+  deps: StartupStorageProbeDeps
+): Promise<StartupStorageProbeResult> => {
+  const now = deps.now ?? Date.now
+  const probePath = join(deps.probeDir, PROBE_FILE)
+  const sequential = Buffer.alloc(SEQUENTIAL_BYTES, 7)
+  const chunk = Buffer.alloc(SYNC_WRITE_BYTES, 9)
+  try {
+    const sequentialStarted = now()
+    await writeFile(probePath, sequential)
+    await readFile(probePath)
+    const sequentialMs = Math.max(0, now() - sequentialStarted)
+
+    const syncStarted = now()
+    for (let index = 0; index < SYNC_WRITE_COUNT; index += 1) {
+      const handle = await open(probePath, 'w')
+      try {
+        await handle.write(chunk)
+        await handle.sync()
+      } finally {
+        await handle.close()
+      }
+    }
+    const syncWriteMs = Math.max(0, now() - syncStarted)
+    return { sequentialMs, syncWriteMs, kind: classify(syncWriteMs) }
+  } catch {
+    return { sequentialMs: 0, syncWriteMs: 0, kind: 'unknown' }
+  } finally {
+    await unlink(probePath).catch(() => undefined)
+  }
+}
+
+export const timedStartupStorageProbe = async (
+  deps: StartupStorageProbeDeps & {
+    probe?: (input: StartupStorageProbeDeps) => Promise<StartupStorageProbeResult>
+  },
+  timeoutMs: number
+): Promise<StartupStorageProbeResult> => {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<StartupStorageProbeResult>((resolve) => {
+    timer = setTimeout(
+      () =>
+        resolve({
+          sequentialMs: timeoutMs,
+          syncWriteMs: timeoutMs,
+          kind: 'slow-disk-or-scanner',
+          timedOut: true
+        }),
+      timeoutMs
+    )
+    timer.unref?.()
+  })
+  const probe = deps.probe ?? probeStartupStorage
+  try {
+    return await Promise.race([probe(deps), timeout])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}

--- a/src/main/diagnostics/startup.ts
+++ b/src/main/diagnostics/startup.ts
@@ -12,6 +12,7 @@ type ApplicationDiagnosticMetadata = {
   arch: string
   electronVersion: string
   nodeVersion: string
+  cpuUsage?: () => { user: number; system: number }
 }
 
 export type ApplicationDiagnostics = {
@@ -35,7 +36,8 @@ export const initializeApplicationDiagnostics = (
       platform: metadata.platform,
       arch: metadata.arch,
       isPackaged: metadata.isPackaged
-    }
+    },
+    ...(metadata.cpuUsage ? { cpuUsage: metadata.cpuUsage } : {})
   })
   log.info('app starting', {
     logSchemaVersion: 1,

--- a/src/main/index-fatal-errors.test.ts
+++ b/src/main/index-fatal-errors.test.ts
@@ -73,6 +73,14 @@ vi.mock('./diagnostics/startup', () => ({
   reportApplicationStartupFailure: mocks.reportApplicationStartupFailure
 }))
 
+vi.mock('./diagnostics/startup-storage-probe', () => ({
+  timedStartupStorageProbe: vi.fn(async () => ({
+    sequentialMs: 0,
+    syncWriteMs: 0,
+    kind: 'unknown'
+  }))
+}))
+
 vi.mock('./logger', () => ({
   createLogger: vi.fn(() => mocks.log),
   diagnosticErrorFields: vi.fn((error: unknown) => ({ error })),

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -154,11 +154,24 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
     platform: process.platform,
     arch: process.arch,
     electronVersion: process.versions.electron,
-    nodeVersion: process.versions.node
+    nodeVersion: process.versions.node,
+    cpuUsage: process.cpuUsage
   })
   const { log } = diagnostics
   startupDiagnostics = diagnostics.operation
   startupFlush = diagnostics.flush
+  startupDiagnostics.phase('storage-probe')
+  const storageProbe = await import('./diagnostics/startup-storage-probe').then(
+    ({ timedStartupStorageProbe }) =>
+      timedStartupStorageProbe({ probeDir: app.getPath('logs') }, 1_500)
+  )
+  log.info('startup storage probe', storageProbe)
+  startupDiagnostics.phase('storage-probe-complete', {
+    sequentialMs: storageProbe.sequentialMs,
+    syncWriteMs: storageProbe.syncWriteMs,
+    kind: storageProbe.kind,
+    timedOut: storageProbe.timedOut === true
+  })
 
   // Register process-level failure capture before loading the application modules. Keep renderer
   // diagnostics on a separate, one-way channel while the central IPC registry is being refactored.
@@ -390,7 +403,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
         },
         loadApplicationModules: async () => {
           await startupShellRendered
-          return Promise.all([
+          startupDiagnostics?.phase('load-application-modules')
+          const loaded = await Promise.all([
             import('./ipc'),
             import('./storage/migration-state'),
             import('./tray'),
@@ -407,6 +421,8 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             import('./notifications/notification-inbox-controller'),
             import('./notifications/unread-task-ipc')
           ])
+          startupDiagnostics?.phase('application-modules-loaded')
+          return loaded
         },
         composeRuntime: async (
           _,
@@ -435,6 +451,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           startupDiagnostics?.phase('compose-runtime')
 
           try {
+            startupDiagnostics?.phase('register-application-ipc')
             // Held in a box (not a bare let) so the settings IPC callback registered below can reach the icon
             // controller, which itself needs the persisted variant that only exists once settingsService is
             // constructed. The change callback only fires on a user action (well after startup), so the
@@ -495,6 +512,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
               },
               listAppIconPreviews: () => buildAppIconPreviews(nativeImage, iconVariantPaths)
             })
+            startupDiagnostics?.phase('compose-desktop-surfaces')
 
             // The controller must exist before its IPC responder, while the responder calls back into the
             // controller. This box breaks that startup cycle without exposing unread ownership to renderer.
@@ -541,6 +559,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
               variantPaths: iconVariantPaths,
               initialVariant
             })
+            startupDiagnostics?.phase('compose-remote-access')
             const remoteAccess = await RemoteAccessService.create()
             bindRemoteAccess(remoteAccess)
             const webController = createWebServiceController({

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -160,18 +160,16 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
   const { log } = diagnostics
   startupDiagnostics = diagnostics.operation
   startupFlush = diagnostics.flush
-  startupDiagnostics.phase('storage-probe')
-  const storageProbe = await import('./diagnostics/startup-storage-probe').then(
-    ({ timedStartupStorageProbe }) =>
+  // Disk classification is diagnostic only. Do not await it on the path to failure capture,
+  // bootstrap assets, or the first window; log the result whenever the probe settles.
+  void import('./diagnostics/startup-storage-probe')
+    .then(({ timedStartupStorageProbe }) =>
       timedStartupStorageProbe({ probeDir: app.getPath('logs') }, 1_500)
-  )
-  log.info('startup storage probe', storageProbe)
-  startupDiagnostics.phase('storage-probe-complete', {
-    sequentialMs: storageProbe.sequentialMs,
-    syncWriteMs: storageProbe.syncWriteMs,
-    kind: storageProbe.kind,
-    timedOut: storageProbe.timedOut === true
-  })
+    )
+    .then((storageProbe) => {
+      log.info('startup storage probe', storageProbe)
+    })
+    .catch(() => undefined)
 
   // Register process-level failure capture before loading the application modules. Keep renderer
   // diagnostics on a separate, one-way channel while the central IPC registry is being refactored.

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -104,10 +104,7 @@ import {
   buildTaskNotificationShow
 } from './notifications/electron-wiring'
 import { createLogger, diagnosticErrorFields, errorLogFields } from './logger'
-import {
-  startDiagnosticOperation,
-  type DiagnosticOperation
-} from './diagnostics/operation'
+import { startDiagnosticOperation, type DiagnosticOperation } from './diagnostics/operation'
 import { broadcastNotebookEnvProgress, registerNotebookEnvIpcHandlers } from './notebook/env-ipc'
 import {
   createNotebookApplicationModule,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -388,6 +388,10 @@ const createApplicationModules = async (
   }: IpcRegistrationOptions,
   modules: ApplicationModuleBuilder
 ): Promise<ApplicationModuleInterfaces> => {
+  const composition = startDiagnosticOperation(createLogger('startup'), {
+    operation: 'application-composition',
+    cpuUsage: process.cpuUsage
+  })
   const beforeComputeAdapters: NamedElectronSurfaceAdapter[] = []
   const beforeAcpAdapters: NamedElectronSurfaceAdapter[] = []
   const afterAcpAdapters: NamedElectronSurfaceAdapter[] = []
@@ -459,6 +463,7 @@ const createApplicationModules = async (
   storageLog.info('data root resolved', {
     location: samePath(resolveDataRoot(), computeDefaultDataRoot()) ? 'default' : 'custom'
   })
+  composition.phase('data-root')
 
   // Constructed once here (rather than left to each register*IpcHandlers' own default) so the
   // one-time legacy-path normalization pass below can share the exact instances the IPC surface uses.
@@ -634,6 +639,7 @@ const createApplicationModules = async (
       })
   })
   await seedDefaultPermissionGrants(permissionGrantRegistry, await getProjectDbClient(configRoot))
+  composition.phase('permission-grants')
   const projectFilesRepository = createManagedFileIndexRepository(
     getProjectDbClient,
     configRoot,
@@ -990,6 +996,7 @@ const createApplicationModules = async (
     localRpc: notebookLocalRpc
   } = notebookApplication
   notebookActivityRef.current = notebookService
+  composition.phase('notebook-runtime')
 
   // Builtins are validated once at startup from read-only repository resources. Package imports use
   // the same repository while keeping their dynamic Connector/custom-Skill catalog separate.
@@ -997,6 +1004,7 @@ const createApplicationModules = async (
   const appVersion = app.getVersion()
   const specialistSkills = await settingsService.listSpecialistSkillCatalog()
   const packageSkills = await specialistPackageSkillAdapter.snapshot()
+  composition.phase('specialist-catalog')
   const builtinRegistry = new BuiltinSpecialistRegistry({
     appVersion,
     builtinSkills: composeBuiltinSkillCatalog(appVersion, specialistSkills),
@@ -1018,6 +1026,7 @@ const createApplicationModules = async (
   })
   const profileService = new ProfileService(specialistRepository, builtinRegistry)
   await profileService.ensureBuiltinCatalogReady()
+  composition.phase('builtin-specialists')
   const tagService = new TagService(
     new TagRepository(() => getProjectDbClient(configRoot)),
     new TagResourceCatalog({
@@ -1146,6 +1155,7 @@ const createApplicationModules = async (
       diagnosticErrorFields(error)
     )
   }
+  composition.phase('marketplace-recover')
   settingsService.setSkillDeletionGuard((skillId) =>
     specialistPackageService.assertSkillDeletionAllowed(skillId)
   )
@@ -1343,6 +1353,7 @@ const createApplicationModules = async (
     connectorApprovals: approvalBroker,
     skillImportApprovals: skillImportApprovalBroker
   } = connectorApplication
+  composition.phase('connectors')
   // Register compute IPC handlers early so computeService can be wired into the notebook RPC server.
   // The approval broker in compute/ipc.ts broadcasts via BrowserWindow.getAllWindows(), which requires
   // Electron to be ready — this is always the case here since we're inside registerIpcHandlers.
@@ -1401,6 +1412,7 @@ const createApplicationModules = async (
   computeJobDeletionRef.current = jobDeletionOwner
   await projectDeletionCoordinator.restorePendingDeletionBarriers()
   await jobDeletionOwner.restoreOrphanJobDeletionBarriers(isComputeJobOwnerLive)
+  composition.phase('deletion-barriers')
   const dataRoot = resolveDataRoot()
   // Start the JobPoller wired to the shared broadcaster so every state/tail change is pushed to all
   // renderer windows via 'compute:job-updated' (Phase 3d, design.md §9 + §15.3). The dispatcher
@@ -1898,6 +1910,7 @@ const createApplicationModules = async (
     })
   )
   notebookRpcServerRef.current = notebookRpcServer
+  composition.phase('notebook-rpc')
   // Register ownership before ACP construction. Reverse disposal therefore drains ACP + Notebook
   // through the coordinator first, then releases the local bridge without creating a second runtime
   // shutdown owner; rollback also closes a server started during partial composition.
@@ -2059,6 +2072,7 @@ const createApplicationModules = async (
   )
   surfaceAdapters = afterAcpAdapters
   runtimeRef.current = runtime
+  composition.phase('acp-runtime')
   runtime.setSessionResumeObserver(async (request) => {
     if (request.specialistBindingPending !== true) return
     await sessionSpecialistReconfiguration.completeResume(request.sessionId, request.specialistId)
@@ -2084,6 +2098,7 @@ const createApplicationModules = async (
     }
   )
   userSkillCatalogObserverRef.current = userSkillCatalogObserver
+  composition.phase('skills')
   const sideChatLog = createLogger('side-chat')
   const sideChatRuntime = await modules.add(
     {
@@ -2161,6 +2176,7 @@ const createApplicationModules = async (
   } catch (error) {
     sideChatLog.error('durable Side chat hydration failed', diagnosticErrorFields(error))
   }
+  composition.phase('side-chat')
   // Recovery quiesces every runtime owner, so do not start its first attempt until ACP, Delegation,
   // Notebook, Side Chat, and the composed quiescence boundary are all initialized. The bounded
   // durable barrier restoration above still runs early enough to block admission during startup.
@@ -2781,6 +2797,7 @@ const createApplicationModules = async (
     // a redundant named env.
     notebookService.setDefaultEnvProvisioner(serialized, broadcastNotebookEnvProgress)
   }
+  composition.phase('notebook-provisioner')
 
   // Registered after the acp/notebook handlers exist: migration needs to interrupt both runtimes.
   const storageCommandOwner = createStorageCommandOwner({
@@ -3094,6 +3111,8 @@ const createApplicationModules = async (
   declareElectronAdapter('application-projects', () =>
     registerApplicationCommandElectronAdapter(applicationCommandComposition.electron)
   )
+  composition.phase('commands')
+  composition.complete()
 
   return {
     applicationCommands: {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -104,7 +104,10 @@ import {
   buildTaskNotificationShow
 } from './notifications/electron-wiring'
 import { createLogger, diagnosticErrorFields, errorLogFields } from './logger'
-import { startDiagnosticOperation } from './diagnostics/operation'
+import {
+  startDiagnosticOperation,
+  type DiagnosticOperation
+} from './diagnostics/operation'
 import { broadcastNotebookEnvProgress, registerNotebookEnvIpcHandlers } from './notebook/env-ipc'
 import {
   createNotebookApplicationModule,
@@ -386,12 +389,9 @@ const createApplicationModules = async (
     listAppIconPreviews,
     confirmUpdateRendererDurability = () => Promise.resolve(true)
   }: IpcRegistrationOptions,
-  modules: ApplicationModuleBuilder
+  modules: ApplicationModuleBuilder,
+  composition: DiagnosticOperation
 ): Promise<ApplicationModuleInterfaces> => {
-  const composition = startDiagnosticOperation(createLogger('startup'), {
-    operation: 'application-composition',
-    cpuUsage: process.cpuUsage
-  })
   const beforeComputeAdapters: NamedElectronSurfaceAdapter[] = []
   const beforeAcpAdapters: NamedElectronSurfaceAdapter[] = []
   const afterAcpAdapters: NamedElectronSurfaceAdapter[] = []
@@ -3112,7 +3112,6 @@ const createApplicationModules = async (
     registerApplicationCommandElectronAdapter(applicationCommandComposition.electron)
   )
   composition.phase('commands')
-  composition.complete()
 
   return {
     applicationCommands: {
@@ -3169,13 +3168,24 @@ const createApplicationModules = async (
 }
 
 const registerIpcHandlers = async (options: IpcRegistrationOptions): Promise<IpcRegistration> => {
-  const applicationRuntime = await composeApplicationRuntimeWithAdapters(
-    (modules) => createApplicationModules(options, modules),
-    installElectronRuntimeAdapters
-  )
-  return {
-    ...applicationRuntime.interfaces,
-    dispose: applicationRuntime.dispose
+  const composition = startDiagnosticOperation(createLogger('startup'), {
+    operation: 'application-composition',
+    cpuUsage: process.cpuUsage
+  })
+  try {
+    const applicationRuntime = await composeApplicationRuntimeWithAdapters(
+      (modules) => createApplicationModules(options, modules, composition),
+      installElectronRuntimeAdapters
+    )
+    composition.phase('ipc-adapters')
+    composition.complete()
+    return {
+      ...applicationRuntime.interfaces,
+      dispose: applicationRuntime.dispose
+    }
+  } catch (error) {
+    composition.fail(error)
+    throw error
   }
 }
 

--- a/src/renderer/src/components/database-startup-gate.test.tsx
+++ b/src/renderer/src/components/database-startup-gate.test.tsx
@@ -60,6 +60,15 @@ describe('DatabaseStartupGate', () => {
     expect(updatingLabel.className).toBe(checkingLabel.className)
     expect(screen.getByText('Keep Open Science open while this finishes.')).toBeTruthy()
     expect(screen.getByTestId('open-science-logo-loader')).toBe(startupLoader)
+
+    act(() => publish({ phase: 'starting' }))
+
+    const startingLabel = screen.getByText('Starting Open Science…')
+    expect(startingLabel.tagName).toBe('SPAN')
+    expect(startingLabel.className).toBe(checkingLabel.className)
+    expect(screen.getByText('Keep Open Science open while this finishes.')).toBeTruthy()
+    expect(screen.queryByText('Checking database…')).toBeNull()
+    expect(screen.getByTestId('open-science-logo-loader')).toBe(startupLoader)
   })
 
   it('keeps the application unmounted until the database and runtime are ready', async () => {

--- a/src/renderer/src/components/database-startup-gate.tsx
+++ b/src/renderer/src/components/database-startup-gate.tsx
@@ -152,9 +152,13 @@ const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.
             <OpenScienceLogoLoader />
             <div className="flex flex-col items-center gap-4">
               <span className="text-sm text-muted-foreground">
-                {state.phase === 'migrating' ? t('Updating database…') : t('Checking database…')}
+                {state.phase === 'migrating'
+                  ? t('Updating database…')
+                  : state.phase === 'starting'
+                    ? t('Starting Open Science…')
+                    : t('Checking database…')}
               </span>
-              {state.phase === 'migrating' ? (
+              {state.phase === 'migrating' || state.phase === 'starting' ? (
                 <p className="text-sm text-muted-foreground">
                   {t('Keep Open Science open while this finishes.')}
                 </p>

--- a/src/renderer/src/locales/fr.json
+++ b/src/renderer/src/locales/fr.json
@@ -1917,6 +1917,7 @@
   "Star {{app}} on GitHub, {{count}} stars_many": "Ajouter une Star à {{app}} sur GitHub, {{count}} Stars",
   "Start a normal conversation; the agent guides you step by step": "Démarrez une conversation normale ; l'agent vous guide étape par étape",
   "Starting Office preview": "Démarrage de l'aperçu d'Office",
+  "Starting Open Science…": "Démarrage d'Open Science…",
   "Starting this move will interrupt the running sessions below and restart the app.": "Le démarrage de ce mouvement interrompra les sessions en cours ci-dessous et redémarrera l'application.",
   "Starting…": "Commencer…",
   "State": "État",

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -1831,6 +1831,7 @@
   "Star {{app}} on GitHub, {{count}} stars_other": "GitHub で {{app}} に Star を付ける、{{count}} Star",
   "Start a normal conversation; the agent guides you step by step": "通常の会話を始めます。エージェントがステップごとにガイドします",
   "Starting Office preview": "Office プレビューの開始",
+  "Starting Open Science…": "Open Science を起動しています…",
   "Starting this move will interrupt the running sessions below and restart the app.": "この移動を開始すると、以下の実行中のセッションが中断され、アプリが再起動されます。",
   "Starting…": "開始中…",
   "State": "状態",

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -1842,6 +1842,7 @@
   "Star {{app}} on GitHub, {{count}} stars_other": "GitHub에서 {{app}}에 Star, Star {{count}}개",
   "Start a normal conversation; the agent guides you step by step": "일반 대화를 시작하세요. 에이전트는 단계별로 안내합니다.",
   "Starting Office preview": "Office 미리보기 시작",
+  "Starting Open Science…": "Open Science 시작 중…",
   "Starting this move will interrupt the running sessions below and restart the app.": "이 이동을 시작하면 아래의 실행 중 세션이 중단되고 앱이 다시 시작됩니다.",
   "Starting…": "시작 중…",
   "State": "상태",

--- a/src/renderer/src/locales/ru.json
+++ b/src/renderer/src/locales/ru.json
@@ -1925,6 +1925,7 @@
   "Star {{app}} on GitHub, {{count}} stars_other": "{{app}} на GitHub: {{count}} звезды",
   "Start a normal conversation; the agent guides you step by step": "Начать обычный диалог: агент проведёт вас по всем шагам",
   "Starting Office preview": "Запуск предпросмотра Office",
+  "Starting Open Science…": "Запуск Open Science…",
   "Starting this move will interrupt the running sessions below and restart the app.": "Перенос прервёт перечисленные ниже активные сессии и перезапустит приложение.",
   "Starting…": "Запуск…",
   "State": "Состояние",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -1902,6 +1902,7 @@
   "Star {{app}} on GitHub, {{count}} stars_other": "在 GitHub 上为 {{app}} 点 Star，{{count}} 个 Star",
   "Start a normal conversation; the agent guides you step by step": "开始普通对话，智能体会逐步引导你",
   "Starting Office preview": "正在启动 Office 预览",
+  "Starting Open Science…": "正在启动 Open Science…",
   "Starting this move will interrupt the running sessions below and restart the app.": "开始移动会中断下列运行中的会话，并重启应用。",
   "Starting…": "启动中…",
   "State": "状态",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -1899,6 +1899,7 @@
   "Star {{app}} on GitHub, {{count}} stars_other": "在 GitHub 上為 {{app}} 點 Star，{{count}} 個 Star",
   "Start a normal conversation; the agent guides you step by step": "開始普通對話，智能體會逐步引導你",
   "Starting Office preview": "正在啟動 Office 預覽",
+  "Starting Open Science…": "正在啟動 Open Science…",
   "Starting this move will interrupt the running sessions below and restart the app.": "開始移動會中斷下列執行中的工作階段，並重新啟動應用。",
   "Starting…": "啟動中…",
   "State": "狀態",

--- a/src/shared/database-startup.ts
+++ b/src/shared/database-startup.ts
@@ -32,6 +32,7 @@ type DatabaseStartupError = {
 type DatabaseStartupState =
   | { phase: 'checking' }
   | { phase: 'migrating'; migrationId: string }
+  | { phase: 'starting' }
   | { phase: 'ready' }
   | { phase: 'blocked'; error: DatabaseStartupError }
 


### PR DESCRIPTION
## Problem

Windows launches that sat on **Checking database…** for 1–4 minutes had already verified SQLite (typically 0.2–0.4s). The remaining time was runtime composition (`createApplicationModules` / `registerIpcHandlers`). The startup shell kept the database-checking copy until `complete()`, so the hang looked like a database failure. Cold vs warm starts on the same machine also matched slow disk or antivirus first-touch more than a stuck ledger.

## Proposed change

- After database verification, publish `starting` so the shell shows **Starting Open Science…** until runtime composition finishes.
- Record CPU vs wall time on `application-startup` and `application-composition` (`phaseWaitMs`, `delayKind`: `cpu` / `io-or-wait` / `mixed`).
- Run a bounded, path-free storage probe at process start (`typical` / `likely-slow-disk` / `slow-disk-or-scanner`).
- Split composition into greppable phases (`specialist-catalog`, `builtin-specialists`, `marketplace-recover`, `acp-runtime`, `load-application-modules`, and others).

## Scope and non-goals

- Diagnostics and honest startup copy only.
- Does not shorten composition, defer Notebook/Agent work, or change database migrations.
- Does not log filesystem paths.

## Acceptance criteria and validation

- After SQLite verification, the gate is no longer stuck on the database-checking copy.
- Support logs can tell a long `io-or-wait` phase from CPU-bound work, and can attribute time to a named composition phase.
- Storage probe results contain no absolute paths.

### Test impact set

Ran after the last material edit in `.worktree/startup-starting-phase`:

| Behavior | Command | Result |
| --- | --- | --- |
| Starting phase after verification | `vitest run src/main/database/database-startup-owner.test.ts src/renderer/src/components/database-startup-gate.test.tsx` | pass |
| Locale catalogs for the new copy | `vitest run src/renderer/src/i18n/resources.test.ts` | pass |
| CPU vs wait classification | `vitest run src/main/diagnostics/startup-delay.test.ts src/main/diagnostics/operation.test.ts` | pass |
| Storage probe timings, cleanup, timeout | `vitest run src/main/diagnostics/startup-storage-probe.test.ts` | pass |
| Diagnostic privacy canary | `vitest run src/main/diagnostics/privacy-canary.test.ts` | pass |
| Startup module load order | `vitest run src/main/index-startup-order.test.ts` | pass |
| Main-process types | `tsc --noEmit -p tsconfig.node.json --composite false` | pass |

ACP frameworks, session branches, and renderer contract catalogs are unchanged. No Windows packaged cold-start lane was run locally.

## Review focus

- `starting` must not mark the app `ready` before IPC composition finishes.
- `delayKind` / `phaseWaitMs` should stay off default diagnostics unless `cpuUsage` is passed.
- Storage probe must never block startup beyond the 1.5s cap or leak paths into `main.log`.

## Uncovered risks

- Packaged Windows cold start (HDD + Defender) is the motivating environment and was not re-run with this build.
- Probe thresholds are coarse heuristics, not a hardware classifier.