### PR TITLE
fix(providers): offer GLM-4.5-Air for Zhipu

### DIFF
--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -97,6 +97,13 @@ describe('provider registry', () => {
     )
   })
 
+  it('offers GLM-4.5-Air through the official Zhipu provider', () => {
+    expect(getOfficialVendor('zhipu')?.models).toContainEqual({
+      id: 'glm-4.5-air',
+      contextWindow: 128_000
+    })
+  })
+
   it('routes the GLM Coding Plan through the /api/coding OpenAI path, per region', () => {
     expect(vendorHasRegions('glmcodingplan')).toBe(true)
     expect(resolveVendorApiEndpoints('glmcodingplan')).toEqual(['anthropic', 'openai'])

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -359,7 +359,8 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
       { id: 'glm-5.1', contextWindow: 200_000 },
       { id: 'glm-5', contextWindow: 200_000 },
       { id: 'glm-5v-turbo', contextWindow: 200_000 },
-      { id: 'glm-5-turbo', contextWindow: 200_000 }
+      { id: 'glm-5-turbo', contextWindow: 200_000 },
+      { id: 'glm-4.5-air', contextWindow: 128_000 }
     ],
     // GLM marks vision variants with a `v` after the major version (e.g. glm-5v-turbo); the pattern
     // also covers future `Nv` ids the live refresh may surface.


### PR DESCRIPTION
## Problem

`glm-4.5-air` is documented by Zhipu but was absent from the built-in Zhipu provider catalog. Users therefore tried the Custom Gateway form with `https://open.bigmodel.cn/api/paas/v4`; that contract appends `/v1/chat/completions`, producing a nonexistent endpoint and the reported `Not Found` validation failure.

## Proposed change

- expose `glm-4.5-air` through the existing official Zhipu provider
- record its documented 128K context window
- add a regression test at the shared provider-catalog boundary

The official provider already preserves Zhipu's exact `/api/paas/v4` OpenAI-compatible base, so no URL-routing change is needed.

## Scope and non-goals

- no custom-gateway endpoint templates or exact-path mode
- no schema, persisted-format, enum, or interaction changes
- no historical-data migration; existing custom-provider records remain unchanged and can be replaced with an official Zhipu provider

## Acceptance criteria and validation

- Zhipu's official catalog offers `glm-4.5-air` with a 128K context window
- existing Z.AI and BigModel endpoint routing remains unchanged

Final checks ran after the last material edit:

- official catalog exposure -> `npm test -- src/shared/provider-registry.test.ts` -> 59 passed
- provider account ownership, routing, validation, and consumers -> `npm run test:module -- settings_provider_accounts` -> 394 passed
- shared main-process types -> `npm run typecheck:node` -> passed
- shared renderer types -> `npm run typecheck:web` -> passed
- source lint -> `npm run lint` -> passed

The complete local `npm test` suite was intentionally not run; exact-head PR CI remains authoritative. No live authenticated Zhipu request was made because validation would require a user API key.

## Review focus

Please confirm that the catalog-only change is preferable to broadening the Custom Gateway URL contract for this vendor-specific versioned endpoint.

Closes #1717
