### PR TITLE
fix(remote-access): harden pairing authorization

### DIFF
--- a/src/main/remote-access/pairing-page.ts
+++ b/src/main/remote-access/pairing-page.ts
@@ -72,7 +72,7 @@ export const renderPairingPage = (params: {
       <h1>Approve this browser</h1>
       <p>On your home computer, open Open Science → Settings → Remote, then verify and approve the pairing code below.</p>
       <div class="code" aria-label="Pairing code">${code}</div>
-      <p>Choose “Allow once” or “Always trust this browser”. Do not share this pairing code with anyone.</p>
+      <p>Choose “Allow for up to 12 hours” or “Always trust this browser”. Do not share this pairing code with anyone.</p>
       <div class="device">${browser} · ${platform}</div>
       <div id="status" class="status"><span class="dot"></span><span>Waiting for approval…</span></div>
     </main>

--- a/src/main/remote-access/pairing.test.ts
+++ b/src/main/remote-access/pairing.test.ts
@@ -36,17 +36,20 @@ type CapturedResponse = {
   response: ServerResponse
   headers: Map<string, string | string[]>
   body: () => string
+  status: () => number | undefined
 }
 
 const response = (): CapturedResponse => {
   const headers = new Map<string, string | string[]>()
   let body = ''
+  let status: number | undefined
   const value = {
     setHeader: (name: string, headerValue: string | string[]) => {
       headers.set(name.toLowerCase(), headerValue)
       return value
     },
-    writeHead: (_status: number, responseHeaders?: Record<string, string>) => {
+    writeHead: (responseStatus: number, responseHeaders?: Record<string, string>) => {
+      status = responseStatus
       for (const [name, headerValue] of Object.entries(responseHeaders ?? {})) {
         headers.set(name.toLowerCase(), headerValue)
       }
@@ -57,13 +60,18 @@ const response = (): CapturedResponse => {
       return value
     }
   }
-  return { response: value as unknown as ServerResponse, headers, body: () => body }
+  return {
+    response: value as unknown as ServerResponse,
+    headers,
+    body: () => body,
+    status: () => status
+  }
 }
 
 const cookiePair = (header: string): string => header.split(';', 1)[0]
 
 describe('RemoteSessionPairingManager', () => {
-  it('grants one-time access without allowing the browser to manage pairing', async () => {
+  it('grants temporary access without allowing the browser to manage pairing', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
     roots.push(root)
     const changed = vi.fn()
@@ -90,6 +98,8 @@ describe('RemoteSessionPairingManager', () => {
     expect(firstResponse.body()).not.toContain('class="mark"')
     expect(firstResponse.body()).toContain('Approve this browser')
     expect(firstResponse.body()).toContain('Open Science → Settings → Remote')
+    expect(firstResponse.body()).toContain('Choose “Allow for up to 12 hours”')
+    expect(firstResponse.body()).not.toContain('Choose “Allow once”')
     expect(firstResponse.body()).not.toContain('Settings → Remote control')
     const pendingCookie = cookiePair(firstResponse.headers.get('set-cookie') as string)
     const [pending] = manager.pendingViews()
@@ -119,6 +129,46 @@ describe('RemoteSessionPairingManager', () => {
     ).resolves.toMatchObject({ kind: 'authorized' })
     expect(manager.trustedViews()).toHaveLength(0)
     expect(changed).toHaveBeenCalled()
+  })
+
+  it('keeps an existing pairing request pending when the queue reaches capacity', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
+    roots.push(root)
+    const manager = await RemoteSessionPairingManager.create({
+      repository: new RemoteAccessRepository(root),
+      isAllowedRemoteHost: (hostname) => hostname === 'home.example.ts.net',
+      isEnabled: () => true,
+      onChanged: vi.fn()
+    })
+
+    const firstResponse = response()
+    await manager.webAccess.authorizeHttp(
+      request('/'),
+      firstResponse.response,
+      new URL('https://home.example.ts.net/')
+    )
+    const firstCookie = cookiePair(firstResponse.headers.get('set-cookie') as string)
+
+    let rejectedResponse: CapturedResponse | undefined
+    for (let index = 0; index < 20; index += 1) {
+      rejectedResponse = response()
+      await manager.webAccess.authorizeHttp(
+        request('/', { 'x-forwarded-for': `203.0.113.${index + 11}` }),
+        rejectedResponse.response,
+        new URL('https://home.example.ts.net/')
+      )
+    }
+
+    expect(rejectedResponse?.status()).toBe(429)
+    expect(rejectedResponse?.headers.get('retry-after')).toBeDefined()
+
+    const statusResponse = response()
+    await manager.webAccess.authorizeHttp(
+      request('/__open_science_remote/pair/status', { cookie: firstCookie }),
+      statusResponse.response,
+      new URL('https://home.example.ts.net/__open_science_remote/pair/status')
+    )
+    expect(JSON.parse(statusResponse.body())).toMatchObject({ status: 'pending' })
   })
 
   it('persists always-trusted browsers and rejects the wrong public host or origin', async () => {
@@ -324,6 +374,81 @@ describe('RemoteSessionPairingManager', () => {
     expect(save).toHaveBeenCalledTimes(2)
     expect(save.mock.calls[1][0].trustedBrowsers).toHaveLength(0)
     expect(manager.trustedViews()).toHaveLength(0)
+  })
+
+  it('allows only one concurrent persistent approval for a pairing request', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
+    roots.push(root)
+    const repository = new RemoteAccessRepository(root)
+    const manager = await RemoteSessionPairingManager.create({
+      repository,
+      isAllowedRemoteHost: (hostname) => hostname === 'home.example.ts.net',
+      isEnabled: () => true,
+      onChanged: vi.fn()
+    })
+    await manager.webAccess.authorizeHttp(
+      request('/'),
+      response().response,
+      new URL('https://home.example.ts.net/')
+    )
+    const [pending] = manager.pendingViews()
+    let releaseSave: (() => void) | undefined
+    const saveGate = new Promise<void>((resolve) => {
+      releaseSave = resolve
+    })
+    const save = vi
+      .spyOn(repository, 'save')
+      .mockReturnValueOnce(saveGate)
+      .mockResolvedValue(undefined)
+
+    const firstApproval = manager.approve(pending.id, 'always')
+    await vi.waitFor(() => expect(save).toHaveBeenCalledOnce())
+    const secondApproval = manager.approve(pending.id, 'always')
+    releaseSave?.()
+
+    const outcomes = await Promise.allSettled([firstApproval, secondApproval])
+    expect(outcomes.filter((outcome) => outcome.status === 'fulfilled')).toHaveLength(1)
+    expect(outcomes.filter((outcome) => outcome.status === 'rejected')).toHaveLength(1)
+    expect(manager.trustedViews()).toHaveLength(1)
+  })
+
+  it('removes a persistent approval invalidated before the browser claims it', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
+    roots.push(root)
+    const repository = new RemoteAccessRepository(root)
+    const manager = await RemoteSessionPairingManager.create({
+      repository,
+      isAllowedRemoteHost: (hostname) => hostname === 'home.example.ts.net',
+      isEnabled: () => true,
+      onChanged: vi.fn()
+    })
+    await manager.webAccess.authorizeHttp(
+      request('/'),
+      response().response,
+      new URL('https://home.example.ts.net/')
+    )
+    const [pending] = manager.pendingViews()
+    let releaseSave: (() => void) | undefined
+    const saveGate = new Promise<void>((resolve) => {
+      releaseSave = resolve
+    })
+    const persist = repository.save.bind(repository)
+    const save = vi.spyOn(repository, 'save')
+    save
+      .mockImplementationOnce(async (value) => {
+        await saveGate
+        await persist(value)
+      })
+      .mockImplementation((value) => persist(value))
+
+    const approval = manager.approve(pending.id, 'always')
+    await vi.waitFor(() => expect(save).toHaveBeenCalledOnce())
+    const invalidation = manager.clearTransientAccess()
+    releaseSave?.()
+
+    await expect(approval).rejects.toThrow('expired or is no longer pending')
+    await invalidation
+    expect((await repository.load()).trustedBrowsers).toHaveLength(0)
   })
 
   it('rejects an invalid pairing decision without granting or persisting access', async () => {

--- a/src/main/remote-access/pairing.test.ts
+++ b/src/main/remote-access/pairing.test.ts
@@ -451,6 +451,46 @@ describe('RemoteSessionPairingManager', () => {
     expect((await repository.load()).trustedBrowsers).toHaveLength(0)
   })
 
+  it('removes a persistent approval when the browser never claims it before expiry', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
+    roots.push(root)
+    const repository = new RemoteAccessRepository(root)
+    let now = 0
+    const manager = await RemoteSessionPairingManager.create({
+      repository,
+      isAllowedRemoteHost: (hostname) => hostname === 'home.example.ts.net',
+      isEnabled: () => true,
+      onChanged: vi.fn(),
+      now: () => now
+    })
+    await manager.webAccess.authorizeHttp(
+      request('/'),
+      response().response,
+      new URL('https://home.example.ts.net/')
+    )
+    const [pending] = manager.pendingViews()
+    await manager.approve(pending.id, 'always')
+    expect((await repository.load()).trustedBrowsers).toHaveLength(1)
+
+    const persist = repository.save.bind(repository)
+    const save = vi
+      .spyOn(repository, 'save')
+      .mockRejectedValueOnce(new Error('cleanup persistence failed'))
+      .mockImplementation((value) => persist(value))
+
+    now = 11 * 60 * 1_000
+    expect(manager.pendingViews()).toHaveLength(0)
+
+    await vi.waitFor(() => expect(save).toHaveBeenCalledOnce())
+    expect((await repository.load()).trustedBrowsers).toHaveLength(1)
+
+    await vi.waitFor(async () => {
+      manager.pendingViews()
+      expect((await repository.load()).trustedBrowsers).toHaveLength(0)
+    })
+    expect(save).toHaveBeenCalledTimes(2)
+  })
+
   it('rejects an invalid pairing decision without granting or persisting access', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
     roots.push(root)

--- a/src/main/remote-access/pairing.ts
+++ b/src/main/remote-access/pairing.ts
@@ -31,6 +31,7 @@ type BrowserDescription = { browser: string; platform: string }
 
 type PairingGrant = {
   decision: RemotePairingDecision
+  sessionId: string
   cookieValue: string
 }
 
@@ -41,7 +42,7 @@ type PendingPairing = BrowserDescription & {
   address?: string
   requestedAt: number
   expiresAt: number
-  status: 'pending' | 'approved' | 'rejected'
+  status: 'pending' | 'approving' | 'approved' | 'rejected'
   grant?: PairingGrant
 }
 
@@ -159,6 +160,7 @@ export class RemoteSessionPairingManager {
   private readonly pendingRevocations = new Set<string>()
   private readonly now: () => number
   private storedMutationQueue: Promise<void> = Promise.resolve()
+  private authorizationGeneration = 0
 
   private constructor(
     private readonly options: PairingManagerOptions,
@@ -267,28 +269,52 @@ export class RemoteSessionPairingManager {
     const sessionId = randomUUID()
     const secret = randomBytes(32).toString('base64url')
     const cookieValue = `${sessionId}.${secret}`
-    if (decision === 'once') {
-      this.oneTimeSessions.set(sessionId, {
-        tokenHash: hash(secret),
-        expiresAt: this.now() + ONE_TIME_SESSION_TTL_MS
-      })
-    } else {
-      const trusted: StoredTrustedBrowser = {
-        id: sessionId,
-        browser: request.browser,
-        platform: request.platform,
-        tokenHash: hash(secret),
-        createdAt: this.now(),
-        lastSeenAt: this.now()
+    const authorizationGeneration = this.authorizationGeneration
+    request.status = 'approving'
+    request.grant = { decision, sessionId, cookieValue }
+
+    try {
+      if (decision === 'once') {
+        this.oneTimeSessions.set(sessionId, {
+          tokenHash: hash(secret),
+          expiresAt: this.now() + ONE_TIME_SESSION_TTL_MS
+        })
+      } else {
+        const trusted: StoredTrustedBrowser = {
+          id: sessionId,
+          browser: request.browser,
+          platform: request.platform,
+          tokenHash: hash(secret),
+          createdAt: this.now(),
+          lastSeenAt: this.now()
+        }
+        await this.commitStoredMutation((stored) => ({
+          ...stored,
+          trustedBrowsers: [...stored.trustedBrowsers, trusted]
+        }))
       }
-      await this.commitStoredMutation((stored) => ({
-        ...stored,
-        trustedBrowsers: [...stored.trustedBrowsers, trusted]
-      }))
+
+      if (
+        authorizationGeneration !== this.authorizationGeneration ||
+        this.pending.get(requestId) !== request
+      ) {
+        if (decision === 'once') this.oneTimeSessions.delete(sessionId)
+        else await this.removeStoredTrustedBrowsers(new Set([sessionId]))
+        throw new Error('This pairing request has expired or is no longer pending.')
+      }
+
+      request.status = 'approved'
+      this.options.onChanged()
+    } catch (error) {
+      if (
+        authorizationGeneration === this.authorizationGeneration &&
+        this.pending.get(requestId) === request
+      ) {
+        request.status = 'pending'
+        request.grant = undefined
+      }
+      throw error
     }
-    request.status = 'approved'
-    request.grant = { decision, cookieValue }
-    this.options.onChanged()
   }
 
   reject(requestId: string): void {
@@ -323,10 +349,19 @@ export class RemoteSessionPairingManager {
     }
   }
 
-  clearTransientAccess(): void {
+  async clearTransientAccess(): Promise<void> {
+    this.authorizationGeneration += 1
+    const unclaimedTrustedBrowsers = new Set(
+      [...this.pending.values()].flatMap((request) =>
+        request.grant?.decision === 'always' ? [request.grant.sessionId] : []
+      )
+    )
     this.pending.clear()
     this.oneTimeSessions.clear()
     this.options.onChanged()
+    if (unclaimedTrustedBrowsers.size === 0) return
+    const changed = await this.removeStoredTrustedBrowsers(unclaimedTrustedBrowsers)
+    if (changed) this.options.onChanged()
   }
 
   readonly webAccess: ExternalWebAccess = {
@@ -382,6 +417,15 @@ export class RemoteSessionPairingManager {
     if (request.method !== 'GET' && request.method !== 'HEAD') return 'denied'
 
     const pending = this.ensurePending(request, response)
+    if (!pending) {
+      const retryAt = Math.min(...[...this.pending.values()].map((entry) => entry.expiresAt))
+      response.setHeader(
+        'retry-after',
+        String(Math.max(1, Math.ceil((retryAt - this.now()) / 1_000)))
+      )
+      json(response, 429, { error: 'Too many pairing requests. Try again later.' })
+      return 'handled'
+    }
     const page = renderPairingPage(pending)
     response.writeHead(200, {
       'content-type': 'text/html; charset=utf-8',
@@ -426,15 +470,15 @@ export class RemoteSessionPairingManager {
     return sessionAccess ? { sessionId: sessionAccess.sessionId } : undefined
   }
 
-  private ensurePending(request: IncomingMessage, response: ServerResponse): PendingPairing {
+  private ensurePending(
+    request: IncomingMessage,
+    response: ServerResponse
+  ): PendingPairing | undefined {
     this.pruneExpired()
     const existing = this.readPendingCookie(request)
     if (existing) return existing
 
-    if (this.pending.size >= MAX_PENDING_REQUESTS) {
-      const oldest = [...this.pending.values()].sort((a, b) => a.requestedAt - b.requestedAt)[0]
-      if (oldest) this.pending.delete(oldest.id)
-    }
+    if (this.pending.size >= MAX_PENDING_REQUESTS) return undefined
 
     const id = randomUUID()
     const secret = randomBytes(24).toString('base64url')
@@ -478,7 +522,7 @@ export class RemoteSessionPairingManager {
       json(response, 200, { status: 'expired' })
       return
     }
-    if (pending.status === 'pending') {
+    if (pending.status === 'pending' || pending.status === 'approving') {
       json(response, 200, { status: 'pending', expiresAt: pending.expiresAt })
       return
     }
@@ -550,6 +594,17 @@ export class RemoteSessionPairingManager {
       () => undefined
     )
     return operation
+  }
+
+  private removeStoredTrustedBrowsers(browserIds: Set<string>): Promise<boolean> {
+    return this.commitStoredMutation((stored) => {
+      const trustedBrowsers = stored.trustedBrowsers.filter(
+        (browser) => !browserIds.has(browser.id)
+      )
+      return trustedBrowsers.length === stored.trustedBrowsers.length
+        ? undefined
+        : { ...stored, trustedBrowsers }
+    })
   }
 
   private pruneExpired(): void {

--- a/src/main/remote-access/pairing.ts
+++ b/src/main/remote-access/pairing.ts
@@ -161,6 +161,7 @@ export class RemoteSessionPairingManager {
   private readonly unclaimedTrustedBrowserCleanup = new Set<string>()
   private readonly now: () => number
   private storedMutationQueue: Promise<void> = Promise.resolve()
+  private unclaimedTrustedBrowserCleanupTask: Promise<void> | undefined
   private authorizationGeneration = 0
 
   private constructor(
@@ -617,14 +618,41 @@ export class RemoteSessionPairingManager {
     return changed
   }
 
+  private scheduleUnclaimedTrustedBrowserCleanup(): void {
+    if (this.unclaimedTrustedBrowserCleanupTask || this.unclaimedTrustedBrowserCleanup.size === 0) {
+      return
+    }
+
+    let succeeded = false
+    const cleanupTask = this.cleanupUnclaimedTrustedBrowsers([])
+      .then((changed) => {
+        succeeded = true
+        if (changed) this.options.onChanged()
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        if (this.unclaimedTrustedBrowserCleanupTask !== cleanupTask) return
+        this.unclaimedTrustedBrowserCleanupTask = undefined
+        if (succeeded) this.scheduleUnclaimedTrustedBrowserCleanup()
+      })
+    this.unclaimedTrustedBrowserCleanupTask = cleanupTask
+  }
+
   private pruneExpired(): void {
     const now = this.now()
     for (const [id, request] of this.pending) {
-      if (request.expiresAt <= now) this.pending.delete(id)
+      if (request.expiresAt > now) continue
+      if (request.grant?.decision === 'always') {
+        this.unclaimedTrustedBrowserCleanup.add(request.grant.sessionId)
+      } else if (request.grant?.decision === 'once') {
+        this.oneTimeSessions.delete(request.grant.sessionId)
+      }
+      this.pending.delete(id)
     }
     for (const [id, session] of this.oneTimeSessions) {
       if (session.expiresAt <= now) this.oneTimeSessions.delete(id)
     }
+    this.scheduleUnclaimedTrustedBrowserCleanup()
   }
 }
 

--- a/src/main/remote-access/pairing.ts
+++ b/src/main/remote-access/pairing.ts
@@ -158,6 +158,7 @@ export class RemoteSessionPairingManager {
   private readonly pending = new Map<string, PendingPairing>()
   private readonly oneTimeSessions = new Map<string, OneTimeSession>()
   private readonly pendingRevocations = new Set<string>()
+  private readonly unclaimedTrustedBrowserCleanup = new Set<string>()
   private readonly now: () => number
   private storedMutationQueue: Promise<void> = Promise.resolve()
   private authorizationGeneration = 0
@@ -299,7 +300,7 @@ export class RemoteSessionPairingManager {
         this.pending.get(requestId) !== request
       ) {
         if (decision === 'once') this.oneTimeSessions.delete(sessionId)
-        else await this.removeStoredTrustedBrowsers(new Set([sessionId]))
+        else await this.cleanupUnclaimedTrustedBrowsers([sessionId])
         throw new Error('This pairing request has expired or is no longer pending.')
       }
 
@@ -359,8 +360,7 @@ export class RemoteSessionPairingManager {
     this.pending.clear()
     this.oneTimeSessions.clear()
     this.options.onChanged()
-    if (unclaimedTrustedBrowsers.size === 0) return
-    const changed = await this.removeStoredTrustedBrowsers(unclaimedTrustedBrowsers)
+    const changed = await this.cleanupUnclaimedTrustedBrowsers(unclaimedTrustedBrowsers)
     if (changed) this.options.onChanged()
   }
 
@@ -605,6 +605,16 @@ export class RemoteSessionPairingManager {
         ? undefined
         : { ...stored, trustedBrowsers }
     })
+  }
+
+  private async cleanupUnclaimedTrustedBrowsers(browserIds: Iterable<string>): Promise<boolean> {
+    for (const browserId of browserIds) this.unclaimedTrustedBrowserCleanup.add(browserId)
+    if (this.unclaimedTrustedBrowserCleanup.size === 0) return false
+
+    const cleanup = new Set(this.unclaimedTrustedBrowserCleanup)
+    const changed = await this.removeStoredTrustedBrowsers(cleanup)
+    for (const browserId of cleanup) this.unclaimedTrustedBrowserCleanup.delete(browserId)
+    return changed
   }
 
   private pruneExpired(): void {

--- a/src/main/remote-access/service.test.ts
+++ b/src/main/remote-access/service.test.ts
@@ -137,7 +137,7 @@ describe('RemoteAccessService', () => {
     await expect(service.approve({ requestId: 'request-1', decision: 'always' })).rejects.toThrow(
       'Remote access configuration could not be loaded'
     )
-    expect(() => service.reject('request-1')).toThrow(
+    await expect(service.reject('request-1')).rejects.toThrow(
       'Remote access configuration could not be loaded'
     )
     await expect(service.revoke('browser-1')).rejects.toThrow(
@@ -361,9 +361,49 @@ describe('RemoteAccessService', () => {
 
     const revocation = service.revoke('trusted-browser')
 
-    expect(controller.closeExternalConnections).toHaveBeenCalledWith('trusted-browser')
+    await vi.waitFor(() =>
+      expect(controller.closeExternalConnections).toHaveBeenCalledWith('trusted-browser')
+    )
     releaseSave?.()
     await revocation
+  })
+
+  it('does not retain an unclaimed trusted browser when access is disabled during approval', async () => {
+    const repository = await createRepository()
+    const service = await RemoteAccessService.create({
+      repository,
+      ...createReadyDeps(),
+      broadcast: vi.fn()
+    })
+    service.attachWebController(webController())
+    await service.setMode('remoteit')
+    await service.webAccess.authorizeHttp(
+      remoteRequest('private-app.r3proxy.com'),
+      remoteResponse(),
+      new URL('https://private-app.r3proxy.com/')
+    )
+    const [pending] = service.snapshot(true).pendingRequests
+    let releaseSave: (() => void) | undefined
+    const saveGate = new Promise<void>((resolve) => {
+      releaseSave = resolve
+    })
+    const persist = repository.save.bind(repository)
+    const save = vi.spyOn(repository, 'save')
+    save
+      .mockImplementationOnce(async (value) => {
+        await saveGate
+        await persist(value)
+      })
+      .mockImplementation((value) => persist(value))
+
+    const approval = service.approve({ requestId: pending.id, decision: 'always' })
+    await vi.waitFor(() => expect(save).toHaveBeenCalledOnce())
+    const disabling = service.disable()
+    await Promise.resolve()
+    releaseSave?.()
+    await Promise.all([approval, disabling])
+
+    expect((await repository.load()).trustedBrowsers).toHaveLength(0)
   })
 
   it('soft-disables access without deleting either provider service', async () => {

--- a/src/main/remote-access/service.test.ts
+++ b/src/main/remote-access/service.test.ts
@@ -406,6 +406,79 @@ describe('RemoteAccessService', () => {
     expect((await repository.load()).trustedBrowsers).toHaveLength(0)
   })
 
+  it('retries unclaimed trusted-browser cleanup after disable persistence fails', async () => {
+    const repository = await createRepository()
+    const service = await RemoteAccessService.create({
+      repository,
+      ...createReadyDeps(),
+      broadcast: vi.fn()
+    })
+    service.attachWebController(webController())
+    await service.setMode('remoteit')
+    await service.webAccess.authorizeHttp(
+      remoteRequest('private-app.r3proxy.com'),
+      remoteResponse(),
+      new URL('https://private-app.r3proxy.com/')
+    )
+    const [pending] = service.snapshot(true).pendingRequests
+    await service.approve({ requestId: pending.id, decision: 'always' })
+
+    const persist = repository.save.bind(repository)
+    vi.spyOn(repository, 'save')
+      .mockRejectedValueOnce(new Error('cleanup persistence failed'))
+      .mockImplementation((value) => persist(value))
+
+    await expect(service.disable()).resolves.toMatchObject({
+      mode: 'off',
+      enabled: false,
+      lifecycle: 'error',
+      error: 'cleanup persistence failed'
+    })
+    expect(await repository.load()).toMatchObject({
+      mode: 'off',
+      trustedBrowsers: [expect.objectContaining({ id: expect.any(String) })]
+    })
+
+    await expect(service.disable()).resolves.toMatchObject({
+      mode: 'off',
+      enabled: false,
+      lifecycle: 'disabled'
+    })
+    expect((await repository.load()).trustedBrowsers).toHaveLength(0)
+  })
+
+  it('reports a lifecycle error when setup invalidation cleanup fails', async () => {
+    const repository = await createRepository()
+    const deps = createReadyDeps()
+    const service = await RemoteAccessService.create({
+      repository,
+      ...deps,
+      broadcast: vi.fn()
+    })
+    service.attachWebController(webController())
+    await service.setMode('remoteit')
+    await service.webAccess.authorizeHttp(
+      remoteRequest('private-app.r3proxy.com'),
+      remoteResponse(),
+      new URL('https://private-app.r3proxy.com/')
+    )
+    const [pending] = service.snapshot(true).pendingRequests
+    await service.approve({ requestId: pending.id, decision: 'always' })
+
+    const persist = repository.save.bind(repository)
+    vi.spyOn(repository, 'save')
+      .mockRejectedValueOnce(new Error('cleanup persistence failed'))
+      .mockImplementation((value) => persist(value))
+
+    await expect(service.setMode('remoteit-public')).resolves.toMatchObject({
+      mode: 'remoteit-public',
+      enabled: false,
+      lifecycle: 'error',
+      error: 'cleanup persistence failed'
+    })
+    expect(deps.enableRemoteIt).toHaveBeenCalledTimes(1)
+  })
+
   it('soft-disables access without deleting either provider service', async () => {
     const repository = await createRepository()
     const deps = createReadyDeps()

--- a/src/main/remote-access/service.ts
+++ b/src/main/remote-access/service.ts
@@ -213,17 +213,27 @@ export class RemoteAccessService {
       if (this.activeMode !== 'off') this.assertProviderReady()
     } catch (error) {
       if (this.shutdownStarted) return this.snapshot(true)
-      await this.invalidateExternalAccess()
+      let failure = error
+      try {
+        await this.invalidateExternalAccess()
+      } catch (cleanupError) {
+        failure = cleanupError
+      }
       this.lifecycle = 'error'
-      this.error = error instanceof Error ? error.message : String(error)
+      this.error = failure instanceof Error ? failure.message : String(failure)
       this.notifyChanged()
       return this.snapshot(true)
     }
 
     if (this.activeMode === 'off') {
-      await this.invalidateExternalAccess()
-      this.lifecycle = 'disabled'
-      this.error = undefined
+      try {
+        await this.invalidateExternalAccess()
+        this.lifecycle = 'disabled'
+        this.error = undefined
+      } catch (error) {
+        this.lifecycle = 'error'
+        this.error = error instanceof Error ? error.message : String(error)
+      }
       this.notifyChanged()
       return this.snapshot(true)
     }
@@ -278,11 +288,12 @@ export class RemoteAccessService {
     const webStopGeneration = this.webStopGeneration
 
     this.lifecycle = 'starting'
-    await this.invalidateExternalAccess(this.runtimeEnabled)
+    const invalidation = this.invalidateExternalAccess(this.runtimeEnabled)
     this.error = undefined
     this.notifyChanged()
 
     try {
+      await invalidation
       await this.refreshInstallation()
       if (this.shutdownStarted) return this.snapshot(true)
       this.assertProviderReady()
@@ -440,7 +451,13 @@ export class RemoteAccessService {
     this.lifecycle = 'stopping'
     const invalidation = this.invalidateExternalAccess()
     this.notifyChanged()
-    await invalidation
+
+    let failure: unknown
+    try {
+      await invalidation
+    } catch (error) {
+      failure = error
+    }
 
     if (this.activeMode !== 'off') {
       this.log.info('Provider route kept configured while local remote access is disabled', {
@@ -449,7 +466,20 @@ export class RemoteAccessService {
     }
     this.activeMode = 'off'
     this.accessUrl = undefined
-    if (persistPreference) await this.pairing.setModePreference('off')
+    if (persistPreference) {
+      try {
+        await this.pairing.setModePreference('off')
+      } catch (error) {
+        failure ??= error
+      }
+    }
+    if (failure) {
+      this.lifecycle = 'error'
+      this.error = failure instanceof Error ? failure.message : String(failure)
+      this.log.error('Remote access disable failed', failure)
+      this.notifyChanged()
+      return this.snapshot(true)
+    }
     this.lifecycle = 'disabled'
     this.error = undefined
     this.log.info('Remote access disabled locally')

--- a/src/main/remote-access/service.ts
+++ b/src/main/remote-access/service.ts
@@ -163,7 +163,9 @@ export class RemoteAccessService {
       this.webStopGeneration += 1
       if (this.shutdownStarted) return
       const shouldReportFailure = this.runtimeEnabled && this.activeMode !== 'off'
-      this.invalidateExternalAccess(false)
+      void this.invalidateExternalAccess(false).catch((error) => {
+        this.log.error('Remote access invalidation cleanup failed', error)
+      })
       if (!shouldReportFailure) return
       this.lifecycle = 'error'
       this.error = 'The local web service stopped. Detect again to restore remote access.'
@@ -211,7 +213,7 @@ export class RemoteAccessService {
       if (this.activeMode !== 'off') this.assertProviderReady()
     } catch (error) {
       if (this.shutdownStarted) return this.snapshot(true)
-      this.invalidateExternalAccess()
+      await this.invalidateExternalAccess()
       this.lifecycle = 'error'
       this.error = error instanceof Error ? error.message : String(error)
       this.notifyChanged()
@@ -219,7 +221,7 @@ export class RemoteAccessService {
     }
 
     if (this.activeMode === 'off') {
-      this.invalidateExternalAccess()
+      await this.invalidateExternalAccess()
       this.lifecycle = 'disabled'
       this.error = undefined
       this.notifyChanged()
@@ -276,7 +278,7 @@ export class RemoteAccessService {
     const webStopGeneration = this.webStopGeneration
 
     this.lifecycle = 'starting'
-    this.invalidateExternalAccess(this.runtimeEnabled)
+    await this.invalidateExternalAccess(this.runtimeEnabled)
     this.error = undefined
     this.notifyChanged()
 
@@ -361,20 +363,28 @@ export class RemoteAccessService {
     return this.setMode('off')
   }
 
-  async approve(
+  approve(
     request: ApproveRemotePairingRequest,
     canManage = true,
     canManagePairing = canManage
   ): Promise<RemoteAccessSnapshot> {
-    this.assertConfigurationAvailable()
-    await this.pairing.approve(request.requestId, request.decision)
-    return this.snapshot(canManage, canManagePairing)
+    return this.serialize(async () => {
+      this.assertConfigurationAvailable()
+      await this.pairing.approve(request.requestId, request.decision)
+      return this.snapshot(canManage, canManagePairing)
+    })
   }
 
-  reject(requestId: string, canManage = true, canManagePairing = canManage): RemoteAccessSnapshot {
-    this.assertConfigurationAvailable()
-    this.pairing.reject(requestId)
-    return this.snapshot(canManage, canManagePairing)
+  reject(
+    requestId: string,
+    canManage = true,
+    canManagePairing = canManage
+  ): Promise<RemoteAccessSnapshot> {
+    return this.serialize(async () => {
+      this.assertConfigurationAvailable()
+      this.pairing.reject(requestId)
+      return this.snapshot(canManage, canManagePairing)
+    })
   }
 
   async revoke(
@@ -382,12 +392,14 @@ export class RemoteAccessService {
     canManage = true,
     canManagePairing = canManage
   ): Promise<RemoteAccessSnapshot> {
-    this.assertConfigurationAvailable()
-    const revocation = this.pairing.revoke(browserId)
-    this.authorizationGeneration += 1
-    this.webController?.closeExternalConnections(browserId)
-    await revocation
-    return this.snapshot(canManage, canManagePairing)
+    return this.serialize(async () => {
+      this.assertConfigurationAvailable()
+      const revocation = this.pairing.revoke(browserId)
+      this.authorizationGeneration += 1
+      this.webController?.closeExternalConnections(browserId)
+      await revocation
+      return this.snapshot(canManage, canManagePairing)
+    })
   }
 
   shutdown(): Promise<void> {
@@ -395,12 +407,13 @@ export class RemoteAccessService {
     this.shutdownStarted = true
     this.detachWebController?.()
     this.detachWebController = undefined
-    this.invalidateExternalAccess()
+    const invalidation = this.invalidateExternalAccess()
     this.activeMode = 'off'
     this.lifecycle = 'disabled'
     this.error = undefined
     this.notifyChanged()
     this.shutdownPromise = this.serialize(async () => {
+      await invalidation
       this.webController = undefined
     })
     return this.shutdownPromise
@@ -414,19 +427,20 @@ export class RemoteAccessService {
     if (this.configurationError) throw this.configurationError
   }
 
-  private invalidateExternalAccess(closeConnections = true): void {
+  private invalidateExternalAccess(closeConnections = true): Promise<void> {
     this.authorizationGeneration += 1
     this.runtimeEnabled = false
     this.remoteHost = undefined
     this.accessUrl = undefined
     if (closeConnections) this.webController?.closeExternalConnections()
-    this.pairing.clearTransientAccess()
+    return this.pairing.clearTransientAccess()
   }
 
   private async stopActiveRoute(persistPreference: boolean): Promise<RemoteAccessSnapshot> {
     this.lifecycle = 'stopping'
-    this.invalidateExternalAccess()
+    const invalidation = this.invalidateExternalAccess()
     this.notifyChanged()
+    await invalidation
 
     if (this.activeMode !== 'off') {
       this.log.info('Provider route kept configured while local remote access is disabled', {

--- a/src/renderer/src/pages/settings/RemoteControlPanel.tsx
+++ b/src/renderer/src/pages/settings/RemoteControlPanel.tsx
@@ -824,7 +824,7 @@ export const RemoteControlPanel: RemoteControlPanelComponent = () => {
                       disabled={busy !== null}
                       onClick={() => approve(request.id, 'once')}
                     >
-                      {t('Allow once')}
+                      {t('Allow for up to 12 hours')}
                     </Button>
                     <Button
                       type="button"

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -2264,6 +2264,8 @@ describe('SettingsPage layout', () => {
       expect(document.body.textContent).toContain('Chrome on iOS · iOS/iPadOS')
       expect(document.body.textContent).toContain('Google Chrome · Windows')
       expect(document.body.textContent).toContain('123456')
+      expect(document.body.textContent).toContain('Allow for up to 12 hours')
+      expect(document.body.textContent).not.toContain('Allow once')
       expect(document.body.textContent).toContain(
         'Two-step verification requests and trusted browsers can be managed below'
       )

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -181,6 +181,7 @@
     "Allow external request?": "Autoriser la demande externe ?",
     "Allow for this conversation": "Autoriser pour cette conversation",
     "Allow for this project": "Autoriser pour ce projet",
+    "Allow for up to 12 hours": "Autoriser pendant 12 heures maximum",
     "Allow globally": "Autoriser pour tous les projets",
     "Allow once": "Autoriser une fois",
     "Allow package install": "Autoriser l'installation de paquets",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -170,6 +170,7 @@
     "Allow external request?": "外部リクエストを許可しますか？",
     "Allow for this conversation": "この会話で許可",
     "Allow for this project": "このプロジェクトで許可",
+    "Allow for up to 12 hours": "最長12時間許可",
     "Allow globally": "すべてのプロジェクトで許可",
     "Allow once": "今回のみ許可",
     "Allow package install": "パッケージのインストールを許可",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -169,6 +169,7 @@
     "Allow external request?": "외부 요청을 허용하시겠습니까?",
     "Allow for this conversation": "이 대화에서 허용",
     "Allow for this project": "이 프로젝트에서 허용",
+    "Allow for up to 12 hours": "최대 12시간 허용",
     "Allow globally": "모든 프로젝트에서 허용",
     "Allow once": "한 번만 허용",
     "Allow package install": "패키지 설치 허용",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -186,6 +186,7 @@
     "Allow external request?": "Разрешить внешний запрос?",
     "Allow for this conversation": "Разрешить для этого диалога",
     "Allow for this project": "Разрешить для этого проекта",
+    "Allow for up to 12 hours": "Разрешить на срок до 12 часов",
     "Allow globally": "Разрешить глобально",
     "Allow once": "Разрешить один раз",
     "Allow package install": "Разрешить установку пакета",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -225,6 +225,7 @@
     "Allow external request?": "允许外部请求？",
     "Allow for this conversation": "允许此对话",
     "Allow for this project": "允许此项目",
+    "Allow for up to 12 hours": "最多允许 12 小时",
     "Allow globally": "全局允许",
     "Allow once": "允许一次",
     "Allow package install": "允许安装软件包",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -225,6 +225,7 @@
     "Allow external request?": "允許外部請求？",
     "Allow for this conversation": "允許此對話",
     "Allow for this project": "允許此專案",
+    "Allow for up to 12 hours": "最多允許 12 小時",
     "Allow globally": "允許全域",
     "Allow once": "允許一次",
     "Allow package install": "允許安裝套件",


### PR DESCRIPTION
## Problem

Remote browser pairing had three mismatches between its security behavior and its public contract:

- Once the 20-request pending queue was full, every new unauthenticated request deleted the oldest request. Repeated refreshes could therefore invalidate a real user's six-digit code before it was approved, producing a remote denial of service.
- A persistent approval awaited the repository write before changing the request out of `pending`, while approval itself was outside the service operation queue. Concurrent administrators could approve the same request more than once, and disabling access during the write could leave an unclaimed trusted credential in `remote-access.json`.
- The UI called temporary access “Allow once”, but the resulting in-memory session can be reused and reconnected for up to 12 hours.

## Proposed change

- Preserve all existing pending requests at capacity and reject only new admissions with HTTP 429 plus `Retry-After`.
- Claim an approval synchronously with a private `approving` state, validate its authorization generation after persistence, and remove an unclaimed persistent credential when the request is invalidated mid-commit.
- Retain failed unclaimed-credential cleanup IDs in memory for retry, and report cleanup failures through a stable lifecycle `error` snapshot while keeping external access disabled.
- Schedule the same retryable cleanup when an approved persistent request expires before the browser claims its cookie.
- Serialize approve, reject, revoke, and mode operations through the existing `RemoteAccessService` queue.
- Rename the temporary decision in the pairing page and Settings UI to “Allow for up to 12 hours”, with all renderer translations.

## Scope and non-goals

- This does not add per-IP limiting. The provider host and forwarded client headers are not a trustworthy source identity at this boundary, so treating `X-Forwarded-For` as a limiter key would create a bypassable security control. An attacker can still occupy all free slots before a legitimate request arrives; the fixed invariant is that later traffic cannot evict an already-issued code.
- The wire decision remains `once`, and temporary access remains an in-memory, reconnectable session with the existing 12-hour maximum. True single-connection authorization would require connection ownership and lifecycle changes in the web server and is intentionally out of scope.
- No historical cleanup is attempted. Existing orphaned trusted records are indistinguishable from credentials that were successfully claimed, so automatic deletion would risk revoking legitimate browsers; they remain manually revocable.

### State, persistence, and compatibility

- New state: private in-memory `PendingPairing.status = 'approving'` plus a private retry set of unclaimed trusted-browser IDs. There is no public/shared/persisted enum addition.
- Persistence: no new field, schema, file version, or migration. Future invalidated, unclaimed `always` grants are removed using the existing repository mutation queue.
- Historical compatibility: `remote-access.json` stays at its current format and loads unchanged. No migration is required.

## Acceptance criteria and validation

The original regression tests were first run against the unfixed implementation twice. They failed deterministically for the reported reasons: the oldest request became `expired`, both concurrent approvals fulfilled, disabling during approval retained one trusted browser, and both surfaces still rendered “Allow once”. Review follow-up tests were likewise run before their fixes and failed because cleanup persistence errors escaped with `starting`/`stopping` lifecycle state, could not be retried, and an approved-but-unclaimed request left its trusted record behind after expiry. The same tests pass with this change.

All commands below ran after the last material edit:

- Pending admission, approval generation, persistent cleanup/retry/expiry, lifecycle failure handling, repository, IPC, and provider behavior → `npm test -- src/main/remote-access/pairing.test.ts src/main/remote-access/service.test.ts src/main/remote-access/ipc.test.ts src/main/remote-access/repository.test.ts src/main/remote-access/remoteit.test.ts` → 5 files / 77 tests passed.
- Host command and composition consumers of the now-async service boundary → `npm test -- src/main/host-application-commands.test.ts src/main/application-command-composition.test.ts` → 2 files / 17 tests passed.
- Settings interaction copy → `npm test -- src/renderer/src/pages/settings/SettingsPage.render.test.tsx` → 1 file / 86 tests passed.
- Renderer locale completeness and script/placeholder rules → `npm test -- src/renderer/src/i18n/resources.test.ts` → 1 file / 694 tests passed.
- Main process types → `npm run typecheck:node` → passed.
- Renderer types → `npm run typecheck:web` → passed.
- Lint → `npm run lint` → passed.

The full local `npm test` suite was intentionally not run; exact-head PR Gate and platform CI remain authoritative for complete coverage.

## Review focus

- The `pending -> approving -> approved` transition and generation check around the durable write.
- Compensating removal when disable/shutdown/web-stop invalidates an unclaimed persistent grant.
- Cleanup retry and lifecycle behavior when the repository write itself fails.
- Expiry cleanup for approved requests whose browsers never claim the cookie.
- The deliberate residual admission-flood risk and absence of a pseudo source limiter.
