### PR TITLE
ci(electron): use GitHub Electron mirrors for remaining CI installs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci.mjs
 
       - name: Check generated database schema
         run: npm run db:schema:check
@@ -147,7 +147,7 @@ jobs:
 
       # npm ci runs postinstall: prisma generate + electron-builder install-app-deps.
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci.mjs
 
       # electron-builder compiles build/icon.icon with actool. Fail here with a focused diagnostic
       # instead of much later in packaging if the runner image ever loses its Xcode 26 selection.

--- a/.github/workflows/desktop-regression.yml
+++ b/.github/workflows/desktop-regression.yml
@@ -87,7 +87,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci.mjs
 
       - name: Download macOS ARM64 package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -149,7 +149,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci.mjs
 
       - name: Build Electron application
         run: npm run build:e2e

--- a/.github/workflows/notarize-mac.yml
+++ b/.github/workflows/notarize-mac.yml
@@ -104,7 +104,7 @@ jobs:
       # @prisma/client at runtime. Install dependencies so the smoke script can resolve them.
       - name: Install dependencies
         if: steps.gate.outputs.enabled == 'true'
-        run: npm ci
+        run: node scripts/ci/npm-ci.mjs
 
       # Call path (from_run): pull this run's signed artifacts for the arch (uploaded by build.yml).
       - name: Download signed mac artifact (from this run)

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -315,7 +315,7 @@ jobs:
           node-version: 22
           cache: npm
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci.mjs
       - name: Check Markdown formatting
         id: docs
         if: ${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'docs') }}
@@ -460,7 +460,7 @@ jobs:
           node-version: 22
           cache: npm
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci.mjs
       - name: Test complete suite shard
         id: unit_macos_shard
         continue-on-error: true
@@ -507,7 +507,7 @@ jobs:
           node-version: 22
           cache: npm
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci.mjs
       - name: Test affected Modules
         id: unit_macos_related
         if: ${{ fromJSON(needs.preflight.outputs.plan).mode == 'selective' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'unit_macos') }}
@@ -589,7 +589,7 @@ jobs:
           cache: npm
       - name: Install dependencies for coverage-only legacy plan
         if: ${{ !contains(fromJSON(needs.preflight.outputs.plan).bundles, 'unit') }}
-        run: npm ci
+        run: node scripts/ci/npm-ci.mjs
       - name: Test coverage-only legacy plan
         if: ${{ !contains(fromJSON(needs.preflight.outputs.plan).bundles, 'unit') }}
         run: npm run test:coverage
@@ -622,7 +622,7 @@ jobs:
           node-version: 22
           cache: npm
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci.mjs
       - name: Test Windows-specific behavior
         id: windows_runtime
         if: ${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'windows_runtime') }}
@@ -712,7 +712,7 @@ jobs:
           node-version: 22
           cache: npm
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci.mjs
       - name: Build Electron application
         id: build_electron
         continue-on-error: true
@@ -830,7 +830,7 @@ jobs:
           node-version: 22
           cache: npm
       - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit --fund=false
+        run: node scripts/ci/npm-ci.mjs --prefer-offline --no-audit --fund=false
       - name: Build Electron application
         id: build_electron
         continue-on-error: true

--- a/.github/workflows/runtime-certification.yml
+++ b/.github/workflows/runtime-certification.yml
@@ -42,7 +42,7 @@ jobs:
       # source path exercised by the rest of CI. The focused dry-run proved that --ignore-scripts leaves
       # Electron intentionally uninstalled and causes those suites to fail during collection.
       - name: Install test dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci.mjs
 
       # Use the same pinned, digest-verified micromamba downloader as the packaged runtime. These are
       # ephemeral source-certification environments, not the immutable CDN packs certified later at

--- a/.github/workflows/windows-full-test.yml
+++ b/.github/workflows/windows-full-test.yml
@@ -67,7 +67,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: node scripts/ci/npm-ci.mjs
 
       - name: Test complete suite shard
         # SQLite-heavy integration suites contend heavily for Windows disk I/O when Vitest uses

--- a/scripts/ci/npm-ci.test.ts
+++ b/scripts/ci/npm-ci.test.ts
@@ -1,3 +1,6 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
 import { describe, expect, it, vi } from 'vitest'
 
 import {
@@ -62,5 +65,20 @@ describe('npm ci Electron mirror policy', () => {
         stdio: 'inherit'
       })
     )
+  })
+
+  it('routes Electron-installing workflow npm ci through the GitHub mirror helper', () => {
+    const workflowDir = join(process.cwd(), '.github', 'workflows')
+    const leftover: string[] = []
+    for (const name of readdirSync(workflowDir).filter((file) => file.endsWith('.yml'))) {
+      const text = readFileSync(join(workflowDir, name), 'utf8')
+      for (const [lineNumber, line] of text.split('\n').entries()) {
+        const match = line.match(/^\s+run:\s*(npm ci.*)$/)
+        if (!match) continue
+        if (match[1].includes('--ignore-scripts')) continue
+        leftover.push(`${name}:${lineNumber + 1}: ${match[1]}`)
+      }
+    }
+    expect(leftover).toEqual([])
   })
 })

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -343,7 +343,9 @@ describe('PR Gate workflow', () => {
     expect(legacyCoverage.steps?.filter(({ run }) => run === 'npm run test:coverage')).toHaveLength(
       1
     )
-    expect(legacyCoverage.steps?.filter(({ run }) => run === 'npm ci')).toHaveLength(1)
+    expect(
+      legacyCoverage.steps?.filter(({ run }) => run === 'node scripts/ci/npm-ci.mjs')
+    ).toHaveLength(1)
     expect(unit).toMatchObject({
       name: 'Module tests and coverage',
       needs: ['preflight', 'unit_shard'],
@@ -417,13 +419,17 @@ describe('PR Gate workflow', () => {
   it('shares dependency installation and Electron builds inside platform bundles', () => {
     for (const bundle of ['static', 'unit', 'unit_shard', 'windows_core', 'macos_e2e']) {
       expect(
-        workflow.jobs[bundle].steps?.filter(({ run }) => run === 'npm ci'),
+        workflow.jobs[bundle].steps?.filter(({ run }) => run === 'node scripts/ci/npm-ci.mjs'),
         `${bundle} must install dependencies exactly once`
       ).toHaveLength(1)
     }
     expect(
       workflow.jobs.windows_e2e.steps?.filter(({ name }) => name === 'Install dependencies')
-    ).toEqual([expect.objectContaining({ run: 'npm ci --prefer-offline --no-audit --fund=false' })])
+    ).toEqual([
+      expect.objectContaining({
+        run: 'node scripts/ci/npm-ci.mjs --prefer-offline --no-audit --fund=false'
+      })
+    ])
 
     const macosRuns = workflow.jobs.macos_e2e.steps?.map(({ run }) => run).filter(Boolean)
     expect(macosRuns?.filter((run) => run === 'npm run build:e2e')).toHaveLength(1)

--- a/scripts/ci/runtime-certification-workflow.test.ts
+++ b/scripts/ci/runtime-certification-workflow.test.ts
@@ -65,7 +65,7 @@ describe('runtime certification workflow', () => {
     const create = step(source, 'Create real Python and R environments')
     const verify = step(source, 'Verify runtime prerequisites')
 
-    expect(install.run).toBe('npm ci')
+    expect(install.run).toBe('node scripts/ci/npm-ci.mjs')
     expect(fetch.run).toContain('scripts/fetch-micromamba.mjs linux-64')
     expect(create.run).toContain('python=3.12 matplotlib-base nomkl')
     expect(create.run).toContain('r-base=4.4 r-jsonlite r-ggplot2')


### PR DESCRIPTION
## Problem

#1679 only routed Package Smoke `npm ci` through `scripts/ci/npm-ci.mjs`. Other GitHub Actions jobs still inherit `.npmrc`'s npmmirror Electron pin and can fail with `getaddrinfo ENOTFOUND npmmirror.com` during Electron's postinstall.

## Proposed change

Use `node scripts/ci/npm-ci.mjs` for every remaining workflow `npm ci` that runs install scripts (and therefore downloads Electron):

- PR Gate (static, unit shards, unit, legacy coverage, Windows core, macOS E2E, Windows E2E)
- Build verify and native package jobs
- Windows Full Test
- Nightly desktop regression
- Runtime certification
- macOS notarize

`--ignore-scripts` installs stay on `npm ci`; they skip the Electron download. A regression test fails if a new workflow reintroduces an Electron-installing `npm ci`.

Independent of #1680 (does not touch `package-smoke.yml`).

## Scope and non-goals

- Does not change `electron-builder.yml` `electronDownload.mirror` (packaging path).
- Does not change local `.npmrc` npmmirror for developers.
- No application runtime, persistence, or enum changes.

## Acceptance criteria and validation

- Electron-installing CI jobs set `npm_config_electron_mirror` to GitHub releases when `GITHUB_ACTIONS=true`.
- `--ignore-scripts` jobs remain on `npm ci`.
- Workflow YAML no longer contains `run: npm ci` without `--ignore-scripts`.

Validation after the last material edit:

- Mirror policy and leftover-`npm ci` guard -> `npm test -- scripts/ci/npm-ci.test.ts` -> 4/4 passed
- PR Gate install steps -> `npm test -- scripts/ci/pr-gate-workflow.test.ts` -> 21/21 passed
- Runtime certification install step -> `npm test -- scripts/ci/runtime-certification-workflow.test.ts` -> 4/4 passed
- Release/Windows workflow topology -> `npm test -- scripts/windows-release-workflows.test.ts scripts/ci/release-workflows.test.ts` -> 20/20 passed
- lint of changed tests -> `npx eslint scripts/ci/npm-ci.test.ts scripts/ci/pr-gate-workflow.test.ts scripts/ci/runtime-certification-workflow.test.ts` -> no issues

PR Gate on this branch is the live `npm ci` dry-run for the changed jobs. Package Smoke install-only dispatch remains the macos-26-intel path after #1680 lands.

Uncovered risks: packaging still uses npmmirror via `electron-builder.yml` if Electron is not already in `node_modules` from `npm ci`.

## Review focus

- Windows E2E extra flags must stay after the helper: `node scripts/ci/npm-ci.mjs --prefer-offline --no-audit --fund=false`.
- Do not convert `--ignore-scripts` installs; those jobs must not download Electron.