### PR TITLE
fix(notebook): keep REPL errors concise for agents

### DIFF
--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -1139,11 +1139,14 @@ describe('compactNotebookExecutionResult', () => {
   })
 
   it('applies the compact projection and global budget to every execution tool', () => {
-    for (const name of ['notebook_execute', 'repl_execute', 'bash_execute']) {
+    for (const name of ['notebook_execute', 'bash_execute']) {
       const tool = NOTEBOOK_RPC_TOOLS.find((entry) => entry.name === name)
       expect(tool?.mapResult).toBe(compactNotebookExecutionResult)
       expect(tool?.resultLimitChars).toBe(NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT)
     }
+    const replTool = NOTEBOOK_RPC_TOOLS.find((entry) => entry.name === 'repl_execute')
+    expect(replTool?.mapResult).not.toBe(compactNotebookExecutionResult)
+    expect(replTool?.resultLimitChars).toBe(NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT)
   })
 
   it('keeps diagnostic streams once and removes duplicated structured stream outputs', () => {
@@ -1218,6 +1221,57 @@ describe('compactNotebookExecutionResult', () => {
 
     expect(compact.stdout).toBe(stdout)
     expect(compact.truncated).toBeUndefined()
+  })
+
+  it('omits internal REPL stack frames from the agent-facing error', () => {
+    const traceback = [
+      'ReferenceError: en2 is not defined',
+      '    at <repl>:5:21',
+      '    at Script.runInContext (node:vm:149:12)',
+      '    at Object.runInContext (node:vm:301:6)',
+      '    at run (/Users/alice/open-science/resources/notebook/repl_loop.js:3527:28)'
+    ].join('\n')
+
+    const replTool = NOTEBOOK_RPC_TOOLS.find((entry) => entry.name === 'repl_execute')
+    const summary = runSummary({ traceback })
+    const raw = {
+      ...summary,
+      status: 'failed',
+      outputs: [
+        {
+          type: 'error',
+          message: 'ReferenceError: en2 is not defined',
+          traceback
+        }
+      ]
+    }
+    const compact = replTool?.mapResult?.(raw, {}) as {
+      traceback: string
+      outputs: Array<Record<string, unknown>>
+    }
+
+    expect(compact.traceback).toBe('ReferenceError: en2 is not defined')
+    expect(compact.outputs).toEqual([
+      { type: 'error', message: 'ReferenceError: en2 is not defined' }
+    ])
+    expect(JSON.stringify(compact)).not.toContain('<repl>')
+    expect(JSON.stringify(compact)).not.toContain('node:vm')
+    expect(JSON.stringify(compact)).not.toContain('repl_loop.js')
+    expect((summary.text as { traceback: string }).traceback).toBe(traceback)
+    expect(raw.outputs[0].traceback).toBe(traceback)
+  })
+
+  it('keeps Python tracebacks intact for the agent', () => {
+    const traceback =
+      'Traceback (most recent call last):\n  File "analysis.py", line 2\nValueError: boom'
+
+    const compact = compactNotebookExecutionResult({
+      ...runSummary({ traceback }),
+      kernelKind: 'python',
+      status: 'failed'
+    }) as { traceback: string }
+
+    expect(compact.traceback).toBe(traceback)
   })
 
   it('preserves producer truncation when no additional MCP clipping is needed', () => {

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -1285,7 +1285,8 @@ describe('compactNotebookExecutionResult', () => {
   it('preserves multiline REPL error messages while omitting stack frames', () => {
     const traceback = [
       'Error: first diagnostic line',
-      'second diagnostic line',
+      '    at the lab, review the second diagnostic line',
+      'third diagnostic line',
       '    at <repl>:1:7',
       '    at run (/Users/alice/open-science/resources/notebook/repl_loop.js:3527:28)'
     ].join('\n')
@@ -1296,7 +1297,9 @@ describe('compactNotebookExecutionResult', () => {
       {}
     ) as { traceback: string }
 
-    expect(compact.traceback).toBe('Error: first diagnostic line\nsecond diagnostic line')
+    expect(compact.traceback).toBe(
+      'Error: first diagnostic line\n    at the lab, review the second diagnostic line\nthird diagnostic line'
+    )
   })
 
   it('keeps Python tracebacks intact for the agent', () => {

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -1261,6 +1261,44 @@ describe('compactNotebookExecutionResult', () => {
     expect(raw.outputs[0].traceback).toBe(traceback)
   })
 
+  it('keeps the actionable SyntaxError after the VM source preamble', () => {
+    const traceback = [
+      '<repl>:2',
+      'const value =',
+      '             ^',
+      '',
+      'SyntaxError: Unexpected end of input',
+      '    at new Script (node:vm:117:7)',
+      '    at Object.runInContext (node:vm:301:6)',
+      '    at run (/Users/alice/open-science/resources/notebook/repl_loop.js:3527:28)'
+    ].join('\n')
+    const replTool = NOTEBOOK_RPC_TOOLS.find((entry) => entry.name === 'repl_execute')
+
+    const compact = replTool?.mapResult?.(
+      { ...runSummary({ traceback }), status: 'failed' },
+      {}
+    ) as { traceback: string }
+
+    expect(compact.traceback).toBe('SyntaxError: Unexpected end of input')
+  })
+
+  it('preserves multiline REPL error messages while omitting stack frames', () => {
+    const traceback = [
+      'Error: first diagnostic line',
+      'second diagnostic line',
+      '    at <repl>:1:7',
+      '    at run (/Users/alice/open-science/resources/notebook/repl_loop.js:3527:28)'
+    ].join('\n')
+    const replTool = NOTEBOOK_RPC_TOOLS.find((entry) => entry.name === 'repl_execute')
+
+    const compact = replTool?.mapResult?.(
+      { ...runSummary({ traceback }), status: 'failed' },
+      {}
+    ) as { traceback: string }
+
+    expect(compact.traceback).toBe('Error: first diagnostic line\nsecond diagnostic line')
+  })
+
   it('keeps Python tracebacks intact for the agent', () => {
     const traceback =
       'Traceback (most recent call last):\n  File "analysis.py", line 2\nValueError: boom'

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -660,7 +660,11 @@ const compactReplTraceback = (value: string): string => {
   const errorLine = lines.findIndex((line) => /^[A-Za-z_$][\w$]*(?:Error|Exception)\b/.test(line))
   const messageStart = errorLine === -1 ? 0 : errorLine
   const frameStart = lines.findIndex(
-    (line, index) => index >= messageStart && /^\s+at(?:\s|$)/.test(line)
+    (line, index) =>
+      index >= messageStart &&
+      /^\s+at (?:(?:async|new)\s+)?(?:.+? \()?(?:node:|<repl>|file:|\/|[A-Za-z]:[\\/]).*:\d+:\d+\)?$/.test(
+        line
+      )
   )
   const message = lines.slice(messageStart, frameStart === -1 ? undefined : frameStart).join('\n')
   return message.trim() || value

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -655,17 +655,27 @@ const compactNotebookExecutionResult = (raw: unknown): unknown => {
 }
 
 // Internal VM frames remain in the durable run but do not help the Agent repair its REPL request.
+const compactReplTraceback = (value: string): string => {
+  const lines = value.split(/\r?\n/)
+  const errorLine = lines.findIndex((line) => /^[A-Za-z_$][\w$]*(?:Error|Exception)\b/.test(line))
+  const messageStart = errorLine === -1 ? 0 : errorLine
+  const frameStart = lines.findIndex(
+    (line, index) => index >= messageStart && /^\s+at(?:\s|$)/.test(line)
+  )
+  const message = lines.slice(messageStart, frameStart === -1 ? undefined : frameStart).join('\n')
+  return message.trim() || value
+}
+
 const compactReplExecutionResult = (raw: unknown): unknown => {
   const record = asRecord(raw)
   if (!record) return raw
 
-  const conciseTraceback = (value: string): string => value.split(/\r?\n/, 1)[0] || value
   const text = asRecord(record.text)
   const outputs = Array.isArray(record.outputs)
     ? record.outputs.map((value) => {
         const output = asRecord(value)
         return output?.type === 'error' && typeof output.traceback === 'string'
-          ? { ...output, traceback: conciseTraceback(output.traceback) }
+          ? { ...output, traceback: compactReplTraceback(output.traceback) }
           : value
       })
     : record.outputs
@@ -673,10 +683,10 @@ const compactReplExecutionResult = (raw: unknown): unknown => {
   return compactNotebookExecutionResult({
     ...record,
     ...(typeof record.traceback === 'string'
-      ? { traceback: conciseTraceback(record.traceback) }
+      ? { traceback: compactReplTraceback(record.traceback) }
       : {}),
     ...(text && typeof text.traceback === 'string'
-      ? { text: { ...text, traceback: conciseTraceback(text.traceback) } }
+      ? { text: { ...text, traceback: compactReplTraceback(text.traceback) } }
       : {}),
     ...(Array.isArray(record.outputs) ? { outputs } : {})
   })

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -654,6 +654,34 @@ const compactNotebookExecutionResult = (raw: unknown): unknown => {
   }
 }
 
+// Internal VM frames remain in the durable run but do not help the Agent repair its REPL request.
+const compactReplExecutionResult = (raw: unknown): unknown => {
+  const record = asRecord(raw)
+  if (!record) return raw
+
+  const conciseTraceback = (value: string): string => value.split(/\r?\n/, 1)[0] || value
+  const text = asRecord(record.text)
+  const outputs = Array.isArray(record.outputs)
+    ? record.outputs.map((value) => {
+        const output = asRecord(value)
+        return output?.type === 'error' && typeof output.traceback === 'string'
+          ? { ...output, traceback: conciseTraceback(output.traceback) }
+          : value
+      })
+    : record.outputs
+
+  return compactNotebookExecutionResult({
+    ...record,
+    ...(typeof record.traceback === 'string'
+      ? { traceback: conciseTraceback(record.traceback) }
+      : {}),
+    ...(text && typeof text.traceback === 'string'
+      ? { text: { ...text, traceback: conciseTraceback(text.traceback) } }
+      : {}),
+    ...(Array.isArray(record.outputs) ? { outputs } : {})
+  })
+}
+
 const compactStateRun = (
   value: unknown,
   includeOutputPreview: boolean,
@@ -1128,7 +1156,7 @@ const NOTEBOOK_RPC_TOOLS: NotebookRpcToolDefinition[] = [
     description: REPL_EXECUTE_DOC,
     method: 'executeControl',
     inputSchema: replExecuteToolSchema,
-    mapResult: compactNotebookExecutionResult,
+    mapResult: compactReplExecutionResult,
     includeViewImages: true,
     resultLimitChars: NOTEBOOK_MCP_EXECUTION_RESULT_LIMIT,
     progressMessage: 'Control-plane REPL execution is still running.'


### PR DESCRIPTION
## Problem

`repl_execute` returned the complete Node VM stack to the Agent for ordinary JavaScript failures. The response exposed internal `<repl>`, `node:vm`, and `resources/notebook/repl_loop.js` frames without helping the Agent correct the request.

## Proposed change

Use a REPL-specific agent-facing projection that keeps the actionable first error line and removes internal stack frames before the existing execution-result compactor runs. The durable Notebook run remains unchanged, so the full diagnostic is still available outside the immediate Agent reply.

## Scope and non-goals

- Applies only to the immediate `repl_execute` MCP result shared by all Agent frameworks.
- Keeps `notebook_execute` Python/R tracebacks and `bash_execute` diagnostics unchanged.
- Adds no dependencies, enum/status values, persistence changes, migrations, or historical-data compatibility behavior.

## Acceptance criteria and validation

Checks ran after the last material edit.

- REPL error projection (including SyntaxError preambles and multiline messages) and Python traceback preservation -> `npm test -- src/main/notebook/mcp-server.test.ts` -> 75 passed.
- Node contract -> `npm run typecheck:node` -> passed.
- Changed source and tests -> `npx eslint src/main/notebook/mcp-server.ts src/main/notebook/mcp-server.test.ts` -> passed.
- Formatting and whitespace -> `prettier` on both changed files plus `git diff --check` -> passed.

Local full `npm test` was intentionally not run. `mcp-server.ts` is not currently owned by a Module in `scripts/ci/module-impact.json`, so the local affected-test explainer selected no Module; exact-head PR Gate CI is the final authority and may fail closed to broader coverage. No local platform lane was included because this is a platform-independent string projection.

## Review focus

- The projection must not mutate the raw result that is persisted for Notebook history.
- Only the REPL tool should use the concise projection; Python/R and shell consumers must retain existing diagnostics.
