### PR TITLE
fix(projects): make update timestamps monotonic

### DIFF
--- a/src/main/database/application-database.integration.test.ts
+++ b/src/main/database/application-database.integration.test.ts
@@ -942,6 +942,53 @@ describe('application database (integration)', () => {
     expect(await repository.list()).toEqual([])
   })
 
+  it('rejects a stale Project update when the system clock moves backward', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-project-revision-'))
+
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+
+    await migrateApplicationDatabase(client)
+
+    const repository = new ProjectRepository(() => Promise.resolve(client))
+    const created = await repository.create({ name: 'Original' })
+
+    // Put the durable timestamp ahead of the database engine's wall clock. This models a Project
+    // created before the system clock moved backward without changing the machine running the test.
+    const futureUpdatedAt = new Date('2100-01-01T00:00:00.000Z')
+    await client.project.update({
+      where: { id: created.id },
+      data: { updatedAt: futureUpdatedAt }
+    })
+
+    // SQLite applies this only inside the temporary test database. It deterministically reproduces
+    // Prisma's wall-clock @updatedAt moving backward by retaining the previously durable value.
+    await client.$executeRawUnsafe(`CREATE TRIGGER freeze_project_updated_at
+      AFTER UPDATE OF name ON "Project"
+      WHEN NEW."updatedAt" <= OLD."updatedAt"
+      BEGIN
+        UPDATE "Project" SET "updatedAt" = OLD."updatedAt" WHERE "id" = NEW."id";
+      END`)
+
+    const staleSnapshot = await repository.get(created.id)
+    expect(staleSnapshot).not.toBeNull()
+
+    const firstUpdate = await repository.update({
+      id: created.id,
+      name: 'First writer',
+      expectedUpdatedAt: staleSnapshot!.updatedAt
+    })
+    expect(firstUpdate.name).toBe('First writer')
+
+    await expect(
+      repository.update({
+        id: created.id,
+        name: 'Stale writer',
+        expectedUpdatedAt: staleSnapshot!.updatedAt
+      })
+    ).rejects.toThrow('Project changed elsewhere.')
+  })
+
   // Verifies the runtime FINDING_TABLE_DDL + migration guard are byte-compatible with the Prisma
   // generated client for the reflagCount column (issue 15).
   it('Finding.reflagCount DDL column is Prisma-compatible and migration guard is idempotent', async () => {

--- a/src/main/projects/repository.test.ts
+++ b/src/main/projects/repository.test.ts
@@ -145,7 +145,7 @@ describe('project repository', () => {
         deletedAt: null,
         updatedAt: new Date(1710000000100)
       },
-      data: { name: 'Renamed' }
+      data: { name: 'Renamed', updatedAt: expect.any(Date) }
     })
     expect(project.update).not.toHaveBeenCalled()
   })
@@ -302,7 +302,7 @@ describe('project repository', () => {
         deletedAt: null,
         updatedAt: new Date(1710000000100)
       },
-      data: { agentContext: 'Prefer Python.' }
+      data: { agentContext: 'Prefer Python.', updatedAt: expect.any(Date) }
     })
   })
 
@@ -330,7 +330,11 @@ describe('project repository', () => {
         deletedAt: null,
         updatedAt: new Date(1710000000100)
       },
-      data: { pinned: true, agentContext: 'Always cite DOIs.' }
+      data: {
+        pinned: true,
+        agentContext: 'Always cite DOIs.',
+        updatedAt: expect.any(Date)
+      }
     })
   })
 

--- a/src/main/projects/repository.ts
+++ b/src/main/projects/repository.ts
@@ -83,8 +83,13 @@ class ProjectRepository {
   // Updates editable fields, ignoring undefined values so callers can patch only what changed.
   // Pin-only changes preserve updatedAt because pinning controls placement, not research activity.
   async update(request: UpdateProjectRequest): Promise<Project> {
-    const data: { name?: string; description?: string; agentContext?: string; pinned?: boolean } =
-      {}
+    const data: {
+      name?: string
+      description?: string
+      agentContext?: string
+      pinned?: boolean
+      updatedAt?: Date
+    } = {}
 
     if (request.name !== undefined) {
       const name = request.name.trim()
@@ -133,6 +138,11 @@ class ProjectRepository {
     }
 
     if (request.pinned !== undefined) data.pinned = request.pinned
+
+    // Prisma's wall-clock @updatedAt can repeat within one millisecond or move backward after a
+    // clock correction. Advance from the caller's compared value so every accepted content edit
+    // receives a distinct token while updatedAt remains the Project activity timestamp.
+    data.updatedAt = new Date(Math.max(Date.now(), request.expectedUpdatedAt + 1))
 
     const result = await client.project.updateMany({
       where: {


### PR DESCRIPTION
## Problem

Project optimistic concurrency compares `expectedUpdatedAt` with the durable `updatedAt`. Prisma wall-clock timestamps can repeat within one millisecond or move backward, so an accepted write can retain the prior token and a stale writer can silently overwrite the newer name, description, or Agent Context.

A real temporary SQLite/Prisma regression reproduced the stale overwrite three consecutive times before the fix: the second promise resolved with `name: "Stale writer"` instead of rejecting with `Project changed elsewhere.`

## Proposed change

Explicitly persist `updatedAt = max(Date.now(), expectedUpdatedAt + 1)` for ordinary Project content updates. The compare-and-set predicate remains atomic and every accepted edit now receives a distinct, monotonic token.

Add a real SQLite regression that models a system clock rollback without changing the test-machine clock and verifies that the stale second writer is rejected.

## Scope and non-goals

- No SQLite or Prisma schema change and no data migration.
- No new field, state, or enum value.
- No IPC, HTTP API, SDK, CLI, renderer interaction, or shared Project contract change.
- Pure pin updates and archive-state concurrency retain their existing independent semantics.
- Full `npm test` was intentionally not run per maintainer direction; PR CI remains authoritative for the complete suite.

## Acceptance criteria and validation

All listed passing checks ran after the last material edit.

- Stale-write rejection and Project persistence/contracts -> `vitest run src/main/projects/repository.test.ts src/main/projects/ipc.test.ts src/shared/projects.test.ts src/main/database/application-database.integration.test.ts` -> 47/47 passed.
- Source lint -> `npm run lint` -> passed.
- Changed-file formatting -> `prettier --check` on the three changed files -> passed.
- Node typecheck -> `npm run typecheck:node` -> attempted but locally blocked by the shared main-checkout `node_modules`: the checked-in `claude-agent-acp` patch was not applied, so unrelated `claude-agent-acp-patch.test.ts` cannot import `waitForMcpServers`. No type errors from changed files were reported before that failure; PR CI uses a clean install.

Consumer and platform lanes are excluded locally because the repository interface and all cross-process contracts are unchanged. The SQLite integration covers the persistence and clock-rollback risk directly. Cross-platform and complete typecheck coverage remain with PR CI.

## Review focus

Please focus on the monotonic timestamp calculation remaining inside the same `updateMany` compare-and-set path and on the regression test accurately preserving the old timestamp only when the database wall clock would fail to advance it.