### PR TITLE
fix(notebook): document CommonJS module loading

### DIFF
--- a/src/main/notebook/mcp-server.test.ts
+++ b/src/main/notebook/mcp-server.test.ts
@@ -591,6 +591,12 @@ describe('repl_execute tool', () => {
     expect(tool?.description).toContain('notebook_execute')
   })
 
+  it('directs Node module loading through the CommonJS REPL contract', () => {
+    expect(tool?.description).toContain(
+      "This is a CommonJS REPL: load Node modules with `require('node:fs')`, not dynamic `import()`."
+    )
+  })
+
   it('advertises the role-scoped subagent Host SDK on the only tool that can call it', () => {
     expect(tool?.description).toContain('Main/root agents')
     expect(tool?.description).toContain('host.help')

--- a/src/main/notebook/mcp-server.ts
+++ b/src/main/notebook/mcp-server.ts
@@ -182,6 +182,7 @@ const SWITCH_RUNTIME_DOC = [
 // Control-plane REPL contract, embedded as the repl_execute description so the agent always sees it.
 const REPL_EXECUTE_DOC = [
   'Run JavaScript in the persistent control-plane REPL, separate from notebook_execute Python/R data kernels.',
+  "This is a CommonJS REPL: load Node modules with `require('node:fs')`, not dynamic `import()`.",
   'Use `await host.capabilities()` to feature-gate optional host namespaces; load the `self-awareness` Skill for its boolean contract and current capability map.',
   'Only this kernel can call temporary tool-less inference (`await host.llm(prompt)` or a bounded prompt batch), connectors (`await host.mcp(server, method, args)`), remote compute (`host.compute`; load its skill for the API), Specialist management (`host.agents`), and Skill authoring (`host.skills`).',
   HOST_SDK_DISCOVERY_GUIDANCE,


### PR DESCRIPTION
## Problem

The persistent JavaScript control REPL runs CommonJS code through `vm.runInContext` without a dynamic import callback. An agent that uses `await import('node:fs')` therefore fails deterministically with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`, even though the supported `require('node:fs')` path works.

The existing `repl_execute` description did not tell agents which module-loading contract applies.

## Proposed change

- Describe the control REPL as CommonJS and direct Node module loading through `require()` rather than dynamic `import()`.
- Lock that guidance at the public `repl_execute` tool-description boundary with a regression test.

## Scope and non-goals

- Do not enable Node's experimental VM module loader.
- Do not add a global system-prompt instruction, runtime error mapping, fields, states, persistence, migrations, or historical-data compatibility handling.
- Do not change the REPL execution protocol or runtime behavior: dynamic `import()` remains unsupported by design.
- All ACP frameworks and launchers receive the same shared Notebook MCP tool description; no framework-, model-, transport-, or platform-specific protocol path changes.

## Acceptance criteria and validation

Red-state evidence before the production edit:

- `../../node_modules/.bin/vitest run src/main/notebook/mcp-server.test.ts -t 'directs Node module loading through the CommonJS REPL contract'` -> failed because the public description lacked the CommonJS/`require()` guidance.

Final evidence after the last material edit:

- `repl_execute` module-loading guidance -> `npm test -- src/main/notebook/mcp-server.test.ts` -> 82 passed.
- Node main-process types -> `npm run typecheck:node` -> passed.
- Linted source and test -> `npm run lint` -> passed.
- Impact-plan explanation -> `npm run test:affected -- --base origin/main --head HEAD --explain` -> full plan because `src/main/notebook/mcp-server.ts` has no registered module owner.

Per maintainer direction, the complete local `npm test` suite was not run; PR CI is the final portable-suite authority. No platform lane is required locally because the final diff changes only shared tool-description text and its contract assertion.

## Review focus

- Confirm the guidance belongs in the tool-specific `REPL_EXECUTE_DOC` rather than the global Notebook system prompt.
- Confirm retaining the stable CommonJS runtime is preferable to enabling Node's experimental VM module loader.
