### PR TITLE
perf(context-window): defer history projection until dialog opens

### DIFF
--- a/src/renderer/src/pages/workspace/ContextWindowDialog.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ContextWindowDialog.render.test.tsx
@@ -175,6 +175,24 @@ describe('ContextWindowDialog', () => {
     document.body.innerHTML = ''
   })
 
+  it('does not inspect Session history while closed', () => {
+    const closedSession = session()
+    Object.defineProperty(closedSession, 'messages', {
+      get: () => {
+        throw new Error('closed dialog inspected Session history')
+      }
+    })
+
+    expect(() => {
+      act(() => {
+        root.render(
+          <ContextWindowDialog open={false} session={closedSession} onOpenChange={vi.fn()} />
+        )
+      })
+    }).not.toThrow()
+    expect(document.body.querySelector('[data-slot="context-window-dialog"]')).toBeNull()
+  })
+
   it('shows current composition, stacked run history, and stable latest-run details', () => {
     act(() => {
       root.render(<ContextWindowDialog open session={session()} onOpenChange={vi.fn()} />)

--- a/src/renderer/src/pages/workspace/ContextWindowDialog.tsx
+++ b/src/renderer/src/pages/workspace/ContextWindowDialog.tsx
@@ -1133,6 +1133,81 @@ const ContextCallHistory = ({
   )
 }
 
+type ContextWindowDialogDataProps = Pick<ContextWindowDialogProps, 'session' | 'contextUsage'> & {
+  granularity: ContextWindowGranularity
+}
+
+// Radix mounts this child only while the dialog is present. Keep history projection here so a
+// closed dialog does not rescan the active Session on every streaming message or tool update.
+const ContextWindowDialogData = ({
+  granularity,
+  session,
+  contextUsage
+}: ContextWindowDialogDataProps): React.JSX.Element => {
+  const { t } = useTranslation()
+  const messages = session?.messages
+  const activities = session?.activities
+  const conversationGraph = session?.conversationGraph
+  const points = useMemo(
+    () =>
+      granularity !== 'turn' || messages === undefined
+        ? []
+        : selectContextWindowTrendPoints({ activities, conversationGraph, messages }),
+    [activities, conversationGraph, granularity, messages]
+  )
+  const latestPoint = points.at(-1)
+  const currentUsage = contextUsage ?? latestPoint?.sample.contextWindow
+  const callPoints = useMemo(
+    () =>
+      granularity !== 'call' || messages === undefined
+        ? []
+        : selectContextWindowCallPoints({ activities, conversationGraph, messages }),
+    [activities, conversationGraph, granularity, messages]
+  )
+  const callSummary = useMemo(() => summarizeContextWindowCallPoints(callPoints), [callPoints])
+
+  return (
+    <div className="space-y-6">
+      {granularity === 'turn' ? (
+        <>
+          {currentUsage ? (
+            <CurrentComposition
+              usage={currentUsage}
+              model={session?.agentModel ?? latestPoint?.runtime?.model}
+            />
+          ) : null}
+          {points.length ? (
+            <ContextHistory points={points} />
+          ) : (
+            <div className="grid min-h-64 place-items-center rounded-lg border border-dashed border-border bg-bg-100/40 px-6 text-center">
+              <div className="max-w-sm">
+                <Activity className="mx-auto size-6 text-muted-foreground" aria-hidden="true" />
+                <h3 className="mt-3 text-sm font-medium text-foreground">
+                  {t('No run history yet')}
+                </h3>
+                <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                  {t(
+                    'A bar appears after a run completes, is interrupted, or ends with an error. Older sessions remain compatible and may not contain history data.'
+                  )}
+                </p>
+              </div>
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          <ContextCallSummary summary={callSummary} />
+          {callPoints.length ? (
+            <ContextCallHistory points={callPoints} />
+          ) : (
+            <ContextCallEmptyState />
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
 const ContextWindowDialog = ({
   open,
   session,
@@ -1141,26 +1216,6 @@ const ContextWindowDialog = ({
 }: ContextWindowDialogProps): React.JSX.Element => {
   const { t } = useTranslation()
   const [granularity, setGranularity] = useState<ContextWindowGranularity>('turn')
-  const messages = session?.messages
-  const activities = session?.activities
-  const conversationGraph = session?.conversationGraph
-  const points = useMemo(
-    () =>
-      messages === undefined
-        ? []
-        : selectContextWindowTrendPoints({ activities, conversationGraph, messages }),
-    [activities, conversationGraph, messages]
-  )
-  const latestPoint = points.at(-1)
-  const currentUsage = contextUsage ?? latestPoint?.sample.contextWindow
-  const callPoints = useMemo(
-    () =>
-      messages === undefined
-        ? []
-        : selectContextWindowCallPoints({ activities, conversationGraph, messages }),
-    [activities, conversationGraph, messages]
-  )
-  const callSummary = useMemo(() => summarizeContextWindowCallPoints(callPoints), [callPoints])
   const contentRef = useRef<HTMLDivElement>(null)
 
   return (
@@ -1226,47 +1281,11 @@ const ContextWindowDialog = ({
             className={cn(dialogBodyClassName, 'min-h-0 flex-1 overflow-y-auto')}
             data-slot="context-window-dialog-body"
           >
-            <div className="space-y-6">
-              {granularity === 'turn' ? (
-                <>
-                  {currentUsage ? (
-                    <CurrentComposition
-                      usage={currentUsage}
-                      model={session?.agentModel ?? latestPoint?.runtime?.model}
-                    />
-                  ) : null}
-                  {points.length ? (
-                    <ContextHistory points={points} />
-                  ) : (
-                    <div className="grid min-h-64 place-items-center rounded-lg border border-dashed border-border bg-bg-100/40 px-6 text-center">
-                      <div className="max-w-sm">
-                        <Activity
-                          className="mx-auto size-6 text-muted-foreground"
-                          aria-hidden="true"
-                        />
-                        <h3 className="mt-3 text-sm font-medium text-foreground">
-                          {t('No run history yet')}
-                        </h3>
-                        <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                          {t(
-                            'A bar appears after a run completes, is interrupted, or ends with an error. Older sessions remain compatible and may not contain history data.'
-                          )}
-                        </p>
-                      </div>
-                    </div>
-                  )}
-                </>
-              ) : (
-                <>
-                  <ContextCallSummary summary={callSummary} />
-                  {callPoints.length ? (
-                    <ContextCallHistory points={callPoints} />
-                  ) : (
-                    <ContextCallEmptyState />
-                  )}
-                </>
-              )}
-            </div>
+            <ContextWindowDialogData
+              granularity={granularity}
+              session={session}
+              contextUsage={contextUsage}
+            />
           </div>
         </Dialog.Content>
       </Dialog.Portal>


### PR DESCRIPTION
## Problem

`ContextWindowDialog` stays instantiated with the active Conversation panel even while Radix has no
visible dialog. Its Turns and Calls selectors therefore rescanned Session messages, activities, and
the conversation graph on streaming updates while the dialog was closed. This created avoidable
renderer CPU work, although it did not create ACP requests or additional listeners.

Model-call detail already has the correct cross-framework lifecycle: Claude Code, OpenCode, managed
Codex Responses, and generic Codex/bridge publish exact all-or-none Calls only after the logical turn
reaches a terminal result. This PR preserves that contract.

## Proposed change

- Move Session history projection into a child mounted under Radix `Dialog.Content`, so a closed
  dialog does not inspect Session history.
- Run only the selector for the selected Turns or Calls granularity while the dialog is open.
- Keep the controlled dialog and granularity state in the existing owner, preserving reopen and
  close-animation behavior.
- Add a render regression that makes Session history unreadable and proves a closed dialog never
  accesses it.

## Scope and non-goals

- Renderer-only change in `ContextWindowDialog.tsx` and its render test.
- No new modal-open fetch, cache, listener, IPC, or ACP subscription.
- No ACP adapter or protocol behavior changes across Claude Code, OpenCode, Codex Responses, or
  Codex bridge.
- Historical compatibility: unchanged; aggregate-only and pre-call-tracking Sessions retain the
  existing empty state without migration or synthetic Calls.
- Enum/state additions: none.
- Persistence: no Session JSON, SQLite projection, field, migration, or write-timing changes.
- No user-visible copy or i18n catalog changes.

## Acceptance criteria and validation

All listed checks ran after the final material edit and after rebasing onto the latest `origin/main`.

| Behavior | Command | Result |
| --- | --- | --- |
| Closed dialog avoids Session-history projection; open Turns/Calls remain functional | `npx vitest run src/renderer/src/pages/workspace/ContextWindowDialog.render.test.tsx` | 1 file, 14 tests passed |
| Renderer type safety | `npm run typecheck:web` | Passed |
| Changed source/test lint | targeted `npx eslint` | No issues |
| Formatting and whitespace | targeted `npx prettier --check`; `git diff --check origin/main...HEAD` | Passed |
| Exact-head impact classification | `npm run test:affected -- --base origin/main --head HEAD --explain` | Failed closed to the full Vitest plan because the changed render test has no module owner |

Per maintainer direction, the full local `npm test` suite was not run. PR Gate is the authority for
the classifier-selected complete Vitest suite and platform checks.

Included locally: the renderer behavior owner test and Web typecheck. Excluded locally: ACP adapter,
database, Electron-only, model-specific, and OS-specific lanes because this diff changes no protocol,
persistence, transport, model, path, or platform behavior.

Uncovered risk before CI: another closed-dialog code path outside Radix presence semantics. The
regression exercises the public controlled-dialog boundary; PR Gate provides the independent full
suite review.

## Review focus

- Confirm the selector-heavy child remains below the Radix presence boundary.
- Confirm only the selected granularity derives history and the outer granularity state preserves
  existing reopen behavior.
