### PR TITLE
fix(connectors): handle versioned IDs and request timeouts

### DIFF
--- a/src/main/connectors/descriptors/genomes-ensembl.test.ts
+++ b/src/main/connectors/descriptors/genomes-ensembl.test.ts
@@ -60,12 +60,20 @@ describe('ensembl_lookup', () => {
     expect(String(fetchImpl.mock.calls[0][0])).toContain('/lookup/symbol/homo_sapiens/BRAF')
   })
 
-  it('accepts a versioned stable ID and LRG id on the ID route', async () => {
-    for (const q of ['ENSG00000157764.16', 'LRG_299']) {
-      const fetchImpl = vi.fn().mockResolvedValueOnce(jsonRes({ id: q }))
-      await run('ensembl_lookup', { query: q }, fetchImpl)
-      expect(String(fetchImpl.mock.calls[0][0])).toContain(`/lookup/id/${encodeURIComponent(q)}`)
-    }
+  it('removes an Ensembl version suffix before calling the stable-ID endpoint', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(jsonRes({ id: 'ENST00000422447' }))
+
+    await run('ensembl_lookup', { query: 'ENST00000422447.8' }, fetchImpl)
+
+    expect(String(fetchImpl.mock.calls[0][0])).toContain('/lookup/id/ENST00000422447?expand=0')
+  })
+
+  it('keeps an LRG id unchanged on the stable-ID route', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(jsonRes({ id: 'LRG_299' }))
+
+    await run('ensembl_lookup', { query: 'LRG_299' }, fetchImpl)
+
+    expect(String(fetchImpl.mock.calls[0][0])).toContain('/lookup/id/LRG_299?expand=0')
   })
 
   it('maps an upstream 400 to found:false, record:null', async () => {
@@ -80,6 +88,17 @@ describe('ensembl_lookup', () => {
 })
 
 describe('ensembl_xrefs', () => {
+  it('removes an Ensembl version suffix before calling the stable-ID endpoint', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(jsonRes([]))
+
+    const out = (await run('ensembl_xrefs', { stable_id: 'ENST00000422447.8' }, fetchImpl)) as {
+      stable_id: string
+    }
+
+    expect(String(fetchImpl.mock.calls[0][0])).toContain('/xrefs/id/ENST00000422447?')
+    expect(out.stable_id).toBe('ENST00000422447.8')
+  })
+
   it('sorts by (dbname, primary_id) and passes external_db through', async () => {
     const rows = [
       { dbname: 'HGNC', primary_id: 'HGNC:1097', display_id: 'BRAF' },
@@ -237,6 +256,21 @@ describe('ensembl_homology', () => {
 })
 
 describe('ensembl_sequence', () => {
+  it('removes an Ensembl version suffix before calling the stable-ID endpoint', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes({ id: 'ENST00000422447', molecule: 'dna', seq: 'ACGT' }))
+
+    const out = (await run(
+      'ensembl_sequence',
+      { stable_id: 'ENST00000422447.8', seq_type: 'cdna' },
+      fetchImpl
+    )) as { query: string }
+
+    expect(String(fetchImpl.mock.calls[0][0])).toContain('/sequence/id/ENST00000422447?type=cdna')
+    expect(out.query).toBe('ENST00000422447.8')
+  })
+
   it('computes length + sha256 for a stable-ID sequence', async () => {
     const seq = 'ACGTACGTAC'
     const fetchImpl = vi

--- a/src/main/connectors/descriptors/genomes-ensembl.ts
+++ b/src/main/connectors/descriptors/genomes-ensembl.ts
@@ -13,6 +13,11 @@ const STABLE_ID_RE = /^(ENS([A-Z]{3,4})?[EGTP]\d{6,}(\.\d+)?|LRG_\d+)$/
 
 const isStableId = (query: string): boolean => STABLE_ID_RE.test(query.trim())
 
+// Ensembl records expose versioned ids, but its lookup/xref/sequence routes accept only the stable
+// base. Keep echoing the caller's exact query while normalizing only the upstream path segment.
+const upstreamStableId = (query: string): string =>
+  isStableId(query) ? query.replace(/\.\d+$/, '') : query
+
 // Reads an integer arg, applying a default when unset and clamping into [lo, hi].
 function clampInt(v: unknown, def: number, lo: number, hi: number): number {
   const n = typeof v === 'number' ? v : Number(v)
@@ -186,7 +191,7 @@ export const GENOMES_ENSEMBL_TOOLS: ToolDescriptor[] = [
       const species = String(a.species ?? DEFAULT_SPECIES)
       const expand = a.expand === true ? 1 : 0
       const url = isStableId(query)
-        ? `${ENSEMBL}/lookup/id/${encodeURIComponent(query)}?expand=${expand}`
+        ? `${ENSEMBL}/lookup/id/${encodeURIComponent(upstreamStableId(query))}?expand=${expand}`
         : `${ENSEMBL}/lookup/symbol/${encodeURIComponent(species)}/${encodeURIComponent(query)}?expand=${expand}`
       try {
         const record = await ctx.fetchJson(url)
@@ -201,7 +206,7 @@ export const GENOMES_ENSEMBL_TOOLS: ToolDescriptor[] = [
     id: 'ensembl_xrefs',
     connector: 'genomes',
     description:
-      'External cross-references of an Ensembl stable ID — the bridge from Ensembl gene/transcript IDs to HGNC, NCBI (EntrezGene), UniProt, OMIM, RefSeq, Expression Atlas and others. Args: stable_id (ENSG.../ENST...); external_db (optional exact upstream database-name filter, e.g. HGNC, EntrezGene, Uniprot_gn, MIM_GENE, RefSeq_mRNA; omit for all). Returns {stable_id, external_db, n_xrefs, xrefs} — the COMPLETE list (never truncated), sorted by (dbname, primary_id); each row {dbname, db_display_name, primary_id, display_id, description, synonyms, info_type}. Unknown IDs return n_xrefs:0.',
+      'External cross-references of an Ensembl stable ID — the bridge from Ensembl gene/transcript IDs to HGNC, NCBI (EntrezGene), UniProt, OMIM, RefSeq, Expression Atlas and others. Args: stable_id (ENSG.../ENST..., versioned accepted); external_db (optional exact upstream database-name filter, e.g. HGNC, EntrezGene, Uniprot_gn, MIM_GENE, RefSeq_mRNA; omit for all). Returns {stable_id, external_db, n_xrefs, xrefs} — the COMPLETE list (never truncated), sorted by (dbname, primary_id); each row {dbname, db_display_name, primary_id, display_id, description, synonyms, info_type}. Unknown IDs return n_xrefs:0.',
     input: {
       type: 'object',
       properties: {
@@ -218,7 +223,7 @@ export const GENOMES_ENSEMBL_TOOLS: ToolDescriptor[] = [
     run: async (ctx, a) => {
       const stableId = String(a.stable_id).trim()
       const externalDb = strArg(a.external_db) ?? ''
-      const url = `${ENSEMBL}/xrefs/id/${encodeURIComponent(stableId)}?external_db=${encodeURIComponent(externalDb)}`
+      const url = `${ENSEMBL}/xrefs/id/${encodeURIComponent(upstreamStableId(stableId))}?external_db=${encodeURIComponent(externalDb)}`
       let rows: Dict[]
       try {
         rows = ((await ctx.fetchJson(url)) as Dict[] | undefined) ?? []
@@ -352,7 +357,7 @@ export const GENOMES_ENSEMBL_TOOLS: ToolDescriptor[] = [
     id: 'ensembl_sequence',
     connector: 'genomes',
     description:
-      'Fetch sequence from Ensembl — by stable ID (gene/transcript/protein) or by genomic region. Pass EITHER stable_id OR region. Args: stable_id (ENSG.../ENST.../ENSP...); region (1-based inclusive chrom:start..end or chrom:start-end, GRCh38 for human, max 10Mb); species (for region route, default homo_sapiens; ignored for stable IDs); seq_type (ID route: genomic default/cdna/cds/protein — protein only for ENST/ENSP; ignored for regions which always return genomic); max_bytes (payload guard default 400000 — larger sequences have `seq` omitted; length/sha256/metadata always returned; re-call with larger max_bytes for full text). Returns {found, query, seq_type, id, description, molecule, length, sha256, seq} — length in the unit implied by molecule (bases for dna, residues for protein); seq replaced by seq_omitted when capped; found:false with null fields for unknown stable IDs; malformed/oversized regions raise with the upstream message.',
+      'Fetch sequence from Ensembl — by stable ID (gene/transcript/protein) or by genomic region. Pass EITHER stable_id OR region. Args: stable_id (ENSG.../ENST.../ENSP..., versioned accepted); region (1-based inclusive chrom:start..end or chrom:start-end, GRCh38 for human, max 10Mb); species (for region route, default homo_sapiens; ignored for stable IDs); seq_type (ID route: genomic default/cdna/cds/protein — protein only for ENST/ENSP; ignored for regions which always return genomic); max_bytes (payload guard default 400000 — larger sequences have `seq` omitted; length/sha256/metadata always returned; re-call with larger max_bytes for full text). Returns {found, query, seq_type, id, description, molecule, length, sha256, seq} — length in the unit implied by molecule (bases for dna, residues for protein); seq replaced by seq_omitted when capped; found:false with null fields for unknown stable IDs; malformed/oversized regions raise with the upstream message.',
     input: {
       type: 'object',
       properties: {
@@ -386,7 +391,7 @@ export const GENOMES_ENSEMBL_TOOLS: ToolDescriptor[] = [
       if (stableId) {
         try {
           resp = (await ctx.fetchJson(
-            `${ENSEMBL}/sequence/id/${encodeURIComponent(stableId)}?type=${encodeURIComponent(seqType)}`
+            `${ENSEMBL}/sequence/id/${encodeURIComponent(upstreamStableId(stableId))}?type=${encodeURIComponent(seqType)}`
           )) as Dict
         } catch (err) {
           if (isNotFound(err)) {

--- a/src/main/connectors/engine.test.ts
+++ b/src/main/connectors/engine.test.ts
@@ -124,13 +124,20 @@ describe('ParserEngine declarative path', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(3)
   })
 
-  it('disarms the request timeout once the upstream response arrives', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => new Promise((resolve) => setTimeout(() => resolve({ value: 9 }), 20))
-    } as Response)
-    const engine = new ParserEngine({ fetchImpl, timeoutMs: 5, retries: 2, retryBackoffMs: 0 })
+  it('resets the timeout while response body chunks keep arriving', async () => {
+    const encoder = new TextEncoder()
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            setTimeout(() => controller.enqueue(encoder.encode('{"value":')), 10)
+            setTimeout(() => controller.enqueue(encoder.encode('9}')), 20)
+            setTimeout(() => controller.close(), 40)
+          }
+        })
+      )
+    )
+    const engine = new ParserEngine({ fetchImpl, timeoutMs: 30, retries: 2, retryBackoffMs: 0 })
     const desc: ToolDescriptor = {
       id: 't',
       connector: 'c',
@@ -142,6 +149,49 @@ describe('ParserEngine declarative path', () => {
 
     await expect(engine.call(desc, {}, {})).resolves.toBe(9)
     expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
+  it('times out and retries when a response body stops producing chunks', async () => {
+    const encoder = new TextEncoder()
+    const fetchImpl = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit): Promise<Response> =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(encoder.encode('{"value":'))
+              init?.signal?.addEventListener('abort', () => controller.error(init.signal?.reason), {
+                once: true
+              })
+            }
+          })
+        )
+    )
+    const engine = new ParserEngine({
+      fetchImpl,
+      timeoutMs: 5,
+      retries: 2,
+      retryBackoffMs: 0
+    })
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      url: () => 'https://x.test/data',
+      parse: (raw) => raw
+    }
+    const result = engine.call(desc, {}, {}).catch((error: unknown) => error)
+
+    await expect(
+      Promise.race([
+        result,
+        new Promise((resolve) => setTimeout(() => resolve('still pending'), 100))
+      ])
+    ).resolves.toMatchObject({
+      name: 'ConnectorRequestTimeoutError',
+      message: 'Connector request timed out after 3 attempts of 5ms for https://x.test/data'
+    })
+    expect(fetchImpl).toHaveBeenCalledTimes(3)
   })
 
   it('aborts an active request without retrying it', async () => {

--- a/src/main/connectors/engine.test.ts
+++ b/src/main/connectors/engine.test.ts
@@ -92,6 +92,58 @@ describe('ParserEngine declarative path', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2)
   })
 
+  it('reports the request and retry budget when every attempt times out', async () => {
+    const fetchImpl = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit): Promise<Response> =>
+        new Promise((_, reject) => {
+          const requestSignal = init?.signal
+          requestSignal?.addEventListener('abort', () => reject(requestSignal.reason), {
+            once: true
+          })
+        })
+    )
+    const engine = new ParserEngine({
+      fetchImpl,
+      timeoutMs: 5,
+      retries: 2,
+      retryBackoffMs: 0
+    })
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      url: () => 'https://x.test/data',
+      parse: (raw) => raw
+    }
+
+    await expect(engine.call(desc, {}, {})).rejects.toMatchObject({
+      name: 'ConnectorRequestTimeoutError',
+      message: 'Connector request timed out after 3 attempts of 5ms for https://x.test/data'
+    })
+    expect(fetchImpl).toHaveBeenCalledTimes(3)
+  })
+
+  it('disarms the request timeout once the upstream response arrives', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => new Promise((resolve) => setTimeout(() => resolve({ value: 9 }), 20))
+    } as Response)
+    const engine = new ParserEngine({ fetchImpl, timeoutMs: 5, retries: 2, retryBackoffMs: 0 })
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      url: () => 'https://x.test/data',
+      parse: (raw) => (raw as { value: number }).value
+    }
+
+    await expect(engine.call(desc, {}, {})).resolves.toBe(9)
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
   it('aborts an active request without retrying it', async () => {
     let observedSignal: AbortSignal | undefined
     const fetchImpl = vi.fn(

--- a/src/main/connectors/engine.ts
+++ b/src/main/connectors/engine.ts
@@ -52,6 +52,16 @@ function redactUrl(url: string): string {
   }
 }
 
+class ConnectorRequestTimeoutError extends Error {
+  override readonly name = 'ConnectorRequestTimeoutError'
+
+  constructor(url: string, timeoutMs: number, attempts: number) {
+    super(
+      `Connector request timed out after ${attempts} ${attempts === 1 ? 'attempt' : 'attempts'} of ${timeoutMs}ms for ${redactUrl(url)}`
+    )
+  }
+}
+
 // Generic executor shared by every connector: declarative { url, parse } or a run() escape hatch.
 export class ParserEngine {
   private readonly fetchImpl: typeof fetch
@@ -120,10 +130,14 @@ export class ParserEngine {
           })
         } catch (err) {
           if (signal?.aborted) throw err
+          const timedOut = controller.signal.aborted
           // Network failure or timeout abort — retry a bounded number of times, then give up.
           if (attempt < this.retries) {
             await sleep(nextDelay(attempt, null), signal)
             continue
+          }
+          if (timedOut) {
+            throw new ConnectorRequestTimeoutError(url, this.timeoutMs, attempt + 1)
           }
           throw err
         } finally {

--- a/src/main/connectors/engine.ts
+++ b/src/main/connectors/engine.ts
@@ -114,23 +114,63 @@ export class ParserEngine {
       return Math.min(this.backoffMs * 2 ** attempt, 4_000) + Math.random() * this.backoffMs
     }
 
-    const doFetch = async (url: string, accept: string, init?: RequestInit): Promise<Response> => {
+    const doFetch = async (
+      url: string,
+      accept: string,
+      init?: RequestInit
+    ): Promise<{ response: Response; bodyText?: string }> => {
       for (let attempt = 0; ; attempt++) {
         const controller = new AbortController()
-        const timer = setTimeout(() => controller.abort(), this.timeoutMs)
+        let timer: ReturnType<typeof setTimeout> | undefined
+        let timedOut = false
+        const armTimeout = (): void => {
+          if (timer) clearTimeout(timer)
+          timer = setTimeout(() => {
+            timedOut = true
+            controller.abort()
+          }, this.timeoutMs)
+        }
         const requestSignal = signal
           ? AbortSignal.any([controller.signal, signal])
           : controller.signal
-        let res: Response
+        let res: Response | undefined
+        let bodyText: string | undefined
+        let caught = false
+        let failure: unknown
         try {
+          armTimeout()
           res = await this.fetchImpl(url, {
             ...init,
             headers: { accept, 'user-agent': USER_AGENT, ...init?.headers },
             signal: requestSignal
           })
+          if (res.ok && res.body) {
+            const reader = res.body.getReader()
+            const decoder = new TextDecoder()
+            const chunks: string[] = []
+            try {
+              armTimeout()
+              for (;;) {
+                const chunk = await reader.read()
+                if (chunk.done) break
+                if (chunk.value.byteLength === 0) continue
+                chunks.push(decoder.decode(chunk.value, { stream: true }))
+                armTimeout()
+              }
+              chunks.push(decoder.decode())
+              bodyText = chunks.join('')
+            } finally {
+              reader.releaseLock()
+            }
+          }
         } catch (err) {
-          if (signal?.aborted) throw err
-          const timedOut = controller.signal.aborted
+          caught = true
+          failure = err
+        } finally {
+          if (timer) clearTimeout(timer)
+        }
+        if (caught) {
+          if (signal?.aborted) throw failure
           // Network failure or timeout abort — retry a bounded number of times, then give up.
           if (attempt < this.retries) {
             await sleep(nextDelay(attempt, null), signal)
@@ -139,13 +179,12 @@ export class ParserEngine {
           if (timedOut) {
             throw new ConnectorRequestTimeoutError(url, this.timeoutMs, attempt + 1)
           }
-          throw err
-        } finally {
-          clearTimeout(timer)
+          throw failure
         }
+        if (!res) throw new Error(`No response for ${redactUrl(url)}`)
         if (res.ok) {
           signal?.throwIfAborted()
-          return res
+          return { response: res, ...(bodyText !== undefined ? { bodyText } : {}) }
         }
         // Retry only transient upstream statuses; client errors (4xx except 429) fail fast.
         if (attempt < this.retries && RETRYABLE_STATUS.has(res.status)) {
@@ -158,20 +197,29 @@ export class ParserEngine {
     return {
       ...(signal ? { signal } : {}),
       credentials,
-      fetchJson: async (url) => (await doFetch(url, 'application/json')).json(),
-      fetchJsonWithHeaders: async (url) => {
-        const res = await doFetch(url, 'application/json')
-        return { body: await res.json(), headers: res.headers }
+      fetchJson: async (url) => {
+        const { response, bodyText } = await doFetch(url, 'application/json')
+        return bodyText === undefined ? response.json() : JSON.parse(bodyText)
       },
-      fetchText: async (url) => (await doFetch(url, 'text/plain, application/xml, */*')).text(),
-      postJson: async (url, body) =>
-        (
-          await doFetch(url, 'application/json', {
-            method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify(body)
-          })
-        ).json()
+      fetchJsonWithHeaders: async (url) => {
+        const { response, bodyText } = await doFetch(url, 'application/json')
+        return {
+          body: bodyText === undefined ? await response.json() : JSON.parse(bodyText),
+          headers: response.headers
+        }
+      },
+      fetchText: async (url) => {
+        const { response, bodyText } = await doFetch(url, 'text/plain, application/xml, */*')
+        return bodyText === undefined ? response.text() : bodyText
+      },
+      postJson: async (url, body) => {
+        const { response, bodyText } = await doFetch(url, 'application/json', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(body)
+        })
+        return bodyText === undefined ? response.json() : JSON.parse(bodyText)
+      }
     }
   }
 }


### PR DESCRIPTION
## Problem

Notebook Connector calls exposed two deterministic integration failures:

- Ensembl lookup responses include versioned stable IDs such as `ENST00000422447.8`, while the lookup, xrefs, and sequence endpoints reject that suffix when the returned ID is reused.
- Exhausting the Connector engine's three 30-second request attempts surfaced only `AbortError: This operation was aborted`, making the roughly 90-second upstream request budget look like a Notebook REPL timeout and hiding which request failed.
- The 30-second timer stopped after response headers arrived, so a response body that started and then stalled could wait until the outer Notebook deadline.

## Proposed change

- Strip a numeric Ensembl version suffix only from the upstream request path for lookup, xrefs, and sequence calls, while preserving the caller's original query in returned data.
- Distinguish an internally exhausted request deadline from caller cancellation and report the redacted request URL, attempt count, and per-attempt timeout.
- Treat the 30-second request deadline as an idle timeout: apply it while waiting for response headers and reset it whenever a non-empty response body chunk arrives. Retry a body stream that stalls just like a connection timeout.
- Cover versioned gene/transcript/protein IDs, LRG preservation, retry exhaustion, caller cancellation, long active streams, and streams that stop after partial content.

## Scope and non-goals

- Keep the existing 30-second per-attempt timeout and two-retry policy.
- Keep the Notebook execution deadline as the overall bound; active response streams are not assigned a second fixed total duration.
- Do not return partial results from multi-request tools such as `gtex_expression_summary`.
- Do not add aliases for guessed Connector IDs or methods; the generated Connector Skills already provide the canonical names.
- No historical-data compatibility, new state/enum values, or persistence changes.

## Acceptance criteria and validation

All listed checks ran against the final material state.

- Versioned Ensembl IDs are accepted without changing caller-facing queries -> `vitest run src/main/connectors` -> pass across the Connector module after rerunning the two loopback-dependent files outside the sandbox (56 files total; 39 skipped).
- Exhausted internal deadlines produce a specific timeout error while caller aborts remain `AbortError`; active body streams can exceed 30 seconds while stalled streams time out -> `vitest run src/main/connectors/engine.test.ts` -> 15 passed.
- Shared Connector engine and descriptor consumers remain type-safe -> `tsc --noEmit -p tsconfig.node.json --composite false` -> passed.
- Changed files satisfy lint and whitespace checks -> targeted ESLint plus `git diff --check origin/main...HEAD` -> passed.

The dependency-impact classifier falls back to the complete suite because the Ensembl descriptor test has no declared module owner. Per the agreed validation scope, the complete `npm test` suite was not run locally; exact-head PR CI is authoritative for that uncovered risk.

## Review focus

- Confirm version stripping remains limited to valid Ensembl stable IDs with numeric suffixes.
- Confirm internal request timeouts are distinguished from caller-driven cancellation without changing retry behavior.
- Confirm only non-empty response chunks reset the idle timeout and the outer Notebook deadline remains the total bound.
