### PR TITLE
feat(notebook): show terminated previews as read-only

### DIFF
--- a/src/renderer/src/components/ui/resizable.test.tsx
+++ b/src/renderer/src/components/ui/resizable.test.tsx
@@ -42,4 +42,14 @@ describe('ResizableHandle', () => {
       ])
     )
   })
+
+  it('renders optional separator content', () => {
+    const markup = renderToStaticMarkup(
+      <ResizableHandle aria-label="Resize stacked panels">
+        <span>Notebook terminal</span>
+      </ResizableHandle>
+    )
+
+    expect(markup).toContain('<span>Notebook terminal</span>')
+  })
 })

--- a/src/renderer/src/components/ui/resizable.tsx
+++ b/src/renderer/src/components/ui/resizable.tsx
@@ -27,6 +27,7 @@ function ResizablePanel({
 function ResizableHandle({
   withHandle,
   className,
+  children,
   ...props
 }: React.ComponentProps<typeof Separator> & {
   withHandle?: boolean
@@ -44,6 +45,7 @@ function ResizableHandle({
       )}
       {...props}
     >
+      {children}
       {withHandle ? (
         <div className="z-10 flex h-6 w-4 items-center justify-center rounded-sm border border-border bg-card">
           <GripVertical className="size-3 text-muted-foreground" aria-hidden="true" />

--- a/src/renderer/src/locales/fr.json
+++ b/src/renderer/src/locales/fr.json
@@ -1484,6 +1484,7 @@
   "Publish skill": "Publier la compétence",
   "Python": "Python",
   "Python kernel · shared with the agent": "Noyau Python · partagé avec l'agent",
+  "Python · view only; this kernel's namespace no longer exists": "Python · lecture seule; l’espace de noms de ce noyau n’existe plus",
   "Python package index (pip)": "Index des paquets Python (pip)",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Les environnements Python/R sont reconstruits au nouvel emplacement lors de la première utilisation (non déplacés).",
   "Question from {{name}}": "Question de {{name}}",

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -1431,6 +1431,7 @@
   "Publish skill": "スキルを公開する",
   "Python": "Python",
   "Python kernel · shared with the agent": "Python カーネル · エージェントと共有",
+  "Python · view only; this kernel's namespace no longer exists": "Python · 表示専用 — このカーネルの名前空間はもう存在しません",
   "Python package index (pip)": "Python パッケージ インデックス (pip)",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Python/R 環境は、最初の使用時に新しい場所に再構築されます (移動されません)。",
   "Question from {{name}}": "{{name}} からの質問",

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -1442,6 +1442,7 @@
   "Publish skill": "스킬 게시",
   "Python": "Python",
   "Python kernel · shared with the agent": "Python 커널 · 에이전트와 공유됨",
+  "Python · view only; this kernel's namespace no longer exists": "Python · 보기 전용 — 이 커널의 네임스페이스가 더 이상 존재하지 않습니다",
   "Python package index (pip)": "Python 패키지 인덱스(pip)",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Python/R 환경은 처음 사용 시 새 위치에 다시 작성됩니다(이동되지 않음).",
   "Question from {{name}}": "{{name}}의 질문",

--- a/src/renderer/src/locales/ru.json
+++ b/src/renderer/src/locales/ru.json
@@ -1479,6 +1479,7 @@
   "Publish skill": "Опубликовать навык",
   "Python": "Python",
   "Python kernel · shared with the agent": "Python ядро · передано агенту",
+  "Python · view only; this kernel's namespace no longer exists": "Python · только просмотр — пространство имён этого ядра больше не существует",
   "Python package index (pip)": "Python индекс пакета (pip)",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Python/R среды пересоздаются на новом месте при первом использовании (не перемещаются).",
   "Question from {{name}}": "Вопрос от {{name}}",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -1502,6 +1502,7 @@
   "Publish skill": "发布技能",
   "Python": "Python",
   "Python kernel · shared with the agent": "Python 内核 · 与智能体共享",
+  "Python · view only; this kernel's namespace no longer exists": "Python · 仅供查看；此内核的命名空间已不存在",
   "Python package index (pip)": "Python 软件包索引（pip）",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Python/R 环境会在首次使用时于新位置重建（不迁移）。",
   "Question from {{name}}": "来自 {{name}} 的提问",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -1499,6 +1499,7 @@
   "Publish skill": "發佈技能",
   "Python": "Python",
   "Python kernel · shared with the agent": "Python 核心 · 與智能體共用",
+  "Python · view only; this kernel's namespace no longer exists": "Python · 僅供檢視；此核心的命名空間已不存在",
   "Python package index (pip)": "Python 套件索引（pip）",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Python/R 環境會在首次使用時於新位置重建（不遷移）。",
   "Question from {{name}}": "來自 {{name}} 的提問",

--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -285,7 +285,8 @@ describe('NotebookPreview per-kernel tabs', () => {
   const mountWithRuns = async (
     runs: NotebookRunRecord[],
     environments: NotebookEnvironmentStatus[] = [],
-    runStaleness: NotebookSessionState['runStaleness'] = {}
+    runStaleness: NotebookSessionState['runStaleness'] = {},
+    kernelStatus: NotebookSessionState['kernelStatus'] = 'idle'
   ): Promise<void> => {
     const readyStatus: ProvisionStatus = {
       pythonReady: true,
@@ -308,9 +309,10 @@ describe('NotebookPreview per-kernel tabs', () => {
             notebookSessionRoot: '/tmp/proj/.notebook',
             dataRoot: '/tmp/proj/.notebook/data',
             runtimeRoot: '/tmp/proj/.notebook/runtime',
-            kernelStatus: 'idle',
+            kernelStatus,
             runJsonPath: '/tmp/proj/.notebook/run.json',
             cells: [],
+            runCount: runs.length,
             runs,
             recentRuns: runs,
             runStaleness,
@@ -357,11 +359,32 @@ describe('NotebookPreview per-kernel tabs', () => {
     expect(divider?.getAttribute('role')).toBe('separator')
     expect(divider?.getAttribute('aria-label')).toBe('Resize notebook and terminal')
     expect(divider?.getAttribute('aria-orientation')).toBe('horizontal')
-    expect(
-      container.querySelector('[data-testid="notebook-terminal-header"]')?.textContent
-    ).toContain('Python kernel')
+    const terminalHeader = container.querySelector('[data-testid="notebook-terminal-header"]')
+    expect(terminalHeader?.textContent).toContain('Python kernel')
+    expect(divider?.contains(terminalHeader)).toBe(true)
+    expect(divider?.className).toContain('before:opacity-60')
     expect(container.querySelector('[data-slot="message-scroller-button"]')).toBeNull()
     expect(container.querySelector('[aria-label="Scroll to end"]')).toBeNull()
+  })
+
+  it('renders terminated notebook history as view-only without terminal controls', async () => {
+    await mountWithRuns(
+      [
+        makeRun({ runId: 'p1', kernelKind: 'python', script: 'print(1)' }),
+        makeRun({ runId: 'p2', kernelKind: 'python', script: 'print(2)' })
+      ],
+      [],
+      {},
+      'terminated'
+    )
+
+    expect(container.querySelectorAll('[data-testid="notebook-cell"]')).toHaveLength(2)
+    expect(container.querySelector('[data-testid="kernel-terminal"]')).toBeNull()
+    expect(container.querySelector('[data-testid="kernel-terminal-input"]')).toBeNull()
+    expect(container.querySelector('[data-separator]')).toBeNull()
+    expect(container.querySelector('[data-testid="notebook-read-only-status"]')?.textContent).toBe(
+      "Python · view only; this kernel's namespace no longer exists2 cells"
+    )
   })
 
   it('describes later variable changes without implying an execution error', async () => {

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -530,6 +530,8 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
       return (entry.environment ?? 'default-r') === activeEnvName
     })?.restartRecommended ??
       false)
+  const isNamespaceLost = notebookState?.kernelStatus === 'terminated'
+  const cellCount = notebookState?.runCount ?? runs.length
 
   // Restarts the shared interpreter, replacing state with the fresh snapshot so the banner clears.
   const handleRestart = async (): Promise<void> => {
@@ -544,6 +546,32 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
       setIsRestarting(false)
     }
   }
+  const notebookCells = (
+    <div
+      ref={cellsViewportRef}
+      className="h-full min-h-0 overflow-y-auto overscroll-contain"
+      data-testid="notebook-cells"
+    >
+      <div className="divide-y divide-border-100">
+        {visibleRuns.map((run, index) => {
+          const staleness = visibleStalenessForRun(run)
+          return (
+            <NotebookRunCell
+              key={run.runId}
+              run={run}
+              index={index}
+              staleness={staleness}
+              causedByRunIndex={
+                staleness?.state === 'stale'
+                  ? visibleRunIndexById.get(staleness.causedByRunId)
+                  : undefined
+              }
+            />
+          )
+        })}
+      </div>
+    </div>
+  )
 
   return (
     <section
@@ -685,75 +713,74 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
         </div>
       ) : null}
 
-      <ResizablePanelGroup orientation="vertical" className="min-h-0 flex-1 flex-col">
-        <ResizablePanel
-          id="notebook-cells-panel"
-          defaultSize="80%"
-          minSize="35%"
-          className="min-h-0 overflow-hidden"
-        >
-          <div
-            ref={cellsViewportRef}
-            className="h-full min-h-0 overflow-y-auto overscroll-contain"
-            data-testid="notebook-cells"
+      {isNamespaceLost ? (
+        <div className="min-h-0 flex-1 overflow-hidden">{notebookCells}</div>
+      ) : (
+        <ResizablePanelGroup orientation="vertical" className="min-h-0 flex-1 flex-col">
+          <ResizablePanel
+            id="notebook-cells-panel"
+            defaultSize="80%"
+            minSize="35%"
+            className="min-h-0 overflow-hidden"
           >
-            <div className="divide-y divide-border-100">
-              {visibleRuns.map((run, index) => {
-                const staleness = visibleStalenessForRun(run)
-                return (
-                  <NotebookRunCell
-                    key={run.runId}
-                    run={run}
-                    index={index}
-                    staleness={staleness}
-                    causedByRunIndex={
-                      staleness?.state === 'stale'
-                        ? visibleRunIndexById.get(staleness.causedByRunId)
-                        : undefined
-                    }
-                  />
-                )
-              })}
-            </div>
-          </div>
-        </ResizablePanel>
+            {notebookCells}
+          </ResizablePanel>
 
-        <ResizableHandle
-          aria-label={t('Resize notebook and terminal')}
-          className="shrink-0 bg-border-200"
-        />
-
-        <ResizablePanel
-          id="notebook-terminal-panel"
-          defaultSize="20%"
-          minSize="15%"
-          className="min-h-0 overflow-hidden"
-        >
-          <div className="flex h-full min-h-0 flex-col bg-bg-200" data-testid="kernel-terminal">
+          <ResizableHandle
+            aria-label={t('Resize notebook and terminal')}
+            className="z-10 shrink-0 border-y border-border-200 bg-bg-200/70 aria-[orientation=horizontal]:h-7 aria-[orientation=horizontal]:before:h-1 aria-[orientation=horizontal]:before:w-10 before:opacity-60 hover:before:opacity-100 focus-visible:before:opacity-100 data-[separator=active]:before:opacity-100"
+          >
             <div
-              className="flex shrink-0 items-center justify-between gap-2 border-b border-border-200 bg-bg-200/70 px-3 py-1 text-[11px] text-text-300"
+              className="pointer-events-none absolute inset-0 flex items-center justify-between gap-2 px-3 text-[11px] text-text-300"
               data-testid="notebook-terminal-header"
             >
               <span>{t('Python kernel · shared with the agent')}</span>
               <span>{isNotebookBusy ? t('running') : t('idle')}</span>
             </div>
-            {actionError ? (
-              <div className="border-b border-border-100/60 px-3 py-2 font-mono text-xs text-danger-000">
-                {actionError}
-              </div>
-            ) : null}
-            <TerminalScrollback runs={projectedRuns} viewportRef={terminalViewportRef} />
-            <TerminalInput
-              code={terminalCode}
-              disabled={isTerminalLocked}
-              onChange={setTerminalCode}
-              onSubmit={() => {
-                void submitTerminalCode()
-              }}
-            />
-          </div>
-        </ResizablePanel>
-      </ResizablePanelGroup>
+          </ResizableHandle>
+
+          <ResizablePanel
+            id="notebook-terminal-panel"
+            defaultSize="20%"
+            minSize="15%"
+            className="min-h-0 overflow-hidden"
+          >
+            <div className="flex h-full min-h-0 flex-col bg-bg-000" data-testid="kernel-terminal">
+              {actionError ? (
+                <div className="border-b border-border-100/60 px-3 py-2 font-mono text-xs text-danger-000">
+                  {actionError}
+                </div>
+              ) : null}
+              <TerminalScrollback runs={projectedRuns} viewportRef={terminalViewportRef} />
+              <TerminalInput
+                code={terminalCode}
+                disabled={isTerminalLocked}
+                onChange={setTerminalCode}
+                onSubmit={() => {
+                  void submitTerminalCode()
+                }}
+              />
+            </div>
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      )}
+
+      {isNamespaceLost ? (
+        <footer
+          className="flex h-7 shrink-0 items-center justify-between gap-3 border-t border-border-200 bg-bg-000 px-2 text-[11px] text-text-300"
+          data-testid="notebook-read-only-status"
+        >
+          <span className="min-w-0 truncate">
+            {t("Python · view only; this kernel's namespace no longer exists")}
+          </span>
+          <span className="shrink-0 tabular-nums">
+            {t('{{count}} cells', {
+              defaultValue_one: '{{count}} cell',
+              count: cellCount
+            })}
+          </span>
+        </footer>
+      ) : null}
     </section>
   )
 }


### PR DESCRIPTION
## Problem

Notebook previews continued to expose the live kernel terminal after the notebook session had terminated, even though that kernel namespace no longer existed. The interactive terminal header also sat outside the resize affordance, so the draggable boundary was visually ambiguous.

## Proposed change

- Render terminated Notebook sessions as view-only history with the cell count in a compact status footer.
- Hide the terminal input and resize separator when `kernelStatus` is `terminated`.
- Keep every other kernel state interactive.
- Combine the live kernel title/status and visible drag pill into the horizontal resize separator.
- Allow `ResizableHandle` consumers to render optional separator content.
- Translate the new view-only message in all six renderer locales.

## Scope and non-goals

- No new kernel status or enum value.
- No persisted schema or data migration.
- No historical-data compatibility path is required; the existing `terminated` state drives the behavior.
- No ending timestamp is introduced because the current state does not persist one.

## Acceptance criteria and validation

- Terminated Notebook preview keeps rendered cells and shows no terminal controls: covered by `NotebookPreview.gate.render.test.tsx`.
- Interactive Notebook preview keeps a horizontal resizable terminal and exposes its header inside the separator: covered by `NotebookPreview.gate.render.test.tsx` and `resizable.test.tsx`.
- Follow-scroll behavior remains intact: covered by `NotebookPreview.follow-scroll.test.tsx`.
- Renderer translations remain complete: covered by `resources.test.ts`.

Commands run:

- `npm test -- src/renderer/src/components/ui/resizable.test.tsx src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx src/renderer/src/pages/workspace/NotebookPreview.follow-scroll.test.tsx src/renderer/src/i18n/resources.test.ts` — 4 files, 622 tests passed.
- `npm run typecheck:web` — passed.
- `npm run lint` — passed.
- `npm run build:web` — passed.
- `npm run test:module -- workspace_page` — 496 passed, 2 pre-existing failures in files unchanged from `origin/main`: the session-store consumer inventory and the existing 715-line workspace message queue architecture limit.

The full `npm test` suite was intentionally not run; PR CI is the complete-suite authority for this change.

## Review focus

- Whether `terminated` is the correct and sufficient namespace-loss signal.
- Whether the compact footer and separator affordance match the intended Notebook preview hierarchy at narrow panel widths.
