### PR TITLE
fix(acp): prefer structured resume failure markers

### DIFF
--- a/src/main/acp/session-resume-policy.test.ts
+++ b/src/main/acp/session-resume-policy.test.ts
@@ -453,6 +453,21 @@ describe('ACP Session resume policy', () => {
     })
   })
 
+  it('does not let diagnostic text override a structured non-session service failure', () => {
+    const policy = new AcpSessionResumePolicy()
+
+    expect(
+      policy.classifyFailure({
+        code: -32603,
+        message: 'Provider diagnostic quoted “Session not found” while loading credentials',
+        data: { service: 'provider' }
+      })
+    ).toEqual({
+      disposition: 'authoritative',
+      reason: 'non-session-service-failure'
+    })
+  })
+
   it('keeps an opaque detail-free Internal error authoritative', () => {
     const policy = new AcpSessionResumePolicy()
 

--- a/src/main/acp/session-resume-policy.ts
+++ b/src/main/acp/session-resume-policy.ts
@@ -268,12 +268,6 @@ class AcpSessionResumePolicy {
 
     const message = readProperty(error, 'message')
     if (!message.readable) return authoritativeFailure('uninspectable-error')
-    if (
-      typeof message.value === 'string' &&
-      /resource not found|session not found|no rollout found for thread id/i.test(message.value)
-    ) {
-      return adoptableFailure('session-not-found-message')
-    }
 
     if (code.value !== -32603) {
       return code.value !== undefined || message.value !== undefined
@@ -288,6 +282,20 @@ class AcpSessionResumePolicy {
     if (!service.readable) return authoritativeFailure('uninspectable-error')
     if (service.value === 'session') return adoptableFailure('session-service-failure')
     if (service.value !== undefined) return authoritativeFailure('non-session-service-failure')
+
+    const errorKind = readProperty(data.value, 'errorKind')
+    if (!errorKind.readable) return authoritativeFailure('uninspectable-error')
+    if (isUnresumableErrorKind(errorKind.value)) {
+      return adoptableFailure('unresumable-error-kind')
+    }
+    if (errorKind.value !== undefined) return authoritativeFailure('unknown-error-kind')
+
+    if (
+      typeof message.value === 'string' &&
+      /resource not found|session not found|no rollout found for thread id/i.test(message.value)
+    ) {
+      return adoptableFailure('session-not-found-message')
+    }
 
     if (typeof message.value === 'string' && /^unknown error\.?$/i.test(message.value.trim())) {
       if (isCodexResponsesResumeContext(context)) {
@@ -306,13 +314,6 @@ class AcpSessionResumePolicy {
     if (typeof message.value !== 'string' || !/^internal error\.?$/i.test(message.value.trim())) {
       return authoritativeFailure('non-internal-error')
     }
-
-    const errorKind = readProperty(data.value, 'errorKind')
-    if (!errorKind.readable) return authoritativeFailure('uninspectable-error')
-    if (isUnresumableErrorKind(errorKind.value)) {
-      return adoptableFailure('unresumable-error-kind')
-    }
-    if (errorKind.value !== undefined) return authoritativeFailure('unknown-error-kind')
 
     const details = readProperty(data.value, 'details')
     if (!details.readable) return authoritativeFailure('uninspectable-error')


### PR DESCRIPTION
## Problem

ACP Session resume failure classification evaluated legacy diagnostic text before structured `data.service` and `data.errorKind` markers. A non-Session failure whose diagnostic quotes `Session not found` could therefore be treated as unresumable, causing fresh provider Session adoption and a context reset instead of preserving the authoritative failure.

## Proposed change

- Prefer structured resume failure markers before inspecting legacy message text.
- Keep the existing message-only fallback for agents that do not return structured error metadata.
- Add a regression test for a structured provider failure whose diagnostic quotes Session-not-found text.

## Scope and non-goals

- Scope is limited to the shared ACP Session resume policy and its regression coverage.
- Notebook and Connector behavior is unchanged because their startup and availability paths already use process results or structured runtime projections, and no equivalent failure was reproduced.
- Renderer contracts, wire shapes, UI interaction, and platform-specific process behavior are unchanged.

## Compatibility and data impact

- Historical compatibility: existing message-only ACP resume failures retain the legacy fallback. No persisted data requires migration.
- New status or enum values: none.
- Data model or schema changes: none.
- Persistence changes: none.

## Acceptance criteria and validation

The checks below ran after the last material edit:

- Structured non-Session metadata overrides quoted diagnostic text -> `vitest run src/main/acp/session-resume-policy.test.ts` -> passed, 48 tests.
- Shared resume caller preserves adoption and authoritative-error behavior -> `vitest run src/main/acp/session-resume-policy.test.ts src/main/acp/provider-session-resumer.test.ts` -> passed, 88 tests.
- Claude Code, OpenCode, Codex Responses, Codex Responses Compatibility, and Codex Bridge policy paths remain covered by the shared policy and resumer suites.
- Main-process types -> `tsc --noEmit -p tsconfig.node.json --composite false` -> passed.
- Repository lint -> `eslint --cache .` -> passed.
- Diff whitespace -> `git diff --check` -> passed.

The affected-test classifier selected the full portable suite because this policy file is not registered to a module owner. Per the requested local test scope, the complete `npm test` suite was not run locally; PR Gate and CI remain authoritative for that coverage. No model-specific, transport-specific, OS-specific, persistence, migration, build, or E2E risk was introduced by this pure shared classification-order change.

## Review focus

Please verify that structured `service` and `errorKind` values remain authoritative while the narrow legacy message fallback still covers agents without structured metadata.