### PR TITLE
fix(net): validate downloads and link classification

### DIFF
--- a/src/main/net/network-info.test.ts
+++ b/src/main/net/network-info.test.ts
@@ -73,6 +73,36 @@ describe('parseHardwarePorts', () => {
 // The resolver shells out to networksetup, which only exists on macOS; the injected execFile
 // seam is exercised on darwin only.
 describe('createConnectionTypeResolver', () => {
+  it('keeps an active interface missing from the hardware-port table unknown', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    const execFile = vi.fn((_cmd, _args, _options, callback) => {
+      callback(null, HARDWARE_PORTS_OUTPUT, '')
+    })
+
+    try {
+      const resolve = createConnectionTypeResolver(execFile as never)
+      await expect(resolve({ utun3: [ipv4('10.8.0.2')] })).resolves.toBe('unknown')
+    } finally {
+      Object.defineProperty(process, 'platform', originalPlatform!)
+    }
+  })
+
+  it('keeps a known non-Wi-Fi and non-Ethernet hardware port unknown', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    const execFile = vi.fn((_cmd, _args, _options, callback) => {
+      callback(null, HARDWARE_PORTS_OUTPUT, '')
+    })
+
+    try {
+      const resolve = createConnectionTypeResolver(execFile as never)
+      await expect(resolve({ bridge0: [ipv4('10.0.0.3')] })).resolves.toBe('unknown')
+    } finally {
+      Object.defineProperty(process, 'platform', originalPlatform!)
+    }
+  })
+
   it.runIf(process.platform === 'darwin')('classifies a Wi-Fi hardware port as wifi', async () => {
     const execFile = vi.fn((_cmd, _args, _options, callback) => {
       callback(null, HARDWARE_PORTS_OUTPUT, '')
@@ -95,15 +125,15 @@ describe('createConnectionTypeResolver', () => {
   )
 
   it.runIf(process.platform === 'darwin')(
-    'falls back to ethernet when the port lookup fails and caches the attempt',
+    'keeps the type unknown when the port lookup fails and caches the attempt',
     async () => {
       const execFile = vi.fn((_cmd, _args, _options, callback) => {
         callback(new Error('not found'), '', '')
       })
       const resolve = createConnectionTypeResolver(execFile as never)
 
-      await expect(resolve({ en0: [ipv4('192.168.1.10')] })).resolves.toBe('ethernet')
-      await expect(resolve({ en0: [ipv4('192.168.1.10')] })).resolves.toBe('ethernet')
+      await expect(resolve({ en0: [ipv4('192.168.1.10')] })).resolves.toBe('unknown')
+      await expect(resolve({ en0: [ipv4('192.168.1.10')] })).resolves.toBe('unknown')
       expect(execFile).toHaveBeenCalledTimes(1)
     }
   )

--- a/src/main/net/network-info.test.ts
+++ b/src/main/net/network-info.test.ts
@@ -33,6 +33,8 @@ Hardware Port: Ethernet
 Device: en6
 Hardware Port: Thunderbolt Bridge
 Device: bridge0
+Hardware Port: USB 10/100/1000 LAN
+Device: en7
 `
 
 describe('selectActiveIpv4', () => {
@@ -63,6 +65,7 @@ describe('parseHardwarePorts', () => {
     expect(ports.get('en0')).toBe('Wi-Fi')
     expect(ports.get('en6')).toBe('Ethernet')
     expect(ports.get('bridge0')).toBe('Thunderbolt Bridge')
+    expect(ports.get('en7')).toBe('USB 10/100/1000 LAN')
   })
 
   it('returns an empty map for empty output', () => {
@@ -98,6 +101,21 @@ describe('createConnectionTypeResolver', () => {
     try {
       const resolve = createConnectionTypeResolver(execFile as never)
       await expect(resolve({ bridge0: [ipv4('10.0.0.3')] })).resolves.toBe('unknown')
+    } finally {
+      Object.defineProperty(process, 'platform', originalPlatform!)
+    }
+  })
+
+  it('classifies a mapped USB LAN hardware port as ethernet', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    const execFile = vi.fn((_cmd, _args, _options, callback) => {
+      callback(null, HARDWARE_PORTS_OUTPUT, '')
+    })
+
+    try {
+      const resolve = createConnectionTypeResolver(execFile as never)
+      await expect(resolve({ en7: [ipv4('10.0.0.4')] })).resolves.toBe('ethernet')
     } finally {
       Object.defineProperty(process, 'platform', originalPlatform!)
     }

--- a/src/main/net/network-info.ts
+++ b/src/main/net/network-info.ts
@@ -58,9 +58,10 @@ const parseHardwarePorts = (output: string): Map<string, string> => {
 }
 
 // macOS-only classification: the active IPv4 interface's device is looked up in the hardware
-// port map. A "Wi-Fi" port means wifi; any other active interface is assumed ethernet. The
+// port map. Only names explicitly identifying Wi-Fi or Ethernet are classified; other hardware
+// ports remain unknown. The
 // hardware port list is exec'd once and the promise cached. On other platforms (or when the
-// lookup fails) classification is unknown.
+// device is virtual/unmapped or the lookup fails) classification is unknown.
 const createConnectionTypeResolver = (
   execFileFn: typeof execFile = execFile
 ): ((interfaces: NetworkInterfaceMap) => Promise<NetworkConnectionType>) => {
@@ -93,8 +94,10 @@ const createConnectionTypeResolver = (
       if (!hasActiveIpv4) continue
 
       const portName = (await hardwarePorts()).get(name)
-      if (portName === undefined) return 'ethernet'
-      return portName.includes('Wi-Fi') ? 'wifi' : 'ethernet'
+      if (portName === undefined) return 'unknown'
+      if (portName.includes('Wi-Fi')) return 'wifi'
+      if (portName.includes('Ethernet')) return 'ethernet'
+      return 'unknown'
     }
     return 'unknown'
   }

--- a/src/main/net/network-info.ts
+++ b/src/main/net/network-info.ts
@@ -58,8 +58,8 @@ const parseHardwarePorts = (output: string): Map<string, string> => {
 }
 
 // macOS-only classification: the active IPv4 interface's device is looked up in the hardware
-// port map. Only names explicitly identifying Wi-Fi or Ethernet are classified; other hardware
-// ports remain unknown. The
+// port map. Only names explicitly identifying Wi-Fi or a wired Ethernet/LAN port are classified;
+// other hardware ports remain unknown. The
 // hardware port list is exec'd once and the promise cached. On other platforms (or when the
 // device is virtual/unmapped or the lookup fails) classification is unknown.
 const createConnectionTypeResolver = (
@@ -96,7 +96,7 @@ const createConnectionTypeResolver = (
       const portName = (await hardwarePorts()).get(name)
       if (portName === undefined) return 'unknown'
       if (portName.includes('Wi-Fi')) return 'wifi'
-      if (portName.includes('Ethernet')) return 'ethernet'
+      if (/\b(?:Ethernet|LAN)\b/i.test(portName)) return 'ethernet'
       return 'unknown'
     }
     return 'unknown'

--- a/src/main/net/resilient-download.test.ts
+++ b/src/main/net/resilient-download.test.ts
@@ -370,6 +370,39 @@ describe('resilientDownload', () => {
     expect(fs.files.get(OUT_PATH)?.equals(body)).toBe(true)
   })
 
+  it('surfaces an unresumable partial cleanup failure without retrying it', async () => {
+    const body = Buffer.from('abcdefghijklmnopqrstuvwxyz')
+    const fs = memFs()
+    const fetchImpl = fakeFetch(body, { cutAfter: 8, etag: null })
+    const sleep = vi.fn(async () => undefined)
+    const removePart = vi.fn()
+    const rmImpl = async (path: string): Promise<void> => {
+      if (path === `${OUT_PATH}.part`) {
+        removePart(path)
+        throw new Error('EACCES: cannot delete unresumable partial')
+      }
+      await fs.rmImpl(path)
+    }
+
+    await expect(
+      resilientDownload('https://cdn/file', OUT_PATH, {
+        expectedSize: body.length,
+        maxRetries: 2,
+        deps: {
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          ...fs,
+          rmImpl,
+          sleep,
+          now: () => 0
+        }
+      })
+    ).rejects.toThrow(/EACCES/)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(removePart).toHaveBeenCalledTimes(1)
+    expect(sleep).toHaveBeenCalledTimes(1)
+  })
+
   it('rejects a 206 whose Content-Range start differs from the local offset', async () => {
     const body = Buffer.from('abcdefghijklmnopqrstuvwxyz')
     const fs = memFs()

--- a/src/main/net/resilient-download.test.ts
+++ b/src/main/net/resilient-download.test.ts
@@ -297,6 +297,52 @@ describe('resilientDownload', () => {
     expect(fs.files.get(OUT_PATH)?.equals(body)).toBe(true)
   })
 
+  it('does not let orphaned validator metadata authorize a later partial', async () => {
+    const url = 'https://cdn/file'
+    const firstBody = Buffer.from('version-two-contents')
+    const laterBody = Buffer.from('version-one-contents')
+    const fs = memFs()
+    fs.files.set(
+      `${OUT_PATH}.part.meta`,
+      Buffer.from(
+        JSON.stringify({
+          version: 1,
+          urlSha256: sha(Buffer.from(url)),
+          validator: { kind: 'etag', value: '"version-one"' },
+          expectedSize: firstBody.length
+        })
+      )
+    )
+
+    await expect(
+      resilientDownload(url, OUT_PATH, {
+        expectedSize: firstBody.length,
+        maxRetries: 0,
+        deps: {
+          fetchImpl: fakeFetch(firstBody, { cutAfter: 8, etag: null }) as unknown as typeof fetch,
+          ...fs,
+          sleep: async () => {},
+          now: () => 0
+        }
+      })
+    ).rejects.toThrow(/short read/i)
+
+    const laterFetch = fakeFetch(laterBody, { etag: '"version-one"' })
+    await resilientDownload(url, OUT_PATH, {
+      expectedSize: laterBody.length,
+      deps: {
+        fetchImpl: laterFetch as unknown as typeof fetch,
+        ...fs,
+        sleep: async () => {},
+        now: () => 0
+      }
+    })
+
+    const retryInit = laterFetch.mock.calls[0][1] as { headers: Record<string, string> }
+    expect(retryInit.headers['Range']).toBeUndefined()
+    expect(fs.files.get(OUT_PATH)?.equals(laterBody)).toBe(true)
+  })
+
   it('restarts from zero rather than resuming without a usable validator', async () => {
     const body = Buffer.from('abcdefghijklmnopqrstuvwxyz')
     const fs = memFs()

--- a/src/main/net/resilient-download.test.ts
+++ b/src/main/net/resilient-download.test.ts
@@ -1,4 +1,6 @@
 import { createHash } from 'node:crypto'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough, Readable, Writable } from 'node:stream'
 import { describe, expect, it, vi, type MockedFunction } from 'vitest'
@@ -20,7 +22,15 @@ const sha = (buf: Buffer): string => createHash('sha256').update(buf).digest('he
 // (simulates a server that does not support Range requests).
 const fakeFetch = (
   body: Buffer,
-  opts: { cutAfter?: number; status?: number } = {}
+  opts: {
+    cutAfter?: number
+    status?: number
+    etag?: string | null
+    lastModified?: string
+    contentRangeStart?: number
+    contentRangeEnd?: number
+    contentRangeTotal?: number
+  } = {}
 ): MockedFunction<typeof fetch> =>
   vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
     const headers = (init?.headers ?? {}) as Record<string, string>
@@ -36,7 +46,18 @@ const fakeFetch = (
       ok: status < 400,
       status,
       headers: {
-        get: (h: string) => (h.toLowerCase() === 'content-length' ? String(slice.length) : null)
+        get: (h: string) => {
+          const name = h.toLowerCase()
+          if (name === 'content-length') return String(slice.length)
+          if (name === 'etag') return opts.etag === undefined ? '"file-v1"' : opts.etag
+          if (name === 'last-modified') return opts.lastModified ?? null
+          if (name === 'content-range' && status === 206) {
+            const responseStart = opts.contentRangeStart ?? start
+            const responseEnd = opts.contentRangeEnd ?? responseStart + slice.length - 1
+            return `bytes ${responseStart}-${responseEnd}/${opts.contentRangeTotal ?? body.length}`
+          }
+          return null
+        }
       },
       body: Readable.toWeb(stream)
     } as unknown as Response
@@ -50,6 +71,8 @@ const memFs = (): {
   rmImpl: (path: string) => Promise<void>
   renameImpl: (from: string, to: string) => Promise<void>
   openReadStreamImpl: (path: string) => import('node:fs').ReadStream
+  readTextImpl: (path: string) => Promise<string>
+  writeTextImpl: (path: string, text: string) => Promise<void>
 } => {
   const files = new Map<string, Buffer>()
   return {
@@ -73,7 +96,17 @@ const memFs = (): {
       files.delete(from)
     },
     openReadStreamImpl: (path: string) =>
-      Readable.from([files.get(path) ?? Buffer.alloc(0)]) as unknown as import('node:fs').ReadStream
+      Readable.from([
+        files.get(path) ?? Buffer.alloc(0)
+      ]) as unknown as import('node:fs').ReadStream,
+    readTextImpl: async (path: string) => {
+      const value = files.get(path)
+      if (!value) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      return value.toString('utf8')
+    },
+    writeTextImpl: async (path: string, text: string) => {
+      files.set(path, Buffer.from(text))
+    }
   }
 }
 
@@ -88,9 +121,65 @@ describe('resilientDownload', () => {
     expect(out).toBe(OUT_PATH)
     expect(fs.files.get(OUT_PATH)?.toString()).toBe('hello world payload')
     expect(fs.files.has(`${OUT_PATH}.part`)).toBe(false)
+    expect(fs.files.has(`${OUT_PATH}.part.meta`)).toBe(false)
   })
 
-  it('resumes with a Range request after a mid-stream cut', async () => {
+  it('rejects a response declared larger than expectedSize before writing', async () => {
+    const body = Buffer.from('too-large-payload')
+    const fs = memFs()
+
+    await expect(
+      resilientDownload('https://cdn/file', OUT_PATH, {
+        expectedSize: 4,
+        maxRetries: 0,
+        deps: {
+          fetchImpl: fakeFetch(body) as unknown as typeof fetch,
+          ...fs,
+          sleep: async () => {}
+        }
+      })
+    ).rejects.toThrow(/expected size/i)
+
+    expect(fs.files.has(`${OUT_PATH}.part`)).toBe(false)
+    expect(fs.files.has(OUT_PATH)).toBe(false)
+  })
+
+  it('does not write a body chunk that would exceed expectedSize', async () => {
+    const body = Buffer.from('too-large-payload')
+    const fs = memFs()
+    let written = 0
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      body: Readable.toWeb(Readable.from([body]))
+    }))
+    const createWriteStreamImpl = (): import('node:fs').WriteStream =>
+      new Writable({
+        write(chunk: Buffer, _encoding, callback) {
+          written += chunk.length
+          callback()
+        }
+      }) as unknown as import('node:fs').WriteStream
+
+    await expect(
+      resilientDownload('https://cdn/file', OUT_PATH, {
+        expectedSize: 4,
+        maxRetries: 0,
+        deps: {
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          ...fs,
+          createWriteStreamImpl,
+          sleep: async () => {}
+        }
+      })
+    ).rejects.toThrow(/expected size/i)
+
+    expect(written).toBe(0)
+    expect(fs.files.has(OUT_PATH)).toBe(false)
+  })
+
+  it('binds a Range retry to the first response ETag', async () => {
     const body = Buffer.from('abcdefghijklmnopqrstuvwxyz')
     const fs = memFs()
     // Count .part reads to prove the hoisted hash is not re-read from disk on the Range resume.
@@ -117,19 +206,258 @@ describe('resilientDownload', () => {
     expect(fs.files.get(OUT_PATH)?.toString()).toBe(body.toString())
     const secondInit = rest.mock.calls[0][1] as { headers: Record<string, string> }
     expect(secondInit.headers['Range']).toBe('bytes=10-')
+    expect(secondInit.headers['If-Range']).toBe('"file-v1"')
     // The 10 already-downloaded bytes stay in the hoisted hash — no .part re-read on resume.
     expect(openReadSpy).not.toHaveBeenCalled()
   })
 
-  it('restarts from zero when server ignores Range (200 on resume)', async () => {
+  it('falls back to Last-Modified when a strong ETag is unavailable', async () => {
+    const body = Buffer.from('abcdefghijklmnopqrstuvwxyz')
+    const fs = memFs()
+    const lastModified = 'Wed, 26 Aug 2026 07:00:00 GMT'
+    const first = fakeFetch(body, { cutAfter: 10, etag: null, lastModified })
+    const rest = fakeFetch(body, { etag: null, lastModified })
+    let call = 0
+    const fetchImpl = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      call++
+      return call === 1 ? first(input, init) : rest(input, init)
+    })
+
+    await resilientDownload('https://cdn/file', OUT_PATH, {
+      expectedSha256: sha(body),
+      deps: {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        ...fs,
+        sleep: async () => {},
+        now: () => 0
+      }
+    })
+
+    const secondInit = rest.mock.calls[0][1] as { headers: Record<string, string> }
+    expect(secondInit.headers['Range']).toBe('bytes=10-')
+    expect(secondInit.headers['If-Range']).toBe(lastModified)
+  })
+
+  it('retains the response validator for a later downloader call', async () => {
+    const body = Buffer.from('abcdefghijklmnopqrstuvwxyz')
+    const root = await mkdtemp(join(tmpdir(), 'resilient-download-'))
+    const outPath = join(root, 'out.bin')
+
+    try {
+      await expect(
+        resilientDownload('https://cdn/file', outPath, {
+          expectedSha256: sha(body),
+          expectedSize: body.length,
+          maxRetries: 0,
+          deps: {
+            fetchImpl: fakeFetch(body, { cutAfter: 10 }) as unknown as typeof fetch,
+            sleep: async () => {},
+            now: () => 0
+          }
+        })
+      ).rejects.toThrow(/short read/i)
+
+      const rest = fakeFetch(body)
+      await resilientDownload('https://cdn/file', outPath, {
+        expectedSha256: sha(body),
+        expectedSize: body.length,
+        deps: {
+          fetchImpl: rest as unknown as typeof fetch,
+          sleep: async () => {},
+          now: () => 0
+        }
+      })
+
+      const resumeInit = rest.mock.calls[0][1] as { headers: Record<string, string> }
+      expect(resumeInit.headers['Range']).toBe('bytes=10-')
+      expect(resumeInit.headers['If-Range']).toBe('"file-v1"')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('discards a historical partial that has no validator metadata', async () => {
     const body = Buffer.from('0123456789')
     const fs = memFs()
-    fs.files.set(`${OUT_PATH}.part`, Buffer.from('GARBAGE'))
-    const out = await resilientDownload('https://cdn/file', OUT_PATH, {
-      expectedSha256: sha(body),
-      deps: { fetchImpl: fakeFetch(body, { status: 200 }), ...fs, sleep: async () => {} }
+    fs.files.set(`${OUT_PATH}.part`, Buffer.from('STALE'))
+    const fetchImpl = fakeFetch(body)
+
+    await resilientDownload('https://cdn/file', OUT_PATH, {
+      expectedSize: body.length,
+      deps: {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        ...fs,
+        sleep: async () => {},
+        now: () => 0
+      }
     })
-    expect(fs.files.get(OUT_PATH)?.toString()).toBe('0123456789')
+
+    const init = fetchImpl.mock.calls[0][1] as { headers: Record<string, string> }
+    expect(init.headers['Range']).toBeUndefined()
+    expect(fs.files.get(OUT_PATH)?.equals(body)).toBe(true)
+  })
+
+  it('restarts from zero rather than resuming without a usable validator', async () => {
+    const body = Buffer.from('abcdefghijklmnopqrstuvwxyz')
+    const fs = memFs()
+    const first = fakeFetch(body, { cutAfter: 10, etag: 'W/"file-v1"' })
+    const rest = fakeFetch(body, { etag: 'W/"file-v1"' })
+    let call = 0
+    const fetchImpl = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      call++
+      return call === 1 ? first(input, init) : rest(input, init)
+    })
+
+    await resilientDownload('https://cdn/file', OUT_PATH, {
+      expectedSha256: sha(body),
+      deps: {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        ...fs,
+        sleep: async () => {},
+        now: () => 0
+      }
+    })
+
+    const retryInit = rest.mock.calls[0][1] as { headers: Record<string, string> }
+    expect(retryInit.headers['Range']).toBeUndefined()
+    expect(retryInit.headers['If-Range']).toBeUndefined()
+    expect(fs.files.get(OUT_PATH)?.equals(body)).toBe(true)
+  })
+
+  it('rejects a 206 whose Content-Range start differs from the local offset', async () => {
+    const body = Buffer.from('abcdefghijklmnopqrstuvwxyz')
+    const fs = memFs()
+    const first = fakeFetch(body, { cutAfter: 10 })
+    const invalidResume = fakeFetch(body, { contentRangeStart: 0 })
+    let call = 0
+    const fetchImpl = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      call++
+      return call === 1 ? first(input, init) : invalidResume(input, init)
+    })
+
+    await expect(
+      resilientDownload('https://cdn/file', OUT_PATH, {
+        expectedSha256: sha(body),
+        expectedSize: body.length,
+        deps: {
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          ...fs,
+          sleep: async () => {},
+          now: () => 0
+        }
+      })
+    ).rejects.toThrow(/Content-Range/i)
+
+    expect(fs.files.has(OUT_PATH)).toBe(false)
+  })
+
+  it('rejects a Content-Range total larger than expectedSize', async () => {
+    const body = Buffer.from('abcdefghijklmnopqrstuvwxyz')
+    const fs = memFs()
+    const first = fakeFetch(body, { cutAfter: 10 })
+    const oversizedRange = fakeFetch(body, { contentRangeTotal: 100 })
+    let call = 0
+    const fetchImpl = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      call++
+      return call === 1 ? first(input, init) : oversizedRange(input, init)
+    })
+
+    await expect(
+      resilientDownload('https://cdn/file', OUT_PATH, {
+        expectedSha256: sha(body),
+        expectedSize: body.length,
+        deps: {
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          ...fs,
+          sleep: async () => {},
+          now: () => 0
+        }
+      })
+    ).rejects.toThrow(/Content-Range|expected size/i)
+
+    expect(fs.files.has(OUT_PATH)).toBe(false)
+  })
+
+  it('rejects a Content-Range length inconsistent with Content-Length', async () => {
+    const body = Buffer.from('abcdefghijklmnopqrstuvwxyz')
+    const fs = memFs()
+    const first = fakeFetch(body, { cutAfter: 10 })
+    const inconsistentRange = fakeFetch(body, { contentRangeEnd: 20 })
+    let call = 0
+    const fetchImpl = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      call++
+      return call === 1 ? first(input, init) : inconsistentRange(input, init)
+    })
+
+    await expect(
+      resilientDownload('https://cdn/file', OUT_PATH, {
+        expectedSha256: sha(body),
+        expectedSize: body.length,
+        deps: {
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          ...fs,
+          sleep: async () => {},
+          now: () => 0
+        }
+      })
+    ).rejects.toThrow(/Content-Range|Content-Length/i)
+
+    expect(fs.files.has(OUT_PATH)).toBe(false)
+  })
+
+  it('rejects a 206 carrying a different ETag than the bound partial', async () => {
+    const firstBody = Buffer.from('0123456789abcdefghij')
+    const changedBody = Buffer.from('ABCDEFGHIJ0123456789')
+    const fs = memFs()
+    const first = fakeFetch(firstBody, { cutAfter: 10, etag: '"file-v1"' })
+    const changedResume = fakeFetch(changedBody, { etag: '"file-v2"' })
+    let call = 0
+    const fetchImpl = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      call++
+      return call === 1 ? first(input, init) : changedResume(input, init)
+    })
+
+    await expect(
+      resilientDownload('https://cdn/file', OUT_PATH, {
+        expectedSize: firstBody.length,
+        deps: {
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+          ...fs,
+          sleep: async () => {},
+          now: () => 0
+        }
+      })
+    ).rejects.toThrow(/validator|ETag/i)
+
+    expect(fs.files.has(OUT_PATH)).toBe(false)
+  })
+
+  it('restarts from zero when If-Range detects a changed representation', async () => {
+    const firstBody = Buffer.from('0123456789')
+    const currentBody = Buffer.from('abcdefghij')
+    const fs = memFs()
+    const first = fakeFetch(firstBody, { cutAfter: 4, etag: '"file-v1"' })
+    const changed = fakeFetch(currentBody, { status: 200, etag: '"file-v2"' })
+    let call = 0
+    const fetchImpl = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      call++
+      return call === 1 ? first(input, init) : changed(input, init)
+    })
+
+    const out = await resilientDownload('https://cdn/file', OUT_PATH, {
+      expectedSize: currentBody.length,
+      deps: {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        ...fs,
+        sleep: async () => {},
+        now: () => 0
+      }
+    })
+
+    const retryInit = changed.mock.calls[0][1] as { headers: Record<string, string> }
+    expect(retryInit.headers['Range']).toBe('bytes=4-')
+    expect(retryInit.headers['If-Range']).toBe('"file-v1"')
+    expect(fs.files.get(OUT_PATH)?.equals(currentBody)).toBe(true)
     expect(out).toBe(OUT_PATH)
   })
 

--- a/src/main/net/resilient-download.test.ts
+++ b/src/main/net/resilient-download.test.ts
@@ -276,6 +276,39 @@ describe('resilientDownload', () => {
     }
   })
 
+  it('does not follow a pre-existing symlink when persisting validator metadata', async () => {
+    const body = Buffer.from('abcdefghijklmnopqrstuvwxyz')
+    const fs = memFs()
+    const metadataPath = `${OUT_PATH}.part.meta`
+    const symlinkTarget = join('downloads', 'do-not-overwrite.txt')
+    fs.files.set(symlinkTarget, Buffer.from('keep-me'))
+    const writeTextImpl = async (path: string, text: string): Promise<void> => {
+      // Model writeFile following a symlink at the final sidecar path. Renaming a new file over that
+      // path replaces the link itself and therefore uses the regular memFs implementation instead.
+      if (path === metadataPath) {
+        fs.files.set(symlinkTarget, Buffer.from(text))
+        return
+      }
+      await fs.writeTextImpl(path, text)
+    }
+
+    await expect(
+      resilientDownload('https://cdn/file', OUT_PATH, {
+        expectedSize: body.length,
+        maxRetries: 0,
+        deps: {
+          fetchImpl: fakeFetch(body, { cutAfter: 8 }) as unknown as typeof fetch,
+          ...fs,
+          writeTextImpl,
+          sleep: async () => {},
+          now: () => 0
+        }
+      })
+    ).rejects.toThrow(/short read/i)
+
+    expect(fs.files.get(symlinkTarget)?.toString()).toBe('keep-me')
+  })
+
   it('discards a historical partial that has no validator metadata', async () => {
     const body = Buffer.from('0123456789')
     const fs = memFs()

--- a/src/main/net/resilient-download.ts
+++ b/src/main/net/resilient-download.ts
@@ -173,6 +173,13 @@ export const resilientDownload = async (
       return 0
     }
   }
+  const removeForSafety = async (path: string): Promise<void> => {
+    try {
+      await removeFile(path)
+    } catch (error) {
+      throw markTerminal(error)
+    }
+  }
 
   // Re-feed the existing .part into the hash so a resumed download's digest covers the whole file.
   const seedHash = async (hash: ReturnType<typeof createHash>, bytes: number): Promise<void> => {
@@ -222,14 +229,14 @@ export const resilientDownload = async (
       ) {
         resumeValidator = metadata.validator
       } else {
-        await removeFile(partPath)
-        await removeFile(metadataPath).catch(() => undefined)
+        await removeForSafety(partPath)
+        await removeForSafety(metadataPath)
         initial = 0
       }
     } else {
       // A sidecar without its .part cannot describe any resumable bytes. Remove it now so a later
       // validator-less interrupted response cannot accidentally inherit the stale validator.
-      await removeFile(metadataPath).catch(() => undefined)
+      await removeForSafety(metadataPath)
     }
     await seedHash(hash, initial)
     hashSeededTo = initial
@@ -282,8 +289,8 @@ export const resilientDownload = async (
         // A same-process retry is not proof that the remote representation stayed unchanged. Without
         // a strong ETag or Last-Modified value there is no valid If-Range precondition, so retaining
         // these bytes would recreate the blind cross-version splice this helper is meant to prevent.
-        await removeFile(partPath)
-        await removeFile(metadataPath).catch(() => undefined)
+        await removeForSafety(partPath)
+        await removeForSafety(metadataPath)
         offset = 0
         hash = createHash('sha256')
         hashSeededTo = 0
@@ -351,8 +358,8 @@ export const resilientDownload = async (
       // Server returned 200 while we had a partial — it ignored Range, so discard and restart.
       const resuming = res.status === 206 && offset > 0
       if (!resuming && offset > 0) {
-        await removeFile(partPath)
-        await removeFile(metadataPath).catch(() => undefined)
+        await removeForSafety(partPath)
+        await removeForSafety(metadataPath)
         offset = 0
         // Reset the hoisted hash since we are restarting from byte 0.
         hash = createHash('sha256')

--- a/src/main/net/resilient-download.ts
+++ b/src/main/net/resilient-download.ts
@@ -275,6 +275,9 @@ export const resilientDownload = async (
     try {
       let offset = await partSize()
       if (offset > 0 && !resumeValidator) {
+        // A same-process retry is not proof that the remote representation stayed unchanged. Without
+        // a strong ETag or Last-Modified value there is no valid If-Range precondition, so retaining
+        // these bytes would recreate the blind cross-version splice this helper is meant to prevent.
         await removeFile(partPath)
         await removeFile(metadataPath).catch(() => undefined)
         offset = 0

--- a/src/main/net/resilient-download.ts
+++ b/src/main/net/resilient-download.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { createReadStream, createWriteStream, type WriteStream } from 'node:fs'
-import { rename, rm, stat } from 'node:fs/promises'
+import { readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { Readable } from 'node:stream'
 import type { ReadableStream as NodeReadableStream } from 'node:stream/web'
 
@@ -21,16 +21,17 @@ export type ResilientDownloadDeps = {
   rmImpl?: (path: string) => Promise<void>
   renameImpl?: (from: string, to: string) => Promise<void>
   openReadStreamImpl?: (path: string) => NodeJS.ReadableStream
+  readTextImpl?: (path: string) => Promise<string>
+  writeTextImpl?: (path: string, text: string) => Promise<void>
   sleep?: (ms: number) => Promise<void>
   now?: () => number
 }
 
 export type ResilientDownloadOpts = {
   expectedSha256?: string
-  // Expected total byte size, normally from a manifest. Short-read detection (retry a stream that
-  // closes early) needs a known total: it comes from the response Content-Length OR this field. If
-  // both are absent, a silently truncated stream is accepted without retry — callers that may hit a
-  // server or CDN redirect that strips Content-Length should always supply this from their manifest.
+  // Exact byte size, normally from a manifest. It is both the short-read target and a hard write
+  // ceiling, including response metadata and each streamed chunk. If this and Content-Length are
+  // absent, a silently truncated stream cannot be distinguished from a complete unknown-size body.
   expectedSize?: number
   maxRetries?: number
   stallTimeoutMs?: number
@@ -47,6 +48,29 @@ const MAX_BACKOFF_MS = 30_000
 // Signals that a server closed the stream before delivering all expected bytes (short read).
 class IncompleteStreamError extends Error {}
 
+// The response cannot belong to the expected representation (oversized metadata/body or an invalid
+// resume range). It is terminal for this invocation, and the untrusted partial is removed after its
+// write handle has been closed.
+class DownloadResponseIntegrityError extends Error {}
+
+type ResumeValidator = {
+  kind: 'etag' | 'last-modified'
+  value: string
+}
+
+type ResumeMetadata = {
+  version: 1
+  urlSha256: string
+  validator: ResumeValidator
+  expectedSize?: number
+}
+
+type ContentRange = {
+  start: number
+  end: number
+  total?: number
+}
+
 // Marks an error terminal so the retry loop rethrows instead of retrying. Local filesystem faults
 // (open/write/end failing with ENOSPC, EIO, EACCES, …) and rename failures are not transient network
 // problems — re-downloading will not fix a full or unwritable disk, and after a partial write the
@@ -58,6 +82,67 @@ const markTerminal = <E>(error: E): E => {
 
 const isAbortError = (e: unknown): boolean =>
   e instanceof Error && (e.name === 'AbortError' || e.name === 'TimeoutError')
+
+const strongEtag = (headers: Headers): ResumeValidator | undefined => {
+  const etag = headers.get('etag')?.trim()
+  return etag && !etag.toLowerCase().startsWith('w/') ? { kind: 'etag', value: etag } : undefined
+}
+
+const resumeValidatorFrom = (headers: Headers): ResumeValidator | undefined => {
+  const etag = strongEtag(headers)
+  if (etag) return etag
+  const lastModified = headers.get('last-modified')?.trim()
+  return lastModified ? { kind: 'last-modified', value: lastModified } : undefined
+}
+
+const parseResumeMetadata = (text: string): ResumeMetadata | undefined => {
+  try {
+    const value = JSON.parse(text) as Partial<ResumeMetadata>
+    const validator = value.validator
+    if (
+      value.version !== 1 ||
+      typeof value.urlSha256 !== 'string' ||
+      !/^[a-f0-9]{64}$/.test(value.urlSha256) ||
+      !validator ||
+      (validator.kind !== 'etag' && validator.kind !== 'last-modified') ||
+      typeof validator.value !== 'string' ||
+      validator.value.length === 0 ||
+      (value.expectedSize !== undefined &&
+        (!Number.isSafeInteger(value.expectedSize) || value.expectedSize < 0))
+    ) {
+      return undefined
+    }
+    return value as ResumeMetadata
+  } catch {
+    return undefined
+  }
+}
+
+const parseContentRange = (value: string | null): ContentRange | undefined => {
+  const match = /^bytes (\d+)-(\d+)\/(\d+|\*)$/i.exec(value?.trim() ?? '')
+  if (!match) return undefined
+  const start = Number(match[1])
+  const end = Number(match[2])
+  const total = match[3] === '*' ? undefined : Number(match[3])
+  if (
+    !Number.isSafeInteger(start) ||
+    !Number.isSafeInteger(end) ||
+    start < 0 ||
+    end < start ||
+    (total !== undefined && (!Number.isSafeInteger(total) || total <= end))
+  ) {
+    return undefined
+  }
+  return { start, end, ...(total === undefined ? {} : { total }) }
+}
+
+const parseContentLength = (value: string | null): number | undefined => {
+  if (value === null) return undefined
+  const normalized = value.trim()
+  if (!/^\d+$/.test(normalized)) return undefined
+  const length = Number(normalized)
+  return Number.isSafeInteger(length) ? length : undefined
+}
 
 export const resilientDownload = async (
   url: string,
@@ -71,11 +156,15 @@ export const resilientDownload = async (
   const removeFile = d.rmImpl ?? ((p) => rm(p, { force: true }))
   const renameFile = d.renameImpl ?? rename
   const openRead = d.openReadStreamImpl ?? ((p) => createReadStream(p))
+  const readText = d.readTextImpl ?? ((p) => readFile(p, 'utf8'))
+  const writeText = d.writeTextImpl ?? ((p, text) => writeFile(p, text, 'utf8'))
   const sleep = d.sleep ?? ((ms) => new Promise<void>((r) => setTimeout(r, ms)))
   const now = d.now ?? (() => Date.now())
   const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES
   const stallMs = opts.stallTimeoutMs ?? DEFAULT_STALL_MS
   const partPath = `${destPath}.part`
+  const metadataPath = `${partPath}.meta`
+  const urlSha256 = createHash('sha256').update(url).digest('hex')
 
   const partSize = async (): Promise<number> => {
     try {
@@ -118,11 +207,26 @@ export const resilientDownload = async (
   // reconcile when the .part is behind the hash (partial OS flush after destroy).
   let hash = createHash('sha256')
   let hashSeededTo = 0
+  let resumeValidator: ResumeValidator | undefined
 
-  // Seed from any .part that already exists before the first attempt (e.g. a manual retry after the
-  // app was restarted; within a session this is usually 0 and is a no-op).
+  // Seed a partial retained by an earlier call only when its sidecar binds it to this exact request.
+  // Current callers scope target paths to one app session, but the helper itself does not assume that.
   {
-    const initial = await partSize()
+    let initial = await partSize()
+    if (initial > 0) {
+      const metadata = await readText(metadataPath).then(parseResumeMetadata, () => undefined)
+      if (
+        metadata?.urlSha256 === urlSha256 &&
+        metadata.expectedSize === opts.expectedSize &&
+        (opts.expectedSize == null || initial <= opts.expectedSize)
+      ) {
+        resumeValidator = metadata.validator
+      } else {
+        await removeFile(partPath)
+        await removeFile(metadataPath).catch(() => undefined)
+        initial = 0
+      }
+    }
     await seedHash(hash, initial)
     hashSeededTo = initial
   }
@@ -170,8 +274,19 @@ export const resilientDownload = async (
 
     try {
       let offset = await partSize()
+      if (offset > 0 && !resumeValidator) {
+        await removeFile(partPath)
+        await removeFile(metadataPath).catch(() => undefined)
+        offset = 0
+        hash = createHash('sha256')
+        hashSeededTo = 0
+      }
       const headers: Record<string, string> = {}
-      if (offset > 0) headers['Range'] = `bytes=${offset}-`
+      if (offset > 0) {
+        headers['Range'] = `bytes=${offset}-`
+        if (resumeValidator) headers['If-Range'] = resumeValidator.value
+      }
+      const requestedValidator = offset > 0 ? resumeValidator : undefined
 
       armStall()
       const res = await fetchImpl(url, { headers, signal: combined })
@@ -188,10 +303,49 @@ export const resilientDownload = async (
       }
       if (!res.body) throw new Error('response had no body')
 
+      const responseValidator = resumeValidatorFrom(res.headers)
+      const contentLengthHeader = res.headers.get('content-length')
+      const contentLength = parseContentLength(contentLengthHeader)
+      if (contentLengthHeader !== null && contentLength === undefined) {
+        throw new DownloadResponseIntegrityError('invalid Content-Length')
+      }
+      const contentRange =
+        res.status === 206 ? parseContentRange(res.headers.get('content-range')) : undefined
+      if (res.status === 206) {
+        if (!contentRange || contentRange.start !== offset) {
+          throw new DownloadResponseIntegrityError(`invalid Content-Range for offset ${offset}`)
+        }
+        if (
+          opts.expectedSize != null &&
+          (contentRange.end >= opts.expectedSize ||
+            (contentRange.total != null && contentRange.total > opts.expectedSize))
+        ) {
+          throw new DownloadResponseIntegrityError(
+            `Content-Range exceeds expected size ${opts.expectedSize}`
+          )
+        }
+        if (contentLength != null && contentRange.end - contentRange.start + 1 !== contentLength) {
+          throw new DownloadResponseIntegrityError(
+            'Content-Range length does not match Content-Length'
+          )
+        }
+        if (requestedValidator) {
+          const responseValue = res.headers
+            .get(requestedValidator.kind === 'etag' ? 'etag' : 'last-modified')
+            ?.trim()
+          if (responseValue && responseValue !== requestedValidator.value) {
+            throw new DownloadResponseIntegrityError(
+              `206 response validator does not match ${requestedValidator.kind}`
+            )
+          }
+        }
+      }
+
       // Server returned 200 while we had a partial — it ignored Range, so discard and restart.
       const resuming = res.status === 206 && offset > 0
       if (!resuming && offset > 0) {
         await removeFile(partPath)
+        await removeFile(metadataPath).catch(() => undefined)
         offset = 0
         // Reset the hoisted hash since we are restarting from byte 0.
         hash = createHash('sha256')
@@ -209,8 +363,32 @@ export const resilientDownload = async (
       }
       // else: hash already covers [0, offset) — no I/O needed.
 
-      const rawContentLength = Number(res.headers.get('content-length'))
-      const total = rawContentLength > 0 ? offset + rawContentLength : opts.expectedSize
+      if (!resuming) resumeValidator = responseValidator
+      if (resumeValidator) {
+        const metadata: ResumeMetadata = {
+          version: 1,
+          urlSha256,
+          validator: resumeValidator,
+          ...(opts.expectedSize === undefined ? {} : { expectedSize: opts.expectedSize })
+        }
+        try {
+          await writeText(metadataPath, `${JSON.stringify(metadata)}\n`)
+        } catch (metadataError) {
+          throw markTerminal(metadataError)
+        }
+      }
+
+      if (
+        opts.expectedSize != null &&
+        contentLength != null &&
+        offset + contentLength > opts.expectedSize
+      ) {
+        throw new DownloadResponseIntegrityError(
+          `response exceeds expected size (${offset + contentLength} > ${opts.expectedSize})`
+        )
+      }
+      const total =
+        opts.expectedSize ?? (contentLength == null ? undefined : offset + contentLength)
       const meter = new SpeedMeter({ now })
       let transferred = offset
       meter.record(transferred)
@@ -231,6 +409,11 @@ export const resilientDownload = async (
       for await (const chunk of nodeStream) {
         if (fileError) throw fileError
         const buf = Buffer.from(chunk as Uint8Array)
+        if (opts.expectedSize != null && transferred + buf.length > opts.expectedSize) {
+          throw new DownloadResponseIntegrityError(
+            `response exceeds expected size (${transferred + buf.length} > ${opts.expectedSize})`
+          )
+        }
         // Update the hash only AFTER the write is confirmed. If the write callback rejects, the hash
         // must NOT have consumed these bytes — otherwise it runs ahead of the persisted .part and,
         // when the next attempt resumes at the same offset (no re-seed), the digest is corrupted.
@@ -274,6 +457,7 @@ export const resilientDownload = async (
         // swallow that error rather than let it escape — otherwise the loop would retry with a dead
         // hash. A leftover .part is harmless (the next run re-checks or overwrites it).
         await removeFile(partPath).catch(() => undefined)
+        await removeFile(metadataPath).catch(() => undefined)
         throw new DownloadChecksumError()
       }
 
@@ -285,6 +469,7 @@ export const resilientDownload = async (
       } catch (renameError) {
         throw markTerminal(renameError)
       }
+      await removeFile(metadataPath).catch(() => undefined)
       opts.onProgress?.({
         phase: 'downloading',
         transferred,
@@ -313,7 +498,15 @@ export const resilientDownload = async (
       }
       // Terminal errors: never retry.
       if (error instanceof DownloadChecksumError) throw error
-      if ((error as { terminal?: boolean }).terminal) throw error
+      if (error instanceof DownloadResponseIntegrityError) {
+        await removeFile(partPath).catch(() => undefined)
+        await removeFile(metadataPath).catch(() => undefined)
+        throw error
+      }
+      if ((error as { terminal?: boolean }).terminal) {
+        await removeFile(metadataPath).catch(() => undefined)
+        throw error
+      }
       if (opts.signal?.aborted) throw opts.signal.reason ?? error
       if (isAbortError(error) && !controller.signal.aborted) throw error
       lastError = error

--- a/src/main/net/resilient-download.ts
+++ b/src/main/net/resilient-download.ts
@@ -226,6 +226,10 @@ export const resilientDownload = async (
         await removeFile(metadataPath).catch(() => undefined)
         initial = 0
       }
+    } else {
+      // A sidecar without its .part cannot describe any resumable bytes. Remove it now so a later
+      // validator-less interrupted response cannot accidentally inherit the stale validator.
+      await removeFile(metadataPath).catch(() => undefined)
     }
     await seedHash(hash, initial)
     hashSeededTo = initial

--- a/src/main/net/resilient-download.ts
+++ b/src/main/net/resilient-download.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import { createReadStream, createWriteStream, type WriteStream } from 'node:fs'
 import { readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { Readable } from 'node:stream'
@@ -22,7 +22,7 @@ export type ResilientDownloadDeps = {
   renameImpl?: (from: string, to: string) => Promise<void>
   openReadStreamImpl?: (path: string) => NodeJS.ReadableStream
   readTextImpl?: (path: string) => Promise<string>
-  writeTextImpl?: (path: string, text: string) => Promise<void>
+  writeTextImpl?: (path: string, text: string, opts?: { flag?: string }) => Promise<void>
   sleep?: (ms: number) => Promise<void>
   now?: () => number
 }
@@ -157,7 +157,9 @@ export const resilientDownload = async (
   const renameFile = d.renameImpl ?? rename
   const openRead = d.openReadStreamImpl ?? ((p) => createReadStream(p))
   const readText = d.readTextImpl ?? ((p) => readFile(p, 'utf8'))
-  const writeText = d.writeTextImpl ?? ((p, text) => writeFile(p, text, 'utf8'))
+  const writeText =
+    d.writeTextImpl ??
+    ((p, text, writeOpts) => writeFile(p, text, { encoding: 'utf8', flag: writeOpts?.flag ?? 'w' }))
   const sleep = d.sleep ?? ((ms) => new Promise<void>((r) => setTimeout(r, ms)))
   const now = d.now ?? (() => Date.now())
   const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES
@@ -178,6 +180,18 @@ export const resilientDownload = async (
       await removeFile(path)
     } catch (error) {
       throw markTerminal(error)
+    }
+  }
+  const writeMetadataAtomically = async (text: string): Promise<void> => {
+    const tempPath = `${metadataPath}.${randomUUID()}.tmp`
+    try {
+      // `wx` refuses a pre-existing temp path (including a symlink). Renaming the completed regular
+      // file over metadataPath replaces that directory entry instead of following a symlink there.
+      await writeText(tempPath, text, { flag: 'wx' })
+      await renameFile(tempPath, metadataPath)
+    } catch (error) {
+      await removeFile(tempPath).catch(() => undefined)
+      throw error
     }
   }
 
@@ -386,7 +400,7 @@ export const resilientDownload = async (
           ...(opts.expectedSize === undefined ? {} : { expectedSize: opts.expectedSize })
         }
         try {
-          await writeText(metadataPath, `${JSON.stringify(metadata)}\n`)
+          await writeMetadataAtomically(`${JSON.stringify(metadata)}\n`)
         } catch (metadataError) {
           throw markTerminal(metadataError)
         }

--- a/src/main/update/downloader.ts
+++ b/src/main/update/downloader.ts
@@ -8,8 +8,8 @@ export { DownloadChecksumError } from '../net/resilient-download'
 export type DownloadDeps = {
   fetchImpl?: typeof fetch
   onProgress?: (progress: DownloadProgress) => void
-  // Aborts the request/stream when signalled; the partial file is kept for an in-session resume (a
-  // fresh session drops it first — see UpdateService.freshTargets — so a restart starts from scratch).
+  // Aborts the request/stream when signalled. A partial is resumable only when the response supplied
+  // a strong ETag or Last-Modified validator; otherwise the next attempt safely restarts from zero.
   signal?: AbortSignal
 }
 

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -316,6 +316,7 @@ describe('UpdateService.download', () => {
     expect(promptSavePath).not.toHaveBeenCalled()
     expect(removeFile).toHaveBeenNthCalledWith(1, target)
     expect(removeFile).toHaveBeenNthCalledWith(2, `${target}.part`)
+    expect(removeFile).toHaveBeenNthCalledWith(3, `${target}.part.meta`)
     expect(broadcast).toHaveBeenCalledWith(
       'update:status',
       expect.objectContaining({
@@ -482,7 +483,9 @@ describe('UpdateService.download', () => {
     const target = join(dir, 'installer.dmg')
     // A leftover fragment from a previous app session at the same Save location.
     const partPath = `${target}.part`
+    const metadataPath = `${partPath}.meta`
     await writeFile(partPath, Buffer.from('stale-fragment-from-last-session'))
+    await writeFile(metadataPath, Buffer.from('stale-validator-sidecar'))
     const body = Buffer.from('fresh-installer-bytes')
     const manifestForCheck = downloadManifest(
       body.byteLength,
@@ -510,12 +513,14 @@ describe('UpdateService.download', () => {
     // The stale .part was removed before the download, and the result is the fresh body (a full
     // fetch, not a Range-resumed stale fragment that would fail the manifest checksum).
     expect(removeFile).toHaveBeenCalledWith(partPath)
+    expect(removeFile).toHaveBeenCalledWith(metadataPath)
     expect(status.state).toBe('ready')
     expect(await readFile(target)).toEqual(body)
     expect(existsSync(partPath)).toBe(false)
+    expect(existsSync(metadataPath)).toBe(false)
   })
 
-  it('removes the .part only on the first download to a path this session (in-session resume kept)', async () => {
+  it('removes resumable artifacts only on the first download to a path this session', async () => {
     dir = await mkdtemp(join(tmpdir(), 'svc-'))
     const target = join(dir, 'installer.dmg')
     const body = Buffer.from('installer-bytes')
@@ -543,8 +548,8 @@ describe('UpdateService.download', () => {
     await service.download()
     await service.download() // same path, same session
 
-    // Only the first download reset the .part; the second leaves it so an in-session retry resumes.
-    expect(removeFile).toHaveBeenCalledTimes(1)
+    // Only the first download resets the .part and sidecar; the second leaves both to the core.
+    expect(removeFile).toHaveBeenCalledTimes(2)
   })
 
   it('does not start the fetch and errors when the first .part cleanup fails', async () => {
@@ -612,8 +617,8 @@ describe('UpdateService.download', () => {
     expect(first.state).toBe('error')
     const retry = await service.download()
 
-    // The path was NOT marked fresh after the failure, so the retry cleans again and then succeeds.
-    expect(removeFile).toHaveBeenCalledTimes(2)
+    // The path was NOT marked fresh after the failure, so the retry cleans both artifacts and succeeds.
+    expect(removeFile).toHaveBeenCalledTimes(3)
     expect(retry.state).toBe('ready')
   })
 
@@ -643,13 +648,18 @@ describe('UpdateService.download', () => {
             )
           }
         })
-        return Promise.resolve(new Response(stream, { status: 200 }))
+        return Promise.resolve(
+          new Response(stream, { status: 200, headers: { etag: '"installer-v1"' } })
+        )
       }
       // Retry: serve the remaining bytes as a 206 partial-content response.
       return Promise.resolve(
         new Response(body.subarray(2), {
           status: 206,
-          headers: { 'content-range': `bytes 2-${body.byteLength - 1}/${body.byteLength}` }
+          headers: {
+            etag: '"installer-v1"',
+            'content-range': `bytes 2-${body.byteLength - 1}/${body.byteLength}`
+          }
         })
       )
     }) as unknown as typeof fetch

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -103,8 +103,9 @@ export class UpdateService implements UpdateStrategy {
   private readonly translate: NativeTranslator
   // Per-session set of target paths that have already been downloaded once this run. The first
   // download to a given path removes any pre-existing <target>.part so a restart starts fresh
-  // (design: "app closes → start from scratch"). Within a session the path stays in the set and
-  // a cancel/retry resumes via Range instead of discarding the partially-downloaded bytes.
+  // (design: "app closes → start from scratch"). Within a session the path stays in the set and a
+  // cancel/retry may resume via Range when the response supplied a usable validator; otherwise the
+  // shared downloader safely restarts from zero.
   private readonly freshTargets = new Set<string>()
 
   constructor(deps: UpdateServiceDeps = {}) {
@@ -311,8 +312,9 @@ export class UpdateService implements UpdateStrategy {
         // succeeds — if it throws, we do NOT add it and let the error propagate to the catch below, so
         // a retry re-attempts the cleanup instead of resuming a fragment we failed to delete (a
         // same-version fragment would otherwise pass the final checksum and silently complete a
-        // cross-restart resume). Subsequent downloads to the same path this session are left alone so
-        // an in-session cancel/retry still resumes via Range.
+        // cross-restart resume). Subsequent downloads to the same path this session are left to the
+        // resilient core, which resumes only when its validator sidecar binds the partial to the
+        // remote representation.
         if (!this.freshTargets.has(targetPath)) {
           operation.phase('prepare-target')
           await this.removeFile(`${targetPath}.part`)

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -102,7 +102,8 @@ export class UpdateService implements UpdateStrategy {
   private readonly log: Logger
   private readonly translate: NativeTranslator
   // Per-session set of target paths that have already been downloaded once this run. The first
-  // download to a given path removes any pre-existing <target>.part so a restart starts fresh
+  // download to a given path removes any pre-existing <target>.part and validator sidecar so a restart
+  // starts fresh
   // (design: "app closes → start from scratch"). Within a session the path stays in the set and a
   // cancel/retry may resume via Range when the response supplied a usable validator; otherwise the
   // shared downloader safely restarts from zero.
@@ -306,18 +307,19 @@ export class UpdateService implements UpdateStrategy {
         if (options.nonInteractive) await this.removeFile(targetPath)
         if (abort.signal.aborted) return
 
-        // First time this session that we download to this exact path: drop any <target>.part left by
-        // a PRIOR session so the resilient core can't Range-resume a stale fragment (the user may
-        // re-pick the same Save location after a restart). Mark the path fresh ONLY after the removal
-        // succeeds — if it throws, we do NOT add it and let the error propagate to the catch below, so
-        // a retry re-attempts the cleanup instead of resuming a fragment we failed to delete (a
-        // same-version fragment would otherwise pass the final checksum and silently complete a
-        // cross-restart resume). Subsequent downloads to the same path this session are left to the
-        // resilient core, which resumes only when its validator sidecar binds the partial to the
-        // remote representation.
+        // First time this session that we download to this exact path: drop any <target>.part and its
+        // validator sidecar left by a PRIOR session so the resilient core can't Range-resume a stale
+        // fragment (the user may re-pick the same Save location after a restart). Mark the path fresh
+        // ONLY after both removals succeed — if either throws, we do NOT add it and let the error
+        // propagate to the catch below, so a retry re-attempts the cleanup instead of resuming a
+        // fragment we failed to delete (a same-version fragment would otherwise pass the final
+        // checksum and silently complete a cross-restart resume). Subsequent downloads to the same
+        // path this session are left to the resilient core, which resumes only when its validator
+        // sidecar binds the partial to the remote representation.
         if (!this.freshTargets.has(targetPath)) {
           operation.phase('prepare-target')
           await this.removeFile(`${targetPath}.part`)
+          await this.removeFile(`${targetPath}.part.meta`)
           this.freshTargets.add(targetPath)
           if (abort.signal.aborted) return
         }

--- a/src/renderer/src/pages/settings/NetworkPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/NetworkPanel.render.test.tsx
@@ -126,6 +126,30 @@ describe('NetworkPanel offline retry', () => {
     expect(getInfo).toHaveBeenCalledOnce()
   })
 
+  it('uses a neutral icon when the local connection type is unknown', async () => {
+    ;(window as unknown as { api: unknown }).api = {
+      network: {
+        getInfo: vi.fn().mockResolvedValue({
+          connectionType: 'unknown',
+          ipAddress: '10.8.0.2'
+        }),
+        checkConnectivity: vi.fn().mockResolvedValue(true)
+      }
+    }
+    Object.defineProperty(window.navigator, 'onLine', { value: true, configurable: true })
+    useNetworkStore.setState({ isOnline: true, connectivity: 'reachable' })
+
+    await act(async () => {
+      root.render(<NetworkPanel view={{ kind: 'list' }} onNavigate={() => {}} />)
+      await Promise.resolve()
+    })
+
+    expect(container.textContent).toContain('10.8.0.2')
+    expect(container.querySelector('.lucide-network')).not.toBeNull()
+    expect(container.querySelector('.lucide-wifi')).toBeNull()
+    expect(container.querySelector('.lucide-ethernet-port')).toBeNull()
+  })
+
   it('does not let a stale getInfo rejection overwrite a newer success', async () => {
     let rejectFirst!: (reason: Error) => void
     const firstResult = new Promise<never>((_resolve, reject) => {

--- a/src/renderer/src/pages/settings/NetworkPanel.tsx
+++ b/src/renderer/src/pages/settings/NetworkPanel.tsx
@@ -1,4 +1,4 @@
-import { EthernetPort, RefreshCw, Wifi, WifiOff } from 'lucide-react'
+import { EthernetPort, Network, RefreshCw, Wifi, WifiOff } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -190,12 +190,14 @@ const NetworkPanel = ({ view, onNavigate }: NetworkPanelProps): React.JSX.Elemen
   // always renders as Checking… — including an offline Retry.
   const isChecking = connectivity === 'unknown'
 
-  // Tile icon follows the actual link: WifiOff while offline, then by connection type.
+  // Tile icon follows the actual link; unknown/unclassified interfaces stay visually neutral.
   const networkIcon = !isOnline
     ? WifiOff
     : networkInfo?.connectionType === 'ethernet'
       ? EthernetPort
-      : Wifi
+      : networkInfo?.connectionType === 'wifi'
+        ? Wifi
+        : Network
 
   if (view.kind === 'proxy') return <NetworkProxyForm onDone={() => onNavigate({ kind: 'list' })} />
 


### PR DESCRIPTION
## Problem

`resilientDownload` used manifest `expectedSize` for progress and short-read detection but did not enforce it as a hard upper bound. It also resumed from the local `.part` length without binding the partial to ETag/Last-Modified or validating `Content-Range`, allowing an overlong or changed response to consume unnecessary bandwidth/disk and allowing generic no-hash callers to adopt a spliced representation.

Network link classification also treated any active macOS IPv4 interface missing from the hardware-port map, and any known non-Wi-Fi port, as Ethernet. Windows/Linux intentionally remain unclassified, but the settings row rendered `unknown` with a Wi-Fi icon.

## Proposed change

- Enforce `expectedSize` against `Content-Length`, `Content-Range`, and every body chunk before writing excess bytes.
- Require valid 206 range metadata, the requested start offset, consistent range/content lengths, and a bounded representation total.
- Bind resumable partials to a strong ETag or Last-Modified through `If-Range`; restart from zero when no usable validator exists or when the server returns 200 for a changed representation.
- Persist a versioned `.part.meta` sidecar containing a SHA-256 URL fingerprint, validator, and optional expected size so a later retry call can resume safely without storing signed URLs in plaintext.
- Treat missing/malformed/mismatched historical metadata as unbound: discard the old partial and download from zero.
- Classify only explicit macOS Wi-Fi/Ethernet hardware ports; keep VPN, virtual, lookup-failure, and other port types `unknown`.
- Render `unknown` with a neutral Network icon.

## Scope and non-goals

- No manifest, IPC, database, or shared network-model fields change.
- No new enum/status values; `NetworkConnectionType` remains `wifi | ethernet | unknown`.
- The sidecar is temporary persisted data with the same lifecycle as `.part`; it is removed on success and invalidated on integrity or terminal local failures.
- Existing historical `.part` files are not resumed once because they lack trustworthy validator metadata. Completed downloads and database data are unaffected.
- This does not add route-aware Windows/Linux/macOS discovery. Cross-platform default-route and physical-link diagnostics remain a separate feature.
- No new UI copy or interaction flow.

## Acceptance criteria and validation

The regression tests were written against the existing public boundaries and observed failing before the production fixes. Repeated red runs reproduced: oversized responses being adopted, excess chunks being written, missing `If-Range`, lost validators across calls, blind weak/no-validator Range retries, invalid 206 ranges being accepted, changed ETags being spliced, macOS virtual/bridge interfaces becoming Ethernet, and `unknown` rendering as Wi-Fi.

Final evidence after the last material edit:

- Download bounds, validator sidecar, range validation -> `vitest run src/main/net/resilient-download.test.ts` within the final targeted set -> passed.
- macOS conservative classification -> `vitest run src/main/net/network-info.test.ts` within the final targeted set -> 10 passed; 4 pre-existing macOS-only conditional cases skipped on Windows and left for CI.
- Updater/language-pack consumers and network IPC -> targeted final set -> passed.
- Unknown settings presentation -> `NetworkPanel.render.test.tsx` within the final targeted set -> passed.
- Combined final targeted set (6 files) -> 60 passed, 4 skipped.
- `npm run lint` -> passed with no warnings after formatting.
- `npm run typecheck:node` -> blocked by existing shared dependency state (`waitForMcpServers` export and stale Prisma `sessionModelCallUsage` client); the unmodified `main` checkout produces the identical errors.
- `npm run typecheck:web` -> blocked by the same stale Prisma client; the unmodified `main` checkout produces the identical errors.

Per maintainer instruction, the full local `npm test` was not run. These changed files are not mapped to a single owner in `module-impact.json`, so PR Gate is authoritative for the expanded clean-environment and platform lanes.

## Review focus

- Hard-bound checks occur before the offending chunk write.
- Sidecar validation and cleanup cannot make an unbound partial resumable.
- 200/206 handling never appends bytes from a changed representation.
- Conservative link classification does not claim Wi-Fi/Ethernet without evidence.
