### PR TITLE
fix(agent-runtime): serialize runtime installations

### DIFF
--- a/src/main/settings/agent-runtime-manager.test.ts
+++ b/src/main/settings/agent-runtime-manager.test.ts
@@ -512,11 +512,11 @@ describe('AgentRuntimeManager', () => {
       installManagedCodexImpl
     })
 
-    const results = await Promise.all([
-      manager.installClaude({ source: 'managed' }, onEvent),
-      manager.installOpencode({ source: 'managed' }, onEvent),
-      manager.installCodex({ source: 'managed' }, onEvent)
-    ])
+    const results = [
+      await manager.installClaude({ source: 'managed' }, onEvent),
+      await manager.installOpencode({ source: 'managed' }, onEvent),
+      await manager.installCodex({ source: 'managed' }, onEvent)
+    ]
 
     expect(results.map((result) => result.installId)).toEqual([
       'install-123-11',
@@ -536,6 +536,43 @@ describe('AgentRuntimeManager', () => {
       'install-opencode-123-12',
       'install-codex-123-13'
     ])
+  })
+
+  it('rejects a second managed runtime install until the active install finishes', async () => {
+    const installStarted = Promise.withResolvers<void>()
+    const releaseInstall = Promise.withResolvers<void>()
+    const installManagedClaudeImpl: NonNullable<ManagerOptions['installManagedClaudeImpl']> = vi.fn(
+      async ({ installId }) => {
+        installStarted.resolve()
+        await releaseInstall.promise
+        return { result: { installId, ok: false, error: 'first install stopped' } }
+      }
+    )
+    const installManagedOpencodeImpl: NonNullable<ManagerOptions['installManagedOpencodeImpl']> =
+      vi.fn(async ({ installId }) => ({
+        result: { installId, ok: false, error: 'second installer was invoked' }
+      }))
+    manager = createManager({ installManagedClaudeImpl, installManagedOpencodeImpl })
+
+    const firstInstall = manager.installClaude({ source: 'managed' }, vi.fn())
+    await installStarted.promise
+
+    try {
+      await expect(manager.installOpencode({ source: 'managed' }, vi.fn())).resolves.toMatchObject({
+        ok: false,
+        error: 'Another install is already in progress.'
+      })
+      expect(installManagedOpencodeImpl).not.toHaveBeenCalled()
+    } finally {
+      releaseInstall.resolve()
+      await firstInstall
+    }
+
+    await expect(manager.installOpencode({ source: 'managed' }, vi.fn())).resolves.toMatchObject({
+      ok: false,
+      error: 'second installer was invoked'
+    })
+    expect(installManagedOpencodeImpl).toHaveBeenCalledOnce()
   })
 
   it('updates only the managed adapter when Codex CLI is user-owned', async () => {

--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -301,6 +301,7 @@ export class AgentRuntimeManager {
   private readonly codexDetectDeps: CodexDetectDeps
   private readonly allocateOpenCodeUsagePort: () => Promise<number>
   private readonly executeClaudeProbe: ExecuteClaudeProbe
+  private activeInstallId: string | undefined
   private environmentCheckRuntimeProbe: ReusableRuntimeProbe | undefined
   private preflightRuntimeProbe: ReusableRuntimeProbe | undefined
   private readonly installManagedClaudeImpl: (
@@ -487,39 +488,41 @@ export class AgentRuntimeManager {
   ): Promise<ClaudeInstallResult> {
     const installId = `install-${Date.now()}-${this.allocateSettingsIdSequence()}`
 
-    if (request.source === 'managed') {
-      const registries =
-        request.managedRegistry === 'npmmirror'
-          ? [DEFAULT_REGISTRIES[1], DEFAULT_REGISTRIES[0]]
-          : DEFAULT_REGISTRIES
-      const outcome = await this.installManagedClaudeImpl({
-        installId,
-        onEvent,
-        dataRoot: this.storageRoot,
-        registries
-      })
+    return this.runExclusiveInstall(installId, async () => {
+      if (request.source === 'managed') {
+        const registries =
+          request.managedRegistry === 'npmmirror'
+            ? [DEFAULT_REGISTRIES[1], DEFAULT_REGISTRIES[0]]
+            : DEFAULT_REGISTRIES
+        const outcome = await this.installManagedClaudeImpl({
+          installId,
+          onEvent,
+          dataRoot: this.storageRoot,
+          registries
+        })
 
-      if (outcome.result.ok && outcome.resolvedPath) {
-        const installedVersion = await this.detectDeps.getVersion(outcome.resolvedPath)
-        if (!installedVersion) {
-          const error =
-            'The installed Claude runtime could not report its version. It may be incompatible or incomplete. Delete it and install again.'
-          onEvent({ kind: 'log', installId, stream: 'system', chunk: `${error}\n` })
-          return { installId, ok: false, error }
+        if (outcome.result.ok && outcome.resolvedPath) {
+          const installedVersion = await this.detectDeps.getVersion(outcome.resolvedPath)
+          if (!installedVersion) {
+            const error =
+              'The installed Claude runtime could not report its version. It may be incompatible or incomplete. Delete it and install again.'
+            onEvent({ kind: 'log', installId, stream: 'system', chunk: `${error}\n` })
+            return { installId, ok: false, error }
+          }
+
+          await this.repository.setClaudeInfo({
+            resolvedPath: outcome.resolvedPath,
+            version: outcome.version
+          })
         }
 
-        await this.repository.setClaudeInfo({
-          resolvedPath: outcome.resolvedPath,
-          version: outcome.version
-        })
+        return outcome.result
       }
 
-      return outcome.result
-    }
-
-    const result = await runInstallWithFallback({ source: request.source, installId, onEvent })
-    if (result.ok) await this.detectClaude()
-    return result
+      const result = await runInstallWithFallback({ source: request.source, installId, onEvent })
+      if (result.ok) await this.detectClaude()
+      return result
+    })
   }
 
   async installOpencode(
@@ -528,26 +531,28 @@ export class AgentRuntimeManager {
   ): Promise<ClaudeInstallResult> {
     const installId = `install-opencode-${Date.now()}-${this.allocateSettingsIdSequence()}`
 
-    if (request.source === 'managed') {
-      const outcome = await this.installManagedOpencodeImpl({
+    return this.runExclusiveInstall(installId, async () => {
+      if (request.source === 'managed') {
+        const outcome = await this.installManagedOpencodeImpl({
+          installId,
+          onEvent,
+          dataRoot: this.storageRoot
+        })
+        if (outcome.result.ok && outcome.resolvedPath) {
+          await this.repository.setOpencodeInfo(outcome.resolvedPath, outcome.version)
+        }
+        return outcome.result
+      }
+
+      const result = await runInstallWithFallback({
+        source: request.source,
         installId,
         onEvent,
-        dataRoot: this.storageRoot
+        installTarget: OPENCODE_INSTALL_TARGET
       })
-      if (outcome.result.ok && outcome.resolvedPath) {
-        await this.repository.setOpencodeInfo(outcome.resolvedPath, outcome.version)
-      }
-      return outcome.result
-    }
-
-    const result = await runInstallWithFallback({
-      source: request.source,
-      installId,
-      onEvent,
-      installTarget: OPENCODE_INSTALL_TARGET
+      if (result.ok) await this.detectOpencode()
+      return result
     })
-    if (result.ok) await this.detectOpencode()
-    return result
   }
 
   async installCodex(
@@ -556,50 +561,68 @@ export class AgentRuntimeManager {
   ): Promise<ClaudeInstallResult> {
     const installId = `install-codex-${Date.now()}-${this.allocateSettingsIdSequence()}`
 
-    if (request.source === 'managed') {
-      const settings = await this.repository.getSettings()
-      const configuredCodexPath = settings.codex?.nativePath
-      const managedCodexPath =
-        this.codexDetectDeps.managedCodexPath ?? managedCodexBinary(this.storageRoot)
-      const externalCodexPath =
-        configuredCodexPath && configuredCodexPath !== managedCodexPath
-          ? configuredCodexPath
-          : undefined
-      const existingCodexPath =
-        externalCodexPath && (await this.codexDetectDeps.getCodexVersion(externalCodexPath))
-          ? externalCodexPath
-          : undefined
-      const outcome = await this.installManagedCodexImpl({
+    return this.runExclusiveInstall(installId, async () => {
+      if (request.source === 'managed') {
+        const settings = await this.repository.getSettings()
+        const configuredCodexPath = settings.codex?.nativePath
+        const managedCodexPath =
+          this.codexDetectDeps.managedCodexPath ?? managedCodexBinary(this.storageRoot)
+        const externalCodexPath =
+          configuredCodexPath && configuredCodexPath !== managedCodexPath
+            ? configuredCodexPath
+            : undefined
+        const existingCodexPath =
+          externalCodexPath && (await this.codexDetectDeps.getCodexVersion(externalCodexPath))
+            ? externalCodexPath
+            : undefined
+        const outcome = await this.installManagedCodexImpl({
+          installId,
+          onEvent,
+          dataRoot: this.storageRoot,
+          ...(existingCodexPath ? { existingCodexPath } : {})
+        })
+        if (
+          outcome.result.ok &&
+          outcome.adapterPath &&
+          outcome.adapterVersion &&
+          outcome.codexPath &&
+          outcome.codexVersion
+        ) {
+          await this.repository.setCodexInfo({
+            resolvedPath: outcome.adapterPath,
+            version: outcome.adapterVersion,
+            nativePath: outcome.codexPath,
+            nativeVersion: outcome.codexVersion
+          })
+        }
+        return outcome.result
+      }
+
+      const result = await runInstallWithFallback({
+        source: request.source,
         installId,
         onEvent,
-        dataRoot: this.storageRoot,
-        ...(existingCodexPath ? { existingCodexPath } : {})
+        installTarget: CODEX_INSTALL_TARGET
       })
-      if (
-        outcome.result.ok &&
-        outcome.adapterPath &&
-        outcome.adapterVersion &&
-        outcome.codexPath &&
-        outcome.codexVersion
-      ) {
-        await this.repository.setCodexInfo({
-          resolvedPath: outcome.adapterPath,
-          version: outcome.adapterVersion,
-          nativePath: outcome.codexPath,
-          nativeVersion: outcome.codexVersion
-        })
-      }
-      return outcome.result
+      if (result.ok) await this.detectCodex()
+      return result
+    })
+  }
+
+  private async runExclusiveInstall(
+    installId: string,
+    install: () => Promise<ClaudeInstallResult>
+  ): Promise<ClaudeInstallResult> {
+    if (this.activeInstallId !== undefined) {
+      return { installId, ok: false, error: 'Another install is already in progress.' }
     }
 
-    const result = await runInstallWithFallback({
-      source: request.source,
-      installId,
-      onEvent,
-      installTarget: CODEX_INSTALL_TARGET
-    })
-    if (result.ok) await this.detectCodex()
-    return result
+    this.activeInstallId = installId
+    try {
+      return await install()
+    } finally {
+      if (this.activeInstallId === installId) this.activeInstallId = undefined
+    }
   }
 
   async uninstallClaude(): Promise<RuntimeUninstallResult> {


### PR DESCRIPTION
## Problem

The renderer synchronously blocks a second agent runtime installation, but the main-process runtime owner did not enforce the same invariant. Duplicate IPC or application-command calls could therefore run multiple installers concurrently. Repeated installs could write the same managed runtime target, and cross-framework installs could also overlap despite sharing one unscoped install-event channel.

A controlled regression test held a managed Claude install open and then started a managed OpenCode install through AgentRuntimeManager. Before the fix, the second underlying installer was invoked on three consecutive runs.

## Proposed change

- Add a transient main-process active-install owner to AgentRuntimeManager.
- Admit only one Claude, OpenCode, or Codex installation at a time, across managed and external install sources.
- Return the existing structured Another install is already in progress. result for a rejected concurrent request.
- Release ownership in finally so later installs remain available after success, failure, or an exception.
- Keep the renderer guard as immediate UI feedback.

## Scope and non-goals

- No renderer interaction changes.
- No shared contract or data-model changes.
- No new enum values.
- No persisted state, schema migration, or historical-data compatibility work.
- Uninstall concurrency is outside this narrowly scoped fix.

## Acceptance criteria and validation

The listed checks ran after the last material edit.

- Concurrent install admission and owner release -> vitest run src/main/settings/agent-runtime-manager.test.ts -> 25 tests passed.
- Main owner plus existing renderer guard consumer -> vitest run src/main/settings/agent-runtime-manager.test.ts src/renderer/src/stores/settings-runtime-slice.test.ts -> 51 tests passed.
- Source lint -> npm run lint -> passed.
- Node typecheck -> npm run typecheck:node -> blocked by the existing baseline error in src/main/acp/claude-agent-acp-patch.test.ts: the installed @agentclientprotocol/claude-agent-acp package does not export waitForMcpServers. The same command fails identically on the main checkout.

Per maintainer direction, the complete npm test suite was not run locally; PR Gate is authoritative for the complete portable and platform lanes. The renderer consumer test is included because it owns the existing presentation guard and error behavior. Settings IPC and service contracts are unchanged, so no new IPC payload or adapter test is required.

## Review focus

- Synchronous admission before the first await.
- Ownership release on every terminal path.
- Preservation of existing install IDs, success behavior, event sinks, and repository updates.