### PR TITLE
fix(notebook): reject malformed host connector calls

### DIFF
--- a/src/main/notebook/local-rpc-server.mcpcall.test.ts
+++ b/src/main/notebook/local-rpc-server.mcpcall.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { AgentComputeService } from '../compute/agent-compute-service'
+import { ConnectorService } from '../connectors/service'
 import { NotebookLocalRpcServer } from './local-rpc-server'
+import type { SpecialistProfileView } from '../../shared/specialist'
 
 const fakeConnector = {
   call: async (s: string, m: string, a: Record<string, unknown>) => ({ s, m, a })
@@ -116,6 +118,52 @@ describe('mcpCall RPC', () => {
     })
     expect(await res.json()).toEqual({
       result: { s: 'chemistry', m: 'pubchem_get_properties', a: { cids: [1] } }
+    })
+  })
+
+  it('rejects a tool name passed as the server without reporting a Specialist permission denial', async () => {
+    const specialist: SpecialistProfileView = {
+      id: 'literature-specialist',
+      name: 'Literature Specialist',
+      description: '',
+      systemPrompt: '',
+      enabled: true,
+      capabilityMode: 'selected',
+      fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+      selectedCapabilities: {
+        skillIds: [],
+        connectorIds: ['literature'],
+        connectorTools: []
+      },
+      revision: 1
+    }
+    const connectorService = new ConnectorService({
+      getConnectors: () => ({ enabledIds: [], autoAllowIds: [] }),
+      resolveApiKey: () => undefined,
+      resolveSpecialistProfile: async () => specialist
+    })
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      connectorService
+    })
+    server.registerSessionSpecialist('s-42', specialist.id)
+    const { endpoint, token } = await sessionConnection(server)
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        method: 'mcpCall',
+        params: {
+          server: 'openalex_search_works',
+          method: { query: 'osimertinib EGFR T790M resistance NSCLC' }
+        }
+      })
+    })
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      error: 'mcpCall requires string server and method names.'
     })
   })
 

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -2019,8 +2019,11 @@ class NotebookLocalRpcServer {
     // handler can attribute side effects to the session that invoked it.
     if (method === 'mcpCall') {
       if (!this.connectorService) throw new Error('Connector service is not configured.')
-      const server = typeof params.server === 'string' ? params.server : ''
-      const toolMethod = typeof params.method === 'string' ? params.method : ''
+      if (typeof params.server !== 'string' || typeof params.method !== 'string') {
+        throw new Error('mcpCall requires string server and method names.')
+      }
+      const server = params.server
+      const toolMethod = params.method
       const args = isRecord(params.args) ? params.args : {}
       const sessionId = typeof params.sessionId === 'string' ? params.sessionId : undefined
       const projectId = typeof params.projectId === 'string' ? params.projectId : undefined


### PR DESCRIPTION
## Problem

A malformed two-argument call such as `host.mcp("openalex_search_works", args)` reaches the Notebook RPC boundary with the args object in `params.method`. The boundary silently converted that non-string method to an empty string and dispatched it through the Specialist capability gate, which returned `specialist_capability_denied` even when the current Specialist had the required `literature` Connector.

The supported call remains `host.mcp("literature", "openalex_search_works", args)`.

## Proposed change

- Validate that `mcpCall` receives string `server` and `method` route names before Connector authorization.
- Return the explicit contract error `mcpCall requires string server and method names.` for malformed calls.
- Add a regression test at the authenticated Notebook RPC boundary with a real Specialist-scoped `ConnectorService`.

## Scope and non-goals

- Valid Connector calls and Specialist capability policy are unchanged.
- No new two-argument `host.mcp(toolName, args)` overload is introduced.
- Historical data compatibility: none.
- New states or enum values: none.
- Persistence changes: none.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Malformed tool-as-server call with a valid `literature` Specialist -> `npm test -- src/main/notebook/local-rpc-server.mcpcall.test.ts -t 'rejects a tool name passed as the server'` -> failed twice before the fix with `specialist_capability_denied`; passed after the fix.
- Notebook `mcpCall` contract and Specialist Connector gate -> `npm test -- src/main/notebook/local-rpc-server.mcpcall.test.ts src/main/connectors/service.test.ts` -> 84 passed.
- Main-process types -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed with 0 errors and two pre-existing Prettier warnings in unrelated `src/main/acp/` files.
- Final impact explanation -> `npm run test:affected -- --base origin/main --head HEAD --explain` -> full PR Gate plan because `local-rpc-server.ts` is not assigned to a module owner.

The dispatch validation is shared by Claude Code, OpenCode, Codex Response/Bridge and by TCP/named-pipe transports, so no framework- or platform-specific behavior branches were added. Full portable and platform coverage remains with PR CI.

## Review focus

- Confirm malformed route fields are rejected before Specialist authorization.
- Confirm the error remains free of Connector arguments and Specialist profile content.
