### PR TITLE
docs(architecture): define external component lifecycle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,7 @@ Three runtime process layers and a shared module live under `src/`:
 Before adding a resource that survives its creating process outside app-managed storage or in a
 third-party control plane, follow the
 [durable external component ownership contract](docs/PRD.md#durable-external-component-ownership).
+The same contract applies when adding a new create, adopt, or remove path to an existing component.
 The pull request must identify:
 
 - the module that owns the component and the exact identity or receipt recorded at creation;
@@ -113,7 +114,9 @@ The pull request must identify:
 - any persisted-format, historical-compatibility, or new-state impact.
 
 A future cleanup hook is not sufficient: do not ship creation until the owner can stop and remove
-the component safely.
+the component safely. If the PR changes a known legacy exception listed in the contract, it must
+either migrate that path to proven ownership or document the bounded exception and its historical
+compatibility plan; do not use an exception as precedent for new behavior.
 
 ### Database schema changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,24 @@ Three runtime process layers and a shared module live under `src/`:
    ownership, consumers, or risks cannot be established.
 5. Open a pull request with a clear description of the change and its motivation.
 
+### Durable external components
+
+Before adding a resource that survives its creating process outside app-managed storage or in a
+third-party control plane, follow the
+[durable external component ownership contract](docs/PRD.md#durable-external-component-ownership).
+The pull request must identify:
+
+- the module that owns the component and the exact identity or receipt recorded at creation;
+- create/start, stop, removal, crash-recovery, and application-uninstall behavior;
+- how cleanup fails closed without scanning system directories or touching shared, user-managed, or
+  otherwise unproven resources;
+- the platform-specific tests for stop-before-remove ordering, retry, idempotency, and preservation
+  of unowned resources; and
+- any persisted-format, historical-compatibility, or new-state impact.
+
+A future cleanup hook is not sufficient: do not ship creation until the owner can stop and remove
+the component safely.
+
 ### Database schema changes
 
 `prisma/schema.prisma` owns tables, columns, defaults, indexes, and foreign keys. SQLite CHECK

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -95,8 +95,9 @@ agents, system services, scheduled tasks, command launchers, shared caches, and 
 service records. A child process that is stopped with its owning runtime is not durable, but its
 owner must still dispose it through the normal runtime lifecycle.
 
-Every new durable external component must ship with one owning module and a complete lifecycle
-contract from its first release:
+Every new durable external component, and every new create, adopt, or remove path added to an
+existing component, must ship with one owning module and a complete lifecycle contract from its
+first release:
 
 - Record an exact immutable identifier, canonical path, or ownership receipt when creation succeeds.
   If creation and receipt persistence cannot be atomic, use a crash-recoverable journal that makes
@@ -113,14 +114,24 @@ contract from its first release:
 - Cover creation, stop-before-remove ordering, interrupted-cleanup retry, repeated removal, and
   preservation of unowned or shared resources on every supported platform where behavior differs.
 
-Current external effects use feature-local ownership evidence rather than a generic registry. The
-command-line launcher verifies its exact target and managed content marker before replacement or
-removal. Windows managed-runtime cache cleanup requires a provenance marker and trusted ownership.
-Remote access does not install its third-party agent, but it does persist the exact IDs of two
-provider-managed service records. Turning remote access off deliberately retains those records for
-reuse; a future complete-removal workflow must continue to operate on the recorded IDs rather than
-discovering candidates by scanning or name matching. Custom stdio Connector processes remain
-process-scoped and are closed by Connector deletion and application shutdown.
+Current external effects use feature-local ownership evidence rather than a generic registry. This
+inventory records both guarded paths and known legacy exceptions; it is not a claim that every
+existing cleanup path already satisfies the contract:
+
+- The command-line launcher verifies its exact target and managed content marker before replacement
+  or removal.
+- One Windows managed-runtime cache cleanup path validates a provenance marker and trusted
+  ownership. Legacy and reactive cleanup paths also remove the canonical cache location using path
+  and content heuristics; these are known exceptions. Work that changes those paths must decide how
+  to handle pre-marker caches and must not broaden destructive cleanup without proven ownership.
+- Remote access does not install its third-party agent and persists the exact IDs of the two
+  provider-managed service records it creates. When those saved IDs are absent, however, current
+  recovery can adopt records matched by the expected name and loopback endpoint; this is a known
+  exception. Work on recovery or complete removal must define compatibility for pre-ID settings and
+  move to recorded IDs or a crash-recoverable creation receipt before modifying or removing a
+  candidate. Turning remote access off deliberately retains the records for reuse.
+- Custom stdio Connector processes remain process-scoped and are closed by Connector deletion and
+  application shutdown.
 
 The Composer owns the desired model and reasoning-effort preference for its Session. On Session
 selection, the renderer validates that preference against the current provider inventory and ACP

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -87,6 +87,41 @@ do not become alternate state stores.
 | Notebook runtime                | Own runtime discovery, Session binding decisions, execution, environment operations, and durable run history. It consumes enablement snapshots through the named Settings capability rather than owning or reading raw Settings state.                                                                                                                                                            |
 | Persistence and artifact owners | Own project/session files, uploads, artifact versions, provenance, and deletion/finalization coordination. Application commands receive narrow handler capabilities instead of repositories.                                                                                                                                                                                                      |
 
+### Durable external component ownership
+
+A durable external component is a resource created by Open Science that survives its creating
+process outside app-managed storage or in a third-party control plane. Examples include launch
+agents, system services, scheduled tasks, command launchers, shared caches, and provider-managed
+service records. A child process that is stopped with its owning runtime is not durable, but its
+owner must still dispose it through the normal runtime lifecycle.
+
+Every new durable external component must ship with one owning module and a complete lifecycle
+contract from its first release:
+
+- Record an exact immutable identifier, canonical path, or ownership receipt when creation succeeds.
+  If creation and receipt persistence cannot be atomic, use a crash-recoverable journal that makes
+  interrupted creation and cleanup retryable.
+- Define how the owner creates or starts, stops, removes, and reconciles the component, including the
+  app-uninstall path. When a platform has no application-uninstall hook, expose an explicit removal
+  action before the component ships and document when the user must run it.
+- Stop the component before removing its files or registration. Both stop and removal must be
+  idempotent, preserve shared and user-managed resources, and fail closed when ownership cannot be
+  proved.
+- Never infer ownership by broadly scanning system directories, matching names alone, or adopting an
+  unrecorded resource that merely resembles an app-created component. Recovery may query the exact
+  recorded identity and validate immutable ownership evidence.
+- Cover creation, stop-before-remove ordering, interrupted-cleanup retry, repeated removal, and
+  preservation of unowned or shared resources on every supported platform where behavior differs.
+
+Current external effects use feature-local ownership evidence rather than a generic registry. The
+command-line launcher verifies its exact target and managed content marker before replacement or
+removal. Windows managed-runtime cache cleanup requires a provenance marker and trusted ownership.
+Remote access does not install its third-party agent, but it does persist the exact IDs of two
+provider-managed service records. Turning remote access off deliberately retains those records for
+reuse; a future complete-removal workflow must continue to operate on the recorded IDs rather than
+discovering candidates by scanning or name matching. Custom stdio Connector processes remain
+process-scoped and are closed by Connector deletion and application shutdown.
+
 The Composer owns the desired model and reasoning-effort preference for its Session. On Session
 selection, the renderer validates that preference against the current provider inventory and ACP
 framework. An unavailable preference is lazily replaced only when the Settings default is itself


### PR DESCRIPTION
## Problem

The architecture documents do not define a repository-wide ownership and removal contract for
durable resources created outside app-managed storage or in a third-party control plane. A future
service, launcher, cache, or provider-managed resource could therefore ship without exact ownership
evidence or a safe cleanup path.

## Proposed change

- Define durable external components and require one owning module with complete create/start, stop,
  remove, recovery, and application-uninstall behavior.
- Require exact ownership evidence, stop-before-remove ordering, idempotent cleanup, fail-closed
  handling, and preservation of shared or user-managed resources.
- Inventory guarded ownership paths and known legacy exceptions without introducing a generic
  runtime registry or claiming that existing exceptions are already compliant.
- Add the same requirements to the contributor workflow, including explicit compatibility,
  persistence, state, and platform-test impact.

## Scope and non-goals

- Documentation and contributor policy only.
- No runtime behavior, persisted format, data migration, enum, or user interaction changes.
- No generic external-component registry or cleanup framework.
- No change to existing remote-access or application-uninstaller behavior.

## Compatibility, state, and persistence

- This PR requires no historical-data migration and adds no persisted fields, enum values, or
  runtime state.
- Future remote-access hardening must decide how to handle settings created without saved provider
  record IDs before disabling name-and-endpoint adoption.
- Future Windows cache hardening must decide how to handle pre-marker cache directories before
  requiring provenance evidence in every cleanup path.

## Acceptance criteria and validation

Checks ran after the last material edit:

- Markdown formatting -> `/Users/eweno/projects/aipoch/open-science/node_modules/.bin/prettier --check CONTRIBUTING.md docs/PRD.md` -> passed.
- Patch integrity -> `git diff --check` -> passed.

No module tests or process typechecks were selected because the final diff changes documentation
only. Consumer and platform lanes are excluded locally for the same reason; PR CI remains the final
validation authority. The remaining risk is that this contract is review-enforced rather than an
automated architecture check.

## Review focus

- Whether the ownership proof and fail-closed removal requirements are strict enough without
  prescribing a premature generic registry.
- Whether the contributor checklist captures the required lifecycle and compatibility evidence for
  future platform-specific components.
