### PR TITLE
fix(network): honor proxy settings consistently

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -516,6 +516,7 @@
     "settings_service_facade": {
       "ownerPaths": [
         "src/main/settings/service.ts",
+        "src/main/settings/network-proxy-settings-owner.ts",
         "src/main/settings/reviewer-model-owner.ts",
         "src/main/settings/subagent-model-owner.ts",
         "src/main/settings/vision-model-owner.ts"

--- a/src/main/connectors/mcp-client-manager.test.ts
+++ b/src/main/connectors/mcp-client-manager.test.ts
@@ -13,6 +13,10 @@ import type { CustomMcpServerConfig } from './mcp-client-manager'
 import { OAuthCallbackServer, type PersistentOAuthClientProvider } from './oauth-client'
 import { EXTRA_PATH_DIRS } from '../settings/shell-path'
 
+const { netFetch } = vi.hoisted(() => ({ netFetch: vi.fn() }))
+
+vi.mock('electron', () => ({ net: { fetch: netFetch } }))
+
 afterEach(() => vi.restoreAllMocks())
 
 // Builds an in-memory MCP server with one echo tool and one always-erroring tool, and an
@@ -637,6 +641,28 @@ describe('buildTransport', () => {
     })
 
     expect(transport).toBeInstanceOf(StreamableHTTPClientTransport)
+  })
+
+  it('routes streamable HTTP requests through the configured Electron proxy session', async () => {
+    const directFetch = vi.fn().mockRejectedValue(new Error('direct path unavailable'))
+    vi.stubGlobal('fetch', directFetch)
+    netFetch.mockResolvedValue(new Response(null, { status: 202 }))
+    const transport = buildTransport({
+      id: 'srv-http',
+      name: 'http-server',
+      transport: 'streamable_http',
+      url: 'https://mcp.example.test'
+    })
+
+    await transport.start()
+    await transport.send({ jsonrpc: '2.0', method: 'notifications/initialized' })
+
+    expect(netFetch).toHaveBeenCalledWith(
+      new URL('https://mcp.example.test'),
+      expect.objectContaining({ method: 'POST' })
+    )
+    expect(directFetch).not.toHaveBeenCalled()
+    await transport.close()
   })
 
   it('throws when a streamable_http config is missing a url', () => {

--- a/src/main/connectors/mcp-client-manager.ts
+++ b/src/main/connectors/mcp-client-manager.ts
@@ -11,6 +11,7 @@ import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js'
 import { OAuthCallbackServer, PersistentOAuthClientProvider } from './oauth-client'
 import type { StoredCustomMcpOAuthState } from '../settings/types'
 import { augmentedPathEnv } from '../settings/shell-path'
+import { netFetchStandard } from '../skills/net-fetch'
 
 // Config for a user-added custom MCP server. OAuth state is a transient main-process projection;
 // stdio remains non-OAuth and remote servers can use OAuth, static headers, or neither.
@@ -118,6 +119,7 @@ export function buildTransport(
         throw new Error(`custom MCP server "${config.name}" is missing a url for streamable_http`)
       }
       return new StreamableHTTPClientTransport(new URL(config.url), {
+        fetch: netFetchStandard,
         ...(authProvider ? { authProvider } : {}),
         ...(config.headers ? { requestInit: { headers: config.headers } } : {})
       })
@@ -127,6 +129,7 @@ export function buildTransport(
         throw new Error(`custom MCP server "${config.name}" is missing a url for sse`)
       }
       return new SSEClientTransport(new URL(config.url), {
+        fetch: netFetchStandard,
         ...(authProvider ? { authProvider } : {}),
         ...(config.headers ? { requestInit: { headers: config.headers } } : {})
       })

--- a/src/main/settings/network-proxy-settings-owner.ts
+++ b/src/main/settings/network-proxy-settings-owner.ts
@@ -1,0 +1,52 @@
+import type { NetworkProxySettings } from '../../shared/network-proxy'
+import { resolveNetworkProxySettings } from '../../shared/network-proxy'
+import type { SetNetworkProxyRequest } from '../../shared/settings'
+import type { SettingsRepository } from './repository'
+
+type NetworkProxySettingsOwnerOptions = Readonly<{
+  repository: Pick<SettingsRepository, 'getSettings' | 'setNetworkProxy'>
+  apply: (settings: NetworkProxySettings) => Promise<void>
+}>
+
+// Owns the full persist-and-apply transaction so concurrent Settings saves cannot leave the
+// stored preference and the live Electron proxy in different orders.
+class NetworkProxySettingsOwner {
+  private writeTail: Promise<void> = Promise.resolve()
+
+  constructor(private readonly options: NetworkProxySettingsOwnerOptions) {}
+
+  set(request: SetNetworkProxyRequest): Promise<NetworkProxySettings> {
+    const operation = this.writeTail.then(() => this.commit(request))
+    this.writeTail = operation.then(
+      () => undefined,
+      () => undefined
+    )
+    return operation
+  }
+
+  private async commit(request: SetNetworkProxyRequest): Promise<NetworkProxySettings> {
+    const previous = resolveNetworkProxySettings(
+      (await this.options.repository.getSettings()).networkProxy
+    )
+    const stored = await this.options.repository.setNetworkProxy(request)
+    const networkProxy = resolveNetworkProxySettings(stored.networkProxy)
+
+    try {
+      await this.options.apply(networkProxy)
+    } catch (error) {
+      try {
+        await this.options.repository.setNetworkProxy(previous)
+      } catch (rollbackError) {
+        throw new AggregateError(
+          [error, rollbackError],
+          'Could not apply or restore the proxy configuration.'
+        )
+      }
+      throw error
+    }
+
+    return networkProxy
+  }
+}
+
+export { NetworkProxySettingsOwner }

--- a/src/main/settings/network-proxy-settings.test.ts
+++ b/src/main/settings/network-proxy-settings.test.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { createEmptySettings } from './types'
+
 vi.mock('electron', () => ({
   app: { getPath: () => tmpdir(), getAppPath: () => tmpdir(), isPackaged: false },
   safeStorage: { isEncryptionAvailable: () => false },
@@ -74,5 +76,52 @@ describe('Network proxy settings persistence', () => {
 
     expect(applyNetworkProxy).toHaveBeenCalledWith({ mode: 'direct' })
     expect((await repository.getSettings()).networkProxy).toEqual({ mode: 'direct' })
+  })
+
+  it('does not persist a proxy setting that the runtime rejected', async () => {
+    const repository = new SettingsRepository(dir)
+    const applyNetworkProxy = vi.fn().mockRejectedValue(new Error('proxy session unavailable'))
+    const service = new SettingsService({ repository, storageRoot: dir, applyNetworkProxy })
+
+    await expect(service.setNetworkProxy({ mode: 'direct' })).rejects.toThrow(
+      'proxy session unavailable'
+    )
+
+    expect((await repository.getSettings()).networkProxy).toBeUndefined()
+  })
+
+  it('keeps persisted and runtime proxy order aligned across concurrent saves', async () => {
+    let stored = createEmptySettings()
+    const repository = {
+      getSettings: vi.fn(async () => stored),
+      setNetworkProxy: vi.fn(async (networkProxy) => {
+        stored = { ...stored, networkProxy }
+        return stored
+      })
+    } as unknown as InstanceType<typeof SettingsRepository>
+    let releaseFirstApply!: () => void
+    const firstApply = new Promise<void>((resolve) => {
+      releaseFirstApply = resolve
+    })
+    let runtimeMode = 'system'
+    const applyNetworkProxy = vi.fn(async (settings: { mode: string }) => {
+      if (settings.mode === 'direct') await firstApply
+      runtimeMode = settings.mode
+    })
+    const service = new SettingsService({ repository, storageRoot: dir, applyNetworkProxy })
+
+    const firstSave = service.setNetworkProxy({ mode: 'direct' })
+    await vi.waitFor(() => expect(applyNetworkProxy).toHaveBeenCalledWith({ mode: 'direct' }))
+    const secondSave = service.setNetworkProxy({
+      mode: 'manual',
+      server: 'http://proxy.example:8080'
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+    releaseFirstApply()
+    await Promise.all([firstSave, secondSave])
+
+    expect(stored.networkProxy?.mode).toBe('manual')
+    expect(runtimeMode).toBe('manual')
   })
 })

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -66,7 +66,7 @@ import type {
 import { createLogger, type Logger } from '../logger'
 import { startDiagnosticOperation } from '../diagnostics/operation'
 import type { PackageMirror } from '../../shared/mirror'
-import { resolveNetworkProxySettings, type NetworkProxySettings } from '../../shared/network-proxy'
+import type { NetworkProxySettings } from '../../shared/network-proxy'
 import type { GrantedLocalRoot } from '../../shared/local-fs'
 import type { NotebookLanguage } from '../../shared/notebook'
 import type { RuntimeEnablement, RuntimeSelection } from '../../shared/notebook-runtime'
@@ -112,6 +112,7 @@ import { ScenarioModelOwner, createScenarioModels } from './scenario-model-owner
 import type { SystemProxyEnvironment } from './system-proxy'
 import { type ClaudeIsolatedAuthControllerPort } from './claude-isolated-auth'
 import { type ClaudeSharedAuthControllerPort } from './claude-shared-auth'
+import { NetworkProxySettingsOwner } from './network-proxy-settings-owner'
 
 // Outcome of uninstalling a managed runtime. `activeBackendAffected` is true only when the removed
 // runtime backed the active framework, so the IPC layer reconnects the agent for that case alone —
@@ -190,7 +191,7 @@ class SettingsService {
   private readonly backendResolver: AgentBackendResolver
   private readonly scenarioModels: ScenarioModelOwner
   private readonly storageRoot: string
-  private readonly applyNetworkProxy: (settings: NetworkProxySettings) => Promise<void>
+  private readonly networkProxy: NetworkProxySettingsOwner
   private readonly userClaudeDir: string
   private readonly log: Logger
   private customServerAuthenticator?: (serverId: string) => Promise<void>
@@ -199,7 +200,10 @@ class SettingsService {
   constructor(options: SettingsServiceOptions = {}) {
     this.storageRoot = options.storageRoot ?? resolveStorageRoot()
     this.repository = options.repository ?? new SettingsRepository(this.storageRoot)
-    this.applyNetworkProxy = options.applyNetworkProxy ?? (async () => undefined)
+    this.networkProxy = new NetworkProxySettingsOwner({
+      repository: this.repository,
+      apply: options.applyNetworkProxy ?? (async () => undefined)
+    })
     this.log = options.log ?? createLogger('settings')
     this.preferences = new SettingsPreferencesModule(this.repository)
     this.notebookRuntimeSettings = new NotebookRuntimeSettingsModule(this.repository)
@@ -355,11 +359,8 @@ class SettingsService {
     return this.notebookRuntimeSettings.setPackageMirror(request)
   }
 
-  async setNetworkProxy(request: SetNetworkProxyRequest): Promise<NetworkProxySettings> {
-    const settings = await this.repository.setNetworkProxy(request)
-    const networkProxy = resolveNetworkProxySettings(settings.networkProxy)
-    await this.applyNetworkProxy(networkProxy)
-    return networkProxy
+  setNetworkProxy(request: SetNetworkProxyRequest): Promise<NetworkProxySettings> {
+    return this.networkProxy.set(request)
   }
 
   private async migrateLegacyKeyRefs(settings: StoredSettings): Promise<StoredSettings> {

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -534,6 +534,7 @@ describe('Settings backend ownership architecture', () => {
       'src/main/settings/agent-runtime-manager.ts',
       'src/main/settings/compute-grant-port.ts',
       'src/main/settings/connector-settings.ts',
+      'src/main/settings/network-proxy-settings-owner.ts',
       'src/main/settings/notebook-runtime-settings.ts',
       'src/main/settings/preferences.ts',
       'src/main/settings/provider-accounts.ts',
@@ -832,6 +833,7 @@ describe('Settings backend ownership architecture', () => {
     ])
     expect(manifest.modules.settings_service_facade.ownerPaths).toEqual([
       'src/main/settings/service.ts',
+      'src/main/settings/network-proxy-settings-owner.ts',
       'src/main/settings/reviewer-model-owner.ts',
       'src/main/settings/subagent-model-owner.ts',
       'src/main/settings/vision-model-owner.ts'


### PR DESCRIPTION
## Problem

The Network setting did not consistently govern all network traffic or remain aligned with its live runtime state:

- Custom remote MCP servers using `streamable_http` or `sse` used Node's global `fetch`, which bypasses Electron Session proxy settings. Behind a proxy/VPN, Settings could show System or Manual proxy while the MCP connection still attempted a blocked direct route.
- `SettingsService.setNetworkProxy` persisted the new preference before applying it to the live Electron Session. If runtime application failed, the rejected value remained on disk even though it was never active.
- Repository writes were serialized, but the complete persist-and-apply operation was not. Concurrent callers could leave the final persisted mode and final runtime mode in different orders.

Without the fix, remote MCP connections can fail despite a valid Network configuration; failed proxy saves can reappear after restart; and concurrent saves can make Settings and the active network stack disagree.

Related to #1136 and follows the proxy settings introduced in #1148.

## Proposed change

- Route both remote MCP HTTP transports through the existing Electron `net.fetch` adapter so they use the configured Electron Session proxy.
- Add an internal `NetworkProxySettingsOwner` that serializes the full save operation, persists and applies each value in order, and restores the previous persisted value if live application fails.
- Keep `SettingsService` as the stable public facade and declare the new owner in the module-impact and architecture contracts.

```mermaid
sequenceDiagram
  participant UI as Settings / IPC
  participant Owner as NetworkProxySettingsOwner
  participant Store as SettingsRepository
  participant Runtime as Electron Session
  UI->>Owner: setNetworkProxy(request)
  Owner->>Store: persist normalized setting
  Owner->>Runtime: apply setting
  alt apply succeeds
    Owner-->>UI: resolved setting
  else apply fails
    Owner->>Store: restore previous setting
    Owner-->>UI: reject original error
  end
```

## Scope and non-goals

- No new data field, schema, migration, enum value, settings interaction, or public API.
- Persisted `networkProxy` shape is unchanged. The only persistence change is rollback on runtime failure and serialization of concurrent saves.
- Historical documents without `networkProxy` still resolve to System mode; no historical-data migration or compatibility branch is required.
- This does not implement the broader arbitrary runtime environment-profile proposal in #1136.
- Existing processes are not restarted or retroactively reconfigured; the existing future-child-process proxy behavior is unchanged.

## Acceptance criteria and validation

The three new public-boundary regressions were run twice against the unmodified production implementation and failed consistently for the reported reasons:

- remote MCP request: `direct path unavailable`
- rejected runtime apply: persisted `{ mode: 'direct' }` instead of the prior System/default value
- concurrent saves: runtime ended in Direct while persistence ended in Manual

After the final material edit:

- Remote MCP and proxy consistency behavior -> `npm test -- --run src/main/connectors/mcp-client-manager.test.ts src/main/settings/network-proxy-settings.test.ts src/main/settings/network-proxy-runtime.test.ts` -> 3 files, 42 tests passed.
- Settings facade owner, contracts, consumers, and architecture ceilings -> `npm run test:module -- settings_service_facade` -> 28 files, 791 tests passed.
- Module ownership and PR classification contracts -> targeted CI-script Vitest command -> 4 files, 110 tests passed.
- Node and renderer type safety -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed.
- Formatting and whitespace -> targeted Prettier check plus `git diff --check` -> passed.

Per the requested local scope, the complete `npm test` suite was not run locally. The exact-head impact plan resolves to **full** because `scripts/ci/module-impact.json` is a global gate input, so PR Gate is authoritative for the complete portable and platform lanes.

Uncovered locally: a live end-to-end proxy server/VPN integration and already-running child-process behavior. The Electron Session runtime itself is unchanged; this PR routes the previously bypassing MCP transports into that existing path.

## Review focus

- Whether the persist/apply/rollback ordering preserves the intended Settings authority on all failure paths.
- Whether `netFetchStandard` is the correct common proxy-aware boundary for both MCP HTTP transports.
- Whether the explicitly excluded runtime environment-profile work should remain separate from this bug fix.
