### PR TITLE
fix(acp): guide provider connection failures

### DIFF
--- a/src/main/acp/prompt-error.ts
+++ b/src/main/acp/prompt-error.ts
@@ -1,5 +1,6 @@
 import {
   isClaudeApiConnectionFailure,
+  PROVIDER_CONNECTION_FAILED_PREFIX,
   PROVIDER_RESOURCE_NOT_FOUND_PREFIX
 } from '../../shared/run-error-classification'
 
@@ -142,11 +143,34 @@ const isProviderNotFound = (
   return isApiError(error) || /resource_not_found/i.test(raw) || hasNotFoundType
 }
 
-// Produces the session-visible error text for a failed prompt: an actionable message for a provider
-// not-found, else the original message untouched.
+// claude-agent-acp currently forwards some explicit provider 4xx and connect-time failures as a
+// generic ACP internal RequestError with `data.errorKind: 'unknown'`. The fixed wrapper and JSON-RPC
+// code are the remaining machine-stable boundary; require both so ordinary app errors containing a
+// status number or the word "connect" stay reportable. Do not infer 5xx ownership here:
+// provider-tagged 5xx errors still use the structural APIError/provider-error paths above, while an
+// untagged internal 5xx may be an adapter defect.
+const isClaudeProviderApiError = (error: unknown): boolean =>
+  error instanceof Error &&
+  error.name === 'RequestError' &&
+  errorCode(error) === -32603 &&
+  (CLAUDE_PROVIDER_CLIENT_ERROR_PATTERN.test(error.message) ||
+    isClaudeApiConnectionFailure(error.message))
+
+const connectionFailureDetail = (message: string): string | undefined =>
+  message.match(/\(([A-Za-z][A-Za-z0-9_-]{0,63})\)\s*$/)?.[1]
+
+// Produces the session-visible error text for a failed prompt: actionable guidance for recognized
+// provider configuration/connectivity failures, else the original message untouched.
 export const describePromptError = (error: unknown, ctx: PromptErrorContext = {}): string => {
   const raw = rawErrorMessage(error)
   const detail = extractUpstreamDetail(raw)
+
+  if (isClaudeProviderApiError(error) && isClaudeApiConnectionFailure(raw)) {
+    const modelPart = ctx.model ? ` for model "${ctx.model}"` : ''
+    const connectionDetail = connectionFailureDetail(raw)
+
+    return `${PROVIDER_CONNECTION_FAILED_PREFIX}${modelPart}. Check the base URL in Settings → Model and your proxy, VPN, or firewall, then retry.${connectionDetail ? ` Connection detail: ${connectionDetail}.` : ''}`
+  }
 
   if (!isProviderNotFound(error, raw, detail)) return raw
 
@@ -174,19 +198,6 @@ const isProviderErrorKind = (error: unknown): boolean => {
     return false
   }
 }
-
-// claude-agent-acp currently forwards some explicit provider 4xx and connect-time failures as a
-// generic ACP internal RequestError with `data.errorKind: 'unknown'`. The fixed wrapper and JSON-RPC
-// code are the remaining machine-stable boundary; require both so ordinary app errors containing a
-// status number or the word "connect" stay reportable. Do not infer 5xx ownership here:
-// provider-tagged 5xx errors still use the structural APIError/provider-error paths above, while an
-// untagged internal 5xx may be an adapter defect.
-const isClaudeProviderApiError = (error: unknown): boolean =>
-  error instanceof Error &&
-  error.name === 'RequestError' &&
-  errorCode(error) === -32603 &&
-  (CLAUDE_PROVIDER_CLIENT_ERROR_PATTERN.test(error.message) ||
-    isClaudeApiConnectionFailure(error.message))
 
 // Whether a failed prompt originates from the model provider (an upstream LLM/HTTP failure the agent
 // relayed) rather than from the app's own ACP layer. Provider failures are the user's/provider's to

--- a/src/main/acp/prompt-outcome-finalizer.test.ts
+++ b/src/main/acp/prompt-outcome-finalizer.test.ts
@@ -309,6 +309,33 @@ describe('AcpPromptOutcomeFinalizer', () => {
     )
   })
 
+  it('guides the user when Claude Code cannot connect to the model provider', async () => {
+    const harness = createHarness({ now: () => 321 })
+    const error = Object.assign(
+      new Error('Internal error: API Error: Unable to connect to API (ConnectionRefused)'),
+      {
+        code: -32603,
+        data: { errorKind: 'unknown' },
+        name: 'RequestError'
+      }
+    )
+
+    await expect(
+      new AcpPromptOutcomeFinalizer().finalize(harness.handles, {
+        kind: 'failed',
+        error
+      })
+    ).rejects.toBe(error)
+
+    expect(harness.events).toContainEqual(
+      expect.objectContaining({
+        kind: 'error',
+        providerError: true,
+        text: 'Could not connect to the model provider for model "test-model". Check the base URL in Settings → Model and your proxy, VPN, or firewall, then retry. Connection detail: ConnectionRefused.'
+      })
+    )
+  })
+
   it.each([
     {
       name: 'context overflow',

--- a/src/main/settings/anthropic-provider-bridge.test.ts
+++ b/src/main/settings/anthropic-provider-bridge.test.ts
@@ -184,6 +184,51 @@ describe('AnthropicProviderBridge', () => {
     expect(upstreamHeaders?.get('x-request-id')).toBe('request-1')
   })
 
+  it('logs a redacted upstream connection failure after the loopback request arrives', async () => {
+    const cause = Object.assign(new Error('connect ECONNREFUSED 203.0.113.1:443'), {
+      code: 'ECONNREFUSED'
+    })
+    const fetchImpl = vi.fn(async () => {
+      throw new TypeError('fetch failed', { cause })
+    }) as typeof fetch
+    const diagnostics = { info: vi.fn(), error: vi.fn() }
+    const target = {
+      id: 'provider/model-a',
+      baseUrl: 'https://user:provider-secret@provider.example.test/gateway?api_key=query-secret',
+      key: 'key-a',
+      model: 'model-a'
+    }
+    const bridge = new AnthropicProviderBridge([target], target.id, fetchImpl, diagnostics)
+    bridges.push(bridge)
+    const connection = await bridge.start()
+
+    const response = await fetch(`${connection.baseUrl}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${connection.token}`,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ model: 'ignored', messages: [] })
+    })
+
+    expect(response.status).toBe(502)
+    await expect(response.json()).resolves.toEqual({
+      error: { type: 'api_error', message: 'fetch failed' }
+    })
+    expect(diagnostics.error).toHaveBeenCalledWith(
+      'anthropic provider request failed',
+      expect.objectContaining({
+        targetId: target.id,
+        upstreamOrigin: 'https://provider.example.test',
+        error: 'fetch failed',
+        cause: expect.objectContaining({ code: 'ECONNREFUSED' })
+      })
+    )
+    expect(JSON.stringify(diagnostics.error.mock.calls)).not.toContain('provider-secret')
+    expect(JSON.stringify(diagnostics.error.mock.calls)).not.toContain('query-secret')
+    expect(JSON.stringify(diagnostics.error.mock.calls)).not.toContain('key-a')
+  })
+
   it('replays an identical deterministic provider error without a second upstream request', async () => {
     const fetchImpl = vi.fn(async () =>
       Response.json(

--- a/src/main/settings/anthropic-provider-bridge.ts
+++ b/src/main/settings/anthropic-provider-bridge.ts
@@ -2,6 +2,7 @@ import type { ServerResponse } from 'node:http'
 import { Readable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 
+import { createLogger, errorLogFields, type Logger } from '../logger'
 import { normalizeAnthropicBaseUrl } from './base-url'
 import {
   ProviderLoopbackHttpHost,
@@ -37,6 +38,16 @@ type ProviderErrorSnapshot = Readonly<{
   headers: Record<string, string>
   status: number
 }>
+
+const defaultDiagnostics = createLogger('provider-loopback')
+
+const upstreamOrigin = (baseUrl: string): string | undefined => {
+  try {
+    return new URL(baseUrl).origin
+  } catch {
+    return undefined
+  }
+}
 
 export type AnthropicProviderBridgeTarget = Readonly<{
   id: string
@@ -87,17 +98,20 @@ export class AnthropicProviderBridge {
   private readonly host: ProviderLoopbackHttpHost<AnthropicProviderBridgeConnection>
   private target: AnthropicProviderBridgeTarget
   private readonly fetchImpl: typeof fetch
+  private readonly diagnostics: Pick<Logger, 'error'>
   private readonly deterministicErrors =
     new DeterministicProviderErrorReplay<ProviderErrorSnapshot>()
 
   constructor(
     targets: readonly AnthropicProviderBridgeTarget[],
     initialTargetId: string,
-    fetchImpl: typeof fetch = fetch
+    fetchImpl: typeof fetch = fetch,
+    diagnostics: Pick<Logger, 'error'> = defaultDiagnostics
   ) {
     this.targets = new Map(targets.map((target) => [target.id, target]))
     const initial = this.targets.get(initialTargetId)
     this.fetchImpl = fetchImpl
+    this.diagnostics = diagnostics
     if (!initial) throw new Error('The initial Anthropic bridge target is not registered.')
     this.target = initial
     this.host = new ProviderLoopbackHttpHost({
@@ -182,13 +196,25 @@ export class AnthropicProviderBridge {
     }
     const baseUrl = normalizeAnthropicBaseUrl(target.baseUrl)
     if (!baseUrl) throw new Error('The Anthropic provider target has no valid base URL.')
-    const upstream = await this.fetchImpl(`${baseUrl}${requestUrl.pathname}${requestUrl.search}`, {
-      method: 'POST',
-      headers: headersToForward,
-      body,
-      redirect: 'manual',
-      signal: request.signal
-    })
+    let upstream: Response
+    try {
+      upstream = await this.fetchImpl(`${baseUrl}${requestUrl.pathname}${requestUrl.search}`, {
+        method: 'POST',
+        headers: headersToForward,
+        body,
+        redirect: 'manual',
+        signal: request.signal
+      })
+    } catch (error) {
+      const origin = upstreamOrigin(baseUrl)
+      this.diagnostics.error('anthropic provider request failed', {
+        targetId: target.id,
+        path: requestUrl.pathname,
+        ...(origin ? { upstreamOrigin: origin } : {}),
+        ...errorLogFields(error)
+      })
+      throw error
+    }
     const headers = responseHeaders(upstream.headers)
     if (isDeterministicProviderErrorStatus(upstream.status)) {
       const upstreamBody = await readBoundedProviderErrorBody(upstream, {

--- a/src/shared/run-error-classification.test.ts
+++ b/src/shared/run-error-classification.test.ts
@@ -91,6 +91,14 @@ describe('isReportableRunFailure (text tier)', () => {
     expect(isReportableRunFailure('Run failed: connection reset')).toBe(true)
   })
 
+  it('recognizes the actionable provider connection reminder without the structural flag', () => {
+    expect(
+      isReportableRunFailure(
+        'Could not connect to the model provider for model "test-model". Check the base URL in Settings → Model and your proxy, VPN, or firewall, then retry. Connection detail: ConnectionRefused.'
+      )
+    ).toBe(false)
+  })
+
   it('does not swallow an ordinary app error that merely mentions a provider word', () => {
     // The text tier only matches the app's own exact strings, so an internal failure that happens to
     // contain a provider-ish word or number is never mistaken for an expected failure.

--- a/src/shared/run-error-classification.ts
+++ b/src/shared/run-error-classification.ts
@@ -100,6 +100,7 @@ export const buildActiveModelIncompatibleMessage = (frameworkDisplayName: string
 // classifier).
 export const PROVIDER_RESOURCE_NOT_FOUND_PREFIX =
   'The model provider could not find the requested resource'
+export const PROVIDER_CONNECTION_FAILED_PREFIX = 'Could not connect to the model provider'
 
 // Claude Code's fixed unreachable-API wrapper. Recognized here so createSession failRun and persisted
 // pre-flag sessions hide Report without a stored-schema migration. Match the distinctive
@@ -144,6 +145,8 @@ export const isExpectedRunFailure = (error: string | null | undefined): boolean 
   if (isUnsupportedCodexAcpVersionError(message)) return true
   // The reworded provider not-found (a model-config problem the user fixes in Settings, not a bug).
   if (message.startsWith(PROVIDER_RESOURCE_NOT_FOUND_PREFIX)) return true
+  // The actionable provider connection reminder produced for Claude Code connection failures.
+  if (message.startsWith(PROVIDER_CONNECTION_FAILED_PREFIX)) return true
   // Model↔framework incompatibility raised at spawn/createSession. The main-side message names the
   // framework (`…compatible with Codex.`) while the resume path rewords it to a generic form; both
   // share this leading phrase, so one prefix covers the createSession path (which is not reworded) and


### PR DESCRIPTION
## Problem

Claude Code reports an unreachable model endpoint as the opaque error `Internal error: API Error: Unable to connect to API (ConnectionRefused)`. Open Science already classifies this as provider-owned, but the conversation still gives the user no recovery steps. Anthropic loopback diagnostics also record only listener lifecycle, so a support log cannot distinguish a request that reached the bridge and failed upstream from one that never reached the bridge.

Related: #1582

## Proposed change

- Reword only the structurally verified Claude `RequestError(-32603)` connection wrapper into actionable model-provider, Base URL, proxy, VPN, and firewall guidance while retaining the bounded connection detail.
- Keep the new reminder classified as an expected provider failure even when a persisted session lacks the structural reportability flag.
- Log Anthropic upstream fetch failures after the authenticated loopback request arrives, including only the target ID, request path, credential-free upstream origin, and the existing log-sanitized error fields.

## Scope and non-goals

- No automatic retry or connection-policy change; Claude Code already performs its provider retry cycle.
- No new field, enum value, schema, migration, domain-model change, or API change.
- Future failed Sessions persist the actionable error text instead of the raw wrapper. Historical raw errors remain recognized without migration.
- The display rewrite is Claude Code-specific. OpenCode and Codex behavior is unchanged. The new upstream diagnostic applies to the Anthropic provider bridge shared by the relevant Claude/OpenCode Anthropic route.

## Acceptance criteria and validation

The regression tests were first run against the unfixed code and failed for the reported reasons: the finalizer emitted the raw wrapper, the actionable reminder was reportable without a structural flag, and the real loopback boundary emitted no upstream-failure diagnostic.

Final evidence after the last material edit:

- Connection failure guidance and provider classification -> `vitest run src/main/acp/prompt-error.test.ts src/main/acp/prompt-outcome-finalizer.test.ts src/shared/run-error-classification.test.ts` (included in the focused set below) -> passed.
- Anthropic upstream failure logging and credential redaction -> `vitest run src/main/settings/anthropic-provider-bridge.test.ts` -> 9 passed.
- Prompt, bridge-constructor consumer, persistence fallback, and renderer error presentation -> focused six-file Vitest set -> 191 passed.
- Node process types -> `tsc --noEmit -p tsconfig.node.json --composite false` -> passed.
- Web/shared consumer types -> `tsc --noEmit -p tsconfig.web.json --composite false` -> passed.
- Lint -> `eslint --cache .` -> passed.
- Changed-file formatting -> `prettier --check ...` -> passed.

`npm run test:module -- settings_backend_resolution` ran 617 tests: 612 passed, 4 skipped, and one unrelated baseline architecture assertion failed because unchanged `src/main/settings/service.ts` is 1071 lines while its ceiling is 1070. The final diff does not modify that file. `npm run test:affected -- --base origin/main --head HEAD --explain` fails closed to the complete suite because `src/main/acp/prompt-error.ts` has no module owner; per maintainer direction the complete suite is left to PR CI.

Platform risk: the report is from Windows and the selected settings module carries `windows_sensitive`; local validation covered platform-neutral protocol/error behavior and real loopback HTTP on macOS, while PR CI remains authoritative for Windows.

## Review focus

- The rewrite must remain gated by the Claude `RequestError` name, JSON-RPC code, and fixed API connection wrapper so nearby app errors stay untouched.
- Diagnostic fields must not expose credentials, request bodies, or full query-bearing URLs.
