### PR TITLE
ci(package-smoke): emit a single-line smoke matrix for Actions

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -3,13 +3,19 @@ name: Package Smoke
 # Blocking native-package certification. Each matrix leg downloads the exact artifact produced by
 # build.yml, so a failed smoke can be retried without rebuilding or re-signing any package.
 #
-# A manual dispatch with install_only reuses this exact job, runner, and npm ci path without
-# downloading artifacts or publishing anything. Use that to certify Electron mirror resolution.
+# Manual dispatch dry-runs reuse this exact workflow:
+# - setup_only=true, platform_name=all: matrix resolution only (the Nightly unfiltered path)
+# - install_only=true, platform_name=macos-x64: matrix resolution plus npm ci, no artifacts
 on:
   workflow_call:
     inputs:
       install_only:
         description: Skip artifact download and package execution; only install dependencies
+        type: boolean
+        required: false
+        default: false
+      setup_only:
+        description: Resolve the smoke matrix and skip every smoke job
         type: boolean
         required: false
         default: false
@@ -20,6 +26,10 @@ on:
         default: ''
   workflow_dispatch:
     inputs:
+      setup_only:
+        description: Resolve the smoke matrix and skip every smoke job
+        type: boolean
+        default: false
       install_only:
         description: Skip artifact download and package execution; only install dependencies
         type: boolean
@@ -49,30 +59,20 @@ jobs:
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
       - id: set
+        name: Resolve platform include list
         shell: bash
         env:
           PLATFORM_NAME: ${{ inputs.platform_name }}
-        run: |
-          include='[
-            {"name":"macos-arm64","os":"macos-26","platform":"mac"},
-            {"name":"macos-x64","os":"macos-26-intel","platform":"mac"},
-            {"name":"linux-x64","os":"ubuntu-latest","platform":"linux"},
-            {"name":"windows-x64","os":"windows-latest","platform":"win"}
-          ]'
-          if [ -n "$PLATFORM_NAME" ] && [ "$PLATFORM_NAME" != "all" ]; then
-            include=$(jq -c --arg name "$PLATFORM_NAME" '[.[] | select(.name == $name)]' <<<"$include")
-            if [ "$include" = "[]" ]; then
-              echo "::error::unknown platform_name '$PLATFORM_NAME'"
-              exit 1
-            fi
-          fi
-          echo "matrix={\"include\":$include}" >> "$GITHUB_OUTPUT"
+        run: echo "matrix=$(node scripts/ci/resolve-package-smoke-matrix.mjs)" >> "$GITHUB_OUTPUT"
 
   smoke:
     name: Smoke ${{ matrix.name }}
     needs: setup
-    if: ${{ needs.setup.result == 'success' }}
+    if: ${{ needs.setup.result == 'success' && !inputs.setup_only }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:

--- a/scripts/ci/resolve-package-smoke-matrix.mjs
+++ b/scripts/ci/resolve-package-smoke-matrix.mjs
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export const PACKAGE_SMOKE_PLATFORMS = [
+  { name: 'macos-arm64', os: 'macos-26', platform: 'mac' },
+  { name: 'macos-x64', os: 'macos-26-intel', platform: 'mac' },
+  { name: 'linux-x64', os: 'ubuntu-latest', platform: 'linux' },
+  { name: 'windows-x64', os: 'windows-latest', platform: 'win' }
+]
+
+export function resolvePackageSmokeMatrix(platformName = '') {
+  const trimmed = platformName.trim()
+  const include =
+    trimmed === '' || trimmed === 'all'
+      ? PACKAGE_SMOKE_PLATFORMS
+      : PACKAGE_SMOKE_PLATFORMS.filter((row) => row.name === trimmed)
+  if (include.length === 0) {
+    throw new Error(`unknown platform_name '${platformName}'`)
+  }
+  return JSON.stringify({ include })
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    process.stdout.write(resolvePackageSmokeMatrix(process.env.PLATFORM_NAME ?? ''))
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`::error::${message}\n`)
+    process.exit(1)
+  }
+}

--- a/scripts/ci/resolve-package-smoke-matrix.test.ts
+++ b/scripts/ci/resolve-package-smoke-matrix.test.ts
@@ -1,0 +1,44 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  PACKAGE_SMOKE_PLATFORMS,
+  resolvePackageSmokeMatrix
+} from './resolve-package-smoke-matrix.mjs'
+
+const scriptPath = fileURLToPath(new URL('./resolve-package-smoke-matrix.mjs', import.meta.url))
+
+describe('package-smoke matrix resolution', () => {
+  it('emits a single-line GitHub Actions matrix for the unfiltered Nightly path', () => {
+    const encoded = resolvePackageSmokeMatrix('')
+    expect(encoded).not.toMatch(/\n|\r/)
+    expect(JSON.parse(encoded)).toEqual({ include: PACKAGE_SMOKE_PLATFORMS })
+  })
+
+  it('treats all as the full matrix and filters a named platform', () => {
+    expect(JSON.parse(resolvePackageSmokeMatrix('all'))).toEqual({
+      include: PACKAGE_SMOKE_PLATFORMS
+    })
+    expect(JSON.parse(resolvePackageSmokeMatrix('macos-x64'))).toEqual({
+      include: [PACKAGE_SMOKE_PLATFORMS[1]]
+    })
+  })
+
+  it('fails closed on an unknown platform name', () => {
+    expect(() => resolvePackageSmokeMatrix('macos-intel')).toThrow(
+      "unknown platform_name 'macos-intel'"
+    )
+  })
+
+  it('prints compact JSON on stdout for GITHUB_OUTPUT', () => {
+    const result = spawnSync(process.execPath, [scriptPath], {
+      encoding: 'utf8',
+      env: { ...process.env, PLATFORM_NAME: '' }
+    })
+    expect(result.status).toBe(0)
+    expect(result.stdout).not.toMatch(/\n|\r/)
+    expect(JSON.parse(result.stdout)).toEqual({ include: PACKAGE_SMOKE_PLATFORMS })
+  })
+})

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -118,6 +118,11 @@ describe('post-merge Windows validation', () => {
       type: 'boolean',
       default: false
     })
+    expect(smokeWorkflow.on?.workflow_call?.inputs?.setup_only).toMatchObject({
+      type: 'boolean',
+      default: false
+    })
+    expect(dispatch?.inputs?.setup_only).toMatchObject({ type: 'boolean', default: false })
     expect(dispatch?.inputs?.install_only).toMatchObject({ type: 'boolean', default: true })
     expect(dispatch?.inputs?.platform_name).toMatchObject({
       type: 'choice',
@@ -135,13 +140,15 @@ describe('post-merge Windows validation', () => {
       'runs-on': 'ubuntu-latest',
       outputs: { matrix: '${{ steps.set.outputs.matrix }}' }
     })
-    expect(setup.steps?.[0]?.run).toContain('"name":"macos-x64","os":"macos-26-intel"')
-    expect(setup.steps?.[0]?.run).toContain(
-      'include=$(jq -c --arg name "$PLATFORM_NAME" \'[.[] | select(.name == $name)]\' <<<"$include")'
+    expect(findStep(setup, 'Checkout').uses).toBe(
+      'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
     )
-    expect(setup.steps?.[0]?.run).toContain("unknown platform_name '$PLATFORM_NAME'")
+    expect(findStep(setup, 'Resolve platform include list')).toMatchObject({
+      id: 'set',
+      run: 'echo "matrix=$(node scripts/ci/resolve-package-smoke-matrix.mjs)" >> "$GITHUB_OUTPUT"'
+    })
     expect(job.needs).toBe('setup')
-    expect(job.if).toBe("${{ needs.setup.result == 'success' }}")
+    expect(job.if).toBe("${{ needs.setup.result == 'success' && !inputs.setup_only }}")
     expect(job.strategy?.matrix).toBe('${{ fromJson(needs.setup.outputs.matrix) }}')
     expect(install.run).toBe('node scripts/ci/npm-ci.mjs')
     expect(download.if).toBe('${{ !inputs.install_only }}')


### PR DESCRIPTION
## Problem

Nightly failed at `package-smoke / Resolve smoke matrix` before any smoke ran:

- [Nightly](https://github.com/aipoch/open-science/actions/runs/32781114581/job/97608034763)
- `Unable to process file command 'output' successfully`
- `Invalid format '  {"name":"macos-arm64","os":"macos-26","platform":"mac"},'`

When `platform_name` is empty (Nightly's `workflow_call` default), the setup script wrote a multiline JSON matrix to `GITHUB_OUTPUT`. Actions treats each newline as a new `key=value` line.

The existing dispatch default (`platform_name=macos-x64`) still ran `jq -c` and hid this path.

## Proposed change

- Encode the matrix with `scripts/ci/resolve-package-smoke-matrix.mjs` as compact one-line JSON.
- Add `setup_only` so a dispatch can run that setup job and skip every smoke/npm ci job.

## Scope and non-goals

- Does not change smoke commands, Electron mirrors, or packaging.
- No application runtime, persistence, or enum changes.

## Acceptance criteria and validation

- Unfiltered (`''` / `all`) matrix output is one line and `JSON.parse`able.
- Named `platform_name` still emits a single row; unknown names fail closed.
- `setup_only=true` completes setup and skips smoke jobs.

Validation after the last material edit:

- compact unfiltered matrix and CLI stdout -> `npm test -- scripts/ci/resolve-package-smoke-matrix.test.ts` -> 4/4 passed
- Package Smoke topology and setup-only skip -> `npm test -- scripts/windows-release-workflows.test.ts` -> 13/13 passed
- Nightly/release reusable-call topology unchanged -> `npm test -- scripts/ci/release-workflows.test.ts` -> 7/7 passed
- workflow expressions -> `actionlint .github/workflows/package-smoke.yml` -> passed
- lint of changed files -> `npx eslint scripts/ci/resolve-package-smoke-matrix.mjs scripts/ci/resolve-package-smoke-matrix.test.ts scripts/windows-release-workflows.test.ts` -> no issues

Focused dry-run after the last material edit, reusing the real Package Smoke workflow on this branch (unfiltered Nightly matrix, no artifacts, no npm ci, no publish):

```
gh workflow run "Package Smoke" --ref ci/package-smoke-matrix-output -f setup_only=true -f platform_name=all
```

Result: [run 32785496861](https://github.com/aipoch/open-science/actions/runs/32785496861) — Resolve smoke matrix succeeded in 7s; smoke jobs skipped.

## Review focus

- Nightly's empty `platform_name` must take the same compact-encoding path as `all`.
- Do not write raw multiline JSON to `GITHUB_OUTPUT`.