### PR TITLE
test(streamdown): cover download and cleanup boundaries

### DIFF
--- a/src/renderer/src/components/streamdown/install-streamdown.download.test.ts
+++ b/src/renderer/src/components/streamdown/install-streamdown.download.test.ts
@@ -15,6 +15,61 @@ const clickBlobDownload = (url: string, filename = 'result.csv'): void => {
   anchor.click()
 }
 
+const createMermaidDownload = (
+  withSvg: boolean
+): {
+  button: HTMLButtonElement
+  diagram: HTMLDivElement
+} => {
+  const block = document.createElement('div')
+  block.dataset.streamdown = 'mermaid-block'
+  const actions = document.createElement('div')
+  actions.dataset.streamdown = 'mermaid-block-actions'
+  const relative = document.createElement('div')
+  relative.className = 'relative'
+  const button = document.createElement('button')
+  const diagram = document.createElement('div')
+  diagram.dataset.streamdown = 'mermaid'
+  if (withSvg) {
+    diagram.appendChild(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
+  }
+  relative.appendChild(button)
+  actions.appendChild(relative)
+  block.append(actions, diagram)
+  document.body.appendChild(block)
+  return { button, diagram }
+}
+
+const clickInlineTableCsvDownload = (): void => {
+  const root = document.createElement('div')
+  root.className = 'agent-markdown-root'
+  root.innerHTML = `
+    <div data-streamdown="table-wrapper">
+      <div>
+        <div class="relative"><button></button></div>
+        <div class="relative"><button></button></div>
+      </div>
+      <table>
+        <thead><tr><th>Name</th><th>Value</th></tr></thead>
+        <tbody><tr><td>alpha</td><td>1</td></tr></tbody>
+      </table>
+    </div>
+  `
+  document.body.appendChild(root)
+  const downloadButton = root.querySelectorAll<HTMLButtonElement>('.relative > button').item(1)
+  downloadButton.dispatchEvent(
+    new MouseEvent('mousedown', { button: 0, bubbles: true, cancelable: true })
+  )
+
+  const csvButton = [
+    ...document.querySelectorAll<HTMLButtonElement>('[data-sd-table-format-menu] button')
+  ].find((button) => button.textContent === 'CSV')
+  if (!csvButton) throw new Error('CSV table format action was not rendered')
+  csvButton.dispatchEvent(
+    new MouseEvent('mousedown', { button: 0, bubbles: true, cancelable: true })
+  )
+}
+
 beforeEach(() => {
   saveBlobFile = vi.fn().mockResolvedValue({ saved: true })
   ;(window as unknown as { api: unknown }).api = { saveBlobFile }
@@ -41,6 +96,33 @@ describe('Streamdown blob download bridge', () => {
 
     button.click()
     await vi.waitFor(() => expect(saveBlobFile).toHaveBeenCalledOnce())
+    const request = saveBlobFile.mock.calls[0]?.[0] as {
+      suggestedName: string
+      mimeType: string
+      data: ArrayBuffer
+    }
+    expect(request).toMatchObject({ suggestedName: 'result.csv', mimeType: 'text/csv' })
+    expect(new TextDecoder().decode(request.data)).toBe('a,b')
+  })
+
+  it('contains save failures from a tracked blob download', async () => {
+    const error = new Error('save failed')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    saveBlobFile.mockRejectedValueOnce(error)
+    const root = document.createElement('div')
+    root.className = 'agent-markdown-root'
+    const button = document.createElement('button')
+    button.addEventListener('click', () => {
+      clickBlobDownload(URL.createObjectURL(new Blob(['a,b'], { type: 'text/csv' })))
+    })
+    root.appendChild(button)
+    document.body.appendChild(root)
+
+    button.click()
+
+    await vi.waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith('[streamdown-download] save failed:', error)
+    )
   })
 
   it('does not claim an unrelated blob download after another Streamdown button click', async () => {
@@ -53,6 +135,24 @@ describe('Streamdown blob download bridge', () => {
 
     button.click()
     clickBlobDownload(unrelatedUrl)
+    await new Promise((resolve) => window.setTimeout(resolve, 0))
+
+    expect(saveBlobFile).not.toHaveBeenCalled()
+  })
+
+  it('does not save a tracked blob after its object URL is revoked', async () => {
+    const root = document.createElement('div')
+    root.className = 'agent-markdown-root'
+    const button = document.createElement('button')
+    button.addEventListener('click', () => {
+      const url = URL.createObjectURL(new Blob(['a,b'], { type: 'text/csv' }))
+      URL.revokeObjectURL(url)
+      clickBlobDownload(url)
+    })
+    root.appendChild(button)
+    document.body.appendChild(root)
+
+    button.click()
     await new Promise((resolve) => window.setTimeout(resolve, 0))
 
     expect(saveBlobFile).not.toHaveBeenCalled()
@@ -73,5 +173,66 @@ describe('Streamdown blob download bridge', () => {
     clickBlobDownload(URL.createObjectURL(new Blob(['png'], { type: 'image/png' })), 'image.png')
 
     await vi.waitFor(() => expect(saveBlobFile).toHaveBeenCalledOnce())
+  })
+})
+
+describe('Streamdown Mermaid download bridge', () => {
+  it('saves an SVG that appears asynchronously after the download action', async () => {
+    const { button, diagram } = createMermaidDownload(false)
+
+    button.click()
+    diagram.appendChild(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
+
+    await vi.waitFor(() => expect(saveBlobFile).toHaveBeenCalledOnce())
+    const request = saveBlobFile.mock.calls[0]?.[0] as {
+      suggestedName: string
+      mimeType: string
+      data: ArrayBuffer
+    }
+    expect(request).toMatchObject({
+      suggestedName: 'diagram.svg',
+      mimeType: 'image/svg+xml'
+    })
+    expect(new TextDecoder().decode(request.data)).toContain('xmlns="http://www.w3.org/2000/svg"')
+  })
+
+  it('contains save failures from the Mermaid download action', async () => {
+    const error = new Error('save failed')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    saveBlobFile.mockRejectedValueOnce(error)
+    const { button } = createMermaidDownload(true)
+
+    button.click()
+
+    await vi.waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith('[streamdown-download] save failed:', error)
+    )
+  })
+})
+
+describe('Streamdown table download bridge', () => {
+  it('saves an inline table as UTF-8 CSV', async () => {
+    clickInlineTableCsvDownload()
+
+    await vi.waitFor(() => expect(saveBlobFile).toHaveBeenCalledOnce())
+    const request = saveBlobFile.mock.calls[0]?.[0] as {
+      suggestedName: string
+      mimeType: string
+      data: ArrayBuffer
+    }
+    expect(request).toMatchObject({ suggestedName: 'table.csv', mimeType: 'text/csv' })
+    expect([...new Uint8Array(request.data).slice(0, 3)]).toEqual([0xef, 0xbb, 0xbf])
+  })
+
+  it('contains table save failures and closes the format menu', async () => {
+    const error = new Error('save failed')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    saveBlobFile.mockRejectedValueOnce(error)
+    clickInlineTableCsvDownload()
+
+    await vi.waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith('[streamdown-table] action failed:', error)
+    )
+    expect(document.querySelector('[data-sd-table-format-menu]')).toBeNull()
   })
 })

--- a/src/renderer/src/components/streamdown/install-streamdown.fullscreen.test.ts
+++ b/src/renderer/src/components/streamdown/install-streamdown.fullscreen.test.ts
@@ -179,6 +179,19 @@ describe('Mermaid fullscreen exit adapter', () => {
     expect(originalClose).toHaveBeenCalledTimes(1)
     expect(overlay.dataset.fullscreenState).toBeUndefined()
   })
+
+  it('cancels a pending close replay when the adapter is uninstalled', () => {
+    const { closeButton } = createMermaidFullscreen()
+    const originalClose = vi.fn()
+    closeButton.addEventListener('click', originalClose)
+
+    closeButton.click()
+    uninstall?.()
+    uninstall = undefined
+    vi.advanceTimersByTime(150)
+
+    expect(originalClose).not.toHaveBeenCalled()
+  })
 })
 
 describe('Table fullscreen exit adapter', () => {

--- a/src/renderer/src/components/streamdown/install-streamdown.lifecycle.test.ts
+++ b/src/renderer/src/components/streamdown/install-streamdown.lifecycle.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { installStreamdown } from './install-streamdown'
+
+let cleanups: Array<() => void>
+let saveBlobFile: ReturnType<typeof vi.fn>
+
+const clickStreamdownBlobDownload = (): void => {
+  const root = document.createElement('div')
+  root.className = 'agent-markdown-root'
+  const button = document.createElement('button')
+  button.addEventListener('click', () => {
+    const anchor = document.createElement('a')
+    anchor.href = URL.createObjectURL(new Blob(['a,b'], { type: 'text/csv' }))
+    anchor.download = 'result.csv'
+    anchor.addEventListener('click', (event) => event.preventDefault())
+    document.body.appendChild(anchor)
+    anchor.click()
+  })
+  root.appendChild(button)
+  document.body.appendChild(root)
+  button.click()
+}
+
+beforeEach(() => {
+  saveBlobFile = vi.fn().mockResolvedValue({ saved: true })
+  ;(window as unknown as { api: unknown }).api = { saveBlobFile }
+  cleanups = []
+})
+
+afterEach(() => {
+  for (const cleanup of cleanups) cleanup()
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+describe('Streamdown installation lifecycle', () => {
+  it('keeps shared URL hooks until the final caller disposes', () => {
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+    const firstCleanup = installStreamdown()
+    const secondCleanup = installStreamdown()
+    cleanups.push(firstCleanup, secondCleanup)
+    const installedCreateObjectURL = URL.createObjectURL
+    const installedRevokeObjectURL = URL.revokeObjectURL
+
+    expect(installedCreateObjectURL).not.toBe(originalCreateObjectURL)
+    expect(installedRevokeObjectURL).not.toBe(originalRevokeObjectURL)
+
+    firstCleanup()
+
+    expect(URL.createObjectURL).toBe(installedCreateObjectURL)
+    expect(URL.revokeObjectURL).toBe(installedRevokeObjectURL)
+
+    secondCleanup()
+
+    expect(URL.createObjectURL).not.toBe(installedCreateObjectURL)
+    expect(URL.revokeObjectURL).not.toBe(installedRevokeObjectURL)
+  })
+
+  it('keeps the shared bridge installed when one caller disposes more than once', async () => {
+    const firstCleanup = installStreamdown()
+    const secondCleanup = installStreamdown()
+    cleanups.push(firstCleanup, secondCleanup)
+
+    firstCleanup()
+    firstCleanup()
+    clickStreamdownBlobDownload()
+    await new Promise((resolve) => window.setTimeout(resolve, 0))
+
+    expect(saveBlobFile).toHaveBeenCalledOnce()
+  })
+
+  it('clears pending image attribution before a later installation', async () => {
+    const firstCleanup = installStreamdown()
+    cleanups.push(firstCleanup)
+    const root = document.createElement('div')
+    root.className = 'agent-markdown-root'
+    const imageWrapper = document.createElement('div')
+    imageWrapper.dataset.streamdown = 'image-wrapper'
+    const button = document.createElement('button')
+    imageWrapper.appendChild(button)
+    root.appendChild(imageWrapper)
+    document.body.appendChild(root)
+
+    button.click()
+    await Promise.resolve()
+    firstCleanup()
+    cleanups.push(installStreamdown())
+
+    const url = URL.createObjectURL(new Blob(['png'], { type: 'image/png' }))
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = 'image.png'
+    anchor.addEventListener('click', (event) => event.preventDefault())
+    document.body.appendChild(anchor)
+    anchor.click()
+    await new Promise((resolve) => window.setTimeout(resolve, 0))
+
+    expect(saveBlobFile).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/streamdown/install-streamdown.ts
+++ b/src/renderer/src/components/streamdown/install-streamdown.ts
@@ -269,7 +269,9 @@ const installMermaidDownload = (): (() => void) => {
     event.preventDefault()
     event.stopImmediatePropagation()
 
-    void saveMermaidSvg(block)
+    void saveMermaidSvg(block).catch((error) => {
+      console.error('[streamdown-download] save failed:', error)
+    })
   }
 
   document.addEventListener('click', onDownloadClick, true)
@@ -763,8 +765,11 @@ const installStreamdown = (): (() => void) => {
   }
 
   installCount += 1
+  let active = true
 
   return () => {
+    if (!active) return
+    active = false
     installCount = Math.max(0, installCount - 1)
     if (installCount === 0) {
       while (uninstallers.length > 0) {


### PR DESCRIPTION
## Problem

`install-streamdown.ts` had only 58.17% line and 33.45% branch coverage. Its tests did not protect
download failures, Mermaid/table downloads, repeated installation, duplicate disposer calls, or
final timer and Blob-attribution cleanup. Inspection also found that a duplicate disposer could
tear down hooks still owned by another caller, and a rejected Mermaid save escaped as an unhandled
promise rejection.

## Proposed change

- cover Blob payloads, rejection containment, URL revocation, and attribution cleanup;
- cover asynchronous Mermaid SVG saving and rejected saves;
- cover representative table CSV saving and rejected table saves;
- cover repeated installation, duplicate disposer calls, and final hook teardown;
- cover cancellation of pending fullscreen close replay during uninstall;
- make each returned disposer idempotent; and
- contain Mermaid save rejection with the existing Streamdown download error log.

## Scope and non-goals

- No platform-specific cases: this renderer module has no OS branch, and Electron/Web differences
  remain behind `window.api.saveBlobFile`.
- No historical compatibility, status/enum, or data-persistence changes.
- No geometry snapshots or exhaustive tests of Streamdown's table conversion library.
- No complete local `npm test`; exact-head PR CI remains authoritative for the portable and platform
  suites.

## Acceptance criteria and validation

Checks below ran after the last material edit:

- Blob save payload/failure/revocation -> targeted Streamdown Vitest files -> passed.
- Mermaid async save/failure -> targeted Streamdown Vitest files -> passed.
- Table CSV save/failure -> targeted Streamdown Vitest files -> passed.
- Repeated install/disposer and attribution cleanup -> lifecycle test -> passed.
- Fullscreen pending-timer cleanup -> fullscreen test -> passed.
- `3` targeted files / `21` tests -> passed.
- `install-streamdown.ts` coverage: statements 75.96%, branches 54.74%, functions 88.40%, lines
  82.61% (baseline: 53.70%, 33.45%, 60.29%, 58.17%).
- Prettier check for all four changed files -> passed.
- `npm run lint` -> passed.
- `npm run typecheck:web` -> blocked by the shared generated Prisma Client: existing
  `src/main/session-persistence/projection.ts` references `sessionModelCallUsage`, which is absent
  from that generated client. No changed file produced a TypeScript diagnostic. Dependency
  generation/install was intentionally not run in the isolated worktree.

Local tests used the lockfile-matching Vitest 4.1.10 shared install. The local Node runtime is v24;
the project-supported Node 22 lane is covered by PR CI. Remaining uncovered paths are primarily menu
geometry, invalid-DOM defensive guards, and additional focus-loop combinations.

## Review focus

- Verify the per-disposer active guard preserves the existing shared reference count.
- Verify Mermaid failures are contained without changing successful save behavior.
- Confirm the DOM-driven tests protect user-observable behavior without coupling to private helpers.
