### PR TITLE
fix(reviewer): preserve committed submission lifecycle

### DIFF
--- a/src/main/reviewer/repository.ts
+++ b/src/main/reviewer/repository.ts
@@ -21,7 +21,11 @@ import type {
   TurnScope,
   UpdateReviewPatch
 } from '../../shared/reviewer'
-import { loadReviewSubmissionProjections, toReviewCheck } from './review-submission-read-model'
+import {
+  loadReviewSubmissionProjection,
+  loadReviewSubmissionProjections,
+  toReviewCheck
+} from './review-submission-read-model'
 import { assertReviewSubmissionWithinLimits } from './submission-limits'
 
 const REVIEW_INTERRUPTED_ON_STARTUP_MESSAGE =
@@ -401,7 +405,7 @@ class ReviewRepository {
       : 'pass'
 
     const client = await this.getClient()
-    const ownership = await client.$transaction(async (tx) => {
+    const committed = await client.$transaction(async (tx) => {
       const assessmentReview = await tx.review.findUnique({ where: { id: input.reviewId } })
       if (!assessmentReview) throw new Error(`Review not found: ${input.reviewId}`)
       if (assessmentReview.lifecycle !== 'running') {
@@ -517,7 +521,7 @@ class ReviewRepository {
       for (const sourceReviewId of touchedSourceReviewIds) {
         await touchReview(tx, sourceReviewId)
       }
-      await tx.review.update({
+      const completedReview = await tx.review.update({
         where: { id: assessmentReview.id },
         data: {
           lifecycle: 'complete',
@@ -526,13 +530,19 @@ class ReviewRepository {
           reviewerLog: JSON.stringify(input.reviewerLog ?? [])
         }
       })
-      return { projectId: assessmentReview.projectId, sessionId: assessmentReview.sessionId }
+      const { checks, submittedChecks } = await loadReviewSubmissionProjection(
+        tx,
+        assessmentReview.id
+      )
+      return {
+        ...toReview(completedReview),
+        checks,
+        submittedChecks,
+        get findings() {
+          return checks
+        }
+      } as ReviewWithChecks
     })
-
-    const committed = (
-      await this.getReviews({ projectId: ownership.projectId, sessionId: ownership.sessionId })
-    ).find((review) => review.id === input.reviewId)
-    if (!committed) throw new Error(`Committed Review not found: ${input.reviewId}`)
     return committed
   }
 

--- a/src/main/reviewer/review-assessment-owner.test.ts
+++ b/src/main/reviewer/review-assessment-owner.test.ts
@@ -1,7 +1,10 @@
+import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { PrismaClient } from '@prisma/client'
 
 import type { AcpRuntime } from '../acp/runtime'
 import type {
@@ -12,7 +15,8 @@ import type {
   TurnScope
 } from '../../shared/reviewer'
 import type { PersistedChatSession } from '../../shared/session-persistence'
-import type { ReviewRepository } from './repository'
+import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
+import { ReviewRepository } from './repository'
 
 const harness = vi.hoisted(() => ({
   events: [] as string[],
@@ -537,5 +541,53 @@ describe('review assessment owner', () => {
     expect(published.findLast((candidate) => candidate.id === 'assessment-review')).toEqual(
       commandRead.find((candidate) => candidate.id === 'assessment-review')
     )
+  })
+
+  it('keeps a committed Review complete when the post-commit projection read is unavailable', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'open-science-reviewer-owner-'))
+    const realClient = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(realClient)
+    let submissionCommitted = false
+    let projectionReadFailed = false
+    const failingClient = {
+      review: {
+        ...realClient.review,
+        findMany: (...args: Parameters<typeof realClient.review.findMany>) => {
+          if (submissionCommitted && !projectionReadFailed) {
+            projectionReadFailed = true
+            return Promise.reject(new Error('temporary Review projection failure'))
+          }
+          return realClient.review.findMany(...args)
+        }
+      },
+      finding: realClient.finding,
+      reviewFindingDisposition: realClient.reviewFindingDisposition,
+      reviewScopeSnapshot: realClient.reviewScopeSnapshot,
+      $executeRaw: realClient.$executeRaw.bind(realClient),
+      $transaction: ((callback: (tx: Record<string, unknown>) => Promise<unknown>) =>
+        realClient
+          .$transaction((tx) => callback(tx as unknown as Record<string, unknown>))
+          .then((result) => {
+            submissionCommitted = true
+            return result
+          })) as PrismaClient['$transaction']
+    } as unknown as PrismaClient
+    const reviewRepository = new ReviewRepository(() => Promise.resolve(failingClient))
+
+    try {
+      const result = await runReviewAssessment({
+        ...commonOptions(reviewRepository),
+        mode: 'initial'
+      })
+      const stableRepository = new ReviewRepository(() => Promise.resolve(realClient))
+      const [stored] = await stableRepository.getReviewsForProjectSession('project-1', 'session-1')
+
+      expect(result.review).toMatchObject({ lifecycle: 'complete', outcome: 'pass' })
+      expect(stored).toMatchObject({ lifecycle: 'complete', outcome: 'pass' })
+      expect(stored.checks).toHaveLength(1)
+    } finally {
+      await realClient.$disconnect()
+      await rm(storageRoot, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## Problem

`commitScopedSubmission()` committed the Review lifecycle, Review Checks, and tracked dispositions in one SQLite transaction, then performed a second projection read outside the transaction. A transient failure in that read escaped as if submission persistence had failed, so `runReviewAssessment()` entered its failure path after durable success.

The regression reproduced this at the public assessment boundary with a real temporary SQLite database. Before the fix it failed consistently: the transaction committed, the injected projection read failed, and the owner attempted to rewrite the completed Review to `error`. On the current schema that rewrite is rejected by `Review_state_check` because the already committed `pass` outcome remains present, so the caller receives an exception instead of the committed result.

## Proposed change

Build the submitted Review projection from the completed Review row plus Finding/Disposition reads inside the existing transaction. A projection failure now rolls back the submission; once the transaction returns successfully, no fallible post-commit projection read can be misclassified as submission failure.

Add a public-boundary regression test that injects the former post-commit read failure and asserts both the returned and durable Review remain `complete/pass` with the submitted Check.

## Scope and non-goals

- No database schema, migration, persisted field, or historical-data compatibility change.
- No lifecycle/outcome enum value or state transition added.
- No API, architecture boundary, renderer interaction, ACP framework, or user interaction change.
- No retry policy or new dependency.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

- Committed submission lifecycle isolation -> `npm test -- src/main/reviewer/repository.test.ts src/main/reviewer/review-assessment-owner.test.ts` -> 44 passed.
- Reviewer owner, contracts, and representative consumers -> `npm run test:module -- reviewer_orchestrator` -> 494 passed across 27 files.
- Main-process types -> `npm run typecheck:node` -> passed.
- Source lint -> `npm run lint` -> passed.
- Patch hygiene -> `git diff --check` -> passed.

The first sandboxed module run could not open local loopback ports or Unix sockets and failed with `listen EPERM`; the same module command passed outside that restriction. Full `npm test` was intentionally not run; exact-head PR Gate remains authoritative for complete portable and platform lanes.

## Review focus

Confirm that loading the one submitted Review projection inside the transaction preserves the existing `ReviewWithChecks` shape and makes projection construction part of the same atomic success boundary as lifecycle, Finding, and disposition writes.