### PR TITLE
ci(test-impact): enforce module-authoritative PR Gate

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -768,7 +768,7 @@ jobs:
     needs: preflight
     if: ${{ needs.preflight.result == 'success' && contains(fromJSON(needs.preflight.outputs.plan).bundles, 'windows_e2e') }}
     runs-on: windows-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -95,6 +95,11 @@ jobs:
           echo "dir=$trusted_dir" >> "$GITHUB_OUTPUT"
 
           required=(
+            scripts/ci/module-impact-authority.mjs
+            scripts/ci/module-impact-shadow.mjs
+            scripts/ci/module-test-impact.mjs
+            scripts/ci/module-impact.json
+            scripts/ci/validate-module-impact.mjs
             scripts/ci/classify-pr-changes.mjs
             scripts/ci/change-impact.json
           )
@@ -155,7 +160,7 @@ jobs:
             exit 0
           fi
           if [[ "$TRUSTED_CLASSIFIER_SOURCE" == "base" ]]; then
-            node "$TRUSTED_CLASSIFIER_DIR/classify-pr-changes.mjs" --base "$BASE_SHA" --head "$HEAD_SHA"
+            node "$TRUSTED_CLASSIFIER_DIR/module-impact-authority.mjs" --base "$BASE_SHA" --head "$HEAD_SHA"
             exit 0
           fi
 
@@ -216,62 +221,6 @@ jobs:
             )
           }
           NODE
-
-      - name: Prepare trusted module shadow
-        id: trusted_module_shadow
-        continue-on-error: true
-        shell: bash
-        env:
-          BASE_SHA: ${{ steps.revisions.outputs.base }}
-        run: |
-          set -euo pipefail
-          trusted_dir="$RUNNER_TEMP/pr-gate-trusted-module-shadow"
-          mkdir -p "$trusted_dir"
-          echo "dir=$trusted_dir" >> "$GITHUB_OUTPUT"
-
-          required=(
-            scripts/ci/module-impact-shadow.mjs
-            scripts/ci/module-test-impact.mjs
-            scripts/ci/module-impact.json
-            scripts/ci/validate-module-impact.mjs
-            scripts/ci/classify-pr-changes.mjs
-            scripts/ci/change-impact.json
-          )
-          for file in "${required[@]}"; do
-            if ! git cat-file -e "${BASE_SHA}:${file}" 2>/dev/null; then
-              echo "source=bootstrap" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          done
-          for file in "${required[@]}"; do
-            git show "${BASE_SHA}:${file}" > "$trusted_dir/${file##*/}"
-          done
-          echo "source=base" >> "$GITHUB_OUTPUT"
-
-      - name: Publish module impact shadow
-        continue-on-error: true
-        env:
-          AUTHORITATIVE_PLAN: ${{ steps.classify.outputs.plan }}
-          BASE_SHA: ${{ steps.revisions.outputs.base }}
-          HEAD_SHA: ${{ steps.revisions.outputs.head }}
-          TRUSTED_MODULE_SHADOW_DIR: ${{ steps.trusted_module_shadow.outputs.dir }}
-          TRUSTED_MODULE_SHADOW_SOURCE: ${{ steps.trusted_module_shadow.outputs.source }}
-        run: |
-          if [[ "$TRUSTED_MODULE_SHADOW_SOURCE" == "base" ]]; then
-            node "$TRUSTED_MODULE_SHADOW_DIR/module-impact-shadow.mjs" \
-              --base "$BASE_SHA" \
-              --head "$HEAD_SHA" \
-              --authoritative-plan "$AUTHORITATIVE_PLAN"
-            exit 0
-          fi
-
-          printf '%s\n' \
-            '## Module impact shadow' \
-            '' \
-            'Status: **bootstrap pending**' \
-            '' \
-            'The base revision does not yet contain the trusted shadow reporter. Module evidence will be published for subsequent changes after this control-plane update merges.' \
-            >> "$GITHUB_STEP_SUMMARY"
 
   policy:
     name: PR policy
@@ -514,9 +463,10 @@ jobs:
         continue-on-error: true
         env:
           BASE_SHA: ${{ needs.preflight.outputs.base }}
-        # Vitest coverage.changed inherits --changed, so this enforces thresholds only for the
-        # affected source boundary while using the same test execution.
-        run: npx vitest run --coverage --changed "$BASE_SHA"
+          HEAD_SHA: ${{ needs.preflight.outputs.head }}
+        # The module graph selects owner, contract, and consumer tests. Coverage remains scoped to
+        # changed sources without handing test discovery back to Vitest's static --changed graph.
+        run: npm run test:affected -- --base "$BASE_SHA" --head "$HEAD_SHA" --coverage-changed "$BASE_SHA"
       - name: Download full-suite blob reports
         if: ${{ needs.unit_shard.result != 'skipped' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/scripts/ci/module-impact-authority.mjs
+++ b/scripts/ci/module-impact-authority.mjs
@@ -1,0 +1,90 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+import { execFileSync } from 'node:child_process'
+import { appendFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { classifyChanges, formatPlanSummary, parseNameStatus } from './classify-pr-changes.mjs'
+import {
+  createModuleImpactShadowReport,
+  formatModuleImpactShadowSummary
+} from './module-impact-shadow.mjs'
+import { createAffectedTestPlan } from './module-test-impact.mjs'
+
+const manifestOnlyGraph = Object.freeze({
+  status: 'unavailable-manifest-only',
+  reason: 'CI authority uses the trusted repository manifest only',
+  testFiles: []
+})
+
+const unusedModulePlan = Object.freeze({
+  mode: 'selective',
+  modules: [],
+  testFiles: [],
+  capabilityOverlays: [],
+  fallbackCapabilities: [],
+  graphStatus: 'not-used',
+  graphReason: 'unit bundle not selected',
+  reasonChains: []
+})
+
+function argumentValue(arguments_, name) {
+  const index = arguments_.indexOf(name)
+  return index === -1 ? undefined : arguments_[index + 1]
+}
+
+function requireCommit(value, name) {
+  if (!value || !/^[0-9a-f]{40}$/i.test(value)) {
+    throw new Error(`${name} must be a full 40-character Git commit SHA`)
+  }
+  return value
+}
+
+function changesFromGit(base, head, { cwd = process.cwd(), execute = execFileSync } = {}) {
+  const diff = execute('git', ['diff', '--name-status', '-z', base, head], { cwd })
+  return parseNameStatus(diff.toString('utf8'))
+}
+
+export function runModuleImpactAuthorityCli(
+  arguments_ = process.argv.slice(2),
+  environment = process.env,
+  { cwd = process.cwd(), execute = execFileSync, append = appendFileSync, write } = {}
+) {
+  const base = requireCommit(argumentValue(arguments_, '--base') ?? environment.BASE_SHA, '--base')
+  const head = requireCommit(argumentValue(arguments_, '--head') ?? environment.HEAD_SHA, '--head')
+  const changes = changesFromGit(base, head, { cwd, execute })
+  const candidatePlan = classifyChanges(changes)
+  const modulePlan = candidatePlan.bundles.includes('unit')
+    ? createAffectedTestPlan(changes, manifestOnlyGraph)
+    : unusedModulePlan
+  const report = createModuleImpactShadowReport(candidatePlan, modulePlan)
+  const plan = report.resolved
+  const planJson = JSON.stringify(plan)
+  const lanesJson = JSON.stringify(plan.lanes)
+
+  if (environment.GITHUB_OUTPUT) {
+    append(environment.GITHUB_OUTPUT, `plan=${planJson}\nlanes=${lanesJson}\n`)
+  } else if (write) {
+    write(`${planJson}\n`)
+  } else {
+    process.stdout.write(`${planJson}\n`)
+  }
+  if (environment.GITHUB_STEP_SUMMARY) {
+    append(environment.GITHUB_STEP_SUMMARY, formatPlanSummary(plan))
+    append(environment.GITHUB_STEP_SUMMARY, formatModuleImpactShadowSummary(report))
+  }
+  return { plan, report }
+}
+
+const isDirectExecution =
+  process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+
+if (isDirectExecution) {
+  try {
+    runModuleImpactAuthorityCli()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  }
+}

--- a/scripts/ci/module-impact-shadow.mjs
+++ b/scripts/ci/module-impact-shadow.mjs
@@ -73,6 +73,55 @@ export function requiredLanesForModulePlan(
   )
 }
 
+function bundlesForLanes(lanes, manifest) {
+  const bundles = lanes.map((lane) => {
+    const bundle = manifest.laneBundles[lane]
+    if (!bundle) throw new Error(`Missing execution bundle for selected lane: ${lane}`)
+    return bundle
+  })
+  return ordered(bundles, manifest.bundleOrder)
+}
+
+export function resolveAuthoritativePlan(
+  candidatePlan,
+  modulePlan,
+  changeImpactManifest = defaultChangeImpactManifest
+) {
+  if (candidatePlan.mode === 'full' || !strings(candidatePlan.bundles).includes('unit')) {
+    return candidatePlan
+  }
+
+  const moduleReasons = strings(modulePlan.reasonChains)
+  if (modulePlan.mode === 'full') {
+    return {
+      schemaVersion: candidatePlan.schemaVersion ?? changeImpactManifest.schemaVersion,
+      mode: 'full',
+      roots: unique([...strings(candidatePlan.roots), 'module_impact']).sort(),
+      lanes: [...changeImpactManifest.laneOrder],
+      bundles: [...changeImpactManifest.bundleOrder],
+      reasonChains: unique([...strings(candidatePlan.reasonChains), ...moduleReasons]).sort()
+    }
+  }
+
+  const lanes = ordered(
+    [
+      ...strings(candidatePlan.lanes),
+      ...requiredLanesForModulePlan(modulePlan, changeImpactManifest)
+    ],
+    changeImpactManifest.laneOrder
+  )
+  return {
+    ...candidatePlan,
+    roots: unique([
+      ...strings(candidatePlan.roots),
+      ...strings(modulePlan.modules).map((moduleId) => `module:${moduleId}`)
+    ]).sort(),
+    lanes,
+    bundles: bundlesForLanes(lanes, changeImpactManifest),
+    reasonChains: unique([...strings(candidatePlan.reasonChains), ...moduleReasons]).sort()
+  }
+}
+
 export function createModuleImpactShadowReport(
   authoritativePlan,
   modulePlan,
@@ -97,6 +146,7 @@ export function createModuleImpactShadowReport(
   const additionalAuthoritativeLanes = selectedLanes.filter((lane) => !requiredLaneSet.has(lane))
   const modeAgreement = authoritativePlan.mode === modulePlan.mode
   const disagreements = []
+  const resolved = resolveAuthoritativePlan(authoritativePlan, modulePlan, changeImpactManifest)
 
   if (!modeAgreement) {
     disagreements.push(
@@ -112,7 +162,7 @@ export function createModuleImpactShadowReport(
 
   return {
     schemaVersion: 1,
-    enforcement: 'non-blocking',
+    enforcement: 'blocking',
     authoritative: {
       mode: authoritativePlan.mode,
       roots: strings(authoritativePlan.roots).sort(),
@@ -130,6 +180,7 @@ export function createModuleImpactShadowReport(
       graphReason: modulePlan.graphReason,
       reasonChains: strings(modulePlan.reasonChains).sort()
     },
+    resolved,
     comparison: {
       modeAgreement,
       coverage: missingLanes.length === 0 ? 'covered' : 'gap',
@@ -164,39 +215,45 @@ function bulletList(values) {
 }
 
 export function formatModuleImpactShadowSummary(report) {
-  return `## Module impact shadow
+  return `## Module impact authority
 
-- Enforcement: **non-blocking**
-- Authoritative mode: **${escapeHtml(report.authoritative.mode)}**
-- Shadow mode: **${escapeHtml(report.shadow.mode)}**
-- Planned coverage: **${escapeHtml(report.comparison.coverage)}**
+- Enforcement: **${escapeHtml(report.enforcement)}**
+- Candidate mode: **${escapeHtml(report.authoritative.mode)}**
+- Module mode: **${escapeHtml(report.shadow.mode)}**
+- Resolved mode: **${escapeHtml(report.resolved.mode)}**
+- Candidate coverage: **${escapeHtml(report.comparison.coverage)}**
 - CodeGraph: **${escapeHtml(report.shadow.graphStatus)}**${report.shadow.graphReason ? ` (${escapeHtml(report.shadow.graphReason)})` : ''}
 
-### Shadow selection
+### Module selection
 
 - Modules: ${inlineList(report.shadow.modules)}
 - Tests: ${inlineList(report.shadow.testFiles)}
 - Capability overlays: ${inlineList(report.shadow.capabilityOverlays)}
 - Fallback capabilities: ${inlineList(report.shadow.fallbackCapabilities)}
 
-### Required versus authoritative lanes
+### Required versus candidate lanes
 
 - Required lanes: ${inlineList(report.comparison.requiredLanes)}
-- Selected lanes: ${inlineList(report.comparison.selectedLanes)}
+- Candidate lanes: ${inlineList(report.comparison.selectedLanes)}
+- Resolved lanes: ${inlineList(report.resolved.lanes)}
 - Missing lanes: ${inlineList(report.comparison.missingLanes)}
-- Additional authoritative lanes: ${inlineList(report.comparison.additionalAuthoritativeLanes)}
+- Additional candidate lanes: ${inlineList(report.comparison.additionalAuthoritativeLanes)}
 
-### Disagreements
+### Candidate disagreements
 
 ${bulletList(report.comparison.disagreements)}
 
-### Authoritative reason chains
+### Candidate reason chains
 
 ${bulletList(report.authoritative.reasonChains)}
 
-### Shadow reason chains
+### Module reason chains
 
 ${bulletList(report.shadow.reasonChains)}
+
+### Resolved reason chains
+
+${bulletList(report.resolved.reasonChains)}
 `
 }
 

--- a/scripts/ci/module-impact-shadow.test.ts
+++ b/scripts/ci/module-impact-shadow.test.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 import { classifyChanges } from './classify-pr-changes.mjs'
+import { runModuleImpactAuthorityCli } from './module-impact-authority.mjs'
 import {
   createModuleImpactShadowReport,
   formatModuleImpactShadowSummary,
@@ -37,7 +38,7 @@ describe('module impact shadow', () => {
       { path: 'src/renderer/src/stores/session-store.ts', status: 'modified' }
     ])
 
-    expect(report.enforcement).toBe('non-blocking')
+    expect(report.enforcement).toBe('blocking')
     expect(report.authoritative.mode).toBe('selective')
     expect(report.shadow).toMatchObject({
       mode: 'selective',
@@ -53,7 +54,7 @@ describe('module impact shadow', () => {
     expect(report.comparison.coverage).toBe('covered')
   })
 
-  it('records mode and lane disagreements without making them blocking', () => {
+  it('records candidate mode and lane disagreements before blocking resolution', () => {
     const modulePlan = createAffectedTestPlan(
       [{ path: 'src/main/artifacts/repository.ts', status: 'modified' }],
       manifestOnlyGraph
@@ -67,7 +68,7 @@ describe('module impact shadow', () => {
     }
     const report = createModuleImpactShadowReport(authoritativePlan, modulePlan)
 
-    expect(report.enforcement).toBe('non-blocking')
+    expect(report.enforcement).toBe('blocking')
     expect(report.comparison.modeAgreement).toBe(false)
     expect(report.comparison.coverage).toBe('gap')
     expect(report.comparison.missingLanes).toContain('unit_macos')
@@ -75,7 +76,7 @@ describe('module impact shadow', () => {
       'mode: authoritative full != shadow selective',
       expect.stringContaining('missing authoritative lanes:')
     ])
-    expect(formatModuleImpactShadowSummary(report)).toContain('Planned coverage: **gap**')
+    expect(formatModuleImpactShadowSummary(report)).toContain('Candidate coverage: **gap**')
   })
 
   it.each([
@@ -108,6 +109,84 @@ describe('module impact shadow', () => {
     expect(report.shadow.mode).toBe('full')
     expect(report.comparison.requiredLanes).toHaveLength(changeImpactManifest.laneOrder.length)
     expect(report.comparison.coverage).toBe(authoritativeMode === 'full' ? 'covered' : 'gap')
+  })
+
+  it('promotes an unowned added Main file to the complete authoritative Windows plan', () => {
+    const report = reportFor([{ path: 'src/main/platform-launcher.ts', status: 'added' }])
+
+    expect(report.enforcement).toBe('blocking')
+    expect(report.resolved).toMatchObject({
+      mode: 'full',
+      lanes: expect.arrayContaining([
+        'unit_macos',
+        'windows_runtime',
+        'windows_path',
+        'e2e_functional_windows',
+        'e2e_workspace_windows'
+      ]),
+      bundles: expect.arrayContaining(['unit', 'windows_core', 'windows_e2e'])
+    })
+    expect(report.resolved.reasonChains).toContain(
+      'src/main/platform-launcher.ts -> unknown module owner -> full'
+    )
+  })
+
+  it('merges a known Module capability overlay into the selective authoritative plan', () => {
+    const report = reportFor([{ path: 'src/main/artifacts/repository.ts', status: 'modified' }])
+
+    expect(report.authoritative.lanes).not.toContain('windows_runtime')
+    expect(report.resolved).toMatchObject({
+      mode: 'selective',
+      lanes: expect.arrayContaining(['unit_macos', 'windows_runtime', 'windows_path']),
+      bundles: expect.arrayContaining(['unit', 'windows_core'])
+    })
+    expect(report.resolved.reasonChains).toContain(
+      'src/main/artifacts/repository.ts -> artifact_storage'
+    )
+  })
+
+  it('publishes the resolved module authority through the existing PR Gate outputs', () => {
+    const base = '1'.repeat(40)
+    const head = '2'.repeat(40)
+    const execute = vi.fn().mockReturnValue(Buffer.from('A\0src/main/platform-launcher.ts\0'))
+    const append = vi.fn()
+
+    const { plan } = runModuleImpactAuthorityCli(
+      ['--base', base, '--head', head],
+      { GITHUB_OUTPUT: '/output', GITHUB_STEP_SUMMARY: '/summary' },
+      { cwd: '/repo', execute, append }
+    )
+
+    expect(execute).toHaveBeenCalledWith(
+      'git',
+      ['diff', '--name-status', '-z', base, head],
+      expect.objectContaining({ cwd: '/repo' })
+    )
+    expect(plan).toMatchObject({
+      mode: 'full',
+      lanes: expect.arrayContaining(['windows_runtime', 'e2e_workspace_windows'])
+    })
+    expect(append).toHaveBeenCalledWith(
+      '/output',
+      expect.stringContaining(`plan=${JSON.stringify(plan)}`)
+    )
+    expect(append).toHaveBeenCalledWith('/summary', expect.stringContaining('Resolved mode'))
+  })
+
+  it('does not require module ownership for a documentation-only plan', () => {
+    const execute = vi.fn().mockReturnValue(Buffer.from('M\0docs/architecture.md\0'))
+    const { plan, report } = runModuleImpactAuthorityCli(
+      ['--base', '1'.repeat(40), '--head', '2'.repeat(40)],
+      {},
+      { cwd: '/repo', execute, write: vi.fn() }
+    )
+
+    expect(plan).toMatchObject({
+      mode: 'selective',
+      lanes: ['policy', 'docs'],
+      bundles: ['policy', 'static']
+    })
+    expect(report.shadow.graphStatus).toBe('not-used')
   })
 
   it.each(['fr.json', 'ja.json', 'ko.json', 'ru.json', 'zh-Hans.json', 'zh-Hant.json'])(
@@ -247,7 +326,7 @@ describe('module impact shadow', () => {
     expect(write).toHaveBeenCalledWith(`${JSON.stringify(report)}\n`)
     expect(append).toHaveBeenCalledWith(
       '/summary',
-      expect.stringContaining('## Module impact shadow')
+      expect.stringContaining('## Module impact authority')
     )
   })
 

--- a/scripts/ci/module-test-impact.mjs
+++ b/scripts/ci/module-test-impact.mjs
@@ -203,12 +203,18 @@ export function executeModuleTestPlan(
     spawn = spawnSync,
     environment = process.env,
     platform = process.platform,
-    nodeExecutable = process.execPath
+    nodeExecutable = process.execPath,
+    testArguments = []
   } = {}
 ) {
   process.stdout.write(formatModuleTestPlan(plan))
   if (plan.mode === 'selective' && plan.testFiles.length === 0) return 0
-  const npmArguments = plan.mode === 'full' ? ['test'] : ['test', '--', ...plan.testFiles]
+  const npmArguments = [
+    'test',
+    '--',
+    ...testArguments,
+    ...(plan.mode === 'full' ? [] : plan.testFiles)
+  ]
   const npmExecPath = environment.npm_execpath
   if (platform === 'win32' && !npmExecPath) {
     throw new Error(
@@ -240,6 +246,10 @@ export function runModuleTestCli(arguments_ = process.argv.slice(2), options = {
   const base = argumentValue(arguments_, '--base')
   const head = argumentValue(arguments_, '--head')
   if (!base || !head) throw new Error('--base and --head are required')
+  const coverageChanged = argumentValue(arguments_, '--coverage-changed')
+  if (arguments_.includes('--coverage-changed') && !coverageChanged) {
+    throw new Error('--coverage-changed requires a Git revision')
+  }
   const changes = changesFromGit(base, head, options)
   const paths = sorted(
     changes.flatMap(({ path, previousPath }) => [path, previousPath].filter(Boolean))
@@ -250,7 +260,12 @@ export function runModuleTestCli(arguments_ = process.argv.slice(2), options = {
     process.stdout.write(formatModuleTestPlan(plan))
     return 0
   }
-  return executeModuleTestPlan(plan, options)
+  return executeModuleTestPlan(plan, {
+    ...options,
+    testArguments: coverageChanged
+      ? ['--coverage', '--coverage.changed', coverageChanged]
+      : options.testArguments
+  })
 }
 
 const isDirectExecution =

--- a/scripts/ci/module-test-impact.test.ts
+++ b/scripts/ci/module-test-impact.test.ts
@@ -8,7 +8,8 @@ import {
   createAffectedTestPlan,
   createModuleTestPlan,
   executeModuleTestPlan,
-  formatModuleTestPlan
+  formatModuleTestPlan,
+  runModuleTestCli
 } from './module-test-impact.mjs'
 
 const currentStatus = JSON.stringify({
@@ -455,6 +456,53 @@ describe('module test impact commands', () => {
       ['/npm/bin/npm-cli.js', 'test', '--', ...plan.testFiles],
       expect.objectContaining({ cwd: '/repo', stdio: 'inherit' })
     )
+    write.mockRestore()
+  })
+
+  it('keeps changed-source coverage separate from authoritative affected test selection', () => {
+    const base = '1'.repeat(40)
+    const head = '2'.repeat(40)
+    const execute = vi.fn((command: string, arguments_: string[]) => {
+      if (command === 'git' && arguments_[0] === 'merge-base') return `${base}\n`
+      if (command === 'git' && arguments_[0] === 'diff') {
+        return Buffer.from('M\0src/main/artifacts/repository.ts\0')
+      }
+      if (command === 'codegraph' && arguments_[0] === 'status') return currentStatus
+      if (command === 'codegraph' && arguments_[0] === 'affected') {
+        return JSON.stringify({ affectedTests: [] })
+      }
+      throw new Error(`Unexpected command: ${command} ${arguments_.join(' ')}`)
+    })
+    const spawn = vi.fn(() => ({ status: 0 }))
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    const expectedPlan = createAffectedTestPlan(
+      [{ path: 'src/main/artifacts/repository.ts', status: 'modified' }],
+      { status: 'current', testFiles: [] }
+    )
+
+    expect(
+      runModuleTestCli(['affected', '--base', base, '--head', head, '--coverage-changed', base], {
+        cwd: '/repo',
+        execute,
+        spawn,
+        environment: { npm_execpath: '/npm/bin/npm-cli.js' },
+        nodeExecutable: '/node'
+      })
+    ).toBe(0)
+    expect(spawn).toHaveBeenCalledWith(
+      '/node',
+      [
+        '/npm/bin/npm-cli.js',
+        'test',
+        '--',
+        '--coverage',
+        '--coverage.changed',
+        base,
+        ...expectedPlan.testFiles
+      ],
+      expect.objectContaining({ cwd: '/repo', stdio: 'inherit' })
+    )
+    expect(spawn.mock.calls[0]?.[1]).toContain('src/main/reviewer/ipc.test.ts')
     write.mockRestore()
   })
 

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -161,7 +161,7 @@ describe('PR Gate workflow', () => {
     expect(classify?.run).toContain('"lanes":["policy","i18n"]')
     expect(classify?.run).toContain('"bundles":["policy","static"]')
     expect(classify?.run).toContain(
-      'node "$TRUSTED_CLASSIFIER_DIR/classify-pr-changes.mjs" --base "$BASE_SHA" --head "$HEAD_SHA"'
+      'node "$TRUSTED_CLASSIFIER_DIR/module-impact-authority.mjs" --base "$BASE_SHA" --head "$HEAD_SHA"'
     )
     expect(classify?.run).toContain("mode: 'full'")
     expect(classify?.run).not.toContain(
@@ -169,11 +169,14 @@ describe('PR Gate workflow', () => {
     )
   })
 
-  it('publishes base-trusted module evidence without changing authoritative outputs', () => {
+  it('makes base-trusted module evidence authoritative without shadow steps', () => {
     const prepare = workflow.jobs.preflight.steps?.find(
+      ({ name }) => name === 'Prepare trusted classifier'
+    )
+    const shadowPrepare = workflow.jobs.preflight.steps?.find(
       ({ name }) => name === 'Prepare trusted module shadow'
     )
-    const publish = workflow.jobs.preflight.steps?.find(
+    const shadowPublish = workflow.jobs.preflight.steps?.find(
       ({ name }) => name === 'Publish module impact shadow'
     )
 
@@ -183,23 +186,15 @@ describe('PR Gate workflow', () => {
       lanes: '${{ steps.classify.outputs.lanes }}',
       plan: '${{ steps.classify.outputs.plan }}'
     })
-    expect(prepare).toMatchObject({ 'continue-on-error': true })
+    expect(prepare?.['continue-on-error']).toBeUndefined()
+    expect(prepare?.run).toContain('scripts/ci/module-impact-authority.mjs')
     expect(prepare?.run).toContain('scripts/ci/module-impact-shadow.mjs')
+    expect(prepare?.run).toContain('scripts/ci/module-test-impact.mjs')
+    expect(prepare?.run).toContain('scripts/ci/module-impact.json')
     expect(prepare?.run).toContain('git show "${BASE_SHA}:${file}"')
     expect(prepare?.run).toContain('source=bootstrap')
-    expect(publish).toMatchObject({
-      'continue-on-error': true,
-      env: {
-        AUTHORITATIVE_PLAN: '${{ steps.classify.outputs.plan }}',
-        BASE_SHA: '${{ steps.revisions.outputs.base }}',
-        HEAD_SHA: '${{ steps.revisions.outputs.head }}',
-        TRUSTED_MODULE_SHADOW_DIR: '${{ steps.trusted_module_shadow.outputs.dir }}',
-        TRUSTED_MODULE_SHADOW_SOURCE: '${{ steps.trusted_module_shadow.outputs.source }}'
-      }
-    })
-    expect(publish?.run).toContain('node "$TRUSTED_MODULE_SHADOW_DIR/module-impact-shadow.mjs"')
-    expect(publish?.run).toContain('Status: **bootstrap pending**')
-    expect(publish?.run).not.toContain('GITHUB_OUTPUT')
+    expect(shadowPrepare).toBeUndefined()
+    expect(shadowPublish).toBeUndefined()
   })
 
   it('aggregates all deterministic bundles into the stable PR Gate job', () => {
@@ -384,9 +379,13 @@ describe('PR Gate workflow', () => {
     expect(related).toMatchObject({
       id: 'unit_macos_related',
       'continue-on-error': true,
-      env: { BASE_SHA: '${{ needs.preflight.outputs.base }}' },
-      run: 'npx vitest run --coverage --changed "$BASE_SHA"'
+      env: {
+        BASE_SHA: '${{ needs.preflight.outputs.base }}',
+        HEAD_SHA: '${{ needs.preflight.outputs.head }}'
+      },
+      run: 'npm run test:affected -- --base "$BASE_SHA" --head "$HEAD_SHA" --coverage-changed "$BASE_SHA"'
     })
+    expect(related?.run).not.toMatch(/(?:^|\s)--changed(?:\s|$)/)
     expect(related?.if).toContain("fromJSON(needs.preflight.outputs.plan).mode == 'selective'")
     expect(download).toMatchObject({
       if: "${{ needs.unit_shard.result != 'skipped' }}",

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -452,6 +452,10 @@ describe('PR Gate workflow', () => {
     )
   })
 
+  it('budgets the complete Windows E2E path beyond dependency and build setup', () => {
+    expect(workflow.jobs.windows_e2e['timeout-minutes']).toBe(25)
+  })
+
   it('runs Windows accessibility only for a legacy selected lane', () => {
     const compatibility = workflow.jobs.windows_e2e.steps?.find(
       ({ name }) => name === 'Run legacy Windows accessibility compatibility'


### PR DESCRIPTION
## Problem

PR Gate maintained two impact authorities: the blocking path classifier/Vitest `--changed` graph and a non-blocking Module impact shadow. Static Vitest discovery can omit declared owner, contract, and consumer tests for dynamic imports, IPC strings, registries, and persistence consumers. An unowned new Main file could also remain on generic macOS lanes even when the Module graph required a full fallback, leaving Windows runtime/path/E2E unselected.

## Proposed change

- Promote trusted-base Module impact evidence into the blocking PR Gate plan.
- Promote incomplete Module ownership to the complete plan, including Windows core and Windows E2E.
- Merge declared Module fallback and capability-overlay lanes into known selective plans.
- Execute selective unit checks through `test:affected` so the curated owner/contract/consumer set is authoritative.
- Keep coverage limited to changed sources with `coverage.changed` without using `--changed` for test discovery.
- Bootstrap to the complete plan when the trusted base does not contain the new authority entry point.

```mermaid
flowchart LR
  D[base-to-head diff] --> C[path capability candidate]
  D --> M[trusted Module impact]
  C --> R[blocking resolver]
  M --> R
  R -->|known owner| S[selective lanes and declared tests]
  R -->|unknown owner| F[complete plan including Windows]
```

## Scope and non-goals

- CI workflow and CI planning scripts only.
- No product data fields, database schema, persistence format, user interaction, or product state changes.
- No historical user-data compatibility is required. Trusted-base compatibility fails closed through the existing bootstrap plan.
- The PR Gate plan schema is unchanged.

## Acceptance criteria and validation

The checks below ran after the last material edit.

- Module owner/contract/consumer selection and coverage separation -> `vitest run scripts/ci/module-impact-shadow.test.ts scripts/ci/module-test-impact.test.ts scripts/ci/validate-module-impact.test.ts scripts/ci/classify-pr-changes.test.ts scripts/ci/pr-gate-workflow.test.ts scripts/ci/check-ci-integrity.test.ts scripts/ci/ci-integrity-workflow.test.ts` -> 7 files, 186 tests passed.
- Original historical mismatch (`2f5b53f8^..2f5b53f8`) -> `node scripts/ci/module-impact-authority.mjs --base <base> --head <head>` -> complete plan selected with `unknown module owner -> full`, `windows_core`, and `windows_e2e`.
- Changed-file formatting -> Prettier `--check` on all seven changed files -> passed.
- Lint -> ESLint repository check -> exited successfully with 0 errors. The locally shared dependency tree emitted five Prettier-plugin warnings while the project Prettier check passed.
- Windows E2E execution budget -> initial full PR run completed install, build, and functional journeys before the 15-minute job timeout cancelled workspace journeys -> regression test failed at 15 minutes, budget raised to 25 minutes, final focused suite passed.
- Patch hygiene -> `git diff --check` -> passed.

The complete local `npm test` was intentionally not run; exact-head PR CI is authoritative for the complete portable and platform suites. Local Node typecheck was blocked by the main checkout's different lockfile/shared `node_modules`: the installed `claude-agent-acp` package lacks the patched `waitForMcpServers` export expected by the worktree. No dependency installation or main-worktree mutation was performed.

## Review focus

- Trusted-base/bootstrap behavior in preflight.
- Full-plan promotion for incomplete ownership.
- Lane union ordering and execution-bundle derivation for known Modules.
- Separation of Module test selection from changed-source coverage.