### PR TITLE
fix(subagents): mark incomplete imported history

### DIFF
--- a/src/renderer/src/locales/fr.json
+++ b/src/renderer/src/locales/fr.json
@@ -934,6 +934,7 @@
   "Import {{count}} Skills_other": "Importer {{count}} compétences",
   "Import {{count}} Skills_many": "Importer {{count}} compétences",
   "Imported": "Importé",
+  "Imported history may be incomplete": "L’historique importé peut être incomplet",
   "Imported ZIP": "ZIP importé",
   "Imported configuration is prefilled below. Enter required credentials locally, review every field, then confirm that you trust the Connector.": "La configuration importée est préremplie ci-dessous. Saisissez les informations d'identification requises localement, examinez chaque champ, puis confirmez que vous faites confiance au connecteur.",
   "Imported skills": "Compétences importées",

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -888,6 +888,7 @@
   "Import selected ({{selected}})": "選択したインポート ({{selected}})",
   "Import {{count}} Skills_other": "{{count}} スキルをインポートします",
   "Imported": "インポート済み",
+  "Imported history may be incomplete": "インポートされた履歴は不完全な可能性があります",
   "Imported ZIP": "インポートした ZIP",
   "Imported configuration is prefilled below. Enter required credentials locally, review every field, then confirm that you trust the Connector.": "インポートされた構成は以下に事前入力されています。必要な資格情報をローカルで入力し、すべてのフィールドを確認して、コネクタを信頼していることを確認します。",
   "Imported skills": "インポート済みスキル",

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -904,6 +904,7 @@
   "Import selected ({{selected}})": "선택 항목 가져오기({{selected}})",
   "Import {{count}} Skills_other": "스킬 {{count}}개 가져오기",
   "Imported": "가져옴",
+  "Imported history may be incomplete": "가져온 기록이 불완전할 수 있습니다",
   "Imported ZIP": "가져온 ZIP",
   "Imported configuration is prefilled below. Enter required credentials locally, review every field, then confirm that you trust the Connector.": "가져온 구성은 아래에 미리 입력되어 있습니다. 필수 자격 증명을 로컬에서 입력하고 모든 필드를 검토한 다음 커넥터를 신뢰할 수 있는지 확인하세요.",
   "Imported skills": "가져온 스킬",

--- a/src/renderer/src/locales/ru.json
+++ b/src/renderer/src/locales/ru.json
@@ -930,6 +930,7 @@
   "Import {{count}} Skills_many": "Импортировать {{count}} навыков",
   "Import {{count}} Skills_other": "Импортировать {{count}} навыка",
   "Imported": "Импортировано",
+  "Imported history may be incomplete": "Импортированная история может быть неполной",
   "Imported ZIP": "ZIP импортирован",
   "Imported configuration is prefilled below. Enter required credentials locally, review every field, then confirm that you trust the Connector.": "Поля ниже заполнены из импортированной конфигурации. Введите необходимые учётные данные на этом устройстве, проверьте каждое поле и подтвердите доверие к коннектору.",
   "Imported skills": "Импортированные навыки",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -959,6 +959,7 @@
   "Import selected ({{selected}})": "导入所选（{{selected}}）",
   "Import {{count}} Skills_other": "导入 {{count}} 个技能",
   "Imported": "已导入",
+  "Imported history may be incomplete": "导入的历史记录可能不完整",
   "Imported ZIP": "导入的 ZIP",
   "Imported configuration is prefilled below. Enter required credentials locally, review every field, then confirm that you trust the Connector.": "导入的配置已预填在下方。在本地输入所需凭据，检查每个字段，然后确认你信任该连接器。",
   "Imported skills": "已导入的技能",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -957,6 +957,7 @@
   "Import selected ({{selected}})": "匯入所選（{{selected}}）",
   "Import {{count}} Skills_other": "匯入 {{count}} 個技能",
   "Imported": "已匯入",
+  "Imported history may be incomplete": "匯入的歷史記錄可能不完整",
   "Imported ZIP": "匯入的 ZIP",
   "Imported configuration is prefilled below. Enter required credentials locally, review every field, then confirm that you trust the Connector.": "匯入的設定已預先填入下方。在本機輸入所需憑證，檢查每個欄位，然後確認你信任該連接器。",
   "Imported skills": "已匯入的技能",

--- a/src/renderer/src/pages/workspace/SubagentReleaseSurfaces.render.test.tsx
+++ b/src/renderer/src/pages/workspace/SubagentReleaseSurfaces.render.test.tsx
@@ -269,6 +269,23 @@ describe('release-gate Subagent surfaces', () => {
     expect(bar.getAttribute('aria-expanded')).toBe('false')
   })
 
+  it('marks imported Subagent history when its origin Message is unavailable', () => {
+    const session = createSession()
+    const importedFrame = session.conversationGraph?.frames.find(({ id }) => id === 'child-a')
+    if (!importedFrame) throw new Error('Expected child-a fixture')
+    importedFrame.originBindingState = 'legacy-unavailable'
+    delete importedFrame.originMessageId
+
+    renderSurface(<SubagentsBar session={session} permissions={[]} />)
+    fireEvent.click(screen.getByRole('button', { name: '2 subagents, 1 running' }))
+
+    const importedRow = screen.getByRole('button', {
+      name: 'Evidence landscape, running',
+      description: 'Imported history may be incomplete'
+    })
+    expect(within(importedRow).getByText('Imported history may be incomplete')).toBeTruthy()
+  })
+
   it('shows a terminal child continuation as running before its first Agent response', () => {
     const completed = structuredClone(createSession())
     const completedFrame = completed.conversationGraph?.frames.find(({ id }) => id === 'child-a')

--- a/src/renderer/src/pages/workspace/SubagentReleaseSurfaces.tsx
+++ b/src/renderer/src/pages/workspace/SubagentReleaseSurfaces.tsx
@@ -210,6 +210,11 @@ const SubagentsBar = ({ session, permissions }: SubagentSurfaceProps): React.JSX
             <button
               key={child.frameId}
               type="button"
+              aria-describedby={
+                child.originUnavailable
+                  ? `subagent-origin-warning-${session.id}-${child.frameId}`
+                  : undefined
+              }
               aria-label={
                 child.awaitingPermission
                   ? t('{{name}}, {{status}}, waiting for permission', {
@@ -233,6 +238,17 @@ const SubagentsBar = ({ session, permissions }: SubagentSurfaceProps): React.JSX
                 </span>
                 <span className="mt-0.5 block truncate text-[10px] leading-4 text-text-300">
                   {child.agentLabel}
+                  {child.originUnavailable ? (
+                    <>
+                      {' · '}
+                      <span
+                        id={`subagent-origin-warning-${session.id}-${child.frameId}`}
+                        className="text-warning-100"
+                      >
+                        {t('Imported history may be incomplete')}
+                      </span>
+                    </>
+                  ) : null}
                 </span>
               </span>
               <SubagentStatus status={child.status} awaitingPermission={child.awaitingPermission} />
@@ -410,6 +426,12 @@ const SubagentPreview = ({
         <div className="flex min-h-0 flex-1 flex-col" aria-live="off">
           <div className="shrink-0 border-b border-border-100 px-4 py-2 text-[11px] text-text-300">
             <span className="font-medium text-text-100">{detail.agentLabel}</span>
+            {detail.originUnavailable ? (
+              <span className="text-warning-100">
+                {' · '}
+                {t('Imported history may be incomplete')}
+              </span>
+            ) : null}
             {detail.attempt?.cancellationReason ? (
               <span> · {detail.attempt.cancellationReason}</span>
             ) : null}

--- a/src/renderer/src/pages/workspace/subagent-release-projection.ts
+++ b/src/renderer/src/pages/workspace/subagent-release-projection.ts
@@ -26,6 +26,7 @@ type SessionSubagentChild = Readonly<{
   title: string
   agentLabel: string
   status: SubagentRawStatus
+  originUnavailable: boolean
   awaitingPermission?: boolean
 }>
 
@@ -39,6 +40,7 @@ type SubagentFrameProjection = Readonly<{
   title: string
   agentLabel: string
   status: SubagentRawStatus
+  originUnavailable: boolean
   attempt?: DelegatedWorkAttemptRecord
   messages: readonly PersistedChatMessage[]
 }>
@@ -102,6 +104,7 @@ const projectSessionSubagents = (
       title: titleForFrame(frame),
       agentLabel: agentLabelForFrame(session, frame),
       status: awaitingUser ? 'awaiting_user' : frame.status,
+      originUnavailable: frame.originBindingState === 'legacy-unavailable',
       ...(awaitingPermission ? { awaitingPermission: true } : {})
     }
   })
@@ -242,6 +245,7 @@ const selectSubagentFrame = (
     )
       ? 'awaiting_user'
       : frame.status,
+    originUnavailable: frame.originBindingState === 'legacy-unavailable',
     attempt: latestAttempt(session, frameId),
     messages
   }


### PR DESCRIPTION
## Problem

Imported Agent Frames whose origin Message cannot be verified already appear in the Subagents UI, but they are visually and accessibly indistinguishable from native validated Frames. Users can therefore mistake incomplete imported history for a complete delegated-work lineage.

Session, Agent Frame, and delegated Attempt statuses describe different scopes. This change does not merge them: Session remains the task-level activity authority, while Frame and Attempt states remain execution-history facts.

## Proposed change

- carry the existing legacy origin-binding fact through the renderer-only subagent projection
- label affected rows and the selected preview with Imported history may be incomplete
- expose the row label as an accessible description
- translate the label in all six renderer locales
- add a public render-boundary regression test

## Scope and non-goals

- no persisted fields or enum values added
- no Session JSON, database, migration, IPC, or renderer-contract changes
- no root Frame status synchronization with Session status
- no generic compatibility Frame surface; compatibility Frames are not necessarily Subagents
- existing historical legacy-unavailable data is not rewritten and remains openable

## Acceptance criteria and validation

The regression command failed three consecutive times before the fix because the imported Frame had only the accessible name Evidence landscape, running and no incompleteness label. It passes after the fix.

Final checks, all run after the last material edit:

- imported-history presentation -> npm test -- src/renderer/src/pages/workspace/SubagentReleaseSurfaces.render.test.tsx -t marks imported Subagent history when its origin Message is unavailable -> 1 passed
- Subagents projection and render consumers -> npm test -- src/renderer/src/pages/workspace/subagent-release-projection.test.ts src/renderer/src/pages/workspace/SubagentReleaseSurfaces.render.test.tsx -t ^(?!.*streams the selected running Frame without mutating root state and completes token usage on stop).*$ -> 21 passed, 1 known baseline test skipped
- locale integrity and coverage -> npx vitest run src/renderer/src/i18n/resources.test.ts -> 590 passed
- renderer types -> npm run typecheck:web -> passed
- lint -> npm run lint -> passed
- dependency impact explanation -> npm run test:affected -- --base origin/main --head HEAD --explain -> conservative full-suite fallback because locale files have no module owner

Per maintainer instruction, the complete local npm test suite was not run; PR CI is the complete-suite authority. The excluded existing render test failed on the unmodified baseline because its asynchronous child message was absent after a reviewer API mock error; it is unrelated to this change.

ACP/framework, launcher, model, platform, persistence, and migration paths are excluded because the final diff is renderer-only presentation over an existing persisted value.

## Review focus

- whether originUnavailable is the smallest correct renderer projection fact
- whether the visible warning and aria-describedby relationship communicate incomplete imported lineage without changing Frame availability
- whether keeping Session and Frame lifecycles independent remains clear