### PR TITLE
fix(composer): keep slash shortcuts visible

### DIFF
--- a/src/renderer/src/pages/workspace/composer/SkillMentionPopup.render.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/SkillMentionPopup.render.test.tsx
@@ -130,6 +130,20 @@ describe('SkillMentionPopup', () => {
     expect(text).not.toContain('Imported')
   })
 
+  it('keeps the shortcut footer outside the scrollable skill list', () => {
+    act(() => {
+      root.render(<SkillMentionPopup query="" onSelect={vi.fn()} onClose={vi.fn()} />)
+    })
+
+    const listbox = document.body.querySelector<HTMLElement>('[role="listbox"]')!
+    const popup = listbox.parentElement!
+    const footer = popup.lastElementChild as HTMLElement
+
+    expect([...popup.classList]).toEqual(expect.arrayContaining(['flex', 'flex-col']))
+    expect([...listbox.classList]).toEqual(expect.arrayContaining(['min-h-0', 'flex-1']))
+    expect(footer.classList).toContain('shrink-0')
+  })
+
   it('moves aria-selected with ArrowDown/ArrowUp and wraps', () => {
     act(() => {
       root.render(

--- a/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
@@ -149,12 +149,12 @@ export const SkillMentionPopup = ({
   }, [matches, safeIndex, onSelect, onClose])
 
   return (
-    <div className="absolute bottom-full left-0 mb-1 z-50 bg-bg-000 border-0.5 border-border-200 rounded-xl shadow-[0_4px_16px_hsl(var(--always-black)/10%)] p-1.5 min-w-[320px] max-w-[440px] max-h-[min(45vh,18rem)] overflow-hidden">
+    <div className="absolute bottom-full left-0 mb-1 z-50 flex flex-col bg-bg-000 border-0.5 border-border-200 rounded-xl shadow-[0_4px_16px_hsl(var(--always-black)/10%)] p-1.5 min-w-[320px] max-w-[440px] max-h-[min(45vh,18rem)] overflow-hidden">
       <ul
         id={resolvedListboxId}
         role="listbox"
         aria-label={t('Skill suggestions')}
-        className="overflow-y-auto max-h-[min(45vh,18rem)]"
+        className="min-h-0 flex-1 overflow-y-auto"
       >
         {matches.map(({ skill, positions }, index) => {
           const isActive = index === safeIndex
@@ -188,7 +188,7 @@ export const SkillMentionPopup = ({
           )
         })}
       </ul>
-      <div className="mt-1 -mx-1.5 -mb-1.5 px-3.5 pt-1.5 pb-2 border-t border-border-300 flex items-center gap-3 text-[11px] text-text-400 select-none">
+      <div className="mt-1 -mx-1.5 -mb-1.5 shrink-0 px-3.5 pt-1.5 pb-2 border-t border-border-300 flex items-center gap-3 text-[11px] text-text-400 select-none">
         <span>
           <span className="text-text-300">↑↓</span> {t('navigate')}
         </span>


### PR DESCRIPTION
## Problem

The composer `/` Skill popup gives its scrollable list the same maximum height as the entire popup. With enough Skills, the list consumes the available height and the popup's `overflow-hidden` clips the shortcut footer.

## Proposed change

- Make the Skill popup a column flex container.
- Let only the Skill list shrink and scroll within the popup height.
- Keep the shortcut footer non-shrinking at the bottom.
- Add a render regression test for the popup/list/footer layout contract.

## Scope and non-goals

- Scope is limited to the composer `/` Skill popup.
- No selection, keyboard, filtering, or Skill-loading behavior changes.
- No historical data compatibility requirement.
- No enum or state additions.
- No data persistence changes.

## Acceptance criteria and validation

Checks below ran after the final material edit unless noted:

- Shortcut footer remains outside the scrollable Skill list -> `npm test -- src/renderer/src/pages/workspace/composer/SkillMentionPopup.render.test.tsx` -> 12 passed.
- Composer mention consumer behavior remains intact -> `npm test -- src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx` -> 26 passed.
- Workspace visual contracts remain intact -> `npm test -- src/renderer/src/pages/workspace/workspace-components.test.tsx` -> 29 passed.
- Renderer types remain valid -> `npm run typecheck:web` -> passed.
- Linted source remains valid -> `npm run lint` -> passed with two pre-existing Prettier warnings in `src/main/acp/application-commands.ts` and `src/main/acp/ipc.ts`; no errors.
- Real-browser layout verification -> authenticated localhost Web UI with 20 Skill rows -> list was scrollable (`scrollHeight 1320`, `clientHeight 247`), and the 31.5px footer was visible, inside the popup, and below the list. This browser check ran after the production layout edit and before a test-assertion-only refinement.
- Final impact explanation -> `npm run test:affected -- --base 1fb047b8787107a83db5d700c7f363eaf6e287cb --head HEAD --explain` -> full CI plan because `SkillMentionPopup.render.test.tsx` is not registered to a module owner.

Per maintainer direction, the complete local `npm test` suite was not run. PR Gate is authoritative and will run the fail-closed full plan.

## Review focus

Confirm the popup owns the height constraint, the list is the only shrinking scroll region, and the footer cannot be clipped when the Skill catalog exceeds the popup height.

## Uncovered risks

No persistence, protocol, platform-path, Electron-only, or data migration risk was identified. Browser verification used the supported localhost Web surface; CSS layout is shared with Electron.
