### PR TITLE
fix(notebook): restore terminal history and kernel gating

### DIFF
--- a/src/main/notebook/ipc.test.ts
+++ b/src/main/notebook/ipc.test.ts
@@ -197,4 +197,57 @@ describe('notebook IPC handlers', () => {
     expect(service.restart).toHaveBeenCalledWith(session)
     expect(service.shutdown).toHaveBeenCalledWith(session)
   })
+
+  it('logs terminal execution and submission failures without logging source code', async () => {
+    const executionFailure = {
+      runId: 'run-failed',
+      status: 'failed',
+      environment: 'default-python',
+      text: {
+        stdout: '',
+        stderr: '',
+        traceback: 'Traceback\nValueError: diagnostic detail',
+        plain: []
+      }
+    }
+    const submissionFailure = new Error('kernel connection closed')
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce(executionFailure)
+      .mockRejectedValueOnce(submissionFailure)
+    const service = { execute } as unknown as NotebookRuntimeService
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    registerNotebookIpcHandlers(createNotebookCommandWorkflows(service))
+    const request = {
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      workspaceCwd: '/workspace',
+      code: 'secret = 42',
+      source: 'user' as const,
+      inputKind: 'terminal' as const,
+      language: 'python' as const
+    }
+    const handler = ipcHandlers.get('notebook:execute')
+
+    await expect(handler?.(undefined, request)).resolves.toBe(executionFailure)
+    await expect(handler?.(undefined, request)).rejects.toBe(submissionFailure)
+
+    expect(errorSpy).toHaveBeenNthCalledWith(1, '[notebook] User terminal execution failed', {
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      language: 'python',
+      environment: 'default-python',
+      runId: 'run-failed',
+      status: 'failed',
+      error: 'ValueError: diagnostic detail'
+    })
+    expect(errorSpy).toHaveBeenNthCalledWith(2, '[notebook] User terminal submission failed', {
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      language: 'python',
+      codeLength: 11,
+      error: submissionFailure
+    })
+    expect(errorSpy.mock.calls.flat().join(' ')).not.toContain('secret = 42')
+  })
 })

--- a/src/main/notebook/ipc.ts
+++ b/src/main/notebook/ipc.ts
@@ -13,6 +13,13 @@ import type {
 } from '../../shared/notebook'
 import type { NotebookCommandWorkflows } from './notebook-workflows'
 
+const lastNonEmptyLine = (value: string): string | undefined =>
+  value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .at(-1)
+
 // Registers renderer-callable notebook commands on the main-process IPC bus.
 const registerNotebookIpcHandlers = (handlers: NotebookCommandWorkflows): void => {
   ipcMainHandle('notebook:state', (_event, request: NotebookSessionStateRequest) =>
@@ -33,9 +40,41 @@ const registerNotebookIpcHandlers = (handlers: NotebookCommandWorkflows): void =
   ipcMainHandle('notebook:run-cell', (_event, request: RunNotebookCellRequest) =>
     handlers.runCell(request)
   )
-  ipcMainHandle('notebook:execute', (_event, request: ExecuteNotebookCodeRequest) =>
-    handlers.execute(request)
-  )
+  ipcMainHandle('notebook:execute', async (_event, request: ExecuteNotebookCodeRequest) => {
+    try {
+      const result = await handlers.execute(request)
+      if (
+        request.source === 'user' &&
+        request.inputKind === 'terminal' &&
+        result.status !== 'completed'
+      ) {
+        console.error('[notebook] User terminal execution failed', {
+          sessionId: request.sessionId,
+          projectId: request.projectId,
+          language: request.language ?? 'python',
+          environment: result.environment,
+          runId: result.runId,
+          status: result.status,
+          error:
+            lastNonEmptyLine(result.text.traceback) ??
+            lastNonEmptyLine(result.text.stderr) ??
+            'unknown'
+        })
+      }
+      return result
+    } catch (error) {
+      if (request.source === 'user' && request.inputKind === 'terminal') {
+        console.error('[notebook] User terminal submission failed', {
+          sessionId: request.sessionId,
+          projectId: request.projectId,
+          language: request.language ?? 'python',
+          codeLength: request.code.length,
+          error
+        })
+      }
+      throw error
+    }
+  })
   ipcMainHandle('notebook:export-ipynb', (_event, request: ExportNotebookKernelRequest) =>
     handlers.exportIpynb(request)
   )

--- a/src/renderer/src/locales/fr.json
+++ b/src/renderer/src/locales/fr.json
@@ -1487,6 +1487,7 @@
   "Python": "Python",
   "Python kernel · shared with the agent": "Noyau Python · partagé avec l'agent",
   "Python · view only; this kernel's namespace no longer exists": "Python · lecture seule; l’espace de noms de ce noyau n’existe plus",
+  "{{kernel}} · view only; the agent must activate this kernel first": "{{kernel}} · lecture seule; l’Agent doit d’abord activer ce noyau",
   "R kernel · shared with the agent": "Noyau R · partagé avec l'agent",
   "R · view only; this kernel's namespace no longer exists": "R · lecture seule; l’espace de noms de ce noyau n’existe plus",
   "{{environment}} · history only; new code runs in {{activeEnvironment}}": "{{environment}} · historique uniquement; le nouveau code s’exécute dans {{activeEnvironment}}",

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -1434,6 +1434,7 @@
   "Python": "Python",
   "Python kernel · shared with the agent": "Python カーネル · エージェントと共有",
   "Python · view only; this kernel's namespace no longer exists": "Python · 表示専用 — このカーネルの名前空間はもう存在しません",
+  "{{kernel}} · view only; the agent must activate this kernel first": "{{kernel}} · 表示専用 — エージェントが先にこのカーネルを有効化する必要があります",
   "R kernel · shared with the agent": "R カーネル · エージェントと共有",
   "R · view only; this kernel's namespace no longer exists": "R · 表示専用 — このカーネルの名前空間はもう存在しません",
   "{{environment}} · history only; new code runs in {{activeEnvironment}}": "{{environment}} · 履歴のみ。新しいコードは {{activeEnvironment}} で実行されます",

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -1445,6 +1445,7 @@
   "Python": "Python",
   "Python kernel · shared with the agent": "Python 커널 · 에이전트와 공유됨",
   "Python · view only; this kernel's namespace no longer exists": "Python · 보기 전용 — 이 커널의 네임스페이스가 더 이상 존재하지 않습니다",
+  "{{kernel}} · view only; the agent must activate this kernel first": "{{kernel}} · 보기 전용 — 에이전트가 먼저 이 커널을 활성화해야 합니다",
   "R kernel · shared with the agent": "R 커널 · 에이전트와 공유됨",
   "R · view only; this kernel's namespace no longer exists": "R · 보기 전용 — 이 커널의 네임스페이스가 더 이상 존재하지 않습니다",
   "{{environment}} · history only; new code runs in {{activeEnvironment}}": "{{environment}} · 기록 전용; 새 코드는 {{activeEnvironment}}에서 실행됩니다",

--- a/src/renderer/src/locales/ru.json
+++ b/src/renderer/src/locales/ru.json
@@ -1482,6 +1482,7 @@
   "Python": "Python",
   "Python kernel · shared with the agent": "Python ядро · передано агенту",
   "Python · view only; this kernel's namespace no longer exists": "Python · только просмотр — пространство имён этого ядра больше не существует",
+  "{{kernel}} · view only; the agent must activate this kernel first": "{{kernel}} · только просмотр — Агент должен сначала активировать это ядро",
   "R kernel · shared with the agent": "Ядро R · совместно используется с агентом",
   "R · view only; this kernel's namespace no longer exists": "R · только просмотр — пространство имён этого ядра больше не существует",
   "{{environment}} · history only; new code runs in {{activeEnvironment}}": "{{environment}} · только история; новый код выполняется в {{activeEnvironment}}",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -1505,6 +1505,7 @@
   "Python": "Python",
   "Python kernel · shared with the agent": "Python 内核 · 与智能体共享",
   "Python · view only; this kernel's namespace no longer exists": "Python · 仅供查看；此内核的命名空间已不存在",
+  "{{kernel}} · view only; the agent must activate this kernel first": "{{kernel}} · 仅供查看；智能体必须先激活此内核",
   "R kernel · shared with the agent": "R 内核 · 与智能体共享",
   "R · view only; this kernel's namespace no longer exists": "R · 仅供查看；此内核的命名空间已不存在",
   "{{environment}} · history only; new code runs in {{activeEnvironment}}": "{{environment}} · 仅查看历史；新代码将在 {{activeEnvironment}} 中运行",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -1502,6 +1502,7 @@
   "Python": "Python",
   "Python kernel · shared with the agent": "Python 核心 · 與智能體共用",
   "Python · view only; this kernel's namespace no longer exists": "Python · 僅供檢視；此核心的命名空間已不存在",
+  "{{kernel}} · view only; the agent must activate this kernel first": "{{kernel}} · 僅供檢視；智能體必須先啟用此核心",
   "R kernel · shared with the agent": "R 核心 · 與智能體共用",
   "R · view only; this kernel's namespace no longer exists": "R · 僅供檢視；此核心的命名空間已不存在",
   "{{environment}} · history only; new code runs in {{activeEnvironment}}": "{{environment}} · 僅供檢視歷史記錄；新程式碼將在 {{activeEnvironment}} 中執行",

--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -749,10 +749,15 @@ describe('NotebookPreview per-kernel tabs', () => {
     expect(userCell?.textContent).toContain('r')
   })
 
-  it('keeps idle terminal input enabled while notebook state refreshes in the background', async () => {
+  it('queues idle terminal input until a background refresh confirms it is safe', async () => {
     await mountWithRuns([makeRun({ runId: 'p1', kernelKind: 'python' })])
 
-    vi.mocked(window.api.notebook.state).mockImplementation(() => new Promise(() => {}))
+    const state = vi.mocked(window.api.notebook.state)
+    const idleState = await state.mock.results[0]?.value
+    let resolveRefresh!: (value: typeof idleState) => void
+    state.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveRefresh = resolve as typeof resolveRefresh))
+    )
     const onChanged = vi.mocked(window.api.notebook.onChanged).mock.calls[0]?.[0]
 
     await act(async () => {
@@ -767,6 +772,63 @@ describe('NotebookPreview per-kernel tabs', () => {
       (container.querySelector('[data-testid="kernel-terminal-input"]') as HTMLTextAreaElement)
         .disabled
     ).toBe(false)
+
+    const input = container.querySelector(
+      '[data-testid="kernel-terminal-input"]'
+    ) as HTMLTextAreaElement
+    fireEvent.change(input, { target: { value: 'print(42)' } })
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' })
+    })
+
+    expect(state).toHaveBeenCalledTimes(2)
+    expect(window.api.notebook.execute).not.toHaveBeenCalled()
+
+    await act(async () => {
+      resolveRefresh(idleState)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(window.api.notebook.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'print(42)', source: 'user' })
+    )
+  })
+
+  it('does not submit from a stale idle snapshot when the fresh state is busy', async () => {
+    await mountWithRuns([makeRun({ runId: 'p1', kernelKind: 'python' })])
+
+    const state = vi.mocked(window.api.notebook.state)
+    const idleState = await state.mock.results[0]?.value
+    let resolveRefresh!: (value: typeof idleState) => void
+    state.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveRefresh = resolve as typeof resolveRefresh))
+    )
+    const onChanged = vi.mocked(window.api.notebook.onChanged).mock.calls[0]?.[0]
+
+    await act(async () => {
+      onChanged?.(item.notebook)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    const input = container.querySelector(
+      '[data-testid="kernel-terminal-input"]'
+    ) as HTMLTextAreaElement
+    fireEvent.change(input, { target: { value: 'print(42)' } })
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' })
+    })
+
+    expect(state).toHaveBeenCalledTimes(2)
+    expect(window.api.notebook.execute).not.toHaveBeenCalled()
+    expect(input.value).toBe('print(42)')
+
+    await act(async () => {
+      resolveRefresh({ ...idleState, activeRunId: 'agent-run' })
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(window.api.notebook.execute).not.toHaveBeenCalled()
+    expect(input.value).toBe('print(42)')
   })
 
   it('shows selected-kernel status while retaining the notebook-wide input lock', async () => {

--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -749,6 +749,26 @@ describe('NotebookPreview per-kernel tabs', () => {
     expect(userCell?.textContent).toContain('r')
   })
 
+  it('keeps idle terminal input enabled while notebook state refreshes in the background', async () => {
+    await mountWithRuns([makeRun({ runId: 'p1', kernelKind: 'python' })])
+
+    vi.mocked(window.api.notebook.state).mockImplementation(() => new Promise(() => {}))
+    const onChanged = vi.mocked(window.api.notebook.onChanged).mock.calls[0]?.[0]
+
+    await act(async () => {
+      onChanged?.(item.notebook)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(container.querySelector('[data-testid="notebook-terminal-header"]')?.textContent).toContain(
+      'idle'
+    )
+    expect(
+      (container.querySelector('[data-testid="kernel-terminal-input"]') as HTMLTextAreaElement)
+        .disabled
+    ).toBe(false)
+  })
+
   it('shows selected-kernel status while retaining the notebook-wide input lock', async () => {
     await mountWithRuns(
       [

--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -299,6 +299,29 @@ describe('NotebookPreview per-kernel tabs', () => {
       status: readyStatus,
       ui: deriveProvisionUi(readyStatus, undefined, undefined, undefined)
     })
+    const liveEnvironments =
+      environments.length > 0
+        ? environments
+        : Array.from(
+            new Map(
+              runs
+                .filter((run) => run.kernelKind === 'python' || run.kernelKind === 'r')
+                .map((run) => {
+                  const environment =
+                    run.environment ?? (run.kernelKind === 'r' ? 'default-r' : 'default-python')
+                  const processKey = `${run.kernelKind}:${environment}`
+                  return [
+                    processKey,
+                    {
+                      processKey,
+                      kind: run.kernelKind as 'python' | 'r',
+                      environment,
+                      status: 'idle' as const
+                    }
+                  ] as const
+                })
+            ).values()
+          )
 
     window.api = {
       notebook: {
@@ -317,7 +340,7 @@ describe('NotebookPreview per-kernel tabs', () => {
             runs,
             recentRuns: runs,
             runStaleness,
-            environments,
+            environments: liveEnvironments,
             ...stateOverrides
           })
         ),
@@ -388,6 +411,44 @@ describe('NotebookPreview per-kernel tabs', () => {
     expect(container.querySelector('[data-testid="notebook-read-only-status"]')?.textContent).toBe(
       "Python · view only; this kernel's namespace no longer exists2 cells"
     )
+  })
+
+  it('keeps persisted idle history view-only until this app process activates its kernel', async () => {
+    await mountWithRuns(
+      [makeRun({ runId: 'p1', kernelKind: 'python', script: 'x = 42' })],
+      [],
+      {},
+      'idle',
+      { environments: [] }
+    )
+
+    expect(container.querySelector('[data-testid="kernel-terminal-input"]')).toBeNull()
+    expect(
+      container.querySelector('[data-testid="notebook-read-only-status"]')?.textContent
+    ).toContain("Python · view only; this kernel's namespace no longer exists")
+
+    const state = vi.mocked(window.api.notebook.state)
+    const persistedState = await state.mock.results[0]?.value
+    state.mockResolvedValue({
+      ...persistedState,
+      environments: [
+        {
+          processKey: 'python:default-python',
+          kind: 'python',
+          environment: 'default-python',
+          status: 'idle'
+        }
+      ]
+    })
+    const onChanged = vi.mocked(window.api.notebook.onChanged).mock.calls[0]?.[0]
+
+    await act(async () => {
+      onChanged?.(item.notebook)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(container.querySelector('[data-testid="notebook-read-only-status"]')).toBeNull()
+    expect(container.querySelector('[data-testid="kernel-terminal-input"]')).not.toBeNull()
   })
 
   it('describes later variable changes without implying an execution error', async () => {
@@ -554,7 +615,10 @@ describe('NotebookPreview per-kernel tabs', () => {
   // the shape a textual merge leaves behind. English assertions above stay green through that, so
   // the locale is what has to be asserted.
   it('translates the terminal header and the resize handle', async () => {
-    await mountWithRuns([makeRun({ runId: 'p1', kernelKind: 'python' })])
+    await mountWithRuns([
+      makeRun({ runId: 'p1', kernelKind: 'python' }),
+      makeRun({ runId: 'r1', kernelKind: 'r' })
+    ])
     await act(async () => i18next.changeLanguage('zh-Hans'))
 
     const header = container.querySelector('[data-testid="notebook-terminal-header"]')
@@ -633,12 +697,64 @@ describe('NotebookPreview per-kernel tabs', () => {
     expect(container.textContent).not.toContain('print("legacy")')
   })
 
+  it('keeps user input in the Main Agent view after a pending Session binds its final ID', async () => {
+    useSessionStore.setState({
+      sessions: [
+        {
+          id: 'session-1',
+          conversationGraph: {
+            rootFrameId: 'root-frame-pending-session-1',
+            frames: [{ id: 'root-frame-pending-session-1', kind: 'root' }]
+          }
+        }
+      ]
+    } as never)
+
+    await mountWithRuns([
+      makeRun({
+        runId: 'agent-run',
+        script: 'print("agent")',
+        rootFrameId: 'root-frame-pending-session-1',
+        agentFrameId: 'root-frame-pending-session-1'
+      }),
+      makeRun({
+        runId: 'user-run',
+        source: 'user',
+        inputKind: 'terminal',
+        script: 'print("user")',
+        rootFrameId: undefined,
+        agentFrameId: 'root-frame-session-1'
+      })
+    ])
+
+    const filter = container.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="Filter notebook runs by Agent"]'
+    )
+    expect(filter?.textContent).toContain('Main Agent · 2 runs')
+    expect(container.textContent).toContain('print("agent")')
+    expect(container.textContent).toContain('print("user")')
+    const userCell = [...container.querySelectorAll('[data-testid="notebook-cell"]')].find((cell) =>
+      cell.textContent?.includes('print("user")')
+    )
+    expect(userCell?.textContent).toContain('you')
+    const userBadge = [...(userCell?.querySelectorAll('span') ?? [])].find(
+      (badge) => badge.textContent === 'you'
+    )
+    expect(userBadge?.className).toContain('bg-blue-500/10')
+    expect(userBadge?.className).toContain('text-blue-700')
+    expect(userBadge?.className).toContain('dark:text-blue-300')
+  })
+
   it('shows Python and R before either kernel has produced a run', async () => {
     await mountWithRuns([])
 
     const switcher = container.querySelector('[data-testid="kernel-switcher"]') as HTMLElement
     expect(switcher.querySelector('[data-testid="kernel-switcher-python"]')).not.toBeNull()
     expect(switcher.querySelector('[data-testid="kernel-switcher-r"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="kernel-terminal-input"]')).toBeNull()
+    expect(
+      container.querySelector('[data-testid="notebook-read-only-status"]')?.textContent
+    ).toContain('Python · view only; the agent must activate this kernel first')
   })
 
   it('shows no Agent SDK/Bash tab for a python-only run set', async () => {
@@ -975,6 +1091,29 @@ describe('NotebookPreview per-environment selector', () => {
       status: readyStatus,
       ui: deriveProvisionUi(readyStatus, undefined, undefined, undefined)
     })
+    const liveEnvironments =
+      environments.length > 0
+        ? environments
+        : Array.from(
+            new Map(
+              runs
+                .filter((run) => run.kernelKind === 'python' || run.kernelKind === 'r')
+                .map((run) => {
+                  const environment =
+                    run.environment ?? (run.kernelKind === 'r' ? 'default-r' : 'default-python')
+                  const processKey = `${run.kernelKind}:${environment}`
+                  return [
+                    processKey,
+                    {
+                      processKey,
+                      kind: run.kernelKind as 'python' | 'r',
+                      environment,
+                      status: 'idle' as const
+                    }
+                  ] as const
+                })
+            ).values()
+          )
 
     window.api = {
       notebook: {
@@ -991,7 +1130,7 @@ describe('NotebookPreview per-environment selector', () => {
             cells: [],
             runs,
             recentRuns: runs,
-            environments,
+            environments: liveEnvironments,
             executionEnvironments
           })
         ),

--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -760,9 +760,9 @@ describe('NotebookPreview per-kernel tabs', () => {
       await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
-    expect(container.querySelector('[data-testid="notebook-terminal-header"]')?.textContent).toContain(
-      'idle'
-    )
+    expect(
+      container.querySelector('[data-testid="notebook-terminal-header"]')?.textContent
+    ).toContain('idle')
     expect(
       (container.querySelector('[data-testid="kernel-terminal-input"]') as HTMLTextAreaElement)
         .disabled

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -547,7 +547,7 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
   // The Session Aggregate owns one active write and run, so input stays globally locked even when a
   // different persistent data kernel is selected.
   const isTerminalLocked =
-    isLoading ||
+    (isLoading && !notebookState) ||
     isSubmitting ||
     Boolean(notebookState?.activeWrite) ||
     Boolean(notebookState?.activeRunId) ||

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -342,7 +342,8 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
   // Selected environment within the active python/r pane; undefined lets the effective-env
   // computation below default to the first (canonical-default-first) environment.
   const [activeEnv, setActiveEnv] = useState<string | undefined>(undefined)
-  const stateLoadInFlight = useRef(false)
+  const latestNotebookState = useRef<NotebookSessionState | undefined>(undefined)
+  const stateLoadInFlight = useRef<Promise<boolean> | undefined>(undefined)
   const stateReloadQueued = useRef(false)
   const notebookRequest = createNotebookRequest(item.notebook)
   const notebookRequestKey = JSON.stringify(notebookRequest)
@@ -371,40 +372,55 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
 
   // Keeps state assignment isolated so load paths and event paths share the same update hook.
   const applyNotebookState = useCallback((nextState: NotebookSessionState): void => {
+    latestNotebookState.current = nextState
     setNotebookState(nextState)
   }, [])
 
   // Reads the latest notebook state from main, including its bounded recent run window.
-  const loadNotebookState = useCallback(async (): Promise<void> => {
+  const loadNotebookState = useCallback(async (): Promise<boolean> => {
     if (stateLoadInFlight.current) {
       stateReloadQueued.current = true
-      return
+      return stateLoadInFlight.current
     }
-    stateLoadInFlight.current = true
-    setIsLoading(true)
-
-    do {
-      stateReloadQueued.current = false
-      const requested = latestNotebookRequest.current
+    const load = (async (): Promise<boolean> => {
+      let succeeded = false
+      setIsLoading(true)
       try {
-        const nextState = await window.api.notebook.state(requested.request)
+        do {
+          stateReloadQueued.current = false
+          const requested = latestNotebookRequest.current
+          try {
+            const nextState = await window.api.notebook.state(requested.request)
 
-        if (latestNotebookRequest.current.key === requested.key) {
-          applyNotebookState(nextState)
-          setActionError(null)
-        } else {
-          stateReloadQueued.current = true
-        }
-      } catch (error) {
-        if (latestNotebookRequest.current.key === requested.key) {
-          setActionError(getErrorMessage(error))
-        } else {
-          stateReloadQueued.current = true
-        }
+            if (latestNotebookRequest.current.key === requested.key) {
+              applyNotebookState(nextState)
+              setActionError(null)
+              succeeded = true
+            } else {
+              stateReloadQueued.current = true
+            }
+          } catch (error) {
+            if (latestNotebookRequest.current.key === requested.key) {
+              setActionError(getErrorMessage(error))
+              succeeded = false
+            } else {
+              stateReloadQueued.current = true
+            }
+          }
+        } while (stateReloadQueued.current)
+        return succeeded
+      } finally {
+        setIsLoading(false)
       }
-    } while (stateReloadQueued.current)
-    stateLoadInFlight.current = false
-    setIsLoading(false)
+    })()
+    stateLoadInFlight.current = load
+    try {
+      return await load
+    } finally {
+      if (stateLoadInFlight.current === load) {
+        stateLoadInFlight.current = undefined
+      }
+    }
   }, [applyNotebookState])
 
   // Defer the initial state load until after the component has mounted.
@@ -560,23 +576,20 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
   const submitTerminalCode = async (): Promise<void> => {
     const code = terminalCode.trim()
 
-    if (
-      !code ||
-      !activeDataLanguage ||
-      !activeEnvName ||
-      isHistoricalEnvironmentView ||
-      notebookState?.activeWrite ||
-      notebookState?.activeRunId
-    ) {
+    if (!code || !activeDataLanguage || !activeEnvName || isHistoricalEnvironmentView) {
       return
     }
 
     const target = `${activeDataLanguage}:${activeEnvName}`
-    setTerminalCode('')
     setSubmittingTarget(target)
     setActionError(null)
 
     try {
+      if (stateLoadInFlight.current && !(await stateLoadInFlight.current)) return
+      const executionState = latestNotebookState.current
+      if (executionState?.activeWrite || executionState?.activeRunId) return
+
+      setTerminalCode('')
       await window.api.notebook.execute({
         ...createNotebookRequest(item.notebook),
         code,

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -48,6 +48,7 @@ import {
 import {
   createNotebookFrameFilterOptions,
   notebookFrameLabels,
+  normalizeNotebookRootFrameRuns,
   projectNotebookRunsForFrame,
   type NotebookFrameFilterValue
 } from './session-notebook-projection'
@@ -178,7 +179,7 @@ const NotebookRunCell = ({
           <span className="font-mono text-text-300">[{index}]</span>
           <span className="rounded bg-bg-300 px-1.5 py-0.5 text-text-200">{kind}</span>
           {run.source === 'user' ? (
-            <span className="rounded bg-accent px-1.5 py-0.5 font-medium text-accent">
+            <span className="rounded bg-blue-500/10 px-1.5 py-0.5 font-medium text-blue-700 dark:text-blue-300">
               {t('you')}
             </span>
           ) : null}
@@ -444,15 +445,16 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
   }, [item.notebook.sessionId, loadNotebookState])
 
   const runs = notebookState?.runs ?? notebookState?.recentRuns ?? []
+  const frameRuns = session ? normalizeNotebookRootFrameRuns(runs, session) : runs
   const frameOptions = createNotebookFrameFilterOptions(
-    runs,
+    frameRuns,
     session ? notebookFrameLabels(session, t) : {}
   )
   const effectiveFrameFilter = frameOptions.some((option) => option.value === frameFilter)
     ? frameFilter
     : frameOptions[0]?.value
   const projectedRuns = effectiveFrameFilter
-    ? projectNotebookRunsForFrame(runs, effectiveFrameFilter)
+    ? projectNotebookRunsForFrame(frameRuns, effectiveFrameFilter)
     : []
 
   // Python and R are executable user targets even before their first run. Agent SDK and Bash remain
@@ -534,10 +536,31 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
       return (entry.environment ?? 'default-r') === (activeEnvName ?? 'default-r')
     })?.restartRecommended ??
       false)
+  const selectedTarget =
+    activeDataLanguage && activeEnvName ? `${activeDataLanguage}:${activeEnvName}` : undefined
+  const activeRun = runs.find((run) => run.runId === notebookState?.activeRunId)
+  const activeRunTarget =
+    activeRun?.kernelKind === 'python' || activeRun?.kernelKind === 'r'
+      ? `${activeRun.kernelKind}:${resolveRunEnvironment(activeRun)}`
+      : undefined
   const activeKernelStatus = activeEnvName ? envOptionStatus(activeEnvName) : undefined
+  const hasActiveKernelHistory =
+    activeDataLanguage !== undefined &&
+    activeEnvName !== undefined &&
+    kindRuns.some((run) => resolveRunEnvironment(run) === activeEnvName)
+  // A persisted `idle` status only describes the last app process. The per-environment status list is
+  // populated from kernels known to this process. Without an entry the kernel is inactive, even when
+  // this language has no history yet; only an Agent execution may activate user input.
+  const isKernelInactive =
+    activeDataLanguage !== undefined &&
+    activeEnvName !== undefined &&
+    activeKernelStatus === undefined &&
+    activeRunTarget !== selectedTarget &&
+    submittingTarget !== selectedTarget
   const isNamespaceLost =
     activeDataLanguage !== undefined &&
-    (activeKernelStatus === 'terminated' ||
+    (isKernelInactive ||
+      activeKernelStatus === 'terminated' ||
       (activeDataLanguage === 'python' &&
         activeEnvName === 'default-python' &&
         notebookState?.kernelStatus === 'terminated'))
@@ -546,13 +569,6 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
     activeEnvName !== undefined &&
     executionEnvironment !== undefined &&
     activeEnvName !== executionEnvironment
-  const selectedTarget =
-    activeDataLanguage && activeEnvName ? `${activeDataLanguage}:${activeEnvName}` : undefined
-  const activeRun = runs.find((run) => run.runId === notebookState?.activeRunId)
-  const activeRunTarget =
-    activeRun?.kernelKind === 'python' || activeRun?.kernelKind === 'r'
-      ? `${activeRun.kernelKind}:${resolveRunEnvironment(activeRun)}`
-      : undefined
   const isSubmitting = submittingTarget !== undefined
   const isSelectedKernelRunning =
     (submittingTarget !== undefined && submittingTarget === selectedTarget) ||
@@ -859,9 +875,13 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
                   environment: activeEnvName,
                   activeEnvironment: executionEnvironment
                 })
-              : activeDataLanguage === 'r'
-                ? t("R · view only; this kernel's namespace no longer exists")
-                : t("Python · view only; this kernel's namespace no longer exists")}
+              : isKernelInactive && !hasActiveKernelHistory
+                ? t('{{kernel}} · view only; the agent must activate this kernel first', {
+                    kernel: activeDataLanguage === 'r' ? 'R' : 'Python'
+                  })
+                : activeDataLanguage === 'r'
+                  ? t("R · view only; this kernel's namespace no longer exists")
+                  : t("Python · view only; this kernel's namespace no longer exists")}
           </span>
           <span className="shrink-0 tabular-nums">
             {t('{{count}} cells', {

--- a/src/renderer/src/pages/workspace/session-notebook-projection.ts
+++ b/src/renderer/src/pages/workspace/session-notebook-projection.ts
@@ -46,6 +46,22 @@ const projectNotebookRunsForFrame = (
 const notebookFrameFilterForExport = (filter: NotebookFrameFilterValue): string =>
   filter.slice('frame:'.length)
 
+// Pending Sessions keep their provisional Conversation Graph IDs when the provider later binds the
+// final Session ID. Renderer-originated terminal runs use the final Session's canonical root ID, so
+// fold that alias back into the graph root before building or applying the Agent filter.
+const normalizeNotebookRootFrameRuns = (
+  runs: readonly NotebookRunRecord[],
+  session: ChatSession
+): NotebookRunRecord[] => {
+  const rootFrameId = session.conversationGraph?.rootFrameId
+  const canonicalRootFrameId = `root-frame-${session.id}`
+  if (!rootFrameId || rootFrameId === canonicalRootFrameId) return [...runs]
+
+  return runs.map((run) =>
+    run.agentFrameId === canonicalRootFrameId ? { ...run, agentFrameId: rootFrameId } : run
+  )
+}
+
 // Takes `t` because the root frame's label is catalog copy while every delegate label is the user's
 // own name for its Subagent, which interpolates unchanged.
 const notebookFrameLabels = (session: ChatSession, t: TFunction): Record<string, string> => {
@@ -64,6 +80,7 @@ export {
   createNotebookFrameFilterOptions,
   notebookFrameFilterForExport,
   notebookFrameLabels,
+  normalizeNotebookRootFrameRuns,
   projectNotebookRunsForFrame
 }
 export type { NotebookFrameFilterOption, NotebookFrameFilterValue }


### PR DESCRIPTION
## Problem

The Notebook terminal had three related inconsistencies:

- It could show `idle` while the textarea remained disabled during a background state refresh.
- Successful user terminal runs were persisted with the canonical Session root frame ID, while a bound pending Session could retain a provisional Conversation Graph root ID. The Main Agent filter then hid the run, so no `you` cell appeared.
- After an app restart, a persisted `idle` snapshot could make Python or R appear writable even though the in-memory kernel and its namespace no longer existed. A language with no historical cells had the same problem.

## Proposed change

- Keep typing responsive during background state refreshes, but queue Enter behind the in-flight refresh and execute only from its fresh idle result.
- Normalize the canonical Session root frame alias to the Conversation Graph root before building and applying Notebook Agent filters.
- Treat only per-environment state from the current app process as an active kernel. Existing history is view-only after restart, and a language with no history is also view-only until an Agent execution activates that kernel.
- Restore input automatically when an Agent activates the selected Python or R environment.
- Render user terminal runs with a readable project blue `you` badge.
- Add sanitized main-process diagnostics for failed terminal execution/submission, including IDs, language, environment, status, run ID or code length, and the last error line without logging source code.

## Historical compatibility

- Existing Sessions may contain provisional Conversation Graph root IDs together with canonical root IDs on renderer-originated terminal runs.
- The renderer now aliases those existing records at projection time; no historical data rewrite or migration is required.

## State and persistence

- No new status enum or enum value.
- No persisted schema or field changes.
- No replay of historical cells and no namespace restoration are introduced.
- Existing `run.json` records remain unchanged; normalization is read-time only.

## Validation

All checks ran after the final material edit:

- `npx vitest run src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx src/main/notebook/ipc.test.ts src/renderer/src/i18n/resources.test.ts`
  - 3 files / 629 tests passed.
- `npm run typecheck`
  - Node and web typechecks passed.
- `npm run lint`
  - passed.
- `git diff --check`
  - passed.
- PR Gate, Module tests and coverage, macOS build and E2E, CodeQL, CI Integrity, and AI review
  - passed on `7a51e6a3`.

The complete local `npm test` suite was not run per maintainer direction; exact-head PR Gate is authoritative for the complete portable and platform plan.

## Review focus

- User terminal runs remain visible in the Main Agent view after a pending Session binds its final ID.
- A restarted or never-activated kernel is view-only even if the persisted aggregate status says `idle`.
- Agent execution activates the selected kernel and restores input without replaying historical cells.
- Failure diagnostics identify the execution target and outcome without exposing submitted code.