### PR TITLE
fix(settings): align package install controls with runtime ownership

### DIFF
--- a/src/main/settings/types.ts
+++ b/src/main/settings/types.ts
@@ -238,7 +238,7 @@ export type StoredSettings = {
   notebookRuntimes?: Partial<Record<NotebookLanguage, RuntimeSelection>>
   // Per-language v4 environment enablement: an explicit per-env enabled override map plus the separate
   // per-env package-install authorization, both keyed by envId (interpreter real path). Absent means
-  // "use the provenance default" (app-managed ON, user-own/agent-created OFF). See RuntimeEnablement.
+  // "use the provenance default" (app-managed/agent-created ON, user-own OFF). See RuntimeEnablement.
   notebookRuntimeEnablement?: Partial<Record<NotebookLanguage, RuntimeEnablement>>
   // Per-language catalog of interpreter paths the user added manually via "Add interpreter…". These
   // are merged into environment discovery (probed + classified user-own) so a manually-picked

--- a/src/renderer/src/locales/fr.json
+++ b/src/renderer/src/locales/fr.json
@@ -1369,6 +1369,7 @@
   "PHASE {{number}}": "PHASE {{number}}",
   "PINNED": "ÉPINGLEÉ",
   "Package": "Paquet",
+  "Open Science cannot install packages into user-owned R environments yet. You can still manage packages in the environment yourself.": "Open Science ne peut pas encore installer de paquets dans les environnements R appartenant à l’utilisateur. Vous pouvez toujours gérer vous-même les paquets dans l’environnement.",
   "Package mirror": "Miroir de paquet",
   "Package provenance": "Provenance du colis",
   "Package version": "Version du paquet",

--- a/src/renderer/src/locales/ja.json
+++ b/src/renderer/src/locales/ja.json
@@ -1316,6 +1316,7 @@
   "PHASE {{number}}": "フェーズ {{number}}",
   "PINNED": "固定された",
   "Package": "パッケージ",
+  "Open Science cannot install packages into user-owned R environments yet. You can still manage packages in the environment yourself.": "Open Science は、ユーザー所有の R 環境にはまだパッケージをインストールできません。環境内のパッケージは引き続きご自身で管理できます。",
   "Package mirror": "パッケージミラー",
   "Package provenance": "パッケージの来歴",
   "Package version": "パッケージバージョン",

--- a/src/renderer/src/locales/ko.json
+++ b/src/renderer/src/locales/ko.json
@@ -1327,6 +1327,7 @@
   "PHASE {{number}}": "단계 {{number}}",
   "PINNED": "고정됨",
   "Package": "패키지",
+  "Open Science cannot install packages into user-owned R environments yet. You can still manage packages in the environment yourself.": "Open Science는 아직 사용자 소유 R 환경에 패키지를 설치할 수 없습니다. 환경의 패키지는 계속 직접 관리할 수 있습니다.",
   "Package mirror": "패키지 미러",
   "Package provenance": "패키지 출처",
   "Package version": "패키지 버전",

--- a/src/renderer/src/locales/ru.json
+++ b/src/renderer/src/locales/ru.json
@@ -1364,6 +1364,7 @@
   "PHASE {{number}}": "ФАЗА {{number}}",
   "PINNED": "ЗАКРЕПЛЕННЫЙ",
   "Package": "Пакет",
+  "Open Science cannot install packages into user-owned R environments yet. You can still manage packages in the environment yourself.": "Open Science пока не может устанавливать пакеты в принадлежащие пользователю среды R. Вы по-прежнему можете самостоятельно управлять пакетами в этих средах.",
   "Package mirror": "Зеркало репозитория пакетов",
   "Package provenance": "Происхождение пакета",
   "Package version": "Версия пакета",

--- a/src/renderer/src/locales/zh-Hans.json
+++ b/src/renderer/src/locales/zh-Hans.json
@@ -1387,6 +1387,7 @@
   "PHASE {{number}}": "阶段 {{number}}",
   "PINNED": "已固定",
   "Package": "软件包",
+  "Open Science cannot install packages into user-owned R environments yet. You can still manage packages in the environment yourself.": "Open Science 暂时无法在用户自有的 R 环境中安装软件包。您仍然可以自行管理该环境中的软件包。",
   "Package mirror": "软件包镜像",
   "Package provenance": "软件包溯源",
   "Package version": "软件包版本",

--- a/src/renderer/src/locales/zh-Hant.json
+++ b/src/renderer/src/locales/zh-Hant.json
@@ -1385,6 +1385,7 @@
   "PHASE {{number}}": "階段 {{number}}",
   "PINNED": "已釘選",
   "Package": "套件",
+  "Open Science cannot install packages into user-owned R environments yet. You can still manage packages in the environment yourself.": "Open Science 目前尚無法在使用者自有的 R 環境中安裝套件。您仍可自行管理該環境中的套件。",
   "Package mirror": "套件鏡像",
   "Package provenance": "套件溯源",
   "Package version": "套件版本",

--- a/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
@@ -315,6 +315,72 @@ describe('RuntimesPanel', () => {
     expect(userToggle?.getAttribute('data-state')).toBe('unchecked')
   })
 
+  it('does not offer package-install authorization for an agent-created environment', async () => {
+    const agentCreated: DiscoveredInterpreter = {
+      language: 'python',
+      provenance: 'agent-created',
+      envId: '/data/runtime/envs/agent-analysis/bin/python',
+      interpreterPath: '/data/runtime/envs/agent-analysis/bin/python',
+      label: 'Agent analysis',
+      version: '3.12.4',
+      runnable: true
+    }
+    listEnvironments.mockResolvedValue({ python: [...pythonEnvs, agentCreated], r: rEnvs })
+
+    await render()
+
+    expect(
+      container.querySelector('[aria-label="Enable Agent analysis"]')?.getAttribute('data-state')
+    ).toBe('checked')
+    expect(
+      container.querySelector('[aria-label="Allow package install for Agent analysis"]')
+    ).toBeNull()
+  })
+
+  it('lets an enabled user-owned Python environment authorize package installation', async () => {
+    getEnablement.mockResolvedValue({
+      enabled: { '/usr/bin/python3': true },
+      installAuthorized: {}
+    })
+    setInstallAuthorized.mockResolvedValue({
+      enabled: { '/usr/bin/python3': true },
+      installAuthorized: { '/usr/bin/python3': true }
+    })
+
+    await render()
+
+    const installToggle = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Allow package install for System Python"]'
+    )
+    expect(installToggle?.disabled).toBe(false)
+
+    await click(installToggle)
+
+    expect(setInstallAuthorized).toHaveBeenCalledWith('python', '/usr/bin/python3', true)
+  })
+
+  it('explains that package installation is unavailable for an enabled user-owned R environment', async () => {
+    getEnablement.mockImplementation(async (language: string) =>
+      language === 'r'
+        ? {
+            enabled: { '/opt/conda/envs/bio/bin/R': true },
+            installAuthorized: { '/opt/conda/envs/bio/bin/R': true }
+          }
+        : enablement
+    )
+
+    await render()
+
+    const installToggle = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Allow package install for R 4.4.1"]'
+    )
+    expect(installToggle?.disabled).toBe(true)
+    expect(installToggle?.getAttribute('data-state')).toBe('unchecked')
+    expect(container.textContent).toContain(
+      'Open Science cannot install packages into user-owned R environments yet. You can still manage packages in the environment yourself.'
+    )
+  })
+
   it('surfaces the "cannot disable the last enabled runtime" error inline', async () => {
     setEnvironmentEnabled.mockRejectedValueOnce(
       new Error('Cannot disable the last enabled runtime for python.')

--- a/src/renderer/src/pages/settings/RuntimesPanel.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.tsx
@@ -325,7 +325,7 @@ const RuntimesPanel = ({ title, description }: RuntimesPanelProps): React.JSX.El
     env: DiscoveredInterpreter
   ): React.JSX.Element => {
     const enabled = isEnabled(language, env)
-    const external = env.provenance !== 'app-managed'
+    const external = env.provenance === 'user-own'
     return (
       <div
         key={env.envId}
@@ -386,15 +386,21 @@ const RuntimesPanel = ({ title, description }: RuntimesPanelProps): React.JSX.El
             <SettingsRow
               className="min-h-0 py-0"
               label={t('Allow package install')}
-              description={t(
-                'Lets Open Science install packages into this environment. Installs go to your own environment, not the app-managed storage.'
-              )}
+              description={
+                language === 'r'
+                  ? t(
+                      'Open Science cannot install packages into user-owned R environments yet. You can still manage packages in the environment yourself.'
+                    )
+                  : t(
+                      'Lets Open Science install packages into this environment. Installs go to your own environment, not the app-managed storage.'
+                    )
+              }
             >
               <div className="flex justify-end">
                 <SettingsToggle
-                  enabled={isInstallAuthorized(language, env)}
+                  enabled={language !== 'r' && isInstallAuthorized(language, env)}
                   onToggle={() => void toggleInstallAuthorized(language, env)}
-                  disabled={busy}
+                  disabled={busy || language === 'r'}
                   aria-label={t('Allow package install for {{label}}', { label: env.label })}
                 />
               </div>


### PR DESCRIPTION
## Problem

Agent-created runtime environments are app-owned and package-manageable by default, but Settings classified them as external and displayed an ineffective Allow package install toggle in the off state. User-owned R environments also displayed an actionable authorization toggle even though Open Science does not currently support package installation into them.

## Proposed change

- Show package-install authorization only for user-owned runtime environments.
- Keep user-owned Python authorization interactive.
- Show user-owned R authorization as disabled and unchecked, including when a historical authorization value is true.
- Clarify that Open Science cannot install into user-owned R environments yet while users can still manage packages themselves.
- Add all six renderer translations and correct the provenance-default settings comment.

## Scope and non-goals

This PR does not change manage_packages admission, runtime ownership, persisted authorization semantics, or package installation support. Historical R authorization values remain stored but are ignored by the UI; the backend already rejects external R package management.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- Runtime ownership and R historical-state behavior -> `npm test -- src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx src/renderer/src/i18n/resources.test.ts` -> 2 files, 622 tests passed.
- Renderer and main settings type consumption -> `npm run typecheck` -> passed.
- Source lint -> `npm run lint` -> passed with 0 errors; two pre-existing unrelated Prettier warnings remain in `src/main/acp/application-commands.ts` and `src/main/acp/ipc.ts`.
- Changed-file formatting and patch integrity -> Prettier check and `git diff --check` -> passed.

E2E and platform lanes were excluded because this is a renderer ownership branch and copy change covered by the Settings owner test; no backend, interface, persistence, or platform behavior changed. Independent review found no blocking issues.

## Review focus

Please focus on the provenance condition, the disabled and unchecked user-owned R state, and the localized explanation.