### PR TITLE
fix(connectors): make gate errors actionable

### DIFF
--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -40,7 +40,9 @@ describe('ConnectorService', () => {
       getConnectors: () => ({ enabledIds: ['chemistry'], autoAllowIds: [] }),
       resolveApiKey: () => undefined
     })
-    await expect(svc.call('chemistry', 'nope', {}, internal)).rejects.toThrow(/unknown tool/)
+    await expect(svc.call('chemistry', 'nope', {}, internal)).rejects.toThrow(
+      'unknown tool: chemistry/nope. Do not retry with guessed method names. Use only methods documented by a loaded mcp-* Skill, then retry with a documented method.'
+    )
   })
   it('routes an enabled call through the engine with resolved credentials', async () => {
     const fetchImpl = vi
@@ -1025,7 +1027,9 @@ describe('ConnectorService', () => {
       guard.commit(replacement)
       approve?.('global')
 
-      await expect(pendingCall).rejects.toThrow('connector_configuration_changed')
+      await expect(pendingCall).rejects.toThrow(
+        'connector call rejected: connector_configuration_changed. The Connector configuration changed before the external tool was called. Retry the exact same call once.'
+      )
       expect(listTools).not.toHaveBeenCalled()
       expect(remember).not.toHaveBeenCalled()
       expect(call).not.toHaveBeenCalled()
@@ -1241,7 +1245,7 @@ describe('ConnectorService', () => {
       })
 
       await expect(svc.call('oauth-server', 'lookup', {}, internal)).rejects.toThrow(
-        'connector_unauthenticated'
+        'connector call rejected: connector_unauthenticated. Connector authentication is required. Do not retry until the user signs in from Settings > Connectors, then retry the same call.'
       )
       expect(mcpClientManager.listTools).not.toHaveBeenCalled()
       expect(call).not.toHaveBeenCalled()
@@ -1604,7 +1608,9 @@ describe('ConnectorService specialist capability gate', () => {
           specialistId: current.id
         }
       )
-    ).rejects.toThrow('specialist_capability_denied')
+    ).rejects.toThrow(
+      "connector call rejected: specialist_capability_denied. The current Specialist is not allowed to use this Connector. Do not retry from this Specialist. Use an allowed Connector, or ask the user to update this Specialist's Connector access in Settings > Specialists, then retry the same call."
+    )
 
     current = specialist({
       capabilityMode: 'selected',
@@ -1706,7 +1712,9 @@ describe('ConnectorService specialist capability gate', () => {
     })
     await expect(
       svc.call('molecule', 'preview_molecule', { token: 'SECRET_ARGS' }, { origin: 'agent' })
-    ).rejects.toThrow('missing_session')
+    ).rejects.toThrow(
+      'connector call rejected: missing_session. The Connector call could not be associated with the current Session. Do not retry this call. Ask the user to start a new Session before retrying.'
+    )
     await expect(
       svc.call(
         'not-installed',
@@ -1749,5 +1757,36 @@ describe('ConnectorService specialist capability gate', () => {
       svc.call('molecule', 'preview_molecule', {}, { origin: 'internal' })
     ).resolves.toEqual({ ok: true })
     await expect(svc.call('molecule', 'preview_molecule', {})).rejects.toThrow('missing_session')
+  })
+
+  it('gives actionable guidance when the Specialist or Connector runtime is unavailable', async () => {
+    const customMcpServers = [
+      {
+        id: 'server-1',
+        name: 'custom-server',
+        displayName: 'Custom server',
+        transport: 'stdio' as const,
+        command: 'custom-server',
+        enabled: true
+      }
+    ]
+    const svc = new ConnectorService({
+      getConnectors: () => ({ enabledIds: [], autoAllowIds: [], customMcpServers }),
+      resolveApiKey: () => undefined
+    })
+
+    await expect(
+      svc.call(
+        'custom-server',
+        'lookup',
+        {},
+        { origin: 'agent', sessionId: 'session-1', specialistId: 'missing-specialist' }
+      )
+    ).rejects.toThrow(
+      'connector call rejected: specialist_unavailable. The current Specialist is unavailable. Do not retry from this Specialist. Ask the user to switch to Main Agent or an available Specialist, then retry the same call.'
+    )
+    await expect(svc.call('custom-server', 'lookup', {}, internal)).rejects.toThrow(
+      'connector call rejected: connector_runtime_unavailable. The Connector runtime is unavailable. Wait briefly and retry the same call once. If it fails again, ask the user to restart Open Science before retrying.'
+    )
   })
 })

--- a/src/main/connectors/service.ts
+++ b/src/main/connectors/service.ts
@@ -150,13 +150,42 @@ const disabledConnectorMessage = (connector: string): string =>
   'Do not retry with guessed Connector names. ' +
   'Ask the user to enable it in Settings > Connectors, then retry the same call.'
 
+const unknownConnectorToolMessage = (connector: string, method: string): string =>
+  `unknown tool: ${connector}/${method}. ` +
+  'Do not retry with guessed method names. ' +
+  'Use only methods documented by a loaded mcp-* Skill, then retry with a documented method.'
+
+const connectorGateGuidance: Readonly<Record<string, string>> = {
+  missing_session:
+    'The Connector call could not be associated with the current Session. Do not retry this call. Ask the user to start a new Session before retrying.',
+  specialist_unavailable:
+    'The current Specialist is unavailable. Do not retry from this Specialist. Ask the user to switch to Main Agent or an available Specialist, then retry the same call.',
+  specialist_capability_denied:
+    "The current Specialist is not allowed to use this Connector. Do not retry from this Specialist. Use an allowed Connector, or ask the user to update this Specialist's Connector access in Settings > Specialists, then retry the same call.",
+  connector_unavailable:
+    'The Connector is unavailable. Do not retry with guessed Connector names or methods. Use only Connector names and methods documented by a loaded mcp-* Skill. Wait briefly and retry the same documented call once. If it remains unavailable, ask the user to check the Connector in Settings > Connectors.',
+  connector_disabled:
+    'The Connector is disabled. Do not retry until the user enables it in Settings > Connectors, then retry the same call.',
+  connector_unauthenticated:
+    'Connector authentication is required. Do not retry until the user signs in from Settings > Connectors, then retry the same call.',
+  connector_runtime_unavailable:
+    'The Connector runtime is unavailable. Wait briefly and retry the same call once. If it fails again, ask the user to restart Open Science before retrying.',
+  connector_configuration_changed:
+    'The Connector configuration changed before the external tool was called. Retry the exact same call once.'
+}
+
+const connectorGateMessage = (category: string): string => {
+  const guidance = connectorGateGuidance[category]
+  return `connector call rejected: ${category}${guidance ? `. ${guidance}` : ''}`
+}
+
 // Deliberately contains only a stable category. In particular it must not interpolate connector
 // arguments, custom-server headers, credentials, or a Specialist's system prompt into an error that
 // may be rendered back to an agent.
 class ConnectorGateError extends Error {
   constructor(
     readonly category: string,
-    message = `connector call rejected: ${category}`
+    message = connectorGateMessage(category)
   ) {
     super(message)
     this.name = 'ConnectorGateError'
@@ -306,7 +335,10 @@ export class ConnectorService {
     signal?: AbortSignal
   ): Promise<unknown> {
     if (!descriptor)
-      throw new ConnectorGateError('connector_unavailable', `unknown tool: ${connector}/${method}`)
+      throw new ConnectorGateError(
+        'connector_unavailable',
+        unknownConnectorToolMessage(connector, method)
+      )
 
     const authorizedConnectors = access.bypassMainPolicy
       ? undefined
@@ -402,7 +434,7 @@ export class ConnectorService {
     if (!tools.some((tool) => tool.name === method)) {
       throw new ConnectorGateError(
         'connector_unavailable',
-        `unknown tool: ${authorization.custom.name}/${method}`
+        unknownConnectorToolMessage(authorization.custom.name, method)
       )
     }
     authorization = await this.authorizeCustomForCurrentPolicy(

--- a/src/main/notebook/host-mcp.integration.test.ts
+++ b/src/main/notebook/host-mcp.integration.test.ts
@@ -199,4 +199,57 @@ gate('repl kernel host.mcp', () => {
     expect(result.traceback).toContain('mcp-* Skill')
     expect(result.traceback).toContain('Settings > Connectors')
   })
+
+  it('tells the agent to wait for sign-in when a Connector requires authentication', async () => {
+    const connectorService = new ConnectorService({
+      getConnectors: () => ({
+        enabledIds: [],
+        autoAllowIds: [],
+        customMcpServers: [
+          {
+            id: 'oauth-server-id',
+            name: 'oauth-server',
+            displayName: 'OAuth server',
+            transport: 'streamable_http',
+            url: 'https://mcp.example.test',
+            oauth: {},
+            enabled: true
+          }
+        ]
+      }),
+      resolveApiKey: () => undefined
+    })
+    const rpcServer = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      connectorService
+    })
+    const connection = await rpcServer.issueControlConnection(
+      'session-42',
+      'project-1',
+      'root-frame-session-42'
+    )
+    const exec = makeExecutor()
+
+    try {
+      const result = await exec.execute(
+        baseRequest({
+          code: "await host.mcp('oauth-server','lookup',{})",
+          mcpRpcEndpoint: connection.endpoint,
+          mcpRpcSocketPath: connection.socketPath,
+          mcpRpcToken: connection.token,
+          sessionId: 'session-42',
+          projectId: 'project-1'
+        })
+      )
+
+      expect(result.status).toBe('failed')
+      expect(result.traceback).toContain('connector_unauthenticated')
+      expect(result.traceback).toContain('Do not retry until the user signs in')
+      expect(result.traceback).toContain('Settings > Connectors')
+      expect(result.traceback).toContain('retry the same call')
+    } finally {
+      await exec.shutdown()
+      connection.release()
+      await rpcServer.close()
+    }
+  })
 })


### PR DESCRIPTION
## Problem

Connector gate failures are delivered to ACP agents through `repl_execute` as Notebook tracebacks. PR #1655 made named unavailable and disabled Connector errors actionable, but the remaining stable gate categories still surfaced as opaque `connector call rejected: <category>` text. Unknown methods also lacked explicit no-guessing guidance.

## Proposed change

- Add safe retry or user-action guidance for every existing `ConnectorGateError` category.
- Preserve each stable category in the message so existing diagnostics and substring consumers continue to work.
- Tell agents not to guess unknown Connector methods and to use only methods documented by a loaded `mcp-*` Skill.
- Add a real REPL integration test proving authentication guidance survives `ConnectorService -> local RPC -> host.mcp -> Notebook traceback` and reaches the ACP agent result.

## Scope and non-goals

- No repository-wide error parser or new error framework.
- No new status, enum value, response field, dependency, or persistence/schema change.
- No historical-data migration or compatibility behavior change.
- Custom MCP transport/tool diagnostics remain hidden; URLs, headers, arguments, credentials, and server-provided errors are not added to agent-facing text.
- Provider-native tool errors and other agent error surfaces are out of scope.

## Acceptance criteria and validation

The following checks ran after the last material edit and after fast-forwarding to the latest `origin/main`:

- Connector gate behavior and safe content -> `npx vitest run src/main/connectors/service.test.ts` as part of the final focused run -> 51 passed.
- Connector local-RPC contract -> `npx vitest run src/main/notebook/local-rpc-server.mcpcall.test.ts` as part of the final focused run -> 34 passed.
- Real REPL/agent-facing traceback delivery -> `RUN_KERNEL=1 npx vitest run src/main/notebook/host-mcp.integration.test.ts` as part of the final focused run -> 5 passed.
- Combined final focused run -> 3 files, 90 tests passed.
- Main-process types -> `npm run typecheck:node` -> passed.
- Changed-file lint -> `npx eslint src/main/connectors/service.ts src/main/connectors/service.test.ts src/main/notebook/host-mcp.integration.test.ts` -> passed.
- Formatting/whitespace -> Prettier check and `git diff --check` -> passed.

The full local `npm test` suite was intentionally not run. PR CI remains authoritative for complete portable and platform coverage.

Uncovered local risk: no live Claude Code, OpenCode, Codex Responses, or Codex Bridge provider process was launched. All four use the same app-owned stdio MCP/Notebook result path; the service, local-RPC contract, and real shipped REPL loop are covered here.

## Review focus

- Are the retry boundaries conservative enough, especially one retry for transient unavailable/runtime/configuration changes?
- Does every message give the agent a concrete next action without exposing custom MCP diagnostics?
- Does retaining the category prefix provide sufficient diagnostic continuity while improving model behavior?
