### PR TITLE
fix(notebook): route user input to selected kernel

### DIFF
--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -410,6 +410,7 @@ class NotebookRuntimeService {
       dependencyAnalyzer: this.dependencyAnalyzer,
       findSession: (sessionId) => this.sessions.get(this.sessionLifecycle.rootLane(sessionId)),
       runtimeBindings: (session) => this.runtimeBindingOwner.snapshot(session),
+      runtimeEnvironment: (session, language) => this.resolveRunEnv(session, language),
       isRestartRecommended: (processKey) =>
         this.environmentOperations.isRestartRecommended(processKey)
     })

--- a/src/main/notebook/session-read-model.test.ts
+++ b/src/main/notebook/session-read-model.test.ts
@@ -120,6 +120,7 @@ const makeReadModel = (
         status: 'active'
       }
     }),
+    runtimeEnvironment: (_session, language) => (language === 'r' ? 'analysis' : 'default-python'),
     isRestartRecommended: (processKey) => processKey === 'r:analysis'
   })
 
@@ -199,6 +200,7 @@ describe('NotebookSessionReadModel', () => {
           restartRecommended: true
         }
       ],
+      executionEnvironments: { python: 'default-python', r: 'analysis' },
       runtimeBindings: { python: { runtimeId: 'managed-python' } }
     })
   })

--- a/src/main/notebook/session-read-model.ts
+++ b/src/main/notebook/session-read-model.ts
@@ -23,7 +23,7 @@ import type { NotebookSessionSnapshot } from './session-aggregate'
 import type { NotebookLaneIdentity } from './lane-identity'
 import { resolveProjectId } from '../../shared/project-scope'
 import { NOTEBOOK_RENDERER_RUN_LIMIT } from './content-limits'
-import { DEFAULT_PY_ENV } from './runtime-paths'
+import { DEFAULT_PY_ENV, DEFAULT_R_ENV } from './runtime-paths'
 import {
   unavailableNotebookDependencyProjection,
   type NotebookDependencyAnalyzer,
@@ -99,6 +99,7 @@ type NotebookSessionReadModelOptions<Session extends NotebookSessionReadSource> 
   dependencyAnalyzer: Pick<NotebookDependencyAnalyzer, 'project'>
   findSession: (sessionId: string) => Session | undefined
   runtimeBindings: (session: Session) => NotebookRuntimeBindings
+  runtimeEnvironment?: (session: Session, language: NotebookLanguage) => string
   isRestartRecommended: (processKey: string) => boolean
 }
 
@@ -221,6 +222,10 @@ class NotebookSessionReadModel<Session extends NotebookSessionReadSource> {
       activeRunId: snapshot.activeRunId,
       runCount: runWindow.total,
       latestRunEnvironments: runWindow.latestRunEnvironments,
+      executionEnvironments: {
+        python: this.options.runtimeEnvironment?.(session, 'python') ?? DEFAULT_PY_ENV,
+        r: this.options.runtimeEnvironment?.(session, 'r') ?? DEFAULT_R_ENV
+      },
       ...(runWindow.historySummary ? { historySummary: runWindow.historySummary } : {}),
       runs: runWindow.runs.map((run) => this.toPublicRunRecord(run)),
       recentRuns: sparseRunRead

--- a/src/renderer/src/locales/fr.json
+++ b/src/renderer/src/locales/fr.json
@@ -1487,6 +1487,7 @@
   "Python · view only; this kernel's namespace no longer exists": "Python · lecture seule; l’espace de noms de ce noyau n’existe plus",
   "R kernel · shared with the agent": "Noyau R · partagé avec l'agent",
   "R · view only; this kernel's namespace no longer exists": "R · lecture seule; l’espace de noms de ce noyau n’existe plus",
+  "{{environment}} · history only; new code runs in {{activeEnvironment}}": "{{environment}} · historique uniquement; le nouveau code s’exécute dans {{activeEnvironment}}",
   "Python package index (pip)": "Index des paquets Python (pip)",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Les environnements Python/R sont reconstruits au nouvel emplacement lors de la première utilisation (non déplacés).",
   "Question from {{name}}": "Question de {{name}}",

--- a/src/renderer/src/locales/fr.json
+++ b/src/renderer/src/locales/fr.json
@@ -1485,6 +1485,8 @@
   "Python": "Python",
   "Python kernel · shared with the agent": "Noyau Python · partagé avec l'agent",
   "Python · view only; this kernel's namespace no longer exists": "Python · lecture seule; l’espace de noms de ce noyau n’existe plus",
+  "R kernel · shared with the agent": "Noyau R · partagé avec l'agent",
+  "R · view only; this kernel's namespace no longer exists": "R · lecture seule; l’espace de noms de ce noyau n’existe plus",
   "Python package index (pip)": "Index des paquets Python (pip)",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Les environnements Python/R sont reconstruits au nouvel emplacement lors de la première utilisation (non déplacés).",
   "Question from {{name}}": "Question de {{name}}",

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -1432,6 +1432,8 @@
   "Python": "Python",
   "Python kernel · shared with the agent": "Python カーネル · エージェントと共有",
   "Python · view only; this kernel's namespace no longer exists": "Python · 表示専用 — このカーネルの名前空間はもう存在しません",
+  "R kernel · shared with the agent": "R カーネル · エージェントと共有",
+  "R · view only; this kernel's namespace no longer exists": "R · 表示専用 — このカーネルの名前空間はもう存在しません",
   "Python package index (pip)": "Python パッケージ インデックス (pip)",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Python/R 環境は、最初の使用時に新しい場所に再構築されます (移動されません)。",
   "Question from {{name}}": "{{name}} からの質問",

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -1434,6 +1434,7 @@
   "Python · view only; this kernel's namespace no longer exists": "Python · 表示専用 — このカーネルの名前空間はもう存在しません",
   "R kernel · shared with the agent": "R カーネル · エージェントと共有",
   "R · view only; this kernel's namespace no longer exists": "R · 表示専用 — このカーネルの名前空間はもう存在しません",
+  "{{environment}} · history only; new code runs in {{activeEnvironment}}": "{{environment}} · 履歴のみ。新しいコードは {{activeEnvironment}} で実行されます",
   "Python package index (pip)": "Python パッケージ インデックス (pip)",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Python/R 環境は、最初の使用時に新しい場所に再構築されます (移動されません)。",
   "Question from {{name}}": "{{name}} からの質問",

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -1445,6 +1445,7 @@
   "Python · view only; this kernel's namespace no longer exists": "Python · 보기 전용 — 이 커널의 네임스페이스가 더 이상 존재하지 않습니다",
   "R kernel · shared with the agent": "R 커널 · 에이전트와 공유됨",
   "R · view only; this kernel's namespace no longer exists": "R · 보기 전용 — 이 커널의 네임스페이스가 더 이상 존재하지 않습니다",
+  "{{environment}} · history only; new code runs in {{activeEnvironment}}": "{{environment}} · 기록 전용; 새 코드는 {{activeEnvironment}}에서 실행됩니다",
   "Python package index (pip)": "Python 패키지 인덱스(pip)",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Python/R 환경은 처음 사용 시 새 위치에 다시 작성됩니다(이동되지 않음).",
   "Question from {{name}}": "{{name}}의 질문",

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -1443,6 +1443,8 @@
   "Python": "Python",
   "Python kernel · shared with the agent": "Python 커널 · 에이전트와 공유됨",
   "Python · view only; this kernel's namespace no longer exists": "Python · 보기 전용 — 이 커널의 네임스페이스가 더 이상 존재하지 않습니다",
+  "R kernel · shared with the agent": "R 커널 · 에이전트와 공유됨",
+  "R · view only; this kernel's namespace no longer exists": "R · 보기 전용 — 이 커널의 네임스페이스가 더 이상 존재하지 않습니다",
   "Python package index (pip)": "Python 패키지 인덱스(pip)",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Python/R 환경은 처음 사용 시 새 위치에 다시 작성됩니다(이동되지 않음).",
   "Question from {{name}}": "{{name}}의 질문",

--- a/src/renderer/src/locales/ru.json
+++ b/src/renderer/src/locales/ru.json
@@ -1482,6 +1482,7 @@
   "Python · view only; this kernel's namespace no longer exists": "Python · только просмотр — пространство имён этого ядра больше не существует",
   "R kernel · shared with the agent": "Ядро R · совместно используется с агентом",
   "R · view only; this kernel's namespace no longer exists": "R · только просмотр — пространство имён этого ядра больше не существует",
+  "{{environment}} · history only; new code runs in {{activeEnvironment}}": "{{environment}} · только история; новый код выполняется в {{activeEnvironment}}",
   "Python package index (pip)": "Python индекс пакета (pip)",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Python/R среды пересоздаются на новом месте при первом использовании (не перемещаются).",
   "Question from {{name}}": "Вопрос от {{name}}",

--- a/src/renderer/src/locales/ru.json
+++ b/src/renderer/src/locales/ru.json
@@ -1480,6 +1480,8 @@
   "Python": "Python",
   "Python kernel · shared with the agent": "Python ядро · передано агенту",
   "Python · view only; this kernel's namespace no longer exists": "Python · только просмотр — пространство имён этого ядра больше не существует",
+  "R kernel · shared with the agent": "Ядро R · совместно используется с агентом",
+  "R · view only; this kernel's namespace no longer exists": "R · только просмотр — пространство имён этого ядра больше не существует",
   "Python package index (pip)": "Python индекс пакета (pip)",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Python/R среды пересоздаются на новом месте при первом использовании (не перемещаются).",
   "Question from {{name}}": "Вопрос от {{name}}",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -1503,6 +1503,8 @@
   "Python": "Python",
   "Python kernel · shared with the agent": "Python 内核 · 与智能体共享",
   "Python · view only; this kernel's namespace no longer exists": "Python · 仅供查看；此内核的命名空间已不存在",
+  "R kernel · shared with the agent": "R 内核 · 与智能体共享",
+  "R · view only; this kernel's namespace no longer exists": "R · 仅供查看；此内核的命名空间已不存在",
   "Python package index (pip)": "Python 软件包索引（pip）",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Python/R 环境会在首次使用时于新位置重建（不迁移）。",
   "Question from {{name}}": "来自 {{name}} 的提问",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -1505,6 +1505,7 @@
   "Python · view only; this kernel's namespace no longer exists": "Python · 仅供查看；此内核的命名空间已不存在",
   "R kernel · shared with the agent": "R 内核 · 与智能体共享",
   "R · view only; this kernel's namespace no longer exists": "R · 仅供查看；此内核的命名空间已不存在",
+  "{{environment}} · history only; new code runs in {{activeEnvironment}}": "{{environment}} · 仅查看历史；新代码将在 {{activeEnvironment}} 中运行",
   "Python package index (pip)": "Python 软件包索引（pip）",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Python/R 环境会在首次使用时于新位置重建（不迁移）。",
   "Question from {{name}}": "来自 {{name}} 的提问",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -1502,6 +1502,7 @@
   "Python · view only; this kernel's namespace no longer exists": "Python · 僅供檢視；此核心的命名空間已不存在",
   "R kernel · shared with the agent": "R 核心 · 與智能體共用",
   "R · view only; this kernel's namespace no longer exists": "R · 僅供檢視；此核心的命名空間已不存在",
+  "{{environment}} · history only; new code runs in {{activeEnvironment}}": "{{environment}} · 僅供檢視歷史記錄；新程式碼將在 {{activeEnvironment}} 中執行",
   "Python package index (pip)": "Python 套件索引（pip）",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Python/R 環境會在首次使用時於新位置重建（不遷移）。",
   "Question from {{name}}": "來自 {{name}} 的提問",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -1500,6 +1500,8 @@
   "Python": "Python",
   "Python kernel · shared with the agent": "Python 核心 · 與智能體共用",
   "Python · view only; this kernel's namespace no longer exists": "Python · 僅供檢視；此核心的命名空間已不存在",
+  "R kernel · shared with the agent": "R 核心 · 與智能體共用",
+  "R · view only; this kernel's namespace no longer exists": "R · 僅供檢視；此核心的命名空間已不存在",
   "Python package index (pip)": "Python 套件索引（pip）",
   "Python/R environments are rebuilt at the new location on first use (not moved).": "Python/R 環境會在首次使用時於新位置重建（不遷移）。",
   "Question from {{name}}": "來自 {{name}} 的提問",

--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -286,11 +286,12 @@ describe('NotebookPreview per-kernel tabs', () => {
     runs: NotebookRunRecord[],
     environments: NotebookEnvironmentStatus[] = [],
     runStaleness: NotebookSessionState['runStaleness'] = {},
-    kernelStatus: NotebookSessionState['kernelStatus'] = 'idle'
+    kernelStatus: NotebookSessionState['kernelStatus'] = 'idle',
+    stateOverrides: Partial<NotebookSessionState> = {}
   ): Promise<void> => {
     const readyStatus: ProvisionStatus = {
       pythonReady: true,
-      rReady: false,
+      rReady: true,
       version: 1,
       provisioning: false
     }
@@ -316,9 +317,11 @@ describe('NotebookPreview per-kernel tabs', () => {
             runs,
             recentRuns: runs,
             runStaleness,
-            environments
+            environments,
+            ...stateOverrides
           })
         ),
+        execute: vi.fn(() => Promise.resolve({})),
         onChanged: vi.fn(() => vi.fn())
       },
       notebookEnv: {
@@ -563,10 +566,15 @@ describe('NotebookPreview per-kernel tabs', () => {
       container.querySelector<HTMLElement>('[data-separator]')?.getAttribute('aria-label')
     ).toBe('调整 Notebook 与终端大小')
 
+    fireEvent.click(
+      container.querySelector('[data-testid="kernel-switcher-r"]') as HTMLButtonElement
+    )
+    expect(header?.textContent).toContain('R 内核 · 与智能体共享')
+
     await act(async () => i18next.changeLanguage('en'))
   })
 
-  it('shows a tab only for kernel kinds present in the runs (no default python/r tab)', async () => {
+  it('always shows Python and R while keeping non-data tabs history-driven', async () => {
     await mountWithRuns([
       makeRun({ runId: 'p1', kernelKind: 'python' }),
       makeRun({ runId: 'x1', kernelKind: 'repl', script: 'await host.notebook.run(...)' }),
@@ -579,8 +587,7 @@ describe('NotebookPreview per-kernel tabs', () => {
       'Agent SDK'
     )
     expect(switcher.querySelector('[data-testid="kernel-switcher-bash"]')?.textContent).toBe('Bash')
-    // R produced no run here, so its tab does not appear (it shows up only once R is used).
-    expect(switcher.querySelector('[data-testid="kernel-switcher-r"]')).toBeNull()
+    expect(switcher.querySelector('[data-testid="kernel-switcher-r"]')).not.toBeNull()
   })
 
   it('projects named Main Agent and Subagent Runs without All, legacy, or Frame IDs', async () => {
@@ -626,13 +633,11 @@ describe('NotebookPreview per-kernel tabs', () => {
     expect(container.textContent).not.toContain('print("legacy")')
   })
 
-  it('shows the R tab only once R has produced a run', async () => {
-    await mountWithRuns([
-      makeRun({ runId: 'p1', kernelKind: 'python' }),
-      makeRun({ runId: 'r1', kernelKind: 'r', script: 'print(1)' })
-    ])
+  it('shows Python and R before either kernel has produced a run', async () => {
+    await mountWithRuns([])
 
     const switcher = container.querySelector('[data-testid="kernel-switcher"]') as HTMLElement
+    expect(switcher.querySelector('[data-testid="kernel-switcher-python"]')).not.toBeNull()
     expect(switcher.querySelector('[data-testid="kernel-switcher-r"]')).not.toBeNull()
   })
 
@@ -667,23 +672,144 @@ describe('NotebookPreview per-kernel tabs', () => {
     expect(container.textContent).not.toContain('print("py")')
   })
 
-  it('defaults to the Agent SDK tab and shows no R tab when only repl runs exist', async () => {
+  it('defaults to the executable Python tab when only Agent SDK history exists', async () => {
     await mountWithRuns([
       makeRun({ runId: 'x1', kernelKind: 'repl', script: 'host.notebook.run(...)' })
     ])
 
-    // No tab click: this is the pre-click default state. repl is the only kind with runs, so it is
-    // the active tab; python and R have no runs, so neither tab is shown.
     const switcher = container.querySelector('[data-testid="kernel-switcher"]') as HTMLElement
+    const pythonTab = switcher.querySelector(
+      '[data-testid="kernel-switcher-python"]'
+    ) as HTMLButtonElement
     const replTab = switcher.querySelector(
       '[data-testid="kernel-switcher-repl"]'
     ) as HTMLButtonElement
-    expect(switcher.querySelector('[data-testid="kernel-switcher-r"]')).toBeNull()
-    expect(switcher.querySelector('[data-testid="kernel-switcher-python"]')).toBeNull()
-    expect(replTab.className).toContain('bg-bg-300')
+    expect(switcher.querySelector('[data-testid="kernel-switcher-r"]')).not.toBeNull()
+    expect(pythonTab.className).toContain('bg-bg-300')
+    expect(replTab.className).not.toContain('bg-bg-300')
 
-    expect(container.querySelectorAll('[data-testid="notebook-cell"]').length).toBe(1)
-    expect(container.textContent).toContain('host.notebook.run')
+    expect(container.querySelectorAll('[data-testid="notebook-cell"]').length).toBe(0)
+    expect(container.textContent).not.toContain('host.notebook.run')
+  })
+
+  it('routes R input to the selected kernel and renders the result as a you call block', async () => {
+    const runs = [
+      makeRun({
+        runId: 'p1',
+        kernelKind: 'python',
+        inputKind: 'terminal',
+        script: 'print("python")'
+      }),
+      makeRun({ runId: 'r1', kernelKind: 'r', inputKind: 'terminal', script: 'print("r")' })
+    ]
+    await mountWithRuns(runs)
+
+    fireEvent.click(
+      container.querySelector('[data-testid="kernel-switcher-r"]') as HTMLButtonElement
+    )
+    const scrollback = container.querySelector('[data-testid="kernel-terminal-scrollback"]')
+    expect(scrollback?.textContent).toContain('> print("r")')
+    expect(scrollback?.textContent).not.toContain('print("python")')
+    const execute = vi.mocked(window.api.notebook.execute)
+    execute.mockImplementation(async (request) => {
+      runs.push(
+        makeRun({
+          runId: 'user-r',
+          cellId: 'user-r-cell',
+          source: 'user',
+          inputKind: 'terminal',
+          kernelKind: request.language ?? 'python',
+          environment: request.environment,
+          script: request.code
+        })
+      )
+      return {} as never
+    })
+
+    const input = container.querySelector(
+      '[data-testid="kernel-terminal-input"]'
+    ) as HTMLTextAreaElement
+    fireEvent.change(input, { target: { value: 'x <- 1' } })
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' })
+    })
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'x <- 1',
+        source: 'user',
+        inputKind: 'terminal',
+        language: 'r',
+        environment: 'default-r'
+      })
+    )
+    const userCell = [...container.querySelectorAll('[data-testid="notebook-cell"]')].find((cell) =>
+      cell.textContent?.includes('x <- 1')
+    )
+    expect(userCell?.textContent).toContain('you')
+    expect(userCell?.textContent).toContain('r')
+  })
+
+  it('shows selected-kernel status while retaining the notebook-wide input lock', async () => {
+    await mountWithRuns(
+      [
+        makeRun({ runId: 'python-running', kernelKind: 'python', status: 'running' }),
+        makeRun({ runId: 'r1', kernelKind: 'r' })
+      ],
+      [
+        {
+          processKey: 'r:default-r',
+          kind: 'r',
+          environment: 'default-r',
+          status: 'idle'
+        }
+      ],
+      {},
+      'running',
+      { activeRunId: 'python-running' }
+    )
+
+    expect(
+      container.querySelector('[data-testid="notebook-terminal-header"]')?.textContent
+    ).toContain('running')
+    fireEvent.click(
+      container.querySelector('[data-testid="kernel-switcher-r"]') as HTMLButtonElement
+    )
+    const header = container.querySelector('[data-testid="notebook-terminal-header"]')
+    expect(header?.textContent).toContain('R kernel')
+    expect(header?.textContent).toContain('idle')
+    expect(
+      (container.querySelector('[data-testid="kernel-terminal-input"]') as HTMLTextAreaElement)
+        .disabled
+    ).toBe(true)
+  })
+
+  it('hides data-kernel input on Agent SDK history and for a terminated selected R kernel', async () => {
+    await mountWithRuns(
+      [makeRun({ runId: 'r1', kernelKind: 'r' }), makeRun({ runId: 'x1', kernelKind: 'repl' })],
+      [
+        {
+          processKey: 'r:default-r',
+          kind: 'r',
+          environment: 'default-r',
+          status: 'terminated'
+        }
+      ]
+    )
+
+    fireEvent.click(
+      container.querySelector('[data-testid="kernel-switcher-r"]') as HTMLButtonElement
+    )
+    expect(container.querySelector('[data-testid="kernel-terminal-input"]')).toBeNull()
+    expect(
+      container.querySelector('[data-testid="notebook-read-only-status"]')?.textContent
+    ).toContain("R · view only; this kernel's namespace no longer exists")
+
+    fireEvent.click(
+      container.querySelector('[data-testid="kernel-switcher-repl"]') as HTMLButtonElement
+    )
+    expect(container.querySelector('[data-testid="kernel-terminal-input"]')).toBeNull()
+    expect(container.querySelector('[data-testid="notebook-read-only-status"]')).toBeNull()
   })
 
   it("renders a repl cell's origin label and uses the stored kernelKind for the language chip", async () => {
@@ -786,6 +912,7 @@ describe('NotebookPreview per-environment selector', () => {
             environments
           })
         ),
+        execute: vi.fn(() => Promise.resolve({})),
         onChanged: vi.fn(() => vi.fn())
       },
       notebookEnv: {
@@ -823,6 +950,31 @@ describe('NotebookPreview per-environment selector', () => {
 
     expect(container.querySelector('[data-testid="env-selector"]')).toBeNull()
     expect(container.querySelectorAll('[data-testid="notebook-cell"]').length).toBe(2)
+  })
+
+  it('submits to the only custom environment even when its selector is hidden', async () => {
+    await mountWithRuns([
+      makeRun({
+        runId: 'p1',
+        kernelKind: 'python',
+        environment: 'my-analysis'
+      })
+    ])
+
+    const input = container.querySelector(
+      '[data-testid="kernel-terminal-input"]'
+    ) as HTMLTextAreaElement
+    fireEvent.change(input, { target: { value: 'print(1)' } })
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' })
+    })
+
+    expect(window.api.notebook.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        language: 'python',
+        environment: 'my-analysis'
+      })
+    )
   })
 
   it('shows the selector across two python envs, defaults labeled "default", and filters on selection', async () => {

--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -719,7 +719,7 @@ describe('NotebookPreview per-kernel tabs', () => {
           source: 'user',
           inputKind: 'terminal',
           kernelKind: request.language ?? 'python',
-          environment: request.environment,
+          environment: request.language === 'r' ? 'default-r' : 'default-python',
           script: request.code
         })
       )
@@ -739,8 +739,7 @@ describe('NotebookPreview per-kernel tabs', () => {
         code: 'x <- 1',
         source: 'user',
         inputKind: 'terminal',
-        language: 'r',
-        environment: 'default-r'
+        language: 'r'
       })
     )
     const userCell = [...container.querySelectorAll('[data-testid="notebook-cell"]')].find((cell) =>
@@ -881,7 +880,8 @@ describe('NotebookPreview per-environment selector', () => {
 
   const mountWithRuns = async (
     runs: NotebookRunRecord[],
-    environments: NotebookEnvironmentStatus[] = []
+    environments: NotebookEnvironmentStatus[] = [],
+    executionEnvironments: NotebookSessionState['executionEnvironments'] = undefined
   ): Promise<void> => {
     const readyStatus: ProvisionStatus = {
       pythonReady: true,
@@ -909,7 +909,8 @@ describe('NotebookPreview per-environment selector', () => {
             cells: [],
             runs,
             recentRuns: runs,
-            environments
+            environments,
+            executionEnvironments
           })
         ),
         execute: vi.fn(() => Promise.resolve({})),
@@ -952,14 +953,18 @@ describe('NotebookPreview per-environment selector', () => {
     expect(container.querySelectorAll('[data-testid="notebook-cell"]').length).toBe(2)
   })
 
-  it('submits to the only custom environment even when its selector is hidden', async () => {
-    await mountWithRuns([
-      makeRun({
-        runId: 'p1',
-        kernelKind: 'python',
-        environment: 'my-analysis'
-      })
-    ])
+  it('submits through the current custom runtime binding even when its selector is hidden', async () => {
+    await mountWithRuns(
+      [
+        makeRun({
+          runId: 'p1',
+          kernelKind: 'python',
+          environment: 'my-analysis'
+        })
+      ],
+      [],
+      { python: 'my-analysis', r: 'default-r' }
+    )
 
     const input = container.querySelector(
       '[data-testid="kernel-terminal-input"]'
@@ -971,9 +976,11 @@ describe('NotebookPreview per-environment selector', () => {
 
     expect(window.api.notebook.execute).toHaveBeenCalledWith(
       expect.objectContaining({
-        language: 'python',
-        environment: 'my-analysis'
+        language: 'python'
       })
+    )
+    expect(window.api.notebook.execute).toHaveBeenCalledWith(
+      expect.not.objectContaining({ environment: expect.anything() })
     )
   })
 
@@ -1010,6 +1017,10 @@ describe('NotebookPreview per-environment selector', () => {
     expect(container.querySelectorAll('[data-testid="notebook-cell"]').length).toBe(1)
     expect(container.textContent).toContain('print("analysis")')
     expect(container.textContent).not.toContain('print("default")')
+    expect(container.querySelector('[data-testid="kernel-terminal-input"]')).toBeNull()
+    expect(container.querySelector('[data-testid="notebook-read-only-status"]')?.textContent).toBe(
+      'my-analysis · history only; new code runs in default-python2 cells'
+    )
   })
 
   it('groups a legacy run with no environment field under default-python', async () => {

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -224,45 +224,55 @@ const NotebookRunCell = ({
 // Mirrors terminal-originated runs in the bottom terminal scrollback.
 const TerminalScrollback = ({
   runs,
+  language,
   viewportRef
 }: {
   runs: NotebookRunRecord[]
+  language: NotebookLanguage
   viewportRef: RefObject<HTMLDivElement | null>
-}): React.JSX.Element => (
-  <div
-    ref={viewportRef}
-    className="min-h-0 flex-1 overflow-y-auto px-3 py-2 font-mono text-xs leading-5"
-    data-testid="kernel-terminal-scrollback"
-  >
-    <div>
-      {runs
-        .filter((run) => run.inputKind === 'terminal')
-        .map((run) => (
-          <div key={run.runId} className="whitespace-pre-wrap">
-            <div>
-              <span className="text-text-300">&gt;&gt;&gt; </span>
-              <span className="text-text-100">{run.script}</span>
-            </div>
-            {getRunOutputText(run) ? (
-              <div className={isProblemRunStatus(run.status) ? 'text-danger-000' : 'text-text-200'}>
-                {getRunOutputText(run)}
+}): React.JSX.Element => {
+  const prompt = language === 'r' ? '>' : '>>>'
+
+  return (
+    <div
+      ref={viewportRef}
+      className="min-h-0 flex-1 overflow-y-auto px-3 py-2 font-mono text-xs leading-5"
+      data-testid="kernel-terminal-scrollback"
+    >
+      <div>
+        {runs
+          .filter((run) => run.inputKind === 'terminal')
+          .map((run) => (
+            <div key={run.runId} className="whitespace-pre-wrap">
+              <div>
+                <span className="text-text-300">{prompt} </span>
+                <span className="text-text-100">{run.script}</span>
               </div>
-            ) : null}
-          </div>
-        ))}
+              {getRunOutputText(run) ? (
+                <div
+                  className={isProblemRunStatus(run.status) ? 'text-danger-000' : 'text-text-200'}
+                >
+                  {getRunOutputText(run)}
+                </div>
+              ) : null}
+            </div>
+          ))}
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 // Captures one-line terminal code and submits on Enter while Shift+Enter keeps editing.
 const TerminalInput = ({
   code,
   disabled,
+  language,
   onChange,
   onSubmit
 }: {
   code: string
   disabled: boolean
+  language: NotebookLanguage
   onChange: (value: string) => void
   onSubmit: () => void
 }): React.JSX.Element => {
@@ -277,7 +287,9 @@ const TerminalInput = ({
 
   return (
     <div className="flex items-start gap-2 border-t border-border-100/60 px-3 py-2">
-      <span className="pt-0.5 font-mono text-xs text-primary">&gt;&gt;&gt;</span>
+      <span className="pt-0.5 font-mono text-xs text-primary">
+        {language === 'r' ? '>' : '>>>'}
+      </span>
       <textarea
         rows={1}
         value={code}
@@ -303,7 +315,7 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
   const [notebookState, setNotebookState] = useState<NotebookSessionState | undefined>()
   const [terminalCode, setTerminalCode] = useState('')
   const [isLoading, setIsLoading] = useState(false)
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submittingTarget, setSubmittingTarget] = useState<string | undefined>()
   const [actionError, setActionError] = useState<string | null>(null)
   const [isRestarting, setIsRestarting] = useState(false)
   const [activeKind, setActiveKind] = useState<NotebookKernelKind>('python')
@@ -415,41 +427,6 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
     })
   }, [item.notebook.sessionId, loadNotebookState])
 
-  // Sends terminal code through the same notebook interpreter and history path as agent code.
-  const submitTerminalCode = async (): Promise<void> => {
-    const code = terminalCode.trim()
-
-    if (!code || notebookState?.activeWrite?.source === 'agent' || notebookState?.activeRunId) {
-      return
-    }
-
-    // Clear optimistically so a running terminal command feels like a REPL submission.
-    setTerminalCode('')
-    setIsSubmitting(true)
-    setActionError(null)
-
-    try {
-      await window.api.notebook.execute({
-        ...createNotebookRequest(item.notebook),
-        code,
-        source: 'user',
-        inputKind: 'terminal'
-      })
-
-      await loadNotebookState()
-    } catch (error) {
-      setTerminalCode(code)
-      setActionError(getErrorMessage(error))
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  // Agent writes and active executions lock terminal input to avoid interleaving code streams.
-  const isAgentWriting = notebookState?.activeWrite?.source === 'agent'
-  const isNotebookBusy = isSubmitting || Boolean(notebookState?.activeRunId)
-  const isTerminalLocked =
-    isLoading || isSubmitting || isAgentWriting || Boolean(notebookState?.activeRunId) || gated
   const runs = notebookState?.runs ?? notebookState?.recentRuns ?? []
   const frameOptions = createNotebookFrameFilterOptions(
     runs,
@@ -462,24 +439,31 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
     ? projectNotebookRunsForFrame(runs, effectiveFrameFilter)
     : []
 
-  // Surface a tab only for kernel kinds that actually produced a run — no default python/r tabs on a
-  // fresh notebook; a kernel's tab appears once it has been used.
+  // Python and R are executable user targets even before their first run. Agent SDK and Bash remain
+  // historical views and appear only after producing a run.
   const kindsWithRuns = new Set(projectedRuns.map(resolveRunKernelKind))
-  const visibleKinds = KERNEL_KIND_ORDER.filter((kind) => kindsWithRuns.has(kind))
-  // Default to the first kind (in fixed order) that actually has runs; fall back to python only when
-  // there are no runs at all (so an empty notebook doesn't render a blank non-python pane).
-  const effectiveActiveKind = visibleKinds.includes(activeKind)
-    ? activeKind
-    : (KERNEL_KIND_ORDER.find((kind) => kindsWithRuns.has(kind)) ?? visibleKinds[0] ?? 'python')
+  const visibleKinds = KERNEL_KIND_ORDER.filter(
+    (kind) => kind === 'python' || kind === 'r' || kindsWithRuns.has(kind)
+  )
+  const effectiveActiveKind = visibleKinds.includes(activeKind) ? activeKind : 'python'
   const kindRuns = projectedRuns.filter((run) => resolveRunKernelKind(run) === effectiveActiveKind)
 
   // Per-environment selector (design D6): only python/r are env-scoped. Distinct env names among
   // this kind's runs, canonical default first, so the selector (when shown) reads default-first.
-  const isEnvScopedKind = effectiveActiveKind === 'python' || effectiveActiveKind === 'r'
-  const envNames = isEnvScopedKind
+  const activeDataLanguage: NotebookLanguage | undefined =
+    effectiveActiveKind === 'python' || effectiveActiveKind === 'r'
+      ? effectiveActiveKind
+      : undefined
+  const envNames = activeDataLanguage
     ? Array.from(
         new Set(
-          kindRuns.map(resolveRunEnvironment).filter((env): env is string => env !== undefined)
+          [
+            ...kindRuns.map(resolveRunEnvironment),
+            ...(notebookState?.environments.flatMap((entry) =>
+              entry.kind === activeDataLanguage && entry.environment ? [entry.environment] : []
+            ) ?? []),
+            notebookState?.latestRunEnvironments?.[activeDataLanguage]
+          ].filter((env): env is string => env !== undefined)
         )
       ).sort((a, b) => {
         const aIsDefault = a === 'default-python' || a === 'default-r'
@@ -491,12 +475,12 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
   // Hide the selector entirely when there's at most one environment — zero visual change for the
   // common single-default-env case.
   const showEnvSelector = envNames.length > 1
-  const effectiveActiveEnv = showEnvSelector
+  const effectiveActiveEnv = activeDataLanguage
     ? envNames.includes(activeEnv ?? '')
       ? (activeEnv as string)
-      : envNames[0]
+      : (envNames[0] ?? (activeDataLanguage === 'r' ? 'default-r' : 'default-python'))
     : undefined
-  const visibleRuns = showEnvSelector
+  const visibleRuns = activeDataLanguage
     ? kindRuns.filter((run) => resolveRunEnvironment(run) === effectiveActiveEnv)
     : kindRuns
   const visibleRunIndexById = new Map(visibleRuns.map((run, index) => [run.runId, index]))
@@ -521,17 +505,84 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
     })?.status
 
   // R-only restart prompt: an R install/uninstall flags the active R env until its kernel restarts.
-  const activeEnvName =
-    effectiveActiveEnv ?? (effectiveActiveKind === 'r' ? 'default-r' : 'default-python')
+  const activeEnvName = effectiveActiveEnv
   const restartRecommended =
-    effectiveActiveKind === 'r' &&
+    activeDataLanguage === 'r' &&
     (notebookState?.environments.find((entry) => {
       if (entry.kind !== 'r') return false
-      return (entry.environment ?? 'default-r') === activeEnvName
+      return (entry.environment ?? 'default-r') === (activeEnvName ?? 'default-r')
     })?.restartRecommended ??
       false)
-  const isNamespaceLost = notebookState?.kernelStatus === 'terminated'
+  const activeKernelStatus = activeEnvName ? envOptionStatus(activeEnvName) : undefined
+  const isNamespaceLost =
+    activeDataLanguage !== undefined &&
+    (activeKernelStatus === 'terminated' ||
+      (activeDataLanguage === 'python' &&
+        activeEnvName === 'default-python' &&
+        notebookState?.kernelStatus === 'terminated'))
+  const selectedTarget =
+    activeDataLanguage && activeEnvName ? `${activeDataLanguage}:${activeEnvName}` : undefined
+  const activeRun = runs.find((run) => run.runId === notebookState?.activeRunId)
+  const activeRunTarget =
+    activeRun?.kernelKind === 'python' || activeRun?.kernelKind === 'r'
+      ? `${activeRun.kernelKind}:${resolveRunEnvironment(activeRun)}`
+      : undefined
+  const isSubmitting = submittingTarget !== undefined
+  const isSelectedKernelRunning =
+    (submittingTarget !== undefined && submittingTarget === selectedTarget) ||
+    (activeRunTarget !== undefined && activeRunTarget === selectedTarget) ||
+    activeKernelStatus === 'starting' ||
+    activeKernelStatus === 'running' ||
+    activeKernelStatus === 'restarting'
+  // The Session Aggregate owns one active write and run, so input stays globally locked even when a
+  // different persistent data kernel is selected.
+  const isTerminalLocked =
+    isLoading ||
+    isSubmitting ||
+    Boolean(notebookState?.activeWrite) ||
+    Boolean(notebookState?.activeRunId) ||
+    gated ||
+    isSelectedKernelRunning ||
+    (activeDataLanguage === 'r' && (!envStatus.rReady || isPreparingR))
   const cellCount = notebookState?.runCount ?? runs.length
+
+  // Sends terminal code through the same notebook interpreter and history path as agent code.
+  const submitTerminalCode = async (): Promise<void> => {
+    const code = terminalCode.trim()
+
+    if (
+      !code ||
+      !activeDataLanguage ||
+      !activeEnvName ||
+      notebookState?.activeWrite ||
+      notebookState?.activeRunId
+    ) {
+      return
+    }
+
+    const target = `${activeDataLanguage}:${activeEnvName}`
+    setTerminalCode('')
+    setSubmittingTarget(target)
+    setActionError(null)
+
+    try {
+      await window.api.notebook.execute({
+        ...createNotebookRequest(item.notebook),
+        code,
+        source: 'user',
+        inputKind: 'terminal',
+        language: activeDataLanguage,
+        environment: activeEnvName
+      })
+
+      await loadNotebookState()
+    } catch (error) {
+      setTerminalCode(code)
+      setActionError(getErrorMessage(error))
+    } finally {
+      setSubmittingTarget(undefined)
+    }
+  }
 
   // Restarts the shared interpreter, replacing state with the fresh snapshot so the banner clears.
   const handleRestart = async (): Promise<void> => {
@@ -713,7 +764,7 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
         </div>
       ) : null}
 
-      {isNamespaceLost ? (
+      {!activeDataLanguage || isNamespaceLost ? (
         <div className="min-h-0 flex-1 overflow-hidden">{notebookCells}</div>
       ) : (
         <ResizablePanelGroup orientation="vertical" className="min-h-0 flex-1 flex-col">
@@ -734,8 +785,12 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
               className="pointer-events-none absolute inset-0 flex items-center justify-between gap-2 px-3 text-[11px] text-text-300"
               data-testid="notebook-terminal-header"
             >
-              <span>{t('Python kernel · shared with the agent')}</span>
-              <span>{isNotebookBusy ? t('running') : t('idle')}</span>
+              <span>
+                {activeDataLanguage === 'r'
+                  ? t('R kernel · shared with the agent')
+                  : t('Python kernel · shared with the agent')}
+              </span>
+              <span>{isSelectedKernelRunning ? t('running') : t('idle')}</span>
             </div>
           </ResizableHandle>
 
@@ -751,10 +806,15 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
                   {actionError}
                 </div>
               ) : null}
-              <TerminalScrollback runs={projectedRuns} viewportRef={terminalViewportRef} />
+              <TerminalScrollback
+                runs={visibleRuns}
+                language={activeDataLanguage}
+                viewportRef={terminalViewportRef}
+              />
               <TerminalInput
                 code={terminalCode}
                 disabled={isTerminalLocked}
+                language={activeDataLanguage}
                 onChange={setTerminalCode}
                 onSubmit={() => {
                   void submitTerminalCode()
@@ -771,7 +831,9 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
           data-testid="notebook-read-only-status"
         >
           <span className="min-w-0 truncate">
-            {t("Python · view only; this kernel's namespace no longer exists")}
+            {activeDataLanguage === 'r'
+              ? t("R · view only; this kernel's namespace no longer exists")
+              : t("Python · view only; this kernel's namespace no longer exists")}
           </span>
           <span className="shrink-0 tabular-nums">
             {t('{{count}} cells', {

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -454,6 +454,10 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
     effectiveActiveKind === 'python' || effectiveActiveKind === 'r'
       ? effectiveActiveKind
       : undefined
+  const executionEnvironment = activeDataLanguage
+    ? (notebookState?.executionEnvironments?.[activeDataLanguage] ??
+      (activeDataLanguage === 'r' ? 'default-r' : 'default-python'))
+    : undefined
   const envNames = activeDataLanguage
     ? Array.from(
         new Set(
@@ -462,7 +466,8 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
             ...(notebookState?.environments.flatMap((entry) =>
               entry.kind === activeDataLanguage && entry.environment ? [entry.environment] : []
             ) ?? []),
-            notebookState?.latestRunEnvironments?.[activeDataLanguage]
+            notebookState?.latestRunEnvironments?.[activeDataLanguage],
+            executionEnvironment
           ].filter((env): env is string => env !== undefined)
         )
       ).sort((a, b) => {
@@ -478,7 +483,7 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
   const effectiveActiveEnv = activeDataLanguage
     ? envNames.includes(activeEnv ?? '')
       ? (activeEnv as string)
-      : (envNames[0] ?? (activeDataLanguage === 'r' ? 'default-r' : 'default-python'))
+      : (executionEnvironment ?? envNames[0])
     : undefined
   const visibleRuns = activeDataLanguage
     ? kindRuns.filter((run) => resolveRunEnvironment(run) === effectiveActiveEnv)
@@ -520,6 +525,11 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
       (activeDataLanguage === 'python' &&
         activeEnvName === 'default-python' &&
         notebookState?.kernelStatus === 'terminated'))
+  const isHistoricalEnvironmentView =
+    activeDataLanguage !== undefined &&
+    activeEnvName !== undefined &&
+    executionEnvironment !== undefined &&
+    activeEnvName !== executionEnvironment
   const selectedTarget =
     activeDataLanguage && activeEnvName ? `${activeDataLanguage}:${activeEnvName}` : undefined
   const activeRun = runs.find((run) => run.runId === notebookState?.activeRunId)
@@ -554,6 +564,7 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
       !code ||
       !activeDataLanguage ||
       !activeEnvName ||
+      isHistoricalEnvironmentView ||
       notebookState?.activeWrite ||
       notebookState?.activeRunId
     ) {
@@ -571,8 +582,7 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
         code,
         source: 'user',
         inputKind: 'terminal',
-        language: activeDataLanguage,
-        environment: activeEnvName
+        language: activeDataLanguage
       })
 
       await loadNotebookState()
@@ -764,7 +774,7 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
         </div>
       ) : null}
 
-      {!activeDataLanguage || isNamespaceLost ? (
+      {!activeDataLanguage || isNamespaceLost || isHistoricalEnvironmentView ? (
         <div className="min-h-0 flex-1 overflow-hidden">{notebookCells}</div>
       ) : (
         <ResizablePanelGroup orientation="vertical" className="min-h-0 flex-1 flex-col">
@@ -825,15 +835,20 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
         </ResizablePanelGroup>
       )}
 
-      {isNamespaceLost ? (
+      {isNamespaceLost || isHistoricalEnvironmentView ? (
         <footer
           className="flex h-7 shrink-0 items-center justify-between gap-3 border-t border-border-200 bg-bg-000 px-2 text-[11px] text-text-300"
           data-testid="notebook-read-only-status"
         >
           <span className="min-w-0 truncate">
-            {activeDataLanguage === 'r'
-              ? t("R · view only; this kernel's namespace no longer exists")
-              : t("Python · view only; this kernel's namespace no longer exists")}
+            {isHistoricalEnvironmentView
+              ? t('{{environment}} · history only; new code runs in {{activeEnvironment}}', {
+                  environment: activeEnvName,
+                  activeEnvironment: executionEnvironment
+                })
+              : activeDataLanguage === 'r'
+                ? t("R · view only; this kernel's namespace no longer exists")
+                : t("Python · view only; this kernel's namespace no longer exists")}
           </span>
           <span className="shrink-0 tabular-nums">
             {t('{{count}} cells', {

--- a/src/shared/notebook.ts
+++ b/src/shared/notebook.ts
@@ -536,6 +536,9 @@ export type NotebookSessionState = {
   runCount: number
   // Latest durable environment evidence per data kernel, independent of the bounded run window.
   latestRunEnvironments: Partial<Record<'python' | 'r', string>>
+  // Live execution target derived from each language's Session runtime binding. This is not
+  // persisted; optional keeps older renderer/remote clients compatible.
+  executionEnvironments?: Partial<Record<'python' | 'r', string>>
   // Present only when state() requested one Agent's complete-history discovery metadata.
   historySummary?: NotebookRunHistorySummary
   runs: NotebookRunRecord[]


### PR DESCRIPTION
## Problem

The live Notebook preview can switch between Python and R history, but its interactive input still
labels and dispatches every submission as Python. It also derives `running` from the whole Session
instead of the selected kernel, and its scrollback is not scoped to the selected environment.

## Proposed change

- Always expose Python and R as executable data-kernel tabs; keep Agent SDK and Bash as historical
  read-only tabs.
- Submit the selected `language` through the existing Notebook execute contract. Main-process
  routing continues to resolve that language's current Session-bound runtime/environment.
- Project each language's current execution environment into renderer state. Non-bound named
  environments remain history-only and explain where new code will run.
- Render the selected kernel label, prompt, status, history, and terminal scrollback consistently.
- Keep the existing Notebook-wide write/run lock while presenting status for the selected kernel.
- Continue persisting user submissions through the existing `run.json` path and render them as
  `you` call blocks.

## Scope and non-goals

- No new status enum, persisted field, database schema, migration, or IPC method.
- Adds one optional, non-persisted `executionEnvironments` field to `NotebookSessionState`; it is
  derived from live Session runtime bindings for renderer compatibility/safety.
- No per-call named-environment switching. The existing invariant remains one runtime binding per
  language per Session.
- No cross-kernel parallel execution. Python and R use different persistent processes, but the
  Session Aggregate still owns one `activeWrite` and `activeRunId`, so input remains globally locked
  during any Notebook write/run.

## Historical compatibility and persistence

- Existing `run.json` files remain unchanged and require no migration.
- An older submission shown under R but dispatched as Python cannot be safely reclassified because
  its persisted `kernelKind: 'python'` is the only durable evidence.
- New user submissions continue through the existing atomic `run.json` persistence path, recording
  the existing `source`, `inputKind`, `kernelKind`, and resolved `environment` fields.

## Acceptance criteria and validation

All listed checks ran after the final material edit:

- Read-model projection, Python/R routing, Session-bound environment behavior, selected status,
  global input lock, R prompt, read-only historical/non-data tabs, `you` call blocks, and i18n ->
  `npx vitest run src/main/notebook/session-read-model.test.ts src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx src/renderer/src/pages/workspace/workspace-components.test.tsx src/renderer/src/i18n/resources.test.ts`
  -> 4 files / 658 tests passed.
- Existing terminal-run persistence ->
  `npx vitest run src/main/notebook/runtime-service.test.ts -t 'records terminal submissions in the shared run history'`
  -> 1 passed / 219 skipped.
- Renderer type safety -> `npm run typecheck:web` -> passed.
- Source and locale lint -> `npm run lint` -> passed.
- The complete local `npm test` suite was not run per maintainer direction; PR Gate is authoritative
  for the full portable/platform plan.

## Review focus

- Python and R must route to different language bindings, while named environment selection must not
  imply unsupported per-call environment switching.
- `running` is selected-kernel-specific, while input locking intentionally remains Notebook-wide.
- A terminated R kernel must be view-only without making a healthy Python kernel read-only.
