### PR TITLE
fix(settings): complete Codex fallback fixture

### DIFF
--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -4883,17 +4883,28 @@ describe('SettingsService: uninstall managed runtime', () => {
   it('falls through to ready Codex when earlier fallback runtimes are unavailable', async () => {
     const opencodeBin = join(managedOpencodeDir(storageRoot), 'opencode')
     const codexAdapter = join(storageRoot, 'fallback', 'codex-acp')
+    const codexNative = join(storageRoot, 'fallback', 'codex')
     await mkdir(dirname(opencodeBin), { recursive: true })
     await mkdir(dirname(codexAdapter), { recursive: true })
     await writeFile(opencodeBin, '', 'utf8')
     await writeFile(codexAdapter, '', 'utf8')
     await repository.setOpencodeInfo(opencodeBin, '1.18.3')
-    await repository.setCodexInfo({ resolvedPath: codexAdapter, version: '1.6.2' })
+    await repository.setCodexInfo({
+      resolvedPath: codexAdapter,
+      version: '1.6.2',
+      nativePath: codexNative,
+      nativeVersion: '0.144.6'
+    })
     await repository.setAgentFramework('opencode')
     const service = createService(
       { found: false },
       {
-        codexDetected: { path: codexAdapter, version: 'codex-acp 1.6.2' }
+        codexDetected: {
+          path: codexAdapter,
+          version: 'codex-acp 1.6.2',
+          nativePath: codexNative,
+          nativeVersion: 'codex-cli 0.144.6'
+        }
       }
     )
 


### PR DESCRIPTION
## Problem

The Nightly verification job fails because the SettingsService Codex fallback test expects Codex to be selected while its fixture only provides the ACP adapter. Production readiness now also requires a usable native Codex CLI, so the fixture describes an incomplete runtime and correctly remains on OpenCode.

## Proposed change

Add the native Codex path and version to the stored settings and detection mock used by the existing fallback test. This makes the fixture match the runnable Codex state named by the test.

## Scope and non-goals

- Test fixture only; no production behavior changes.
- No changes to fallback ordering or Codex readiness requirements.
- No new helpers, dependencies, or UI copy.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Runnable Codex fallback fixture -> npm run test:module -- settings_service_facade -> 28 files passed, 766 tests passed.
- Module-impact manifest validity -> npm test -- scripts/ci/validate-module-impact.test.ts -> 1 file passed, 9 tests passed.
- Affected Node process types -> NODE_OPTIONS=--max-old-space-size=4096 npm run typecheck:node -> passed.
- Repository lint -> npm run lint -> passed.

The module check included the declared Settings owner, contract, and consumer tests plus the renderer_settings, settings_ipc, and windows_sensitive capability overlays. UI E2E and packaging lanes were excluded because this changes only test data and does not alter an interface, production code, UI, persistence, or platform behavior.

Uncovered risks: independent review and authoritative PR CI are pending.

## Review focus

Confirm that the fixture now represents the production Codex readiness contract: a supported ACP adapter plus a version-reporting native CLI.
