### PR TITLE
fix(undo): refine snackbar motion and elevation

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -398,6 +398,12 @@ colors communicate a successful or failed probe/migration result.
   contenteditable editors, IME composition, modified chords, and key repeat retain native behavior.
   Expired receipts never consume the shortcut, and Settings -> Archived remains the durable restore
   path after the transient receipt disappears.
+- Undo notices appear immediately at the top center, entering over 400ms with an 8px upward offset
+  and leaving over 280ms with a 6px upward offset. Animate only opacity and transform; reduced-motion
+  uses a 120ms opacity crossfade. Remaining notices reposition over 220ms when the stack changes.
+  Pause expiry while the notice has pointer hover or keyboard focus. Use the existing opaque popover
+  surface with `shadow-card` and no additional border, and keep the Undo action visually light rather
+  than presenting it as a filled primary button.
 - Session visibility, App Shell shortcut eligibility, and `Cmd/Ctrl+W` routing must consume that
   projection. Do not rebuild parallel Boolean gate lists in `AppContent` or feature components.
 - When a presentation above preview/base owns the shell, base content is `inert` and

--- a/src/renderer/src/components/PermissionUndoSnackbar.test.tsx
+++ b/src/renderer/src/components/PermissionUndoSnackbar.test.tsx
@@ -12,6 +12,14 @@ const PermissionUndoSnackbar = (): React.JSX.Element => (
   <PermissionUndoSnackbarComponent allowsArchiveShortcut={() => true} />
 )
 
+const expectSnackbarExiting = (container: HTMLElement, selector: string): void => {
+  const snackbar = container.querySelector(selector)
+  const presence = snackbar?.closest<HTMLElement>('[data-testid="undo-snackbar-presence"]')
+  expect(presence?.getAttribute('aria-hidden')).toBe('true')
+  expect(presence?.hasAttribute('inert')).toBe(true)
+  expect(presence?.style.pointerEvents).toBe('none')
+}
+
 const archivedProjectNotice = (
   id = 'project-1',
   archivedAt = 10,
@@ -34,6 +42,7 @@ describe('PermissionUndoSnackbar', () => {
   const updateProjectArchive = vi.fn()
 
   beforeEach(async () => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
     await i18next.changeLanguage('en')
     vi.useFakeTimers()
     container = document.createElement('div')
@@ -97,7 +106,7 @@ describe('PermissionUndoSnackbar', () => {
 
     expect(restore).toHaveBeenCalledOnce()
     expect(restore).toHaveBeenCalledWith({ undoToken: 'undo-1' })
-    expect(container.querySelector('[data-testid="permission-undo-snackbar"]')).toBeNull()
+    expectSnackbarExiting(container, '[data-undo-token="undo-1"]')
   })
 
   it('supports explicit dismiss and expiry after Settings has closed', async () => {
@@ -105,7 +114,7 @@ describe('PermissionUndoSnackbar', () => {
     await act(async () =>
       container.querySelector<HTMLButtonElement>('[aria-label="Dismiss permission Undo"]')?.click()
     )
-    expect(container.querySelector('[data-testid="permission-undo-snackbar"]')).toBeNull()
+    expectSnackbarExiting(container, '[data-undo-token="undo-1"]')
 
     await act(async () =>
       usePermissionGrantsStore.setState({
@@ -119,7 +128,7 @@ describe('PermissionUndoSnackbar', () => {
     expect(container.textContent).toContain('Revoked Python')
 
     await act(async () => vi.advanceTimersByTime(8_000))
-    expect(container.querySelector('[data-testid="permission-undo-snackbar"]')).toBeNull()
+    expectSnackbarExiting(container, '[data-undo-token="undo-2"]')
   })
 
   it('retranslates a permission notice when the language changes', async () => {
@@ -155,8 +164,9 @@ describe('PermissionUndoSnackbar', () => {
 
     const snackbar = container.querySelector<HTMLElement>('[data-testid="archive-undo-snackbar"]')
     expect(snackbar?.className).toContain('rounded-2xl')
-    expect(snackbar?.className).toContain('shadow-lg')
-    expect(snackbar?.className).not.toContain('shadow-xl')
+    expect(snackbar?.className).toContain('shadow-card')
+    expect(snackbar?.className).not.toContain('border-border')
+    expect(snackbar?.className).not.toContain('shadow-lg')
     // The notice carries a key plus params, so the interpolated text proves it is translated at
     // render time rather than frozen into the store when the project was archived.
     expect(snackbar?.textContent).toContain('Archived project “Project”.')
@@ -168,7 +178,7 @@ describe('PermissionUndoSnackbar', () => {
       archived: false,
       expectedArchivedAt: 10
     })
-    expect(container.querySelector('[data-testid="archive-undo-snackbar"]')).toBeNull()
+    expectSnackbarExiting(container, '[data-testid="archive-undo-snackbar"]')
   })
 
   it('shows the platform shortcut only on the latest Archive Undo action', async () => {
@@ -343,7 +353,7 @@ describe('PermissionUndoSnackbar', () => {
     await act(async () => vi.advanceTimersByTimeAsync(7_999))
     expect(container.querySelector('[data-testid="permission-undo-snackbar"]')).not.toBeNull()
     await act(async () => vi.advanceTimersByTimeAsync(1))
-    expect(container.querySelector('[data-testid="permission-undo-snackbar"]')).toBeNull()
+    expectSnackbarExiting(container, '[data-undo-token="undo-1"]')
   })
 
   it('dismisses the action when its authoritative receipt cannot be renewed', async () => {
@@ -355,7 +365,7 @@ describe('PermissionUndoSnackbar', () => {
 
     await act(async () => snackbar?.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })))
 
-    expect(container.querySelector('[data-testid="permission-undo-snackbar"]')).toBeNull()
+    expectSnackbarExiting(container, '[data-undo-token="undo-1"]')
   })
 
   it('locally pauses a non-restorable explanation without trying to renew a receipt', async () => {
@@ -379,7 +389,7 @@ describe('PermissionUndoSnackbar', () => {
 
     await act(async () => snackbar?.dispatchEvent(new MouseEvent('mouseout', { bubbles: true })))
     await act(async () => vi.advanceTimersByTime(0))
-    expect(container.querySelector('[data-testid="permission-undo-snackbar"]')).toBeNull()
+    expectSnackbarExiting(container, '[data-undo-token="undo-1"]')
   })
 
   it('renders every unexpired receipt as an independently operable Undo action', async () => {
@@ -418,7 +428,7 @@ describe('PermissionUndoSnackbar', () => {
     await act(async () => fourthUndo?.click())
 
     expect(restore).toHaveBeenCalledWith({ undoToken: 'undo-4' })
-    expect(container.querySelector('[data-undo-token="undo-4"]')).toBeNull()
+    expectSnackbarExiting(container, '[data-undo-token="undo-4"]')
     expect(container.querySelector('[data-undo-token="undo-1"]')).not.toBeNull()
   })
 

--- a/src/renderer/src/components/PermissionUndoSnackbar.tsx
+++ b/src/renderer/src/components/PermissionUndoSnackbar.tsx
@@ -1,5 +1,11 @@
-import { Archive, KeyRound, LoaderCircle, RotateCcw, X } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+/* Hallmark · pre-emit critique: P5 H4 E5 S5 R5 V4 */
+/* Hallmark · component: snackbar · genre: modern-minimal · theme: Open Science semantic tokens
+ * states: default · hover · focus · active · disabled · loading · error · success
+ * contrast: pass (46–50)
+ */
+import { Archive, KeyRound, LoaderCircle, X } from 'lucide-react'
+import { AnimatePresence, motion, useIsPresent, useReducedMotion } from 'motion/react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
@@ -11,6 +17,11 @@ import { useArchiveUndoStore, type ArchiveUndo } from '@/stores/archive-undo-sto
 const EDITABLE_SHORTCUT_TARGET =
   'input, textarea, select, [role="textbox"], [contenteditable]:not([contenteditable="false"])'
 
+const UNDO_ENTER_TRANSITION = { duration: 0.4, ease: [0.16, 1, 0.3, 1] } as const
+const UNDO_EXIT_TRANSITION = { duration: 0.28, ease: [0.7, 0, 0.84, 0] } as const
+const UNDO_LAYOUT_TRANSITION = { duration: 0.22, ease: [0.16, 1, 0.3, 1] } as const
+const UNDO_REDUCED_TRANSITION = { duration: 0.12, ease: 'linear' } as const
+
 const archiveUndoShortcut = (): { aria: string; label: string } =>
   window.api.platform === 'darwin'
     ? { aria: 'Meta+Z', label: '⌘Z' }
@@ -18,6 +29,35 @@ const archiveUndoShortcut = (): { aria: string; label: string } =>
 
 const isEditableShortcutTarget = (target: EventTarget | null): boolean =>
   target instanceof Element && target.closest(EDITABLE_SHORTCUT_TARGET) !== null
+
+const UndoItemPresence = ({ children }: { children: ReactNode }): React.JSX.Element => {
+  const isPresent = useIsPresent()
+  const shouldReduceMotion = useReducedMotion()
+
+  return (
+    <motion.div
+      data-testid="undo-snackbar-presence"
+      aria-hidden={isPresent ? undefined : true}
+      inert={isPresent ? undefined : true}
+      layout={shouldReduceMotion ? false : 'position'}
+      initial={{ opacity: 0, y: shouldReduceMotion ? 0 : -8 }}
+      animate={{
+        opacity: 1,
+        y: 0,
+        transition: shouldReduceMotion ? UNDO_REDUCED_TRANSITION : UNDO_ENTER_TRANSITION
+      }}
+      exit={{
+        opacity: 0,
+        y: shouldReduceMotion ? 0 : -6,
+        transition: shouldReduceMotion ? UNDO_REDUCED_TRANSITION : UNDO_EXIT_TRANSITION
+      }}
+      transition={{ layout: UNDO_LAYOUT_TRANSITION }}
+      style={{ pointerEvents: isPresent ? 'auto' : 'none' }}
+    >
+      {children}
+    </motion.div>
+  )
+}
 
 const PermissionUndoItem = ({
   undo,
@@ -88,7 +128,7 @@ const PermissionUndoItem = ({
       onKeyDown={(event) => {
         if (event.key === 'Escape') dismiss(undo.token)
       }}
-      className="pointer-events-auto flex max-w-[calc(100vw-2rem)] items-center gap-2 rounded-2xl border border-border/80 bg-popover px-3 py-2 text-sm text-popover-foreground shadow-lg shadow-black/10"
+      className="pointer-events-auto flex max-w-[calc(100vw-2rem)] items-center gap-2 rounded-2xl bg-popover px-3 py-2 text-sm text-popover-foreground shadow-card"
     >
       <KeyRound className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
       <span className="max-w-[min(28rem,55vw)] truncate">{t(undo.messageKey, messageParams)}</span>
@@ -97,7 +137,7 @@ const PermissionUndoItem = ({
           type="button"
           variant="ghost"
           size="sm"
-          className="relative ml-1 h-8 gap-1.5 whitespace-nowrap px-2 font-medium before:absolute before:-inset-y-1.5 before:inset-x-0 before:content-['']"
+          className="relative ml-1 h-8 whitespace-nowrap px-2 font-medium text-primary hover:text-primary before:absolute before:-inset-y-1.5 before:inset-x-0 before:content-['']"
           disabled={isRestoring}
           onClick={() => void restore(undo.token)}
         >
@@ -106,9 +146,7 @@ const PermissionUndoItem = ({
               className="size-4 animate-spin motion-reduce:animate-none"
               aria-hidden="true"
             />
-          ) : (
-            <RotateCcw className="size-4" aria-hidden="true" />
-          )}
+          ) : null}
           {isRestoring
             ? undo.retry
               ? t('Retrying…')
@@ -118,7 +156,7 @@ const PermissionUndoItem = ({
               : t('Undo')}
         </Button>
       ) : null}
-      <TooltipProvider delayDuration={200}>
+      <TooltipProvider delayDuration={800}>
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -181,7 +219,7 @@ const ArchiveUndoItem = ({
       onKeyDown={(event) => {
         if (event.key === 'Escape') dismiss(undo.key)
       }}
-      className="pointer-events-auto flex max-w-[calc(100vw-2rem)] items-center gap-2 rounded-2xl border border-border/80 bg-popover px-3 py-2 text-sm text-popover-foreground shadow-lg shadow-black/10"
+      className="pointer-events-auto flex max-w-[calc(100vw-2rem)] items-center gap-2 rounded-2xl bg-popover px-3 py-2 text-sm text-popover-foreground shadow-card"
     >
       <Archive className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
       <span className="max-w-[min(28rem,55vw)] truncate">
@@ -191,7 +229,7 @@ const ArchiveUndoItem = ({
         type="button"
         variant="ghost"
         size="sm"
-        className="relative ml-1 h-8 gap-1.5 whitespace-nowrap px-2 font-medium before:absolute before:-inset-y-1.5 before:inset-x-0 before:content-['']"
+        className="relative ml-1 h-8 whitespace-nowrap px-2 font-medium text-primary hover:text-primary before:absolute before:-inset-y-1.5 before:inset-x-0 before:content-['']"
         aria-keyshortcuts={isShortcutTarget ? shortcut.aria : undefined}
         disabled={isRestoring}
         onClick={() => void restore(undo.key)}
@@ -201,9 +239,7 @@ const ArchiveUndoItem = ({
             className="size-4 animate-spin motion-reduce:animate-none"
             aria-hidden="true"
           />
-        ) : (
-          <RotateCcw className="size-4" aria-hidden="true" />
-        )}
+        ) : null}
         {isRestoring
           ? undo.retry
             ? t('Retrying…')
@@ -220,7 +256,7 @@ const ArchiveUndoItem = ({
           </kbd>
         ) : null}
       </Button>
-      <TooltipProvider delayDuration={200}>
+      <TooltipProvider delayDuration={800}>
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -248,7 +284,7 @@ const PermissionUndoSnackbar = ({
   allowsArchiveShortcut
 }: {
   allowsArchiveShortcut: () => boolean
-}): React.JSX.Element | null => {
+}): React.JSX.Element => {
   const undo = usePermissionGrantsStore((state) => state.undo)
   const undoQueue = usePermissionGrantsStore((state) => state.undoQueue)
   const restore = usePermissionGrantsStore((state) => state.restore)
@@ -318,37 +354,39 @@ const PermissionUndoSnackbar = ({
     () => [undo, ...undoQueue].filter((item): item is PermissionUndo => Boolean(item)),
     [undo, undoQueue]
   )
-  if (items.length === 0 && archiveNotices.length === 0) return null
-
   // The shared stack sizes to its receipts; separate Permission and Archive domains only share this
   // app-root presentation shell, not their timeout or restore authority.
   return (
     <div
       aria-live="polite"
       data-testid="permission-undo-stack"
-      className="pointer-events-auto z-toast fixed top-[max(1.5rem,env(safe-area-inset-top))] left-1/2 max-h-[min(70svh,32rem)] -translate-x-1/2 overflow-y-auto overscroll-contain"
+      className="pointer-events-none z-toast fixed top-[max(1.5rem,env(safe-area-inset-top))] left-1/2 max-h-[min(70svh,32rem)] -translate-x-1/2 overflow-y-auto overscroll-contain"
     >
-      <div className="flex flex-col items-center gap-2 p-1 pr-3">
-        {items.map((item) => (
-          <PermissionUndoItem
-            key={item.token}
-            undo={item}
-            extend={extend}
-            restore={restore}
-            dismiss={dismiss}
-            isRestoring={isRestoring}
-          />
-        ))}
-        {archiveNotices.map((item) => (
-          <ArchiveUndoItem
-            key={item.key}
-            undo={item}
-            dismiss={dismissArchive}
-            restore={restoreArchive}
-            isRestoring={archiveRestoringKey === item.key}
-            isShortcutTarget={item.key === archiveShortcutTargetKey}
-          />
-        ))}
+      <div className="flex flex-col items-center gap-2 p-1">
+        <AnimatePresence>
+          {items.map((item) => (
+            <UndoItemPresence key={`permission:${item.token}`}>
+              <PermissionUndoItem
+                undo={item}
+                extend={extend}
+                restore={restore}
+                dismiss={dismiss}
+                isRestoring={isRestoring}
+              />
+            </UndoItemPresence>
+          ))}
+          {archiveNotices.map((item) => (
+            <UndoItemPresence key={`archive:${item.key}`}>
+              <ArchiveUndoItem
+                undo={item}
+                dismiss={dismissArchive}
+                restore={restoreArchive}
+                isRestoring={archiveRestoringKey === item.key}
+                isShortcutTarget={item.key === archiveShortcutTargetKey}
+              />
+            </UndoItemPresence>
+          ))}
+        </AnimatePresence>
       </div>
     </div>
   )


### PR DESCRIPTION
## Problem

Undo receipts appeared and disappeared abruptly, and their generic border plus heavy shadow made the transient surface feel visually detached from the rest of the app.

## Proposed change

- Animate receipt entry, exit, and stack repositioning with opacity/transform-only motion and a reduced-motion crossfade.
- Make exiting receipts immediately inert, hidden from assistive technology, and non-interactive while the visual transition completes.
- Use the existing `shadow-card` elevation, remove the extra border, simplify the Undo action, and use the standard delayed-hover tooltip timing.
- Preserve the existing 8-second receipt lifetime and hover/focus pause behavior.

## Scope and non-goals

- No changes to receipt stores, backend restore authority, shortcuts, or timeout duration.
- No data model, persisted format, migration, enum, user-visible copy, or dependency changes.
- No Electron-specific or platform-specific behavior changes.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Undo presentation and exit safety -> `npx vitest run src/renderer/src/components/PermissionUndoSnackbar.test.tsx src/renderer/src/stores/archive-undo-store.test.ts src/renderer/src/stores/permission-grants-store.test.ts` -> 35 tests passed.
- Renderer type safety -> `npm run typecheck:web` -> passed.
- Repository lint policy -> `npm run lint` -> passed.
- Responsive layout and interaction states -> authenticated Chromium component preview at 320, 375, 414, and 768 CSS px -> centered with 16px minimum side margins and no horizontal overflow; loading, focus, dark mode, reduced motion, 400ms entry, and 280ms exit were exercised.
- Dependency-aware classification -> `npm run test:affected:explain -- --base origin/main --head HEAD` -> selected the full CI plan because `docs/design.md` is intentionally outside a module owner. The full local Vitest suite was not run; exact-head PR CI remains authoritative for portable and platform coverage.

Local consumers are limited to the existing app-root snackbar host, and no component interface changed. Platform lanes are left to PR CI because the change uses renderer-only presentation primitives and semantic tokens.

## Review focus

- Motion pacing and reduced-motion behavior.
- Immediate loss of focus/pointer interaction during exit.
- Narrow-window truncation and action discoverability.
- Final Test Impact Set coverage; independent review remains required before marking the change verified.
