### PR TITLE
fix(onboarding): prevent duplicate location submissions

### DIFF
--- a/src/renderer/src/pages/onboarding/LocationStep.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/LocationStep.render.test.tsx
@@ -8,6 +8,7 @@ import { LocationStep } from './LocationStep'
 import {
   clickButton,
   DEFAULT_DATA_ROOT,
+  findButton,
   resetOnboardingStores,
   storageInfo,
   stubWindowApi
@@ -150,6 +151,23 @@ describe('LocationStep', () => {
     expect(container.textContent).not.toContain('restart to set this up')
   })
 
+  it('starts only one directory picker while the first request is pending', async () => {
+    window.api.storage.pickDirectory = vi.fn().mockReturnValue(new Promise(() => undefined))
+    await renderStep()
+
+    const browseButton = findButton(/browse/i)
+    await act(async () => {
+      browseButton?.click()
+      browseButton?.click()
+      await Promise.resolve()
+    })
+
+    expect(window.api.storage.pickDirectory).toHaveBeenCalledTimes(1)
+    expect(browseButton?.disabled).toBe(true)
+    expect(findButton(/back/i)?.disabled).toBe(true)
+    expect(findButton(/finish/i)?.disabled).toBe(true)
+  })
+
   it('shows an inline error when browsing for a location rejects', async () => {
     window.api.storage.pickDirectory = vi
       .fn()
@@ -207,6 +225,22 @@ describe('LocationStep', () => {
     expect(useSettingsStore.getState().completeOnboarding).toHaveBeenCalledTimes(1)
     expect(window.api.storage.setDataRootAndRelaunch).not.toHaveBeenCalled()
     expect(document.body.querySelector('[role="alertdialog"]')).toBeNull()
+  })
+
+  it('starts only one default completion while the first request is pending', async () => {
+    const completeOnboarding = vi.fn().mockReturnValue(new Promise(() => undefined))
+    useSettingsStore.setState({ completeOnboarding })
+    await renderStep()
+
+    const finishButton = findButton(/finish/i)
+    await act(async () => {
+      finishButton?.click()
+      finishButton?.click()
+      await Promise.resolve()
+    })
+
+    expect(completeOnboarding).toHaveBeenCalledTimes(1)
+    expect(finishButton?.disabled).toBe(true)
   })
 
   it('a rejected default completion stays recoverable and shows the failure', async () => {
@@ -277,6 +311,28 @@ describe('LocationStep', () => {
     // The renderer-side gate must not flip before the main-process relaunch step: only main marks
     // onboarding complete now, inside set-data-root-and-relaunch, so this must never be called.
     expect(useSettingsStore.getState().completeOnboarding).not.toHaveBeenCalled()
+  })
+
+  it('starts only one confirmed relaunch while the first request is pending', async () => {
+    window.api.storage.pickDirectory = vi.fn().mockResolvedValue('/mnt/data')
+    window.api.storage.inspectDataRoot = vi
+      .fn()
+      .mockResolvedValue({ kind: 'move', dataRoot: '/mnt/data/OpenScience' })
+    window.api.storage.setDataRootAndRelaunch = vi
+      .fn()
+      .mockReturnValue(new Promise(() => undefined))
+    await renderStep()
+    await clickButton(/browse/i)
+    await clickButton(/finish/i)
+
+    const restartButton = findButton(/^restart$/i)
+    await act(async () => {
+      restartButton?.click()
+      restartButton?.click()
+      await Promise.resolve()
+    })
+
+    expect(window.api.storage.setDataRootAndRelaunch).toHaveBeenCalledTimes(1)
   })
 
   it('a setDataRootAndRelaunch failure shows the inline error and resets the relaunch flag', async () => {

--- a/src/renderer/src/pages/onboarding/LocationStep.tsx
+++ b/src/renderer/src/pages/onboarding/LocationStep.tsx
@@ -1,6 +1,6 @@
 import { X } from 'lucide-react'
 import { AlertDialog } from 'radix-ui'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
@@ -66,33 +66,52 @@ const LocationStep = ({
   const { chosenParent, chosenDataRoot, chosenKind } = locationDraft
   const [locationError, setLocationError] = useState<string | undefined>(undefined)
   const [confirmRestart, setConfirmRestart] = useState(false)
+  const requestInFlightRef = useRef(false)
+  const [requestInFlight, setRequestInFlight] = useState(false)
 
-  const handleBrowseLocation = async (): Promise<void> => {
-    setLocationError(undefined)
+  const runExclusive = async (request: () => Promise<void>): Promise<void> => {
+    if (requestInFlightRef.current) return
+
+    requestInFlightRef.current = true
+    setRequestInFlight(true)
     try {
-      const picked = await window.api.storage.pickDirectory()
-      if (!picked) return
-
-      const result = await window.api.storage.inspectDataRoot(picked)
-      if (result.kind !== 'move' && result.kind !== 'adopt') {
-        setLocationError(result.error ?? t('The selected folder is not usable.'))
-        return
-      }
-
-      onLocationDraftChange({
-        chosenParent: picked,
-        chosenDataRoot: result.dataRoot,
-        chosenKind: result.kind
-      })
-      onRelaunchErrorChange(undefined)
-    } catch (error) {
-      setLocationError(
-        onboardingErrorMessage(error, t('Could not choose the data location. Try again.'))
-      )
+      await request()
+    } finally {
+      requestInFlightRef.current = false
+      setRequestInFlight(false)
     }
   }
 
+  const handleBrowseLocation = async (): Promise<void> => {
+    await runExclusive(async () => {
+      setLocationError(undefined)
+      try {
+        const picked = await window.api.storage.pickDirectory()
+        if (!picked) return
+
+        const result = await window.api.storage.inspectDataRoot(picked)
+        if (result.kind !== 'move' && result.kind !== 'adopt') {
+          setLocationError(result.error ?? t('The selected folder is not usable.'))
+          return
+        }
+
+        onLocationDraftChange({
+          chosenParent: picked,
+          chosenDataRoot: result.dataRoot,
+          chosenKind: result.kind
+        })
+        onRelaunchErrorChange(undefined)
+      } catch (error) {
+        setLocationError(
+          onboardingErrorMessage(error, t('Could not choose the data location. Try again.'))
+        )
+      }
+    })
+  }
+
   const handleResetLocation = (): void => {
+    if (requestInFlightRef.current) return
+
     onLocationDraftChange({ chosenParent: '', chosenDataRoot: '', chosenKind: null })
     onRelaunchErrorChange(undefined)
     setLocationError(undefined)
@@ -110,6 +129,8 @@ const LocationStep = ({
   }
 
   const handleFinishLocation = async (): Promise<void> => {
+    if (requestInFlightRef.current) return
+
     if (chosenParent) {
       // A custom location was chosen: gate completeOnboarding behind the user's confirmation.
       // Calling completeOnboarding immediately would flip the App-level startup gate to 'app'
@@ -117,40 +138,44 @@ const LocationStep = ({
       setConfirmRestart(true)
     } else {
       // Default kept: nothing more to do, the App gate takes it from here — no relaunch.
-      await completeWithDefaultLocation()
+      await runExclusive(completeWithDefaultLocation)
     }
   }
 
   const handleKeepDefault = async (): Promise<void> => {
-    setConfirmRestart(false)
-    await completeWithDefaultLocation()
+    await runExclusive(async () => {
+      setConfirmRestart(false)
+      await completeWithDefaultLocation()
+    })
   }
 
   const handleRestart = async (): Promise<void> => {
-    setConfirmRestart(false)
-    onRelaunchErrorChange(undefined)
-    setIsRelaunching(true)
+    await runExclusive(async () => {
+      setConfirmRestart(false)
+      onRelaunchErrorChange(undefined)
+      setIsRelaunching(true)
 
-    // Deliberately NOT calling the renderer completeOnboarding() here: it flips
-    // onboardingCompletedAt immediately, which would make App.tsx's startup gate swap this
-    // wizard for Home (showing the OLD data root) before setDataRootAndRelaunch even runs, and
-    // would turn the failure branch below into dead code. Instead the main-process handler marks
-    // onboarding complete itself, in the same step as setDataRoot, right before it relaunches -
-    // so the gate only flips once the new location is actually persisted.
-    try {
-      const result = await window.api.storage.setDataRootAndRelaunch(chosenParent, true)
-      if (result.ok) return
+      // Deliberately NOT calling the renderer completeOnboarding() here: it flips
+      // onboardingCompletedAt immediately, which would make App.tsx's startup gate swap this
+      // wizard for Home (showing the OLD data root) before setDataRootAndRelaunch even runs, and
+      // would turn the failure branch below into dead code. Instead the main-process handler marks
+      // onboarding complete itself, in the same step as setDataRoot, right before it relaunches -
+      // so the gate only flips once the new location is actually persisted.
+      try {
+        const result = await window.api.storage.setDataRootAndRelaunch(chosenParent, true)
+        if (result.ok) return
 
-      // The app is not relaunching; the gate was never flipped, so we're still on the wizard -
-      // surface the error here and let the user retry or fall back to Keep default.
-      setIsRelaunching(false)
-      onRelaunchErrorChange(result.error ?? 'Could not restart to apply the new location.')
-    } catch (error) {
-      setIsRelaunching(false)
-      onRelaunchErrorChange(
-        onboardingErrorMessage(error, 'Could not restart to apply the new location.')
-      )
-    }
+        // The app is not relaunching; the gate was never flipped, so we're still on the wizard -
+        // surface the error here and let the user retry or fall back to Keep default.
+        setIsRelaunching(false)
+        onRelaunchErrorChange(result.error ?? 'Could not restart to apply the new location.')
+      } catch (error) {
+        setIsRelaunching(false)
+        onRelaunchErrorChange(
+          onboardingErrorMessage(error, 'Could not restart to apply the new location.')
+        )
+      }
+    })
   }
 
   return (
@@ -168,7 +193,11 @@ const LocationStep = ({
       <Separator className="bg-border-200" />
 
       <CardContent className="flex-1 px-4 py-5 sm:px-6">
-        <section aria-label={t('Choose data location')} className="space-y-5">
+        <section
+          aria-label={t('Choose data location')}
+          aria-busy={requestInFlight}
+          className="space-y-5"
+        >
           {dataRootError ? (
             <div
               className="flex flex-col gap-2 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive sm:flex-row sm:items-center sm:justify-between"
@@ -182,6 +211,7 @@ const LocationStep = ({
                 variant="link"
                 size="xs"
                 onClick={onRetryDataRootInfo}
+                disabled={requestInFlight}
                 className="h-auto self-start p-0 text-destructive hover:text-text-000 sm:self-auto"
               >
                 {t('Retry')}
@@ -211,6 +241,7 @@ const LocationStep = ({
               <button
                 type="button"
                 onClick={() => void handleBrowseLocation()}
+                disabled={requestInFlight}
                 className="inline-flex shrink-0 items-center justify-center rounded-lg border border-border-200 px-3 py-1.5 text-sm font-medium text-text-000 transition-colors hover:bg-bg-10"
               >
                 {t('Browse…')}
@@ -230,6 +261,7 @@ const LocationStep = ({
                       <button
                         type="button"
                         onClick={handleResetLocation}
+                        disabled={requestInFlight}
                         className="underline underline-offset-2 hover:text-text-000"
                       />
                     )
@@ -257,10 +289,15 @@ const LocationStep = ({
         </section>
       </CardContent>
       <CardFooter className="mt-auto justify-end gap-2 rounded-b-lg border-border-200 bg-bg-10 px-4 py-3 sm:px-6">
-        <Button type="button" variant="outline" onClick={onBack}>
+        <Button type="button" variant="outline" onClick={onBack} disabled={requestInFlight}>
           {t('Back', { context: 'step' })}
         </Button>
-        <Button type="button" onClick={() => void handleFinishLocation()} className="px-4">
+        <Button
+          type="button"
+          onClick={() => void handleFinishLocation()}
+          disabled={requestInFlight}
+          className="px-4"
+        >
           {t('Finish')}
         </Button>
       </CardFooter>
@@ -283,6 +320,7 @@ const LocationStep = ({
                   variant="ghost"
                   size="icon-sm"
                   aria-label={t('Close')}
+                  disabled={requestInFlight}
                   className={dialogCloseButtonClassName}
                 >
                   <X className="size-4" aria-hidden="true" />
@@ -302,12 +340,21 @@ const LocationStep = ({
 
             <div className={dialogFooterClassName}>
               <AlertDialog.Cancel asChild>
-                <Button type="button" variant="outline" onClick={() => void handleKeepDefault()}>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => void handleKeepDefault()}
+                  disabled={requestInFlight}
+                >
                   {t('Keep default')}
                 </Button>
               </AlertDialog.Cancel>
               <AlertDialog.Action asChild>
-                <Button type="button" onClick={() => void handleRestart()}>
+                <Button
+                  type="button"
+                  onClick={() => void handleRestart()}
+                  disabled={requestInFlight}
+                >
                   {t('Restart')}
                 </Button>
               </AlertDialog.Action>


### PR DESCRIPTION
## Problem

The final onboarding Location step accepted repeated Browse, Finish, and Restart actions while an earlier asynchronous request was still pending. The regression tests reproduced two calls for each path on the unmodified component.

## Proposed change

- Add one component-local, synchronous in-flight mutex shared by directory selection, default completion, and confirmed relaunch.
- Disable related navigation and location controls while a request is pending and expose the busy state to assistive technology.
- Release the mutex after cancellation or failure so the user can retry.
- Add public interaction regression coverage for all three request paths.

## Scope and non-goals

- No database or settings fields are added.
- No IPC contract, architecture, persisted data model, or data relationship changes.
- No new enum values and no historical-data compatibility work.
- Existing onboardingCompletedAt persistence semantics are unchanged.

## Acceptance criteria and validation

- Repeated directory selection while pending issues one picker request -> D:\projects\aipoch\open-science\node_modules\.bin\vitest.cmd run src/renderer/src/pages/onboarding/LocationStep.render.test.tsx -> passed (23/23).
- Repeated default completion while pending issues one store request -> same targeted test -> passed.
- Repeated confirmed relaunch while pending issues one storage IPC request -> same targeted test -> passed.
- Renderer types -> npm run typecheck:web -> passed.
- Lint -> npm run lint -> passed.

All listed checks ran after the last material edit. The project impact classifier maps these currently unowned onboarding files to the full Vitest plan; per maintainer direction, that complete suite was not run locally and PR Gate is authoritative.

## Review focus

Please focus on the synchronous ref guard closing the pre-render double-click window, the shared UI busy state, and release through finally after recoverable outcomes.