### PR TITLE
fix(artifact-finalization): preserve completed run after save conflict

### DIFF
--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -8,6 +8,7 @@ import {
   ARTIFACT_OWNERSHIP_PERSISTENCE_RACE,
   type ArtifactFile
 } from '../../../../shared/artifacts'
+import { SessionRevisionConflictError } from '../../../../shared/session-persistence'
 import type { ActivePlanProjection } from '../../../../shared/session-plan/contract'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -1682,6 +1683,70 @@ describe('workspace runtime events', () => {
     expect(session.messages[1].artifactIds).toEqual([
       `transport-session-1:${responseMessageId}:result.txt`
     ])
+  })
+
+  it('keeps a successful artifact finalization complete when the projection save conflicts', async () => {
+    const promptMessageId = useSessionStore.getState().sessions[0].activeRun?.promptMessageId
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'assistant-before-save-conflict',
+        role: 'assistant',
+        messageId: 'assistant-before-save-conflict',
+        text: 'Saved the result.'
+      })
+    )
+    const responseMessageId = useSessionStore.getState().sessions[0].messages[1].id
+    const finalizedArtifact = createArtifactFile({
+      id: `transport-session-1:${responseMessageId}:result.txt`,
+      sessionId: 'transport-session-1',
+      messageId: responseMessageId,
+      runId: undefined
+    })
+    const operationOrder: string[] = []
+    const finalizeRunArtifacts = vi.fn().mockImplementation(async () => {
+      operationOrder.push('finalize')
+      return [finalizedArtifact]
+    })
+    const revisionConflict = new SessionRevisionConflictError(562, 567)
+    const saveSession = vi.fn(async () => {
+      operationOrder.push('save')
+      if (operationOrder.length === 3) throw revisionConflict
+    })
+
+    await applyWorkspaceRuntimeEvent(
+      createEvent({
+        id: 'artifact-before-save-conflict',
+        kind: 'artifact',
+        runId: 'artifact-run-before-save-conflict',
+        promptMessageId,
+        artifactSessionId: 'artifact-session-1',
+        artifactClaimId: 'claim-before-save-conflict',
+        artifacts: [createArtifactFile({ runId: 'artifact-run-before-save-conflict' })]
+      }),
+      { finalizeRunArtifacts, saveSession }
+    )
+
+    const failure = await applyWorkspaceRuntimeEvent(
+      createEvent({ id: 'stop-after-finalization', kind: 'stop', text: 'end_turn' })
+    ).then(
+      () => undefined,
+      (error: unknown) => error
+    )
+
+    const session = useSessionStore.getState().sessions[0]
+    expect(finalizeRunArtifacts).toHaveBeenCalledOnce()
+    expect(operationOrder).toEqual(['save', 'finalize', 'save'])
+    expect(session).toMatchObject({
+      status: 'idle',
+      activeRun: undefined,
+      error: undefined
+    })
+    expect(session.messages[1]).toMatchObject({
+      id: responseMessageId,
+      status: 'complete',
+      artifactIds: [finalizedArtifact.id]
+    })
+    expect(failure).toBe(revisionConflict)
   })
 
   it.each([

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -273,6 +273,7 @@ const finalizeArtifactEvent = async (
   if (!attached) return true
 
   const store = useSessionStore.getState()
+  let artifactsFinalized = false
 
   try {
     const persistLatestSession = async (): Promise<void> => {
@@ -309,21 +310,22 @@ const finalizeArtifactEvent = async (
       await persistLatestSession()
       finalizedArtifacts = await finalize(finalizeRequest)
     }
+    artifactsFinalized = true
 
     store.replaceMessageArtifacts({
       sessionId: event.sessionId,
       messageId: attached.messageId,
       artifacts: finalizedArtifacts
     })
+    store.clearArtifactError(event.sessionId)
+    openMoleculePreviews(event.sessionId, finalizedArtifacts)
     // Auto-review and every main-process provenance reader load the durable Session, not renderer
     // memory. Persist the checksum-bearing finalized Version descriptors before the stop handler may
     // trigger a Review, otherwise it can freeze a pre-finalization scope.
     await persistLatestSession()
-    store.clearArtifactError(event.sessionId)
-    openMoleculePreviews(event.sessionId, finalizedArtifacts)
     return true
   } catch (error) {
-    store.recordArtifactError(event.sessionId, getErrorText(error))
+    if (!artifactsFinalized) store.recordArtifactError(event.sessionId, getErrorText(error))
     throw error
   }
 }


### PR DESCRIPTION
## Problem

Artifact finalization can complete durably before the follow-up Session projection save encounters a revision conflict. The shared renderer event handler classified that later persistence failure as Generated file finalization failed, leaving the completed Session in an error state even though the Artifact Version was finalized and linked.

Closes #1622.

## Proposed change

- distinguish a completed Artifact finalizer from failures that occur before finalization completes;
- clear any Artifact error and retain the finalized Message projection before the follow-up Session save;
- continue propagating the persistence conflict so the existing ordered persistence and event retry paths can handle it;
- add a public-boundary regression test for the reported expected 562 / actual 567 conflict after successful finalization.

## Scope and non-goals

- no database schema, persisted field, data model, API, or enum changes;
- no user interaction redesign beyond removing the misleading Artifact failure state;
- no automatic repair of Sessions already persisted in the historical error state;
- no generic expansion of Session three-way merge behavior without the complete conflicting snapshots.

The affected behavior is the shared normalized Artifact/stop event path used after framework translation. There are no protocol, launcher, model, or transport changes for claude-code, opencode, codex-response, or codex-bridge. The observed Windows lane remains relevant in CI, but the minimized reproduction is platform-independent.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- successful finalization followed by Session save conflict -> targeted workspace-events regression -> passed;
- genuine Artifact finalization failures and shared runtime event behavior -> workspace_runtime module selection, run directly as the same 8 Vitest files because the linked worktree does not contain a generated Prisma Client -> 8 files, 347 tests passed;
- renderer TypeScript surface -> npm run typecheck:web -> passed;
- linted source -> npm run lint -> 0 errors; 2 pre-existing Prettier warnings remain in src/main/acp/application-commands.ts and src/main/acp/ipc.ts;
- final affected-plan explanation -> workspace_runtime, workspace_page, reviewer_orchestrator, artifact_provenance, and session_persistence selected; exact-head PR Gate CI is the authority for the broader consumer and Windows-sensitive lanes.

Local full npm test was intentionally not run; PR CI owns the complete portable and platform suites.

## Review focus

Please verify that only pre-finalization failures call recordArtifactError, while a post-finalization persistence conflict still propagates for retry without changing the completed Session, Message, or Artifact projection.