### PR TITLE
ci(package-smoke): resolve the smoke matrix in a setup job

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -43,27 +43,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup:
+    name: Resolve smoke matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        shell: bash
+        env:
+          PLATFORM_NAME: ${{ inputs.platform_name }}
+        run: |
+          include='[
+            {"name":"macos-arm64","os":"macos-26","platform":"mac"},
+            {"name":"macos-x64","os":"macos-26-intel","platform":"mac"},
+            {"name":"linux-x64","os":"ubuntu-latest","platform":"linux"},
+            {"name":"windows-x64","os":"windows-latest","platform":"win"}
+          ]'
+          if [ -n "$PLATFORM_NAME" ] && [ "$PLATFORM_NAME" != "all" ]; then
+            include=$(jq -c --arg name "$PLATFORM_NAME" '[.[] | select(.name == $name)]' <<<"$include")
+            if [ "$include" = "[]" ]; then
+              echo "::error::unknown platform_name '$PLATFORM_NAME'"
+              exit 1
+            fi
+          fi
+          echo "matrix={\"include\":$include}" >> "$GITHUB_OUTPUT"
+
   smoke:
     name: Smoke ${{ matrix.name }}
+    needs: setup
+    if: ${{ needs.setup.result == 'success' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
-    if: ${{ inputs.platform_name == '' || inputs.platform_name == 'all' || matrix.name == inputs.platform_name }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - name: macos-arm64
-            os: macos-26
-            platform: mac
-          - name: macos-x64
-            os: macos-26-intel
-            platform: mac
-          - name: linux-x64
-            os: ubuntu-latest
-            platform: linux
-          - name: windows-x64
-            os: windows-latest
-            platform: win
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout certification tooling
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -21,10 +21,11 @@ type WorkflowJob = {
   env?: Record<string, string>
   if?: string
   needs?: string | string[]
+  outputs?: Record<string, string>
   permissions?: Record<string, string>
   'runs-on'?: string
   steps?: WorkflowStep[]
-  strategy?: { matrix?: Record<string, unknown> }
+  strategy?: { matrix?: unknown }
   'timeout-minutes'?: number
   uses?: string
   with?: Record<string, unknown>
@@ -129,9 +130,19 @@ describe('post-merge Windows validation', () => {
         "package-smoke-${{ github.workflow }}-${{ github.ref }}-${{ inputs.platform_name || 'all' }}",
       'cancel-in-progress': true
     })
-    expect(job.if).toBe(
-      "${{ inputs.platform_name == '' || inputs.platform_name == 'all' || matrix.name == inputs.platform_name }}"
+    const setup = smokeWorkflow.jobs.setup
+    expect(setup).toMatchObject({
+      'runs-on': 'ubuntu-latest',
+      outputs: { matrix: '${{ steps.set.outputs.matrix }}' }
+    })
+    expect(setup.steps?.[0]?.run).toContain('"name":"macos-x64","os":"macos-26-intel"')
+    expect(setup.steps?.[0]?.run).toContain(
+      'include=$(jq -c --arg name "$PLATFORM_NAME" \'[.[] | select(.name == $name)]\' <<<"$include")'
     )
+    expect(setup.steps?.[0]?.run).toContain("unknown platform_name '$PLATFORM_NAME'")
+    expect(job.needs).toBe('setup')
+    expect(job.if).toBe("${{ needs.setup.result == 'success' }}")
+    expect(job.strategy?.matrix).toBe('${{ fromJson(needs.setup.outputs.matrix) }}')
     expect(install.run).toBe('node scripts/ci/npm-ci.mjs')
     expect(download.if).toBe('${{ !inputs.install_only }}')
     expect(linux.if).toBe("${{ !inputs.install_only && matrix.platform == 'linux' }}")
@@ -285,14 +296,8 @@ describe('post-merge Windows validation', () => {
     )
     expect(upload.if).toBeUndefined()
     expect(upload.with?.['retention-days']).toBe(7)
-    expect(smoke.strategy?.matrix).toEqual({
-      include: [
-        { name: 'macos-arm64', os: 'macos-26', platform: 'mac' },
-        { name: 'macos-x64', os: 'macos-26-intel', platform: 'mac' },
-        { name: 'linux-x64', os: 'ubuntu-latest', platform: 'linux' },
-        { name: 'windows-x64', os: 'windows-latest', platform: 'win' }
-      ]
-    })
+    expect(smoke.needs).toBe('setup')
+    expect(smoke.strategy?.matrix).toBe('${{ fromJson(needs.setup.outputs.matrix) }}')
     expect(downloadPackage.with?.name).toBe('${{ matrix.name }}')
     expect(downloadPackage.with?.path).toBe('dist')
     expect(macos.if).toBe("${{ !inputs.install_only && matrix.platform == 'mac' }}")


### PR DESCRIPTION
## Problem

Merging #1679 failed GitHub Actions workflow validation on `main` ([run](https://github.com/aipoch/open-science/actions/runs/32743252046)). The install-only dry-run filtered platforms with a job-level `if` that used `matrix`, which is not an allowed context there (`github`, `inputs`, `needs`, `vars` only). The run had no jobs.

## Proposed change

Resolve the smoke matrix in a setup job, the same pattern as `build.yml`:

- Emit the four platform rows.
- When `platform_name` is set and not `all`, keep that row (unknown names fail closed).
- The smoke job consumes `fromJson(needs.setup.outputs.matrix)`.

Install-only dispatch and GitHub Electron mirrors from #1679 are unchanged.

## Scope and non-goals

- Does not change Electron mirror policy or local `.npmrc`.
- Does not migrate other `npm ci` jobs.
- No application runtime, persistence, or enum changes.

## Acceptance criteria and validation

- `actionlint` accepts `.github/workflows/package-smoke.yml`.
- Nightly/release `workflow_call` still smokes every platform when `platform_name` is empty.
- Manual dispatch with `platform_name=macos-x64` emits only that matrix row.

Validation after the last material edit:

- Workflow expressions and job graph -> `actionlint .github/workflows/package-smoke.yml` -> passed
- Package Smoke topology, setup filter, and skipped artifact steps -> `npm test -- scripts/windows-release-workflows.test.ts` -> 13/13 passed
- Nightly/release reusable-call topology unchanged -> `npm test -- scripts/ci/release-workflows.test.ts` -> 7/7 passed
- lint of the workflow tests -> `npx eslint scripts/windows-release-workflows.test.ts` -> no issues

`workflow_dispatch` on Package Smoke becomes usable after this file is valid on `main`. After merge, dispatch **Package Smoke** with `install_only=true` and `platform_name=macos-x64` to exercise the macos-26-intel `npm ci` path.

## Review focus

- Job-level `if` must not reference `matrix`.
- Setup-job filtering must treat `all` and empty `platform_name` as the full matrix.