### PR TITLE
fix(provenance): accept ancestor branch producers

### DIFF
--- a/src/main/artifacts/provenance-producer-capture.ts
+++ b/src/main/artifacts/provenance-producer-capture.ts
@@ -17,7 +17,7 @@ import type {
   NotebookRunRecord
 } from '../../shared/notebook'
 import type { ImmutableInputAuthority } from '../immutable-input-authority'
-import { NotebookRunRepository } from '../notebook/repository'
+import { getNotebookSessionRoot, NotebookRunRepository } from '../notebook/repository'
 import {
   canonicalJson,
   isCanonicalJsonValue,
@@ -130,7 +130,6 @@ type ArtifactVersionProducerCapture =
       argumentsChecksum: string
       inputFiles: NotebookRunInputFile[]
     }
-
 type PreparedArtifactVersionPersistence = {
   notebookSessionId?: string
   producerRunId?: string
@@ -141,13 +140,12 @@ type PreparedArtifactVersionPersistence = {
   executionSnapshotChecksum?: string
   inputs?: Prisma.ArtifactVersionUncheckedCreateInput['inputs']
 }
-
 type ArtifactProvenanceProducerCaptureOptions = {
   inputAuthority: Pick<ImmutableInputAuthority, 'validateVersion'>
   notebookRepository: Pick<NotebookRunRepository, 'readSessionDocuments'>
+  storageRoot: string
   createId: () => string
 }
-
 type PrepareVersionPersistenceInput = {
   request: CreateArtifactVersionRequest
   producer: ArtifactVersionProducerCapture
@@ -158,13 +156,42 @@ type PrepareVersionPersistenceInput = {
   sizeBytes: number
   createdAt: Date
 }
-
 type ProducerScope = {
   rootFrameId: string
   agentFrameId: string
-  messageBranchId: string
-  runtimeSegmentId: string
-  promptMessageId: string
+  activeRuntimeSegmentId: string
+  activePromptMessageId: string
+  eligibleBranchIds: ReadonlySet<string>
+  eligibleMessageIds: ReadonlySet<string>
+}
+
+type SourceFileObservation = NonNullable<CreateArtifactVersionRequest['sourceFileObservation']>
+type SourceFileObservationAssessment = {
+  notebookSessionOwned: boolean
+  verified?: SourceFileObservation
+}
+
+const isStrictDescendant = (root: string, candidate: string): boolean => {
+  const nested = relative(root, candidate)
+  return nested !== '' && nested !== '..' && !nested.startsWith(`..${sep}`) && !isAbsolute(nested)
+}
+
+const canonicalPath = async (path: string): Promise<string> =>
+  realpath(resolve(path)).catch(() => resolve(path))
+const producerScopeMismatch = (
+  run: NotebookRunRecord,
+  scope: ProducerScope
+): keyof NotebookRunRecord | null => {
+  if (run.rootFrameId !== scope.rootFrameId) return 'rootFrameId'
+  if (run.agentFrameId !== scope.agentFrameId) return 'agentFrameId'
+  if (!run.messageBranchId || !scope.eligibleBranchIds.has(run.messageBranchId))
+    return 'messageBranchId'
+  if (!run.promptMessageId || !scope.eligibleMessageIds.has(run.promptMessageId))
+    return 'promptMessageId'
+  return run.promptMessageId === scope.activePromptMessageId &&
+    run.runtimeSegmentId !== scope.activeRuntimeSegmentId
+    ? 'runtimeSegmentId'
+    : null
 }
 
 class ArtifactProvenanceProducerCapture {
@@ -224,31 +251,58 @@ class ArtifactProvenanceProducerCapture {
           )) ??
       documents[0] ??
       null
-    const sourceFileObservation = request.sourceFileObservation
-      ? await this.verifySourceFileObservation(
+    const sourceFileAssessment = request.sourceFileObservation
+      ? await this.assessSourceFileObservation(
           document,
           request.sourceFileObservation,
-          artifactChecksum
+          artifactChecksum,
+          getNotebookSessionRoot(
+            this.options.storageRoot,
+            request.projectId,
+            request.notebookSessionId
+          )
         )
       : undefined
+    const sourceFileObservation = sourceFileAssessment?.verified
     if (request.sourceFileObservation && !sourceFileObservation) {
       if (request.producerRunId) {
         throw new Error(`Notebook producer source could not be verified: ${request.producerRunId}`)
       }
+      if (sourceFileAssessment?.notebookSessionOwned) {
+        throw new Error('Notebook source observation could not be verified.')
+      }
       return { state: 'unavailable', reason: 'producer-source-unverifiable' }
     }
-    const expected = {
+    const eligibleBranchIds = new Set(
+      request.messageBranchAncestry?.length
+        ? request.messageBranchAncestry
+        : [request.messageBranchId]
+    )
+    if (!eligibleBranchIds.has(request.messageBranchId)) {
+      throw new Error('Artifact Branch ancestry does not contain the active Branch.')
+    }
+    const eligibleMessageIds = new Set(
+      request.messageAncestry?.length ? request.messageAncestry : [request.promptMessageId]
+    )
+    if (!eligibleMessageIds.has(request.promptMessageId)) {
+      throw new Error('Artifact Message ancestry does not contain the producer prompt.')
+    }
+    const scope: ProducerScope = {
       rootFrameId: request.rootFrameId,
       agentFrameId: request.agentFrameId,
-      messageBranchId: request.messageBranchId,
-      runtimeSegmentId: request.runtimeSegmentId,
-      promptMessageId: request.promptMessageId
+      activeRuntimeSegmentId: request.runtimeSegmentId,
+      activePromptMessageId: request.promptMessageId,
+      eligibleBranchIds,
+      eligibleMessageIds
     }
     const inferredProducerRunId = request.producerRunId
       ? undefined
-      : await this.inferProducerRunId(document, sourceFileObservation, expected)
+      : await this.inferProducerRunId(document, sourceFileObservation, scope)
     const producerRunId = request.producerRunId ?? inferredProducerRunId
     if (!producerRunId) {
+      if (sourceFileAssessment?.notebookSessionOwned) {
+        throw new Error('Notebook source must have exactly one eligible Run owner.')
+      }
       return {
         state: 'unavailable',
         reason: request.sourceFileObservation
@@ -262,23 +316,22 @@ class ArtifactProvenanceProducerCapture {
     if (!document || !producerRun || producerRunIndex < 0) {
       throw new Error(`Notebook producer run not found: ${producerRunId}`)
     }
-    for (const [field, value] of Object.entries(expected)) {
-      if (producerRun[field as keyof typeof expected] !== value) {
-        if (field === 'agentFrameId') {
-          throw new Error(
-            'Notebook producer run belongs to a different agent frame. Have the producing agent publish it directly, or reference an already completed Artifact Version.'
-          )
-        }
+    const scopeMismatch = producerScopeMismatch(producerRun, scope)
+    if (scopeMismatch) {
+      if (scopeMismatch === 'agentFrameId') {
         throw new Error(
-          `Notebook producer run does not belong to the active Artifact ${field}: ${producerRunId}`
+          'Notebook producer run belongs to a different agent frame. Have the producing agent publish it directly, or reference an already completed Artifact Version.'
         )
       }
+      throw new Error(
+        `Notebook producer run does not belong to the active Artifact ${scopeMismatch}: ${producerRunId}`
+      )
     }
     if (request.producerRunId && sourceFileObservation) {
       const observedOwners = await this.findObservedWorkingFileRunIds(
         document,
         sourceFileObservation,
-        expected
+        scope
       )
       if (observedOwners.length > 0 && !observedOwners.includes(request.producerRunId)) {
         throw new Error(
@@ -290,34 +343,10 @@ class ArtifactProvenanceProducerCapture {
       }
     }
 
-    const eligibleBranchIds = new Set(
-      request.messageBranchAncestry?.length
-        ? request.messageBranchAncestry
-        : [request.messageBranchId]
-    )
-    if (!eligibleBranchIds.has(request.messageBranchId)) {
-      throw new Error('Artifact Branch ancestry does not contain the active Branch.')
-    }
-    const eligibleMessageIds = request.messageAncestry?.length
-      ? new Set(request.messageAncestry)
-      : undefined
-    if (eligibleMessageIds && !eligibleMessageIds.has(request.promptMessageId)) {
-      throw new Error('Artifact Message ancestry does not contain the producer prompt.')
-    }
     const eligibleRuns = document.runs
       .slice(0, producerRunIndex + 1)
       .map((run, runIndex) => ({ run, runIndex }))
-      .filter(
-        ({ run }) =>
-          run.agentFrameId === request.agentFrameId &&
-          !!run.messageBranchId &&
-          eligibleBranchIds.has(run.messageBranchId) &&
-          (eligibleMessageIds
-            ? run.promptMessageId
-              ? eligibleMessageIds.has(run.promptMessageId)
-              : run.messageBranchId === request.messageBranchId
-            : true)
-      )
+      .filter(({ run }) => producerScopeMismatch(run, scope) === null)
     const executionSnapshot = buildBoundedExecutionSnapshot(
       {
         schemaVersion: 2,
@@ -503,59 +532,43 @@ class ArtifactProvenanceProducerCapture {
   private async inferProducerRunId(
     document: Awaited<ReturnType<NotebookRunRepository['findExisting']>>,
     observation: CreateArtifactVersionRequest['sourceFileObservation'],
-    expected: ProducerScope
+    scope: ProducerScope
   ): Promise<string | undefined> {
     if (!document || !observation) return undefined
-    const matches = await this.findObservedWorkingFileRunIds(document, observation, expected)
+    const matches = await this.findObservedWorkingFileRunIds(document, observation, scope)
     return matches.length === 1 ? matches[0] : undefined
   }
 
-  // Treat the RPC observation as an untrusted path hint. Main re-observes the source under the
-  // Notebook's durable roots and proves that its bytes are exactly the immutable Artifact content
-  // before the hint may participate in producer attribution.
-  private async verifySourceFileObservation(
+  // Main re-observes the untrusted RPC path under durable roots and proves its bytes match the
+  // immutable Artifact content before the hint participates in producer attribution.
+  private async assessSourceFileObservation(
     document: Awaited<ReturnType<NotebookRunRepository['findExisting']>>,
-    observation: NonNullable<CreateArtifactVersionRequest['sourceFileObservation']>,
-    artifactChecksum: string
-  ): Promise<NonNullable<CreateArtifactVersionRequest['sourceFileObservation']> | undefined> {
+    observation: SourceFileObservation,
+    artifactChecksum: string,
+    notebookSessionRoot: string
+  ): Promise<SourceFileObservationAssessment> {
+    const observedPath = await canonicalPath(observation.path)
+    const rootPaths = [notebookSessionRoot, ...(document ? [document.workspaceCwd] : [])]
+    const roots = await Promise.all(rootPaths.map(canonicalPath))
+    const assessment = { notebookSessionOwned: isStrictDescendant(roots[0], observedPath) }
     if (
-      !document ||
       !Number.isFinite(observation.sizeBytes) ||
       observation.sizeBytes < 0 ||
       !Number.isFinite(observation.mtimeMs) ||
       observation.mtimeMs < 0
     ) {
-      return undefined
+      return assessment
     }
-
-    const observedPath = await realpath(resolve(observation.path)).catch(() => undefined)
-    if (!observedPath) return undefined
-    const roots = await Promise.all(
-      [document.notebookSessionRoot, document.workspaceCwd].map((root) =>
-        realpath(resolve(root)).catch(() => resolve(root))
-      )
-    )
-    if (
-      !roots.some((root) => {
-        const relativePath = relative(root, observedPath)
-        return (
-          relativePath !== '' &&
-          relativePath !== '..' &&
-          !relativePath.startsWith(`..${sep}`) &&
-          !isAbsolute(relativePath)
-        )
-      })
-    ) {
-      return undefined
+    if (!roots.some((root) => isStrictDescendant(root, observedPath))) {
+      return assessment
     }
-
     const before = await stat(observedPath).catch(() => undefined)
     if (
       !before?.isFile() ||
       before.size !== observation.sizeBytes ||
       before.mtimeMs !== observation.mtimeMs
     ) {
-      return undefined
+      return assessment
     }
     const bytes = await readFile(observedPath).catch(() => undefined)
     const after = await stat(observedPath).catch(() => undefined)
@@ -566,16 +579,18 @@ class ArtifactProvenanceProducerCapture {
       after.mtimeMs !== before.mtimeMs ||
       sha256(bytes) !== artifactChecksum
     ) {
-      return undefined
+      return assessment
     }
-
-    return { path: observedPath, sizeBytes: after.size, mtimeMs: after.mtimeMs }
+    return {
+      ...assessment,
+      verified: { path: observedPath, sizeBytes: after.size, mtimeMs: after.mtimeMs }
+    }
   }
 
   private async findObservedWorkingFileRunIds(
     document: NonNullable<Awaited<ReturnType<NotebookRunRepository['findExisting']>>>,
-    observation: NonNullable<CreateArtifactVersionRequest['sourceFileObservation']>,
-    expected: ProducerScope
+    observation: SourceFileObservation,
+    scope: ProducerScope
   ): Promise<string[]> {
     if (
       !Number.isFinite(observation.sizeBytes) ||
@@ -586,28 +601,16 @@ class ArtifactProvenanceProducerCapture {
       return []
     }
 
-    const canonicalPath = async (path: string): Promise<string> =>
-      realpath(resolve(path)).catch(() => resolve(path))
     const observedPath = await canonicalPath(observation.path)
     const documentRoots = await Promise.all(
       [document.notebookSessionRoot, document.workspaceCwd].map(canonicalPath)
     )
-    const isInsideDocumentRoot = documentRoots.some((root) => {
-      const relativePath = relative(root, observedPath)
-      return (
-        relativePath !== '' &&
-        relativePath !== '..' &&
-        !relativePath.startsWith(`..${sep}`) &&
-        !isAbsolute(relativePath)
-      )
-    })
+    const isInsideDocumentRoot = documentRoots.some((root) =>
+      isStrictDescendant(root, observedPath)
+    )
     if (!isInsideDocumentRoot) return []
 
-    const candidates = document.runs.filter((run) =>
-      Object.entries(expected).every(
-        ([field, value]) => run[field as keyof typeof expected] === value
-      )
-    )
+    const candidates = document.runs.filter((run) => producerScopeMismatch(run, scope) === null)
     const workingFileMatches = (
       await Promise.all(
         candidates.map(async (run) => {

--- a/src/main/artifacts/provenance-repository.test.ts
+++ b/src/main/artifacts/provenance-repository.test.ts
@@ -2366,7 +2366,7 @@ describe('artifact provenance repository', () => {
     ).rejects.toThrow(/execution snapshot input metadata mismatch/i)
   })
 
-  it('does not infer an omitted producer from source mtime alone', async () => {
+  it('rejects an omitted Notebook producer when mtime is the only association', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-artifact-auto-producer-'))
     const client = createProjectDbClient(storageRoot)
     disconnect = () => client.$disconnect()
@@ -2444,46 +2444,32 @@ describe('artifact provenance repository', () => {
       source: { kind: 'inline', content: content.toString('base64'), encoding: 'base64' }
     })
 
-    const version = await repository.createVersion({
-      projectId: 'project-1',
-      appSessionId: 'session-1',
-      artifactStorageSessionId: 'artifact-session-1',
-      artifactRunId: 'artifact-run-1',
-      writeOperationId: 'write-auto-producer',
-      writeRequestChecksum: 'f'.repeat(64),
-      ...graph,
-      notebookSessionId: 'session-1',
-      sourceFileObservation: {
-        path: resolvedSourcePath,
-        sizeBytes: sourceStat.size,
-        mtimeMs: sourceStat.mtimeMs
-      },
-      filename: 'sin.png',
-      contentType: 'image/png'
-    })
-    const row = await client.artifactVersion.findUniqueOrThrow({
-      where: { id: version.versionId }
-    })
-
-    expect(row).toMatchObject({ producerRunId: null, producerRunIndex: null })
-    expect(JSON.parse(row.evidenceJson)).toMatchObject({
-      producer: {
-        state: 'unavailable',
-        reason: 'producer-source-unverifiable'
-      },
-      execution_status: { state: 'unavailable', reason: 'producer-source-unverifiable' }
-    })
     await expect(
-      repository.replayVersion({
+      repository.createVersion({
         projectId: 'project-1',
         appSessionId: 'session-1',
         artifactStorageSessionId: 'artifact-session-1',
         artifactRunId: 'artifact-run-1',
         writeOperationId: 'write-auto-producer',
+        writeRequestChecksum: 'f'.repeat(64),
+        ...graph,
+        notebookSessionId: 'session-1',
+        sourceFileObservation: {
+          path: resolvedSourcePath,
+          sizeBytes: sourceStat.size,
+          mtimeMs: sourceStat.mtimeMs
+        },
         filename: 'sin.png',
         contentType: 'image/png'
       })
-    ).resolves.toMatchObject({ versionId: version.versionId })
+    ).rejects.toThrow('Notebook source must have exactly one eligible Run owner.')
+    await expect(
+      repository.listRunVersions({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactRunId: 'artifact-run-1'
+      })
+    ).resolves.toEqual([])
   })
 
   it('bounds execution evidence while retaining the producer run', async () => {

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -173,6 +173,7 @@ class ArtifactProvenanceRepository {
     this.producerCapture = new ArtifactProvenanceProducerCapture({
       inputAuthority,
       notebookRepository,
+      storageRoot: options.storageRoot,
       createId: this.createId
     })
     this.messageFinalizer = new ArtifactProvenanceMessageFinalizer({

--- a/src/main/artifacts/provenance-write-contract.test.ts
+++ b/src/main/artifacts/provenance-write-contract.test.ts
@@ -4,7 +4,7 @@ import { mkdir, readFile, realpath, stat, writeFile } from 'node:fs/promises'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
-import type { NotebookRunInputFile } from '../../shared/notebook'
+import type { NotebookRunInputFile, NotebookRunRecord } from '../../shared/notebook'
 import { ImmutableInputAuthority } from '../immutable-input-authority'
 import { createFrameNotebookLane } from '../notebook/lane-identity'
 import { NotebookRuntimeService, type NotebookExecutionResult } from '../notebook/runtime-service'
@@ -205,6 +205,12 @@ const appendNotebookRun = async (
     payload: string
     ownsSource: boolean
     inputFiles?: NotebookRunInputFile[]
+    provenanceContext?: Partial<
+      Pick<
+        NotebookRunRecord,
+        'rootFrameId' | 'agentFrameId' | 'messageBranchId' | 'runtimeSegmentId' | 'promptMessageId'
+      >
+    >
   }
 ): Promise<{ path: string; sizeBytes: number; mtimeMs: number }> => {
   const lane = createFrameNotebookLane('project-1', 'session-1', provenanceGraph.agentFrameId)
@@ -247,7 +253,8 @@ const appendNotebookRun = async (
             }
           ]
         : [],
-      ...provenanceGraph
+      ...provenanceGraph,
+      ...input.provenanceContext
     }
   })
   return {
@@ -450,6 +457,79 @@ describe('artifact provenance producer and source validation', () => {
     await expect(value.client.artifactVersion.count()).resolves.toBe(1)
   })
 
+  it('accepts a declared source owner from an ancestor Conversation Branch', async () => {
+    const value = await fixture()
+    const observation = await appendNotebookRun(value, {
+      runId: 'ancestor-producer-run',
+      filename: 'plot.png',
+      payload: 'ancestor producer bytes',
+      ownsSource: true,
+      provenanceContext: {
+        messageBranchId: 'branch-parent',
+        runtimeSegmentId: 'runtime-segment-parent',
+        promptMessageId: 'prompt-parent'
+      }
+    })
+    await value.stagePng('ancestor producer bytes')
+
+    const version = await value.repository.createVersion(
+      createArtifactVersionRequest({
+        writeOperationId: 'ancestor-producer-operation',
+        notebookSessionId: 'session-1',
+        producerRunId: 'ancestor-producer-run',
+        sourceKind: 'localPath',
+        sourceFileObservation: observation,
+        messageBranchAncestry: ['branch-parent', provenanceGraph.messageBranchId],
+        messageAncestry: ['prompt-parent', provenanceGraph.promptMessageId]
+      })
+    )
+
+    await expect(
+      value.repository.getVersionExecution({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactId: version.artifactId,
+        versionId: version.versionId
+      })
+    ).resolves.toMatchObject({ execution: { producerRunId: 'ancestor-producer-run' } })
+  })
+
+  it('infers the exact source owner from an ancestor Branch when producerRunId is omitted', async () => {
+    const value = await fixture()
+    const observation = await appendNotebookRun(value, {
+      runId: 'inferred-ancestor-run',
+      filename: 'plot.png',
+      payload: 'inferred ancestor bytes',
+      ownsSource: true,
+      provenanceContext: {
+        messageBranchId: 'branch-parent',
+        runtimeSegmentId: 'runtime-segment-parent',
+        promptMessageId: 'prompt-parent'
+      }
+    })
+    await value.stagePng('inferred ancestor bytes')
+
+    const version = await value.repository.createVersion(
+      createArtifactVersionRequest({
+        writeOperationId: 'inferred-ancestor-operation',
+        notebookSessionId: 'session-1',
+        sourceKind: 'localPath',
+        sourceFileObservation: observation,
+        messageBranchAncestry: ['branch-parent', provenanceGraph.messageBranchId],
+        messageAncestry: ['prompt-parent', provenanceGraph.promptMessageId]
+      })
+    )
+
+    await expect(
+      value.repository.getVersionExecution({
+        projectId: 'project-1',
+        appSessionId: 'session-1',
+        artifactId: version.artifactId,
+        versionId: version.versionId
+      })
+    ).resolves.toMatchObject({ execution: { producerRunId: 'inferred-ancestor-run' } })
+  })
+
   it('rejects a missing declared run but never infers a producer from mtime alone', async () => {
     const value = await fixture()
     const observation = await appendNotebookRun(value, {
@@ -473,19 +553,14 @@ describe('artifact provenance producer and source validation', () => {
       })
     ).rejects.toThrow('Notebook producer run not found: missing-run')
 
-    const version = await value.repository.createVersion({
-      ...base,
-      writeOperationId: 'mtime-operation',
-      writeRequestChecksum: '6'.repeat(64)
-    })
-    const row = await value.client.artifactVersion.findUniqueOrThrow({
-      where: { id: version.versionId }
-    })
-    expect(row).toMatchObject({ producerRunId: null, producerRunIndex: null })
-    expect(JSON.parse(row.evidenceJson)).toMatchObject({
-      producer: { state: 'unavailable', reason: 'producer-source-unverifiable' },
-      execution_status: { state: 'unavailable', reason: 'producer-source-unverifiable' }
-    })
+    await expect(
+      value.repository.createVersion({
+        ...base,
+        writeOperationId: 'mtime-operation',
+        writeRequestChecksum: '6'.repeat(64)
+      })
+    ).rejects.toThrow('Notebook source must have exactly one eligible Run owner.')
+    await expect(listFixtureRunVersions(value)).resolves.toEqual([])
   })
 
   it('rejects Artifact Finalization when a declared producer source observation is corrupt', async () => {
@@ -509,6 +584,53 @@ describe('artifact provenance producer and source validation', () => {
         })
       )
     ).rejects.toThrow('Notebook producer source could not be verified: observed-run')
+    await expect(listFixtureRunVersions(value)).resolves.toEqual([])
+  })
+
+  it('rejects a corrupt Notebook-owned source observation when producerRunId is omitted', async () => {
+    const value = await fixture()
+    const observation = await appendNotebookRun(value, {
+      runId: 'inferred-corrupt-observation-run',
+      filename: 'plot.png',
+      payload: 'inferred corrupt observation bytes',
+      ownsSource: true
+    })
+    await value.stagePng('inferred corrupt observation bytes')
+
+    await expect(
+      value.repository.createVersion(
+        createArtifactVersionRequest({
+          writeOperationId: 'inferred-corrupt-observation-operation',
+          notebookSessionId: 'session-1',
+          sourceKind: 'localPath',
+          sourceFileObservation: { ...observation, sizeBytes: observation.sizeBytes + 1 }
+        })
+      )
+    ).rejects.toThrow('Notebook source observation could not be verified.')
+    await expect(listFixtureRunVersions(value)).resolves.toEqual([])
+  })
+
+  it('rejects a Notebook-owned source when its Run document is unreadable', async () => {
+    const value = await fixture()
+    const observation = await appendNotebookRun(value, {
+      runId: 'unreadable-document-run',
+      filename: 'plot.png',
+      payload: 'unreadable document bytes',
+      ownsSource: true
+    })
+    await writeFile(join(dirname(dirname(observation.path)), 'run.json'), '{ not-json', 'utf8')
+    await value.stagePng('unreadable document bytes')
+
+    await expect(
+      value.repository.createVersion(
+        createArtifactVersionRequest({
+          writeOperationId: 'unreadable-document-operation',
+          notebookSessionId: 'session-1',
+          sourceKind: 'localPath',
+          sourceFileObservation: observation
+        })
+      )
+    ).rejects.toThrow('Notebook source must have exactly one eligible Run owner.')
     await expect(listFixtureRunVersions(value)).resolves.toEqual([])
   })
 
@@ -556,6 +678,29 @@ describe('artifact provenance producer and source validation', () => {
         })
       )
     ).rejects.toThrow('Producer source must have exactly one Run owner: unowned-source-run')
+    await expect(listFixtureRunVersions(value)).resolves.toEqual([])
+  })
+
+  it('rejects an unowned Notebook source when producerRunId is omitted', async () => {
+    const value = await fixture()
+    const observation = await appendNotebookRun(value, {
+      runId: 'unowned-inferred-run',
+      filename: 'plot.png',
+      payload: 'unowned inferred bytes',
+      ownsSource: false
+    })
+    await value.stagePng('unowned inferred bytes')
+
+    await expect(
+      value.repository.createVersion(
+        createArtifactVersionRequest({
+          writeOperationId: 'unowned-inferred-operation',
+          notebookSessionId: 'session-1',
+          sourceKind: 'localPath',
+          sourceFileObservation: observation
+        })
+      )
+    ).rejects.toThrow('Notebook source must have exactly one eligible Run owner.')
     await expect(listFixtureRunVersions(value)).resolves.toEqual([])
   })
 

--- a/src/shared/notebook.ts
+++ b/src/shared/notebook.ts
@@ -417,7 +417,8 @@ export type NotebookRunRecord = {
   environmentManifest?: NotebookEnvironmentManifest
   environmentManifestChecksum?: string
   // Trusted turn/Branch attribution injected by the main-process RPC bridge. Legacy and user-run
-  // records may omit it; a supplied Artifact producer must match all five fields.
+  // records may omit it. An Artifact producer must share root/agent identity, belong to the trusted
+  // Branch and message ancestry, and match the active Runtime Segment for the active prompt.
   rootFrameId?: string
   agentFrameId?: string
   messageBranchId?: string


### PR DESCRIPTION
## Problem

After forking a Conversation Branch, Artifact publication can correctly reference a Notebook Run from the ancestor Branch. Producer validation previously required the active Branch, Runtime Segment, and prompt identities exactly, so it rejected that valid owner. The Agent could then retry without `producerRunId`, allowing an Artifact Version with unavailable provenance.

This follows up #1659.

## Proposed change

- Validate producer Runs against trusted Branch and message ancestry while retaining exact root/agent identity.
- Require the active Runtime Segment only for a Run owned by the active prompt; ancestor prompts retain their own Runtime Segment.
- Infer an omitted producer only from one exact eligible WorkingFile owner.
- Fail closed for Notebook Session sources when the owner is missing, ambiguous, corrupt, or backed by an unreadable `run.json`.
- Derive Notebook ownership from the authoritative Session storage root, independently of successful Run-document decoding.

## Scope and non-goals

- No database migration or renderer changes.
- No silent compatibility path for old malformed Notebook provenance.
- Existing unavailable Artifact Versions are not backfilled; they must be regenerated after the fix.
- External Workspace sources retain unavailable-provenance behavior when they are not Notebook-owned.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Ancestor declaration/inference and Notebook all-or-nothing contract -> `npx vitest run src/main/artifacts/provenance-write-contract.test.ts src/main/artifacts/provenance-repository.architecture.test.ts` -> 30 passed.
- Repository persistence, MCP publication, and reconstruction consumers -> `npx vitest run src/main/artifacts/provenance-repository.test.ts src/main/artifacts/mcp-server.test.ts src/main/artifacts/code-reconstruction.test.ts` -> 70 passed.
- Main/shared TypeScript contracts -> `npm run typecheck:node` -> passed.
- Source standards -> `npm run lint` -> passed.
- Independent Standards and Spec reviews -> no findings.

No platform lane was added because the change is main-process path/provenance policy exercised through filesystem-backed public contract tests and does not change platform-specific APIs. The remaining uncovered risk is manual end-to-end UI replay of the reported session flow; CI remains authoritative for its selected lanes.

## Review focus

- The ancestry trust boundary in producer scope validation.
- The fail-closed distinction between Notebook-owned and external Workspace sources.
- Ownership behavior when Run documents are corrupt or unreadable.