### PR TITLE
fix(renderer): recover asynchronous job and provider state

### DIFF
--- a/src/renderer/src/lib/compute/useJobAnalysisEffect.render.test.tsx
+++ b/src/renderer/src/lib/compute/useJobAnalysisEffect.render.test.tsx
@@ -78,6 +78,7 @@ describe('useJobAnalysisEffect persistence readiness', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     act(() => root.unmount())
     container.remove()
   })
@@ -227,5 +228,65 @@ describe('useJobAnalysisEffect persistence readiness', () => {
 
     expect(jobsPendingNotification).toHaveBeenCalledWith('session-1')
     expect(sendMessage).toHaveBeenCalledOnce()
+  })
+
+  it('retries a pending-analysis scan after a transient transport failure', async () => {
+    vi.useFakeTimers()
+    jobsPendingNotification
+      .mockRejectedValueOnce(new Error('main process unavailable'))
+      .mockResolvedValueOnce([makeCompletedJob()])
+
+    await act(async () => root.render(<Probe enabled />))
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync()
+    })
+
+    expect(jobsPendingNotification).toHaveBeenCalledTimes(2)
+    expect(sendMessage).toHaveBeenCalledOnce()
+    vi.useRealTimers()
+  })
+
+  it('projects successful consumption locally without waiting for a follow-up hydration', async () => {
+    jobsPendingNotification.mockResolvedValueOnce([])
+    jobsList.mockImplementationOnce(() => new Promise(() => undefined))
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'project-a',
+          title: 'Ready',
+          cwd: '/workspace/project-a',
+          status: 'idle',
+          messages: [],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    })
+
+    await act(async () => root.render(<Probe enabled />))
+    act(() => useSessionJobStore.getState().applyUpdate(makeCompletedJob()))
+    await act(async () => new Promise((resolve) => setTimeout(resolve, 0)))
+
+    expect(sendMessage).toHaveBeenCalledOnce()
+    act(() => {
+      useSessionStore.setState((state) => ({
+        sessions: state.sessions.map((session) =>
+          session.id === 'session-1' ? { ...session, status: 'running' } : session
+        )
+      }))
+      useSessionStore.setState((state) => ({
+        sessions: state.sessions.map((session) =>
+          session.id === 'session-1' ? { ...session, status: 'idle' } : session
+        )
+      }))
+    })
+    await act(async () => new Promise((resolve) => setTimeout(resolve, 0)))
+
+    expect(jobsMarkConsumed).toHaveBeenCalledWith('session-1', ['job-1'])
+    expect(useSessionJobStore.getState().jobsById.get('job-1')?.notification_consumed_at).toEqual(
+      expect.any(Number)
+    )
   })
 })

--- a/src/renderer/src/lib/compute/useJobAnalysisEffect.render.test.tsx
+++ b/src/renderer/src/lib/compute/useJobAnalysisEffect.render.test.tsx
@@ -230,6 +230,16 @@ describe('useJobAnalysisEffect persistence readiness', () => {
     expect(sendMessage).toHaveBeenCalledOnce()
   })
 
+  it('adds pending-scan jobs to the local store before dispatching analysis', async () => {
+    await act(async () => {
+      root.render(<Probe enabled />)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(useSessionJobStore.getState().jobsById.get('job-1')).toEqual(makeCompletedJob())
+    expect(sendMessage).toHaveBeenCalledOnce()
+  })
+
   it('retries a pending-analysis scan after a transient transport failure', async () => {
     vi.useFakeTimers()
     jobsPendingNotification

--- a/src/renderer/src/lib/compute/useJobAnalysisEffect.ts
+++ b/src/renderer/src/lib/compute/useJobAnalysisEffect.ts
@@ -111,7 +111,8 @@ export const useJobAnalysisEffect = ({
         .jobsPendingNotification(sessionId)
         .then((jobs) => {
           if (!isActive) return
-          for (const job of jobs) trigger.onJobDone(job)
+          const jobStore = useSessionJobStore.getState()
+          for (const job of jobs) jobStore.applyUpdate(job)
         })
         .catch((error) => {
           if (!isActive || useSessionJobStore.getState().hydratedSessionId !== sessionId) return

--- a/src/renderer/src/lib/compute/useJobAnalysisEffect.ts
+++ b/src/renderer/src/lib/compute/useJobAnalysisEffect.ts
@@ -41,6 +41,7 @@ export const useJobAnalysisEffect = ({
     if (!enabled) return
 
     let isActive = true
+    let pendingScanRetry: ReturnType<typeof setTimeout> | undefined
     const turnEndUnsubscribes = new Set<() => void>()
     const trigger = createJobAnalysisTrigger({
       isSessionInFlight: (sessionId) => {
@@ -59,8 +60,14 @@ export const useJobAnalysisEffect = ({
         if (!isActive) return
         if (typeof window.api?.compute?.jobsMarkConsumed === 'function') {
           await window.api.compute.jobsMarkConsumed(sessionId, jobIds)
-          // Refresh the in-memory job store so CompletedJobCard re-renders with consumed state.
-          void useSessionJobStore.getState().hydrate(sessionId)
+          const consumedAt = Date.now()
+          const jobStore = useSessionJobStore.getState()
+          for (const jobId of jobIds) {
+            const job = jobStore.jobsById.get(jobId)
+            if (job?.session_id === sessionId) {
+              jobStore.applyUpdate({ ...job, notification_consumed_at: consumedAt })
+            }
+          }
         }
       },
       onTurnEnd: (sessionId, callback) => {
@@ -93,14 +100,27 @@ export const useJobAnalysisEffect = ({
       }
     }
 
-    const scanPendingJobs = (sessionId: string | undefined): void => {
+    const scanPendingJobs = (sessionId: string | undefined, retryDelay = 1_000): void => {
       if (!sessionId) return
       if (typeof window.api?.compute?.jobsPendingNotification !== 'function') return
+      if (useSessionJobStore.getState().hydratedSessionId !== sessionId) return
+      clearTimeout(pendingScanRetry)
+      pendingScanRetry = undefined
 
-      void window.api.compute.jobsPendingNotification(sessionId).then((jobs) => {
-        if (!isActive) return
-        for (const job of jobs) trigger.onJobDone(job)
-      })
+      void window.api.compute
+        .jobsPendingNotification(sessionId)
+        .then((jobs) => {
+          if (!isActive) return
+          for (const job of jobs) trigger.onJobDone(job)
+        })
+        .catch((error) => {
+          if (!isActive || useSessionJobStore.getState().hydratedSessionId !== sessionId) return
+          console.warn('[compute] analysis-turn:pending-scan-failed', error)
+          pendingScanRetry = setTimeout(() => {
+            pendingScanRetry = undefined
+            scanPendingJobs(sessionId, Math.min(retryDelay * 2, 30_000))
+          }, retryDelay)
+        })
     }
 
     const initialState = useSessionJobStore.getState()
@@ -116,6 +136,7 @@ export const useJobAnalysisEffect = ({
 
     return () => {
       isActive = false
+      clearTimeout(pendingScanRetry)
       unsubscribeJobs()
       for (const unsubscribe of turnEndUnsubscribes) unsubscribe()
       turnEndUnsubscribes.clear()

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -1665,6 +1665,39 @@ describe('SettingsPage layout', () => {
     await waitFor(() => expect(document.body.textContent).not.toContain('Testing…'))
   })
 
+  it('ignores post-save Provider validation after the provider disappears', async () => {
+    installCustomProviderSnapshot()
+    let rejectValidation: ((error: Error) => void) | undefined
+    const validateProvider = vi.fn(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectValidation = reject
+        })
+    )
+    useSettingsStore.setState({
+      persistProvider: vi.fn().mockResolvedValue('custom-messages'),
+      validateProvider
+    })
+
+    await act(async () => root.render(<SettingsPage open onClose={vi.fn()} />))
+    await act(async () =>
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Edit"]')?.click()
+    )
+    await act(async () =>
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((button) => button.textContent?.trim() === 'Save')
+        ?.click()
+    )
+    await waitFor(() => expect(validateProvider).toHaveBeenCalledOnce())
+
+    act(() => useSettingsStore.setState({ providers: [] }))
+    await act(async () => rejectValidation?.(new Error('deleted provider validation failure')))
+
+    expect(document.body.querySelector('[role="alert"]')?.textContent ?? '').not.toContain(
+      'Could not test the provider connection.'
+    )
+  })
+
   it('switches to the General panel and shows the diagnostic log file', async () => {
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -1610,6 +1610,61 @@ describe('SettingsPage layout', () => {
     })
   })
 
+  it('ignores an older post-save Provider validation failure', async () => {
+    installCustomProviderSnapshot()
+    let rejectFirstValidation: ((error: Error) => void) | undefined
+    let resolveSecondValidation: (() => void) | undefined
+    const validateProvider = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectFirstValidation = reject
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSecondValidation = resolve
+          })
+      )
+    useSettingsStore.setState({
+      persistProvider: vi.fn().mockResolvedValue('custom-messages'),
+      validateProvider
+    })
+
+    await act(async () => root.render(<SettingsPage open onClose={vi.fn()} />))
+    await act(async () =>
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Edit"]')?.click()
+    )
+    await act(async () =>
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((button) => button.textContent?.trim() === 'Save')
+        ?.click()
+    )
+    await waitFor(() => expect(validateProvider).toHaveBeenCalledTimes(1))
+
+    await act(async () =>
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Edit"]')?.click()
+    )
+    await act(async () =>
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((button) => button.textContent?.trim() === 'Save')
+        ?.click()
+    )
+    await waitFor(() => expect(validateProvider).toHaveBeenCalledTimes(2))
+
+    await act(async () => rejectFirstValidation?.(new Error('stale settings IPC failure')))
+
+    expect(document.body.querySelector('[role="alert"]')?.textContent ?? '').not.toContain(
+      'Could not test the provider connection.'
+    )
+    expect(document.body.textContent).toContain('Testing…')
+
+    await act(async () => resolveSecondValidation?.())
+    await waitFor(() => expect(document.body.textContent).not.toContain('Testing…'))
+  })
+
   it('switches to the General panel and shows the diagnostic log file', async () => {
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -1584,6 +1584,32 @@ describe('SettingsPage layout', () => {
     )
   })
 
+  it('reports when post-save Provider validation does not complete', async () => {
+    installCustomProviderSnapshot()
+    const validateProvider = vi.fn().mockRejectedValue(new Error('settings IPC unavailable'))
+    useSettingsStore.setState({
+      persistProvider: vi.fn().mockResolvedValue('custom-messages'),
+      validateProvider
+    })
+
+    await act(async () => root.render(<SettingsPage open onClose={vi.fn()} />))
+    await act(async () =>
+      document.body.querySelector<HTMLButtonElement>('[aria-label="Edit"]')?.click()
+    )
+    await act(async () =>
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+        .find((button) => button.textContent?.trim() === 'Save')
+        ?.click()
+    )
+
+    await waitFor(() => {
+      expect(validateProvider).toHaveBeenCalledWith({ providerId: 'custom-messages' })
+      expect(document.body.querySelector('[role="alert"]')?.textContent).toContain(
+        'Could not test the provider connection.'
+      )
+    })
+  })
+
   it('switches to the General panel and shows the diagnostic log file', async () => {
     await act(async () => {
       root.render(<SettingsPage open onClose={vi.fn()} />)

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -389,6 +389,17 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
   const [busyProviderId, setBusyProviderId] = useState<string | undefined>(undefined)
   const [postSaveValidationFailed, setPostSaveValidationFailed] = useState(false)
   const postSaveValidationGeneration = useRef(0)
+  const postSaveValidationProviderId = useRef<string | undefined>(undefined)
+
+  useEffect(() => {
+    const providerId = postSaveValidationProviderId.current
+    if (!providerId || providers.some((provider) => provider.id === providerId)) return
+
+    postSaveValidationGeneration.current += 1
+    postSaveValidationProviderId.current = undefined
+    setBusyProviderId(undefined)
+    setPostSaveValidationFailed(false)
+  }, [providers])
 
   // Refresh settings whenever the dialog opens so external changes are reflected.
   useEffect(() => {
@@ -782,6 +793,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
 
   const openCreate = (): void => {
     postSaveValidationGeneration.current += 1
+    postSaveValidationProviderId.current = undefined
     setBusyProviderId(undefined)
     setPostSaveValidationFailed(false)
     navigate({ panel: 'model', view: { kind: 'create' } })
@@ -789,6 +801,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
 
   const openEdit = (provider: ProviderView): void => {
     postSaveValidationGeneration.current += 1
+    postSaveValidationProviderId.current = undefined
     setBusyProviderId(undefined)
     setPostSaveValidationFailed(false)
     navigate({
@@ -802,6 +815,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
   const handleSave = async (): Promise<void> => {
     if (providerEditTargetMissing) return
     postSaveValidationGeneration.current += 1
+    postSaveValidationProviderId.current = undefined
     setBusyProviderId(undefined)
     setIsSaving(true)
     setStatusMessage(undefined)
@@ -820,10 +834,12 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
 
       if (providerId) {
         const validationGeneration = ++postSaveValidationGeneration.current
+        postSaveValidationProviderId.current = providerId
         setBusyProviderId(providerId)
         void validateProvider({ providerId })
           .then(() => {
             if (postSaveValidationGeneration.current === validationGeneration) {
+              postSaveValidationProviderId.current = undefined
               setPostSaveValidationFailed(false)
             }
           })
@@ -1483,6 +1499,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                           setBusyProviderId(providerId)
                           if (providerId) {
                             postSaveValidationGeneration.current += 1
+                            postSaveValidationProviderId.current = undefined
                             setPostSaveValidationFailed(false)
                           }
                         }}

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -387,6 +387,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
   // Shared with ProvidersPanel: the post-save validation and the list's manual test both mark the
   // provider busy so its card shows "Testing…".
   const [busyProviderId, setBusyProviderId] = useState<string | undefined>(undefined)
+  const [postSaveValidationFailed, setPostSaveValidationFailed] = useState(false)
 
   // Refresh settings whenever the dialog opens so external changes are reflected.
   useEffect(() => {
@@ -778,13 +779,18 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
     setStatusMessage(undefined)
   }
 
-  const openCreate = (): void => navigate({ panel: 'model', view: { kind: 'create' } })
+  const openCreate = (): void => {
+    setPostSaveValidationFailed(false)
+    navigate({ panel: 'model', view: { kind: 'create' } })
+  }
 
-  const openEdit = (provider: ProviderView): void =>
+  const openEdit = (provider: ProviderView): void => {
+    setPostSaveValidationFailed(false)
     navigate({
       panel: 'model',
       view: { kind: 'edit', providerId: provider.id }
     })
+  }
 
   const closeForm = (): void => navigate({ panel: 'model', view: { kind: 'list' } })
 
@@ -792,6 +798,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
     if (providerEditTargetMissing) return
     setIsSaving(true)
     setStatusMessage(undefined)
+    setPostSaveValidationFailed(false)
 
     try {
       // Persist first and return to the provider list immediately — don't hold the form open waiting
@@ -806,7 +813,9 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
 
       if (providerId) {
         setBusyProviderId(providerId)
-        void validateProvider({ providerId }).finally(() => setBusyProviderId(undefined))
+        void validateProvider({ providerId })
+          .catch(() => setPostSaveValidationFailed(true))
+          .finally(() => setBusyProviderId(undefined))
       }
     } catch (error) {
       setStatusOk(false)
@@ -1439,12 +1448,22 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                       </div>
                     </div>
                   ) : (
-                    <ProvidersPanel
-                      onCreateProvider={openCreate}
-                      onEditProvider={openEdit}
-                      busyProviderId={busyProviderId}
-                      onBusyProviderChange={setBusyProviderId}
-                    />
+                    <>
+                      {postSaveValidationFailed ? (
+                        <p className="mx-5 mt-5 text-sm text-destructive" role="alert">
+                          {t('Could not test the provider connection.')}
+                        </p>
+                      ) : null}
+                      <ProvidersPanel
+                        onCreateProvider={openCreate}
+                        onEditProvider={openEdit}
+                        busyProviderId={busyProviderId}
+                        onBusyProviderChange={(providerId) => {
+                          setBusyProviderId(providerId)
+                          if (providerId) setPostSaveValidationFailed(false)
+                        }}
+                      />
+                    </>
                   )}
                 </SettingsPanelLoadingBoundary>
               </div>

--- a/src/renderer/src/pages/settings/SettingsPage.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.tsx
@@ -388,6 +388,7 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
   // provider busy so its card shows "Testing…".
   const [busyProviderId, setBusyProviderId] = useState<string | undefined>(undefined)
   const [postSaveValidationFailed, setPostSaveValidationFailed] = useState(false)
+  const postSaveValidationGeneration = useRef(0)
 
   // Refresh settings whenever the dialog opens so external changes are reflected.
   useEffect(() => {
@@ -780,11 +781,15 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
   }
 
   const openCreate = (): void => {
+    postSaveValidationGeneration.current += 1
+    setBusyProviderId(undefined)
     setPostSaveValidationFailed(false)
     navigate({ panel: 'model', view: { kind: 'create' } })
   }
 
   const openEdit = (provider: ProviderView): void => {
+    postSaveValidationGeneration.current += 1
+    setBusyProviderId(undefined)
     setPostSaveValidationFailed(false)
     navigate({
       panel: 'model',
@@ -796,6 +801,8 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
 
   const handleSave = async (): Promise<void> => {
     if (providerEditTargetMissing) return
+    postSaveValidationGeneration.current += 1
+    setBusyProviderId(undefined)
     setIsSaving(true)
     setStatusMessage(undefined)
     setPostSaveValidationFailed(false)
@@ -812,10 +819,24 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
       navigate({ panel: 'model', view: { kind: 'list' } })
 
       if (providerId) {
+        const validationGeneration = ++postSaveValidationGeneration.current
         setBusyProviderId(providerId)
         void validateProvider({ providerId })
-          .catch(() => setPostSaveValidationFailed(true))
-          .finally(() => setBusyProviderId(undefined))
+          .then(() => {
+            if (postSaveValidationGeneration.current === validationGeneration) {
+              setPostSaveValidationFailed(false)
+            }
+          })
+          .catch(() => {
+            if (postSaveValidationGeneration.current === validationGeneration) {
+              setPostSaveValidationFailed(true)
+            }
+          })
+          .finally(() => {
+            if (postSaveValidationGeneration.current === validationGeneration) {
+              setBusyProviderId(undefined)
+            }
+          })
       }
     } catch (error) {
       setStatusOk(false)
@@ -1460,7 +1481,10 @@ const SettingsPage = forwardRef<SettingsPageHandle, SettingsPageProps>(function 
                         busyProviderId={busyProviderId}
                         onBusyProviderChange={(providerId) => {
                           setBusyProviderId(providerId)
-                          if (providerId) setPostSaveValidationFailed(false)
+                          if (providerId) {
+                            postSaveValidationGeneration.current += 1
+                            setPostSaveValidationFailed(false)
+                          }
                         }}
                       />
                     </>

--- a/src/renderer/src/stores/session-job-store.test.ts
+++ b/src/renderer/src/stores/session-job-store.test.ts
@@ -64,6 +64,50 @@ describe('session job store — hydrate', () => {
     expect(state.jobsById.has('new')).toBe(true)
     expect(state.hydratedSessionId).toBe('sess-2')
   })
+
+  it('does not let an older response replace a newer session hydration', async () => {
+    let resolveFirst: ((jobs: JobSummary[]) => void) | undefined
+    let resolveSecond: ((jobs: JobSummary[]) => void) | undefined
+    setJobsApi({
+      jobsList: vi
+        .fn()
+        .mockImplementationOnce(
+          () => new Promise<JobSummary[]>((resolve) => (resolveFirst = resolve))
+        )
+        .mockImplementationOnce(
+          () => new Promise<JobSummary[]>((resolve) => (resolveSecond = resolve))
+        )
+    })
+
+    const firstHydration = useSessionJobStore.getState().hydrate('sess-1')
+    const secondHydration = useSessionJobStore.getState().hydrate('sess-2')
+
+    resolveSecond?.([makeJob({ job_id: 'new-session-job', session_id: 'sess-2' })])
+    await secondHydration
+    resolveFirst?.([makeJob({ job_id: 'old-session-job', session_id: 'sess-1' })])
+    await firstHydration
+
+    const state = useSessionJobStore.getState()
+    expect(state.hydratedSessionId).toBe('sess-2')
+    expect(state.jobsById.has('new-session-job')).toBe(true)
+    expect(state.jobsById.has('old-session-job')).toBe(false)
+  })
+
+  it('preserves a pushed update that arrives while hydration is pending', async () => {
+    let resolveHydration: ((jobs: JobSummary[]) => void) | undefined
+    setJobsApi({
+      jobsList: vi.fn(() => new Promise<JobSummary[]>((resolve) => (resolveHydration = resolve)))
+    })
+
+    const hydration = useSessionJobStore.getState().hydrate('sess-1')
+    useSessionJobStore
+      .getState()
+      .applyUpdate(makeJob({ job_id: 'job-race', session_id: 'sess-1', status: 'success' }))
+    resolveHydration?.([makeJob({ job_id: 'job-race', session_id: 'sess-1', status: 'running' })])
+    await hydration
+
+    expect(useSessionJobStore.getState().jobsById.get('job-race')?.status).toBe('success')
+  })
 })
 
 describe('session job store — applyUpdate', () => {

--- a/src/renderer/src/stores/session-job-store.ts
+++ b/src/renderer/src/stores/session-job-store.ts
@@ -31,36 +31,68 @@ export const createInitialSessionJobState = (): SessionJobStoreData => ({
   isLoaded: false
 })
 
-export const useSessionJobStore = create<SessionJobStore>((set, get) => ({
-  ...createInitialSessionJobState(),
+export const useSessionJobStore = create<SessionJobStore>((set, get) => {
+  let latestHydrationRequest = 0
+  let latestUpdateRevision = 0
+  const updateRevisionByJobId = new Map<string, number>()
 
-  // Fetches all jobs for `sessionId` from the main process and replaces the current map.
-  // Multiple concurrent calls are safe — the last one wins (state is plain data).
-  hydrate: async (sessionId) => {
-    const jobs = await window.api.compute.jobsList({ sessionId })
-    const jobsById = new Map(jobs.map((j) => [j.job_id, j]))
-    set({ jobsById, hydratedSessionId: sessionId, isLoaded: true })
-  },
+  return {
+    ...createInitialSessionJobState(),
 
-  // Upserts a single job received via broadcast. Works even if the store has not been hydrated yet
-  // (the job simply lands in the map for when selectors query it).
-  applyUpdate: (job) => {
-    set((state) => {
-      const next = new Map(state.jobsById)
-      next.set(job.job_id, job)
-      return { jobsById: next }
-    })
-  },
+    // Fetches all jobs for `sessionId`. A newer hydration intent wins, while broadcasts received
+    // after this request started remain authoritative over its snapshot.
+    hydrate: async (sessionId) => {
+      const requestId = ++latestHydrationRequest
+      const startedAtUpdateRevision = latestUpdateRevision
+      const jobs = await window.api.compute.jobsList({ sessionId })
+      if (requestId !== latestHydrationRequest) return
 
-  // Returns running jobs for the given session — used by RemoteJobBadge and similar UI.
-  runningJobsForSession: (sessionId) =>
-    Array.from(get().jobsById.values()).filter(
-      (j) => j.session_id === sessionId && j.status === 'running'
-    ),
+      set((state) => {
+        const next = new Map<string, JobSummary>()
 
-  // Returns all jobs for the given session, sorted by created_at descending.
-  allJobsForSession: (sessionId) =>
-    Array.from(get().jobsById.values())
-      .filter((j) => j.session_id === sessionId)
-      .sort((a, b) => b.created_at - a.created_at)
-}))
+        for (const [jobId, job] of state.jobsById) {
+          const updateRevision = updateRevisionByJobId.get(jobId)
+          if (
+            (job.session_id !== sessionId && updateRevision !== undefined) ||
+            (job.session_id === sessionId &&
+              updateRevision !== undefined &&
+              updateRevision > startedAtUpdateRevision)
+          ) {
+            next.set(jobId, job)
+          }
+        }
+
+        for (const job of jobs) {
+          const updateRevision = updateRevisionByJobId.get(job.job_id)
+          if (updateRevision !== undefined && updateRevision > startedAtUpdateRevision) continue
+          next.set(job.job_id, job)
+        }
+
+        return { jobsById: next, hydratedSessionId: sessionId, isLoaded: true }
+      })
+    },
+
+    // Upserts a single job received via broadcast. Works even if the store has not been hydrated yet
+    // (the job simply lands in the map for when selectors query it).
+    applyUpdate: (job) => {
+      updateRevisionByJobId.set(job.job_id, ++latestUpdateRevision)
+      set((state) => {
+        const next = new Map(state.jobsById)
+        next.set(job.job_id, job)
+        return { jobsById: next }
+      })
+    },
+
+    // Returns running jobs for the given session — used by RemoteJobBadge and similar UI.
+    runningJobsForSession: (sessionId) =>
+      Array.from(get().jobsById.values()).filter(
+        (j) => j.session_id === sessionId && j.status === 'running'
+      ),
+
+    // Returns all jobs for the given session, sorted by created_at descending.
+    allJobsForSession: (sessionId) =>
+      Array.from(get().jobsById.values())
+        .filter((j) => j.session_id === sessionId)
+        .sort((a, b) => b.created_at - a.created_at)
+  }
+})


### PR DESCRIPTION
## Problem

Three renderer recovery paths could silently stall or expose stale state when the main process or IPC transport was briefly unavailable:

1. Saving a Provider starts connection validation in the background. A rejected validation promise was only followed by `finally`, so the card stopped showing `Testing…` but the rejection was unhandled and the UI never said that validation had not completed. Overlapping saves could also let an older validation settle after a newer one and overwrite the latest notice/busy state.
2. The post-compute pending-analysis scan had no rejection handler. A transient IPC failure stopped recovery until another broadcast, navigation, or restart. After a successful consumed-state write, the renderer also depended on an unobserved follow-up hydration, so its local consumed state could remain stale.
3. `SessionJobStore.hydrate()` let an older request replace a newer session response and replaced the complete job map, including newer broadcast updates that arrived while hydration was pending.

The regressions occur specifically when requests overlap or an asynchronous renderer-to-main call rejects/does not settle. They do not require corrupt persisted data, but they can leave the renderer misleadingly idle or stale for the rest of the current lifecycle.

## Proposed change

- Catch post-save Provider validation transport failures and show the existing connection-test failure copy. A renderer-local generation makes only the latest save/test authoritative for the notice and busy state, and a provider-id ref invalidates it when the target disappears.
- Retry failed pending-analysis recovery scans with a renderer-owned exponential delay (1s, capped at 30s), scoped to the active hydrated session and cancelled on effect cleanup.
- Merge pending-scan results into the existing in-memory store before analysis. After the main process confirms jobs were consumed, project the existing `notification_consumed_at` field locally instead of relying on a second hydration request.
- Make the latest hydration request authoritative and merge broadcast updates that are newer than the hydration snapshot.

This is a renderer-only recovery fix. It adds no IPC fields, database columns, persisted data, shared state enum values, or public data-model changes. The only new UI state is a local boolean; the Provider generation/id refs, hydration request/update revisions, and retry timer are private in-memory implementation details. No historical-data compatibility handling or migration is required.

## Scope and non-goals

- Included: the three reproduced Provider, Compute recovery, and Session Job hydration races described above.
- Excluded: Specialists, Update, Grant folder, Local file actions, and unrelated failure surfaces.
- Excluded: changing Provider validation result models, compute IPC contracts, persistence schemas, or user interaction flows beyond surfacing the incomplete validation and automatically retrying recovery.

## Acceptance criteria and validation

Regression tests were added first and failed consistently on the unfixed implementation for the reported reasons: missing Provider alert plus an unhandled rejection, a single failed analysis scan plus stale consumed state, and stale hydration responses overwriting newer state. They pass after the fix.

Final impact evidence, run after the last material edit:

- Provider post-save transport failure, overlapping-validation ordering, and target disappearance -> `SettingsPage.render.test.tsx` -> passed (89 tests in file).
- Pending-analysis retry, pending-job projection, and local consumed projection -> `useJobAnalysisEffect.render.test.tsx` + `job-analysis-trigger.test.ts` -> passed (24 tests).
- Hydration ordering and push reconciliation -> `session-job-store.test.ts` -> passed (11 tests).
- Existing job-store consumers -> `RemoteJobBadge.render.test.tsx` + `JobDetailModal.render.test.tsx` -> passed.
- Existing translated error copy -> `src/renderer/src/i18n/resources.test.ts` -> passed (684 tests).
- Combined targeted run -> 7 files, 828 tests passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Lint -> `npm run lint` -> passed.
- Formatting and whitespace -> Prettier check + `git diff --check` -> passed.

The store's exported shape and shared interfaces are unchanged, so broader main/preload contract tests were excluded. Full `npm test` was intentionally not run; exact-head PR Gate and platform lanes remain authoritative. The remaining uncovered local risk is a prolonged real-process outage/E2E lifecycle; the retry is unit-tested through its first failure/recovery cycle and bounded/cancelled in code.

## Review focus

- Whether the pending scan retry is correctly scoped and cleaned up across hydration/session lifecycle changes.
- Whether hydration reconciliation gives priority to the latest session intent and broadcasts received after each request starts.
- Whether the Provider generation/id refs correctly prevent older or deleted-target callbacks from changing the latest notice/busy state without introducing a new validation status model.
- Whether routing pending scan results through `applyUpdate` correctly keeps recovery and broadcast state on the same store path.
