### PR TITLE
perf(session-renderer): bound transcript rendering and cache images

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -530,6 +530,12 @@ colors communicate a successful or failed probe/migration result.
 - Outer shell: `ScrollArea className="min-w-0 flex-1"`.
 - Message scroller surface uses `bg-bg-10` with a top fade `bg-gradient-to-b from-bg-10 to-bg-10/0`.
 - Message content is centered in `mx-auto w-full max-w-4xl pb-[56px]`.
+- Selecting a Session whose persisted content is not hydrated yet replaces the transcript with a
+  conversation-shaped skeleton: one right-aligned user bubble and two left-aligned Agent text
+  groups on `bg-bg-10`, using `bg-bg-300`, the existing message radii, and pulse opacity motion.
+  Keep the header, sidebar, preview, and composer stable; hide the decorative skeleton from assistive
+  technology, and disable its pulse under reduced motion. Already-hydrated Session switches render
+  directly so short in-memory transitions never flash a loading surface.
 - Desktop conversations with at least two visible human-authored runs show **Run Marks** in the
   scroller's left gutter. One mark belongs to the visible user Message that admitted the Run; model
   Turns inside that Run do not create marks. At rest, every mark is the same short gray segment.

--- a/src/main/find-overlay.test.ts
+++ b/src/main/find-overlay.test.ts
@@ -7,7 +7,11 @@ import {
   createFindOverlayManager,
   type FindOverlayManager
 } from './find-overlay'
-import { WINDOW_FIND_APPEARANCE_CHANNEL, WINDOW_FIND_SHOW_CHANNEL } from '../shared/window-controls'
+import {
+  WINDOW_FIND_APPEARANCE_CHANNEL,
+  WINDOW_FIND_HIDE_CHANNEL,
+  WINDOW_FIND_SHOW_CHANNEL
+} from '../shared/window-controls'
 
 describe('computeOverlayBounds', () => {
   it('anchors the bar to the top-right of the content area with a margin', () => {
@@ -39,7 +43,7 @@ type FindOverlayTestFakes = {
     getContentBounds: () => { width: number; height: number }
     on: Mock
     removeListener: Mock
-    webContents: { focus: Mock; stopFindInPage: Mock }
+    webContents: { focus: Mock; send: Mock; stopFindInPage: Mock }
   }
   createView: Mock
   registerOwner: Mock
@@ -58,7 +62,7 @@ const createFakes = (): FindOverlayTestFakes => {
     getContentBounds: () => ({ width: 1000, height: 800 }),
     on: vi.fn(),
     removeListener: vi.fn(),
-    webContents: { focus: vi.fn(), stopFindInPage: vi.fn() }
+    webContents: { focus: vi.fn(), send: vi.fn(), stopFindInPage: vi.fn() }
   }
   const createView = vi.fn(() => view)
   const registerOwner = vi.fn()
@@ -137,6 +141,7 @@ describe('find overlay manager', () => {
 
     expect(view.setBounds).toHaveBeenCalledWith({ x: 0, y: 0, width: 0, height: 0 })
     expect(mainWindow.webContents.stopFindInPage).toHaveBeenCalledWith('clearSelection')
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith(WINDOW_FIND_HIDE_CHANNEL)
     expect(manager.isOpen()).toBe(false)
   })
 
@@ -256,7 +261,7 @@ describe('find overlay manager', () => {
     const mainWindow = Object.assign(new EventEmitter(), {
       contentView: { addChildView: vi.fn() },
       getContentBounds: () => ({ width: 1000, height: 800 }),
-      webContents: { focus: vi.fn(), stopFindInPage: vi.fn() }
+      webContents: { focus: vi.fn(), send: vi.fn(), stopFindInPage: vi.fn() }
     })
     const manager = createFindOverlayManager({
       mainWindow,

--- a/src/main/find-overlay.ts
+++ b/src/main/find-overlay.ts
@@ -1,5 +1,6 @@
 import {
   WINDOW_FIND_APPEARANCE_CHANNEL,
+  WINDOW_FIND_HIDE_CHANNEL,
   WINDOW_FIND_SHOW_CHANNEL,
   type WindowFindAppearance
 } from '../shared/window-controls'
@@ -47,7 +48,11 @@ type OverlayMainWindow = {
   on(event: 'resize', listener: () => void): void
   removeListener?(event: 'resize', listener: () => void): void
   off?(event: 'resize', listener: () => void): void
-  webContents: { focus(): void; stopFindInPage(action: 'clearSelection'): void }
+  webContents: {
+    focus(): void
+    send(channel: string, payload?: unknown): void
+    stopFindInPage(action: 'clearSelection'): void
+  }
 }
 
 export type FindOverlayDeps = {
@@ -106,6 +111,7 @@ export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayMana
     opened = false
     view?.setBounds(ZERO_BOUNDS)
     deps.mainWindow.webContents.stopFindInPage('clearSelection')
+    deps.mainWindow.webContents.send(WINDOW_FIND_HIDE_CHANNEL)
     deps.mainWindow.webContents.focus()
   }
 

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -4,6 +4,7 @@ import {
   CLOSE_ACTIVE_PANE_CHANNEL,
   CLOSE_ACTIVE_PANE_READY_CHANNEL,
   CLOSE_ACTIVE_PANE_UNREADY_CHANNEL,
+  WINDOW_FIND_CONTENT_READY_CHANNEL,
   WINDOW_FIND_READY_CHANNEL,
   WINDOW_FIND_SHOW_CHANNEL,
   WINDOW_FIND_UNREADY_CHANNEL,
@@ -362,6 +363,9 @@ describe('close chord interception', () => {
   const signalWindowFindGone = (window: FakeBrowserWindow): void =>
     fireHandshake(window, WINDOW_FIND_UNREADY_CHANNEL)
 
+  const signalWindowFindContentReady = (window: FakeBrowserWindow): void =>
+    fireHandshake(window, WINDOW_FIND_CONTENT_READY_CHANNEL)
+
   // Drives one of the captured webContents lifecycle handlers (render-process-gone, unresponsive, ...).
   const fireWebContentsEvent = (
     window: FakeBrowserWindow,
@@ -408,7 +412,7 @@ describe('close chord interception', () => {
     expect(window.closeMock).not.toHaveBeenCalled()
   })
 
-  it('opens the find overlay only after the Workspace listener is ready', () => {
+  it('opens the find overlay only after the full Workspace transcript is mounted', () => {
     createMainWindow()
     const window = currentWindow!
 
@@ -416,11 +420,20 @@ describe('close chord interception', () => {
     const preventDefault = fireInput(window, findChord())
 
     expect(preventDefault).toHaveBeenCalled()
-    expect(findOverlayMock.open).toHaveBeenCalledTimes(1)
+    expect(findOverlayMock.open).not.toHaveBeenCalled()
     expect(window.sendMock).toHaveBeenCalledWith(WINDOW_FIND_SHOW_CHANNEL, {
       theme: 'light',
       followsSystem: true
     })
+
+    signalWindowFindContentReady(window)
+    expect(findOverlayMock.open).toHaveBeenCalledTimes(1)
+
+    // A Session switch commits a new full transcript while the same overlay remains open. Re-open is
+    // intentional: the overlay re-runs its remembered query against the new Session DOM.
+    findOverlayMock.isOpen.mockReturnValue(true)
+    signalWindowFindContentReady(window)
+    expect(findOverlayMock.open).toHaveBeenCalledTimes(2)
     expect(window.closeMock).not.toHaveBeenCalled()
   })
 

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -5,6 +5,7 @@ import {
   CLOSE_ACTIVE_PANE_READY_CHANNEL,
   CLOSE_ACTIVE_PANE_UNREADY_CHANNEL,
   WINDOW_FIND_READY_CHANNEL,
+  WINDOW_FIND_SHOW_CHANNEL,
   WINDOW_FIND_UNREADY_CHANNEL,
   WINDOW_FIND_APPEARANCE_CHANGED_CHANNEL,
   type KeyChordInput
@@ -416,8 +417,10 @@ describe('close chord interception', () => {
 
     expect(preventDefault).toHaveBeenCalled()
     expect(findOverlayMock.open).toHaveBeenCalledTimes(1)
-    // The overlay is opened directly in main now; no OPEN message is sent to the renderer.
-    expect(window.sendMock).not.toHaveBeenCalled()
+    expect(window.sendMock).toHaveBeenCalledWith(WINDOW_FIND_SHOW_CHANNEL, {
+      theme: 'light',
+      followsSystem: true
+    })
     expect(window.closeMock).not.toHaveBeenCalled()
   })
 

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -23,6 +23,7 @@ import {
   CLOSE_ACTIVE_PANE_UNREADY_CHANNEL,
   WINDOW_FIND_APPEARANCE_CHANGED_CHANNEL,
   WINDOW_FIND_READY_CHANNEL,
+  WINDOW_FIND_SHOW_CHANNEL,
   WINDOW_FIND_UNREADY_CHANNEL,
   isCloseWindowChord,
   isFindInPageChord,
@@ -142,6 +143,7 @@ const createMainWindow = (
   // When either fails, main closes the window itself so the chord always does something.
   let rendererListenerReady = false
   let windowFindListenerReady = false
+  let windowFindAppearance: WindowFindAppearance = { theme: 'light', followsSystem: true }
   let rendererResponsive = true
   let rendererUnresponsiveAt: number | undefined
   let rendererRecoveryTimes: number[] = []
@@ -174,6 +176,7 @@ const createMainWindow = (
   }
   const onWindowFindAppearanceChanged = (event: IpcMainEvent, appearance: unknown): void => {
     if (event.sender !== window.webContents || !isWindowFindAppearance(appearance)) return
+    windowFindAppearance = appearance
     findOverlay.updateAppearance(appearance)
     mainWindowCloseOptions.get(window)?.onAppearanceChanged?.(appearance)
   }
@@ -330,6 +333,7 @@ const createMainWindow = (
     if (isFindInPageChord(input, process.platform)) {
       if (windowFindListenerReady && rendererResponsive) {
         event.preventDefault()
+        window.webContents.send(WINDOW_FIND_SHOW_CHANNEL, windowFindAppearance)
         findOverlay.open()
       }
       return

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -22,6 +22,8 @@ import {
   CLOSE_ACTIVE_PANE_READY_CHANNEL,
   CLOSE_ACTIVE_PANE_UNREADY_CHANNEL,
   WINDOW_FIND_APPEARANCE_CHANGED_CHANNEL,
+  WINDOW_FIND_CONTENT_READY_CHANNEL,
+  WINDOW_FIND_HIDE_CHANNEL,
   WINDOW_FIND_READY_CHANNEL,
   WINDOW_FIND_SHOW_CHANNEL,
   WINDOW_FIND_UNREADY_CHANNEL,
@@ -143,6 +145,7 @@ const createMainWindow = (
   // When either fails, main closes the window itself so the chord always does something.
   let rendererListenerReady = false
   let windowFindListenerReady = false
+  let windowFindOpenPending = false
   let windowFindAppearance: WindowFindAppearance = { theme: 'light', followsSystem: true }
   let rendererResponsive = true
   let rendererUnresponsiveAt: number | undefined
@@ -172,7 +175,19 @@ const createMainWindow = (
   const onWindowFindGone = (event: IpcMainEvent): void => {
     if (event.sender !== window.webContents) return
     windowFindListenerReady = false
+    windowFindOpenPending = false
     findOverlay.close()
+  }
+  const onWindowFindContentReady = (event: IpcMainEvent): void => {
+    if (
+      event.sender !== window.webContents ||
+      !windowFindListenerReady ||
+      !rendererResponsive ||
+      (!windowFindOpenPending && !findOverlay.isOpen())
+    )
+      return
+    windowFindOpenPending = false
+    findOverlay.open()
   }
   const onWindowFindAppearanceChanged = (event: IpcMainEvent, appearance: unknown): void => {
     if (event.sender !== window.webContents || !isWindowFindAppearance(appearance)) return
@@ -184,6 +199,7 @@ const createMainWindow = (
   ipcMain.on(CLOSE_ACTIVE_PANE_UNREADY_CHANNEL, onListenerGone)
   ipcMain.on(WINDOW_FIND_READY_CHANNEL, onWindowFindReady)
   ipcMain.on(WINDOW_FIND_UNREADY_CHANNEL, onWindowFindGone)
+  ipcMain.on(WINDOW_FIND_CONTENT_READY_CHANNEL, onWindowFindContentReady)
   ipcMain.on(WINDOW_FIND_APPEARANCE_CHANGED_CHANNEL, onWindowFindAppearanceChanged)
   // A top-level document swap replaces the mounted hook, which must re-subscribe; a dead render process
   // took its listener with it. Both revoke readiness until the next READY handshake. Gate on the main
@@ -193,6 +209,7 @@ const createMainWindow = (
     if (details.isMainFrame && !details.isSameDocument) {
       rendererListenerReady = false
       windowFindListenerReady = false
+      windowFindOpenPending = false
       findOverlay.close()
     }
   })
@@ -222,6 +239,7 @@ const createMainWindow = (
     })
     rendererListenerReady = false
     windowFindListenerReady = false
+    windowFindOpenPending = false
     clearRendererHangState()
     findOverlay.close()
 
@@ -287,6 +305,7 @@ const createMainWindow = (
       log.warn('renderer became unresponsive')
     }
     rendererResponsive = false
+    windowFindOpenPending = false
     findOverlay.close()
   })
   window.webContents.on('responsive', () => {
@@ -302,6 +321,7 @@ const createMainWindow = (
     ipcMain.removeListener(CLOSE_ACTIVE_PANE_UNREADY_CHANNEL, onListenerGone)
     ipcMain.removeListener(WINDOW_FIND_READY_CHANNEL, onWindowFindReady)
     ipcMain.removeListener(WINDOW_FIND_UNREADY_CHANNEL, onWindowFindGone)
+    ipcMain.removeListener(WINDOW_FIND_CONTENT_READY_CHANNEL, onWindowFindContentReady)
     ipcMain.removeListener(WINDOW_FIND_APPEARANCE_CHANGED_CHANNEL, onWindowFindAppearanceChanged)
     findOverlay.destroy()
   })
@@ -333,17 +353,25 @@ const createMainWindow = (
     if (isFindInPageChord(input, process.platform)) {
       if (windowFindListenerReady && rendererResponsive) {
         event.preventDefault()
+        windowFindOpenPending = true
         window.webContents.send(WINDOW_FIND_SHOW_CHANNEL, windowFindAppearance)
-        findOverlay.open()
       }
       return
     }
 
     // Escape closes an open find bar even when focus has wandered into the main content — the overlay's
     // own handler covers the input-focused case, this covers the rest.
-    if (input.type === 'keyDown' && input.key === 'Escape' && findOverlay.isOpen()) {
+    if (
+      input.type === 'keyDown' &&
+      input.key === 'Escape' &&
+      (windowFindOpenPending || findOverlay.isOpen())
+    ) {
       event.preventDefault()
-      findOverlay.close()
+      if (windowFindOpenPending) {
+        windowFindOpenPending = false
+        if (findOverlay.isOpen()) findOverlay.close()
+        else window.webContents.send(WINDOW_FIND_HIDE_CHANNEL)
+      } else findOverlay.close()
       return
     }
 

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -155,6 +155,7 @@ type PreloadApi = {
     onShowWindowFind?: (
       listener: (appearance: { theme: 'light' | 'dark'; followsSystem: boolean }) => void
     ) => unknown
+    onHideWindowFind?: (listener: () => void) => unknown
     onWindowFindAppearance?: (
       listener: (appearance: { theme: 'light' | 'dark'; followsSystem: boolean }) => void
     ) => unknown
@@ -631,6 +632,7 @@ describe('preload bridge — public surface inventory', () => {
       'window.onCloseActivePane',
       'window.onCloseConfirmRequest',
       'window.onFindInPageResult',
+      'window.onHideWindowFind',
       'window.onShowWindowFind',
       'window.onWindowFindAppearance',
       'window.sendCloseConfirmResponse'
@@ -940,15 +942,18 @@ describe('preload bridge — window find IPC channels', () => {
     expect(sendMock).toHaveBeenNthCalledWith(2, 'window:clear-find-in-page')
   })
 
-  it('forwards the overlay close request and both appearance-bearing events from main', () => {
+  it('forwards the overlay close request and find-overlay events from main', () => {
     const showListener = vi.fn()
+    const hideListener = vi.fn()
     const appearanceListener = vi.fn()
     api.window.closeFind?.()
     api.window.onShowWindowFind?.(showListener)
+    api.window.onHideWindowFind?.(hideListener)
     api.window.onWindowFindAppearance?.(appearanceListener)
 
     expect(sendMock).toHaveBeenCalledWith('window:find-close')
     expect(onMock).toHaveBeenCalledWith('window:find-show', expect.any(Function))
+    expect(onMock).toHaveBeenCalledWith('window:find-hide', expect.any(Function))
     expect(onMock).toHaveBeenCalledWith('window:find-appearance', expect.any(Function))
 
     const wrappedListener = onMock.mock.calls.find(

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -164,6 +164,7 @@ type PreloadApi = {
       followsSystem: boolean
     }) => void
     announceWindowFindReady?: () => unknown
+    announceWindowFindContentReady?: () => void
     onCloseActivePane: (listener: () => void) => () => void
   }
 }
@@ -624,6 +625,7 @@ describe('preload bridge — public surface inventory', () => {
       'uploads.stageLocalFile',
       'uploads.stageLocalPath',
       'window.announceWindowFindAppearance',
+      'window.announceWindowFindContentReady',
       'window.announceWindowFindReady',
       'window.clearFind',
       'window.close',
@@ -978,6 +980,12 @@ describe('preload bridge — window find IPC channels', () => {
     dispose?.()
 
     expect(sendMock).toHaveBeenNthCalledWith(2, 'shortcut:window-find-unready')
+  })
+
+  it('announces that the searchable transcript has committed before native find opens', () => {
+    api.window.announceWindowFindContentReady?.()
+
+    expect(sendMock).toHaveBeenCalledWith('shortcut:window-find-content-ready')
   })
 
   it('forwards renderer theme changes to main as a typed appearance payload', () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -873,6 +873,8 @@ const api: OpenScienceAPI = {
     // overlay asks main to hide it. The localhost Web UI never loads this overlay, so both stay optional.
     onShowWindowFind: (listener) =>
       electronRendererContracts.subscribe('window.onShowWindowFind', listener),
+    onHideWindowFind: (listener) =>
+      electronRendererContracts.subscribe('window.onHideWindowFind', listener),
     onWindowFindAppearance: (listener) =>
       electronRendererContracts.subscribe('window.onWindowFindAppearance', listener),
     announceWindowFindAppearance: (appearance) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -867,6 +867,8 @@ const api: OpenScienceAPI = {
     // Cmd/Ctrl+F. Returns a teardown that announces UNREADY on unmount.
     announceWindowFindReady: () =>
       announceWindowFindReady({ send: (channel) => ipcRenderer.send(channel) }),
+    announceWindowFindContentReady: () =>
+      electronRendererContracts.send('window.announceWindowFindContentReady'),
     onFindInPageResult: (listener) =>
       electronRendererContracts.subscribe('window.onFindInPageResult', listener),
     // Overlay-only surface: main signals the bar was shown (focus + restore remembered query), and the

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -1042,6 +1042,8 @@ export interface OpenScienceAPI {
     onFindInPageResult?(listener: AcpListener<WindowFindResult>): RemoveListener
     // Overlay-only: main signals the bar was shown; the overlay asks main to hide it.
     onShowWindowFind?(listener: AcpListener<WindowFindAppearance>): RemoveListener
+    // Main renderer only: the overlay was hidden, so temporary searchable content can be released.
+    onHideWindowFind?(listener: () => void): RemoveListener
     onWindowFindAppearance?(listener: AcpListener<WindowFindAppearance>): RemoveListener
     announceWindowFindAppearance?(appearance: WindowFindAppearance): void
     closeFind?(): void

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -1039,6 +1039,8 @@ export interface OpenScienceAPI {
     clearFind?(): void
     // Announces the Workspace is mounted (READY) and returns a teardown that announces UNREADY.
     announceWindowFindReady?(): RemoveListener
+    // Announces that the full searchable transcript has committed to the renderer DOM.
+    announceWindowFindContentReady?(): void
     onFindInPageResult?(listener: AcpListener<WindowFindResult>): RemoveListener
     // Overlay-only: main signals the bar was shown; the overlay asks main to hide it.
     onShowWindowFind?(listener: AcpListener<WindowFindAppearance>): RemoveListener

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -613,6 +613,51 @@ describe('ConversationPanel header spacing', () => {
   })
 })
 
+describe('ConversationPanel session loading presentation', () => {
+  it('replaces the transcript with a skeleton until lazy Session content is hydrated', () => {
+    const loadingSession: ChatSession = {
+      id: 'session-loading',
+      projectId: 'project-a',
+      title: 'Loading conversation',
+      cwd: '/workspace',
+      status: 'idle',
+      messages: [],
+      contentLoaded: false,
+      activeMessageCount: 12,
+      createdAt: 1,
+      updatedAt: 2
+    }
+
+    renderPanel({ view: { activeSession: loadingSession } })
+
+    expect(container.querySelector('[data-testid="session-switch-skeleton"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="scroller-pending-elicitations"]')).toBeNull()
+
+    renderPanel({
+      view: {
+        activeSession: {
+          ...loadingSession,
+          contentLoaded: undefined,
+          messages: [
+            {
+              id: 'message-1',
+              role: 'user',
+              content: 'Loaded content',
+              status: 'complete',
+              eventIds: [],
+              createdAt: 1,
+              updatedAt: 1
+            }
+          ]
+        }
+      }
+    })
+
+    expect(container.querySelector('[data-testid="session-switch-skeleton"]')).toBeNull()
+    expect(container.querySelector('[data-testid="scroller-pending-elicitations"]')).not.toBeNull()
+  })
+})
+
 const hasDropOverlay = (): boolean =>
   container.textContent?.includes('Drop files to attach') ?? false
 

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -91,6 +91,7 @@ import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
 import { WorkspaceElicitationCard } from './WorkspaceElicitationCard'
 import { WorkspaceDelegatedQuestionCard } from './WorkspaceDelegatedQuestionCard'
 import { WorkspaceMessageScroller } from './WorkspaceMessageScroller'
+import { SessionSwitchSkeleton } from './SessionSwitchSkeleton'
 import { PlanProgressChip, WorkspacePlanCard } from './session-plan/SessionPlanSurfaces'
 import { projectDelegatedQuestionQueue } from './subagent-release-projection'
 import { selectActiveBranchPlan } from './session-plan/active-branch-plan'
@@ -862,21 +863,25 @@ const ConversationPanel = ({
           </button>
         </header>
 
-        <WorkspaceMessageEditStateProvider canEditMessage={canEditMessage && !sideChat}>
-          <WorkspaceMessageScroller
-            activeSession={activeSession}
-            optimisticMessage={optimisticMessage}
-            isResumingSession={isResuming}
-            notebookReference={notebookReference}
-            onSendEditedMessage={onSendEditedMessage}
-            canBranchInNewSession={canBranchInNewSession}
-            onBranchInNewSession={onBranchFromAgentMessage}
-            pendingElicitations={sideChat ? [] : sessionPendingElicitations}
-            handoffLifecycleSource={workspaceHandoffLifecycleClient}
-            onRetryHandoff={(request) => workspaceHandoffLifecycleClient.retry(request)}
-            reportPresentationRevealing
-          />
-        </WorkspaceMessageEditStateProvider>
+        {activeSession?.contentLoaded === false ? (
+          <SessionSwitchSkeleton />
+        ) : (
+          <WorkspaceMessageEditStateProvider canEditMessage={canEditMessage && !sideChat}>
+            <WorkspaceMessageScroller
+              activeSession={activeSession}
+              optimisticMessage={optimisticMessage}
+              isResumingSession={isResuming}
+              notebookReference={notebookReference}
+              onSendEditedMessage={onSendEditedMessage}
+              canBranchInNewSession={canBranchInNewSession}
+              onBranchInNewSession={onBranchFromAgentMessage}
+              pendingElicitations={sideChat ? [] : sessionPendingElicitations}
+              handoffLifecycleSource={workspaceHandoffLifecycleClient}
+              onRetryHandoff={(request) => workspaceHandoffLifecycleClient.retry(request)}
+              reportPresentationRevealing
+            />
+          </WorkspaceMessageEditStateProvider>
+        )}
 
         <div className="relative shrink-0">
           <div

--- a/src/renderer/src/pages/workspace/SessionSwitchSkeleton.tsx
+++ b/src/renderer/src/pages/workspace/SessionSwitchSkeleton.tsx
@@ -1,0 +1,29 @@
+/* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5 */
+/* Hallmark · component: Session switch skeleton · genre: modern-minimal · theme: Open Science workspace · state: loading · contrast: pass · mobile: pass */
+
+const SessionSwitchSkeleton = (): React.JSX.Element => (
+  <div
+    aria-hidden="true"
+    data-testid="session-switch-skeleton"
+    className="min-h-0 flex-1 overflow-hidden"
+  >
+    <div className="mx-auto flex h-full w-full max-w-4xl flex-col gap-8 px-4 py-5 motion-safe:animate-pulse md:px-6 md:py-8">
+      <div className="ml-auto h-14 w-[min(72%,34rem)] shrink-0 rounded-2xl bg-bg-300" />
+
+      <div className="flex flex-col gap-3">
+        <div className="h-3 w-[42%] rounded-full bg-bg-300" />
+        <div className="h-3 w-[96%] rounded-full bg-bg-300" />
+        <div className="h-3 w-[81%] rounded-full bg-bg-300" />
+        <div className="h-3 w-[88%] rounded-full bg-bg-300" />
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <div className="h-3 w-[31%] rounded-full bg-bg-300" />
+        <div className="h-3 w-[73%] rounded-full bg-bg-300" />
+        <div className="h-3 w-[62%] rounded-full bg-bg-300" />
+      </div>
+    </div>
+  </div>
+)
+
+export { SessionSwitchSkeleton }

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -222,6 +222,13 @@ const createSessionSubagentsPreviewItem = vi.fn(
   })
 )
 const announceWindowFindReady = vi.fn(() => () => undefined)
+let showWindowFindListener: (() => void) | undefined
+const onShowWindowFind = vi.fn((listener: () => void) => {
+  showWindowFindListener = listener
+  return () => {
+    if (showWindowFindListener === listener) showWindowFindListener = undefined
+  }
+})
 
 vi.mock('@/stores/preview-workbench-store', () => ({
   usePreviewWorkbenchStore: {
@@ -338,6 +345,8 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     useGrantedFoldersStore.setState(createInitialGrantedFoldersState())
     createSessionSubagentsPreviewItem.mockClear()
     announceWindowFindReady.mockClear()
+    onShowWindowFind.mockClear()
+    showWindowFindListener = undefined
     flushSessionPersistenceMock.mockReset().mockResolvedValue(undefined)
     useReviewStore.setState(createInitialReviewState())
     container = document.createElement('div')
@@ -376,7 +385,8 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
         getForSession: vi.fn().mockResolvedValue([])
       },
       window: {
-        announceWindowFindReady
+        announceWindowFindReady,
+        onShowWindowFind
       }
     } as unknown as Window['api']
   })
@@ -3044,8 +3054,8 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
       )
     })
 
-    // The find bar is an Electron overlay owned by main; the Workspace's only job is to announce it is
-    // mounted and searchable so main intercepts Cmd/Ctrl+F.
+    // The find bar is an Electron overlay owned by main; the Workspace announces that its transcript
+    // is mounted and searchable so main intercepts Cmd/Ctrl+F.
     expect(announceWindowFindReady).toHaveBeenCalledTimes(1)
   })
 
@@ -3512,6 +3522,73 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
         indicator.classList.contains('scale-x-[0.4]')
       )
     ).toBe(true)
+  })
+
+  it('mounts a bounded long transcript and reveals an older run on demand', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const messages = Array.from({ length: 240 }, (_, index) =>
+      createMessage({
+        id: `message-${index + 1}`,
+        role: index % 2 === 0 ? 'user' : 'agent',
+        content:
+          index === 0
+            ? 'oldest transcript sentinel'
+            : index === 239
+              ? 'newest transcript sentinel'
+              : `transcript message ${index + 1}`,
+        responseToMessageId: index % 2 === 0 ? undefined : `message-${index}`,
+        createdAt: 1710000000000 + index,
+        updatedAt: 1710000000000 + index
+      })
+    )
+
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={createSession({ status: 'idle', messages })}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    })
+
+    expect(container.textContent).toContain('newest transcript sentinel')
+    expect(container.textContent).not.toContain('oldest transcript sentinel')
+    expect(agentMarkdownRenderMock.mock.calls.length).toBeLessThan(80)
+
+    const firstRun = document.body.querySelector<HTMLButtonElement>('[aria-label^="Go to run 1:"]')
+    expect(firstRun).not.toBeNull()
+    await act(async () => firstRun?.click())
+
+    expect(container.textContent).toContain('oldest transcript sentinel')
+  })
+
+  it('reveals the full transcript while whole-window find is open', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const messages = Array.from({ length: 240 }, (_, index) =>
+      createMessage({
+        id: `message-${index + 1}`,
+        role: index % 2 === 0 ? 'user' : 'agent',
+        content: index === 0 ? 'searchable oldest sentinel' : `transcript message ${index + 1}`,
+        responseToMessageId: index % 2 === 0 ? undefined : `message-${index}`,
+        createdAt: 1710000000000 + index,
+        updatedAt: 1710000000000 + index
+      })
+    )
+
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={createSession({ status: 'idle', messages })}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    })
+
+    expect(container.textContent).not.toContain('searchable oldest sentinel')
+    await act(async () => showWindowFindListener?.())
+    expect(container.textContent).toContain('searchable oldest sentinel')
   })
 
   it('does not leave the active Plan card in the transcript', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -222,6 +222,7 @@ const createSessionSubagentsPreviewItem = vi.fn(
   })
 )
 const announceWindowFindReady = vi.fn(() => () => undefined)
+const announceWindowFindContentReady = vi.fn()
 let showWindowFindListener: (() => void) | undefined
 const onShowWindowFind = vi.fn((listener: () => void) => {
   showWindowFindListener = listener
@@ -352,6 +353,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     useGrantedFoldersStore.setState(createInitialGrantedFoldersState())
     createSessionSubagentsPreviewItem.mockClear()
     announceWindowFindReady.mockClear()
+    announceWindowFindContentReady.mockClear()
     onShowWindowFind.mockClear()
     showWindowFindListener = undefined
     onHideWindowFind.mockClear()
@@ -395,6 +397,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
       },
       window: {
         announceWindowFindReady,
+        announceWindowFindContentReady,
         onShowWindowFind,
         onHideWindowFind
       }
@@ -3599,8 +3602,30 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(container.textContent).not.toContain('searchable oldest sentinel')
     await act(async () => showWindowFindListener?.())
     expect(container.textContent).toContain('searchable oldest sentinel')
+    expect(announceWindowFindContentReady).toHaveBeenCalledTimes(1)
+
+    const nextSessionMessages = messages.map((message, index) => ({
+      ...message,
+      id: `next-${message.id}`,
+      content: index === 0 ? 'next session oldest sentinel' : message.content
+    }))
+    await act(async () => {
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={createSession({
+            id: 'session-2',
+            status: 'idle',
+            messages: nextSessionMessages
+          })}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    })
+    expect(container.textContent).toContain('next session oldest sentinel')
+    expect(announceWindowFindContentReady).toHaveBeenCalledTimes(2)
+
     await act(async () => hideWindowFindListener?.())
-    expect(container.textContent).not.toContain('searchable oldest sentinel')
+    expect(container.textContent).not.toContain('next session oldest sentinel')
     expect(container.textContent).toContain('transcript message 120')
   })
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -3651,6 +3651,61 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(container.textContent).toContain('transcript message 120')
   }, 30_000)
 
+  it('waits for the presentation barrier to clear before announcing find readiness', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (callback: FrameRequestCallback) =>
+        setTimeout(() => callback(performance.now()), 16) as unknown as number
+    )
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const prompt = createMessage({ id: 'prompt-find-barrier', createdAt: 100 })
+    const streamingAnswer = createMessage({
+      id: 'answer-find-barrier',
+      role: 'agent',
+      content: 'Hold find readiness until this presentation finishes.',
+      status: 'streaming',
+      streamId: 'stream-find-barrier',
+      responseToMessageId: prompt.id,
+      createdAt: 101
+    })
+    const bufferedPrompt = createMessage({ id: 'prompt-behind-find-barrier', createdAt: 102 })
+    const bufferedAnswer = createMessage({
+      id: 'answer-behind-find-barrier',
+      role: 'agent',
+      content: 'Searchable only after the presentation barrier clears.',
+      responseToMessageId: bufferedPrompt.id,
+      createdAt: 103
+    })
+    const render = async (messages: ChatMessage[]): Promise<void> => {
+      await act(async () => {
+        root.render(
+          <WorkspaceMessageScroller
+            activeSession={createSession({
+              messages,
+              activeRun: { promptMessageId: prompt.id, startedAt: 100 }
+            })}
+            onSendEditedMessage={vi.fn()}
+          />
+        )
+      })
+    }
+
+    root = createRoot(container)
+    await render([prompt])
+    await render([prompt, streamingAnswer])
+    await render([prompt, streamingAnswer, bufferedPrompt, bufferedAnswer])
+
+    await act(async () => showWindowFindListener?.())
+    expect(container.textContent).not.toContain('Searchable only after the presentation barrier')
+    expect(announceWindowFindContentReady).not.toHaveBeenCalled()
+
+    await act(async () => vi.advanceTimersByTimeAsync(5_000))
+    expect(container.textContent).toContain('Searchable only after the presentation barrier')
+    expect(announceWindowFindContentReady).toHaveBeenCalledTimes(1)
+  })
+
   it('does not leave the active Plan card in the transcript', async () => {
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
     const activePlanProjection: ActivePlanProjection = {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -3743,6 +3743,9 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     await render([...history, prompt, streamingAnswer, bufferedPrompt, bufferedAnswer])
 
     expect(container.textContent).not.toContain('presentation history oldest sentinel')
+    const oldestRun = document.body.querySelector<HTMLButtonElement>('[aria-label^="Go to run 1:"]')
+    expect(oldestRun).not.toBeNull()
+    expect(oldestRun?.disabled).toBe(true)
     await act(async () => showWindowFindListener?.())
     expect(container.textContent).not.toContain('Searchable only after the presentation barrier')
     expect(announceWindowFindContentReady).not.toHaveBeenCalled()
@@ -3750,6 +3753,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     await act(async () => vi.advanceTimersByTimeAsync(5_000))
     expect(container.textContent).toContain('presentation history oldest sentinel')
     expect(container.textContent).toContain('Searchable only after the presentation barrier')
+    expect(oldestRun?.disabled).toBe(false)
     expect(announceWindowFindContentReady).toHaveBeenCalledTimes(1)
   })
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -3604,6 +3604,28 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(container.textContent).toContain('searchable oldest sentinel')
     expect(announceWindowFindContentReady).toHaveBeenCalledTimes(1)
 
+    const streamedMessages = [
+      ...messages,
+      createMessage({
+        id: 'message-121',
+        role: 'agent',
+        content: 'streamed searchable update',
+        responseToMessageId: 'message-119',
+        createdAt: 1710000000120,
+        updatedAt: 1710000000120
+      })
+    ]
+    await act(async () => {
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={createSession({ status: 'running', messages: streamedMessages })}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    })
+    expect(container.textContent).toContain('streamed searchable update')
+    expect(announceWindowFindContentReady).toHaveBeenCalledTimes(1)
+
     const nextSessionMessages = messages.map((message, index) => ({
       ...message,
       id: `next-${message.id}`,
@@ -3627,7 +3649,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     await act(async () => hideWindowFindListener?.())
     expect(container.textContent).not.toContain('next session oldest sentinel')
     expect(container.textContent).toContain('transcript message 120')
-  })
+  }, 30_000)
 
   it('does not leave the active Plan card in the transcript', async () => {
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -229,6 +229,13 @@ const onShowWindowFind = vi.fn((listener: () => void) => {
     if (showWindowFindListener === listener) showWindowFindListener = undefined
   }
 })
+let hideWindowFindListener: (() => void) | undefined
+const onHideWindowFind = vi.fn((listener: () => void) => {
+  hideWindowFindListener = listener
+  return () => {
+    if (hideWindowFindListener === listener) hideWindowFindListener = undefined
+  }
+})
 
 vi.mock('@/stores/preview-workbench-store', () => ({
   usePreviewWorkbenchStore: {
@@ -347,6 +354,8 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     announceWindowFindReady.mockClear()
     onShowWindowFind.mockClear()
     showWindowFindListener = undefined
+    onHideWindowFind.mockClear()
+    hideWindowFindListener = undefined
     flushSessionPersistenceMock.mockReset().mockResolvedValue(undefined)
     useReviewStore.setState(createInitialReviewState())
     container = document.createElement('div')
@@ -386,7 +395,8 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
       },
       window: {
         announceWindowFindReady,
-        onShowWindowFind
+        onShowWindowFind,
+        onHideWindowFind
       }
     } as unknown as Window['api']
   })
@@ -3563,9 +3573,9 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(container.textContent).toContain('oldest transcript sentinel')
   })
 
-  it('reveals the full transcript while whole-window find is open', async () => {
+  it('reveals the full transcript only while whole-window find is open', async () => {
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
-    const messages = Array.from({ length: 240 }, (_, index) =>
+    const messages = Array.from({ length: 120 }, (_, index) =>
       createMessage({
         id: `message-${index + 1}`,
         role: index % 2 === 0 ? 'user' : 'agent',
@@ -3589,6 +3599,9 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(container.textContent).not.toContain('searchable oldest sentinel')
     await act(async () => showWindowFindListener?.())
     expect(container.textContent).toContain('searchable oldest sentinel')
+    await act(async () => hideWindowFindListener?.())
+    expect(container.textContent).not.toContain('searchable oldest sentinel')
+    expect(container.textContent).toContain('transcript message 120')
   })
 
   it('does not leave the active Plan card in the transcript', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -3569,6 +3569,38 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(container.textContent).not.toContain('oldest transcript sentinel')
     expect(agentMarkdownRenderMock.mock.calls.length).toBeLessThan(80)
 
+    await act(async () => showWindowFindListener?.())
+    await act(async () => hideWindowFindListener?.())
+    expect(container.textContent).not.toContain('oldest transcript sentinel')
+
+    const appendedMessages = [
+      ...messages,
+      ...Array.from({ length: 80 }, (_, offset) => {
+        const index = messages.length + offset
+        return createMessage({
+          id: `message-${index + 1}`,
+          role: index % 2 === 0 ? 'user' : 'agent',
+          content:
+            index === 319
+              ? 'newest appended transcript sentinel'
+              : `transcript message ${index + 1}`,
+          responseToMessageId: index % 2 === 0 ? undefined : `message-${index}`,
+          createdAt: 1710000000000 + index,
+          updatedAt: 1710000000000 + index
+        })
+      })
+    ]
+    await act(async () => {
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={createSession({ status: 'idle', messages: appendedMessages })}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    })
+    expect(container.textContent).toContain('newest appended transcript sentinel')
+    expect(container.textContent).not.toContain('transcript message 161')
+
     const firstRun = document.body.querySelector<HTMLButtonElement>('[aria-label^="Go to run 1:"]')
     expect(firstRun).not.toBeNull()
     await act(async () => firstRun?.click())
@@ -3660,7 +3692,19 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     )
     vi.stubGlobal('cancelAnimationFrame', (frameId: number) => clearTimeout(frameId))
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
-    const prompt = createMessage({ id: 'prompt-find-barrier', createdAt: 100 })
+    const history = Array.from({ length: 120 }, (_, index) =>
+      createMessage({
+        id: `history-${index + 1}`,
+        role: index % 2 === 0 ? 'user' : 'agent',
+        content:
+          index === 0
+            ? 'presentation history oldest sentinel'
+            : `presentation history ${index + 1}`,
+        responseToMessageId: index % 2 === 0 ? undefined : `history-${index}`,
+        createdAt: index
+      })
+    )
+    const prompt = createMessage({ id: 'prompt-find-barrier', createdAt: 120 })
     const streamingAnswer = createMessage({
       id: 'answer-find-barrier',
       role: 'agent',
@@ -3668,15 +3712,15 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
       status: 'streaming',
       streamId: 'stream-find-barrier',
       responseToMessageId: prompt.id,
-      createdAt: 101
+      createdAt: 121
     })
-    const bufferedPrompt = createMessage({ id: 'prompt-behind-find-barrier', createdAt: 102 })
+    const bufferedPrompt = createMessage({ id: 'prompt-behind-find-barrier', createdAt: 122 })
     const bufferedAnswer = createMessage({
       id: 'answer-behind-find-barrier',
       role: 'agent',
       content: 'Searchable only after the presentation barrier clears.',
       responseToMessageId: bufferedPrompt.id,
-      createdAt: 103
+      createdAt: 123
     })
     const render = async (messages: ChatMessage[]): Promise<void> => {
       await act(async () => {
@@ -3684,7 +3728,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
           <WorkspaceMessageScroller
             activeSession={createSession({
               messages,
-              activeRun: { promptMessageId: prompt.id, startedAt: 100 }
+              activeRun: { promptMessageId: prompt.id, startedAt: 120 }
             })}
             onSendEditedMessage={vi.fn()}
           />
@@ -3693,15 +3737,18 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     }
 
     root = createRoot(container)
-    await render([prompt])
-    await render([prompt, streamingAnswer])
-    await render([prompt, streamingAnswer, bufferedPrompt, bufferedAnswer])
+    await render(history)
+    await render([...history, prompt])
+    await render([...history, prompt, streamingAnswer])
+    await render([...history, prompt, streamingAnswer, bufferedPrompt, bufferedAnswer])
 
+    expect(container.textContent).not.toContain('presentation history oldest sentinel')
     await act(async () => showWindowFindListener?.())
     expect(container.textContent).not.toContain('Searchable only after the presentation barrier')
     expect(announceWindowFindContentReady).not.toHaveBeenCalled()
 
     await act(async () => vi.advanceTimersByTimeAsync(5_000))
+    expect(container.textContent).toContain('presentation history oldest sentinel')
     expect(container.textContent).toContain('Searchable only after the presentation barrier')
     expect(announceWindowFindContentReady).toHaveBeenCalledTimes(1)
   })

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -601,7 +601,11 @@ const WorkspaceMessageScrollerImpl = ({
   )
   const revealFullTranscript = transcriptWindow.revealAll
   const [windowFindOpen, setWindowFindOpen] = useState(false)
+  const windowFindAcknowledgedScopeRef = useRef<{ scopeId: string | undefined } | undefined>(
+    undefined
+  )
   const showWindowFind = useCallback((): void => {
+    windowFindAcknowledgedScopeRef.current = undefined
     setWindowFindOpen(true)
     revealFullTranscript()
   }, [revealFullTranscript])
@@ -610,6 +614,7 @@ const WorkspaceMessageScrollerImpl = ({
   }, [showWindowFind])
   const restoreTranscriptWindow = transcriptWindow.restoreWindow
   const hideWindowFind = useCallback((): void => {
+    windowFindAcknowledgedScopeRef.current = undefined
     setWindowFindOpen(false)
     restoreTranscriptWindow()
   }, [restoreTranscriptWindow])
@@ -621,6 +626,9 @@ const WorkspaceMessageScrollerImpl = ({
   }, [currentPresentationScopeId, revealFullTranscript, windowFindOpen])
   useLayoutEffect(() => {
     if (!windowFindOpen || transcriptWindow.entries.length !== conversationItems.length) return
+    const acknowledgedScope = windowFindAcknowledgedScopeRef.current
+    if (acknowledgedScope && acknowledgedScope.scopeId === currentPresentationScopeId) return
+    windowFindAcknowledgedScopeRef.current = { scopeId: currentPresentationScopeId }
     window.api?.window?.announceWindowFindContentReady?.()
   }, [
     conversationItems.length,

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -1121,7 +1121,9 @@ const WorkspaceMessageScrollerImpl = ({
           <WorkspaceRunMarks
             items={presentedConversationItems}
             viewport={messageScrollerViewport}
-            onRevealMessage={transcriptWindow.revealMessage}
+            onRevealMessage={
+              presentationBarrierIndex >= 0 ? undefined : transcriptWindow.revealMessage
+            }
           />
           <div
             aria-hidden="true"

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -600,13 +600,34 @@ const WorkspaceMessageScrollerImpl = ({
     messageScrollerViewportRef
   )
   const revealFullTranscript = transcriptWindow.revealAll
-  useEffect(() => {
-    return window.api?.window?.onShowWindowFind?.(revealFullTranscript)
+  const [windowFindOpen, setWindowFindOpen] = useState(false)
+  const showWindowFind = useCallback((): void => {
+    setWindowFindOpen(true)
+    revealFullTranscript()
   }, [revealFullTranscript])
-  const restoreTranscriptWindow = transcriptWindow.restoreWindow
   useEffect(() => {
-    return window.api?.window?.onHideWindowFind?.(restoreTranscriptWindow)
+    return window.api?.window?.onShowWindowFind?.(showWindowFind)
+  }, [showWindowFind])
+  const restoreTranscriptWindow = transcriptWindow.restoreWindow
+  const hideWindowFind = useCallback((): void => {
+    setWindowFindOpen(false)
+    restoreTranscriptWindow()
   }, [restoreTranscriptWindow])
+  useEffect(() => {
+    return window.api?.window?.onHideWindowFind?.(hideWindowFind)
+  }, [hideWindowFind])
+  useLayoutEffect(() => {
+    if (windowFindOpen) revealFullTranscript()
+  }, [currentPresentationScopeId, revealFullTranscript, windowFindOpen])
+  useLayoutEffect(() => {
+    if (!windowFindOpen || transcriptWindow.entries.length !== conversationItems.length) return
+    window.api?.window?.announceWindowFindContentReady?.()
+  }, [
+    conversationItems.length,
+    currentPresentationScopeId,
+    transcriptWindow.entries.length,
+    windowFindOpen
+  ])
   // Brand-new conversation (nothing presented, no resume in flight): invite the first prompt with
   // a centered placeholder banner over the empty transcript area.
   const showEmptyConversationBanner =

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -625,7 +625,13 @@ const WorkspaceMessageScrollerImpl = ({
     if (windowFindOpen) revealFullTranscript()
   }, [currentPresentationScopeId, revealFullTranscript, windowFindOpen])
   useLayoutEffect(() => {
-    if (!windowFindOpen || transcriptWindow.entries.length !== conversationItems.length) return
+    if (
+      !windowFindOpen ||
+      presentationBarrierIndex >= 0 ||
+      transcriptWindow.entries.length !== conversationItems.length
+    ) {
+      return
+    }
     const acknowledgedScope = windowFindAcknowledgedScopeRef.current
     if (acknowledgedScope && acknowledgedScope.scopeId === currentPresentationScopeId) return
     windowFindAcknowledgedScopeRef.current = { scopeId: currentPresentationScopeId }
@@ -633,6 +639,7 @@ const WorkspaceMessageScrollerImpl = ({
   }, [
     conversationItems.length,
     currentPresentationScopeId,
+    presentationBarrierIndex,
     transcriptWindow.entries.length,
     windowFindOpen
   ])

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -603,6 +603,10 @@ const WorkspaceMessageScrollerImpl = ({
   useEffect(() => {
     return window.api?.window?.onShowWindowFind?.(revealFullTranscript)
   }, [revealFullTranscript])
+  const restoreTranscriptWindow = transcriptWindow.restoreWindow
+  useEffect(() => {
+    return window.api?.window?.onHideWindowFind?.(restoreTranscriptWindow)
+  }, [restoreTranscriptWindow])
   // Brand-new conversation (nothing presented, no resume in flight): invite the first prompt with
   // a centered placeholder banner over the empty transcript area.
   const showEmptyConversationBanner =

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -84,6 +84,7 @@ import { WorkspaceElicitationCard } from './WorkspaceElicitationCard'
 import { WorkspaceSubagentMessageRow } from './WorkspaceSubagentMessageRow'
 import { getNotebookRunIdFromActivity } from './workspace-tool-activity-details'
 import { setWorkspacePresentationRevealing } from './workspace-presentation-revealing'
+import { useTranscriptWindow } from './use-transcript-window'
 
 type WorkspaceMessageScrollerProps = {
   activeSession: ChatSession | undefined
@@ -405,8 +406,8 @@ const WorkspaceMessageScrollerImpl = ({
     : undefined
   const artifactVisibility = useWorkspaceArtifactVisibility(activeSession)
   const handoffEvents = useHandoffLifecycleEvents(handoffLifecycleSource, currentSessionId)
-  // The whole-window find bar is an Electron overlay owned by main; the Workspace only needs to tell
-  // main it is mounted and searchable so Cmd/Ctrl+F is intercepted (and re-arm UNREADY on unmount).
+  // The whole-window find bar is an Electron overlay owned by main. Announce that this transcript is
+  // searchable, and expand a bounded transcript before native find scans the main renderer document.
   useEffect(() => {
     const stop = window.api?.window?.announceWindowFindReady?.()
     return () => stop?.()
@@ -592,6 +593,16 @@ const WorkspaceMessageScrollerImpl = ({
     presentationBarrierIndex >= 0
       ? conversationItems.slice(0, presentationBarrierIndex + 1)
       : conversationItems
+  const transcriptWindow = useTranscriptWindow(
+    currentPresentationScopeId,
+    conversationItems,
+    presentationBarrierIndex,
+    messageScrollerViewportRef
+  )
+  const revealFullTranscript = transcriptWindow.revealAll
+  useEffect(() => {
+    return window.api?.window?.onShowWindowFind?.(revealFullTranscript)
+  }, [revealFullTranscript])
   // Brand-new conversation (nothing presented, no resume in flight): invite the first prompt with
   // a centered placeholder banner over the empty transcript area.
   const showEmptyConversationBanner =
@@ -668,16 +679,17 @@ const WorkspaceMessageScrollerImpl = ({
       setScrollToFirstMessageRevealed(false)
     }, SCROLL_TO_FIRST_MESSAGE_IDLE_TIMEOUT_MS)
   }, [clearScrollToFirstMessageHideTimeout, setScrollToFirstMessageRevealed])
-  const handleMessageScrollerScroll = useCallback((): void => {
+  const handleMessageScrollerScroll = (): void => {
     const viewport = messageScrollerViewportRef.current
     if (!viewport) return
 
     const previousScrollTop = previousMessageScrollerScrollTopRef.current
     previousMessageScrollerScrollTopRef.current = viewport.scrollTop
     const eligible = updateScrollToFirstMessageEligibility()
+    transcriptWindow.expandAtScrollEdge(previousScrollTop)
     if (viewport.scrollTop < previousScrollTop && eligible) revealScrollToFirstMessage()
     else if (viewport.scrollTop > previousScrollTop) hideScrollToFirstMessage()
-  }, [hideScrollToFirstMessage, revealScrollToFirstMessage, updateScrollToFirstMessageEligibility])
+  }
   useLayoutEffect(() => {
     updateScrollToFirstMessageEligibility()
   }, [currentSessionId, updateScrollToFirstMessageEligibility, visibleMessageIdsKey])
@@ -1069,6 +1081,7 @@ const WorkspaceMessageScrollerImpl = ({
           <WorkspaceRunMarks
             items={presentedConversationItems}
             viewport={messageScrollerViewport}
+            onRevealMessage={transcriptWindow.revealMessage}
           />
           <div
             aria-hidden="true"
@@ -1116,7 +1129,7 @@ const WorkspaceMessageScrollerImpl = ({
                 onCommit={handleVisibleMessageSnapshotCommit}
               />
               {/* Messages and tool activities share one sorted transcript timeline. */}
-              {conversationItems.map((item, itemIndex) => {
+              {transcriptWindow.entries.map(({ item, itemIndex }) => {
                 // Only later text messages stay behind the presentation barrier; tool,
                 // activity, and other non-message rows render in real time so their
                 // running state stays visible while the reply paces above them.
@@ -1444,19 +1457,21 @@ const WorkspaceMessageScrollerImpl = ({
               })}
 
               {/* Render any remaining unbound completed jobs after all conversation items */}
-              {trailingJobs.map((job) => (
-                <MessageScrollerItem
-                  key={`completed-job-${job.job_id}`}
-                  messageId={`completed-job-${job.job_id}`}
-                  className="min-w-0"
-                >
-                  <div className="px-4 py-1 md:px-6">
-                    <div className="mx-auto w-full max-w-4xl">
-                      <CompletedJobCard job={job} onOpen={handleOpenJobDetail} />
-                    </div>
-                  </div>
-                </MessageScrollerItem>
-              ))}
+              {transcriptWindow.end === conversationItems.length
+                ? trailingJobs.map((job) => (
+                    <MessageScrollerItem
+                      key={`completed-job-${job.job_id}`}
+                      messageId={`completed-job-${job.job_id}`}
+                      className="min-w-0"
+                    >
+                      <div className="px-4 py-1 md:px-6">
+                        <div className="mx-auto w-full max-w-4xl">
+                          <CompletedJobCard job={job} onOpen={handleOpenJobDetail} />
+                        </div>
+                      </div>
+                    </MessageScrollerItem>
+                  ))
+                : null}
 
               {optimisticMessage ? (
                 <WorkspaceMessageItem
@@ -1489,6 +1504,12 @@ const WorkspaceMessageScrollerImpl = ({
             <MessageScrollerButton
               ref={scrollToFirstMessageButtonRef}
               direction="start"
+              onClick={() => {
+                const firstMessage = conversationItems.find((item) => item.type === 'message')
+                if (firstMessage?.type === 'message') {
+                  transcriptWindow.revealMessage(firstMessage.message.id)
+                }
+              }}
               aria-label={t('Scroll to first message')}
               aria-hidden="true"
               data-revealed="false"

--- a/src/renderer/src/pages/workspace/WorkspaceRunMarks.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceRunMarks.tsx
@@ -21,6 +21,7 @@ import {
 type WorkspaceRunMarksProps = {
   items: readonly WorkspaceConversationTimelineItem[]
   viewport: HTMLDivElement | null
+  onRevealMessage?: (messageId: string) => void
 }
 
 const RUN_MARK_HOVER_DELAY_MS = 200
@@ -37,7 +38,8 @@ type RunMarkRailPosition = {
 
 const WorkspaceRunMarks = ({
   items,
-  viewport
+  viewport,
+  onRevealMessage
 }: WorkspaceRunMarksProps): React.JSX.Element | null => {
   const { t } = useTranslation()
   const marks = useMemo(() => createRunMarks(items), [items])
@@ -137,7 +139,11 @@ const WorkspaceRunMarks = ({
   const scrollToRun = (mark: RunMark, index: number): void => {
     if (!viewport) return
     const target = findMessageTarget(viewport, mark.id)
-    if (!target) return
+    if (!target) {
+      onRevealMessage?.(mark.id)
+      setCurrentIndex(index)
+      return
+    }
 
     const viewportTop = viewport.getBoundingClientRect().top
     const targetTop = target.getBoundingClientRect().top
@@ -174,7 +180,7 @@ const WorkspaceRunMarks = ({
         <ol className="pointer-events-auto grid w-full" style={railStyle}>
           {marks.map((mark, index) => {
             const isCurrent = index === currentIndex
-            const disabled = !availableMessageIds.has(mark.id)
+            const disabled = !onRevealMessage && !availableMessageIds.has(mark.id)
             const userPreview = normalizePreviewText(mark.userMessage, previewFallback)
             const agentPreview = mark.agentMessage
               ? normalizePreviewText(mark.agentMessage, previewFallback)

--- a/src/renderer/src/pages/workspace/artifact-preview.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/artifact-preview.interaction.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ArtifactPreview } from './artifact-preview'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+type PreviewArtifact = React.ComponentProps<typeof ArtifactPreview>['artifact']
+
+const imageArtifact: PreviewArtifact = {
+  id: 'artifact-chart',
+  kind: 'managed-file',
+  path: '/workspace/chart.png',
+  fileUrl: 'file:///workspace/chart.png',
+  name: 'chart.png',
+  mimeType: 'image/png',
+  size: 2048,
+  mtimeMs: 1710000000100
+}
+
+describe('ArtifactPreview image lifecycle', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(new Blob(['image bytes'], { type: 'image/png' })))
+    )
+    vi.stubGlobal(
+      'URL',
+      class extends URL {
+        static createObjectURL = vi.fn(() => 'blob:cached-transcript-chart')
+        static revokeObjectURL = vi.fn()
+      }
+    )
+    window.api = {
+      previewResources: {
+        acquire: vi.fn().mockResolvedValue({
+          id: 'resource-chart',
+          url: 'open-science-preview://resource/resource-chart',
+          size: 2048,
+          mimeType: 'image/png',
+          version: 1
+        }),
+        readRange: vi.fn(),
+        release: vi.fn().mockResolvedValue(undefined)
+      }
+    } as unknown as Window['api']
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    vi.unstubAllGlobals()
+    container.remove()
+  })
+
+  it('reuses a transcript image after its Session is switched away and back', async () => {
+    const renderImage = async (): Promise<void> => {
+      await act(async () => {
+        root.render(
+          <ArtifactPreview artifact={imageArtifact} projectId="project-1" sessionId="session-1" />
+        )
+      })
+      await waitFor(() => expect(container.querySelector('img')).not.toBeNull())
+    }
+
+    root = createRoot(container)
+    await renderImage()
+    await act(async () => {
+      root.render(
+        <ArtifactPreview
+          artifact={imageArtifact}
+          projectId="project-1"
+          sessionId="session-1"
+          isVisible={false}
+        />
+      )
+    })
+    await act(async () => root.render(<div />))
+    await renderImage()
+
+    expect(window.api.previewResources.acquire).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/pages/workspace/artifact-preview.tsx
+++ b/src/renderer/src/pages/workspace/artifact-preview.tsx
@@ -16,7 +16,7 @@ import {
 import { PdfThumbnail } from './previews/renderers/PdfThumbnail'
 import { TiffThumbnail } from './previews/renderers/TiffThumbnail'
 import { createPreviewResourceKey } from './previews/preview-resource-key'
-import { useManagedPreviewResource } from './previews/useManagedPreviewResource'
+import { useCachedPreviewImage } from './previews/useCachedPreviewImage'
 
 type MessageArtifact = NonNullable<ChatSession['artifacts']>[number]
 type ArtifactIconKind = 'archive' | 'code' | 'file' | 'image' | 'spreadsheet' | 'text'
@@ -267,7 +267,7 @@ const FileTypePreview = ({ artifact }: { artifact: MessageArtifact }): React.JSX
   )
 }
 
-// Streams image bytes through a short-lived managed URL instead of copying them into renderer state.
+// Copies managed image bytes into the bounded renderer cache so transcript remounts can reuse them.
 const ManagedImageThumbnail = ({
   artifact,
   name,
@@ -296,7 +296,7 @@ const ManagedImageThumbnail = ({
   const [failedRequestKey, setFailedRequestKey] = useState<string | undefined>(undefined)
   const hasFailed = failedRequestKey === requestKey
   // A decode failure disables the hook, which releases the protocol capability immediately.
-  const resourceState = useManagedPreviewResource(
+  const imageState = useCachedPreviewImage(
     {
       path: artifact.path,
       projectId,
@@ -306,14 +306,15 @@ const ManagedImageThumbnail = ({
       size: artifact.size,
       mtimeMs: artifact.mtimeMs
     },
-    enabled && !hasFailed
+    enabled && !hasFailed,
+    hasFailed
   )
 
-  if (resourceState.status !== 'ready') return <FileTypePreview artifact={artifact} />
+  if (imageState.status !== 'ready') return <FileTypePreview artifact={artifact} />
 
   return (
     <img
-      src={resourceState.resource.url}
+      src={imageState.url}
       alt={t('Preview of {{name}}', { name })}
       className="size-full object-cover object-top"
       loading="lazy"

--- a/src/renderer/src/pages/workspace/preview-image-content.test.tsx
+++ b/src/renderer/src/pages/workspace/preview-image-content.test.tsx
@@ -1,10 +1,15 @@
 // @vitest-environment jsdom
-import { act } from 'react'
+import { act, type ComponentProps } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { PreviewUnsupportedContent } from './previews/PreviewFallback'
-import { PreviewImageContent } from './previews/renderers/ImagePreview'
+import { PreviewImageContent as CachedPreviewImageContent } from './previews/renderers/ImagePreview'
+
+let previewVersion = 0
+const PreviewImageContent = (
+  props: ComponentProps<typeof CachedPreviewImageContent>
+): React.JSX.Element => <CachedPreviewImageContent {...props} mtimeMs={previewVersion} />
 
 describe('PreviewUnsupportedContent', () => {
   let container: HTMLDivElement
@@ -70,8 +75,14 @@ describe('PreviewImageContent', () => {
   let root: Root
 
   beforeEach(() => {
+    previewVersion += 1
     container = document.createElement('div')
     document.body.appendChild(container)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(new Blob(['image bytes'], { type: 'image/png' })))
+    )
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue(`blob:cached-image-${previewVersion}`)
     window.api = {
       previewResources: {
         acquire: vi.fn().mockResolvedValue({
@@ -96,6 +107,8 @@ describe('PreviewImageContent', () => {
     await act(async () => {
       root.unmount()
     })
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
     container.remove()
   })
 
@@ -127,16 +140,38 @@ describe('PreviewImageContent', () => {
     })
   })
 
-  it('renders an arbitrarily large image from the managed stream URL', async () => {
+  it('streams an image larger than the cache budget without copying it into a Blob', async () => {
+    vi.mocked(window.api.previewResources.acquire).mockResolvedValue({
+      id: 'resource-1',
+      url: 'open-science-preview://resource-1/photo.png',
+      size: 80 * 1024 * 1024,
+      mimeType: 'image/png',
+      version: 1
+    })
+    const fetchImage = vi
+      .fn()
+      .mockResolvedValue(new Response(new Blob(['image bytes'], { type: 'image/png' })))
+    vi.stubGlobal('fetch', fetchImage)
+
     root = createRoot(container)
     await act(async () => {
       root.render(<PreviewImageContent path="/workspace/photo.png" name="photo.png" />)
     })
 
+    expect(fetchImage).not.toHaveBeenCalled()
     const image = container.querySelector('img')
     expect(image?.getAttribute('src')).toBe('open-science-preview://resource-1/photo.png')
     expect(image?.getAttribute('alt')).toBe('photo.png')
     expect(window.api.artifacts.readPreview).not.toHaveBeenCalled()
+
+    await act(async () => root.unmount())
+    expect(window.api.previewResources.release).toHaveBeenCalledWith({ resourceId: 'resource-1' })
+
+    root = createRoot(container)
+    await act(async () => {
+      root.render(<PreviewImageContent path="/workspace/photo.png" name="photo.png" />)
+    })
+    expect(window.api.previewResources.acquire).toHaveBeenCalledTimes(2)
   })
 
   it('acquires upload-sourced images through the unified resource API', async () => {
@@ -159,9 +194,7 @@ describe('PreviewImageContent', () => {
       sessionId: 'session-1',
       path: 'upload-version:upload-version-1'
     })
-    expect(container.querySelector('img')?.getAttribute('src')).toBe(
-      'open-science-preview://resource-1/photo.png'
-    )
+    expect(container.querySelector('img')?.getAttribute('src')).toMatch(/^blob:/)
   })
 
   it('falls back to the error state when resource acquisition rejects', async () => {

--- a/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
@@ -198,6 +198,39 @@ describe('PreviewFileContent', () => {
     })
   }
 
+  it('reuses a loaded image when its preview is unmounted and mounted again', async () => {
+    const fetchImage = vi
+      .fn()
+      .mockResolvedValue(new Response(new Blob(['image bytes'], { type: 'image/png' })))
+    vi.stubGlobal('fetch', fetchImage)
+    vi.stubGlobal(
+      'URL',
+      class extends URL {
+        static createObjectURL = vi.fn(() => 'blob:cached-chart')
+        static revokeObjectURL = vi.fn()
+      }
+    )
+    const image = createFileItem({
+      format: 'image',
+      name: 'chart.png',
+      path: '/workspace/chart.png',
+      mimeType: 'image/png',
+      size: 2048,
+      mtimeMs: 1710000000100
+    })
+
+    await renderFile(image)
+    await vi.waitFor(() => expect(container.querySelector('img')).not.toBeNull())
+
+    await act(async () => root.render(<div />))
+    await act(async () => root.render(<PreviewFileContent item={image} />))
+    await vi.waitFor(() => expect(container.querySelector('img')).not.toBeNull())
+
+    expect(window.api.previewResources.acquire).toHaveBeenCalledTimes(1)
+    expect(fetchImage).toHaveBeenCalledTimes(1)
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1)
+  })
+
   it('shows the format-aware quiet progress state while a file is loading', async () => {
     vi.mocked(window.api.artifacts.readPreview).mockReturnValue(new Promise(() => undefined))
 

--- a/src/renderer/src/pages/workspace/previews/renderers/ImagePreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/ImagePreview.tsx
@@ -6,7 +6,7 @@ import type { PreviewFileSource } from '@/stores/preview-workbench-store'
 import { PreviewErrorCard, PreviewFallbackCard, PreviewLoadingContent } from '../PreviewFallback'
 import { createPreviewResourceKey } from '../preview-resource-key'
 import type { PreviewFileRendererProps } from '../preview-types'
-import { useManagedPreviewResource } from '../useManagedPreviewResource'
+import { useCachedPreviewImage } from '../useCachedPreviewImage'
 import { ZoomablePreview } from './ZoomablePreview'
 
 const ZoomableImage = ({
@@ -63,9 +63,10 @@ export const PreviewImageContent = ({
   const [failedRequestKey, setFailedRequestKey] = useState<string | undefined>(undefined)
   const hasFailed = failedRequestKey === requestKey
   // A decode failure disables the hook, which releases the protocol capability immediately.
-  const state = useManagedPreviewResource(
+  const state = useCachedPreviewImage(
     { projectId, sessionId, path, source, mimeType, size, mtimeMs },
-    !hasFailed
+    !hasFailed,
+    hasFailed
   )
 
   if (state.status === 'loading') return <PreviewLoadingContent />
@@ -94,11 +95,7 @@ export const PreviewImageContent = ({
 
   return (
     <div className="relative size-full overflow-hidden p-4">
-      <ZoomableImage
-        url={state.resource.url}
-        name={name}
-        onError={() => setFailedRequestKey(requestKey)}
-      />
+      <ZoomableImage url={state.url} name={name} onError={() => setFailedRequestKey(requestKey)} />
     </div>
   )
 }

--- a/src/renderer/src/pages/workspace/previews/useCachedPreviewImage.ts
+++ b/src/renderer/src/pages/workspace/previews/useCachedPreviewImage.ts
@@ -8,7 +8,7 @@ import { createPreviewResourceKey } from './preview-resource-key'
 const MAX_CACHED_IMAGE_BYTES = 64 * 1024 * 1024
 const MAX_CACHED_IMAGE_COUNT = 32
 
-type CachedImage = { url: string; size: number }
+type CachedImage = { url: string; size: number; managedResourceId?: string }
 type CachedImageEntry = {
   key: string
   promise: Promise<CachedImage>
@@ -33,7 +33,13 @@ let cachedImageBytes = 0
 const dispose = (entry: CachedImageEntry): void => {
   if (entry.disposed || entry.refs > 0 || entry.retained) return
   entry.disposed = true
-  void entry.promise.then(({ url }) => URL.revokeObjectURL(url)).catch(() => undefined)
+  void entry.promise
+    .then(({ url, managedResourceId }) =>
+      managedResourceId
+        ? window.api.previewResources.release({ resourceId: managedResourceId })
+        : URL.revokeObjectURL(url)
+    )
+    .catch(() => undefined)
 }
 
 const evict = (entry: CachedImageEntry): void => {
@@ -60,6 +66,11 @@ const loadImage = async (item: PreviewImageItem): Promise<CachedImage> => {
     ...(requestScope.sessionId ? { sessionId: requestScope.sessionId } : {}),
     ...(item.mimeType ? { mimeType: item.mimeType } : {})
   })
+
+  const imageSize = Math.max(item.size ?? 0, resource.size)
+  if (imageSize > MAX_CACHED_IMAGE_BYTES) {
+    return { url: resource.url, size: imageSize, managedResourceId: resource.id }
+  }
 
   try {
     // The managed protocol intentionally disables HTTP caching. Copy the decoded source bytes into
@@ -95,7 +106,10 @@ const acquire = (item: PreviewImageItem, key: string): CachedImageEntry => {
   entry.promise = pending.then(
     (value) => {
       entry.value = value
-      if (entry.retained) {
+      if (value.managedResourceId) {
+        entry.retained = false
+        if (entry.refs === 0) evict(entry)
+      } else if (entry.retained) {
         cachedImageBytes += value.size
         prune()
       } else {
@@ -115,7 +129,8 @@ const acquire = (item: PreviewImageItem, key: string): CachedImageEntry => {
 
 const release = (entry: CachedImageEntry): void => {
   entry.refs = Math.max(0, entry.refs - 1)
-  dispose(entry)
+  if (entry.refs === 0 && !entry.retained) evict(entry)
+  else dispose(entry)
   prune()
 }
 

--- a/src/renderer/src/pages/workspace/previews/useCachedPreviewImage.ts
+++ b/src/renderer/src/pages/workspace/previews/useCachedPreviewImage.ts
@@ -1,0 +1,199 @@
+import { useEffect, useState } from 'react'
+
+import type { PreviewFileItem } from '@/stores/preview-workbench-store'
+
+import { createPreviewRequestScope } from './preview-file-reader'
+import { createPreviewResourceKey } from './preview-resource-key'
+
+const MAX_CACHED_IMAGE_BYTES = 64 * 1024 * 1024
+const MAX_CACHED_IMAGE_COUNT = 32
+
+type CachedImage = { url: string; size: number }
+type CachedImageEntry = {
+  key: string
+  promise: Promise<CachedImage>
+  refs: number
+  retained: boolean
+  disposed: boolean
+  value?: CachedImage
+}
+
+type CachedPreviewImageState =
+  | { status: 'idle'; url?: undefined; error?: undefined }
+  | { status: 'loading'; url?: undefined; error?: undefined }
+  | { status: 'ready'; url: string; error?: undefined }
+  | { status: 'error'; url?: undefined; error: Error }
+
+type PreviewImageItem = Pick<PreviewFileItem, 'path' | 'source' | 'mimeType' | 'size' | 'mtimeMs'> &
+  Partial<Pick<PreviewFileItem, 'projectId' | 'sessionId'>>
+
+const entries = new Map<string, CachedImageEntry>()
+let cachedImageBytes = 0
+
+const dispose = (entry: CachedImageEntry): void => {
+  if (entry.disposed || entry.refs > 0 || entry.retained) return
+  entry.disposed = true
+  void entry.promise.then(({ url }) => URL.revokeObjectURL(url)).catch(() => undefined)
+}
+
+const evict = (entry: CachedImageEntry): void => {
+  if (entries.get(entry.key) === entry) entries.delete(entry.key)
+  if (entry.retained && entry.value) cachedImageBytes -= entry.value.size
+  entry.retained = false
+  dispose(entry)
+}
+
+const prune = (): void => {
+  while (entries.size > MAX_CACHED_IMAGE_COUNT || cachedImageBytes > MAX_CACHED_IMAGE_BYTES) {
+    const candidate = Array.from(entries.values()).find((entry) => entry.refs === 0)
+    if (!candidate) return
+    evict(candidate)
+  }
+}
+
+const loadImage = async (item: PreviewImageItem): Promise<CachedImage> => {
+  const requestScope = createPreviewRequestScope(item)
+  const resource = await window.api.previewResources.acquire({
+    source: item.source ?? 'artifact',
+    path: item.path,
+    ...(requestScope.projectId ? { projectId: requestScope.projectId } : {}),
+    ...(requestScope.sessionId ? { sessionId: requestScope.sessionId } : {}),
+    ...(item.mimeType ? { mimeType: item.mimeType } : {})
+  })
+
+  try {
+    // The managed protocol intentionally disables HTTP caching. Copy the decoded source bytes into
+    // a renderer-owned Blob URL so Session switches can reuse them without retaining a path-bearing
+    // main-process capability.
+    const response = await fetch(resource.url, { cache: 'no-store' })
+    if (!response.ok)
+      throw new Error(`Image preview request failed with status ${response.status}.`)
+    const blob = await response.blob()
+    return { url: URL.createObjectURL(blob), size: blob.size }
+  } finally {
+    void window.api.previewResources.release({ resourceId: resource.id })
+  }
+}
+
+const acquire = (item: PreviewImageItem, key: string): CachedImageEntry => {
+  const existing = entries.get(key)
+  if (existing) {
+    existing.refs += 1
+    entries.delete(key)
+    entries.set(key, existing)
+    return existing
+  }
+
+  const pending = loadImage(item)
+  const entry: CachedImageEntry = {
+    key,
+    promise: pending,
+    refs: 1,
+    retained: true,
+    disposed: false
+  }
+  entry.promise = pending.then(
+    (value) => {
+      entry.value = value
+      if (entry.retained) {
+        cachedImageBytes += value.size
+        prune()
+      } else {
+        dispose(entry)
+      }
+      return value
+    },
+    (error: unknown) => {
+      evict(entry)
+      throw error
+    }
+  )
+  entries.set(key, entry)
+  prune()
+  return entry
+}
+
+const release = (entry: CachedImageEntry): void => {
+  entry.refs = Math.max(0, entry.refs - 1)
+  dispose(entry)
+  prune()
+}
+
+const invalidate = (key: string): void => {
+  const entry = entries.get(key)
+  if (entry) evict(entry)
+}
+
+const useCachedPreviewImage = (
+  item: PreviewImageItem,
+  enabled = true,
+  invalidateWhenDisabled = false
+): CachedPreviewImageState => {
+  const requestKey = createPreviewResourceKey(item)
+  const [result, setResult] = useState<
+    | { requestKey: string; status: 'ready'; url: string }
+    | { requestKey: string; status: 'error'; error: Error }
+    | null
+  >(null)
+
+  useEffect(() => {
+    if (!enabled) {
+      if (invalidateWhenDisabled) invalidate(requestKey)
+      return
+    }
+
+    let disposed = false
+    const entry = acquire(
+      {
+        path: item.path,
+        source: item.source,
+        mimeType: item.mimeType,
+        size: item.size,
+        mtimeMs: item.mtimeMs,
+        projectId: item.projectId,
+        sessionId: item.sessionId
+      },
+      requestKey
+    )
+    void entry.promise.then(
+      ({ url }) => {
+        if (!disposed) setResult({ requestKey, status: 'ready', url })
+      },
+      (error: unknown) => {
+        if (!disposed) {
+          setResult({
+            requestKey,
+            status: 'error',
+            error: error instanceof Error ? error : new Error(String(error))
+          })
+        }
+      }
+    )
+
+    return () => {
+      disposed = true
+      release(entry)
+      queueMicrotask(() => {
+        setResult((current) => (current?.requestKey === requestKey ? null : current))
+      })
+    }
+  }, [
+    enabled,
+    invalidateWhenDisabled,
+    item.mimeType,
+    item.mtimeMs,
+    item.path,
+    item.projectId,
+    item.sessionId,
+    item.size,
+    item.source,
+    requestKey
+  ])
+
+  if (!enabled) return { status: 'idle' }
+  if (result?.requestKey !== requestKey) return { status: 'loading' }
+  return result
+}
+
+export { useCachedPreviewImage }
+export type { CachedPreviewImageState }

--- a/src/renderer/src/pages/workspace/use-transcript-window.test.tsx
+++ b/src/renderer/src/pages/workspace/use-transcript-window.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { act, createRef } from 'react'
+import { createRoot } from 'react-dom/client'
+import { describe, expect, it } from 'vitest'
+
+import { useTranscriptWindow } from './use-transcript-window'
+import type { WorkspaceConversationTimelineItem } from './workspace-conversation-timeline'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const items = Array.from(
+  { length: 120 },
+  (_, index) =>
+    ({ id: `message-${index + 1}`, type: 'message' }) as WorkspaceConversationTimelineItem
+)
+
+describe('useTranscriptWindow', () => {
+  it('keeps the full transcript mounted when revealing a run during whole-window find', () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    const result = {
+      current: undefined as unknown as ReturnType<typeof useTranscriptWindow>
+    }
+    const HookHarness = (): null => {
+      result.current = useTranscriptWindow('session-1', items, -1, createRef())
+      return null
+    }
+
+    act(() => root.render(<HookHarness />))
+    expect(result.current.entries).toHaveLength(80)
+
+    act(() => result.current.revealAll())
+    expect(result.current.entries).toHaveLength(120)
+
+    act(() => result.current.revealMessage('message-1'))
+    expect(result.current.entries).toHaveLength(120)
+
+    act(() => root.unmount())
+  })
+})

--- a/src/renderer/src/pages/workspace/use-transcript-window.ts
+++ b/src/renderer/src/pages/workspace/use-transcript-window.ts
@@ -1,0 +1,121 @@
+import { useCallback, useLayoutEffect, useRef, useState, type RefObject } from 'react'
+
+import type { WorkspaceConversationTimelineItem } from './workspace-conversation-timeline'
+import { findMessageTarget } from './workspace-run-marks'
+
+const TRANSCRIPT_WINDOW_SIZE = 80
+
+type TranscriptWindowState = {
+  scopeId: string | undefined
+  itemCount: number
+  start: number
+  end: number
+}
+
+const useTranscriptWindow = (
+  scopeId: string | undefined,
+  items: readonly WorkspaceConversationTimelineItem[],
+  presentationBarrierIndex: number,
+  viewportRef: RefObject<HTMLDivElement | null>
+): {
+  entries: Array<{ item: WorkspaceConversationTimelineItem; itemIndex: number }>
+  end: number
+  revealMessage: (messageId: string) => void
+  revealAll: () => void
+  expandAtScrollEdge: (previousScrollTop: number) => void
+} => {
+  const [state, setState] = useState<TranscriptWindowState>(() => ({
+    scopeId: undefined,
+    itemCount: 0,
+    start: 0,
+    end: 0
+  }))
+  const initialStart = Math.max(0, items.length - TRANSCRIPT_WINDOW_SIZE)
+  const start = state.scopeId === scopeId ? Math.min(state.start, items.length) : initialStart
+  const end =
+    state.scopeId === scopeId
+      ? state.end === state.itemCount
+        ? items.length
+        : Math.min(state.end, items.length)
+      : items.length
+  const pendingTargetRef = useRef<string | undefined>(undefined)
+
+  const revealMessage = useCallback(
+    (messageId: string): void => {
+      const itemIndex = items.findIndex(
+        (item) =>
+          item.id === messageId || (item.type === 'message' && item.message.id === messageId)
+      )
+      if (itemIndex < 0) return
+
+      const nextStart = Math.max(0, itemIndex - Math.floor(TRANSCRIPT_WINDOW_SIZE / 4))
+      pendingTargetRef.current = messageId
+      setState({
+        scopeId,
+        itemCount: items.length,
+        start: nextStart,
+        end: Math.min(items.length, nextStart + TRANSCRIPT_WINDOW_SIZE)
+      })
+    },
+    [items, scopeId]
+  )
+
+  const revealAll = useCallback((): void => {
+    setState({
+      scopeId,
+      itemCount: items.length,
+      start: 0,
+      end: items.length
+    })
+  }, [items.length, scopeId])
+
+  const expandAtScrollEdge = (previousScrollTop: number): void => {
+    const viewport = viewportRef.current
+    if (!viewport || presentationBarrierIndex >= 0) return
+
+    if (viewport.scrollTop < previousScrollTop && viewport.scrollTop <= 64 && start > 0) {
+      setState({
+        scopeId,
+        itemCount: items.length,
+        start: Math.max(0, start - TRANSCRIPT_WINDOW_SIZE),
+        end
+      })
+    } else if (
+      viewport.scrollTop > previousScrollTop &&
+      viewport.scrollTop + viewport.clientHeight >= viewport.scrollHeight - 64 &&
+      end < items.length
+    ) {
+      setState({
+        scopeId,
+        itemCount: items.length,
+        start,
+        end: Math.min(items.length, end + TRANSCRIPT_WINDOW_SIZE)
+      })
+    }
+  }
+
+  useLayoutEffect(() => {
+    const messageId = pendingTargetRef.current
+    const viewport = viewportRef.current
+    if (!messageId || !viewport) return
+    const target = findMessageTarget(viewport, messageId)
+    if (!target) return
+
+    pendingTargetRef.current = undefined
+    const top = Math.max(
+      0,
+      viewport.scrollTop + target.getBoundingClientRect().top - viewport.getBoundingClientRect().top
+    )
+    if (typeof viewport.scrollTo === 'function') viewport.scrollTo({ top, behavior: 'auto' })
+    else viewport.scrollTop = top
+  }, [end, start, viewportRef])
+
+  const entries =
+    presentationBarrierIndex >= 0
+      ? items.map((item, itemIndex) => ({ item, itemIndex }))
+      : items.slice(start, end).map((item, offset) => ({ item, itemIndex: start + offset }))
+
+  return { entries, end, revealMessage, revealAll, expandAtScrollEdge }
+}
+
+export { useTranscriptWindow }

--- a/src/renderer/src/pages/workspace/use-transcript-window.ts
+++ b/src/renderer/src/pages/workspace/use-transcript-window.ts
@@ -22,6 +22,7 @@ const useTranscriptWindow = (
   end: number
   revealMessage: (messageId: string) => void
   revealAll: () => void
+  restoreWindow: () => void
   expandAtScrollEdge: (previousScrollTop: number) => void
 } => {
   const [state, setState] = useState<TranscriptWindowState>(() => ({
@@ -39,6 +40,7 @@ const useTranscriptWindow = (
         : Math.min(state.end, items.length)
       : items.length
   const pendingTargetRef = useRef<string | undefined>(undefined)
+  const findRestoreRef = useRef<TranscriptWindowState | undefined>(undefined)
 
   const revealMessage = useCallback(
     (messageId: string): void => {
@@ -61,11 +63,31 @@ const useTranscriptWindow = (
   )
 
   const revealAll = useCallback((): void => {
+    if (findRestoreRef.current?.scopeId !== scopeId) {
+      findRestoreRef.current = { scopeId, itemCount: items.length, start, end }
+    }
     setState({
       scopeId,
       itemCount: items.length,
       start: 0,
       end: items.length
+    })
+  }, [end, items.length, scopeId, start])
+
+  const restoreWindow = useCallback((): void => {
+    const previous = findRestoreRef.current
+    findRestoreRef.current = undefined
+    if (!previous || previous.scopeId !== scopeId) return
+
+    const wasPinnedToEnd = previous.end === previous.itemCount
+    const previousWindowSize = previous.end - previous.start
+    setState({
+      scopeId,
+      itemCount: items.length,
+      start: wasPinnedToEnd
+        ? Math.max(0, items.length - previousWindowSize)
+        : Math.min(previous.start, items.length),
+      end: wasPinnedToEnd ? items.length : Math.min(previous.end, items.length)
     })
   }, [items.length, scopeId])
 
@@ -115,7 +137,7 @@ const useTranscriptWindow = (
       ? items.map((item, itemIndex) => ({ item, itemIndex }))
       : items.slice(start, end).map((item, offset) => ({ item, itemIndex: start + offset }))
 
-  return { entries, end, revealMessage, revealAll, expandAtScrollEdge }
+  return { entries, end, revealMessage, revealAll, restoreWindow, expandAtScrollEdge }
 }
 
 export { useTranscriptWindow }

--- a/src/renderer/src/pages/workspace/use-transcript-window.ts
+++ b/src/renderer/src/pages/workspace/use-transcript-window.ts
@@ -58,6 +58,7 @@ const useTranscriptWindow = (
 
       const nextStart = Math.max(0, itemIndex - Math.floor(TRANSCRIPT_WINDOW_SIZE / 4))
       pendingTargetRef.current = messageId
+      if (findRestoreRef.current?.scopeId === scopeId) return
       setState({
         scopeId,
         itemCount: items.length,

--- a/src/renderer/src/pages/workspace/use-transcript-window.ts
+++ b/src/renderer/src/pages/workspace/use-transcript-window.ts
@@ -32,13 +32,19 @@ const useTranscriptWindow = (
     end: 0
   }))
   const initialStart = Math.max(0, items.length - TRANSCRIPT_WINDOW_SIZE)
-  const start = state.scopeId === scopeId ? Math.min(state.start, items.length) : initialStart
-  const end =
-    state.scopeId === scopeId
-      ? state.end === state.itemCount
-        ? items.length
-        : Math.min(state.end, items.length)
-      : items.length
+  const stateMatchesScope = state.scopeId === scopeId && state.itemCount > 0
+  const wasPinnedToEnd = stateMatchesScope && state.end === state.itemCount
+  const retainedWindowSize = state.end - state.start
+  const start = stateMatchesScope
+    ? wasPinnedToEnd
+      ? Math.max(0, items.length - retainedWindowSize)
+      : Math.min(state.start, items.length)
+    : initialStart
+  const end = stateMatchesScope
+    ? state.end === state.itemCount
+      ? items.length
+      : Math.min(state.end, items.length)
+    : items.length
   const pendingTargetRef = useRef<string | undefined>(undefined)
   const findRestoreRef = useRef<TranscriptWindowState | undefined>(undefined)
 
@@ -132,9 +138,18 @@ const useTranscriptWindow = (
     else viewport.scrollTop = top
   }, [end, start, viewportRef])
 
+  const presentationStart = Math.max(0, presentationBarrierIndex - TRANSCRIPT_WINDOW_SIZE + 1)
   const entries =
     presentationBarrierIndex >= 0
-      ? items.map((item, itemIndex) => ({ item, itemIndex }))
+      ? items.flatMap((item, itemIndex) => {
+          const withinPresentationWindow =
+            itemIndex >= presentationStart && itemIndex <= presentationBarrierIndex
+          const liveActivityAfterBarrier =
+            itemIndex > presentationBarrierIndex &&
+            item.type !== 'message' &&
+            item.type !== 'subagent-message'
+          return withinPresentationWindow || liveActivityAfterBarrier ? [{ item, itemIndex }] : []
+        })
       : items.slice(start, end).map((item, offset) => ({ item, itemIndex: start + offset }))
 
   return { entries, end, revealMessage, revealAll, restoreWindow, expandAtScrollEdge }

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -399,7 +399,8 @@ export const RENDERER_CONTRACT_GROUPS = Object.freeze([
     ['clearFind', 'window:clear-find-in-page', SEND], ['close', 'window:close', MAPPED_NATIVE], ['closeFind', 'window:find-close', SEND],
     ['findInPage', 'window:find-in-page', SEND], ['onCloseActivePane', 'shortcut:close-active-pane', CLOSE_PANE_EVENT],
     ['onCloseConfirmRequest', 'window:close-confirm-request', ELECTRON_EVENT], ['onFindInPageResult', 'window:find-in-page-result', ELECTRON_EVENT],
-    ['onShowWindowFind', 'window:find-show', ELECTRON_EVENT], ['onWindowFindAppearance', 'window:find-appearance', ELECTRON_EVENT],
+    ['onHideWindowFind', 'window:find-hide', ELECTRON_EVENT], ['onShowWindowFind', 'window:find-show', ELECTRON_EVENT],
+    ['onWindowFindAppearance', 'window:find-appearance', ELECTRON_EVENT],
     ['sendCloseConfirmResponse', 'window:close-confirm-response', SEND],
   ]),
 ])

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -395,7 +395,8 @@ export const RENDERER_CONTRACT_GROUPS = Object.freeze([
     ['stageLocalFile', 'uploads:stage-local-file', MAPPED_ELECTRON, NATIVE_FILE_UPLOAD], ['stageLocalPath', 'uploads:stage-local-path', LOCAL],
   ]),
   group('window', 'window', [
-    ['announceWindowFindAppearance', 'window:find-appearance-changed', SEND], ['announceWindowFindReady', 'shortcut:window-find-ready', WINDOW_FIND_READY],
+    ['announceWindowFindAppearance', 'window:find-appearance-changed', SEND], ['announceWindowFindContentReady', 'shortcut:window-find-content-ready', SEND],
+    ['announceWindowFindReady', 'shortcut:window-find-ready', WINDOW_FIND_READY],
     ['clearFind', 'window:clear-find-in-page', SEND], ['close', 'window:close', MAPPED_NATIVE], ['closeFind', 'window:find-close', SEND],
     ['findInPage', 'window:find-in-page', SEND], ['onCloseActivePane', 'shortcut:close-active-pane', CLOSE_PANE_EVENT],
     ['onCloseConfirmRequest', 'window:close-confirm-request', ELECTRON_EVENT], ['onFindInPageResult', 'window:find-in-page-result', ELECTRON_EVENT],

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -119,6 +119,7 @@ const GENERATED_SOURCE_OMISSIONS = [
   'specialist.setSessionSpecialist',
   'specialist.update',
   'window.announceWindowFindAppearance',
+  'window.announceWindowFindContentReady',
   'window.announceWindowFindReady',
   'window.clearFind',
   'window.closeFind',

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -125,6 +125,7 @@ const GENERATED_SOURCE_OMISSIONS = [
   'window.findInPage',
   'window.onCloseConfirmRequest',
   'window.onFindInPageResult',
+  'window.onHideWindowFind',
   'window.onShowWindowFind',
   'window.onWindowFindAppearance',
   'window.sendCloseConfirmResponse'

--- a/src/shared/window-controls.ts
+++ b/src/shared/window-controls.ts
@@ -25,6 +25,7 @@ export const CLOSE_ACTIVE_PANE_UNREADY_CHANNEL = 'shortcut:close-active-pane-unr
 // normal Cmd/Ctrl+F behavior outside Workspace rather than swallowing the chord into a missing UI.
 export const WINDOW_FIND_READY_CHANNEL = 'shortcut:window-find-ready'
 export const WINDOW_FIND_UNREADY_CHANNEL = 'shortcut:window-find-unready'
+export const WINDOW_FIND_CONTENT_READY_CHANNEL = 'shortcut:window-find-content-ready'
 
 // Renderer -> main requests and main -> renderer result events for Electron's native whole-window find.
 export const WINDOW_FIND_REQUEST_CHANNEL = 'window:find-in-page'

--- a/src/shared/window-controls.ts
+++ b/src/shared/window-controls.ts
@@ -36,6 +36,10 @@ export const WINDOW_FIND_RESULT_CHANNEL = 'window:find-in-page-result'
 // live-follow OS changes without trying to read the renderer's origin-scoped localStorage.
 export const WINDOW_FIND_SHOW_CHANNEL = 'window:find-show'
 
+// Main -> main renderer: the find overlay was hidden, so any temporary searchable expansion can be
+// released and the transcript can return to its previous bounded window.
+export const WINDOW_FIND_HIDE_CHANNEL = 'window:find-hide'
+
 // Main -> overlay: refresh only the overlay appearance after an asynchronous renderer lookup. Kept
 // separate from SHOW so a late theme result never steals focus or re-runs the remembered query.
 export const WINDOW_FIND_APPEARANCE_CHANNEL = 'window:find-appearance'


### PR DESCRIPTION
## Problem

Switching to a long Session remounted every transcript item. Reproduction with generated Sessions showed warm switches of about 575–762 ms for 900 messages and 2.2–3.25 s for 1,200 messages, with the renderer spending most of that time in script/layout work. Repeated switches did not call `sessions.loadAll`, so repeated `session.json` reads were not the primary cause.

Transcript images also reacquired a managed preview URL after the Session was switched away and back. The managed protocol intentionally sends `cache-control: no-store`, so the browser could not reuse those bytes.

## Proposed change

- Mount the latest 80 transcript timeline items initially, keep an end-pinned window bounded as messages append, keep the same bound around an active presentation barrier while preserving later live activity rows, and grow/reposition the window when the user scrolls to an edge, selects a Run Mark, or chooses the first-message action.
- Expand the complete transcript when Electron's native find overlay opens so historical messages remain searchable, wait for one renderer acknowledgement per find-open transcript scope after any paced message presentation finishes, re-run that query after a Session switch while the overlay remains open, then restore the previous bounded window when the overlay closes. Streaming updates within the same Session do not reopen or refocus the overlay.
- Cache versioned image bytes as bounded renderer-process Blob URLs (32 images / 64 MiB), shared by transcript thumbnails and the image preview panel. Images larger than the byte budget stay on the managed streaming URL and are never admitted to the Blob cache.
- Show a conversation-shaped skeleton only while a lazily selected Session still has `contentLoaded === false`; already-hydrated switches render directly so fast in-memory transitions do not flash a loading surface.
- Reuse existing Artifact metadata, Run Marks, managed preview resources, workspace colors, message geometry, and reduced-motion rules. The only new cross-process contracts are a main-to-renderer `window:find-hide` notification and a renderer-to-main searchable-content-ready acknowledgement; no persistence or storage protocol is added.

Final manual verification on the production web build:

- 900-message warm switch: 137 ms; 1,200-message warm switch: 115 ms.
- Both long Sessions mounted 80 transcript message nodes.
- Transcript image switch-away/back: one resource acquire and the same Blob URL on both mounts.
- Skeleton presentation checked at 414, 768, and 1,440 CSS-pixel widths, plus dark mode and reduced motion; no horizontal overflow, and reduced motion resolves to no animation.

## Scope and non-goals

- No database/schema changes, new data fields, data-model changes, or enum values.
- No durable cache or new persisted state. Image cache lifetime is the renderer process only; cached-image capabilities are released after fetching, while oversized streamed-image capabilities are released on unmount.
- No historical-data compatibility work is required; cache identity uses existing path/source/size/mtime metadata, and existing Session JSON remains unchanged.
- First hydration of a Session can still read its JSON. This change targets repeated renderer work after hydration, not durable Session storage.

## Acceptance criteria and validation

The final Test Impact Set ran after the last material edit:

- Bounded transcript, Run Mark navigation, native find readiness/restoration across Session switches and paced presentation, transcript image reuse, preview-panel image reuse, oversized-image streaming, skeleton presentation, and window-find contracts -> targeted Vitest command covering the affected renderer, main, preload, and shared modules -> 10 files / 359 tests passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Main-process types -> `npm run typecheck:node` -> passed.
- Affected TypeScript/TSX files -> targeted `eslint` -> passed with 0 errors or warnings.
- Production web integration/build -> `npm run build:web` -> passed.

The original regression tests were run twice before their fixes and failed stably for the reported reasons: the oldest long-transcript message was mounted immediately, and a remounted transcript image performed a second resource acquire. Review regressions were also captured red-first: closing native find left the full transcript mounted; an 80 MiB image was copied into a Blob; an oversized streamed resource could remain as a stale cache entry after release; the native find overlay searched before the full transcript committed; switching Sessions while find stayed open did not search the new transcript; same-Session streaming emitted a second readiness acknowledgement that reopened the overlay; find readiness was announced while rows behind a presentation barrier were still hidden; an end-pinned transcript window grew as messages appended; active presentation remounted the full historical transcript; Run Mark reveal collapsed a whole-window find transcript; an unavailable presentation-era Run Mark remained enabled; and an unhydrated Session entered the empty message scroller instead of a skeleton. All pass after the change.

Per maintainer direction, the complete local `npm test` suite was not run; exact-head PR CI is authoritative for the complete portable/platform plan. The native Electron find timing is covered at the main/renderer contract boundary but was not exercised as a packaged desktop E2E locally.

## Review focus

- Transcript window transitions when scrolling or activating an off-window Run Mark.
- Native find behavior across show/content-ready/hide, including switching Sessions with the overlay open and paced transcript presentation.
- Blob URL cache eviction/invalidation, oversized-image admission, and managed-capability release timing.
- Skeleton scope: cold lazy hydration only, with warm switches intentionally bypassing it.
