### PR TITLE
fix(compute): cancel approvals for deleted sessions

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -219,6 +219,9 @@
     },
     "compute_service": {
       "ownerPaths": [
+        "src/main/compute/approval-session-lifecycle.ts",
+        "src/main/compute/agent-compute-service.ts",
+        "src/main/compute/compute-approval-broker.ts",
         "src/main/compute/compute-host-profile-owner.ts",
         "src/main/compute/compute-job-lifecycle.ts",
         "src/main/compute/job-deletion-owner.ts",
@@ -246,6 +249,10 @@
       "consumerModules": [],
       "testFiles": {
         "owner": [
+          "src/main/compute/approval-session-lifecycle.test.ts",
+          "src/main/compute/agent-compute-service.test.ts",
+          "src/main/compute/agent-no-list-jobs.test.ts",
+          "src/main/compute/compute-approval-broker.test.ts",
           "src/main/compute/compute-job-lifecycle.test.ts",
           "src/main/compute/job-deletion-owner.test.ts",
           "src/main/compute/compute-service.architecture.test.ts",

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -133,6 +133,7 @@ type AcpRuntimeCompositionOptions = AcpRuntimeArtifacts & {
   onSessionUnavailable?: (sessionId: string) => void
   onAllSessionsCancellationRequested?: () => void
   onDisconnected?: () => void
+  onSessionDeleteStarted?: (sessionId: string) => void
   beforeSessionDelete?: (sessionId: string) => Promise<void>
   afterSessionDelete?: (sessionId: string, retained: boolean) => void
   profileService?: ProfileService
@@ -181,6 +182,7 @@ const createAcpRuntime = ({
   onSessionUnavailable,
   onAllSessionsCancellationRequested,
   onDisconnected,
+  onSessionDeleteStarted,
   beforeSessionDelete,
   afterSessionDelete,
   profileService,
@@ -533,6 +535,7 @@ const createAcpRuntime = ({
       onSkillImportAttachmentEligible,
       onSessionCancellationRequested,
       onAllSessionsCancellationRequested,
+      onSessionDeleteStarted,
       beforeSessionDelete,
       afterSessionDelete
     },

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -134,6 +134,7 @@ type AcpRuntimeCompositionOptions = AcpRuntimeArtifacts & {
   onAllSessionsCancellationRequested?: () => void
   onDisconnected?: () => void
   beforeSessionDelete?: (sessionId: string) => Promise<void>
+  afterSessionDelete?: (sessionId: string, retained: boolean) => void
   profileService?: ProfileService
   sessionPersistenceCoordinator?: Pick<
     SessionPersistenceCoordinator,
@@ -181,6 +182,7 @@ const createAcpRuntime = ({
   onAllSessionsCancellationRequested,
   onDisconnected,
   beforeSessionDelete,
+  afterSessionDelete,
   profileService,
   sessionPersistenceCoordinator,
   delegatedWork,
@@ -531,7 +533,8 @@ const createAcpRuntime = ({
       onSkillImportAttachmentEligible,
       onSessionCancellationRequested,
       onAllSessionsCancellationRequested,
-      beforeSessionDelete
+      beforeSessionDelete,
+      afterSessionDelete
     },
     permissionGrantRegistry
       ? () => projectRegistrySessionGrants(permissionGrantRegistry.listCached())

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -3554,8 +3554,20 @@ describe('AcpRuntimeCoordinator', () => {
 
   it('holds the Session deletion lifecycle until runtime deletion settles', async () => {
     const created: ReturnType<typeof createFakeRuntime>[] = []
+    const onSessionDeleteStarted = vi.fn()
     const beforeSessionDelete = vi.fn().mockResolvedValue(undefined)
     const afterSessionDelete = vi.fn()
+    const delegatedDeletion = createDeferred<void>()
+    const delegatedWork: RootDelegatedWorkControl = {
+      pendingPermissions: () => [],
+      subscribe: () => () => undefined,
+      respondToPermission: async () => false,
+      setPermissionProfile: async () => undefined,
+      stopSession: async () => undefined,
+      stopAll: async () => undefined,
+      deleteSession: vi.fn(() => delegatedDeletion.promise),
+      deleteProject: async () => undefined
+    }
     const coordinator = new AcpRuntimeCoordinator(
       (callbacks) => {
         const fake = createFakeRuntime({
@@ -3571,13 +3583,25 @@ describe('AcpRuntimeCoordinator', () => {
       undefined,
       undefined,
       undefined,
-      { beforeSessionDelete, afterSessionDelete }
+      { onSessionDeleteStarted, beforeSessionDelete, afterSessionDelete },
+      undefined,
+      delegatedWork
     )
     const deletion = createDeferred<AcpStateSnapshot>()
     created[0].deleteSession.mockReturnValueOnce(deletion.promise)
 
     await coordinator.createSession()
     const deleting = coordinator.deleteSession({ sessionId: 'session-1' })
+    await vi.waitFor(() => expect(delegatedWork.deleteSession).toHaveBeenCalledOnce())
+
+    expect(onSessionDeleteStarted).toHaveBeenCalledWith('session-1')
+    expect(onSessionDeleteStarted.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(delegatedWork.deleteSession).mock.invocationCallOrder[0]
+    )
+    expect(beforeSessionDelete).not.toHaveBeenCalled()
+    expect(afterSessionDelete).not.toHaveBeenCalled()
+
+    delegatedDeletion.resolve()
     await vi.waitFor(() => expect(created[0].deleteSession).toHaveBeenCalledOnce())
 
     expect(beforeSessionDelete).toHaveBeenCalledWith('session-1')

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -3552,6 +3552,76 @@ describe('AcpRuntimeCoordinator', () => {
     expect(onSessionUnavailable).toHaveBeenCalledWith('session-1')
   })
 
+  it('holds the Session deletion lifecycle until runtime deletion settles', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const beforeSessionDelete = vi.fn().mockResolvedValue(undefined)
+    const afterSessionDelete = vi.fn()
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId: 'claude-code',
+          sessionIds: ['session-1'],
+          callbacks
+        })
+        created.push(fake)
+        return fake.runtime
+      },
+      {},
+      '',
+      undefined,
+      undefined,
+      undefined,
+      { beforeSessionDelete, afterSessionDelete }
+    )
+    const deletion = createDeferred<AcpStateSnapshot>()
+    created[0].deleteSession.mockReturnValueOnce(deletion.promise)
+
+    await coordinator.createSession()
+    const deleting = coordinator.deleteSession({ sessionId: 'session-1' })
+    await vi.waitFor(() => expect(created[0].deleteSession).toHaveBeenCalledOnce())
+
+    expect(beforeSessionDelete).toHaveBeenCalledWith('session-1')
+    expect(afterSessionDelete).not.toHaveBeenCalled()
+
+    deletion.resolve(emptySnapshot())
+    await deleting
+
+    expect(afterSessionDelete).toHaveBeenCalledWith('session-1', false)
+    expect(created[0].deleteSession.mock.invocationCallOrder[0]).toBeLessThan(
+      afterSessionDelete.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('releases the Session deletion lifecycle when runtime deletion fails', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const afterSessionDelete = vi.fn()
+    const coordinator = new AcpRuntimeCoordinator(
+      (callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId: 'claude-code',
+          sessionIds: ['session-1'],
+          callbacks
+        })
+        created.push(fake)
+        return fake.runtime
+      },
+      {},
+      '',
+      undefined,
+      undefined,
+      undefined,
+      { afterSessionDelete }
+    )
+
+    await coordinator.createSession()
+    created[0].deleteSession.mockRejectedValueOnce(new Error('delete failed'))
+
+    await expect(coordinator.deleteSession({ sessionId: 'session-1' })).rejects.toThrow(
+      'delete failed'
+    )
+    expect(afterSessionDelete).toHaveBeenCalledWith('session-1', true)
+  })
+
   it('invalidates a successfully deleted detached session without a runtime state event', async () => {
     const created: ReturnType<typeof createFakeRuntime>[] = []
     const onSessionUnavailable = vi.fn()
@@ -3609,6 +3679,7 @@ describe('AcpRuntimeCoordinator', () => {
   it('preserves a session adopted by a new generation while the old delete is in flight', async () => {
     const created: ReturnType<typeof createFakeRuntime>[] = []
     const onSessionUnavailable = vi.fn()
+    const afterSessionDelete = vi.fn()
     const coordinator = new AcpRuntimeCoordinator(
       (callbacks) => {
         const fake = createFakeRuntime({
@@ -3623,7 +3694,8 @@ describe('AcpRuntimeCoordinator', () => {
       '',
       undefined,
       undefined,
-      onSessionUnavailable
+      onSessionUnavailable,
+      { afterSessionDelete }
     )
 
     await coordinator.createSession()
@@ -3648,6 +3720,7 @@ describe('AcpRuntimeCoordinator', () => {
       expect.any(String)
     )
     expect(onSessionUnavailable).not.toHaveBeenCalled()
+    expect(afterSessionDelete).toHaveBeenCalledWith('session-1', true)
   })
 
   it('attempts every runtime quit teardown and preserves the surviving snapshot primary', async () => {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -63,6 +63,7 @@ type AcpRuntimeCoordinatorTeardownCallbacks = {
   ) => void
   onSessionCancellationRequested?: (sessionId: string) => void
   onAllSessionsCancellationRequested?: () => void
+  onSessionDeleteStarted?: (sessionId: string) => void
   beforeSessionDelete?: (sessionId: string) => Promise<void>
   // Runs after the runtime deletion attempt. `retained` is true after failure or when a concurrent
   // runtime adoption kept the logical Session alive.
@@ -1189,6 +1190,7 @@ class AcpRuntimeCoordinator {
 
   async deleteSession(request: AcpDeleteSessionRequest): Promise<AcpStateSnapshot> {
     this.invalidateSessionTurn(request.sessionId)
+    this.teardownCallbacks.onSessionDeleteStarted?.(request.sessionId)
     this.activePromptRequests.delete(request.sessionId)
     this.pendingResumeReconciliations.delete(request.sessionId)
     const runtime = this.runtimeForSession(request.sessionId)

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -64,6 +64,9 @@ type AcpRuntimeCoordinatorTeardownCallbacks = {
   onSessionCancellationRequested?: (sessionId: string) => void
   onAllSessionsCancellationRequested?: () => void
   beforeSessionDelete?: (sessionId: string) => Promise<void>
+  // Runs after the runtime deletion attempt. `retained` is true after failure or when a concurrent
+  // runtime adoption kept the logical Session alive.
+  afterSessionDelete?: (sessionId: string, retained: boolean) => void
 }
 
 type PermissionGrantSnapshotProvider = () => AcpStateSnapshot['permissionGrants']
@@ -1190,10 +1193,16 @@ class AcpRuntimeCoordinator {
     this.pendingResumeReconciliations.delete(request.sessionId)
     const runtime = this.runtimeForSession(request.sessionId)
     const ownedBeforeDelete = this.sessionRuntimes.get(request.sessionId) === runtime
-    await this.delegatedWork?.deleteSession(request.sessionId)
-    await this.teardownCallbacks.beforeSessionDelete?.(request.sessionId)
-    await runtime.deleteSession(request)
+    try {
+      await this.delegatedWork?.deleteSession(request.sessionId)
+      await this.teardownCallbacks.beforeSessionDelete?.(request.sessionId)
+      await runtime.deleteSession(request)
+    } catch (error) {
+      this.teardownCallbacks.afterSessionDelete?.(request.sessionId, true)
+      throw error
+    }
     const ownerAfterDelete = this.sessionRuntimes.get(request.sessionId)
+    const retained = ownerAfterDelete !== undefined && ownerAfterDelete !== runtime
     // Attached deletes emit a runtime state change, whose reconciliation already notifies exactly once.
     // Detached cleanup deliberately emits no state, so complete its session-scoped teardown here. A
     // concurrent resume may have transferred the same app session to a new generation while the old
@@ -1205,6 +1214,7 @@ class AcpRuntimeCoordinator {
       this.clearApplicationSessionEvents(request.sessionId)
       this.onSessionUnavailable?.(request.sessionId)
     }
+    this.teardownCallbacks.afterSessionDelete?.(request.sessionId, retained)
     await this.retireUnusedTargetedRuntime(runtime)
     return this.getSnapshot()
   }

--- a/src/main/compute/agent-compute-service.test.ts
+++ b/src/main/compute/agent-compute-service.test.ts
@@ -131,10 +131,19 @@ describe('AgentComputeService', () => {
   it('delegates enabled provider calls with trusted context', async () => {
     const { raw, service } = createHarness()
     const context = { sessionId: 'session-1', projectId: 'project-1' }
+    const signal = new AbortController().signal
 
-    await service.callCommand(context, 'ssh:available', 'true', 'test', false, 5)
+    await service.callCommand(context, 'ssh:available', 'true', 'test', false, 5, signal)
 
-    expect(raw.callCommand).toHaveBeenCalledWith('ssh:available', 'true', 'test', false, 5, context)
+    expect(raw.callCommand).toHaveBeenCalledWith(
+      'ssh:available',
+      'true',
+      'test',
+      false,
+      5,
+      context,
+      signal
+    )
   })
 
   it('scopes job reads to the trusted Session and an enabled provider', async () => {

--- a/src/main/compute/agent-compute-service.ts
+++ b/src/main/compute/agent-compute-service.ts
@@ -115,20 +115,30 @@ export class AgentComputeService {
     cmd: string,
     intent: string,
     loginShell = true,
-    timeoutSeconds?: number
+    timeoutSeconds?: number,
+    signal?: AbortSignal
   ): Promise<ExecResult> {
     await this.requireEnabled(context.sessionId, providerId)
-    return this.compute.callCommand(providerId, cmd, intent, loginShell, timeoutSeconds, context)
+    return this.compute.callCommand(
+      providerId,
+      cmd,
+      intent,
+      loginShell,
+      timeoutSeconds,
+      context,
+      signal
+    )
   }
 
   async download(
     context: AgentComputeContext,
     providerId: string,
     remotePath: string,
-    dest: DownloadDest
+    dest: DownloadDest,
+    signal?: AbortSignal
   ): Promise<LocalFile> {
     await this.requireEnabled(context.sessionId, providerId)
-    return this.compute.download(providerId, remotePath, dest, context)
+    return this.compute.download(providerId, remotePath, dest, context, signal)
   }
 
   async submitJob(
@@ -136,10 +146,11 @@ export class AgentComputeService {
     providerId: string,
     intent: string,
     command: string,
-    options: Parameters<RawComputeService['submitJob']>[3]
+    options: Parameters<RawComputeService['submitJob']>[3],
+    signal?: AbortSignal
   ): Promise<SubmitJobResult> {
     await this.requireEnabled(context.sessionId, providerId)
-    return this.compute.submitJob(providerId, intent, command, options, context)
+    return this.compute.submitJob(providerId, intent, command, options, context, signal)
   }
 
   async getJobStatus(

--- a/src/main/compute/approval-session-lifecycle.test.ts
+++ b/src/main/compute/approval-session-lifecycle.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { bindComputeApprovalSessionLifecycle } from './approval-session-lifecycle'
+
+describe('compute approval Session lifecycle', () => {
+  it('cancels approvals with the current turn and reopens them for the next turn', () => {
+    const onSessionCancellationRequested = vi.fn()
+    const onSessionTurnStarted = vi.fn()
+    const compute = {
+      approvalCancelSession: vi.fn(),
+      approvalCompleteSessionCancellation: vi.fn(),
+      approvalCancelAll: vi.fn()
+    }
+    const lifecycle = bindComputeApprovalSessionLifecycle(
+      { onSessionCancellationRequested, onSessionTurnStarted },
+      compute
+    )
+
+    lifecycle.onSessionCancellationRequested?.('session-1')
+    lifecycle.onSessionTurnStarted?.('session-1', 'turn-2')
+
+    expect(compute.approvalCancelSession).toHaveBeenCalledWith('session-1')
+    expect(compute.approvalCompleteSessionCancellation).toHaveBeenCalledWith('session-1')
+    expect(onSessionCancellationRequested).toHaveBeenCalledWith('session-1')
+    expect(onSessionTurnStarted).toHaveBeenCalledWith('session-1', 'turn-2')
+  })
+
+  it('cancels approvals when a Session becomes unavailable or all Sessions stop', () => {
+    const onSessionUnavailable = vi.fn()
+    const onAllSessionsCancellationRequested = vi.fn()
+    const compute = {
+      approvalCancelSession: vi.fn(),
+      approvalCompleteSessionCancellation: vi.fn(),
+      approvalCancelAll: vi.fn()
+    }
+    const lifecycle = bindComputeApprovalSessionLifecycle(
+      { onSessionUnavailable, onAllSessionsCancellationRequested },
+      compute
+    )
+
+    lifecycle.onSessionUnavailable?.('session-1')
+    lifecycle.onAllSessionsCancellationRequested?.()
+
+    expect(compute.approvalCancelSession).toHaveBeenCalledWith('session-1')
+    expect(compute.approvalCancelAll).toHaveBeenCalledOnce()
+    expect(onSessionUnavailable).toHaveBeenCalledWith('session-1')
+    expect(onAllSessionsCancellationRequested).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/compute/approval-session-lifecycle.test.ts
+++ b/src/main/compute/approval-session-lifecycle.test.ts
@@ -9,7 +9,8 @@ describe('compute approval Session lifecycle', () => {
     const compute = {
       approvalCancelSession: vi.fn(),
       approvalCompleteSessionCancellation: vi.fn(),
-      approvalCancelAll: vi.fn()
+      approvalCancelAll: vi.fn(),
+      approvalCompleteGlobalCancellation: vi.fn()
     }
     const lifecycle = bindComputeApprovalSessionLifecycle(
       { onSessionCancellationRequested, onSessionTurnStarted },
@@ -20,6 +21,7 @@ describe('compute approval Session lifecycle', () => {
     lifecycle.onSessionTurnStarted?.('session-1', 'turn-2')
 
     expect(compute.approvalCancelSession).toHaveBeenCalledWith('session-1')
+    expect(compute.approvalCompleteGlobalCancellation).toHaveBeenCalledOnce()
     expect(compute.approvalCompleteSessionCancellation).toHaveBeenCalledWith('session-1')
     expect(onSessionCancellationRequested).toHaveBeenCalledWith('session-1')
     expect(onSessionTurnStarted).toHaveBeenCalledWith('session-1', 'turn-2')
@@ -31,7 +33,8 @@ describe('compute approval Session lifecycle', () => {
     const compute = {
       approvalCancelSession: vi.fn(),
       approvalCompleteSessionCancellation: vi.fn(),
-      approvalCancelAll: vi.fn()
+      approvalCancelAll: vi.fn(),
+      approvalCompleteGlobalCancellation: vi.fn()
     }
     const lifecycle = bindComputeApprovalSessionLifecycle(
       { onSessionUnavailable, onAllSessionsCancellationRequested },

--- a/src/main/compute/approval-session-lifecycle.ts
+++ b/src/main/compute/approval-session-lifecycle.ts
@@ -1,0 +1,41 @@
+type SessionApprovalLifecycleCallbacks = {
+  onSessionTurnStarted?: (sessionId: string, turnToken: string) => void
+  onSessionTurnEnded?: (sessionId: string, turnToken: string) => void
+  onSkillImportAttachmentEligible?: (
+    sessionId: string,
+    turnToken: string,
+    attachmentUri: string
+  ) => void
+  onSessionCancellationRequested?: (sessionId: string) => void
+  onSessionUnavailable?: (sessionId: string) => void
+  onAllSessionsCancellationRequested?: () => void
+}
+
+type ComputeApprovalLifecycleHandlers = {
+  approvalCancelSession: (sessionId: string) => void
+  approvalCompleteSessionCancellation: (sessionId: string) => void
+  approvalCancelAll: () => void
+}
+
+export const bindComputeApprovalSessionLifecycle = (
+  callbacks: SessionApprovalLifecycleCallbacks,
+  compute: ComputeApprovalLifecycleHandlers
+): SessionApprovalLifecycleCallbacks => ({
+  ...callbacks,
+  onSessionTurnStarted: (sessionId, turnToken) => {
+    compute.approvalCompleteSessionCancellation(sessionId)
+    callbacks.onSessionTurnStarted?.(sessionId, turnToken)
+  },
+  onSessionCancellationRequested: (sessionId) => {
+    compute.approvalCancelSession(sessionId)
+    callbacks.onSessionCancellationRequested?.(sessionId)
+  },
+  onSessionUnavailable: (sessionId) => {
+    compute.approvalCancelSession(sessionId)
+    callbacks.onSessionUnavailable?.(sessionId)
+  },
+  onAllSessionsCancellationRequested: () => {
+    compute.approvalCancelAll()
+    callbacks.onAllSessionsCancellationRequested?.()
+  }
+})

--- a/src/main/compute/approval-session-lifecycle.ts
+++ b/src/main/compute/approval-session-lifecycle.ts
@@ -15,6 +15,7 @@ type ComputeApprovalLifecycleHandlers = {
   approvalCancelSession: (sessionId: string) => void
   approvalCompleteSessionCancellation: (sessionId: string) => void
   approvalCancelAll: () => void
+  approvalCompleteGlobalCancellation: () => void
 }
 
 export const bindComputeApprovalSessionLifecycle = (
@@ -23,6 +24,7 @@ export const bindComputeApprovalSessionLifecycle = (
 ): SessionApprovalLifecycleCallbacks => ({
   ...callbacks,
   onSessionTurnStarted: (sessionId, turnToken) => {
+    compute.approvalCompleteGlobalCancellation()
     compute.approvalCompleteSessionCancellation(sessionId)
     callbacks.onSessionTurnStarted?.(sessionId, turnToken)
   },

--- a/src/main/compute/compute-approval-broker.test.ts
+++ b/src/main/compute/compute-approval-broker.test.ts
@@ -373,6 +373,71 @@ describe('ComputeApprovalBroker', () => {
     broker.completeProviderInvalidation('ssh:biowulf')
   })
 
+  it('does not allow a remembered grant when the request aborts during lookup', async () => {
+    let finishGrantLookup: ((scope: 'project') => void) | undefined
+    const resolveGrant = vi.fn(
+      () =>
+        new Promise<'project'>((resolve) => {
+          finishGrantLookup = resolve
+        })
+    )
+    const broadcast = vi.fn()
+    const controller = new AbortController()
+    const broker = new ComputeApprovalBroker({
+      generateId: () => 'id-1',
+      broadcast,
+      permissionGrants: { resolve: resolveGrant, remember: vi.fn() } as never
+    })
+
+    const decision = broker.requestWithContext(
+      makeRequest(),
+      {
+        sessionId: 'session-1',
+        projectId: 'project-1',
+        operation: 'call_command',
+        ownerId: 'host-row-1'
+      },
+      controller.signal
+    )
+    await vi.waitFor(() => expect(resolveGrant).toHaveBeenCalledOnce())
+
+    controller.abort()
+    finishGrantLookup?.('project')
+
+    await expect(decision).rejects.toMatchObject({ name: 'AbortError' })
+    expect(broadcast).not.toHaveBeenCalled()
+  })
+
+  it('does not allow a remembered grant after its Session is deleted during lookup', async () => {
+    let finishGrantLookup: ((scope: 'project') => void) | undefined
+    const resolveGrant = vi.fn(
+      () =>
+        new Promise<'project'>((resolve) => {
+          finishGrantLookup = resolve
+        })
+    )
+    const broadcast = vi.fn()
+    const broker = new ComputeApprovalBroker({
+      generateId: () => 'id-1',
+      broadcast,
+      permissionGrants: { resolve: resolveGrant, remember: vi.fn() } as never
+    })
+
+    const decision = broker.requestWithContext(makeRequest(), {
+      sessionId: 'session-deleted',
+      projectId: 'project-1',
+      operation: 'call_command',
+      ownerId: 'host-row-1'
+    })
+    await vi.waitFor(() => expect(resolveGrant).toHaveBeenCalledOnce())
+
+    broker.cancelSession('session-deleted')
+    finishGrantLookup?.('project')
+
+    await expect(decision).resolves.toBe('deny')
+    expect(broadcast).not.toHaveBeenCalled()
+  })
+
   it('does not remember approval when the provider id belongs to a recreated host', async () => {
     const timer = makeTimer()
     const remember = vi.fn()

--- a/src/main/compute/compute-approval-broker.test.ts
+++ b/src/main/compute/compute-approval-broker.test.ts
@@ -95,6 +95,26 @@ describe('ComputeApprovalBroker', () => {
     expect(onSettled).toHaveBeenNthCalledWith(3, 'id-3', 'expired')
   })
 
+  it('cancels a pending approval when its request is aborted', async () => {
+    const timer = makeTimer()
+    const onSettled = vi.fn()
+    const controller = new AbortController()
+    const broker = new ComputeApprovalBroker({
+      generateId: () => 'id-1',
+      broadcast: () => undefined,
+      setTimer: timer.set,
+      clearTimer: timer.clear,
+      onSettled
+    })
+
+    const decision = broker.request(makeRequest(), undefined, controller.signal)
+    controller.abort()
+
+    expect(broker.getPending('id-1')).toBeNull()
+    await expect(decision).resolves.toBe('deny')
+    expect(onSettled).toHaveBeenCalledWith('id-1', 'cancelled')
+  })
+
   it('resolves with deny when user denies', async () => {
     const timer = makeTimer()
     let n = 0
@@ -248,6 +268,47 @@ describe('ComputeApprovalBroker', () => {
     replay.mockClear()
     broker.replayPending()
     expect(replay).not.toHaveBeenCalled()
+  })
+
+  it('cancels only pending approvals owned by a deleted Session', async () => {
+    const timer = makeTimer()
+    const onSettled = vi.fn()
+    let sequence = 0
+    const broker = new ComputeApprovalBroker({
+      generateId: () => `id-${++sequence}`,
+      broadcast: () => undefined,
+      setTimer: timer.set,
+      clearTimer: timer.clear,
+      onSettled
+    })
+    const deletedCall = broker.request(makeRequest(), {
+      sessionId: 'session-deleted',
+      projectId: 'project-1',
+      operation: 'call_command'
+    })
+    const deletedDownload = broker.request(makeDownloadRequest(), {
+      sessionId: 'session-deleted',
+      projectId: 'project-1',
+      operation: 'download'
+    })
+    const retainedCall = broker.request(makeRequest(), {
+      sessionId: 'session-retained',
+      projectId: 'project-1',
+      operation: 'call_command'
+    })
+
+    broker.cancelSession('session-deleted')
+
+    await expect(deletedCall).resolves.toBe('deny')
+    await expect(deletedDownload).resolves.toBe('deny')
+    expect(broker.getPending('id-1')).toBeNull()
+    expect(broker.getPending('id-2')).toBeNull()
+    expect(broker.getPending('id-3')).not.toBeNull()
+    expect(onSettled).toHaveBeenCalledWith('id-1', 'cancelled')
+    expect(onSettled).toHaveBeenCalledWith('id-2', 'cancelled')
+
+    broker.respond('id-3', 'deny')
+    await retainedCall
   })
 
   it('denies a pending approval when its compute provider is invalidated', async () => {

--- a/src/main/compute/compute-approval-broker.test.ts
+++ b/src/main/compute/compute-approval-broker.test.ts
@@ -347,6 +347,38 @@ describe('ComputeApprovalBroker', () => {
     expect(onSettled).toHaveBeenCalledWith('id-3', 'cancelled')
   })
 
+  it('fences approvals that enter the broker after all Session runtimes stop', async () => {
+    const broadcast = vi.fn()
+    const broker = new ComputeApprovalBroker({
+      generateId: () => 'id-1',
+      broadcast
+    })
+
+    broker.cancelAll()
+    const lateApproval = broker.request(makeRequest(), {
+      sessionId: 'session-late',
+      projectId: 'project-1',
+      operation: 'call_command'
+    })
+
+    try {
+      expect(broadcast).not.toHaveBeenCalled()
+      await expect(lateApproval).resolves.toBe('deny')
+    } finally {
+      broker.respond('id-1', 'deny')
+    }
+
+    broker.completeGlobalCancellation()
+    const resumedApproval = broker.request(makeRequest(), {
+      sessionId: 'session-resumed',
+      projectId: 'project-1',
+      operation: 'call_command'
+    })
+    expect(broadcast).toHaveBeenCalledOnce()
+    broker.respond('id-1', 'once')
+    await expect(resumedApproval).resolves.toBe('once')
+  })
+
   it('holds cancellation through deletion and allows new approvals only if the Session is retained', async () => {
     const timer = makeTimer()
     const broker = new ComputeApprovalBroker({

--- a/src/main/compute/compute-approval-broker.test.ts
+++ b/src/main/compute/compute-approval-broker.test.ts
@@ -347,7 +347,7 @@ describe('ComputeApprovalBroker', () => {
     expect(onSettled).toHaveBeenCalledWith('id-3', 'cancelled')
   })
 
-  it('allows new approvals if Session deletion fails after pending requests are cancelled', async () => {
+  it('holds cancellation through deletion and allows new approvals only if the Session is retained', async () => {
     const timer = makeTimer()
     const broker = new ComputeApprovalBroker({
       generateId: () => 'id-1',
@@ -361,13 +361,34 @@ describe('ComputeApprovalBroker', () => {
       operation: 'call_command'
     }
 
-    broker.cancelSession('session-retained')
+    broker.beginSessionDeletion('session-retained')
     broker.completeSessionCancellation('session-retained')
+    await expect(broker.request(makeRequest(), context)).resolves.toBe('deny')
+
+    broker.finishSessionDeletion('session-retained', true)
     const retried = broker.request(makeRequest(), context)
 
     expect(broker.getPending('id-1')).not.toBeNull()
     broker.respond('id-1', 'once')
     await expect(retried).resolves.toBe('once')
+  })
+
+  it('keeps approvals cancelled after a Session is successfully deleted', async () => {
+    const broker = new ComputeApprovalBroker({
+      generateId: () => 'id-1',
+      broadcast: () => undefined
+    })
+    const context = {
+      sessionId: 'session-deleted',
+      projectId: 'project-1',
+      operation: 'call_command'
+    }
+
+    broker.beginSessionDeletion('session-deleted')
+    broker.finishSessionDeletion('session-deleted', false)
+
+    await expect(broker.request(makeRequest(), context)).resolves.toBe('deny')
+    expect(broker.getPending('id-1')).toBeNull()
   })
 
   it('denies a pending approval when its compute provider is invalidated', async () => {
@@ -490,8 +511,8 @@ describe('ComputeApprovalBroker', () => {
     })
     await vi.waitFor(() => expect(resolveGrant).toHaveBeenCalledOnce())
 
-    broker.cancelSession('session-deleting')
-    broker.completeSessionCancellation('session-deleting')
+    broker.beginSessionDeletion('session-deleting')
+    broker.finishSessionDeletion('session-deleting', false)
     finishGrantLookup?.()
 
     await expect(decision).resolves.toBe('deny')

--- a/src/main/compute/compute-approval-broker.test.ts
+++ b/src/main/compute/compute-approval-broker.test.ts
@@ -311,6 +311,42 @@ describe('ComputeApprovalBroker', () => {
     await retainedCall
   })
 
+  it('cancels every pending approval when all Session runtimes stop', async () => {
+    const timer = makeTimer()
+    const onSettled = vi.fn()
+    let sequence = 0
+    const broker = new ComputeApprovalBroker({
+      generateId: () => `id-${++sequence}`,
+      broadcast: () => undefined,
+      setTimer: timer.set,
+      clearTimer: timer.clear,
+      onSettled
+    })
+    const first = broker.request(makeRequest(), {
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      operation: 'call_command'
+    })
+    const second = broker.request(makeDownloadRequest(), {
+      sessionId: 'session-2',
+      projectId: 'project-1',
+      operation: 'download'
+    })
+    const contextless = broker.request(makeRequest())
+
+    broker.cancelAll()
+
+    await expect(Promise.all([first, second, contextless])).resolves.toEqual([
+      'deny',
+      'deny',
+      'deny'
+    ])
+    expect(onSettled).toHaveBeenCalledTimes(3)
+    expect(onSettled).toHaveBeenCalledWith('id-1', 'cancelled')
+    expect(onSettled).toHaveBeenCalledWith('id-2', 'cancelled')
+    expect(onSettled).toHaveBeenCalledWith('id-3', 'cancelled')
+  })
+
   it('allows new approvals if Session deletion fails after pending requests are cancelled', async () => {
     const timer = makeTimer()
     const broker = new ComputeApprovalBroker({

--- a/src/main/compute/compute-approval-broker.test.ts
+++ b/src/main/compute/compute-approval-broker.test.ts
@@ -326,6 +326,7 @@ describe('ComputeApprovalBroker', () => {
     }
 
     broker.cancelSession('session-retained')
+    broker.completeSessionCancellation('session-retained')
     const retried = broker.request(makeRequest(), context)
 
     expect(broker.getPending('id-1')).not.toBeNull()
@@ -427,6 +428,37 @@ describe('ComputeApprovalBroker', () => {
     finishGrantLookup?.('project')
 
     await expect(decision).rejects.toMatchObject({ name: 'AbortError' })
+    expect(broadcast).not.toHaveBeenCalled()
+  })
+
+  it('does not publish an approval after Session cancellation starts during grant lookup', async () => {
+    let finishGrantLookup: (() => void) | undefined
+    const resolveGrant = vi.fn(
+      () =>
+        new Promise<undefined>((resolve) => {
+          finishGrantLookup = () => resolve(undefined)
+        })
+    )
+    const broadcast = vi.fn()
+    const broker = new ComputeApprovalBroker({
+      generateId: () => 'id-1',
+      broadcast,
+      permissionGrants: { resolve: resolveGrant, remember: vi.fn() } as never
+    })
+
+    const decision = broker.requestWithContext(makeRequest(), {
+      sessionId: 'session-deleting',
+      projectId: 'project-1',
+      operation: 'call_command',
+      ownerId: 'host-row-1'
+    })
+    await vi.waitFor(() => expect(resolveGrant).toHaveBeenCalledOnce())
+
+    broker.cancelSession('session-deleting')
+    broker.completeSessionCancellation('session-deleting')
+    finishGrantLookup?.()
+
+    await expect(decision).resolves.toBe('deny')
     expect(broadcast).not.toHaveBeenCalled()
   })
 

--- a/src/main/compute/compute-approval-broker.test.ts
+++ b/src/main/compute/compute-approval-broker.test.ts
@@ -311,6 +311,28 @@ describe('ComputeApprovalBroker', () => {
     await retainedCall
   })
 
+  it('allows new approvals if Session deletion fails after pending requests are cancelled', async () => {
+    const timer = makeTimer()
+    const broker = new ComputeApprovalBroker({
+      generateId: () => 'id-1',
+      broadcast: () => undefined,
+      setTimer: timer.set,
+      clearTimer: timer.clear
+    })
+    const context = {
+      sessionId: 'session-retained',
+      projectId: 'project-1',
+      operation: 'call_command'
+    }
+
+    broker.cancelSession('session-retained')
+    const retried = broker.request(makeRequest(), context)
+
+    expect(broker.getPending('id-1')).not.toBeNull()
+    broker.respond('id-1', 'once')
+    await expect(retried).resolves.toBe('once')
+  })
+
   it('denies a pending approval when its compute provider is invalidated', async () => {
     const timer = makeTimer()
     const remember = vi.fn()
@@ -408,36 +430,6 @@ describe('ComputeApprovalBroker', () => {
     expect(broadcast).not.toHaveBeenCalled()
   })
 
-  it('does not allow a remembered grant after its Session is deleted during lookup', async () => {
-    let finishGrantLookup: ((scope: 'project') => void) | undefined
-    const resolveGrant = vi.fn(
-      () =>
-        new Promise<'project'>((resolve) => {
-          finishGrantLookup = resolve
-        })
-    )
-    const broadcast = vi.fn()
-    const broker = new ComputeApprovalBroker({
-      generateId: () => 'id-1',
-      broadcast,
-      permissionGrants: { resolve: resolveGrant, remember: vi.fn() } as never
-    })
-
-    const decision = broker.requestWithContext(makeRequest(), {
-      sessionId: 'session-deleted',
-      projectId: 'project-1',
-      operation: 'call_command',
-      ownerId: 'host-row-1'
-    })
-    await vi.waitFor(() => expect(resolveGrant).toHaveBeenCalledOnce())
-
-    broker.cancelSession('session-deleted')
-    finishGrantLookup?.('project')
-
-    await expect(decision).resolves.toBe('deny')
-    expect(broadcast).not.toHaveBeenCalled()
-  })
-
   it('does not remember approval when the provider id belongs to a recreated host', async () => {
     const timer = makeTimer()
     const remember = vi.fn()
@@ -507,6 +499,54 @@ describe('ComputeApprovalBroker', () => {
     await invalidation
     await expect(decision).resolves.toBe('deny')
     broker.completeProviderInvalidation('ssh:biowulf')
+  })
+
+  it('aborts the operation but preserves a broad scope the user approved before cancellation', async () => {
+    const timer = makeTimer()
+    let releaseRemember: (() => void) | undefined
+    const remember = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseRemember = resolve
+        })
+    )
+    const controller = new AbortController()
+    const broker = new ComputeApprovalBroker({
+      generateId: () => 'id-1',
+      broadcast: () => undefined,
+      setTimer: timer.set,
+      clearTimer: timer.clear,
+      permissionGrants: { resolve: vi.fn(), remember } as never,
+      isProviderCurrent: vi.fn().mockResolvedValue(true)
+    })
+
+    const decision = broker.requestWithContext(
+      makeRequest(),
+      {
+        sessionId: 'session-1',
+        projectId: 'project-1',
+        operation: 'call_command',
+        ownerId: 'host-row-1'
+      },
+      controller.signal
+    )
+    await Promise.resolve()
+    broker.respond('id-1', 'project')
+    await vi.waitFor(() => expect(remember).toHaveBeenCalledOnce())
+
+    controller.abort()
+    releaseRemember?.()
+
+    await expect(decision).rejects.toMatchObject({ name: 'AbortError' })
+    expect(remember).toHaveBeenCalledWith(
+      {
+        sessionId: 'session-1',
+        projectId: 'project-1',
+        operation: 'call_command',
+        providerId: 'ssh:biowulf'
+      },
+      'project'
+    )
   })
 
   it('denies new requests while provider deletion is draining', async () => {

--- a/src/main/compute/compute-approval-broker.ts
+++ b/src/main/compute/compute-approval-broker.ts
@@ -58,6 +58,8 @@ type PendingComputeApproval = {
   timerStartedAt?: number
   providerId: string
   context?: ComputeApprovalContext
+  signal?: AbortSignal
+  abortListener?: () => void
 }
 
 // Bridges the main-process compute gate to the renderer approval card. Holds the call_command
@@ -97,8 +99,10 @@ export class ComputeApprovalBroker {
   // Does NOT check grants — use requestWithContext for that.
   request(
     info: Omit<ComputeApprovalRequest, 'id'>,
-    context?: ComputeApprovalContext
+    context?: ComputeApprovalContext,
+    signal?: AbortSignal
   ): Promise<ComputeApprovalDecision> {
+    signal?.throwIfAborted()
     const id = this.deps.generateId()
     const providerId = info.provider_id
     const request = { id, ...info }
@@ -109,9 +113,18 @@ export class ComputeApprovalBroker {
         resolve,
         remainingMs: this.timeoutMs,
         providerId,
-        context
+        context,
+        signal
       }
       this.pending.set(id, entry)
+      if (signal) {
+        entry.abortListener = () => this.settle(id, 'deny', 'cancelled')
+        signal.addEventListener('abort', entry.abortListener, { once: true })
+        if (signal.aborted) {
+          this.settle(id, 'deny', 'cancelled')
+          return
+        }
+      }
       this.schedule(id, entry)
       this.deps.broadcast(request, context)
     })
@@ -135,12 +148,14 @@ export class ComputeApprovalBroker {
   // immediately without broadcasting. When the user responds with a scope that has memory, records it.
   requestWithContext(
     info: Omit<ComputeApprovalRequest, 'id'>,
-    ctx: ComputeApprovalContext
+    ctx: ComputeApprovalContext,
+    signal?: AbortSignal
   ): Promise<ComputeApprovalDecision> {
+    signal?.throwIfAborted()
     const providerId = info.provider_id
     if (this.invalidatingProviders.has(providerId)) return Promise.resolve('deny')
 
-    const request = this.requestWithContextOperation(info, ctx)
+    const request = this.requestWithContextOperation(info, ctx, signal)
     const requests = this.inFlightRequests.get(providerId) ?? new Set()
     requests.add(request)
     this.inFlightRequests.set(providerId, requests)
@@ -153,7 +168,8 @@ export class ComputeApprovalBroker {
 
   private async requestWithContextOperation(
     info: Omit<ComputeApprovalRequest, 'id'>,
-    ctx: ComputeApprovalContext
+    ctx: ComputeApprovalContext,
+    signal?: AbortSignal
   ): Promise<ComputeApprovalDecision> {
     const { sessionId, projectId, operation } = ctx
     const providerId = info.provider_id
@@ -203,7 +219,7 @@ export class ComputeApprovalBroker {
     ) {
       return 'deny'
     }
-    const decision = await this.request(info, ctx)
+    const decision = await this.request(info, ctx, signal)
 
     if ((this.providerGenerations.get(providerId) ?? 0) !== providerGeneration) return 'deny'
 
@@ -261,6 +277,16 @@ export class ComputeApprovalBroker {
     if (!this.pausedSessions.delete(sessionId)) return
     for (const [id, entry] of this.pending) {
       if (entry.context?.sessionId === sessionId) this.schedule(id, entry)
+    }
+  }
+
+  cancelSession(sessionId: string): void {
+    this.pausedSessions.delete(sessionId)
+    for (const key of this.conversationGrants) {
+      if (key.startsWith(`${sessionId}:`)) this.conversationGrants.delete(key)
+    }
+    for (const [id, entry] of this.pending) {
+      if (entry.context?.sessionId === sessionId) this.settle(id, 'deny', 'cancelled')
     }
   }
 
@@ -325,6 +351,9 @@ export class ComputeApprovalBroker {
     const entry = this.pending.get(id)
     if (!entry) return
     if (entry.timer !== undefined) this.clearTimer(entry.timer)
+    if (entry.signal && entry.abortListener) {
+      entry.signal.removeEventListener('abort', entry.abortListener)
+    }
     this.pending.delete(id)
     entry.resolve(decision)
     try {

--- a/src/main/compute/compute-approval-broker.ts
+++ b/src/main/compute/compute-approval-broker.ts
@@ -326,6 +326,19 @@ export class ComputeApprovalBroker {
     }
   }
 
+  cancelAll(): void {
+    const sessionIds = new Set(this.inFlightSessionRequests.keys())
+    for (const entry of this.pending.values()) {
+      if (entry.context) sessionIds.add(entry.context.sessionId)
+    }
+    for (const sessionId of sessionIds) this.cancelSession(sessionId)
+    for (const [id, entry] of this.pending) {
+      if (!entry.context) this.settle(id, 'deny', 'cancelled')
+    }
+    this.pausedSessions.clear()
+    this.conversationGrants.clear()
+  }
+
   completeSessionCancellation(sessionId: string): void {
     if (!this.cancellingSessions.has(sessionId)) return
     if (this.inFlightSessionRequests.has(sessionId)) {

--- a/src/main/compute/compute-approval-broker.ts
+++ b/src/main/compute/compute-approval-broker.ts
@@ -75,6 +75,9 @@ type PendingComputeApproval = {
 export class ComputeApprovalBroker {
   private readonly pending = new Map<string, PendingComputeApproval>()
   private readonly pausedSessions = new Set<string>()
+  // Session deletion is terminal; retain a process-local tombstone so an async grant lookup cannot
+  // create or authorize work after the pending-card sweep has completed.
+  private readonly cancelledSessions = new Set<string>()
 
   private readonly providerGenerations = new Map<string, number>()
   private readonly invalidatingProviders = new Set<string>()
@@ -103,6 +106,7 @@ export class ComputeApprovalBroker {
     signal?: AbortSignal
   ): Promise<ComputeApprovalDecision> {
     signal?.throwIfAborted()
+    if (context && this.cancelledSessions.has(context.sessionId)) return Promise.resolve('deny')
     const id = this.deps.generateId()
     const providerId = info.provider_id
     const request = { id, ...info }
@@ -152,6 +156,7 @@ export class ComputeApprovalBroker {
     signal?: AbortSignal
   ): Promise<ComputeApprovalDecision> {
     signal?.throwIfAborted()
+    if (this.cancelledSessions.has(ctx.sessionId)) return Promise.resolve('deny')
     const providerId = info.provider_id
     if (this.invalidatingProviders.has(providerId)) return Promise.resolve('deny')
 
@@ -174,6 +179,10 @@ export class ComputeApprovalBroker {
     const { sessionId, projectId, operation } = ctx
     const providerId = info.provider_id
     const providerGeneration = this.providerGenerations.get(providerId) ?? 0
+    const sessionWasCancelled = (): boolean => {
+      signal?.throwIfAborted()
+      return this.cancelledSessions.has(sessionId)
+    }
 
     if (this.deps.permissionGrants) {
       const durableScope = await this.deps.permissionGrants.resolve({
@@ -182,8 +191,14 @@ export class ComputeApprovalBroker {
         operation,
         providerId
       })
+      if (sessionWasCancelled()) return 'deny'
       if (durableScope) {
-        if (!(await this.isProviderCurrent(providerId, ctx.ownerId, providerGeneration))) {
+        const providerIsCurrent = await this.isProviderCurrent(
+          providerId,
+          ctx.ownerId,
+          providerGeneration
+        )
+        if (sessionWasCancelled() || !providerIsCurrent) {
           return 'deny'
         }
         if (durableScope === 'session') return 'conversation'
@@ -194,19 +209,28 @@ export class ComputeApprovalBroker {
     // ── legacy project grant check (persistent) ───────────────────────────────────
     if (this.deps.checkProjectGrant) {
       const hasProject = await this.deps.checkProjectGrant({ projectId, operation, providerId })
+      if (sessionWasCancelled()) return 'deny'
       if (hasProject) {
-        return (await this.isProviderCurrent(providerId, ctx.ownerId, providerGeneration))
-          ? 'project'
-          : 'deny'
+        const providerIsCurrent = await this.isProviderCurrent(
+          providerId,
+          ctx.ownerId,
+          providerGeneration
+        )
+        if (sessionWasCancelled() || !providerIsCurrent) return 'deny'
+        return 'project'
       }
     }
 
     // ── conversation grant check (session in-memory) ───────────────────────────────
     const convKey = `${sessionId}:${operation}:${providerId}`
     if (this.conversationGrants.has(convKey)) {
-      return (await this.isProviderCurrent(providerId, ctx.ownerId, providerGeneration))
-        ? 'conversation'
-        : 'deny'
+      const providerIsCurrent = await this.isProviderCurrent(
+        providerId,
+        ctx.ownerId,
+        providerGeneration
+      )
+      if (sessionWasCancelled() || !providerIsCurrent) return 'deny'
+      return 'conversation'
     }
 
     // ── no grant — show approval card ─────────────────────────────────────────────
@@ -214,6 +238,7 @@ export class ComputeApprovalBroker {
     // entered the in-flight set but before it reached the approval card. Fail closed here so the
     // invalidator cannot miss a newly-created pending request and wait on it indefinitely.
     if (
+      sessionWasCancelled() ||
       this.invalidatingProviders.has(providerId) ||
       (this.providerGenerations.get(providerId) ?? 0) !== providerGeneration
     ) {
@@ -224,11 +249,13 @@ export class ComputeApprovalBroker {
     if ((this.providerGenerations.get(providerId) ?? 0) !== providerGeneration) return 'deny'
 
     const allowsDecision = decision !== 'deny'
-    if (
-      allowsDecision &&
-      !(await this.isProviderCurrent(providerId, ctx.ownerId, providerGeneration))
-    ) {
-      return 'deny'
+    if (allowsDecision) {
+      const providerIsCurrent = await this.isProviderCurrent(
+        providerId,
+        ctx.ownerId,
+        providerGeneration
+      )
+      if (sessionWasCancelled() || !providerIsCurrent) return 'deny'
     }
 
     // Record grant if applicable.
@@ -243,11 +270,13 @@ export class ComputeApprovalBroker {
       await this.deps.saveProjectGrant({ projectId, operation, providerId })
     }
 
-    if (
-      allowsDecision &&
-      !(await this.isProviderCurrent(providerId, ctx.ownerId, providerGeneration))
-    ) {
-      return 'deny'
+    if (allowsDecision) {
+      const providerIsCurrent = await this.isProviderCurrent(
+        providerId,
+        ctx.ownerId,
+        providerGeneration
+      )
+      if (sessionWasCancelled() || !providerIsCurrent) return 'deny'
     }
 
     return decision
@@ -281,6 +310,7 @@ export class ComputeApprovalBroker {
   }
 
   cancelSession(sessionId: string): void {
+    this.cancelledSessions.add(sessionId)
     this.pausedSessions.delete(sessionId)
     for (const key of this.conversationGrants) {
       if (key.startsWith(`${sessionId}:`)) this.conversationGrants.delete(key)

--- a/src/main/compute/compute-approval-broker.ts
+++ b/src/main/compute/compute-approval-broker.ts
@@ -76,6 +76,7 @@ export class ComputeApprovalBroker {
   private readonly pending = new Map<string, PendingComputeApproval>()
   private readonly pausedSessions = new Set<string>()
   private readonly cancellingSessions = new Set<string>()
+  private readonly deletingSessions = new Set<string>()
   private readonly completingSessionCancellations = new Set<string>()
 
   private readonly providerGenerations = new Map<string, number>()
@@ -339,8 +340,19 @@ export class ComputeApprovalBroker {
     this.conversationGrants.clear()
   }
 
+  beginSessionDeletion(sessionId: string): void {
+    this.deletingSessions.add(sessionId)
+    this.cancelSession(sessionId)
+  }
+
+  finishSessionDeletion(sessionId: string, retained: boolean): void {
+    this.deletingSessions.delete(sessionId)
+    if (retained) this.completeSessionCancellation(sessionId)
+  }
+
   completeSessionCancellation(sessionId: string): void {
     if (!this.cancellingSessions.has(sessionId)) return
+    if (this.deletingSessions.has(sessionId)) return
     if (this.inFlightSessionRequests.has(sessionId)) {
       this.completingSessionCancellations.add(sessionId)
       return
@@ -390,7 +402,10 @@ export class ComputeApprovalBroker {
     sessionRequests?.delete(request)
     if (sessionRequests?.size !== 0) return
     this.inFlightSessionRequests.delete(sessionId)
-    if (this.completingSessionCancellations.delete(sessionId)) {
+    if (
+      this.completingSessionCancellations.delete(sessionId) &&
+      !this.deletingSessions.has(sessionId)
+    ) {
       this.cancellingSessions.delete(sessionId)
     }
   }

--- a/src/main/compute/compute-approval-broker.ts
+++ b/src/main/compute/compute-approval-broker.ts
@@ -75,9 +75,6 @@ type PendingComputeApproval = {
 export class ComputeApprovalBroker {
   private readonly pending = new Map<string, PendingComputeApproval>()
   private readonly pausedSessions = new Set<string>()
-  // Session deletion is terminal; retain a process-local tombstone so an async grant lookup cannot
-  // create or authorize work after the pending-card sweep has completed.
-  private readonly cancelledSessions = new Set<string>()
 
   private readonly providerGenerations = new Map<string, number>()
   private readonly invalidatingProviders = new Set<string>()
@@ -106,7 +103,6 @@ export class ComputeApprovalBroker {
     signal?: AbortSignal
   ): Promise<ComputeApprovalDecision> {
     signal?.throwIfAborted()
-    if (context && this.cancelledSessions.has(context.sessionId)) return Promise.resolve('deny')
     const id = this.deps.generateId()
     const providerId = info.provider_id
     const request = { id, ...info }
@@ -156,7 +152,6 @@ export class ComputeApprovalBroker {
     signal?: AbortSignal
   ): Promise<ComputeApprovalDecision> {
     signal?.throwIfAborted()
-    if (this.cancelledSessions.has(ctx.sessionId)) return Promise.resolve('deny')
     const providerId = info.provider_id
     if (this.invalidatingProviders.has(providerId)) return Promise.resolve('deny')
 
@@ -179,10 +174,6 @@ export class ComputeApprovalBroker {
     const { sessionId, projectId, operation } = ctx
     const providerId = info.provider_id
     const providerGeneration = this.providerGenerations.get(providerId) ?? 0
-    const sessionWasCancelled = (): boolean => {
-      signal?.throwIfAborted()
-      return this.cancelledSessions.has(sessionId)
-    }
 
     if (this.deps.permissionGrants) {
       const durableScope = await this.deps.permissionGrants.resolve({
@@ -191,16 +182,15 @@ export class ComputeApprovalBroker {
         operation,
         providerId
       })
-      if (sessionWasCancelled()) return 'deny'
+      signal?.throwIfAborted()
       if (durableScope) {
         const providerIsCurrent = await this.isProviderCurrent(
           providerId,
           ctx.ownerId,
           providerGeneration
         )
-        if (sessionWasCancelled() || !providerIsCurrent) {
-          return 'deny'
-        }
+        signal?.throwIfAborted()
+        if (!providerIsCurrent) return 'deny'
         if (durableScope === 'session') return 'conversation'
         return durableScope
       }
@@ -209,14 +199,15 @@ export class ComputeApprovalBroker {
     // ── legacy project grant check (persistent) ───────────────────────────────────
     if (this.deps.checkProjectGrant) {
       const hasProject = await this.deps.checkProjectGrant({ projectId, operation, providerId })
-      if (sessionWasCancelled()) return 'deny'
+      signal?.throwIfAborted()
       if (hasProject) {
         const providerIsCurrent = await this.isProviderCurrent(
           providerId,
           ctx.ownerId,
           providerGeneration
         )
-        if (sessionWasCancelled() || !providerIsCurrent) return 'deny'
+        signal?.throwIfAborted()
+        if (!providerIsCurrent) return 'deny'
         return 'project'
       }
     }
@@ -229,7 +220,8 @@ export class ComputeApprovalBroker {
         ctx.ownerId,
         providerGeneration
       )
-      if (sessionWasCancelled() || !providerIsCurrent) return 'deny'
+      signal?.throwIfAborted()
+      if (!providerIsCurrent) return 'deny'
       return 'conversation'
     }
 
@@ -238,7 +230,6 @@ export class ComputeApprovalBroker {
     // entered the in-flight set but before it reached the approval card. Fail closed here so the
     // invalidator cannot miss a newly-created pending request and wait on it indefinitely.
     if (
-      sessionWasCancelled() ||
       this.invalidatingProviders.has(providerId) ||
       (this.providerGenerations.get(providerId) ?? 0) !== providerGeneration
     ) {
@@ -255,10 +246,12 @@ export class ComputeApprovalBroker {
         ctx.ownerId,
         providerGeneration
       )
-      if (sessionWasCancelled() || !providerIsCurrent) return 'deny'
+      signal?.throwIfAborted()
+      if (!providerIsCurrent) return 'deny'
     }
 
-    // Record grant if applicable.
+    // Record the scope the user already selected. A later request/Session cancellation still stops
+    // this operation at the final check below, but must not revoke an approved Project/Global grant.
     if (this.deps.permissionGrants) {
       await this.deps.permissionGrants.remember(
         { sessionId, projectId, operation, providerId },
@@ -276,7 +269,8 @@ export class ComputeApprovalBroker {
         ctx.ownerId,
         providerGeneration
       )
-      if (sessionWasCancelled() || !providerIsCurrent) return 'deny'
+      signal?.throwIfAborted()
+      if (!providerIsCurrent) return 'deny'
     }
 
     return decision
@@ -310,7 +304,6 @@ export class ComputeApprovalBroker {
   }
 
   cancelSession(sessionId: string): void {
-    this.cancelledSessions.add(sessionId)
     this.pausedSessions.delete(sessionId)
     for (const key of this.conversationGrants) {
       if (key.startsWith(`${sessionId}:`)) this.conversationGrants.delete(key)

--- a/src/main/compute/compute-approval-broker.ts
+++ b/src/main/compute/compute-approval-broker.ts
@@ -75,10 +75,16 @@ type PendingComputeApproval = {
 export class ComputeApprovalBroker {
   private readonly pending = new Map<string, PendingComputeApproval>()
   private readonly pausedSessions = new Set<string>()
+  private readonly cancellingSessions = new Set<string>()
+  private readonly completingSessionCancellations = new Set<string>()
 
   private readonly providerGenerations = new Map<string, number>()
   private readonly invalidatingProviders = new Set<string>()
   private readonly inFlightRequests = new Map<string, Set<Promise<ComputeApprovalDecision>>>()
+  private readonly inFlightSessionRequests = new Map<
+    string,
+    Set<Promise<ComputeApprovalDecision>>
+  >()
 
   // Legacy fallback used only when no durable adapter is supplied.
   private readonly conversationGrants = new Set<string>()
@@ -103,6 +109,7 @@ export class ComputeApprovalBroker {
     signal?: AbortSignal
   ): Promise<ComputeApprovalDecision> {
     signal?.throwIfAborted()
+    if (context && this.cancellingSessions.has(context.sessionId)) return Promise.resolve('deny')
     const id = this.deps.generateId()
     const providerId = info.provider_id
     const request = { id, ...info }
@@ -152,6 +159,7 @@ export class ComputeApprovalBroker {
     signal?: AbortSignal
   ): Promise<ComputeApprovalDecision> {
     signal?.throwIfAborted()
+    if (this.cancellingSessions.has(ctx.sessionId)) return Promise.resolve('deny')
     const providerId = info.provider_id
     if (this.invalidatingProviders.has(providerId)) return Promise.resolve('deny')
 
@@ -159,9 +167,12 @@ export class ComputeApprovalBroker {
     const requests = this.inFlightRequests.get(providerId) ?? new Set()
     requests.add(request)
     this.inFlightRequests.set(providerId, requests)
+    const sessionRequests = this.inFlightSessionRequests.get(ctx.sessionId) ?? new Set()
+    sessionRequests.add(request)
+    this.inFlightSessionRequests.set(ctx.sessionId, sessionRequests)
     void request.then(
-      () => this.releaseInFlightRequest(providerId, request),
-      () => this.releaseInFlightRequest(providerId, request)
+      () => this.releaseInFlightRequest(providerId, ctx.sessionId, request),
+      () => this.releaseInFlightRequest(providerId, ctx.sessionId, request)
     )
     return request
   }
@@ -174,6 +185,10 @@ export class ComputeApprovalBroker {
     const { sessionId, projectId, operation } = ctx
     const providerId = info.provider_id
     const providerGeneration = this.providerGenerations.get(providerId) ?? 0
+    const requestWasCancelled = (): boolean => {
+      signal?.throwIfAborted()
+      return this.cancellingSessions.has(sessionId)
+    }
 
     if (this.deps.permissionGrants) {
       const durableScope = await this.deps.permissionGrants.resolve({
@@ -182,15 +197,14 @@ export class ComputeApprovalBroker {
         operation,
         providerId
       })
-      signal?.throwIfAborted()
+      if (requestWasCancelled()) return 'deny'
       if (durableScope) {
         const providerIsCurrent = await this.isProviderCurrent(
           providerId,
           ctx.ownerId,
           providerGeneration
         )
-        signal?.throwIfAborted()
-        if (!providerIsCurrent) return 'deny'
+        if (requestWasCancelled() || !providerIsCurrent) return 'deny'
         if (durableScope === 'session') return 'conversation'
         return durableScope
       }
@@ -199,15 +213,14 @@ export class ComputeApprovalBroker {
     // ── legacy project grant check (persistent) ───────────────────────────────────
     if (this.deps.checkProjectGrant) {
       const hasProject = await this.deps.checkProjectGrant({ projectId, operation, providerId })
-      signal?.throwIfAborted()
+      if (requestWasCancelled()) return 'deny'
       if (hasProject) {
         const providerIsCurrent = await this.isProviderCurrent(
           providerId,
           ctx.ownerId,
           providerGeneration
         )
-        signal?.throwIfAborted()
-        if (!providerIsCurrent) return 'deny'
+        if (requestWasCancelled() || !providerIsCurrent) return 'deny'
         return 'project'
       }
     }
@@ -220,8 +233,7 @@ export class ComputeApprovalBroker {
         ctx.ownerId,
         providerGeneration
       )
-      signal?.throwIfAborted()
-      if (!providerIsCurrent) return 'deny'
+      if (requestWasCancelled() || !providerIsCurrent) return 'deny'
       return 'conversation'
     }
 
@@ -230,6 +242,7 @@ export class ComputeApprovalBroker {
     // entered the in-flight set but before it reached the approval card. Fail closed here so the
     // invalidator cannot miss a newly-created pending request and wait on it indefinitely.
     if (
+      requestWasCancelled() ||
       this.invalidatingProviders.has(providerId) ||
       (this.providerGenerations.get(providerId) ?? 0) !== providerGeneration
     ) {
@@ -246,8 +259,7 @@ export class ComputeApprovalBroker {
         ctx.ownerId,
         providerGeneration
       )
-      signal?.throwIfAborted()
-      if (!providerIsCurrent) return 'deny'
+      if (requestWasCancelled() || !providerIsCurrent) return 'deny'
     }
 
     // Record the scope the user already selected. A later request/Session cancellation still stops
@@ -269,8 +281,7 @@ export class ComputeApprovalBroker {
         ctx.ownerId,
         providerGeneration
       )
-      signal?.throwIfAborted()
-      if (!providerIsCurrent) return 'deny'
+      if (requestWasCancelled() || !providerIsCurrent) return 'deny'
     }
 
     return decision
@@ -304,6 +315,8 @@ export class ComputeApprovalBroker {
   }
 
   cancelSession(sessionId: string): void {
+    this.cancellingSessions.add(sessionId)
+    this.completingSessionCancellations.delete(sessionId)
     this.pausedSessions.delete(sessionId)
     for (const key of this.conversationGrants) {
       if (key.startsWith(`${sessionId}:`)) this.conversationGrants.delete(key)
@@ -311,6 +324,15 @@ export class ComputeApprovalBroker {
     for (const [id, entry] of this.pending) {
       if (entry.context?.sessionId === sessionId) this.settle(id, 'deny', 'cancelled')
     }
+  }
+
+  completeSessionCancellation(sessionId: string): void {
+    if (!this.cancellingSessions.has(sessionId)) return
+    if (this.inFlightSessionRequests.has(sessionId)) {
+      this.completingSessionCancellations.add(sessionId)
+      return
+    }
+    this.cancellingSessions.delete(sessionId)
   }
 
   private schedule(id: string, entry: PendingComputeApproval): void {
@@ -344,11 +366,20 @@ export class ComputeApprovalBroker {
 
   private releaseInFlightRequest(
     providerId: string,
+    sessionId: string,
     request: Promise<ComputeApprovalDecision>
   ): void {
     const requests = this.inFlightRequests.get(providerId)
     requests?.delete(request)
     if (requests?.size === 0) this.inFlightRequests.delete(providerId)
+
+    const sessionRequests = this.inFlightSessionRequests.get(sessionId)
+    sessionRequests?.delete(request)
+    if (sessionRequests?.size !== 0) return
+    this.inFlightSessionRequests.delete(sessionId)
+    if (this.completingSessionCancellations.delete(sessionId)) {
+      this.cancellingSessions.delete(sessionId)
+    }
   }
 
   private async isProviderCurrent(

--- a/src/main/compute/compute-approval-broker.ts
+++ b/src/main/compute/compute-approval-broker.ts
@@ -78,6 +78,7 @@ export class ComputeApprovalBroker {
   private readonly cancellingSessions = new Set<string>()
   private readonly deletingSessions = new Set<string>()
   private readonly completingSessionCancellations = new Set<string>()
+  private globalCancellationActive = false
 
   private readonly providerGenerations = new Map<string, number>()
   private readonly invalidatingProviders = new Set<string>()
@@ -110,6 +111,7 @@ export class ComputeApprovalBroker {
     signal?: AbortSignal
   ): Promise<ComputeApprovalDecision> {
     signal?.throwIfAborted()
+    if (this.globalCancellationActive) return Promise.resolve('deny')
     if (context && this.cancellingSessions.has(context.sessionId)) return Promise.resolve('deny')
     const id = this.deps.generateId()
     const providerId = info.provider_id
@@ -160,6 +162,7 @@ export class ComputeApprovalBroker {
     signal?: AbortSignal
   ): Promise<ComputeApprovalDecision> {
     signal?.throwIfAborted()
+    if (this.globalCancellationActive) return Promise.resolve('deny')
     if (this.cancellingSessions.has(ctx.sessionId)) return Promise.resolve('deny')
     const providerId = info.provider_id
     if (this.invalidatingProviders.has(providerId)) return Promise.resolve('deny')
@@ -188,7 +191,7 @@ export class ComputeApprovalBroker {
     const providerGeneration = this.providerGenerations.get(providerId) ?? 0
     const requestWasCancelled = (): boolean => {
       signal?.throwIfAborted()
-      return this.cancellingSessions.has(sessionId)
+      return this.globalCancellationActive || this.cancellingSessions.has(sessionId)
     }
 
     if (this.deps.permissionGrants) {
@@ -328,6 +331,7 @@ export class ComputeApprovalBroker {
   }
 
   cancelAll(): void {
+    this.globalCancellationActive = true
     const sessionIds = new Set(this.inFlightSessionRequests.keys())
     for (const entry of this.pending.values()) {
       if (entry.context) sessionIds.add(entry.context.sessionId)
@@ -338,6 +342,10 @@ export class ComputeApprovalBroker {
     }
     this.pausedSessions.clear()
     this.conversationGrants.clear()
+  }
+
+  completeGlobalCancellation(): void {
+    this.globalCancellationActive = false
   }
 
   beginSessionDeletion(sessionId: string): void {

--- a/src/main/compute/compute-job-workflow-owner.test.ts
+++ b/src/main/compute/compute-job-workflow-owner.test.ts
@@ -364,18 +364,21 @@ describe('ComputeJobWorkflowOwner.submitJob', () => {
     } as unknown as ComputeApprovalBroker
 
     const service = makeOwner(runner, repo, broker, jobRepo)
+    const signal = new AbortController().signal
 
     await service.submitJob(
       'ssh:biowulf',
       'test',
       'echo hi',
       {},
-      { sessionId: 's1', projectId: 'p1' }
+      { sessionId: 's1', projectId: 'p1' },
+      signal
     )
 
     expect(requestWithContext).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ operation: 'submit_job' })
+      expect.objectContaining({ operation: 'submit_job' }),
+      signal
     )
   })
 

--- a/src/main/compute/compute-job-workflow-owner.ts
+++ b/src/main/compute/compute-job-workflow-owner.ts
@@ -162,7 +162,8 @@ export class ComputeJobWorkflowOwner {
       timeoutSeconds?: number
       workspaceCwd?: string
     },
-    context: { sessionId: string; projectId: string }
+    context: { sessionId: string; projectId: string },
+    signal?: AbortSignal
   ): Promise<SubmitJobResult> {
     if (!this.jobRepository) {
       throw new Error('ComputeJobRepository is required to call submitJob.')
@@ -268,7 +269,8 @@ export class ComputeJobWorkflowOwner {
         projectId: context.projectId,
         operation: 'submit_job',
         ownerId: host.id
-      }
+      },
+      signal
     )
 
     if (decision === 'deny') {

--- a/src/main/compute/compute-remote-operation-owner.test.ts
+++ b/src/main/compute/compute-remote-operation-owner.test.ts
@@ -106,6 +106,40 @@ const makeOwner = (
   )
 
 describe('ComputeRemoteOperationOwner.callCommand', () => {
+  it('binds request cancellation to connection acquisition and SSH execution', async () => {
+    const run = vi.fn(async () => ({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      truncated: false,
+      timedOut: false
+    }))
+    const acquire = vi.fn(async () => ({
+      run,
+      upload: vi.fn(),
+      download: vi.fn()
+    }))
+    const { repo } = makeRepo()
+    const service = new ComputeRemoteOperationOwner({ acquire }, repo, makeApprovalBroker('once'))
+    const signal = new AbortController().signal
+
+    await service.callCommand(
+      'ssh:biowulf',
+      'echo hi',
+      'intent',
+      true,
+      undefined,
+      undefined,
+      signal
+    )
+
+    expect(acquire).toHaveBeenCalledWith('ssh:biowulf', {
+      intent: 'direct_command',
+      signal
+    })
+    expect(run).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ signal }))
+  })
+
   it('preserves a stable sanitized password-authentication error code', async () => {
     const runner: SshRunner = {
       run: vi.fn(async () => {
@@ -1000,6 +1034,46 @@ describe('ComputeRemoteOperationOwner.download (session-cache)', () => {
 
   afterEach(async () => {
     await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('binds request cancellation to connection acquisition and SCP transfer', async () => {
+    const download = vi.fn(async (_remotePath: string, localPath: string) => {
+      await writeFile(localPath, 'content')
+      return {
+        exitCode: 0,
+        stderr: '',
+        timedOut: false,
+        bytesWritten: 7,
+        exceeded: false
+      }
+    })
+    const acquire = vi.fn(async () => ({
+      run: vi.fn(),
+      upload: vi.fn(),
+      download
+    }))
+    const { repo } = makeRepo()
+    const service = new ComputeRemoteOperationOwner(
+      { acquire },
+      repo,
+      makeApprovalBroker('once'),
+      tmpDir
+    )
+    const signal = new AbortController().signal
+
+    await service.download(
+      'ssh:biowulf',
+      '/remote/results.csv',
+      { kind: 'session-cache' },
+      undefined,
+      signal
+    )
+
+    expect(acquire).toHaveBeenCalledWith('ssh:biowulf', {
+      intent: 'direct_download',
+      signal
+    })
+    expect(download).toHaveBeenCalledOnce()
   })
 
   it('downloads to session cache and returns LocalFile when approved', async () => {

--- a/src/main/compute/compute-remote-operation-owner.ts
+++ b/src/main/compute/compute-remote-operation-owner.ts
@@ -172,7 +172,8 @@ export class ComputeRemoteOperationOwner {
     intent: string,
     loginShell = true,
     timeoutSeconds?: number,
-    context?: { sessionId: string; projectId: string }
+    context?: { sessionId: string; projectId: string },
+    signal?: AbortSignal
   ): Promise<ExecResult> {
     const host = await this.repository.get(providerId)
     if (!host) throw hostNotFound(providerId)
@@ -191,13 +192,17 @@ export class ComputeRemoteOperationOwner {
       command_full: cmd
     }
     const decision = context
-      ? await this.approvalBroker.requestWithContext(approvalInfo, {
-          sessionId: context.sessionId,
-          projectId: context.projectId,
-          operation: 'call_command',
-          ownerId: host.id
-        })
-      : await this.approvalBroker.request(approvalInfo)
+      ? await this.approvalBroker.requestWithContext(
+          approvalInfo,
+          {
+            sessionId: context.sessionId,
+            projectId: context.projectId,
+            operation: 'call_command',
+            ownerId: host.id
+          },
+          signal
+        )
+      : await this.approvalBroker.request(approvalInfo, undefined, signal)
 
     if (decision === 'deny') {
       const error = new Error(
@@ -274,7 +279,8 @@ export class ComputeRemoteOperationOwner {
     providerId: string,
     remotePath: string,
     dest: DownloadDest,
-    context?: { sessionId: string; projectId: string }
+    context?: { sessionId: string; projectId: string },
+    signal?: AbortSignal
   ): Promise<LocalFile> {
     const host = await this.repository.get(providerId)
     if (!host) throw hostNotFound(providerId)
@@ -317,13 +323,17 @@ export class ComputeRemoteOperationOwner {
       remote_path: remotePath
     }
     const decision = context
-      ? await this.approvalBroker.requestWithContext(approvalInfo, {
-          sessionId: context.sessionId,
-          projectId: context.projectId,
-          operation: 'download',
-          ownerId: host.id
-        })
-      : await this.approvalBroker.request(approvalInfo)
+      ? await this.approvalBroker.requestWithContext(
+          approvalInfo,
+          {
+            sessionId: context.sessionId,
+            projectId: context.projectId,
+            operation: 'download',
+            ownerId: host.id
+          },
+          signal
+        )
+      : await this.approvalBroker.request(approvalInfo, undefined, signal)
 
     if (decision === 'deny') {
       const error = new Error(

--- a/src/main/compute/compute-remote-operation-owner.ts
+++ b/src/main/compute/compute-remote-operation-owner.ts
@@ -218,7 +218,10 @@ export class ComputeRemoteOperationOwner {
 
     let connection
     try {
-      connection = await this.connectionBroker.acquire(providerId, { intent: 'direct_command' })
+      connection = await this.connectionBroker.acquire(providerId, {
+        intent: 'direct_command',
+        ...(signal ? { signal } : {})
+      })
     } catch (error) {
       throw computeCallConnectionError(error)
     }
@@ -236,7 +239,8 @@ export class ComputeRemoteOperationOwner {
       runResult = await connection.run(wrappedCommand, {
         timeoutMs,
         loginShell,
-        maxOutputBytes: CALL_COMMAND_MAX_OUTPUT_BYTES
+        maxOutputBytes: CALL_COMMAND_MAX_OUTPUT_BYTES,
+        ...(signal ? { signal } : {})
       })
     } catch (error) {
       throw computeCallConnectionError(error)
@@ -299,7 +303,10 @@ export class ComputeRemoteOperationOwner {
 
     let connection
     try {
-      connection = await this.connectionBroker.acquire(providerId, { intent: 'direct_download' })
+      connection = await this.connectionBroker.acquire(providerId, {
+        intent: 'direct_download',
+        ...(signal ? { signal } : {})
+      })
     } catch (error) {
       throw remoteConnectionError(error)
     }

--- a/src/main/compute/compute-service.architecture.test.ts
+++ b/src/main/compute/compute-service.architecture.test.ts
@@ -520,6 +520,9 @@ describe('Compute service architecture', () => {
     const computeService = manifest.modules.compute_service
 
     expect(computeService.ownerPaths).toEqual([
+      'src/main/compute/approval-session-lifecycle.ts',
+      'src/main/compute/agent-compute-service.ts',
+      'src/main/compute/compute-approval-broker.ts',
       'src/main/compute/compute-host-profile-owner.ts',
       'src/main/compute/compute-job-lifecycle.ts',
       'src/main/compute/job-deletion-owner.ts',
@@ -547,6 +550,9 @@ describe('Compute service architecture', () => {
     expect(computeService.testFiles.owner).toEqual(
       expect.arrayContaining([
         architectureTestPath,
+        'src/main/compute/approval-session-lifecycle.test.ts',
+        'src/main/compute/agent-compute-service.test.ts',
+        'src/main/compute/compute-approval-broker.test.ts',
         'src/main/compute/connection-broker.test.ts',
         'src/main/compute/compute-job-lifecycle.test.ts',
         'src/main/compute/job-deletion-owner.test.ts',

--- a/src/main/compute/compute-service.ts
+++ b/src/main/compute/compute-service.ts
@@ -152,7 +152,8 @@ export class ComputeService {
     intent: string,
     loginShell = true,
     timeoutSeconds?: number,
-    context?: { sessionId: string; projectId: string }
+    context?: { sessionId: string; projectId: string },
+    signal?: AbortSignal
   ): Promise<ExecResult> {
     return this.remoteOperations.callCommand(
       providerId,
@@ -160,7 +161,8 @@ export class ComputeService {
       intent,
       loginShell,
       timeoutSeconds,
-      context
+      context,
+      signal
     )
   }
 
@@ -168,9 +170,10 @@ export class ComputeService {
     providerId: string,
     remotePath: string,
     dest: DownloadDest,
-    context?: { sessionId: string; projectId: string }
+    context?: { sessionId: string; projectId: string },
+    signal?: AbortSignal
   ): Promise<LocalFile> {
-    return this.remoteOperations.download(providerId, remotePath, dest, context)
+    return this.remoteOperations.download(providerId, remotePath, dest, context, signal)
   }
 
   async submitJob(
@@ -186,9 +189,10 @@ export class ComputeService {
       timeoutSeconds?: number
       workspaceCwd?: string
     },
-    context: { sessionId: string; projectId: string }
+    context: { sessionId: string; projectId: string },
+    signal?: AbortSignal
   ): Promise<SubmitJobResult> {
-    return this.jobWorkflow.submitJob(providerId, intent, command, options, context)
+    return this.jobWorkflow.submitJob(providerId, intent, command, options, context, signal)
   }
 
   async getJobStatus(

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -190,6 +190,7 @@ type ComputeHandlers = {
   approvalReplayPending: () => void
   approvalPauseSession: (sessionId: string) => void
   approvalResumeSession: (sessionId: string) => void
+  approvalCancelSession: (sessionId: string) => void
   // Returns JobSummary[] for a session, optionally filtered by status (renderer feed, issue 05).
   jobsList: (filter: { sessionId: string; status?: string[] }) => Promise<JobSummary[]>
   // Returns jobs with notifiedAt set and notificationConsumedAt null (issue 05 restart recovery).
@@ -436,6 +437,7 @@ const createComputeHandlers = (
     approvalReplayPending: () => broker.replayPending(),
     approvalPauseSession: (sessionId) => broker.pauseSession(sessionId),
     approvalResumeSession: (sessionId) => broker.resumeSession(sessionId),
+    approvalCancelSession: (sessionId) => broker.cancelSession(sessionId),
     jobsList: async (filter) => {
       if (!jobRepository || !storageRoot) return []
       const hosts = await repository.list()

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -193,6 +193,8 @@ type ComputeHandlers = {
   approvalCancelSession: (sessionId: string) => void
   approvalCancelAll: () => void
   approvalCompleteSessionCancellation: (sessionId: string) => void
+  approvalBeginSessionDeletion: (sessionId: string) => void
+  approvalFinishSessionDeletion: (sessionId: string, retained: boolean) => void
   // Returns JobSummary[] for a session, optionally filtered by status (renderer feed, issue 05).
   jobsList: (filter: { sessionId: string; status?: string[] }) => Promise<JobSummary[]>
   // Returns jobs with notifiedAt set and notificationConsumedAt null (issue 05 restart recovery).
@@ -443,6 +445,9 @@ const createComputeHandlers = (
     approvalCancelAll: () => broker.cancelAll(),
     approvalCompleteSessionCancellation: (sessionId) =>
       broker.completeSessionCancellation(sessionId),
+    approvalBeginSessionDeletion: (sessionId) => broker.beginSessionDeletion(sessionId),
+    approvalFinishSessionDeletion: (sessionId, retained) =>
+      broker.finishSessionDeletion(sessionId, retained),
     jobsList: async (filter) => {
       if (!jobRepository || !storageRoot) return []
       const hosts = await repository.list()

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -191,6 +191,7 @@ type ComputeHandlers = {
   approvalPauseSession: (sessionId: string) => void
   approvalResumeSession: (sessionId: string) => void
   approvalCancelSession: (sessionId: string) => void
+  approvalCompleteSessionCancellation: (sessionId: string) => void
   // Returns JobSummary[] for a session, optionally filtered by status (renderer feed, issue 05).
   jobsList: (filter: { sessionId: string; status?: string[] }) => Promise<JobSummary[]>
   // Returns jobs with notifiedAt set and notificationConsumedAt null (issue 05 restart recovery).
@@ -438,6 +439,8 @@ const createComputeHandlers = (
     approvalPauseSession: (sessionId) => broker.pauseSession(sessionId),
     approvalResumeSession: (sessionId) => broker.resumeSession(sessionId),
     approvalCancelSession: (sessionId) => broker.cancelSession(sessionId),
+    approvalCompleteSessionCancellation: (sessionId) =>
+      broker.completeSessionCancellation(sessionId),
     jobsList: async (filter) => {
       if (!jobRepository || !storageRoot) return []
       const hosts = await repository.list()

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -191,6 +191,7 @@ type ComputeHandlers = {
   approvalPauseSession: (sessionId: string) => void
   approvalResumeSession: (sessionId: string) => void
   approvalCancelSession: (sessionId: string) => void
+  approvalCancelAll: () => void
   approvalCompleteSessionCancellation: (sessionId: string) => void
   // Returns JobSummary[] for a session, optionally filtered by status (renderer feed, issue 05).
   jobsList: (filter: { sessionId: string; status?: string[] }) => Promise<JobSummary[]>
@@ -439,6 +440,7 @@ const createComputeHandlers = (
     approvalPauseSession: (sessionId) => broker.pauseSession(sessionId),
     approvalResumeSession: (sessionId) => broker.resumeSession(sessionId),
     approvalCancelSession: (sessionId) => broker.cancelSession(sessionId),
+    approvalCancelAll: () => broker.cancelAll(),
     approvalCompleteSessionCancellation: (sessionId) =>
       broker.completeSessionCancellation(sessionId),
     jobsList: async (filter) => {

--- a/src/main/compute/ipc.ts
+++ b/src/main/compute/ipc.ts
@@ -192,6 +192,7 @@ type ComputeHandlers = {
   approvalResumeSession: (sessionId: string) => void
   approvalCancelSession: (sessionId: string) => void
   approvalCancelAll: () => void
+  approvalCompleteGlobalCancellation: () => void
   approvalCompleteSessionCancellation: (sessionId: string) => void
   approvalBeginSessionDeletion: (sessionId: string) => void
   approvalFinishSessionDeletion: (sessionId: string, retained: boolean) => void
@@ -443,6 +444,7 @@ const createComputeHandlers = (
     approvalResumeSession: (sessionId) => broker.resumeSession(sessionId),
     approvalCancelSession: (sessionId) => broker.cancelSession(sessionId),
     approvalCancelAll: () => broker.cancelAll(),
+    approvalCompleteGlobalCancellation: () => broker.completeGlobalCancellation(),
     approvalCompleteSessionCancellation: (sessionId) =>
       broker.completeSessionCancellation(sessionId),
     approvalBeginSessionDeletion: (sessionId) => broker.beginSessionDeletion(sessionId),

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2163,14 +2163,12 @@ const createApplicationModules = async (
       onAllSessionsCancellationRequested:
         approvalSessionLifecycle.onAllSessionsCancellationRequested,
       beforeSessionDelete: async (sessionId) => {
-        computeIpcModule.handlers.approvalCancelSession(sessionId)
-        try {
-          await sideChatOwnerRef.current?.invalidateParents([sessionId])
-          await notebookService.shutdownSession(sessionId)
-        } finally {
-          computeIpcModule.handlers.approvalCompleteSessionCancellation(sessionId)
-        }
+        computeIpcModule.handlers.approvalBeginSessionDeletion(sessionId)
+        await sideChatOwnerRef.current?.invalidateParents([sessionId])
+        await notebookService.shutdownSession(sessionId)
       },
+      afterSessionDelete: (sessionId, retained) =>
+        computeIpcModule.handlers.approvalFinishSessionDeletion(sessionId, retained),
       initializationBarrier: initialConnectorSkillsReady,
       profileService,
       sessionPersistenceCoordinator,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -66,6 +66,7 @@ import { ArtifactProvenanceRepository } from './artifacts/provenance-repository'
 import { ProvenanceMessageSnapshotRepository } from './artifacts/provenance-message-snapshot'
 import { ArtifactRunRegistry } from './artifacts/run-registry'
 import { createComputeIpcModule } from './compute/ipc'
+import { bindComputeApprovalSessionLifecycle } from './compute/approval-session-lifecycle'
 import type { ComputeJobOwnerLiveness } from './compute/job-deletion-owner'
 import { AgentComputeService } from './compute/agent-compute-service'
 import { createSessionCatalogHydration } from './compute/session-catalog-hydration'
@@ -2121,6 +2122,21 @@ const createApplicationModules = async (
   })
   // ACP identity resolution and the Specialist settings IPC must use the same service instance.
   // Creating it only for settings leaves create-session unable to resolve a selected UUID.
+  const approvalSessionLifecycle = bindComputeApprovalSessionLifecycle(
+    {
+      onSessionTurnStarted: (sessionId, turnToken) =>
+        skillImportApprovalBroker.beginSessionTurn(sessionId, turnToken),
+      onSessionTurnEnded: (sessionId, turnToken) =>
+        skillImportApprovalBroker.endSessionTurn(sessionId, turnToken),
+      onSkillImportAttachmentEligible: (sessionId, turnToken, attachmentUri) =>
+        skillImportApprovalBroker.allowSessionTurnAttachment(sessionId, turnToken, attachmentUri),
+      onSessionCancellationRequested: (sessionId) =>
+        skillImportApprovalBroker.cancelSession(sessionId),
+      onSessionUnavailable: (sessionId) => skillImportApprovalBroker.cancelSession(sessionId),
+      onAllSessionsCancellationRequested: () => skillImportApprovalBroker.cancelAll()
+    },
+    computeIpcModule.handlers
+  )
   const runtime = await modules.add(
     {
       mcpEntryPath: mainEntryPath,
@@ -2137,18 +2153,15 @@ const createApplicationModules = async (
       permissionGrantRegistry,
       taskNotifications,
       notificationInbox,
-      onSessionTurnStarted: (sessionId, turnToken) =>
-        skillImportApprovalBroker.beginSessionTurn(sessionId, turnToken),
-      onSessionTurnEnded: (sessionId, turnToken) =>
-        skillImportApprovalBroker.endSessionTurn(sessionId, turnToken),
-      onSkillImportAttachmentEligible: (sessionId, turnToken, attachmentUri) =>
-        skillImportApprovalBroker.allowSessionTurnAttachment(sessionId, turnToken, attachmentUri),
+      onSessionTurnStarted: approvalSessionLifecycle.onSessionTurnStarted,
+      onSessionTurnEnded: approvalSessionLifecycle.onSessionTurnEnded,
+      onSkillImportAttachmentEligible: approvalSessionLifecycle.onSkillImportAttachmentEligible,
       onTrustedMessageAttribution: (projectId, event) =>
         messageAttributionAuthority.recordRuntimeEvent(projectId, event),
-      onSessionCancellationRequested: (sessionId) =>
-        skillImportApprovalBroker.cancelSession(sessionId),
-      onSessionUnavailable: (sessionId) => skillImportApprovalBroker.cancelSession(sessionId),
-      onAllSessionsCancellationRequested: () => skillImportApprovalBroker.cancelAll(),
+      onSessionCancellationRequested: approvalSessionLifecycle.onSessionCancellationRequested,
+      onSessionUnavailable: approvalSessionLifecycle.onSessionUnavailable,
+      onAllSessionsCancellationRequested:
+        approvalSessionLifecycle.onAllSessionsCancellationRequested,
       beforeSessionDelete: async (sessionId) => {
         computeIpcModule.handlers.approvalCancelSession(sessionId)
         try {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2150,6 +2150,7 @@ const createApplicationModules = async (
       onSessionUnavailable: (sessionId) => skillImportApprovalBroker.cancelSession(sessionId),
       onAllSessionsCancellationRequested: () => skillImportApprovalBroker.cancelAll(),
       beforeSessionDelete: async (sessionId) => {
+        computeIpcModule.handlers.approvalCancelSession(sessionId)
         await sideChatOwnerRef.current?.invalidateParents([sessionId])
         await notebookService.shutdownSession(sessionId)
       },

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2151,8 +2151,12 @@ const createApplicationModules = async (
       onAllSessionsCancellationRequested: () => skillImportApprovalBroker.cancelAll(),
       beforeSessionDelete: async (sessionId) => {
         computeIpcModule.handlers.approvalCancelSession(sessionId)
-        await sideChatOwnerRef.current?.invalidateParents([sessionId])
-        await notebookService.shutdownSession(sessionId)
+        try {
+          await sideChatOwnerRef.current?.invalidateParents([sessionId])
+          await notebookService.shutdownSession(sessionId)
+        } finally {
+          computeIpcModule.handlers.approvalCompleteSessionCancellation(sessionId)
+        }
       },
       initializationBarrier: initialConnectorSkillsReady,
       profileService,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2162,8 +2162,9 @@ const createApplicationModules = async (
       onSessionUnavailable: approvalSessionLifecycle.onSessionUnavailable,
       onAllSessionsCancellationRequested:
         approvalSessionLifecycle.onAllSessionsCancellationRequested,
+      onSessionDeleteStarted: (sessionId) =>
+        computeIpcModule.handlers.approvalBeginSessionDeletion(sessionId),
       beforeSessionDelete: async (sessionId) => {
-        computeIpcModule.handlers.approvalBeginSessionDeletion(sessionId)
         await sideChatOwnerRef.current?.invalidateParents([sessionId])
         await notebookService.shutdownSession(sessionId)
       },

--- a/src/main/notebook/local-rpc-server.mcpcall.test.ts
+++ b/src/main/notebook/local-rpc-server.mcpcall.test.ts
@@ -312,6 +312,74 @@ describe('mcpCall RPC', () => {
 })
 
 describe('computeCall RPC', () => {
+  it.each([
+    {
+      operation: 'call_command',
+      params: { op: 'call_command', provider_id: 'ssh:cluster', cmd: 'true', intent: 'test' },
+      serviceMethod: 'callCommand',
+      signalIndex: 6
+    },
+    {
+      operation: 'download',
+      params: { op: 'download', provider_id: 'ssh:cluster', remote_path: '/tmp/result.csv' },
+      serviceMethod: 'download',
+      signalIndex: 4
+    },
+    {
+      operation: 'submit_job',
+      params: {
+        op: 'submit_job',
+        provider_id: 'ssh:cluster',
+        intent: 'test',
+        command: 'true'
+      },
+      serviceMethod: 'submitJob',
+      signalIndex: 5
+    }
+  ] as const)(
+    'aborts a pending $operation when the RPC client disconnects',
+    async ({ params, serviceMethod, signalIndex }) => {
+      let observedSignal: AbortSignal | undefined
+      let markCallStarted!: () => void
+      let releaseCall!: (value: Record<string, never>) => void
+      const callStarted = new Promise<void>((resolve) => {
+        markCallStarted = resolve
+      })
+      const callPending = new Promise<Record<string, never>>((resolve) => {
+        releaseCall = resolve
+      })
+      const fakeCompute = {
+        [serviceMethod]: async (...args: unknown[]) => {
+          observedSignal = args[signalIndex] as AbortSignal | undefined
+          markCallStarted()
+          return callPending
+        }
+      }
+      server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+        transport: 'tcp',
+        computeService: fakeCompute as never
+      })
+      const { endpoint, token } = await sessionConnection(server)
+      const disconnect = new AbortController()
+      const request = fetch(endpoint, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: JSON.stringify({ method: 'computeCall', params }),
+        signal: disconnect.signal
+      })
+
+      await callStarted
+      disconnect.abort()
+      try {
+        await expect(request).rejects.toThrow()
+        expect(observedSignal).toBeInstanceOf(AbortSignal)
+        await vi.waitFor(() => expect(observedSignal?.aborted).toBe(true))
+      } finally {
+        releaseCall({})
+      }
+    }
+  )
+
   it('uses the Session admission facade for discovery and guessed provider calls', async () => {
     const callCommand = vi.fn(async () => ({}))
     const raw = {
@@ -967,7 +1035,8 @@ describe('computeCall RPC', () => {
         harvestConfig: JSON.stringify({ mode: 'manifest' }),
         timeoutSeconds: 600,
         workspaceCwd: 'workspace/project'
-      }
+      },
+      expect.any(AbortSignal)
     ])
   })
 

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -114,7 +114,8 @@ type NotebookLocalRpcServerOptions = {
       cmd: string,
       intent: string,
       loginShell?: boolean,
-      timeoutSeconds?: number
+      timeoutSeconds?: number,
+      signal?: AbortSignal
     ): Promise<unknown>
     list(sessionId: string): Promise<ComputeHost[]>
     listHosts(sessionId: string): Promise<AgentComputeHostSummary[]>
@@ -136,7 +137,8 @@ type NotebookLocalRpcServerOptions = {
       context: { sessionId: string; projectId: string },
       providerId: string,
       remotePath: string,
-      dest: { kind: 'session-cache' }
+      dest: { kind: 'session-cache' },
+      signal?: AbortSignal
     ): Promise<unknown>
     submitJob(
       context: { sessionId: string; projectId: string },
@@ -151,7 +153,8 @@ type NotebookLocalRpcServerOptions = {
         harvestConfig?: string
         timeoutSeconds?: number
         workspaceCwd?: string
-      }
+      },
+      signal?: AbortSignal
     ): Promise<unknown>
     getJobStatus(
       context: { sessionId: string; projectId: string },
@@ -2066,7 +2069,8 @@ class NotebookLocalRpcServer {
             cmd,
             intent,
             loginShell,
-            timeoutSeconds
+            timeoutSeconds,
+            signal
           )
         } catch (err) {
           // Re-throw compute call errors as structured error objects so the Python shim can
@@ -2138,9 +2142,15 @@ class NotebookLocalRpcServer {
       if (op === 'download') {
         const providerId = typeof params.provider_id === 'string' ? params.provider_id : ''
         const remotePath = typeof params.remote_path === 'string' ? params.remote_path : ''
-        return this.computeService.download(context, providerId, remotePath, {
-          kind: 'session-cache'
-        })
+        return this.computeService.download(
+          context,
+          providerId,
+          remotePath,
+          {
+            kind: 'session-cache'
+          },
+          signal
+        )
       }
 
       // op='submit_job' — non-blocking job submission (design.md §3a).
@@ -2171,7 +2181,8 @@ class NotebookLocalRpcServer {
               providerId,
               intent,
               command,
-              options
+              options,
+              signal
             )
           }
 
@@ -2195,7 +2206,8 @@ class NotebookLocalRpcServer {
             providerId,
             intent,
             command,
-            options
+            options,
+            signal
           )
           const invocation = { fingerprint, submission, completed: false }
           sessionInvocations.set(invocationId, invocation)

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -139,8 +139,7 @@ export type SettingsServiceOptions = {
   // The machine's own Claude config dir, used by the shared provider for auth/spawn and scanned as a
   // user skill source. Injectable so tests don't touch the real ~/.claude.
   userClaudeDir?: string
-  // The machine's own Codex config dir, scanned for installed skills while Codex is active.
-  // Injectable for the same reason as userClaudeDir.
+  // The machine's own Codex config dir, scanned for installed skills; injectable like userClaudeDir.
   userCodexDir?: string
   // The framework-neutral Agents config dir. Codex and other compatible agents discover skills
   // under ~/.agents/skills; it is scanned regardless of the active framework.


### PR DESCRIPTION
## Problem

Compute approvals for agent-initiated `call_command`, Session-cache `download`, and `submit_job` were not tied to the Notebook RPC or Session-turn lifecycle. If the client disconnected, the user cancelled the current turn, the runtime made the Session unavailable, or the owning Session was deleted while an approval card was pending, the broker kept the request alive until a response or the five-minute timeout.

That left stale approval cards and retained promises/resources. More importantly, a late approval could resume a remote command or download after the Session was gone, and `submit_job` could create work after the existing Session job cleanup had completed. An approval request still resolving an asynchronous grant lookup could also publish a new stale card after Session deletion began.

## Proposed change

- Forward the existing Notebook RPC `AbortSignal` through the agent compute facade and Compute owners into `ComputeApprovalBroker`.
- Bind that signal to SSH connection acquisition, command execution, and SCP download so `call_command` and `download` continue to observe disconnects after approval settles.
- Settle an aborted pending approval as denied with the existing `cancelled` lifecycle state, remove its listener, and let the existing renderer settlement event remove the card.
- Bracket the complete Session deletion attempt with broker cancellation before delegated cleanup begins: reject new requests while delegated work, Side Chat, Notebook, and agent-runtime teardown run; restore availability only if deletion fails or a concurrent runtime adoption retains the logical Session.
- Bind ordinary turn cancellation, unavailable-Session, and all-runtime shutdown callbacks to the same broker lifecycle. A new turn reopens approvals only after requests from the cancelled turn drain.
- Keep a process-local global fence after all-runtime cancellation so RPCs still resolving pre-broker checks cannot publish late approvals; only a generation-validated new turn clears it.
- Recheck request/Session cancellation after asynchronous grant and provider-liveness lookups so cancellation cannot release remembered authority into the current operation or publish a late card.
- Add public Notebook RPC regressions for all three operations plus broker and remote-owner regressions for abort, Session isolation, asynchronous races, failed-deletion recovery, and SSH/SCP signal forwarding.

## Scope and non-goals

- No new database fields, tables, migrations, serialized fields, or persistence behavior.
- No data-model changes and no new decision or lifecycle enum values; this reuses `deny` and `cancelled`.
- No permanent tombstone for a retained Session. The cancellation marker covers teardown or the cancelled turn and any approval setup already in flight. It clears after a failed/superseded deletion or when the next turn starts and old requests drain; a successfully deleted Session remains cancelled.
- No new renderer interaction or copy. The visible change is that stale cards disappear through the existing settlement path.
- No historical-data migration or compatibility handling is needed. Pending approvals and cancellation markers are process-local; existing orphan-job recovery remains unchanged.
- The shared Notebook RPC and Session teardown paths cover all supported agent frameworks; no framework-specific wire behavior changes.
- A Project/Global grant whose user-approved write has already started remains authorization state for that broader scope; cancellation still prevents the current operation from proceeding after the write completes.
- A `submit_job` that has already passed approval retains its existing durable background-job lifecycle. This change cancels its pending approval/request setup, while the existing job cancellation and Session cleanup paths remain responsible after job creation.

## Acceptance criteria and validation

The checks below ran after the last material edit:

- RPC disconnect cancellation for `call_command`, `download`, and `submit_job` -> `src/main/notebook/local-rpc-server.mcpcall.test.ts` -> 37 passed.
- Approval abort, Session-isolated cancellation, asynchronous lookup/deletion races, broad-grant linearization, and failed-deletion recovery -> `src/main/compute/compute-approval-broker.test.ts` -> passed.
- Post-approval SSH command and SCP download signal forwarding -> `src/main/compute/compute-remote-operation-owner.test.ts` -> passed.
- Ordinary turn cancellation, unavailable Session, all-runtime shutdown, and next-turn recovery -> `src/main/compute/approval-session-lifecycle.test.ts` -> failed twice before the fix because Compute cancellation had zero calls, then passed after the lifecycle was bound.
- Session deletion barrier ordering and retained/deleted outcomes -> `src/main/acp/runtime-coordinator.test.ts` and `src/main/compute/compute-approval-broker.test.ts` -> one regression failed before the fix because the post-delete lifecycle callback had zero calls; the delegated-cleanup regression separately failed because the start-fence callback had zero calls after delegated cleanup began. Both pass after the lifecycle was extended.
- Global teardown late-entry fence -> `src/main/compute/compute-approval-broker.test.ts` -> failed before the fix because a post-`cancelAll()` request still broadcast one approval, then passed after the global fence was added.
- Compute owner, adapter, consumer, and Notebook RPC coverage -> declared `compute_service` module set -> 31 files passed, 1 skipped; 800 tests passed, 6 skipped.
- ACP cancellation/deletion composition coverage -> 6 focused files; 289 tests passed.
- Main-process interface compatibility -> `npm run typecheck:node` -> passed.
- Source lint -> focused ESLint over the affected files -> passed.
- Changed-file formatting and whitespace -> Prettier check and `git diff --check` -> passed.
- Latest-main merge compatibility -> `src/main/settings/settings-backend.architecture.test.ts` initially reproduced the main-branch regression (`1071` lines over the existing `1070` ceiling); consolidating one unchanged comment line restores the ceiling without changing code, and all 11 architecture tests pass on a temporary `HEAD` + `origin/main` merge.

Per the requested validation scope, the full portable suite is intentionally deferred to PR Gate rather than run locally. The previously unowned approval broker, agent facade, and new lifecycle seam are now registered under `compute_service`, with the architecture guard updated to keep future module selection deterministic.

## Review focus

- Confirm Session deletion cancellation starts before delegated, Side Chat, and Notebook teardown, remains active until agent-runtime deletion settles, and releases only for failure or concurrent Session retention.
- Confirm ordinary cancellation/unavailability settles current approval cards and that the next turn resets the gate only after old approval setup drains.
- Confirm RPC cancellation reaches both approval waits and the existing SSH/SCP runner signal conventions.
- Confirm Project/Global authorization writes keep their existing broader-scope semantics while the cancelled current operation remains denied.
