### PR TITLE
fix(notebook): compact REPL errors in state context

### DIFF
--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -1786,6 +1786,40 @@ describe('compactNotebookStateResult', () => {
     expect(JSON.stringify(compact)).not.toContain('image/png')
   })
 
+  it('keeps REPL connector guidance without exposing its host stack through notebook_state', () => {
+    const message =
+      'Error: connector call rejected: invalid_arguments. Invalid tool arguments for biomart/get_data: field "mart" is required. Correct the arguments to match the Input schema in the loaded mcp-biomart Skill, then retry the same method once. Do not retry unchanged or bypass host.mcp.'
+    const traceback = [
+      message,
+      '    at Object.hostMcp [as mcp] (/Users/alice/open-science/resources/notebook/repl_loop.js:1024:22)',
+      '    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)',
+      '    at async <repl>:3:20',
+      '    at async run (/Users/alice/open-science/resources/notebook/repl_loop.js:3562:19)'
+    ].join('\n')
+    const state = {
+      sessionId: 'session-1',
+      runs: [
+        {
+          runId: 'run-1',
+          kernelKind: 'repl',
+          status: 'failed',
+          text: { stdout: '', stderr: '', traceback, plain: [] }
+        }
+      ]
+    }
+
+    const compact = compactNotebookStateResult(state) as {
+      recentRuns: Array<{ outputPreview?: string }>
+    }
+    const serialized = JSON.stringify(compact)
+
+    expect(compact.recentRuns[0].outputPreview).toBe(message)
+    expect(serialized).not.toContain('node:internal')
+    expect(serialized).not.toContain('<repl>')
+    expect(serialized).not.toContain('repl_loop.js')
+    expect(state.runs[0].text.traceback).toBe(traceback)
+  })
+
   it('bounds dependency staleness on compact recent runs', () => {
     const recentRuns = Array.from({ length: 10 }, (_, index) => ({
       runId: `run-${index}`,

--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -1529,6 +1529,39 @@ describe('compactNotebookExecutionResult', () => {
     expect(raw.outputs[0].traceback).toBe(traceback)
   })
 
+  it('keeps connector guidance while omitting host MCP stack frames from the agent-facing error', () => {
+    const message =
+      'Error: connector call rejected: invalid_arguments. Invalid tool arguments for biomart/get_data: field "mart" is required. Correct the arguments to match the Input schema in the loaded mcp-biomart Skill, then retry the same method once. Do not retry unchanged or bypass host.mcp.'
+    const traceback = [
+      message,
+      '    at Object.hostMcp [as mcp] (/Users/alice/open-science/resources/notebook/repl_loop.js:1024:22)',
+      '    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)',
+      '    at async <repl>:3:20',
+      '    at async run (/Users/alice/open-science/resources/notebook/repl_loop.js:3562:19)',
+      '    at async /Users/alice/open-science/resources/notebook/repl_loop.js:3608:20'
+    ].join('\n')
+    const replTool = NOTEBOOK_RPC_TOOLS.find((entry) => entry.name === 'repl_execute')
+    const summary = runSummary({ traceback })
+    const raw = {
+      ...summary,
+      status: 'failed',
+      outputs: [{ type: 'error', message, traceback }]
+    }
+
+    const compact = replTool?.mapResult?.(raw, {}) as {
+      traceback: string
+      outputs: Array<Record<string, unknown>>
+    }
+
+    expect(compact.traceback).toBe(message)
+    expect(compact.outputs).toEqual([{ type: 'error', message }])
+    expect(JSON.stringify(compact)).not.toContain('node:internal')
+    expect(JSON.stringify(compact)).not.toContain('<repl>')
+    expect(JSON.stringify(compact)).not.toContain('repl_loop.js')
+    expect((summary.text as { traceback: string }).traceback).toBe(traceback)
+    expect(raw.outputs[0].traceback).toBe(traceback)
+  })
+
   it('keeps the actionable SyntaxError after the VM source preamble', () => {
     const traceback = [
       '<repl>:2',

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -723,9 +723,14 @@ const compactStateRun = (
   const record = asRecord(value)
   if (!record) return value
   const text = asRecord(record.text)
-  const diagnosticOutput = ['traceback', 'stderr', 'stdout']
-    .map((field) => text?.[field])
-    .find((candidate) => typeof candidate === 'string' && candidate.length > 0)
+  const traceback = text?.traceback
+  const diagnosticOutput = [
+    record.kernelKind === 'repl' && typeof traceback === 'string'
+      ? compactReplTraceback(traceback)
+      : traceback,
+    text?.stderr,
+    text?.stdout
+  ].find((candidate) => typeof candidate === 'string' && candidate.length > 0)
   const displayOutput = Array.isArray(record.outputs)
     ? record.outputs
         .map((candidate) => {


### PR DESCRIPTION
## Problem

Failed control-plane REPL calls retain a full traceback for the Notebook UI and durable run record. The direct `repl_execute` MCP response already keeps only actionable error guidance, but a later `notebook_state` call projected the persisted traceback verbatim into Agent context. A real BioMart validation failure therefore exposed `host.mcp`, Node internals, `<repl>`, and `repl_loop.js` frames through this second path.

## Proposed change

- Keep the existing compact `repl_execute` response behavior and its real connector-error regression fixture.
- Reuse the same REPL traceback compaction when `notebook_state` builds the latest run's `outputPreview`.
- Apply the new projection only to `kernelKind: "repl"`; Python/R tracebacks and stderr/stdout retain their existing behavior.
- Assert that the input state still contains the complete traceback after projection.

## Scope and non-goals

The change is limited to the Agent-facing state projection in the shared app-owned `open-science-notebook` MCP server used by `claude-code`, `opencode`, `codex-response`, and `codex-bridge`. No framework-specific adapter or OS path transforms this result.

- Historical compatibility: no migration is required. Existing and future durable runs keep their raw traceback, and are compacted only when projected to Agent context.
- Enum/status additions: none.
- Persistence: no schema, format, or stored-content change. Notebook UI and durable run data continue to retain the full stack.

## Acceptance criteria and validation

Final local checks after the last material edit:

- `npm test -- src/main/notebook/mcp-server.test.ts` -> passed, 83 tests.
- `npm run typecheck:node` -> passed.
- `npm run lint -- --no-cache src/main/notebook/mcp-server.ts src/main/notebook/mcp-server.test.ts` -> passed.
- `git diff --check` -> passed.
- `npm run test:affected -- --base origin/main --head HEAD --explain` -> conservatively selected the complete Vitest suite because `mcp-server.ts` has no module owner; per project workflow, the complete matrix is delegated to exact-head PR CI.

Uncovered local risk: no live provider session was run. The regression is exercised at the shared serialized MCP boundary; exact-head PR CI remains the final validation authority.

## Review focus

Confirm that both Agent-facing paths omit internal REPL frames while preserving the connector's correction guidance, and that `notebook_state` compaction does not mutate the full traceback consumed by Notebook UI or durable run storage.
