### PR TITLE
style(settings): use captions icon for the session details scenario row

### DIFF
--- a/src/renderer/src/pages/settings/ScenarioModelList.tsx
+++ b/src/renderer/src/pages/settings/ScenarioModelList.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { ChevronRight, Eye, SearchCheck, Sparkles, Workflow, type LucideIcon } from 'lucide-react'
+import { Captions, ChevronRight, Eye, SearchCheck, Workflow, type LucideIcon } from 'lucide-react'
 import type { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 
@@ -331,7 +331,7 @@ const ScenarioModelList = (): React.JSX.Element => {
     },
     {
       id: 'session-details',
-      icon: Sparkles,
+      icon: Captions,
       name: t('Session details'),
       description:
         sessionDetailsModel.mode === 'disabled'


### PR DESCRIPTION
## Problem

In **Settings → Model → Scenario models**, the Session details row used the `Sparkles` glyph — a decorative "AI magic" motif that reads inconsistently next to its siblings, which are all functional-metaphor icons: `Workflow` (Subagent), `SearchCheck` (Reviewer), `Eye` (Vision).

## Proposed change

Icon only: `Sparkles` → `Captions` (lucide). A panel with a title line and text lines — literally "title + description", which is what the scenario does (it generates a session title and description after the first message is saved). Same lucide family, `size-4`, `text-muted-foreground` as the other rows; no custom SVG introduced.

The row label stays `Session details`; i18n catalogs, scenario id `session-details`, `SessionDetailsModelSelect`, and all selectors/tests are unchanged.

## Scope and non-goals

- Renderer presentation only. No behavior, routing, persistence, or settings-schema changes.
- No new enum/state values; no data migration; no history compatibility concerns.
- The expanded row description ("Generates a title and description after the first message is saved.") is unchanged.

## Acceptance criteria and validation

- The Session details row renders with the Captions icon alongside Workflow / SearchCheck / Eye (mock preview verified visually; glyph harmony confirmed).

Evidence (all run after the last material edit, from the linked worktree):

| Behavior | Command | Result |
| --- | --- | --- |
| Scenario rows render unchanged with new icon | `npx vitest run src/renderer/src/pages/settings/ScenarioModelList.render.test.tsx` | pass |
| i18n catalogs: no orphaned/missing keys | `npx vitest run src/renderer/src/i18n/resources.test.ts` | pass (694 tests) |
| Renderer typecheck | `npm run typecheck:web` | pass |
| Lint on changed source | `npx eslint src/renderer/src/pages/settings/ScenarioModelList.tsx` | pass |

Uncovered risks: exact-head PR Gate CI remains authoritative for the full portable and platform suites (including any visual-regression lanes). App-level Web UI screenshot was not taken locally because a desktop instance already holds the single-instance lock and port 44100; a same-styling mock preview was used instead.

## Review focus

- Icon choice (`Captions`) for the Session details row.
