### PR TITLE
fix(preview): pin Electron-only sourcePreview surface inventory

### DIFF
--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -169,8 +169,8 @@ test('shows context compaction loading and completion inside the Session transcr
 test('previews and opens an Agent HTTPS source link in the isolated preview tab', async ({
   app
 }, testInfo) => {
-  let page = await app.completeOnboarding()
-  page = await app.configureFakeAgent()
+  await app.completeOnboarding()
+  const page = await app.configureFakeAgent()
   let sourceDocumentRequestCount = 0
   let releaseSourceDocument: (() => void) | undefined
   const sourceDocumentGate = new Promise<void>((resolve) => {
@@ -457,8 +457,8 @@ test('previews and opens an Agent HTTPS source link in the isolated preview tab'
 })
 
 test('shows the Electron failure reason when a source request fails', async ({ app }, testInfo) => {
-  let page = await app.completeOnboarding()
-  page = await app.configureFakeAgent()
+  await app.completeOnboarding()
+  const page = await app.configureFakeAgent()
   app.allowRendererConsoleError('Failed to load resource: net::ERR_CONNECTION_REFUSED')
   let sourceDocumentRequestCount = 0
   await page.route('https://citation.example/paper', async (route) => {

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -86,6 +86,8 @@ const GENERATED_SOURCE_OMISSIONS = [
   'sideChat.onRelayDelivered',
   'sideChat.send',
   'sideChat.start',
+  'sourcePreview.onLoadState',
+  'sourcePreview.release',
   'specialist.addMarketplaceSource',
   'specialist.cancelHandoff',
   'specialist.cancelMarketplaceCandidate',


### PR DESCRIPTION
## Problem

Two external PRs just landed on `main`:

- #1524 `feat(preview): open Agent source links in-app`
- #1772 `feat(workspace): restyle elicitation choice cards with per-question review`

#1524's PR Gate failed Static checks, Windows core, module tests, and the follow-on PR Gate job. Electron preload exposes `sourcePreview.onLoadState` and `sourcePreview.release`, but `GENERATED_SOURCE_OMISSIONS` still pinned the previous 80-path set. Those APIs are Electron-only (`ELECTRON_EVENT` / `SEND`), the same class as `officePreview.*`.

#1772's PR Gate passed. Elicitation interaction, scroller, and i18n resource tests pass on current `main`; no GitHub Actions failure reproduced for that PR.

## Proposed change

- Add `sourcePreview.onLoadState` and `sourcePreview.release` to `GENERATED_SOURCE_OMISSIONS`. `ELECTRON_ONLY_CALLABLE_PATHS` is derived from that list.
- Drop unused E2E `page` assignments in the two new source-preview workspace-conversation tests. `configureFakeAgent()` relaunches, so the onboarding page object is stale.

## Scope and non-goals

- No historical data compatibility work.
- No new state or enum values.
- No persisted-format, schema, or migration changes.
- No catalog, preload, or Web map changes. The catalog already declared these Electron-only methods; only the inventory pin was missing.

## Acceptance criteria and validation

The renderer surface inventory pin matches the installed Electron API. Source preview remains unavailable on local/remote Web.

Evidence (after the last material edit):

| Behavior | Command | Result |
| --- | --- | --- |
| Surface inventory pin | `npx vitest run src/shared/renderer-surface-inventory.test.ts` | pass |
| Catalog / matrix / argument-shape / preload | `npx vitest run` on those files | pass |
| Web RPC, API installer, command wiring | `npx vitest run` on those files | pass |
| Generated Web map | `npm run check:web-api-map` | pass |
| Node types | `npm run typecheck:node` | pass |
| Web types | `npm run typecheck:web` | pass |
| Lint of changed files | `npx eslint src/shared/renderer-surface-inventory.test.ts e2e/workspace-conversation.spec.ts` | pass |
| #1772 elicitation + i18n | `npx vitest run` on `WorkspaceElicitationCard.interaction.test.tsx`, `WorkspaceMessageScroller.interaction.test.tsx`, `resources.test.ts` | pass |

Full `npm test` left to PR CI. E2E was an assignment cleanup only and was not re-run locally.

Uncovered risks: Windows E2E for the new source-preview journeys was red on #1524 for more than this pin; this PR does not change that product path. PR CI remains the authority for the Windows E2E lane.

## Review focus

- The two paths belong in `GENERATED_SOURCE_OMISSIONS` because they are Electron-only, not because the Web generator should start emitting them.
- Do not add them to the generated Web map.