### PR TITLE
fix(composer): hide placeholder during IME composition

### DIFF
--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -302,6 +302,26 @@ describe('ComposerEditor', () => {
     expect(document.body.querySelector('[aria-hidden="true"]')).toBeNull()
   })
 
+  it('hides the placeholder while an IME composition is active', () => {
+    renderEditor({ doc: emptyDoc })
+    const hasPlaceholder = (): boolean =>
+      Array.from(document.body.querySelectorAll('[aria-hidden="true"]')).some(
+        (node) => node.textContent === 'Ask anything'
+      )
+
+    expect(hasPlaceholder()).toBe(true)
+
+    act(() => {
+      editor().dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
+    })
+    expect(hasPlaceholder()).toBe(false)
+
+    act(() => {
+      editor().dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }))
+    })
+    expect(hasPlaceholder()).toBe(true)
+  })
+
   it('keeps an inline placeholder and a visible caret host after a pasted-text marker', () => {
     renderEditor({ focusRequest: 'session-a' })
     const root = editor()

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -443,8 +443,9 @@ export const ComposerEditor = ({
   const [activeMentionOptionId, setActiveMentionOptionId] = useState<string | undefined>()
   const restoreHistoryCaretRef = useRef(false)
   const handledCaretRequestRef = useRef<number | undefined>(undefined)
-  // Tracks IME composition so Enter never submits mid-composition.
+  // Tracks IME composition synchronously for handlers and reactively for placeholder visibility.
   const composingRef = useRef(false)
+  const [isComposing, setIsComposing] = useState(false)
 
   // At most one skill per message: once a chip exists, suppress the trigger so a further `/` does nothing.
   const hasSkill = doc.nodes.some((node) => node.type === 'skill')
@@ -452,7 +453,7 @@ export const ComposerEditor = ({
     (node) => node.type !== 'pasted-text' && (node.type !== 'text' || node.text !== '')
   )
   const hasPastedText = doc.nodes.some((node) => node.type === 'pasted-text')
-  const showInlinePlaceholder = hasPastedText && !hasVisibleContent
+  const showInlinePlaceholder = hasPastedText && !hasVisibleContent && !isComposing
 
   // The hook guards a null current internally; widen the element type for its generic ref option.
   const mention = useMentionTrigger({
@@ -836,9 +837,11 @@ export const ComposerEditor = ({
           const root = editorRef.current
           undoCaretRef.current = root ? currentCaretPosition(root) : undefined
           composingRef.current = true
+          setIsComposing(true)
         }}
         onCompositionEnd={() => {
           composingRef.current = false
+          setIsComposing(false)
           emitDocFromDom()
         }}
       />
@@ -848,7 +851,7 @@ export const ComposerEditor = ({
       <span id={historyStatusId} role="status" aria-live="polite" className="sr-only">
         {historyStatus}
       </span>
-      {!hasVisibleContent && !hasPastedText ? (
+      {!isComposing && !hasVisibleContent && !hasPastedText ? (
         <div aria-hidden="true" className={composerPlaceholderClassName}>
           {placeholder}
         </div>


### PR DESCRIPTION
## Problem

The composer placeholder remains visible while an IME composition is active because document emission is intentionally deferred until `compositionend`. Native IME text can therefore overlap the model-driven placeholder.

## Proposed change

- Track IME composition reactively in `ComposerEditor` while retaining the synchronous ref used by keyboard and input handlers.
- Hide both the empty-document overlay and the inline pasted-text placeholder during composition.
- Add a regression test covering placeholder visibility across composition start and end.

## Scope and non-goals

- Preserve deferred document emission so one IME composition remains one undoable edit.
- Preserve Enter-to-submit protection and mention/history behavior.
- No persisted data, schema, domain enum, compatibility, dependency, or translation changes.

## Acceptance criteria and validation

All commands below ran after the final material edit.

- IME placeholder visibility -> `npm test -- src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx` -> 41 tests passed.
- Workspace consumers -> `npm run test:module -- workspace_page --explain` -> 25 files and 544 tests passed.
- Renderer types -> `npm run typecheck:web` -> passed.
- Source lint -> `npm run lint` -> passed.

The affected-test classifier falls back to the complete suite because the existing `ComposerEditor.interaction.test.tsx` file is not registered to a module owner. The complete local suite was intentionally not run; PR CI remains authoritative for complete and platform coverage.

## Review focus

Please verify that composition state is cleared before the final document emission without changing the existing single-edit IME undo behavior.
