### PR TITLE
perf(skills): defer user skill startup scanning

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1058,22 +1058,19 @@ const createApplicationModules = async (
   // the same repository while keeping their dynamic Connector/custom-Skill catalog separate.
   const specialistRepository = new SpecialistRepository(resolveStorageRoot())
   const appVersion = app.getVersion()
-  const specialistSkills = await settingsService.listSpecialistSkillCatalog()
-  const packageSkills = await specialistPackageSkillAdapter.snapshot()
+  const specialistSkills = await settingsService.listSpecialistSkillCatalog({ bundledOnly: true })
   composition.phase('specialist-catalog')
   const builtinRegistry = new BuiltinSpecialistRegistry({
     appVersion,
     builtinSkills: composeBuiltinSkillCatalog(appVersion, specialistSkills),
     skills: specialistSkills.map((skill) => {
-      const packageSkill = packageSkills.find((candidate) => candidate.id === skill.id)
       return {
         id: skill.id,
         name: skill.frameworkName,
         builtin: skill.source === 'featured',
         displayName: skill.displayName,
         source: skill.source,
-        mainEnabled: skill.mainEnabled,
-        ...(packageSkill ?? {})
+        mainEnabled: skill.mainEnabled
       }
     }),
     connectorIds: ALL_CONNECTOR_IDS,

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -530,9 +530,9 @@ class SettingsService {
     return this.skills.buildSkillExport(id)
   }
 
-  // Specialist scopes intentionally see the installed catalog irrespective of Main Agent toggles.
-  // The result is rebuilt for every caller so future imports and removals take effect on the next turn.
-  async listSpecialistSkillCatalog(): Promise<
+  // Specialist scopes see the installed catalog irrespective of Main Agent toggles. Bundled
+  // Specialist startup validation can restrict this to immutable application resources.
+  async listSpecialistSkillCatalog(options: { bundledOnly?: boolean } = {}): Promise<
     Array<{
       id: string
       frameworkName: string
@@ -543,7 +543,7 @@ class SettingsService {
       compatibility?: string
     }>
   > {
-    return this.skills.listSpecialistSkillCatalog()
+    return this.skills.listSpecialistSkillCatalog(options)
   }
 
   // Returns the mcp-<id> skill names for connectors provisioned at the Main Agent level (enabled

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -79,6 +79,59 @@ const userSkillSourceDir = (catalog: SkillCatalogModule, source: 'personal' | 'i
   join(catalogStorageRoots.get(catalog)!, 'skills', source)
 
 describe('SkillCatalogModule', () => {
+  it('lists bundled Specialist dependencies without consulting user Skills', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'settings-skill-catalog-'))
+    roots.push(storageRoot)
+    const userSkills = { list: vi.fn() } as unknown as UserSkillRepository
+    const catalog = new SkillCatalogModule({
+      repository: new SettingsRepository(storageRoot),
+      storageRoot,
+      skillRegistry: {
+        list: async () => [
+          {
+            id: 'featured',
+            name: 'featured',
+            displayName: 'Featured',
+            description: 'Bundled.',
+            source: 'featured' as const,
+            updatedAt: '2026-08-25T00:00:00.000Z',
+            sourceDir: '/bundled/featured',
+            compatibility: `sha256:${'a'.repeat(64)}`
+          }
+        ]
+      } as unknown as SkillRegistry,
+      userSkills
+    })
+
+    await expect(catalog.listSpecialistSkillCatalog({ bundledOnly: true })).resolves.toEqual([
+      expect.objectContaining({ id: 'featured', source: 'featured', available: true })
+    ])
+    expect(userSkills.list).not.toHaveBeenCalled()
+  })
+
+  it('shares an in-flight user Skill scan between observer and agent materialization', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'settings-skill-catalog-'))
+    const runtimeRoot = await mkdtemp(join(tmpdir(), 'settings-skill-runtime-'))
+    roots.push(storageRoot, runtimeRoot)
+    let finishScan: ((skills: []) => void) | undefined
+    const list = vi.fn<() => Promise<[]>>(
+      () => new Promise<[]>((resolve) => (finishScan = resolve))
+    )
+    const catalog = new SkillCatalogModule({
+      repository: new SettingsRepository(storageRoot),
+      storageRoot,
+      skillRegistry: { list: vi.fn().mockResolvedValue([]) } as unknown as SkillRegistry,
+      userSkills: { list } as unknown as UserSkillRepository
+    })
+
+    const observerRead = catalog.listUserSkills()
+    const sessionRead = catalog.materializeSkills(runtimeRoot, [])
+
+    expect(list).toHaveBeenCalledOnce()
+    finishScan?.([])
+    await expect(Promise.all([observerRead, sessionRead])).resolves.toEqual([[], undefined])
+  })
+
   it('keeps only the newest user Skill when Personal and Imported packages share a name', async () => {
     const storageRoot = await mkdtemp(join(tmpdir(), 'settings-skill-catalog-'))
     roots.push(storageRoot)

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -105,6 +105,7 @@ class SkillCatalogModule {
   private readonly skillRegistry: SkillRegistry
   private readonly userSkills: UserSkillRepository
   private readonly githubFetch: FetchLike
+  private userSkillCatalogRead: Promise<BundledSkill[]> | undefined
 
   constructor(private readonly options: SkillCatalogModuleOptions) {
     this.skillRegistry = options.skillRegistry ?? new SkillRegistry()
@@ -158,7 +159,7 @@ class SkillCatalogModule {
   }
 
   private async catalog(): Promise<BundledSkill[]> {
-    const [featured, user] = await Promise.all([this.skillRegistry.list(), this.userSkills.list()])
+    const [featured, user] = await Promise.all([this.skillRegistry.list(), this.listUserSkills()])
     const bundledNames = new Set(featured.map((skill) => skill.name))
     const bundledIds = new Set(featured.map((skill) => skill.id))
     const userIdCounts = new Map<string, number>()
@@ -215,7 +216,12 @@ class SkillCatalogModule {
   // second production transaction facade while excluding immutable bundled packages from each
   // writable-directory reconciliation.
   async listUserSkills(): Promise<BundledSkill[]> {
-    return this.userSkills.list()
+    if (this.userSkillCatalogRead) return this.userSkillCatalogRead
+    const read = this.userSkills.list().finally(() => {
+      if (this.userSkillCatalogRead === read) this.userSkillCatalogRead = undefined
+    })
+    this.userSkillCatalogRead = read
+    return read
   }
 
   async withHostSkillRead<T>(
@@ -247,7 +253,7 @@ class SkillCatalogModule {
     return skills.map((skill) => this.toSkillView(skill, disabled))
   }
 
-  async listSpecialistSkillCatalog(): Promise<
+  async listSpecialistSkillCatalog(options: { bundledOnly?: boolean } = {}): Promise<
     Array<{
       id: string
       frameworkName: string
@@ -259,7 +265,11 @@ class SkillCatalogModule {
     }>
   > {
     const [skills, settings] = await Promise.all([
-      this.managedCatalog(),
+      options.bundledOnly
+        ? this.skillRegistry
+            .list()
+            .then((entries) => entries.filter((skill) => skill.exposure !== 'internal'))
+        : this.managedCatalog(),
       this.options.repository.getSettings()
     ])
     const disabled = new Set(settings.disabledSkillIds ?? [])

--- a/src/main/skills/user-skill-catalog-observer.test.ts
+++ b/src/main/skills/user-skill-catalog-observer.test.ts
@@ -98,6 +98,28 @@ describe('UserSkillCatalogObserver', () => {
     observer.dispose()
   })
 
+  it('publishes the first successful retry after the initial scan fails', async () => {
+    const watcher = fakeWatcher()
+    const list = vi.fn().mockRejectedValueOnce(new Error('transient')).mockResolvedValue([])
+    const onCatalogChanged = vi.fn()
+    const observer = new UserSkillCatalogObserver({
+      storageRoot: await makeStorage(),
+      catalog: { list },
+      onCatalogChanged,
+      watchDirectory: watcher.watchDirectory,
+      debounceMs: 1,
+      reconcileIntervalMs: 60_000
+    })
+    await observer.start()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    watcher.emitChange()
+
+    await waitForCalls(list, 2)
+    await waitForCalls(onCatalogChanged, 1)
+    observer.dispose()
+  })
+
   it('publishes valid direct additions and ignores malformed packages', async () => {
     const storageRoot = await makeStorage()
     const watcher = fakeWatcher()

--- a/src/main/skills/user-skill-catalog-observer.test.ts
+++ b/src/main/skills/user-skill-catalog-observer.test.ts
@@ -37,19 +37,84 @@ const waitForCalls = async (callback: ReturnType<typeof vi.fn>, count: number): 
 }
 
 describe('UserSkillCatalogObserver', () => {
-  it('publishes valid direct additions and ignores malformed packages', async () => {
-    const storageRoot = await makeStorage()
+  it('starts watching without waiting for the initial catalog scan', async () => {
     const watcher = fakeWatcher()
+    let finishInitialScan: ((skills: []) => void) | undefined
+    const list = vi.fn<() => Promise<[]>>(
+      () => new Promise<[]>((resolve) => (finishInitialScan = resolve))
+    )
     const onCatalogChanged = vi.fn()
     const observer = new UserSkillCatalogObserver({
-      storageRoot,
-      catalog: new UserSkillRepository(storageRoot),
+      storageRoot: await makeStorage(),
+      catalog: { list },
+      onCatalogChanged,
+      watchDirectory: watcher.watchDirectory,
+      reconcileIntervalMs: 60_000
+    })
+
+    await observer.start()
+
+    expect(watcher.watchDirectory).toHaveBeenCalledOnce()
+    expect(list).toHaveBeenCalledOnce()
+    observer.dispose()
+    finishInitialScan?.([])
+    await Promise.resolve()
+    expect(onCatalogChanged).not.toHaveBeenCalled()
+  })
+
+  it('reconciles a filesystem event that arrives during the initial scan', async () => {
+    const watcher = fakeWatcher()
+    let finishInitialScan: ((skills: []) => void) | undefined
+    const changedSkill = {
+      id: 'personal-direct',
+      name: 'direct',
+      displayName: 'Direct',
+      description: 'Directly installed.',
+      source: 'personal' as const,
+      updatedAt: '2026-08-25T00:00:00.000Z',
+      sourceDir: '/skills/personal/direct'
+    }
+    const list = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise<[]>((resolve) => (finishInitialScan = resolve)))
+      .mockResolvedValue([changedSkill])
+    const onCatalogChanged = vi.fn()
+    const observer = new UserSkillCatalogObserver({
+      storageRoot: await makeStorage(),
+      catalog: { list },
       onCatalogChanged,
       watchDirectory: watcher.watchDirectory,
       debounceMs: 1,
       reconcileIntervalMs: 60_000
     })
     await observer.start()
+
+    watcher.emitChange()
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    finishInitialScan?.([])
+
+    await waitForCalls(list, 2)
+    await waitForCalls(onCatalogChanged, 1)
+    observer.dispose()
+  })
+
+  it('publishes valid direct additions and ignores malformed packages', async () => {
+    const storageRoot = await makeStorage()
+    const watcher = fakeWatcher()
+    const onCatalogChanged = vi.fn()
+    const catalog = new UserSkillRepository(storageRoot)
+    const list = vi.spyOn(catalog, 'list')
+    const observer = new UserSkillCatalogObserver({
+      storageRoot,
+      catalog,
+      onCatalogChanged,
+      watchDirectory: watcher.watchDirectory,
+      debounceMs: 1,
+      reconcileIntervalMs: 60_000
+    })
+    await observer.start()
+    await waitForCalls(list, 1)
+    await list.mock.results[0].value
 
     const direct = join(storageRoot, 'skills', 'personal', 'direct')
     await mkdir(direct, { recursive: true })
@@ -80,15 +145,19 @@ describe('UserSkillCatalogObserver', () => {
 
     const watcher = fakeWatcher()
     const onCatalogChanged = vi.fn()
+    const catalog = new UserSkillRepository(storageRoot)
+    const list = vi.spyOn(catalog, 'list')
     const observer = new UserSkillCatalogObserver({
       storageRoot,
-      catalog: new UserSkillRepository(storageRoot),
+      catalog,
       onCatalogChanged,
       watchDirectory: watcher.watchDirectory,
       debounceMs: 1,
       reconcileIntervalMs: 60_000
     })
     await observer.start()
+    await waitForCalls(list, 1)
+    await list.mock.results[0].value
 
     watcher.emitChange()
     await new Promise((resolve) => setTimeout(resolve, 20))

--- a/src/main/skills/user-skill-catalog-observer.ts
+++ b/src/main/skills/user-skill-catalog-observer.ts
@@ -57,6 +57,7 @@ class UserSkillCatalogObserver {
   private reconcileDrain: Promise<void> | undefined
   private reconcilePending = false
   private reconcileForcePending = false
+  private initialReconciliationFailed = false
   private disposed = false
 
   constructor(private readonly options: UserSkillCatalogObserverOptions) {}
@@ -147,6 +148,7 @@ class UserSkillCatalogObserver {
         await this.reconcile(force)
       } catch (error) {
         failure ??= error
+        if (this.fingerprint === undefined) this.initialReconciliationFailed = true
         log.warn('user skill catalog reconciliation failed', diagnosticErrorFields(error))
       }
     }
@@ -158,8 +160,11 @@ class UserSkillCatalogObserver {
     const fingerprint = catalogFingerprint(await this.options.catalog.list())
     if (this.disposed) return
     const changed = this.fingerprint !== undefined && fingerprint !== this.fingerprint
+    const recoveredInitialReconciliation =
+      this.fingerprint === undefined && this.initialReconciliationFailed
     this.fingerprint = fingerprint
-    if (changed || force) await this.options.onCatalogChanged()
+    this.initialReconciliationFailed = false
+    if (changed || recoveredInitialReconciliation || force) await this.options.onCatalogChanged()
   }
 }
 

--- a/src/main/skills/user-skill-catalog-observer.ts
+++ b/src/main/skills/user-skill-catalog-observer.ts
@@ -53,7 +53,7 @@ class UserSkillCatalogObserver {
   private watcher: FSWatcher | undefined
   private debounceTimer: ReturnType<typeof setTimeout> | undefined
   private reconcileTimer: ReturnType<typeof setInterval> | undefined
-  private fingerprint = ''
+  private fingerprint: string | undefined
   private reconcileDrain: Promise<void> | undefined
   private reconcilePending = false
   private reconcileForcePending = false
@@ -66,8 +66,6 @@ class UserSkillCatalogObserver {
     await Promise.all(
       OBSERVED_SOURCES.map((source) => mkdir(join(skillsRoot, source), { recursive: true }))
     )
-    this.fingerprint = catalogFingerprint(await this.options.catalog.list())
-
     try {
       this.watcher = (this.options.watchDirectory ?? watch)(skillsRoot, { recursive: true }, () =>
         this.scheduleReconcile()
@@ -86,6 +84,8 @@ class UserSkillCatalogObserver {
       })
       this.startPeriodicReconciliation()
     }
+
+    void this.enqueueReconcile(false)
   }
 
   notifyCatalogChanged(): Promise<void> {
@@ -157,7 +157,7 @@ class UserSkillCatalogObserver {
     if (this.disposed) return
     const fingerprint = catalogFingerprint(await this.options.catalog.list())
     if (this.disposed) return
-    const changed = fingerprint !== this.fingerprint
+    const changed = this.fingerprint !== undefined && fingerprint !== this.fingerprint
     this.fingerprint = fingerprint
     if (changed || force) await this.options.onCatalogChanged()
   }


### PR DESCRIPTION
## Problem

Application startup scanned every Personal and Imported Skill twice: once while validating the
bundled Specialist registry and once to establish the writable Skill observer fingerprint. Local
profiles show 32–125 ms for the first scan and 14–61 ms for the second, with cost growing with user
package count and size.

## Proposed change

- Restrict bundled Specialist startup validation to Featured Skills and stop reading Specialist
  package sidecars from Personal/Imported directories on that path.
- Install the writable Skill watcher before returning from startup, then reconcile its initial
  fingerprint in the background through the existing serialized queue.
- Coalesce concurrent user-catalog reads while one authoritative repository scan is in flight. If a
  user sends a Session immediately, observer reconciliation and agent Skill materialization share
  that scan; the Session still waits for the authoritative projection before the agent starts.

## Scope and non-goals

- Connector discovery remains a background refresh with its existing bounded first-ACP-session
  barrier.
- Custom Specialist loading and Marketplace/package transaction recovery are unchanged.
- No catalog cache, worker, dependency, user-visible copy, schema, migration, or persisted format is
  added.
- Historical Skill directories and the rebuildable `user-skill-compatibility-v1.json` format are
  unchanged.
- No persisted/domain state or enum value is added. Coordination consists only of process-local
  in-flight Promise/fingerprint state plus a boolean cleared after the first successful retry of a
  failed initial reconciliation.

## Acceptance criteria and validation

The checks below ran after the last material edit.

| Behavior | Check | Result |
| --- | --- | --- |
| Observer startup is non-blocking, retains concurrent events, and publishes after a failed baseline recovers | `npm test -- --run src/main/skills/user-skill-catalog-observer.test.ts` | 11/11 passed |
| Bundled Specialist startup excludes user Skills; immediate agent materialization shares the observer scan | `npm run test:module -- user_skills_repository` | passed |
| User Skill owner, contracts, Settings/renderer consumers, Specialist packages, preload, and local RPC integration | same module command | 19 files, 777/777 passed |
| Node and renderer TypeScript contracts | `npm run typecheck` | passed |
| Repository lint rules | `npm run lint` | passed |
| Formatting and whitespace | Prettier check on changed files; `git diff --check` | passed |

`npm run test:affected:explain -- --base origin/main --head HEAD` fails closed to the complete
Vitest plan because `src/main/ipc.ts` is a centralized file with no module owner. Per the requested
workflow, the complete local suite was not run; PR Gate is authoritative for the full portable and
platform lanes. Filesystem watcher/platform behavior is therefore intentionally left to CI beyond
the module's local coverage. No packaged-app startup benchmark was run; the diff removes the two
user-catalog startup dependencies directly and pins those boundaries with tests.

## Review focus

- The watcher is installed before the background baseline starts, and its existing one-running /
  one-pending queue retains concurrent filesystem and explicit mutation notifications.
- The in-flight catalog Promise is cleared immediately on settlement and does not become a cache.
- Runtime Specialist catalogs still include Personal and Imported Skills; only bundled registry
  startup uses the Featured-only mode.
