### PR TITLE
fix(compute): harden remote job coordination

### DIFF
--- a/src/main/compute/concurrency-manager.test.ts
+++ b/src/main/compute/concurrency-manager.test.ts
@@ -483,6 +483,53 @@ describe('ConcurrencyManager', () => {
       expect(dispatchJob).toHaveBeenNthCalledWith(2, 'job-2', expect.any(Function))
     })
 
+    it('does not block another provider behind a slow dispatch', async () => {
+      const queuedJobs: ComputeJob[] = [
+        {
+          job_id: 'job-1',
+          project_id: 'project-1',
+          session_id: 'session-1',
+          provider_id: 'ssh:cluster-a',
+          created_at: 1000,
+          status: 'queued'
+        } as ComputeJob,
+        {
+          job_id: 'job-2',
+          project_id: 'project-2',
+          session_id: 'session-2',
+          provider_id: 'ssh:cluster-b',
+          created_at: 2000,
+          status: 'queued'
+        } as ComputeJob
+      ]
+      vi.mocked(jobRepo.findQueuedJobs).mockResolvedValue(queuedJobs)
+      vi.mocked(jobRepo.countActiveBySession).mockResolvedValue(0)
+      vi.mocked(jobRepo.countActiveByProvider).mockResolvedValue(0)
+      vi.mocked(hostRepo.get).mockResolvedValue({ concurrencyLimit: 1 } as ComputeHost)
+
+      let releaseFirstDispatch!: () => void
+      dispatchJob.mockImplementation(async (jobId) => {
+        if (jobId === 'job-1') {
+          await new Promise<void>((resolve) => {
+            releaseFirstDispatch = resolve
+          })
+        }
+      })
+
+      const reconciliation = manager.onJobCompleted()
+      await vi.waitFor(() =>
+        expect(dispatchJob).toHaveBeenCalledWith('job-1', expect.any(Function))
+      )
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      const secondStartedBeforeFirstFinished = dispatchJob.mock.calls.some(
+        ([jobId]) => jobId === 'job-2'
+      )
+      releaseFirstDispatch()
+      await reconciliation
+
+      expect(secondStartedBeforeFirstFinished).toBe(true)
+    })
+
     it('does not dispatch a queued projection after another writer changes its status', async () => {
       vi.mocked(jobRepo.findQueuedJobs).mockResolvedValue([
         {

--- a/src/main/compute/concurrency-manager.ts
+++ b/src/main/compute/concurrency-manager.ts
@@ -260,6 +260,7 @@ export class ConcurrencyManager {
       do {
         this.reconciliationRequested = false
         const queuedJobs = await this.jobRepository.findQueuedJobs()
+        const operations: Promise<void>[] = []
 
         for (const job of queuedJobs) {
           const owner = { projectId: job.project_id, sessionId: job.session_id }
@@ -291,12 +292,13 @@ export class ConcurrencyManager {
             }
           })()
           this.ownerOperations.set(operation, owner)
-          try {
-            await operation
-          } finally {
-            this.ownerOperations.delete(operation)
-          }
+          operations.push(
+            operation.finally(() => {
+              this.ownerOperations.delete(operation)
+            })
+          )
         }
+        await Promise.all(operations)
       } while (this.reconciliationRequested)
     } finally {
       this.dispatching = false

--- a/src/main/compute/job-deletion-owner.test.ts
+++ b/src/main/compute/job-deletion-owner.test.ts
@@ -147,10 +147,12 @@ describe('ComputeJobDeletionOwner', () => {
     const handle = JSON.parse(rawHandle) as Parameters<typeof cleanupCommand>[1]
     const command = cleanupCommand('~/.openscience/jobs/job-1', handle)
     expect(command).toContain('kill_job_pid() {')
+    expect(command).toContain('process_owned_by_workdir() {')
     expect(command).toContain('process_workdir=$(readlink "/proc/$pid/cwd"')
     expect(command).toContain('command -v lsof')
     expect(command).toContain('lsof -a -p "$pid" -d cwd -Fn')
-    expect(command).toContain('[ "$process_workdir" = "$workdir" ] || return 0')
+    expect(command).toContain('[ "$process_workdir" = "$expected_workdir" ]')
+    expect(command).toContain('process_owned_by_workdir "$pid" "$workdir" || return 0')
     expect(command).toContain('kill_job_pid 123')
     expect(command).not.toContain('kill -TERM -- -123')
     expect(command).toContain('[ ! -L ')

--- a/src/main/compute/job-deletion-owner.ts
+++ b/src/main/compute/job-deletion-owner.ts
@@ -1,6 +1,11 @@
 import type { ComputeJob } from '../../shared/compute'
 import { sharedDispatchTracker, type DispatchTracker } from './dispatch-tracker'
-import { computeRemoteWorkdir, quoteRemotePath, type RemoteHandle } from './job-dispatcher'
+import {
+  computeRemoteWorkdir,
+  quoteRemotePath,
+  REMOTE_PROCESS_OWNERSHIP_FUNCTION,
+  type RemoteHandle
+} from './job-dispatcher'
 import { ComputeJobLifecycle } from './compute-job-lifecycle'
 import type {
   ComputeJobOwner,
@@ -108,17 +113,13 @@ const cleanupCommand = (workdir: string, handle: RemoteHandle | undefined): stri
     `workdir=$(cd -- ${quotedWorkdir} 2>/dev/null && pwd -P || true)`,
     'expected_workdir=${scratch_root%/}/' + quotedWorkdirSuffix,
     '[ -z "$workdir" ] || { [ -n "$scratch_root" ] && [ "$workdir" = "$expected_workdir" ]; } || exit 1',
+    REMOTE_PROCESS_OWNERSHIP_FUNCTION,
     'kill_job_pid() {',
     '  pid=$1',
-    "  case $pid in ''|*[!0-9]*) return 0 ;; esac",
-    '  [ -n "$workdir" ] || return 0',
-    '  process_workdir=$(readlink "/proc/$pid/cwd" 2>/dev/null || true)',
-    '  if [ -z "$process_workdir" ] && command -v lsof >/dev/null 2>&1; then',
-    `    process_workdir=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1)`,
-    '  fi',
-    '  [ "$process_workdir" = "$workdir" ] || return 0',
+    '  process_owned_by_workdir "$pid" "$workdir" || return 0',
     '  kill -TERM -- -$pid 2>/dev/null || true',
     '  kill -TERM $pid 2>/dev/null || true',
+    '  process_owned_by_workdir "$pid" "$workdir" || return 0',
     '  kill -KILL -- -$pid 2>/dev/null || true',
     '  kill -KILL $pid 2>/dev/null || true',
     '}'

--- a/src/main/compute/job-dispatcher.ts
+++ b/src/main/compute/job-dispatcher.ts
@@ -30,6 +30,20 @@ export type RemoteHandle = {
   workdir: string
 }
 
+export const REMOTE_PROCESS_OWNERSHIP_FUNCTION = [
+  'process_owned_by_workdir() {',
+  '  pid=$1',
+  '  expected_workdir=$2',
+  "  case $pid in ''|*[!0-9]*) return 1 ;; esac",
+  '  [ -n "$expected_workdir" ] || return 1',
+  '  process_workdir=$(readlink "/proc/$pid/cwd" 2>/dev/null || true)',
+  '  if [ -z "$process_workdir" ] && command -v lsof >/dev/null 2>&1; then',
+  `    process_workdir=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1)`,
+  '  fi',
+  '  [ "$process_workdir" = "$expected_workdir" ]',
+  '}'
+].join('\n')
+
 // Builds the launcher.sh script content for a given job.
 // Uses timeout(1) with SIGTERM then SIGKILL after 30s grace. The login shell loads profile
 // configuration, then attempts to source a readable .bashrc (non-interactive bash does not do so

--- a/src/main/compute/job-poller.test.ts
+++ b/src/main/compute/job-poller.test.ts
@@ -820,9 +820,17 @@ describe('JobPoller', () => {
     )
     // Second run call should have been the kill command.
     expect(runFn).toHaveBeenCalledTimes(2)
+    const pollCall = runFn.mock.calls[0]
     const killCall = runFn.mock.calls[1]
+    expect(pollCall[1]).toContain('/proc/$pid/cwd')
+    expect(pollCall[1]).toContain('process_workdir')
+    expect(pollCall[1]).toContain('process_owned_by_workdir 1234 "$workdir" && kill -0 1234')
     expect(killCall[1]).toContain('kill')
     expect(killCall[1]).toContain('1234') // pid from makeJob
+    expect(killCall[1]).toContain('/proc/$pid/cwd')
+    expect(killCall[1]).toContain('process_workdir')
+    expect(killCall[1]).toContain('process_owned_by_workdir 1234 "$workdir" && kill 1234')
+    expect(killCall[1]).toContain('process_owned_by_workdir 1234 "$workdir" && kill -9 1234')
     expect(runFn.mock.invocationCallOrder[1]).toBeLessThan(
       updateIfStatus.mock.invocationCallOrder[0]
     )
@@ -1093,6 +1101,70 @@ describe('JobPoller', () => {
     // Calling stop() again is a no-op.
     poller.stop()
     expect(clearIntervalMock).toHaveBeenCalledOnce()
+  })
+
+  it('does not count overlapping interval callbacks as separate vanish observations', async () => {
+    const job = makeJob()
+    const update = vi.fn((_id: string, updates: unknown) =>
+      Promise.resolve({ ...job, ...(updates as object) })
+    )
+    const jobRepo = {
+      findNonTerminal: vi.fn(() => Promise.resolve([job])),
+      update,
+      updateIfStatus: guardStatusUpdate(update)
+    } as unknown as ComputeJobRepository
+    const vanishedOutput = withNonce([
+      'JOB_START:job-1',
+      'alive:0',
+      '',
+      '',
+      'STDOUT_END:job-1',
+      '',
+      'STDERR_END:job-1'
+    ])
+    let releasePoll!: () => void
+    const pollReleased = new Promise<void>((resolve) => {
+      releasePoll = resolve
+    })
+    const run = vi.fn(async () => {
+      await pollReleased
+      return {
+        exitCode: 0,
+        stdout: vanishedOutput,
+        stderr: '',
+        truncated: false,
+        timedOut: false
+      }
+    })
+    let intervalCallback!: () => void
+    const poller = new JobPoller({
+      connectionBroker: brokerFromRunner({ run } as SshRunner),
+      hostRepository: {
+        get: vi.fn(() => Promise.resolve(sampleHost()))
+      } as unknown as ComputeHostRepository,
+      jobRepository: jobRepo,
+      makeNonce: () => NONCE,
+      setInterval: (callback) => {
+        intervalCallback = callback
+        return 999 as unknown as ReturnType<typeof setInterval>
+      },
+      clearInterval: vi.fn()
+    })
+
+    poller.start()
+    await vi.waitFor(() => expect(run).toHaveBeenCalledOnce())
+    intervalCallback()
+    intervalCallback()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    releasePoll()
+    await poller.pause()
+    poller.stop()
+
+    expect(run).toHaveBeenCalledOnce()
+    expect(update).not.toHaveBeenCalledWith(
+      'job-1',
+      expect.objectContaining({ status: 'failed', errorCode: 'process_vanished' })
+    )
   })
 })
 

--- a/src/main/compute/job-poller.ts
+++ b/src/main/compute/job-poller.ts
@@ -10,7 +10,11 @@ import {
   type ComputeConnectionBrokerAcquirer,
   type ComputeConnectionLease
 } from './connection-broker'
-import { quoteRemotePath, type RemoteHandle } from './job-dispatcher'
+import {
+  quoteRemotePath,
+  REMOTE_PROCESS_OWNERSHIP_FUNCTION,
+  type RemoteHandle
+} from './job-dispatcher'
 import { parsePollOutput } from './job-poll-output'
 import { sharedDispatchTracker, type DispatchTracker } from './dispatch-tracker'
 import { emitJobNotification } from './job-notifier'
@@ -164,7 +168,7 @@ export class JobPoller {
   }
 
   private runTick(): void {
-    if (this.paused) return
+    if (this.paused || this.activeTicks.size > 0) return
     const task = this.tick()
     this.activeTicks.add(task)
     void task.then(
@@ -360,13 +364,14 @@ export class JobPoller {
     // Build per-job check commands, batched into one SSH round-trip.
     // Format per job (each marker carries the nonce prefix):
     //   echo "<nonce>JOB_START:<jobId>"
+    //   resolve the canonical workdir and prove the pid still owns it
     //   kill -0 <pid> 2>/dev/null && echo "<nonce>alive:1" || echo "<nonce>alive:0"
     //   test -f <exit_code_path> && cat <exit_code_path> || echo ""
     //   tail -c 65536 <stdout_path> 2>/dev/null || true
     //   echo "<nonce>STDOUT_END:<jobId>"
     //   tail -c 65536 <stderr_path> 2>/dev/null || true
     //   echo "<nonce>STDERR_END:<jobId>"
-    const parts: string[] = []
+    const parts: string[] = [REMOTE_PROCESS_OWNERSHIP_FUNCTION]
     const batched: ComputeJob[] = []
     for (const job of jobs) {
       const handle = this._parseHandle(job.remote_handle)
@@ -375,7 +380,8 @@ export class JobPoller {
 
       parts.push(
         `echo "${nonce}JOB_START:${job.job_id}"`,
-        `kill -0 ${handle.pid} 2>/dev/null && echo "${nonce}alive:1" || echo "${nonce}alive:0"`,
+        `workdir=$(cd -- ${quoteRemotePath(handle.workdir)} 2>/dev/null && pwd -P || true)`,
+        `process_owned_by_workdir ${handle.pid} "$workdir" && kill -0 ${handle.pid} 2>/dev/null && echo "${nonce}alive:1" || echo "${nonce}alive:0"`,
         `if [ -f ${quoteRemotePath(handle.exit_code_path)} ]; then cat ${quoteRemotePath(handle.exit_code_path)}; else echo ""; fi`,
         `tail -c ${TAIL_MAX_BYTES} ${quoteRemotePath(handle.stdout_path)} 2>/dev/null || true`,
         `echo "${nonce}STDOUT_END:${job.job_id}"`,
@@ -384,7 +390,7 @@ export class JobPoller {
       )
     }
 
-    if (parts.length === 0) return
+    if (batched.length === 0) return
 
     // Size the output cap to this batch: one PER_JOB_POLL_BYTES budget per job that emits a section.
     const maxOutputBytes = batched.length * PER_JOB_POLL_BYTES
@@ -589,7 +595,12 @@ export class JobPoller {
           // Best-effort kill; ignore errors (process may have already exited).
           try {
             await connection.run(
-              `kill ${handle.pid} 2>/dev/null; kill -9 ${handle.pid} 2>/dev/null; true`,
+              [
+                REMOTE_PROCESS_OWNERSHIP_FUNCTION,
+                `workdir=$(cd -- ${quoteRemotePath(handle.workdir)} 2>/dev/null && pwd -P || true)`,
+                `process_owned_by_workdir ${handle.pid} "$workdir" && kill ${handle.pid} 2>/dev/null || true`,
+                `process_owned_by_workdir ${handle.pid} "$workdir" && kill -9 ${handle.pid} 2>/dev/null || true`
+              ].join('\n'),
               {
                 timeoutMs: 10_000,
                 loginShell: false,


### PR DESCRIPTION
## Problem

Compute Job coordination had three independent race/safety gaps:

- persisted remote PIDs authorized liveness checks and timeout signals without proving that the PID still belonged to the Job;
- overlapping 15-second interval callbacks could consume two vanish observations inside one polling window;
- queue promotion awaited each complete SSH dispatch, so slow staging on one provider blocked eligible Jobs on another provider.

## Proposed change

- Reuse the cleanup flow's canonical cwd ownership proof before remote liveness checks and before each fallback timeout signal.
- Skip scheduled interval callbacks while the previous scheduled tick is still active.
- Preserve FIFO and limit reservation under the existing admission lock, then run the reserved Jobs' SSH dispatches concurrently outside that lock.

## Scope and non-goals

- No database schema change or migration.
- No new persisted RemoteHandle field; existing handles already contain workdir and remain compatible.
- No new or changed Job status/error enum.
- No renderer, IPC, or user-interaction change.
- No remote supervisor/daemon or scheduler redesign.

Remote hosts must expose either procfs cwd links or lsof for positive process ownership proof. If neither is available, polling fails closed and never signals the PID; this matches the existing cleanup safety mechanism.

## Acceptance criteria and validation

The three focused regressions were each run three times against the unfixed baseline and failed consistently for the reported reason, then passed after the fix.

Final checks after the last material edit:

- Compute Job ownership, poll timing, queue dispatch, and representative consumers -> npm run test:module -- compute_service -> 31 files passed, 1 skipped; 802 tests passed, 6 skipped.
- Main-process type safety -> npm run typecheck:node -> passed.
- Source/test lint and formatting -> npm run lint -> passed.
- Exact-head impact selection -> npm run test:affected -- --base origin/main --head HEAD --explain -> selective compute_service plan with windows_sensitive and main_runtime coverage.

The complete portable and platform suites are left to required PR CI as requested.

## Review focus

- Shell ownership checks remain fail-closed and precede every liveness/destructive signal.
- Scheduled poll non-reentrancy preserves explicit tick calls and pause/stop behavior.
- Parallel dispatch does not weaken FIFO reservation, provider/session ceilings, owner pause, or terminal reconciliation.
