### PR TITLE
perf(workspace): index long-session transcript projections

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -38,6 +38,8 @@ import {
   createInitialGrantedFoldersState,
   useGrantedFoldersStore
 } from '@/stores/granted-folders-store'
+import { createInitialSessionJobState, useSessionJobStore } from '@/stores/session-job-store'
+import type { JobSummary } from '../../../../shared/compute'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -351,6 +353,7 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     openFileDialog.mockClear()
     listGrantedRoots.mockReset().mockResolvedValue([])
     useGrantedFoldersStore.setState(createInitialGrantedFoldersState())
+    useSessionJobStore.setState(createInitialSessionJobState())
     createSessionSubagentsPreviewItem.mockClear()
     announceWindowFindReady.mockClear()
     announceWindowFindContentReady.mockClear()
@@ -3606,6 +3609,111 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     await act(async () => firstRun?.click())
 
     expect(container.textContent).toContain('oldest transcript sentinel')
+  })
+
+  it('binds a long session job feed without repeatedly scanning every activity', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const itemCount = 120
+    let rawOutputReads = 0
+    const activities = Array.from({ length: itemCount }, (_, index) => {
+      const activity = createActivity({
+        id: `job-activity-${index}`,
+        status: 'completed',
+        sortIndex: index,
+        createdAt: 1710000000000 + index,
+        updatedAt: 1710000000000 + index
+      })
+      Object.defineProperty(activity, 'rawOutput', {
+        enumerable: true,
+        get: () => {
+          rawOutputReads += 1
+          return { result: JSON.stringify({ job_id: `job-${index}` }) }
+        }
+      })
+      return activity
+    })
+    const jobs = Array.from({ length: itemCount }, (_, index): JobSummary => ({
+      job_id: `job-${index}`,
+      provider_id: 'ssh:test',
+      display_name: 'Test host',
+      shape: 'direct_ssh',
+      session_id: 'session-1',
+      status: 'success',
+      intent: `Job ${index}`,
+      created_at: 1710000000000 + index,
+      started_at: 1710000000000 + index,
+      finished_at: 1710000001000 + index,
+      exit_code: 0,
+      error_code: undefined,
+      remote_workdir: '/workspace',
+      stdout_tail: undefined,
+      stderr_tail: undefined,
+      notified_at: undefined,
+      notification_consumed_at: undefined
+    }))
+    useSessionJobStore.setState({
+      jobsById: new Map(jobs.map((job) => [job.job_id, job])),
+      hydratedSessionId: 'session-1',
+      isLoaded: true
+    })
+
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={createSession({ status: 'idle', activities })}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    })
+
+    expect(rawOutputReads).toBeLessThanOrEqual(itemCount * 8)
+  })
+
+  it('renders a long conversation graph without rescanning it for every visible revision', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const itemCount = 240
+    const messages = Array.from({ length: itemCount }, (_, index) =>
+      createMessage({
+        id: `graph-message-${index}`,
+        role: index % 2 === 0 ? 'user' : 'agent',
+        content: `Graph message ${index}`,
+        responseToMessageId: index % 2 === 0 ? undefined : `graph-message-${index - 1}`,
+        sortIndex: index,
+        createdAt: 1710000000000 + index,
+        updatedAt: 1710000000000 + index
+      })
+    )
+    const conversationGraph = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages,
+      frameworkId: 'codex',
+      createdAt: 1710000000000,
+      updatedAt: 1710000000000 + itemCount
+    })
+    let graphRoleReads = 0
+    for (const message of conversationGraph.messages) {
+      const role = message.role
+      Object.defineProperty(message, 'role', {
+        enumerable: true,
+        get: () => {
+          graphRoleReads += 1
+          return role
+        }
+      })
+    }
+
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={createSession({ status: 'idle', conversationGraph, messages })}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    })
+
+    expect(graphRoleReads).toBeLessThanOrEqual(itemCount * 4)
   })
 
   it('prefetches older transcript items before upward scrolling reaches the top edge', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -162,6 +162,7 @@ const VisibleMessageSnapshotCommit = ({
 }
 
 type MessageUploadAttachment = NonNullable<ChatSession['messages'][number]['uploads']>[number]
+type ConversationMessageNode = NonNullable<ChatSession['conversationGraph']>['messages'][number]
 const SCROLL_TO_FIRST_MESSAGE_MIN_USER_TURNS = 2
 const SCROLL_TO_FIRST_MESSAGE_MIN_HEIGHT_VIEWPORTS = 2
 const SCROLL_TO_FIRST_MESSAGE_MIN_PROGRESS = 0.1
@@ -398,8 +399,9 @@ const WorkspaceMessageScrollerImpl = ({
     messageScrollerViewportRef.current = node
     setMessageScrollerViewport(node)
   }, [])
-  const activeConversationFrame = activeSession?.conversationGraph?.frames.find(
-    (frame) => frame.id === activeSession.conversationGraph?.activeFrameId
+  const conversationGraph = activeSession?.conversationGraph
+  const activeConversationFrame = conversationGraph?.frames.find(
+    (frame) => frame.id === conversationGraph.activeFrameId
   )
   const currentPresentationScopeId = currentSessionId
     ? JSON.stringify([currentSessionId, activeConversationFrame?.activeBranchId ?? 'legacy'])
@@ -838,21 +840,47 @@ const WorkspaceMessageScrollerImpl = ({
         : undefined,
     [legacyAgentBackendId, legacyAgentModel]
   )
-  const messageCreatedAtById = new Map(
-    activeSession?.messages.map((message) => [message.id, message.createdAt]) ?? []
+  const { conversationMessageById, runtimeSegmentById, revisionsByRootMessageId } = useMemo(() => {
+    const messageById = new Map(conversationGraph?.messages.map((message) => [message.id, message]))
+    const segmentById = new Map(
+      conversationGraph?.runtimeSegments.map((segment) => [segment.id, segment])
+    )
+    const revisionsByRoot = new Map<string, ConversationMessageNode[]>()
+    for (const message of conversationGraph?.messages ?? []) {
+      if (message.role !== 'user' || !message.revisionRootMessageId) continue
+      const revisions = revisionsByRoot.get(message.revisionRootMessageId) ?? []
+      revisions.push(message)
+      revisionsByRoot.set(message.revisionRootMessageId, revisions)
+    }
+    for (const revisions of revisionsByRoot.values()) {
+      revisions.sort(
+        (left, right) => left.createdAt - right.createdAt || left.id.localeCompare(right.id)
+      )
+    }
+    return {
+      conversationMessageById: messageById,
+      runtimeSegmentById: segmentById,
+      revisionsByRootMessageId: revisionsByRoot
+    }
+  }, [conversationGraph])
+  const messageCreatedAtById = useMemo(
+    () => new Map(activeSession?.messages.map((message) => [message.id, message.createdAt]) ?? []),
+    [activeSession?.messages]
   )
 
   // Counts the user turns after each message; the destructive-resend warning keys off turns, not
   // raw message count, so a single follow-up turn stays warning-free.
-  const subsequentTurnCountByMessageId = new Map<string, number>()
-  if (activeSession) {
+  const subsequentTurnCountByMessageId = useMemo(() => {
+    const counts = new Map<string, number>()
     let subsequentTurns = 0
-    for (let index = activeSession.messages.length - 1; index >= 0; index -= 1) {
-      const message = activeSession.messages[index]
-      subsequentTurnCountByMessageId.set(message.id, subsequentTurns)
+    for (let index = (activeSession?.messages.length ?? 0) - 1; index >= 0; index -= 1) {
+      const message = activeSession?.messages[index]
+      if (!message) continue
+      counts.set(message.id, subsequentTurns)
       if (message.role === 'user') subsequentTurns += 1
     }
-  }
+    return counts
+  }, [activeSession?.messages])
 
   // Build a map from job_id → JobSummary for all session jobs (used in binding)
   const sessionJobs = useMemo((): JobSummary[] => {
@@ -865,18 +893,15 @@ const WorkspaceMessageScrollerImpl = ({
   const { jobsByActivityId, boundJobIds } = useMemo(() => {
     const byActivityId = new Map<string, JobSummary>()
     const bound = new Set<string>()
+    const jobsByJobId = new Map(sessionJobs.map((job) => [job.job_id, job]))
 
-    const allActivities = activeSession?.activities ?? []
-    for (const job of sessionJobs) {
-      // Scan all activities for this job_id
-      for (const activity of allActivities) {
-        const extracted = extractJobIdFromActivity(activity)
-        if (extracted === job.job_id) {
-          byActivityId.set(job.job_id, job)
-          bound.add(job.job_id)
-          break // Found — no need to scan further activities for this job
-        }
-      }
+    for (const activity of activeSession?.activities ?? []) {
+      const jobId = extractJobIdFromActivity(activity)
+      if (!jobId) continue
+      const job = jobsByJobId.get(jobId)
+      if (!job) continue
+      byActivityId.set(jobId, job)
+      bound.add(jobId)
     }
 
     return { jobsByActivityId: byActivityId, boundJobIds: bound }
@@ -1187,14 +1212,9 @@ const WorkspaceMessageScrollerImpl = ({
                   const artifacts = artifactVisibility.artifactsForMessage(item.message)
                   // Jobs pre-assigned to this slot: each job appears in exactly one slot.
                   const jobsBeforeMessage = jobSlotsByItemIndex.get(itemIndex) ?? []
-                  const graph = activeSession?.conversationGraph
-                  const messageNode = graph?.messages.find(
-                    (message) => message.id === item.message.id
-                  )
+                  const messageNode = conversationMessageById.get(item.message.id)
                   const runtimeSegment = messageNode?.runtimeSegmentId
-                    ? graph?.runtimeSegments.find(
-                        (segment) => segment.id === messageNode.runtimeSegmentId
-                      )
+                    ? runtimeSegmentById.get(messageNode.runtimeSegmentId)
                     : undefined
                   // Legacy sessions synthesize this segment with a fallback framework. Keep only
                   // the session-level values that were actually persisted.
@@ -1209,16 +1229,7 @@ const WorkspaceMessageScrollerImpl = ({
                     ? messageNode?.revisionRootMessageId
                     : undefined
                   const revisions = revisionRootMessageId
-                    ? (graph?.messages
-                        .filter(
-                          (message) =>
-                            message.role === 'user' &&
-                            message.revisionRootMessageId === revisionRootMessageId
-                        )
-                        .sort(
-                          (left, right) =>
-                            left.createdAt - right.createdAt || left.id.localeCompare(right.id)
-                        ) ?? [])
+                    ? (revisionsByRootMessageId.get(revisionRootMessageId) ?? [])
                     : []
                   const revisionIndex = revisions.findIndex(
                     (message) => message.id === item.message.id
@@ -1331,14 +1342,9 @@ const WorkspaceMessageScrollerImpl = ({
                 }
 
                 if (item.type === 'turn-completion') {
-                  const graph = activeSession?.conversationGraph
-                  const messageNode = graph?.messages.find(
-                    (message) => message.id === item.message.id
-                  )
+                  const messageNode = conversationMessageById.get(item.message.id)
                   const runtimeSegment = messageNode?.runtimeSegmentId
-                    ? graph?.runtimeSegments.find(
-                        (segment) => segment.id === messageNode.runtimeSegmentId
-                      )
+                    ? runtimeSegmentById.get(messageNode.runtimeSegmentId)
                     : undefined
                   const synthesizedLegacyRuntime =
                     runtimeSegment?.id === `runtime-segment-${activeSession?.id}` &&


### PR DESCRIPTION
## Problem

The current main branch already bounds mounted transcript rows through the transcript window added in #1636, so the earlier claim that every React row is still created is no longer accurate. Two pre-window projection paths nevertheless remained quadratic for long Sessions:

- matching every Session job by rescanning every activity;
- resolving each visible message and revision by rescanning and sorting the full conversation graph.

Deterministic public-boundary regressions reproduced 7,980 raw activity-output reads for 120 jobs and activities, and 19,440 graph role reads for a 240-message conversation.

## Proposed change

Build render-local memoized indexes for job bindings, graph messages, runtime segments, and revision groups. Reuse memoized message timestamp and subsequent-turn maps across internal scroller renders.

The regression inputs now observe 840 activity-output reads and 480 graph role reads, preserving linear growth.

## Scope and non-goals

- No new persisted or renderer data fields.
- No architecture, interaction, data-model, enum, IPC, or persistence changes.
- No historical-data compatibility work is required.
- No second virtualization framework or cache layer is introduced.
- The unbound-job insertion findIndex path is unchanged because this investigation did not produce an equally controlled failure for it; optimizing it would require additional ordering assumptions or machinery.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- quadratic job/activity binding -> npm test -- src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx -> 49 passed
- conversation-graph revision/runtime lookup -> same command -> 49 passed
- SSR transcript behavior and subagent consumer -> npm test -- src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx src/renderer/src/pages/workspace/SubagentReleaseSurfaces.render.test.tsx -> 86 passed
- ConversationPanel consumer -> npm test -- src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx -> 120 passed
- renderer types -> npm run typecheck:web -> passed
- lint -> npm run lint -> passed

The affected-test classifier selects the full CI plan because WorkspaceMessageScroller.tsx is currently an unknown module owner. Per task direction, the complete npm test suite was not run locally; PR CI is authoritative for that coverage.

## Review focus

Please verify that graph/session arrays retain their existing immutable-update contract so memoized indexes invalidate with the current Session update boundary, and that the operation-count regressions express the intended linear ceiling without coupling to wall-clock timing.