### PR TITLE
fix(session-persistence): preserve Main-owned Session details on rebase

### DIFF
--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -1232,6 +1232,122 @@ describe('renderer session persistence bridge', () => {
     ])
   })
 
+  it('retries local activity when Session details advance before a permission revision conflict', async () => {
+    const base = materializeSessionConversationGraph(
+      createPersistedSession({
+        projectId: 'project-a',
+        revision: 8,
+        status: 'running',
+        messages: [
+          {
+            id: 'prompt-1',
+            role: 'user',
+            content: 'Run the command',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ],
+        sessionDetailsSource: 'fallback',
+        sessionDetailsGeneration: {
+          status: 'queued',
+          sourceMessageId: 'prompt-1',
+          requestId: 'prompt-1:session-details',
+          queuedAt: 2
+        }
+      })
+    )
+    const runningDetails = {
+      ...base,
+      revision: 9,
+      sessionDetailsGeneration: {
+        ...base.sessionDetailsGeneration!,
+        status: 'running' as const,
+        startedAt: 3,
+        frameworkId: 'opencode' as const,
+        model: 'e2e-model',
+        reasoningEffort: 'low' as const
+      },
+      updatedAt: base.updatedAt + 1
+    }
+    const permissionAuthority = {
+      ...runningDetails,
+      revision: 10,
+      status: 'waiting-permission' as const,
+      sessionDetailsGeneration: {
+        ...runningDetails.sessionDetailsGeneration,
+        status: 'failed' as const,
+        completedAt: 4,
+        usageUnavailable: true
+      },
+      runtimeContext: {
+        version: 1 as const,
+        revision: 1,
+        permission: {
+          state: 'pending' as const,
+          request: {
+            requestId: 'permission-1',
+            sessionId: base.id,
+            toolCallId: 'tool-1',
+            title: 'Run the command',
+            options: [{ optionId: 'allow', name: 'Allow', kind: 'allow_once' as const }]
+          },
+          originatingPromptMessageId: 'prompt-1',
+          fingerprint: 'a'.repeat(64),
+          createdAt: 4
+        }
+      },
+      updatedAt: runningDetails.updatedAt + 1
+    }
+    const firstSave = createDeferred<void>()
+    const conflict = new SessionRevisionConflictError(8, 10)
+    const saveSession = vi
+      .fn<SessionPersistenceApi['saveSession']>()
+      .mockImplementationOnce(async () => {
+        await firstSave.promise
+        throw conflict
+      })
+      .mockImplementationOnce(async (submitted) => ({ ...submitted, revision: 11 }))
+    const api = createApi({
+      loadOne: vi.fn().mockResolvedValue(permissionAuthority),
+      saveSession
+    })
+
+    useSessionStore.getState().hydrateSessions([base])
+    const save = createStoreSaver(api, useSessionStore.getState())
+    useSessionStore.getState().upsertToolActivity({
+      sessionId: base.id,
+      toolCallId: 'tool-1',
+      eventId: 'tool-event-1',
+      promptMessageId: 'prompt-1',
+      title: 'Run the command',
+      status: 'pending'
+    })
+    const savingLocalActivity = save(useSessionStore.getState())
+    await vi.waitFor(() => expect(saveSession).toHaveBeenCalledOnce())
+
+    const source = useSessionStore.getState().sessions[0]
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: runningDetails,
+      mode: 'session-details-authority'
+    })
+    await save(useSessionStore.getState())
+
+    firstSave.resolve()
+    await expect(savingLocalActivity).resolves.toBeUndefined()
+
+    expect(saveSession).toHaveBeenCalledTimes(2)
+    expect(saveSession.mock.calls[1][0]).toMatchObject({
+      revision: 10,
+      status: 'waiting-permission',
+      sessionDetailsGeneration: { status: 'failed' },
+      runtimeContext: permissionAuthority.runtimeContext,
+      activities: [expect.objectContaining({ id: 'tool-1', status: 'pending' })]
+    })
+  })
+
   it('retries a pending tool activity save over disjoint concurrent Main graph changes', async () => {
     const base = materializeSessionConversationGraph(
       createPersistedSession({

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -132,6 +132,14 @@ const MAIN_OWNED_SESSION_FIELDS = new Set<keyof PersistedChatSession>([
   'specialistBindingPending'
 ])
 
+const MAIN_OWNED_SESSION_DETAILS_FIELDS = new Set<keyof PersistedChatSession>([
+  'title',
+  'description',
+  'sessionDetailsSource',
+  'sessionDetailsGenerationEligible',
+  'sessionDetailsGeneration'
+])
+
 const jsonValuesEqual = (left: unknown, right: unknown): boolean => {
   if (Object.is(left, right)) return true
   if (Array.isArray(left) || Array.isArray(right)) {
@@ -416,6 +424,8 @@ const rebaseSessionAfterRevisionConflict = (
   const mainOwnsStatus =
     latest.runtimeContext?.permission?.state === 'pending' ||
     latest.status === 'waiting-plan-approval'
+  const mainOwnsSessionDetails =
+    latest.sessionDetailsSource !== undefined || latest.sessionDetailsGeneration !== undefined
 
   for (const key of keys) {
     if (
@@ -426,6 +436,7 @@ const rebaseSessionAfterRevisionConflict = (
     }
     if (
       MAIN_OWNED_SESSION_FIELDS.has(key) ||
+      (mainOwnsSessionDetails && MAIN_OWNED_SESSION_DETAILS_FIELDS.has(key)) ||
       key === 'updatedAt' ||
       (key === 'status' && mainOwnsStatus)
     ) {


### PR DESCRIPTION
## Problem

Windows E2E exposed a real Session persistence race in the Agent permission flow. A local tool-activity save could begin at revision 8 while Main advanced Session-details generation and then persisted permission authority at revision 10. Conflict recovery treated Main's newer Session-details lifecycle as a renderer edit conflict, surfaced the fixed `session-persistence-alert`, and blocked the pending **Allow** interaction.

## Proposed change

- Treat established Session-details authority (`title`, `description`, source, eligibility, and generation lifecycle) as Main-owned during renderer revision-conflict rebase.
- Preserve the latest Main permission/status/details authority while rebasing and retrying pending local conversation activity.
- Add a deterministic public-boundary regression test for the exact queued -> running -> failed details transition overlapping local activity and permission persistence.

The graph/activity three-way merge remains unchanged and still fails closed for genuine overlapping renderer edits.

## Scope and non-goals

- No alert UI, pointer-events, E2E wait, or z-index workaround.
- No persisted schema or format change.
- No new enum or state value.
- No migration or historical-data compatibility requirement.
- No ACP wire/adapter permission behavior change.

The persistence boundary is shared by all Agent frameworks. The reported timing was observed with the fake OpenCode E2E Agent on Windows, and the exact Windows scheduling case remains covered by CI rather than duplicated per framework.

## Validation

Red evidence before the fix:

- New regression failed 3/3 runs with `SessionRevisionConflictError: expected 8, actual 10`, matching the unresolved conflict behind the reported alert.

Green evidence after the fix:

- `npm test -- src/renderer/src/lib/session-persistence/session-persistence.test.ts` — 49 passed
- `npm run test:module -- session_persistence` — 352 passed
- `npm test -- src/renderer/src/hooks/useLifecycleSync.test.tsx src/renderer/src/lib/acp/workspace-events.test.ts` — 116 passed
- `npm run typecheck:web` — passed
- `npm run lint` — passed
- `npm run build:e2e` — passed
- `npm run test:e2e:workspace -- --grep 'resolves Agent permission requests through both Allow and Deny decisions'` — 1 passed locally
- `git diff --check` and focused Prettier check — passed

## Review focus

- Confirm the Main-owned Session-details boundary matches `SessionDetailsOwner` and does not relax graph/activity conflict detection.
- Confirm the Windows E2E lane no longer surfaces `session-persistence-alert` during permission resolution.

Independent review found no actionable Standards or Spec issues.

Context: exposed by the Windows CI run associated with #1763, but intentionally fixed in this independent PR.
