### PR TITLE
test(vitest): stabilize the full-suite worker pool

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "format": "prettier --write .",
     "lint": "eslint --cache .",
+    "pretest": "node scripts/check-prisma-client.mjs",
     "test": "vitest run",
     "test:module": "node scripts/ci/module-test-impact.mjs module",
     "test:affected": "node scripts/ci/module-test-impact.mjs affected",

--- a/scripts/check-prisma-client.mjs
+++ b/scripts/check-prisma-client.mjs
@@ -18,6 +18,48 @@ export function prismaClientFingerprintMismatchMessage(schemaPath, clientSchemaP
   ].join('\n')
 }
 
+// Prisma generate copies the schema into the Client package after realigning field columns.
+// Compare tokens, not bytes: comments and alignment spaces are not part of the datamodel.
+export function prismaSchemaFingerprint(schema) {
+  let out = ''
+  let index = 0
+  const source = String(schema).replaceAll('\r\n', '\n').replaceAll('\r', '\n')
+  while (index < source.length) {
+    const char = source[index]
+    if (char === '/' && source[index + 1] === '/') {
+      while (index < source.length && source[index] !== '\n') index += 1
+      continue
+    }
+    if (char === '"' || char === "'") {
+      const quote = char
+      out += char
+      index += 1
+      while (index < source.length) {
+        out += source[index]
+        if (source[index] === '\\' && index + 1 < source.length) {
+          out += source[index + 1]
+          index += 2
+          continue
+        }
+        if (source[index] === quote) {
+          index += 1
+          break
+        }
+        index += 1
+      }
+      continue
+    }
+    if (/\s/.test(char)) {
+      if (out.length > 0 && out.at(-1) !== ' ') out += ' '
+      index += 1
+      continue
+    }
+    out += char
+    index += 1
+  }
+  return out.trim()
+}
+
 export function checkPrismaClient({
   root = repositoryRoot,
   schemaPath = resolve(root, PRISMA_SOURCE_SCHEMA_RELATIVE_PATH),
@@ -33,7 +75,7 @@ export function checkPrismaClient({
   }
   const source = readFileSync(schemaPath, 'utf8')
   const generated = readFileSync(clientSchemaPath, 'utf8')
-  if (source !== generated) {
+  if (prismaSchemaFingerprint(source) !== prismaSchemaFingerprint(generated)) {
     throw new Error(prismaClientFingerprintMismatchMessage(schemaPath, clientSchemaPath))
   }
 }

--- a/scripts/check-prisma-client.mjs
+++ b/scripts/check-prisma-client.mjs
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export const PRISMA_SOURCE_SCHEMA_RELATIVE_PATH = 'prisma/schema.prisma'
+export const PRISMA_CLIENT_SCHEMA_RELATIVE_PATH = 'node_modules/.prisma/client/schema.prisma'
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+export function prismaClientFingerprintMismatchMessage(schemaPath, clientSchemaPath) {
+  return [
+    'Generated Prisma Client is out of date with prisma/schema.prisma.',
+    'Run `npx prisma generate` (or `npm install`) in this worktree before tests.',
+    `Source: ${schemaPath}`,
+    `Client: ${clientSchemaPath}`
+  ].join('\n')
+}
+
+export function checkPrismaClient({
+  root = repositoryRoot,
+  schemaPath = resolve(root, PRISMA_SOURCE_SCHEMA_RELATIVE_PATH),
+  clientSchemaPath = resolve(root, PRISMA_CLIENT_SCHEMA_RELATIVE_PATH)
+} = {}) {
+  if (!existsSync(schemaPath)) {
+    throw new Error(`Prisma schema not found: ${schemaPath}`)
+  }
+  if (!existsSync(clientSchemaPath)) {
+    throw new Error(
+      `Prisma Client is not generated. Run \`npx prisma generate\` (or \`npm install\`).\nMissing: ${clientSchemaPath}`
+    )
+  }
+  const source = readFileSync(schemaPath, 'utf8')
+  const generated = readFileSync(clientSchemaPath, 'utf8')
+  if (source !== generated) {
+    throw new Error(prismaClientFingerprintMismatchMessage(schemaPath, clientSchemaPath))
+  }
+}
+
+const isDirectExecution =
+  process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+
+if (isDirectExecution) {
+  try {
+    checkPrismaClient()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  }
+}

--- a/scripts/check-prisma-client.test.ts
+++ b/scripts/check-prisma-client.test.ts
@@ -8,7 +8,8 @@ import {
   PRISMA_CLIENT_SCHEMA_RELATIVE_PATH,
   PRISMA_SOURCE_SCHEMA_RELATIVE_PATH,
   checkPrismaClient,
-  prismaClientFingerprintMismatchMessage
+  prismaClientFingerprintMismatchMessage,
+  prismaSchemaFingerprint
 } from './check-prisma-client.mjs'
 
 const writeTree = (
@@ -43,6 +44,57 @@ describe('Prisma Client fingerprint', () => {
   it('accepts a generated client that matches the source schema', () => {
     const schema = 'model Probe { id String @id }\n'
     const { root, schemaPath, clientSchemaPath } = writeTree(schema, schema)
+    try {
+      expect(() => checkPrismaClient({ root, schemaPath, clientSchemaPath })).not.toThrow()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  // Captured from `prisma generate` 6.19.3: the client copy realigns field columns and does not
+  // copy the source bytes. Byte equality would reject a fresh Client.
+  const unformattedSource = `generator client {
+  provider = "prisma-client-js"
+  output   = "./generated"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model Probe {
+  id          String   @id @default(cuid())
+  name String
+  description String   @default("")
+  archivedAt  DateTime?
+}
+`
+
+  const generatedFormatted = `generator client {
+  provider = "prisma-client-js"
+  output   = "./generated"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model Probe {
+  id          String    @id @default(cuid())
+  name        String
+  description String    @default("")
+  archivedAt  DateTime?
+}
+`
+
+  it('accepts a fresh Prisma Client whose generated schema only reformats field alignment', () => {
+    expect(unformattedSource).not.toBe(generatedFormatted)
+    expect(prismaSchemaFingerprint(unformattedSource)).toBe(
+      prismaSchemaFingerprint(generatedFormatted)
+    )
+    const { root, schemaPath, clientSchemaPath } = writeTree(unformattedSource, generatedFormatted)
     try {
       expect(() => checkPrismaClient({ root, schemaPath, clientSchemaPath })).not.toThrow()
     } finally {

--- a/scripts/check-prisma-client.test.ts
+++ b/scripts/check-prisma-client.test.ts
@@ -1,0 +1,77 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  PRISMA_CLIENT_SCHEMA_RELATIVE_PATH,
+  PRISMA_SOURCE_SCHEMA_RELATIVE_PATH,
+  checkPrismaClient,
+  prismaClientFingerprintMismatchMessage
+} from './check-prisma-client.mjs'
+
+const writeTree = (
+  schema: string,
+  clientSchema?: string
+): { root: string; schemaPath: string; clientSchemaPath: string } => {
+  const root = mkdtempSync(join(tmpdir(), 'prisma-fingerprint-'))
+  const schemaPath = join(root, 'prisma', 'schema.prisma')
+  const clientSchemaPath = join(root, 'node_modules', '.prisma', 'client', 'schema.prisma')
+  mkdirSync(join(root, 'prisma'), { recursive: true })
+  writeFileSync(schemaPath, schema)
+  if (clientSchema !== undefined) {
+    mkdirSync(join(root, 'node_modules', '.prisma', 'client'), { recursive: true })
+    writeFileSync(clientSchemaPath, clientSchema)
+  }
+  return { root, schemaPath, clientSchemaPath }
+}
+
+describe('Prisma Client fingerprint', () => {
+  it('names the source schema and generated client copy', () => {
+    expect(PRISMA_SOURCE_SCHEMA_RELATIVE_PATH).toBe('prisma/schema.prisma')
+    expect(PRISMA_CLIENT_SCHEMA_RELATIVE_PATH).toBe('node_modules/.prisma/client/schema.prisma')
+  })
+
+  it('runs the fingerprint check before npm test', () => {
+    const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
+      scripts: { pretest?: string }
+    }
+    expect(pkg.scripts.pretest).toBe('node scripts/check-prisma-client.mjs')
+  })
+
+  it('accepts a generated client that matches the source schema', () => {
+    const schema = 'model Probe { id String @id }\n'
+    const { root, schemaPath, clientSchemaPath } = writeTree(schema, schema)
+    try {
+      expect(() => checkPrismaClient({ root, schemaPath, clientSchemaPath })).not.toThrow()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('fails with a fingerprint error when the generated client is missing', () => {
+    const { root, schemaPath, clientSchemaPath } = writeTree('model Probe { id String @id }\n')
+    try {
+      expect(() => checkPrismaClient({ root, schemaPath, clientSchemaPath })).toThrow(
+        /Prisma Client is not generated/i
+      )
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('fails with a fingerprint error when the generated client does not match the source schema', () => {
+    const { root, schemaPath, clientSchemaPath } = writeTree(
+      'model Probe { id String @id }\n',
+      'model Probe { id String @id\n  extra String }\n'
+    )
+    try {
+      expect(() => checkPrismaClient({ root, schemaPath, clientSchemaPath })).toThrow(
+        prismaClientFingerprintMismatchMessage(schemaPath, clientSchemaPath)
+      )
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/acp/application-commands.test.ts
+++ b/src/main/acp/application-commands.test.ts
@@ -538,13 +538,10 @@ describe('ACP application commands', () => {
     const router = createApplicationCommandRouter()
     registerAcpCommands(router.registrar, dependencies)
 
-    const outcome = await Promise.race([
-      router.dispatcher.invoke(
-        acpCommands.steerFollowUp,
-        invocation([{ sessionId: 'session-1', text: 'focus on tests' }])
-      ),
-      new Promise<'timed-out'>((resolve) => setTimeout(() => resolve('timed-out'), 50))
-    ])
+    const outcome = await router.dispatcher.invoke(
+      acpCommands.steerFollowUp,
+      invocation([{ sessionId: 'session-1', text: 'focus on tests' }])
+    )
 
     expect(outcome).toEqual({ injected: false, reason: 'prompt-required' })
     expect(dependencies.runtime.steerFollowUp).toHaveBeenCalledOnce()

--- a/src/main/acp/handler-workflows.test.ts
+++ b/src/main/acp/handler-workflows.test.ts
@@ -192,18 +192,12 @@ describe('ACP interrupted turn workflow', () => {
       }
     )
 
-    const outcome = await Promise.race([
-      harness.workflows
-        .continueInterruptedTurn({
-          projectId: 'project-1',
-          sessionId: 'session-1',
-          promptMessageId: 'prompt-1'
-        })
-        .then(() => 'completed' as const),
-      new Promise<'timed-out'>((resolve) => setTimeout(() => resolve('timed-out'), 50))
-    ])
+    await harness.workflows.continueInterruptedTurn({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      promptMessageId: 'prompt-1'
+    })
 
-    expect(outcome).toBe('completed')
     expect(harness.startContinuationWhenDispatchAdmitted).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/acp/ipc.test.ts
+++ b/src/main/acp/ipc.test.ts
@@ -1152,10 +1152,7 @@ describe('installAcpIpcHandlers — reset-session-context bridge', () => {
     installAcpIpcHandlers({ steerFollowUp } as never, {} as never, undefined, archiveAvailability)
     const request: AcpSteerFollowUpRequest = { sessionId: 's-1', text: 'focus on tests' }
 
-    const outcome = await Promise.race([
-      Promise.resolve(handlers.get('acp:steer-follow-up')?.({}, request)),
-      new Promise<'timed-out'>((resolve) => setTimeout(() => resolve('timed-out'), 50))
-    ])
+    const outcome = await handlers.get('acp:steer-follow-up')?.({}, request)
 
     expect(outcome).toEqual({ injected: false, reason: 'prompt-required' })
     expect(withSessionAvailableById).toHaveBeenCalledWith('s-1', expect.any(Function))

--- a/src/main/acp/prompt-outcome-finalizer.test.ts
+++ b/src/main/acp/prompt-outcome-finalizer.test.ts
@@ -424,12 +424,7 @@ describe('AcpPromptOutcomeFinalizer', () => {
         harness.handles,
         stopped({ stopReason })
       )
-      const completed = Promise.race([
-        finalization.then(() => 'settled' as const),
-        new Promise<'blocked'>((resolve) => setTimeout(() => resolve('blocked'), 50))
-      ])
-
-      await expect(completed).resolves.toBe('settled')
+      await finalization
       expect(harness.handles.autoCompactIfNeeded).not.toHaveBeenCalled()
       expect(harness.interactions.current('s1')).toBeUndefined()
       compact.resolve()

--- a/src/main/reviewer/reviewer-orchestrator.architecture.test.ts
+++ b/src/main/reviewer/reviewer-orchestrator.architecture.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync, readdirSync } from 'node:fs'
 import { dirname, extname, relative, resolve, sep } from 'node:path'
 
 import {
@@ -33,6 +32,10 @@ import {
 } from 'typescript'
 import { describe, expect, it } from 'vitest'
 
+import {
+  listProductionSources,
+  readProductionSource
+} from '../../../test/architecture-source-index'
 import { RENDERER_CONTRACT_CATALOG } from '../../shared/renderer-contract-catalog'
 import { REVIEWER_MCP_TOOLS } from '../../shared/reviewer'
 import { REVIEWER_BRIDGE_NAMESPACED_TOOLS } from './bridge-tools'
@@ -57,7 +60,7 @@ const privateOwnerPaths = [
   reviewerPaths.sessionDriver
 ] as const
 
-const readSource = (path: string): string => readFileSync(path, 'utf8')
+const readSource = (path: string): string => readProductionSource(path, projectRoot)
 const rawLineCount = (source: string): number =>
   source.split(/\r?\n/).length - Number(source.endsWith('\n'))
 const modulePath = (path: string): string => path.replace(/\.[cm]?[jt]sx?$/, '')
@@ -72,24 +75,7 @@ const sourceFileFor = (path: string): SourceFile =>
     extname(path) === '.tsx' ? ScriptKind.TSX : ScriptKind.TS
   )
 
-const productionSources = (): string[] => {
-  const sources: string[] = []
-  const visit = (directory: string): void => {
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
-      const path = resolve(directory, entry.name)
-      if (entry.isDirectory()) visit(path)
-      else if (
-        ['.ts', '.tsx'].includes(extname(path)) &&
-        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
-      ) {
-        sources.push(path)
-      }
-    }
-  }
-  visit(resolve(projectRoot, 'src'))
-  visit(resolve(projectRoot, 'packages'))
-  return sources.sort()
-}
+const productionSources = (): readonly string[] => listProductionSources(projectRoot)
 
 const importSpecifiersFrom = (sourcePath: string): string[] => {
   const specifiers: string[] = []

--- a/src/main/settings/backend-route-planner.architecture.test.ts
+++ b/src/main/settings/backend-route-planner.architecture.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync, readdirSync } from 'node:fs'
 import { extname, relative, resolve } from 'node:path'
 
 import {
@@ -20,10 +19,15 @@ import {
 } from 'typescript'
 import { describe, expect, it } from 'vitest'
 
+import {
+  listProductionSources,
+  readProductionSource
+} from '../../../test/architecture-source-index'
+
 const projectRoot = resolve(__dirname, '../../..')
 const plannerPath = resolve(__dirname, 'backend-route-planner.ts')
 const manifestPath = resolve(projectRoot, 'scripts/ci/module-impact.json')
-const readSource = (path: string): string => readFileSync(path, 'utf8')
+const readSource = (path: string): string => readProductionSource(path, projectRoot)
 const sourceFileFor = (path: string): SourceFile =>
   createSourceFile(
     path,
@@ -34,24 +38,7 @@ const sourceFileFor = (path: string): SourceFile =>
   )
 const portablePath = (path: string): string => relative(projectRoot, path).replaceAll('\\', '/')
 
-const productionSources = (): string[] => {
-  const sources: string[] = []
-  const visit = (directory: string): void => {
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
-      const path = resolve(directory, entry.name)
-      if (entry.isDirectory()) visit(path)
-      else if (
-        ['.ts', '.tsx'].includes(extname(path)) &&
-        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
-      ) {
-        sources.push(path)
-      }
-    }
-  }
-  visit(resolve(projectRoot, 'src'))
-  visit(resolve(projectRoot, 'packages'))
-  return sources
-}
+const productionSources = (): readonly string[] => listProductionSources(projectRoot)
 
 const importsPlanner = (path: string): boolean => {
   let imports = false

--- a/src/main/settings/backend-selection-owner.architecture.test.ts
+++ b/src/main/settings/backend-selection-owner.architecture.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync, readdirSync } from 'node:fs'
 import { extname, relative, resolve } from 'node:path'
 
 import {
@@ -20,10 +19,15 @@ import {
 } from 'typescript'
 import { describe, expect, it } from 'vitest'
 
+import {
+  listProductionSources,
+  readProductionSource
+} from '../../../test/architecture-source-index'
+
 const projectRoot = resolve(__dirname, '../../..')
 const ownerPath = resolve(__dirname, 'backend-selection-owner.ts')
 const manifestPath = resolve(projectRoot, 'scripts/ci/module-impact.json')
-const readSource = (path: string): string => readFileSync(path, 'utf8')
+const readSource = (path: string): string => readProductionSource(path, projectRoot)
 const sourceFileFor = (path: string): SourceFile =>
   createSourceFile(
     path,
@@ -34,24 +38,7 @@ const sourceFileFor = (path: string): SourceFile =>
   )
 const portablePath = (path: string): string => relative(projectRoot, path).replaceAll('\\', '/')
 
-const productionSources = (): string[] => {
-  const sources: string[] = []
-  const visit = (directory: string): void => {
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
-      const path = resolve(directory, entry.name)
-      if (entry.isDirectory()) visit(path)
-      else if (
-        ['.ts', '.tsx'].includes(extname(path)) &&
-        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
-      ) {
-        sources.push(path)
-      }
-    }
-  }
-  visit(resolve(projectRoot, 'src'))
-  visit(resolve(projectRoot, 'packages'))
-  return sources
-}
+const productionSources = (): readonly string[] => listProductionSources(projectRoot)
 
 const importsOwner = (path: string): boolean => {
   let imports = false

--- a/src/main/settings/provider-auth-lifecycle.architecture.test.ts
+++ b/src/main/settings/provider-auth-lifecycle.architecture.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync, readdirSync } from 'node:fs'
 import { extname, relative, resolve } from 'node:path'
 
 import {
@@ -20,10 +19,15 @@ import {
 } from 'typescript'
 import { describe, expect, it } from 'vitest'
 
+import {
+  listProductionSources,
+  readProductionSource
+} from '../../../test/architecture-source-index'
+
 const projectRoot = resolve(__dirname, '../../..')
 const ownerPath = resolve(__dirname, 'provider-auth-lifecycle.ts')
 const manifestPath = resolve(projectRoot, 'scripts/ci/module-impact.json')
-const readSource = (path: string): string => readFileSync(path, 'utf8')
+const readSource = (path: string): string => readProductionSource(path, projectRoot)
 const sourceFileFor = (path: string): SourceFile =>
   createSourceFile(
     path,
@@ -34,24 +38,7 @@ const sourceFileFor = (path: string): SourceFile =>
   )
 const portablePath = (path: string): string => relative(projectRoot, path).replaceAll('\\', '/')
 
-const productionSources = (): string[] => {
-  const sources: string[] = []
-  const visit = (directory: string): void => {
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
-      const path = resolve(directory, entry.name)
-      if (entry.isDirectory()) visit(path)
-      else if (
-        ['.ts', '.tsx'].includes(extname(path)) &&
-        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
-      ) {
-        sources.push(path)
-      }
-    }
-  }
-  visit(resolve(projectRoot, 'src'))
-  visit(resolve(projectRoot, 'packages'))
-  return sources
-}
+const productionSources = (): readonly string[] => listProductionSources(projectRoot)
 
 const importsOwner = (path: string): boolean => {
   let imports = false

--- a/src/main/settings/provider-loopback-http-host.architecture.test.ts
+++ b/src/main/settings/provider-loopback-http-host.architecture.test.ts
@@ -1,7 +1,11 @@
-import { readFileSync, readdirSync } from 'node:fs'
-import { extname, relative, resolve } from 'node:path'
+import { relative, resolve } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
+
+import {
+  listProductionSources,
+  readProductionSource
+} from '../../../test/architecture-source-index'
 
 const projectRoot = resolve(__dirname, '../../..')
 const hostPath = resolve(__dirname, 'provider-loopback-http-host.ts')
@@ -12,27 +16,9 @@ const adapterPaths = [
   resolve(__dirname, 'responses-bridge.ts'),
   resolve(__dirname, 'xai-oauth-provider-bridge.ts')
 ]
-const readSource = (path: string): string => readFileSync(path, 'utf8')
+const readSource = (path: string): string => readProductionSource(path, projectRoot)
 const portablePath = (path: string): string => relative(projectRoot, path).replaceAll('\\', '/')
-
-const productionSources = (): string[] => {
-  const sources: string[] = []
-  const visit = (directory: string): void => {
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
-      const path = resolve(directory, entry.name)
-      if (entry.isDirectory()) visit(path)
-      else if (
-        ['.ts', '.tsx'].includes(extname(path)) &&
-        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
-      ) {
-        sources.push(path)
-      }
-    }
-  }
-  visit(resolve(projectRoot, 'src'))
-  visit(resolve(projectRoot, 'packages'))
-  return sources
-}
+const productionSources = (): readonly string[] => listProductionSources(projectRoot)
 
 describe('Provider loopback HTTP ownership', () => {
   it('keeps the fixed lifecycle and security envelope in one bounded module', () => {

--- a/src/main/settings/provider-runtime-projection.architecture.test.ts
+++ b/src/main/settings/provider-runtime-projection.architecture.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync, readdirSync } from 'node:fs'
 import { extname, relative, resolve } from 'node:path'
 
 import {
@@ -20,10 +19,15 @@ import {
 } from 'typescript'
 import { describe, expect, it } from 'vitest'
 
+import {
+  listProductionSources,
+  readProductionSource
+} from '../../../test/architecture-source-index'
+
 const projectRoot = resolve(__dirname, '../../..')
 const ownerPath = resolve(__dirname, 'provider-runtime-projection.ts')
 const manifestPath = resolve(projectRoot, 'scripts/ci/module-impact.json')
-const readSource = (path: string): string => readFileSync(path, 'utf8')
+const readSource = (path: string): string => readProductionSource(path, projectRoot)
 const sourceFileFor = (path: string): SourceFile =>
   createSourceFile(
     path,
@@ -34,24 +38,7 @@ const sourceFileFor = (path: string): SourceFile =>
   )
 const portablePath = (path: string): string => relative(projectRoot, path).replaceAll('\\', '/')
 
-const productionSources = (): string[] => {
-  const sources: string[] = []
-  const visit = (directory: string): void => {
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
-      const path = resolve(directory, entry.name)
-      if (entry.isDirectory()) visit(path)
-      else if (
-        ['.ts', '.tsx'].includes(extname(path)) &&
-        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
-      ) {
-        sources.push(path)
-      }
-    }
-  }
-  visit(resolve(projectRoot, 'src'))
-  visit(resolve(projectRoot, 'packages'))
-  return sources
-}
+const productionSources = (): readonly string[] => listProductionSources(projectRoot)
 
 const importsOwner = (path: string): boolean => {
   let imports = false

--- a/src/main/settings/provider-transport-owner.architecture.test.ts
+++ b/src/main/settings/provider-transport-owner.architecture.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync, readdirSync } from 'node:fs'
 import { extname, relative, resolve } from 'node:path'
 
 import {
@@ -20,10 +19,15 @@ import {
 } from 'typescript'
 import { describe, expect, it } from 'vitest'
 
+import {
+  listProductionSources,
+  readProductionSource
+} from '../../../test/architecture-source-index'
+
 const projectRoot = resolve(__dirname, '../../..')
 const ownerPath = resolve(__dirname, 'provider-transport-owner.ts')
 const resolverPath = resolve(__dirname, 'backend-resolver.ts')
-const readSource = (path: string): string => readFileSync(path, 'utf8')
+const readSource = (path: string): string => readProductionSource(path, projectRoot)
 const sourceFileFor = (path: string): SourceFile =>
   createSourceFile(
     path,
@@ -33,24 +37,7 @@ const sourceFileFor = (path: string): SourceFile =>
     extname(path) === '.tsx' ? ScriptKind.TSX : ScriptKind.TS
   )
 
-const productionSources = (): string[] => {
-  const sources: string[] = []
-  const visit = (directory: string): void => {
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
-      const path = resolve(directory, entry.name)
-      if (entry.isDirectory()) visit(path)
-      else if (
-        ['.ts', '.tsx'].includes(extname(path)) &&
-        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
-      ) {
-        sources.push(path)
-      }
-    }
-  }
-  visit(resolve(projectRoot, 'src'))
-  visit(resolve(projectRoot, 'packages'))
-  return sources
-}
+const productionSources = (): readonly string[] => listProductionSources(projectRoot)
 
 const importsOwner = (path: string): boolean => {
   let imports = false

--- a/src/main/settings/responses-request-adapter.architecture.test.ts
+++ b/src/main/settings/responses-request-adapter.architecture.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync, readdirSync } from 'node:fs'
 import { basename, dirname, extname, relative, resolve } from 'node:path'
 
 import {
@@ -28,11 +27,16 @@ import {
 } from 'typescript'
 import { describe, expect, it } from 'vitest'
 
+import {
+  listProductionSources,
+  readProductionSource
+} from '../../../test/architecture-source-index'
+
 const projectRoot = resolve(__dirname, '../../..')
 const adapterPath = resolve(__dirname, 'responses-request-adapter.ts')
 const bridgePath = resolve(__dirname, 'responses-bridge.ts')
 const hostPath = resolve(__dirname, 'provider-loopback-http-host.ts')
-const readSource = (path: string): string => readFileSync(path, 'utf8')
+const readSource = (path: string): string => readProductionSource(path, projectRoot)
 const rawLineCount = (source: string): number =>
   source.split(/\r?\n/).length - Number(source.endsWith('\n'))
 const modulePath = (path: string): string => path.replace(/\.[cm]?[jt]sx?$/, '')
@@ -47,24 +51,7 @@ const sourceFileFor = (path: string): SourceFile =>
     extname(path) === '.tsx' ? ScriptKind.TSX : ScriptKind.TS
   )
 
-const productionSources = (): string[] => {
-  const sources: string[] = []
-  const visit = (directory: string): void => {
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
-      const path = resolve(directory, entry.name)
-      if (entry.isDirectory()) visit(path)
-      else if (
-        ['.ts', '.tsx'].includes(extname(path)) &&
-        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
-      ) {
-        sources.push(path)
-      }
-    }
-  }
-  visit(resolve(projectRoot, 'src'))
-  visit(resolve(projectRoot, 'packages'))
-  return sources.sort()
-}
+const productionSources = (): readonly string[] => listProductionSources(projectRoot)
 
 const importSpecifiersFrom = (sourcePath: string): string[] => {
   const specifiers: string[] = []

--- a/src/main/settings/responses-response-adapter.architecture.test.ts
+++ b/src/main/settings/responses-response-adapter.architecture.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync, readdirSync } from 'node:fs'
 import { basename, dirname, extname, relative, resolve } from 'node:path'
 
 import {
@@ -28,11 +27,16 @@ import {
 } from 'typescript'
 import { describe, expect, it } from 'vitest'
 
+import {
+  listProductionSources,
+  readProductionSource
+} from '../../../test/architecture-source-index'
+
 const projectRoot = resolve(__dirname, '../../..')
 const adapterPath = resolve(__dirname, 'responses-response-adapter.ts')
 const bridgePath = resolve(__dirname, 'responses-bridge.ts')
 const hostPath = resolve(__dirname, 'provider-loopback-http-host.ts')
-const readSource = (path: string): string => readFileSync(path, 'utf8')
+const readSource = (path: string): string => readProductionSource(path, projectRoot)
 const rawLineCount = (source: string): number =>
   source.split(/\r?\n/).length - Number(source.endsWith('\n'))
 const modulePath = (path: string): string => path.replace(/\.[cm]?[jt]sx?$/, '')
@@ -47,24 +51,7 @@ const sourceFileFor = (path: string): SourceFile =>
     extname(path) === '.tsx' ? ScriptKind.TSX : ScriptKind.TS
   )
 
-const productionSources = (): string[] => {
-  const sources: string[] = []
-  const visit = (directory: string): void => {
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
-      const path = resolve(directory, entry.name)
-      if (entry.isDirectory()) visit(path)
-      else if (
-        ['.ts', '.tsx'].includes(extname(path)) &&
-        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
-      ) {
-        sources.push(path)
-      }
-    }
-  }
-  visit(resolve(projectRoot, 'src'))
-  visit(resolve(projectRoot, 'packages'))
-  return sources.sort()
-}
+const productionSources = (): readonly string[] => listProductionSources(projectRoot)
 
 const importSpecifiersFrom = (sourcePath: string): string[] => {
   const specifiers: string[] = []

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync, readdirSync } from 'node:fs'
 import { basename, dirname, extname, relative, resolve } from 'node:path'
 
 import {
@@ -34,6 +33,11 @@ import {
 } from 'typescript'
 import { describe, expect, it } from 'vitest'
 
+import {
+  listProductionSources,
+  readProductionSource
+} from '../../../test/architecture-source-index'
+
 const projectRoot = resolve(__dirname, '../../..')
 const settingsRoot = resolve(projectRoot, 'src/main/settings')
 const manifestPath = resolve(projectRoot, 'scripts/ci/module-impact.json')
@@ -62,14 +66,7 @@ const settingsPaths = {
   types: resolve(settingsRoot, 'types.ts'),
   notebookLocalRpcServer: resolve(projectRoot, 'src/main/notebook/local-rpc-server.ts')
 } as const
-const sourceCache = new Map<string, string>()
-const readSource = (path: string): string => {
-  const cached = sourceCache.get(path)
-  if (cached) return cached
-  const source = readFileSync(path, 'utf8')
-  sourceCache.set(path, source)
-  return source
-}
+const readSource = (path: string): string => readProductionSource(path, projectRoot)
 const rawLineCount = (source: string): number =>
   source.split(/\r?\n/).length - Number(source.endsWith('\n'))
 const modulePath = (path: string): string => path.replace(/\.[cm]?[jt]sx?$/, '')
@@ -89,24 +86,7 @@ const sourceFileFor = (path: string): SourceFile => {
   sourceFileCache.set(path, sourceFile)
   return sourceFile
 }
-const productionSources = (): string[] => {
-  const sources: string[] = []
-  const visit = (directory: string): void => {
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
-      const path = resolve(directory, entry.name)
-      if (entry.isDirectory()) visit(path)
-      else if (
-        ['.ts', '.tsx'].includes(extname(path)) &&
-        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
-      ) {
-        sources.push(path)
-      }
-    }
-  }
-  visit(resolve(projectRoot, 'src'))
-  visit(resolve(projectRoot, 'packages'))
-  return sources.sort()
-}
+const productionSources = (): readonly string[] => listProductionSources(projectRoot)
 const importSpecifiersCache = new Map<string, string[]>()
 const importSpecifiersFrom = (sourcePath: string): string[] => {
   const cached = importSpecifiersCache.get(sourcePath)

--- a/src/main/skills/user-skill-repository.architecture.test.ts
+++ b/src/main/skills/user-skill-repository.architecture.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync, readdirSync } from 'node:fs'
 import { basename, dirname, extname, relative, resolve } from 'node:path'
 
 import {
@@ -28,6 +27,11 @@ import {
 } from 'typescript'
 import { describe, expect, it } from 'vitest'
 
+import {
+  listProductionSources,
+  readProductionSource
+} from '../../../test/architecture-source-index'
+
 const projectRoot = resolve(__dirname, '../../..')
 const skillsRoot = resolve(projectRoot, 'src/main/skills')
 const repositoryPath = resolve(skillsRoot, 'user-skill-repository.ts')
@@ -41,7 +45,7 @@ const catalogObserverPath = resolve(skillsRoot, 'user-skill-catalog-observer.ts'
 const compatibilityIndexPath = resolve(skillsRoot, 'user-skill-compatibility-index.ts')
 const manifestPath = resolve(projectRoot, 'scripts/ci/module-impact.json')
 
-const readSource = (path: string): string => readFileSync(path, 'utf8')
+const readSource = (path: string): string => readProductionSource(path, projectRoot)
 const rawLineCount = (source: string): number => source.trimEnd().split(/\r?\n/).length
 const modulePath = (path: string): string => path.replace(/\.[cm]?[jt]sx?$/, '')
 const portableProjectPath = (path: string): string =>
@@ -55,24 +59,7 @@ const sourceFileFor = (path: string): SourceFile =>
     extname(path) === '.tsx' ? ScriptKind.TSX : ScriptKind.TS
   )
 
-const productionSources = (): string[] => {
-  const sources: string[] = []
-  const visit = (directory: string): void => {
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
-      const path = resolve(directory, entry.name)
-      if (entry.isDirectory()) visit(path)
-      else if (
-        ['.ts', '.tsx'].includes(extname(path)) &&
-        !/\.(?:test|spec)\.[cm]?tsx?$/.test(entry.name)
-      ) {
-        sources.push(path)
-      }
-    }
-  }
-  visit(resolve(projectRoot, 'src'))
-  visit(resolve(projectRoot, 'packages'))
-  return sources.sort()
-}
+const productionSources = (): readonly string[] => listProductionSources(projectRoot)
 
 const importSpecifiersFrom = (path: string): string[] => {
   const specifiers: string[] = []

--- a/test/architecture-source-index.test.ts
+++ b/test/architecture-source-index.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  listProductionSources,
+  readProductionSource,
+  resetProductionSourceIndexForTests
+} from './architecture-source-index'
+
+const projectRoot = resolve(import.meta.dirname, '..')
+
+describe('architecture production source index', () => {
+  it('walks src and packages once and reuses the same snapshot', () => {
+    resetProductionSourceIndexForTests()
+    const first = listProductionSources(projectRoot)
+    const second = listProductionSources(projectRoot)
+    expect(second).toBe(first)
+    expect(first.some((path) => path.replaceAll('\\', '/').endsWith('src/main/index.ts'))).toBe(
+      true
+    )
+    expect(first.every((path) => !/\.(?:test|spec)\.[cm]?tsx?$/.test(path))).toBe(true)
+    expect(
+      first.every((path) => {
+        const relative = path.slice(projectRoot.length).replaceAll('\\', '/')
+        return relative.startsWith('/src/') || relative.startsWith('/packages/')
+      })
+    ).toBe(true)
+  })
+
+  it('reuses file contents so architecture cases do not re-read the tree', () => {
+    resetProductionSourceIndexForTests()
+    const [path] = listProductionSources(projectRoot)
+    expect(path).toBeDefined()
+    const contents = readProductionSource(path!, projectRoot)
+    expect(contents).toBe(readFileSync(path!, 'utf8'))
+    expect(readProductionSource(path!, projectRoot)).toBe(contents)
+  })
+})
+
+it('keeps full-repo architecture scans on the shared index', () => {
+  const walkers = [
+    'src/main/settings/provider-loopback-http-host.architecture.test.ts',
+    'src/main/settings/backend-route-planner.architecture.test.ts',
+    'src/main/reviewer/reviewer-orchestrator.architecture.test.ts',
+    'src/main/skills/user-skill-repository.architecture.test.ts'
+  ]
+  for (const relativePath of walkers) {
+    expect(readFileSync(resolve(projectRoot, relativePath), 'utf8'), relativePath).toContain(
+      'listProductionSources'
+    )
+  }
+})

--- a/test/architecture-source-index.ts
+++ b/test/architecture-source-index.ts
@@ -1,0 +1,54 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { extname, resolve } from 'node:path'
+
+export const PRODUCTION_SOURCE_ROOTS = ['src', 'packages'] as const
+
+type ProductionSourceIndex = {
+  paths: readonly string[]
+  contents: ReadonlyMap<string, string>
+}
+
+const indexByRoot = new Map<string, ProductionSourceIndex>()
+
+const isProductionSource = (name: string): boolean =>
+  ['.ts', '.tsx'].includes(extname(name)) && !/\.(?:test|spec)\.[cm]?tsx?$/.test(name)
+
+const walkProductionSources = (directory: string, paths: string[]): void => {
+  if (!existsSync(directory)) return
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = resolve(directory, entry.name)
+    if (entry.isDirectory()) walkProductionSources(path, paths)
+    else if (isProductionSource(entry.name)) paths.push(path)
+  }
+}
+
+export const resetProductionSourceIndexForTests = (): void => {
+  indexByRoot.clear()
+}
+
+export const productionSourceIndex = (
+  projectRoot: string,
+  roots: readonly string[] = PRODUCTION_SOURCE_ROOTS
+): ProductionSourceIndex => {
+  const key = `${projectRoot}\0${roots.join('\0')}`
+  const cached = indexByRoot.get(key)
+  if (cached) return cached
+
+  const paths: string[] = []
+  for (const root of roots) walkProductionSources(resolve(projectRoot, root), paths)
+  paths.sort()
+  const contents = new Map(paths.map((path) => [path, readFileSync(path, 'utf8')]))
+  const index = { paths: Object.freeze(paths), contents }
+  indexByRoot.set(key, index)
+  return index
+}
+
+export const listProductionSources = (
+  projectRoot: string,
+  roots: readonly string[] = PRODUCTION_SOURCE_ROOTS
+): readonly string[] => productionSourceIndex(projectRoot, roots).paths
+
+export const readProductionSource = (path: string, projectRoot: string): string => {
+  const cached = productionSourceIndex(projectRoot).contents.get(path)
+  return cached ?? readFileSync(path, 'utf8')
+}

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -1,9 +1,14 @@
+import { availableParallelism, cpus } from 'node:os'
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 import vitestConfig, {
   coverageThresholdsEnabled,
+  resolveVitestMaxWorkers,
+  VITEST_ARCHITECTURE_TEST_GLOBS,
   VITEST_COVERAGE_EXCLUDE_PATTERNS,
-  VITEST_EXCLUDE_PATTERNS
+  VITEST_EXCLUDE_PATTERNS,
+  VITEST_PROCESS_TEST_GLOBS
 } from './vitest.config'
 
 describe('Vitest discovery boundaries', () => {
@@ -27,4 +32,77 @@ it('defers coverage thresholds only for explicit shard collection', () => {
 
 it('keeps a safe default timeout for schema-backed hooks', () => {
   expect(vitestConfig.test?.hookTimeout).toBe(30_000)
+})
+
+it('pins the full-suite worker cap to the machine rather than leaving it unbounded', () => {
+  const available =
+    typeof availableParallelism === 'function' ? availableParallelism() : cpus().length
+  expect(resolveVitestMaxWorkers(8)).toBe(7)
+  expect(resolveVitestMaxWorkers(1)).toBe(1)
+  expect(resolveVitestMaxWorkers(0)).toBe(1)
+  expect(vitestConfig.test?.maxWorkers).toBe(resolveVitestMaxWorkers())
+  expect(vitestConfig.test?.maxWorkers).toBe(Math.max(available - 1, 1))
+})
+
+type VitestProjectTest = {
+  name: string
+  include?: string[]
+  exclude?: string[]
+  isolate?: boolean
+  fileParallelism?: boolean
+  maxWorkers?: number
+  sequence?: { groupOrder?: number }
+}
+
+const projectByName = (name: string): VitestProjectTest => {
+  const projects = vitestConfig.test?.projects
+  expect(Array.isArray(projects)).toBe(true)
+  const project = (projects as Array<{ test?: { name?: string } }>).find(
+    (candidate) => candidate.test?.name === name
+  )
+  expect(project, name).toBeDefined()
+  return project!.test as VitestProjectTest
+}
+
+it('runs whole-tree architecture scans in one reused worker after the parallel unit pool', () => {
+  expect(VITEST_ARCHITECTURE_TEST_GLOBS).toEqual(['**/*.architecture.test.ts'])
+  const architecture = projectByName('architecture')
+  expect(architecture.include).toEqual([...VITEST_ARCHITECTURE_TEST_GLOBS])
+  expect(architecture.isolate).toBe(false)
+  expect(architecture.fileParallelism).toBe(false)
+  expect(architecture.maxWorkers).toBe(1)
+  expect(architecture.sequence?.groupOrder).toBe(1)
+  expect(projectByName('default').exclude).toEqual(
+    expect.arrayContaining([...VITEST_ARCHITECTURE_TEST_GLOBS, ...VITEST_PROCESS_TEST_GLOBS])
+  )
+})
+
+it('serializes real kernels, TCP servers, and integration files so they cannot starve the unit pool', () => {
+  expect(VITEST_PROCESS_TEST_GLOBS).toEqual(
+    expect.arrayContaining([
+      '**/*.integration.test.ts',
+      '**/*.certification.test.ts',
+      'src/main/notebook/kernel-executor.test.ts',
+      'src/main/local-rpc-transport.test.ts',
+      'src/main/session-plan/plan-mcp-server.test.ts',
+      'src/main/acp/mcp-http-host.test.ts'
+    ])
+  )
+  const processProject = projectByName('process')
+  expect(processProject.include).toEqual([...VITEST_PROCESS_TEST_GLOBS])
+  expect(processProject.isolate).toBe(true)
+  expect(processProject.fileParallelism).toBe(false)
+  expect(processProject.maxWorkers).toBe(1)
+})
+
+it('does not treat a 50ms scheduler delay as ACP deadlock', () => {
+  const sources = [
+    'src/main/acp/handler-workflows.test.ts',
+    'src/main/acp/ipc.test.ts',
+    'src/main/acp/application-commands.test.ts',
+    'src/main/acp/prompt-outcome-finalizer.test.ts'
+  ].map((path) => readFileSync(path, 'utf8'))
+  for (const source of sources) {
+    expect(source).not.toMatch(/setTimeout\(\(\) => resolve\('(?:timed-out|blocked)'\), 50\)/)
+  }
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,30 @@
+import { availableParallelism, cpus } from 'node:os'
 import { basename, dirname, resolve } from 'path'
 import { defineConfig, configDefaults } from 'vitest/config'
 
 const testRoot = resolve('.')
 const sharedInstallRoot = basename(dirname(testRoot)) === '.worktree' ? resolve('../..') : testRoot
+
+export function resolveVitestMaxWorkers(
+  available = typeof availableParallelism === 'function' ? availableParallelism() : cpus().length
+): number {
+  return Math.max(available - 1, 1)
+}
+
+export const VITEST_ARCHITECTURE_TEST_GLOBS = ['**/*.architecture.test.ts'] as const
+
+export const VITEST_PROCESS_TEST_GLOBS = [
+  '**/*.integration.test.ts',
+  '**/*.certification.test.ts',
+  'src/main/notebook/kernel-executor.test.ts',
+  'src/main/notebook/full-stack.smoke.test.ts',
+  'src/main/local-rpc-transport.test.ts',
+  'src/main/session-plan/plan-mcp-server.test.ts',
+  'src/main/acp/mcp-http-host.test.ts',
+  'src/main/settings/openai-provider-bridge.test.ts',
+  'src/main/settings/anthropic-provider-bridge.test.ts',
+  'resources/skills/literature-review/kernel.test.ts'
+] as const
 
 const VITEST_EXCLUDE_PATTERNS = [
   ...configDefaults.exclude,
@@ -75,6 +97,45 @@ export default defineConfig({
     // Schema-backed hooks can exceed Vitest's 10s default on loaded runners. Keep a safe repository
     // default while allowing slower platform workflows to raise it explicitly from the CLI.
     hookTimeout: 30000,
+    // Pin the pool to Vitest's own CPU-minus-one bound so full-suite runs cannot spawn an unbounded
+    // set of short-lived workers. Heavy files below run in later groups and do not share that pool.
+    maxWorkers: resolveVitestMaxWorkers(),
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'default',
+          exclude: [
+            ...VITEST_EXCLUDE_PATTERNS,
+            ...VITEST_ARCHITECTURE_TEST_GLOBS,
+            ...VITEST_PROCESS_TEST_GLOBS
+          ]
+        }
+      },
+      {
+        extends: true,
+        test: {
+          name: 'architecture',
+          include: [...VITEST_ARCHITECTURE_TEST_GLOBS],
+          exclude: [...VITEST_EXCLUDE_PATTERNS],
+          isolate: false,
+          fileParallelism: false,
+          maxWorkers: 1,
+          sequence: { groupOrder: 1 }
+        }
+      },
+      {
+        extends: true,
+        test: {
+          name: 'process',
+          include: [...VITEST_PROCESS_TEST_GLOBS],
+          exclude: [...VITEST_EXCLUDE_PATTERNS],
+          isolate: true,
+          fileParallelism: false,
+          maxWorkers: 1
+        }
+      }
+    ],
     coverage: {
       provider: 'v8',
       // text for the CI log, lcov for upload/tooling, html for local inspection.


### PR DESCRIPTION
## Problem

A full `npm test` / `npx vitest run` is not a stable functional gate. After regenerating Prisma Client, a local full run reported 1189 files, 18,880 tests, 6 failures, ~499s. Every failure passed when rerun alone (ACP, Notebook R cancel, Subagent rendering, architecture scan, completion gate).

This is not six independent product-assertion bugs. Under the full concurrent pool, real R/Python loops, TCP servers, huge payloads, and whole-tree AST walks starve ordinary tests past the fixed 15s timeout. Several ACP tests also `Promise.race` success against `setTimeout(..., 50)`, so scheduler delay is treated as deadlock. A separate class is a stale generated Prisma Client: `prisma generate` runs only in `postinstall`, and a shared `node_modules` (or another worktree) can make `node_modules/.prisma/client/schema.prisma` disagree with `prisma/schema.prisma`, producing a mass of Prisma errors instead of the six flakes.

Vitest already defaults `maxWorkers` to `availableParallelism() - 1`. The missing contract is an explicit cap plus a serial group for heavy files so they cannot overlap the parallel unit pool.

## Proposed change

Test-harness only:

- Pin `maxWorkers` to Vitest’s CPU-minus-one bound.
- Run architecture scans in a later one-worker project (`isolate: false`) with a shared in-memory source index.
- Run `*.integration.test.ts`, `*.certification.test.ts`, real kernel, and TCP files in Vitest’s sequential group (`maxWorkers: 1`, `isolate: true`).
- Replace ACP 50ms deadlock races with a direct await (true hangs still fail via `testTimeout`).
- Fail `npm test` pretest when the generated Prisma Client does not match `prisma/schema.prisma`.

## Scope and non-goals

No product architecture, data model, interaction, enum, or persistence change.

| Concern | Change? |
| --- | --- |
| Historical compatibility | None |
| New enum / status values | None |
| Data persistence / Session JSON / SQLite | None |

Not done, as over-design for the reproduced failure:

- Virtual clocks for real R cancel (`abortOnNextStdinWrite` is already a handshake; fake timers cannot replace SIGINT).
- Global `restoreAllMocks` / Zustand reset (high blast radius; file isolate already separates files).
- Auto `prisma generate` in pretest (would mutate a shared install).
- Raising the 15s timeout as the primary fix.

## Acceptance criteria and validation

- Harness tests failed on unfixed `vitest.config.ts` (no `maxWorkers`, no serial projects) and on a missing Prisma checker; they pass after the fix.
- A fixture Prisma mismatch throws a fingerprint error, not a Prisma query error. `node scripts/check-prisma-client.mjs` currently fails closed on this machine because the generated client does not match source schema.
- ACP tests no longer contain `setTimeout(..., 50)` deadlock races and still pass.
- Converted full-repo architecture scans use the shared source index.

Checks after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Worker cap, serial projects, ACP 50ms contract | `npx vitest run vitest.config.test.ts` | pass |
| Prisma fingerprint fixtures + pretest wiring | `npx vitest run scripts/check-prisma-client.test.ts` | pass |
| Shared architecture source index | `npx vitest run test/architecture-source-index.test.ts` | pass |
| Converted architecture scans + ACP files | `npx vitest run` of the touched ACP and architecture test files | pass (180) |
| `scripts.test` remains the complete portable suite | `npx vitest run scripts/ci/module-test-impact.test.ts` | pass |
| Node typecheck | `npm run typecheck:node` | pass |
| Lint of changed files | `npx eslint --cache` on the changed paths | pass |

`vitest.config.ts` and `package.json` are global PR Gate inputs, so exact-head CI (full unit shards) is authoritative for the complete portable suite. Full local `npm test` was not run.

Uncovered risks: CI uses `npx vitest run` after `npm ci`, so pretest does not run there; `npm ci` already generates a matching client. A live `npm test` on a machine whose shared `node_modules` was generated from another worktree’s schema will fail closed at pretest until `npx prisma generate` is run for that tree.

## Review focus

- Vitest `projects` grouping: architecture (`groupOrder: 1`, `isolate: false`) and process (`maxWorkers: 1`, isolate true → sequential group after the parallel pool).
- Whether the process glob list (`*.integration.test.ts`, kernel, TCP) is the right serial set.
- Prisma fingerprint compares the generated `schema.prisma` copy rather than hashing models only.