### PR TITLE
feat(global-search): add session number lookup

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -723,6 +723,12 @@ colors communicate a successful or failed probe/migration result.
   list is empty, each Project row also shows its artifact count from a complete Project Files index;
   partial index counts are omitted. While those counts are visible, Project Files change events
   refresh the affected Project so index repair and file changes do not leave stale totals.
+- Global search Session rows share the same result skeleton as Artifact rows: a `size-10` leading
+  visual anchor, two text lines, and stable trailing metadata. Artifact rows use their thumbnail and
+  contextual actions; Session rows use a neutral icon tile and show their SQLite-backed `#number` as
+  quiet monospaced tabular text. Do not render a redundant Session type badge. A pure numeric query
+  matches positive Session-number prefixes and ranks an exact number first; nonnumeric queries remain
+  title-only so global search does not expand into message-body or metadata search.
 - List row: `h-10 rounded-lg px-3 hover:bg-accent hover:text-accent-foreground`.
 - Inline more actions: default `opacity-0`, then `opacity-100` on hover or focus-visible.
 

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -258,6 +258,55 @@ describe('GlobalSearchDialog', () => {
     expect(sessionRows[1].querySelector('.font-mono.tabular-nums')?.textContent).toBe('#123')
   })
 
+  it('selects an exact Session number from another Project before a local prefix match', async () => {
+    vi.mocked(window.api.projectFiles.searchArtifacts).mockResolvedValue({
+      primary: { items: [], totalCount: 0 },
+      other: [],
+      isIndexComplete: true
+    })
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === 'session-a'
+          ? { ...session, number: 123 }
+          : session.id === 'session-b'
+            ? { ...session, number: 12 }
+            : session
+      )
+    }))
+    const onOpenChange = vi.fn()
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={onOpenChange} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+
+    const input = document.body.querySelector<HTMLInputElement>('input[role="combobox"]')
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      'value'
+    )?.set
+    await act(async () => {
+      valueSetter?.call(input, '12')
+      input?.dispatchEvent(new Event('input', { bubbles: true }))
+      await new Promise((resolve) => window.setTimeout(resolve, 180))
+    })
+
+    const selectedOption = document.body.querySelector<HTMLElement>(
+      '[role="option"][aria-selected="true"]'
+    )
+    expect(selectedOption?.textContent).toContain('Other sin session')
+    expect(selectedOption?.textContent).toContain('Beta')
+    expect(selectedOption?.textContent).toContain('#12')
+
+    await act(async () => {
+      input?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+      )
+    })
+    expect(useNavigationStore.getState().activeProjectId).toBe('project-b')
+    expect(useSessionStore.getState().selectedSessionId).toBe('session-b')
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
   it('waits for Artifact search before showing a complete keyword result set', async () => {
     await act(async () => {
       root.render(<GlobalSearchDialog open onOpenChange={vi.fn()} isSessionPersistenceReady />)

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -154,6 +154,12 @@ describe('GlobalSearchDialog', () => {
     expect(sessionRow.querySelector('[data-testid="global-search-session-icon"]')).not.toBeNull()
     expect(sessionRow.querySelector('.font-mono.tabular-nums')?.textContent).toBe('#12')
     expect(document.body.textContent).toContain('New session')
+    const newSession = [...document.body.querySelectorAll<HTMLElement>('[role="option"]')].find(
+      (element) => element.textContent?.includes('New session')
+    )
+    const newSessionIcon = newSession?.querySelector('[data-testid="global-search-command-icon"]')
+    expect(newSessionIcon?.classList.contains('size-10')).toBe(true)
+    expect(newSessionIcon?.classList.contains('shrink-0')).toBe(true)
     const input = document.body.querySelector<HTMLInputElement>('input[role="combobox"]')
     expect(input?.placeholder).toBe('Search this project…')
     expect(input?.parentElement?.textContent).toContain('Alpha')
@@ -743,6 +749,9 @@ describe('GlobalSearchDialog', () => {
     const newProject = [...document.body.querySelectorAll<HTMLElement>('[role="option"]')].find(
       (element) => element.textContent?.includes('New project')
     )
+    const newProjectIcon = newProject?.querySelector('[data-testid="global-search-command-icon"]')
+    expect(newProjectIcon?.classList.contains('size-10')).toBe(true)
+    expect(newProjectIcon?.classList.contains('shrink-0')).toBe(true)
     await act(async () => newProject?.click())
     expect(useNavigationStore.getState()).toMatchObject({
       view: 'home',

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -74,6 +74,7 @@ beforeEach(() => {
         id: 'session-a',
         projectId: 'project-a',
         title: 'Python 绘制 sin 函数图',
+        number: 12,
         cwd: '/workspace',
         status: 'idle',
         createdAt: Date.now(),
@@ -85,6 +86,7 @@ beforeEach(() => {
         id: 'session-b',
         projectId: 'project-b',
         title: 'Other sin session',
+        number: 123,
         cwd: '/workspace',
         status: 'idle',
         createdAt: Date.now() - 1,
@@ -145,6 +147,12 @@ describe('GlobalSearchDialog', () => {
 
     expect(document.body.textContent).toContain('Recent artifacts')
     expect(document.body.textContent).toContain('Recent sessions')
+    const sessionRow = [...document.body.querySelectorAll('[role="option"]')].find((element) =>
+      element.querySelector('[data-testid="global-search-session-icon"]')
+    ) as HTMLElement
+    expect(sessionRow.textContent).toContain('#12')
+    expect(sessionRow.querySelector('[data-testid="global-search-session-icon"]')).not.toBeNull()
+    expect(sessionRow.querySelector('.font-mono.tabular-nums')?.textContent).toBe('#12')
     expect(document.body.textContent).toContain('New session')
     const input = document.body.querySelector<HTMLInputElement>('input[role="combobox"]')
     expect(input?.placeholder).toBe('Search this project…')
@@ -209,6 +217,39 @@ describe('GlobalSearchDialog', () => {
       artifactId: 'artifact-1',
       projectId: 'project-a'
     })
+  })
+
+  it('finds Sessions by number while keeping the number visible as trailing metadata', async () => {
+    vi.mocked(window.api.projectFiles.searchArtifacts).mockResolvedValue({
+      primary: { items: [], totalCount: 0 },
+      other: [],
+      isIndexComplete: true
+    })
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={vi.fn()} isSessionPersistenceReady />)
+      await new Promise((resolve) => window.setTimeout(resolve, 20))
+    })
+
+    const input = document.body.querySelector<HTMLInputElement>('input[role="combobox"]')
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      'value'
+    )?.set
+    await act(async () => {
+      valueSetter?.call(input, '12')
+      input?.dispatchEvent(new Event('input', { bubbles: true }))
+      await new Promise((resolve) => window.setTimeout(resolve, 180))
+    })
+
+    const sessionRows = [...document.body.querySelectorAll<HTMLElement>('[role="option"]')].filter(
+      (element) => element.querySelector('[data-testid="global-search-session-icon"]')
+    )
+    expect(sessionRows.map((row) => row.textContent)).toEqual([
+      expect.stringContaining('Python 绘制 sin 函数图'),
+      expect.stringContaining('Other sin session')
+    ])
+    expect(sessionRows[0].querySelector('.font-mono.tabular-nums')?.textContent).toBe('#12')
+    expect(sessionRows[1].querySelector('.font-mono.tabular-nums')?.textContent).toBe('#123')
   })
 
   it('waits for Artifact search before showing a complete keyword result set', async () => {

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -6,7 +6,7 @@
  */
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ArrowUpRight, AtSign, Hash, LoaderCircle, MessageCircle, Search, Zap } from 'lucide-react'
+import { ArrowUpRight, AtSign, LoaderCircle, MessageCircle, Search, Zap } from 'lucide-react'
 import { Dialog } from 'radix-ui'
 import { useShallow } from 'zustand/react/shallow'
 
@@ -234,6 +234,7 @@ export const GlobalSearchDialog = ({
               id: session.id,
               projectId: session.projectId,
               title: session.title,
+              number: session.number,
               updatedAt: session.updatedAt,
               artifactCount: session.artifacts?.length ?? session.artifactCount ?? 0,
               isPending: session.isPending
@@ -262,6 +263,7 @@ export const GlobalSearchDialog = ({
               id: session.id,
               projectId: session.projectId,
               title: session.title,
+              number: session.number,
               updatedAt: session.updatedAt,
               artifactCount: session.artifacts?.length ?? session.artifactCount ?? 0,
               isPending: session.isPending
@@ -610,7 +612,13 @@ export const GlobalSearchDialog = ({
         onMouseEnter={() => setActiveIndex(rowIndex)}
         onClick={() => activate({ kind: 'session', session })}
       >
-        <MessageCircle className="size-5 shrink-0 text-primary" aria-hidden="true" />
+        <span
+          data-testid="global-search-session-icon"
+          className="flex size-10 shrink-0 items-center justify-center rounded-md border border-border-300/50 bg-bg-200 text-primary"
+          aria-hidden="true"
+        >
+          <MessageCircle className="size-5" />
+        </span>
         <span className="min-w-0 flex-1">
           <span className="block truncate text-sm font-medium text-foreground">
             {session.title}
@@ -626,13 +634,13 @@ export const GlobalSearchDialog = ({
             · {relativeTime(session.updatedAt)}
           </span>
         </span>
-        {active ? (
-          <Hash className="size-5 shrink-0 text-foreground" aria-label={t('Session')} />
-        ) : (
-          <span className="rounded bg-primary/15 px-2 py-0.5 text-xs font-medium text-primary">
-            {t('Session')}
+        {session.number !== undefined &&
+        Number.isSafeInteger(session.number) &&
+        session.number > 0 ? (
+          <span className="shrink-0 font-mono text-xs text-muted-foreground tabular-nums">
+            #{session.number}
           </span>
-        )}
+        ) : null}
       </div>
     )
   }

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -948,11 +948,17 @@ export const GlobalSearchDialog = ({
                       activate({ kind: isProjectScope ? 'new-session' : 'new-project' })
                     }
                   >
-                    {isProjectScope ? (
-                      <MessageCircle className="size-5 text-primary" aria-hidden="true" />
-                    ) : (
-                      <Zap className="size-5 text-primary" aria-hidden="true" />
-                    )}
+                    <span
+                      data-testid="global-search-command-icon"
+                      className="flex size-10 shrink-0 items-center justify-center rounded-md border border-border-300/50 bg-bg-200 text-primary"
+                      aria-hidden="true"
+                    >
+                      {isProjectScope ? (
+                        <MessageCircle className="size-5" />
+                      ) : (
+                        <Zap className="size-5" />
+                      )}
+                    </span>
                     <span className="text-sm font-medium">
                       {isProjectScope ? t('New session') : t('New project')}
                     </span>

--- a/src/renderer/src/components/global-search/global-search-catalog.test.ts
+++ b/src/renderer/src/components/global-search/global-search-catalog.test.ts
@@ -12,6 +12,7 @@ const sessions = (count: number, projectId = 'project-a'): SearchableSession[] =
     id: `session-${index}`,
     projectId,
     title: `Python sin ${index}`,
+    number: index + 1,
     updatedAt: 1_000 - index,
     artifactCount: index,
     isPending: false
@@ -73,6 +74,29 @@ describe('global search catalog', () => {
     expect(result.primary).toHaveLength(5)
     expect(result.primaryTotalCount).toBe(6)
     expect(result.other).toEqual([])
+  })
+
+  it('matches positive Session-number prefixes and ranks an exact number first', () => {
+    const result = searchSessionTitles({
+      sessions: [
+        { ...sessions(1)[0], id: 'newer-prefix', number: 123, updatedAt: 3_000 },
+        { ...sessions(1)[0], id: 'exact', number: 12, updatedAt: 1_000 },
+        { ...sessions(1)[0], id: 'older-prefix', number: 120, updatedAt: 2_000 },
+        { ...sessions(1)[0], id: 'title-only', title: 'Session 12', number: 7, updatedAt: 4_000 },
+        { ...sessions(1)[0], id: 'missing', number: undefined, updatedAt: 5_000 },
+        { ...sessions(1)[0], id: 'invalid', number: 0, updatedAt: 6_000 }
+      ],
+      projectNames: new Map([['project-a', 'Alpha']]),
+      primaryProjectId: 'project-a',
+      query: '12',
+      visiblePrimaryCount: 8
+    })
+
+    expect(result.primary.map((session) => session.id)).toEqual([
+      'exact',
+      'newer-prefix',
+      'older-prefix'
+    ])
   })
 
   it('returns recent non-pending sessions in recency order with a five-row cap', () => {

--- a/src/renderer/src/components/global-search/global-search-catalog.test.ts
+++ b/src/renderer/src/components/global-search/global-search-catalog.test.ts
@@ -99,6 +99,40 @@ describe('global search catalog', () => {
     ])
   })
 
+  it('promotes an exact Session-number match from another Project ahead of local prefixes', () => {
+    const result = searchSessionTitles({
+      sessions: [
+        { ...sessions(1)[0], id: 'local-prefix', number: 123, updatedAt: 3_000 },
+        {
+          ...sessions(1, 'project-b')[0],
+          id: 'cross-project-exact',
+          number: 12,
+          updatedAt: 1_000
+        },
+        {
+          ...sessions(1, 'project-b')[0],
+          id: 'cross-project-prefix',
+          number: 120,
+          updatedAt: 2_000
+        }
+      ],
+      projectNames: new Map([
+        ['project-a', 'Alpha'],
+        ['project-b', 'Beta']
+      ]),
+      primaryProjectId: 'project-a',
+      query: '12',
+      visiblePrimaryCount: 8
+    })
+
+    expect(result.primary.map((session) => session.id)).toEqual([
+      'cross-project-exact',
+      'local-prefix'
+    ])
+    expect(result.primary[0].projectName).toBe('Beta')
+    expect(result.other.map((session) => session.id)).toEqual(['cross-project-prefix'])
+  })
+
   it('returns recent non-pending sessions in recency order with a five-row cap', () => {
     const recent = getRecentSessions(
       [

--- a/src/renderer/src/components/global-search/global-search-catalog.ts
+++ b/src/renderer/src/components/global-search/global-search-catalog.ts
@@ -79,8 +79,19 @@ export const searchSessionTitles = ({
       }
       return compareByRecency(left, right)
     })
+  const promotedExactMatch =
+    primaryProjectId && numericQuery
+      ? matches.find(
+          (session) =>
+            session.projectId !== primaryProjectId &&
+            String(validSessionNumber(session.number)) === numericQuery
+        )
+      : undefined
   const primaryMatches = primaryProjectId
-    ? matches.filter((session) => session.projectId === primaryProjectId)
+    ? [
+        ...(promotedExactMatch ? [promotedExactMatch] : []),
+        ...matches.filter((session) => session.projectId === primaryProjectId)
+      ]
     : matches
 
   return {
@@ -90,7 +101,9 @@ export const searchSessionTitles = ({
     primaryTotalCount: primaryMatches.length,
     other: primaryProjectId
       ? matches
-          .filter((session) => session.projectId !== primaryProjectId)
+          .filter(
+            (session) => session.projectId !== primaryProjectId && session !== promotedExactMatch
+          )
           .slice(0, OTHER_PROJECT_RESULT_LIMIT)
           .map((session) => toResult(session, projectNames))
       : []

--- a/src/renderer/src/components/global-search/global-search-catalog.ts
+++ b/src/renderer/src/components/global-search/global-search-catalog.ts
@@ -6,6 +6,7 @@ export type SearchableSession = {
   id: string
   projectId: string
   title: string
+  number?: number
   updatedAt: number
   artifactCount: number
   isPending?: boolean
@@ -30,6 +31,9 @@ const foldAsciiCase = (value: string): string =>
 const compareByRecency = (left: SearchableSession, right: SearchableSession): number =>
   right.updatedAt - left.updatedAt || right.id.localeCompare(left.id)
 
+const validSessionNumber = (number: number | undefined): number | undefined =>
+  number !== undefined && Number.isSafeInteger(number) && number > 0 ? number : undefined
+
 const toResult = (
   session: SearchableSession,
   projectNames: Map<string, string>
@@ -39,8 +43,9 @@ const toResult = (
   projectName: projectNames.get(session.projectId)
 })
 
-// Session titles are already hydrated in the renderer. Keep this local filter deliberately narrow
-// so global search does not accidentally become message-body or metadata search.
+// Session titles and numbers are already hydrated in the renderer. Keep this local filter
+// deliberately narrow so global search does not accidentally become message-body or metadata
+// search. A numeric query is an identity lookup: exact number first, then number prefixes.
 export const searchSessionTitles = ({
   sessions,
   projectNames,
@@ -55,14 +60,25 @@ export const searchSessionTitles = ({
   visiblePrimaryCount: number
 }): SessionSearchGroups => {
   const foldedQuery = foldAsciiCase(query.trim())
+  const numericQuery = /^\d+$/.test(foldedQuery) ? foldedQuery : undefined
   const matches = sessions
     .filter(
       (session) =>
         !session.isPending &&
         projectNames.has(session.projectId) &&
-        foldAsciiCase(session.title).includes(foldedQuery)
+        (numericQuery
+          ? String(validSessionNumber(session.number) ?? '').startsWith(numericQuery)
+          : foldAsciiCase(session.title).includes(foldedQuery))
     )
-    .sort(compareByRecency)
+    .sort((left, right) => {
+      if (numericQuery) {
+        const exactOrder =
+          Number(String(validSessionNumber(right.number)) === numericQuery) -
+          Number(String(validSessionNumber(left.number)) === numericQuery)
+        if (exactOrder !== 0) return exactOrder
+      }
+      return compareByRecency(left, right)
+    })
   const primaryMatches = primaryProjectId
     ? matches.filter((session) => session.projectId === primaryProjectId)
     : matches


### PR DESCRIPTION
## Problem

Session numbers are available in persisted Session summaries and in Composer references, but global search neither displays them nor accepts them as a lookup key.

## Proposed change

- display each valid Session number as stable trailing metadata in global search
- align Session rows with the existing Artifact result skeleton through a matching leading visual slot and two-line text hierarchy
- match pure numeric queries against Session-number prefixes and rank an exact number first
- retain title-only matching for nonnumeric Session queries

## Scope and non-goals

- no database, migration, persistence, IPC, or renderer contract changes
- no new state or enum values
- historical Sessions without a valid positive number remain searchable by title and omit number metadata
- no number presentation changes outside global search

## Acceptance criteria and validation

Checks below ran after the last material edit:

- Session number filtering and exact-match ordering -> `npx vitest run src/renderer/src/components/global-search/global-search-catalog.test.ts src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx` -> 23 passed
- localized global-search rendering and renderer i18n catalog guard -> `npx vitest run src/renderer/src/components/global-search/GlobalSearchDialog.i18n.render.test.tsx src/renderer/src/i18n/resources.test.ts` -> 597 passed
- renderer type safety -> `npm run typecheck:web` -> passed
- source lint -> `npm run lint` -> passed
- changed-file formatting -> `npx prettier --check ...` -> passed

`npm run test:affected -- --base origin/main --head HEAD --explain` conservatively selected the full suite because `docs/design.md` has no module owner. Per the requested validation scope, the local full suite was not run; PR Gate remains authoritative for complete and platform-specific coverage.

## Review focus

- whether the Session and Artifact result rows now form one coherent hierarchy
- whether numeric lookup remains narrowly scoped to Session identity without expanding text search into other metadata
- whether missing historical numbers degrade without visual or search regressions
