### PR TITLE
feat(workspace): add Session hover previews

### DIFF
--- a/src/renderer/src/pages/workspace/SessionHoverPreview.preview.tsx
+++ b/src/renderer/src/pages/workspace/SessionHoverPreview.preview.tsx
@@ -1,0 +1,70 @@
+/* Hallmark · SessionHoverPreview 8-state development preview; not mounted in production. */
+import { LoaderCircle } from 'lucide-react'
+
+import { SessionHoverPreviewCard } from './SessionHoverPreview'
+
+const STATES = [
+  'default',
+  'hover',
+  'focus',
+  'active',
+  'disabled',
+  'loading',
+  'error',
+  'success'
+] as const
+const PREVIEW_TITLE = 'Session title'
+
+const SessionHoverPreviewPreview = (): React.JSX.Element => (
+  <div className="grid max-w-md gap-3 bg-background p-5 text-foreground">
+    {STATES.map((state) => (
+      <div key={state} className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-3">
+        <span className="pt-3 text-xs text-muted-foreground">{state}</span>
+        {state === 'default' || state === 'disabled' ? (
+          <div
+            className={
+              state === 'disabled'
+                ? 'rounded-md bg-muted px-3 py-2 text-sm text-muted-foreground opacity-50'
+                : 'rounded-md px-3 py-2 text-sm'
+            }
+          >
+            {PREVIEW_TITLE}
+          </div>
+        ) : (
+          <SessionHoverPreviewCard
+            session={{
+              title: PREVIEW_TITLE,
+              description:
+                state === 'loading'
+                  ? 'Loading session details…'
+                  : state === 'error'
+                    ? 'The Session stopped before completing.'
+                    : state === 'success'
+                      ? 'The Session completed successfully.'
+                      : 'A concise description of the Session.'
+            }}
+            className={
+              state === 'focus'
+                ? 'outline-2 outline-offset-2 outline-ring'
+                : state === 'active'
+                  ? 'translate-y-px'
+                  : state === 'error'
+                    ? 'border-destructive'
+                    : state === 'success'
+                      ? 'border-primary'
+                      : undefined
+            }
+          />
+        )}
+        {state === 'loading' ? (
+          <LoaderCircle
+            className="col-start-2 size-4 animate-spin text-muted-foreground motion-reduce:animate-none"
+            aria-hidden="true"
+          />
+        ) : null}
+      </div>
+    ))}
+  </div>
+)
+
+export { SessionHoverPreviewPreview }

--- a/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
+++ b/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
@@ -187,7 +187,7 @@ const SessionHoverPreviewCard = ({
         className
       )}
     >
-      <p className="line-clamp-3 break-words text-[15px] font-semibold leading-5 tracking-[-0.01em] [text-wrap:pretty]">
+      <p className="truncate text-[15px] font-semibold leading-5 tracking-[-0.01em]">
         {session.title}
       </p>
       {description ? (

--- a/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
+++ b/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
@@ -187,11 +187,11 @@ const SessionHoverPreviewCard = ({
         className
       )}
     >
-      <p className="break-words text-[15px] font-semibold leading-5 tracking-[-0.01em] [text-wrap:pretty]">
+      <p className="line-clamp-3 break-words text-[15px] font-semibold leading-5 tracking-[-0.01em] [text-wrap:pretty]">
         {session.title}
       </p>
       {description ? (
-        <p className="mt-2 whitespace-pre-wrap break-words text-sm leading-5 text-muted-foreground">
+        <p className="mt-2 line-clamp-3 whitespace-pre-wrap break-words text-sm leading-5 text-muted-foreground">
           {description}
         </p>
       ) : descriptionLoading ? (

--- a/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
+++ b/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
@@ -1,0 +1,280 @@
+/* Hallmark · macrostructure: anchored session context card · genre: modern-minimal · theme: Open Science
+ * states: default · hover · focus · active · disabled · loading · error · success
+ * contrast: pass (40–41) · slop: pass (applicable component gates)
+ * pre-emit critique: P5 H4 E5 S5 R5 V4
+ */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode
+} from 'react'
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+const SESSION_HOVER_PREVIEW_DELAY_MS = 2_000
+const SESSION_HOVER_PREVIEW_SKIP_DELAY_MS = 300
+
+type SessionPreviewContent = {
+  title: string
+  description?: string
+}
+type SessionPreviewDetails = SessionPreviewContent & { id: string }
+
+type SessionHoverPreviewContextValue = {
+  activeSessionId: string | null
+  closeNow: (sessionId: string) => void
+  keepOpen: () => void
+  requestOpen: (sessionId: string, immediate?: boolean) => void
+  scheduleClose: (sessionId: string) => void
+}
+
+const SessionHoverPreviewContext = createContext<SessionHoverPreviewContextValue | null>(null)
+
+const SessionHoverPreviewProvider = ({ children }: { children: ReactNode }): React.JSX.Element => {
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
+  const activeSessionIdRef = useRef<string | null>(null)
+  const pendingSessionIdRef = useRef<string | null>(null)
+  const openTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  const clearOpenTimer = useCallback((): void => {
+    clearTimeout(openTimerRef.current)
+    openTimerRef.current = undefined
+    pendingSessionIdRef.current = null
+  }, [])
+
+  const keepOpen = useCallback((): void => {
+    clearTimeout(closeTimerRef.current)
+    closeTimerRef.current = undefined
+  }, [])
+
+  const requestOpen = useCallback(
+    (sessionId: string, immediate = false): void => {
+      keepOpen()
+      if (immediate || activeSessionIdRef.current !== null) {
+        clearOpenTimer()
+        activeSessionIdRef.current = sessionId
+        setActiveSessionId(sessionId)
+        return
+      }
+      if (pendingSessionIdRef.current === sessionId) return
+
+      clearOpenTimer()
+      pendingSessionIdRef.current = sessionId
+      openTimerRef.current = setTimeout(() => {
+        pendingSessionIdRef.current = null
+        activeSessionIdRef.current = sessionId
+        setActiveSessionId(sessionId)
+      }, SESSION_HOVER_PREVIEW_DELAY_MS)
+    },
+    [clearOpenTimer, keepOpen]
+  )
+
+  const scheduleClose = useCallback(
+    (sessionId: string): void => {
+      if (pendingSessionIdRef.current === sessionId) clearOpenTimer()
+      if (activeSessionIdRef.current !== sessionId) return
+
+      keepOpen()
+      closeTimerRef.current = setTimeout(() => {
+        if (activeSessionIdRef.current !== sessionId) return
+        activeSessionIdRef.current = null
+        setActiveSessionId(null)
+      }, SESSION_HOVER_PREVIEW_SKIP_DELAY_MS)
+    },
+    [clearOpenTimer, keepOpen]
+  )
+
+  const closeNow = useCallback(
+    (sessionId: string): void => {
+      if (pendingSessionIdRef.current === sessionId) clearOpenTimer()
+      if (activeSessionIdRef.current !== sessionId) return
+
+      keepOpen()
+      activeSessionIdRef.current = null
+      setActiveSessionId(null)
+    },
+    [clearOpenTimer, keepOpen]
+  )
+
+  useEffect(
+    () => () => {
+      clearOpenTimer()
+      keepOpen()
+    },
+    [clearOpenTimer, keepOpen]
+  )
+
+  const value = useMemo(
+    () => ({ activeSessionId, closeNow, keepOpen, requestOpen, scheduleClose }),
+    [activeSessionId, closeNow, keepOpen, requestOpen, scheduleClose]
+  )
+
+  return (
+    <SessionHoverPreviewContext.Provider value={value}>
+      <TooltipProvider
+        delayDuration={SESSION_HOVER_PREVIEW_DELAY_MS}
+        skipDelayDuration={SESSION_HOVER_PREVIEW_SKIP_DELAY_MS}
+      >
+        {children}
+      </TooltipProvider>
+    </SessionHoverPreviewContext.Provider>
+  )
+}
+
+const SessionTitleMarquee = ({
+  title,
+  className
+}: {
+  title: string
+  className?: string
+}): React.JSX.Element => {
+  const viewportRef = useRef<HTMLSpanElement>(null)
+  const contentRef = useRef<HTMLSpanElement>(null)
+  const animationRef = useRef<Animation>(undefined)
+
+  useEffect(() => {
+    const trigger = viewportRef.current?.closest('button')
+    const stop = (): void => {
+      animationRef.current?.cancel()
+      animationRef.current = undefined
+    }
+    const start = (): void => {
+      stop()
+      const viewport = viewportRef.current
+      const content = contentRef.current
+      if (
+        !viewport ||
+        !content ||
+        content.scrollWidth <= viewport.clientWidth ||
+        typeof content.animate !== 'function' ||
+        window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+      ) {
+        return
+      }
+
+      const overflow = content.scrollWidth - viewport.clientWidth
+      animationRef.current = content.animate(
+        [{ transform: 'translateX(0)' }, { transform: `translateX(-${overflow}px)` }],
+        {
+          delay: 300,
+          duration: Math.min(12_000, Math.max(2_000, overflow * 35)),
+          easing: 'linear',
+          fill: 'forwards'
+        }
+      )
+    }
+
+    trigger?.addEventListener('pointerenter', start)
+    trigger?.addEventListener('pointerleave', stop)
+    return () => {
+      trigger?.removeEventListener('pointerenter', start)
+      trigger?.removeEventListener('pointerleave', stop)
+      stop()
+    }
+  }, [])
+
+  return (
+    <span
+      ref={viewportRef}
+      data-slot="session-title-marquee"
+      className={cn('min-w-0 flex-1 overflow-hidden whitespace-nowrap', className)}
+    >
+      <span ref={contentRef} className="inline-block min-w-max">
+        {title}
+      </span>
+    </span>
+  )
+}
+
+const SessionHoverPreviewCard = ({
+  session,
+  className
+}: {
+  session: SessionPreviewContent
+  className?: string
+}): React.JSX.Element => {
+  const description = session.description?.trim()
+
+  return (
+    <div
+      data-slot="session-hover-preview"
+      className={cn(
+        'w-80 max-w-[calc(100vw-1rem)] overflow-y-auto rounded-xl border border-border bg-popover p-4 text-popover-foreground shadow-dialog',
+        'max-h-[min(24rem,calc(100vh-1rem))]',
+        className
+      )}
+    >
+      <p className="break-words text-[15px] font-semibold leading-5 tracking-[-0.01em] [text-wrap:pretty]">
+        {session.title}
+      </p>
+      {description ? (
+        <p className="mt-2 whitespace-pre-wrap break-words text-sm leading-5 text-muted-foreground">
+          {description}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+const SessionHoverPreview = ({
+  session,
+  children
+}: {
+  session: SessionPreviewDetails
+  children: ReactElement
+}): React.JSX.Element => {
+  const context = useContext(SessionHoverPreviewContext)
+  if (!context) throw new Error('SessionHoverPreview must be inside SessionHoverPreviewProvider')
+
+  const { activeSessionId, closeNow, keepOpen, requestOpen, scheduleClose } = context
+  const open = activeSessionId === session.id
+
+  return (
+    <Tooltip open={open}>
+      <TooltipTrigger
+        asChild
+        onPointerEnter={() => requestOpen(session.id)}
+        onPointerLeave={(event) => {
+          if (event.currentTarget.matches(':focus-visible')) return
+          scheduleClose(session.id)
+        }}
+        onFocus={() => requestOpen(session.id, true)}
+        onBlur={(event) => {
+          if (event.currentTarget.matches(':hover')) return
+          scheduleClose(session.id)
+        }}
+      >
+        {children}
+      </TooltipTrigger>
+      <TooltipContent
+        side="right"
+        align="start"
+        sideOffset={10}
+        collisionPadding={8}
+        onPointerEnter={keepOpen}
+        onPointerLeave={() => scheduleClose(session.id)}
+        onEscapeKeyDown={() => closeNow(session.id)}
+        className="max-w-none overflow-visible bg-transparent p-0 text-inherit shadow-none motion-reduce:animate-none"
+      >
+        <SessionHoverPreviewCard session={session} />
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+export {
+  SESSION_HOVER_PREVIEW_DELAY_MS,
+  SESSION_HOVER_PREVIEW_SKIP_DELAY_MS,
+  SessionHoverPreview,
+  SessionHoverPreviewCard,
+  SessionHoverPreviewProvider,
+  SessionTitleMarquee
+}

--- a/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
+++ b/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
@@ -18,7 +18,7 @@ import {
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
-const SESSION_HOVER_PREVIEW_DELAY_MS = 2_000
+const SESSION_HOVER_PREVIEW_DELAY_MS = 0
 const SESSION_HOVER_PREVIEW_SKIP_DELAY_MS = 300
 
 type SessionPreviewContent = {
@@ -32,7 +32,7 @@ type SessionHoverPreviewContextValue = {
   activeSessionId: string | null
   closeNow: (sessionId: string) => void
   keepOpen: () => void
-  requestOpen: (sessionId: string, immediate?: boolean) => void
+  requestOpen: (sessionId: string) => void
   scheduleClose: (sessionId: string) => void
 }
 
@@ -41,15 +41,7 @@ const SessionHoverPreviewContext = createContext<SessionHoverPreviewContextValue
 const SessionHoverPreviewProvider = ({ children }: { children: ReactNode }): React.JSX.Element => {
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
   const activeSessionIdRef = useRef<string | null>(null)
-  const pendingSessionIdRef = useRef<string | null>(null)
-  const openTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const closeTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
-
-  const clearOpenTimer = useCallback((): void => {
-    clearTimeout(openTimerRef.current)
-    openTimerRef.current = undefined
-    pendingSessionIdRef.current = null
-  }, [])
 
   const keepOpen = useCallback((): void => {
     clearTimeout(closeTimerRef.current)
@@ -57,30 +49,16 @@ const SessionHoverPreviewProvider = ({ children }: { children: ReactNode }): Rea
   }, [])
 
   const requestOpen = useCallback(
-    (sessionId: string, immediate = false): void => {
+    (sessionId: string): void => {
       keepOpen()
-      if (immediate || activeSessionIdRef.current !== null) {
-        clearOpenTimer()
-        activeSessionIdRef.current = sessionId
-        setActiveSessionId(sessionId)
-        return
-      }
-      if (pendingSessionIdRef.current === sessionId) return
-
-      clearOpenTimer()
-      pendingSessionIdRef.current = sessionId
-      openTimerRef.current = setTimeout(() => {
-        pendingSessionIdRef.current = null
-        activeSessionIdRef.current = sessionId
-        setActiveSessionId(sessionId)
-      }, SESSION_HOVER_PREVIEW_DELAY_MS)
+      activeSessionIdRef.current = sessionId
+      setActiveSessionId(sessionId)
     },
-    [clearOpenTimer, keepOpen]
+    [keepOpen]
   )
 
   const scheduleClose = useCallback(
     (sessionId: string): void => {
-      if (pendingSessionIdRef.current === sessionId) clearOpenTimer()
       if (activeSessionIdRef.current !== sessionId) return
 
       keepOpen()
@@ -90,28 +68,21 @@ const SessionHoverPreviewProvider = ({ children }: { children: ReactNode }): Rea
         setActiveSessionId(null)
       }, SESSION_HOVER_PREVIEW_SKIP_DELAY_MS)
     },
-    [clearOpenTimer, keepOpen]
+    [keepOpen]
   )
 
   const closeNow = useCallback(
     (sessionId: string): void => {
-      if (pendingSessionIdRef.current === sessionId) clearOpenTimer()
       if (activeSessionIdRef.current !== sessionId) return
 
       keepOpen()
       activeSessionIdRef.current = null
       setActiveSessionId(null)
     },
-    [clearOpenTimer, keepOpen]
+    [keepOpen]
   )
 
-  useEffect(
-    () => () => {
-      clearOpenTimer()
-      keepOpen()
-    },
-    [clearOpenTimer, keepOpen]
-  )
+  useEffect(() => () => keepOpen(), [keepOpen])
 
   const value = useMemo(
     () => ({ activeSessionId, closeNow, keepOpen, requestOpen, scheduleClose }),
@@ -166,7 +137,7 @@ const SessionTitleMarquee = ({
         [{ transform: 'translateX(0)' }, { transform: `translateX(-${overflow}px)` }],
         {
           delay: 300,
-          duration: Math.min(12_000, Math.max(2_000, overflow * 35)),
+          duration: overflow * 35,
           easing: 'linear',
           fill: 'forwards'
         }
@@ -280,7 +251,7 @@ const SessionHoverPreview = ({
           if (event.currentTarget.matches(':focus-visible')) return
           scheduleClose(session.id)
         }}
-        onFocus={() => requestOpen(session.id, true)}
+        onFocus={() => requestOpen(session.id)}
         onBlur={(event) => {
           if (event.currentTarget.matches(':hover')) return
           scheduleClose(session.id)

--- a/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
+++ b/src/renderer/src/pages/workspace/SessionHoverPreview.tsx
@@ -26,6 +26,7 @@ type SessionPreviewContent = {
   description?: string
 }
 type SessionPreviewDetails = SessionPreviewContent & { id: string }
+type SessionPreviewRequest = (sessionId: string) => Promise<void> | void
 
 type SessionHoverPreviewContextValue = {
   activeSessionId: string | null
@@ -196,9 +197,11 @@ const SessionTitleMarquee = ({
 
 const SessionHoverPreviewCard = ({
   session,
+  descriptionLoading = false,
   className
 }: {
   session: SessionPreviewContent
+  descriptionLoading?: boolean
   className?: string
 }): React.JSX.Element => {
   const description = session.description?.trim()
@@ -206,6 +209,7 @@ const SessionHoverPreviewCard = ({
   return (
     <div
       data-slot="session-hover-preview"
+      aria-busy={descriptionLoading || undefined}
       className={cn(
         'w-80 max-w-[calc(100vw-1rem)] overflow-y-auto rounded-xl border border-border bg-popover p-4 text-popover-foreground shadow-dialog',
         'max-h-[min(24rem,calc(100vh-1rem))]',
@@ -219,6 +223,12 @@ const SessionHoverPreviewCard = ({
         <p className="mt-2 whitespace-pre-wrap break-words text-sm leading-5 text-muted-foreground">
           {description}
         </p>
+      ) : descriptionLoading ? (
+        <span
+          data-slot="session-hover-preview-description-loading"
+          className="mt-2 block h-4 w-3/4 animate-pulse rounded bg-muted motion-reduce:animate-none"
+          aria-hidden="true"
+        />
       ) : null}
     </div>
   )
@@ -226,9 +236,11 @@ const SessionHoverPreviewCard = ({
 
 const SessionHoverPreview = ({
   session,
+  onPreviewRequest,
   children
 }: {
   session: SessionPreviewDetails
+  onPreviewRequest?: SessionPreviewRequest
   children: ReactElement
 }): React.JSX.Element => {
   const context = useContext(SessionHoverPreviewContext)
@@ -236,6 +248,28 @@ const SessionHoverPreview = ({
 
   const { activeSessionId, closeNow, keepOpen, requestOpen, scheduleClose } = context
   const open = activeSessionId === session.id
+  const onPreviewRequestRef = useRef(onPreviewRequest)
+  const [descriptionLoading, setDescriptionLoading] = useState(false)
+
+  useEffect(() => {
+    onPreviewRequestRef.current = onPreviewRequest
+  }, [onPreviewRequest])
+
+  useEffect(() => {
+    if (!open) return
+
+    const request = onPreviewRequestRef.current?.(session.id)
+    if (!request) {
+      void Promise.resolve().then(() => setDescriptionLoading(false))
+      return
+    }
+    void Promise.resolve().then(() => setDescriptionLoading(true))
+    void request.finally(() => {
+      setDescriptionLoading(false)
+    })
+  }, [open, session.id])
+
+  useEffect(() => () => closeNow(session.id), [closeNow, session.id])
 
   return (
     <Tooltip open={open}>
@@ -264,7 +298,10 @@ const SessionHoverPreview = ({
         onEscapeKeyDown={() => closeNow(session.id)}
         className="max-w-none overflow-visible bg-transparent p-0 text-inherit shadow-none motion-reduce:animate-none"
       >
-        <SessionHoverPreviewCard session={session} />
+        <SessionHoverPreviewCard
+          session={session}
+          descriptionLoading={open && descriptionLoading}
+        />
       </TooltipContent>
     </Tooltip>
   )
@@ -278,3 +315,4 @@ export {
   SessionHoverPreviewProvider,
   SessionTitleMarquee
 }
+export type { SessionPreviewRequest }

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -227,7 +227,7 @@ describe('WorkspaceSidebar accessible render', () => {
     expect(html).not.toContain('-top-6 h-6 bg-gradient-to-t from-rail-card-bg')
   })
 
-  it('wraps desktop Session rows in the shared delayed-preview provider only', async () => {
+  it('wraps desktop Session rows in the shared hover-preview provider only', async () => {
     const { SESSION_HOVER_PREVIEW_DELAY_MS, SESSION_HOVER_PREVIEW_SKIP_DELAY_MS } =
       await import('./SessionHoverPreview')
     const desktop = await renderSidebar([createSession({ id: 'session-a' })])
@@ -239,7 +239,7 @@ describe('WorkspaceSidebar accessible render', () => {
     const desktopSessionButton = desktopContainer.querySelector('[data-slot="session-open-button"]')
     const mobileSessionButton = mobileContainer.querySelector('[data-slot="session-open-button"]')
 
-    expect(SESSION_HOVER_PREVIEW_DELAY_MS).toBe(2_000)
+    expect(SESSION_HOVER_PREVIEW_DELAY_MS).toBe(0)
     expect(SESSION_HOVER_PREVIEW_SKIP_DELAY_MS).toBe(300)
     expect(desktopSessionButton?.getAttribute('data-state')).toBe('closed')
     expect(desktopSessionButton?.closest('[title="Analysis session"]')).toBeNull()
@@ -247,7 +247,7 @@ describe('WorkspaceSidebar accessible render', () => {
     expect(mobileSessionButton?.closest('[title="Analysis session"]')).not.toBeNull()
   })
 
-  it('delays the first pointer preview and switches directly to the next Session', async () => {
+  it('opens pointer previews immediately and switches directly to the next Session', async () => {
     vi.useFakeTimers()
     const { SessionHoverPreview, SessionHoverPreviewProvider } =
       await import('./SessionHoverPreview')
@@ -285,11 +285,6 @@ describe('WorkspaceSidebar accessible render', () => {
       if (!first || !second) throw new Error('Session preview triggers did not render')
 
       await act(async () => pointerOver(first))
-      await act(async () => vi.advanceTimersByTime(1_999))
-      expect(document.body.querySelector('[data-slot="session-hover-preview"]')).toBeNull()
-      expect(firstPreviewRequest).not.toHaveBeenCalled()
-
-      await act(async () => vi.advanceTimersByTime(1))
       expect(document.body.querySelector('[data-slot="session-hover-preview"]')?.textContent).toBe(
         'First SessionFirst Description'
       )
@@ -303,44 +298,6 @@ describe('WorkspaceSidebar accessible render', () => {
         'Second SessionSecond Description'
       )
       expect(secondPreviewRequest).toHaveBeenCalledOnce()
-    } finally {
-      act(() => root.unmount())
-      container.remove()
-      vi.useRealTimers()
-    }
-  })
-
-  it('cancels a pending Session preview when its row is removed', async () => {
-    vi.useFakeTimers()
-    const { SessionHoverPreview, SessionHoverPreviewProvider } =
-      await import('./SessionHoverPreview')
-    const container = document.createElement('div')
-    document.body.appendChild(container)
-    const root = createRoot(container)
-
-    try {
-      await act(async () => {
-        root.render(
-          <SessionHoverPreviewProvider>
-            <SessionHoverPreview session={{ id: 'removed', title: 'Removed Session' }}>
-              <button type="button">Removed trigger</button>
-            </SessionHoverPreview>
-          </SessionHoverPreviewProvider>
-        )
-      })
-      const trigger = container.querySelector('button')
-      if (!trigger) throw new Error('Session preview trigger did not render')
-      const pointerOver = new MouseEvent('pointerover', { bubbles: true })
-      Object.defineProperty(pointerOver, 'pointerType', { value: 'mouse' })
-
-      await act(async () => trigger.dispatchEvent(pointerOver))
-      await act(async () => vi.advanceTimersByTime(1_000))
-      await act(async () =>
-        root.render(<SessionHoverPreviewProvider>{null}</SessionHoverPreviewProvider>)
-      )
-      await act(async () => vi.advanceTimersByTime(1_000))
-
-      expect(document.body.querySelector('[data-slot="session-hover-preview"]')).toBeNull()
     } finally {
       act(() => root.unmount())
       container.remove()
@@ -372,7 +329,6 @@ describe('WorkspaceSidebar accessible render', () => {
       Object.defineProperty(pointerOver, 'pointerType', { value: 'mouse' })
 
       await act(async () => trigger.dispatchEvent(pointerOver))
-      await act(async () => vi.advanceTimersByTime(2_000))
       expect(document.body.querySelector('[data-slot="session-hover-preview"]')).not.toBeNull()
 
       await act(async () =>
@@ -486,6 +442,16 @@ describe('WorkspaceSidebar accessible render', () => {
         trigger?.dispatchEvent(new MouseEvent('pointerleave'))
       })
       expect(cancel).toHaveBeenCalledTimes(1)
+
+      animate.mockClear()
+      Object.defineProperty(content, 'scrollWidth', { configurable: true, value: 260 })
+      await act(async () => {
+        trigger?.dispatchEvent(new MouseEvent('pointerenter'))
+      })
+      expect(animate).toHaveBeenCalledWith(
+        [{ transform: 'translateX(0)' }, { transform: 'translateX(-160px)' }],
+        expect.objectContaining({ delay: 300, duration: 5_600, fill: 'forwards' })
+      )
 
       animate.mockClear()
       Object.defineProperty(content, 'scrollWidth', { configurable: true, value: 90 })

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -251,6 +251,8 @@ describe('WorkspaceSidebar accessible render', () => {
     vi.useFakeTimers()
     const { SessionHoverPreview, SessionHoverPreviewProvider } =
       await import('./SessionHoverPreview')
+    const firstPreviewRequest = vi.fn().mockResolvedValue(undefined)
+    const secondPreviewRequest = vi.fn().mockResolvedValue(undefined)
     const container = document.createElement('div')
     document.body.appendChild(container)
     const root = createRoot(container)
@@ -266,11 +268,13 @@ describe('WorkspaceSidebar accessible render', () => {
           <SessionHoverPreviewProvider>
             <SessionHoverPreview
               session={{ id: 'first', title: 'First Session', description: 'First Description' }}
+              onPreviewRequest={firstPreviewRequest}
             >
               <button type="button">First trigger</button>
             </SessionHoverPreview>
             <SessionHoverPreview
               session={{ id: 'second', title: 'Second Session', description: 'Second Description' }}
+              onPreviewRequest={secondPreviewRequest}
             >
               <button type="button">Second trigger</button>
             </SessionHoverPreview>
@@ -283,11 +287,13 @@ describe('WorkspaceSidebar accessible render', () => {
       await act(async () => pointerOver(first))
       await act(async () => vi.advanceTimersByTime(1_999))
       expect(document.body.querySelector('[data-slot="session-hover-preview"]')).toBeNull()
+      expect(firstPreviewRequest).not.toHaveBeenCalled()
 
       await act(async () => vi.advanceTimersByTime(1))
       expect(document.body.querySelector('[data-slot="session-hover-preview"]')?.textContent).toBe(
         'First SessionFirst Description'
       )
+      expect(firstPreviewRequest).toHaveBeenCalledOnce()
 
       const leave = new MouseEvent('pointerout', { bubbles: true, relatedTarget: second })
       Object.defineProperty(leave, 'pointerType', { value: 'mouse' })
@@ -296,6 +302,84 @@ describe('WorkspaceSidebar accessible render', () => {
       expect(document.body.querySelector('[data-slot="session-hover-preview"]')?.textContent).toBe(
         'Second SessionSecond Description'
       )
+      expect(secondPreviewRequest).toHaveBeenCalledOnce()
+    } finally {
+      act(() => root.unmount())
+      container.remove()
+      vi.useRealTimers()
+    }
+  })
+
+  it('cancels a pending Session preview when its row is removed', async () => {
+    vi.useFakeTimers()
+    const { SessionHoverPreview, SessionHoverPreviewProvider } =
+      await import('./SessionHoverPreview')
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    try {
+      await act(async () => {
+        root.render(
+          <SessionHoverPreviewProvider>
+            <SessionHoverPreview session={{ id: 'removed', title: 'Removed Session' }}>
+              <button type="button">Removed trigger</button>
+            </SessionHoverPreview>
+          </SessionHoverPreviewProvider>
+        )
+      })
+      const trigger = container.querySelector('button')
+      if (!trigger) throw new Error('Session preview trigger did not render')
+      const pointerOver = new MouseEvent('pointerover', { bubbles: true })
+      Object.defineProperty(pointerOver, 'pointerType', { value: 'mouse' })
+
+      await act(async () => trigger.dispatchEvent(pointerOver))
+      await act(async () => vi.advanceTimersByTime(1_000))
+      await act(async () =>
+        root.render(<SessionHoverPreviewProvider>{null}</SessionHoverPreviewProvider>)
+      )
+      await act(async () => vi.advanceTimersByTime(1_000))
+
+      expect(document.body.querySelector('[data-slot="session-hover-preview"]')).toBeNull()
+    } finally {
+      act(() => root.unmount())
+      container.remove()
+      vi.useRealTimers()
+    }
+  })
+
+  it('closes an active Session preview when its row is removed', async () => {
+    vi.useFakeTimers()
+    const { SessionHoverPreview, SessionHoverPreviewProvider } =
+      await import('./SessionHoverPreview')
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    try {
+      await act(async () => {
+        root.render(
+          <SessionHoverPreviewProvider>
+            <SessionHoverPreview session={{ id: 'removed', title: 'Removed Session' }}>
+              <button type="button">Removed trigger</button>
+            </SessionHoverPreview>
+          </SessionHoverPreviewProvider>
+        )
+      })
+      const trigger = container.querySelector('button')
+      if (!trigger) throw new Error('Session preview trigger did not render')
+      const pointerOver = new MouseEvent('pointerover', { bubbles: true })
+      Object.defineProperty(pointerOver, 'pointerType', { value: 'mouse' })
+
+      await act(async () => trigger.dispatchEvent(pointerOver))
+      await act(async () => vi.advanceTimersByTime(2_000))
+      expect(document.body.querySelector('[data-slot="session-hover-preview"]')).not.toBeNull()
+
+      await act(async () =>
+        root.render(<SessionHoverPreviewProvider>{null}</SessionHoverPreviewProvider>)
+      )
+
+      expect(document.body.querySelector('[data-slot="session-hover-preview"]')).toBeNull()
     } finally {
       act(() => root.unmount())
       container.remove()
@@ -350,12 +434,17 @@ describe('WorkspaceSidebar accessible render', () => {
     const withoutDescription = renderToStaticMarkup(
       <SessionHoverPreviewCard session={{ title: 'Title only', description: '   ' }} />
     )
+    const loading = renderToStaticMarkup(
+      <SessionHoverPreviewCard session={{ title: 'Loading details' }} descriptionLoading />
+    )
 
     expect(html).toContain('data-slot="session-hover-preview"')
     expect(html).toContain('Complete analysis title')
     expect(html).toContain('Compare both cohorts.')
     expect(withoutDescription).toContain('Title only')
     expect(withoutDescription).not.toContain('<p class="mt-2')
+    expect(loading).toContain('aria-busy="true"')
+    expect(loading).toContain('data-slot="session-hover-preview-description-loading"')
   })
 
   it('scrolls only an overflowing Session title and resets it on pointer leave', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -227,6 +227,223 @@ describe('WorkspaceSidebar accessible render', () => {
     expect(html).not.toContain('-top-6 h-6 bg-gradient-to-t from-rail-card-bg')
   })
 
+  it('wraps desktop Session rows in the shared delayed-preview provider only', async () => {
+    const { SESSION_HOVER_PREVIEW_DELAY_MS, SESSION_HOVER_PREVIEW_SKIP_DELAY_MS } =
+      await import('./SessionHoverPreview')
+    const desktop = await renderSidebar([createSession({ id: 'session-a' })])
+    const mobile = await renderSidebar([createSession({ id: 'session-a' })], true)
+    const desktopContainer = document.createElement('div')
+    const mobileContainer = document.createElement('div')
+    desktopContainer.innerHTML = desktop
+    mobileContainer.innerHTML = mobile
+    const desktopSessionButton = desktopContainer.querySelector('[data-slot="session-open-button"]')
+    const mobileSessionButton = mobileContainer.querySelector('[data-slot="session-open-button"]')
+
+    expect(SESSION_HOVER_PREVIEW_DELAY_MS).toBe(2_000)
+    expect(SESSION_HOVER_PREVIEW_SKIP_DELAY_MS).toBe(300)
+    expect(desktopSessionButton?.getAttribute('data-state')).toBe('closed')
+    expect(desktopSessionButton?.closest('[title="Analysis session"]')).toBeNull()
+    expect(mobileSessionButton?.getAttribute('data-state')).toBeNull()
+    expect(mobileSessionButton?.closest('[title="Analysis session"]')).not.toBeNull()
+  })
+
+  it('delays the first pointer preview and switches directly to the next Session', async () => {
+    vi.useFakeTimers()
+    const { SessionHoverPreview, SessionHoverPreviewProvider } =
+      await import('./SessionHoverPreview')
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    const pointerOver = (target: Element, relatedTarget: EventTarget | null = null): void => {
+      const event = new MouseEvent('pointerover', { bubbles: true, relatedTarget })
+      Object.defineProperty(event, 'pointerType', { value: 'mouse' })
+      target.dispatchEvent(event)
+    }
+
+    try {
+      await act(async () => {
+        root.render(
+          <SessionHoverPreviewProvider>
+            <SessionHoverPreview
+              session={{ id: 'first', title: 'First Session', description: 'First Description' }}
+            >
+              <button type="button">First trigger</button>
+            </SessionHoverPreview>
+            <SessionHoverPreview
+              session={{ id: 'second', title: 'Second Session', description: 'Second Description' }}
+            >
+              <button type="button">Second trigger</button>
+            </SessionHoverPreview>
+          </SessionHoverPreviewProvider>
+        )
+      })
+      const [first, second] = Array.from(container.querySelectorAll('button'))
+      if (!first || !second) throw new Error('Session preview triggers did not render')
+
+      await act(async () => pointerOver(first))
+      await act(async () => vi.advanceTimersByTime(1_999))
+      expect(document.body.querySelector('[data-slot="session-hover-preview"]')).toBeNull()
+
+      await act(async () => vi.advanceTimersByTime(1))
+      expect(document.body.querySelector('[data-slot="session-hover-preview"]')?.textContent).toBe(
+        'First SessionFirst Description'
+      )
+
+      const leave = new MouseEvent('pointerout', { bubbles: true, relatedTarget: second })
+      Object.defineProperty(leave, 'pointerType', { value: 'mouse' })
+      await act(async () => first.dispatchEvent(leave))
+      await act(async () => pointerOver(second, first))
+      expect(document.body.querySelector('[data-slot="session-hover-preview"]')?.textContent).toBe(
+        'Second SessionSecond Description'
+      )
+    } finally {
+      act(() => root.unmount())
+      container.remove()
+      vi.useRealTimers()
+    }
+  })
+
+  it('opens a Session preview immediately on keyboard focus', async () => {
+    const { SessionHoverPreview, SessionHoverPreviewProvider } =
+      await import('./SessionHoverPreview')
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    try {
+      await act(async () => {
+        root.render(
+          <SessionHoverPreviewProvider>
+            <SessionHoverPreview
+              session={{
+                id: 'focused',
+                title: 'Focused Session',
+                description: 'Focused Description'
+              }}
+            >
+              <button type="button">Focus trigger</button>
+            </SessionHoverPreview>
+          </SessionHoverPreviewProvider>
+        )
+      })
+      const trigger = container.querySelector('button')
+      if (!trigger) throw new Error('Session preview trigger did not render')
+
+      await act(async () => trigger.focus())
+
+      expect(document.body.querySelector('[data-slot="session-hover-preview"]')?.textContent).toBe(
+        'Focused SessionFocused Description'
+      )
+    } finally {
+      act(() => root.unmount())
+      container.remove()
+    }
+  })
+
+  it('renders full Session title and Description in the hover preview', async () => {
+    const { SessionHoverPreviewCard } = await import('./SessionHoverPreview')
+    const html = renderToStaticMarkup(
+      <SessionHoverPreviewCard
+        session={{ title: 'Complete analysis title', description: 'Compare both cohorts.' }}
+      />
+    )
+    const withoutDescription = renderToStaticMarkup(
+      <SessionHoverPreviewCard session={{ title: 'Title only', description: '   ' }} />
+    )
+
+    expect(html).toContain('data-slot="session-hover-preview"')
+    expect(html).toContain('Complete analysis title')
+    expect(html).toContain('Compare both cohorts.')
+    expect(withoutDescription).toContain('Title only')
+    expect(withoutDescription).not.toContain('<p class="mt-2')
+  })
+
+  it('scrolls only an overflowing Session title and resets it on pointer leave', async () => {
+    const { SessionTitleMarquee } = await import('./SessionHoverPreview')
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    const originalMatchMedia = window.matchMedia
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false })
+
+    try {
+      await act(async () => {
+        root.render(
+          <button type="button">
+            <SessionTitleMarquee title="A title wider than the Session row" />
+          </button>
+        )
+      })
+      const viewport = container.querySelector<HTMLElement>('[data-slot="session-title-marquee"]')
+      const content = viewport?.firstElementChild as HTMLElement | null
+      const trigger = viewport?.closest('button')
+      const cancel = vi.fn()
+      const animate = vi.fn().mockReturnValue({ cancel } as unknown as Animation)
+      expect(viewport).not.toBeNull()
+      expect(content).not.toBeNull()
+      if (!viewport || !content) throw new Error('Session title marquee did not render')
+      Object.defineProperty(viewport, 'clientWidth', { configurable: true, value: 100 })
+      Object.defineProperty(content, 'scrollWidth', { configurable: true, value: 180 })
+      Object.defineProperty(content, 'animate', { configurable: true, value: animate })
+
+      await act(async () => {
+        trigger?.dispatchEvent(new MouseEvent('pointerenter'))
+      })
+      expect(animate).toHaveBeenCalledWith(
+        [{ transform: 'translateX(0)' }, { transform: 'translateX(-80px)' }],
+        expect.objectContaining({ delay: 300, duration: 2_800, fill: 'forwards' })
+      )
+
+      await act(async () => {
+        trigger?.dispatchEvent(new MouseEvent('pointerleave'))
+      })
+      expect(cancel).toHaveBeenCalledTimes(1)
+
+      animate.mockClear()
+      Object.defineProperty(content, 'scrollWidth', { configurable: true, value: 90 })
+      await act(async () => {
+        trigger?.dispatchEvent(new MouseEvent('pointerenter'))
+      })
+      expect(animate).not.toHaveBeenCalled()
+    } finally {
+      act(() => root.unmount())
+      window.matchMedia = originalMatchMedia
+    }
+  })
+
+  it('keeps overflowing Session titles still when reduced motion is requested', async () => {
+    const { SessionTitleMarquee } = await import('./SessionHoverPreview')
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    const originalMatchMedia = window.matchMedia
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true })
+
+    try {
+      await act(async () => {
+        root.render(
+          <button type="button">
+            <SessionTitleMarquee title="A title wider than the Session row" />
+          </button>
+        )
+      })
+      const viewport = container.querySelector<HTMLElement>('[data-slot="session-title-marquee"]')
+      const content = viewport?.firstElementChild as HTMLElement | null
+      const trigger = viewport?.closest('button')
+      const animate = vi.fn()
+      if (!viewport || !content) throw new Error('Session title marquee did not render')
+      Object.defineProperty(viewport, 'clientWidth', { configurable: true, value: 100 })
+      Object.defineProperty(content, 'scrollWidth', { configurable: true, value: 180 })
+      Object.defineProperty(content, 'animate', { configurable: true, value: animate })
+
+      await act(async () => {
+        trigger?.dispatchEvent(new MouseEvent('pointerenter'))
+      })
+      expect(animate).not.toHaveBeenCalled()
+    } finally {
+      act(() => root.unmount())
+      window.matchMedia = originalMatchMedia
+    }
+  })
+
   it('docks the update action on the row above Settings', async () => {
     useUpdateStore.setState({
       status: { state: 'available', current: '0.2.0', latest: '0.3.0' }
@@ -734,7 +951,7 @@ describe('WorkspaceSidebar accessible render', () => {
     const notebookButton = elements.find(
       (element) =>
         element.type === 'button' &&
-        getTextContent(element).includes('Notebook review') &&
+        element.props['data-slot'] === 'session-open-button' &&
         typeof element.props.onClick === 'function'
     )
     const renameItems = elements.filter((element) => getTextContent(element).trim() === 'Edit…')

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -380,7 +380,7 @@ describe('WorkspaceSidebar accessible render', () => {
     }
   })
 
-  it('renders full Session title and Description in the hover preview', async () => {
+  it('clamps long Session titles and Descriptions to three preview lines', async () => {
     const { SessionHoverPreviewCard } = await import('./SessionHoverPreview')
     const html = renderToStaticMarkup(
       <SessionHoverPreviewCard
@@ -397,6 +397,7 @@ describe('WorkspaceSidebar accessible render', () => {
     expect(html).toContain('data-slot="session-hover-preview"')
     expect(html).toContain('Complete analysis title')
     expect(html).toContain('Compare both cohorts.')
+    expect(html.match(/line-clamp-3/g)).toHaveLength(2)
     expect(withoutDescription).toContain('Title only')
     expect(withoutDescription).not.toContain('<p class="mt-2')
     expect(loading).toContain('aria-busy="true"')

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.render.test.tsx
@@ -380,7 +380,7 @@ describe('WorkspaceSidebar accessible render', () => {
     }
   })
 
-  it('clamps long Session titles and Descriptions to three preview lines', async () => {
+  it('truncates long Session titles to one line and Descriptions to three lines', async () => {
     const { SessionHoverPreviewCard } = await import('./SessionHoverPreview')
     const html = renderToStaticMarkup(
       <SessionHoverPreviewCard
@@ -397,7 +397,8 @@ describe('WorkspaceSidebar accessible render', () => {
     expect(html).toContain('data-slot="session-hover-preview"')
     expect(html).toContain('Complete analysis title')
     expect(html).toContain('Compare both cohorts.')
-    expect(html.match(/line-clamp-3/g)).toHaveLength(2)
+    expect(html).toContain('class="truncate ')
+    expect(html.match(/line-clamp-3/g)).toHaveLength(1)
     expect(withoutDescription).toContain('Title only')
     expect(withoutDescription).not.toContain('<p class="mt-2')
     expect(loading).toContain('aria-busy="true"')

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -38,7 +38,8 @@ import { projectPresentedSessionActionability } from './session-wait-reason'
 import {
   SessionHoverPreview,
   SessionHoverPreviewProvider,
-  SessionTitleMarquee
+  SessionTitleMarquee,
+  type SessionPreviewRequest
 } from './SessionHoverPreview'
 
 type WorkspaceSidebarProps = {
@@ -54,6 +55,7 @@ type WorkspaceSidebarProps = {
   isFilesOpen: boolean
   onOpenFiles: () => void
   onOpenSession: (sessionId: string) => void
+  onPreviewSession?: SessionPreviewRequest
   onRenameSession: (session: ChatSession) => void
   canDownloadArtifacts: boolean
   onDownloadArtifacts: (session: ChatSession) => void
@@ -219,6 +221,7 @@ const WorkspaceSidebarView = ({
   isFilesOpen,
   onOpenFiles,
   onOpenSession,
+  onPreviewSession,
   onRenameSession,
   canDownloadArtifacts,
   onDownloadArtifacts,
@@ -504,7 +507,10 @@ const WorkspaceSidebarView = ({
                           {mobileMode ? (
                             openSessionButton
                           ) : (
-                            <SessionHoverPreview session={session}>
+                            <SessionHoverPreview
+                              session={session}
+                              onPreviewRequest={onPreviewSession}
+                            >
                               {openSessionButton}
                             </SessionHoverPreview>
                           )}

--- a/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebar.tsx
@@ -35,6 +35,11 @@ import type { ChatSession, SessionStatus } from '@/stores/session-store'
 import { NotificationBell } from '@/components/NotificationBell'
 
 import { projectPresentedSessionActionability } from './session-wait-reason'
+import {
+  SessionHoverPreview,
+  SessionHoverPreviewProvider,
+  SessionTitleMarquee
+} from './SessionHoverPreview'
 
 type WorkspaceSidebarProps = {
   projectName: string
@@ -424,198 +429,221 @@ const WorkspaceSidebarView = ({
 
           <div className="mx-2 my-1 h-px bg-border-300/15" />
 
-          <div className="min-h-0 flex-1 overflow-y-auto py-1">
-            {sections.map((section) => (
-              <div key={section.label}>
-                <div className="px-2 pb-[5px] pt-3.5 text-[11px] font-medium text-muted-foreground">
-                  {t(section.label)}
-                </div>
-                {section.items.map((session) => {
-                  const isActive = session.id === activeSessionId
-                  const shortcutNumber = shortcutNumberBySessionId.get(session.id)
-                  const presentedStatus = getPresentedSessionStatus(session)
-                  const isExportDisabled =
-                    (session.activeMessageCount ?? session.messages.length) === 0 ||
-                    presentedStatus === 'running' ||
-                    presentedStatus === 'waiting-for-user' ||
-                    presentedStatus === 'waiting-permission' ||
-                    presentedStatus === 'waiting-plan-approval'
-
-                  return (
-                    <div
-                      key={session.id}
-                      className={cn(sessionRowClassName, isActive && 'bg-bg-300 text-text-000')}
-                      title={session.title}
-                    >
-                      <div className="flex w-full min-w-0 items-center">
-                        <button
-                          type="button"
-                          className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
-                          aria-current={isActive ? 'page' : undefined}
-                          aria-keyshortcuts={
-                            shortcutNumber
-                              ? `${isMac ? 'Meta' : 'Control'}+${shortcutNumber}`
-                              : undefined
-                          }
-                          onClick={() => onOpenSession(session.id)}
+          <SessionHoverPreviewProvider>
+            <div className="min-h-0 flex-1 overflow-y-auto py-1">
+              {sections.map((section) => (
+                <div key={section.label}>
+                  <div className="px-2 pb-[5px] pt-3.5 text-[11px] font-medium text-muted-foreground">
+                    {t(section.label)}
+                  </div>
+                  {section.items.map((session) => {
+                    const isActive = session.id === activeSessionId
+                    const shortcutNumber = shortcutNumberBySessionId.get(session.id)
+                    const presentedStatus = getPresentedSessionStatus(session)
+                    const isExportDisabled =
+                      (session.activeMessageCount ?? session.messages.length) === 0 ||
+                      presentedStatus === 'running' ||
+                      presentedStatus === 'waiting-for-user' ||
+                      presentedStatus === 'waiting-permission' ||
+                      presentedStatus === 'waiting-plan-approval'
+                    const openSessionButton = (
+                      <button
+                        type="button"
+                        data-slot="session-open-button"
+                        className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
+                        aria-current={isActive ? 'page' : undefined}
+                        aria-keyshortcuts={
+                          shortcutNumber
+                            ? `${isMac ? 'Meta' : 'Control'}+${shortcutNumber}`
+                            : undefined
+                        }
+                        onClick={() => onOpenSession(session.id)}
+                      >
+                        <span
+                          className="inline-flex size-3 shrink-0 items-center justify-center"
+                          aria-hidden="true"
                         >
                           <span
-                            className="inline-flex size-3 shrink-0 items-center justify-center"
-                            aria-hidden="true"
-                          >
-                            <span
-                              className={cn(
-                                'size-[7px] shrink-0 rounded-full',
-                                sessionStatusDotClassName[presentedStatus]
-                              )}
-                            />
-                          </span>
-                          <span className="sr-only">
-                            {t('Session status: {{status}}', {
-                              status: t(sessionStatusLabelKeys[presentedStatus])
-                            })}
-                          </span>
-                          <span
                             className={cn(
-                              'min-w-0 flex-1 overflow-hidden whitespace-nowrap',
-                              section.label === 'Active' &&
-                                presentedStatus !== 'idle' &&
-                                'font-semibold'
+                              'size-[7px] shrink-0 rounded-full',
+                              sessionStatusDotClassName[presentedStatus]
                             )}
-                          >
-                            {session.title}
-                          </span>
-                          {showSessionShortcuts && shortcutNumber ? (
-                            <kbd
-                              aria-hidden="true"
-                              className="relative z-[2] mr-5 shrink-0 rounded-full bg-bg-300 px-1.5 py-0.5 font-sans text-[11px] font-medium leading-none tabular-nums text-text-100"
-                            >
-                              {isMac ? `⌘${shortcutNumber}` : `Ctrl+${shortcutNumber}`}
-                            </kbd>
-                          ) : null}
-                        </button>
-
-                        <span
-                          aria-hidden="true"
+                          />
+                        </span>
+                        <span className="sr-only">
+                          {t('Session status: {{status}}', {
+                            status: t(sessionStatusLabelKeys[presentedStatus])
+                          })}
+                        </span>
+                        <SessionTitleMarquee
+                          title={session.title}
                           className={cn(
-                            'pointer-events-none absolute inset-y-0 right-0 z-[1] w-12 rounded-r-md bg-gradient-to-r from-transparent via-rail-card-bg to-rail-card-bg group-hover:via-bg-300 group-hover:to-bg-300',
-                            isActive && 'via-bg-300 to-bg-300'
+                            section.label === 'Active' &&
+                              presentedStatus !== 'idle' &&
+                              'font-semibold'
                           )}
                         />
-
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <button
-                              type="button"
-                              className={cn(sessionRowActionClassName, mobileMode && 'opacity-100')}
-                              aria-label={t('Open actions for {{title}}', { title: session.title })}
-                            >
-                              <span
-                                className="flex size-3.5 items-center justify-center"
-                                aria-hidden="true"
-                              >
-                                <MoreVertical className="size-3.5" strokeWidth={2} />
-                              </span>
-                            </button>
-                          </DropdownMenuTrigger>
-                          {/* Session action menu: uses shadcn default light-surface tokens. */}
-                          <DropdownMenuContent
-                            aria-label={t('Session actions')}
-                            className={cn('min-w-[9rem]', mobileMode && 'z-[80]')}
-                            side="right"
-                            align="start"
-                            sideOffset={6}
+                        {showSessionShortcuts && shortcutNumber ? (
+                          <kbd
+                            aria-hidden="true"
+                            className="relative z-[2] mr-5 shrink-0 rounded-full bg-bg-300 px-1.5 py-0.5 font-sans text-[11px] font-medium leading-none tabular-nums text-text-100"
                           >
-                            {/* Pin / Unpin toggles the conversation into or out of the pinned section. */}
-                            <DropdownMenuItem
-                              className="gap-2"
-                              disabled={!canMutateConversations}
-                              onSelect={() => onTogglePin(session)}
-                            >
-                              <span className={sessionMenuIconClassName}>
-                                {session.pinned ? (
-                                  <PinOff className="size-4" strokeWidth={2} aria-hidden="true" />
-                                ) : (
-                                  <Pin className="size-4" strokeWidth={2} aria-hidden="true" />
+                            {isMac ? `⌘${shortcutNumber}` : `Ctrl+${shortcutNumber}`}
+                          </kbd>
+                        ) : null}
+                      </button>
+                    )
+
+                    return (
+                      <div
+                        key={session.id}
+                        className={cn(sessionRowClassName, isActive && 'bg-bg-300 text-text-000')}
+                        title={mobileMode ? session.title : undefined}
+                      >
+                        <div className="flex w-full min-w-0 items-center">
+                          {mobileMode ? (
+                            openSessionButton
+                          ) : (
+                            <SessionHoverPreview session={session}>
+                              {openSessionButton}
+                            </SessionHoverPreview>
+                          )}
+
+                          <span
+                            aria-hidden="true"
+                            className={cn(
+                              'pointer-events-none absolute inset-y-0 right-0 z-[1] w-12 rounded-r-md bg-gradient-to-r from-transparent via-rail-card-bg to-rail-card-bg group-hover:via-bg-300 group-hover:to-bg-300',
+                              isActive && 'via-bg-300 to-bg-300'
+                            )}
+                          />
+
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <button
+                                type="button"
+                                className={cn(
+                                  sessionRowActionClassName,
+                                  mobileMode && 'opacity-100'
                                 )}
-                              </span>
-                              {session.pinned ? t('Unpin') : t('Pin')}
-                            </DropdownMenuItem>
-                            <DropdownMenuItem
-                              className="gap-2"
-                              disabled={!canMutateConversations}
-                              onSelect={() => onRenameSession(session)}
+                                aria-label={t('Open actions for {{title}}', {
+                                  title: session.title
+                                })}
+                              >
+                                <span
+                                  className="flex size-3.5 items-center justify-center"
+                                  aria-hidden="true"
+                                >
+                                  <MoreVertical className="size-3.5" strokeWidth={2} />
+                                </span>
+                              </button>
+                            </DropdownMenuTrigger>
+                            {/* Session action menu: uses shadcn default light-surface tokens. */}
+                            <DropdownMenuContent
+                              aria-label={t('Session actions')}
+                              className={cn('min-w-[9rem]', mobileMode && 'z-[80]')}
+                              side="right"
+                              align="start"
+                              sideOffset={6}
                             >
-                              <span className={sessionMenuIconClassName}>
-                                <Pencil className="size-4" strokeWidth={2} aria-hidden="true" />
-                              </span>
-                              {t('Edit…')}
-                            </DropdownMenuItem>
-                            <DropdownMenuSeparator />
-                            {canDownloadArtifacts ? (
+                              {/* Pin / Unpin toggles the conversation into or out of the pinned section. */}
                               <DropdownMenuItem
                                 className="gap-2"
-                                onSelect={() => onDownloadArtifacts(session)}
+                                disabled={!canMutateConversations}
+                                onSelect={() => onTogglePin(session)}
                               >
                                 <span className={sessionMenuIconClassName}>
-                                  <Download className="size-4" strokeWidth={2} aria-hidden="true" />
+                                  {session.pinned ? (
+                                    <PinOff className="size-4" strokeWidth={2} aria-hidden="true" />
+                                  ) : (
+                                    <Pin className="size-4" strokeWidth={2} aria-hidden="true" />
+                                  )}
                                 </span>
-                                {t('Download all artifacts')}
+                                {session.pinned ? t('Unpin') : t('Pin')}
                               </DropdownMenuItem>
-                            ) : null}
-                            <DropdownMenuItem
-                              className="gap-2"
-                              onSelect={() => onViewNotebook(session)}
-                            >
-                              <span className={sessionMenuIconClassName}>
-                                <BookOpen className="size-4" strokeWidth={2} aria-hidden="true" />
-                              </span>
-                              {t('View notebook')}
-                            </DropdownMenuItem>
-                            {onExportSession ? (
                               <DropdownMenuItem
                                 className="gap-2"
-                                disabled={isExportDisabled}
-                                onSelect={() => onExportSession(session)}
+                                disabled={!canMutateConversations}
+                                onSelect={() => onRenameSession(session)}
                               >
                                 <span className={sessionMenuIconClassName}>
-                                  <Download className="size-4" strokeWidth={2} aria-hidden="true" />
+                                  <Pencil className="size-4" strokeWidth={2} aria-hidden="true" />
                                 </span>
-                                {t('Export conversation…')}
+                                {t('Edit…')}
                               </DropdownMenuItem>
-                            ) : null}
-                            <DropdownMenuItem
-                              className="gap-2"
-                              disabled={!canArchiveSession?.(session)}
-                              onSelect={() => onArchiveSession?.(session)}
-                            >
-                              <span className={sessionMenuIconClassName}>
-                                <Archive className="size-4" strokeWidth={2} aria-hidden="true" />
-                              </span>
-                              {/* The verb. Bare 'Archive' is the noun (a .zip) in the file browser. */}
-                              {t('Archive', { context: 'verb' })}
-                            </DropdownMenuItem>
-                            <DropdownMenuSeparator />
-                            {/* Delete uses the project's danger token pair for light surfaces. */}
-                            <DropdownMenuItem
-                              className="gap-2 text-danger-000 data-[highlighted]:bg-danger-900 data-[highlighted]:text-danger-000"
-                              disabled={!canDeleteConversations}
-                              onSelect={() => onDeleteSession(session)}
-                            >
-                              <span className={sessionMenuIconClassName}>
-                                <Trash2 className="size-4" strokeWidth={2} aria-hidden="true" />
-                              </span>
-                              {t('Delete')}
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
+                              <DropdownMenuSeparator />
+                              {canDownloadArtifacts ? (
+                                <DropdownMenuItem
+                                  className="gap-2"
+                                  onSelect={() => onDownloadArtifacts(session)}
+                                >
+                                  <span className={sessionMenuIconClassName}>
+                                    <Download
+                                      className="size-4"
+                                      strokeWidth={2}
+                                      aria-hidden="true"
+                                    />
+                                  </span>
+                                  {t('Download all artifacts')}
+                                </DropdownMenuItem>
+                              ) : null}
+                              <DropdownMenuItem
+                                className="gap-2"
+                                onSelect={() => onViewNotebook(session)}
+                              >
+                                <span className={sessionMenuIconClassName}>
+                                  <BookOpen className="size-4" strokeWidth={2} aria-hidden="true" />
+                                </span>
+                                {t('View notebook')}
+                              </DropdownMenuItem>
+                              {onExportSession ? (
+                                <DropdownMenuItem
+                                  className="gap-2"
+                                  disabled={isExportDisabled}
+                                  onSelect={() => onExportSession(session)}
+                                >
+                                  <span className={sessionMenuIconClassName}>
+                                    <Download
+                                      className="size-4"
+                                      strokeWidth={2}
+                                      aria-hidden="true"
+                                    />
+                                  </span>
+                                  {t('Export conversation…')}
+                                </DropdownMenuItem>
+                              ) : null}
+                              <DropdownMenuItem
+                                className="gap-2"
+                                disabled={!canArchiveSession?.(session)}
+                                onSelect={() => onArchiveSession?.(session)}
+                              >
+                                <span className={sessionMenuIconClassName}>
+                                  <Archive className="size-4" strokeWidth={2} aria-hidden="true" />
+                                </span>
+                                {/* The verb. Bare 'Archive' is the noun (a .zip) in the file browser. */}
+                                {t('Archive', { context: 'verb' })}
+                              </DropdownMenuItem>
+                              <DropdownMenuSeparator />
+                              {/* Delete uses the project's danger token pair for light surfaces. */}
+                              <DropdownMenuItem
+                                className="gap-2 text-danger-000 data-[highlighted]:bg-danger-900 data-[highlighted]:text-danger-000"
+                                disabled={!canDeleteConversations}
+                                onSelect={() => onDeleteSession(session)}
+                              >
+                                <span className={sessionMenuIconClassName}>
+                                  <Trash2 className="size-4" strokeWidth={2} aria-hidden="true" />
+                                </span>
+                                {t('Delete')}
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        </div>
                       </div>
-                    </div>
-                  )
-                })}
-              </div>
-            ))}
-          </div>
+                    )
+                  })}
+                </div>
+              ))}
+            </div>
+          </SessionHoverPreviewProvider>
 
           <div className="relative shrink-0 px-2 pt-2">
             <div

--- a/src/renderer/src/pages/workspace/WorkspaceSidebarContainer.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebarContainer.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+import { act, type ComponentProps } from 'react'
+import { createRoot } from 'react-dom/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ChatSession } from '@/stores/session-store'
+import { useSessionStore } from '@/stores/session-store'
+
+const persistenceMocks = vi.hoisted(() => ({
+  hydratePersistedSessionIfPresent: vi.fn(),
+  loadPersistedSession: vi.fn()
+}))
+
+vi.mock('@/lib/session-persistence/session-persistence', () => persistenceMocks)
+
+vi.mock('./WorkspaceSidebar', () => ({
+  WorkspaceSidebar: ({
+    onPreviewSession
+  }: {
+    onPreviewSession?: (sessionId: string) => Promise<void> | void
+  }) => (
+    <button type="button" onClick={() => void onPreviewSession?.('lazy-session')}>
+      Preview Session
+    </button>
+  )
+}))
+
+import { WorkspaceSidebarContainer } from './WorkspaceSidebarContainer'
+
+const lazySession: ChatSession = {
+  id: 'lazy-session',
+  projectId: 'project-1',
+  title: 'Lazy Session',
+  cwd: '/workspace',
+  status: 'idle',
+  messages: [],
+  createdAt: 1,
+  updatedAt: 1,
+  contentLoaded: false
+}
+
+beforeEach(() => {
+  persistenceMocks.hydratePersistedSessionIfPresent.mockReset()
+  persistenceMocks.loadPersistedSession.mockReset()
+  useSessionStore.setState({ sessions: [lazySession] })
+})
+
+describe('WorkspaceSidebarContainer Session previews', () => {
+  it('loads lazy Session details on demand and deduplicates concurrent requests', async () => {
+    let resolveLoad: ((value: { id: string; projectId: string }) => void) | undefined
+    persistenceMocks.loadPersistedSession.mockReturnValue(
+      new Promise((resolve) => {
+        resolveLoad = resolve
+      })
+    )
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkspaceSidebarContainer
+            {...({
+              projectId: 'project-1',
+              isProjectArchived: false
+            } as ComponentProps<typeof WorkspaceSidebarContainer>)}
+          />
+        )
+      })
+      const trigger = container.querySelector('button')
+      if (!trigger) throw new Error('Preview trigger did not render')
+
+      await act(async () => {
+        trigger.click()
+        trigger.click()
+      })
+
+      expect(persistenceMocks.loadPersistedSession).toHaveBeenCalledOnce()
+      expect(persistenceMocks.loadPersistedSession).toHaveBeenCalledWith({
+        projectId: 'project-1',
+        sessionId: 'lazy-session'
+      })
+
+      await act(async () => resolveLoad?.({ id: 'lazy-session', projectId: 'project-1' }))
+
+      expect(persistenceMocks.hydratePersistedSessionIfPresent).toHaveBeenCalledWith({
+        id: 'lazy-session',
+        projectId: 'project-1'
+      })
+    } finally {
+      act(() => root.unmount())
+    }
+  })
+
+  it('does not load details for an already hydrated Session', async () => {
+    useSessionStore.setState({ sessions: [{ ...lazySession, contentLoaded: undefined }] })
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    try {
+      await act(async () => {
+        root.render(
+          <WorkspaceSidebarContainer
+            {...({
+              projectId: 'project-1',
+              isProjectArchived: false
+            } as ComponentProps<typeof WorkspaceSidebarContainer>)}
+          />
+        )
+      })
+      const trigger = container.querySelector('button')
+      if (!trigger) throw new Error('Preview trigger did not render')
+
+      await act(async () => trigger.click())
+
+      expect(persistenceMocks.loadPersistedSession).not.toHaveBeenCalled()
+    } finally {
+      act(() => root.unmount())
+    }
+  })
+})

--- a/src/renderer/src/pages/workspace/WorkspaceSidebarContainer.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceSidebarContainer.tsx
@@ -1,5 +1,10 @@
+import { useCallback, useRef } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 
+import {
+  hydratePersistedSessionIfPresent,
+  loadPersistedSession
+} from '@/lib/session-persistence/session-persistence'
 import { useSessionStore } from '@/stores/session-store'
 
 import { NO_VISIBLE_SESSIONS, visibleProjectSessions } from './visible-project-sessions'
@@ -7,7 +12,7 @@ import { WorkspaceSidebar } from './WorkspaceSidebar'
 
 type WorkspaceSidebarContainerProps = Omit<
   React.ComponentProps<typeof WorkspaceSidebar>,
-  'sessions' | 'starNudgeKey'
+  'sessions' | 'starNudgeKey' | 'onPreviewSession'
 > & {
   projectId: string
   isProjectArchived: boolean
@@ -21,12 +26,46 @@ const WorkspaceSidebarContainer = ({
   isProjectArchived,
   ...sidebarProps
 }: WorkspaceSidebarContainerProps): React.JSX.Element => {
+  const previewLoadsRef = useRef(new Map<string, Promise<void>>())
   const sessions = useSessionStore(
     useShallow((state) =>
       isProjectArchived ? NO_VISIBLE_SESSIONS : visibleProjectSessions(state.sessions, projectId)
     )
   )
-  return <WorkspaceSidebar {...sidebarProps} starNudgeKey={projectId} sessions={sessions} />
+  const loadPreviewSession = useCallback(
+    (sessionId: string): Promise<void> | void => {
+      const session = useSessionStore
+        .getState()
+        .sessions.find(
+          (candidate) => candidate.id === sessionId && candidate.projectId === projectId
+        )
+      if (!session || session.contentLoaded !== false) return
+
+      const pending = previewLoadsRef.current.get(sessionId)
+      if (pending) return pending
+
+      const load = loadPersistedSession({ projectId, sessionId })
+        .then((persisted) => {
+          if (persisted) hydratePersistedSessionIfPresent(persisted)
+        })
+        .catch(() => undefined)
+        .finally(() => {
+          previewLoadsRef.current.delete(sessionId)
+        })
+      previewLoadsRef.current.set(sessionId, load)
+      return load
+    },
+    [projectId]
+  )
+
+  return (
+    <WorkspaceSidebar
+      {...sidebarProps}
+      starNudgeKey={projectId}
+      sessions={sessions}
+      onPreviewSession={loadPreviewSession}
+    />
+  )
 }
 
 export { WorkspaceSidebarContainer }


### PR DESCRIPTION
## Problem

Long Session titles are truncated in the workspace sidebar, and the sidebar does not expose a Session's Description without opening it. This makes nearby Sessions difficult to distinguish.

## Proposed change

- Scroll an overflowing Session title at a constant speed while its row is hovered, and reset it when the pointer leaves.
- Show a title-and-Description preview immediately on hover or keyboard focus.
- Truncate the preview title to one line and clamp the Description with an ellipsis after three lines.
- Move the open preview directly between Session rows as the pointer moves.
- Load details for lazy Session summaries on demand and deduplicate concurrent reads.
- Respect reduced-motion preferences.
- Keep hover previews desktop-only; mobile rows retain the native title fallback.

## Scope and non-goals

- No Session schema or historical-data migration.
- No new enum values or persisted state.
- No changes to Session creation, selection, or mutation behavior.
- Empty or missing Description values render a title-only preview.

## Acceptance criteria / validation

- [x] Pointer hover and keyboard focus open the preview immediately.
- [x] Moving to another Session updates and repositions the preview immediately.
- [x] Title is ellipsized after one line; Description is ellipsized after three lines.
- [x] Only overflowing titles animate, using the same pixels-per-second speed for every overflow distance.
- [x] Leaving restores the original title position.
- [x] Reduced-motion users do not receive title motion.
- [x] Lazy Session descriptions load on demand without duplicate concurrent reads.
- [x] Removed Session rows clear an active preview.
- [x] Mobile Session rows do not mount hover previews.
- [x] `npm run test:module -- workspace_page` — 25 files, 551 tests passed.
- [x] `npm test -- WorkspaceSidebar.render.test.tsx WorkspaceSidebarContainer.test.tsx` — 39 tests passed.
- [x] `npm run lint`
- [x] `npm run typecheck:web`
- [x] `npx vitest run src/renderer/src/i18n/resources.test.ts src/shared/renderer-surface-inventory.test.ts` — 747 tests passed.
- [x] Headless Web interaction check at 320, 375, 414, 768, and 1280 px; no horizontal overflow, and hover triggers are absent below the desktop breakpoint.

The complete local `npm test` suite was intentionally not run; PR CI is the authority for the full suite.

## Review focus

- Constant-speed title motion across different overflow distances.
- Pointer/focus lifecycle and Escape dismissal.
- Lazy Session detail hydration and removal cleanup.
- Tooltip collision behavior for long title and Description content.
