### PR TITLE
fix(session-persistence): preserve unknown framework identifiers

### DIFF
--- a/src/main/artifacts/provenance-snapshot-decoder.test.ts
+++ b/src/main/artifacts/provenance-snapshot-decoder.test.ts
@@ -47,6 +47,30 @@ const executionSnapshot = (schemaVersion: number): Record<string, unknown> => ({
 })
 
 describe('Artifact persistence decoders', () => {
+  it('preserves attribution from a not-yet-known Agent framework', () => {
+    const decoded = decodeArtifactMessageSnapshot(
+      JSON.stringify({
+        ...messageSnapshot(3),
+        messages: [
+          {
+            id: 'message-1',
+            role: 'agent',
+            content: 'Persist me',
+            createdAt: 1,
+            agentAttribution: { frameworkId: 'future-acp' }
+          }
+        ]
+      })
+    )
+
+    expect(decoded).toMatchObject({
+      status: 'valid',
+      value: {
+        messages: [{ agentAttribution: { frameworkId: 'future-acp' } }]
+      }
+    })
+  })
+
   it('classifies Message v3 as valid, v2 as legacy, and future versions as unsupported', () => {
     expect(decodeArtifactMessageSnapshot(JSON.stringify(messageSnapshot(3))).status).toBe('valid')
     expect(decodeArtifactMessageSnapshot(JSON.stringify(messageSnapshot(2))).status).toBe('legacy')

--- a/src/main/artifacts/provenance-snapshot-decoder.ts
+++ b/src/main/artifacts/provenance-snapshot-decoder.ts
@@ -164,9 +164,8 @@ const messageValue = (value: unknown): boolean => {
     const attribution = recordValue(message.agentAttribution)
     if (
       !attribution ||
-      (attribution.frameworkId !== 'claude-code' &&
-        attribution.frameworkId !== 'opencode' &&
-        attribution.frameworkId !== 'codex') ||
+      typeof attribution.frameworkId !== 'string' ||
+      attribution.frameworkId.trim().length === 0 ||
       !optionalString(attribution.agentName) ||
       !optionalString(attribution.model)
     ) {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -192,9 +192,8 @@ const TurnTokenUsage = ({
   const providers = useSettingsStore((state) =>
     open && runtimeIdentity ? state.providers : undefined
   )
-  const frameworkName = frameworks?.find(
-    (framework) => framework.id === runtimeIdentity?.frameworkId
-  )?.displayName
+  const framework = frameworks?.find((framework) => framework.id === runtimeIdentity?.frameworkId)
+  const frameworkName = framework?.displayName
   const providerId = resolveSessionProviderId(runtimeIdentity?.backendId)
   const provider = providers?.find((candidate) => candidate.id === providerId)
   const kindKey = provider ? providerKindKey(provider.type, provider.vendorId) : undefined
@@ -322,7 +321,7 @@ const TurnTokenUsage = ({
             <div className="text-[13px] font-medium">{t('Usage')}</div>
             {frameworkName || provider ? (
               <div data-slot="turn-runtime-icons" className="flex items-center gap-1">
-                {frameworkName && runtimeIdentity?.frameworkId ? (
+                {framework ? (
                   <span
                     data-slot="turn-runtime-framework"
                     role="img"
@@ -330,7 +329,7 @@ const TurnTokenUsage = ({
                     title={t('Agent framework: {{name}}', { name: frameworkName })}
                     className="inline-flex size-5 items-center justify-center rounded-full border border-border bg-background"
                   >
-                    <AgentFrameworkIcon frameworkId={runtimeIdentity.frameworkId} size={12} />
+                    <AgentFrameworkIcon frameworkId={framework.id} size={12} />
                   </span>
                 ) : null}
                 {provider && kindKey ? (

--- a/src/shared/artifact-provenance.ts
+++ b/src/shared/artifact-provenance.ts
@@ -7,7 +7,6 @@ import type {
   NotebookRunInputFile,
   NotebookRunStatus
 } from './notebook'
-import type { AgentFrameworkId } from './settings'
 import type {
   MessageAttribution,
   PersistedActivityGroup,
@@ -544,7 +543,7 @@ export type ProvenanceMessage = {
   createdAt: number
   hasOmittedMedia?: boolean
   agentAttribution?: {
-    frameworkId: AgentFrameworkId
+    frameworkId: string
     agentName?: string
     model?: string
   }

--- a/src/shared/conversation-graph.ts
+++ b/src/shared/conversation-graph.ts
@@ -9,7 +9,8 @@ import { parseNestedDelegateInvocationId } from './delegated-caller-source'
 export type PersistedRuntimeSegment = {
   id: string
   agentFrameId: string
-  frameworkId: AgentFrameworkId
+  // Historical evidence may outlive the runtime's current framework registry.
+  frameworkId: string
   backendId?: string
   agentName?: string
   model?: string

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -255,6 +255,45 @@ const createHistoricalPlan = (): ActivePlanProjection => ({
 })
 
 describe('conversation graph materialization diagnostics', () => {
+  it('preserves a conversation written by a not-yet-known Agent framework', () => {
+    const messages: PersistedChatMessage[] = [
+      {
+        id: 'message-1',
+        role: 'user',
+        content: 'Persist me',
+        status: 'complete',
+        eventIds: [],
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ]
+    const conversationGraph = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages,
+      createdAt: 1,
+      updatedAt: 1
+    })
+    conversationGraph.runtimeSegments[0].frameworkId = 'future-acp'
+
+    const decoded = decodeSessionFile({
+      version: SESSION_FILE_VERSION,
+      session: {
+        ...createSessionWithActivity(undefined),
+        messages,
+        conversationGraph
+      }
+    })
+
+    expect(decoded).toMatchObject({
+      status: 'ok',
+      session: {
+        conversationGraph: {
+          runtimeSegments: [{ frameworkId: 'future-acp' }]
+        }
+      }
+    })
+  })
+
   it('writes a canonical graph while retaining flat messages as the active projection', () => {
     const session: PersistedChatSession = {
       id: 'session-1',

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -3393,15 +3393,9 @@ const sanitizeConversationGraph = (
         if (!isRecord(candidate)) return []
         const id = asString(candidate.id)
         const agentFrameId = asString(candidate.agentFrameId)
-        const frameworkId = asString(candidate.frameworkId) as AgentFrameworkId | undefined
+        const frameworkId = asString(candidate.frameworkId)
         const startedAt = asNumber(candidate.startedAt)
-        if (
-          !id ||
-          !agentFrameId ||
-          !frameworkId ||
-          !AGENT_FRAMEWORK_IDS.has(frameworkId) ||
-          startedAt === undefined
-        ) {
+        if (!id || !agentFrameId || !frameworkId || startedAt === undefined) {
           return []
         }
         return [


### PR DESCRIPTION
## Summary

- preserve unknown Agent framework identifiers in persisted Conversation Graph runtime segments
- accept the same opaque identifiers in immutable Artifact provenance snapshots
- keep runtime framework selection and startup on the existing closed AgentFrameworkId enum
- render framework metadata only when the persisted identifier matches a configured framework

## Root cause

A Session written by a branch that introduced a new ACP framework could be opened by an older branch whose sanitizer knew only claude-code, opencode, and codex. The sanitizer dropped the unknown runtime segment, graph validation then failed because Messages still referenced it, and the repository quarantined the Session file. Any quarantine warning made the Project catalog incomplete, so Home displayed Session count unavailable for every Project.

## Test plan

- targeted Session persistence and provenance decoder tests: 141 passed
- npm run test:module -- artifact_provenance: 1371 passed
- npm run test:module -- session_persistence: 347 passed
- npm run test:module -- workspace_page: 544 passed
- typecheck:node
- typecheck:web
- eslint

The first artifact_provenance run was blocked by sandbox socket permissions; the same module passed outside the sandbox.

## Compatibility and persistence

- Historical compatibility: unknown non-empty framework identifiers are preserved as opaque evidence. Older builds can read and count Sessions created by a newer or experimental ACP, but they still cannot start or resume that unknown framework.
- Existing quarantined data: this PR does not restore or rewrite the five current .json.invalid-* files. Recovery remains a separate explicit data operation.
- Enum changes: none.
- Database schema or migration changes: none.
- Persisted contract: PersistedRuntimeSegment.frameworkId and provenance agentAttribution.frameworkId are widened from AgentFrameworkId to non-empty string on read; new runtime configuration remains closed.