### PR TITLE
feat(diagnostics): correlate HTTP request logs

### DIFF
--- a/src/main/logger.test.ts
+++ b/src/main/logger.test.ts
@@ -11,6 +11,7 @@ import {
   flushLogs,
   formatLine,
   initLogger,
+  runWithDiagnosticCorrelation,
   writeFatalLogSync
 } from './logger'
 import {
@@ -342,6 +343,29 @@ describe('logger: process run context', () => {
       data: { phase: 'ready' }
     })
     expect(typeof record.t).toBe('string')
+  })
+
+  it('adds one request correlation ID across an async diagnostic context', async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'os-logger-correlation-'))
+    initLogger({ logDir, fileName: 'main.log', mirrorToConsole: false })
+    const log = createLogger('request')
+
+    await runWithDiagnosticCorrelation(async () => {
+      log.info('started')
+      await Promise.resolve()
+      log.warn('failed', { sessionId: 'session-1', runId: 'run-1' })
+    })
+    log.info('outside request')
+    await flushLogs()
+
+    const records = (await readFile(join(logDir, 'main.log'), 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+    expect(records[0]?.correlationId).toEqual(expect.any(String))
+    expect(records[1]?.correlationId).toBe(records[0]?.correlationId)
+    expect(records[2]).not.toHaveProperty('correlationId')
+    expect(records[1]?.data).toMatchObject({ sessionId: 'session-1', runId: 'run-1' })
   })
 })
 

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -1,6 +1,7 @@
 import { appendFile, mkdir, rename, rm, stat } from 'node:fs/promises'
 import { appendFileSync, mkdirSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
+import { AsyncLocalStorage } from 'node:async_hooks'
 import { extname, join } from 'node:path'
 
 // Lightweight structured file logger for the main process. Kept free of Electron imports so it stays
@@ -36,6 +37,17 @@ let config: LoggerConfig | undefined
 let writeChain: Promise<void> = Promise.resolve()
 // Running size of the live file; undefined until seeded from disk on the first write after init.
 let currentBytes: number | undefined
+const diagnosticCorrelation = new AsyncLocalStorage<string>()
+
+const runWithDiagnosticCorrelation = <Result>(operation: () => Result): Result => {
+  let correlationId: string
+  try {
+    correlationId = randomUUID()
+  } catch {
+    return operation()
+  }
+  return diagnosticCorrelation.run(correlationId, operation)
+}
 
 // Turns arbitrary log payloads into JSON-safe values, unwrapping Errors (whose fields are non-enumerable)
 // so a stack trace actually lands in the log instead of `{}`.
@@ -692,7 +704,8 @@ const formatLine = (
   scope: string,
   message: string,
   data?: unknown,
-  runId?: string
+  runId?: string,
+  correlationId?: string
 ): string => {
   const record: Record<string, unknown> = {
     t: new Date().toISOString(),
@@ -702,6 +715,7 @@ const formatLine = (
   }
 
   if (runId !== undefined) record.runId = runId
+  if (correlationId !== undefined) record.correlationId = correlationId
   if (data !== undefined) record.data = toSerializable(data)
 
   try {
@@ -712,6 +726,7 @@ const formatLine = (
       t: record.t,
       level,
       ...(runId === undefined ? {} : { runId }),
+      ...(correlationId === undefined ? {} : { correlationId }),
       scope,
       msg: message,
       data: '[unserializable]'
@@ -826,7 +841,14 @@ const writeFatalLogSync = (scope: string, message: string, data?: unknown): void
     mkdirSync(config.logDir, { recursive: true })
     appendFileSync(
       join(config.logDir, config.fileName),
-      `${formatLine('error', scope, message, data, config.runId)}\n`,
+      `${formatLine(
+        'error',
+        scope,
+        message,
+        data,
+        config.runId,
+        diagnosticCorrelation.getStore()
+      )}\n`,
       'utf8'
     )
   } catch {
@@ -836,7 +858,14 @@ const writeFatalLogSync = (scope: string, message: string, data?: unknown): void
 
 const emit = (level: LogLevel, scope: string, message: string, data?: unknown): void => {
   const mirror = config?.mirrorToConsole ?? true
-  const line = formatLine(level, scope, message, data, config?.runId)
+  const line = formatLine(
+    level,
+    scope,
+    message,
+    data,
+    config?.runId,
+    diagnosticCorrelation.getStore()
+  )
 
   if (mirror) {
     const consoleMethod = level === 'debug' ? 'log' : level
@@ -875,5 +904,6 @@ export {
   formatLine,
   getLogFilePath,
   initLogger,
+  runWithDiagnosticCorrelation,
   writeFatalLogSync
 }

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { request as httpRequest, ServerResponse } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -22,6 +22,7 @@ import {
 } from '../../shared/web-rpc-contract'
 import { ApplicationEventHub } from '../application-events'
 import type { CallerContext } from '../caller-context'
+import { createLogger, flushLogs, initLogger } from '../logger'
 import {
   REMOTE_LOCAL_ONLY_RPC_CHANNELS,
   startWebHttpServer,
@@ -33,6 +34,7 @@ import { TaskApiError } from './task-api'
 
 const roots: string[] = []
 const servers: RunningWebServer[] = []
+let diagnosticLogDir: string | undefined
 const applicationEvents = new ApplicationEventHub()
 type TestWebServerOptions = Omit<
   Parameters<typeof startWebHttpServer>[0],
@@ -84,9 +86,21 @@ const accessOnlyExternalAccess = (): ExternalWebAccessAuthorization => ({
 const runWithCallerContext = <Result>(_context: CallerContext, operation: () => Result): Result =>
   operation()
 
+const readLogRecords = async (logDir: string): Promise<Record<string, unknown>[]> => {
+  await flushLogs()
+  return (await readFile(join(logDir, 'main.log'), 'utf8'))
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line) as Record<string, unknown>)
+}
+
 afterEach(async () => {
   await Promise.all(servers.splice(0).map((server) => server.close()))
+  await flushLogs()
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+  if (diagnosticLogDir) {
+    await rm(diagnosticLogDir, { recursive: true, force: true })
+  }
 })
 
 describe('startWebHttpServer', () => {
@@ -271,6 +285,133 @@ describe('startWebHttpServer', () => {
     secondSocket.close()
     await new Promise<void>((resolve) => secondSocket.once('close', () => resolve()))
     await vi.waitFor(() => expect(directSignal.aborted).toBe(true))
+  })
+
+  it('correlates a rejected Web RPC with logs emitted by its command', async () => {
+    const logDir = await mkdtemp(join(tmpdir(), 'open-science-web-rpc-log-'))
+    diagnosticLogDir = logDir
+    initLogger({ logDir, mirrorToConsole: false })
+    const invoke = vi.fn(async () => {
+      createLogger('test-command').warn('command execution failed', {
+        sessionId: 'session-1',
+        runId: 'run-1'
+      })
+      throw new Error('private command failure')
+    })
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      rpc: { channels: () => ['projects:list'], invoke },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+
+    const response = await fetch(`http://127.0.0.1:${server.port}/rpc/projects%3Alist`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
+    })
+
+    expect(response.status).toBe(500)
+    const records = (await readLogRecords(logDir)).filter(
+      (record) =>
+        record.scope === 'test-command' ||
+        (record.scope === 'web-service' && record.msg === 'web rpc rejected')
+    )
+    expect(records).toHaveLength(2)
+    expect(new Set(records.map((record) => record.correlationId))).toEqual(
+      new Set([expect.any(String)])
+    )
+    expect(records[0]?.data).toMatchObject({ sessionId: 'session-1', runId: 'run-1' })
+    expect(records[1]?.data).toEqual({
+      channel: 'projects:list',
+      surface: 'web',
+      location: 'local',
+      errorCategory: 'error'
+    })
+    expect(JSON.stringify(records)).not.toContain('private command failure')
+  })
+
+  it('correlates a rejected Task HTTP request with logs emitted by its Run', async () => {
+    const logDir = await mkdtemp(join(tmpdir(), 'open-science-task-http-log-'))
+    diagnosticLogDir = logDir
+    initLogger({ logDir, mirrorToConsole: false })
+    const startRun = vi.fn(async () => {
+      createLogger('test-task-run').warn('task run execution failed', {
+        sessionId: 'session-1',
+        runId: 'run-1'
+      })
+      throw new Error('private task run failure')
+    })
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      rpc: { channels: () => [], invoke: vi.fn() },
+      tasks: {
+        runWithCallerContext,
+        subscribeProgress: vi.fn(() => vi.fn()),
+        listProjects: vi.fn(),
+        createProject: vi.fn(),
+        updateProject: vi.fn(),
+        listSessions: vi.fn(),
+        getSession: vi.fn(),
+        startRun,
+        getRun: vi.fn(),
+        cancelRun: vi.fn(),
+        listArtifacts: vi.fn(),
+        acquireArtifact: vi.fn(),
+        releaseArtifact: vi.fn()
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+
+    const response = await fetch(`http://127.0.0.1:${server.port}/api/v1/runs`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ project: 'project-1', sessionId: 'session-1', prompt: 'Run task.' })
+    })
+
+    expect(response.status).toBe(500)
+    const records = (await readLogRecords(logDir)).filter(
+      (record) =>
+        record.scope === 'test-task-run' ||
+        (record.scope === 'web-service' && record.msg === 'task http request rejected')
+    )
+    expect(records).toHaveLength(2)
+    expect(new Set(records.map((record) => record.correlationId))).toEqual(
+      new Set([expect.any(String)])
+    )
+    expect(records[0]?.data).toMatchObject({ sessionId: 'session-1', runId: 'run-1' })
+    expect(records[1]?.data).toEqual({
+      method: 'POST',
+      surface: 'task',
+      location: 'local',
+      errorCategory: 'error'
+    })
+    expect(JSON.stringify(records)).not.toContain('private task run failure')
   })
 
   it('releases its application-event subscription when listening fails', async () => {

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -26,6 +26,7 @@ import {
 import { createApplicationCommandClient } from '../application-command-client'
 import type { ApplicationCommandComposition } from '../application-command-composition'
 import type { ApplicationEventSource } from '../application-events'
+import { createLogger, diagnosticErrorFields, runWithDiagnosticCorrelation } from '../logger'
 import {
   WEB_RPC_CAPABILITIES,
   WEB_EVENT_STREAM_PROTOCOL_VERSION,
@@ -60,6 +61,7 @@ const MIN_TASK_IDEMPOTENCY_ENTRY_BYTES = 16 * 1024
 const MAX_IDEMPOTENCY_KEY_LENGTH = 255
 const MAX_CACHED_TASK_ERROR_MESSAGE_LENGTH = 4_096
 const gzipAsync = promisify(gzip)
+const log = createLogger('web-service')
 const STATIC_RESPONSE_SECURITY_HEADERS = {
   'content-security-policy':
     "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; media-src 'self' https: blob:; frame-src 'self'; connect-src 'self' ws: wss:; frame-ancestors 'none'",
@@ -658,6 +660,12 @@ const handleTaskApiRequest = async (
         return true
       }
     } catch (error) {
+      log.warn('task http request rejected', {
+        method: request.method,
+        surface: callerContext.surface,
+        location: callerContext.location,
+        ...diagnosticErrorFields(error)
+      })
       taskError(response, error)
       return true
     }
@@ -727,7 +735,10 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
   })
   const wsServer = new WebSocketServer({ noServer: true })
 
-  const server = createServer(async (request, response) => {
+  const handleRequest = async (
+    request: IncomingMessage,
+    response: ServerResponse
+  ): Promise<void> => {
     try {
       const url = new URL(request.url ?? '/', `http://${request.headers.host ?? '127.0.0.1'}`)
       const auth = authenticateRequest(request, url, options.token)
@@ -905,6 +916,12 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
             result: result ?? null
           })
         } catch (error) {
+          log.warn('web rpc rejected', {
+            channel,
+            surface: callerContext.surface,
+            location: callerContext.location,
+            ...diagnosticErrorFields(error)
+          })
           if (error instanceof ExternalAuthorizationExpiredError) {
             webRpcError(response, 401, 'invalid_request', error.message)
             return
@@ -934,7 +951,10 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
         error: INTERNAL_SERVER_ERROR_MESSAGE
       })
     }
-  })
+  }
+  const server = createServer((request, response) =>
+    runWithDiagnosticCorrelation(() => handleRequest(request, response))
+  )
 
   server.on('upgrade', (request, socket, head) => {
     void (async () => {


### PR DESCRIPTION
## Problem

Main-process diagnostics could not reliably connect an incoming Web RPC or Task HTTP request with command, session, and run logs. The existing top-level runId identifies the app process launch, while renderer diagnostics and direct console calls are separate surfaces. A boundary rejection also had no structured log entry.

Current inventory found 95 console.warn/error call sites across 59 production TS/TSX files. This PR deliberately does not migrate that inventory.

## Reproduction and regression coverage

The regression tests use real local HTTP endpoints and the real JSONL logger. A command or task run logs safe sessionId/runId data and then rejects. Before the fix, each test found only the handler log, with no request-boundary record or shared correlation ID; both failures reproduced on three consecutive runs.

## Change

- Create one opaque correlationId for each HTTP request with Node AsyncLocalStorage.
- Add that optional top-level field automatically to structured logs emitted in the request async context.
- Add bounded, redacted warning records at rejected Web RPC and Task HTTP boundaries.
- Preserve existing HTTP status codes and response bodies.

## Scope and compatibility

- Adds one optional field only to persisted diagnostic JSONL records: correlationId.
- Existing historical log lines remain valid without the field; no migration or backfill is needed. Consumers must continue treating JSONL records as additive.
- No request or response protocol field, renderer interaction, business data-model, database schema, or application architecture change.
- No new enum or state values.
- No business-data persistence changes.
- Renderer diagnostics and direct console calls remain explicit non-goals for this focused foundation.

## Validation

All checks below ran after the last material edit:

- npm test -- src/main/logger.test.ts — 68 passed.
- npm test -- src/main/web-service/http-server.test.ts — 26 passed.
- Focused HTTP correlation cases — 2 passed.
- npm run typecheck:node — passed.
- npm run lint — passed.
- Prettier check for changed files — passed.
- npm run test:affected -- --base origin/main --head HEAD --explain — selected the full fallback because logger.test.ts has no module owner. Per maintainer direction, the complete suite is delegated to PR CI.

## Review focus

Please review privacy at the rejection boundary, AsyncLocalStorage propagation/isolation, and the additive JSONL compatibility contract.