### PR TITLE
feat(side-chat): inject advisories into running main turns

### DIFF
--- a/src/main/acp/native-follow-up-workflow.test.ts
+++ b/src/main/acp/native-follow-up-workflow.test.ts
@@ -178,6 +178,37 @@ describe('AcpNativeFollowUpWorkflow', () => {
     expect(published).toEqual([])
   })
 
+  it('refuses an advisory when steering starts a new Main turn', async () => {
+    const { workflow } = createWorkflow({
+      request: vi.fn(async () => ({ outcome: 'startedNewTurn' }))
+    })
+
+    await expect(
+      workflow.steerSideChatAdvisory({ sessionId: 'app-1', text: 'Context-only advisory' })
+    ).resolves.toEqual({ injected: false })
+    expect(published).toEqual([])
+  })
+
+  it('refuses an advisory when Main changes turns during steering', async () => {
+    let liveTurnToken = 'turn-1'
+    const { workflow } = createWorkflow({
+      request: vi.fn(async () => {
+        liveTurnToken = 'turn-2'
+        return { outcome: 'injected' }
+      }),
+      livePromptTurn: () => ({
+        turnToken: liveTurnToken,
+        signal: new AbortController().signal,
+        promptMessageId: liveTurnToken === 'turn-1' ? 'prompt-1' : 'prompt-2'
+      })
+    })
+
+    await expect(
+      workflow.steerSideChatAdvisory({ sessionId: 'app-1', text: 'Context-only advisory' })
+    ).resolves.toEqual({ injected: false })
+    expect(published).toEqual([])
+  })
+
   it('treats startedNewTurn as injected because the adapter consumed the prompt', async () => {
     const { workflow } = createWorkflow({
       request: vi.fn(async () => ({ outcome: 'startedNewTurn' }))

--- a/src/main/acp/native-follow-up-workflow.test.ts
+++ b/src/main/acp/native-follow-up-workflow.test.ts
@@ -16,7 +16,8 @@ const createWorkflow = (
     advertised?: boolean
     livePrompt?: boolean | (() => boolean)
     pendingPermission?: boolean | (() => boolean)
-    livePromptTurn?: () => { turnToken: string; signal: AbortSignal } | undefined
+    livePromptTurn?: () =>
+      { turnToken: string; signal: AbortSignal; promptMessageId?: string } | undefined
     frameworkId?: 'claude-code' | 'opencode' | 'codex'
     openCodeHttp?: boolean
     providerSessionId?: string | null
@@ -78,7 +79,13 @@ const createWorkflow = (
           typeof overrides.livePrompt === 'function'
             ? overrides.livePrompt()
             : (overrides.livePrompt ?? true)
-        return isLive ? { turnToken: 'turn-1', signal: new AbortController().signal } : undefined
+        return isLive
+          ? {
+              turnToken: 'turn-1',
+              signal: new AbortController().signal,
+              promptMessageId: 'prompt-live'
+            }
+          : undefined
       },
       sessionCwd: () => '/workspace',
       publishUserMessage: (input) => {
@@ -117,6 +124,58 @@ describe('AcpNativeFollowUpWorkflow', () => {
     expect(published).toEqual([
       { sessionId: 'app-1', messageId: 'message-steer-1', text: 'focus on tests' }
     ])
+  })
+
+  it('injects an advisory without publishing an ordinary user message', async () => {
+    const { workflow } = createWorkflow()
+
+    await expect(
+      workflow.steerSideChatAdvisory({ sessionId: 'app-1', text: 'Context-only advisory' })
+    ).resolves.toEqual({
+      injected: true,
+      promptMessageId: 'prompt-live'
+    })
+    expect(published).toEqual([])
+  })
+
+  it('refuses an advisory when the live prompt has no durable message identity', async () => {
+    const { workflow } = createWorkflow({
+      livePromptTurn: () => ({
+        turnToken: 'turn-1',
+        signal: new AbortController().signal
+      })
+    })
+
+    await expect(
+      workflow.steerSideChatAdvisory({ sessionId: 'app-1', text: 'Context-only advisory' })
+    ).resolves.toEqual({ injected: false })
+    expect(published).toEqual([])
+  })
+
+  it('refuses an advisory when Main changes turns while the advisory is prepared', async () => {
+    let livePromptReads = 0
+    const request = vi.fn(async () => ({ outcome: 'injected' }))
+    const { workflow } = createWorkflow({
+      request,
+      livePromptTurn: () => {
+        livePromptReads += 1
+        return {
+          turnToken: livePromptReads === 1 ? 'turn-1' : 'turn-2',
+          signal: new AbortController().signal,
+          promptMessageId: livePromptReads === 1 ? 'prompt-1' : 'prompt-2'
+        }
+      },
+      prepareFollowUp: async () => ({
+        prompt: [{ type: 'text' as const, text: 'Context-only advisory' }],
+        uploads: []
+      })
+    })
+
+    await expect(
+      workflow.steerSideChatAdvisory({ sessionId: 'app-1', text: 'Context-only advisory' })
+    ).resolves.toEqual({ injected: false })
+    expect(request).not.toHaveBeenCalled()
+    expect(published).toEqual([])
   })
 
   it('treats startedNewTurn as injected because the adapter consumed the prompt', async () => {

--- a/src/main/acp/native-follow-up-workflow.test.ts
+++ b/src/main/acp/native-follow-up-workflow.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { createMainPromptSideChatRelay } from '../side-chat/main-prompt-relay'
 import {
   AcpNativeFollowUpWorkflow,
   finalizeNativeFollowUpPreparedContent,
   type NativeFollowUpUserMessage
 } from './native-follow-up-workflow'
 import { ACP_STEERING_METHOD } from './native-follow-up'
+import { SideChatRelayOwner } from './side-chat-relay-owner'
 
 const published: NativeFollowUpUserMessage[] = []
 
@@ -178,18 +180,56 @@ describe('AcpNativeFollowUpWorkflow', () => {
     expect(published).toEqual([])
   })
 
-  it('refuses an advisory when steering starts a new Main turn', async () => {
+  it('does not requeue an advisory after steering consumes it into a new Main turn', async () => {
+    let originalTurnRunning = true
     const { workflow } = createWorkflow({
-      request: vi.fn(async () => ({ outcome: 'startedNewTurn' }))
+      request: vi.fn(async () => {
+        originalTurnRunning = false
+        return { outcome: 'startedNewTurn' }
+      }),
+      livePromptTurn: () =>
+        originalTurnRunning
+          ? {
+              turnToken: 'turn-1',
+              signal: new AbortController().signal,
+              promptMessageId: 'prompt-live'
+            }
+          : undefined
+    })
+    const relay = new SideChatRelayOwner({
+      targetState: () => 'running',
+      appendRelay: async () => undefined
+    })
+    relay.bind({
+      sideSessionId: 'side-1',
+      sideChatId: 'chat-1',
+      parentSessionId: 'app-1',
+      projectId: 'project-1'
+    })
+    const queued = await relay.send({
+      sideSessionId: 'side-1',
+      target: 'main',
+      text: 'Context-only advisory'
+    })
+    const commitSideChatRelays = vi.fn(async () => [])
+    const mainRelay = createMainPromptSideChatRelay({
+      relay,
+      steerAdvisory: (request) => workflow.steerSideChatAdvisory(request),
+      commitSideChatRelays,
+      onDelivered: vi.fn()
     })
 
-    await expect(
-      workflow.steerSideChatAdvisory({ sessionId: 'app-1', text: 'Context-only advisory' })
-    ).resolves.toEqual({ injected: false })
+    await expect(mainRelay.tryInject('app-1', queued)).resolves.toMatchObject({
+      status: 'injected'
+    })
+    expect(commitSideChatRelays).toHaveBeenCalledWith(
+      expect.objectContaining({ relayIds: [queued.messageId], promptMessageId: 'prompt-live' })
+    )
+    expect(mainRelay.claim('app-1')).toBeUndefined()
     expect(published).toEqual([])
   })
 
-  it('refuses an advisory when Main changes turns during steering', async () => {
+  it('keeps an advisory consumed when Main finishes during steering', async () => {
     let liveTurnToken = 'turn-1'
     const { workflow } = createWorkflow({
       request: vi.fn(async () => {
@@ -205,7 +245,7 @@ describe('AcpNativeFollowUpWorkflow', () => {
 
     await expect(
       workflow.steerSideChatAdvisory({ sessionId: 'app-1', text: 'Context-only advisory' })
-    ).resolves.toEqual({ injected: false })
+    ).resolves.toEqual({ injected: true, promptMessageId: 'prompt-1' })
     expect(published).toEqual([])
   })
 

--- a/src/main/acp/native-follow-up-workflow.ts
+++ b/src/main/acp/native-follow-up-workflow.ts
@@ -298,14 +298,6 @@ class AcpNativeFollowUpWorkflow {
         return refused('dispatch-failed')
       }
       const outcome = parseSteerOutcome(result)
-      if (expectedTurnToken && outcome.kind === 'started-new-turn') {
-        log.info('native follow-up refused', {
-          sessionId: request.sessionId,
-          reason: 'started-new-turn',
-          transport: route.transport
-        })
-        return refused('started-new-turn')
-      }
       const dispatched = interpretSteerOutcome(outcome)
       if (dispatched.kind !== 'injected') {
         log.info('native follow-up refused', {
@@ -352,14 +344,6 @@ class AcpNativeFollowUpWorkflow {
     }
 
     const sameLivePrompt = this.sameLivePrompt(request.sessionId, live)
-    if (expectedTurnToken && !sameLivePrompt) {
-      log.info('native follow-up refused', {
-        sessionId: request.sessionId,
-        reason: 'no-live-turn',
-        transport: route.transport
-      })
-      return refused('no-live-turn')
-    }
     if (sameLivePrompt) {
       await this.commitNotebookTurnInputs(notebookTurnInputs)
     } else {

--- a/src/main/acp/native-follow-up-workflow.ts
+++ b/src/main/acp/native-follow-up-workflow.ts
@@ -71,7 +71,11 @@ type NativeFollowUpRegisterTurnInputs = (request: {
 type NativeFollowUpLivePrompt = Readonly<{
   turnToken: string
   signal: AbortSignal
+  promptMessageId?: string
 }>
+
+type SideChatAdvisoryFollowUpResult =
+  Readonly<{ injected: true; promptMessageId: string }> | Readonly<{ injected: false }>
 
 type NativeFollowUpWorkflowOptions = Readonly<{
   connection: () => ClientConnection | undefined
@@ -163,7 +167,26 @@ const injected = (transport: NativeFollowUpTransport, messageId: string): AcpSte
 class AcpNativeFollowUpWorkflow {
   constructor(private readonly options: NativeFollowUpWorkflowOptions) {}
 
+  async steerSideChatAdvisory(
+    request: AcpSteerFollowUpRequest
+  ): Promise<SideChatAdvisoryFollowUpResult> {
+    const live = this.options.livePrompt?.(request.sessionId)
+    if (!live?.promptMessageId) return Object.freeze({ injected: false })
+    const result = await this.dispatch(request, false, live.turnToken)
+    return result.injected
+      ? Object.freeze({ injected: true, promptMessageId: live.promptMessageId })
+      : Object.freeze({ injected: false })
+  }
+
   async steerFollowUp(request: AcpSteerFollowUpRequest): Promise<AcpSteerFollowUpResult> {
+    return this.dispatch(request, true)
+  }
+
+  private async dispatch(
+    request: AcpSteerFollowUpRequest,
+    publishUserMessage: boolean,
+    expectedTurnToken?: string
+  ): Promise<AcpSteerFollowUpResult> {
     const text = typeof request.text === 'string' ? request.text : ''
     const attachments = request.attachments ?? []
     const forcedSkillIds = request.forcedSkillIds ?? []
@@ -229,6 +252,14 @@ class AcpNativeFollowUpWorkflow {
 
     const live = this.options.livePrompt?.(request.sessionId)
     if (!this.options.hasLivePrompt(request.sessionId) || (this.options.livePrompt && !live)) {
+      log.info('native follow-up refused', {
+        sessionId: request.sessionId,
+        reason: 'no-live-turn',
+        transport: route.transport
+      })
+      return refused('no-live-turn')
+    }
+    if (expectedTurnToken && live?.turnToken !== expectedTurnToken) {
       log.info('native follow-up refused', {
         sessionId: request.sessionId,
         reason: 'no-live-turn',
@@ -324,13 +355,15 @@ class AcpNativeFollowUpWorkflow {
     const messageId = this.options.createMessageId?.() ?? `message-${randomUUID()}`
     const uploads = persistableUploads(preparedUploads ?? attachments)
     const parts = request.parts ?? []
-    this.options.publishUserMessage({
-      sessionId: request.sessionId,
-      messageId,
-      text,
-      ...(uploads.length > 0 ? { uploads } : {}),
-      ...(parts.length > 0 ? { parts } : {})
-    })
+    if (publishUserMessage) {
+      this.options.publishUserMessage({
+        sessionId: request.sessionId,
+        messageId,
+        text,
+        ...(uploads.length > 0 ? { uploads } : {}),
+        ...(parts.length > 0 ? { parts } : {})
+      })
+    }
     log.info('native follow-up injected', {
       sessionId: request.sessionId,
       transport: route.transport,
@@ -426,5 +459,6 @@ export { AcpNativeFollowUpWorkflow, finalizeNativeFollowUpPreparedContent }
 export type {
   NativeFollowUpPreparedContent,
   NativeFollowUpUserMessage,
-  NativeFollowUpWorkflowOptions
+  NativeFollowUpWorkflowOptions,
+  SideChatAdvisoryFollowUpResult
 }

--- a/src/main/acp/native-follow-up-workflow.ts
+++ b/src/main/acp/native-follow-up-workflow.ts
@@ -297,7 +297,16 @@ class AcpNativeFollowUpWorkflow {
         })
         return refused('dispatch-failed')
       }
-      const dispatched = interpretSteerOutcome(parseSteerOutcome(result))
+      const outcome = parseSteerOutcome(result)
+      if (expectedTurnToken && outcome.kind === 'started-new-turn') {
+        log.info('native follow-up refused', {
+          sessionId: request.sessionId,
+          reason: 'started-new-turn',
+          transport: route.transport
+        })
+        return refused('started-new-turn')
+      }
+      const dispatched = interpretSteerOutcome(outcome)
       if (dispatched.kind !== 'injected') {
         log.info('native follow-up refused', {
           sessionId: request.sessionId,
@@ -342,7 +351,16 @@ class AcpNativeFollowUpWorkflow {
       }
     }
 
-    if (this.sameLivePrompt(request.sessionId, live)) {
+    const sameLivePrompt = this.sameLivePrompt(request.sessionId, live)
+    if (expectedTurnToken && !sameLivePrompt) {
+      log.info('native follow-up refused', {
+        sessionId: request.sessionId,
+        reason: 'no-live-turn',
+        transport: route.transport
+      })
+      return refused('no-live-turn')
+    }
+    if (sameLivePrompt) {
       await this.commitNotebookTurnInputs(notebookTurnInputs)
     } else {
       log.info('native follow-up skipped notebook registration', {

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -75,6 +75,7 @@ const createFakeRuntime = (options: {
   sendPrompt: ReturnType<typeof vi.fn>
   sendAppContinuation: ReturnType<typeof vi.fn>
   steerFollowUp: ReturnType<typeof vi.fn>
+  steerSideChatAdvisory: ReturnType<typeof vi.fn>
   applyReasoningEffortChange: ReturnType<typeof vi.fn>
   applyModelChange: ReturnType<typeof vi.fn>
   captureBackend: ReturnType<typeof vi.fn>
@@ -215,6 +216,10 @@ const createFakeRuntime = (options: {
     transport: 'acp-steering' as const,
     messageId: 'message-steer-1'
   }))
+  const steerSideChatAdvisory = vi.fn(async () => ({
+    injected: true as const,
+    promptMessageId: 'prompt-live'
+  }))
   const sendApplicationPrompt = vi.fn(
     (
       ...[request, _attribution, promptAttemptId]: Parameters<AcpRuntime['sendApplicationPrompt']>
@@ -253,6 +258,7 @@ const createFakeRuntime = (options: {
     sendApplicationPrompt,
     sendAppContinuation,
     steerFollowUp,
+    steerSideChatAdvisory,
     withActivity: vi.fn(
       async (_activityOptions: unknown, work: (scopedRuntime: AcpRuntime) => Promise<unknown>) =>
         work(runtime)
@@ -296,6 +302,7 @@ const createFakeRuntime = (options: {
     sendPrompt,
     sendAppContinuation,
     steerFollowUp,
+    steerSideChatAdvisory,
     applyReasoningEffortChange,
     applyModelChange,
     captureBackend,
@@ -2220,6 +2227,46 @@ describe('AcpRuntimeCoordinator', () => {
       coordinator.steerFollowUp({ sessionId: session.sessionId, text: 'focus on tests' })
     ).rejects.toThrow(/Close Side chat/)
     expect(createdRuntime.steerFollowUp).not.toHaveBeenCalled()
+  })
+
+  it('admits a Side chat advisory through the deletion fence without opening a Main prompt', async () => {
+    const dispatchAdmission = createDeferred<void>()
+    let createdRuntime!: ReturnType<typeof createFakeRuntime>
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      createdRuntime = createFakeRuntime({
+        frameworkId: 'claude-code',
+        sessionIds: ['session-1'],
+        callbacks
+      })
+      return createdRuntime.runtime
+    })
+    const session = await coordinator.createSession({ cwd: '/workspace' })
+    const promptAdmissionGuard = vi.fn(async () => {
+      throw new Error('Side chat owns Main prompt admission.')
+    })
+    coordinator.setPromptAdmissionGuard(promptAdmissionGuard)
+    coordinator.setPromptDispatchAdmissionGuard(async (_sessionId, dispatch) => {
+      await dispatchAdmission.promise
+      return dispatch()
+    })
+
+    const advisory = coordinator.steerSideChatAdvisory({
+      sessionId: session.sessionId,
+      text: 'context-only advisory'
+    })
+    await Promise.resolve()
+    expect(createdRuntime.steerSideChatAdvisory).not.toHaveBeenCalled()
+
+    dispatchAdmission.resolve()
+    await expect(advisory).resolves.toEqual({
+      injected: true,
+      promptMessageId: 'prompt-live'
+    })
+    expect(promptAdmissionGuard).not.toHaveBeenCalled()
+    expect(createdRuntime.steerSideChatAdvisory).toHaveBeenCalledWith({
+      sessionId: session.sessionId,
+      text: 'context-only advisory'
+    })
   })
 
   it('does not reacquire dispatch admission for an already admitted continuation', async () => {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -1056,6 +1056,19 @@ class AcpRuntimeCoordinator {
       : dispatch()
   }
 
+  async steerSideChatAdvisory(
+    request: AcpSteerFollowUpRequest
+  ): ReturnType<AcpRuntime['steerSideChatAdvisory']> {
+    this.assertPromptAdmissionOpen()
+    await this.waitForInitialization()
+    this.assertPromptAdmissionOpen()
+    const dispatch = (): ReturnType<AcpRuntime['steerSideChatAdvisory']> =>
+      this.runtimeForSession(request.sessionId).steerSideChatAdvisory(request)
+    return this.promptDispatchAdmissionGuard
+      ? this.promptDispatchAdmissionGuard(request.sessionId, dispatch)
+      : dispatch()
+  }
+
   async cancelPrompt(request: AcpCancelPromptRequest): Promise<AcpStateSnapshot> {
     if (request.scope === 'subagents') {
       await this.delegatedWork?.stopActiveBranch?.(request.sessionId)

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -524,7 +524,11 @@ class AcpRuntime {
       livePrompt: (sessionId) => {
         const current = this.sessionInteractions.current(sessionId)
         return current?.kind === 'prompt'
-          ? { turnToken: current.turnToken, signal: current.signal }
+          ? {
+              turnToken: current.turnToken,
+              signal: current.signal,
+              ...(current.promptMessageId ? { promptMessageId: current.promptMessageId } : {})
+            }
           : undefined
       },
       sessionCwd: (sessionId) => this.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().cwd,
@@ -1123,6 +1127,14 @@ class AcpRuntime {
   async steerFollowUp(request: AcpSteerFollowUpRequest): Promise<AcpSteerFollowUpResult> {
     return this.withOperationLease(() =>
       withDataRootWrite(() => this.nativeFollowUp.steerFollowUp(request))
+    )
+  }
+
+  async steerSideChatAdvisory(
+    request: AcpSteerFollowUpRequest
+  ): ReturnType<AcpNativeFollowUpWorkflow['steerSideChatAdvisory']> {
+    return this.withOperationLease(() =>
+      withDataRootWrite(() => this.nativeFollowUp.steerSideChatAdvisory(request))
     )
   }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -773,6 +773,10 @@ const createApplicationModules = async (
   })
   const mainPromptSideChatRelay = createMainPromptSideChatRelay({
     relay: sideChatRelay,
+    steerAdvisory: async (request) =>
+      runtimeRef.current
+        ? runtimeRef.current.steerSideChatAdvisory(request)
+        : Object.freeze({ injected: false }),
     commitSideChatRelays: (command) => sessionPersistenceCoordinator.commitSideChatRelays(command),
     onDelivered: (event) => broadcastToRenderers('side-chat:relay-delivered', event)
   })
@@ -2194,6 +2198,8 @@ const createApplicationModules = async (
       resolveTarget: (target, context) =>
         settingsService.resolveExplicitAgentBackend(target, context),
       relay: sideChatRelay,
+      deliverRelay: (parentSessionId, queued) =>
+        mainPromptSideChatRelay.tryInject(parentSessionId, queued),
       persistence: {
         save: ({ projectId, parentSessionId, sideChat }) =>
           sessionPersistenceCoordinator.saveSideChatProjection({

--- a/src/main/side-chat/host-message-mcp-server.ts
+++ b/src/main/side-chat/host-message-mcp-server.ts
@@ -15,7 +15,7 @@ const HOST_MESSAGE_NAMESPACED_TOOLS = [
   {
     namespace: 'mcp__open_science_host_message',
     name: HOST_SEND_MESSAGE_TOOL_NAME,
-    description: `Queue advisory text for the parent main conversation without waking or interrupting it. Use only after the user explicitly asks in the current Side chat turn to send, relay, forward, or tell something to Main. Do not use for ordinary Side chat questions, requests, follow-ups, or suggestions. ${HOST_MESSAGE_CONTENT_INSTRUCTION}`,
+    description: `Send advisory context to the parent main conversation. If Main is running, delivery is attempted in the current turn; otherwise it is queued for the next real main user turn without waking Main. Use only after the user explicitly asks in the current Side chat turn to send, relay, forward, or tell something to Main. Do not use for ordinary Side chat questions, requests, follow-ups, or suggestions. ${HOST_MESSAGE_CONTENT_INSTRUCTION}`,
     parameters: {
       type: 'object',
       properties: {
@@ -42,7 +42,7 @@ const createHostMessageMcpServer = (handler: HostMessageMcpHandler): ModelContex
     HOST_SEND_MESSAGE_TOOL_NAME,
     {
       title: 'Send advisory to main',
-      description: `Queue advisory text for the parent main conversation. Use only after the user explicitly asks in the current Side chat turn to send, relay, forward, or tell something to Main. Do not use for ordinary Side chat questions, requests, follow-ups, or suggestions. ${HOST_MESSAGE_CONTENT_INSTRUCTION} This does not wake, interrupt, or authorize the main Agent; delivery waits for the next real main user turn.`,
+      description: `Send advisory context to the parent main conversation. If Main is running, delivery is attempted in the current turn; otherwise it is queued for the next real main user turn without waking Main. Use only after the user explicitly asks in the current Side chat turn to send, relay, forward, or tell something to Main. Do not use for ordinary Side chat questions, requests, follow-ups, or suggestions. ${HOST_MESSAGE_CONTENT_INSTRUCTION} This does not independently authorize the main Agent.`,
       inputSchema: {
         target: z.literal('main'),
         text: z.string().trim().min(1).max(SIDE_CHAT_MESSAGE_LIMIT)

--- a/src/main/side-chat/ipc.test.ts
+++ b/src/main/side-chat/ipc.test.ts
@@ -93,7 +93,12 @@ describe('Side chat IPC', () => {
     registerSideChatIpcHandlers(
       runtime as never,
       {
-        loadParentSession: vi.fn(async () => ({ messages: [] })),
+        loadParentSession: vi.fn(async () => ({
+          messages: [
+            { role: 'user', content: 'Please update the result.', status: 'complete' },
+            { role: 'assistant', content: 'Latest Main output.', status: 'complete' }
+          ]
+        })),
         hasLiveParentSession: vi.fn(() => false),
         withParentAvailable: vi.fn(async (_sessionId, operation) => operation())
       } as never
@@ -106,7 +111,11 @@ describe('Side chat IPC', () => {
     await handlers.get('side-chat:cancel')?.(undefined, { sideSessionId: 'side-1' } as never)
     await handlers.get('side-chat:close')?.(undefined, { sideSessionId: 'side-1' } as never)
 
-    expect(runtime.send).toHaveBeenCalledWith({ sideSessionId: 'side-1', text: 'Follow up' })
+    expect(runtime.send).toHaveBeenCalledWith({
+      sideSessionId: 'side-1',
+      text: 'Follow up',
+      historyPreamble: expect.stringContaining('Latest Main output.')
+    })
     expect(runtime.cancel).toHaveBeenCalledWith({ sideSessionId: 'side-1' })
     expect(runtime.close).toHaveBeenCalledWith({ sideSessionId: 'side-1' })
   })

--- a/src/main/side-chat/ipc.ts
+++ b/src/main/side-chat/ipc.ts
@@ -62,8 +62,14 @@ const registerSideChatIpcHandlers = (
     const parent = runtime.parentFor(request.sideSessionId)
     if (!parent) throw new Error('Side chat Session is not active.')
     return dependencies.withParentAvailable(parent.parentSessionId, async () => {
-      await loadAvailableParent(parent.projectId, parent.parentSessionId)
-      return runtime.send(request)
+      const parentSession = await loadAvailableParent(parent.projectId, parent.parentSessionId)
+      const historyPreamble = parentSession
+        ? buildHistoryPreamble(parentSession.messages, {
+            target: 'codex-bridge',
+            budget: SIDE_CHAT_MESSAGE_LIMIT
+          })
+        : undefined
+      return runtime.send({ ...request, historyPreamble })
     })
   })
   ipcMainHandle('side-chat:cancel', (_event, request: SideChatSessionRequest) =>

--- a/src/main/side-chat/main-prompt-relay.test.ts
+++ b/src/main/side-chat/main-prompt-relay.test.ts
@@ -65,6 +65,111 @@ describe('main prompt side-chat relay', () => {
     expect(adapter.claim('main-1')).toBeUndefined()
   })
 
+  it('injects a running relay into the live Main prompt and commits it against that prompt', async () => {
+    const relay = new SideChatRelayOwner({
+      targetState: () => 'running',
+      appendRelay: async () => undefined
+    })
+    relay.bind({
+      sideSessionId: 'side-1',
+      sideChatId: 'chat-1',
+      parentSessionId: 'main-1',
+      projectId: 'project-1'
+    })
+    const queued = await relay.send({
+      sideSessionId: 'side-1',
+      target: 'main',
+      text: 'Use the latest result.'
+    })
+    const steerAdvisory = vi.fn(async () => ({
+      injected: true as const,
+      promptMessageId: 'prompt-live'
+    }))
+    const commitSideChatRelays = vi.fn(async () => [])
+    const adapter = createMainPromptSideChatRelay({
+      relay,
+      steerAdvisory,
+      commitSideChatRelays,
+      onDelivered: vi.fn()
+    })
+
+    await expect(adapter.tryInject('main-1', queued)).resolves.toMatchObject({
+      status: 'injected',
+      delivery: 'current-turn',
+      messageId: queued.messageId,
+      persisted: true
+    })
+    expect(steerAdvisory).toHaveBeenCalledWith({
+      sessionId: 'main-1',
+      text: expect.stringContaining('Use the latest result.')
+    })
+    expect(commitSideChatRelays).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      sessionId: 'main-1',
+      relayIds: [queued.messageId],
+      promptMessageId: 'prompt-live'
+    })
+    expect(adapter.claim('main-1')).toBeUndefined()
+  })
+
+  it('restores a running relay when native injection is refused', async () => {
+    const relay = new SideChatRelayOwner({
+      targetState: () => 'running',
+      appendRelay: async () => undefined
+    })
+    relay.bind({
+      sideSessionId: 'side-1',
+      sideChatId: 'chat-1',
+      parentSessionId: 'main-1',
+      projectId: 'project-1'
+    })
+    const queued = await relay.send({
+      sideSessionId: 'side-1',
+      target: 'main',
+      text: 'Keep this durable.'
+    })
+    const adapter = createMainPromptSideChatRelay({
+      relay,
+      steerAdvisory: async () => ({ injected: false }),
+      commitSideChatRelays: vi.fn(),
+      onDelivered: vi.fn()
+    })
+
+    await expect(adapter.tryInject('main-1', queued)).resolves.toBe(queued)
+    expect(adapter.claim('main-1')?.historyPreamble).toContain('Keep this durable.')
+  })
+
+  it('restores a running relay when native injection fails unexpectedly', async () => {
+    const relay = new SideChatRelayOwner({
+      targetState: () => 'running',
+      appendRelay: async () => undefined
+    })
+    relay.bind({
+      sideSessionId: 'side-1',
+      sideChatId: 'chat-1',
+      parentSessionId: 'main-1',
+      projectId: 'project-1'
+    })
+    const queued = await relay.send({
+      sideSessionId: 'side-1',
+      target: 'main',
+      text: 'Keep this advisory durable.'
+    })
+    const adapter = createMainPromptSideChatRelay({
+      relay,
+      steerAdvisory: vi.fn(async () => {
+        throw new Error('transport unavailable')
+      }),
+      commitSideChatRelays: vi.fn(async () => []),
+      onDelivered: vi.fn()
+    })
+
+    await expect(adapter.tryInject('main-1', queued)).rejects.toThrow('transport unavailable')
+    const restored = adapter.claim('main-1')
+    expect(restored?.historyPreamble).toContain('Keep this advisory durable.')
+    restored?.restore()
+  })
+
   it('commits one parent claim containing relays from successive Side chats', async () => {
     const relay = new SideChatRelayOwner({
       targetState: () => 'idle',

--- a/src/main/side-chat/main-prompt-relay.test.ts
+++ b/src/main/side-chat/main-prompt-relay.test.ts
@@ -260,6 +260,47 @@ describe('main prompt side-chat relay', () => {
     )
   })
 
+  it('does not report the current relay as injected when an older bounded claim fills the turn', async () => {
+    const relay = new SideChatRelayOwner({
+      targetState: () => 'running',
+      appendRelay: async () => undefined
+    })
+    relay.bind({
+      sideSessionId: 'side-1',
+      sideChatId: 'chat-1',
+      parentSessionId: 'main-1',
+      projectId: 'project-1'
+    })
+    const first = await relay.send({
+      sideSessionId: 'side-1',
+      target: 'main',
+      text: `first-${'a'.repeat(7_000)}`
+    })
+    const second = await relay.send({
+      sideSessionId: 'side-1',
+      target: 'main',
+      text: `second-${'b'.repeat(7_000)}`
+    })
+    const commitSideChatRelays = vi.fn(async () => [])
+    const adapter = createMainPromptSideChatRelay({
+      relay,
+      steerAdvisory: vi.fn(async () => ({
+        injected: true as const,
+        promptMessageId: 'prompt-live'
+      })),
+      commitSideChatRelays,
+      onDelivered: vi.fn()
+    })
+
+    await expect(adapter.tryInject('main-1', second)).resolves.toBe(second)
+    expect(commitSideChatRelays).toHaveBeenCalledWith(
+      expect.objectContaining({ relayIds: [first.messageId], promptMessageId: 'prompt-live' })
+    )
+    const remaining = adapter.claim('main-1')
+    expect(remaining?.historyPreamble).toContain('second-')
+    remaining?.restore()
+  })
+
   it('restores a claim before provider admission', async () => {
     const relay = new SideChatRelayOwner({
       targetState: () => 'completed',

--- a/src/main/side-chat/main-prompt-relay.ts
+++ b/src/main/side-chat/main-prompt-relay.ts
@@ -1,5 +1,9 @@
 import type { PersistedChatMessage } from '../../shared/session-persistence'
-import { SIDE_CHAT_MESSAGE_LIMIT, type SideChatRelayDeliveredEvent } from '../../shared/side-chat'
+import {
+  SIDE_CHAT_MESSAGE_LIMIT,
+  type SideChatRelayDeliveredEvent,
+  type SideChatSendMessageResult
+} from '../../shared/side-chat'
 import type { SideChatRelayOwner } from '../acp/side-chat-relay-owner'
 import { createLogger } from '../logger'
 
@@ -7,6 +11,10 @@ const log = createLogger('side-chat-relay')
 
 type MainPromptSideChatRelayOptions = Readonly<{
   relay: SideChatRelayOwner
+  steerAdvisory?: (request: {
+    sessionId: string
+    text: string
+  }) => Promise<Readonly<{ injected: true; promptMessageId: string } | { injected: false }>>
   commitSideChatRelays: (command: {
     projectId: string
     sessionId: string
@@ -24,6 +32,10 @@ type MainPromptSideChatRelayClaim = Readonly<{
 
 type MainPromptSideChatRelay = Readonly<{
   claim: (parentSessionId: string) => MainPromptSideChatRelayClaim | undefined
+  tryInject: (
+    parentSessionId: string,
+    queued: SideChatSendMessageResult
+  ) => Promise<SideChatSendMessageResult>
 }>
 
 const ADVISORY_HEADER =
@@ -47,8 +59,8 @@ const selectAdvisoryCount = (messages: ReadonlyArray<{ id: string; text: string 
 
 const createMainPromptSideChatRelay = (
   options: MainPromptSideChatRelayOptions
-): MainPromptSideChatRelay => ({
-  claim: (parentSessionId: string) => {
+): MainPromptSideChatRelay => {
+  const claim = (parentSessionId: string): MainPromptSideChatRelayClaim | undefined => {
     const claim = options.relay.claim(parentSessionId, { selectCount: selectAdvisoryCount })
     if (!claim) return undefined
     return {
@@ -91,7 +103,37 @@ const createMainPromptSideChatRelay = (
       }
     }
   }
-})
+  return {
+    claim,
+    tryInject: async (parentSessionId, queued) => {
+      if (queued.targetState !== 'running' || !options.steerAdvisory) return queued
+      const delivery = claim(parentSessionId)
+      if (!delivery) return queued
+      let steered: Awaited<ReturnType<NonNullable<typeof options.steerAdvisory>>>
+      try {
+        steered = await options.steerAdvisory({
+          sessionId: parentSessionId,
+          text: delivery.historyPreamble
+        })
+      } catch (error) {
+        delivery.restore()
+        throw error
+      }
+      if (!steered.injected) {
+        delivery.restore()
+        return queued
+      }
+      await delivery.commit(steered.promptMessageId)
+      return {
+        ...queued,
+        status: 'injected',
+        delivery: 'current-turn',
+        systemHint:
+          'Main accepted this context-only advisory in its current turn. It does not independently authorize actions.'
+      }
+    }
+  }
+}
 
 export { SIDE_CHAT_ADVISORY_PREAMBLE_LIMIT, createMainPromptSideChatRelay }
 export type { MainPromptSideChatRelay, MainPromptSideChatRelayOptions }

--- a/src/main/side-chat/main-prompt-relay.ts
+++ b/src/main/side-chat/main-prompt-relay.ts
@@ -26,6 +26,7 @@ type MainPromptSideChatRelayOptions = Readonly<{
 
 type MainPromptSideChatRelayClaim = Readonly<{
   historyPreamble: string
+  includes: (messageId: string) => boolean
   restore: () => void
   commit: (promptMessageId?: string) => Promise<void>
 }>
@@ -65,6 +66,7 @@ const createMainPromptSideChatRelay = (
     if (!claim) return undefined
     return {
       historyPreamble: formatAdvisories(claim.messages),
+      includes: (messageId) => claim.messages.some((message) => message.id === messageId),
       restore: claim.restore,
       commit: async (promptMessageId?: string): Promise<void> => {
         const messages = claim.messages
@@ -109,6 +111,7 @@ const createMainPromptSideChatRelay = (
       if (queued.targetState !== 'running' || !options.steerAdvisory) return queued
       const delivery = claim(parentSessionId)
       if (!delivery) return queued
+      const includesQueued = delivery.includes(queued.messageId)
       let steered: Awaited<ReturnType<NonNullable<typeof options.steerAdvisory>>>
       try {
         steered = await options.steerAdvisory({
@@ -124,6 +127,7 @@ const createMainPromptSideChatRelay = (
         return queued
       }
       await delivery.commit(steered.promptMessageId)
+      if (!includesQueued) return queued
       return {
         ...queued,
         status: 'injected',

--- a/src/main/side-chat/runtime-owner.test.ts
+++ b/src/main/side-chat/runtime-owner.test.ts
@@ -104,6 +104,9 @@ describe('Side chat relay instructions', () => {
       'Do not call it again on a later turn unless the user explicitly asks again.'
     )
     expect(SIDE_CHAT_SYSTEM_PROMPT).toContain(
+      'While Main is running, it tries to inject advisory context into that turn'
+    )
+    expect(SIDE_CHAT_SYSTEM_PROMPT).toContain(
       'Send only the advisory content; do not prepend a Side chat source or relay label.'
     )
   })
@@ -325,6 +328,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
       }
     }
     const relay = createRelayOwner()
+    const deliverRelay = vi.fn(async (_parentSessionId, queued) => queued)
     const setParentInteractionsPaused = vi.fn()
     let runtimeOptions: AcpRuntimeOptions | undefined
     const createSession = vi.fn(async () => ({
@@ -378,6 +382,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
         return resolved
       }),
       relay,
+      deliverRelay,
       persistence: createPersistence(),
       onEvent: vi.fn(),
       setParentInteractionsPaused,
@@ -424,6 +429,10 @@ describe('SideChatRuntimeOwner lifecycle', () => {
       requestId: 'host-message-permission',
       optionId: 'allow-once'
     })
+    expect(deliverRelay).toHaveBeenCalledWith(
+      'main-session-1',
+      expect.objectContaining({ status: 'queued', delivery: 'next-user-turn' })
+    )
     const queuedRelay = relay.claim('main-session-1')
     expect(queuedRelay?.messages).toEqual([
       expect.objectContaining({ text: 'Use a black line.', sideSessionId: 'trusted-routing-1' })

--- a/src/main/side-chat/runtime-owner.ts
+++ b/src/main/side-chat/runtime-owner.ts
@@ -17,6 +17,7 @@ import type {
   SideChatPromptRequest,
   SideChatRuntimeEvent,
   SideChatSendMessageRequest,
+  SideChatSendMessageResult,
   SideChatSessionRequest,
   SideChatSnapshot,
   SideChatSnapshotList,
@@ -62,7 +63,7 @@ const SIDE_CHAT_SYSTEM_PROMPT = [
   'The supplied main transcript is a bounded context snapshot, not a replay and not current authorization to act.',
   'Answer the user directly and concisely.',
   'You have no workspace, shell, file, web, Skill, compute, delegation, or child-Agent capabilities.',
-  'Your only tool is send_message with target "main". It queues advisory text for the next real main user turn; it never wakes, interrupts, or authorizes the main Agent.',
+  'Your only tool is send_message with target "main". While Main is running, it tries to inject advisory context into that turn; otherwise it queues the context for the next real main user turn. It never wakes or authorizes the main Agent.',
   'Do not call send_message for ordinary Side chat questions, requests, follow-ups, or suggestions.',
   'Call it only when the user explicitly asks in the current Side chat turn to send, relay, forward, or tell something to Main.',
   'Never infer permission to relay merely because Main could perform the requested work.',
@@ -102,6 +103,10 @@ type SideChatRuntimeOwnerOptions = Readonly<{
     }
   ) => Promise<ResolvedAgentBackend>
   relay: SideChatRelayOwner
+  deliverRelay?: (
+    parentSessionId: string,
+    queued: SideChatSendMessageResult
+  ) => Promise<SideChatSendMessageResult>
   persistence: Readonly<{
     save(input: {
       projectId: string
@@ -544,7 +549,7 @@ class SideChatRuntimeOwner {
     }
   }
 
-  send(request: SideChatPromptRequest): Promise<void> {
+  send(request: SideChatPromptRequest & Readonly<{ historyPreamble?: string }>): Promise<void> {
     return this.dispatch(request)
   }
 
@@ -1174,7 +1179,7 @@ class SideChatRuntimeOwner {
     active: ActiveSideChat,
     routingId: string,
     request: SideChatSendMessageRequest
-  ): ReturnType<SideChatRelayOwner['send']> {
+  ): Promise<SideChatSendMessageResult> {
     if (active.closing || this.activeByParent.get(active.parentSessionId) !== active) {
       throw new Error('Side chat sender is no longer active.')
     }
@@ -1187,7 +1192,13 @@ class SideChatRuntimeOwner {
       })
       active.relaySenderIds.add(routingId)
     }
-    return this.options.relay.send({ sideSessionId: routingId, ...request })
+    return this.options.relay
+      .send({ sideSessionId: routingId, ...request })
+      .then((queued) =>
+        this.options.deliverRelay
+          ? this.options.deliverRelay(active.parentSessionId, queued)
+          : queued
+      )
   }
 
   private releaseRelaySenders(active: ActiveSideChat): void {

--- a/src/shared/side-chat.ts
+++ b/src/shared/side-chat.ts
@@ -8,10 +8,10 @@ export type SideChatSendMessageRequest = Readonly<{
 }>
 
 export type SideChatSendMessageResult = Readonly<{
-  status: 'queued'
+  status: 'queued' | 'injected'
   messageId: string
   targetState: SideChatTargetState
-  delivery: 'next-user-turn'
+  delivery: 'next-user-turn' | 'current-turn'
   persisted: true
   systemHint: string
 }>


### PR DESCRIPTION
## Problem

Side Chat currently receives only the Main transcript captured when it starts. Its `send_message` tool always waits for the next real Main user turn, even when Main is already running and the selected ACP backend can accept a native follow-up.

## Proposed change

- Refresh the bounded active-Branch Main transcript before every Side Chat follow-up.
- Persist each Side Chat relay first, then attempt context-only injection when Main is running.
- Reuse existing native follow-up transports:
  - Claude Code and Codex framework sessions: ACP `_session/steering` with prompt-required idle behavior.
  - OpenCode: authenticated HTTP message admission with `noReply: true`.
  - Codex Responses and Codex bridge backend variants share the Codex framework steering path.
- Suppress ordinary Main user-message publication for Side Chat advisories.
- Commit delivery against the captured live Main prompt only after native admission succeeds.
- Restore the durable relay for the next real Main user turn on refusal, transport failure, permission boundary, missing prompt identity, or turn-change race.

## Scope and non-goals

- No idle Main wake-up and no second prompt interaction.
- No renderer surface or user-visible localization changes.
- No new ACP transport or provider-specific protocol.
- No continuous transcript co-streaming; Side Chat refreshes at its own turn boundaries.

### Historical compatibility

Existing persisted Side Chat relays and sessions remain readable and use the same delivery path. No migration or backfill is required.

### State additions

`SideChatSendMessageResult` adds `status: "injected"` and `delivery: "current-turn"`. Existing `"queued"` / `"next-user-turn"` values remain unchanged.

### Persistence impact

No new tables, fields, record versions, or persisted enum values are introduced. Relays continue to use `PersistedSideChatRelay`; live injection is persist-first and only marks the existing relay delivered after a durable commit against the live prompt message id.

## Acceptance criteria and validation

All listed checks ran after the final material implementation edit.

- Live injection, framework routing, refusal/failure durability, prompt-identity and turn-race guards, Side Chat runtime/IPC contracts, and representative ACP consumers:
  - `npm test -- --run src/main/acp/native-follow-up.test.ts src/main/acp/native-follow-up-workflow.test.ts src/main/acp/runtime.test.ts src/main/acp/runtime-coordinator.test.ts src/main/acp/side-chat-relay-owner.test.ts src/main/acp/application-commands.test.ts src/main/acp/ipc.test.ts src/main/side-chat/host-message-mcp-server.test.ts src/main/side-chat/main-prompt-relay.test.ts src/main/side-chat/ipc.test.ts src/main/side-chat/runtime-owner.test.ts`
  - 11 files passed, 827 tests passed.
- Main/shared TypeScript contracts:
  - `npm run typecheck:node`
  - passed.
- Changed-file lint:
  - `npx eslint <14 changed TypeScript files>`
  - passed with no issues.
- Repository lint:
  - `npm run lint`
  - 0 errors; two existing Prettier warnings in unchanged `src/main/acp/application-commands.ts` and `src/main/acp/ipc.ts`.

Per task scope, the complete local `npm test` suite was not run; PR Gate is authoritative for complete portable and platform coverage. No E2E coverage was added because this changes main-process relay admission without renderer behavior.

## Review focus

- The narrow coordinator bypass: Side Chat advisory injection skips normal user-prompt admission while retaining initialization, quit, deletion, live-turn, and permission fences.
- Persist-first/restore-on-failure ordering in `MainPromptSideChatRelay.tryInject`.
- The distinction between context-only advisory delivery and ordinary Main user-message publication.
