### PR TITLE
test(coverage): cover high-risk boundary logic

### DIFF
--- a/src/main/specialist/package/semver.test.ts
+++ b/src/main/specialist/package/semver.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import { compareSemver } from './semver'
+
+describe('compareSemver', () => {
+  it('orders major, minor, and patch versions', () => {
+    expect(compareSemver('1.0.0', '2.0.0')).toBe(-1)
+    expect(compareSemver('2.1.0', '2.0.9')).toBe(1)
+    expect(compareSemver('2.1.1', '2.1.0')).toBe(1)
+    expect(compareSemver('2.1.1', '2.1.1')).toBe(0)
+  })
+
+  it('follows SemVer prerelease precedence', () => {
+    const precedence = [
+      '1.0.0-alpha',
+      '1.0.0-alpha.1',
+      '1.0.0-alpha.beta',
+      '1.0.0-beta',
+      '1.0.0-beta.2',
+      '1.0.0-beta.11',
+      '1.0.0-rc.1',
+      '1.0.0'
+    ]
+
+    for (let index = 0; index < precedence.length - 1; index += 1) {
+      expect(compareSemver(precedence[index], precedence[index + 1])).toBe(-1)
+      expect(compareSemver(precedence[index + 1], precedence[index])).toBe(1)
+    }
+  })
+
+  it('orders numeric prerelease identifiers before non-numeric identifiers', () => {
+    expect(compareSemver('1.0.0-1', '1.0.0-alpha')).toBe(-1)
+    expect(compareSemver('1.0.0-alpha.2', '1.0.0-alpha.11')).toBe(-1)
+    expect(compareSemver('1.0.0-alpha', '1.0.0-alpha')).toBe(0)
+  })
+
+  it('ignores build metadata when comparing precedence', () => {
+    expect(compareSemver('1.2.3+build.1', '1.2.3+build.2')).toBe(0)
+    expect(compareSemver('1.2.3-alpha+linux', '1.2.3-alpha+windows')).toBe(0)
+  })
+
+  it.each([
+    ['1.0', '1.0.0'],
+    ['v1.0.0', '1.0.0'],
+    ['1.01.0', '1.1.0'],
+    ['not-a-version', '1.0.0'],
+    ['1.0.0', '']
+  ])('returns undefined when either input is invalid: %s / %s', (left, right) => {
+    expect(compareSemver(left, right)).toBeUndefined()
+  })
+})

--- a/src/renderer/src/stores/settings-preferences-slice.test.ts
+++ b/src/renderer/src/stores/settings-preferences-slice.test.ts
@@ -2,11 +2,16 @@ import { createStore, type StoreApi } from 'zustand/vanilla'
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 
 import type { PackageMirror } from '../../../shared/mirror'
+import type { NetworkProxySettings } from '../../../shared/network-proxy'
 import type {
   AppIconVariant,
   ProjectFilesFilterPreference,
   ReasoningEffort,
-  SettingsSnapshot
+  ReviewerModelConfiguration,
+  SessionDetailsModelConfiguration,
+  SettingsSnapshot,
+  SubagentModelConfiguration,
+  VisionModelConfiguration
 } from '../../../shared/settings'
 import type { CloseActionPreference } from '../../../shared/window-controls'
 import type { PermissionProfileId } from '../../../shared/permission-profiles'
@@ -19,6 +24,11 @@ import { createSettingsWriteCoordinator } from './settings-write-coordinator'
 type PreferencesCommands = Pick<
   Window['api']['settings'],
   | 'setReasoningEffort'
+  | 'getSettings'
+  | 'setReviewerModel'
+  | 'setSessionDetailsModel'
+  | 'setSubagentModel'
+  | 'setVisionModel'
   | 'setNotificationsEnabled'
   | 'setConversationSkillImportEnabled'
   | 'setClosePreference'
@@ -27,14 +37,24 @@ type PreferencesCommands = Pick<
   | 'setDefaultPermissionProfile'
   | 'markOnboardingComplete'
   | 'setPackageMirror'
+  | 'setNetworkProxy'
 >
 
-type CommandMocks = { [Command in keyof PreferencesCommands]: Mock }
+type CommandMocks = Required<{ [Command in keyof PreferencesCommands]: Mock }>
 
 type TestStore = SettingsPreferencesActions & {
   onboardingCompletedAt?: number
+  networkProxy?: NetworkProxySettings
   packageMirror?: PackageMirror
   reasoningEffort: ReasoningEffort
+  reviewerModel?: ReviewerModelConfiguration
+  reviewerModelPending?: boolean
+  sessionDetailsModel?: SessionDetailsModelConfiguration
+  sessionDetailsModelPending?: boolean
+  subagentModel?: SubagentModelConfiguration
+  subagentModelPending?: boolean
+  visionModel?: VisionModelConfiguration
+  visionModelPending?: boolean
   notificationsEnabled: boolean
   conversationSkillImportEnabled: boolean
   closePreference: CloseActionPreference | undefined
@@ -88,7 +108,14 @@ const createCommands = (persisted: Partial<SettingsSnapshot>): CommandMocks => {
     Promise.resolve(snapshot({ ...persisted, [key]: (persisted[key] = value) }))
 
   return {
+    getSettings: vi.fn(() => Promise.resolve(snapshot(persisted))),
     setReasoningEffort: vi.fn(({ effort }) => save('reasoningEffort', effort)),
+    setReviewerModel: vi.fn(({ configuration }) => save('reviewerModel', configuration)),
+    setSessionDetailsModel: vi.fn(({ configuration }) =>
+      save('sessionDetailsModel', configuration)
+    ),
+    setSubagentModel: vi.fn(({ configuration }) => save('subagentModel', configuration)),
+    setVisionModel: vi.fn(({ configuration }) => save('visionModel', configuration)),
     setNotificationsEnabled: vi.fn(({ enabled }) => save('notificationsEnabled', enabled)),
     setConversationSkillImportEnabled: vi.fn(({ enabled }) =>
       save('conversationSkillImportEnabled', enabled)
@@ -98,7 +125,8 @@ const createCommands = (persisted: Partial<SettingsSnapshot>): CommandMocks => {
     setProjectFilesFilter: vi.fn(({ filter }) => save('projectFilesFilter', filter)),
     setDefaultPermissionProfile: vi.fn(({ profile }) => save('defaultPermissionProfile', profile)),
     markOnboardingComplete: vi.fn().mockResolvedValue(snapshot({ onboardingCompletedAt: 42 })),
-    setPackageMirror: vi.fn((mirror) => Promise.resolve(mirror))
+    setPackageMirror: vi.fn((mirror) => Promise.resolve(mirror)),
+    setNetworkProxy: vi.fn((settings) => Promise.resolve(settings))
   }
 }
 
@@ -112,8 +140,13 @@ const createHarness = (): {
   const reconcileSnapshot = vi.fn((next: SettingsSnapshot) => {
     store.setState({
       onboardingCompletedAt: next.onboardingCompletedAt,
+      networkProxy: next.networkProxy,
       packageMirror: next.packageMirror,
       reasoningEffort: next.reasoningEffort,
+      reviewerModel: next.reviewerModel,
+      sessionDetailsModel: next.sessionDetailsModel,
+      subagentModel: next.subagentModel,
+      visionModel: next.visionModel,
       notificationsEnabled: next.notificationsEnabled,
       conversationSkillImportEnabled: next.conversationSkillImportEnabled,
       closePreference: next.closePreference,
@@ -124,6 +157,10 @@ const createHarness = (): {
   })
   const store = createStore<TestStore>((set, get) => ({
     reasoningEffort: 'default',
+    reviewerModelPending: false,
+    sessionDetailsModelPending: false,
+    subagentModelPending: false,
+    visionModelPending: false,
     notificationsEnabled: true,
     conversationSkillImportEnabled: true,
     closePreference: undefined,
@@ -230,5 +267,125 @@ describe('settings preferences slice', () => {
     commands.setPackageMirror.mockResolvedValueOnce({})
     await store.getState().setPackageMirror({})
     expect(store.getState().packageMirror).toBeUndefined()
+  })
+
+  it('persists scenario model preferences and clears their pending flags', async () => {
+    const reviewer = {
+      mode: 'fixed',
+      providerId: 'provider-1',
+      model: 'reviewer-model',
+      reasoningEffort: 'high'
+    } as const satisfies ReviewerModelConfiguration
+    const sessionDetails = {
+      mode: 'inherit',
+      reasoningEffort: 'low'
+    } as const satisfies SessionDetailsModelConfiguration
+    const subagent = {
+      mode: 'fixed',
+      providerId: 'provider-1',
+      model: 'subagent-model',
+      reasoningEffort: 'medium'
+    } as const satisfies SubagentModelConfiguration
+    const vision = {
+      providerId: 'provider-1',
+      model: 'vision-model',
+      reasoningEffort: 'default'
+    } as const satisfies VisionModelConfiguration
+
+    const reviewerWrite = store.getState().setReviewerModel(reviewer)
+    expect(store.getState().reviewerModelPending).toBe(true)
+    await reviewerWrite
+
+    const sessionDetailsWrite = store.getState().setSessionDetailsModel(sessionDetails)
+    expect(store.getState().sessionDetailsModelPending).toBe(true)
+    await sessionDetailsWrite
+
+    const subagentWrite = store.getState().setSubagentModel(subagent)
+    expect(store.getState().subagentModelPending).toBe(true)
+    await subagentWrite
+
+    const visionWrite = store.getState().setVisionModel(vision)
+    expect(store.getState().visionModelPending).toBe(true)
+    await visionWrite
+
+    expect(commands.setReviewerModel).toHaveBeenCalledWith({ configuration: reviewer })
+    expect(commands.setSessionDetailsModel).toHaveBeenCalledWith({ configuration: sessionDetails })
+    expect(commands.setSubagentModel).toHaveBeenCalledWith({ configuration: subagent })
+    expect(commands.setVisionModel).toHaveBeenCalledWith({ configuration: vision })
+    expect(store.getState()).toMatchObject({
+      reviewerModel: reviewer,
+      reviewerModelPending: false,
+      sessionDetailsModel: sessionDetails,
+      sessionDetailsModelPending: false,
+      subagentModel: subagent,
+      subagentModelPending: false,
+      visionModel: vision,
+      visionModelPending: false
+    })
+  })
+
+  it('refreshes settings and reports each rejected non-optimistic model write', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    commands.setReviewerModel.mockRejectedValueOnce(new Error('reviewer rejected'))
+    commands.setSubagentModel.mockRejectedValueOnce(new Error('subagent rejected'))
+    commands.setVisionModel.mockRejectedValueOnce(new Error('vision rejected'))
+
+    await store.getState().setReviewerModel({ mode: 'inherit' })
+    await store.getState().setSubagentModel({ mode: 'inherit' })
+    await store.getState().setVisionModel(undefined)
+
+    expect(commands.getSettings).toHaveBeenCalledTimes(3)
+    expect(reconcileSnapshot).toHaveBeenCalledTimes(3)
+    expect(store.getState()).toMatchObject({
+      reviewerModelPending: false,
+      subagentModelPending: false,
+      visionModelPending: false
+    })
+    expect(store.getState().settingsWriteError).toContain('Could not save Reviewer model.')
+    expect(store.getState().settingsWriteError).toContain('Could not save Subagent model.')
+    expect(store.getState().settingsWriteError).toContain('Could not save Vision model.')
+    expect(consoleError).toHaveBeenCalledTimes(3)
+  })
+
+  it('ignores a stale Reviewer model completion after a newer write settles', async () => {
+    const older = deferred<SettingsSnapshot>()
+    const newer = deferred<SettingsSnapshot>()
+    commands.setReviewerModel.mockReturnValueOnce(older.promise).mockReturnValueOnce(newer.promise)
+
+    const olderWrite = store.getState().setReviewerModel({ mode: 'inherit' })
+    const fixed = {
+      mode: 'fixed',
+      providerId: 'provider-1',
+      model: 'reviewer-model',
+      reasoningEffort: 'high'
+    } as const satisfies ReviewerModelConfiguration
+    const newerWrite = store.getState().setReviewerModel(fixed)
+
+    newer.resolve(snapshot({ reviewerModel: fixed }))
+    await newerWrite
+    older.resolve(snapshot({ reviewerModel: { mode: 'inherit' } }))
+    await olderWrite
+
+    expect(store.getState().reviewerModel).toEqual(fixed)
+    expect(store.getState().reviewerModelPending).toBe(false)
+    expect(reconcileSnapshot).toHaveBeenCalledOnce()
+  })
+
+  it('persists network proxy settings and fails closed when the command is unavailable', async () => {
+    const proxy = {
+      mode: 'manual',
+      server: 'http://127.0.0.1:1086',
+      bypassRules: 'localhost'
+    } as const satisfies NetworkProxySettings
+
+    await store.getState().setNetworkProxy(proxy)
+
+    expect(commands.setNetworkProxy).toHaveBeenCalledWith(proxy)
+    expect(store.getState().networkProxy).toEqual(proxy)
+
+    commands.setNetworkProxy = undefined as unknown as Mock
+    await expect(store.getState().setNetworkProxy({ mode: 'direct' })).rejects.toThrow(
+      'Network proxy settings are unavailable.'
+    )
   })
 })

--- a/src/shared/tool-detail-sanitizer.test.ts
+++ b/src/shared/tool-detail-sanitizer.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+
+import { capToolDetailText, sanitizeToolContent } from './tool-detail-sanitizer'
+
+describe('capToolDetailText', () => {
+  it('preserves bounded text and truncates oversized text at the shared limit', () => {
+    const bounded = 'x'.repeat(16_000)
+
+    expect(capToolDetailText(bounded)).toBe(bounded)
+    expect(capToolDetailText(`${bounded}tail`)).toBe(`${bounded}\n…`)
+  })
+})
+
+describe('sanitizeToolContent', () => {
+  it('keeps only supported content projections and strips unknown fields', () => {
+    expect(
+      sanitizeToolContent([
+        null,
+        { type: 'content', content: { type: 'text', text: 'result', secret: 'drop-me' } },
+        {
+          type: 'content',
+          content: {
+            type: 'resource_link',
+            uri: 'file:///report.csv',
+            name: 'report.csv',
+            title: 'Report',
+            description: 'drop-me'
+          }
+        },
+        {
+          type: 'content',
+          content: {
+            type: 'resource',
+            resource: { uri: 'file:///notes.txt', text: 'notes', blob: 'drop-me' }
+          }
+        },
+        { type: 'content', content: { type: 'image', data: 'drop-me' } }
+      ])
+    ).toEqual([
+      { type: 'content', content: { type: 'text', text: 'result' } },
+      {
+        type: 'content',
+        content: {
+          type: 'resource_link',
+          uri: 'file:///report.csv',
+          name: 'report.csv',
+          title: 'Report'
+        }
+      },
+      {
+        type: 'content',
+        content: { type: 'resource', resource: { uri: 'file:///notes.txt', text: 'notes' } }
+      }
+    ])
+  })
+
+  it('normalizes diffs and caps each text field independently', () => {
+    const oversized = 'x'.repeat(16_001)
+
+    expect(
+      sanitizeToolContent([
+        { type: 'diff', path: '/repo/new.ts', newText: 42 },
+        { type: 'diff', path: '', oldText: 'ignored', newText: 'ignored' }
+      ])
+    ).toEqual([{ type: 'diff', path: '/repo/new.ts', oldText: null, newText: '' }])
+    expect(
+      sanitizeToolContent([
+        { type: 'diff', path: '/repo/old.ts', oldText: oversized, newText: 'replacement' }
+      ])
+    ).toEqual([
+      {
+        type: 'diff',
+        path: '/repo/old.ts',
+        oldText: `${'x'.repeat(16_000)}\n…`,
+        newText: 'replacement'
+      }
+    ])
+    expect(
+      sanitizeToolContent([
+        { type: 'diff', path: '/repo/new.ts', oldText: 'original', newText: oversized }
+      ])
+    ).toEqual([
+      {
+        type: 'diff',
+        path: '/repo/new.ts',
+        oldText: 'original',
+        newText: `${'x'.repeat(16_000)}\n…`
+      }
+    ])
+  })
+
+  it('drops malformed or empty projections', () => {
+    expect(sanitizeToolContent(undefined)).toBeUndefined()
+    expect(
+      sanitizeToolContent([
+        'text',
+        { type: 'content', content: { type: 'text', text: '' } },
+        { type: 'content', content: { type: 'resource_link', uri: '' } },
+        { type: 'content', content: { type: 'resource', resource: {} } },
+        { type: 'terminal', terminalId: 'terminal-1' }
+      ])
+    ).toBeUndefined()
+  })
+
+  it('stops before an entry that would exceed the aggregate content budget', () => {
+    const result = sanitizeToolContent([
+      { type: 'content', content: { type: 'text', text: 'a'.repeat(16_000) } },
+      { type: 'content', content: { type: 'text', text: 'b'.repeat(16_000) } },
+      { type: 'content', content: { type: 'text', text: 'after-budget' } }
+    ])
+
+    expect(result).toEqual([
+      { type: 'content', content: { type: 'text', text: 'a'.repeat(16_000) } }
+    ])
+  })
+})


### PR DESCRIPTION
## Problem

The latest full PR Gate coverage artifact showed strong aggregate coverage, but several high-risk modules were still masked by the global average:

- `tool-detail-sanitizer.ts`: 70.91% lines / 49.06% branches, with no direct unit test
- `semver.ts`: 48.28% lines / 30.95% branches, despite controlling package version precedence
- `settings-preferences-slice.ts`: 48.42% lines / 30.00% branches, with scenario-model and proxy write paths largely uncovered

## Proposed change

- add direct boundary and aggregate-budget tests for tool-detail sanitization
- add SemVer core and prerelease precedence tests, including invalid inputs
- extend Settings preference tests for scenario-model persistence, rejected-write refresh, stale completion suppression, pending flags, and network proxy availability

Targeted post-change coverage:

- `tool-detail-sanitizer.ts`: 100% lines / 92.45% branches
- `semver.ts`: 100% lines / 100% branches
- `settings-preferences-slice.ts`: 92.63% lines / 63.33% branches

## Scope and non-goals

- tests only; no production behavior or Interface changes
- no schema, migration, persisted field, or data-file changes
- no new state or enum values
- historical Artifact compatibility is deliberately out of scope; Message snapshot v2 and Review scope v1 behavior remains unchanged and is not newly locked by this PR
- Streamdown DOM interaction, Omics connector contracts, coverage threshold ratcheting, and Module ownership changes remain separate follow-ups

## Acceptance criteria and validation

All listed successful checks ran after the last material edit.

| Behavior | Command | Result |
| --- | --- | --- |
| Tool detail projection, truncation, malformed input, and aggregate budget | focused Vitest: `src/shared/tool-detail-sanitizer.test.ts` | passed, 5 tests |
| SemVer precedence and invalid input handling | focused Vitest: `src/main/specialist/package/semver.test.ts` | passed, 9 tests |
| Settings scenario-model/proxy settlement and concurrency | focused Vitest: `src/renderer/src/stores/settings-preferences-slice.test.ts` | passed, 8 tests |
| Targeted source coverage for the three owners | Vitest coverage with exact `coverage.include` paths | passed, 22 tests |
| Repository lint | `eslint --cache .` | passed |
| Diff whitespace validation | `git diff --check` | passed |

Local Node/Web typechecks were attempted but the shared worktree dependency install is incompatible with this branch's lock/schema: the generated Prisma client lacks `sessionModelCallUsage`, and the installed Claude ACP package lacks `waitForMcpServers`. No private worktree dependency install was performed. Exact-head PR Gate is authoritative for typechecks and complete tests.

The Module impact classifier selects `Mode: full` because the new SemVer test has no Module owner. The complete local Vitest suite was intentionally not run; CI will execute the full plan. No consumer or platform lane is required by a production Interface change, because the diff contains tests only, but PR Gate remains authoritative for all selected lanes.

## Review focus

- whether the tests characterize stable public behavior instead of implementation details
- whether truncation/budget boundaries and SemVer precedence cover the meaningful risk
- whether Settings write tests correctly exercise stale completion and rejected-write recovery