### PR TITLE
fix(compute): preserve concurrent Session Compute Host bindings

### DIFF
--- a/src/main/compute/session-catalog-hydration.integration.test.ts
+++ b/src/main/compute/session-catalog-hydration.integration.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ComputeHost } from '../../shared/compute'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import {
+  SessionPersistenceCoordinator,
+  type SessionFileIndex,
+  type SessionMutationRepository
+} from '../session-persistence/coordinator'
+import { AgentComputeService } from './agent-compute-service'
+import { EnabledComputeHostsRegistry } from './enabled-hosts-registry'
+import { createSessionCatalogHydration } from './session-catalog-hydration'
+import { SessionEnabledComputeHostsOwner } from './session-enabled-hosts-owner'
+
+const createSession = (id: string): PersistedChatSession => ({
+  id,
+  projectId: 'project-1',
+  title: id,
+  cwd: '/workspace',
+  status: 'idle',
+  messages: [],
+  filesRevision: 1,
+  enabledComputeHosts: ['ssh:alpha'],
+  selectedComputeHosts: ['ssh:alpha'],
+  createdAt: 1,
+  updatedAt: 1
+})
+
+const computeHost: ComputeHost = {
+  id: 'ssh:alpha',
+  providerId: 'ssh:alpha',
+  displayName: 'alpha',
+  shape: 'direct_ssh',
+  sshAlias: 'alpha',
+  sshOverrides: undefined,
+  scratchRoot: undefined,
+  scratchPinned: false,
+  concurrencyLimit: undefined,
+  probeResult: undefined,
+  detailsDoc: '',
+  detailsUpdatedAt: undefined,
+  detailsUpdatedBy: undefined,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+describe('production Session catalog hydration wiring', () => {
+  it('keeps the first Compute operation available to five Sessions created after an old complete snapshot', async () => {
+    const durableSessions = new Map<string, PersistedChatSession>()
+    const snapshotCaptured = Promise.withResolvers<void>()
+    const releaseSnapshot = Promise.withResolvers<void>()
+    let firstLoad = true
+    const repository: SessionMutationRepository = {
+      loadAllWithDiagnostics: vi.fn(async () => {
+        const sessions = [...durableSessions.values()].map((session) => structuredClone(session))
+        if (firstLoad) {
+          firstLoad = false
+          snapshotCaptured.resolve()
+          await releaseSnapshot.promise
+        }
+        return {
+          result: { sessions, manifest: { version: 1 as const } },
+          isComplete: true
+        }
+      }),
+      loadProjectWithDiagnostics: vi.fn(async () => ({ sessions: [], isComplete: true })),
+      loadCommittedProjectWithDiagnostics: vi.fn(async () => ({
+        sessions: [],
+        isComplete: true
+      })),
+      loadSessionWithDiagnostics: vi.fn(async (_projectId, sessionId) => {
+        const session = durableSessions.get(sessionId)
+        return session
+          ? { status: 'found' as const, session: structuredClone(session) }
+          : { status: 'missing' as const }
+      }),
+      assertSessionIdentityOwnership: vi.fn(async () => undefined),
+      saveSession: vi.fn(async (session) => {
+        durableSessions.set(session.id, structuredClone(session))
+        return session
+      }),
+      saveCommittedProjectSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+      deleteProjectSessions: vi.fn(async () => undefined),
+      getProjectSessionDeletionState: vi.fn(async () => 'live' as const),
+      markCommittedProjectSessionsPrepared: vi.fn(async () => undefined),
+      completeProjectSessionDeletion: vi.fn(async () => undefined),
+      listLegacyProjectSessionTombstones: vi.fn(async () => []),
+      saveManifest: vi.fn(async () => undefined)
+    }
+    const fileIndex: SessionFileIndex = {
+      syncSession: vi.fn(async () => []),
+      softDeleteSession: vi.fn(async () => 'delete-token'),
+      restoreSession: vi.fn(async () => undefined),
+      softDeleteProject: vi.fn(async () => 'delete-token'),
+      reconcileActiveSessions: vi.fn(async () => undefined),
+      markReconciliationIncomplete: vi.fn()
+    }
+    const coordinator = new SessionPersistenceCoordinator(repository, fileIndex)
+    const registry = new EnabledComputeHostsRegistry()
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry,
+      hostExists: async (providerId) => providerId === 'ssh:alpha',
+      listHostIds: async () => ['ssh:alpha'],
+      sessionAuthority: coordinator,
+      withDataRootWrite: (operation) => operation()
+    })
+    const hydration = createSessionCatalogHydration({
+      owner: () => owner,
+      projectRecovery: { recoverPendingDeletions: async () => undefined },
+      sessionLoader: coordinator
+    })
+    const compute = new AgentComputeService({ list: async () => [computeHost] } as never, registry)
+
+    const loading = hydration.loadAll()
+    await snapshotCaptured.promise
+    const creations = Array.from({ length: 5 }, (_, index) => {
+      const session = createSession(`session-${index + 1}`)
+      return owner.createSession(session, (candidate) => coordinator.saveSession(candidate))
+    })
+    releaseSnapshot.resolve()
+
+    await Promise.all([loading, ...creations])
+
+    const firstComputeOperations = await Promise.all(
+      [...durableSessions.keys()].map((sessionId) => compute.listPreferred(sessionId))
+    )
+    expect(firstComputeOperations).toEqual(
+      Array.from({ length: 5 }, () => [expect.objectContaining({ provider_id: 'ssh:alpha' })])
+    )
+    expect([...durableSessions.values()]).toHaveLength(5)
+  })
+})

--- a/src/main/compute/session-catalog-hydration.ts
+++ b/src/main/compute/session-catalog-hydration.ts
@@ -1,0 +1,48 @@
+import type { LoadAllSessionsResult } from '../../shared/session-persistence'
+import {
+  loadSessionsAfterProjectRecovery,
+  recoverProjectDeletionsForSessionRead,
+  type ProjectDeletionRecoveryBackend,
+  type ProjectDeletionRecoveryForSessionRead,
+  type SessionCatalogHydrator
+} from '../session-persistence/ipc'
+import type { SessionEnabledComputeHostsOwner } from './session-enabled-hosts-owner'
+
+type SessionCatalogLoader = Readonly<{
+  loadAll(): Promise<LoadAllSessionsResult>
+  loadAllReadOnly(): Promise<LoadAllSessionsResult>
+}>
+
+type SessionCatalogHydration = Readonly<{
+  loadAll(): Promise<LoadAllSessionsResult>
+  recoverProjectDeletions(): Promise<ProjectDeletionRecoveryForSessionRead>
+}>
+
+const createSessionCatalogHydration = (options: {
+  owner(): SessionEnabledComputeHostsOwner
+  projectRecovery: ProjectDeletionRecoveryBackend
+  sessionLoader: SessionCatalogLoader
+}): SessionCatalogHydration => {
+  const hydrateCatalog: SessionCatalogHydrator = (loadCatalog) =>
+    options.owner().hydrateFromSessionCatalog(loadCatalog)
+
+  return {
+    loadAll: () =>
+      loadSessionsAfterProjectRecovery(
+        options.projectRecovery,
+        options.sessionLoader,
+        undefined,
+        hydrateCatalog
+      ),
+    recoverProjectDeletions: () =>
+      recoverProjectDeletionsForSessionRead(
+        options.projectRecovery,
+        options.sessionLoader,
+        undefined,
+        hydrateCatalog
+      )
+  }
+}
+
+export { createSessionCatalogHydration }
+export type { SessionCatalogHydration, SessionCatalogLoader }

--- a/src/main/compute/session-enabled-hosts-owner.test.ts
+++ b/src/main/compute/session-enabled-hosts-owner.test.ts
@@ -27,6 +27,24 @@ const createPruneResult = (
   previousSelections: []
 })
 type PruneResult = ReturnType<typeof createPruneResult>
+const createCatalog = (
+  sessions: PersistedChatSession[],
+  isComplete: boolean
+): {
+  sessions: PersistedChatSession[]
+  diagnostics: {
+    isComplete: boolean
+    warnings: never[]
+    isProjectDeletionRecoveryComplete: true
+  }
+} => ({
+  sessions,
+  diagnostics: {
+    isComplete,
+    warnings: [],
+    isProjectDeletionRecoveryComplete: true
+  }
+})
 
 describe('SessionEnabledComputeHostsOwner', () => {
   it('projects only the enabled hosts committed by Session authority', async () => {
@@ -180,10 +198,48 @@ describe('SessionEnabledComputeHostsOwner', () => {
       withDataRootWrite: passthroughDataRootWrite
     })
 
-    await owner.reconcile([createSession({ enabledComputeHosts: ['ssh:cluster'] })], true)
+    await owner.hydrateFromSessionCatalog(async () =>
+      createCatalog([createSession({ enabledComputeHosts: ['ssh:cluster'] })], true)
+    )
 
     expect(owner.get('session-1')).toEqual(['ssh:cluster'])
     expect(owner.get('stale-session')).toEqual([])
+  })
+
+  it('keeps a concurrently created Session projected after complete catalog hydration', async () => {
+    const registry = new EnabledComputeHostsRegistry()
+    const catalogLoaded = Promise.withResolvers<void>()
+    const releaseCatalog = Promise.withResolvers<void>()
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry,
+      hostExists: async () => true,
+      listHostIds: async () => ['ssh:cluster'],
+      sessionAuthority: {
+        sessionProjectId: async () => undefined,
+        setSessionEnabledComputeHosts: async () => {
+          throw new Error('not expected')
+        },
+        pruneSessionEnabledComputeHosts: async () => createPruneResult()
+      },
+      withDataRootWrite: passthroughDataRootWrite
+    })
+
+    const hydration = owner.hydrateFromSessionCatalog(async () => {
+      const catalog = createCatalog([], true)
+      catalogLoaded.resolve()
+      await releaseCatalog.promise
+      return catalog
+    })
+    await catalogLoaded.promise
+    const creation = owner.createSession(
+      createSession({ enabledComputeHosts: ['ssh:cluster'] }),
+      async (session) => session
+    )
+    releaseCatalog.resolve()
+
+    await Promise.all([hydration, creation])
+
+    expect(owner.get('session-1')).toEqual(['ssh:cluster'])
   })
 
   it('durably prunes missing hosts before replacing a complete cache', async () => {
@@ -206,11 +262,13 @@ describe('SessionEnabledComputeHostsOwner', () => {
     })
 
     await expect(
-      owner.reconcile(
-        [createSession({ enabledComputeHosts: ['ssh:cluster', 'ssh:deleted'] })],
-        true
+      owner.hydrateFromSessionCatalog(async () =>
+        createCatalog(
+          [createSession({ enabledComputeHosts: ['ssh:cluster', 'ssh:deleted'] })],
+          true
+        )
       )
-    ).resolves.toEqual([repaired])
+    ).resolves.toMatchObject({ sessions: [repaired] })
 
     expect(pruneSessionEnabledComputeHosts).toHaveBeenCalledWith(['ssh:cluster'])
     expect(owner.get('session-1')).toEqual(['ssh:cluster'])
@@ -236,7 +294,9 @@ describe('SessionEnabledComputeHostsOwner', () => {
     })
 
     const sessions = [createSession({ enabledComputeHosts: ['ssh:cluster', 'ssh:deleted'] })]
-    await expect(owner.reconcile(sessions, false)).resolves.toEqual(sessions)
+    await expect(
+      owner.hydrateFromSessionCatalog(async () => createCatalog(sessions, false))
+    ).resolves.toMatchObject({ sessions })
 
     expect(pruneSessionEnabledComputeHosts).not.toHaveBeenCalled()
     expect(owner.get('session-1')).toEqual(['ssh:cluster'])
@@ -330,9 +390,8 @@ describe('SessionEnabledComputeHostsOwner', () => {
       withDataRootWrite: passthroughDataRootWrite
     })
 
-    const reconciling = owner.reconcile(
-      [createSession({ enabledComputeHosts: ['ssh:cluster'] })],
-      true
+    const reconciling = owner.hydrateFromSessionCatalog(async () =>
+      createCatalog([createSession({ enabledComputeHosts: ['ssh:cluster'] })], true)
     )
     await vi.waitFor(() => expect(listHostIds).toHaveBeenCalledOnce())
     const clearing = owner.clear(['session-1'])
@@ -425,7 +484,9 @@ describe('SessionEnabledComputeHostsOwner', () => {
       withDataRootWrite: passthroughDataRootWrite
     })
 
-    await expect(owner.reconcile(sessions, true)).resolves.toEqual(sessions)
+    await expect(
+      owner.hydrateFromSessionCatalog(async () => createCatalog(sessions, true))
+    ).resolves.toMatchObject({ sessions })
 
     expect(owner.get('cached-session')).toEqual(['ssh:cached'])
     expect(owner.get('session-1')).toEqual([])

--- a/src/main/compute/session-enabled-hosts-owner.ts
+++ b/src/main/compute/session-enabled-hosts-owner.ts
@@ -5,6 +5,10 @@ import {
   sessionComputeHostAccess,
   type SessionComputeHostAccessMutation
 } from './session-compute-host-access'
+import {
+  canReconcileSessionAbsences,
+  type SessionCatalog
+} from '../session-persistence/catalog-authority'
 
 type SessionEnabledComputeHostsAuthority = Readonly<{
   sessionProjectId(sessionId: string): Promise<string | undefined>
@@ -192,48 +196,58 @@ class SessionEnabledComputeHostsOwner {
     })
   }
 
-  reconcile(
+  hydrateFromSessionCatalog<Result extends SessionCatalog>(
+    loadCatalog: () => Promise<Result>
+  ): Promise<Result> {
+    return this.enqueueWrite(async () => {
+      const catalog = await loadCatalog()
+      return {
+        ...catalog,
+        sessions: await this.reconcileNow(catalog.sessions, canReconcileSessionAbsences(catalog))
+      }
+    })
+  }
+
+  private async reconcileNow(
     sessions: readonly PersistedChatSession[],
     isComplete: boolean
   ): Promise<PersistedChatSession[]> {
-    return this.enqueueWrite(async () => {
-      let validProviderIds: readonly string[]
-      try {
-        validProviderIds = await this.options.listHostIds()
-      } catch {
-        return [...sessions]
-      }
-      const validProviderIdSet = new Set(validProviderIds)
-      const hasMissingHost = sessions.some((session) => {
-        const access = sessionComputeHostAccess(session)
-        return [...access.enabledProviderIds, ...access.selectedProviderIds].some(
-          (providerId) => !validProviderIdSet.has(providerId)
-        )
-      })
-      const authoritativeSessions =
-        isComplete && hasMissingHost
-          ? (await this.options.sessionAuthority.pruneSessionEnabledComputeHosts(validProviderIds))
-              .sessions
-          : sessions
-      this.options.registry.reconcileAccess(
-        authoritativeSessions.map((session) => {
-          const access = sessionComputeHostAccess(session)
-          return [
-            session.id,
-            {
-              enabledProviderIds: access.enabledProviderIds.filter((providerId) =>
-                validProviderIdSet.has(providerId)
-              ),
-              selectedProviderIds: access.selectedProviderIds.filter((providerId) =>
-                validProviderIdSet.has(providerId)
-              )
-            }
-          ] as const
-        }),
-        isComplete
+    let validProviderIds: readonly string[]
+    try {
+      validProviderIds = await this.options.listHostIds()
+    } catch {
+      return [...sessions]
+    }
+    const validProviderIdSet = new Set(validProviderIds)
+    const hasMissingHost = sessions.some((session) => {
+      const access = sessionComputeHostAccess(session)
+      return [...access.enabledProviderIds, ...access.selectedProviderIds].some(
+        (providerId) => !validProviderIdSet.has(providerId)
       )
-      return [...authoritativeSessions]
     })
+    const authoritativeSessions =
+      isComplete && hasMissingHost
+        ? (await this.options.sessionAuthority.pruneSessionEnabledComputeHosts(validProviderIds))
+            .sessions
+        : sessions
+    this.options.registry.reconcileAccess(
+      authoritativeSessions.map((session) => {
+        const access = sessionComputeHostAccess(session)
+        return [
+          session.id,
+          {
+            enabledProviderIds: access.enabledProviderIds.filter((providerId) =>
+              validProviderIdSet.has(providerId)
+            ),
+            selectedProviderIds: access.selectedProviderIds.filter((providerId) =>
+              validProviderIdSet.has(providerId)
+            )
+          }
+        ] as const
+      }),
+      isComplete
+    )
+    return [...authoritativeSessions]
   }
 
   reconcileSession(session: PersistedChatSession): Promise<PersistedChatSession> {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -68,6 +68,7 @@ import { ArtifactRunRegistry } from './artifacts/run-registry'
 import { createComputeIpcModule } from './compute/ipc'
 import type { ComputeJobOwnerLiveness } from './compute/job-deletion-owner'
 import { AgentComputeService } from './compute/agent-compute-service'
+import { createSessionCatalogHydration } from './compute/session-catalog-hydration'
 import { SessionEnabledComputeHostsOwner } from './compute/session-enabled-hosts-owner'
 import { createComputeJobRuntime } from './compute/job-runtime'
 import { waitForInitialConnectorRefresh } from './connector-reload'
@@ -173,7 +174,6 @@ import {
   createDefaultSessionRepository,
   createSessionPersistenceHandlersWithAttributionAuthority,
   loadSessionMetadataAfterProjectRecovery,
-  loadSessionsAfterProjectRecovery,
   recoverProjectDeletionsForSessionRead,
   registerSessionPersistenceIpcHandlers
 } from './session-persistence/ipc'
@@ -888,22 +888,17 @@ const createApplicationModules = async (
   // flushed to disk on the session's first save so an approved switch survives an app restart before
   // the next message. Shared by persistSessionSpecialist (stash) and saveSession (flush).
   const pendingSpecialistBindings = new PendingSessionSpecialistBindings()
-  const loadAllSessions = async (): Promise<LoadAllSessionsResult> => {
-    const result = await loadSessionsAfterProjectRecovery(
-      projectDeletionCoordinator,
-      sessionPersistenceCoordinator
-    )
-    if (!sessionEnabledComputeHostsOwnerRef.current) {
-      throw new Error('Session enabled Compute Host ownership is not initialized.')
-    }
-    return {
-      ...result,
-      sessions: await sessionEnabledComputeHostsOwnerRef.current.reconcile(
-        result.sessions,
-        canReconcileSessionAbsences(result)
-      )
-    }
-  }
+  const sessionCatalogHydration = createSessionCatalogHydration({
+    owner: () => {
+      if (!sessionEnabledComputeHostsOwnerRef.current) {
+        throw new Error('Session enabled Compute Host ownership is not initialized.')
+      }
+      return sessionEnabledComputeHostsOwnerRef.current
+    },
+    projectRecovery: projectDeletionCoordinator,
+    sessionLoader: sessionPersistenceCoordinator
+  })
+  const loadAllSessions = (): Promise<LoadAllSessionsResult> => sessionCatalogHydration.loadAll()
   const ensureSessionProjection = async (): Promise<{
     result?: LoadAllSessionsResult
     sessions: SessionSummary[]
@@ -911,29 +906,9 @@ const createApplicationModules = async (
     // Reconcile a JSON write from a committed Project tombstone before deletion recovery removes
     // that temporary authority. Its SQLite facts remain part of retained Project history.
     await sessionRepository.reconcilePendingSessionProjection()
-    const recovery = await recoverProjectDeletionsForSessionRead(
-      projectDeletionCoordinator,
-      sessionPersistenceCoordinator
-    )
-    let readOnlyResult: Promise<LoadAllSessionsResult> | undefined
-    const loadReadOnlyResult = (): Promise<LoadAllSessionsResult> => {
-      readOnlyResult ??= (async () => {
-        if (recovery.isComplete) throw new Error('Read-only Session recovery is unavailable.')
-        if (!sessionEnabledComputeHostsOwnerRef.current) {
-          throw new Error('Session enabled Compute Host ownership is not initialized.')
-        }
-        return {
-          ...recovery.result,
-          sessions: await sessionEnabledComputeHostsOwnerRef.current.reconcile(
-            recovery.result.sessions,
-            false
-          )
-        }
-      })()
-      return readOnlyResult
-    }
+    const recovery = await sessionCatalogHydration.recoverProjectDeletions()
     if (!recovery.isComplete) {
-      const result = await loadReadOnlyResult()
+      const result = recovery.result
       const sessions = await sessionRepository.summarizeReadOnlyAuthority(result)
       await sessionPersistenceCoordinator.replaceSessionMetadata(sessions, false)
       return { result, sessions }

--- a/src/main/session-persistence/catalog-authority.ts
+++ b/src/main/session-persistence/catalog-authority.ts
@@ -1,4 +1,9 @@
-import type { SessionLoadWarning } from '../../shared/session-persistence'
+import type {
+  LoadAllSessionsResult,
+  PersistedChatSession,
+  SessionLoadDiagnostics,
+  SessionLoadWarning
+} from '../../shared/session-persistence'
 
 type SessionCatalogDiagnostics = {
   isComplete: boolean
@@ -11,4 +16,31 @@ const isSessionCatalogAuthoritative = (
   diagnostics?.isComplete === true &&
   !diagnostics.warnings?.some((warning) => warning.kind === 'corrupt')
 
-export { isSessionCatalogAuthoritative }
+type SessionCatalog = Readonly<{
+  sessions: PersistedChatSession[]
+  diagnostics?: SessionLoadDiagnostics
+}>
+
+const canReconcileSessionAbsences = <Catalog extends SessionCatalog>(catalog: Catalog): boolean =>
+  catalog.diagnostics?.isProjectDeletionRecoveryComplete === true &&
+  isSessionCatalogAuthoritative(catalog.diagnostics)
+
+const withProjectDeletionRecoveryStatus = (
+  result: LoadAllSessionsResult,
+  isProjectDeletionRecoveryComplete: boolean
+): LoadAllSessionsResult => ({
+  ...result,
+  diagnostics: {
+    isComplete: result.diagnostics?.isComplete ?? true,
+    warnings: result.diagnostics?.warnings ?? [],
+    ...result.diagnostics,
+    isProjectDeletionRecoveryComplete
+  }
+})
+
+export {
+  canReconcileSessionAbsences,
+  isSessionCatalogAuthoritative,
+  withProjectDeletionRecoveryStatus
+}
+export type { SessionCatalog }

--- a/src/main/session-persistence/ipc.ts
+++ b/src/main/session-persistence/ipc.ts
@@ -28,7 +28,7 @@ import { getProjectDbClient } from '../projects/prisma-client'
 import { withDataRootWrite } from '../storage/migration-state'
 import type { SessionMetadataSnapshot } from './coordinator'
 import { MainMessageAttributionAuthority } from './message-attribution-authority'
-import { isSessionCatalogAuthoritative } from './catalog-authority'
+import { canReconcileSessionAbsences, withProjectDeletionRecoveryStatus } from './catalog-authority'
 import { sanitizeRendererSaveSessionOptions } from './renderer-save-options'
 
 type SessionPersistenceBackend = {
@@ -78,6 +78,12 @@ type SessionStartupLoader = {
   loadAllReadOnly: () => Promise<LoadAllSessionsResult>
 }
 
+type SessionCatalogHydrator = (
+  loadCatalog: () => Promise<LoadAllSessionsResult>
+) => Promise<LoadAllSessionsResult>
+
+const loadCatalogDirectly: SessionCatalogHydrator = (loadCatalog) => loadCatalog()
+
 type SessionMetadataLoader = {
   sessionMetadataSnapshot: () => Promise<SessionMetadataSnapshot>
 }
@@ -85,27 +91,11 @@ type SessionMetadataLoader = {
 type ProjectDeletionRecoveryForSessionRead =
   { isComplete: true } | { isComplete: false; result: LoadAllSessionsResult }
 
-const withProjectDeletionRecoveryStatus = (
-  result: LoadAllSessionsResult,
-  isProjectDeletionRecoveryComplete: boolean
-): LoadAllSessionsResult => ({
-  ...result,
-  diagnostics: {
-    isComplete: result.diagnostics?.isComplete ?? true,
-    warnings: result.diagnostics?.warnings ?? [],
-    ...result.diagnostics,
-    isProjectDeletionRecoveryComplete
-  }
-})
-
-const canReconcileSessionAbsences = (result: LoadAllSessionsResult): boolean =>
-  result.diagnostics?.isProjectDeletionRecoveryComplete === true &&
-  isSessionCatalogAuthoritative(result.diagnostics)
-
 const recoverProjectDeletionsForSessionRead = async (
   projectRecovery: ProjectDeletionRecoveryBackend,
   sessionLoader: Pick<SessionStartupLoader, 'loadAllReadOnly'>,
-  log: Pick<Logger, 'warn'> = createLogger('session-persistence')
+  log: Pick<Logger, 'warn'> = createLogger('session-persistence'),
+  hydrateCatalog: SessionCatalogHydrator = loadCatalogDirectly
 ): Promise<ProjectDeletionRecoveryForSessionRead> => {
   try {
     await projectRecovery.recoverPendingDeletions()
@@ -123,7 +113,9 @@ const recoverProjectDeletionsForSessionRead = async (
     }
     return {
       isComplete: false,
-      result: withProjectDeletionRecoveryStatus(await sessionLoader.loadAllReadOnly(), false)
+      result: await hydrateCatalog(async () =>
+        withProjectDeletionRecoveryStatus(await sessionLoader.loadAllReadOnly(), false)
+      )
     }
   }
 }
@@ -144,12 +136,20 @@ const loadSessionMetadataAfterProjectRecovery = async (
 const loadSessionsAfterProjectRecovery = async (
   projectRecovery: ProjectDeletionRecoveryBackend,
   sessionLoader: SessionStartupLoader,
-  log: Pick<Logger, 'warn'> = createLogger('session-persistence')
+  log: Pick<Logger, 'warn'> = createLogger('session-persistence'),
+  hydrateCatalog: SessionCatalogHydrator = loadCatalogDirectly
 ): Promise<LoadAllSessionsResult> => {
-  const recovery = await recoverProjectDeletionsForSessionRead(projectRecovery, sessionLoader, log)
+  const recovery = await recoverProjectDeletionsForSessionRead(
+    projectRecovery,
+    sessionLoader,
+    log,
+    hydrateCatalog
+  )
   if (!recovery.isComplete) return recovery.result
 
-  return withProjectDeletionRecoveryStatus(await sessionLoader.loadAll(), true)
+  return hydrateCatalog(async () =>
+    withProjectDeletionRecoveryStatus(await sessionLoader.loadAll(), true)
+  )
 }
 
 // Adapts the coordinator into small handlers that are easy to unit test.
@@ -318,6 +318,8 @@ export {
 }
 export type {
   ProjectDeletionRecoveryForSessionRead,
+  ProjectDeletionRecoveryBackend,
+  SessionCatalogHydrator,
   SessionPersistenceBackend,
   SessionPersistenceHandlers
 }

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -4,7 +4,10 @@ import type { AcpRuntimeEvent } from '../../shared/acp'
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import type { ApplicationCommandByNameDispatcher } from '../application-command-composition'
 import { createTaskCallerContext, type CallerContext } from '../caller-context'
-import { EnabledComputeHostsRegistry } from '../compute/enabled-hosts-registry'
+import {
+  attachEnabledComputeHosts,
+  EnabledComputeHostsRegistry
+} from '../compute/enabled-hosts-registry'
 import {
   sessionComputeHostAccess,
   transitionSessionComputeHostAccess,
@@ -221,6 +224,112 @@ describe('HeadlessTaskApi adapter', () => {
     expect(registry.getSelected('session-created')).toEqual(['ssh:alpha'])
     await api.dispose()
   }, 1_000)
+
+  it('keeps the selected Compute Host visible to five Sessions initialized concurrently', async () => {
+    const concurrency = 5
+    const durableSessions = new Map<string, PersistedChatSession>()
+    const registry = new EnabledComputeHostsRegistry()
+    const ownerRef: { current?: SessionEnabledComputeHostsOwner } = {}
+    const creationIndexBySessionId = new Map<string, number>()
+
+    const invoke = vi.fn(
+      async (channel: string, _callerContext: CallerContext, args: unknown[]) => {
+        if (channel === 'projects:list') return [project]
+        if (channel === 'sessions:load-all') {
+          return ownerRef.current!.hydrateFromSessionCatalog(async () => ({
+            sessions: [...durableSessions.values()].map((session) => structuredClone(session)),
+            manifest: { version: 1 as const },
+            diagnostics: {
+              isComplete: true,
+              warnings: [],
+              isProjectDeletionRecoveryComplete: true
+            }
+          }))
+        }
+        if (channel === 'sessions:save-session') {
+          const session = args[0] as PersistedChatSession
+          const sessionIndex = creationIndexBySessionId.get(session.id)
+          if (sessionIndex === undefined) throw new Error(`Unknown Session: ${session.id}`)
+          const committed = await ownerRef.current!.createSession(session, async (candidate) => {
+            durableSessions.set(candidate.id, structuredClone(candidate))
+            return candidate
+          })
+          return committed
+        }
+        throw new Error(`Unexpected Task command: ${channel}`)
+      }
+    )
+    const owner = new SessionEnabledComputeHostsOwner({
+      registry,
+      hostExists: async (providerId) => providerId === 'ssh:alpha',
+      listHostIds: async () => ['ssh:alpha'],
+      sessionAuthority: {
+        sessionProjectId: async (sessionId) => durableSessions.get(sessionId)?.projectId,
+        setSessionEnabledComputeHosts: async () => {
+          throw new Error('Unexpected existing Session update.')
+        },
+        mutateSessionComputeHostAccess: async () => {
+          throw new Error('Unexpected existing Session mutation.')
+        },
+        pruneSessionEnabledComputeHosts: async () => ({ sessions: [], previousSelections: [] })
+      },
+      withDataRootWrite: (operation) => operation()
+    })
+    ownerRef.current = owner
+    const compute = attachEnabledComputeHosts({}, registry)
+    const allPromptsEntered = Promise.withResolvers<void>()
+    let promptCount = 0
+    const visibleHosts = new Map<string, string[]>()
+    let nextSessionId = 0
+    const agent = createAgent({
+      createSession: vi.fn(async () => {
+        const creationIndex = nextSessionId++
+        const sessionId = `session-${creationIndex + 1}`
+        creationIndexBySessionId.set(sessionId, creationIndex)
+        return { sessionId, cwd: '/workspace' }
+      }),
+      prompt: vi.fn(async ({ sessionId }) => {
+        promptCount += 1
+        if (promptCount === concurrency) allPromptsEntered.resolve()
+        await allPromptsEntered.promise
+        visibleHosts.set(sessionId, compute.getSelectedComputeHosts(sessionId))
+      })
+    })
+    let nextId = 0
+    const api = new HeadlessTaskApi(
+      { commands: commandsFrom(invoke), agent, computePreferences: owner },
+      { createId: () => `task-id-${++nextId}`, now: () => 10 }
+    )
+
+    const started = await Promise.all(
+      Array.from({ length: concurrency }, (_, index) =>
+        api.startRun({
+          project: project.id,
+          prompt: `Research stream ${index + 1}.`,
+          computeHostIds: ['ssh:alpha']
+        })
+      )
+    )
+    await Promise.all(started.map(({ id }) => api.waitForRun(id)))
+    await api.dispose()
+
+    expect({
+      durable: started.map(({ sessionId }) => {
+        const persisted = durableSessions.get(sessionId)
+        return {
+          enabledComputeHosts: persisted?.enabledComputeHosts,
+          selectedComputeHosts: persisted?.selectedComputeHosts
+        }
+      }),
+      runtime: started.map(({ sessionId }) => visibleHosts.get(sessionId))
+    }).toEqual({
+      durable: Array.from({ length: concurrency }, () => ({
+        enabledComputeHosts: ['ssh:alpha'],
+        selectedComputeHosts: ['ssh:alpha']
+      })),
+      runtime: Array.from({ length: concurrency }, () => ['ssh:alpha'])
+    })
+  })
 
   it('dispatches façade operations through the narrow Task command view', async () => {
     const commandInvoke = vi.fn(async () => [


### PR DESCRIPTION
## Problem

When multiple CLI runs initialize Sessions concurrently, a complete Session catalog hydration can load an older authority snapshot and apply it after a newer Session has completed its durable commit and runtime projection. That stale projection removes the new in-memory Compute Host binding even though `enabledComputeHosts` and `selectedComputeHosts` remain correct on disk, leaving the running Session unable to use its selected host.

## Proposed change

- Perform the Session catalog authority load and Compute Host runtime projection atomically within one owner queue operation, closing the TOCTOU window in which a stale snapshot could overwrite a newer binding.
- Route complete catalog loading and Project recovery/degraded hydration through the production hydration module while preserving complete, partial, and corrupt authority semantics.
- Add a five-way concurrent Task regression test and a deterministic concurrency contract test through the real persistence scheduler, Owner, Registry, and `AgentComputeService`.

## Scope and non-goals

- Only the short Session hydration and projection operation is serialized; complete agent execution remains concurrent.
- This PR does not fix the separate stale completion-save revision conflict tracked in #1662.
- It does not introduce fixed launch delays or make tests depend on a real SSH endpoint.
- The real-host validation was deliberately lightweight and did not write files, install software, or start background work.

## Acceptance criteria and validation

- Deterministic regression coverage: the five-way `HeadlessTaskApi.startRun()` test and production hydration integration test pass.
- Real Compute validation: five Sessions were started simultaneously with explicit `--approval-profile full`, `--delegation deny`, and `--no-auto-review`.
- Host visibility and selection: 5/5 Sessions saw the target host as selected and connected; durable Enabled/Selected host data was correct in all five.
- Remote execution: 5/5 lightweight commands exited 0 and emitted START, END, and OK markers. The five real remote executions overlapped, including a 515 ms common overlap window.
- Failure checks: no Compute Host unavailable result, empty host list, approval prompt, or timeout occurred.
- CLI final status: all five CLIs exited 1 only after successful remote work because of the independent `Session revision conflict: expected 1, actual 8-12` tracked in #1662. A single warm-up run reproduced that separate issue with actual revision 16. This does not invalidate the #1657 Compute Host binding result.
- Standards review: PASS.
- Spec review: PASS.
- `npm run typecheck`: PASS.
- `npm run lint`: PASS with 0 errors and 2 unrelated existing warnings.
- `npm test`: PASS with 1,185 files passed, 15 skipped; 18,884 tests passed, 227 skipped.

## Review focus

- Owner queue to persistence scheduler lock ordering.
- Complete, partial, and corrupt authority classification.
- The first Compute admission after the new Session durable commit.
- Prompt concurrency after initialization completes.
- The branch is based on `393939a8`. `origin/main` has advanced since that base; GitHub currently reports the PR mergeable with no conflicts, so the branch was not rebased solely for recency.

Closes #1657

Follow-up: #1662