### PR TITLE
fix(notebook): show active runtime binding

### DIFF
--- a/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx
@@ -1090,7 +1090,8 @@ describe('NotebookPreview per-environment selector', () => {
   const mountWithRuns = async (
     runs: NotebookRunRecord[],
     environments: NotebookEnvironmentStatus[] = [],
-    executionEnvironments: NotebookSessionState['executionEnvironments'] = undefined
+    executionEnvironments: NotebookSessionState['executionEnvironments'] = undefined,
+    runtimeBindings: NotebookSessionState['runtimeBindings'] = undefined
   ): Promise<void> => {
     const readyStatus: ProvisionStatus = {
       pythonReady: true,
@@ -1142,7 +1143,8 @@ describe('NotebookPreview per-environment selector', () => {
             runs,
             recentRuns: runs,
             environments: liveEnvironments,
-            executionEnvironments
+            executionEnvironments,
+            runtimeBindings
           })
         ),
         execute: vi.fn(() => Promise.resolve({})),
@@ -1183,6 +1185,122 @@ describe('NotebookPreview per-environment selector', () => {
 
     expect(container.querySelector('[data-testid="env-selector"]')).toBeNull()
     expect(container.querySelectorAll('[data-testid="notebook-cell"]').length).toBe(2)
+    expect(container.querySelector('[data-testid="kernel-switcher-python"]')?.textContent).toBe(
+      'Python'
+    )
+  })
+
+  it('shows the current python runtime binding while keeping a single environment selector hidden', async () => {
+    await mountWithRuns(
+      [
+        makeRun({
+          runId: 'p1',
+          kernelKind: 'python',
+          environment: 'default-python'
+        })
+      ],
+      [],
+      { python: 'default-python', r: 'default-r' },
+      {
+        python: {
+          runtimeId: '/runtime/envs/pandas-demo2/bin/python',
+          language: 'python',
+          label: 'pandas-demo2',
+          source: 'external',
+          provenance: 'user-own',
+          interpreterPath: '/runtime/envs/pandas-demo2/bin/python',
+          version: 'Python 3.12.7',
+          status: 'active'
+        }
+      }
+    )
+
+    expect(container.querySelector('[data-testid="env-selector"]')).toBeNull()
+    expect(container.querySelector('[data-testid="kernel-switcher-python"]')?.textContent).toBe(
+      'Python'
+    )
+    const badge = container.querySelector<HTMLButtonElement>(
+      '[data-testid="notebook-runtime-binding"]'
+    )
+    expect(badge?.textContent).toBe('pandas-demo2')
+    expect(badge?.className).toContain('max-w-')
+    expect(badge?.querySelector('.truncate')).not.toBeNull()
+    fireEvent.focus(badge as HTMLButtonElement)
+    expect((await screen.findByRole('tooltip')).textContent).toBe('pandas-demo2 · Python 3.12.7')
+    expect(container.querySelector('[data-testid="notebook-cell"]')?.textContent).not.toContain(
+      'pandas-demo2'
+    )
+  })
+
+  it('shows the current R runtime binding on the R kernel tab', async () => {
+    await mountWithRuns(
+      [
+        makeRun({
+          runId: 'r1',
+          kernelKind: 'r',
+          environment: 'analysis'
+        })
+      ],
+      [],
+      { python: 'default-python', r: 'analysis' },
+      {
+        r: {
+          runtimeId: '/runtime/envs/renv-analysis/bin/R',
+          language: 'r',
+          label: 'renv-analysis',
+          source: 'managed',
+          provenance: 'agent-created',
+          interpreterPath: '/runtime/envs/renv-analysis/bin/R',
+          status: 'active'
+        }
+      }
+    )
+
+    expect(container.querySelector('[data-testid="kernel-switcher-r"]')?.textContent).toBe('R')
+    expect(container.querySelector('[data-testid="notebook-runtime-binding"]')?.textContent).toBe(
+      'renv-analysis'
+    )
+  })
+
+  it('does not apply data runtime bindings to Agent SDK or Bash tabs', async () => {
+    await mountWithRuns(
+      [makeRun({ runId: 'x1', kernelKind: 'repl' }), makeRun({ runId: 'b1', kernelKind: 'bash' })],
+      [],
+      undefined,
+      {
+        python: {
+          runtimeId: '/runtime/python',
+          language: 'python',
+          label: 'bound-python',
+          source: 'managed',
+          provenance: 'app-managed',
+          interpreterPath: '/runtime/python',
+          status: 'active'
+        },
+        r: {
+          runtimeId: '/runtime/R',
+          language: 'r',
+          label: 'bound-r',
+          source: 'managed',
+          provenance: 'app-managed',
+          interpreterPath: '/runtime/R',
+          status: 'active'
+        }
+      }
+    )
+
+    expect(container.querySelector('[data-testid="kernel-switcher-repl"]')?.textContent).toBe(
+      'Agent SDK'
+    )
+    expect(container.querySelector('[data-testid="kernel-switcher-bash"]')?.textContent).toBe(
+      'Bash'
+    )
+    expect(container.querySelector('[data-testid="notebook-runtime-binding"]')).toBeNull()
+
+    fireEvent.click(
+      container.querySelector('[data-testid="kernel-switcher-bash"]') as HTMLButtonElement
+    )
+    expect(container.querySelector('[data-testid="notebook-runtime-binding"]')).toBeNull()
   })
 
   it('submits through the current custom runtime binding even when its selector is hidden', async () => {

--- a/src/renderer/src/pages/workspace/NotebookPreview.tsx
+++ b/src/renderer/src/pages/workspace/NotebookPreview.tsx
@@ -464,6 +464,13 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
     ? activeKind
     : (visibleKinds[0] ?? 'python')
   const kindRuns = projectedRuns.filter((run) => resolveRunKernelKind(run) === effectiveActiveKind)
+  const activeRuntimeBinding =
+    effectiveActiveKind === 'python' || effectiveActiveKind === 'r'
+      ? notebookState?.runtimeBindings?.[effectiveActiveKind]
+      : undefined
+  const activeRuntimeDetails = activeRuntimeBinding
+    ? [activeRuntimeBinding.label, activeRuntimeBinding.version].filter(Boolean).join(' · ')
+    : undefined
 
   // Per-environment selector (design D6): only python/r are env-scoped. Distinct env names among
   // this kind's runs, canonical default first, so the selector (when shown) reads default-first.
@@ -750,6 +757,25 @@ const NotebookPreview = ({ item }: NotebookPreviewProps): React.JSX.Element => {
             )
           )}
         </div>
+        {activeRuntimeBinding && activeRuntimeDetails ? (
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={activeRuntimeDetails}
+                  className="ml-2 flex min-w-0 max-w-40 shrink-0 rounded-md bg-bg-300 px-2 py-1 text-[11px] text-text-200"
+                  data-testid="notebook-runtime-binding"
+                >
+                  <span className="min-w-0 truncate">{activeRuntimeBinding.label}</span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="max-w-[320px] break-words">
+                {activeRuntimeDetails}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : null}
       </header>
 
       {showEnvSelector ? (

--- a/src/shared/notebook.ts
+++ b/src/shared/notebook.ts
@@ -552,6 +552,9 @@ export type NotebookSessionState = {
   // Live execution target derived from each language's Session runtime binding. This is not
   // persisted; optional keeps older renderer/remote clients compatible.
   executionEnvironments?: Partial<Record<'python' | 'r', string>>
+  // Current per-language runtime bindings returned by state(); optional keeps older renderer and
+  // remote clients compatible. The binding itself is already persisted on NotebookRunDocument.
+  runtimeBindings?: NotebookRuntimeBindings
   // Present only when state() requested one Agent's complete-history discovery metadata.
   historySummary?: NotebookRunHistorySummary
   // Present on normal and cursor-paged renderer reads; omitted for sparse run-id/summary requests.


### PR DESCRIPTION
## Problem

After a Session binds a Python or R Runtime Environment, Notebook execution uses that binding but the preview does not identify the current execution target. The environment selector is intentionally hidden when only one environment exists, leaving no visible indication that code runs in a named or external runtime.

## Proposed change

- expose the already-returned per-language `runtimeBindings` on the optional renderer state contract
- show the active Python or R binding as a compact badge at the right side of the Notebook kernel header
- truncate long labels while preserving the full label and version in a hover/focus tooltip
- keep Python/R tabs compact and hide the badge for Agent SDK and Bash

## Scope and non-goals

- no database, `run.json`, migration, or persistence changes
- no changes to runtime binding, execution, switching, or environment filtering
- the badge describes the current execution target; it does not relabel historical Runs with the current binding

## Acceptance criteria and validation

The following checks ran after the final material edit:

- current binding visibility, single-environment behavior, R/Python behavior, historical Run isolation, and Agent SDK/Bash regression coverage → `npx vitest run src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx src/main/notebook/session-read-model.test.ts src/renderer/src/i18n/resources.test.ts` → 637 passed
- renderer contract compatibility → `npm run typecheck:web` → passed
- main/shared type compatibility → `npm run typecheck:node` → passed
- changed source lint and whitespace validation → targeted ESLint and `git diff --check` → passed

GitHub CI remains authoritative for the complete portable and platform-specific suites.

## Review focus

- whether the header badge clearly communicates the current binding without implying historical Run provenance
- optional state typing compatibility with older renderer and remote clients
- keyboard focus and truncation behavior for long runtime labels