### PR TITLE
perf(transcript): prefetch window before scroll edge

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -3608,6 +3608,47 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(container.textContent).toContain('oldest transcript sentinel')
   })
 
+  it('prefetches older transcript items before upward scrolling reaches the top edge', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const messages = Array.from({ length: 240 }, (_, index) =>
+      createMessage({
+        id: `prefetch-message-${index + 1}`,
+        role: index % 2 === 0 ? 'user' : 'agent',
+        content:
+          index === 159 ? 'prefetched transcript sentinel' : `prefetch transcript ${index + 1}`,
+        responseToMessageId: index % 2 === 0 ? undefined : `prefetch-message-${index}`,
+        createdAt: 1710000000000 + index,
+        updatedAt: 1710000000000 + index
+      })
+    )
+
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={createSession({ status: 'idle', messages })}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    })
+
+    expect(container.textContent).not.toContain('prefetched transcript sentinel')
+    const viewport = container.querySelector<HTMLElement>(
+      '[data-testid="message-scroller-viewport"]'
+    )
+    Object.defineProperties(viewport, {
+      clientHeight: { configurable: true, value: 800 },
+      scrollHeight: { configurable: true, value: 10_000 },
+      scrollTop: { configurable: true, writable: true, value: 900 }
+    })
+    await act(async () => viewport?.dispatchEvent(new Event('scroll', { bubbles: true })))
+
+    if (viewport) viewport.scrollTop = 700
+    await act(async () => viewport?.dispatchEvent(new Event('scroll', { bubbles: true })))
+
+    expect(container.textContent).toContain('prefetched transcript sentinel')
+  })
+
   it('reveals the full transcript only while whole-window find is open', async () => {
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
     const messages = Array.from({ length: 120 }, (_, index) =>
@@ -3743,6 +3784,19 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     await render([...history, prompt, streamingAnswer, bufferedPrompt, bufferedAnswer])
 
     expect(container.textContent).not.toContain('presentation history oldest sentinel')
+    const viewport = container.querySelector<HTMLElement>(
+      '[data-testid="message-scroller-viewport"]'
+    )
+    Object.defineProperties(viewport, {
+      clientHeight: { configurable: true, value: 800 },
+      scrollHeight: { configurable: true, value: 10_000 },
+      scrollTop: { configurable: true, writable: true, value: 900 }
+    })
+    await act(async () => viewport?.dispatchEvent(new Event('scroll', { bubbles: true })))
+    if (viewport) viewport.scrollTop = 700
+    await act(async () => viewport?.dispatchEvent(new Event('scroll', { bubbles: true })))
+    expect(container.textContent).not.toContain('presentation history oldest sentinel')
+
     const oldestRun = document.body.querySelector<HTMLButtonElement>('[aria-label^="Go to run 1:"]')
     expect(oldestRun).not.toBeNull()
     expect(oldestRun?.disabled).toBe(true)

--- a/src/renderer/src/pages/workspace/use-transcript-window.ts
+++ b/src/renderer/src/pages/workspace/use-transcript-window.ts
@@ -1,4 +1,11 @@
-import { useCallback, useLayoutEffect, useRef, useState, type RefObject } from 'react'
+import {
+  startTransition,
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject
+} from 'react'
 
 import type { WorkspaceConversationTimelineItem } from './workspace-conversation-timeline'
 import { findMessageTarget } from './workspace-run-marks'
@@ -101,24 +108,33 @@ const useTranscriptWindow = (
   const expandAtScrollEdge = (previousScrollTop: number): void => {
     const viewport = viewportRef.current
     if (!viewport || presentationBarrierIndex >= 0) return
+    const prefetchDistance = Math.max(64, viewport.clientHeight)
 
-    if (viewport.scrollTop < previousScrollTop && viewport.scrollTop <= 64 && start > 0) {
-      setState({
-        scopeId,
-        itemCount: items.length,
-        start: Math.max(0, start - TRANSCRIPT_WINDOW_SIZE),
-        end
+    if (
+      viewport.scrollTop < previousScrollTop &&
+      viewport.scrollTop <= prefetchDistance &&
+      start > 0
+    ) {
+      startTransition(() => {
+        setState({
+          scopeId,
+          itemCount: items.length,
+          start: Math.max(0, start - TRANSCRIPT_WINDOW_SIZE),
+          end
+        })
       })
     } else if (
       viewport.scrollTop > previousScrollTop &&
-      viewport.scrollTop + viewport.clientHeight >= viewport.scrollHeight - 64 &&
+      viewport.scrollTop + viewport.clientHeight >= viewport.scrollHeight - prefetchDistance &&
       end < items.length
     ) {
-      setState({
-        scopeId,
-        itemCount: items.length,
-        start,
-        end: Math.min(items.length, end + TRANSCRIPT_WINDOW_SIZE)
+      startTransition(() => {
+        setState({
+          scopeId,
+          itemCount: items.length,
+          start,
+          end: Math.min(items.length, end + TRANSCRIPT_WINDOW_SIZE)
+        })
       })
     }
   }

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -505,7 +505,9 @@ describe('conversation message scroller integration', () => {
     expect(workspaceMessageScrollerSource).not.toContain('createActivityToggleLabel(')
     expect(workspaceMessageScrollerSource).not.toContain('renderWebSearchDetails(')
     expect(workspaceMessageScrollerSource).not.toContain('formatActivityDetails(activity)')
-    expect(workspaceMessageScrollerSource).toContain('conversationItems.map((item, itemIndex)')
+    expect(workspaceMessageScrollerSource).toContain(
+      'transcriptWindow.entries.map(({ item, itemIndex })'
+    )
     expect(workspaceMessageScrollerSource).toMatch(/import \{[^}]*\buseState\b[^}]*\} from 'react'/)
     expect(workspaceMessageScrollerSource).toContain('const currentSessionId = activeSession?.id')
     expect(workspaceMessageScrollerSource).toContain(


### PR DESCRIPTION
## Problem

The transcript already limits initial rendering to the latest 80 conversation items, but it only expands when scrolling reaches within 64 px of a window edge. Rich Markdown and tool rows can therefore mount at the moment the user reaches the edge, increasing the chance of a visible pause on long Sessions.

## Proposed change

- Prefetch the next 80-item transcript batch when the user scrolls within one viewport of either window edge.
- Schedule edge expansion with React `startTransition` so the render is non-urgent relative to input and scrolling.
- Keep the existing MessageScroller prepend anchoring and resize correction as the source of scroll-position preservation.
- Keep transcript expansion disabled while an Agent response is being progressively presented.

This follows the standard overscan/prefetch pattern used by virtualized lists while retaining the existing implementation: https://tanstack.com/virtual/latest/docs/api/virtualizer and https://react.dev/reference/react/startTransition.

## Scope and non-goals

- No change to the initial 80-item window size or batch size.
- No full virtual-list rewrite and no eviction of already visited transcript items.
- No change to Message Nav targeting, whole-window find behavior, or Session interaction semantics.
- No data fields, enum values, persistence changes, migrations, or historical-data compatibility work.

## Acceptance criteria and validation

- Older items render before upward scrolling reaches the previous 64 px threshold.
- Progressive Agent presentation does not prefetch hidden history.
- Existing Message Nav and transcript-window tests continue to pass.
- Prepending rich real-world content preserves the visible anchor without blank content or a position jump.

Final checks were run after the last material edit:

- Early prefetch and streaming guard -> `npx vitest run src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx src/renderer/src/pages/workspace/use-transcript-window.test.tsx src/renderer/src/pages/workspace/workspace-components.test.tsx` -> 3 files, 77 tests passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Repository lint -> `npm run lint` -> 0 errors; 2 pre-existing Prettier warnings in untouched main-process files.
- Local Web validation -> exercised a persisted 115-item Session with rich Markdown and tool content; the same visible anchor moved 0 px after prepend/height recalculation and no blank content was observed.

The regression test was confirmed to fail on the pre-change code because the older sentinel remained unmounted at 700 px from the top, then pass after the change.

Uncovered risk: the local persisted fixture did not contain a Session large enough to exercise multiple consecutive 80-item boundaries in the browser; the 240-item interaction test covers the deterministic window boundary behavior.

## Review focus

- Whether one viewport is the right conservative prefetch distance for rich transcript content.
- Whether transition scheduling and the presentation barrier preserve the expected streaming behavior.
- Whether the existing MessageScroller anchor ownership remains the correct boundary for position preservation.
