### PR TITLE
fix(settings): restore model-panel CI after accordion layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,20 +121,20 @@ for a known set of script-specific characters and will fail on cross-script cont
 
 ### Glossary (mandatory)
 
-| Term                 | fr                  | zh-Hans      | zh-Hant      | ja                     | ko                | ru                       | Note                                              |
-| -------------------- | ------------------- | ------------ | ------------ | ---------------------- | ----------------- | ------------------------ | ------------------------------------------------- |
-| Skill / Skills       | **Compétence(s)**   | **技能**     | **技能**     | **スキル**             | **스킬**          | **Навык / Навыки**       | Translate user-visible prose                      |
-| Agent / Agents       | **Agent(s)**        | **智能体**   | **智能體**   | **エージェント**       | **에이전트**      | **Агент / Агенты**       | Translate user-visible prose                      |
-| Notebook             | **Notebook**        | **Notebook** | **Notebook** | **Notebook**           | **Notebook**      | **Notebook**             | Keep as-is                                        |
-| token (model usage)  | **Jeton(s)**        | **词元**     | **詞元**     | **トークン**           | **토큰**          | **токен**                | Model input, output, context, and usage counts    |
-| token (credential)   | **Jeton(s)**        | **令牌**     | **權杖**     | **トークン**           | **토큰**          | **токен**                | Authentication and personal access credentials    |
-| Specialist           | **Spécialiste**     | **专家**     | **專家**     | **スペシャリスト**     | **스페셜리스트**  | **Специалист**           | Generic role; translate                           |
-| Marketplace          | **Place de marché** | **市场**     | **市集**     | **マーケットプレイス** | **마켓플레이스**  | **Маркетплейс**          | Generic surface; retain third-party product names |
-| Connector            | **Connecteur**      | **连接器**   | **連接器**   | **コネクタ**           | **커넥터**        | **Коннектор**            | Generic noun; retain exact directory names        |
-| Main Agent           | **Agent principal** | **主智能体** | **主智能體** | **メインエージェント** | **메인 에이전트** | **Главный агент**        | Translate as a complete compound                  |
-| Main model           | **Modèle principal** | **主模型** | **主模型** | **メインモデル** | **메인 모델** | **Основная модель** | Settings main-model label; not a Main Agent role  |
-| Subagent / Subagents | **Sous-agent(s)**   | **子智能体** | **子智能體** | **サブエージェント**   | **서브에이전트**  | **Субагент / Субагенты** | Translate as a complete compound                  |
-| Shell                | **Terminal**        | **命令行**   | **命令列**   | **シェル**             | **셸**            | **Командная строка**     | User-facing label; `Notebook` remains English     |
+| Term                 | fr                   | zh-Hans      | zh-Hant      | ja                     | ko                | ru                       | Note                                              |
+| -------------------- | -------------------- | ------------ | ------------ | ---------------------- | ----------------- | ------------------------ | ------------------------------------------------- |
+| Skill / Skills       | **Compétence(s)**    | **技能**     | **技能**     | **スキル**             | **스킬**          | **Навык / Навыки**       | Translate user-visible prose                      |
+| Agent / Agents       | **Agent(s)**         | **智能体**   | **智能體**   | **エージェント**       | **에이전트**      | **Агент / Агенты**       | Translate user-visible prose                      |
+| Notebook             | **Notebook**         | **Notebook** | **Notebook** | **Notebook**           | **Notebook**      | **Notebook**             | Keep as-is                                        |
+| token (model usage)  | **Jeton(s)**         | **词元**     | **詞元**     | **トークン**           | **토큰**          | **токен**                | Model input, output, context, and usage counts    |
+| token (credential)   | **Jeton(s)**         | **令牌**     | **權杖**     | **トークン**           | **토큰**          | **токен**                | Authentication and personal access credentials    |
+| Specialist           | **Spécialiste**      | **专家**     | **專家**     | **スペシャリスト**     | **스페셜리스트**  | **Специалист**           | Generic role; translate                           |
+| Marketplace          | **Place de marché**  | **市场**     | **市集**     | **マーケットプレイス** | **마켓플레이스**  | **Маркетплейс**          | Generic surface; retain third-party product names |
+| Connector            | **Connecteur**       | **连接器**   | **連接器**   | **コネクタ**           | **커넥터**        | **Коннектор**            | Generic noun; retain exact directory names        |
+| Main Agent           | **Agent principal**  | **主智能体** | **主智能體** | **メインエージェント** | **메인 에이전트** | **Главный агент**        | Translate as a complete compound                  |
+| Main model           | **Modèle principal** | **主模型**   | **主模型**   | **メインモデル**       | **메인 모델**     | **Основная модель**      | Settings main-model label; not a Main Agent role  |
+| Subagent / Subagents | **Sous-agent(s)**    | **子智能体** | **子智能體** | **サブエージェント**   | **서브에이전트**  | **Субагент / Субагенты** | Translate as a complete compound                  |
+| Shell                | **Terminal**         | **命令行**   | **命令列**   | **シェル**             | **셸**            | **Командная строка**     | User-facing label; `Notebook` remains English     |
 
 Exact technical identifiers are exempt from prose translation. Keep file names, extensions,
 commands, paths, protocol identifiers, and code spans unchanged, including `SKILL.md`, `.skill`,

--- a/e2e/settings-persistence.spec.ts
+++ b/e2e/settings-persistence.spec.ts
@@ -65,6 +65,9 @@ const localizedSettingsCases = [
     general: '通用',
     appearance: '外观',
     interfaceLanguage: '界面语言',
+    mainModel: '主模型',
+    scenarioModels: '场景模型',
+    expandSubagent: '展开子智能体设置',
     reasoningEffort: '推理强度',
     defaultEffort: '默认',
     closeSettings: '关闭设置'
@@ -80,6 +83,9 @@ const localizedSettingsCases = [
     general: '一般',
     appearance: '外觀',
     interfaceLanguage: '介面語言',
+    mainModel: '主模型',
+    scenarioModels: '情境模型',
+    expandSubagent: '展開子智能體設定',
     reasoningEffort: '推理強度',
     defaultEffort: '預設',
     closeSettings: '關閉設定'
@@ -95,6 +101,9 @@ const localizedSettingsCases = [
     general: '一般',
     appearance: '外観',
     interfaceLanguage: '表示言語',
+    mainModel: 'メインモデル',
+    scenarioModels: 'シナリオモデル',
+    expandSubagent: 'サブエージェント設定を展開',
     reasoningEffort: '推論の強度',
     defaultEffort: 'デフォルト',
     closeSettings: '設定を閉じる'
@@ -110,6 +119,9 @@ const localizedSettingsCases = [
     general: '일반',
     appearance: '외관',
     interfaceLanguage: '인터페이스 언어',
+    mainModel: '메인 모델',
+    scenarioModels: '시나리오 모델',
+    expandSubagent: '서브에이전트 설정 펼치기',
     reasoningEffort: '추론 강도',
     defaultEffort: '기본값',
     closeSettings: '설정 닫기'
@@ -125,6 +137,9 @@ const localizedSettingsCases = [
     general: 'Общие',
     appearance: 'Внешний вид',
     interfaceLanguage: 'Язык интерфейса',
+    mainModel: 'Основная модель',
+    scenarioModels: 'Сценарные модели',
+    expandSubagent: 'Развернуть настройки: Субагент',
     reasoningEffort: 'Глубина рассуждений',
     defaultEffort: 'По умолчанию',
     closeSettings: 'Закрыть настройки'
@@ -140,6 +155,9 @@ const localizedSettingsCases = [
     general: 'Général',
     appearance: 'Apparence',
     interfaceLanguage: "Langue de l'interface",
+    mainModel: 'Modèle principal',
+    scenarioModels: 'Modèles de scénario',
+    expandSubagent: 'Développer les paramètres de Sous-agent',
     reasoningEffort: 'Effort de raisonnement',
     defaultEffort: 'Par défaut',
     closeSettings: 'Fermer les paramètres'
@@ -174,14 +192,16 @@ for (const localized of localizedSettingsCases) {
 
       await page.getByRole('button', { name: localized.modelSettings }).click()
       const settings = page.getByRole('dialog', { name: localized.settings })
-      const reasoningSection = settings.getByRole('region', { name: localized.reasoningEffort })
-      const effort = reasoningSection.getByRole('radiogroup', {
+      // Active model and Reasoning effort now share the Main model region; the effort control is
+      // still a named radiogroup, but the parent region title is Main model.
+      const mainModel = settings.getByRole('region', { name: localized.mainModel })
+      const effort = mainModel.getByRole('radiogroup', {
         name: localized.reasoningEffort
       })
       await expect(effort).toBeVisible()
       await expect
         .poll(() =>
-          reasoningSection.locator('p').evaluate((description) => {
+          mainModel.locator('p').evaluate((description) => {
             if (!(description instanceof HTMLElement)) return false
             return description.scrollWidth <= description.clientWidth + 1
           })
@@ -234,24 +254,38 @@ for (const localized of localizedSettingsCases) {
             .locator('[data-slot="settings-segment-label"]')
         ).toHaveAttribute('data-compact', 'true')
       }
-      const clippedPolicyLabels = await settings
-        .locator('[data-slot="settings-row"] [data-slot="select-trigger"] .truncate')
-        .evaluateAll((labels) =>
-          labels.flatMap((label) =>
-            label instanceof HTMLElement && label.scrollWidth > label.clientWidth + 1
-              ? [label.textContent?.trim()]
-              : []
+      const clippedPolicyLabels = async (): Promise<Array<string | undefined>> =>
+        settings
+          .locator('[data-slot="settings-row"] [data-slot="select-trigger"] .truncate')
+          .evaluateAll((labels) =>
+            labels.flatMap((label) =>
+              label instanceof HTMLElement && label.scrollWidth > label.clientWidth + 1
+                ? [label.textContent?.trim()]
+                : []
+            )
           )
-        )
-      expect(clippedPolicyLabels).toEqual([])
-      const firstPolicyRow = settings.locator('[data-slot="settings-row"]').first()
+      expect(await clippedPolicyLabels()).toEqual([])
+      const mainModelRow = mainModel.locator('[data-slot="settings-row"]').first()
       await expect
         .poll(() =>
-          firstPolicyRow.evaluate(
+          mainModelRow.evaluate(
             (row) => getComputedStyle(row).gridTemplateColumns.trim().split(/\s+/).length
           )
         )
         .toBe(1)
+
+      await settings.getByRole('button', { name: localized.expandSubagent, exact: true }).click()
+      const scenarioModels = settings.getByRole('region', { name: localized.scenarioModels })
+      const subagentRow = scenarioModels.locator('[data-slot="settings-row"]').first()
+      await expect(subagentRow).toBeVisible()
+      await expect
+        .poll(() =>
+          subagentRow.evaluate(
+            (row) => getComputedStyle(row).gridTemplateColumns.trim().split(/\s+/).length
+          )
+        )
+        .toBe(1)
+      expect(await clippedPolicyLabels()).toEqual([])
 
       const navigation = settings.getByRole('navigation', { name: localized.settings })
       if (!(await navigation.isVisible())) {

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -788,6 +788,16 @@ describe('SettingsPage layout', () => {
         section.getAttribute('aria-label')
       )
     ).toEqual(['Main model', 'Scenario models', 'Providers'])
+    const mainModel = Array.from(
+      document.body.querySelectorAll('[data-slot="settings-section"]')
+    ).find((section) => section.getAttribute('aria-label') === 'Main model')
+    expect(mainModel?.querySelector('[aria-label="Reasoning effort"]')).not.toBeNull()
+    expect(mainModel?.querySelector('[data-slot="settings-row"]')?.className).toContain(
+      'grid-cols-1'
+    )
+    expect(mainModel?.querySelector('[data-slot="settings-row"]')?.className).toContain(
+      'lg:grid-cols-[minmax(0,1fr)_auto]'
+    )
     expect(document.body.textContent).toContain(
       'Models for subagents, review, and image understanding.'
     )


### PR DESCRIPTION
## Problem

#1645 collapsed scenario model routing into an accordion and merged Active model + Reasoning effort into a single **Main model** section. PR Gate then failed on the merge commit:

- **Static checks / markdown Prettier**: `AGENTS.md` gained a `Main model` glossary row without re-aligning the table, so `prettier --check` failed on the changed markdown file.
- **macOS E2E / settings-persistence**: the narrow-viewport language cases still looked up a `region` named Reasoning effort and treated `settings-row` `.first()` as a stacked policy row. That region no longer exists, and the first row in the dialog is now the Main model `model-effort` row (or a collapsed accordion header), so the 640px column-count poll timed out.

## Proposed change

- Format the `AGENTS.md` glossary table so changed-markdown Prettier passes.
- Retarget the persistence e2e to the Main model region (effort radiogroup still lives there), assert that row stacks to one column below `lg`, then expand Subagent and repeat the stacked-row + unclipped-select checks on the Scenario models card.
- Pin the same Main model nesting in `SettingsPage.render.test.tsx` so a future split of Reasoning effort into its own section fails without waiting for E2E.

## Scope and non-goals

- No Settings document, IPC, schema, or store changes.
- Accordion expand/collapse remains session-local UI state; it is not persisted.
- PR policy still failed on #1645 because the branch contained a `Merge remote-tracking branch 'origin/main'` commit. That is existing commit-message policy, not a product bug; this PR does not exempt merge commits.

## Acceptance criteria and validation

The following checks ran after the last material edit, on `origin/main` (`5a6350e5`) plus this commit:

- Settings model-panel renderer tests: `npx vitest run src/renderer/src/pages/settings/SettingsPage.render.test.tsx src/renderer/src/pages/settings/ScenarioModelList.render.test.tsx src/renderer/src/pages/settings/ActiveModelSelect.render.test.tsx src/renderer/src/pages/settings/SubagentModelSelect.render.test.tsx` → 109 tests passed.
- ESLint on the touched TypeScript files → 0 errors, 0 warnings.
- Prettier on `AGENTS.md` and the touched test files → passed.

`e2e/settings-persistence.spec.ts` was not executed locally; trusted PR Gate E2E lanes remain authoritative.

## Review focus

- Confirm the e2e now names the Main model region and expands Subagent before measuring policy-row columns.
- Confirm the glossary table alignment is the only `AGENTS.md` change.

## Uncovered risks

- Functional journey E2E and Windows E2E were not run locally.
- Localized expand-Subagent accessible names are copied from the six catalogs; a catalog wording change would desync the spec.