### PR TITLE
fix(skills): abort stalled GitHub imports

### DIFF
--- a/src/main/connectors/application.test.ts
+++ b/src/main/connectors/application.test.ts
@@ -40,8 +40,12 @@ const createHarness = (): ConnectorApplicationHarness => {
     resumeSession: vi.fn()
   }
   const skillImportApprovals = {
-    createCancellationGuard: vi.fn().mockReturnValue({ isCancelled: () => false }),
-    createSessionCancellationGuard: vi.fn().mockReturnValue({ isCancelled: () => false }),
+    createCancellationGuard: vi
+      .fn()
+      .mockReturnValue({ signal: new AbortController().signal, isCancelled: () => false }),
+    createSessionCancellationGuard: vi
+      .fn()
+      .mockReturnValue({ signal: new AbortController().signal, isCancelled: () => false }),
     request: vi.fn(),
     respond: vi.fn(),
     replayPending: vi.fn(),
@@ -99,6 +103,35 @@ describe('Connector application composition', () => {
 
     await runtime.dispose()
     expect(mcpClientManager.closeAll).toHaveBeenCalledOnce()
+  })
+
+  it('forwards the conversation cancellation signal to GitHub scanning', async () => {
+    const { settings, skillImportApprovals, deps } = createHarness()
+    const controller = new AbortController()
+    skillImportApprovals.createSessionCancellationGuard.mockReturnValue({
+      signal: controller.signal,
+      isCancelled: () => false
+    })
+    const runtime = await composeApplicationRuntime(async (modules) => ({
+      application: await modules.add(deps, createConnectorApplicationModule)
+    }))
+
+    await expect(
+      runtime.interfaces.application.skillImporter.request({
+        sessionId: 'session-1',
+        githubUrl: 'https://github.com/acme/skills'
+      })
+    ).rejects.toThrow('No importable Skills were found')
+    expect(settings.scanRepoSkills).toHaveBeenCalledWith(
+      { repo: 'https://github.com/acme/skills' },
+      expect.any(AbortSignal)
+    )
+    const forwardedSignal = settings.scanRepoSkills.mock.calls[0][1] as AbortSignal
+    expect(forwardedSignal.aborted).toBe(false)
+    controller.abort()
+    expect(forwardedSignal.aborted).toBe(true)
+
+    await runtime.dispose()
   })
 
   it('closes the MCP manager when construction fails before runtime ownership', async () => {

--- a/src/main/connectors/application.ts
+++ b/src/main/connectors/application.ts
@@ -121,8 +121,9 @@ const createConnectorApplication = (
       skillImportApprovals.createSessionCancellationGuard(sessionId),
     previewBundle: (bundle) => deps.settings.previewSkillArchive(bundle),
     importBundle: (bundle, items) => deps.settings.importSkillArchiveBatch(bundle, items),
-    scanGitHub: async (url) => (await deps.settings.scanRepoSkills({ repo: url })).skills,
-    importGitHub: (url) => deps.settings.importSkill({ url }),
+    scanGitHub: async (url, signal) =>
+      (await deps.settings.scanRepoSkills({ repo: url }, signal)).skills,
+    importGitHub: (url, signal) => deps.settings.importSkill({ url }, signal),
     requestApproval: (request, cancellation) => skillImportApprovals.request(request, cancellation),
     onSkillsChanged: deps.onSkillsChanged
   })

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -4331,13 +4331,15 @@ describe('SettingsService: skills', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       userSkills: { importFromGitHub, list: () => Promise.resolve([]) } as any
     })
+    const signal = new AbortController().signal
 
-    await service.importSkill({ url: 'https://github.com/o/r/tree/main/skills/demo' })
+    await service.importSkill({ url: 'https://github.com/o/r/tree/main/skills/demo' }, signal)
 
     expect(importFromGitHub).toHaveBeenCalledWith(
       'https://github.com/o/r/tree/main/skills/demo',
       netFetch,
-      ['demo']
+      ['demo'],
+      { signal }
     )
   })
 
@@ -4349,10 +4351,11 @@ describe('SettingsService: skills', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       userSkills: { scanRepo } as any
     })
+    const signal = new AbortController().signal
 
-    await service.scanRepoSkills({ repo: 'o/r' })
+    await service.scanRepoSkills({ repo: 'o/r' }, signal)
 
-    expect(scanRepo).toHaveBeenCalledWith('o/r', netFetch)
+    expect(scanRepo).toHaveBeenCalledWith('o/r', netFetch, { signal })
   })
 
   it('searches GitHub repositories for keyword input without scanning a guessed repo', async () => {
@@ -4414,7 +4417,7 @@ describe('SettingsService: skills', () => {
       sourceLabel: 'github.com/o/r@main/skills/demo',
       body: '# Demo'
     })
-    expect(previewGitHubSkill).toHaveBeenCalledWith(url, netFetch)
+    expect(previewGitHubSkill).toHaveBeenCalledWith(url, netFetch, { signal: undefined })
   })
 })
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -615,8 +615,8 @@ class SettingsService {
   }
 
   // Imports a skill from a public GitHub URL (deduplicated), returning the outcome + refreshed list.
-  async importSkill(request: ImportSkillRequest): Promise<ImportSkillResult> {
-    return this.skills.importSkill(request)
+  async importSkill(request: ImportSkillRequest, signal?: AbortSignal): Promise<ImportSkillResult> {
+    return this.skills.importSkill(request, signal)
   }
 
   async getGitHubTokenStatus(): Promise<GitHubTokenStatus> {
@@ -667,13 +667,16 @@ class SettingsService {
 
   // Lazily loads one selected GitHub candidate. The repository's bounded helper downloads only its
   // SKILL.md; the display label is reconstructed from the public URL and contains no host paths.
-  async previewGitHubSkill(request: PreviewGitHubSkillRequest): Promise<SkillImportPreviewContent> {
-    return this.skills.previewGitHubSkill(request)
+  async previewGitHubSkill(
+    request: PreviewGitHubSkillRequest,
+    signal?: AbortSignal
+  ): Promise<SkillImportPreviewContent> {
+    return this.skills.previewGitHubSkill(request, signal)
   }
 
   // Scans a GitHub repo for importable skill directories (marking already-imported ones).
-  async scanRepoSkills(request: ScanRepoRequest): Promise<ScanRepoResult> {
-    return this.skills.scanRepoSkills(request)
+  async scanRepoSkills(request: ScanRepoRequest, signal?: AbortSignal): Promise<ScanRepoResult> {
+    return this.skills.scanRepoSkills(request, signal)
   }
 
   // Compatibility facade for installed Skill discovery, preview, and batch import.

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -129,10 +129,13 @@ class SkillCatalogModule {
 
   async saveGitHubToken(token: string): Promise<GitHubTokenStatus> {
     const trimmed = token.trim()
-    const response = await createAuthenticatedGitHubFetch(this.githubFetch, trimmed)(
-      'https://api.github.com/rate_limit',
-      { headers: { 'User-Agent': 'open-science', Accept: 'application/vnd.github+json' } }
-    )
+    const response = await createAuthenticatedGitHubFetch(
+      this.githubFetch,
+      trimmed,
+      {}
+    )('https://api.github.com/rate_limit', {
+      headers: { 'User-Agent': 'open-science', Accept: 'application/vnd.github+json' }
+    })
 
     if (!response.ok) {
       if (response.status === 401) {
@@ -469,11 +472,12 @@ class SkillCatalogModule {
     return this.listSkills()
   }
 
-  async importSkill(request: ImportSkillRequest): Promise<ImportSkillResult> {
+  async importSkill(request: ImportSkillRequest, signal?: AbortSignal): Promise<ImportSkillResult> {
     const outcome = await this.userSkills.importFromGitHub(
       request.url,
       await this.authenticatedGitHubFetch(),
-      await this.bundledSkillNames()
+      await this.bundledSkillNames(),
+      { signal }
     )
     return { ...outcome, skills: await this.listSkills() }
   }
@@ -520,12 +524,16 @@ class SkillCatalogModule {
     return this.userSkills.importFromZipBatch(zip, items, await this.bundledSkillNames())
   }
 
-  async previewGitHubSkill(request: PreviewGitHubSkillRequest): Promise<SkillImportPreviewContent> {
+  async previewGitHubSkill(
+    request: PreviewGitHubSkillRequest,
+    signal?: AbortSignal
+  ): Promise<SkillImportPreviewContent> {
     const location = parseGitHubSkillUrl(request.url)
     if (!location) throw new Error('Not a recognizable GitHub URL.')
     const preview = await this.userSkills.previewGitHubSkill(
       request.url,
-      await this.authenticatedGitHubFetch()
+      await this.authenticatedGitHubFetch(),
+      { signal }
     )
     const suffix = location.path ? `/${location.path}` : ''
     const revision = location.ref ? `@${location.ref}` : ''
@@ -535,17 +543,22 @@ class SkillCatalogModule {
     }
   }
 
-  async scanRepoSkills(request: ScanRepoRequest): Promise<ScanRepoResult> {
+  async scanRepoSkills(request: ScanRepoRequest, signal?: AbortSignal): Promise<ScanRepoResult> {
     if (parseGitHubRepo(request.repo)) {
       return {
-        skills: await this.userSkills.scanRepo(request.repo, await this.authenticatedGitHubFetch())
+        skills: await this.userSkills.scanRepo(
+          request.repo,
+          await this.authenticatedGitHubFetch(),
+          { signal }
+        )
       }
     }
     return {
       skills: [],
       repositories: await searchGitHubSkillRepositories(
         request.repo,
-        await this.authenticatedGitHubFetch()
+        await this.authenticatedGitHubFetch(),
+        { signal }
       )
     }
   }

--- a/src/main/skills/conversation-import.test.ts
+++ b/src/main/skills/conversation-import.test.ts
@@ -88,7 +88,11 @@ const buildNamedSkillZip = (name: string): Buffer =>
     }
   ])
 
-const createActiveCancellationGuard = (): { isCancelled: () => boolean } => ({
+const createActiveCancellationGuard = (): {
+  signal: AbortSignal
+  isCancelled: () => boolean
+} => ({
+  signal: new AbortController().signal,
   isCancelled: () => false
 })
 
@@ -150,9 +154,9 @@ describe('ConversationSkillImporter', () => {
       status: 'imported',
       skills: [{ id: 'imported-chart-master', name: 'Chart Master', status: 'imported' }]
     })
-    expect(scanGitHub).toHaveBeenCalledWith(githubUrl)
+    expect(scanGitHub).toHaveBeenCalledWith(githubUrl, expect.any(AbortSignal))
     expect(importGitHub).toHaveBeenCalledOnce()
-    expect(importGitHub).toHaveBeenCalledWith(chartMasterUrl)
+    expect(importGitHub).toHaveBeenCalledWith(chartMasterUrl, expect.any(AbortSignal))
     expect(onSkillsChanged).toHaveBeenCalledOnce()
   })
 
@@ -246,8 +250,48 @@ describe('ConversationSkillImporter', () => {
       skills: [{ id: 'imported-first', name: 'First', status: 'imported' }]
     })
     expect(importGitHub).toHaveBeenCalledOnce()
-    expect(importGitHub).toHaveBeenCalledWith(firstUrl)
-    expect(importGitHub).not.toHaveBeenCalledWith(secondUrl)
+    expect(importGitHub).toHaveBeenCalledWith(firstUrl, expect.any(AbortSignal))
+    expect(importGitHub).not.toHaveBeenCalledWith(secondUrl, expect.any(AbortSignal))
+  })
+
+  it('aborts an in-flight GitHub scan when its conversation is cancelled', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'conversation-skill-import-'))
+    roots.push(root)
+    const broker = new SkillImportApprovalBroker({
+      generateId: () => 'approval-github-in-flight-cancelled',
+      broadcast: vi.fn()
+    })
+    let scanSignal: AbortSignal | undefined
+    const scanGitHub = vi.fn((...args: unknown[]) => {
+      scanSignal = args[1] as AbortSignal | undefined
+      return new Promise<never>((_resolve, reject) => {
+        scanSignal?.addEventListener('abort', () => reject(scanSignal?.reason), { once: true })
+      })
+    })
+    const importer = new ConversationSkillImporter({
+      uploads: new UploadRepository(root),
+      createCancellationGuard: (sessionId, turnToken, attachmentUri) =>
+        broker.createCancellationGuard(sessionId, turnToken, attachmentUri),
+      createSessionCancellationGuard: (sessionId) =>
+        broker.createSessionCancellationGuard(sessionId),
+      previewBundle: async () => ({ previews: [], skipped: [] }),
+      importBundle: async () => [],
+      scanGitHub,
+      importGitHub: vi.fn(),
+      requestApproval: (request, cancellation) => broker.request(request, cancellation)
+    })
+    broker.beginSessionTurn('session-1', 'turn-1')
+
+    const result = importer.request({
+      sessionId: 'session-1',
+      githubUrl: 'https://github.com/acme/skills'
+    })
+    await vi.waitFor(() => expect(scanGitHub).toHaveBeenCalledOnce())
+    expect(scanSignal).toBeInstanceOf(AbortSignal)
+
+    broker.cancelSession('session-1')
+
+    await expect(result).resolves.toEqual({ status: 'cancelled', skills: [] })
   })
 
   it('imports a session-owned Skill attachment after the user confirms its preview', async () => {
@@ -839,14 +883,17 @@ describe('SkillImportApprovalBroker lifecycle', () => {
     const unlisted = broker.createCancellationGuard('session-1', 'turn-1', 'file:///older.skill')
     const second = broker.createCancellationGuard('session-2', 'turn-a', 'file:///second.skill')
     expect(first.isCancelled()).toBe(false)
+    expect(first.signal.aborted).toBe(false)
     expect(unlisted.isCancelled()).toBe(true)
 
     broker.cancelSession('session-1')
     expect(first.isCancelled()).toBe(true)
+    expect(first.signal.aborted).toBe(true)
     expect(second.isCancelled()).toBe(false)
 
     broker.cancelAll()
     expect(second.isCancelled()).toBe(true)
+    expect(second.signal.aborted).toBe(true)
 
     broker.beginSessionTurn('session-1', 'turn-2')
     broker.allowSessionTurnAttachment('session-1', 'turn-2', 'file:///next.skill')
@@ -855,6 +902,7 @@ describe('SkillImportApprovalBroker lifecycle', () => {
     expect(next.isCancelled()).toBe(false)
     broker.endSessionTurn('session-1', 'turn-2')
     expect(next.isCancelled()).toBe(true)
+    expect(next.signal.aborted).toBe(true)
   })
 
   it('cancels every pending approval when all agent runtimes disconnect', async () => {

--- a/src/main/skills/conversation-import.ts
+++ b/src/main/skills/conversation-import.ts
@@ -13,12 +13,17 @@ import type {
   SkillBundlePreviewResult
 } from '../../shared/settings'
 import type { UploadRepository } from '../uploads/repository'
+import { GITHUB_TOTAL_TIMEOUT_MS } from './github-import'
 import { SKILL_IMPORT_LIMITS } from './import-limits'
 import { isImportableSkillArchivePath } from './skill-archive-sniffer'
 
 type SkillImportApprovalInfo = Omit<ConversationSkillImportApprovalRequest, 'id'>
 
+const withGitHubFlowTimeout = (signal: AbortSignal): AbortSignal =>
+  AbortSignal.any([signal, AbortSignal.timeout(GITHUB_TOTAL_TIMEOUT_MS)])
+
 type SkillImportCancellationGuard = {
+  signal: AbortSignal
   isCancelled: () => boolean
 }
 
@@ -49,7 +54,7 @@ class SkillImportApprovalBroker {
   private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
   private readonly activeSessionTurns = new Map<
     string,
-    { turnToken: string; eligibleAttachmentUris: Set<string> }
+    { turnToken: string; eligibleAttachmentUris: Set<string>; controller: AbortController }
   >()
 
   constructor(private readonly options: SkillImportApprovalBrokerOptions) {
@@ -59,9 +64,11 @@ class SkillImportApprovalBroker {
   }
 
   beginSessionTurn(sessionId: string, turnToken: string): void {
+    this.activeSessionTurns.get(sessionId)?.controller.abort()
     this.activeSessionTurns.set(sessionId, {
       turnToken,
-      eligibleAttachmentUris: new Set()
+      eligibleAttachmentUris: new Set(),
+      controller: new AbortController()
     })
     // A new turn cannot inherit an unanswered dialog from an older turn of the same session.
     for (const [id, pending] of this.pending) {
@@ -75,7 +82,9 @@ class SkillImportApprovalBroker {
   }
 
   endSessionTurn(sessionId: string, turnToken: string): void {
-    if (this.activeSessionTurns.get(sessionId)?.turnToken !== turnToken) return
+    const turn = this.activeSessionTurns.get(sessionId)
+    if (turn?.turnToken !== turnToken) return
+    turn.controller.abort()
     this.activeSessionTurns.delete(sessionId)
     for (const [id, pending] of this.pending) {
       if (pending.sessionId === sessionId) this.settle({ id, cancelled: true }, 'cancelled')
@@ -87,10 +96,15 @@ class SkillImportApprovalBroker {
     turnToken: string,
     attachmentUri: string
   ): SkillImportCancellationGuard {
+    const turn = this.activeSessionTurns.get(sessionId)
     return {
+      signal: turn?.controller.signal ?? AbortSignal.abort(),
       isCancelled: () => {
-        const turn = this.activeSessionTurns.get(sessionId)
-        return turn?.turnToken !== turnToken || !turn.eligibleAttachmentUris.has(attachmentUri)
+        const activeTurn = this.activeSessionTurns.get(sessionId)
+        return (
+          activeTurn?.turnToken !== turnToken ||
+          !activeTurn.eligibleAttachmentUris.has(attachmentUri)
+        )
       }
     }
   }
@@ -98,6 +112,7 @@ class SkillImportApprovalBroker {
   createSessionCancellationGuard(sessionId: string): SkillImportCancellationGuard {
     const turn = this.activeSessionTurns.get(sessionId)
     return {
+      signal: turn?.controller.signal ?? AbortSignal.abort(),
       isCancelled: () => !turn || this.activeSessionTurns.get(sessionId) !== turn
     }
   }
@@ -132,6 +147,7 @@ class SkillImportApprovalBroker {
   }
 
   cancelSession(sessionId: string): void {
+    this.activeSessionTurns.get(sessionId)?.controller.abort()
     this.activeSessionTurns.delete(sessionId)
     for (const [id, pending] of this.pending) {
       if (pending.sessionId === sessionId) this.settle({ id, cancelled: true }, 'cancelled')
@@ -139,6 +155,7 @@ class SkillImportApprovalBroker {
   }
 
   cancelAll(): void {
+    for (const turn of this.activeSessionTurns.values()) turn.controller.abort()
     this.activeSessionTurns.clear()
     for (const id of this.pending.keys()) this.settle({ id, cancelled: true }, 'cancelled')
   }
@@ -184,8 +201,8 @@ type ConversationSkillImporterOptions = {
       error?: string
     }>
   >
-  scanGitHub?: (url: string) => Promise<ScannedSkillView[]>
-  importGitHub?: (url: string) => Promise<ImportSkillResult>
+  scanGitHub?: (url: string, signal: AbortSignal) => Promise<ScannedSkillView[]>
+  importGitHub?: (url: string, signal: AbortSignal) => Promise<ImportSkillResult>
   createSessionCancellationGuard?: (sessionId: string) => SkillImportCancellationGuard
   requestApproval: (
     request: SkillImportApprovalInfo,
@@ -394,7 +411,14 @@ class ConversationSkillImporter {
 
     const cancellation = createCancellation(request.sessionId)
     if (cancellation.isCancelled()) return { status: 'cancelled', skills: [] }
-    const scanned = await scanGitHub(request.githubUrl)
+    const scanSignal = withGitHubFlowTimeout(cancellation.signal)
+    let scanned: ScannedSkillView[]
+    try {
+      scanned = await scanGitHub(request.githubUrl, scanSignal)
+    } catch (error) {
+      if (cancellation.isCancelled()) return { status: 'cancelled', skills: [] }
+      throw error
+    }
     if (scanned.length === 0) {
       throw new Error('No importable Skills were found in that GitHub repo.')
     }
@@ -428,13 +452,16 @@ class ConversationSkillImporter {
     const candidates = new Map(scanned.map((candidate) => [candidate.path || '.', candidate]))
     const skills: ConversationSkillImportResult['skills'] = []
     const errors: NonNullable<ConversationSkillImportResult['errors']> = []
+    const importSignal = withGitHubFlowTimeout(cancellation.signal)
     for (const item of items) {
       if (cancellation.isCancelled()) break
       const candidate = candidates.get(item.subPath)!
       try {
-        const outcome = await importGitHub(candidate.url)
+        const outcome = await importGitHub(candidate.url, importSignal)
         skills.push({ id: outcome.id, name: candidate.name, status: outcome.status })
       } catch (error) {
+        if (cancellation.isCancelled()) break
+        if (importSignal.aborted) throw importSignal.reason
         errors.push({
           name: candidate.name,
           error: error instanceof Error ? error.message : 'Import failed.'
@@ -445,6 +472,9 @@ class ConversationSkillImporter {
     const changed = skills.some(
       (skill) => skill.status === 'imported' || skill.status === 'updated'
     )
+    if (cancellation.isCancelled() && skills.length === 0 && errors.length === 0) {
+      return { status: 'cancelled', skills: [] }
+    }
     if (changed) this.options.onSkillsChanged?.()
     return {
       status: errors.length > 0 ? 'partial' : changed ? 'imported' : 'unchanged',

--- a/src/main/skills/github-import.test.ts
+++ b/src/main/skills/github-import.test.ts
@@ -17,6 +17,24 @@ import {
 const OVER_FILE = SKILL_IMPORT_LIMITS.maxFileBytes + 1
 const AT_FILE = SKILL_IMPORT_LIMITS.maxFileBytes
 
+type FetchSkillFilesWithDeadlines = (
+  location: Parameters<typeof fetchSkillFiles>[0],
+  fetchImpl: FetchLike,
+  options: { requestTimeoutMs: number; totalTimeoutMs: number }
+) => ReturnType<typeof fetchSkillFiles>
+
+const hangingFetch = (): FetchLike => (_url, init) =>
+  new Promise((_resolve, reject) => {
+    const signal = (init as { signal?: AbortSignal } | undefined)?.signal
+    if (!signal) {
+      reject(new Error('GitHub fetch did not receive an AbortSignal.'))
+      return
+    }
+    const rejectAborted = (): void => reject(signal.reason)
+    if (signal.aborted) rejectAborted()
+    else signal.addEventListener('abort', rejectAborted, { once: true })
+  })
+
 describe('createAuthenticatedGitHubFetch', () => {
   it('adds the token only to exact trusted HTTPS GitHub hosts', async () => {
     const requests: Array<{ url: string; headers?: Record<string, string> }> = []
@@ -250,6 +268,30 @@ describe('fetchSkillPreview', () => {
 })
 
 describe('fetchSkillFiles', () => {
+  it('aborts a stalled GitHub request at the per-request deadline', async () => {
+    const fetchWithDeadlines = fetchSkillFiles as unknown as FetchSkillFilesWithDeadlines
+
+    await expect(
+      fetchWithDeadlines(
+        { owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' },
+        hangingFetch(),
+        { requestTimeoutMs: 10, totalTimeoutMs: 1_000 }
+      )
+    ).rejects.toMatchObject({ name: 'TimeoutError' })
+  })
+
+  it('aborts a stalled GitHub import at the total-flow deadline', async () => {
+    const fetchWithDeadlines = fetchSkillFiles as unknown as FetchSkillFilesWithDeadlines
+
+    await expect(
+      fetchWithDeadlines(
+        { owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' },
+        hangingFetch(),
+        { requestTimeoutMs: 1_000, totalTimeoutMs: 10 }
+      )
+    ).rejects.toMatchObject({ name: 'TimeoutError' })
+  })
+
   it('downloads files relative to the skill directory', async () => {
     const files = await fetchSkillFiles(
       { owner: 'acme', repo: 'skills', ref: 'main', path: 'pack/foo' },

--- a/src/main/skills/github-import.ts
+++ b/src/main/skills/github-import.ts
@@ -35,7 +35,7 @@ type ByteStream = {
 // arrayBuffer() read plus the post-read size guard.
 export type FetchLike = (
   url: string,
-  init?: { headers?: Record<string, string> }
+  init?: { headers?: Record<string, string>; signal?: AbortSignal }
 ) => Promise<{
   ok: boolean
   status: number
@@ -45,15 +45,54 @@ export type FetchLike = (
   body?: ByteStream | null
 }>
 
+export type GitHubFetchOptions = {
+  signal?: AbortSignal
+  requestTimeoutMs?: number
+  totalTimeoutMs?: number
+}
+
 const GITHUB_HEADERS = { 'User-Agent': 'open-science', Accept: 'application/vnd.github+json' }
+const GITHUB_REQUEST_TIMEOUT_MS = 30_000
+const GITHUB_TOTAL_TIMEOUT_MS = 5 * 60_000
 
 const TRUSTED_GITHUB_TOKEN_HOSTS = new Set(['api.github.com', 'raw.githubusercontent.com'])
 
+const combineSignals = (...signals: Array<AbortSignal | undefined>): AbortSignal => {
+  const active = signals.filter((signal): signal is AbortSignal => Boolean(signal))
+  return active.length === 1 ? active[0] : AbortSignal.any(active)
+}
+
+// Gives every GitHub operation one overall deadline and every individual request its own deadline.
+// The request signal stays alive after headers arrive, so stalled response-body reads are aborted too.
+const createGitHubFlowFetch = (
+  fetchImpl: FetchLike,
+  options: GitHubFetchOptions = {}
+): FetchLike => {
+  const flowSignal = combineSignals(
+    options.signal,
+    AbortSignal.timeout(options.totalTimeoutMs ?? GITHUB_TOTAL_TIMEOUT_MS)
+  )
+  return (url, init) =>
+    fetchImpl(url, {
+      ...init,
+      signal: combineSignals(
+        init?.signal,
+        flowSignal,
+        AbortSignal.timeout(options.requestTimeoutMs ?? GITHUB_REQUEST_TIMEOUT_MS)
+      )
+    })
+}
+
 // Adds a token only for exact HTTPS GitHub hosts used by this module. GitHub-controlled download
 // metadata can never redirect the credential to an arbitrary host.
-const createAuthenticatedGitHubFetch = (fetchImpl: FetchLike, token?: string): FetchLike => {
+const createAuthenticatedGitHubFetch = (
+  fetchImpl: FetchLike,
+  token?: string,
+  options?: GitHubFetchOptions
+): FetchLike => {
+  const request = options ? createGitHubFlowFetch(fetchImpl, options) : fetchImpl
   const trimmed = token?.trim()
-  if (!trimmed) return fetchImpl
+  if (!trimmed) return request
 
   return (url, init) => {
     let trusted = false
@@ -64,7 +103,7 @@ const createAuthenticatedGitHubFetch = (fetchImpl: FetchLike, token?: string): F
       trusted = false
     }
 
-    return fetchImpl(url, {
+    return request(url, {
       ...init,
       headers: {
         ...(init?.headers ?? {}),
@@ -183,8 +222,10 @@ export type FetchedSkillPreview = { skillMd: Buffer; files: string[] }
 // and request count share the import caps, while the rendered body uses the smaller IPC preview cap.
 const fetchSkillPreview = async (
   location: GitHubSkillLocation,
-  fetchImpl: FetchLike
+  fetchImpl: FetchLike,
+  options: GitHubFetchOptions = {}
 ): Promise<FetchedSkillPreview> => {
+  const flowFetch = createGitHubFlowFetch(fetchImpl, options)
   const rootPrefix = location.path ? `${location.path}/` : ''
   const files: string[] = []
   let skillMd: Buffer | undefined
@@ -195,7 +236,7 @@ const fetchSkillPreview = async (
     if (requests > SKILL_IMPORT_LIMITS.maxRequests) {
       throw new Error(`Skill preview exceeded ${SKILL_IMPORT_LIMITS.maxRequests} requests.`)
     }
-    return fetchImpl(url, init)
+    return flowFetch(url, init)
   }
 
   const walk = async (path: string, depth: number): Promise<void> => {
@@ -251,8 +292,10 @@ const fetchSkillPreview = async (
 // Recursively downloads every file under a skill directory via the public GitHub contents API.
 const fetchSkillFiles = async (
   location: GitHubSkillLocation,
-  fetchImpl: FetchLike
+  fetchImpl: FetchLike,
+  options: GitHubFetchOptions = {}
 ): Promise<FetchedSkillFile[]> => {
+  const flowFetch = createGitHubFlowFetch(fetchImpl, options)
   const rootPrefix = location.path ? `${location.path}/` : ''
 
   // Bound the recursive download so a huge (or maliciously deep) repository can't freeze or exhaust
@@ -269,7 +312,7 @@ const fetchSkillFiles = async (
     if (requests > SKILL_IMPORT_LIMITS.maxRequests) {
       throw new Error(`Skill import exceeded ${SKILL_IMPORT_LIMITS.maxRequests} requests.`)
     }
-    return fetchImpl(url, init)
+    return flowFetch(url, init)
   }
 
   const walk = async (path: string, depth: number): Promise<FetchedSkillFile[]> => {
@@ -366,7 +409,8 @@ const parseGitHubRepo = (input: string): GitHubRepoRef | null => {
 
 const searchGitHubSkillRepositories = async (
   input: string,
-  fetchImpl: FetchLike
+  fetchImpl: FetchLike,
+  options: GitHubFetchOptions = {}
 ): Promise<GitHubRepositorySearchView[]> => {
   const keywords = input.trim()
   const searchTerms = `${keywords} SKILL.md`
@@ -374,7 +418,7 @@ const searchGitHubSkillRepositories = async (
     throw new Error(GITHUB_REPOSITORY_SEARCH_TOO_LONG_MESSAGE)
   }
   const query = `${searchTerms} in:name,description,topics,readme`
-  const response = await fetchImpl(
+  const response = await createGitHubFlowFetch(fetchImpl, options)(
     `https://api.github.com/search/repositories?q=${encodeURIComponent(query)}&per_page=10`,
     { headers: GITHUB_HEADERS }
   )
@@ -420,18 +464,20 @@ const searchGitHubSkillRepositories = async (
 // each. Resolve branch/tag refs to a commit first so a later preview and import read the same snapshot.
 const scanRepoForSkills = async (
   repo: GitHubRepoRef,
-  fetchImpl: FetchLike
+  fetchImpl: FetchLike,
+  options: GitHubFetchOptions = {}
 ): Promise<ScannedSkill[]> => {
+  const flowFetch = createGitHubFlowFetch(fetchImpl, options)
   let ref = repo.ref
   if (!ref) {
-    const meta = await fetchImpl(`https://api.github.com/repos/${repo.owner}/${repo.repo}`, {
+    const meta = await flowFetch(`https://api.github.com/repos/${repo.owner}/${repo.repo}`, {
       headers: GITHUB_HEADERS
     })
     if (!meta.ok) throw githubRequestError(meta)
     ref = ((await meta.json()) as { default_branch?: string }).default_branch ?? 'main'
   }
 
-  const commitResponse = await fetchImpl(
+  const commitResponse = await flowFetch(
     `https://api.github.com/repos/${repo.owner}/${repo.repo}/commits/${encodeURIComponent(ref)}`,
     { headers: GITHUB_HEADERS }
   )
@@ -439,7 +485,7 @@ const scanRepoForSkills = async (
   const commitSha = ((await commitResponse.json()) as { sha?: string }).sha
   if (!commitSha) throw new Error('GitHub did not return a commit SHA for that ref.')
 
-  const treeResponse = await fetchImpl(
+  const treeResponse = await flowFetch(
     `https://api.github.com/repos/${repo.owner}/${repo.repo}/git/trees/${encodeURIComponent(commitSha)}?recursive=1`,
     { headers: GITHUB_HEADERS }
   )
@@ -474,6 +520,7 @@ const scanRepoForSkills = async (
 }
 
 export {
+  GITHUB_TOTAL_TIMEOUT_MS,
   parseGitHubSkillUrl,
   parseGitHubRepo,
   createAuthenticatedGitHubFetch,

--- a/src/main/skills/skill-bundle-import-owner.ts
+++ b/src/main/skills/skill-bundle-import-owner.ts
@@ -16,6 +16,7 @@ import {
   scanRepoForSkills,
   type FetchLike,
   type FetchedSkillFile,
+  type GitHubFetchOptions,
   type ScannedSkill
 } from './github-import'
 import { parseSkillDocument } from './frontmatter'
@@ -193,7 +194,8 @@ export class SkillBundleImportOwner {
   async importFromGitHub(
     url: string,
     fetchImpl?: FetchLike,
-    reservedNames: readonly string[] = []
+    reservedNames: readonly string[] = [],
+    options: GitHubFetchOptions = {}
   ): Promise<ImportOutcome> {
     const location = parseGitHubSkillUrl(url)
     if (!location) throw new Error('Not a recognizable GitHub URL.')
@@ -201,7 +203,7 @@ export class SkillBundleImportOwner {
     const fetcher = fetchImpl ?? (globalThis.fetch as unknown as FetchLike | undefined)
     if (!fetcher) throw new Error('No fetch implementation available.')
 
-    const files = await fetchSkillFiles(location, fetcher)
+    const files = await fetchSkillFiles(location, fetcher, options)
     const signature = signatureOf(files)
     const preview = parsedSkillPreview(
       files
@@ -229,14 +231,18 @@ export class SkillBundleImportOwner {
     })
   }
 
-  async previewGitHubSkill(url: string, fetchImpl?: FetchLike): Promise<ParsedSkillPreview> {
+  async previewGitHubSkill(
+    url: string,
+    fetchImpl?: FetchLike,
+    options: GitHubFetchOptions = {}
+  ): Promise<ParsedSkillPreview> {
     const location = parseGitHubSkillUrl(url)
     if (!location) throw new Error('Not a recognizable GitHub URL.')
 
     const fetcher = fetchImpl ?? (globalThis.fetch as unknown as FetchLike | undefined)
     if (!fetcher) throw new Error('No fetch implementation available.')
 
-    const { skillMd, files } = await fetchSkillPreview(location, fetcher)
+    const { skillMd, files } = await fetchSkillPreview(location, fetcher, options)
     const fallbackName = location.path.split('/').filter(Boolean).pop() ?? location.repo
     return parsedSkillPreview(skillMd.toString('utf8'), files, fallbackName)
   }
@@ -332,7 +338,8 @@ export class SkillBundleImportOwner {
 
   async scanRepo(
     repoInput: string,
-    fetchImpl?: FetchLike
+    fetchImpl?: FetchLike,
+    options: GitHubFetchOptions = {}
   ): Promise<(ScannedSkill & { alreadyImported: boolean })[]> {
     const repo = parseGitHubRepo(repoInput)
     if (!repo) throw new Error('Not a recognizable GitHub repo (owner/repo or a github.com URL).')
@@ -341,7 +348,7 @@ export class SkillBundleImportOwner {
     if (!fetcher) throw new Error('No fetch implementation available.')
 
     const [found, index] = await Promise.all([
-      scanRepoForSkills(repo, fetcher),
+      scanRepoForSkills(repo, fetcher, options),
       this.transactions.runRecovered(() => this.importedIndex())
     ])
     return found.map((skill) => ({

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -10,7 +10,7 @@ import {
   type AgentHomeMatchResult,
   type AgentHomeSkillSummary
 } from './agent-home-skill-owner'
-import type { FetchLike, ScannedSkill } from './github-import'
+import type { FetchLike, GitHubFetchOptions, ScannedSkill } from './github-import'
 import type { BundledSkill } from './registry'
 import { SkillBundleImportOwner } from './skill-bundle-import-owner'
 import {
@@ -112,13 +112,18 @@ class UserSkillRepository {
   async importFromGitHub(
     url: string,
     fetchImpl?: FetchLike,
-    reservedNames: readonly string[] = []
+    reservedNames: readonly string[] = [],
+    options: GitHubFetchOptions = {}
   ): Promise<ImportOutcome> {
-    return this.bundleImports.importFromGitHub(url, fetchImpl, reservedNames)
+    return this.bundleImports.importFromGitHub(url, fetchImpl, reservedNames, options)
   }
 
-  async previewGitHubSkill(url: string, fetchImpl?: FetchLike): Promise<ParsedSkillPreview> {
-    return this.bundleImports.previewGitHubSkill(url, fetchImpl)
+  async previewGitHubSkill(
+    url: string,
+    fetchImpl?: FetchLike,
+    options: GitHubFetchOptions = {}
+  ): Promise<ParsedSkillPreview> {
+    return this.bundleImports.previewGitHubSkill(url, fetchImpl, options)
   }
 
   async previewZip(zip: Buffer): Promise<SkillBundlePreviewResult> {
@@ -142,9 +147,10 @@ class UserSkillRepository {
 
   async scanRepo(
     repoInput: string,
-    fetchImpl?: FetchLike
+    fetchImpl?: FetchLike,
+    options: GitHubFetchOptions = {}
   ): Promise<(ScannedSkill & { alreadyImported: boolean })[]> {
-    return this.bundleImports.scanRepo(repoInput, fetchImpl)
+    return this.bundleImports.scanRepo(repoInput, fetchImpl, options)
   }
 
   async matchImportedAgentHomeSkills(


### PR DESCRIPTION
## Problem

GitHub Skill scans, previews, and downloads bounded repository shape and bytes but did not bound network wait time. Session teardown only changed a polling cancellation guard, so an in-flight GitHub fetch could keep the import tool call and conversation turn pending until the network eventually settled.

## Proposed change

- Give active conversation turns an in-memory AbortController and abort it on turn replacement, turn end, session cancellation, and runtime teardown.
- Thread the signal through the conversation importer, Settings facade, Skill repository, and every GitHub fetch.
- Combine session cancellation with a 30-second per-request deadline and a 5-minute total network-flow deadline. Conversation scanning and the selected-Skill batch each share one total deadline.
- Convert session-driven aborts to the existing cancelled import result while preserving timeout failures as errors.

## Scope and non-goals

- No renderer contract, user interaction, persisted schema, historical-data compatibility, data model, or enum changes.
- No new dependency or generic cancellation framework.
- Existing host, request-count, path, depth, file-count, and byte limits remain unchanged.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Per-request timeout, total-flow timeout, and in-flight session cancellation -> npm test -- src/main/skills/github-import.test.ts src/main/skills/conversation-import.test.ts src/main/skills/user-skill-repository.test.ts src/main/skills/user-skill-repository.atomic.test.ts src/main/skills/user-skill-repository.architecture.test.ts -> 178 passed.
- Signal wiring through connector composition and Settings GitHub consumers -> npm test -- src/main/settings/skill-catalog.test.ts src/main/connectors/application.test.ts -> 36 passed.
- Settings GitHub import, scan, and preview facade behavior -> npm test -- src/main/settings/service.test.ts -t GitHub skill|GitHub repo|selected GitHub -> 4 passed.
- Main-process type safety -> npm run typecheck:node -> passed.
- Source lint -> npm run lint -> passed with no errors or warnings.
- Impact selection -> npm run test:affected -- --base origin/main --head HEAD --explain -> full PR Gate plan because connector application tests currently have unknown module ownership.

The complete local npm test suite was intentionally not run per maintainer instruction. PR Gate remains authoritative for the complete portable and platform suites. A full SettingsService attempt was not usable as evidence because the managed sandbox rejects its loopback listeners with EPERM; the focused GitHub tests do not require those listeners and passed.

## Review focus

- AbortController ownership across turn replacement and teardown.
- Preservation of session cancellation versus network timeout outcomes.
- Coverage of every GitHub request path, including token verification and response-body reads.