### PR TITLE
perf(session-renderer): avoid repeated history scans per stream batch

### DIFF
--- a/src/renderer/src/stores/session-store-run-output-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-output-helpers.ts
@@ -73,6 +73,12 @@ type SessionProjectionResult = {
   shouldCommit?: boolean
 }
 
+type SessionBatchProjectionResult = {
+  session: ChatSession
+  results: Array<AppendMessageResult | undefined>
+  shouldCommit: boolean
+}
+
 const createPersistedArtifact = (
   artifact: ArtifactFile,
   fallbackCreatedAt?: number
@@ -165,114 +171,184 @@ const appendUniqueStrings = (
   incomingItems: string[]
 ): string[] => Array.from(new Set([...(existingItems ?? []), ...incomingItems]))
 
-export const projectAgentMessageChunk = (
+// A presentation tick can contain several deltas for one stream. Index durable replay and current
+// messages once, then advance the batch locally so long Session history is not rescanned per delta.
+export const projectAgentMessageChunks = (
   session: ChatSession,
-  input: AppendAgentMessageChunkInput
-): SessionProjectionResult => {
-  let sanitizedImage = sanitizeAcpMessageImage(input.image)
-  const content = input.content ?? ''
-  if (!input.streamId || !input.eventId || (content.length === 0 && !sanitizedImage)) {
-    return { session }
-  }
-  const responseToMessageId = input.promptMessageId ?? session.activeRun?.promptMessageId
-  const replayedGraphMessage = session.conversationGraph?.messages.find(
-    (message) =>
-      message.role === 'agent' &&
-      message.responseToMessageId === responseToMessageId &&
-      message.eventIds.includes(input.eventId)
+  inputs: AppendAgentMessageChunkInput[]
+): SessionBatchProjectionResult => {
+  const preparedInputs = inputs.map((input) => ({
+    input,
+    content: input.content ?? '',
+    image: sanitizeAcpMessageImage(input.image)
+  }))
+  const streamIds = new Set(
+    preparedInputs.flatMap(({ input, content, image }) =>
+      input.streamId && input.eventId && (content.length > 0 || image) ? [input.streamId] : []
+    )
   )
-  if (replayedGraphMessage) {
-    return { session, result: { sessionId: input.sessionId, messageId: replayedGraphMessage.id } }
-  }
-
-  const sessionImageBytes = session.messages.reduce(
-    (total, message) =>
-      total + (message.images ?? []).reduce((sum, candidate) => sum + candidate.byteLength, 0),
-    0
+  const incomingEventIds = new Set(
+    preparedInputs.flatMap(({ input, content, image }) =>
+      input.streamId && input.eventId && (content.length > 0 || image) ? [input.eventId] : []
+    )
   )
-  if (
-    sanitizedImage &&
-    sessionImageBytes + sanitizedImage.byteLength > MAX_ACP_SESSION_IMAGE_BYTES
-  ) {
-    sanitizedImage = undefined
-    if (content.length === 0) return { session }
+  if (streamIds.size === 0) {
+    return { session, results: inputs.map(() => undefined), shouldCommit: false }
   }
-
-  const hasVisibleOutput = content.trim().length > 0 || Boolean(sanitizedImage)
-  const existingMessage = session.messages.find(
-    (message) => message.role === 'agent' && message.streamId === input.streamId
-  )
-  const mergedContent = (current = ''): string => {
-    const text = `${current}${content}`
-    return session.agentFrameworkId === 'claude-code' ? normalizeClaudeCodeRefusalText(text) : text
-  }
-  const messageId =
-    existingMessage?.id ??
-    createRuntimeAgentMessageId(input.sessionId, input.streamId, responseToMessageId)
-  const result = { sessionId: input.sessionId, messageId }
-  const now = Date.now()
-
-  if (existingMessage) {
-    if (existingMessage.eventIds.includes(input.eventId)) {
-      return { session, result, shouldCommit: true }
+  const replayedGraphMessages = new Map<string, ChatMessage[]>()
+  for (const message of session.conversationGraph?.messages ?? []) {
+    if (message.role !== 'agent') continue
+    for (const eventId of message.eventIds) {
+      if (!incomingEventIds.has(eventId)) continue
+      const matches = replayedGraphMessages.get(eventId)
+      if (matches) matches.push(message)
+      else replayedGraphMessages.set(eventId, [message])
     }
-    return {
-      result,
-      shouldCommit: true,
-      session: {
-        ...session,
-        status:
-          session.status === 'waiting-for-user' || session.status === 'waiting-permission'
-            ? session.status
-            : 'running',
-        awaitingFirstAgentOutput: hasVisibleOutput ? undefined : session.awaitingFirstAgentOutput,
-        messages: session.messages.map((message) =>
-          message.id === existingMessage.id
-            ? {
-                ...message,
-                content: mergedContent(message.content),
-                images: sanitizedImage
-                  ? sanitizeMessageImages([
-                      ...(message.images ?? []),
-                      { id: input.eventId, ...sanitizedImage }
-                    ])
-                  : message.images,
-                eventIds: [...message.eventIds, input.eventId],
-                updatedAt: now
-              }
-            : message
-        ),
-        updatedAt: now
+  }
+
+  const hasIncomingImage = preparedInputs.some(({ input, content, image }) =>
+    Boolean(input.streamId && input.eventId && (content.length > 0 || image) && image)
+  )
+  let sessionImageBytes = 0
+  const messageByStreamId = new Map<string, { index: number; message: ChatMessage }>()
+  for (let index = 0; index < session.messages.length; index += 1) {
+    const message = session.messages[index]
+    if (hasIncomingImage) {
+      sessionImageBytes += (message.images ?? []).reduce(
+        (total, image) => total + image.byteLength,
+        0
+      )
+    }
+    if (
+      message.role === 'agent' &&
+      message.streamId &&
+      streamIds.has(message.streamId) &&
+      !messageByStreamId.has(message.streamId)
+    ) {
+      messageByStreamId.set(message.streamId, { index, message })
+    }
+  }
+
+  const results: Array<AppendMessageResult | undefined> = []
+  let messages = session.messages
+  let changed = false
+  let shouldCommit = false
+  let awaitingFirstAgentOutput = session.awaitingFirstAgentOutput
+  let updatedAt = session.updatedAt
+
+  for (const prepared of preparedInputs) {
+    const { input, content } = prepared
+    let sanitizedImage = prepared.image
+    if (!input.streamId || !input.eventId || (content.length === 0 && !sanitizedImage)) {
+      results.push(undefined)
+      continue
+    }
+    const responseToMessageId = input.promptMessageId ?? session.activeRun?.promptMessageId
+    const replayedGraphMessage = replayedGraphMessages
+      .get(input.eventId)
+      ?.find((message) => message.responseToMessageId === responseToMessageId)
+    if (replayedGraphMessage) {
+      results.push({ sessionId: input.sessionId, messageId: replayedGraphMessage.id })
+      continue
+    }
+
+    if (
+      sanitizedImage &&
+      sessionImageBytes + sanitizedImage.byteLength > MAX_ACP_SESSION_IMAGE_BYTES
+    ) {
+      sanitizedImage = undefined
+      if (content.length === 0) {
+        results.push(undefined)
+        continue
       }
     }
+
+    const existing = messageByStreamId.get(input.streamId)
+    const messageId =
+      existing?.message.id ??
+      createRuntimeAgentMessageId(input.sessionId, input.streamId, responseToMessageId)
+    const result = { sessionId: input.sessionId, messageId }
+    results.push(result)
+
+    if (existing?.message.eventIds.includes(input.eventId)) {
+      shouldCommit = true
+      continue
+    }
+
+    const hasVisibleOutput = content.trim().length > 0 || Boolean(sanitizedImage)
+    const now = Date.now()
+    const mergeContent = (current = ''): string => {
+      const text = `${current}${content}`
+      return session.agentFrameworkId === 'claude-code'
+        ? normalizeClaudeCodeRefusalText(text)
+        : text
+    }
+    const nextMessage: ChatMessage = existing
+      ? {
+          ...existing.message,
+          content: mergeContent(existing.message.content),
+          images: sanitizedImage
+            ? sanitizeMessageImages([
+                ...(existing.message.images ?? []),
+                { id: input.eventId, ...sanitizedImage }
+              ])
+            : existing.message.images,
+          eventIds: [...existing.message.eventIds, input.eventId],
+          updatedAt: now
+        }
+      : {
+          id: messageId,
+          role: 'agent',
+          content: mergeContent(),
+          status: 'streaming',
+          streamId: input.streamId,
+          responseToMessageId,
+          eventIds: [input.eventId],
+          images: sanitizedImage ? [{ id: input.eventId, ...sanitizedImage }] : undefined,
+          sortIndex: createSortIndex(),
+          createdAt: now,
+          updatedAt: now
+        }
+
+    if (!changed) messages = session.messages.slice()
+    if (existing) messages[existing.index] = nextMessage
+    else messages.push(nextMessage)
+    messageByStreamId.set(input.streamId, {
+      index: existing?.index ?? messages.length - 1,
+      message: nextMessage
+    })
+    if (sanitizedImage) {
+      const previousImageBytes = (existing?.message.images ?? []).reduce(
+        (total, image) => total + image.byteLength,
+        0
+      )
+      const nextImageBytes = (nextMessage.images ?? []).reduce(
+        (total, image) => total + image.byteLength,
+        0
+      )
+      sessionImageBytes += nextImageBytes - previousImageBytes
+    }
+    if (hasVisibleOutput) awaitingFirstAgentOutput = undefined
+    updatedAt = now
+    changed = true
+    shouldCommit = true
   }
 
-  const agentMessage: ChatMessage = {
-    id: messageId,
-    role: 'agent',
-    content: mergedContent(),
-    status: 'streaming',
-    streamId: input.streamId,
-    responseToMessageId,
-    eventIds: [input.eventId],
-    images: sanitizedImage ? [{ id: input.eventId, ...sanitizedImage }] : undefined,
-    sortIndex: createSortIndex(),
-    createdAt: now,
-    updatedAt: now
-  }
   return {
-    result,
-    shouldCommit: true,
-    session: {
-      ...session,
-      status:
-        session.status === 'waiting-for-user' || session.status === 'waiting-permission'
-          ? session.status
-          : 'running',
-      awaitingFirstAgentOutput: hasVisibleOutput ? undefined : session.awaitingFirstAgentOutput,
-      messages: [...session.messages, agentMessage],
-      updatedAt: now
-    }
+    results,
+    shouldCommit,
+    session: changed
+      ? {
+          ...session,
+          status:
+            session.status === 'waiting-for-user' || session.status === 'waiting-permission'
+              ? session.status
+              : 'running',
+          awaitingFirstAgentOutput,
+          messages,
+          updatedAt
+        }
+      : session
   }
 }
 

--- a/src/renderer/src/stores/session-store-run-projection-owner.ts
+++ b/src/renderer/src/stores/session-store-run-projection-owner.ts
@@ -21,7 +21,7 @@ import {
   type UpsertToolActivityInput
 } from './session-store-run-activity-helpers'
 import {
-  projectAgentMessageChunk,
+  projectAgentMessageChunks,
   projectMessageArtifacts,
   projectMessageUploads,
   projectRunArtifacts,
@@ -153,26 +153,31 @@ export const createSessionRunProjectionOwner = <
     if (inputs.length === 0) return []
 
     const state = get()
-    let sessions = state.sessions
+    const inputIndexesBySessionId = new Map<string, number[]>()
+    inputs.forEach((input, index) => {
+      if (!input.sessionId) return
+      const indexes = inputIndexesBySessionId.get(input.sessionId)
+      if (indexes) indexes.push(index)
+      else inputIndexesBySessionId.set(input.sessionId, [index])
+    })
     let shouldCommit = false
-    const results: AppendMessageResult[] = []
-
-    for (const input of inputs) {
-      if (!input.sessionId) continue
-      const session = sessions.find((candidate) => candidate.id === input.sessionId)
-      if (!session) continue
-      const projection = projectAgentMessageChunk(session, input)
-      if (projection.result) results.push(projection.result)
-      if (!projection.shouldCommit) continue
-
-      shouldCommit = true
-      sessions = sessions.map((candidate) =>
-        candidate.id === input.sessionId ? projection.session : candidate
+    const indexedResults: Array<AppendMessageResult | undefined> = []
+    const sessions = state.sessions.map((session) => {
+      const indexes = inputIndexesBySessionId.get(session.id)
+      if (!indexes) return session
+      const projection = projectAgentMessageChunks(
+        session,
+        indexes.map((index) => inputs[index])
       )
-    }
+      indexes.forEach((inputIndex, resultIndex) => {
+        indexedResults[inputIndex] = projection.results[resultIndex]
+      })
+      shouldCommit ||= projection.shouldCommit
+      return projection.session
+    })
 
     if (shouldCommit) setSessionState({ sessions } as Partial<State>)
-    return results
+    return indexedResults.filter((result): result is AppendMessageResult => Boolean(result))
   }
 
   return {

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -397,6 +397,69 @@ describe('session store', () => {
     })
   })
 
+  it('does not repeat history-sized scans for every delta in one Agent text batch', () => {
+    const measureHistoricalReads = (chunkCount: number): number => {
+      let historicalReads = 0
+      const messages = Array.from(
+        { length: 200 },
+        (_, index) =>
+          new Proxy<ChatMessage>(
+            {
+              id: `history-${index}`,
+              role: index % 2 === 0 ? 'user' : 'agent',
+              content: `Historical message ${index}`,
+              status: 'complete',
+              eventIds: [],
+              createdAt: index,
+              updatedAt: index
+            },
+            {
+              get(target, property, receiver) {
+                historicalReads += 1
+                return Reflect.get(target, property, receiver)
+              }
+            }
+          )
+      )
+      useSessionStore.setState({
+        sessions: [
+          {
+            id: 'transport-session-1',
+            projectId: 'project-1',
+            title: 'Long conversation',
+            cwd: '/workspace',
+            status: 'running',
+            messages,
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ],
+        selectedSessionId: 'transport-session-1'
+      })
+      historicalReads = 0
+
+      useSessionStore.getState().appendAgentMessageChunks(
+        Array.from({ length: chunkCount }, (_, index) => ({
+          sessionId: 'transport-session-1',
+          streamId: 'assistant-message-1',
+          eventId: `event-${index}`,
+          content: 'x'
+        }))
+      )
+
+      return historicalReads
+    }
+
+    const singleChunkReads = measureHistoricalReads(1)
+    const batchedChunkReads = measureHistoricalReads(8)
+
+    expect(batchedChunkReads).toBeLessThanOrEqual(singleChunkReads * 2)
+    expect(useSessionStore.getState().sessions[0].messages.at(-1)).toMatchObject({
+      content: 'xxxxxxxx',
+      eventIds: Array.from({ length: 8 }, (_, index) => `event-${index}`)
+    })
+  })
+
   it('keeps artifact finalization idempotent across independent renderer projections', () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',


### PR DESCRIPTION
## Problem

ACP runtime events already reach the renderer in presentation batches, but `appendAgentMessageChunks`
projected every delta independently. Each delta rescanned the complete conversation graph and Session
message history, recomputed image bytes, and copied the message array before the owner issued its one
Zustand commit. Streaming work therefore grew approximately with `batch size × Session history`, so a
long conversation paid the history cost once per delta inside the same frame.

A deterministic public Store-boundary regression reproduced this on unmodified `main` three times:
one delta read the historical fixture 500 times, while eight adjacent deltas read it 5,400 times
(`5,400 > 1,000` budget). Gating image accounting alone still failed (`3,800 > 600`), isolating the
remaining repeated replay lookup, stream lookup, and array copy.

## Proposed change

- Group a streamed chunk batch by Session at the existing Store facade.
- Build graph replay and active-stream indexes once per Session batch.
- Count historical image bytes only when the batch actually contains an image.
- Advance deltas in input order against a local projection and lazily copy `messages` once.
- Preserve per-event results, duplicate detection, deterministic Message identity, prompt ownership,
  image budgets, Claude refusal normalization, and the existing one-commit boundary.
- Add a deterministic regression comparing historical work for one delta with eight adjacent deltas.

## Scope and non-goals

- No ACP protocol, framework adapter, launcher, model, IPC contract, or presentation-cadence change.
- No historical data compatibility work: persisted Session and conversation-graph formats are unchanged.
- No new state or enum values.
- No persistence policy, ordering, or storage change.
- No claim about real-provider time-to-first-token or end-to-end p50/p95/p99 improvements; those remain
  environment-dependent and require a separate fixed-fixture trace.
- Full transcript projection and complete Session serialization may be separate overlays; this PR does
  not change them without their own red-capable behavior tests.

All four ACP framework paths (`claude-code`, `opencode`, `codex-response`, and `codex-bridge`) converge
on this shared renderer Store boundary. No framework-specific fixture is included because the wire
shape and adapter behavior do not change. Electron, local Web, and remote Web also share this
post-delivery renderer projection; no platform-specific path changes.

## Acceptance criteria and validation

The checks below ran after the last material edit. The complete local `npm test` suite was intentionally
not run; exact-head PR CI remains the final authority.

- History-amplified Store projection → focused regression → failed three times before the fix and
  passed three times after the fix.
- Session projection ownership, persistence contract, and representative runtime consumer →
  `npm run test:module -- session_renderer` → 4 files, 479/479 passed.
- Workspace event application, ordering, and projection consumer →
  `npm test -- src/renderer/src/lib/acp/workspace-events.test.ts` → 87/87 passed.
- Incremental admission, presentation batching, and persistence barrier → targeted
  `useWorkspaceAgentRuntime.test.ts` selection → 6/6 passed.
- IPC event coalescing and Markdown backlog catch-up → targeted coalescer/AgentMarkdown selection →
  4/4 passed.
- Renderer types → `npm run typecheck:web` → passed.
- Lint → `npm run lint` → 0 errors; two pre-existing Prettier warnings remain in unchanged
  `src/main/acp/application-commands.ts` and `src/main/acp/ipc.ts`.

Uncovered risk: no packaged Electron/Web replay with a real long provider conversation, and no fixed
model/prompt benchmark across history sizes. The deterministic regression proves removal of repeated
history work, not a machine-independent latency percentage.

## Review focus

- Verify batch-local indexes preserve the previous first-match and replay semantics.
- Verify mixed streams, duplicate event IDs, image accounting, and result ordering remain equivalent.
- Confirm the Test Impact Set covers the unchanged public Session Store facade and its runtime consumer.
