### PR TITLE
test(acp): raise notebook static context budget after package-tool growth

### DIFF
--- a/src/main/acp/context-usage-static-context.test.ts
+++ b/src/main/acp/context-usage-static-context.test.ts
@@ -65,6 +65,7 @@ describe('contextUsageMcpSections', () => {
     ]
 
     // Baseline before deduplication was about 5.2k cl100k tokens (3.6k schema + 1.6k prompt).
+    // Package-progress schema (installer enum + Bioconductor/GitHub install docs) added ~30 tokens.
     for (const { frameworkId, codexBridgeAliases } of frameworks) {
       const [{ text: schema }] = contextUsageMcpSections(frameworkId, {
         artifacts: false,
@@ -75,7 +76,7 @@ describe('contextUsageMcpSections', () => {
       expect(
         tokenCount(`${NOTEBOOK_SYSTEM_PROMPT_APPEND}\n${schema}`) + bashHeadroom,
         `${frameworkId}${codexBridgeAliases ? ' (bridge aliases)' : ''}`
-      ).toBeLessThanOrEqual(3_500)
+      ).toBeLessThanOrEqual(3_600)
     }
   })
 


### PR DESCRIPTION
## Problem

Nightly Verify and Windows Full Test fail the notebook static-context budget: Codex measured about 3531–3532 cl100k tokens against a 3500 cap.

Seen on:

- [Nightly](https://github.com/aipoch/open-science/actions/runs/32769951393)
- [Windows Full Test](https://github.com/aipoch/open-science/actions/runs/32771545530)

#1650 added `installer` to `manage_packages` and Bioconductor/GitHub install docs, which grew the serialized notebook schema plus scoped guidance by ~30 tokens.

## Proposed change

Raise the notebook schema-plus-guidance cap from 3500 to 3600 cl100k tokens. The test still counts Windows PowerShell bash-doc headroom so POSIX hosts cannot hide a Windows-only overflow.

## Scope and non-goals

- Test-only. Does not shorten Agent-facing notebook instructions or tool schema.
- No persistence, enum, or historical-data changes.

## Acceptance criteria and validation

- Notebook schema plus scoped guidance, including Windows bash-doc headroom, stays at or under 3600 cl100k tokens for every framework path.

Validation after the last material edit:

- notebook static context budget -> `npm test -- src/main/acp/context-usage-static-context.test.ts` -> 7/7 passed
- lint of the changed test -> `npx eslint src/main/acp/context-usage-static-context.test.ts` -> no issues

Nightly / Windows Full Test remain the authority for the complete portable suite, including Windows bash-doc headroom.

## Review focus

- Keep the budget as a regression cap, not as license to grow the prompt unbounded.