### PR TITLE
fix(notebook): validate interrupted environment prefixes

### DIFF
--- a/src/main/notebook/recovery-coordinator.test.ts
+++ b/src/main/notebook/recovery-coordinator.test.ts
@@ -1,12 +1,12 @@
 import { existsSync } from 'node:fs'
-import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { chmod, lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { operationJournalPath, RuntimeOperationJournal } from './operation-journal'
 import { NotebookRecoveryCoordinator } from './recovery-coordinator'
-import { DEFAULT_PY_ENV, envPrefix, pythonBin } from './runtime-paths'
+import { DEFAULT_PY_ENV, DEFAULT_R_ENV, envPrefix, pythonBin, rBin } from './runtime-paths'
 
 let root: string | undefined
 
@@ -25,14 +25,15 @@ const createRuntimeRoot = async (): Promise<string> => {
 const beginInterruptedMaterialize = async (
   runtimeRoot: string,
   operationId: string,
-  targetPath: string
+  targetPath: string,
+  options: { runtimeId?: string; phase?: string } = {}
 ): Promise<RuntimeOperationJournal> => {
   const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
   await journal.begin({
     operationId,
     kind: 'materialize',
-    runtimeId: DEFAULT_PY_ENV,
-    phase: 'create-python',
+    runtimeId: options.runtimeId ?? DEFAULT_PY_ENV,
+    phase: options.phase ?? 'create-python',
     startedAt: 100,
     targetPath
   })
@@ -87,6 +88,32 @@ describe('NotebookRecoveryCoordinator', () => {
       prefixExists: false,
       pending: []
     })
+  })
+
+  describe.skipIf(process.platform === 'win32')('language-specific interpreter recovery', () => {
+    it.each(['create-r', 'restore'])(
+      'verifies the R interpreter for an interrupted %s operation',
+      async (phase) => {
+        const runtimeRoot = await createRuntimeRoot()
+        const prefix = envPrefix(runtimeRoot, DEFAULT_R_ENV)
+        await mkdir(join(prefix, 'conda-meta'), { recursive: true })
+        await mkdir(dirname(pythonBin(prefix)), { recursive: true })
+        await writeFile(pythonBin(prefix), `#!${process.execPath}\nprocess.exit(0)\n`)
+        await chmod(pythonBin(prefix), 0o755)
+        await writeFile(rBin(prefix), 'not an R interpreter')
+        const journal = await beginInterruptedMaterialize(runtimeRoot, `r-${phase}`, prefix, {
+          runtimeId: DEFAULT_R_ENV,
+          phase
+        })
+
+        await new NotebookRecoveryCoordinator(runtimeRoot).recover()
+
+        expect({ prefixExists: existsSync(prefix), pending: await journal.pending() }).toEqual({
+          prefixExists: false,
+          pending: []
+        })
+      }
+    )
   })
 
   it('retains recovery evidence without touching a journal target outside managed envs', async () => {

--- a/src/main/notebook/recovery-coordinator.test.ts
+++ b/src/main/notebook/recovery-coordinator.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -167,6 +167,28 @@ describe('NotebookRecoveryCoordinator', () => {
     expect(existsSync(sibling)).toBe(true)
     expect((await journal.pending()).map(({ operationId }) => operationId)).toEqual([
       'sibling-prefix'
+    ])
+    expect(coordinator.isPrefixBlocked(prefix)).toBe(true)
+    expect(coordinator.isRuntimeIdBlocked(DEFAULT_PY_ENV)).toBe(true)
+  })
+
+  it('retains recovery evidence for a dangling managed prefix symlink', async () => {
+    const runtimeRoot = await createRuntimeRoot()
+    const prefix = envPrefix(runtimeRoot, DEFAULT_PY_ENV)
+    await mkdir(dirname(prefix), { recursive: true })
+    await symlink(
+      join(dirname(prefix), 'missing'),
+      prefix,
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    const journal = await beginInterruptedMaterialize(runtimeRoot, 'dangling-prefix', prefix)
+
+    const coordinator = new NotebookRecoveryCoordinator(runtimeRoot)
+    await coordinator.recover()
+
+    expect((await lstat(prefix)).isSymbolicLink()).toBe(true)
+    expect((await journal.pending()).map(({ operationId }) => operationId)).toEqual([
+      'dangling-prefix'
     ])
     expect(coordinator.isPrefixBlocked(prefix)).toBe(true)
     expect(coordinator.isRuntimeIdBlocked(DEFAULT_PY_ENV)).toBe(true)

--- a/src/main/notebook/recovery-coordinator.test.ts
+++ b/src/main/notebook/recovery-coordinator.test.ts
@@ -1,12 +1,12 @@
 import { existsSync } from 'node:fs'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { operationJournalPath, RuntimeOperationJournal } from './operation-journal'
 import { NotebookRecoveryCoordinator } from './recovery-coordinator'
-import { DEFAULT_PY_ENV, envPrefix } from './runtime-paths'
+import { DEFAULT_PY_ENV, envPrefix, pythonBin } from './runtime-paths'
 
 let root: string | undefined
 
@@ -20,6 +20,23 @@ afterEach(async () => {
 const createRuntimeRoot = async (): Promise<string> => {
   root = await mkdtemp(join(tmpdir(), 'open-science-notebook-recovery-'))
   return join(root, 'runtime')
+}
+
+const beginInterruptedMaterialize = async (
+  runtimeRoot: string,
+  operationId: string,
+  targetPath: string
+): Promise<RuntimeOperationJournal> => {
+  const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+  await journal.begin({
+    operationId,
+    kind: 'materialize',
+    runtimeId: DEFAULT_PY_ENV,
+    phase: 'create-python',
+    startedAt: 100,
+    targetPath
+  })
+  return journal
 }
 
 describe('NotebookRecoveryCoordinator', () => {
@@ -62,15 +79,7 @@ describe('NotebookRecoveryCoordinator', () => {
     const runtimeRoot = await createRuntimeRoot()
     const prefix = envPrefix(runtimeRoot, DEFAULT_PY_ENV)
     await mkdir(join(prefix, 'conda-meta'), { recursive: true })
-    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
-    await journal.begin({
-      operationId: 'partial-python',
-      kind: 'materialize',
-      runtimeId: DEFAULT_PY_ENV,
-      phase: 'create-python',
-      startedAt: 100,
-      targetPath: prefix
-    })
+    const journal = await beginInterruptedMaterialize(runtimeRoot, 'partial-python', prefix)
 
     await new NotebookRecoveryCoordinator(runtimeRoot).recover()
 
@@ -78,6 +87,45 @@ describe('NotebookRecoveryCoordinator', () => {
       prefixExists: false,
       pending: []
     })
+  })
+
+  it('retains recovery evidence without touching a journal target outside managed envs', async () => {
+    const runtimeRoot = await createRuntimeRoot()
+    const outside = join(dirname(runtimeRoot), 'outside')
+    await mkdir(join(outside, 'conda-meta'), { recursive: true })
+    const journal = await beginInterruptedMaterialize(runtimeRoot, 'outside-target', outside)
+
+    const coordinator = new NotebookRecoveryCoordinator(runtimeRoot)
+    await coordinator.recover()
+
+    expect(existsSync(outside)).toBe(true)
+    expect((await journal.pending()).map(({ operationId }) => operationId)).toEqual([
+      'outside-target'
+    ])
+    expect(coordinator.isPrefixBlocked(outside)).toBe(true)
+    expect(coordinator.isRuntimeIdBlocked(DEFAULT_PY_ENV)).toBe(true)
+  })
+
+  it('retains recovery evidence when a managed prefix resolves outside the env root', async () => {
+    const runtimeRoot = await createRuntimeRoot()
+    const outside = join(dirname(runtimeRoot), 'outside')
+    await mkdir(join(outside, 'conda-meta'), { recursive: true })
+    await mkdir(dirname(pythonBin(outside)), { recursive: true })
+    await writeFile(pythonBin(outside), 'not an interpreter')
+    const prefix = envPrefix(runtimeRoot, DEFAULT_PY_ENV)
+    await mkdir(dirname(prefix), { recursive: true })
+    await symlink(outside, prefix, process.platform === 'win32' ? 'junction' : 'dir')
+    const journal = await beginInterruptedMaterialize(runtimeRoot, 'escaping-prefix', prefix)
+
+    const coordinator = new NotebookRecoveryCoordinator(runtimeRoot)
+    await coordinator.recover()
+
+    expect(existsSync(prefix)).toBe(true)
+    expect((await journal.pending()).map(({ operationId }) => operationId)).toEqual([
+      'escaping-prefix'
+    ])
+    expect(coordinator.isPrefixBlocked(prefix)).toBe(true)
+    expect(coordinator.isRuntimeIdBlocked(DEFAULT_PY_ENV)).toBe(true)
   })
 
   it('fails closed after disposal even if reset commands clear known blocks', async () => {

--- a/src/main/notebook/recovery-coordinator.test.ts
+++ b/src/main/notebook/recovery-coordinator.test.ts
@@ -153,6 +153,25 @@ describe('NotebookRecoveryCoordinator', () => {
     expect(coordinator.isRuntimeIdBlocked(DEFAULT_PY_ENV)).toBe(true)
   })
 
+  it('retains a managed prefix symlink without deleting its sibling target', async () => {
+    const runtimeRoot = await createRuntimeRoot()
+    const sibling = join(runtimeRoot, 'envs', 'sibling')
+    await mkdir(join(sibling, 'conda-meta'), { recursive: true })
+    const prefix = envPrefix(runtimeRoot, DEFAULT_PY_ENV)
+    await symlink(sibling, prefix, process.platform === 'win32' ? 'junction' : 'dir')
+    const journal = await beginInterruptedMaterialize(runtimeRoot, 'sibling-prefix', prefix)
+
+    const coordinator = new NotebookRecoveryCoordinator(runtimeRoot)
+    await coordinator.recover()
+
+    expect(existsSync(sibling)).toBe(true)
+    expect((await journal.pending()).map(({ operationId }) => operationId)).toEqual([
+      'sibling-prefix'
+    ])
+    expect(coordinator.isPrefixBlocked(prefix)).toBe(true)
+    expect(coordinator.isRuntimeIdBlocked(DEFAULT_PY_ENV)).toBe(true)
+  })
+
   it('fails closed after disposal even if reset commands clear known blocks', async () => {
     const coordinator = new NotebookRecoveryCoordinator(await createRuntimeRoot())
     const prefix = '/runtime/envs/default-python'

--- a/src/main/notebook/recovery-coordinator.test.ts
+++ b/src/main/notebook/recovery-coordinator.test.ts
@@ -1,10 +1,12 @@
+import { existsSync } from 'node:fs'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { operationJournalPath } from './operation-journal'
+import { operationJournalPath, RuntimeOperationJournal } from './operation-journal'
 import { NotebookRecoveryCoordinator } from './recovery-coordinator'
+import { DEFAULT_PY_ENV, envPrefix } from './runtime-paths'
 
 let root: string | undefined
 
@@ -54,6 +56,28 @@ describe('NotebookRecoveryCoordinator', () => {
 
     expect(coordinator.isPrefixBlocked(resetPrefix)).toBe(false)
     expect(coordinator.isPrefixBlocked(otherPrefix)).toBe(true)
+  })
+
+  it('removes an interrupted materialize prefix that has conda metadata but no interpreter', async () => {
+    const runtimeRoot = await createRuntimeRoot()
+    const prefix = envPrefix(runtimeRoot, DEFAULT_PY_ENV)
+    await mkdir(join(prefix, 'conda-meta'), { recursive: true })
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+    await journal.begin({
+      operationId: 'partial-python',
+      kind: 'materialize',
+      runtimeId: DEFAULT_PY_ENV,
+      phase: 'create-python',
+      startedAt: 100,
+      targetPath: prefix
+    })
+
+    await new NotebookRecoveryCoordinator(runtimeRoot).recover()
+
+    expect({ prefixExists: existsSync(prefix), pending: await journal.pending() }).toEqual({
+      prefixExists: false,
+      pending: []
+    })
   })
 
   it('fails closed after disposal even if reset commands clear known blocks', async () => {

--- a/src/main/notebook/recovery-coordinator.test.ts
+++ b/src/main/notebook/recovery-coordinator.test.ts
@@ -128,6 +128,31 @@ describe('NotebookRecoveryCoordinator', () => {
     expect(coordinator.isRuntimeIdBlocked(DEFAULT_PY_ENV)).toBe(true)
   })
 
+  it('retains an incomplete prefix when the managed env root resolves outside the runtime', async () => {
+    const runtimeRoot = await createRuntimeRoot()
+    const outsideEnvs = join(dirname(runtimeRoot), 'outside-envs')
+    await mkdir(outsideEnvs, { recursive: true })
+    await mkdir(runtimeRoot, { recursive: true })
+    await symlink(
+      outsideEnvs,
+      join(runtimeRoot, 'envs'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    const prefix = envPrefix(runtimeRoot, DEFAULT_PY_ENV)
+    await mkdir(join(prefix, 'conda-meta'), { recursive: true })
+    const journal = await beginInterruptedMaterialize(runtimeRoot, 'escaping-env-root', prefix)
+
+    const coordinator = new NotebookRecoveryCoordinator(runtimeRoot)
+    await coordinator.recover()
+
+    expect(existsSync(prefix)).toBe(true)
+    expect((await journal.pending()).map(({ operationId }) => operationId)).toEqual([
+      'escaping-env-root'
+    ])
+    expect(coordinator.isPrefixBlocked(prefix)).toBe(true)
+    expect(coordinator.isRuntimeIdBlocked(DEFAULT_PY_ENV)).toBe(true)
+  })
+
   it('fails closed after disposal even if reset commands clear known blocks', async () => {
     const coordinator = new NotebookRecoveryCoordinator(await createRuntimeRoot())
     const prefix = '/runtime/envs/default-python'

--- a/src/main/notebook/recovery-coordinator.ts
+++ b/src/main/notebook/recovery-coordinator.ts
@@ -9,7 +9,8 @@ import {
   RuntimeOperationJournal
 } from './operation-journal'
 import { defaultOperationChildLiveness, reconcileInterruptedOperations } from './operation-recovery'
-import { addRepairRequired } from './runtime-paths'
+import { verifyExecutable } from './provisioner-runtime'
+import { addRepairRequired, pythonBin, rBin } from './runtime-paths'
 import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
 
 export type NotebookRecoveryReadiness =
@@ -188,7 +189,17 @@ export class NotebookRecoveryCoordinator {
       },
       verifyOrRebuildEnv: async (record) => {
         if (!record.targetPath || !existsSync(record.targetPath)) return
-        if (existsSync(join(record.targetPath, 'conda-meta'))) return
+        const bin = [pythonBin(record.targetPath), rBin(record.targetPath)].find((candidate) =>
+          existsSync(candidate)
+        )
+        if (existsSync(join(record.targetPath, 'conda-meta')) && bin) {
+          try {
+            await verifyExecutable(bin, { prefix: record.targetPath })
+            return
+          } catch {
+            // An interrupted mutation can leave an interpreter file before the prefix is runnable.
+          }
+        }
         await rm(record.targetPath, { recursive: true, force: true })
       },
       markRepairRequired: async (record) => {

--- a/src/main/notebook/recovery-coordinator.ts
+++ b/src/main/notebook/recovery-coordinator.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { realpath, rm } from 'node:fs/promises'
+import { lstat, realpath, rm } from 'node:fs/promises'
 import { isAbsolute, join, relative, sep } from 'node:path'
 
 import {
@@ -208,6 +208,12 @@ export class NotebookRecoveryCoordinator {
           rejectUnsafe('Interrupted environment target is outside the managed runtime root.')
         }
         if (!existsSync(targetPath)) return
+        const targetStat = await lstat(targetPath).catch(() =>
+          rejectUnsafe('Interrupted environment target could not be validated.')
+        )
+        if (targetStat.isSymbolicLink()) {
+          rejectUnsafe('Interrupted environment target must not be a symbolic link.')
+        }
         const [canonicalRuntimeRoot, canonicalEnvsRoot, canonicalPrefix] = await Promise.all([
           realpath(this.runtimeRoot),
           realpath(envsRoot),

--- a/src/main/notebook/recovery-coordinator.ts
+++ b/src/main/notebook/recovery-coordinator.ts
@@ -208,19 +208,25 @@ export class NotebookRecoveryCoordinator {
           rejectUnsafe('Interrupted environment target is outside the managed runtime root.')
         }
         if (!existsSync(targetPath)) return
+        const [canonicalRuntimeRoot, canonicalEnvsRoot, canonicalPrefix] = await Promise.all([
+          realpath(this.runtimeRoot),
+          realpath(envsRoot),
+          realpath(targetPath)
+        ]).catch(() => rejectUnsafe('Interrupted environment paths could not be validated.'))
+        if (
+          canonicalEnvsRoot !== join(canonicalRuntimeRoot, 'envs') ||
+          !isDirectChild(canonicalEnvsRoot, canonicalPrefix)
+        ) {
+          rejectUnsafe('Interrupted environment target escapes the managed runtime root.')
+        }
         const bin = [pythonBin(targetPath), rBin(targetPath)].find((candidate) =>
           existsSync(candidate)
         )
         if (existsSync(join(targetPath, 'conda-meta')) && bin) {
-          const [canonicalEnvsRoot, canonicalPrefix, canonicalBin] = await Promise.all([
-            realpath(envsRoot),
-            realpath(targetPath),
-            realpath(bin)
-          ]).catch(() => rejectUnsafe('Interrupted environment paths could not be validated.'))
-          if (
-            !isDirectChild(canonicalEnvsRoot, canonicalPrefix) ||
-            !isPathInside(canonicalPrefix, canonicalBin)
-          ) {
+          const canonicalBin = await realpath(bin).catch(() =>
+            rejectUnsafe('Interrupted environment executable could not be validated.')
+          )
+          if (!isPathInside(canonicalPrefix, canonicalBin)) {
             rejectUnsafe('Interrupted environment executable escapes the managed runtime root.')
           }
           try {
@@ -230,7 +236,7 @@ export class NotebookRecoveryCoordinator {
             // An interrupted mutation can leave an interpreter file before the prefix is runnable.
           }
         }
-        await rm(targetPath, { recursive: true, force: true })
+        await rm(canonicalPrefix, { recursive: true, force: true })
       },
       markRepairRequired: async (record) => {
         if (!record.runtimeId) return

--- a/src/main/notebook/recovery-coordinator.ts
+++ b/src/main/notebook/recovery-coordinator.ts
@@ -207,10 +207,11 @@ export class NotebookRecoveryCoordinator {
         if (!isDirectChild(envsRoot, targetPath)) {
           rejectUnsafe('Interrupted environment target is outside the managed runtime root.')
         }
-        if (!existsSync(targetPath)) return
-        const targetStat = await lstat(targetPath).catch(() =>
-          rejectUnsafe('Interrupted environment target could not be validated.')
-        )
+        const targetStat = await lstat(targetPath).catch((error: NodeJS.ErrnoException) => {
+          if (error.code === 'ENOENT') return undefined
+          return rejectUnsafe('Interrupted environment target could not be validated.')
+        })
+        if (!targetStat) return
         if (targetStat.isSymbolicLink()) {
           rejectUnsafe('Interrupted environment target must not be a symbolic link.')
         }

--- a/src/main/notebook/recovery-coordinator.ts
+++ b/src/main/notebook/recovery-coordinator.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
-import { rm } from 'node:fs/promises'
-import { join } from 'node:path'
+import { realpath, rm } from 'node:fs/promises'
+import { isAbsolute, join, relative, sep } from 'node:path'
 
 import {
   operationJournalPath,
@@ -12,6 +12,14 @@ import { defaultOperationChildLiveness, reconcileInterruptedOperations } from '.
 import { verifyExecutable } from './provisioner-runtime'
 import { addRepairRequired, pythonBin, rBin } from './runtime-paths'
 import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
+
+const isPathInside = (root: string, candidate: string): boolean => {
+  const nested = relative(root, candidate)
+  return nested !== '' && !isAbsolute(nested) && nested !== '..' && !nested.startsWith(`..${sep}`)
+}
+
+const isDirectChild = (root: string, candidate: string): boolean =>
+  isPathInside(root, candidate) && !relative(root, candidate).includes(sep)
 
 export type NotebookRecoveryReadiness =
   'not-started' | 'recovering' | 'ready' | 'failed' | 'disposed'
@@ -188,19 +196,41 @@ export class NotebookRecoveryCoordinator {
         if (record.targetPath) await rm(record.targetPath, { recursive: true, force: true })
       },
       verifyOrRebuildEnv: async (record) => {
-        if (!record.targetPath || !existsSync(record.targetPath)) return
-        const bin = [pythonBin(record.targetPath), rBin(record.targetPath)].find((candidate) =>
+        const targetPath = record.targetPath
+        if (!targetPath) return
+        const rejectUnsafe = (message: string): never => {
+          nextStartupBlockedPrefixes.add(targetPath)
+          nextStartupBlockedRuntimeIds.add(record.runtimeId)
+          throw new Error(message)
+        }
+        const envsRoot = join(this.runtimeRoot, 'envs')
+        if (!isDirectChild(envsRoot, targetPath)) {
+          rejectUnsafe('Interrupted environment target is outside the managed runtime root.')
+        }
+        if (!existsSync(targetPath)) return
+        const bin = [pythonBin(targetPath), rBin(targetPath)].find((candidate) =>
           existsSync(candidate)
         )
-        if (existsSync(join(record.targetPath, 'conda-meta')) && bin) {
+        if (existsSync(join(targetPath, 'conda-meta')) && bin) {
+          const [canonicalEnvsRoot, canonicalPrefix, canonicalBin] = await Promise.all([
+            realpath(envsRoot),
+            realpath(targetPath),
+            realpath(bin)
+          ]).catch(() => rejectUnsafe('Interrupted environment paths could not be validated.'))
+          if (
+            !isDirectChild(canonicalEnvsRoot, canonicalPrefix) ||
+            !isPathInside(canonicalPrefix, canonicalBin)
+          ) {
+            rejectUnsafe('Interrupted environment executable escapes the managed runtime root.')
+          }
           try {
-            await verifyExecutable(bin, { prefix: record.targetPath })
+            await verifyExecutable(canonicalBin, { prefix: canonicalPrefix })
             return
           } catch {
             // An interrupted mutation can leave an interpreter file before the prefix is runnable.
           }
         }
-        await rm(record.targetPath, { recursive: true, force: true })
+        await rm(targetPath, { recursive: true, force: true })
       },
       markRepairRequired: async (record) => {
         if (!record.runtimeId) return

--- a/src/main/notebook/recovery-coordinator.ts
+++ b/src/main/notebook/recovery-coordinator.ts
@@ -10,7 +10,7 @@ import {
 } from './operation-journal'
 import { defaultOperationChildLiveness, reconcileInterruptedOperations } from './operation-recovery'
 import { verifyExecutable } from './provisioner-runtime'
-import { addRepairRequired, pythonBin, rBin } from './runtime-paths'
+import { addRepairRequired, DEFAULT_PY_ENV, DEFAULT_R_ENV, pythonBin, rBin } from './runtime-paths'
 import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
 
 const isPathInside = (root: string, candidate: string): boolean => {
@@ -226,9 +226,25 @@ export class NotebookRecoveryCoordinator {
         ) {
           rejectUnsafe('Interrupted environment target escapes the managed runtime root.')
         }
-        const bin = [pythonBin(targetPath), rBin(targetPath)].find((candidate) =>
-          existsSync(candidate)
-        )
+        const language =
+          record.phase.endsWith('-r') ||
+          (record.phase === 'restore' && record.runtimeId === DEFAULT_R_ENV)
+            ? 'r'
+            : record.phase.endsWith('-python') ||
+                (record.phase === 'restore' && record.runtimeId === DEFAULT_PY_ENV)
+              ? 'python'
+              : undefined
+        const expectedBin =
+          language === 'r'
+            ? rBin(targetPath)
+            : language === 'python'
+              ? pythonBin(targetPath)
+              : undefined
+        const bin = expectedBin
+          ? existsSync(expectedBin)
+            ? expectedBin
+            : undefined
+          : [pythonBin(targetPath), rBin(targetPath)].find((candidate) => existsSync(candidate))
         if (existsSync(join(targetPath, 'conda-meta')) && bin) {
           const canonicalBin = await realpath(bin).catch(() =>
             rejectUnsafe('Interrupted environment executable could not be validated.')


### PR DESCRIPTION
## Problem

Startup recovery treated the presence of conda-meta as proof that an interrupted materialize or upgrade had committed. A partial prefix with no interpreter was retained while its operation journal entry was cleared, so later startup could no longer recover it.

## Proposed change

Reuse the production verifyExecutable probe before accepting a recovered conda prefix, selecting the interpreter from the existing operation phase/default runtime identity. Before any execution or cleanup, require the journal target to be a non-symlink direct child of runtime/envs and verify that the canonical env root, prefix, and executable remain inside the canonical managed runtime. Use lstat so dangling links cannot masquerade as absent paths. Remove genuinely incomplete or non-runnable prefixes; retain the journal and use the existing prefix/runtime block when path validation is unsafe.

## Scope and non-goals

- No new journal fields, enum values, schema, data model, or UI interaction.
- Existing journal records remain compatible. Records whose language is not encoded (legacy or named restore) retain the existing interpreter-presence fallback.
- Existing blocked-prefix/runtime states are reused; no state value is added.
- This broadens the existing persistent cleanup of incomplete prefixes; it does not add a persistence format.
- No separate kernel-protocol probe is introduced; recovery matches the production materialize and upgrade interpreter verification boundary.

## Acceptance criteria and validation

All listed passing checks ran after the final material edit.

- Original report reproduction: conda-meta-only prefix is removed and journal reconciliation completes.
- Language regression: interrupted R create/default-R restore records verify R rather than accepting an auxiliary Python executable.
- Security review reproductions: outside journal targets, escaping prefix symlinks, a symlinked env root, in-root prefix symlinks, and dangling prefix links are not executed or used to delete their referents; journal evidence is retained and recovery stays blocked.
- Recovery, dispatch, interpreter verifier, and runtime-service consumer boundaries -> npm test -- src/main/notebook/recovery-coordinator.test.ts src/main/notebook/operation-recovery.test.ts src/main/notebook/provisioner-runtime.test.ts src/main/notebook/runtime-service.test.ts -t "NotebookRecoveryCoordinator|reconcileInterruptedOperations|verifyExecutable|recovers an interrupted download|shares one startup recovery attempt|treats a missing startup journal as ready|blocks a no-binding execute" -> 28 passed.
- Main-process types -> npm run typecheck:node -> pass.
- Repository lint, uncached -> npm run lint -- --no-cache -> pass.
- Impact explanation -> npm run test:affected -- --base origin/main --head HEAD --explain -> full fallback because the notebook recovery test has no registered module owner.

The original regression test was run three times before the fix and failed deterministically with prefixExists true and pending [], matching the report. Each subsequently reported unsafe-path/language case was also reproduced before its fix. The symlinked-env-root, in-root sibling-symlink, dangling-link, and R-language regressions each failed three times on the relevant intermediate implementation, then passed after validation was tightened. The complete local npm test suite was intentionally not run; PR Gate is the authority for portable and platform lanes. A broad provisioner-runtime run exposed four pre-existing Node 26 process-reaping failures in timeout, cancellation, and PID-recording tests; the directly affected verifyExecutable subset passes.

## Review focus

Please verify that recovery selects the intended interpreter, accepts an interrupted prefix only after the normal interpreter probe, rejects all symlinked recovery prefixes including dangling links, validates canonical containment before every execution and cleanup branch, and retains blocked recovery evidence when path validation fails.
