### PR TITLE
fix(notebook): scope Python call uncertainty

### DIFF
--- a/src/main/notebook/dependency-analysis-python.ts
+++ b/src/main/notebook/dependency-analysis-python.ts
@@ -1390,7 +1390,7 @@ class FunctionEffectVisitor extends NodeVisitor {
   }
 
   visit_FunctionDef(): void {
-    this.unknown()
+    this.unknown(true)
   }
   visit_AsyncFunctionDef = this.visit_FunctionDef
   visit_Lambda(): void {

--- a/src/main/notebook/dependency-analysis-python.ts
+++ b/src/main/notebook/dependency-analysis-python.ts
@@ -1409,6 +1409,25 @@ class FunctionEffectVisitor extends NodeVisitor {
   visit_DictComp = this.visit_ListComp
   visit_GeneratorExp = this.visit_ListComp
 
+  visitImplicitEffect(node: PyNode): void {
+    this.unknown()
+    this.genericVisit(node)
+  }
+  visit_With = this.visitImplicitEffect
+  visit_AsyncWith = this.visitImplicitEffect
+  visit_For = this.visitImplicitEffect
+  visit_AsyncFor = this.visitImplicitEffect
+  visit_Await = this.visitImplicitEffect
+  visit_Yield = this.visitImplicitEffect
+  visit_YieldFrom = this.visitImplicitEffect
+
+  visitImport(node: PyNode): void {
+    this.unknown(true)
+    this.genericVisit(node)
+  }
+  visit_Import = this.visitImport
+  visit_ImportFrom = this.visitImport
+
   visit_Assign(node: PyNode): void {
     if (
       (node.targets ?? []).some(
@@ -1691,6 +1710,12 @@ class Analyzer extends NodeVisitor {
 
   addPossibleAlias(target: string, source: string, access?: string, member?: string): void {
     this.possibleAliases.add(`${target}\0${source}\0${access ?? ''}\0${member ?? ''}`)
+  }
+
+  clearPossibleAliases(target: string): void {
+    for (const alias of this.possibleAliases) {
+      if (alias.split('\0', 1)[0] === target) this.possibleAliases.delete(alias)
+    }
   }
 
   visibleRootName(node: PyNode | null | undefined): string | undefined {
@@ -2050,8 +2075,11 @@ class Analyzer extends NodeVisitor {
     if (conditional) {
       this.unknown.add('control-flow')
       for (const name of targetNames) this.conditionallyDefined.add(name)
+    } else {
+      for (const name of targetNames) this.conditionallyDefined.delete(name)
     }
     for (const name of targetNames) {
+      if (!conditional) this.clearPossibleAliases(name)
       this.importedModules.delete(name)
       this.importedFunctions.delete(name)
       this.typeBindings = this.typeBindings.filter((binding) => binding.target !== name)
@@ -2752,8 +2780,16 @@ const analyzePythonTree = (root: Node): NotebookRunDependencyFacts => {
   const analyzer = new Analyzer(scopedEffectLoops(tree))
   analyzer.visit(tree)
   const facts = factsFromAnalyzer(analyzer)
-  if (analyzer.unknown.size) {
-    return { state: 'unknown', reasons: [...analyzer.unknown].sort(), ...facts }
+  const reasons = new Set(analyzer.unknown)
+  const hasRemainingConditionalEffects =
+    analyzer.conditionallyDefined.size > 0 ||
+    analyzer.possiblyMutated.size > 0 ||
+    analyzer.possibleAliases.size > 0 ||
+    analyzer.receiverCalls.some((call) => call.conditional) ||
+    analyzer.memberWrites.some((write) => write.conditional)
+  if (!hasRemainingConditionalEffects) reasons.delete('control-flow')
+  if (reasons.size) {
+    return { state: 'unknown', reasons: [...reasons].sort(), ...facts }
   }
   return { state: 'available', ...facts }
 }

--- a/src/main/notebook/dependency-analysis-python.ts
+++ b/src/main/notebook/dependency-analysis-python.ts
@@ -50,13 +50,9 @@ const SAFE_CALLS = new Set([
   'filter',
   'float',
   'frozenset',
-  'getattr',
   'hash',
-  'hasattr',
   'id',
   'int',
-  'isinstance',
-  'issubclass',
   'len',
   'list',
   'map',
@@ -78,6 +74,7 @@ const SAFE_CALLS = new Set([
 ])
 const EXTERNAL_READ_CALLS = new Set(['open'])
 const SCOPED_MUTATION_CALLS = new Set(['next'])
+const SCOPED_OPAQUE_CALLS = new Set(['getattr', 'hasattr', 'isinstance', 'issubclass'])
 const SAFE_LITERAL_METHODS = new Set([
   'capitalize',
   'casefold',
@@ -1974,6 +1971,7 @@ class Analyzer extends NodeVisitor {
       const methods = Object.entries(summary.methods).map(([methodName, effect]) => ({
         name: methodName,
         effect: effect.effect,
+        ...(effect.unknownScope ? { unknownScope: effect.unknownScope } : {}),
         ...(effect.returnType ? { returnType: effect.returnType } : {}),
         ...(effect.destructuredReturnTypes
           ? { destructuredReturnTypes: effect.destructuredReturnTypes }
@@ -2006,6 +2004,7 @@ class Analyzer extends NodeVisitor {
     const method = {
       name: '__call__',
       effect: effect.effect,
+      ...(effect.unknownScope ? { unknownScope: effect.unknownScope } : {}),
       ...(effect.returnType ? { returnType: effect.returnType } : {}),
       ...(effect.destructuredReturnTypes
         ? { destructuredReturnTypes: effect.destructuredReturnTypes }
@@ -2189,6 +2188,7 @@ class Analyzer extends NodeVisitor {
       !DYNAMIC_CALLS.has(value.func.id) &&
       !EXTERNAL_READ_CALLS.has(value.func.id) &&
       !SCOPED_MUTATION_CALLS.has(value.func.id) &&
+      !SCOPED_OPAQUE_CALLS.has(value.func.id) &&
       !this.importedFunctions.has(value.func.id)
     let constructorArguments = new Set<string>()
     if (constructor && value) {
@@ -2460,6 +2460,8 @@ class Analyzer extends NodeVisitor {
       this.unknown.add('opaque-call')
       this.unknown.add('dynamic-namespace')
     }
+    if (libraryEffect?.scopedOpaque) this.unknown.add('scoped-opaque-call')
+    if (libraryEffect?.externalState) this.unknown.add('external-state')
     const formulaRule = libraryEffect?.formulaArgument
     if (formulaRule) {
       const args = Array.isArray(node.args) ? node.args : []
@@ -2543,6 +2545,23 @@ class Analyzer extends NodeVisitor {
       )
       for (const name of possible) this.safeCallArgumentNames.add(name)
       for (const name of possible) this.possiblyMutated.add(name)
+      if (possible.size) this.unknown.add('opaque-mutation')
+    } else if (
+      isPyNode(node.func) &&
+      node.func.type === 'Name' &&
+      SCOPED_OPAQUE_CALLS.has(node.func.id ?? '')
+    ) {
+      this.safeCallNames.add(node.func.id ?? '')
+      const possible = new Set(
+        [...args, ...(node.keywords ?? []).map((keyword) => keyword.value)]
+          .map((candidate) => this.visibleRootName(candidate))
+          .filter((name): name is string => Boolean(name))
+      )
+      for (const name of possible) {
+        this.safeCallArgumentNames.add(name)
+        this.possiblyMutated.add(name)
+      }
+      this.unknown.add('scoped-opaque-call')
       if (possible.size) this.unknown.add('opaque-mutation')
     } else if (
       isPyNode(node.func) &&

--- a/src/main/notebook/dependency-analysis-python.ts
+++ b/src/main/notebook/dependency-analysis-python.ts
@@ -1406,6 +1406,12 @@ class FunctionEffectVisitor extends NodeVisitor {
   visit_DictComp = this.visit_ListComp
   visit_GeneratorExp = this.visit_ListComp
 
+  visit_Return(node: PyNode): void {
+    const value = isPyNode(node.value) ? node.value : undefined
+    if (value && value.type !== 'Constant') this.unknown(true)
+    this.genericVisit(node)
+  }
+
   visitImplicitEffect(node: PyNode): void {
     this.unknown()
     this.genericVisit(node)
@@ -2030,7 +2036,7 @@ class Analyzer extends NodeVisitor {
         name: callableType,
         kind: 'python-class',
         fields: [],
-        methods: [{ name: '__call__', effect: 'unknown', unknownScope: 'receiver' }]
+        methods: [{ name: '__call__', effect: 'unknown', unknownScope: 'namespace' }]
       })
     }
     this.typeBindings.push({ target, typeName: callableType, argumentNames: [] })

--- a/src/main/notebook/dependency-analysis-python.ts
+++ b/src/main/notebook/dependency-analysis-python.ts
@@ -2223,7 +2223,11 @@ class Analyzer extends NodeVisitor {
     ) {
       if (memberSource) this.addPossibleAlias(target.id, memberSource, memberAccess, member)
       if (value.type === 'Attribute' && importedMemberModule && member) {
-        this.bindUnknownImport(target.id, importedMemberModule, member)
+        this.bindLibraryModule(target.id, `${importedMemberModule}.${member}`)
+        this.bindLibraryFunction(target.id, importedMemberModule, member)
+        if (!this.importedModules.has(target.id) && !this.importedFunctions.has(target.id)) {
+          this.bindUnknownImport(target.id, importedMemberModule, member)
+        }
       }
     } else if (
       constructor &&

--- a/src/main/notebook/dependency-analysis-python.ts
+++ b/src/main/notebook/dependency-analysis-python.ts
@@ -1680,6 +1680,15 @@ class Analyzer extends NodeVisitor {
     else this.priorUsed.set(name, priorCount - 1)
   }
 
+  addMutation(name: string): void {
+    if (this.controlDepth > 0) this.possiblyMutated.add(name)
+    else this.mutated.add(name)
+  }
+
+  conditionalFact(): { conditional?: true } {
+    return this.controlDepth > 0 ? { conditional: true } : {}
+  }
+
   addPossibleAlias(target: string, source: string, access?: string, member?: string): void {
     this.possibleAliases.add(`${target}\0${source}\0${access ?? ''}\0${member ?? ''}`)
   }
@@ -2074,7 +2083,7 @@ class Analyzer extends NodeVisitor {
       if (this.controlDepth > 0) this.conditionallyDefined.add(node.id)
     } else if (node.ctx === 'Del') {
       this.prepareAssignment([node.id])
-      this.mutated.add(node.id)
+      this.addMutation(node.id)
     }
   }
 
@@ -2348,11 +2357,12 @@ class Analyzer extends NodeVisitor {
     if (name) {
       this.addUsed(name)
       const patchedMember = node.target ? dynamicMemberWrite(node.target) : undefined
-      if (!patchedMember || !patchedMember[1]) this.mutated.add(name)
+      if (!patchedMember || !patchedMember[1]) this.addMutation(name)
       if (patchedMember) {
         const [member, typeWide] = patchedMember
         this.memberWrites.push({
           receiver: name,
+          ...this.conditionalFact(),
           ...(member ? { member } : {}),
           ...(typeWide ? { scope: 'type' as const } : {})
         })
@@ -2371,11 +2381,12 @@ class Analyzer extends NodeVisitor {
       if (name) {
         this.addUsed(name)
         const patchedMember = dynamicMemberWrite(node)
-        if (!patchedMember || !patchedMember[1]) this.mutated.add(name)
+        if (!patchedMember || !patchedMember[1]) this.addMutation(name)
         if (patchedMember) {
           const [member, typeWide] = patchedMember
           this.memberWrites.push({
             receiver: name,
+            ...this.conditionalFact(),
             ...(member ? { member } : {}),
             ...(typeWide ? { scope: 'type' as const } : {})
           })
@@ -2398,9 +2409,10 @@ class Analyzer extends NodeVisitor {
         this.addUsed(name)
         const patchedMember = dynamicMemberWrite(node)
         const [member, typeWide] = patchedMember ?? [node.attr, false]
-        if (!typeWide) this.mutated.add(name)
+        if (!typeWide) this.addMutation(name)
         this.memberWrites.push({
           receiver: name,
+          ...this.conditionalFact(),
           ...(member ? { member } : {}),
           ...(typeWide ? { scope: 'type' as const } : {})
         })
@@ -2439,6 +2451,7 @@ class Analyzer extends NodeVisitor {
         this.receiverCalls.push({
           receiver: node.func.id,
           member: '__call__',
+          ...this.conditionalFact(),
           kind: 'callable',
           argumentNames: this.visibleRoots(candidates),
           receiverChain: [],
@@ -2512,6 +2525,7 @@ class Analyzer extends NodeVisitor {
       this.receiverCalls.push({
         receiver: this.importedFunctions.get(node.func.id) ?? node.func.id,
         member: '__call__',
+        ...this.conditionalFact(),
         kind: 'callable',
         argumentNames: this.visibleRoots([
           ...args,
@@ -2543,6 +2557,7 @@ class Analyzer extends NodeVisitor {
       this.receiverCalls.push({
         receiver: node.func.id,
         member: '__call__',
+        ...this.conditionalFact(),
         kind: 'callable',
         argumentNames: this.visibleRoots([
           ...args,
@@ -2597,6 +2612,7 @@ class Analyzer extends NodeVisitor {
           this.receiverCalls.push({
             receiver: name,
             member: node.func.attr ?? '',
+            ...this.conditionalFact(),
             ...(MUTATING_METHODS.has(node.func.attr ?? '') || inplace
               ? { kind: 'mutating' as const }
               : {}),
@@ -2633,7 +2649,7 @@ class Analyzer extends NodeVisitor {
               if (this.hasLocalRoot(keyword.value)) {
                 this.possiblyMutated.add(output)
                 this.unknown.add('opaque-mutation')
-              } else this.mutated.add(output)
+              } else this.addMutation(output)
             }
           }
         }
@@ -2681,6 +2697,7 @@ class Analyzer extends NodeVisitor {
         const typeWide = args[0]?.type === 'Attribute' && args[0].attr === '__class__'
         this.memberWrites.push({
           receiver,
+          ...this.conditionalFact(),
           ...(member ? { member } : {}),
           ...(typeWide ? { scope: 'type' as const } : {})
         })

--- a/src/main/notebook/dependency-analysis-python.ts
+++ b/src/main/notebook/dependency-analysis-python.ts
@@ -43,15 +43,20 @@ const SAFE_CALLS = new Set([
   'any',
   'bool',
   'bytes',
+  'callable',
   'complex',
   'dict',
   'enumerate',
   'filter',
   'float',
   'frozenset',
+  'getattr',
   'hash',
+  'hasattr',
   'id',
   'int',
+  'isinstance',
+  'issubclass',
   'len',
   'list',
   'map',
@@ -1375,6 +1380,73 @@ class MethodEffectVisitor extends NodeVisitor {
   }
 }
 
+class FunctionEffectVisitor extends NodeVisitor {
+  effect: 'read' | 'unknown' = 'read'
+  namespaceUnknown = false
+
+  unknown(namespace = false): void {
+    this.effect = 'unknown'
+    if (namespace) this.namespaceUnknown = true
+  }
+
+  visit_FunctionDef(): void {
+    this.unknown()
+  }
+  visit_AsyncFunctionDef = this.visit_FunctionDef
+  visit_Lambda(): void {
+    this.unknown()
+  }
+  visit_Global(): void {
+    this.unknown(true)
+  }
+  visit_Nonlocal(): void {
+    this.unknown(true)
+  }
+  visit_ListComp(): void {
+    this.unknown()
+  }
+  visit_SetComp = this.visit_ListComp
+  visit_DictComp = this.visit_ListComp
+  visit_GeneratorExp = this.visit_ListComp
+
+  visit_Assign(node: PyNode): void {
+    if (
+      (node.targets ?? []).some(
+        (target) => target.type === 'Attribute' || target.type === 'Subscript'
+      )
+    ) {
+      this.unknown()
+    }
+    this.genericVisit(node)
+  }
+
+  visit_AnnAssign(node: PyNode): void {
+    if (node.target?.type === 'Attribute' || node.target?.type === 'Subscript') this.unknown()
+    this.genericVisit(node)
+  }
+
+  visit_AugAssign = this.visit_AnnAssign
+
+  visit_Delete(node: PyNode): void {
+    if (
+      (node.targets ?? []).some(
+        (target) => target.type === 'Attribute' || target.type === 'Subscript'
+      )
+    ) {
+      this.unknown()
+    }
+    this.genericVisit(node)
+  }
+
+  visit_Call(node: PyNode): void {
+    if (isPyNode(node.func) && node.func.type === 'Name') {
+      if (DYNAMIC_CALLS.has(node.func.id ?? '')) this.unknown(true)
+      else if (!SAFE_CALLS.has(node.func.id ?? '')) this.unknown()
+    } else this.unknown()
+    this.genericVisit(node)
+  }
+}
+
 class FieldVisitor extends NodeVisitor {
   constructor(
     private readonly receiver: string,
@@ -1525,8 +1597,48 @@ const summarizeClass = (node: PyNode): NotebookDependencyTypeSummary | undefined
   }
 }
 
+const summarizeFunction = (node: PyNode): NotebookDependencyTypeSummary | undefined => {
+  if ((node.decorator_list ?? []).length || !node.name) return undefined
+  const fnArgs = node.args as PyArguments | undefined
+  const names = new MethodNameVisitor()
+  for (const argument of [
+    ...(fnArgs?.posonlyargs ?? []),
+    ...(fnArgs?.args ?? []),
+    ...(fnArgs?.kwonlyargs ?? [])
+  ]) {
+    names.locals.add(argument.arg)
+  }
+  if (fnArgs?.vararg) names.locals.add(fnArgs.vararg.arg)
+  if (fnArgs?.kwarg) names.locals.add(fnArgs.kwarg.arg)
+  const visitor = new FunctionEffectVisitor()
+  const body = Array.isArray(node.body) ? node.body : []
+  for (const statement of body) visitor.visit(statement)
+  for (const statement of body) names.visit(statement)
+  const shadowedSafeCalls = new Set(
+    [...names.safeCalls].filter((name) => names.locals.has(name) && !names.globals.has(name))
+  )
+  if (shadowedSafeCalls.size) visitor.unknown(true)
+  return {
+    name: `python-function:${node.name}`,
+    kind: 'python-class',
+    fields: [],
+    methods: [
+      {
+        name: '__call__',
+        effect: visitor.effect,
+        usedNames: [...names.loaded]
+          .filter((name) => !(names.locals.has(name) && !names.globals.has(name)))
+          .sort(),
+        safeCallNames: [...names.safeCalls].filter((name) => !shadowedSafeCalls.has(name)).sort(),
+        unknownScope: visitor.namespaceUnknown ? 'namespace' : 'receiver'
+      }
+    ]
+  }
+}
+
 class Analyzer extends NodeVisitor {
   defined = new Set<string>()
+  conditionallyDefined = new Set<string>()
   used = new Map<string, number>()
   priorUsed = new Map<string, number>()
   mutated = new Set<string>()
@@ -1885,7 +1997,7 @@ class Analyzer extends NodeVisitor {
         name: callableType,
         kind: 'python-class',
         fields: [],
-        methods: [{ name: '__call__', effect: 'unknown', unknownScope: 'namespace' }]
+        methods: [{ name: '__call__', effect: 'unknown', unknownScope: 'receiver' }]
       })
     }
     this.typeBindings.push({ target, typeName: callableType, argumentNames: [] })
@@ -1926,7 +2038,10 @@ class Analyzer extends NodeVisitor {
 
   prepareAssignment(targetNames: string[]): void {
     const conditional = this.controlDepth > 0
-    if (conditional) this.unknown.add('control-flow')
+    if (conditional) {
+      this.unknown.add('control-flow')
+      for (const name of targetNames) this.conditionallyDefined.add(name)
+    }
     for (const name of targetNames) {
       this.importedModules.delete(name)
       this.importedFunctions.delete(name)
@@ -1954,8 +2069,10 @@ class Analyzer extends NodeVisitor {
   visit_Name(node: PyNode): void {
     if (!node.id || this.localScopes.some((scope) => node.id! in scope)) return
     if (node.ctx === 'Load') this.addUsed(node.id)
-    else if (node.ctx === 'Store') this.defined.add(node.id)
-    else if (node.ctx === 'Del') {
+    else if (node.ctx === 'Store') {
+      this.defined.add(node.id)
+      if (this.controlDepth > 0) this.conditionallyDefined.add(node.id)
+    } else if (node.ctx === 'Del') {
       this.prepareAssignment([node.id])
       this.mutated.add(node.id)
     }
@@ -2015,6 +2132,7 @@ class Analyzer extends NodeVisitor {
         : undefined
     const memberAccess = value?.type === 'Subscript' ? 'subscript' : 'attribute'
     const member = memberSource ? memberName(value) : undefined
+    const importedMemberModule = memberSource ? this.importedModules.get(memberSource) : undefined
     const conditionalSources =
       value?.type === 'IfExp'
         ? new Set(
@@ -2061,6 +2179,9 @@ class Analyzer extends NodeVisitor {
       (value.type === 'Attribute' || value.type === 'Subscript')
     ) {
       if (memberSource) this.addPossibleAlias(target.id, memberSource, memberAccess, member)
+      if (value.type === 'Attribute' && importedMemberModule && member) {
+        this.bindUnknownImport(target.id, importedMemberModule, member)
+      }
     } else if (
       constructor &&
       target?.type === 'Name' &&
@@ -2132,8 +2253,10 @@ class Analyzer extends NodeVisitor {
       this.prepareAssignment(targetNames)
       for (const name of targetNames) this.defined.add(name)
     }
-    const source = this.visibleRootName(node.iter)
-    this.localScopes.push(Object.fromEntries(targetNames.map((name) => [name, source])))
+    const sources = this.expressionVisibleRoots(node.iter)
+    this.localScopes.push(
+      Object.fromEntries(targetNames.map((name, index) => [name, sources[index] ?? sources[0]]))
+    )
     for (const statement of body) this.visit(statement)
     this.localScopes.pop()
     for (const statement of node.orelse ?? []) this.visit(statement)
@@ -2155,7 +2278,11 @@ class Analyzer extends NodeVisitor {
       this.prepareAssignment([node.name])
       this.defined.add(node.name)
     }
-    this.unknown.add('function-scope')
+    const summary = summarizeFunction(node)
+    if (node.name && summary) {
+      this.typeSummaries.push(summary)
+      this.typeBindings.push({ target: node.name, typeName: summary.name, argumentNames: [] })
+    } else this.unknown.add('function-scope')
     const fnArgs = node.args as PyArguments | undefined
     for (const value of [
       ...(node.decorator_list ?? []),
@@ -2193,8 +2320,10 @@ class Analyzer extends NodeVisitor {
     this.localScopes.push(scope)
     for (const generator of node.generators ?? []) {
       this.visit(generator.iter)
-      const source = this.visibleRootName(generator.iter)
-      for (const name of this.assignedNames(generator.target)) scope[name] = source
+      const sources = this.expressionVisibleRoots(generator.iter)
+      for (const [index, name] of this.assignedNames(generator.target).entries()) {
+        scope[name] = sources[index] ?? sources[0]
+      }
       for (const condition of generator.ifs) this.visit(condition)
     }
     for (const value of values) this.visit(value)
@@ -2584,6 +2713,7 @@ const factsFromAnalyzer = (
   ]
   return {
     definedNames: [...analyzer.defined].sort(),
+    conditionallyDefinedNames: [...analyzer.conditionallyDefined].sort(),
     usedNames: [...analyzer.used.keys()].sort(),
     priorUsedNames: [...analyzer.priorUsed.keys()].sort(),
     possiblyUsedNames: [...analyzer.possiblyUsed].sort(),

--- a/src/main/notebook/dependency-analysis-types.ts
+++ b/src/main/notebook/dependency-analysis-types.ts
@@ -43,6 +43,7 @@ type NotebookDependencyCopyBinding = {
 type NotebookDependencyReceiverCall = {
   receiver: string
   member: string
+  conditional?: boolean
   kind?: 'receiver' | 'generic' | 'mutating' | 'callable'
   argumentNames?: string[]
   receiverChain?: string[]
@@ -69,6 +70,7 @@ type NotebookDependencyMemberWrite = {
   receiver: string
   member?: string
   scope?: 'instance' | 'type'
+  conditional?: boolean
 }
 
 type NotebookRunDependencyFacts =

--- a/src/main/notebook/dependency-analysis-types.ts
+++ b/src/main/notebook/dependency-analysis-types.ts
@@ -75,6 +75,7 @@ type NotebookRunDependencyFacts =
   | {
       state: 'available'
       definedNames: string[]
+      conditionallyDefinedNames?: string[]
       usedNames: string[]
       priorUsedNames?: string[]
       possiblyUsedNames?: string[]
@@ -96,6 +97,7 @@ type NotebookRunDependencyFacts =
       state: 'unknown'
       reasons: string[]
       definedNames?: string[]
+      conditionallyDefinedNames?: string[]
       usedNames?: string[]
       priorUsedNames?: string[]
       possiblyUsedNames?: string[]

--- a/src/main/notebook/dependency-analysis.notebook-repro.test.ts
+++ b/src/main/notebook/dependency-analysis.notebook-repro.test.ts
@@ -90,6 +90,16 @@ describe('reported Python call tracking regressions', () => {
     })
   })
 
+  it('restores a definite binding after unconditional reassignment', async () => {
+    const projection = await project([
+      'source = []\nenabled = True\nif enabled:\n    value = source\nvalue = 2',
+      'snapshot = value',
+      'source.append(1)'
+    ])
+
+    expect(projection.stalenessByRunId['run-2']).toEqual({ state: 'clear' })
+  })
+
   it.each([
     ['method call', 'if enabled:\n    items.append(1)'],
     ['augmented assignment', 'if enabled:\n    items += [1]'],
@@ -130,6 +140,31 @@ describe('reported Python call tracking regressions', () => {
     expect(projection.stalenessByRunId['run-2']).toMatchObject({
       state: 'unknown',
       reasons: expect.arrayContaining(['opaque-mutation'])
+    })
+  })
+
+  it('keeps implicit iteration effects in local functions conservative', async () => {
+    const projection = await project([
+      'items = []',
+      'snapshot = len(items)',
+      'def consume():\n    for item in items:\n        pass\nconsume()'
+    ])
+
+    expect(projection.stalenessByRunId['run-2']).toMatchObject({
+      state: 'unknown',
+      reasons: expect.arrayContaining(['opaque-mutation'])
+    })
+  })
+
+  it('keeps imports inside local functions namespace-scoped', async () => {
+    const projection = await project([
+      'def load():\n    import custom_plugin\nload()',
+      'unrelated = 1'
+    ])
+
+    expect(projection.stalenessByRunId['run-2']).toMatchObject({
+      state: 'unknown',
+      reasons: expect.arrayContaining(['dynamic-namespace'])
     })
   })
 

--- a/src/main/notebook/dependency-analysis.notebook-repro.test.ts
+++ b/src/main/notebook/dependency-analysis.notebook-repro.test.ts
@@ -90,6 +90,23 @@ describe('reported Python call tracking regressions', () => {
     })
   })
 
+  it.each([
+    ['method call', 'if enabled:\n    items.append(1)'],
+    ['augmented assignment', 'if enabled:\n    items += [1]'],
+    ['member write', 'if enabled:\n    items.value = 1']
+  ])('keeps conditional %s mutations possible rather than definite', async (_, mutation) => {
+    const projection = await project([
+      'items = []\nenabled = True',
+      'snapshot = len(items)',
+      mutation
+    ])
+
+    expect(projection.stalenessByRunId['run-2']).toMatchObject({
+      state: 'unknown',
+      reasons: expect.arrayContaining(['control-flow'])
+    })
+  })
+
   it('scopes unknown imported call effects to their arguments', async () => {
     const projection = await project([
       'from custom import transform\nsource = []\nresult = transform(source)',

--- a/src/main/notebook/dependency-analysis.notebook-repro.test.ts
+++ b/src/main/notebook/dependency-analysis.notebook-repro.test.ts
@@ -143,7 +143,7 @@ describe('reported Python call tracking regressions', () => {
     })
   })
 
-  it('scopes unknown imported call effects to their arguments', async () => {
+  it('keeps unknown imported call effects namespace-scoped', async () => {
     const projection = await project([
       'from custom import transform\nsource = []\nresult = transform(source)',
       'unrelated = 1'
@@ -151,9 +151,12 @@ describe('reported Python call tracking regressions', () => {
 
     expect(projection.stalenessByRunId['run-1']).toMatchObject({
       state: 'unknown',
-      reasons: expect.arrayContaining(['scoped-opaque-call'])
+      reasons: expect.arrayContaining(['dynamic-namespace'])
     })
-    expect(projection.stalenessByRunId['run-2']).toEqual({ state: 'clear' })
+    expect(projection.stalenessByRunId['run-2']).toMatchObject({
+      state: 'unknown',
+      reasons: expect.arrayContaining(['dynamic-namespace'])
+    })
   })
 
   it('tracks captured names mutated by a local function', async () => {
@@ -166,6 +169,19 @@ describe('reported Python call tracking regressions', () => {
     expect(projection.stalenessByRunId['run-2']).toMatchObject({
       state: 'unknown',
       reasons: expect.arrayContaining(['opaque-mutation'])
+    })
+  })
+
+  it('keeps mutable return aliases from local functions conservative', async () => {
+    const projection = await project([
+      'items = []\ndef expose():\n    return items\nout = expose()',
+      'snapshot = len(items)',
+      'out.append(1)'
+    ])
+
+    expect(projection.stalenessByRunId['run-2']).toMatchObject({
+      state: 'unknown',
+      reasons: expect.arrayContaining(['dynamic-namespace'])
     })
   })
 
@@ -225,7 +241,7 @@ describe('reported Python call tracking regressions', () => {
     })
   })
 
-  it('recognizes callables assigned from imported module attributes', async () => {
+  it('keeps unmodeled callables assigned from module attributes conservative', async () => {
     const projection = await project([
       'import matplotlib.pyplot as plt\ncmap = plt.cm.Set2\ncolor = cmap(0)',
       'unrelated = 1'
@@ -235,7 +251,10 @@ describe('reported Python call tracking regressions', () => {
       state: 'unknown',
       reasons: expect.arrayContaining(['scoped-opaque-call'])
     })
-    expect(projection.stalenessByRunId['run-2']).toEqual({ state: 'clear' })
+    expect(projection.stalenessByRunId['run-2']).toMatchObject({
+      state: 'unknown',
+      reasons: expect.arrayContaining(['dynamic-namespace'])
+    })
   })
 
   it('keeps unknown members of from-import bindings scoped', async () => {

--- a/src/main/notebook/dependency-analysis.notebook-repro.test.ts
+++ b/src/main/notebook/dependency-analysis.notebook-repro.test.ts
@@ -1,0 +1,156 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { NotebookRunRecord } from '../../shared/notebook'
+import { NotebookDependencyAnalyzer } from './dependency-analysis'
+import type { NotebookDependencyProjection } from './dependency-analysis-types'
+
+const temporaryRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map((path) => rm(path, { recursive: true })))
+})
+
+const run = (index: number, script: string): NotebookRunRecord => ({
+  runId: `run-${index}`,
+  cellId: `cell-${index}`,
+  source: 'agent',
+  inputKind: 'cell',
+  kernelKind: 'python',
+  kernelEpochId: 'epoch-1',
+  environment: 'default-python',
+  script,
+  status: 'completed',
+  startedAt: index,
+  endedAt: index,
+  executionCount: index,
+  text: { stdout: '', stderr: '', traceback: '', plain: [] },
+  outputs: [],
+  artifacts: [],
+  workingFiles: [],
+  inputFiles: []
+})
+
+const project = async (scripts: string[]): Promise<NotebookDependencyProjection> => {
+  const storageRoot = await mkdtemp(join(tmpdir(), 'open-science-python-call-repro-'))
+  temporaryRoots.push(storageRoot)
+  const runs = scripts.map((script, index) => run(index + 1, script))
+  return new NotebookDependencyAnalyzer({
+    storageRoot,
+    repository: { readSessionRuns: async () => runs }
+  }).project({
+    projectId: 'default-project',
+    sessionId: 'session-1',
+    completedRun: runs.at(-1),
+    interpreter: { command: 'unused-python' }
+  })
+}
+
+describe('reported Python call tracking regressions', () => {
+  it('does not poison an unrelated later run after scoped control flow', async () => {
+    const projection = await project(['for item in []:\n    value = item', 'unrelated = 1'])
+
+    expect(projection.stalenessByRunId).toEqual({
+      'run-1': { state: 'unknown', reasons: ['control-flow'] },
+      'run-2': { state: 'clear' }
+    })
+  })
+
+  it('classifies import and reflection helpers as read-only', async () => {
+    const projection = await project([
+      [
+        'import importlib',
+        'module = importlib.import_module("json")',
+        'version = getattr(module, "__version__", "ok")'
+      ].join('\n')
+    ])
+
+    expect(projection.stalenessByRunId['run-1']).toEqual({ state: 'clear' })
+  })
+
+  it('classifies JSON decoding as read-only', async () => {
+    const projection = await project(['import json\npayload = json.loads("{}")'])
+
+    expect(projection.stalenessByRunId['run-1']).toEqual({ state: 'clear' })
+  })
+
+  it('keeps dependencies on conditionally assigned names unknown', async () => {
+    const projection = await project([
+      'source = []\nvalue = 1',
+      'snapshot = value',
+      'for item in source:\n    value = item'
+    ])
+
+    expect(projection.stalenessByRunId['run-2']).toEqual({
+      state: 'unknown',
+      reasons: ['control-flow']
+    })
+  })
+
+  it('scopes unknown imported call effects to their arguments', async () => {
+    const projection = await project([
+      'from custom import transform\nsource = []\nresult = transform(source)',
+      'unrelated = 1'
+    ])
+
+    expect(projection.stalenessByRunId['run-1']).toMatchObject({
+      state: 'unknown',
+      reasons: expect.arrayContaining(['scoped-opaque-call'])
+    })
+    expect(projection.stalenessByRunId['run-2']).toEqual({ state: 'clear' })
+  })
+
+  it('tracks captured names mutated by a local function', async () => {
+    const projection = await project([
+      'items = []',
+      'snapshot = len(items)',
+      'def update():\n    items.append(1)\nupdate()'
+    ])
+
+    expect(projection.stalenessByRunId['run-2']).toMatchObject({
+      state: 'unknown',
+      reasons: expect.arrayContaining(['opaque-mutation'])
+    })
+  })
+
+  it('keeps explicit global writes namespace-scoped', async () => {
+    const projection = await project([
+      'value = 1\ndef replace():\n    global value\n    value = 2\nreplace()',
+      'unrelated = 1'
+    ])
+
+    expect(projection.stalenessByRunId['run-2']).toMatchObject({
+      state: 'unknown',
+      reasons: expect.arrayContaining(['dynamic-namespace'])
+    })
+  })
+
+  it('recognizes callables assigned from imported module attributes', async () => {
+    const projection = await project([
+      'import matplotlib.pyplot as plt\ncmap = plt.cm.Set2\ncolor = cmap(0)',
+      'unrelated = 1'
+    ])
+
+    expect(projection.stalenessByRunId['run-1']).toMatchObject({
+      state: 'unknown',
+      reasons: expect.arrayContaining(['scoped-opaque-call'])
+    })
+    expect(projection.stalenessByRunId['run-2']).toEqual({ state: 'clear' })
+  })
+
+  it('keeps unknown members of from-import bindings scoped', async () => {
+    const projection = await project([
+      'from custom import namespace\nresult = namespace.build()',
+      'unrelated = 1'
+    ])
+
+    expect(projection.stalenessByRunId['run-1']).toMatchObject({
+      state: 'unknown',
+      reasons: expect.arrayContaining(['scoped-opaque-call'])
+    })
+    expect(projection.stalenessByRunId['run-2']).toEqual({ state: 'clear' })
+  })
+})

--- a/src/main/notebook/dependency-analysis.notebook-repro.test.ts
+++ b/src/main/notebook/dependency-analysis.notebook-repro.test.ts
@@ -128,6 +128,25 @@ describe('reported Python call tracking regressions', () => {
     })
   })
 
+  it('keeps nested helper effects namespace-scoped', async () => {
+    const projection = await project([
+      [
+        'items = []',
+        'def outer():',
+        '    def nested():',
+        '        items.append(1)',
+        '    nested()',
+        'outer()'
+      ].join('\n'),
+      'unrelated = 1'
+    ])
+
+    expect(projection.stalenessByRunId['run-2']).toMatchObject({
+      state: 'unknown',
+      reasons: expect.arrayContaining(['dynamic-namespace'])
+    })
+  })
+
   it('recognizes callables assigned from imported module attributes', async () => {
     const projection = await project([
       'import matplotlib.pyplot as plt\ncmap = plt.cm.Set2\ncolor = cmap(0)',

--- a/src/main/notebook/dependency-analysis.notebook-repro.test.ts
+++ b/src/main/notebook/dependency-analysis.notebook-repro.test.ts
@@ -59,16 +59,30 @@ describe('reported Python call tracking regressions', () => {
     })
   })
 
-  it('classifies import and reflection helpers as read-only', async () => {
+  it('keeps dynamic module imports opaque without poisoning unrelated bindings', async () => {
     const projection = await project([
-      [
-        'import importlib',
-        'module = importlib.import_module("json")',
-        'version = getattr(module, "__version__", "ok")'
-      ].join('\n')
+      'import importlib\nmodule = importlib.import_module("custom_plugin")',
+      'unrelated = 1'
     ])
 
-    expect(projection.stalenessByRunId['run-1']).toEqual({ state: 'clear' })
+    expect(projection.stalenessByRunId['run-1']).toMatchObject({
+      state: 'unknown',
+      reasons: expect.arrayContaining(['scoped-opaque-call'])
+    })
+    expect(projection.stalenessByRunId['run-2']).toEqual({ state: 'clear' })
+  })
+
+  it('keeps reflection hooks conservative', async () => {
+    const projection = await project([
+      'items = []',
+      'snapshot = len(items)',
+      'value = getattr(items, "custom", None)'
+    ])
+
+    expect(projection.stalenessByRunId['run-2']).toMatchObject({
+      state: 'unknown',
+      reasons: expect.arrayContaining(['opaque-mutation'])
+    })
   })
 
   it('classifies JSON decoding as read-only', async () => {
@@ -98,6 +112,18 @@ describe('reported Python call tracking regressions', () => {
     ])
 
     expect(projection.stalenessByRunId['run-2']).toEqual({ state: 'clear' })
+  })
+
+  it('does not retain summaries for conditionally defined classes', async () => {
+    const projection = await project([
+      'enabled = True\nif enabled:\n    class Conditional:\n        pass',
+      'instance = Conditional()'
+    ])
+
+    expect(projection.stalenessByRunId['run-2']).toMatchObject({
+      state: 'unknown',
+      reasons: expect.arrayContaining(['opaque-call'])
+    })
   })
 
   it.each([

--- a/src/main/notebook/dependency-analysis.notebook-repro.test.ts
+++ b/src/main/notebook/dependency-analysis.notebook-repro.test.ts
@@ -91,6 +91,16 @@ describe('reported Python call tracking regressions', () => {
     expect(projection.stalenessByRunId['run-1']).toEqual({ state: 'clear' })
   })
 
+  it('preserves modeled effects for aliases assigned from module members', async () => {
+    const projection = await project([
+      'import numpy as np\nsine = np.sin\nvalues = [0.0]\nresult = sine(values)',
+      'unrelated = 1'
+    ])
+
+    expect(projection.stalenessByRunId['run-1']).toEqual({ state: 'clear' })
+    expect(projection.stalenessByRunId['run-2']).toEqual({ state: 'clear' })
+  })
+
   it('keeps dependencies on conditionally assigned names unknown', async () => {
     const projection = await project([
       'source = []\nvalue = 1',

--- a/src/main/notebook/dependency-analysis.test.ts
+++ b/src/main/notebook/dependency-analysis.test.ts
@@ -3495,6 +3495,59 @@ describe('projectNotebookDependencies', { timeout: 60_000 }, () => {
     expect(projection.stalenessByRunId['run-4']).toEqual({ state: 'clear' })
   })
 
+  it('tracks conditional class writes without mutating the persistent method summary', () => {
+    const summary = {
+      name: 'Reader',
+      kind: 'python-class' as const,
+      fields: [],
+      methods: [{ name: 'inspect', effect: 'read' as const }]
+    }
+
+    const projection = projectNotebookDependencies([
+      {
+        run: run('run-1', 'define-reader', 'class Reader: ...\nreader = Reader()', 1),
+        facts: {
+          state: 'available',
+          definedNames: ['Reader', 'reader'],
+          usedNames: [],
+          mutatedNames: [],
+          typeSummaries: [summary],
+          typeBindings: [{ target: 'reader', typeName: 'Reader' }]
+        }
+      },
+      {
+        run: run('run-2', 'read', 'result = reader.inspect()', 2),
+        facts: {
+          state: 'available',
+          definedNames: ['result'],
+          usedNames: ['reader'],
+          mutatedNames: [],
+          receiverCalls: [{ receiver: 'reader', member: 'inspect' }]
+        }
+      },
+      {
+        run: run('run-3', 'maybe-patch', 'if enabled:\n    Reader.inspect = replacement', 3),
+        facts: {
+          state: 'unknown',
+          definedNames: [],
+          usedNames: ['Reader', 'enabled', 'replacement'],
+          mutatedNames: [],
+          conditionallyDefinedNames: [],
+          memberWrites: [
+            { receiver: 'Reader', member: 'inspect', scope: 'type' as const, conditional: true }
+          ],
+          reasons: ['control-flow']
+        }
+      }
+    ])
+
+    expect(projection.stalenessByRunId['run-2']).toEqual({
+      state: 'unknown',
+      reasons: ['opaque-mutation']
+    })
+    expect(summary.methods[0]?.effect).toBe('read')
+  })
+
   it('keeps existing instances bound to the class summary used at construction', () => {
     const projection = projectNotebookDependencies([
       {

--- a/src/main/notebook/dependency-analysis.ts
+++ b/src/main/notebook/dependency-analysis.ts
@@ -28,7 +28,7 @@ import { getNotebookSessionRoot, getRuntimeRoot, type NotebookRunRepository } fr
 import { envPrefix, pythonBin, resolveEnvName, rScriptBin } from './runtime-paths'
 
 const ANALYZER_VERSION = 1 as const
-const ANALYZER_REVISION = 'tree-sitter-in-process-1'
+const ANALYZER_REVISION = 'tree-sitter-in-process-2'
 const SIDECAR_FILE = 'dependency-analysis.json'
 const MAX_NAMES_PER_RUN = 512
 const RETRYABLE_ANALYSIS_FAILURES = new Set([
@@ -610,6 +610,9 @@ const normalizeFacts = (value: unknown): NotebookRunDependencyFacts => {
       ...(stringArray(record.definedNames)
         ? { definedNames: stringArray(record.definedNames) }
         : {}),
+      ...(stringArray(record.conditionallyDefinedNames)
+        ? { conditionallyDefinedNames: stringArray(record.conditionallyDefinedNames) }
+        : {}),
       ...(stringArray(record.usedNames) ? { usedNames: stringArray(record.usedNames) } : {}),
       priorUsedNames,
       possiblyUsedNames,
@@ -640,6 +643,7 @@ const normalizeFacts = (value: unknown): NotebookRunDependencyFacts => {
   }
   if (record.state !== 'available') return unknownFacts('invalid-parser-result')
   const definedNames = stringArray(record.definedNames)
+  const conditionallyDefinedNames = stringArray(record.conditionallyDefinedNames ?? [])
   const usedNames = stringArray(record.usedNames)
   const priorUsedNames = stringArray(record.priorUsedNames ?? record.usedNames)
   const possiblyUsedNames = stringArray(record.possiblyUsedNames ?? [])
@@ -657,6 +661,7 @@ const normalizeFacts = (value: unknown): NotebookRunDependencyFacts => {
   const receiverCalls = receiverCallArray(record.receiverCalls ?? [])
   const memberWrites = memberWriteArray(record.memberWrites ?? [])
   return definedNames &&
+    conditionallyDefinedNames &&
     usedNames &&
     priorUsedNames &&
     possiblyUsedNames &&
@@ -672,6 +677,7 @@ const normalizeFacts = (value: unknown): NotebookRunDependencyFacts => {
     ? {
         state: 'available',
         definedNames,
+        ...(conditionallyDefinedNames.length ? { conditionallyDefinedNames } : {}),
         usedNames,
         priorUsedNames,
         possiblyUsedNames,
@@ -911,6 +917,8 @@ class NotebookDependencyAnalyzer {
         const validFacts =
           factsRecord.state === 'available'
             ? stringArray(factsRecord.definedNames) !== undefined &&
+              (factsRecord.conditionallyDefinedNames === undefined ||
+                stringArray(factsRecord.conditionallyDefinedNames) !== undefined) &&
               stringArray(factsRecord.usedNames) !== undefined &&
               stringArray(factsRecord.priorUsedNames) !== undefined &&
               stringArray(factsRecord.possiblyUsedNames) !== undefined &&
@@ -936,6 +944,8 @@ class NotebookDependencyAnalyzer {
               Boolean(stringArray(factsRecord.reasons)?.length) &&
               (factsRecord.definedNames === undefined ||
                 stringArray(factsRecord.definedNames) !== undefined) &&
+              (factsRecord.conditionallyDefinedNames === undefined ||
+                stringArray(factsRecord.conditionallyDefinedNames) !== undefined) &&
               (factsRecord.usedNames === undefined ||
                 stringArray(factsRecord.usedNames) !== undefined) &&
               stringArray(factsRecord.priorUsedNames) !== undefined &&

--- a/src/main/notebook/dependency-analysis.ts
+++ b/src/main/notebook/dependency-analysis.ts
@@ -28,7 +28,7 @@ import { getNotebookSessionRoot, getRuntimeRoot, type NotebookRunRepository } fr
 import { envPrefix, pythonBin, resolveEnvName, rScriptBin } from './runtime-paths'
 
 const ANALYZER_VERSION = 1 as const
-const ANALYZER_REVISION = 'tree-sitter-in-process-2'
+const ANALYZER_REVISION = 'tree-sitter-in-process-3'
 const SIDECAR_FILE = 'dependency-analysis.json'
 const MAX_NAMES_PER_RUN = 512
 const RETRYABLE_ANALYSIS_FAILURES = new Set([
@@ -268,14 +268,16 @@ const memberWriteArray = (
       typeof record.receiver !== 'string' ||
       (record.member !== undefined && typeof record.member !== 'string') ||
       (requireScope && record.scope === undefined) ||
-      (record.scope !== undefined && record.scope !== 'instance' && record.scope !== 'type')
+      (record.scope !== undefined && record.scope !== 'instance' && record.scope !== 'type') ||
+      (record.conditional !== undefined && typeof record.conditional !== 'boolean')
     ) {
       return undefined
     }
     writes.push({
       receiver: record.receiver,
       ...(record.member ? { member: record.member } : {}),
-      scope: record.scope === 'type' ? 'type' : 'instance'
+      scope: record.scope === 'type' ? 'type' : 'instance',
+      ...(record.conditional === true ? { conditional: true } : {})
     })
   }
   return writes
@@ -507,6 +509,7 @@ const receiverCallArray = (
         record.kind !== 'generic' &&
         record.kind !== 'mutating' &&
         record.kind !== 'callable') ||
+      (record.conditional !== undefined && typeof record.conditional !== 'boolean') ||
       (requireArgumentNames && record.kind === undefined) ||
       (requireArgumentNames && record.argumentNames === undefined) ||
       (requireArgumentNames && record.receiverChain === undefined) ||
@@ -556,6 +559,7 @@ const receiverCallArray = (
     calls.push({
       receiver: record.receiver,
       member: record.member,
+      ...(record.conditional === true ? { conditional: true } : {}),
       kind:
         record.kind === 'generic' || record.kind === 'mutating' || record.kind === 'callable'
           ? record.kind

--- a/src/main/notebook/dependency-projection.ts
+++ b/src/main/notebook/dependency-projection.ts
@@ -222,6 +222,7 @@ const projectNotebookDependencies = (
     const incompleteRun = isIncompleteRun(run)
     const incomplete = incompleteRun ? incompleteRunFacts(analyzedFacts) : undefined
     const facts = incomplete?.facts ?? analyzedFacts
+    const conditionallyDefinedNames = new Set(facts.conditionallyDefinedNames ?? [])
     const namespace = namespaceKey(run)
     if (!namespace) {
       if (run.status === 'completed' && (run.kernelKind === 'python' || run.kernelKind === 'r')) {
@@ -851,6 +852,9 @@ const projectNotebookDependencies = (
       if (method?.effect === 'unknown' && method.unknownScope === 'namespace') {
         typeAwareReasons.push('opaque-call', 'dynamic-namespace')
       }
+      if (!method && typeSummary?.name.startsWith('python-callable:unknown.')) {
+        typeAwareReasons.push('scoped-opaque-call')
+      }
       if (method?.effect === 'read' && call.kind !== 'mutating') continue
       if (method?.effect === 'mutate' || call.kind === 'mutating') {
         if (call.receiverChain?.length) {
@@ -864,8 +868,19 @@ const projectNotebookDependencies = (
         typeAwarePossiblyMutatedNames.push(call.receiver, ...(call.argumentNames ?? []))
         typeAwareReasons.push('opaque-mutation', 'opaque-call', 'dynamic-namespace')
       } else if (method?.effect === 'unknown') {
-        typeAwarePossiblyMutatedNames.push(...mutationReceiverNames, ...(call.argumentNames ?? []))
+        const safeCallNames = new Set(method.safeCallNames ?? [])
+        typeAwarePossiblyMutatedNames.push(
+          ...mutationReceiverNames,
+          ...(call.argumentNames ?? []),
+          ...(method.usedNames ?? []).filter((name) => !safeCallNames.has(name))
+        )
         typeAwareReasons.push('opaque-mutation')
+        if (
+          typeSummary?.name.startsWith('python-callable:unknown.') ||
+          typeSummary?.name.startsWith('python-function:')
+        ) {
+          typeAwareReasons.push('scoped-opaque-call')
+        }
       } else if (call.kind === 'generic') {
         const argumentNames = call.argumentNames?.length
           ? [...mutationReceiverNames, ...call.argumentNames]
@@ -958,7 +973,6 @@ const projectNotebookDependencies = (
           'dynamic-assignment',
           'wildcard-import',
           'alias-rebind',
-          'control-flow',
           'class-scope',
           'comprehension-scope',
           'analysis-unavailable',
@@ -1132,11 +1146,22 @@ const projectNotebookDependencies = (
       }
     }
 
-    const definedNames = [...new Set(facts.definedNames ?? [])]
+    const definedNames = [...new Set(facts.definedNames ?? [])].filter(
+      (name) => !conditionallyDefinedNames.has(name)
+    )
     for (const name of definedNames) {
       invalidateName(name, 'stale')
       uncertainBindings.delete(name)
       referenceTokens.set(name, `${run.runId}\0${name}`)
+      detachPossibleAlias(name, possibleAliases)
+      detachPossibleAlias(name, rCopyAliases)
+      builtinContainers.delete(name)
+      copyOnModifyNames.delete(name)
+      objectTypes.delete(name)
+    }
+    for (const name of conditionallyDefinedNames) {
+      invalidateName(name, 'unknown', ['control-flow'], false)
+      uncertainBindings.set(name, ['control-flow'])
       detachPossibleAlias(name, possibleAliases)
       detachPossibleAlias(name, rCopyAliases)
       builtinContainers.delete(name)
@@ -1156,10 +1181,15 @@ const projectNotebookDependencies = (
       consumers.add(run.runId)
       possibleConsumers.set(name, consumers)
     }
-    for (const name of facts.builtinContainerNames ?? []) builtinContainers.add(name)
-    for (const name of facts.copyOnModifyNames ?? []) copyOnModifyNames.add(name)
+    for (const name of facts.builtinContainerNames ?? []) {
+      if (!conditionallyDefinedNames.has(name)) builtinContainers.add(name)
+    }
+    for (const name of facts.copyOnModifyNames ?? []) {
+      if (!conditionallyDefinedNames.has(name)) copyOnModifyNames.add(name)
+    }
     if (!incompleteRun) {
       for (const [name, typeSummary] of pendingTypeBindings) {
+        if (conditionallyDefinedNames.has(name)) continue
         objectTypes.set(name, typeSummary)
         if (typeSummary.kind === 'r-r6') copyOnModifyNames.delete(name)
       }

--- a/src/main/notebook/dependency-projection.ts
+++ b/src/main/notebook/dependency-projection.ts
@@ -1177,6 +1177,7 @@ const projectNotebookDependencies = (
       builtinContainers.delete(name)
       copyOnModifyNames.delete(name)
       objectTypes.delete(name)
+      typeSummaries.delete(name)
     }
     for (const name of typeBehaviorChanges) {
       invalidateName(name, 'unknown', ['opaque-mutation'], false)

--- a/src/main/notebook/dependency-projection.ts
+++ b/src/main/notebook/dependency-projection.ts
@@ -464,6 +464,14 @@ const projectNotebookDependencies = (
     }
 
     for (const call of facts.receiverCalls ?? []) {
+      const addTypeAwareMutation = (names: readonly string[]): void => {
+        if (call.conditional) {
+          typeAwarePossiblyMutatedNames.push(...names)
+          if (names.length) typeAwareReasons.push('opaque-mutation')
+        } else {
+          typeAwareMutatedNames.push(...names)
+        }
+      }
       const modifiedR6Summary =
         call.member === 'set'
           ? [...typeSummaries.entries()].find(
@@ -490,6 +498,7 @@ const projectNotebookDependencies = (
       const configuredTypeName = typeSummary
         ? (facts.memberWrites ?? []).find(
             (write) =>
+              !write.conditional &&
               write.member !== undefined &&
               receiversMayAlias(write.receiver, call.receiver) &&
               PYTHON_LIBRARY_EFFECTS[typeSummary!.name]?.typeWhenMembersWritten?.[write.member]
@@ -604,6 +613,7 @@ const projectNotebookDependencies = (
       const hasUnpackedKeywords = call.keywordArguments?.some((keyword) => keyword.name === '**')
       if (
         !incompleteRun &&
+        !call.conditional &&
         receiverTypeRule &&
         ((receiverTypeKeyword && receiverTypeKeyword.staticBoolean !== true) || hasUnpackedKeywords)
       ) {
@@ -832,12 +842,12 @@ const projectNotebookDependencies = (
         (keyword) => keyword.name === method?.mutatesKeyword
       )
       if (libraryEffect?.mutatesPositionalArgument !== undefined) {
-        typeAwareMutatedNames.push(
-          ...(call.positionalArgumentNames?.[libraryEffect.mutatesPositionalArgument] ?? [])
+        addTypeAwareMutation(
+          call.positionalArgumentNames?.[libraryEffect.mutatesPositionalArgument] ?? []
         )
       }
       if (mutatedKeyword?.argumentNames) {
-        typeAwareMutatedNames.push(...mutatedKeyword.argumentNames)
+        addTypeAwareMutation(mutatedKeyword.argumentNames)
       }
       if (mutatedKeyword?.possibleArgumentNames?.length) {
         typeAwarePossiblyMutatedNames.push(...mutatedKeyword.possibleArgumentNames)
@@ -861,7 +871,7 @@ const projectNotebookDependencies = (
           typeAwarePossiblyMutatedNames.push(...mutationReceiverNames)
           if (mutationReceiverNames.length) typeAwareReasons.push('opaque-mutation')
         } else {
-          typeAwareMutatedNames.push(call.receiver)
+          addTypeAwareMutation([call.receiver])
         }
       } else if (knownConstructorCall) continue
       else if (methodWasShadowed) {
@@ -1274,7 +1284,7 @@ const projectNotebookDependencies = (
     for (const write of facts.memberWrites ?? []) {
       const receiverSummary = objectTypes.get(write.receiver)
       const configuredType =
-        write.member && receiverSummary
+        !write.conditional && write.member && receiverSummary
           ? PYTHON_LIBRARY_EFFECTS[receiverSummary.name]?.typeWhenMembersWritten?.[write.member]
           : undefined
       const configuredSummary = configuredType ? typeSummaries.get(configuredType) : undefined
@@ -1372,7 +1382,11 @@ const projectNotebookDependencies = (
         const member = call.member.startsWith('data.table::')
           ? call.member.slice('data.table::'.length)
           : call.member
-        if (call.kind === 'mutating' && R_DATA_TABLE_REFERENCE_MUTATORS.has(member)) {
+        if (
+          !call.conditional &&
+          call.kind === 'mutating' &&
+          R_DATA_TABLE_REFERENCE_MUTATORS.has(member)
+        ) {
           const shadowedUnqualifiedCall =
             member === call.member &&
             currentSafeCallNames.includes(member) &&
@@ -1408,7 +1422,11 @@ const projectNotebookDependencies = (
           : namesSharingRCopy(namesSharingReference(target))
       )
     }
-    const copyWriteNames = new Set((facts.memberWrites ?? []).map((write) => write.receiver))
+    const copyWriteNames = new Set(
+      (facts.memberWrites ?? [])
+        .filter((write) => !write.conditional)
+        .map((write) => write.receiver)
+    )
     const ambiguousCopyWriteNames = new Set<string>()
     const ambiguousReferenceAliasNames = new Set<string>()
     const referenceAliasStates = new Map<string, 'stale' | 'unknown'>()
@@ -1477,6 +1495,9 @@ const projectNotebookDependencies = (
     const possibleMutations = new Set<string>()
     const possibleMutationRoots = [
       ...(facts.possiblyMutatedNames ?? []),
+      ...(facts.memberWrites ?? [])
+        .filter((write) => write.conditional)
+        .map((write) => write.receiver),
       ...(incompleteRun ? typeAwareMutatedNames : []),
       ...typeAwarePossiblyMutatedNames,
       ...ambiguousReferenceAliasNames,

--- a/src/main/notebook/dependency-projection.ts
+++ b/src/main/notebook/dependency-projection.ts
@@ -209,6 +209,7 @@ const projectNotebookDependencies = (
   const typeSummariesByNamespace = new Map<string, Map<string, NotebookDependencyTypeSummary>>()
   const objectTypesByNamespace = new Map<string, Map<string, NotebookDependencyTypeSummary>>()
   const shadowedMembersByNamespace = new Map<string, Map<string, Set<string>>>()
+  const shadowedTypeMembers = new WeakMap<NotebookDependencyTypeSummary, Set<string>>()
   const safeCallConsumersByNamespace = new Map<string, Map<string, Set<string>>>()
   const possibleConsumersByNamespace = new Map<string, Map<string, Set<string>>>()
   const unknownReasonsByNamespace = new Map<string, string[]>()
@@ -420,6 +421,12 @@ const projectNotebookDependencies = (
         .filter(([, summary]) => summary === classSummary)
         .map(([name]) => name)
       for (const name of affectedObjects) typeBehaviorChanges.add(name)
+      if (write.conditional) {
+        const members = shadowedTypeMembers.get(classSummary) ?? new Set<string>()
+        members.add(write.member ?? '*')
+        shadowedTypeMembers.set(classSummary, members)
+        continue
+      }
       const methods = write.member
         ? classSummary.methods.filter((method) => method.name === write.member)
         : classSummary.methods
@@ -515,7 +522,13 @@ const projectNotebookDependencies = (
       let projectedReceiverValueNames = [call.receiver]
       let chainProvenanceResolved = false
       for (const [chainIndex, chainedMember] of (call.receiverChain ?? []).entries()) {
-        if (priorShadow?.has('*') === true || priorShadow?.has(chainedMember) === true) {
+        const typeShadow = typeSummary ? shadowedTypeMembers.get(typeSummary) : undefined
+        if (
+          priorShadow?.has('*') === true ||
+          priorShadow?.has(chainedMember) === true ||
+          typeShadow?.has('*') === true ||
+          typeShadow?.has(chainedMember) === true
+        ) {
           chainWasShadowed = true
           typeSummary = undefined
           break
@@ -594,11 +607,14 @@ const projectNotebookDependencies = (
           receiversMayAlias(write.receiver, call.receiver) &&
           (write.member === undefined || write.member === call.member)
       )
+      const typeShadow = typeSummary ? shadowedTypeMembers.get(typeSummary) : undefined
       const methodWasShadowed =
         chainWasShadowed ||
         writtenInThisRun ||
         priorShadow?.has('*') === true ||
-        priorShadow?.has(call.member) === true
+        priorShadow?.has(call.member) === true ||
+        typeShadow?.has('*') === true ||
+        typeShadow?.has(call.member) === true
       const methodName = call.kind === 'callable' ? '__call__' : call.member
       const method = methodWasShadowed
         ? undefined
@@ -826,7 +842,15 @@ const projectNotebookDependencies = (
             if (writtenInThisRun) return true
             const token = referenceTokens.get(reference.root)
             const shadow = token ? shadowedMembers.get(token) : undefined
-            if (shadow?.has('*') || shadow?.has(reference.member)) return true
+            const typeShadow = shadowedTypeMembers.get(summary)
+            if (
+              shadow?.has('*') ||
+              shadow?.has(reference.member) ||
+              typeShadow?.has('*') ||
+              typeShadow?.has(reference.member)
+            ) {
+              return true
+            }
             return (
               summary.methods.find((candidate) => candidate.name === reference.member)?.effect !==
               'read'
@@ -1304,6 +1328,7 @@ const projectNotebookDependencies = (
         receiversMayAlias(write.receiver, name)
       )?.[1]
       if (classSummary) {
+        if (write.conditional) continue
         if (write.member) {
           const method = classSummary.methods.find((candidate) => candidate.name === write.member)
           if (method) {

--- a/src/main/notebook/python-library-effects.ts
+++ b/src/main/notebook/python-library-effects.ts
@@ -1,6 +1,9 @@
 export type PythonLibraryMethodEffect = {
-  effect: 'read' | 'mutate'
+  effect: 'read' | 'mutate' | 'unknown'
+  unknownScope?: 'receiver' | 'namespace'
   unsafeNamespace?: boolean
+  scopedOpaque?: boolean
+  externalState?: boolean
   returnType?: string
   destructuredReturnTypes?: string[]
   mutatesKeyword?: string
@@ -49,7 +52,12 @@ const PYTHON_LIBRARY_EFFECTS: PythonLibraryEffects = {
   importlib: {
     kind: 'module',
     methods: {
-      import_module: { effect: 'read' }
+      import_module: {
+        effect: 'unknown',
+        unknownScope: 'receiver',
+        scopedOpaque: true,
+        externalState: true
+      }
     }
   },
   pickle: {

--- a/src/main/notebook/python-library-effects.ts
+++ b/src/main/notebook/python-library-effects.ts
@@ -46,6 +46,12 @@ type PythonLibraryEffects = Record<string, PythonLibraryObjectSummary>
 // Static effects are deliberately limited to stable, documented behavior used by ordinary
 // scientific Notebook code. Unknown methods continue through the conservative receiver-call path.
 const PYTHON_LIBRARY_EFFECTS: PythonLibraryEffects = {
+  importlib: {
+    kind: 'module',
+    methods: {
+      import_module: { effect: 'read' }
+    }
+  },
   pickle: {
     kind: 'module',
     methods: {


### PR DESCRIPTION
## Problem

Python dependency analysis conflated scoped uncertainty with namespace-wide mutation. Conditional bindings, local helper functions, and unknown third-party callables could therefore make every later run show limited variable tracking. Replaying the reported Notebook left 40/40 completed Python runs unknown.

## Proposed change

- Record conditionally defined names and invalidate only those bindings for control-flow uncertainty.
- Preserve conditional context on calls and member writes so possible mutations produce unknown rather than definite stale invalidations.
- Summarize undecorated local functions, including free-name reads, argument/captured-object mutation, and explicit global/nonlocal writes.
- Keep implicit execution protocols in local functions conservative, including context managers, iteration, await/yield, and imports.
- Clear conditional binding and alias metadata when a later unconditional assignment determines the final binding.
- Keep explicitly modeled calls scoped while retaining namespace uncertainty for unmodeled imported callables.
- Recognize imported-module attribute callables while keeping reflection hooks and dynamic module loading scoped-opaque.
- Preserve known library effects for module-member aliases and track conditional class patches as possible member shadowing without mutating persistent summaries.
- Bump the analyzer revision so existing derived analyses are recomputed.

## Scope and non-goals

- Unsafe deserialization, dynamic namespace APIs, explicit global/nonlocal writes, wildcard imports, and unresolved local callables remain conservative.
- No renderer copy or UI behavior was changed.
- No run-state enum was added; clear/stale/unknown are unchanged. scoped-opaque-call is an analysis reason only.

## Compatibility and persistence

- Historical compatibility: existing analysis sidecars remain readable because conditionallyDefinedNames and conditional are optional. The revision bump recomputes historical derived facts; runs missing kernelEpochId retain their existing conservative behavior.
- Persistence: only the derived dependency-analysis.json sidecar gains an optional conditionallyDefinedNames array and optional conditional flags on call/member-write facts. There is no database, session-run, or migration change.

## Validation

- Reported Notebook replay: all 40 successful runs remain unknown after correctness review because every run contains an unmodeled third-party callable, dynamic hook, or mutable return provenance. Earlier 40→35/23 results were rejected as false-clear risks.
- 424 targeted Notebook dependency-analysis tests passed.
- npm run typecheck:node passed.
- ESLint and Prettier passed for all changed files.
- git diff --check passed.
- test:affected:explain selected the full suite because Notebook analysis has no module owner; per request, the full suite is left to PR CI.

## Review focus

Please focus on the boundary between scoped-opaque-call and dynamic-namespace, conditional binding invalidation, possible-versus-definite mutations under control flow, and implicit effects inside summarized local functions.
