### PR TITLE
fix(session-persistence): bound live Session save cadence

### DIFF
--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -1144,6 +1144,60 @@ describe('renderer session persistence bridge', () => {
     }
   })
 
+  it('flushes a fast alternating multi-Session stream without draining cadence timers', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    let flushing: Promise<void> | undefined
+    try {
+      const sessions = [
+        createPersistedSession({ id: 'session-1' }),
+        createPersistedSession({ id: 'session-2' })
+      ]
+      const writeLatest = vi.fn(async (session: PersistedChatSession) => session)
+      const persistence = createOrderedSessionPersistence(createApi())
+
+      for (let frame = 0; frame < 30; frame += 1) {
+        const session = sessions[frame % sessions.length]
+        void persistence.saveLatestSession(`session:${session.id}`, () => writeLatest(session))
+        await vi.advanceTimersByTimeAsync(33)
+      }
+
+      let flushed = false
+      flushing = persistence.flush().then(() => {
+        flushed = true
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(flushed).toBe(true)
+      expect(writeLatest.mock.calls.length).toBeLessThanOrEqual(5)
+    } finally {
+      await vi.runAllTimersAsync()
+      await flushing
+      vi.useRealTimers()
+    }
+  })
+
+  it('invalidates a delayed save when a new hydration generation starts', async () => {
+    const session = createPersistedSession({ revision: 1, title: 'Old local title' })
+    const authority = createPersistedSession({ revision: 2, title: 'Hydrated title' })
+    const persistence = createOrderedSessionPersistence(createApi())
+    persistence.seedAcknowledgedSessions([session])
+    await persistence.saveLatestSession('session:session-1', async () => session)
+
+    const staleWrite = vi.fn(async () => session)
+    const staleSave = persistence.saveLatestSession('session:session-1', staleWrite)
+    persistence.seedAcknowledgedSessions([authority])
+
+    await staleSave.catch(() => undefined)
+    await persistence.flush()
+
+    expect(staleWrite).not.toHaveBeenCalled()
+    expect(persistence.getAcknowledgedSession('session-1')).toMatchObject({
+      revision: 2,
+      title: 'Hydrated title'
+    })
+  })
+
   it('chains queued local saves from the last acknowledged durable revision', async () => {
     const firstSave = createDeferred<PersistedChatSession>()
     const saveSession = vi

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -1121,6 +1121,29 @@ describe('renderer session persistence bridge', () => {
     expect(saveSession.mock.calls[1][1]).toEqual({ conflictRebaseFields: ['title'] })
   })
 
+  it('bounds fast whole-Session writes during a 30 fps live stream', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    try {
+      const session = createPersistedSession()
+      const writeLatest = vi.fn(async () => session)
+      const persistence = createOrderedSessionPersistence(createApi())
+      const writes: Promise<PersistedChatSession>[] = []
+
+      for (let frame = 0; frame < 30; frame += 1) {
+        writes.push(persistence.saveLatestSession('session:session-1', writeLatest))
+        await vi.advanceTimersByTimeAsync(33)
+      }
+
+      await vi.runAllTimersAsync()
+      await Promise.all(writes)
+
+      expect(writeLatest).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('chains queued local saves from the last acknowledged durable revision', async () => {
     const firstSave = createDeferred<PersistedChatSession>()
     const saveSession = vi

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -1135,7 +1135,7 @@ describe('renderer session persistence bridge', () => {
         await vi.advanceTimersByTimeAsync(33)
       }
 
-      await vi.runAllTimersAsync()
+      await persistence.flush()
       await Promise.all(writes)
 
       expect(writeLatest).toHaveBeenCalledTimes(3)

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -565,11 +565,15 @@ const createOrderedSessionPersistence = (
     acknowledgedSessions.set(session.id, structuredClone(session))
   }
 
-  const enqueue = <Result>(task: () => Promise<Result>): Promise<Result> => {
+  const releasePendingLatestCadence = (): void => {
     if (pendingLatest) {
       pendingLatest.bypassCadence = true
       pendingLatest.releaseCadence?.()
     }
+  }
+
+  const enqueue = <Result>(task: () => Promise<Result>): Promise<Result> => {
+    releasePendingLatestCadence()
     pendingLatest = undefined
     pendingLatestPromise = undefined
     const run = queue.then(task, task)
@@ -660,7 +664,10 @@ const createOrderedSessionPersistence = (
         }
       }),
     saveManifest: (request) => enqueue(() => api.saveManifest(request)),
-    flush: () => queue.then(() => undefined)
+    flush: () => {
+      releasePendingLatestCadence()
+      return queue.then(() => undefined)
+    }
   }
 }
 

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -508,6 +508,8 @@ const mergeSaveSessionOptions = (
   return conflictRebaseFields.length > 0 ? { conflictRebaseFields } : undefined
 }
 
+const LATEST_SESSION_SAVE_INTERVAL_MS = 500
+
 // Serializes every renderer-originated Session write through one ordering seam. Store snapshots at
 // the queue tail use latest-wins coalescing; explicit Session and Manifest writes remain barriers, so
 // Artifact finalization cannot be overtaken by an older store snapshot.
@@ -522,9 +524,29 @@ const createOrderedSessionPersistence = (
         target: string
         task: LatestSessionSaveTask
         options: SaveSessionOptions | undefined
+        bypassCadence?: boolean
+        releaseCadence?: () => void
       }
     | undefined
   let pendingLatestPromise: Promise<PersistedChatSession> | undefined
+  let latestSessionSaveStartedAt = Number.NEGATIVE_INFINITY
+
+  const waitForLatestSessionSaveCadence = async (
+    entry: NonNullable<typeof pendingLatest>
+  ): Promise<void> => {
+    const waitMs = latestSessionSaveStartedAt + LATEST_SESSION_SAVE_INTERVAL_MS - performance.now()
+    if (waitMs > 0 && !entry.bypassCadence) {
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(resolve, waitMs)
+        entry.releaseCadence = () => {
+          clearTimeout(timeout)
+          resolve()
+        }
+      })
+    }
+    entry.releaseCadence = undefined
+    latestSessionSaveStartedAt = performance.now()
+  }
 
   const acknowledgeSession = (session: PersistedChatSession): void => {
     const revision = sessionRevision(session)
@@ -544,6 +566,10 @@ const createOrderedSessionPersistence = (
   }
 
   const enqueue = <Result>(task: () => Promise<Result>): Promise<Result> => {
+    if (pendingLatest) {
+      pendingLatest.bypassCadence = true
+      pendingLatest.releaseCadence?.()
+    }
     pendingLatest = undefined
     pendingLatestPromise = undefined
     const run = queue.then(task, task)
@@ -582,15 +608,17 @@ const createOrderedSessionPersistence = (
     }
 
     const entry = { target, task, options }
-    const runTask = (): Promise<PersistedChatSession> => {
+    const runTask = async (): Promise<PersistedChatSession> => {
+      // A fast IPC/disk round-trip otherwise defeats latest-wins coalescing and rewrites the entire
+      // Session at the live presentation frame rate. Keep the entry replaceable while it waits.
+      await waitForLatestSessionSaveCadence(entry)
       if (pendingLatest === entry) {
         pendingLatest = undefined
         pendingLatestPromise = undefined
       }
-      return entry.task(entry.options).then((durable) => {
-        acknowledgeSession(durable)
-        return durable
-      })
+      const durable = await entry.task(entry.options)
+      acknowledgeSession(durable)
+      return durable
     }
     const run = queue.then(runTask, runTask)
     pendingLatest = entry
@@ -605,6 +633,9 @@ const createOrderedSessionPersistence = (
   return {
     saveLatestSession,
     seedAcknowledgedSessions: (sessions) => {
+      // A newly hydrated store starts a fresh live-save cadence. The ordered queue remains shared,
+      // but a save from the previous mount must not delay this mount's first observable write.
+      latestSessionSaveStartedAt = Number.NEGATIVE_INFINITY
       for (const session of sessions) {
         acknowledgedRevisions.set(session.id, sessionRevision(session))
         acknowledgedSessions.set(session.id, structuredClone(session))

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -510,6 +510,23 @@ const mergeSaveSessionOptions = (
 
 const LATEST_SESSION_SAVE_INTERVAL_MS = 500
 
+type PendingLatestSessionSave = {
+  target: string
+  task: LatestSessionSaveTask
+  options: SaveSessionOptions | undefined
+  generation: number
+  promise?: Promise<PersistedChatSession>
+  bypassCadence?: boolean
+  releaseCadence?: () => void
+}
+
+class SessionPersistenceGenerationChangedError extends Error {
+  constructor() {
+    super('Session persistence hydration generation changed.')
+    this.name = 'SessionPersistenceGenerationChangedError'
+  }
+}
+
 // Serializes every renderer-originated Session write through one ordering seam. Store snapshots at
 // the queue tail use latest-wins coalescing; explicit Session and Manifest writes remain barriers, so
 // Artifact finalization cannot be overtaken by an older store snapshot.
@@ -519,20 +536,12 @@ const createOrderedSessionPersistence = (
   let queue: Promise<unknown> = Promise.resolve()
   const acknowledgedRevisions = new Map<string, number>()
   const acknowledgedSessions = new Map<string, PersistedChatSession>()
-  let pendingLatest:
-    | {
-        target: string
-        task: LatestSessionSaveTask
-        options: SaveSessionOptions | undefined
-        bypassCadence?: boolean
-        releaseCadence?: () => void
-      }
-    | undefined
-  let pendingLatestPromise: Promise<PersistedChatSession> | undefined
+  const pendingLatestByTarget = new Map<string, PendingLatestSessionSave>()
+  let hydrationGeneration = 0
   let latestSessionSaveStartedAt = Number.NEGATIVE_INFINITY
 
   const waitForLatestSessionSaveCadence = async (
-    entry: NonNullable<typeof pendingLatest>
+    entry: PendingLatestSessionSave
   ): Promise<void> => {
     const waitMs = latestSessionSaveStartedAt + LATEST_SESSION_SAVE_INTERVAL_MS - performance.now()
     if (waitMs > 0 && !entry.bypassCadence) {
@@ -545,7 +554,7 @@ const createOrderedSessionPersistence = (
       })
     }
     entry.releaseCadence = undefined
-    latestSessionSaveStartedAt = performance.now()
+    if (entry.generation === hydrationGeneration) latestSessionSaveStartedAt = performance.now()
   }
 
   const acknowledgeSession = (session: PersistedChatSession): void => {
@@ -566,16 +575,15 @@ const createOrderedSessionPersistence = (
   }
 
   const releasePendingLatestCadence = (): void => {
-    if (pendingLatest) {
-      pendingLatest.bypassCadence = true
-      pendingLatest.releaseCadence?.()
+    for (const entry of pendingLatestByTarget.values()) {
+      entry.bypassCadence = true
+      entry.releaseCadence?.()
     }
   }
 
   const enqueue = <Result>(task: () => Promise<Result>): Promise<Result> => {
     releasePendingLatestCadence()
-    pendingLatest = undefined
-    pendingLatestPromise = undefined
+    pendingLatestByTarget.clear()
     const run = queue.then(task, task)
     queue = run.then(
       () => undefined,
@@ -605,28 +613,34 @@ const createOrderedSessionPersistence = (
     task: LatestSessionSaveTask,
     options?: SaveSessionOptions
   ): Promise<PersistedChatSession> => {
-    if (pendingLatest?.target === target && pendingLatestPromise) {
-      pendingLatest.task = task
-      pendingLatest.options = mergeSaveSessionOptions(pendingLatest.options, options)
-      return pendingLatestPromise
+    const pending = pendingLatestByTarget.get(target)
+    if (pending?.promise) {
+      pending.task = task
+      pending.options = mergeSaveSessionOptions(pending.options, options)
+      return pending.promise
     }
 
-    const entry = { target, task, options }
+    const entry: PendingLatestSessionSave = {
+      target,
+      task,
+      options,
+      generation: hydrationGeneration
+    }
     const runTask = async (): Promise<PersistedChatSession> => {
       // A fast IPC/disk round-trip otherwise defeats latest-wins coalescing and rewrites the entire
       // Session at the live presentation frame rate. Keep the entry replaceable while it waits.
       await waitForLatestSessionSaveCadence(entry)
-      if (pendingLatest === entry) {
-        pendingLatest = undefined
-        pendingLatestPromise = undefined
+      if (pendingLatestByTarget.get(target) === entry) pendingLatestByTarget.delete(target)
+      if (entry.generation !== hydrationGeneration) {
+        throw new SessionPersistenceGenerationChangedError()
       }
       const durable = await entry.task(entry.options)
       acknowledgeSession(durable)
       return durable
     }
     const run = queue.then(runTask, runTask)
-    pendingLatest = entry
-    pendingLatestPromise = run
+    entry.promise = run
+    pendingLatestByTarget.set(target, entry)
     queue = run.then(
       () => undefined,
       () => undefined
@@ -637,8 +651,11 @@ const createOrderedSessionPersistence = (
   return {
     saveLatestSession,
     seedAcknowledgedSessions: (sessions) => {
-      // A newly hydrated store starts a fresh live-save cadence. The ordered queue remains shared,
-      // but a save from the previous mount must not delay this mount's first observable write.
+      // A newly hydrated store invalidates delayed snapshots from the previous store generation.
+      // The shared queue still preserves barriers, but stale local state can no longer write later.
+      hydrationGeneration += 1
+      releasePendingLatestCadence()
+      pendingLatestByTarget.clear()
       latestSessionSaveStartedAt = Number.NEGATIVE_INFINITY
       for (const session of sessions) {
         acknowledgedRevisions.set(session.id, sessionRevision(session))
@@ -1341,6 +1358,7 @@ const createStoreSaver = (
           return result
         },
         (error: unknown) => {
+          if (error instanceof SessionPersistenceGenerationChangedError) return undefined
           observer.onFailure?.(target, error, failureContext)
           throw error
         }


### PR DESCRIPTION
## Problem

The attached Windows log covers long-running Sessions whose persisted Session directory grew from about 356 MB to 380 MB. During a live run, renderer presentation updates can arrive at roughly 30 fps. The existing latest-wins persistence queue coalesced only while an IPC or disk write was still backpressured, so a fast write path could still serialize, clone, send, stringify, and atomically rewrite the entire Session once per frame.

The deterministic regression reproduced that amplification at the existing ordered-persistence boundary: 30 updates in one second produced 30 whole-Session writes on the pre-fix code. It failed three consecutive runs with the report-consistent reason (expected 3 writes, received 30).

The log does not contain an OOM, disk-corruption, or kernel-level cause, so this PR does not claim that Session persistence alone caused the full Windows freeze or the unrecoverable result folder. It removes one evidenced, avoidable source of sustained CPU, memory-allocation, IPC, and disk pressure.

## Proposed change

- Bound automatic latest-Session snapshots to a 500 ms cadence while retaining latest-wins coalescing.
- Keep one replaceable waiting snapshot per Session target, so alternating active Sessions cannot build a frame-by-frame timer backlog.
- Treat explicit saves, retry/recovery, manifest writes, and flush as barriers that release every waiting target immediately and preserve existing ordering.
- Invalidate delayed snapshots when a newly hydrated store generation starts, preventing pre-reload local state from writing after authoritative hydration.

At a 30 fps update rate this reduces steady-state whole-Session rewrites from up to 30 per second to at most 2 per second. The leading and trailing boundaries make the one-second regression observe 3 writes.

## Scope and non-goals

- No data fields, schema, migration, enum values, architecture boundary, data model, or user interaction changes.
- Internal transient state only: a per-target pending-save map and hydration generation counter inside the existing ordered persistence module. Neither is exposed or persisted.
- Persistence impact: the existing Session JSON format and atomic temp-file rename remain unchanged. Automatic intermediate snapshots may be delayed by at most 500 ms; explicit barriers and quit flush remain immediate and still wait for the newest queued snapshot to finish.
- Historical compatibility: none required; existing Session data is read and written unchanged.
- No aggregate Session-size cap, truncation, compaction, or deletion behavior.
- No OS process quota or notebook/agent compute throttling. The supplied log has no process telemetry proving that such a broader mechanism is warranted.
- No claim to repair an already corrupted external result directory.

This is intentionally a narrow fix rather than a persistence redesign: the expensive behavior is reproducible at a public ordering boundary, and the change substantially reduces pressure without changing durable data contracts.

## Acceptance criteria and validation

All listed checks ran after the final material edit.

- Fast 30 fps whole-Session persistence is bounded, alternating Session targets flush without draining cadence timers, and a new hydration generation invalidates stale delayed writes -> `npm test -- --run src/renderer/src/lib/session-persistence/session-persistence.test.ts src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx src/renderer/src/hooks/useQuitPersistenceFlush.test.ts` -> 3 files passed, 78 tests passed.
- Retry, revision-conflict, manifest, hydration, and quit-flush consumers retain their behavior -> same targeted command -> passed.
- Renderer types remain valid -> `npm run typecheck:web` -> passed.
- Source style remains valid -> `npm run lint` -> passed with no findings.
- Patch whitespace remains valid -> `git diff --check` -> passed.

Per the requested workflow, the full portable suite was not run locally; exact-head PR CI is authoritative. The remaining uncovered risk is an end-to-end Windows resource-exhaustion reproduction: the log lacks per-process CPU/memory/I/O telemetry, so CI and future telemetry may identify an additional independent compute-heavy cause.

## Review focus

- Whether 500 ms is the appropriate bounded persistence cadence for live presentation updates.
- Whether per-target coalescing bounds alternating Session streams and every explicit ordering barrier releases all cadence waits.
- Whether hydration-generation invalidation prevents stale pre-reload snapshots without surfacing a false write failure.
- Whether the regression adequately represents the observed amplification without adding a production-only test seam.

Independent review is still required before marking the final Test Impact Set verified under CONTRIBUTING.md.
