### PR TITLE
fix(workspace): make mobile sidebar focus modal

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
@@ -123,9 +123,10 @@ vi.mock('@/components/ui/resizable', () => ({
 
     return <div data-testid={id ?? 'resizable-panel'}>{children}</div>
   },
-  ResizablePanelGroup: ({ children }: { children: React.ReactNode }): React.JSX.Element => (
-    <div>{children}</div>
-  ),
+  ResizablePanelGroup: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement>): React.JSX.Element => <div {...props}>{children}</div>,
   ResizableHandle: ({
     elementRef,
     className,
@@ -162,7 +163,8 @@ vi.mock('./WorkspaceSidebar', () => ({
   WorkspaceSidebar: ({
     isMobileOpen,
     sidebarToggle,
-    sidebarToggleButtonRef
+    sidebarToggleButtonRef,
+    onMobileClose
   }: {
     isMobileOpen?: boolean
     sidebarToggle?: {
@@ -170,8 +172,18 @@ vi.mock('./WorkspaceSidebar', () => ({
       onToggle: () => void
     }
     sidebarToggleButtonRef?: React.Ref<HTMLButtonElement>
+    onMobileClose?: () => void
   }): React.JSX.Element => (
-    <aside data-mobile-open={isMobileOpen ? 'true' : 'false'}>
+    <aside
+      aria-hidden={isMobileOpen === false ? true : undefined}
+      inert={isMobileOpen === false ? true : undefined}
+      data-mobile-open={isMobileOpen ? 'true' : 'false'}
+    >
+      {isMobileOpen !== undefined ? (
+        <button type="button" data-testid="mobile-sidebar-action" onClick={onMobileClose}>
+          Close navigation
+        </button>
+      ) : null}
       {sidebarToggle && sidebarToggle.state !== 'collapsed' ? (
         // Structural stand-in only: style-class coverage lives in WorkspaceSidebar.render.test
         // against the real component, so this mock deliberately does not replicate the styles.
@@ -877,6 +889,31 @@ describe('WorkspacePage preview panel resize sync', () => {
     expect(
       container.querySelector('[data-testid="mobile-preview-sheet"]')?.getAttribute('data-open')
     ).toBe('true')
+  })
+
+  it('keeps mobile navigation focus modal and restores its trigger on close', async () => {
+    workspacePageHarness.isMobile = true
+    await renderPage()
+
+    const trigger = container.querySelector<HTMLButtonElement>('[data-testid="navigation-toggle"]')
+    const conversation = container.querySelector<HTMLElement>('[data-testid="conversation-panel"]')
+    trigger?.focus()
+
+    await act(async () => trigger?.click())
+
+    const sidebar = container.querySelector<HTMLElement>('aside')
+    const dialog = sidebar?.closest<HTMLElement>('[role="dialog"]')
+    expect(sidebar?.contains(document.activeElement)).toBe(true)
+    expect(dialog?.getAttribute('aria-modal')).toBe('true')
+    expect(conversation?.closest('[inert]')).not.toBeNull()
+
+    await act(async () => trigger?.focus())
+    expect(sidebar?.contains(document.activeElement)).toBe(true)
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+    expect(document.activeElement).toBe(trigger)
   })
 
   it('toggles the mobile navigation drawer with Ctrl+B', async () => {

--- a/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
+++ b/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
@@ -1,5 +1,6 @@
 import { animate } from 'motion'
 import { PanelLeft, PanelRight } from 'lucide-react'
+import { FocusScope } from '@radix-ui/react-focus-scope'
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { PanelImperativeHandle, PanelSize } from 'react-resizable-panels'
@@ -251,24 +252,37 @@ type PreviewPanelLayoutPort = {
 }
 
 // Presents one layout contract to WorkspacePage across desktop and mobile surfaces.
-const useWorkspacePanelLayout = (previewPort: PreviewPanelLayoutPort): WorkspacePanelLayout => {
+const useWorkspacePanelLayout = (
+  previewPort: PreviewPanelLayoutPort,
+  mobileSidebarDialogRef: React.RefObject<HTMLDivElement | null>
+): WorkspacePanelLayout => {
   const { t } = useTranslation()
   const [sidebarState, setSidebarState] = useState<ResizablePanelState>('open')
   const sidebarToggleRef = useRef<HTMLButtonElement | null>(null)
   const previewToggleRef = useRef<HTMLButtonElement | null>(null)
   const isMobile = useMediaQuery('(max-width: 767px)')
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false)
+  const mobileSidebarReturnFocusRef = useRef<HTMLElement | null>(null)
+  const mobileSidebarWasOpenRef = useRef(false)
   // Latest sidebar width in pixels and a render-phase-independent mirror of the collapse state,
   // so the floating fallback can be positioned no matter which toggle instance holds the ref.
   const sidebarPixelWidthRef = useRef<number | null>(null)
   const sidebarStateRef = useRef(sidebarState)
 
-  const openMobileSidebar = useCallback((): void => setIsMobileSidebarOpen(true), [])
+  const rememberMobileSidebarReturnFocus = useCallback((): void => {
+    const activeElement = document.activeElement
+    mobileSidebarReturnFocusRef.current =
+      activeElement instanceof HTMLElement && activeElement !== document.body ? activeElement : null
+  }, [])
+  const openMobileSidebar = useCallback((): void => {
+    rememberMobileSidebarReturnFocus()
+    setIsMobileSidebarOpen(true)
+  }, [rememberMobileSidebarReturnFocus])
   const closeMobileSidebar = useCallback((): void => setIsMobileSidebarOpen(false), [])
-  const toggleMobileSidebar = useCallback(
-    (): void => setIsMobileSidebarOpen((isOpen) => !isOpen),
-    []
-  )
+  const toggleMobileSidebar = useCallback((): void => {
+    if (!isMobileSidebarOpen) rememberMobileSidebarReturnFocus()
+    setIsMobileSidebarOpen(!isMobileSidebarOpen)
+  }, [isMobileSidebarOpen, rememberMobileSidebarReturnFocus])
   const toggleSidebar = useCallback(
     (): void => setSidebarState((state) => (state === 'collapsed' ? 'open' : 'collapsed')),
     []
@@ -306,6 +320,36 @@ const useWorkspacePanelLayout = (previewPort: PreviewPanelLayoutPort): Workspace
   useEffect(() => {
     sidebarStateRef.current = sidebarState
   }, [sidebarState])
+
+  useEffect(() => {
+    const dialog = mobileSidebarDialogRef.current
+    if (isMobile && isMobileSidebarOpen) {
+      mobileSidebarWasOpenRef.current = true
+      dialog
+        ?.querySelector<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )
+        ?.focus()
+      return
+    }
+
+    if (!mobileSidebarWasOpenRef.current) return
+    mobileSidebarWasOpenRef.current = false
+
+    const activeElement = document.activeElement
+    if (
+      activeElement instanceof HTMLElement &&
+      activeElement !== document.body &&
+      document.contains(activeElement) &&
+      !dialog?.contains(activeElement)
+    ) {
+      return
+    }
+
+    const returnFocus = mobileSidebarReturnFocusRef.current
+    mobileSidebarReturnFocusRef.current = null
+    if (returnFocus?.isConnected && !returnFocus.closest('[inert]')) returnFocus.focus()
+  }, [isMobile, isMobileSidebarOpen, mobileSidebarDialogRef])
 
   // Drag-to-collapse emits its final zero-width resize while the header toggle still holds the
   // ref, so the freshly mounted floating fallback reapplies the tracked width on collapse.
@@ -350,6 +394,9 @@ const useWorkspacePanelLayout = (previewPort: PreviewPanelLayoutPort): Workspace
   useEffect(() => {
     const toggleSidebarFromShortcut = (event: KeyboardEvent): void => {
       const isMac = window.api?.platform === 'darwin'
+      const hasBlockingDialog = Array.from(
+        document.querySelectorAll<HTMLElement>(OPEN_DIALOG_SELECTOR)
+      ).some((dialog) => dialog !== mobileSidebarDialogRef.current)
       if (
         event.defaultPrevented ||
         event.isComposing ||
@@ -358,7 +405,7 @@ const useWorkspacePanelLayout = (previewPort: PreviewPanelLayoutPort): Workspace
         !(isMac ? event.metaKey : event.ctrlKey) ||
         event.altKey ||
         event.shiftKey ||
-        document.querySelector(OPEN_DIALOG_SELECTOR) !== null
+        hasBlockingDialog
       ) {
         return
       }
@@ -370,7 +417,7 @@ const useWorkspacePanelLayout = (previewPort: PreviewPanelLayoutPort): Workspace
 
     window.addEventListener('keydown', toggleSidebarFromShortcut)
     return () => window.removeEventListener('keydown', toggleSidebarFromShortcut)
-  }, [isMobile, toggleMobileSidebar, toggleSidebar])
+  }, [isMobile, mobileSidebarDialogRef, toggleMobileSidebar, toggleSidebar])
 
   return {
     isMobile,
@@ -477,7 +524,11 @@ const WorkspacePanelLayout = ({
   renderConversation
 }: WorkspacePanelLayoutProps): React.JSX.Element => {
   const { t } = useTranslation()
-  const { isMobile, mobileSidebar, sidebar, preview } = useWorkspacePanelLayout(previewPort)
+  const mobileSidebarDialogRef = useRef<HTMLDivElement | null>(null)
+  const { isMobile, mobileSidebar, sidebar, preview } = useWorkspacePanelLayout(
+    previewPort,
+    mobileSidebarDialogRef
+  )
 
   return (
     <>
@@ -487,14 +538,36 @@ const WorkspacePanelLayout = ({
             type="button"
             className="fixed inset-0 z-[65] bg-black/45 md:hidden"
             aria-label={t('Close navigation')}
+            tabIndex={-1}
             onClick={mobileSidebar.close}
           />
         ) : null}
-        {isMobile
-          ? renderMobileSidebar({ isOpen: mobileSidebar.isOpen, close: mobileSidebar.close })
-          : null}
+        {isMobile ? (
+          <FocusScope
+            asChild
+            loop={mobileSidebar.isOpen}
+            trapped={mobileSidebar.isOpen}
+            onMountAutoFocus={(event) => event.preventDefault()}
+            onUnmountAutoFocus={(event) => event.preventDefault()}
+          >
+            <div
+              ref={mobileSidebarDialogRef}
+              role={mobileSidebar.isOpen ? 'dialog' : undefined}
+              aria-modal={mobileSidebar.isOpen ? true : undefined}
+              aria-label={mobileSidebar.isOpen ? t('Workspace navigation') : undefined}
+              className="contents"
+            >
+              {renderMobileSidebar({
+                isOpen: mobileSidebar.isOpen,
+                close: mobileSidebar.close
+              })}
+            </div>
+          </FocusScope>
+        ) : null}
         <ResizablePanelGroup
           orientation="horizontal"
+          aria-hidden={isMobile && mobileSidebar.isOpen ? true : undefined}
+          inert={isMobile && mobileSidebar.isOpen ? true : undefined}
           className={isMobile ? 'min-w-0 flex-1' : '-mr-[10px] min-w-0 flex-1'}
         >
           {!isMobile ? (


### PR DESCRIPTION
## Problem

On mobile viewports, the workspace navigation drawer looked modal but only supported Escape and overlay dismissal. Opening it left focus in the obscured conversation, allowed focus to escape back into that background, did not expose modal semantics, and did not reliably restore the opening control on close.

The regression test was run twice before the fix and failed consistently because `document.activeElement` remained outside the open sidebar.

## Proposed change

- Wrap the mounted mobile sidebar in the existing Radix `FocusScope`, trapping and looping focus only while open.
- Move focus into the sidebar on open and restore the connected opening control on close.
- Expose `role="dialog"` / `aria-modal="true"` while open and mark the conversation panel `inert` / `aria-hidden`.
- Remove the overlay from the tab order.
- Preserve `Ctrl+B` dismissal by excluding the mobile drawer itself from the existing open-dialog shortcut guard while continuing to block for other dialogs.

## Scope and non-goals

- Renderer presentation behavior only.
- No data fields, schema, domain model, persistence, migration, or enum changes.
- No historical-data compatibility work is required.
- The sidebar remains mounted while closed, preserving its existing state/subscription and slide-transition lifecycle.

## Acceptance criteria and validation

- Opening mobile navigation moves focus into the drawer.
- Focus cannot move into the obscured conversation while the drawer is open.
- The drawer exposes modal semantics and the background is inert.
- Escape closes the drawer and restores its opening control.
- Existing overlay dismissal, `Ctrl+B`, desktop sidebar, and preview behavior remain intact.

Final checks, all run after the last material edit:

- mobile modal behavior -> `vitest run --config src/renderer/vitest.worktree.config.ts src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx -t "keeps mobile navigation focus modal"` -> passed (1/1; failed twice before the fix at the focus-entry assertion)
- workspace owner/contract behavior -> `npm run test:module -- workspace_page` -> passed (25 files, 510 tests)
- renderer types -> `npm run typecheck:web` -> passed
- linted source/config -> `npm run lint` -> passed

The complete `npm test` suite was intentionally left to PR CI. Manual Web UI verification was not available because the in-app browser blocked the localhost loopback URL; the public WorkspacePage interaction seam provides the local regression signal.

## Review focus

- Focus restoration when actions close the drawer while another surface is opening.
- Interaction between the drawer's modal role and the existing open-dialog `Ctrl+B` guard.
- Keeping the persistently mounted mobile sidebar inert only while closed and the conversation inert only while the drawer is open.