### PR TITLE
test(settings): include native CLI in Codex uninstall fallback

### DIFF
--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -4883,17 +4883,29 @@ describe('SettingsService: uninstall managed runtime', () => {
   it('falls through to ready Codex when earlier fallback runtimes are unavailable', async () => {
     const opencodeBin = join(managedOpencodeDir(storageRoot), 'opencode')
     const codexAdapter = join(storageRoot, 'fallback', 'codex-acp')
+    const nativePath = join(storageRoot, 'fallback', 'codex')
     await mkdir(dirname(opencodeBin), { recursive: true })
     await mkdir(dirname(codexAdapter), { recursive: true })
     await writeFile(opencodeBin, '', 'utf8')
     await writeFile(codexAdapter, '', 'utf8')
+    await writeFile(nativePath, '', 'utf8')
     await repository.setOpencodeInfo(opencodeBin, '1.18.3')
-    await repository.setCodexInfo({ resolvedPath: codexAdapter, version: '1.6.2' })
+    await repository.setCodexInfo({
+      resolvedPath: codexAdapter,
+      version: '1.6.2',
+      nativePath,
+      nativeVersion: '0.144.6'
+    })
     await repository.setAgentFramework('opencode')
     const service = createService(
       { found: false },
       {
-        codexDetected: { path: codexAdapter, version: 'codex-acp 1.6.2' }
+        codexDetected: {
+          path: codexAdapter,
+          version: 'codex-acp 1.6.2',
+          nativePath,
+          nativeVersion: 'codex-cli 0.144.6'
+        }
       }
     )
 


### PR DESCRIPTION
## Problem

Nightly and Windows Full Test on `main` fail after recently merged PRs:

```
FAIL src/main/settings/service.test.ts > SettingsService: uninstall managed runtime > falls through to ready Codex when earlier fallback runtimes are unavailable
expected 'opencode' to be 'codex'
```

`#1594` tightened Codex uninstall fallback so a candidate is ready only when:

- the adapter version is supported (`>= 1.6.2`)
- a stored native CLI path exists
- that native CLI still reports a version

The service-level fixture still recorded only the adapter path/version. Uninstall therefore left the active framework on OpenCode, matching the existing “not ready, do not auto-switch” rule.

PR Gate on `#1594` itself failed this module test, but the PR was merged. Later PRs did not re-run the full portable suite, so Nightly and Windows Full Test kept failing on `main`.

Earlier Nightly failures from `#1587` / `#1593` (renderer inventory count and `workspace-message-queue-controller.ts` line-budget) were already resolved by later merges (`#1603` split the queue controller). The remaining `main` failure is this Codex fallback fixture.

## Proposed change

Give the uninstall-fallback fixture a complete ready Codex pair: adapter plus native CLI path/version, matching `agent-runtime-manager.test.ts`.

No production code change.

## Scope and non-goals

- In scope: the stale service-level fixture for uninstall fallback.
- Out of scope: changing fallback order, readiness rules, or stored Codex records.

## Acceptance criteria and validation

- Uninstalling managed OpenCode selects Codex when Claude is unavailable and the stored Codex adapter + native CLI are ready.
- Nightly / Windows Full Test no longer fail this assertion.

### Evidence mapping (after last material edit)

| Behavior | Command | Result |
| --- | --- | --- |
| Uninstall fallback to ready Codex | `npm test -- src/main/settings/service.test.ts -t 'SettingsService: uninstall managed runtime'` | 6 passed |
| Runtime-manager uninstall guards | `npm test -- src/main/settings/agent-runtime-manager.test.ts -t uninstall` | 4 passed |
| Settings service owner file | `npm test -- src/main/settings/service.test.ts` | 257 passed |
| Other `settings_service_facade` owner tests | `npm test -- src/main/settings/service.providers.test.ts src/main/settings/service.connectors.test.ts src/main/settings/settings-backend.architecture.test.ts` | 15 passed |
| Lint changed test | `npx eslint src/main/settings/service.test.ts` | no issues |

PR Gate remains authoritative for the complete portable and platform suites.

Excluded: full `npm test`, typecheck (test-only fixture), consumer IPC/renderer contract tests (fixture only, no interface change).

## Review focus

- Fixture now supplies the same native-CLI readiness data production `autoSwitchAwayFrom` requires.
- This does not relax the `#1594` contract.

## Historical compatibility

Not changed by this PR. Already in effect from `#1594`: stored Codex records that have an adapter but no usable `nativePath` / native version are **not** treated as a ready fallback after uninstalling another runtime. The active framework stays on the uninstalled id (here OpenCode) until the user updates or re-detects Codex.

No backfill or migration of historical `codex` records is included. If we need old adapter-only records to become fallback-eligible, that is a separate product decision.

## New state / enum values

None.

## Persistence

None. This PR does not add or change stored fields. `codex.nativePath` / `codex.nativeVersion` already exist from the Codex pair model.