### PR TITLE
test(preview): restore cached image tests under jsdom

### DIFF
--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
+import { waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatSession } from '@/stores/session-store'
@@ -12,6 +13,7 @@ import { createInitialProjectState, useProjectStore } from '@/stores/project-sto
 import { createInitialSessionState, useSessionStore } from '@/stores/session-store'
 import { useNavigationStore } from '@/stores/navigation-store'
 
+import { createCachedImageFetchResponse } from '../../pages/workspace/previews/cached-preview-image.test-support'
 import { GlobalSearchDialog } from './GlobalSearchDialog'
 
 let container: HTMLDivElement
@@ -103,6 +105,7 @@ beforeEach(() => {
     artifactMentionAvailability: { projectId: 'project-a', canMention: true }
   })
   usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(createCachedImageFetchResponse()))
   Object.defineProperty(window, 'api', {
     configurable: true,
     value: {
@@ -130,6 +133,7 @@ afterEach(() => {
   container.remove()
   Reflect.deleteProperty(window.HTMLElement.prototype, 'scrollIntoView')
   vi.restoreAllMocks()
+  vi.unstubAllGlobals()
 })
 
 describe('GlobalSearchDialog', () => {
@@ -154,9 +158,11 @@ describe('GlobalSearchDialog', () => {
     ) as HTMLElement
     expect(artifactRow.classList).toContain('cursor-pointer')
     expect(artifactRow.classList).toContain('select-none')
-    expect(
-      artifactRow.querySelector<HTMLImageElement>('img[alt="Preview of sin.png"]')
-    ).not.toBeNull()
+    await waitFor(() => {
+      expect(
+        artifactRow.querySelector<HTMLImageElement>('img[alt="Preview of sin.png"]')
+      ).not.toBeNull()
+    })
     expect(artifactRow.textContent).toContain('Python 绘制 sin 函数图 · 3 days ago')
     act(() => artifactRow.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true })))
     const mention = document.body.querySelector<HTMLElement>('[aria-label="Mention sin.png"]')

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { act, StrictMode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
+import { waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -27,6 +28,7 @@ import {
   getUploadedAttachmentPath,
   type UploadedAttachment
 } from '../../../../shared/uploads'
+import { createCachedImageFetchResponse } from './previews/cached-preview-image.test-support'
 
 const createMessage = (overrides: Partial<ChatMessage>): ChatMessage => ({
   id: 'message-1',
@@ -321,6 +323,7 @@ describe('ProjectFilesView', () => {
     projectFilesChangedListener = undefined
     container = document.createElement('div')
     document.body.appendChild(container)
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(createCachedImageFetchResponse()))
     window.api = {
       saveManagedFile: vi.fn().mockResolvedValue({ saved: true }),
       previewResources: {
@@ -2864,12 +2867,14 @@ describe('ProjectFilesView', () => {
         .mocked(window.api.uploads.readPreview)
         .mock.calls.every(([request]) => request.maxBytes === 1)
     ).toBe(true)
-    expect(
-      container.querySelector('img[alt="Preview of typhoon_tracks.png"]')?.getAttribute('src')
-    ).toContain('open-science-preview://')
-    expect(
-      container.querySelector('img[alt="Preview of uploaded_image.png"]')?.getAttribute('src')
-    ).toContain('open-science-preview://')
+    await waitFor(() => {
+      expect(
+        container.querySelector('img[alt="Preview of typhoon_tracks.png"]')?.getAttribute('src')
+      ).toMatch(/^blob:/)
+      expect(
+        container.querySelector('img[alt="Preview of uploaded_image.png"]')?.getAttribute('src')
+      ).toMatch(/^blob:/)
+    })
   })
 
   it('reacquires an image thumbnail when the file changes at the same path', async () => {
@@ -3124,9 +3129,11 @@ describe('ProjectFilesView', () => {
     })
 
     expect(window.api.uploads.readPreview).toHaveBeenCalledTimes(uploads.length)
-    expect(container.querySelectorAll('img[alt^="Preview of upload-"]')).toHaveLength(
-      uploads.length
-    )
+    await waitFor(() => {
+      expect(container.querySelectorAll('img[alt^="Preview of upload-"]')).toHaveLength(
+        uploads.length
+      )
+    })
   })
 
   it('uses the same text preview capability for generated files and uploads', async () => {

--- a/src/renderer/src/pages/workspace/artifact-preview.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/artifact-preview.interaction.test.tsx
@@ -5,6 +5,7 @@ import { waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ArtifactPreview } from './artifact-preview'
+import { createCachedImageFetchResponse } from './previews/cached-preview-image.test-support'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -28,10 +29,7 @@ describe('ArtifactPreview image lifecycle', () => {
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue(new Response(new Blob(['image bytes'], { type: 'image/png' })))
-    )
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(createCachedImageFetchResponse()))
     vi.stubGlobal(
       'URL',
       class extends URL {

--- a/src/renderer/src/pages/workspace/preview-image-content.test.tsx
+++ b/src/renderer/src/pages/workspace/preview-image-content.test.tsx
@@ -3,6 +3,7 @@ import { act, type ComponentProps } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { createCachedImageFetchResponse } from './previews/cached-preview-image.test-support'
 import { PreviewUnsupportedContent } from './previews/PreviewFallback'
 import { PreviewImageContent as CachedPreviewImageContent } from './previews/renderers/ImagePreview'
 
@@ -78,10 +79,7 @@ describe('PreviewImageContent', () => {
     previewVersion += 1
     container = document.createElement('div')
     document.body.appendChild(container)
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue(new Response(new Blob(['image bytes'], { type: 'image/png' })))
-    )
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(createCachedImageFetchResponse()))
     vi.spyOn(URL, 'createObjectURL').mockReturnValue(`blob:cached-image-${previewVersion}`)
     window.api = {
       previewResources: {
@@ -148,9 +146,7 @@ describe('PreviewImageContent', () => {
       mimeType: 'image/png',
       version: 1
     })
-    const fetchImage = vi
-      .fn()
-      .mockResolvedValue(new Response(new Blob(['image bytes'], { type: 'image/png' })))
+    const fetchImage = vi.fn().mockResolvedValue(createCachedImageFetchResponse())
     vi.stubGlobal('fetch', fetchImage)
 
     root = createRoot(container)

--- a/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { PreviewFileItem } from '@/stores/preview-workbench-store'
+import { createCachedImageFetchResponse } from './cached-preview-image.test-support'
 import { PreviewFileContent } from './PreviewFileContent'
 
 const highlightSpy = vi.hoisted(() => vi.fn())
@@ -199,9 +200,7 @@ describe('PreviewFileContent', () => {
   }
 
   it('reuses a loaded image when its preview is unmounted and mounted again', async () => {
-    const fetchImage = vi
-      .fn()
-      .mockResolvedValue(new Response(new Blob(['image bytes'], { type: 'image/png' })))
+    const fetchImage = vi.fn().mockResolvedValue(createCachedImageFetchResponse())
     vi.stubGlobal('fetch', fetchImage)
     vi.stubGlobal(
       'URL',

--- a/src/renderer/src/pages/workspace/previews/cached-preview-image.test-support.ts
+++ b/src/renderer/src/pages/workspace/previews/cached-preview-image.test-support.ts
@@ -1,0 +1,13 @@
+// jsdom's Blob has no stream(), so `new Response(new Blob(...))` throws in Node's undici.
+// Production only reads `ok` / `status` / `blob()`, so tests can stub that shape directly.
+
+const createCachedImageFetchResponse = (
+  body = 'image bytes',
+  type = 'image/png'
+): { ok: true; status: 200; blob: () => Promise<Blob> } => ({
+  ok: true,
+  status: 200,
+  blob: () => Promise.resolve(new Blob([body], { type }))
+})
+
+export { createCachedImageFetchResponse }

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -505,7 +505,9 @@ describe('conversation message scroller integration', () => {
     expect(workspaceMessageScrollerSource).not.toContain('createActivityToggleLabel(')
     expect(workspaceMessageScrollerSource).not.toContain('renderWebSearchDetails(')
     expect(workspaceMessageScrollerSource).not.toContain('formatActivityDetails(activity)')
-    expect(workspaceMessageScrollerSource).toContain('conversationItems.map((item, itemIndex)')
+    expect(workspaceMessageScrollerSource).toContain(
+      'transcriptWindow.entries.map(({ item, itemIndex })'
+    )
     expect(workspaceMessageScrollerSource).toMatch(/import \{[^}]*\buseState\b[^}]*\} from 'react'/)
     expect(workspaceMessageScrollerSource).toContain('const currentSessionId = activeSession?.id')
     expect(workspaceMessageScrollerSource).toContain(


### PR DESCRIPTION
## Problem

#1643 (`fix(host-sdk)!: camel-case public result fields`) and #1648 (`fix(settings): align package install controls with runtime ownership`) merged with red PR Gate module shards. The failures were not from those diffs:

- #1649 already inventory-fixed the settings-store architecture guard.
- The remaining 18 unit failures came from #1636's managed-image cache and windowed transcript rendering: jsdom `Blob` cannot be passed to Node's `Response`, so image tests never reached a ready `<img>`, and the architecture test still expected a linear `conversationItems.map`.

## Proposed change

- Stub `fetch` with the `{ ok, status, blob() }` shape the cache actually reads, instead of `new Response(new Blob(...))`.
- Wait for thumbnails to settle and assert cached `blob:` URLs for in-budget images.
- Pin `transcriptWindow.entries.map(({ item, itemIndex })` as the scroller render loop.

No production code changes.

## Scope and non-goals

Does not change Host SDK camelCase, package-install authorization UI, image cache eviction, or transcript windowing.

## Compatibility notes

- **Historical data compatibility:** none. Preview image cache lives in renderer memory as blob URLs and is not persisted.
- **New enum / status values:** none.
- **Data persistence:** none. #1648 still stores historical user-owned R `installAuthorized` values and ignores them in the UI; this PR does not touch that.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- Cached image and transcript architecture regressions -> `npm test -- src/renderer/src/pages/workspace/preview-image-content.test.tsx src/renderer/src/pages/workspace/artifact-preview.interaction.test.tsx src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx src/renderer/src/pages/workspace/workspace-components.test.tsx src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx src/renderer/src/pages/workspace/ProjectFilesView.test.tsx src/renderer/src/stores/settings-store.architecture.test.ts` -> 7 files, 206 tests passed.
- `project_files_view` module tests -> `npm run test:module -- project_files_view` -> 6 files passed.
- External PR owner tests (unchanged by this branch) -> `npm test -- src/main/host-sdk/delegate-contract.test.ts src/main/host-sdk/help.test.ts src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx` -> 3 files, 51 tests passed.
- Lint of changed files -> `npx eslint` on the 7 touched files -> no issues.
- Diff hygiene -> `git diff --check` -> passed.

Full portable `npm test` was not run locally; PR Gate remains authoritative.

## Review focus

Please focus on the fetch stub matching `useCachedPreviewImage` (`ok` / `blob()` only) and the thumbnail assertions now expecting `blob:` URLs for images under the 64 MiB cache budget.