### PR TITLE
fix(provider-bridge): log loopback listener lifecycle

### DIFF
--- a/src/main/settings/anthropic-provider-bridge.ts
+++ b/src/main/settings/anthropic-provider-bridge.ts
@@ -101,6 +101,7 @@ export class AnthropicProviderBridge {
     if (!initial) throw new Error('The initial Anthropic bridge target is not registered.')
     this.target = initial
     this.host = new ProviderLoopbackHttpHost({
+      diagnosticName: 'anthropic',
       credentialMode: 'bearer-or-api-key',
       createConnection: (origin, token) => Object.freeze({ baseUrl: origin, token }),
       onUnauthorized: (response) =>

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -374,6 +374,7 @@ export class NativeResponsesCompatibilityProxy {
     private readonly options: NativeResponsesCompatibilityOptions = {}
   ) {
     this.host = new ProviderLoopbackHttpHost({
+      diagnosticName: 'native-responses-compatibility',
       credentialMode: 'bearer',
       createConnection: (origin, token) => ({
         baseUrl: origin + '/v1',

--- a/src/main/settings/openai-provider-bridge.ts
+++ b/src/main/settings/openai-provider-bridge.ts
@@ -106,6 +106,7 @@ export class OpenAiProviderBridge {
     this.target = initial
     this.wire = initial.wire
     this.host = new ProviderLoopbackHttpHost({
+      diagnosticName: 'openai',
       credentialMode: 'bearer-or-api-key',
       createConnection: (origin, token) => Object.freeze({ baseUrl: origin, token }),
       onUnauthorized: (response) =>

--- a/src/main/settings/provider-loopback-http-host.test.ts
+++ b/src/main/settings/provider-loopback-http-host.test.ts
@@ -2,14 +2,18 @@ import { connect } from 'node:net'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import type { Logger } from '../logger'
 import { ProviderLoopbackHttpHost, writeProviderLoopbackJson } from './provider-loopback-http-host'
 
 type Connection = Readonly<{ baseUrl: string; token: string }>
 
 const jsonHost = (
-  credentialMode: 'bearer' | 'bearer-or-api-key' = 'bearer'
+  credentialMode: 'bearer' | 'bearer-or-api-key' = 'bearer',
+  diagnostics: Pick<Logger, 'info' | 'error'> = { info: vi.fn(), error: vi.fn() }
 ): ProviderLoopbackHttpHost<Connection> =>
   new ProviderLoopbackHttpHost<Connection>({
+    diagnosticName: 'test-provider',
+    diagnostics,
     credentialMode,
     createConnection: (origin, token) => Object.freeze({ baseUrl: origin, token }),
     onUnauthorized: (response) =>
@@ -68,6 +72,31 @@ describe('ProviderLoopbackHttpHost', () => {
 
     const secondConnection = await host.start()
     expect(secondConnection.token).not.toBe(firstConnection.token)
+  })
+
+  it('records the loopback listener lifecycle without exposing its credential', async () => {
+    const diagnostics = { info: vi.fn(), error: vi.fn() }
+    const host = jsonHost('bearer', diagnostics)
+    hosts.push(host)
+
+    const connection = await host.start()
+    const port = Number(new URL(connection.baseUrl).port)
+    expect(diagnostics.info).toHaveBeenCalledWith('provider loopback listening', {
+      bridge: 'test-provider',
+      bridgeId: expect.any(String),
+      port
+    })
+    const listeningData = diagnostics.info.mock.calls[0][1]
+
+    await host.close()
+    expect(diagnostics.info).toHaveBeenCalledWith('provider loopback closed', {
+      bridge: 'test-provider',
+      bridgeId: (listeningData as { bridgeId: string }).bridgeId,
+      port,
+      expected: true,
+      lifetimeMs: expect.any(Number)
+    })
+    expect(JSON.stringify(diagnostics.info.mock.calls)).not.toContain(connection.token)
   })
 
   it('authenticates before routing and preserves each adapter credential mode', async () => {
@@ -143,6 +172,8 @@ describe('ProviderLoopbackHttpHost', () => {
       markAborted = resolve
     })
     const host = new ProviderLoopbackHttpHost<Connection>({
+      diagnosticName: 'test-provider',
+      diagnostics: { info: vi.fn(), error: vi.fn() },
       credentialMode: 'bearer',
       createConnection: (origin, token) => Object.freeze({ baseUrl: origin, token }),
       onUnauthorized: (response) => writeProviderLoopbackJson(response, 401, {}),

--- a/src/main/settings/provider-loopback-http-host.ts
+++ b/src/main/settings/provider-loopback-http-host.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'node:crypto'
+import { randomBytes, randomUUID } from 'node:crypto'
 import {
   createServer,
   type IncomingHttpHeaders,
@@ -6,6 +6,8 @@ import {
   type Server,
   type ServerResponse
 } from 'node:http'
+
+import { createLogger, errorLogFields, type Logger } from '../logger'
 
 // A turn may contain up to 24 MiB of base64 image data before frameworks add text, replayed history,
 // and tool declarations. Keep every authenticated Provider bridge on one memory-bounded envelope.
@@ -28,12 +30,16 @@ type ProviderLoopbackHttpRequest = Readonly<{
 }>
 
 type ProviderLoopbackHttpHostOptions<Connection extends ProviderLoopbackConnection> = Readonly<{
+  diagnosticName: string
+  diagnostics?: Pick<Logger, 'info' | 'error'>
   credentialMode: 'bearer' | 'bearer-or-api-key'
   createConnection: (origin: string, token: string) => Connection
   handle: (request: ProviderLoopbackHttpRequest, response: ServerResponse) => Promise<void>
   onUnauthorized: (response: ServerResponse) => void
   onError: (error: unknown, response: ServerResponse) => void
 }>
+
+const defaultDiagnostics = createLogger('provider-loopback')
 
 class ProviderLoopbackRequestError extends Error {
   constructor(message: string, options: ErrorOptions = {}) {
@@ -115,6 +121,7 @@ class ProviderLoopbackHttpHost<Connection extends ProviderLoopbackConnection> {
   private startPromise: Promise<Connection> | undefined
   private closePromise: Promise<void> | undefined
   private closingStartPromise: Promise<Connection> | undefined
+  private lifecycle: { expectedClose: boolean } | undefined
 
   constructor(private readonly options: ProviderLoopbackHttpHostOptions<Connection>) {}
 
@@ -157,6 +164,16 @@ class ProviderLoopbackHttpHost<Connection extends ProviderLoopbackConnection> {
 
   private async startServer(): Promise<Connection> {
     const token = randomBytes(24).toString('hex')
+    const diagnostics = this.options.diagnostics ?? defaultDiagnostics
+    const bridgeId = randomUUID()
+    const startedAt = Date.now()
+    const lifecycle = { expectedClose: false }
+    let port: number | undefined
+    const diagnosticFields = (): Record<string, unknown> => ({
+      bridge: this.options.diagnosticName,
+      bridgeId,
+      ...(port === undefined ? {} : { port })
+    })
     const server = createServer((request, response) => {
       void this.serve(request, response, token).catch((error: unknown) => {
         if (response.destroyed || response.writableEnded) return
@@ -167,7 +184,21 @@ class ProviderLoopbackHttpHost<Connection extends ProviderLoopbackConnection> {
         }
       })
     })
+    server.on('error', (error) =>
+      diagnostics.error('provider loopback server error', {
+        ...diagnosticFields(),
+        ...errorLogFields(error)
+      })
+    )
+    server.once('close', () =>
+      diagnostics.info('provider loopback closed', {
+        ...diagnosticFields(),
+        expected: lifecycle.expectedClose,
+        lifetimeMs: Date.now() - startedAt
+      })
+    )
     this.server = server
+    this.lifecycle = lifecycle
     try {
       await new Promise<void>((resolve, reject) => {
         const onError = (error: Error): void => reject(error)
@@ -182,13 +213,21 @@ class ProviderLoopbackHttpHost<Connection extends ProviderLoopbackConnection> {
       if (!address || typeof address === 'string') {
         throw new Error('Provider loopback HTTP host did not bind a port.')
       }
+      port = address.port
+      diagnostics.info('provider loopback listening', diagnosticFields())
       const connection = this.options.createConnection(`http://127.0.0.1:${address.port}`, token)
       this.connection = connection
       return connection
     } catch (error) {
+      lifecycle.expectedClose = true
+      diagnostics.error('provider loopback failed to start', {
+        ...diagnosticFields(),
+        ...errorLogFields(error)
+      })
       if (this.server === server) this.server = undefined
       this.connection = undefined
       await closeServer(server).catch(() => undefined)
+      if (this.lifecycle === lifecycle) this.lifecycle = undefined
       throw error
     }
   }
@@ -196,9 +235,12 @@ class ProviderLoopbackHttpHost<Connection extends ProviderLoopbackConnection> {
   private async closeAfterStart(starting: Promise<Connection> | undefined): Promise<void> {
     await starting?.catch(() => undefined)
     const server = this.server
+    const lifecycle = this.lifecycle
     this.server = undefined
     this.connection = undefined
+    if (lifecycle) lifecycle.expectedClose = true
     if (server) await closeServer(server)
+    if (this.lifecycle === lifecycle) this.lifecycle = undefined
   }
 
   private finishClose(closing: Promise<void>, starting: Promise<Connection> | undefined): void {

--- a/src/main/settings/responses-bridge.ts
+++ b/src/main/settings/responses-bridge.ts
@@ -91,7 +91,6 @@ type ResponsesBridgeOptions = {
 }
 
 type BridgeFetch = typeof fetch
-
 const DEFAULT_REASONING_CACHE_MAX_ENTRIES = 4_096
 const DEFAULT_REASONING_CACHE_MAX_CHARACTERS = 8 * 1024 * 1024
 
@@ -128,6 +127,7 @@ export class ResponsesBridge {
   ) {
     this.target = target
     this.host = new ProviderLoopbackHttpHost({
+      diagnosticName: 'responses',
       credentialMode: 'bearer',
       createConnection: (origin, token) => ({
         baseUrl: origin + '/v1',

--- a/src/main/settings/xai-oauth-provider-bridge.ts
+++ b/src/main/settings/xai-oauth-provider-bridge.ts
@@ -78,6 +78,7 @@ export class XaiOAuthProviderBridge {
     )
     for (const target of targets) this.advertisedIds.add(target.model)
     this.host = new ProviderLoopbackHttpHost({
+      diagnosticName: `xai-oauth-${this.wire}`,
       credentialMode: 'bearer-or-api-key',
       createConnection: (origin, token) => ({ baseUrl: origin, token }),
       onUnauthorized: (response) => json(response, 401, { error: { message: 'Unauthorized' } }),


### PR DESCRIPTION
## Problem

A Claude Code session using an official provider can report `API Error: Unable to connect to API (ConnectionRefused)`. The captured log shows the child process was configured to call an app-managed `127.0.0.1:<ephemeral-port>` provider bridge, but it does not record whether that listener started, failed, or disappeared. That leaves bridge lifecycle failures indistinguishable from Windows proxy/security interference with loopback traffic.

## Proposed change

- Record provider loopback listener startup, startup failure, server errors, and closure in the shared host used by the Anthropic, OpenAI, Responses, native Responses compatibility, and xAI OAuth adapters.
- Correlate each listener generation with a random bridge ID, bridge kind, loopback port, expected/unexpected closure, and lifetime.
- Keep diagnostics free of provider credentials, request bodies, headers, model content, and upstream addresses.

## Scope and non-goals

- This is a diagnostic improvement, not a speculative fix for the unproven root cause of the reported refusal.
- No provider routing, proxy behavior, request forwarding, renderer interaction, persistence, schema, data model, or status enum changes.
- No historical-data compatibility work is required.

## Acceptance criteria and validation

The focused regression was added first and failed on the previous implementation because the lifecycle logger received zero calls, then passed after the change.

Final checks ran after the last material edit:

- Shared listener lifecycle and architecture -> focused Vitest command -> 9/9 passed.
- All directly affected provider adapters -> focused Vitest command -> 115/115 passed across 7 files.
- Changed source/test style -> targeted ESLint -> passed with no findings.
- Repository lint -> full ESLint -> 0 errors; 2 pre-existing Prettier warnings remain in `src/main/acp/application-commands.ts` and `src/main/acp/ipc.ts`.
- Changed-file formatting -> Prettier check -> passed.
- Main-process typecheck -> attempted, but the existing parent dependency installation lacks the `waitForMcpServers` export referenced by `src/main/acp/claude-agent-acp-patch.test.ts`; no new diagnostic-change type error was reported. Exact dependency and complete platform coverage remain delegated to PR CI.

Consumer suites were excluded locally because the exported adapter contracts, routing, and request behavior are unchanged. Windows-sensitive CI remains relevant because the original symptom is platform/network specific.

## Review focus

- Whether the listener lifecycle fields are sufficient to distinguish expected teardown, unexpected closure, bind/server failure, and an externally blocked but still-running loopback listener.
- Whether the logged fields remain safely free of credentials and request content.
