### PR TITLE
test(notebook): keep related package changes on managePackages receipts

### DIFF
--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -5335,7 +5335,7 @@ describe('notebook runtime service', () => {
   })
 
   describe('managePackages', () => {
-    it('returns verified version changes for requested packages without transitive inventory noise', async () => {
+    it('returns verified requested package changes alongside related inventory changes', async () => {
       const root = await createStorageRoot()
       const service = new NotebookRuntimeService({
         configRoot: root,
@@ -5388,9 +5388,17 @@ describe('notebook runtime service', () => {
       expect(result.packageChanges).toEqual([
         expect.objectContaining({
           name: 'numpy',
+          relationship: 'requested',
           change: 'updated',
           beforeVersion: '2.1.0',
           afterVersion: '2.2.0'
+        }),
+        expect.objectContaining({
+          name: 'packaging',
+          relationship: 'unattributed',
+          change: 'updated',
+          beforeVersion: '24.0',
+          afterVersion: '25.0'
         })
       ])
       expect(result.target).toMatchObject({


### PR DESCRIPTION
## Problem

Nightly Verify and Windows Full Test fail because `managePackages` returns related unattributed inventory changes (for the package-progress UI) while the receipt test still expects a requested-only list.

Seen on:

- [Nightly](https://github.com/aipoch/open-science/actions/runs/32769951393)
- [Windows Full Test](https://github.com/aipoch/open-science/actions/runs/32771545530)

The failing case installs `numpy` and also records an unattributed `packaging` update from the before/after inventory.

## Proposed change

Expect both the requested `numpy` change and the related `packaging` change on the service receipt. MCP compaction already orders requested changes first for the Agent; the full list remains on `InstallResult` for the transcript UI.

## Scope and non-goals

- Test-only. Does not change installer, inventory, or MCP compact behavior.
- No persistence, enum, or historical-data changes.

## Acceptance criteria and validation

- `managePackages` receipts keep requested changes and related unattributed inventory updates.

Validation after the last material edit:

- related inventory changes stay on the receipt -> `npm test -- src/main/notebook/runtime-service.test.ts -t 'returns verified requested package changes'` -> 1/1 passed
- lint of the changed test -> `npx eslint src/main/notebook/runtime-service.test.ts` -> no issues

Nightly / Windows Full Test remain the authority for the complete portable suite.

## Review focus

- Do not filter `unattributed` out of `InstallResult`; the progress card uses those rows as related changes.