### PR TITLE
fix(responses): add artifact completion diagnostics

### DIFF
--- a/src/main/settings/native-responses-compatibility.test.ts
+++ b/src/main/settings/native-responses-compatibility.test.ts
@@ -387,6 +387,218 @@ describe('native Responses compatibility', () => {
     })
   })
 
+  it('diagnoses a completed stream that stops after a Notebook file without saving an Artifact', async () => {
+    const privateAssistantText = 'I will export the private result as an artifact:'
+    const upstream = [
+      {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          id: 'message-1',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: privateAssistantText }]
+        }
+      },
+      {
+        type: 'response.completed',
+        response: {
+          id: 'response-1',
+          status: 'completed',
+          output: [
+            {
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: privateAssistantText }]
+            }
+          ]
+        }
+      },
+      '[DONE]'
+    ]
+      .map((event) => `data: ${typeof event === 'string' ? event : JSON.stringify(event)}\n\n`)
+      .join('')
+    const proxy = new NativeResponsesCompatibilityProxy(
+      { baseUrl: 'https://api.example/v1', model: 'model-a' },
+      vi.fn(
+        async () =>
+          new Response(upstream, {
+            status: 200,
+            headers: { 'content-type': 'text/event-stream' }
+          })
+      )
+    )
+    const connection = await proxy.start()
+
+    try {
+      const response = await fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: 'model-a',
+          stream: true,
+          instructions: 'base provider instructions',
+          input: [
+            {
+              type: 'message',
+              role: 'developer',
+              content: '<open_science_artifact_instructions>private guidance'
+            },
+            {
+              type: 'function_call',
+              namespace: 'mcp__open_science_notebook',
+              name: 'notebook_execute',
+              call_id: 'notebook-call-1',
+              arguments: '{}'
+            },
+            {
+              type: 'function_call_output',
+              call_id: 'notebook-call-1',
+              output: '{"workingFiles":[{"relativePath":"data/private.png"}]}'
+            }
+          ],
+          tools: [
+            {
+              type: 'namespace',
+              name: 'mcp__open_science_notebook',
+              tools: [
+                {
+                  type: 'function',
+                  name: 'notebook_execute',
+                  parameters: { type: 'object' }
+                }
+              ]
+            },
+            {
+              type: 'namespace',
+              name: 'mcp__open_science_artifacts',
+              tools: [
+                {
+                  type: 'function',
+                  name: 'write_artifact_file',
+                  parameters: { type: 'object' }
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      const responseBody = await response.text()
+      expect(response.ok, responseBody).toBe(true)
+      expect(responseBody).toContain('response.completed')
+      expect(responseBody).toContain(privateAssistantText)
+      expect(responseBody).not.toContain('write_artifact_file')
+      const requestLog = logSpies.info.mock.calls.find(
+        ([message]) => message === 'native Responses compatibility request'
+      )
+      const streamLog = logSpies.info.mock.calls.find(
+        ([message]) => message === 'native Responses compatibility stream completed'
+      )
+      expect(requestLog?.[1]).toMatchObject({
+        topLevelArtifactInstructionPresent: false,
+        developerArtifactInstructionPresent: true,
+        artifactInstructionPresent: true,
+        artifactToolPresent: true,
+        functionCallOutputHistoryCount: 1
+      })
+      expect(streamLog?.[1]).toMatchObject({
+        requestId: requestLog?.[1]?.requestId,
+        terminalEventType: 'response.completed',
+        terminalStatus: 'completed',
+        terminalOutputItemCount: 1,
+        terminalMessageCount: 1,
+        observedFunctionCallCount: 0,
+        observedArtifactFunctionCallCount: 0
+      })
+      expect(
+        JSON.stringify(Object.values(logSpies).flatMap((spy) => spy.mock.calls))
+      ).not.toContain(privateAssistantText)
+    } finally {
+      await proxy.close()
+    }
+  })
+
+  it('counts an Artifact call emitted before a sparse terminal event', async () => {
+    const artifactCall = {
+      id: 'artifact-call-item-1',
+      type: 'function_call',
+      name: 'mcp__open_science_artifacts__write_artifact_file',
+      call_id: 'artifact-call-1',
+      arguments: '{}'
+    }
+    const upstream = [
+      { type: 'response.output_item.added', output_index: 0, item: artifactCall },
+      { type: 'response.output_item.done', output_index: 0, item: artifactCall },
+      {
+        type: 'response.completed',
+        response: {
+          id: 'response-1',
+          status: 'completed',
+          output: [{ ...artifactCall, id: undefined }]
+        }
+      },
+      '[DONE]'
+    ]
+      .map((event) => `data: ${typeof event === 'string' ? event : JSON.stringify(event)}\n\n`)
+      .join('')
+    const proxy = new NativeResponsesCompatibilityProxy(
+      { baseUrl: 'https://api.example/v1', model: 'model-a' },
+      vi.fn(
+        async () =>
+          new Response(upstream, {
+            status: 200,
+            headers: { 'content-type': 'text/event-stream' }
+          })
+      )
+    )
+    const connection = await proxy.start()
+
+    try {
+      const response = await fetch(`${connection.baseUrl}/responses`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${connection.token}`,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          model: 'model-a',
+          stream: true,
+          input: [],
+          tools: [
+            {
+              type: 'namespace',
+              name: 'mcp__open_science_artifacts',
+              tools: [
+                {
+                  type: 'function',
+                  name: 'write_artifact_file',
+                  parameters: { type: 'object' }
+                }
+              ]
+            }
+          ]
+        })
+      })
+
+      expect(response.ok, await response.text()).toBe(true)
+      const streamLog = logSpies.info.mock.calls.find(
+        ([message]) => message === 'native Responses compatibility stream completed'
+      )
+      expect(streamLog?.[1]).toMatchObject({
+        terminalEventType: 'response.completed',
+        terminalOutputItemCount: 1,
+        observedFunctionCallCount: 1,
+        observedArtifactFunctionCallCount: 1
+      })
+    } finally {
+      await proxy.close()
+    }
+  })
+
   it('aborts a native Responses stream after the configured idle period', async () => {
     let upstreamSignal: AbortSignal | undefined
     let failUpstream: ((reason?: unknown) => void) | undefined

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -61,6 +61,15 @@ export type NativeResponsesToolAliases = Map<string, NativeResponsesToolIdentity
 
 type NativeFetch = typeof fetch
 
+type NativeResponsesStreamSummary = Readonly<{
+  terminalEventType: string
+  terminalStatus?: string
+  terminalOutputItemCount: number
+  terminalMessageCount: number
+  observedFunctionCallCount: number
+  observedArtifactFunctionCallCount: number
+}>
+
 const log = createLogger('native-responses-compatibility')
 const DEFAULT_RESPONSE_HEADER_TIMEOUT_MS = 2 * 60_000
 const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 5 * 60_000
@@ -119,6 +128,23 @@ const upstreamResponseType = (contentType: string): 'event-stream' | 'json' | 'b
 
 const isObject = (value: unknown): value is JsonObject =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const containsText = (value: unknown, marker: string): boolean => {
+  if (typeof value === 'string') return value.includes(marker)
+  if (Array.isArray(value)) return value.some((item) => containsText(item, marker))
+  return isObject(value) && Object.values(value).some((item) => containsText(item, marker))
+}
+
+const isArtifactTool = (value: unknown, aliases: NativeResponsesToolAliases): boolean => {
+  if (!isObject(value) || typeof value.name !== 'string') return false
+  const identity =
+    typeof value.namespace === 'string'
+      ? { namespace: value.namespace, name: value.name }
+      : aliases.get(value.name)
+  return (
+    identity?.namespace === 'mcp__open_science_artifacts' && identity.name === 'write_artifact_file'
+  )
+}
 
 const namespaceAlias = (namespace: string, name: string): string => `${namespace}__${name}`
 
@@ -292,12 +318,93 @@ const copyResponseHeaders = (upstream: Response): Record<string, string> => {
   return headers
 }
 
-const rewriteSseLine = (line: string, aliases: NativeResponsesToolAliases): string => {
+const streamSummaryObserver = (
+  aliases: NativeResponsesToolAliases
+): Readonly<{
+  observe: (value: unknown) => void
+  summary: () => NativeResponsesStreamSummary | undefined
+}> => {
+  const functionCallKeys = new Set<string>()
+  const artifactFunctionCallKeys = new Set<string>()
+  let terminal:
+    | Readonly<{
+        type: string
+        status?: string
+        output: unknown[]
+      }>
+    | undefined
+
+  const observeFunctionCall = (item: unknown, outputIndex?: unknown): void => {
+    if (!isObject(item) || (item.type !== 'function_call' && item.type !== 'custom_tool_call')) {
+      return
+    }
+    const key =
+      typeof item.call_id === 'string'
+        ? `call:${item.call_id}`
+        : typeof item.id === 'string'
+          ? `id:${item.id}`
+          : typeof outputIndex === 'number'
+            ? `index:${outputIndex}`
+            : `anonymous:${functionCallKeys.size}`
+    functionCallKeys.add(key)
+    if (isArtifactTool(item, aliases)) artifactFunctionCallKeys.add(key)
+  }
+
+  const observe = (value: unknown): void => {
+    if (!isObject(value)) return
+    if (
+      (value.type === 'response.output_item.added' || value.type === 'response.output_item.done') &&
+      isObject(value.item)
+    ) {
+      observeFunctionCall(value.item, value.output_index)
+    }
+    if (
+      (value.type !== 'response.completed' &&
+        value.type !== 'response.failed' &&
+        value.type !== 'response.incomplete') ||
+      !isObject(value.response)
+    ) {
+      return
+    }
+    const output = Array.isArray(value.response.output) ? value.response.output : []
+    output.forEach((item, index) => observeFunctionCall(item, index))
+    terminal = {
+      type: value.type,
+      ...(typeof value.response.status === 'string' ? { status: value.response.status } : {}),
+      output
+    }
+  }
+
+  return {
+    observe,
+    summary: () => {
+      if (!terminal) return undefined
+      return {
+        terminalEventType: terminal.type,
+        ...(terminal.status ? { terminalStatus: terminal.status } : {}),
+        terminalOutputItemCount: terminal.output.length,
+        terminalMessageCount: terminal.output.filter(
+          (item) => isObject(item) && item.type === 'message'
+        ).length,
+        observedFunctionCallCount: functionCallKeys.size,
+        observedArtifactFunctionCallCount: artifactFunctionCallKeys.size
+      }
+    }
+  }
+}
+
+const rewriteSseLine = (
+  line: string,
+  aliases: NativeResponsesToolAliases,
+  observe: (value: unknown) => void
+): string => {
   if (!line.startsWith('data:')) return line
   const data = line.slice('data:'.length).trimStart()
   if (!data || data === '[DONE]') return line
   try {
-    return `data: ${JSON.stringify(restoreNativeResponsesPayload(JSON.parse(data), aliases))}`
+    const payload = JSON.parse(data) as unknown
+    observe(payload)
+    return `data: ${JSON.stringify(restoreNativeResponsesPayload(payload, aliases))}`
   } catch {
     return line
   }
@@ -308,21 +415,23 @@ const streamResponse = async (
   response: ServerResponse,
   aliases: NativeResponsesToolAliases,
   onActivity: () => void
-): Promise<void> => {
+): Promise<NativeResponsesStreamSummary | undefined> => {
   if (!upstream.body) throw new Error('native Responses upstream returned no body')
   response.writeHead(upstream.status, copyResponseHeaders(upstream))
   const decoder = new TextDecoder()
   let buffered = ''
+  const observer = streamSummaryObserver(aliases)
   for await (const chunk of upstream.body) {
     onActivity()
     buffered += decoder.decode(chunk, { stream: true })
     const lines = buffered.split('\n')
     buffered = lines.pop() ?? ''
-    for (const line of lines) response.write(`${rewriteSseLine(line, aliases)}\n`)
+    for (const line of lines) response.write(`${rewriteSseLine(line, aliases, observer.observe)}\n`)
   }
   buffered += decoder.decode()
-  if (buffered) response.write(rewriteSseLine(buffered, aliases))
+  if (buffered) response.write(rewriteSseLine(buffered, aliases, observer.observe))
   response.end()
+  return observer.summary()
 }
 
 const readResponseText = async (upstream: Response, onActivity: () => void): Promise<string> => {
@@ -659,6 +768,17 @@ export class NativeResponsesCompatibilityProxy {
                 Buffer.byteLength(JSON.stringify(upstreamRequestWithoutInput), 'utf8') -
                 (Object.keys(upstreamRequestWithoutInput).length > 0 ? 9 : 8)
             )
+      const inputItems = Array.isArray(upstreamInput) ? upstreamInput : []
+      const developerItems = inputItems.filter(
+        (item) => isObject(item) && item.type === 'message' && item.role === 'developer'
+      )
+      const topLevelArtifactInstructionPresent = containsText(
+        upstreamRequest.instructions,
+        '<open_science_artifact_instructions>'
+      )
+      const developerArtifactInstructionPresent = developerItems.some((item) =>
+        containsText(item.content, '<open_science_artifact_instructions>')
+      )
       log.info('native Responses compatibility request', {
         requestId,
         requestBytes,
@@ -675,6 +795,17 @@ export class NativeResponsesCompatibilityProxy {
         toolDefinitionCount: Array.isArray(upstreamRequest.tools)
           ? upstreamRequest.tools.length
           : 0,
+        developerInstructionItemCount: developerItems.length,
+        topLevelArtifactInstructionPresent,
+        developerArtifactInstructionPresent,
+        artifactInstructionPresent:
+          topLevelArtifactInstructionPresent || developerArtifactInstructionPresent,
+        artifactToolPresent:
+          Array.isArray(upstreamRequest.tools) &&
+          upstreamRequest.tools.some((tool: unknown) => isArtifactTool(tool, aliases)),
+        functionCallOutputHistoryCount: inputItems.filter(
+          (item) => isObject(item) && item.type === 'function_call_output'
+        ).length,
         promptCacheKeyPresent: promptCacheKey !== undefined,
         namespaceToolCount: aliases.size,
         stream: body.stream === true,
@@ -773,7 +904,11 @@ export class NativeResponsesCompatibilityProxy {
         response.end(snapshot.body)
       } else if (responseType === 'event-stream') {
         armStreamIdleTimeout()
-        await streamResponse(upstream, response, aliases, armStreamIdleTimeout)
+        const summary = await streamResponse(upstream, response, aliases, armStreamIdleTimeout)
+        log.info('native Responses compatibility stream completed', {
+          requestId,
+          ...(summary ?? { terminalEventType: 'missing' })
+        })
       } else if (responseType === 'json') {
         armStreamIdleTimeout()
         const payload = restoreNativeResponsesPayload(


### PR DESCRIPTION
## Problem

A native Responses turn can complete after a Notebook tool creates a user-facing file even though the assistant only says it will export the file and never calls `write_artifact_file`. The observed MiniMax-M3 dev session ended normally at the ACP boundary, and the existing logs cannot distinguish missing Artifact instructions/tools from an upstream stream that completed without the call.

## Proposed change

- Add privacy-safe structural request diagnostics for Artifact instruction/tool presence and prior function-call outputs.
- Observe the raw upstream SSE shape through terminal events and count function calls, including Artifact calls emitted before a sparse terminal event.
- Add an HTTP/SSE regression fixture matching the reported Notebook-file-then-clean-completion behavior.

No request or response bytes are changed by the diagnostics.

## Scope and non-goals

- No automatic continuation, retry, or heuristic recovery.
- No automatic publishing of Notebook working files.
- No UI or interaction change.
- No database/schema, Session/Notebook/Artifact data-model, persisted state, or enum change.
- No historical migration or compatibility path is required; old logs cannot be backfilled.

## Acceptance criteria and validation

- Red on the pre-fix implementation: the public proxy fixture reproduced a completed assistant-text stream with Notebook output history and no Artifact call, then failed because the structural diagnostics were absent.
- `npm test -- --run src/main/settings/native-responses-compatibility.test.ts` — 29 passed.
- `npm run test:module -- settings_backend_resolution` — 618 passed, 4 skipped across 38 files.
- `npm run typecheck:node` — passed.
- `npm run lint` — passed.
- `git diff --check` — passed.

Per request, the full `npm test` suite was not run; PR CI is the final validation authority.

## Framework/path risk matrix

| Path | Status | Reason |
| --- | --- | --- |
| Codex native Responses compatibility proxy | Included | This is the only behavior/logging boundary changed. |
| Provider-native Responses models (observed with MiniMax-M3) | Included | Diagnostics are provider-agnostic and use protocol structure only. |
| Codex Chat bridge and direct official provider path | Excluded | They do not traverse this compatibility stream path. |
| Claude Code and OpenCode | Excluded | Their transports are unchanged. |
| macOS, Windows, Linux | Included structurally | All use the same Node stream observer; no OS-specific behavior was introduced. CI remains authoritative for cross-platform validation. |

## Review focus

- Confirm logs expose only counts/booleans/status and never prompt text, tool arguments, paths, or credentials.
- Confirm incremental and terminal SSE items are deduplicated without altering forwarded bytes.
- Confirm diagnostics-only scope is preferable to speculative recovery after a single observed incident.
