### PR TITLE
fix(updater): wait for in-flight checks before downloading

### DIFF
--- a/scripts/windows-updater-certification.mjs
+++ b/scripts/windows-updater-certification.mjs
@@ -232,6 +232,23 @@ const invokeWebRpc = async ({ endpoint, auth, protocolVersion, channel, fetchImp
   return payload.result
 }
 
+// 0.18.0–0.18.2 return the in-flight check snapshot from update:download while the startup
+// scheduler still owns check() (notes hydration). Poll until the download actually reaches ready.
+const classifyUpdaterDownloadStatus = (downloaded, expectedVersion) => {
+  if (!downloaded || typeof downloaded !== 'object') return 'unexpected'
+  if (
+    downloaded.state === 'ready' &&
+    downloaded.applyKind === 'restart' &&
+    downloaded.latest === expectedVersion
+  ) {
+    return 'ready'
+  }
+  if (downloaded.state === 'error') return 'failed'
+  if (downloaded.state === 'checking' || downloaded.state === 'downloading') return 'pending'
+  if (downloaded.state === 'available' && downloaded.latest === expectedVersion) return 'pending'
+  return 'unexpected'
+}
+
 const waitForInstallerExit = async ({ installer, env, signal, runProcessImpl = runProcess }) => {
   const script = String.raw`
 Add-Type -TypeDefinition @'
@@ -363,18 +380,22 @@ const runElectronUpdater = async ({
     if (checked.state !== 'available' || checked.latest !== expectedVersion) {
       throw new Error(`Unexpected updater check result: ${JSON.stringify(checked)}`)
     }
-    const downloaded = await withTimeout(
-      invokeWebRpc({
-        endpoint,
-        auth,
-        protocolVersion: bootstrap.rpcProtocolVersion,
-        channel: 'update:download'
-      }),
-      'electron-updater differential download'
+    await waitFor(
+      'electron-updater differential download',
+      async () => {
+        const status = await invokeWebRpc({
+          endpoint,
+          auth,
+          protocolVersion: bootstrap.rpcProtocolVersion,
+          channel: 'update:download'
+        })
+        const classification = classifyUpdaterDownloadStatus(status, expectedVersion)
+        if (classification === 'ready') return status
+        if (classification === 'pending') return undefined
+        throw new Error(`Unexpected updater download result: ${JSON.stringify(status)}`)
+      },
+      UPDATE_TIMEOUT_MS
     )
-    if (downloaded.state !== 'ready' || downloaded.applyKind !== 'restart') {
-      throw new Error(`Unexpected updater download result: ${JSON.stringify(downloaded)}`)
-    }
     await onDownloaded()
 
     // electron-updater intentionally detaches NSIS, so the app exit is not evidence that the
@@ -642,6 +663,7 @@ if (invokedAsScript) {
 export {
   assertDifferentialObservation,
   buildLocalUpdaterConfig,
+  classifyUpdaterDownloadStatus,
   invokeWebRpc,
   redactPackagedAppOutput,
   waitForInstallerExit,

--- a/scripts/windows-updater-certification.test.ts
+++ b/scripts/windows-updater-certification.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   assertDifferentialObservation,
   buildLocalUpdaterConfig,
+  classifyUpdaterDownloadStatus,
   invokeWebRpc,
   parseArguments,
   parseSingleRange,
@@ -148,5 +149,38 @@ describe('Windows updater certification', () => {
       output: expect.stringContaining('observation.json')
     })
     expect(() => parseArguments(['--current-dir', 'current'])).toThrow(/Usage/)
+  })
+
+  it('retries download while a shipped updater still reports the in-flight check', () => {
+    expect(
+      classifyUpdaterDownloadStatus(
+        { state: 'available', latest: '0.18.2', applyKind: 'restart' },
+        '0.18.2'
+      )
+    ).toBe('pending')
+    expect(classifyUpdaterDownloadStatus({ state: 'checking', current: '0.18.1' }, '0.18.2')).toBe(
+      'pending'
+    )
+    expect(
+      classifyUpdaterDownloadStatus(
+        { state: 'downloading', latest: '0.18.2', applyKind: 'restart' },
+        '0.18.2'
+      )
+    ).toBe('pending')
+    expect(
+      classifyUpdaterDownloadStatus(
+        { state: 'ready', latest: '0.18.2', applyKind: 'restart' },
+        '0.18.2'
+      )
+    ).toBe('ready')
+    expect(classifyUpdaterDownloadStatus({ state: 'error', error: 'offline' }, '0.18.2')).toBe(
+      'failed'
+    )
+    expect(
+      classifyUpdaterDownloadStatus(
+        { state: 'available', latest: '0.18.2', applyKind: 'restart' },
+        '0.19.0'
+      )
+    ).toBe('unexpected')
   })
 })

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -261,7 +261,35 @@ describe('ElectronUpdaterStrategy', () => {
     )
   })
 
-  it('does not start an in-place download while a provider check is active', async () => {
+  it('coalesces overlapping in-place checks onto the in-flight provider query', async () => {
+    const updater = new FakeUpdater()
+    let releaseCheck: (() => void) | undefined
+    const checkGate = new Promise<void>((resolve) => {
+      releaseCheck = resolve
+    })
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('checking-for-update')
+      await checkGate
+      updater.emit('update-available', { version: '0.3.0', releaseNotes: 'notes' })
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+
+    const first = strategy.check()
+    const second = strategy.check()
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(1)
+    releaseCheck?.()
+    const [left, right] = await Promise.all([first, second])
+    expect(left).toBe(right)
+    expect(left.state).toBe('available')
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits for an in-flight provider check before starting an in-place download', async () => {
     const updater = new FakeUpdater()
     let releaseCheck: (() => void) | undefined
     const checkGate = new Promise<void>((resolve) => {
@@ -280,13 +308,54 @@ describe('ElectronUpdaterStrategy', () => {
     })
 
     const checking = strategy.check()
-    const checkingStatus = strategy.getStatus()
-    expect(checkingStatus.state).toBe('checking')
-    expect(await strategy.download()).toBe(checkingStatus)
+    expect(strategy.getStatus().state).toBe('checking')
+    const downloading = strategy.download()
     expect(updater.downloadUpdate).not.toHaveBeenCalled()
 
     releaseCheck?.()
     expect((await checking).state).toBe('available')
+    expect((await downloading).state).toBe('ready')
+    expect(updater.downloadUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits for notes hydration after update-available before starting an in-place download', async () => {
+    const updater = new FakeUpdater()
+    let releaseNotes: (() => void) | undefined
+    const notesGate = new Promise<void>((resolve) => {
+      releaseNotes = resolve
+    })
+    const fetchImpl = vi.fn(async () => {
+      await notesGate
+      return {
+        ok: true,
+        json: async () => ({
+          version: '0.3.0',
+          releaseDate: '',
+          notes: 'cdn notes',
+          downloads: {}
+        })
+      }
+    }) as unknown as typeof fetch
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl
+    })
+
+    const checking = strategy.check()
+    expect(strategy.getStatus()).toEqual(
+      expect.objectContaining({ state: 'available', latest: '0.3.0', notes: 'notes' })
+    )
+    const downloading = strategy.download()
+    expect(updater.downloadUpdate).not.toHaveBeenCalled()
+
+    releaseNotes?.()
+    expect(await checking).toEqual(
+      expect.objectContaining({ state: 'available', notes: 'cdn notes' })
+    )
+    expect((await downloading).state).toBe('ready')
+    expect(updater.downloadUpdate).toHaveBeenCalledTimes(1)
   })
 
   it('records a failed in-place download without the provider error message', async () => {

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -185,7 +185,9 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   // latest, so an older (drained) download can't clear a newer one's lifecycle.
   private downloadGeneration = 0
   private downloadOperation?: DiagnosticOperation
-  private checkInFlight = false
+  // In-flight check() promise. Overlapping check()/download() await this instead of returning a
+  // snapshot taken after `update-available` but before notes hydration finishes.
+  private checkLifecycle?: Promise<UpdateStatus>
   private readyCheckStatus?: UpdateStatus
   private readyCheckError?: unknown
   private status: UpdateStatus
@@ -358,46 +360,54 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
   async check(): Promise<UpdateStatus> {
     // Keep provider checks mutually exclusive with downloads. A ready update may still be refreshed,
     // but its events are reconciled against the downloaded version by the subscribers above.
-    if (this.applying || this.checkInFlight || this.downloadLifecycle) {
+    if (this.applying || this.downloadLifecycle) {
       return this.status
     }
+    if (this.checkLifecycle) return this.checkLifecycle
+
     const readyStatus = this.status.state === 'ready' ? this.status : undefined
     const operation = startDiagnosticOperation(this.log, {
       operation: 'update-check',
       fields: { strategy: 'in-place' }
     })
-    this.checkInFlight = true
     this.readyCheckStatus = readyStatus
     this.readyCheckError = undefined
-    try {
-      operation.phase('query-provider')
-      let providerFailure: unknown
+    const lifecycle = (async () => {
       try {
-        await this.updater.checkForUpdates()
-      } catch (error) {
-        providerFailure = error
-        if (!readyStatus || this.status !== readyStatus) {
-          this.setStatus({
-            state: 'error',
-            error: error instanceof Error ? error.message : 'Update check failed'
-          })
+        operation.phase('query-provider')
+        let providerFailure: unknown
+        try {
+          await this.updater.checkForUpdates()
+        } catch (error) {
+          providerFailure = error
+          if (!readyStatus || this.status !== readyStatus) {
+            this.setStatus({
+              state: 'error',
+              error: error instanceof Error ? error.message : 'Update check failed'
+            })
+          }
         }
+        // Wait for the notes fetch triggered by update-available so the returned status carries them.
+        await this.notesHydration
+        providerFailure ??= this.readyCheckError
+        if (providerFailure) {
+          operation.fail(providerFailure, { result: 'error' })
+        } else if (this.status.state === 'error') {
+          operation.fail(new Error('Updater check failed'), { result: 'error' })
+        } else {
+          operation.complete({ result: this.status.state })
+        }
+        return this.status
+      } finally {
+        this.readyCheckStatus = undefined
+        this.readyCheckError = undefined
       }
-      // Wait for the notes fetch triggered by update-available so the returned status carries them.
-      await this.notesHydration
-      providerFailure ??= this.readyCheckError
-      if (providerFailure) {
-        operation.fail(providerFailure, { result: 'error' })
-      } else if (this.status.state === 'error') {
-        operation.fail(new Error('Updater check failed'), { result: 'error' })
-      } else {
-        operation.complete({ result: this.status.state })
-      }
-      return this.status
+    })()
+    this.checkLifecycle = lifecycle
+    try {
+      return await lifecycle
     } finally {
-      this.checkInFlight = false
-      this.readyCheckStatus = undefined
-      this.readyCheckError = undefined
+      if (this.checkLifecycle === lifecycle) this.checkLifecycle = undefined
     }
   }
 
@@ -405,7 +415,14 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     // An active download is in flight; ignore repeat clicks / concurrent renderers. Starting a second
     // would overwrite downloadToken and orphan the first (cancel() could no longer stop it). This guard
     // and the token claim below are synchronous so a racing download()/cancel() sees a consistent slot.
-    if (this.applying || this.checkInFlight || this.downloadToken) return this.status
+    if (this.applying || this.downloadToken) return this.status
+    // The startup scheduler and notes hydration keep check() in flight after `update-available` has
+    // already marked the status `available`. Returning that snapshot dropped RPC/UI download requests,
+    // including the Windows upgrade-smoke harness talking to 0.18.0+. Wait for the check, then start.
+    if (this.checkLifecycle) await this.checkLifecycle
+    if (this.applying || this.downloadToken) return this.status
+    if (this.status.state === 'ready') return this.status
+    if (this.status.state !== 'available') return this.status
 
     const operation = startDiagnosticOperation(this.log, {
       operation: 'update-download',

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -159,6 +159,35 @@ describe('UpdateService.check', () => {
     expect(status.state).toBe('available')
     expect(status.totalBytes).toBe(5)
   })
+
+  it('coalesces overlapping manifest checks onto the in-flight fetch', async () => {
+    let releaseCheck: (() => void) | undefined
+    const checkGate = new Promise<void>((resolve) => {
+      releaseCheck = resolve
+    })
+    let fetches = 0
+    const fetchImpl = (async () => {
+      fetches += 1
+      await checkGate
+      return jsonResponse(manifest)
+    }) as unknown as typeof fetch
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      broadcast: vi.fn()
+    })
+
+    const first = service.check()
+    const second = service.check()
+    expect(fetches).toBe(1)
+    releaseCheck?.()
+    const [left, right] = await Promise.all([first, second])
+    expect(left).toBe(right)
+    expect(left.state).toBe('available')
+    expect(fetches).toBe(1)
+  })
 })
 
 describe('UpdateService.download', () => {
@@ -206,6 +235,47 @@ describe('UpdateService.download', () => {
     expect(status.state).toBe('ready')
     expect(status.localPath).toBe(target)
     expect(existsSync(target)).toBe(true)
+  })
+
+  it('waits for an in-flight check before starting a download', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'svc-wait-check-'))
+    const target = join(dir, 'installer.dmg')
+    const body = Buffer.from('installer-bytes')
+    const manifestForCheck = downloadManifest(
+      body.byteLength,
+      createHash('sha256').update(body).digest('hex')
+    )
+    let releaseCheck: (() => void) | undefined
+    const checkGate = new Promise<void>((resolve) => {
+      releaseCheck = resolve
+    })
+    let installerFetches = 0
+    const fetchImpl = (async (input: unknown) => {
+      if (String(input).endsWith('version.json')) {
+        await checkGate
+        return jsonResponse(manifestForCheck)
+      }
+      installerFetches += 1
+      return new Response(body, { status: 200 })
+    }) as unknown as typeof fetch
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://statics.aipoch.com/version.json',
+      broadcast: vi.fn(),
+      promptSavePath: () => Promise.resolve(target)
+    })
+
+    const checking = service.check()
+    expect(service.getStatus().state).toBe('checking')
+    const downloading = service.download()
+    expect(installerFetches).toBe(0)
+    releaseCheck?.()
+    expect((await checking).state).toBe('available')
+    expect((await downloading).state).toBe('ready')
+    expect(installerFetches).toBe(1)
   })
 
   it('uses the deterministic download path without opening a save dialog when non-interactive', async () => {

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -84,7 +84,9 @@ export class UpdateService implements UpdateStrategy {
   // latest, so an older (drained) download can't clear a newer one's lifecycle.
   private downloadGeneration = 0
   private downloadOperation?: DiagnosticOperation
-  private checkInFlight = false
+  // In-flight check() promise. Overlapping check()/download() await this instead of returning a
+  // snapshot taken while the startup scheduler still owns the manifest fetch.
+  private checkLifecycle?: Promise<UpdateStatus>
   private readonly fetchImpl?: typeof fetch
   private readonly platform: NodeJS.Platform
   private readonly arch: string
@@ -157,15 +159,15 @@ export class UpdateService implements UpdateStrategy {
   async check(): Promise<UpdateStatus> {
     // A transfer and a manifest check cannot own the status concurrently. Once ready, checks still run
     // but only a strictly newer release may supersede the downloaded installer.
-    if (this.downloadLifecycle || this.checkInFlight) return this.status
+    if (this.downloadLifecycle) return this.status
+    if (this.checkLifecycle) return this.checkLifecycle
 
     const readyStatus = this.status.state === 'ready' ? this.status : undefined
     const operation = startDiagnosticOperation(this.log, {
       operation: 'update-check',
       fields: { strategy: 'manifest' }
     })
-    this.checkInFlight = true
-    try {
+    const lifecycle = (async () => {
       if (!readyStatus) this.setStatus({ state: 'checking', current: this.currentVersion })
       operation.phase('fetch-manifest')
       try {
@@ -214,8 +216,12 @@ export class UpdateService implements UpdateStrategy {
         operation.fail(error, { result: 'error' })
       }
       return this.status
+    })()
+    this.checkLifecycle = lifecycle
+    try {
+      return await lifecycle
     } finally {
-      this.checkInFlight = false
+      if (this.checkLifecycle === lifecycle) this.checkLifecycle = undefined
     }
   }
 
@@ -223,7 +229,11 @@ export class UpdateService implements UpdateStrategy {
     // An active download is in flight; ignore repeat clicks / concurrent renderers. The abort claim
     // below is synchronous (before any await) so this guard and a cancel() during the drain both target
     // a consistent slot — a cancel while a retry is still draining must abort it, not be a no-op.
-    if (this.checkInFlight || this.downloadAbort) return this.status
+    if (this.downloadAbort) return this.status
+    // The startup scheduler owns check() at launch. Returning the in-flight snapshot dropped download
+    // requests that arrived after the UI/RPC already observed `available`. Wait, then start.
+    if (this.checkLifecycle) await this.checkLifecycle
+    if (this.downloadAbort) return this.status
 
     const { download } = this.status
     if (!download) return this.status


### PR DESCRIPTION
## Problem

[Windows Upgrade Smoke](https://github.com/aipoch/open-science/actions/workflows/windows-upgrade-smoke.yml) has failed on every stable release since v0.18.1. The installer drill passed; the electron-updater drill failed with:

```text
Unexpected updater download result: {"state":"available","latest":"0.18.2",...,"applyKind":"restart"}
```

`update:download` returned the in-flight check snapshot instead of `ready`. v0.18.0 added `checkInFlight` serialization and notes hydration (`#1402`). The startup scheduler starts `check()` immediately; `update-available` marks the status `available` while notes hydration still owns the check. A subsequent `update:download` then no-op'd. v0.17.0 did not have that guard, so 0.17.0 → 0.18.0 smoke still passed.

The same race exists on the manifest `UpdateService` path.

## Proposed change

- Coalesce overlapping `check()` calls onto the in-flight provider/manifest query.
- Wait for that in-flight check, then start `download()` when the status is `available`.
- Keep overlapping `download()` while a transfer is already running as an immediate no-op.
- In the Windows upgrade-smoke harness, poll `update:download` while a shipped 0.18.0–0.18.2 build still reports `available`/`checking`/`downloading`, so already-published previous installers keep certifying.

```mermaid
sequenceDiagram
  participant Scheduler
  participant Strategy
  participant Smoke
  Scheduler->>Strategy: check()
  Strategy-->>Strategy: update-available (state=available)
  Note over Strategy: notes hydration still in flight
  Smoke->>Strategy: check() (now awaits in-flight)
  Smoke->>Strategy: download() (now waits, then transfers)
```

## Scope and non-goals

- No workflow YAML changes.
- No new `UpdateState` values.
- No persisted data or migration changes.
- Does not rewrite shipped 0.18.0–0.18.2 binaries; the harness retry covers those previous versions until they age out.

## Acceptance criteria and validation

- In-place and manifest strategies wait for an in-flight check before downloading.
- Overlapping checks share one provider/manifest query.
- The smoke harness classifies a shipped `available` download snapshot as pending, not failure.
- Listed checks ran after the last material edit.

| Behavior | Command | Result |
| --- | --- | --- |
| In-place check coalescing, wait-then-download, notes-hydration race | `npx vitest run src/main/update/electron-updater-strategy.test.ts` | pass |
| Manifest check coalescing and wait-then-download | `npx vitest run src/main/update/service.test.ts` | pass |
| Update IPC command wiring unchanged | `npx vitest run src/main/update/ipc.test.ts` | pass |
| Smoke harness download-status classification | `npx vitest run scripts/windows-updater-certification.test.ts` | pass |
| Changed TypeScript | `npm run typecheck:node` | pass |
| Changed files | `npx eslint` on the six touched files | pass |

Excluded: local Windows installer/electron-updater end-to-end (requires Windows hosted runners and published NSIS artifacts). PR Gate remains authoritative for the portable suite; `windows-upgrade-smoke` will be dispatched against `v0.18.2` from this branch as the focused dry-run.

Uncovered risks: GitHub-hosted Windows runner timing against a hung CDN notes fetch still depends on the 180s download timeout; a previous installer older than 0.18.0 is already known-good.

## Review focus

- Waiting for `checkLifecycle` in `download()` vs. keeping download/check mutual exclusion.
- Harness retry must not treat a wrong-version `available` snapshot as success.