### PR TITLE
fix(session-resume): recover empty-data Codex resume failures

### DIFF
--- a/src/main/acp/provider-session-resumer.test.ts
+++ b/src/main/acp/provider-session-resumer.test.ts
@@ -706,6 +706,35 @@ describe('AcpProviderSessionResumer', () => {
     expect(harness.adopt).toHaveBeenCalledOnce()
   })
 
+  it.each([
+    ['Responses', codexResponsesBackend],
+    ['Responses Compatibility', codexResponsesCompatibilityBackend]
+  ] as const)(
+    'fresh-adopts a persisted Codex %s Session after the ACP router returns empty error data',
+    async (_route, initialBackend) => {
+      const providerSessionId = '019fb8c8-6c66-7f22-9653-17b5b287dbbb'
+      const harness = createHarness({
+        initialBackend,
+        resumeError: acp.RequestError.internalError({})
+      })
+
+      await expect(
+        harness.resume({
+          providerSessionId,
+          previousFrameworkId: 'codex',
+          previousBackendId: initialBackend.backendId
+        })
+      ).resolves.toMatchObject({ contextReset: true })
+
+      expect(harness.request).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ sessionId: providerSessionId })
+      )
+      expect(harness.release).toHaveBeenCalledWith({ ownsStableIdentity: true })
+      expect(harness.adopt).toHaveBeenCalledOnce()
+    }
+  )
+
   it('fresh-adopts a legacy OpenCode Session after its adapter returns Unknown error', async () => {
     const harness = createHarness({
       initialBackend: opencodeBackend,

--- a/src/main/acp/session-resume-policy.ts
+++ b/src/main/acp/session-resume-policy.ts
@@ -157,6 +157,19 @@ const isCodexResponsesResumeContext = (
   (context.currentModelRoute === 'codex-responses' ||
     context.currentModelRoute === 'codex-responses-compatibility')
 
+const hasNoStructuredErrorData = (value: unknown): boolean => {
+  if (value === undefined) return true
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  try {
+    const prototype = Object.getPrototypeOf(value)
+    return (
+      (prototype === Object.prototype || prototype === null) && Reflect.ownKeys(value).length === 0
+    )
+  } catch {
+    return false
+  }
+}
+
 // ARD-04 intentionally adds this pure policy without a production caller. ARD-20 exclusively owns
 // the Runtime cutover once its transaction seams exist; integrating here would violate the serialized
 // hot-file boundary. Session ownership, protocol calls, and replay stay with those transactions.
@@ -306,7 +319,7 @@ class AcpSessionResumePolicy {
     if (describesUnresumableSession(details.value)) {
       return adoptableFailure('legacy-unresumable-details')
     }
-    if (data.value === undefined && isCodexResponsesResumeContext(context)) {
+    if (hasNoStructuredErrorData(data.value) && isCodexResponsesResumeContext(context)) {
       return adoptableFailure('legacy-codex-session-unavailable')
     }
     return authoritativeFailure('unrelated-internal-error')


### PR DESCRIPTION
## Problem

Codex Responses adapters can surface a provider Session that cannot be resumed as JSON-RPC `-32603 Internal error` with `data: {}`. The ACP router emits this empty object when a downstream exception has no diagnostic details.

The resume policy already treated the equivalent error with omitted `data` as an unavailable provider Session, but rejected the empty-object form. Electron then reduced the opaque error to `Agent session resume failed: Unknown error`, so reopening the same persisted Session failed repeatedly instead of reaching the existing fresh-adoption and transcript-replay path.

The attached Windows 0.20.0 diagnostic log captured three consecutive failures after the Codex agent initialized successfully. A regression test using `RequestError.internalError({})` reproduced the same rejection three times on the pre-fix code.

## Proposed change

- Treat omitted error data and an empty plain error-data object as the same detail-free failure, only on `codex-responses` and `codex-responses-compatibility` routes.
- Reuse the existing fresh provider Session adoption, context-reset, and persisted transcript replay behavior.
- Cover both affected routes at the public `AcpProviderSessionResumer` behavior boundary with the SDK error shape emitted by the ACP router.

## Scope and non-goals

- Structured errors with `service`, `errorKind`, `details`, or any other data remain authoritative.
- Claude Code, OpenCode, and Codex Bridge failure handling is unchanged and remains covered by the policy matrix.
- No renderer interaction, user-visible copy, API, protocol field, enum, dependency, architecture, database schema, migration, or persisted Session format changes.
- Existing persisted Sessions require no migration. Successful fallback may update the existing `providerSessionId` through the normal Session save path; no new persisted field is introduced.
- Subscription behavior is unaffected.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

| Behavior | Framework / path | Command | Result |
| --- | --- | --- | --- |
| Empty-data opaque resume failure fresh-adopts and replays instead of surfacing `Unknown error` | Codex / Responses and Responses Compatibility | `npm test -- src/main/acp/provider-session-resumer.test.ts src/main/acp/session-resume-policy.test.ts` | Passed: 87 tests |
| Structured and non-Codex failures remain authoritative | Claude Code, OpenCode, Codex Bridge, and structured Codex failures | Same policy/resumer test command | Passed as part of 87 tests |
| Node runtime types remain valid | Main / ACP | `npm run typecheck:node` | Passed |
| Changed files satisfy lint and formatting | Main / ACP | `npx eslint src/main/acp/session-resume-policy.ts src/main/acp/provider-session-resumer.test.ts` and `npx prettier --check ...` | Passed |

The exact-head affected-test explanation selects the full CI plan because these ACP files currently have no module owner in `scripts/ci/module-impact.json`. Per maintainer direction, the complete `npm test` suite was not run locally; PR Gate is authoritative for the complete portable and Windows-sensitive coverage.

Uncovered local risk: the packaged Windows application was not rebuilt and exercised locally. The failing wire shape is platform-neutral and is reproduced with the installed ACP SDK, while the original report supplies Windows evidence.

## Review focus

- Confirm the fallback remains limited to a detail-free `-32603 Internal error` on the two Codex Responses routes.
- Confirm empty plain error data is equivalent to omitted error data at the ACP router boundary without weakening structured failure handling.
