### PR TITLE
fix(composer): unify draft undo behavior

### DIFF
--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -388,7 +388,7 @@ const createPanelDefaults = (): PanelProps => ({
       cancelTransfer: vi.fn(),
       removeAttachment: vi.fn(),
       restorePastedText: vi.fn(),
-      undoPastedTextRemoval: vi.fn(() => false),
+      undo: vi.fn(() => false),
       setError: vi.fn()
     }
   },

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -395,7 +395,7 @@ const ConversationPanel = ({
       cancelTransfer: onCancelAttachmentTransfer,
       removeAttachment: onRemoveAttachment,
       restorePastedText: onRestorePastedText,
-      undoPastedTextRemoval: onUndoPastedTextRemoval
+      undo: onUndo
     }
   } = composer
   const {
@@ -1536,7 +1536,7 @@ const ConversationPanel = ({
                           onPaste={handleMessageDraftPaste}
                           onLongTextPaste={onStagePastedText}
                           onLocatePastedText={handleLocatePastedText}
-                          onUndoPastedTextRemoval={onUndoPastedTextRemoval}
+                          onUndo={onUndo}
                           disabled={!canEditDraft}
                           placeholder={t(
                             'Ask anything — / skills · @ files · # sessions · {{shortcut}} search · ↑↓ history',

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -210,7 +210,7 @@ type Overrides = Partial<{
   onPaste: (event: React.ClipboardEvent<HTMLDivElement>) => void
   onLongTextPaste: (doc: ComposerDoc, node: ComposerPastedTextStage) => void
   onLocatePastedText: (pastedTextId: string) => void
-  onUndoPastedTextRemoval: () => boolean
+  onUndo: () => boolean
   disabled: boolean
   isHistoryBrowsing: boolean
   historyStatus: string
@@ -231,7 +231,7 @@ const renderEditor = (overrides: Overrides = {}): void => {
         onPaste={overrides.onPaste ?? noop}
         onLongTextPaste={overrides.onLongTextPaste}
         onLocatePastedText={overrides.onLocatePastedText}
-        onUndoPastedTextRemoval={overrides.onUndoPastedTextRemoval}
+        onUndo={overrides.onUndo}
         disabled={overrides.disabled}
         placeholder="Ask anything"
         ariaLabel="Ask anything"
@@ -762,9 +762,9 @@ describe('ComposerEditor', () => {
     expect(onDocChange).toHaveBeenCalledWith({ nodes: [{ type: 'text', text: 'before  after' }] })
   })
 
-  it('uses custom Cmd+Z only while a pasted-text removal is undoable', () => {
-    const onUndoPastedTextRemoval = vi.fn(() => true)
-    renderEditor({ onUndoPastedTextRemoval })
+  it('routes Cmd+Z through Composer undo and yields when there is nothing to undo', () => {
+    const onUndo = vi.fn(() => true)
+    renderEditor({ onUndo })
     const handled = new KeyboardEvent('keydown', {
       key: 'z',
       metaKey: true,
@@ -773,9 +773,9 @@ describe('ComposerEditor', () => {
     })
     act(() => editor().dispatchEvent(handled))
     expect(handled.defaultPrevented).toBe(true)
-    expect(onUndoPastedTextRemoval).toHaveBeenCalledOnce()
+    expect(onUndo).toHaveBeenCalledOnce()
 
-    onUndoPastedTextRemoval.mockReturnValue(false)
+    onUndo.mockReturnValue(false)
     const native = new KeyboardEvent('keydown', {
       key: 'z',
       metaKey: true,

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -663,11 +663,16 @@ describe('ComposerEditor', () => {
     })
 
     expect(onDocChange).not.toHaveBeenCalled()
-    const [nextDoc, node] = onLongTextPaste.mock.calls[0] as [ComposerDoc, ComposerPastedTextNode]
+    const [nextDoc, node, caret] = onLongTextPaste.mock.calls[0] as [
+      ComposerDoc,
+      ComposerPastedTextNode,
+      { nodeIndex: number; offset: number }
+    ]
     expect(node).toMatchObject({ type: 'pasted-text', text: payload })
     expect(nextDoc).toEqual({
       nodes: [{ type: 'text', text: 'before ' }, node, { type: 'text', text: ' after' }]
     })
+    expect(caret).toEqual({ nodeIndex: 0, offset: 'before '.length })
     expect(editor().textContent).not.toContain(payload)
   })
 

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -896,7 +896,7 @@ describe('ComposerEditor', () => {
     dispatchKey(editor(), 'Backspace')
 
     expect(editor().querySelector('[data-skill-id]')).toBeNull()
-    expect(onDocChange).toHaveBeenLastCalledWith(emptyDoc)
+    expect(onDocChange).toHaveBeenLastCalledWith(emptyDoc, { nodeIndex: 1, offset: 0 })
   })
 
   it('suppresses the popup once a skill chip exists (one skill per message)', () => {
@@ -1088,7 +1088,7 @@ describe('ComposerEditor', () => {
     dispatchKey(editor(), 'Backspace')
 
     expect(editor().querySelector('[data-mention-type="artifact"]')).toBeNull()
-    expect(onDocChange).toHaveBeenLastCalledWith(emptyDoc)
+    expect(onDocChange).toHaveBeenLastCalledWith(emptyDoc, { nodeIndex: 1, offset: 0 })
   })
 
   it('opens a linked-folder chip in the preview workbench on click', () => {

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -762,7 +762,7 @@ describe('ComposerEditor', () => {
     expect(onDocChange).toHaveBeenCalledWith({ nodes: [{ type: 'text', text: 'before  after' }] })
   })
 
-  it('routes Cmd+Z through Composer undo and yields when there is nothing to undo', () => {
+  it('routes Cmd+Z only through Composer undo, including after its history is empty', () => {
     const onUndo = vi.fn(() => true)
     renderEditor({ onUndo })
     const handled = new KeyboardEvent('keydown', {
@@ -783,7 +783,8 @@ describe('ComposerEditor', () => {
       cancelable: true
     })
     act(() => editor().dispatchEvent(native))
-    expect(native.defaultPrevented).toBe(false)
+    expect(native.defaultPrevented).toBe(true)
+    expect(onUndo).toHaveBeenCalledTimes(2)
   })
 
   it('places the caret immediately after restored pasted text', () => {

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -916,6 +916,7 @@ describe('ComposerEditor', () => {
 
     const lastCall = onDocChange.mock.calls.at(-1)?.[0] as ComposerDoc
     expect(lastCall.nodes.some((node) => node.type === 'skill' && node.id === 'lit')).toBe(true)
+    expect(onDocChange.mock.calls.at(-1)?.[1]).toEqual({ nodeIndex: 0, offset: 4 })
   })
 
   it('exposes the active skill suggestion from the focused editor', () => {

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -421,6 +421,28 @@ describe('ComposerEditor', () => {
     expect(onDocChange).toHaveBeenCalledWith({ nodes: [{ type: 'text', text: 'hello' }] })
   })
 
+  it('captures the selection start before replacing selected Composer text', () => {
+    const onDocChange = vi.fn()
+    renderEditor({ doc: { nodes: [{ type: 'text', text: 'hello' }] }, onDocChange })
+    const text = editor().firstChild as Text
+    const range = document.createRange()
+    range.setStart(text, 1)
+    range.setEnd(text, 4)
+    window.getSelection()?.removeAllRanges()
+    window.getSelection()?.addRange(range)
+
+    dispatchKey(editor(), 'x')
+    act(() => {
+      editor().textContent = 'hXo'
+      editor().dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    expect(onDocChange).toHaveBeenCalledWith(
+      { nodes: [{ type: 'text', text: 'hXo' }] },
+      { nodeIndex: 0, offset: 1 }
+    )
+  })
+
   it('submits on Enter without shift and not on Shift+Enter', () => {
     const onSubmit = vi.fn()
     renderEditor({ onSubmit })
@@ -607,7 +629,10 @@ describe('ComposerEditor', () => {
 
     expect(onPaste).toHaveBeenCalledTimes(1)
     expect(editor().textContent).toContain('pasted')
-    expect(onDocChange).toHaveBeenCalledWith({ nodes: [{ type: 'text', text: 'pasted' }] })
+    expect(onDocChange).toHaveBeenCalledWith(
+      { nodes: [{ type: 'text', text: 'pasted' }] },
+      { nodeIndex: 0, offset: 0 }
+    )
   })
 
   it('replaces the active selection with a long-paste anchor at the exact document position', () => {
@@ -783,7 +808,10 @@ describe('ComposerEditor', () => {
     expect(cut.defaultPrevented).toBe(true)
     expect(clipboard.get('text/plain')).toBe('full payload')
     expect(clipboard.get('application/x-open-science-composer-fragment')).toContain('full payload')
-    expect(onDocChange).toHaveBeenCalledWith({ nodes: [{ type: 'text', text: 'before  after' }] })
+    expect(onDocChange).toHaveBeenCalledWith(
+      { nodes: [{ type: 'text', text: 'before  after' }] },
+      { nodeIndex: 1, offset: 0 }
+    )
   })
 
   it('routes Cmd+Z only through Composer undo, including after its history is empty', () => {
@@ -851,7 +879,10 @@ describe('ComposerEditor', () => {
 
     // No chip is created; the doc holds only a text node, so it carries no skill id.
     expect(editor().querySelector('[data-skill-id]')).toBeNull()
-    expect(onDocChange).toHaveBeenLastCalledWith({ nodes: [{ type: 'text', text: '/Literature' }] })
+    expect(onDocChange).toHaveBeenLastCalledWith(
+      { nodes: [{ type: 'text', text: '/Literature' }] },
+      { nodeIndex: 0, offset: 0 }
+    )
   })
 
   it('inserts a skill chip when a suggestion is chosen from the popup', () => {

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -450,6 +450,30 @@ describe('ComposerEditor', () => {
     expect(onSubmit).toHaveBeenCalledTimes(1)
   })
 
+  it('emits one undoable document edit for an IME composition', () => {
+    const onDocChange = vi.fn()
+    renderEditor({ onDocChange })
+    setCaret(editor(), 0)
+
+    act(() => {
+      editor().dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
+      editor().textContent = 'n'
+      editor().dispatchEvent(new Event('input', { bubbles: true }))
+      editor().textContent = '你'
+      editor().dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    expect(onDocChange).not.toHaveBeenCalled()
+
+    act(() => {
+      editor().dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }))
+    })
+    expect(onDocChange).toHaveBeenCalledOnce()
+    expect(onDocChange).toHaveBeenCalledWith(
+      { nodes: [{ type: 'text', text: '你' }] },
+      { nodeIndex: 0, offset: 0 }
+    )
+  })
+
   it('enters history with ArrowUp only from a collapsed caret at the logical start', () => {
     const onNavigateHistory = vi.fn(() => true)
     renderEditor({

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -765,12 +765,16 @@ export const ComposerEditor = ({
 
   // Replace the active `/query` token with a skill chip, then close the popup.
   const handleSelectSkill = (skill: SkillView): void => {
+    const root = editorRef.current
+    undoCaretRef.current = root ? currentCaretPosition(root) : undefined
     mention.replaceTokenWith({ type: 'skill', id: skill.id, name: skill.displayName })
     mention.cancel()
   }
 
   // Replace the active `@query` token with an artifact chip, then close the popup.
   const handleSelectArtifact = (ref: PickedArtifact): void => {
+    const root = editorRef.current
+    undoCaretRef.current = root ? currentCaretPosition(root) : undefined
     artifactMention.replaceTokenWith({
       type: 'artifact',
       id: ref.id,
@@ -784,6 +788,8 @@ export const ComposerEditor = ({
   }
 
   const handleSelectSession = (session: PickedSession): void => {
+    const root = editorRef.current
+    undoCaretRef.current = root ? currentCaretPosition(root) : undefined
     sessionMention.replaceTokenWith(session)
     sessionMention.cancel()
   }

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -388,7 +388,7 @@ const currentCaretPosition = (root: HTMLElement): ComposerCaretPosition | undefi
   const selection = window.getSelection()
   if (!selection || selection.rangeCount === 0) return undefined
   const range = selection.getRangeAt(0)
-  if (!range.collapsed || !root.contains(range.startContainer)) return undefined
+  if (!root.contains(range.startContainer)) return undefined
   if (range.startContainer === root) {
     return { nodeIndex: Math.min(range.startOffset, root.childNodes.length), offset: 0 }
   }
@@ -617,6 +617,15 @@ export const ComposerEditor = ({
       return
     }
     if (disabled) return
+    if (
+      !event.altKey &&
+      !event.ctrlKey &&
+      !event.metaKey &&
+      (event.key.length === 1 || event.key === 'Backspace' || event.key === 'Delete')
+    ) {
+      const root = editorRef.current
+      undoCaretRef.current = root ? currentCaretPosition(root) : undefined
+    }
     const primaryUndoModifier =
       (event.metaKey && !event.ctrlKey) || (event.ctrlKey && !event.metaKey)
     if (
@@ -678,6 +687,8 @@ export const ComposerEditor = ({
   }
 
   const handlePaste = (event: React.ClipboardEvent<HTMLDivElement>): void => {
+    const activeRoot = editorRef.current
+    undoCaretRef.current = activeRoot ? currentCaretPosition(activeRoot) : undefined
     // Forward first so the panel can route file attachments to its intake.
     onPaste(event)
     if (disabled || event.isDefaultPrevented()) return
@@ -722,6 +733,7 @@ export const ComposerEditor = ({
   const handleCut = (event: React.ClipboardEvent<HTMLDivElement>): void => {
     const root = editorRef.current
     if (!root || !writeComposerClipboardSelection(root, doc, event)) return
+    undoCaretRef.current = currentCaretPosition(root)
     const selection = window.getSelection()
     if (!selection || selection.rangeCount === 0) return
     const range = selection.getRangeAt(0)

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -512,7 +512,9 @@ export const ComposerEditor = ({
     if (root && restoreFocusRequest !== undefined && canReceiveFocus(root)) moveCaretToEnd(root)
   }, [restoreFocusRequest])
 
-  const handleInput = useCallback((): void => emitDocFromDom(), [emitDocFromDom])
+  const handleInput = useCallback((): void => {
+    if (!composingRef.current) emitDocFromDom()
+  }, [emitDocFromDom])
 
   // Clicking an `@` mention chip opens the file in the preview workbench, like the sent-message
   // pills do. Linked-folder chips resolve rootId + relativePath through the granted-roots store
@@ -792,7 +794,9 @@ export const ComposerEditor = ({
         onInput={handleInput}
         onBeforeInput={() => {
           const root = editorRef.current
-          undoCaretRef.current = root ? currentCaretPosition(root) : undefined
+          if (!composingRef.current) {
+            undoCaretRef.current = root ? currentCaretPosition(root) : undefined
+          }
         }}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
@@ -800,10 +804,13 @@ export const ComposerEditor = ({
         onCopy={handleCopy}
         onCut={handleCut}
         onCompositionStart={() => {
+          const root = editorRef.current
+          undoCaretRef.current = root ? currentCaretPosition(root) : undefined
           composingRef.current = true
         }}
         onCompositionEnd={() => {
           composingRef.current = false
+          emitDocFromDom()
         }}
       />
       <span id={historyDescriptionId} className="sr-only">

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -596,9 +596,10 @@ export const ComposerEditor = ({
       !event.shiftKey &&
       !event.repeat &&
       !event.nativeEvent.isComposing &&
-      onUndo?.()
+      onUndo
     ) {
       event.preventDefault()
+      onUndo()
       return
     }
     // While either mention popup is open it owns Enter/arrow keys; leave them to its document listener.

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -48,7 +48,7 @@ const composerPlaceholderClassName =
 
 type ComposerEditorProps = {
   doc: ComposerDoc
-  onDocChange: (doc: ComposerDoc) => void
+  onDocChange: (doc: ComposerDoc, caret?: ComposerCaretPosition) => void
   onSubmit: () => void
   onPaste: (event: React.ClipboardEvent<HTMLDivElement>) => void
   onLongTextPaste?: (doc: ComposerDoc, node: ComposerPastedTextStage) => void
@@ -380,6 +380,21 @@ const moveCaretToPosition = (root: HTMLElement, position: ComposerCaretPosition)
   selection?.addRange(range)
 }
 
+const currentCaretPosition = (root: HTMLElement): ComposerCaretPosition | undefined => {
+  const selection = window.getSelection()
+  if (!selection || selection.rangeCount === 0) return undefined
+  const range = selection.getRangeAt(0)
+  if (!range.collapsed || !root.contains(range.startContainer)) return undefined
+  let topLevel: Node = range.startContainer
+  while (topLevel.parentNode && topLevel.parentNode !== root) topLevel = topLevel.parentNode
+  const nodeIndex = Array.prototype.indexOf.call(root.childNodes, topLevel) as number
+  if (nodeIndex < 0) return undefined
+  return {
+    nodeIndex,
+    offset: topLevel.nodeType === Node.TEXT_NODE ? range.startOffset : 0
+  }
+}
+
 const canReceiveFocus = (root: HTMLElement): boolean =>
   root.getAttribute('contenteditable') === 'true' && root.closest('[hidden]') === null
 
@@ -445,11 +460,17 @@ export const ComposerEditor = ({
     disabled: disabled || docSessionCount(doc) >= MAX_COMPOSER_SESSION_MENTIONS
   })
   const mentionPopupOpen = mention.active || artifactMention.active || sessionMention.active
+  const undoCaretRef = useRef<ComposerCaretPosition | undefined>(undefined)
 
   // Read the live DOM back into a doc and notify the parent.
   const emitDocFromDom = useCallback((): void => {
     const root = editorRef.current
-    if (root) onDocChange(domToDoc(root))
+    if (root) {
+      const nextDoc = domToDoc(root)
+      if (undoCaretRef.current) onDocChange(nextDoc, undoCaretRef.current)
+      else onDocChange(nextDoc)
+    }
+    undoCaretRef.current = undefined
   }, [onDocChange])
 
   // Apply the incoming doc to the DOM only when it diverges from what the editor already shows.
@@ -761,6 +782,10 @@ export const ComposerEditor = ({
           className
         )}
         onInput={handleInput}
+        onBeforeInput={() => {
+          const root = editorRef.current
+          undoCaretRef.current = root ? currentCaretPosition(root) : undefined
+        }}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         onPaste={handlePaste}

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -370,10 +370,14 @@ const moveCaretToEnd = (root: HTMLElement): void => {
 
 const moveCaretToPosition = (root: HTMLElement, position: ComposerCaretPosition): void => {
   const node = root.childNodes[position.nodeIndex]
-  if (!node || node.nodeType !== Node.TEXT_NODE) return moveCaretToEnd(root)
   root.focus()
   const range = document.createRange()
-  range.setStart(node, Math.min(position.offset, node.textContent?.length ?? 0))
+  if (!node) range.setStart(root, root.childNodes.length)
+  else if (node.nodeType === Node.TEXT_NODE) {
+    range.setStart(node, Math.min(position.offset, node.textContent?.length ?? 0))
+  } else {
+    range.setStart(root, position.nodeIndex)
+  }
   range.collapse(true)
   const selection = window.getSelection()
   selection?.removeAllRanges()
@@ -385,6 +389,9 @@ const currentCaretPosition = (root: HTMLElement): ComposerCaretPosition | undefi
   if (!selection || selection.rangeCount === 0) return undefined
   const range = selection.getRangeAt(0)
   if (!range.collapsed || !root.contains(range.startContainer)) return undefined
+  if (range.startContainer === root) {
+    return { nodeIndex: Math.min(range.startOffset, root.childNodes.length), offset: 0 }
+  }
   let topLevel: Node = range.startContainer
   while (topLevel.parentNode && topLevel.parentNode !== root) topLevel = topLevel.parentNode
   const nodeIndex = Array.prototype.indexOf.call(root.childNodes, topLevel) as number
@@ -655,6 +662,7 @@ export const ComposerEditor = ({
       const chip = root && chipBesideCaret(root, event.key === 'Backspace' ? 'before' : 'after')
       if (chip) {
         event.preventDefault()
+        undoCaretRef.current = currentCaretPosition(root)
         chip.remove()
         emitDocFromDom()
         return

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -53,7 +53,7 @@ type ComposerEditorProps = {
   onPaste: (event: React.ClipboardEvent<HTMLDivElement>) => void
   onLongTextPaste?: (doc: ComposerDoc, node: ComposerPastedTextStage) => void
   onLocatePastedText?: (pastedTextId: string) => void
-  onUndoPastedTextRemoval?: () => boolean
+  onUndo?: () => boolean
   disabled?: boolean
   placeholder: string
   className?: string
@@ -392,7 +392,7 @@ export const ComposerEditor = ({
   onPaste,
   onLongTextPaste,
   onLocatePastedText,
-  onUndoPastedTextRemoval,
+  onUndo,
   disabled = false,
   placeholder,
   className,
@@ -596,7 +596,7 @@ export const ComposerEditor = ({
       !event.shiftKey &&
       !event.repeat &&
       !event.nativeEvent.isComposing &&
-      onUndoPastedTextRemoval?.()
+      onUndo?.()
     ) {
       event.preventDefault()
       return

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -51,7 +51,11 @@ type ComposerEditorProps = {
   onDocChange: (doc: ComposerDoc, caret?: ComposerCaretPosition) => void
   onSubmit: () => void
   onPaste: (event: React.ClipboardEvent<HTMLDivElement>) => void
-  onLongTextPaste?: (doc: ComposerDoc, node: ComposerPastedTextStage) => void
+  onLongTextPaste?: (
+    doc: ComposerDoc,
+    node: ComposerPastedTextStage,
+    caret?: ComposerCaretPosition
+  ) => void
   onLocatePastedText?: (pastedTextId: string) => void
   onUndo?: () => boolean
   disabled?: boolean
@@ -702,7 +706,8 @@ export const ComposerEditor = ({
         ? insertComposerClipboardFragmentAtCaret(root, internalFragment)
         : []
       if (root && pastedTextNodes.length > 0) {
-        onLongTextPaste(domToDoc(root), pastedTextNodes)
+        onLongTextPaste(domToDoc(root), pastedTextNodes, undoCaretRef.current)
+        undoCaretRef.current = undefined
       }
       return
     }
@@ -717,7 +722,10 @@ export const ComposerEditor = ({
           id: crypto.randomUUID(),
           text
         }
-        if (root && insertPastedTextAtCaret(root, node)) onLongTextPaste(domToDoc(root), node)
+        if (root && insertPastedTextAtCaret(root, node)) {
+          onLongTextPaste(domToDoc(root), node, undoCaretRef.current)
+          undoCaretRef.current = undefined
+        }
       } else {
         if (root && insertPlainTextAtCaret(root, text)) emitDocFromDom()
       }

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
@@ -287,11 +287,17 @@ describe('workspace composer controller', () => {
     mounted.push(hook)
     const node: ComposerPastedTextNode = { type: 'pasted-text', id: 'paste-1', text: 'payload' }
 
-    act(() => hook.result.current.actions.stagePastedText(pastedDoc(node), node))
+    act(() =>
+      hook.result.current.actions.stagePastedText(pastedDoc(node), node, {
+        nodeIndex: 0,
+        offset: 3
+      })
+    )
     await flushAsyncWork()
     act(() => expect(hook.result.current.actions.undo()).toBe(true))
 
     expect(hook.result.current.view.doc).toEqual(emptyDoc)
+    expect(hook.result.current.view.caretRequest?.position).toEqual({ nodeIndex: 0, offset: 3 })
     expect(hook.result.current.view.attachments).toEqual([])
     expect(uploadApi.deleteUpload).toHaveBeenCalledWith({ path: '/uploads/paste.txt' })
   })

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
@@ -138,6 +138,8 @@ describe('workspace composer controller', () => {
     act(() => expect(hook.result.current.actions.undo()).toBe(true))
 
     expect(hook.result.current.view.doc).toEqual(emptyDoc)
+    expect(hook.result.current.actions.undo()).toBe(false)
+    expect(hook.result.current.view.doc).toEqual(emptyDoc)
   })
 
   it('undoes a pasted image after its attachment finishes staging', async () => {

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
@@ -142,6 +142,27 @@ describe('workspace composer controller', () => {
     expect(hook.result.current.view.doc).toEqual(emptyDoc)
   })
 
+  it('restores the caret captured before a Composer document edit', () => {
+    const hook = renderController()
+    mounted.push(hook)
+
+    act(() => hook.result.current.actions.changeDoc(textDoc('draft'), { nodeIndex: 0, offset: 2 }))
+    act(() => expect(hook.result.current.actions.undo()).toBe(true))
+
+    expect(hook.result.current.view.caretRequest?.position).toEqual({ nodeIndex: 0, offset: 2 })
+  })
+
+  it('releases Composer undo history when its session is deleted', () => {
+    const hook = renderController()
+    mounted.push(hook)
+
+    act(() => hook.result.current.actions.changeDoc(textDoc('draft')))
+    expect(hook.result.current.lifecycle.beginSessionDeletion('session-a')).toBe(true)
+    act(() => hook.result.current.lifecycle.settleSessionDeletion('session-a', true))
+
+    expect(hook.result.current.actions.undo()).toBe(false)
+  })
+
   it('undoes a pasted image after its attachment finishes staging', async () => {
     const image = {
       id: 'upload-image',
@@ -451,7 +472,28 @@ describe('workspace composer controller', () => {
     expect(hook.result.current.view.doc).toEqual(textDoc('before payload after'))
     expect(hook.result.current.view.attachments).toEqual([])
     expect(hook.result.current.view.error).toBe('disk full')
-    expect(hook.result.current.actions.undo()).toBe(false)
+    act(() => expect(hook.result.current.actions.undo()).toBe(true))
+    expect(hook.result.current.view.doc).toEqual(emptyDoc)
+  })
+
+  it('keeps later text edits undoable when a converted paste upload fails', async () => {
+    const pending = deferred<UploadedAttachment | null>()
+    const hook = renderController(uploads(vi.fn(() => pending.promise)))
+    mounted.push(hook)
+    const node: ComposerPastedTextNode = { type: 'pasted-text', id: 'paste-1', text: 'payload' }
+
+    act(() => hook.result.current.actions.stagePastedText(pastedDoc(node), node))
+    act(() =>
+      hook.result.current.actions.changeDoc({
+        nodes: [...hook.result.current.view.doc.nodes, { type: 'text', text: ' typed' }]
+      })
+    )
+    pending.reject(new Error('disk full'))
+    await flushAsyncWork()
+
+    expect(docToText(hook.result.current.view.doc)).toBe('before payload after typed')
+    act(() => expect(hook.result.current.actions.undo()).toBe(true))
+    expect(docToText(hook.result.current.view.doc)).toBe('before payload after')
   })
 
   it('rebinds an undo snapshot when a pending long paste finishes uploading', async () => {
@@ -645,6 +687,46 @@ describe('workspace composer controller', () => {
       id: 'paste-1',
       attachmentId: 'upload-restaged'
     })
+  })
+
+  it('undoes a selection edit that removes a pasted-text anchor and surrounding text', async () => {
+    const stageLocalFile = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'upload-first',
+        sessionId: '.pending',
+        name: 'Pastedtext-payload.txt',
+        originalName: 'Pastedtext-payload.txt',
+        path: '/uploads/first.txt',
+        mimeType: 'text/plain',
+        size: 7
+      })
+      .mockResolvedValueOnce({
+        id: 'upload-restaged',
+        sessionId: '.pending',
+        name: 'Pastedtext-payload.txt',
+        originalName: 'Pastedtext-payload.txt',
+        path: '/uploads/restaged.txt',
+        mimeType: 'text/plain',
+        size: 7
+      })
+    const hook = renderController(uploads(stageLocalFile))
+    mounted.push(hook)
+    const node: ComposerPastedTextNode = { type: 'pasted-text', id: 'paste-1', text: 'payload' }
+    act(() => hook.result.current.actions.stagePastedText(pastedDoc(node), node))
+    await flushAsyncWork()
+
+    act(() => hook.result.current.actions.changeDoc(textDoc('replacement')))
+    act(() => expect(hook.result.current.actions.undo()).toBe(true))
+    await flushAsyncWork()
+
+    expect(hook.result.current.view.doc.nodes).toContainEqual(
+      expect.objectContaining({
+        type: 'pasted-text',
+        id: 'paste-1',
+        attachmentId: 'upload-restaged'
+      })
+    )
   })
 
   it('undoes only the closed paste when another staged paste falls back inline', async () => {

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
@@ -4,6 +4,7 @@ import { createRoot } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { UploadedAttachment } from '../../../../shared/uploads'
+import type { CustomizePrefillIntent } from '@/stores/navigation-store'
 
 import type { UploadStagingApi } from './composer-upload-transfer'
 import {
@@ -60,6 +61,7 @@ const uploads = (
 type ControllerHook = {
   result: { current: ReturnType<typeof useWorkspaceComposerController> }
   selectDraft: (draftKey: string) => void
+  setCustomizePrefill: (prefill: CustomizePrefillIntent) => void
   unmount: () => void
 }
 
@@ -69,6 +71,7 @@ const renderController = (
   historyEntries: ComposerHistoryEntry[] = []
 ): ControllerHook => {
   let currentDraftKey = 'session-a'
+  let pendingCustomizePrefill: CustomizePrefillIntent | undefined
   const container = document.createElement('div')
   const root = createRoot(container)
   const result = {
@@ -79,7 +82,7 @@ const renderController = (
       currentDraftKey,
       newConversationDraftKey: 'new:project',
       activeProjectId: 'project',
-      pendingCustomizePrefill: undefined,
+      pendingCustomizePrefill,
       onCustomizePrefillApplied: vi.fn(),
       historyEntries,
       hasActiveSession: true,
@@ -107,6 +110,11 @@ const renderController = (
     result,
     selectDraft: (draftKey: string): void => {
       currentDraftKey = draftKey
+      render()
+    },
+    setCustomizePrefill: (prefill: CustomizePrefillIntent): void => {
+      pendingCustomizePrefill = prefill
+      currentDraftKey = 'new:project'
       render()
     },
     unmount: (): void => act(() => root.unmount())
@@ -221,6 +229,22 @@ describe('workspace composer controller', () => {
     act(() => expect(hook.result.current.actions.navigateHistory('previous')).toBe(true))
 
     expect(hook.result.current.view.doc).toEqual(textDoc('history prompt'))
+    expect(hook.result.current.actions.undo()).toBe(false)
+  })
+
+  it('clears draft undo when a customize prefill replaces the Composer document', () => {
+    const hook = renderController()
+    mounted.push(hook)
+    hook.selectDraft('new:project')
+    act(() => hook.result.current.actions.changeDoc(textDoc('scratch')))
+
+    hook.setCustomizePrefill({
+      requestId: 1,
+      projectId: 'project',
+      goal: 'specialist'
+    })
+
+    expect(docToText(hook.result.current.view.doc)).not.toBe('scratch')
     expect(hook.result.current.actions.undo()).toBe(false)
   })
 
@@ -425,6 +449,45 @@ describe('workspace composer controller', () => {
     expect(hook.result.current.view.doc).toEqual(textDoc('before payload after'))
     expect(hook.result.current.view.attachments).toEqual([])
     expect(hook.result.current.view.error).toBe('disk full')
+    expect(hook.result.current.actions.undo()).toBe(false)
+  })
+
+  it('rebinds an undo snapshot when a pending long paste finishes uploading', async () => {
+    const pending = deferred<UploadedAttachment | null>()
+    const hook = renderController(uploads(vi.fn(() => pending.promise)))
+    mounted.push(hook)
+    const node: ComposerPastedTextNode = { type: 'pasted-text', id: 'paste-1', text: 'payload' }
+
+    act(() => hook.result.current.actions.stagePastedText(pastedDoc(node), node))
+    act(() =>
+      hook.result.current.actions.changeDoc({
+        nodes: [...hook.result.current.view.doc.nodes, { type: 'text', text: ' question' }]
+      })
+    )
+    await act(async () => {
+      pending.resolve({
+        id: 'upload-paste',
+        sessionId: '.pending',
+        name: 'Pastedtext-payload.txt',
+        originalName: 'Pastedtext-payload.txt',
+        path: '/uploads/paste.txt',
+        mimeType: 'text/plain',
+        size: 7
+      })
+      await pending.promise
+      await Promise.resolve()
+    })
+
+    act(() => expect(hook.result.current.actions.undo()).toBe(true))
+
+    expect(hook.result.current.view.doc.nodes[1]).toMatchObject({
+      type: 'pasted-text',
+      id: 'paste-1',
+      attachmentId: 'upload-paste',
+      transferId: undefined
+    })
+    expect(hook.result.current.view.attachments.map(({ id }) => id)).toEqual(['upload-paste'])
+    expect(hook.result.current.view.transfers).toEqual([])
   })
 
   it('keeps the long paste inline when the composer attachment cap is already full', () => {

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
@@ -6,7 +6,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { UploadedAttachment } from '../../../../shared/uploads'
 
 import type { UploadStagingApi } from './composer-upload-transfer'
-import { docToText, type ComposerDoc, type ComposerPastedTextNode } from './composer/composer-doc'
+import {
+  docToText,
+  emptyDoc,
+  type ComposerDoc,
+  type ComposerPastedTextNode
+} from './composer/composer-doc'
 import { useWorkspaceComposerController } from './workspace-composer-controller'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -115,6 +120,88 @@ afterEach(() => {
 })
 
 describe('workspace composer controller', () => {
+  it('undoes typed text through the current Composer draft', () => {
+    const hook = renderController()
+    mounted.push(hook)
+
+    act(() => hook.result.current.actions.changeDoc(textDoc('draft')))
+    act(() => expect(hook.result.current.actions.undo()).toBe(true))
+
+    expect(hook.result.current.view.doc).toEqual(emptyDoc)
+  })
+
+  it('undoes a pasted image after its attachment finishes staging', async () => {
+    const image = {
+      id: 'upload-image',
+      sessionId: '.pending',
+      name: 'figure.png',
+      originalName: 'figure.png',
+      path: '/uploads/figure.png',
+      mimeType: 'image/png',
+      size: 5
+    }
+    const uploadApi = uploads(vi.fn().mockResolvedValue(image))
+    const hook = renderController(uploadApi)
+    mounted.push(hook)
+
+    act(() =>
+      hook.result.current.actions.stageFiles([
+        new File(['image'], 'figure.png', { type: 'image/png' })
+      ])
+    )
+    await flushAsyncWork()
+    expect(hook.result.current.view.attachments).toEqual([image])
+
+    act(() => expect(hook.result.current.actions.undo()).toBe(true))
+
+    expect(hook.result.current.view.attachments).toEqual([])
+    expect(uploadApi.deleteUpload).toHaveBeenCalledWith({ path: '/uploads/figure.png' })
+  })
+
+  it('undoes a pasted image while its upload is still pending', () => {
+    const pending = deferred<UploadedAttachment | null>()
+    const uploadApi = uploads(vi.fn(() => pending.promise))
+    const hook = renderController(uploadApi)
+    mounted.push(hook)
+
+    act(() =>
+      hook.result.current.actions.stageFiles([
+        new File(['image'], 'figure.png', { type: 'image/png' })
+      ])
+    )
+    expect(hook.result.current.view.transfers).toHaveLength(1)
+
+    act(() => expect(hook.result.current.actions.undo()).toBe(true))
+
+    expect(hook.result.current.view.transfers).toEqual([])
+    expect(uploadApi.abortTransfer).toHaveBeenCalledOnce()
+  })
+
+  it('undoes a long paste as one Composer edit', async () => {
+    const uploadApi = uploads(
+      vi.fn().mockResolvedValue({
+        id: 'upload-paste',
+        sessionId: '.pending',
+        name: 'Pastedtext-payload.txt',
+        originalName: 'Pastedtext-payload.txt',
+        path: '/uploads/paste.txt',
+        mimeType: 'text/plain',
+        size: 7
+      })
+    )
+    const hook = renderController(uploadApi)
+    mounted.push(hook)
+    const node: ComposerPastedTextNode = { type: 'pasted-text', id: 'paste-1', text: 'payload' }
+
+    act(() => hook.result.current.actions.stagePastedText(pastedDoc(node), node))
+    await flushAsyncWork()
+    act(() => expect(hook.result.current.actions.undo()).toBe(true))
+
+    expect(hook.result.current.view.doc).toEqual(emptyDoc)
+    expect(hook.result.current.view.attachments).toEqual([])
+    expect(uploadApi.deleteUpload).toHaveBeenCalledWith({ path: '/uploads/paste.txt' })
+  })
+
   it('stages a long pasted text node and binds the managed attachment back to its anchor', async () => {
     const pastedTextName = 'Pastedtext-div-data-pane-body-l.txt'
     const stageLocalFile = vi.fn().mockResolvedValue({
@@ -260,7 +347,7 @@ describe('workspace composer controller', () => {
     })
     expect(uploadApi.deleteUpload).toHaveBeenCalledWith({ path: '/uploads/Pasted text.txt' })
 
-    act(() => expect(hook.result.current.actions.undoPastedTextRemoval()).toBe(true))
+    act(() => expect(hook.result.current.actions.undo()).toBe(true))
     await flushAsyncWork()
 
     expect(hook.result.current.view.doc.nodes[1]).toMatchObject({
@@ -351,7 +438,7 @@ describe('workspace composer controller', () => {
     })
   })
 
-  it('undoes a pasted attachment close by re-staging it, but yields after ordinary typing', async () => {
+  it('undoes a pasted attachment close by re-staging it, then undoes ordinary typing', async () => {
     const stageLocalFile = vi
       .fn()
       .mockResolvedValueOnce({
@@ -389,7 +476,7 @@ describe('workspace composer controller', () => {
     expect(hook.result.current.view.doc).toEqual(textDoc('before  after'))
     expect(hook.result.current.view.attachments).toEqual([])
 
-    act(() => expect(hook.result.current.actions.undoPastedTextRemoval()).toBe(true))
+    act(() => expect(hook.result.current.actions.undo()).toBe(true))
     await flushAsyncWork()
     expect(hook.result.current.view.attachments[0]?.id).toBe('upload-restaged')
     expect(hook.result.current.view.doc.nodes[1]).toMatchObject({
@@ -401,7 +488,8 @@ describe('workspace composer controller', () => {
 
     act(() => hook.result.current.actions.removeAttachment(hook.result.current.view.attachments[0]))
     act(() => hook.result.current.actions.changeDoc(textDoc('new typing')))
-    expect(hook.result.current.actions.undoPastedTextRemoval()).toBe(false)
+    act(() => expect(hook.result.current.actions.undo()).toBe(true))
+    expect(hook.result.current.view.doc).toEqual(textDoc('before  after'))
   })
 
   it('undoes an atomic pasted-text anchor deletion emitted by the editor', async () => {
@@ -438,7 +526,7 @@ describe('workspace composer controller', () => {
     act(() => hook.result.current.actions.changeDoc(textDoc('before  after')))
     expect(hook.result.current.view.attachments).toEqual([])
 
-    act(() => expect(hook.result.current.actions.undoPastedTextRemoval()).toBe(true))
+    act(() => expect(hook.result.current.actions.undo()).toBe(true))
     await flushAsyncWork()
     expect(hook.result.current.view.doc.nodes[1]).toMatchObject({
       type: 'pasted-text',
@@ -503,7 +591,7 @@ describe('workspace composer controller', () => {
     )
     expect(docToText(hook.result.current.view.doc)).toBe('before  middle bravo after')
 
-    act(() => expect(hook.result.current.actions.undoPastedTextRemoval()).toBe(true))
+    act(() => expect(hook.result.current.actions.undo()).toBe(true))
     await flushAsyncWork()
     expect(docToText(hook.result.current.view.doc)).toBe('before  middle bravo after')
     expect(hook.result.current.view.doc.nodes).toContainEqual(

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
@@ -785,6 +785,45 @@ describe('workspace composer controller', () => {
     ])
   })
 
+  it('re-stages a pending pasted attachment when undo restores its replaced anchor', async () => {
+    const oldUpload = deferred<UploadedAttachment | null>()
+    const newUpload = deferred<UploadedAttachment | null>()
+    const stageLocalFile = vi
+      .fn()
+      .mockImplementationOnce(() => oldUpload.promise)
+      .mockImplementationOnce(() => newUpload.promise)
+      .mockResolvedValueOnce({
+        id: 'upload-old-restaged',
+        sessionId: '.pending',
+        name: 'Pasted text.txt',
+        originalName: 'Pasted text.txt',
+        path: '/uploads/old-restaged.txt',
+        mimeType: 'text/plain',
+        size: 3
+      })
+    const hook = renderController(uploads(stageLocalFile))
+    mounted.push(hook)
+    const oldPaste: ComposerPastedTextNode = { type: 'pasted-text', id: 'paste-old', text: 'old' }
+    const newPaste: ComposerPastedTextNode = { type: 'pasted-text', id: 'paste-new', text: 'new' }
+
+    act(() => hook.result.current.actions.stagePastedText(pastedDoc(oldPaste), oldPaste))
+    act(() => hook.result.current.actions.stagePastedText(pastedDoc(newPaste), newPaste))
+    act(() => expect(hook.result.current.actions.undo()).toBe(true))
+    await flushAsyncWork()
+
+    expect(stageLocalFile).toHaveBeenCalledTimes(3)
+    expect(hook.result.current.view.doc.nodes).toContainEqual(
+      expect.objectContaining({
+        type: 'pasted-text',
+        id: 'paste-old',
+        attachmentId: 'upload-old-restaged'
+      })
+    )
+    expect(hook.result.current.view.attachments.map(({ id }) => id)).toEqual([
+      'upload-old-restaged'
+    ])
+  })
+
   it('reuses the attachment slot when a new long paste replaces an anchor at the cap', () => {
     const blocked = deferred<UploadedAttachment | null>()
     const hook = renderController(uploads(vi.fn(() => blocked.promise)))

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
@@ -13,6 +13,7 @@ import {
   type ComposerPastedTextNode
 } from './composer/composer-doc'
 import { useWorkspaceComposerController } from './workspace-composer-controller'
+import type { ComposerHistoryEntry } from './composer/composer-history'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -64,7 +65,8 @@ type ControllerHook = {
 
 const renderController = (
   uploadApi = uploads(),
-  loadSkills = vi.fn().mockResolvedValue(undefined)
+  loadSkills = vi.fn().mockResolvedValue(undefined),
+  historyEntries: ComposerHistoryEntry[] = []
 ): ControllerHook => {
   let currentDraftKey = 'session-a'
   const container = document.createElement('div')
@@ -79,7 +81,7 @@ const renderController = (
       activeProjectId: 'project',
       pendingCustomizePrefill: undefined,
       onCustomizePrefillApplied: vi.fn(),
-      historyEntries: [],
+      historyEntries,
       hasActiveSession: true,
       historyPolicy: {
         catalogSkillIds: new Set(),
@@ -175,6 +177,51 @@ describe('workspace composer controller', () => {
 
     expect(hook.result.current.view.transfers).toEqual([])
     expect(uploadApi.abortTransfer).toHaveBeenCalledOnce()
+  })
+
+  it('keeps an attachment whose pending transfer completed after a later text edit', async () => {
+    const pending = deferred<UploadedAttachment | null>()
+    const uploadApi = uploads(vi.fn(() => pending.promise))
+    const hook = renderController(uploadApi)
+    mounted.push(hook)
+
+    act(() => hook.result.current.actions.stageFiles([new File(['a'], 'paper.pdf')]))
+    act(() => hook.result.current.actions.changeDoc(textDoc('explain this')))
+    await act(async () => {
+      pending.resolve({
+        id: 'upload-a',
+        sessionId: '.pending',
+        name: 'paper.pdf',
+        originalName: 'paper.pdf',
+        path: '/uploads/paper.pdf',
+        size: 1
+      })
+      await pending.promise
+      await Promise.resolve()
+    })
+
+    act(() => expect(hook.result.current.actions.undo()).toBe(true))
+
+    expect(hook.result.current.view.doc).toEqual(emptyDoc)
+    expect(hook.result.current.view.attachments.map(({ id }) => id)).toEqual(['upload-a'])
+    expect(hook.result.current.view.transfers).toEqual([])
+    expect(uploadApi.deleteUpload).not.toHaveBeenCalled()
+  })
+
+  it('clears draft undo when prompt history replaces the Composer document', () => {
+    const historyEntry: ComposerHistoryEntry = {
+      id: 'session:message',
+      messageId: 'message',
+      doc: textDoc('history prompt')
+    }
+    const hook = renderController(uploads(), vi.fn().mockResolvedValue(undefined), [historyEntry])
+    mounted.push(hook)
+
+    act(() => hook.result.current.actions.changeDoc(textDoc('scratch')))
+    act(() => expect(hook.result.current.actions.navigateHistory('previous')).toBe(true))
+
+    expect(hook.result.current.view.doc).toEqual(textDoc('history prompt'))
+    expect(hook.result.current.actions.undo()).toBe(false)
   })
 
   it('undoes a long paste as one Composer edit', async () => {
@@ -627,6 +674,15 @@ describe('workspace composer controller', () => {
         mimeType: 'text/plain',
         size: 3
       })
+      .mockResolvedValueOnce({
+        id: 'upload-old-restaged',
+        sessionId: '.pending',
+        name: 'Pasted text.txt',
+        originalName: 'Pasted text.txt',
+        path: '/uploads/old-restaged.txt',
+        mimeType: 'text/plain',
+        size: 3
+      })
     const uploadApi = uploads(stageLocalFile)
     const hook = renderController(uploadApi)
     mounted.push(hook)
@@ -648,6 +704,20 @@ describe('workspace composer controller', () => {
     expect(hook.result.current.view.doc.nodes).not.toContainEqual(
       expect.objectContaining({ type: 'pasted-text', id: 'paste-old' })
     )
+
+    act(() => expect(hook.result.current.actions.undo()).toBe(true))
+    await flushAsyncWork()
+
+    expect(hook.result.current.view.doc.nodes).toContainEqual(
+      expect.objectContaining({
+        type: 'pasted-text',
+        id: 'paste-old',
+        attachmentId: 'upload-old-restaged'
+      })
+    )
+    expect(hook.result.current.view.attachments.map(({ id }) => id)).toEqual([
+      'upload-old-restaged'
+    ])
   })
 
   it('reuses the attachment slot when a new long paste replaces an anchor at the cap', () => {

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.ts
@@ -70,7 +70,11 @@ type WorkspaceComposerController = {
     changeDoc: (doc: ComposerDoc, caret?: ComposerCaretPosition) => void
     navigateHistory: (direction: 'previous' | 'next') => boolean
     stageFiles: (files: File[]) => void
-    stagePastedText: (doc: ComposerDoc, node: ComposerPastedTextStage) => void
+    stagePastedText: (
+      doc: ComposerDoc,
+      node: ComposerPastedTextStage,
+      caret?: ComposerCaretPosition
+    ) => void
     cancelTransfer: (transfer: ComposerUploadTransfer) => void
     removeAttachment: (attachment: UploadedAttachment) => void
     restorePastedText: (pastedTextId: string) => void

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.ts
@@ -67,7 +67,7 @@ type WorkspaceComposerController = {
     caretRequest: { key: number; position: ComposerCaretPosition } | undefined
   }
   actions: {
-    changeDoc: (doc: ComposerDoc) => void
+    changeDoc: (doc: ComposerDoc, caret?: ComposerCaretPosition) => void
     navigateHistory: (direction: 'previous' | 'next') => boolean
     stageFiles: (files: File[]) => void
     stagePastedText: (doc: ComposerDoc, node: ComposerPastedTextStage) => void

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.ts
@@ -268,6 +268,7 @@ const useWorkspaceComposerController = ({
           delete historyRef.current[currentDraftKey]
           markChanged(currentDraftKey)
           clearPastedTextUndo(currentDraftKey)
+          clearUndo(currentDraftKey)
           setActiveDoc(navigation.scratch)
           setHistoryBrowsingKey(undefined)
           setHistoryStatus('Draft restored')
@@ -307,6 +308,7 @@ const useWorkspaceComposerController = ({
       )
       markChanged(currentDraftKey)
       clearPastedTextUndo(currentDraftKey)
+      clearUndo(currentDraftKey)
       setActiveDoc(normalized.doc)
       setHistoryBrowsingKey(currentDraftKey)
       setHistoryStatus(
@@ -327,6 +329,7 @@ const useWorkspaceComposerController = ({
       markChanged,
       ready,
       clearPastedTextUndo,
+      clearUndo,
       setActiveDoc,
       transfers.length
     ]
@@ -352,6 +355,7 @@ const useWorkspaceComposerController = ({
     if (JSON.stringify(normalized.doc) !== JSON.stringify(doc)) {
       markChanged(currentDraftKey)
       clearPastedTextUndo(currentDraftKey)
+      clearUndo(currentDraftKey)
       setActiveDoc(normalized.doc)
     }
     setHistoryStatus(
@@ -363,6 +367,7 @@ const useWorkspaceComposerController = ({
     )
   }, [
     clearPastedTextUndo,
+    clearUndo,
     currentDraftKey,
     doc,
     historyBrowsingKey,
@@ -386,11 +391,13 @@ const useWorkspaceComposerController = ({
     delete historyRef.current[currentDraftKey]
     markChanged(currentDraftKey)
     clearPastedTextUndo(currentDraftKey)
+    clearUndo(currentDraftKey)
     setActiveDoc(navigation.scratch)
     setHistoryBrowsingKey(undefined)
     setHistoryStatus('Draft restored')
   }, [
     clearPastedTextUndo,
+    clearUndo,
     currentDraftKey,
     hasActiveSession,
     historyBrowsingKey,

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.ts
@@ -74,7 +74,7 @@ type WorkspaceComposerController = {
     cancelTransfer: (transfer: ComposerUploadTransfer) => void
     removeAttachment: (attachment: UploadedAttachment) => void
     restorePastedText: (pastedTextId: string) => void
-    undoPastedTextRemoval: () => boolean
+    undo: () => boolean
     setError: (error: string | null) => void
   }
   lifecycle: {
@@ -159,9 +159,10 @@ const useWorkspaceComposerController = ({
     cancelTransfer,
     removeAttachment,
     restorePastedText,
-    undoPastedTextRemoval,
+    undo,
     setError,
-    clearPastedTextUndo
+    clearPastedTextUndo,
+    clearUndo
   } = uploadController.actions
   const {
     activateDraftAttachments,
@@ -400,19 +401,21 @@ const useWorkspaceComposerController = ({
 
   const captureSend = useCallback((): ComposerSendSnapshot => {
     clearPastedTextUndo()
+    clearUndo()
     return {
       draftKey: activeDraftKeyRef.current,
       version: versionsRef.current[activeDraftKeyRef.current] ?? 0,
       doc,
       attachments
     }
-  }, [attachments, clearPastedTextUndo, doc])
+  }, [attachments, clearPastedTextUndo, clearUndo, doc])
   const clearDraft = useCallback(
     (draftKey: string, expectedVersion?: number): boolean => {
       const currentVersion = versionsRef.current[draftKey] ?? 0
       if (expectedVersion !== undefined && currentVersion !== expectedVersion) return false
       clearHistory(draftKey)
       clearPastedTextUndo(draftKey)
+      clearUndo(draftKey)
       delete draftsRef.current[draftKey]
       if (activeDraftKeyRef.current !== draftKey) return true
       setActiveDoc(emptyDoc)
@@ -420,7 +423,7 @@ const useWorkspaceComposerController = ({
       setError(null)
       return true
     },
-    [clearActiveAttachments, clearHistory, clearPastedTextUndo, setActiveDoc, setError]
+    [clearActiveAttachments, clearHistory, clearPastedTextUndo, clearUndo, setActiveDoc, setError]
   )
   const restoreFailedSend = useCallback(
     (snapshot: ComposerSendSnapshot, preserveOnConflict = false): boolean => {
@@ -477,7 +480,7 @@ const useWorkspaceComposerController = ({
       cancelTransfer,
       removeAttachment,
       restorePastedText,
-      undoPastedTextRemoval,
+      undo,
       setError
     },
     lifecycle: {

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.ts
@@ -191,8 +191,15 @@ const useWorkspaceComposerController = ({
     if (appliedCustomizePrefill?.projectId === activeProjectId) {
       delete historyRef.current[newConversationDraftKey]
       clearPastedTextUndo(newConversationDraftKey)
+      clearUndo(newConversationDraftKey)
     }
-  }, [activeProjectId, appliedCustomizePrefill, clearPastedTextUndo, newConversationDraftKey])
+  }, [
+    activeProjectId,
+    appliedCustomizePrefill,
+    clearPastedTextUndo,
+    clearUndo,
+    newConversationDraftKey
+  ])
 
   useLayoutEffect(() => {
     docRef.current = doc

--- a/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
@@ -703,10 +703,13 @@ export const useWorkspaceComposerUploadController = ({
     clearHistory(draftKey)
     markChanged(draftKey)
     const currentAttachmentIds = new Set(attachmentsRef.current.map(({ id }) => id))
+    const currentTransferIds = new Set(transfersRef.current.map(({ transferId }) => transferId))
     const pastedTextToRestage = snapshot.doc.nodes.filter(
       (node): node is ComposerPastedTextNode =>
         node.type === 'pasted-text' &&
-        Boolean(node.attachmentId && !currentAttachmentIds.has(node.attachmentId))
+        (node.attachmentId
+          ? !currentAttachmentIds.has(node.attachmentId)
+          : !node.transferId || !currentTransferIds.has(node.transferId))
     )
     setActiveAttachments(
       attachmentsRef.current.filter((attachment) => attachmentIds.has(attachment.id))

--- a/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
@@ -282,6 +282,13 @@ export const useWorkspaceComposerUploadController = ({
         snapshot.attachmentTransfers.some((transfer) => transfer.transferId === transferId)
           ? {
               ...snapshot,
+              doc: pastedTextId
+                ? updatePastedTextNode(snapshot.doc, pastedTextId, (node) => ({
+                    ...node,
+                    transferId: undefined,
+                    attachmentId: attachment.id
+                  }))
+                : snapshot.doc,
               attachmentTransfers: snapshot.attachmentTransfers.filter(
                 (transfer) => transfer.transferId !== transferId
               ),
@@ -362,6 +369,7 @@ export const useWorkspaceComposerUploadController = ({
               const message = asText(uploadError)
               if (transfer.pastedTextId) {
                 updateTransfer({ remove: true })
+                clearUndo(draftKey)
                 restorePastedTextInline(draftKey, transfer.pastedTextId)
               } else {
                 updateTransfer({ status: 'error', error: message })
@@ -379,6 +387,7 @@ export const useWorkspaceComposerUploadController = ({
       activeDraftKeyRef,
       commitDraftAttachment,
       restorePastedTextInline,
+      clearUndo,
       updateDraftTransfers,
       uploads
     ]
@@ -550,6 +559,7 @@ export const useWorkspaceComposerUploadController = ({
   const removePastedText = useCallback(
     (node: ComposerPastedTextNode): void => {
       const draftKey = activeDraftKeyRef.current
+      clearUndo(draftKey)
       const stack = removedPastedTextRef.current[draftKey] ?? []
       removedPastedTextRef.current[draftKey] = [
         ...stack,
@@ -563,7 +573,15 @@ export const useWorkspaceComposerUploadController = ({
       setActiveDoc(removePastedTextNode(docRef.current, node.id))
       deletePastedTextUpload(node, draftKey)
     },
-    [activeDraftKeyRef, clearHistory, deletePastedTextUpload, docRef, markChanged, setActiveDoc]
+    [
+      activeDraftKeyRef,
+      clearHistory,
+      clearUndo,
+      deletePastedTextUpload,
+      docRef,
+      markChanged,
+      setActiveDoc
+    ]
   )
 
   const restorePastedText = useCallback(

--- a/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
@@ -64,7 +64,11 @@ type WorkspaceComposerUploadController = {
   actions: {
     changeDoc: (doc: ComposerDoc, caret?: ComposerCaretPosition) => void
     stageFiles: (files: File[]) => void
-    stagePastedText: (doc: ComposerDoc, node: ComposerPastedTextStage) => void
+    stagePastedText: (
+      doc: ComposerDoc,
+      node: ComposerPastedTextStage,
+      caret?: ComposerCaretPosition
+    ) => void
     cancelTransfer: (transfer: ComposerUploadTransfer) => void
     removeAttachment: (attachment: UploadedAttachment) => void
     restorePastedText: (pastedTextId: string) => void
@@ -498,12 +502,17 @@ export const useWorkspaceComposerUploadController = ({
   )
 
   const stagePastedText = useCallback(
-    (nextDoc: ComposerDoc, staged: ComposerPastedTextStage, preserveRemovalUndo = false): void => {
+    (
+      nextDoc: ComposerDoc,
+      staged: ComposerPastedTextStage,
+      preserveRemovalUndo = false,
+      caret?: ComposerCaretPosition
+    ): void => {
       const draftKey = activeDraftKeyRef.current
       if (!preserveRemovalUndo) clearPastedTextUndo(draftKey)
       clearHistory(draftKey)
       markChanged(draftKey)
-      if (!preserveRemovalUndo) captureUndo(draftKey)
+      if (!preserveRemovalUndo) captureUndo(draftKey, caret)
       const releasedSlots = reconcileRemovedPastedTextUploads(nextDoc, draftKey)
       const nodes: readonly ComposerPastedTextNode[] = Array.isArray(staged)
         ? staged
@@ -905,7 +914,7 @@ export const useWorkspaceComposerUploadController = ({
     actions: {
       changeDoc,
       stageFiles,
-      stagePastedText,
+      stagePastedText: (doc, node, caret) => stagePastedText(doc, node, false, caret),
       cancelTransfer,
       removeAttachment,
       restorePastedText,

--- a/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
@@ -35,6 +35,8 @@ type PastedTextUndoReceipt = {
   attachmentDoc?: ComposerDoc
 }
 
+type ComposerUndoSnapshot = ComposerDraft
+
 export type ComposerUploadApi = UploadStagingApi & {
   claimLocalFile?: (request: { transferId: string }) => Promise<void>
 }
@@ -66,9 +68,10 @@ type WorkspaceComposerUploadController = {
     cancelTransfer: (transfer: ComposerUploadTransfer) => void
     removeAttachment: (attachment: UploadedAttachment) => void
     restorePastedText: (pastedTextId: string) => void
-    undoPastedTextRemoval: () => boolean
+    undo: () => boolean
     setError: (error: string | null) => void
     clearPastedTextUndo: (draftKey?: string) => void
+    clearUndo: (draftKey?: string) => void
   }
   lifecycle: {
     activateDraftAttachments: (draft: ComposerDraft) => void
@@ -127,6 +130,7 @@ export const useWorkspaceComposerUploadController = ({
   const cancelledTransfersRef = useRef(new Set<string>())
   const deletionCleanupRef = useRef<Record<string, ComposerDeletionCleanup>>({})
   const removedPastedTextRef = useRef<Record<string, PastedTextUndoReceipt[]>>({})
+  const undoRef = useRef<Record<string, ComposerUndoSnapshot[]>>({})
   const setActiveAttachments = useCallback((next: UploadedAttachment[]): void => {
     attachmentsRef.current = next
     setAttachments(next)
@@ -137,6 +141,16 @@ export const useWorkspaceComposerUploadController = ({
     },
     [setActiveAttachments]
   )
+  const setActiveTransfers = useCallback((next: ComposerUploadTransfer[]): void => {
+    transfersRef.current = next
+    setTransfers(next)
+  }, [])
+  const updateActiveTransfers = useCallback(
+    (update: (current: ComposerUploadTransfer[]) => ComposerUploadTransfer[]): void => {
+      setActiveTransfers(update(transfersRef.current))
+    },
+    [setActiveTransfers]
+  )
   const clearPastedTextUndo = useCallback(
     (draftKey = activeDraftKeyRef.current): void => {
       delete removedPastedTextRef.current[draftKey]
@@ -146,10 +160,27 @@ export const useWorkspaceComposerUploadController = ({
   const clearAllPastedTextUndo = useCallback((): void => {
     removedPastedTextRef.current = {}
   }, [])
+  const clearUndo = useCallback(
+    (draftKey = activeDraftKeyRef.current): void => {
+      delete undoRef.current[draftKey]
+    },
+    [activeDraftKeyRef]
+  )
+  const captureUndo = useCallback(
+    (draftKey = activeDraftKeyRef.current): void => {
+      const stack = undoRef.current[draftKey] ?? []
+      undoRef.current[draftKey] = [
+        ...stack,
+        {
+          doc: docRef.current,
+          attachments: [...attachmentsRef.current],
+          attachmentTransfers: [...transfersRef.current]
+        }
+      ].slice(-100)
+    },
+    [activeDraftKeyRef, docRef]
+  )
 
-  useEffect(() => {
-    transfersRef.current = transfers
-  }, [transfers])
   useEffect(
     () => () => {
       const transferIds = new Set(Object.keys(controllersRef.current))
@@ -180,13 +211,13 @@ export const useWorkspaceComposerUploadController = ({
       update: (current: ComposerUploadTransfer[]) => ComposerUploadTransfer[]
     ): void => {
       if (activeDraftKeyRef.current === draftKey) {
-        setTransfers(update)
+        updateActiveTransfers(update)
         return
       }
       const draft = draftsRef.current[draftKey]
       if (draft) draft.attachmentTransfers = update(draft.attachmentTransfers)
     },
-    [activeDraftKeyRef, draftsRef]
+    [activeDraftKeyRef, draftsRef, updateActiveTransfers]
   )
   const updateDraftDoc = useCallback(
     (draftKey: string, update: (current: ComposerDoc) => ComposerDoc): void => {
@@ -226,7 +257,9 @@ export const useWorkspaceComposerUploadController = ({
         return
       }
       if (activeDraftKeyRef.current === draftKey) {
-        setTransfers((current) => current.filter((transfer) => transfer.transferId !== transferId))
+        updateActiveTransfers((current) =>
+          current.filter((transfer) => transfer.transferId !== transferId)
+        )
         updateActiveAttachments((current) => [...current, attachment])
       } else {
         const draft = draftsRef.current[draftKey]
@@ -251,6 +284,7 @@ export const useWorkspaceComposerUploadController = ({
       docRef,
       draftsRef,
       updateActiveAttachments,
+      updateActiveTransfers,
       updateDraftDoc,
       updateDraftTransfers,
       uploads
@@ -364,7 +398,8 @@ export const useWorkspaceComposerUploadController = ({
           status: 'queued' as const
         }
       }))
-      setTransfers((current) => [...current, ...pending.map(({ transfer }) => transfer)])
+      captureUndo(draftKey)
+      updateActiveTransfers((current) => [...current, ...pending.map(({ transfer }) => transfer)])
       deletionCleanupRef.current[draftKey]?.attachmentTransfers.push(
         ...pending.map(({ transfer }) => transfer)
       )
@@ -379,7 +414,9 @@ export const useWorkspaceComposerUploadController = ({
       markChanged,
       runPendingUploads,
       supportsImageInput,
-      transfers.length
+      transfers.length,
+      captureUndo,
+      updateActiveTransfers
     ]
   )
 
@@ -388,7 +425,7 @@ export const useWorkspaceComposerUploadController = ({
       if (node.transferId) {
         cancelledTransfersRef.current.add(node.transferId)
         controllersRef.current[node.transferId]?.abort()
-        setTransfers((current) =>
+        updateActiveTransfers((current) =>
           current.filter((transfer) => transfer.transferId !== node.transferId)
         )
         void uploads.abortTransfer({ transferId: node.transferId }).catch(() => undefined)
@@ -405,7 +442,7 @@ export const useWorkspaceComposerUploadController = ({
         .deleteUpload({ path: attachment.path })
         .catch((deleteError) => setError(asText(deleteError)))
     },
-    [updateActiveAttachments, uploads]
+    [updateActiveAttachments, updateActiveTransfers, uploads]
   )
 
   const reconcileRemovedPastedTextUploads = useCallback(
@@ -439,6 +476,7 @@ export const useWorkspaceComposerUploadController = ({
         node,
         file: new File([node.text], pastedTextFilename(node.text), { type: 'text/plain' })
       }))
+      if (!preserveRemovalUndo) captureUndo(draftKey)
       const intake = canStageAttachments
         ? planComposerAttachmentIntake(
             records.map(({ file }) => file),
@@ -477,7 +515,7 @@ export const useWorkspaceComposerUploadController = ({
       if (restoredCaret) requestCaret(restoredCaret)
       if (pending.length === 0) return
       const pendingTransfers = pending.map(({ transfer }) => transfer)
-      setTransfers((current) => [...current, ...pendingTransfers])
+      updateActiveTransfers((current) => [...current, ...pendingTransfers])
       deletionCleanupRef.current[draftKey]?.attachmentTransfers.push(...pendingTransfers)
       runPendingUploads(draftKey, pending)
     },
@@ -492,7 +530,9 @@ export const useWorkspaceComposerUploadController = ({
       requestCaret,
       runPendingUploads,
       setActiveDoc,
-      transfers.length
+      transfers.length,
+      captureUndo,
+      updateActiveTransfers
     ]
   )
 
@@ -581,6 +621,16 @@ export const useWorkspaceComposerUploadController = ({
         removePastedText(atomicallyRemovedPastedText)
         return
       }
+      if (serializedNextDoc === JSON.stringify(docRef.current)) return
+      const removesPastedText = docRef.current.nodes.some(
+        (node) =>
+          node.type === 'pasted-text' &&
+          !nextDoc.nodes.some(
+            (candidate) => candidate.type === 'pasted-text' && candidate.id === node.id
+          )
+      )
+      if (removesPastedText) clearUndo(draftKey)
+      else captureUndo(draftKey)
       clearPastedTextUndo(draftKey)
       clearHistory(draftKey)
       reconcileRemovedPastedTextUploads(nextDoc, draftKey)
@@ -591,13 +641,53 @@ export const useWorkspaceComposerUploadController = ({
       activeDraftKeyRef,
       clearHistory,
       clearPastedTextUndo,
+      clearUndo,
       docRef,
       markChanged,
       reconcileRemovedPastedTextUploads,
       removePastedText,
-      setActiveDoc
+      setActiveDoc,
+      captureUndo
     ]
   )
+
+  const undo = useCallback((): boolean => {
+    if (undoPastedTextRemoval()) return true
+    const draftKey = activeDraftKeyRef.current
+    const stack = undoRef.current[draftKey]
+    const snapshot = stack?.at(-1)
+    if (!snapshot) return false
+    if (stack && stack.length > 1) undoRef.current[draftKey] = stack.slice(0, -1)
+    else delete undoRef.current[draftKey]
+
+    const attachmentIds = new Set(snapshot.attachments.map(({ id }) => id))
+    deleteAttachmentFiles(
+      attachmentsRef.current.filter((attachment) => !attachmentIds.has(attachment.id))
+    )
+    const transferIds = new Set(snapshot.attachmentTransfers.map(({ transferId }) => transferId))
+    for (const transfer of transfersRef.current) {
+      if (transferIds.has(transfer.transferId)) continue
+      cancelledTransfersRef.current.add(transfer.transferId)
+      controllersRef.current[transfer.transferId]?.abort()
+      void uploads.abortTransfer({ transferId: transfer.transferId }).catch(() => undefined)
+    }
+    clearHistory(draftKey)
+    markChanged(draftKey)
+    setActiveDoc(snapshot.doc)
+    setActiveAttachments(snapshot.attachments)
+    setActiveTransfers(snapshot.attachmentTransfers)
+    return true
+  }, [
+    activeDraftKeyRef,
+    clearHistory,
+    deleteAttachmentFiles,
+    markChanged,
+    setActiveAttachments,
+    setActiveDoc,
+    setActiveTransfers,
+    undoPastedTextRemoval,
+    uploads
+  ])
 
   const cancelTransfer = useCallback(
     (transfer: ComposerUploadTransfer): void => {
@@ -613,6 +703,7 @@ export const useWorkspaceComposerUploadController = ({
       }
       const draftKey = activeDraftKeyRef.current
       clearPastedTextUndo(draftKey)
+      clearUndo(draftKey)
       markChanged(draftKey)
       cancelledTransfersRef.current.add(transfer.transferId)
       controllersRef.current[transfer.transferId]?.abort()
@@ -635,6 +726,7 @@ export const useWorkspaceComposerUploadController = ({
     [
       activeDraftKeyRef,
       clearPastedTextUndo,
+      clearUndo,
       docRef,
       markChanged,
       removePastedText,
@@ -654,6 +746,7 @@ export const useWorkspaceComposerUploadController = ({
         return
       }
       clearPastedTextUndo()
+      clearUndo()
       markChanged()
       updateActiveAttachments((current) => current.filter((item) => item.id !== attachment.id))
       const cleanup = deletionCleanupRef.current[activeDraftKeyRef.current]
@@ -667,6 +760,7 @@ export const useWorkspaceComposerUploadController = ({
     [
       activeDraftKeyRef,
       clearPastedTextUndo,
+      clearUndo,
       docRef,
       markChanged,
       removePastedText,
@@ -678,10 +772,10 @@ export const useWorkspaceComposerUploadController = ({
   const activateDraftAttachments = useCallback(
     (draft: ComposerDraft): void => {
       setActiveAttachments(draft.attachments)
-      setTransfers(draft.attachmentTransfers)
+      setActiveTransfers(draft.attachmentTransfers)
       clearAllPastedTextUndo()
     },
-    [clearAllPastedTextUndo, setActiveAttachments]
+    [clearAllPastedTextUndo, setActiveAttachments, setActiveTransfers]
   )
 
   const clearActiveAttachments = useCallback(
@@ -744,9 +838,10 @@ export const useWorkspaceComposerUploadController = ({
       cancelTransfer,
       removeAttachment,
       restorePastedText,
-      undoPastedTextRemoval,
+      undo,
       setError,
-      clearPastedTextUndo
+      clearPastedTextUndo,
+      clearUndo
     },
     lifecycle: {
       activateDraftAttachments,

--- a/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
@@ -278,6 +278,17 @@ export const useWorkspaceComposerUploadController = ({
           }))
         )
       }
+      undoRef.current[draftKey] = (undoRef.current[draftKey] ?? []).map((snapshot) =>
+        snapshot.attachmentTransfers.some((transfer) => transfer.transferId === transferId)
+          ? {
+              ...snapshot,
+              attachmentTransfers: snapshot.attachmentTransfers.filter(
+                (transfer) => transfer.transferId !== transferId
+              ),
+              attachments: [...snapshot.attachments, attachment]
+            }
+          : snapshot
+      )
     },
     [
       activeDraftKeyRef,
@@ -468,6 +479,7 @@ export const useWorkspaceComposerUploadController = ({
       if (!preserveRemovalUndo) clearPastedTextUndo(draftKey)
       clearHistory(draftKey)
       markChanged(draftKey)
+      if (!preserveRemovalUndo) captureUndo(draftKey)
       const releasedSlots = reconcileRemovedPastedTextUploads(nextDoc, draftKey)
       const nodes: readonly ComposerPastedTextNode[] = Array.isArray(staged)
         ? staged
@@ -476,7 +488,6 @@ export const useWorkspaceComposerUploadController = ({
         node,
         file: new File([node.text], pastedTextFilename(node.text), { type: 'text/plain' })
       }))
-      if (!preserveRemovalUndo) captureUndo(draftKey)
       const intake = canStageAttachments
         ? planComposerAttachmentIntake(
             records.map(({ file }) => file),
@@ -673,9 +684,38 @@ export const useWorkspaceComposerUploadController = ({
     }
     clearHistory(draftKey)
     markChanged(draftKey)
-    setActiveDoc(snapshot.doc)
-    setActiveAttachments(snapshot.attachments)
-    setActiveTransfers(snapshot.attachmentTransfers)
+    const currentAttachmentIds = new Set(attachmentsRef.current.map(({ id }) => id))
+    const pastedTextToRestage = snapshot.doc.nodes.filter(
+      (node): node is ComposerPastedTextNode =>
+        node.type === 'pasted-text' &&
+        Boolean(node.attachmentId && !currentAttachmentIds.has(node.attachmentId))
+    )
+    setActiveAttachments(
+      attachmentsRef.current.filter((attachment) => attachmentIds.has(attachment.id))
+    )
+    setActiveTransfers(
+      transfersRef.current.filter((transfer) => transferIds.has(transfer.transferId))
+    )
+    if (pastedTextToRestage.length > 0) {
+      const restagedIds = new Set(pastedTextToRestage.map(({ id }) => id))
+      stagePastedText(
+        {
+          nodes: snapshot.doc.nodes.map((node) =>
+            node.type === 'pasted-text' && restagedIds.has(node.id)
+              ? { ...node, attachmentId: undefined, transferId: undefined }
+              : node
+          )
+        },
+        pastedTextToRestage.map((node) => ({
+          ...node,
+          attachmentId: undefined,
+          transferId: undefined
+        })),
+        true
+      )
+    } else {
+      setActiveDoc(snapshot.doc)
+    }
     return true
   }, [
     activeDraftKeyRef,
@@ -685,6 +725,7 @@ export const useWorkspaceComposerUploadController = ({
     setActiveAttachments,
     setActiveDoc,
     setActiveTransfers,
+    stagePastedText,
     undoPastedTextRemoval,
     uploads
   ])

--- a/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
@@ -35,7 +35,7 @@ type PastedTextUndoReceipt = {
   attachmentDoc?: ComposerDoc
 }
 
-type ComposerUndoSnapshot = ComposerDraft
+type ComposerUndoSnapshot = ComposerDraft & { caret?: ComposerCaretPosition }
 
 export type ComposerUploadApi = UploadStagingApi & {
   claimLocalFile?: (request: { transferId: string }) => Promise<void>
@@ -62,7 +62,7 @@ type WorkspaceComposerUploadController = {
     isUploading: boolean
   }
   actions: {
-    changeDoc: (doc: ComposerDoc) => void
+    changeDoc: (doc: ComposerDoc, caret?: ComposerCaretPosition) => void
     stageFiles: (files: File[]) => void
     stagePastedText: (doc: ComposerDoc, node: ComposerPastedTextStage) => void
     cancelTransfer: (transfer: ComposerUploadTransfer) => void
@@ -167,18 +167,33 @@ export const useWorkspaceComposerUploadController = ({
     [activeDraftKeyRef]
   )
   const captureUndo = useCallback(
-    (draftKey = activeDraftKeyRef.current): void => {
+    (draftKey = activeDraftKeyRef.current, caret?: ComposerCaretPosition): void => {
       const stack = undoRef.current[draftKey] ?? []
       undoRef.current[draftKey] = [
         ...stack,
         {
           doc: docRef.current,
           attachments: [...attachmentsRef.current],
-          attachmentTransfers: [...transfersRef.current]
+          attachmentTransfers: [...transfersRef.current],
+          caret
         }
       ].slice(-100)
     },
     [activeDraftKeyRef, docRef]
+  )
+  const reconcileFailedPastedTextUndo = useCallback(
+    (draftKey: string, pastedTextId: string, transferId: string): void => {
+      const stack = undoRef.current[draftKey]
+      if (!stack) return
+      undoRef.current[draftKey] = stack.map((snapshot) => ({
+        ...snapshot,
+        doc: restorePastedTextNode(snapshot.doc, pastedTextId)?.doc ?? snapshot.doc,
+        attachmentTransfers: snapshot.attachmentTransfers.filter(
+          (candidate) => candidate.transferId !== transferId
+        )
+      }))
+    },
+    []
   )
 
   useEffect(
@@ -369,7 +384,7 @@ export const useWorkspaceComposerUploadController = ({
               const message = asText(uploadError)
               if (transfer.pastedTextId) {
                 updateTransfer({ remove: true })
-                clearUndo(draftKey)
+                reconcileFailedPastedTextUndo(draftKey, transfer.pastedTextId, transfer.transferId)
                 restorePastedTextInline(draftKey, transfer.pastedTextId)
               } else {
                 updateTransfer({ status: 'error', error: message })
@@ -387,7 +402,7 @@ export const useWorkspaceComposerUploadController = ({
       activeDraftKeyRef,
       commitDraftAttachment,
       restorePastedTextInline,
-      clearUndo,
+      reconcileFailedPastedTextUndo,
       updateDraftTransfers,
       uploads
     ]
@@ -636,7 +651,7 @@ export const useWorkspaceComposerUploadController = ({
   }, [activeDraftKeyRef, docRef, stagePastedText])
 
   const changeDoc = useCallback(
-    (nextDoc: ComposerDoc): void => {
+    (nextDoc: ComposerDoc, caret?: ComposerCaretPosition): void => {
       const draftKey = activeDraftKeyRef.current
       const serializedNextDoc = JSON.stringify(nextDoc)
       // Backspace/Delete emits the current doc with exactly one atomic marker removed. Reuse the
@@ -651,15 +666,7 @@ export const useWorkspaceComposerUploadController = ({
         return
       }
       if (serializedNextDoc === JSON.stringify(docRef.current)) return
-      const removesPastedText = docRef.current.nodes.some(
-        (node) =>
-          node.type === 'pasted-text' &&
-          !nextDoc.nodes.some(
-            (candidate) => candidate.type === 'pasted-text' && candidate.id === node.id
-          )
-      )
-      if (removesPastedText) clearUndo(draftKey)
-      else captureUndo(draftKey)
+      captureUndo(draftKey, caret)
       clearPastedTextUndo(draftKey)
       clearHistory(draftKey)
       reconcileRemovedPastedTextUploads(nextDoc, draftKey)
@@ -670,7 +677,6 @@ export const useWorkspaceComposerUploadController = ({
       activeDraftKeyRef,
       clearHistory,
       clearPastedTextUndo,
-      clearUndo,
       docRef,
       markChanged,
       reconcileRemovedPastedTextUploads,
@@ -737,6 +743,7 @@ export const useWorkspaceComposerUploadController = ({
     } else {
       setActiveDoc(snapshot.doc)
     }
+    requestCaret(snapshot.caret ?? { nodeIndex: snapshot.doc.nodes.length, offset: 0 })
     return true
   }, [
     activeDraftKeyRef,
@@ -747,6 +754,7 @@ export const useWorkspaceComposerUploadController = ({
     setActiveDoc,
     setActiveTransfers,
     stagePastedText,
+    requestCaret,
     undoPastedTextRemoval,
     uploads
   ])
@@ -876,6 +884,7 @@ export const useWorkspaceComposerUploadController = ({
       delete draftsRef.current[draftKey]
       clearHistory(draftKey)
       clearPastedTextUndo(draftKey)
+      clearUndo(draftKey)
       for (const transfer of cleanup.attachmentTransfers) {
         cancelledTransfersRef.current.add(transfer.transferId)
         controllersRef.current[transfer.transferId]?.abort()
@@ -883,7 +892,7 @@ export const useWorkspaceComposerUploadController = ({
       }
       deleteAttachmentFiles(cleanup.attachments)
     },
-    [clearHistory, clearPastedTextUndo, deleteAttachmentFiles, draftsRef, uploads]
+    [clearHistory, clearPastedTextUndo, clearUndo, deleteAttachmentFiles, draftsRef, uploads]
   )
 
   return {


### PR DESCRIPTION
## Problem

Composer relied on browser-native undo for ordinary editable content while long pasted text and file attachments lived in React-managed draft state. After those managed updates, Cmd/Ctrl-Z could do nothing or only undo part of the visible Composer content. Pasted images could not be undone at all.

## Proposed change

- Route Cmd/Ctrl-Z exclusively through one Composer undo action.
- Keep a bounded, per-draft in-memory history of document, attachment, and pending-transfer snapshots.
- Undo ordinary Composer document edits, long-text paste anchors, completed image attachments, and in-flight image transfers.
- Reconcile snapshots when pending uploads complete and re-stage long text when replacing it deleted or canceled the prior upload.
- Preserve the existing pasted-text removal behavior that re-stages deleted long text.
- Invalidate undo state when prompt history, customize prefill, failed transfers, or removals invalidate a prior snapshot; clear it on send/clear.

## Scope and non-goals

- No database or persisted-data changes.
- No schema, enum, IPC, or renderer API changes.
- No historical-data compatibility requirement.
- No redo implementation.
- Undo history remains process-local and is intentionally not restored after restart.

## Acceptance criteria and validation

- Cmd/Ctrl-Z dispatch and Composer draft undo for text, IME composition coalescing, collapsed and selection-replacement caret restoration, exhausted history, long paste, completed/pending image paste, upload completion/failure races, atomic and selection-based anchor deletion, replaced completed or pending long text, session deletion, prompt history, and customize prefill -> direct Vitest run of ComposerEditor.interaction.test.tsx, workspace-composer-controller.test.ts, and ConversationPanel.interaction.test.tsx -> 193 passed on the final local head.
- Workspace owner and representative consumers -> workspace_page module impact plan executed directly with Vitest -> 25 files, 529 tests passed before the final isolated long-paste race regression was added.
- Renderer type safety -> npm run typecheck:web -> passed on the final local head.
- Changed-file lint -> npx eslint over all seven changed files -> passed with zero warnings on the final local head.
- Diff hygiene -> git diff --check -> passed on the final local head.

The npm test and npm run test:module wrappers were not used for execution because their pretest detected that the shared worktree Prisma Client predates the current schema. The selected Vitest files were run directly without changing generated dependencies. Full npm test was intentionally not run per task scope; exact-head PR CI remains the final authority.

## Review focus

- Confirm that undo cleanup correctly aborts pending transfers and deletes completed staged uploads.
- Confirm that upload completion updates stored snapshots without resurrecting settled transfers.
- Confirm that replaced long-text attachments are re-staged rather than restored as dangling metadata, including when the old transfer was still pending.
- Confirm that per-draft histories cannot leak across prompt history, customize prefill, draft switching, send, or clear boundaries.
- Confirm that exhausted custom history remains a no-op and never falls through to stale browser-native undo.
- Remaining interaction risk: application-managed text undo records each emitted document change, which may use finer undo granularity than browser-native history.
