### PR TITLE
fix(notebook): reject flag-like named-env packages

### DIFF
--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -1374,6 +1374,24 @@ describe('DefaultRuntimeProvisioner.createNamedEnvironment', () => {
     expect(runArgv).not.toHaveBeenCalled()
   })
 
+  it('rejects flag-like package entries before starting micromamba', async () => {
+    const root = makeRoot()
+    const runArgv = vi.fn(async () => undefined)
+    const { deps } = makeNamedEnvDeps(root, { runArgv })
+    let error: unknown
+
+    try {
+      await new DefaultRuntimeProvisioner(deps).createNamedEnvironment('analysis', 'python', [
+        '--offline'
+      ])
+    } catch (caught) {
+      error = caught
+    }
+
+    expect(runArgv).not.toHaveBeenCalled()
+    expect(error).toEqual(expect.objectContaining({ message: expect.stringMatching(/package/i) }))
+  })
+
   it('builds the create argv from the base floor + user packages (deduped), targeting envs/<name>', async () => {
     const root = makeRoot()
     const { deps, argvs } = makeNamedEnvDeps(root)

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -1148,6 +1148,12 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
     language: NotebookLanguage,
     packages: string[] = []
   ): Promise<EnvironmentInfo> {
+    const flagLike = packages.find((pkg) => pkg.trim().startsWith('-'))
+    if (flagLike) {
+      throw new Error(
+        `"${flagLike}" is not a valid package specifier — options/flags cannot be passed as packages.`
+      )
+    }
     const base = language === 'python' ? BASE_PYTHON_PACKAGES : BASE_R_PACKAGES
     const pkgs = [...new Set([...base, ...packages])]
     const prefix = envPrefix(this.deps.root, name)


### PR DESCRIPTION
## Problem

`manage_environments(action:"create")` accepted any non-empty initial package string. `DefaultRuntimeProvisioner.createNamedEnvironment` appended those values to the micromamba create argv, so a value such as `--offline` was parsed as an option-shaped argument instead of remaining a package specifier.

This is treated as a parameter-boundary consistency and robustness defect, not a security issue.

## Proposed change

Reject initial package entries whose trimmed value starts with `-` at the public provisioner boundary, before recovery, cache maintenance, or micromamba execution. This matches the existing `manage_packages` rule while covering every caller of named-environment creation.

Add a regression test through `DefaultRuntimeProvisioner.createNamedEnvironment` that proves the pre-fix argv contained `--offline`, asserts micromamba is not started, and verifies a package-related error is returned.

## Scope and non-goals

- No new fields, schema, architecture, interaction, data-model, enum/state, migration, or persistence changes.
- No historical-data compatibility work is required; existing environments and stored records are unchanged.
- The MCP schema remains structurally unchanged. Validation lives at the shared production boundary rather than being duplicated for one transport.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- flag-like initial package is rejected before micromamba -> `npm test -- src/main/notebook/provisioner.test.ts -t "rejects flag-like package entries before starting micromamba"` -> passed twice after failing deterministically three times before the fix; the red output showed `--offline` in the actual `runArgv` argv
- named-environment provisioning behavior -> `npm test -- src/main/notebook/provisioner.test.ts` -> 94 passed
- Node process types -> `npm run typecheck:node` -> passed
- linted source -> `npm run lint` -> passed
- affected-plan explanation -> `npm run test:affected -- --base origin/main --head HEAD --explain` -> full fallback because `provisioner.test.ts` has unknown module ownership

Per maintainer direction, the local full `npm test` fallback was not run; PR CI is the authority for complete and platform coverage.

## Review focus

Confirm the guard is placed at the common named-environment creation boundary and occurs before all mutation side effects, while normal package specs and the existing base-floor merge remain unchanged.