### PR TITLE
test(coverage): ratchet full-suite thresholds

### DIFF
--- a/scripts/ci/module-test-impact.mjs
+++ b/scripts/ci/module-test-impact.mjs
@@ -260,8 +260,15 @@ export function runModuleTestCli(arguments_ = process.argv.slice(2), options = {
     process.stdout.write(formatModuleTestPlan(plan))
     return 0
   }
+  const environment = coverageChanged
+    ? {
+        ...(options.environment ?? process.env),
+        VITEST_CHANGED_COVERAGE_THRESHOLDS: '1'
+      }
+    : options.environment
   return executeModuleTestPlan(plan, {
     ...options,
+    environment,
     testArguments: coverageChanged
       ? ['--coverage', '--coverage.changed', coverageChanged]
       : options.testArguments

--- a/scripts/ci/module-test-impact.test.ts
+++ b/scripts/ci/module-test-impact.test.ts
@@ -456,6 +456,7 @@ describe('module test impact commands', () => {
       ['/npm/bin/npm-cli.js', 'test', '--', ...plan.testFiles],
       expect.objectContaining({ cwd: '/repo', stdio: 'inherit' })
     )
+    expect(spawn.mock.calls[0]?.[2]?.env).not.toHaveProperty('VITEST_CHANGED_COVERAGE_THRESHOLDS')
     write.mockRestore()
   })
 
@@ -475,6 +476,7 @@ describe('module test impact commands', () => {
     })
     const spawn = vi.fn(() => ({ status: 0 }))
     const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    const environment = { npm_execpath: '/npm/bin/npm-cli.js' }
     const expectedPlan = createAffectedTestPlan(
       [{ path: 'src/main/artifacts/repository.ts', status: 'modified' }],
       { status: 'current', testFiles: [] }
@@ -485,7 +487,7 @@ describe('module test impact commands', () => {
         cwd: '/repo',
         execute,
         spawn,
-        environment: { npm_execpath: '/npm/bin/npm-cli.js' },
+        environment,
         nodeExecutable: '/node'
       })
     ).toBe(0)
@@ -500,9 +502,17 @@ describe('module test impact commands', () => {
         base,
         ...expectedPlan.testFiles
       ],
-      expect.objectContaining({ cwd: '/repo', stdio: 'inherit' })
+      expect.objectContaining({
+        cwd: '/repo',
+        env: {
+          npm_execpath: '/npm/bin/npm-cli.js',
+          VITEST_CHANGED_COVERAGE_THRESHOLDS: '1'
+        },
+        stdio: 'inherit'
+      })
     )
     expect(spawn.mock.calls[0]?.[1]).toContain('src/main/reviewer/ipc.test.ts')
+    expect(environment).toEqual({ npm_execpath: '/npm/bin/npm-cli.js' })
     write.mockRestore()
   })
 

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -3,7 +3,10 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 import vitestConfig, {
+  CHANGED_SOURCE_COVERAGE_THRESHOLDS,
   coverageThresholdsEnabled,
+  coverageThresholdsFor,
+  FULL_COVERAGE_THRESHOLDS,
   resolveVitestMaxWorkers,
   VITEST_ARCHITECTURE_TEST_GLOBS,
   VITEST_COVERAGE_EXCLUDE_PATTERNS,
@@ -28,6 +31,37 @@ it('defers coverage thresholds only for explicit shard collection', () => {
   expect(coverageThresholdsEnabled({})).toBe(true)
   expect(coverageThresholdsEnabled({ VITEST_DEFER_COVERAGE_THRESHOLDS: '1' })).toBe(false)
   expect(coverageThresholdsEnabled({ VITEST_DEFER_COVERAGE_THRESHOLDS: '0' })).toBe(true)
+  expect(
+    coverageThresholdsFor({
+      VITEST_CHANGED_COVERAGE_THRESHOLDS: '1',
+      VITEST_DEFER_COVERAGE_THRESHOLDS: '1'
+    })
+  ).toBeUndefined()
+})
+
+it('ratchets full coverage without raising selective changed-source thresholds', () => {
+  expect(FULL_COVERAGE_THRESHOLDS).toEqual({
+    lines: 90,
+    functions: 88,
+    branches: 79,
+    statements: 88
+  })
+  expect(CHANGED_SOURCE_COVERAGE_THRESHOLDS).toEqual({
+    lines: 66,
+    functions: 62,
+    branches: 57,
+    statements: 64
+  })
+  expect(coverageThresholdsFor({})).toMatchObject(FULL_COVERAGE_THRESHOLDS)
+  expect(coverageThresholdsFor({ VITEST_CHANGED_COVERAGE_THRESHOLDS: '1' })).toMatchObject(
+    CHANGED_SOURCE_COVERAGE_THRESHOLDS
+  )
+  expect(coverageThresholdsFor({ VITEST_CHANGED_COVERAGE_THRESHOLDS: '0' })).toMatchObject(
+    FULL_COVERAGE_THRESHOLDS
+  )
+  expect(vitestConfig.test?.coverage).toMatchObject({
+    thresholds: expect.objectContaining(FULL_COVERAGE_THRESHOLDS)
+  })
 })
 
 it('keeps a safe default timeout for schema-backed hooks', () => {

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -59,9 +59,11 @@ it('ratchets full coverage without raising selective changed-source thresholds',
   expect(coverageThresholdsFor({ VITEST_CHANGED_COVERAGE_THRESHOLDS: '0' })).toMatchObject(
     FULL_COVERAGE_THRESHOLDS
   )
-  expect(vitestConfig.test?.coverage).toMatchObject({
-    thresholds: expect.objectContaining(FULL_COVERAGE_THRESHOLDS)
-  })
+  expect(vitestConfig.test?.coverage?.thresholds).toEqual(
+    coverageThresholdsEnabled(process.env)
+      ? expect.objectContaining(FULL_COVERAGE_THRESHOLDS)
+      : undefined
+  )
 })
 
 it('keeps a safe default timeout for schema-backed hooks', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -51,6 +51,54 @@ function coverageThresholdsEnabled(env: NodeJS.ProcessEnv): boolean {
   return env.VITEST_DEFER_COVERAGE_THRESHOLDS !== '1'
 }
 
+const FULL_COVERAGE_THRESHOLDS = {
+  lines: 90,
+  functions: 88,
+  branches: 79,
+  statements: 88
+} as const
+
+// `coverage.changed` limits the report to changed source files. Preserve its existing contract
+// instead of requiring every selective diff to match the whole repository's aggregate baseline.
+const CHANGED_SOURCE_COVERAGE_THRESHOLDS = {
+  lines: 66,
+  functions: 62,
+  branches: 57,
+  statements: 64
+} as const
+
+type CoverageThresholds = Record<
+  string,
+  number | { lines: number; functions: number; branches: number; statements: number }
+>
+
+function coverageThresholdsFor(env: NodeJS.ProcessEnv): CoverageThresholds | undefined {
+  if (!coverageThresholdsEnabled(env)) return undefined
+
+  const aggregate =
+    env.VITEST_CHANGED_COVERAGE_THRESHOLDS === '1'
+      ? CHANGED_SOURCE_COVERAGE_THRESHOLDS
+      : FULL_COVERAGE_THRESHOLDS
+
+  return {
+    ...aggregate,
+    // Keep the now-covered update wiring from being masked by the global aggregate.
+    'src/main/update/**': {
+      lines: 85,
+      functions: 75,
+      branches: 70,
+      statements: 80
+    },
+    // CSV is a user-facing renderer with bounded-data and fallback behavior worth protecting.
+    'src/renderer/src/pages/workspace/previews/renderers/CsvPreview.tsx': {
+      lines: 95,
+      functions: 95,
+      branches: 80,
+      statements: 95
+    }
+  }
+}
+
 // Mirrors the renderer alias from electron.vite.config.ts so tests that mount real component
 // trees (instead of mocking every aliased import) can resolve '@/...' without a build step.
 export default defineConfig({
@@ -144,33 +192,18 @@ export default defineConfig({
       include: ['src/**/*.{ts,tsx}'],
       // Exclude non-logic files so coverage reflects testable code, not wiring/types.
       exclude: VITEST_COVERAGE_EXCLUDE_PATTERNS,
-      // Baseline thresholds: fail CI when global coverage drops below these. Set ~5pts under the
-      // current measured baseline (lines 71 / statements 70 / functions 68 / branches 62) so the gate
-      // catches regressions while absorbing minor cross-environment variance. Raise over time.
-      thresholds: coverageThresholdsEnabled(process.env)
-        ? {
-            lines: 66,
-            functions: 62,
-            branches: 57,
-            statements: 64,
-            // Keep the now-covered update wiring from being masked by the global aggregate.
-            'src/main/update/**': {
-              lines: 85,
-              functions: 75,
-              branches: 70,
-              statements: 80
-            },
-            // CSV is a user-facing renderer with bounded-data and fallback behavior worth protecting.
-            'src/renderer/src/pages/workspace/previews/renderers/CsvPreview.tsx': {
-              lines: 95,
-              functions: 95,
-              branches: 80,
-              statements: 95
-            }
-          }
-        : undefined
+      // Keep the full-suite gate about one point below the measured main baseline. Selective
+      // changed-source runs retain their separately calibrated compatibility thresholds.
+      thresholds: coverageThresholdsFor(process.env)
     }
   }
 })
 
-export { coverageThresholdsEnabled, VITEST_COVERAGE_EXCLUDE_PATTERNS, VITEST_EXCLUDE_PATTERNS }
+export {
+  CHANGED_SOURCE_COVERAGE_THRESHOLDS,
+  coverageThresholdsEnabled,
+  coverageThresholdsFor,
+  FULL_COVERAGE_THRESHOLDS,
+  VITEST_COVERAGE_EXCLUDE_PATTERNS,
+  VITEST_EXCLUDE_PATTERNS
+}


### PR DESCRIPTION
## Problem

The configured global Vitest thresholds (64% statements, 57% branches, 62% functions, 66% lines) trail the current full-suite baseline by 17-25 points, so they cannot stop a clear repository-wide regression. A direct threshold replacement would also apply the repository aggregate target to selective `coverage.changed` reports, whose denominator is only changed source files.

## Proposed change

- raise full/unsharded and merged full-suite thresholds to 88% statements, 79% branches, 88% functions, and 90% lines
- retain the existing 64/57/62/66 compatibility thresholds for selective changed-source coverage
- have the project-owned affected-test command set an explicit process-local flag only when it constructs `--coverage.changed`
- preserve shard threshold deferral and both existing path-specific thresholds
- add focused contract tests for threshold selection and environment propagation

The latest completed parent-tree aggregate (PR #1756, merged-coverage job `98047292349`) is 89.24% statements, 80.67% branches, 89.78% functions, and 91.80% lines. Current main adds only a test file, so the proposed floors retain at least 1.24/1.67/1.78/1.80 points of headroom respectively before its exact PR #1758 report.

## Scope and non-goals

- no workflow YAML, shard topology, reporters, include/exclude patterns, runner platforms, or package metadata changes
- no production behavior or application architecture changes
- no automatic threshold updates
- no changed-source policy tightening beyond preserving its current thresholds

Historical compatibility: preserves the legacy `coverage_macos` path, shard deferral behavior, direct Build coverage behavior, existing path-specific gates, and selective changed-source thresholds.

State/enums: no application state or persisted enum changes. One exact-value, process-local environment flag selects the changed-source threshold profile.

Data persistence: none; no schema, migration, durable setting, cache, or file-format change.

## Acceptance criteria and validation

- threshold profile selection and shard deferral: `node ..\\..\\node_modules\\vitest\\vitest.mjs run vitest.config.test.ts scripts\\ci\\module-test-impact.test.ts` -> 2 files, 41 tests passed
- changed-source flag propagation, absence on ordinary runs, and caller-environment immutability: covered by the same focused run -> passed
- targeted static analysis: `node ..\\..\\node_modules\\eslint\\bin\\eslint.js vitest.config.ts vitest.config.test.ts scripts\\ci\\module-test-impact.mjs scripts\\ci\\module-test-impact.test.ts` -> passed
- diff integrity: `git diff --check origin/main...HEAD` -> passed
- all checks above were rerun after rebasing onto the latest `origin/main`

Per task scope, the complete local `npm run test` suite was not run. A discarded Windows/Node 24 full-coverage attempt hit ACL-dependent test failures and is not used as evidence. PR Gate's Node 22 macOS shards and Ubuntu merge job are the authoritative full-suite validation.

## Review focus

- confirm the full-suite margins are appropriately conservative relative to the merged CI baseline
- confirm selective `coverage.changed` runs keep their existing contract while full merge/direct callers receive the ratcheted thresholds
- confirm no caller can accidentally inherit the changed-source flag through mutation
