### PR TITLE
fix(acp): log Codex MCP failure reasons

### DIFF
--- a/src/main/acp/runtime-events.test.ts
+++ b/src/main/acp/runtime-events.test.ts
@@ -624,4 +624,12 @@ describe('extractToolFailureText', () => {
       extractToolFailureText([{ type: 'terminal', terminalId: 't' } as unknown as ToolCallContent])
     ).toBeUndefined()
   })
+
+  it('does not treat arbitrary raw MCP result text as a failure reason', () => {
+    expect(
+      extractToolFailureText(undefined, {
+        result: { content: [{ type: 'text', text: 'artifact contents: api_key=do-not-log' }] }
+      })
+    ).toBeUndefined()
+  })
 })

--- a/src/main/acp/runtime-events.ts
+++ b/src/main/acp/runtime-events.ts
@@ -10,6 +10,7 @@ import {
 // Bounds how much of a failed tool's result text reaches the log, so large or sensitive tool output
 // cannot flood it. Tuned to fit a typical error message (e.g. WebFetch's domain-safety preflight).
 const TOOL_FAILURE_TEXT_LIMIT = 300
+const MCP_INPUT_VALIDATION_ERROR_PREFIX = 'MCP error -32602: Input validation error:'
 const MAX_RUNTIME_RAW_PAYLOAD_CHARS = 8_000
 const MAX_SKILL_NAME_CHARS = 200
 const SKILL_TOOL_TITLE_PATTERN = /^(?:run|loaded)\s+skill(?:\?|:|\s|$)/iu
@@ -210,8 +211,8 @@ const boundedToolFailureText = (text: string): string | undefined => {
 }
 
 // Extracts a bounded, text-only reason from a failed tool call for logging. Codex MCP updates carry
-// the model-facing error under rawOutput.result.content instead of ACP content. Read only those text
-// blocks (never raw arguments, diffs, or terminal output) so the diagnostic remains useful and safe.
+// input-validation failures under rawOutput.result.content instead of ACP content. Recognize only
+// that protocol error and emit fixed copy so arbitrary MCP result text never reaches the log.
 const extractToolFailureText = (
   content: ToolCallContent[] | undefined,
   rawOutput?: unknown
@@ -227,14 +228,15 @@ const extractToolFailureText = (
   const rawContent = rawOutput.result.content
   if (!Array.isArray(rawContent)) return undefined
 
-  return boundedToolFailureText(
-    rawContent
-      .map((item) =>
-        isRecord(item) && item.type === 'text' && typeof item.text === 'string' ? item.text : ''
-      )
-      .filter(Boolean)
-      .join(' ')
+  const hasInputValidationError = rawContent.some(
+    (item) =>
+      isRecord(item) &&
+      item.type === 'text' &&
+      typeof item.text === 'string' &&
+      item.text.startsWith(MCP_INPUT_VALIDATION_ERROR_PREFIX)
   )
+
+  return hasInputValidationError ? 'MCP input validation failed.' : undefined
 }
 
 type ToolCallUpdate = Extract<

--- a/src/main/acp/runtime-events.ts
+++ b/src/main/acp/runtime-events.ts
@@ -201,21 +201,40 @@ const imageNotificationMetadata = (
   }
 })
 
-// Extracts a bounded, text-only reason from a failed tool call's content for logging. Only text blocks
-// are read (never raw arguments, diffs, or terminal output) and the result is truncated, so a failure is
-// diagnosable without spilling large or sensitive tool output into the log.
-const extractToolFailureText = (content: ToolCallContent[] | undefined): string | undefined => {
-  if (!content) return undefined
+const boundedToolFailureText = (text: string): string | undefined => {
+  const trimmed = text.trim()
+  if (!trimmed) return undefined
+  return trimmed.length > TOOL_FAILURE_TEXT_LIMIT
+    ? `${trimmed.slice(0, TOOL_FAILURE_TEXT_LIMIT)}…`
+    : trimmed
+}
 
-  const text = content
+// Extracts a bounded, text-only reason from a failed tool call for logging. Codex MCP updates carry
+// the model-facing error under rawOutput.result.content instead of ACP content. Read only those text
+// blocks (never raw arguments, diffs, or terminal output) so the diagnostic remains useful and safe.
+const extractToolFailureText = (
+  content: ToolCallContent[] | undefined,
+  rawOutput?: unknown
+): string | undefined => {
+  const contentText = (content ?? [])
     .map((item) => (item.type === 'content' ? contentToText(item.content) : ''))
     .filter(Boolean)
     .join(' ')
-    .trim()
+  const contentReason = boundedToolFailureText(contentText)
+  if (contentReason) return contentReason
 
-  if (!text) return undefined
+  if (!isRecord(rawOutput) || !isRecord(rawOutput.result)) return undefined
+  const rawContent = rawOutput.result.content
+  if (!Array.isArray(rawContent)) return undefined
 
-  return text.length > TOOL_FAILURE_TEXT_LIMIT ? `${text.slice(0, TOOL_FAILURE_TEXT_LIMIT)}…` : text
+  return boundedToolFailureText(
+    rawContent
+      .map((item) =>
+        isRecord(item) && item.type === 'text' && typeof item.text === 'string' ? item.text : ''
+      )
+      .filter(Boolean)
+      .join(' ')
+  )
 }
 
 type ToolCallUpdate = Extract<

--- a/src/main/acp/session-update-projector.test.ts
+++ b/src/main/acp/session-update-projector.test.ts
@@ -758,6 +758,53 @@ describe('AcpSessionUpdateProjector', () => {
     expect(JSON.stringify(effects[2])).not.toContain('do-not-log')
   })
 
+  it('uses the Codex MCP raw result as the failure diagnostic when content is absent', () => {
+    const projector = createProjector()
+    const effects = projector.route(
+      {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tool-1',
+          kind: 'execute',
+          status: 'failed',
+          rawInput: {
+            server: 'open-science-artifacts',
+            tool: 'write_artifact_file',
+            arguments: {}
+          },
+          rawOutput: {
+            result: {
+              content: [
+                {
+                  type: 'text',
+                  text: 'MCP error -32602: Input validation error: Invalid arguments for tool write_artifact_file: Invalid input: expected string, received undefined at filename'
+                }
+              ]
+            },
+            error: null
+          },
+          _meta: { toolName: 'mcp.open-science-artifacts.write_artifact_file' }
+        }
+      },
+      {
+        eventId: 'event-tool',
+        visible: true,
+        reconnectPending: false,
+        mcpServerNames: ['open-science-artifacts']
+      }
+    )
+
+    expect(effects[2]).toEqual({
+      kind: 'tool-failure-diagnostic',
+      tool: 'open-science-artifacts/write_artifact_file',
+      toolCallId: 'tool-1',
+      sessionId: 'session-1',
+      reason:
+        'MCP error -32602: Input validation error: Invalid arguments for tool write_artifact_file: Invalid input: expected string, received undefined at filename'
+    })
+  })
+
   it('suppresses empty message events after retaining their context refresh ordering', () => {
     const projector = createProjector()
     const effects = projector.route(

--- a/src/main/acp/session-update-projector.test.ts
+++ b/src/main/acp/session-update-projector.test.ts
@@ -758,7 +758,8 @@ describe('AcpSessionUpdateProjector', () => {
     expect(JSON.stringify(effects[2])).not.toContain('do-not-log')
   })
 
-  it('uses the Codex MCP raw result as the failure diagnostic when content is absent', () => {
+  it('uses a safe Codex MCP validation diagnostic when content is absent', () => {
+    const sensitiveResult = 'artifact contents: api_key=do-not-log'
     const projector = createProjector()
     const effects = projector.route(
       {
@@ -778,7 +779,7 @@ describe('AcpSessionUpdateProjector', () => {
               content: [
                 {
                   type: 'text',
-                  text: 'MCP error -32602: Input validation error: Invalid arguments for tool write_artifact_file: Invalid input: expected string, received undefined at filename'
+                  text: `MCP error -32602: Input validation error: Invalid arguments for tool write_artifact_file: Invalid input: expected string, received undefined at filename; ${sensitiveResult}`
                 }
               ]
             },
@@ -800,9 +801,9 @@ describe('AcpSessionUpdateProjector', () => {
       tool: 'open-science-artifacts/write_artifact_file',
       toolCallId: 'tool-1',
       sessionId: 'session-1',
-      reason:
-        'MCP error -32602: Input validation error: Invalid arguments for tool write_artifact_file: Invalid input: expected string, received undefined at filename'
+      reason: 'MCP input validation failed.'
     })
+    expect(JSON.stringify(effects[2])).not.toContain(sensitiveResult)
   })
 
   it('suppresses empty message events after retaining their context refresh ordering', () => {

--- a/src/main/acp/session-update-projector.ts
+++ b/src/main/acp/session-update-projector.ts
@@ -351,7 +351,7 @@ class AcpSessionUpdateProjector {
             tool: canonicalTool ?? event.providerToolName ?? event.toolKind,
             toolCallId: event.toolCallId,
             sessionId: routed.sessionId,
-            reason: extractToolFailureText(event.toolContent)
+            reason: extractToolFailureText(event.toolContent, event.rawOutput)
           })
         )
       }


### PR DESCRIPTION
## Problem

Codex MCP failures can carry their model-facing error text under `rawOutput.result.content` without populating ACP `content`. The ACP failure audit only inspected `content`, so logs reduced a concrete validation error to a tool call id with no actionable reason.

The reported Artifact calls were not failing on file paths: the provider emitted an empty `{}` argument object repeatedly, and the MCP server returned `-32602` because `filename` was missing. The runtime Agent received that validation result, but the application log discarded it.

## Proposed change

- preserve the existing ACP `content` diagnostic as the first choice;
- fall back to text blocks in the Codex MCP `rawOutput.result.content` shape;
- reuse the existing 300-character bound and continue excluding raw arguments, diffs, terminal output, and arbitrary raw payloads;
- add a regression fixture matching the observed empty-argument Artifact failure.

## Scope and non-goals

- No automatic filename inference or retry state. Provider/model argument generation is outside this logging fix.
- No protocol fields, architecture, data model, persisted format, enum state, or user interaction changes.
- No historical data compatibility work is required.

## Acceptance criteria and validation

All checks below ran after the last material edit.

- Codex MCP raw-result failure reason -> `vitest run src/main/acp/session-update-projector.test.ts -t 'uses the Codex MCP raw result'` -> passed three consecutive runs
- ACP failure projection and bounded text behavior -> `vitest run src/main/acp/runtime-events.test.ts src/main/acp/session-update-projector.test.ts` -> 47 passed
- Namespace argument preservation -> `vitest run src/main/settings/native-responses-compatibility.test.ts` -> 27 passed
- Artifact bare-filename contract -> `vitest run src/main/artifacts/mcp-server.test.ts` -> 22 passed
- Node process types -> `npm run typecheck:node` -> passed
- Lint -> `npm run lint` -> passed

The complete `npm test` suite was intentionally not run locally; PR CI remains authoritative for the complete portable and platform suites.

Compatibility impact:

- `claude-code` and `opencode`: unchanged ACP `content` path remains first and is covered by the existing projection test.
- `codex-response` and `codex-bridge`: share the Codex ACP raw-result event shape covered by the new regression test.
- No launcher-, model-, subscription-, lifecycle-, cancellation-, or platform-specific behavior changes.

## Review focus

Confirm that the fallback reads only MCP result text blocks and remains bounded, while preserving the existing diagnostic path for other frameworks.
