### PR TITLE
test(session-store): include package progress activity as a store consumer

### DIFF
--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -5298,6 +5298,7 @@ describe('session store public contract', () => {
       'src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.tsx',
       'src/renderer/src/pages/workspace/WorkspaceArtifactVisibility.tsx',
       'src/renderer/src/pages/workspace/WorkspaceContextCompactionActivityRow.tsx',
+      'src/renderer/src/pages/workspace/WorkspaceManagePackagesActivityRow.tsx',
       'src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx',
       'src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx',
       'src/renderer/src/pages/workspace/WorkspacePage.tsx',


### PR DESCRIPTION
## Problem

Nightly Verify and Windows Full Test fail after #1650 because `WorkspaceManagePackagesActivityRow` imports `ToolActivity` from the public session-store facade, and the consumer inventory still omits that file.

Seen on:

- [Nightly](https://github.com/aipoch/open-science/actions/runs/32769951393)
- [Windows Full Test](https://github.com/aipoch/open-science/actions/runs/32771545530)

## Proposed change

Add `src/renderer/src/pages/workspace/WorkspaceManagePackagesActivityRow.tsx` to the expected production consumer list.

## Scope and non-goals

- Test-only. No runtime, persistence, or enum changes.
- Does not change how package progress reads activity.

## Acceptance criteria and validation

- Direct session-store consumers include the package-progress activity row.

Validation after the last material edit:

- consumer inventory includes the new activity row -> `npm test -- src/renderer/src/stores/session-store.test.ts -t 'keeps production consumers on the public store facade'` -> 1/1 passed
- lint of the changed test -> `npx eslint src/renderer/src/stores/session-store.test.ts` -> no issues

Nightly / Windows Full Test remain the authority for the complete portable suite.

## Review focus

- Keep the path in alphabetical order with the other `Workspace*` consumers.