### PR TITLE
fix(workspace): stabilize plan preview

### DIFF
--- a/src/renderer/src/pages/workspace/previews/PreviewToolContent.plan.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewToolContent.plan.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ActivePlanProjection } from '../../../../../shared/session-plan/contract'
@@ -142,7 +142,7 @@ describe('Plan Preview workbench integration', () => {
       />
     )
 
-    expect(screen.getByText('Historical branch Plan')).toBeTruthy()
+    expect(screen.getByRole('heading', { level: 1, name: 'Historical branch Plan' })).toBeTruthy()
   })
 
   it('uses the shared full-screen state and applies the approved projection', async () => {
@@ -231,6 +231,99 @@ describe('Plan Preview workbench integration', () => {
     expect(screen.queryByRole('button', { name: 'Dismiss' })).toBeNull()
     expect(screen.getByText(/original Agent interaction has ended/u)).toBeTruthy()
     expect(screen.getByText('Session Plan')).toBeTruthy()
+  })
+
+  it('preserves the Plan scroll position across a streamed durable progress refresh', () => {
+    useSessionStore.setState({
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'project-1',
+          title: 'Plan progress',
+          cwd: '/workspace',
+          status: 'running',
+          messages: [],
+          runtimeContext: {
+            version: 1,
+            revision: pendingProjection.revision,
+            plan: {
+              artifactId: pendingProjection.artifactId,
+              artifactVersionId: pendingProjection.artifactVersionId,
+              artifactChecksum: pendingProjection.artifactChecksum,
+              approval: pendingProjection.approval,
+              stepStatuses: pendingProjection.stepStatuses
+            }
+          },
+          activePlanProjection: pendingProjection,
+          artifacts: sessionPlanArtifacts,
+          createdAt: 1,
+          updatedAt: 2
+        } as never
+      ]
+    })
+    const item = {
+      id: 'tool:session-1:plan:version-1',
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      type: 'tool' as const,
+      toolKind: 'plan' as const,
+      title: 'Session Plan',
+      planArtifactVersionId: 'version-1'
+    }
+    const { container, rerender } = render(<PreviewToolContent item={item} />)
+    const viewport = container.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]')
+    expect(viewport).not.toBeNull()
+    if (!viewport) return
+
+    viewport.scrollTop = 240
+    const source = useSessionStore.getState().sessions[0]
+    const streamedStepStatuses = {
+      'Analyze the data': { status: 'in_progress' as const, updatedAt: 3 }
+    }
+    act(() => {
+      useSessionStore.getState().applyDurableSessionProjection({
+        source,
+        session: {
+          ...source,
+          activePlanProjection: undefined,
+          runtimeContext: {
+            ...source.runtimeContext!,
+            revision: 4,
+            plan: { ...source.runtimeContext!.plan!, stepStatuses: streamedStepStatuses }
+          },
+          updatedAt: 3
+        } as never,
+        mode: 'runtime-context-authority'
+      })
+    })
+    const streamingViewport = container.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]'
+    )
+    expect(streamingViewport).toBe(viewport)
+    expect(streamingViewport?.scrollTop).toBe(240)
+
+    rerender(<PreviewToolContent item={{ ...item }} />)
+    expect(container.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]')).toBe(
+      viewport
+    )
+
+    const refreshedProjection: ActivePlanProjection = {
+      ...pendingProjection,
+      revision: 4,
+      lifecycle: 'in_progress',
+      stepStatuses: streamedStepStatuses,
+      stepStates: streamedStepStatuses,
+      counts: { ...pendingProjection.counts, inProgress: 1 }
+    }
+    act(() => {
+      useSessionStore.getState().setActivePlanProjection('session-1', refreshedProjection)
+    })
+
+    const updatedViewport = container.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]'
+    )
+    expect(updatedViewport).toBe(viewport)
+    expect(updatedViewport?.scrollTop).toBe(240)
   })
 
   it('routes restored pending Plan decisions through the session-bound responder', async () => {

--- a/src/renderer/src/pages/workspace/previews/PreviewToolContent.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewToolContent.tsx
@@ -1,7 +1,8 @@
 import { LoaderCircle } from 'lucide-react'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import type { ActivePlanProjection } from '../../../../../shared/session-plan/contract'
 import { Button } from '@/components/ui/button'
 import {
   selectProjectSessionReviewLoadError,
@@ -10,7 +11,7 @@ import {
 } from '@/stores/review-store'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { type PreviewToolItem, usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
-import { useSessionStore } from '@/stores/session-store'
+import { type ChatSession, type SessionStore, useSessionStore } from '@/stores/session-store'
 
 import { NotebookPreview } from '../NotebookPreview'
 import type { NotebookPreviewItem } from '../NotebookPreview'
@@ -23,6 +24,54 @@ import { useIsSideChatOpenForSession } from '../use-side-chat-controller'
 
 const isNotebookPreviewItem = (item: PreviewToolItem): item is NotebookPreviewItem =>
   item.toolKind === 'notebook' && Boolean(item.notebook)
+
+const resolvePlanProjection = (
+  session: ChatSession | undefined,
+  planArtifactVersionId: string | undefined
+): ActivePlanProjection | undefined => {
+  const activePlanProjection = session?.activePlanProjection
+  if (!planArtifactVersionId) return activePlanProjection
+
+  return (
+    session?.planHistoryProjections?.find(
+      (projection) => projection.artifactVersionId === planArtifactVersionId
+    ) ??
+    (activePlanProjection?.artifactVersionId === planArtifactVersionId
+      ? activePlanProjection
+      : undefined)
+  )
+}
+
+// Durable progress updates can invalidate the full projection while WorkspacePage reloads it.
+// Keep the matching document visible for that short gap so the preview viewport stays mounted.
+const createVisiblePlanProjectionSelector = (
+  sessionId: string,
+  planArtifactVersionId: string | undefined
+): ((state: SessionStore) => ActivePlanProjection | undefined) => {
+  let retainedProjection: ActivePlanProjection | undefined
+
+  return (state) => {
+    const session = state.sessions.find((candidate) => candidate.id === sessionId)
+    const projection = resolvePlanProjection(session, planArtifactVersionId)
+    if (projection) {
+      retainedProjection = projection
+      return projection
+    }
+
+    const runtimePlan = session?.runtimeContext?.plan
+    const retainedMatchesRuntime =
+      retainedProjection &&
+      runtimePlan &&
+      retainedProjection.artifactVersionId === runtimePlan.artifactVersionId &&
+      retainedProjection.artifactId === runtimePlan.artifactId &&
+      retainedProjection.artifactChecksum === runtimePlan.artifactChecksum &&
+      (!planArtifactVersionId || retainedProjection.artifactVersionId === planArtifactVersionId)
+
+    if (retainedMatchesRuntime) return retainedProjection
+    retainedProjection = undefined
+    return undefined
+  }
+}
 
 // Renders the Session reviewer panel from persisted review data for the tool item's session.
 const SessionReviewerContent = ({
@@ -104,29 +153,26 @@ const SessionReviewerContent = ({
   return <SessionReviewerPanel review={review} activeFindingId={item.reviewerActiveFindingId} />
 }
 
-export const PreviewToolContent = ({
+const PlanPreviewToolContent = ({
   item,
   restoredPlanResponder
 }: {
   item: PreviewToolItem
   restoredPlanResponder?: RestoredPlanResponder
 }): React.JSX.Element | null => {
-  const activeProjectId = useNavigationStore((state) => state.activeProjectId)
   const isSideChatOpen = useIsSideChatOpenForSession(item.sessionId)
   const planSession = useSessionStore((state) =>
     state.sessions.find((session) => session.id === item.sessionId)
   )
+  const [selectVisiblePlanProjection] = useState(() =>
+    createVisiblePlanProjectionSelector(item.sessionId, item.planArtifactVersionId)
+  )
+  const visiblePlanProjection = useSessionStore(selectVisiblePlanProjection)
   const isPlanExpanded = usePreviewWorkbenchStore((state) => state.expandedToolItemId === item.id)
   const setToolItemExpanded = usePreviewWorkbenchStore((state) => state.setToolItemExpanded)
   const activePlanProjection = planSession?.activePlanProjection
-  const planProjection = item.planArtifactVersionId
-    ? (planSession?.planHistoryProjections?.find(
-        (projection) => projection.artifactVersionId === item.planArtifactVersionId
-      ) ??
-      (activePlanProjection?.artifactVersionId === item.planArtifactVersionId
-        ? activePlanProjection
-        : undefined))
-    : activePlanProjection
+  const planProjection = resolvePlanProjection(planSession, item.planArtifactVersionId)
+  const runtimePlan = planSession?.runtimeContext?.plan
 
   const respondPlan = async (decision: 'approved' | 'rejected'): Promise<void> => {
     if (!planProjection || !item.projectId) return
@@ -143,7 +189,40 @@ export const PreviewToolContent = ({
   const hasPlanResponsePath =
     planSession?.activeRun !== undefined || restoredPlanResponder?.sessionId === item.sessionId
   const canRespondToPlan =
-    planSession?.status === 'waiting-plan-approval' && hasPlanResponsePath && !isSideChatOpen
+    planProjection !== undefined &&
+    planSession?.status === 'waiting-plan-approval' &&
+    hasPlanResponsePath &&
+    !isSideChatOpen
+
+  if (!visiblePlanProjection || !planSession) return null
+  const currentPlanArtifactVersionId =
+    activePlanProjection?.artifactVersionId ?? runtimePlan?.artifactVersionId
+  const stale = visiblePlanProjection.artifactVersionId !== currentPlanArtifactVersionId
+  // The Plan's real artifact filename from the Session's artifact metadata; absent when the
+  // artifact entry has not been loaded, in which case the header shows the label only.
+  const planFilename = planSession.artifacts?.find(
+    (artifact) => artifact.versionId === visiblePlanProjection.artifactVersionId
+  )?.name
+  return (
+    <PlanPreviewSurface
+      projection={visiblePlanProjection}
+      stale={stale}
+      isFullScreen={isPlanExpanded}
+      planFilename={planFilename}
+      onRespond={canRespondToPlan ? respondPlan : undefined}
+      onToggleFullScreen={() => setToolItemExpanded(isPlanExpanded ? null : item.id)}
+    />
+  )
+}
+
+export const PreviewToolContent = ({
+  item,
+  restoredPlanResponder
+}: {
+  item: PreviewToolItem
+  restoredPlanResponder?: RestoredPlanResponder
+}): React.JSX.Element | null => {
+  const activeProjectId = useNavigationStore((state) => state.activeProjectId)
 
   // Remount the Files tool per project so its transient dialog cannot outlive the project it opened.
   if (item.toolKind === 'files') {
@@ -159,21 +238,11 @@ export const PreviewToolContent = ({
   }
 
   if (item.toolKind === 'plan') {
-    if (!planProjection || !planSession) return null
-    const stale = planProjection.artifactVersionId !== activePlanProjection?.artifactVersionId
-    // The Plan's real artifact filename from the Session's artifact metadata; absent when the
-    // artifact entry has not been loaded, in which case the header shows the label only.
-    const planFilename = planSession.artifacts?.find(
-      (artifact) => artifact.versionId === planProjection.artifactVersionId
-    )?.name
     return (
-      <PlanPreviewSurface
-        projection={planProjection}
-        stale={stale}
-        isFullScreen={isPlanExpanded}
-        planFilename={planFilename}
-        onRespond={canRespondToPlan ? respondPlan : undefined}
-        onToggleFullScreen={() => setToolItemExpanded(isPlanExpanded ? null : item.id)}
+      <PlanPreviewToolContent
+        key={`${item.sessionId}:${item.planArtifactVersionId ?? 'active'}`}
+        item={item}
+        restoredPlanResponder={restoredPlanResponder}
       />
     )
   }

--- a/src/renderer/src/pages/workspace/previews/renderers/PlanJsonPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PlanJsonPreview.test.tsx
@@ -71,7 +71,9 @@ describe('Plan-aware JSON preview', () => {
 
     render(<PlanJsonPreview item={item} />)
 
-    expect(await screen.findByRole('heading', { name: 'Analyze one dataset' })).toBeTruthy()
+    const heading = await screen.findByRole('heading', { name: 'Analyze one dataset' })
+    expect(heading.className).not.toContain('line-clamp-3')
+    expect(screen.getAllByText('Analyze one dataset')).toHaveLength(1)
     expect(screen.getByRole('button', { name: 'View raw JSON' })).toBeTruthy()
     expect(screen.getByLabelText('Analyze the data status: completed')).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'Approve' })).toBeNull()

--- a/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.test.tsx
+++ b/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { ActivePlanProjection } from '../../../../../shared/session-plan/contract'
@@ -299,6 +299,54 @@ describe('Session Plan renderer surfaces', () => {
     expect(onRespond).toHaveBeenCalledOnce()
     expect(onRespond).toHaveBeenCalledWith('rejected')
     expect(onToggleFullScreen).toHaveBeenCalledOnce()
+  })
+
+  it('keeps a long Preview summary compact while retaining its full text at the bottom', () => {
+    const longSummary =
+      'Compare longitudinal cohorts, validate every source, reconcile conflicting evidence, produce publication-ready figures, and draft a complete review report with limitations.'
+    render(
+      <PlanPreviewSurface
+        projection={{
+          ...projection,
+          document: { ...projection.document, task_summary: longSummary }
+        }}
+      />
+    )
+
+    const heading = screen.getByRole('heading', { level: 1, name: longSummary })
+    expect(heading.className).toContain('line-clamp-3')
+    const summaryCopies = screen.getAllByText(longSummary)
+    expect(summaryCopies).toHaveLength(2)
+    const fullSummary = summaryCopies.find((element) => element !== heading)
+    expect(fullSummary?.className).toContain('text-xs')
+    expect(fullSummary?.parentElement?.lastElementChild).toBe(fullSummary)
+  })
+
+  it('reveals the complete Preview summary after a deliberate pointer hover', async () => {
+    vi.useFakeTimers()
+    const longSummary =
+      'Compare longitudinal cohorts, validate every source, reconcile conflicting evidence, produce publication-ready figures, and draft a complete review report with limitations.'
+    try {
+      render(
+        <PlanPreviewSurface
+          projection={{
+            ...projection,
+            document: { ...projection.document, task_summary: longSummary }
+          }}
+        />
+      )
+
+      const heading = screen.getByRole('heading', { level: 1, name: longSummary })
+      fireEvent.pointerMove(heading, { pointerType: 'mouse' })
+      expect(screen.queryByRole('tooltip')).toBeNull()
+
+      await act(() => vi.advanceTimersByTimeAsync(1_199))
+      expect(screen.queryByRole('tooltip')).toBeNull()
+      await act(() => vi.advanceTimersByTimeAsync(1))
+      expect(screen.getByRole('tooltip').textContent).toBe(longSummary)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('overlays every public step status while hiding ordinary status notes', () => {

--- a/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.tsx
+++ b/src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.tsx
@@ -345,16 +345,47 @@ const validatedPreviewDocument = (value: unknown): PlanDocumentV1 | null => {
 // rendering without the in-chat surface's header and approval banners. An invalid document renders
 // nothing; the embedding surface owns that error presentation.
 const PlanDocumentBody = ({
-  projection
-}: Readonly<{ projection: PlanDocumentProjection }>): React.JSX.Element => {
+  projection,
+  compactSummary = false
+}: Readonly<{
+  projection: PlanDocumentProjection
+  compactSummary?: boolean
+}>): React.JSX.Element => {
   const { t } = useTranslation()
 
   const planDocument = validatedPreviewDocument(projection.document)
   if (!planDocument) return <></>
+  const summaryHeading = (
+    <h1
+      className={
+        compactSummary
+          ? 'line-clamp-3 break-words text-[22px] leading-7 font-semibold'
+          : 'text-[22px] font-semibold'
+      }
+    >
+      {planDocument.task_summary}
+    </h1>
+  )
   return (
     <ScrollArea className="min-h-0 flex-1">
       <div className="px-8 py-8">
-        <h1 className="text-[22px] font-semibold">{planDocument.task_summary}</h1>
+        {compactSummary ? (
+          <TooltipProvider delayDuration={1_200}>
+            <Tooltip>
+              <TooltipTrigger asChild>{summaryHeading}</TooltipTrigger>
+              <TooltipContent
+                side="bottom"
+                align="start"
+                sideOffset={8}
+                className="max-w-[min(28rem,calc(100vw-1rem))] px-3 py-2 leading-5"
+              >
+                {planDocument.task_summary}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          summaryHeading
+        )}
         {/* One sentence, one key. It used to be assembled from three pieces — a spelled-out
             count, a hand-picked 'phase'/'phases', and a bare tail — which pins English word
             order and leaves the tail untranslatable. The count is now a number so i18next
@@ -452,6 +483,14 @@ const PlanDocumentBody = ({
           </div>
           <p className="mt-1 text-xs text-muted-foreground">{planDocument.feasibility.rationale}</p>
         </div>
+        {compactSummary ? (
+          <p
+            aria-hidden="true"
+            className="mt-7 select-text break-words border-t border-border pt-4 text-xs leading-5 text-muted-foreground"
+          >
+            {planDocument.task_summary}
+          </p>
+        ) : null}
       </div>
     </ScrollArea>
   )
@@ -595,7 +634,7 @@ const PlanPreviewSurface = ({
         </PlanNoticeBanner>
       ) : null}
       {planDocument ? (
-        <PlanDocumentBody projection={projection} />
+        <PlanDocumentBody projection={projection} compactSummary />
       ) : (
         <div className="flex min-h-0 flex-1 items-center justify-center p-8">
           <div


### PR DESCRIPTION
## Summary

- clamp long task summaries to three lines at the top of the right-side Plan Preview, reveal the complete summary after a 1.2-second title hover, and repeat it as secondary text at the bottom, without changing the Files-tab Plan renderer
- keep a matching Plan projection mounted during streamed durable-progress refreshes so the preview retains its scroll position
- add focused regressions for both behaviors

## Problem

Long Plan summaries can occupy most of the preview before the phase content begins. Separately, a streamed durable-progress update briefly clears the active Plan projection while the full projection reloads. That transient gap unmounts the preview scroll container; when it mounts again, the viewport starts at the top. On long-running tasks, users therefore lose the place they were reading whenever progress updates arrive.

This is worth fixing because both problems affect the primary reading surface during normal agent execution. The implementation stays local to the Plan Preview and avoids introducing broader state or lifecycle machinery.

## Approach and impact

- **Interaction:** the top summary remains the document heading but is limited to three lines; a delayed hover tooltip and selectable small secondary text at the bottom expose the complete summary. No new controls are introduced.
- **Scroll behavior:** retain the last complete projection only during a matching artifact/version/checksum authority gap. Approval actions continue to require the current authoritative projection.
- **Architecture:** no service boundaries or store shape changes; a keyed Plan child owns the presentation-level selector for the matching session/version lifecycle.
- **Data model/schema:** unchanged.
- **Historical-data compatibility:** not applicable; existing Plan documents render without migration.
- **New states or enum values:** none.
- **Persistence:** unchanged; no new persisted fields or records.

## Regression evidence

- Before the presentation change, the long-summary test fails because the heading has no multiline clamp.
- Before the hover change, the delayed interaction test fails because no complete-summary tooltip appears after 1.2 seconds.
- A negative consumer regression confirms the Files-tab Plan renderer retains its original single-summary presentation.
- Before the scroll fix, the streamed-progress test fails because the preview viewport disappears during the authority gap, reproducing the reset-to-top mechanism.
- Both tests pass after the fix.

## Verification

- `npx vitest run src/renderer/src/pages/workspace/previews/PreviewToolContent.plan.test.tsx src/renderer/src/pages/workspace/session-plan/SessionPlanSurfaces.test.tsx src/renderer/src/pages/workspace/previews/renderers/PlanJsonPreview.test.tsx src/renderer/src/pages/workspace/session-plan/plan-preview-i18n.render.test.tsx src/renderer/src/i18n/resources.test.ts`
- `npm run typecheck:web`
- `npm run lint`
- `git diff --check origin/main...HEAD`

The full local test suite was intentionally not run; pull-request CI is the authoritative full-suite check.
