### PR TITLE
perf(startup): defer transcript and runtime probes

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -830,6 +830,28 @@ describe('App startup routing', () => {
     expect(mocks.syncWindowFindAppearance).toHaveBeenCalledTimes(1)
   })
 
+  it('renders Home while existing-user runtime probes continue', async () => {
+    mocks.settings.isLoaded = true
+    mocks.settings.isLoading = true
+    mocks.startupView = 'app'
+
+    await render()
+
+    expect(container.querySelector('[data-testid="home-page"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="settings-startup-loading"]')).toBeNull()
+  })
+
+  it('keeps first-run onboarding behind runtime initialization', async () => {
+    mocks.settings.isLoaded = true
+    mocks.settings.isLoading = true
+    mocks.startupView = 'onboarding'
+
+    await render()
+
+    expect(container.querySelector('[data-testid="settings-startup-loading"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="onboarding-page"]')).toBeNull()
+  })
+
   it('shows a settings load error and retries the complete initialization', async () => {
     mocks.settings.loadError = 'settings IPC unavailable'
     mocks.settings.load.mockReset().mockResolvedValueOnce(false).mockResolvedValueOnce(true)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -514,7 +514,7 @@ const AppContent = (): React.JSX.Element | null => {
 
   // Settings carry the persisted first-run marker. No environment result is awaited here: existing
   // users proceed directly to Home while the launch check runs in the background.
-  if (!isSettingsLoaded) {
+  if (!isSettingsLoaded || (startupView === 'onboarding' && isSettingsLoading)) {
     if (settingsLoadError) {
       return (
         <main

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -189,7 +189,8 @@ describe('session persistence startup', () => {
       useSessionStore.getState().selectSession(lazy.id)
       await Promise.resolve()
     })
-    expect(loadOne).toHaveBeenCalledTimes(2)
+    expect(loadOne).toHaveBeenCalledOnce()
+    expect(loadOne).toHaveBeenCalledWith({ projectId: lazy.projectId, sessionId: lazy.id })
 
     await act(async () => {
       useSessionStore.getState().deleteSession(lazy.id)

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -185,12 +185,27 @@ describe('session persistence startup', () => {
     } as unknown as Window['api']
 
     await act(async () => root.render(<Probe />))
+    expect(useSessionStore.getState().selectedSessionId).toBe(selected.id)
+    expect(loadOne).not.toHaveBeenCalled()
+
+    // Entering Workspace selects the summary again. The whole-store subscription observes that
+    // navigation write even when the selected id is unchanged and starts transcript hydration.
+    await act(async () => {
+      useSessionStore.getState().selectSession(selected.id)
+      await Promise.resolve()
+    })
+    expect(loadOne).toHaveBeenCalledOnce()
+    expect(loadOne).toHaveBeenLastCalledWith({
+      projectId: selected.projectId,
+      sessionId: selected.id
+    })
+
     await act(async () => {
       useSessionStore.getState().selectSession(lazy.id)
       await Promise.resolve()
     })
-    expect(loadOne).toHaveBeenCalledOnce()
-    expect(loadOne).toHaveBeenCalledWith({ projectId: lazy.projectId, sessionId: lazy.id })
+    expect(loadOne).toHaveBeenCalledTimes(2)
+    expect(loadOne).toHaveBeenLastCalledWith({ projectId: lazy.projectId, sessionId: lazy.id })
 
     await act(async () => {
       useSessionStore.getState().deleteSession(lazy.id)

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -247,8 +247,7 @@ describe('renderer session persistence bridge', () => {
     expect(useSessionStore.getState().selectedSessionId).toBe('session-1')
   })
 
-  it('loads only the selected Session JSON from the SQLite summary list', async () => {
-    const selected = createPersistedSession({ id: 'session-1', projectId: 'project-1' })
+  it('hydrates the SQLite summary list without opening Session JSON', async () => {
     const list = vi.fn().mockResolvedValue({
       sessions: [
         {
@@ -286,19 +285,17 @@ describe('renderer session persistence bridge', () => {
       ],
       manifest: { version: SESSION_MANIFEST_VERSION, lastSessionId: 'session-1' }
     })
-    const loadOne = vi.fn().mockResolvedValue(selected)
+    const loadOne = vi.fn().mockResolvedValue(undefined)
     const api = createApi({ list, loadOne })
 
     await loadPersistedSessions(api)
 
     expect(api.loadAll).not.toHaveBeenCalled()
-    expect(loadOne).toHaveBeenCalledOnce()
-    expect(loadOne).toHaveBeenCalledWith({ projectId: 'project-1', sessionId: 'session-1' })
+    expect(loadOne).not.toHaveBeenCalled()
     expect(useSessionStore.getState().sessions).toMatchObject([
-      { id: 'session-1' },
+      { id: 'session-1', contentLoaded: false, messages: [] },
       { id: 'session-2', contentLoaded: false, activeMessageCount: 12, messages: [] }
     ])
-    expect(useSessionStore.getState().sessions[0]?.contentLoaded).not.toBe(false)
   })
 
   it('also hydrates unopened Sessions that require startup recovery', async () => {
@@ -333,15 +330,52 @@ describe('renderer session persistence bridge', () => {
 
     await loadPersistedSessions(createApi({ list, loadOne }))
 
-    expect(loadOne).toHaveBeenCalledTimes(2)
+    expect(loadOne).toHaveBeenCalledOnce()
+    expect(loadOne).toHaveBeenCalledWith({
+      projectId: recovering.projectId,
+      sessionId: recovering.id
+    })
     expect(useSessionStore.getState().sessions).toMatchObject([
-      { id: selected.id },
+      { id: selected.id, contentLoaded: false },
       { id: recovering.id }
     ])
     expect(useSessionStore.getState().sessions[1]?.contentLoaded).not.toBe(false)
   })
 
-  it('does not hydrate a selected Session after its lazy JSON load is cancelled', async () => {
+  it('opens the explicitly selected Session again during a recovery retry', async () => {
+    const selected = createPersistedSession({ id: 'session-1', projectId: 'project-1' })
+    const list = vi.fn().mockResolvedValue({
+      sessions: [
+        {
+          number: 1,
+          id: selected.id,
+          projectId: selected.projectId,
+          title: selected.title,
+          status: selected.status,
+          presentedStatus: selected.status,
+          pinned: false,
+          revision: 1,
+          activeMessageCount: selected.messages.length,
+          artifactCount: 0,
+          filesRevision: 0,
+          createdAt: selected.createdAt,
+          updatedAt: selected.updatedAt,
+          needsStartupRecovery: false
+        }
+      ],
+      manifest: { version: SESSION_MANIFEST_VERSION, lastSessionId: selected.id }
+    })
+    const loadOne = vi.fn().mockResolvedValue(selected)
+
+    await loadPersistedSessions(createApi({ list, loadOne }), () => true, {
+      sessionId: selected.id
+    })
+
+    expect(loadOne).toHaveBeenCalledWith({ projectId: selected.projectId, sessionId: selected.id })
+    expect(useSessionStore.getState().sessions[0]?.contentLoaded).not.toBe(false)
+  })
+
+  it('does not hydrate a recovery Session after its startup JSON load is cancelled', async () => {
     const selected = createPersistedSession({ id: 'session-1', projectId: 'project-1' })
     const lazyLoad = createDeferred<PersistedChatSession | undefined>()
     const api = createApi({
@@ -361,7 +395,7 @@ describe('renderer session persistence bridge', () => {
             filesRevision: 0,
             createdAt: 1,
             updatedAt: 2,
-            needsStartupRecovery: false
+            needsStartupRecovery: true
           }
         ],
         manifest: { version: SESSION_MANIFEST_VERSION, lastSessionId: selected.id }

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -934,13 +934,9 @@ const loadPersistedSessions = async (
   if (api.list) {
     const result = await api.list()
     if (!shouldHydrate()) return undefined
-    const requestedSelection =
-      preferredSelection !== undefined
-        ? preferredSelection.sessionId
-        : (result.manifest.lastSessionId ?? result.sessions[0]?.id)
-    const selectedSummary = result.sessions.find((session) => session.id === requestedSelection)
+    const retrySessionId = preferredSelection?.sessionId
     const summariesToHydrate = result.sessions.filter(
-      (session) => session.id === selectedSummary?.id || session.needsStartupRecovery
+      (session) => session.needsStartupRecovery || session.id === retrySessionId
     )
     const hydratedSessions = new Map(
       await Promise.all(
@@ -956,7 +952,7 @@ const loadPersistedSessions = async (
         )
       )
     )
-    const selected = selectedSummary ? hydratedSessions.get(selectedSummary.id) : undefined
+    const selected = retrySessionId ? hydratedSessions.get(retrySessionId) : undefined
     if (!shouldHydrate()) return undefined
     const missing = summariesToHydrate.find((summary) => !hydratedSessions.get(summary.id))
     if (missing) {

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -795,6 +795,28 @@ describe('settings store: onboarding completion', () => {
 })
 
 describe('settings store: startup loading', () => {
+  it('publishes the settings snapshot before startup probes finish', async () => {
+    let resolvePreflight:
+      ((value: { claudeReady: boolean; activeProviderReady: boolean }) => void) | undefined
+    api.getPreflight.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePreflight = resolve
+      })
+    )
+
+    const loading = useSettingsStore.getState().load()
+    await vi.waitFor(() => expect(useSettingsStore.getState().isLoaded).toBe(true))
+
+    expect(useSettingsStore.getState()).toMatchObject({
+      isLoaded: true,
+      isLoading: true,
+      loadError: undefined
+    })
+
+    resolvePreflight?.({ claudeReady: true, activeProviderReady: true })
+    await expect(loading).resolves.toBe(true)
+  })
+
   it('deduplicates concurrent StrictMode startup loads', async () => {
     let resolveSettings: ((value: SettingsSnapshot) => void) | undefined
     api.getSettings.mockReturnValue(
@@ -839,12 +861,12 @@ describe('settings store: startup loading', () => {
     expect(useSettingsStore.getState().onboardingCompletedAt).toBe(222)
   })
 
-  it('keeps startup blocked after an IPC failure and recovers on retry', async () => {
+  it('keeps startup blocked after a Settings authority failure and recovers on retry', async () => {
     const rawError = new Error(
       'EACCES: /Users/private/.open-science/settings.json could not be read'
     )
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    api.getPreflight.mockRejectedValueOnce(rawError)
+    api.getSettings.mockRejectedValueOnce(rawError)
 
     await expect(useSettingsStore.getState().load()).resolves.toBe(false)
     expect(useSettingsStore.getState()).toMatchObject({
@@ -861,6 +883,21 @@ describe('settings store: startup loading', () => {
       isLoading: false,
       loadError: undefined
     })
+  })
+
+  it('keeps valid Settings available when a runtime probe fails', async () => {
+    const rawError = new Error('runtime probe unavailable')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    api.getPreflight.mockRejectedValueOnce(rawError)
+
+    await expect(useSettingsStore.getState().load()).resolves.toBe(true)
+
+    expect(useSettingsStore.getState()).toMatchObject({
+      isLoaded: true,
+      isLoading: false,
+      loadError: undefined
+    })
+    expect(warn).toHaveBeenCalledWith('Settings loading failed', rawError)
   })
 
   it('keeps the newest retry result when an older load finishes later', async () => {

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -367,48 +367,60 @@ const createSettingsStoreState = (
     // generation and remains authoritative over any older request.
     if (!options?.force && settingsLoadPromise) return settingsLoadPromise
     const generation = get().settingsLoadGeneration + 1
+    const shouldInitializeRuntime = options?.force || !get().isLoaded
     set(
-      options?.force || !get().isLoaded
+      shouldInitializeRuntime
         ? { settingsLoadGeneration: generation, isLoading: true, loadError: undefined }
         : { settingsLoadGeneration: generation }
     )
 
     const loadPromise = (async (): Promise<boolean> => {
+      const settingsPromise = window.api.settings.getSettings()
+      const runtimeInitialization = shouldInitializeRuntime
+        ? Promise.all([
+            window.api.settings.getPreflight(),
+            window.api.settings.isEncryptionAvailable(),
+            window.api.settings.isNpmAvailable()
+          ])
+        : undefined
+      // A newer forced load may supersede this generation before it awaits the runtime result.
+      // Attach a rejection handler immediately so a stale subprocess failure is never unhandled.
+      void runtimeInitialization?.catch(() => undefined)
+
       try {
-        const [snapshot, preflight, encryptionAvailable, npmAvailable] = await Promise.all([
-          window.api.settings.getSettings(),
-          get().isLoading ? window.api.settings.getPreflight() : Promise.resolve(undefined),
-          get().isLoading
-            ? window.api.settings.isEncryptionAvailable()
-            : Promise.resolve(undefined),
-          get().isLoading ? window.api.settings.isNpmAvailable() : Promise.resolve(undefined)
-        ])
+        const snapshot = await settingsPromise
 
         if (get().settingsLoadGeneration !== generation) return false
-
-        if (
-          preflight === undefined ||
-          encryptionAvailable === undefined ||
-          npmAvailable === undefined
-        ) {
+        if (!runtimeInitialization) {
           set({ ...applySnapshot(snapshot), loadError: undefined })
           return true
         }
 
-        set({
-          ...applySnapshot(snapshot),
-          ...createRuntimeSetupLoadPatch(preflight, npmAvailable),
-          encryptionAvailable,
-          isLoaded: true,
-          isLoading: false,
-          loadError: undefined
-        })
+        // The persisted Settings authority is enough for an existing user to enter Home. Runtime
+        // probes continue in this same deduplicated pass; first-run onboarding still waits in App.
+        set({ ...applySnapshot(snapshot), isLoaded: true, loadError: undefined })
+
+        try {
+          const [preflight, encryptionAvailable, npmAvailable] = await runtimeInitialization
+          if (get().settingsLoadGeneration !== generation) return false
+
+          set({
+            ...createRuntimeSetupLoadPatch(preflight, npmAvailable),
+            encryptionAvailable,
+            isLoading: false,
+            loadError: undefined
+          })
+        } catch (error) {
+          if (get().settingsLoadGeneration !== generation) return false
+          reportSettingsLoadError(error)
+          set({ isLoading: false, loadError: undefined })
+        }
         return true
       } catch (error) {
         if (get().settingsLoadGeneration !== generation) return false
 
         reportSettingsLoadError(error)
-        if (get().isLoading) {
+        if (shouldInitializeRuntime) {
           set({
             isLoading: false,
             loadError: SAFE_SETTINGS_LOAD_ERROR


### PR DESCRIPTION
## Problem

App startup waited for work that existing users do not need before entering Home:

- Session bootstrap read the complete lightweight SQLite summary catalog and then opened the manifest-selected Session JSON, even though Home only consumes summary metadata.
- Settings bootstrap waited for runtime preflight, encryption, and npm probes before publishing an already-valid persisted Settings snapshot.

This kept the global `Loading saved conversations` and `Loading settings` gates visible longer than the actual startup data dependencies required.

## Proposed change

- Keep the complete lightweight SQLite Session summary catalog at startup so Home counts, recent Sessions, archived Sessions, search titles, notifications, and deep links retain their current complete view.
- Stop opening the manifest-selected Session transcript during ordinary startup. Transcript JSON remains lazy and opens when Workspace selects it.
- Continue eagerly opening Sessions marked for startup recovery, and preserve explicit selected-Session loading when retrying persistence recovery.
- Publish the persisted Settings snapshot as soon as it resolves, while runtime probes continue in the existing deduplicated load pass.
- Let existing users enter Home during those probes; keep first-run onboarding gated until runtime initialization completes.
- Treat a runtime-probe failure as a runtime availability problem instead of misreporting valid Settings as unreadable.

## Scope / non-goals

- No Session summary pagination or new aggregate/search/by-id backend API in this PR.
- No SQLite schema, migration, projection shape, JSON format, write ordering, or IPC contract changes.
- No new persisted state, enum value, or user-visible copy.
- Legacy/web `loadAll` fallback behavior is unchanged.

Historical compatibility: no new compatibility path is required. Existing SQLite projection rebuild/recovery behavior remains in place, and explicit recovery retry still reopens the selected Session.

## Acceptance / validation

- Ordinary SQLite startup hydrates all summaries without opening the manifest-selected Session JSON.
- Startup-recovery Sessions and explicit recovery retry still hydrate full JSON.
- Existing users render Home after the Settings snapshot while probes continue.
- First-run onboarding remains behind runtime initialization.
- Settings authority failures remain blocking; runtime-probe failures do not discard valid Settings.

Local evidence:

- `npm test -- src/renderer/src/lib/session-persistence/session-persistence.test.ts src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx src/renderer/src/stores/settings-store.test.ts src/renderer/src/App.test.tsx` — 4 files, 222 tests passed.
- `npm run typecheck:web` — passed.
- ESLint on the 7 changed renderer files — passed.
- Prettier check on the 7 changed renderer files — passed.
- `npm run test:affected:explain -- --base origin/main --head HEAD` escalates to the complete suite solely because `App.test.tsx` has no module owner. Per the agreed module-focused validation strategy, the complete suite is left to PR CI.

## Review focus

- The distinction between ordinary startup (`preferredSelection` absent) and explicit persistence recovery retry (`preferredSelection` present).
- Whether any existing-user route still requires runtime probe results before Home renders.
- The Settings load generation/deduplication behavior when a forced retry supersedes an in-flight startup load.
