### PR TITLE
fix(settings-usage): stabilize token usage refresh

### DIFF
--- a/src/renderer/src/pages/settings/TokenUsagePanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/TokenUsagePanel.render.test.tsx
@@ -322,6 +322,12 @@ describe('TokenUsagePanel', () => {
     expect(document.body.querySelector('[data-slot="token-usage-summary"]')?.textContent).toContain(
       'Total tokens20'
     )
+
+    await act(async () => {
+      vi.advanceTimersByTime(2 * 60_000)
+    })
+
+    expect(document.body.textContent).toContain('Updated 2 minutes ago')
   })
 
   it('renders the stat strip, 30-day charts, coverage, and period controls', () => {

--- a/src/renderer/src/pages/settings/TokenUsagePanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/TokenUsagePanel.render.test.tsx
@@ -179,7 +179,7 @@ describe('TokenUsagePanel', () => {
     )
   })
 
-  it('refreshes the SQLite usage projection after a durable Session revision changes', async () => {
+  it('keeps the loaded projection stable while Session revisions change', async () => {
     const now = localTime(2026, 8, 15, 18)
     const projection = (inputTokens: number): SessionUsageProjection => ({
       sessionCreatedAt: [now],
@@ -197,10 +197,7 @@ describe('TokenUsagePanel', () => {
       ],
       totalArtifacts: 0
     })
-    const loadUsage = vi
-      .fn()
-      .mockResolvedValueOnce(projection(10))
-      .mockResolvedValueOnce(projection(20))
+    const loadUsage = vi.fn().mockResolvedValue(projection(10))
     window.api = { sessions: { loadUsage } } as unknown as Window['api']
     const persisted = { ...createSession(now), revision: 1 }
 
@@ -221,13 +218,13 @@ describe('TokenUsagePanel', () => {
       )
     })
 
-    expect(loadUsage).toHaveBeenCalledTimes(2)
+    expect(loadUsage).toHaveBeenCalledOnce()
     expect(document.body.querySelector('[data-slot="token-usage-summary"]')?.textContent).toContain(
-      'Total tokens20'
+      'Total tokens10'
     )
   })
 
-  it('refreshes the SQLite usage projection after the Project catalog changes', async () => {
+  it('keeps the loaded projection stable while the Project catalog changes', async () => {
     const now = localTime(2026, 8, 15, 18)
     const projection = (projectCreatedAt: number[]): SessionUsageProjection => ({
       sessionCreatedAt: [],
@@ -237,10 +234,7 @@ describe('TokenUsagePanel', () => {
       usageEvents: [],
       totalArtifacts: 0
     })
-    const loadUsage = vi
-      .fn()
-      .mockResolvedValueOnce(projection([now]))
-      .mockResolvedValueOnce(projection([now, now]))
+    const loadUsage = vi.fn().mockResolvedValue(projection([now]))
     window.api = { sessions: { loadUsage } } as unknown as Window['api']
 
     await act(async () => {
@@ -261,9 +255,72 @@ describe('TokenUsagePanel', () => {
       )
     })
 
-    expect(loadUsage).toHaveBeenCalledTimes(2)
+    expect(loadUsage).toHaveBeenCalledOnce()
     expect(document.body.querySelector('[data-slot="token-usage-summary"]')?.textContent).toContain(
-      'Total projects2'
+      'Total projects1'
+    )
+  })
+
+  it('refreshes on demand without replacing the loaded projection with a loading state', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 7, 15, 18))
+    const now = Date.now()
+    const projection = (inputTokens: number): SessionUsageProjection => ({
+      sessionCreatedAt: [now],
+      projectCreatedAt: [now],
+      artifactCreatedAt: [],
+      runsAt: [now],
+      usageEvents: [
+        {
+          timestamp: now,
+          inputTokens,
+          cacheTokens: 0,
+          outputTokens: 0,
+          rootRunUsage: true
+        }
+      ],
+      totalArtifacts: 0
+    })
+    let resolveRefresh: ((value: SessionUsageProjection) => void) | undefined
+    const loadUsage = vi
+      .fn()
+      .mockResolvedValueOnce(projection(10))
+      .mockImplementationOnce(
+        () =>
+          new Promise<SessionUsageProjection>((resolve) => {
+            resolveRefresh = resolve
+          })
+      )
+    window.api = { sessions: { loadUsage } } as unknown as Window['api']
+
+    await act(async () => {
+      root.render(
+        <TokenUsagePanel sessions={[createSession(now)]} projects={[createProject(now)]} />
+      )
+    })
+
+    expect(document.body.textContent).toContain('Updated now')
+
+    await act(async () => {
+      document.body.querySelector<HTMLButtonElement>('button[aria-label="Refresh"]')?.click()
+    })
+
+    expect(loadUsage).toHaveBeenCalledTimes(2)
+    expect(document.body.querySelector('[data-slot="token-usage-loading"]')).toBeNull()
+    expect(document.body.querySelector('[data-slot="token-usage-summary"]')?.textContent).toContain(
+      'Total tokens10'
+    )
+    expect(document.body.textContent).toContain('Refreshing…')
+
+    await act(async () => {
+      resolveRefresh?.(projection(20))
+      await Promise.resolve()
+    })
+
+    expect(document.body.textContent).not.toContain('Refreshing…')
+    expect(document.body.textContent).toContain('Updated now')
+    expect(document.body.querySelector('[data-slot="token-usage-summary"]')?.textContent).toContain(
+      'Total tokens20'
     )
   })
 

--- a/src/renderer/src/pages/settings/TokenUsagePanel.tsx
+++ b/src/renderer/src/pages/settings/TokenUsagePanel.tsx
@@ -90,6 +90,7 @@ function TokenUsagePanel({
   const { t, i18n } = useTranslation()
   const formatRelative = useRelativeTimeFormat()
   const [currentTime, setCurrentTime] = useState(() => Date.now())
+  const [relativeTimeNow, setRelativeTimeNow] = useState(() => Date.now())
   const now = providedNow ?? currentTime
   const [period, setPeriod] = useState<TokenUsagePeriod>('30-days')
   const [heatmapMetric, setHeatmapMetric] = useState<TokenUsageHeatmapMetric>('totalTokens')
@@ -114,6 +115,7 @@ function TokenUsagePanel({
         const refreshedAt = Date.now()
         setUsageProjectionLoadResult({ projection, lastRefreshedAt: refreshedAt })
         setCurrentTime(refreshedAt)
+        setRelativeTimeNow(refreshedAt)
       })
       .catch(() => {
         if (active) setUsageProjectionLoadResult((current) => ({ ...current, failed: true }))
@@ -125,6 +127,12 @@ function TokenUsagePanel({
       active = false
     }
   }, [usageProjectionLoadAttempt])
+
+  useEffect(() => {
+    if (lastRefreshedAt === undefined) return
+    const intervalId = window.setInterval(() => setRelativeTimeNow(Date.now()), 60_000)
+    return () => window.clearInterval(intervalId)
+  }, [lastRefreshedAt])
 
   useEffect(() => {
     if (providedNow !== undefined) return
@@ -367,7 +375,7 @@ function TokenUsagePanel({
                       <span className="truncate">
                         ·{' '}
                         {t('Updated {{time}}', {
-                          time: formatRelative(lastRefreshedAt, currentTime)
+                          time: formatRelative(lastRefreshedAt, relativeTimeNow)
                         })}
                       </span>
                     ) : null}
@@ -375,7 +383,7 @@ function TokenUsagePanel({
                 ) : lastRefreshedAt ? (
                   <span>
                     {t('Updated {{time}}', {
-                      time: formatRelative(lastRefreshedAt, currentTime)
+                      time: formatRelative(lastRefreshedAt, relativeTimeNow)
                     })}
                   </span>
                 ) : null}

--- a/src/renderer/src/pages/settings/TokenUsagePanel.tsx
+++ b/src/renderer/src/pages/settings/TokenUsagePanel.tsx
@@ -1,4 +1,4 @@
-import { ChartNoAxesCombined, Info } from 'lucide-react'
+import { ChartNoAxesCombined, Info, Loader2, RefreshCw } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -10,7 +10,9 @@ import type { Project } from '../../../../shared/projects'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { useRelativeTimeFormat } from '@/hooks/useDateTimeFormat'
 import { cn } from '@/lib/utils'
+import { SettingsIconAction } from './SettingsLayout'
 import {
   buildTokenUsageAnalytics,
   buildTokenUsageAnalyticsFromProjection,
@@ -31,9 +33,9 @@ type TokenUsagePanelProps = {
 }
 
 type UsageProjectionLoadResult = Readonly<{
-  requestKey: string
   projection?: SessionUsageProjection
   failed?: boolean
+  lastRefreshedAt?: number
 }>
 
 const PERIODS: ReadonlyArray<{ value: TokenUsagePeriod; label: string; shortLabel: string }> = [
@@ -86,6 +88,7 @@ function TokenUsagePanel({
   now: providedNow
 }: TokenUsagePanelProps): React.JSX.Element {
   const { t, i18n } = useTranslation()
+  const formatRelative = useRelativeTimeFormat()
   const [currentTime, setCurrentTime] = useState(() => Date.now())
   const now = providedNow ?? currentTime
   const [period, setPeriod] = useState<TokenUsagePeriod>('30-days')
@@ -94,25 +97,12 @@ function TokenUsagePanel({
     useState<UsageProjectionLoadResult>()
   const [usageProjectionLoadAttempt, setUsageProjectionLoadAttempt] = useState(0)
   const canLoadUsageProjection = typeof window.api?.sessions?.loadUsage === 'function'
-  const usageRevision = sessions
-    .map((session) => `${session.id}:${session.revision ?? 0}`)
-    .join('\u0000')
-  const projectRevision = projects
-    .map((project) => `${project.id}:${project.createdAt}`)
-    .sort()
-    .join('\u0000')
-  const usageProjectionRequestKey = [
-    usageRevision,
-    projectRevision,
-    usageProjectionLoadAttempt
-  ].join('\u0001')
-  const currentUsageProjectionLoadResult =
-    usageProjectionLoadResult?.requestKey === usageProjectionRequestKey
-      ? usageProjectionLoadResult
-      : undefined
-  const usageProjection = currentUsageProjectionLoadResult?.projection
-  const usageProjectionLoadSettled = currentUsageProjectionLoadResult !== undefined
-  const usageProjectionLoadFailed = currentUsageProjectionLoadResult?.failed === true
+  const [isUsageProjectionRefreshing, setIsUsageProjectionRefreshing] =
+    useState(canLoadUsageProjection)
+  const usageProjection = usageProjectionLoadResult?.projection
+  const usageProjectionLoadSettled = usageProjectionLoadResult !== undefined
+  const usageProjectionLoadFailed = usageProjectionLoadResult?.failed === true
+  const lastRefreshedAt = usageProjectionLoadResult?.lastRefreshedAt
 
   useEffect(() => {
     const loadUsage = window.api?.sessions?.loadUsage
@@ -120,17 +110,21 @@ function TokenUsagePanel({
     let active = true
     void loadUsage()
       .then((projection) => {
-        if (active)
-          setUsageProjectionLoadResult({ requestKey: usageProjectionRequestKey, projection })
+        if (!active) return
+        const refreshedAt = Date.now()
+        setUsageProjectionLoadResult({ projection, lastRefreshedAt: refreshedAt })
+        setCurrentTime(refreshedAt)
       })
       .catch(() => {
-        if (active)
-          setUsageProjectionLoadResult({ requestKey: usageProjectionRequestKey, failed: true })
+        if (active) setUsageProjectionLoadResult((current) => ({ ...current, failed: true }))
+      })
+      .finally(() => {
+        if (active) setIsUsageProjectionRefreshing(false)
       })
     return () => {
       active = false
     }
-  }, [usageProjectionRequestKey])
+  }, [usageProjectionLoadAttempt])
 
   useEffect(() => {
     if (providedNow !== undefined) return
@@ -274,7 +268,15 @@ function TokenUsagePanel({
       output: formatNumber(point.outputTokens)
     })
 
-  if (canLoadUsageProjection && usageProjectionLoadFailed) {
+  const refreshUsageProjection = (): void => {
+    setIsUsageProjectionRefreshing(true)
+    setUsageProjectionLoadResult((current) =>
+      current?.projection ? { ...current, failed: false } : undefined
+    )
+    setUsageProjectionLoadAttempt((attempt) => attempt + 1)
+  }
+
+  if (canLoadUsageProjection && usageProjectionLoadFailed && usageProjection === undefined) {
     return (
       <div data-slot="token-usage-panel" className="min-w-0 overflow-x-clip">
         <div role="alert" data-slot="token-usage-load-error" className="px-4 py-6 sm:px-5">
@@ -284,7 +286,7 @@ function TokenUsagePanel({
             variant="outline"
             size="sm"
             className="mt-3"
-            onClick={() => setUsageProjectionLoadAttempt((attempt) => attempt + 1)}
+            onClick={refreshUsageProjection}
           >
             {t('Try again')}
           </Button>
@@ -311,7 +313,7 @@ function TokenUsagePanel({
     <TooltipProvider delayDuration={200}>
       <div data-slot="token-usage-panel" className="min-w-0 overflow-x-clip">
         <section className="flex flex-col gap-5 px-4 pb-5 pt-6 sm:px-5">
-          <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
             <div className="min-w-0 max-w-xl">
               <h1 className="min-w-0 text-xl font-semibold tracking-tight text-foreground [overflow-wrap:anywhere]">
                 {t('Token usage')}
@@ -323,7 +325,7 @@ function TokenUsagePanel({
             <div
               role="group"
               aria-label={t('Time range')}
-              className="grid w-full grid-cols-4 gap-1 rounded-lg bg-muted p-1 sm:w-auto"
+              className="grid w-full grid-cols-4 gap-1 rounded-lg bg-muted p-1 lg:w-auto"
             >
               {PERIODS.map((item) => (
                 <Button
@@ -347,8 +349,59 @@ function TokenUsagePanel({
             </div>
           </div>
 
+          {canLoadUsageProjection ? (
+            <div className="-mt-2 flex min-h-7 items-center justify-between gap-3">
+              <p
+                role="status"
+                aria-live="polite"
+                className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground"
+              >
+                {isUsageProjectionRefreshing ? (
+                  <>
+                    <Loader2
+                      className="size-3.5 shrink-0 animate-spin motion-reduce:animate-none"
+                      aria-hidden="true"
+                    />
+                    <span className="font-medium text-foreground">{t('Refreshing…')}</span>
+                    {lastRefreshedAt ? (
+                      <span className="truncate">
+                        ·{' '}
+                        {t('Updated {{time}}', {
+                          time: formatRelative(lastRefreshedAt, currentTime)
+                        })}
+                      </span>
+                    ) : null}
+                  </>
+                ) : lastRefreshedAt ? (
+                  <span>
+                    {t('Updated {{time}}', {
+                      time: formatRelative(lastRefreshedAt, currentTime)
+                    })}
+                  </span>
+                ) : null}
+              </p>
+              <SettingsIconAction
+                label={t('Refresh')}
+                icon={RefreshCw}
+                disabled={isUsageProjectionRefreshing}
+                className={
+                  isUsageProjectionRefreshing
+                    ? '[&_svg]:animate-spin motion-reduce:[&_svg]:animate-none'
+                    : ''
+                }
+                onClick={refreshUsageProjection}
+              />
+            </div>
+          ) : null}
+
+          {usageProjectionLoadFailed ? (
+            <p role="alert" className="-mt-2 text-xs text-destructive">
+              {t('Could not load token usage.')}
+            </p>
+          ) : null}
+
           <div data-slot="token-usage-summary" className="border-y border-border py-5">
-            <div className="grid grid-cols-2 gap-x-5 gap-y-5 sm:grid-cols-4">
+            <div className="grid grid-cols-2 gap-x-5 gap-y-5 lg:grid-cols-4">
               {tokenSummaryItems.map((item) => (
                 <div key={item.label} className="min-w-0">
                   <p
@@ -378,7 +431,7 @@ function TokenUsagePanel({
               ))}
             </div>
 
-            <div className="mt-5 grid grid-cols-2 gap-x-5 gap-y-5 sm:grid-cols-4">
+            <div className="mt-5 grid grid-cols-2 gap-x-5 gap-y-5 lg:grid-cols-4">
               {entitySummaryItems.map((item) => (
                 <div key={item.totalLabel} className="grid min-w-0 gap-5">
                   {item.newLabel && item.newValue ? (


### PR DESCRIPTION
## Problem

Settings > Usage tied its SQLite projection request key to every Session revision and Project catalog change. A running Session therefore triggered repeated reloads, temporarily replaced the loaded projection with the full loading state, and made the panel flicker.

## Proposed change

- Load the usage projection once when the panel is entered, then refresh only on explicit user action.
- Keep the last successful projection visible during manual refresh and surface a Marketplace-style `Updated …` timestamp and refresh state; a cleaned-up minute ticker keeps the relative timestamp current without reloading usage data.
- Keep initial-load retry behavior, while retaining cached data if a later manual refresh fails.
- Use the responsive two-column summary layout until the Settings surface is wide enough for four columns.

## Scope and non-goals

- Renderer-only Settings change; no IPC or backend contract changes.
- No historical data compatibility work is required because no stored format or read path changes.
- No enum or state-machine values are added.
- No persistence, schema, or migration changes are introduced; the refresh timestamp is component-local state.
- Automatic interval refresh is intentionally not added. Re-entering the panel or pressing Refresh obtains a new projection.

## Acceptance criteria and validation

The following checks ran after the last material edit:

- Session/Project updates do not reload the projection, and manual refresh preserves the loaded summary: `npm test -- src/renderer/src/pages/settings/TokenUsagePanel.render.test.tsx` -> 9 tests passed.
- Existing translated refresh/status copy remains valid in all renderer locales: `npx vitest run src/renderer/src/i18n/resources.test.ts` -> 590 tests passed.
- Renderer type safety: `npm run typecheck:web` -> passed.
- Source lint: `npm run lint` -> passed with 0 errors and 2 pre-existing, unrelated Prettier warnings in `src/main/acp/application-commands.ts` and `src/main/acp/ipc.ts`.
- Web production render: `npm run build:web` -> passed.
- Responsive layout: Web UI inspection at 320, 375, 414, and 768 CSS px -> passed with no panel overflow, clipped values, or loading-state replacement. The final exact-head macOS visual regression also passed after the non-layout timestamp ticker follow-up.

The local exact-head impact explainer conservatively reported a full fallback because the changed renderer test has no local module owner. The trusted PR Gate classified the final PR diff selectively and passed its selected static, Module test/coverage, and macOS build/E2E lanes, including functional, workspace, accessibility, and visual journeys. Per maintainer direction, the complete `npm test` suite was not duplicated locally; trusted PR Gate remains authoritative for the selected portable and platform coverage.

## Review focus

- Confirm a running Session no longer causes Usage to reload or flicker.
- Confirm Refresh retains stale data until the new projection succeeds and updates the displayed timestamp.
- Confirm the compact status/action row follows the Specialist Marketplace interaction pattern.
