### PR TITLE
fix(session-persistence): publish side chat session updates

### DIFF
--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -582,6 +582,65 @@ describe('SessionPersistenceCoordinator', () => {
     })
   })
 
+  it('publishes the parent Session after every Side chat mutation', async () => {
+    let durable = createSession()
+    const repository = createSessionRepository({
+      loadSessionWithDiagnostics: vi.fn(async () => ({
+        status: 'found' as const,
+        session: durable
+      })),
+      saveSession: vi.fn(async (session) => {
+        durable = structuredClone(session)
+      })
+    })
+    const publishSession = vi.fn()
+    const coordinator = new SessionPersistenceCoordinator(
+      repository,
+      createFileIndex(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      publishSession
+    )
+
+    await coordinator.saveSideChatProjection({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      sideChat: createSideChatProjection()
+    })
+    await coordinator.appendSideChatRelay({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      sideChatId: 'side-chat-1',
+      relay: { id: 'relay-1', text: 'Use a black line.', createdAt: 11 }
+    })
+    await coordinator.commitSideChatRelays({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      relayIds: ['relay-1'],
+      promptMessageId: 'main-prompt-1'
+    })
+    await coordinator.clearSideChat({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      sideChatId: 'side-chat-1'
+    })
+
+    expect(publishSession.mock.calls).toEqual(
+      [1, 2, 3, 4].map((revision) => [
+        expect.objectContaining({
+          id: 'session-1',
+          runtimeContext: expect.objectContaining({ revision })
+        }),
+        'runtime-context'
+      ])
+    )
+  })
+
   it('keeps durable relays deliverable after clearing their producer Side chat', async () => {
     let durable = createSession({
       runtimeContext: {

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -78,7 +78,6 @@ import {
   type SessionUpdatePublisher
 } from './session-update-publication'
 import { sanitizeRendererSaveSessionOptions } from './renderer-save-options'
-
 const SESSION_CPU_TRACE_ENABLED = process.env.OPEN_SCIENCE_PERF_SESSION_TRACE === '1'
 type SessionMutationRepository = {
   loadAllWithDiagnostics(options?: { mode?: 'repair' | 'read-only' }): Promise<{
@@ -234,7 +233,8 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
     this.sideChatOwner = new SessionSideChatPersistenceOwner({
       repository,
       assertMutable: (projectId, sessionId) => assertMutable(projectId, sessionId, 'mutate'),
-      recordSession: (session) => this.stateOwner.recordSession(session)
+      recordSession: (session) => this.stateOwner.recordSession(session),
+      notifySessionUpdated: (session) => publishSessionUpdate(session, 'runtime-context')
     })
     this.deletionOwner = new SessionPersistenceDeletionOwner({
       repository,

--- a/src/main/session-persistence/side-chat-owner.ts
+++ b/src/main/session-persistence/side-chat-owner.ts
@@ -59,6 +59,7 @@ type SessionSideChatPersistenceOwnerOptions = Readonly<{
   repository: SideChatStateRepository
   assertMutable(projectId: string, sessionId: string): void
   recordSession(session: PersistedChatSession): void
+  notifySessionUpdated(session: PersistedChatSession): void
 }>
 
 const emptyRuntimeContext = (): SessionRuntimeContext => ({ version: 1, revision: 0 })
@@ -195,6 +196,7 @@ class SessionSideChatPersistenceOwner {
     })
     const persisted = await saveSessionWithRevision(this.options.repository, durable)
     this.options.recordSession(persisted)
+    this.options.notifySessionUpdated(persisted)
     return messages
   }
 
@@ -245,6 +247,7 @@ class SessionSideChatPersistenceOwner {
     }
     const persisted = await saveSessionWithRevision(this.options.repository, durable)
     this.options.recordSession(persisted)
+    this.options.notifySessionUpdated(persisted)
   }
 }
 


### PR DESCRIPTION
## Problem

Opening or using Side chat persists runtime context directly in the parent Session. Those writes advanced the durable Session revision without publishing the updated parent Session to renderer lifecycle subscribers. A later renderer save therefore used a stale revision and surfaced: “Conversation storage needs attention”.

## Proposed change

- publish the persisted parent Session after every Side chat projection, relay append, relay commit, and clear mutation
- reuse the existing runtime-context Session update channel so the renderer acknowledges the new durable revision
- add a coordinator regression test covering all four Side chat mutation paths

## Scope and non-goals

- no persisted schema or data-format change
- no historical-data compatibility handling required
- no new state or enum values
- no database migration
- no ACP wire-protocol behavior change; the fix is shared Session persistence publication, independent of claude-code, opencode, codex-response, and codex-bridge adapters
- no subscription API change; existing sessionUpdated timing is extended to Side chat-owned mutations

## Acceptance criteria and validation

Checks listed below ran after the last material edit.

- Side chat mutation -> shared session_persistence owner/contract/consumer suite -> npm run test:module -- session_persistence -> 7 files, 324 tests passed
- main-process types -> npm run typecheck:node -> passed
- lint -> npm run lint -> 0 errors; 2 pre-existing ACP Prettier warnings outside this diff
- final base-to-head impact plan -> npm run test:affected:explain -- --base main --head HEAD -> selective project_files_repository, artifact_provenance, and session_persistence plan; expanded consumers and Windows-sensitive/main-runtime coverage delegated to PR Gate

Framework/path coverage:

- behavior: parent Session revision publication after Side chat persistence
- included locally: shared main-process Session persistence path used by every Side chat framework
- excluded locally: framework-specific live ACP traffic, model-specific paths, Windows lane, and full affected consumer plan because the change does not alter ACP translation and PR CI is the requested validation authority

## Review focus

- confirm every Side chat durable mutation publishes exactly one authoritative parent Session update
- confirm the existing runtime-context lifecycle origin remains the correct renderer synchronization boundary
- confirm the final CI matrix covers the expanded artifact/project-files consumers and Windows-sensitive overlay
