### PR TITLE
test(providers): align Zhipu default model fallback with glm-5.3

### DIFF
--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from 'node:os'
 import { execPath } from 'node:process'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { defaultVendorModel } from '../../shared/provider-registry'
 import {
   CLAUDE_ISOLATED_PROVIDER_ID,
   CLAUDE_SHARED_PROVIDER_ID,
@@ -3290,17 +3291,20 @@ describe('SettingsService: official vendors', () => {
       await service.upsertProvider({ type: 'official', name: 'GLM', vendorId: 'zhipu', key: 'k' })
     ).providers[0]
 
+    const catalogDefault = defaultVendorModel('zhipu')
+    expect(catalogDefault).toBe('glm-5.3')
+
     // A model in the catalog is honored.
     let snapshot = await service.setActiveProvider(created.id, 'glm-5.2')
     expect(snapshot.activeModel).toBe('glm-5.2')
 
     // An unknown model falls back to the vendor's first catalog entry.
     snapshot = await service.setActiveProvider(created.id, 'not-a-model')
-    expect(snapshot.activeModel).toBe('glm-5.2')
+    expect(snapshot.activeModel).toBe(catalogDefault)
 
     // No model given also defaults to the first catalog entry.
     snapshot = await service.setActiveProvider(created.id)
-    expect(snapshot.activeModel).toBe('glm-5.2')
+    expect(snapshot.activeModel).toBe(catalogDefault)
   })
 
   it('builds spawn env from the registry base URL and the active model', async () => {


### PR DESCRIPTION
## Problem

[PR Gate run 32930673968](https://github.com/aipoch/open-science/actions/runs/32930673968) failed after `#1766` made `glm-5.3` the first Zhipu catalog entry. The three red jobs (`Full Module tests (macOS, shard 1/2)`, `Module tests and coverage`, `PR Gate`) all come from one test:

`src/main/settings/service.test.ts` — `activates a chosen catalog model, falling back to the default for an unknown one`

That test still expected the unknown-model / omitted-model fallback to persist `glm-5.2`. Production already falls back to the first catalog entry (`glm-5.3`).

## Proposed change

Update the settings activation test to pin the Zhipu catalog default to `glm-5.3` via `defaultVendorModel('zhipu')`, while still proving an in-catalog id such as `glm-5.2` can be selected explicitly.

No production code change.

## Scope and non-goals

- Scope: one settings service test.
- Non-goals: catalog contents, default-selection production logic, UI picker copy, and migration of already-stored `activeModel` values.

## Acceptance criteria and validation

- Activating a Zhipu provider with an unknown or omitted model stores `glm-5.3`.
- Activating `glm-5.2` still stores `glm-5.2`.
- The previously failing assertion no longer expects the old first catalog entry.

## Review focus

The fallback contract is “first catalog entry”, not a hard-coded historical id. Confirm we should keep `glm-5.3` as that default.

## Historical data compatibility

This PR does not change persisted data. The default already shipped in `#1766`:

- Existing stored `activeModel: 'glm-5.2'` remains valid; `glm-5.2` is still in the Zhipu catalog.
- Newly added Zhipu providers, and activations with an unknown or omitted model, already persist `glm-5.3`.
- No upgrade rewrite of historical `activeModel` values is included. If we should migrate old Zhipu defaults from `glm-5.2` to `glm-5.3`, that needs a separate decision.

## New state / enum values

None in this PR. `glm-5.3` is already a catalog model id from `#1766`.

## Persistence

None in this PR. `activeModel` is already persisted settings state. The write value for an unknown/omitted Zhipu model already became `glm-5.3` in `#1766`; this change only updates the test that still expected `glm-5.2`.

## Validation

Checks ran after the last material edit.

| Behavior | Command | Result |
| --- | --- | --- |
| Unknown/omitted Zhipu model falls back to `glm-5.3`; explicit `glm-5.2` is kept | `npm test -- src/main/settings/service.test.ts -t 'activates a chosen catalog model'` | pass (1 passed, 257 skipped) |
| Settings service facade owner/contract/consumer tests | `npm run test:module -- settings_service_facade` | pass (28 files, 794 tests) |
| Lint of the changed test | `npx eslint src/main/settings/service.test.ts` | pass |

Consumers, renderer, Windows, and E2E lanes are excluded locally: this is a test-only assertion update with no production or UI change. Exact-head PR Gate remains authoritative for the full portable suite.

Uncovered risks: none identified beyond CI re-running the complete module suite.