### PR TITLE
test(app-shell): realign architecture consumers after host extraction

### DIFF
--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -10,6 +10,8 @@ const workspaceSidebarContainerPath = resolve(__dirname, 'WorkspaceSidebarContai
 const conversationPanelPath = resolve(__dirname, 'ConversationPanel.tsx')
 const permissionApprovalControlsPath = resolve(__dirname, 'PermissionApprovalControls.tsx')
 const appPath = resolve(__dirname, '../../App.tsx')
+const presentationHostPath = resolve(__dirname, '../../ApplicationPresentationHost.tsx')
+const applicationStartupPath = resolve(__dirname, '../../hooks/useApplicationStartup.ts')
 const workspaceMessageScrollerPath = resolve(__dirname, 'WorkspaceMessageScroller.tsx')
 const workspaceConversationTimelinePath = resolve(__dirname, 'workspace-conversation-timeline.ts')
 const workspaceActivityGroupPath = resolve(__dirname, 'WorkspaceActivityGroup.tsx')
@@ -102,17 +104,18 @@ describe('workspace page component boundaries', () => {
 
   it('starts session persistence from the app shell and passes readiness into the workspace', () => {
     const appSource = readFileSync(appPath, 'utf8')
+    const hostSource = readFileSync(presentationHostPath, 'utf8')
+    const startupSource = readFileSync(applicationStartupPath, 'utf8')
     const workspacePageSource = readFileSync(workspacePagePath, 'utf8')
     const workspaceSidebarSource = readFileSync(workspaceSidebarPath, 'utf8')
     const conversationPanelSource = readFileSync(conversationPanelPath, 'utf8')
 
-    // Persistence is hoisted to App so sessions stay loaded across Home <-> Workspace navigation.
-    expect(appSource).toContain(
-      "import { useSessionPersistence } from '@/lib/session-persistence/session-persistence'"
-    )
-    expect(appSource).toContain('const sessionPersistence = useSessionPersistence()')
-    expect(appSource).toContain('const isSessionPersistenceReady = sessionPersistence.isReady')
-    expect(appSource).toContain('isSessionPersistenceReady={isSessionPersistenceReady}')
+    // Persistence is hoisted to the app-shell startup owner so sessions stay loaded across Home <-> Workspace navigation.
+    expect(startupSource).toContain("from '@/lib/session-persistence/session-persistence'")
+    expect(startupSource).toContain('const sessions = useSessionPersistence()')
+    expect(hostSource).toContain('useApplicationStartup()')
+    expect(hostSource).toContain('isSessionPersistenceReady={sessions.isReady}')
+    expect(appSource).not.toContain('useSessionPersistence')
 
     expect(workspacePageSource).toContain('isSessionPersistenceReady')
     expect(workspacePageSource).toContain('isSessionPersistenceReady &&')

--- a/src/renderer/src/pages/workspace/workspace-page.architecture.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-page.architecture.test.ts
@@ -183,7 +183,7 @@ describe('workspace page architecture', () => {
       'pages/workspace/workspace-message-queue-owner.ts'
     ])
     expect(importersOf(ownerPaths.messageQueue)).toEqual([
-      'App.tsx',
+      'ApplicationPresentationHost.tsx',
       'pages/workspace/ComposerMessageQueue.tsx',
       'pages/workspace/workspace-conversation-controller.ts'
     ])
@@ -225,6 +225,7 @@ describe('workspace page architecture', () => {
     ])
     expect(importersOf(ownerPaths.sideChat)).toEqual([
       'App.tsx',
+      'hooks/useApplicationEventBindings.ts',
       'pages/workspace/ConversationPanel.tsx',
       'pages/workspace/SideChatPanel.tsx',
       'pages/workspace/WorkspacePage.tsx',

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -5252,12 +5252,12 @@ describe('session store public contract', () => {
 
   it('keeps production consumers on the public store facade', () => {
     expect(directConsumerPaths()).toEqual([
-      'src/renderer/src/App.tsx',
       'src/renderer/src/components/NotificationBell.tsx',
       'src/renderer/src/components/NotificationLiveToast.tsx',
       'src/renderer/src/components/global-search/GlobalSearchDialog.tsx',
       'src/renderer/src/components/job-binding-utils.ts',
       'src/renderer/src/components/notification-inbox-presentation.ts',
+      'src/renderer/src/hooks/useApplicationEventBindings.ts',
       'src/renderer/src/hooks/useLifecycleSync.ts',
       'src/renderer/src/hooks/useUnreadTaskViewSync.ts',
       'src/renderer/src/lib/acp/history-preamble.ts',


### PR DESCRIPTION
## Problem

PR #1670's fail-closed full macOS module shards exposed three renderer architecture assertion failures that are unrelated to the Notebook REPL error projection. They were introduced by #1669 (`refactor(app-shell): deepen renderer application orchestration`), which moved application orchestration out of `App.tsx` and skipped the full macOS module shards under its affected-test plan.

The assertions still expected `App.tsx` to own session persistence, session-store consumption, and the message-queue provider.

## Proposed change

Update the stale architecture invariants so they match the extracted app-shell ownership:

- Session-store production consumers: `App.tsx` → `hooks/useApplicationEventBindings.ts`
- Session persistence hoist: `useApplicationStartup` owns `useSessionPersistence()`, and `ApplicationPresentationHost` passes `isSessionPersistenceReady` into the workspace
- Message-queue controller consumers: `App.tsx` → `ApplicationPresentationHost.tsx`
- Side-chat controller consumers: keep `App.tsx` (`SideChatProvider`) and add `hooks/useApplicationEventBindings.ts`

No production runtime behavior changes.

## Scope and non-goals

- Test-only realignment of architecture/source-shape assertions.
- Does not reopen or amend #1670.
- Does not change REPL error projection, app-shell runtime wiring, or workspace page behavior.

### Historical data compatibility

None. No persisted documents, migrations, or on-disk formats are read or rewritten.

### New state / enum values

None. No status, kind, or other enumerated values are added.

### Data persistence

None. Session persistence ownership is already in `useApplicationStartup`; this PR only updates tests that still pointed at `App.tsx`.

## Acceptance criteria and validation

Checks ran after the last material edit.

- Architecture consumer and persistence-hoist assertions → `npx vitest run src/renderer/src/stores/session-store.test.ts src/renderer/src/pages/workspace/workspace-components.test.tsx src/renderer/src/pages/workspace/workspace-page.architecture.test.ts -t 'keeps production consumers on the public store facade|starts session persistence from the app shell|keeps private controller consumers explicit'` → 3 passed (205 skipped).
- App-shell presentation owner + App facade → `npx vitest run src/renderer/src/App.test.tsx src/renderer/src/app-shell-presentation-owner.architecture.test.ts` → 57 passed.
- workspace_page module → `npm run test:module -- workspace_page` → 25 files, 510 passed.
- session_renderer module → `npm run test:module -- session_renderer` → 4 files, 481 passed.
- Changed tests → `npx eslint` on the three files → no issues.
- Formatting → `npx prettier --write` on the three files → already formatted.

Local full `npm test` was intentionally not run. Exact-head PR Gate CI is the final authority. No platform lane was included because this is a platform-independent source-shape assertion update.

## Review focus

- Consumer lists should match the post-#1669 ownership: host/startup/event-bindings, not the thin `App.tsx` facade.
- `App.tsx` should still wrap `SideChatProvider`; persistence and store wiring must stay out of that facade.