### PR TITLE
fix(web-events): align renderer event deliverability

### DIFF
--- a/scripts/generate-web-api-map.mjs
+++ b/scripts/generate-web-api-map.mjs
@@ -18,9 +18,9 @@ const stringLiteral = (node, label) => {
 
 // prettier-ignore
 const invokeProfiles = new Set(['WEB', 'LOCAL', 'MAPPED_ELECTRON', 'MAPPED_NATIVE', 'DELEGATED_NATIVE'])
-const eventProfiles = new Set(['EVENT', 'DORMANT_EVENT', 'CLOSE_PANE_EVENT'])
+const eventProfiles = new Set(['EVENT'])
 // prettier-ignore
-const unprojectedProfiles = new Set(['ELECTRON', 'SEND', 'WINDOW_FIND_READY', 'ELECTRON_EVENT', 'NATIVE'])
+const unprojectedProfiles = new Set(['ELECTRON', 'SEND', 'WINDOW_FIND_READY', 'ELECTRON_EVENT', 'CLOSE_PANE_EVENT', 'NATIVE'])
 
 const projectionFor = (node) => {
   if (!node) return 'invoke'

--- a/src/main/application-event-flow.test.ts
+++ b/src/main/application-event-flow.test.ts
@@ -6,11 +6,14 @@ const windows: Array<{
 }> = []
 
 vi.mock('electron', () => ({
-  BrowserWindow: { getAllWindows: () => windows }
+  BrowserWindow: { getAllWindows: () => windows },
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() }
 }))
 
 import type { AcpRuntimeEvent } from '../shared/acp'
+import type { ProvisionProgress } from '../shared/notebook-env'
 import { ApplicationEventHub } from './application-events'
+import { broadcastNotebookEnvProgress } from './notebook/env-ipc'
 import { broadcastToRenderers, installRendererBroadcastEventHub } from './renderer-broadcast'
 import {
   projectPublicTaskEvent,
@@ -23,6 +26,46 @@ beforeEach(() => {
 })
 
 describe('application event flow', () => {
+  it('delivers notebook environment progress once to Electron and Web renderers', () => {
+    const progress: ProvisionProgress = {
+      phase: 'download',
+      message: 'Downloading Python runtime',
+      progress: 0.42,
+      operationId: 'operation-1',
+      scope: 'python',
+      language: 'python'
+    }
+    const webEvents: unknown[] = []
+    windows.push({
+      isDestroyed: () => false,
+      webContents: { send: vi.fn() }
+    })
+    const hub = new ApplicationEventHub()
+    const uninstall = installRendererBroadcastEventHub(hub)
+    const removeWeb = hub.subscribe((event) => {
+      const projection = projectWebRendererEvent(event)
+      if (projection) webEvents.push(projection)
+    })
+
+    try {
+      broadcastNotebookEnvProgress(progress)
+
+      expect(windows[0].webContents.send).toHaveBeenCalledOnce()
+      expect(windows[0].webContents.send).toHaveBeenCalledWith('notebook-env:progress', progress)
+      expect(webEvents).toEqual([
+        {
+          protocolVersion: 1,
+          channel: 'notebook-env:progress',
+          payload: progress
+        }
+      ])
+    } finally {
+      removeWeb()
+      uninstall()
+      hub.dispose()
+    }
+  })
+
   it('delivers terminal stop and failure events once in Electron, Task, and Web order', () => {
     const order: string[] = []
     const payloads: AcpRuntimeEvent[] = [

--- a/src/main/application-events.ts
+++ b/src/main/application-events.ts
@@ -14,6 +14,7 @@ import type {
   SessionUpsertEvent
 } from '../shared/lifecycle-events'
 import type { NotebookAvailableEvent, NotebookChangedEvent } from '../shared/notebook'
+import type { ProvisionProgress } from '../shared/notebook-env'
 import type { NotificationInboxChanged } from '../shared/notifications'
 import type { PermissionGrantsChangedEvent } from '../shared/permission-grants'
 import type { ProjectFilesChangedEvent } from '../shared/project-files'
@@ -47,6 +48,7 @@ export type ApplicationEventMap = {
   'side-chat:relay-delivered': SideChatRelayDeliveredEvent
   'notebook:available': NotebookAvailableEvent
   'notebook:changed': NotebookChangedEvent
+  'notebook-env:progress': ProvisionProgress
   'notifications:changed': NotificationInboxChanged
   'project:created': Project
   'project:updated': Project

--- a/src/main/notebook/env-ipc.ts
+++ b/src/main/notebook/env-ipc.ts
@@ -1,15 +1,12 @@
-import { BrowserWindow } from 'electron'
-
 import type { NotebookLanguage } from '../../shared/notebook'
 import { ipcMainHandle } from '../ipc-handler-registry'
+import { broadcastToRenderers } from '../renderer-broadcast'
 import type { NotebookEnvironmentLifecycle } from './environment-lifecycle-workflows'
 import type { ProvisionProgress } from './provisioner'
 
-// Broadcasts a progress event to every live renderer window.
+// Publishes progress through the application event hub so Electron and Web share one ordered event.
 export const broadcastNotebookEnvProgress = (progress: ProvisionProgress): void => {
-  for (const window of BrowserWindow.getAllWindows()) {
-    if (!window.isDestroyed()) window.webContents.send('notebook-env:progress', progress)
-  }
+  broadcastToRenderers('notebook-env:progress', progress)
 }
 
 // Registers the stable renderer surface while lifecycle ordering and state stay behind the workflow

--- a/src/preload/renderer-api.d.ts
+++ b/src/preload/renderer-api.d.ts
@@ -692,7 +692,7 @@ export interface OpenScienceAPI {
       request: NotificationMarkSessionCompletionsReadRequest
     ): Promise<void>
     onChanged(listener: AcpListener<NotificationInboxChanged>): RemoveListener
-    onOpenSession(listener: () => void): RemoveListener
+    onOpenSession?(listener: () => void): RemoveListener
     peekPendingOpenSession(): Promise<OpenSessionFromNotificationRequest | null>
     takePendingOpenSession(
       expectedToken: number
@@ -881,7 +881,7 @@ export interface OpenScienceAPI {
     getTransferStatus(request: UploadTransferRequest): Promise<UploadTransferStatus | null>
     finishTransfer(request: UploadTransferRequest): Promise<UploadedAttachment>
     abortTransfer(request: UploadTransferRequest): Promise<void>
-    onTransferProgress(listener: AcpListener<UploadTransferProgress>): RemoveListener
+    onTransferProgress?(listener: AcpListener<UploadTransferProgress>): RemoveListener
     // Deletes a staged upload when the composer chip is removed or the draft is abandoned.
     deleteUpload(request: DeleteUploadRequest): Promise<void>
     // Moves pending uploads into the durable session directory once a session id exists.
@@ -1034,7 +1034,7 @@ export interface OpenScienceAPI {
     // Closes the focused window (the Cmd+W / Ctrl+W fallback when no preview panel is open).
     close(): Promise<void>
     // Fires when Cmd+W / Ctrl+W is pressed; the renderer decides pane-vs-window.
-    onCloseActivePane(listener: () => void): RemoveListener
+    onCloseActivePane?(listener: () => void): RemoveListener
     findInPage?(request: WindowFindRequest): void
     clearFind?(): void
     // Announces the Workspace is mounted (READY) and returns a teardown that announces UNREADY.

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -455,7 +455,7 @@ const AppContent = (): React.JSX.Element | null => {
   // open during partial recovery; unresolved ones remain pending for the retry path below.
   useEffect(
     () =>
-      window.api.notifications.onOpenSession(() => {
+      window.api.notifications.onOpenSession?.(() => {
         const intent = {
           generation: notificationOpenIntent.current.generation + 1,
           userNavigationRevision: useNavigationStore.getState().userNavigationRevision

--- a/src/renderer/src/hooks/useCloseActivePaneShortcut.ts
+++ b/src/renderer/src/hooks/useCloseActivePaneShortcut.ts
@@ -35,7 +35,7 @@ export const useCloseActivePaneShortcut = (
 
   useEffect(
     () =>
-      window.api.window.onCloseActivePane(() => {
+      window.api.window.onCloseActivePane?.(() => {
         const request = resolveCloseRequestRef.current?.() ?? 'close-base'
         if (request === 'handled') return
 

--- a/src/renderer/src/pages/workspace/composer-upload-transfer.ts
+++ b/src/renderer/src/pages/workspace/composer-upload-transfer.ts
@@ -21,7 +21,7 @@ export type UploadStagingApi = {
   finishTransfer: (request: UploadTransferRequest) => Promise<UploadedAttachment>
   abortTransfer: (request: UploadTransferRequest) => Promise<void>
   deleteUpload: (request: { path: string }) => Promise<void>
-  onTransferProgress: (listener: (progress: UploadTransferProgress) => void) => () => void
+  onTransferProgress?: (listener: (progress: UploadTransferProgress) => void) => () => void
 }
 
 type StageComposerFileOptions = {
@@ -98,9 +98,10 @@ export const stageComposerFile = async (
     totalBytes: request.size
   })
 
-  const removeProgressListener = api.onTransferProgress((progress) => {
-    if (progress.transferId === request.transferId) options.onProgress?.(progress)
-  })
+  const removeProgressListener =
+    api.onTransferProgress?.((progress) => {
+      if (progress.transferId === request.transferId) options.onProgress?.(progress)
+    }) ?? (() => undefined)
 
   try {
     assertNotAborted(options.signal)

--- a/src/renderer/web/api-installer.test.ts
+++ b/src/renderer/web/api-installer.test.ts
@@ -72,7 +72,7 @@ describe('installWebRendererContracts', () => {
     ])
   })
 
-  it('installs browser-native and inert event adapters without Electron lifecycle dispatch', () => {
+  it('installs Web event subscriptions and omits Electron-only event adapters', () => {
     const api: Record<string, unknown> = {}
     const close = vi.fn()
     const subscribe = vi.fn(() => vi.fn())
@@ -90,9 +90,14 @@ describe('installWebRendererContracts', () => {
     expect(methodAt(api, 'specialist.list')).toBeUndefined()
     expect(methodAt(api, 'uploads.stageLocalFile')).toBeUndefined()
     expect(methodAt(api, 'window.announceWindowFindReady')).toBeUndefined()
+    expect(methodAt(api, 'notifications.onOpenSession')).toBeUndefined()
+    expect(methodAt(api, 'notifications.onViewProbe')).toBeUndefined()
+    expect(methodAt(api, 'uploads.onTransferProgress')).toBeUndefined()
+    expect(methodAt(api, 'window.onCloseActivePane')).toBeUndefined()
 
-    const unsubscribe = methodAt(api, 'window.onCloseActivePane')?.(listener)
-    expect(subscribe).toHaveBeenCalledWith('shortcut:close-active-pane', listener)
+    const unsubscribe = methodAt(api, 'notebookEnv.onProgress')?.(listener)
+    expect(subscribe).toHaveBeenCalledOnce()
+    expect(subscribe).toHaveBeenCalledWith('notebook-env:progress', listener)
     expect(unsubscribe).toBe(subscribe.mock.results[0]?.value)
   })
 

--- a/src/shared/renderer-contract-catalog.test.ts
+++ b/src/shared/renderer-contract-catalog.test.ts
@@ -49,16 +49,12 @@ describe('renderer contract catalog', () => {
     })
 
     expect(
-      paths(({ eventDeliverability }) =>
-        Object.values(eventDeliverability).includes('installed-undelivered')
+      paths(
+        ({ surfaceInstallation, eventDeliverability }) =>
+          surfaceInstallation.localWeb === 'web-event' &&
+          eventDeliverability.localWeb !== 'application-event'
       )
-    ).toEqual([
-      'notebookEnv.onProgress',
-      'notifications.onOpenSession',
-      'notifications.onViewProbe',
-      'uploads.onTransferProgress',
-      'window.onCloseActivePane'
-    ])
+    ).toEqual([])
   })
 
   it('records every intentional and known-deviating argument codec without normalizing it', () => {

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -11,7 +11,6 @@ import { DATABASE_STARTUP_CHANNELS } from './database-startup'
 const WEB = 'web'
 const LOCAL = 'local'
 const EVENT = 'event'
-const DORMANT_EVENT = 'dormant-event'
 const CLOSE_PANE_EVENT = 'close-pane-event'
 const ELECTRON = 'electron'
 const MAPPED_ELECTRON = 'mapped-electron'
@@ -40,7 +39,7 @@ const SESSION_SAVE_JSON = 'session-save-json-undefined'
 const RUNTIME_VALIDATED = 'runtime-validated'
 
 // prettier-ignore
-type ContractProfile = typeof WEB | typeof LOCAL | typeof EVENT | typeof DORMANT_EVENT | typeof CLOSE_PANE_EVENT | typeof ELECTRON | typeof MAPPED_ELECTRON | typeof SEND | typeof WINDOW_FIND_READY | typeof ELECTRON_EVENT | typeof NATIVE | typeof MAPPED_NATIVE | typeof DELEGATED_NATIVE
+type ContractProfile = typeof WEB | typeof LOCAL | typeof EVENT | typeof CLOSE_PANE_EVENT | typeof ELECTRON | typeof MAPPED_ELECTRON | typeof SEND | typeof WINDOW_FIND_READY | typeof ELECTRON_EVENT | typeof NATIVE | typeof MAPPED_NATIVE | typeof DELEGATED_NATIVE
 
 // prettier-ignore
 type ContractEntry = readonly [member: string, channel: string | null, profile?: ContractProfile, electronCodec?: RendererParameterCodec, webCodec?: RendererParameterCodec, applicationCommand?: typeof RUNTIME_VALIDATED]
@@ -61,9 +60,8 @@ const expandEntry = (
   [member, channel, profile = WEB, electronCodec, webCodec, applicationCommand]: ContractEntry
 ): RendererContractSeed => {
   const isWebRequest = profile === WEB || profile === LOCAL
-  const isDormantEvent = profile === DORMANT_EVENT || profile === CLOSE_PANE_EVENT
-  const isWebEvent = profile === EVENT || isDormantEvent
-  const isElectronEvent = profile === ELECTRON_EVENT
+  const isWebEvent = profile === EVENT
+  const isElectronEvent = profile === ELECTRON_EVENT || profile === CLOSE_PANE_EVENT
   const isNative = profile === NATIVE || profile === MAPPED_NATIVE || profile === DELEGATED_NATIVE
   const kind = isWebEvent || isElectronEvent ? 'event' : 'method'
   const defaultElectronCodec =
@@ -114,20 +112,8 @@ const expandEntry = (
     ),
     eventDeliverability: surface(
       kind === 'event' ? 'electron-ipc' : 'not-event',
-      profile === EVENT
-        ? 'application-event'
-        : isDormantEvent
-          ? 'installed-undelivered'
-          : kind === 'event'
-            ? 'unavailable'
-            : 'not-event',
-      profile === EVENT
-        ? 'application-event'
-        : isDormantEvent
-          ? 'installed-undelivered'
-          : kind === 'event'
-            ? 'unavailable'
-            : 'not-event'
+      profile === EVENT ? 'application-event' : kind === 'event' ? 'unavailable' : 'not-event',
+      profile === EVENT ? 'application-event' : kind === 'event' ? 'unavailable' : 'not-event'
     ),
     authorityFlow: surface(
       kind === 'event' || profile === NATIVE ? 'none' : 'electron-sender',
@@ -232,14 +218,14 @@ export const RENDERER_CONTRACT_GROUPS = Object.freeze([
     ['state', 'notebook:state'],
   ]),
   group('notebook-environment', 'notebookEnv', [
-    ['onProgress', 'notebook-env:progress', DORMANT_EVENT], ['cancel', 'notebook-env:cancel', LOCAL, OPTIONAL_ARGUMENT_SLOT, POSITIONAL], ['getStatus', 'notebook-env:status'],
+    ['onProgress', 'notebook-env:progress', EVENT], ['cancel', 'notebook-env:cancel', LOCAL, OPTIONAL_ARGUMENT_SLOT, POSITIONAL], ['getStatus', 'notebook-env:status'],
     ['provision', 'notebook-env:provision', LOCAL], ['repair', 'notebook-env:repair', LOCAL],
   ]),
   group('notifications', 'notifications', [
     ['getSnapshot', 'notifications:get-snapshot'], ['markAllRead', 'notifications:mark-all-read'], ['markRead', 'notifications:mark-read'],
     ['markSessionCompletionsRead', 'notifications:mark-session-completions-read'],
-    ['onChanged', 'notifications:changed', EVENT], ['onOpenSession', 'notifications:open-session', DORMANT_EVENT],
-    ['onViewProbe', 'notifications:probe-unread-view', DORMANT_EVENT], ['peekPendingOpenSession', 'notifications:peek-pending-open-session'],
+    ['onChanged', 'notifications:changed', EVENT], ['onOpenSession', 'notifications:open-session', ELECTRON_EVENT],
+    ['onViewProbe', 'notifications:probe-unread-view', ELECTRON_EVENT], ['peekPendingOpenSession', 'notifications:peek-pending-open-session'],
     ['syncViewState', 'notifications:sync-unread-view', SEND], ['takePendingOpenSession', 'notifications:take-pending-open-session'],
   ]),
   group('office-preview', 'officePreview', [
@@ -391,7 +377,7 @@ export const RENDERER_CONTRACT_GROUPS = Object.freeze([
     ['abortTransfer', 'uploads:abort-transfer'], ['appendTransfer', 'uploads:append-transfer'], ['beginTransfer', 'uploads:begin-transfer'],
     ['claimLocalFile', 'uploads:claim-local-file'], ['deleteUpload', 'uploads:delete'], ['finalizeSession', 'uploads:finalize-session'],
     ['finishTransfer', 'uploads:finish-transfer'], ['getTransferStatus', 'uploads:transfer-status'],
-    ['onTransferProgress', 'uploads:transfer-progress', DORMANT_EVENT], ['readPreview', 'uploads:read-preview'],
+    ['onTransferProgress', 'uploads:transfer-progress', ELECTRON_EVENT], ['readPreview', 'uploads:read-preview'],
     ['stageLocalFile', 'uploads:stage-local-file', MAPPED_ELECTRON, NATIVE_FILE_UPLOAD], ['stageLocalPath', 'uploads:stage-local-path', LOCAL],
   ]),
   group('window', 'window', [

--- a/src/shared/renderer-contract.ts
+++ b/src/shared/renderer-contract.ts
@@ -10,7 +10,7 @@ export type RendererSurfaceInstallation =
 export type RendererDispatchPolicy = 'electron-ipc-request' | 'electron-ipc-send' | 'electron-ipc-subscription' | 'direct-application-request' | 'browser-native-with-direct-application-request' | 'web-event-subscription' | 'surface-native' | 'rejecting-stub' | 'none'
 
 export type RendererEventDeliverability =
-  'not-event' | 'electron-ipc' | 'application-event' | 'installed-undelivered' | 'unavailable'
+  'not-event' | 'electron-ipc' | 'application-event' | 'unavailable'
 
 export type RendererAuthorityFlow = 'electron-sender' | 'caller-context' | 'none'
 export type RendererMapProjection = 'invoke' | 'event' | 'none'

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -42,13 +42,10 @@ type InstalledButNotDeliveredEventChannel = Exclude<
   ApplicationEventChannel
 >
 
-const INSTALLED_BUT_NOT_DELIVERED_EVENTS = {
-  'notebook-env:progress': true,
-  'notifications:open-session': true,
-  'notifications:probe-unread-view': true,
-  'shortcut:close-active-pane': true,
-  'uploads:transfer-progress': true
-} as const satisfies Record<InstalledButNotDeliveredEventChannel, true>
+const INSTALLED_BUT_NOT_DELIVERED_EVENTS = {} as const satisfies Record<
+  InstalledButNotDeliveredEventChannel,
+  true
+>
 
 // These functions exist on the real Electron preload API but the current AST generator does not
 // recognize their implementation shape or channel constants. T1b must make each omission explicit.
@@ -67,6 +64,8 @@ const GENERATED_SOURCE_OMISSIONS = [
   'locale.setPreference',
   'network.checkConnectivity',
   'network.getInfo',
+  'notifications.onOpenSession',
+  'notifications.onViewProbe',
   'notifications.syncViewState',
   'officePreview.attachFrame',
   'officePreview.close',
@@ -121,11 +120,13 @@ const GENERATED_SOURCE_OMISSIONS = [
   'specialist.setEnabled',
   'specialist.setSessionSpecialist',
   'specialist.update',
+  'uploads.onTransferProgress',
   'window.announceWindowFindAppearance',
   'window.announceWindowFindReady',
   'window.clearFind',
   'window.closeFind',
   'window.findInPage',
+  'window.onCloseActivePane',
   'window.onCloseConfirmRequest',
   'window.onFindInPageResult',
   'window.onShowWindowFind',
@@ -281,14 +282,8 @@ describe('renderer surface inventory', () => {
     )
   })
 
-  it('pins subscriptions installed in Web but not published through ApplicationEventHub', () => {
-    expectSameSet(Object.keys(INSTALLED_BUT_NOT_DELIVERED_EVENTS), [
-      'notebook-env:progress',
-      'notifications:open-session',
-      'notifications:probe-unread-view',
-      'shortcut:close-active-pane',
-      'uploads:transfer-progress'
-    ])
+  it('does not install Web subscriptions that lack ApplicationEventHub delivery', () => {
+    expectSameSet(Object.keys(INSTALLED_BUT_NOT_DELIVERED_EVENTS), [])
   })
 
   it('pins browser-native replacements and Electron-only categories', () => {

--- a/src/shared/web-api-map.generated.ts
+++ b/src/shared/web-api-map.generated.ts
@@ -292,8 +292,6 @@ export const WEB_EVENT_CHANNELS = {
   'notebook.onChanged': 'notebook:changed',
   'notebookEnv.onProgress': 'notebook-env:progress',
   'notifications.onChanged': 'notifications:changed',
-  'notifications.onOpenSession': 'notifications:open-session',
-  'notifications.onViewProbe': 'notifications:probe-unread-view',
   'permissions.onChanged': 'permissions:changed',
   'projectFiles.onChanged': 'project-files:changed',
   'projects.onCreated': 'project:created',
@@ -318,7 +316,5 @@ export const WEB_EVENT_CHANNELS = {
   'storage.onProgress': 'storage:migrate-progress',
   'tags.onChanged': 'tags:changed',
   'update.onProgress': 'update:progress',
-  'update.onStatus': 'update:status',
-  'uploads.onTransferProgress': 'uploads:transfer-progress',
-  'window.onCloseActivePane': 'shortcut:close-active-pane'
+  'update.onStatus': 'update:status'
 } as const


### PR DESCRIPTION
## Problem

Local Web installed event subscription functions for channels that production never delivered through the Web event stream. Notebook environment provision and repair were callable locally, but their progress bypassed ApplicationEventHub and went directly to Electron BrowserWindow instances.

## Proposed change

- publish notebook environment progress through ApplicationEventHub so Electron and Web receive the same ordered event
- classify native notification nudges, unread visibility probes, native upload progress, and close-pane shortcuts as Electron-only events
- make those shared renderer capabilities optional and keep Web upload progress on its existing chunk-response path
- remove the installed-undelivered contract state and regenerate the Web API map
- add regressions at the application event flow and Web API installation boundaries

## Scope and non-goals

- no database, persistence, migration, or historical-data compatibility changes
- no new data fields or status enum values
- no cross-client notification-click routing or visibility challenge protocol
- Electron behavior remains unchanged

## Acceptance criteria and validation

The regressions were observed red before the fix twice: Electron received notebook progress while the Web projection stayed empty, and the Web installer exposed Electron-only subscriptions.

Final checks after the last material edit:

- notebook progress and renderer event contracts -> targeted Vitest set -> 15 files, 218 tests passed
- workspace upload consumer module -> npm run test:module -- workspace_page -> 506 passed; one unrelated baseline failure, workspace-session-controller.ts is 701 lines against a 700-line gate, reproduced on main
- generated Web API contract -> npm run check:web-api-map -> passed
- Web types -> npm run typecheck:web -> passed
- Node types -> npm run typecheck:node -> blocked by an unrelated shared-dependency baseline: claude-agent-acp does not export waitForMcpServers; reproduced on main
- lint -> npm run lint -> 0 errors; two existing Prettier warnings in untouched ACP files
- whitespace -> git diff --check -> passed

Per request, the full npm test suite was not run locally; PR CI is authoritative for the complete suite and platform lanes.

## Review focus

- notebook-env:progress now has exactly one application-event publication path
- Web no longer advertises subscriptions that cannot be delivered
- native notification, visibility, upload, and shortcut semantics remain Electron-only