### PR TITLE
fix(acp): preserve permission denial boundary

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -21247,7 +21247,7 @@ describe('ACP runtime session management', () => {
     expect(permissionResponses).toEqual([{ outcome: { outcome: 'selected', optionId: 'reject' } }])
   })
 
-  it('continues a Claude turn after a rejected permission cancels the provider prompt', async () => {
+  it('continues a Claude turn with an explicit authorization boundary after permission denial', async () => {
     const process = new FakeAgentProcess()
     const continuationGate = createDeferred<PromptResponse>()
     const prompts: string[] = []
@@ -21323,7 +21323,12 @@ describe('ACP runtime session management', () => {
     await runtime.sendPrompt({ sessionId: session.sessionId, text: 'inspect the workspace' })
 
     await vi.waitFor(() => expect(prompts).toHaveLength(2))
-    expect(prompts[1]).toContain('permission')
+    expect(prompts[1]).toContain('The user explicitly denied this operation')
+    expect(prompts[1]).toContain('You do not have authorization to perform it')
+    expect(prompts[1]).toContain(
+      'Do not retry or approximate the denied operation with a different command, tool, or route'
+    )
+    expect(prompts[1]).toContain('Continue only with independent work that is already permitted')
     expect(runtime.getSnapshot().events).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -2631,6 +2631,94 @@ describe('ACP runtime restored permission continuation', () => {
     )
   })
 
+  it('does not present a cancelled restored permission as an explicit user denial', async () => {
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['restored-session'])
+    let runtimeContext: SessionRuntimeContext = {
+      version: 1,
+      revision: 1,
+      permission: {
+        state: 'pending',
+        request: {
+          requestId: 'permission-restored',
+          sessionId: 'restored-session',
+          toolCallId: 'tool-restored',
+          title: 'Run npm test',
+          options: [
+            { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+            { optionId: 'reject-once', name: 'Reject once', kind: 'reject_once' }
+          ]
+        },
+        originatingPromptMessageId: 'prompt-1',
+        fingerprint: 'a'.repeat(64),
+        createdAt: 1
+      }
+    }
+    const messages: PersistedChatSession['messages'] = [
+      {
+        id: 'prompt-1',
+        role: 'user',
+        content: 'Run the requested test command.',
+        status: 'complete',
+        eventIds: [],
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ]
+    const persistedSession: PersistedChatSession = {
+      id: 'restored-session',
+      projectId: 'project-1',
+      title: 'Restored permission',
+      cwd: '/workspace',
+      status: 'waiting-permission',
+      messages,
+      conversationGraph: createLinearConversationGraph({
+        sessionId: 'restored-session',
+        messages,
+        frameworkId: 'claude-code',
+        backendId: 'claude-code:provider-a',
+        createdAt: 1,
+        updatedAt: 1
+      }),
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      framework: claudeCodeFramework,
+      spawnAgent: () => asAgentProcess(process),
+      permissionWait: {
+        sessions: {
+          readSessionRuntimeContext: vi.fn(async () => structuredClone(runtimeContext)),
+          patchSessionRuntimeContext: vi.fn(async (command) => {
+            runtimeContext = {
+              ...runtimeContext,
+              ...command.patch,
+              revision: runtimeContext.revision + 1
+            }
+            return structuredClone(runtimeContext)
+          }),
+          containsMessageOnActiveBranch: vi.fn(async () => true),
+          loadSessionForContinuation: vi.fn(async () => structuredClone(persistedSession))
+        }
+      }
+    })
+    await runtime.createSession({ cwd: '/workspace', projectId: 'project-1' })
+
+    await runtime.respondToPermission({
+      requestId: 'permission-restored',
+      cancelled: true,
+      restored: { sessionId: 'restored-session', projectId: 'project-1' }
+    })
+
+    await vi.waitFor(() => expect(fakeAgent.prompts).toHaveLength(1))
+    expect(fakeAgent.prompts[0]?.text).toContain(
+      'The pending permission interaction was cancelled without granting authorization'
+    )
+    expect(fakeAgent.prompts[0]?.text).not.toContain('The user explicitly denied this operation')
+  })
+
   it.each(RESTORED_CONTINUATION_FRAMEWORKS)(
     'continues an approved restored wait through %s and then clears its authority',
     async (_name, framework, modelRoute, backendId) => {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -389,6 +389,11 @@ const PERMISSION_DENIED_CONTINUATION_TEXT =
   'that is already permitted. If the denied operation is required, explain the boundary and wait ' +
   'for the user to explicitly change their decision in a new message.'
 
+const PERMISSION_CANCELLED_CONTINUATION_TEXT =
+  'The pending permission interaction was cancelled without granting authorization. Do not ' +
+  'execute or retry the parked tool call unless the user explicitly approves it later. Continue ' +
+  'only with independent work that is already permitted, or explain what cannot be completed.'
+
 const PLAN_CONTINUATION_CLAIM_MAX_ATTEMPTS = 3
 const PLAN_CONTINUATION_CLAIM_RETRY_BASE_DELAY_MS = 25
 
@@ -1507,10 +1512,12 @@ class AcpRuntime {
     }
 
     const scope = decision.option?.scope
-    const text = decision.denied
-      ? PERMISSION_DENIED_CONTINUATION_TEXT
-      : `The user approved the pending tool permission${scope ? ` for ${scope}` : ''}. Retry only ` +
-        'the exact parked tool call and continue the current task. Do not broaden or reinterpret the approval.'
+    const text = response.cancelled
+      ? PERMISSION_CANCELLED_CONTINUATION_TEXT
+      : decision.denied
+        ? PERMISSION_DENIED_CONTINUATION_TEXT
+        : `The user approved the pending tool permission${scope ? ` for ${scope}` : ''}. Retry only ` +
+          'the exact parked tool call and continue the current task. Do not broaden or reinterpret the approval.'
     this.appContinuations.set(restored.sessionId, {
       condition: 'always',
       request: {

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -382,6 +382,13 @@ const errorMessage = (error: unknown): string => {
 
 const log = createLogger('acp')
 
+const PERMISSION_DENIED_CONTINUATION_TEXT =
+  'The user explicitly denied this operation. You do not have authorization to perform it. ' +
+  'Do not retry or approximate the denied operation with a different command, tool, or route, ' +
+  'and do not request permission for it again in this turn. Continue only with independent work ' +
+  'that is already permitted. If the denied operation is required, explain the boundary and wait ' +
+  'for the user to explicitly change their decision in a new message.'
+
 const PLAN_CONTINUATION_CLAIM_MAX_ATTEMPTS = 3
 const PLAN_CONTINUATION_CLAIM_RETRY_BASE_DELAY_MS = 25
 
@@ -1375,11 +1382,7 @@ class AcpRuntime {
         condition: 'provider-cancelled',
         request: {
           sessionId: permissionRequest.sessionId,
-          text:
-            'The user denied the requested tool permission. Continue the current task without ' +
-            'that tool call. Use an alternative that does not require the denied permission, or ' +
-            'explain what cannot be completed. Do not request the same permission again unless the ' +
-            'user explicitly asks.',
+          text: PERMISSION_DENIED_CONTINUATION_TEXT,
           suppressUserMessage: true,
           ...(promptInteraction.promptMessageId
             ? { provenanceContext: { promptMessageId: promptInteraction.promptMessageId } }
@@ -1505,9 +1508,7 @@ class AcpRuntime {
 
     const scope = decision.option?.scope
     const text = decision.denied
-      ? 'The user denied the pending tool permission. Continue the current task without that tool ' +
-        'call. Use an alternative that does not require the denied permission, or explain what ' +
-        'cannot be completed. Do not request the same permission again unless the user explicitly asks.'
+      ? PERMISSION_DENIED_CONTINUATION_TEXT
       : `The user approved the pending tool permission${scope ? ` for ${scope}` : ''}. Retry only ` +
         'the exact parked tool call and continue the current task. Do not broaden or reinterpret the approval.'
     this.appContinuations.set(restored.sessionId, {


### PR DESCRIPTION
## Problem

Claude Code cancels its provider prompt after a rejected permission. Open Science resumes the same logical turn with a hidden continuation, but the old continuation encouraged the Agent to use an alternative. That could turn an explicit user denial into repeated commands or another permission request for the same operation.

## Proposed change

Keep the logical run alive, but carry an explicit authorization boundary into both live Claude continuation and restored durable permission continuation. The Agent is told that the user denied the operation, it has no authorization for it, and it must not retry or approximate that operation through another command, tool, route, or permission request in the current turn. Independent already-permitted work may continue.

## Scope and non-goals

- Preserve the ACP reject response and existing provider wire behavior.
- Preserve Claude provider-turn recovery and the user-visible logical run.
- Do not terminate the whole message or run.
- Do not add permission states, persisted fields, migrations, or compatibility codecs.

## Acceptance criteria and validation

Checks ran after the last material edit.

- explicit live Claude denial boundary -> `npm test -- src/main/acp/runtime.test.ts` -> 564 passed
- Claude Code, OpenCode, Codex Responses, and Codex Bridge permission projection -> `npm test -- src/main/acp/runtime.test.ts -t projects session/request_permission` -> passed as part of 13 focused permission cases
- Node runtime types -> `npm run typecheck:node` -> passed
- source lint -> `npm run lint` -> passed with 0 errors and 2 pre-existing formatting warnings in unrelated `application-commands.ts` and `ipc.ts`
- diff formatting -> `git diff --check` -> passed before commit

A sandboxed runtime test attempt first reported three loopback-bind failures with `listen EPERM: operation not permitted 127.0.0.1`; the same focused runtime suite passed outside that network sandbox.

Excluded: renderer, Web typecheck, database, migration, and platform-specific lanes because the final diff changes only main-process continuation text and its protocol-level regression assertion. PR CI remains authoritative for complete portable and platform coverage.

## Review focus

Confirm that the denial boundary forbids semantic retries of the rejected operation while still allowing independent permitted work, and that sharing the text between live and restored continuations keeps both lifecycle paths aligned.