### PR TITLE
fix(workspace): link Codex resume errors to Agent settings

### DIFF
--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -4944,6 +4944,30 @@ describe('ConversationPanel error box + report affordance', () => {
     expect(openSettingsToPanel).toHaveBeenCalledWith('agent')
   })
 
+  it('opens Agent settings from an unsupported Codex ACP session resume failure', () => {
+    const openSettingsToPanel = vi.fn()
+    useSettingsStore.setState({ openSettingsToPanel })
+    renderPanel({
+      view: {
+        activeSession: {
+          ...errorSession,
+          status: 'idle',
+          interrupted: true,
+          error:
+            'Agent session resume failed: Codex ACP adapter 1.1.4 is no longer supported. Update to 1.6.2 or later in settings.'
+        }
+      }
+    })
+
+    expect(container.textContent).toContain('Agent session resume failed: Codex ACP adapter 1.1.4')
+    const button = Array.from(container.querySelectorAll('button')).find(
+      (candidate) => candidate.textContent === 'Agent settings'
+    )
+    expect(button).toBeDefined()
+    act(() => button?.click())
+    expect(openSettingsToPanel).toHaveBeenCalledWith('agent')
+  })
+
   it('shows both a transient actionError and the run failure, keeping the Report button', () => {
     // Both present: each error gets its own row, and the run failure keeps its report entry — a
     // transient error must not suppress the ability to report the actual failure.

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -4968,6 +4968,25 @@ describe('ConversationPanel error box + report affordance', () => {
     expect(openSettingsToPanel).toHaveBeenCalledWith('agent')
   })
 
+  it('keeps an unrelated session resume failure in the Resume banner', () => {
+    renderPanel({
+      view: {
+        activeSession: {
+          ...errorSession,
+          interrupted: true,
+          error: 'Agent session resume failed: connection reset'
+        }
+      }
+    })
+
+    expect(container.querySelector('[aria-label="Resume session"]')).not.toBeNull()
+    expect(
+      Array.from(container.querySelectorAll('button')).find(
+        (candidate) => candidate.textContent === 'Agent settings'
+      )
+    ).toBeUndefined()
+  })
+
   it('shows both a transient actionError and the run failure, keeping the Report button', () => {
     // Both present: each error gets its own row, and the run failure keeps its report entry — a
     // transient error must not suppress the ability to report the actual failure.

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -4951,7 +4951,6 @@ describe('ConversationPanel error box + report affordance', () => {
       view: {
         activeSession: {
           ...errorSession,
-          status: 'idle',
           interrupted: true,
           error:
             'Agent session resume failed: Codex ACP adapter 1.1.4 is no longer supported. Update to 1.6.2 or later in settings.'
@@ -4959,7 +4958,8 @@ describe('ConversationPanel error box + report affordance', () => {
       }
     })
 
-    expect(container.textContent).toContain('Agent session resume failed: Codex ACP adapter 1.1.4')
+    expect(errorBoxText()).toContain('Agent session resume failed: Codex ACP adapter 1.1.4')
+    expect(container.querySelector('[aria-label="Resume session"]')).toBeNull()
     const button = Array.from(container.querySelectorAll('button')).find(
       (candidate) => candidate.textContent === 'Agent settings'
     )

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -899,17 +899,12 @@ const ConversationPanel = ({
               <div className="px-1 md:px-3">
                 {/* Interrupted sessions get a neutral banner with a Resume action instead of the
                     red error box, so the user can re-attach and continue the interrupted turn. */}
-                {!sideChat && activeSession?.interrupted ? (
+                {!sideChat && activeSession?.interrupted && !hasUnsupportedCodexAcpRunError ? (
                   <SessionInterruptedBanner
                     message={activeSession.error ?? t('This session was interrupted.')}
                     isDisabled={!canResumeSession}
                     isResuming={isResuming}
                     onResume={() => void handleResume()}
-                    onOpenAgentSettings={
-                      hasUnsupportedCodexAcpRunError
-                        ? () => openSettingsToPanel('agent')
-                        : undefined
-                    }
                   />
                 ) : activeSession?.compacting ? (
                   // Auto-recovery after a request-size overflow: a neutral note, not the red error box,

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -905,6 +905,11 @@ const ConversationPanel = ({
                     isDisabled={!canResumeSession}
                     isResuming={isResuming}
                     onResume={() => void handleResume()}
+                    onOpenAgentSettings={
+                      hasUnsupportedCodexAcpRunError
+                        ? () => openSettingsToPanel('agent')
+                        : undefined
+                    }
                   />
                 ) : activeSession?.compacting ? (
                   // Auto-recovery after a request-size overflow: a neutral note, not the red error box,

--- a/src/renderer/src/pages/workspace/SessionInterruptedBanner.tsx
+++ b/src/renderer/src/pages/workspace/SessionInterruptedBanner.tsx
@@ -8,29 +8,42 @@ type SessionInterruptedBannerProps = {
   isDisabled: boolean
   isResuming: boolean
   onResume: () => void
+  onOpenAgentSettings?: () => void
 }
 
-const resumeButtonClassName =
+const actionButtonClassName =
   'gap-1.5 rounded-md text-[12px] text-text-000 hover:bg-bg-300 hover:text-text-000'
 
-// Neutral recovery banner for a session interrupted by an app restart. The Resume button re-attaches
-// the ACP runtime; while that request is in flight it is disabled so a second click cannot double-resume.
+// Neutral recovery banner for a session interrupted by an app restart. Resume re-attaches the ACP
+// runtime; recognized setup failures can also link to their Settings recovery surface.
 const SessionInterruptedBanner = ({
   message,
   isDisabled,
   isResuming,
-  onResume
+  onResume,
+  onOpenAgentSettings
 }: SessionInterruptedBannerProps): React.JSX.Element => {
   const { t } = useTranslation()
 
   return (
     <div className="mb-2 flex items-center gap-3 rounded-lg border border-border-200 bg-bg-200 px-3 py-2">
       <p className="min-w-0 flex-1 text-[12px] leading-5 text-text-100">{message}</p>
+      {onOpenAgentSettings ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className={actionButtonClassName}
+          onClick={onOpenAgentSettings}
+        >
+          {t('Agent settings')}
+        </Button>
+      ) : null}
       <Button
         type="button"
         variant="ghost"
         size="sm"
-        className={resumeButtonClassName}
+        className={actionButtonClassName}
         onClick={onResume}
         disabled={isDisabled || isResuming}
         aria-label={t('Resume session')}

--- a/src/renderer/src/pages/workspace/SessionInterruptedBanner.tsx
+++ b/src/renderer/src/pages/workspace/SessionInterruptedBanner.tsx
@@ -8,42 +8,29 @@ type SessionInterruptedBannerProps = {
   isDisabled: boolean
   isResuming: boolean
   onResume: () => void
-  onOpenAgentSettings?: () => void
 }
 
-const actionButtonClassName =
+const resumeButtonClassName =
   'gap-1.5 rounded-md text-[12px] text-text-000 hover:bg-bg-300 hover:text-text-000'
 
-// Neutral recovery banner for a session interrupted by an app restart. Resume re-attaches the ACP
-// runtime; recognized setup failures can also link to their Settings recovery surface.
+// Neutral recovery banner for a session interrupted by an app restart. The Resume button re-attaches
+// the ACP runtime; while that request is in flight it is disabled so a second click cannot double-resume.
 const SessionInterruptedBanner = ({
   message,
   isDisabled,
   isResuming,
-  onResume,
-  onOpenAgentSettings
+  onResume
 }: SessionInterruptedBannerProps): React.JSX.Element => {
   const { t } = useTranslation()
 
   return (
     <div className="mb-2 flex items-center gap-3 rounded-lg border border-border-200 bg-bg-200 px-3 py-2">
       <p className="min-w-0 flex-1 text-[12px] leading-5 text-text-100">{message}</p>
-      {onOpenAgentSettings ? (
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className={actionButtonClassName}
-          onClick={onOpenAgentSettings}
-        >
-          {t('Agent settings')}
-        </Button>
-      ) : null}
       <Button
         type="button"
         variant="ghost"
         size="sm"
-        className={actionButtonClassName}
+        className={resumeButtonClassName}
         onClick={onResume}
         disabled={isDisabled || isResuming}
         aria-label={t('Resume session')}

--- a/src/shared/codex-runtime.ts
+++ b/src/shared/codex-runtime.ts
@@ -14,8 +14,9 @@ const CODEX_ACP_UNSUPPORTED_VERSION_SUFFIX = ` is no longer supported. Update to
 export const buildUnsupportedCodexAcpVersionMessage = (installedVersion: string): string =>
   `${CODEX_ACP_UNSUPPORTED_VERSION_PREFIX}${installedVersion}${CODEX_ACP_UNSUPPORTED_VERSION_SUFFIX}`
 
-// Recognizes only the app-authored version guidance, either directly or after Electron wraps it.
-// The installed version varies, so validate the fixed prefix/suffix and require one version token.
+// Recognizes only the app-authored version guidance, either directly or after Electron or the
+// Session resume flow wraps it. The installed version varies, so validate the fixed prefix/suffix
+// and require one version token.
 export const isUnsupportedCodexAcpVersionError = (error: string | null | undefined): boolean => {
   const message = error?.trim()
   if (!message?.endsWith(CODEX_ACP_UNSUPPORTED_VERSION_SUFFIX)) return false
@@ -30,5 +31,9 @@ export const isUnsupportedCodexAcpVersionError = (error: string | null | undefin
   if (!version || /\s/.test(version)) return false
 
   const wrapper = message.slice(0, start)
-  return wrapper === '' || wrapper.endsWith('Error: ')
+  return (
+    wrapper === '' ||
+    wrapper.endsWith('Error: ') ||
+    wrapper.endsWith('Agent session resume failed: ')
+  )
 }

--- a/src/shared/run-error-classification.test.ts
+++ b/src/shared/run-error-classification.test.ts
@@ -149,9 +149,11 @@ describe('isReportableRunFailure (text tier)', () => {
   it('does not report an unsupported Codex ACP version', () => {
     const message = buildUnsupportedCodexAcpVersionMessage('1.1.4')
     const wrapped = `Error invoking remote method 'acp:create-session': Error: ${message}`
+    const resumeWrapped = `Agent session resume failed: ${message}`
 
     expect(isReportableRunFailure(message)).toBe(false)
     expect(isReportableRunFailure(wrapped)).toBe(false)
+    expect(isReportableRunFailure(resumeWrapped)).toBe(false)
   })
 
   it('recognizes the framework-specific model-incompat message built by service.ts (prefix)', () => {


### PR DESCRIPTION
## Problem

When resuming an interrupted Codex session with an unsupported ACP adapter, the resume flow wraps the actionable version error as `Agent session resume failed: ...`. The existing classifier did not recognize that wrapper, and the interrupted-session banner exposed only **Resume**, leaving users without a direct route to the Agent settings that can repair the adapter.

## Proposed change

- Recognize the existing unsupported-Codex-version guidance when it is wrapped by the session resume flow.
- Route that recognized failure through the existing composer error notice used by Vision model setup errors, with **Agent settings** navigating directly to Settings > Agent.
- Do not offer **Resume** for this non-retryable setup failure; preserve the interrupted-session banner and **Resume** behavior for unrelated interruptions.

## Scope and non-goals

- No ACP methods, wire shapes, protocol translation, lifecycle events, session routing, permissions, elicitations, or subscriptions change.
- The `codex-responses` and `codex-bridge` routes share the Codex adapter preflight that can produce this exact error, so both receive the same renderer recovery action.
- `claude-code` and `opencode` cannot produce the exact Codex adapter version guidance and remain unchanged.
- No model-specific or platform-specific behavior changes; the recovery action uses the shared renderer Settings navigation on Electron, local Web, and remote Web surfaces.
- No historical data compatibility handling is required.
- No enum or persisted status value is added.
- No persistence format, schema, or migration changes.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Unsupported Codex ACP resume wrapper classification -> `npm test -- src/shared/run-error-classification.test.ts src/renderer/src/pages/workspace/SessionInterruptedBanner.test.tsx src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx` -> passed (3 files, 137 tests)
- Composer error-notice navigation to Settings > Agent, without a Resume action -> same targeted command -> passed
- Renderer translations and existing `Agent settings` catalog coverage -> `npx vitest run src/renderer/src/i18n/resources.test.ts` -> passed (590 tests)
- Renderer/shared type safety -> `npm run typecheck:web` -> passed
- Source lint -> `npm run lint` -> passed
- Changed-file formatting -> `npx prettier --check src/shared/codex-runtime.ts src/shared/run-error-classification.test.ts src/renderer/src/pages/workspace/SessionInterruptedBanner.tsx src/renderer/src/pages/workspace/ConversationPanel.tsx src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx` -> passed

The complete portable and platform suites were intentionally left to PR CI, per maintainer direction. No uncovered local risk was identified beyond visual behavior across CI/platform surfaces.

## Review focus

- The classifier remains fail-closed to the app-authored fixed prefix/suffix and a single version token.
- The recognized error reuses the existing red composer warning; the neutral interrupted-session banner remains unchanged.
