### PR TITLE
perf(preview): avoid redundant persistence and reads

### DIFF
--- a/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
@@ -276,6 +276,41 @@ describe('preview persistence projections', () => {
 
     expect(restored.items).toMatchObject([{ format: 'text' }, { format: 'json' }])
   })
+
+  it('updates and removes Upload index entries when a Session is replaced or deleted', () => {
+    const persisted: PersistedPreviewState = {
+      version: PREVIEW_STATE_VERSION,
+      panelState: 'open',
+      activeItemId: 'upload:upload-1',
+      items: [
+        {
+          id: 'upload:upload-1',
+          sessionId: '.pending',
+          title: 'data.csv',
+          source: 'upload',
+          path: '/workspace/uploads/.pending/data.csv',
+          format: 'csv',
+          name: 'data.csv'
+        }
+      ]
+    }
+    const originalSession = createSession(createUpload())
+    const replacementSession = createSession(
+      createUpload({ path: '/workspace/uploads/session-final/replaced.csv', size: 256 })
+    )
+
+    expect(toRestoredSlice(persisted, [originalSession]).items?.[0]).toMatchObject({
+      path: '/workspace/uploads/session-final/data.csv',
+      size: 128
+    })
+    expect(toRestoredSlice(persisted, [replacementSession]).items?.[0]).toMatchObject({
+      path: '/workspace/uploads/session-final/replaced.csv',
+      size: 256
+    })
+    expect(toRestoredSlice(persisted, []).items?.[0]).toMatchObject({
+      path: '/workspace/uploads/.pending/data.csv'
+    })
+  })
 })
 
 // Minimal wrapper so the effect-only hook can be mounted/rerendered/unmounted.
@@ -546,6 +581,91 @@ describe('usePreviewPersistence per-project save/restore', () => {
           selectedAgentFrameId: 'child-05'
         }
       }
+    })
+  })
+
+  it('does not save when a runtime-only tool tab changes without changing the durable projection', async () => {
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+      await flushPreviewPersistence()
+    })
+
+    const fileItem = createStoredFileItem()
+    const toolItem = createStoredToolItem()
+    act(() => {
+      usePreviewWorkbenchStore.setState({
+        panelState: 'open',
+        activeItemId: fileItem.id,
+        items: [fileItem, toolItem]
+      })
+    })
+    await flushPreviewPersistence()
+    save.mockClear()
+
+    act(() => {
+      usePreviewWorkbenchStore.setState({
+        items: [{ ...toolItem, title: 'Notebook runtime updated' }, fileItem]
+      })
+    })
+    await flushPreviewPersistence()
+
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  it('does not rescan unchanged hydrated Session messages when returning to a Project', async () => {
+    const finalizedUpload = createUpload()
+    const session = createSession(finalizedUpload)
+    const messages = session.messages
+    let messageReads = 0
+    Object.defineProperty(session, 'messages', {
+      configurable: true,
+      get: () => {
+        messageReads += 1
+        return messages
+      }
+    })
+    useSessionStore.setState({
+      ...createInitialSessionState(),
+      sessions: [session]
+    })
+    const persistedUpload: PreviewStateSnapshot = {
+      revision: 7,
+      state: {
+        version: PREVIEW_STATE_VERSION,
+        panelState: 'open',
+        activeItemId: 'upload:upload-1',
+        items: [
+          {
+            id: 'upload:upload-1',
+            sessionId: '.pending',
+            title: 'data.csv',
+            source: 'upload',
+            path: '/workspace/uploads/.pending/data.csv',
+            format: 'csv',
+            name: 'data.csv'
+          }
+        ]
+      }
+    }
+    load.mockImplementation(({ projectId }: { projectId: string }) =>
+      Promise.resolve(projectId === 'project-a' ? persistedUpload : null)
+    )
+
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+    })
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-b" />)
+    })
+    await act(async () => {
+      root.render(<PersistenceHarness projectId="project-a" />)
+    })
+
+    expect(messageReads).toBe(1)
+    expect(usePreviewWorkbenchStore.getState().items[0]).toMatchObject({
+      id: 'upload:upload-1',
+      sessionId: 'session-final',
+      path: '/workspace/uploads/session-final/data.csv'
     })
   })
 
@@ -904,7 +1024,7 @@ describe('usePreviewPersistence per-project save/restore', () => {
       revision: 5,
       state: toPersistedPreviewState({
         ...usePreviewWorkbenchStore.getState(),
-        panelState: 'open',
+        panelState: 'collapsed',
         items: [item]
       })
     })
@@ -919,7 +1039,7 @@ describe('usePreviewPersistence per-project save/restore', () => {
     save.mockReturnValueOnce(pendingSave.promise)
     load.mockReturnValueOnce(pendingLoad.promise)
 
-    act(() => usePreviewWorkbenchStore.setState({ activeItemId: item.id }))
+    act(() => usePreviewWorkbenchStore.setState({ panelState: 'open' }))
     await act(async () => root.unmount())
     root = createRoot(container)
     await act(async () => {
@@ -992,7 +1112,7 @@ describe('usePreviewPersistence per-project save/restore', () => {
     expect(durableState?.activeItemId).toBe(item.id)
   })
 
-  it('flushes the active project on unmount', async () => {
+  it('does not duplicate an accepted active-project snapshot on unmount', async () => {
     await act(async () => {
       root.render(<PersistenceHarness projectId="project-a" />)
     })
@@ -1016,27 +1136,7 @@ describe('usePreviewPersistence per-project save/restore', () => {
       root.unmount()
     })
 
-    expect(save).toHaveBeenCalledTimes(1)
-    expect(save).toHaveBeenCalledWith({
-      projectId: 'project-a',
-      expectedRevision: expect.any(Number),
-      state: {
-        version: PREVIEW_STATE_VERSION,
-        panelState: 'open',
-        activeItemId: 'file:session-1:/workspace/project/report.md',
-        items: [
-          {
-            id: 'file:session-1:/workspace/project/report.md',
-            sessionId: 'session-1',
-            title: 'report.md',
-            source: 'artifact',
-            path: '/workspace/project/report.md',
-            format: 'markdown',
-            name: 'report.md'
-          }
-        ]
-      }
-    })
+    expect(save).not.toHaveBeenCalled()
     expect(usePreviewWorkbenchStore.getState().fileDialogItem).toBeUndefined()
   })
 })

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
@@ -311,6 +311,52 @@ describe('preview persistence projections', () => {
       path: '/workspace/uploads/.pending/data.csv'
     })
   })
+
+  it('evicts the oldest Upload index after eight Projects', () => {
+    let oldestProjectMessageReads = 0
+    let oldestProject: { persisted: PersistedPreviewState; session: ChatSession } | undefined
+
+    for (let index = 0; index < 9; index += 1) {
+      const projectId = `indexed-project-${index}`
+      const sessionId = `indexed-session-${index}`
+      const upload = createUpload({ id: `indexed-upload-${index}`, sessionId })
+      const session = createSession(upload, { id: sessionId, projectId })
+      const messages = session.messages
+      if (index === 0) {
+        Object.defineProperty(session, 'messages', {
+          configurable: true,
+          get: () => {
+            oldestProjectMessageReads += 1
+            return messages
+          }
+        })
+      }
+      const persisted: PersistedPreviewState = {
+        version: PREVIEW_STATE_VERSION,
+        panelState: 'open',
+        activeItemId: `upload:${upload.id}`,
+        items: [
+          {
+            id: `upload:${upload.id}`,
+            sessionId: '.pending',
+            title: upload.name,
+            source: 'upload',
+            path: `/workspace/uploads/.pending/${upload.name}`,
+            format: 'csv',
+            name: upload.name
+          }
+        ]
+      }
+
+      toRestoredSlice(persisted, [session])
+      if (index === 0) oldestProject = { persisted, session }
+    }
+
+    expect(oldestProject).toBeDefined()
+    toRestoredSlice(oldestProject!.persisted, [oldestProject!.session])
+
+    expect(oldestProjectMessageReads).toBe(2)
+  })
 })
 
 // Minimal wrapper so the effect-only hook can be mounted/rerendered/unmounted.

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.ts
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.ts
@@ -74,8 +74,27 @@ const previewValuesEqual = (left: unknown, right: unknown): boolean => {
 }
 
 // Session store updates replace changed Sessions. Keep a derived Project lookup so restores query
-// only the persisted Upload ids and rescan Messages only when a Session object changes.
+// only the persisted Upload ids and rescan Messages only when a Session object changes. Bound the
+// recent-Project cache so removed or long-inactive Projects cannot retain Session message graphs for
+// the renderer lifetime.
+const MAX_UPLOAD_PREVIEW_INDEX_PROJECTS = 8
 const uploadPreviewIndexes = new Map<string, ProjectUploadPreviewIndex>()
+
+const getUploadPreviewIndex = (projectId: string): ProjectUploadPreviewIndex => {
+  const cached = uploadPreviewIndexes.get(projectId)
+  const index = cached ?? { sessions: new Map(), uploads: new Map() }
+
+  // Map insertion order supplies a small LRU without another cache abstraction.
+  if (cached) uploadPreviewIndexes.delete(projectId)
+  uploadPreviewIndexes.set(projectId, index)
+  while (uploadPreviewIndexes.size > MAX_UPLOAD_PREVIEW_INDEX_PROJECTS) {
+    const oldestProjectId = uploadPreviewIndexes.keys().next().value
+    if (oldestProjectId === undefined) break
+    uploadPreviewIndexes.delete(oldestProjectId)
+  }
+
+  return index
+}
 
 const synchronizeUploadPreviewIndex = (
   sessions: ChatSession[]
@@ -83,10 +102,7 @@ const synchronizeUploadPreviewIndex = (
   const projectId = sessions[0]?.projectId
   if (!projectId) return new Map()
 
-  const index = uploadPreviewIndexes.get(projectId) ?? {
-    sessions: new Map(),
-    uploads: new Map()
-  }
+  const index = getUploadPreviewIndex(projectId)
   const currentSessionIds = new Set<string>()
 
   for (const session of sessions) {
@@ -117,7 +133,6 @@ const synchronizeUploadPreviewIndex = (
     index.sessions.delete(sessionId)
   }
 
-  uploadPreviewIndexes.set(projectId, index)
   return index.uploads
 }
 

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.ts
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.ts
@@ -22,10 +22,24 @@ import { getPreviewFormatForFile } from '../../pages/workspace/preview-support'
 type PreviewStoreState = ReturnType<typeof usePreviewWorkbenchStore.getState>
 type PreviewSave = (request: SavePreviewStateRequest) => Promise<SavePreviewStateResult>
 type PreviewSaveInput = Omit<SavePreviewStateRequest, 'expectedRevision'>
+type FinalizedUploadPreview = {
+  sessionId: string
+  path: string
+  size: number
+  mimeType?: string
+}
+type ProjectUploadPreviewIndex = {
+  sessions: Map<string, { session: ChatSession; uploadIds: Set<string> }>
+  uploads: Map<string, FinalizedUploadPreview>
+}
 type PreviewSaveScheduler = {
   schedule: (request: PreviewSaveInput) => void
   getGeneration: (projectId: string) => number
-  acceptLoadedRevision: (projectId: string, generation: number, revision: number) => boolean
+  acceptLoadedSnapshot: (
+    projectId: string,
+    generation: number,
+    snapshot: PreviewStateSnapshot | null
+  ) => boolean
   hasFailure: (projectId: string) => boolean
   waitForIdle: (projectId: string) => Promise<void>
   flush: () => Promise<void>
@@ -57,6 +71,54 @@ const previewValuesEqual = (left: unknown, right: unknown): boolean => {
         Object.hasOwn(rightRecord, key) && previewValuesEqual(leftRecord[key], rightRecord[key])
     )
   )
+}
+
+// Session store updates replace changed Sessions. Keep a derived Project lookup so restores query
+// only the persisted Upload ids and rescan Messages only when a Session object changes.
+const uploadPreviewIndexes = new Map<string, ProjectUploadPreviewIndex>()
+
+const synchronizeUploadPreviewIndex = (
+  sessions: ChatSession[]
+): ReadonlyMap<string, FinalizedUploadPreview> => {
+  const projectId = sessions[0]?.projectId
+  if (!projectId) return new Map()
+
+  const index = uploadPreviewIndexes.get(projectId) ?? {
+    sessions: new Map(),
+    uploads: new Map()
+  }
+  const currentSessionIds = new Set<string>()
+
+  for (const session of sessions) {
+    if (session.projectId !== projectId) continue
+    currentSessionIds.add(session.id)
+    const cached = index.sessions.get(session.id)
+    if (cached?.session === session) continue
+
+    for (const uploadId of cached?.uploadIds ?? []) index.uploads.delete(uploadId)
+
+    const uploadIds = new Set<string>()
+    for (const message of session.messages) {
+      for (const upload of message.uploads ?? []) {
+        const previewId = `upload:${upload.id}`
+        uploadIds.add(previewId)
+        index.uploads.set(previewId, {
+          ...upload,
+          path: getUploadedAttachmentPath(upload, session.projectId)
+        })
+      }
+    }
+    index.sessions.set(session.id, { session, uploadIds })
+  }
+
+  for (const [sessionId, cached] of index.sessions) {
+    if (currentSessionIds.has(sessionId)) continue
+    for (const uploadId of cached.uploadIds) index.uploads.delete(uploadId)
+    index.sessions.delete(sessionId)
+  }
+
+  uploadPreviewIndexes.set(projectId, index)
+  return index.uploads
 }
 
 // Applies only the changes made after `base` to the authoritative state. This preserves remote tabs
@@ -108,6 +170,7 @@ const createPreviewSaveScheduler = (
     {
       pendingState: PersistedPreviewState | undefined
       pendingBaseState: PersistedPreviewState | undefined
+      inFlightState: PersistedPreviewState | undefined
       drain: Promise<void> | undefined
     }
   >()
@@ -120,6 +183,7 @@ const createPreviewSaveScheduler = (
   >()
   const revisions = new Map<string, number>()
   const generations = new Map<string, number>()
+  const acceptedStates = new Map<string, PersistedPreviewState>()
 
   const bumpGeneration = (projectId: string): void => {
     generations.set(projectId, (generations.get(projectId) ?? 0) + 1)
@@ -129,8 +193,19 @@ const createPreviewSaveScheduler = (
     const queue = queues.get(projectId) ?? {
       pendingState: undefined,
       pendingBaseState: undefined,
+      inFlightState: undefined,
       drain: undefined
     }
+    if (queue.pendingState && previewValuesEqual(queue.pendingState, state)) return
+    if (
+      !queue.pendingState &&
+      queue.inFlightState &&
+      previewValuesEqual(queue.inFlightState, state)
+    ) {
+      return
+    }
+    if (!queue.drain && previewValuesEqual(acceptedStates.get(projectId), state)) return
+
     queue.pendingState = state
     queue.pendingBaseState = undefined
     queues.set(projectId, queue)
@@ -145,6 +220,7 @@ const createPreviewSaveScheduler = (
           const nextBaseState = queue.pendingBaseState
           queue.pendingState = undefined
           queue.pendingBaseState = undefined
+          queue.inFlightState = nextState
 
           try {
             const result = await save({
@@ -159,6 +235,7 @@ const createPreviewSaveScheduler = (
               const localBaseState = queue.pendingState ? nextState : nextBaseState
               const revision = result.snapshot?.revision ?? 0
               revisions.set(projectId, revision)
+              acceptedStates.set(projectId, authoritativeState)
               bumpGeneration(projectId)
               failures.delete(projectId)
 
@@ -183,12 +260,15 @@ const createPreviewSaveScheduler = (
               break
             }
             revisions.set(projectId, Math.max(revisions.get(projectId) ?? 0, result.revision))
+            acceptedStates.set(projectId, nextState)
             bumpGeneration(projectId)
             failures.delete(projectId)
           } catch (error) {
             failures.set(projectId, { state: nextState, error })
             bumpGeneration(projectId)
             reportError(error)
+          } finally {
+            queue.inFlightState = undefined
           }
         }
       } finally {
@@ -229,10 +309,10 @@ const createPreviewSaveScheduler = (
     }
   }
 
-  const acceptLoadedRevision = (
+  const acceptLoadedSnapshot = (
     projectId: string,
     generation: number,
-    revision: number
+    snapshot: PreviewStateSnapshot | null
   ): boolean => {
     if (
       generation !== getGeneration(projectId) ||
@@ -242,11 +322,12 @@ const createPreviewSaveScheduler = (
       return false
     }
 
-    revisions.set(projectId, Math.max(revisions.get(projectId) ?? 0, revision))
+    revisions.set(projectId, Math.max(revisions.get(projectId) ?? 0, snapshot?.revision ?? 0))
+    acceptedStates.set(projectId, snapshot?.state ?? createEmptyPersistedPreviewState())
     return true
   }
 
-  return { schedule, getGeneration, acceptLoadedRevision, hasFailure, waitForIdle, flush }
+  return { schedule, getGeneration, acceptLoadedSnapshot, hasFailure, waitForIdle, flush }
 }
 
 // Projects the live store slice down to its durable subset: file previews plus the one Session-scoped
@@ -298,21 +379,7 @@ const toRestoredSlice = (
   sessions: ChatSession[] = []
 ): RestoredPreviewSlice => {
   // Hydrated sessions hold finalized upload paths while persisted tabs may still reference staging.
-  const uploadByPreviewId = new Map<
-    string,
-    { sessionId: string; path: string; size: number; mimeType?: string }
-  >()
-
-  for (const session of sessions) {
-    for (const message of session.messages) {
-      for (const upload of message.uploads ?? []) {
-        uploadByPreviewId.set(`upload:${upload.id}`, {
-          ...upload,
-          path: getUploadedAttachmentPath(upload, session.projectId)
-        })
-      }
-    }
-  }
+  const uploadByPreviewId = synchronizeUploadPreviewIndex(sessions)
 
   return {
     panelState: persisted.panelState,
@@ -427,13 +494,7 @@ export const usePreviewPersistence = (
       const snapshot = await window.api.preview.load({ projectId: activeProjectId })
       if (cancelled) return
 
-      if (
-        !previewSaveScheduler.acceptLoadedRevision(
-          activeProjectId,
-          loadGeneration,
-          snapshot?.revision ?? 0
-        )
-      ) {
+      if (!previewSaveScheduler.acceptLoadedSnapshot(activeProjectId, loadGeneration, snapshot)) {
         const currentStore = usePreviewWorkbenchStore.getState()
         if (currentStore.activeProjectId === activeProjectId) return
         if (previewSaveScheduler.hasFailure(activeProjectId)) {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -869,7 +869,9 @@ const ArtifactCard = ({
   const missing = useUnavailablePreviewProbe({
     enabled: isNearViewport,
     path: artifact.path,
-    source: 'artifact'
+    source: 'artifact',
+    size: artifact.size,
+    mtimeMs: artifact.mtimeMs
   })
 
   return (

--- a/src/renderer/src/pages/workspace/WorkspaceToolDetailsRow.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolDetailsRow.render.test.tsx
@@ -8,6 +8,7 @@ import type { ToolActivity } from '@/stores/session-store'
 import type { NotebookRunRecord } from '../../../../shared/notebook'
 
 import { formatNotebookRunOutputLineMeta } from './notebook-run-figures'
+import { createManagedPreviewTestTransport } from './previews/managed-preview-test-support'
 import { buildToolActivityDetails } from './workspace-tool-activity-details'
 import { WorkspaceToolDetailsRow } from './WorkspaceToolDetailsRow'
 import { i18next } from '@/i18n'
@@ -48,6 +49,21 @@ const createNotebookRun = (overrides: Partial<NotebookRunRecord> = {}): Notebook
   ],
   ...overrides
 })
+
+const installManagedImagePreview = (
+  readPreview: Window['api']['artifacts']['readPreview']
+): void => {
+  const transport = createManagedPreviewTestTransport({
+    encoding: 'base64',
+    read: (_source, request) => readPreview(request)
+  })
+  window.api.previewResources = {
+    acquire: vi.fn(transport.acquire),
+    readRange: vi.fn(),
+    release: vi.fn(transport.release)
+  }
+  vi.stubGlobal('fetch', vi.fn(transport.fetch))
+}
 
 describe('WorkspaceToolDetailsRow', () => {
   let container: HTMLDivElement
@@ -106,18 +122,20 @@ describe('WorkspaceToolDetailsRow', () => {
   })
 
   it('renders an image artifact-write result as an inline image preview', async () => {
+    const readPreview = vi.fn().mockResolvedValue({
+      content: 'aGVsbG8=',
+      encoding: 'base64',
+      size: 6,
+      truncated: false
+    })
     window.api = {
       artifacts: {
         openFile: vi.fn(),
-        readPreview: vi.fn().mockResolvedValue({
-          content: 'aGVsbG8=',
-          encoding: 'base64',
-          size: 6,
-          truncated: false
-        }),
+        readPreview,
         finalizeRunArtifacts: vi.fn()
       }
     } as unknown as Window['api']
+    installManagedImagePreview(readPreview)
 
     const activity = createActivity({
       providerToolName: 'write_artifact_file',
@@ -157,14 +175,14 @@ describe('WorkspaceToolDetailsRow', () => {
       )
     })
 
-    expect(window.api.artifacts.readPreview).toHaveBeenCalledWith({
-      path: '/artifacts/.pending/run-1/sin_curve.png',
-      maxBytes: 10 * 1024 * 1024,
-      encoding: 'base64',
-      // #147 added paginated reads; usePreviewFileContent now passes the page offset.
-      offset: 0
+    expect(window.api.previewResources.acquire).toHaveBeenCalledWith({
+      source: 'artifact',
+      path: '/artifacts/.pending/run-1/sin_curve.png'
     })
 
+    await waitFor(() =>
+      expect(container.querySelector('[data-testid="tool-output-image"]')).not.toBeNull()
+    )
     const image = container.querySelector('[data-testid="tool-output-image"]')
     expect(image?.getAttribute('src')).toBe('data:image/png;base64,aGVsbG8=')
     expect(container.textContent).toContain('sin_curve.png')
@@ -173,17 +191,19 @@ describe('WorkspaceToolDetailsRow', () => {
 
   it('falls back to the filename while the image preview is still loading', async () => {
     let resolveRead: ((value: unknown) => void) | undefined
+    const readPreview = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveRead = resolve
+      })
+    )
     window.api = {
       artifacts: {
         openFile: vi.fn(),
-        readPreview: vi.fn().mockReturnValue(
-          new Promise((resolve) => {
-            resolveRead = resolve
-          })
-        ),
+        readPreview,
         finalizeRunArtifacts: vi.fn()
       }
     } as unknown as Window['api']
+    installManagedImagePreview(readPreview)
 
     const activity = createActivity({
       providerToolName: 'write_artifact_file',
@@ -227,7 +247,9 @@ describe('WorkspaceToolDetailsRow', () => {
       resolveRead?.({ content: 'aGVsbG8=', encoding: 'base64', size: 6, truncated: false })
     })
 
-    expect(container.querySelector('[data-testid="tool-output-image"]')).not.toBeNull()
+    await waitFor(() =>
+      expect(container.querySelector('[data-testid="tool-output-image"]')).not.toBeNull()
+    )
   })
 
   it('renders a non-image, non-JSON tool output as a code section', async () => {

--- a/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { PreviewFileItem } from '@/stores/preview-workbench-store'
 import { createCachedImageFetchResponse } from './cached-preview-image.test-support'
+import { createManagedPreviewTestTransport } from './managed-preview-test-support'
 import { PreviewFileContent } from './PreviewFileContent'
 
 const highlightSpy = vi.hoisted(() => vi.fn())
@@ -146,17 +147,6 @@ describe('PreviewFileContent', () => {
     document.body.appendChild(container)
     restorePdbLayoutMocks = undefined
     window.api = {
-      previewResources: {
-        acquire: vi.fn().mockResolvedValue({
-          id: 'resource-1',
-          url: 'open-science-preview://resource-1/report.html',
-          size: 88,
-          mimeType: 'text/html; charset=utf-8',
-          version: 1
-        }),
-        readRange: vi.fn(),
-        release: vi.fn().mockResolvedValue(undefined)
-      },
       artifacts: {
         openFile: vi.fn().mockResolvedValue(undefined),
         readPreview: vi.fn().mockResolvedValue({
@@ -178,6 +168,18 @@ describe('PreviewFileContent', () => {
         })
       }
     } as unknown as Window['api']
+    const transport = createManagedPreviewTestTransport({
+      read: (source, request) =>
+        source === 'upload'
+          ? window.api.uploads.readPreview(request)
+          : window.api.artifacts.readPreview(request)
+    })
+    window.api.previewResources = {
+      acquire: vi.fn(transport.acquire),
+      readRange: vi.fn(),
+      release: vi.fn(transport.release)
+    }
+    vi.stubGlobal('fetch', vi.fn(transport.fetch))
     vi.clearAllMocks()
     highlightSpy.mockClear()
   })
@@ -284,12 +286,10 @@ describe('PreviewFileContent', () => {
 
     await renderFile(createFileItem({ format: 'json', name: 'data.json' }))
 
-    expect(window.api.artifacts.readPreview).toHaveBeenCalledWith({
+    expect(window.api.previewResources.acquire).toHaveBeenCalledWith({
+      source: 'artifact',
       path: '/workspace/data.json',
-      sessionId: 'session-1',
-      maxBytes: 1024 * 1024,
-      encoding: 'utf8',
-      offset: 0
+      sessionId: 'session-1'
     })
     expect(container.querySelector('pre')?.textContent).toContain('"name": "sample"')
     expect(container.querySelector('pre')?.textContent).toContain('"values": [')
@@ -467,20 +467,6 @@ describe('PreviewFileContent', () => {
     expect(container.querySelector('.text-danger-000')?.textContent).not.toBe('')
   })
 
-  it('uses the CSV fallback for a non-UTF8 preview', async () => {
-    vi.mocked(window.api.artifacts.readPreview).mockResolvedValue({
-      content: 'AAECAw==',
-      encoding: 'base64',
-      size: 4,
-      truncated: false
-    })
-
-    await renderFile(createFileItem({ format: 'csv', name: 'binary.csv' }))
-
-    expect(container.textContent).toContain("CSV couldn't be read for preview")
-    expect(container.querySelector('table')).toBeNull()
-  })
-
   it('loads the next bounded page of a large text preview on demand', async () => {
     vi.mocked(window.api.artifacts.readPreview).mockImplementation(async (request) =>
       request.offset === 5
@@ -512,13 +498,10 @@ describe('PreviewFileContent', () => {
       await Promise.resolve()
     })
 
-    expect(window.api.artifacts.readPreview).toHaveBeenLastCalledWith({
-      path: '/workspace/large.txt',
-      sessionId: 'session-1',
-      maxBytes: 1024 * 1024,
-      encoding: 'utf8',
-      offset: 5
-    })
+    expect(fetch).toHaveBeenLastCalledWith(
+      'open-science-preview://resource-2/large.txt',
+      expect.objectContaining({ headers: { Range: expect.stringMatching(/^bytes=5-/u) } })
+    )
     expect(container.textContent).toContain('second page')
     expect(container.textContent).not.toContain('first')
   })
@@ -625,7 +608,7 @@ describe('PreviewFileContent', () => {
     expect(iframe).not.toBeNull()
     expect(iframe?.getAttribute('sandbox')).toBe('allow-scripts')
     expect(iframe?.getAttribute('referrerpolicy')).toBe('no-referrer')
-    expect(iframe?.getAttribute('src')).toBe('open-science-preview://resource-1/report.html')
+    expect(iframe?.getAttribute('src')).toBe('open-science-preview://resource-1/data.json')
     expect(iframe?.hasAttribute('srcdoc')).toBe(false)
     expect(window.api.artifacts.readPreview).not.toHaveBeenCalled()
   })
@@ -957,7 +940,7 @@ describe('PreviewFileContent', () => {
     })
   })
 
-  it('reads upload-sourced text previews through the uploads API', async () => {
+  it('reads upload-sourced text previews through a managed upload resource', async () => {
     vi.mocked(window.api.uploads.readPreview).mockResolvedValue({
       content: 'uploaded content',
       encoding: 'utf8',
@@ -975,12 +958,10 @@ describe('PreviewFileContent', () => {
       })
     )
 
-    expect(window.api.uploads.readPreview).toHaveBeenCalledWith({
+    expect(window.api.previewResources.acquire).toHaveBeenCalledWith({
+      source: 'upload',
       path: '/Users/example/.open-science/uploads/default-project/session-1/notes.txt',
-      sessionId: 'session-1',
-      maxBytes: 1024 * 1024,
-      encoding: 'utf8',
-      offset: 0
+      sessionId: 'session-1'
     })
     expect(window.api.artifacts.readPreview).not.toHaveBeenCalled()
     expect(container.textContent).toContain('uploaded content')

--- a/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
@@ -537,6 +537,24 @@ describe('PreviewFileContent', () => {
     expect(window.api.artifacts.openFile).not.toHaveBeenCalled()
   })
 
+  it('keeps the unavailable classification when a managed fetch returns 404 after acquire', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 404 }))
+
+    await renderFile(
+      createFileItem({ format: 'text', name: 'gone.txt', path: '/workspace/gone.txt' })
+    )
+
+    expect(container.textContent).toContain('This file is no longer available')
+    expect(container.querySelector('pre')).toBeNull()
+    expect(consoleError).not.toHaveBeenCalledWith('Failed to read file preview', expect.anything())
+    expect(window.api.previewResources.release).toHaveBeenCalledWith({
+      resourceId: 'resource-1'
+    })
+
+    consoleError.mockRestore()
+  })
+
   it('renders line numbers next to formatted JSON previews', async () => {
     vi.mocked(window.api.artifacts.readPreview).mockResolvedValue({
       content: '{"name":"sample","values":[1,true]}',

--- a/src/renderer/src/pages/workspace/previews/managed-preview-test-support.ts
+++ b/src/renderer/src/pages/workspace/previews/managed-preview-test-support.ts
@@ -1,0 +1,96 @@
+import type {
+  ArtifactPreviewResult,
+  ReadArtifactPreviewRequest
+} from '../../../../../shared/artifacts'
+import type { AcquireManagedPreviewRequest } from '../../../../../shared/preview-resources'
+
+type PreviewSource = AcquireManagedPreviewRequest['source']
+
+type ManagedPreviewTestTransportOptions = {
+  read: (
+    source: PreviewSource,
+    request: ReadArtifactPreviewRequest
+  ) => Promise<ArtifactPreviewResult>
+  encoding?: 'utf8' | 'base64'
+}
+
+const decodeBase64 = (content: string): ArrayBuffer => {
+  const binary = atob(content)
+  const bytes = new Uint8Array(binary.length)
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index)
+  }
+  return bytes.buffer
+}
+
+// Adapts the existing content fixtures in renderer tests to the managed streaming boundary.
+// Production code does not import this file.
+export const createManagedPreviewTestTransport = ({
+  read,
+  encoding = 'utf8'
+}: ManagedPreviewTestTransportOptions): {
+  acquire: Window['api']['previewResources']['acquire']
+  release: Window['api']['previewResources']['release']
+  fetch: typeof fetch
+} => {
+  let nextResourceId = 1
+  const requests = new Map<string, AcquireManagedPreviewRequest>()
+
+  return {
+    acquire: async (request) => {
+      const id = `resource-${nextResourceId++}`
+      const filename = request.path.split('/').at(-1) ?? 'preview'
+      const url = `open-science-preview://${id}/${filename}`
+      requests.set(url, request)
+      return {
+        id,
+        url,
+        // The response Content-Range supplies the fixture's real size. This only keeps the
+        // renderer's bounded Range request open until that response arrives.
+        size: 64 * 1024 * 1024,
+        mimeType: 'application/octet-stream',
+        version: 1
+      }
+    },
+    release: async ({ resourceId }) => {
+      for (const [url] of requests) {
+        if (url.includes(`://${resourceId}/`)) requests.delete(url)
+      }
+    },
+    fetch: async (input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      const acquired = requests.get(url)
+      if (!acquired) throw new Error(`Unknown managed preview URL: ${url}`)
+
+      const rangeHeader = new Headers(init?.headers).get('range')
+      const range = rangeHeader?.match(/^bytes=(\d+)-(\d+)$/u)
+      if (!range) throw new Error('Managed preview test request is missing a byte Range.')
+
+      const offset = Number(range[1])
+      const requestedBytes = Number(range[2]) - offset + 1
+      const result = await read(acquired.source, {
+        path: acquired.path,
+        ...(acquired.projectId ? { projectId: acquired.projectId } : {}),
+        ...(acquired.sessionId ? { sessionId: acquired.sessionId } : {}),
+        maxBytes: Math.max(1, requestedBytes - (encoding === 'utf8' ? 3 : 0)),
+        encoding,
+        offset
+      })
+      const body: BodyInit =
+        result.encoding === 'base64' ? decodeBase64(result.content) : result.content
+      const bytesRead =
+        result.encoding === 'base64'
+          ? (body as ArrayBuffer).byteLength
+          : new Blob([result.content]).size
+      const responseEnd = offset + Math.max(0, bytesRead - 1)
+      const responseSize = result.truncated
+        ? Math.max(result.size, offset + bytesRead + 1)
+        : offset + bytesRead
+
+      return new Response(body, {
+        status: 206,
+        headers: { 'Content-Range': `bytes ${offset}-${responseEnd}/${responseSize}` }
+      })
+    }
+  }
+}

--- a/src/renderer/src/pages/workspace/previews/renderers/PlanJsonPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PlanJsonPreview.test.tsx
@@ -7,6 +7,7 @@ import { useSessionStore } from '@/stores/session-store'
 
 import { planTestDocument, planTestProjection } from '../../session-plan/plan-test-fixtures'
 
+import { createManagedPreviewTestTransport } from '../managed-preview-test-support'
 import { PlanJsonPreview } from './PlanJsonPreview'
 
 const item = {
@@ -33,14 +34,28 @@ const mockFile = (content: string, options?: { truncated?: boolean }): void => {
 
 beforeEach(() => {
   readPreview.mockReset()
+  const transport = createManagedPreviewTestTransport({
+    read: (_source, request) => readPreview(request)
+  })
   Object.defineProperty(window, 'api', {
     configurable: true,
-    value: { artifacts: { readPreview } }
+    value: {
+      previewResources: {
+        acquire: vi.fn(transport.acquire),
+        readRange: vi.fn(),
+        release: vi.fn(transport.release)
+      },
+      artifacts: { readPreview }
+    }
   })
+  vi.stubGlobal('fetch', vi.fn(transport.fetch))
   useSessionStore.setState({ sessions: [] })
 })
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
 
 describe('Plan-aware JSON preview', () => {
   it('renders the Plan document view for a previewed Plan artifact', async () => {

--- a/src/renderer/src/pages/workspace/previews/usePreviewFileContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/usePreviewFileContent.test.tsx
@@ -13,6 +13,17 @@ const Probe = (): React.JSX.Element => {
     path: 'upload-version:project-1/source-session/upload-version-1'
   })
 
+  return <div>{state.status === 'ready' ? state.preview.content : state.status}</div>
+}
+
+const SwitchingProbe = ({ path }: { path: string }): React.JSX.Element => {
+  const state = usePreviewFileContent({
+    projectId: 'project-1',
+    sessionId: 'session-1',
+    source: 'upload',
+    path
+  })
+
   return <div>{state.status}</div>
 }
 
@@ -24,6 +35,17 @@ describe('usePreviewFileContent', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     window.api = {
+      previewResources: {
+        acquire: vi.fn(async ({ path }: { path: string }) => ({
+          id: `resource:${path}`,
+          url: `https://preview.test/${encodeURIComponent(path)}`,
+          size: 15,
+          mimeType: 'text/plain',
+          version: 1
+        })),
+        readRange: vi.fn(),
+        release: vi.fn().mockResolvedValue(undefined)
+      },
       uploads: {
         readPreview: vi.fn().mockResolvedValue({
           content: 'group,count\nA,2',
@@ -33,24 +55,113 @@ describe('usePreviewFileContent', () => {
         })
       }
     } as unknown as Window['api']
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('group,count\nA,2', { status: 206 }))
+    )
   })
 
   afterEach(async () => {
     await act(async () => root?.unmount())
     container.remove()
+    vi.unstubAllGlobals()
   })
 
-  it('keeps project and session scope when reading a version-backed upload', async () => {
+  it('keeps project and session scope when acquiring a version-backed upload', async () => {
     root = createRoot(container)
     await act(async () => root.render(<Probe />))
 
-    expect(window.api.uploads.readPreview).toHaveBeenCalledWith({
+    expect(window.api.previewResources.acquire).toHaveBeenCalledWith({
       projectId: 'project-1',
       sessionId: 'source-session',
-      path: 'upload-version:project-1/source-session/upload-version-1',
-      maxBytes: 1024 * 1024,
-      encoding: 'utf8',
-      offset: 0
+      source: 'upload',
+      path: 'upload-version:project-1/source-session/upload-version-1'
     })
+    expect(fetch).toHaveBeenCalledWith(
+      'https://preview.test/upload-version%3Aproject-1%2Fsource-session%2Fupload-version-1',
+      {
+        cache: 'no-store',
+        headers: { Range: 'bytes=0-14' },
+        signal: expect.any(AbortSignal)
+      }
+    )
+    expect(window.api.previewResources.release).toHaveBeenCalledWith({
+      resourceId: 'resource:upload-version:project-1/source-session/upload-version-1'
+    })
+    expect(container.textContent).toBe('group,count\nA,2')
+  })
+
+  it('does not leave concurrent direct preview reads when switching files', async () => {
+    let activeDirectReads = 0
+    vi.mocked(window.api.uploads.readPreview).mockImplementation(
+      () =>
+        new Promise(() => {
+          activeDirectReads += 1
+        })
+    )
+    const signals: AbortSignal[] = []
+    vi.mocked(fetch).mockImplementation(
+      (_input, init) =>
+        new Promise((_resolve, reject) => {
+          const signal = init?.signal
+          if (!(signal instanceof AbortSignal)) throw new Error('Preview fetch signal is missing.')
+          signals.push(signal)
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+        })
+    )
+    root = createRoot(container)
+
+    await act(async () => root.render(<SwitchingProbe path="/managed/first.txt" />))
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1))
+    await act(async () => root.render(<SwitchingProbe path="/managed/second.txt" />))
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2))
+
+    expect(activeDirectReads).toBeLessThanOrEqual(1)
+    expect(signals[0]?.aborted).toBe(true)
+    expect(window.api.previewResources.release).toHaveBeenCalledWith({
+      resourceId: 'resource:/managed/first.txt'
+    })
+  })
+
+  it('requests the next UTF-8 page from the previous byte boundary', async () => {
+    vi.mocked(window.api.previewResources.acquire).mockResolvedValue({
+      id: 'resource:utf8',
+      url: 'https://preview.test/utf8',
+      size: 8,
+      mimeType: 'text/plain',
+      version: 1
+    })
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(new Response(new TextEncoder().encode('abcé'), { status: 206 }))
+      .mockResolvedValueOnce(new Response(new TextEncoder().encode('xyz'), { status: 206 }))
+
+    const PaginatedProbe = (): React.JSX.Element => {
+      const state = usePreviewFileContent({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        source: 'upload',
+        path: '/managed/utf8.txt',
+        maxBytes: 4
+      })
+      return state.status === 'ready' ? (
+        <button type="button" onClick={state.pagination.nextPage}>
+          {state.preview.content}
+        </button>
+      ) : (
+        <div>{state.status}</div>
+      )
+    }
+
+    root = createRoot(container)
+    await act(async () => root.render(<PaginatedProbe />))
+    expect(container.textContent).toBe('abcé')
+
+    await act(async () => container.querySelector('button')?.click())
+
+    expect(fetch).toHaveBeenLastCalledWith(
+      'https://preview.test/utf8',
+      expect.objectContaining({ headers: { Range: 'bytes=5-7' } })
+    )
+    expect(container.textContent).toBe('xyz')
   })
 })

--- a/src/renderer/src/pages/workspace/previews/usePreviewFileContent.ts
+++ b/src/renderer/src/pages/workspace/previews/usePreviewFileContent.ts
@@ -95,6 +95,11 @@ const readManagedPreviewPage = async (
         signal: request.signal
       })
       if (!response.ok) {
+        if (response.status === 404) {
+          throw Object.assign(new Error('ENOENT: managed preview file is no longer available.'), {
+            code: 'ENOENT'
+          })
+        }
         throw new Error(`Managed preview request failed with status ${response.status}.`)
       }
       size = readResponseSize(response, resource.size)

--- a/src/renderer/src/pages/workspace/previews/usePreviewFileContent.ts
+++ b/src/renderer/src/pages/workspace/previews/usePreviewFileContent.ts
@@ -3,10 +3,11 @@ import { useEffect, useState } from 'react'
 import type { ArtifactPreviewResult } from '../../../../../shared/artifacts'
 import type { PreviewFileSource } from '@/stores/preview-workbench-store'
 
-import { createPreviewRequestScope, getPreviewFileReader } from './preview-file-reader'
+import { createPreviewRequestScope } from './preview-file-reader'
 import { isUnavailableFileError } from './preview-errors'
 
 export const PREVIEW_TEXT_MAX_BYTES = 1024 * 1024
+const MAX_PREVIEW_BYTES = 10 * 1024 * 1024
 
 type PreviewPagination = {
   pageNumber: number
@@ -33,6 +34,96 @@ type UsePreviewFileContentRequest = {
   source?: PreviewFileSource
   maxBytes?: number
   encoding?: 'utf8' | 'base64'
+}
+
+const encodeBase64 = (bytes: Uint8Array): string => {
+  let binary = ''
+  for (let offset = 0; offset < bytes.length; offset += 32 * 1024) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 32 * 1024))
+  }
+  return btoa(binary)
+}
+
+const readResponseSize = (response: Response, fallback: number): number => {
+  const contentRange = response.headers.get('content-range')
+  const match = contentRange?.match(/\/(\d+)$/u)
+  if (!match) return fallback
+
+  const size = Number(match[1])
+  return Number.isSafeInteger(size) && size >= 0 ? size : fallback
+}
+
+const readManagedPreviewPage = async (
+  request: UsePreviewFileContentRequest & {
+    source: PreviewFileSource
+    maxBytes: number
+    encoding: 'utf8' | 'base64'
+    offset: number
+    signal: AbortSignal
+  }
+): Promise<ArtifactPreviewResult> => {
+  const requestScope = createPreviewRequestScope(request)
+  const resource = await window.api.previewResources.acquire({
+    source: request.source,
+    path: request.path,
+    ...requestScope
+  })
+
+  try {
+    if (request.signal.aborted) throw request.signal.reason
+
+    const requestedBytes = Number.isFinite(request.maxBytes)
+      ? Math.floor(request.maxBytes)
+      : PREVIEW_TEXT_MAX_BYTES
+    const maxBytes = Math.max(1, Math.min(requestedBytes, MAX_PREVIEW_BYTES))
+    if (
+      !Number.isSafeInteger(request.offset) ||
+      request.offset < 0 ||
+      request.offset > resource.size
+    ) {
+      throw new Error('Invalid managed file preview offset.')
+    }
+
+    const readBudget = request.encoding === 'utf8' ? maxBytes + 3 : maxBytes
+    const end = Math.min(resource.size, request.offset + readBudget)
+    let bytes = new Uint8Array()
+    let size = resource.size
+    if (end > request.offset) {
+      const response = await fetch(resource.url, {
+        cache: 'no-store',
+        headers: { Range: `bytes=${request.offset}-${end - 1}` },
+        signal: request.signal
+      })
+      if (!response.ok) {
+        throw new Error(`Managed preview request failed with status ${response.status}.`)
+      }
+      size = readResponseSize(response, resource.size)
+      bytes = new Uint8Array(await response.arrayBuffer())
+    }
+
+    let contentBytesRead = Math.min(bytes.length, maxBytes)
+    if (request.encoding === 'utf8') {
+      while (contentBytesRead < bytes.length && (bytes[contentBytesRead] & 0xc0) === 0x80) {
+        contentBytesRead += 1
+      }
+    }
+    const contentBytes = bytes.subarray(0, contentBytesRead)
+    const nextOffset = request.offset + contentBytesRead
+
+    return {
+      content:
+        request.encoding === 'utf8'
+          ? new TextDecoder().decode(contentBytes)
+          : encodeBase64(contentBytes),
+      encoding: request.encoding,
+      size,
+      truncated: size > nextOffset,
+      offset: request.offset,
+      ...(size > nextOffset ? { nextOffset } : {})
+    }
+  } finally {
+    await window.api.previewResources.release({ resourceId: resource.id }).catch(() => undefined)
+  }
 }
 
 // Centralizes artifact/upload preview reads so each renderer only handles parsing and display.
@@ -71,19 +162,23 @@ export const usePreviewFileContent = ({
 
   useEffect(() => {
     let canceled = false
-    const readPreview = getPreviewFileReader(source)
+    const abortController = new AbortController()
 
-    void readPreview({
-      ...createPreviewRequestScope({ projectId, sessionId, source, path }),
+    void readManagedPreviewPage({
+      projectId,
+      sessionId,
+      source,
       path,
       maxBytes,
       encoding,
-      offset
+      offset,
+      signal: abortController.signal
     })
       .then((preview) => {
         if (!canceled) setState({ status: 'ready', preview, requestKey })
       })
       .catch((error) => {
+        if (canceled) return
         // Unavailable files (missing / outside storage) surface as a handled preview state; only
         // log genuine read failures to avoid console noise for deleted/relocated files.
         if (!isUnavailableFileError(error)) console.error('Failed to read file preview', error)
@@ -92,6 +187,7 @@ export const usePreviewFileContent = ({
 
     return () => {
       canceled = true
+      abortController.abort()
     }
   }, [encoding, maxBytes, offset, path, projectId, requestKey, sessionId, source])
 

--- a/src/renderer/src/pages/workspace/previews/useUnavailablePreviewProbe.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/useUnavailablePreviewProbe.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useUnavailablePreviewProbe } from './useUnavailablePreviewProbe'
+
+const Probe = ({ size, mtimeMs }: { size: number; mtimeMs: number }): React.JSX.Element => {
+  const missing = useUnavailablePreviewProbe({
+    enabled: true,
+    projectId: 'project-1',
+    sessionId: 'session-1',
+    source: 'upload',
+    path: '/managed/upload.csv',
+    size,
+    mtimeMs
+  })
+
+  return <div data-missing={String(missing)} />
+}
+
+describe('useUnavailablePreviewProbe', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let readPreview: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    readPreview = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+      .mockResolvedValue({
+        content: 'YQ==',
+        encoding: 'base64',
+        size: 1,
+        truncated: false
+      })
+    window.api = { uploads: { readPreview } } as unknown as Window['api']
+    root = createRoot(container)
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    container.remove()
+  })
+
+  it('re-probes the same path when its file version metadata changes', async () => {
+    await act(async () => root.render(<Probe size={10} mtimeMs={100} />))
+    expect(container.querySelector('div')?.dataset.missing).toBe('true')
+
+    await act(async () => root.render(<Probe size={12} mtimeMs={200} />))
+
+    expect(readPreview).toHaveBeenCalledTimes(2)
+    expect(container.querySelector('div')?.dataset.missing).toBe('false')
+  })
+})

--- a/src/renderer/src/pages/workspace/previews/useUnavailablePreviewProbe.ts
+++ b/src/renderer/src/pages/workspace/previews/useUnavailablePreviewProbe.ts
@@ -16,15 +16,26 @@ const useUnavailablePreviewProbe = ({
   projectId,
   sessionId,
   path,
-  source
+  source,
+  size,
+  mtimeMs
 }: {
   enabled: boolean
   projectId?: string
   sessionId?: string
   path: string
   source: PreviewFileSource
+  size?: number
+  mtimeMs?: number
 }): boolean => {
-  const requestKey = JSON.stringify([projectId ?? null, sessionId ?? null, source, path])
+  const requestKey = JSON.stringify([
+    projectId ?? null,
+    sessionId ?? null,
+    source,
+    path,
+    size ?? null,
+    mtimeMs ?? null
+  ])
   const [result, setResult] = useState<UnavailableProbeResult | null>(null)
   const hasCurrentResult = result?.requestKey === requestKey
 

--- a/src/renderer/src/pages/workspace/project-files-presentation-owner.tsx
+++ b/src/renderer/src/pages/workspace/project-files-presentation-owner.tsx
@@ -209,7 +209,9 @@ const FileTile = ({
     projectId,
     sessionId,
     path: previewArtifact.path,
-    source
+    source,
+    size,
+    mtimeMs: timestamp
   })
 
   return (
@@ -296,7 +298,9 @@ const FileListRow = ({
     projectId: file.projectId,
     sessionId: file.sessionId,
     path: file.path,
-    source: file.source
+    source: file.source,
+    size: file.size,
+    mtimeMs: file.mtimeMs
   })
   const sizeLabel = formatByteSize(file.size)
   const relativeTimeLabel = formatRelativeFileTime(file.mtimeMs ?? file.sortAtMs, t)


### PR DESCRIPTION
## Summary

- skip preview saves when a store notification has the same durable projection as the accepted, pending, or in-flight snapshot
- maintain a renderer-lifetime incremental Upload index keyed by upload preview id, invalidated by immutable Session replacement and deletion
- move text preview pages onto the existing managed Range stream so rapid navigation aborts obsolete reads and releases capabilities
- include existing size and mtime metadata in unavailable-probe identity so in-place file changes are re-probed

## Reproduction and regression coverage

Focused regressions were added before the production changes. On the unmodified code they failed deterministically because:

- a runtime-only tool update performed one preview.save instead of zero
- Project A to B to A read the same hydrated Session messages twice instead of once
- switching files left two unresolved direct preview reads instead of aborting the obsolete stream
- changing size and mtime for the same path performed one unavailable probe instead of two

All four pass after the fix, along with the surrounding preview consumers and existing Main managed-stream cancellation contract.

## Validation

- npm test -- [8 focused files]: 98 passed
- npm run typecheck:web
- targeted ESLint for all changed source and test files
- git diff --check

The affected-test planner conservatively selected the full suite because the new regression test is not yet represented in the module-impact manifest. Per request, the full local npm test was not run; PR CI is the complete-suite authority.

## Compatibility and data impact

- Historical compatibility: none required; persisted preview and Session shapes are unchanged
- New states or enum values: none
- Persistence: no fields, schema, migration, or revision format changes; semantically identical snapshots now stop before IPC and database revision writes
- Public contracts and interaction: no new IPC/API surface and no intentional UI change