### PR TITLE
fix(workspace-runtime): preserve usage for interrupted turns

### DIFF
--- a/src/renderer/src/lib/acp/workspace-events.test.ts
+++ b/src/renderer/src/lib/acp/workspace-events.test.ts
@@ -478,7 +478,23 @@ describe('workspace runtime events', () => {
         id: 'event-2',
         kind: 'stop',
         text: 'cancelled',
-        turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14 }
+        turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14, turnCount: 2 },
+        modelCallUsage: [
+          {
+            id: 'prompt-message:model-call:0',
+            index: 0,
+            inputTokens: 19,
+            cacheTokens: 8,
+            outputTokens: 5
+          },
+          {
+            id: 'prompt-message:model-call:1',
+            index: 1,
+            inputTokens: 12,
+            cacheTokens: 7,
+            outputTokens: 9
+          }
+        ]
       })
     )
 
@@ -493,7 +509,19 @@ describe('workspace runtime events', () => {
     expect(session.messages[0]).toMatchObject({ id: promptMessageId, interrupted: true })
     expect(session.messages[1]).toMatchObject({
       content: 'I will search PubMed now.',
-      status: 'error'
+      status: 'error',
+      turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14, turnCount: 2 },
+      modelCallUsage: [
+        expect.objectContaining({ id: 'prompt-message:model-call:0', index: 0 }),
+        expect.objectContaining({ id: 'prompt-message:model-call:1', index: 1 })
+      ]
+    })
+    expect(toPersistedSession(session).messages[1]).toMatchObject({
+      turnUsage: { inputTokens: 31, cacheTokens: 15, outputTokens: 14, turnCount: 2 },
+      modelCallUsage: [
+        expect.objectContaining({ id: 'prompt-message:model-call:0', index: 0 }),
+        expect.objectContaining({ id: 'prompt-message:model-call:1', index: 1 })
+      ]
     })
     expect(session.messages[1].completedAt).toBeUndefined()
   })

--- a/src/renderer/src/lib/acp/workspace-events.ts
+++ b/src/renderer/src/lib/acp/workspace-events.ts
@@ -688,7 +688,9 @@ const applyWorkspaceRuntimeEvent = async (
         'cancelled',
         INTERRUPTED_TURN_ERROR,
         terminalPromptMessageId,
-        contextWindowSample
+        contextWindowSample,
+        event.turnUsage,
+        event.modelCallUsage
       )
       return true
     }

--- a/src/renderer/src/stores/session-store-run-projection-owner.ts
+++ b/src/renderer/src/stores/session-store-run-projection-owner.ts
@@ -79,7 +79,9 @@ export type SessionRunProjectionActions = {
     cause: PersistedSessionResumeRecovery['cause'],
     error: string,
     promptMessageId?: string,
-    contextWindowSample?: RunTerminalContextWindowSample
+    contextWindowSample?: RunTerminalContextWindowSample,
+    turnUsage?: AcpTurnTokenUsage,
+    modelCallUsage?: readonly AcpModelCallUsage[]
   ) => void
   markResumed: (
     sessionId: string,
@@ -341,10 +343,26 @@ export const createSessionRunProjectionOwner = <
       }))
     },
 
-    interruptRun: (sessionId, cause, error, promptMessageId, contextWindowSample) => {
+    interruptRun: (
+      sessionId,
+      cause,
+      error,
+      promptMessageId,
+      contextWindowSample,
+      turnUsage,
+      modelCallUsage
+    ) => {
       setSessionState((state) => ({
         sessions: projectSession(state.sessions, sessionId, (session) =>
-          projectInterruptedRun(session, cause, error, promptMessageId, contextWindowSample)
+          projectInterruptedRun(
+            session,
+            cause,
+            error,
+            promptMessageId,
+            contextWindowSample,
+            turnUsage,
+            modelCallUsage
+          )
         )
       }))
     },

--- a/src/renderer/src/stores/session-store-run-terminal-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-terminal-helpers.ts
@@ -433,12 +433,18 @@ export const projectInterruptedRun = (
   recoveryCause: PersistedSessionResumeRecovery['cause'],
   error: string,
   promptMessageId = session.activeRun?.promptMessageId,
-  contextWindowSample?: RunTerminalContextWindowSample
+  contextWindowSample?: RunTerminalContextWindowSample,
+  turnUsage?: AcpTurnTokenUsage,
+  modelCallUsage?: readonly AcpModelCallUsage[]
 ): ChatSession => {
   const now = Math.max(Date.now(), session.updatedAt + 1)
+  const failedMessages = failStreamingMessages(session.messages, now)
   const messages = appendContextWindowSample(
     session,
-    failStreamingMessages(session.messages, now).map((message) =>
+    (turnUsage
+      ? completeStreamingMessages(failedMessages, promptMessageId, turnUsage, modelCallUsage, now)
+      : failedMessages
+    ).map((message) =>
       message.id === promptMessageId && message.role === 'user'
         ? { ...message, interrupted: true as const, updatedAt: now }
         : message


### PR DESCRIPTION
## Problem

When a user stops a Codex turn after the provider has already reported exact turn and model-call usage, the runtime stop event carries both `turnUsage` and `modelCallUsage`. The renderer's cancelled-stop branch called `interruptRun` without either field, so the interrupted Agent message lost the data and the Context window Calls view stayed empty even though the provider had supplied complete call coverage.

This does not cover stops that happen before the provider reports usage. Those calls remain unavailable rather than being synthesized from context estimates.

## Proposed change

- Route existing `turnUsage` and `modelCallUsage` fields through the interrupted-run projection.
- Reuse the existing completed-run usage-footer projection after marking streamed messages as failed, preserving interrupted/error semantics while attaching usage to the final Agent message.
- Extend the cancelled runtime-event regression test to assert both in-memory and persisted call usage.

## Scope and non-goals

- No new persisted fields, database schema, migration, or enum value.
- No UI or interaction changes.
- No historical backfill; older interrupted turns without call data remain readable and unchanged.
- No partial or estimated call records. Existing exact-coverage validation remains authoritative.

## Acceptance criteria and validation

The regression test was run three times against the unfixed code and failed deterministically because `turnUsage` and `modelCallUsage` were absent from the interrupted Agent message. After the final material edit:

- cancelled-stop usage retention -> `npm test -- src/renderer/src/lib/acp/workspace-events.test.ts -t 'retains a cancelled prompt as an interrupted turn instead of completing it'` -> 1 passed
- workspace runtime event behavior -> `npm test -- src/renderer/src/lib/acp/workspace-events.test.ts` -> 88 passed
- Session renderer owner/contracts/representative consumer -> `npm run test:module -- session_renderer` -> 500 passed
- Workspace runtime owner/contract/consumer slice -> `npm run test:module -- workspace_runtime` -> 347 passed
- Renderer types -> `npm run typecheck:web` -> passed
- Source lint -> `npm run lint` -> passed with no warnings

The exact affected-test plan expands through shared consumer declarations into `project_files_view`, `workspace_page`, reviewer, artifact provenance, and session persistence suites. Per project guidance, those broader portable and platform checks are left to exact-head PR CI rather than running a near-full local suite. No platform-specific production behavior changed; Windows-sensitive overlays remain covered by CI.

## Review focus

- Confirm interrupted Agent messages keep `status: error` and do not gain `completedAt`.
- Confirm exact usage is attached only when supplied by the stop event and older/partial data remains absent.
- Confirm the optional tail parameters leave connection-loss and Save-as-Skill interruption callers unchanged.
