### PR TITLE
fix(notebook): hide unused kernel tabs

### DIFF
--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -638,7 +638,7 @@ describe('NotebookPreview per-kernel tabs', () => {
     await act(async () => i18next.changeLanguage('en'))
   })
 
-  it('always shows Python and R while keeping non-data tabs history-driven', async () => {
+  it('always shows Python while keeping other tabs history-driven', async () => {
     await mountWithRuns([
       makeRun({ runId: 'p1', kernelKind: 'python' }),
       makeRun({ runId: 'x1', kernelKind: 'repl', script: 'await host.notebook.run(...)' }),
@@ -651,7 +651,7 @@ describe('NotebookPreview per-kernel tabs', () => {
       'Agent SDK'
     )
     expect(switcher.querySelector('[data-testid="kernel-switcher-bash"]')?.textContent).toBe('Bash')
-    expect(switcher.querySelector('[data-testid="kernel-switcher-r"]')).not.toBeNull()
+    expect(switcher.querySelector('[data-testid="kernel-switcher-r"]')).toBeNull()
   })
 
   it('projects named Main Agent and Subagent Runs without All, legacy, or Frame IDs', async () => {
@@ -745,25 +745,27 @@ describe('NotebookPreview per-kernel tabs', () => {
     expect(userBadge?.className).toContain('dark:text-blue-300')
   })
 
-  it('shows Python and R before either kernel has produced a run', async () => {
+  it('shows only Python before another kernel has produced a run', async () => {
     await mountWithRuns([])
 
     const switcher = container.querySelector('[data-testid="kernel-switcher"]') as HTMLElement
     expect(switcher.querySelector('[data-testid="kernel-switcher-python"]')).not.toBeNull()
-    expect(switcher.querySelector('[data-testid="kernel-switcher-r"]')).not.toBeNull()
+    expect(switcher.querySelector('[data-testid="kernel-switcher-r"]')).toBeNull()
+    expect(switcher.querySelector('[data-testid="kernel-switcher-repl"]')).toBeNull()
     expect(container.querySelector('[data-testid="kernel-terminal-input"]')).toBeNull()
     expect(
       container.querySelector('[data-testid="notebook-read-only-status"]')?.textContent
     ).toContain('Python · view only; the agent must activate this kernel first')
   })
 
-  it('shows no Agent SDK/Bash tab for a python-only run set', async () => {
+  it('hides unused R, Agent SDK, and Bash tabs for a python-only run set', async () => {
     await mountWithRuns([
       makeRun({ runId: 'p1', kernelKind: 'python' }),
       makeRun({ runId: 'p2', kernelKind: 'python' })
     ])
 
     const switcher = container.querySelector('[data-testid="kernel-switcher"]') as HTMLElement
+    expect(switcher.querySelector('[data-testid="kernel-switcher-r"]')).toBeNull()
     expect(switcher.querySelector('[data-testid="kernel-switcher-repl"]')).toBeNull()
     expect(switcher.querySelector('[data-testid="kernel-switcher-bash"]')).toBeNull()
   })
@@ -800,7 +802,7 @@ describe('NotebookPreview per-kernel tabs', () => {
     const replTab = switcher.querySelector(
       '[data-testid="kernel-switcher-repl"]'
     ) as HTMLButtonElement
-    expect(switcher.querySelector('[data-testid="kernel-switcher-r"]')).not.toBeNull()
+    expect(switcher.querySelector('[data-testid="kernel-switcher-r"]')).toBeNull()
     expect(pythonTab.className).toContain('bg-bg-300')
     expect(replTab.className).not.toContain('bg-bg-300')
 

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -457,11 +457,10 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
     ? projectNotebookRunsForFrame(frameRuns, effectiveFrameFilter)
     : []
 
-  // Python and R are executable user targets even before their first run. Agent SDK and Bash remain
-  // historical views and appear only after producing a run.
+  // Python is the default executable target. Other kernels appear only after producing a run.
   const kindsWithRuns = new Set(projectedRuns.map(resolveRunKernelKind))
   const visibleKinds = KERNEL_KIND_ORDER.filter(
-    (kind) => kind === 'python' || kind === 'r' || kindsWithRuns.has(kind)
+    (kind) => kind === 'python' || kindsWithRuns.has(kind)
   )
   const effectiveActiveKind = visibleKinds.includes(activeKind) ? activeKind : 'python'
   const kindRuns = projectedRuns.filter((run) => resolveRunKernelKind(run) === effectiveActiveKind)


### PR DESCRIPTION
## Problem

After #1604, the live Notebook preview always displayed the R kernel tab before the session had executed any R code. This made an unused kernel appear beside the active Python kernel. Agent SDK (JS REPL) should follow the same run-driven visibility rule.

## Proposed change

- Keep Python visible as the default executable target.
- Show R, Agent SDK, and Bash tabs only when the current projected Notebook history contains a run for that kernel.
- Cover empty, Python-only, and Agent SDK-only histories with renderer regression assertions; existing cases continue to cover R and Agent SDK tabs appearing after execution.

## Scope and non-goals

- No persistence or schema changes.
- No new state or enum values.
- No historical-data migration or compatibility branch is required; existing run history already provides the visibility evidence.
- The read-only Session Notebook dialog was already run-driven and is unchanged.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Kernel tab visibility -> `npm test -- src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx` -> 35 tests passed.
- Renderer type safety -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint` -> passed.
- Impact explanation -> `npm run test:affected:explain -- --base origin/main --head HEAD` -> conservatively selected the full suite because the render test has no registered module owner; the full local suite was intentionally not run, and PR Gate remains the final authority.

Uncovered local risk: platform-specific renderer behavior is not exercised locally; this change is DOM-only and has no platform or process boundary.

## Review focus

Confirm that Python remains the only pre-run entry point and that R and Agent SDK appear as soon as their first projected run exists.
