### PR TITLE
test(settings-store): inventory deferred load facade locals

### DIFF
--- a/src/renderer/src/stores/settings-store.architecture.test.ts
+++ b/src/renderer/src/stores/settings-store.architecture.test.ts
@@ -308,24 +308,31 @@ const importBoundaryViolations = (path: string, source = readSource(path)): read
   return violations
 }
 
-const allowedFacadeVariables = new Set([
-  'createInitialSettingsState',
-  'applySnapshot',
-  'DEFAULT_FRAMEWORK_API_ENDPOINTS',
-  'selectFrameworkApiEndpoints',
-  'selectVisionRelayAvailable',
-  'configuration',
-  'selectedKey',
-  'selectProviderModelOptions',
-  'settingsLoadPromise',
-  'SAFE_SETTINGS_LOAD_ERROR',
-  'reportSettingsLoadError',
-  'createSettingsStoreState',
-  'generation',
-  '[snapshot, preflight, encryptionAvailable, npmAvailable]',
-  'loadPromise',
-  'error',
-  'useSettingsStore'
+// Exact declaration counts for every facade binding. `load` now publishes the Settings snapshot
+// before runtime probes finish, so its locals (and the two `catch (error)` bindings) must stay
+// inventoried here instead of being treated as new facade state.
+const allowedFacadeVariableCounts = new Map<string, number>([
+  ['createInitialSettingsState', 1],
+  ['applySnapshot', 1],
+  ['DEFAULT_FRAMEWORK_API_ENDPOINTS', 1],
+  ['selectFrameworkApiEndpoints', 1],
+  ['selectVisionRelayAvailable', 1],
+  ['configuration', 1],
+  ['selectedKey', 1],
+  ['selectProviderModelOptions', 1],
+  ['settingsLoadPromise', 1],
+  ['SAFE_SETTINGS_LOAD_ERROR', 1],
+  ['reportSettingsLoadError', 1],
+  ['createSettingsStoreState', 1],
+  ['generation', 1],
+  ['shouldInitializeRuntime', 1],
+  ['settingsPromise', 1],
+  ['runtimeInitialization', 1],
+  ['snapshot', 1],
+  ['[preflight, encryptionAvailable, npmAvailable]', 1],
+  ['loadPromise', 1],
+  ['error', 2],
+  ['useSettingsStore', 1]
 ])
 
 const staticMemberPath = (node: Node): readonly string[] | undefined => {
@@ -361,7 +368,7 @@ const settingsAccessAudit = (source: string): SettingsAccessAudit => {
     if (isVariableDeclaration(node)) {
       const name = node.name.getText(sourceFile)
       variableCounts.set(name, (variableCounts.get(name) ?? 0) + 1)
-      if (!allowedFacadeVariables.has(name)) violations.push(`${name} is new facade state`)
+      if (!allowedFacadeVariableCounts.has(name)) violations.push(`${name} is new facade state`)
       const directPath = node.initializer
         ? staticMemberPath(node.initializer)?.join('.')
         : undefined
@@ -419,8 +426,8 @@ const settingsAccessAudit = (source: string): SettingsAccessAudit => {
     forEachChild(node, visit)
   }
   visit(sourceFile)
-  for (const name of allowedFacadeVariables) {
-    if (variableCounts.get(name) !== 1) {
+  for (const [name, expectedCount] of allowedFacadeVariableCounts) {
+    if (variableCounts.get(name) !== expectedCount) {
       violations.push(`${name} declared ${variableCounts.get(name) ?? 0} times`)
     }
   }


### PR DESCRIPTION
## Problem

`perf(startup): defer transcript and runtime probes` (#1637) changed `settings-store` `load()` so the persisted Settings snapshot can publish before runtime probes finish. The architecture inventory still expected the previous combined `Promise.all` binding and a single `catch (error)`.

That guard only runs in the full portable suite (`Full Module tests (macOS)`), not in `test:module`, so later PRs fail PR Gate even when they do not touch Settings.

Observed on PRs including #1641, #1643, #1648, #1524, and #1432:

```
shouldInitializeRuntime is new facade state
settingsPromise is new facade state
runtimeInitialization is new facade state
snapshot is new facade state
[preflight, encryptionAvailable, npmAvailable] is new facade state
[snapshot, preflight, encryptionAvailable, npmAvailable] declared 0 times
error declared 2 times
```

## Proposed change

Update the facade variable inventory to the current `load()` locals and allow the two `catch (error)` bindings. Production load behavior is unchanged.

## Scope and non-goals

- In scope: `settings-store.architecture.test.ts` inventory only.
- Out of scope: original feature PRs, Settings load behavior, module-impact routing.
- This does not fix PR-specific failures such as #1645 (PR policy / E2E / other unit tests) or #1204 (CI Integrity).

## Acceptance criteria and validation

- Architecture inventory matches the deferred-load `load()` locals.
- New undeclared facade bindings are still rejected.
- After the last material edit:
  - `npm test -- src/renderer/src/stores/settings-store.architecture.test.ts src/renderer/src/stores/settings-store.test.ts` → pass
  - `npx vitest run --project architecture` → 28 files / 221 tests pass
  - `npx eslint src/renderer/src/stores/settings-store.architecture.test.ts` → pass

## Review focus

Confirm the inventoried names are load-local control flow from #1637, not new feature actions or Settings writes on the facade.

## Historical compatibility

None. No schema, Session JSON, or on-disk format change.

## New enum / state values

None.

## Persistence

None.