### PR TITLE
perf(settings): batch installer logs and cap renderer retention

### DIFF
--- a/src/main/settings/claude-install.test.ts
+++ b/src/main/settings/claude-install.test.ts
@@ -176,6 +176,72 @@ describe('claude-install: run', () => {
     expect(logs.some((e) => e.kind === 'log' && e.stream === 'stderr')).toBe(true)
   })
 
+  it('coalesces a same-tick stdout burst into one log event before settle', async () => {
+    const child = new FakeChild()
+    const events: ClaudeInstallEvent[] = []
+    const promise = runInstall({
+      source: 'npm',
+      installId: 'install-burst',
+      onEvent: (event) => events.push(event),
+      spawnImpl: () => child as never,
+      npmPrefixWritable: () => Promise.resolve(true)
+    })
+
+    setImmediate(() => {
+      for (let index = 0; index < 10_000; index += 1) {
+        child.stdout.emit('data', Buffer.from('x'))
+      }
+      child.emit('exit', 0)
+    })
+
+    await expect(promise).resolves.toMatchObject({ installId: 'install-burst', ok: true })
+
+    const stdout = events.filter(
+      (event): event is Extract<ClaudeInstallEvent, { kind: 'log' }> =>
+        event.kind === 'log' && event.stream === 'stdout'
+    )
+    expect(events).toHaveLength(3)
+    expect(stdout).toEqual([
+      { kind: 'log', installId: 'install-burst', stream: 'stdout', chunk: 'x'.repeat(10_000) }
+    ])
+  })
+
+  it('flushes coalesced stdout on the presentation-frame timer while the install is still running', async () => {
+    vi.useFakeTimers()
+    const child = new FakeChild()
+    const events: ClaudeInstallEvent[] = []
+    const promise = runInstall({
+      source: 'npm',
+      installId: 'install-live',
+      onEvent: (event) => events.push(event),
+      timeoutMs: 60_000,
+      spawnImpl: () => child as never,
+      npmPrefixWritable: () => Promise.resolve(true)
+    })
+
+    try {
+      await Promise.resolve()
+      await Promise.resolve()
+
+      for (let index = 0; index < 100; index += 1) {
+        child.stdout.emit('data', Buffer.from('a'))
+      }
+      expect(events.filter((event) => event.kind === 'log' && event.stream === 'stdout')).toEqual(
+        []
+      )
+
+      await vi.advanceTimersByTimeAsync(33)
+      expect(events.filter((event) => event.kind === 'log' && event.stream === 'stdout')).toEqual([
+        { kind: 'log', installId: 'install-live', stream: 'stdout', chunk: 'a'.repeat(100) }
+      ])
+
+      child.emit('exit', 0)
+      await expect(promise).resolves.toMatchObject({ installId: 'install-live', ok: true })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('resolves not ok on a non-zero exit', async () => {
     const child = new FakeChild()
     const promise = runInstall({

--- a/src/main/settings/claude-install.ts
+++ b/src/main/settings/claude-install.ts
@@ -8,6 +8,8 @@ import { promisify } from 'node:util'
 
 import type {
   ClaudeInstallEvent,
+  ClaudeInstallLogEvent,
+  ClaudeInstallProgressEvent,
   ClaudeInstallResult,
   ClaudeInstallSource,
   NpmAvailability
@@ -93,6 +95,80 @@ const getInstallSpawnSpec = (
 
 // Default guard so a hung network install cannot block the wizard forever.
 const DEFAULT_INSTALL_TIMEOUT_MS = 5 * 60 * 1000
+
+// Consecutive stdout/stderr chunks share one onEvent until this frame elapses, the pending payload
+// hits INSTALL_LOG_COALESCE_MAX_CHARS, the stream changes, or the install settles.
+const INSTALL_LOG_COALESCE_INTERVAL_MS = 33
+const INSTALL_LOG_COALESCE_MAX_CHARS = 64 * 1024
+
+type InstallStreamPublisher = {
+  flush: () => void
+  log: (stream: ClaudeInstallLogEvent['stream'], chunk: string) => void
+  progress: (event: ClaudeInstallProgressEvent) => void
+}
+
+// Collapses chatty child-process data events so IPC/Web subscribers see at most one log per stream
+// per presentation frame. System lines and progress ticks flush immediately so the command echo,
+// timeout notice, and progress bar never wait on stdout.
+const createInstallStreamPublisher = (
+  installId: string,
+  onEvent: (event: ClaudeInstallEvent) => void
+): InstallStreamPublisher => {
+  let pendingStream: ClaudeInstallLogEvent['stream'] | undefined
+  let pendingChunk = ''
+  let coalesceTimer: ReturnType<typeof setTimeout> | undefined
+
+  const flush = (): void => {
+    if (coalesceTimer !== undefined) {
+      clearTimeout(coalesceTimer)
+      coalesceTimer = undefined
+    }
+    if (!pendingStream || pendingChunk.length === 0) {
+      pendingStream = undefined
+      pendingChunk = ''
+      return
+    }
+
+    const stream = pendingStream
+    const chunk = pendingChunk
+    pendingStream = undefined
+    pendingChunk = ''
+    onEvent({ kind: 'log', installId, stream, chunk })
+  }
+
+  const schedule = (): void => {
+    if (coalesceTimer !== undefined) return
+    coalesceTimer = setTimeout(() => {
+      coalesceTimer = undefined
+      flush()
+    }, INSTALL_LOG_COALESCE_INTERVAL_MS)
+  }
+
+  return {
+    flush,
+    log(stream, chunk) {
+      if (chunk.length === 0) return
+      if (stream === 'system') {
+        flush()
+        onEvent({ kind: 'log', installId, stream, chunk })
+        return
+      }
+      if (pendingStream === stream) {
+        pendingChunk += chunk
+      } else {
+        flush()
+        pendingStream = stream
+        pendingChunk = chunk
+      }
+      if (pendingChunk.length >= INSTALL_LOG_COALESCE_MAX_CHARS) flush()
+      else schedule()
+    },
+    progress(event) {
+      flush()
+      onEvent(event)
+    }
+  }
+}
 
 // Cap on retained installer output used only for region-block detection (keeps memory bounded on a
 // chatty install while still holding enough tail to spot the HTML signature).
@@ -243,8 +319,8 @@ const defaultInstallSpawn = (
     env: augmentedPathEnv()
   }) as ChildProcessWithoutNullStreams
 
-// Runs an install source to completion, forwarding every stdout/stderr chunk through onLog and
-// enforcing a timeout. Resolves (never rejects) with a structured result the service can act on.
+// Runs an install source to completion, coalescing stdout/stderr through onEvent and enforcing a
+// timeout. Resolves (never rejects) with a structured result the service can act on.
 const runInstall = async ({
   source,
   installId,
@@ -264,13 +340,9 @@ const runInstall = async ({
       : undefined
 
   const spec = getInstallSpawnSpec(source, platform, npmPrefixOverride, installTarget)
+  const publisher = createInstallStreamPublisher(installId, onEvent)
 
-  onEvent({
-    kind: 'log',
-    installId,
-    stream: 'system',
-    chunk: `$ ${spec.command} ${spec.args.join(' ')}\n`
-  })
+  publisher.log('system', `$ ${spec.command} ${spec.args.join(' ')}\n`)
 
   return new Promise<ClaudeInstallResult>((resolve) => {
     let child: ChildProcessWithoutNullStreams
@@ -278,6 +350,7 @@ const runInstall = async ({
     try {
       child = spawnImpl(spec.command, spec.args, { shell: spec.shell })
     } catch (error) {
+      publisher.flush()
       resolve({
         installId,
         ok: false,
@@ -288,7 +361,7 @@ const runInstall = async ({
     }
 
     // No byte total for a shelled installer, so the bar runs indeterminate while it streams output.
-    onEvent({ kind: 'progress', installId, phase: 'installing' })
+    publisher.progress({ kind: 'progress', installId, phase: 'installing' })
 
     let settled = false
     let timedOut = false
@@ -305,30 +378,26 @@ const runInstall = async ({
 
       settled = true
       clearTimeout(timer)
+      publisher.flush()
       resolve(result)
     }
 
     const timer = setTimeout(() => {
       timedOut = true
-      onEvent({
-        kind: 'log',
-        installId,
-        stream: 'system',
-        chunk: 'Install timed out; terminating.\n'
-      })
+      publisher.log('system', 'Install timed out; terminating.\n')
       child.kill()
     }, timeoutMs)
 
     child.stdout.on('data', (data: Buffer) => {
       const chunk = data.toString('utf8')
       capture(chunk)
-      onEvent({ kind: 'log', installId, stream: 'stdout', chunk })
+      publisher.log('stdout', chunk)
     })
 
     child.stderr.on('data', (data: Buffer) => {
       const chunk = data.toString('utf8')
       capture(chunk)
-      onEvent({ kind: 'log', installId, stream: 'stderr', chunk })
+      publisher.log('stderr', chunk)
     })
 
     child.on('error', (error) => {

--- a/src/renderer/src/stores/settings-runtime-slice.test.ts
+++ b/src/renderer/src/stores/settings-runtime-slice.test.ts
@@ -15,6 +15,7 @@ import type {
 import {
   createRuntimeSetupLoadPatch,
   createRuntimeSetupSlice,
+  INSTALL_UI_LOG_CHAR_LIMIT,
   type RuntimeSetupSlice,
   selectAnyInstalling
 } from './settings-runtime-slice'
@@ -215,6 +216,65 @@ describe('runtime setup slice: install lifecycle', () => {
       installProgress: null,
       installError: undefined
     })
+  })
+
+  it('commits a 10,000-chunk log burst in two store updates and keeps the tail', async () => {
+    const install = deferred<ClaudeInstallResult>()
+    let emit: (event: ClaudeInstallEvent) => void = () => undefined
+    commands.onInstallLog.mockImplementation((listener) => {
+      emit = listener
+      return vi.fn()
+    })
+    commands.installCodex.mockReturnValue(install.promise)
+
+    const pending = store.getState().installCodex()
+    let logCommits = 0
+    const unsubscribe = store.subscribe((state, previous) => {
+      if (state.installStates.codex.installLogs !== previous.installStates.codex.installLogs) {
+        logCommits += 1
+      }
+    })
+
+    for (let index = 0; index < 10_000; index += 1) {
+      emit({ kind: 'log', installId: 'codex-1', stream: 'stdout', chunk: 'x' })
+    }
+
+    expect(logCommits).toBe(1)
+    expect(store.getState().installStates.codex.installLogs).toEqual(['x'])
+
+    await Promise.resolve()
+
+    expect(logCommits).toBe(2)
+    expect(store.getState().installStates.codex.installLogs).toEqual(['x'.repeat(10_000)])
+
+    unsubscribe()
+    install.resolve({ installId: 'codex-1', ok: true })
+    await pending
+  })
+
+  it('keeps only the last 256 KiB of install log text', async () => {
+    const install = deferred<ClaudeInstallResult>()
+    let emit: (event: ClaudeInstallEvent) => void = () => undefined
+    commands.onInstallLog.mockImplementation((listener) => {
+      emit = listener
+      return vi.fn()
+    })
+    commands.installCodex.mockReturnValue(install.promise)
+
+    const pending = store.getState().installCodex()
+    emit({
+      kind: 'log',
+      installId: 'codex-1',
+      stream: 'stdout',
+      chunk: `head${'t'.repeat(INSTALL_UI_LOG_CHAR_LIMIT)}`
+    })
+
+    expect(store.getState().installStates.codex.installLogs).toEqual([
+      't'.repeat(INSTALL_UI_LOG_CHAR_LIMIT)
+    ])
+
+    install.resolve({ installId: 'codex-1', ok: true })
+    await pending
   })
 
   it('keeps the global guard while logs are cleared and silently refuses a second install', async () => {

--- a/src/renderer/src/stores/settings-runtime-slice.ts
+++ b/src/renderer/src/stores/settings-runtime-slice.ts
@@ -20,6 +20,18 @@ export type RuntimeInstallState = {
   installError: string | undefined
 }
 
+// Retained UI log is a diagnostic tail, not a transcript. 256 KiB is far more than the max-h-48
+// pane can show; dropping the head keeps store copies and <pre> joins bounded during a 5-minute run.
+export const INSTALL_UI_LOG_CHAR_LIMIT = 256 * 1024
+
+const appendCappedInstallLogs = (existing: string[], chunks: readonly string[]): string[] => {
+  if (chunks.length === 0) return existing
+
+  const merged = existing.length === 0 ? chunks.join('') : `${existing.join('')}${chunks.join('')}`
+  if (merged.length <= INSTALL_UI_LOG_CHAR_LIMIT) return merged.length === 0 ? existing : [merged]
+  return [merged.slice(-INSTALL_UI_LOG_CHAR_LIMIT)]
+}
+
 export type RuntimeSetupState = {
   preflight: Preflight
   npmAvailable: boolean
@@ -181,19 +193,47 @@ const runRuntimeInstall = async <Store extends RuntimeSetupHost>(
   })
 
   const commands = getCommands()
-  const unsubscribe = commands.onInstallLog((event) => {
-    if (event.kind === 'progress') {
-      patchInstallState(set, runtime, { installProgress: event })
-      return
-    }
+  let pendingLogChunks: string[] = []
+  let flushScheduled = false
+  let acceptingEvents = true
 
+  const applyLogChunks = (chunks: readonly string[]): void => {
+    if (!acceptingEvents || chunks.length === 0) return
     updateInstallStates(set, (installStates) => ({
       ...installStates,
       [runtime]: {
         ...installStates[runtime],
-        installLogs: [...installStates[runtime].installLogs, event.chunk]
+        installLogs: appendCappedInstallLogs(installStates[runtime].installLogs, chunks)
       }
     }))
+  }
+
+  const flushPendingLogChunks = (): void => {
+    flushScheduled = false
+    if (pendingLogChunks.length === 0) return
+    const chunks = pendingLogChunks
+    pendingLogChunks = []
+    applyLogChunks(chunks)
+  }
+
+  const unsubscribe = commands.onInstallLog((event) => {
+    if (!acceptingEvents) return
+    if (event.kind === 'progress') {
+      flushPendingLogChunks()
+      patchInstallState(set, runtime, { installProgress: event })
+      return
+    }
+
+    // First chunk in a turn commits immediately so a single log stays synchronous for existing
+    // callers; the rest of the same turn collapses into one follow-up store update.
+    if (!flushScheduled && pendingLogChunks.length === 0) {
+      applyLogChunks([event.chunk])
+      flushScheduled = true
+      queueMicrotask(flushPendingLogChunks)
+      return
+    }
+
+    pendingLogChunks.push(event.chunk)
   })
 
   try {
@@ -221,6 +261,8 @@ const runRuntimeInstall = async <Store extends RuntimeSetupHost>(
 
     return result
   } finally {
+    flushPendingLogChunks()
+    acceptingEvents = false
     unsubscribe()
     patchInstallState(set, runtime, { isInstalling: false, installProgress: null })
   }


### PR DESCRIPTION
## Problem

A chatty runtime installer (`runInstall()` for npm / official-script) forwarded every Node `data` chunk as its own `ClaudeInstallEvent`. The 2026-08-23 responsiveness audit measured 10,000 stdout chunks producing 10,002 callbacks in about 8.7 ms on the installer side, then about 246 ms of synchronous UI-thread work in the renderer store because each log copied the full `installLogs` array and committed immediately.

The installer process is already bounded by a five-minute timeout. Log publication was not batched, and retained UI logs were unbounded.

This happens when Settings or onboarding starts a one-click Claude Code / OpenCode / Codex install from the npm or official-script source. App-managed downloads are not this bug: their progress path already emits at most one tick per whole percent.

If left unfixed, a verbose install stalls input, progress-bar updates, and the rest of Settings for hundreds of milliseconds to several seconds. The child still finishes or times out; the freeze is presentation.

## Proposed change

Keep `ClaudeInstallEvent` as a single log-or-progress object and `installLogs: string[]`. No new IPC channel, catalog entry, field, enum, or UI chrome.

1. **Main (`runInstall`)** — coalesce consecutive stdout/stderr chunks for the same stream on a 33 ms timer, and flush when the stream changes, a `system` log or `progress` event must go out, the pending payload reaches 64 KiB, or the install settles. Region-block capture still sees every raw chunk.
2. **Renderer (`runRuntimeInstall`)** — first log chunk in a turn commits immediately; the rest of the same turn collapses into one `queueMicrotask` store update. Retained UI text is compacted to a single tail string and capped at 256 KiB (silent drop of the head).
3. **UI** — still `{installLogs.join('')}` in the existing log pane. Live lines may appear up to one 33 ms frame later.

```mermaid
sequenceDiagram
  participant Child as installer child
  participant Run as runInstall
  participant Bus as settings:install-log
  participant Store as runtime setup slice
  participant UI as AgentFrameworkCard

  Child->>Run: stdout data (N chunks)
  Run->>Run: coalesce same-stream chunks
  Run->>Bus: one log event per flush
  Bus->>Store: onInstallLog
  Store->>Store: first chunk now, rest of tick in one microtask
  Store->>Store: cap tail to 256KiB
  Store->>UI: one or two installLogs commits
```

## Scope and non-goals

- No historical-data migration. `installLogs` is renderer-only ephemeral state.
- No new status or enum values.
- No persistence of install logs.
- No renderer-contract catalog change.
- No truncation banner or i18n copy.
- App-managed download progress is already percent-throttled and is left alone.

## Acceptance criteria and validation

- 10,000 same-tick stdout chunks then exit produce 3 `onEvent` calls (system, progress, one concatenated stdout).
- 10,000 renderer log events produce at most two `installLogs` store commits.
- An oversized chunk keeps only the last 256 KiB of UI log text.
- Existing single-log, cross-runtime isolation, and clear-while-installing tests stay green.

### Evidence mapping (after last material edit)

| Behavior | Command | Result |
| --- | --- | --- |
| Coalesce stdout burst and live 33 ms flush | `npx vitest run src/main/settings/claude-install.test.ts` | 31 passed |
| Bounded renderer commits and 256 KiB cap | `npx vitest run src/renderer/src/stores/settings-runtime-slice.test.ts` | 26 passed |
| Settings store install isolation (#278) | `npx vitest run src/renderer/src/stores/settings-store.test.ts` | 99 passed |
| Node typecheck | `npm run typecheck:node` | passed |
| Web typecheck | `npm run typecheck:web` | passed |
| Lint | `npm run lint` | passed (0 errors) |

Exact-head PR CI is authoritative for the full portable suite. Full local `npm test` was not run.

**Included:** Settings installer spawn path (`runInstall`) and the renderer runtime-setup store. Electron IPC and Web `settings:install-log` both consume coalesced `onEvent` output.

**Excluded:** ACP framework paths (this is not an agent-runtime event); renderer-contract catalog / web-api-map (event shape unchanged); E2E (no interaction chrome change); managed-download progress (already throttled).

**Uncovered risks:** real npm/official-script chunk sizes on Windows may differ from the harness; the coalescer is stream-agnostic. Web SSE was not separately profiled; it receives the same coalesced events.

## Review focus

- Flush-on-settle so the renderer still subscribed when the last concatenated log is published.
- First-chunk-immediate renderer path so existing synchronous single-log tests keep working.
- Silent 256 KiB tail cap: diagnostic value is the end of the log, not a full transcript.

## Compatibility flags

- Historical data: not required.
- New status / enum values: none.
- Data persistence: none.