### PR TITLE
fix(settings): allow Codex subscription vision models

### DIFF
--- a/src/main/acp/artifact-code-reconstruction-runner.test.ts
+++ b/src/main/acp/artifact-code-reconstruction-runner.test.ts
@@ -102,7 +102,11 @@ describe('Artifact code reconstruction backend profiles', () => {
     )
 
     expect(prepared.env.CODEX_HOME).toBe(join(temporaryRoot, 'codex'))
-    expect(JSON.parse(prepared.env.CODEX_CONFIG!)).toEqual({ model_provider: 'open-science' })
+    expect(JSON.parse(prepared.env.CODEX_CONFIG!)).toMatchObject({
+      model_provider: 'open-science',
+      features: { shell_tool: false },
+      tools: { web_search: false }
+    })
     await expect(
       readFile(join(prepared.env.CODEX_HOME!, 'config.toml'), 'utf8')
     ).resolves.toContain('cli_auth_credentials_store = "ephemeral"')

--- a/src/main/acp/artifact-code-reconstruction-runner.ts
+++ b/src/main/acp/artifact-code-reconstruction-runner.ts
@@ -64,7 +64,11 @@ export class ArtifactCodeReconstructionRunner {
       appVersion: options.appVersion,
       configRoot: options.configRoot,
       profileNamespace: 'artifact-code-reconstruction',
-      resolveTarget: options.resolveTarget,
+      resolveTarget: (target, context) =>
+        options.resolveTarget(target, {
+          ...context,
+          forceCodexNativeResponsesCompatibility: true
+        }),
       now: options.now
     })
   }

--- a/src/main/acp/restricted-inference-runner.test.ts
+++ b/src/main/acp/restricted-inference-runner.test.ts
@@ -157,6 +157,20 @@ describe('RestrictedInferenceRunner', () => {
     const sourceHome = join(temporaryRoot, 'subscription-home')
     await mkdir(sourceHome)
     await writeFile(join(sourceHome, 'auth.json'), '{"tokens":{"access_token":"secret"}}')
+    await writeFile(
+      join(sourceHome, 'config.toml'),
+      [
+        'cli_auth_credentials_store = "file"',
+        'model_provider = "subscription-route"',
+        '',
+        '[model_providers."subscription-route"]',
+        'name = "Subscription route"',
+        'base_url = "http://127.0.0.1:43123/v1"',
+        'wire_api = "responses"',
+        'requires_openai_auth = true',
+        ''
+      ].join('\n')
+    )
 
     const prepared = await prepareRestrictedBackend(
       backend(codexFramework, {
@@ -179,9 +193,10 @@ describe('RestrictedInferenceRunner', () => {
     )
 
     expect(await readFile(join(prepared.env.CODEX_HOME!, 'auth.json'), 'utf8')).toContain('secret')
-    expect(await readFile(join(prepared.env.CODEX_HOME!, 'config.toml'), 'utf8')).toContain(
-      'cli_auth_credentials_store = "file"'
-    )
+    const configToml = await readFile(join(prepared.env.CODEX_HOME!, 'config.toml'), 'utf8')
+    expect(configToml).toContain('cli_auth_credentials_store = "file"')
+    expect(configToml).toContain('model_provider = "subscription-route"')
+    expect(configToml).toContain('base_url = "http://127.0.0.1:43123/v1"')
     expect(JSON.parse(prepared.env.CODEX_CONFIG!)).toMatchObject({
       experimental_use_unified_exec_tool: false,
       features: {
@@ -258,7 +273,7 @@ describe('RestrictedInferenceRunner', () => {
   })
 
   it('runs a native Codex subscription target through its restricted profile', async () => {
-    const { runner } = await makeRunner(backend(codexFramework), {
+    const { runner, resolveTarget } = await makeRunner(backend(codexFramework), {
       events: [event({ role: 'assistant', text: 'PONG' })]
     })
 
@@ -270,6 +285,10 @@ describe('RestrictedInferenceRunner', () => {
     ).resolves.toMatchObject({
       text: 'PONG',
       frameworkId: 'codex'
+    })
+    expect(resolveTarget).toHaveBeenCalledWith(target('codex', CODEX_SHARED_PROVIDER_ID), {
+      systemPromptAppends: ['Do not use tools.'],
+      includeSkillAndConnectorContext: false
     })
   })
 

--- a/src/main/acp/restricted-inference-runner.test.ts
+++ b/src/main/acp/restricted-inference-runner.test.ts
@@ -168,6 +168,9 @@ describe('RestrictedInferenceRunner', () => {
         'base_url = "http://127.0.0.1:43123/v1"',
         'wire_api = "responses"',
         'requires_openai_auth = true',
+        '',
+        '[mcp_servers.persisted-tool]',
+        'command = "unsafe-tool"',
         ''
       ].join('\n')
     )
@@ -177,6 +180,8 @@ describe('RestrictedInferenceRunner', () => {
         backendId: `codex:${CODEX_SHARED_PROVIDER_ID}`,
         env: {
           CODEX_HOME: sourceHome,
+          HOME: sourceHome,
+          USERPROFILE: sourceHome,
           CODEX_CONFIG: JSON.stringify({
             developer_instructions: 'load every tool',
             features: { multi_agent: false }
@@ -197,6 +202,10 @@ describe('RestrictedInferenceRunner', () => {
     expect(configToml).toContain('cli_auth_credentials_store = "file"')
     expect(configToml).toContain('model_provider = "subscription-route"')
     expect(configToml).toContain('base_url = "http://127.0.0.1:43123/v1"')
+    expect(configToml).not.toContain('mcp_servers')
+    expect(configToml).not.toContain('unsafe-tool')
+    expect(prepared.env.HOME).toBe(prepared.env.CODEX_HOME)
+    expect(prepared.env.USERPROFILE).toBe(prepared.env.CODEX_HOME)
     expect(JSON.parse(prepared.env.CODEX_CONFIG!)).toMatchObject({
       experimental_use_unified_exec_tool: false,
       features: {

--- a/src/main/acp/restricted-inference-runner.test.ts
+++ b/src/main/acp/restricted-inference-runner.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -129,6 +129,7 @@ const makeRunner = async (
     configRoot: temporaryRoot,
     profileNamespace: 'test-inference',
     resolveTarget,
+    allowNativeCodexSubscription: true,
     createRuntime: (options) => {
       runtime.onRuntime?.()
       const created = runtimeHarness(options, runtime)
@@ -151,6 +152,54 @@ const runInput = (
 })
 
 describe('RestrictedInferenceRunner', () => {
+  it('builds a disposable tool-less profile from app-owned Codex subscription auth', async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-restricted-codex-subscription-'))
+    const sourceHome = join(temporaryRoot, 'subscription-home')
+    await mkdir(sourceHome)
+    await writeFile(join(sourceHome, 'auth.json'), '{"tokens":{"access_token":"secret"}}')
+
+    const prepared = await prepareRestrictedBackend(
+      backend(codexFramework, {
+        backendId: `codex:${CODEX_SHARED_PROVIDER_ID}`,
+        env: {
+          CODEX_HOME: sourceHome,
+          CODEX_CONFIG: JSON.stringify({
+            developer_instructions: 'load every tool',
+            features: { multi_agent: false }
+          })
+        }
+      }),
+      temporaryRoot,
+      {
+        agentName: 'restricted-fixture',
+        description: 'Synthetic restricted inference fixture.',
+        systemPrompt: 'Do not use tools.',
+        openCodePermissions: { '*': 'deny' }
+      }
+    )
+
+    expect(await readFile(join(prepared.env.CODEX_HOME!, 'auth.json'), 'utf8')).toContain('secret')
+    expect(await readFile(join(prepared.env.CODEX_HOME!, 'config.toml'), 'utf8')).toContain(
+      'cli_auth_credentials_store = "file"'
+    )
+    expect(JSON.parse(prepared.env.CODEX_CONFIG!)).toMatchObject({
+      experimental_use_unified_exec_tool: false,
+      features: {
+        multi_agent: false,
+        shell_tool: false,
+        code_mode: false,
+        code_mode_host: false,
+        apply_patch_freeform: false,
+        apps: false,
+        browser_use: false,
+        computer_use: false,
+        image_generation: false,
+        workspace_dependencies: false
+      },
+      tools: { web_search: false }
+    })
+  })
+
   it('removes the Claude Skill projection and loader from restricted Session setup', async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-restricted-inference-'))
     const projectionRoot = '/runtime-support/agent-skills/claude/revision'
@@ -208,17 +257,19 @@ describe('RestrictedInferenceRunner', () => {
     expect(JSON.stringify(claudeOptions)).not.toContain(LOAD_SKILL_TOOL_CALLABLE_NAME)
   })
 
-  it('fails closed only for native Codex subscription targets', async () => {
-    const { runner } = await makeRunner(backend(claudeCodeFramework))
+  it('runs a native Codex subscription target through its restricted profile', async () => {
+    const { runner } = await makeRunner(backend(codexFramework), {
+      events: [event({ role: 'assistant', text: 'PONG' })]
+    })
 
     expect(runner.supportsTarget(target('claude-code'))).toBe(true)
     expect(runner.supportsTarget(target('opencode'))).toBe(true)
     expect(runner.supportsTarget(target('codex'))).toBe(true)
-    expect(runner.supportsTarget(target('codex', CODEX_SHARED_PROVIDER_ID))).toBe(false)
     await expect(
       runner.run(runInput({ target: target('codex', CODEX_SHARED_PROVIDER_ID) }))
-    ).rejects.toMatchObject({
-      code: 'transport-unavailable'
+    ).resolves.toMatchObject({
+      text: 'PONG',
+      frameworkId: 'codex'
     })
   })
 

--- a/src/main/acp/restricted-inference-runner.ts
+++ b/src/main/acp/restricted-inference-runner.ts
@@ -61,7 +61,7 @@ type RestrictedInferenceRunnerOptions = Readonly<{
     context: {
       systemPromptAppends: string[]
       includeSkillAndConnectorContext: false
-      forceCodexNativeResponsesCompatibility: true
+      forceCodexNativeResponsesCompatibility?: true
     }
   ) => Promise<ResolvedAgentBackend>
   now?: () => number
@@ -213,10 +213,14 @@ class RestrictedInferenceRunner {
       const cwd = join(jobRoot, 'cwd')
       const profileRoot = join(jobRoot, 'profile')
       await Promise.all([mkdir(cwd), mkdir(profileRoot)])
+      const nativeCodexSubscriptionAllowed =
+        input.target.frameworkId === 'codex' &&
+        isCodexSubscriptionProviderId(input.target.providerId) &&
+        this.options.allowNativeCodexSubscription === true
       backend = await this.options.resolveTarget(input.target, {
         systemPromptAppends: [input.systemPrompt],
         includeSkillAndConnectorContext: false,
-        forceCodexNativeResponsesCompatibility: true
+        ...(nativeCodexSubscriptionAllowed ? {} : { forceCodexNativeResponsesCompatibility: true })
       })
       ensureActive()
       const resolvedBackend = await prepareRestrictedBackend(backend, profileRoot, {
@@ -230,9 +234,7 @@ class RestrictedInferenceRunner {
       ensureActive()
       const bridge = resolvedBackend.responsesBridgeLease
       const nativeCodexSubscriptionToolingDisabled =
-        resolvedBackend.framework.id === 'codex' &&
-        isCodexSubscriptionProviderId(input.target.providerId) &&
-        this.options.allowNativeCodexSubscription === true
+        resolvedBackend.framework.id === 'codex' && nativeCodexSubscriptionAllowed
       if (
         resolvedBackend.framework.id === 'codex' &&
         !nativeCodexSubscriptionToolingDisabled &&

--- a/src/main/acp/restricted-inference-runner.ts
+++ b/src/main/acp/restricted-inference-runner.ts
@@ -66,6 +66,7 @@ type RestrictedInferenceRunnerOptions = Readonly<{
   ) => Promise<ResolvedAgentBackend>
   now?: () => number
   createRuntime?: (options: AcpRuntimeOptions) => RestrictedInferenceRuntime
+  allowNativeCodexSubscription?: boolean
 }>
 
 type ActiveRun = {
@@ -117,7 +118,11 @@ class RestrictedInferenceRunner {
   }
 
   supportsTarget(target: ExplicitAgentBackendTarget): boolean {
-    return !(target.frameworkId === 'codex' && isCodexSubscriptionProviderId(target.providerId))
+    return !(
+      target.frameworkId === 'codex' &&
+      isCodexSubscriptionProviderId(target.providerId) &&
+      this.options.allowNativeCodexSubscription !== true
+    )
   }
 
   async sweepStaleProfiles(): Promise<void> {
@@ -224,8 +229,13 @@ class RestrictedInferenceRunner {
       backend = resolvedBackend
       ensureActive()
       const bridge = resolvedBackend.responsesBridgeLease
+      const nativeCodexSubscriptionToolingDisabled =
+        resolvedBackend.framework.id === 'codex' &&
+        isCodexSubscriptionProviderId(input.target.providerId) &&
+        this.options.allowNativeCodexSubscription === true
       if (
         resolvedBackend.framework.id === 'codex' &&
+        !nativeCodexSubscriptionToolingDisabled &&
         (!bridge?.registerToolLessSession || !bridge.unregisterToolLessSession)
       ) {
         throw new RestrictedInferenceError(

--- a/src/main/acp/restricted-runtime-profile.ts
+++ b/src/main/acp/restricted-runtime-profile.ts
@@ -60,6 +60,22 @@ const copyCodexAuthentication = async (
   }
 }
 
+const copyCodexConfig = async (
+  sourceHome: string | undefined,
+  targetHome: string
+): Promise<boolean> => {
+  if (!sourceHome || sourceHome === targetHome) return false
+  try {
+    const target = join(targetHome, 'config.toml')
+    await copyFile(join(sourceHome, 'config.toml'), target)
+    await chmod(target, 0o600)
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
+    throw error
+  }
+}
+
 const removeClaudeSkillRuntimeCapability = (
   source: Readonly<Record<string, unknown>> | undefined
 ): Record<string, unknown> => {
@@ -144,12 +160,17 @@ const prepareCodexBackend = async (
 ): Promise<ResolvedAgentBackend> => {
   const codexHome = join(profileRoot, 'codex')
   await mkdir(codexHome, { recursive: true })
-  const hasFileAuthentication = await copyCodexAuthentication(backend.env.CODEX_HOME, codexHome)
-  await writeFile(
-    join(codexHome, 'config.toml'),
-    `cli_auth_credentials_store = "${hasFileAuthentication ? 'file' : 'ephemeral'}"\n`,
-    { encoding: 'utf8', mode: 0o600 }
-  )
+  const [hasFileAuthentication, hasAppOwnedConfig] = await Promise.all([
+    copyCodexAuthentication(backend.env.CODEX_HOME, codexHome),
+    copyCodexConfig(backend.env.CODEX_HOME, codexHome)
+  ])
+  if (!hasAppOwnedConfig) {
+    await writeFile(
+      join(codexHome, 'config.toml'),
+      `cli_auth_credentials_store = "${hasFileAuthentication ? 'file' : 'ephemeral'}"\n`,
+      { encoding: 'utf8', mode: 0o600 }
+    )
+  }
   const codexConfig = record(JSON.parse(backend.env.CODEX_CONFIG ?? '{}'))
   delete codexConfig.developer_instructions
   codexConfig.experimental_use_unified_exec_tool = false

--- a/src/main/acp/restricted-runtime-profile.ts
+++ b/src/main/acp/restricted-runtime-profile.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises'
+import { chmod, copyFile, mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import type { ResolvedAgentBackend } from '../agent-framework'
@@ -17,6 +17,48 @@ const record = (value: unknown): Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {}
+
+// Keep this denylist aligned with the built-in tool features of every supported native Codex
+// version. The runtime's permission and tool-event guards remain the second fail-closed boundary.
+const RESTRICTED_CODEX_FEATURES = Object.freeze({
+  multi_agent: false,
+  multi_agent_v2: false,
+  shell_tool: false,
+  code_mode: false,
+  code_mode_host: false,
+  code_mode_only: false,
+  apply_patch_freeform: false,
+  apps: false,
+  enable_mcp_apps: false,
+  browser_use: false,
+  browser_use_external: false,
+  browser_use_full_cdp_access: false,
+  computer_use: false,
+  image_generation: false,
+  workspace_dependencies: false,
+  goals: false,
+  tool_suggest: false,
+  request_permissions_tool: false,
+  enable_fanout: false,
+  default_mode_request_user_input: false,
+  plugin_sharing: false
+})
+
+const copyCodexAuthentication = async (
+  sourceHome: string | undefined,
+  targetHome: string
+): Promise<boolean> => {
+  if (!sourceHome || sourceHome === targetHome) return false
+  try {
+    const target = join(targetHome, 'auth.json')
+    await copyFile(join(sourceHome, 'auth.json'), target)
+    await chmod(target, 0o600)
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
+    throw error
+  }
+}
 
 const removeClaudeSkillRuntimeCapability = (
   source: Readonly<Record<string, unknown>> | undefined
@@ -102,12 +144,20 @@ const prepareCodexBackend = async (
 ): Promise<ResolvedAgentBackend> => {
   const codexHome = join(profileRoot, 'codex')
   await mkdir(codexHome, { recursive: true })
-  await writeFile(join(codexHome, 'config.toml'), 'cli_auth_credentials_store = "ephemeral"\n', {
-    encoding: 'utf8',
-    mode: 0o600
-  })
+  const hasFileAuthentication = await copyCodexAuthentication(backend.env.CODEX_HOME, codexHome)
+  await writeFile(
+    join(codexHome, 'config.toml'),
+    `cli_auth_credentials_store = "${hasFileAuthentication ? 'file' : 'ephemeral'}"\n`,
+    { encoding: 'utf8', mode: 0o600 }
+  )
   const codexConfig = record(JSON.parse(backend.env.CODEX_CONFIG ?? '{}'))
   delete codexConfig.developer_instructions
+  codexConfig.experimental_use_unified_exec_tool = false
+  codexConfig.features = {
+    ...record(codexConfig.features),
+    ...RESTRICTED_CODEX_FEATURES
+  }
+  codexConfig.tools = { ...record(codexConfig.tools), web_search: false }
   return {
     ...backend,
     env: { ...backend.env, CODEX_HOME: codexHome, CODEX_CONFIG: JSON.stringify(codexConfig) },

--- a/src/main/acp/restricted-runtime-profile.ts
+++ b/src/main/acp/restricted-runtime-profile.ts
@@ -1,7 +1,8 @@
-import { chmod, copyFile, mkdir, writeFile } from 'node:fs/promises'
+import { chmod, copyFile, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import type { ResolvedAgentBackend } from '../agent-framework'
+import { projectSafeCodexProviderRoute } from '../settings/codex-auth'
 import { OPEN_SCIENCE_SKILL_RUNTIME_SESSION_OPTION } from '../skills/runtime-mcp-server'
 
 type RestrictedRuntimeProfile = Readonly<{
@@ -60,18 +61,14 @@ const copyCodexAuthentication = async (
   }
 }
 
-const copyCodexConfig = async (
-  sourceHome: string | undefined,
-  targetHome: string
-): Promise<boolean> => {
-  if (!sourceHome || sourceHome === targetHome) return false
+const readCodexProviderRoute = async (
+  sourceHome: string | undefined
+): Promise<string | undefined> => {
+  if (!sourceHome) return undefined
   try {
-    const target = join(targetHome, 'config.toml')
-    await copyFile(join(sourceHome, 'config.toml'), target)
-    await chmod(target, 0o600)
-    return true
+    return projectSafeCodexProviderRoute(await readFile(join(sourceHome, 'config.toml'), 'utf8'))
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
     throw error
   }
 }
@@ -160,17 +157,15 @@ const prepareCodexBackend = async (
 ): Promise<ResolvedAgentBackend> => {
   const codexHome = join(profileRoot, 'codex')
   await mkdir(codexHome, { recursive: true })
-  const [hasFileAuthentication, hasAppOwnedConfig] = await Promise.all([
+  const [hasFileAuthentication, providerRoute] = await Promise.all([
     copyCodexAuthentication(backend.env.CODEX_HOME, codexHome),
-    copyCodexConfig(backend.env.CODEX_HOME, codexHome)
+    readCodexProviderRoute(backend.env.CODEX_HOME)
   ])
-  if (!hasAppOwnedConfig) {
-    await writeFile(
-      join(codexHome, 'config.toml'),
-      `cli_auth_credentials_store = "${hasFileAuthentication ? 'file' : 'ephemeral'}"\n`,
-      { encoding: 'utf8', mode: 0o600 }
-    )
-  }
+  await writeFile(
+    join(codexHome, 'config.toml'),
+    `cli_auth_credentials_store = "${hasFileAuthentication ? 'file' : 'ephemeral'}"\n${providerRoute ? `\n${providerRoute}` : ''}`,
+    { encoding: 'utf8', mode: 0o600 }
+  )
   const codexConfig = record(JSON.parse(backend.env.CODEX_CONFIG ?? '{}'))
   delete codexConfig.developer_instructions
   codexConfig.experimental_use_unified_exec_tool = false
@@ -181,7 +176,13 @@ const prepareCodexBackend = async (
   codexConfig.tools = { ...record(codexConfig.tools), web_search: false }
   return {
     ...backend,
-    env: { ...backend.env, CODEX_HOME: codexHome, CODEX_CONFIG: JSON.stringify(codexConfig) },
+    env: {
+      ...backend.env,
+      CODEX_HOME: codexHome,
+      HOME: codexHome,
+      ...(backend.env.USERPROFILE === undefined ? {} : { USERPROFILE: codexHome }),
+      CODEX_CONFIG: JSON.stringify(codexConfig)
+    },
     systemPromptAppends: [profile.systemPrompt],
     persistentSystemPrompt: undefined
   }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1992,7 +1992,9 @@ const createApplicationModules = async (
     appVersion: app.getVersion(),
     configRoot,
     profileNamespace: 'vision-evidence',
-    resolveTarget: (target, context) => settingsService.resolveExplicitAgentBackend(target, context)
+    resolveTarget: (target, context) =>
+      settingsService.resolveExplicitAgentBackend(target, context),
+    allowNativeCodexSubscription: true
   })
   void visionInferenceRunner
     .sweepStaleProfiles()

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -11,6 +11,7 @@ import {
   createCodexAuthEnvironment,
   ensureCodexAuthHome,
   importCodexAuthentication,
+  projectSafeCodexProviderRoute,
   type CodexAuthSession
 } from './codex-auth'
 
@@ -159,6 +160,38 @@ describe('createCodexAuthEnvironment', () => {
 })
 
 describe('importCodexAuthentication', () => {
+  it('projects only a validated provider route from app-owned configuration', () => {
+    expect(
+      projectSafeCodexProviderRoute(
+        [
+          'cli_auth_credentials_store = "file"',
+          'model_provider = "subscription-route"',
+          '',
+          '[model_providers.subscription-route]',
+          'name = "OpenAI"',
+          'base_url = "http://127.0.0.1:1087/v1"',
+          'wire_api = "responses"',
+          'requires_openai_auth = true',
+          '',
+          '[mcp_servers.private]',
+          'command = "private-command"',
+          ''
+        ].join('\n')
+      )
+    ).toBe(
+      [
+        'model_provider = "subscription-route"',
+        '',
+        '[model_providers."subscription-route"]',
+        'name = "OpenAI"',
+        'base_url = "http://127.0.0.1:1087/v1"',
+        'wire_api = "responses"',
+        'requires_openai_auth = true',
+        ''
+      ].join('\n')
+    )
+  })
+
   it('copies auth.json without unrelated Codex config or private runtime data', async () => {
     const root = await mkdtemp(join(tmpdir(), 'codex-auth-import-'))
     const source = join(root, 'source')

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -265,6 +265,11 @@ const serializeLegacyCodexProviderRoute = (route: ImportedCodexProviderRoute): s
     ''
   ].join('\n')
 
+export const projectSafeCodexProviderRoute = (configToml: string): string | undefined => {
+  const route = extractCodexProviderRoute(configToml)
+  return route ? serializeLegacyCodexProviderRoute(route) : undefined
+}
+
 const IMPORTED_ROUTE_SELECTION_BEGIN = '# Open Science: begin imported Codex route selection'
 const IMPORTED_ROUTE_SELECTION_END = '# Open Science: end imported Codex route selection'
 const IMPORTED_ROUTE_PROVIDER_BEGIN = '# Open Science: begin imported Codex provider'

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -5635,6 +5635,27 @@ describe('SettingsService: Reviewer model', () => {
 })
 
 describe('SettingsService: Vision model', () => {
+  it('persists and admits an image-capable Codex subscription model', async () => {
+    const service = createService()
+    const codex = (await service.upsertProvider({ type: 'codex-isolated' })).providers[0]
+    await repository.setAgentFramework('codex')
+    const configuration = {
+      providerId: codex.id,
+      model: 'gpt-5.6-sol',
+      reasoningEffort: 'high' as const
+    }
+
+    await expect(service.setVisionModel(configuration)).resolves.toMatchObject({
+      visionModel: configuration
+    })
+    await expect(service.admitVisionModel()).resolves.toMatchObject({
+      frameworkId: 'codex',
+      providerId: configuration.providerId,
+      model: { kind: 'required', id: 'gpt-5.6-sol' },
+      reasoningEffort: 'high'
+    })
+  })
+
   it('persists and admits one image-capable fixed target', async () => {
     const service = createService()
     const created = await service.upsertProvider({

--- a/src/main/settings/vision-model-owner.ts
+++ b/src/main/settings/vision-model-owner.ts
@@ -1,10 +1,6 @@
 import { createHash } from 'node:crypto'
 
-import {
-  isCodexSubscriptionProvider,
-  providerValidationFailed,
-  type VisionModelConfiguration
-} from '../../shared/settings'
+import { providerValidationFailed, type VisionModelConfiguration } from '../../shared/settings'
 import { DEFAULT_AGENT_FRAMEWORK_ID, getAgentFramework } from '../agent-framework'
 import type { AgentBackendResolver, ExplicitAgentBackendTarget } from './backend-resolver'
 import type { ProviderAccountsModule } from './provider-accounts'
@@ -32,9 +28,6 @@ class VisionModelOwner {
         throw new Error(
           'The selected Vision model is no longer available. Refresh the model catalog.'
         )
-      }
-      if (isCodexSubscriptionProvider(provider.type)) {
-        throw new Error('Codex subscription models cannot run as the Vision model.')
       }
       const framework = getAgentFramework(
         frameworkId ?? settings.agentFrameworkId ?? DEFAULT_AGENT_FRAMEWORK_ID
@@ -68,9 +61,6 @@ class VisionModelOwner {
     const provider = settings.providers.find((entry) => entry.id === configuration.providerId)
     if (!provider || providerValidationFailed(provider)) {
       throw new Error('The configured Vision model provider is unavailable.')
-    }
-    if (isCodexSubscriptionProvider(provider.type)) {
-      throw new Error('The configured Vision model transport is unavailable.')
     }
     const { frameworkId } = await this.options.backendResolver.captureConfiguredSelection()
     const framework = getAgentFramework(frameworkId)

--- a/src/renderer/src/pages/settings/ScenarioModelList.render.test.tsx
+++ b/src/renderer/src/pages/settings/ScenarioModelList.render.test.tsx
@@ -216,6 +216,45 @@ describe('ScenarioModelList', () => {
     act(() => root.unmount())
   })
 
+  it('summarizes an image-capable Codex subscription Vision model as available', () => {
+    useSettingsStore.setState({
+      agentFrameworkId: 'codex',
+      agentFrameworks: [
+        {
+          id: 'codex',
+          displayName: 'Codex',
+          supportsSkills: true,
+          supportedApiTypes: ['responses']
+        }
+      ],
+      providers: [
+        {
+          id: 'builtin-codex-isolated',
+          type: 'codex-isolated',
+          name: 'Codex subscription',
+          apiEndpoints: ['responses'],
+          models: ['gpt-5.6-sol'],
+          supportsImageInput: true,
+          hasKey: false,
+          needsKey: false
+        }
+      ],
+      visionModel: {
+        providerId: 'builtin-codex-isolated',
+        model: 'gpt-5.6-sol',
+        reasoningEffort: 'high'
+      }
+    })
+    const root = renderList()
+
+    const visionRow = rowButton('Vision')
+    expect(visionRow?.textContent).toContain('gpt-5.6-sol')
+    expect(visionRow?.textContent).toContain('Codex subscription')
+    expect(visionRow?.textContent).not.toContain('Unavailable')
+
+    act(() => root.unmount())
+  })
+
   it('marks a Vision model without image input as unavailable', () => {
     useSettingsStore.setState({
       providers: [

--- a/src/renderer/src/pages/settings/ScenarioModelList.tsx
+++ b/src/renderer/src/pages/settings/ScenarioModelList.tsx
@@ -11,11 +11,7 @@ import {
   configuredModelKey,
   type ConfiguredModelCatalogEntry
 } from '../../../../shared/configured-model-catalog'
-import {
-  isCodexSubscriptionProvider,
-  type ProviderView,
-  type ReasoningEffort
-} from '../../../../shared/settings'
+import type { ProviderView, ReasoningEffort } from '../../../../shared/settings'
 import { resolveProviderReasoningEffortProfile } from '../../../../shared/provider-reasoning-effort'
 import {
   resolveReasoningEffortControl,
@@ -253,9 +249,7 @@ const ScenarioModelList = (): React.JSX.Element => {
     frameworkEndpoints
   })
   // Vision offers only image-capable models, so its summary resolves against the same filter.
-  const visionCatalog = catalog.filter(
-    (entry) => entry.supportsImageInput && !isCodexSubscriptionProvider(entry.providerType)
-  )
+  const visionCatalog = catalog.filter((entry) => entry.supportsImageInput)
 
   const scenarios: readonly Scenario[] = [
     {

--- a/src/renderer/src/pages/settings/SubagentModelSelect.render.test.tsx
+++ b/src/renderer/src/pages/settings/SubagentModelSelect.render.test.tsx
@@ -338,4 +338,49 @@ describe('VisionModelSelect', () => {
     })
     act(() => root.unmount())
   })
+
+  it('offers an image-capable Codex subscription model', () => {
+    useSettingsStore.setState({
+      agentFrameworkId: 'codex',
+      agentFrameworks: [
+        {
+          id: 'codex',
+          displayName: 'Codex',
+          supportsSkills: true,
+          supportedApiTypes: ['responses']
+        }
+      ],
+      providers: [
+        {
+          id: 'builtin-codex-isolated',
+          type: 'codex-isolated',
+          name: 'Codex subscription',
+          apiEndpoints: ['responses'],
+          models: ['gpt-5.6-sol'],
+          supportsImageInput: true,
+          hasKey: false,
+          needsKey: false
+        }
+      ]
+    })
+    const container = document.createElement('div')
+    document.body.append(container)
+    const root = createRoot(container)
+    act(() => root.render(<VisionModelSelect />))
+
+    const trigger = document.body.querySelector<HTMLButtonElement>(
+      '[aria-label="Vision model Model"]'
+    )
+    act(() => {
+      trigger?.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }))
+      trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(
+      Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]')).some((candidate) =>
+        candidate.textContent?.includes('gpt-5.6-sol')
+      )
+    ).toBe(true)
+    act(() => root.unmount())
+  })
 })

--- a/src/renderer/src/pages/settings/SubagentModelSelect.tsx
+++ b/src/renderer/src/pages/settings/SubagentModelSelect.tsx
@@ -24,10 +24,7 @@ import {
 import { ProviderKindIcon } from './provider-icons'
 import { providerKindKey } from './provider-form-value'
 import { SettingsField, SettingsRow } from './SettingsLayout'
-import {
-  isCodexSubscriptionProvider,
-  type SubagentModelConfiguration
-} from '../../../../shared/settings'
+import type { SubagentModelConfiguration } from '../../../../shared/settings'
 
 const INHERIT_KEY = 'same-as-main-model'
 
@@ -280,9 +277,7 @@ const VisionModelSelect = (): React.JSX.Element => {
       inheritLabel={t('Not configured')}
       configuration={configuration ? { mode: 'fixed', ...configuration } : { mode: 'inherit' }}
       pending={useSettingsStore((state) => state.visionModelPending)}
-      entryFilter={(entry) =>
-        entry.supportsImageInput && !isCodexSubscriptionProvider(entry.providerType)
-      }
+      entryFilter={(entry) => entry.supportsImageInput}
       setConfiguration={(next) =>
         setVisionModel(
           next.mode === 'fixed'


### PR DESCRIPTION
## Problem

Codex subscription models are projected as image-capable and `gpt-5.6-sol` is registered as multimodal, but Settings excluded every Codex subscription model from the Vision picker. Save and admission also rejected the provider, and the restricted inference path could not safely execute a native Codex subscription target.

## Proposed change

- Use the existing image-capability and framework gates for the Vision picker, scenario summary, save, and admission paths.
- Permit native Codex subscription execution only for the Vision restricted-inference runner.
- Run it from a disposable profile containing only app-owned authentication and a validated loopback Responses provider route.
- Disable native tool surfaces and isolate `CODEX_HOME`, `HOME`, and `USERPROFILE` from persistent Skills and state.
- Preserve the existing fail-closed behavior for Artifact reconstruction and `host.llm`.

## Scope and non-goals

- No model catalog or capability metadata changes.
- No new state or enum values.
- No database, persisted schema, or data-format changes.
- No historical-data compatibility handling is required.
- The native subscription policy is process-local and enabled only for Vision inference.

## Acceptance criteria and validation

The regression tests were first run against the unfixed behavior and failed for the reported reasons:

- The Vision picker omitted `gpt-5.6-sol`.
- Settings admission rejected Codex subscription Vision models.
- Restricted inference rejected the native subscription target upstream.
- The Vision summary displayed the selected model as unavailable.
- The disposable profile dropped the imported provider route.
- Copying the whole app-owned configuration leaked MCP configuration and persistent home discovery into the restricted profile.

Final Test Impact Set, run after the last material edit:

- Vision selection, summary, admission, restricted inference, Artifact/host consumers, and Codex authentication route projection → targeted Vitest run across 8 affected test files → 384 tests passed.
- Main-process types → `npm run typecheck:node` → passed.
- Renderer types → `npm run typecheck:web` → passed.
- Source lint → `npm run lint` → passed with no warnings.
- Patch hygiene → `git diff --check` → passed.

The full `npm test` suite was intentionally not run per maintainer request. Exact-head PR CI remains authoritative for broader portable and platform coverage. The final exact-head AI review completed on `d96a7600` with verdict **mergeable** and no actionable findings.

Uncovered local risk: packaged native Codex behavior remains covered by the PR's selected CI/platform lanes rather than a local packaged-app run.

## Review focus

- Confirm the Vision-only native subscription policy boundary.
- Confirm that the disposable profile projects only the validated provider route and excludes MCP/tool-capable configuration.
- Confirm that Artifact reconstruction and `host.llm` retain their prior fail-closed behavior.
