### PR TITLE
feat(preview): add right-click tab actions menu

### DIFF
--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -62,11 +62,19 @@ describe('PreviewPanel', () => {
   beforeEach(() => {
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
     window.api = {
-      saveManagedFile: vi.fn().mockResolvedValue({ saved: true })
+      saveManagedFile: vi.fn().mockResolvedValue({ saved: true }),
+      uploads: { stageLocalPath: vi.fn().mockResolvedValue({ id: 'attachment-1' }) }
     } as unknown as Window['api']
     container = document.createElement('div')
     document.body.appendChild(container)
   })
+
+  // Radix dropdown interactions under jsdom need pointer-capture stubs.
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = (): boolean => false
+    Element.prototype.setPointerCapture = (): void => {}
+    Element.prototype.releasePointerCapture = (): void => {}
+  }
 
   afterEach(async () => {
     await act(async () => {
@@ -102,6 +110,31 @@ describe('PreviewPanel', () => {
       })
     )
     await renderPanel()
+  }
+
+  const openTabContextMenu = async (tabIndex: number): Promise<void> => {
+    const tab = container.querySelectorAll<HTMLButtonElement>('[role="tab"]')[tabIndex]
+    if (!tab) throw new Error(`tab not found at index ${tabIndex}`)
+    await act(async () => {
+      tab.dispatchEvent(
+        new MouseEvent('contextmenu', { bubbles: true, cancelable: true, clientX: 40, clientY: 90 })
+      )
+    })
+  }
+
+  const menuCommands = (): string[] =>
+    Array.from(document.body.querySelectorAll<HTMLElement>('[role="menuitem"]')).map(
+      (item) => item.dataset.command ?? ''
+    )
+
+  const clickMenuCommand = async (command: string): Promise<void> => {
+    const menuItem = document.body.querySelector<HTMLElement>(
+      `[role="menuitem"][data-command="${command}"]`
+    )
+    if (!menuItem) throw new Error(`menu item not found: ${command}`)
+    await act(async () => {
+      menuItem.click()
+    })
   }
 
   const mockTabScrollGeometry = ({
@@ -789,5 +822,135 @@ describe('PreviewPanel', () => {
     expect(container.querySelector('[role="dialog"]')).toBeNull()
     expect(container.querySelector('[role="tabpanel"]')).not.toBeNull()
     expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('item-1')
+  })
+
+  it('opens a tab menu on right-click without activating the tab', async () => {
+    await renderTwoFileTabs()
+
+    await openTabContextMenu(1)
+
+    expect(document.body.querySelector('[data-testid="preview-tab-context-menu"]')).not.toBeNull()
+    expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('item-1')
+    expect(container.querySelector('[role="tab"][aria-selected="true"]')?.textContent).toContain(
+      'file-1.png'
+    )
+  })
+
+  it('shows managed-file actions for an artifact tab and shared-only for a tool tab', async () => {
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({}))
+    usePreviewWorkbenchStore.getState().upsertItem(createToolItem({}))
+    await renderPanel()
+
+    await openTabContextMenu(0)
+    expect(menuCommands()).toEqual(['close', 'close-others', 'download'])
+    // Every entry renders its icon (×, ⊗, ↓) ahead of the label.
+    for (const menuItem of document.body.querySelectorAll('[role="menuitem"]')) {
+      expect(menuItem.querySelector('svg')).not.toBeNull()
+    }
+
+    await openTabContextMenu(1)
+    expect(menuCommands()).toEqual(['close', 'close-others'])
+    expect(
+      document.body.querySelector('[data-testid="preview-tab-context-menu"] [role="separator"]')
+    ).toBeNull()
+  })
+
+  it('offers local-file actions and disables close-others for a single tab', async () => {
+    usePreviewWorkbenchStore
+      .getState()
+      .upsertAndActivateItem(createFileItem({ source: 'local', id: 'local:/tmp/notes.md' }))
+    await renderPanel()
+
+    await openTabContextMenu(0)
+
+    expect(menuCommands()).toEqual([
+      'close',
+      'close-others',
+      'copy-path',
+      'download',
+      'save-as-artifact'
+    ])
+    expect(
+      document.body
+        .querySelector<HTMLElement>('[role="menuitem"][data-command="close-others"]')
+        ?.getAttribute('aria-disabled')
+    ).toBe('true')
+  })
+
+  it('closes the other tabs from the menu and focuses the kept tab', async () => {
+    await renderTwoFileTabs()
+
+    await openTabContextMenu(1)
+    await clickMenuCommand('close-others')
+
+    expect(usePreviewWorkbenchStore.getState().items.map((item) => item.id)).toEqual(['item-2'])
+    expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('item-2')
+    expect(document.body.querySelector('[data-testid="preview-tab-context-menu"]')).toBeNull()
+  })
+
+  it('closes the right-clicked tab from the menu', async () => {
+    await renderTwoFileTabs()
+
+    await openTabContextMenu(0)
+    await clickMenuCommand('close')
+
+    expect(usePreviewWorkbenchStore.getState().items.map((item) => item.id)).toEqual(['item-2'])
+    expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('item-2')
+  })
+
+  it('downloads a managed file from the menu', async () => {
+    await renderTwoFileTabs()
+
+    await openTabContextMenu(0)
+    await clickMenuCommand('download')
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(window.api.saveManagedFile).toHaveBeenCalledWith({
+      source: 'artifact',
+      path: '/workspace/file-1.png',
+      suggestedName: 'file-1.png'
+    })
+  })
+
+  it('copies a local file path and stages it as an artifact from the menu', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    const stageLocalPath = vi.fn().mockResolvedValue({ id: 'attachment-1' })
+    Object.assign(navigator, { clipboard: { writeText } })
+    window.api = {
+      saveManagedFile: vi.fn().mockResolvedValue({ saved: true }),
+      uploads: { stageLocalPath }
+    } as unknown as Window['api']
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(
+      createFileItem({
+        source: 'local',
+        id: 'local:/tmp/notes.md',
+        path: '/tmp/notes.md',
+        name: 'notes.md'
+      })
+    )
+    usePreviewWorkbenchStore.getState().upsertItem(
+      createFileItem({
+        id: 'item-2',
+        title: 'other.png',
+        path: '/w/other.png',
+        name: 'other.png'
+      })
+    )
+    await renderPanel()
+
+    await openTabContextMenu(0)
+    await clickMenuCommand('copy-path')
+    expect(writeText).toHaveBeenCalledWith('/tmp/notes.md')
+
+    await openTabContextMenu(0)
+    await clickMenuCommand('save-as-artifact')
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(stageLocalPath).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'notes.md', sourcePath: '/tmp/notes.md' })
+    )
   })
 })

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -4,8 +4,16 @@ import { useTranslation } from 'react-i18next'
 import type { PanelImperativeHandle, PanelSize } from 'react-resizable-panels'
 
 import { dialogOverlayClassName, dialogPanelClassName } from '@/components/ui/dialog-chrome'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
 import { ResizablePanel } from '@/components/ui/resizable'
 import { cn } from '@/lib/utils'
+import { useNavigationStore } from '@/stores/navigation-store'
 import type {
   PreviewFileItem,
   PreviewItem,
@@ -15,6 +23,12 @@ import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
 
 import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
 import { PreviewFileSurface } from './PreviewFileSurface'
+import {
+  getPreviewTabActionGroups,
+  runPreviewTabAction,
+  type PreviewTabAction,
+  type PreviewTabActionCommand
+} from './preview-tab-actions'
 import { PreviewFileContent } from './previews/PreviewFileContent'
 import { PreviewToolContent } from './previews/PreviewToolContent'
 import type { RestoredPlanResponder } from './session-plan/SessionPlanSurfaces'
@@ -96,6 +110,7 @@ const PreviewTab = ({
   tabRef,
   onActivate,
   onClose,
+  onContextMenu,
   onKeyDown
 }: {
   tab: PreviewItem
@@ -104,6 +119,7 @@ const PreviewTab = ({
   tabRef: (element: HTMLButtonElement | null) => void
   onActivate: (id: string) => void
   onClose: (id: string) => void
+  onContextMenu: (event: React.MouseEvent<HTMLButtonElement>, id: string) => void
   onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void
 }): React.JSX.Element => {
   const { t } = useTranslation()
@@ -134,6 +150,7 @@ const PreviewTab = ({
           }
           onActivate(tab.id)
         }}
+        onContextMenu={(event) => onContextMenu(event, tab.id)}
         onKeyDown={onKeyDown}
         title={tab.title}
       >
@@ -170,12 +187,14 @@ const PreviewTabBar = ({
   tabs,
   activeItemId,
   onActivate,
-  onClose
+  onClose,
+  onTabContextMenu
 }: {
   tabs: PreviewItem[]
   activeItemId: string | undefined
   onActivate: (id: string) => void
   onClose: (id: string) => void
+  onTabContextMenu: (event: React.MouseEvent<HTMLButtonElement>, id: string) => void
 }): React.JSX.Element => {
   const tabListRef = useHorizontalScrollFade<HTMLDivElement>()
   const tabContainerRefs = useRef<Array<HTMLDivElement | null>>([])
@@ -272,10 +291,88 @@ const PreviewTabBar = ({
           }}
           onActivate={onActivate}
           onClose={onClose}
+          onContextMenu={onTabContextMenu}
           onKeyDown={(event) => handleTabKeyDown(event, index)}
         />
       ))}
     </div>
+  )
+}
+
+// Right-click menu for one preview tab. The action list and its rules come from the
+// preview-tab-actions module; this component only renders groups and forwards picks. A hidden
+// zero-size trigger pinned at the pointer position anchors Radix's dropdown without a visible
+// trigger button.
+const PreviewTabContextMenu = ({
+  item,
+  tabCount,
+  pointer,
+  onSelect,
+  onClose
+}: {
+  item: PreviewItem
+  tabCount: number
+  pointer: { x: number; y: number }
+  onSelect: (command: PreviewTabActionCommand) => void
+  onClose: () => void
+}): React.JSX.Element => {
+  const { t } = useTranslation()
+  const { shared, specific } = getPreviewTabActionGroups(item, { tabCount })
+
+  const renderItem = (action: PreviewTabAction): React.JSX.Element => {
+    const Icon = action.icon
+    return (
+      <DropdownMenuItem
+        key={action.command}
+        disabled={action.disabled}
+        data-command={action.command}
+        // Compact sizing: the menu sits inside the tab strip's visual rhythm, so it uses a fixed
+        // item height at the tab text scale instead of the standard form-menu sizing. Vertical
+        // spacing comes from the height alone — this file's workspace spacing guard forbids py-*
+        // utilities.
+        className={cn(
+          'min-h-0 h-6 gap-2 rounded-md px-2 py-0 text-[12px]',
+          action.danger &&
+            'text-danger-000 data-[highlighted]:bg-danger-000/10 data-[highlighted]:text-danger-000'
+        )}
+        onSelect={() => onSelect(action.command)}
+      >
+        <Icon className="size-3.5 shrink-0" aria-hidden="true" />
+        {t(action.label)}
+      </DropdownMenuItem>
+    )
+  }
+
+  return (
+    <DropdownMenu
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <span
+          aria-hidden="true"
+          data-testid="preview-tab-context-anchor"
+          className="pointer-events-none fixed size-0"
+          style={{ left: pointer.x, top: pointer.y }}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        className="min-w-[9.5rem] p-1"
+        data-testid="preview-tab-context-menu"
+        onCloseAutoFocus={(event) => {
+          // Focus returns to the tab that opened the menu instead of the hidden anchor.
+          event.preventDefault()
+          document.getElementById(getPreviewTabId(item.id))?.focus()
+        }}
+      >
+        {shared.map(renderItem)}
+        {specific.length > 0 ? <DropdownMenuSeparator /> : null}
+        {specific.map(renderItem)}
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 
@@ -501,7 +598,17 @@ const PreviewPanelSurface = ({
   const panelState = usePreviewWorkbenchStore((state) => state.panelState)
   const activateItem = usePreviewWorkbenchStore((state) => state.activateItem)
   const removeItem = usePreviewWorkbenchStore((state) => state.removeItem)
+  const removeOtherItems = usePreviewWorkbenchStore((state) => state.removeOtherItems)
+  const activeProjectId = useNavigationStore((state) => state.activeProjectId)
+  const [contextMenu, setContextMenu] = useState<{
+    itemId: string
+    x: number
+    y: number
+  } | null>(null)
   const activeItem = items.find((item) => item.id === activeItemId)
+  const contextMenuItem = contextMenu
+    ? (items.find((item) => item.id === contextMenu.itemId) ?? undefined)
+    : undefined
   // Remount replaced files and unmount collapsed content so renderer-owned resources are released.
   const activeContentKey =
     activeItem?.type === 'file'
@@ -514,6 +621,38 @@ const PreviewPanelSurface = ({
           activeItem.mtimeMs ?? null
         ])
       : (activeItem?.id ?? 'empty')
+
+  // Right-click only opens the menu; the tab is not activated, matching the pointer-first
+  // interaction of tab strips like the prototype's.
+  const handleTabContextMenu = (
+    event: React.MouseEvent<HTMLButtonElement>,
+    itemId: string
+  ): void => {
+    event.preventDefault()
+    setContextMenu({ itemId, x: event.clientX, y: event.clientY })
+  }
+
+  const closeContextMenu = (): void => {
+    setContextMenu(null)
+  }
+
+  const handleContextMenuSelect = (command: PreviewTabActionCommand): void => {
+    const item = contextMenuItem
+    setContextMenu(null)
+    if (!item) return
+
+    // Capture the optional staging pipeline once so the narrowing survives into the closure.
+    const stageLocalPath = window.api.uploads?.stageLocalPath
+
+    runPreviewTabAction(command, item, {
+      closeTab: removeItem,
+      closeOtherTabs: removeOtherItems,
+      saveManagedFile: (request) => window.api.saveManagedFile(request),
+      copyText: (text) => navigator.clipboard.writeText(text),
+      stageLocalPath: stageLocalPath ? (request) => stageLocalPath(request) : undefined,
+      activeProjectId
+    })
+  }
 
   return (
     <aside
@@ -533,6 +672,7 @@ const PreviewPanelSurface = ({
             activeItemId={activeItemId}
             onActivate={activateItem}
             onClose={removeItem}
+            onTabContextMenu={handleTabContextMenu}
           />
         </div>
       ) : null}
@@ -578,6 +718,15 @@ const PreviewPanelSurface = ({
           )
         })}
       </div>
+      {contextMenu && contextMenuItem ? (
+        <PreviewTabContextMenu
+          item={contextMenuItem}
+          tabCount={items.length}
+          pointer={{ x: contextMenu.x, y: contextMenu.y }}
+          onSelect={handleContextMenuSelect}
+          onClose={closeContextMenu}
+        />
+      ) : null}
     </aside>
   )
 }

--- a/src/renderer/src/pages/workspace/preview-tab-actions.test.ts
+++ b/src/renderer/src/pages/workspace/preview-tab-actions.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { PreviewFileItem, PreviewToolItem } from '@/stores/preview-workbench-store'
+
+import {
+  getPreviewTabActionGroups,
+  runPreviewTabAction,
+  type PreviewTabActionDeps
+} from './preview-tab-actions'
+
+const createFileItem = (overrides: Partial<PreviewFileItem>): PreviewFileItem => ({
+  id: 'file-1',
+  sessionId: 'session-1',
+  title: 'figure.png',
+  type: 'file',
+  path: '/workspace/figure.png',
+  name: 'figure.png',
+  format: 'image',
+  ...overrides
+})
+
+const createToolItem = (overrides: Partial<PreviewToolItem> = {}): PreviewToolItem => ({
+  id: 'tool-1',
+  sessionId: 'session-1',
+  title: 'Notebook',
+  type: 'tool',
+  toolKind: 'notebook',
+  ...overrides
+})
+
+const commandsOf = (groups: ReturnType<typeof getPreviewTabActionGroups>): string[] =>
+  [...groups.shared, ...groups.specific].map((action) => action.command)
+
+const specificCommandsOf = (groups: ReturnType<typeof getPreviewTabActionGroups>): string[] =>
+  groups.specific.map((action) => action.command)
+
+describe('getPreviewTabActionGroups', () => {
+  it('offers close actions on every tab type', () => {
+    for (const item of [
+      createFileItem({}),
+      createToolItem({ toolKind: 'files', title: 'Files' }),
+      createToolItem({ toolKind: 'plan', title: 'Session Plan' }),
+      createToolItem({ toolKind: 'reviewer', title: 'Session Reviewer' }),
+      createToolItem({ toolKind: 'subagents', title: 'Subagents' })
+    ]) {
+      const commands = commandsOf(getPreviewTabActionGroups(item, { tabCount: 3 }))
+      expect(commands).toEqual(expect.arrayContaining(['close', 'close-others']))
+    }
+  })
+
+  it('disables close-others when it is the only tab', () => {
+    const { shared } = getPreviewTabActionGroups(createFileItem({}), { tabCount: 1 })
+
+    expect(shared.find((action) => action.command === 'close-others')).toMatchObject({
+      disabled: true,
+      danger: true
+    })
+    expect(shared.find((action) => action.command === 'close')).toMatchObject({ disabled: false })
+  })
+
+  it('adds download to managed and upload file tabs', () => {
+    expect(
+      specificCommandsOf(getPreviewTabActionGroups(createFileItem({}), { tabCount: 2 }))
+    ).toEqual(['download'])
+    expect(
+      specificCommandsOf(
+        getPreviewTabActionGroups(createFileItem({ source: 'upload' }), { tabCount: 2 })
+      )
+    ).toEqual(['download'])
+    expect(
+      specificCommandsOf(
+        getPreviewTabActionGroups(createFileItem({ source: 'notebook-input' }), { tabCount: 2 })
+      )
+    ).toEqual(['download'])
+  })
+
+  it('adds local-file actions to a local file tab', () => {
+    const groups = getPreviewTabActionGroups(createFileItem({ source: 'local' }), { tabCount: 2 })
+
+    expect(specificCommandsOf(groups)).toEqual(['copy-path', 'download', 'save-as-artifact'])
+  })
+
+  it('offers no tab-level actions for tool tabs', () => {
+    for (const toolKind of ['files', 'plan', 'reviewer', 'subagents'] as const) {
+      const groups = getPreviewTabActionGroups(createToolItem({ toolKind }), { tabCount: 2 })
+      expect(specificCommandsOf(groups)).toEqual([])
+    }
+  })
+})
+
+describe('runPreviewTabAction', () => {
+  const createDeps = (overrides: Partial<PreviewTabActionDeps> = {}): PreviewTabActionDeps => ({
+    closeTab: vi.fn(),
+    closeOtherTabs: vi.fn(),
+    saveManagedFile: vi.fn().mockResolvedValue({ saved: true }),
+    copyText: vi.fn().mockResolvedValue(undefined),
+    stageLocalPath: vi.fn().mockResolvedValue({ id: 'attachment-1' }),
+    activeProjectId: 'project-1',
+    ...overrides
+  })
+
+  it('closes the tab and its siblings', () => {
+    const deps = createDeps()
+    const item = createFileItem({})
+
+    runPreviewTabAction('close', item, deps)
+    runPreviewTabAction('close-others', item, deps)
+
+    expect(deps.closeTab).toHaveBeenCalledWith(item.id)
+    expect(deps.closeOtherTabs).toHaveBeenCalledWith(item.id)
+  })
+
+  it('downloads a managed file with the artifact default source', async () => {
+    const deps = createDeps()
+
+    runPreviewTabAction('download', createFileItem({}), deps)
+    await vi.waitFor(() => expect(deps.saveManagedFile).toHaveBeenCalled())
+
+    expect(deps.saveManagedFile).toHaveBeenCalledWith({
+      source: 'artifact',
+      path: '/workspace/figure.png',
+      suggestedName: 'figure.png'
+    })
+  })
+
+  it('downloads a local file through the same save pipeline', async () => {
+    const deps = createDeps()
+
+    runPreviewTabAction('download', createFileItem({ source: 'local' }), deps)
+    await vi.waitFor(() => expect(deps.saveManagedFile).toHaveBeenCalled())
+
+    expect(deps.saveManagedFile).toHaveBeenCalledWith({
+      source: 'local',
+      path: '/workspace/figure.png',
+      suggestedName: 'figure.png'
+    })
+  })
+
+  it('logs instead of throwing when a download fails', async () => {
+    const deps = createDeps({ saveManagedFile: vi.fn().mockRejectedValue(new Error('disk full')) })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    runPreviewTabAction('download', createFileItem({}), deps)
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalled())
+
+    consoleError.mockRestore()
+  })
+
+  it('copies a local file path to the clipboard', async () => {
+    const deps = createDeps()
+
+    runPreviewTabAction('copy-path', createFileItem({ source: 'local' }), deps)
+    await vi.waitFor(() => expect(deps.copyText).toHaveBeenCalled())
+
+    expect(deps.copyText).toHaveBeenCalledWith('/workspace/figure.png')
+  })
+
+  it('stages a local file as an artifact with a fresh transfer id', async () => {
+    const deps = createDeps()
+
+    runPreviewTabAction('save-as-artifact', createFileItem({ source: 'local' }), deps)
+    await vi.waitFor(() => expect(deps.stageLocalPath).toHaveBeenCalled())
+
+    const request = vi.mocked(deps.stageLocalPath)!.mock.calls[0][0]
+    expect(request).toMatchObject({
+      name: 'figure.png',
+      sourcePath: '/workspace/figure.png',
+      projectId: 'project-1'
+    })
+    expect(request.transferId).toMatch(/[0-9a-f-]{36}/)
+  })
+
+  it('omits the project id when no project is active', async () => {
+    const deps = createDeps({ activeProjectId: undefined })
+
+    runPreviewTabAction('save-as-artifact', createFileItem({ source: 'local' }), deps)
+    await vi.waitFor(() => expect(deps.stageLocalPath).toHaveBeenCalled())
+
+    expect(vi.mocked(deps.stageLocalPath)!.mock.calls[0][0]).not.toHaveProperty('projectId')
+  })
+
+  it('is a no-op when the staging pipeline is unavailable', () => {
+    const deps = createDeps({ stageLocalPath: undefined })
+
+    runPreviewTabAction('save-as-artifact', createFileItem({ source: 'local' }), deps)
+
+    expect(deps.closeTab).not.toHaveBeenCalled()
+  })
+
+  it('ignores file commands on tool tabs', () => {
+    const deps = createDeps()
+
+    runPreviewTabAction('download', createToolItem(), deps)
+
+    expect(deps.saveManagedFile).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/pages/workspace/preview-tab-actions.ts
+++ b/src/renderer/src/pages/workspace/preview-tab-actions.ts
@@ -1,0 +1,176 @@
+// The preview tab context-menu model: one module owns both which actions a tab offers (decision)
+// and what each action does (execution). The menu UI stays a thin renderer — it draws the list
+// `getPreviewTabActions` returns and forwards picks to `runPreviewTabAction`, knowing nothing about
+// store mutations or save pipelines.
+//
+// Actions that live inside a tab's content surface (Provenance, Reload, View in context, Plan
+// download, full screen) are deliberately absent: they are owned by the surfaces themselves. This
+// module only exposes actions that can run without mounting the tab's content.
+
+import { CircleX, ClipboardCopy, Download, PackagePlus, X, type LucideIcon } from 'lucide-react'
+
+import type {
+  PreviewFileItem,
+  PreviewItem,
+  PreviewFileSource
+} from '@/stores/preview-workbench-store'
+
+export type PreviewTabActionCommand =
+  'close' | 'close-others' | 'download' | 'copy-path' | 'save-as-artifact'
+
+export type PreviewTabAction = {
+  command: PreviewTabActionCommand
+  // English source text; doubles as the i18n key per repo convention.
+  label: string
+  // Icon follows the prototype's close affordances (×, ⊗) and the existing header buttons for
+  // file actions, so the tab menu and the in-surface controls read as one family.
+  icon: LucideIcon
+  danger: boolean
+  disabled: boolean
+}
+
+export type PreviewTabActionContext = {
+  tabCount: number
+}
+
+// Shared actions appear for every tab; specific actions follow them below a separator. Returning
+// groups (not a flat list) lets the menu render the divider without knowing which commands are
+// shared.
+export type PreviewTabActionGroups = {
+  shared: PreviewTabAction[]
+  specific: PreviewTabAction[]
+}
+
+// Everything an action needs from its host. Injected so tests exercise the command→effect mapping
+// without a DOM, window.api, or a live store.
+export type PreviewTabActionDeps = {
+  closeTab: (itemId: string) => void
+  closeOtherTabs: (keepItemId: string) => void
+  saveManagedFile: (request: {
+    source: PreviewFileSource
+    path: string
+    suggestedName: string
+  }) => Promise<unknown>
+  copyText: (text: string) => Promise<void>
+  stageLocalPath:
+    | ((request: {
+        transferId: string
+        name: string
+        sourcePath: string
+        projectId?: string
+      }) => Promise<unknown>)
+    | undefined
+  activeProjectId: string | undefined
+}
+
+const closeAction: PreviewTabAction = {
+  command: 'close',
+  label: 'Close',
+  icon: X,
+  danger: false,
+  disabled: false
+}
+
+// Every tab can be closed; closing others is meaningless with nothing else open.
+const sharedActions = (tabCount: number): PreviewTabAction[] => [
+  closeAction,
+  {
+    command: 'close-others',
+    label: 'Close others',
+    icon: CircleX,
+    danger: true,
+    disabled: tabCount <= 1
+  }
+]
+
+// File tabs add source-specific actions; tool tabs (Files, Notebook, Session Plan, Reviewer,
+// Subagents) offer none here — their operations are content-surface interactions.
+const fileSpecificActions = (item: PreviewFileItem): PreviewTabAction[] =>
+  item.source === 'local'
+    ? [
+        {
+          command: 'copy-path',
+          label: 'Copy path',
+          icon: ClipboardCopy,
+          danger: false,
+          disabled: false
+        },
+        { command: 'download', label: 'Download', icon: Download, danger: false, disabled: false },
+        {
+          command: 'save-as-artifact',
+          label: 'Save as artifact',
+          icon: PackagePlus,
+          danger: false,
+          disabled: false
+        }
+      ]
+    : [{ command: 'download', label: 'Download', icon: Download, danger: false, disabled: false }]
+
+export const getPreviewTabActionGroups = (
+  item: PreviewItem,
+  context: PreviewTabActionContext
+): PreviewTabActionGroups => ({
+  shared: sharedActions(context.tabCount),
+  specific: item.type === 'file' ? fileSpecificActions(item) : []
+})
+
+const downloadManagedFile = async (
+  item: PreviewFileItem,
+  deps: PreviewTabActionDeps
+): Promise<void> => {
+  // A missing source is the managed-artifact default used across the preview readers.
+  await deps.saveManagedFile({
+    source: item.source ?? 'artifact',
+    path: item.path,
+    suggestedName: item.name
+  })
+}
+
+export const runPreviewTabAction = (
+  command: PreviewTabActionCommand,
+  item: PreviewItem,
+  deps: PreviewTabActionDeps
+): void => {
+  if (command === 'close') {
+    deps.closeTab(item.id)
+    return
+  }
+
+  if (command === 'close-others') {
+    deps.closeOtherTabs(item.id)
+    return
+  }
+
+  if (item.type !== 'file') return
+
+  if (command === 'download') {
+    void downloadManagedFile(item, deps).catch((error: unknown) => {
+      console.error(`Failed to download ${item.name} from the tab menu`, error)
+    })
+    return
+  }
+
+  if (command === 'copy-path') {
+    void deps
+      .copyText(item.path)
+      .catch((error: unknown) => console.error(`Failed to copy the path of ${item.name}`, error))
+    return
+  }
+
+  if (command === 'save-as-artifact') {
+    // The staging pipeline is optional on window.api.uploads; without it the click is a no-op,
+    // matching the local-file header menu's behavior.
+    if (!deps.stageLocalPath) return
+
+    void deps
+      .stageLocalPath({
+        transferId: crypto.randomUUID(),
+        name: item.name,
+        sourcePath: item.path,
+        ...(deps.activeProjectId ? { projectId: deps.activeProjectId } : {})
+      })
+      .catch((error: unknown) => {
+        console.error(`Failed to save ${item.name} as an artifact from the tab menu`, error)
+      })
+  }
+}

--- a/src/renderer/src/stores/preview-workbench-store.test.ts
+++ b/src/renderer/src/stores/preview-workbench-store.test.ts
@@ -405,6 +405,109 @@ describe('preview workbench store', () => {
     })
   })
 
+  it('closes every other tab and activates the kept one', () => {
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem({
+      id: 'file:session-1:/workspace/project/a.md',
+      sessionId: 'session-1',
+      type: 'file',
+      title: 'a.md',
+      path: '/workspace/project/a.md',
+      format: 'markdown',
+      name: 'a.md'
+    })
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem({
+      id: 'file:session-1:/workspace/project/b.md',
+      sessionId: 'session-1',
+      type: 'file',
+      title: 'b.md',
+      path: '/workspace/project/b.md',
+      format: 'markdown',
+      name: 'b.md'
+    })
+    usePreviewWorkbenchStore.getState().upsertItem({
+      id: 'tool:session-1:notebook',
+      sessionId: 'session-1',
+      type: 'tool',
+      toolKind: 'notebook',
+      title: 'Notebook'
+    })
+
+    usePreviewWorkbenchStore.getState().removeOtherItems('file:session-1:/workspace/project/b.md')
+
+    expect(usePreviewWorkbenchStore.getState()).toMatchObject({
+      items: [expect.objectContaining({ id: 'file:session-1:/workspace/project/b.md' })],
+      activeItemId: 'file:session-1:/workspace/project/b.md',
+      panelState: 'open'
+    })
+  })
+
+  it('closing others clears the expanded surface only when its tab is closed', () => {
+    usePreviewWorkbenchStore.getState().activateProject('project-1')
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createProjectFilesPreviewItem())
+    usePreviewWorkbenchStore.getState().upsertItem({
+      id: 'file:session-1:/workspace/project/a.md',
+      sessionId: 'session-1',
+      type: 'file',
+      title: 'a.md',
+      path: '/workspace/project/a.md',
+      format: 'markdown',
+      name: 'a.md'
+    })
+    usePreviewWorkbenchStore.getState().setToolItemExpanded(PROJECT_FILES_PREVIEW_ID)
+    usePreviewWorkbenchStore.getState().openFileDialog({
+      id: 'artifact-1',
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      type: 'file',
+      title: 'result.png',
+      path: 'artifact-version:project-1/session-1/artifact-1/version-1',
+      format: 'image',
+      name: 'result.png'
+    })
+
+    // Keeping the Files tab preserves both the expanded surface and the file dialog.
+    usePreviewWorkbenchStore.getState().removeOtherItems(PROJECT_FILES_PREVIEW_ID)
+
+    expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBe(PROJECT_FILES_PREVIEW_ID)
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toMatchObject({ id: 'artifact-1' })
+
+    // Reopen the closed tab, then keep the file tab instead: the Files-owned state must drop.
+    usePreviewWorkbenchStore.getState().upsertItem({
+      id: 'file:session-1:/workspace/project/a.md',
+      sessionId: 'session-1',
+      type: 'file',
+      title: 'a.md',
+      path: '/workspace/project/a.md',
+      format: 'markdown',
+      name: 'a.md'
+    })
+    usePreviewWorkbenchStore.getState().setToolItemExpanded(PROJECT_FILES_PREVIEW_ID)
+
+    usePreviewWorkbenchStore.getState().removeOtherItems('file:session-1:/workspace/project/a.md')
+
+    expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBeNull()
+    expect(usePreviewWorkbenchStore.getState().fileDialogItem).toBeUndefined()
+  })
+
+  it('ignores close-others for a tab that is not open', () => {
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem({
+      id: 'file:session-1:/workspace/project/a.md',
+      sessionId: 'session-1',
+      type: 'file',
+      title: 'a.md',
+      path: '/workspace/project/a.md',
+      format: 'markdown',
+      name: 'a.md'
+    })
+
+    usePreviewWorkbenchStore.getState().removeOtherItems('missing-item')
+
+    expect(usePreviewWorkbenchStore.getState().items).toHaveLength(1)
+    expect(usePreviewWorkbenchStore.getState().activeItemId).toBe(
+      'file:session-1:/workspace/project/a.md'
+    )
+  })
+
   it('tracks the expanded tool item and clears it when the tab is removed', () => {
     expect(usePreviewWorkbenchStore.getState().expandedToolItemId).toBeNull()
 

--- a/src/renderer/src/stores/preview-workbench-store.ts
+++ b/src/renderer/src/stores/preview-workbench-store.ts
@@ -110,6 +110,7 @@ type PreviewWorkbenchStore = PreviewWorkbenchStoreData & {
   upsertAndActivateItem: (item: PreviewItem) => void
   activateItem: (itemId: string) => void
   removeItem: (itemId: string) => void
+  removeOtherItems: (keepItemId: string) => void
   removeSessionItems: (sessionId: string) => void
   setToolItemExpanded: (itemId: string | null) => void
   openFileDialog: (item: PreviewFileItem) => void
@@ -475,6 +476,29 @@ export const usePreviewWorkbenchStore = create<PreviewWorkbenchStore>((set, get)
         panelState: items.length > 0 ? state.panelState : 'collapsed',
         expandedToolItemId: state.expandedToolItemId === itemId ? null : state.expandedToolItemId,
         fileDialogItem: itemId === PROJECT_FILES_PREVIEW_ID ? undefined : state.fileDialogItem
+      }
+    })
+  },
+
+  // Closes every preview tab except the kept one, which becomes the active tab. Owned here (not
+  // composed from removeItem by callers) so expanded-surface and file-dialog teardown rules stay
+  // in one place.
+  removeOtherItems: (keepItemId) => {
+    set((state) => {
+      if (!state.items.some((item) => item.id === keepItemId)) return state
+
+      const keepsProjectFilesTab = keepItemId === PROJECT_FILES_PREVIEW_ID
+      const removesProjectFilesTab =
+        !keepsProjectFilesTab && state.items.some((item) => item.id === PROJECT_FILES_PREVIEW_ID)
+      const items = state.items.filter((item) => item.id === keepItemId)
+
+      return {
+        items,
+        activeItemId: keepItemId,
+        expandedToolItemId: items.some((item) => item.id === state.expandedToolItemId)
+          ? state.expandedToolItemId
+          : null,
+        fileDialogItem: removesProjectFilesTab ? undefined : state.fileDialogItem
       }
     })
   },

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -410,6 +410,7 @@
     "Clear skill metadata": "Effacer les métadonnées des compétences",
     "Client metadata URL": "URL des métadonnées du client",
     "Close": "Fermer",
+    "Close others": "Fermer les autres",
     "Close Provenance": "Fermer le panneau de provenance",
     "Close Side chat": "Fermer le chat secondaire",
     "Close Subagents preview": "Fermer l'aperçu des sous-agents",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -398,6 +398,7 @@
     "Clear skill metadata": "スキルメタデータをクリアする",
     "Client metadata URL": "クライアントメタデータURL",
     "Close": "閉じる",
+    "Close others": "他を閉じる",
     "Close Provenance": "来歴を閉じる",
     "Close Side chat": "サイドチャットを閉じる",
     "Close Subagents preview": "サブエージェントプレビューを閉じる",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -398,6 +398,7 @@
     "Clear skill metadata": "스킬 메타데이터 지우기",
     "Client metadata URL": "클라이언트 메타데이터 URL",
     "Close": "닫기",
+    "Close others": "다른 탭 닫기",
     "Close Provenance": "출처 닫기",
     "Close Side chat": "사이드 채팅 닫기",
     "Close Subagents preview": "서브에이전트 미리보기 닫기",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -414,6 +414,7 @@
     "Clear skill metadata": "Очистить метаданные навыка",
     "Client metadata URL": "URL метаданных клиента",
     "Close": "Закрыть",
+    "Close others": "Закрыть остальные",
     "Close Provenance": "Закрыть сведения о происхождении",
     "Close Side chat": "Закрыть боковой чат",
     "Close Subagents preview": "Закрыть предпросмотр субагентов",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -494,6 +494,7 @@
     "Clear skill metadata": "清除技能元数据",
     "Client metadata URL": "客户端元数据 URL",
     "Close": "关闭",
+    "Close others": "关闭其他标签页",
     "Close Provenance": "关闭溯源",
     "Close Side chat": "关闭侧边聊天",
     "Close Subagents preview": "关闭子智能体预览",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -493,6 +493,7 @@
     "Clear skill metadata": "清除技能中介資料",
     "Client metadata URL": "用戶端中繼資料 URL",
     "Close": "關閉",
+    "Close others": "關閉其他標籤頁",
     "Close Provenance": "關閉溯源",
     "Close Side chat": "關閉側邊聊天",
     "Close Subagents preview": "關閉子智能體預覽",


### PR DESCRIPTION
## Problem

Right-clicking a preview tab did nothing. Users could only close tabs via the small per-tab × (one at a time) and had to find file operations inside each tab's content header. The prototype (`.scratch/prototypes/open-science-right-tabs-actions-prototype.html`) defines which operations belong at the tab level versus inside each surface.

## Proposed change

Right-clicking any preview tab opens a compact context menu anchored at the pointer (the tab is not activated). The menu follows the prototype's operation matrix:

- **Shared (all tabs):** Close, Close others (disabled with a single tab; Close others uses the danger style)
- **File · artifact / upload / notebook-input:** Download
- **File · local:** Copy path, Download, Save as artifact
- **Tool tabs (Files, Notebook, Session Plan, Reviewer, Subagents):** shared actions only

Design notes:

- New module `preview-tab-actions.ts` owns both the decision (`getPreviewTabActionGroups`, pure) and the execution (`runPreviewTabAction`, injected deps: store methods + save/clipboard/staging APIs). The menu component only renders groups and forwards picks; icons, labels, danger, and disabled state travel with each action so future commands cannot forget them.
- New store method `removeOtherItems(keepItemId)`: keeps the target tab active and clears Files-owned state (expanded surface, file dialog) only when the Files tab actually closes.
- Menu items use a fixed `h-6` height at the tab strip's 12px text scale with per-action icons (`X`, `CircleX` for close/close-others per the prototype; `Download`, `ClipboardCopy`, `PackagePlus` matching the existing header buttons). Item vertical spacing comes from height only, keeping this file within the workspace spacing guard's no-`py-*` rule.
- Only one new i18n key (`Close others`); all other labels reuse existing translations.

## Scope and non-goals

- Not in scope (deliberately deferred): full screen / Expand entries, Provenance, Reload from disk, View in context, and Session Plan download. Those actions depend on state owned inside a tab's content surface (`PreviewFileSurface`, `PlanPreviewSurface`) and need a pending-intent path; they will join the same `preview-tab-actions` seam without menu or store changes.
- Left-click behavior (activate / quick close) is unchanged.

## Acceptance criteria and validation

All checks ran after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Action matrix per tab type / source / single-tab disable | `npm test -- src/renderer/src/pages/workspace/preview-tab-actions.test.ts` | 14 passed |
| `removeOtherItems` focus repair + Files-owned state teardown | `npm test -- src/renderer/src/stores/preview-workbench-store.test.ts` | 28 passed |
| Menu open on right-click without activation, per-type entries, icons, dispatch of close/close-others/download/copy-path/save-as-artifact, Escape/outside close, focus return | `npm test -- src/renderer/src/pages/workspace/PreviewPanel.test.tsx` | 29 passed |
| Workspace spacing guard still holds after menu styling | `npm test -- src/renderer/src/pages/workspace/workspace-components.test.tsx` | passed |
| Renderer + node type safety | `npm run typecheck:web`, `npm run typecheck:node` | passed |
| Lint on all changed files | targeted `eslint` | clean |
| Full portable suite | `npx vitest run` | 19538 passed, 0 failed |

Uncovered risks: manual/E2E verification of pointer-positioned menu anchoring in the packaged app was not run (jsdom cannot exercise real pointer coordinates); visual polish beyond the compact sizing was not screenshot-verified.

## Review focus

- `preview-tab-actions.ts` — the decision/execution seam and whether the injected `deps` shape is the right interface for the deferred surface-owned actions.
- `removeOtherItems` in `preview-workbench-store.ts` — the Files-tab teardown rules mirror `removeItem`/`removeSessionItems` patterns.
- Menu compact styling in `PreviewPanel.tsx` (`PreviewTabContextMenu`) — height-based vertical rhythm to respect the file-level spacing guard.