### PR TITLE
fix(host-sdk)!: camel-case public result fields

### DIFF
--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -772,7 +772,7 @@ if (process.argv.includes('--version')) {
           const terminal = controlResultValue(
             await executeControlCode(
               context.params.sessionId,
-              `const slow = globalThis.s2Pending.children[1]; return await host.collect([{ frameId: slow.frame_id, attemptId: slow.attempt_id }], { timeoutSeconds: 30 })`
+              `const slow = globalThis.s2Pending.children[1]; return await host.collect([{ frameId: slow.frameId, attemptId: slow.attemptId }], { timeoutSeconds: 30 })`
             )
           )
           if (terminal.length !== 1 || terminal[0].status !== 'completed') {
@@ -834,7 +834,7 @@ if (process.argv.includes('--version')) {
           if (
             delegated.kind !== 'results' ||
             delegated.children?.[0]?.status !== 'completed' ||
-            delegated.children?.[0]?.agent_name !== 'Release Specialist'
+            delegated.children?.[0]?.agentName !== 'Release Specialist'
           ) {
             throw new Error(`Inherited Specialist delegation failed: ${JSON.stringify(delegated)}`)
           }
@@ -848,14 +848,14 @@ if (process.argv.includes('--version')) {
             )
           )
           const child = dispatched.children?.[0]
-          if (!child?.frame_id || !child?.attempt_id) {
+          if (!child?.frameId || !child?.attemptId) {
             throw new Error(`Reliable child admission failed: ${JSON.stringify(dispatched)}`)
           }
-          reliableMessagingChildren.set(context.params.sessionId, child.frame_id)
+          reliableMessagingChildren.set(context.params.sessionId, child.frameId)
           const downward = controlResultValue(
             await executeControlCode(
               context.params.sessionId,
-              `const sent = await host.sendFrameMessage(${JSON.stringify(child.frame_id)}, ${JSON.stringify(RELIABLE_CHILD_DIRECTIVE)}, { kind: "info", requestId: "e2e-main-to-child" }); return await host.messageReceipt(sent.message_id, { timeoutSeconds: 30 })`
+              `const sent = await host.sendFrameMessage(${JSON.stringify(child.frameId)}, ${JSON.stringify(RELIABLE_CHILD_DIRECTIVE)}, { kind: "info", requestId: "e2e-main-to-child" }); return await host.messageReceipt(sent.messageId, { timeoutSeconds: 30 })`
             )
           )
           if (downward.status !== 'accepted' || downward.direction !== 'to_child') {
@@ -974,7 +974,7 @@ if (process.argv.includes('--version')) {
           if (delegated.kind !== 'results' || child?.status !== 'completed') {
             throw new Error(`Subagent model initial Attempt failed: ${JSON.stringify(delegated)}`)
           }
-          globalThis.subagentModelContinuationFrameId = child.frame_id
+          globalThis.subagentModelContinuationFrameId = child.frameId
           reply = 'Subagent model initial Attempt completed.'
         } else if (prompt.includes(SUBAGENT_MODEL_CONTINUATION_FINISH_PROMPT)) {
           const frameId = globalThis.subagentModelContinuationFrameId
@@ -982,7 +982,7 @@ if (process.argv.includes('--version')) {
           const continued = controlResultValue(
             await executeControlCode(
               context.params.sessionId,
-              `const receipt = await host.sendFrameMessage(${JSON.stringify(frameId)}, "Continue after Settings changed"); return await host.collect([{ frameId: receipt.target_frame_id, attemptId: receipt.continuation_attempt_id }], { timeoutSeconds: 30 })`
+              `const receipt = await host.sendFrameMessage(${JSON.stringify(frameId)}, "Continue after Settings changed"); return await host.collect([{ frameId: receipt.targetFrameId, attemptId: receipt.continuationAttemptId }], { timeoutSeconds: 30 })`
             )
           )
           if (continued.length !== 1 || continued[0].status !== 'completed') {
@@ -1035,7 +1035,7 @@ if (process.argv.includes('--version')) {
             child.response !== 'Structured child completed.' ||
             child.structured_output?.count !== 3 ||
             child.structured_output_unsatisfied !== false ||
-            child.artifacts_created?.length !== 1
+            child.artifactsCreated?.length !== 1
           ) {
             throw new Error(`Structured delegation failed: ${JSON.stringify(delegated)}`)
           }
@@ -1057,7 +1057,7 @@ if (process.argv.includes('--version')) {
           const upward = controlResultValue(
             await executeControlCode(
               context.params.sessionId,
-              `const sent = await host.sendFrameMessage("parent", "Child reliable question reached Main", { kind: "question", requestId: "e2e-child-to-main" }); return await host.messageReceipt(sent.message_id, { timeoutSeconds: 0 })`
+              `const sent = await host.sendFrameMessage("parent", "Child reliable question reached Main", { kind: "question", requestId: "e2e-child-to-main" }); return await host.messageReceipt(sent.messageId, { timeoutSeconds: 0 })`
             )
           )
           if (upward.status !== 'queued' || upward.direction !== 'to_parent') {
@@ -1099,7 +1099,7 @@ if (process.argv.includes('--version')) {
           const answered = controlResultValue(
             await executeControlCode(
               context.params.sessionId,
-              `const sent = await host.sendFrameMessage(${JSON.stringify(childFrameId)}, "Main answered the reliable child question", { kind: "info", requestId: "e2e-main-reply-to-child" }); return await host.messageReceipt(sent.message_id, { timeoutSeconds: 30 })`
+              `const sent = await host.sendFrameMessage(${JSON.stringify(childFrameId)}, "Main answered the reliable child question", { kind: "info", requestId: "e2e-main-reply-to-child" }); return await host.messageReceipt(sent.messageId, { timeoutSeconds: 30 })`
             )
           )
           if (answered.status !== 'accepted' || answered.direction !== 'to_child') {

--- a/e2e/fixtures/fake-opencode.mjs
+++ b/e2e/fixtures/fake-opencode.mjs
@@ -763,7 +763,7 @@ if (process.argv.includes('--version')) {
             dispatched.children.length !== 2 ||
             dispatched.children[0].status !== 'completed' ||
             dispatched.children[1].status !== 'running' ||
-            Object.hasOwn(dispatched.children[1], 'artifacts_created')
+            Object.hasOwn(dispatched.children[1], 'artifactsCreated')
           ) {
             throw new Error(`Timed delegate observation failed: ${JSON.stringify(dispatched)}`)
           }
@@ -1033,8 +1033,8 @@ if (process.argv.includes('--version')) {
             delegated.kind !== 'results' ||
             child?.status !== 'completed' ||
             child.response !== 'Structured child completed.' ||
-            child.structured_output?.count !== 3 ||
-            child.structured_output_unsatisfied !== false ||
+            child.structuredOutput?.count !== 3 ||
+            child.structuredOutputUnsatisfied !== false ||
             child.artifactsCreated?.length !== 1
           ) {
             throw new Error(`Structured delegation failed: ${JSON.stringify(delegated)}`)

--- a/resources/notebook/repl_loop.js
+++ b/resources/notebook/repl_loop.js
@@ -1558,6 +1558,19 @@ const exactObject = (value, requiredKeys, optionalKeys = []) => {
   )
 }
 
+const camelCasedHostValue = (value) => {
+  if (Array.isArray(value)) return Object.freeze(value.map(camelCasedHostValue))
+  if (!value || typeof value !== 'object') return value
+  return Object.freeze(
+    Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key.replace(/_([a-z])/gu, (_, letter) => letter.toUpperCase()),
+        camelCasedHostValue(entry)
+      ])
+    )
+  )
+}
+
 const hostFrameString = (value) => typeof value === 'string'
 const hostFrameCount = (value) => Number.isSafeInteger(value) && value >= 0
 const hostFrameOptionalString = (value) => value === undefined || hostFrameString(value)
@@ -2547,21 +2560,25 @@ async function hostLineageGraph(versionId, options = {}) {
   if (arguments.length < 1 || arguments.length > 2) {
     throw new TypeError('host.lineage.graph accepts versionId and at most one options object')
   }
-  return validatedHostLineageGraph(
-    await lineageRpc('graph', {
-      version_id: versionId,
-      options: remappedHostObject(options, 'host.lineage.graph options', {
-        direction: 'direction',
-        maxDepth: 'max_depth',
-        maxNodes: 'max_nodes'
+  return camelCasedHostValue(
+    validatedHostLineageGraph(
+      await lineageRpc('graph', {
+        version_id: versionId,
+        options: remappedHostObject(options, 'host.lineage.graph options', {
+          direction: 'direction',
+          maxDepth: 'max_depth',
+          maxNodes: 'max_nodes'
+        })
       })
-    })
+    )
   )
 }
 
 async function hostLineageGet(versionId) {
   if (arguments.length !== 1) throw new TypeError('host.lineage.get accepts one versionId')
-  return validatedHostLineageVersion(await lineageRpc('get', { version_id: versionId }))
+  return camelCasedHostValue(
+    validatedHostLineageVersion(await lineageRpc('get', { version_id: versionId }))
+  )
 }
 
 const hostLineage = Object.freeze({ graph: hostLineageGraph, get: hostLineageGet })
@@ -2594,9 +2611,9 @@ async function hostFramesList(options = {}) {
   ) {
     throw new Error('host.frames.list returned an invalid result')
   }
-  return Object.freeze({
+  return camelCasedHostValue({
     project_id: result.project_id,
-    frames: Object.freeze(result.frames.map(validatedHostFrame)),
+    frames: result.frames.map(validatedHostFrame),
     total_count: result.total_count,
     ...(result.next_cursor !== undefined ? { next_cursor: result.next_cursor } : {})
   })
@@ -2628,13 +2645,13 @@ async function hostFramesGet(frameId, options = {}) {
   if (frame.frame_id !== frameId || frame.session_id !== session.session_id) {
     throw new Error('host.frames.get returned an invalid result')
   }
-  return Object.freeze({
+  return camelCasedHostValue({
     project_id: result.project_id,
     session,
     frame,
     branch: validatedHostFrameBranch(result.branch),
     transcript: validatedHostFrameTranscript(result.transcript),
-    runtime_segments: Object.freeze(result.runtime_segments.map(validatedHostRuntimeSegment))
+    runtime_segments: result.runtime_segments.map(validatedHostRuntimeSegment)
   })
 }
 
@@ -2835,20 +2852,20 @@ async function delegateRpc(request, options = {}) {
   return {
     kind: outcome.kind,
     children: (outcome.children || []).map((child) => ({
-      frame_id: child.frameId,
-      attempt_id: child.attemptId,
+      frameId: child.frameId,
+      attemptId: child.attemptId,
       ...(child.name !== undefined ? { name: child.name } : {}),
-      ...(child.agentName !== undefined ? { agent_name: child.agentName } : {}),
+      ...(child.agentName !== undefined ? { agentName: child.agentName } : {}),
       status: child.status,
-      ...(child.terminalMessageId ? { terminal_message_id: child.terminalMessageId } : {}),
+      ...(child.terminalMessageId ? { terminalMessageId: child.terminalMessageId } : {}),
       ...(child.response !== undefined ? { response: child.response } : {}),
-      ...(child.status !== 'running' ? { artifacts_created: child.artifactsCreated || [] } : {}),
-      ...(child.cancellationReason ? { cancellation_reason: child.cancellationReason } : {}),
+      ...(child.status !== 'running' ? { artifactsCreated: child.artifactsCreated || [] } : {}),
+      ...(child.cancellationReason ? { cancellationReason: child.cancellationReason } : {}),
       ...(child.error ? { error: child.error } : {}),
       ...(child.structuredOutputUnsatisfied !== undefined
-        ? { structured_output_unsatisfied: child.structuredOutputUnsatisfied }
+        ? { structuredOutputUnsatisfied: child.structuredOutputUnsatisfied }
         : {}),
-      ...(child.structuredOutput !== undefined ? { structured_output: child.structuredOutput } : {})
+      ...(child.structuredOutput !== undefined ? { structuredOutput: child.structuredOutput } : {})
     }))
   }
 }
@@ -2906,7 +2923,7 @@ async function hostStopChild(frameIds) {
     throw hostDelegationError('stopChild', body.error || 'HTTP ' + res.status)
   }
   return (body.result || []).map((child) => ({
-    frame_id: child.frameId,
+    frameId: child.frameId,
     status: child.status
   }))
 }
@@ -2934,23 +2951,23 @@ async function delegatedObservationRpc(op, selectors = undefined, options = unde
     throw hostDelegationError(op, body.error || 'HTTP ' + res.status)
   }
   return (body.result || []).map((child) => ({
-    frame_id: child.frameId,
-    attempt_id: child.attemptId,
+    frameId: child.frameId,
+    attemptId: child.attemptId,
     ...(child.title !== undefined ? { title: child.title } : {}),
     ...(child.name !== undefined ? { name: child.name } : {}),
-    ...(child.agentName !== undefined ? { agent_name: child.agentName } : {}),
+    ...(child.agentName !== undefined ? { agentName: child.agentName } : {}),
     status: child.status,
-    ...(child.terminalMessageId ? { terminal_message_id: child.terminalMessageId } : {}),
+    ...(child.terminalMessageId ? { terminalMessageId: child.terminalMessageId } : {}),
     ...(child.response !== undefined ? { response: child.response } : {}),
     ...(op === 'collect' && child.status !== 'running'
-      ? { artifacts_created: child.artifactsCreated || [] }
+      ? { artifactsCreated: child.artifactsCreated || [] }
       : {}),
-    ...(child.cancellationReason ? { cancellation_reason: child.cancellationReason } : {}),
+    ...(child.cancellationReason ? { cancellationReason: child.cancellationReason } : {}),
     ...(child.error ? { error: child.error } : {}),
     ...(child.structuredOutputUnsatisfied !== undefined
-      ? { structured_output_unsatisfied: child.structuredOutputUnsatisfied }
+      ? { structuredOutputUnsatisfied: child.structuredOutputUnsatisfied }
       : {}),
-    ...(child.structuredOutput !== undefined ? { structured_output: child.structuredOutput } : {})
+    ...(child.structuredOutput !== undefined ? { structuredOutput: child.structuredOutput } : {})
   }))
 }
 
@@ -3024,7 +3041,7 @@ async function hostSendFrameMessage(target, message, options = undefined) {
   if (!res.ok || body.error) {
     throw hostDelegationError('sendFrameMessage', body.error || 'HTTP ' + res.status)
   }
-  return body.result
+  return camelCasedHostValue(body.result)
 }
 
 async function hostMessageReceipt(selector, options = undefined) {
@@ -3062,7 +3079,7 @@ async function delegatedMessageRpc(op, publicMethod, params) {
   if (!res.ok || body.error) {
     throw hostDelegationError(publicMethod, body.error || 'HTTP ' + res.status)
   }
-  return body.result
+  return camelCasedHostValue(body.result)
 }
 
 // host.agents namespace. JavaScript methods, inputs, and returned records use camelCase. The private

--- a/resources/skills/self-awareness/SKILL.md
+++ b/resources/skills/self-awareness/SKILL.md
@@ -141,14 +141,14 @@ When `caps.lineage === true`, start with
 Artifact content. `options` accepts only `direction` (`'up'` by default or `'down'`), `maxDepth`
 (default 5, maximum 20), and `maxNodes` (default 100, maximum 500). Graphs use stable BFS order;
 an Upload is an upstream leaf and may be a downstream root. A truncated result includes a reason
-and `frontier_version_ids` for a narrower follow-up query.
+and `frontierVersionIds` for a narrower follow-up query.
 
 ```javascript
 const caps = await host.capabilities()
 if (caps.lineage === true) {
   const graph = await host.lineage.graph(versionId)
-  const generated = graph.nodes.find((node) => !node.is_user_upload)
-  const provenance = generated ? await host.lineage.get(generated.version_id) : undefined
+  const generated = graph.nodes.find((node) => !node.isUserUpload)
+  const provenance = generated ? await host.lineage.get(generated.versionId) : undefined
 }
 ```
 
@@ -170,13 +170,13 @@ When `caps.frames === true`, use `await host.frames.list(options)` for a metadat
 Sessions in the token-owned current Project. It never searches message bodies. Optional camelCase
 fields are `search`, `sessionId`, `rootsOnly` (default `true`), `kind`, `archived`
 (`exclude`/`include`/`only`, default `exclude`), `after`, `before`, `cursor`, and `limit` (default 20,
-maximum 100). Metadata search fuzzily matches Session title, `agent_name`, and `delegate_name`.
+maximum 100). Metadata search fuzzily matches Session title, `agentName`, and `delegateName`.
 
 Use `await host.frames.get(frameId, options)` with an exact full Frame ID to read one visible
 conversation path. `sessionId` may narrow or disambiguate within the current Project. `branchId`
 selects a specific Branch; without it, the Frame's active Branch is used. The latest 40 messages are
 returned chronologically by default, with a maximum of 100. Pass `before` with the returned
-`previous_cursor` to page backward through older messages.
+`previousCursor` to page backward through older messages.
 
 The result contains frozen Project, Session, Frame, Branch, visible transcript, and sanitized runtime
 segment projections. Messages follow the selected Branch graph rather than stored array order. The

--- a/src/main/host-sdk/delegate-contract.test.ts
+++ b/src/main/host-sdk/delegate-contract.test.ts
@@ -44,7 +44,7 @@ describe('Agent-facing delegate contract', () => {
     })
     expect(DELEGATE_AGENT_CONTRACT.options.properties).not.toHaveProperty('timeout_seconds')
     expect(DELEGATE_AGENT_CONTRACT.returns.oneOf[0].properties.children.items.required).toContain(
-      'frame_id'
+      'frameId'
     )
     expect(singleRequest.properties.profile.description).toContain(
       'Omit to inherit the authenticated parent Specialist'
@@ -117,7 +117,7 @@ describe('Agent-facing delegate contract', () => {
 })
 
 describe('Agent-facing collect contract', () => {
-  it('publishes camel-case selector and option inputs while retaining snake-case returns', () => {
+  it('publishes camel-case selector, option, and return fields', () => {
     const explicitSelector = COLLECT_AGENT_CONTRACT.selectors.items.oneOf[1]
     expect(explicitSelector).toMatchObject({
       additionalProperties: false,
@@ -137,8 +137,8 @@ describe('Agent-facing collect contract', () => {
     })
     expect(COLLECT_AGENT_CONTRACT.options.properties).not.toHaveProperty('timeout_seconds')
     expect(COLLECT_AGENT_CONTRACT.options.additionalProperties).toBe(false)
-    expect(COLLECT_AGENT_CONTRACT.returns.items.oneOf[0].required).toContain('frame_id')
-    expect(COLLECT_AGENT_CONTRACT.returns.items.oneOf[0].required).toContain('attempt_id')
+    expect(COLLECT_AGENT_CONTRACT.returns.items.oneOf[0].required).toContain('frameId')
+    expect(COLLECT_AGENT_CONTRACT.returns.items.oneOf[0].required).toContain('attemptId')
   })
 
   it('parses private snake-case wire selectors with bounded options', () => {

--- a/src/main/host-sdk/delegate-contract.ts
+++ b/src/main/host-sdk/delegate-contract.ts
@@ -8,55 +8,55 @@ import { MAX_DELEGATE_NAME_CODE_POINTS } from '../delegation/delegated-work-admi
 
 const RUNNING_OBSERVATION_SCHEMA = {
   type: 'object',
-  required: ['frame_id', 'attempt_id', 'name', 'agent_name', 'status'],
+  required: ['frameId', 'attemptId', 'name', 'agentName', 'status'],
   optional: [],
   properties: {
-    frame_id: { type: 'string' },
-    attempt_id: { type: 'string' },
+    frameId: { type: 'string' },
+    attemptId: { type: 'string' },
     name: { type: 'string' },
-    agent_name: { type: 'string' },
+    agentName: { type: 'string' },
     status: { type: 'string', enum: ['running'] }
   }
 } as const
 
 const AWAITING_USER_OBSERVATION_SCHEMA = {
   type: 'object',
-  required: ['frame_id', 'attempt_id', 'name', 'agent_name', 'status'],
+  required: ['frameId', 'attemptId', 'name', 'agentName', 'status'],
   optional: ['title'],
   properties: {
-    frame_id: { type: 'string' },
-    attempt_id: { type: 'string' },
+    frameId: { type: 'string' },
+    attemptId: { type: 'string' },
     title: { type: 'string' },
     name: { type: 'string' },
-    agent_name: { type: 'string' },
+    agentName: { type: 'string' },
     status: { type: 'string', enum: ['awaiting_user'] }
   }
 } as const
 
 const TERMINAL_RESULT_SCHEMA = {
   type: 'object',
-  required: ['frame_id', 'attempt_id', 'name', 'agent_name', 'status', 'artifacts_created'],
+  required: ['frameId', 'attemptId', 'name', 'agentName', 'status', 'artifactsCreated'],
   optional: [
-    'terminal_message_id',
+    'terminalMessageId',
     'response',
-    'cancellation_reason',
+    'cancellationReason',
     'error',
-    'structured_output',
-    'structured_output_unsatisfied'
+    'structuredOutput',
+    'structuredOutputUnsatisfied'
   ],
   properties: {
-    frame_id: { type: 'string' },
-    attempt_id: { type: 'string' },
+    frameId: { type: 'string' },
+    attemptId: { type: 'string' },
     name: { type: 'string', description: 'Child delegation name.' },
-    agent_name: { type: 'string', description: 'Resolved Attempt agent display name.' },
+    agentName: { type: 'string', description: 'Resolved Attempt agent display name.' },
     status: { type: 'string', enum: ['completed', 'cancelled', 'error'] },
-    terminal_message_id: { type: 'string' },
+    terminalMessageId: { type: 'string' },
     response: { type: 'string' },
-    artifacts_created: {
+    artifactsCreated: {
       type: 'array',
       items: { type: 'object', description: 'Finalized Artifact Version metadata.' }
     },
-    cancellation_reason: {
+    cancellationReason: {
       type: 'string',
       enum: ['main_agent_stop', 'session_stop', 'runtime_interrupted']
     },
@@ -65,8 +65,8 @@ const TERMINAL_RESULT_SCHEMA = {
       required: ['code', 'message'],
       properties: { code: { type: 'string' }, message: { type: 'string' } }
     },
-    structured_output: { description: 'Accepted JSON value for the exact Attempt.' },
-    structured_output_unsatisfied: { type: 'boolean' }
+    structuredOutput: { description: 'Accepted JSON value for the exact Attempt.' },
+    structuredOutputUnsatisfied: { type: 'boolean' }
   }
 } as const
 
@@ -194,13 +194,13 @@ const DELEGATE_AGENT_CONTRACT = {
             type: 'array',
             items: {
               type: 'object',
-              required: ['frame_id', 'attempt_id', 'name', 'agent_name', 'status'],
+              required: ['frameId', 'attemptId', 'name', 'agentName', 'status'],
               optional: [],
               properties: {
-                frame_id: { type: 'string' },
-                attempt_id: { type: 'string' },
+                frameId: { type: 'string' },
+                attemptId: { type: 'string' },
                 name: { type: 'string', description: 'Child delegation name.' },
-                agent_name: { type: 'string', description: 'Resolved Attempt agent display name.' },
+                agentName: { type: 'string', description: 'Resolved Attempt agent display name.' },
                 status: { type: 'string', enum: ['running'] }
               }
             }

--- a/src/main/host-sdk/help.test.ts
+++ b/src/main/host-sdk/help.test.ts
@@ -238,21 +238,21 @@ describe('Host SDK help', () => {
     })
     const childFields = fields(canonical.returns, 'child_fields')
     expect(childFields.map(({ name }) => name)).toEqual([
-      'frame_id',
-      'attempt_id',
+      'frameId',
+      'attemptId',
       'name',
-      'agent_name',
+      'agentName',
       'status',
-      'terminal_message_id',
+      'terminalMessageId',
       'response',
-      'artifacts_created',
-      'cancellation_reason',
+      'artifactsCreated',
+      'cancellationReason',
       'error',
-      'structured_output',
-      'structured_output_unsatisfied'
+      'structuredOutput',
+      'structuredOutputUnsatisfied'
     ])
-    expect(named(childFields, 'frame_id')).toMatchObject({ type: 'string', required: true })
-    expect(named(childFields, 'artifacts_created')).toMatchObject({
+    expect(named(childFields, 'frameId')).toMatchObject({ type: 'string', required: true })
+    expect(named(childFields, 'artifactsCreated')).toMatchObject({
       type: 'array',
       when: 'terminal'
     })
@@ -289,11 +289,11 @@ describe('Host SDK help', () => {
       expect.objectContaining({ name: 'frameIds', type: 'string[]', required: false })
     ])
     expect(fields(children.returns, 'item_fields').map(({ name }) => name)).toEqual([
-      'frame_id',
-      'attempt_id',
+      'frameId',
+      'attemptId',
       'title',
       'name',
-      'agent_name',
+      'agentName',
       'status'
     ])
     expect(named(fields(children.returns, 'item_fields'), 'status').description).toContain(
@@ -311,14 +311,14 @@ describe('Host SDK help', () => {
     expect(named(fields(collect.options), 'returnWhen')).toMatchObject({ default: 'all' })
     expect(collect.constraints.join(' ')).toContain('currently running')
     expect(collect.call_forms[0]?.signature).toBe('await host.collect(selectors, options?)')
-    expect(collect.examples[0]?.code).toContain('{ frameId: frame_id, attemptId: attempt_id }')
+    expect(collect.examples[0]?.code).toContain('{ frameId, attemptId }')
 
     const stop = operation('stopChild')
     expect(fields(stop.request)).toEqual([
       expect.objectContaining({ name: 'frameIds', type: 'string[]', required: true })
     ])
     expect(fields(stop.returns, 'item_fields').map(({ name }) => name)).toEqual([
-      'frame_id',
+      'frameId',
       'status'
     ])
     expect(stop.call_forms[0]?.signature).toBe('await host.stopChild(frameIds)')
@@ -361,29 +361,29 @@ describe('Host SDK help', () => {
         ]
       })
       expect(fields(help.returns).map(({ name }) => name)).toEqual([
-        'request_id',
-        'message_id',
-        'source_frame_id',
-        'target_frame_id',
-        'reply_to_message_id',
-        'queued_at',
+        'requestId',
+        'messageId',
+        'sourceFrameId',
+        'targetFrameId',
+        'replyToMessageId',
+        'queuedAt',
         'direction',
         'disposition',
-        'target_attempt_id',
-        'continuation_attempt_id',
-        'source_attempt_id',
-        'root_prompt_message_id',
+        'targetAttemptId',
+        'continuationAttemptId',
+        'sourceAttemptId',
+        'rootPromptMessageId',
         'status',
-        'dispatch_started_at',
-        'accepted_at',
+        'dispatchStartedAt',
+        'acceptedAt',
         'evidence',
-        'failed_at',
+        'failedAt',
         'error',
-        'uncertain_at',
-        'delivery_may_have_occurred',
+        'uncertainAt',
+        'deliveryMayHaveOccurred',
         'resolution',
-        'new_request_retry_safe',
-        'same_request_safe'
+        'newRequestRetrySafe',
+        'sameRequestSafe'
       ])
     }
     expect(operation('resolveMessage').returns).toMatchObject({

--- a/src/main/host-sdk/help.test.ts
+++ b/src/main/host-sdk/help.test.ts
@@ -47,6 +47,15 @@ const named = (items: HelpField[], name: string): HelpField => {
   return result
 }
 
+const snakeCaseObjectKeys = (value: unknown): string[] => {
+  if (Array.isArray(value)) return value.flatMap(snakeCaseObjectKeys)
+  if (!value || typeof value !== 'object') return []
+  return Object.entries(value).flatMap(([key, entry]) => [
+    ...(key.includes('_') ? [key] : []),
+    ...snakeCaseObjectKeys(entry)
+  ])
+}
+
 describe('Host SDK help', () => {
   it('lists only registered operation topics in a compact deterministic catalog', () => {
     const catalog = hostSdkHelp.query(undefined, mainContext)
@@ -82,7 +91,7 @@ describe('Host SDK help', () => {
       kind: 'operation',
       id: 'host.viewImage',
       availability: { status: 'available' },
-      call_forms: [{ signature: 'await host.viewImage(source, options?)' }]
+      callForms: [{ signature: 'await host.viewImage(source, options?)' }]
     })
     if (help.kind !== 'operation') throw new Error('expected operation help')
     const request = JSON.stringify(help.request)
@@ -102,14 +111,14 @@ describe('Host SDK help', () => {
       kind: 'operation',
       id: 'host.currentModel',
       availability: { status: 'available' },
-      call_forms: [{ signature: 'await host.currentModel()' }],
+      callForms: [{ signature: 'await host.currentModel()' }],
       returns: { type: 'string' }
     })
     expect(hostSdkHelp.query('listModels', { ...mainContext, capabilities })).toMatchObject({
       kind: 'operation',
       id: 'host.listModels',
       availability: { status: 'unavailable' },
-      call_forms: [{ signature: 'await host.listModels()' }],
+      callForms: [{ signature: 'await host.listModels()' }],
       returns: { type: 'string[]' }
     })
   })
@@ -124,7 +133,7 @@ describe('Host SDK help', () => {
       kind: 'operation',
       id: 'host.llm',
       availability: { status: 'available' },
-      call_forms: [{ signature: 'await host.llm(request, options?)' }]
+      callForms: [{ signature: 'await host.llm(request, options?)' }]
     })
     expect(hostSdkHelp.query('host.llm', { ...mainContext, capabilities })).toEqual(help)
     if (help.kind !== 'operation') throw new Error('expected operation help')
@@ -137,15 +146,15 @@ describe('Host SDK help', () => {
       default: 2,
       range: '1..4'
     })
-    expect(fields(help.returns, 'success_fields').map(({ name }) => name)).toEqual([
+    expect(fields(help.returns, 'successFields').map(({ name }) => name)).toEqual([
       'text',
       'model',
       'stopReason',
       'usage'
     ])
-    expect(fields(help.returns, 'batch_error_fields').map(({ name }) => name)).toEqual(['error'])
+    expect(fields(help.returns, 'batchErrorFields').map(({ name }) => name)).toEqual(['error'])
     expect(
-      fields(help.returns, 'usage_fields').map(({ name, required }) => ({ name, required }))
+      fields(help.returns, 'usageFields').map(({ name, required }) => ({ name, required }))
     ).toEqual([
       { name: 'inputTokens', required: true },
       { name: 'cacheTokens', required: true },
@@ -169,7 +178,7 @@ describe('Host SDK help', () => {
       kind: 'operation',
       id: 'host.sessions',
       availability: { status: 'available' },
-      call_forms: [
+      callForms: [
         { signature: 'await host.sessions.list(options?)' },
         { signature: 'await host.sessions.inspect(sessionId)' }
       ]
@@ -236,7 +245,7 @@ describe('Host SDK help', () => {
         }
       ]
     })
-    const childFields = fields(canonical.returns, 'child_fields')
+    const childFields = fields(canonical.returns, 'childFields')
     expect(childFields.map(({ name }) => name)).toEqual([
       'frameId',
       'attemptId',
@@ -270,11 +279,12 @@ describe('Host SDK help', () => {
   })
 
   it('uses the same flat field-description shape for every operation topic', () => {
-    for (const id of HOST_SDK_SUBAGENT_OPERATION_IDS) {
+    for (const id of HOST_SDK_OPERATION_IDS) {
       const help = operation(id, id === 'host.submitOutput' ? 'delegate' : 'main')
       expect(Array.isArray((help.request as { fields?: unknown }).fields)).toBe(true)
       expect(Array.isArray((help.options as { fields?: unknown }).fields)).toBe(true)
       expect(help).not.toHaveProperty('errors')
+      expect(snakeCaseObjectKeys(help)).toEqual([])
       const serialized = JSON.stringify(help)
       expect(serialized).not.toContain('"oneOf"')
       expect(serialized).not.toContain('"allOf"')
@@ -288,7 +298,7 @@ describe('Host SDK help', () => {
     expect(fields(children.request)).toEqual([
       expect.objectContaining({ name: 'frameIds', type: 'string[]', required: false })
     ])
-    expect(fields(children.returns, 'item_fields').map(({ name }) => name)).toEqual([
+    expect(fields(children.returns, 'itemFields').map(({ name }) => name)).toEqual([
       'frameId',
       'attemptId',
       'title',
@@ -296,7 +306,7 @@ describe('Host SDK help', () => {
       'agentName',
       'status'
     ])
-    expect(named(fields(children.returns, 'item_fields'), 'status').description).toContain(
+    expect(named(fields(children.returns, 'itemFields'), 'status').description).toContain(
       'awaiting_user'
     )
 
@@ -310,18 +320,18 @@ describe('Host SDK help', () => {
     })
     expect(named(fields(collect.options), 'returnWhen')).toMatchObject({ default: 'all' })
     expect(collect.constraints.join(' ')).toContain('currently running')
-    expect(collect.call_forms[0]?.signature).toBe('await host.collect(selectors, options?)')
+    expect(collect.callForms[0]?.signature).toBe('await host.collect(selectors, options?)')
     expect(collect.examples[0]?.code).toContain('{ frameId, attemptId }')
 
     const stop = operation('stopChild')
     expect(fields(stop.request)).toEqual([
       expect.objectContaining({ name: 'frameIds', type: 'string[]', required: true })
     ])
-    expect(fields(stop.returns, 'item_fields').map(({ name }) => name)).toEqual([
+    expect(fields(stop.returns, 'itemFields').map(({ name }) => name)).toEqual([
       'frameId',
       'status'
     ])
-    expect(stop.call_forms[0]?.signature).toBe('await host.stopChild(frameIds)')
+    expect(stop.callForms[0]?.signature).toBe('await host.stopChild(frameIds)')
 
     const send = operation('sendFrameMessage')
     expect(fields(send.options).map(({ name }) => name)).toEqual([
@@ -329,7 +339,7 @@ describe('Host SDK help', () => {
       'requestId',
       'replyToMessageId'
     ])
-    expect(send.call_forms[0]?.signature).toBe(
+    expect(send.callForms[0]?.signature).toBe(
       'await host.sendFrameMessage(target, message, options?)'
     )
 
@@ -345,7 +355,7 @@ describe('Host SDK help', () => {
     ])
 
     const submitOutput = operation('submitOutput', 'delegate')
-    expect(submitOutput.call_forms[0]?.signature).toBe('await host.submitOutput(value)')
+    expect(submitOutput.callForms[0]?.signature).toBe('await host.submitOutput(value)')
     expect(submitOutput.constraints.join(' ')).toContain('mandatory')
     expect(submitOutput.constraints.join(' ')).toContain('ordinary final response')
   })

--- a/src/main/host-sdk/help.ts
+++ b/src/main/host-sdk/help.ts
@@ -41,7 +41,7 @@ type HostSdkHelpOperationDescriptor = Readonly<{
   path: string
   aliases: readonly string[]
   summary: string
-  call_forms: readonly Readonly<{ signature: string; accepts: string }>[]
+  callForms: readonly Readonly<{ signature: string; accepts: string }>[]
   request: Readonly<Record<string, unknown>>
   options: Readonly<Record<string, unknown>>
   returns: Readonly<Record<string, unknown>>
@@ -155,7 +155,7 @@ const DELEGATE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   path: 'host.delegate',
   aliases: ['delegate'],
   summary: 'Dispatch one child or an atomic fan-out; optionally observe it.',
-  call_forms: [
+  callForms: [
     {
       signature: 'await host.delegate(request | requests, options?)',
       accepts: 'object_or_non_empty_array'
@@ -230,7 +230,7 @@ const DELEGATE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
         statuses: ['completed', 'cancelled', 'error']
       }
     ],
-    child_fields: DELEGATION_CHILD_FIELDS
+    childFields: DELEGATION_CHILD_FIELDS
   },
   constraints: [
     'Main/root only; no nested delegation.',
@@ -276,7 +276,7 @@ const CHILDREN_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   path: 'host.children',
   aliases: ['children'],
   summary: 'List current direct-child Attempts on the active Message Branch.',
-  call_forms: [{ signature: 'await host.children(frameIds?)', accepts: 'optional_frame_id_array' }],
+  callForms: [{ signature: 'await host.children(frameIds?)', accepts: 'optional_frame_id_array' }],
   request: {
     fields: [
       {
@@ -288,7 +288,7 @@ const CHILDREN_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
     ]
   },
   options: NO_OPTIONS,
-  returns: { type: 'array', item_fields: INVENTORY_FIELDS },
+  returns: { type: 'array', itemFields: INVENTORY_FIELDS },
   constraints: [
     'Main/root only; results cover current direct-child Attempts on the active branch.',
     'Results preserve durable admission order; historical Attempt handles are not recovered.'
@@ -306,7 +306,7 @@ const COLLECT_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   path: 'host.collect',
   aliases: ['collect'],
   summary: 'Observe pinned Attempts until any/all settle or time expires.',
-  call_forms: [
+  callForms: [
     { signature: 'await host.collect(selectors, options?)', accepts: 'non_empty_selector_array' }
   ],
   request: {
@@ -338,7 +338,7 @@ const COLLECT_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
       }
     ]
   },
-  returns: { type: 'array', item_fields: DELEGATION_CHILD_FIELDS },
+  returns: { type: 'array', itemFields: DELEGATION_CHILD_FIELDS },
   constraints: [
     'Main/root only; only direct children on the active branch are collectible.',
     'Expiry returns every latest observation and never stops a child.',
@@ -359,9 +359,7 @@ const STOP_CHILD_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   path: 'host.stopChild',
   aliases: ['stopChild'],
   summary: 'Stop one or more direct-child Frames.',
-  call_forms: [
-    { signature: 'await host.stopChild(frameIds)', accepts: 'non_empty_frame_id_array' }
-  ],
+  callForms: [{ signature: 'await host.stopChild(frameIds)', accepts: 'non_empty_frame_id_array' }],
   request: {
     fields: [
       {
@@ -375,7 +373,7 @@ const STOP_CHILD_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   options: NO_OPTIONS,
   returns: {
     type: 'array',
-    item_fields: [
+    itemFields: [
       { name: 'frameId', type: 'string', required: true, description: 'Requested Frame.' },
       {
         name: 'status',
@@ -407,7 +405,7 @@ const SUBMIT_OUTPUT_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   path: 'host.submitOutput',
   aliases: ['submitOutput'],
   summary: 'Submit the authenticated child Attempt structured JSON value.',
-  call_forms: [{ signature: 'await host.submitOutput(value)', accepts: 'json_value' }],
+  callForms: [{ signature: 'await host.submitOutput(value)', accepts: 'json_value' }],
   request: {
     fields: [
       {
@@ -546,7 +544,7 @@ const SEND_FRAME_MESSAGE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   path: 'host.sendFrameMessage',
   aliases: ['sendFrameMessage'],
   summary: 'Queue a running coordination message to a child or parent.',
-  call_forms: [
+  callForms: [
     {
       signature: 'await host.sendFrameMessage(target, message, options?)',
       accepts: 'positional_arguments'
@@ -599,7 +597,7 @@ const MESSAGE_RECEIPT_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   path: 'host.messageReceipt',
   aliases: ['messageReceipt'],
   summary: 'Observe an owned delivery receipt for a bounded time.',
-  call_forms: [
+  callForms: [
     { signature: 'await host.messageReceipt(selector, options?)', accepts: 'selector_options' }
   ],
   request: {
@@ -648,7 +646,7 @@ const RESOLVE_MESSAGE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   path: 'host.resolveMessage',
   aliases: ['resolveMessage'],
   summary: 'Acknowledge uncertain delivery risk and release its lane fence.',
-  call_forms: [
+  callForms: [
     {
       signature: "await host.resolveMessage(messageId, { action: 'acknowledge_uncertain' })",
       accepts: 'message_resolution'
@@ -698,7 +696,7 @@ const VIEW_IMAGE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   path: 'host.viewImage',
   aliases: ['viewImage'],
   summary: 'Attach an authorized existing image to the current repl_execute result.',
-  call_forms: [{ signature: 'await host.viewImage(source, options?)', accepts: 'source_options' }],
+  callForms: [{ signature: 'await host.viewImage(source, options?)', accepts: 'source_options' }],
   request: {
     fields: [
       {
@@ -766,7 +764,7 @@ const CURRENT_MODEL_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   path: 'host.currentModel',
   aliases: ['currentModel'],
   summary: "Return the calling Session's exact current model id.",
-  call_forms: [{ signature: 'await host.currentModel()', accepts: 'no_arguments' }],
+  callForms: [{ signature: 'await host.currentModel()', accepts: 'no_arguments' }],
   request: NO_OPTIONS,
   options: NO_OPTIONS,
   returns: { type: 'string', description: 'Exact model id for the token-bound Session.' },
@@ -787,7 +785,7 @@ const LLM_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   path: 'host.llm',
   aliases: ['llm'],
   summary: 'Run bounded, one-shot, tool-less inference through the active Host LLM backend.',
-  call_forms: [{ signature: 'await host.llm(request, options?)', accepts: 'request_options' }],
+  callForms: [{ signature: 'await host.llm(request, options?)', accepts: 'request_options' }],
   request: {
     accepts: ['prompt_string', 'exact_prompt_object', 'request_array'],
     fields: [
@@ -813,7 +811,7 @@ const LLM_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   },
   returns: {
     mirrorsInput: true,
-    success_fields: [
+    successFields: [
       { name: 'text', type: 'string', required: true, description: 'Generated text.' },
       { name: 'model', type: 'string', required: true, description: 'Observed model id.' },
       {
@@ -829,7 +827,7 @@ const LLM_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
         description: 'Provider-neutral camelCase token usage when available.'
       }
     ],
-    usage_fields: [
+    usageFields: [
       {
         name: 'inputTokens',
         type: 'integer',
@@ -867,7 +865,7 @@ const LLM_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
         description: 'Positive provider-turn count when available.'
       }
     ],
-    batch_error_fields: [
+    batchErrorFields: [
       { name: 'error', type: 'string', required: true, description: 'Public per-item failure.' }
     ]
   },
@@ -895,7 +893,7 @@ const LIST_MODELS_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   path: 'host.listModels',
   aliases: ['listModels'],
   summary: 'List configured models for the current Host LLM Provider and framework.',
-  call_forms: [{ signature: 'await host.listModels()', accepts: 'no_arguments' }],
+  callForms: [{ signature: 'await host.listModels()', accepts: 'no_arguments' }],
   request: NO_OPTIONS,
   options: NO_OPTIONS,
   returns: {
@@ -919,7 +917,7 @@ const SESSIONS_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   path: 'host.sessions',
   aliases: ['sessions'],
   summary: 'List or inspect read-only Session diagnostics in the current Project.',
-  call_forms: [
+  callForms: [
     { signature: 'await host.sessions.list(options?)', accepts: 'optional_list_options' },
     { signature: 'await host.sessions.inspect(sessionId)', accepts: 'exact_session_id' }
   ],
@@ -967,12 +965,12 @@ const SESSIONS_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   },
   returns: {
     type: 'SessionDiagnostic | SessionDiagnosticPage',
-    list_fields: [
+    listFields: [
       { name: 'totalCount', type: 'integer', required: true, description: 'Total matches.' },
       { name: 'nextCursor', type: 'string', required: false, description: 'Next page.' },
       { name: 'sessions', type: 'SessionDiagnostic[]', required: true, description: 'Page.' }
     ],
-    session_fields: [
+    sessionFields: [
       { name: 'sessionId', type: 'string', required: true, description: 'Exact Session id.' },
       { name: 'title', type: 'string', required: true, description: 'Durable title.' },
       { name: 'status', type: 'string', required: true, description: 'Durable Session status.' },
@@ -1133,7 +1131,7 @@ const hostSdkHelp: HostSdkHelpRegistry = Object.freeze({
       {
         kind: descriptor.kind,
         id: descriptor.id,
-        call_forms: descriptor.call_forms,
+        callForms: descriptor.callForms,
         request: descriptor.request,
         options: descriptor.options,
         returns: descriptor.returns,

--- a/src/main/host-sdk/help.ts
+++ b/src/main/host-sdk/help.ts
@@ -100,15 +100,15 @@ const rootOnlyAvailability =
 const NO_OPTIONS = { fields: [] } as const
 
 const DELEGATION_CHILD_FIELDS = [
-  { name: 'frame_id', type: 'string', required: true, description: 'Child Frame id.' },
+  { name: 'frameId', type: 'string', required: true, description: 'Child Frame id.' },
   {
-    name: 'attempt_id',
+    name: 'attemptId',
     type: 'string',
     required: true,
     description: 'Selected Attempt id.'
   },
   { name: 'name', type: 'string', required: true, description: 'Child name.' },
-  { name: 'agent_name', type: 'string', required: true, description: 'Specialist.' },
+  { name: 'agentName', type: 'string', required: true, description: 'Specialist.' },
   {
     name: 'status',
     type: 'string',
@@ -116,33 +116,33 @@ const DELEGATION_CHILD_FIELDS = [
     description: 'running/completed/cancelled/error.'
   },
   {
-    name: 'terminal_message_id',
+    name: 'terminalMessageId',
     type: 'string',
     when: 'terminal',
     description: 'Terminal message id.'
   },
   { name: 'response', type: 'string', when: 'completed', description: 'Final text.' },
   {
-    name: 'artifacts_created',
+    name: 'artifactsCreated',
     type: 'array',
     when: 'terminal',
     description: 'Created Artifacts.'
   },
   {
-    name: 'cancellation_reason',
+    name: 'cancellationReason',
     type: 'string',
     when: 'cancelled',
     description: 'Stop reason.'
   },
   { name: 'error', type: 'object', when: 'error', description: 'Failure details.' },
   {
-    name: 'structured_output',
+    name: 'structuredOutput',
     type: 'JSON value',
     when: 'submitted',
     description: 'Validated output.'
   },
   {
-    name: 'structured_output_unsatisfied',
+    name: 'structuredOutputUnsatisfied',
     type: 'boolean',
     when: 'terminal without required submission',
     description: 'Required output missing.'
@@ -257,11 +257,11 @@ const DELEGATE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
 }
 
 const INVENTORY_FIELDS = [
-  { name: 'frame_id', type: 'string', required: true, description: 'Stable child Frame id.' },
-  { name: 'attempt_id', type: 'string', required: true, description: 'Current Attempt id.' },
+  { name: 'frameId', type: 'string', required: true, description: 'Stable child Frame id.' },
+  { name: 'attemptId', type: 'string', required: true, description: 'Current Attempt id.' },
   { name: 'title', type: 'string', required: false, description: 'Legacy display title.' },
   { name: 'name', type: 'string', required: true, description: 'Child name.' },
-  { name: 'agent_name', type: 'string', required: true, description: 'Specialist name.' },
+  { name: 'agentName', type: 'string', required: true, description: 'Specialist name.' },
   {
     name: 'status',
     type: 'string',
@@ -347,7 +347,7 @@ const COLLECT_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   examples: [
     {
       title: 'Collect pinned Attempts',
-      code: 'await host.collect(sent.children.map(({ frame_id, attempt_id }) => ({ frameId: frame_id, attemptId: attempt_id })))'
+      code: 'await host.collect(sent.children.map(({ frameId, attemptId }) => ({ frameId, attemptId })))'
     }
   ],
   resolveAvailability: rootOnlyAvailability('collect', 'Delegate agents cannot collect children.')
@@ -376,7 +376,7 @@ const STOP_CHILD_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   returns: {
     type: 'array',
     item_fields: [
-      { name: 'frame_id', type: 'string', required: true, description: 'Requested Frame.' },
+      { name: 'frameId', type: 'string', required: true, description: 'Requested Frame.' },
       {
         name: 'status',
         type: 'string',
@@ -392,7 +392,7 @@ const STOP_CHILD_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   examples: [
     {
       title: 'Stop children',
-      code: 'await host.stopChild(current.map(({ frame_id }) => frame_id))'
+      code: 'await host.stopChild(current.map(({ frameId }) => frameId))'
     }
   ],
   resolveAvailability: rootOnlyAvailability(
@@ -449,17 +449,17 @@ const messageAvailability =
     capabilities[operation] ? { status: 'available' } : unavailableProvisioning(operation)
 
 const DELIVERY_RECEIPT_FIELDS = [
-  { name: 'request_id', type: 'string', required: true, description: 'Idempotency key.' },
-  { name: 'message_id', type: 'string', required: true, description: 'Command id.' },
-  { name: 'source_frame_id', type: 'string', required: true, description: 'Sender Frame.' },
-  { name: 'target_frame_id', type: 'string', required: true, description: 'Receiver Frame.' },
+  { name: 'requestId', type: 'string', required: true, description: 'Idempotency key.' },
+  { name: 'messageId', type: 'string', required: true, description: 'Command id.' },
+  { name: 'sourceFrameId', type: 'string', required: true, description: 'Sender Frame.' },
+  { name: 'targetFrameId', type: 'string', required: true, description: 'Receiver Frame.' },
   {
-    name: 'reply_to_message_id',
+    name: 'replyToMessageId',
     type: 'string',
     required: false,
     description: 'Replied-to message.'
   },
-  { name: 'queued_at', type: 'number', required: true, description: 'Queue time.' },
+  { name: 'queuedAt', type: 'number', required: true, description: 'Queue time.' },
   { name: 'direction', type: 'string', required: true, description: 'Route.' },
   {
     name: 'disposition',
@@ -468,25 +468,25 @@ const DELIVERY_RECEIPT_FIELDS = [
     description: 'Delivery form.'
   },
   {
-    name: 'target_attempt_id',
+    name: 'targetAttemptId',
     type: 'string',
     when: 'to_child message',
     description: 'Receiver Attempt.'
   },
   {
-    name: 'continuation_attempt_id',
+    name: 'continuationAttemptId',
     type: 'string',
     when: 'to_child continued',
     description: 'New Attempt.'
   },
   {
-    name: 'source_attempt_id',
+    name: 'sourceAttemptId',
     type: 'string',
     when: 'to_parent',
     description: 'Sender Attempt.'
   },
   {
-    name: 'root_prompt_message_id',
+    name: 'rootPromptMessageId',
     type: 'string',
     when: 'to_parent',
     description: 'Root prompt id.'
@@ -498,18 +498,18 @@ const DELIVERY_RECEIPT_FIELDS = [
     description: 'Delivery state.'
   },
   {
-    name: 'dispatch_started_at',
+    name: 'dispatchStartedAt',
     type: 'number',
     when: 'queued',
     description: 'Dispatch start.'
   },
-  { name: 'accepted_at', type: 'number', when: 'accepted', description: 'Acceptance time.' },
+  { name: 'acceptedAt', type: 'number', when: 'accepted', description: 'Acceptance time.' },
   { name: 'evidence', type: 'string', when: 'accepted', description: 'Acceptance proof.' },
-  { name: 'failed_at', type: 'number', when: 'failed', description: 'Failure time.' },
+  { name: 'failedAt', type: 'number', when: 'failed', description: 'Failure time.' },
   { name: 'error', type: 'object', when: 'failed', description: 'Failure/retry details.' },
-  { name: 'uncertain_at', type: 'number', when: 'uncertain', description: 'Uncertainty time.' },
+  { name: 'uncertainAt', type: 'number', when: 'uncertain', description: 'Uncertainty time.' },
   {
-    name: 'delivery_may_have_occurred',
+    name: 'deliveryMayHaveOccurred',
     type: 'boolean',
     when: 'uncertain',
     description: 'Delivery is unknown.'
@@ -521,13 +521,13 @@ const DELIVERY_RECEIPT_FIELDS = [
     description: 'Risk resolution.'
   },
   {
-    name: 'new_request_retry_safe',
+    name: 'newRequestRetrySafe',
     type: 'boolean',
     required: true,
     description: 'New-id retry safety.'
   },
   {
-    name: 'same_request_safe',
+    name: 'sameRequestSafe',
     type: 'boolean',
     required: true,
     description: 'Same-id recovery safety.'
@@ -636,7 +636,7 @@ const MESSAGE_RECEIPT_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   examples: [
     {
       title: 'Observe delivery',
-      code: 'await host.messageReceipt(receipt.message_id, { timeoutSeconds: 30 })'
+      code: 'await host.messageReceipt(receipt.messageId, { timeoutSeconds: 30 })'
     }
   ],
   resolveAvailability: messageAvailability('messageReceipt')
@@ -683,7 +683,7 @@ const RESOLVE_MESSAGE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   examples: [
     {
       title: 'Release fence',
-      code: "await host.resolveMessage(receipt.message_id, { action: 'acknowledge_uncertain' })"
+      code: "await host.resolveMessage(receipt.messageId, { action: 'acknowledge_uncertain' })"
     }
   ],
   resolveAvailability: rootOnlyAvailability(

--- a/src/main/notebook/repl-loop.integration.test.ts
+++ b/src/main/notebook/repl-loop.integration.test.ts
@@ -303,35 +303,35 @@ describe('repl_loop local RPC transport', () => {
           kind: 'results',
           children: [
             {
-              frame_id: 'child-1',
-              attempt_id: 'attempt-1',
+              frameId: 'child-1',
+              attemptId: 'attempt-1',
               name: 'Source trace',
-              agent_name: 'Evidence Analyst',
+              agentName: 'Evidence Analyst',
               status: 'completed',
               response: 'Durable answer',
-              artifacts_created: []
+              artifactsCreated: []
             }
           ]
         },
         children: [
           {
-            frame_id: 'child-1',
-            attempt_id: 'attempt-1',
+            frameId: 'child-1',
+            attemptId: 'attempt-1',
             title: 'Source trace',
             name: 'Source trace',
-            agent_name: 'Evidence Analyst',
+            agentName: 'Evidence Analyst',
             status: 'completed'
           }
         ],
         collected: [
           {
-            frame_id: 'child-1',
-            attempt_id: 'attempt-1',
+            frameId: 'child-1',
+            attemptId: 'attempt-1',
             name: 'Source trace',
-            agent_name: 'Evidence Analyst',
+            agentName: 'Evidence Analyst',
             status: 'completed',
             response: 'Durable answer',
-            artifacts_created: []
+            artifactsCreated: []
           }
         ]
       })
@@ -408,15 +408,15 @@ describe('repl_loop local RPC transport', () => {
       const result = JSON.parse(response.result ?? '{}')
       expect(result.selected).toEqual({ id: selected.id, name: selected.name })
       expect(result.byId.children[0]).toMatchObject({
-        agent_name: 'Evidence Analyst',
+        agentName: 'Evidence Analyst',
         status: 'running'
       })
       expect(result.byName.children[0]).toMatchObject({
-        agent_name: 'Evidence Analyst',
+        agentName: 'Evidence Analyst',
         status: 'running'
       })
       expect(result.main.children[0]).toMatchObject({
-        agent_name: 'Main Agent',
+        agentName: 'Main Agent',
         status: 'running'
       })
 
@@ -537,42 +537,42 @@ describe('repl_loop local RPC transport', () => {
           kind: 'receipts',
           children: [
             {
-              frame_id: 'child-1',
-              attempt_id: 'attempt-1',
+              frameId: 'child-1',
+              attemptId: 'attempt-1',
               name: 'Source trace',
-              agent_name: 'Main Agent',
+              agentName: 'Main Agent',
               status: 'running'
             }
           ]
         },
         children: [
           {
-            frame_id: 'child-1',
-            attempt_id: 'attempt-1',
+            frameId: 'child-1',
+            attemptId: 'attempt-1',
             title: 'Source trace',
             status: 'running'
           }
         ]
       })
       const secondCell = await send(
-        "return { results: await host.collect(globalThis.pendingDelegation.children.map(({ frame_id, attempt_id }) => ({ frameId: frame_id, attemptId: attempt_id })), { timeoutSeconds: 0, returnWhen: 'any' }) }"
+        "return { results: await host.collect(globalThis.pendingDelegation.children.map(({ frameId, attemptId }) => ({ frameId, attemptId })), { timeoutSeconds: 0, returnWhen: 'any' }) }"
       )
       expect(secondCell.error).toBeNull()
       expect(JSON.parse(secondCell.result ?? '{}')).toEqual({
         results: [
           {
-            frame_id: 'child-1',
-            attempt_id: 'attempt-1',
+            frameId: 'child-1',
+            attemptId: 'attempt-1',
             status: 'completed',
-            terminal_message_id: 'message-1',
+            terminalMessageId: 'message-1',
             response: 'Durable answer',
-            artifacts_created: []
+            artifactsCreated: []
           },
           {
-            frame_id: 'child-2',
-            attempt_id: 'attempt-2',
+            frameId: 'child-2',
+            attemptId: 'attempt-2',
             name: 'Long analysis',
-            agent_name: 'Main Agent',
+            agentName: 'Main Agent',
             status: 'running'
           }
         ]
@@ -684,7 +684,7 @@ describe('repl_loop local RPC transport', () => {
         direction: 'to_child',
         disposition: 'continued',
         status: 'queued',
-        continuation_attempt_id: 'attempt-2'
+        continuationAttemptId: 'attempt-2'
       })
       expect(received).toEqual({
         method: 'delegatedWorkCall',
@@ -746,7 +746,7 @@ describe('repl_loop local RPC transport', () => {
         direction: 'to_child',
         disposition: 'continued',
         status: 'queued',
-        continuation_attempt_id: 'attempt-2'
+        continuationAttemptId: 'attempt-2'
       })
       expect(received).toEqual({
         method: 'delegatedWorkCall',
@@ -806,9 +806,9 @@ describe('repl_loop local RPC transport', () => {
         direction: 'to_parent',
         disposition: 'message',
         status: 'queued',
-        message_id: 'message-1',
-        target_frame_id: 'parent-frame',
-        source_attempt_id: 'attempt-1'
+        messageId: 'message-1',
+        targetFrameId: 'parent-frame',
+        sourceAttemptId: 'attempt-1'
       })
       expect(received).toEqual({
         method: 'delegatedWorkCall',
@@ -860,7 +860,7 @@ describe('repl_loop local RPC transport', () => {
       )
       expect(result.error).toBeNull()
       expect(JSON.parse(result.result ?? '{}')).toEqual({
-        stopped: [{ frame_id: 'child-frame', status: 'cancelled' }],
+        stopped: [{ frameId: 'child-frame', status: 'cancelled' }],
         observed: { status: 'accepted' },
         resolved: { status: 'accepted' }
       })
@@ -1425,9 +1425,9 @@ describe('repl_loop local RPC transport', () => {
           'environmentFrozen: Object.isFrozen(core.environment), ' +
           'packagesFrozen: Object.isFrozen(core.environment.packages), ' +
           'packageFrozen: Object.isFrozen(core.environment.packages[0]), ' +
-          'opLogFrozen: Object.isFrozen(core.environment.op_log), ' +
-          'attemptFrozen: Object.isFrozen(core.environment.op_log[0].attempts[0]), ' +
-          'returnFields: [first.root_version_id, first.nodes[0].version_id, core.version_id] })'
+          'opLogFrozen: Object.isFrozen(core.environment.opLog), ' +
+          'attemptFrozen: Object.isFrozen(core.environment.opLog[0].attempts[0]), ' +
+          'returnFields: [first.rootVersionId, first.nodes[0].versionId, core.versionId] })'
       )
       expect(projection.error).toBeNull()
       expect(JSON.parse(projection.result ?? '{}')).toEqual({
@@ -2127,18 +2127,18 @@ describe('repl_loop local RPC transport', () => {
           'framesFrozen: Object.isFrozen(page.frames), frameFrozen: Object.isFrozen(page.frames[0]), ' +
           'detailFrozen: Object.isFrozen(detail), transcriptFrozen: Object.isFrozen(detail.transcript), ' +
           'sessionFrozen: Object.isFrozen(detail.session), detailFrameFrozen: Object.isFrozen(detail.frame), ' +
-          'branchFrozen: Object.isFrozen(detail.branch), segmentsFrozen: Object.isFrozen(detail.runtime_segments), ' +
-          'segmentFrozen: Object.isFrozen(detail.runtime_segments[0]), ' +
+          'branchFrozen: Object.isFrozen(detail.branch), segmentsFrozen: Object.isFrozen(detail.runtimeSegments), ' +
+          'segmentFrozen: Object.isFrozen(detail.runtimeSegments[0]), ' +
           'messagesFrozen: Object.isFrozen(detail.transcript.messages), ' +
           'messageFrozen: Object.isFrozen(detail.transcript.messages[0]), ' +
-          'usageFrozen: Object.isFrozen(detail.transcript.messages[0].turn_usage), ' +
+          'usageFrozen: Object.isFrozen(detail.transcript.messages[0].turnUsage), ' +
           'attachmentsFrozen: Object.isFrozen(detail.transcript.messages[0].attachments), ' +
           'attachmentFrozen: Object.isFrozen(detail.transcript.messages[0].attachments[0]) })'
       )
       expect(projection.error).toBeNull()
       expect(JSON.parse(projection.result ?? '{}')).toMatchObject({
-        page: { project_id: 'project-a', total_count: 1, next_cursor: 'next' },
-        detail: { project_id: 'project-a', frame: { frame_id: 'frame-1' } },
+        page: { projectId: 'project-a', totalCount: 1, nextCursor: 'next' },
+        detail: { projectId: 'project-a', frame: { frameId: 'frame-1' } },
         pageFrozen: true,
         framesFrozen: true,
         frameFrozen: true,


### PR DESCRIPTION
## Problem

Public JavaScript Host SDK inputs use camelCase, while delegation receipts and several other result objects exposed snake_case fields. Agents could copy frame_id, attempt_id, or message_id from a result into an API that accepts frameId, attemptId, or messageId and receive a validation failure. The same inconsistency also affected frames, lineage, and help descriptors.

Related issue: none.

## Proposed change

- Project delegation child observations and durable message receipts to camelCase at the agent-facing REPL boundary.
- Project host.frames and host.lineage result objects to camelCase after strict validation while preserving deep freezing.
- Migrate host.help descriptor keys and examples to camelCase.
- Update the self-awareness skill, E2E fixture consumers, contracts, and integration tests.
- Add a recursive guard preventing snake_case keys in registered host.help operation descriptors.

BREAKING CHANGE: agent-facing Host SDK result fields that previously used snake_case now use camelCase.

## Scope and non-goals

Internal durable-work RPC and persistence wire fields remain unchanged. User-owned structuredOutput data is not recursively rewritten. host.compute retains its documented wire-field exception, and third-party MCP payloads are unchanged.

## Acceptance criteria and validation

The following checks ran after the last material edit:

- Delegation result projection and round-trip selectors -> targeted host SDK contract and REPL integration tests -> 46 passed, 31 skipped.
- Public help descriptor naming -> host help tests plus recursive key guard -> 15 passed.
- Node interfaces and adapters -> npm run typecheck:node -> passed.
- Source style -> npm run lint and Prettier checks -> passed.
- E2E fixture syntax -> node --check e2e/fixtures/fake-opencode.mjs -> passed.
- Final diff hygiene -> git diff --check -> passed.
- Final base-to-head impact plan -> npm run test:affected -- --base origin/main --head HEAD -> 18,809 passed, 227 skipped, with one unrelated existing renderer settings-store architecture failure. Neither that test nor its target module is changed by this branch.
- Independent two-axis code review after the fixes -> Standards: no findings; Spec: no findings.

## Review focus

Please focus on the public/private naming boundary in resources/notebook/repl_loop.js, preservation of user-owned structured output, and the host.help recursive naming guard.

## Uncovered risks

The targeted Playwright subagent release gate timed out during application fixture setup before entering the test body; 10 remaining cases did not run. CI remains authoritative for that E2E lane and the unrelated renderer architecture failure.