### PR TITLE
ci(pr-gate): classify restricted runtime profile as Windows-sensitive

### DIFF
--- a/scripts/ci/change-impact.json
+++ b/scripts/ci/change-impact.json
@@ -112,6 +112,7 @@
         "src/main/acp/agent-process.ts",
         "src/main/acp/claude-executable.ts",
         "src/main/acp/permission-broker.ts",
+        "src/main/acp/restricted-runtime-profile.ts",
         "src/main/acp/runtime.ts",
         "src/main/agent-framework/codex.ts",
         "src/main/agent-framework/opencode.ts",

--- a/scripts/ci/classify-pr-changes.test.ts
+++ b/scripts/ci/classify-pr-changes.test.ts
@@ -330,7 +330,8 @@ describe('pull request change classification', () => {
     ['file save', 'src/main/file-save.ts'],
     ['specialist repository', 'src/main/specialist/repository.ts'],
     ['notebook runtime settings', 'src/main/settings/notebook-runtime-settings.ts'],
-    ['preferences', 'src/main/settings/preferences.ts']
+    ['preferences', 'src/main/settings/preferences.ts'],
+    ['restricted runtime profile', 'src/main/acp/restricted-runtime-profile.ts']
   ])('adds native Windows lanes for %s changes', (_category, path) => {
     const plan = classifyChanges([{ path, status: 'modified' }])
 


### PR DESCRIPTION
## Problem

PR #1529's full-suite macOS shard failed `scripts/ci/classify-pr-changes.test.ts`:

```
covers every production source file with an explicit Windows runtime signal
AssertionError: expected [ Array(1) ] to deeply equal []
+ [ "src/main/acp/restricted-runtime-profile.ts" ]
```

`prepareCodexBackend` copies `USERPROFILE` when isolating `CODEX_HOME`. That is an explicit Windows runtime signal, but the PR Gate `windows_sensitive` overlay did not include this file, so a change to it would not select Windows runtime/path or Windows E2E lanes.

## Proposed change

Add `src/main/acp/restricted-runtime-profile.ts` to the `windows_sensitive` overlay in `scripts/ci/change-impact.json`, and pin the same path in the classifier's native-Windows-lane examples so the #1529 coverage gap cannot regress silently.

## Scope and non-goals

- Classifier overlay only. No production behavior, schema, locale, or workflow file changes.
- Does not modify PR #1529's i18n commits.
- Does not change Windows runtime code in `restricted-runtime-profile.ts`.

## Acceptance criteria and validation

The listed checks ran after the last material edit, from the worktree at `.worktree/windows-sensitive-restricted-runtime-profile`:

| Behavior | Command | Result |
| --- | --- | --- |
| Windows-signal files must select `windows_sensitive` plus Windows E2E lanes; restricted runtime profile is included | `npx vitest run scripts/ci/classify-pr-changes.test.ts scripts/ci/module-impact-shadow.test.ts scripts/ci/pr-gate-workflow.test.ts` | 102/102 passed |
| Changed TypeScript stays lint-clean | `npx eslint scripts/ci/classify-pr-changes.test.ts` | 0 errors |

Excluded: full `npm test`, process typechecks, and E2E. This PR only updates the trusted classifier overlay and its owner test; PR Gate on this branch remains the complete portable/platform authority. Changing `scripts/ci/change-impact.json` selects the full plan, which is the intended verification for a global gate input.

## Review focus

- Confirm `USERPROFILE` in `prepareCodexBackend` is a real Windows process-environment concern, not a false-positive signal.
- Confirm the overlay path is the file that owns that assignment, not a consumer.

## Historical compatibility

None. No persisted data, settings schema, or migration is involved.

## New state / enum values

None.

## Data persistence

None.

Refs: #1529