### PR TITLE
fix(acp): isolate restricted inference prompts

### DIFF
--- a/src/main/acp/restricted-inference-runner.test.ts
+++ b/src/main/acp/restricted-inference-runner.test.ts
@@ -67,7 +67,7 @@ type RuntimeHarnessOptions = Readonly<{
   events?: AcpRuntimeEvent[]
   permissionRequest?: true
   onRuntime?: () => void
-  onCreateSession?: () => Promise<void>
+  onCreateSession?: (backend: ResolvedAgentBackend) => Promise<void>
   onPrompt?: () => Promise<void>
 }>
 
@@ -79,7 +79,7 @@ const runtimeHarness = (
   return {
     createSession: vi.fn(async () => {
       resolvedBackend = await (options.resolveBackend as () => Promise<ResolvedAgentBackend>)()
-      await input.onCreateSession?.()
+      await input.onCreateSession?.(resolvedBackend)
       return { sessionId: 'provider-session-1' } as never
     }),
     sendPrompt: vi.fn(async () => {
@@ -296,10 +296,91 @@ describe('RestrictedInferenceRunner', () => {
       frameworkId: 'codex'
     })
     expect(resolveTarget).toHaveBeenCalledWith(target('codex', CODEX_SHARED_PROVIDER_ID), {
-      systemPromptAppends: ['Do not use tools.'],
+      systemPromptAppends: [],
       includeSkillAndConnectorContext: false
     })
   })
+
+  it('keeps restricted instructions out of the shared OpenCode config used by the first conversation', async () => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-restricted-inference-'))
+    const sharedInstructionsDir = join(temporaryRoot, 'shared-opencode', 'instructions')
+    const sharedInstructionsPath = join(sharedInstructionsDir, 'open-science.md')
+    const mainInstructions = 'Answer the user request normally.'
+    await mkdir(sharedInstructionsDir, { recursive: true })
+    await writeFile(sharedInstructionsPath, mainInstructions)
+
+    const runner = new RestrictedInferenceRunner({
+      appVersion: '0.11.0',
+      configRoot: temporaryRoot,
+      profileNamespace: 'test-inference',
+      resolveTarget: async (_target, context) => {
+        if (context.systemPromptAppends.length > 0) {
+          await writeFile(sharedInstructionsPath, context.systemPromptAppends.join('\n\n'))
+        }
+        return backend(opencodeFramework, { modelRoute: 'opencode-openai' })
+      },
+      createRuntime: (options) =>
+        runtimeHarness(options, {
+          events: [
+            event({
+              role: 'assistant',
+              text: '{"title":"Plot sine wave","description":"Plot a sine function."}'
+            })
+          ]
+        })
+    })
+
+    await expect(
+      runner.run(
+        runInput({
+          target: target('opencode'),
+          systemPrompt: 'Return Session metadata only.'
+        })
+      )
+    ).resolves.toMatchObject({ frameworkId: 'opencode' })
+    await expect(readFile(sharedInstructionsPath, 'utf8')).resolves.toBe(mainInstructions)
+  })
+
+  it.each([
+    ['Claude Code', backend(claudeCodeFramework), target('claude-code')],
+    ['OpenCode', backend(opencodeFramework), target('opencode')],
+    [
+      'Codex Responses',
+      backend(codexFramework, {
+        modelRoute: 'codex-responses',
+        responsesBridgeLease: codexToolLessBridgeLease()
+      }),
+      target('codex')
+    ],
+    [
+      'Codex Bridge',
+      backend(codexFramework, {
+        modelRoute: 'codex-bridge',
+        responsesBridgeLease: codexToolLessBridgeLease()
+      }),
+      target('codex')
+    ]
+  ] as const)(
+    'installs restricted instructions after resolving the %s backend',
+    async (_name, resolved, runTarget) => {
+      const onCreateSession = vi.fn(async (prepared: ResolvedAgentBackend) => {
+        expect(prepared.systemPromptAppends).toEqual(['Do not use tools.'])
+      })
+      const { runner, resolveTarget } = await makeRunner(resolved, {
+        events: [event({ role: 'assistant', text: 'PONG' })],
+        onCreateSession
+      })
+
+      await expect(runner.run(runInput({ target: runTarget }))).resolves.toMatchObject({
+        text: 'PONG'
+      })
+      expect(resolveTarget).toHaveBeenCalledWith(
+        runTarget,
+        expect.objectContaining({ systemPromptAppends: [] })
+      )
+      expect(onCreateSession).toHaveBeenCalledOnce()
+    }
+  )
 
   it('collects text and provider-neutral usage while verifying the Codex tool-less scope', async () => {
     const usage: AcpTurnTokenUsage = {
@@ -341,7 +422,7 @@ describe('RestrictedInferenceRunner', () => {
       usage
     })
     expect(resolveTarget).toHaveBeenCalledWith(target('codex'), {
-      systemPromptAppends: ['Do not use tools.'],
+      systemPromptAppends: [],
       includeSkillAndConnectorContext: false,
       forceCodexNativeResponsesCompatibility: true
     })

--- a/src/main/acp/restricted-inference-runner.ts
+++ b/src/main/acp/restricted-inference-runner.ts
@@ -219,7 +219,9 @@ class RestrictedInferenceRunner {
         isCodexSubscriptionProviderId(input.target.providerId) &&
         this.options.allowNativeCodexSubscription === true
       backend = await this.options.resolveTarget(input.target, {
-        systemPromptAppends: [input.systemPrompt],
+        // Install restricted instructions only in the disposable profile prepared below. OpenCode
+        // materializes resolver appends into the shared Main Agent config before this isolation step.
+        systemPromptAppends: [],
         includeSkillAndConnectorContext: false,
         ...(nativeCodexSubscriptionAllowed ? {} : { forceCodexNativeResponsesCompatibility: true })
       })


### PR DESCRIPTION
## Problem

Saving the first human Prompt Message starts Session-details generation in the background. When that restricted inference used OpenCode, `RestrictedInferenceRunner` passed its metadata-only system instruction into the shared backend resolver before creating the disposable profile. OpenCode materializes resolver system appends into the Main Agent's shared `open-science.md`, so an overlapping first conversation could read the Session-details instruction and return title/description JSON as its visible Agent Message.

The recently added Session-details lifecycle IPC is not the cause: its renderer projection already preserves live prompt and Agent Message state. The leak occurs earlier, during backend resolution.

## Proposed change

- Resolve restricted inference backends without system-prompt appends.
- Continue installing the restricted instruction after resolution, exclusively in the disposable restricted profile.
- Add a regression test at the public `RestrictedInferenceRunner.run()` boundary that reproduces OpenCode's shared-config materialization. It failed three consecutive times on the unfixed code because the Main Agent instruction was replaced by the metadata instruction.
- Verify instruction installation for Claude Code, OpenCode, Codex Responses, and Codex Bridge.

## Scope and non-goals

- No new data fields or enum values.
- No database, persisted format, migration, or historical-data compatibility change.
- No IPC/API contract, renderer interaction, or architecture change.
- No dependency change.

## Acceptance criteria and validation

All listed checks ran after the last material edit.

| Behavior | Framework/path | Command | Result |
| --- | --- | --- | --- |
| Metadata prompt cannot overwrite the shared first-conversation instructions | OpenCode restricted inference | `vitest run src/main/acp/restricted-inference-runner.test.ts` | 25 passed |
| Restricted prompt remains installed after backend resolution | Claude Code, OpenCode, Codex Responses, Codex Bridge | same contract test | passed for all four paths |
| Session-details owner and restricted-inference consumers remain valid | Session details, Artifact reconstruction, Notebook host model | targeted six-file Vitest impact set | 211 passed; the loopback-dependent resolver file was rerun outside the sandbox |
| Node types | Main/ACP | `tsc --noEmit -p tsconfig.node.json --composite false` | passed |
| Lint | repository | `eslint --cache .` | passed |

`test:affected:explain` selected the full plan because `src/main/acp/restricted-inference-runner.ts` currently has no module owner in `module-impact.json`. Per maintainer direction, the complete local `npm test` suite was not run; exact-head PR Gate/CI remains the authority for the full portable and platform suites.

No local OS-specific lane was added because the change only controls when an in-memory prompt is handed to backend resolution. OpenCode config materialization and all materially distinct framework paths are covered by deterministic fixtures; live provider/model behavior remains covered by PR CI rather than a billable local model call.

## Review focus

Confirm that restricted instructions are installed only by `prepareRestrictedBackend` and never handed to the shared resolver, while all four framework paths retain their private prompt.
