### PR TITLE
perf(notifications): coalesce snapshot refresh bursts

### DIFF
--- a/src/renderer/src/stores/notification-inbox-store.test.ts
+++ b/src/renderer/src/stores/notification-inbox-store.test.ts
@@ -137,4 +137,24 @@ describe('notification inbox store', () => {
     expect(getSnapshot).toHaveBeenCalledTimes(2)
     expect(useNotificationInboxStore.getState().revision).toBe(2)
   })
+
+  it('reports snapshot failures without rejecting refresh callers', async () => {
+    const getSnapshot = vi
+      .fn()
+      .mockRejectedValueOnce('offline')
+      .mockRejectedValueOnce(new Error('network unavailable'))
+    vi.stubGlobal('window', { api: { notifications: { getSnapshot } } })
+
+    await useNotificationInboxStore.getState().refresh()
+    expect(useNotificationInboxStore.getState()).toMatchObject({
+      status: 'error',
+      error: 'Messages could not be loaded.'
+    })
+
+    await useNotificationInboxStore.getState().refresh()
+    expect(useNotificationInboxStore.getState()).toMatchObject({
+      status: 'error',
+      error: 'network unavailable'
+    })
+  })
 })

--- a/src/renderer/src/stores/notification-inbox-store.test.ts
+++ b/src/renderer/src/stores/notification-inbox-store.test.ts
@@ -78,4 +78,63 @@ describe('notification inbox store', () => {
     expect(getSnapshot).not.toHaveBeenCalled()
     expect(removeChanged).toHaveBeenCalledOnce()
   })
+
+  it('coalesces a burst of notification changes into one snapshot refresh', async () => {
+    let changed: (() => void) | undefined
+    const getSnapshot = vi.fn(async () => ({
+      revision: 2,
+      unreadCount: 1,
+      latestSequence: 3,
+      items: []
+    }))
+    const webWindow = Object.assign(new EventTarget(), {
+      api: {
+        notifications: {
+          getSnapshot,
+          onChanged: vi.fn((listener: () => void) => {
+            changed = listener
+            return () => undefined
+          })
+        }
+      }
+    })
+    vi.stubGlobal('window', webWindow)
+
+    const cleanup = useNotificationInboxStore.getState().listen()
+    await vi.waitFor(() => expect(getSnapshot).toHaveBeenCalledOnce())
+    getSnapshot.mockClear()
+
+    changed?.()
+    changed?.()
+    changed?.()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(getSnapshot).toHaveBeenCalledOnce()
+    cleanup()
+  })
+
+  it('performs one trailing refresh when changes arrive during a snapshot request', async () => {
+    let resolveFirst: ((snapshot: typeof EMPTY_SNAPSHOT) => void) | undefined
+    const getSnapshot = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<typeof EMPTY_SNAPSHOT>((resolve) => {
+            resolveFirst = resolve
+          })
+      )
+      .mockResolvedValue({ ...EMPTY_SNAPSHOT, revision: 2 })
+    vi.stubGlobal('window', { api: { notifications: { getSnapshot } } })
+
+    const first = useNotificationInboxStore.getState().refresh()
+    await vi.waitFor(() => expect(getSnapshot).toHaveBeenCalledOnce())
+    const second = useNotificationInboxStore.getState().refresh()
+    const third = useNotificationInboxStore.getState().refresh()
+
+    resolveFirst?.({ ...EMPTY_SNAPSHOT, revision: 1 })
+    await Promise.all([first, second, third])
+
+    expect(getSnapshot).toHaveBeenCalledTimes(2)
+    expect(useNotificationInboxStore.getState().revision).toBe(2)
+  })
 })

--- a/src/renderer/src/stores/notification-inbox-store.ts
+++ b/src/renderer/src/stores/notification-inbox-store.ts
@@ -22,27 +22,45 @@ const EMPTY_SNAPSHOT: NotificationInboxSnapshot = {
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : 'Messages could not be loaded.'
 
-let refreshTail: Promise<void> = Promise.resolve()
+let refreshTail: Promise<void> | undefined
+let refreshInFlight = false
+let trailingRefreshRequested = false
 
-// Mirrors the backend-owned snapshot. Every renderer subscribes before its first read, while the
-// serialized refresh queue prevents an older RPC response from overwriting a newer event-triggered one.
+// Mirrors the backend-owned snapshot. Every renderer subscribes before its first read. Synchronous
+// bursts share one request; changes observed during that request schedule one authoritative follow-up.
 export const useNotificationInboxStore = create<NotificationInboxStore>((set, get) => ({
   ...EMPTY_SNAPSHOT,
   status: 'idle',
 
   refresh: () => {
-    const operation = async (): Promise<void> => {
-      const api = window.api?.notifications
-      if (!api?.getSnapshot) return
-      if (get().status === 'idle') set({ status: 'loading', error: undefined })
-      try {
-        const snapshot = await api.getSnapshot()
-        set({ ...snapshot, status: 'ready', error: undefined })
-      } catch (error) {
-        set({ status: 'error', error: errorMessage(error) })
-      }
+    if (refreshTail) {
+      if (refreshInFlight) trailingRefreshRequested = true
+      return refreshTail
     }
-    refreshTail = refreshTail.then(operation, operation)
+
+    refreshTail = Promise.resolve()
+      .then(async () => {
+        do {
+          trailingRefreshRequested = false
+          refreshInFlight = true
+          const api = window.api?.notifications
+          if (!api?.getSnapshot) return
+          if (get().status === 'idle') set({ status: 'loading', error: undefined })
+          try {
+            const snapshot = await api.getSnapshot()
+            set({ ...snapshot, status: 'ready', error: undefined })
+          } catch (error) {
+            set({ status: 'error', error: errorMessage(error) })
+          } finally {
+            refreshInFlight = false
+          }
+        } while (trailingRefreshRequested)
+      })
+      .finally(() => {
+        refreshInFlight = false
+        refreshTail = undefined
+      })
+
     return refreshTail
   },
 


### PR DESCRIPTION
## Problem

Each notifications:changed callback queued another full getSnapshot RPC. A synchronous burst therefore produced N serialized snapshot reads, adding avoidable IPC and backend work while still showing only the final snapshot.

## Reproduction and regression coverage

The regression test uses the public store listen/refresh boundary. Before the fix, three synchronous change notifications produced three snapshot requests on three consecutive runs; the assertion expected one. A second test covers changes arriving while a request is already in flight. The existing public error-state behavior is also covered so changed-file coverage exercises both error-message branches.

## Change

- Coalesce synchronous refresh requests into one microtask-backed snapshot read.
- If changes arrive while that read is in flight, perform one trailing authoritative refresh.
- Preserve the existing snapshot, status, and error behavior.

## Scope and compatibility

- No API or protocol fields.
- No architecture, interaction, or business data-model changes.
- No new enum or state values.
- No persistence or migration changes.
- No historical-data compatibility work is required.

## Validation

All checks below ran after the last material edit:

- npm test -- src/renderer/src/stores/notification-inbox-store.test.ts — 6 passed.
- npx vitest run --coverage --changed origin/main — 19 files and 441 tests passed; changed-file branch coverage 57.14%, above the 57% gate.
- npm run typecheck:web — passed.
- npm run lint — passed.
- Prettier and diff checks — passed.
- npm run test:affected -- --base origin/main --head HEAD --explain — selected the full fallback because this test file has no module owner. Per maintainer direction, the complete suite is delegated to PR CI.

The first PR Gate run had 440/440 tests pass but failed changed-file branch coverage at 50%. The follow-up test covers the pre-existing refresh error behavior and reproduces the exact CI command locally above.

## Review focus

Please verify the coalescing semantics: one request for a synchronous burst and at most one pending follow-up for changes observed during an active request.