### PR TITLE
fix(specialists): align built-in list rows

### DIFF
--- a/src/renderer/src/components/app-icons/custom-glyphs.tsx
+++ b/src/renderer/src/components/app-icons/custom-glyphs.tsx
@@ -19,3 +19,17 @@ export const MoleculeIcon = createLucideIcon('Molecule', [
   ['polygon', { points: '12 3 19.8 7.5 19.8 16.5 12 21 4.2 16.5 4.2 7.5' }],
   ['circle', { cx: '12', cy: '12', r: '4' }]
 ])
+
+// Owl wearing a mortarboard, reserved for the built-in Reviewer identity.
+export const OwlScholarIcon = createLucideIcon('OwlScholar', [
+  ['path', { d: 'M5 9v7c0 3 3 5 7 5s7-2 7-5V9' }],
+  ['path', { d: 'm5 10-1-3 4 3m11 0 1-3-4 3' }],
+  ['path', { d: 'm6 6 6-3 6 3-6 3z' }],
+  ['path', { d: 'M18 6v4' }],
+  ['circle', { cx: '8.5', cy: '13.5', r: '2.5' }],
+  ['circle', { cx: '15.5', cy: '13.5', r: '2.5' }],
+  ['circle', { cx: '8.5', cy: '13.5', r: '.7', fill: 'currentColor', stroke: 'none' }],
+  ['circle', { cx: '15.5', cy: '13.5', r: '.7', fill: 'currentColor', stroke: 'none' }],
+  ['path', { d: 'm11 15.5 1 1 1-1' }],
+  ['path', { d: 'M8 21v1m8-1v1M7 22h3m4 0h3' }]
+])

--- a/src/renderer/src/components/app-icons/custom-glyphs.tsx
+++ b/src/renderer/src/components/app-icons/custom-glyphs.tsx
@@ -22,14 +22,11 @@ export const MoleculeIcon = createLucideIcon('Molecule', [
 
 // Owl wearing a mortarboard, reserved for the built-in Reviewer identity.
 export const OwlScholarIcon = createLucideIcon('OwlScholar', [
-  ['path', { d: 'M5 9v7c0 3 3 5 7 5s7-2 7-5V9' }],
-  ['path', { d: 'm5 10-1-3 4 3m11 0 1-3-4 3' }],
-  ['path', { d: 'm6 6 6-3 6 3-6 3z' }],
-  ['path', { d: 'M18 6v4' }],
-  ['circle', { cx: '8.5', cy: '13.5', r: '2.5' }],
-  ['circle', { cx: '15.5', cy: '13.5', r: '2.5' }],
-  ['circle', { cx: '8.5', cy: '13.5', r: '.7', fill: 'currentColor', stroke: 'none' }],
-  ['circle', { cx: '15.5', cy: '13.5', r: '.7', fill: 'currentColor', stroke: 'none' }],
-  ['path', { d: 'm11 15.5 1 1 1-1' }],
-  ['path', { d: 'M8 21v1m8-1v1M7 22h3m4 0h3' }]
+  ['path', { d: 'm6 6 6-3 6 3-6 3zM18 6v3' }],
+  ['path', { d: 'M5 10v7a3 3 0 0 0 3 3h8a3 3 0 0 0 3-3v-7' }],
+  ['path', { d: 'm5 10-1-2 4 2m11 0 1-2-4 2' }],
+  ['circle', { cx: '9', cy: '13.5', r: '2' }],
+  ['circle', { cx: '15', cy: '13.5', r: '2' }],
+  ['path', { d: 'M9 13.5h.01M15 13.5h.01' }],
+  ['path', { d: 'm11.2 16 .8 1 .8-1' }]
 ])

--- a/src/renderer/src/components/app-icons/registry.test.ts
+++ b/src/renderer/src/components/app-icons/registry.test.ts
@@ -40,6 +40,13 @@ describe('app icon registry', () => {
     }
   })
 
+  it('keeps the fixed Reviewer identity outside the appearance picker', () => {
+    expect(APP_ICONS['owl-scholar']).toBeDefined()
+    expect(
+      APP_ICON_GROUPS.flatMap((group) => group.icons).some((icon) => icon.key === 'owl-scholar')
+    ).toBe(false)
+  })
+
   it('exposes the Brain icon as the documented unknown-key fallback', () => {
     // Consumers render `APP_ICONS[key] ?? DEFAULT_APP_ICON` (direct map access, not a
     // resolver call) so React lint rules never see a component created during render.

--- a/src/renderer/src/components/app-icons/registry.test.ts
+++ b/src/renderer/src/components/app-icons/registry.test.ts
@@ -40,8 +40,8 @@ describe('app icon registry', () => {
     }
   })
 
-  it('keeps the fixed Reviewer identity outside the appearance picker', () => {
-    expect(APP_ICONS['owl-scholar']).toBeDefined()
+  it('keeps the fixed Reviewer identity outside the generic appearance registry', () => {
+    expect(APP_ICONS['owl-scholar']).toBeUndefined()
     expect(
       APP_ICON_GROUPS.flatMap((group) => group.icons).some((icon) => icon.key === 'owl-scholar')
     ).toBe(false)

--- a/src/renderer/src/components/app-icons/registry.ts
+++ b/src/renderer/src/components/app-icons/registry.ts
@@ -31,7 +31,7 @@ import {
   Telescope,
   type LucideIcon
 } from 'lucide-react'
-import { MoleculeIcon, OwlScholarIcon, PetriDishIcon } from './custom-glyphs'
+import { MoleculeIcon, PetriDishIcon } from './custom-glyphs'
 
 // Shared app icon registry: the single source of truth for the small stroke-style icon
 // set ("logos") used by Specialist avatars and reusable by any future surface. Prefer a
@@ -104,12 +104,8 @@ export const APP_ICON_GROUPS: readonly AppIconGroup[] = [
   }
 ]
 
-export const APP_ICONS: Record<string, LucideIcon> = {
-  ...Object.fromEntries(
-    APP_ICON_GROUPS.flatMap((group) => group.icons.map((icon) => [icon.key, icon.Icon]))
-  ),
-  // Fixed system identity; intentionally excluded from the user-facing appearance picker.
-  'owl-scholar': OwlScholarIcon
-}
+export const APP_ICONS: Record<string, LucideIcon> = Object.fromEntries(
+  APP_ICON_GROUPS.flatMap((group) => group.icons.map((icon) => [icon.key, icon.Icon]))
+)
 
 export const DEFAULT_APP_ICON = Brain

--- a/src/renderer/src/components/app-icons/registry.ts
+++ b/src/renderer/src/components/app-icons/registry.ts
@@ -31,7 +31,7 @@ import {
   Telescope,
   type LucideIcon
 } from 'lucide-react'
-import { MoleculeIcon, PetriDishIcon } from './custom-glyphs'
+import { MoleculeIcon, OwlScholarIcon, PetriDishIcon } from './custom-glyphs'
 
 // Shared app icon registry: the single source of truth for the small stroke-style icon
 // set ("logos") used by Specialist avatars and reusable by any future surface. Prefer a
@@ -104,8 +104,12 @@ export const APP_ICON_GROUPS: readonly AppIconGroup[] = [
   }
 ]
 
-export const APP_ICONS: Record<string, LucideIcon> = Object.fromEntries(
-  APP_ICON_GROUPS.flatMap((group) => group.icons.map((icon) => [icon.key, icon.Icon]))
-)
+export const APP_ICONS: Record<string, LucideIcon> = {
+  ...Object.fromEntries(
+    APP_ICON_GROUPS.flatMap((group) => group.icons.map((icon) => [icon.key, icon.Icon]))
+  ),
+  // Fixed system identity; intentionally excluded from the user-facing appearance picker.
+  'owl-scholar': OwlScholarIcon
+}
 
 export const DEFAULT_APP_ICON = Brain

--- a/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
@@ -1177,8 +1177,10 @@ describe('SpecialistsPanel', () => {
       document.body.querySelector('[aria-label="Change appearance for Builtin Curator"]')
     ).toBeNull()
     const builtinRow = builtin?.closest('[data-slot="settings-list-row"]')
+    expect(builtinRow?.firstElementChild?.tagName).toBe('SPAN')
     expect(builtinRow?.firstElementChild?.className).toContain('size-11')
     expect(builtinRow?.children[1]?.className).toContain('flex-1')
+    expect(builtinRow?.querySelectorAll('[aria-label="View Builtin Curator"]')).toHaveLength(2)
 
     const reviewerLabel = Array.from(document.body.querySelectorAll('span')).find(
       (element) => element.textContent === 'Reviewer'

--- a/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
@@ -1176,6 +1176,18 @@ describe('SpecialistsPanel', () => {
     expect(
       document.body.querySelector('[aria-label="Change appearance for Builtin Curator"]')
     ).toBeNull()
+    const builtinRow = builtin?.closest('[data-slot="settings-list-row"]')
+    expect(builtinRow?.firstElementChild?.className).toContain('size-11')
+    expect(builtinRow?.children[1]?.className).toContain('flex-1')
+
+    const reviewerLabel = Array.from(document.body.querySelectorAll('span')).find(
+      (element) => element.textContent === 'Reviewer'
+    )
+    const reviewerRow = reviewerLabel?.closest('[data-slot="settings-list-row"]')
+    expect(reviewerRow?.firstElementChild?.className).toContain('size-11')
+    expect(reviewerRow?.children[1]?.className).toContain('flex-1')
+    expect(reviewerRow?.querySelector('[data-specialist-icon="bug"]')).not.toBeNull()
+
     await act(async () => builtin!.click())
     expect(onNavigate).toHaveBeenCalledWith({ kind: 'builtin', id: 'builtin-curator' })
 

--- a/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
@@ -1188,7 +1188,9 @@ describe('SpecialistsPanel', () => {
     const reviewerRow = reviewerLabel?.closest('[data-slot="settings-list-row"]')
     expect(reviewerRow?.firstElementChild?.className).toContain('size-11')
     expect(reviewerRow?.children[1]?.className).toContain('flex-1')
-    expect(reviewerRow?.querySelector('[data-specialist-icon="owl-scholar"]')).not.toBeNull()
+    const reviewerIcon = reviewerRow?.querySelector('[data-specialist-icon="owl-scholar"]')
+    expect(reviewerIcon).not.toBeNull()
+    expect(reviewerIcon?.getAttribute('class')).toContain('size-[18px]')
 
     await act(async () => builtin!.click())
     expect(onNavigate).toHaveBeenCalledWith({ kind: 'builtin', id: 'builtin-curator' })

--- a/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx
@@ -1186,7 +1186,7 @@ describe('SpecialistsPanel', () => {
     const reviewerRow = reviewerLabel?.closest('[data-slot="settings-list-row"]')
     expect(reviewerRow?.firstElementChild?.className).toContain('size-11')
     expect(reviewerRow?.children[1]?.className).toContain('flex-1')
-    expect(reviewerRow?.querySelector('[data-specialist-icon="bug"]')).not.toBeNull()
+    expect(reviewerRow?.querySelector('[data-specialist-icon="owl-scholar"]')).not.toBeNull()
 
     await act(async () => builtin!.click())
     expect(onNavigate).toHaveBeenCalledWith({ kind: 'builtin', id: 'builtin-curator' })

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -2079,7 +2079,10 @@ const InstalledSpecialistsPanel = ({
                         style={getAvatarStyle('teal')}
                         aria-hidden="true"
                       >
-                        <OwlScholarIcon className="size-3.5" data-specialist-icon="owl-scholar" />
+                        <OwlScholarIcon
+                          className="size-[18px]"
+                          data-specialist-icon="owl-scholar"
+                        />
                       </span>
                     </span>
                     <div className="min-w-0 flex-1">

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -2077,7 +2077,7 @@ const InstalledSpecialistsPanel = ({
                     className="flex min-h-14 items-center gap-2 py-2.5"
                   >
                     <span className="flex size-11 shrink-0 items-center justify-center">
-                      <SpecialistAvatar iconKey="bug" colorKey="teal" />
+                      <SpecialistAvatar iconKey="owl-scholar" colorKey="teal" />
                     </span>
                     <div className="min-w-0 flex-1">
                       <span className="block truncate text-sm text-foreground">

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -2020,14 +2020,9 @@ const InstalledSpecialistsPanel = ({
                     data-slot="settings-list-row"
                     className="flex min-h-14 items-center gap-2 py-2.5"
                   >
-                    <button
-                      type="button"
-                      onClick={() => onNavigate({ kind: 'builtin', id: item.id })}
-                      aria-label={t('View {{name}}', { name: item.displayName ?? item.name })}
-                      className="flex size-11 shrink-0 cursor-pointer items-center justify-center rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    >
+                    <span className="flex size-11 shrink-0 items-center justify-center">
                       <SpecialistAvatar iconKey={item.iconKey} colorKey={item.colorKey} />
-                    </button>
+                    </span>
                     <div className="min-w-0 flex-1">
                       <button
                         type="button"

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -2020,25 +2020,30 @@ const InstalledSpecialistsPanel = ({
                     data-slot="settings-list-row"
                     className="flex min-h-14 items-center gap-2 py-2.5"
                   >
+                    <button
+                      type="button"
+                      onClick={() => onNavigate({ kind: 'builtin', id: item.id })}
+                      aria-label={t('View {{name}}', { name: item.displayName ?? item.name })}
+                      className="flex size-11 shrink-0 cursor-pointer items-center justify-center rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      <SpecialistAvatar iconKey={item.iconKey} colorKey={item.colorKey} />
+                    </button>
                     <div className="min-w-0 flex-1">
                       <button
                         type="button"
                         onClick={() => onNavigate({ kind: 'builtin', id: item.id })}
                         aria-label={t('View {{name}}', { name: item.displayName ?? item.name })}
-                        className="flex w-full min-w-0 cursor-pointer items-center gap-2 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        className="block w-full min-w-0 cursor-pointer rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                       >
-                        <SpecialistAvatar iconKey={item.iconKey} colorKey={item.colorKey} />
-                        <div className="min-w-0 flex-1">
-                          <span className="block truncate text-sm text-foreground">
-                            {item.displayName ?? item.name}
-                          </span>
-                          <span className="block truncate text-xs text-muted-foreground">
-                            {item.description}
-                          </span>
-                        </div>
+                        <span className="block truncate text-sm text-foreground">
+                          {item.displayName ?? item.name}
+                        </span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {item.description}
+                        </span>
                       </button>
                       <div
-                        className="mt-0.5 ml-9 flex min-w-0 items-center gap-2"
+                        className="mt-0.5 flex min-w-0 items-center gap-2"
                         data-specialist-metadata-group={item.id}
                       >
                         <button
@@ -2071,11 +2076,8 @@ const InstalledSpecialistsPanel = ({
                     data-slot="settings-list-row"
                     className="flex min-h-14 items-center gap-2 py-2.5"
                   >
-                    <span
-                      className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-[13px] text-primary"
-                      aria-hidden="true"
-                    >
-                      ✓
+                    <span className="flex size-11 shrink-0 items-center justify-center">
+                      <SpecialistAvatar iconKey="bug" colorKey="teal" />
                     </span>
                     <div className="min-w-0 flex-1">
                       <span className="block truncate text-sm text-foreground">

--- a/src/renderer/src/pages/settings/SpecialistsPanel.tsx
+++ b/src/renderer/src/pages/settings/SpecialistsPanel.tsx
@@ -18,6 +18,7 @@ import {
   X
 } from 'lucide-react'
 import { AlertDialog, Collapsible } from 'radix-ui'
+import { OwlScholarIcon } from '@/components/app-icons/custom-glyphs'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -66,6 +67,7 @@ import {
 import { SettingsSearchInput } from './SettingsSearchInput'
 import { SpecialistAppearancePicker } from './SpecialistAppearancePicker'
 import { SpecialistAvatar } from './specialist-avatar'
+import { getAvatarStyle } from './specialist-icons'
 import { SpecialistSkillConflictChoices } from './SpecialistSkillConflictChoices'
 import {
   skillConflictResolutionList,
@@ -2072,7 +2074,13 @@ const InstalledSpecialistsPanel = ({
                     className="flex min-h-14 items-center gap-2 py-2.5"
                   >
                     <span className="flex size-11 shrink-0 items-center justify-center">
-                      <SpecialistAvatar iconKey="owl-scholar" colorKey="teal" />
+                      <span
+                        className="flex size-7 shrink-0 items-center justify-center rounded-lg text-[13px]"
+                        style={getAvatarStyle('teal')}
+                        aria-hidden="true"
+                      >
+                        <OwlScholarIcon className="size-3.5" data-specialist-icon="owl-scholar" />
+                      </span>
                     </span>
                     <div className="min-w-0 flex-1">
                       <span className="block truncate text-sm text-foreground">


### PR DESCRIPTION
## Problem

Built-in Specialist rows use a narrower avatar layout than Marketplace and Custom rows, so their icon centers, text columns, and metadata do not align. Reviewer also uses a one-off status mark instead of a stable Specialist identity.

## Proposed change

- Give Built-in and Reviewer rows the same 44px avatar slot used by Marketplace and Custom rows, aligning their icon centers and text columns.
- Keep read-only Built-in avatars presentational so the alignment change does not add a duplicate keyboard or screen-reader focus target; existing detail controls remain unchanged.
- Add a fixed hand-drawn Reviewer avatar: a minimal outline built from a mortarboard, ear tufts, paired eyes, a small beak, and one rounded body contour.
- Optically size the owl at 18px inside the unchanged 28px avatar tile so its visual weight matches the Marketplace and Custom glyphs.
- Render the owl only in the Reviewer row and keep it out of the generic `APP_ICONS` registry, so custom Specialists cannot select, persist, or resolve the fixed identity.
- Add render and registry regression assertions for row structure, focus targets, and the fixed Reviewer identity.

## Scope and non-goals

- Renderer presentation only; no Specialist catalog or runtime behavior changes.
- No historical-data compatibility handling is required.
- No enum or state values are added.
- No persisted data format or production persistence is changed.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- Built-in/Reviewer layout, focus behavior, and fixed icon registry -> `npm test -- src/renderer/src/components/app-icons/registry.test.ts src/renderer/src/pages/settings/SpecialistsPanel.render.test.tsx` -> passed (56 tests).
- Renderer type safety -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint` -> passed.
- Web renderer production build -> `npm run build:web` -> passed.

The localhost Web UI built and loaded the Specialists panel successfully, but its current capability profile does not expose the Specialist catalog, so Built-in/Reviewer rows could not be populated there for a live screenshot. Exact row structure is covered by the targeted render test; PR visual/E2E CI remains the final authority.

Consumer and platform lanes are excluded locally because no shared interface, persistence contract, platform path, or interaction contract changed. Full `npm test` was intentionally not run; PR Gate will select the complete required CI plan from the exact diff.

## Review focus

- All three source groups share the same avatar center and text start position.
- Built-in avatars remain non-interactive and do not add redundant focus targets.
- Reviewer uses the fixed internal owl identity, which is excluded from the appearance picker.
