### PR TITLE
fix(elicitation): enforce form schema invariants

### DIFF
--- a/src/main/acp/elicitation-owner.test.ts
+++ b/src/main/acp/elicitation-owner.test.ts
@@ -210,6 +210,25 @@ describe('AcpElicitationOwner', () => {
     expect(onProjection).not.toHaveBeenCalled()
   })
 
+  it('does not rehydrate a detached choice with duplicate field identities', () => {
+    const owner = new AcpElicitationOwner({ onProjection: vi.fn() })
+
+    expect(
+      owner.restoreDetached({
+        requestId: 'choice-1',
+        sessionId: 'app-session-1',
+        toolCallId: 'tool-choice-1',
+        message: 'Choose an approach',
+        fields: [
+          { id: 'answer', label: 'First answer', kind: 'text' },
+          { id: 'answer', label: 'Second answer', kind: 'text' }
+        ],
+        durable: { kind: 'agent-user-choice', requestId: 'choice-1' }
+      })
+    ).toBeUndefined()
+    expect(owner.getPendingRequests()).toEqual([])
+  })
+
   it('parks a form request and resumes it with validated typed content', async () => {
     const onProjection = vi.fn()
     const owner = new AcpElicitationOwner({
@@ -300,6 +319,55 @@ describe('AcpElicitationOwner', () => {
         ]
       })
     )
+  })
+
+  it('does not expose schema defaults that Main would reject as submitted values', () => {
+    let sequence = 0
+    const owner = new AcpElicitationOwner({
+      createRequestId: () => `elicitation-${++sequence}`,
+      onProjection: vi.fn()
+    })
+    const properties: ElicitationSchema['properties'][] = [
+      {
+        value: {
+          type: 'string',
+          enum: ['minimal', 'expanded'],
+          default: 'unsupported'
+        }
+      },
+      { value: { type: 'integer', minimum: 1, maximum: 3, default: 1.5 } },
+      { value: { type: 'number', minimum: 1, maximum: 3, default: 4 } },
+      { value: { type: 'string', format: 'email', default: 'not-an-email' } },
+      {
+        value: {
+          type: 'array',
+          items: { type: 'string', enum: ['alpha', 'beta'] },
+          default: ['unsupported']
+        }
+      }
+    ]
+
+    for (const property of properties) {
+      void owner.request(
+        {
+          mode: 'form',
+          sessionId: 'agent-session-1',
+          toolCallId: `tool-ask-${sequence + 1}`,
+          message: 'Choose a value',
+          requestedSchema: { type: 'object', properties: property }
+        },
+        { sessionId: 'app-session-1' }
+      )
+    }
+
+    expect(owner.getPendingRequests().map((request) => request.fields[0].defaultValue)).toEqual([
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    ])
+    owner.dispose()
   })
 
   it('cancels only requests owned by the selected session', async () => {

--- a/src/main/acp/elicitation-owner.ts
+++ b/src/main/acp/elicitation-owner.ts
@@ -7,14 +7,15 @@ import {
   MAX_ELICITATION_LABEL_CHARS,
   MAX_ELICITATION_MESSAGE_CHARS,
   MAX_ELICITATION_MULTI_SELECT_VALUES,
+  isValidElicitationValue,
   resolveAgentUserChoiceQuestions,
+  sanitizeElicitationField,
   sanitizeElicitationProjection,
   sanitizePendingElicitationRequest,
   type ElicitationAnswer,
   type ElicitationField,
   type ElicitationProjection,
   type ElicitationResponse,
-  type ElicitationValue,
   type AgentTurnProvenanceContext,
   type PendingElicitationRequest
 } from '../../shared/elicitation'
@@ -90,6 +91,11 @@ const normalizeOptions = (value: unknown): ElicitationField['options'] | undefin
     : undefined
 }
 
+const withValidDefault = (
+  field: ElicitationField,
+  defaultValue: unknown
+): ElicitationField | undefined => sanitizeElicitationField({ ...field, defaultValue })
+
 const normalizeField = (
   id: string,
   schema: unknown,
@@ -128,15 +134,15 @@ const normalizeField = (
     ) {
       return undefined
     }
-    return {
+    const field: ElicitationField = {
       ...common,
       kind: options ? 'single-select' : 'text',
       ...(options ? { options } : {}),
       ...(format ? { format } : {}),
       ...(minLength !== undefined ? { minLength } : {}),
-      ...(maxLength !== undefined ? { maxLength } : {}),
-      ...(defaultValue !== undefined ? { defaultValue } : {})
+      ...(maxLength !== undefined ? { maxLength } : {})
     }
+    return withValidDefault(field, defaultValue)
   }
 
   if (type === 'number' || type === 'integer') {
@@ -144,21 +150,21 @@ const normalizeField = (
     const minimum = readNumber(schema.minimum)
     const maximum = readNumber(schema.maximum)
     if (minimum !== undefined && maximum !== undefined && minimum > maximum) return undefined
-    return {
+    const field: ElicitationField = {
       ...common,
       kind: type,
       ...(minimum !== undefined ? { minimum } : {}),
-      ...(maximum !== undefined ? { maximum } : {}),
-      ...(defaultValue !== undefined ? { defaultValue } : {})
+      ...(maximum !== undefined ? { maximum } : {})
     }
+    return withValidDefault(field, defaultValue)
   }
 
   if (type === 'boolean') {
-    return {
+    const field: ElicitationField = {
       ...common,
-      kind: 'boolean',
-      ...(typeof schema.default === 'boolean' ? { defaultValue: schema.default } : {})
+      kind: 'boolean'
     }
+    return withValidDefault(field, schema.default)
   }
 
   if (type === 'array' && isRecord(schema.items)) {
@@ -183,14 +189,14 @@ const normalizeField = (
     ) {
       return undefined
     }
-    return {
+    const field: ElicitationField = {
       ...common,
       kind: 'multi-select',
       options,
       ...(minItems !== undefined ? { minItems } : {}),
-      ...(maxItems !== undefined ? { maxItems } : {}),
-      ...(defaultValue ? { defaultValue } : {})
+      ...(maxItems !== undefined ? { maxItems } : {})
     }
+    return withValidDefault(field, defaultValue)
   }
 
   return undefined
@@ -252,70 +258,6 @@ const containsUnknownFieldSchema = (params: CreateElicitationRequest): boolean =
   })
 }
 
-const isValidCalendarDate = (value: string): boolean => {
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
-  if (!match) return false
-  const year = Number(match[1])
-  const month = Number(match[2])
-  const day = Number(match[3])
-  const date = new Date(Date.UTC(year, month - 1, day))
-  return (
-    date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
-  )
-}
-
-const isValidFormattedString = (format: ElicitationField['format'], value: string): boolean => {
-  if (!format) return true
-  if (format === 'email') return /^[^\s@]+@[^\s@]+$/.test(value)
-  if (format === 'uri') {
-    try {
-      new URL(value)
-      return true
-    } catch {
-      return false
-    }
-  }
-  if (format === 'date') return isValidCalendarDate(value)
-
-  const match =
-    /^(\d{4}-\d{2}-\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?(?:Z|([+-])(\d{2}):(\d{2}))$/.exec(
-      value
-    )
-  if (!match || !isValidCalendarDate(match[1])) return false
-  const hour = Number(match[2])
-  const minute = Number(match[3])
-  const second = Number(match[4])
-  const offsetHour = match[6] === undefined ? 0 : Number(match[6])
-  const offsetMinute = match[7] === undefined ? 0 : Number(match[7])
-  return hour <= 23 && minute <= 59 && second <= 59 && offsetHour <= 23 && offsetMinute <= 59
-}
-
-const validateAnswerValue = (field: ElicitationField, value: ElicitationValue): boolean => {
-  if (field.kind === 'text' || field.kind === 'single-select') {
-    if (typeof value !== 'string') return false
-    if (value.length > MAX_ELICITATION_MESSAGE_CHARS) return false
-    if (field.minLength !== undefined && value.length < field.minLength) return false
-    if (field.maxLength !== undefined && value.length > field.maxLength) return false
-    if (field.options && !field.options.some((option) => option.value === value)) return false
-    if (!isValidFormattedString(field.format, value)) return false
-    return true
-  }
-  if (field.kind === 'number' || field.kind === 'integer') {
-    if (typeof value !== 'number' || !Number.isFinite(value)) return false
-    if (field.kind === 'integer' && !Number.isInteger(value)) return false
-    if (field.minimum !== undefined && value < field.minimum) return false
-    if (field.maximum !== undefined && value > field.maximum) return false
-    return true
-  }
-  if (field.kind === 'boolean') return typeof value === 'boolean'
-  if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) return false
-  if (value.length > MAX_ELICITATION_MULTI_SELECT_VALUES) return false
-  if (field.minItems !== undefined && value.length < field.minItems) return false
-  if (field.maxItems !== undefined && value.length > field.maxItems) return false
-  const allowed = new Set(field.options?.map((option) => option.value) ?? [])
-  return value.every((item) => allowed.has(item))
-}
-
 export const validateElicitationAnswers = (
   request: PendingElicitationRequest,
   answers: ElicitationAnswer[] | undefined
@@ -329,7 +271,7 @@ export const validateElicitationAnswers = (
 
   for (const answer of candidates) {
     const field = fields.get(answer.fieldId)
-    if (!field || seen.has(answer.fieldId) || !validateAnswerValue(field, answer.value)) {
+    if (!field || seen.has(answer.fieldId) || !isValidElicitationValue(field, answer.value)) {
       throw new Error('Invalid structured input response')
     }
     seen.add(answer.fieldId)

--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
@@ -843,6 +843,45 @@ describe('WorkspaceElicitationCard generic ACP form', () => {
     expect(onRespond).not.toHaveBeenCalled()
   })
 
+  it('submits an RFC3339 date-time default accepted by Main', async () => {
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    const field = {
+      id: 'scheduled-at',
+      label: 'Scheduled at',
+      kind: 'text' as const,
+      required: true,
+      format: 'date-time' as const,
+      defaultValue: '2026-08-02T12:00:00Z'
+    }
+
+    await act(async () => {
+      root.render(
+        <WorkspaceElicitationCard
+          elicitation={{ message: 'Choose a time', fields: [field], state: 'pending' }}
+          request={{
+            requestId: 'generic-date-time-default',
+            sessionId: 'session-1',
+            toolCallId: 'tool-generic-date-time-default',
+            message: 'Choose a time',
+            fields: [field]
+          }}
+          onRespond={onRespond}
+        />
+      )
+    })
+
+    const continueButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Continue'
+    )
+    expect(continueButton?.disabled).toBe(false)
+    await act(async () => continueButton?.click())
+    expect(onRespond).toHaveBeenCalledWith({
+      requestId: 'generic-date-time-default',
+      action: 'accept',
+      answers: [{ fieldId: 'scheduled-at', value: '2026-08-02T12:00:00Z' }]
+    })
+  })
+
   it('keeps non-question form fields on the generic submit path', async () => {
     const onRespond = vi.fn().mockResolvedValue(undefined)
     const genericFields = [

--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
@@ -780,6 +780,69 @@ describe('WorkspaceElicitationCard choice question', () => {
 })
 
 describe('WorkspaceElicitationCard generic ACP form', () => {
+  it.each([
+    [
+      'a wrong-kind preset',
+      {
+        id: 'attempts',
+        label: 'Attempts',
+        kind: 'integer' as const,
+        required: true,
+        defaultValue: '2'
+      }
+    ],
+    [
+      'an out-of-enum preset',
+      {
+        id: 'approach',
+        label: 'Approach',
+        kind: 'single-select' as const,
+        required: true,
+        options: [
+          { value: 'minimal', label: 'Minimal' },
+          { value: 'expanded', label: 'Expanded' }
+        ],
+        defaultValue: 'unsupported'
+      }
+    ],
+    [
+      'an invalid formatted preset',
+      {
+        id: 'contact',
+        label: 'Contact',
+        kind: 'text' as const,
+        required: true,
+        format: 'email' as const,
+        defaultValue: 'not-an-email'
+      }
+    ]
+  ])('keeps Continue disabled for %s', async (_label, field) => {
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+
+    await act(async () => {
+      root.render(
+        <WorkspaceElicitationCard
+          elicitation={{ message: 'Provide a value', fields: [field], state: 'pending' }}
+          request={{
+            requestId: 'generic-invalid-default',
+            sessionId: 'session-1',
+            toolCallId: 'tool-generic-invalid-default',
+            message: 'Provide a value',
+            fields: [field]
+          }}
+          onRespond={onRespond}
+        />
+      )
+    })
+
+    const continueButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Continue'
+    )
+    expect(continueButton?.disabled).toBe(true)
+    await act(async () => continueButton?.click())
+    expect(onRespond).not.toHaveBeenCalled()
+  })
+
   it('keeps non-question form fields on the generic submit path', async () => {
     const onRespond = vi.fn().mockResolvedValue(undefined)
     const genericFields = [

--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
@@ -851,7 +851,7 @@ describe('WorkspaceElicitationCard generic ACP form', () => {
       kind: 'text' as const,
       required: true,
       format: 'date-time' as const,
-      defaultValue: '2026-08-02T12:00:00Z'
+      defaultValue: '2026-08-02T12:00:00.123456Z'
     }
 
     await act(async () => {
@@ -878,7 +878,7 @@ describe('WorkspaceElicitationCard generic ACP form', () => {
     expect(onRespond).toHaveBeenCalledWith({
       requestId: 'generic-date-time-default',
       action: 'accept',
-      answers: [{ fieldId: 'scheduled-at', value: '2026-08-02T12:00:00Z' }]
+      answers: [{ fieldId: 'scheduled-at', value: '2026-08-02T12:00:00.123456Z' }]
     })
   })
 

--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
@@ -85,13 +85,27 @@ const valueForSubmission = (field: ElicitationField, value: ElicitationValue): E
     ? (normalizeLocalDateTime(value) ?? value)
     : value
 
+const valueForTextInput = (
+  field: ElicitationField,
+  value: ElicitationValue | undefined
+): string => {
+  if (typeof value !== 'string' || field.format !== 'date-time') {
+    return typeof value === 'string' ? value : ''
+  }
+  if (normalizeLocalDateTime(value) || !isValidElicitationValue(field, value)) return value
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  const pad = (part: number, width = 2): string => String(part).padStart(width, '0')
+  const milliseconds = date.getMilliseconds()
+  const fraction = milliseconds === 0 ? '' : `.${pad(milliseconds, 3)}`
+  return `${pad(date.getFullYear(), 4)}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}${fraction}`
+}
+
 const hasValidValue = (field: ElicitationField, value: ElicitationValue | undefined): boolean => {
   if (value === undefined) return !field.required
   if (field.required && typeof value === 'string' && value.trim().length === 0) return false
   if (field.required && Array.isArray(value) && value.length === 0) return false
-  if (field.format === 'date-time' && typeof value === 'string' && !normalizeLocalDateTime(value)) {
-    return false
-  }
   return isValidElicitationValue(field, valueForSubmission(field, value))
 }
 
@@ -847,7 +861,7 @@ const WorkspaceElicitationCard = ({
                         ? 'datetime-local'
                         : undefined
               const textProps = {
-                value: typeof value === 'string' ? value : '',
+                value: valueForTextInput(field, value),
                 disabled: isSubmitting,
                 required: field.required,
                 minLength: field.minLength,

--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
@@ -10,6 +10,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { cn } from '@/lib/utils'
 import {
   MAX_ELICITATION_MESSAGE_CHARS,
+  isValidElicitationValue,
   resolveAgentUserChoiceQuestions,
   type AgentUserChoiceQuestion,
   type ElicitationAnswer,
@@ -55,25 +56,43 @@ const initialValues = (
   return values
 }
 
+const normalizeLocalDateTime = (value: string): string | undefined => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?$/.exec(value)
+  if (!match) return undefined
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const hour = Number(match[4])
+  const minute = Number(match[5])
+  const second = Number(match[6] ?? 0)
+  const millisecond = Number((match[7] ?? '').padEnd(3, '0'))
+  const date = new Date(year, month - 1, day, hour, minute, second, millisecond)
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day ||
+    date.getHours() !== hour ||
+    date.getMinutes() !== minute ||
+    date.getSeconds() !== second
+  ) {
+    return undefined
+  }
+  return date.toISOString()
+}
+
+const valueForSubmission = (field: ElicitationField, value: ElicitationValue): ElicitationValue =>
+  field.format === 'date-time' && typeof value === 'string'
+    ? (normalizeLocalDateTime(value) ?? value)
+    : value
+
 const hasValidValue = (field: ElicitationField, value: ElicitationValue | undefined): boolean => {
   if (value === undefined) return !field.required
-  if (typeof value === 'string') {
-    if (field.required && value.trim().length === 0) return false
-    if (value.length > MAX_ELICITATION_MESSAGE_CHARS) return false
-    if (field.minLength !== undefined && value.length < field.minLength) return false
-    if (field.maxLength !== undefined && value.length > field.maxLength) return false
+  if (field.required && typeof value === 'string' && value.trim().length === 0) return false
+  if (field.required && Array.isArray(value) && value.length === 0) return false
+  if (field.format === 'date-time' && typeof value === 'string' && !normalizeLocalDateTime(value)) {
+    return false
   }
-  if (typeof value === 'number') {
-    if (field.kind === 'integer' && !Number.isInteger(value)) return false
-    if (field.minimum !== undefined && value < field.minimum) return false
-    if (field.maximum !== undefined && value > field.maximum) return false
-  }
-  if (Array.isArray(value)) {
-    if (field.required && value.length === 0) return false
-    if (field.minItems !== undefined && value.length < field.minItems) return false
-    if (field.maxItems !== undefined && value.length > field.maxItems) return false
-  }
-  return true
+  return isValidElicitationValue(field, valueForSubmission(field, value))
 }
 
 const submittedAnswers = (
@@ -84,13 +103,7 @@ const submittedAnswers = (
     const value = values[field.id]
     if (value === undefined || value === '' || (Array.isArray(value) && value.length === 0))
       return []
-    const submittedValue =
-      field.format === 'date-time' &&
-      typeof value === 'string' &&
-      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?$/.test(value)
-        ? new Date(value).toISOString()
-        : value
-    return [{ fieldId: field.id, value: submittedValue }]
+    return [{ fieldId: field.id, value: valueForSubmission(field, value) }]
   })
 
 type WorkspaceElicitationCardProps = {

--- a/src/shared/acp.ts
+++ b/src/shared/acp.ts
@@ -24,6 +24,7 @@ import type {
 
 export {
   isDurableAgentUserChoiceRequest,
+  isValidElicitationValue,
   MAX_ELICITATION_MESSAGE_CHARS,
   resolveAgentUserChoiceQuestions
 } from './elicitation'

--- a/src/shared/elicitation.ts
+++ b/src/shared/elicitation.ts
@@ -354,13 +354,18 @@ export const sanitizeElicitationField = (value: unknown): ElicitationField | und
   if (!id || !label || !kind || !ELICITATION_FIELD_KINDS.has(kind)) return undefined
 
   const description = cappedString(value.description, MAX_ELICITATION_MESSAGE_CHARS)
-  const options = Array.isArray(value.options) ? value.options.map(sanitizeOption) : undefined
   if (
     value.options !== undefined &&
-    (!options ||
-      options.length === 0 ||
-      options.length > MAX_ELICITATION_OPTIONS_PER_FIELD ||
-      options.some((option) => !option) ||
+    (!Array.isArray(value.options) ||
+      value.options.length === 0 ||
+      value.options.length > MAX_ELICITATION_OPTIONS_PER_FIELD)
+  ) {
+    return undefined
+  }
+  const options = Array.isArray(value.options) ? value.options.map(sanitizeOption) : undefined
+  if (
+    options &&
+    (options.some((option) => !option) ||
       new Set(options.map((option) => option!.value)).size !== options.length)
   ) {
     return undefined

--- a/src/shared/elicitation.ts
+++ b/src/shared/elicitation.ts
@@ -137,6 +137,72 @@ export const MAX_AGENT_USER_CHOICE_OPTIONS = 4
 export const MAX_AGENT_USER_CHOICE_QUESTIONS = 3
 export const MAX_AGENT_TURN_PROVENANCE_ANCESTRY = 256
 
+const isValidCalendarDate = (value: string): boolean => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (!match) return false
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const date = new Date(Date.UTC(year, month - 1, day))
+  return (
+    date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
+  )
+}
+
+const isValidFormattedString = (format: ElicitationField['format'], value: string): boolean => {
+  if (!format) return true
+  if (format === 'email') return /^[^\s@]+@[^\s@]+$/.test(value)
+  if (format === 'uri') {
+    try {
+      new URL(value)
+      return true
+    } catch {
+      return false
+    }
+  }
+  if (format === 'date') return isValidCalendarDate(value)
+
+  const match =
+    /^(\d{4}-\d{2}-\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?(?:Z|([+-])(\d{2}):(\d{2}))$/.exec(
+      value
+    )
+  if (!match || !isValidCalendarDate(match[1])) return false
+  const hour = Number(match[2])
+  const minute = Number(match[3])
+  const second = Number(match[4])
+  const offsetHour = match[6] === undefined ? 0 : Number(match[6])
+  const offsetMinute = match[7] === undefined ? 0 : Number(match[7])
+  return hour <= 23 && minute <= 59 && second <= 59 && offsetHour <= 23 && offsetMinute <= 59
+}
+
+export const isValidElicitationValue = (
+  field: ElicitationField,
+  value: unknown
+): value is ElicitationValue => {
+  if (field.kind === 'text' || field.kind === 'single-select') {
+    if (typeof value !== 'string') return false
+    if (value.length > MAX_ELICITATION_MESSAGE_CHARS) return false
+    if (field.minLength !== undefined && value.length < field.minLength) return false
+    if (field.maxLength !== undefined && value.length > field.maxLength) return false
+    if (field.options && !field.options.some((option) => option.value === value)) return false
+    return isValidFormattedString(field.format, value)
+  }
+  if (field.kind === 'number' || field.kind === 'integer') {
+    if (typeof value !== 'number' || !Number.isFinite(value)) return false
+    if (field.kind === 'integer' && !Number.isInteger(value)) return false
+    if (field.minimum !== undefined && value < field.minimum) return false
+    if (field.maximum !== undefined && value > field.maximum) return false
+    return true
+  }
+  if (field.kind === 'boolean') return typeof value === 'boolean'
+  if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) return false
+  if (value.length > MAX_ELICITATION_MULTI_SELECT_VALUES) return false
+  if (field.minItems !== undefined && value.length < field.minItems) return false
+  if (field.maxItems !== undefined && value.length > field.maxItems) return false
+  const allowed = new Set(field.options?.map((option) => option.value) ?? [])
+  return value.every((item) => allowed.has(item))
+}
+
 const resolveAgentUserChoiceQuestion = (
   choiceField: ElicitationField,
   customField: ElicitationField
@@ -200,6 +266,9 @@ const cappedDataString = (value: unknown, max: number): string | undefined => {
   return value.slice(0, max)
 }
 
+const boundedDataString = (value: unknown, max: number): string | undefined =>
+  typeof value === 'string' && value.trim() && value.length <= max ? value : undefined
+
 const boundedString = (value: unknown, max: number): string | undefined => {
   if (typeof value !== 'string') return undefined
   const text = value.trim()
@@ -261,7 +330,7 @@ export const sanitizeAgentUserChoiceRequest = (
 
 const sanitizeOption = (value: unknown): ElicitationOption | undefined => {
   if (!isRecord(value)) return undefined
-  const optionValue = cappedDataString(value.value, MAX_ELICITATION_LABEL_CHARS)
+  const optionValue = boundedDataString(value.value, MAX_ELICITATION_LABEL_CHARS)
   const label = cappedString(value.label, MAX_ELICITATION_LABEL_CHARS)
   if (!optionValue || !label) return undefined
 
@@ -269,20 +338,34 @@ const sanitizeOption = (value: unknown): ElicitationOption | undefined => {
   return { value: optionValue, label, ...(description ? { description } : {}) }
 }
 
-const sanitizeField = (value: unknown): ElicitationField | undefined => {
+const withSanitizedDefault = (
+  field: ElicitationField,
+  value: Record<string, unknown>
+): ElicitationField =>
+  value.defaultValue !== undefined && isValidElicitationValue(field, value.defaultValue)
+    ? { ...field, defaultValue: value.defaultValue }
+    : field
+
+export const sanitizeElicitationField = (value: unknown): ElicitationField | undefined => {
   if (!isRecord(value)) return undefined
-  const id = cappedDataString(value.id, MAX_ELICITATION_LABEL_CHARS)
+  const id = boundedDataString(value.id, MAX_ELICITATION_LABEL_CHARS)
   const label = cappedString(value.label, MAX_ELICITATION_LABEL_CHARS)
   const kind = value.kind as ElicitationField['kind'] | undefined
   if (!id || !label || !kind || !ELICITATION_FIELD_KINDS.has(kind)) return undefined
 
   const description = cappedString(value.description, MAX_ELICITATION_MESSAGE_CHARS)
-  const options = Array.isArray(value.options)
-    ? value.options
-        .slice(0, MAX_ELICITATION_OPTIONS_PER_FIELD)
-        .map(sanitizeOption)
-        .filter((option): option is ElicitationOption => !!option)
-    : undefined
+  const options = Array.isArray(value.options) ? value.options.map(sanitizeOption) : undefined
+  if (
+    value.options !== undefined &&
+    (!options ||
+      options.length === 0 ||
+      options.length > MAX_ELICITATION_OPTIONS_PER_FIELD ||
+      options.some((option) => !option) ||
+      new Set(options.map((option) => option!.value)).size !== options.length)
+  ) {
+    return undefined
+  }
+  const sanitizedOptions = options as ElicitationOption[] | undefined
   const format =
     value.format === 'email' ||
     value.format === 'uri' ||
@@ -290,6 +373,7 @@ const sanitizeField = (value: unknown): ElicitationField | undefined => {
     value.format === 'date-time'
       ? value.format
       : undefined
+  if (value.format !== undefined && !format) return undefined
   const finiteNumber = (candidate: unknown): number | undefined =>
     typeof candidate === 'number' && Number.isFinite(candidate) ? candidate : undefined
   const nonNegativeInteger = (candidate: unknown): number | undefined => {
@@ -302,24 +386,126 @@ const sanitizeField = (value: unknown): ElicitationField | undefined => {
   const maximum = finiteNumber(value.maximum)
   const minItems = nonNegativeInteger(value.minItems)
   const maxItems = nonNegativeInteger(value.maxItems)
-  const defaultValue = sanitizeAnswerValue(value.defaultValue)
+  if (
+    (value.minLength !== undefined && minLength === undefined) ||
+    (value.maxLength !== undefined && maxLength === undefined) ||
+    (value.minimum !== undefined && minimum === undefined) ||
+    (value.maximum !== undefined && maximum === undefined) ||
+    (value.minItems !== undefined && minItems === undefined) ||
+    (value.maxItems !== undefined && maxItems === undefined)
+  ) {
+    return undefined
+  }
 
-  return {
+  const common = {
     id,
     label,
-    kind,
     ...(description ? { description } : {}),
-    ...(value.required === true ? { required: true } : {}),
-    ...(options && options.length > 0 ? { options } : {}),
-    ...(format ? { format } : {}),
-    ...(minLength !== undefined ? { minLength } : {}),
-    ...(maxLength !== undefined ? { maxLength } : {}),
-    ...(minimum !== undefined ? { minimum } : {}),
-    ...(maximum !== undefined ? { maximum } : {}),
-    ...(minItems !== undefined ? { minItems } : {}),
-    ...(maxItems !== undefined ? { maxItems } : {}),
-    ...(defaultValue !== undefined ? { defaultValue } : {})
+    ...(value.required === true ? { required: true } : {})
   }
+  const hasNumericConstraints = minimum !== undefined || maximum !== undefined
+  const hasLengthConstraints = minLength !== undefined || maxLength !== undefined
+  const hasItemConstraints = minItems !== undefined || maxItems !== undefined
+
+  if (kind === 'text' || kind === 'single-select') {
+    if (
+      hasNumericConstraints ||
+      hasItemConstraints ||
+      (minLength !== undefined && minLength > MAX_ELICITATION_MESSAGE_CHARS) ||
+      (minLength !== undefined && maxLength !== undefined && minLength > maxLength) ||
+      (value.required === true && maxLength === 0) ||
+      (kind === 'text' && sanitizedOptions !== undefined) ||
+      (kind === 'single-select' && sanitizedOptions === undefined)
+    ) {
+      return undefined
+    }
+    const field: ElicitationField = {
+      ...common,
+      kind,
+      ...(sanitizedOptions ? { options: sanitizedOptions } : {}),
+      ...(format ? { format } : {}),
+      ...(minLength !== undefined ? { minLength } : {}),
+      ...(maxLength !== undefined ? { maxLength } : {})
+    }
+    if (
+      kind === 'single-select' &&
+      !sanitizedOptions!.every((option) => isValidElicitationValue(field, option.value))
+    ) {
+      return undefined
+    }
+    return withSanitizedDefault(field, value)
+  }
+
+  if (kind === 'number' || kind === 'integer') {
+    if (
+      sanitizedOptions !== undefined ||
+      format !== undefined ||
+      hasLengthConstraints ||
+      hasItemConstraints ||
+      (minimum !== undefined && maximum !== undefined && minimum > maximum) ||
+      (kind === 'integer' &&
+        minimum !== undefined &&
+        maximum !== undefined &&
+        Math.ceil(minimum) > Math.floor(maximum))
+    ) {
+      return undefined
+    }
+    const field: ElicitationField = {
+      ...common,
+      kind,
+      ...(minimum !== undefined ? { minimum } : {}),
+      ...(maximum !== undefined ? { maximum } : {})
+    }
+    return withSanitizedDefault(field, value)
+  }
+
+  if (kind === 'boolean') {
+    if (
+      sanitizedOptions !== undefined ||
+      format !== undefined ||
+      hasLengthConstraints ||
+      hasNumericConstraints ||
+      hasItemConstraints
+    ) {
+      return undefined
+    }
+    return withSanitizedDefault({ ...common, kind }, value)
+  }
+
+  if (
+    sanitizedOptions === undefined ||
+    format !== undefined ||
+    hasLengthConstraints ||
+    hasNumericConstraints ||
+    (minItems !== undefined && minItems > MAX_ELICITATION_MULTI_SELECT_VALUES) ||
+    (minItems !== undefined && maxItems !== undefined && minItems > maxItems) ||
+    (minItems !== undefined && minItems > sanitizedOptions.length) ||
+    (value.required === true && maxItems === 0)
+  ) {
+    return undefined
+  }
+  const field: ElicitationField = {
+    ...common,
+    kind: 'multi-select',
+    options: sanitizedOptions,
+    ...(minItems !== undefined ? { minItems } : {}),
+    ...(maxItems !== undefined ? { maxItems } : {})
+  }
+  return withSanitizedDefault(field, value)
+}
+
+const sanitizeFields = (value: unknown): ElicitationField[] | undefined => {
+  if (!Array.isArray(value) || value.length === 0 || value.length > MAX_ELICITATION_FIELDS) {
+    return undefined
+  }
+  const fields = value.map(sanitizeElicitationField)
+  if (
+    fields.some((field) => !field) ||
+    new Set(fields.map((field) => field!.id)).size !== fields.length
+  ) {
+    return undefined
+  }
+  return fields as ElicitationField[]
 }
 
 const sanitizeAnswerValue = (value: unknown): ElicitationValue | undefined => {
@@ -357,6 +543,7 @@ const sanitizeAgentTurnProvenanceContext = (
   if (!promptMessageId) return undefined
 
   const optionalIds = [
+    'originMessageId',
     'rootFrameId',
     'agentFrameId',
     'messageBranchId',
@@ -387,6 +574,7 @@ const sanitizeAgentTurnProvenanceContext = (
 
   return {
     promptMessageId,
+    ...(ids.originMessageId ? { originMessageId: ids.originMessageId } : {}),
     ...(ids.rootFrameId ? { rootFrameId: ids.rootFrameId } : {}),
     ...(ids.agentFrameId ? { agentFrameId: ids.agentFrameId } : {}),
     ...(ids.messageBranchId ? { messageBranchId: ids.messageBranchId } : {}),
@@ -429,18 +617,14 @@ export const sanitizePendingElicitationRequest = (
   const sessionId = boundedString(value.sessionId, MAX_ELICITATION_LABEL_CHARS)
   const toolCallId = boundedString(value.toolCallId, MAX_ELICITATION_LABEL_CHARS)
   const message = boundedString(value.message, MAX_ELICITATION_MESSAGE_CHARS)
-  const fields = value.fields
-    .slice(0, MAX_ELICITATION_FIELDS)
-    .map(sanitizeField)
-    .filter((field): field is ElicitationField => !!field)
+  const fields = sanitizeFields(value.fields)
   const durable = sanitizeDurableElicitation(value.durable)
   if (
     !requestId ||
     !sessionId ||
     !toolCallId ||
     !message ||
-    fields.length === 0 ||
-    fields.length !== value.fields.length ||
+    !fields ||
     (value.durable !== undefined && !durable) ||
     (durable && durable.requestId !== requestId)
   ) {
@@ -466,11 +650,8 @@ export const sanitizeElicitationProjection = (
     return undefined
   }
 
-  const fields = value.fields
-    .slice(0, MAX_ELICITATION_FIELDS)
-    .map(sanitizeField)
-    .filter((field): field is ElicitationField => !!field)
-  if (fields.length === 0) return undefined
+  const fields = sanitizeFields(value.fields)
+  if (!fields) return undefined
 
   const answers = Array.isArray(value.answers)
     ? value.answers

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -1523,6 +1523,99 @@ describe('sanitizeToolActivity', () => {
     })
   })
 
+  it.each([
+    [
+      'duplicate field identities',
+      [
+        { id: 'answer', label: 'First answer', kind: 'text' },
+        { id: 'answer', label: 'Second answer', kind: 'text' }
+      ]
+    ],
+    [
+      'contradictory field constraints',
+      [{ id: 'answer', label: 'Answer', kind: 'text', minLength: 2, maxLength: 1 }]
+    ]
+  ])('drops a persisted elicitation with %s', (_label, fields) => {
+    const activity = sanitizeToolActivity({
+      id: 'tool-invalid-elicitation',
+      status: 'in_progress',
+      elicitation: {
+        message: 'Provide an answer',
+        fields,
+        state: 'pending'
+      }
+    })
+
+    expect(activity).not.toHaveProperty('elicitation')
+  })
+
+  it('removes an invalid persisted default without discarding the elicitation', () => {
+    const activity = sanitizeToolActivity({
+      id: 'tool-invalid-default',
+      status: 'in_progress',
+      elicitation: {
+        message: 'Choose the number of attempts',
+        fields: [
+          {
+            id: 'attempts',
+            label: 'Attempts',
+            kind: 'integer',
+            minimum: 1,
+            maximum: 3,
+            defaultValue: '2'
+          }
+        ],
+        state: 'pending'
+      }
+    })
+
+    expect(activity?.elicitation?.fields).toEqual([
+      {
+        id: 'attempts',
+        label: 'Attempts',
+        kind: 'integer',
+        minimum: 1,
+        maximum: 3
+      }
+    ])
+  })
+
+  it('preserves the authorization origin in durable elicitation provenance', () => {
+    const activity = sanitizeToolActivity({
+      id: 'tool-durable-choice',
+      status: 'in_progress',
+      elicitation: {
+        message: 'Choose an approach',
+        fields: [
+          {
+            id: 'approach',
+            label: 'Approach',
+            kind: 'single-select',
+            options: [
+              { value: 'minimal', label: 'Minimal' },
+              { value: 'expanded', label: 'Expanded' }
+            ]
+          }
+        ],
+        state: 'pending',
+        durable: {
+          kind: 'agent-user-choice',
+          requestId: 'choice-1',
+          promptMessageId: 'synthetic-continuation',
+          provenanceContext: {
+            promptMessageId: 'synthetic-continuation',
+            originMessageId: 'authorizing-user-message'
+          }
+        }
+      }
+    })
+
+    expect(activity?.elicitation?.durable?.provenanceContext).toEqual({
+      promptMessageId: 'synthetic-continuation',
+      originMessageId: 'authorizing-user-message'
+    })
+  })
+
   it('keeps identity fields and known text/diff content', () => {
     const activity = sanitizeToolActivity({
       id: 'tool-1',

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { MAX_ACP_SESSION_IMAGE_BYTES } from './acp'
+import { MAX_ELICITATION_OPTIONS_PER_FIELD } from './elicitation'
 
 import {
   SESSION_FILE_VERSION,
@@ -1547,6 +1548,27 @@ describe('sanitizeToolActivity', () => {
     })
 
     expect(activity).not.toHaveProperty('elicitation')
+  })
+
+  it('rejects an oversized option list before reading its entries', () => {
+    const options = new Array(MAX_ELICITATION_OPTIONS_PER_FIELD + 1)
+    Object.defineProperty(options, 0, {
+      get: () => {
+        throw new Error('oversized options should be rejected before entry access')
+      }
+    })
+
+    expect(() =>
+      sanitizeToolActivity({
+        id: 'tool-oversized-options',
+        status: 'in_progress',
+        elicitation: {
+          message: 'Choose an option',
+          fields: [{ id: 'answer', label: 'Answer', kind: 'single-select', options }],
+          state: 'pending'
+        }
+      })
+    ).not.toThrow()
   })
 
   it('removes an invalid persisted default without discarding the elicitation', () => {


### PR DESCRIPTION
## Problem

Live ACP form normalization copied defaults after only shallow type checks, while the Renderer used
a looser submit predicate than Main. Invalid enum, integer, range, or formatted defaults could make
a form appear submittable before Main rejected the response.

Persisted elicitation projections also accepted duplicate field identities, contradictory
constraints, and kind-incompatible defaults. In addition,
`AgentTurnProvenanceContext.originMessageId` was declared and consumed downstream but dropped by the
durable projection sanitizer.

## Proposed change

- Share one field/value validation boundary across live request normalization, Main response
  validation, Renderer submit enablement, and persisted request restoration.
- Retain only schema-valid defaults; discard an invalid default without rejecting the otherwise
  usable form.
- Reject persisted elicitation payloads with duplicate identities, duplicate options,
  contradictory constraints, or incompatible field shapes.
- Reject oversized persisted option arrays before reading or sanitizing their entries.
- Preserve `originMessageId` when sanitizing durable elicitation provenance.
- Validate local `datetime-local` values before converting them to canonical ISO strings for Main,
  while displaying already-canonical RFC3339 values in the browser-compatible local input shape.

## Scope and non-goals

- No Prisma or database schema change, migration, IPC addition, or wire-format version.
- No new status or enum value.
- No new user-visible text, layout, or interaction flow.
- No provider-specific translation or subscription change. Claude Code, OpenCode, Codex Responses,
  and Codex bridge paths converge on the shared owner/persistence/Renderer boundaries changed here.

## Historical compatibility and persistence

- Historical invalid defaults are omitted while retaining the remaining form.
- Ambiguous or impossible elicitation payloads are omitted; their containing tool activity and
  Session remain readable.
- A pending durable response cannot be resumed from a duplicate or contradictory field model.
- Missing historical `originMessageId` remains valid because the field is optional. When present,
  it now survives Session JSON sanitization.

## Acceptance criteria and validation

Every regression was first run against the unfixed implementation and failed with the reported
symptom:

- invalid live defaults were present in all five normalized pending fields;
- wrong-kind, out-of-enum, and invalid-format presets all enabled Continue;
- an RFC3339 date-time default accepted by Main left Continue disabled and could not submit;
- an oversized persisted option array was traversed before its configured bound was enforced;
- duplicate IDs, contradictory constraints, and incompatible persisted defaults were accepted;
- `originMessageId` was absent after sanitization.

Final checks ran after the last material edit:

- live schema normalization, persisted sanitization/restore, provenance round trip, and Renderer
  submit state -> `vitest run` on the three focused files -> 174 passed;
- framework routing, online ACP form, app-owned choice, persisted choice restoration, and Agent Frame
  provenance -> focused consumer `vitest run` -> 7 passed, 569 skipped;
- linted source -> full `eslint .` without cache -> passed;
- Node/Web typechecks -> no branch-specific errors, but both remain locally blocked by the shared
  root dependency tree. The same commands on unchanged `main` produce the identical missing
  `waitForMcpServers` export and stale Prisma `sessionModelCallUsage` errors. PR CI is authoritative
  with a clean dependency install.

Per maintainer direction, the complete `npm test` suite was not run locally.

## Review focus

- Whether invalid defaults should remain repairable annotations while duplicate/contradictory field
  identity is rejected.
- Whether the shared value predicate remains aligned with Main's canonical response validation and
  the Renderer's local date-time conversion.
- Whether preserving the existing optional `originMessageId` closes the persistence drift without
  introducing a migration requirement.
