### PR TITLE
fix(connectors): validate bundled tool arguments

### DIFF
--- a/src/main/connectors/registry.test.ts
+++ b/src/main/connectors/registry.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { getConnectorTools, getDescriptor, ALL_CONNECTOR_IDS } from './registry'
+import {
+  getConnectorTools,
+  getDescriptor,
+  validateToolArguments,
+  ALL_CONNECTOR_IDS
+} from './registry'
 import { CONNECTOR_CATALOG } from './catalog'
 
 describe('registry + catalog', () => {
@@ -16,5 +21,22 @@ describe('registry + catalog', () => {
   })
   it('uses kebab-case for every bundled connector identity', () => {
     for (const id of ALL_CONNECTOR_IDS) expect(id).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+  })
+  it('compiles every bundled input Schema when the registry loads', () => {
+    expect(ALL_CONNECTOR_IDS.flatMap(getConnectorTools).length).toBeGreaterThan(0)
+  })
+  it('validates arguments against the compiled input Schema without coercion', () => {
+    const descriptor = getDescriptor('chemistry', 'pubchem_get_compounds')!
+
+    expect(() => validateToolArguments(descriptor, { cids: [2244] })).not.toThrow()
+    expect(() => validateToolArguments(descriptor, { cids: '2244' })).toThrow(
+      /invalid tool arguments.*cids.*array/i
+    )
+  })
+  it('uses Schema-required fields instead of the drifted descriptor required list', () => {
+    const descriptor = getDescriptor('biorxiv', 'get_preprint')!
+
+    expect(descriptor.required).toBeUndefined()
+    expect(() => validateToolArguments(descriptor, {})).toThrow(/doi.*required/i)
   })
 })

--- a/src/main/connectors/registry.ts
+++ b/src/main/connectors/registry.ts
@@ -1,3 +1,5 @@
+import Ajv2020, { type ErrorObject, type ValidateFunction } from 'ajv/dist/2020.js'
+
 import { BIOMART_TOOLS } from './descriptors/biomart'
 import { BIORXIV_TOOLS } from './descriptors/biorxiv'
 import { CANCER_MODELS_TOOLS } from './descriptors/cancer-models'
@@ -50,6 +52,58 @@ const ALL_TOOLS: ToolDescriptor[] = [
   ...VARIANTS_TOOLS,
   ...ZINC_TOOLS
 ]
+
+const inputSchemaCompiler = new Ajv2020({
+  strict: true,
+  allErrors: false,
+  validateFormats: false,
+  coerceTypes: false,
+  useDefaults: false,
+  removeAdditional: false,
+  ownProperties: true,
+  addUsedSchema: false
+})
+
+const inputValidators = new Map<ToolDescriptor, ValidateFunction>(
+  ALL_TOOLS.map((tool) => [tool, inputSchemaCompiler.compile(tool.input)])
+)
+
+const boundedField = (value: unknown): string | undefined =>
+  typeof value === 'string' && value ? value.slice(0, 128) : undefined
+
+const validationDetail = (error: ErrorObject | undefined): string => {
+  if (!error) return 'arguments must match the registered Input schema'
+  if (error.keyword === 'required') {
+    const field = boundedField(error.params.missingProperty)
+    return field ? `field ${JSON.stringify(field)} is required` : 'a required field is missing'
+  }
+  if (error.keyword === 'additionalProperties') {
+    const field = boundedField(error.params.additionalProperty)
+    return field
+      ? `field ${JSON.stringify(field)} is not allowed`
+      : 'an unknown field is not allowed'
+  }
+
+  const path = boundedField(error.instancePath.replace(/^\//, '').replaceAll('/', '.'))
+  const subject = path ? `field ${JSON.stringify(path)}` : 'arguments'
+  return `${subject} ${error.message ?? 'must match the registered Input schema'}`
+}
+
+export function validateToolArguments(
+  descriptor: ToolDescriptor,
+  args: Record<string, unknown>
+): void {
+  const validate = inputValidators.get(descriptor)
+  if (!validate)
+    throw new Error(`unregistered tool descriptor: ${descriptor.connector}/${descriptor.id}`)
+  if (validate(args)) return
+
+  throw new Error(
+    `connector call rejected: invalid_arguments. Invalid tool arguments for ${descriptor.connector}/${descriptor.id}: ${validationDetail(validate.errors?.[0])}. ` +
+      `Correct the arguments to match the Input schema in the loaded mcp-${descriptor.connector} Skill, then retry the same method once. ` +
+      'Do not retry unchanged or bypass host.mcp.'
+  )
+}
 
 export const ALL_CONNECTOR_IDS = [...new Set(ALL_TOOLS.map((t) => t.connector))]
 

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -61,6 +61,21 @@ describe('ConnectorService', () => {
     const out = await svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] }, internal)
     expect(out).toEqual({ n_requested: 1, duplicates: [], records: [{ CID: 1 }], not_found: [] })
   })
+  it('rejects bundled tool arguments that do not match the registered JSON Schema', async () => {
+    const engine = {
+      call: vi.fn().mockResolvedValue({ accepted: true })
+    } as unknown as ParserEngine
+    const svc = new ConnectorService({
+      engine,
+      getConnectors: () => ({ enabledIds: ['chemistry'], autoAllowIds: [] }),
+      resolveApiKey: () => undefined
+    })
+
+    await expect(
+      svc.call('chemistry', 'pubchem_get_compounds', { cids: '2244' }, internal)
+    ).rejects.toThrow(/invalid tool arguments.*cids.*array/i)
+    expect(engine.call).not.toHaveBeenCalled()
+  })
   it('routes a bundled tool with a registered local handler through it, not the engine', async () => {
     const localHandler = vi.fn().mockResolvedValue({ ok: true })
     const engine = { call: vi.fn() } as unknown as ParserEngine
@@ -82,6 +97,19 @@ describe('ConnectorService', () => {
     )
     expect(out).toEqual({ ok: true })
     expect(engine.call).not.toHaveBeenCalled()
+  })
+  it('validates bundled tool arguments before dispatching to a local handler', async () => {
+    const localHandler = vi.fn().mockResolvedValue({ ok: true })
+    const svc = new ConnectorService({
+      getConnectors: () => ({ enabledIds: ['molecule'], autoAllowIds: [] }),
+      resolveApiKey: () => undefined,
+      localToolHandlers: { 'molecule/preview_molecule': localHandler }
+    })
+
+    await expect(
+      svc.call('molecule', 'preview_molecule', { smiles: 42 }, internal)
+    ).rejects.toThrow(/invalid tool arguments.*smiles.*string/i)
+    expect(localHandler).not.toHaveBeenCalled()
   })
   it('passes the caller signal to a bundled local handler', async () => {
     const localHandler = vi.fn().mockResolvedValue({ ok: true })

--- a/src/main/connectors/service.ts
+++ b/src/main/connectors/service.ts
@@ -1,7 +1,7 @@
 import { createHmac, randomBytes } from 'node:crypto'
 
 import { ParserEngine } from './engine'
-import { ALL_CONNECTOR_IDS, getDescriptor } from './registry'
+import { ALL_CONNECTOR_IDS, getDescriptor, validateToolArguments } from './registry'
 import {
   classifyCustomMcpFailure,
   isCustomMcpServerRouteSafe,
@@ -339,6 +339,8 @@ export class ConnectorService {
         'connector_unavailable',
         unknownConnectorToolMessage(connector, method)
       )
+
+    validateToolArguments(descriptor, args)
 
     const authorizedConnectors = access.bypassMainPolicy
       ? undefined


### PR DESCRIPTION
## Problem

Bundled Connector tools advertise JSON Schema input contracts, but the shared call path only checked
the descriptor's duplicate `required` list. Invalid types, array shapes, item counts, enums, and
ranges could reach a local handler or external dispatch. A real catalog drift also left two biorxiv
Schema-required inputs unenforced.

## Proposed change

- compile every bundled tool input Schema once when the registry loads, using the existing AJV 8
  dependency with coercion, defaults, and removal disabled
- validate bundled arguments at the shared `ConnectorService` boundary before approval or dispatch
- return a bounded, value-free, actionable error that points the Agent back to the loaded Connector
  Skill's Input schema
- keep descriptor-owned domain validation for cross-field and upstream-specific rules

## Scope and non-goals

- bundled Connector inputs only; custom MCP servers continue to own their live tool validation
- no output validation, Skill format changes, Agent tool injection, dependency additions, persisted
  fields, migrations, data-model changes, or new state/enum values
- no automatic coercion, default injection, extra-field removal, or rewrite of descriptor validators

## Acceptance criteria and validation

The regression test was added before the implementation and failed three consecutive times on the
unfixed code because `{ cids: "2244" }` was dispatched instead of rejected.

Final evidence after the last material edit:

- invalid bundled input -> `npm test -- src/main/connectors/registry.test.ts src/main/connectors/service.test.ts` -> 60 passed
- ordinary and local-handler dispatch boundaries -> same command -> covered and passed
- bundled Connector module compatibility -> `npm test -- src/main/connectors` -> 54 files passed; 2 loopback OAuth files were sandbox-blocked
- loopback OAuth remainder -> `npm test -- src/main/connectors/oauth-client.test.ts src/main/connectors/mcp-client-manager.test.ts` outside the restricted sandbox -> 45 passed
- Node types -> `npm run typecheck:node` -> passed
- lint -> `npm run lint` -> passed
- affected-plan explanation -> `npm run test:affected -- --base main --head HEAD --explain` -> full fallback because Connector files have no declared module owner

Per maintainer direction, the complete local `npm test` fallback was not run; exact-head PR CI is the
authority for the complete portable suite and platform lanes. The change is in the shared Connector
service used by every Agent framework path; it does not change ACP protocol translation or a
framework-specific adapter.

## Review focus

- validation happens before both bundled dispatch paths and does not mutate arguments
- errors expose field names and Schema constraints, never argument values
- registration-time compilation is fail-fast without expanding validation to custom MCP servers

Uncovered risk: callers that previously relied on undocumented numeric-string or scalar-to-array
coercion will now receive the advertised Schema error and must correct their arguments before retrying.
