### PR TITLE
ci(package-smoke): use GitHub Electron mirrors on Actions

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -2,17 +2,52 @@ name: Package Smoke
 
 # Blocking native-package certification. Each matrix leg downloads the exact artifact produced by
 # build.yml, so a failed smoke can be retried without rebuilding or re-signing any package.
+#
+# A manual dispatch with install_only reuses this exact job, runner, and npm ci path without
+# downloading artifacts or publishing anything. Use that to certify Electron mirror resolution.
 on:
   workflow_call:
+    inputs:
+      install_only:
+        description: Skip artifact download and package execution; only install dependencies
+        type: boolean
+        required: false
+        default: false
+      platform_name:
+        description: Limit the smoke matrix to one platform name, or empty for every platform
+        type: string
+        required: false
+        default: ''
+  workflow_dispatch:
+    inputs:
+      install_only:
+        description: Skip artifact download and package execution; only install dependencies
+        type: boolean
+        default: true
+      platform_name:
+        description: Platform to install on
+        type: choice
+        default: macos-x64
+        options:
+          - macos-x64
+          - macos-arm64
+          - linux-x64
+          - windows-x64
+          - all
 
 permissions:
   contents: read
+
+concurrency:
+  group: package-smoke-${{ github.workflow }}-${{ github.ref }}-${{ inputs.platform_name || 'all' }}
+  cancel-in-progress: true
 
 jobs:
   smoke:
     name: Smoke ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    if: ${{ inputs.platform_name == '' || inputs.platform_name == 'all' || matrix.name == inputs.platform_name }}
     strategy:
       fail-fast: false
       matrix:
@@ -40,26 +75,27 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci.mjs
 
       - name: Download packaged artifacts
+        if: ${{ !inputs.install_only }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ matrix.name }}
           path: dist
 
       - name: Smoke test macOS packages
-        if: matrix.platform == 'mac'
+        if: ${{ !inputs.install_only && matrix.platform == 'mac' }}
         timeout-minutes: 10
         run: node scripts/macos-package-smoke.mjs --artifact-dir dist
 
       - name: Smoke test Windows installer
-        if: matrix.platform == 'win'
+        if: ${{ !inputs.install_only && matrix.platform == 'win' }}
         timeout-minutes: 10
         run: node scripts/windows-installer-smoke.mjs --installer-dir dist
 
       - name: Smoke test Linux packages
-        if: matrix.platform == 'linux'
+        if: ${{ !inputs.install_only && matrix.platform == 'linux' }}
         timeout-minutes: 10
         shell: bash
         run: |
@@ -70,6 +106,7 @@ jobs:
             --installed-executable /usr/bin/open-science
 
       - name: Record platform certification evidence
+        if: ${{ !inputs.install_only }}
         shell: bash
         run: |
           database_certification="dist/database-migration-certification-${{ matrix.name }}.json"
@@ -89,6 +126,7 @@ jobs:
             --authenticode "$authenticode"
 
       - name: Upload platform certification evidence
+        if: ${{ !inputs.install_only }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: certification-${{ matrix.name }}

--- a/scripts/ci/npm-ci.mjs
+++ b/scripts/ci/npm-ci.mjs
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Official GitHub artifact URLs. Project .npmrc pins npmmirror.com for local installs; GitHub-hosted
+// runners cannot always resolve that host (`getaddrinfo ENOTFOUND npmmirror.com`).
+export const GITHUB_ELECTRON_MIRROR = 'https://github.com/electron/electron/releases/download/'
+export const GITHUB_ELECTRON_BUILDER_BINARIES_MIRROR =
+  'https://github.com/electron-userland/electron-builder-binaries/releases/download/'
+
+export function shouldForceGitHubElectronMirrors(env = process.env) {
+  return env.GITHUB_ACTIONS === 'true'
+}
+
+export function githubElectronMirrorEnv(env = process.env) {
+  return {
+    ...env,
+    npm_config_electron_mirror: GITHUB_ELECTRON_MIRROR,
+    npm_config_electron_builder_binaries_mirror: GITHUB_ELECTRON_BUILDER_BINARIES_MIRROR,
+    ELECTRON_MIRROR: GITHUB_ELECTRON_MIRROR,
+    ELECTRON_BUILDER_BINARIES_MIRROR: GITHUB_ELECTRON_BUILDER_BINARIES_MIRROR
+  }
+}
+
+export function npmCiEnv(env = process.env) {
+  return shouldForceGitHubElectronMirrors(env) ? githubElectronMirrorEnv(env) : { ...env }
+}
+
+export function npmCiCommand(platform = process.platform) {
+  return platform === 'win32' ? 'npm.cmd' : 'npm'
+}
+
+export function runNpmCi({
+  args = process.argv.slice(2),
+  env = process.env,
+  platform = process.platform,
+  spawn = spawnSync
+} = {}) {
+  const result = spawn(npmCiCommand(platform), ['ci', ...args], {
+    env: npmCiEnv(env),
+    stdio: 'inherit',
+    shell: platform === 'win32'
+  })
+  return result.status ?? 1
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exit(runNpmCi())
+}

--- a/scripts/ci/npm-ci.test.ts
+++ b/scripts/ci/npm-ci.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  GITHUB_ELECTRON_BUILDER_BINARIES_MIRROR,
+  GITHUB_ELECTRON_MIRROR,
+  npmCiCommand,
+  npmCiEnv,
+  runNpmCi,
+  shouldForceGitHubElectronMirrors
+} from './npm-ci.mjs'
+
+describe('npm ci Electron mirror policy', () => {
+  it('forces GitHub Electron artifact URLs on GitHub Actions', () => {
+    const env = npmCiEnv({
+      GITHUB_ACTIONS: 'true',
+      npm_config_electron_mirror: 'https://npmmirror.com/mirrors/electron/',
+      PATH: '/usr/bin'
+    })
+
+    expect(shouldForceGitHubElectronMirrors({ GITHUB_ACTIONS: 'true' })).toBe(true)
+    expect(env.npm_config_electron_mirror).toBe(GITHUB_ELECTRON_MIRROR)
+    expect(env.npm_config_electron_builder_binaries_mirror).toBe(
+      GITHUB_ELECTRON_BUILDER_BINARIES_MIRROR
+    )
+    expect(env.ELECTRON_MIRROR).toBe(GITHUB_ELECTRON_MIRROR)
+    expect(env.ELECTRON_BUILDER_BINARIES_MIRROR).toBe(GITHUB_ELECTRON_BUILDER_BINARIES_MIRROR)
+    expect(env.PATH).toBe('/usr/bin')
+  })
+
+  it('leaves local installs on the repository npmmirror pin', () => {
+    const env = npmCiEnv({
+      npm_config_electron_mirror: 'https://npmmirror.com/mirrors/electron/',
+      PATH: '/usr/bin'
+    })
+
+    expect(shouldForceGitHubElectronMirrors({})).toBe(false)
+    expect(env.npm_config_electron_mirror).toBe('https://npmmirror.com/mirrors/electron/')
+    expect(env.ELECTRON_MIRROR).toBeUndefined()
+  })
+
+  it('runs npm ci with the resolved environment and platform command', () => {
+    const spawn = vi.fn(() => ({ status: 0 }))
+
+    expect(
+      runNpmCi({
+        args: ['--no-audit'],
+        env: { GITHUB_ACTIONS: 'true' },
+        platform: 'linux',
+        spawn
+      })
+    ).toBe(0)
+    expect(npmCiCommand('linux')).toBe('npm')
+    expect(npmCiCommand('win32')).toBe('npm.cmd')
+    expect(spawn).toHaveBeenCalledWith(
+      'npm',
+      ['ci', '--no-audit'],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          npm_config_electron_mirror: GITHUB_ELECTRON_MIRROR
+        }),
+        shell: false,
+        stdio: 'inherit'
+      })
+    )
+  })
+})

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -31,6 +31,7 @@ type WorkflowJob = {
 }
 
 type Workflow = {
+  concurrency?: { 'cancel-in-progress'?: boolean; group?: string }
   jobs: Record<string, WorkflowJob>
   permissions?: Record<string, string>
   on?: {
@@ -40,7 +41,9 @@ type Workflow = {
     workflow_call?: {
       inputs?: Record<string, { default?: unknown; description?: string; type?: string }>
     }
-    workflow_dispatch?: unknown
+    workflow_dispatch?: {
+      inputs?: Record<string, { default?: unknown; options?: string[]; type?: string }>
+    }
   }
 }
 
@@ -93,9 +96,47 @@ describe('post-merge Windows validation', () => {
     const smoke = findStep(job, 'Smoke test Windows installer')
 
     expect(job['continue-on-error']).toBeUndefined()
-    expect(smoke.if).toBe("matrix.platform == 'win'")
+    expect(smoke.if).toBe("${{ !inputs.install_only && matrix.platform == 'win' }}")
     expect(smoke.run).toBe('node scripts/windows-installer-smoke.mjs --installer-dir dist')
     expect(smoke['timeout-minutes']).toBe(10)
+  })
+
+  it('installs Electron from GitHub mirrors and exposes an install-only dry-run', () => {
+    const smokeWorkflow = readWorkflow('package-smoke.yml')
+    const job = smokeWorkflow.jobs.smoke
+    const install = findStep(job, 'Install dependencies')
+    const download = findStep(job, 'Download packaged artifacts')
+    const linux = findStep(job, 'Smoke test Linux packages')
+    const evidence = findStep(job, 'Record platform certification evidence')
+    const uploadEvidence = findStep(job, 'Upload platform certification evidence')
+    const dispatch = smokeWorkflow.on?.workflow_dispatch
+
+    expect(smokeWorkflow.on).toHaveProperty('workflow_call')
+    expect(smokeWorkflow.on).toHaveProperty('workflow_dispatch')
+    expect(smokeWorkflow.on?.workflow_call?.inputs?.install_only).toMatchObject({
+      type: 'boolean',
+      default: false
+    })
+    expect(dispatch?.inputs?.install_only).toMatchObject({ type: 'boolean', default: true })
+    expect(dispatch?.inputs?.platform_name).toMatchObject({
+      type: 'choice',
+      default: 'macos-x64',
+      options: ['macos-x64', 'macos-arm64', 'linux-x64', 'windows-x64', 'all']
+    })
+    expect(smokeWorkflow.permissions).toEqual({ contents: 'read' })
+    expect(smokeWorkflow.concurrency).toEqual({
+      group:
+        "package-smoke-${{ github.workflow }}-${{ github.ref }}-${{ inputs.platform_name || 'all' }}",
+      'cancel-in-progress': true
+    })
+    expect(job.if).toBe(
+      "${{ inputs.platform_name == '' || inputs.platform_name == 'all' || matrix.name == inputs.platform_name }}"
+    )
+    expect(install.run).toBe('node scripts/ci/npm-ci.mjs')
+    expect(download.if).toBe('${{ !inputs.install_only }}')
+    expect(linux.if).toBe("${{ !inputs.install_only && matrix.platform == 'linux' }}")
+    expect(evidence.if).toBe('${{ !inputs.install_only }}')
+    expect(uploadEvidence.if).toBe('${{ !inputs.install_only }}')
   })
 
   it('keeps Windows packaging unsigned until signing credentials are available', () => {
@@ -254,7 +295,7 @@ describe('post-merge Windows validation', () => {
     })
     expect(downloadPackage.with?.name).toBe('${{ matrix.name }}')
     expect(downloadPackage.with?.path).toBe('dist')
-    expect(macos.if).toBe("matrix.platform == 'mac'")
+    expect(macos.if).toBe("${{ !inputs.install_only && matrix.platform == 'mac' }}")
     expect(macos.run).toBe('node scripts/macos-package-smoke.mjs --artifact-dir dist')
     expect(windows.run).toBe('node scripts/windows-installer-smoke.mjs --installer-dir dist')
     expect(linux.run).toContain('scripts/linux-package-smoke.mjs')


### PR DESCRIPTION
## Problem

Nightly `package-smoke / Smoke macos-x64` failed during `npm ci` because Electron's postinstall could not download binaries:

```
RequestError: getaddrinfo ENOTFOUND npmmirror.com
```

`.npmrc` pins `electron_mirror` and `electron_builder_binaries_mirror` to npmmirror. GitHub-hosted runners cannot always resolve that host, so smoke never reaches the packaged app.

Observed on [Nightly](https://github.com/aipoch/open-science/actions/runs/32736419791) at `c4c1d93b`. linux-x64, windows-x64, and macos-arm64 smoke on the same run succeeded.

## Proposed change

- Add `scripts/ci/npm-ci.mjs` that, when `GITHUB_ACTIONS=true`, overrides the npmmirror pin with official GitHub Electron and electron-builder-binaries URLs (`npm_config_electron_mirror` wins over `.npmrc`).
- Use that installer in Package Smoke.
- Add a `workflow_dispatch` install-only dry-run on the same reusable job and runner matrix. Default dispatch is `install_only=true` and `platform_name=macos-x64`: checkout + `npm ci` only, no artifacts, no publish.

Local installs keep the npmmirror pin in `.npmrc`.

## Scope and non-goals

- Does not change `electron-builder.yml` `electronDownload.mirror` (packaging path).
- Does not switch PR Gate, Windows Full Test, or other `npm ci` jobs in this PR.
- Does not skip Electron binary download (`ELECTRON_SKIP_BINARY_DOWNLOAD`).
- No application runtime, persistence, or enum changes.

## Acceptance criteria and validation

- On GitHub Actions, `npm ci` downloads Electron from `https://github.com/electron/electron/releases/download/`.
- Local `npm ci` still honors `.npmrc` npmmirror.
- Manual Package Smoke dispatch with `install_only` does not download artifacts or write certification evidence.

Validation after the last material edit:

- GitHub Actions forces GitHub Electron URLs; local env keeps npmmirror -> `npm test -- scripts/ci/npm-ci.test.ts` -> 3/3 passed
- Package Smoke dry-run topology, install command, and skipped artifact steps -> `npm test -- scripts/windows-release-workflows.test.ts` -> 13/13 passed
- Nightly/release reusable-call topology unchanged -> `npm test -- scripts/ci/release-workflows.test.ts` -> 7/7 passed
- lint of the changed test and installer files -> `npx eslint scripts/ci/npm-ci.mjs scripts/ci/npm-ci.test.ts scripts/windows-release-workflows.test.ts` -> no issues

`workflow_dispatch` on Package Smoke is only available after this file exists on `main`. Until then, the unit tests above are the local dry-run of the install policy. After merge, dispatch **Package Smoke** with `install_only=true` and `platform_name=macos-x64` to exercise the real macos-26-intel `npm ci` path.

Uncovered risks: packaging still uses npmmirror via `electron-builder.yml`; other CI `npm ci` jobs still inherit `.npmrc`. Those can fail the same DNS error until they switch to `scripts/ci/npm-ci.mjs`.

## Review focus

- `npm_config_electron_mirror` must be set; `ELECTRON_MIRROR` alone does not override `.npmrc`.
- Nightly `workflow_call` must keep `install_only` default false so real smokes still download artifacts.