### PR TITLE
fix(connectors): bound parser response resources

### DIFF
--- a/src/main/connectors/engine.test.ts
+++ b/src/main/connectors/engine.test.ts
@@ -151,6 +151,120 @@ describe('ParserEngine declarative path', () => {
     expect(fetchImpl).toHaveBeenCalledOnce()
   })
 
+  it('enforces a tool total deadline while response body chunks keep arriving', async () => {
+    const encoder = new TextEncoder()
+    const fetchImpl = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const chunks = ['{"value":', '9', '}', ' ']
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              init?.signal?.addEventListener('abort', () => controller.error(init.signal?.reason), {
+                once: true
+              })
+            },
+            async pull(controller) {
+              await new Promise((resolve) => setTimeout(resolve, 10))
+              if (init?.signal?.aborted) return
+              const next = chunks.shift()
+              if (next === undefined) controller.close()
+              else controller.enqueue(encoder.encode(next))
+            }
+          })
+        )
+      }
+    )
+    const engine = new ParserEngine({
+      fetchImpl,
+      timeoutMs: 30,
+      retries: 0,
+      retryBackoffMs: 0
+    })
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      totalTimeoutMs: 25,
+      url: () => 'https://x.test/data',
+      parse: (raw) => raw
+    }
+
+    await expect(engine.call(desc, {}, {})).rejects.toMatchObject({
+      name: 'ConnectorRequestTimeoutError',
+      message:
+        'Connector request exceeded the 25ms total deadline after 1 attempt for https://x.test/data'
+    })
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a response as soon as it exceeds the tool byte limit', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('abcdef'))
+    const engine = new ParserEngine({ fetchImpl, retries: 2, retryBackoffMs: 0 })
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      format: 'text',
+      maxResponseBytes: 5,
+      url: () => 'https://x.test/data',
+      parse: (raw) => raw
+    }
+
+    await expect(engine.call(desc, {}, {})).rejects.toMatchObject({
+      name: 'ConnectorResponseTooLargeError',
+      message: 'Connector response exceeded the 5-byte limit for https://x.test/data'
+    })
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
+  it('allows a tool to raise both engine response budgets', async () => {
+    const encoder = new TextEncoder()
+    const fetchImpl = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit): Promise<Response> =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              const timer = setTimeout(() => {
+                controller.enqueue(encoder.encode('abcdef'))
+                controller.close()
+              }, 10)
+              init?.signal?.addEventListener(
+                'abort',
+                () => {
+                  clearTimeout(timer)
+                  controller.error(init.signal?.reason)
+                },
+                { once: true }
+              )
+            }
+          })
+        )
+    )
+    const engine = new ParserEngine({
+      fetchImpl,
+      timeoutMs: 30,
+      totalTimeoutMs: 5,
+      maxResponseBytes: 5,
+      retries: 0
+    })
+    const desc: ToolDescriptor = {
+      id: 't',
+      connector: 'c',
+      description: '',
+      input: {},
+      format: 'text',
+      totalTimeoutMs: 50,
+      maxResponseBytes: 6,
+      url: () => 'https://x.test/data',
+      parse: (raw) => raw
+    }
+
+    await expect(engine.call(desc, {}, {})).resolves.toBe('abcdef')
+    expect(fetchImpl).toHaveBeenCalledOnce()
+  })
+
   it('times out and retries when a response body stops producing chunks', async () => {
     const encoder = new TextEncoder()
     const fetchImpl = vi.fn(

--- a/src/main/connectors/engine.ts
+++ b/src/main/connectors/engine.ts
@@ -1,6 +1,8 @@
 import type { ConnectorCredentials, ToolContext, ToolDescriptor } from './types'
 
 const DEFAULT_TIMEOUT_MS = 30_000
+const DEFAULT_TOTAL_TIMEOUT_MS = 120_000
+const DEFAULT_MAX_RESPONSE_BYTES = 64 * 1024 * 1024
 
 // Transient-failure retry policy shared by every connector call. Public bio APIs (PubChem PUG-REST,
 // GTEx, NCBI) routinely return 429/5xx or a brief timeout under load; a couple of backed-off retries
@@ -55,10 +57,20 @@ function redactUrl(url: string): string {
 class ConnectorRequestTimeoutError extends Error {
   override readonly name = 'ConnectorRequestTimeoutError'
 
-  constructor(url: string, timeoutMs: number, attempts: number) {
+  constructor(url: string, timeoutMs: number, attempts: number, kind: 'idle' | 'total' = 'idle') {
     super(
-      `Connector request timed out after ${attempts} ${attempts === 1 ? 'attempt' : 'attempts'} of ${timeoutMs}ms for ${redactUrl(url)}`
+      kind === 'total'
+        ? `Connector request exceeded the ${timeoutMs}ms total deadline after ${attempts} ${attempts === 1 ? 'attempt' : 'attempts'} for ${redactUrl(url)}`
+        : `Connector request timed out after ${attempts} ${attempts === 1 ? 'attempt' : 'attempts'} of ${timeoutMs}ms for ${redactUrl(url)}`
     )
+  }
+}
+
+class ConnectorResponseTooLargeError extends Error {
+  override readonly name = 'ConnectorResponseTooLargeError'
+
+  constructor(url: string, maxResponseBytes: number) {
+    super(`Connector response exceeded the ${maxResponseBytes}-byte limit for ${redactUrl(url)}`)
   }
 }
 
@@ -66,17 +78,23 @@ class ConnectorRequestTimeoutError extends Error {
 export class ParserEngine {
   private readonly fetchImpl: typeof fetch
   private readonly timeoutMs: number
+  private readonly totalTimeoutMs: number
+  private readonly maxResponseBytes: number
   private readonly retries: number
   private readonly backoffMs: number
 
   constructor(opts?: {
     fetchImpl?: typeof fetch
     timeoutMs?: number
+    totalTimeoutMs?: number
+    maxResponseBytes?: number
     retries?: number
     retryBackoffMs?: number
   }) {
     this.fetchImpl = opts?.fetchImpl ?? fetch
     this.timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    this.totalTimeoutMs = opts?.totalTimeoutMs ?? DEFAULT_TOTAL_TIMEOUT_MS
+    this.maxResponseBytes = opts?.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES
     this.retries = opts?.retries ?? DEFAULT_RETRIES
     this.backoffMs = opts?.retryBackoffMs ?? DEFAULT_BACKOFF_MS
   }
@@ -91,7 +109,12 @@ export class ParserEngine {
     for (const key of descriptor.required ?? []) {
       if (args[key] == null) throw new Error(`missing required arg: ${key}`)
     }
-    const ctx = this.makeContext(credentials, signal)
+    const ctx = this.makeContext(
+      credentials,
+      signal,
+      descriptor.totalTimeoutMs ?? this.totalTimeoutMs,
+      descriptor.maxResponseBytes ?? this.maxResponseBytes
+    )
     if (descriptor.run) {
       const result = await descriptor.run(ctx, args)
       signal?.throwIfAborted()
@@ -105,7 +128,12 @@ export class ParserEngine {
     return descriptor.parse(raw, args)
   }
 
-  private makeContext(credentials: ConnectorCredentials, signal?: AbortSignal): ToolContext {
+  private makeContext(
+    credentials: ConnectorCredentials,
+    signal: AbortSignal | undefined,
+    totalTimeoutMs: number,
+    maxResponseBytes: number
+  ): ToolContext {
     // Delay before the next attempt: honour a numeric Retry-After (seconds, capped), else exponential
     // backoff with jitter off the configured base.
     const nextDelay = (attempt: number, retryAfter: string | null): number => {
@@ -121,15 +149,17 @@ export class ParserEngine {
     ): Promise<{ response: Response; bodyText?: string }> => {
       for (let attempt = 0; ; attempt++) {
         const controller = new AbortController()
-        let timer: ReturnType<typeof setTimeout> | undefined
-        let timedOut = false
-        const armTimeout = (): void => {
-          if (timer) clearTimeout(timer)
-          timer = setTimeout(() => {
-            timedOut = true
-            controller.abort()
-          }, this.timeoutMs)
+        let idleTimer: ReturnType<typeof setTimeout> | undefined
+        let timedOut: 'idle' | 'total' | undefined
+        const abortForTimeout = (kind: 'idle' | 'total'): void => {
+          timedOut ??= kind
+          controller.abort()
         }
+        const armTimeout = (): void => {
+          if (idleTimer) clearTimeout(idleTimer)
+          idleTimer = setTimeout(() => abortForTimeout('idle'), this.timeoutMs)
+        }
+        const totalTimer = setTimeout(() => abortForTimeout('total'), totalTimeoutMs)
         const requestSignal = signal
           ? AbortSignal.any([controller.signal, signal])
           : controller.signal
@@ -148,12 +178,19 @@ export class ParserEngine {
             const reader = res.body.getReader()
             const decoder = new TextDecoder()
             const chunks: string[] = []
+            let responseBytes = 0
             try {
               armTimeout()
               for (;;) {
                 const chunk = await reader.read()
                 if (chunk.done) break
                 if (chunk.value.byteLength === 0) continue
+                responseBytes += chunk.value.byteLength
+                if (responseBytes > maxResponseBytes) {
+                  const error = new ConnectorResponseTooLargeError(url, maxResponseBytes)
+                  controller.abort(error)
+                  throw error
+                }
                 chunks.push(decoder.decode(chunk.value, { stream: true }))
                 armTimeout()
               }
@@ -167,17 +204,24 @@ export class ParserEngine {
           caught = true
           failure = err
         } finally {
-          if (timer) clearTimeout(timer)
+          if (idleTimer) clearTimeout(idleTimer)
+          if (totalTimer) clearTimeout(totalTimer)
         }
         if (caught) {
           if (signal?.aborted) throw failure
+          if (failure instanceof ConnectorResponseTooLargeError) throw failure
           // Network failure or timeout abort — retry a bounded number of times, then give up.
           if (attempt < this.retries) {
             await sleep(nextDelay(attempt, null), signal)
             continue
           }
           if (timedOut) {
-            throw new ConnectorRequestTimeoutError(url, this.timeoutMs, attempt + 1)
+            throw new ConnectorRequestTimeoutError(
+              url,
+              timedOut === 'total' ? totalTimeoutMs : this.timeoutMs,
+              attempt + 1,
+              timedOut
+            )
           }
           throw failure
         }

--- a/src/main/connectors/types.ts
+++ b/src/main/connectors/types.ts
@@ -28,6 +28,10 @@ export type ToolDescriptor = {
   example?: string
   required?: string[]
   format?: 'json' | 'text'
+  // Per-attempt wall-clock deadline, including response-body streaming. Overrides the engine default.
+  totalTimeoutMs?: number
+  // Raw response-body budget. Overrides the engine default for tools with unusually small or large payloads.
+  maxResponseBytes?: number
   url?: (args: Record<string, unknown>) => string
   parse?: (raw: unknown, args: Record<string, unknown>) => unknown
   run?: (ctx: ToolContext, args: Record<string, unknown>) => Promise<unknown>


### PR DESCRIPTION
## Problem

ParserEngine treated its 30-second timer as an idle timeout because every non-empty response chunk rearmed it. A continuously streaming upstream could therefore keep a connector request alive indefinitely while every decoded chunk accumulated in memory without a byte limit.

## Proposed change

- keep the existing 30-second idle timeout
- add a 120-second per-attempt wall-clock deadline that is never rearmed
- reject raw response bodies above the 64 MiB default before retaining the excess chunk
- allow each ToolDescriptor to raise or lower totalTimeoutMs and maxResponseBytes
- keep oversized-response failures non-retryable to avoid multiplying deterministic resource use

## Scope and non-goals

This changes only the in-memory connector execution contract. It does not change UI interactions, persistence, database schemas, historical data, or status enums. HTTP code paths that do not use ParserEngine or its ToolContext are outside this PR.

## Acceptance criteria and validation

- continuously arriving chunks cannot extend one attempt beyond its total deadline
- response buffering stops when the raw byte budget is exceeded
- tool descriptors can choose smaller or larger budgets than engine defaults
- existing idle timeout, retry, cancellation, and connector parsing behavior remains intact

Final-state evidence after the last material edit:

- total-deadline regression -> targeted Vitest on the unmodified implementation -> failed twice because the stream resolved after exceeding the declared deadline
- response-byte regression -> targeted Vitest on the unmodified implementation -> failed because the six-byte response resolved under a five-byte tool limit
- ParserEngine and all bundled connector behavior -> node D:/projects/aipoch/open-science/node_modules/vitest/vitest.mjs run src/main/connectors -> 56 files passed; 770 tests passed; 39 skipped
- lint -> npm run lint -> passed
- Node typecheck -> npm run typecheck:node -> locally blocked by the shared main-checkout dependency tree: the installed @agentclientprotocol/claude-agent-acp package does not export waitForMcpServers expected by this worktree lockfile. No private worktree dependency install was performed; clean PR CI is authoritative.

No renderer, persistence, migration, platform-specific, or external protocol lanes are needed based on the final diff. The optional ToolDescriptor interface fields are exercised through ParserEngine and every bundled connector test; clean CI will provide the Node typecheck unavailable in the shared local dependency environment.

## Review focus

Please review the per-attempt deadline semantics, the 64 MiB default, and whether the error messages provide enough context while continuing to redact credential query parameters.