### PR TITLE
test(notebook): use platform-aware interpreter paths in runtime target tests

### DIFF
--- a/src/main/notebook/environment-management.test.ts
+++ b/src/main/notebook/environment-management.test.ts
@@ -6,7 +6,7 @@ import {
   NotebookEnvironmentManagementOwner,
   type NotebookEnvironmentManager
 } from './environment-management'
-import { envPrefix } from './runtime-paths'
+import { envPrefix, pythonBin } from './runtime-paths'
 
 type OwnerOptions = ConstructorParameters<typeof NotebookEnvironmentManagementOwner>[0]
 type EnvironmentSession =
@@ -33,15 +33,17 @@ const session = (
   runtimeBindingEntries: () => bindings
 })
 
+const managedPythonRuntimeId = (name: string): string => pythonBin(envPrefix('/runtime', name))
+
 const runtimeBinding = (
   name: string,
   overrides: Partial<NotebookSessionRuntimeBinding> = {}
 ): NotebookSessionRuntimeBinding => ({
   language: 'python',
-  runtimeId: `/runtime/envs/${name}/bin/python`,
+  runtimeId: managedPythonRuntimeId(name),
   source: 'managed',
   provenance: 'agent-created',
-  interpreterPath: `/runtime/envs/${name}/bin/python`,
+  interpreterPath: managedPythonRuntimeId(name),
   label: name,
   envName: name,
   ...overrides
@@ -139,7 +141,7 @@ describe('NotebookEnvironmentManagementOwner', () => {
       created: {
         name: 'analysis',
         language: 'python',
-        runtimeId: '/runtime/envs/analysis/bin/python',
+        runtimeId: managedPythonRuntimeId('analysis'),
         runnable: true
       }
     })

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -5617,8 +5617,8 @@ describe('notebook runtime service', () => {
       const runtimeRoot = getRuntimeRoot(root)
       const envName = 'shared-analysis'
       const prefix = envPrefix(runtimeRoot, envName)
-      const namedPython = join(prefix, 'bin', 'python')
-      const namedR = join(prefix, 'bin', 'R')
+      const namedPython = pythonBin(prefix)
+      const namedR = rBin(prefix)
       const terminate = vi.fn(async () => undefined)
       const execute = vi.fn(async (): Promise<NotebookExecutionResult> => {
         throw new Error('a repair-blocked shared prefix must not execute')
@@ -6308,7 +6308,7 @@ describe('notebook runtime service', () => {
       let releaseInstall: (() => void) | undefined
       // v4: a session runs ONE env per language, so "different envs" now means different SESSIONS —
       // an installer session bound to a named env vs a runner session on the app-managed default.
-      const namedPy = join(root, 'runtime', 'envs', 'my-analysis', 'bin', 'python')
+      const namedPy = pythonBin(envPrefix(getRuntimeRoot(root), 'my-analysis'))
       const service = new NotebookRuntimeService({
         configRoot: root,
         dataRoot: root,
@@ -6554,8 +6554,8 @@ describe('notebook runtime service', () => {
                 {
                   language: 'python',
                   provenance: 'agent-created',
-                  envId: join(root, 'runtime', 'envs', 'my-analysis', 'bin', 'python'),
-                  interpreterPath: join(root, 'runtime', 'envs', 'my-analysis', 'bin', 'python'),
+                  envId: pythonBin(envPrefix(getRuntimeRoot(root), 'my-analysis')),
+                  interpreterPath: pythonBin(envPrefix(getRuntimeRoot(root), 'my-analysis')),
                   label: 'my-analysis',
                   condaEnv: 'my-analysis',
                   version: '3.12',
@@ -6595,7 +6595,7 @@ describe('notebook runtime service', () => {
         sessionId: 's',
         workspaceCwd: root,
         language: 'python',
-        runtimeId: join(root, 'runtime', 'envs', 'my-analysis', 'bin', 'python')
+        runtimeId: pythonBin(envPrefix(getRuntimeRoot(root), 'my-analysis'))
       })
       await service.execute({ sessionId: 's', workspaceCwd: root, code: '1', language: 'python' })
 
@@ -7057,7 +7057,7 @@ describe('v4 runtime bindings & agent tools', () => {
     // gate must not fire.
     const root = await createStorageRoot()
     const executions: NotebookExecutionRequest[] = []
-    const namedPyId = join(root, 'runtime', 'envs', 'my-analysis', 'bin', 'python')
+    const namedPyId = pythonBin(envPrefix(getRuntimeRoot(root), 'my-analysis'))
     const defaultPyId = pythonBin(envPrefix(getRuntimeRoot(root), DEFAULT_PY_ENV))
     const namedEnv: DiscoveredInterpreter = {
       language: 'python',
@@ -7742,8 +7742,8 @@ describe('v4 runtime bindings & agent tools', () => {
     const namedRuntime = (name: string): DiscoveredInterpreter => ({
       language: 'python',
       provenance: 'agent-created',
-      envId: join(runtimeRoot, 'envs', name, 'bin', 'python'),
-      interpreterPath: join(runtimeRoot, 'envs', name, 'bin', 'python'),
+      envId: pythonBin(envPrefix(runtimeRoot, name)),
+      interpreterPath: pythonBin(envPrefix(runtimeRoot, name)),
       label: name,
       condaEnv: name,
       version: '3.12',
@@ -7967,7 +7967,7 @@ describe('v4 runtime bindings & agent tools', () => {
     // external branch, so it never covered the managed gate).
     const root = await createStorageRoot()
     let installRan = false
-    const namedPyId = join(root, 'runtime', 'envs', 'my-analysis', 'bin', 'python')
+    const namedPyId = pythonBin(envPrefix(getRuntimeRoot(root), 'my-analysis'))
     const namedEnv: DiscoveredInterpreter = {
       language: 'python',
       provenance: 'agent-created',
@@ -8812,8 +8812,8 @@ describe('v4 runtime bindings & agent tools', () => {
     const namedPython: DiscoveredInterpreter = {
       language: 'python',
       provenance: 'agent-created',
-      envId: join(prefix, 'bin', 'python'),
-      interpreterPath: join(prefix, 'bin', 'python'),
+      envId: pythonBin(prefix),
+      interpreterPath: pythonBin(prefix),
       label: envName,
       condaEnv: envName,
       version: '3.12',
@@ -8822,8 +8822,8 @@ describe('v4 runtime bindings & agent tools', () => {
     const namedR: DiscoveredInterpreter = {
       language: 'r',
       provenance: 'agent-created',
-      envId: join(prefix, 'bin', 'R'),
-      interpreterPath: join(prefix, 'bin', 'R'),
+      envId: rBin(prefix),
+      interpreterPath: rBin(prefix),
       label: envName,
       condaEnv: envName,
       version: '4.4.3',
@@ -8995,8 +8995,8 @@ describe('v4 runtime bindings & agent tools', () => {
     const namedR: DiscoveredInterpreter = {
       language: 'r',
       provenance: 'agent-created',
-      envId: join(prefix, 'bin', 'R'),
-      interpreterPath: join(prefix, 'bin', 'R'),
+      envId: rBin(prefix),
+      interpreterPath: rBin(prefix),
       label: envName,
       condaEnv: envName,
       version: '4.4.3',


### PR DESCRIPTION
## Problem

Windows Full Test on `main` failed after #1671 because managed runtime target tests hardcoded POSIX interpreter paths. Production receipts use `pythonBin()` / `rBin()`, which resolve to `<prefix>\python.exe` and `<prefix>\Lib\R\bin\R.exe` on Windows.

Observed on [Windows Full Test](https://github.com/aipoch/open-science/actions/runs/32733707290):

- `environment-management.test.ts` expected `/runtime/envs/analysis/bin/python`, received `\runtime\envs\analysis\python.exe`
- `runtime-service.test.ts` expected `Lib\R\bin\R.exe`, received `bin\R` from a POSIX bind fixture

## Proposed change

Replace POSIX `bin/python` and `bin/R` fixtures with the same `pythonBin()` / `rBin()` helpers production uses, so expected runtime IDs match the current platform.

## Scope and non-goals

- Test-only. No production path resolution, binding, or receipt changes.
- Does not canonicalize persisted Session runtime bindings.
- Does not change Windows conda layout helpers themselves.

## Acceptance criteria and validation

- Create receipts and shared-prefix package-failure receipts use platform-aware interpreter IDs.
- Other named managed-env fixtures in `runtime-service.test.ts` use the same helpers so later receipt assertions do not reintroduce POSIX-only IDs.

Validation after the last material edit:

- managed create receipt matches `pythonBin(envPrefix(...))` on the current platform -> `npm test -- src/main/notebook/environment-management.test.ts` -> 13/13 passed
- shared-prefix quarantine and named managed-env binding fixtures stay internally consistent -> `npm test -- src/main/notebook/runtime-service.test.ts` -> 224/224 passed
- lint of the two test files -> `npx eslint src/main/notebook/environment-management.test.ts src/main/notebook/runtime-service.test.ts` -> no issues

Windows Full Test / PR Gate remain the authority for the win32 interpreter layout. Local checks ran on macOS, where `pythonBin`/`rBin` still return POSIX paths.

Uncovered risks: this host cannot execute the Windows interpreter-layout assertions locally.

## Review focus

- Fixtures for managed environments should go through `pythonBin`/`rBin` rather than `join(..., 'bin', ...)`.
- Confirm production still prefers a bound `runtimeId` when present (`runtimeTargetReceipt`); this PR does not change that.