### PR TITLE
fix(provenance): capture handoff producer execution

### DIFF
--- a/src/main/artifacts/provenance-producer-capture.ts
+++ b/src/main/artifacts/provenance-producer-capture.ts
@@ -192,18 +192,16 @@ class ArtifactProvenanceProducerCapture {
         inputFiles
       }
     }
-    // Local files require an app-side observation before an Agent-declared run may become evidence.
-    // Inline bytes have no file observation, so they retain the declared run only after the durable
-    // Notebook Session and graph-scope checks below succeed.
+    if (request.producerRunId && !request.notebookSessionId) {
+      throw new Error('producerRunId requires notebookSessionId in the active Artifact run.')
+    }
+    // Agent-declared local files require an app observation; inline bytes use the durable checks below.
     if (
       request.producerRunId &&
       !request.sourceFileObservation &&
       request.sourceKind !== 'inline'
     ) {
-      return { state: 'unavailable', reason: 'producer-source-unverifiable' }
-    }
-    if (request.producerRunId && !request.notebookSessionId) {
-      throw new Error('producerRunId requires notebookSessionId in the active Artifact run.')
+      throw new Error(`Notebook producer source observation is required: ${request.producerRunId}`)
     }
     if (!request.notebookSessionId) {
       return { state: 'unavailable', reason: 'producer-not-supplied' }
@@ -234,6 +232,9 @@ class ArtifactProvenanceProducerCapture {
         )
       : undefined
     if (request.sourceFileObservation && !sourceFileObservation) {
+      if (request.producerRunId) {
+        throw new Error(`Notebook producer source could not be verified: ${request.producerRunId}`)
+      }
       return { state: 'unavailable', reason: 'producer-source-unverifiable' }
     }
     const expected = {
@@ -285,7 +286,7 @@ class ArtifactProvenanceProducerCapture {
         )
       }
       if (observedOwners.length !== 1) {
-        return { state: 'unavailable', reason: 'producer-source-unverifiable' }
+        throw new Error(`Producer source must have exactly one Run owner: ${request.producerRunId}`)
       }
     }
 

--- a/src/main/artifacts/provenance-repository.test.ts
+++ b/src/main/artifacts/provenance-repository.test.ts
@@ -2785,27 +2785,29 @@ describe('artifact provenance repository', () => {
       filename: 'spoof.png',
       source: createPngInlineSource('different artifact bytes')
     })
-    const spoofedObservation = await repository.createVersion({
-      projectId: 'project-1',
-      appSessionId: 'session-1',
-      artifactStorageSessionId: 'artifact-session-1',
-      artifactRunId: 'artifact-run-1',
-      writeOperationId: 'write-spoofed-source-observation',
-      writeRequestChecksum: 'e'.repeat(64),
-      ...graph,
-      notebookSessionId: 'session-1',
-      producerRunId: 'notebook-run-owner',
-      sourceFileObservation,
-      filename: 'spoof.png',
-      contentType: 'image/png'
-    })
-    const spoofedRow = await client.artifactVersion.findUniqueOrThrow({
-      where: { id: spoofedObservation.versionId }
-    })
-    expect(spoofedRow).toMatchObject({ producerRunId: null, producerRunIndex: null })
-    expect(JSON.parse(spoofedRow.evidenceJson)).toMatchObject({
-      producer: { state: 'unavailable', reason: 'producer-source-unverifiable' }
-    })
+    await expect(
+      repository.createVersion({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactStorageSessionId: 'artifact-session-1',
+        artifactRunId: 'artifact-run-1',
+        writeOperationId: 'write-spoofed-source-observation',
+        writeRequestChecksum: 'e'.repeat(64),
+        ...graph,
+        notebookSessionId: 'session-1',
+        producerRunId: 'notebook-run-owner',
+        sourceFileObservation,
+        filename: 'spoof.png',
+        contentType: 'image/png'
+      })
+    ).rejects.toThrow('Notebook producer source could not be verified: notebook-run-owner')
+    await expect(
+      repository.listRunVersions({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactRunId: 'artifact-run-1'
+      })
+    ).resolves.toHaveLength(1)
 
     await compatibilityRepository.writePendingFile({
       projectId: 'project-1',
@@ -2851,28 +2853,29 @@ describe('artifact provenance repository', () => {
       filename: 'unobserved-local.png',
       source: createPngInlineSource('unobserved local bytes')
     })
-    const unobservedLocal = await repository.createVersion({
-      projectId: 'project-1',
-      appSessionId: 'session-1',
-      artifactStorageSessionId: 'artifact-session-1',
-      artifactRunId: 'artifact-run-1',
-      writeOperationId: 'write-unobserved-local-producer',
-      writeRequestChecksum: 'c'.repeat(64),
-      ...graph,
-      notebookSessionId: 'session-1',
-      producerRunId: 'notebook-run-owner',
-      sourceKind: 'localPath',
-      filename: 'unobserved-local.png',
-      contentType: 'image/png'
-    })
-    const unobservedLocalRow = await client.artifactVersion.findUniqueOrThrow({
-      where: { id: unobservedLocal.versionId }
-    })
-    expect(unobservedLocalRow).toMatchObject({ producerRunId: null, producerRunIndex: null })
-    expect(JSON.parse(unobservedLocalRow.evidenceJson)).toMatchObject({
-      producer: { state: 'unavailable', reason: 'producer-source-unverifiable' },
-      execution_status: { state: 'unavailable', reason: 'producer-source-unverifiable' }
-    })
+    await expect(
+      repository.createVersion({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactStorageSessionId: 'artifact-session-1',
+        artifactRunId: 'artifact-run-1',
+        writeOperationId: 'write-unobserved-local-producer',
+        writeRequestChecksum: 'c'.repeat(64),
+        ...graph,
+        notebookSessionId: 'session-1',
+        producerRunId: 'notebook-run-owner',
+        sourceKind: 'localPath',
+        filename: 'unobserved-local.png',
+        contentType: 'image/png'
+      })
+    ).rejects.toThrow('Notebook producer source observation is required: notebook-run-owner')
+    await expect(
+      repository.listRunVersions({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactRunId: 'artifact-run-1'
+      })
+    ).resolves.toHaveLength(2)
   })
 
   it('rejects a renderer-supplied message that the durable Conversation Graph does not own', async () => {

--- a/src/main/artifacts/provenance-write-contract.test.ts
+++ b/src/main/artifacts/provenance-write-contract.test.ts
@@ -26,6 +26,15 @@ const fixture = async (): Promise<Fixture> => {
   return value
 }
 
+const listFixtureRunVersions = (
+  value: Fixture
+): ReturnType<Fixture['repository']['listRunVersions']> =>
+  value.repository.listRunVersions({
+    projectId: 'project-1',
+    appSessionId: 'session-1',
+    artifactRunId: 'artifact-run-1'
+  })
+
 afterEach(async () => {
   await Promise.all(fixtures.splice(0).map((value) => value.dispose()))
 })
@@ -479,7 +488,7 @@ describe('artifact provenance producer and source validation', () => {
     })
   })
 
-  it('fails closed to unavailable evidence when the source observation is corrupt', async () => {
+  it('rejects Artifact Finalization when a declared producer source observation is corrupt', async () => {
     const value = await fixture()
     const observation = await appendNotebookRun(value, {
       runId: 'observed-run',
@@ -489,22 +498,65 @@ describe('artifact provenance producer and source validation', () => {
     })
     await value.stagePng('observed bytes')
 
-    const version = await value.repository.createVersion(
-      createArtifactVersionRequest({
-        writeOperationId: 'corrupt-observation-operation',
-        notebookSessionId: 'session-1',
-        producerRunId: 'observed-run',
-        sourceKind: 'localPath',
-        sourceFileObservation: { ...observation, sizeBytes: observation.sizeBytes + 1 }
-      })
-    )
-    const row = await value.client.artifactVersion.findUniqueOrThrow({
-      where: { id: version.versionId }
+    await expect(
+      value.repository.createVersion(
+        createArtifactVersionRequest({
+          writeOperationId: 'corrupt-observation-operation',
+          notebookSessionId: 'session-1',
+          producerRunId: 'observed-run',
+          sourceKind: 'localPath',
+          sourceFileObservation: { ...observation, sizeBytes: observation.sizeBytes + 1 }
+        })
+      )
+    ).rejects.toThrow('Notebook producer source could not be verified: observed-run')
+    await expect(listFixtureRunVersions(value)).resolves.toEqual([])
+  })
+
+  it('rejects Artifact Finalization when a declared local producer has no source observation', async () => {
+    const value = await fixture()
+    await appendNotebookRun(value, {
+      runId: 'unobserved-source-run',
+      filename: 'plot.png',
+      payload: 'unobserved source bytes',
+      ownsSource: true
     })
-    expect(row).toMatchObject({ producerRunId: null, producerRunIndex: null })
-    expect(JSON.parse(row.evidenceJson)).toMatchObject({
-      producer: { state: 'unavailable', reason: 'producer-source-unverifiable' }
+    await value.stagePng('unobserved source bytes')
+
+    await expect(
+      value.repository.createVersion(
+        createArtifactVersionRequest({
+          writeOperationId: 'unobserved-source-operation',
+          notebookSessionId: 'session-1',
+          producerRunId: 'unobserved-source-run',
+          sourceKind: 'localPath'
+        })
+      )
+    ).rejects.toThrow('Notebook producer source observation is required: unobserved-source-run')
+    await expect(listFixtureRunVersions(value)).resolves.toEqual([])
+  })
+
+  it('rejects Artifact Finalization when no Run owns the declared producer source', async () => {
+    const value = await fixture()
+    const observation = await appendNotebookRun(value, {
+      runId: 'unowned-source-run',
+      filename: 'plot.png',
+      payload: 'unowned source bytes',
+      ownsSource: false
     })
+    await value.stagePng('unowned source bytes')
+
+    await expect(
+      value.repository.createVersion(
+        createArtifactVersionRequest({
+          writeOperationId: 'unowned-source-operation',
+          notebookSessionId: 'session-1',
+          producerRunId: 'unowned-source-run',
+          sourceKind: 'localPath',
+          sourceFileObservation: observation
+        })
+      )
+    ).rejects.toThrow('Producer source must have exactly one Run owner: unowned-source-run')
+    await expect(listFixtureRunVersions(value)).resolves.toEqual([])
   })
 
   it('requires a Notebook Session for an inline declared producer', async () => {
@@ -536,28 +588,22 @@ describe('artifact provenance producer and source validation', () => {
     const outsideStat = await stat(outsidePath)
     await value.stagePng('outside root bytes')
 
-    const version = await value.repository.createVersion(
-      createArtifactVersionRequest({
-        writeOperationId: 'outside-root-observation-operation',
-        notebookSessionId: 'session-1',
-        producerRunId: 'outside-root-run',
-        sourceKind: 'localPath',
-        sourceFileObservation: {
-          path: await realpath(outsidePath),
-          sizeBytes: outsideStat.size,
-          mtimeMs: outsideStat.mtimeMs
-        }
-      })
-    )
-    const row = await value.client.artifactVersion.findUniqueOrThrow({
-      where: { id: version.versionId }
-    })
-
-    expect(row).toMatchObject({ producerRunId: null, producerRunIndex: null })
-    expect(JSON.parse(row.evidenceJson)).toMatchObject({
-      producer: { state: 'unavailable', reason: 'producer-source-unverifiable' },
-      execution_status: { state: 'unavailable', reason: 'producer-source-unverifiable' }
-    })
+    await expect(
+      value.repository.createVersion(
+        createArtifactVersionRequest({
+          writeOperationId: 'outside-root-observation-operation',
+          notebookSessionId: 'session-1',
+          producerRunId: 'outside-root-run',
+          sourceKind: 'localPath',
+          sourceFileObservation: {
+            path: await realpath(outsidePath),
+            sizeBytes: outsideStat.size,
+            mtimeMs: outsideStat.mtimeMs
+          }
+        })
+      )
+    ).rejects.toThrow('Notebook producer source could not be verified: outside-root-run')
+    await expect(listFixtureRunVersions(value)).resolves.toEqual([])
   })
 })
 

--- a/src/main/notebook/kernel-executor.test.ts
+++ b/src/main/notebook/kernel-executor.test.ts
@@ -486,6 +486,37 @@ gate('NotebookKernelExecutor (fake loop)', () => {
     }
   })
 
+  it('records files created by a data-kernel cell in the shared handoff directory', async () => {
+    cwdDir = await makeDefaultEnvCwd('os-kernel-handoff-working-file-')
+    const sessionRoot = join(cwdDir, 'nb')
+    const dataRoot = join(sessionRoot, 'data')
+    const handoffRoot = join(sessionRoot, 'handoff')
+    await Promise.all([
+      mkdir(dataRoot, { recursive: true }),
+      mkdir(handoffRoot, { recursive: true })
+    ])
+    const executor = makeExecutor()
+    try {
+      const result = await executor.execute({
+        ...baseRequest(cwdDir),
+        cwd: dataRoot,
+        code: '__WRITE_HANDOFF_FILE__'
+      })
+
+      expect(result.status).toBe('completed')
+      expect(result.workingFiles).toEqual([
+        expect.objectContaining({
+          path: resolve(handoffRoot, 'generated.csv'),
+          relativePath: 'handoff/generated.csv',
+          kind: 'other',
+          size: 8
+        })
+      ])
+    } finally {
+      await executor.shutdown()
+    }
+  })
+
   it('records overwritten outputs without claiming unchanged data files', async () => {
     cwdDir = await makeDefaultEnvCwd('os-kernel-overwritten-file-')
     const dataRoot = join(cwdDir, 'nb', 'data')

--- a/src/main/notebook/working-file-observer.ts
+++ b/src/main/notebook/working-file-observer.ts
@@ -21,7 +21,7 @@ type ActiveObservation = {
   conflicted: boolean
 }
 
-const activeByDataRoot = new Map<string, Set<ActiveObservation>>()
+const activeByObservedRoot = new Map<string, Set<ActiveObservation>>()
 const MAX_CHANGED_PATHS = 10_000
 const MAX_FALLBACK_SNAPSHOT_ENTRIES = 50_000
 const EVENT_SETTLE_MS = 20
@@ -40,18 +40,21 @@ const unavailableObservation = (): WorkingFileObservation => ({
   finish: async () => []
 })
 
-const registerObservation = (dataRoot: string, observation: ActiveObservation): (() => void) => {
-  const active = activeByDataRoot.get(dataRoot) ?? new Set<ActiveObservation>()
+const registerObservation = (
+  observedRoot: string,
+  observation: ActiveObservation
+): (() => void) => {
+  const active = activeByObservedRoot.get(observedRoot) ?? new Set<ActiveObservation>()
   if (active.size > 0) {
     observation.conflicted = true
     for (const existing of active) existing.conflicted = true
   }
   active.add(observation)
-  activeByDataRoot.set(dataRoot, active)
+  activeByObservedRoot.set(observedRoot, active)
 
   return () => {
     active.delete(observation)
-    if (active.size === 0) activeByDataRoot.delete(dataRoot)
+    if (active.size === 0) activeByObservedRoot.delete(observedRoot)
   }
 }
 
@@ -64,8 +67,8 @@ const waitForWatcherReady = (): Promise<void> =>
 type SnapshotEntry = NotebookWorkingFile & { ctimeMs: number }
 
 const resolveChangedFile = async (
-  dataRoot: string,
-  logicalDataRoot: string,
+  observedRoot: string,
+  logicalObservedRoot: string,
   logicalSessionRoot: string,
   candidatePath: string
 ): Promise<SnapshotEntry | undefined> => {
@@ -74,10 +77,10 @@ const resolveChangedFile = async (
     if (linkMetadata.isSymbolicLink()) return undefined
 
     const canonicalPath = await realpath(candidatePath)
-    if (!isPathInside(dataRoot, canonicalPath)) return undefined
+    if (!isPathInside(observedRoot, canonicalPath)) return undefined
     const metadata = await stat(canonicalPath)
     if (!metadata.isFile()) return undefined
-    const logicalPath = resolve(logicalDataRoot, relative(dataRoot, canonicalPath))
+    const logicalPath = resolve(logicalObservedRoot, relative(observedRoot, canonicalPath))
 
     return {
       path: logicalPath,
@@ -116,8 +119,8 @@ const diffSnapshots = (
     }))
 
 const captureFallbackSnapshot = async (
-  dataRoot: string,
-  logicalDataRoot: string,
+  observedRoot: string,
+  logicalObservedRoot: string,
   logicalSessionRoot: string
 ): Promise<Map<string, SnapshotEntry> | undefined> => {
   try {
@@ -142,10 +145,10 @@ const captureFallbackSnapshot = async (
         if (!entry.isFile()) continue
 
         const canonicalPath = await realpath(candidatePath)
-        if (!isPathInside(dataRoot, canonicalPath))
-          throw new Error('Working file escaped data root.')
+        if (!isPathInside(observedRoot, canonicalPath))
+          throw new Error('Working file escaped observed root.')
         const metadata = await stat(canonicalPath)
-        const logicalPath = resolve(logicalDataRoot, relative(dataRoot, canonicalPath))
+        const logicalPath = resolve(logicalObservedRoot, relative(observedRoot, canonicalPath))
         files.set(logicalPath, {
           path: logicalPath,
           relativePath: toPortableNotebookRelativePath(relative(logicalSessionRoot, logicalPath)),
@@ -157,7 +160,7 @@ const captureFallbackSnapshot = async (
       }
     }
 
-    await visit(dataRoot)
+    await visit(observedRoot)
     return files
   } catch {
     return undefined
@@ -165,20 +168,28 @@ const captureFallbackSnapshot = async (
 }
 
 const startFallbackObservation = async (
-  dataRoot: string,
-  logicalDataRoot: string,
+  observedRoot: string,
+  logicalObservedRoot: string,
   logicalSessionRoot: string
 ): Promise<WorkingFileObservation> => {
   const active: ActiveObservation = { conflicted: false }
-  const unregister = registerObservation(dataRoot, active)
-  const before = await captureFallbackSnapshot(dataRoot, logicalDataRoot, logicalSessionRoot)
+  const unregister = registerObservation(observedRoot, active)
+  const before = await captureFallbackSnapshot(
+    observedRoot,
+    logicalObservedRoot,
+    logicalSessionRoot
+  )
   let finished = false
 
   return {
     finish: async () => {
       if (finished) return []
       finished = true
-      const after = await captureFallbackSnapshot(dataRoot, logicalDataRoot, logicalSessionRoot)
+      const after = await captureFallbackSnapshot(
+        observedRoot,
+        logicalObservedRoot,
+        logicalSessionRoot
+      )
       unregister()
       if (active.conflicted || !before || !after) return []
 
@@ -187,19 +198,21 @@ const startFallbackObservation = async (
   }
 }
 
-const startWorkingFileObservation = async (
-  request: WorkingFileObservationRequest,
+const startRootObservation = async (
+  rootPath: string,
+  logicalRootPath: string,
+  logicalSessionRootPath: string,
   dependencies: WorkingFileObservationDependencies = {}
 ): Promise<WorkingFileObservation> => {
   let watcher: FSWatcher | undefined
   try {
-    const logicalDataRoot = resolve(request.dataRoot)
-    const logicalSessionRoot = resolve(request.notebookSessionRoot)
-    const [dataRoot, sessionRoot] = await Promise.all([
-      realpath(request.dataRoot),
-      realpath(request.notebookSessionRoot)
+    const logicalObservedRoot = resolve(logicalRootPath)
+    const logicalSessionRoot = resolve(logicalSessionRootPath)
+    const [observedRoot, sessionRoot] = await Promise.all([
+      realpath(rootPath),
+      realpath(logicalSessionRootPath)
     ])
-    if (!isPathInside(sessionRoot, dataRoot)) return unavailableObservation()
+    if (!isPathInside(sessionRoot, observedRoot)) return unavailableObservation()
 
     const active: ActiveObservation = { conflicted: false }
     const changedPaths = new Set<string>()
@@ -208,7 +221,7 @@ const startWorkingFileObservation = async (
 
     try {
       watcher = (dependencies.watchDirectory ?? watch)(
-        dataRoot,
+        observedRoot,
         { recursive: true },
         (_eventType, filename) => {
           if (invalid) return
@@ -222,8 +235,8 @@ const startWorkingFileObservation = async (
             invalid = true
             return
           }
-          const candidatePath = resolve(dataRoot, eventPath)
-          if (!isPathInside(dataRoot, candidatePath)) {
+          const candidatePath = resolve(observedRoot, eventPath)
+          if (!isPathInside(observedRoot, candidatePath)) {
             invalid = true
             return
           }
@@ -236,7 +249,7 @@ const startWorkingFileObservation = async (
         }
       )
     } catch {
-      return startFallbackObservation(dataRoot, logicalDataRoot, logicalSessionRoot)
+      return startFallbackObservation(observedRoot, logicalObservedRoot, logicalSessionRoot)
     }
     watcher.on('error', () => {
       invalid = true
@@ -244,17 +257,21 @@ const startWorkingFileObservation = async (
     await waitForWatcherReady()
     if (invalid) {
       watcher.close()
-      return startFallbackObservation(dataRoot, logicalDataRoot, logicalSessionRoot)
+      return startFallbackObservation(observedRoot, logicalObservedRoot, logicalSessionRoot)
     }
     // Recursive watchers can replay pre-existing paths while their initial scan settles. Execution
     // has not started yet, so those events cannot prove this run created or changed the files.
     changedPaths.clear()
-    const before = await captureFallbackSnapshot(dataRoot, logicalDataRoot, logicalSessionRoot)
+    const before = await captureFallbackSnapshot(
+      observedRoot,
+      logicalObservedRoot,
+      logicalSessionRoot
+    )
     if (!before) {
       watcher.close()
       return unavailableObservation()
     }
-    const unregister = registerObservation(dataRoot, active)
+    const unregister = registerObservation(observedRoot, active)
 
     return {
       finish: async () => {
@@ -270,7 +287,12 @@ const startWorkingFileObservation = async (
             Array.from(changedPaths)
               .sort((left, right) => left.localeCompare(right))
               .map((candidatePath) =>
-                resolveChangedFile(dataRoot, logicalDataRoot, logicalSessionRoot, candidatePath)
+                resolveChangedFile(
+                  observedRoot,
+                  logicalObservedRoot,
+                  logicalSessionRoot,
+                  candidatePath
+                )
               )
           )
           const changedFiles = candidates
@@ -296,7 +318,11 @@ const startWorkingFileObservation = async (
           // macOS can deliver recursive watcher events after the bounded settle window. A full diff
           // is reserved for the empty/no-op event path so correctness does not impose two tree scans
           // on normal runs.
-          const after = await captureFallbackSnapshot(dataRoot, logicalDataRoot, logicalSessionRoot)
+          const after = await captureFallbackSnapshot(
+            observedRoot,
+            logicalObservedRoot,
+            logicalSessionRoot
+          )
           return after ? diffSnapshots(before, after) : []
         } catch {
           return []
@@ -306,6 +332,37 @@ const startWorkingFileObservation = async (
   } catch {
     watcher?.close()
     return unavailableObservation()
+  }
+}
+
+const startWorkingFileObservation = async (
+  request: WorkingFileObservationRequest,
+  dependencies: WorkingFileObservationDependencies = {}
+): Promise<WorkingFileObservation> => {
+  const logicalSessionRoot = resolve(request.notebookSessionRoot)
+  const handoffRoot = join(logicalSessionRoot, 'handoff')
+  const roots = [
+    { path: request.dataRoot, logicalPath: request.dataRoot },
+    ...(await realpath(handoffRoot).then(
+      () => [{ path: handoffRoot, logicalPath: handoffRoot }],
+      () => []
+    ))
+  ]
+  const observations = await Promise.all(
+    roots.map((root) =>
+      startRootObservation(root.path, root.logicalPath, logicalSessionRoot, dependencies)
+    )
+  )
+  let finished = false
+
+  return {
+    finish: async () => {
+      if (finished) return []
+      finished = true
+      return (await Promise.all(observations.map((observation) => observation.finish())))
+        .flat()
+        .sort((left, right) => left.path.localeCompare(right.path))
+    }
   }
 }
 

--- a/test/fixtures/fake_loop.py
+++ b/test/fixtures/fake_loop.py
@@ -11,6 +11,7 @@
 #   __FIGURE__         write a real 1x1 PNG into the figures dir and reference it in the response
 #   __OVERSIZED_LINE__:<bytes>  write an unframed stdout line of the requested size
 #   __WRITE_FILE__      write an output file into the kernel working directory
+#   __WRITE_HANDOFF_FILE__ write an output file into the shared handoff directory
 #   __OVERWRITE_FILE__  replace a pre-existing output in the kernel working directory
 #   __WRITE_DELAYED_A__ / __WRITE_DELAYED_B__ overlap two kernels writing the same data root
 import base64
@@ -36,6 +37,10 @@ def _respond(req_id, code, error=None, interrupt_ack=False):
         figures = [{"mime": "image/png", "path": path}]
     if code == "__WRITE_FILE__":
         with open("generated.csv", "w", encoding="utf-8") as handle:
+            handle.write("x,y\n1,2\n")
+    if code == "__WRITE_HANDOFF_FILE__":
+        handoff_dir = os.environ["OPEN_SCIENCE_HANDOFF_DIR"]
+        with open(os.path.join(handoff_dir, "generated.csv"), "w", encoding="utf-8") as handle:
             handle.write("x,y\n1,2\n")
     if code == "__OVERWRITE_FILE__":
         previous = os.stat("generated.csv")


### PR DESCRIPTION
## Problem

Notebook executions can create artifact source files in the shared handoff directory, but working-file observation only watched the data directory. The durable Run then had no ownership receipt for the source. Artifact Finalization silently discarded an explicitly declared producer, leaving the immutable Execution Log and Code reconstruction unavailable.

## Proposed change

- Observe both the data and shared handoff roots behind the existing Notebook working-file interface.
- Persist handoff changes as working files owned by the producing Run.
- Reject Artifact Finalization when an explicit Notebook producer has a missing, corrupt, or non-unique source observation instead of creating a Version with unavailable producer evidence.
- Preserve unavailable evidence for writes that omit a producer.

## Scope and non-goals

- No renderer or public interface changes.
- No database migration or retroactive provenance backfill.
- Existing Artifact Versions remain readable.
- Concurrent observations continue to fail closed when ownership cannot be proven.

## Acceptance criteria and validation

Final checks ran after the last material edits.

- Handoff file capture and Run ownership -> npx vitest run src/main/notebook/kernel-executor.test.ts -> 60 passed, 18 skipped.
- Artifact Finalization, atomic rejection, and architecture boundaries -> npx vitest run src/main/artifacts/provenance-write-contract.test.ts src/main/artifacts/provenance-repository.test.ts src/main/artifacts/provenance-repository.architecture.test.ts -> 65 passed.
- Node process types -> npm run typecheck:node -> passed.
- Changed-file formatting, lint, and diff integrity -> Prettier check, ESLint, and git diff --check -> passed.
- Independent two-axis code review -> Standards and Spec final reviews reported no findings.

A full-suite probe also exposed existing unrelated renderer test-environment and architecture-baseline failures. No changed main-process provenance or Notebook test remained failing; the relevant provenance architecture failure found during the probe was fixed and rerun successfully.

## Review focus

- Whether observing the shared handoff root preserves conservative concurrent ownership semantics.
- Whether explicit producer declarations should remain all-or-nothing while omitted producers retain unavailable provenance.