### PR TITLE
fix(projects): preserve activity time when archiving

### DIFF
--- a/src/main/database/application-database.integration.test.ts
+++ b/src/main/database/application-database.integration.test.ts
@@ -936,6 +936,21 @@ describe('application database (integration)', () => {
     expect(pinned.pinned).toBe(true)
     expect(pinned.updatedAt).toBe(renamed.updatedAt)
 
+    const archivedAt = renamed.updatedAt + 1000
+    const archived = await repository.updateArchive(
+      { id: created.id, archived: true, expectedArchivedAt: null },
+      archivedAt
+    )
+    expect(archived.archivedAt).toBe(archivedAt)
+    expect(archived.updatedAt).toBe(renamed.updatedAt)
+
+    const restored = await repository.updateArchive(
+      { id: created.id, archived: false, expectedArchivedAt: archivedAt },
+      archivedAt + 1
+    )
+    expect(restored.archivedAt).toBeUndefined()
+    expect(restored.updatedAt).toBe(renamed.updatedAt)
+
     // Any project is deletable — there is no protected default.
     await repository.delete(created.id)
     expect(await repository.get(created.id)).toBeNull()
@@ -987,6 +1002,43 @@ describe('application database (integration)', () => {
         expectedUpdatedAt: staleSnapshot!.updatedAt
       })
     ).rejects.toThrow('Project changed elsewhere.')
+  })
+
+  it('does not roll back activity time when a concurrent edit races with archiving', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-project-archive-race-'))
+
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+
+    await migrateApplicationDatabase(client)
+
+    const repository = new ProjectRepository(() => Promise.resolve(client))
+    const created = await repository.create({ name: 'Before edit' })
+    const concurrentUpdatedAt = new Date('2099-01-01T00:00:00.000Z')
+    const archivedAt = created.updatedAt + 1000
+
+    await client.$executeRawUnsafe(`
+      CREATE TRIGGER "simulate_concurrent_project_edit"
+      BEFORE UPDATE OF "archivedAt" ON "Project"
+      FOR EACH ROW
+      BEGIN
+        UPDATE "Project"
+        SET "name" = 'Edited concurrently',
+            "updatedAt" = '${concurrentUpdatedAt.toISOString()}'
+        WHERE "id" = OLD."id";
+      END
+    `)
+
+    await expect(
+      repository.updateArchive(
+        { id: created.id, archived: true, expectedArchivedAt: null },
+        archivedAt
+      )
+    ).resolves.toMatchObject({
+      name: 'Edited concurrently',
+      archivedAt,
+      updatedAt: concurrentUpdatedAt.getTime()
+    })
   })
 
   // Verifies the runtime FINDING_TABLE_DDL + migration guard are byte-compatible with the Prisma

--- a/src/main/projects/repository.test.ts
+++ b/src/main/projects/repository.test.ts
@@ -219,13 +219,12 @@ describe('project repository', () => {
   })
 
   it('changes archive visibility with compare-and-set while preserving activity time', async () => {
-    const current = createRow({ updatedAt: new Date(1710000000100), archivedAt: null })
     const archived = createRow({
       updatedAt: new Date(1710000000100),
       archivedAt: new Date(1710000000200)
     })
-    const findUnique = vi.fn().mockResolvedValueOnce(current).mockResolvedValueOnce(archived)
-    const { client, project } = createMockClient({
+    const findUnique = vi.fn().mockResolvedValue(archived)
+    const { client, executeRaw, project } = createMockClient({
       findUnique,
       updateMany: () => Promise.resolve({ count: 1 })
     })
@@ -238,13 +237,8 @@ describe('project repository', () => {
       )
     ).resolves.toMatchObject({ archivedAt: 1710000000200, updatedAt: 1710000000100 })
 
-    expect(project.updateMany).toHaveBeenCalledWith({
-      where: { id: 'project-1', deletedAt: null, archivedAt: null },
-      data: {
-        archivedAt: new Date(1710000000200),
-        updatedAt: new Date(1710000000100)
-      }
-    })
+    expect(executeRaw).toHaveBeenCalledOnce()
+    expect(project.updateMany).not.toHaveBeenCalled()
   })
 
   it('persists, lists, and clears project deletion intents', async () => {

--- a/src/main/projects/repository.ts
+++ b/src/main/projects/repository.ts
@@ -173,24 +173,19 @@ class ProjectRepository {
     }
 
     const client = await this.getClient()
-    const current = await client.project.findUnique({ where: { id: request.id } })
-    if (!current || current.deletedAt !== null) throw new Error('Project not found.')
-
     const expectedArchivedAt = request.expectedArchivedAt
-    const result = await client.project.updateMany({
-      where: {
-        id: request.id,
-        deletedAt: null,
-        archivedAt: expectedArchivedAt === null ? null : new Date(expectedArchivedAt)
-      },
-      data: {
-        archivedAt: request.archived ? new Date(archivedAt) : null,
-        // Prisma otherwise updates this @updatedAt field. Administrative visibility changes must
-        // not make a Project look newer than its underlying work.
-        updatedAt: current.updatedAt
-      }
-    })
-    if (result.count !== 1) {
+    // Prisma's @updatedAt automation also runs for administrative changes. Updating only the archive
+    // column in SQL preserves the activity timestamp without reading and later restoring a stale value.
+    const updated = await client.$executeRaw`
+      UPDATE "Project"
+      SET "archivedAt" = ${request.archived ? new Date(archivedAt) : null}
+      WHERE "id" = ${request.id}
+        AND "deletedAt" IS NULL
+        AND "archivedAt" IS ${expectedArchivedAt === null ? null : new Date(expectedArchivedAt)}
+    `
+    if (updated !== 1) {
+      const current = await client.project.findUnique({ where: { id: request.id } })
+      if (!current || current.deletedAt !== null) throw new Error('Project not found.')
       throw new Error('Project archive state changed elsewhere.')
     }
 


### PR DESCRIPTION
## Problem

Project archiving read the current Project row, then used updateMany to write both archivedAt and that pre-read updatedAt value. Because the compare-and-set condition only covered archivedAt, a concurrent ordinary edit could advance project activity and still be overwritten by the archive write. The archive succeeded, but project ordering and later optimistic-concurrency checks observed an older activity timestamp.

## Proposed change

Update archivedAt with one parameterized SQLite compare-and-set statement that touches only the archive column. Preserve the existing archive-state CAS and distinguish missing Projects from archive-state conflicts with a read only after a failed write.

Add a deterministic regression at the public ProjectRepository boundary against real SQLite. A temporary trigger inserts a concurrent Project edit during the archive statement, reproducing the lost updatedAt write on the old implementation.

## Scope and non-goals

- No database field, schema, migration, or historical-data conversion.
- No new status or enum value.
- No IPC, renderer interaction, or Project data-model change.
- Persistence behavior changes only for Project archive/restore writes.

## Acceptance criteria and validation

Checks listed below ran after the last material edit and after rebasing onto the latest main.

- Concurrent archive regression -> targeted application-database integration test -> passed; the same final test failed on the unfixed implementation in 3 of 3 runs with updatedAt rolling back while the concurrent name edit remained.
- Project archive repository behavior -> node ../../node_modules/vitest/vitest.mjs run src/main/projects/repository.test.ts -> 15 passed.
- SQLite persistence and migration-adapter compatibility -> node ../../node_modules/vitest/vitest.mjs run src/main/database/application-database.integration.test.ts -> 22 passed.
- Changed TypeScript lint -> targeted ESLint for the three changed files -> passed.
- Changed-file formatting -> targeted Prettier check -> passed.
- Patch integrity -> git diff --check -> passed.
- Local Node typecheck -> attempted; blocked by the shared local dependency tree not having the repository patch-package export waitForMcpServers. The unrelated error was in src/main/acp/claude-agent-acp-patch.test.ts.
- PR Static checks -> clean dependency install, Node/Web typecheck, lint, formatting, interface contract, and i18n checks -> passed.
- PR Module tests and coverage -> passed.
- Independent Codex review -> mergeable, no actionable findings.

The repository impact classifier selected a conservative plan because application-database.integration.test.ts has no module owner. Per local-test scope, the complete CI-selected plan is authoritative. The macOS build and E2E job remains queued at the time of this update.

## Review focus

- The raw SQL updates only archivedAt and retains CAS behavior for both NULL and timestamp archive states.
- A failed CAS still reports Project not found for missing or deleted rows and Project archive state changed elsewhere for a live state conflict.
- The regression observes public repository behavior through real SQLite rather than production-only test seams.