### PR TITLE
feat(notebook): relocate workload caches

### DIFF
--- a/build/windows-runtime-cache-uninstall.ps1
+++ b/build/windows-runtime-cache-uninstall.ps1
@@ -1,4 +1,11 @@
+param([switch]$LoadFunctionsOnly)
+
 $ErrorActionPreference = 'Stop'
+
+# The uninstaller invokes the system Windows PowerShell explicitly. Load the ACL cmdlets from that
+# same trusted installation instead of relying on a user-controlled PSModulePath/autoload lookup.
+$securityModule = Join-Path $PSHOME 'Modules\Microsoft.PowerShell.Security\Microsoft.PowerShell.Security.psd1'
+Import-Module -Name $securityModule -Force -ErrorAction Stop
 
 function Get-CanonicalPath([string]$Path) {
   $full = [System.IO.Path]::GetFullPath($Path)
@@ -6,6 +13,25 @@ function Get-CanonicalPath([string]$Path) {
     return (Get-Item -LiteralPath $full -Force).FullName
   }
   return $full
+}
+
+function Test-NoReparsePointInPath([string]$Path) {
+  $full = [System.IO.Path]::GetFullPath($Path)
+  $root = [System.IO.Path]::GetPathRoot($full)
+  if ([string]::IsNullOrWhiteSpace($root)) { return $false }
+  $current = $root
+  $relative = $full.Substring($root.Length)
+  foreach ($segment in $relative.Split(
+      [System.IO.Path]::DirectorySeparatorChar,
+      [System.StringSplitOptions]::RemoveEmptyEntries
+    )) {
+    $current = Join-Path $current $segment
+    $item = Get-Item -LiteralPath $current -Force
+    if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+      return $false
+    }
+  }
+  return $true
 }
 
 function Get-CacheLeaf([string]$RuntimeRoot, [string]$UserIdentity) {
@@ -47,24 +73,42 @@ function Get-CompactCacheLeaf([string]$RuntimeRoot, [string]$UserIdentity) {
   }
 }
 
-function Test-TrustedCache([string]$Path, [string]$CanonicalRoot, [string]$UserIdentity) {
-  $item = Get-Item -LiteralPath $Path -Force
-  if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) { return $false }
+function Get-WorkingCacheLeaf([string]$RuntimeRoot, [string]$UserIdentity) {
+  $key = $UserIdentity.ToLowerInvariant() + [char]0 + $RuntimeRoot.ToLowerInvariant()
+  $sha = [System.Security.Cryptography.SHA256]::Create()
+  try {
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($key)
+    $digest = $sha.ComputeHash($bytes)
+    $alphabet = '0123456789abcdefghjkmnpqrstvwxyz'
+    $encoded = ''
+    $value = 0
+    $bits = 0
+    foreach ($byte in $digest[0..4]) {
+      $value = ($value -shl 8) -bor $byte
+      $bits += 8
+      while ($bits -ge 5) {
+        $bits -= 5
+        $encoded += $alphabet[($value -shr $bits) -band 31]
+        $value = $value -band ((1 -shl $bits) - 1)
+      }
+    }
+    return 'm-' + $encoded
+  }
+  finally {
+    $sha.Dispose()
+  }
+}
 
-  $marker = Get-Content -LiteralPath (Join-Path $Path '.open-science-cache.json') -Raw |
-    ConvertFrom-Json
-  if ($marker.schema -ne 1 -or
-      $marker.canonicalRoot -ne $CanonicalRoot.ToLowerInvariant() -or
-      $marker.userIdentity -ne $UserIdentity) { return $false }
-
+function Test-TrustedAcl([string]$Path) {
   $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
   $acl = Get-Acl -LiteralPath $Path
   $ownerSid = ([System.Security.Principal.NTAccount]$acl.Owner).Translate(
     [System.Security.Principal.SecurityIdentifier]
   ).Value
-  if ($ownerSid -ne $identity.User.Value) { return $false }
+  $trustedOwnerSids = @($identity.User.Value, 'S-1-5-18', 'S-1-5-32-544')
+  if ($trustedOwnerSids -notcontains $ownerSid) { return $false }
 
-  $trustedWriteSids = @($identity.User.Value, 'S-1-5-18', 'S-1-5-32-544', 'S-1-3-0')
+  $trustedWriteSids = @($trustedOwnerSids + 'S-1-3-0')
   # Keep this complete dangerous-rights set in sync with micromamba-cache.ts. A foreign principal
   # with any of these rights can replace content or grant itself full control.
   $writeMask = [System.Security.AccessControl.FileSystemRights]::Write -bor
@@ -86,6 +130,57 @@ function Test-TrustedCache([string]$Path, [string]$CanonicalRoot, [string]$UserI
   }
   return $true
 }
+
+function Test-TrustedCache([string]$Path, [string]$CanonicalRoot, [string]$UserIdentity) {
+  if (-not (Test-NoReparsePointInPath $Path)) { return $false }
+  $item = Get-Item -LiteralPath $Path -Force
+  if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) { return $false }
+
+  $marker = Get-Content -LiteralPath (Join-Path $Path '.open-science-cache.json') -Raw |
+    ConvertFrom-Json
+  if ($marker.schema -ne 1 -or
+      $marker.canonicalRoot -ne $CanonicalRoot.ToLowerInvariant() -or
+      $marker.userIdentity -ne $UserIdentity) { return $false }
+
+  return (Test-TrustedAcl $Path)
+}
+
+function Test-TrustedManagedParent([string]$Path, [string]$UserIdentity) {
+  if (-not (Test-NoReparsePointInPath $Path)) { return $false }
+  $item = Get-Item -LiteralPath $Path -Force
+  if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) { return $false }
+
+  $marker = Get-Content -LiteralPath (Join-Path $Path '.open-science-temp.json') -Raw |
+    ConvertFrom-Json
+  if ($marker.schema -ne 1 -or
+      $marker.kind -ne 'micromamba-working-cache-parent' -or
+      $marker.userIdentity -ne $UserIdentity) { return $false }
+  return (Test-TrustedAcl $Path)
+}
+
+function Remove-EmptyManagedParent([string]$Path, [string]$UserIdentity) {
+  if (-not (Test-TrustedManagedParent $Path $UserIdentity)) { return }
+  $markerPath = Join-Path $Path '.open-science-temp.json'
+  $markerContents = Get-Content -LiteralPath $markerPath -Raw
+  $entries = @(Get-ChildItem -LiteralPath $Path -Force)
+  if ($entries.Count -ne 1 -or $entries[0].Name -ne '.open-science-temp.json') { return }
+  Remove-Item -LiteralPath $markerPath -Force
+  try {
+    # Non-recursive removal fails safely if another app process adds a child after the empty check.
+    Remove-Item -LiteralPath $Path -Force
+  }
+  catch {
+    try {
+      if (-not (Test-Path -LiteralPath $markerPath)) {
+        [System.IO.File]::WriteAllText($markerPath, $markerContents)
+      }
+    }
+    catch {}
+    throw
+  }
+}
+
+if ($LoadFunctionsOnly) { return }
 
 $identityParts = @($env:USERDOMAIN, $env:USERNAME) |
   Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
@@ -111,19 +206,50 @@ foreach ($root in $roots) {
     $canonicalRoot = Get-CanonicalPath $root
     $leaf = Get-CacheLeaf $canonicalRoot $userIdentity
     $compactLeaf = Get-CompactCacheLeaf $canonicalRoot $userIdentity
+    $workingLeaf = Get-WorkingCacheLeaf $canonicalRoot $userIdentity
     $candidates = @(
-      (Join-Path ([System.IO.Path]::GetPathRoot($canonicalRoot)) $leaf)
-      if (-not [string]::IsNullOrWhiteSpace($env:PUBLIC)) {
-        (Join-Path $env:PUBLIC $leaf)
+      [pscustomobject]@{
+        Path = (Join-Path ([System.IO.Path]::GetPathRoot($canonicalRoot)) $leaf)
+        ManagedParent = $false
       }
-      (Join-Path $env:USERPROFILE $leaf)
-      (Join-Path $env:USERPROFILE $compactLeaf)
-    ) | Select-Object -Unique
+      if (-not [string]::IsNullOrWhiteSpace($env:PUBLIC)) {
+        [pscustomobject]@{ Path = (Join-Path $env:PUBLIC $leaf); ManagedParent = $false }
+      }
+      [pscustomobject]@{ Path = (Join-Path $env:USERPROFILE $leaf); ManagedParent = $false }
+      [pscustomobject]@{ Path = (Join-Path $env:USERPROFILE $compactLeaf); ManagedParent = $false }
+      $managedParents = @(
+        (Join-Path ([System.IO.Path]::GetPathRoot($canonicalRoot)) 'OpenScienceTmp')
+        foreach ($configuredTemp in @($env:TEMP, $env:TMP)) {
+          if ($configuredTemp) {
+            (Join-Path $configuredTemp 'OpenScienceTmp')
+          }
+        }
+        (Join-Path $env:USERPROFILE 'os-tmp')
+      ) | Select-Object -Unique
+      foreach ($managedParent in $managedParents) {
+        [pscustomobject]@{
+          Path = (Join-Path $managedParent $workingLeaf)
+          ManagedParent = $true
+        }
+      }
+    ) | Select-Object -Property Path, ManagedParent -Unique
     foreach ($candidate in $candidates) {
       try {
-        if ((Test-Path -LiteralPath $candidate) -and
-            (Test-TrustedCache $candidate $canonicalRoot $userIdentity)) {
-          Remove-Item -LiteralPath $candidate -Recurse -Force
+        $candidatePath = [string]$candidate.Path
+        $parent = Split-Path -Parent $candidatePath
+        if ((Test-Path -LiteralPath $candidatePath) -and
+            (-not $candidate.ManagedParent -or
+              (Test-TrustedManagedParent $parent $userIdentity)) -and
+            (Test-TrustedCache $candidatePath $canonicalRoot $userIdentity)) {
+          Remove-Item -LiteralPath $candidatePath -Recurse -Force
+          if ($candidate.ManagedParent) {
+            Remove-EmptyManagedParent $parent $userIdentity
+          }
+        }
+        elseif ($candidate.ManagedParent -and (Test-Path -LiteralPath $parent)) {
+          # A prior cleanup may have removed the child but lost a race or lock while removing the now
+          # marker-only parent. Revalidate it and retry the same non-recursive empty-parent cleanup.
+          Remove-EmptyManagedParent $parent $userIdentity
         }
       }
       catch {}

--- a/scripts/electron-builder-config.test.ts
+++ b/scripts/electron-builder-config.test.ts
@@ -4,7 +4,10 @@ import { join } from 'node:path'
 import { load } from 'js-yaml'
 import { describe, expect, it } from 'vitest'
 
-import { WINDOWS_CACHE_DANGEROUS_RIGHT_NAMES } from '../src/main/notebook/micromamba-cache'
+import {
+  WINDOWS_CACHE_DANGEROUS_RIGHT_NAMES,
+  WINDOWS_CACHE_TRUSTED_OWNER_SIDS
+} from '../src/main/notebook/micromamba-cache'
 
 describe('electron-builder native image processing', () => {
   it('ships sharp and its platform binary outside the ASAR archive', () => {
@@ -45,9 +48,22 @@ describe('electron-builder Windows targets', () => {
     expect(cleanup).toContain('.open-science-cache.json')
     expect(cleanup).toContain('Get-CompactCacheLeaf')
     expect(cleanup).toContain('$compactLeaf = Get-CompactCacheLeaf $canonicalRoot $userIdentity')
+    expect(cleanup).toContain('Get-WorkingCacheLeaf')
+    expect(cleanup).toContain('$workingLeaf = Get-WorkingCacheLeaf $canonicalRoot $userIdentity')
+    expect(cleanup).toContain('foreach ($configuredTemp in @($env:TEMP, $env:TMP))')
+    expect(cleanup).toContain("(Join-Path $configuredTemp 'OpenScienceTmp')")
+    expect(cleanup).toContain("(Join-Path $env:USERPROFILE 'os-tmp')")
+    expect(cleanup).toContain('Test-TrustedManagedParent')
+    expect(cleanup).toContain('Test-NoReparsePointInPath')
+    expect(cleanup).toContain("'.open-science-temp.json'")
+    expect(cleanup).toContain('$env:TMP')
+    expect(cleanup).toContain('$trustedOwnerSids -notcontains $ownerSid')
+    expect(cleanup).toContain('elseif ($candidate.ManagedParent')
     expect(cleanup).toContain('(Join-Path $env:PUBLIC $leaf)')
     expect(cleanup).toContain('(Join-Path $env:USERPROFILE $compactLeaf)')
-    expect(cleanup).toContain('S-1-5-32-544')
+    for (const sid of WINDOWS_CACHE_TRUSTED_OWNER_SIDS) {
+      expect(cleanup).toContain("'" + sid + "'")
+    }
     expect(cleanup).toContain('$trustedWriteSids -notcontains $sid')
     for (const right of WINDOWS_CACHE_DANGEROUS_RIGHT_NAMES) {
       expect(cleanup).toContain(`[System.Security.AccessControl.FileSystemRights]::${right}`)

--- a/scripts/windows-runtime-cache-uninstall.test.ts
+++ b/scripts/windows-runtime-cache-uninstall.test.ts
@@ -1,0 +1,265 @@
+import { spawnSync } from 'node:child_process'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, win32 } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { micromambaWorkingCachePaths } from '../src/main/notebook/micromamba-cache'
+
+type Fixture = {
+  sandbox: string
+  runtimeRoot: string
+  managedParent: string
+  cachePath: string
+  env: NodeJS.ProcessEnv
+  userIdentity: string
+}
+
+const roots: string[] = []
+
+const run = (executable: string, args: string[], env?: NodeJS.ProcessEnv): void => {
+  const result = spawnSync(executable, args, {
+    encoding: 'utf8',
+    env: env ?? process.env,
+    timeout: 30_000
+  })
+  if (result.status !== 0) {
+    throw new Error(
+      `${executable} exited with ${String(result.status)}: ${result.stderr || result.stdout}`
+    )
+  }
+}
+
+const runOutput = (executable: string, args: string[], env?: NodeJS.ProcessEnv): string => {
+  const result = spawnSync(executable, args, {
+    encoding: 'utf8',
+    env: env ?? process.env,
+    timeout: 30_000
+  })
+  if (result.status !== 0) {
+    throw new Error(
+      `${executable} exited with ${String(result.status)}: ${result.stderr || result.stdout}`
+    )
+  }
+  return result.stdout.trim()
+}
+
+const hardenDirectory = (path: string): void => {
+  const identity = [process.env.USERDOMAIN, process.env.USERNAME].filter(Boolean).join('\\')
+  if (!identity) throw new Error('Windows test identity is unavailable.')
+  run('icacls.exe', [
+    path,
+    '/inheritance:r',
+    '/grant:r',
+    `${identity}:(OI)(CI)F`,
+    '*S-1-5-18:(OI)(CI)F',
+    '*S-1-5-32-544:(OI)(CI)F'
+  ])
+}
+
+const makeFixture = (): Fixture => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'open-science-uninstall-cache-'))
+  roots.push(sandbox)
+  const profile = join(sandbox, 'profile')
+  const dataRoot = join(sandbox, 'data')
+  const runtimeRoot = join(dataRoot, 'runtime')
+  const configuredTemp = join(sandbox, 'temp')
+  const configuredTmp = join(sandbox, 'tmp')
+  mkdirSync(runtimeRoot, { recursive: true })
+  mkdirSync(configuredTemp)
+  mkdirSync(configuredTmp)
+  mkdirSync(join(profile, '.open-science'), { recursive: true })
+  writeFileSync(
+    join(profile, '.open-science', 'settings.json'),
+    `${JSON.stringify({ dataRoot })}\n`
+  )
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    USERPROFILE: profile,
+    TEMP: configuredTemp,
+    TMP: configuredTmp,
+    PUBLIC: '',
+    PSModulePath: [
+      process.env.ProgramFiles
+        ? join(process.env.ProgramFiles, 'WindowsPowerShell', 'Modules')
+        : undefined,
+      process.env.SystemRoot
+        ? join(process.env.SystemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'Modules')
+        : undefined
+    ]
+      .filter(Boolean)
+      .join(';')
+  }
+  const userIdentity = [env.USERDOMAIN, env.USERNAME].filter(Boolean).join('\\')
+  const managedParent = join(configuredTemp, 'OpenScienceTmp')
+  const cachePath = micromambaWorkingCachePaths(runtimeRoot, {
+    platform: 'win32',
+    env
+  }).find(
+    (candidate) =>
+      win32
+        .dirname(candidate)
+        .localeCompare(managedParent, undefined, { sensitivity: 'accent' }) === 0
+  )
+  if (!cachePath || !userIdentity) throw new Error('Could not resolve the Windows cache fixture.')
+  return { sandbox, runtimeRoot, managedParent, cachePath, env, userIdentity }
+}
+
+const writeParentMarker = (fixture: Fixture): void => {
+  mkdirSync(fixture.managedParent, { recursive: true })
+  writeFileSync(
+    join(fixture.managedParent, '.open-science-temp.json'),
+    `${JSON.stringify({
+      schema: 1,
+      kind: 'micromamba-working-cache-parent',
+      userIdentity: fixture.userIdentity
+    })}\n`
+  )
+  hardenDirectory(fixture.managedParent)
+}
+
+const writeCache = (
+  fixture: Fixture,
+  canonicalRoot = realpathSync.native(fixture.runtimeRoot)
+): void => {
+  mkdirSync(fixture.cachePath, { recursive: true })
+  writeFileSync(
+    join(fixture.cachePath, '.open-science-cache.json'),
+    `${JSON.stringify({
+      schema: 1,
+      canonicalRoot: canonicalRoot.toLowerCase(),
+      userIdentity: fixture.userIdentity
+    })}\n`
+  )
+  writeFileSync(join(fixture.cachePath, 'payload.bin'), 'cache payload')
+  hardenDirectory(fixture.cachePath)
+}
+
+const runUninstaller = (fixture: Fixture): void => {
+  const systemRoot = process.env.SystemRoot
+  if (!systemRoot) throw new Error('SystemRoot is unavailable.')
+  run(
+    join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'),
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      join(process.cwd(), 'build', 'windows-runtime-cache-uninstall.ps1')
+    ],
+    fixture.env
+  )
+}
+
+const inspectTrust = (fixture: Fixture): string => {
+  const systemRoot = process.env.SystemRoot
+  if (!systemRoot) throw new Error('SystemRoot is unavailable.')
+  const script = join(process.cwd(), 'build', 'windows-runtime-cache-uninstall.ps1').replace(
+    /'/g,
+    "''"
+  )
+  const parent = fixture.managedParent.replace(/'/g, "''")
+  const cache = fixture.cachePath.replace(/'/g, "''")
+  const runtimeRoot = realpathSync.native(fixture.runtimeRoot).replace(/'/g, "''")
+  const identity = fixture.userIdentity.replace(/'/g, "''")
+  return runOutput(
+    join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'),
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-Command',
+      `. '${script}' -LoadFunctionsOnly; [pscustomobject]@{ Parent = (Test-TrustedManagedParent '${parent}' '${identity}'); Cache = (Test-TrustedCache '${cache}' '${runtimeRoot}' '${identity}'); Leaf = (Get-WorkingCacheLeaf '${runtimeRoot}' '${identity}') } | ConvertTo-Json -Compress`
+    ],
+    fixture.env
+  )
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe.skipIf(process.platform !== 'win32')('Windows runtime cache uninstaller', () => {
+  it('removes a marker-owned working cache and its empty managed parent idempotently', () => {
+    const fixture = makeFixture()
+    writeParentMarker(fixture)
+    writeCache(fixture)
+
+    expect(JSON.parse(inspectTrust(fixture))).toEqual({
+      Parent: true,
+      Cache: true,
+      Leaf: win32.basename(fixture.cachePath)
+    })
+
+    runUninstaller(fixture)
+
+    expect(existsSync(fixture.cachePath)).toBe(false)
+    expect(existsSync(fixture.managedParent)).toBe(false)
+    expect(() => runUninstaller(fixture)).not.toThrow()
+  })
+
+  it('retries removal of a marker-only managed parent left by an interrupted cleanup', () => {
+    const fixture = makeFixture()
+    writeParentMarker(fixture)
+
+    runUninstaller(fixture)
+
+    expect(existsSync(fixture.managedParent)).toBe(false)
+  })
+
+  it('preserves a cache whose ownership marker does not match the runtime root', () => {
+    const fixture = makeFixture()
+    writeParentMarker(fixture)
+    writeCache(fixture, join(fixture.sandbox, 'foreign-runtime'))
+
+    runUninstaller(fixture)
+
+    expect(existsSync(join(fixture.cachePath, 'payload.bin'))).toBe(true)
+    expect(existsSync(fixture.managedParent)).toBe(true)
+  })
+
+  it('preserves a marker-matching cache that grants a foreign principal write access', () => {
+    const fixture = makeFixture()
+    writeParentMarker(fixture)
+    writeCache(fixture)
+    run('icacls.exe', [fixture.cachePath, '/grant', '*S-1-1-0:(OI)(CI)M'])
+
+    expect(JSON.parse(inspectTrust(fixture))).toEqual({
+      Parent: true,
+      Cache: false,
+      Leaf: win32.basename(fixture.cachePath)
+    })
+
+    runUninstaller(fixture)
+
+    expect(existsSync(join(fixture.cachePath, 'payload.bin'))).toBe(true)
+    expect(existsSync(fixture.managedParent)).toBe(true)
+  })
+
+  it('preserves a reparse-point cache and its target', () => {
+    const fixture = makeFixture()
+    writeParentMarker(fixture)
+    const target = join(fixture.sandbox, 'foreign-target')
+    mkdirSync(target)
+    writeFileSync(join(target, 'payload.bin'), 'foreign payload')
+    symlinkSync(target, fixture.cachePath, 'junction')
+
+    runUninstaller(fixture)
+
+    expect(existsSync(fixture.cachePath)).toBe(true)
+    expect(existsSync(join(target, 'payload.bin'))).toBe(true)
+    expect(existsSync(fixture.managedParent)).toBe(true)
+  })
+})

--- a/src/main/notebook/kernel-executor.test.ts
+++ b/src/main/notebook/kernel-executor.test.ts
@@ -2819,6 +2819,25 @@ describe('NotebookKernelExecutor spawn env', () => {
     expect(buildEnv('repl', request, '/tmp/figs').OPEN_SCIENCE_HANDOFF_DIR).toBe(expected)
   })
 
+  it('projects cache-only Data Storage paths for every kernel language', () => {
+    const executor = new NotebookKernelExecutor({ pythonLoopPath: FIXTURE })
+    const request = { ...baseRequest('/tmp/os-cache-env'), code: 'x' }
+    const buildEnv = (executor as unknown as { buildEnv: BuildEnvFn }).buildEnv.bind(executor)
+    const cacheRoot = join(request.runtimeRoot, 'cache', 'notebook')
+
+    for (const kind of ['python', 'r', 'repl'] as const) {
+      expect(buildEnv(kind, request, '/tmp/figs')).toMatchObject({
+        OPEN_SCIENCE_NOTEBOOK_CACHE_DIR: cacheRoot,
+        PIP_CACHE_DIR: join(cacheRoot, 'pip'),
+        UV_CACHE_DIR: join(cacheRoot, 'uv'),
+        HF_HUB_CACHE: join(cacheRoot, 'huggingface', 'hub'),
+        HF_XET_CACHE: join(cacheRoot, 'huggingface', 'xet'),
+        HF_ASSETS_CACHE: join(cacheRoot, 'huggingface', 'assets'),
+        TORCH_HOME: join(cacheRoot, 'torch')
+      })
+    }
+  })
+
   it('gives the repl kernel ELECTRON_RUN_AS_NODE plus the connector RPC endpoint/token', () => {
     const executor = new NotebookKernelExecutor({ replLoopPath: '/tmp/repl_loop.js' })
     const request = {

--- a/src/main/notebook/kernel-executor.ts
+++ b/src/main/notebook/kernel-executor.ts
@@ -21,6 +21,10 @@ import {
 import { mapLoopOutputs, type MappedFigure } from './loop-output-mapper'
 import { protectManagedRuntimeWrites } from './managed-runtime-guard'
 import {
+  notebookWorkloadCacheEnv,
+  prepareNotebookWorkloadCache
+} from './notebook-workload-cache-paths'
+import {
   condaActivatedPath,
   DEFAULT_PY_ENV,
   DEFAULT_R_ENV,
@@ -731,10 +735,11 @@ class NotebookKernelExecutor implements NotebookExecutor {
     request: NotebookExecutionRequest
   ): Promise<ChildProcessWithoutNullStreams> {
     const figuresDir = this.ensureFiguresDir()
+    const workloadCacheEnv = prepareNotebookWorkloadCache(request.runtimeRoot)
     // A missing session dir would surface as an opaque ENOENT; fall back to the OS default cwd so
     // spawn fails only for a genuinely missing interpreter.
     const spawnCwd = existsSync(request.cwd) ? request.cwd : undefined
-    const spawnEnv = this.buildEnv(kind, request, figuresDir)
+    const spawnEnv = this.buildEnv(kind, request, figuresDir, workloadCacheEnv)
     const prefix = envPrefix(request.runtimeRoot, env)
 
     let command: string
@@ -756,9 +761,10 @@ class NotebookKernelExecutor implements NotebookExecutor {
     }
 
     // The semantic guard rejects known installers before dispatch. This native layer makes the
-    // app-owned runtime read-only to the complete persistent-kernel process tree as well, covering
-    // dynamically constructed R/Python/REPL calls. manage_packages runs in the main process outside
-    // this wrapper and remains the only package writer.
+    // managed runtime state read-only to the complete persistent-kernel process tree as well, covering
+    // dynamically constructed R/Python/REPL calls. Only the disposable workload-cache subtree remains
+    // writable; manage_packages runs in the main process outside this wrapper and remains the only
+    // package writer.
     const invocation = protectManagedRuntimeWrites(
       { executable: command, args },
       request.runtimeRoot,
@@ -778,7 +784,8 @@ class NotebookKernelExecutor implements NotebookExecutor {
   private buildEnv(
     kind: KernelProcessKind,
     request: NotebookExecutionRequest,
-    figuresDir: string
+    figuresDir: string,
+    workloadCacheEnv: NodeJS.ProcessEnv = notebookWorkloadCacheEnv(request.runtimeRoot)
   ): NodeJS.ProcessEnv {
     // A resolved interpreter is user-owned (BYO/overlay). Never put app-managed conda DLLs ahead of
     // it: on Windows that can load an incompatible BLAS/compiler runtime into the external R process.
@@ -793,6 +800,7 @@ class NotebookKernelExecutor implements NotebookExecutor {
           : envPrefix(request.runtimeRoot, resolveRequestEnv(kind, request))
     const env: NodeJS.ProcessEnv = {
       ...process.env,
+      ...workloadCacheEnv,
       // Force a non-interactive matplotlib backend so plt.show() never opens a GUI window in this
       // headless runtime; respect an explicitly configured backend if present.
       MPLBACKEND: process.env.MPLBACKEND || 'Agg',

--- a/src/main/notebook/managed-runtime-guard.test.ts
+++ b/src/main/notebook/managed-runtime-guard.test.ts
@@ -1,4 +1,5 @@
-import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
+import { spawnSync } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, rm, stat, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { performance } from 'node:perf_hooks'
@@ -277,10 +278,51 @@ describe('protectManagedRuntimeWrites', () => {
     expect(protectedInvocation.args[1]).toContain(
       '(deny file-write* (literal "/tmp/open-science/runtime"))'
     )
+    expect(protectedInvocation.args[1]).toContain('(subpath "/tmp/open-science/runtime")')
     expect(protectedInvocation.args[1]).toContain(
-      '(deny file-write* (subpath "/tmp/open-science/runtime"))'
+      '(require-not (literal "/tmp/open-science/runtime/cache/notebook"))'
+    )
+    expect(protectedInvocation.args[1]).toContain(
+      '(require-not (subpath "/tmp/open-science/runtime/cache/notebook"))'
     )
   })
+
+  it.skipIf(process.platform !== 'darwin')(
+    'allows the workload cache while keeping the rest of runtime read-only on macOS',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'open-science-seatbelt-cache-'))
+      const runtimeRoot = join(root, 'runtime')
+      const cacheRoot = join(runtimeRoot, 'cache', 'notebook')
+      const cacheFile = join(cacheRoot, 'allowed.txt')
+      const blockedFile = join(runtimeRoot, 'blocked.txt')
+      await mkdir(cacheRoot, { recursive: true })
+
+      try {
+        const invocation = protectManagedRuntimeWrites(
+          {
+            executable: '/bin/sh',
+            args: [
+              '-c',
+              'printf cache > "$1"; printf blocked > "$2"',
+              'open-science-seatbelt-test',
+              cacheFile,
+              blockedFile
+            ]
+          },
+          runtimeRoot,
+          'darwin'
+        )
+        const result = spawnSync(invocation.executable, invocation.args, { encoding: 'utf8' })
+
+        expect(result.status).not.toBe(0)
+        expect(result.stderr).toMatch(/Operation not permitted/)
+        expect(await readFile(cacheFile, 'utf8')).toBe('cache')
+        await expect(stat(blockedFile)).rejects.toMatchObject({ code: 'ENOENT' })
+      } finally {
+        await rm(root, { recursive: true, force: true })
+      }
+    }
+  )
 
   it('leaves the invocation unchanged where no native sandbox adapter exists', () => {
     expect(protectManagedRuntimeWrites(invocation, '/tmp/open-science/runtime', 'linux')).toBe(

--- a/src/main/notebook/managed-runtime-guard.ts
+++ b/src/main/notebook/managed-runtime-guard.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer'
 import { realpathSync } from 'node:fs'
-import { basename, dirname, isAbsolute, relative, resolve, sep } from 'node:path'
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 import type { NotebookLanguage } from '../../shared/notebook'
 
@@ -1157,9 +1157,11 @@ const seatbeltString = (value: string): string => JSON.stringify(value)
 
 // macOS Seatbelt is the hard filesystem layer beneath the semantic policy above. It applies to the
 // whole child process tree, so dynamically constructed paths and nested R/Python/subprocess writers
-// cannot modify the app-owned runtime. The trusted main-process package manager is spawned outside
-// this wrapper and remains the only writer. Other platforms still use the main-process policy; their
-// native process-sandbox adapters can be added at this same seam without changing callers.
+// cannot modify managed runtime state. The sole writable exception is the marker-owned workload-cache
+// subtree, which contains disposable third-party cache data rather than environments or app metadata.
+// The trusted main-process package manager is spawned outside this wrapper and remains the only managed
+// runtime writer. Other platforms still use the main-process policy; their native process-sandbox
+// adapters can be added at this same seam without changing callers.
 export const protectManagedRuntimeWrites = (
   invocation: RuntimeProcessInvocation,
   runtimeRoot: string,
@@ -1180,7 +1182,10 @@ export const protectManagedRuntimeWrites = (
     '(allow default)',
     ...protectedRoots.flatMap((root) => [
       `(deny file-write* (literal ${seatbeltString(root)}))`,
-      `(deny file-write* (subpath ${seatbeltString(root)}))`
+      `(deny file-write* (require-all`,
+      `  (subpath ${seatbeltString(root)})`,
+      `  (require-not (literal ${seatbeltString(join(root, 'cache', 'notebook'))}))`,
+      `  (require-not (subpath ${seatbeltString(join(root, 'cache', 'notebook'))}))))`
     ])
   ].join('\n')
 

--- a/src/main/notebook/micromamba-archive-store.test.ts
+++ b/src/main/notebook/micromamba-archive-store.test.ts
@@ -1,0 +1,223 @@
+import { createHash } from 'node:crypto'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  archiveAuthorizationsFromCondaResult,
+  archiveAuthorizationsFromExplicitLock,
+  publishMicromambaArchives,
+  type MicromambaArchiveAuthorization
+} from './micromamba-archive-store'
+
+const roots: string[] = []
+
+const authorization = (
+  file: string,
+  contents: string,
+  algorithm: MicromambaArchiveAuthorization['algorithm'] = 'sha256'
+): MicromambaArchiveAuthorization => ({
+  file,
+  algorithm,
+  digest: createHash(algorithm).update(contents).digest('hex')
+})
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('publishMicromambaArchives', () => {
+  it('derives archive authority from explicit locks and structured transaction results', () => {
+    const md5 = createHash('md5').update('a').digest('hex')
+    const sha256 = createHash('sha256').update('b').digest('hex')
+
+    expect(
+      archiveAuthorizationsFromExplicitLock(
+        `@EXPLICIT\nhttps://conda.example/win-64/a-1.tar.bz2#${md5}\n`
+      )
+    ).toEqual([{ file: 'a-1.tar.bz2', algorithm: 'md5', digest: md5 }])
+    expect(
+      archiveAuthorizationsFromCondaResult({
+        actions: { FETCH: [{ fn: 'b-1.conda', sha256 }] }
+      })
+    ).toEqual([{ file: 'b-1.conda', algorithm: 'sha256', digest: sha256 }])
+  })
+
+  it('publishes nested package archives into the durable data-root store', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'os-mm-archive-'))
+    roots.push(root)
+    const runtimeRoot = join(root, 'OpenScience', 'runtime')
+    const workingRoot = join(root, 'OpenScienceTmp', 'm-test')
+    await mkdir(join(workingRoot, 'https', 'conda.example', 'win-64'), { recursive: true })
+    await writeFile(join(workingRoot, 'https', 'conda.example', 'win-64', 'a-1.conda'), 'a')
+    await writeFile(join(workingRoot, 'b-1.tar.bz2'), 'b')
+    await writeFile(join(workingRoot, 'injected-1.conda'), 'malicious')
+    await writeFile(join(workingRoot, 'tampered-1.conda'), 'malicious')
+    await writeFile(join(workingRoot, 'repodata.json'), 'ignored')
+
+    await expect(
+      publishMicromambaArchives(runtimeRoot, workingRoot, [
+        authorization('a-1.conda', 'a'),
+        authorization('b-1.tar.bz2', 'b', 'md5')
+      ])
+    ).resolves.toBe(2)
+
+    expect(await readFile(join(runtimeRoot, 'pkgs', 'a-1.conda'), 'utf8')).toBe('a')
+    expect(await readFile(join(runtimeRoot, 'pkgs', 'b-1.tar.bz2'), 'utf8')).toBe('b')
+    await expect(readFile(join(runtimeRoot, 'pkgs', 'injected-1.conda'))).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+    await expect(readFile(join(runtimeRoot, 'pkgs', 'tampered-1.conda'))).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+  })
+
+  it('retains publication evidence when an authorized archive is missing or tampered', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'os-mm-archive-incomplete-'))
+    roots.push(root)
+    const runtimeRoot = join(root, 'runtime')
+    const workingRoot = join(root, 'working')
+    await mkdir(workingRoot)
+    await writeFile(join(workingRoot, 'tampered-1.conda'), 'malicious')
+
+    await expect(
+      publishMicromambaArchives(runtimeRoot, workingRoot, [
+        authorization('tampered-1.conda', 'trusted')
+      ])
+    ).rejects.toThrow(/unavailable|verification/i)
+    await expect(readFile(join(runtimeRoot, 'pkgs', 'tampered-1.conda'))).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+  })
+
+  it('accepts an absent recovered source after every authorized archive is durable', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'os-mm-archive-durable-'))
+    roots.push(root)
+    const runtimeRoot = join(root, 'runtime')
+    const workingRoot = join(root, 'removed-working-cache')
+    const expected = authorization('a-1.conda', 'trusted')
+    await mkdir(join(runtimeRoot, 'pkgs'), { recursive: true })
+    await writeFile(join(runtimeRoot, 'pkgs', expected.file), 'trusted')
+
+    await expect(publishMicromambaArchives(runtimeRoot, workingRoot, [expected])).resolves.toBe(0)
+  })
+
+  it('revalidates the source only when durable archives are still missing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'os-mm-archive-revalidate-'))
+    roots.push(root)
+    const runtimeRoot = join(root, 'runtime')
+    const workingRoot = join(root, 'working')
+    const validateWorkingRoot = vi.fn().mockReturnValue(false)
+
+    await expect(
+      publishMicromambaArchives(
+        runtimeRoot,
+        workingRoot,
+        [authorization('a-1.conda', 'trusted')],
+        undefined,
+        validateWorkingRoot
+      )
+    ).rejects.toThrow(/trust validation/i)
+    expect(validateWorkingRoot).toHaveBeenCalledOnce()
+  })
+
+  it('aborts when the validated root identity changes during traversal', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'os-mm-archive-traversal-'))
+    roots.push(root)
+    const runtimeRoot = join(root, 'runtime')
+    const workingRoot = join(root, 'working')
+    await mkdir(workingRoot)
+    await writeFile(join(workingRoot, 'a-1.conda'), 'trusted')
+    const validateWorkingRoot = vi
+      .fn()
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+
+    await expect(
+      publishMicromambaArchives(
+        runtimeRoot,
+        workingRoot,
+        [authorization('a-1.conda', 'trusted')],
+        undefined,
+        validateWorkingRoot
+      )
+    ).rejects.toThrow(/changed during archive traversal/i)
+    expect(validateWorkingRoot).toHaveBeenCalledTimes(3)
+  })
+
+  it('refuses to overwrite a conflicting durable archive', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'os-mm-archive-conflict-'))
+    roots.push(root)
+    const runtimeRoot = join(root, 'runtime')
+    const workingRoot = join(root, 'working')
+    await mkdir(join(runtimeRoot, 'pkgs'), { recursive: true })
+    await mkdir(workingRoot)
+    await writeFile(join(runtimeRoot, 'pkgs', 'a-1.conda'), 'trusted')
+    await writeFile(join(workingRoot, 'a-1.conda'), 'different')
+
+    await expect(
+      publishMicromambaArchives(runtimeRoot, workingRoot, [
+        authorization('a-1.conda', 'different', 'md5')
+      ])
+    ).rejects.toThrow(/conflicts/i)
+    expect(await readFile(join(runtimeRoot, 'pkgs', 'a-1.conda'), 'utf8')).toBe('trusted')
+  })
+
+  it('does not trust mutable environment metadata', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'os-mm-archive-untrusted-'))
+    roots.push(root)
+    const runtimeRoot = join(root, 'runtime')
+    const workingRoot = join(root, 'working')
+    const prefix = join(runtimeRoot, 'envs', 'default-python')
+    await mkdir(workingRoot, { recursive: true })
+    await mkdir(join(prefix, 'conda-meta'), { recursive: true })
+    await writeFile(join(workingRoot, 'injected-1.conda'), 'malicious')
+    await writeFile(
+      join(prefix, 'conda-meta', 'injected-1.json'),
+      JSON.stringify({
+        fn: 'injected-1.conda',
+        sha256: createHash('sha256').update('malicious').digest('hex')
+      })
+    )
+
+    await expect(publishMicromambaArchives(runtimeRoot, workingRoot, [])).resolves.toBe(0)
+    await expect(readFile(join(runtimeRoot, 'pkgs', 'injected-1.conda'))).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+  })
+
+  it('rejects conflicting transaction authorizations', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'os-mm-archive-auth-conflict-'))
+    roots.push(root)
+    const runtimeRoot = join(root, 'runtime')
+    const workingRoot = join(root, 'working')
+    await mkdir(workingRoot)
+    await writeFile(join(workingRoot, 'a-1.conda'), 'a')
+
+    await expect(
+      publishMicromambaArchives(runtimeRoot, workingRoot, [
+        authorization('a-1.conda', 'a'),
+        authorization('a-1.conda', 'different')
+      ])
+    ).rejects.toThrow(/authorizations conflict/i)
+  })
+
+  it('accepts equivalent MD5 and SHA-256 authority for the same archive', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'os-mm-archive-multi-digest-'))
+    roots.push(root)
+    const runtimeRoot = join(root, 'runtime')
+    const workingRoot = join(root, 'working')
+    await mkdir(workingRoot)
+    await writeFile(join(workingRoot, 'a-1.conda'), 'a')
+
+    await expect(
+      publishMicromambaArchives(runtimeRoot, workingRoot, [
+        authorization('a-1.conda', 'a', 'md5'),
+        authorization('a-1.conda', 'a', 'sha256')
+      ])
+    ).resolves.toBe(1)
+    expect(await readFile(join(runtimeRoot, 'pkgs', 'a-1.conda'), 'utf8')).toBe('a')
+  })
+})

--- a/src/main/notebook/micromamba-archive-store.ts
+++ b/src/main/notebook/micromamba-archive-store.ts
@@ -1,0 +1,269 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { createReadStream } from 'node:fs'
+import { copyFile, lstat, mkdir, readdir, realpath, rename, rm, stat } from 'node:fs/promises'
+import { basename, isAbsolute, join, relative, sep } from 'node:path'
+
+import { withExclusiveCacheLock } from './pkgs-cache-lock'
+import { pkgsCache } from './runtime-paths'
+
+const isPackageArchive = (path: string): boolean => /\.(?:conda|tar\.bz2)$/i.test(path)
+
+export type MicromambaArchiveAuthorization = {
+  file: string
+  algorithm: 'md5' | 'sha256'
+  digest: string
+}
+
+const archiveFileName = (record: Record<string, unknown>): string | undefined => {
+  if (typeof record.fn === 'string') return record.fn
+  if (typeof record.url !== 'string') return undefined
+  try {
+    return basename(new URL(record.url).pathname)
+  } catch {
+    return undefined
+  }
+}
+
+const digestFile = (
+  path: string,
+  algorithm: MicromambaArchiveAuthorization['algorithm']
+): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const hash = createHash(algorithm)
+    const stream = createReadStream(path)
+    stream.on('error', reject)
+    stream.on('data', (chunk) => hash.update(chunk))
+    stream.on('end', () => resolve(hash.digest('hex')))
+  })
+
+const authorizationFromRecord = (
+  record: Record<string, unknown>
+): MicromambaArchiveAuthorization | undefined => {
+  if (
+    typeof record.file === 'string' &&
+    basename(record.file) === record.file &&
+    isPackageArchive(record.file) &&
+    record.algorithm === 'sha256' &&
+    typeof record.digest === 'string' &&
+    /^[0-9a-f]{64}$/i.test(record.digest)
+  ) {
+    return { file: record.file, algorithm: 'sha256', digest: record.digest.toLowerCase() }
+  }
+  if (
+    typeof record.file === 'string' &&
+    basename(record.file) === record.file &&
+    isPackageArchive(record.file) &&
+    record.algorithm === 'md5' &&
+    typeof record.digest === 'string' &&
+    /^[0-9a-f]{32}$/i.test(record.digest)
+  ) {
+    return { file: record.file, algorithm: 'md5', digest: record.digest.toLowerCase() }
+  }
+  const file = archiveFileName(record)
+  if (!file || basename(file) !== file || !isPackageArchive(file)) return undefined
+  if (typeof record.sha256 === 'string' && /^[0-9a-f]{64}$/i.test(record.sha256)) {
+    return { file, algorithm: 'sha256', digest: record.sha256.toLowerCase() }
+  }
+  if (typeof record.md5 === 'string' && /^[0-9a-f]{32}$/i.test(record.md5)) {
+    return { file, algorithm: 'md5', digest: record.md5.toLowerCase() }
+  }
+  return undefined
+}
+
+export const archiveAuthorizationsFromCondaResult = (
+  value: unknown
+): MicromambaArchiveAuthorization[] => {
+  const authorizations: MicromambaArchiveAuthorization[] = []
+  const visit = (nested: unknown): void => {
+    if (Array.isArray(nested)) {
+      nested.forEach(visit)
+      return
+    }
+    if (typeof nested !== 'object' || nested === null) return
+    const record = nested as Record<string, unknown>
+    const authorization = authorizationFromRecord(record)
+    if (authorization) authorizations.push(authorization)
+    Object.values(record).forEach(visit)
+  }
+  visit(value)
+  return authorizations
+}
+
+export const archiveAuthorizationsFromExplicitLock = (
+  lock: string
+): MicromambaArchiveAuthorization[] =>
+  lock
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .flatMap((line) => {
+      const match = /^(https?:\/\/[^#]+)#([0-9a-f]{32}|[0-9a-f]{64})$/iu.exec(line)
+      if (!match) return []
+      const file = basename(new URL(match[1]).pathname)
+      if (!file || !isPackageArchive(file)) return []
+      return [
+        {
+          file,
+          algorithm: match[2].length === 64 ? ('sha256' as const) : ('md5' as const),
+          digest: match[2].toLowerCase()
+        }
+      ]
+    })
+
+const trustedArchiveDigests = (
+  authorizations: readonly MicromambaArchiveAuthorization[]
+): Map<string, MicromambaArchiveAuthorization[]> => {
+  const trusted = new Map<string, MicromambaArchiveAuthorization[]>()
+  for (const authorization of authorizations) {
+    if (
+      basename(authorization.file) !== authorization.file ||
+      !isPackageArchive(authorization.file) ||
+      !new RegExp(
+        authorization.algorithm === 'sha256' ? '^[0-9a-f]{64}$' : '^[0-9a-f]{32}$',
+        'i'
+      ).test(authorization.digest)
+    ) {
+      continue
+    }
+    const normalized = { ...authorization, digest: authorization.digest.toLowerCase() }
+    const previous = trusted.get(normalized.file) ?? []
+    const sameAlgorithm = previous.find((entry) => entry.algorithm === normalized.algorithm)
+    if (sameAlgorithm && sameAlgorithm.digest !== normalized.digest) {
+      throw new Error(`package transaction authorizations conflict for ${normalized.file}`)
+    }
+    if (!sameAlgorithm) trusted.set(normalized.file, [...previous, normalized])
+  }
+  return trusted
+}
+
+const matchesAuthorizations = async (
+  path: string,
+  authorizations: readonly MicromambaArchiveAuthorization[]
+): Promise<boolean> => {
+  for (const authorization of authorizations) {
+    if ((await digestFile(path, authorization.algorithm)) !== authorization.digest) return false
+  }
+  return true
+}
+
+const isInsideOrEqual = (root: string, candidate: string): boolean => {
+  const nested = relative(root, candidate)
+  return nested === '' || (!isAbsolute(nested) && nested !== '..' && !nested.startsWith(`..${sep}`))
+}
+
+const archiveFiles = async (root: string, validateRoot?: () => boolean): Promise<string[]> => {
+  const files: string[] = []
+  if (validateRoot && !validateRoot()) {
+    throw new Error('Micromamba working cache changed before archive traversal.')
+  }
+  const physicalRoot = await realpath(root)
+  const visit = async (dir: string): Promise<void> => {
+    const before = await lstat(dir)
+    if (!before.isDirectory() || before.isSymbolicLink()) {
+      throw new Error('Micromamba working cache contains an untrusted directory link.')
+    }
+    const physicalDir = await realpath(dir)
+    if (!isInsideOrEqual(physicalRoot, physicalDir)) {
+      throw new Error('Micromamba working cache traversal escaped its validated root.')
+    }
+    let entries
+    try {
+      entries = await readdir(dir, { withFileTypes: true })
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+      throw error
+    }
+    if (validateRoot && !validateRoot()) {
+      throw new Error('Micromamba working cache changed during archive traversal.')
+    }
+    if ((await realpath(dir)) !== physicalDir) {
+      throw new Error('Micromamba working cache directory identity changed during traversal.')
+    }
+    for (const entry of entries) {
+      const path = join(dir, entry.name)
+      const state = await lstat(path)
+      if (state.isSymbolicLink()) {
+        throw new Error('Micromamba working cache contains an untrusted reparse entry.')
+      }
+      const physical = await realpath(path)
+      if (!isInsideOrEqual(physicalRoot, physical)) {
+        throw new Error('Micromamba working cache entry escaped its validated root.')
+      }
+      if (state.isDirectory()) await visit(path)
+      else if (state.isFile() && isPackageArchive(entry.name)) files.push(path)
+    }
+  }
+  await visit(root)
+  return files
+}
+
+export const publishMicromambaArchives = async (
+  runtimeRoot: string,
+  workingRoot: string,
+  authorizations: readonly MicromambaArchiveAuthorization[],
+  durableLockKey = pkgsCache(runtimeRoot),
+  validateWorkingRoot?: () => boolean
+): Promise<number> => {
+  const durableRoot = pkgsCache(runtimeRoot)
+  // Notebook processes can write the working cache, so its names and bytes are never authority.
+  // Only archives matching immutable main-process transaction/lock authorizations may cross into
+  // the durable package store used for offline rebuilds.
+  const trusted = trustedArchiveDigests(authorizations)
+  if (trusted.size === 0) return 0
+
+  await mkdir(durableRoot, { recursive: true })
+  return withExclusiveCacheLock(durableLockKey, async () => {
+    const missing: Array<[string, MicromambaArchiveAuthorization[]]> = []
+    for (const [file, expected] of trusted) {
+      const destination = join(durableRoot, file)
+      try {
+        const destinationState = await stat(destination)
+        if (!destinationState.isFile() || !(await matchesAuthorizations(destination, expected))) {
+          throw new Error(`durable package archive conflicts with ${file}`)
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+        missing.push([file, expected])
+      }
+    }
+    // Recovery can crash after removing one of several working roots but before clearing the shared
+    // journal record. If every authorized archive is already durable, an absent source is a completed
+    // publication, not permanent corruption; avoid traversing or trusting any source path in this case.
+    if (missing.length === 0) return 0
+    if (validateWorkingRoot && !validateWorkingRoot()) {
+      throw new Error('Micromamba working cache failed recovery trust validation.')
+    }
+
+    const sourcesByFile = new Map<string, string[]>()
+    for (const source of await archiveFiles(workingRoot, validateWorkingRoot)) {
+      const file = basename(source)
+      sourcesByFile.set(file, [...(sourcesByFile.get(file) ?? []), source])
+    }
+    let published = 0
+    for (const [file, expected] of missing) {
+      const destination = join(durableRoot, file)
+      let source: string | undefined
+      for (const candidate of sourcesByFile.get(file) ?? []) {
+        if (await matchesAuthorizations(candidate, expected)) {
+          source = candidate
+          break
+        }
+      }
+      if (!source) {
+        throw new Error(`authorized package archive is unavailable or failed verification: ${file}`)
+      }
+
+      const temp = `${destination}.${process.pid}-${randomUUID()}.tmp`
+      try {
+        await copyFile(source, temp)
+        if (!(await matchesAuthorizations(temp, expected))) {
+          throw new Error(`copied package archive failed verification: ${file}`)
+        }
+        await rename(temp, destination)
+        published += 1
+      } finally {
+        await rm(temp, { force: true }).catch(() => undefined)
+      }
+    }
+    return published
+  })
+}

--- a/src/main/notebook/micromamba-cache-powershell.test.ts
+++ b/src/main/notebook/micromamba-cache-powershell.test.ts
@@ -48,7 +48,7 @@ describe('Windows micromamba cache PowerShell invocation', () => {
 
     expect(hardenWindowsCacheAcl('D:\\osp-cache')).toBe(true)
 
-    expect(childProcessMocks.execFileSync).toHaveBeenCalledTimes(4)
+    expect(childProcessMocks.execFileSync).toHaveBeenCalledTimes(3)
     expect(childProcessMocks.execFileSync).toHaveBeenNthCalledWith(
       2,
       'C:\\Windows\\System32\\whoami.exe',
@@ -57,12 +57,6 @@ describe('Windows micromamba cache PowerShell invocation', () => {
     )
     expect(childProcessMocks.execFileSync).toHaveBeenNthCalledWith(
       3,
-      'C:\\Windows\\System32\\icacls.exe',
-      ['D:\\osp-cache', '/setowner', '*S-1-5-21-1000'],
-      { encoding: 'utf8', windowsHide: true }
-    )
-    expect(childProcessMocks.execFileSync).toHaveBeenNthCalledWith(
-      4,
       'C:\\Windows\\System32\\icacls.exe',
       [
         'D:\\osp-cache',
@@ -76,7 +70,17 @@ describe('Windows micromamba cache PowerShell invocation', () => {
     )
   })
 
-  it('propagates owner update failures from the fallback ACL tool', () => {
+  it('propagates current-user SID lookup failures from the fallback ACL tool', () => {
+    childProcessMocks.execFileSync.mockReset()
+    childProcessMocks.execFileSync.mockImplementationOnce(() => {
+      throw new Error('whoami failed')
+    })
+
+    expect(() => hardenWindowsCacheAclWithIcacls('D:\\osp-cache')).toThrow('whoami failed')
+    expect(childProcessMocks.execFileSync).toHaveBeenCalledOnce()
+  })
+
+  it('propagates DACL update failures from the fallback ACL tool', () => {
     childProcessMocks.execFileSync.mockReset()
     childProcessMocks.execFileSync.mockReturnValueOnce('CONTOSO\\alice,S-1-5-21-1000\r\n')
     childProcessMocks.execFileSync.mockImplementationOnce(() => {
@@ -87,24 +91,13 @@ describe('Windows micromamba cache PowerShell invocation', () => {
     expect(childProcessMocks.execFileSync).toHaveBeenCalledTimes(2)
   })
 
-  it('propagates DACL update failures from the fallback ACL tool', () => {
-    childProcessMocks.execFileSync.mockReset()
-    childProcessMocks.execFileSync.mockReturnValueOnce('CONTOSO\\alice,S-1-5-21-1000\r\n')
-    childProcessMocks.execFileSync.mockReturnValueOnce('owner updated')
-    childProcessMocks.execFileSync.mockImplementationOnce(() => {
-      throw new Error('icacls failed')
-    })
-
-    expect(() => hardenWindowsCacheAclWithIcacls('D:\\osp-cache')).toThrow('icacls failed')
-    expect(childProcessMocks.execFileSync).toHaveBeenCalledTimes(3)
-  })
-
-  it('does not hide PowerShell script failures behind the fallback', () => {
+  it('uses the independent ACL fallback for non-permission PowerShell failures too', () => {
     childProcessMocks.execFileSync.mockImplementationOnce(() => {
       throw Object.assign(new Error('PowerShell command failed'), { code: 'UNKNOWN' })
     })
+    childProcessMocks.execFileSync.mockReturnValueOnce('CONTOSO\\alice,S-1-5-21-1000\r\n')
 
-    expect(() => hardenWindowsCacheAcl('D:\\osp-cache')).toThrow('PowerShell command failed')
-    expect(childProcessMocks.execFileSync).toHaveBeenCalledOnce()
+    expect(hardenWindowsCacheAcl('D:\\osp-cache')).toBe(true)
+    expect(childProcessMocks.execFileSync).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/main/notebook/micromamba-cache-preparation.test.ts
+++ b/src/main/notebook/micromamba-cache-preparation.test.ts
@@ -9,12 +9,15 @@ const fsMocks = vi.hoisted(() => {
     { native }
   )
   return {
+    existsSync: vi.fn(() => false),
     lstatSync: vi.fn(() => {
       throw Object.assign(new Error('missing'), { code: 'ENOENT' })
     }),
     mkdirSync: vi.fn(),
     readFileSync: vi.fn(),
+    readdirSync: vi.fn(() => []),
     realpathSync,
+    rmdirSync: vi.fn(),
     rmSync: vi.fn(),
     writeFileSync: vi.fn()
   }
@@ -50,9 +53,10 @@ describe('Windows micromamba cache preparation', () => {
       deps
     )
 
-    expect(cache.path).toMatch(/^D:\\osp[0-9a-f]{10}$/)
-    expect(hardenOwnership).toHaveBeenCalledOnce()
-    expect(hardenOwnership).toHaveBeenCalledWith(cache.path)
+    expect(cache.path).toMatch(/^D:\\OpenScienceTmp\\m-[0-9a-hjkmnp-tv-z]{8}$/)
+    expect(hardenOwnership).toHaveBeenCalledTimes(2)
+    expect(hardenOwnership).toHaveBeenNthCalledWith(1, 'D:\\OpenScienceTmp')
+    expect(hardenOwnership).toHaveBeenNthCalledWith(2, cache.path)
     expect(hardenOwnership.mock.invocationCallOrder[0]).toBeLessThan(
       fsMocks.writeFileSync.mock.invocationCallOrder[0]
     )
@@ -61,9 +65,9 @@ describe('Windows micromamba cache preparation', () => {
     )
   })
 
-  it('does not require a PowerShell ACL read after a new cache was securely hardened', () => {
+  it('verifies the shared parent but skips a second ACL read for a securely hardened cache child', () => {
     const hardenOwnership = vi.fn(() => true)
-    const verifyOwnership = vi.fn(() => false)
+    const verifyOwnership = vi.fn((path: string) => path === 'D:\\OpenScienceTmp')
 
     const cache = selectMicromambaCache(
       'D:\\OpenScience\\runtime',
@@ -77,9 +81,10 @@ describe('Windows micromamba cache preparation', () => {
       }
     )
 
-    expect(cache.path).toMatch(/^D:\\osp[0-9a-f]{10}$/)
-    expect(hardenOwnership).toHaveBeenCalledOnce()
-    expect(verifyOwnership).not.toHaveBeenCalled()
+    expect(cache.path).toMatch(/^D:\\OpenScienceTmp\\m-[0-9a-hjkmnp-tv-z]{8}$/)
+    expect(hardenOwnership).toHaveBeenCalledTimes(2)
+    expect(verifyOwnership).toHaveBeenCalledOnce()
+    expect(verifyOwnership).toHaveBeenCalledWith('D:\\OpenScienceTmp', 'alice')
   })
 
   it('removes newly created candidates when ACL hardening fails', () => {
@@ -95,23 +100,71 @@ describe('Windows micromamba cache preparation', () => {
         hardenOwnership,
         verifyOwnership: () => true
       })
-    ).toThrow(/cache ACL could not be hardened \(Set-Acl denied\)/)
+    ).toThrow(/temporary parent ACL could not be hardened \(Set-Acl denied\)/)
 
-    expect(hardenOwnership).toHaveBeenCalledTimes(3)
-    expect(fsMocks.rmSync).toHaveBeenCalledTimes(3)
-    for (const [path, options] of fsMocks.rmSync.mock.calls) {
-      expect(path).toMatch(/^(D:\\|C:\\Users\\alice\\)os/)
-      expect(options).toEqual({ recursive: true, force: true })
-    }
+    expect(hardenOwnership).toHaveBeenCalledTimes(2)
+    expect(fsMocks.rmdirSync).toHaveBeenCalledWith('D:\\OpenScienceTmp')
+    expect(fsMocks.rmdirSync).toHaveBeenCalledWith('C:\\Users\\alice\\os-tmp')
+    expect(fsMocks.rmSync).not.toHaveBeenCalledWith(
+      expect.stringMatching(/(?:OpenScienceTmp|os-tmp)$/),
+      expect.objectContaining({ recursive: true })
+    )
+  })
+
+  it('never recursively removes a newly created shared parent after a sibling appears', () => {
+    const hardenOwnership = vi
+      .fn<() => boolean>()
+      .mockReturnValueOnce(true)
+      .mockImplementationOnce(() => {
+        throw new Error('child ACL denied')
+      })
+      .mockReturnValue(true)
+    fsMocks.readFileSync.mockReturnValue(
+      JSON.stringify({
+        schema: 1,
+        kind: 'micromamba-working-cache-parent',
+        userIdentity: 'alice'
+      })
+    )
+    fsMocks.readdirSync.mockReturnValue([
+      '.open-science-temp.json' as never,
+      'm-concurrent' as never
+    ])
+
+    expect(() =>
+      selectMicromambaCache('D:\\OpenScience\\runtime', DEFAULT_MAX_CACHE_RELATIVE_PATH, {
+        platform: 'win32',
+        env: { USERNAME: 'alice', USERPROFILE: 'C:\\Users\\alice' },
+        canonicalize: (path) => win32.normalize(path),
+        hardenOwnership,
+        verifyOwnership: () => true
+      })
+    ).not.toThrow()
+
+    expect(fsMocks.rmSync).toHaveBeenCalledWith(expect.stringMatching(/^D:\\OpenScienceTmp\\m-/), {
+      recursive: true,
+      force: true
+    })
+    expect(fsMocks.rmSync).not.toHaveBeenCalledWith(
+      'D:\\OpenScienceTmp',
+      expect.objectContaining({ recursive: true })
+    )
+    expect(fsMocks.rmdirSync).not.toHaveBeenCalledWith('D:\\OpenScienceTmp')
   })
 
   it('does not harden or take over an existing marked candidate', () => {
-    fsMocks.lstatSync.mockImplementationOnce(
-      () =>
-        ({
-          isDirectory: () => true,
-          isSymbolicLink: () => false
-        }) as never
+    const directory = {
+      isDirectory: () => true,
+      isSymbolicLink: () => false
+    } as never
+    fsMocks.lstatSync.mockImplementationOnce(() => directory)
+    fsMocks.lstatSync.mockImplementationOnce(() => directory)
+    fsMocks.readFileSync.mockImplementationOnce(() =>
+      JSON.stringify({
+        schema: 1,
+        kind: 'micromamba-working-cache-parent',
+        userIdentity: 'alice'
+      })
     )
     fsMocks.readFileSync.mockImplementationOnce(() =>
       JSON.stringify({
@@ -134,11 +187,11 @@ describe('Windows micromamba cache preparation', () => {
       }
     )
 
-    expect(cache.path).toMatch(/^D:\\osp/)
+    expect(cache.path).toMatch(/^D:\\OpenScienceTmp\\m-/)
     expect(hardenOwnership).not.toHaveBeenCalled()
   })
 
-  it('rejects an untrusted existing cache before accepting a newly hardened fallback', () => {
+  it('rejects both an untrusted primary parent and an untrusted per-user fallback', () => {
     fsMocks.lstatSync.mockImplementationOnce(
       () =>
         ({
@@ -149,28 +202,27 @@ describe('Windows micromamba cache preparation', () => {
     fsMocks.readFileSync.mockImplementationOnce(() =>
       JSON.stringify({
         schema: 1,
-        canonicalRoot: 'd:\\openscience\\runtime',
+        kind: 'micromamba-working-cache-parent',
         userIdentity: 'alice'
       })
     )
     const hardenOwnership = vi.fn(() => true)
     const verifyOwnership = vi.fn(() => false)
 
-    const cache = selectMicromambaCache(
-      'D:\\OpenScience\\runtime',
-      DEFAULT_MAX_CACHE_RELATIVE_PATH,
-      {
+    expect(() =>
+      selectMicromambaCache('D:\\OpenScience\\runtime', DEFAULT_MAX_CACHE_RELATIVE_PATH, {
         platform: 'win32',
         env: { USERNAME: 'alice', USERPROFILE: 'C:\\Users\\alice' },
         canonicalize: (path) => win32.normalize(path),
         hardenOwnership,
         verifyOwnership
-      }
-    )
+      })
+    ).toThrow(/temporary parent ownership or permissions are not trusted/i)
 
-    expect(cache.path).toMatch(/^C:\\Users\\alice\\osp[0-9a-f]{10}$/)
-    expect(verifyOwnership).toHaveBeenCalledOnce()
+    // The third call is the fail-closed parent cleanup recheck; because it remains untrusted, the
+    // shared parent is preserved instead of being recursively removed.
+    expect(verifyOwnership).toHaveBeenCalledTimes(3)
     expect(hardenOwnership).toHaveBeenCalledOnce()
-    expect(hardenOwnership).toHaveBeenCalledWith(cache.path)
+    expect(hardenOwnership).toHaveBeenCalledWith('C:\\Users\\alice\\os-tmp')
   })
 })

--- a/src/main/notebook/micromamba-cache.test.ts
+++ b/src/main/notebook/micromamba-cache.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, symlinkSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, win32 } from 'node:path'
 
@@ -6,16 +6,24 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   DEFAULT_MAX_CACHE_RELATIVE_PATH,
+  isTrustedMicromambaWorkingCacheForRoot,
   isTrustedWindowsCacheAcl,
   micromambaCacheLockKey,
+  removeEmptyManagedParent,
   removeMicromambaCacheForRoot,
   selectMicromambaCache,
   WINDOWS_CACHE_DANGEROUS_RIGHT_NAMES,
-  WINDOWS_MAX_USABLE_PATH,
   windowsCacheAclHardeningScript,
   windowsCacheAclReadScript,
+  type MicromambaCacheCleanupDeps,
   type MicromambaCacheDeps
 } from './micromamba-cache'
+import {
+  finalizeRecoveredMicromambaWorkingCache,
+  managedNotebookWorkingCache,
+  retainMicromambaWorkingCache
+} from './windows-micromamba-working-cache'
+import { operationJournalPath, RuntimeOperationJournal } from './operation-journal'
 
 const windowsDeps = (overrides: Partial<MicromambaCacheDeps> = {}): MicromambaCacheDeps => ({
   platform: 'win32',
@@ -24,6 +32,19 @@ const windowsDeps = (overrides: Partial<MicromambaCacheDeps> = {}): MicromambaCa
   prepare: (path) => win32.normalize(path),
   verifyOwnership: () => true,
   ...overrides
+})
+
+describe('managedNotebookWorkingCache', () => {
+  it('exposes archive lifecycle capabilities only on Windows', () => {
+    expect(managedNotebookWorkingCache('linux')).toEqual({
+      finalizeWorkingCache: undefined,
+      retainWorkingCache: undefined
+    })
+    expect(managedNotebookWorkingCache('win32')).toEqual({
+      finalizeWorkingCache: expect.any(Function),
+      retainWorkingCache: expect.any(Function)
+    })
+  })
 })
 
 describe('selectMicromambaCache', () => {
@@ -59,69 +80,77 @@ describe('selectMicromambaCache', () => {
       windowsDeps()
     )
 
-    expect(first.path).toMatch(/^D:\\osp[0-9a-f]{10}$/)
+    expect(first.path).toMatch(/^D:\\OpenScienceTmp\\m-[0-9a-hjkmnp-tv-z]{8}$/)
     expect(repeated).toEqual(first)
     expect(otherRoot.path).not.toBe(first.path)
     expect(first.lockKey).toBe(first.path.toLowerCase())
   })
 
-  it('uses a trusted profile fallback when the volume-root candidate cannot be prepared', () => {
+  it('falls back to a per-user temporary directory when the volume root is not writable', () => {
     const prepare = vi.fn((path: string) =>
-      path.startsWith('D:\\') ? undefined : win32.normalize(path)
+      path.startsWith('D:\\') ? { rejection: 'volume root is not writable' } : path
     )
-    const selected = selectMicromambaCache(
+
+    const cache = selectMicromambaCache(
       'D:\\OpenScience\\runtime',
       DEFAULT_MAX_CACHE_RELATIVE_PATH,
       windowsDeps({
-        env: { USERNAME: 'alice', PUBLIC: 'C:\\Users\\Public', USERPROFILE: 'C:\\Users\\alice' },
-        prepare
-      })
-    )
-
-    expect(selected.path).toMatch(/^C:\\Users\\alice\\osp[0-9a-f]{10}$/)
-    expect(prepare).toHaveBeenCalledTimes(2)
-  })
-
-  it('uses a compact profile cache when the volume root is untrusted and the legacy leaf is too long', () => {
-    const prepare = vi.fn((path: string) =>
-      path.startsWith('E:\\') ? undefined : win32.normalize(path)
-    )
-    const selected = selectMicromambaCache(
-      'E:\\open science\\OpenScience\\runtime',
-      DEFAULT_MAX_CACHE_RELATIVE_PATH,
-      windowsDeps({
         env: {
-          USERNAME: 'peipeidamowang',
-          USERPROFILE: 'C:\\Users\\peipeidamowang'
+          USERNAME: 'alice',
+          USERPROFILE: 'C:\\Users\\alice',
+          TEMP: 'C:\\Users\\alice\\AppData\\Local\\Temp'
         },
         prepare
       })
     )
 
-    expect(selected.path).toMatch(/^C:\\Users\\peipeidamowang\\os[0-9a-hjkmnp-tv-z]{8}$/)
-    expect(selected.path.length + DEFAULT_MAX_CACHE_RELATIVE_PATH).toBe(WINDOWS_MAX_USABLE_PATH)
+    expect(cache.path).toMatch(/^C:\\Users\\alice\\os-tmp\\m-[0-9a-hjkmnp-tv-z]{8}$/)
     expect(prepare).toHaveBeenCalledTimes(2)
   })
 
-  it('uses the public directory when the runtime volume is untrusted and the profile path is too long', () => {
-    const prepare = vi.fn((path: string) =>
-      path.startsWith('E:\\') ? undefined : win32.normalize(path)
+  it('keeps the runtime-volume primary ahead of an existing per-user fallback', () => {
+    const prepare = vi.fn((path: string) => path)
+
+    const cache = selectMicromambaCache(
+      'D:\\OpenScience\\runtime',
+      DEFAULT_MAX_CACHE_RELATIVE_PATH,
+      windowsDeps({
+        exists: (path) => path.includes('\\os-tmp\\'),
+        prepare
+      })
     )
-    const selected = selectMicromambaCache(
-      'E:\\deeply\\nested\\storage\\OpenScience\\runtime',
+
+    expect(cache.path).toMatch(/^D:\\OpenScienceTmp\\m-[0-9a-hjkmnp-tv-z]{8}$/)
+    expect(prepare).toHaveBeenCalledOnce()
+    expect(prepare).toHaveBeenCalledWith(
+      expect.stringMatching(/^D:\\OpenScienceTmp\\m-/),
+      expect.any(Object)
+    )
+  })
+
+  it('tries TMP after an unusable TEMP before falling back to the user profile', () => {
+    const prepare = vi.fn((path: string) =>
+      path.startsWith('D:\\') || path.startsWith('C:\\Temp')
+        ? { rejection: 'candidate is unavailable' }
+        : path
+    )
+
+    const cache = selectMicromambaCache(
+      'D:\\OpenScience\\runtime',
       DEFAULT_MAX_CACHE_RELATIVE_PATH,
       windowsDeps({
         env: {
-          USERNAME: 'peipeidamowang',
-          PUBLIC: 'C:\\Users\\Public',
-          USERPROFILE: 'C:\\Users\\peipeidamowang-with-a-long-profile'
+          USERNAME: 'alice',
+          USERPROFILE: 'C:\\Users\\alice',
+          TEMP: 'C:\\Temp',
+          TMP: 'E:\\Tmp'
         },
         prepare
       })
     )
 
-    expect(selected.path).toMatch(/^C:\\Users\\Public\\osp[0-9a-f]{10}$/)
-    expect(prepare).toHaveBeenCalledTimes(2)
+    expect(cache.path).toMatch(/^E:\\Tmp\\OpenScienceTmp\\m-[0-9a-hjkmnp-tv-z]{8}$/)
+    expect(prepare).toHaveBeenCalledTimes(3)
   })
 
   it('rejects candidates that are writable but do not fit the actual pack budget', () => {
@@ -162,29 +191,12 @@ describe('selectMicromambaCache', () => {
     }
 
     expect(message).toContain('Candidate diagnostics:')
-    expect(message).toMatch(/E:\\osp[0-9a-f]{10}: ownership or permissions are not trusted/)
     expect(message).toMatch(
-      /C:\\Users\\peipeidamowang-with-a-long-profile\\osp[0-9a-f]{10}: exceeds the Windows path budget/
-    )
-    expect(message).toMatch(
-      /C:\\Users\\peipeidamowang-with-a-long-profile\\os[0-9a-hjkmnp-tv-z]{8}: exceeds the Windows path budget/
+      /E:\\OpenScienceTmp\\m-[0-9a-hjkmnp-tv-z]{8}: ownership or permissions are not trusted/
     )
     expect(message).not.toContain('unavailable, untrusted, or not writable')
     expect(message).not.toContain('restrict write access')
     expect(message).not.toMatch(/shorter data-root/i)
-  })
-
-  it('rejects an untrusted candidate and tries the profile location', () => {
-    const prepare = vi.fn((path: string) =>
-      path.startsWith('D:\\') ? undefined : win32.normalize(path)
-    )
-    const selected = selectMicromambaCache(
-      'D:\\OpenScience\\runtime',
-      DEFAULT_MAX_CACHE_RELATIVE_PATH,
-      windowsDeps({ prepare })
-    )
-
-    expect(selected.path).toContain('C:\\Users\\alice')
   })
 
   it('keeps non-Windows cache behavior unchanged', () => {
@@ -204,19 +216,13 @@ describe('selectMicromambaCache', () => {
   })
 
   it('rejects a cache whose OS ownership/trust boundary cannot be verified', () => {
-    const verifyOwnership = vi
-      .fn<(path: string, userIdentity: string) => boolean>()
-      .mockReturnValueOnce(false)
-      .mockReturnValueOnce(true)
-    const prepare = (path: string): string => win32.normalize(path)
-    const selected = selectMicromambaCache(
-      'D:\\OpenScience\\runtime',
-      DEFAULT_MAX_CACHE_RELATIVE_PATH,
-      windowsDeps({ prepare, verifyOwnership })
-    )
-
-    expect(selected.path).toMatch(/^C:\\Users\\alice\\osp[0-9a-f]{10}$/)
-    expect(verifyOwnership).toHaveBeenCalledTimes(2)
+    expect(() =>
+      selectMicromambaCache(
+        'D:\\OpenScience\\runtime',
+        DEFAULT_MAX_CACHE_RELATIVE_PATH,
+        windowsDeps({ verifyOwnership: () => false })
+      )
+    ).toThrow(/ownership or permissions are not trusted/i)
   })
 })
 
@@ -232,15 +238,28 @@ describe('removeMicromambaCacheForRoot', () => {
     canonicalRoot: root.toLowerCase(),
     userIdentity: 'alice'
   }
+  const inspectTrustedParent: NonNullable<MicromambaCacheCleanupDeps['inspectParent']> = (
+    path
+  ) => ({
+    directory: true,
+    symbolicLink: false,
+    physical: win32.normalize(path),
+    marker: {
+      schema: 1,
+      kind: 'micromamba-working-cache-parent',
+      userIdentity: 'alice'
+    }
+  })
 
   it('removes only a correctly marked and OS-owned cache', () => {
     const removed: string[] = []
     let inspected = 0
-    removeMicromambaCacheForRoot(root, {
+    const completed = removeMicromambaCacheForRoot(root, {
       platform: 'win32',
       env,
       canonicalize: (path) => win32.normalize(path),
       verifyOwnership: () => true,
+      inspectParent: inspectTrustedParent,
       inspect: () => ({
         directory: true,
         symbolicLink: false,
@@ -249,8 +268,9 @@ describe('removeMicromambaCacheForRoot', () => {
       remove: (path) => removed.push(path)
     })
 
+    expect(completed).toBe(true)
     expect(removed).toHaveLength(1)
-    expect(removed[0]).toMatch(/^D:\\osp[0-9a-f]{10}$/)
+    expect(removed[0]).toMatch(/^D:\\OpenScienceTmp\\m-[0-9a-hjkmnp-tv-z]{8}$/)
   })
 
   it('retains symlinked, unowned, and non-Windows candidates', () => {
@@ -261,6 +281,7 @@ describe('removeMicromambaCacheForRoot', () => {
       env,
       canonicalize: (path) => win32.normalize(path),
       verifyOwnership: () => false,
+      inspectParent: inspectTrustedParent,
       inspect: () => ({ directory: true, symbolicLink: inspected++ === 0, marker }),
       remove
     })
@@ -275,22 +296,676 @@ describe('removeMicromambaCacheForRoot', () => {
     expect(remove).not.toHaveBeenCalled()
   })
 
-  it('removes a correctly marked compact profile cache', () => {
+  it('removes both same-volume and per-user fallback candidates when they are owned', () => {
     const removed: string[] = []
     removeMicromambaCacheForRoot(root, {
       platform: 'win32',
       env,
       canonicalize: (path) => win32.normalize(path),
       verifyOwnership: () => true,
+      inspectParent: inspectTrustedParent,
       inspect: () => ({ directory: true, symbolicLink: false, marker }),
       remove: (path) => removed.push(path)
     })
 
-    expect(removed).toHaveLength(4)
-    expect(removed).toContainEqual(expect.stringMatching(/^C:\\Users\\Public\\osp[0-9a-f]{10}$/))
-    expect(removed).toContainEqual(
-      expect.stringMatching(/^C:\\Users\\alice\\os[0-9a-hjkmnp-tv-z]{8}$/)
+    expect(removed).toHaveLength(6)
+    expect(removed[0]).toMatch(/^D:\\OpenScienceTmp\\m-[0-9a-hjkmnp-tv-z]{8}$/)
+    expect(removed[1]).toMatch(/^C:\\Users\\alice\\os-tmp\\m-[0-9a-hjkmnp-tv-z]{8}$/)
+    expect(removed.slice(2)).toEqual([
+      expect.stringMatching(/^D:\\osp[0-9a-f]{10}$/),
+      expect.stringMatching(/^C:\\Users\\alice\\osp[0-9a-f]{10}$/),
+      expect.stringMatching(/^C:\\Users\\alice\\os[0-9a-hjkmnp-tv-z]{8}$/),
+      expect.stringMatching(/^C:\\Users\\Public\\osp[0-9a-f]{10}$/)
+    ])
+  })
+
+  it('refuses cleanup when the managed parent is linked or resolves elsewhere', () => {
+    const remove = vi.fn()
+    removeMicromambaCacheForRoot(root, {
+      platform: 'win32',
+      env,
+      canonicalize: (path) => win32.normalize(path),
+      verifyOwnership: () => true,
+      inspectParent: (path) => ({
+        ...inspectTrustedParent(path),
+        symbolicLink: path === 'D:\\OpenScienceTmp',
+        physical: path === 'C:\\Users\\alice\\os-tmp' ? 'C:\\Users\\alice\\unexpected-parent' : path
+      }),
+      inspect: (path) => ({
+        directory: true,
+        symbolicLink: false,
+        marker:
+          path.includes('\\OpenScienceTmp\\') || path.includes('\\os-tmp\\')
+            ? marker
+            : { ...marker, canonicalRoot: 'd:\\tampered' }
+      }),
+      remove
+    })
+
+    expect(remove).not.toHaveBeenCalled()
+  })
+
+  it('refuses per-user cleanup when the physical parent escapes its boundary', () => {
+    const remove = vi.fn()
+    removeMicromambaCacheForRoot(root, {
+      platform: 'win32',
+      env,
+      canonicalize: (path) => win32.normalize(path),
+      verifyOwnership: () => true,
+      inspectParent: (path) => ({
+        ...inspectTrustedParent(path),
+        physical: path === 'C:\\Users\\alice\\os-tmp' ? 'C:\\outside\\os-tmp' : path
+      }),
+      inspect: (path) => ({
+        directory: true,
+        symbolicLink: false,
+        marker: path.includes('\\os-tmp\\') ? marker : { ...marker, canonicalRoot: 'd:\\tampered' }
+      }),
+      remove
+    })
+
+    expect(remove).not.toHaveBeenCalled()
+  })
+
+  it('reports unexpected inspection failures so durable cleanup can be retried', () => {
+    expect(
+      removeMicromambaCacheForRoot(root, {
+        platform: 'win32',
+        env,
+        canonicalize: (path) => win32.normalize(path),
+        inspectParent: () => {
+          throw new Error('access denied')
+        }
+      })
+    ).toBe(false)
+  })
+})
+
+describe('removeEmptyManagedParent', () => {
+  const parent = 'D:\\OpenScienceTmp'
+  const raw = `${JSON.stringify({
+    schema: 1,
+    kind: 'micromamba-working-cache-parent',
+    userIdentity: 'alice'
+  })}\n`
+
+  it('removes only the marker and then the verified empty parent non-recursively', () => {
+    const removeMarker = vi.fn()
+    const removeParent = vi.fn()
+
+    removeEmptyManagedParent(parent, 'alice', () => true, {
+      readMarker: () => raw,
+      list: () => ['.open-science-temp.json'],
+      removeMarker,
+      removeParent
+    })
+
+    expect(removeMarker).toHaveBeenCalledWith('D:\\OpenScienceTmp\\.open-science-temp.json')
+    expect(removeParent).toHaveBeenCalledWith(parent)
+  })
+
+  it('restores the marker when a concurrent child makes parent removal fail', () => {
+    const restoreMarker = vi.fn()
+
+    expect(() =>
+      removeEmptyManagedParent(parent, 'alice', () => true, {
+        readMarker: () => raw,
+        list: () => ['.open-science-temp.json'],
+        removeMarker: vi.fn(),
+        removeParent: () => {
+          throw Object.assign(new Error('directory not empty'), { code: 'ENOTEMPTY' })
+        },
+        restoreMarker
+      })
+    ).toThrow(/directory not empty/)
+    expect(restoreMarker).toHaveBeenCalledWith('D:\\OpenScienceTmp\\.open-science-temp.json', raw)
+  })
+})
+
+describe('isTrustedMicromambaWorkingCacheForRoot', () => {
+  const root = 'D:\\OpenScience\\runtime'
+  const env = { USERNAME: 'alice', USERPROFILE: 'C:\\Users\\alice' }
+  const cache = selectMicromambaCache(root, DEFAULT_MAX_CACHE_RELATIVE_PATH, windowsDeps({ env }))
+  const marker = {
+    schema: 1,
+    canonicalRoot: root.toLowerCase(),
+    userIdentity: 'alice'
+  }
+  const trustedDeps: MicromambaCacheCleanupDeps = {
+    platform: 'win32',
+    env,
+    canonicalize: (path) => win32.normalize(path),
+    verifyOwnership: () => true,
+    inspectParent: (path) => ({
+      directory: true,
+      symbolicLink: false,
+      physical: win32.normalize(path),
+      marker: {
+        schema: 1,
+        kind: 'micromamba-working-cache-parent',
+        userIdentity: 'alice'
+      }
+    }),
+    inspect: () => ({ directory: true, symbolicLink: false, marker })
+  }
+
+  it('accepts the exact marker- and ownership-verified retained cache', () => {
+    expect(isTrustedMicromambaWorkingCacheForRoot(root, cache.path, trustedDeps)).toBe(true)
+  })
+
+  it('accepts a marker-owned OpenScienceTmp fallback after TEMP changes', () => {
+    const retained = win32.join('E:\\PreviousTemp\\OpenScienceTmp', win32.basename(cache.path))
+
+    expect(isTrustedMicromambaWorkingCacheForRoot(root, retained, trustedDeps)).toBe(true)
+  })
+
+  it('rejects a journal path outside a managed temporary parent before scanning it', () => {
+    const inspect = vi.fn(trustedDeps.inspect)
+    expect(
+      isTrustedMicromambaWorkingCacheForRoot(
+        root,
+        win32.join('C:\\Users\\alice\\Documents', win32.basename(cache.path)),
+        { ...trustedDeps, inspect }
+      )
+    ).toBe(false)
+    expect(inspect).not.toHaveBeenCalled()
+  })
+
+  it('rejects a retained cache whose parent became a reparse point', () => {
+    expect(
+      isTrustedMicromambaWorkingCacheForRoot(root, cache.path, {
+        ...trustedDeps,
+        inspectParent: (path) => ({
+          directory: true,
+          symbolicLink: true,
+          physical: win32.normalize(path)
+        })
+      })
+    ).toBe(false)
+  })
+
+  it('rejects an os-tmp fallback outside the current profile', () => {
+    expect(
+      isTrustedMicromambaWorkingCacheForRoot(
+        root,
+        win32.join('C:\\OtherUser\\os-tmp', win32.basename(cache.path)),
+        trustedDeps
+      )
+    ).toBe(false)
+  })
+
+  it('accepts a physical POSIX package cache and rejects a linked one', () => {
+    const sandbox = mkdtempSync(join(tmpdir(), 'os-posix-cache-trust-'))
+    const runtimeRoot = join(sandbox, 'runtime')
+    const physical = join(runtimeRoot, 'pkgs')
+    const linkedRuntime = join(sandbox, 'linked-runtime')
+    try {
+      mkdirSync(physical, { recursive: true })
+      expect(
+        isTrustedMicromambaWorkingCacheForRoot(runtimeRoot, physical, { platform: 'linux' })
+      ).toBe(true)
+      mkdirSync(linkedRuntime)
+      symlinkSync(
+        physical,
+        join(linkedRuntime, 'pkgs'),
+        process.platform === 'win32' ? 'junction' : 'dir'
+      )
+      expect(
+        isTrustedMicromambaWorkingCacheForRoot(linkedRuntime, join(linkedRuntime, 'pkgs'), {
+          platform: 'linux'
+        })
+      ).toBe(false)
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('retainMicromambaWorkingCache', () => {
+  const env = { USERNAME: 'alice', USERPROFILE: 'C:\\Users\\alice' }
+
+  it('publishes and cleans only after the final concurrent user releases', async () => {
+    const publishArchives = vi.fn().mockResolvedValue(2)
+    const cleanup = vi.fn()
+    const deps = {
+      platform: 'win32' as const,
+      canonicalize: (path: string) => win32.normalize(path),
+      publishArchives,
+      cleanup
+    }
+    const releaseFirst = await retainMicromambaWorkingCache('D:\\OpenScience\\runtime', deps)
+    const releaseSecond = await retainMicromambaWorkingCache('D:\\OpenScience\\runtime', deps)
+    const archiveAuthorization = {
+      file: 'a-1.conda',
+      algorithm: 'sha256' as const,
+      digest: 'a'.repeat(64)
+    }
+    const secondAuthorization = {
+      file: 'b-1.conda',
+      algorithm: 'sha256' as const,
+      digest: 'b'.repeat(64)
+    }
+
+    const firstCompletion = releaseFirst({
+      archivePublications: [
+        {
+          workingRoot: 'D:\\OpenScienceTmp\\m-test',
+          authorizations: [archiveAuthorization]
+        }
+      ]
+    })
+    await Promise.resolve()
+    expect(publishArchives).not.toHaveBeenCalled()
+    const secondCompletion = releaseSecond({
+      archivePublications: [
+        {
+          workingRoot: 'C:\\Users\\alice\\os-tmp\\m-bundle',
+          authorizations: [secondAuthorization]
+        }
+      ]
+    })
+    await expect(Promise.all([firstCompletion, secondCompletion])).resolves.toEqual([true, true])
+    expect(publishArchives).toHaveBeenNthCalledWith(
+      1,
+      'D:\\OpenScience\\runtime',
+      'D:\\OpenScienceTmp\\m-test',
+      [archiveAuthorization]
     )
+    expect(publishArchives).toHaveBeenNthCalledWith(
+      2,
+      'D:\\OpenScience\\runtime',
+      'C:\\Users\\alice\\os-tmp\\m-bundle',
+      [secondAuthorization]
+    )
+    expect(cleanup).toHaveBeenCalledOnce()
+  })
+
+  it('keeps finalization incomplete when cleanup reports a retryable failure', async () => {
+    const release = await retainMicromambaWorkingCache('G:\\OpenScience\\runtime', {
+      platform: 'win32',
+      canonicalize: (path) => win32.normalize(path),
+      cleanup: () => false,
+      requiresRecoveryRetention: async () => false
+    })
+
+    await expect(release({})).resolves.toBe(false)
+  })
+
+  it('blocks a new lease until final publication and cleanup finish', async () => {
+    let finishPublication: (() => void) | undefined
+    const publication = new Promise<number>((resolve) => {
+      finishPublication = () => resolve(1)
+    })
+    const publishArchives = vi.fn(() => publication)
+    const cleanup = vi.fn()
+    const deps = {
+      platform: 'win32' as const,
+      canonicalize: (path: string) => win32.normalize(path),
+      publishArchives,
+      cleanup
+    }
+    const releaseFirst = await retainMicromambaWorkingCache('D:\\OpenScience\\runtime', deps)
+    const firstRelease = releaseFirst({
+      archivePublications: [
+        {
+          workingRoot: 'D:\\OpenScienceTmp\\m-test',
+          authorizations: [{ file: 'a-1.conda', algorithm: 'sha256', digest: 'a'.repeat(64) }]
+        }
+      ]
+    })
+    await vi.waitFor(() => expect(publishArchives).toHaveBeenCalledOnce())
+
+    let secondAcquired = false
+    const secondLease = retainMicromambaWorkingCache('D:\\OpenScience\\runtime', deps).then(
+      (lease) => {
+        secondAcquired = true
+        return lease
+      }
+    )
+    await Promise.resolve()
+    expect(secondAcquired).toBe(false)
+    expect(cleanup).not.toHaveBeenCalled()
+
+    finishPublication?.()
+    await expect(firstRelease).resolves.toBe(true)
+    const releaseSecond = await secondLease
+    expect(cleanup).toHaveBeenCalledOnce()
+    await expect(releaseSecond({})).resolves.toBe(true)
+    expect(cleanup).toHaveBeenCalledTimes(2)
+  })
+
+  it('retains the working cache when publication fails or recovery may still need it', async () => {
+    const cleanup = vi.fn()
+    const publishArchives = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('disk full'))
+      .mockResolvedValueOnce(1)
+    const deps = {
+      platform: 'win32',
+      canonicalize: (path: string) => win32.normalize(path),
+      publishArchives,
+      cleanup
+    } as const
+    const failedRelease = await retainMicromambaWorkingCache('E:\\OpenScience\\runtime', deps)
+    await expect(
+      failedRelease({
+        archivePublications: [
+          {
+            workingRoot: 'E:\\OpenScienceTmp\\m-test',
+            authorizations: [{ file: 'a-1.conda', algorithm: 'sha256', digest: 'a'.repeat(64) }]
+          }
+        ]
+      })
+    ).resolves.toBe(false)
+    expect(cleanup).not.toHaveBeenCalled()
+
+    const retryRelease = await retainMicromambaWorkingCache('E:\\OpenScience\\runtime', deps)
+    await expect(retryRelease({})).resolves.toBe(true)
+    expect(publishArchives).toHaveBeenCalledTimes(2)
+    expect(cleanup).toHaveBeenCalledOnce()
+    cleanup.mockClear()
+
+    const retainedRelease = await retainMicromambaWorkingCache('F:\\OpenScience\\runtime', {
+      platform: 'win32',
+      canonicalize: (path) => win32.normalize(path),
+      cleanup
+    })
+    await expect(retainedRelease({ retainForRecovery: true })).resolves.toBe(false)
+    expect(cleanup).not.toHaveBeenCalled()
+
+    const publishAfterRetention = vi.fn().mockResolvedValue(1)
+    const laterRelease = await retainMicromambaWorkingCache('F:\\OpenScience\\runtime', {
+      platform: 'win32',
+      canonicalize: (path) => win32.normalize(path),
+      publishArchives: publishAfterRetention,
+      cleanup
+    })
+    const laterAuthorization = {
+      file: 'later-1.conda',
+      algorithm: 'sha256' as const,
+      digest: 'c'.repeat(64)
+    }
+    await expect(
+      laterRelease({
+        archivePublications: [
+          {
+            workingRoot: 'F:\\OpenScienceTmp\\m-later',
+            authorizations: [laterAuthorization]
+          }
+        ]
+      })
+    ).resolves.toBe(true)
+    expect(publishAfterRetention).toHaveBeenCalledWith(
+      'F:\\OpenScience\\runtime',
+      'F:\\OpenScienceTmp\\m-later',
+      [laterAuthorization]
+    )
+    expect(cleanup).not.toHaveBeenCalled()
+
+    await finalizeRecoveredMicromambaWorkingCache(
+      'F:\\OpenScience\\runtime',
+      {
+        platform: 'win32',
+        env,
+        canonicalize: (path) => win32.normalize(path),
+        exists: () => true,
+        cleanup
+      },
+      { mode: 'current-candidates' }
+    )
+    expect(cleanup).toHaveBeenCalledOnce()
+
+    cleanup.mockClear()
+    const releaseAfterRecovery = await retainMicromambaWorkingCache('F:\\OpenScience\\runtime', {
+      platform: 'win32',
+      canonicalize: (path) => win32.normalize(path),
+      cleanup
+    })
+    await expect(releaseAfterRecovery({})).resolves.toBe(true)
+    expect(cleanup).toHaveBeenCalledOnce()
+  })
+
+  it('retains and blocks new writers after restart while publication authority is pending', async () => {
+    const runtimeRoot = mkdtempSync(join(tmpdir(), 'os-working-cache-recovery-'))
+    try {
+      const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+      await journal.begin({
+        operationId: 'interrupted-install',
+        kind: 'install',
+        runtimeId: 'analysis::python',
+        phase: 'install-python',
+        startedAt: Date.now(),
+        targetPath: join(runtimeRoot, 'envs', 'analysis'),
+        archivePublicationPending: true
+      })
+      const cleanup = vi.fn()
+      const deps = {
+        platform: 'win32' as const,
+        canonicalize: (path: string) => win32.normalize(path),
+        cleanup
+      }
+
+      await expect(retainMicromambaWorkingCache(runtimeRoot, deps, 'new-install')).rejects.toThrow(
+        'RUNTIME_CACHE_RECOVERY_BLOCKED'
+      )
+      expect(cleanup).not.toHaveBeenCalled()
+
+      await journal.complete('interrupted-install')
+      const releaseAfterRecovery = await retainMicromambaWorkingCache(
+        runtimeRoot,
+        deps,
+        'new-install'
+      )
+      await expect(releaseAfterRecovery({ completedOperationId: 'new-install' })).resolves.toBe(
+        true
+      )
+      expect(cleanup).toHaveBeenCalledOnce()
+    } finally {
+      rmSync(runtimeRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('does not let a successfully published operation retain its own cache', async () => {
+    const runtimeRoot = mkdtempSync(join(tmpdir(), 'os-working-cache-published-'))
+    try {
+      const operationId = 'completed-install'
+      const workingRoot = 'C:\\OpenScienceTmp\\m-current'
+      const authorization = {
+        file: 'numpy-1.conda',
+        algorithm: 'sha256' as const,
+        digest: 'a'.repeat(64)
+      }
+      const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+      await journal.begin({
+        operationId,
+        kind: 'install',
+        runtimeId: 'analysis::python',
+        phase: 'install-python',
+        startedAt: Date.now(),
+        targetPath: join(runtimeRoot, 'envs', 'analysis'),
+        archivePublications: [{ workingRoot, authorizations: [authorization] }]
+      })
+      const cleanup = vi.fn()
+      const publishArchives = vi.fn().mockResolvedValue(1)
+      const release = await retainMicromambaWorkingCache(
+        runtimeRoot,
+        {
+          platform: 'win32',
+          canonicalize: (path) => win32.normalize(path),
+          cleanup,
+          publishArchives
+        },
+        operationId
+      )
+
+      await expect(
+        release({
+          archivePublications: [{ workingRoot, authorizations: [authorization] }],
+          completedOperationId: operationId
+        })
+      ).resolves.toBe(true)
+
+      expect(publishArchives).toHaveBeenCalledOnce()
+      expect(cleanup).toHaveBeenCalledOnce()
+    } finally {
+      rmSync(runtimeRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses a new writer while recovered archive publication is still pending', async () => {
+    const runtimeRoot = mkdtempSync(join(tmpdir(), 'os-working-cache-publication-block-'))
+    try {
+      const workingRoot = 'C:\\OpenScienceTmp\\m-recovered'
+      const authorization = {
+        file: 'numpy-1.conda',
+        algorithm: 'sha256' as const,
+        digest: 'b'.repeat(64)
+      }
+      const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+      await journal.begin({
+        operationId: 'recovered-install',
+        kind: 'install',
+        runtimeId: 'analysis::python',
+        phase: 'install-python',
+        startedAt: Date.now(),
+        targetPath: join(runtimeRoot, 'envs', 'analysis'),
+        archivePublications: [{ workingRoot, authorizations: [authorization] }]
+      })
+      const cleanup = vi.fn()
+      const deps = {
+        platform: 'win32' as const,
+        canonicalize: (path: string) => win32.normalize(path),
+        cleanup
+      }
+
+      await expect(retainMicromambaWorkingCache(runtimeRoot, deps, 'new-install')).rejects.toThrow(
+        'RUNTIME_CACHE_RECOVERY_BLOCKED'
+      )
+      expect(cleanup).not.toHaveBeenCalled()
+
+      await journal.complete('recovered-install')
+      const releaseAfterRepair = await retainMicromambaWorkingCache(
+        runtimeRoot,
+        deps,
+        'new-install'
+      )
+      await expect(releaseAfterRepair({ completedOperationId: 'new-install' })).resolves.toBe(true)
+      expect(cleanup).toHaveBeenCalledOnce()
+    } finally {
+      rmSync(runtimeRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('finalizes a marker-owned cache left by a recovered hard exit without creating an absent one', async () => {
+    const cleanup = vi.fn()
+    const exists = vi.fn().mockReturnValue(true)
+    await expect(
+      finalizeRecoveredMicromambaWorkingCache(
+        'G:\\OpenScience\\runtime',
+        {
+          platform: 'win32',
+          env,
+          canonicalize: (path) => win32.normalize(path),
+          exists,
+          cleanup
+        },
+        { mode: 'current-candidates' }
+      )
+    ).resolves.toBe(true)
+
+    expect(exists).toHaveBeenCalledWith(
+      expect.stringMatching(/^G:\\OpenScienceTmp\\m-[0-9a-hjkmnp-tv-z]{8}$/)
+    )
+    expect(cleanup).toHaveBeenCalledWith('G:\\OpenScience\\runtime')
+
+    exists.mockReturnValue(false)
+    await expect(
+      finalizeRecoveredMicromambaWorkingCache(
+        'H:\\OpenScience\\runtime',
+        {
+          platform: 'win32',
+          env,
+          canonicalize: (path) => win32.normalize(path),
+          exists,
+          cleanup
+        },
+        { mode: 'current-candidates' }
+      )
+    ).resolves.toBe(false)
+  })
+
+  it('finds and finalizes a recovered per-user fallback cache', async () => {
+    const cleanup = vi.fn()
+
+    await expect(
+      finalizeRecoveredMicromambaWorkingCache(
+        'G:\\OpenScience\\runtime',
+        {
+          platform: 'win32',
+          env,
+          canonicalize: (path) => win32.normalize(path),
+          exists: (path) => path.includes('\\os-tmp\\'),
+          cleanup
+        },
+        { mode: 'current-candidates' }
+      )
+    ).resolves.toBe(true)
+
+    expect(cleanup).toHaveBeenCalledWith('G:\\OpenScience\\runtime')
+  })
+
+  it('finalizes the exact recovered fallback even after TEMP changes', async () => {
+    const recovered = 'E:\\PreviousTemp\\OpenScienceTmp\\m-retained'
+    const cleanupExact = vi.fn().mockReturnValue(true)
+
+    await expect(
+      finalizeRecoveredMicromambaWorkingCache(
+        'G:\\OpenScience\\runtime',
+        {
+          platform: 'win32',
+          env,
+          canonicalize: (path) => win32.normalize(path),
+          exists: (path) => win32.normalize(path) === win32.normalize(recovered),
+          cleanupExact
+        },
+        { mode: 'exact', workingRoots: [recovered] }
+      )
+    ).resolves.toBe(true)
+
+    expect(cleanupExact).toHaveBeenCalledWith('G:\\OpenScience\\runtime', recovered)
+  })
+
+  it('retains the journal when exact-cache inspection is inconclusive', async () => {
+    const cleanupExact = vi.fn().mockReturnValue(true)
+
+    await expect(
+      finalizeRecoveredMicromambaWorkingCache(
+        'G:\\OpenScience\\runtime',
+        {
+          platform: 'win32',
+          env,
+          canonicalize: (path) => win32.normalize(path),
+          workingRootState: () => 'unknown',
+          cleanupExact
+        },
+        {
+          mode: 'exact',
+          workingRoots: ['E:\\PreviousTemp\\OpenScienceTmp\\m-retained']
+        }
+      )
+    ).resolves.toBe(false)
+    expect(cleanupExact).not.toHaveBeenCalled()
+  })
+
+  it('treats the non-Windows durable package root as requiring no disposable cleanup', async () => {
+    const runtimeRoot = join('data', 'OpenScience', 'runtime')
+    await expect(
+      finalizeRecoveredMicromambaWorkingCache(
+        runtimeRoot,
+        { platform: 'linux', canonicalize: (path) => path },
+        { mode: 'exact', workingRoots: [join(runtimeRoot, 'pkgs')] }
+      )
+    ).resolves.toBe(true)
   })
 })
 
@@ -299,7 +974,8 @@ describe('isTrustedWindowsCacheAcl', () => {
     const script = windowsCacheAclHardeningScript("C:\\Users\\O'Brien\\cache")
 
     expect(script).toContain("$path='C:\\Users\\O''Brien\\cache'")
-    expect(script).toContain('$acl.SetOwner($current)')
+    expect(script).toContain('[System.IO.Directory]::GetAccessControl($path)')
+    expect(script).not.toContain('.SetOwner(')
     expect(script).toContain('$acl.SetAccessRuleProtection($true,$false)')
     expect(script).toContain('S-1-5-18')
     expect(script).toContain('S-1-5-32-544')
@@ -334,6 +1010,23 @@ describe('isTrustedWindowsCacheAcl', () => {
       })
     ).toBe(true)
   })
+
+  it.each(['S-1-5-18', 'S-1-5-32-544'])(
+    'accepts a trusted system owner %s when no foreign principal can write',
+    (owner) => {
+      const current = 'S-1-5-21-1000'
+      expect(
+        isTrustedWindowsCacheAcl({
+          OwnerSid: owner,
+          CurrentSid: current,
+          Rules: [
+            { Sid: current, Rights: 'FullControl', Type: 'Allow' },
+            { Sid: owner, Rights: 'FullControl', Type: 'Allow' }
+          ]
+        })
+      ).toBe(true)
+    }
+  )
 
   it('rejects a foreign owner or any custom group with write access', () => {
     const current = 'S-1-5-21-1000'

--- a/src/main/notebook/micromamba-cache.ts
+++ b/src/main/notebook/micromamba-cache.ts
@@ -1,6 +1,15 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { execFileSync } from 'node:child_process'
-import { lstatSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmdirSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import { basename, dirname, join, posix, resolve, win32 } from 'node:path'
 
 import { resolveWindowsPowerShellExecutable } from '../windows-powershell'
@@ -36,16 +45,36 @@ export type MicromambaCacheDeps = {
     ownership: CacheOwnership
   ) => string | MicromambaCachePreparation | undefined
   verifyOwnership?: (path: string, userIdentity: string) => boolean
+  exists?: (path: string) => boolean
 }
 
 type CacheMarker = { schema?: number; canonicalRoot?: string; userIdentity?: string }
+
+type TempParentMarker = { schema?: number; kind?: string; userIdentity?: string }
+
+const WINDOWS_TEMP_PARENT = 'OpenScienceTmp'
+const TEMP_PARENT_MARKER_FILE = '.open-science-temp.json'
+const TEMP_PARENT_MARKER_KIND = 'micromamba-working-cache-parent'
 
 export type MicromambaCacheCleanupDeps = Pick<
   MicromambaCacheDeps,
   'platform' | 'env' | 'canonicalize' | 'verifyOwnership'
 > & {
   inspect?: (path: string) => { directory: boolean; symbolicLink: boolean; marker: CacheMarker }
+  inspectParent?: (path: string) => {
+    directory: boolean
+    symbolicLink: boolean
+    physical: string
+    marker?: TempParentMarker
+  }
   remove?: (path: string) => void
+  preserveParent?: boolean
+}
+
+type CachePathCandidate = {
+  path: string
+  profileBoundary?: string
+  managedParent?: boolean
 }
 
 const windowsKey = (path: string): string => win32.normalize(path).toLowerCase()
@@ -91,8 +120,7 @@ export const windowsCacheAclHardeningScript = (path: string): string => {
     '[System.Security.AccessControl.InheritanceFlags]::ObjectInherit; ' +
     '$propagation=[System.Security.AccessControl.PropagationFlags]::None; ' +
     '$allow=[System.Security.AccessControl.AccessControlType]::Allow; ' +
-    '$acl=[System.Security.AccessControl.DirectorySecurity]::new(); ' +
-    '$acl.SetOwner($current); ' +
+    '$acl=[System.IO.Directory]::GetAccessControl($path); ' +
     '$acl.SetAccessRuleProtection($true,$false); ' +
     '@($current,$system,$administrators) | ForEach-Object { ' +
     '$rule=[System.Security.AccessControl.FileSystemAccessRule]::new(' +
@@ -123,11 +151,6 @@ export const hardenWindowsCacheAclWithIcacls = (path: string): void => {
   const currentSid = currentWindowsUserSid()
   execFileSync(
     resolveWindowsSystemExecutable('icacls.exe'),
-    [path, '/setowner', `*${currentSid}`],
-    { encoding: 'utf8', windowsHide: true }
-  )
-  execFileSync(
-    resolveWindowsSystemExecutable('icacls.exe'),
     [
       path,
       '/inheritance:r',
@@ -148,9 +171,10 @@ export const hardenWindowsCacheAcl = (path: string): boolean => {
       ['-NoProfile', '-NonInteractive', '-Command', windowsCacheAclHardeningScript(path)],
       { encoding: 'utf8', windowsHide: true }
     )
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code
-    if (code !== 'EPERM' && code !== 'EACCES') throw error
+  } catch {
+    // Windows PowerShell reports .NET ACL failures as a normal non-zero process exit (not always
+    // EPERM/EACCES, and the localized stderr is not stable). icacls is the independent system fallback;
+    // if it also fails its error propagates and cache preparation remains fail-closed.
     hardenWindowsCacheAclWithIcacls(path)
   }
   return true
@@ -179,10 +203,17 @@ export const WINDOWS_CACHE_DANGEROUS_RIGHT_NAMES = [
   'TakeOwnership'
 ] as const
 
+export const WINDOWS_CACHE_TRUSTED_OWNER_SIDS = [
+  'S-1-5-18', // LocalSystem
+  'S-1-5-32-544' // Builtin Administrators
+] as const
+
 const dangerousWindowsCacheRight = new RegExp(WINDOWS_CACHE_DANGEROUS_RIGHT_NAMES.join('|'), 'i')
 
 export const isTrustedWindowsCacheAcl = (acl: WindowsCacheAcl): boolean => {
-  if (!acl.OwnerSid || acl.OwnerSid !== acl.CurrentSid) return false
+  if (!acl.OwnerSid || !acl.CurrentSid) return false
+  const trustedOwnerSids = new Set([acl.CurrentSid, ...WINDOWS_CACHE_TRUSTED_OWNER_SIDS])
+  if (!trustedOwnerSids.has(acl.OwnerSid)) return false
   const trustedWriteSids = new Set([
     acl.CurrentSid,
     'S-1-5-18', // LocalSystem
@@ -249,13 +280,30 @@ const defaultPrepare = (
   verifyOwnership: (path: string, userIdentity: string) => boolean
 ): MicromambaCachePreparation => {
   let created = false
+  let parentCreated = false
+  let parentMarkerWritten = false
   let verifiedByHardening = false
+  const parent = win32.dirname(path)
   const reject = (rejection: string): MicromambaCachePreparation => {
     if (created) {
       try {
         rmSync(path, { recursive: true, force: true })
       } catch {
         // Preserve the original rejection; cleanup is best-effort for a directory this call created.
+      }
+    }
+    if (parentCreated) {
+      try {
+        if (parentMarkerWritten) {
+          removeEmptyManagedParent(parent, ownership.userIdentity, verifyOwnership)
+        } else {
+          // The marker was never published, so this call can only remove the still-empty directory it
+          // created. A concurrent child makes this non-recursive removal fail safely.
+          rmdirSync(parent)
+        }
+      } catch {
+        // Preserve the original rejection. Never recurse through the shared parent: another app
+        // process may already have created a sibling cache after this call created the directory.
       }
     }
     return { rejection }
@@ -266,6 +314,65 @@ const defaultPrepare = (
     return code ? `${code}: ${error.message}` : error.message
   }
   try {
+    const expectedParent: Required<TempParentMarker> = {
+      schema: 1,
+      kind: TEMP_PARENT_MARKER_KIND,
+      userIdentity: ownership.userIdentity
+    }
+    let parentState
+    try {
+      parentState = lstatSync(parent)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        return reject(`temporary parent could not be inspected (${errorDetail(error)})`)
+      }
+    }
+    if (parentState) {
+      if (!parentState.isDirectory() || parentState.isSymbolicLink()) {
+        return reject('temporary parent exists but is not a trusted directory')
+      }
+      let parentMarker: TempParentMarker
+      try {
+        parentMarker = JSON.parse(
+          readFileSync(win32.join(parent, TEMP_PARENT_MARKER_FILE), 'utf8')
+        ) as TempParentMarker
+      } catch (error) {
+        return reject(
+          `temporary parent ownership marker is missing or unreadable (${errorDetail(error)})`
+        )
+      }
+      if (
+        parentMarker.schema !== expectedParent.schema ||
+        parentMarker.kind !== expectedParent.kind ||
+        parentMarker.userIdentity !== expectedParent.userIdentity
+      ) {
+        return reject('temporary parent ownership marker does not match the current Windows user')
+      }
+      if (windowsKey(realpathSync.native(parent)) !== windowsKey(parent)) {
+        return reject('temporary parent resolves to an unexpected physical location')
+      }
+      if (!verifyOwnership(parent, ownership.userIdentity)) {
+        return reject('temporary parent ownership or permissions are not trusted')
+      }
+    } else {
+      mkdirSync(parent, { mode: 0o700 })
+      parentCreated = true
+      try {
+        hardenOwnership(parent)
+      } catch (error) {
+        return reject(`temporary parent ACL could not be hardened (${errorDetail(error)})`)
+      }
+      writeFileSync(
+        win32.join(parent, TEMP_PARENT_MARKER_FILE),
+        `${JSON.stringify(expectedParent)}\n`,
+        { encoding: 'utf8', mode: 0o600, flag: 'wx' }
+      )
+      parentMarkerWritten = true
+      if (!verifyOwnership(parent, ownership.userIdentity)) {
+        return reject('temporary parent ownership or permissions are not trusted')
+      }
+    }
+
     try {
       const stat = lstatSync(path)
       if (!stat.isDirectory()) return reject('path exists but is not a directory')
@@ -358,7 +465,13 @@ const cacheIdentity = (
   root: string,
   env: NodeJS.ProcessEnv,
   canonicalize: (path: string) => string
-): { canonicalRoot: string; userIdentity: string; leaf: string; compactLeaf: string } => {
+): {
+  canonicalRoot: string
+  userIdentity: string
+  leaf: string
+  legacyLeaf: string
+  legacyCompactLeaf: string
+} => {
   const userIdentity = [env.USERDOMAIN, env.USERNAME].filter(Boolean).join('\\')
   if (!userIdentity) {
     throw new Error('Cannot determine the Windows user identity for the managed runtime cache.')
@@ -370,32 +483,95 @@ const cacheIdentity = (
   return {
     canonicalRoot,
     userIdentity,
-    leaf: `osp${digest.toString('hex').slice(0, 10)}`,
-    compactLeaf: `os${compactCacheHash(digest)}`
+    leaf: `m-${compactCacheHash(digest)}`,
+    legacyLeaf: `osp${digest.toString('hex').slice(0, 10)}`,
+    legacyCompactLeaf: `os${compactCacheHash(digest)}`
   }
 }
 
 const candidatePaths = (
   canonicalRoot: string,
   leaf: string,
-  compactLeaf: string,
   env: NodeJS.ProcessEnv,
   canonicalize: (path: string) => string
-): Array<{ path: string; profileBoundary?: string }> => {
-  const profile = env.USERPROFILE ? win32.normalize(canonicalize(env.USERPROFILE)) : undefined
-  const publicRoot = env.PUBLIC ? win32.normalize(canonicalize(env.PUBLIC)) : undefined
+): CachePathCandidate[] => {
   const runtimeVolume = win32.parse(canonicalRoot).root
+  const seenTemporaryRoots = new Set([windowsKey(runtimeVolume)])
+  const perUserTemps = [env.TEMP, env.TMP]
+    .filter((path): path is string => Boolean(path))
+    .map((path) => win32.normalize(canonicalize(path)))
+    .filter((path) => {
+      const key = windowsKey(path)
+      if (seenTemporaryRoots.has(key)) return false
+      seenTemporaryRoots.add(key)
+      return true
+    })
+  const profile = env.USERPROFILE ? win32.normalize(canonicalize(env.USERPROFILE)) : undefined
+  const primary = {
+    path: win32.join(runtimeVolume, WINDOWS_TEMP_PARENT, leaf),
+    managedParent: true
+  }
   return [
-    { path: win32.join(runtimeVolume, leaf) },
+    primary,
+    ...perUserTemps.map((perUserTemp) => ({
+      path: win32.join(perUserTemp, WINDOWS_TEMP_PARENT, leaf),
+      profileBoundary: perUserTemp,
+      managedParent: true
+    })),
     ...(profile
       ? [
-          { path: win32.join(profile, leaf), profileBoundary: profile },
-          { path: win32.join(profile, compactLeaf), profileBoundary: profile }
+          {
+            path: win32.join(profile, 'os-tmp', leaf),
+            profileBoundary: profile,
+            managedParent: true
+          }
         ]
-      : []),
-    ...(publicRoot ? [{ path: win32.join(publicRoot, leaf) }] : [])
+      : [])
   ]
 }
+
+// Released versions used these external layouts. They are never selected again, but migration and
+// eligible cleanup must still remove them after applying the same marker and ACL checks as the new
+// working cache; otherwise large disposable package caches remain orphaned indefinitely.
+const legacyCleanupCandidatePaths = (
+  canonicalRoot: string,
+  legacyLeaf: string,
+  legacyCompactLeaf: string,
+  env: NodeJS.ProcessEnv,
+  canonicalize: (path: string) => string
+): CachePathCandidate[] => {
+  const runtimeVolume = win32.parse(canonicalRoot).root
+  const profile = env.USERPROFILE ? win32.normalize(canonicalize(env.USERPROFILE)) : undefined
+  const publicRoot = env.PUBLIC ? win32.normalize(canonicalize(env.PUBLIC)) : undefined
+  return [
+    { path: win32.join(runtimeVolume, legacyLeaf) },
+    ...(profile
+      ? [
+          { path: win32.join(profile, legacyLeaf), profileBoundary: profile },
+          { path: win32.join(profile, legacyCompactLeaf), profileBoundary: profile }
+        ]
+      : []),
+    ...(publicRoot ? [{ path: win32.join(publicRoot, legacyLeaf) }] : [])
+  ]
+}
+
+export const micromambaWorkingCachePaths = (
+  root: string,
+  deps: Pick<MicromambaCacheDeps, 'platform' | 'env' | 'canonicalize'> = {}
+): string[] => {
+  if ((deps.platform ?? process.platform) !== 'win32') return [posix.join(root, 'pkgs')]
+  const env = deps.env ?? process.env
+  const canonicalize = deps.canonicalize ?? canonicalizeExisting
+  const identity = cacheIdentity(root, env, canonicalize)
+  return candidatePaths(identity.canonicalRoot, identity.leaf, env, canonicalize).map(
+    (candidate) => candidate.path
+  )
+}
+
+export const micromambaWorkingCachePath = (
+  root: string,
+  deps: Pick<MicromambaCacheDeps, 'platform' | 'env' | 'canonicalize'> = {}
+): string => micromambaWorkingCachePaths(root, deps)[0]
 
 export const selectMicromambaCache = (
   root: string,
@@ -413,14 +589,14 @@ export const selectMicromambaCache = (
 
   const env = deps.env ?? process.env
   const canonicalize = deps.canonicalize ?? canonicalizeExisting
-  const { canonicalRoot, userIdentity, leaf, compactLeaf } = cacheIdentity(root, env, canonicalize)
+  const { canonicalRoot, userIdentity, leaf } = cacheIdentity(root, env, canonicalize)
   const hardenOwnership = deps.hardenOwnership ?? hardenWindowsCacheAcl
   const verifyOwnership = deps.verifyOwnership ?? defaultVerifyOwnership
   const prepare =
     deps.prepare ??
     ((path: string, ownership: CacheOwnership) =>
       defaultPrepare(path, ownership, hardenOwnership, verifyOwnership))
-  const candidates = candidatePaths(canonicalRoot, leaf, compactLeaf, env, canonicalize)
+  const candidates = candidatePaths(canonicalRoot, leaf, env, canonicalize)
   const rejections: string[] = []
 
   for (const candidate of candidates) {
@@ -475,21 +651,196 @@ export const selectMicromambaCache = (
   )
 }
 
-// Removes only the app-owned cache for a previous runtime root. This is used after a successful data
-// root migration because the physical cache intentionally lives outside the data tree. Marker and
-// ownership checks are repeated here so a stale or tampered path is left untouched.
-export const removeMicromambaCacheForRoot = (
+// Recovery reads an exact working-cache path from the operation journal. Revalidate that persisted
+// path without creating it before any recursive scan: a damaged journal must not turn archive
+// publication into an arbitrary-directory traversal, and a cache parent may have been replaced by a
+// reparse point while the app was stopped. The marker-bound OpenScienceTmp form remains valid even if
+// TEMP changed between runs; the fixed profile fallback must remain inside the current profile.
+export const isTrustedMicromambaWorkingCacheForRoot = (
   root: string,
+  path: string,
   deps: MicromambaCacheCleanupDeps = {}
+): boolean => {
+  const platform = deps.platform ?? process.platform
+  const canonicalize = deps.canonicalize ?? canonicalizeExisting
+  if (platform !== 'win32') {
+    try {
+      const expected = posix.join(root, 'pkgs')
+      const state = lstatSync(path)
+      return (
+        state.isDirectory() &&
+        !state.isSymbolicLink() &&
+        canonicalize(path) === canonicalize(expected)
+      )
+    } catch {
+      return false
+    }
+  }
+
+  const env = deps.env ?? process.env
+  let identity: ReturnType<typeof cacheIdentity>
+  try {
+    identity = cacheIdentity(root, env, canonicalize)
+  } catch {
+    return false
+  }
+  const normalized = win32.normalize(path)
+  if (!win32.isAbsolute(normalized) || !isAsciiPath(normalized)) return false
+  if (windowsKey(win32.basename(normalized)) !== windowsKey(identity.leaf)) return false
+
+  const parent = win32.dirname(normalized)
+  const parentLeaf = win32.basename(parent).toLowerCase()
+  if (parentLeaf !== WINDOWS_TEMP_PARENT.toLowerCase() && parentLeaf !== 'os-tmp') return false
+  const profile = env.USERPROFILE ? win32.normalize(canonicalize(env.USERPROFILE)) : undefined
+  if (parentLeaf === 'os-tmp' && (!profile || !isInside(profile, parent))) return false
+
+  const verifyOwnership = deps.verifyOwnership ?? defaultVerifyOwnership
+  const inspectParent =
+    deps.inspectParent ??
+    ((candidate: string) => {
+      const stat = lstatSync(candidate)
+      return {
+        directory: stat.isDirectory(),
+        symbolicLink: stat.isSymbolicLink(),
+        physical: realpathSync.native(candidate),
+        marker: JSON.parse(
+          readFileSync(win32.join(candidate, TEMP_PARENT_MARKER_FILE), 'utf8')
+        ) as TempParentMarker
+      }
+    })
+  const inspect =
+    deps.inspect ??
+    ((candidate: string): { directory: boolean; symbolicLink: boolean; marker: CacheMarker } => {
+      const stat = lstatSync(candidate)
+      return {
+        directory: stat.isDirectory(),
+        symbolicLink: stat.isSymbolicLink(),
+        marker: JSON.parse(
+          readFileSync(win32.join(candidate, '.open-science-cache.json'), 'utf8')
+        ) as CacheMarker
+      }
+    })
+
+  try {
+    const parentState = inspectParent(parent)
+    if (
+      !parentState.directory ||
+      parentState.symbolicLink ||
+      windowsKey(parentState.physical) !== windowsKey(parent) ||
+      parentState.marker?.schema !== 1 ||
+      parentState.marker.kind !== TEMP_PARENT_MARKER_KIND ||
+      parentState.marker.userIdentity !== identity.userIdentity ||
+      !verifyOwnership(parentState.physical, identity.userIdentity)
+    ) {
+      return false
+    }
+    const state = inspect(normalized)
+    return (
+      state.directory &&
+      !state.symbolicLink &&
+      windowsKey(canonicalize(normalized)) === windowsKey(normalized) &&
+      state.marker.schema === 1 &&
+      state.marker.canonicalRoot === windowsKey(identity.canonicalRoot) &&
+      state.marker.userIdentity === identity.userIdentity &&
+      verifyOwnership(normalized, identity.userIdentity)
+    )
+  } catch {
+    return false
+  }
+}
+
+type EmptyManagedParentRemovalDeps = {
+  readMarker?: (path: string) => string
+  list?: (path: string) => string[]
+  removeMarker?: (path: string) => void
+  removeParent?: (path: string) => void
+  restoreMarker?: (path: string, raw: string) => void
+}
+
+export const removeEmptyManagedParent = (
+  parent: string,
+  userIdentity: string,
+  verifyOwnership: (path: string, userIdentity: string) => boolean,
+  deps: EmptyManagedParentRemovalDeps = {}
 ): void => {
-  if ((deps.platform ?? process.platform) !== 'win32') return
+  const markerPath = win32.join(parent, TEMP_PARENT_MARKER_FILE)
+  const raw = (deps.readMarker ?? ((path: string) => readFileSync(path, 'utf8')))(markerPath)
+  const marker = JSON.parse(raw) as TempParentMarker
+  if (
+    marker.schema !== 1 ||
+    marker.kind !== TEMP_PARENT_MARKER_KIND ||
+    marker.userIdentity !== userIdentity ||
+    !verifyOwnership(parent, userIdentity) ||
+    !(deps.list ?? readdirSync)(parent).every((entry) => entry === TEMP_PARENT_MARKER_FILE)
+  ) {
+    return
+  }
+
+  // Remove the marker first, then use a non-recursive directory removal. If another app process adds a
+  // child after the emptiness check, rmdir fails instead of recursively deleting that active cache. Put
+  // the marker back best-effort so the surviving parent remains recognizable on the next startup.
+  ;(deps.removeMarker ?? ((path: string) => rmSync(path)))(markerPath)
+  try {
+    ;(deps.removeParent ?? rmdirSync)(parent)
+  } catch (error) {
+    try {
+      ;(
+        deps.restoreMarker ??
+        ((path: string, contents: string) =>
+          writeFileSync(path, contents, { encoding: 'utf8', mode: 0o600, flag: 'wx' }))
+      )(markerPath, raw)
+    } catch {
+      // Preserve the non-destructive outcome; a concurrent owner may already have restored the marker.
+    }
+    throw error
+  }
+}
+
+export const removeTrustedMicromambaWorkingCacheForRoot = (
+  root: string,
+  path: string,
+  deps: MicromambaCacheCleanupDeps = {}
+): boolean => {
+  if ((deps.platform ?? process.platform) !== 'win32') return false
+  if (!isTrustedMicromambaWorkingCacheForRoot(root, path, deps)) return false
   const env = deps.env ?? process.env
   const canonicalize = deps.canonicalize ?? canonicalizeExisting
   let identity: ReturnType<typeof cacheIdentity>
   try {
     identity = cacheIdentity(root, env, canonicalize)
   } catch {
-    return
+    return false
+  }
+  const parent = win32.dirname(win32.normalize(path))
+  const verifyOwnership = deps.verifyOwnership ?? defaultVerifyOwnership
+  try {
+    ;(deps.remove ?? ((candidate: string) => rmSync(candidate, { recursive: true, force: true })))(
+      path
+    )
+    if (!deps.remove && !deps.preserveParent) {
+      removeEmptyManagedParent(parent, identity.userIdentity, verifyOwnership)
+    }
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Removes only the app-owned cache for a previous runtime root. This is used after a successful data
+// root migration because the physical cache intentionally lives outside the data tree. Marker and
+// ownership checks are repeated here so a stale or tampered path is left untouched.
+export const removeMicromambaCacheForRoot = (
+  root: string,
+  deps: MicromambaCacheCleanupDeps = {}
+): boolean => {
+  if ((deps.platform ?? process.platform) !== 'win32') return true
+  const env = deps.env ?? process.env
+  const canonicalize = deps.canonicalize ?? canonicalizeExisting
+  let identity: ReturnType<typeof cacheIdentity>
+  try {
+    identity = cacheIdentity(root, env, canonicalize)
+  } catch {
+    return false
   }
   const verifyOwnership = deps.verifyOwnership ?? defaultVerifyOwnership
   const inspect =
@@ -504,16 +855,57 @@ export const removeMicromambaCacheForRoot = (
         ) as CacheMarker
       }
     })
+  const inspectParent =
+    deps.inspectParent ??
+    ((path: string) => {
+      const stat = lstatSync(path)
+      let marker: TempParentMarker | undefined
+      try {
+        marker = JSON.parse(
+          readFileSync(win32.join(path, TEMP_PARENT_MARKER_FILE), 'utf8')
+        ) as TempParentMarker
+      } catch {
+        // Released legacy layouts did not own their parent, while managed parents are rejected below.
+      }
+      return {
+        directory: stat.isDirectory(),
+        symbolicLink: stat.isSymbolicLink(),
+        physical: realpathSync.native(path),
+        marker
+      }
+    })
   const remove =
     deps.remove ?? ((path: string): void => rmSync(path, { recursive: true, force: true }))
-  for (const candidate of candidatePaths(
-    identity.canonicalRoot,
-    identity.leaf,
-    identity.compactLeaf,
-    env,
-    canonicalize
-  )) {
+  const cleanupCandidates = [
+    ...candidatePaths(identity.canonicalRoot, identity.leaf, env, canonicalize),
+    ...legacyCleanupCandidatePaths(
+      identity.canonicalRoot,
+      identity.legacyLeaf,
+      identity.legacyCompactLeaf,
+      env,
+      canonicalize
+    )
+  ]
+  let completed = true
+  for (const candidate of cleanupCandidates) {
     try {
+      const parent = win32.dirname(candidate.path)
+      const parentState = inspectParent(parent)
+      if (
+        !parentState.directory ||
+        parentState.symbolicLink ||
+        windowsKey(parentState.physical) !== windowsKey(parent) ||
+        (candidate.profileBoundary && !isInside(candidate.profileBoundary, parentState.physical))
+      )
+        continue
+      if (
+        candidate.managedParent &&
+        (parentState.marker?.schema !== 1 ||
+          parentState.marker.kind !== TEMP_PARENT_MARKER_KIND ||
+          parentState.marker.userIdentity !== identity.userIdentity ||
+          !verifyOwnership(parentState.physical, identity.userIdentity))
+      )
+        continue
       const state = inspect(candidate.path)
       if (!state.directory || state.symbolicLink) continue
       const marker = state.marker
@@ -525,8 +917,14 @@ export const removeMicromambaCacheForRoot = (
       )
         continue
       remove(candidate.path)
-    } catch {
-      // Cleanup is best-effort; migration success must not be turned into a failure by stale cache I/O.
+      if (!deps.remove && !deps.preserveParent) {
+        removeEmptyManagedParent(parent, identity.userIdentity, verifyOwnership)
+      }
+    } catch (error) {
+      // A missing candidate or marker means there is nothing app-owned to remove. Preserve every other
+      // failure so operation journals can retain the exact cleanup evidence for a later retry.
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') completed = false
     }
   }
+  return completed
 }

--- a/src/main/notebook/micromamba.test.ts
+++ b/src/main/notebook/micromamba.test.ts
@@ -286,11 +286,11 @@ describe('micromambaSpawnEnv', () => {
         PUBLIC: 'C:\\Users\\Public'
       },
       canonicalize: (path) => win32.normalize(path),
-      prepare: (path) => (path.startsWith('C:\\osp') ? undefined : win32.normalize(path)),
+      prepare: (path) => win32.normalize(path),
       verifyOwnership: () => true
     })
 
-    expect(env.CONDA_PKGS_DIRS).toMatch(/^C:\\Users\\Public\\osp[0-9a-f]{10}$/)
+    expect(env.CONDA_PKGS_DIRS).toMatch(/^C:\\OpenScienceTmp\\m-[0-9a-hjkmnp-tv-z]{8}$/)
   })
 
   it('cleans inherited conda/mamba values before injecting the Windows app cache and CA vars', () => {

--- a/src/main/notebook/notebook-workload-cache-paths.ts
+++ b/src/main/notebook/notebook-workload-cache-paths.ts
@@ -1,0 +1,179 @@
+import { lstatSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+
+const MARKER_FILE = '.open-science-notebook-cache.json'
+const MARKER_KIND = 'notebook-workload-cache'
+
+type WorkloadCacheMarker = {
+  schema?: number
+  kind?: string
+  canonicalRoot?: string
+}
+
+const pathKey = (path: string, platform: NodeJS.Platform = process.platform): string => {
+  const normalized = resolve(path)
+  return platform === 'win32' ? normalized.toLowerCase() : normalized
+}
+
+const expectedMarker = (cacheRoot: string): Required<WorkloadCacheMarker> => ({
+  schema: 1,
+  kind: MARKER_KIND,
+  canonicalRoot: realpathSync.native(cacheRoot)
+})
+
+const markerMatches = (
+  marker: WorkloadCacheMarker,
+  expected: Required<WorkloadCacheMarker>,
+  platform: NodeJS.Platform = process.platform
+): boolean =>
+  marker.schema === expected.schema &&
+  marker.kind === expected.kind &&
+  typeof marker.canonicalRoot === 'string' &&
+  pathKey(marker.canonicalRoot, platform) === pathKey(expected.canonicalRoot, platform)
+
+const isExpectedPhysicalChild = (parent: string, child: string, name: string): boolean =>
+  pathKey(realpathSync.native(child)) === pathKey(join(realpathSync.native(parent), name))
+
+export const notebookWorkloadCacheRoot = (runtimeRoot: string): string =>
+  join(runtimeRoot, 'cache', 'notebook')
+
+export const notebookWorkloadCacheEnv = (runtimeRoot: string): NodeJS.ProcessEnv => {
+  const cacheRoot = notebookWorkloadCacheRoot(runtimeRoot)
+  return {
+    OPEN_SCIENCE_NOTEBOOK_CACHE_DIR: cacheRoot,
+    PIP_CACHE_DIR: join(cacheRoot, 'pip'),
+    UV_CACHE_DIR: join(cacheRoot, 'uv'),
+    HF_HUB_CACHE: join(cacheRoot, 'huggingface', 'hub'),
+    HF_DATASETS_CACHE: join(cacheRoot, 'huggingface', 'datasets'),
+    HF_XET_CACHE: join(cacheRoot, 'huggingface', 'xet'),
+    HF_ASSETS_CACHE: join(cacheRoot, 'huggingface', 'assets'),
+    TORCH_HOME: join(cacheRoot, 'torch'),
+    TORCHINDUCTOR_CACHE_DIR: join(cacheRoot, 'torch', 'inductor'),
+    TORCH_EXTENSIONS_DIR: join(cacheRoot, 'torch', 'extensions'),
+    PYTORCH_KERNEL_CACHE_PATH: join(cacheRoot, 'torch', 'kernels'),
+    TRITON_CACHE_DIR: join(cacheRoot, 'torch', 'triton'),
+    NUMBA_CACHE_DIR: join(cacheRoot, 'numba'),
+    R_USER_CACHE_DIR: join(cacheRoot, 'r')
+  }
+}
+
+export const prepareNotebookWorkloadCache = (runtimeRoot: string): NodeJS.ProcessEnv => {
+  const cacheRoot = notebookWorkloadCacheRoot(runtimeRoot)
+  const cacheParent = dirname(cacheRoot)
+  let created = false
+
+  try {
+    // Validate the parent before creating the removable subtree. A linked runtime/cache directory could
+    // otherwise redirect both cache writes and the later recursive cleanup outside the data root.
+    mkdirSync(runtimeRoot, { recursive: true, mode: 0o700 })
+    try {
+      const parentState = lstatSync(cacheParent)
+      if (!parentState.isDirectory() || parentState.isSymbolicLink()) {
+        throw new Error('Notebook workload cache parent is not a trusted directory.')
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+      mkdirSync(cacheParent, { mode: 0o700 })
+    }
+    if (!isExpectedPhysicalChild(runtimeRoot, cacheParent, 'cache')) {
+      throw new Error('Notebook workload cache parent resolves to an unexpected physical path.')
+    }
+
+    let state
+    try {
+      state = lstatSync(cacheRoot)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+      mkdirSync(cacheRoot, { mode: 0o700 })
+      created = true
+      state = lstatSync(cacheRoot)
+    }
+
+    if (!state.isDirectory() || state.isSymbolicLink()) {
+      throw new Error('Notebook workload cache path is not a trusted directory.')
+    }
+    if (!isExpectedPhysicalChild(cacheParent, cacheRoot, 'notebook')) {
+      throw new Error('Notebook workload cache resolves to an unexpected physical path.')
+    }
+    const marker = expectedMarker(cacheRoot)
+
+    // Keep ownership authority in the protected parent, outside the subtree exposed to kernels and
+    // shells. Deleting the disposable cache root then leaves enough authority for the main process to
+    // recreate it safely on the next operation.
+    const markerPath = join(cacheParent, MARKER_FILE)
+    let existing: WorkloadCacheMarker | undefined
+    try {
+      existing = JSON.parse(readFileSync(markerPath, 'utf8')) as WorkloadCacheMarker
+    } catch (error) {
+      if (!created || (error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw new Error('Notebook workload cache ownership marker is missing or unreadable.')
+      }
+      writeFileSync(markerPath, `${JSON.stringify(marker)}\n`, {
+        encoding: 'utf8',
+        mode: 0o600,
+        flag: 'wx'
+      })
+    }
+    if (existing && !markerMatches(existing, marker)) {
+      throw new Error('Notebook workload cache ownership marker does not match this location.')
+    }
+  } catch (error) {
+    if (created) {
+      try {
+        rmSync(cacheRoot, { recursive: true, force: true })
+      } catch {
+        // Preserve the preparation failure; later startup can inspect any residue.
+      }
+    }
+    throw error
+  }
+
+  return notebookWorkloadCacheEnv(runtimeRoot)
+}
+
+export const removeNotebookWorkloadCache = (runtimeRoot: string): boolean => {
+  const cacheRoot = notebookWorkloadCacheRoot(runtimeRoot)
+  const cacheParent = dirname(cacheRoot)
+  try {
+    let parentState: ReturnType<typeof lstatSync>
+    try {
+      parentState = lstatSync(cacheParent)
+    } catch (error) {
+      return (error as NodeJS.ErrnoException).code === 'ENOENT'
+    }
+    if (!parentState.isDirectory() || parentState.isSymbolicLink()) return false
+    if (!isExpectedPhysicalChild(runtimeRoot, cacheParent, 'cache')) return false
+    const markerPath = join(cacheParent, MARKER_FILE)
+    let state: ReturnType<typeof lstatSync>
+    try {
+      state = lstatSync(cacheRoot)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return false
+      try {
+        const existing = JSON.parse(readFileSync(markerPath, 'utf8')) as WorkloadCacheMarker
+        if (
+          !markerMatches(existing, {
+            schema: 1,
+            kind: MARKER_KIND,
+            canonicalRoot: join(realpathSync.native(cacheParent), 'notebook')
+          })
+        )
+          return false
+        rmSync(markerPath, { force: true })
+        return true
+      } catch (markerError) {
+        return (markerError as NodeJS.ErrnoException).code === 'ENOENT'
+      }
+    }
+    if (!state.isDirectory() || state.isSymbolicLink()) return false
+    if (!isExpectedPhysicalChild(cacheParent, cacheRoot, 'notebook')) return false
+    const marker = expectedMarker(cacheRoot)
+    const existing = JSON.parse(readFileSync(markerPath, 'utf8')) as WorkloadCacheMarker
+    if (!markerMatches(existing, marker)) return false
+    rmSync(cacheRoot, { recursive: true, force: true })
+    rmSync(markerPath, { force: true })
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/main/notebook/notebook-workload-cache.test.ts
+++ b/src/main/notebook/notebook-workload-cache.test.ts
@@ -1,0 +1,155 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  notebookWorkloadCacheRoot,
+  prepareNotebookWorkloadCache,
+  removeNotebookWorkloadCache
+} from './notebook-workload-cache-paths'
+
+const roots: string[] = []
+const makeRuntime = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'open-science-workload-cache-'))
+  roots.push(root)
+  return join(root, '数据', 'OpenScience', 'runtime')
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('NotebookWorkloadCache', () => {
+  it('prepares one marker-owned Unicode cache root and cache-only environment projection', () => {
+    const runtimeRoot = makeRuntime()
+    const cacheRoot = notebookWorkloadCacheRoot(runtimeRoot)
+
+    const env = prepareNotebookWorkloadCache(runtimeRoot)
+
+    expect(env).toEqual({
+      OPEN_SCIENCE_NOTEBOOK_CACHE_DIR: cacheRoot,
+      PIP_CACHE_DIR: join(cacheRoot, 'pip'),
+      UV_CACHE_DIR: join(cacheRoot, 'uv'),
+      HF_HUB_CACHE: join(cacheRoot, 'huggingface', 'hub'),
+      HF_DATASETS_CACHE: join(cacheRoot, 'huggingface', 'datasets'),
+      HF_XET_CACHE: join(cacheRoot, 'huggingface', 'xet'),
+      HF_ASSETS_CACHE: join(cacheRoot, 'huggingface', 'assets'),
+      TORCH_HOME: join(cacheRoot, 'torch'),
+      TORCHINDUCTOR_CACHE_DIR: join(cacheRoot, 'torch', 'inductor'),
+      TORCH_EXTENSIONS_DIR: join(cacheRoot, 'torch', 'extensions'),
+      PYTORCH_KERNEL_CACHE_PATH: join(cacheRoot, 'torch', 'kernels'),
+      TRITON_CACHE_DIR: join(cacheRoot, 'torch', 'triton'),
+      NUMBA_CACHE_DIR: join(cacheRoot, 'numba'),
+      R_USER_CACHE_DIR: join(cacheRoot, 'r')
+    })
+    expect(
+      JSON.parse(
+        readFileSync(join(runtimeRoot, 'cache', '.open-science-notebook-cache.json'), 'utf8')
+      )
+    ).toEqual({
+      schema: 1,
+      kind: 'notebook-workload-cache',
+      canonicalRoot: realpathSync.native(cacheRoot)
+    })
+    expect(existsSync(join(cacheRoot, '.open-science-notebook-cache.json'))).toBe(false)
+    expect(existsSync(join(cacheRoot, 'pip'))).toBe(false)
+  })
+
+  it('recreates a user-deleted cache subtree from its protected sibling marker', () => {
+    const runtimeRoot = makeRuntime()
+    const cacheRoot = notebookWorkloadCacheRoot(runtimeRoot)
+    prepareNotebookWorkloadCache(runtimeRoot)
+
+    rmSync(cacheRoot, { recursive: true, force: true })
+
+    expect(() => prepareNotebookWorkloadCache(runtimeRoot)).not.toThrow()
+    expect(existsSync(cacheRoot)).toBe(true)
+  })
+
+  it('removes only a matching marker-owned cache subtree', () => {
+    const runtimeRoot = makeRuntime()
+    const cacheRoot = notebookWorkloadCacheRoot(runtimeRoot)
+    prepareNotebookWorkloadCache(runtimeRoot)
+    const sibling = join(runtimeRoot, 'keep.txt')
+    writeFileSync(sibling, 'keep')
+
+    expect(removeNotebookWorkloadCache(runtimeRoot)).toBe(true)
+
+    expect(existsSync(cacheRoot)).toBe(false)
+    expect(readFileSync(sibling, 'utf8')).toBe('keep')
+  })
+
+  it('treats an absent cache as already removed', () => {
+    const runtimeRoot = makeRuntime()
+
+    expect(removeNotebookWorkloadCache(runtimeRoot)).toBe(true)
+  })
+
+  it('removes a matching orphaned sibling marker when the cache subtree is absent', () => {
+    const runtimeRoot = makeRuntime()
+    const cacheRoot = notebookWorkloadCacheRoot(runtimeRoot)
+    const cacheParent = join(runtimeRoot, 'cache')
+    const markerPath = join(cacheParent, '.open-science-notebook-cache.json')
+    prepareNotebookWorkloadCache(runtimeRoot)
+    rmSync(cacheRoot, { recursive: true })
+
+    expect(removeNotebookWorkloadCache(runtimeRoot)).toBe(true)
+    expect(existsSync(markerPath)).toBe(false)
+  })
+
+  it('accepts a runtime reached through a trusted ancestor alias', () => {
+    const sandbox = mkdtempSync(join(tmpdir(), 'open-science-workload-cache-alias-'))
+    roots.push(sandbox)
+    const physicalRoot = join(sandbox, 'physical')
+    const aliasRoot = join(sandbox, 'alias')
+    mkdirSync(physicalRoot)
+    symlinkSync(physicalRoot, aliasRoot, process.platform === 'win32' ? 'junction' : 'dir')
+    const runtimeRoot = join(aliasRoot, 'runtime')
+    const physicalRuntimeRoot = join(physicalRoot, 'runtime')
+
+    expect(() => prepareNotebookWorkloadCache(runtimeRoot)).not.toThrow()
+    expect(existsSync(notebookWorkloadCacheRoot(runtimeRoot))).toBe(true)
+    expect(() => prepareNotebookWorkloadCache(physicalRuntimeRoot)).not.toThrow()
+    expect(removeNotebookWorkloadCache(physicalRuntimeRoot)).toBe(true)
+  })
+
+  it('refuses a pre-existing unmarked or mismatched directory', () => {
+    const runtimeRoot = makeRuntime()
+    const cacheRoot = notebookWorkloadCacheRoot(runtimeRoot)
+    mkdirSync(cacheRoot, { recursive: true })
+    writeFileSync(join(cacheRoot, 'foreign.txt'), 'keep')
+
+    expect(() => prepareNotebookWorkloadCache(runtimeRoot)).toThrow(/ownership marker/i)
+    expect(removeNotebookWorkloadCache(runtimeRoot)).toBe(false)
+    expect(readFileSync(join(cacheRoot, 'foreign.txt'), 'utf8')).toBe('keep')
+  })
+
+  it('refuses a linked cache parent without writing to or deleting its target', () => {
+    const runtimeRoot = makeRuntime()
+    const linkedTarget = mkdtempSync(join(tmpdir(), 'open-science-foreign-cache-'))
+    roots.push(linkedTarget)
+    mkdirSync(runtimeRoot, { recursive: true })
+    symlinkSync(
+      linkedTarget,
+      join(runtimeRoot, 'cache'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    writeFileSync(join(linkedTarget, 'foreign.txt'), 'keep')
+
+    expect(() => prepareNotebookWorkloadCache(runtimeRoot)).toThrow(/parent.*trusted directory/i)
+    expect(removeNotebookWorkloadCache(runtimeRoot)).toBe(false)
+    expect(readFileSync(join(linkedTarget, 'foreign.txt'), 'utf8')).toBe('keep')
+  })
+})

--- a/src/main/notebook/operation-journal.test.ts
+++ b/src/main/notebook/operation-journal.test.ts
@@ -198,6 +198,73 @@ describe('RuntimeOperationJournal', () => {
     expect(await journal.readState()).toBe('corrupt')
   })
 
+  it('validates persisted archive publication evidence fail-closed', async () => {
+    const path = await journalPath()
+    const journal = new RuntimeOperationJournal(path)
+    await mkdir(dirname(path), { recursive: true })
+    const publication = {
+      workingRoot: 'D:\\OpenScienceTmp\\m-test',
+      authorizations: [{ file: 'python-1.conda', algorithm: 'sha256', digest: 'a'.repeat(64) }]
+    }
+
+    await writeFile(
+      path,
+      JSON.stringify([{ ...record(), archivePublications: [publication] }]),
+      'utf8'
+    )
+    expect(await journal.readState()).not.toBe('corrupt')
+
+    await writeFile(
+      path,
+      JSON.stringify([{ ...record(), archivePublicationPending: true }]),
+      'utf8'
+    )
+    expect(await journal.readState()).not.toBe('corrupt')
+
+    for (const invalidPending of [
+      { archivePublicationPending: false },
+      { archivePublicationPending: true, archivePublications: [publication] }
+    ]) {
+      await writeFile(path, JSON.stringify([{ ...record(), ...invalidPending }]), 'utf8')
+      expect(await journal.readState()).toBe('corrupt')
+    }
+
+    for (const archivePublications of [
+      [],
+      [{ ...publication, workingRoot: '' }],
+      [{ ...publication, authorizations: [] }],
+      [
+        {
+          ...publication,
+          authorizations: [
+            { file: '../python-1.conda', algorithm: 'sha256', digest: 'a'.repeat(64) }
+          ]
+        }
+      ],
+      [
+        {
+          ...publication,
+          authorizations: [{ file: 'python-1.conda', algorithm: 'sha256', digest: 'bad' }]
+        }
+      ]
+    ]) {
+      await writeFile(path, JSON.stringify([{ ...record(), archivePublications }]), 'utf8')
+      expect(await journal.readState()).toBe('corrupt')
+    }
+
+    await writeFile(
+      path,
+      JSON.stringify([
+        {
+          ...record({ childPid: 4242, childStartedAt: 100 }),
+          archivePublications: [publication]
+        }
+      ]),
+      'utf8'
+    )
+    expect(await journal.readState()).toBe('corrupt')
+  })
+
   it('treats a record with a PRESENT-but-malformed childStartToken as corrupt (fail-closed)', async () => {
     const path = await journalPath()
     const journal = new RuntimeOperationJournal(path)

--- a/src/main/notebook/operation-journal.ts
+++ b/src/main/notebook/operation-journal.ts
@@ -3,6 +3,8 @@ import { mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync
 import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
+import type { MicromambaArchiveAuthorization } from './micromamba-archive-store'
+
 // The journal file for a runtime root (<storageRoot>/runtime). Derived from the root so the write side
 // (provisioner/fetch) and the startup recovery side agree on one path without sharing an instance.
 export const operationJournalPath = (runtimeRoot: string): string =>
@@ -237,6 +239,11 @@ export const listOperationChildren = (
 // next startup can reconcile (redownload/verify/repair). See notebook-runtime-crash-recovery.
 export type RuntimeOperationKind = 'download' | 'materialize' | 'upgrade' | 'install' | 'disable'
 
+export type RuntimeArchivePublication = {
+  workingRoot: string
+  authorizations: readonly MicromambaArchiveAuthorization[]
+}
+
 export type RuntimeOperationRecord = {
   operationId: string
   kind: RuntimeOperationKind
@@ -264,6 +271,18 @@ export type RuntimeOperationRecord = {
   // — a malformed value fails closed). Absent off Linux / on legacy records — a live pid with no token is
   // then always 'unknown' (a wall-clock start time can't soundly prove a live pid dead).
   childStartToken?: string
+  // Persisted before a mutation that can create relocatable package archives. If the process dies after
+  // the child commits but before exact filename/digest authority is recorded, recovery cannot safely
+  // publish or discard the working cache. It therefore blocks the target and retains the cache until an
+  // explicit repair. A normal settled operation atomically removes this flag while recording either its
+  // archivePublications or the fact that there are none.
+  archivePublicationPending?: true
+  // Present only after the runtime mutation itself has committed. Keeping the exact working-cache path
+  // and immutable transaction/lock digests in the journal makes archive publication crash-recoverable:
+  // recovery publishes these verified bytes before clearing this record and cleaning the disposable
+  // cache. Absence means the runtime operation itself may have been interrupted and needs its normal
+  // reconcile action.
+  archivePublications?: readonly RuntimeArchivePublication[]
   // TRANSIENT, recovery-only: set from the child-state sidecar during hydration when the op reached the
   // spawn stage ({ spawning: true }) but no PID was ever recorded. It is never persisted to the journal;
   // it tells recovery "a child MAY be live, PID unknown" so it blocks rather than reconciles.
@@ -469,6 +488,56 @@ const hasValidChildGroup = (record: Record<string, unknown>): boolean => {
   )
 }
 
+const isArchiveAuthorization = (value: unknown): value is MicromambaArchiveAuthorization => {
+  if (typeof value !== 'object' || value === null) return false
+  const authorization = value as Record<string, unknown>
+  return (
+    typeof authorization.file === 'string' &&
+    authorization.file.length > 0 &&
+    !/[\\/]/u.test(authorization.file) &&
+    /\.(?:conda|tar\.bz2)$/iu.test(authorization.file) &&
+    ((authorization.algorithm === 'sha256' &&
+      typeof authorization.digest === 'string' &&
+      /^[0-9a-f]{64}$/iu.test(authorization.digest)) ||
+      (authorization.algorithm === 'md5' &&
+        typeof authorization.digest === 'string' &&
+        /^[0-9a-f]{32}$/iu.test(authorization.digest)))
+  )
+}
+
+const hasValidArchivePublications = (record: Record<string, unknown>): boolean => {
+  if (
+    (record.archivePublicationPending !== undefined && record.archivePublicationPending !== true) ||
+    (record.archivePublicationPending === true && record.archivePublications !== undefined)
+  ) {
+    return false
+  }
+  if (record.archivePublications === undefined) return true
+  if (!Array.isArray(record.archivePublications) || record.archivePublications.length === 0) {
+    return false
+  }
+  // Publication intent is written only after the mutation and every child has settled. A record that
+  // claims both a pending publication and a live child is contradictory and must fail closed.
+  if (
+    record.childPid !== undefined ||
+    record.childStartedAt !== undefined ||
+    record.childStartToken !== undefined
+  ) {
+    return false
+  }
+  return record.archivePublications.every((value) => {
+    if (typeof value !== 'object' || value === null) return false
+    const publication = value as Record<string, unknown>
+    return (
+      typeof publication.workingRoot === 'string' &&
+      publication.workingRoot.length > 0 &&
+      Array.isArray(publication.authorizations) &&
+      publication.authorizations.length > 0 &&
+      publication.authorizations.every(isArchiveAuthorization)
+    )
+  })
+}
+
 const isOperationRecord = (value: unknown): value is RuntimeOperationRecord => {
   if (typeof value !== 'object' || value === null) return false
   const record = value as Record<string, unknown>
@@ -483,6 +552,7 @@ const isOperationRecord = (value: unknown): value is RuntimeOperationRecord => {
       record.repairReason === 'protected-identity-change') &&
     // Child fields are validated as a lifecycle GROUP (parity with the sidecar's exact-shape rule):
     // all-absent or a complete {childPid + childStartedAt (+ token?)}, never a partial subset.
-    hasValidChildGroup(record)
+    hasValidChildGroup(record) &&
+    hasValidArchivePublications(record)
   )
 }

--- a/src/main/notebook/operation-recovery.test.ts
+++ b/src/main/notebook/operation-recovery.test.ts
@@ -80,6 +80,122 @@ describe('reconcileInterruptedOperations', () => {
     expect(await journal.pending()).toEqual([])
   })
 
+  it('publishes a committed archive intent without replaying interrupted-install recovery', async () => {
+    const journal = await newJournal()
+    const committed = record({
+      kind: 'install',
+      archivePublications: [
+        {
+          workingRoot: '/working-cache',
+          authorizations: [{ file: 'numpy-1.conda', algorithm: 'sha256', digest: 'a'.repeat(64) }]
+        }
+      ]
+    })
+    await journal.begin(committed)
+    const deps = makeDeps({ publishArchives: vi.fn().mockResolvedValue(undefined) })
+
+    await expect(reconcileInterruptedOperations(journal, deps)).resolves.toEqual([committed])
+
+    expect(deps.publishArchives).toHaveBeenCalledWith(committed)
+    expect(deps.markRepairRequired).not.toHaveBeenCalled()
+    expect(deps.operationChildLiveness).not.toHaveBeenCalled()
+    expect(await journal.pending()).toEqual([])
+  })
+
+  it('blocks the target when recovered archive publication fails', async () => {
+    const journal = await newJournal()
+    const committed = record({
+      kind: 'install',
+      targetPath: '/runtime/envs/analysis',
+      archivePublications: [
+        {
+          workingRoot: '/working-cache',
+          authorizations: [{ file: 'numpy-1.conda', algorithm: 'sha256', digest: 'a'.repeat(64) }]
+        }
+      ]
+    })
+    await journal.begin(committed)
+    const deps = makeDeps({
+      publishArchives: vi.fn().mockRejectedValue(new Error('disk full')),
+      onRetained: vi.fn()
+    })
+
+    await expect(reconcileInterruptedOperations(journal, deps)).resolves.toEqual([])
+
+    expect(deps.blockUnknownChildTarget).toHaveBeenCalledWith(committed)
+    expect(deps.onRetained).toHaveBeenCalledWith(committed)
+    expect(await journal.pending()).toEqual([committed])
+  })
+
+  it('retains a committed archive intent while its hydrated child evidence is unconfirmed', async () => {
+    const journal = await newJournal()
+    await journal.begin(
+      record({
+        kind: 'install',
+        archivePublications: [
+          {
+            workingRoot: '/working-cache',
+            authorizations: [{ file: 'numpy-1.conda', algorithm: 'sha256', digest: 'a'.repeat(64) }]
+          }
+        ]
+      })
+    )
+    const deps = makeDeps({
+      hydrateInterruptedChild: (pending) => ({ ...pending, spawnAttempted: true }),
+      publishArchives: vi.fn().mockResolvedValue(undefined),
+      onRetained: vi.fn()
+    })
+
+    await expect(reconcileInterruptedOperations(journal, deps)).resolves.toEqual([])
+
+    expect(deps.blockUnknownChildTarget).toHaveBeenCalledOnce()
+    expect(deps.publishArchives).not.toHaveBeenCalled()
+    expect(deps.onRetained).toHaveBeenCalledOnce()
+    expect(await journal.pending()).toHaveLength(1)
+  })
+
+  it('blocks and retains a cache whose post-mutation publication authority was never persisted', async () => {
+    const journal = await newJournal()
+    const ambiguous = record({
+      kind: 'install',
+      targetPath: '/runtime/envs/analysis',
+      archivePublicationPending: true
+    })
+    await journal.begin(ambiguous)
+    const deps = makeDeps({
+      publishArchives: vi.fn().mockResolvedValue(undefined),
+      onRetained: vi.fn(),
+      onReconciled: vi.fn()
+    })
+
+    await expect(reconcileInterruptedOperations(journal, deps)).resolves.toEqual([])
+
+    expect(deps.blockUnknownChildTarget).toHaveBeenCalledWith(ambiguous)
+    expect(deps.markRepairRequired).not.toHaveBeenCalled()
+    expect(deps.publishArchives).not.toHaveBeenCalled()
+    expect(deps.onRetained).toHaveBeenCalledWith(ambiguous)
+    expect(await journal.pending()).toEqual([ambiguous])
+  })
+
+  it('persists a protected repair reason before retaining ambiguous archive evidence', async () => {
+    const journal = await newJournal()
+    const ambiguous = record({
+      kind: 'install',
+      targetPath: '/runtime/envs/analysis',
+      repairReason: 'protected-identity-change',
+      archivePublicationPending: true
+    })
+    await journal.begin(ambiguous)
+    const deps = makeDeps({ onRetained: vi.fn() })
+
+    await expect(reconcileInterruptedOperations(journal, deps)).resolves.toEqual([])
+
+    expect(deps.markRepairRequired).toHaveBeenCalledWith(ambiguous)
+    expect(deps.blockUnknownChildTarget).toHaveBeenCalledWith(ambiguous)
+    expect(deps.onRetained).toHaveBeenCalledWith(ambiguous)
+    expect(await journal.pending()).toEqual([ambiguous])
+  })
+
   it('BLOCKS (never kills or reconciles) a surviving orphan child instead of signalling it', async () => {
     // Design: recovery never auto-signals a possibly-live orphan (no strict "safe to kill" guarantee).
     // A live child surfaces as liveness 'unknown', so the op is blocked and its entry is LEFT for a

--- a/src/main/notebook/operation-recovery.ts
+++ b/src/main/notebook/operation-recovery.ts
@@ -39,8 +39,19 @@ export type OperationRecoveryDeps = {
   // journal entry only helps the NEXT boot; THIS session would still race the orphan once recovery
   // "completes" and the barrier opens.
   blockUnknownChildTarget: (record: RuntimeOperationRecord) => Promise<void>
+  // A record carrying archivePublications has already committed its runtime mutation. Recovery must
+  // publish those transaction-authorized archives before clearing the journal; it must not rerun the
+  // normal interrupted-operation action (notably, a successful install must not be marked broken).
+  publishArchives?: (record: RuntimeOperationRecord) => Promise<void>
+  // The coordinator defers clearing successfully published records until their exact disposable cache
+  // roots are also removed. Keeping the record durable makes a transient cleanup failure retryable even
+  // when the recorded TEMP fallback is no longer one of the current process's candidates.
+  deferArchiveCompletion?: boolean
   // Observed reconcile outcome per record (telemetry/tests). action is the branch taken.
   onReconciled?: (record: RuntimeOperationRecord, action: RecoveryAction) => void
+  // Reports a record left pending because its child is unconfirmed or its recovery action failed.
+  // Startup uses this to retain shared disposable state without rereading the journal.
+  onRetained?: (record: RuntimeOperationRecord) => void
   // Fills in a record's childPid/childStartedAt from the SYNCHRONOUS PID sidecar when the journal's
   // async childPid update was lost to a crash. Returns the record enriched (or unchanged). This is what
   // makes a missing childPid provably mean "never spawned" (safe to reconcile) rather than a guess.
@@ -95,13 +106,47 @@ export const reconcileInterruptedOperations = async (
         // journal entry so a LATER startup — when the pid is provably gone — reconciles it. The env
         // self-heals on a subsequent boot; we never destroy data on a guess.
         await deps.blockUnknownChildTarget(record)
+        deps.onRetained?.(record)
         deps.onReconciled?.(record, 'skipped-child-unknown')
+        continue
+      }
+      if (record.archivePublicationPending) {
+        // The mutation may have committed, but the process died before immutable archive authority was
+        // persisted. Normal interrupted-operation repair could be safe for the prefix yet must not also
+        // authorize deletion of the only retained archive bytes. Keep both target and working cache
+        // blocked; an explicit repair can discard them, but recovery never guesses whether to publish.
+        // A protected interpreter change is independent, stronger evidence and must remain durable too.
+        if (record.kind === 'install' && record.repairReason === 'protected-identity-change') {
+          await deps.markRepairRequired(record)
+        }
+        await deps.blockUnknownChildTarget(record)
+        deps.onRetained?.(record)
+        continue
+      }
+      if (record.archivePublications) {
+        if (!deps.publishArchives) {
+          throw new Error('archive publication recovery is not configured')
+        }
+        await deps.publishArchives(record)
+        if (!deps.deferArchiveCompletion) await journal.complete(record.operationId)
+        reconciled.push(record)
         continue
       }
       await runReconcileAction(record, deps)
       await journal.complete(record.operationId)
       reconciled.push(record)
     } catch (error) {
+      if (raw.archivePublications) {
+        try {
+          await deps.blockUnknownChildTarget(raw)
+        } catch (blockError) {
+          console.error(
+            `[notebook] could not block cache publication recovery for ${raw.operationId}`,
+            blockError
+          )
+        }
+      }
+      deps.onRetained?.(raw)
       console.error(
         `[notebook] operation recovery failed for ${raw.operationId}; leaving journal entry`,
         error

--- a/src/main/notebook/package-manager.test.ts
+++ b/src/main/notebook/package-manager.test.ts
@@ -20,7 +20,7 @@ import {
   type InstallSpawn,
   type SpawnResult
 } from './package-manager'
-import { micromambaCacheLockKey, selectMicromambaCache } from './micromamba-cache'
+import { micromambaCacheLockKey } from './micromamba-cache'
 import { withExclusiveCacheLock } from './pkgs-cache-lock'
 import { CHILD_UNCONFIRMED } from './provisioner-runtime'
 import {
@@ -92,6 +92,8 @@ const notManaged: SpawnResult = {
 const base = {
   micromamba: '/mm/bin/micromamba',
   storageRoot: '/root',
+  // Keep baseline tests hermetic on Windows; Windows cache behavior is covered by explicit overrides.
+  micromambaEnv: { platform: 'linux' as const },
   condaChannel: 'https://mirror.test/conda-forge',
   readCondaPackageIdentity: () => ({
     name: 'r-base',
@@ -180,7 +182,7 @@ describe('defaultSpawn (fail-closed spawn hooks)', () => {
         `error: ['Invalid package cache; file is missing; Package cache error', String.fromCharCode(39) + 'C:/cache/' + 'p'.repeat(280) + String.fromCharCode(39), 'for ' + String.fromCharCode(39) + 'broken-package-1.0-0.conda' + String.fromCharCode(39)],`,
         `padding: 'x'.repeat(${INSTALLER_STREAM_LOG_LIMIT_BYTES}),`,
         `solver_problems: ['unsatisfiable dependency constraints'],`,
-        `actions: { LINK: [{ name: 'r-base', version: '4.5.0' }], UNLINK: [] }`,
+        `actions: { LINK: [{ name: 'r-base', version: '4.5.0' }], UNLINK: [], FETCH: [{ fn: 'r-base-4.5.0.conda', sha256: 'a'.repeat(64) }] }`,
         `};`,
         `process.stdout.write(JSON.stringify(value));`
       ].join(''),
@@ -197,10 +199,48 @@ describe('defaultSpawn (fail-closed spawn hooks)', () => {
         LINK: [{ name: 'r-base', version: '4.5.0' }],
         UNLINK: []
       },
+      archives: [{ file: 'r-base-4.5.0.conda', algorithm: 'sha256', digest: 'a'.repeat(64) }],
+      archiveEvidenceComplete: true,
       diagnostics: ['solver failed']
     })
     expect(result.maxPathRecoveryEvidence).toMatch(/Invalid package cache/)
     expect(result.maxPathRecoveryEvidence).toContain('broken-package-1.0-0.conda')
+  })
+
+  it('marks summarized archive evidence incomplete instead of silently capping it', async () => {
+    const result = await defaultSpawn(process.execPath, [
+      '-e',
+      [
+        `const fetch = Array.from({ length: 1025 }, (_, index) => ({ fn: 'pkg-' + index + '.conda', sha256: index.toString(16).padStart(64, '0') }));`,
+        `const value = { padding: 'x'.repeat(${INSTALLER_STREAM_LOG_LIMIT_BYTES}), actions: { FETCH: fetch } };`,
+        `process.stdout.write(JSON.stringify(value));`
+      ].join(''),
+      '--',
+      '--json'
+    ])
+
+    expect(result.code).toBe(0)
+    expect(result.stdoutDroppedBytes).toBeGreaterThan(0)
+    expect(result.structuredCondaResult?.archives).toHaveLength(1024)
+    expect(result.structuredCondaResult?.archiveEvidenceComplete).toBe(false)
+  })
+
+  it('retains archive authority from summarized URLs with query parameters', async () => {
+    const result = await defaultSpawn(process.execPath, [
+      '-e',
+      [
+        `const value = { padding: 'x'.repeat(${INSTALLER_STREAM_LOG_LIMIT_BYTES}), actions: { FETCH: [{ url: 'https://packages.example.test/pkg-1.0-0.conda?token=temporary', sha256: 'b'.repeat(64) }] } };`,
+        `process.stdout.write(JSON.stringify(value));`
+      ].join(''),
+      '--',
+      '--json'
+    ])
+
+    expect(result.stdoutDroppedBytes).toBeGreaterThan(0)
+    expect(result.structuredCondaResult?.archives).toEqual([
+      { file: 'pkg-1.0-0.conda', algorithm: 'sha256', digest: 'b'.repeat(64) }
+    ])
+    expect(result.structuredCondaResult?.archiveEvidenceComplete).toBe(true)
   })
 
   it('fails closed when micromamba JSON exceeds the bounded temporary capture', async () => {
@@ -304,6 +344,70 @@ describe('installPackages', () => {
     expect(result.ok).toBe(true)
     expect(runner.resolve).toHaveBeenCalledOnce()
     expect(calls[0][0]).toBe('/local-tools/micromamba-compat.exe')
+  })
+
+  it('reports archive digests from the successful micromamba transaction', async () => {
+    const digest = 'a'.repeat(64)
+    const transaction: SpawnResult = {
+      code: 0,
+      stdout: JSON.stringify({
+        success: true,
+        actions: { FETCH: [{ fn: 'numpy-1.conda', sha256: digest }] }
+      }),
+      stderr: ''
+    }
+    const { spawn } = scriptedSpawn([transaction])
+    const onCondaArchiveAuthorizations = vi.fn()
+
+    await installPackages(
+      { language: 'python', packages: ['numpy'] },
+      { spawn, ...base, onCondaArchiveAuthorizations }
+    )
+
+    expect(onCondaArchiveAuthorizations).toHaveBeenCalledWith(
+      [{ file: 'numpy-1.conda', algorithm: 'sha256', digest }],
+      expect.stringMatching(/[\\/]pkgs$/u),
+      true
+    )
+  })
+
+  it('does not report an empty archive publication for a transaction without fetch records', async () => {
+    const transaction: SpawnResult = {
+      code: 0,
+      stdout: JSON.stringify({ success: true, actions: { LINK: [] } }),
+      stderr: ''
+    }
+    const { spawn } = scriptedSpawn([transaction])
+    const onCondaArchiveAuthorizations = vi.fn()
+
+    await installPackages(
+      { language: 'python', packages: ['already-installed'] },
+      { spawn, ...base, onCondaArchiveAuthorizations }
+    )
+
+    expect(onCondaArchiveAuthorizations).not.toHaveBeenCalled()
+  })
+
+  it('reports incomplete archive evidence when successful JSON output was truncated', async () => {
+    const transaction: SpawnResult = {
+      code: 0,
+      stdout: 'truncated-json-tail',
+      stderr: '',
+      stdoutDroppedBytes: 1
+    }
+    const { spawn } = scriptedSpawn([transaction])
+    const onCondaArchiveAuthorizations = vi.fn()
+
+    await installPackages(
+      { language: 'python', packages: ['numpy'] },
+      { spawn, ...base, onCondaArchiveAuthorizations }
+    )
+
+    expect(onCondaArchiveAuthorizations).toHaveBeenCalledWith(
+      [],
+      expect.stringMatching(/[\\/]pkgs$/u),
+      false
+    )
   })
 
   it('routes python usePip installs to the env pip with the resolved index url', async () => {
@@ -799,6 +903,7 @@ describe('installPackages', () => {
       structuredCondaResult: {
         transaction: false,
         actions: { LINK: [], UNLINK: [] },
+        archives: [],
         diagnostics: ['solver failed']
       }
     }
@@ -884,6 +989,23 @@ describe('installPackages', () => {
     expect(env.REQUESTS_CA_BUNDLE).toBe('/etc/corp-ca.pem')
     expect(env.PIP_CERT).toBe('/etc/corp-ca.pem')
     expect(env.CURL_CA_BUNDLE).toBe('/etc/corp-ca.pem')
+  })
+
+  it('routes pip and R workload caches under the configured data storage runtime', async () => {
+    const { spawn, calls } = scriptedSpawn([ok])
+    await installPackages(
+      { language: 'python', packages: ['numpy'], usePip: true },
+      { spawn, ...base }
+    )
+    const env = calls[0][2] ?? {}
+    const cacheRoot = join(runtimeRoot(base.storageRoot), 'cache', 'notebook')
+
+    expect(env).toMatchObject({
+      OPEN_SCIENCE_NOTEBOOK_CACHE_DIR: cacheRoot,
+      PIP_CACHE_DIR: join(cacheRoot, 'pip'),
+      UV_CACHE_DIR: join(cacheRoot, 'uv'),
+      R_USER_CACHE_DIR: join(cacheRoot, 'r')
+    })
   })
 
   it('does not set CA vars when no bundle is configured', async () => {
@@ -1787,12 +1909,12 @@ describe('installPackages shared pkgs cache lock', () => {
     // on the same key the source uses.
     const install = installPackages({ language: 'python', packages: ['numpy'] }, { spawn, ...base })
     await installStarted
-    const exclusive = withExclusiveCacheLock(
-      selectMicromambaCache(runtimeRoot('/root')).lockKey,
-      async () => {
-        order.push('repair')
-      }
-    )
+    const cacheKey = micromambaCacheLockKey(join(runtimeRoot(base.storageRoot), 'pkgs'), {
+      platform: 'linux'
+    })
+    const exclusive = withExclusiveCacheLock(cacheKey, async () => {
+      order.push('repair')
+    })
     await Promise.all([install, exclusive])
 
     expect(order).toEqual(['install-start', 'install-end', 'repair'])
@@ -1823,12 +1945,12 @@ describe('installPackages shared pkgs cache lock', () => {
       { spawn, ...base, pathExists: () => true }
     )
     await removeStarted
-    const exclusive = withExclusiveCacheLock(
-      selectMicromambaCache(runtimeRoot('/root')).lockKey,
-      async () => {
-        order.push('repair')
-      }
-    )
+    const cacheKey = micromambaCacheLockKey(join(runtimeRoot(base.storageRoot), 'pkgs'), {
+      platform: 'linux'
+    })
+    const exclusive = withExclusiveCacheLock(cacheKey, async () => {
+      order.push('repair')
+    })
     await Promise.all([remove, exclusive])
 
     expect(order).toEqual(['remove-start', 'remove-end', 'repair'])
@@ -1850,12 +1972,12 @@ describe('installPackages shared pkgs cache lock', () => {
       { language: 'python', packages: ['seaborn'], usePip: true, environment: 'my-analysis' },
       { spawn, ...base, pathExists: () => true }
     )
-    const exclusive = withExclusiveCacheLock(
-      selectMicromambaCache(runtimeRoot('/root')).lockKey,
-      async () => {
-        order.push('repair')
-      }
-    )
+    const cacheKey = micromambaCacheLockKey(join(runtimeRoot(base.storageRoot), 'pkgs'), {
+      platform: 'linux'
+    })
+    const exclusive = withExclusiveCacheLock(cacheKey, async () => {
+      order.push('repair')
+    })
     await Promise.all([install, exclusive])
 
     // The repair interleaved (ran before pip finished) because pip never held the shared lock.

--- a/src/main/notebook/package-manager.ts
+++ b/src/main/notebook/package-manager.ts
@@ -31,6 +31,10 @@ import {
 } from './micromamba'
 import type { MicromambaRunner } from './windows-micromamba-runner'
 import {
+  archiveAuthorizationsFromCondaResult,
+  type MicromambaArchiveAuthorization
+} from './micromamba-archive-store'
+import {
   DEFAULT_MAX_CACHE_RELATIVE_PATH,
   micromambaCacheLockKey,
   selectMicromambaCache,
@@ -41,6 +45,7 @@ import {
   packageCacheCleanArgv
 } from './micromamba-cache-maintenance'
 import { recoverWindowsMaxPathPackage } from './micromamba-cache-recovery'
+import { notebookWorkloadCacheEnv } from './notebook-workload-cache-paths'
 import { withExclusiveCacheLocks, withSharedCacheLocks } from './pkgs-cache-lock'
 import { CHILD_UNCONFIRMED, killAndConfirmExit } from './provisioner-runtime'
 import {
@@ -111,6 +116,8 @@ type CondaStructuredResult = {
     LINK: Array<{ name: 'r-base'; version?: string }>
     UNLINK: Array<{ name: 'r-base'; version?: string }>
   }
+  archives: MicromambaArchiveAuthorization[]
+  archiveEvidenceComplete?: boolean
   diagnostics: string[]
 }
 
@@ -177,6 +184,13 @@ export type InstallDeps = {
   // Invoked after cache maintenance has either completed or failed with its child confirmed stopped.
   // The journal owner uses it to clear the maintenance child's evidence before any solver/install spawn.
   onCacheMaintenanceSettled?: () => Promise<void> | void
+  // Receives digest-bearing archive identities directly from a successful micromamba transaction.
+  // The caller may use these in-memory authorizations to publish notebook-writable cache bytes.
+  onCondaArchiveAuthorizations?: (
+    authorizations: readonly MicromambaArchiveAuthorization[],
+    workingRoot: string,
+    evidenceComplete?: boolean
+  ) => void
 }
 
 const DEFAULT_CONDA_CHANNEL = 'conda-forge'
@@ -238,6 +252,11 @@ const parseStructuredCondaResult = (result: SpawnResult): Record<string, unknown
     }
   }
   return undefined
+}
+
+const condaArchiveAuthorizations = (result: SpawnResult): MicromambaArchiveAuthorization[] => {
+  const structured = parseStructuredCondaResult(result)
+  return structured ? archiveAuthorizationsFromCondaResult(structured) : []
 }
 
 export type CondaPackageIdentity = {
@@ -611,12 +630,42 @@ const strings = (value) =>
 const summarize = (value) => {
   let transaction = false
   const actions = { LINK: [], UNLINK: [] }
+  const archives = []
+  let archiveEvidenceComplete = true
   const visit = (nested) => {
     if (Array.isArray(nested)) {
       nested.forEach(visit)
       return
     }
     if (typeof nested !== 'object' || nested === null) return
+    const file = typeof nested.fn === 'string'
+      ? nested.fn
+      : typeof nested.url === 'string'
+        ? (() => {
+            try {
+              return new URL(nested.url).pathname.split('/').pop()
+            } catch {
+              return undefined
+            }
+          })()
+        : undefined
+    const sha256 = typeof nested.sha256 === 'string' && /^[0-9a-f]{64}$/i.test(nested.sha256)
+      ? nested.sha256.toLowerCase()
+      : undefined
+    const md5 = typeof nested.md5 === 'string' && /^[0-9a-f]{32}$/i.test(nested.md5)
+      ? nested.md5.toLowerCase()
+      : undefined
+    if (typeof file === 'string' && /\.(?:conda|tar\.bz2)$/i.test(file) && (sha256 || md5)) {
+      if (archives.length < 1024) {
+        archives.push({
+          file,
+          algorithm: sha256 ? 'sha256' : 'md5',
+          digest: sha256 || md5
+        })
+      } else {
+        archiveEvidenceComplete = false
+      }
+    }
     for (const [key, child] of Object.entries(nested)) {
       const normalized = key.toUpperCase()
       if (/^(?:LINK|UNLINK|FETCH|PREFIX_ACTIONS|TRANSACTION)$/.test(normalized)) {
@@ -656,6 +705,8 @@ const summarize = (value) => {
   return {
     transaction,
     actions,
+    archives,
+    archiveEvidenceComplete,
     diagnostics: canonicalDiagnostic ? [canonicalDiagnostic] : []
   }
 }
@@ -793,8 +844,19 @@ const isCondaStructuredResult = (value: unknown): value is CondaStructuredResult
     !candidate.actions ||
     !Array.isArray(candidate.actions.LINK) ||
     !Array.isArray(candidate.actions.UNLINK) ||
+    !Array.isArray(candidate.archives) ||
+    !candidate.archives.every(
+      (archive) =>
+        typeof archive === 'object' &&
+        archive !== null &&
+        typeof archive.file === 'string' &&
+        (archive.algorithm === 'md5' || archive.algorithm === 'sha256') &&
+        typeof archive.digest === 'string'
+    ) ||
     !Array.isArray(candidate.diagnostics) ||
-    !candidate.diagnostics.every((diagnostic) => typeof diagnostic === 'string')
+    !candidate.diagnostics.every((diagnostic) => typeof diagnostic === 'string') ||
+    (candidate.archiveEvidenceComplete !== undefined &&
+      typeof candidate.archiveEvidenceComplete !== 'boolean')
   ) {
     return false
   }
@@ -1147,6 +1209,7 @@ export async function installPackages(
     process.env.OPEN_SCIENCE_STORAGE_ROOT ??
     join(homedir(), PROD_SESSION_DIR_NAME)
   const root = runtimeRoot(storageRoot)
+  Object.assign(spawnEnv, notebookWorkloadCacheEnv(root))
   const channels = condaInstallChannels(deps.condaChannel ?? DEFAULT_CONDA_CHANNEL, req.channels)
   const prefix = envPrefix(root, envName)
   // micromamba install/remove extract into and mutate the SHARED pkgs cache (<root>/runtime/pkgs), so
@@ -1221,6 +1284,18 @@ export async function installPackages(
       baseSpawn(command, args, context.env)
     )
   }
+  const reportCondaArchives = (result: SpawnResult, workingRoot: string): void => {
+    const structured = parseStructuredCondaResult(result)
+    const authorizations = condaArchiveAuthorizations(result)
+    const summarizedCompleteness = result.structuredCondaResult?.archiveEvidenceComplete
+    const retainedOutputComplete =
+      (result.stdoutDroppedBytes ?? 0) === 0 && (result.stderrDroppedBytes ?? 0) === 0
+    const evidenceComplete =
+      summarizedCompleteness ?? (retainedOutputComplete && structured !== undefined)
+    if (authorizations.length > 0 || !evidenceComplete) {
+      deps.onCondaArchiveAuthorizations?.(authorizations, workingRoot, evidenceComplete)
+    }
+  }
   const runConda = async (
     command: string,
     args: string[],
@@ -1236,7 +1311,10 @@ export async function installPackages(
       baseSpawn(command, args, context.env, deps.onChild, deps.onBeforeSpawn)
     )
     if (await stopAfterSpawn?.(result)) return result
-    if (result.code === 0) return result
+    if (result.code === 0) {
+      reportCondaArchives(result, context.cache.path)
+      return result
+    }
     const evidence = [result.maxPathRecoveryEvidence, result.stdout, result.stderr]
       .filter(Boolean)
       .join('\n')
@@ -1281,7 +1359,10 @@ export async function installPackages(
           `Retry result after MAX_PATH recovery (stderr):\n${retry.stderr}`
       }
     }
-    if (retry.code === 0) return retry
+    if (retry.code === 0) {
+      reportCondaArchives(retry, context.cache.path)
+      return retry
+    }
     return {
       ...retry,
       ...spawnLogTruncation(result, retry),

--- a/src/main/notebook/package-mutation.test.ts
+++ b/src/main/notebook/package-mutation.test.ts
@@ -254,6 +254,230 @@ describe('NotebookPackageMutationOwner', () => {
     expect(options.runtimeRepair.quarantineProtectedIdentity).not.toHaveBeenCalled()
   })
 
+  it('publishes a successful conda transaction before releasing its working cache', async () => {
+    let finishPublication!: (published: boolean) => void
+    const publication = new Promise<boolean>((resolve) => {
+      finishPublication = resolve
+    })
+    const release = vi.fn(() => publication)
+    const retainWorkingCache = vi.fn(() => release)
+    const installedPrefix = '/runtime/envs/analysis'
+    const archiveAuthorization = {
+      file: 'numpy-1.conda',
+      algorithm: 'sha256' as const,
+      digest: 'a'.repeat(64)
+    }
+    const workingRoot = '/working-cache'
+    const { owner, target, runtimeRoot } = ownerHarness({
+      retainWorkingCache,
+      installPackages: vi.fn(async (_request, deps) => {
+        deps?.onCondaArchiveAuthorizations?.([archiveAuthorization], workingRoot)
+        return {
+          ok: true,
+          needsRestart: false,
+          log: 'installed',
+          method: 'conda' as const,
+          prefix: installedPrefix,
+          attempts: [
+            {
+              groupOrdinal: 0,
+              installer: 'conda' as const,
+              packages: ['numpy'],
+              status: 'succeeded' as const,
+              mutationRisk: 'confirmed' as const
+            }
+          ]
+        }
+      })
+    })
+
+    const mutation = owner.mutate({ target, mirror: {} })
+
+    await vi.waitFor(async () => {
+      expect((await pending(runtimeRoot))[0]).toMatchObject({
+        archivePublications: [{ workingRoot, authorizations: [archiveAuthorization] }]
+      })
+    })
+    finishPublication(true)
+    await expect(mutation).resolves.toMatchObject({ ok: true })
+    expect(await pending(runtimeRoot)).toEqual([])
+
+    expect(retainWorkingCache).toHaveBeenCalledWith(runtimeRoot, expect.any(String))
+    expect(release).toHaveBeenCalledWith({
+      archivePublications: [{ workingRoot, authorizations: [archiveAuthorization] }],
+      completedOperationId: expect.any(String),
+      retainForRecovery: false
+    })
+  })
+
+  it('does not persist an empty archive publication', async () => {
+    const release = vi.fn().mockResolvedValue(true)
+    const { owner, target, runtimeRoot } = ownerHarness({
+      retainWorkingCache: vi.fn(() => release),
+      installPackages: vi.fn(async (_request, deps) => {
+        deps?.onCondaArchiveAuthorizations?.([], '/working-cache')
+        return { ok: true, needsRestart: false, log: 'already installed', method: 'conda' as const }
+      })
+    })
+
+    await expect(owner.mutate({ target, mirror: {} })).resolves.toMatchObject({ ok: true })
+
+    expect(release).toHaveBeenCalledWith({
+      archivePublications: [],
+      completedOperationId: expect.any(String),
+      retainForRecovery: false
+    })
+    expect(await pending(runtimeRoot)).toEqual([])
+  })
+
+  it('retains and blocks when a successful conda result has incomplete archive evidence', async () => {
+    const release = vi.fn().mockResolvedValue(false)
+    const { owner, options, target, runtimeRoot } = ownerHarness({
+      retainWorkingCache: vi.fn(() => release),
+      installPackages: vi.fn(async (_request, deps) => {
+        deps?.onCondaArchiveAuthorizations?.([], '/working-cache', false)
+        return { ok: true, needsRestart: false, log: 'installed', method: 'conda' as const }
+      })
+    })
+
+    await expect(owner.mutate({ target, mirror: {} })).rejects.toThrow(
+      'CACHE_ARCHIVE_EVIDENCE_INCOMPLETE'
+    )
+
+    expect(options.blockUnconfirmedChild).toHaveBeenCalledWith(target)
+    expect(release).toHaveBeenCalledWith({
+      archivePublications: [],
+      completedOperationId: expect.any(String),
+      retainForRecovery: true
+    })
+    expect(await pending(runtimeRoot)).toEqual([
+      expect.objectContaining({ archivePublicationPending: true })
+    ])
+  })
+
+  it('keeps external installs on normal repair recovery without retaining micromamba cache state', async () => {
+    const retainWorkingCache = vi.fn()
+    const { owner, target, runtimeRoot } = ownerHarness(
+      {
+        retainWorkingCache,
+        installPackages: vi.fn(async () => {
+          const [record] = await pending(runtimeRoot)
+          expect(record).not.toHaveProperty('archivePublicationPending')
+          return { ok: true, needsRestart: false, log: 'installed', method: 'pip' as const }
+        })
+      },
+      {
+        journalTarget: undefined,
+        environmentCaptureTarget: {
+          language: 'python',
+          environmentName: 'external-python',
+          runtimeSource: 'external',
+          command: 'C:\\Python\\python.exe'
+        }
+      }
+    )
+
+    await expect(owner.mutate({ target, mirror: {} })).resolves.toMatchObject({ ok: true })
+
+    expect(retainWorkingCache).not.toHaveBeenCalled()
+    expect(await pending(runtimeRoot)).toEqual([])
+  })
+
+  it('keeps an explicit managed pip install out of archive publication recovery', async () => {
+    const retainWorkingCache = vi.fn()
+    const { owner, target, runtimeRoot } = ownerHarness(
+      {
+        retainWorkingCache,
+        installPackages: vi.fn(async () => {
+          const [record] = await pending(runtimeRoot)
+          expect(record).not.toHaveProperty('archivePublicationPending')
+          return { ok: true, needsRestart: false, log: 'installed', method: 'pip' as const }
+        })
+      },
+      {
+        request: {
+          language: 'python',
+          packages: ['numpy'],
+          environment: 'analysis',
+          usePip: true
+        }
+      }
+    )
+
+    await expect(owner.mutate({ target, mirror: {} })).resolves.toMatchObject({ ok: true })
+
+    expect(retainWorkingCache).not.toHaveBeenCalled()
+    expect(await pending(runtimeRoot)).toEqual([])
+  })
+
+  it('retains and blocks when post-mutation archive authority cannot be persisted', async () => {
+    const updateFailure = new Error('journal publication update denied')
+    vi.spyOn(RuntimeOperationJournal.prototype, 'update').mockRejectedValueOnce(updateFailure)
+    const release = vi.fn().mockResolvedValue(false)
+    const archiveAuthorization = {
+      file: 'numpy-1.conda',
+      algorithm: 'sha256' as const,
+      digest: 'a'.repeat(64)
+    }
+    const { owner, options, target, runtimeRoot } = ownerHarness({
+      retainWorkingCache: vi.fn(() => release),
+      installPackages: vi.fn(async (_request, deps) => {
+        deps?.onCondaArchiveAuthorizations?.([archiveAuthorization], '/working-cache')
+        return { ok: true, needsRestart: false, log: 'installed', method: 'conda' as const }
+      })
+    })
+
+    await expect(owner.mutate({ target, mirror: {} })).rejects.toBe(updateFailure)
+
+    expect(options.blockUnconfirmedChild).toHaveBeenCalledWith(target)
+    expect(release).toHaveBeenCalledWith({
+      archivePublications: [
+        { workingRoot: '/working-cache', authorizations: [archiveAuthorization] }
+      ],
+      completedOperationId: expect.any(String),
+      retainForRecovery: true
+    })
+    const retained = await pending(runtimeRoot)
+    expect(retained).toEqual([expect.objectContaining({ archivePublicationPending: true })])
+    expect(retained[0].archivePublications).toBeUndefined()
+  })
+
+  it('still publishes a settled transaction when the mutation lock wrapper fails while unwinding', async () => {
+    const wrapperFailure = new Error('lock release failed')
+    const release = vi.fn().mockResolvedValue(true)
+    const archiveAuthorization = {
+      file: 'numpy-1.conda',
+      algorithm: 'sha256' as const,
+      digest: 'a'.repeat(64)
+    }
+    const { owner, target, runtimeRoot } = ownerHarness({
+      environmentOperations: {
+        runMutation: async <T>(_environment: string, operation: () => Promise<T>): Promise<T> => {
+          await operation()
+          throw wrapperFailure
+        },
+        logPackageFailure: vi.fn(),
+        logPackageResult: vi.fn()
+      },
+      retainWorkingCache: vi.fn(() => release),
+      installPackages: vi.fn(async (_request, deps) => {
+        deps?.onCondaArchiveAuthorizations?.([archiveAuthorization], '/working-cache')
+        return { ok: true, needsRestart: false, log: 'installed', method: 'conda' as const }
+      })
+    })
+
+    await expect(owner.mutate({ target, mirror: {} })).rejects.toBe(wrapperFailure)
+
+    expect(release).toHaveBeenCalledWith({
+      archivePublications: [
+        { workingRoot: '/working-cache', authorizations: [archiveAuthorization] }
+      ],
+      completedOperationId: expect.any(String),
+      retainForRecovery: false
+    })
+    expect(await pending(runtimeRoot)).toEqual([])
+  })
+
   it('clears settled cache-maintenance child evidence before the installer transaction', async () => {
     let operationId = ''
     const { owner, target, runtimeRoot } = ownerHarness({
@@ -432,7 +656,9 @@ describe('NotebookPackageMutationOwner', () => {
   it('retains sidecar and journal and blocks the target for an unconfirmed child', async () => {
     let operationId = ''
     const childFailure = new Error(`install failed: ${CHILD_UNCONFIRMED}`)
+    const release = vi.fn().mockResolvedValue(false)
     const { owner, options, target, runtimeRoot } = ownerHarness({
+      retainWorkingCache: vi.fn(() => release),
       environmentStateTracker: {
         markPackageMutationDirty: vi.fn(async (_target, mutation) => {
           operationId = mutation.operationId
@@ -449,6 +675,11 @@ describe('NotebookPackageMutationOwner', () => {
     await expect(owner.mutate({ target, mirror: {} })).rejects.toBe(childFailure)
 
     expect(options.blockUnconfirmedChild).toHaveBeenCalledWith(target)
+    expect(release).toHaveBeenCalledWith({
+      archivePublications: [],
+      completedOperationId: operationId,
+      retainForRecovery: true
+    })
     expect(await pending(runtimeRoot)).toEqual([expect.objectContaining({ operationId })])
     expect(readOperationChild(runtimeRoot, operationId)).toMatchObject({ spawning: true })
   })

--- a/src/main/notebook/package-mutation.ts
+++ b/src/main/notebook/package-mutation.ts
@@ -15,15 +15,24 @@ import {
 } from './operation-journal'
 import type { NotebookPackageAdmission, NotebookPackageAdmittedTarget } from './package-admission'
 import type { InstallDeps, InstallResult } from './package-manager'
+import type {
+  MicromambaWorkingCacheRetainer,
+  WorkingCacheArchivePublication
+} from './windows-micromamba-working-cache'
+import { prepareNotebookWorkloadCache } from './notebook-workload-cache-paths'
 import { readProcessStartToken } from './operation-recovery'
 import { isChildUnconfirmedError } from './provisioner-runtime'
 import type { NotebookRuntimeRepairOwner } from './runtime-repair'
 import type { MicromambaRunner } from './windows-micromamba-runner'
 
 const REPAIR_QUARANTINE_FAILED = 'REPAIR_QUARANTINE_FAILED'
+const CACHE_ARCHIVE_EVIDENCE_INCOMPLETE = 'CACHE_ARCHIVE_EVIDENCE_INCOMPLETE'
 
 const isRepairQuarantineError = (error: unknown): boolean =>
   error instanceof Error && error.message.includes(REPAIR_QUARANTINE_FAILED)
+
+const isArchiveEvidenceIncompleteError = (error: unknown): boolean =>
+  error instanceof Error && error.message.includes(CACHE_ARCHIVE_EVIDENCE_INCOMPLETE)
 
 type NotebookPackageMutationInput = Readonly<{
   target: NotebookPackageAdmittedTarget
@@ -54,6 +63,7 @@ type NotebookPackageMutationOwnerOptions = {
     'quarantineProtectedIdentity' | 'completeInterruptedInstall'
   >
   blockUnconfirmedChild: (target: NotebookPackageAdmittedTarget) => void
+  retainWorkingCache?: MicromambaWorkingCacheRetainer
 }
 
 /** Owns the complete crash-recoverable transaction for one admitted package mutation. */
@@ -73,15 +83,29 @@ class NotebookPackageMutationOwner {
     const { runtimeRoot } = this.options
     const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
     const operationId = randomUUID()
-    let result: InstallResult
+    const archiveCacheTransaction =
+      journalTarget !== undefined &&
+      this.options.retainWorkingCache !== undefined &&
+      request.usePip !== true &&
+      request.installer === undefined
+    const releaseWorkingCache = archiveCacheTransaction
+      ? await this.options.retainWorkingCache?.(runtimeRoot, operationId)
+      : undefined
+    let result: InstallResult | undefined
     let retainForRecovery = false
     let begun = false
+    let publicationIntentPersisted = false
+    let archiveEvidenceIncomplete = false
+    const archivePublications = new Map<string, WorkingCacheArchivePublication>()
     try {
       // The journal begins inside the environment lock so Reset cannot clear this new operation
       // between intent recording and the first installer spawn.
-      result = await this.options.environmentOperations.runMutation(environmentName, async () => {
+      await this.options.environmentOperations.runMutation(environmentName, async () => {
         const repairRefusal = this.options.recheckRepair(target)
-        if (repairRefusal) return repairRefusal.result
+        if (repairRefusal) {
+          result = repairRefusal.result
+          return result
+        }
         await journal.begin({
           operationId,
           kind: 'install',
@@ -89,9 +113,11 @@ class NotebookPackageMutationOwner {
           phase: `install-${request.language}`,
           startedAt: Date.now(),
           targetPath: journalTarget,
-          repairReason: 'interrupted-install'
+          repairReason: 'interrupted-install',
+          archivePublicationPending: archiveCacheTransaction ? true : undefined
         })
         begun = true
+        prepareNotebookWorkloadCache(runtimeRoot)
         const mutation = {
           operationId,
           operation: request.operation ?? ('install' as const),
@@ -143,6 +169,15 @@ class NotebookPackageMutationOwner {
                   childStartToken: undefined
                 })
                 removeOperationChildSync(runtimeRoot, operationId)
+              },
+              onCondaArchiveAuthorizations: (authorizations, workingRoot, evidenceComplete) => {
+                if (evidenceComplete === false) archiveEvidenceIncomplete = true
+                if (authorizations.length === 0) return
+                const previous = archivePublications.get(workingRoot)
+                archivePublications.set(workingRoot, {
+                  workingRoot,
+                  authorizations: [...(previous?.authorizations ?? []), ...authorizations]
+                })
               }
             })
             installerDurationMs = Date.now() - installerStartedAt
@@ -242,6 +277,29 @@ class NotebookPackageMutationOwner {
             durationMs: installerDurationMs
           })
         }
+        const publications = installResult?.ok ? [...archivePublications.values()] : []
+        // Publish from this settled result even if the lock wrapper itself fails while unwinding after
+        // the callback returns. Otherwise the outer assignment never lands and finally could mistake a
+        // committed transaction for an empty publication set.
+        result = installResult
+        if (archiveCacheTransaction && archiveEvidenceIncomplete) {
+          retainForRecovery = true
+          throw new Error(
+            `${CACHE_ARCHIVE_EVIDENCE_INCOMPLETE}: micromamba completed, but its complete archive ` +
+              'authorization set could not be captured; retaining the cache for explicit recovery'
+          )
+        }
+        // Close the pre-mutation crash marker while still holding the environment lock. A successful
+        // transaction records exact immutable authority; every other settled result records that there
+        // is nothing to publish. The cache cannot be released until this atomic transition is durable.
+        await journal.update(operationId, {
+          childPid: undefined,
+          childStartedAt: undefined,
+          childStartToken: undefined,
+          archivePublicationPending: undefined,
+          archivePublications: publications.length > 0 ? publications : undefined
+        })
+        publicationIntentPersisted = true
         return installResult
       })
     } catch (error) {
@@ -255,6 +313,20 @@ class NotebookPackageMutationOwner {
             `not started (installing without a recovery record could strand a worker process). ${
               error instanceof Error ? error.message : String(error)
             }`
+        }
+      }
+      if (
+        !publicationIntentPersisted &&
+        archivePublications.size === 0 &&
+        !isRepairQuarantineError(error) &&
+        !isArchiveEvidenceIncompleteError(error) &&
+        !isChildUnconfirmedError(error)
+      ) {
+        try {
+          await journal.update(operationId, { archivePublicationPending: undefined })
+          publicationIntentPersisted = true
+        } catch {
+          // Keep the durable ambiguity marker, target block, and working cache below.
         }
       }
       if (isRepairQuarantineError(error)) retainForRecovery = true
@@ -273,11 +345,24 @@ class NotebookPackageMutationOwner {
       }
       throw error
     } finally {
+      const publications = result?.ok ? [...archivePublications.values()] : []
+      if (begun && !publicationIntentPersisted) {
+        retainForRecovery = true
+        this.options.blockUnconfirmedChild(target)
+      }
       if (begun && !retainForRecovery) {
         removeOperationChildSync(runtimeRoot, operationId)
+      }
+      const cacheFinalized = await releaseWorkingCache?.({
+        archivePublications: publications,
+        completedOperationId: operationId,
+        retainForRecovery
+      }).catch(() => false)
+      if (begun && !retainForRecovery && (publications.length === 0 || cacheFinalized)) {
         await journal.complete(operationId).catch(() => undefined)
       }
     }
+    if (!result) throw new Error('package mutation completed without an installer result')
     if (result.ok) await this.options.runtimeRepair.completeInterruptedInstall(target)
     return result
   }

--- a/src/main/notebook/package-operations.ts
+++ b/src/main/notebook/package-operations.ts
@@ -11,6 +11,7 @@ import { boundedFailureDiagnostic } from './failure-diagnostic'
 import { effectiveMirrorAsync, type ProbeDeps } from './mirror-probe'
 import { NotebookPackageAdmissionOwner } from './package-admission'
 import type { InstallDeps, InstallRequest, InstallResult } from './package-manager'
+import type { MicromambaWorkingCacheRetainer } from './windows-micromamba-working-cache'
 import { NotebookPackageMutationOwner } from './package-mutation'
 import type { NotebookRecoveryCoordinator } from './recovery-coordinator'
 import {
@@ -89,6 +90,7 @@ type NotebookPackageOperationsOptions = {
   >
   installPackages: (request: InstallRequest, deps?: Partial<InstallDeps>) => Promise<InstallResult>
   micromambaRunner?: Pick<MicromambaRunner, 'resolve'>
+  retainWorkingCache?: MicromambaWorkingCacheRetainer
   createEnvironmentCaptureTarget: (
     language: NotebookLanguage,
     environmentName: string,
@@ -137,6 +139,7 @@ class NotebookPackageOperations {
       environmentStateTracker: options.environmentStateTracker,
       installPackages: options.installPackages,
       micromambaRunner: options.micromambaRunner,
+      retainWorkingCache: options.retainWorkingCache,
       recheckRepair: (target) => this.admission.recheckRepair(target),
       runtimeRepair: options.runtimeRepair,
       blockUnconfirmedChild: ({ repairRuntimeId, journalTarget }) => {

--- a/src/main/notebook/provisioner.startup.test.ts
+++ b/src/main/notebook/provisioner.startup.test.ts
@@ -19,6 +19,7 @@ import {
   type ProductionProvisionerDeps
 } from './provisioner'
 import { selectMicromambaCache } from './micromamba-cache'
+import { notebookWorkloadCacheRoot } from './notebook-workload-cache-paths'
 
 const makeRoot = (): string => mkdtempSync(join(tmpdir(), 'os-start-'))
 const touchBin = (path: string): void => {
@@ -313,5 +314,47 @@ describe('createProductionProvisioner', () => {
       expect(call[3]).toEqual(expect.any(Function))
       expect(call[4]).toEqual(expect.any(Function))
     }
+  })
+
+  it('projects the workload cache environment into the default provisioning subprocess', async () => {
+    const root = makeRoot()
+    const mmPath = join(root, 'bin', micromambaBinName)
+    const lockPath = join(root, 'python.lock')
+    touchBin(mmPath)
+    writeFileSync(lockPath, '@EXPLICIT\n')
+    const spawnMicromamba = vi.fn<NonNullable<ProductionProvisionerDeps['runMicromamba']>>(
+      async (argv, _env, _signal, _onChild, onBeforeSpawn) => {
+        onBeforeSpawn?.()
+        const prefix = argv[argv.findIndex((arg) => arg === '-p' || arg === '--prefix') + 1]
+        touchBin(pythonBin(prefix))
+      }
+    )
+    const provisioner = createProductionProvisioner(
+      {
+        root,
+        channel: 'conda-forge',
+        micromamba: { env: { OPEN_SCIENCE_MICROMAMBA_BIN: mmPath } }
+      },
+      {
+        runner: { initialPath: mmPath, resolve: async () => mmPath },
+        fetchBundle: async () => ({ lockPath }),
+        maintainCache: async () => undefined,
+        runMicromamba: spawnMicromamba,
+        verify: async () => undefined,
+        retainWorkingCache: async () => async () => true,
+        captureExplicitLock: async () => '@EXPLICIT\n'
+      }
+    )
+
+    await provisioner.provisionPython(() => undefined)
+
+    const cacheRoot = notebookWorkloadCacheRoot(root)
+    expect(spawnMicromamba).toHaveBeenCalledOnce()
+    expect(spawnMicromamba.mock.calls[0]?.[1]).toMatchObject({
+      PIP_CACHE_DIR: join(cacheRoot, 'pip'),
+      UV_CACHE_DIR: join(cacheRoot, 'uv'),
+      HF_DATASETS_CACHE: join(cacheRoot, 'huggingface', 'datasets'),
+      TORCH_HOME: join(cacheRoot, 'torch')
+    })
   })
 })

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
 
@@ -37,7 +38,7 @@ import { envsLockDir } from './runtime-relocation'
 import { serializeProvisioner } from './environment-operation-foundation'
 import { withExclusiveCacheLock, withSharedCacheLock } from './pkgs-cache-lock'
 import { validateAndSeedPack } from './pack-content'
-import { micromambaCacheLockKey, selectMicromambaCache } from './micromamba-cache'
+import { micromambaCacheLockKey } from './micromamba-cache'
 import {
   operationJournalPath,
   readOperationChild,
@@ -48,6 +49,18 @@ import {
 } from './operation-journal'
 
 const makeRoot = (): string => mkdtempSync(join(tmpdir(), 'os-prov-'))
+const RELOCATION_ARCHIVE = 'x-1.conda'
+const RELOCATION_ARCHIVE_CONTENT = 'relocation archive'
+const RELOCATION_ARCHIVE_MD5 = createHash('md5').update(RELOCATION_ARCHIVE_CONTENT).digest('hex')
+const writeRelocationLock = (root: string, name: string): void => {
+  mkdirSync(envsLockDir(root), { recursive: true })
+  mkdirSync(pkgsCache(root), { recursive: true })
+  writeFileSync(join(pkgsCache(root), RELOCATION_ARCHIVE), RELOCATION_ARCHIVE_CONTENT)
+  writeFileSync(
+    join(envsLockDir(root), `${name}.lock`),
+    `@EXPLICIT\nhttps://conda.anaconda.org/conda-forge/noarch/${RELOCATION_ARCHIVE}#${RELOCATION_ARCHIVE_MD5}\n`
+  )
+}
 const logicalNameForPrefix = (prefix: string): string =>
   logicalEnvNameFromDirectory(basename(prefix))
 const expectedMarker = (name: string, preparedAt: string): Record<string, string | number> => ({
@@ -78,6 +91,10 @@ const makeDeps = (root: string, overrides: Partial<ProvisionerDeps> = {}): Provi
       created.push(argv[1])
     },
     maintainCache: async () => undefined,
+    cache: {
+      path: pkgsCache(root),
+      lockKey: micromambaCacheLockKey(pkgsCache(root))
+    },
     verify: async (): Promise<void> => undefined,
     now: () => 't-now',
     ...overrides
@@ -1332,6 +1349,10 @@ const makeNamedEnvDeps = (
       writeFileSync(bin, 'x')
     },
     maintainCache: async () => undefined,
+    cache: {
+      path: pkgsCache(root),
+      lockKey: micromambaCacheLockKey(pkgsCache(root))
+    },
     verify: async () => undefined,
     ...overrides
   }
@@ -1339,6 +1360,98 @@ const makeNamedEnvDeps = (
 }
 
 describe('DefaultRuntimeProvisioner.createNamedEnvironment', () => {
+  it('publishes and releases the Windows working cache after a successful create', async () => {
+    const root = makeRoot()
+    const release = vi.fn().mockResolvedValue(true)
+    const retainWorkingCache = vi.fn(() => release)
+    const digest = 'a'.repeat(32)
+    const { deps } = makeNamedEnvDeps(root, {
+      retainWorkingCache,
+      captureExplicitLock: async () =>
+        `@EXPLICIT\nhttps://conda.example/win-64/python-1.tar.bz2#${digest}\n`
+    })
+
+    await new DefaultRuntimeProvisioner(deps).createNamedEnvironment('analysis', 'python')
+
+    expect(retainWorkingCache).toHaveBeenCalledWith(root, expect.any(String))
+    expect(release).toHaveBeenCalledWith({
+      archivePublications: [
+        {
+          workingRoot: pkgsCache(root),
+          authorizations: [{ file: 'python-1.tar.bz2', algorithm: 'md5', digest }]
+        }
+      ],
+      completedOperationId: expect.any(String),
+      retainForRecovery: false
+    })
+  })
+
+  it('keeps durable publication evidence until the working archive is published', async () => {
+    const root = makeRoot()
+    let finishPublication!: (published: boolean) => void
+    const publication = new Promise<boolean>((resolve) => {
+      finishPublication = resolve
+    })
+    const digest = 'a'.repeat(32)
+    const { deps } = makeNamedEnvDeps(root, {
+      retainWorkingCache: vi.fn(() => vi.fn(() => publication)),
+      captureExplicitLock: async () =>
+        `@EXPLICIT\nhttps://conda.example/win-64/python-1.tar.bz2#${digest}\n`
+    })
+    const create = new DefaultRuntimeProvisioner(deps).createNamedEnvironment('analysis', 'python')
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(root))
+
+    await vi.waitFor(async () => {
+      expect((await journal.pending())[0]).toMatchObject({
+        archivePublications: [
+          {
+            workingRoot: pkgsCache(root),
+            authorizations: [{ file: 'python-1.tar.bz2', algorithm: 'md5', digest }]
+          }
+        ]
+      })
+    })
+
+    finishPublication(true)
+    await create
+    expect(await journal.pending()).toEqual([])
+  })
+
+  it('retains and blocks when post-create archive authority cannot be persisted', async () => {
+    const root = makeRoot()
+    const updateFailure = new Error('journal publication update denied')
+    vi.spyOn(RuntimeOperationJournal.prototype, 'update').mockRejectedValueOnce(updateFailure)
+    const release = vi.fn().mockResolvedValue(false)
+    const blockPrefix = vi.fn()
+    const digest = 'a'.repeat(32)
+    const { deps } = makeNamedEnvDeps(root, {
+      retainWorkingCache: vi.fn(() => release),
+      blockPrefix,
+      maintainCache: undefined,
+      captureExplicitLock: async () =>
+        `@EXPLICIT\nhttps://conda.example/win-64/python-1.tar.bz2#${digest}\n`
+    })
+
+    await expect(
+      new DefaultRuntimeProvisioner(deps).createNamedEnvironment('analysis', 'python')
+    ).rejects.toBe(updateFailure)
+
+    expect(blockPrefix).toHaveBeenCalledWith(envPrefix(root, 'analysis'))
+    expect(release).toHaveBeenCalledWith({
+      archivePublications: [
+        {
+          workingRoot: pkgsCache(root),
+          authorizations: [{ file: 'python-1.tar.bz2', algorithm: 'md5', digest }]
+        }
+      ],
+      completedOperationId: expect.any(String),
+      retainForRecovery: true
+    })
+    const retained = await RuntimeOperationJournal.forPath(operationJournalPath(root)).pending()
+    expect(retained).toEqual([expect.objectContaining({ archivePublicationPending: true })])
+    expect(retained[0].archivePublications).toBeUndefined()
+  })
+
   it('maintains the cache before the online create', async () => {
     const root = makeRoot()
     const order: string[] = []
@@ -1361,7 +1474,9 @@ describe('DefaultRuntimeProvisioner.createNamedEnvironment', () => {
   it('does not start a named create when the cleanup worker cannot be confirmed stopped', async () => {
     const root = makeRoot()
     const runArgv = vi.fn(async () => undefined)
+    const release = vi.fn().mockResolvedValue(false)
     const { deps } = makeNamedEnvDeps(root, {
+      retainWorkingCache: vi.fn(() => release),
       maintainCache: async () => {
         throw new Error(`${CHILD_UNCONFIRMED}: cleanup worker may still be running`)
       },
@@ -1372,6 +1487,11 @@ describe('DefaultRuntimeProvisioner.createNamedEnvironment', () => {
       new DefaultRuntimeProvisioner(deps).createNamedEnvironment('analysis', 'python')
     ).rejects.toThrow(CHILD_UNCONFIRMED)
     expect(runArgv).not.toHaveBeenCalled()
+    expect(release).toHaveBeenCalledWith({
+      archivePublications: [],
+      completedOperationId: expect.any(String),
+      retainForRecovery: true
+    })
   })
 
   it('rejects flag-like package entries before starting micromamba', async () => {
@@ -1455,7 +1575,7 @@ describe('DefaultRuntimeProvisioner.createNamedEnvironment', () => {
     // so the lock is taken a tick later), then request the cache EXCLUSIVE on the same root.
     const create = provisioner.createNamedEnvironment('my-analysis', 'python', ['numpy'])
     await held
-    const exclusive = withExclusiveCacheLock(selectMicromambaCache(root).lockKey, async () => {
+    const exclusive = withExclusiveCacheLock(deps.cache!.lockKey, async () => {
       order.push('repair')
     })
     await Promise.all([create, exclusive])
@@ -1546,7 +1666,7 @@ describe('DefaultRuntimeProvisioner.upgradeIfNeeded (shared pkgs cache lock)', (
     // Start the upgrade, wait until its install holds the shared lock, then request the cache EXCLUSIVE.
     const upgrade = new DefaultRuntimeProvisioner(deps).upgradeIfNeeded(() => {})
     await held
-    const exclusive = withExclusiveCacheLock(selectMicromambaCache(root).lockKey, async () => {
+    const exclusive = withExclusiveCacheLock(deps.cache!.lockKey, async () => {
       order.push('repair')
     })
     await Promise.all([upgrade, exclusive])
@@ -1638,12 +1758,7 @@ describe('DefaultRuntimeProvisioner journals every prefix write', () => {
 
   it('journals a relocation restore with the child pid, cleared on completion', async () => {
     const root = makeRoot()
-    const dir = envsLockDir(root)
-    mkdirSync(dir, { recursive: true })
-    writeFileSync(
-      join(dir, `${DEFAULT_PY_ENV}.lock`),
-      '@EXPLICIT\nhttps://conda.anaconda.org/conda-forge/noarch/x-1.conda#abc\n'
-    )
+    writeRelocationLock(root, DEFAULT_PY_ENV)
     const prefix = envPrefix(root, DEFAULT_PY_ENV)
     let during: RuntimeOperationRecord | undefined
     const deps = makeDeps(
@@ -1763,13 +1878,28 @@ describe('DefaultRuntimeProvisioner.removeEnvironment', () => {
 describe('DefaultRuntimeProvisioner.restoreRelocatedEnvs', () => {
   // Writes a relocation lock at <root>/envs.lock/<name>.lock with one package URL.
   const writeLock = (root: string, name: string): void => {
-    const dir = envsLockDir(root)
-    mkdirSync(dir, { recursive: true })
-    writeFileSync(
-      join(dir, `${name}.lock`),
-      '@EXPLICIT\nhttps://conda.anaconda.org/conda-forge/noarch/x-1.conda#abc\n'
-    )
+    writeRelocationLock(root, name)
   }
+
+  it('seeds the short operation cache from durable archives before an offline restore', async () => {
+    const root = makeRoot()
+    writeLock(root, DEFAULT_PY_ENV)
+    const shortCache = join(root, 'short-cache')
+    const deps = makeDeps(root, {
+      cache: { path: shortCache, lockKey: micromambaCacheLockKey(shortCache) },
+      runArgv: async (argv) => {
+        expect(existsSync(join(shortCache, RELOCATION_ARCHIVE))).toBe(true)
+        const prefix = argv[argv.findIndex((arg) => arg === '-p' || arg === '--prefix') + 1]
+        const bin = pythonBin(prefix)
+        mkdirSync(join(bin, '..'), { recursive: true })
+        writeFileSync(bin, 'x')
+      }
+    })
+
+    await new DefaultRuntimeProvisioner(deps).restoreRelocatedEnvs(() => {})
+
+    expect(existsSync(pythonBin(envPrefix(root, DEFAULT_PY_ENV)))).toBe(true)
+  })
 
   it('clears a half-built (conda-meta, no interpreter) prefix before the offline recreate (3.2 parity)', async () => {
     // The create/materialize path removes a conda-meta-but-no-interpreter leftover; the restore path
@@ -1978,7 +2108,7 @@ describe('DefaultRuntimeProvisioner.restoreRelocatedEnvs', () => {
     // Kick off the restore, wait until its recreate holds the shared lock, then request the EXCLUSIVE.
     const restore = new DefaultRuntimeProvisioner(deps).restoreRelocatedEnvs(() => {})
     await held
-    const exclusive = withExclusiveCacheLock(selectMicromambaCache(root).lockKey, async () => {
+    const exclusive = withExclusiveCacheLock(deps.cache!.lockKey, async () => {
       order.push('repair')
     })
     await Promise.all([restore, exclusive])
@@ -2749,10 +2879,8 @@ describe('DefaultRuntimeProvisioner prefix-block self-guard (startup gate path)'
   it('restoreRelocatedEnvs skips a blocked prefix (leaves its lock) but restores the rest', async () => {
     const root = makeRoot()
     const dir = envsLockDir(root)
-    mkdirSync(dir, { recursive: true })
-    const lock = '@EXPLICIT\nhttps://conda.anaconda.org/conda-forge/noarch/x-1.conda#abc\n'
-    writeFileSync(join(dir, `${DEFAULT_PY_ENV}.lock`), lock)
-    writeFileSync(join(dir, 'my-analysis.lock'), lock)
+    writeRelocationLock(root, DEFAULT_PY_ENV)
+    writeRelocationLock(root, 'my-analysis')
 
     const restored: string[] = []
     const deps = blocking(root, envPrefix(root, 'my-analysis'), {

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -1,4 +1,4 @@
-import { type Dirent, existsSync, readdirSync, rmSync, statSync } from 'node:fs'
+import { type Dirent, existsSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { basename, dirname, join } from 'node:path'
 
@@ -41,6 +41,12 @@ import {
   type MicromambaCache
 } from './micromamba-cache'
 import {
+  retainMicromambaWorkingCache,
+  type MicromambaWorkingCacheRetainer,
+  type WorkingCacheArchivePublication
+} from './windows-micromamba-working-cache'
+import { archiveAuthorizationsFromExplicitLock } from './micromamba-archive-store'
+import {
   maintainPackageCacheBestEffort,
   packageCacheCleanArgv
 } from './micromamba-cache-maintenance'
@@ -51,6 +57,7 @@ import {
   installFromLockArgv,
   micromambaSpawnEnv
 } from './micromamba'
+import { prepareNotebookWorkloadCache } from './notebook-workload-cache-paths'
 import {
   createProductionMicromambaRunner,
   type MicromambaRunner,
@@ -59,6 +66,7 @@ import {
 import { defaultOperationChildLiveness, readProcessStartToken } from './operation-recovery'
 import {
   isChildUnconfirmedError,
+  captureMicromamba,
   micromambaDiagnosticText,
   runMicromamba,
   verifyExecutable
@@ -185,6 +193,11 @@ export type ProvisionerDeps = {
     onChild: (pid: number) => void,
     signal?: AbortSignal
   ) => Promise<void>
+  // Owns the operation-scoped Windows package cache. Production retains one lease around every
+  // journaled prefix write; tests can inject a recorder or omit it entirely.
+  retainWorkingCache?: MicromambaWorkingCacheRetainer
+  // Captures the new environment's explicit lock before a named environment is exposed to a kernel.
+  captureExplicitLock?: (prefix: string) => Promise<string>
   // Verifies `<bin> --version`; rejects otherwise.
   verify: (bin: string, prefix: string) => Promise<void>
   // Clock injection for the ready-marker timestamp.
@@ -561,22 +574,30 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       onBeforeSpawn: () => void,
       onChild: (pid: number) => void,
       onCacheMaintenanceSettled: () => Promise<void>
-    ) => Promise<void>
+    ) => Promise<void | readonly WorkingCacheArchivePublication[]>
   ): Promise<void> {
     const journal = RuntimeOperationJournal.forPath(operationJournalPath(this.deps.root))
     const operationId = randomUUID()
+    const archiveCacheTransaction = this.deps.retainWorkingCache !== undefined
     // Fail CLOSED: if we can't record the write-intent, we can't crash-safely perform the write (a
     // crash would leave nothing for recovery to block), so refuse rather than doing an un-recoverable
     // prefix write. (complete() below stays best-effort — a stale record is harmless; the next startup
     // reconciles it.)
-    await journal.begin({
-      operationId,
-      kind,
-      runtimeId,
-      phase,
-      startedAt: Date.now(),
-      targetPath: prefix
-    })
+    const releaseWorkingCache = await this.deps.retainWorkingCache?.(this.deps.root, operationId)
+    try {
+      await journal.begin({
+        operationId,
+        kind,
+        runtimeId,
+        phase,
+        startedAt: Date.now(),
+        targetPath: prefix,
+        archivePublicationPending: archiveCacheTransaction ? true : undefined
+      })
+    } catch (error) {
+      await releaseWorkingCache?.({ completedOperationId: operationId }).catch(() => false)
+      throw error
+    }
     // Re-arm the spawn intent immediately before EACH spawn (fail-closed: throwing aborts the spawn).
     // Writing it per-spawn — not once per op — means a second spawn (create retry) whose PID isn't
     // recorded yet leaves a fresh "spawning" sidecar (block), not a stale earlier PID (reconcile).
@@ -613,9 +634,34 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       removeOperationChildSync(this.deps.root, operationId)
     }
     let retainForRecovery = false
+    let archivePublications: readonly WorkingCacheArchivePublication[] = []
+    let publicationIntentPersisted = false
+    let mutationReturned = false
     try {
-      await run(onBeforeSpawn, onChild, onCacheMaintenanceSettled)
+      const completedPublications = await run(onBeforeSpawn, onChild, onCacheMaintenanceSettled)
+      mutationReturned = true
+      archivePublications = (completedPublications ?? []).filter(
+        (publication) => publication.authorizations.length > 0
+      )
+      // Atomically transition from "mutation may commit" to its exact post-mutation publication state.
+      // Even an empty authorization set must clear the durable pre-mutation ambiguity before cleanup.
+      await journal.update(operationId, {
+        childPid: undefined,
+        childStartedAt: undefined,
+        childStartToken: undefined,
+        archivePublicationPending: undefined,
+        archivePublications: archivePublications.length > 0 ? archivePublications : undefined
+      })
+      publicationIntentPersisted = true
     } catch (error) {
+      if (!mutationReturned && !isChildUnconfirmedError(error)) {
+        try {
+          await journal.update(operationId, { archivePublicationPending: undefined })
+          publicationIntentPersisted = true
+        } catch {
+          // Keep the durable ambiguity marker, target block, and working cache below.
+        }
+      }
       // A teardown whose child tree could NOT be confirmed stopped: a worker may still be writing the
       // prefix, so KEEP the sidecar + journal record (recovery blocks) instead of clearing them.
       if (isChildUnconfirmedError(error)) {
@@ -640,8 +686,19 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       }
       throw error
     } finally {
+      if (!publicationIntentPersisted) {
+        retainForRecovery = true
+        this.deps.blockPrefix?.(prefix)
+      }
       if (!retainForRecovery) {
         removeOperationChildSync(this.deps.root, operationId)
+      }
+      const cacheFinalized = await releaseWorkingCache?.({
+        archivePublications,
+        completedOperationId: operationId,
+        retainForRecovery
+      })
+      if (!retainForRecovery && (archivePublications.length === 0 || cacheFinalized)) {
         await journal.complete(operationId).catch(() => undefined)
       }
     }
@@ -1107,27 +1164,44 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
               name,
               prefix,
               'restore',
-              (onBeforeSpawn, onChild) =>
-                this.runWithMaxPathRecovery(
+              async (onBeforeSpawn, onChild) => {
+                const cache = this.cache
+                const lockPath = join(dir, file)
+                // Windows extracts from the short operation cache, while relocation intentionally
+                // persists only verified archives under runtime/pkgs. Re-seed the working cache from
+                // this env's explicit lock before invoking the offline create.
+                await validateAndSeedPackIntoCache(pkgsCache(this.deps.root), lockPath, cache)
+                await this.runWithMaxPathRecovery(
                   () =>
-                    withSharedCacheLocks(this.cacheLockKeys(this.cache), () => {
+                    withSharedCacheLocks(this.cacheLockKeys(cache), () => {
                       // Reaching here means the prefix is broken (verify failed) or a partial (e.g.
                       // conda-meta with no interpreter, which would wedge `create -p` forever) — clear it
                       // so the offline recreate starts clean. No abort signal: restore has no per-language
                       // cancel path, and this.abort may belong to a concurrent default provision.
                       rmSync(prefix, { recursive: true, force: true })
                       return this.deps.runArgv(
-                        createFromLockArgv(this.deps.mm, this.deps.root, prefix, join(dir, file)),
+                        createFromLockArgv(this.deps.mm, this.deps.root, prefix, lockPath),
                         undefined,
                         onChild,
                         onBeforeSpawn,
-                        this.cache,
+                        cache,
                         DEFAULT_MAX_CACHE_RELATIVE_PATH
                       )
                     }),
                   undefined,
-                  this.cache
+                  cache
                 )
+                return this.deps.retainWorkingCache
+                  ? [
+                      {
+                        workingRoot: cache.path,
+                        authorizations: archiveAuthorizationsFromExplicitLock(
+                          readFileSync(lockPath, 'utf8')
+                        )
+                      }
+                    ]
+                  : []
+              }
             )
             const bin = existsSync(pythonBin(prefix)) ? pythonBin(prefix) : rBin(prefix)
             await this.deps.verify(bin, prefix)
@@ -1199,7 +1273,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
           onChild,
           onCacheMaintenanceSettled
         )
-        return this.runWithMaxPathRecovery(() =>
+        await this.runWithMaxPathRecovery(() =>
           withSharedCacheLocks(this.cacheLockKeys(this.cache), async () => {
             // Clear a half-built prefix from an interrupted prior create (incl. conda-meta-but-no-
             // interpreter) so micromamba doesn't abort on it.
@@ -1218,6 +1292,16 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
             )
           })
         )
+        await this.deps.verify(bin, prefix)
+        const explicitLock = await this.deps.captureExplicitLock?.(prefix)
+        return explicitLock
+          ? [
+              {
+                workingRoot: this.cache.path,
+                authorizations: archiveAuthorizationsFromExplicitLock(explicitLock)
+              }
+            ]
+          : []
       }
     )
     await this.deps.verify(bin, prefix)
@@ -1340,7 +1424,7 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
         }
         await this.seedBundleCache(bundle, selected.cache)
         await this.cleanLegacyWindowsUrlCache(selected.cache, onProgress)
-        return this.runWithMaxPathRecovery(
+        await this.runWithMaxPathRecovery(
           () =>
             withSharedCacheLocks(this.cacheLockKeys(selected.cache), () =>
               this.deps.runArgv(
@@ -1355,6 +1439,16 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
           undefined,
           selected.cache
         )
+        return this.deps.retainWorkingCache
+          ? [
+              {
+                workingRoot: selected.cache.path,
+                authorizations: archiveAuthorizationsFromExplicitLock(
+                  readFileSync(bundle.lockPath, 'utf8')
+                )
+              }
+            ]
+          : []
       }
     )
     await this.deps.verify(bin, prefix)
@@ -1439,6 +1533,8 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       prefix,
       `create-${spec.language}`,
       async (onBeforeSpawn, onChild, onCacheMaintenanceSettled) => {
+        let completedLockPath = bundle.lockPath
+        let completedCache = selected.cache
         // Fetch completes before cleanup so its child can reuse this materialize journal. Tarballs stay
         // intact for future offline relocation; only unused extracted package directories are reclaimed.
         await this.maintainCacheBeforeMutation(
@@ -1543,7 +1639,19 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
           const retrySelected = this.cacheForBundle(spec, reseeded)
           await this.seedBundleCache(reseeded, retrySelected.cache)
           await runCreate(reseeded.lockPath, retrySelected.cache, retrySelected.budget)
+          completedLockPath = reseeded.lockPath
+          completedCache = retrySelected.cache
         }
+        return this.deps.retainWorkingCache
+          ? [
+              {
+                workingRoot: completedCache.path,
+                authorizations: archiveAuthorizationsFromExplicitLock(
+                  readFileSync(completedLockPath, 'utf8')
+                )
+              }
+            ]
+          : []
       }
     )
 
@@ -1690,7 +1798,11 @@ export type ProductionProvisionerDeps = {
   maintainCache?: ProvisionerDeps['maintainCache']
   // Narrow subprocess seam for the default maintenance adapter's argv/environment contract test.
   runCacheMaintenance?: typeof runMicromamba
+  // Narrow subprocess seam for the default provisioning adapter's argv/environment contract test.
+  runMicromamba?: typeof runMicromamba
   verify?: ProvisionerDeps['verify']
+  retainWorkingCache?: ProvisionerDeps['retainWorkingCache']
+  captureExplicitLock?: ProvisionerDeps['captureExplicitLock']
 }
 
 // Wires the real micromamba binary, CDN fetch, subprocess runner and interpreter verification into a
@@ -1755,21 +1867,25 @@ export const createProductionProvisioner = (
           maxCacheRelativePath
         )
       }
-      return runMicromamba(
+      const workloadCacheEnv = prepareNotebookWorkloadCache(opts.root)
+      return (deps.runMicromamba ?? runMicromamba)(
         selectedArgv,
-        micromambaSpawnEnv(
-          opts.root,
-          opts.caBundle,
-          {
-            selectCache: () =>
-              runCache ??
-              selectMicromambaCache(
-                opts.root,
-                maxCacheRelativePath ?? DEFAULT_MAX_CACHE_RELATIVE_PATH
-              )
-          },
-          maxCacheRelativePath ?? DEFAULT_MAX_CACHE_RELATIVE_PATH
-        ),
+        {
+          ...micromambaSpawnEnv(
+            opts.root,
+            opts.caBundle,
+            {
+              selectCache: () =>
+                runCache ??
+                selectMicromambaCache(
+                  opts.root,
+                  maxCacheRelativePath ?? DEFAULT_MAX_CACHE_RELATIVE_PATH
+                )
+            },
+            maxCacheRelativePath ?? DEFAULT_MAX_CACHE_RELATIVE_PATH
+          ),
+          ...workloadCacheEnv
+        },
         signal,
         onChild,
         onBeforeSpawn
@@ -1779,12 +1895,14 @@ export const createProductionProvisioner = (
       deps.maintainCache ??
       (async (runCache, onBeforeSpawn, onChild, signal) => {
         const selected = await runner.resolve()
+        const workloadCacheEnv = prepareNotebookWorkloadCache(opts.root)
         await (deps.runCacheMaintenance ?? runMicromamba)(
           packageCacheCleanArgv(selected),
           {
             ...micromambaSpawnEnv(opts.root, opts.caBundle, {
               selectCache: () => runCache
             }),
+            ...workloadCacheEnv,
             MAMBA_ROOT_PREFIX: opts.root,
             CONDA_PKGS_DIRS: runCache.path
           },
@@ -1793,6 +1911,22 @@ export const createProductionProvisioner = (
           onBeforeSpawn
         )
       }),
+    retainWorkingCache:
+      deps.retainWorkingCache ??
+      (deps.runArgv || process.platform !== 'win32'
+        ? undefined
+        : (root, operationId) => retainMicromambaWorkingCache(root, {}, operationId)),
+    captureExplicitLock:
+      deps.captureExplicitLock ??
+      (deps.runArgv
+        ? undefined
+        : async (prefix) => {
+            const selected = await runner.resolve()
+            return captureMicromamba(
+              [selected, '--no-rc', 'list', '--prefix', prefix, '--explicit', '--md5'],
+              caEnv
+            )
+          }),
     verify: deps.verify ?? ((bin, prefix) => verifyExecutable(bin, { prefix, env: caEnv })),
     isPrefixBlocked: opts.isPrefixBlocked,
     clearPrefixBlock: opts.clearPrefixBlock,

--- a/src/main/notebook/recovery-coordinator.test.ts
+++ b/src/main/notebook/recovery-coordinator.test.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs'
 import { chmod, lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { dirname, join, win32 } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { operationJournalPath, RuntimeOperationJournal } from './operation-journal'
 import { NotebookRecoveryCoordinator } from './recovery-coordinator'
@@ -41,6 +41,292 @@ const beginInterruptedMaterialize = async (
 }
 
 describe('NotebookRecoveryCoordinator', () => {
+  it('finalizes a leftover working cache only after recovery has no blocked writer', async () => {
+    const runtimeRoot = await createRuntimeRoot()
+    const finalizeWorkingCache = vi.fn().mockResolvedValue(true)
+    const coordinator = new NotebookRecoveryCoordinator(runtimeRoot, undefined, {
+      finalizeWorkingCache
+    })
+
+    await coordinator.recover()
+
+    expect(finalizeWorkingCache).toHaveBeenCalledWith(runtimeRoot, {
+      mode: 'current-candidates'
+    })
+  })
+
+  it('publishes a committed archive intent before clearing its journal and working cache', async () => {
+    const runtimeRoot = await createRuntimeRoot()
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+    const publications = [
+      {
+        workingRoot: 'D:\\OpenScienceTmp\\m-test',
+        authorizations: [
+          { file: 'python-1.conda', algorithm: 'sha256' as const, digest: 'a'.repeat(64) }
+        ]
+      }
+    ]
+    await journal.begin({
+      operationId: 'publish-after-crash',
+      kind: 'install',
+      runtimeId: 'analysis',
+      phase: 'install-python',
+      startedAt: 100,
+      archivePublications: publications
+    })
+    const publishWorkingCacheArchives = vi.fn().mockResolvedValue(undefined)
+    const finalizeWorkingCache = vi.fn().mockResolvedValue(true)
+
+    await new NotebookRecoveryCoordinator(runtimeRoot, undefined, {
+      publishWorkingCacheArchives,
+      finalizeWorkingCache
+    }).recover()
+
+    expect(publishWorkingCacheArchives).toHaveBeenCalledWith(runtimeRoot, publications)
+    expect(await journal.pending()).toEqual([])
+    expect(finalizeWorkingCache).toHaveBeenCalledWith(runtimeRoot, {
+      mode: 'exact',
+      workingRoots: [publications[0].workingRoot]
+    })
+  })
+
+  it('completes publication recovery when no disposable-cache finalizer is configured', async () => {
+    const runtimeRoot = await createRuntimeRoot()
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+    await journal.begin({
+      operationId: 'publish-without-finalizer',
+      kind: 'install',
+      runtimeId: 'analysis',
+      phase: 'install-python',
+      startedAt: 100,
+      archivePublications: [
+        {
+          workingRoot: 'D:\\OpenScienceTmp\\m-test',
+          authorizations: [{ file: 'python-1.conda', algorithm: 'sha256', digest: 'a'.repeat(64) }]
+        }
+      ]
+    })
+
+    await new NotebookRecoveryCoordinator(runtimeRoot, undefined, {
+      publishWorkingCacheArchives: vi.fn().mockResolvedValue(undefined)
+    }).recover()
+
+    expect(await journal.pending()).toEqual([])
+  })
+
+  it('retains publication evidence and the working cache when recovered publication fails', async () => {
+    const runtimeRoot = await createRuntimeRoot()
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+    await journal.begin({
+      operationId: 'publish-retry',
+      kind: 'materialize',
+      runtimeId: DEFAULT_PY_ENV,
+      phase: 'create-python',
+      startedAt: 100,
+      archivePublications: [
+        {
+          workingRoot: 'D:\\OpenScienceTmp\\m-test',
+          authorizations: [{ file: 'python-1.conda', algorithm: 'sha256', digest: 'a'.repeat(64) }]
+        }
+      ]
+    })
+    const finalizeWorkingCache = vi.fn().mockResolvedValue(true)
+
+    await new NotebookRecoveryCoordinator(runtimeRoot, undefined, {
+      publishWorkingCacheArchives: vi.fn().mockRejectedValue(new Error('disk full')),
+      finalizeWorkingCache
+    }).recover()
+
+    expect((await journal.pending()).map(({ operationId }) => operationId)).toEqual([
+      'publish-retry'
+    ])
+    expect(finalizeWorkingCache).not.toHaveBeenCalled()
+  })
+
+  it('cleans a distinct recovered fallback when a later publication remains retained', async () => {
+    const runtimeRoot = await createRuntimeRoot()
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+    const completedRoot = 'E:\\PreviousTemp\\OpenScienceTmp\\m-complete'
+    const retainedRoot = 'F:\\PreviousTemp\\OpenScienceTmp\\m-retained'
+    for (const [operationId, workingRoot] of [
+      ['publish-complete', completedRoot],
+      ['publish-retained', retainedRoot]
+    ]) {
+      await journal.begin({
+        operationId,
+        kind: 'install',
+        runtimeId: operationId,
+        phase: 'install-python',
+        startedAt: 100,
+        archivePublications: [
+          {
+            workingRoot,
+            authorizations: [
+              {
+                file: `${operationId}.conda`,
+                algorithm: 'sha256',
+                digest: 'a'.repeat(64)
+              }
+            ]
+          }
+        ]
+      })
+    }
+    const publishWorkingCacheArchives = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('disk full'))
+    const finalizeWorkingCache = vi.fn().mockResolvedValue(true)
+
+    await new NotebookRecoveryCoordinator(runtimeRoot, undefined, {
+      publishWorkingCacheArchives,
+      finalizeWorkingCache
+    }).recover()
+
+    expect((await journal.pending()).map((record) => record.operationId)).toEqual([
+      'publish-retained'
+    ])
+    expect(finalizeWorkingCache).toHaveBeenCalledWith(runtimeRoot, {
+      mode: 'exact',
+      workingRoots: [completedRoot]
+    })
+  })
+
+  it('keeps the exact fallback durable until transient cleanup succeeds on a later startup', async () => {
+    const runtimeRoot = await createRuntimeRoot()
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+    const workingRoot = 'E:\\PreviousTemp\\OpenScienceTmp\\m-retry'
+    await journal.begin({
+      operationId: 'cleanup-retry',
+      kind: 'install',
+      runtimeId: 'analysis',
+      phase: 'install-python',
+      startedAt: 100,
+      archivePublications: [
+        {
+          workingRoot,
+          authorizations: [{ file: 'analysis.conda', algorithm: 'sha256', digest: 'a'.repeat(64) }]
+        }
+      ]
+    })
+    const publishWorkingCacheArchives = vi.fn().mockResolvedValue(undefined)
+    const finalizeWorkingCache = vi.fn().mockResolvedValueOnce(false).mockResolvedValue(true)
+
+    await new NotebookRecoveryCoordinator(runtimeRoot, undefined, {
+      publishWorkingCacheArchives,
+      finalizeWorkingCache
+    }).recover()
+    expect((await journal.pending()).map((record) => record.operationId)).toEqual(['cleanup-retry'])
+
+    await new NotebookRecoveryCoordinator(runtimeRoot, undefined, {
+      publishWorkingCacheArchives,
+      finalizeWorkingCache
+    }).recover()
+    expect(await journal.pending()).toEqual([])
+    expect(publishWorkingCacheArchives).toHaveBeenCalledTimes(2)
+  })
+
+  it('suppresses cleanup when the journal becomes corrupt during recovery', async () => {
+    const runtimeRoot = await createRuntimeRoot()
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+    await journal.begin({
+      operationId: 'corrupt-after-publication',
+      kind: 'install',
+      runtimeId: 'analysis',
+      phase: 'install-python',
+      startedAt: 100,
+      archivePublications: [
+        {
+          workingRoot: 'D:\\OpenScienceTmp\\m-test',
+          authorizations: [{ file: 'python-1.conda', algorithm: 'sha256', digest: 'a'.repeat(64) }]
+        }
+      ]
+    })
+    const finalizeWorkingCache = vi.fn().mockResolvedValue(true)
+    const coordinator = new NotebookRecoveryCoordinator(runtimeRoot, undefined, {
+      publishWorkingCacheArchives: async () => {
+        await writeFile(operationJournalPath(runtimeRoot), '{ corrupt', 'utf8')
+      },
+      finalizeWorkingCache
+    })
+
+    await coordinator.recover()
+
+    expect(coordinator.snapshot().corruptJournal).toBe(true)
+    expect(finalizeWorkingCache).not.toHaveBeenCalled()
+  })
+
+  it('does not clean a cache retained under an equivalent Windows path spelling', async () => {
+    const runtimeRoot = await createRuntimeRoot()
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+    const firstRoot = 'E:\\PreviousTemp\\OpenScienceTmp\\m-shared'
+    const secondRoot = 'e:/previoustemp/opensciencetmp/m-shared'
+    for (const [operationId, workingRoot] of [
+      ['shared-published', firstRoot],
+      ['shared-retained', secondRoot]
+    ]) {
+      await journal.begin({
+        operationId,
+        kind: 'install',
+        runtimeId: operationId,
+        phase: 'install-python',
+        startedAt: 100,
+        archivePublications: [
+          {
+            workingRoot,
+            authorizations: [
+              { file: `${operationId}.conda`, algorithm: 'sha256', digest: 'a'.repeat(64) }
+            ]
+          }
+        ]
+      })
+    }
+    const finalizeWorkingCache = vi.fn().mockResolvedValue(true)
+
+    await new NotebookRecoveryCoordinator(runtimeRoot, undefined, {
+      publishWorkingCacheArchives: vi
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('disk full')),
+      finalizeWorkingCache,
+      workingCacheKey: (path) => win32.normalize(path).toLowerCase()
+    }).recover()
+
+    expect(finalizeWorkingCache).not.toHaveBeenCalled()
+    expect((await journal.pending()).map((record) => record.operationId).sort()).toEqual([
+      'shared-published',
+      'shared-retained'
+    ])
+  })
+
+  it('blocks an ambiguous post-mutation publication and retains the working cache', async () => {
+    const runtimeRoot = await createRuntimeRoot()
+    const targetPath = join(runtimeRoot, 'envs', 'analysis')
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+    await journal.begin({
+      operationId: 'publication-crash-window',
+      kind: 'install',
+      runtimeId: 'analysis',
+      phase: 'install-python',
+      startedAt: 100,
+      targetPath,
+      archivePublicationPending: true
+    })
+    const finalizeWorkingCache = vi.fn().mockResolvedValue(true)
+    const coordinator = new NotebookRecoveryCoordinator(runtimeRoot, undefined, {
+      finalizeWorkingCache
+    })
+
+    await coordinator.recover()
+
+    expect(coordinator.snapshot()).toMatchObject({
+      blockedPrefixes: [targetPath],
+      blockedRuntimeIds: ['analysis']
+    })
+    expect(await journal.pending()).toHaveLength(1)
+    expect(finalizeWorkingCache).not.toHaveBeenCalled()
+  })
+
   it('owns blocked and live-unconfirmed recovery state in one snapshot', async () => {
     const coordinator = new NotebookRecoveryCoordinator(await createRuntimeRoot())
 

--- a/src/main/notebook/recovery-coordinator.ts
+++ b/src/main/notebook/recovery-coordinator.ts
@@ -7,8 +7,15 @@ import {
   operationJournalPath,
   readOperationChild,
   removeOperationChildSync,
-  RuntimeOperationJournal
+  RuntimeOperationJournal,
+  type RuntimeOperationRecord
 } from './operation-journal'
+import { micromambaCacheLockKey } from './micromamba-cache'
+import {
+  publishRecoveredMicromambaArchives,
+  type WorkingCacheArchivePublication,
+  type WorkingCacheFinalizationTarget
+} from './windows-micromamba-working-cache'
 import { defaultOperationChildLiveness, reconcileInterruptedOperations } from './operation-recovery'
 import { verifyExecutable } from './provisioner-runtime'
 import { addRepairRequired, DEFAULT_PY_ENV, DEFAULT_R_ENV, pythonBin, rBin } from './runtime-paths'
@@ -35,6 +42,18 @@ export type NotebookRecoverySnapshot = {
   lastFailure?: Error
 }
 
+type NotebookRecoveryCoordinatorDeps = {
+  finalizeWorkingCache?: (
+    runtimeRoot: string,
+    target: WorkingCacheFinalizationTarget
+  ) => Promise<boolean>
+  publishWorkingCacheArchives?: (
+    runtimeRoot: string,
+    publications: readonly WorkingCacheArchivePublication[]
+  ) => Promise<void>
+  workingCacheKey?: (path: string) => string
+}
+
 export class NotebookRecoveryCoordinator {
   private recoveryComplete: Promise<void> | undefined
   private recoveryInFlight: Promise<void> | undefined
@@ -55,7 +74,8 @@ export class NotebookRecoveryCoordinator {
     private readonly repairPolicy: Pick<
       NotebookRuntimeRepairPolicy,
       'recoveryMarker'
-    > = new NotebookRuntimeRepairPolicy(runtimeRoot)
+    > = new NotebookRuntimeRepairPolicy(runtimeRoot),
+    private readonly deps: NotebookRecoveryCoordinatorDeps = {}
   ) {}
 
   async recover(): Promise<void> {
@@ -164,6 +184,8 @@ export class NotebookRecoveryCoordinator {
   private async reconcile(): Promise<void> {
     const nextStartupBlockedPrefixes = new Set<string>()
     const nextStartupBlockedRuntimeIds = new Set<string>()
+    const publishedArchiveRecords: RuntimeOperationRecord[] = []
+    let recoveryIncomplete = false
 
     await rm(join(this.runtimeRoot, 'packs', '.cache'), { recursive: true, force: true }).catch(
       () => undefined
@@ -270,6 +292,15 @@ export class NotebookRecoveryCoordinator {
       blockUnknownChildTarget: async (record) => {
         if (record.kind === 'install') nextStartupBlockedRuntimeIds.add(record.runtimeId)
         if (record.targetPath) nextStartupBlockedPrefixes.add(record.targetPath)
+      },
+      publishArchives: async (record) => {
+        const publish = this.deps.publishWorkingCacheArchives ?? publishRecoveredMicromambaArchives
+        await publish(this.runtimeRoot, record.archivePublications ?? [])
+        publishedArchiveRecords.push(record)
+      },
+      deferArchiveCompletion: true,
+      onRetained: () => {
+        recoveryIncomplete = true
       }
     })
 
@@ -299,6 +330,70 @@ export class NotebookRecoveryCoordinator {
     this.recoveryCorrupt = false
     this.corruptResetAllowlist.clear()
 
-    for (const record of reconciled) removeOperationChildSync(this.runtimeRoot, record.operationId)
+    for (const record of reconciled) {
+      if (!record.archivePublications) {
+        removeOperationChildSync(this.runtimeRoot, record.operationId)
+      }
+    }
+    const retainedState = await journal.readState()
+    const finalizedWorkingRootKeys = new Set<string>()
+    const workingCacheKey = this.deps.workingCacheKey ?? micromambaCacheLockKey
+    if (
+      retainedState !== 'corrupt' &&
+      !retainedState.records.some((record) => record.archivePublicationPending === true)
+    ) {
+      const publishedOperationIds = new Set(
+        publishedArchiveRecords.map((record) => record.operationId)
+      )
+      const retainedWorkingRootKeys = new Set(
+        retainedState.records.flatMap((record) =>
+          publishedOperationIds.has(record.operationId)
+            ? []
+            : (record.archivePublications?.map((publication) =>
+                workingCacheKey(publication.workingRoot)
+              ) ?? [])
+        )
+      )
+      const publishedWorkingRoots = new Map<string, string>()
+      for (const record of publishedArchiveRecords) {
+        for (const publication of record.archivePublications ?? []) {
+          const key = workingCacheKey(publication.workingRoot)
+          if (!retainedWorkingRootKeys.has(key))
+            publishedWorkingRoots.set(key, publication.workingRoot)
+        }
+      }
+      for (const [key, workingRoot] of publishedWorkingRoots) {
+        const finalized = this.deps.finalizeWorkingCache
+          ? await this.deps.finalizeWorkingCache(this.runtimeRoot, {
+              mode: 'exact',
+              workingRoots: [workingRoot]
+            })
+          : true
+        if (finalized) {
+          finalizedWorkingRootKeys.add(key)
+        }
+      }
+      for (const record of publishedArchiveRecords) {
+        const recordKeys = (record.archivePublications ?? []).map((publication) =>
+          workingCacheKey(publication.workingRoot)
+        )
+        if (recordKeys.every((key) => finalizedWorkingRootKeys.has(key))) {
+          await journal.complete(record.operationId)
+          removeOperationChildSync(this.runtimeRoot, record.operationId)
+        } else {
+          recoveryIncomplete = true
+        }
+      }
+    } else if (retainedState === 'corrupt') {
+      recoveryIncomplete = true
+      this.recoveryCorrupt = true
+    }
+    if (
+      nextStartupBlockedPrefixes.size === 0 &&
+      nextStartupBlockedRuntimeIds.size === 0 &&
+      !recoveryIncomplete
+    ) {
+      await this.deps.finalizeWorkingCache?.(this.runtimeRoot, { mode: 'current-candidates' })
+    }
   }
 }

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -3458,8 +3458,9 @@ describe('notebook runtime service', () => {
     releaseRead()
     await Promise.all([first, second])
 
-    // One healthy recovery reads once for the fail-closed preflight and once for reconciliation.
-    expect(readState).toHaveBeenCalledTimes(2)
+    // One healthy recovery reads once for the fail-closed preflight, once for reconciliation, and
+    // once more before cache cleanup so a journal mutation during publication remains fail-closed.
+    expect(readState).toHaveBeenCalledTimes(3)
     readState.mockRestore()
   })
 

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -78,6 +78,7 @@ import type {
 } from '../../shared/notebook-runtime'
 import type { NotebookRuntimeSettings } from '../settings/capabilities'
 import { NotebookRecoveryCoordinator } from './recovery-coordinator'
+import { managedNotebookWorkingCache } from './windows-micromamba-working-cache'
 import { NotebookRuntimeRepairOwner } from './runtime-repair'
 import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
 import { NotebookEnvironmentOperations, type DefaultEnvProvisioner } from './environment-operations'
@@ -118,8 +119,7 @@ import {
 } from './content-limits'
 import { NotebookHelperModuleHost, type NotebookHelperModuleCatalog } from './helper-module-host'
 
-// Locale fallback when no explicit locale is injected (see shared/mirror.ts: non-CN locales resolve
-// to public hosts, so this default never silently forces a CN mirror).
+// The default stays outside CN mirror routing when no explicit locale is injected.
 const DEFAULT_LOCALE = 'en-US'
 
 const EMPTY_NOTEBOOK_RUNTIME_SETTINGS: Pick<NotebookRuntimeSettings, 'getSnapshot'> = {
@@ -342,9 +342,6 @@ class NotebookRuntimeService {
   private readonly runtimeEnablementResolver:
     ((language: NotebookLanguage) => Promise<RuntimeEnablement | undefined>) | undefined
   private readonly runtimeBindingOwner: NotebookRuntimeBindingOwner
-  // Owns startup-recovery promises, journal reconciliation, fail-closed block decisions, Reset
-  // allowlisting, and same-process live-unconfirmed tracking. The service retains its public recovery
-  // facade so Electron, Web, CLI, and IPC adapters keep the same contract.
   private readonly recoveryCoordinator: NotebookRecoveryCoordinator
   private readonly runtimeLogger?: RuntimeDiagnosticLogger
   private readonly environmentStateTracker: Pick<
@@ -372,8 +369,13 @@ class NotebookRuntimeService {
       }
     })
     const runtimeRoot = getRuntimeRoot(options.dataRoot)
+    const workingCache = managedNotebookWorkingCache(options.platform, !options.installPackagesImpl)
     this.repairPolicy = new NotebookRuntimeRepairPolicy(runtimeRoot)
-    this.recoveryCoordinator = new NotebookRecoveryCoordinator(runtimeRoot, this.repairPolicy)
+    this.recoveryCoordinator = new NotebookRecoveryCoordinator(
+      runtimeRoot,
+      this.repairPolicy,
+      workingCache
+    )
     this.mcpRpcConnectionResolver = options.getMcpRpcConnection
     const runtimeSettings = options.notebookRuntimeSettings ?? EMPTY_NOTEBOOK_RUNTIME_SETTINGS
     this.runtimeEnablementResolver = async (language) =>
@@ -492,6 +494,7 @@ class NotebookRuntimeService {
       environmentStateTracker: this.environmentStateTracker,
       installPackages: options.installPackagesImpl ?? installPackagesDefault,
       micromambaRunner: options.micromambaRunner,
+      ...workingCache,
       createEnvironmentCaptureTarget: (...args) => this.environmentCaptureTarget(...args)
     })
     this.dataExecutionAdmission = new NotebookDataExecutionAdmissionOwner({

--- a/src/main/notebook/shell-process.test.ts
+++ b/src/main/notebook/shell-process.test.ts
@@ -117,18 +117,25 @@ describe('notebook shell process behavior', () => {
     })
 
     it('keeps Windows shell runtime variables while excluding host secrets', () => {
-      const env = buildShellEnv('/notebook/handoff', 'win32', {
-        PATH: 'C:\\Windows\\System32',
-        ProgramFiles: 'C:\\Program Files',
-        SystemRoot: 'C:\\Windows',
-        WINDIR: 'C:\\Windows',
-        ComSpec: 'C:\\Windows\\System32\\cmd.exe',
-        PATHEXT: '.COM;.EXE;.BAT;.CMD',
-        USERPROFILE: 'C:\\Users\\Ada',
-        PSModulePath: 'C:\\host\\third-party-modules',
-        OPEN_SCIENCE_PSMODULEPATH: 'C:\\host\\controlled-modules',
-        OPEN_SCIENCE_TEST_SECRET: 'must-not-leak'
-      })
+      const runtimeRoot = 'D:\\OpenScience\\runtime'
+      const env = buildShellEnv(
+        '/notebook/handoff',
+        'win32',
+        {
+          PATH: 'C:\\Windows\\System32',
+          ProgramFiles: 'C:\\Program Files',
+          SystemRoot: 'C:\\Windows',
+          WINDIR: 'C:\\Windows',
+          ComSpec: 'C:\\Windows\\System32\\cmd.exe',
+          PATHEXT: '.COM;.EXE;.BAT;.CMD',
+          USERPROFILE: 'C:\\Users\\Ada',
+          PSModulePath: 'C:\\host\\third-party-modules',
+          OPEN_SCIENCE_PSMODULEPATH: 'C:\\host\\controlled-modules',
+          OPEN_SCIENCE_TEST_SECRET: 'must-not-leak'
+        },
+        runtimeRoot
+      )
+      const cacheRoot = join(runtimeRoot, 'cache', 'notebook')
 
       expect(env).toMatchObject({
         PATH: 'C:\\Windows\\System32',
@@ -141,7 +148,11 @@ describe('notebook shell process behavior', () => {
           'C:\\Program Files\\WindowsPowerShell\\Modules;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules',
         OPEN_SCIENCE_PSMODULEPATH:
           'C:\\Program Files\\WindowsPowerShell\\Modules;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules',
-        OPEN_SCIENCE_HANDOFF_DIR: '/notebook/handoff'
+        OPEN_SCIENCE_HANDOFF_DIR: '/notebook/handoff',
+        OPEN_SCIENCE_NOTEBOOK_CACHE_DIR: cacheRoot,
+        PIP_CACHE_DIR: join(cacheRoot, 'pip'),
+        HF_HUB_CACHE: join(cacheRoot, 'huggingface', 'hub'),
+        TORCH_HOME: join(cacheRoot, 'torch')
       })
       expect(env.ProgramFiles).toBeUndefined()
       expect(env.OPEN_SCIENCE_TEST_SECRET).toBeUndefined()

--- a/src/main/notebook/shell-process.ts
+++ b/src/main/notebook/shell-process.ts
@@ -6,6 +6,10 @@ import { terminateProcessTree } from '../process-tree'
 import { resolveWindowsPowerShellExecutable } from '../windows-powershell'
 import { NOTEBOOK_SHELL_DEFAULT_TIMEOUT_MS } from '../../shared/notebook'
 import {
+  notebookWorkloadCacheEnv,
+  prepareNotebookWorkloadCache
+} from './notebook-workload-cache-paths'
+import {
   NOTEBOOK_DIAGNOSTIC_RESERVE_BYTES,
   NOTEBOOK_TEXT_LIMIT_BYTES,
   limitUtf8
@@ -66,7 +70,9 @@ const WINDOWS_SHELL_ENV_ALLOWLIST = ['ComSpec', 'PATHEXT', 'SystemRoot', 'WINDIR
 const buildShellEnv = (
   handoffDir: string,
   platform: NodeJS.Platform = process.platform,
-  sourceEnv: NodeJS.ProcessEnv = process.env
+  sourceEnv: NodeJS.ProcessEnv = process.env,
+  runtimeRoot?: string,
+  workloadCacheEnv?: NodeJS.ProcessEnv
 ): NodeJS.ProcessEnv => {
   const env: NodeJS.ProcessEnv = {}
   const keys =
@@ -100,6 +106,9 @@ const buildShellEnv = (
     }
   }
   env.OPEN_SCIENCE_HANDOFF_DIR = handoffDir
+  if (runtimeRoot) {
+    Object.assign(env, workloadCacheEnv ?? notebookWorkloadCacheEnv(runtimeRoot))
+  }
   return env
 }
 
@@ -273,6 +282,25 @@ const runShellCommand = (
       return
     }
 
+    let shellEnv: NodeJS.ProcessEnv
+    try {
+      const workloadCacheEnv = prepareNotebookWorkloadCache(options.runtimeRoot)
+      shellEnv = buildShellEnv(
+        options.handoffDir,
+        options.platform ?? process.platform,
+        process.env,
+        options.runtimeRoot,
+        workloadCacheEnv
+      )
+    } catch (error) {
+      resolve({
+        stdout: '',
+        stderr: error instanceof Error ? error.message : String(error),
+        exitCode: null
+      })
+      return
+    }
+
     const timeoutMs = options.timeoutMs ?? NOTEBOOK_SHELL_DEFAULT_TIMEOUT_MS
     const platform = options.platform ?? process.platform
     const invocation = protectManagedRuntimeWrites(
@@ -282,7 +310,7 @@ const runShellCommand = (
     )
     const child = spawn(invocation.executable, invocation.args, {
       cwd: options.cwd,
-      env: buildShellEnv(options.handoffDir),
+      env: shellEnv,
       // On POSIX this makes the shell the leader of a private process group/session. Keep its handle
       // and stdio referenced (no unref), preserving normal completion while enabling safe -PGID kills.
       detached: platform !== 'win32'

--- a/src/main/notebook/windows-micromamba-working-cache.ts
+++ b/src/main/notebook/windows-micromamba-working-cache.ts
@@ -1,0 +1,335 @@
+import { existsSync, lstatSync } from 'node:fs'
+
+import {
+  publishMicromambaArchives,
+  type MicromambaArchiveAuthorization
+} from './micromamba-archive-store'
+import {
+  isTrustedMicromambaWorkingCacheForRoot,
+  micromambaCacheLockKey,
+  micromambaWorkingCachePaths,
+  removeMicromambaCacheForRoot,
+  removeTrustedMicromambaWorkingCacheForRoot,
+  type MicromambaCacheDeps
+} from './micromamba-cache'
+import {
+  operationJournalPath,
+  RuntimeOperationJournal,
+  type RuntimeArchivePublication
+} from './operation-journal'
+import { pkgsCache } from './runtime-paths'
+
+export type WorkingCacheArchivePublication = RuntimeArchivePublication
+
+export type WorkingCacheReleaseOptions = {
+  archivePublications?: readonly WorkingCacheArchivePublication[]
+  completedOperationId?: string
+  retainForRecovery?: boolean
+}
+
+export type WorkingCacheFinalizationTarget =
+  { mode: 'current-candidates' } | { mode: 'exact'; workingRoots: readonly string[] }
+
+export type MicromambaWorkingCacheLease = (options: WorkingCacheReleaseOptions) => Promise<boolean>
+export type MicromambaWorkingCacheRetainer = (
+  root: string,
+  operationId?: string
+) => MicromambaWorkingCacheLease | Promise<MicromambaWorkingCacheLease>
+
+type ManagedNotebookWorkingCache = Readonly<{
+  finalizeWorkingCache?: (root: string, target: WorkingCacheFinalizationTarget) => Promise<boolean>
+  retainWorkingCache?: MicromambaWorkingCacheRetainer
+}>
+
+type WorkingCacheLeaseDeps = Pick<
+  MicromambaCacheDeps,
+  'platform' | 'canonicalize' | 'env' | 'exists'
+> & {
+  publishArchives?: typeof publishMicromambaArchives
+  cleanup?: (root: string) => boolean | void
+  requiresRecoveryRetention?: (
+    root: string,
+    completedOperationIds: ReadonlySet<string>
+  ) => Promise<boolean>
+  cleanupExact?: (root: string, workingRoot: string) => boolean
+  workingRootState?: (path: string) => 'present' | 'absent' | 'unknown'
+}
+
+type ActiveWorkingCache = {
+  leases: number
+  operationIds: Set<string>
+  completedOperationIds: Set<string>
+  archivePublications: Map<
+    string,
+    { workingRoot: string; authorizations: Map<string, MicromambaArchiveAuthorization> }
+  >
+  finalization?: Promise<boolean>
+  completion: Promise<boolean>
+  resolveCompletion: (completed: boolean) => void
+}
+
+const activeWorkingCaches = new Map<string, ActiveWorkingCache>()
+// Recovery retention protects the shared on-disk cache for the rest of this process, but is not part
+// of a later lease's publication result. A later operation may publish its own verified archives and
+// complete its journal while cleanup remains deferred until startup recovery reconciles the old writer.
+const recoveryRetainedWorkingCaches = new Set<string>()
+
+const completionSignal = (): Pick<ActiveWorkingCache, 'completion' | 'resolveCompletion'> => {
+  let resolveCompletion!: (completed: boolean) => void
+  const completion = new Promise<boolean>((resolve) => {
+    resolveCompletion = resolve
+  })
+  return { completion, resolveCompletion }
+}
+
+const cleanupWorkingCache = (root: string): boolean => removeMicromambaCacheForRoot(root)
+
+const hasDurableRecoveryRetention = async (
+  root: string,
+  completedOperationIds: ReadonlySet<string>
+): Promise<boolean> => {
+  const state = await RuntimeOperationJournal.forPath(operationJournalPath(root)).readState()
+  if (state === 'corrupt') return true
+  return state.records.some(
+    (record) =>
+      record.archivePublicationPending === true ||
+      (record.archivePublications !== undefined && !completedOperationIds.has(record.operationId))
+  )
+}
+
+const hasRecoveredArchivePublications = async (
+  root: string,
+  operationId: string | undefined,
+  activeOperationIds: ReadonlySet<string>
+): Promise<boolean> => {
+  const state = await RuntimeOperationJournal.forPath(operationJournalPath(root)).readState()
+  if (state === 'corrupt') return true
+  return state.records.some(
+    (record) =>
+      (record.archivePublicationPending === true || record.archivePublications !== undefined) &&
+      record.operationId !== operationId &&
+      !activeOperationIds.has(record.operationId)
+  )
+}
+
+const publishWorkingArchives = (
+  root: string,
+  workingRoot: string,
+  authorizations: readonly MicromambaArchiveAuthorization[],
+  deps: WorkingCacheLeaseDeps
+): Promise<number> => {
+  if (deps.publishArchives) return deps.publishArchives(root, workingRoot, authorizations)
+  return publishMicromambaArchives(
+    root,
+    workingRoot,
+    authorizations,
+    micromambaCacheLockKey(pkgsCache(root), deps),
+    () => isTrustedMicromambaWorkingCacheForRoot(root, workingRoot, deps)
+  )
+}
+
+export const retainMicromambaWorkingCache = async (
+  root: string,
+  deps: WorkingCacheLeaseDeps = {},
+  operationId?: string
+): Promise<MicromambaWorkingCacheLease> => {
+  const platform = deps.platform ?? process.platform
+  if (platform !== 'win32') return async () => true
+  const key = micromambaCacheLockKey(root, deps)
+  let active: ActiveWorkingCache
+  while (true) {
+    const existing = activeWorkingCaches.get(key)
+    if (existing?.finalization) {
+      await existing.finalization.catch(() => false)
+      continue
+    }
+    if (
+      await hasRecoveredArchivePublications(root, operationId, existing?.operationIds ?? new Set())
+    ) {
+      throw new Error(
+        'RUNTIME_CACHE_RECOVERY_BLOCKED: verified package archives are still awaiting recovery publication'
+      )
+    }
+    if (activeWorkingCaches.get(key) !== existing || existing?.finalization) continue
+    active =
+      existing ??
+      ({
+        leases: 0,
+        operationIds: new Set(),
+        completedOperationIds: new Set(),
+        archivePublications: new Map(),
+        ...completionSignal()
+      } satisfies ActiveWorkingCache)
+    if (existing && existing.leases === 0) Object.assign(active, completionSignal())
+    active.leases += 1
+    if (operationId) active.operationIds.add(operationId)
+    activeWorkingCaches.set(key, active)
+    break
+  }
+  let released = false
+
+  return async ({
+    archivePublications = [],
+    completedOperationId,
+    retainForRecovery = false
+  }): Promise<boolean> => {
+    if (released) return false
+    released = true
+    if (operationId) active.operationIds.delete(operationId)
+    if (completedOperationId) active.completedOperationIds.add(completedOperationId)
+    if (retainForRecovery) {
+      recoveryRetainedWorkingCaches.add(key)
+    } else {
+      for (const publication of archivePublications) {
+        if (publication.authorizations.length === 0) continue
+        const publicationKey = micromambaCacheLockKey(publication.workingRoot, deps)
+        const collected = active.archivePublications.get(publicationKey) ?? {
+          workingRoot: publication.workingRoot,
+          authorizations: new Map<string, MicromambaArchiveAuthorization>()
+        }
+        for (const authorization of publication.authorizations) {
+          const key = `${authorization.file}\0${authorization.algorithm}\0${authorization.digest}`
+          collected.authorizations.set(key, authorization)
+        }
+        active.archivePublications.set(publicationKey, collected)
+      }
+    }
+    active.leases -= 1
+    if (active.leases > 0) return retainForRecovery ? false : active.completion
+    let publicationFailed = false
+    const finalization = Promise.resolve().then(async (): Promise<boolean> => {
+      try {
+        if (active.archivePublications.size > 0) {
+          try {
+            for (const publication of active.archivePublications.values()) {
+              await publishWorkingArchives(
+                root,
+                publication.workingRoot,
+                [...publication.authorizations.values()],
+                deps
+              )
+            }
+          } catch {
+            // Preserve the working cache when durable publication fails; a later operation can retry.
+            publicationFailed = true
+            active.resolveCompletion(false)
+            return false
+          }
+        }
+        const durableRetention = await (
+          deps.requiresRecoveryRetention ?? hasDurableRecoveryRetention
+        )(root, active.completedOperationIds)
+        if (!recoveryRetainedWorkingCaches.has(key) && !durableRetention) {
+          const cleanupCompleted = (deps.cleanup ?? cleanupWorkingCache)(root)
+          if (cleanupCompleted === false) {
+            publicationFailed = true
+            active.resolveCompletion(false)
+            return false
+          }
+        }
+        active.resolveCompletion(true)
+        return true
+      } catch {
+        publicationFailed = true
+        active.resolveCompletion(false)
+        return false
+      } finally {
+        if (activeWorkingCaches.get(key) === active) {
+          active.finalization = undefined
+          if (!publicationFailed) activeWorkingCaches.delete(key)
+        }
+      }
+    })
+    active.finalization = finalization
+    const completed = await finalization
+    return retainForRecovery ? false : completed
+  }
+}
+
+export const publishRecoveredMicromambaArchives = async (
+  root: string,
+  archivePublications: readonly WorkingCacheArchivePublication[],
+  deps: WorkingCacheLeaseDeps = {}
+): Promise<void> => {
+  for (const publication of archivePublications) {
+    await publishWorkingArchives(root, publication.workingRoot, publication.authorizations, deps)
+  }
+}
+
+// On Windows, a hard app exit loses the in-memory lease but leaves the marker-owned working cache. Startup recovery
+// calls this only after every interrupted writer has been reconciled. Avoid selectMicromambaCache when
+// the expected path is absent because selection intentionally creates and hardens the working folder.
+export const finalizeRecoveredMicromambaWorkingCache = async (
+  root: string,
+  deps: WorkingCacheLeaseDeps & { exists?: (path: string) => boolean },
+  target: WorkingCacheFinalizationTarget
+): Promise<boolean> => {
+  const recoveredWorkingRoots = target.mode === 'exact' ? target.workingRoots : []
+  const platform = deps.platform ?? process.platform
+  if (platform !== 'win32') {
+    if (recoveredWorkingRoots.length === 0) return false
+    const durableKey = micromambaCacheLockKey(pkgsCache(root), { ...deps, platform })
+    return recoveredWorkingRoots.every(
+      (workingRoot) => micromambaCacheLockKey(workingRoot, { ...deps, platform }) === durableKey
+    )
+  }
+  let recoveredComplete = recoveredWorkingRoots.length > 0
+  const workingRootState =
+    deps.workingRootState ??
+    (deps.exists
+      ? (path: string) => (deps.exists?.(path) ? ('present' as const) : ('absent' as const))
+      : (path: string) => {
+          try {
+            lstatSync(path)
+            return 'present' as const
+          } catch (error) {
+            return (error as NodeJS.ErrnoException).code === 'ENOENT'
+              ? ('absent' as const)
+              : ('unknown' as const)
+          }
+        })
+  for (const workingRoot of new Set(recoveredWorkingRoots)) {
+    const state = workingRootState(workingRoot)
+    if (state === 'unknown') {
+      recoveredComplete = false
+      continue
+    }
+    if (state === 'absent') continue
+    recoveredComplete =
+      (deps.cleanupExact ?? removeTrustedMicromambaWorkingCacheForRoot)(root, workingRoot) &&
+      recoveredComplete
+  }
+  if (target.mode === 'exact') return recoveredComplete
+  let expectedPaths: string[]
+  try {
+    expectedPaths = micromambaWorkingCachePaths(root, deps)
+  } catch {
+    return recoveredComplete
+  }
+  const exists = deps.exists ?? existsSync
+  if (!expectedPaths.some((path) => exists(path))) return recoveredComplete
+
+  // A crash loses the in-memory transaction/lock authorization. The working cache is disposable, so
+  // never reconstruct trust from notebook-writable environment metadata during startup recovery.
+  const key = micromambaCacheLockKey(root, deps)
+  activeWorkingCaches.delete(key)
+  recoveryRetainedWorkingCaches.delete(key)
+  return (deps.cleanup ?? cleanupWorkingCache)(root) !== false
+}
+
+export const managedNotebookWorkingCache = (
+  platform: NodeJS.Platform = process.platform,
+  enabled = true
+): ManagedNotebookWorkingCache => {
+  const archiveCacheEnabled = enabled && platform === 'win32'
+  return {
+    finalizeWorkingCache: archiveCacheEnabled
+      ? (root: string, target: WorkingCacheFinalizationTarget) =>
+          finalizeRecoveredMicromambaWorkingCache(root, { platform }, target)
+      : undefined,
+    retainWorkingCache: archiveCacheEnabled
+      ? (root: string, operationId?: string) =>
+          retainMicromambaWorkingCache(root, { platform }, operationId)
+      : undefined
+  }
+}

--- a/src/main/storage/command-owner.ts
+++ b/src/main/storage/command-owner.ts
@@ -29,6 +29,7 @@ import type { MicromambaRunner } from '../notebook/windows-micromamba-runner'
 import { captureMicromamba } from '../notebook/provisioner-runtime'
 import { exportRuntimeLocks } from '../notebook/runtime-relocation'
 import { removeMicromambaCacheForRoot } from '../notebook/micromamba-cache'
+import { removeNotebookWorkloadCache } from '../notebook/notebook-workload-cache-paths'
 import { detectActiveSessions } from './detect-active'
 import { isDataRootMissing } from './path-presence'
 import { beginMigration, clearMigrationPending, endMigrationCopy } from './migration-state'
@@ -82,7 +83,7 @@ type StorageCommandOwnerDeps = {
   showOpenDialog?: () => Promise<string | null>
   relaunch?: () => void
   broadcastProgress?: (progress: MigrationProgress) => void
-  cleanupRuntimeCache?: (runtimeRoot: string) => void
+  cleanupRuntimeCache?: (runtimeRoot: string) => boolean
   logger?: Logger
   micromambaRunner?: Pick<MicromambaRunner, 'resolve'>
   exportRuntimeLocks?: typeof exportRuntimeLocks
@@ -110,7 +111,13 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
   let activeStaged:
     { token: string; target: string; correlationId: string; recovered: boolean } | undefined
   let resolutionInProgress = false
-  const cleanupRuntimeCache = deps.cleanupRuntimeCache ?? removeMicromambaCacheForRoot
+  const cleanupRuntimeCache =
+    deps.cleanupRuntimeCache ??
+    ((runtimeRoot: string): boolean => {
+      const workloadRemoved = removeNotebookWorkloadCache(runtimeRoot)
+      const micromambaRemoved = removeMicromambaCacheForRoot(runtimeRoot)
+      return workloadRemoved && micromambaRemoved
+    })
   const discardStagedCopyImpl = deps.discardStagedCopy ?? discardStagedCopy
   const runDataRootMigrationImpl = deps.runDataRootMigration ?? runDataRootMigration
   const pauseDataRootWritersImpl = deps.pauseDataRootWriters ?? pauseDataRootWriters
@@ -270,6 +277,7 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
           diagnosticCorrelationId: correlationId,
           runtime: deps.runtime,
           notebook: deps.notebook,
+          cleanupRuntimeCache,
           // Preserve the runtime across the move by exporting each env to an offline lock at the
           // new root; the copied pkgs cache lets the provisioner rebuild them offline on relaunch.
           exportRuntimeLocks: async (fromDataRoot, toDataRoot) =>

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -93,6 +93,7 @@ const fakeDeps = (overrides: Partial<FakeDeps> = {}): FakeDeps => ({
     dismissLegacyDataMovePrompt: vi.fn().mockResolvedValue(undefined),
     getStoredSettings: vi.fn().mockResolvedValue({})
   },
+  cleanupRuntimeCache: vi.fn(() => true),
   relaunch: vi.fn(),
   ...overrides
 })
@@ -710,7 +711,7 @@ describe('storage IPC handlers', () => {
   it('commit-and-relaunch delegates production cleanup to the orderly app quit lifecycle', async () => {
     initDataRoot(dataRoot)
     // No injected relaunch: exercise the real app.relaunch -> app.quit handoff.
-    const cleanupRuntimeCache = vi.fn()
+    const cleanupRuntimeCache = vi.fn(() => true)
     const deps = fakeDeps({ relaunch: undefined, cleanupRuntimeCache })
     appQuit.mockImplementationOnce(() => {
       expect(currentApplicationShutdownTrigger()).toBe('migration-relaunch')
@@ -756,7 +757,7 @@ describe('storage IPC handlers', () => {
 
   it('commit-and-relaunch returns switchoverFailed and does NOT relaunch when setDataRoot throws', async () => {
     initDataRoot(dataRoot)
-    const cleanupRuntimeCache = vi.fn()
+    const cleanupRuntimeCache = vi.fn(() => true)
     const deps = fakeDeps({
       settingsService: {
         setDataRoot: vi.fn().mockRejectedValue(new Error('disk full')),
@@ -767,6 +768,7 @@ describe('storage IPC handlers', () => {
     })
     registerStorageIpcHandlers(deps)
     await invoke('storage:migrate', { parent: targetParent })
+    cleanupRuntimeCache.mockClear()
 
     const outcome = (await invoke('storage:commit-and-relaunch', { parent: targetParent })) as {
       ok: boolean

--- a/src/main/storage/migration-service.test.ts
+++ b/src/main/storage/migration-service.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
@@ -538,7 +538,8 @@ describe('validateNewDataRoot', () => {
 type FakeDeps = {
   currentDataRoot: string
   runtime: { disconnect: Mock<() => Promise<unknown>> }
-  notebook: { shutdownAll: Mock<() => Promise<void>> }
+  notebook: { shutdownAll: Mock<() => Promise<{ reaped: boolean } | void>> }
+  cleanupRuntimeCache: Mock<(runtimeRoot: string) => boolean>
   setDataRoot: Mock<(path: string) => Promise<void>>
 }
 
@@ -546,7 +547,10 @@ type FakeDeps = {
 const fakeDeps = (): FakeDeps => ({
   currentDataRoot,
   runtime: { disconnect: vi.fn<() => Promise<unknown>>().mockResolvedValue(undefined) },
-  notebook: { shutdownAll: vi.fn<() => Promise<void>>().mockResolvedValue(undefined) },
+  notebook: {
+    shutdownAll: vi.fn<() => Promise<{ reaped: boolean } | void>>().mockResolvedValue(undefined)
+  },
+  cleanupRuntimeCache: vi.fn<(runtimeRoot: string) => boolean>().mockReturnValue(true),
   setDataRoot: vi.fn<(path: string) => Promise<void>>().mockResolvedValue(undefined)
 })
 
@@ -611,6 +615,7 @@ describe('runDataRootMigration (copy phase)', () => {
     )
 
     expect(result).toEqual({ ok: true })
+    expect(deps.cleanupRuntimeCache).toHaveBeenCalledWith(join(dataRootFor(emptyParent), 'runtime'))
     const records = diagnosticRecords(logger)
     expect(
       records.filter((record) => record.phase && !record.outcome).map((record) => record.phase)
@@ -631,6 +636,29 @@ describe('runDataRootMigration (copy phase)', () => {
         preservedEnvironmentCount: 0
       })
     )
+  })
+
+  it('refuses a runtime-only target whose Notebook cache cannot be safely replaced', async () => {
+    const deps = fakeDeps()
+    deps.cleanupRuntimeCache.mockReturnValue(false)
+    const target = dataRootFor(emptyParent)
+    await mkdir(join(target, 'runtime', 'cache', 'notebook'), { recursive: true })
+    const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({ ok: true }))
+
+    const result = await runDataRootMigration(
+      { ...deps, currentDataRoot, copyAndVerify },
+      emptyParent,
+      runOpts()
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error:
+        'The new data location contains a Notebook cache that Open Science cannot safely replace. Choose another location or remove that cache first.'
+    })
+    expect(deps.cleanupRuntimeCache).toHaveBeenCalledWith(join(target, 'runtime'))
+    expect(copyAndVerify).not.toHaveBeenCalled()
+    expect(existsSync(target)).toBe(true)
   })
 
   it('records bounded copy quartiles without retaining the current file path', async () => {
@@ -736,10 +764,10 @@ describe('runDataRootMigration (copy phase)', () => {
       expect.objectContaining({
         from: currentDataRoot,
         to: target,
-        dirs: [...MIGRATED_DIRS, RUNTIME_ENVIRONMENT_MANIFESTS_DIR]
+        dirs: [...MIGRATED_DIRS, RUNTIME_ENVIRONMENT_MANIFESTS_DIR, join('runtime', 'pkgs')]
       })
     )
-    // runtime/ is excluded from the moved set (non-relocatable; rebuilt on demand).
+    // runtime/ is excluded wholesale; only relocatable durable subtrees are copied explicitly.
     expect(MIGRATED_DIRS).not.toContain('runtime')
     expect(MIGRATED_DIRS).toContain('delegation')
     expect(MIGRATED_DIRS).toContain('workspaces')
@@ -938,7 +966,7 @@ describe('runDataRootMigration (copy phase)', () => {
     expect(copyAndVerify).not.toHaveBeenCalled()
   })
 
-  it('moves immutable Environment manifests without relocating dirty runtime cache state', async () => {
+  it('moves immutable Environment manifests without relocating dirty runtime inventory', async () => {
     const deps = fakeDeps()
     const environmentKey = '6781bee2cc7128dad60abe39756695758edd2dc2f9b42bb53db430253a7d8b43'
     const inventoryTarget = join(
@@ -977,9 +1005,6 @@ describe('runDataRootMigration (copy phase)', () => {
     )
     await mkdir(destinationInventory, { recursive: true })
     await writeFile(join(destinationInventory, 'binding.json'), '{"state":"dirty"}\n')
-    const destinationRuntimeSentinel = join(target, 'runtime', 'cache-sentinel')
-    await writeFile(destinationRuntimeSentinel, 'keep')
-
     const result = await runDataRootMigration(
       { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook },
       emptyParent,
@@ -989,7 +1014,65 @@ describe('runDataRootMigration (copy phase)', () => {
     expect(result).toEqual({ ok: true })
     expect(existsSync(join(target, RUNTIME_ENVIRONMENT_MANIFESTS_DIR, manifestName))).toBe(true)
     expect(existsSync(join(target, 'runtime', 'provenance', 'environment-inventory'))).toBe(false)
-    expect(existsSync(destinationRuntimeSentinel)).toBe(true)
+  })
+
+  it('refuses and preserves a target containing durable runtime archives', async () => {
+    const deps = fakeDeps()
+    const target = dataRootFor(emptyParent)
+    const archive = join(target, 'runtime', 'pkgs', 'preserve.conda')
+    await mkdir(join(target, 'runtime', 'pkgs'), { recursive: true })
+    await writeFile(archive, 'existing archive')
+    const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({ ok: true }))
+
+    const result = await runDataRootMigration(
+      { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook, copyAndVerify },
+      emptyParent,
+      runOpts()
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error:
+        'The new data location contains runtime data that Open Science cannot safely replace. Choose another location or remove that data first.'
+    })
+    expect(copyAndVerify).not.toHaveBeenCalled()
+    expect(deps.runtime.disconnect).not.toHaveBeenCalled()
+    expect(deps.notebook.shutdownAll).not.toHaveBeenCalled()
+    expect(await readFile(archive, 'utf8')).toBe('existing archive')
+    expect(await readMigrationMarker(target)).toBeNull()
+  })
+
+  it('refuses a linked target runtime without touching its contents', async () => {
+    const deps = fakeDeps()
+    const target = dataRootFor(emptyParent)
+    const foreignRuntime = join(emptyParent, 'foreign-runtime')
+    const foreignInventory = join(
+      foreignRuntime,
+      'provenance',
+      'environment-inventory',
+      'binding.json'
+    )
+    await mkdir(join(target), { recursive: true })
+    await mkdir(join(foreignRuntime, 'provenance', 'environment-inventory'), { recursive: true })
+    await writeFile(foreignInventory, 'foreign inventory')
+    await symlink(
+      foreignRuntime,
+      join(target, 'runtime'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({ ok: true }))
+
+    const result = await runDataRootMigration(
+      { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook, copyAndVerify },
+      emptyParent,
+      runOpts()
+    )
+
+    expect(result.ok).toBe(false)
+    expect(copyAndVerify).not.toHaveBeenCalled()
+    expect(deps.cleanupRuntimeCache).not.toHaveBeenCalled()
+    expect(await readFile(foreignInventory, 'utf8')).toBe('foreign inventory')
+    expect(existsSync(join(target, 'runtime'))).toBe(true)
   })
 
   it("stamps a 'copying' marker before the copy and promotes it to 'verified' on success", async () => {
@@ -1203,6 +1286,25 @@ describe('runDataRootMigration (copy phase)', () => {
       })
     )
     expect(JSON.stringify(diagnosticRecords(logger))).not.toContain('disconnect boom')
+  })
+
+  it('aborts before copying when a Notebook child cannot be reaped', async () => {
+    const deps = fakeDeps()
+    deps.notebook.shutdownAll.mockResolvedValue({ reaped: false })
+    const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({ ok: true }))
+
+    const result = await runDataRootMigration(
+      { currentDataRoot, runtime: deps.runtime, notebook: deps.notebook, copyAndVerify },
+      emptyParent,
+      runOpts()
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Could not pause running work to copy your data safely. Please try again in a moment.'
+    })
+    expect(copyAndVerify).not.toHaveBeenCalled()
+    expect(existsSync(dataRootFor(emptyParent))).toBe(false)
   })
 })
 
@@ -1616,6 +1718,26 @@ describe('commitDataRootSwitch (commit phase)', () => {
     expect(setDataRoot).not.toHaveBeenCalled()
   })
 
+  it('refuses a legacy staged marker that omitted existing durable package archives', async () => {
+    await mkdir(join(currentDataRoot, 'runtime', 'pkgs'), { recursive: true })
+    await writeFile(join(currentDataRoot, 'runtime', 'pkgs', 'archive.conda'), 'durable archive')
+    await seedVerifiedMarker(emptyParent, currentDataRoot)
+    const setDataRoot = vi.fn(async () => {})
+    const deleteSources = vi.fn(async (): Promise<DeleteResult> => ({ deleted: [], failed: [] }))
+
+    const result = await commitDataRootSwitch(
+      { currentDataRoot, setDataRoot, deleteSources, expectedToken: 'tok-test' },
+      emptyParent
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'The staged copy does not include all required provenance data. Run the move again.'
+    })
+    expect(setDataRoot).not.toHaveBeenCalled()
+    expect(deleteSources).not.toHaveBeenCalled()
+  })
+
   it('refuses commit when the verified target inventory has changed', async () => {
     await mkdir(join(currentDataRoot, 'artifacts'), { recursive: true })
     await writeFile(join(currentDataRoot, 'artifacts', 'keep.txt'), 'hello')
@@ -1800,7 +1922,7 @@ describe('runtime preservation + old-runtime cleanup', () => {
     )
   })
 
-  it('omits the pkgs cache when nothing was preserved', async () => {
+  it('copies durable package archives even when no environment was preserved', async () => {
     const deps = fakeDeps()
     const exportRuntimeLocks = vi.fn(async () => [] as string[])
     const copyAndVerify = vi.fn(async (): Promise<MigrationResult> => ({ ok: true }))
@@ -1819,7 +1941,7 @@ describe('runtime preservation + old-runtime cleanup', () => {
 
     expect(copyAndVerify).toHaveBeenCalledWith(
       expect.objectContaining({
-        dirs: [...MIGRATED_DIRS, RUNTIME_ENVIRONMENT_MANIFESTS_DIR]
+        dirs: [...MIGRATED_DIRS, RUNTIME_ENVIRONMENT_MANIFESTS_DIR, join('runtime', 'pkgs')]
       })
     )
   })
@@ -1848,7 +1970,7 @@ describe('runtime preservation + old-runtime cleanup', () => {
     expect(result).toEqual({ ok: true })
     expect(copyAndVerify).toHaveBeenCalledWith(
       expect.objectContaining({
-        dirs: [...MIGRATED_DIRS, RUNTIME_ENVIRONMENT_MANIFESTS_DIR]
+        dirs: [...MIGRATED_DIRS, RUNTIME_ENVIRONMENT_MANIFESTS_DIR, join('runtime', 'pkgs')]
       })
     )
     expect(diagnosticRecords(logger)).toContainEqual(

--- a/src/main/storage/migration-service.ts
+++ b/src/main/storage/migration-service.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { existsSync, readFileSync, readdirSync, type Dirent } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { join, resolve } from 'node:path'
@@ -65,6 +65,47 @@ const WINDOWS_MAX_USABLE_PATH = 259
 // Keep the migration guard aligned with the physical default prefix selected by runtime-paths plus
 // the longest linked package path. Logical names deliberately do not participate in this budget.
 const WINDOWS_ENV_PREFIX_RESERVE = windowsDefaultEnvPrefixReserve()
+
+const runtimeTreeContainsLink = async (path: string): Promise<boolean> => {
+  let state
+  try {
+    state = await lstat(path)
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ENOENT'
+  }
+  if (state.isSymbolicLink() || !state.isDirectory()) return state.isSymbolicLink()
+
+  let entries: Dirent[]
+  try {
+    entries = await readdir(path, { withFileTypes: true })
+  } catch {
+    return true
+  }
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) return true
+    if (entry.isDirectory() && (await runtimeTreeContainsLink(join(path, entry.name)))) return true
+  }
+  return false
+}
+
+// A move target may contain empty runtime scaffolding left by a prior Data Storage location, but it
+// must not contain files or links. Once the staging marker is written, migration failures remove the
+// whole target; accepting pre-existing runtime data here would therefore turn rollback into data loss.
+// Read failures also mean "contains data" so the migration fails closed without deleting the target.
+const runtimeTreeContainsData = async (runtimeRoot: string): Promise<boolean> => {
+  let entries: Dirent[]
+  try {
+    entries = await readdir(runtimeRoot, { withFileTypes: true })
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ENOENT'
+  }
+
+  for (const entry of entries) {
+    if (entry.isSymbolicLink() || !entry.isDirectory()) return true
+    if (await runtimeTreeContainsData(join(runtimeRoot, entry.name))) return true
+  }
+  return false
+}
 
 export const maxManagedEnvRelativePath = (dataRoot: string): number => {
   let maximum = DEFAULT_MAX_ENV_RELATIVE_PATH
@@ -366,9 +407,7 @@ const sameInventory = (left: MigrationInventory, right: MigrationInventory): boo
 type DataRootWriterPauseDeps = {
   logger?: Logger
   runtime: { disconnect: () => Promise<unknown> }
-  // Return ignored (awaited only), so kept as Promise<unknown> — mirrors runtime.disconnect above and
-  // stays compatible with both the real service (now returns { reaped }) and void test fakes.
-  notebook: { shutdownAll: () => Promise<unknown> }
+  notebook: { shutdownAll: () => Promise<{ reaped: boolean } | void> }
   // Releases the shared SQLite authority connection before migration validation opens its dedicated
   // checkpoint client. Injectable so ordering remains testable without module-level state.
   disconnectProjectDb?: () => Promise<void>
@@ -379,7 +418,10 @@ type DataRootWriterPauseDeps = {
 // while existing leases drain.
 export const pauseDataRootWriters = async (deps: DataRootWriterPauseDeps): Promise<void> => {
   await deps.runtime.disconnect()
-  await deps.notebook.shutdownAll()
+  const notebookShutdown = await deps.notebook.shutdownAll()
+  if (notebookShutdown?.reaped === false) {
+    throw new Error('Notebook processes could not be stopped before data migration.')
+  }
   await (deps.disconnectProjectDb ?? disconnectProjectDbClient)()
   await waitForDataRootWriters()
 }
@@ -387,6 +429,9 @@ export const pauseDataRootWriters = async (deps: DataRootWriterPauseDeps): Promi
 type MigrationCopyDeps = DataRootWriterPauseDeps & {
   currentDataRoot: string
   diagnosticCorrelationId?: string
+  // The composition root supplies Notebook-owned cache cleanup. A runtime-only target may contain
+  // rebuildable residue, but migration must not commit a stale or ownership-unverified cache.
+  cleanupRuntimeCache?: (runtimeRoot: string) => boolean
   // Exports each conda env under the old runtime to an @EXPLICIT lock at the new root (offline
   // reconstruction bundle). Returns the env names preserved; [] when nothing could be exported.
   // Injectable/optional so tests and non-notebook contexts skip it. Best-effort (must not throw).
@@ -460,15 +505,59 @@ export const runDataRootMigration = async (
     status: 'copying'
   }
   operation.phase('prepare-staging')
+  const targetRuntimeRoot = join(target, 'runtime')
+  if (await runtimeTreeContainsLink(targetRuntimeRoot)) {
+    const error = new Error('The new data location contains a linked runtime path.')
+    operation.fail(error)
+    return {
+      ok: false,
+      error:
+        'The new data location contains runtime data that Open Science cannot safely replace. Choose another location or remove that data first.'
+    }
+  }
+  let targetRuntimeCacheClean = true
+  try {
+    targetRuntimeCacheClean = deps.cleanupRuntimeCache?.(targetRuntimeRoot) ?? true
+  } catch {
+    targetRuntimeCacheClean = false
+  }
+  if (!targetRuntimeCacheClean) {
+    const error = new Error('The new data location contains an untrusted runtime cache.')
+    operation.fail(error)
+    return {
+      ok: false,
+      error:
+        'The new data location contains a Notebook cache that Open Science cannot safely replace. Choose another location or remove that cache first.'
+    }
+  }
   try {
     await mkdir(target, { recursive: true })
     // A runtime-only destination is a valid move target and may be residue from an earlier location.
-    // Drop only its path-keyed mutable Environment cache before staging; keep relocatable packages,
-    // exported locks, and every other rebuildable runtime file intact.
+    // The injected owner cleanup above removed verified rebuildable caches; now drop the path-keyed
+    // mutable Environment inventory. Any remaining runtime data is rejected below before the target
+    // becomes staging-owned, so rollback can never delete pre-existing archives or unknown files.
     await rm(join(target, RUNTIME_ENVIRONMENT_INVENTORY_DIR), { recursive: true, force: true })
+  } catch (err) {
+    operation.fail(err)
+    return { ok: false, error: 'Could not prepare the new data location. Please try again.' }
+  }
+
+  if (await runtimeTreeContainsData(targetRuntimeRoot)) {
+    const error = new Error('The new data location contains existing runtime data.')
+    operation.fail(error)
+    return {
+      ok: false,
+      error:
+        'The new data location contains runtime data that Open Science cannot safely replace. Choose another location or remove that data first.'
+    }
+  }
+
+  try {
     await writeMigrationMarker(target, marker)
   } catch (err) {
-    await rm(target, { recursive: true, force: true }).catch(() => undefined)
+    // The target is not staging-owned until its marker is complete. Remove only a possibly partial
+    // marker; preserving the target avoids deleting data written by another actor during preparation.
+    await removeMigrationMarker(target).catch(() => undefined)
     operation.fail(err)
     return { ok: false, error: 'Could not prepare the new data location. Please try again.' }
   }
@@ -502,9 +591,9 @@ export const runDataRootMigration = async (
   }
 
   // Preserve the runtime: export each env to an offline @EXPLICIT lock at the new root, then copy the
-  // (relocatable) pkgs cache alongside the user data so the envs can be rebuilt offline there. Both
-  // are best-effort — a failure just leaves the new root to re-provision defaults, never blocks the
-  // user-data copy. pkgs is copied only when at least one env was actually preserved.
+  // (relocatable) pkgs archive store alongside the user data. Exporting environment locks is
+  // best-effort, but already-published durable archives follow Data Storage independently of whether
+  // any environment could be exported.
   operation.phase('preserve-runtime')
   let preservedEnvs: string[] = []
   let runtimePreservationDegraded = false
@@ -515,8 +604,7 @@ export const runDataRootMigration = async (
       runtimePreservationDegraded = true
     }
   }
-  const migrateDirs =
-    preservedEnvs.length > 0 ? [...BASE_MIGRATION_DIRS, RUNTIME_PKGS_DIR] : [...BASE_MIGRATION_DIRS]
+  const migrateDirs = [...BASE_MIGRATION_DIRS, RUNTIME_PKGS_DIR]
 
   const doCopyAndVerify = deps.copyAndVerify ?? copyAndVerify
   let result: MigrationResult
@@ -674,7 +762,7 @@ export const commitDataRootSwitch = async (
   }
 
   const migratedDirs = marker.migratedDirs ?? [...MIGRATED_DIRS]
-  const requiredPaths = [RUNTIME_ENVIRONMENT_MANIFESTS_DIR].filter((path) =>
+  const requiredPaths = [RUNTIME_ENVIRONMENT_MANIFESTS_DIR, RUNTIME_PKGS_DIR].filter((path) =>
     existsSync(join(deps.currentDataRoot, path))
   )
   if (requiredPaths.some((path) => !migratedDirs.includes(path))) {


### PR DESCRIPTION
## Summary

Move rebuildable Notebook workload caches under the selected Data Storage root, keep Windows micromamba extraction in a short ASCII temporary working cache, and publish only transaction-authorized package archives back to durable Data Storage.

Closes #1516.

## Why

Managed environments already live below `<dataRoot>/runtime/envs`, but Notebook subprocesses still inherited host cache defaults. On Windows, micromamba also needs a short ASCII extraction path and may need to use TEMP/profile storage. That produced two confusing outcomes:

- large Notebook caches could remain on the system drive after Data Storage was moved;
- Storage totals could not include a temporary micromamba cache outside Data Storage.

Storage continues to report only the configured Data Storage tree. Config storage is not used for package or workload caches.

## Data layout

| Data | Location | Lifecycle | Included in Storage |
| --- | --- | --- | --- |
| Notebook workload caches | `<dataRoot>/runtime/cache/notebook` | Rebuildable; cleared rather than copied during migration | Yes, existing runtime breakdown |
| Managed environments | `<dataRoot>/runtime/envs` | Reconstructed from preserved manifests when needed | Yes |
| Verified package archives | `<dataRoot>/runtime/pkgs` | Durable; follows Data Storage migration | Yes |
| Windows micromamba working cache | short ASCII `OpenScienceTmp\m-<hash>` / verified TEMP fallback | Disposable; removed after the last safe lease or by NSIS uninstall | No, because it is outside Data Storage |
| App configuration / credentials | existing config storage and user profile | Unchanged | No |

```mermaid
flowchart LR
  Workload[Notebook workload] --> Rebuildable["dataRoot/runtime/cache/notebook"]
  Mutation[Conda mutation] --> Working["OpenScienceTmp/m-hash\nshort ASCII, disposable"]
  Working --> Verify["transaction / explicit-lock digest evidence"]
  Verify --> Durable["dataRoot/runtime/pkgs\ndurable archives"]
  Journal[operation journal] --> Verify
  Journal --> Working
```

## Implementation

### Workload cache projection

- Project pip, uv, Hugging Face Hub/Datasets/Xet/assets, Torch/Triton, Numba, and R cache variables to `<dataRoot>/runtime/cache/notebook`.
- Apply the projection to kernels, Notebook shells, package mutations, provisioning, and provisioning cache maintenance.
- Keep `HOME`, `USERPROFILE`, `HF_HOME`, and broad `XDG_CACHE_HOME` unchanged so credentials and third-party configuration are not relocated.
- Require marker match, canonical containment, and non-link checks before recursive workload-cache cleanup.

### Windows micromamba working cache

- Candidate order is fixed: runtime volume, `TEMP`, `TMP`, then `%USERPROFILE%\os-tmp`.
- Candidates must satisfy ASCII/path budget, owner marker, current-user/SYSTEM/Administrators ACL, canonical path, and reparse-point checks.
- One marker-owned parent is shared to reduce root-folder and antivirus churn.
- Failure rollback removes only the operation child; parent cleanup is marker-verified and non-recursive, so a concurrent sibling cache is preserved.
- NSIS uninstall recognizes current `m-*` and released `osp*`/`os*` layouts, fails closed for untrusted ACLs/reparse points, and has real Windows PowerShell lifecycle coverage.

### Archive publication and crash recovery

- Publish only `.conda` / `.tar.bz2` archives authorized by an immutable micromamba transaction result or `@EXPLICIT` lock.
- Persist exact working-root and digest evidence before recovery publication/cleanup.
- Keep archive-pending recovery only where a Windows micromamba archive transaction is possible. Explicit pip/R-installer and non-Windows operations keep normal interrupted-operation recovery.
- A cleanup record completes only after its exact working path is confirmed removed or absent.

### Data Storage migration

- Rebuildable `runtime/cache/notebook` is not copied; the new root starts empty and the marker-verified old cache is removed best-effort.
- Durable `runtime/pkgs` is copied even when no environment manifest was preserved.
- A legacy verified staging marker that omitted an existing source `runtime/pkgs` is rejected and must be staged again.
- Pre-existing unknown target runtime data and untrusted linked runtime trees are preserved and cause migration refusal.

## Compatibility and impact

### Historical compatibility

- Existing profile/AppData/TEMP workload caches are not moved or deleted because other applications may share them.
- Existing managed environments remain usable; rebuildable cache bytes are intentionally not migrated.
- Existing `<dataRoot>/runtime/pkgs` archives follow Data Storage migration.
- Released `osp*` / `os*` cache layouts are cleanup-only and are never selected or recreated.
- Legacy staging markers missing required environment provenance or durable archives are refused and must rerun staging.
- A journal entry already written by an older build as archive-pending for a Windows pip/R-installer operation cannot be distinguished from a real Conda ambiguity and still requires explicit recovery/Reset. New operations no longer create that false state.

### State and enum

- No public enum value, database status, IPC status, or UI state is added.
- The existing JSON operation journal gains backward-compatible optional persisted fields: `archivePublicationPending` and exact `archivePublications` receipts. Missing fields retain the previous recovery behavior.

### Persistence

- No settings field, Prisma/SQLite migration, Notebook run schema, or Session schema is added.
- `<dataRoot>/runtime/cache/notebook` is rebuildable persisted filesystem data and is excluded from migration copying.
- `<dataRoot>/runtime/pkgs` is durable persisted filesystem data and increases migration bytes when archives exist.
- Exact archive receipts remain in the operation journal until publication and exact cleanup complete.

### User interaction

- No new setting or UI surface is added; `dataRoot` remains the only durable location pointer.
- Storage continues to show only Data Storage contents, not config storage or external temporary cache bytes.
- After a crash, non-archive package operations return to normal repair/rebuild recovery instead of being incorrectly blocked as archive publication ambiguity.

## Design decisions still requiring confirmation

These are intentionally not changed in this revision because they alter safety architecture or migration acceptance semantics:

1. **Pre-marker migration deletion / linked-ancestor TOCTOU.** Current preparation can clean recognized runtime residue before the staging marker exists, and validation cannot atomically bind later recursive rollback to the same filesystem objects. The conservative fix is “zero deletion before ownership”: reject every non-empty runtime target and every linked selected-parent/target ancestor. That changes historical acceptance and the folder-selection error path.
2. **Durable archive physical containment.** Publication validates authorized filenames/digests but does not provide an identity-bound, race-free guarantee that a user-replaced `runtime/pkgs` ancestor remains physically below `dataRoot` through final rename. Closing this needs a platform-safe containment/handle strategy and changes the durable-storage trust boundary.

Other disclosed follow-ups:

- replace process-global working-cache registries with an `ipc.ts`-owned disposable owner and inject a narrow Notebook cleanup capability into Storage;
- close the authorization-in-memory to exact-journal persistence window;
- add a durable receipt/retry lifecycle for best-effort old-root cleanup;
- decide whether portable ZIP needs an explicit cleanup command because it has no uninstall event;
- keep Windows/Linux sibling markers as consistency evidence, not an unforgeable boundary against workloads running as the same OS user.

## Validation

| Area | Evidence |
| --- | --- |
| Rebase | one commit on `origin/main` `25cb9cc68e4a7c0677822a30a6db22293047a835` |
| Independent review | fresh read-only Codex task reviewed exact rebased head `794b11c923f150432dfb8125b0e9a7fd96929370`; actionable low-conflict findings were fixed in `9b901dca4` |
| Focused modules | 9 files passed; 205 passed, 77 platform/fixture skips |
| Archive/cache regression subset | 4 files passed; 14 passed, 154 unrelated tests skipped by name filter |
| Node contracts | `npm run typecheck:node` passed after refreshing the rebased Prisma client |
| Changed TypeScript | targeted ESLint/Prettier passed |
| PowerShell | PowerShell 7 and Windows PowerShell 5.1 parser checks passed |
| Patch | `git diff --check` passed |

The full local `npm test` suite was intentionally not run per maintainer guidance. Full cross-platform coverage is delegated to PR CI. A local full `provisioner.test.ts` run from this deep Windows worktree hit the feature's existing path-budget guard before 38 unrelated cases; the archive/working-cache provisioner subset passed.

## Review focus

- Whether the two design-confirmation items above should be resolved in this PR or explicit follow-ups.
- Fail-closed path, marker, ACL, reparse-point, ASCII, and path-budget validation before use or deletion.
- Exact authorization and journal evidence before archive publication or cleanup.
- Migration preservation of pre-existing target data and durable `runtime/pkgs`.

