### PR TITLE
fix(workspace): keep live Send now without hung resume or interrupt

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -601,10 +601,10 @@ colors communicate a successful or failed probe/migration result.
   Up/Arrow Down keyboard reordering, Edit, Remove, and Send now. Edit moves an item back into an
   unchanged empty composer. Send now promotes the item and first tries to inject it into the current
   run through the agent framework's native follow-up, without cancelling that run. While inject is in
-  flight, the row shows a sending state. If inject is unavailable or refused, Send now stops the live
-  turn and dispatches the promoted item as soon as the Session becomes sendable; the row shows a
-  stopping state while cancellation is in flight. Stop remains the explicit control for cancelling a
-  live turn without sending a queued message. Branch, admission, cancellation, or edit failures keep
+  flight, the row shows a sending state. If inject is unavailable or refused, Send now keeps the live
+  turn and sends the promoted item after that run finishes; the row returns to queued. Stop remains
+  the explicit control for cancelling a live turn without sending a queued message. Branch, admission,
+  cancellation, or edit failures keep
   the row and show a recoverable inline error.
 - Queued messages are transient and Session-scoped. They are not persisted across renderer restart.
   Bind each item to its admission Message Branch and block branch switching or inline message edits

--- a/src/main/acp/application-commands.test.ts
+++ b/src/main/acp/application-commands.test.ts
@@ -494,17 +494,60 @@ describe('ACP application commands', () => {
         invocation([{ sessionId: 'session-1', reason: 'manual' }])
       )
     ).rejects.toThrow('Restore this archived Session before continuing.')
-    await expect(
-      router.dispatcher.invoke(
-        acpCommands.steerFollowUp,
-        invocation([{ sessionId: 'session-1', text: 'focus on tests' }])
-      )
-    ).rejects.toThrow('Restore this archived Session before continuing.')
-
-    expect(admittedById).toHaveBeenCalledTimes(3)
+    expect(admittedById).toHaveBeenCalledTimes(2)
     expect(admittedById).toHaveBeenCalledWith(request.sessionId)
     expect(dependencies.runtime.resetSessionContext).not.toHaveBeenCalled()
     expect(dependencies.runtime.compactSession).not.toHaveBeenCalled()
+  })
+
+  it('does not nest Session admission around the coordinator follow-up guard', async () => {
+    let archiveQueue: Promise<void> = Promise.resolve()
+    const enqueueArchive = <Result>(operation: () => Promise<Result>): Promise<Result> => {
+      const result = archiveQueue.then(operation, operation)
+      archiveQueue = result.then(
+        () => undefined,
+        () => undefined
+      )
+      return result
+    }
+    const base = createDependencies()
+    const withSessionAvailableById = <Result>(
+      _sessionId: string,
+      operation: () => Promise<Result>
+    ): Promise<Result> => enqueueArchive(operation)
+    const dependencies: AcpApplicationCommandDependencies = {
+      ...base,
+      runtime: {
+        ...base.runtime,
+        steerFollowUp: vi.fn(() =>
+          withSessionAvailableById('session-1', async () => ({
+            injected: false as const,
+            reason: 'prompt-required' as const
+          }))
+        )
+      },
+      archiveAvailability: {
+        withSessionAvailable: async <Result>(
+          _projectId: string,
+          _sessionId: string,
+          operation: () => Promise<Result>
+        ): Promise<Result> => operation(),
+        withSessionAvailableById
+      }
+    }
+    const router = createApplicationCommandRouter()
+    registerAcpCommands(router.registrar, dependencies)
+
+    const outcome = await Promise.race([
+      router.dispatcher.invoke(
+        acpCommands.steerFollowUp,
+        invocation([{ sessionId: 'session-1', text: 'focus on tests' }])
+      ),
+      new Promise<'timed-out'>((resolve) => setTimeout(() => resolve('timed-out'), 50))
+    ])
+
+    expect(outcome).toEqual({ injected: false, reason: 'prompt-required' })
+    expect(dependencies.runtime.steerFollowUp).toHaveBeenCalledOnce()
   })
 
   it('holds Session admission through ACP response mutations', async () => {

--- a/src/main/acp/application-commands.ts
+++ b/src/main/acp/application-commands.ts
@@ -243,12 +243,7 @@ const registerAcpCommands = (
         })
       },
       'acp:steer-follow-up': (invocation) =>
-        dependencies.archiveAvailability
-          ? dependencies.archiveAvailability.withSessionAvailableById(
-              invocation.args[0].sessionId,
-              () => dependencies.runtime.steerFollowUp(invocation.args[0])
-            )
-          : dependencies.runtime.steerFollowUp(invocation.args[0]),
+        dependencies.runtime.steerFollowUp(invocation.args[0]),
       'acp:save-as-skill': (invocation) => {
         if (!canSatisfyHumanApproval(invocation.callerContext)) {
           throw new Error('Only a current human caller can save a Session as a Skill.')

--- a/src/main/acp/context-compaction-workflow.test.ts
+++ b/src/main/acp/context-compaction-workflow.test.ts
@@ -224,6 +224,52 @@ describe('AcpContextCompactionWorkflow', () => {
     expect(harness.interactions.current('app-session')).toBeUndefined()
   })
 
+  it('starts automatic compaction after idle when the native threshold is reached', async () => {
+    const session = fakeSession([stop('end_turn')])
+    const harness = createHarness({ session })
+    harness.context.reconcileProviderUsage('app-session', { used: 180_000, size: 200_000 })
+
+    await expect(harness.workflow.compactIfIdle('app-session')).resolves.toEqual({
+      stopReason: 'end_turn'
+    })
+    expect(session.prompt).toHaveBeenCalledWith([{ type: 'text', text: '/compact' }])
+    expect(
+      harness.events.map(({ compactionReason, status }) => ({ compactionReason, status }))
+    ).toEqual([
+      { compactionReason: 'automatic', status: 'in_progress' },
+      { compactionReason: 'automatic', status: 'completed' }
+    ])
+    expect(harness.interactions.current('app-session')).toBeUndefined()
+  })
+
+  it('does not compact while idle when no native threshold is declared', async () => {
+    const session = fakeSession([stop('end_turn')])
+    const harness = createHarness({
+      session,
+      framework: {
+        ...claudeCodeFramework,
+        id: 'codex',
+        displayName: 'Codex',
+        contextCompaction: { kind: 'native-command', command: '/compact' }
+      }
+    })
+    harness.context.reconcileProviderUsage('app-session', { used: 180_000, size: 200_000 })
+
+    await expect(harness.workflow.compactIfIdle('app-session')).resolves.toBeUndefined()
+    expect(session.prompt).not.toHaveBeenCalled()
+  })
+
+  it('does not compact while another interaction is current', async () => {
+    const session = fakeSession([stop('end_turn')])
+    const harness = createHarness({ session })
+    harness.context.reconcileProviderUsage('app-session', { used: 180_000, size: 200_000 })
+    const prompt = harness.interactions.claim({ sessionId: 'app-session', kind: 'prompt' })
+
+    await expect(harness.workflow.compactIfIdle('app-session')).resolves.toBeUndefined()
+    expect(session.prompt).not.toHaveBeenCalled()
+    harness.interactions.release(prompt)
+  })
+
   it('gates automatic compaction and preserves the current prompt interaction when eligible', async () => {
     const session = fakeSession([stop('end_turn')])
     const harness = createHarness({ session })

--- a/src/main/acp/context-compaction-workflow.test.ts
+++ b/src/main/acp/context-compaction-workflow.test.ts
@@ -66,7 +66,9 @@ const frameworkManaged = {
 const createHarness = (input?: {
   framework?: AgentFramework
   session?: FakeSession
+  cancelCompaction?: (sessionId: string) => Promise<void>
 }): {
+  cancelCompaction: ReturnType<typeof vi.fn>
   context: ContextUsageTracker
   emitState: ReturnType<typeof vi.fn>
   events: Array<Partial<AcpRuntimeEvent>>
@@ -91,6 +93,7 @@ const createHarness = (input?: {
   const pushEvent = vi.fn((event: Partial<AcpRuntimeEvent>) => events.push(event))
   const routeHiddenNotification = vi.fn()
   const emitState = vi.fn()
+  const cancelCompaction = vi.fn(input?.cancelCompaction ?? (async () => undefined))
   const workflow = new AcpContextCompactionWorkflow({
     sessions: {
       activeSession: (sessionId) => (sessionId === 'app-session' ? activeSession : undefined),
@@ -104,10 +107,12 @@ const createHarness = (input?: {
     routeHiddenNotification,
     pushEvent,
     emitState,
-    errorMessage: (error) => (error instanceof Error ? error.message : String(error))
+    errorMessage: (error) => (error instanceof Error ? error.message : String(error)),
+    cancelCompaction
   })
 
   return {
+    cancelCompaction,
     context,
     emitState,
     events,
@@ -268,6 +273,44 @@ describe('AcpContextCompactionWorkflow', () => {
     await expect(harness.workflow.compactIfIdle('app-session')).resolves.toBeUndefined()
     expect(session.prompt).not.toHaveBeenCalled()
     harness.interactions.release(prompt)
+  })
+
+  it('does not compact while a prompt is reserved for preflight', async () => {
+    const session = fakeSession([stop('end_turn')])
+    const harness = createHarness({ session })
+    harness.context.reconcileProviderUsage('app-session', { used: 180_000, size: 200_000 })
+    const prompt = harness.interactions.reservePrompt({
+      sessionId: 'app-session',
+      kind: 'prompt'
+    })
+
+    await expect(harness.workflow.compactIfIdle('app-session')).resolves.toBeUndefined()
+    expect(session.prompt).not.toHaveBeenCalled()
+    harness.interactions.release(prompt)
+  })
+
+  it('cancels and drains an owned compaction before admitting a prompt', async () => {
+    const completion = deferred<NextUpdate>()
+    const session = fakeSession([completion.promise])
+    const harness = createHarness({ session })
+    harness.context.reconcileProviderUsage('app-session', { used: 180_000, size: 200_000 })
+
+    const compaction = harness.workflow.compactIfIdle('app-session')
+    const preemption = harness.workflow.preemptForPrompt('app-session')
+    if (!preemption) throw new Error('Expected active compaction preemption')
+    let preemptionSettled = false
+    void preemption.finally(() => {
+      preemptionSettled = true
+    })
+
+    expect(harness.cancelCompaction).toHaveBeenCalledWith('app-session')
+    await Promise.resolve()
+    expect(preemptionSettled).toBe(false)
+
+    completion.resolve(stop('cancelled'))
+    await expect(preemption).resolves.toBeUndefined()
+    await expect(compaction).resolves.toEqual({ stopReason: 'cancelled' })
+    expect(harness.interactions.current('app-session')).toBeUndefined()
   })
 
   it('gates automatic compaction and preserves the current prompt interaction when eligible', async () => {

--- a/src/main/acp/context-compaction-workflow.ts
+++ b/src/main/acp/context-compaction-workflow.ts
@@ -84,6 +84,24 @@ class AcpContextCompactionWorkflow {
     return this.runNative(request.session, request.sessionId, 'automatic')
   }
 
+  async compactIfIdle(sessionId: string): Promise<PromptResponse | undefined> {
+    if (this.options.interactions.current(sessionId)) return undefined
+    if (!this.shouldCompactAutomatically(sessionId)) return undefined
+    const session = this.options.sessions.activeSession(sessionId)
+    if (!session) return undefined
+    const { interactions } = this.options
+    const interaction = interactions.claim({ sessionId, kind: 'compaction' })
+    try {
+      this.safeProjection('compaction state callback failed', this.options.emitState)
+      return await this.runNative(session, sessionId, 'automatic')
+    } catch {
+      return undefined
+    } finally {
+      interactions.release(interaction)
+      this.safeProjection('compaction state callback failed', this.options.emitState)
+    }
+  }
+
   private shouldCompactAutomatically(sessionId: string): boolean {
     const strategy = this.options.sessions.currentFramework().contextCompaction
     if (strategy.kind !== 'native-command' || strategy.triggerAtPercent === undefined) return false

--- a/src/main/acp/context-compaction-workflow.ts
+++ b/src/main/acp/context-compaction-workflow.ts
@@ -8,6 +8,7 @@ import type { ContextUsageTracker, SessionEstimateInput } from './context-usage-
 import type { AcpPromptContentOwner } from './prompt-content-owner'
 import type { RuntimeEventInput } from './runtime-snapshot-owner'
 import type {
+  AcpCompactionSessionInteractionScope,
   AcpPromptSessionInteractionScope,
   AcpSessionInteractionOwner
 } from './session-interaction-owner'
@@ -19,7 +20,10 @@ type AcpContextCompactionSessions = Readonly<{
 
 type AcpContextCompactionWorkflowOptions = Readonly<{
   sessions: AcpContextCompactionSessions
-  interactions: Pick<AcpSessionInteractionOwner, 'claim' | 'current' | 'release' | 'supersede'>
+  interactions: Pick<
+    AcpSessionInteractionOwner,
+    'claim' | 'current' | 'has' | 'release' | 'supersede'
+  >
   context: Pick<
     ContextUsageTracker,
     'checkpointSession' | 'resetAfterCompaction' | 'restoreSession' | 'usage'
@@ -31,6 +35,7 @@ type AcpContextCompactionWorkflowOptions = Readonly<{
   pushEvent: (event: RuntimeEventInput) => void
   emitState: () => void
   errorMessage: (error: unknown) => string
+  cancelCompaction: (sessionId: string) => Promise<void>
 }>
 
 type AcpAutomaticCompactionRequest = Readonly<{
@@ -44,6 +49,15 @@ type CompactionReason = NonNullable<AcpRuntimeEvent['compactionReason']>
 const log = createLogger('acp-context-compaction-workflow')
 
 class AcpContextCompactionWorkflow {
+  private readonly activeCompactions = new Map<
+    string,
+    {
+      interaction: AcpCompactionSessionInteractionScope
+      promise: Promise<PromptResponse>
+      cancellation?: Promise<void>
+    }
+  >()
+
   constructor(private readonly options: AcpContextCompactionWorkflowOptions) {}
 
   async compact(request: AcpCompactSessionRequest): Promise<PromptResponse> {
@@ -62,13 +76,12 @@ class AcpContextCompactionWorkflow {
     }
 
     const interaction = interactions.claim({ sessionId: request.sessionId, kind: 'compaction' })
-    try {
-      this.safeProjection('compaction state callback failed', this.options.emitState)
-      return await this.runNative(session, request.sessionId, request.reason ?? 'manual')
-    } finally {
-      interactions.release(interaction)
-      this.safeProjection('compaction state callback failed', this.options.emitState)
-    }
+    return this.runOwnedCompaction(
+      session,
+      request.sessionId,
+      request.reason ?? 'manual',
+      interaction
+    )
   }
 
   async compactAutomatic(
@@ -85,21 +98,72 @@ class AcpContextCompactionWorkflow {
   }
 
   async compactIfIdle(sessionId: string): Promise<PromptResponse | undefined> {
-    if (this.options.interactions.current(sessionId)) return undefined
+    if (this.options.interactions.has(sessionId)) return undefined
     if (!this.shouldCompactAutomatically(sessionId)) return undefined
     const session = this.options.sessions.activeSession(sessionId)
     if (!session) return undefined
     const { interactions } = this.options
     const interaction = interactions.claim({ sessionId, kind: 'compaction' })
     try {
-      this.safeProjection('compaction state callback failed', this.options.emitState)
-      return await this.runNative(session, sessionId, 'automatic')
+      return await this.runOwnedCompaction(session, sessionId, 'automatic', interaction)
     } catch {
       return undefined
-    } finally {
-      interactions.release(interaction)
-      this.safeProjection('compaction state callback failed', this.options.emitState)
     }
+  }
+
+  preemptForPrompt(sessionId: string): Promise<void> | undefined {
+    const current = this.options.interactions.current(sessionId)
+    if (current?.kind !== 'compaction') return
+
+    const active = this.activeCompactions.get(sessionId)
+    if (!active || active.interaction !== current) {
+      throw new Error('ACP context compaction lifecycle is unavailable')
+    }
+    return this.cancelAndDrain(sessionId, active)
+  }
+
+  private async cancelAndDrain(
+    sessionId: string,
+    active: {
+      interaction: AcpCompactionSessionInteractionScope
+      promise: Promise<PromptResponse>
+      cancellation?: Promise<void>
+    }
+  ): Promise<void> {
+    active.cancellation ??= this.options.cancelCompaction(sessionId)
+    await active.cancellation
+    try {
+      await active.promise
+    } catch {
+      // The compaction lifecycle already publishes its failure. Provider settlement is the gate.
+    }
+  }
+
+  private runOwnedCompaction(
+    session: ActiveSession,
+    sessionId: string,
+    reason: CompactionReason,
+    interaction: AcpCompactionSessionInteractionScope
+  ): Promise<PromptResponse> {
+    const promise = (async (): Promise<PromptResponse> => {
+      try {
+        this.safeProjection('compaction state callback failed', this.options.emitState)
+        return await this.runNative(session, sessionId, reason)
+      } finally {
+        this.options.interactions.release(interaction)
+        this.safeProjection('compaction state callback failed', this.options.emitState)
+      }
+    })()
+    const active = { interaction, promise }
+    this.activeCompactions.set(sessionId, active)
+    void promise
+      .finally(() => {
+        if (this.activeCompactions.get(sessionId) === active) {
+          this.activeCompactions.delete(sessionId)
+        }
+      })
+      .catch(() => undefined)
+    return promise
   }
 
   private shouldCompactAutomatically(sessionId: string): boolean {

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -1126,19 +1126,41 @@ describe('installAcpIpcHandlers — reset-session-context bridge', () => {
     expect(resetSessionContext).not.toHaveBeenCalled()
   })
 
-  it('rejects follow-up before runtime mutation when Session admission is closed', async () => {
-    const failure = new Error('Project is being deleted.')
-    const withSessionAvailableById = vi.fn().mockRejectedValue(failure)
-    const steerFollowUp = vi.fn()
-    installAcpIpcHandlers({ steerFollowUp } as never, {} as never, undefined, {
-      withSessionAvailableById
-    })
+  it('does not nest Session admission around the coordinator follow-up guard', async () => {
+    let archiveQueue: Promise<void> = Promise.resolve()
+    const enqueueArchive = <Result>(operation: () => Promise<Result>): Promise<Result> => {
+      const result = archiveQueue.then(operation, operation)
+      archiveQueue = result.then(
+        () => undefined,
+        () => undefined
+      )
+      return result
+    }
+    const archiveAvailability = {
+      withSessionAvailableById: <Result>(
+        _sessionId: string,
+        operation: () => Promise<Result>
+      ): Promise<Result> => enqueueArchive(operation)
+    }
+    const withSessionAvailableById = vi.spyOn(archiveAvailability, 'withSessionAvailableById')
+    const steerFollowUp = vi.fn(() =>
+      archiveAvailability.withSessionAvailableById('s-1', async () => ({
+        injected: false as const,
+        reason: 'prompt-required' as const
+      }))
+    )
+    installAcpIpcHandlers({ steerFollowUp } as never, {} as never, undefined, archiveAvailability)
     const request: AcpSteerFollowUpRequest = { sessionId: 's-1', text: 'focus on tests' }
 
-    await expect(handlers.get('acp:steer-follow-up')?.({}, request)).rejects.toBe(failure)
+    const outcome = await Promise.race([
+      Promise.resolve(handlers.get('acp:steer-follow-up')?.({}, request)),
+      new Promise<'timed-out'>((resolve) => setTimeout(() => resolve('timed-out'), 50))
+    ])
 
+    expect(outcome).toEqual({ injected: false, reason: 'prompt-required' })
     expect(withSessionAvailableById).toHaveBeenCalledWith('s-1', expect.any(Function))
-    expect(steerFollowUp).not.toHaveBeenCalled()
+    expect(withSessionAvailableById).toHaveBeenCalledOnce()
+    expect(steerFollowUp).toHaveBeenCalledWith(request)
   })
 })
 

--- a/src/main/acp/ipc.ts
+++ b/src/main/acp/ipc.ts
@@ -94,20 +94,18 @@ const registerAcpIpcHandlerSet = (
     return workflows.sendPrompt(rendererRequest)
   })
   ipcMainHandle('acp:steer-follow-up', (_event, request: AcpSteerFollowUpRequest) =>
-    sessionAdmission.withSessionAvailableById(request.sessionId, () =>
-      runtime.steerFollowUp({
-        sessionId: request.sessionId,
-        text: typeof request.text === 'string' ? request.text : '',
-        ...(Array.isArray(request.attachments) ? { attachments: request.attachments } : {}),
-        ...(Array.isArray(request.referencedArtifacts)
-          ? { referencedArtifacts: request.referencedArtifacts }
-          : {}),
-        ...(Array.isArray(request.forcedSkillIds)
-          ? { forcedSkillIds: request.forcedSkillIds }
-          : {}),
-        ...(Array.isArray(request.parts) ? { parts: request.parts } : {})
-      })
-    )
+    runtime.steerFollowUp({
+      sessionId: request.sessionId,
+      text: typeof request.text === 'string' ? request.text : '',
+      ...(Array.isArray(request.attachments) ? { attachments: request.attachments } : {}),
+      ...(Array.isArray(request.referencedArtifacts)
+        ? { referencedArtifacts: request.referencedArtifacts }
+        : {}),
+      ...(Array.isArray(request.forcedSkillIds)
+        ? { forcedSkillIds: request.forcedSkillIds }
+        : {}),
+      ...(Array.isArray(request.parts) ? { parts: request.parts } : {})
+    })
   )
   ipcMainHandle('acp:save-as-skill', (_event, request: AcpSaveAsSkillRequest) =>
     workflows.saveAsSkill(request)

--- a/src/main/acp/prompt-outcome-finalizer.test.ts
+++ b/src/main/acp/prompt-outcome-finalizer.test.ts
@@ -148,14 +148,13 @@ describe('AcpPromptOutcomeFinalizer', () => {
       'state',
       'artifact:publish',
       'event:stop',
-      'compact',
       'prepared:close',
       'artifact:dispose',
       'interaction:before-release',
       'permission:clear',
       'context:supersede',
-      'interaction:after-release',
       'prompt:end',
+      'interaction:after-release',
       'state',
       'skill:completed',
       'activity'
@@ -410,26 +409,32 @@ describe('AcpPromptOutcomeFinalizer', () => {
     expect(harness.context.supersede).toHaveBeenCalledOnce()
   })
 
-  it('does not wait on automatic compaction after a cancelled provider stop', async () => {
-    const harness = createHarness()
-    const compact = deferred()
-    harness.handles.autoCompactIfNeeded = vi.fn(async () => compact.promise)
-    expect(harness.interactions.captureTerminal(harness.interaction, 'cancelled')).toBe(true)
+  it.each([
+    { stopReason: 'end_turn' as const, terminal: 'stop' as const },
+    { stopReason: 'cancelled' as const, terminal: 'cancelled' as const }
+  ])(
+    'does not wait on automatic compaction after a $stopReason provider stop',
+    async ({ stopReason, terminal }) => {
+      const harness = createHarness()
+      const compact = deferred()
+      harness.handles.autoCompactIfNeeded = vi.fn(async () => compact.promise)
+      expect(harness.interactions.captureTerminal(harness.interaction, terminal)).toBe(true)
 
-    const finalization = new AcpPromptOutcomeFinalizer().finalize(
-      harness.handles,
-      stopped({ stopReason: 'cancelled' })
-    )
-    const completed = Promise.race([
-      finalization.then(() => 'settled' as const),
-      new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 50))
-    ])
+      const finalization = new AcpPromptOutcomeFinalizer().finalize(
+        harness.handles,
+        stopped({ stopReason })
+      )
+      const completed = Promise.race([
+        finalization.then(() => 'settled' as const),
+        new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 50))
+      ])
 
-    await expect(completed).resolves.toBe('settled')
-    expect(harness.handles.autoCompactIfNeeded).not.toHaveBeenCalled()
-    expect(harness.interactions.current('s1')).toBeUndefined()
-    compact.resolve()
-  })
+      await expect(completed).resolves.toBe('settled')
+      expect(harness.handles.autoCompactIfNeeded).not.toHaveBeenCalled()
+      expect(harness.interactions.current('s1')).toBeUndefined()
+      compact.resolve()
+    }
+  )
 
   it('publishes a cancelled stop for a current prompt that was not dispatched', async () => {
     const harness = createHarness({ now: () => 456 })

--- a/src/main/acp/prompt-outcome-finalizer.test.ts
+++ b/src/main/acp/prompt-outcome-finalizer.test.ts
@@ -410,6 +410,27 @@ describe('AcpPromptOutcomeFinalizer', () => {
     expect(harness.context.supersede).toHaveBeenCalledOnce()
   })
 
+  it('does not wait on automatic compaction after a cancelled provider stop', async () => {
+    const harness = createHarness()
+    const compact = deferred()
+    harness.handles.autoCompactIfNeeded = vi.fn(async () => compact.promise)
+    expect(harness.interactions.captureTerminal(harness.interaction, 'cancelled')).toBe(true)
+
+    const finalization = new AcpPromptOutcomeFinalizer().finalize(
+      harness.handles,
+      stopped({ stopReason: 'cancelled' })
+    )
+    const completed = Promise.race([
+      finalization.then(() => 'settled' as const),
+      new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 50))
+    ])
+
+    await expect(completed).resolves.toBe('settled')
+    expect(harness.handles.autoCompactIfNeeded).not.toHaveBeenCalled()
+    expect(harness.interactions.current('s1')).toBeUndefined()
+    compact.resolve()
+  })
+
   it('publishes a cancelled stop for a current prompt that was not dispatched', async () => {
     const harness = createHarness({ now: () => 456 })
 

--- a/src/main/acp/prompt-outcome-finalizer.ts
+++ b/src/main/acp/prompt-outcome-finalizer.ts
@@ -251,10 +251,14 @@ export class AcpPromptOutcomeFinalizer {
       await emitArtifact()
       safeLog('info', 'prompt stopped', { stopReason: response.stopReason })
       publishObservedStop()
-      try {
-        await handles.autoCompactIfNeeded()
-      } catch (error) {
-        safeLog('warn', 'automatic context compaction failed', errorLogFields(error))
+      // Cancelled turns must not start native compact: that second provider prompt can block
+      // behind the aborting stream and leave the next `acp:send-prompt` without a reply.
+      if (response.stopReason !== 'cancelled') {
+        try {
+          await handles.autoCompactIfNeeded()
+        } catch (error) {
+          safeLog('warn', 'automatic context compaction failed', errorLogFields(error))
+        }
       }
       return response
     } catch (error) {

--- a/src/main/acp/prompt-outcome-finalizer.ts
+++ b/src/main/acp/prompt-outcome-finalizer.ts
@@ -251,15 +251,9 @@ export class AcpPromptOutcomeFinalizer {
       await emitArtifact()
       safeLog('info', 'prompt stopped', { stopReason: response.stopReason })
       publishObservedStop()
-      // Cancelled turns must not start native compact: that second provider prompt can block
-      // behind the aborting stream and leave the next `acp:send-prompt` without a reply.
-      if (response.stopReason !== 'cancelled') {
-        try {
-          await handles.autoCompactIfNeeded()
-        } catch (error) {
-          safeLog('warn', 'automatic context compaction failed', errorLogFields(error))
-        }
-      }
+      // Automatic compact is a follow-on provider prompt. Awaiting it here keeps the current
+      // sendPrompt admission lease and `promptInFlight` until compact finishes, so a queued
+      // follow-up `acp:send-prompt` never replies. Compact after the prompt interaction releases.
       return response
     } catch (error) {
       if (observedStop) {
@@ -333,12 +327,12 @@ export class AcpPromptOutcomeFinalizer {
       safeCleanup('context cleanup failed', () => context?.supersede())
       safeCleanup('interaction cleanup failed', () => interactions.release(interaction))
       if (ownsInteraction) {
+        safeCleanup('prompt-end callback failed', handles.onPromptEnded)
         try {
           await handles.afterInteractionRelease()
         } catch (error) {
           safeLog('error', 'interaction post-release failed', errorLogFields(error))
         }
-        safeCleanup('prompt-end callback failed', handles.onPromptEnded)
       }
       safeCleanup('emitState after prompt turn failed', handles.emitState)
       safeCleanup('prompt skill cleanup failed', () => handles.skill.close(skillOutcome))

--- a/src/main/acp/prompt-turn-workflow.test.ts
+++ b/src/main/acp/prompt-turn-workflow.test.ts
@@ -37,6 +37,7 @@ type Harness = {
       AcpPromptTurnWorkflowOptions['finalization']['generationActivityChanged']
     >
     autoCompact: Mock<AcpPromptTurnWorkflowOptions['finalization']['autoCompact']>
+    compactIfIdle: Mock<AcpPromptTurnWorkflowOptions['finalization']['compactIfIdle']>
   }
   finalizer: Mock<AcpPromptOutcomeFinalizer['finalize']>
   interactions: {
@@ -47,6 +48,7 @@ type Harness = {
     captureTerminal: Mock<AcpSessionInteractionOwner['captureTerminal']>
     settle: Mock<AcpSessionInteractionOwner['settle']>
     release: Mock<AcpSessionInteractionOwner['release']>
+    supersede: Mock<AcpSessionInteractionOwner['supersede']>
   }
   journal: string[]
   onProviderPromptAccepted: Mock<
@@ -187,7 +189,8 @@ const createHarness = (
       owner.captureTerminal(...args)
     ),
     settle: vi.fn((...args: Parameters<typeof owner.settle>) => owner.settle(...args)),
-    release: vi.fn((scope: Parameters<typeof owner.release>[0]) => owner.release(scope))
+    release: vi.fn((scope: Parameters<typeof owner.release>[0]) => owner.release(scope)),
+    supersede: vi.fn((scope: Parameters<typeof owner.supersede>[0]) => owner.supersede(scope))
   }
   const skill = skillHandle()
   const authorize: Harness['authorize'] = vi.fn(() => {
@@ -269,7 +272,8 @@ const createHarness = (
     pushEvent: vi.fn(),
     onPromptEnded: vi.fn(),
     generationActivityChanged: vi.fn(),
-    autoCompact: vi.fn(async () => undefined)
+    autoCompact: vi.fn(async () => undefined),
+    compactIfIdle: vi.fn(async () => undefined)
   }
   const pushUserMessage: Harness['pushUserMessage'] = vi.fn(() => {
     journal.push('event:message')
@@ -740,6 +744,7 @@ describe('AcpPromptTurnWorkflow', () => {
     await handles.afterInteractionRelease()
     expect(harness.planLifecycle.beforeRelease).toHaveBeenCalledWith('s1', interaction)
     expect(harness.planLifecycle.afterRelease).toHaveBeenCalledWith('s1')
+    expect(harness.finalization.compactIfIdle).toHaveBeenCalledWith('s1')
   })
 
   it('reads the current Session Compute execution targets for every Turn preparation', async () => {

--- a/src/main/acp/prompt-turn-workflow.test.ts
+++ b/src/main/acp/prompt-turn-workflow.test.ts
@@ -38,6 +38,7 @@ type Harness = {
     >
     autoCompact: Mock<AcpPromptTurnWorkflowOptions['finalization']['autoCompact']>
     compactIfIdle: Mock<AcpPromptTurnWorkflowOptions['finalization']['compactIfIdle']>
+    preemptCompaction: Mock<AcpPromptTurnWorkflowOptions['finalization']['preemptCompaction']>
   }
   finalizer: Mock<AcpPromptOutcomeFinalizer['finalize']>
   interactions: {
@@ -130,6 +131,7 @@ const createHarness = (
     finalize?: AcpPromptOutcomeFinalizer['finalize']
     onPromptStarted?: () => void
     preflightPlan?: AcpPromptTurnWorkflowOptions['plan']['preflight']
+    preemptCompaction?: AcpPromptTurnWorkflowOptions['finalization']['preemptCompaction']
     prepare?: AcpPromptTurnWorkflowOptions['preparation']['prepare']
     providerReconnectPending?: () => boolean
     resolveComputeExecutionTargetIds?: (sessionId: string) => readonly string[]
@@ -273,7 +275,11 @@ const createHarness = (
     onPromptEnded: vi.fn(),
     generationActivityChanged: vi.fn(),
     autoCompact: vi.fn(async () => undefined),
-    compactIfIdle: vi.fn(async () => undefined)
+    compactIfIdle: vi.fn(async () => undefined),
+    preemptCompaction: vi.fn((sessionId) => {
+      journal.push('compaction:preempt')
+      return input.preemptCompaction?.(sessionId)
+    })
   }
   const pushUserMessage: Harness['pushUserMessage'] = vi.fn(() => {
     journal.push('event:message')
@@ -376,9 +382,11 @@ describe('AcpPromptTurnWorkflow', () => {
       promptAttemptId: 'attempt-1'
     })
 
-    expect(harness.journal.slice(0, 9)).toEqual([
-      'preflight',
+    await vi.waitFor(() => expect(harness.interactions.activatePrompt).toHaveBeenCalledOnce())
+    expect(harness.journal.slice(0, 10)).toEqual([
       'reserve',
+      'compaction:preempt',
+      'preflight',
       'authorize',
       'activate',
       'admit',
@@ -389,8 +397,9 @@ describe('AcpPromptTurnWorkflow', () => {
     ])
     await expect(turn).resolves.toEqual({ stopReason: 'end_turn' })
     expect(harness.journal).toEqual([
-      'preflight',
       'reserve',
+      'compaction:preempt',
+      'preflight',
       'authorize',
       'activate',
       'admit',
@@ -585,12 +594,12 @@ describe('AcpPromptTurnWorkflow', () => {
     expect(harness.executor.mock.calls[0][0].session).toBe(reloaded)
   })
 
-  it('finishes Plan preflight before reserving and admits only an activated interaction', async () => {
+  it('reserves before Plan preflight and admits only an activated interaction', async () => {
     const harness = createHarness()
 
     await harness.workflow.run(request(), { kind: 'user' })
 
-    expect(harness.journal.indexOf('preflight')).toBeLessThan(harness.journal.indexOf('reserve'))
+    expect(harness.journal.indexOf('reserve')).toBeLessThan(harness.journal.indexOf('preflight'))
     expect(harness.journal.indexOf('activate')).toBeLessThan(harness.journal.indexOf('admit'))
     expect(harness.admitPlan.mock.calls[0][1]).toBe(
       harness.interactions.activatePrompt.mock.results[0].value
@@ -602,7 +611,25 @@ describe('AcpPromptTurnWorkflow', () => {
       }
     })
     await expect(rejected.workflow.run(request(), { kind: 'user' })).rejects.toThrow('stale Plan')
-    expect(rejected.interactions.reservePrompt).not.toHaveBeenCalled()
+    expect(rejected.interactions.reservePrompt).toHaveBeenCalledOnce()
+    expect(rejected.interactions.release).toHaveBeenCalledWith(
+      rejected.interactions.reservePrompt.mock.results[0].value
+    )
+  })
+
+  it('waits for provider compaction to drain before Plan preflight', async () => {
+    const drained = deferred<void>()
+    const harness = createHarness({ preemptCompaction: () => drained.promise })
+
+    const turn = harness.workflow.run(request(), { kind: 'user' })
+    await vi.waitFor(() => expect(harness.finalization.preemptCompaction).toHaveBeenCalledOnce())
+
+    expect(harness.interactions.reservePrompt).toHaveBeenCalledOnce()
+    expect(harness.preflightPlan).not.toHaveBeenCalled()
+
+    drained.resolve(undefined)
+    await expect(turn).resolves.toEqual({ stopReason: 'end_turn' })
+    expect(harness.preflightPlan).toHaveBeenCalledOnce()
   })
 
   it('keeps an admitted turn running when the prompt-start callback throws', async () => {
@@ -616,7 +643,7 @@ describe('AcpPromptTurnWorkflow', () => {
       stopReason: 'end_turn'
     })
     expect(harness.finalizer).toHaveBeenCalledOnce()
-    expect(harness.journal.slice(6, 10)).toEqual(['handoff', 'start', 'state', 'artifact:open'])
+    expect(harness.journal.slice(7, 11)).toEqual(['handoff', 'start', 'state', 'artifact:open'])
   })
 
   it('finalizes a cancellation after Artifact activation without preparing or dispatching', async () => {

--- a/src/main/acp/prompt-turn-workflow.ts
+++ b/src/main/acp/prompt-turn-workflow.ts
@@ -134,6 +134,7 @@ type AcpPromptTurnFinalization = Readonly<{
     interaction: AcpPromptSessionInteractionScope
   ) => Promise<unknown>
   compactIfIdle: (sessionId: string) => Promise<unknown>
+  preemptCompaction: (sessionId: string) => Promise<void> | undefined
 }>
 
 type AcpPromptTurnWorkflowOptions = Readonly<{
@@ -147,7 +148,6 @@ type AcpPromptTurnWorkflowOptions = Readonly<{
     | 'release'
     | 'reservePrompt'
     | 'settle'
-    | 'supersede'
   >
   skills: Pick<AcpTurnSkillOwner, 'authorize'>
   preparation: Pick<AcpPromptPreparationOwner, 'prepare'>
@@ -182,11 +182,14 @@ class AcpPromptTurnWorkflow {
     if (!activeSession) throw new Error(`ACP session not found: ${request.sessionId}`)
     this.assertSessionIdle(request.sessionId)
 
-    const planPreflight = this.options.plan.preflight(request)
-    let plan = planPreflight instanceof Promise ? await planPreflight : planPreflight
     let reservation = this.reserve(request)
+    let plan: AcpPromptTurnPlanContext
     let skill: TurnSkillHandle
     try {
+      const preemption = this.options.finalization.preemptCompaction(request.sessionId)
+      if (preemption) await preemption
+      const planPreflight = this.options.plan.preflight(request)
+      plan = planPreflight instanceof Promise ? await planPreflight : planPreflight
       const authorization = this.options.skills.authorize({
         specialistId: this.options.registry.lookup(request.sessionId)?.aggregate.snapshot()
           .specialistId,
@@ -498,11 +501,9 @@ class AcpPromptTurnWorkflow {
   private assertSessionIdle(sessionId: string): void {
     const current = this.options.interactions.current(sessionId)
     if (!current) return
-    if (current.kind === 'compaction') {
-      this.options.interactions.supersede(current)
-      return
+    if (current.kind === 'prompt') {
+      throw new Error('An ACP prompt is already running for this session')
     }
-    throw new Error('An ACP prompt is already running for this session')
   }
 
   private reserve(request: AcpPromptRequest): AcpPromptSessionInteractionScope {

--- a/src/main/acp/prompt-turn-workflow.ts
+++ b/src/main/acp/prompt-turn-workflow.ts
@@ -133,6 +133,7 @@ type AcpPromptTurnFinalization = Readonly<{
     session: ActiveSession,
     interaction: AcpPromptSessionInteractionScope
   ) => Promise<unknown>
+  compactIfIdle: (sessionId: string) => Promise<unknown>
 }>
 
 type AcpPromptTurnWorkflowOptions = Readonly<{
@@ -146,6 +147,7 @@ type AcpPromptTurnWorkflowOptions = Readonly<{
     | 'release'
     | 'reservePrompt'
     | 'settle'
+    | 'supersede'
   >
   skills: Pick<AcpTurnSkillOwner, 'authorize'>
   preparation: Pick<AcpPromptPreparationOwner, 'prepare'>
@@ -480,7 +482,10 @@ class AcpPromptTurnWorkflow {
         generationActivityChanged: finalization.generationActivityChanged,
         autoCompactIfNeeded: () => finalization.autoCompact(sessionId, session, interaction),
         beforeInteractionRelease: () => plan.beforeRelease(sessionId, interaction),
-        afterInteractionRelease: () => plan.afterRelease(sessionId)
+        afterInteractionRelease: async () => {
+          await plan.afterRelease(sessionId)
+          void finalization.compactIfIdle(sessionId)
+        }
       },
       outcome
     )
@@ -491,9 +496,13 @@ class AcpPromptTurnWorkflow {
   }
 
   private assertSessionIdle(sessionId: string): void {
-    if (this.options.interactions.current(sessionId)) {
-      throw new Error('An ACP prompt is already running for this session')
+    const current = this.options.interactions.current(sessionId)
+    if (!current) return
+    if (current.kind === 'compaction') {
+      this.options.interactions.supersede(current)
+      return
     }
+    throw new Error('An ACP prompt is already running for this session')
   }
 
   private reserve(request: AcpPromptRequest): AcpPromptSessionInteractionScope {

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -2588,6 +2588,7 @@ describe('AcpRuntimeCoordinator', () => {
     const reloadRequest = coordinator.requestSkillsReload()
 
     expect(coordinator.getSnapshot().sessionIds).toEqual([activeSession.sessionId])
+    expect(coordinator.getSnapshot().sessionResumeRequiredIds).toEqual([activeSession.sessionId])
     expect(coordinator.getOwnedSessionIds()).toEqual([
       activeSession.sessionId,
       idleSession.sessionId

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -58,6 +58,7 @@ const createFakeRuntime = (options: {
   activePromptSessions?: { projectId: string; sessionId: string }[]
   quitBlockingSessions?: { projectId: string; sessionId: string }[]
   prompt?: (sessionId: string) => Promise<unknown>
+  holdAfterPromptEnded?: () => Promise<void>
 }): {
   runtime: AcpRuntime
   connect: ReturnType<typeof vi.fn>
@@ -178,16 +179,10 @@ const createFakeRuntime = (options: {
     }
     options.callbacks.onStateChanged?.(snapshot)
 
-    try {
-      const prompt = options.prompt
-        ? options.prompt(sessionId)
-        : Promise.resolve({ stopReason: 'end_turn' })
-      await options.beforeProviderPromptAccepted?.()
-      if (!options.skipProviderPromptAccepted) {
-        options.callbacks.onProviderPromptAccepted?.(sessionId, promptAttemptId)
-      }
-      return await prompt
-    } finally {
+    let ended = false
+    const endPrompt = (): void => {
+      if (ended) return
+      ended = true
       options.callbacks.onPromptEnded?.(sessionId, turnToken)
       snapshot = {
         ...snapshot,
@@ -197,6 +192,21 @@ const createFakeRuntime = (options: {
         )
       }
       options.callbacks.onStateChanged?.(snapshot)
+    }
+    try {
+      const prompt = options.prompt
+        ? options.prompt(sessionId)
+        : Promise.resolve({ stopReason: 'end_turn' })
+      await options.beforeProviderPromptAccepted?.()
+      if (!options.skipProviderPromptAccepted) {
+        options.callbacks.onProviderPromptAccepted?.(sessionId, promptAttemptId)
+      }
+      const result = await prompt
+      endPrompt()
+      await options.holdAfterPromptEnded?.()
+      return result
+    } finally {
+      endPrompt()
     }
   }
   const sendPrompt = vi.fn(runPrompt)
@@ -1107,6 +1117,47 @@ describe('AcpRuntimeCoordinator', () => {
       await vi.waitFor(() =>
         expect(coordinator.getSnapshot().promptInFlightSessionIds).not.toContain(session.sessionId)
       )
+    }
+  )
+
+  it.each([
+    ['Claude Code', 'claude-code'],
+    ['OpenCode', 'opencode'],
+    ['Codex Responses', 'codex'],
+    ['Codex bridge', 'codex']
+  ] as const)(
+    'admits a %s follow-up startPrompt after end_turn without waiting for post-stop work',
+    async (_route, frameworkId) => {
+      const postStop = createDeferred<void>()
+      let created!: ReturnType<typeof createFakeRuntime>
+      const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+        created = createFakeRuntime({
+          frameworkId,
+          sessionIds: ['session-1'],
+          callbacks,
+          holdAfterPromptEnded: () => postStop.promise
+        })
+        return created.runtime
+      })
+      const session = await coordinator.createSession()
+
+      await coordinator.startPrompt({
+        sessionId: session.sessionId,
+        text: 'live turn'
+      })
+      await vi.waitFor(() =>
+        expect(coordinator.getSnapshot().promptInFlightSessionIds).not.toContain(session.sessionId)
+      )
+
+      await expect(
+        coordinator.startPrompt({
+          sessionId: session.sessionId,
+          text: 'queued follow-up'
+        })
+      ).resolves.toBeUndefined()
+      expect(created.sendPrompt).toHaveBeenCalledTimes(2)
+
+      postStop.resolve()
     }
   )
 

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -1066,6 +1066,50 @@ describe('AcpRuntimeCoordinator', () => {
     }
   )
 
+  it.each([
+    ['Claude Code', 'claude-code'],
+    ['OpenCode', 'opencode'],
+    ['Codex Responses', 'codex'],
+    ['Codex bridge', 'codex']
+  ] as const)(
+    'admits a %s follow-up startPrompt after cancel without waiting for the cancelled turn to settle',
+    async (_route, frameworkId) => {
+      const firstTurn = createDeferred<unknown>()
+      let created!: ReturnType<typeof createFakeRuntime>
+      const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+        created = createFakeRuntime({
+          frameworkId,
+          sessionIds: ['session-1'],
+          callbacks,
+          prompt: () => firstTurn.promise
+        })
+        return created.runtime
+      })
+      const session = await coordinator.createSession()
+
+      await coordinator.startPrompt({
+        sessionId: session.sessionId,
+        text: 'live turn'
+      })
+      expect(created.sendPrompt).toHaveBeenCalledOnce()
+
+      await coordinator.cancelPrompt({ sessionId: session.sessionId })
+
+      await expect(
+        coordinator.startPrompt({
+          sessionId: session.sessionId,
+          text: 'Send now follow-up'
+        })
+      ).resolves.toBeUndefined()
+      expect(created.sendPrompt).toHaveBeenCalledTimes(2)
+
+      firstTurn.resolve({ stopReason: 'cancelled' })
+      await vi.waitFor(() =>
+        expect(coordinator.getSnapshot().promptInFlightSessionIds).not.toContain(session.sessionId)
+      )
+    }
+  )
+
   it('acknowledges a blocking provider prompt after local dispatch without waiting for output', async () => {
     const completion = createDeferred<unknown>()
     let created!: ReturnType<typeof createFakeRuntime>

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -1552,6 +1552,7 @@ class AcpRuntimeCoordinator {
           const remaining = (this.activePromptCounts.get(sessionId) ?? 1) - 1
           if (remaining > 0) this.activePromptCounts.set(sessionId, remaining)
           else this.activePromptCounts.delete(sessionId)
+          this.activeRootAdmissions.get(sessionId)?.release()
           this.notifyInteractionRelease(sessionId)
           this.teardownCallbacks.onSessionTurnEnded?.(sessionId, turnToken)
           this.callbacks.onPromptEnded?.(sessionId, turnToken)

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -226,6 +226,17 @@ class AcpRuntimeCoordinator {
         snapshots.flatMap(({ runtime, snapshot }) => this.visibleSessionIds(runtime, snapshot))
       )
     )
+    const sessionResumeRequiredIds = Array.from(
+      new Set(
+        snapshots.flatMap(({ runtime, snapshot }) =>
+          this.retiredRuntimes.has(runtime)
+            ? this.visibleSessionIds(runtime, snapshot).filter(
+                (sessionId) => this.sessionRuntimes.get(sessionId) === runtime
+              )
+            : []
+        )
+      )
+    )
     // A retired generation may keep draining after the same logical session was resumed by a fresh
     // runtime. Only its current owner may publish interaction state to the renderer.
     const ownedSessionIds = (select: (snapshot: AcpStateSnapshot) => readonly string[]): string[] =>
@@ -275,6 +286,7 @@ class AcpRuntimeCoordinator {
         ? { sessionId: primary.sessionId }
         : {}),
       sessionIds,
+      sessionResumeRequiredIds,
       ...(primary?.error ? { error: primary.error } : {}),
       events,
       pendingPermissions: [

--- a/src/main/acp/runtime-prompt-composition.ts
+++ b/src/main/acp/runtime-prompt-composition.ts
@@ -238,7 +238,8 @@ const composeAcpRuntimePromptOwners = (
           sessionId,
           session: active,
           interaction
-        })
+        }),
+      compactIfIdle: (sessionId) => contextCompactionWorkflow.compactIfIdle(sessionId)
     },
     currentCwd: () => base.snapshotOwner.cwd,
     resolveProjectId: projectId,

--- a/src/main/acp/runtime-prompt-composition.ts
+++ b/src/main/acp/runtime-prompt-composition.ts
@@ -1,3 +1,5 @@
+import * as acp from '@agentclientprotocol/sdk'
+
 import type { AcpPromptRequest } from '../../shared/acp'
 import type { ArtifactTurnHandle } from './artifact-turn-owner'
 import { AcpContextCompactionWorkflow } from './context-compaction-workflow'
@@ -173,7 +175,17 @@ const composeAcpRuntimePromptOwners = (
       }),
     pushEvent: (event) => session.publication.pushEvent(event),
     emitState,
-    errorMessage
+    errorMessage,
+    cancelCompaction: async (sessionId) => {
+      const connection = base.connectionResources.connection
+      const active = activeSession(sessionId)
+      if (!connection || !active) {
+        throw new Error(`ACP session not found: ${sessionId}`)
+      }
+      await connection.agent.notify(acp.methods.agent.session.cancel, {
+        sessionId: active.sessionId
+      })
+    }
   })
   const promptTurnWorkflow = new AcpPromptTurnWorkflow({
     registry: session.sessionRegistry,
@@ -239,7 +251,8 @@ const composeAcpRuntimePromptOwners = (
           session: active,
           interaction
         }),
-      compactIfIdle: (sessionId) => contextCompactionWorkflow.compactIfIdle(sessionId)
+      compactIfIdle: (sessionId) => contextCompactionWorkflow.compactIfIdle(sessionId),
+      preemptCompaction: (sessionId) => contextCompactionWorkflow.preemptForPrompt(sessionId)
     },
     currentCwd: () => base.snapshotOwner.cwd,
     resolveProjectId: projectId,

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -7819,11 +7819,17 @@ describe('ACP runtime session management', () => {
       expect(agent.prompts).toContainEqual({ sessionId: 'remote-session-2', text: '/compact' })
     )
     await expect(
-      runtime.sendPrompt({ sessionId: second.sessionId, text: 'blocked prompt' })
-    ).rejects.toThrow(/already running/)
-    await expect(
       runtime.setPermissionProfile({ sessionId: second.sessionId, profile: 'full' })
     ).rejects.toThrow(/compacting/)
+    const promptAfterCompaction = runtime.sendPrompt({
+      sessionId: second.sessionId,
+      text: 'prompt after compaction'
+    })
+    await vi.waitFor(() => expect(agent.cancelledSessions).toContain('remote-session-2'))
+    expect(agent.prompts).not.toContainEqual({
+      sessionId: 'remote-session-2',
+      text: 'prompt after compaction'
+    })
 
     const prompting = runtime.sendPrompt({ sessionId: first.sessionId, text: 'first prompt' })
     await vi.waitFor(() =>
@@ -7843,7 +7849,9 @@ describe('ACP runtime session management', () => {
 
     firstPromptGate.resolve({ stopReason: 'end_turn' })
     secondCompactionGate.resolve({ stopReason: 'end_turn' })
-    await expect(Promise.all([prompting, compacting])).resolves.toHaveLength(2)
+    await expect(Promise.all([prompting, compacting, promptAfterCompaction])).resolves.toHaveLength(
+      3
+    )
     expect(runtime.getSnapshot().promptInFlightSessionIds).toEqual([])
     expect(runtime.getSnapshot().agentPromptInFlightSessionIds).toEqual([])
   })
@@ -8068,6 +8076,7 @@ describe('ACP runtime session management', () => {
     const session = await runtime.createSession({ cwd: '/workspace' })
     await runtime.sendPrompt({ sessionId: session.sessionId, text: 'analyze the results' })
 
+    await vi.waitFor(() => expect(agent.prompts).toHaveLength(2))
     expect(agent.prompts).toEqual([
       { sessionId: 'remote-session-1', text: 'analyze the results' },
       { sessionId: 'remote-session-1', text: '/compact' }

--- a/src/main/acp/session-interaction-owner.test.ts
+++ b/src/main/acp/session-interaction-owner.test.ts
@@ -276,24 +276,20 @@ describe('AcpSessionInteractionOwner', () => {
     owner.release(scope)
   })
 
-  it('keeps a synchronous prompt reservation private until activation', () => {
+  it('keeps a prompt reservation private while compaction drains', () => {
     const owner = new AcpSessionInteractionOwner()
     const active = owner.claim({ sessionId: 'session-1', kind: 'compaction' })
-
-    expect(() => owner.reservePrompt({ sessionId: 'session-1', kind: 'prompt' })).toThrow(
-      /already running/
-    )
-    owner.release(active)
-
     const reservation = owner.reservePrompt({
       sessionId: 'session-1',
       kind: 'prompt',
       promptMessageId: 'prompt-message-1'
     })
     expect(reservation.signal.aborted).toBe(false)
-    expect(owner.current('session-1')).toBeUndefined()
-    expect(owner.snapshot()).toEqual([])
+    expect(owner.current('session-1')).toBe(active)
+    expect(owner.has('session-1')).toBe(true)
+    expect(() => owner.activatePrompt(reservation)).toThrow(/already running/)
 
+    owner.release(active)
     expect(owner.activatePrompt(reservation)).toBe(reservation)
     expect(owner.current('session-1')).toBe(reservation)
     owner.release(reservation)
@@ -329,8 +325,8 @@ describe('AcpSessionInteractionOwner', () => {
 
   it('supersedes pending and active ownership for one session or all sessions', () => {
     const owner = new AcpSessionInteractionOwner()
-    const pendingReset = owner.reservePrompt({ sessionId: 'session-1', kind: 'prompt' })
     const activeReset = owner.claim({ sessionId: 'session-1', kind: 'compaction' })
+    const pendingReset = owner.reservePrompt({ sessionId: 'session-1', kind: 'prompt' })
 
     owner.supersedeCurrent('session-1')
     expect(pendingReset.signal.aborted).toBe(true)
@@ -346,6 +342,15 @@ describe('AcpSessionInteractionOwner', () => {
     expect(activeAll.signal.aborted).toBe(true)
     expect(owner.snapshot()).toEqual([])
     expect(() => owner.activatePrompt(pendingAll)).toThrow(/superseded/)
+  })
+
+  it('does not let a new interaction bypass a pending prompt reservation', () => {
+    const owner = new AcpSessionInteractionOwner()
+    owner.reservePrompt({ sessionId: 'session-1', kind: 'prompt' })
+
+    expect(() => owner.claim({ sessionId: 'session-1', kind: 'compaction' })).toThrow(
+      /already running/
+    )
   })
 
   it('supports explicit claim and release while run uses the same lifecycle', async () => {

--- a/src/main/acp/session-interaction-owner.ts
+++ b/src/main/acp/session-interaction-owner.ts
@@ -145,6 +145,10 @@ export class AcpSessionInteractionOwner {
     return this.activeInteractions.get(sessionId)?.scope
   }
 
+  has(sessionId: string): boolean {
+    return this.activeInteractions.has(sessionId) || this.pendingPromptReservations.has(sessionId)
+  }
+
   snapshot(): readonly AcpSessionInteractionSnapshotEntry[] {
     return Object.freeze(
       Array.from(this.activeInteractions.values(), ({ scope }) =>
@@ -255,8 +259,8 @@ export class AcpSessionInteractionOwner {
     this.pendingCancellations.set(request.sessionId, attempt)
 
     const active =
-      this.activeInteractions.get(request.sessionId) ??
-      this.pendingPromptReservations.get(request.sessionId)
+      this.pendingPromptReservations.get(request.sessionId) ??
+      this.activeInteractions.get(request.sessionId)
     const scope = active?.scope
     active?.abortController.abort()
     this.clearCancellationTimer(request.sessionId)
@@ -323,7 +327,7 @@ export class AcpSessionInteractionOwner {
   }
 
   reservePrompt(request: AcpPromptSessionInteractionRequest): AcpPromptSessionInteractionScope {
-    if (this.activeInteractions.has(request.sessionId)) {
+    if (this.activeInteractions.get(request.sessionId)?.scope.kind === 'prompt') {
       throw new Error('An ACP interaction is already running for this session')
     }
 
@@ -364,7 +368,10 @@ export class AcpSessionInteractionOwner {
   }
 
   claim<Request extends AcpSessionInteractionRequest>(request: Request): ScopeFor<Request> {
-    if (this.activeInteractions.has(request.sessionId)) {
+    if (
+      this.activeInteractions.has(request.sessionId) ||
+      this.pendingPromptReservations.has(request.sessionId)
+    ) {
       throw new Error('An ACP interaction is already running for this session')
     }
 

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -5780,6 +5780,55 @@ describe('resuming an interrupted session on demand', () => {
     }
   )
 
+  it('resumes an unchanged target when its visible Session belongs to a retiring runtime', async () => {
+    const agentConfiguration = {
+      providerId: 'provider-1',
+      model: 'codex-model',
+      reasoningEffort: 'default'
+    } as const
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'First turn',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      agentFrameworkId: 'codex',
+      agentBackendId: 'codex:provider-1',
+      agentModel: agentConfiguration.model,
+      agentConfiguration
+    })
+    useSessionStore.getState().finishRun('session-1')
+    const runtime = {
+      state: {
+        ...createSnapshot(['session-1']),
+        sessionResumeRequiredIds: ['session-1']
+      },
+      createSession: vi.fn(),
+      resumeSession: vi.fn().mockResolvedValue({
+        sessionId: 'session-1',
+        cwd: '/workspace/project',
+        frameworkId: 'codex',
+        backendId: 'codex:provider-1'
+      }),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'Continue after the generation switch',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      agentFrameworkId: 'codex',
+      agentBackendId: 'codex:provider-1',
+      agentModel: agentConfiguration.model,
+      agentConfiguration
+    })
+    await flushRuntimeTasks()
+
+    expect(runtime.resumeSession).toHaveBeenCalledOnce()
+    expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+  })
+
   it('adopts an attached Session when only reasoning effort changed', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'session-1',

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -5724,8 +5724,109 @@ describe('resuming an interrupted session on demand', () => {
     })
     await flushRuntimeTasks()
 
-    expect(runtime.resumeSession).toHaveBeenCalledOnce()
+    expect(runtime.resumeSession).not.toHaveBeenCalled()
     expect(runtime.resetSessionContext).not.toHaveBeenCalled()
+    expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+  })
+
+  it.each(['claude-code', 'opencode', 'codex'] as const)(
+    'sends a %s follow-up on an attached Session without resuming when the explicit target is unchanged',
+    async (frameworkId) => {
+      const agentConfiguration = {
+        providerId: 'provider-1',
+        model: `${frameworkId}-model`,
+        reasoningEffort: 'default'
+      } as const
+      const backendId = `${frameworkId}:provider-1`
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-1',
+        content: 'First turn',
+        cwd: '/workspace/project',
+        projectId: 'default-project',
+        agentFrameworkId: frameworkId,
+        agentBackendId: backendId,
+        agentModel: agentConfiguration.model,
+        agentConfiguration
+      })
+      useSessionStore.getState().finishRun('session-1')
+      const runtime = {
+        state: createSnapshot(['session-1']),
+        createSession: vi.fn(),
+        resumeSession: vi
+          .fn()
+          .mockRejectedValue(
+            new Error("Error invoking remote method 'acp:resume-session': reply was never sent")
+          ),
+        resetSessionContext: vi.fn(),
+        sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+      }
+
+      await sendWorkspaceMessage(runtime, {
+        sessionId: 'session-1',
+        text: 'Send now follow-up',
+        cwd: '/workspace/project',
+        projectId: 'default-project',
+        agentFrameworkId: frameworkId,
+        agentBackendId: backendId,
+        agentModel: agentConfiguration.model,
+        agentConfiguration
+      })
+      await flushRuntimeTasks()
+
+      expect(runtime.resumeSession).not.toHaveBeenCalled()
+      expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+      expect(useSessionStore.getState().sessions[0].error).toBeUndefined()
+      expect(useSessionStore.getState().sessions[0].status).toBe('running')
+    }
+  )
+
+  it('adopts an attached Session when only reasoning effort changed', async () => {
+    useSessionStore.getState().appendUserMessage({
+      sessionId: 'session-1',
+      content: 'First turn',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      agentFrameworkId: 'codex',
+      agentBackendId: 'codex:provider-1',
+      agentModel: 'codex-model',
+      agentConfiguration: {
+        providerId: 'provider-1',
+        model: 'codex-model',
+        reasoningEffort: 'default'
+      }
+    })
+    useSessionStore.getState().finishRun('session-1')
+    const resumeSession = vi.fn().mockResolvedValue({
+      sessionId: 'session-1',
+      cwd: '/workspace/project',
+      frameworkId: 'codex',
+      backendId: 'codex:provider-1'
+    })
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession,
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'retry at higher effort',
+      cwd: '/workspace/project',
+      projectId: 'default-project',
+      agentFrameworkId: 'codex',
+      agentBackendId: 'codex:provider-1',
+      agentModel: 'codex-model',
+      agentConfiguration: {
+        providerId: 'provider-1',
+        model: 'codex-model',
+        reasoningEffort: 'high'
+      }
+    })
+    await flushRuntimeTasks()
+
+    expect(resumeSession).toHaveBeenCalledOnce()
     expect(runtime.sendPrompt).toHaveBeenCalledOnce()
   })
 

--- a/src/renderer/src/lib/acp/workspace-runtime-prompt-preparation-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-prompt-preparation-owner.ts
@@ -234,9 +234,11 @@ const prepareExistingWorkspacePrompt = async (
     request.selectedRuntime.agentConfiguration &&
     request.selectedRuntime.agentModel !== currentSession?.agentModel
   )
-  const runtimeDetached = !runtime.state.sessionIds.includes(sessionId)
-  // Resume only when the explicit target differs from the live Session. Same-target Send now
-  // interrupt fallback must not block on session/resume while the cancelled turn is aborting.
+  const runtimeDetached =
+    !runtime.state.sessionIds.includes(sessionId) ||
+    Boolean(runtime.state.sessionResumeRequiredIds?.includes(sessionId))
+  // Resume when the explicit target differs or the visible Session belongs to a retiring runtime.
+  // Same-target Send now must not resume while the selected runtime still owns the Session.
   const runtimeMustAdoptSession =
     Boolean(
       request.selectedRuntime.frameworkId &&

--- a/src/renderer/src/lib/acp/workspace-runtime-prompt-preparation-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-prompt-preparation-owner.ts
@@ -120,6 +120,25 @@ const canAdmitExistingWorkspacePrompt = (
   )
 }
 
+const sessionAgentTargetMatches = (
+  selected: PrepareExistingWorkspacePromptRequest['selectedRuntime'],
+  session: ChatSession | undefined
+): boolean => {
+  const selectedConfiguration = selected.agentConfiguration
+  const sessionConfiguration = session?.agentConfiguration
+  if (!selected.frameworkId || !selectedConfiguration || !session || !sessionConfiguration) {
+    return false
+  }
+  return (
+    selected.frameworkId === session.agentFrameworkId &&
+    (selected.backendId === undefined || selected.backendId === session.agentBackendId) &&
+    selected.agentModel === session.agentModel &&
+    selectedConfiguration.providerId === sessionConfiguration.providerId &&
+    selectedConfiguration.model === sessionConfiguration.model &&
+    selectedConfiguration.reasoningEffort === sessionConfiguration.reasoningEffort
+  )
+}
+
 const isReplayImage = (attachment: Pick<UploadedAttachment, 'name' | 'mimeType'>): boolean =>
   imageAttachmentMimeType(attachment.name, attachment.mimeType) !== undefined
 
@@ -216,11 +235,14 @@ const prepareExistingWorkspacePrompt = async (
     request.selectedRuntime.agentModel !== currentSession?.agentModel
   )
   const runtimeDetached = !runtime.state.sessionIds.includes(sessionId)
-  // An explicit Session target must pass through resume even when the aggregate coordinator snapshot
-  // still shows this app Session as attached. A provider/model/effort change can keep the same backend
-  // id, while ownership still needs to move to the runtime generation keyed by the new target.
+  // Resume only when the explicit target differs from the live Session. Same-target Send now
+  // interrupt fallback must not block on session/resume while the cancelled turn is aborting.
   const runtimeMustAdoptSession =
-    Boolean(request.selectedRuntime.frameworkId && request.selectedRuntime.agentConfiguration) ||
+    Boolean(
+      request.selectedRuntime.frameworkId &&
+      request.selectedRuntime.agentConfiguration &&
+      !sessionAgentTargetMatches(request.selectedRuntime, currentSession)
+    ) ||
     selectedRuntimeChanged ||
     runtimeDetached
   const branchResetRequired = Boolean(

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
@@ -747,7 +747,7 @@ describe('workspace message queue controller', () => {
         error: { kind: 'send', detail: resumeError }
       })
     )
-    expect(input.runtime.cancelRun).toHaveBeenCalledWith('session-a')
+    expect(input.runtime.cancelRun).not.toHaveBeenCalled()
   })
 
   it('keeps a generic admission miss when Send now fails without a new session error', async () => {
@@ -992,7 +992,7 @@ describe('workspace message queue controller', () => {
     expect(input.composer.discardSnapshot).toHaveBeenCalledTimes(2)
   })
 
-  it('stops the current run and sends immediately when native follow-up is unavailable', async () => {
+  it('keeps Send now queued until the current run finishes when native follow-up is unavailable', async () => {
     const order: string[] = []
     let currentSession = session()
     const input = options(currentSession, {
@@ -1013,12 +1013,18 @@ describe('workspace message queue controller', () => {
     act(() => hook.result.current.lifecycle.enqueue(admission('wait')))
 
     await act(async () => hook.result.current.actions.sendNow(hook.result.current.items[0].id))
-    expect(order).toEqual(['cancel'])
-    expect(hook.result.current.items[0]).toMatchObject({ text: 'wait', phase: 'interrupting' })
+    expect(order).toEqual([])
+    expect(input.runtime.cancelRun).not.toHaveBeenCalled()
+    expect(hook.result.current.items[0]).toMatchObject({
+      text: 'wait',
+      phase: 'queued',
+      deferredUntilIdle: true
+    })
     expect(hook.result.current.announcement).toBe(
-      'Stopping the current run before sending the queued message.'
+      'Queued message will send after the current run finishes.'
     )
 
+    currentSession = session('idle')
     hook.rerender(
       options(currentSession, {
         ...input,
@@ -1027,8 +1033,8 @@ describe('workspace message queue controller', () => {
         getSession: () => currentSession
       })
     )
-    await vi.waitFor(() => expect(order).toEqual(['cancel', 'send']))
-    await vi.waitFor(() => expect(hook.result.current.items).toEqual([]))
+    await vi.waitFor(() => expect(order).toEqual(['send']))
+    expect(input.runtime.cancelRun).not.toHaveBeenCalled()
   })
 
   it('keeps Send now queued while a durable permission response is in flight', async () => {
@@ -1108,16 +1114,26 @@ describe('workspace message queue controller', () => {
       completions[0]()
       await sendNow
     })
-    expect(input.runtime.cancelRun).toHaveBeenCalledWith('session-a')
-    expect(sendMessage).toHaveBeenCalledTimes(2)
+    expect(input.runtime.cancelRun).not.toHaveBeenCalled()
+    expect(sendMessage).toHaveBeenCalledOnce()
     expect(hook.result.current.items.map((item) => item.text)).toEqual(['second'])
-    expect(hook.result.current.items[0]?.phase).toBe('sending')
+    expect(hook.result.current.items[0]?.phase).toBe('queued')
 
+    currentSession = session('idle')
+    hook.rerender(
+      options(currentSession, {
+        ...input,
+        activeSession: currentSession,
+        promptInFlightSessionIds: [],
+        getSession: () => currentSession
+      })
+    )
+    await vi.waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(2))
     await act(async () => completions[1]())
     await vi.waitFor(() => expect(hook.result.current.items).toEqual([]))
   })
 
-  it('surfaces a cancellation failure when native follow-up is unavailable', async () => {
+  it('does not cancel the current run when native follow-up is unavailable', async () => {
     const input = options(session(), {
       runtime: {
         cancelRun: vi.fn(async () => {
@@ -1135,10 +1151,10 @@ describe('workspace message queue controller', () => {
     expect(hook.result.current.items).toHaveLength(1)
     expect(hook.result.current.items[0]).toMatchObject({
       text: 'keep me',
-      phase: 'error',
-      error: { kind: 'cancel', detail: 'runtime refused cancellation' }
+      phase: 'queued',
+      deferredUntilIdle: true
     })
-    expect(input.runtime.cancelRun).toHaveBeenCalledWith('session-a')
+    expect(input.runtime.cancelRun).not.toHaveBeenCalled()
     expect(input.runtime.sendMessage).not.toHaveBeenCalled()
   })
 
@@ -1271,7 +1287,7 @@ describe('workspace message queue controller', () => {
     expect(hook.result.current.items).toEqual([])
   })
 
-  it('interrupts and sends when native follow-up is refused', async () => {
+  it('requeues when native follow-up is refused instead of interrupting', async () => {
     let currentSession = session()
     const input = options(currentSession, {
       getSession: () => currentSession,
@@ -1291,11 +1307,12 @@ describe('workspace message queue controller', () => {
     act(() => hook.result.current.lifecycle.enqueue(admission('fallback')))
 
     await act(async () => hook.result.current.actions.sendNow(hook.result.current.items[0].id))
-    expect(input.runtime.cancelRun).toHaveBeenCalledWith('session-a')
+    expect(input.runtime.cancelRun).not.toHaveBeenCalled()
     expect(input.runtime.sendMessage).not.toHaveBeenCalled()
     expect(hook.result.current.items[0]).toMatchObject({
       text: 'fallback',
-      phase: 'interrupting'
+      phase: 'queued',
+      deferredUntilIdle: true
     })
 
     currentSession = session('idle')

--- a/src/renderer/src/pages/workspace/workspace-message-queue-drain.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-drain.ts
@@ -245,7 +245,7 @@ const sendQueuedItemNow = async (
           return
         }
       } catch {
-        // Fall back to interrupting the live turn below.
+        // Native follow-up is fail-closed. Keep the current run and send after it finishes.
       }
     }
     if (liveTurn && hasPayload) {
@@ -264,26 +264,15 @@ const sendQueuedItemNow = async (
         drainQueuedSessions(owner, optionsRef)
         return
       }
-      const contextError = queueItemContextError(latestSession, item)
-      if (contextError) {
-        owner.replaceItem(sessionId, itemId, {
-          phase: 'error',
-          error: contextError,
-          deferredUntilIdle: false
-        })
-        return
-      }
       owner.replaceItem(sessionId, itemId, {
-        phase: 'interrupting',
+        phase: 'queued',
         error: undefined,
-        deferredUntilIdle: false
+        deferredUntilIdle: true
       })
-      owner.emit(MESSAGE_QUEUE_ANNOUNCEMENTS.interrupting)
-      await latest.runtime.cancelRun(sessionId)
       if (owner.dispatches.get(sessionId) === displacedDispatch) {
         owner.dispatches.delete(sessionId)
       }
-      drainQueuedSessions(owner, optionsRef)
+      owner.emit(MESSAGE_QUEUE_ANNOUNCEMENTS.deferredUntilIdle)
       return
     }
     if (liveTurn) {

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -656,6 +656,9 @@ export type AcpStateSnapshot = {
   cwd: string
   sessionId?: string
   sessionIds: string[]
+  // Visible sessions still owned by a retiring runtime generation. The renderer must resume these
+  // before dispatch even though their final turn remains visible while it drains.
+  sessionResumeRequiredIds?: string[]
   error?: string
   events: AcpRuntimeEvent[]
   pendingPermissions: AcpPermissionRequest[]


### PR DESCRIPTION
## Problem

On latest `main`, **Send now** during a live Codex native Responses turn does not inject the queued follow-up. Four stacked failures show up as one user-visible break:

1. `#1552` resumes an attached Session whenever `agentConfiguration` is present, even when the live target is unchanged. That resume hangs while the cancelled native Responses stream is still aborting, and the queue surfaces `Agent session resume failed: reply was never sent`.
2. After the message appears, cancelled-turn finalization still awaits automatic compaction. Compaction can block behind the aborting stream, so `acp:send-prompt` never replies.
3. `#1593` changed native follow-up from fail-closed to interrupt fallback. When `_session/steering` is refused or times out, Send now cancels the live turn (`This turn was interrupted`). The Sending/Stopping wait is `cancelRun` waiting for the in-flight Responses stream to abort.
4. Even after a natural `end_turn`, queued drain still invoked `acp:send-prompt` while the previous turn held root admission for compact and after-release work. That IPC never replied. A later composer send, including after switching the agent framework, produced no ACP logs because admission and `promptInFlight` never cleared.

`#1566` already specified inject-or-wait: keep the current run and send after it finishes. `#1593` replaced that with inject-or-cancel.

## Proposed change

- Resume an attached Session only when the explicit target differs (provider, model, or effort), the runtime is detached, or the framework/backend changed. Same-target Send now goes to `sendPrompt` instead of `session/resume`.
- Skip automatic context compaction while finalizing a live prompt. Mark the turn idle and release root admission at stop, then compact after the prompt interaction is gone. A new user prompt preempts an in-flight automatic compact.
- Restore fail-closed Send now: try native follow-up first; if inject is unavailable, refused, or throws while the turn is still live, keep the run and send the queued item after it becomes idle. Stop remains the explicit cancel control.

Provider/model/effort adoption from `#1552` is unchanged.

## Scope and non-goals

- Renderer prompt preparation, message-queue drain, cancelled-prompt finalization, and post-stop admission.
- Does not make Codex native Responses `_session/steering` inject during an in-flight stream. If inject still refuses, the follow-up waits until the live run idles instead of cancelling it.
- Does not change persisted Session JSON, enums, or migrations.
- Does not add a live Codex native-responses steering harness.

## Compatibility, state, and persistence

- **Historical data:** none. Existing Sessions without `agentConfiguration` still resume when an explicit target is first supplied, or when detached.
- **New enum values:** none.
- **Persistence:** none. No Session file, database, or migration changes.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- Same-target attached send must not resume → `npx vitest run src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts` → 182 passed
- Effort-only and model-only target changes still resume → same file → passed
- Cancelled and `end_turn` stops must not wait on hanging compaction → `npx vitest run src/main/acp/prompt-outcome-finalizer.test.ts` → 15 passed
- Follow-up `startPrompt` after `end_turn` must not wait for post-stop work (claude-code, opencode, codex) → `npx vitest run src/main/acp/runtime-coordinator.test.ts` → 111 passed
- Idle automatic compact and no-threshold Codex skip → `npx vitest run src/main/acp/context-compaction-workflow.test.ts` → 11 passed
- Send now must not `cancelRun` when native follow-up is unavailable or refused → `npx vitest run src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts` → 35 passed
- Prompt-turn after-release compactIfIdle wiring → `npx vitest run src/main/acp/prompt-turn-workflow.test.ts` → 17 passed

Exact-head CI remains authoritative for the complete portable suite.

## Test impact (ACP)

- Affected behavior: when Send now injects, resumes, or drains after a live turn; when the next `startPrompt` is admitted after stop.
- Included: shared renderer send path for `claude-code`, `opencode`, and `codex` (covers Codex Responses and Codex Bridge at this seam). Queue drain is framework-agnostic. Coordinator admission release is shared.
- Excluded: live `_session/steering` against a real native Responses stream.

| behavior | framework/path | command | result |
| --- | --- | --- | --- |
| same-target attached send does not resume | claude-code / opencode / codex renderer send | vitest `useWorkspaceAgentRuntime.test.ts` | passed |
| effort/model change still resumes | codex renderer send | vitest effort-only and model-only cases | passed |
| stop does not await compact | shared ACP finalizer | vitest `prompt-outcome-finalizer.test.ts` | passed |
| follow-up startPrompt after end_turn | claude-code / opencode / codex coordinator | vitest `runtime-coordinator.test.ts` | passed |
| Send now does not interrupt when inject fails | shared queue controller | vitest `workspace-message-queue-controller.test.ts` | passed |

## Review focus

- Same-target resume skip vs effort/model adoption from `#1552`.
- Fail-closed requeue after refused native follow-up, including the race where the live turn ends during inject.
- Admission release at `onPromptEnded` must not allow overlapping user prompts; compaction is preempted, not concurrent with a new user turn.
