### PR TITLE
fix(application-events): isolate subscriber failures

### DIFF
--- a/src/main/application-events.test.ts
+++ b/src/main/application-events.test.ts
@@ -61,7 +61,7 @@ describe('ApplicationEventHub', () => {
     expect(second).toHaveBeenCalledWith({ channel: 'acp:event', payload: [event] })
   })
 
-  it('preserves live Set cancellation and failure propagation semantics', () => {
+  it('preserves live Set cancellation while isolating subscriber failures', () => {
     const hub = new ApplicationEventHub()
     const skipped = vi.fn()
     const removeSkipped = hub.subscribe(skipped)
@@ -77,9 +77,12 @@ describe('ApplicationEventHub', () => {
     removeSkipped()
     hub.subscribe(skipped)
 
-    expect(() => hub.publish('specialist:catalog-changed', undefined)).toThrow(failure)
+    expect(() => hub.publish('specialist:catalog-changed', undefined)).not.toThrow()
     expect(skipped).not.toHaveBeenCalled()
-    expect(afterFailure).not.toHaveBeenCalled()
+    expect(afterFailure).toHaveBeenCalledWith({
+      channel: 'specialist:catalog-changed',
+      payload: undefined
+    })
   })
 
   it('clears subscriptions and ignores late work after disposal', () => {

--- a/src/main/application-events.ts
+++ b/src/main/application-events.ts
@@ -35,6 +35,9 @@ import type { SideChatRelayDeliveredEvent, SideChatRuntimeEvent } from '../share
 import type { UpdateStatus } from '../shared/update'
 import type { LocalePreferenceSnapshot } from '../shared/locale'
 import type { TagsChangedEvent } from '../shared/tags'
+import { createLogger, errorLogFields } from './logger'
+
+const log = createLogger('application-events')
 
 // This catalog describes only events that already flow through renderer-broadcast. Window-only
 // signals and generated Web-only channels stay on their existing transports until their owner moves
@@ -132,10 +135,27 @@ export class ApplicationEventHub implements ApplicationEvents {
     if (this.disposed) return
     const event = Object.freeze({ channel, payload }) as ApplicationEvent
 
-    // Iterate the live Set deliberately. The compatibility broadcaster used the same semantics:
-    // removing a not-yet-called listener skips it in the active publication, and listener failures
-    // stop later delivery and propagate to the publisher.
-    for (const listener of this.listeners) listener(event)
+    // Iterate the live Set deliberately so removing a not-yet-called listener still skips it in the
+    // active publication. Isolate subscriber failures because notification delivery cannot roll back
+    // an already-committed owner mutation or suppress healthy later projections.
+    let failures: unknown[] | undefined
+    for (const listener of this.listeners) {
+      try {
+        listener(event)
+      } catch (error) {
+        if (failures) failures.push(error)
+        else failures = [error]
+      }
+    }
+    if (failures) {
+      log.warn('Application event subscriber delivery failed (non-fatal)', {
+        channel,
+        subscriberFailureCount: failures.length,
+        ...errorLogFields(
+          new AggregateError(failures, 'One or more application event subscribers failed.')
+        )
+      })
+    }
   }
 
   subscribe(listener: ApplicationEventListener): () => void {

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -18,6 +18,7 @@ import {
   type SessionDeletionResult
 } from '../shared/session-persistence'
 import { ApplicationCommandError } from '../shared/application-command-contract'
+import { ApplicationEventHub } from './application-events'
 
 const callerContext = createCallerContext({
   clientId: 'renderer-1',
@@ -935,14 +936,20 @@ describe('Data and content application commands', () => {
     })
   })
 
-  it('preserves standalone upload publication failures after the upload commits', async () => {
+  it('returns a committed standalone upload when one event subscriber fails', async () => {
     const router = createApplicationCommandRouter()
     const deps = createDependencies()
+    const events = new ApplicationEventHub()
     const publicationFailure = new Error('renderer broadcast failed')
-    deps.events.publish.mockImplementationOnce(() => {
+    const laterSubscriber = vi.fn()
+    events.subscribe(() => {
       throw publicationFailure
     })
-    registerDataContentApplicationCommands(router.registrar, deps.dependencies)
+    events.subscribe(laterSubscriber)
+    registerDataContentApplicationCommands(router.registrar, {
+      ...deps.dependencies,
+      events
+    })
     const request = {
       transferId: 'transfer-standalone',
       sourcePath: '/tmp/report.txt',
@@ -955,8 +962,16 @@ describe('Data and content application commands', () => {
         dataContentApplicationCommands.uploadStageLocalPath,
         invocation([request] as const)
       )
-    ).rejects.toBe(publicationFailure)
+    ).resolves.toBe(deps.attachment)
     expect(deps.uploads.stageLocalPath).toHaveBeenCalledOnce()
-    expect(deps.events.publish).toHaveBeenCalledOnce()
+    expect(laterSubscriber).toHaveBeenCalledWith({
+      channel: 'project-files:changed',
+      payload: {
+        projectId: 'project-1',
+        sessionId: 'standalone-uploads',
+        sources: ['upload'],
+        kind: 'upsert'
+      }
+    })
   })
 })


### PR DESCRIPTION
## Problem

Application event subscribers run synchronously in registration order. A subscriber exception escaped `ApplicationEventHub.publish` after a durable owner had already committed, so callers could observe a false command failure, retries could duplicate work, and later projections missed the event.

## Proposed change

- isolate each application event subscriber failure;
- continue delivering the live event to healthy later subscribers;
- aggregate subscriber failures into one non-fatal structured diagnostic;
- lock the behavior at the public standalone-upload command boundary.

## Scope and non-goals

This changes only the in-process event hub failure semantics. It adds no data fields, schema migration, enum values, durable event storage, retry worker, outbox, or UI contract. Existing repository commits remain authoritative. Durable outbox/replay is intentionally out of scope because current notifications are reconstructable projections or already have owner-specific replay.

## Acceptance criteria and validation

Checks listed below ran after the last material edit.

- committed command result and later-subscriber delivery -> `vitest run src/main/application-events.test.ts src/main/data-content-application-commands.test.ts` -> 2 files passed, 21 tests passed;
- source lint -> `eslint --cache .` -> passed;
- whitespace/patch integrity -> `git diff --check` -> passed;
- Main typecheck -> `tsc --noEmit -p tsconfig.node.json --composite false` -> locally blocked by the shared dependency tree exposing no `waitForMcpServers` from `@agentclientprotocol/claude-agent-acp`; this is unrelated to the diff and PR CI with a clean lockfile install is authoritative.

The event hub is a cross-module interface not explicitly owned in `module-impact.json`, so no single module suite can establish complete downstream coverage. PR Gate should conservatively select the required consumer and platform lanes. The change has no persistence, migration, renderer, or platform-specific behavior. Full local `npm test` was intentionally not run; PR CI is authoritative as requested.

## Review focus

- subscriber exceptions never escape publication;
- later subscribers still receive the event;
- live-Set unsubscribe behavior remains unchanged;
- aggregate diagnostics do not include event payloads.