### PR TITLE
fix(notebook): show only used kernel tabs

### DIFF
--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -638,7 +638,7 @@ describe('NotebookPreview per-kernel tabs', () => {
     await act(async () => i18next.changeLanguage('en'))
   })
 
-  it('always shows Python while keeping other tabs history-driven', async () => {
+  it('shows only kernels present in the projected history', async () => {
     await mountWithRuns([
       makeRun({ runId: 'p1', kernelKind: 'python' }),
       makeRun({ runId: 'x1', kernelKind: 'repl', script: 'await host.notebook.run(...)' }),
@@ -745,17 +745,15 @@ describe('NotebookPreview per-kernel tabs', () => {
     expect(userBadge?.className).toContain('dark:text-blue-300')
   })
 
-  it('shows only Python before another kernel has produced a run', async () => {
+  it('shows no kernel tabs before a kernel has produced a run', async () => {
     await mountWithRuns([])
 
     const switcher = container.querySelector('[data-testid="kernel-switcher"]') as HTMLElement
-    expect(switcher.querySelector('[data-testid="kernel-switcher-python"]')).not.toBeNull()
+    expect(switcher.querySelector('[data-testid="kernel-switcher-python"]')).toBeNull()
     expect(switcher.querySelector('[data-testid="kernel-switcher-r"]')).toBeNull()
     expect(switcher.querySelector('[data-testid="kernel-switcher-repl"]')).toBeNull()
+    expect(switcher.querySelector('[data-testid="kernel-switcher-bash"]')).toBeNull()
     expect(container.querySelector('[data-testid="kernel-terminal-input"]')).toBeNull()
-    expect(
-      container.querySelector('[data-testid="notebook-read-only-status"]')?.textContent
-    ).toContain('Python · view only; the agent must activate this kernel first')
   })
 
   it('hides unused R, Agent SDK, and Bash tabs for a python-only run set', async () => {
@@ -765,6 +763,7 @@ describe('NotebookPreview per-kernel tabs', () => {
     ])
 
     const switcher = container.querySelector('[data-testid="kernel-switcher"]') as HTMLElement
+    expect(switcher.querySelector('[data-testid="kernel-switcher-python"]')).not.toBeNull()
     expect(switcher.querySelector('[data-testid="kernel-switcher-r"]')).toBeNull()
     expect(switcher.querySelector('[data-testid="kernel-switcher-repl"]')).toBeNull()
     expect(switcher.querySelector('[data-testid="kernel-switcher-bash"]')).toBeNull()
@@ -790,24 +789,34 @@ describe('NotebookPreview per-kernel tabs', () => {
     expect(container.textContent).not.toContain('print("py")')
   })
 
-  it('defaults to the executable Python tab when only Agent SDK history exists', async () => {
+  it('shows and selects only R when only R history exists', async () => {
+    await mountWithRuns([makeRun({ runId: 'r1', kernelKind: 'r', script: 'print("r")' })])
+
+    const switcher = container.querySelector('[data-testid="kernel-switcher"]') as HTMLElement
+    const rTab = switcher.querySelector('[data-testid="kernel-switcher-r"]') as HTMLButtonElement
+    expect(switcher.querySelector('[data-testid="kernel-switcher-python"]')).toBeNull()
+    expect(switcher.querySelector('[data-testid="kernel-switcher-repl"]')).toBeNull()
+    expect(switcher.querySelector('[data-testid="kernel-switcher-bash"]')).toBeNull()
+    expect(rTab.className).toContain('bg-bg-300')
+    expect(container.textContent).toContain('print("r")')
+  })
+
+  it('shows and selects only Agent SDK when only Agent SDK history exists', async () => {
     await mountWithRuns([
       makeRun({ runId: 'x1', kernelKind: 'repl', script: 'host.notebook.run(...)' })
     ])
 
     const switcher = container.querySelector('[data-testid="kernel-switcher"]') as HTMLElement
-    const pythonTab = switcher.querySelector(
-      '[data-testid="kernel-switcher-python"]'
-    ) as HTMLButtonElement
     const replTab = switcher.querySelector(
       '[data-testid="kernel-switcher-repl"]'
     ) as HTMLButtonElement
+    expect(switcher.querySelector('[data-testid="kernel-switcher-python"]')).toBeNull()
     expect(switcher.querySelector('[data-testid="kernel-switcher-r"]')).toBeNull()
-    expect(pythonTab.className).toContain('bg-bg-300')
-    expect(replTab.className).not.toContain('bg-bg-300')
+    expect(switcher.querySelector('[data-testid="kernel-switcher-bash"]')).toBeNull()
+    expect(replTab.className).toContain('bg-bg-300')
 
-    expect(container.querySelectorAll('[data-testid="notebook-cell"]').length).toBe(0)
-    expect(container.textContent).not.toContain('host.notebook.run')
+    expect(container.querySelectorAll('[data-testid="notebook-cell"]').length).toBe(1)
+    expect(container.textContent).toContain('host.notebook.run')
   })
 
   it('routes R input to the selected kernel and renders the result as a you call block', async () => {

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -457,12 +457,12 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
     ? projectNotebookRunsForFrame(frameRuns, effectiveFrameFilter)
     : []
 
-  // Python is the default executable target. Other kernels appear only after producing a run.
+  // Kernels appear only after producing a run in the current projected history.
   const kindsWithRuns = new Set(projectedRuns.map(resolveRunKernelKind))
-  const visibleKinds = KERNEL_KIND_ORDER.filter(
-    (kind) => kind === 'python' || kindsWithRuns.has(kind)
-  )
-  const effectiveActiveKind = visibleKinds.includes(activeKind) ? activeKind : 'python'
+  const visibleKinds = KERNEL_KIND_ORDER.filter((kind) => kindsWithRuns.has(kind))
+  const effectiveActiveKind = visibleKinds.includes(activeKind)
+    ? activeKind
+    : (visibleKinds[0] ?? 'python')
   const kindRuns = projectedRuns.filter((run) => resolveRunKernelKind(run) === effectiveActiveKind)
 
   // Per-environment selector (design D6): only python/r are env-scoped. Distinct env names among


### PR DESCRIPTION
## Problem

PR #1615 made R, Agent SDK, and Bash tabs history-driven but kept Python permanently visible. A Notebook history can contain only R or only Agent SDK runs, so the preview still showed an unused Python tab and selected an empty Python view.

## Proposed change

- Derive every visible kernel tab from the current projected Notebook run history.
- When the previous selection is absent, select the first kernel that actually has a projected run.
- Cover empty, Python-only, R-only, Agent SDK-only, and mixed histories with renderer regression assertions.

## Scope and non-goals

- No persistence or schema changes.
- No new state or enum values.
- No historical-data migration or compatibility branch is required; existing run history already supplies the visibility evidence.
- No new user-visible strings.
- The read-only Session Notebook dialog already uses the same history-driven rule and is unchanged.

## Acceptance criteria and validation

All listed local checks ran after the last material edit.

- Kernel tab visibility and fallback selection -> `npm test -- src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx` -> 36 tests passed.
- Renderer type safety -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint` -> passed with 0 errors and 2 pre-existing Prettier warnings in unchanged ACP files.
- Impact explanation -> `npm run test:affected:explain -- --base origin/main --head HEAD` -> conservatively selected the full suite because the render test has no registered module owner. Per maintainer direction, the full local suite was not run; PR Gate is the final authority.

Uncovered local risk: platform-specific renderer behavior is not exercised locally. The change is DOM-only and does not cross a platform or process boundary.

## Review focus

Confirm that the live Notebook preview shows only kernel kinds present in the selected Agent Frame history, and that R-only or Agent SDK-only histories immediately select and display that sole kind.

Follow-up to #1615.
