### PR TITLE
fix(connectors): restrict OAuth authorization URLs

### DIFF
--- a/src/main/connectors/oauth-client.test.ts
+++ b/src/main/connectors/oauth-client.test.ts
@@ -214,18 +214,21 @@ describe('PersistentOAuthClientProvider', () => {
 
     for (const authorizationUrl of [
       'https://auth.example.test/authorize',
-      'http://127.0.0.1:4000/authorize'
+      'http://127.0.0.2:4000/authorize',
+      'http://[::1]:4000/authorize'
     ]) {
       await provider.redirectToAuthorization(new URL(authorizationUrl))
     }
     expect(openExternal.mock.calls).toEqual([
       ['https://auth.example.test/authorize'],
-      ['http://127.0.0.1:4000/authorize']
+      ['http://127.0.0.2:4000/authorize'],
+      ['http://[::1]:4000/authorize']
     ])
 
     openExternal.mockClear()
     for (const authorizationUrl of [
       'http://auth.example.test/authorize',
+      'http://127.example.test/authorize',
       'file:///tmp/oauth-authorization'
     ]) {
       await expect(provider.redirectToAuthorization(new URL(authorizationUrl))).rejects.toThrow(

--- a/src/main/connectors/oauth-client.test.ts
+++ b/src/main/connectors/oauth-client.test.ts
@@ -203,6 +203,38 @@ describe('PersistentOAuthClientProvider', () => {
     expect(saveState).toHaveBeenLastCalledWith({})
   })
 
+  it('opens only HTTPS and loopback HTTP authorization URLs', async () => {
+    const openExternal = vi.fn(async () => undefined)
+    const provider = new PersistentOAuthClientProvider({
+      serverId: 'server-1',
+      redirectUrl: 'http://127.0.0.1:4000/oauth/callback',
+      config: {},
+      openExternal
+    })
+
+    for (const authorizationUrl of [
+      'https://auth.example.test/authorize',
+      'http://127.0.0.1:4000/authorize'
+    ]) {
+      await provider.redirectToAuthorization(new URL(authorizationUrl))
+    }
+    expect(openExternal.mock.calls).toEqual([
+      ['https://auth.example.test/authorize'],
+      ['http://127.0.0.1:4000/authorize']
+    ])
+
+    openExternal.mockClear()
+    for (const authorizationUrl of [
+      'http://auth.example.test/authorize',
+      'file:///tmp/oauth-authorization'
+    ]) {
+      await expect(provider.redirectToAuthorization(new URL(authorizationUrl))).rejects.toThrow(
+        'OAuth authorization URL must use HTTPS or loopback HTTP.'
+      )
+    }
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
   it('retains tokens until auth reads a dynamic registration tied to an old callback', async () => {
     const saveState = vi.fn(async () => undefined)
     const provider = new PersistentOAuthClientProvider({

--- a/src/main/connectors/oauth-client.test.ts
+++ b/src/main/connectors/oauth-client.test.ts
@@ -214,6 +214,7 @@ describe('PersistentOAuthClientProvider', () => {
 
     for (const authorizationUrl of [
       'https://auth.example.test/authorize',
+      'http://localhost:4000/authorize',
       'http://127.0.0.2:4000/authorize',
       'http://[::1]:4000/authorize'
     ]) {
@@ -221,6 +222,7 @@ describe('PersistentOAuthClientProvider', () => {
     }
     expect(openExternal.mock.calls).toEqual([
       ['https://auth.example.test/authorize'],
+      ['http://localhost:4000/authorize'],
       ['http://127.0.0.2:4000/authorize'],
       ['http://[::1]:4000/authorize']
     ])
@@ -228,6 +230,7 @@ describe('PersistentOAuthClientProvider', () => {
     openExternal.mockClear()
     for (const authorizationUrl of [
       'http://auth.example.test/authorize',
+      'http://localhost.example.test/authorize',
       'http://127.example.test/authorize',
       'file:///tmp/oauth-authorization'
     ]) {

--- a/src/main/connectors/oauth-client.test.ts
+++ b/src/main/connectors/oauth-client.test.ts
@@ -238,6 +238,24 @@ describe('PersistentOAuthClientProvider', () => {
     expect(openExternal).not.toHaveBeenCalled()
   })
 
+  it('clears a stale token before rejecting an unsafe authorization URL', async () => {
+    const saveState = vi.fn(async () => undefined)
+    const provider = new PersistentOAuthClientProvider({
+      serverId: 'server-1',
+      redirectUrl: 'http://127.0.0.1:4000/oauth/callback',
+      config: {},
+      state: { tokens: { access_token: 'stale', token_type: 'Bearer' } },
+      saveState,
+      openExternal: vi.fn()
+    })
+
+    await expect(
+      provider.redirectToAuthorization(new URL('http://auth.example.test/authorize'))
+    ).rejects.toThrow('OAuth authorization URL must use HTTPS or loopback HTTP.')
+    expect(provider.tokens()).toBeUndefined()
+    expect(saveState).toHaveBeenLastCalledWith({})
+  })
+
   it('retains tokens until auth reads a dynamic registration tied to an old callback', async () => {
     const saveState = vi.fn(async () => undefined)
     const provider = new PersistentOAuthClientProvider({

--- a/src/main/connectors/oauth-client.ts
+++ b/src/main/connectors/oauth-client.ts
@@ -258,6 +258,13 @@ export class PersistentOAuthClientProvider implements OAuthClientProvider {
   }
 
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    // The SDK only redirects after the current token cannot authorize the connection. Clear that
+    // proven-stale token before opening the browser so a fast Cancel cannot preserve it by racing
+    // the manager's generation guard. A valid token never reaches this method.
+    if (this.oauthState.tokens) {
+      delete this.oauthState.tokens
+      await this.persist()
+    }
     const hostname = authorizationUrl.hostname
     if (
       authorizationUrl.protocol !== 'https:' &&
@@ -267,13 +274,6 @@ export class PersistentOAuthClientProvider implements OAuthClientProvider {
       )
     ) {
       throw new Error('OAuth authorization URL must use HTTPS or loopback HTTP.')
-    }
-    // The SDK only redirects after the current token cannot authorize the connection. Clear that
-    // proven-stale token before opening the browser so a fast Cancel cannot preserve it by racing
-    // the manager's generation guard. A valid token never reaches this method.
-    if (this.oauthState.tokens) {
-      delete this.oauthState.tokens
-      await this.persist()
     }
     if (!this.openExternal) {
       throw new Error('OAuth authentication required. Sign in from Settings > Connectors.')

--- a/src/main/connectors/oauth-client.ts
+++ b/src/main/connectors/oauth-client.ts
@@ -270,7 +270,9 @@ export class PersistentOAuthClientProvider implements OAuthClientProvider {
       authorizationUrl.protocol !== 'https:' &&
       !(
         authorizationUrl.protocol === 'http:' &&
-        ((isIP(hostname) === 4 && hostname.startsWith('127.')) || hostname === '[::1]')
+        (hostname === 'localhost' ||
+          (isIP(hostname) === 4 && hostname.startsWith('127.')) ||
+          hostname === '[::1]')
       )
     ) {
       throw new Error('OAuth authorization URL must use HTTPS or loopback HTTP.')

--- a/src/main/connectors/oauth-client.ts
+++ b/src/main/connectors/oauth-client.ts
@@ -257,6 +257,12 @@ export class PersistentOAuthClientProvider implements OAuthClientProvider {
   }
 
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    if (
+      authorizationUrl.protocol !== 'https:' &&
+      !(authorizationUrl.protocol === 'http:' && authorizationUrl.hostname === '127.0.0.1')
+    ) {
+      throw new Error('OAuth authorization URL must use HTTPS or loopback HTTP.')
+    }
     // The SDK only redirects after the current token cannot authorize the connection. Clear that
     // proven-stale token before opening the browser so a fast Cancel cannot preserve it by racing
     // the manager's generation guard. A valid token never reaches this method.

--- a/src/main/connectors/oauth-client.ts
+++ b/src/main/connectors/oauth-client.ts
@@ -1,5 +1,6 @@
 import { createServer, type Server } from 'node:http'
 import { randomUUID } from 'node:crypto'
+import { isIP } from 'node:net'
 
 import type {
   OAuthClientProvider,
@@ -257,9 +258,13 @@ export class PersistentOAuthClientProvider implements OAuthClientProvider {
   }
 
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    const hostname = authorizationUrl.hostname
     if (
       authorizationUrl.protocol !== 'https:' &&
-      !(authorizationUrl.protocol === 'http:' && authorizationUrl.hostname === '127.0.0.1')
+      !(
+        authorizationUrl.protocol === 'http:' &&
+        ((isIP(hostname) === 4 && hostname.startsWith('127.')) || hostname === '[::1]')
+      )
     ) {
       throw new Error('OAuth authorization URL must use HTTPS or loopback HTTP.')
     }


### PR DESCRIPTION
## Problem

OAuth discovery metadata can supply an authorization endpoint whose scheme is accepted by the MCP SDK but should not be handed to the operating system. The connector provider previously forwarded that URL unchanged to Electron external opening, so remote `http:`, `file:`, or other registered schemes could reach an OS handler.

## Proposed change

Validate the SDK-provided authorization URL at the connector OAuth boundary before any external open. Allow `https:`, exact `localhost` HTTP, and literal loopback HTTP addresses (`127/8` and `::1`); reject remote `http:`, other DNS hostnames, and all other schemes. Preserve the existing OAuth state flow by clearing and persisting any token already proven stale before applying the external-open policy.

## Scope and non-goals

- No settings or persisted data fields.
- No schema, architecture, data-model, or enum changes.
- No UI or interaction changes for supported OAuth endpoints.
- No migration or historical-data compatibility work.
- No new dependency or reusable abstraction.

## Acceptance criteria and validation

The original regression test was first run against the unmodified implementation and failed because unsafe URLs resolved successfully instead of rejecting, matching the reported external-open behavior. The `localhost` extension was likewise first run against the preceding implementation and failed with the URL-policy error before the exact-host allowance was added. The following checks ran after the last material edit:

- OAuth authorization URL policy and stale-token invalidation -> `npm test -- src/main/connectors/oauth-client.test.ts src/main/connectors/mcp-client-manager.test.ts` -> 45 tests passed.
- Main-process TypeScript contract -> `npm run typecheck:node` -> passed.
- Source lint and formatting policy -> `npm run lint`, Prettier, and `git diff --check` -> passed.

The owner test and direct MCP manager consumer test are included. Renderer and persistence tests are excluded because no renderer contract, stored format, or data path changes. Platform E2E is not run locally because the policy is enforced before Electron and is observed through the injected external opener. Full `npm test` was intentionally not run per maintainer request; PR CI remains the final cross-platform authority.

## Review focus

Please confirm that the HTTP exception is limited to exact `localhost`, literal IPv4 `127/8`, and IPv6 `::1`, without accepting lookalike DNS hostnames, and that stale token invalidation remains ordered before URL rejection.
