### PR TITLE
feat(providers): add OpenCode Go and Zen

### DIFF
--- a/src/renderer/src/pages/onboarding/ProviderStep.render.test.tsx
+++ b/src/renderer/src/pages/onboarding/ProviderStep.render.test.tsx
@@ -105,6 +105,31 @@ const submitClaudeFallbackToken = async (token: string): Promise<void> => {
 }
 
 describe('ProviderStep', () => {
+  it('offers OpenCode Go and Zen when OpenCode is the active framework', async () => {
+    useSettingsStore.setState({
+      agentFrameworkId: 'opencode',
+      agentFrameworks: [
+        {
+          id: 'opencode',
+          displayName: 'OpenCode',
+          supportedApiTypes: ['anthropic', 'openai'],
+          supportsSkills: true
+        }
+      ]
+    })
+
+    await renderStep()
+
+    const trigger = container.querySelector<HTMLButtonElement>('[aria-label="Provider type"]')
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }))
+      trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(document.body.textContent).toContain('OpenCode Go')
+    expect(document.body.textContent).toContain('OpenCode Zen')
+  })
+
   it('defaults an untouched custom gateway to the active framework API format', async () => {
     useSettingsStore.setState({
       agentFrameworkId: 'opencode',

--- a/src/renderer/src/pages/settings/provider-icons.render.test.tsx
+++ b/src/renderer/src/pages/settings/provider-icons.render.test.tsx
@@ -1,0 +1,17 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import { ProviderKindIcon } from './provider-icons'
+
+describe('ProviderKindIcon', () => {
+  it.each(['official:opencode-go', 'official:opencode'])(
+    'reuses the OpenCode logo for %s',
+    (kindKey) => {
+      const html = renderToStaticMarkup(<ProviderKindIcon kindKey={kindKey} />)
+
+      expect(html).toContain('<svg')
+      expect(html).toContain('text-foreground')
+      expect(html).not.toContain('text-muted-foreground')
+    }
+  )
+})

--- a/src/renderer/src/pages/settings/provider-icons.tsx
+++ b/src/renderer/src/pages/settings/provider-icons.tsx
@@ -101,6 +101,16 @@ export const ProviderKindIcon = ({
     return <img src={claudeLogo} alt="" className={cn('size-5 shrink-0', className)} />
   }
 
+  if (kindKey === 'official:opencode-go' || kindKey === 'official:opencode') {
+    return (
+      <OpenCode
+        size={20}
+        className={cn('size-5 shrink-0 text-foreground', className)}
+        aria-hidden="true"
+      />
+    )
+  }
+
   const vendorId = kindKey.slice('official:'.length) as OfficialVendorId
   const logo = VENDOR_LOGO[vendorId]
 

--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -46,6 +46,22 @@ describe('provider registry', () => {
     expect(OFFICIAL_VENDORS[anthropicIndex + 1]?.id).toBe('xai')
   })
 
+  it('places OpenCode Go and Zen immediately before OpenRouter with curated Chat catalogs', () => {
+    const openRouterIndex = OFFICIAL_VENDORS.findIndex((vendor) => vendor.id === 'openrouter')
+
+    expect(
+      OFFICIAL_VENDORS.slice(openRouterIndex - 2, openRouterIndex + 1).map(({ id }) => id)
+    ).toEqual(['opencode-go', 'opencode', 'openrouter'])
+    expect(resolveVendorBaseUrl('opencode-go')).toBe('https://opencode.ai/zen/go/v1')
+    expect(resolveVendorBaseUrl('opencode')).toBe('https://opencode.ai/zen/v1')
+    expect(resolveVendorApiEndpoints('opencode-go')).toEqual(['openai'])
+    expect(resolveVendorApiEndpoints('opencode')).toEqual(['openai'])
+    expect(resolveVendorModelsUrl('opencode-go')).toBeUndefined()
+    expect(resolveVendorModelsUrl('opencode')).toBeUndefined()
+    expect(defaultVendorModel('opencode-go')).toBe('kimi-k2.7-code')
+    expect(defaultVendorModel('opencode')).toBe('kimi-k2.7-code')
+  })
+
   it('resolves a single-endpoint vendor base URL', () => {
     expect(resolveVendorBaseUrl('openai')).toBe('https://api.openai.com')
     expect(getOfficialVendor('openai')?.apiEndpoints).toEqual(['responses'])

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -31,6 +31,8 @@ export type OfficialVendorId =
   | 'xiaomimimo'
   | 'sensenova'
   | 'volcengine'
+  | 'opencode-go'
+  | 'opencode'
   | 'openrouter'
 
 // A selectable endpoint for vendors that publish more than one host — e.g. a Global vs. China region
@@ -605,6 +607,40 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
         'doubao-seed-2-0-mini-260215'
       ]
     }
+  },
+  {
+    id: 'opencode-go',
+    label: 'OpenCode Go',
+    reasoningEffort: 'unsupported',
+    apiEndpoints: ['openai'],
+    baseUrl: 'https://opencode.ai/zen/go/v1',
+    apiKeyUrl: 'https://opencode.ai/zen',
+    // The public catalog mixes Chat Completions, Responses, and Messages models but does not expose
+    // protocol metadata. Keep this list to models that use the provider's default OpenAI-compatible
+    // package instead of offering a refresh that could surface models this transport cannot drive.
+    models: [
+      { id: 'kimi-k2.7-code', contextWindow: 262_144 },
+      { id: 'kimi-k3', contextWindow: 1_048_576 },
+      { id: 'deepseek-v4-flash', contextWindow: 1_000_000 },
+      { id: 'glm-5.3', contextWindow: 1_000_000 }
+    ]
+  },
+  {
+    id: 'opencode',
+    label: 'OpenCode Zen',
+    reasoningEffort: 'unsupported',
+    apiEndpoints: ['openai'],
+    baseUrl: 'https://opencode.ai/zen/v1',
+    apiKeyUrl: 'https://opencode.ai/zen',
+    // Zen's public list has the same mixed-protocol limitation as Go, so this catalog is deliberately
+    // curated to default OpenAI-compatible models.
+    models: [
+      { id: 'kimi-k2.7-code', contextWindow: 262_144 },
+      { id: 'kimi-k3', contextWindow: 1_048_576 },
+      { id: 'deepseek-v4-flash', contextWindow: 1_000_000 },
+      { id: 'deepseek-v4-pro', contextWindow: 1_000_000 },
+      { id: 'glm-5.2', contextWindow: 1_000_000 }
+    ]
   },
   // OpenRouter is an aggregation gateway (many vendors behind one key), so it sits last in the picker.
   {


### PR DESCRIPTION
## Problem

OpenCode users with an OpenCode Go subscription or OpenCode Zen balance cannot choose either service in the provider picker. Both services accept API keys; adding an OAuth flow would create an unnecessary second account lifecycle.

Closes #1750.

## Proposed change

- Register OpenCode Go and OpenCode Zen as ordinary official API-key providers immediately before OpenRouter.
- Use the official Go and Zen API bases and a conservative catalog of models documented for Chat Completions.
- Reuse the existing OpenCode logo for both provider choices.
- Reuse the existing official-provider lifecycle for encrypted key storage, connection testing, editing, deletion, default-model selection, and runtime reconnection.

The public Go and Zen model endpoints are intentionally not wired to Refresh models: those lists mix Chat Completions, Responses, and Messages models without protocol metadata. Surfacing the entire response through the current Chat-only provider transport would create selectable models that fail at runtime.

## Scope and non-goals

- No OAuth or browser login.
- No new ProviderType, AgentFrameworkId, validation status, settings field, database field, migration, or settings-version bump.
- The only enum-like additions are the OfficialVendorId literals opencode-go and opencode.
- Existing official-provider persistence remains unchanged: vendorId plus the existing encrypted key reference and provider metadata.
- Existing custom Go/Zen providers are not converted because their endpoint and model intent is ambiguous; historical settings require no migration.
- Native mixed-protocol catalog discovery and account-specific Go usage / Zen balance status are outside this minimal API-key preset.

## Acceptance criteria and validation

The regression test uses the existing onboarding provider picker. Before the implementation it failed three consecutive runs at the same assertion because OpenCode Go was absent; after the change it passes.

- Provider choices, order, endpoints, default models, and OpenCode logos -> targeted Vitest files -> 3 files / 90 tests passed.
- Official-provider account lifecycle and representative consumers -> npm run test:module -- settings_provider_accounts -> 21 files / 394 tests passed.
- Node and renderer types -> npm run typecheck -> passed.
- Repository lint -> npm run lint -> passed.
- Whitespace/error check -> git diff --check -> passed.

All listed checks ran after the final material edit. The complete npm test suite was not run locally per maintainer direction; exact-head PR CI remains authoritative, including the selected Windows-sensitive provider lane.

## Review focus

- Go and Zen endpoint/catalog accuracy.
- The deliberate omission of dynamic mixed-protocol model refresh.
- Reuse of existing official-provider credential persistence without schema changes.

An independent final-diff review found no remaining actionable issues after removing one model whose two upstream metadata sources disagreed on protocol.
