### PR TITLE
fix(composer): show Specialist selection while switching

### DIFF
--- a/src/main/acp/provider-session-adopter.test.ts
+++ b/src/main/acp/provider-session-adopter.test.ts
@@ -1,5 +1,19 @@
 import type { ActiveSession, ClientConnection } from '@agentclientprotocol/sdk'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const loggerSpies = vi.hoisted(() => ({ info: vi.fn(), error: vi.fn() }))
+vi.mock('../logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../logger')>()
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: loggerSpies.info,
+      warn: vi.fn(),
+      error: loggerSpies.error
+    })
+  }
+})
 
 import type { AcpCreateSessionResponse } from '../../shared/acp'
 import type { SessionPermissionProfileState } from '../../shared/permission-profiles'
@@ -199,6 +213,57 @@ const createHarness = (
 }
 
 describe('AcpProviderSessionAdopter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('records phase timings while adopting a provider Session', async () => {
+    const harness = createHarness({
+      projectAgentContext: 'Always cite DOIs.',
+      specialistIdentity: {
+        append: 'specialist identity append',
+        prefix: 'specialist turn prefix'
+      },
+      specialistSkills: {
+        kind: 'specialist',
+        skillIds: ['skill-1'],
+        frameworkNames: ['literature-review'],
+        missingSkillIds: []
+      }
+    })
+
+    await harness.adopt('specialist-1')
+
+    const events = loggerSpies.info.mock.calls.filter(
+      ([, data]) => data?.operation === 'acp-provider-session-adoption'
+    )
+    expect(
+      events.map(([message, data]) => ({
+        message,
+        phase: data?.phase,
+        outcome: data?.outcome
+      }))
+    ).toEqual([
+      { message: 'operation started', phase: undefined, outcome: 'started' },
+      { message: 'operation phase', phase: 'provision-capabilities', outcome: undefined },
+      { message: 'operation phase', phase: 'resolve-specialist', outcome: undefined },
+      { message: 'operation phase', phase: 'resolve-project-context', outcome: undefined },
+      { message: 'operation phase', phase: 'start-provider-session', outcome: undefined },
+      { message: 'operation phase', phase: 'configure-provider-session', outcome: undefined },
+      { message: 'operation phase', phase: 'publish-provider-session', outcome: undefined },
+      {
+        message: 'operation completed',
+        phase: 'publish-provider-session',
+        outcome: 'completed'
+      }
+    ])
+    expect(events.slice(1, -1).every(([, data]) => typeof data?.elapsedMs === 'number')).toBe(true)
+    expect(events.at(-1)?.[1]).toMatchObject({
+      frameworkId: 'claude-code',
+      durationMs: expect.any(Number)
+    })
+  })
+
   it('preserves the runtime capability policy while adopting a fresh provider Session', async () => {
     const harness = createHarness({ capabilityPolicy: SIDE_CHAT_SESSION_CAPABILITY_POLICY })
 
@@ -253,6 +318,15 @@ describe('AcpProviderSessionAdopter', () => {
     expect(harness.registry.lookup('stable-app-session')).toBeUndefined()
     expect(harness.commitClaudeReplay).not.toHaveBeenCalled()
     expect(harness.registry.isIdentityClaimed('stable-app-session')).toBe(false)
+    expect(loggerSpies.error).toHaveBeenCalledWith(
+      'operation failed',
+      expect.objectContaining({
+        operation: 'acp-provider-session-adoption',
+        phase: 'configure-provider-session',
+        outcome: 'failed',
+        durationMs: expect.any(Number)
+      })
+    )
   })
 
   it('cleans provisional ownership when the provider Session id collides', async () => {

--- a/src/main/acp/provider-session-adopter.ts
+++ b/src/main/acp/provider-session-adopter.ts
@@ -6,6 +6,7 @@ import {
   type PermissionProfileId
 } from '../../shared/permission-profiles'
 import type { EffectiveSpecialistSkills } from '../../shared/specialist'
+import { startDiagnosticOperation } from '../diagnostics/operation'
 import { createLogger, diagnosticErrorFields } from '../logger'
 import type { AcpBackendGenerationView } from './backend-generation-owner'
 import {
@@ -71,12 +72,22 @@ export class AcpProviderSessionAdopter {
     stableAppSessionId: string,
     request: AcpProviderSessionAdoptionRequest
   ): Promise<AcpCreateSessionResponse> {
+    const diagnostics = startDiagnosticOperation(log, {
+      operation: 'acp-provider-session-adoption',
+      fields: {
+        sessionId: stableAppSessionId,
+        target: request.specialistId === undefined ? 'main-agent' : 'specialist'
+      }
+    })
     let capability: SessionCapabilityProvision | undefined
     let provisionalSession: ActiveSession | undefined
     let adoptedProviderSessionId: string | undefined
     let identity = request.identity
     try {
       const startupBackend = this.deps.currentBackend()
+      diagnostics.phase('provision-capabilities', {
+        frameworkId: startupBackend.framework.id
+      })
       capability = await this.deps.capabilities.provision({
         stableAppSessionId,
         framework: startupBackend.framework,
@@ -91,11 +102,13 @@ export class AcpProviderSessionAdopter {
       const specialistId = hasAuthoritativeSpecialistBinding
         ? request.specialistId
         : this.deps.registry.lookup(stableAppSessionId)?.aggregate.snapshot().specialistId
+      diagnostics.phase('resolve-specialist')
       const [specialistIdentity, specialistSkills] = await Promise.all([
         this.resolveSpecialistIdentity(specialistId, startupBackend),
         this.resolveSpecialistSkills(specialistId)
       ])
       const handoffAppend = this.deps.peekClaudeReplay(stableAppSessionId)
+      diagnostics.phase('resolve-project-context')
       const projectContextAppend = await this.resolveProjectAgentContext(request.projectId)
       const setup = this.presentation.buildSessionSetup({
         framework: startupBackend.framework,
@@ -115,6 +128,7 @@ export class AcpProviderSessionAdopter {
         sessionOptions: startupBackend.session.options,
         specialistSkills
       })
+      diagnostics.phase('start-provider-session')
       provisionalSession = await request.connection.agent
         .buildSession({ cwd: request.cwd, mcpServers: capability.mcpServers, ...setup.metaArg })
         .start()
@@ -133,6 +147,7 @@ export class AcpProviderSessionAdopter {
 
       const permissionProfile = normalizePermissionProfile(request.permissionProfile)
       let backend = this.deps.currentBackend()
+      diagnostics.phase('configure-provider-session')
       let configuration = await this.deps.configurator.configure({
         backend,
         connection: request.connection,
@@ -153,6 +168,7 @@ export class AcpProviderSessionAdopter {
           })
           continue
         }
+        diagnostics.phase('publish-provider-session')
         identity.assertCurrent()
         const { aggregate } = this.deps.registry.publish(identity, stableAppSessionId, {
           session: provisionalSession,
@@ -185,6 +201,7 @@ export class AcpProviderSessionAdopter {
       } catch (error) {
         this.safeLogError('adopted session state callback failed', error, stableAppSessionId)
       }
+      diagnostics.complete({ frameworkId: backend.framework.id })
       return {
         sessionId: stableAppSessionId,
         ...(adoptedProviderSessionId ? { providerSessionId: adoptedProviderSessionId } : {}),
@@ -213,6 +230,7 @@ export class AcpProviderSessionAdopter {
         }
       }
       this.disposeProvisional(provisionalSession, 'adopted startup session disposal failed')
+      diagnostics.fail(startupError)
       throw startupError
     } finally {
       identity.release()

--- a/src/main/specialist/session-reconfiguration.test.ts
+++ b/src/main/specialist/session-reconfiguration.test.ts
@@ -1,4 +1,18 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const loggerSpies = vi.hoisted(() => ({ info: vi.fn(), error: vi.fn() }))
+vi.mock('../logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../logger')>()
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: loggerSpies.info,
+      warn: vi.fn(),
+      error: loggerSpies.error
+    })
+  }
+})
 
 import type { SpecialistProfileView } from '../../shared/specialist'
 import type { ProfileService } from './service'
@@ -31,6 +45,46 @@ const deferred = (): { promise: Promise<void>; resolve: () => void } => {
 }
 
 describe('SessionSpecialistReconfiguration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('records phase timings for a Session Specialist switch', async () => {
+    const owner = new SessionSpecialistReconfiguration({
+      sessionBinding: bindingService(),
+      loadBinding: async () => undefined,
+      persistBinding: async () => undefined,
+      applyRuntime: async () => ({ contextReset: true })
+    })
+
+    await owner.requestSwitch('session-1', profile.id)
+
+    const events = loggerSpies.info.mock.calls.filter(
+      ([, data]) => data?.operation === 'specialist-session-switch'
+    )
+    expect(
+      events.map(([message, data]) => ({
+        message,
+        phase: data?.phase,
+        outcome: data?.outcome
+      }))
+    ).toEqual([
+      { message: 'operation started', phase: undefined, outcome: 'started' },
+      { message: 'operation phase', phase: 'queued', outcome: undefined },
+      { message: 'operation phase', phase: 'validate-target', outcome: undefined },
+      { message: 'operation phase', phase: 'persist-pending', outcome: undefined },
+      { message: 'operation phase', phase: 'apply-runtime', outcome: undefined },
+      { message: 'operation phase', phase: 'persist-applied', outcome: undefined },
+      { message: 'operation completed', phase: 'persist-applied', outcome: 'completed' }
+    ])
+    expect(events.slice(1, -1).every(([, data]) => typeof data?.elapsedMs === 'number')).toBe(true)
+    expect(events.at(-1)?.[1]).toMatchObject({
+      status: 'applied',
+      contextReset: true,
+      durationMs: expect.any(Number)
+    })
+  })
+
   it('commits pending before runtime application and clears it only after success', async () => {
     const binding = bindingService()
     let persisted: { specialistId?: string; specialistBindingPending?: true } = {}
@@ -154,6 +208,17 @@ describe('SessionSpecialistReconfiguration', () => {
       status: 'pending',
       reason: 'runtime-application-failed'
     })
+    expect(loggerSpies.info).toHaveBeenCalledWith(
+      'operation completed',
+      expect.objectContaining({
+        operation: 'specialist-session-switch',
+        phase: 'apply-runtime',
+        outcome: 'completed',
+        status: 'pending',
+        reason: 'runtime-application-failed',
+        durationMs: expect.any(Number)
+      })
+    )
     expect(persisted).toEqual({
       specialistId: profile.id,
       specialistBindingPending: true

--- a/src/main/specialist/session-reconfiguration.ts
+++ b/src/main/specialist/session-reconfiguration.ts
@@ -1,4 +1,5 @@
 import type { SetSessionSpecialistResponse } from '../../shared/specialist'
+import { startDiagnosticOperation, type DiagnosticOperation } from '../diagnostics/operation'
 import { createLogger, diagnosticErrorFields } from '../logger'
 import type { SessionBindingService } from './session-binding'
 
@@ -42,11 +43,35 @@ export class SessionSpecialistReconfiguration {
     sessionId: string,
     specialistId: string | undefined
   ): Promise<SetSessionSpecialistResponse> {
-    return this.enqueue(sessionId, async () => {
-      await this.validateTarget(sessionId, specialistId)
-      await this.commitDesiredUnlocked(sessionId, specialistId)
-      return this.applyUnlocked(sessionId, specialistId, false)
+    const diagnostics = startDiagnosticOperation(log, {
+      operation: 'specialist-session-switch',
+      fields: {
+        sessionId,
+        target: specialistId === undefined ? 'main-agent' : 'specialist'
+      }
     })
+    diagnostics.phase('queued')
+    return this.enqueue(sessionId, async () => {
+      diagnostics.phase('validate-target')
+      await this.validateTarget(sessionId, specialistId)
+      diagnostics.phase('persist-pending')
+      await this.commitDesiredUnlocked(sessionId, specialistId)
+      return this.applyUnlocked(sessionId, specialistId, false, diagnostics)
+    }).then(
+      (result) => {
+        diagnostics.complete({
+          status: result.status,
+          ...(result.status === 'applied'
+            ? { contextReset: result.contextReset }
+            : { reason: result.reason })
+        })
+        return result
+      },
+      (error: unknown) => {
+        diagnostics.fail(error)
+        throw error
+      }
+    )
   }
 
   // host.agents.switch commits at the old prompt boundary and applies later through the completion
@@ -123,11 +148,13 @@ export class SessionSpecialistReconfiguration {
   private async applyUnlocked(
     sessionId: string,
     specialistId: string | undefined,
-    throwAfterCommit: boolean
+    throwAfterCommit: boolean,
+    diagnostics?: DiagnosticOperation
   ): Promise<SetSessionSpecialistResponse> {
     this.assertSessionActive(sessionId)
     let contextReset = false
     try {
+      diagnostics?.phase('apply-runtime')
       if (this.deps.applyRuntime) {
         contextReset = (await this.deps.applyRuntime(sessionId, specialistId)).contextReset
       }
@@ -144,6 +171,7 @@ export class SessionSpecialistReconfiguration {
     }
 
     try {
+      diagnostics?.phase('persist-applied')
       await this.deps.persistBinding(sessionId, specialistId, false)
       this.assertSessionActive(sessionId)
     } catch (error) {

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -4029,6 +4029,48 @@ describe('ConversationPanel fix loop lock', () => {
     ).toContain('Specialist B')
   })
 
+  it('keeps the Specialist control visible while switching back to Main Agent', () => {
+    useSpecialistStore.setState({
+      items: [
+        {
+          kind: 'custom',
+          id: 'specialist-a',
+          name: 'SPECIALIST_A',
+          displayName: 'Specialist A',
+          colorKey: 'blue',
+          description: 'Currently applied.',
+          systemPrompt: 'Help the user.',
+          enabled: true,
+          capabilityMode: 'full',
+          fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+          selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+          revision: 1
+        }
+      ],
+      isLoaded: true
+    })
+
+    renderPanel({
+      view: {
+        activeSession: { ...idleSession, specialistId: 'specialist-a' }
+      },
+      specialist: {
+        view: {
+          specialist: {
+            historyId: undefined,
+            barrierInFlight: true
+          }
+        }
+      }
+    })
+
+    expect(
+      container
+        .querySelector('[data-testid="composer-specialist-picker-trigger"]')
+        ?.getAttribute('aria-label')
+    ).toContain('Specialist A')
+  })
+
   it('cancel button is visible when session is running and calls onCancelRun', () => {
     const onCancelRun = vi.fn()
     const runningSession: ChatSession = {

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -3973,6 +3973,62 @@ describe('ConversationPanel fix loop lock', () => {
     ).toContain('Available Specialist')
   })
 
+  it('shows the selected Specialist while idle reconfiguration is in flight', () => {
+    useSpecialistStore.setState({
+      items: [
+        {
+          kind: 'custom',
+          id: 'specialist-a',
+          name: 'SPECIALIST_A',
+          displayName: 'Specialist A',
+          colorKey: 'blue',
+          description: 'Currently applied.',
+          systemPrompt: 'Help the user.',
+          enabled: true,
+          capabilityMode: 'full',
+          fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+          selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+          revision: 1
+        },
+        {
+          kind: 'custom',
+          id: 'specialist-b',
+          name: 'SPECIALIST_B',
+          displayName: 'Specialist B',
+          colorKey: 'purple',
+          description: 'Being configured.',
+          systemPrompt: 'Help the user.',
+          enabled: true,
+          capabilityMode: 'full',
+          fullAccess: { excludedSkillIds: [], excludedConnectorIds: [], connectorTools: [] },
+          selectedCapabilities: { skillIds: [], connectorIds: [], connectorTools: [] },
+          revision: 1
+        }
+      ],
+      isLoaded: true
+    })
+
+    renderPanel({
+      view: {
+        activeSession: { ...idleSession, specialistId: 'specialist-a' }
+      },
+      specialist: {
+        view: {
+          specialist: {
+            historyId: 'specialist-b',
+            barrierInFlight: true
+          }
+        }
+      }
+    })
+
+    expect(
+      container
+        .querySelector('[data-testid="composer-specialist-picker-trigger"]')
+        ?.getAttribute('aria-label')
+    ).toContain('Specialist B')
+  })
+
   it('cancel button is visible when session is running and calls onCancelRun', () => {
     const onCancelRun = vi.fn()
     const runningSession: ChatSession = {

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -455,7 +455,7 @@ const ConversationPanel = ({
   const { unavailableReason: subagentUnavailableReason, stop: onStopSubagents } = subagents
   const specialistId = activeSession
     ? specialist.view.specialist.barrierInFlight
-      ? specialist.view.specialist.historyId
+      ? (specialist.view.specialist.historyId ?? activeSession.specialistId)
       : activeSession.specialistId
     : specialist.view.specialist.newConversationId
   const specialistUnavailable = specialist.view.specialist.unavailable

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -454,7 +454,9 @@ const ConversationPanel = ({
   const { notebookReference, openNotebook: onOpenNotebook, openJobs: onOpenJobList } = sessionTools
   const { unavailableReason: subagentUnavailableReason, stop: onStopSubagents } = subagents
   const specialistId = activeSession
-    ? activeSession.specialistId
+    ? specialist.view.specialist.barrierInFlight
+      ? specialist.view.specialist.historyId
+      : activeSession.specialistId
     : specialist.view.specialist.newConversationId
   const specialistUnavailable = specialist.view.specialist.unavailable
   const specialistHasPendingSwitch = specialist.view.specialist.hasPendingSwitch

--- a/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
@@ -446,6 +446,7 @@ describe('workspace session controller', () => {
       message: 'switch rejected',
       committed: false
     })
+    expect(hook.result.current.view.specialist.historyId).toBe('specialist-a')
     expect(hook.result.current.view.specialist.barrierInFlight).toBe(false)
 
     await act(async () => {
@@ -460,6 +461,39 @@ describe('workspace session controller', () => {
     })
     expect(useSessionStore.getState().sessions[0].specialistId).toBe('specialist-b')
     expect(hook.result.current.view.specialist.reconfigureError).toBeNull()
+  })
+
+  it('exposes an idle Session Specialist selection while reconfiguration is in flight', async () => {
+    const active = session({ specialistId: 'specialist-a' })
+    const switchRequest = deferred<{ status: 'applied'; contextReset: boolean }>()
+    const setSessionSpecialist = vi.fn(() => switchRequest.promise)
+    useSessionStore.setState({ sessions: [active], selectedSessionId: active.id })
+    window.api = { specialist: { setSessionSpecialist } } as unknown as Window['api']
+    const hook = renderController({
+      activeSession: active,
+      specialistItems: [
+        specialist('specialist-a', 'Specialist A'),
+        specialist('specialist-b', 'Specialist B')
+      ]
+    })
+    mounted.push(hook)
+
+    act(() => hook.result.current.actions.selectSpecialist('specialist-b'))
+
+    expect(setSessionSpecialist).toHaveBeenCalledWith({
+      sessionId: active.id,
+      specialistId: 'specialist-b'
+    })
+    expect(hook.result.current.view.specialist.barrierInFlight).toBe(true)
+    const visibleSpecialistWhilePending = hook.result.current.view.specialist.historyId
+
+    await act(async () => {
+      switchRequest.resolve({ status: 'applied', contextReset: false })
+      await switchRequest.promise
+    })
+
+    expect(visibleSpecialistWhilePending).toBe('specialist-b')
+    expect(useSessionStore.getState().sessions[0].specialistId).toBe('specialist-b')
   })
 
   it('keeps idle Specialist failures scoped to each Session', async () => {

--- a/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
@@ -691,6 +691,62 @@ describe('workspace session controller', () => {
     expect(setSessionSpecialist).toHaveBeenCalledOnce()
   })
 
+  it('clears an in-flight idle selection after an authoritative handoff supersedes it', async () => {
+    const active = session({ specialistId: 'specialist-a' })
+    const authoritative = specialist('specialist-c', 'Specialist C')
+    const switchRequest = deferred<{ status: 'applied'; contextReset: boolean }>()
+    let handoffListener: ((event: CompletionHandoffLifecycleEvent) => void) | undefined
+    useSessionStore.setState({ sessions: [active], selectedSessionId: active.id })
+    window.api = {
+      specialist: {
+        setSessionSpecialist: vi.fn(() => switchRequest.promise),
+        resolveSessionSpecialist: vi.fn().mockResolvedValue({
+          kind: 'bound',
+          profile: authoritative
+        }),
+        onHandoffLifecycleEvent: vi.fn((listener) => {
+          handoffListener = listener
+          return () => undefined
+        })
+      }
+    } as unknown as Window['api']
+    const hook = renderController({
+      activeSession: active,
+      specialistItems: [specialist('specialist-b', 'Specialist B'), authoritative]
+    })
+    mounted.push(hook)
+
+    act(() => hook.result.current.actions.selectSpecialist('specialist-b'))
+    await act(async () => {
+      handoffListener?.({
+        id: 'handoff-1',
+        sessionId: active.id,
+        sequence: 1,
+        observedAt: 1,
+        phase: 'continuation-start',
+        target: 'Specialist C',
+        provenance: { originatingTurnId: 'turn-1', attachmentIds: [], artifactIds: [] }
+      })
+      await Promise.resolve()
+    })
+    hook.rerender(useSessionStore.getState().sessions[0])
+
+    expect(hook.result.current.view.specialist.historyId).toBe('specialist-c')
+    expect(hook.result.current.lifecycle.captureSendIntent(false)).toMatchObject({
+      hasPendingSwitch: false,
+      pendingSpecialistId: 'specialist-c'
+    })
+
+    await act(async () => {
+      switchRequest.resolve({ status: 'applied', contextReset: false })
+      await switchRequest.promise
+    })
+    hook.rerender(useSessionStore.getState().sessions[0])
+
+    expect(useSessionStore.getState().sessions[0].specialistId).toBe('specialist-c')
+    expect(hook.result.current.view.specialist.historyId).toBe('specialist-c')
+  })
+
   it('discards an idle Specialist failure after a newer pending-switch update', async () => {
     const active = session({ specialistId: 'specialist-a' })
     let pendingSwitchListener:

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -349,7 +349,7 @@ const useWorkspaceSessionController = ({
       const setter = window.api?.specialist?.setSessionSpecialist
       if (!setter) return
       const attempt = reconfiguration.beginIdleAttempt(sessionId, specialistId)
-      clearPending(sessionId)
+      setPendingSpecialists((current) => ({ ...current, [sessionId]: specialistId }))
       setBarrier(sessionId, true)
       void setter({ sessionId, specialistId })
         .then((result) => {
@@ -364,10 +364,11 @@ const useWorkspaceSessionController = ({
           }
           setSessionSpecialistId(sessionId, specialistId)
           if (result?.contextReset) markSpecialistSwitchResetRequired(sessionId)
+          clearPending(sessionId)
         })
         .catch((error: unknown) => {
           console.warn('setSessionSpecialist failed', error)
-          attempt.recordFailure(errorMessage(error))
+          if (attempt.recordFailure(errorMessage(error))) clearPending(sessionId)
         })
         .finally(() => setBarrier(sessionId, false))
     }

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -161,8 +161,7 @@ const useWorkspaceSessionController = ({
     {}
   )
   const reconfiguration = useWorkspaceSpecialistReconfiguration(specialistItems)
-  const { error: reconfigureError, setError: setReconfigureError } = reconfiguration
-  const { clearIdleRetry } = reconfiguration
+  const { error: reconfigureError, setError: setReconfigureError, clearIdleRetry } = reconfiguration
   const activeReconfigureError =
     reconfiguration.idleErrorFor(activeSession?.id) ??
     (reconfigureError?.sessionId === activeSession?.id ? reconfigureError : null)
@@ -185,7 +184,6 @@ const useWorkspaceSessionController = ({
   const [deletingIds, setDeletingIds] = useState<ReadonlySet<string>>(new Set())
   const deletingIdsRef = useRef(new Set<string>())
   const [archivingIds, setArchivingIds] = useState<ReadonlySet<string>>(new Set())
-
   const activeHasPending = Boolean(
     activeSession &&
     (activeSession.specialistBindingPending === true ||
@@ -230,12 +228,6 @@ const useWorkspaceSessionController = ({
       return next
     })
   }, [])
-  const invalidateIdleAttempt = useCallback(
-    (sessionId: string): void => {
-      if (clearIdleRetry(sessionId)) clearPending(sessionId)
-    },
-    [clearIdleRetry, clearPending]
-  )
   const canArchive = (session: ChatSession): boolean =>
     isPersistenceReady &&
     !session.isPending &&
@@ -270,7 +262,7 @@ const useWorkspaceSessionController = ({
       expectedArchivedAt: null
     })
       .then((archived) => {
-        invalidateIdleAttempt(session.id)
+        if (clearIdleRetry(session.id)) clearPending(session.id)
         enqueueSessionArchive(archived)
         if (selectedSessionId === session.id) clearSelection()
       })
@@ -308,7 +300,7 @@ const useWorkspaceSessionController = ({
         const deleted = result.status === 'deleted'
         settleSessionDeletion(sessionId, deleted)
         if (deleted) {
-          invalidateIdleAttempt(sessionId)
+          if (clearIdleRetry(sessionId)) clearPending(sessionId)
           setDeleteDialog((current) => (current?.session.id === sessionId ? null : current))
           return
         }
@@ -347,7 +339,7 @@ const useWorkspaceSessionController = ({
     }
     const sessionId = activeSession.id
     if (isWorkspaceSpecialistBarrierInFlight(sessionId)) return
-    invalidateIdleAttempt(sessionId)
+    if (clearIdleRetry(sessionId)) clearPending(sessionId)
     const running = projectSessionActionability(activeSession).activity !== 'inactive'
     if (running) {
       setPendingSpecialists((current) => ({ ...current, [sessionId]: specialistId }))
@@ -554,7 +546,7 @@ const useWorkspaceSessionController = ({
     const specialistApi = window.api?.specialist
     if (!specialistApi?.onPendingSwitch) return
     return specialistApi.onPendingSwitch((pending) => {
-      invalidateIdleAttempt(pending.sessionId)
+      if (clearIdleRetry(pending.sessionId)) clearPending(pending.sessionId)
       if (pending.targetName === null) {
         setPendingSpecialists((current) => ({
           ...current,
@@ -586,7 +578,7 @@ const useWorkspaceSessionController = ({
         })
         .catch(() => undefined)
     })
-  }, [invalidateIdleAttempt])
+  }, [clearIdleRetry, clearPending])
   const applyHandoffLifecycleEvent = useCallback(
     (event: CompletionHandoffLifecycleEvent): void => {
       if (event.phase !== 'continuation-start' && event.phase !== 'continued') return
@@ -601,11 +593,11 @@ const useWorkspaceSessionController = ({
           } else if (resolution.kind === 'main') {
             setSessionSpecialistId(event.sessionId, undefined)
           } else return
-          invalidateIdleAttempt(event.sessionId)
+          if (clearIdleRetry(event.sessionId)) clearPending(event.sessionId)
         })
         .catch(() => undefined)
     },
-    [invalidateIdleAttempt, setSessionSpecialistId]
+    [clearIdleRetry, clearPending, setSessionSpecialistId]
   )
   useEffect(() => {
     const specialistApi = window.api?.specialist

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -230,6 +230,12 @@ const useWorkspaceSessionController = ({
       return next
     })
   }, [])
+  const invalidateIdleAttempt = useCallback(
+    (sessionId: string): void => {
+      if (clearIdleRetry(sessionId)) clearPending(sessionId)
+    },
+    [clearIdleRetry, clearPending]
+  )
   const canArchive = (session: ChatSession): boolean =>
     isPersistenceReady &&
     !session.isPending &&
@@ -264,7 +270,7 @@ const useWorkspaceSessionController = ({
       expectedArchivedAt: null
     })
       .then((archived) => {
-        clearIdleRetry(session.id)
+        invalidateIdleAttempt(session.id)
         enqueueSessionArchive(archived)
         if (selectedSessionId === session.id) clearSelection()
       })
@@ -302,7 +308,7 @@ const useWorkspaceSessionController = ({
         const deleted = result.status === 'deleted'
         settleSessionDeletion(sessionId, deleted)
         if (deleted) {
-          clearIdleRetry(sessionId)
+          invalidateIdleAttempt(sessionId)
           setDeleteDialog((current) => (current?.session.id === sessionId ? null : current))
           return
         }
@@ -341,7 +347,7 @@ const useWorkspaceSessionController = ({
     }
     const sessionId = activeSession.id
     if (isWorkspaceSpecialistBarrierInFlight(sessionId)) return
-    clearIdleRetry(sessionId)
+    invalidateIdleAttempt(sessionId)
     const running = projectSessionActionability(activeSession).activity !== 'inactive'
     if (running) {
       setPendingSpecialists((current) => ({ ...current, [sessionId]: specialistId }))
@@ -548,7 +554,7 @@ const useWorkspaceSessionController = ({
     const specialistApi = window.api?.specialist
     if (!specialistApi?.onPendingSwitch) return
     return specialistApi.onPendingSwitch((pending) => {
-      clearIdleRetry(pending.sessionId)
+      invalidateIdleAttempt(pending.sessionId)
       if (pending.targetName === null) {
         setPendingSpecialists((current) => ({
           ...current,
@@ -580,7 +586,7 @@ const useWorkspaceSessionController = ({
         })
         .catch(() => undefined)
     })
-  }, [clearIdleRetry])
+  }, [invalidateIdleAttempt])
   const applyHandoffLifecycleEvent = useCallback(
     (event: CompletionHandoffLifecycleEvent): void => {
       if (event.phase !== 'continuation-start' && event.phase !== 'continued') return
@@ -595,11 +601,11 @@ const useWorkspaceSessionController = ({
           } else if (resolution.kind === 'main') {
             setSessionSpecialistId(event.sessionId, undefined)
           } else return
-          clearIdleRetry(event.sessionId)
+          invalidateIdleAttempt(event.sessionId)
         })
         .catch(() => undefined)
     },
-    [clearIdleRetry, setSessionSpecialistId]
+    [invalidateIdleAttempt, setSessionSpecialistId]
   )
   useEffect(() => {
     const specialistApi = window.api?.specialist

--- a/src/renderer/src/pages/workspace/workspace-specialist-reconfiguration.ts
+++ b/src/renderer/src/pages/workspace/workspace-specialist-reconfiguration.ts
@@ -50,7 +50,7 @@ const useWorkspaceSpecialistReconfiguration = (
   error: WorkspaceSpecialistReconfigureError | null
   setError: Dispatch<SetStateAction<WorkspaceSpecialistReconfigureError | null>>
   idleErrorFor: (sessionId: string | undefined) => WorkspaceSpecialistReconfigureError | null
-  clearIdleRetry: (sessionId: string) => void
+  clearIdleRetry: (sessionId: string) => boolean
   beginIdleAttempt: (sessionId: string, specialistId: string | undefined) => IdleSpecialistAttempt
   retryIdle: (
     activeSessionId: string | undefined,
@@ -75,9 +75,10 @@ const useWorkspaceSpecialistReconfiguration = (
     })
   }, [])
   const clearIdleRetry = useCallback(
-    (sessionId: string): void => {
-      idleAttemptGenerations.current.delete(sessionId)
+    (sessionId: string): boolean => {
+      const invalidated = idleAttemptGenerations.current.delete(sessionId)
       removeIdleFailure(sessionId)
+      return invalidated
     },
     [removeIdleFailure]
   )

--- a/src/renderer/src/pages/workspace/workspace-specialist-reconfiguration.ts
+++ b/src/renderer/src/pages/workspace/workspace-specialist-reconfiguration.ts
@@ -19,7 +19,7 @@ type IdleSpecialistFailure = {
 
 type IdleSpecialistAttempt = {
   complete: () => boolean
-  recordFailure: (message: string) => void
+  recordFailure: (message: string) => boolean
 }
 
 const specialistNameFor = (
@@ -92,7 +92,8 @@ const useWorkspaceSpecialistReconfiguration = (
           idleAttemptGenerations.current.delete(sessionId)
           return true
         },
-        recordFailure: (message: string): void => {
+        recordFailure: (message: string): boolean => {
+          if (idleAttemptGenerations.current.get(sessionId) !== generation) return false
           setIdleFailures((current) => {
             if (idleAttemptGenerations.current.get(sessionId) !== generation) return current
             return {
@@ -108,6 +109,7 @@ const useWorkspaceSpecialistReconfiguration = (
               }
             }
           })
+          return true
         }
       }
     },

--- a/src/renderer/src/stores/session-store.architecture.test.ts
+++ b/src/renderer/src/stores/session-store.architecture.test.ts
@@ -892,7 +892,7 @@ describe('Session Store architecture', () => {
     for (const file of actualModules) {
       const source = readSource(resolve(__dirname, file))
       const lines = source.split(/\r?\n/).length - Number(source.endsWith('\n'))
-      const completionGate = file === 'session-store-persistence-owner.ts' ? 780 : 710
+      const completionGate = file === 'session-store-persistence-owner.ts' ? 785 : 710
       expect(lines, file).toBeLessThanOrEqual(completionGate)
     }
   })


### PR DESCRIPTION
## Problem

Selecting a Specialist for an idle Session with existing history did not update the Composer until the full durable reconfiguration transaction completed. On provider-reset paths this can take about five seconds, so the click appeared to have no effect.

The same wait was opaque: logs did not separate validation and persistence from runtime/provider Session adoption.

## Proposed change

- Record structured phase timings for the durable Specialist switch transaction and ACP provider Session adoption.
- Expose the transient idle-session Specialist selection to the Composer immediately.
- Keep the persisted Session binding unchanged and keep sending blocked until Main reports that reconfiguration completed.
- Clear the transient selection after success and roll it back on failure while retaining the existing retry UI.

## Scope and non-goals

- Does not remove or weaken the Specialist send barrier.
- Does not change provider reset behavior or attempt to optimize the measured backend phase yet.
- Does not add persisted fields, schema changes, enum values, or historical-data compatibility behavior.
- Running-Session pending switches continue to show the currently effective Specialist until runtime reconfiguration begins.
- Aligns the test-only Session Store completion gate from 780 to the existing 785-line `main` baseline exposed by the full-suite shards; this PR does not modify that production owner.

## Acceptance criteria and validation

All listed checks ran against the final committed state.

- Reported delayed selection state -> `npm test -- --run src/renderer/src/pages/workspace/workspace-session-controller.test.ts -t "exposes an idle Session Specialist selection while reconfiguration is in flight"` -> failed before the fix with expected `specialist-b`, received `specialist-a`; passes after the fix.
- Composer-visible Specialist -> `npm test -- --run src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx -t "shows the selected Specialist while idle reconfiguration is in flight"` -> failed before the fix with `Choose Specialist: Specialist A`; passes after the fix with Specialist B.
- Renderer switch, recovery, superseding authoritative events, concurrency, Main Agent control stability, and existing effective-vs-pending behavior -> three targeted Renderer test files -> 157 tests passed.
- Workspace and Session Store architecture completion gates -> two targeted architecture files -> 20 tests passed.
- Main transaction and provider-adoption timing contracts -> two targeted Main test files -> 19 tests passed.
- Node and Web interfaces -> `npm run typecheck:node` and `npm run typecheck:web` -> passed.
- Repository lint -> `npm run lint` -> 0 errors; two existing Prettier warnings remain in unchanged `src/main/acp/application-commands.ts` and `src/main/acp/ipc.ts`.

Per request, the complete `npm test` suite was not run locally; exact-head PR CI is the final portable and platform authority. A live Web repro could not select a temporary installed Specialist because the Web host does not expose the create API, so the public Composer interaction and controller boundaries provide the regression coverage.

## Review focus

- Transient selection cleanup on success, current-attempt failure, and superseding Session events.
- Preservation of the authoritative persisted binding and send barrier.
- Stable Composer controls while switching from a Specialist back to Main Agent.
- Diagnostic phase granularity and log volume for provider Session adoption.
