### PR TITLE
fix(settings): preserve concurrent notebook runtime updates

### DIFF
--- a/src/main/settings/notebook-runtime-settings.test.ts
+++ b/src/main/settings/notebook-runtime-settings.test.ts
@@ -78,6 +78,38 @@ describe('NotebookRuntimeSettingsModule', () => {
     })
   })
 
+  it('preserves concurrent environment enablement updates', async () => {
+    const settings = await createModule()
+    const firstPath = resolve('/usr/bin/python3')
+    const secondPath = resolve('/opt/python/bin/python3')
+
+    await Promise.all([
+      settings.setEnvironmentEnabled('python', firstPath, true),
+      settings.setEnvironmentEnabled('python', secondPath, false)
+    ])
+
+    expect((await settings.getSnapshot('python')).runtimeEnablement.enabled).toEqual({
+      [firstPath]: true,
+      [secondPath]: false
+    })
+  })
+
+  it('preserves concurrent manual interpreter additions', async () => {
+    const settings = await createModule()
+    const firstPath = resolve('/usr/bin/python3')
+    const secondPath = resolve('/opt/python/bin/python3')
+
+    await Promise.all([
+      settings.addManualInterpreter('python', firstPath),
+      settings.addManualInterpreter('python', secondPath)
+    ])
+
+    expect((await settings.getSnapshot('python')).manualInterpreters).toEqual([
+      firstPath,
+      secondPath
+    ])
+  })
+
   it('preserves repository normalization for manual interpreters and package mirrors', async () => {
     const settings = await createModule()
     const interpreterPath = resolve('/opt/python/bin/python3')

--- a/src/main/settings/notebook-runtime-settings.ts
+++ b/src/main/settings/notebook-runtime-settings.ts
@@ -62,11 +62,10 @@ class NotebookRuntimeSettingsModule implements NotebookRuntimeSettings {
     envId: string,
     enabled: boolean
   ): Promise<RuntimeEnablement> {
-    const current = (await this.getSnapshot(language)).runtimeEnablement
-    const settings = await this.repository.setRuntimeEnablement(language, {
+    const settings = await this.repository.setRuntimeEnablement(language, (current) => ({
       enabled: { ...current.enabled, [envId]: enabled },
       installAuthorized: { ...current.installAuthorized }
-    })
+    }))
 
     return cloneRuntimeEnablement(settings.notebookRuntimeEnablement?.[language])
   }
@@ -76,26 +75,25 @@ class NotebookRuntimeSettingsModule implements NotebookRuntimeSettings {
     envId: string,
     authorized: boolean
   ): Promise<RuntimeEnablement> {
-    const current = (await this.getSnapshot(language)).runtimeEnablement
-    const settings = await this.repository.setRuntimeEnablement(language, {
+    const settings = await this.repository.setRuntimeEnablement(language, (current) => ({
       enabled: { ...current.enabled },
       installAuthorized: { ...current.installAuthorized, [envId]: authorized }
-    })
+    }))
 
     return cloneRuntimeEnablement(settings.notebookRuntimeEnablement?.[language])
   }
 
   async addManualInterpreter(language: NotebookLanguage, path: string): Promise<string[]> {
-    const current = (await this.getSnapshot(language)).manualInterpreters
-    const settings = await this.repository.setManualInterpreters(language, [...current, path])
+    const settings = await this.repository.setManualInterpreters(language, (current) => [
+      ...current,
+      path
+    ])
 
     return [...(settings.notebookManualInterpreters?.[language] ?? [])]
   }
 
   async removeManualInterpreter(language: NotebookLanguage, path: string): Promise<string[]> {
-    const current = (await this.getSnapshot(language)).manualInterpreters
-    const settings = await this.repository.setManualInterpreters(
-      language,
+    const settings = await this.repository.setManualInterpreters(language, (current) =>
       current.filter((candidate) => candidate !== path)
     )
 

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -1358,13 +1358,15 @@ describe('settings repository: v2 official providers & activeModel migration', (
       enabled: { '/usr/bin/python3': true },
       installAuthorized: { '/usr/bin/python3': false }
     }
-    await repository.setRuntimeEnablement('python', enablement)
+    await repository.setRuntimeEnablement('python', () => enablement)
     expect((await repository.getSettings()).notebookRuntimeEnablement).toEqual({
       python: enablement
     })
 
-    // An entry that sanitizes to empty deletes the language and drops the map when it becomes empty.
-    await repository.setRuntimeEnablement('python', { enabled: {}, installAuthorized: {} })
+    await repository.setRuntimeEnablement('python', () => ({
+      enabled: {},
+      installAuthorized: {}
+    }))
     expect((await repository.getSettings()).notebookRuntimeEnablement).toBeUndefined()
   })
 
@@ -1372,7 +1374,7 @@ describe('settings repository: v2 official providers & activeModel migration', (
     const repository = new SettingsRepository(await createStorageRoot())
 
     // Trim + dedupe on write.
-    await repository.setManualInterpreters('python', [
+    await repository.setManualInterpreters('python', () => [
       '/opt/py/bin/python3',
       '  /opt/py/bin/python3  ',
       '/other/python'
@@ -1381,8 +1383,7 @@ describe('settings repository: v2 official providers & activeModel migration', (
       python: ['/opt/py/bin/python3', '/other/python']
     })
 
-    // An empty list deletes the language and drops the map once empty.
-    await repository.setManualInterpreters('python', [])
+    await repository.setManualInterpreters('python', () => [])
     expect((await repository.getSettings()).notebookManualInterpreters).toBeUndefined()
   })
 })

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -454,55 +454,48 @@ class SettingsRepository {
     })
   }
 
-  // Replaces one language's v4 RuntimeEnablement (the explicit enabled-override + install-auth maps).
-  // The value is run through the SAME sanitizer used on read, so a corrupt entry can never be
-  // persisted. An entry that sanitizes to empty (both maps empty) deletes the language's entry, and
-  // the whole `notebookRuntimeEnablement` map is dropped once it becomes empty, so an absent map keeps
-  // meaning "use the provenance default".
+  // Applies one RuntimeEnablement change to the latest persisted value inside the write queue.
   async setRuntimeEnablement(
     language: NotebookLanguage,
-    enablement: RuntimeEnablement
+    update: (current: RuntimeEnablement) => RuntimeEnablement
   ): Promise<StoredSettings> {
-    const sanitized = sanitizeSettings({ notebookRuntimeEnablement: { [language]: enablement } })
-      .notebookRuntimeEnablement?.[language] ?? { enabled: {}, installAuthorized: {} }
-    const isEmpty =
-      Object.keys(sanitized.enabled).length === 0 &&
-      Object.keys(sanitized.installAuthorized).length === 0
-
     return this.mutate((settings) => {
-      const current: Partial<Record<NotebookLanguage, RuntimeEnablement>> = {
-        ...settings.notebookRuntimeEnablement
+      const current = settings.notebookRuntimeEnablement?.[language]
+      const enablement = update({
+        enabled: { ...current?.enabled },
+        installAuthorized: { ...current?.installAuthorized }
+      })
+      const sanitized = sanitizeSettings({ notebookRuntimeEnablement: { [language]: enablement } })
+        .notebookRuntimeEnablement?.[language]
+      const notebookRuntimeEnablement = { ...settings.notebookRuntimeEnablement }
+      if (sanitized) notebookRuntimeEnablement[language] = sanitized
+      else delete notebookRuntimeEnablement[language]
+      return {
+        ...settings,
+        notebookRuntimeEnablement:
+          Object.keys(notebookRuntimeEnablement).length > 0 ? notebookRuntimeEnablement : undefined
       }
-
-      if (isEmpty) delete current[language]
-      else current[language] = sanitized
-
-      const notebookRuntimeEnablement = Object.keys(current).length > 0 ? current : undefined
-
-      return { ...settings, notebookRuntimeEnablement }
     })
   }
 
-  // Replaces one language's manual-interpreter catalog (the paths the user added via "Add interpreter…").
-  // Sanitized like on read (trim + dedupe + drop empties); an empty list deletes the language's entry,
-  // and the whole map is dropped once empty, so an absent map keeps meaning "no manual interpreters".
+  // Applies one catalog change to the latest persisted paths inside the write queue.
   async setManualInterpreters(
     language: NotebookLanguage,
-    paths: string[]
+    update: (current: string[]) => string[]
   ): Promise<StoredSettings> {
-    const cleaned = [...new Set(paths.map((p) => p.trim()).filter((p) => p.length > 0))]
-
     return this.mutate((settings) => {
-      const current: Partial<Record<NotebookLanguage, string[]>> = {
-        ...settings.notebookManualInterpreters
+      const paths = update([...(settings.notebookManualInterpreters?.[language] ?? [])])
+      const cleaned = [...new Set(paths.map((path) => path.trim()).filter(Boolean))]
+      const notebookManualInterpreters = { ...settings.notebookManualInterpreters }
+      if (cleaned.length > 0) notebookManualInterpreters[language] = cleaned
+      else delete notebookManualInterpreters[language]
+      return {
+        ...settings,
+        notebookManualInterpreters:
+          Object.keys(notebookManualInterpreters).length > 0
+            ? notebookManualInterpreters
+            : undefined
       }
-
-      if (cleaned.length === 0) delete current[language]
-      else current[language] = cleaned
-
-      const notebookManualInterpreters = Object.keys(current).length > 0 ? current : undefined
-
-      return { ...settings, notebookManualInterpreters }
     })
   }
 


### PR DESCRIPTION
## Problem

Notebook runtime settings read the complete per-language enablement or manual-interpreter snapshot before entering the serialized settings write queue. Two overlapping environment toggles, install-authorization changes, or interpreter catalog changes could therefore derive replacements from the same stale snapshot, and the later write silently removed the earlier choice.

The regression tests reproduced this on the unmodified implementation: both concurrent cases failed on all five attempts (`--retry=4`), with only the second envId/path remaining.

## Proposed change

- Change the existing repository operations to accept synchronous transformations.
- Execute those transformations against the latest persisted settings inside `SettingsDocumentStore.mutate()`.
- Keep sanitization, normalization, and empty-map cleanup inside the repository transaction.
- Add public-boundary regression coverage for concurrent environment enablement and manual-interpreter additions.

## Scope and non-goals

- No new persisted fields or enum/status values.
- No schema, migration, storage-format, data-model, or user-interaction changes.
- Existing `settings.json` documents remain compatible without migration.
- This change covers Notebook runtime settings mutations that share the production `SettingsService` repository/store. Cross-process or independently constructed document-store coordination is unchanged.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- concurrent Notebook runtime updates -> `npm test -- src/main/settings/notebook-runtime-settings.test.ts` -> 6/6 passed
- persistence normalization and Settings facade constraints -> `npm test -- src/main/settings/notebook-runtime-settings.test.ts src/main/settings/repository.test.ts src/main/settings/settings-backend.architecture.test.ts` -> 112/112 passed
- Settings repository owner, contract, and declared consumer impact set -> `npm run test:module -- settings_repository` -> 20 files, 618/618 passed
- main-process types -> `npm run typecheck:node` -> passed
- lint -> `npm run lint` -> passed with no warnings

The complete local `npm test` suite was intentionally not run; PR Gate remains authoritative for the full and platform-specific lanes.

## Review focus

- Confirm both updater callbacks execute only inside the serialized document mutation.
- Confirm detached clones preserve the existing no-shared-mutation behavior.
- Confirm persisted field shapes and normalization remain unchanged.
