### PR TITLE
fix(compute): cancel poller work during shutdown

### DIFF
--- a/src/main/compute/compute-service.architecture.test.ts
+++ b/src/main/compute/compute-service.architecture.test.ts
@@ -340,6 +340,17 @@ describe('Compute service architecture', () => {
     expect(backgroundProjectRecovery).toBeGreaterThan(backgroundSessionRecovery)
   })
 
+  it('gives Compute Job shutdown the transport cancellation budget', () => {
+    const source = readSource(computePaths.mainIpc)
+    const runtimeStart = source.indexOf('const jobPoller = createComputeJobRuntime')
+    const runtimeEnd = source.indexOf('const agentComputeService', runtimeStart)
+    const runtimeRegistration = source.slice(runtimeStart, runtimeEnd)
+
+    expect(runtimeStart).toBeGreaterThan(-1)
+    expect(runtimeEnd).toBeGreaterThan(runtimeStart)
+    expect(runtimeRegistration).toContain('disposeTimeoutMs: QUIT_SHUTDOWN_BUDGET_MS')
+  })
+
   it('awaits Compute Job barrier rollback when a new Project deletion aborts', () => {
     const source = readSource(computePaths.mainIpc)
     const abortStart = source.indexOf('abortProjectDeletion: async (projectId) => {')

--- a/src/main/compute/harvest-engine.test.ts
+++ b/src/main/compute/harvest-engine.test.ts
@@ -277,16 +277,19 @@ describe('harvestJob — clean harvest', () => {
     const scp = makeScpRunner()
     const { repo: jobRepo, updates } = makeJobRepo(job)
     const connectionBroker = brokerFromRunners(ssh, scp)
+    const signal = new AbortController().signal
 
     await harvestJob(job, {
       connectionBroker,
       hostRepository: makeHostRepo(host),
       jobRepository: jobRepo,
-      storageRoot
+      storageRoot,
+      signal
     })
 
     expect(connectionBroker.acquire).toHaveBeenCalledWith(job.provider_id, {
-      intent: 'job_harvest'
+      intent: 'job_harvest',
+      signal
     })
     expect(vi.mocked(ssh.run).mock.calls[0]?.[1]).toContain(
       "find ~/'.openscience/jobs/job-1' -type f"

--- a/src/main/compute/harvest-engine.test.ts
+++ b/src/main/compute/harvest-engine.test.ts
@@ -356,6 +356,29 @@ describe('harvestJob — data-root migration gate', () => {
 // ---------------------------------------------------------------------------
 
 describe('harvestJob — harvest_failed', () => {
+  it('does not finalize a harvest cancelled during the initial free-space query', async () => {
+    const storageRoot = await mkTmp()
+    const job = makeJob()
+    const controller = new AbortController()
+    const { repo: jobRepo, updates } = makeJobRepo(job)
+    const freeSpaceError = new Error('free-space query failed during shutdown')
+
+    await expect(
+      harvestJob(job, {
+        connectionBroker: brokerFromRunners(makeSshRunner(findOutput([])), makeScpRunner()),
+        hostRepository: makeHostRepo(sampleHost()),
+        jobRepository: jobRepo,
+        storageRoot,
+        signal: controller.signal,
+        getFreeDiskBytesFn: async () => {
+          controller.abort()
+          throw freeSpaceError
+        }
+      })
+    ).rejects.toThrow(freeSpaceError.message)
+    expect(updates).toEqual([])
+  })
+
   it.each(['ssh_config', 'password'] as const)(
     'leaves %s connection failures unharvested so restart recovery can retry safely',
     async () => {

--- a/src/main/compute/harvest-engine.ts
+++ b/src/main/compute/harvest-engine.ts
@@ -451,6 +451,7 @@ const harvestJobUnchecked = async (job: ComputeJob, deps: HarvestDeps): Promise<
       throw new Error('free-space query returned an invalid value')
     }
   } catch (err) {
+    if (deps.signal?.aborted) throw err
     const msg = err instanceof Error ? err.message : String(err)
     await finalizeAndReturn(`free-space check failed: ${msg}`, '[]')
     return

--- a/src/main/compute/harvest-engine.ts
+++ b/src/main/compute/harvest-engine.ts
@@ -218,6 +218,7 @@ export type HarvestDeps = {
   hostRepository: Pick<ComputeHostRepository, 'get'>
   jobRepository: Pick<ComputeJobRepository, 'update'>
   storageRoot: string
+  signal?: AbortSignal
   /** Override free-space discovery for deterministic tests. */
   getFreeDiskBytesFn?: (path: string) => Promise<number>
   /**
@@ -267,10 +268,12 @@ const buildLeftOnRemoteUri = (
  * previous harvest (re-downloads files, re-writes DB fields).
  */
 export const harvestJob = async (job: ComputeJob, deps: HarvestDeps): Promise<void> => {
+  deps.signal?.throwIfAborted()
   // Serialize before acquiring the data-root writer lease so queued harvests do not unnecessarily
   // delay a storage migration. The active harvest keeps its lease through every download.
   return await withHarvestBudgetLock(async () =>
     withDataRootWrite(async () => {
+      deps.signal?.throwIfAborted()
       try {
         await harvestJobUnchecked(job, deps)
       } catch (error) {
@@ -292,6 +295,7 @@ const harvestJobUnchecked = async (job: ComputeJob, deps: HarvestDeps): Promise<
   // Ensure harvest directory structure exists (idempotent).
   await mkdir(featuredDir, { recursive: true })
   await mkdir(hiddenDir, { recursive: true })
+  deps.signal?.throwIfAborted()
 
   // finalize writes harvestedAt + harvestError + leftOnRemote + notifiedAt in a single atomic
   // update (fix: was two separate writes causing notification loss on restart between them).
@@ -373,10 +377,13 @@ const harvestJobUnchecked = async (job: ComputeJob, deps: HarvestDeps): Promise<
   try {
     host = await hostRepository.get(job.provider_id)
   } catch (err) {
+    if (deps.signal?.aborted) throw err
     const msg = err instanceof Error ? err.message : String(err)
     await finalizeAndReturn(`host lookup failed: ${msg}`, '[]')
     return
   }
+
+  deps.signal?.throwIfAborted()
 
   if (!host) {
     await finalizeAndReturn(`host not found: ${job.provider_id}`, '[]')
@@ -385,7 +392,8 @@ const harvestJobUnchecked = async (job: ComputeJob, deps: HarvestDeps): Promise<
 
   // ── 2. Acquire one Host/revision-scoped connection lease ────────────────────
   const connection: ComputeConnectionLease = await connectionBroker.acquire(job.provider_id, {
-    intent: 'job_harvest'
+    intent: 'job_harvest',
+    signal: deps.signal
   })
 
   const remoteWorkdir = job.remote_workdir ?? `~/.openscience/jobs/${job.job_id}`
@@ -395,10 +403,13 @@ const harvestJobUnchecked = async (job: ComputeJob, deps: HarvestDeps): Promise<
   try {
     remoteFiles = await enumerateRemoteFiles(connection, remoteWorkdir)
   } catch (err) {
+    if (deps.signal?.aborted) throw err
     if (err instanceof ComputeConnectionError) throw err
     await finalizeAndReturn('Remote file enumeration failed.', '[]')
     return
   }
+
+  deps.signal?.throwIfAborted()
 
   // ── 4. Classify files ───────────────────────────────────────────────────────
   let outputs: OutputDeclaration[] = []
@@ -471,6 +482,7 @@ const harvestJobUnchecked = async (job: ComputeJob, deps: HarvestDeps): Promise<
   }
 
   const safeDownload = async (relativePath: string, localPath: string): Promise<boolean> => {
+    deps.signal?.throwIfAborted()
     const expectedBytes = remoteSizeByPath.get(relativePath) ?? 0
     let currentFreeBytes: number
     try {
@@ -504,11 +516,13 @@ const harvestJobUnchecked = async (job: ComputeJob, deps: HarvestDeps): Promise<
         temporaryPath,
         maxBytes
       )
+      deps.signal?.throwIfAborted()
       await rename(temporaryPath, localPath)
       remainingBudgetBytes = Math.max(0, remainingBudgetBytes - bytesWritten)
       return true
     } catch (error) {
       await unlink(temporaryPath).catch(() => undefined)
+      if (deps.signal?.aborted) throw error
       if (error instanceof ComputeConnectionError) throw error
       const candidate = error as HarvestDownloadLimitError
       if (candidate.limitExceeded) {
@@ -526,6 +540,7 @@ const harvestJobUnchecked = async (job: ComputeJob, deps: HarvestDeps): Promise<
 
   // Download featured files.
   for (const relativePath of classification.featured) {
+    deps.signal?.throwIfAborted()
     const localPath = join(featuredDir, relativePath)
     await mkdir(dirname(localPath), { recursive: true })
     await safeDownload(relativePath, localPath)
@@ -533,6 +548,7 @@ const harvestJobUnchecked = async (job: ComputeJob, deps: HarvestDeps): Promise<
 
   // Download hidden files.
   for (const relativePath of classification.hidden) {
+    deps.signal?.throwIfAborted()
     const localPath = join(hiddenDir, relativePath)
     await mkdir(dirname(localPath), { recursive: true })
     await safeDownload(relativePath, localPath)
@@ -541,6 +557,7 @@ const harvestJobUnchecked = async (job: ComputeJob, deps: HarvestDeps): Promise<
   // ── 6. Build left_on_remote JSON and finalize ────────────────────────────────
   // Download full logs last; bounded tails remain available when the budget excludes them.
   for (const relativePath of classification.logs) {
+    deps.signal?.throwIfAborted()
     await safeDownload(relativePath, join(harvestDir, relativePath))
   }
 
@@ -555,6 +572,7 @@ const harvestJobUnchecked = async (job: ComputeJob, deps: HarvestDeps): Promise<
       ? `harvest_failed: ${errors.slice(0, 3).join('; ')}${errors.length > 3 ? ` (and ${errors.length - 3} more)` : ''}`
       : null
 
+  deps.signal?.throwIfAborted()
   const updatedJob = await finalize(harvestError, JSON.stringify(leftOnRemote))
   // Broadcast notification for the successful harvest path (early-exit paths use finalizeAndReturn).
   if (deps.broadcast) {

--- a/src/main/compute/job-poller.test.ts
+++ b/src/main/compute/job-poller.test.ts
@@ -843,6 +843,53 @@ describe('JobPoller', () => {
     )
   })
 
+  it('does not mark timeout when shutdown cancels the fallback kill', async () => {
+    const job = makeJob({ timeout_seconds: 10, started_at: Date.now() - 71_000 })
+    const controller = new AbortController()
+    const update = vi.fn((_id: string, u: unknown) => Promise.resolve({ ...job, ...(u as object) }))
+    const updateIfStatus = guardStatusUpdate(update)
+    const jobRepo = {
+      findNonTerminal: vi.fn(async () => [job]),
+      get: vi.fn(async () => job),
+      update,
+      updateIfStatus
+    } as unknown as ComputeJobRepository
+    const pollOutput = withNonce([
+      'JOB_START:job-1',
+      'alive:1',
+      '',
+      '',
+      'STDOUT_END:job-1',
+      '',
+      'STDERR_END:job-1'
+    ])
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: pollOutput,
+        stderr: '',
+        truncated: false,
+        timedOut: false
+      })
+      .mockImplementationOnce(async () => {
+        controller.abort()
+        throw Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' })
+      })
+    const poller = new JobPoller({
+      connectionBroker: brokerFromRunner({ run }),
+      hostRepository: { get: vi.fn(async () => sampleHost()) } as unknown as ComputeHostRepository,
+      jobRepository: jobRepo,
+      makeNonce: () => NONCE
+    })
+
+    await poller.tick(controller.signal)
+
+    expect(run).toHaveBeenCalledTimes(2)
+    expect(updateIfStatus).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+  })
+
   it('serializes overlapping results so a late fallback timeout cannot kill after success', async () => {
     const job = makeJob({ timeout_seconds: 10, started_at: Date.now() - 71_000 })
     let current = job

--- a/src/main/compute/job-poller.test.ts
+++ b/src/main/compute/job-poller.test.ts
@@ -211,9 +211,13 @@ describe('JobPoller', () => {
 
     await poller.tick()
 
-    expect(connectionBroker.acquire).toHaveBeenCalledWith(job.provider_id, {
-      intent: 'job_poll'
-    })
+    expect(connectionBroker.acquire).toHaveBeenCalledWith(
+      job.provider_id,
+      expect.objectContaining({
+        intent: 'job_poll',
+        signal: expect.any(AbortSignal)
+      })
+    )
     expect(update).toHaveBeenCalledWith(
       'job-1',
       expect.objectContaining({ status: 'success', exitCode: 0 })
@@ -1503,7 +1507,7 @@ describe('JobPoller — harvest wiring', () => {
     await Promise.resolve()
 
     // The orphaned terminal+unharvested job should have been harvested
-    expect(harvestFn).toHaveBeenCalledWith(terminalJob)
+    expect(harvestFn).toHaveBeenCalledWith(terminalJob, expect.any(AbortSignal))
   })
 
   it('does not re-harvest already-harvested jobs in recovery scan', async () => {

--- a/src/main/compute/job-poller.ts
+++ b/src/main/compute/job-poller.ts
@@ -52,12 +52,8 @@ const POLLER_KILL_GRACE_SECONDS = 60
 // Maximum concurrent harvest operations (design.md §3: concurrency limit 2).
 const HARVEST_CONCURRENCY_LIMIT = 2
 
-/**
- * Injectable harvest function type. The poller calls this for each terminal job that needs
- * harvesting (design §3). In production this is `harvestJob` from harvest-engine.ts.
- * Accepting the full job object lets the function access all fields without extra lookups.
- */
-export type HarvestFn = (job: ComputeJob) => Promise<void>
+/** Injectable harvest operation. Production supplies `harvestJob` from harvest-engine.ts. */
+export type HarvestFn = (job: ComputeJob, signal?: AbortSignal) => Promise<void>
 
 export type JobPollerDeps = {
   connectionBroker: ComputeConnectionBrokerAcquirer
@@ -100,6 +96,7 @@ type VanishState = { ticks: number }
 export class JobPoller {
   private handle: ReturnType<typeof setInterval> | undefined
   private paused = false
+  private workAbortController = new AbortController()
   private readonly activeTicks = new Set<Promise<void>>()
   private readonly backgroundTasks = new Set<Promise<void>>()
   private readonly vanishCounters = new Map<string, VanishState>()
@@ -116,13 +113,10 @@ export class JobPoller {
   private readonly harvestFn: HarvestFn | undefined
   private readonly lifecycle: ComputeJobLifecycle
 
-  // Harvest concurrency state (design §3):
-  //   inFlightHarvests: jobIds whose harvest is currently running — prevents duplicate dispatches
-  //   harvestSemaphore: count of available harvest slots (starts at HARVEST_CONCURRENCY_LIMIT)
-  //   harvestQueue: jobs waiting for a semaphore slot
+  // Harvest concurrency state: deduplicate by job id and run at most two operations at once.
   private readonly inFlightHarvests = new Set<string>()
   private harvestSemaphore = HARVEST_CONCURRENCY_LIMIT
-  private readonly harvestQueue: ComputeJob[] = []
+  private readonly harvestQueue: Array<{ job: ComputeJob; signal: AbortSignal }> = []
   //   inFlightErrorNotifs: jobIds whose error-notification emit is in progress — prevents a second
   //   overlapping tick from re-emitting before notified_at is persisted (ticks are not serialized)
   private readonly inFlightErrorNotifs = new Set<string>()
@@ -136,11 +130,13 @@ export class JobPoller {
     this.lifecycle = new ComputeJobLifecycle(deps.jobRepository, deps.onJobUpdated)
   }
 
-  // Starts the poller. Polls once immediately (picks up jobs that were running before restart),
-  // then on every interval.
+  // Poll once immediately for restart recovery, then on every interval.
   start(): void {
     if (this.handle) return // already running
 
+    if (this.workAbortController.signal.aborted) {
+      this.workAbortController = new AbortController()
+    }
     this.paused = false
     this.runTick() // first tick immediately (restart recovery)
     this.handle = this.setIntervalFn(() => this.runTick(), POLL_INTERVAL_MS)
@@ -151,6 +147,10 @@ export class JobPoller {
     if (this.handle) {
       this.clearIntervalFn(this.handle)
       this.handle = undefined
+    }
+    this.workAbortController.abort()
+    for (const { job } of this.harvestQueue.splice(0)) {
+      this.inFlightHarvests.delete(job.job_id)
     }
     await this.drainTrackedWork()
   }
@@ -174,7 +174,7 @@ export class JobPoller {
 
   private runTick(): void {
     if (this.paused || this.activeTicks.size > 0) return
-    const task = this.tick()
+    const task = this.tick(this.workAbortController.signal)
     this.activeTicks.add(task)
     void task.then(
       () => this.activeTicks.delete(task),
@@ -190,15 +190,16 @@ export class JobPoller {
     )
   }
 
-  // One poll cycle: group non-terminal jobs by provider, poll each provider's jobs.
-  // Also runs the restart-recovery harvest scan (design §3): re-queues terminal+unharvested jobs.
-  async tick(): Promise<void> {
+  // Poll non-terminal jobs by provider and recover interrupted harvests.
+  async tick(signal: AbortSignal = this.workAbortController.signal): Promise<void> {
+    if (signal.aborted) return
     // Restart-recovery harvest scan: re-queue terminal jobs whose harvest was interrupted by restart.
     // harvestFn must be configured; without it, harvest is disabled entirely.
     if (this.harvestFn) {
       const unharvested = await this.deps.jobRepository.findTerminalUnharvested()
+      if (signal.aborted) return
       for (const job of unharvested) {
-        this._dispatchHarvest(job)
+        this._dispatchHarvest(job, signal)
       }
     }
 
@@ -210,6 +211,7 @@ export class JobPoller {
     if (this.deps.broadcast && this.deps.storageRoot) {
       const { broadcast, storageRoot } = this.deps
       const errorUnnotified = await this.deps.jobRepository.findErrorUnnotified()
+      if (signal.aborted) return
       for (const job of errorUnnotified) {
         // emitJobNotification guards on notified_at (idempotent), but that is a check-then-act
         // with a real window: ticks are not serialized, so a second tick could re-select this row
@@ -234,6 +236,7 @@ export class JobPoller {
     }
 
     const jobs = await this.deps.jobRepository.findNonTerminal()
+    if (signal.aborted) return
     if (jobs.length === 0) return
 
     // Group by provider.
@@ -247,7 +250,7 @@ export class JobPoller {
     // Poll each provider's jobs in parallel (different SSH connections, no ordering dependency).
     await Promise.all(
       Array.from(byProvider.entries()).map(([providerId, providerJobs]) =>
-        this._pollProvider(providerId, providerJobs)
+        this._pollProvider(providerId, providerJobs, signal)
       )
     )
   }
@@ -256,12 +259,9 @@ export class JobPoller {
   // Harvest dispatch helpers (design §3)
   // ---------------------------------------------------------------------------
 
-  // Dispatches a harvest for a terminal job. Fire-and-forget: does NOT await the harvest so the
-  // poller tick returns immediately (hard constraint: design §3 "never await in tick loop").
-  // Enforces: in-flight dedup (same job not re-dispatched while harvest is running), and the
-  // concurrency semaphore (at most HARVEST_CONCURRENCY_LIMIT harvests run simultaneously).
-  private _dispatchHarvest(job: ComputeJob): void {
-    if (!this.harvestFn) return
+  // Fire-and-forget harvest dispatch with in-flight deduplication and bounded concurrency.
+  private _dispatchHarvest(job: ComputeJob, signal: AbortSignal): void {
+    if (!this.harvestFn || signal.aborted) return
     // In-flight dedup: if already harvesting this job, skip.
     if (this.inFlightHarvests.has(job.job_id)) return
 
@@ -269,20 +269,20 @@ export class JobPoller {
 
     if (this.harvestSemaphore > 0) {
       // Slot available — start immediately.
-      this._runHarvest(job)
+      this._runHarvest(job, signal)
     } else {
       // No slot — enqueue; will be started when a running harvest completes.
-      this.harvestQueue.push(job)
+      this.harvestQueue.push({ job, signal })
     }
   }
 
   // Acquires a semaphore slot, runs harvestFn, then releases the slot and drains the queue.
-  private _runHarvest(job: ComputeJob): void {
+  private _runHarvest(job: ComputeJob, signal: AbortSignal): void {
     if (!this.harvestFn) return
     this.harvestSemaphore--
 
     // Fire-and-forget: intentionally not awaited.
-    const task = this.harvestFn(job)
+    const task = this.harvestFn(job, signal)
       .catch(() => {
         // Individual harvest failures must not propagate to the poller (design §3: error isolation).
       })
@@ -291,22 +291,23 @@ export class JobPoller {
         this.harvestSemaphore++
         // Drain one item from the queue if any are waiting.
         const next = this.harvestQueue.shift()
-        if (next) {
-          this._runHarvest(next)
+        if (next && !next.signal.aborted) {
+          this._runHarvest(next.job, next.signal)
+        } else if (next) {
+          this.inFlightHarvests.delete(next.job.job_id)
         }
       })
     this.trackBackground(task)
   }
 
   // Polls all jobs for one provider in a single SSH round-trip (where possible).
-  private async _pollProvider(providerId: string, jobs: ComputeJob[]): Promise<void> {
-    // Handle jobs stuck in 'submitted' with no pid. A job sits in this state for the whole dispatch
-    // window (mkdir + input staging + launch), and input staging can scp GB-scale files for up to
-    // 30 min. So 'submitted'+no-handle does NOT by itself mean a failed dispatch: it only means a
-    // failed dispatch if no dispatch is actively running for it in this process. The shared
-    // DispatchTracker disambiguates — an untracked such job was orphaned by an app restart and is
-    // marked error/dispatch_failed (design.md §8 boundary 3); a tracked one is still dispatching and
-    // is left alone until the dispatcher writes its terminal or running state.
+  private async _pollProvider(
+    providerId: string,
+    jobs: ComputeJob[],
+    signal: AbortSignal
+  ): Promise<void> {
+    // A submitted job without a handle may still be staging large inputs. Only an untracked job is
+    // an interrupted dispatch; DispatchTracker distinguishes it from live work in this process.
     const noHandle: ComputeJob[] = []
     const withHandle: ComputeJob[] = []
     for (const job of jobs) {
@@ -319,6 +320,7 @@ export class JobPoller {
     }
 
     for (const job of noHandle) {
+      if (signal.aborted) return
       const transition = await this.lifecycle.recoverInterruptedDispatch(job.job_id)
       if (transition.kind === 'ignored') continue
       const updated = transition.job
@@ -341,41 +343,36 @@ export class JobPoller {
 
     let connection: ComputeConnectionLease
     try {
-      connection = await this.deps.connectionBroker.acquire(providerId, { intent: 'job_poll' })
+      connection = await this.deps.connectionBroker.acquire(providerId, {
+        intent: 'job_poll',
+        signal
+      })
     } catch (error) {
+      if (signal.aborted) return
       const errorCode = error instanceof ComputeConnectionError ? error.code : 'host_unreachable'
-      await this._recordPollError(withHandle, errorCode)
+      await this._recordPollError(withHandle, errorCode, signal)
       return
     }
 
-    // Poll in sub-batches so the SSH output cap always fits every job's section. Each sub-batch is
-    // one SSH round-trip; batches for the same provider run sequentially to reuse one connection and
-    // avoid a fan-out of concurrent ssh processes per provider.
+    // Poll bounded sub-batches sequentially over one provider connection.
     for (let i = 0; i < withHandle.length; i += POLL_BATCH_MAX_JOBS) {
+      if (signal.aborted) return
       const batch = withHandle.slice(i, i + POLL_BATCH_MAX_JOBS)
-      await this._pollBatch(batch, connection)
+      await this._pollBatch(batch, connection, signal)
     }
   }
 
   // Polls one sub-batch of jobs (all with handles) in a single SSH round-trip, sizing the output cap
   // to the batch so no job's section is truncated away.
-  private async _pollBatch(jobs: ComputeJob[], connection: ComputeConnectionLease): Promise<void> {
-    // Per-tick random nonce prefixed onto every structural marker. Job stdout/stderr tails are
-    // interleaved into the same stream, so bare markers (JOB_START:/alive:/STDOUT_END:/...) printed
-    // by the job could otherwise hijack section splitting or field parsing. An unpredictable nonce
-    // the job cannot know makes such collisions effectively impossible.
+  private async _pollBatch(
+    jobs: ComputeJob[],
+    connection: ComputeConnectionLease,
+    signal: AbortSignal
+  ): Promise<void> {
+    // Prefix structural markers with an unpredictable nonce so job output cannot spoof them.
     const nonce = this.makeNonceFn()
 
-    // Build per-job check commands, batched into one SSH round-trip.
-    // Format per job (each marker carries the nonce prefix):
-    //   echo "<nonce>JOB_START:<jobId>"
-    //   resolve the canonical workdir and prove the pid still owns it
-    //   kill -0 <pid> 2>/dev/null && echo "<nonce>alive:1" || echo "<nonce>alive:0"
-    //   test -f <exit_code_path> && cat <exit_code_path> || echo ""
-    //   tail -c 65536 <stdout_path> 2>/dev/null || true
-    //   echo "<nonce>STDOUT_END:<jobId>"
-    //   tail -c 65536 <stderr_path> 2>/dev/null || true
-    //   echo "<nonce>STDERR_END:<jobId>"
+    // Build one ownership/status/tail command section per job.
     const parts: string[] = [REMOTE_PROCESS_OWNERSHIP_FUNCTION]
     const batched: ComputeJob[] = []
     for (const job of jobs) {
@@ -405,19 +402,23 @@ export class JobPoller {
       runResult = await connection.run(pollCmd, {
         timeoutMs: POLL_TIMEOUT_MS,
         loginShell: false,
-        maxOutputBytes
+        maxOutputBytes,
+        signal
       })
     } catch (err) {
+      if (signal.aborted) return
       // SSH threw — record lastPollError for each job but do NOT flip status (design.md §8 boundary 2).
       const errorCode = err instanceof ComputeConnectionError ? err.code : 'host_unreachable'
-      await this._recordPollError(batched, errorCode)
+      await this._recordPollError(batched, errorCode, signal)
       return
     }
+
+    if (signal.aborted) return
 
     const connectionFailure = classifyConnectionFailure(runResult, false)
     if (connectionFailure) {
       // Host unreachable — record error per job but do NOT flip status (design.md §8 boundary 2).
-      await this._recordPollError(batched, connectionFailure.code)
+      await this._recordPollError(batched, connectionFailure.code, signal)
       return
     }
 
@@ -425,7 +426,7 @@ export class JobPoller {
     // A truncated result should be impossible now that the cap is sized to the batch, but if it ever
     // happens the head is kept, so leading jobs still parse; any job whose section was dropped simply
     // stays non-terminal and is re-polled next tick (its remote exit_code file persists).
-    await this._parsePollOutput(runResult.stdout, batched, nonce, connection)
+    await this._parsePollOutput(runResult.stdout, batched, nonce, connection, signal)
   }
 
   private _parseHandle(raw: string | undefined): RemoteHandle | null {
@@ -439,8 +440,13 @@ export class JobPoller {
 
   // Records a transient SSH connectivity error for each job without changing job status.
   // Implements design.md §8 boundary 2: "host unreachable ≠ job failed".
-  private async _recordPollError(jobs: ComputeJob[], message: string): Promise<void> {
+  private async _recordPollError(
+    jobs: ComputeJob[],
+    message: string,
+    signal: AbortSignal
+  ): Promise<void> {
     for (const job of jobs) {
+      if (signal.aborted) return
       if (job.status !== 'submitted' && job.status !== 'running') continue
       await this.lifecycle.recordPollError(job.job_id, job.status, message)
     }
@@ -453,7 +459,8 @@ export class JobPoller {
     output: string,
     jobs: ComputeJob[],
     nonce: string,
-    connection: ComputeConnectionLease
+    connection: ComputeConnectionLease,
+    signal: AbortSignal
   ): Promise<void> {
     const parsedResults = parsePollOutput(output, jobs, nonce)
 
@@ -461,7 +468,9 @@ export class JobPoller {
       connection,
       parsedResults.flatMap(({ stdoutTail, stderrTail }) => [stdoutTail, stderrTail])
     )
+    if (signal.aborted) return
     for (const [index, result] of parsedResults.entries()) {
+      if (signal.aborted) return
       await this._applyPollResult(
         result.job,
         {
@@ -471,7 +480,8 @@ export class JobPoller {
           stdoutTail: safeTails[index * 2] ?? '',
           stderrTail: safeTails[index * 2 + 1] ?? ''
         },
-        connection
+        connection,
+        signal
       )
     }
   }
@@ -485,12 +495,13 @@ export class JobPoller {
       stdoutTail: string
       stderrTail: string
     },
-    connection: ComputeConnectionLease
+    connection: ComputeConnectionLease,
+    signal: AbortSignal
   ): Promise<void> {
     const previous = this.pollResultChains.get(job.job_id) ?? Promise.resolve()
     const current = previous
       .catch(() => undefined)
-      .then(() => this._applyPollResultExclusive(job, result, connection))
+      .then(() => this._applyPollResultExclusive(job, result, connection, signal))
     this.pollResultChains.set(job.job_id, current)
 
     try {
@@ -511,8 +522,10 @@ export class JobPoller {
       stdoutTail: string
       stderrTail: string
     },
-    connection: ComputeConnectionLease
+    connection: ComputeConnectionLease,
+    signal: AbortSignal
   ): Promise<void> {
+    if (signal.aborted) return
     const { alive, exitCode, hasExitCode, stdoutTail, stderrTail } = result
 
     // Terminal: exit_code file exists — this is authoritative.
@@ -555,7 +568,7 @@ export class JobPoller {
       if (transition.kind === 'ignored') return
       // Async-dispatch harvest for success/failed/timeout (design §3). Not awaited — must not
       // block the tick loop. 'error' status is never reached here (only in the noHandle path).
-      this._dispatchHarvest(transition.job)
+      this._dispatchHarvest(transition.job, signal)
       return
     }
 
@@ -574,7 +587,7 @@ export class JobPoller {
           stderrTail: stderrTail || null
         })
         // process_vanished is a terminal state — dispatch harvest (design §3).
-        if (transition.kind === 'applied') this._dispatchHarvest(transition.job)
+        if (transition.kind === 'applied') this._dispatchHarvest(transition.job, signal)
       }
       // else: keep running, check again next tick
       return
@@ -593,6 +606,7 @@ export class JobPoller {
         // Same-job poll results are serialized. Re-read after acquiring that chain so an earlier
         // terminal result can suppress this stale destructive observation before any remote kill.
         const current = await this.deps.jobRepository.get(job.job_id)
+        if (signal.aborted) return
         if (!current || (current.status !== 'submitted' && current.status !== 'running')) return
 
         const handle = this._parseHandle(current.remote_handle)
@@ -609,7 +623,8 @@ export class JobPoller {
               {
                 timeoutMs: 10_000,
                 loginShell: false,
-                maxOutputBytes: 64
+                maxOutputBytes: 64,
+                signal
               }
             )
           } catch {
@@ -624,12 +639,13 @@ export class JobPoller {
         })
         if (transition.kind === 'ignored') return
         // Poller-fallback timeout is a terminal state — dispatch harvest (design §3).
-        this._dispatchHarvest(transition.job)
+        this._dispatchHarvest(transition.job, signal)
         return
       }
     }
 
     if (job.status !== 'submitted' && job.status !== 'running') return
+    if (signal.aborted) return
     // Transition a submitted-with-handle recovery to running, or refresh an existing running row.
     // A successful poll also clears any stale connectivity projection.
     await this.lifecycle.observeRunning(job.job_id, job.status, {

--- a/src/main/compute/job-poller.ts
+++ b/src/main/compute/job-poller.ts
@@ -631,6 +631,7 @@ export class JobPoller {
             // Ignore kill errors — the job is marked terminal regardless.
           }
         }
+        if (signal.aborted) return
         const transition = await this.lifecycle.finishPolled(job.job_id, {
           status: 'timeout',
           errorCode: 'timeout',

--- a/src/main/compute/job-poller.ts
+++ b/src/main/compute/job-poller.ts
@@ -146,16 +146,21 @@ export class JobPoller {
     this.handle = this.setIntervalFn(() => this.runTick(), POLL_INTERVAL_MS)
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
     this.paused = true
     if (this.handle) {
       this.clearIntervalFn(this.handle)
       this.handle = undefined
     }
+    await this.drainTrackedWork()
   }
 
   async pause(): Promise<void> {
     this.paused = true
+    await this.drainTrackedWork()
+  }
+
+  private async drainTrackedWork(): Promise<void> {
     while (this.activeTicks.size > 0 || this.backgroundTasks.size > 0) {
       await Promise.allSettled([...this.activeTicks, ...this.backgroundTasks])
     }

--- a/src/main/compute/job-runtime.test.ts
+++ b/src/main/compute/job-runtime.test.ts
@@ -11,7 +11,7 @@ describe('createComputeJobRuntime', () => {
   it('routes updates through the service-owned seams and delegates runtime start/stop', async () => {
     const handleJobUpdated = vi.fn()
     const start = vi.fn()
-    const stop = vi.fn()
+    const stop = vi.fn(async () => undefined)
     const pause = vi.fn(async () => undefined)
     const resume = vi.fn()
     const unbind = vi.fn()
@@ -48,7 +48,7 @@ describe('createComputeJobRuntime', () => {
     pollerDeps?.onJobUpdated?.(job)
     await pollerDeps?.harvestFn?.(job)
     runtime.start()
-    runtime.stop()
+    await runtime.stop()
 
     expect(handleJobUpdated).toHaveBeenCalledWith(job)
     expect(harvest).toHaveBeenCalledWith(job, {
@@ -62,5 +62,42 @@ describe('createComputeJobRuntime', () => {
     expect(stop).toHaveBeenCalledTimes(1)
     expect(jobDeletionOwner.bindRuntime).toHaveBeenCalledWith({ start, stop, pause, resume })
     expect(unbind).toHaveBeenCalledOnce()
+  })
+
+  it('waits for already-started polling work when the runtime stops', async () => {
+    let releaseRecovery!: () => void
+    const findTerminalUnharvested = vi.fn(
+      () =>
+        new Promise<ComputeJob[]>((resolve) => {
+          releaseRecovery = () => resolve([])
+        })
+    )
+    const jobRepository = {
+      findTerminalUnharvested,
+      findErrorUnnotified: vi.fn(async () => []),
+      findNonTerminal: vi.fn(async () => [])
+    } as unknown as ComputeJobRepository
+    const runtime = createComputeJobRuntime({
+      computeService: { handleJobUpdated: vi.fn() },
+      hostRepository: {} as ComputeHostRepository,
+      jobRepository,
+      connectionBroker: {} as ComputeConnectionBroker,
+      storageRoot: '/data'
+    })
+
+    runtime.start()
+    await vi.waitFor(() => expect(findTerminalUnharvested).toHaveBeenCalledOnce())
+
+    let stopped = false
+    const stopping = Promise.resolve(runtime.stop()).then(() => {
+      stopped = true
+    })
+    await Promise.resolve()
+
+    expect(stopped).toBe(false)
+
+    releaseRecovery()
+    await stopping
+    expect(stopped).toBe(true)
   })
 })

--- a/src/main/compute/job-runtime.test.ts
+++ b/src/main/compute/job-runtime.test.ts
@@ -100,4 +100,88 @@ describe('createComputeJobRuntime', () => {
     await stopping
     expect(stopped).toBe(true)
   })
+
+  it('cancels in-flight polling and harvest work when the runtime stops', async () => {
+    const runningJob = {
+      job_id: 'job-running',
+      provider_id: 'ssh:cluster',
+      status: 'running',
+      remote_handle: JSON.stringify({
+        pid: 1234,
+        exit_code_path: '~/.openscience/jobs/job-running/exit_code',
+        stdout_path: '~/.openscience/jobs/job-running/stdout',
+        stderr_path: '~/.openscience/jobs/job-running/stderr',
+        workdir: '~/.openscience/jobs/job-running'
+      })
+    } as ComputeJob
+    const terminalJob = {
+      ...runningJob,
+      job_id: 'job-terminal',
+      status: 'success'
+    } as ComputeJob
+    let pollSignal: AbortSignal | undefined
+    let harvestSignal: AbortSignal | undefined
+    let releasePoll!: () => void
+    let releaseHarvest!: () => void
+    const run = vi.fn(
+      () =>
+        new Promise<{
+          exitCode: number
+          stdout: string
+          stderr: string
+          timedOut: boolean
+          truncated: boolean
+        }>((resolve) => {
+          releasePoll = () =>
+            resolve({ exitCode: 0, stdout: '', stderr: '', timedOut: false, truncated: false })
+        })
+    )
+    const connectionBroker = {
+      acquire: vi.fn(async (_providerId: string, request: { signal?: AbortSignal }) => {
+        pollSignal = request.signal
+        request.signal?.addEventListener('abort', () => releasePoll(), { once: true })
+        return { run }
+      })
+    } as unknown as ComputeConnectionBroker
+    const harvest = vi.fn(
+      (_job: ComputeJob, deps: unknown) =>
+        new Promise<void>((resolve) => {
+          harvestSignal = (deps as { signal?: AbortSignal }).signal
+          releaseHarvest = resolve
+          harvestSignal?.addEventListener('abort', () => releaseHarvest(), { once: true })
+        })
+    )
+    const jobRepository = {
+      findTerminalUnharvested: vi.fn(async () => [terminalJob]),
+      findErrorUnnotified: vi.fn(async () => []),
+      findNonTerminal: vi.fn(async () => [runningJob])
+    } as unknown as ComputeJobRepository
+    const runtime = createComputeJobRuntime(
+      {
+        computeService: { handleJobUpdated: vi.fn() },
+        hostRepository: {} as ComputeHostRepository,
+        jobRepository,
+        connectionBroker,
+        storageRoot: '/data'
+      },
+      { harvest }
+    )
+
+    runtime.start()
+    await vi.waitFor(() => {
+      expect(harvest).toHaveBeenCalledOnce()
+      expect(run).toHaveBeenCalledOnce()
+    })
+
+    const stopping = runtime.stop()
+    try {
+      expect(pollSignal?.aborted).toBe(true)
+      expect(harvestSignal?.aborted).toBe(true)
+      await stopping
+    } finally {
+      releasePoll()
+      releaseHarvest()
+      await stopping
+    }
+  })
 })

--- a/src/main/compute/job-runtime.ts
+++ b/src/main/compute/job-runtime.ts
@@ -54,9 +54,9 @@ export const createComputeJobRuntime = (
   const unbindDeletionRuntime = deps.jobDeletionOwner?.bindRuntime(poller)
   return {
     start: () => poller.start(),
-    stop: () => {
+    stop: async () => {
       unbindDeletionRuntime?.()
-      poller.stop()
+      await poller.stop()
     }
   }
 }

--- a/src/main/compute/job-runtime.ts
+++ b/src/main/compute/job-runtime.ts
@@ -40,13 +40,14 @@ export const createComputeJobRuntime = (
     onJobUpdated: deps.computeService.handleJobUpdated,
     broadcast,
     storageRoot: deps.storageRoot,
-    harvestFn: (job) =>
+    harvestFn: (job, signal) =>
       harvest(job, {
         connectionBroker: deps.connectionBroker,
         hostRepository: deps.hostRepository,
         jobRepository: deps.jobRepository,
         storageRoot: deps.storageRoot,
-        broadcast
+        broadcast,
+        signal
       })
   }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1506,6 +1506,7 @@ const createApplicationModules = async (
         name: 'compute-job-runtime',
         capability: undefined,
         start: () => jobPoller.start(),
+        disposeTimeoutMs: QUIT_SHUTDOWN_BUDGET_MS,
         dispose: () => jobPoller.stop()
       }
     }


### PR DESCRIPTION
## Problem

The Compute Job runtime cleared its polling interval during application disposal but returned before already-started polling, notification, and harvest work settled. The runtime wrapper also discarded an asynchronous Poller stop result. Application shutdown could therefore report the module disposed while tracked Compute work was still using SSH, database, or event-publication resources.

Simply awaiting that work was not bounded: the default module disposal budget is one second, while polling may run for 30 seconds and SSH cancellation itself has a three-second termination boundary. Shutdown could time out and continue tearing down dependencies underneath those operations.

This affects the shared main-process runtime used by the Electron UI and headless/Web modes. MCP helper processes, preload, and renderer lifecycles do not construct this Poller.

## Proposed change

- Make `JobPoller.stop()` prevent future ticks, abort active polling and harvest operations, then drain all tracked work.
- Keep deletion `pause()` non-cancelling so the same runtime can safely resume after deletion coordination.
- Thread one lifecycle `AbortSignal` through the existing connection broker, SSH/SCP runners, and harvest dependencies; suppress cancellation-derived job status writes, including free-space-query failure paths.
- Propagate and await the Poller stop result from `createComputeJobRuntime()`.
- Give the production compute module the existing five-second normal-quit budget, which covers the transport cancellation boundary without introducing a new timeout policy.
- Add regression coverage for early disposal, active cancellation, cancelled harvest retry eligibility, and production disposal registration.

## Scope and non-goals

- No schema, data-model, persistence-format, historical-data compatibility, enum, IPC payload, or user-interaction changes.
- No new generic lifecycle framework or resource registry.
- No new timeout constant; the compute module reuses `QUIT_SHUTDOWN_BUDGET_MS`, already used by other long-running shutdown owners.

## Acceptance criteria and validation

All listed successful checks ran after the last material edit.

- Early-disposal regression: failed twice before its fix at `expected true to be false`.
- Poll/harvest cancellation regression: failed twice before its fix at `expected undefined to be true`.
- Free-space/abort retry regression: failed twice before its fix because `harvestJob()` resolved and finalized.
- Production registration regression: failed twice before its fix because `compute-job-runtime` had no `disposeTimeoutMs`.
- All four regressions pass after their fixes.
- `compute_service` module-impact file list plus `harvest-engine.test.ts`, invoked directly through the canonical Vitest runtime because the worktree intentionally has no private dependency install: 32 files passed, 1 skipped; 810 tests passed, 25 skipped.
- Compute architecture gate: passed with `job-poller.ts` at 656 lines against the 660-line limit.
- Targeted ESLint and `git diff --check`: passed.
- `npm run typecheck:node` did not provide valid branch evidence because the worktree resolves the main checkout's mismatched generated Prisma Client and ACP patch. Failures remain confined to unchanged `sessionModelCallUsage` and `waitForMcpServers` consumers; there are no new Compute diagnostics. Exact-head PR CI is authoritative for typechecking.
- Full `npm test` was not run; the PR Gate runs the repository-selected exact-head plan.

The `compute_service` manifest includes the changed owners, runtime registration architecture check, and Windows-sensitive capability overlay. No renderer or Web consumer lane is needed because no interface crosses into those processes.

## Review focus

- Confirm final stop aborts the active lifecycle generation before draining tracked work.
- Confirm cancellation reaches poll SSH calls and harvest SSH/SCP transfers without persisting a false failure or consuming restart eligibility.
- Confirm the five-second compute disposal budget covers the three-second SSH cancellation boundary while retaining deletion pause/resume semantics.
