### PR TITLE
fix(connectors): preserve scalar identifier inputs

### DIFF
--- a/src/main/connectors/descriptors/pubmed.ts
+++ b/src/main/connectors/descriptors/pubmed.ts
@@ -16,6 +16,11 @@ const IDCONV_BATCH = 200
 // How many ids are OR-ed together in one Europe PMC availability query.
 const SEARCH_BATCH = 8
 
+const STRING_OR_STRING_ARRAY = {
+  type: ['string', 'array'],
+  items: { type: 'string' }
+}
+
 // MCP sort enum -> esearch sort value.
 const SORT_MAP: Record<string, string> = {
   relevance: 'relevance',
@@ -577,9 +582,8 @@ export const PUBMED_TOOLS: ToolDescriptor[] = [
       type: 'object',
       properties: {
         pmids: {
-          type: 'array',
-          items: { type: 'string' },
-          description: 'One or more PubMed IDs, e.g. ["35486828", "33264437"].'
+          ...STRING_OR_STRING_ARRAY,
+          description: 'One PubMed ID or a list.'
         }
       },
       required: ['pmids']
@@ -609,7 +613,7 @@ export const PUBMED_TOOLS: ToolDescriptor[] = [
     input: {
       type: 'object',
       properties: {
-        pmids: { type: 'array', items: { type: 'string' } },
+        pmids: { ...STRING_OR_STRING_ARRAY },
         link_type: {
           type: 'string',
           enum: [
@@ -759,7 +763,7 @@ export const PUBMED_TOOLS: ToolDescriptor[] = [
     input: {
       type: 'object',
       properties: {
-        ids: { type: 'array', items: { type: 'string' } },
+        ids: { ...STRING_OR_STRING_ARRAY },
         id_type: { type: 'string', enum: ['pmid', 'pmcid', 'doi'], default: 'pmid' }
       },
       required: ['ids']
@@ -813,9 +817,8 @@ export const PUBMED_TOOLS: ToolDescriptor[] = [
       type: 'object',
       properties: {
         pmc_ids: {
-          type: 'array',
-          items: { type: 'string' },
-          description: 'PMC ids, e.g. ["PMC9046468"] or ["9046468"]. Max 20 per call.'
+          ...STRING_OR_STRING_ARRAY,
+          description: 'One PMC ID or a list (max 20).'
         }
       },
       required: ['pmc_ids']
@@ -913,7 +916,7 @@ export const PUBMED_TOOLS: ToolDescriptor[] = [
       'Report copyright and license status per PMID by combining PubMed CopyrightInformation, the PMC ID Converter (PMID -> PMCID/DOI), and the PMC <permissions> block (license type, ALI license URL, copyright statement/year). Use to check open-access reuse rights before reproducing content.',
     input: {
       type: 'object',
-      properties: { pmids: { type: 'array', items: { type: 'string' } } },
+      properties: { pmids: { ...STRING_OR_STRING_ARRAY } },
       required: ['pmids']
     },
     required: ['pmids'],

--- a/src/main/connectors/descriptors/variants-clinvar.ts
+++ b/src/main/connectors/descriptors/variants-clinvar.ts
@@ -302,7 +302,10 @@ export const VARIANTS_CLINVAR_TOOLS: ToolDescriptor[] = [
     input: {
       type: 'object',
       properties: {
-        accessions: { type: 'array', items: { type: 'string' } }
+        accessions: {
+          type: ['string', 'array'],
+          items: { type: 'string' }
+        }
       },
       required: ['accessions']
     },

--- a/src/main/connectors/descriptors/zinc.ts
+++ b/src/main/connectors/descriptors/zinc.ts
@@ -37,6 +37,11 @@ const ID_DELIM_RE = /[,\s]/
 // Result sources, presentation order (current release first) — mirrors upstream SOURCE_ORDER.
 const SOURCE_ORDER = ['zinc22', 'zinc20']
 
+const STRING_OR_STRING_ARRAY = {
+  type: ['string', 'array'],
+  items: { type: 'string' }
+}
+
 type ZincRecord = {
   zinc_id?: string
   smiles?: string
@@ -401,8 +406,7 @@ export const ZINC_TOOLS: ToolDescriptor[] = [
       type: 'object',
       properties: {
         zinc_ids: {
-          type: 'array',
-          items: { type: 'string' },
+          ...STRING_OR_STRING_ARRAY,
           description: 'One or more ZINC ids, e.g. ZINC000000000012 (max 100 per call).'
         },
         max_results: {
@@ -503,8 +507,7 @@ export const ZINC_TOOLS: ToolDescriptor[] = [
       type: 'object',
       properties: {
         supplier_codes: {
-          type: 'array',
-          items: { type: 'string' },
+          ...STRING_OR_STRING_ARRAY,
           description: 'One or more vendor catalog codes, e.g. MCULE-2311834287 (max 100 per call).'
         },
         max_results: {
@@ -597,8 +600,7 @@ export const ZINC_TOOLS: ToolDescriptor[] = [
       type: 'object',
       properties: {
         zinc_ids: {
-          type: 'array',
-          items: { type: 'string' },
+          ...STRING_OR_STRING_ARRAY,
           description: 'ZINC ids to prepare, e.g. ZINC000000000012 (max 50 per call).'
         },
         timeout_s: {

--- a/src/main/connectors/registry.test.ts
+++ b/src/main/connectors/registry.test.ts
@@ -33,6 +33,25 @@ describe('registry + catalog', () => {
       /invalid tool arguments.*cids.*array/i
     )
   })
+  it('accepts scalar forms that bundled handlers normalize to one-item lists', () => {
+    const cases = [
+      ['pubmed', 'get_article_metadata', 'pmids', '35486828'],
+      ['pubmed', 'find_related_articles', 'pmids', '35486828'],
+      ['pubmed', 'convert_article_ids', 'ids', 'PMC9046468'],
+      ['pubmed', 'get_full_text_article', 'pmc_ids', 'PMC9046468'],
+      ['pubmed', 'get_copyright_status', 'pmids', '35891187'],
+      ['variants', 'clinvar_get_records', 'accessions', 'VCV000045122'],
+      ['zinc', 'zinc_search_by_id', 'zinc_ids', 'ZINC000000000012'],
+      ['zinc', 'zinc_search_by_supplier', 'supplier_codes', 'MCULE-2311834287'],
+      ['zinc', 'zinc_get_3d', 'zinc_ids', 'ZINC000000000012']
+    ] as const
+
+    for (const [connector, method, field, value] of cases) {
+      const descriptor = getDescriptor(connector, method)!
+      expect(() => validateToolArguments(descriptor, { [field]: value })).not.toThrow()
+      expect(() => validateToolArguments(descriptor, { [field]: [value] })).not.toThrow()
+    }
+  })
   it('uses Schema-required fields instead of the drifted descriptor required list', () => {
     const descriptor = getDescriptor('biorxiv', 'get_preprint')!
 

--- a/src/main/connectors/registry.ts
+++ b/src/main/connectors/registry.ts
@@ -55,6 +55,7 @@ const ALL_TOOLS: ToolDescriptor[] = [
 
 const inputSchemaCompiler = new Ajv2020({
   strict: true,
+  allowUnionTypes: true,
   allErrors: false,
   validateFormats: false,
   coerceTypes: false,

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -61,6 +61,34 @@ describe('ConnectorService', () => {
     const out = await svc.call('chemistry', 'pubchem_get_compounds', { cids: [1] }, internal)
     expect(out).toEqual({ n_requested: 1, duplicates: [], records: [{ CID: 1 }], not_found: [] })
   })
+  it('preserves bundled handler support for a single id when the schema recommends a list', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonRes({
+        status: 'ok',
+        records: [{ 'requested-id': 'PMC9046468', pmcid: 'PMC9046468', pmid: 34713412 }]
+      })
+    )
+    const svc = new ConnectorService({
+      engine: new ParserEngine({ fetchImpl }),
+      getConnectors: () => ({ enabledIds: ['pubmed'], autoAllowIds: [] }),
+      resolveApiKey: () => undefined
+    })
+
+    const out = (await svc.call(
+      'pubmed',
+      'convert_article_ids',
+      { ids: 'PMC9046468', id_type: 'pmcid' },
+      internal
+    )) as { records: Array<Record<string, unknown>> }
+
+    expect(fetchImpl).toHaveBeenCalledOnce()
+    expect(String(fetchImpl.mock.calls[0][0])).toContain('ids=PMC9046468')
+    expect(out.records[0]).toMatchObject({
+      pmcid: 'PMC9046468',
+      pmid: '34713412',
+      'requested-id': 'PMC9046468'
+    })
+  })
   it('rejects bundled tool arguments that do not match the registered JSON Schema', async () => {
     const engine = {
       call: vi.fn().mockResolvedValue({ accepted: true })


### PR DESCRIPTION
## Problem

PR #1725 made bundled Connector input Schemas a strict pre-dispatch contract. Nine bundled handlers,
however, already normalized a single identifier into a one-item list while their descriptors
advertised only arrays. Calls such as `pubmed/convert_article_ids` with `{ ids: "PMC9046468" }`
therefore became false `invalid_arguments` failures before the existing handler could run.

The regression test was added before the implementation and failed three consecutive times on
unfixed `main` with `field "ids" must be array`; the fake upstream transport was never called.

## Proposed change

- widen the nine affected PubMed, ClinVar, and ZINC descriptor properties to the JSON Schema union
  `string | string[]`
- enable AJV's `allowUnionTypes` syntax support while keeping coercion, defaults, and mutation disabled
- keep array examples as the recommended batch form
- cover all nine Schema contracts and drive the real PubMed handler through the shared
  `ConnectorService` boundary

## Scope and non-goals

- bundled Connector descriptor correction only; custom MCP behavior is unchanged
- strict validation remains in place for types not supported by handlers, including scalar PubChem
  `cids` and numeric molecule `smiles`
- no validation mode, compatibility flag, fallback dispatch, dependency, migration, persisted field,
  data-model relationship, architecture, human interaction, or new state/enum value
- no historical persisted-data compatibility is required; this preserves historical runtime request
  compatibility for scalar identifier arguments
- no ACP method, protocol translation, tool-call correlation, framework adapter, or platform-specific
  behavior changes

## Acceptance criteria and validation

Final evidence after the last material edit:

- scalar identifier compatibility -> `npm test -- src/main/connectors/registry.test.ts src/main/connectors/service.test.ts src/main/connectors/skill-doc.test.ts src/main/connectors/descriptors/pubmed.test.ts src/main/connectors/descriptors/variants-clinvar.test.ts src/main/connectors/descriptors/zinc.test.ts` -> 6 files, 131 tests passed
- ordinary Connector module behavior -> `npm test -- src/main/connectors` -> 54 files passed; only 2 loopback OAuth files were sandbox-blocked by `listen EPERM 127.0.0.1`
- loopback OAuth remainder -> `npm test -- src/main/connectors/oauth-client.test.ts src/main/connectors/mcp-client-manager.test.ts` outside the restricted sandbox -> 2 files, 45 tests passed
- Node types -> `npm run typecheck:node` -> passed
- lint -> `npm run lint` -> passed
- changed-file formatting -> `npx prettier --check <six changed files>` -> passed
- affected-plan explanation -> `npm run test:affected -- --base origin/main --head HEAD --explain` -> full fallback because Connector descriptor files have no declared module owner

Per maintainer direction, the complete local `npm test` fallback was not run. Exact-head PR CI is the
authority for the complete portable suite and platform lanes.

## Review focus

- the widened Schemas exactly match explicit scalar-to-array normalization already present in the
  handlers
- AJV remains strict and non-coercing for every other input
- generated Skill docs stay within their on-demand token budgets

Uncovered risk: undocumented shapes that handlers do not explicitly normalize remain rejected, as
intended.

