### PR TITLE
fix(dev): detect stale Prisma Client before startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "build:linux": "npm run build:web && electron-vite build && electron-builder --linux",
     "build:win": "npm run build:web && electron-vite build && electron-builder --win",
     "stage-default-envs": "node scripts/stage-default-envs.mjs",
-    "predev": "node scripts/dev-app-branding.cjs"
+    "predev": "node scripts/check-prisma-client.mjs && node scripts/dev-app-branding.cjs"
   },
   "dependencies": {
     "@agentclientprotocol/claude-agent-acp": "^0.70.0",

--- a/scripts/check-prisma-client.mjs
+++ b/scripts/check-prisma-client.mjs
@@ -12,7 +12,7 @@ const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 export function prismaClientFingerprintMismatchMessage(schemaPath, clientSchemaPath) {
   return [
     'Generated Prisma Client is out of date with prisma/schema.prisma.',
-    'Run `npx prisma generate` (or `npm install`) in this worktree before tests.',
+    'Run `npx prisma generate` (or `npm install`) in this worktree before development commands or tests.',
     `Source: ${schemaPath}`,
     `Client: ${clientSchemaPath}`
   ].join('\n')

--- a/scripts/check-prisma-client.test.ts
+++ b/scripts/check-prisma-client.test.ts
@@ -34,11 +34,14 @@ describe('Prisma Client fingerprint', () => {
     expect(PRISMA_CLIENT_SCHEMA_RELATIVE_PATH).toBe('node_modules/.prisma/client/schema.prisma')
   })
 
-  it('runs the fingerprint check before npm test', () => {
+  it('runs the fingerprint check before npm test and npm run dev', () => {
     const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
-      scripts: { pretest?: string }
+      scripts: { predev?: string; pretest?: string }
     }
     expect(pkg.scripts.pretest).toBe('node scripts/check-prisma-client.mjs')
+    expect(pkg.scripts.predev).toBe(
+      'node scripts/check-prisma-client.mjs && node scripts/dev-app-branding.cjs'
+    )
   })
 
   it('accepts a generated client that matches the source schema', () => {


### PR DESCRIPTION
## Problem

After `prisma/schema.prisma` changes, an existing generated Prisma Client can remain stale. `npm run dev` previously launched Electron anyway, read the Session catalog, and then failed during Session projection with an opaque `application-composition` / `errorCategory: object` diagnostic.

## Proposed change

- Run the existing Prisma Client fingerprint guard from `predev`, before Electron startup.
- Make the mismatch instruction apply to development commands as well as tests.
- Pin the `predev` wiring in the existing fingerprint test.

This keeps generation explicit: a stale checkout fails immediately with `npx prisma generate` or `npm install` instead of rewriting dependencies on every development launch.

## Scope and non-goals

- No runtime application behavior changes when the generated client is current.
- No database schema, migration, Session JSON, projection format, persistence owner, or enum/state changes.
- No historical-data compatibility path is added; existing Session data was not the cause.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- stale Prisma Client detection -> `node scripts/check-prisma-client.mjs` before regeneration -> failed with the expected regeneration instruction
- Prisma Client recovery -> `npx prisma generate` then `node scripts/check-prisma-client.mjs` -> passed
- predev wiring and fingerprint behavior -> `npx vitest run scripts/check-prisma-client.test.ts` -> 6 tests passed
- changed script lint -> `npx eslint scripts/check-prisma-client.mjs scripts/check-prisma-client.test.ts` -> passed
- original startup symptom -> `npm run dev` after regeneration -> application startup completed; graceful shutdown completed
- patch integrity -> `git diff --check` -> passed

The change touches package script metadata, so exact-head PR Gate is the final authority for the complete and platform-selected checks. Full local `npm test` was intentionally not run per maintainer instruction.

## Review focus

- Confirm that failing fast is preferable to running `prisma generate` automatically on every dev launch.
- Confirm the existing fingerprint guard is the right shared boundary for both tests and development startup.
