### PR TITLE
fix(composer): show messages during runtime admission

### DIFF
--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -389,6 +389,7 @@ const createPanelDefaults = (): PanelProps => ({
     }
   },
   conversation: {
+    optimisticMessage: undefined,
     availability: {
       submit: false,
       submitMode: undefined,

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -391,7 +391,8 @@ const ConversationPanel = ({
       resume: onResumeSession,
       cancel: onCancelRun
     },
-    queue: messageQueue
+    queue: messageQueue,
+    optimisticMessage
   } = conversation
   const {
     view: sideChat,
@@ -857,6 +858,7 @@ const ConversationPanel = ({
         <WorkspaceMessageEditStateProvider canEditMessage={canEditMessage && !sideChat}>
           <WorkspaceMessageScroller
             activeSession={activeSession}
+            optimisticMessage={optimisticMessage}
             isResumingSession={isResuming}
             notebookReference={notebookReference}
             onSendEditedMessage={onSendEditedMessage}

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -22,6 +22,7 @@ import {
   GitBranch,
   Image as ImageIcon,
   MessageCircleMore,
+  Loader2,
   Pencil
 } from 'lucide-react'
 import {
@@ -98,6 +99,8 @@ type WorkspaceMessageItemProps = {
   canEditMessage?: boolean
   // Immutable transcript surfaces can reuse the normal message renderer without live actions.
   showUserActions?: boolean
+  // Renderer-only optimistic Composer submission; never persisted in the Session graph.
+  sending?: boolean
   // Embedded transcript surfaces can supply their own horizontal gutter without changing live chat.
   contentPaddingClassName?: string
   onSendEditedMessage?: (messageId: string, doc: ComposerDoc) => void
@@ -1120,6 +1123,7 @@ const WorkspaceMessageItemImpl = ({
   onPreviewMentionArtifact,
   canEditMessage = false,
   showUserActions = true,
+  sending = false,
   contentPaddingClassName,
   onSendEditedMessage,
   canBranchInNewSession = false,
@@ -1162,7 +1166,7 @@ const WorkspaceMessageItemImpl = ({
   }, [isAssistantPresenting, message.id, onPresentationChange, presentsAssistantMessage])
 
   const uploads = message.uploads ?? []
-  const sentDate = toMessageDate(message.createdAt)
+  const sentDate = sending ? undefined : toMessageDate(message.createdAt)
   const showRevisionNavigation =
     showUserActions && isHumanUser && revisionNavigation && revisionNavigation.total > 1
   const [copied, setCopied] = useState(false)
@@ -1402,11 +1406,20 @@ const WorkspaceMessageItemImpl = ({
                   )}
                 </div>
               </div>
-              {sentDate || message.interrupted || showRevisionNavigation ? (
+              {sending || sentDate || message.interrupted || showRevisionNavigation ? (
                 <div
                   data-slot="user-message-footer"
                   className="mt-1 flex min-h-6 w-full flex-wrap items-center justify-end gap-x-2 text-[11px] leading-4 text-text-000/70 tabular-nums"
                 >
+                  {sending ? (
+                    <span className="flex items-center gap-1" role="status" aria-live="polite">
+                      <Loader2
+                        className="size-3 animate-spin motion-reduce:animate-none"
+                        aria-hidden="true"
+                      />
+                      {t('Sending…')}
+                    </span>
+                  ) : null}
                   {message.interrupted ? (
                     <span
                       data-slot="user-message-interrupted"
@@ -1562,6 +1575,7 @@ const areWorkspaceMessageItemPropsEqual = (
   previous.onBranchInNewSession === next.onBranchInNewSession &&
   (previous.canEditMessage ?? false) === (next.canEditMessage ?? false) &&
   (previous.showUserActions ?? true) === (next.showUserActions ?? true) &&
+  (previous.sending ?? false) === (next.sending ?? false) &&
   previous.contentPaddingClassName === next.contentPaddingClassName &&
   previous.turnStartedAt === next.turnStartedAt &&
   (previous.showAssistantFooter ?? true) === (next.showAssistantFooter ?? true) &&

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx
@@ -194,7 +194,7 @@ const createUpload = (overrides: Partial<UploadedAttachment> = {}): UploadedAtta
 
 const renderScroller = async (
   session: ChatSession,
-  props: { isResumingSession?: boolean } = {}
+  props: { isResumingSession?: boolean; optimisticMessage?: ChatMessage } = {}
 ): Promise<string> => {
   const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
 
@@ -202,10 +202,29 @@ const renderScroller = async (
     <WorkspaceMessageScroller
       activeSession={session}
       isResumingSession={props.isResumingSession}
+      optimisticMessage={props.optimisticMessage}
       onSendEditedMessage={vi.fn()}
     />
   )
 }
+
+describe('WorkspaceMessageScroller optimistic send render', () => {
+  it('renders a sending user bubble before the authoritative Message is admitted', async () => {
+    const html = await renderScroller(createSession({ status: 'idle' }), {
+      optimisticMessage: createMessage({
+        id: 'optimistic-session-1-1',
+        content: 'Follow-up request',
+        createdAt: 0,
+        updatedAt: 0
+      })
+    })
+
+    expect(html).toContain('data-message-id="optimistic-session-1-1"')
+    expect(html).toContain('data-slot="user-message-bubble"')
+    expect(html).toContain('Follow-up request')
+    expect(html).toContain('Sending…')
+  })
+})
 
 describe('WorkspaceMessageScroller Run Marks render', () => {
   it('passes the presented conversation to Run Marks', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -90,6 +90,7 @@ type WorkspaceMessageScrollerProps = {
   isResumingSession?: boolean
   notebookReference?: NotebookSessionReference
   onSendEditedMessage: (messageId: string, doc: ComposerDoc) => void
+  optimisticMessage?: ChatMessage
   canBranchInNewSession?: boolean
   onBranchInNewSession?: (messageId: string) => void
   trailingContent?: ReactNode
@@ -359,6 +360,7 @@ const WorkspaceMessageScrollerImpl = ({
   isResumingSession = false,
   notebookReference,
   onSendEditedMessage,
+  optimisticMessage,
   canBranchInNewSession = false,
   onBranchInNewSession,
   trailingContent,
@@ -556,7 +558,8 @@ const WorkspaceMessageScrollerImpl = ({
       : conversationItems
   // Brand-new conversation (nothing presented, no resume in flight): invite the first prompt with
   // a centered placeholder banner over the empty transcript area.
-  const showEmptyConversationBanner = presentedConversationItems.length === 0 && !isResumingSession
+  const showEmptyConversationBanner =
+    presentedConversationItems.length === 0 && !optimisticMessage && !isResumingSession
   const visibleMessageIds = presentedConversationItems.flatMap((item) =>
     item.type === 'message' ? [item.message.id] : []
   )
@@ -1418,6 +1421,19 @@ const WorkspaceMessageScrollerImpl = ({
                 </MessageScrollerItem>
               ))}
 
+              {optimisticMessage ? (
+                <WorkspaceMessageItem
+                  message={optimisticMessage}
+                  onPreviewArtifact={onPreviewArtifact}
+                  onPreviewArtifactModal={onPreviewArtifactModal}
+                  onPreviewUploadAttachment={onPreviewUploadAttachment}
+                  onOpenSkillMention={onOpenSkillMention}
+                  onPreviewMentionArtifact={onPreviewMentionArtifact}
+                  showUserActions={false}
+                  sending
+                />
+              ) : null}
+
               {presentationBarrierIndex < 0 ? trailingContent : null}
 
               {isResumingSession && activeSession ? (
@@ -1533,6 +1549,7 @@ const areWorkspaceMessageScrollerPropsEqual = (
   next: WorkspaceMessageScrollerProps
 ): boolean =>
   previous.onSendEditedMessage === next.onSendEditedMessage &&
+  previous.optimisticMessage === next.optimisticMessage &&
   (previous.canBranchInNewSession ?? false) === (next.canBranchInNewSession ?? false) &&
   (previous.reportPresentationRevealing ?? false) === (next.reportPresentationRevealing ?? false) &&
   previous.onBranchInNewSession === next.onBranchInNewSession &&

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
@@ -190,6 +190,29 @@ afterEach(() => {
 })
 
 describe('workspace conversation controller', () => {
+  it('exposes the submitted draft immediately while runtime admission is pending', async () => {
+    let resolveAdmission!: (value: { sessionId: string; messageId: string }) => void
+    const admission = new Promise<{ sessionId: string; messageId: string }>((resolve) => {
+      resolveAdmission = resolve
+    })
+    const input = options()
+    input.runtime.sendMessage = vi.fn(() => admission)
+    const hook = renderController(input)
+    mounted.push(hook)
+
+    act(() => hook.result.current.actions.submit.draft({ forcedSkillIds: [] }))
+
+    expect(hook.result.current.optimisticMessage).toMatchObject({
+      role: 'user',
+      content: 'hello',
+      parts: textDoc('hello').nodes,
+      uploads: []
+    })
+
+    await act(async () => resolveAdmission({ sessionId: 'session-a', messageId: 'message-a' }))
+    expect(hook.result.current.optimisticMessage).toBeUndefined()
+  })
+
   it('branches from a completed Agent Message without consuming the composer draft', async () => {
     const input = options()
     const hook = renderController(input)
@@ -735,6 +758,7 @@ describe('workspace conversation controller', () => {
     expect(input.composer.lifecycle.restoreFailedSend).toHaveBeenCalledWith(
       expect.objectContaining({ draftKey: 'session-a', version: 1 })
     )
+    expect(hook.result.current.optimisticMessage).toBeUndefined()
   })
 
   it('includes new-Session Compute intent in creation and stamps Review after submit succeeds', async () => {

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
@@ -3,7 +3,11 @@ import { useLayoutEffect, useRef, useState } from 'react'
 import type { PermissionProfileId } from '../../../../shared/permission-profiles'
 import type { SessionAgentConfiguration } from '../../../../shared/settings'
 import { VISION_MODEL_NOT_CONFIGURED_MESSAGE } from '../../../../shared/run-error-classification'
-import type { ChatSession, SessionActionabilityProjection } from '@/stores/session-store'
+import type {
+  ChatMessage,
+  ChatSession,
+  SessionActionabilityProjection
+} from '@/stores/session-store'
 import type { WorkspaceAgentRuntime } from '@/lib/acp/useWorkspaceAgentRuntime'
 
 import {
@@ -98,6 +102,7 @@ type WorkspaceConversationControllerOptions = {
 }
 
 type WorkspaceConversationController = {
+  optimisticMessage: ChatMessage | undefined
   availability: {
     submit: boolean
     submitMode: 'send' | 'queue' | undefined
@@ -224,6 +229,7 @@ const useWorkspaceConversationController = (
     optionsRef.current = options
   }, [options])
   const inFlightDraftKeysRef = useRef(new Set<string>())
+  const [optimisticMessages, setOptimisticMessages] = useState<Record<string, ChatMessage>>({})
   const messageQueue = useWorkspaceMessageQueueController({
     activeSession: options.activeSession,
     promptInFlightSessionIds: options.promptInFlightSessionIds,
@@ -306,6 +312,22 @@ const useWorkspaceConversationController = (
         session.lifecycle.captureSendIntent(branchInNewSession)
 
       const dispatch = (sessionId: string | undefined): void => {
+        const optimisticMessage = sessionId
+          ? {
+              id: `optimistic-${snapshot.draftKey}-${snapshot.version}`,
+              role: 'user' as const,
+              content: docToText(snapshot.doc),
+              status: 'complete' as const,
+              eventIds: [],
+              uploads: snapshot.attachments,
+              parts: snapshot.doc.nodes,
+              createdAt: 0,
+              updatedAt: 0
+            }
+          : undefined
+        if (sessionId && optimisticMessage) {
+          setOptimisticMessages((current) => ({ ...current, [sessionId]: optimisticMessage }))
+        }
         void runtime
           .sendMessage({
             sessionId,
@@ -345,7 +367,16 @@ const useWorkspaceConversationController = (
             current.resetNewConversationSettings()
             session.actions.resetNewConversationSpecialist()
           })
-          .finally(() => inFlightDraftKeysRef.current.delete(snapshot.draftKey))
+          .finally(() => {
+            inFlightDraftKeysRef.current.delete(snapshot.draftKey)
+            if (!sessionId || !optimisticMessage) return
+            setOptimisticMessages((current) => {
+              if (current[sessionId]?.id !== optimisticMessage.id) return current
+              const next = { ...current }
+              delete next[sessionId]
+              return next
+            })
+          })
       }
 
       if (hasPendingSwitch && activeSession) {
@@ -463,6 +494,9 @@ const useWorkspaceConversationController = (
   const queueDraft = canQueueDraft(options)
 
   return {
+    optimisticMessage: options.activeSession
+      ? optimisticMessages[options.activeSession.id]
+      : undefined,
     availability: {
       submit: submitImmediately || queueDraft,
       submitMode: submitImmediately ? 'send' : queueDraft ? 'queue' : undefined,


### PR DESCRIPTION
## Problem

When a Composer submission targets an existing Session, the draft is cleared before runtime admission finishes. Admission may need to resume or adopt the runtime and finalize prompt inputs before the authoritative user Message is appended, leaving an empty Composer and unchanged transcript long enough to look stuck.

This is most visible on existing Sessions that require runtime preparation. New-Session sends already append their pending Message synchronously, and queued sends follow a separate interaction.

Without feedback, users can interpret a valid send as a freeze, lose confidence in whether input was accepted, or attempt the action again.

## Proposed change

- Capture the submitted Composer snapshot as a renderer-only optimistic user Message for the active Session.
- Render it immediately through the existing message-bubble component with the existing localized `Sending…` status.
- Remove the optimistic Message after authoritative admission succeeds; on failure, remove it while the existing draft-restoration path restores the Composer.
- Guard cleanup by optimistic Message ID so an older completion cannot remove a newer pending submission.

## Scope and non-goals

- Interaction change only: an immediate transient message bubble is added during runtime admission.
- No database or persisted payload fields are added.
- No Session/Message graph or data-model changes are made.
- No enum or status value is added; `sending` is a renderer-only prop.
- No historical-data compatibility or migration is required.
- Runtime ownership, resume/adoption ordering, queued sends, and new-Session admission are unchanged.

## Acceptance criteria and validation

- Controller regression: while a controlled runtime admission Promise is pending, the captured text, parts, and uploads are immediately exposed as an optimistic user Message; after admission it is reconciled away.
- Render regression: the real Workspace message scroller renders the optimistic user bubble and `Sending…` before authoritative admission.
- Failure regression: a failed send removes the optimistic bubble and preserves the existing draft rollback behavior.

Checks after the final material edit:

- `npx vitest run src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts` — 34 passed
- `npx vitest run src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx` — 71 passed
- `npx vitest run src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx` — 27 passed
- `npx vitest run src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx` — 115 passed
- `npx vitest run src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx` — 20 passed
- `npx vitest run src/renderer/src/i18n/resources.test.ts` — 590 passed
- `npm run typecheck:web` — passed
- `npm run lint` — passed

The two new regression tests were run against the unfixed behavior first and failed for the reported reason: the controller exposed no optimistic Message and the scroller rendered no immediate user bubble.

`npm run test:module -- workspace_page` currently reports two unrelated architecture-baseline failures. Both reproduce on unmodified `main`: the session-store direct-consumer allowlist is missing `session-message-artifact-reference.ts`, and `workspace-message-queue-controller.ts` exceeds its existing 700-line gate (715 lines). Per task scope, the complete suite was not run locally; PR CI is the full validation boundary.

## Review focus

- The optimistic Message must remain renderer-only and must not enter persistence or the authoritative Session graph.
- Success and failure cleanup should never remove a newer pending Message for the same Session.
- The existing bubble UI, attachment previews, accessibility status, and localized copy are reused without exposing sent-only actions on the transient Message.
