### PR TITLE
feat(providers): offer GLM-5.3 for Zhipu API

### DIFF
--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -104,6 +104,14 @@ describe('provider registry', () => {
     })
   })
 
+  it('offers GLM-5.3 through the pay-as-you-go Zhipu provider', () => {
+    expect(getOfficialVendor('zhipu')?.models).toContainEqual({
+      id: 'glm-5.3',
+      contextWindow: 1_000_000,
+      reasoningEffort: 'low-high-max'
+    })
+  })
+
   it('routes the GLM Coding Plan through the /api/coding OpenAI path, per region', () => {
     expect(vendorHasRegions('glmcodingplan')).toBe(true)
     expect(resolveVendorApiEndpoints('glmcodingplan')).toEqual(['anthropic', 'openai'])
@@ -134,7 +142,7 @@ describe('provider registry', () => {
   it('exposes the first catalog entry as the default model', () => {
     expect(defaultVendorModel('openai')).toBe('gpt-5.6-sol')
     expect(defaultVendorModel('xai')).toBe('grok-4.6')
-    expect(defaultVendorModel('zhipu')).toBe('glm-5.2')
+    expect(defaultVendorModel('zhipu')).toBe('glm-5.3')
   })
 
   it('resolves model-specific static reasoning effort profiles without network discovery', () => {

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -355,6 +355,7 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
       }
     ],
     models: [
+      { id: 'glm-5.3', contextWindow: 1_000_000, reasoningEffort: 'low-high-max' },
       { id: 'glm-5.2', contextWindow: 1_000_000, reasoningEffort: 'none-high-max' },
       { id: 'glm-5.1', contextWindow: 200_000 },
       { id: 'glm-5', contextWindow: 200_000 },


### PR DESCRIPTION
## Problem

GLM-5.3 is now available through Zhipu's regular Model API, but the built-in `Zhipu AI (GLM)` Provider only offers models through GLM-5.2. Users can currently select GLM-5.3 only through the separate `GLM Coding Plan` Provider even when they want pay-as-you-go API billing.

Official references:

- [BigModel GLM-5.3 documentation](https://docs.bigmodel.cn/cn/guide/models/text/glm-5.3)
- [Z.AI GLM-5.3 documentation](https://docs.z.ai/guides/llm/glm-5.3)

Both document a 1M-token context window, `low`/`high`/`max` reasoning effort, and a Model API Chat Completions call using model ID `glm-5.3`.

## Proposed change

- Add `glm-5.3` to the regular Zhipu Provider catalog with its documented 1M context window and reasoning profile.
- Put it first so newly added Zhipu Providers default to the latest model.
- Add a regression test at the shared provider-catalog boundary.

## Scope and non-goals

- Existing Zhipu region endpoints and the Chat Completions bridge remain unchanged.
- Existing providers keep their persisted active-model selection; only newly added Zhipu Providers receive the new default.
- No schema, settings format, state enum, UI, or migration changes.
- This PR does not add a separate native Responses base URL. The existing OpenAI Chat Completions path already makes the model available to Codex through the current bridge, without expanding the region endpoint model.

## Acceptance and validation

- Before the production change, the new targeted regression failed because the pay-as-you-go Zhipu catalog did not contain `glm-5.3`.
- `npm test -- src/shared/provider-registry.test.ts` — 60 passed.
- `npm run test:module -- settings_provider_accounts` — 21 files, 395 tests passed.
- `npm run typecheck:node` — passed.
- `npm run typecheck:web` — passed.
- `npm run lint` — passed.

The full local `npm test` suite was not run; PR CI remains the full-suite authority. A live authenticated Zhipu request was not run because no user API key was used.

## Review focus

- Confirm the regular `zhipu` catalog, rather than only `glmcodingplan`, should expose `glm-5.3`.
- Confirm the documented context and reasoning-effort metadata.
