### PR TITLE
fix(project-files): disable context navigation during deletion

### DIFF
--- a/src/renderer/src/locales/fr.json
+++ b/src/renderer/src/locales/fr.json
@@ -2627,6 +2627,7 @@
   "{{size}} on disk · default location": "{{size}} sur le disque · emplacement par défaut",
   "{{step}} status: {{status}}": "Statut {{step}} : {{status}}",
   "{{title}} · Source session deleted": "{{title}} · Session source supprimée",
+  "{{title}} · Source session is being deleted": "{{title}} · Suppression de la session source en cours",
   "{{used}} / {{limit}} chars": "Caractères {{used}} / {{limit}}",
   "{{value}} (default)": "{{value}} (par défaut)",
   "{{visible}} of {{total}}": "{{visible}} sur {{total}}",

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -2409,6 +2409,7 @@
   "{{size}} on disk · default location": "ディスク上の {{size}} · デフォルトの場所",
   "{{step}} status: {{status}}": "{{step}} ステータス：{{status}}",
   "{{title}} · Source session deleted": "{{title}} · ソースセッションが削除されました",
+  "{{title}} · Source session is being deleted": "{{title}} · ソースセッションを削除しています",
   "{{used}} / {{limit}} chars": "{{used}} / {{limit}} 文字",
   "{{value}} (default)": "{{value}} (デフォルト)",
   "{{visible}} of {{total}}": "{{visible}} / {{total}}",

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -2420,6 +2420,7 @@
   "{{size}} on disk · default location": "디스크의 {{size}} · 기본 위치",
   "{{step}} status: {{status}}": "{{step}} 상태: {{status}}",
   "{{title}} · Source session deleted": "{{title}} · 소스 세션 삭제됨",
+  "{{title}} · Source session is being deleted": "{{title}} · 소스 세션 삭제 중",
   "{{used}} / {{limit}} chars": "{{used}} / {{limit}} 문자",
   "{{value}} (default)": "{{value}} (기본값)",
   "{{visible}} of {{total}}": "{{visible}} 중 {{total}}",

--- a/src/renderer/src/locales/ru.json
+++ b/src/renderer/src/locales/ru.json
@@ -2704,6 +2704,7 @@
   "{{size}} on disk · default location": "{{size}} на диске · по умолчанию",
   "{{step}} status: {{status}}": "{{step}} статус: {{status}}",
   "{{title}} · Source session deleted": "{{title}} · источник сессии удалён",
+  "{{title}} · Source session is being deleted": "{{title}} · Исходная сессия удаляется",
   "{{used}} / {{limit}} chars": "{{used}} / {{limit}} символов",
   "{{value}} (default)": "{{value}} (по умолчанию)",
   "{{visible}} of {{total}}": "{{visible}} из {{total}}",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -2480,6 +2480,7 @@
   "{{size}} on disk · default location": "占用磁盘 {{size}} · 默认位置",
   "{{step}} status: {{status}}": "{{step}} 状态：{{status}}",
   "{{title}} · Source session deleted": "{{title}} · 源会话已删除",
+  "{{title}} · Source session is being deleted": "{{title}} · 正在删除源会话",
   "{{used}} / {{limit}} chars": "{{used}} / {{limit}} 字符",
   "{{value}} (default)": "{{value}}（默认）",
   "{{visible}} of {{total}}": "已显示 {{visible}} / {{total}}",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -2477,6 +2477,7 @@
   "{{size}} on disk · default location": "佔用磁碟 {{size}} · 預設位置",
   "{{step}} status: {{status}}": "{{step}} 狀態：{{status}}",
   "{{title}} · Source session deleted": "{{title}} · 來源會話已刪除",
+  "{{title}} · Source session is being deleted": "{{title}} · 正在刪除來源會話",
   "{{used}} / {{limit}} chars": "{{used}} / {{limit}} 字元",
   "{{value}} (default)": "{{value}}（預設）",
   "{{visible}} of {{total}}": "已顯示 {{visible}} / {{total}}",

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -653,6 +653,27 @@ describe('PreviewFileSurface View in context entry', () => {
     expect(menu?.textContent).not.toContain('View in context')
   })
 
+  it('hides View in context while the origin session is deleting', async () => {
+    seedWorkspaceStores()
+
+    await act(async () => {
+      root.render(
+        <PreviewFileSurface
+          item={{ ...item, originSession: { state: 'deleting' } }}
+          onClose={vi.fn()}
+        />
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await openMenu(container.querySelector('[aria-label="File actions for sin.png"]'))
+
+    const menu = document.body.querySelector('[role="menu"]')
+    expect(menu?.textContent).toContain('Provenance')
+    expect(menu?.textContent).not.toContain('View in context')
+  })
+
   it('lets the lineage report of a deleted origin session override the stale item snapshot', async () => {
     seedWorkspaceStores()
     // The preview tab still carries its creation-time snapshot; the refetched lineage is the
@@ -661,6 +682,33 @@ describe('PreviewFileSurface View in context entry', () => {
       artifactId: 'artifact-1',
       filename: 'sin.png',
       originSession: { sessionId: 'session-1', state: 'deleted', title: 'Sine' },
+      versions: [descriptor, secondDescriptor]
+    })
+
+    await act(async () => {
+      root.render(
+        <PreviewFileSurface
+          item={{ ...item, originSession: { state: 'active' } }}
+          onClose={vi.fn()}
+        />
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await openMenu(container.querySelector('[aria-label="File actions for sin.png"]'))
+
+    const menu = document.body.querySelector('[role="menu"]')
+    expect(menu?.textContent).toContain('Provenance')
+    expect(menu?.textContent).not.toContain('View in context')
+  })
+
+  it('lets the lineage report of a deleting origin session override the stale item snapshot', async () => {
+    seedWorkspaceStores()
+    window.api.artifacts.getLineage = vi.fn().mockResolvedValue({
+      artifactId: 'artifact-1',
+      filename: 'sin.png',
+      originSession: { sessionId: 'session-1', state: 'deleting', title: 'Sine' },
       versions: [descriptor, secondDescriptor]
     })
 

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -655,6 +655,8 @@ describe('PreviewFileSurface View in context entry', () => {
 
   it('hides View in context while the origin session is deleting', async () => {
     seedWorkspaceStores()
+    // Until a newer lineage projection resolves, the item snapshot is the only lifecycle signal.
+    window.api.artifacts.getLineage = vi.fn().mockRejectedValue(new Error('lineage unavailable'))
 
     await act(async () => {
       root.render(
@@ -728,6 +730,31 @@ describe('PreviewFileSurface View in context entry', () => {
     const menu = document.body.querySelector('[role="menu"]')
     expect(menu?.textContent).toContain('Provenance')
     expect(menu?.textContent).not.toContain('View in context')
+  })
+
+  it('lets active lineage restore View in context after a deleting item snapshot is compensated', async () => {
+    seedWorkspaceStores()
+    window.api.artifacts.getLineage = vi.fn().mockResolvedValue({
+      artifactId: 'artifact-1',
+      filename: 'sin.png',
+      originSession: { sessionId: 'session-1', state: 'active', title: 'Sine' },
+      versions: [descriptor, secondDescriptor]
+    })
+
+    await act(async () => {
+      root.render(
+        <PreviewFileSurface
+          item={{ ...item, originSession: { state: 'deleting' } }}
+          onClose={vi.fn()}
+        />
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await openMenu(container.querySelector('[aria-label="File actions for sin.png"]'))
+
+    expect(document.body.querySelector('[role="menu"]')?.textContent).toContain('View in context')
   })
 
   it('does not notify View in context consumers when the guard rejects the navigation', async () => {

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -757,6 +757,49 @@ describe('PreviewFileSurface View in context entry', () => {
     expect(document.body.querySelector('[role="menu"]')?.textContent).toContain('View in context')
   })
 
+  it('stops using active lineage while a newer deleting item snapshot is refreshing', async () => {
+    seedWorkspaceStores()
+    const getLineage = vi
+      .fn()
+      .mockResolvedValueOnce({
+        artifactId: 'artifact-1',
+        filename: 'sin.png',
+        originSession: { sessionId: 'session-1', state: 'active', title: 'Sine' },
+        versions: [descriptor, secondDescriptor]
+      })
+      .mockImplementationOnce(() => new Promise(() => undefined))
+    window.api.artifacts.getLineage = getLineage
+
+    await act(async () => {
+      root.render(
+        <PreviewFileSurface
+          item={{ ...item, originSession: { state: 'active' } }}
+          onClose={vi.fn()}
+        />
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      root.render(
+        <PreviewFileSurface
+          item={{ ...item, originSession: { state: 'deleting' } }}
+          onClose={vi.fn()}
+        />
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await openMenu(container.querySelector('[aria-label="File actions for sin.png"]'))
+
+    expect(getLineage).toHaveBeenCalledTimes(2)
+    expect(document.body.querySelector('[role="menu"]')?.textContent).not.toContain(
+      'View in context'
+    )
+  })
+
   it('does not notify View in context consumers when the guard rejects the navigation', async () => {
     seedWorkspaceStores()
     // The origin session vanished after render (deleted mid-flight): the guard must reject the

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -404,10 +404,11 @@ const PreviewFileSurface = ({
     (state) =>
       state.sessions.find((session) => session.id === previewItem.sessionId)?.filesRevision ?? 0
   )
-  // A GENERATED-card click updates selectedVersionId on the stable preview tab. Refetch even when the
-  // Artifact identity is unchanged; the cached lineage may predate that immutable Version.
-  const lineageRequestKey = `${lineageKey}:${sessionFilesRevision}:${previewItem.selectedVersionId ?? ''}`
-  const lineage = lineageResult?.key === lineageKey ? lineageResult.value : undefined
+  // A GENERATED-card click or origin lifecycle refresh can update the stable preview tab while its
+  // Artifact identity stays unchanged. Refetch and stop consuming the prior snapshot until the
+  // matching lineage resolves.
+  const lineageRequestKey = `${lineageKey}:${sessionFilesRevision}:${previewItem.selectedVersionId ?? ''}:${previewItem.originSession?.state ?? ''}`
+  const lineage = lineageResult?.key === lineageRequestKey ? lineageResult.value : undefined
   const exactSelectedVersion = lineage?.versions.find(
     (version) => version.versionId === previewItem.selectedVersionId
   )
@@ -442,7 +443,7 @@ const PreviewFileSurface = ({
         artifactId: previewItem.artifactId
       })
       .then((value) => {
-        if (active) setLineageResult({ key: lineageKey, value })
+        if (active) setLineageResult({ key: lineageRequestKey, value })
       })
       .catch(() => undefined)
 

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -476,14 +476,13 @@ const PreviewFileSurface = ({
   }
 
   // View in context needs the same managed-artifact identity as Provenance, plus a live origin
-  // session. Once deletion starts, the runtime has already detached, so either signal hides the
-  // entry: the refetched lineage or the item's creation-time snapshot. A compensated deletion will
-  // become active again on a later projection refresh.
-  const originSessionUnavailable =
-    lineage?.originSession.state === 'deleting' ||
-    lineage?.originSession.state === 'deleted' ||
-    previewItem.originSession?.state === 'deleting' ||
-    previewItem.originSession?.state === 'deleted'
+  // session. Deleted is terminal, so either signal fails closed. Deleting can be compensated;
+  // there, the refetched lineage is authoritative over the item's creation-time snapshot.
+  const originSessionDeleted =
+    lineage?.originSession.state === 'deleted' || previewItem.originSession?.state === 'deleted'
+  const currentOriginSessionState =
+    lineage?.originSession.state ?? previewItem.originSession?.state ?? 'active'
+  const originSessionUnavailable = originSessionDeleted || currentOriginSessionState === 'deleting'
   const canViewInContext =
     previewItem.source !== 'upload' &&
     previewItem.artifactId !== undefined &&

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -476,15 +476,19 @@ const PreviewFileSurface = ({
   }
 
   // View in context needs the same managed-artifact identity as Provenance, plus a live origin
-  // session. Deletion is terminal, so either signal hides the entry: the refetched lineage or the
-  // item's creation-time originSession snapshot (the lineage may not have refetched yet).
-  const originSessionDeleted =
-    lineage?.originSession.state === 'deleted' || previewItem.originSession?.state === 'deleted'
+  // session. Once deletion starts, the runtime has already detached, so either signal hides the
+  // entry: the refetched lineage or the item's creation-time snapshot. A compensated deletion will
+  // become active again on a later projection refresh.
+  const originSessionUnavailable =
+    lineage?.originSession.state === 'deleting' ||
+    lineage?.originSession.state === 'deleted' ||
+    previewItem.originSession?.state === 'deleting' ||
+    previewItem.originSession?.state === 'deleted'
   const canViewInContext =
     previewItem.source !== 'upload' &&
     previewItem.artifactId !== undefined &&
     projectId !== undefined &&
-    !originSessionDeleted
+    !originSessionUnavailable
   // Archive is reversible, so the entry stays visible but inert rather than disappearing.
   const originSessionArchived = useSessionStore(
     (state) =>

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -2052,10 +2052,11 @@ describe('ProjectFilesView', () => {
     ).toBe('true')
   })
 
-  it('refreshes the count for a collapsed selected session outside the catalog group page', async () => {
+  it('refreshes a collapsed selected session outside the catalog group page', async () => {
     const sessions = createArtifactSessions(12)
     await renderView(sessions)
     let selectedSessionCount = 1
+    let selectedOriginState: 'active' | 'deleting' = 'active'
     const catalogListener = vi.mocked(window.api.projectFiles.onChanged).mock.calls[0]?.[0]
 
     vi.mocked(window.api.projectFiles.listArtifactGroups).mockImplementation(async (request) => ({
@@ -2084,7 +2085,8 @@ describe('ProjectFilesView', () => {
           name: `file-12-${index}.txt`,
           path: `/workspace/file-12-${index}.txt`,
           size: 1,
-          sortAtMs: 12 - index
+          sortAtMs: 12 - index,
+          originSession: { state: selectedOriginState, title: 'Session 12' }
         })),
         totalCount: selectedSessionCount
       }
@@ -2136,6 +2138,7 @@ describe('ProjectFilesView', () => {
     })
 
     selectedSessionCount = 2
+    selectedOriginState = 'deleting'
     await act(async () => {
       catalogListener?.({
         projectId: 'default',
@@ -2150,6 +2153,7 @@ describe('ProjectFilesView', () => {
       '[aria-label="Search project files"]'
     )?.parentElement?.nextElementSibling
     expect(countLabel?.textContent).toBe('2 files')
+    expect(filterButton?.textContent).toContain('Session 12 · Source session is being deleted')
   })
 
   it.each([

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -2152,22 +2152,32 @@ describe('ProjectFilesView', () => {
     expect(countLabel?.textContent).toBe('2 files')
   })
 
-  it('preserves a deleted source session title in a scoped search group', async () => {
+  it.each([
+    {
+      state: 'deleted' as const,
+      expectedTitle: 'Retained analysis · Source session deleted'
+    },
+    {
+      state: 'deleting' as const,
+      expectedTitle: 'Retained analysis · Source session is being deleted'
+    }
+  ])('preserves a $state source session title in a scoped search group', async (testCase) => {
     await renderView([])
     const catalogListener = vi.mocked(window.api.projectFiles.onChanged).mock.calls[0]?.[0]
     const originSession = {
-      state: 'deleted' as const,
+      state: testCase.state,
       title: 'Retained analysis',
-      deletedAt: '2026-07-27T12:00:00.000Z'
+      ...(testCase.state === 'deleted' ? { deletedAt: '2026-07-27T12:00:00.000Z' } : {})
     }
+    const sessionId = `${testCase.state}-session`
     const retainedFile: ProjectFileItem = {
       id: 'retained-artifact',
       source: 'artifact',
       sourceFileId: 'retained-artifact',
       projectId: 'default',
-      sessionId: 'deleted-session',
+      sessionId,
       name: 'result.csv',
-      path: 'artifact-version:default/deleted-session/retained-artifact/version-1',
+      path: `artifact-version:default/${sessionId}/retained-artifact/version-1`,
       size: 12,
       sortAtMs: 1,
       originSession
@@ -2181,7 +2191,7 @@ describe('ProjectFilesView', () => {
       isIndexComplete: true
     })
     vi.mocked(window.api.projectFiles.listArtifactGroups).mockResolvedValue({
-      items: [{ sessionId: 'deleted-session', artifactCount: 1, originSession }],
+      items: [{ sessionId, artifactCount: 1, originSession }],
       totalCount: 1
     })
     vi.mocked(window.api.projectFiles.listFiles).mockResolvedValue({
@@ -2204,7 +2214,7 @@ describe('ProjectFilesView', () => {
     })
     await act(async () => {
       document.body
-        .querySelector<HTMLElement>('[data-filter-id="session:deleted-session"]')
+        .querySelector<HTMLElement>(`[data-filter-id="session:${sessionId}"]`)
         ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
       await new Promise((resolve) => setTimeout(resolve, 0))
     })
@@ -2222,7 +2232,7 @@ describe('ProjectFilesView', () => {
       '[data-testid="project-file-section-header"]'
     )
     expect(selectedHeader).not.toBeNull()
-    expect(selectedHeader?.textContent).toContain('Retained analysis · Source session deleted')
+    expect(selectedHeader?.textContent).toContain(testCase.expectedTitle)
   })
 
   it('keeps filtered content and trigger icon synchronized with the selected category', async () => {

--- a/src/renderer/src/pages/workspace/project-files-query-model.ts
+++ b/src/renderer/src/pages/workspace/project-files-query-model.ts
@@ -265,6 +265,9 @@ const useProjectFilesQueryModel = (activeProjectId: string | undefined): Project
   const getArtifactGroupTitle = useCallback(
     (group: ArtifactGroupItem): string => {
       const title = group.originSession?.title ?? getSessionTitle(group.sessionId)
+      if (group.originSession?.state === 'deleting') {
+        return t('{{title}} · Source session is being deleted', { title })
+      }
       return group.originSession?.state === 'deleted'
         ? t('{{title}} · Source session deleted', { title })
         : title

--- a/src/renderer/src/pages/workspace/project-files-query-model.ts
+++ b/src/renderer/src/pages/workspace/project-files-query-model.ts
@@ -305,10 +305,16 @@ const useProjectFilesQueryModel = (activeProjectId: string | undefined): Project
       !options.some((option) => option.id === selectedSessionFallback.id)
     ) {
       const sessionId = selectedSessionFallback.id.slice('session:'.length)
+      const sessionPage = catalogIndex.artifactsBySession[sessionId]
+      const originSession = sessionPage?.items.find((item) => item.originSession)?.originSession
+      const count = sessionPage?.totalCount ?? selectedSessionFallback.count
       options.push({
         ...selectedSessionFallback,
-        count:
-          catalogIndex.artifactsBySession[sessionId]?.totalCount ?? selectedSessionFallback.count
+        label: originSession
+          ? getArtifactGroupTitle({ sessionId, artifactCount: count, originSession })
+          : selectedSessionFallback.label,
+        count,
+        ...(originSession ? { originSession } : {})
       })
     }
 


### PR DESCRIPTION
## Problem

`FileOriginSession` enters `deleting` only after the source Session runtime has detached, but Files and Preview treated only `deleted` as unavailable. A retained Artifact could therefore still expose **View in context** while its source Session was being removed, and the Files group title looked like an ordinary live Session.

## Proposed change

- Treat `deleting` item/lineage projections as unavailable for Preview context navigation while keeping `deleted` terminal.
- Let a newer active lineage restore navigation when a deleting origin is compensated.
- Refetch lineage when the item lifecycle changes and ignore an older lifecycle result while that refresh is pending.
- Keep Provenance available for retained Artifacts.
- Give `deleting` Files groups a distinct **Source session is being deleted** label, including selected filters outside the loaded group page.
- Add regression coverage for item snapshots, newer lineage, compensation recovery, lifecycle refresh races, and deleting/deleted scoped Files groups.
- Translate the new label in all six renderer locales.

## Scope and non-goals

- No Prisma schema, persisted field, enum, migration, or deletion-workflow changes.
- No historical-data migration or compatibility branch is required; the existing three states are interpreted consistently.
- The existing actionable incomplete-index state remains unchanged and covered.

## Acceptance criteria and validation

Checks listed here ran after the last material edit.

- Deleting origin item/lineage blocks context navigation while retaining Provenance; compensated active lineage restores it; stale active lineage is ignored during an active-to-deleting refresh -> `npm run test:module -- project_files_view` -> 6 files, 169 tests passed.
- Deleting/deleted Files group labels remain distinct, including the out-of-page selected-filter fallback -> `npm run test:module -- project_files_view` -> passed.
- New copy exists in every locale with matching interpolation -> `vitest run src/renderer/src/i18n/resources.test.ts` -> 590 tests passed.
- Changed source and test lint -> targeted `eslint` -> passed with no warnings.
- Local `tsc --noEmit -p tsconfig.web.json --composite false` was attempted but the shared root dependency tree predates the branch lockfile and lacks `web-tree-sitter`; it stopped on existing notebook imports before checking this diff. Exact-head PR CI is authoritative for typecheck.

The Project Files module plan includes its owner, contract, and representative Preview consumers. Main-process, database, persistence, migration, and platform-specific lanes were not run locally because the final diff changes only renderer behavior, tests, and locale catalogs. The complete portable suite was not run locally; PR Gate remains authoritative.

## Review focus

- Confirm the precedence: either `deleted` signal fails closed, while a fresh active lineage can compensate a `deleting` item snapshot.
- Confirm lifecycle changes invalidate the prior lineage during refetch, so `active -> deleting` cannot temporarily expose stale navigation.
- Confirm selected session fallbacks should inherit origin lifecycle metadata from their independently loaded file page.
