### PR TITLE
test(settings): resolve the Zhipu default model from the catalog

### DIFF
--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3290,17 +3290,22 @@ describe('SettingsService: official vendors', () => {
       await service.upsertProvider({ type: 'official', name: 'GLM', vendorId: 'zhipu', key: 'k' })
     ).providers[0]
 
+    // The vendor's first catalog entry is the fallback default; resolve it from the catalog so
+    // the assertion tracks registry ordering (newer GLM models become the default over time).
+    const defaultModel = created.models[0]
+    expect(defaultModel).toBe('glm-5.3')
+
     // A model in the catalog is honored.
     let snapshot = await service.setActiveProvider(created.id, 'glm-5.2')
     expect(snapshot.activeModel).toBe('glm-5.2')
 
     // An unknown model falls back to the vendor's first catalog entry.
     snapshot = await service.setActiveProvider(created.id, 'not-a-model')
-    expect(snapshot.activeModel).toBe('glm-5.2')
+    expect(snapshot.activeModel).toBe(defaultModel)
 
     // No model given also defaults to the first catalog entry.
     snapshot = await service.setActiveProvider(created.id)
-    expect(snapshot.activeModel).toBe('glm-5.2')
+    expect(snapshot.activeModel).toBe(defaultModel)
   })
 
   it('builds spawn env from the registry base URL and the active model', async () => {


### PR DESCRIPTION
## Problem

The second v0.20.1 Release run failed: `src/main/settings/service.test.ts > activates a chosen catalog model, falling back to the default for an unknown one` asserted the Zhipu fallback default as `glm-5.2`, but #1766 made `glm-5.3` the first Zhipu catalog entry, so the vendor default changed. The PR-time lane for #1766 did not run this settings-suite test.

## Proposed change

Resolve the expected default from the vendor catalog (`created.models[0]`) with a guard assertion that it currently is `glm-5.3`, so the test tracks registry ordering instead of a fixed model id. The explicit `glm-5.2` selection assertions stay — that model remains in the catalog.

## Scope and non-goals

- Test-only change; no production code touched.
- No registry or model-list changes.

## Acceptance criteria and validation

- Targeted suite -> `npx vitest run src/main/settings/service.test.ts` -> 258 passed
- Full local `npm test` is running in parallel and will be reported on this PR before the tag is re-cut; PR CI runs the complete suites regardless.

## Release

This is the last blocker for the v0.20.1 re-tag. After merge, `v0.20.1` moves to the resulting `main` commit and the Release workflow re-runs.
