### PR TITLE
fix(session-persistence): validate projection before authority write

### DIFF
--- a/src/main/session-persistence/projection.test.ts
+++ b/src/main/session-persistence/projection.test.ts
@@ -374,6 +374,60 @@ describe('Session projection', () => {
     await expect(projection.pending()).resolves.toEqual([])
   })
 
+  it('rejects whitespace projection identifiers before replacing Session authority', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-session-text-validation-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project' } })
+    const projection = new SessionProjectionRepository(async () => client!)
+    const repository = new SessionRepository(storageRoot, {}, projection)
+    const saved = await repository.saveSession(session('blank-source'))
+    const authorityPath = join(storageRoot, 'sessions', 'project-1', 'blank-source.json')
+    const originalAuthority = await readFile(authorityPath, 'utf8')
+    const invalid = { ...session('blank-source'), number: saved.number, revision: saved.revision }
+    invalid.messages[1].modelCallUsage![0].sourceInvocationId = ' '
+
+    const saveError = await repository
+      .saveSession(invalid)
+      .then(() => undefined)
+      .catch((error: unknown) => error)
+
+    expect.soft(await readFile(authorityPath, 'utf8')).toBe(originalAuthority)
+    expect(saveError).toEqual(
+      expect.objectContaining({
+        message: 'Session projection modelCall.sourceInvocationId must be a non-empty string.'
+      })
+    )
+    await expect(projection.pending()).resolves.toEqual([])
+  })
+
+  it('rejects invalid Session statuses before replacing authority', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-session-status-validation-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project' } })
+    const projection = new SessionProjectionRepository(async () => client!)
+    const repository = new SessionRepository(storageRoot, {}, projection)
+    const saved = await repository.saveSession(session('invalid-status'))
+    const authorityPath = join(storageRoot, 'sessions', 'project-1', 'invalid-status.json')
+    const originalAuthority = await readFile(authorityPath, 'utf8')
+    const invalid = { ...session('invalid-status'), number: saved.number, revision: saved.revision }
+    Object.assign(invalid, { status: 'paused' })
+
+    const saveError = await repository
+      .saveSession(invalid)
+      .then(() => undefined)
+      .catch((error: unknown) => error)
+
+    expect.soft(await readFile(authorityPath, 'utf8')).toBe(originalAuthority)
+    expect(saveError).toEqual(
+      expect.objectContaining({
+        message: 'Session projection status must be a persisted Session status.'
+      })
+    )
+    await expect(projection.pending()).resolves.toEqual([])
+  })
+
   it('rejects an invalid Session save while projection publication is suspended', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-session-suspended-validation-'))
     client = createProjectDbClient(storageRoot)

--- a/src/main/session-persistence/projection.test.ts
+++ b/src/main/session-persistence/projection.test.ts
@@ -323,6 +323,57 @@ describe('Session projection', () => {
     await expect(projection.pending()).resolves.toEqual([])
   })
 
+  it('validates the incremented Session revision before writing authority', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-session-revision-validation-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project' } })
+    const projection = new SessionProjectionRepository(async () => client!)
+    const repository = new SessionRepository(storageRoot, {}, projection)
+    const authorityPath = join(storageRoot, 'sessions', 'project-1', 'revision-overflow.json')
+
+    const saveError = await repository
+      .saveSession({ ...session('revision-overflow'), revision: Number.MAX_SAFE_INTEGER })
+      .then(() => undefined)
+      .catch((error: unknown) => error)
+    const authority = await readFile(authorityPath, 'utf8').catch(() => undefined)
+
+    expect.soft(authority).toBeUndefined()
+    expect(saveError).toEqual(
+      expect.objectContaining({
+        message: 'Session revision cannot be incremented safely.'
+      })
+    )
+    await expect(projection.pending()).resolves.toEqual([])
+  })
+
+  it('rejects a zero context-window size before replacing Session authority', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-session-context-window-validation-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project' } })
+    const projection = new SessionProjectionRepository(async () => client!)
+    const repository = new SessionRepository(storageRoot, {}, projection)
+    const saved = await repository.saveSession(session('context-window'))
+    const authorityPath = join(storageRoot, 'sessions', 'project-1', 'context-window.json')
+    const originalAuthority = await readFile(authorityPath, 'utf8')
+    const invalid = { ...session('context-window'), number: saved.number, revision: saved.revision }
+    invalid.messages[1].modelCallUsage![0].contextWindowSize = 0
+
+    const saveError = await repository
+      .saveSession(invalid)
+      .then(() => undefined)
+      .catch((error: unknown) => error)
+
+    expect.soft(await readFile(authorityPath, 'utf8')).toBe(originalAuthority)
+    expect(saveError).toEqual(
+      expect.objectContaining({
+        message: 'Session projection modelCall.contextWindowSize must be a positive safe integer.'
+      })
+    )
+    await expect(projection.pending()).resolves.toEqual([])
+  })
+
   it('rejects an invalid Session save while projection publication is suspended', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-session-suspended-validation-'))
     client = createProjectDbClient(storageRoot)

--- a/src/main/session-persistence/projection.test.ts
+++ b/src/main/session-persistence/projection.test.ts
@@ -108,6 +108,10 @@ const session = (id: string, createdAt = 100): PersistedChatSession => ({
   updatedAt: createdAt + 5
 })
 
+const sessionWithInvalidProjection = (id: string, createdAt = 100): PersistedChatSession => {
+  return { ...session(id, createdAt), updatedAt: Number.MAX_VALUE }
+}
+
 describe('Session projection', () => {
   let client: PrismaClient | undefined
   let storageRoot: string | undefined
@@ -317,6 +321,45 @@ describe('Session projection', () => {
 
     expect.soft(await readFile(authorityPath, 'utf8')).toBe(originalAuthority)
     await expect(projection.pending()).resolves.toEqual([])
+  })
+
+  it('rejects an invalid Session save while projection publication is suspended', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-session-suspended-validation-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project' } })
+    const files = new SessionRepository(storageRoot)
+    await files.saveSession(session('older', 100))
+    const stale = await files.loadAll()
+    const projection = new SessionProjectionRepository(async () => client!)
+    const repository = new SessionRepository(storageRoot, {}, projection)
+    const authorityStarted = createDeferred<void>()
+    const authorityReleased = createDeferred<void>()
+    const initializing = repository.ensureSessionProjection(async () => {
+      authorityStarted.resolve()
+      await authorityReleased.promise
+      return stale
+    })
+
+    await authorityStarted.promise
+    const saveError = await repository
+      .saveSession(sessionWithInvalidProjection('invalid', 200))
+      .then(() => undefined)
+      .catch((error: unknown) => error)
+    const authorityPath = join(storageRoot, 'sessions', 'project-1', 'invalid.json')
+    const authority = await readFile(authorityPath, 'utf8').catch(() => undefined)
+    authorityReleased.resolve()
+    const initializationError = await initializing
+      .then(() => undefined)
+      .catch((error: unknown) => error)
+
+    expect(saveError).toEqual(
+      expect.objectContaining({
+        message: 'Session projection updatedAt must be a non-negative safe integer.'
+      })
+    )
+    expect(authority).toBeUndefined()
+    expect(initializationError).toBeUndefined()
   })
 
   it('keeps a deleted metadata tombstone, excludes its facts, and never reuses its number', async () => {
@@ -628,6 +671,34 @@ describe('Session projection', () => {
     await expect(
       client.sessionNumberSequence.findUnique({ where: { id: 'global' } })
     ).resolves.toMatchObject({ nextNumber: 3 })
+  })
+
+  it('rejects an invalid backfill before clearing the existing projection', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-session-rebuild-validation-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project' } })
+    const projection = new SessionProjectionRepository(async () => client!)
+    const repository = new SessionRepository(storageRoot, {}, projection)
+    const retained = await repository.saveSession(session('retained', 100))
+    await projection.replaceAll([retained])
+    await client.sessionProjectionState.update({
+      where: { id: 'session-projection' },
+      data: { projectionVersion: 1 }
+    })
+    const files = new SessionRepository(storageRoot)
+    await files.saveSession(sessionWithInvalidProjection('invalid', 200))
+
+    await expect(repository.ensureSessionProjection(() => files.loadAll())).rejects.toThrow(
+      'Session projection updatedAt must be a non-negative safe integer.'
+    )
+    await expect(client.session.findUnique({ where: { id: retained.id } })).resolves.toMatchObject({
+      id: retained.id,
+      deletedAtMs: null
+    })
+    await expect(
+      client.sessionProjectionState.findUnique({ where: { id: 'session-projection' } })
+    ).resolves.toMatchObject({ projectionVersion: 1 })
   })
 
   it('derives degraded summaries from read-only authority instead of stale SQLite rows', async () => {

--- a/src/main/session-persistence/projection.test.ts
+++ b/src/main/session-persistence/projection.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rename, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rename, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -292,6 +292,31 @@ describe('Session projection', () => {
     await expect(client.session.count()).resolves.toBe(75)
     await expect(client.sessionTurnUsage.count()).resolves.toBe(75)
     await expect(client.sessionModelCallUsage.count()).resolves.toBe(150)
+  })
+
+  it('does not replace Session authority when an invalid projection integer rejects the save', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-session-save-validation-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.project.create({
+      data: { id: 'project-1', name: 'Project', createdAt: new Date(50) }
+    })
+    const projection = new SessionProjectionRepository(async () => client!)
+    const repository = new SessionRepository(storageRoot, {}, projection)
+    const saved = await repository.saveSession(session('session-1'))
+    const authorityPath = join(storageRoot, 'sessions', 'project-1', 'session-1.json')
+    const originalAuthority = await readFile(authorityPath, 'utf8')
+
+    await expect(
+      repository.saveSession({
+        ...saved,
+        title: 'Rejected update',
+        updatedAt: Number.MAX_VALUE
+      })
+    ).rejects.toThrow('Session projection updatedAt must be a non-negative safe integer.')
+
+    expect.soft(await readFile(authorityPath, 'utf8')).toBe(originalAuthority)
+    await expect(projection.pending()).resolves.toEqual([])
   })
 
   it('keeps a deleted metadata tombstone, excludes its facts, and never reuses its number', async () => {

--- a/src/main/session-persistence/projection.ts
+++ b/src/main/session-persistence/projection.ts
@@ -18,6 +18,8 @@ import {
 const PROJECTION_STATE_ID = 'session-projection'
 const PROJECTION_VERSION = 2
 const SESSION_NUMBER_SEQUENCE_ID = 'global'
+const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER)
+const MAX_SQLITE_INT = 2_147_483_647
 
 type ProjectionClient = () => Promise<PrismaClient>
 
@@ -53,6 +55,109 @@ type SessionProjection = Readonly<{
   runs: Array<{ messageId: string; createdAtMs: bigint }>
   artifactRefs: Array<{ artifactId: string; artifactCreatedAtMs: bigint | null }>
 }>
+
+const assertProjectionStorageShape = (projection: SessionProjection): void => {
+  const assertText = (value: unknown, field: string): void => {
+    if (typeof value !== 'string') {
+      throw new Error(`Session projection ${field} must be a string.`)
+    }
+  }
+  const assertInt = (value: number, field: string): void => {
+    if (!Number.isSafeInteger(value) || value < 0 || value > MAX_SQLITE_INT) {
+      throw new Error(`Session projection ${field} must fit a non-negative SQLite Int.`)
+    }
+  }
+  const assertSafeNumber = (value: number, field: string): void => {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new Error(`Session projection ${field} must be a non-negative safe integer.`)
+    }
+  }
+  const assertBigInt = (value: bigint, field: string): void => {
+    if (value < 0n || value > MAX_SAFE_INTEGER_BIGINT) {
+      throw new Error(`Session projection ${field} must be a non-negative safe integer.`)
+    }
+  }
+  const assertNullableText = (value: string | null, field: string): void => {
+    if (value !== null) assertText(value, field)
+  }
+  const assertNullableBigInt = (value: bigint | null, field: string): void => {
+    if (value !== null) assertBigInt(value, field)
+  }
+  const assertUnique = (values: string[], field: string): void => {
+    if (new Set(values).size !== values.length) {
+      throw new Error(`Session projection ${field} must be unique.`)
+    }
+  }
+
+  for (const field of ['id', 'projectId', 'title', 'status', 'presentedStatus'] as const) {
+    assertText(projection.summary[field], field)
+  }
+  for (const field of ['activeMessageCount', 'artifactCount', 'filesRevision'] as const) {
+    assertInt(projection.summary[field], field)
+  }
+  for (const field of ['revision', 'createdAt', 'updatedAt'] as const) {
+    assertSafeNumber(projection.summary[field], field)
+  }
+  if (projection.summary.archivedAt !== undefined) {
+    assertSafeNumber(projection.summary.archivedAt, 'archivedAt')
+  }
+  if (projection.summary.presentedActivityAt !== undefined) {
+    assertSafeNumber(projection.summary.presentedActivityAt, 'presentedActivityAt')
+  }
+
+  for (const usage of projection.turnUsage) {
+    assertText(usage.messageId, 'turnUsage.messageId')
+    assertBigInt(usage.completedAtMs, 'turnUsage.completedAtMs')
+    assertBigInt(usage.inputTokens, 'turnUsage.inputTokens')
+    assertBigInt(usage.cacheTokens, 'turnUsage.cacheTokens')
+    assertNullableBigInt(usage.cachedReadTokens, 'turnUsage.cachedReadTokens')
+    assertNullableBigInt(usage.cachedWriteTokens, 'turnUsage.cachedWriteTokens')
+    assertBigInt(usage.outputTokens, 'turnUsage.outputTokens')
+    if (usage.modelCallCount !== null) assertInt(usage.modelCallCount, 'turnUsage.modelCallCount')
+  }
+  assertUnique(
+    projection.turnUsage.map(({ messageId }) => messageId),
+    'turnUsage.messageId'
+  )
+  for (const call of projection.modelCalls) {
+    assertText(call.messageId, 'modelCall.messageId')
+    assertText(call.callId, 'modelCall.callId')
+    assertInt(call.callIndex, 'modelCall.callIndex')
+    assertNullableText(call.sourceInvocationId, 'modelCall.sourceInvocationId')
+    assertNullableText(call.frameworkId, 'modelCall.frameworkId')
+    assertNullableText(call.backendId, 'modelCall.backendId')
+    assertNullableText(call.model, 'modelCall.model')
+    assertBigInt(call.inputTokens, 'modelCall.inputTokens')
+    assertBigInt(call.cacheTokens, 'modelCall.cacheTokens')
+    assertNullableBigInt(call.cachedReadTokens, 'modelCall.cachedReadTokens')
+    assertNullableBigInt(call.cachedWriteTokens, 'modelCall.cachedWriteTokens')
+    assertBigInt(call.outputTokens, 'modelCall.outputTokens')
+    assertNullableBigInt(call.contextUsedTokens, 'modelCall.contextUsedTokens')
+    assertNullableBigInt(call.contextWindowSize, 'modelCall.contextWindowSize')
+  }
+  assertUnique(
+    projection.modelCalls.map(({ callId }) => callId),
+    'modelCall.callId'
+  )
+  assertUnique(
+    projection.modelCalls.map(({ messageId, callIndex }) => `${messageId}\0${callIndex}`),
+    'modelCall.messageId/callIndex'
+  )
+  for (const run of projection.runs) {
+    assertText(run.messageId, 'run.messageId')
+    assertBigInt(run.createdAtMs, 'run.createdAtMs')
+  }
+  assertUnique(
+    projection.runs.map(({ messageId }) => messageId),
+    'run.messageId'
+  )
+  for (const artifact of projection.artifactRefs) {
+    assertText(artifact.artifactId, 'artifactRef.artifactId')
+    if (artifact.artifactCreatedAtMs !== null) {
+      assertBigInt(artifact.artifactCreatedAtMs, 'artifactRef.artifactCreatedAtMs')
+    }
+  }
+}
 
 const finiteNonNegativeInteger = (value: number | undefined): number =>
   value !== undefined && Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0
@@ -400,6 +505,7 @@ export class SessionProjectionRepository {
   async prepareSave(session: PersistedChatSession): Promise<PersistedChatSession> {
     const client = await this.client()
     const projection = buildSessionProjection(session)
+    assertProjectionStorageShape(projection)
     const number = await client.$transaction(async (tx) => {
       const project = await tx.project.findFirst({
         where: { id: session.projectId, deletedAt: null },

--- a/src/main/session-persistence/projection.ts
+++ b/src/main/session-persistence/projection.ts
@@ -355,6 +355,10 @@ export const buildSessionProjection = (session: PersistedChatSession): SessionPr
   }
 }
 
+export const assertSessionProjectionStorageShape = (session: PersistedChatSession): void => {
+  assertProjectionStorageShape(buildSessionProjection(session))
+}
+
 const sessionData = (
   projection: SessionProjection,
   number: number
@@ -559,8 +563,9 @@ export class SessionProjectionRepository {
   async commitSave(session: PersistedChatSession): Promise<void> {
     const number = session.number
     if (number === undefined) throw new Error('Session projection requires a number.')
-    const client = await this.client()
     const projection = buildSessionProjection(session)
+    assertProjectionStorageShape(projection)
+    const client = await this.client()
     await client.$transaction(async (tx) => {
       const project = await tx.project.findFirst({
         where: { id: session.projectId, deletedAt: null },
@@ -587,8 +592,9 @@ export class SessionProjectionRepository {
   // Session row and number were allocated when the pending marker was created, so reconciliation
   // updates only that existing identity and cannot create new authority for a deleted Project.
   async commitReconciliation(session: PersistedChatSession): Promise<void> {
-    const client = await this.client()
     const projection = buildSessionProjection(session)
+    assertProjectionStorageShape(projection)
+    const client = await this.client()
     await client.$transaction(async (tx) => {
       const existing = await tx.session.findUnique({ where: { id: session.id } })
       if (!existing) throw new Error('Pending Session projection identity is missing.')
@@ -658,7 +664,9 @@ export class SessionProjectionRepository {
       .map((session) => {
         const number = session.number
         if (number === undefined) throw new Error('Backfilled Session is missing its number.')
-        return { session: { ...session, number }, projection: buildSessionProjection(session) }
+        const projection = buildSessionProjection(session)
+        assertProjectionStorageShape(projection)
+        return { session: { ...session, number }, projection }
       })
     const turnUsage = projected.flatMap(({ session, projection }) =>
       projection.turnUsage.map((usage) => ({ sessionId: session.id, ...usage }))

--- a/src/main/session-persistence/projection.ts
+++ b/src/main/session-persistence/projection.ts
@@ -20,6 +20,14 @@ const PROJECTION_VERSION = 2
 const SESSION_NUMBER_SEQUENCE_ID = 'global'
 const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER)
 const MAX_SQLITE_INT = 2_147_483_647
+const PERSISTED_SESSION_STATUSES: ReadonlySet<string> = new Set([
+  'idle',
+  'running',
+  'waiting-for-user',
+  'waiting-permission',
+  'waiting-plan-approval',
+  'error'
+] satisfies readonly PersistedSessionStatus[])
 
 type ProjectionClient = () => Promise<PrismaClient>
 
@@ -62,6 +70,16 @@ const assertProjectionStorageShape = (projection: SessionProjection): void => {
       throw new Error(`Session projection ${field} must be a string.`)
     }
   }
+  const assertNonEmptyText = (value: unknown, field: string): void => {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+      throw new Error(`Session projection ${field} must be a non-empty string.`)
+    }
+  }
+  const assertStatus = (value: unknown, field: string): void => {
+    if (typeof value !== 'string' || !PERSISTED_SESSION_STATUSES.has(value)) {
+      throw new Error(`Session projection ${field} must be a persisted Session status.`)
+    }
+  }
   const assertInt = (value: number, field: string): void => {
     if (!Number.isSafeInteger(value) || value < 0 || value > MAX_SQLITE_INT) {
       throw new Error(`Session projection ${field} must fit a non-negative SQLite Int.`)
@@ -77,8 +95,8 @@ const assertProjectionStorageShape = (projection: SessionProjection): void => {
       throw new Error(`Session projection ${field} must be a non-negative safe integer.`)
     }
   }
-  const assertNullableText = (value: string | null, field: string): void => {
-    if (value !== null) assertText(value, field)
+  const assertNullableNonEmptyText = (value: string | null, field: string): void => {
+    if (value !== null) assertNonEmptyText(value, field)
   }
   const assertNullableBigInt = (value: bigint | null, field: string): void => {
     if (value !== null) assertBigInt(value, field)
@@ -94,9 +112,12 @@ const assertProjectionStorageShape = (projection: SessionProjection): void => {
     }
   }
 
-  for (const field of ['id', 'projectId', 'title', 'status', 'presentedStatus'] as const) {
-    assertText(projection.summary[field], field)
+  for (const field of ['id', 'projectId'] as const) {
+    assertNonEmptyText(projection.summary[field], field)
   }
+  assertText(projection.summary.title, 'title')
+  assertStatus(projection.summary.status, 'status')
+  assertStatus(projection.summary.presentedStatus, 'presentedStatus')
   for (const field of ['activeMessageCount', 'artifactCount', 'filesRevision'] as const) {
     assertInt(projection.summary[field], field)
   }
@@ -111,7 +132,7 @@ const assertProjectionStorageShape = (projection: SessionProjection): void => {
   }
 
   for (const usage of projection.turnUsage) {
-    assertText(usage.messageId, 'turnUsage.messageId')
+    assertNonEmptyText(usage.messageId, 'turnUsage.messageId')
     assertBigInt(usage.completedAtMs, 'turnUsage.completedAtMs')
     assertBigInt(usage.inputTokens, 'turnUsage.inputTokens')
     assertBigInt(usage.cacheTokens, 'turnUsage.cacheTokens')
@@ -125,13 +146,13 @@ const assertProjectionStorageShape = (projection: SessionProjection): void => {
     'turnUsage.messageId'
   )
   for (const call of projection.modelCalls) {
-    assertText(call.messageId, 'modelCall.messageId')
-    assertText(call.callId, 'modelCall.callId')
+    assertNonEmptyText(call.messageId, 'modelCall.messageId')
+    assertNonEmptyText(call.callId, 'modelCall.callId')
     assertInt(call.callIndex, 'modelCall.callIndex')
-    assertNullableText(call.sourceInvocationId, 'modelCall.sourceInvocationId')
-    assertNullableText(call.frameworkId, 'modelCall.frameworkId')
-    assertNullableText(call.backendId, 'modelCall.backendId')
-    assertNullableText(call.model, 'modelCall.model')
+    assertNullableNonEmptyText(call.sourceInvocationId, 'modelCall.sourceInvocationId')
+    assertNullableNonEmptyText(call.frameworkId, 'modelCall.frameworkId')
+    assertNullableNonEmptyText(call.backendId, 'modelCall.backendId')
+    assertNullableNonEmptyText(call.model, 'modelCall.model')
     assertBigInt(call.inputTokens, 'modelCall.inputTokens')
     assertBigInt(call.cacheTokens, 'modelCall.cacheTokens')
     assertNullableBigInt(call.cachedReadTokens, 'modelCall.cachedReadTokens')
@@ -149,7 +170,7 @@ const assertProjectionStorageShape = (projection: SessionProjection): void => {
     'modelCall.messageId/callIndex'
   )
   for (const run of projection.runs) {
-    assertText(run.messageId, 'run.messageId')
+    assertNonEmptyText(run.messageId, 'run.messageId')
     assertBigInt(run.createdAtMs, 'run.createdAtMs')
   }
   assertUnique(
@@ -157,7 +178,7 @@ const assertProjectionStorageShape = (projection: SessionProjection): void => {
     'run.messageId'
   )
   for (const artifact of projection.artifactRefs) {
-    assertText(artifact.artifactId, 'artifactRef.artifactId')
+    assertNonEmptyText(artifact.artifactId, 'artifactRef.artifactId')
     if (artifact.artifactCreatedAtMs !== null) {
       assertBigInt(artifact.artifactCreatedAtMs, 'artifactRef.artifactCreatedAtMs')
     }

--- a/src/main/session-persistence/projection.ts
+++ b/src/main/session-persistence/projection.ts
@@ -83,6 +83,11 @@ const assertProjectionStorageShape = (projection: SessionProjection): void => {
   const assertNullableBigInt = (value: bigint | null, field: string): void => {
     if (value !== null) assertBigInt(value, field)
   }
+  const assertNullablePositiveBigInt = (value: bigint | null, field: string): void => {
+    if (value !== null && (value <= 0n || value > MAX_SAFE_INTEGER_BIGINT)) {
+      throw new Error(`Session projection ${field} must be a positive safe integer.`)
+    }
+  }
   const assertUnique = (values: string[], field: string): void => {
     if (new Set(values).size !== values.length) {
       throw new Error(`Session projection ${field} must be unique.`)
@@ -133,7 +138,7 @@ const assertProjectionStorageShape = (projection: SessionProjection): void => {
     assertNullableBigInt(call.cachedWriteTokens, 'modelCall.cachedWriteTokens')
     assertBigInt(call.outputTokens, 'modelCall.outputTokens')
     assertNullableBigInt(call.contextUsedTokens, 'modelCall.contextUsedTokens')
-    assertNullableBigInt(call.contextWindowSize, 'modelCall.contextWindowSize')
+    assertNullablePositiveBigInt(call.contextWindowSize, 'modelCall.contextWindowSize')
   }
   assertUnique(
     projection.modelCalls.map(({ callId }) => callId),

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -40,6 +40,13 @@ const MANIFEST_FILE = 'manifest.json'
 const PRE_S2_BACKUP_SUFFIX = '.pre-s2-backup'
 const PRE_SUBAGENT_MODEL_BACKUP_SUFFIX = '.pre-subagent-model-backup'
 
+const nextSessionRevision = (revision: number): number => {
+  if (!Number.isSafeInteger(revision) || revision < 0 || revision >= Number.MAX_SAFE_INTEGER) {
+    throw new Error('Session revision cannot be incremented safely.')
+  }
+  return revision + 1
+}
+
 const hasS2AttemptSchema = (value: unknown): boolean => {
   if (typeof value !== 'object' || value === null) return false
   const envelope = value as Record<string, unknown>
@@ -774,6 +781,7 @@ class SessionRepository {
         throw new SessionRevisionConflictError(expectedRevision, actualRevision)
       }
     }
+    const nextRevision = nextSessionRevision(actualRevision)
 
     if (this.projection && this.projectionWritesSuspended) {
       assertSessionProjectionStorageShape(session)
@@ -784,7 +792,7 @@ class SessionRepository {
         : session
     const durableSession: PersistedChatSession = {
       ...projectedSession,
-      revision: actualRevision + 1
+      revision: nextRevision
     }
     await this.writeSession(durableSession)
     if (this.projectionWritesSuspended) {
@@ -807,7 +815,9 @@ class SessionRepository {
       const key = `${session.projectId}:${session.id}`
       const durableSession: PersistedChatSession = {
         ...session,
-        revision: Math.max(sessionRevision(session), this.sessionRevisions.get(key) ?? 0) + 1
+        revision: nextSessionRevision(
+          Math.max(sessionRevision(session), this.sessionRevisions.get(key) ?? 0)
+        )
       }
       await this.writeSessionToDirectory(durableSession, this.deletedProjectDir(session.projectId))
       if (this.projectionWritesSuspended) this.suspendedProjectionCatalogMutation = true

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -21,7 +21,11 @@ import {
 } from '../../shared/session-persistence'
 import { decodeSessionDataPaths, encodeSessionDataPaths } from './session-data-paths'
 import { SessionPersistenceOperationScheduler } from './operation-scheduler'
-import { buildSessionProjection, type SessionProjectionRepository } from './projection'
+import {
+  assertSessionProjectionStorageShape,
+  buildSessionProjection,
+  type SessionProjectionRepository
+} from './projection'
 import {
   DurableJsonRecoveryBarrierError,
   readDurableJsonFile,
@@ -448,6 +452,7 @@ class SessionRepository {
       if (freshResult.diagnostics?.isComplete === false) {
         return { result: freshResult, sessions: projectIncompleteSummaries(freshResult) }
       }
+      for (const session of freshResult.sessions) assertSessionProjectionStorageShape(session)
       const assignments = await this.projection!.numberAssignments()
       const existingNumberById = new Map(assignments.map(({ id, number }) => [id, number]))
       const existingIdByNumber = new Map(assignments.map(({ id, number }) => [number, id]))
@@ -770,6 +775,9 @@ class SessionRepository {
       }
     }
 
+    if (this.projection && this.projectionWritesSuspended) {
+      assertSessionProjectionStorageShape(session)
+    }
     const projectedSession =
       this.projection && !this.projectionWritesSuspended
         ? await this.projection.prepareSave(session)


### PR DESCRIPTION
## Problem

`sessions:save-session` can receive runtime values that TypeScript cannot protect against. A Session update with `updatedAt: Number.MAX_VALUE` reproduces a cross-store split: the authoritative JSON is atomically replaced, then Prisma rejects the SQLite projection value and leaves a pending reconciliation row. The caller sees a failed command even though the Session authority changed.

## Proposed change

Validate the exact Session projection storage shape in `prepareSave`, before the transaction creates or updates any pending reconciliation state. The validation covers SQLite `Int` bounds, safe integer-backed `BigInt` values, required and nullable text values, and the uniqueness constraints used by turn, model-call, and run projections.

Add an integration regression test at the public `SessionRepository.saveSession` boundary. It creates a real migrated SQLite database and Session JSON, submits the malformed update, and verifies that the save rejects while both the original JSON and an empty pending queue remain unchanged.

## Scope and non-goals

- No persisted fields, enum values, database schema, migration, or data-model changes.
- No Electron/Web API shape or valid user interaction changes.
- No change to the JSON-first crash-recovery protocol; genuine post-authority I/O failures remain recoverable through the existing pending mechanism.
- No whole-Session byte or array-count budget. That needs a separately chosen product limit and capacity test; this PR does not invent one while fixing the reproduced consistency defect.
- No historical-data migration or read-path change. Existing Session files continue through the current durable decoder and reconciliation behavior.

## Acceptance criteria and validation

All checks below ran after the final material edit:

- malformed projection value is rejected before JSON/pending mutation -> `npm test -- src/main/session-persistence/projection.test.ts src/main/session-persistence/repository.test.ts src/main/session-persistence/ipc.test.ts` -> 3 files, 115 tests passed
- Node contracts and Prisma projection types remain valid -> `npm run typecheck:node` -> passed
- changed files satisfy lint rules -> `npx eslint src/main/session-persistence/projection.ts src/main/session-persistence/projection.test.ts` -> passed

The regression was also run against the unfixed final base: Prisma rejected the save, the JSON diff showed the rejected title/timestamp/revision had already replaced authority, and `pending()` returned the Session save intent. With the fix restored, the same test passes.

Per maintainer request, the complete local `npm test` suite was not run. The impact selector falls back to the full plan because `projection.ts` is not assigned to a module owner; PR CI remains authoritative for the complete portable and platform suites.

## Review focus

- Confirm `prepareSave` remains the last side-effect-free boundary before pending reconciliation is written.
- Confirm the validator mirrors every scalar and uniqueness constraint currently written by `sessionData` and `replaceChildren`, including model-call usage introduced in projection version 2.
- Confirm the narrower storage-shape guard is preferable here to duplicating the full evolving `PersistedChatSession` model in a second runtime schema.
