### PR TITLE
fix(host-sdk): validate delegate requests before admission

### DIFF
--- a/src/main/delegation/delegated-work-admission.ts
+++ b/src/main/delegation/delegated-work-admission.ts
@@ -1,6 +1,9 @@
 import { DurableDelegatedWorkError } from './durable-delegated-work-error'
 import type { DelegatedWorkDurableRecords } from './delegated-work-record-types'
-import { prepareStructuredOutputSchema } from './structured-output'
+import {
+  prepareStructuredOutputSchema,
+  type PreparedStructuredOutputSchema
+} from './structured-output'
 import type {
   DurableDelegateRequest,
   DurableSnapshot,
@@ -122,6 +125,7 @@ class DelegatedWorkAdmissionPolicy {
     Readonly<{
       requests: readonly DurableDelegateRequest[]
       resolvedAgents: readonly DurableResolvedAgent[]
+      contracts: readonly (PreparedStructuredOutputSchema | undefined)[]
     }>
   > {
     const rawRequests: readonly unknown[] = Array.isArray(requestOrRequests)
@@ -159,18 +163,6 @@ class DelegatedWorkAdmissionPolicy {
       ...request,
       name: normalizeExplicitDelegateName(request.name)
     }))
-    const inheritedAgent = requests.some((request) => request.profile === undefined)
-      ? parentSpecialistProfileId === undefined
-        ? ({ kind: 'main' } as const)
-        : await this.resolveAgent(parentSpecialistProfileId)
-      : undefined
-    const resolvedAgents = await Promise.all(
-      requests.map((request) =>
-        request.profile === undefined
-          ? (inheritedAgent as DurableResolvedAgent)
-          : this.resolveRequestedAgent(request.profile)
-      )
-    )
     if (
       requests.some(
         (request) =>
@@ -184,6 +176,23 @@ class DelegatedWorkAdmissionPolicy {
         'delegation inputs must be immutable Version identities'
       )
     }
+    const contracts = requests.map((request) =>
+      request.outputSchema === undefined
+        ? undefined
+        : prepareStructuredOutputSchema(request.outputSchema)
+    )
+    const inheritedAgent = requests.some((request) => request.profile === undefined)
+      ? parentSpecialistProfileId === undefined
+        ? ({ kind: 'main' } as const)
+        : await this.resolveAgent(parentSpecialistProfileId)
+      : undefined
+    const resolvedAgents = await Promise.all(
+      requests.map((request) =>
+        request.profile === undefined
+          ? (inheritedAgent as DurableResolvedAgent)
+          : this.resolveRequestedAgent(request.profile)
+      )
+    )
     const inputs = requests.flatMap((request) => request.inputs ?? [])
     if (inputs.length > 0) {
       if (!this.validateInput) {
@@ -200,12 +209,13 @@ class DelegatedWorkAdmissionPolicy {
         )
       }
     }
-    return { requests, resolvedAgents }
+    return { requests, resolvedAgents, contracts }
   }
 
   buildChildren(
     requests: readonly DurableDelegateRequest[],
     resolvedAgents: readonly DurableResolvedAgent[],
+    contracts: readonly (PreparedStructuredOutputSchema | undefined)[],
     executionModel: NonNullable<
       Parameters<
         DelegatedWorkDurableRecords['admitChildren']
@@ -214,11 +224,6 @@ class DelegatedWorkAdmissionPolicy {
     createId: (prefix: 'frame' | 'message' | 'runtime' | 'attempt') => string,
     now: () => number
   ): Parameters<DelegatedWorkDurableRecords['admitChildren']>[0]['children'] {
-    const contracts = requests.map((request) =>
-      request.outputSchema === undefined
-        ? undefined
-        : prepareStructuredOutputSchema(request.outputSchema)
-    )
     const titles = allocateDelegateNames(requests.map((request) => request.name))
     return requests.map((request, index) => {
       const task = request.task.trim()

--- a/src/main/delegation/durable-delegated-work.ts
+++ b/src/main/delegation/durable-delegated-work.ts
@@ -694,7 +694,7 @@ const createDurableDelegatedWork = (
         'Delegated work is unavailable for this Agent framework configuration. Open Settings and choose a certified configuration.'
       )
     }
-    const { requests, resolvedAgents } = await admissionPolicy.admit(
+    const { requests, resolvedAgents, contracts } = await admissionPolicy.admit(
       requestOrRequests,
       caller.parentSpecialistProfileId
     )
@@ -705,6 +705,7 @@ const createDurableDelegatedWork = (
       admissions = admissionPolicy.buildChildren(
         requests,
         resolvedAgents,
+        contracts,
         executionModel,
         createId,
         now

--- a/src/main/delegation/structured-output-owner.test.ts
+++ b/src/main/delegation/structured-output-owner.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { createDeterministicDelegateExecution } from './deterministic-execution'
 import {
@@ -155,6 +155,44 @@ describe('DurableDelegatedWork structured output', () => {
       )
     ).rejects.toMatchObject({ code: 'conflict' })
     await expect(work.submitOutput(parent, null)).rejects.toMatchObject({ code: 'authorization' })
+  })
+
+  it('rejects an invalid schema before resolving Specialists or validating inputs', async () => {
+    const resolveSpecialist = vi.fn(async () => ({
+      id: 'specialist-1',
+      name: 'EVIDENCE_ANALYST',
+      displayName: 'Evidence Analyst',
+      enabled: true,
+      setupPending: false,
+      revision: 1
+    }))
+    const validateInput = vi.fn(async () => true)
+    const work = createStructuredOutputWork({
+      execution: createDeterministicDelegateExecution(),
+      records: createInMemoryDelegatedWorkRecords({
+        session: parent.session,
+        rootFrameId: parent.frameId,
+        originMessageId: parent.originMessageId
+      }),
+      resolveSpecialist,
+      validateInput
+    })
+
+    await expect(
+      work.delegate(
+        parent,
+        {
+          task: 'Extract',
+          name: 'Extract',
+          profile: 'specialist-1',
+          inputs: ['upload-version-1'],
+          outputSchema: { format: 'email' }
+        },
+        { wait: false }
+      )
+    ).rejects.toMatchObject({ code: 'unsupported_schema' })
+    expect(resolveSpecialist).not.toHaveBeenCalled()
+    expect(validateInput).not.toHaveBeenCalled()
   })
 
   it('retains a submission committed before stop and rejects the terminal-first race order', async () => {

--- a/src/main/host-sdk/delegate-contract.test.ts
+++ b/src/main/host-sdk/delegate-contract.test.ts
@@ -32,7 +32,7 @@ describe('Agent-facing delegate contract', () => {
         })
       }
     })
-    expect(requestArray).toEqual({ type: 'array', minItems: 1, items: singleRequest })
+    expect(requestArray).toEqual({ type: 'array', minItems: 1, maxItems: 4, items: singleRequest })
     expect(singleRequest.properties).not.toHaveProperty('context')
     expect(singleRequest.properties).not.toHaveProperty('output_schema')
     expect(singleRequest.additionalProperties).toBe(false)
@@ -70,7 +70,9 @@ describe('Agent-facing delegate contract', () => {
       request: [{ task: 'Audit', inputs: ['upload-version-1'] }],
       options: { wait: false }
     })
-    expect(parseDelegateRpcCall({ request: [] })).toEqual({ request: [], options: {} })
+    expect(() => parseDelegateRpcCall({ request: [] })).toThrow(
+      'host.delegate request must be one object or a non-empty object array'
+    )
     expect(
       parseDelegateRpcCall({
         request: { task: 'Observe' },

--- a/src/main/host-sdk/delegate-contract.ts
+++ b/src/main/host-sdk/delegate-contract.ts
@@ -6,6 +6,8 @@ import type {
 } from '../delegation/durable-delegated-work'
 import { MAX_DELEGATE_NAME_CODE_POINTS } from '../delegation/delegated-work-admission'
 
+const MAX_DELEGATE_BATCH_ITEMS = 4
+
 const RUNNING_OBSERVATION_SCHEMA = {
   type: 'object',
   required: ['frameId', 'attemptId', 'name', 'agentName', 'status'],
@@ -175,6 +177,7 @@ const DELEGATE_AGENT_CONTRACT = {
       {
         type: 'array',
         minItems: 1,
+        maxItems: MAX_DELEGATE_BATCH_ITEMS,
         items: DELEGATE_REQUEST_OBJECT_SCHEMA
       }
     ]
@@ -263,9 +266,16 @@ const hasOwn = (value: Record<string, unknown>, key: string): boolean =>
 
 const parseDelegateRpcCall = (params: Readonly<Record<string, unknown>>): DelegateRpcCall => {
   const request = params.request
-  if (!isRecord(request) && !Array.isArray(request)) {
+  const requests = Array.isArray(request) ? request : [request]
+  const requestObjects = requests.filter(isRecord)
+  if (requests.length === 0 || requestObjects.length !== requests.length) {
     throw new Error(
       'host.delegate request must be one object or a non-empty object array; pass it as the first argument.'
+    )
+  }
+  if (requests.length > MAX_DELEGATE_BATCH_ITEMS) {
+    throw new Error(
+      `host.delegate request batches must contain from 1 through ${MAX_DELEGATE_BATCH_ITEMS} objects.`
     )
   }
   if (params.options !== undefined && !isRecord(params.options)) {
@@ -313,10 +323,10 @@ const parseDelegateRpcCall = (params: Readonly<Record<string, unknown>>): Delega
   }
   return {
     // Semantic request validation remains in DelegatedWorkAdmissionPolicy so RPC callers retain
-    // the existing domain errors for empty arrays, tasks, profiles, and input identities.
+    // the existing domain errors for tasks, profiles, and input identities.
     request: Array.isArray(request)
-      ? request.map((candidate) => mapRequest(candidate as Record<string, unknown>))
-      : mapRequest(request),
+      ? requestObjects.map(mapRequest)
+      : mapRequest(requestObjects[0]),
     options: {
       ...(typeof requestedOptions.wait === 'boolean' ? { wait: requestedOptions.wait } : {}),
       ...(typeof timeoutSeconds === 'number' ? { timeoutSeconds } : {})

--- a/src/main/host-sdk/help.ts
+++ b/src/main/host-sdk/help.ts
@@ -234,7 +234,7 @@ const DELEGATE_DESCRIPTOR: HostSdkHelpOperationDescriptor = {
   },
   constraints: [
     'Main/root only; no nested delegation.',
-    'Non-empty batches are admitted atomically.',
+    'Batches of 1–4 children are admitted atomically.',
     'Use host.agents.list() for profiles; omission inherits.',
     'Timeout observes; it does not stop children.',
     'Async follow-up: host.children() recovers; host.collect(selectors) observes; host.stopChild(frameIds) cancels.'

--- a/src/main/notebook/local-rpc-server.delegated-work.test.ts
+++ b/src/main/notebook/local-rpc-server.delegated-work.test.ts
@@ -311,6 +311,51 @@ describe('authenticated delegatedWorkCall route', () => {
     connection.release()
   })
 
+  it('rejects malformed or over-capacity arrays at the authenticated host seam', async () => {
+    const delegate = vi.fn(async () => ({ kind: 'receipts' as const, children: [] }))
+    server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
+      transport: 'tcp',
+      delegatedWorkService: { delegate }
+    })
+    const connection = await server.issueControlConnection('session-1', 'project-1', 'root-frame')
+    const endInvocation = connection.beginControlInvocation({
+      turnId: 'turn-1',
+      controlInvocationGeneration: 1,
+      toolInvocationId: 'tool-call-1',
+      originatingUserMessageId: 'origin-message-1'
+    })
+
+    const shapeError =
+      'host.delegate request must be one object or a non-empty object array; pass it as the first argument.'
+    for (const { request, error } of [
+      { request: [], error: shapeError },
+      { request: [null], error: shapeError },
+      { request: ['not-an-object'], error: shapeError },
+      {
+        request: Array.from({ length: 5 }, (_, index) => ({
+          task: `Task ${index + 1}`,
+          name: `Child ${index + 1}`
+        })),
+        error: 'host.delegate request batches must contain from 1 through 4 objects.'
+      }
+    ]) {
+      const response = await fetch(connection.endpoint, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ method: 'delegatedWorkCall', params: { request } })
+      })
+
+      expect(response.status).toBe(500)
+      await expect(response.json()).resolves.toEqual({ error })
+    }
+    expect(delegate).not.toHaveBeenCalled()
+    endInvocation()
+    connection.release()
+  })
+
   it('derives delegation authority from the active control capability and ignores forged owner fields', async () => {
     const session = { projectId: 'trusted-project', sessionId: 'trusted-session' }
     const execution = createDeterministicDelegateExecution()


### PR DESCRIPTION
## Problem

The private `host.delegate` RPC boundary accepted an empty array and cast every array item to an object without validating it. As a result, malformed items could either leak a native `TypeError` (for example, `null`) or reach deeper layers before being rejected. The published request contract also did not expose the production batch capacity.

Structured-output limits already existed, but admission compiled and checked the schema only after resolving Specialists and validating inputs. An invalid schema could therefore cause avoidable I/O before rejection.

## Proposed change

- Require `host.delegate` to receive one object or a non-empty array of objects.
- Reject batches larger than four at the Host SDK boundary, matching the existing production execution capacity.
- Publish the same `maxItems: 4` constraint and update the help text.
- Prepare each structured-output schema once, before Specialist resolution and input validation, and carry the ephemeral prepared contract into child construction.
- Preserve stable domain error messages for malformed request shapes.

## Scope and compatibility

- No request or response fields are added.
- No data model, storage schema, persisted state, or enum value changes.
- No migration or historical-data compatibility handling is required; persisted sessions are not revalidated.
- Existing valid requests keep the same behavior. Batches above four already could not be admitted by the production executor; they now fail earlier and consistently.
- New task-length and input-count limits are intentionally not included. Adding those limits could reject requests that currently succeed and needs a separate compatibility decision.
- `codex-response` and `codex-bridge` share the same Host SDK parsing/admission path (`frameworkId=codex`); their transport and continuation behavior are unchanged. Claude Code and OpenCode use the same boundary as well.

## Regression evidence

The tests were added before the fix and reproduced the report at the authenticated local RPC boundary:

- `[]` returned HTTP 200 instead of the expected domain error.
- `[null]` leaked `TypeError: Cannot convert undefined or null to object`.
- A five-child batch returned HTTP 200 instead of being rejected at the Host SDK boundary.
- An invalid output schema called Specialist resolution once before failing.

After the fix, malformed and over-capacity batches return the stable Host SDK error without dispatch, and invalid schemas fail before Specialist or input I/O.

## Validation

- `npm test -- src/main/notebook/local-rpc-server.delegated-work.test.ts` — 14/14 passed
- `npm test -- src/main/host-sdk/delegate-contract.test.ts src/main/host-sdk/help.test.ts src/main/delegation/structured-output.test.ts src/main/delegation/structured-output-owner.test.ts src/main/delegation/durable-delegated-work.test.ts` — 119/119 passed
- `npm test -- src/main/delegation/production-composition.test.ts` — 49/49 passed across `codex`, `claude-code`, and `opencode`
- `npm test -- src/main/delegation/durable-delegated-work.architecture.test.ts src/main/delegation/certification-contract.test.ts` — 9/9 passed
- `npm run typecheck:node`
- `npm run lint`

The full `npm test` suite was intentionally not run; PR CI is the full-suite authority for this change.

## Review focus

- Whether four should remain the single published batch limit, matching production capacity.
- Whether the error strings are suitable as the stable private RPC contract.
- Whether carrying the prepared schema through admission keeps validation ownership clear without changing persistence semantics.
