### PR TITLE
fix(session-plan): allow structured clarification questions

### DIFF
--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -5421,7 +5421,6 @@ describe('ACP runtime session management', () => {
     expect(planPrompt).toContain(
       'Review the Skills available in the current session to confirm the catalog covers the task.'
     )
-    expect(planPrompt).toContain('directly ask the user in an ordinary response')
     expect(planPrompt).toContain('complete revised plan')
     expect(planPrompt).toContain('short exact `title`')
     expect(planPrompt).toContain('Execution starts only after approval.')
@@ -9646,7 +9645,7 @@ describe('ACP runtime session management', () => {
       'Notebook tool instructions (only applies when using open-science-notebook tools)'
     )
     expect(fakeAgent.prompts[0].text).toContain('`ask_user_question`')
-    expect(fakeAgent.prompts[0].text).toContain('Default mode')
+    expect(fakeAgent.prompts[0].text).toContain('app-owned `ask_user_question`')
     expect(fakeAgent.prompts[0].text).not.toContain('<open_science_artifact_instructions>')
   })
 
@@ -9674,7 +9673,7 @@ describe('ACP runtime session management', () => {
       fakeAgent.newSessions[0].mcpServers.map((server) => (server as { name: string }).name)
     ).toEqual(['open-science-notebook'])
     expect(fakeAgent.prompts[0].text).toContain('`ask_user_question`')
-    expect(fakeAgent.prompts[0].text).toContain('Default mode')
+    expect(fakeAgent.prompts[0].text).toContain('app-owned `ask_user_question`')
   })
 
   it('does not tell Codex to skip the native SKILL.md read required for progressive loading', async () => {

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -243,15 +243,14 @@ describe('notebook MCP server config', () => {
 describe('ask_user_question tool', () => {
   const tool = NOTEBOOK_RPC_TOOLS.find((entry) => entry.name === 'ask_user_question')
 
-  it('is available in Default mode and accepts 1-3 compact questions', () => {
+  it('accepts 1-3 compact questions', () => {
     expect(tool).toBeDefined()
     expect(tool?.method).toBe('requestUserInput')
-    expect(tool?.description).toContain('Default mode')
+    expect(tool?.description).toContain('app-owned tool')
     expect(tool?.description).toContain('materially different interpretations')
     expect(tool?.description).toContain('first tool call')
     expect(tool?.description).toContain('include every known question in one call')
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain('ask_user_question')
-    expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain('Default mode')
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain('materially different interpretations')
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain('first tool call')
     expect(NOTEBOOK_SYSTEM_PROMPT_APPEND).toContain('all 1-3 known questions in one call')

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -32,7 +32,7 @@ const HOST_SDK_DISCOVERY_GUIDANCE =
 const NOTEBOOK_SYSTEM_PROMPT_APPEND = [
   '<open_science_notebook_instructions>',
   'Notebook tool instructions (only applies when using open-science-notebook tools).',
-  'In Default mode, use `ask_user_question` as the first tool call when a request has materially different interpretations; do not inspect or use other tools first, and never print a textual choice list. Put all 1-3 known questions in one call with 2-4 real options each. Infer minor reversible details and omit Other; the UI adds custom, agent-decide, and Skip. It shows questions one at a time, then continues the task after Finish. A pending result ends the turn normally.',
+  'Use the app-owned `ask_user_question` as the first tool call when a request has materially different interpretations; do not inspect or use other tools first, and never print a textual choice list. Put all 1-3 known questions in one call with 2-4 real options each. Infer minor reversible details and omit Other; the UI adds custom, agent-decide, and Skip. It shows questions one at a time, then continues the task after Finish. A pending result ends the turn normally.',
   'Notebook preview is only for code and execution results; keep chat, explanation, and diagnosis in the chat area.',
   'Use `notebook_execute` for one persistent Python/R cell per call; reuse `cellId` to rerun it. Python/R data kernels cannot call connectors; use `repl_execute` for `host.capabilities`/`host.llm`/`host.mcp`/`host.compute`/`host.agents`/`host.skills`. For large cross-kernel data, write under `process.env.OPEN_SCIENCE_HANDOFF_DIR` in the REPL and read that path from Python/R.',
   HOST_SDK_DISCOVERY_GUIDANCE,
@@ -1230,7 +1230,7 @@ const NOTEBOOK_RPC_TOOLS: NotebookRpcToolDefinition[] = [
     name: 'ask_user_question',
     title: 'Ask the user to choose',
     description:
-      'In Default mode, collect 1-3 decisions when a request has materially different interpretations. Use this as the first tool call, before inspecting the workspace or using other tools, and include every known question in one call. Never print a textual choice list. Give each question 2-4 unique options with descriptions and omit Other; the app adds custom, agent-decide, and Skip. Questions appear one at a time. A pending result ends the turn normally; the app continues after Finish.',
+      'Collect 1-3 decisions when a request has materially different interpretations. Use this app-owned tool as the first tool call, before inspecting the workspace or using other tools, and include every known question in one call. Never print a textual choice list. Give each question 2-4 unique options with descriptions and omit Other; the app adds custom, agent-decide, and Skip. Questions appear one at a time. A pending result ends the turn normally; the app continues after Finish.',
     method: 'requestUserInput',
     inputSchema: requestUserInputToolSchema,
     mapResult: compactUserChoiceResult,

--- a/src/main/session-plan/guidance.ts
+++ b/src/main/session-plan/guidance.ts
@@ -21,10 +21,10 @@ This turn must create a Plan before doing work. Execution starts only after appr
 1. **Discover skills**: Review the Skills available in the current session to confirm the catalog covers the task. You do not need to load them yet.
 2. **Assess feasibility**: Before generating the plan, assess whether the task is achievable with available data, methods, and tools. Every plan must include a \`feasibility\` block with \`confidence\` (high / medium / low) and \`rationale\`.
    - For medium or low confidence, identify the material risks and a useful fallback deliverable.
-   - If \`confidence\` is "low", directly ask the user in an ordinary response BEFORE calling \`generate_plan\` to confirm the user wants an attempt despite the risks, and to ask what fallback deliverable they would accept. Wait for the user's reply before continuing.
+   - If \`confidence\` is "low", ask BEFORE calling \`generate_plan\` to confirm the user wants an attempt despite the risks and what fallback deliverable they would accept. Wait for the user's reply before continuing.
    - Keep the user-facing rationale to at most two sentences and the most important limitations.
-3. **Clarify requirements**: If the request has ambiguous aspects, directly ask the user in an ordinary response with specific choices that would affect the plan structure (e.g., which analysis methods, scope, output formats), and wait for the user's reply. Skip clarification only if the request is fully unambiguous.
-4. **Identify desired outputs**: Directly ask the user in an ordinary response what **final deliverables** they want (e.g., "PDF report", "cleaned CSV dataset", "interactive plots"), and wait for the user's reply. Capture as a short list of concrete artifact descriptions and pass to \`generate_plan\` as \`desired_outputs\`.
+3. **Clarify requirements**: If the request has ambiguous aspects, ask with specific choices that would affect the plan structure (e.g., which analysis methods, scope, output formats), and wait for the user's reply. Skip clarification only if the request is fully unambiguous.
+4. **Identify desired outputs**: Ask what **final deliverables** the user wants (e.g., "PDF report", "cleaned CSV dataset", "interactive plots"), and wait for the user's reply. Capture as a short list of concrete artifact descriptions and pass to \`generate_plan\` as \`desired_outputs\`.
 5. **Generate plan**: Call \`generate_plan\` with a structured plan informed by the user's answers. For requested revisions, submit the complete revised plan and preserve unchanged \`phases\`/\`delegations\`/\`steps\`.
 
 Each step needs a short exact \`title\` (≤10 words) and a sequential, actionable \`description\` (1-3 sentences).`


### PR DESCRIPTION
## Problem

Session Plan guidance required clarification and desired-output questions to be asked in an ordinary response. That conflicted with the app-owned structured clarification workflow, causing agents to report that user-input tooling was unavailable instead of presenting the choice UI.

## Proposed change

- Remove the ordinary-response restriction from Plan-first guidance.
- Make the notebook guidance and `ask_user_question` tool description mode-agnostic so the structured workflow applies in every interaction mode.
- Update ACP and notebook regression expectations for the shared guidance.

## Scope and non-goals

This is a prompt-guidance and regression-test fix. It does not change the MCP schema, elicitation transport, permission policy, renderer UI, or framework-specific tool names.

## Acceptance criteria and validation

All checks below ran after the final material edit:

- Session Plan clarification no longer requires ordinary chat responses -> `npm test -- src/main/agent-framework/app-mcp-names.test.ts src/main/notebook/mcp-server.test.ts src/main/acp/runtime.test.ts` -> 721 tests passed.
- Structured clarification guidance is independent of interaction mode -> same targeted test command -> passed.
- Main-process TypeScript contracts remain valid -> `npm run typecheck:node` -> passed.
- Changed source conforms to repository lint rules -> `npm run lint` -> passed.

Web typecheck and UI/E2E lanes were excluded because the final diff changes only main-process prompt strings and their unit/runtime tests; it does not change renderer, persistence, platform, schema, or public transport behavior. Independent review and exact-head CI remain pending.

## Review focus

Please verify that the shared notebook guidance is the correct ownership boundary for structured clarification behavior and that the Plan-first reminder remains framework-agnostic.